### PR TITLE
fix(#1778): show resolved sector name in execution-guard BUY/ADD reasons

### DIFF
--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -419,16 +419,22 @@ def _load_instrument_details(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT instrument_id, symbol, sector
-            FROM instruments
-            WHERE instrument_id = ANY(%(ids)s)
+            SELECT i.instrument_id, i.symbol, i.sector, esi.name AS sector_name
+            FROM instruments i
+            LEFT JOIN etoro_stocks_industries esi
+              ON esi.industry_id::text = i.sector
+            WHERE i.instrument_id = ANY(%(ids)s)
             """,
             {"ids": instrument_ids},
         )
         for r in cur.fetchall():
             iid = int(r["instrument_id"])
             details[iid]["symbol"] = str(r["symbol"])
+            # ``sector`` is the eToro numeric industry id (provider contract) — it
+            # remains the grouping/cap key. ``sector_name`` resolves it to the
+            # human label (sql/070) used ONLY in operator-facing reason strings.
             details[iid]["sector"] = r["sector"]
+            details[iid]["sector_name"] = r["sector_name"]
 
     # Latest thesis
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -702,9 +708,12 @@ def _evaluate_add(
     pending_pct = pending_sector_pct.get(pos.sector, 0.0) if pos.sector is not None else 0.0
     sector_after = held_sector_pct + pending_pct + add_pct
     if pos.sector is not None and sector_after > MAX_SECTOR_EXPOSURE_PCT:
+        # Display the resolved industry name (#1778); fall back to the raw id
+        # when unmapped. Keying above stays on the raw ``pos.sector``.
+        label = details.get("sector_name") or pos.sector
         return (
             False,
-            f"ADD blocked: sector {pos.sector!r} would reach {sector_after:.1%} > max {MAX_SECTOR_EXPOSURE_PCT:.0%}",
+            f"ADD blocked: sector {label!r} would reach {sector_after:.1%} > max {MAX_SECTOR_EXPOSURE_PCT:.0%}",
         )
 
     signals: list[str] = []
@@ -777,9 +786,12 @@ def _evaluate_buy(
         pending_pct = pending_sector_pct.get(sector, 0.0)
         sector_after = held_pct + pending_pct + MAX_INITIAL_POSITION_PCT
         if sector_after > MAX_SECTOR_EXPOSURE_PCT:
+            # Display the resolved industry name (#1778); fall back to the raw id
+            # when unmapped. Keying above stays on the raw ``sector``.
+            label = details.get("sector_name") or sector
             return (
                 False,
-                f"BUY blocked: sector {sector!r} would reach {sector_after:.1%} > max {MAX_SECTOR_EXPOSURE_PCT:.0%}",
+                f"BUY blocked: sector {label!r} would reach {sector_after:.1%} > max {MAX_SECTOR_EXPOSURE_PCT:.0%}",
             )
 
     if cash is not None and total_aum > 0:

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -304,6 +304,47 @@ class TestEvaluateAdd:
         assert should_add is False
         assert "sector" in reason.lower()
 
+    def test_add_block_reason_shows_resolved_sector_name_not_raw_id(self) -> None:
+        """#1778: the breach reason displays the resolved eToro industry name
+        (from details['sector_name']); the raw numeric id never reaches the
+        operator. Keying still uses the raw id."""
+        pos1 = _pos(instrument_id=1, symbol="A", sector="8", market_value=2_000.0)
+        pos2 = _pos(instrument_id=2, symbol="B", sector="8", market_value=400.0)
+        details: dict[str, Any] = {
+            "thesis": _thesis(stance="buy"),
+            "prev_thesis_confidence": 0.60,
+            "sector_name": "Technology",
+        }
+        should_add, reason = _evaluate_add(
+            pos2,
+            details,
+            _score(total_score=0.80, confidence_score=0.80),
+            prev_score_total=0.60,
+            total_aum=10_000.0,
+            positions={1: pos1, 2: pos2},
+            pending_sector_pct={},
+        )
+        assert should_add is False
+        assert "Technology" in reason
+        assert "'8'" not in reason
+
+    def test_add_block_reason_falls_back_to_raw_id_when_unmapped(self) -> None:
+        """#1778: when sector_name is absent (unmapped id), the reason falls
+        back to the raw id rather than crashing."""
+        pos1 = _pos(instrument_id=1, symbol="A", sector="99", market_value=2_000.0)
+        pos2 = _pos(instrument_id=2, symbol="B", sector="99", market_value=400.0)
+        should_add, reason = _evaluate_add(
+            pos2,
+            {"thesis": _thesis(stance="buy"), "prev_thesis_confidence": 0.60},
+            _score(total_score=0.80, confidence_score=0.80),
+            prev_score_total=0.60,
+            total_aum=10_000.0,
+            positions={1: pos1, 2: pos2},
+            pending_sector_pct={},
+        )
+        assert should_add is False
+        assert "'99'" in reason
+
     def test_pending_sector_pct_accumulator_pushes_add_over_cap(self) -> None:
         """#42: even if held-sector-only math stays under the cap, a large
         in-flight pending BUY allocation in the same sector should block
@@ -435,6 +476,44 @@ class TestEvaluateBuy:
         )
         assert should_buy is False
         assert "sector" in reason
+
+    def test_buy_block_reason_shows_resolved_sector_name_not_raw_id(self) -> None:
+        """#1778: BUY breach reason displays the resolved industry name, not the
+        raw eToro id. Keying still uses the raw id."""
+        pos = _pos(sector="8", market_value=25_000.0)
+        should_buy, reason = _evaluate_buy(
+            2,
+            "MSFT",
+            "8",
+            {"thesis": _thesis(stance="buy"), "sector_name": "Technology"},
+            _score(total_score=0.80),
+            {1: pos},
+            total_aum=100_000.0,
+            cash=10_000.0,
+            pending_buy_count=0,
+            pending_sector_pct={},
+        )
+        assert should_buy is False
+        assert "Technology" in reason
+        assert "'8'" not in reason
+
+    def test_buy_block_reason_falls_back_to_raw_id_when_unmapped(self) -> None:
+        """#1778: BUY breach reason falls back to the raw id when unmapped."""
+        pos = _pos(sector="99", market_value=25_000.0)
+        should_buy, reason = _evaluate_buy(
+            2,
+            "MSFT",
+            "99",
+            {"thesis": _thesis(stance="buy")},
+            _score(total_score=0.80),
+            {1: pos},
+            total_aum=100_000.0,
+            cash=10_000.0,
+            pending_buy_count=0,
+            pending_sector_pct={},
+        )
+        assert should_buy is False
+        assert "'99'" in reason
 
     def test_sector_cap_blocks_second_buy_via_accumulator(self) -> None:
         # No held positions; first BUY approved (5% Tech pending).
@@ -687,7 +766,7 @@ class TestRunPortfolioReview:
                 ]
             ),
             # 4a. _load_instrument_details: instruments
