### PR TITLE
fix(#1328): rotate var/runbooks/*.jsonl logs after 30 days

### DIFF
--- a/app/runbooks/safety.py
+++ b/app/runbooks/safety.py
@@ -25,8 +25,10 @@ precondition) so runbooks can re-raise without wrapping.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
+from pathlib import Path
 from typing import cast
 from urllib.parse import urlparse
 
@@ -34,6 +36,8 @@ import psycopg
 
 from app.config import settings
 from app.jobs.locks import probe_jobs_process_running
+
+logger = logging.getLogger(__name__)
 
 # Default dev-DB allowlist when EBULL_DEV_DB_NAMES is unset. Matches the
 # post-connection default in ``assert_dev_db`` so pre + post checks agree.
@@ -288,3 +292,40 @@ def assert_no_multixact_wraparound(conn: psycopg.Connection[object]) -> None:
             f"project_1233_pr12_ownership_merge_writer.md) BEFORE "
             f"re-running this runbook."
         )
+
+
+# #1328 — runbook log retention. ``var/runbooks/*.jsonl`` is .gitignored +
+# dev-local, so these logs only accrete on a long-running dev box; bound the
+# growth instead of letting them grow forever.
+RUNBOOK_LOG_RETENTION_DAYS = 30
+
+
+def prune_old_runbook_logs(
+    log_dir: Path,
+    *,
+    retention_days: int = RUNBOOK_LOG_RETENTION_DAYS,
+    now: float | None = None,
+) -> list[Path]:
+    """Delete ``*.jsonl`` logs in ``log_dir`` older than ``retention_days``
+    (by mtime). Returns the files actually removed.
+
+    Best-effort + FAIL-OPEN: rotation is a side cleanup, never the runbook's
+    purpose, so it must not break the write it is bundled with. Every
+    filesystem error (dir absent, file vanished mid-prune, permission race) is
+    swallowed and logged at DEBUG. ``now`` is injectable for tests.
+    """
+    cutoff = (now if now is not None else time.time()) - retention_days * 86400
+    deleted: list[Path] = []
+    try:
+        candidates = sorted(log_dir.glob("*.jsonl"))
+    except OSError:
+        logger.debug("prune_old_runbook_logs: glob failed for %s", log_dir, exc_info=True)
+        return deleted
+    for path in candidates:
+        try:
+            if path.stat().st_mtime < cutoff:
+                path.unlink()
+                deleted.append(path)
+        except OSError:
+            logger.debug("prune_old_runbook_logs: skip %s", path, exc_info=True)
+    return deleted

--- a/app/runbooks/sec_lazy_body_backfill.py
+++ b/app/runbooks/sec_lazy_body_backfill.py
@@ -47,6 +47,7 @@ from app.runbooks.safety import (
     assert_dev_db,
     assert_dev_db_name_in_url,
     assert_dev_env,
+    prune_old_runbook_logs,
 )
 
 LOG_DIR: Path = Path("var/runbooks")
