### PR TITLE
fix(#1576): exclude .zip sidecars from _list_archives_matching

### DIFF
--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -72,15 +72,23 @@ def _archive_path(name: str) -> Path:
 
 
 def _list_archives_matching(prefix: str) -> list[Path]:
-    """Return every archive in the cache whose filename starts with ``prefix``.
+    """Return every ``.zip`` archive in the cache whose filename starts with ``prefix``.
 
-    Used for the multi-quarter Phase C ingesters (13F, insider, N-PORT)
+    Used for the multi-quarter Phase C ingesters (13F, insider, N-PORT, FSDS)
     which iterate every quarterly ZIP in the cache.
+
+    The ``.zip`` suffix filter is load-bearing (#1576): the downloader writes
+    ``<archive>.zip.etag`` / ``.zip.sha256`` sidecars next to each zip, and those
+    also match ``startswith(prefix)``. In orchestrated bootstrap mode the run-manifest
+    name filter hides them, but in STANDALONE mode (run_id None — manual trigger /
+    direct invocation) each sidecar reached ``zipfile.ZipFile`` and logged a
+    ``BadZipFile`` ERROR per sidecar per run (caught per-archive, so pure noise +
+    misleading "failed" lines). All callers only ever want the zips.
     """
     base = _bulk_dir()
     if not base.exists():
         return []
-    return sorted(p for p in base.iterdir() if p.is_file() and p.name.startswith(prefix))
+    return sorted(p for p in base.iterdir() if p.is_file() and p.name.startswith(prefix) and p.name.endswith(".zip"))
 
 
 def _run_with_conn(fn: Callable[[psycopg.Connection[tuple]], object]) -> None:

--- a/tests/test_sec_bulk_disk_hygiene.py
+++ b/tests/test_sec_bulk_disk_hygiene.py
@@ -89,3 +89,28 @@ class TestS16CleanupSubmissionsZip:
         # _delete_archive_after_success.
         _cleanup_submissions_zip_after_drain(archive)
         assert not archive.exists()
+
+
+class TestListArchivesExcludesSidecars:
+    """#1576 — ``_list_archives_matching`` must return only ``.zip`` archives,
+    never the ``.zip.etag`` / ``.zip.sha256`` sidecars the downloader writes
+    alongside each zip. Those also match ``startswith(prefix)`` and, in STANDALONE
+    mode (no run-manifest name filter), reached ``zipfile.ZipFile`` → a
+    ``BadZipFile`` ERROR per sidecar per run (caught, but pure log noise)."""
+
+    def test_sidecars_excluded(self, tmp_path: Path) -> None:
+        base = tmp_path / "sec" / "bulk"
+        base.mkdir(parents=True)
+        (base / "form13f_2025q1.zip").write_bytes(b"PK\x03\x04")
+        (base / "form13f_2025q1.zip.etag").write_text('"abc"')
+        (base / "form13f_2025q1.zip.sha256").write_text("deadbeef")
+        (base / "form13f_2024q4.zip").write_bytes(b"PK\x03\x04")
+        (base / "nport_2025q1.zip").write_bytes(b"PK\x03\x04")  # different prefix
+
+        with patch.object(jobs, "_bulk_dir", return_value=base):
+            matched = jobs._list_archives_matching("form13f_")
+
+        names = [p.name for p in matched]
+        assert names == ["form13f_2024q4.zip", "form13f_2025q1.zip"]  # sorted, zips only
+        assert all(n.endswith(".zip") for n in names)
+        assert not any(n.endswith((".etag", ".sha256")) for n in names)


### PR DESCRIPTION
Closes #1576.

## Problem
`_list_archives_matching(prefix)` (`app/services/sec_bulk_orchestrator_jobs.py`) returned every file whose name `startswith(prefix)` — including the `.zip.etag` / `.zip.sha256` sidecars the downloader writes next to each zip. In orchestrated bootstrap mode the run-manifest name filter hides them, but in **STANDALONE** mode (run_id None — manual trigger / direct invocation) each sidecar reached `zipfile.ZipFile` → a `BadZipFile` ERROR + traceback per sidecar per run (caught per-archive, so the run completes — pure noise + misleading "failed" log lines). Observed live 2026-06-11 during the #740 standalone re-ingest.

## Fix
Filter to `p.name.endswith(".zip")` in the single helper — covers all 5 callers (`form13f_`/`insider_`/`nport_`/`fsds_`×2), which only ever want the quarterly zips. Pure log-hygiene: no data-path or output change, no backfill needed.

## Verification
- New unit pin `tests/test_sec_bulk_disk_hygiene.py::TestListArchivesExcludesSidecars` — asserts the two sidecars are excluded and only `.zip` archives return (sorted). Passes.
- Codex ckpt-2 (filings-ETL fresh-agent lens): no bugs — confirmed every consumer passes the path straight to `zipfile.ZipFile` (zip-only; no `.tar`/`.gz`/uncompressed inputs), sidecars are handled separately by explicit path in the downloader, and local cache names are generated lowercase (`build_bulk_archive_inventory`), so the `.zip` filter drops nothing legitimate.
- `ruff` + `pyright` clean.

## Tradeoff
None — strictly removes erroring non-archive inputs that were never valid. No daemon data-output change; no `sec_rebuild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)