-            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology"}]),
+            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology", "sector_name": "Technology"}]),
             # 4b. theses
             _make_cursor(
                 [
@@ -758,7 +837,7 @@ class TestRunPortfolioReview:
                 ]
             ),
             # _load_instrument_details: instruments
-            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology"}]),
+            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology", "sector_name": "Technology"}]),
             # theses
             _make_cursor(
                 [
@@ -821,7 +900,7 @@ class TestRunPortfolioReview:
                     }
                 ]
             ),
-            _make_cursor([{"instrument_id": 1, "symbol": "XYZ", "sector": "Energy"}]),
+            _make_cursor([{"instrument_id": 1, "symbol": "XYZ", "sector": "Energy", "sector_name": "Energy"}]),
             _make_cursor(
                 [
                     {
@@ -871,7 +950,7 @@ class TestRunPortfolioReview:
             # ranked_scores — instrument 1 is NOT here
             _make_cursor([]),
             # _load_instrument_details — called for held instrument
-            _make_cursor([{"instrument_id": 1, "symbol": "OLD", "sector": "Utilities"}]),
+            _make_cursor([{"instrument_id": 1, "symbol": "OLD", "sector": "Utilities", "sector_name": "Utilities"}]),
             _make_cursor([]),  # theses
             _make_cursor([]),  # prev thesis
             _make_cursor([]),  # filing_events
@@ -919,7 +998,7 @@ class TestRunPortfolioReview:
                     }
                 ]
             ),
-            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology"}]),
+            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology", "sector_name": "Technology"}]),
             _make_cursor(
                 [
                     {
@@ -1008,9 +1087,9 @@ class TestRunPortfolioReview:
             # instruments — includes held instrument 10 and candidates 1, 2
             _make_cursor(
                 [
-                    {"instrument_id": 1, "symbol": "AAPL", "sector": "Technology"},
-                    {"instrument_id": 2, "symbol": "MSFT", "sector": "Technology"},
-                    {"instrument_id": 10, "symbol": "HELD", "sector": "Technology"},
+                    {"instrument_id": 1, "symbol": "AAPL", "sector": "Technology", "sector_name": "Technology"},
+                    {"instrument_id": 2, "symbol": "MSFT", "sector": "Technology", "sector_name": "Technology"},
+                    {"instrument_id": 10, "symbol": "HELD", "sector": "Technology", "sector_name": "Technology"},
                 ]
             ),
             # theses
@@ -1096,7 +1175,7 @@ class TestRunPortfolioReview:
                     }
                 ]
             ),
-            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology"}]),
+            _make_cursor([{"instrument_id": 1, "symbol": "AAPL", "sector": "Technology", "sector_name": "Technology"}]),
             _make_cursor(
                 [
                     {


### PR DESCRIPTION
## Problem
Portfolio-review concentration-cap rejection reasons emitted the raw eToro numeric industry id:
> `BUY blocked: sector '8' would reach 29.0% > max 25%`

The cap **math is correct** — grouping/keying is on the raw id (`_sector_pct`, `pending_sector_pct`); only the operator-facing string leaked the id. Carved out of #1599 to keep that PR off the guard module.

## Source rule
`sql/070_etoro_lookup_tables.sql` — `instruments.sector` = eToro numeric industry id; `etoro_stocks_industries` maps id → human name.

## Change
- `_load_instrument_details`: `LEFT JOIN etoro_stocks_industries esi ON esi.industry_id::text = i.sector`; store `details[iid]["sector_name"]`.
- `_evaluate_buy` / `_evaluate_add`: reason string displays `details.get("sector_name") or sector`. **All keying + the accumulator stay on the raw id**; unmapped ids fall back to the raw id (no crash).
- Tests: BUY + ADD breach reasons show the resolved name (not the id) when mapped; fall back to the raw id when unmapped.

## Verification
- `tests/test_portfolio.py`: 43 passed (4 new). ruff + ruff format + pyright clean on `app/services/portfolio.py`.
- Codex ckpt-2: no findings (confirmed keying unchanged at the cap checks + accumulator; fallback safe; JOIN consistent with existing patterns).
- JOIN pattern live-verified in #1599 (full-pop dev: 0 unresolved).

Read-path/display only — no schema change, no backfill. Daemon restart on merge to pick up the new reason strings (no rebuild).

Closes #1778.