@@ -87,6 +88,7 @@ def _flip_deferred_to_pending(conn: psycopg.Connection[Any], *, source: str, ins
 
 def _write_log_jsonl(envelope: dict[str, Any]) -> Path:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
+    prune_old_runbook_logs(LOG_DIR)  # #1328 — bound dev-local log growth
     ts = int(time.time())
     path = LOG_DIR / f"sec_lazy_body_backfill-{ts}.jsonl"
     with path.open("a") as fh:

--- a/app/runbooks/stream_a_run_8_verify.py
+++ b/app/runbooks/stream_a_run_8_verify.py
@@ -81,6 +81,7 @@ from app.runbooks.safety import (
     assert_jobs_process_stopped,
     assert_no_multixact_wraparound,
     parse_db_name_from_url,
+    prune_old_runbook_logs,
     wait_for_jobs_process_started,
 )
 
@@ -377,6 +378,7 @@ def _poll_once_with_retry(
 
 def _write_log_jsonl(envelope: dict[str, Any]) -> Path:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
+    prune_old_runbook_logs(LOG_DIR)  # #1328 — bound dev-local log growth
     ts = int(time.time())
     run_id = envelope.get("captured_run_id") or "queued"
     path = LOG_DIR / f"stream_a_run_8_verify-{run_id}-{ts}.jsonl"

--- a/app/runbooks/stream_a_stream_c_gate.py
+++ b/app/runbooks/stream_a_stream_c_gate.py
@@ -46,6 +46,7 @@ from app.runbooks.safety import (  # noqa: E402
     assert_dev_db,
     assert_dev_db_name_in_url,
     assert_dev_env,
+    prune_old_runbook_logs,
 )
 from app.runbooks.stream_a_stream_c_gate_schema import validate_envelope  # noqa: E402
 from app.services.capability_manifest_mapping import (  # noqa: E402
@@ -354,6 +355,7 @@ def _persist_status(conn: psycopg.Connection[Any], *, run_id: int, status_value:
 def _write_log_jsonl(envelope: dict[str, Any]) -> Path:
     """Append the envelope to ``var/runbooks/stream_a_stream_c_gate-<id>-<ts>.jsonl``."""
     LOG_DIR.mkdir(parents=True, exist_ok=True)
+    prune_old_runbook_logs(LOG_DIR)  # #1328 — bound dev-local log growth
     ts = int(time.time())
     run_id = envelope.get("bootstrap_run_id", "unknown")
     path = LOG_DIR / f"stream_a_stream_c_gate-{run_id}-{ts}.jsonl"

--- a/app/runbooks/stream_a_t13_sidecar_repair.py
+++ b/app/runbooks/stream_a_t13_sidecar_repair.py
@@ -43,6 +43,7 @@ from app.runbooks.safety import (
     assert_dev_db_name_in_url,
     assert_dev_env,
     assert_jobs_process_stopped,
+    prune_old_runbook_logs,
 )
 from app.services.sec_submissions_ingest import repair_cik_sidecar_from_archive
 
@@ -71,6 +72,7 @@ def _count_archive_entries(archive_path: Path, *, cik: str | None) -> int:
 
 def _write_log_jsonl(envelope: dict[str, Any]) -> Path:
     LOG_DIR.mkdir(parents=True, exist_ok=True)
+    prune_old_runbook_logs(LOG_DIR)  # #1328 — bound dev-local log growth
     ts = int(time.time())
     path = LOG_DIR / f"stream_a_t13_sidecar_repair-{ts}.jsonl"
     with path.open("a") as fh:

--- a/tests/test_runbook_log_rotation.py
+++ b/tests/test_runbook_log_rotation.py
@@ -1,0 +1,73 @@
+"""#1328 — runbook log retention (``prune_old_runbook_logs``).
+
+Pure filesystem logic (tmp_path, no DB). Backdates files via ``os.utime`` to
+exercise the mtime cutoff, per the issue's acceptance criterion.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from app.runbooks.safety import RUNBOOK_LOG_RETENTION_DAYS, prune_old_runbook_logs
+
+_DAY = 86400
+
+
+def _touch(path: Path, *, age_days: float) -> None:
+    path.write_text("{}\n")
+    when = time.time() - age_days * _DAY
+    os.utime(path, (when, when))
+
+
+def test_deletes_only_logs_older_than_retention(tmp_path: Path) -> None:
+    old = tmp_path / "run-1.jsonl"
+    recent = tmp_path / "run-2.jsonl"
+    _touch(old, age_days=RUNBOOK_LOG_RETENTION_DAYS + 1)  # 31d → stale
+    _touch(recent, age_days=RUNBOOK_LOG_RETENTION_DAYS - 1)  # 29d → kept
+
+    deleted = prune_old_runbook_logs(tmp_path)
+
+    assert deleted == [old]
+    assert not old.exists()
+    assert recent.exists()
+
+
+def test_boundary_exactly_retention_is_kept(tmp_path: Path) -> None:
+    # mtime == cutoff is NOT older than cutoff (strict <), so a file aged
+    # exactly retention_days survives. Pin a fixed clock so the file's mtime
+    # and the cutoff derive from the SAME `now` — otherwise the microseconds
+    # between stamping and the call tip strict-equality over the edge.
+    now = 1_000_000_000.0
+    edge = tmp_path / "edge.jsonl"
+    edge.write_text("{}\n")
+    mtime = now - RUNBOOK_LOG_RETENTION_DAYS * _DAY  # exactly the cutoff
+    os.utime(edge, (mtime, mtime))
+
+    deleted = prune_old_runbook_logs(tmp_path, now=now)
+
+    assert edge.exists()
+    assert deleted == []
+
+
+def test_ignores_non_jsonl_files(tmp_path: Path) -> None:
+    keep = tmp_path / "old.log"  # not *.jsonl
+    _touch(keep, age_days=999)
+    deleted = prune_old_runbook_logs(tmp_path)
+    assert deleted == []
+    assert keep.exists()
+
+
+def test_missing_dir_is_a_noop_not_a_raise(tmp_path: Path) -> None:
+    absent = tmp_path / "does-not-exist"
+    # Fail-open: a rotation over an absent dir must not raise (it must never
+    # break the runbook write it is bundled with).
+    assert prune_old_runbook_logs(absent) == []
+
+
+def test_custom_retention_days(tmp_path: Path) -> None:
+    f = tmp_path / "x.jsonl"
+    _touch(f, age_days=10)
+    assert prune_old_runbook_logs(f.parent, retention_days=7) == [f]
+    assert not f.exists()


### PR DESCRIPTION
## What
Operator runbook logs under `var/runbooks/*.jsonl` (`.gitignored`, dev-local) accrete forever on a long-running dev box. Add a fail-open rotation helper, called from each runbook's log writer (#1233 polish T10).

## How
- **`app/runbooks/safety.py`** — `prune_old_runbook_logs(log_dir, *, retention_days=30, now=None) -> list[Path]`. Deletes `*.jsonl` in `log_dir` older than the cutoff by mtime (strict `<`, so an exact-boundary file is kept). **Fail-open**: every filesystem error (absent dir, file vanished mid-prune, permission race) is swallowed + logged at DEBUG — a rotation failure must never break the runbook write it's bundled with. `now` injectable for tests. `RUNBOOK_LOG_RETENTION_DAYS = 30`.
- Called from each `_write_log_jsonl` right after `LOG_DIR.mkdir(...)`: `sec_lazy_body_backfill`, `stream_a_run_8_verify`, `stream_a_stream_c_gate`, `stream_a_t13_sidecar_repair` (all share `LOG_DIR = Path("var/runbooks")`). Chose the issue's option (b) — one shared helper — over a per-runbook `find -delete` so the policy lives in one place.

## Safety / security model
- Deletion is scoped to direct `*.jsonl` children of the supplied `log_dir`; no recursion, no other extensions. Call sites only ever pass `var/runbooks` (dev-local, gitignored) — no commit risk.
- Fail-open by design: the helper is a side cleanup, so it never raises into the runbook's logging path.

## Verification
- **Tests** (`tests/test_runbook_log_rotation.py`, pure / tmp_path + `os.utime` backdating per the acceptance criterion): deletes >30d only; keeps exact-boundary (fixed clock to avoid the strict-equality race); ignores non-`.jsonl`; missing-dir is a no-op not a raise; custom retention. 5 pass.
- Lint + format + pyright clean; all 4 runbook modules still import. Pre-push gate green (fast tier + smoke).
- Codex ckpt-2: no findings.

Closes #1328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)