### PR TITLE
fix(#1766): calendar section title + intro track the selected horizon

### DIFF
--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -61,8 +61,12 @@ describe("CalendarPage", () => {
     );
     await waitFor(() => expect(screen.getByText("US equity")).toBeInTheDocument());
     expect(fetchCalendarEvents).toHaveBeenCalledWith("portfolio", 7);
+    // Default window phrasing tracks the 1-week horizon.
+    expect(screen.getByText("Market status — this week")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "4 weeks" }));
     await waitFor(() => expect(fetchCalendarEvents).toHaveBeenCalledWith("portfolio", 28));
+    // Section title + intro now reflect the wider horizon, not a stale "this week".
+    await waitFor(() => expect(screen.getByText("Market status — next 4 weeks")).toBeInTheDocument());
   });
 });

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -26,10 +26,12 @@ const SCOPES: ReadonlyArray<{ key: CalendarScope; label: string }> = [
   { key: "all", label: "All" },
 ];
 
-const HORIZONS: ReadonlyArray<{ days: number; label: string }> = [
-  { days: 7, label: "1 week" },
-  { days: 14, label: "2 weeks" },
-  { days: 28, label: "4 weeks" },
+const HORIZONS: ReadonlyArray<{ days: number; label: string; window: string }> = [
+  // `window` is the period phrasing used in the section title + intro so they
+  // track the selected horizon (not a stale "this week").
+  { days: 7, label: "1 week", window: "this week" },
+  { days: 14, label: "2 weeks", window: "next 2 weeks" },
+  { days: 28, label: "4 weeks", window: "next 4 weeks" },
 ];
 
 const DAY_TYPE_STYLE: Record<MarketDayType, string> = {
@@ -88,12 +90,16 @@ export function CalendarPage(): JSX.Element {
   const nowBar = useMemo(() => [{ time: Math.floor(Date.now() / 1000) }], []);
   const specials = useMarketSpecials("us_equity", nowBar);
 
+  // Period phrasing for the intro + section title, tracking the selected
+  // horizon (falls back to the default if days is ever off-list).
+  const windowLabel = HORIZONS.find((h) => h.days === days)?.window ?? "this week";
+
   return (
     <div className="mx-auto max-w-screen-lg space-y-4 p-4">
       <header className="border-b border-slate-200 pb-3 dark:border-slate-800">
         <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Calendar</h1>
         <p className="mt-1 text-xs text-slate-500">
-          Market status for the week ahead + upcoming ex-dividends across your{" "}
+          Market status for {windowLabel} + upcoming ex-dividends across your{" "}
           {scope === "all" ? "portfolio & watchlist" : scope}. US markets are NYSE-precise;
           foreign exchanges show weekday/weekend only (holidays not modelled).
         </p>
@@ -149,7 +155,7 @@ export function CalendarPage(): JSX.Element {
         />
       ) : (
         <>
-          <Section title="Market status — this week">
+          <Section title={`Market status — ${windowLabel}`}>
             <div className="space-y-3">
               {events.data.market_status.map((row) => (
                 <div key={row.profile}>


### PR DESCRIPTION
## What

Follow-up to #1766 (PR #1783). The horizon control (1 / 2 / 4 weeks) shipped,
but the section title was hardcoded **"Market status — this week"** and the
intro read **"for the week ahead"** — both stale once the operator picked 2 or
4 weeks. Caught in live FE-QA of the merged change (screenshot showed a 4-week
grid under a "THIS WEEK" header).

`HORIZONS` now carries a `window` phrase (`"this week"` / `"next 2 weeks"` /
`"next 4 weeks"`); the section title and intro derive from the selected
horizon. Default (1 week) phrasing is unchanged.

## Scope / security

Frontend copy only — no API, schema, or behaviour change. No security surface.

## Verification

- `pnpm typecheck` clean; `CalendarPage.test.tsx` 2 passed (test asserts the
  title flips to "next 4 weeks" on the 4-week button).
- Live-verified at `:5173` after clicking **4 weeks**: title
  "MARKET STATUS — NEXT 4 WEEKS", intro "Market status for next 4 weeks …".

Refs #1766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)