### PR TITLE
fix(#987): drain Check F tinted-bg dark-partner skip-list (30 files)

### DIFF
--- a/frontend/scripts/check-dark-classes.mjs
+++ b/frontend/scripts/check-dark-classes.mjs
@@ -36,10 +36,10 @@
  *
  * Exits non-zero with file:line:reason for each violation.
  *
- * SKIP_FILES below records pre-existing violators that are queued
- * for a separate sweep PR. Each entry should reference the tracking
- * issue. New files MUST NOT be added to this list — fix the
- * violation in the same PR that introduces it.
+ * All checks (A-F) apply tree-wide with no per-file exemptions. The
+ * Check F tinted-bg skip-list was fully drained in #987; do NOT
+ * reintroduce one — fix the violation in the same PR that introduces
+ * it.
  */
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative, sep } from "node:path";
@@ -48,49 +48,10 @@ import { fileURLToPath } from "node:url";
 const ROOT = fileURLToPath(new URL("../src", import.meta.url));
 const SKIP_DIRS = new Set(["test", "__mocks__"]);
 
-/**
- * Files exempt from check F only — they carry pre-existing tinted-bg
- * violations being drained in a separate sweep ticket.
- *
- * Tracking: #987 (sweep). When that ticket lands the entire set
- * should empty out and this constant can be removed.
- *
- * Do NOT add new files here. Fix the violation in the same PR.
- */
-const CHECK_F_SKIP_FILES = new Set([
-  "src/components/broker/ValidationResultDisplay.tsx",
-  "src/components/dashboard/AlertsStrip.tsx",
-  "src/components/dashboard/RecentRecommendations.tsx",
-  "src/components/instrument/CrossRefPopover.tsx",
-  "src/components/instrument/EightKEventsPanel.tsx",
-  "src/components/instrument/InsiderActivityPanel.tsx",
-  "src/components/instrument/KeyStatsPane.tsx",
-  "src/components/instrument/RightRail.tsx",
-  "src/components/instrument/SummaryStrip.tsx",
-  "src/components/instrument/dividendsShared.tsx",
-  "src/components/orders/ClosePositionModal.tsx",
-  "src/components/orders/DemoLivePill.tsx",
-  "src/components/orders/OrderEntryModal.tsx",
-  "src/components/rankings/RankingsTable.tsx",
-  "src/components/recommendations/AuditTrail.tsx",
-  "src/components/recommendations/RecommendationsTable.tsx",
-  "src/components/settings/BudgetConfigSection.tsx",
-  "src/components/settings/DisplayCurrencySection.tsx",
-  "src/components/states/ErrorBanner.tsx",
-  "src/components/ui/Pagination.tsx",
-  "src/pages/AdminPage.tsx",
-  "src/pages/ChartPage.tsx",
-  "src/pages/CopyTradingPage.tsx",
-  "src/pages/DashboardPage.tsx",
-  "src/pages/EightKListPage.tsx",
-  "src/pages/InstrumentPage.tsx",
-  "src/pages/InstrumentsPage.tsx",
-  "src/pages/LoginPage.tsx",
-  "src/pages/OperatorsPage.tsx",
-  "src/pages/ReportsPage.tsx",
-  "src/pages/SettingsPage.tsx",
-  "src/pages/SetupPage.tsx",
-]);
+// #987 — the Check F tinted-bg skip-list has been fully drained (every
+// file received its dark:bg- partner). Check F now applies to the whole
+// tree with no exemptions; do NOT reintroduce a skip-list — fix the
+// violation in the same PR.
 
 function walk(dir) {
   const out = [];
@@ -219,9 +180,6 @@ const violations = [];
 const files = walk(ROOT);
 for (const file of files) {
   const lines = readFileSync(file, "utf8").split("\n");
-  const rel = relative(ROOT, file).split(sep).join("/");
-  const relFromSrc = `src/${rel}`;
-  const skipCheckF = CHECK_F_SKIP_FILES.has(relFromSrc);
   lines.forEach((line, i) => {
     const lineNo = i + 1;
     const dups = findDuplicateVariants(line);
@@ -248,11 +206,9 @@ for (const file of files) {
     if (deadHover) {
       violations.push({ file, line: lineNo, reason: deadHover });
     }
-    if (!skipCheckF) {
-      const tintedMiss = findMissingTintedBgPartner(line);
-      if (tintedMiss) {
-        violations.push({ file, line: lineNo, reason: tintedMiss });
-      }
+    const tintedMiss = findMissingTintedBgPartner(line);
+    if (tintedMiss) {
+      violations.push({ file, line: lineNo, reason: tintedMiss });
     }
   });
 }

--- a/frontend/src/components/broker/ValidationResultDisplay.tsx
+++ b/frontend/src/components/broker/ValidationResultDisplay.tsx
@@ -9,7 +9,7 @@ export function ValidationResultDisplay({
 }): JSX.Element | null {
   if (error !== null) {
     return (
-      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+      <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
         {error}
       </div>
     );
@@ -18,7 +18,7 @@ export function ValidationResultDisplay({
 
   if (!result.auth_valid) {
     return (
-      <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+      <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
         Authentication failed — check your eToro public key and private key.
       </div>
     );
@@ -27,7 +27,7 @@ export function ValidationResultDisplay({
   if (!result.env_valid) {
     return (
       <div className="space-y-1">
-        <div className="rounded bg-amber-50 px-2 py-1.5 text-xs text-amber-700">
+        <div className="rounded bg-amber-50 dark:bg-amber-950/40 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-300">
           Authenticated, but environment check failed: {result.env_check}
         </div>
         {result.note && (
@@ -39,7 +39,7 @@ export function ValidationResultDisplay({
 
   return (
     <div className="space-y-1">
-      <div className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+      <div className="rounded bg-emerald-50 dark:bg-emerald-950/40 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-300">
         Connection verified
         {result.identity?.gcid != null && (
           <span className="ml-1 text-emerald-600">

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -109,8 +109,8 @@ function isUnseen(r: AlertRow, c: Cursors): boolean {
 
 function KindPill({ kind }: { kind: AlertRow["kind"] }) {
   const style = {
-    guard: "bg-amber-100 text-amber-800",
-    position: "bg-red-100 text-red-800",
+    guard: "bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200",
+    position: "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200",
     coverage: "bg-slate-100 dark:bg-slate-800 text-slate-700",
   }[kind];
   const label = { guard: "GUARD", position: "POSITION", coverage: "COVERAGE" }[kind];
@@ -410,7 +410,7 @@ export function AlertsStrip(): JSX.Element | null {
             Alerts
           </h2>
           {totalUnseen > 0 ? (
-            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+            <span className="rounded-full bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
               {totalUnseen} new
             </span>
           ) : null}
@@ -429,7 +429,7 @@ export function AlertsStrip(): JSX.Element | null {
             <button
               type="button"
               onClick={onDismissAll}
-              className="rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs font-medium text-amber-800 hover:bg-amber-100"
+              className="rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 px-2 py-1 text-xs font-medium text-amber-800 dark:text-amber-200 hover:bg-amber-100"
             >
               Dismiss all ({totalUnseen}) as acknowledged
             </button>

--- a/frontend/src/components/dashboard/RecentRecommendations.tsx
+++ b/frontend/src/components/dashboard/RecentRecommendations.tsx
@@ -4,17 +4,17 @@ import { formatDateTime } from "@/lib/format";
 import { EmptyState } from "@/components/states/EmptyState";
 
 const ACTION_TONE: Record<string, string> = {
-  BUY: "bg-emerald-100 text-emerald-700",
-  ADD: "bg-emerald-50 text-emerald-700",
+  BUY: "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300",
+  ADD: "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300",
   HOLD: "bg-slate-100 dark:bg-slate-800 text-slate-600",
-  EXIT: "bg-red-100 text-red-700",
+  EXIT: "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300",
 };
 
 const STATUS_TONE: Record<string, string> = {
-  proposed: "bg-amber-100 text-amber-700",
-  approved: "bg-blue-100 text-blue-700",
-  rejected: "bg-red-100 text-red-700",
-  executed: "bg-emerald-100 text-emerald-700",
+  proposed: "bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300",
+  approved: "bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300",
+  rejected: "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300",
+  executed: "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300",
 };
 
 export function RecentRecommendations({ items }: { items: RecommendationListItem[] }) {

--- a/frontend/src/components/instrument/CrossRefPopover.tsx
+++ b/frontend/src/components/instrument/CrossRefPopover.tsx
@@ -53,7 +53,7 @@ export function CrossRefPopover({
     <span className="relative inline-block">
       <button
         type="button"
-        className="rounded bg-sky-100 px-1.5 py-0.5 text-[11px] font-medium text-sky-700 hover:bg-sky-200"
+        className="rounded bg-sky-100 dark:bg-sky-900/40 px-1.5 py-0.5 text-[11px] font-medium text-sky-700 dark:text-sky-300 hover:bg-sky-200"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
       >

--- a/frontend/src/components/instrument/EightKEventsPanel.tsx
+++ b/frontend/src/components/instrument/EightKEventsPanel.tsx
@@ -45,9 +45,9 @@ export interface EightKEventsPanelProps {
 function severityTone(severity: string | null): string {
   switch (severity) {
     case "critical":
-      return "bg-rose-100 text-rose-800";
+      return "bg-rose-100 dark:bg-rose-900/40 text-rose-800 dark:text-rose-200";
     case "material":
-      return "bg-amber-100 text-amber-800";
+      return "bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200";
     case "informational":
       return "bg-slate-100 dark:bg-slate-800 text-slate-600";
     default:
@@ -109,8 +109,8 @@ function FilingCard({ filing }: { filing: EightKFiling }) {
         <span
           className={`rounded px-1.5 py-0.5 text-[11px] font-semibold ${
             filing.is_amendment
-              ? "bg-amber-50 text-amber-800"
-              : "bg-sky-50 text-sky-800"
+              ? "bg-amber-50 dark:bg-amber-950/40 text-amber-800 dark:text-amber-200"
+              : "bg-sky-50 dark:bg-sky-950/40 text-sky-800 dark:text-sky-200"
           }`}
         >
           {filing.document_type}

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -120,12 +120,12 @@ function formatDelta(raw: string): { label: string; colour: string } {
   if (num > 0) {
     return {
       label: `+${Math.round(num).toLocaleString("en-US")}`,
-      colour: "bg-emerald-100 text-emerald-800",
+      colour: "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-800 dark:text-emerald-200",
     };
   }
   return {
     label: Math.round(num).toLocaleString("en-US"),
-    colour: "bg-rose-100 text-rose-800",
+    colour: "bg-rose-100 dark:bg-rose-900/40 text-rose-800 dark:text-rose-200",
   };
 }
 
@@ -273,7 +273,7 @@ function Row({ txn }: { txn: InsiderTransactionDetail }) {
         )}
         {late && (
           <span
-            className="ml-1 rounded bg-amber-100 px-1 py-0.5 text-[10px] font-medium text-amber-800"
+            className="ml-1 rounded bg-amber-100 dark:bg-amber-900/40 px-1 py-0.5 text-[10px] font-medium text-amber-800 dark:text-amber-200"
             title="Filed after the 2-business-day deadline"
           >
             Late

--- a/frontend/src/components/instrument/KeyStatsPane.tsx
+++ b/frontend/src/components/instrument/KeyStatsPane.tsx
@@ -31,15 +31,15 @@ function FieldSourceTag({ source }: { source: KeyStatsFieldSource | undefined })
   let label: string = source;
   switch (source) {
     case "sec_xbrl":
-      tone = "bg-emerald-50 text-emerald-700";
+      tone = "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300";
       label = "SEC";
       break;
     case "sec_dividend_summary":
-      tone = "bg-emerald-50 text-emerald-700";
+      tone = "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300";
       label = "SEC · div";
       break;
     case "sec_xbrl_price_missing":
-      tone = "bg-amber-50 text-amber-700";
+      tone = "bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300";
       label = "SEC · price?";
       break;
     case "unavailable":

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -233,8 +233,8 @@ function RecentNews({ instrumentId }: { instrumentId: number }) {
 
 function sentimentTone(score: number | null): string {
   if (score === null) return "bg-slate-100 dark:bg-slate-800 text-slate-500";
-  if (score >= 0.3) return "bg-emerald-50 text-emerald-700";
-  if (score <= -0.3) return "bg-red-50 text-red-700";
+  if (score >= 0.3) return "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300";
+  if (score <= -0.3) return "bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300";
   return "bg-slate-100 dark:bg-slate-800 text-slate-600";
 }
 

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -56,12 +56,12 @@ function isThesisStale(thesis: ThesisDetail | null): boolean {
 function thesisTone(stance: string): string {
   switch (stance.toLowerCase()) {
     case "buy":
-      return "bg-emerald-50 text-emerald-700 border-emerald-300";
+      return "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700";
     case "hold":
       return "bg-slate-100 dark:bg-slate-800 text-slate-700 border-slate-300 dark:border-slate-700";
     case "exit":
     case "sell":
-      return "bg-red-50 text-red-700 border-red-300";
+      return "bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 border-red-300 dark:border-red-700";
     default:
       return "bg-slate-100 dark:bg-slate-800 text-slate-700 border-slate-300 dark:border-slate-700";
   }
@@ -151,7 +151,7 @@ export function SummaryStrip({
         {summary.coverage_tier !== null ? (
           <Term
             term={`Tier ${summary.coverage_tier}`}
-            className="rounded bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-700 no-underline"
+            className="rounded bg-blue-100 dark:bg-blue-900/40 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-300 no-underline"
           >
             Tier {summary.coverage_tier}
           </Term>
@@ -223,7 +223,7 @@ export function SummaryStrip({
         {thesisError ? (
           <span
             data-testid="thesis-badge-error"
-            className="inline-flex items-center rounded border border-red-300 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700"
+            className="inline-flex items-center rounded border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-300"
           >
             Thesis unavailable
           </span>
@@ -232,14 +232,14 @@ export function SummaryStrip({
         {positionError ? (
           <span
             data-testid="position-badge-error"
-            className="inline-flex items-center rounded border border-red-300 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700"
+            className="inline-flex items-center rounded border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 px-2 py-0.5 text-xs font-medium text-red-700 dark:text-red-300"
           >
             Holdings unavailable
           </span>
         ) : positionLoaded && isHeld ? (
           <span
             data-testid="held-badge"
-            className="inline-flex items-center rounded border border-blue-300 bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700"
+            className="inline-flex items-center rounded border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-950/40 px-2 py-0.5 text-xs font-medium text-blue-700 dark:text-blue-300"
           >
             Held: {heldUnits}u
           </span>

--- a/frontend/src/components/instrument/dividendsShared.tsx
+++ b/frontend/src/components/instrument/dividendsShared.tsx
@@ -76,7 +76,7 @@ export function NextDividendBanner({ upcoming }: { upcoming: UpcomingDividend })
   // banner's job is "operator awareness", not a filled-in calendar.
   const exOrPay = upcoming.ex_date ?? upcoming.pay_date;
   return (
-    <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+    <div className="mb-4 rounded-md border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/40 px-3 py-2 text-sm">
       <div className="flex items-baseline justify-between gap-3">
         <span className="font-semibold text-amber-900">Next dividend</span>
         {upcoming.dps_declared !== null && (

--- a/frontend/src/components/orders/ClosePositionModal.tsx
+++ b/frontend/src/components/orders/ClosePositionModal.tsx
@@ -155,7 +155,7 @@ export function ClosePositionModal({
         </header>
 
         {detail.error !== null ? (
-          <div className="rounded border border-red-200 bg-red-50 px-2 py-1.5 text-xs text-red-700">
+          <div className="rounded border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300">
             <span>Could not load position details.</span>{" "}
             <button
               type="button"
@@ -170,7 +170,7 @@ export function ClosePositionModal({
         ) : staleTrade ? (
           <p
             role="alert"
-            className="rounded border border-red-300 bg-red-50 px-2 py-1.5 text-xs text-red-700"
+            className="rounded border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
           >
             This position no longer exists — refresh the portfolio.
           </p>
@@ -282,7 +282,7 @@ export function ClosePositionModal({
         {errorMessage !== null ? (
           <p
             role="alert"
-            className="rounded border border-red-300 bg-red-50 px-2 py-1.5 text-xs text-red-700"
+            className="rounded border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
           >
             {errorMessage}
           </p>

--- a/frontend/src/components/orders/DemoLivePill.tsx
+++ b/frontend/src/components/orders/DemoLivePill.tsx
@@ -37,8 +37,8 @@ export function DemoLivePill(): JSX.Element {
     <span
       className={
         isLive
-          ? "inline-flex items-center gap-1 rounded border border-red-300 bg-red-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-700"
-          : "inline-flex items-center gap-1 rounded border border-blue-300 bg-blue-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-blue-700"
+          ? "inline-flex items-center gap-1 rounded border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-700 dark:text-red-300"
+          : "inline-flex items-center gap-1 rounded border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-950/40 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-blue-700 dark:text-blue-300"
       }
       data-testid="demo-live-pill"
       data-live={isLive ? "true" : "false"}

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -223,7 +223,7 @@ export function OrderEntryModal({
         {errorMessage !== null ? (
           <p
             role="alert"
-            className="rounded border border-red-300 bg-red-50 px-2 py-1.5 text-xs text-red-700"
+            className="rounded border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
           >
             {errorMessage}
           </p>
@@ -275,7 +275,7 @@ function PriceContext({
 }): JSX.Element {
   if (detailError !== null) {
     return (
-      <div className="rounded border border-red-200 bg-red-50 px-2 py-1.5 text-xs text-red-700">
+      <div className="rounded border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300">
         <span>Could not load price context.</span>{" "}
         <button
           type="button"

--- a/frontend/src/components/rankings/RankingsTable.tsx
+++ b/frontend/src/components/rankings/RankingsTable.tsx
@@ -125,7 +125,7 @@ export function RankingsTable({ view }: { view: RankingsView }) {
             <MessageRow>
               <div
                 role="alert"
-                className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+                className="rounded-md border border-amber-200 dark:border-amber-900/60 bg-amber-50 dark:bg-amber-950/40 px-4 py-3 text-sm text-amber-800 dark:text-amber-200"
               >
                 Authentication required. Sign in to view rankings.
               </div>
@@ -134,7 +134,7 @@ export function RankingsTable({ view }: { view: RankingsView }) {
             <MessageRow>
               <div
                 role="alert"
-                className="flex items-center justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                className="flex items-center justify-between rounded-md border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"
               >
                 <span>Failed to load. Check the browser console for details.</span>
                 <button

--- a/frontend/src/components/recommendations/AuditTrail.tsx
+++ b/frontend/src/components/recommendations/AuditTrail.tsx
@@ -36,7 +36,7 @@ export function AuditTrail({ view }: { view: AuditView }) {
     return (
       <div
         role="alert"
-        className="flex items-center justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        className="flex items-center justify-between rounded-md border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"
       >
         <span>Failed to load. Check the browser console for details.</span>
         <button

--- a/frontend/src/components/recommendations/RecommendationsTable.tsx
+++ b/frontend/src/components/recommendations/RecommendationsTable.tsx
@@ -8,17 +8,17 @@ import { SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 
 const ACTION_TONE: Record<string, string> = {
-  BUY: "bg-emerald-100 text-emerald-700",
-  ADD: "bg-emerald-50 text-emerald-700",
+  BUY: "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300",
+  ADD: "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300",
   HOLD: "bg-slate-100 dark:bg-slate-800 text-slate-600",
-  EXIT: "bg-red-100 text-red-700",
+  EXIT: "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300",
 };
 
 const STATUS_TONE: Record<string, string> = {
-  proposed: "bg-amber-100 text-amber-700",
-  approved: "bg-blue-100 text-blue-700",
-  rejected: "bg-red-100 text-red-700",
-  executed: "bg-emerald-100 text-emerald-700",
+  proposed: "bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300",
+  approved: "bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300",
+  rejected: "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300",
+  executed: "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300",
 };
 
 export type RecommendationsView =
@@ -39,7 +39,7 @@ export function RecommendationsTable({ view }: { view: RecommendationsView }) {
     return (
       <div
         role="alert"
-        className="flex items-center justify-between rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        className="flex items-center justify-between rounded-md border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-3 py-2 text-sm text-red-700 dark:text-red-300"
       >
         <span>Failed to load. Check the browser console for details.</span>
         <button

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -206,14 +206,14 @@ export function BudgetConfigSection() {
               </button>
 
               {configSuccess && (
-                <p className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+                <p className="rounded bg-emerald-50 dark:bg-emerald-950/40 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-300">
                   Budget config updated.
                 </p>
               )}
               {configError && (
                 <p
                   role="alert"
-                  className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+                  className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
                 >
                   Failed to save budget config. Check the browser console for
                   details.
@@ -301,14 +301,14 @@ export function BudgetConfigSection() {
             </button>
 
             {eventSuccess && (
-              <p className="rounded bg-emerald-50 px-2 py-1.5 text-xs text-emerald-700">
+              <p className="rounded bg-emerald-50 dark:bg-emerald-950/40 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-300">
                 Capital event recorded.
               </p>
             )}
             {eventError && (
               <p
                 role="alert"
-                className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+                className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
               >
                 Failed to record capital event. Check the browser console for
                 details.

--- a/frontend/src/components/settings/DisplayCurrencySection.tsx
+++ b/frontend/src/components/settings/DisplayCurrencySection.tsx
@@ -75,7 +75,7 @@ export function DisplayCurrencySection({ currentCurrency, onChanged }: Props) {
         {error !== null && (
           <div
             role="alert"
-            className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+            className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
           >
             {error}
           </div>

--- a/frontend/src/components/states/ErrorBanner.tsx
+++ b/frontend/src/components/states/ErrorBanner.tsx
@@ -2,7 +2,7 @@ export function ErrorBanner({ message }: { message: string }) {
   return (
     <div
       role="alert"
-      className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      className="rounded-md border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-4 py-3 text-sm text-red-700 dark:text-red-300"
     >
       {message}
     </div>

--- a/frontend/src/components/ui/Pagination.tsx
+++ b/frontend/src/components/ui/Pagination.tsx
@@ -53,7 +53,7 @@ const BTN_BASE =
 const BTN_IDLE =
   "border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-slate-600 hover:bg-slate-50 dark:hover:bg-slate-800/40";
 const BTN_ACTIVE =
-  "border-blue-400 bg-blue-50 text-blue-700";
+  "border-blue-400 bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300";
 const BTN_DISABLED =
   "border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-slate-300 cursor-not-allowed";
 

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -496,9 +496,9 @@ function RunButton({
           : "Run now";
   const tone =
     state.kind === "error"
-      ? "border-red-300 bg-red-50 text-red-700 hover:bg-red-100"
+      ? "border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 hover:bg-red-100"
       : state.kind === "queued"
-        ? "border-emerald-300 bg-emerald-50 text-emerald-700"
+        ? "border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300"
         : "border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 text-slate-700 hover:bg-slate-50 dark:hover:bg-slate-800/40";
   return (
     <button

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -539,7 +539,7 @@ export function ChartPage(): JSX.Element {
                 key={sym}
                 className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${
                   hasFailed
-                    ? "border-red-400 bg-red-50 text-red-700"
+                    ? "border-red-400 bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300"
                     : "border-slate-300 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 text-slate-700"
                 }`}
                 title={hasFailed ? "Failed to fetch — check ticker" : undefined}

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -297,7 +297,7 @@ function SubPositionRow({
       <td className="py-1.5 pl-6 pr-2 text-left">
         <span
           className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${
-            position.is_buy ? "bg-emerald-50 text-emerald-700" : "bg-red-50 text-red-700"
+            position.is_buy ? "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300" : "bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300"
           }`}
         >
           {position.is_buy ? "LONG" : "SHORT"}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -168,7 +168,7 @@ export function DashboardPage() {
 
       <Section title={`Watchlist${watchlist.data ? ` · ${watchlist.data.total}` : ""}`}>
         {watchlistError !== null && (
-          <div className="mb-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">
+          <div className="mb-2 rounded border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 p-2 text-xs text-red-700 dark:text-red-300">
             {watchlistError}
             <button
               type="button"

--- a/frontend/src/pages/EightKListPage.tsx
+++ b/frontend/src/pages/EightKListPage.tsx
@@ -213,7 +213,7 @@ export function EightKListPage(): JSX.Element {
                       <tr
                         key={f.accession_number}
  className={`cursor-pointer border-b border-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800/40 ${
-                          isSelected ? "bg-sky-50" : ""
+                          isSelected ? "bg-sky-50 dark:bg-sky-950/40" : ""
                         }`}
                         onClick={() => selectAccession(f.accession_number)}
                       >

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -54,7 +54,7 @@ import { useAsync } from "@/lib/useAsync";
 function ErrorView({ error, onRetry }: { error: unknown; onRetry?: () => void }) {
   const message = error instanceof Error ? error.message : "Request failed.";
   return (
-    <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+    <div className="rounded border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 p-3 text-sm text-red-700 dark:text-red-300">
       <p>{message}</p>
       {onRetry && (
         <button
@@ -320,9 +320,9 @@ function sentimentBadge(score: number | null) {
   const positive = score > 0.2;
   const negative = score < -0.2;
   const color = positive
-    ? "bg-emerald-100 text-emerald-700"
+    ? "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
     : negative
-      ? "bg-red-100 text-red-700"
+      ? "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300"
       : "bg-slate-100 dark:bg-slate-800 text-slate-600";
   const prefix = positive ? "+" : negative ? "" : "";
   return (
@@ -397,9 +397,9 @@ function redFlagBadge(score: number | null) {
   if (score === null) return null;
   const color =
     score > 0.5
-      ? "bg-red-100 text-red-700"
+      ? "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300"
       : score > 0.2
-        ? "bg-amber-100 text-amber-700"
+        ? "bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300"
         : "bg-slate-100 dark:bg-slate-800 text-slate-600";
   return (
     <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${color}`}>
@@ -667,7 +667,7 @@ function InstrumentPageBody({
       {thesisErr !== null ? (
         <div
           role="status"
-          className="rounded border border-red-200 bg-red-50 px-3 py-1.5 text-xs text-red-700"
+          className="rounded border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-3 py-1.5 text-xs text-red-700 dark:text-red-300"
         >
           Thesis generation failed: {thesisErr}
         </div>

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -87,8 +87,8 @@ function sortValue(item: InstrumentListItem, key: SortKey): unknown {
 // ---------------------------------------------------------------------------
 
 const TIER_TONE: Record<number, string> = {
-  1: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  2: "bg-blue-50 text-blue-700 border-blue-200",
+  1: "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-900/60",
+  2: "bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 border-blue-200 dark:border-blue-900/60",
   3: "bg-slate-50 dark:bg-slate-900/40 text-slate-600 border-slate-200 dark:border-slate-800",
 };
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -93,7 +93,7 @@ export function LoginPage(): JSX.Element {
           />
         </label>
         {error !== null && (
-          <div role="alert" className="mb-3 rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+          <div role="alert" className="mb-3 rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
             {error}
           </div>
         )}

--- a/frontend/src/pages/OperatorsPage.tsx
+++ b/frontend/src/pages/OperatorsPage.tsx
@@ -119,7 +119,7 @@ export function OperatorsPage(): JSX.Element {
       </div>
 
       {loadError !== null && (
-        <div role="alert" className="rounded bg-rose-50 px-3 py-2 text-xs text-rose-700">
+        <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-3 py-2 text-xs text-rose-700 dark:text-rose-300">
           {loadError}
         </div>
       )}
@@ -198,7 +198,7 @@ export function OperatorsPage(): JSX.Element {
           {createError !== null && (
             <div
               role="alert"
-              className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+              className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
             >
               {createError}
             </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -400,7 +400,7 @@ function BrokerCredentialsSection(): JSX.Element {
       </div>
 
       {loadError !== null && (
-        <div role="alert" className="rounded bg-rose-50 px-3 py-2 text-xs text-rose-700">
+        <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-3 py-2 text-xs text-rose-700 dark:text-rose-300">
           {loadError}
         </div>
       )}
@@ -531,7 +531,7 @@ function BrokerCredentialsSection(): JSX.Element {
             />
           </label>
           {editError !== null && (
-            <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+            <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
               {editError}
             </div>
           )}
@@ -614,7 +614,7 @@ function BrokerCredentialsSection(): JSX.Element {
           />
 
           {editError !== null && (
-            <div role="alert" className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700">
+            <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
               {editError}
             </div>
           )}
@@ -715,7 +715,7 @@ function BrokerCredentialsSection(): JSX.Element {
           {createError !== null && (
             <div
               role="alert"
-              className="rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700"
+              className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
             >
               {createError}
             </div>


### PR DESCRIPTION
Follow-up to #970. Check F of `frontend/scripts/check-dark-classes.mjs` (tinted `bg-<color>-(50|100|200)` requires a `dark:bg-` partner on the same line, else it reads light-on-light in dark mode) shipped with a per-file allow-list of pre-existing violators. This drains the list to empty.

## What changed
- **30 `.tsx` files**: every flagged tinted banner / badge / status pill received its `dark:bg-` partner (plus matching `dark:text-` / `dark:border-` partners on the same element) per the #987 mapping:
  | Light | Dark partner |
  |---|---|
  | `bg-X-50` | `dark:bg-X-950/40` |
  | `bg-X-100` | `dark:bg-X-900/40` |
  | `bg-X-200` | `dark:bg-X-900/60` |
  | `text-X-700` | `dark:text-X-300` |
  | `text-X-800` | `dark:text-X-200` |
  | `border-X-200` | `dark:border-X-900/60` |
  | `border-X-300` | `dark:border-X-700` |
- **`check-dark-classes.mjs`**: removed `CHECK_F_SKIP_FILES` + the `skipCheckF` gating. Check F now applies tree-wide with no exemptions; header comment updated to forbid reintroducing a skip-list.

The two files queued for deletion in #971/#972 (`RecoverPage.tsx`, `RecoveryPhraseConfirm.tsx`) were already removed from the list; `ReportsPage.tsx`/`SetupPage.tsx` carried no live violation.

## Verification (commit 0d0b6876)
- `pnpm dark:check` → **227 files, no violations** (acceptance #2 — allow-list empty/removed).
- `pnpm typecheck` clean; `pnpm test:unit` → **1147 passed**.
- **Visual smoke, dark mode** (dev-session cookie injected via Playwright `addCookies`) — acceptance #3:
  - **Dashboard** — alert pills (amber/red) render dark-tinted, readable.
  - **Recommendations** — `rejected` status pills dark-red, and the `AuditTrail` error banner (edited) renders correct dark-red border+bg+text.
  - **Instrument/GME** — `SummaryStrip` tier chip + held badge, `KeyStatsPane` tones read correctly.
  - No light-on-light wash-out observed.
- Codex ckpt-2: no wrong-partner findings (color/weight correct, light+dark tokens same-line, no duplicate variants); one stale header comment flagged + fixed.

Mechanical edits done via 5 parallel agents (disjoint file sets); each verified per-file that no tinted-bg line lacks a `dark:bg-` partner. Out of scope (per issue): files queued for deletion in #971/#972.

Closes #987.