### PR TITLE
fix(#1764): collapse same-accession control-group double-count (insider/blockholder rollup)

### DIFF
--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -1845,6 +1845,134 @@ def _collapse_insider_control_group(cluster: list[Holder]) -> tuple[Holder, Corr
     return collapsed, correction
 
 
+def _collapse_same_accession_channel(
+    holders: list[Holder],
+    *,
+    eligible: Callable[[Holder], bool],
+    collapse: Callable[[list[Holder]], tuple[Holder, CorrectionApplied]],
+    corrections: list[CorrectionApplied],
+    sort_cluster_shares_desc: bool = False,
+) -> list[Holder]:
+    """Collapse same-(``winning_accession``, ``shares``) groups within one channel.
+
+    Eligible holders are bucketed by ``(winning_accession, shares)``; a bucket with **≥2
+    distinct** :func:`_identity_key` collapses via ``collapse`` (one rep + the folded
+    members in ``dropped_sources`` + one ``corrections`` entry). Single-member buckets and
+    ineligible holders pass through unchanged. ``sort_cluster_shares_desc`` pre-sorts the
+    cluster shares-descending (with a deterministic ``(shares, filer_cik, accession)``
+    tie-break) for collapsers that take the rep as ``cluster[0]``
+    (:func:`_collapse_blockholder_group`); the insider collapser sorts internally."""
+    groups: dict[tuple[str, Decimal], list[Holder]] = {}
+    out: list[Holder] = []
+    for h in holders:
+        if eligible(h):
+            groups.setdefault((h.winning_accession, h.shares), []).append(h)
+        else:
+            out.append(h)
+    for cluster in groups.values():
+        if len({_identity_key(h.filer_cik, h.filer_name) for h in cluster}) >= 2:
+            if sort_cluster_shares_desc:
+                cluster = sorted(
+                    cluster,
+                    key=lambda h: (h.shares, h.filer_cik or "", h.winning_accession),
+                    reverse=True,
+                )
+            rep, correction = collapse(cluster)
+            out.append(rep)
+            corrections.append(correction)
+        else:
+            out.extend(cluster)
+    return out
+
+
+def _reconcile_same_accession_groups(
+    survivors: list[Holder],
+    blockholders: list[Holder],
+) -> tuple[list[Holder], list[Holder], list[CorrectionApplied]]:
+    """Collapse a same-accession control-chain duplicate to ONE holder, counted once (#1764).
+
+    A joint Form 4/3 (or 13D/G) accession reports the SAME deemed block under ≥2 distinct
+    reporting owners (the controlling person + the controlled entity, or a fund GP/LP chain)
+    — Rule 16a-1(a)(2) / Rule 13d-3 deemed beneficial ownership. Per-CIK dedup keeps all N
+    rows and a ``SUM`` counts the one block N× (data-engineer I14: MAX overlapping, SUM
+    additive). This is the PRECISE same-accession variant of the fuzzy cross-accession #1652
+    pass: the accession itself is direct group-membership evidence (parties co-file ONE
+    accession only when they ARE a group under Rule 16a-3(j) / Rule 13d-1(k)), so unlike
+    #1652/#1645 it needs **NO magnitude floor or roundness proxy** — those guards exist only
+    to substitute for the membership evidence that a shared accession already provides.
+
+    Restricted to insider sources ``{form4, form3}`` (in ``survivors``) and the blockholder
+    channel ``{13d, 13g}`` (in ``blockholders``) ONLY. DEF 14A is deliberately excluded: all
+    proxy holders share ONE accession, so same-accession does NOT separate independent
+    equal-grant executives there (the #1659 false-positive class) — and a def14a-source
+    holder CAN reach ``survivors`` (matched proxy rows). 13F is excluded too (one filer per
+    accession → no same-accession multi-holder dup by construction).
+
+    Group key = ``(winning_accession, shares)`` with a NON-EMPTY accession (a NULL/'' accession
+    coerces to '' and would wrongly bucket unrelated equal-share holders — Codex ckpt-2 #1),
+    ``shares > 0``, and ≥2 distinct :func:`_identity_key`. Distinctness is keyed on holder
+    identity, NOT rows, so a single person's direct+indirect on one accession (distinct count
+    = 1) is untouched and flows to :func:`_reconcile_owner_once`'s additive SUM.
+
+    **Cross-channel consume (Codex ckpt-2 #2, like #1652).** A folded insider member often ALSO
+    restates the SAME deemed block on a 13D/G (226 such pairs on dev). If only the insider rows
+    collapsed, the loser's matching blockholder row would orphan — it is no longer a survivor so
+    ``survivor_keys`` cannot exclude it and owner-once would re-count it (relocating, not removing,
+    the double-count). So each insider group ALSO pulls in every blockholder row whose
+    ``(_identity_key, shares)`` matches a group member; those fold into the insider rep's
+    ``dropped_sources`` and are removed from ``blockholders``. The blockholder-only same-accession
+    pass then runs over the remainder (a purely-13D/G co-investor group with no insider member).
+
+    Pure read-path; runs BEFORE the #1652 and #1645 fuzzy passes (so they see the single
+    representative, never the N dups). The rep keeps its original ``_identity_key`` so the
+    downstream survivor-key exclusion + owner-once see it correctly."""
+    corrections: list[CorrectionApplied] = []
+
+    # --- Insider side: bucket form4/form3 survivors by (accession, shares), pull matching
+    #     cross-channel 13D/G restatements into the cluster so they fold into the rep. ---
+    eligible_insider: dict[tuple[str, Decimal], list[Holder]] = {}
+    survivors_out: list[Holder] = []
+    for h in survivors:
+        if h.winning_source in _INSIDER_GROUP_SOURCES and h.shares > 0 and h.winning_accession.strip():
+            eligible_insider.setdefault((h.winning_accession, h.shares), []).append(h)
+        else:
+            survivors_out.append(h)
+
+    blockholders_by_key: dict[tuple[str, Decimal], list[Holder]] = {}
+    for b in blockholders:
+        blockholders_by_key.setdefault((_identity_key(b.filer_cik, b.filer_name), b.shares), []).append(b)
+    consumed_blockholders: set[int] = set()
+
+    for (_acc, shares), cluster in eligible_insider.items():
+        if len({_identity_key(h.filer_cik, h.filer_name) for h in cluster}) < 2:
+            survivors_out.extend(cluster)
+            continue
+        cross_channel: list[Holder] = []
+        for member in cluster:
+            for b in blockholders_by_key.get((_identity_key(member.filer_cik, member.filer_name), shares), []):
+                if id(b) not in consumed_blockholders:
+                    cross_channel.append(b)
+                    consumed_blockholders.add(id(b))
+        rep, correction = _collapse_insider_control_group(cluster + cross_channel)
+        survivors_out.append(rep)
+        corrections.append(correction)
+
+    blockholders_remaining = [b for b in blockholders if id(b) not in consumed_blockholders]
+
+    # --- Blockholder-only side: a purely-13D/G joint accession (Rule 13d-5 group, each member
+    #     deemed to own the whole stake → identical aggregate) with no insider footprint. ---
+    blockholders_out = _collapse_same_accession_channel(
+        blockholders_remaining,
+        eligible=lambda h: (
+            h.winning_source in _BLOCK_GROUP_SOURCES and h.shares > 0 and bool(h.winning_accession.strip())
+        ),
+        collapse=_collapse_blockholder_group,
+        corrections=corrections,
+        sort_cluster_shares_desc=True,
+    )
+    return survivors_out, blockholders_out, corrections
+
+
 def _reconcile_insider_control_groups(
     survivors: list[Holder],
     blockholders: list[Holder],
@@ -3087,6 +3215,13 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     # consumed rows from BOTH lists (nothing orphaned). Runs BEFORE #1645 so the control
     # group's 13D rows are consumed here; a purely-13D co-investor group (no insider
     # member) is left for #1645.
+    # Same-accession control-group collapse (#1764): a joint Form 4/3 (or 13D/G) accession
+    # reports the SAME deemed block under ≥2 distinct reporting owners (controlling person +
+    # entity, or a fund chain). The fuzzy #1652 pass only fires ≥1M, so every sub-1M same-
+    # accession dup leaks. Collapse the PRECISE same-accession signal first (no floor — the
+    # shared accession IS the group evidence #1652/#1645 must infer); insiders restricted to
+    # {form4,form3}, blockholders to {13d,13g}, never def14a (#1659 FP class).
+    survivors, blockholders, same_accession_corrections = _reconcile_same_accession_groups(survivors, blockholders)
     survivors, blockholders, insider_group_corrections = _reconcile_insider_control_groups(survivors, blockholders)
     # 13D/G group collapse (#1645): a Rule 13d-5 group's members each report the
     # identical aggregate stake on separate accessions/CIKs and otherwise sum N× in
@@ -3185,6 +3320,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     corrections_applied = (
         *_read_notice_suppressions(conn, instrument_id),
         *family_corrections,
+        *same_accession_corrections,
         *insider_group_corrections,
         *group_corrections,
     )

--- a/docs/specs/etl/2026-06-28-insider-same-accession-control-group-collapse.md
+++ b/docs/specs/etl/2026-06-28-insider-same-accession-control-group-collapse.md
@@ -1,0 +1,146 @@
+# Insider/blockholder same-accession control-group collapse (#1764)
+
+## Problem
+`ownership_insiders_current` (and rarely `ownership_blockholders_current`) double-counts a single
+beneficial-ownership position when a Form 4/3 (or 13D/G) control chain reports the SAME block more
+than once on ONE accession: the controlling person (indirect) and the entity (direct), or a stack
+of fund entities, each get a row with the SAME `shares` from the SAME `source_accession`. A
+`SUM(shares)` rollup counts the one position N times.
+
+Example — BKTI (instrument_id 13585), accession `0001104659-24-090956`:
+- `Horowitz Joshua` — indirect 90,000 (controls the fund)
+- `Palm Global Small Cap Master Fund LP` — direct 90,000 (the fund)
+
+Both report the same 90,000 block under Rule 16a-1 deemed beneficial ownership. Raw insider
+`SUM` = 815,453; endpoint shows 795,453; true ≈ 705,453 (the 90k counted once).
+
+## Why the existing #1652 pass misses it
+`_reconcile_insider_control_groups` (#1652) collapses control groups bucketed by EXACT `shares`
+value **across the whole instrument (cross-accession)**, gated by `_INSIDER_GROUP_MIN_SHARES = 1M`
++ a non-round guard. That floor exists to suppress false positives in the FUZZY cross-accession
+value-match (independent equal-grant directors coincidentally sharing a round number). It is the
+right guard for that signal but it means every sub-1M same-accession dup leaks onto the endpoint.
+
+## Source rule
+SEC **Rule 16a-1(a)(2)** (and Rule 13d-3) — beneficial ownership is "deemed": a controlling person
+and the entity it controls each report the SAME shares as their own beneficial position. The block
+exists ONCE; the joint filing lists it under each deemed owner. Count it once (data-engineer I14:
+"MAX overlapping, SUM additive"; prevention-log "deemed/overlapping = MAX, not additive"). A single
+Form 4/3 accession listing the same `shares` under ≥2 distinct reporting persons is, by the form's
+own structure, one deemed block reported jointly — structurally unambiguous, unlike the fuzzy
+cross-accession value-match.
+
+## Full-population verification (passes the #1659 trap)
+Per prevention-log #1659 (an exact-same-value clustering heuristic was falsified by a full-pop scan —
+independent equal-grant executives coincidentally share exact values), the signal was verified on the
+FULL sub-1M population on dev (2026-06-28) BEFORE speccing:
+
+```
+signature = (instrument_id, source_accession, shares>0) with ≥2 distinct holder_identity_key
+in ownership_insiders_current:
+  raw (all magnitudes): 1,255 groups / 813 instruments / 74.5B shares overcounted
+  sub-1M (what #1652's floor misses): 316 groups / 253 instruments / 387M shares overcounted
+in ownership_blockholders_current: 1 group / ~154k shares.
+```
+
+Every sampled group is a genuine Rule 16a-1 deemed-ownership **joint filing** — a fund GP/LP/management
+chain + the controlling person, all reporting the SAME block on ONE accession (Voss Capital, OrbiMed,
+Ridgemont/REP, Blackstone/Legence, Framework Ventures). The #1659 false-positive class (independent
+equal-grant executives) does NOT appear here, because those file **separate** accessions (each exec
+files their own Form 4). **Same-accession cleanly separates deemed groups from coincidental equal
+grants for the #1659 class → no magnitude floor needed.**
+
+### Why same-accession needs no roundness/tolerance proxy (the #1645 guard is unnecessary here)
+The #1645 blockholder pass had to *infer* group membership from circumstantial signals (same period_end,
+near-equal non-round values, tiered distinct-CIK tolerance) because separate 13D/G accessions carry NO
+direct membership evidence — so it needs the roundness/tolerance guards as proxies against coincidence.
+A **joint Form 4/3 (or 13D/G) accession is itself the direct group-membership evidence**: under the
+joint-filing rules (Rule 16a-3(j); Rule 13d-1(k)) parties co-file ONE accession precisely because they
+ARE a group with a control/deemed relationship. Unrelated holders never share one accession. So the
+same-accession + same-exact-shares signal already HAS the evidence #1645 lacked; the roundness/floor
+proxies are redundant here and would wrongly skip round-value deemed blocks.
+
+**Residual FP (Codex ckpt-1 #4), accepted + bounded.** It is not logically impossible for two affiliated
+co-filers on one accession to each hold an *equal-but-separate* block (collapse would under-count by one
+member's block). This is rare (the full sub-1M scan found zero), bounded (one member's block, never a
+runaway), and **audit-surfaced**: every collapse emits an `insider_control_group_collapse` /
+`blockholder_group_collapse` `corrections_applied[]` entry naming each folded member + shares, so an
+operator can see exactly what was counted once. Erring toward collapse is also the correct bias for an
+over-count fix: the rare under-count is strictly smaller than the systematic over-count it removes.
+
+### Critical FP guard — exclude DEF 14A
+DEF 14A is the inverse case: all named holders sit on ONE proxy accession, so same-accession does NOT
+separate independent equal-grant executives there (the exact #1659 FPs — BXP Koop+LaBelle @1,875,000,
+FOXA Ciongoli+Tomsic @2,750,000 — ARE same-accession). DEF 14A is already a non-additive memo overlay
+(#1659/I21) and a def14a-source Holder CAN reach `survivors` (matched proxy rows, `ownership_rollup.py`
+~1018-1047). So the new pass is restricted to insider sources `{form4, form3}` and the blockholder
+channel `{13d, 13g}` ONLY — never def14a, never 13f.
+
+## Fix — read-path collapse, no backfill
+The rollup computes live from `_current`, so this is a pure read-path pass; no migration, no re-ingest.
+
+Add `_reconcile_same_accession_groups(survivors, blockholders) -> (survivors, blockholders, corrections)`
+in `ownership_rollup.py`, called immediately BEFORE `_reconcile_insider_control_groups` (#1652) at the
+existing pipeline site (~line 3090, after `_reconcile_institutional_families`):
+
+- **Insider side**: among `survivors` with `winning_source in {form4, form3}` and `shares > 0`, group by
+  `(winning_accession, shares)`. A group with **≥2 distinct `_identity_key`** collapses via the existing
+  `_collapse_insider_control_group(cluster)` (rep = deterministic tie-break already in that helper;
+  losers → `dropped_sources` + one `insider_control_group_collapse` correction). Survivors not in a
+  collapsing group (incl. all non-form4/form3 survivors) pass through unchanged.
+- **Blockholder side**: among `blockholders` (all `13d/13g` by construction) with `shares > 0`, group by
+  `(winning_accession, shares)`. A group with ≥2 distinct `_identity_key` collapses via the existing
+  `_collapse_blockholder_group(cluster)` (rep = `cluster[0]` after a deterministic shares-desc +
+  tie-break sort; `blockholder_group_collapse` correction). Rest pass through.
+
+**No magnitude floor, no roundness guard** — the same-accession + same-shares + ≥2-distinct-holder
+signature is unambiguous (justified above). The `_INSIDER_GROUP_MIN_SHARES` floor + `_is_group_block`
+roundness guard stay ONLY on the fuzzy cross-accession #1652 / #1645 paths.
+
+### Codex ckpt-2 findings (resolved before push)
+- **#1 empty-accession guard.** The readers coerce a NULL `source_accession` to `""`, so the eligible
+  predicate requires `winning_accession.strip()` — otherwise two unrelated equal-share holders with no
+  accession would bucket as `("", shares)` and wrongly collapse. (Dev: 0 such buckets today; latent.)
+- **#2 cross-channel consume.** A folded insider member often ALSO restates the same deemed block on a
+  13D/G (dev: 226 such pairs). Collapsing only the insider rows would orphan the loser's blockholder
+  row (no longer a survivor → `survivor_keys` can't exclude it → owner-once re-counts it, *relocating*
+  the double-count to the blockholders wedge). So each insider group also pulls in every blockholder
+  row whose `(_identity_key, shares)` matches a group member; they fold into the insider rep's
+  `dropped_sources` and are removed from `blockholders` — exactly как #1652 consumes cross-channel.
+  Live-verified on WAY: 2 insider reps carry the consumed 13G restatement (Derby LuxCo, CPP) instead
+  of orphaning. A loser's 13D at a *different* value (a larger full-group block) is NOT consumed.
+- **#3 (rebutted).** "A joint 13D/G accession could list separate member stakes, not one block."
+  Rule 13d-5(b): each group member is deemed to own the WHOLE group stake, so members report the
+  IDENTICAL aggregate — equal shares on one accession is the deemed-group signature (same as #1645/I17).
+  Genuinely separate stakes have *different* shares and so never share a `(accession, shares)` bucket.
+
+### Ordering rationale
+Placed BEFORE #1652 so the precise same-accession collapse runs first; #1652's cross-accession fuzzy
+pass then sees one representative row (not the N dup rows) at that value and is unaffected (it only
+fires ≥1M anyway). Placed BEFORE #1645 so the blockholder same-accession collapse precedes the fuzzy
+near-equal clustering. Distinctness keyed on holder identity (not row), so a single person's
+direct+indirect on one accession (distinct count = 1) is NOT touched — it flows to owner-once's
+existing additive SUM, unchanged. Same-shares-EXACT requirement means two genuinely different positions
+on one accession (different share counts) are never merged.
+
+The collapse **preserves `dropped_sources`** (Codex ckpt-1 #3): both reuse helpers
+(`_collapse_insider_control_group`, `_collapse_blockholder_group`) append the folded members to the
+representative's existing `dropped_sources` and return the rep with the SAME `_identity_key` it had,
+so the downstream `survivor_keys` exclusion (#1645) and `_reconcile_owner_once` see the representative
+correctly and the folded members' provenance is non-lossy.
+
+## Acceptance
+- Insider rollup counts a same-accession control-chain position once across the full sub-1M population
+  (387M overcount eliminated); blockholder 154k group collapsed.
+- BKTI insider total: 795,453 → 705,453 (Horowitz indirect 90k + Palm Global direct 90k counted once).
+- AAPL: Berkshire/Buffett same-accession pair (if same-accession) counted once.
+- `corrections_applied[]` lists each collapse (kind + folded members).
+- Panel (`AAPL`, `GME`, `MSFT`, `JPM`, `HD` + BKTI) renders on `/instruments/{symbol}/ownership-rollup`.
+
+## Tests
+- Pure-logic table tests on `_reconcile_same_accession_groups`: collapses a 2-holder same-accession
+  same-shares insider group; does NOT collapse (a) same holder direct+indirect (distinct=1),
+  (b) different shares same accession, (c) def14a-source rows on one accession (#1659 FP guard),
+  (d) round/sub-1M values (no floor → still collapses, proving floor-independence), (e) blockholder
+  same-accession group. Asserts the surviving rep + `dropped_sources` + correction shape.
+- Dev-verify on the endpoint for the panel + BKTI.

--- a/tests/test_same_accession_group_collapse.py
+++ b/tests/test_same_accession_group_collapse.py
@@ -1,0 +1,203 @@
+"""Pure-logic tests for same-accession control-group collapse (#1764).
+
+A joint Form 4/3 (or 13D/G) accession reports the SAME deemed block under ≥2 distinct
+reporting owners (the controlling person + the entity, or a fund GP/LP chain) — Rule
+16a-1(a)(2) deemed beneficial ownership. A SUM rollup counts the one block N×. This pass
+collapses the PRECISE same-(accession, shares) signal to ONE holder with NO magnitude floor
+(the shared accession IS the group-membership evidence the fuzzy #1652/#1645 passes must
+infer). Restricted to {form4,form3} survivors + {13d,13g} blockholders; never def14a (the
+#1659 false-positive class) or 13f. No DB — hand-built ``Holder`` objects.
+See docs/specs/etl/2026-06-28-insider-same-accession-control-group-collapse.md.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.ownership_rollup import (
+    Holder,
+    SourceTag,
+    _reconcile_same_accession_groups,
+)
+
+_P = date(2024, 8, 5)
+_ACC = "0001104659-24-090956"  # BKTI joint Form 4 — Horowitz (indirect) + Palm Global (direct)
+
+
+def _h(
+    cik: str | None,
+    name: str,
+    shares: str,
+    *,
+    source: SourceTag = "form4",
+    accession: str = _ACC,
+) -> Holder:
+    return Holder(
+        filer_cik=cik,
+        filer_name=name,
+        shares=Decimal(shares),
+        pct_outstanding=Decimal(0),
+        winning_source=source,
+        winning_accession=accession,
+        winning_edgar_url=f"https://sec.gov/{accession}",
+        as_of_date=_P,
+        filer_type=None,
+        dropped_sources=(),
+    )
+
+
+def _kinds(corrs: list) -> list[str]:
+    return [c.kind for c in corrs]
+
+
+# ---------------------------------------------------------------------------
+# Core collapse — the in-scope win (BKTI)
+# ---------------------------------------------------------------------------
+
+
+def test_insider_same_accession_pair_collapses_to_one() -> None:
+    """Horowitz (indirect 90k) + Palm Global (direct 90k) on ONE accession → counted once."""
+    survivors = [
+        _h("0001104659", "Horowitz Joshua", "90000"),
+        _h("0001428336", "Palm Global Small Cap Master Fund LP", "90000"),
+        _h("0009999999", "Unrelated Director", "39896", accession="other-acc"),
+    ]
+    out_s, out_b, corrs = _reconcile_same_accession_groups(survivors, [])
+    assert out_b == []
+    assert _kinds(corrs) == ["insider_control_group_collapse"]
+    block = [h for h in out_s if h.shares == Decimal("90000")]
+    assert len(block) == 1  # the 90k block counted ONCE
+    assert any(h.filer_name == "Unrelated Director" for h in out_s)  # different accession untouched
+    (corr,) = corrs
+    assert corr.shares_removed == Decimal("90000")  # one member folded
+    assert len(block[0].dropped_sources) == 1  # folded member preserved in dropped_sources
+
+
+def test_collapse_has_no_magnitude_floor() -> None:
+    """A sub-1M AND a round-lot same-accession pair both collapse (the #1652 floor is gone)."""
+    survivors = [
+        _h("0000000001", "GP LLC", "200000"),  # round multiple of 100k — #1652 would skip
+        _h("0000000002", "Managed Fund LP", "200000"),
+    ]
+    out_s, _out_b, corrs = _reconcile_same_accession_groups(survivors, [])
+    assert _kinds(corrs) == ["insider_control_group_collapse"]
+    assert len([h for h in out_s if h.shares == Decimal("200000")]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Guards — what must NOT collapse
+# ---------------------------------------------------------------------------
+
+
+def test_same_holder_direct_indirect_not_collapsed() -> None:
+    """One person's direct+indirect on one accession (distinct identity = 1) is NOT touched —
+    it flows to owner-once's additive SUM unchanged."""
+    survivors = [
+        _h("0001077430", "GOLDBERG ALAN E", "90000"),
+        _h("0001077430", "GOLDBERG ALAN E", "90000"),  # same CIK, same accession
+    ]
+    out_s, _out_b, corrs = _reconcile_same_accession_groups(survivors, [])
+    assert corrs == []
+    assert len(out_s) == 2  # both pass through
+
+
+def test_different_shares_same_accession_not_collapsed() -> None:
+    """Two genuinely different positions on one accession (different share counts) never merge."""
+    survivors = [
+        _h("0000000001", "Holder A", "90000"),
+        _h("0000000002", "Holder B", "45000"),
+    ]
+    out_s, _out_b, corrs = _reconcile_same_accession_groups(survivors, [])
+    assert corrs == []
+    assert len(out_s) == 2
+
+
+def test_def14a_same_accession_not_collapsed() -> None:
+    """The #1659 FP guard: independent equal-grant execs share ONE proxy accession, so a
+    def14a-source pair on one accession must NOT collapse (def14a is non-additive memo, and a
+    matched proxy row can reach survivors)."""
+    survivors = [
+        _h("0000000010", "Koop Bryan", "1875000", source="def14a"),
+        _h("0000000011", "LaBelle Douglas", "1875000", source="def14a"),
+    ]
+    out_s, _out_b, corrs = _reconcile_same_accession_groups(survivors, [])
+    assert corrs == []
+    assert len(out_s) == 2
+
+
+def test_empty_accession_does_not_bucket() -> None:
+    """Codex ckpt-2 #1: a NULL/'' accession coerces to '' on read; two UNRELATED holders with
+    the same exact shares and no accession must NOT bucket as ('', shares) and collapse."""
+    survivors = [
+        _h("0000000001", "Holder A", "90000", accession=""),
+        _h("0000000002", "Holder B", "90000", accession=""),
+    ]
+    out_s, _out_b, corrs = _reconcile_same_accession_groups(survivors, [])
+    assert corrs == []
+    assert len(out_s) == 2
+
+
+def test_cross_channel_blockholder_restatement_consumed() -> None:
+    """Codex ckpt-2 #2: a folded insider member that ALSO restates the SAME block on a 13D/G
+    must have that blockholder row consumed (folded into the insider rep), not orphaned into the
+    blockholders wedge where owner-once would re-count it."""
+    survivors = [
+        _h("0001104659", "Horowitz Joshua", "90000"),
+        _h("0001428336", "Palm Global LP", "90000"),
+    ]
+    # Palm Global also files a 13D for the same 90k block (different accession).
+    blockholders = [_h("0001428336", "Palm Global LP", "90000", source="13d", accession="0001-13d")]
+    out_s, out_b, corrs = _reconcile_same_accession_groups(survivors, blockholders)
+    assert _kinds(corrs) == ["insider_control_group_collapse"]
+    assert out_b == []  # the cross-channel 13D restatement was consumed, not orphaned
+    block = [h for h in out_s if h.shares == Decimal("90000")]
+    assert len(block) == 1
+    (corr,) = corrs
+    # two folded members (the other insider + the cross-channel 13D), both at 90k
+    assert corr.shares_removed == Decimal("180000")
+    assert len(block[0].dropped_sources) == 2
+
+
+def test_blockholder_at_different_value_not_consumed() -> None:
+    """A folded insider member's 13D at a DIFFERENT (larger full-group) value is a separate
+    position — it must stay in blockholders, not be consumed by the same-accession insider pass."""
+    survivors = [
+        _h("0000000001", "GP LLC", "90000"),
+        _h("0000000002", "Managed Fund LP", "90000"),
+    ]
+    blockholders = [_h("0000000002", "Managed Fund LP", "250000", source="13d", accession="0001-13d")]
+    _out_s, out_b, corrs = _reconcile_same_accession_groups(survivors, blockholders)
+    assert _kinds(corrs) == ["insider_control_group_collapse"]
+    assert len(out_b) == 1  # the 250k block is a different position, untouched
+    assert out_b[0].shares == Decimal("250000")
+
+
+def test_13f_same_accession_not_collapsed() -> None:
+    """13F survivors are excluded (one filer per accession by construction)."""
+    survivors = [
+        _h("0000000020", "Manager One", "500000", source="13f"),
+        _h("0000000021", "Manager Two", "500000", source="13f"),
+    ]
+    out_s, _out_b, corrs = _reconcile_same_accession_groups(survivors, [])
+    assert corrs == []
+    assert len(out_s) == 2
+
+
+# ---------------------------------------------------------------------------
+# Blockholder channel
+# ---------------------------------------------------------------------------
+
+
+def test_blockholder_same_accession_pair_collapses() -> None:
+    """A 13D/G joint accession listing 2 reporters at the same stake → counted once at MAX."""
+    blockholders = [
+        _h("0000000030", "Activist GP", "154000", source="13d"),
+        _h("0000000031", "Activist Fund LP", "154000", source="13d"),
+    ]
+    out_s, out_b, corrs = _reconcile_same_accession_groups([], blockholders)
+    assert out_s == []
+    assert _kinds(corrs) == ["blockholder_group_collapse"]
+    assert len([h for h in out_b if h.shares == Decimal("154000")]) == 1
+    (corr,) = corrs
+    assert corr.shares_removed == Decimal("154000")


### PR DESCRIPTION
Closes #1764.

## Problem
A joint Form 4/3 (or 13D/G) accession reports the SAME deemed block under ≥2 distinct reporting owners (the controlling person + the controlled entity, or a fund GP/LP chain) — Rule 16a-1(a)(2) / 13d-3 deemed beneficial ownership. Per-CIK dedup keeps all N rows and a `SUM` counts the one block N×. The existing fuzzy `_reconcile_insider_control_groups` (#1652) only fires ≥`_INSIDER_GROUP_MIN_SHARES` (1M), so every sub-1M same-accession dup leaks onto the endpoint.

## Source rule
SEC **Rule 16a-1(a)(2)** / Rule 13d-3 — beneficial ownership is "deemed": a controlling person and the entity it controls each report the SAME shares as their own beneficial position; the block exists ONCE (data-engineer I14: MAX overlapping, SUM additive). A joint Form 4/3 accession listing the same shares under ≥2 distinct reporting persons is, by the form's own structure (Rule 16a-3(j) / 13d-1(k) joint filing), one deemed block reported jointly.

## Full-population verification (dev, 2026-06-28)
Signature = `(instrument_id, source_accession, shares>0)` with ≥2 distinct `holder_identity_key`:
- insiders: 1,255 raw groups / 813 instruments; **sub-1M (what #1652 misses): 316 groups / 253 instruments / 387M shares**.
- blockholders: 1 group / ~154k. institutions: 0 (one filer per accession).

Sampled groups are all genuine deemed joint filings (Voss, OrbiMed, Ridgemont/REP, Blackstone/Legence). The #1659 FP class (independent equal-grant execs) does NOT appear — those file SEPARATE accessions. **DEF 14A is excluded** (all proxy holders share ONE accession, so same-accession does not separate them — the #1659 trap; a def14a-source holder can reach `survivors`).

## Fix (read-path, no backfill)
`_reconcile_same_accession_groups(survivors, blockholders)` in `ownership_rollup.py`, run BEFORE the fuzzy #1652/#1645 passes. Groups eligible holders by `(winning_accession, shares)`, ≥2 distinct `_identity_key` → collapse via the existing `_collapse_insider_control_group` / `_collapse_blockholder_group`. **No magnitude floor** — the shared accession IS the group-membership evidence the fuzzy passes must infer. Restricted to `{form4,form3}` survivors + `{13d,13g}` blockholders. Distinctness keyed on holder identity, so a single person's direct+indirect (distinct=1) stays additive.

### Codex ckpt-2 (pre-pr-fresh-agent-review lenses)
- **empty-accession guard** — require non-empty `winning_accession` (NULL coerces to `''` on read); else unrelated equal-share holders bucket as `('', shares)`. (Dev: 0 today; latent.)
- **cross-channel consume** — a folded insider member often ALSO restates the block on a 13D/G (dev: 226 pairs). Collapsing only insiders would orphan the loser's blockholder row → owner-once re-counts it (relocating the double-count). Each insider group now pulls matching `(_identity_key, shares)` blockholder rows into the rep's `dropped_sources` and removes them from `blockholders` — exactly как #1652. A 13D at a *different* value (larger full-group block) is NOT consumed.
- **#3 rebutted** — Rule 13d-5(b): each group member is deemed to own the WHOLE stake → identical aggregate; genuinely separate stakes have different shares and never share a bucket.

## Verification (DoD clauses 8-11) — commit `<HEAD>`
- **Smoke panel** (`/instruments/{symbol}/ownership-rollup`, live `:8000`): AAPL 9,751,270 · GME 44,750,445 · MSFT 14,296,558 · JPM 9,142,457 · HD 578,102 — all render clean, no regression.
- **Target figure**: **BKTI insiders 795,453 → 705,453** (Horowitz indirect 90k + Palm Global direct 90k counted once; `insider_control_group_collapse` removes 90,000).
- **Cross-channel consume (live)**: WAY — 2 insider reps carry the consumed 13G restatement in `dropped_sources` (Derby LuxCo 24,879,437 + 13G; CPP 19,025,452 + 13G) instead of orphaning into blockholders. UPB/FWRD/ALTG collapse fires + audit-surfaced.
- **Cross-source**: BKTI accession `0001104659-24-090956` confirmed on SEC EDGAR as a joint Form 4 (Horowitz / Palm Global), same 90,000 block.
- **No backfill / no daemon restart** — pure read-path; `_current` unchanged; API `--reload` already serves it.
- **Tests**: 10 new pure-logic tests (`tests/test_same_accession_group_collapse.py`) + 78 ownership-suite green + 4588 fast-tier green.

## Tradeoff
Coarse residual FP (two affiliated co-filers each holding equal-but-separate blocks) is rare (full-pop scan: zero), bounded (one member's block), and audit-surfaced in `corrections_applied[]`. Erring toward collapse is the correct bias for an over-count fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)