### PR TITLE
feat(#677): targeted fundamentals force-refresh API (Part A)

### DIFF
--- a/app/api/fundamentals_admin.py
+++ b/app/api/fundamentals_admin.py
@@ -1,0 +1,129 @@
+"""Targeted SEC-fundamentals force-refresh endpoint (#677 Part A).
+
+``POST /admin/fundamentals/refresh`` lets an operator re-extract
+companyfacts for a named set of symbols *now*, bypassing the
+``plan_refresh`` watermark gate. The daily job only refreshes CIKs whose
+top-accession changed, so a ``TRACKED_CONCEPTS`` / allowlist extension
+does not backfill existing instruments until SEC ships them a fresh
+filing. This endpoint closes that gap.
+
+The resolve -> fetch -> normalize core is shared with the CLI
+(``scripts/force_refresh_fundamentals.py``) via
+``app.services.fundamentals.force_refresh.run_force_refresh`` — one
+reviewed implementation, no drift. Data treatment is unchanged from the
+daily path (settled "Fundamentals provider posture", #532); only the
+trigger is new.
+
+Connection model: the handler is a sync ``def`` (FastAPI runs it in the
+threadpool — no event-loop block) and opens a dedicated ``connect_job()``
+connection for the multi-second SEC fetch rather than the pooled
+``get_conn`` dependency, so a slow refresh never starves the request
+pool. ``run_force_refresh`` owns commit discipline and closes the
+connection via the ``with`` block.
+
+Auth: ``require_session_or_service_token`` (matches ``/jobs/{name}/run``).
+
+Spec: docs/specs/api/2026-06-28-fundamentals-force-refresh.md.
+Part B (``expected_filings`` poll watchlist) is a deferred follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.api.auth import require_session_or_service_token
+from app.jobs.job_connection import connect_job
+from app.services.fundamentals.force_refresh import run_force_refresh
+
+logger = logging.getLogger(__name__)
+
+# Work-bounding safety cap on distinct symbols, NOT a latency guarantee
+# — companyfacts latency + normalization volume vary. SEC's 10 req/s
+# shared throttle means ~50 issuers finish in the single-digit-seconds
+# range typically.
+MAX_SYMBOLS = 50
+
+router = APIRouter(
+    prefix="/admin/fundamentals",
+    tags=["admin", "fundamentals"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+class ForceRefreshRequest(BaseModel):
+    symbols: list[str] = Field(..., description="Ticker symbols to force-refresh (case-insensitive).")
+
+
+class SymbolResult(BaseModel):
+    symbol: str
+    resolved: bool
+    instrument_id: int | None
+    cik: str | None
+
+
+class ForceRefreshResponse(BaseModel):
+    requested: int  # distinct, normalized symbols
+    resolved: int
+    facts_upserted: int
+    facts_skipped: int
+    symbols_failed: int  # fetch/parse failures among resolved (see spec §4)
+    periods_canonical_upserted: int
+    results: list[SymbolResult]  # resolved entries first, then unresolved
+
+
+def _distinct_symbols(raw: list[str]) -> list[str]:
+    """Upper-case, strip, drop empties, dedup preserving first-seen order."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for s in raw:
+        sym = s.strip().upper()
+        if not sym or sym in seen:
+            continue
+        seen.add(sym)
+        out.append(sym)
+    return out
+
+
+@router.post("/refresh", response_model=ForceRefreshResponse)
+def force_refresh_fundamentals(req: ForceRefreshRequest) -> ForceRefreshResponse:
+    """Force a companyfacts re-fetch + re-normalization for ``symbols``.
+
+    Unresolved symbols (unknown instrument or no primary SEC CIK) are
+    reported per-symbol with ``resolved=false`` — not a whole-call 404,
+    since partial resolution is normal.
+    """
+    symbols = _distinct_symbols(req.symbols)
+    if not symbols:
+        raise HTTPException(status_code=400, detail="symbols must contain at least one non-empty symbol")
+    if len(symbols) > MAX_SYMBOLS:
+        raise HTTPException(status_code=400, detail=f"at most {MAX_SYMBOLS} symbols per call")
+
+    with connect_job() as conn:
+        result = run_force_refresh(conn, symbols)
+
+    results = [
+        SymbolResult(symbol=r.symbol.upper(), resolved=True, instrument_id=r.instrument_id, cik=r.cik)
+        for r in result.resolved
+    ] + [SymbolResult(symbol=m, resolved=False, instrument_id=None, cik=None) for m in result.missing]
+
+    logger.info(
+        "force_refresh_fundamentals: requested=%d resolved=%d facts_upserted=%d failed=%d canonical=%d",
+        len(symbols),
+        len(result.resolved),
+        result.facts.facts_upserted,
+        result.facts.symbols_failed,
+        result.periods.periods_canonical_upserted,
+    )
+
+    return ForceRefreshResponse(
+        requested=len(symbols),
+        resolved=len(result.resolved),
+        facts_upserted=result.facts.facts_upserted,
+        facts_skipped=result.facts.facts_skipped,
+        symbols_failed=result.facts.symbols_failed,
+        periods_canonical_upserted=result.periods.periods_canonical_upserted,
+        results=results,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.api.copy_trading import router as copy_trading_router
 from app.api.coverage import router as coverage_router
 from app.api.filings import router as filings_router
 from app.api.fund_metadata import router as fund_metadata_router
+from app.api.fundamentals_admin import router as fundamentals_admin_router
 from app.api.instruments import router as instruments_router
 from app.api.jobs import router as jobs_router
 from app.api.market_calendar import router as market_calendar_router
@@ -529,6 +530,7 @@ app.include_router(copy_trading_router)
 app.include_router(coverage_router)
 app.include_router(business_summary_admin_router)
 app.include_router(fund_metadata_router)  # #1171 fund-metadata endpoints
+app.include_router(fundamentals_admin_router)  # #677 fundamentals force-refresh
 # Debug router is dev/test-only — exposes operator-credentialled
 # pass-throughs to eToro (`/_debug/etoro-candles-probe`,
 # `/_debug/etoro-instrument-raw`) plus internal subscriber state

--- a/app/services/fundamentals/force_refresh.py
+++ b/app/services/fundamentals/force_refresh.py
@@ -1,0 +1,167 @@
+"""Shared targeted force-refresh core (#677).
+
+Single source of truth for the resolve -> fetch -> normalize sequence,
+consumed by BOTH:
+
+  * the CLI ``scripts/force_refresh_fundamentals.py`` (#674 quick-win), and
+  * the HTTP endpoint ``app/api/fundamentals_admin.py`` (#677 Part A).
+
+Both bypass the ``plan_refresh`` watermark gate so an operator can
+re-fetch SEC companyfacts + re-derive ``financial_periods`` for a
+hand-picked cohort without waiting for SEC to ship those CIKs a new
+filing. Data treatment is unchanged from the daily path (settled
+"Fundamentals provider posture", #532) — only the trigger is new.
+
+Commit discipline (psycopg3 savepoint != commit): the resolver SELECT
+opens an implicit read transaction; we ``commit()`` it before any
+HTTP-backed work so the ``with conn.transaction()`` blocks inside
+``refresh_financial_facts`` / ``normalize_financial_periods`` run as
+top-level transactions, not savepoints under one multi-minute outer tx
+that would leave the session idle-in-transaction and roll back the whole
+cohort on a late failure. Same pattern the per-CIK daily path uses.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
+from app.services.fundamentals import (
+    FactsRefreshSummary,
+    NormalizationSummary,
+    normalize_financial_periods,
+    refresh_financial_facts,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedSymbol:
+    symbol: str
+    instrument_id: int
+    cik: str
+
+
+@dataclass(frozen=True)
+class ForceRefreshResult:
+    """Outcome of one force-refresh run.
+
+    ``resolved`` has one entry per matched symbol (request order) — the
+    per-symbol response contract. ``fetched`` is ``resolved`` deduped by
+    ``instrument_id`` (two tickers can share one instrument) — the work
+    actually sent to SEC; counts/exit-codes key off this, not
+    ``resolved``.
+    """
+
+    resolved: list[ResolvedSymbol]  # one per matched symbol, request order
+    fetched: list[ResolvedSymbol]  # resolved deduped by instrument_id
+    missing: list[str]  # UPPER-cased symbols with no primary SEC CIK
+    facts: FactsRefreshSummary
+    periods: NormalizationSummary
+
+
+def resolve_symbols(
+    conn: psycopg.Connection[tuple],
+    symbols: list[str],
+) -> tuple[list[ResolvedSymbol], list[str]]:
+    """Map each symbol to its (instrument_id, primary SEC CIK).
+
+    Returns ``(resolved, missing)``: ``resolved`` contains every symbol
+    with a primary SEC CIK, in caller order; ``missing`` is the list of
+    UPPER-cased symbols that either don't exist in ``instruments`` or
+    have no primary SEC CIK row in ``external_identifiers``. The caller
+    surfaces the missing list rather than aborting — partial coverage is
+    expected (operator may include a non-US symbol by mistake).
+    """
+    if not symbols:
+        return [], []
+    upper = [s.upper() for s in symbols]
+    rows = conn.execute(
+        """
+        SELECT i.symbol, i.instrument_id, ei.identifier_value
+        FROM instruments i
+        JOIN external_identifiers ei
+          ON ei.instrument_id = i.instrument_id
+         AND ei.provider = 'sec'
+         AND ei.identifier_type = 'cik'
+         AND ei.is_primary = TRUE
+        WHERE UPPER(i.symbol) = ANY(%(symbols)s)
+        ORDER BY i.is_primary_listing DESC NULLS LAST, i.instrument_id ASC
+        """,
+        {"symbols": upper},
+    ).fetchall()
+
+    by_symbol: dict[str, ResolvedSymbol] = {}
+    for row in rows:
+        sym = str(row[0]).upper()
+        # Caller may pass duplicates — keep the first match (highest
+        # is_primary_listing) per symbol so a duplicate/retired listing
+        # can't shadow the canonical one.
+        if sym not in by_symbol:
+            by_symbol[sym] = ResolvedSymbol(
+                symbol=str(row[0]),
+                instrument_id=int(row[1]),
+                cik=str(row[2]),
+            )
+
+    resolved = [by_symbol[s] for s in upper if s in by_symbol]
+    missing = [s for s in upper if s not in by_symbol]
+    return resolved, missing
+
+
+def dedupe_resolved(resolved: list[ResolvedSymbol]) -> list[ResolvedSymbol]:
+    """Drop duplicate instrument_ids, keeping first occurrence.
+
+    Operator input is symbol-keyed, but two symbols (or a typo like
+    ``IEP IEP``) can map to the same instrument — re-fetching the same
+    CIK twice is wasted SEC budget. First-occurrence order is preserved
+    so log/response output stays predictable.
+    """
+    seen: set[int] = set()
+    unique: list[ResolvedSymbol] = []
+    for r in resolved:
+        if r.instrument_id in seen:
+            continue
+        seen.add(r.instrument_id)
+        unique.append(r)
+    return unique
+
+
+def run_force_refresh(
+    conn: psycopg.Connection[tuple],
+    symbols: list[str],
+) -> ForceRefreshResult:
+    """Resolve -> fetch companyfacts -> re-normalize for ``symbols``.
+
+    Commits between phases (see module docstring). When no symbol
+    resolves, returns zero summaries without touching SEC. Idempotent:
+    re-fetching unchanged companyfacts + re-running normalization is a
+    no-op for unchanged rows.
+    """
+    resolved, missing = resolve_symbols(conn, symbols)
+    # Close the implicit read tx before any HTTP-backed work below.
+    conn.commit()
+
+    fetched = dedupe_resolved(resolved)
+    facts = FactsRefreshSummary(symbols_attempted=0, facts_upserted=0, facts_skipped=0, symbols_failed=0)
+    periods = NormalizationSummary(instruments_processed=0, periods_raw_upserted=0, periods_canonical_upserted=0)
+
+    if fetched:
+        triples = [(r.symbol, r.instrument_id, r.cik) for r in fetched]
+        with SecFundamentalsProvider(user_agent=settings.sec_user_agent) as provider:
+            facts = refresh_financial_facts(provider, conn, triples)
+        # Separate the fetch phase from normalization so the per-
+        # instrument transactions inside normalize are top-level.
+        conn.commit()
+        # Normalize all fetched ids regardless of per-fetch outcome:
+        # idempotent — a fetch-failed instrument re-derives from its
+        # existing raw store (no corruption, no new data).
+        periods = normalize_financial_periods(conn, [r.instrument_id for r in fetched])
+        conn.commit()
+
+    return ForceRefreshResult(resolved=resolved, fetched=fetched, missing=missing, facts=facts, periods=periods)

--- a/docs/specs/api/2026-06-28-fundamentals-force-refresh.md
+++ b/docs/specs/api/2026-06-28-fundamentals-force-refresh.md
@@ -1,0 +1,84 @@
+# Fundamentals targeted force-refresh API (#677 Part A)
+
+Status: live spec (shipping). Part B (filing-poll watchlist / `expected_filings`) deferred to a follow-up ticket.
+
+## Problem
+
+SEC fundamentals refresh is gated by `plan_refresh()` (`app/services/fundamentals/__init__.py:2027`): only CIKs whose top-accession differs from the stored watermark get refreshed. So a `TRACKED_CONCEPTS` / allowlist extension does **not** backfill existing instruments until SEC ships them a fresh filing — the operator has no targeted way to say "re-extract IEP, ET, EPD now."
+
+## Source rule
+
+No SEC reg governs the *trigger* shape (it's an operator action, not a data-treatment decision). The *data treatment* is unchanged and governed by our settled "Fundamentals provider posture" (`docs/settled-decisions.md` — free regulated-source-only, #532): the endpoint reuses the exact `refresh_financial_facts` → `normalize_financial_periods` path the daily job uses, including the existing `TRACKED_CONCEPTS` whitelist and retention rules — it only bypasses the `plan_refresh` watermark gate. SEC fair-use: 10 req/s shared throttle (`_PROCESS_RATE_LIMIT_CLOCK` in `sec_edgar.py`) is enforced inside the provider — unchanged.
+
+## What ships
+
+### `POST /admin/fundamentals/refresh`
+
+Body: `{ "symbols": ["IEP", "ET", ...] }`. Auth: `require_session_or_service_token` (matches `/jobs/{name}/run`, `/admin/business-summary-failures/*`).
+
+Behaviour:
+1. Validate `symbols` non-empty, `<= 50` (a work-bounding safety cap, not a latency guarantee — companyfacts latency + normalization volume vary). 400 on empty/oversize. Uppercase + dedup the requested list (case-insensitive) before resolving — duplicate symbols collapse to one entry in `results` and one SEC fetch.
+2. Resolve each distinct symbol → `(symbol, instrument_id, primary_sec_cik)` in **one** query. Match `UPPER(i.symbol)` (operator input may be lowercase; mirrors the existing instrument-page resolvers) and pick the canonical primary listing via `DISTINCT ON` so a duplicate/retired listing row can't shadow it. This is a one-shot manual admin call, not a per-tick hot path, so the `UPPER()` scan over ~12k rows is acceptable (prevention-log #1186 targets per-tick resolvers):
+   ```sql
+   SELECT DISTINCT ON (UPPER(i.symbol))
+          UPPER(i.symbol) AS symbol, i.instrument_id, ei.identifier_value AS cik
+   FROM instruments i
+   JOIN external_identifiers ei
+     ON ei.instrument_id = i.instrument_id
+    AND ei.provider = 'sec' AND ei.identifier_type = 'cik' AND ei.is_primary = TRUE
+   WHERE UPPER(i.symbol) = ANY(%(symbols)s)
+   ORDER BY UPPER(i.symbol), i.is_primary_listing DESC, i.instrument_id ASC
+   ```
+   Symbols with no row (unknown instrument OR no primary SEC CIK) → reported per-symbol as `resolved=false`, not fetched. NOT a 404 for the whole call (partial-resolution is normal). `is_tradable` is **not** filtered — the operator explicitly named the symbol, so a retired-but-named instrument is still refreshable; the `DISTINCT ON` primary-listing winner already prevents shadow duplicates.
+3. `refresh_financial_facts(provider, conn, triples)` — always re-fetches companyfacts, writes `financial_facts_raw`. Bypasses `plan_refresh`.
+4. `normalize_financial_periods(conn, instrument_ids=[resolved ids])` — re-derive `financial_periods` from the now-current raw store. Normalization runs over **all** resolved ids regardless of per-fetch outcome: it is idempotent — an instrument whose fetch failed simply re-derives from its existing raw store (no corruption, no new data). `normalize_financial_periods` swallows per-instrument exceptions internally (logged server-side) and returns only success counts; the endpoint surfaces `periods_canonical_upserted` (actual successes) so a shortfall is visible, and `symbols_failed` (fetch/parse failures). A silently-failed normalize is logged, not counted — acceptable for a manual admin tool the operator can re-run; documented as a known limitation.
+5. Return per-symbol results + a roll-up.
+
+`results` carries one entry per **distinct requested symbol** (request order, resolved entries then unresolved). Two distinct tickers that map to the same `instrument_id` (e.g. `GOOG`/`GOOGL`) both appear as `resolved=true`, but the SEC fetch + normalization de-dups by `instrument_id` so the work runs once — the batch counts reflect the single fetch, the per-symbol `results` reflect every requested symbol.
+
+### Concurrency
+
+No advisory lock. Two concurrent force-refreshes (or an overlap with the daily job) of the same symbol are safe: `financial_facts_raw` writes are upserts (idempotent, last-writer-wins identical data) under per-instrument savepoints, and normalization is idempotent. Worst case is duplicated work, not corruption.
+
+### Connection model
+
+The handler is a **sync `def`** (FastAPI runs it in the threadpool — no event-loop block). It opens a dedicated `connect_job()` connection for the multi-second SEC fetch, NOT the pooled `get_conn` dependency — holding a pooled request connection across 5-60s of SEC I/O would starve the request pool. `refresh_financial_facts` commits its ledger row early and runs per-instrument savepoint transactions; we `conn.commit()` after `normalize_financial_periods` (psycopg3 savepoint≠commit — prevention-log). Connection closed in `finally`.
+
+### Response shape
+
+```jsonc
+{
+  "requested": 3,
+  "resolved": 2,
+  "facts_upserted": 410,
+  "facts_skipped": 12,
+  "symbols_failed": 0,                 // fetch/parse failures among resolved
+  "periods_canonical_upserted": 88,
+  "results": [
+    { "symbol": "IEP", "resolved": true,  "instrument_id": 123, "cik": "0000813762" },
+    { "symbol": "ET",  "resolved": true,  "instrument_id": 456, "cik": "0001276187" },
+    { "symbol": "ZZZZ","resolved": false, "instrument_id": null, "cik": null }
+  ]
+}
+```
+
+`FactsRefreshSummary` is batch-level (no per-symbol upsert breakdown), so per-symbol counts are not surfaced — only `resolved` + the batch rollup. Documented as a known limitation; per-symbol counts would need a `refresh_financial_facts` signature change, out of scope.
+
+## Tests (pure-logic-first)
+
+- Pure: symbol-resolution stitching — given resolved DB rows + the requested symbols, produce the ordered `results` list with correct `resolved` flags and the `(symbol, id, cik)` triples passed to refresh. Extract a pure `build_refresh_plan(requested, resolved_rows)` helper (uppercases + dedups requested, joins against resolved rows) and table-test it: unknown symbol, no-CIK symbol, duplicate symbol (collapses to one), mixed-case input (`aapl`/`AAPL` → one), all-unknown.
+- Validation: empty list → 400, 51 symbols → 400.
+- One light integration test only if a new SQL mechanism is introduced (it is not — the resolve query is standard); rely on dev-verify for the live path.
+
+## Definition-of-done (ETL clauses 8-12)
+
+Touches the fundamentals write path (`financial_facts_raw` + `financial_periods`), so:
+- Smoke `POST /admin/fundamentals/refresh {"symbols":["AAPL","GME","MSFT","JPM","HD"]}` on dev → record `facts_upserted` + `periods_canonical_upserted`.
+- Cross-source: spot-check one instrument's resulting `/instruments/{symbol}/fundamentals` (or financial_periods rollup) figure vs SEC EDGAR companyfacts directly.
+- Backfill: the endpoint IS the backfill trigger — exercising it on the panel satisfies the "run, don't queue" clause.
+- Operator-visible figure: confirm `/instruments/AAPL/...` fundamentals figure renders post-refresh.
+- PR records commit SHA + the figures.
+
+## Out of scope (follow-up ticket)
+
+Part B — `expected_filings` table + `expected_filings_poller` job (event-driven catch-up). Filed as a follow-up; needs schema migration + scheduler lane.

--- a/scripts/force_refresh_fundamentals.py
+++ b/scripts/force_refresh_fundamentals.py
@@ -1,5 +1,5 @@
 """Targeted SEC fundamentals refresh for a hand-picked set of symbols
-(#674 follow-up, #677 precursor).
+(#674 follow-up, #677 precursor) — CLI wrapper.
 
 Bypasses the staleness gate in
 :func:`app.services.fundamentals.plan_refresh` so the operator can
@@ -10,35 +10,21 @@ or for the next universe-wide sweep.
 Concrete trigger: PR #676 (#674) extended ``TRACKED_CONCEPTS`` with
 LP/LLC partnership-distribution tags. The dividend chart for IEP /
 ET / EPD / MPLX / KMI etc. won't fill until each of those CIKs is
-re-fetched with the new allowlist applied. ``plan_refresh``'s
-master-index selector only schedules CIKs SEC has filed something
-new for in the last 7 days — schema changes don't qualify, so
-without this script those instruments wait days/weeks.
+re-fetched with the new allowlist applied.
 
 Run from the repo root via the module form so the ``app`` package
 imports resolve:
 
     uv run python -m scripts.force_refresh_fundamentals IEP ET EPD MPLX KMI
 
-(The bare ``uv run python scripts/foo.py`` form does NOT add the
-repo root to ``sys.path`` on this layout — every script under
-``scripts/`` has to be invoked as a module.)
-
 Defaults to dry-run (logs the resolved (symbol, CIK) cohort, no
 fetches). Pass ``--apply`` to actually call SEC + write to the DB.
-The script is idempotent: re-fetching the same companyfacts payload
-and re-running normalisation is a no-op for unchanged rows
-(``upsert_facts_for_instrument`` ON CONFLICT DO UPDATE WHERE
-``IS DISTINCT FROM``; ``_canonical_merge_instrument`` likewise).
 
-Rate limit: SEC public-key tier is 10 req/sec. The provider's
-internal throttle handles spacing; this script does not need to
-manage rate limits itself.
-
-Out of scope (deliberate): no new HTTP API surface, no UI, no
-expected-filings poller. Those live in #677 — this is the
-operational quick-win that unblocks the dividend chart for the
-known-affected MLP cohort while #677 is designed.
+The resolve -> fetch -> normalize core lives in
+``app.services.fundamentals.force_refresh`` so the CLI and the HTTP
+endpoint (#677 Part A, ``POST /admin/fundamentals/refresh``) share one
+reviewed implementation. ``resolve_symbols`` / ``ResolvedSymbol`` are
+re-exported here for backward compatibility with existing callers/tests.
 """
 
 from __future__ import annotations
@@ -46,74 +32,21 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from dataclasses import dataclass
 
 import psycopg
 
 from app.config import settings
-from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
-from app.services.fundamentals import (
-    normalize_financial_periods,
-    refresh_financial_facts,
+from app.services.fundamentals.force_refresh import (  # re-export for back-compat
+    ResolvedSymbol,
+    dedupe_resolved,
+    resolve_symbols,
+    run_force_refresh,
 )
+
+__all__ = ["ResolvedSymbol", "resolve_symbols", "main"]
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class ResolvedSymbol:
-    symbol: str
-    instrument_id: int
-    cik: str
-
-
-def resolve_symbols(
-    conn: psycopg.Connection[tuple],
-    symbols: list[str],
-) -> tuple[list[ResolvedSymbol], list[str]]:
-    """Map each symbol to its (instrument_id, primary SEC CIK).
-
-    Returns ``(resolved, missing)``: ``resolved`` contains every symbol
-    with a primary SEC CIK, in caller order; ``missing`` is the list of
-    symbols that either don't exist in ``instruments`` or have no
-    primary SEC CIK row in ``external_identifiers``. The caller logs
-    the missing list rather than aborting — partial coverage is
-    expected (operator may include a non-US symbol by mistake).
-    """
-    if not symbols:
-        return [], []
-    upper = [s.upper() for s in symbols]
-    rows = conn.execute(
-        """
-        SELECT i.symbol, i.instrument_id, ei.identifier_value
-        FROM instruments i
-        JOIN external_identifiers ei
-          ON ei.instrument_id = i.instrument_id
-         AND ei.provider = 'sec'
-         AND ei.identifier_type = 'cik'
-         AND ei.is_primary = TRUE
-        WHERE UPPER(i.symbol) = ANY(%(symbols)s)
-        ORDER BY i.is_primary_listing DESC NULLS LAST, i.instrument_id ASC
-        """,
-        {"symbols": upper},
-    ).fetchall()
-
-    by_symbol: dict[str, ResolvedSymbol] = {}
-    for row in rows:
-        sym = str(row[0]).upper()
-        # Caller may pass duplicates — keep the first match (highest
-        # is_primary_listing) per symbol.
-        if sym not in by_symbol:
-            by_symbol[sym] = ResolvedSymbol(
-                symbol=str(row[0]),
-                instrument_id=int(row[1]),
-                cik=str(row[2]),
-            )
-
-    resolved = [by_symbol[s] for s in upper if s in by_symbol]
-    missing = [s for s in upper if s not in by_symbol]
-    return resolved, missing
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -131,107 +64,73 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     with psycopg.connect(settings.database_url) as conn:
-        resolved, missing = resolve_symbols(conn, args.symbols)
-        # Close the implicit read transaction opened by the resolver
-        # SELECT before any HTTP-backed work below. Without this, the
-        # ``with conn.transaction()`` blocks inside
-        # ``refresh_financial_facts`` / ``normalize_financial_periods``
-        # would degrade to savepoints under one giant outer
-        # transaction, leaving the session idle-in-transaction
-        # across multi-minute SEC fetches and rolling back the
-        # whole cohort on a late failure. Same pattern the per-CIK
-        # path in app/services/fundamentals.py uses.
-        conn.commit()
-
-        if missing:
-            logger.warning(
-                "force_refresh: %d/%d symbols have no primary SEC CIK and will be skipped: %s",
-                len(missing),
-                len(args.symbols),
-                ", ".join(missing),
-            )
-
-        if not resolved:
-            logger.error("force_refresh: no resolvable symbols; nothing to do")
-            return 1
-
-        # Dedupe by instrument_id before the expensive work — the
-        # operator's CLI is positional, so a typo like
-        # ``IEP IEP MPLX`` shouldn't triple-fetch IEP. Caller-order
-        # of first occurrence is preserved so log output stays
-        # predictable.
-        seen_ids: set[int] = set()
-        unique: list[ResolvedSymbol] = []
-        for r in resolved:
-            if r.instrument_id in seen_ids:
-                continue
-            seen_ids.add(r.instrument_id)
-            unique.append(r)
-        if len(unique) < len(resolved):
-            logger.info(
-                "force_refresh: deduped %d duplicate input(s)",
-                len(resolved) - len(unique),
-            )
-
-        logger.info(
-            "force_refresh: %d symbols resolved: %s",
-            len(unique),
-            ", ".join(f"{r.symbol}({r.cik})" for r in unique),
-        )
-
         if not args.apply:
+            resolved, missing = resolve_symbols(conn, args.symbols)
+            conn.commit()
+            _log_missing(missing, len(args.symbols))
+            fetched = dedupe_resolved(resolved)
+            if not fetched:
+                logger.error("force_refresh: no resolvable symbols; nothing to do")
+                return 1
+            _log_deduped(resolved, fetched)
+            logger.info(
+                "force_refresh: %d symbols resolved: %s",
+                len(fetched),
+                ", ".join(f"{r.symbol}({r.cik})" for r in fetched),
+            )
             logger.info("force_refresh: DRY-RUN — pass --apply to actually fetch")
             return 0
 
-        # Re-fetch companyfacts for every resolved CIK and write to
-        # ``financial_facts_raw``. ``refresh_financial_facts`` owns the
-        # ingestion-run ledger + per-symbol error isolation, so a
-        # single SEC 5xx for one CIK doesn't abort the rest of the
-        # cohort.
-        instrument_ids = [r.instrument_id for r in unique]
-        symbols_for_refresh: list[tuple[str, int, str]] = [(r.symbol, r.instrument_id, r.cik) for r in unique]
-        with SecFundamentalsProvider(user_agent=settings.sec_user_agent) as provider:
-            facts_summary = refresh_financial_facts(provider, conn, symbols_for_refresh)
-        # `refresh_financial_facts` opens an `ingestion_runs` row at
-        # entry and closes it at exit; the per-CIK `with
-        # conn.transaction()` blocks inside its loop work correctly,
-        # but the surrounding ledger writes can leave the session in
-        # a transaction once the function returns. Explicit commit
-        # here separates the fetch phase from the normalisation
-        # phase so the per-instrument transactions inside
-        # `normalize_financial_periods` are top-level (not savepoints
-        # under a multi-minute outer tx). Codex review #2 finding.
-        conn.commit()
-        logger.info(
-            "force_refresh: facts upserted=%d skipped=%d failed=%d",
-            facts_summary.facts_upserted,
-            facts_summary.facts_skipped,
-            facts_summary.symbols_failed,
-        )
+        result = run_force_refresh(conn, args.symbols)
 
-        # Re-derive ``financial_periods`` from the now-current raw
-        # store. Scoped to the resolved cohort so unrelated rows
-        # don't get touched.
-        norm_summary = normalize_financial_periods(conn, instrument_ids=instrument_ids)
-        conn.commit()
-        logger.info(
-            "force_refresh: normalisation processed=%d raw_upserted=%d canonical_upserted=%d",
-            norm_summary.instruments_processed,
-            norm_summary.periods_raw_upserted,
-            norm_summary.periods_canonical_upserted,
-        )
-
-    # Surface any per-symbol SEC failure as a non-zero exit so an
-    # automation wrapper / shell pipeline can detect it. A partial
-    # failure (some succeeded, some failed) returns 2 so the caller
-    # can distinguish "nothing landed" (1) from "review the log"
-    # (2). Resolver-only failures (no resolvable symbols) already
-    # returned 1 earlier.
-    if facts_summary.symbols_failed == len(unique):
+    _log_missing(result.missing, len(args.symbols))
+    if not result.fetched:
+        logger.error("force_refresh: no resolvable symbols; nothing to do")
         return 1
-    if facts_summary.symbols_failed > 0:
+
+    _log_deduped(result.resolved, result.fetched)
+    logger.info(
+        "force_refresh: %d symbols resolved: %s",
+        len(result.fetched),
+        ", ".join(f"{r.symbol}({r.cik})" for r in result.fetched),
+    )
+    logger.info(
+        "force_refresh: facts upserted=%d skipped=%d failed=%d",
+        result.facts.facts_upserted,
+        result.facts.facts_skipped,
+        result.facts.symbols_failed,
+    )
+    logger.info(
+        "force_refresh: normalisation processed=%d raw_upserted=%d canonical_upserted=%d",
+        result.periods.instruments_processed,
+        result.periods.periods_raw_upserted,
+        result.periods.periods_canonical_upserted,
+    )
+
+    # Exit codes: distinguish "nothing landed" (1) from "review the log"
+    # (2). Resolver-only failure (no resolvable symbols) already returned
+    # 1 above. ``symbols_failed`` is counted over the deduped fetch set.
+    if result.facts.symbols_failed == len(result.fetched):
+        return 1
+    if result.facts.symbols_failed > 0:
         return 2
     return 0
+
+
+def _log_deduped(resolved: list[ResolvedSymbol], fetched: list[ResolvedSymbol]) -> None:
+    dropped = len(resolved) - len(fetched)
+    if dropped > 0:
+        logger.info("force_refresh: deduped %d duplicate input(s)", dropped)
+
+
+def _log_missing(missing: list[str], requested: int) -> None:
+    if missing:
+        logger.warning(
+            "force_refresh: %d/%d symbols have no primary SEC CIK and will be skipped: %s",
+            len(missing),
+            requested,
+            ", ".join(missing),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_fundamentals_force_refresh_helpers.py
+++ b/tests/test_fundamentals_force_refresh_helpers.py
@@ -1,0 +1,48 @@
+"""Pure-logic tests for the force-refresh helpers (#677 Part A).
+
+No DB — these pin the symbol-normalization + instrument-dedup contracts
+that shape the ``POST /admin/fundamentals/refresh`` request handling.
+The DB-backed resolver (``resolve_symbols``) is covered separately in
+``tests/test_force_refresh_fundamentals.py``.
+"""
+
+from __future__ import annotations
+
+from app.api.fundamentals_admin import _distinct_symbols
+from app.services.fundamentals.force_refresh import ResolvedSymbol, dedupe_resolved
+
+
+class TestDistinctSymbols:
+    def test_uppercases_strips_and_dedups_preserving_order(self) -> None:
+        assert _distinct_symbols([" aapl ", "MSFT", "AApl", "msft", "gme"]) == ["AAPL", "MSFT", "GME"]
+
+    def test_drops_empty_and_whitespace_only(self) -> None:
+        assert _distinct_symbols(["", "   ", "IEP"]) == ["IEP"]
+
+    def test_empty_input(self) -> None:
+        assert _distinct_symbols([]) == []
+
+
+def _rs(symbol: str, instrument_id: int, cik: str = "0000000001") -> ResolvedSymbol:
+    return ResolvedSymbol(symbol=symbol, instrument_id=instrument_id, cik=cik)
+
+
+class TestDedupeResolved:
+    def test_collapses_duplicate_instrument_ids_first_wins(self) -> None:
+        rows = [_rs("IEP", 1), _rs("IEP", 1), _rs("MPLX", 2)]
+        out = dedupe_resolved(rows)
+        assert [(r.symbol, r.instrument_id) for r in out] == [("IEP", 1), ("MPLX", 2)]
+
+    def test_two_symbols_same_instrument_keep_first(self) -> None:
+        # Distinct tickers can map to the same instrument_id; we re-fetch
+        # the CIK once, keeping the first occurrence.
+        rows = [_rs("GOOG", 9), _rs("GOOGL", 9)]
+        out = dedupe_resolved(rows)
+        assert [r.symbol for r in out] == ["GOOG"]
+
+    def test_no_duplicates_passthrough(self) -> None:
+        rows = [_rs("A", 1), _rs("B", 2), _rs("C", 3)]
+        assert dedupe_resolved(rows) == rows
+
+    def test_empty(self) -> None:
+        assert dedupe_resolved([]) == []


### PR DESCRIPTION
## What

`POST /admin/fundamentals/refresh` — re-fetch SEC companyfacts + re-derive `financial_periods` for a named symbol cohort *now*, bypassing the `plan_refresh` watermark gate.

Body: `{"symbols": ["IEP","ET",...]}` (case-insensitive, ≤50 distinct). Auth: `require_session_or_service_token`.

## Why

The daily job only refreshes CIKs whose top-accession changed, so a `TRACKED_CONCEPTS`/allowlist extension never backfills existing instruments until SEC ships them a fresh filing (issue #677). This gives the operator a targeted trigger.

## Design

- **Single source of truth.** The resolve→fetch→normalize core (previously inline in `scripts/force_refresh_fundamentals.py`, #674) is extracted to `app/services/fundamentals/force_refresh.py::run_force_refresh`. Both the CLI and the new endpoint consume it — no drift. `resolve_symbols`/`ResolvedSymbol` re-exported from the script for back-compat (existing test unchanged).
- **Connection model.** Sync handler (FastAPI runs it in the threadpool — no event-loop block) on a dedicated `connect_job()` connection, **not** the pooled `get_conn` dependency: a 5-60s SEC fetch must not starve the request pool.
- **Commit discipline** (psycopg3 savepoint≠commit): commit between resolve / fetch / normalize phases so the per-instrument transactions inside `refresh_financial_facts`/`normalize_financial_periods` run top-level, not as savepoints under one multi-minute outer tx.
- **Per-symbol response contract.** Instrument-dedup applies to fetch/normalize *work* (`ForceRefreshResult.fetched`), not the *response* (`ForceRefreshResult.resolved`) — two tickers sharing one instrument both appear in `results`, work runs once.
- Data treatment unchanged from the daily path (settled "Fundamentals provider posture", #532); only the trigger is new.

## Security model

Endpoint gated by `require_session_or_service_token` (same gate as `/jobs/{name}/run`). No new auth surface. Resolver uses bound params (`UPPER(i.symbol) = ANY(%(symbols)s)`), no interpolation. Writes only `financial_facts_raw` + `financial_periods` via the existing reviewed ingest functions.

## Tests

- Pure, fast-tier: `tests/test_fundamentals_force_refresh_helpers.py` — `_distinct_symbols` (case/dedup/empty), `dedupe_resolved` (instrument-dedup, two-symbols-one-instrument, passthrough). 7 passed.
- DB-tier resolver coverage already exists (`tests/test_force_refresh_fundamentals.py`, imports unchanged via re-export).

## Codex

- ckpt-1 (spec): case-insensitive resolve + primary-listing winner, dedup requested, idempotent-normalize + concurrency documented.
- ckpt-2 (diff): caught the per-symbol-response-vs-work dedup conflation (fixed) + restored the CLI deduped-count log.

## Dev verification (commit 97fabe52)

| Clause | Result |
|---|---|
| Smoke panel `{AAPL,GME,MSFT,JPM,HD,aapl}` | `requested=5` (aapl deduped), `resolved=5`, `facts_upserted=33407`, `symbols_failed=0`, `periods_canonical_upserted=419` |
| Validation | empty→400, unauth→401 |
| Operator-visible figure | `/instruments/AAPL/financials` renders revenue **$111.184B** (Q2 FY2026, end 2026-03-28) from `financial_periods` |
| Cross-source | SEC companyconcept AAPL `RevenueFromContractWithCustomerExcludingAssessedTax` = **111,184,000,000** for 2025-12-28→2026-03-28 (10-Q FY2026 Q2) — exact match |

## Scope

Part A only. **Part B** (`expected_filings` table + `expected_filings_poller` job — event-driven filing-poll watchlist) deferred to **#1788**; needs a schema migration + scheduler lane.

Spec: `docs/specs/api/2026-06-28-fundamentals-force-refresh.md`.

Closes #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
