### PR TITLE
feat(#1766): calendar closure reason + selectable horizon

### DIFF
--- a/app/api/calendar.py
+++ b/app/api/calendar.py
@@ -39,7 +39,7 @@ from pydantic import BaseModel
 from app.api.auth import require_session_or_service_token
 from app.api.instruments import _SESSION_PROFILE_SQL
 from app.db import get_conn
-from app.services.market_calendar import us_market_status
+from app.services.market_calendar import us_market_reason, us_market_status
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
 
 router = APIRouter(
@@ -49,7 +49,8 @@ router = APIRouter(
 )
 
 _NY = ZoneInfo("America/New_York")
-_WEEK_DAYS = 7
+_DEFAULT_HORIZON_DAYS = 7
+_MAX_HORIZON_DAYS = 28
 
 CalendarScope = Literal["portfolio", "watchlist", "all"]
 DayType = Literal["open", "half_day", "closed", "not_modelled"]
@@ -67,6 +68,10 @@ _PROFILE_META: dict[str, tuple[str, str, bool]] = {
 class MarketStatusDay(BaseModel):
     date: date
     day_type: DayType
+    # Why the day is not a regular session (holiday / early-close occasion /
+    # "Weekend"), or None on a normal open day. US is precise; foreign carries
+    # only "Weekend" (holidays not modelled); continuous is always None.
+    reason: str | None = None
 
 
 class MarketStatusRow(BaseModel):
@@ -108,6 +113,20 @@ def _day_type(profile: str, d: date) -> DayType:
         # the same way the chart + the live now-badge do, not as not_modelled.
         return "open"
     return "not_modelled"  # unknown/future profile — safe default
+
+
+def _day_reason(profile: str, d: date) -> str | None:
+    """Operator-facing reason a day is non-open, paired with ``_day_type``.
+
+    US profiles are NYSE-precise (holiday/early-close names + "Weekend").
+    ``foreign_equity`` carries only "Weekend" — its holidays are not modelled,
+    so naming a weekday closure we cannot detect would be misleading.
+    ``continuous`` / unknown profiles have no reason."""
+    if profile in ("us_equity", "us_equity_rth"):
+        return us_market_reason(d)
+    if profile == "foreign_equity":
+        return "Weekend" if d.weekday() >= 5 else None
+    return None
 
 
 def _scope_instruments(conn: psycopg.Connection[object], scope: CalendarScope) -> list[tuple[int, str, str]]:
@@ -157,20 +176,23 @@ def _scope_instruments(conn: psycopg.Connection[object], scope: CalendarScope) -
 def calendar_events(
     conn: psycopg.Connection[object] = Depends(get_conn),
     scope: CalendarScope = Query(default="portfolio"),
+    days: int = Query(
+        default=_DEFAULT_HORIZON_DAYS, ge=1, le=_MAX_HORIZON_DAYS, description="Horizon in days (incl. today)."
+    ),
 ) -> CalendarEvents:
     instruments = _scope_instruments(conn, scope)
     today_ny = datetime.now(tz=_NY).date()
 
     # One market-status row per DISTINCT profile present in the scope.
     profiles = sorted({p for _, _, p in instruments})
-    week_dates = [today_ny + timedelta(days=i) for i in range(_WEEK_DAYS)]
+    horizon_dates = [today_ny + timedelta(days=i) for i in range(days)]
     market_status = [
         MarketStatusRow(
             profile=p,
             label=_PROFILE_META.get(p, (p, "UTC", False))[0],
             timezone=_PROFILE_META.get(p, (p, "UTC", False))[1],
             holidays_modelled=_PROFILE_META.get(p, (p, "UTC", False))[2],
-            week=[MarketStatusDay(date=d, day_type=_day_type(p, d)) for d in week_dates],
+            week=[MarketStatusDay(date=d, day_type=_day_type(p, d), reason=_day_reason(p, d)) for d in horizon_dates],
         )
         for p in profiles
     ]

--- a/app/services/market_calendar.py
+++ b/app/services/market_calendar.py
@@ -46,10 +46,13 @@ closed day shown as open).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
-from typing import Literal
+from types import MappingProxyType
+from typing import Literal, cast
 
+from pandas import Series, Timestamp
 from pandas.tseries.holiday import (
     AbstractHolidayCalendar,
     GoodFriday,
@@ -88,81 +91,103 @@ _CACHE: dict[int, MarketYear] = {}
 # Ad-hoc NYSE full closures not produced by the scheduled-holiday rules,
 # transcribed from the NYSE historical record. Source: NYSE holidays &
 # trading-hours history (https://www.nyse.com/markets/hours-calendars) +
-# press releases for national days of mourning.
-_EXTRAORDINARY_CLOSURES: frozenset[date] = frozenset(
-    {
-        date(2001, 9, 11),  # 9/11 attacks — markets closed Sep 11-14
-        date(2001, 9, 12),
-        date(2001, 9, 13),
-        date(2001, 9, 14),
-        date(2004, 6, 11),  # National day of mourning — President Reagan
-        date(2007, 1, 2),  # National day of mourning — President Ford
-        date(2012, 10, 29),  # Hurricane Sandy — closed Oct 29-30
-        date(2012, 10, 30),
-        date(2018, 12, 5),  # National day of mourning — President G.H.W. Bush
-        date(2025, 1, 9),  # National day of mourning — President Carter
-    }
-)
+# press releases for national days of mourning. Each date carries its
+# operator-facing reason; the closure SET is derived from this map so the two
+# can never drift (the reasons map is total over the closures by construction).
+_EXTRAORDINARY_CLOSURE_NAMES: dict[date, str] = {
+    date(2001, 9, 11): "9/11 attacks",  # markets closed Sep 11-14
+    date(2001, 9, 12): "9/11 attacks",
+    date(2001, 9, 13): "9/11 attacks",
+    date(2001, 9, 14): "9/11 attacks",
+    date(2004, 6, 11): "Day of mourning — President Reagan",
+    date(2007, 1, 2): "Day of mourning — President Ford",
+    date(2012, 10, 29): "Hurricane Sandy",  # closed Oct 29-30
+    date(2012, 10, 30): "Hurricane Sandy",
+    date(2018, 12, 5): "Day of mourning — President G.H.W. Bush",
+    date(2025, 1, 9): "Day of mourning — President Carter",
+}
+_EXTRAORDINARY_CLOSURES: frozenset[date] = frozenset(_EXTRAORDINARY_CLOSURE_NAMES)
 
 
 @dataclass(frozen=True)
 class MarketYear:
     """The NYSE special days for one calendar year, as ``America/New_York``
     civil dates. ``full_closures`` = no trading; ``half_days`` = 13:00 ET
-    early close."""
+    early close; ``reasons`` = each special date → its operator-facing name
+    (holiday / early-close occasion). ``reasons`` is read-only so the cached
+    instance stays effectively immutable."""
 
     year: int
     full_closures: frozenset[date]
     half_days: frozenset[date]
+    reasons: Mapping[date, str]
 
 
-def _full_closures_for_year(year: int) -> frozenset[date]:
-    """Observed NYSE full closures whose observed date lands in ``year``.
+def _scheduled_closure_names(year: int) -> dict[date, str]:
+    """Observed scheduled NYSE closures landing in ``year`` → holiday name.
 
     The query window straddles the adjacent year boundaries so a New Year's
     Day that falls on a Saturday — observed on the prior Dec 31 — is
     attributed to the year its *observed* date lands in (mirrors
-    ``sec_calendar._holidays_for_year``)."""
-    stamps = _CALENDAR.holidays(start=date(year - 1, 12, 15), end=date(year + 1, 1, 15))
-    scheduled = {ts.date() for ts in stamps if ts.year == year}
-    scheduled.update(d for d in _EXTRAORDINARY_CLOSURES if d.year == year)
-    return frozenset(scheduled)
+    ``sec_calendar._holidays_for_year``). ``return_name=True`` reuses the same
+    ``pandas`` rules that produce the dates, so the names cannot drift from the
+    closure set."""
+    # ``return_name=True`` makes ``holidays`` return a name-valued Series keyed
+    # by the observed dates; the pandas stub types it as ``DatetimeIndex`` (it
+    # does not model the overload), so cast for the ``.items()`` iteration.
+    named = cast(
+        Series,
+        _CALENDAR.holidays(start=date(year - 1, 12, 15), end=date(year + 1, 1, 15), return_name=True),
+    )
+    out: dict[date, str] = {}
+    for ts, name in named.items():
+        stamp = cast(Timestamp, ts)
+        if stamp.year == year:
+            out[stamp.date()] = str(name)
+    return out
 
 
-def _half_days_for_year(year: int, full_closures: frozenset[date]) -> frozenset[date]:
-    """Rule-derived 13:00 ET early-close days, minus any that are full
+def _half_day_names_for_year(year: int, full_closures: frozenset[date]) -> dict[date, str]:
+    """Rule-derived 13:00 ET early-close days → name, minus any that are full
     closures (closure wins). See module docstring for the rule set + the
     single known omission (Saturday-Christmas → Dec 23)."""
-    candidates: set[date] = set()
+    candidates: dict[date, str] = {}
 
     # Friday after Thanksgiving. Thanksgiving (4th Thursday of Nov) is always
     # a full closure; the early-close day is the Thursday + 1.
     for c in full_closures:
         if c.month == 11 and c.weekday() == 3:  # the Thursday Thanksgiving
-            candidates.add(date(c.year, 11, c.day + 1))
+            candidates[date(c.year, 11, c.day + 1)] = "Friday after Thanksgiving"
 
     # Christmas Eve when a weekday.
     dec24 = date(year, 12, 24)
     if dec24.weekday() < 5:
-        candidates.add(dec24)
+        candidates[dec24] = "Christmas Eve"
 
     # Eve of Independence Day: Jul 3 when both Jul 3 and Jul 4 are weekdays.
     jul3, jul4 = date(year, 7, 3), date(year, 7, 4)
     if jul3.weekday() < 5 and jul4.weekday() < 5:
-        candidates.add(jul3)
+        candidates[jul3] = "Independence Day eve"
 
-    return frozenset(c for c in candidates if c not in full_closures)
+    return {d: name for d, name in candidates.items() if d not in full_closures}
 
 
 def us_market_specials(year: int) -> MarketYear:
     """NYSE full closures + half days for ``year`` (cached; immutable)."""
     cached = _CACHE.get(year)
     if cached is None:
-        closures = _full_closures_for_year(year)
+        scheduled = _scheduled_closure_names(year)
+        extraordinary = {d: name for d, name in _EXTRAORDINARY_CLOSURE_NAMES.items() if d.year == year}
+        closures = frozenset(scheduled) | frozenset(extraordinary)
+        half_day_names = _half_day_names_for_year(year, closures)
+        # Closures and half days are disjoint (closure-wins is applied above),
+        # so the merged reasons map has no key collisions.
+        reasons = {**scheduled, **extraordinary, **half_day_names}
         cached = MarketYear(
             year=year,
             full_closures=closures,
-            half_days=_half_days_for_year(year, closures),
+            half_days=frozenset(half_day_names),
+            reasons=MappingProxyType(reasons),
         )
         _CACHE[year] = cached
     return cached
@@ -184,3 +209,17 @@ def us_market_status(d: date) -> UsMarketStatus:
     if d in specials.half_days:
         return "half_day"
     return "open"
+
+
+def us_market_reason(d: date) -> str | None:
+    """Operator-facing reason a NYSE civil date is not a regular session, or
+    ``None`` for a normal open day.
+
+    ``"Weekend"`` on Sat/Sun (checked first, matching ``us_market_status``'s
+    weekend-or-closure precedence — observed NYSE closures are always shifted
+    onto weekdays, so a special date never lands on a weekend). Otherwise the
+    holiday / early-close name from the year's ``reasons`` map; ``None`` on a
+    plain trading weekday."""
+    if d.weekday() >= 5:
+        return "Weekend"
+    return us_market_specials(d.year).reasons.get(d)

--- a/docs/specs/api/2026-06-28-calendar-closure-reason-horizon.md
+++ b/docs/specs/api/2026-06-28-calendar-closure-reason-horizon.md
@@ -1,0 +1,88 @@
+# Calendar: closure reason + selectable horizon (#1766)
+
+Issue #1766 (epic #585, predecessor #1754). Smallest-high-value slice of the
+"calendar too thin" finding: **(2) surface WHY a day is non-open** + **(1) let
+the operator widen the window** beyond a fixed week. Items 3/4/5 (foreign
+holiday depth, futures sessions, forward earnings/filings) stay out — no data
+source today (stated on-page already; #1754 premise unchanged).
+
+## Source rule
+
+NYSE published holidays + early-closings
+(https://www.nyse.com/markets/hours-calendars), already the governing source in
+`app/services/market_calendar.py`. Holiday **names** come from the same
+`pandas.tseries.holiday` rules that derive the closure dates —
+`AbstractHolidayCalendar.holidays(..., return_name=True)` returns the name per
+observed date (verified on dev: 2026-07-03 → "Independence Day", i.e. the
+observed Jul-4 closure). No new source, no new dependency, no first-principles
+inference: the names are a byproduct of the existing closure derivation.
+
+Premise check (dev): the service already computes `full_closures` + `half_days`;
+the API just was not carrying a reason. Confirmed — the only gap is plumbing.
+
+## Behaviour
+
+### Reason (item 2)
+
+`app/services/market_calendar.py`:
+- `MarketYear` gains `reasons: Mapping[date, str]` — observed closure/half-day
+  date → human name. Built alongside the existing sets:
+  - scheduled full closures → pandas `return_name=True` name.
+  - extraordinary closures → name from a new `_EXTRAORDINARY_CLOSURE_NAMES`
+    dict (the dates are already enumerated + commented; lift the comment text).
+  - half days → name set at derivation (`"Friday after Thanksgiving"`,
+    `"Christmas Eve"`, `"Independence Day eve"`). Closure-wins precedence is
+    already applied to the set; the reasons map only carries the surviving days.
+- New pure helper `us_market_reason(d: date) -> str | None`:
+  - weekend → `"Weekend"`.
+  - date in `reasons` → its name.
+  - else `None` (regular open day).
+
+### API (`app/api/calendar.py`)
+
+- `MarketStatusDay` gains `reason: str | None`.
+- US profiles (`us_equity`, `us_equity_rth`): `reason = us_market_reason(d)`.
+- `foreign_equity`: `reason = "Weekend"` on Sat/Sun, else `None` (holidays not
+  modelled — unchanged; only the weekend gets a label).
+- `continuous` / unknown: `None`.
+- New query param `days: int = Query(default=7, ge=1, le=28)` replaces the fixed
+  `_WEEK_DAYS`. Window = `[today_ny + i for i in range(days)]`. Default 7 keeps
+  the current view; FE offers 1/2/4-week presets. Ex-dividends stay unbounded
+  forward (all upcoming) — out of scope to bound, and "all upcoming" is more
+  useful than a window cap.
+
+### Frontend (`frontend/src/pages/CalendarPage.tsx`, `api/calendar.ts`, `api/types.ts`)
+
+- `MarketStatusDay` gains `reason: string | null`.
+- `fetchCalendarEvents(scope, days)` adds the `days` param.
+- Horizon control: three buttons `1 week / 2 weeks / 4 weeks` → `days` 7/14/28,
+  state-driven like the scope toggle. Default 1 week.
+- Each non-open tile shows its reason: closure/half-day tiles render the reason
+  under the status label (small, truncated) and in the `title` tooltip. Open
+  tiles unchanged. Weekend tiles get the "Weekend" reason too (de-clutters the
+  blank closed look the issue called out).
+
+## Out of scope (no source / tracked elsewhere)
+
+Foreign-exchange holiday set, futures session model, forward earnings + filing
+dates. The on-page note already states earnings/filings are not ingested; leave
+it.
+
+## Tests (pure)
+
+- `tests/test_market_calendar.py`: `us_market_reason` — a scheduled holiday name
+  ("Independence Day" for 2026-07-03), an extraordinary closure name, a half-day
+  name ("Christmas Eve" 2026-12-24), a weekend ("Weekend"), a plain weekday
+  (`None`). Observed-shift case: 2026-07-03 reads "Independence Day", not None.
+- `tests/test_market_calendar_status.py`: `_day_type` unchanged; add reason
+  assertions via a small `_day_reason`-style check at the API layer if one
+  exists, else assert `us_market_reason` (kept pure, no DB).
+- FE: extend `CalendarPage.test.tsx` — reason renders on a closed tile; horizon
+  buttons change the requested `days`.
+
+## Verification
+
+FE+API read-path only. No schema, no backfill, no daemon restart. Dev-verify:
+`GET /calendar/events?scope=all&days=28` returns `reason` populated on Jul-3
+(and any in-window holiday) + 28 day tiles; load `/calendar`, confirm the
+horizon buttons widen the grid and closed tiles show the reason.

--- a/frontend/src/api/calendar.ts
+++ b/frontend/src/api/calendar.ts
@@ -1,7 +1,10 @@
 import { apiFetch } from "@/api/client";
 import type { CalendarEvents, CalendarScope } from "@/api/types";
 
-export function fetchCalendarEvents(scope: CalendarScope = "portfolio"): Promise<CalendarEvents> {
-  const params = new URLSearchParams({ scope });
+export function fetchCalendarEvents(
+  scope: CalendarScope = "portfolio",
+  days = 7,
+): Promise<CalendarEvents> {
+  const params = new URLSearchParams({ scope, days: String(days) });
   return apiFetch<CalendarEvents>(`/calendar/events?${params.toString()}`);
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1143,6 +1143,7 @@ export type MarketDayType = "open" | "half_day" | "closed" | "not_modelled";
 export interface MarketStatusDay {
   date: string; // YYYY-MM-DD
   day_type: MarketDayType;
+  reason: string | null; // why non-open (holiday / "Weekend"); null on open days
 }
 
 export interface MarketStatusRow {

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
 import { CalendarPage } from "./CalendarPage";
+import { fetchCalendarEvents } from "@/api/calendar";
 import type { CalendarEvents } from "@/api/types";
 
 const sample: CalendarEvents = {
@@ -15,8 +17,8 @@ const sample: CalendarEvents = {
       timezone: "America/New_York",
       holidays_modelled: true,
       week: [
-        { date: "2026-06-29", day_type: "open" },
-        { date: "2026-07-03", day_type: "closed" },
+        { date: "2026-06-29", day_type: "open", reason: null },
+        { date: "2026-07-03", day_type: "closed", reason: "Independence Day" },
       ],
     },
   ],
@@ -47,5 +49,20 @@ describe("CalendarPage", () => {
     expect(screen.getByText(/ex 2026-07-01/)).toBeInTheDocument();
     // the honest "not ingested" note about earnings/filings.
     expect(screen.getByText(/does not ingest forward earnings/i)).toBeInTheDocument();
+    // closure reason (#1766) renders on the closed tile.
+    expect(screen.getByText("Independence Day")).toBeInTheDocument();
+  });
+
+  it("requests the default 1-week horizon, then widens to 4 weeks", async () => {
+    render(
+      <MemoryRouter>
+        <CalendarPage />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("US equity")).toBeInTheDocument());
+    expect(fetchCalendarEvents).toHaveBeenCalledWith("portfolio", 7);
+
+    await userEvent.click(screen.getByRole("button", { name: "4 weeks" }));
+    await waitFor(() => expect(fetchCalendarEvents).toHaveBeenCalledWith("portfolio", 28));
   });
 });

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -26,6 +26,12 @@ const SCOPES: ReadonlyArray<{ key: CalendarScope; label: string }> = [
   { key: "all", label: "All" },
 ];
 
+const HORIZONS: ReadonlyArray<{ days: number; label: string }> = [
+  { days: 7, label: "1 week" },
+  { days: 14, label: "2 weeks" },
+  { days: 28, label: "4 weeks" },
+];
+
 const DAY_TYPE_STYLE: Record<MarketDayType, string> = {
   open: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
   half_day: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
@@ -66,9 +72,10 @@ function nowSession(
 
 export function CalendarPage(): JSX.Element {
   const [scope, setScope] = useState<CalendarScope>("portfolio");
+  const [days, setDays] = useState<number>(7);
   const events = useAsync<CalendarEvents>(
-    useCallback(() => fetchCalendarEvents(scope), [scope]),
-    [scope],
+    useCallback(() => fetchCalendarEvents(scope, days), [scope, days]),
+    [scope, days],
   );
 
   // "Now" frozen at mount — the live-session badge is a load-time snapshot
@@ -90,21 +97,40 @@ export function CalendarPage(): JSX.Element {
           {scope === "all" ? "portfolio & watchlist" : scope}. US markets are NYSE-precise;
           foreign exchanges show weekday/weekend only (holidays not modelled).
         </p>
-        <div className="mt-2 flex gap-1">
-          {SCOPES.map((s) => (
-            <button
-              key={s.key}
-              type="button"
-              onClick={() => setScope(s.key)}
-              className={`rounded px-2 py-1 text-xs ${
-                scope === s.key
-                  ? "bg-sky-600 text-white"
-                  : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300"
-              }`}
-            >
-              {s.label}
-            </button>
-          ))}
+        <div className="mt-2 flex flex-wrap items-center gap-3">
+          <div className="flex gap-1">
+            {SCOPES.map((s) => (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => setScope(s.key)}
+                className={`rounded px-2 py-1 text-xs ${
+                  scope === s.key
+                    ? "bg-sky-600 text-white"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300"
+                }`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-1" role="group" aria-label="Horizon">
+            {HORIZONS.map((h) => (
+              <button
+                key={h.days}
+                type="button"
+                onClick={() => setDays(h.days)}
+                aria-pressed={days === h.days}
+                className={`rounded px-2 py-1 text-xs ${
+                  days === h.days
+                    ? "bg-slate-700 text-white dark:bg-slate-600"
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300"
+                }`}
+              >
+                {h.label}
+              </button>
+            ))}
+          </div>
         </div>
       </header>
 
@@ -142,11 +168,14 @@ export function CalendarPage(): JSX.Element {
                     {row.week.map((d) => (
                       <div
                         key={d.date}
-                        className={`rounded px-2 py-1 text-[11px] tabular-nums ${DAY_TYPE_STYLE[d.day_type]}`}
-                        title={`${d.date}: ${DAY_TYPE_LABEL[d.day_type]}`}
+                        className={`w-[4.75rem] rounded px-2 py-1 text-[11px] tabular-nums ${DAY_TYPE_STYLE[d.day_type]}`}
+                        title={`${d.date}: ${DAY_TYPE_LABEL[d.day_type]}${d.reason !== null ? ` — ${d.reason}` : ""}`}
                       >
                         <span className="block font-medium">{weekdayShort(d.date)}</span>
                         <span className="block">{DAY_TYPE_LABEL[d.day_type]}</span>
+                        {d.reason !== null && d.reason !== "Weekend" && (
+                          <span className="block truncate text-[10px] opacity-80">{d.reason}</span>
+                        )}
                       </div>
                     ))}
                   </div>

--- a/tests/test_market_calendar.py
+++ b/tests/test_market_calendar.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from datetime import date
 
 from app.providers.implementations.sec_calendar import is_us_federal_holiday
-from app.services.market_calendar import us_market_specials
+from app.services.market_calendar import us_market_reason, us_market_specials
 
 # NYSE published full closures (https://www.nyse.com/markets/hours-calendars).
 _CLOSURES_2025 = {
@@ -154,3 +154,46 @@ def test_endpoint_rejects_out_of_range_year() -> None:
             assert exc.status_code == 400
         else:  # pragma: no cover - guard
             raise AssertionError(f"year {bad} should have raised")
+
+
+class TestUsMarketReason:
+    """`us_market_reason` (#1766) — the operator-facing name for a non-open
+    NYSE day, or None on a regular session. Names come from the same pandas
+    rules that derive the closure set (no drift)."""
+
+    def test_scheduled_holiday_name(self) -> None:
+        assert us_market_reason(date(2026, 1, 1)) == "New Year's Day"
+        assert us_market_reason(date(2026, 12, 25)) == "Christmas"
+
+    def test_observed_shift_carries_name(self) -> None:
+        # Jul 4 2026 is a Saturday → observed full closure on Fri Jul 3.
+        assert us_market_reason(date(2026, 7, 3)) == "Independence Day"
+
+    def test_independence_day_eve_vs_observed_closure_across_years(self) -> None:
+        # 2025: Jul 4 is a Friday (full closure), Jul 3 Thu is the half-day eve.
+        assert us_market_reason(date(2025, 7, 3)) == "Independence Day eve"
+        assert us_market_reason(date(2025, 7, 4)) == "Independence Day"
+        # 2026: Jul 4 Sat → Jul 3 is the OBSERVED closure, not an eve.
+        assert us_market_reason(date(2026, 7, 3)) == "Independence Day"
+
+    def test_half_day_names(self) -> None:
+        assert us_market_reason(date(2026, 12, 24)) == "Christmas Eve"
+        assert us_market_reason(date(2026, 11, 27)) == "Friday after Thanksgiving"
+
+    def test_extraordinary_closure_name(self) -> None:
+        assert us_market_reason(date(2025, 1, 9)) == "Day of mourning — President Carter"
+        assert us_market_reason(date(2012, 10, 30)) == "Hurricane Sandy"
+
+    def test_weekend(self) -> None:
+        assert us_market_reason(date(2026, 6, 27)) == "Weekend"  # Saturday
+        assert us_market_reason(date(2026, 6, 28)) == "Weekend"  # Sunday
+
+    def test_plain_weekday_is_none(self) -> None:
+        assert us_market_reason(date(2026, 6, 23)) is None  # Tuesday
+
+    def test_reasons_total_over_specials(self) -> None:
+        # Every special date has a reason; closure/half-day sets stay disjoint.
+        sp = us_market_specials(2026)
+        assert sp.full_closures.isdisjoint(sp.half_days)
+        for d in sp.full_closures | sp.half_days:
+            assert sp.reasons.get(d), f"missing reason for {d}"

--- a/tests/test_market_calendar_status.py
+++ b/tests/test_market_calendar_status.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from app.api.calendar import _day_type
+from app.api.calendar import _day_reason, _day_type
 from app.services.market_calendar import us_market_status
 
 
@@ -41,3 +41,28 @@ class TestDayType:
         # Matches the shipped #609 classifySession (continuous = always trading).
         assert _day_type("continuous", date(2026, 6, 23)) == "open"
         assert _day_type("continuous", date(2026, 6, 27)) == "open"  # weekend too
+
+
+class TestDayReason:
+    """`_day_reason` (#1766) — operator-facing reason per profile/day."""
+
+    def test_us_holiday_name(self) -> None:
+        assert _day_reason("us_equity", date(2026, 1, 1)) == "New Year's Day"
+        assert _day_reason("us_equity_rth", date(2026, 12, 24)) == "Christmas Eve"
+        assert _day_reason("us_equity", date(2026, 7, 3)) == "Independence Day"  # observed
+
+    def test_us_plain_weekday_none(self) -> None:
+        assert _day_reason("us_equity", date(2026, 6, 23)) is None  # Tuesday
+
+    def test_us_weekend(self) -> None:
+        assert _day_reason("us_equity", date(2026, 6, 27)) == "Weekend"  # Saturday
+
+    def test_foreign_only_weekend(self) -> None:
+        # Holidays not modelled — a weekday holiday gets no reason.
+        assert _day_reason("foreign_equity", date(2026, 1, 1)) is None  # Thu, but unmodelled
+        assert _day_reason("foreign_equity", date(2026, 6, 27)) == "Weekend"  # Sat
+
+    def test_continuous_and_unknown_none(self) -> None:
+        assert _day_reason("continuous", date(2026, 1, 1)) is None
+        assert _day_reason("continuous", date(2026, 6, 27)) is None  # weekend too
+        assert _day_reason("mystery_profile", date(2026, 1, 1)) is None


### PR DESCRIPTION
## What

Smallest-high-value slice of #1766 (calendar page too thin; epic #585): surface
**why** a day is non-open, and let the operator **widen the window** beyond the
fixed week.

- **`app/services/market_calendar.py`** — `MarketYear` gains a read-only
  `reasons` map (`date -> holiday / early-close name`), built from the SAME
  pandas rules + straddled window that derive the closure set, so names cannot
  drift. Extraordinary-closure names are now the single source the closure SET
  is constructed from (total over the set by construction). New pure
  `us_market_reason(d) -> str | None`: `"Weekend"` (Sat/Sun, checked first) /
  holiday or early-close name / `None` on a plain trading weekday.
- **`app/api/calendar.py`** — `MarketStatusDay` gains `reason`; new `_day_reason`
  per profile (US precise; `foreign_equity` carries only `"Weekend"` since its
  holidays are not modelled; `continuous`/unknown → `None`). New `days` query
  param (`ge=1, le=28`, default `7`) replaces the fixed-week window.
- **Frontend** — `CalendarPage` horizon control (1 / 2 / 4 weeks) + per-tile
  reason render (holiday name inline; `"Weekend"` in the tooltip only, to
  declutter); `types.ts` + `api/calendar.ts` carry `days`/`reason`.

Items 3/4/5 of the issue (foreign-exchange holiday depth, futures session
model, forward earnings/filing dates) stay out — **no data source today** (the
on-page note already states earnings/filings are not ingested; #1754 premise
unchanged).

## Source rule

NYSE published holidays + early-closings
(https://www.nyse.com/markets/hours-calendars) — the governing source already
in `market_calendar.py`. Names come from the same `pandas.tseries.holiday`
rules via `return_name=True` (verified on dev: 2026-07-03 → "Independence Day",
the observed Jul-4 closure). No new source, no new dependency, no
first-principles inference. Premise confirmed on dev: the service already
computed `full_closures` + `half_days`; only the API plumbing was missing.

## Security model

No change. `/calendar/events` keeps `require_session_or_service_token`; scope
auth (operator-scoped watchlist, global positions) is untouched. `days` is a
bounded int (`ge=1, le=28`) — no injection surface; the only SQL
(`_scope_instruments`, ex-dividends) is unchanged and parameterised.

## Tests

- Pure (`tests/test_market_calendar.py`): `us_market_reason` — scheduled
  holiday name, observed-shift naming (Jul-3 2026 → "Independence Day"),
  Independence-Day-eve vs observed-closure across 2025/2026 (closure-wins),
  half-day names, extraordinary closure, weekend, plain weekday, and a
  reasons-total-over-specials invariant.
- Pure (`tests/test_market_calendar_status.py`): `_day_reason` per profile.
- FE (`CalendarPage.test.tsx`): closure reason renders on the closed tile;
  horizon buttons drive the requested `days` (default 7 → 28).

## Verification

Read-path only — **no schema, no backfill, no daemon restart.**

- Local gates green: `ruff check`, `ruff format --check`, `pyright` (changed
  modules clean), `pytest -m "not db"` (4617 passed), `tests/smoke` (129),
  `pnpm typecheck`, `pnpm test:unit` (1147).
- Dev-verified at `06d53828`: `GET /calendar/events?scope=all&days=28` →
  `reason` populated (`2026-07-03` "Independence Day", weekends "Weekend"),
  28 day tiles; default omitted-`days` still serves 7.
- Codex ckpt-1 (spec) + ckpt-2 (branch diff): no correctness bugs;
  reasons-map totality + closure-wins + horizon off-by-one all confirmed.

Spec: `docs/specs/api/2026-06-28-calendar-closure-reason-horizon.md`

Closes #1766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)