### PR TITLE
fix(#1771): mandate foreground push/PR in the autonomy loop prompt

### DIFF
--- a/scripts/autonomy/loop_prompt.md
+++ b/scripts/autonomy/loop_prompt.md
@@ -24,6 +24,19 @@ branches, no unpushed WIP).
    If the latest round is **rebuttal-only** (no code change, you think the bot is
    wrong), do NOT merge unattended — that needs Codex ckpt-3 + human judgment;
    leave the PR open with your reasoning and move on.
+
+   **Push discipline — run the terminal push/PR step in the FOREGROUND, never
+   background it (#1771).** The pre-push gate is slow (full fast tier + smoke +
+   chokepoint lints, often >2 min); run `git push` as a normal FOREGROUND Bash
+   call with a long timeout (up to 10 min / 600000 ms), and run `gh pr create`
+   right after it succeeds — both foreground. Do **NOT** kick off the push or the
+   gate as a background task and then yield/end the turn: a headless run that
+   completes kills any still-running background tasks, so the push never finishes,
+   no branch is pushed and **no PR ever opens** even though the fix is committed
+   locally. Only AFTER the branch is pushed AND the PR is confirmed open may you
+   background the review-bot/CI **poll** (the PR already exists at that point).
+   Never end a turn with an unpushed commit or an un-opened PR for work you
+   intended to ship — verify `git push` succeeded and the PR URL exists first.
 3. **Restart the jobs daemon** onto new main after any jobs/ingest/parser/
    scheduler merge (graceful SIGTERM, confirm old PID gone), `sec_rebuild` the
    affected source only if output changed. FE/API/docs/test/script merges need


### PR DESCRIPTION
Closes #1771.

## Problem
A headless board-drain session did all the real work (spec→build→test→Codex→commit) but ran its **final pre-push gate + push as BACKGROUND tasks**, then yielded and the headless `claude` run completed. The harness kills any still-running background tasks on completion → the push never finished → **no branch pushed, no PR opened**, even though the fix was committed locally. This was THE reason zero PRs landed in the first supervisor run (`session-20260628T023308`: real #1769 work committed `fbb3a50b` locally, 0 PRs on GitHub).

## Fix
Add explicit **push discipline** to `loop_prompt.md` step 2: run the slow pre-push gate + `git push` as a FOREGROUND Bash call (long timeout, up to 600000 ms), then `gh pr create` foreground; never background the terminal push step and yield. Only AFTER the branch is pushed AND the PR is confirmed open may the review-bot/CI **poll** be backgrounded. Never end a turn with an unpushed commit or an un-opened PR.

## Verification
Prompt-doc change only (`scripts/autonomy/loop_prompt.md`). No code, no daemon, no DB. This very PR was opened by following the new discipline (foreground push with a 600000 ms timeout, then foreground `gh pr create`).

## Note on merge
Doc-only diff → the Claude review bot may auto-SKIP it. `safe_merge.sh` requires a bot APPROVE newer than head, so if the bot skips this cannot be merged unattended — it is left for an operator merge (a change to the loop's own governing prompt is reasonable to eyeball). Surfaces a structural limitation: the autonomy substrate cannot self-merge doc-only PRs through the APPROVE gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)