### PR TITLE
fix(#1599): resolve eToro industry id → name at watchlist + identity read sites

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -170,7 +170,11 @@ class InstrumentListResponse(BaseModel):
 class InstrumentIdentity(BaseModel):
     symbol: str
     display_name: str | None
-    sector: str | None
+    sector: str | None  # eToro numeric industry id, as text (provider contract)
+    # Resolved eToro industry name via etoro_stocks_industries (sql/070); None when
+    # sector is NULL or unmapped. The FE uses this as the fallback sector label for
+    # non-SEC instruments that have no GICS sector (resolved from SIC below).
+    sector_name: str | None
     industry: str | None
     # #1634: real GICS sector + its sector-SPDR, resolved on-read from the SEC
     # SIC code (instruments.sector is an opaque 1-9 code). NULL when the
@@ -3598,7 +3602,8 @@ def get_instrument_summary(
         # ORDER BY / LIMIT needed.
         lookup_sql = f"""
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
-                   i.currency, i.sector, i.industry, i.country,
+                   i.currency, i.sector, esi.name AS sector_name,
+                   i.industry, i.country,
                    i.is_tradable, c.coverage_tier,
                    q.bid, q.ask, q.last,
                    p.sic,
@@ -3609,6 +3614,8 @@ def get_instrument_summary(
             LEFT JOIN quotes q USING (instrument_id)
             LEFT JOIN instrument_sec_profile p USING (instrument_id)
             LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+            LEFT JOIN etoro_stocks_industries esi
+              ON esi.industry_id::text = i.sector
             LEFT JOIN instruments canonical
               ON canonical.instrument_id = i.canonical_instrument_id
             WHERE i.instrument_id = %(id)s AND UPPER(i.symbol) = %(symbol)s
@@ -3617,7 +3624,8 @@ def get_instrument_summary(
     else:
         lookup_sql = f"""
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
-                   i.currency, i.sector, i.industry, i.country,
+                   i.currency, i.sector, esi.name AS sector_name,
+                   i.industry, i.country,
                    i.is_tradable, c.coverage_tier,
                    q.bid, q.ask, q.last,
                    p.sic,
@@ -3628,6 +3636,8 @@ def get_instrument_summary(
             LEFT JOIN quotes q USING (instrument_id)
             LEFT JOIN instrument_sec_profile p USING (instrument_id)
             LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+            LEFT JOIN etoro_stocks_industries esi
+              ON esi.industry_id::text = i.sector
             LEFT JOIN instruments canonical
               ON canonical.instrument_id = i.canonical_instrument_id
             WHERE UPPER(i.symbol) = %(symbol)s
@@ -3651,6 +3661,7 @@ def get_instrument_summary(
         symbol=row["symbol"],  # type: ignore[arg-type]
         display_name=row["company_name"] or None,  # type: ignore[arg-type]
         sector=row["sector"],  # type: ignore[arg-type]
+        sector_name=row["sector_name"],  # type: ignore[arg-type]
         industry=row["industry"],  # type: ignore[arg-type]
         gics_sector=sector_cls.gics_sector if sector_cls is not None else None,
         sector_spdr=sector_cls.spdr_symbol if sector_cls is not None else None,

--- a/app/api/watchlist.py
+++ b/app/api/watchlist.py
@@ -39,7 +39,10 @@ class WatchlistItem(BaseModel):
     company_name: str
     exchange: str | None
     currency: str | None
-    sector: str | None
+    sector: str | None  # eToro numeric industry id, as text (provider contract)
+    # Resolved eToro industry name via etoro_stocks_industries (sql/070); None when
+    # sector is NULL or the id has no dictionary row. The operator-facing label.
+    sector_name: str | None
     added_at: datetime
     notes: str | None
 
@@ -75,10 +78,12 @@ def list_watchlist(
         cur.execute(
             """
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
-                   i.currency, i.sector,
+                   i.currency, i.sector, esi.name AS sector_name,
                    w.added_at, w.notes
             FROM watchlist w
             JOIN instruments i USING (instrument_id)
+            LEFT JOIN etoro_stocks_industries esi
+              ON esi.industry_id::text = i.sector
             WHERE w.operator_id = %(op)s
             ORDER BY w.added_at DESC
             """,
@@ -93,6 +98,7 @@ def list_watchlist(
             exchange=r["exchange"],  # type: ignore[union-attr]
             currency=r["currency"],  # type: ignore[union-attr]
             sector=r["sector"],  # type: ignore[union-attr]
+            sector_name=r["sector_name"],  # type: ignore[union-attr]
             added_at=r["added_at"],  # type: ignore[arg-type]
             notes=r["notes"],  # type: ignore[union-attr]
         )
@@ -113,8 +119,11 @@ def add_to_watchlist(
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            "SELECT instrument_id, symbol, company_name, exchange, currency, sector "
-            "FROM instruments WHERE UPPER(symbol) = %(s)s LIMIT 1",
+            "SELECT i.instrument_id, i.symbol, i.company_name, i.exchange, "
+            "i.currency, i.sector, esi.name AS sector_name "
+            "FROM instruments i "
+            "LEFT JOIN etoro_stocks_industries esi ON esi.industry_id::text = i.sector "
+            "WHERE UPPER(i.symbol) = %(s)s LIMIT 1",
             {"s": symbol_clean},
         )
         inst = cur.fetchone()
@@ -152,6 +161,7 @@ def add_to_watchlist(
         exchange=inst["exchange"],  # type: ignore[union-attr]
         currency=inst["currency"],  # type: ignore[union-attr]
         sector=inst["sector"],  # type: ignore[union-attr]
+        sector_name=inst["sector_name"],  # type: ignore[union-attr]
         added_at=wl_row["added_at"],  # type: ignore[arg-type]
         notes=wl_row["notes"],  # type: ignore[union-attr]
     )

--- a/docs/specs/api/2026-06-28-resolve-etoro-sector-name.md
+++ b/docs/specs/api/2026-06-28-resolve-etoro-sector-name.md
@@ -1,0 +1,75 @@
+# Resolve eToro industry id → name at the remaining display read sites (#1599)
+
+## Problem (verified live, dev 2026-06-28)
+`#1598` fixed the eToro mapper casing, so `instruments.sector` now populates with
+eToro's **numeric** industry id as text. Full-population dev query:
+```sql
+SELECT count(*) total, count(sector) with_sector, count(DISTINCT sector) FROM instruments;
+-- total=12598, with_sector=9271, distinct=9
+SELECT sector, count(*) FROM instruments WHERE sector IS NOT NULL GROUP BY 1 ORDER BY 2 DESC;
+-- distinct values are exactly '1'..'9'
+```
+`etoro_stocks_industries` holds ids 1–9 all named, so every populated id resolves
+cleanly — no "Unknown" leakage on the current population.
+
+Two read sites still surface the **raw id** to the operator (FE renders it):
+- `app/api/watchlist.py` — `WatchlistItem.sector` selects `i.sector` verbatim; FE
+  `WatchlistPanel.tsx:56` renders `{item.sector ?? "—"}` → operator sees **"8"**.
+- `app/api/instruments.py` `InstrumentIdentity.sector` — FE `SummaryStrip.tsx:184`
+  falls back `gics_sector ?? sector` → for a **non-SEC** instrument (no GICS) the
+  raw id "8" shows.
+
+Not leaks (already correct, confirmed this session):
+- Instruments-list / scores items carry raw `sector` for the **deprecated** filter
+  back-compat (`#1675`); FE displays `gics_sector`, never raw `sector`.
+- Reports holdings (`reporting.py:1288`) already use `h.sector_name` (resolved).
+- The deprecated `sector` exact-match filter is documented (`#1675`) and superseded
+  by `sector_spdr` — out of scope.
+
+## Source rule
+eToro provider contract, documented at `sql/070_etoro_lookup_tables.sql:1-8`
+("universe ingest stores `stocksIndustryId` as a raw integer in
+`instruments.sector`") + the `etoro_stocks_industries` table comment
+(`sql/070_etoro_lookup_tables.sql:49-54`: "Maps numeric industryID … to the
+human-readable industry name rendered as the instrument-page sector label").
+`instruments.sector` = eToro's numeric industry id (text); the id→name dictionary
+is `etoro_stocks_industries (industry_id int, name text)`.
+Settled resolution pattern already in `app/services/valuation.py`
+(`_POSITIONS_SQL`, `HoldingValuation.sector` + `.sector_name`):
+```sql
+LEFT JOIN etoro_stocks_industries esi ON esi.industry_id::text = i.sector
+```
+Keep the raw `sector` field (provider contract); ADD a resolved `sector_name`.
+
+## Change
+1. `WatchlistItem`: add `sector_name: str | None`. Both queries (list GET, add POST)
+   LEFT JOIN `etoro_stocks_industries`; populate `sector_name`. Keep `sector` raw.
+2. `InstrumentIdentity`: add `sector_name: str | None`. The identity lookup SQL
+   (both branches) LEFT JOIN `etoro_stocks_industries`; populate it. Keep `sector`.
+3. FE types: add `sector_name: string | null` to `WatchlistItem`
+   (`frontend/src/api/watchlist.ts:3`) and to the `InstrumentIdentity` type
+   (`frontend/src/api/types.ts`).
+4. FE `WatchlistPanel.tsx`: render `{item.sector_name ?? "—"}`.
+5. FE `SummaryStrip.tsx`: fallback chain `gics_sector ?? sector_name ?? "—"`
+   (drop the raw-id fallback). Keep the `(sector_spdr)` suffix logic on gics.
+6. Tests:
+   - watchlist API: `sector_name` resolves id → name; null when id unmapped/NULL.
+   - instruments identity API: `sector_name` populated on BOTH lookup branches
+     (`instrument_id` path + symbol-only path), incl. unmapped id → null.
+   - FE component tests render the name, not the id.
+
+`sector_name` is `None` when `sector` is NULL or the id has no dictionary row —
+display falls back to "—" (safe; not a hard-rule check). Nullable, no default, to
+mirror TS `string | null` exactly (prevention-log identity-nullable convention).
+
+## Out of scope (follow-up)
+- `app/services/portfolio.py` BUY/ADD guard reason strings emit `sector {id!r}`
+  ("sector '8' would reach…"). Grouping math is correct (id-keyed); only the
+  human string leaks. Guard-internal cosmetic → focused follow-up ticket, not this
+  read-path display PR.
+
+## Verification
+- Unit: watchlist resolution test; FE component tests.
+- Dev endpoint: GET `/watchlist` + GET `/instruments/<sym>` (a non-SEC instrument)
+  and confirm `sector_name` renders the eToro name, raw `sector` unchanged.
+- No schema change, no backfill, no daemon restart (read-path only).

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -294,6 +294,9 @@ export interface InstrumentIdentity {
   symbol: string;
   display_name: string | null;
   sector: string | null;
+  /** #1599: resolved eToro industry name (the bare `sector` is the opaque eToro
+   * numeric id). The display fallback when `gics_sector` is null (non-SEC). */
+  sector_name: string | null;
   industry: string | null;
   /** #1634: real GICS sector + its sector-SPDR, resolved from the SEC SIC
    * (the bare `sector` is an opaque 1-9 code). null when the instrument has

--- a/frontend/src/api/watchlist.ts
+++ b/frontend/src/api/watchlist.ts
@@ -6,7 +6,8 @@ export interface WatchlistItem {
   company_name: string;
   exchange: string | null;
   currency: string | null;
-  sector: string | null;
+  sector: string | null; // eToro numeric industry id (provider contract)
+  sector_name: string | null; // resolved eToro industry name — the display label
   added_at: string;
   notes: string | null;
 }

--- a/frontend/src/components/dashboard/WatchlistPanel.test.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import type { WatchlistItem } from "@/api/watchlist";
+import { WatchlistPanel } from "@/components/dashboard/WatchlistPanel";
+
+function item(overrides: Partial<WatchlistItem> = {}): WatchlistItem {
+  return {
+    instrument_id: 1,
+    symbol: "AAPL",
+    company_name: "Apple Inc.",
+    exchange: "NMS",
+    currency: "USD",
+    sector: "8",
+    sector_name: "Technology",
+    added_at: "2026-04-15",
+    notes: null,
+    ...overrides,
+  };
+}
+
+describe("WatchlistPanel", () => {
+  it("renders the resolved sector name, never the raw eToro id (#1599)", () => {
+    render(
+      <MemoryRouter>
+        <WatchlistPanel items={[item()]} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Technology")).toBeInTheDocument();
+    // The opaque eToro numeric id must never reach the operator.
+    expect(screen.queryByText("8")).not.toBeInTheDocument();
+  });
+
+  it("falls back to em-dash when the sector is unmapped", () => {
+    render(
+      <MemoryRouter>
+        <WatchlistPanel items={[item({ sector: null, sector_name: null })]} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("shows the empty state with no items", () => {
+    render(
+      <MemoryRouter>
+        <WatchlistPanel items={[]} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Watchlist empty")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/WatchlistPanel.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.tsx
@@ -53,7 +53,9 @@ export function WatchlistPanel({ items, onRemove }: Props) {
                 </Link>
               </td>
               <td className="px-2 py-1">{item.company_name}</td>
-              <td className="px-2 py-1 text-slate-500 dark:text-slate-400">{item.sector ?? "—"}</td>
+              <td className="px-2 py-1 text-slate-500 dark:text-slate-400">
+                {item.sector_name ?? "—"}
+              </td>
               <td className="px-2 py-1 text-xs text-slate-500 dark:text-slate-400">
                 {item.notes ?? ""}
               </td>

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -27,7 +27,8 @@ function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary 
     identity: {
       symbol: "AAPL",
       display_name: "Apple Inc.",
-      sector: "Technology",
+      sector: "8",
+      sector_name: "Technology",
       industry: "Consumer Electronics",
       gics_sector: null,
       sector_spdr: null,
@@ -176,6 +177,28 @@ describe("SummaryStrip — action gating", () => {
     ).toBeInTheDocument();
     // The opaque code is not surfaced when a real sector resolves.
     expect(screen.queryByText(/^3 ·/)).not.toBeInTheDocument();
+  });
+
+  it("falls back to the resolved eToro industry name, never the raw id (#1599)", () => {
+    render(
+      <SummaryStrip
+        summary={summary({
+          identity: {
+            ...summary().identity,
+            sector: "5",
+            sector_name: "Healthcare",
+            gics_sector: null,
+            sector_spdr: null,
+          },
+        })}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByText(/Healthcare/)).toBeInTheDocument();
+    // The opaque eToro numeric id must never be surfaced.
+    expect(screen.queryByText(/^5 ·/)).not.toBeInTheDocument();
   });
 
   it("hides Close when not held", () => {

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -179,9 +179,10 @@ export function SummaryStrip({
       </div>
 
       {/* Row 2: sector strip. Prefer the real GICS sector (#1634, resolved from
-          the SEC SIC) over the opaque 1-9 `sector` code; show its sector-SPDR. */}
+          the SEC SIC); fall back to the resolved eToro industry name (#1599) for
+          non-SEC instruments. Never the opaque numeric `sector` id. */}
       <div className="mt-1 text-xs text-slate-500">
-        {identity.gics_sector ?? identity.sector ?? "—"}
+        {identity.gics_sector ?? identity.sector_name ?? "—"}
         {identity.gics_sector && identity.sector_spdr
           ? ` (${identity.sector_spdr})`
           : ""}

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -95,9 +95,11 @@ def test_happy_path_with_quote_and_no_sec(client: TestClient) -> None:
         "exchange": "8",
         "currency": "USD",
         "sector": None,
+        "sector_name": None,
         "industry": None,
         "country": None,
         "is_tradable": True,
+        "session_profile": "continuous",
         "coverage_tier": 3,
         "bid": Decimal("60000.50"),
         "ask": Decimal("60001.00"),
@@ -119,6 +121,7 @@ def test_happy_path_with_quote_and_no_sec(client: TestClient) -> None:
     assert body["identity"]["currency"] == "USD"
     # No yfinance fill-in for sector/industry/country.
     assert body["identity"]["sector"] is None
+    assert body["identity"]["sector_name"] is None
     assert body["identity"]["industry"] is None
     # Price reflects ``quotes.last``, not yfinance.
     assert body["price"]["current"] == "60000.75"
@@ -146,9 +149,11 @@ def test_no_quote_returns_null_price_block(client: TestClient) -> None:
         "exchange": "8",
         "currency": "USD",
         "sector": None,
+        "sector_name": None,
         "industry": None,
         "country": None,
         "is_tradable": True,
+        "session_profile": "continuous",
         "coverage_tier": 3,
         "bid": None,
         "ask": None,
@@ -179,9 +184,11 @@ def test_bid_ask_mid_when_last_missing(client: TestClient) -> None:
         "exchange": "NYSE",
         "currency": "USD",
         "sector": None,
+        "sector_name": None,
         "industry": None,
         "country": None,
         "is_tradable": True,
+        "session_profile": "continuous",
         "coverage_tier": 2,
         "bid": Decimal("12.34"),
         "ask": Decimal("12.36"),
@@ -211,9 +218,11 @@ def test_zero_last_uses_bid_ask_mid(client: TestClient) -> None:
         "exchange": "NYSE",
         "currency": "USD",
         "sector": None,
+        "sector_name": None,
         "industry": None,
         "country": None,
         "is_tradable": True,
+        "session_profile": "continuous",
         "coverage_tier": 2,
         "bid": Decimal("697.16"),
         "ask": Decimal("697.22"),
@@ -241,10 +250,12 @@ def test_local_company_name_authoritative(client: TestClient) -> None:
         "company_name": "Apple Inc.",
         "exchange": "NMS",
         "currency": "USD",
-        "sector": "Technology",
+        "sector": "8",
+        "sector_name": "Technology",
         "industry": "Consumer Electronics",
         "country": "United States",
         "is_tradable": True,
+        "session_profile": "continuous",
         "coverage_tier": 1,
         "bid": Decimal("180.00"),
         "ask": Decimal("180.05"),
@@ -262,7 +273,10 @@ def test_local_company_name_authoritative(client: TestClient) -> None:
     body = resp.json()
     assert body["identity"]["display_name"] == "Apple Inc."
     assert body["identity"]["symbol"] == "AAPL"
-    assert body["identity"]["sector"] == "Technology"
+    # #1599: raw `sector` keeps the eToro numeric id (provider contract);
+    # `sector_name` carries the resolved label the FE renders.
+    assert body["identity"]["sector"] == "8"
+    assert body["identity"]["sector_name"] == "Technology"
     assert body["identity"]["industry"] == "Consumer Electronics"
 
 
@@ -362,10 +376,14 @@ def test_id_override_pinned_lookup(client: TestClient) -> None:
         "company_name": "Grayscale Bitcoin Mini Trust",
         "exchange": "5",
         "currency": "USD",
-        "sector": None,
+        # #1599: prove the ?id= lookup branch also carries the resolved
+        # sector_name (raw eToro id preserved, name resolved via the join).
+        "sector": "4",
+        "sector_name": "Financial",
         "industry": None,
         "country": "United States",
         "is_tradable": True,
+        "session_profile": "us_equity",
         "coverage_tier": 3,
         "bid": Decimal("34.30"),
         "ask": Decimal("34.40"),
@@ -379,6 +397,9 @@ def test_id_override_pinned_lookup(client: TestClient) -> None:
         _clear_conn()
     assert resp.status_code == 200, resp.text
     assert resp.json()["instrument_id"] == 12220
+    # id-branch SELECT carries the resolved sector_name (#1599).
+    assert resp.json()["identity"]["sector"] == "4"
+    assert resp.json()["identity"]["sector_name"] == "Financial"
 
 
 def test_id_override_symbol_mismatch_returns_404(client: TestClient) -> None:
@@ -407,9 +428,11 @@ def test_dividend_only_partial_stats_surface(client: TestClient) -> None:
         "exchange": "NYSE",
         "currency": "USD",
         "sector": None,
+        "sector_name": None,
         "industry": None,
         "country": "United States",
         "is_tradable": True,
+        "session_profile": "continuous",
         "coverage_tier": 2,
         "bid": Decimal("50"),
         "ask": Decimal("50.10"),
@@ -472,9 +495,11 @@ def test_canonical_symbol_surfaced_for_rth_variant(client: TestClient) -> None:
         "exchange": "33",
         "currency": None,
         "sector": None,
+        "sector_name": None,
         "industry": None,
         "country": None,
         "is_tradable": True,
+        "session_profile": "us_equity_rth",
         "coverage_tier": None,
         "bid": None,
         "ask": None,
@@ -504,10 +529,12 @@ def test_canonical_symbol_null_for_canonical_instrument(client: TestClient) -> N
         "company_name": "Apple Inc",
         "exchange": "4",
         "currency": "USD",
-        "sector": "Technology",
+        "sector": "8",  # eToro numeric industry id (provider contract)
+        "sector_name": "Technology",
         "industry": "Consumer Electronics",
         "country": "US",
         "is_tradable": True,
+        "session_profile": "us_equity",
         "coverage_tier": 1,
         "bid": None,
         "ask": None,

--- a/tests/test_api_watchlist.py
+++ b/tests/test_api_watchlist.py
@@ -66,7 +66,8 @@ def test_list_returns_items_sorted_newest_first(client: TestClient) -> None:
             "company_name": "Apple Inc.",
             "exchange": "NMS",
             "currency": "USD",
-            "sector": "Technology",
+            "sector": "8",  # eToro numeric industry id (provider contract)
+            "sector_name": "Technology",  # resolved via etoro_stocks_industries join
             "added_at": datetime(2026, 4, 15),
             "notes": "core holding",
         },
@@ -76,7 +77,10 @@ def test_list_returns_items_sorted_newest_first(client: TestClient) -> None:
             "company_name": "Vodafone",
             "exchange": "LSE",
             "currency": "GBP",
-            "sector": "Telecom",
+            # raw eToro id present but absent from etoro_stocks_industries →
+            # the join yields NULL; sector_name must surface as None, not the id.
+            "sector": "99",
+            "sector_name": None,
             "added_at": datetime(2026, 4, 10),
             "notes": None,
         },
@@ -90,6 +94,10 @@ def test_list_returns_items_sorted_newest_first(client: TestClient) -> None:
     assert body["items"][0]["symbol"] == "AAPL"
     assert body["items"][0]["notes"] == "core holding"
     assert body["items"][1]["notes"] is None
+    # #1599: raw `sector` keeps the eToro id; `sector_name` is the resolved label.
+    assert body["items"][0]["sector"] == "8"
+    assert body["items"][0]["sector_name"] == "Technology"
+    assert body["items"][1]["sector_name"] is None
 
 
 def test_add_happy_path(client: TestClient) -> None:
@@ -101,7 +109,8 @@ def test_add_happy_path(client: TestClient) -> None:
             "company_name": "Apple Inc.",
             "exchange": "NMS",
             "currency": "USD",
-            "sector": "Technology",
+            "sector": "8",
+            "sector_name": "Technology",
         },
         {"added_at": datetime(2026, 4, 19), "notes": "watch for earnings"},
     ]
@@ -115,6 +124,7 @@ def test_add_happy_path(client: TestClient) -> None:
     body = resp.json()
     assert body["symbol"] == "AAPL"
     assert body["notes"] == "watch for earnings"
+    assert body["sector_name"] == "Technology"  # #1599 resolved on add
 
 
 def test_add_without_notes_preserves_existing_notes(client: TestClient) -> None:
@@ -127,7 +137,8 @@ def test_add_without_notes_preserves_existing_notes(client: TestClient) -> None:
             "company_name": "Apple Inc.",
             "exchange": "NMS",
             "currency": "USD",
-            "sector": "Technology",
+            "sector": "8",
+            "sector_name": "Technology",
         },
         # Server returns the PRESERVED note, not NULL.
         {"added_at": datetime(2026, 4, 10), "notes": "core holding"},


### PR DESCRIPTION
## Problem (verified live, dev 2026-06-28)
After #1598 fixed the eToro mapper casing, `instruments.sector` now populates with eToro's **numeric** industry id as text. Full-population dev query: `total=12598, with_sector=9271, distinct=9`, values exactly `'1'..'9'`, **0 unresolved** against `etoro_stocks_industries`.

Two read sites still surfaced the **raw id** to the operator:
- **Watchlist** — `WatchlistItem.sector` selected `i.sector` verbatim; FE `WatchlistPanel.tsx` rendered `{item.sector ?? "—"}` → operator saw **"8"**.
- **Instrument identity** — `SummaryStrip.tsx` fell back `gics_sector ?? sector` → a **non-SEC** instrument (no GICS from SIC) showed the raw id "8". Live-confirmed: `GET /instruments/00001.HK/summary` previously exposed `sector="7"`.

## Source rule
`sql/070_etoro_lookup_tables.sql:1-8,49-54` — universe ingest stores `stocksIndustryId` as a raw integer in `instruments.sector`; `etoro_stocks_industries (industry_id, name)` maps id → human label. Mirror the settled `app/services/valuation.py` pattern: keep raw `sector` (provider contract), ADD resolved `sector_name` via `LEFT JOIN etoro_stocks_industries esi ON esi.industry_id::text = i.sector`.

## Change
- `app/api/watchlist.py`: `WatchlistItem.sector_name`; join in list GET + add POST.
- `app/api/instruments.py`: `InstrumentIdentity.sector_name`; join in **both** lookup branches (`?id=` + symbol-only).
- FE: `WatchlistItem` (`api/watchlist.ts`) + `InstrumentIdentity` (`api/types.ts`) gain `sector_name`. `WatchlistPanel` renders `sector_name`; `SummaryStrip` fallback chain `gics_sector ?? sector_name ?? "—"` (never the raw id).
- Tests: watchlist resolution + unmapped (raw id present, no dict row → null); identity `sector_name` on **both** SQL branches; SummaryStrip eToro-name fallback; new `WatchlistPanel.test.tsx`.

## Pre-existing rot repaired (bundled, file already touched)
`test_api_instrument_summary.py` mocked-row fixtures were missing the `session_profile` key added to the query by #609 — these are `db`-marked (TestClient) so they sit **off the fast-tier push gate** and had been red & ungated. Added `session_profile` per the `_SESSION_PROFILE_SQL` rule for each fixture's exchange (exchange "33"→`us_equity_rth`, "8"=crypto/string-labels→`continuous`, "4"/"5"=us_equity→`us_equity`; asset_class confirmed against dev `exchanges`).

## Out of scope
- **#1778** (filed): execution-guard BUY/ADD reason strings still emit the raw id. Grouping math is correct (id-keyed); cosmetic string only — carved out to keep this PR off the guard module.
- Instruments-list / scores raw `sector` field is intentional provider-contract back-compat (FE displays `gics_sector`, #1675); the deprecated `sector` exact-match filter is superseded by `sector_spdr` (#1675). Not leaks.

## Verification
- **Source rule**: `sql/070` cited (Codex ckpt-1).
- **Full-population**: dev join — every populated id resolves, 0 unresolved.
- **Live endpoint** (clause 11): `GET /instruments/00001.HK/summary` (non-SEC) now returns `sector="7"` (raw preserved) + `sector_name="Services"` + `gics_sector=null`. Watchlist is auth-gated (401); resolution mechanism verified via the summary endpoint + DB join + unit tests.
- **Gates green** @ `5372c0f3`: ruff, ruff format, pyright (0 errors), fast tier (4589 passed), smoke (129 passed), FE typecheck, FE unit (1146 + 3 new + 1 new SummaryStrip).
- **Codex**: ckpt-1 (spec) + ckpt-2 (branch) — all findings FIXED (id-branch coverage, unmapped-id case, per-exchange session_profile values, numeric raw-sector fixtures).

No schema change, no backfill, no daemon restart (read-path only).

Closes #1599.