### PR TITLE
feat(#1788): expected-filings poller for event-driven fundamentals catch-up (#677 Part B)

### DIFF
--- a/app/jobs/expected_filings_poller.py
+++ b/app/jobs/expected_filings_poller.py
@@ -1,0 +1,438 @@
+"""Event-driven fundamentals catch-up — expected-filings seed + poller (#1788).
+
+`daily_financial_facts` already detects new 10-Q/10-K filings (via
+`plan_refresh` → submissions.json) and force-refreshes companyfacts +
+`financial_periods` — but once a day over the whole universe. This module
+adds a small, budget-bounded, high-frequency watchlist so the operator's
+high-value instruments (held + watchlisted) get refreshed within minutes
+of an expected filing appearing, ahead of the daily backstop.
+
+Strictly additive: a mis-sized window or a missed filing just falls back
+to the ≤24 h daily path. The poller acts ONLY on a strictly-newer,
+exact-form, non-amendment accession (baseline-watermarked), so it can
+never false-fulfil or write wrong data.
+
+See docs/specs/etl/2026-06-28-expected-filings-poller.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+
+import psycopg
+
+from app.providers.implementations.sec_submissions import (
+    FilingIndexRow,
+    HttpGet,
+    check_freshness,
+)
+from app.services.fundamentals.force_refresh import run_force_refresh
+from app.services.sec_manifest import record_manifest_entry
+
+logger = logging.getLogger(__name__)
+
+# Quarterly cadence: the next fiscal period ends ~one quarter after the
+# latest reported one (Rule 13a-13). 91d ≈ one quarter; the wide window
+# below absorbs fiscal-calendar drift.
+_QUARTER_DAYS = 91
+
+# Poll window offsets from the predicted next period-end, padded around
+# the widest statutory filing deadline (Form 10-Q A.(1): 40-45d after
+# quarter-end; Form 10-K A.(2): 60-90d after FY-end). Start is offset to
+# the earliest realistic filing date so we don't burn polls in the
+# pre-deadline dead zone; an early filer caught late falls to the daily
+# backstop.
+_WINDOW_OFFSETS: dict[str, tuple[int, int]] = {
+    "10-Q": (30, 55),
+    "10-K": (50, 100),
+}
+
+# Manifest source code per expected form (sec_filing_manifest.source).
+_SOURCE_FOR_FORM: dict[str, str] = {
+    "10-Q": "sec_10q",
+    "10-K": "sec_10k",
+}
+
+
+def next_form_and_window(
+    latest_period_type: str,
+    latest_period_end: date,
+) -> tuple[str, date, date]:
+    """Derive the next expected (form, window_start, window_end).
+
+    Form is fixed by fiscal position, not by quarterly-cadence guessing
+    (a domestic issuer files three 10-Qs then one 10-K — a Q3 issuer's
+    next filing is the FY 10-K, NOT a phantom 10-Q):
+
+      latest Q1, Q2 -> next 10-Q   (following quarter)
+      latest Q3     -> next 10-K   (fiscal year-end period)
+      latest Q4, FY -> next 10-Q   (first quarter of the new year)
+      else          -> next 10-Q   (default for sparse/odd period types)
+
+    The window is anchored on the predicted next period-end + the
+    statutory-deadline-padded offsets.
+    """
+    expected = "10-K" if latest_period_type == "Q3" else "10-Q"
+    next_period_end = latest_period_end + timedelta(days=_QUARTER_DAYS)
+    start_off, end_off = _WINDOW_OFFSETS[expected]
+    return (
+        expected,
+        next_period_end + timedelta(days=start_off),
+        next_period_end + timedelta(days=end_off),
+    )
+
+
+def match_filing(
+    new_filings: list[FilingIndexRow],
+    expected_filing_type: str,
+) -> FilingIndexRow | None:
+    """Return the newest filing matching the expected form, or None.
+
+    Exact-form + non-amendment match: ``10-Q/A`` / ``10-K/A`` map to the
+    same manifest source as the original, so source-level matching would
+    let an amendment false-fulfil an expected original filing. ``form``
+    is matched verbatim and amendments are excluded.
+    """
+    for row in new_filings:
+        if row.form == expected_filing_type and not row.is_amendment:
+            return row
+    return None
+
+
+@dataclass(frozen=True)
+class SeedStats:
+    instruments_scoped: int
+    rows_upserted: int
+
+
+def _baseline_accession(
+    conn: psycopg.Connection[tuple],
+    instrument_id: int,
+    source: str,
+) -> str | None:
+    """Last known non-amendment accession of ``source`` for the instrument."""
+    row = conn.execute(
+        """
+        SELECT accession_number
+        FROM sec_filing_manifest
+        WHERE instrument_id = %s AND source = %s AND is_amendment = FALSE
+        ORDER BY filed_at DESC
+        LIMIT 1
+        """,
+        (instrument_id, source),
+    ).fetchone()
+    return str(row[0]) if row else None
+
+
+def _scope_latest_periods(
+    conn: psycopg.Connection[tuple],
+    *,
+    only_symbol: str | None,
+) -> list[tuple[int, date, str]]:
+    """Return (instrument_id, latest_period_end, latest_period_type).
+
+    Scope is the operator high-value set — watchlist ∪ open positions —
+    restricted to instruments with ≥1 financial_periods row. ``only_symbol``
+    force-scopes one instrument (CLI / dev verification), bypassing
+    membership.
+    """
+    if only_symbol is not None:
+        scope_cte = "scope AS (SELECT instrument_id FROM instruments WHERE UPPER(symbol) = %(sym)s)"
+        params: dict[str, object] = {"sym": only_symbol.upper()}
+    else:
+        scope_cte = (
+            "scope AS ("
+            " SELECT instrument_id FROM watchlist"
+            " UNION SELECT instrument_id FROM positions WHERE current_units > 0"
+            ")"
+        )
+        params = {}
+    rows = conn.execute(
+        f"""
+        WITH {scope_cte}
+        SELECT DISTINCT ON (fp.instrument_id)
+               fp.instrument_id, fp.period_end_date, fp.period_type
+        FROM financial_periods fp
+        JOIN scope s ON s.instrument_id = fp.instrument_id
+        WHERE fp.superseded_at IS NULL
+        ORDER BY fp.instrument_id, fp.period_end_date DESC
+        """,
+        params,
+    ).fetchall()
+    return [(int(r[0]), r[1], str(r[2])) for r in rows]
+
+
+@dataclass(frozen=True)
+class SeedRow:
+    instrument_id: int
+    expected_filing_type: str
+    anchor_period_end: date
+    expected_window_start: date
+    expected_window_end: date
+    baseline_accession: str | None
+
+
+def derive_seed_rows(
+    conn: psycopg.Connection[tuple],
+    *,
+    only_symbol: str | None = None,
+) -> list[SeedRow]:
+    """Compute (no writes) the next expected filing per in-scope instrument."""
+    scoped = _scope_latest_periods(conn, only_symbol=only_symbol)
+    rows: list[SeedRow] = []
+    for instrument_id, latest_period_end, latest_period_type in scoped:
+        expected, win_start, win_end = next_form_and_window(latest_period_type, latest_period_end)
+        baseline = _baseline_accession(conn, instrument_id, _SOURCE_FOR_FORM[expected])
+        if baseline is None:
+            # No known prior filing of the expected form → no watermark to
+            # poll against. check_freshness(last_known_filing_id=None) would
+            # return every recent same-source filing, so the poller would
+            # false-fulfil on the existing last filing instead of waiting for
+            # the new one. Skip — the daily backstop covers these instruments.
+            logger.info(
+                "seed_expected_filings: skipping instrument_id=%d %s — no manifest baseline",
+                instrument_id,
+                expected,
+            )
+            continue
+        rows.append(
+            SeedRow(
+                instrument_id=instrument_id,
+                expected_filing_type=expected,
+                anchor_period_end=latest_period_end,
+                expected_window_start=win_start,
+                expected_window_end=win_end,
+                baseline_accession=baseline,
+            )
+        )
+    return rows
+
+
+def seed_expected_filings(
+    conn: psycopg.Connection[tuple],
+    *,
+    only_symbol: str | None = None,
+) -> SeedStats:
+    """Derive + upsert the next expected filing per in-scope instrument.
+
+    Idempotent: one row per instrument (UNIQUE). The conditional upsert
+    rolls a row forward and resets fulfilment ONLY when the cycle key
+    (``anchor_period_end`` = latest reported period-end) advances, so a
+    no-change re-seed leaves a fulfilled row untouched.
+    """
+    seed_rows = derive_seed_rows(conn, only_symbol=only_symbol)
+    upserted = 0
+    for sr in seed_rows:
+        cur = conn.execute(
+            """
+            INSERT INTO expected_filings (
+                instrument_id, expected_filing_type, anchor_period_end,
+                expected_window_start, expected_window_end, baseline_accession)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            ON CONFLICT (instrument_id) DO UPDATE
+            SET expected_filing_type  = EXCLUDED.expected_filing_type,
+                anchor_period_end     = EXCLUDED.anchor_period_end,
+                expected_window_start = EXCLUDED.expected_window_start,
+                expected_window_end   = EXCLUDED.expected_window_end,
+                baseline_accession    = EXCLUDED.baseline_accession,
+                last_polled_at        = NULL,
+                fulfilled_at          = NULL,
+                fulfilled_accession   = NULL
+            WHERE expected_filings.anchor_period_end IS DISTINCT FROM EXCLUDED.anchor_period_end
+            """,
+            (
+                sr.instrument_id,
+                sr.expected_filing_type,
+                sr.anchor_period_end,
+                sr.expected_window_start,
+                sr.expected_window_end,
+                sr.baseline_accession,
+            ),
+        )
+        upserted += cur.rowcount
+
+    pruned = 0
+    if only_symbol is None:
+        # Full-scope re-seed prunes rows for instruments that have left the
+        # high-value set (un-watchlisted / position closed) so the poller
+        # doesn't keep spending SEC budget outside the watchlist ∪ open-positions
+        # invariant. The --symbol path is additive and never prunes.
+        cur = conn.execute(
+            """
+            DELETE FROM expected_filings
+            WHERE instrument_id NOT IN (
+                SELECT instrument_id FROM watchlist
+                UNION SELECT instrument_id FROM positions WHERE current_units > 0
+            )
+            """
+        )
+        pruned = cur.rowcount
+    conn.commit()
+    logger.info(
+        "seed_expected_filings: scoped=%d upserted=%d pruned=%d (only_symbol=%s)",
+        len(seed_rows),
+        upserted,
+        pruned,
+        only_symbol,
+    )
+    return SeedStats(instruments_scoped=len(seed_rows), rows_upserted=upserted)
+
+
+@dataclass(frozen=True)
+class PollStats:
+    subjects_polled: int
+    fulfilled: int
+    poll_errors: int
+
+
+@dataclass(frozen=True)
+class _DueRow:
+    expected_filings_id: int
+    instrument_id: int
+    symbol: str
+    cik: str
+    expected_filing_type: str
+    baseline_accession: str | None
+
+
+def _select_due(
+    conn: psycopg.Connection[tuple],
+    *,
+    now: datetime,
+    max_subjects: int,
+) -> list[_DueRow]:
+    """Unfulfilled rows whose window is open and poll interval elapsed.
+
+    Most-stale-first (``last_polled_at NULLS FIRST``) so a large in-window
+    set round-robins under the subject cap rather than starving the tail.
+    """
+    rows = conn.execute(
+        """
+        SELECT ef.id, ef.instrument_id, i.symbol, ei.identifier_value,
+               ef.expected_filing_type, ef.baseline_accession
+        FROM expected_filings ef
+        JOIN instruments i ON i.instrument_id = ef.instrument_id
+        JOIN external_identifiers ei
+          ON ei.instrument_id = ef.instrument_id
+         AND ei.provider = 'sec'
+         AND ei.identifier_type = 'cik'
+         AND ei.is_primary = TRUE
+        WHERE ef.fulfilled_at IS NULL
+          AND %(today)s BETWEEN ef.expected_window_start AND ef.expected_window_end
+          AND (ef.last_polled_at IS NULL
+               OR ef.last_polled_at < %(now)s - make_interval(mins => ef.poll_interval_minutes))
+        ORDER BY ef.last_polled_at ASC NULLS FIRST, ef.id ASC
+        LIMIT %(cap)s
+        """,
+        {"today": now.date(), "now": now, "cap": max_subjects},
+    ).fetchall()
+    return [
+        _DueRow(
+            expected_filings_id=int(r[0]),
+            instrument_id=int(r[1]),
+            symbol=str(r[2]),
+            cik=str(r[3]),
+            expected_filing_type=str(r[4]),
+            baseline_accession=r[5],
+        )
+        for r in rows
+    ]
+
+
+def run_expected_filings_poller(
+    conn: psycopg.Connection[tuple],
+    *,
+    http_get: HttpGet,
+    now: datetime,
+    user_agent: str,
+    max_subjects: int = 100,
+) -> PollStats:
+    """Poll submissions.json for due rows; force-refresh on a matching filing.
+
+    Commit discipline mirrors ``run_force_refresh``: the read tx (select)
+    is committed before any HTTP-backed work so each per-subject mutation
+    runs as a top-level transaction.
+    """
+    due = _select_due(conn, now=now, max_subjects=max_subjects)
+    conn.commit()
+
+    fulfilled = 0
+    errors = 0
+    for row in due:
+        source = _SOURCE_FOR_FORM[row.expected_filing_type]
+        try:
+            delta = check_freshness(
+                http_get,
+                cik=row.cik,
+                last_known_filing_id=row.baseline_accession,
+                sources={source},  # type: ignore[arg-type]
+                user_agent=user_agent,
+            )
+        except Exception:
+            logger.exception(
+                "expected_filings_poller: probe failed instrument_id=%d cik=%s",
+                row.instrument_id,
+                row.cik,
+            )
+            # Bump last_polled_at on failure too, so a bad CIK / network
+            # error respects poll_interval_minutes instead of staying
+            # most-stale and re-firing every tick (which would starve
+            # healthy due rows under the subject cap).
+            conn.execute(
+                "UPDATE expected_filings SET last_polled_at = %s WHERE id = %s",
+                (now, row.expected_filings_id),
+            )
+            conn.commit()
+            errors += 1
+            continue
+
+        match = match_filing(delta.new_filings, row.expected_filing_type)
+        if match is None or match.source is None:
+            conn.execute(
+                "UPDATE expected_filings SET last_polled_at = %s WHERE id = %s",
+                (now, row.expected_filings_id),
+            )
+            conn.commit()
+            continue
+
+        # Record the discovered filing first (keeps the manifest invariant
+        # and lets the next daily seed observe the advanced filing) — then
+        # force-refresh fundamentals, then mark fulfilled.
+        record_manifest_entry(
+            conn,
+            match.accession_number,
+            cik=match.cik,
+            form=match.form,
+            source=match.source,
+            subject_type="issuer",
+            subject_id=str(row.instrument_id),
+            instrument_id=row.instrument_id,
+            filed_at=match.filed_at,
+            accepted_at=match.accepted_at,
+            primary_document_url=match.primary_document_url,
+            is_amendment=match.is_amendment,
+        )
+        conn.commit()
+
+        run_force_refresh(conn, [row.symbol])
+
+        conn.execute(
+            """
+            UPDATE expected_filings
+            SET fulfilled_at = %s, fulfilled_accession = %s, last_polled_at = %s
+            WHERE id = %s
+            """,
+            (now, match.accession_number, now, row.expected_filings_id),
+        )
+        conn.commit()
+        fulfilled += 1
+        logger.info(
+            "expected_filings_poller: fulfilled %s %s accession=%s",
+            row.symbol,
+            row.expected_filing_type,
+            match.accession_number,
+        )
+
+    return PollStats(subjects_polled=len(due), fulfilled=fulfilled, poll_errors=errors)

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -390,6 +390,12 @@ from app.workers import scheduler as _scheduler  # noqa: E402
 _INVOKERS[_scheduler.JOB_FILINGS_HISTORY_SEED] = _scheduler.filings_history_seed
 _INVOKERS[_scheduler.JOB_SEC_FIRST_INSTALL_DRAIN] = _scheduler.sec_first_install_drain
 
+# #1788 (#677 Part B) — expected-filings seed + poller. Both zero-arg bodies
+# defined in scheduler.py; registered here (lazy ``_scheduler.`` access) so the
+# scheduler's SCHEDULED_JOBS rows have dispatchable invokers.
+_INVOKERS[_scheduler.JOB_EXPECTED_FILINGS_SEED] = _adapt_zero_arg(_scheduler.expected_filings_seed)
+_INVOKERS[_scheduler.JOB_EXPECTED_FILINGS_POLLER] = _adapt_zero_arg(_scheduler.expected_filings_poller)
+
 # #1174 — dedicated MF directory refresh + N-CSR fund-scoped bootstrap
 # drain. Both invokers are params-aware natively (no ``_adapt_zero_arg``).
 # Both discard params: ``mf_directory_sync`` never honoured any, and

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -65,6 +65,7 @@ Lane = Literal[
     "sec_rate",
     "sec_manifest",
     "sec_per_cik",
+    "sec_expected_filings",
     "sec_filing_docs",
     "sec_insider_backfill",
     "sec_insider_ingest",
@@ -132,6 +133,15 @@ the rate — it does not.
   ``sec.last_modified.per_cik_poll`` namespace) have no other lane writer.
   Scheduled-only, so NOT added to the ``bootstrap_stages.lane`` CHECK (like
   ``sec_manifest`` / ``db_liveness`` / ``db_retry``).
+* ``sec_expected_filings`` — ``expected_filings_poller`` only (#1788). The 15-min
+  targeted submissions.json poll for instruments in an expected 10-Q/10-K window.
+  Own lane so its high cadence can't lose the JobLock race to the hourly
+  ``sec_per_cik_poll`` / manifest worker. Its only shared write target is
+  ``sec_filing_manifest`` via ``record_manifest_entry`` (idempotent ``ON CONFLICT``
+  upsert keyed by accession — already written concurrently from other lanes since
+  #1478, proven-safe). Scheduled-only, so NOT added to the ``bootstrap_stages.lane``
+  CHECK. (The companion ``expected_filings_seed`` runs on the existing
+  ``db_fundamentals_raw`` lane — DB-only, no SEC HTTP.)
 * ``sec_filing_docs`` — ``sec_filing_documents_ingest`` only (#1540). The
   hourly @ :35 producer holds the lane ~96s per tick (it expands every filing's
   ``{accession}-index.json`` into ``filing_documents`` rows). On the shared

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -355,6 +355,12 @@ JOB_FINANCIAL_FACTS_RETENTION_SWEEP = "financial_facts_retention_sweep"
 # #1564 — daily pg_database_size snapshot into pg_size_sample, read by the
 # postgres-health db_size_growth_7d trend signal. Own ``db_size_sample`` lane.
 JOB_PG_SIZE_SAMPLE = "pg_size_sample"
+# #1788 (#677 Part B) — event-driven fundamentals catch-up. The seed derives
+# the next expected 10-Q/10-K window per high-value instrument; the poller
+# force-refreshes fundamentals the moment that filing appears (own
+# ``sec_expected_filings`` lane).
+JOB_EXPECTED_FILINGS_SEED = "expected_filings_seed"
+JOB_EXPECTED_FILINGS_POLLER = "expected_filings_poller"
 # #1013 — one-shot retroactive cleanup of skip-tier filing_events rows.
 # Manual-trigger-only (NOT in SCHEDULED_JOBS): a one-shot delete must
 # never auto-fire. Source-lock binding in MANUAL_TRIGGER_JOB_SOURCES,
@@ -1132,6 +1138,48 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # completes — harmless, the DB is tiny then and there is no trend to
         # track yet.
         catch_up_on_boot=True,
+    ),
+    ScheduledJob(
+        name=JOB_EXPECTED_FILINGS_SEED,
+        display_name="Expected-filings seed",
+        # #1788 — derive the next-expected 10-Q/10-K window per high-value
+        # instrument (watchlist + open positions) from financial_periods.
+        # Reads financial_periods + sec_filing_manifest only (no SEC HTTP) →
+        # the fundamentals-raw DB lane. Daily refresh because scope membership
+        # (watchlist/positions) is operator-mutable and rolls forward as new
+        # filings land. catch_up_on_boot so a bootstrapped install self-seeds
+        # within one cycle of bootstrap completion (prevention:
+        # backfills-belong-in-bootstrap — the surface ships seeded, not
+        # per-tick only).
+        source="db_fundamentals_raw",
+        description=(
+            "#1788 (#677 Part B) — upsert the next expected periodic filing "
+            "(10-Q/10-K) per high-value instrument, period-end anchored from "
+            "financial_periods. Conditional re-seed on anchor advance; feeds "
+            "the expected_filings_poller."
+        ),
+        cadence=Cadence.daily(hour=6, minute=0),
+        catch_up_on_boot=True,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_EXPECTED_FILINGS_POLLER,
+        display_name="Expected-filings poller",
+        # #1788 — own lane so the 15-min cadence can't lose the JobLock race
+        # to the hourly sec_per_cik poll / manifest worker. The shared 10 req/s
+        # SEC HTTP floor is enforced process-wide in sec_edgar regardless of
+        # lane; this lane only serialises job overlap.
+        source="sec_expected_filings",
+        description=(
+            "#1788 (#677 Part B) — 15-min targeted submissions.json poll for "
+            "instruments in an expected 10-Q/10-K window; on a strictly-newer, "
+            "exact-form, non-amendment accession records the manifest row and "
+            "force-refreshes fundamentals (Part A run_force_refresh). "
+            "Budget-bounded (max 100 subjects/run, most-stale-first)."
+        ),
+        cadence=Cadence.every_n_minutes(interval=15),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
     ),
     ScheduledJob(
         name=JOB_ORPHAN_TEST_DB_REAP,
@@ -6205,6 +6253,53 @@ def sec_per_cik_poll() -> None:
             stats.poll_errors,
             stats.recheck_subjects_polled,
             stats.recheck_new_filings_recorded,
+        )
+
+
+def expected_filings_seed() -> None:
+    """``_INVOKERS['expected_filings_seed']`` — #1788 daily seed.
+
+    Derives the next expected 10-Q/10-K window per high-value instrument
+    (watchlist + open positions) from financial_periods and upserts
+    expected_filings. Reads only the DB (no SEC HTTP)."""
+    from app.jobs.expected_filings_poller import seed_expected_filings
+
+    with _tracked_job(JOB_EXPECTED_FILINGS_SEED) as tracker:
+        with connect_job() as conn:
+            stats = seed_expected_filings(conn)
+        tracker.row_count = stats.rows_upserted
+        logger.info(
+            "expected_filings_seed: scoped=%d upserted=%d",
+            stats.instruments_scoped,
+            stats.rows_upserted,
+        )
+
+
+def expected_filings_poller() -> None:
+    """``_INVOKERS['expected_filings_poller']`` — #1788 15-min targeted poll.
+
+    Polls submissions.json for instruments in an expected filing window;
+    on a strictly-newer exact-form non-amendment accession records the
+    manifest row + force-refreshes fundamentals (Part A)."""
+    from app.jobs.expected_filings_poller import run_expected_filings_poller
+
+    with _tracked_job(JOB_EXPECTED_FILINGS_POLLER) as tracker:
+        with (
+            SecFilingsProvider(user_agent=settings.sec_user_agent) as sec,
+            connect_job() as conn,
+        ):
+            stats = run_expected_filings_poller(
+                conn,
+                http_get=_make_sec_http_get(sec),  # type: ignore[arg-type]
+                now=datetime.now(UTC),
+                user_agent=settings.sec_user_agent,
+            )
+        tracker.row_count = stats.fulfilled
+        logger.info(
+            "expected_filings_poller: subjects=%d fulfilled=%d errors=%d",
+            stats.subjects_polled,
+            stats.fulfilled,
+            stats.poll_errors,
         )
 
 

--- a/docs/specs/etl/2026-06-28-expected-filings-poller.md
+++ b/docs/specs/etl/2026-06-28-expected-filings-poller.md
@@ -1,0 +1,239 @@
+# Expected-filings poller — event-driven fundamentals catch-up (#1788 / #677 Part B)
+
+## Problem
+
+`daily_financial_facts` already polls SEC `submissions.json` (via `plan_refresh`,
+`app/services/fundamentals/__init__.py:2027`) and refreshes companyfacts +
+`financial_periods` when a new filing lands — but it runs **once a day over the full
+covered universe**. A 10-Q that posts at 09:00 is not reflected on the instrument page
+until the next daily run (≤ ~24 h later).
+
+Part A (#1787) shipped the targeted `run_force_refresh(conn, symbols)` core. Part B adds
+a **small, budget-bounded, high-frequency watchlist** so the operator's high-attention
+instruments (held + watchlisted) get force-refreshed within minutes of an expected
+10-Q/10-K appearing — without re-polling the whole universe at that cadence.
+
+## Premise check (falsified → refined)
+
+The handoff framed this as "event-driven catch-up is missing." **Not true** —
+`plan_refresh` is already event-driven (master-index lookback → per-CIK submissions →
+seeds/refreshes). The real gap is **latency**, not capability. So Part B is a *latency
+optimisation for a small high-value subset*, NOT a second filing-detection implementation,
+and it reuses the Part A fetch path (`run_force_refresh`).
+
+**Strictly additive / never-worse-than-status-quo.** The daily `daily_financial_facts`
+remains the universal backstop. A mis-sized window or a filing missed past
+`expected_window_end` simply falls back to the ≤24 h daily path. The poller acts **only**
+on a strictly-newer, exact-form, non-amendment accession (baseline-watermarked), so it
+can never false-fulfil or write wrong data.
+
+## Source rule (SEC)
+
+- **Reports exist & cadence:** periodic reports are mandated by **Exchange Act Rule 13a-1**
+  (annual 10-K) and **Rule 13a-13** (quarterly 10-Q). A domestic issuer files **three**
+  10-Qs (fiscal Q1/Q2/Q3) and **one** 10-K per fiscal year — there is **no Q4 10-Q**; the
+  fourth period is reported on the 10-K.
+- **Deadlines run from FISCAL PERIOD-END, not from the prior filing date** (Form 10-K
+  Gen. Instr. A.(2): 60/75/90 days after FY-end for large-accelerated/accelerated/non-
+  accelerated; Form 10-Q Gen. Instr. A.(1): 40/45 days after quarter-end). Filer category
+  is not reliably known → use the **widest** deadline as the window ceiling.
+- **WHEN-to-poll is an operational schedule, not a data-treatment decision.** The window
+  governs only *when we look*; it never classifies/aggregates/dedups any value. Padding
+  below is conservative ops tuning; correctness is enforced by exact-form +
+  non-amendment + baseline-accession matching, not by the window.
+
+## Seed model (period-end anchored — fixes the Q3→Q1 gap)
+
+For each in-scope instrument, read its **latest** `financial_periods` row
+(`MAX(period_end_date)` → `period_type`). Map the **next** fiscal period to a form using
+the 3-10-Qs-then-10-K structure, and anchor the poll window on the next period-end:
+
+```
+latest period_type   next period   expected form   next_period_end ≈
+  Q1, Q2               Q2/Q3          10-Q            latest_period_end + 91d
+  Q3                   Q4/FY          10-K            latest_period_end + 91d
+  Q4, FY               Q1             10-Q            latest_period_end + 91d
+  (unknown/sparse)     —              10-Q (default)  latest_period_end + 91d
+
+10-Q window = [next_period_end + 30, next_period_end + 55]   (deadline 40-45d ± slack)
+10-K window = [next_period_end + 50, next_period_end + 100]  (deadline 60-90d ± slack)
+```
+
+This is period-end-grounded (the documented rule), and the fiscal-position → form map
+removes the false-quarterly-cadence bug (a Q3 issuer's next filing is a 10-K, not a phantom
+10-Q ~91 d after the Q3 10-Q). Window start is offset to the earliest realistic filing date
+so we don't burn polls during the pre-deadline dead zone; an early filer caught a few days
+late just falls to the daily backstop.
+
+The seed records `anchor_period_end = latest_period_end` (the cycle key — see Schema).
+Reads only **non-superseded** `financial_periods` (`superseded_at IS NULL`) so a restated
+later-dated row can't anchor the wrong window. An instrument with **no manifest baseline**
+of the expected form is **skipped** (a null `last_known_filing_id` would make every recent
+filing read as "new" → false-fulfil on the existing last filing). The full-scope daily
+re-seed (`only_symbol=None`) also **prunes** rows for instruments that have left the
+high-value set (un-watchlisted / position closed); the `--symbol` path is additive and
+never prunes.
+
+**Baseline accession:** the seed also records the accession of the instrument's latest
+**non-amendment** filing of that form from `sec_filing_manifest`
+(`MAX(filed_at) WHERE source IN ('sec_10k'|'sec_10q') AND NOT is_amendment`). Stored as
+`baseline_accession` and passed to detection as `last_known_filing_id` so only a
+**strictly-newer** accession counts as the expected filing (without it, the existing last
+filing reads as "new" and instantly false-fulfils — `sec_submissions.check_freshness`).
+
+## Scope (small high-value set — makes the latency claim true)
+
+Seed only `instrument_id ∈ (watchlist ∪ positions WHERE current_units > 0)` that also have
+≥1 `financial_periods` row. Full-pop on dev (2026-06-28): combined scope = **4** instruments
+(watchlist empty + a few positions) → ≤ 8 seed rows; nowhere near the 8.3k full universe.
+Empty-when-no-watchlist is **correct**, not a gap — there is nothing to fast-track and the
+daily path covers everything. The operator CLI `--symbol` force-seeds an ad-hoc instrument
+(used for dev verification, e.g. AAPL). Extending scope to ranking top-N is a noted
+follow-up.
+
+## Schema — `sql/207_expected_filings.sql`
+
+**One row per instrument** = its single *next* expected filing (a domestic issuer has
+exactly one next periodic filing at a time — Q-next or the FY 10-K). `UNIQUE (instrument_id)`,
+not per-form: the seed derives THE next filing, so a per-form key would leave the other
+form's row permanently stale/fulfilled (Codex ckpt-1 round 2). `expected_filing_type` is an
+attribute that flips '10-Q'↔'10-K' across the year. Plus `baseline_accession` (correctness
+watermark) and `anchor_period_end` (cycle key — the latest reported `period_end_date` the
+derivation used).
+
+```sql
+CREATE TABLE IF NOT EXISTS expected_filings (
+    id                    BIGSERIAL PRIMARY KEY,
+    instrument_id         INT  NOT NULL UNIQUE REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    expected_filing_type  TEXT NOT NULL,            -- '10-Q' | '10-K' (flips across the year)
+    anchor_period_end     DATE NOT NULL,            -- latest financial_periods.period_end_date used to derive
+    expected_window_start DATE NOT NULL,
+    expected_window_end   DATE NOT NULL,
+    poll_interval_minutes INT  NOT NULL DEFAULT 30,
+    baseline_accession    TEXT,                     -- last known non-amendment accession of expected form
+    last_polled_at        TIMESTAMPTZ,
+    fulfilled_at          TIMESTAMPTZ,
+    fulfilled_accession   TEXT,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_expected_filings_due
+    ON expected_filings (expected_window_end, last_polled_at)
+    WHERE fulfilled_at IS NULL;
+```
+
+(New table name → no prior shape; the prevention-log "pair CREATE with ALTER ADD COLUMN
+IF NOT EXISTS" self-review resolves clean. `DEFAULT 30` aligns the per-row interval with
+the 15-min scheduler cadence — no hourly-vs-15-min mismatch.)
+
+**Conditional re-seed (cycle key = `anchor_period_end`, no fulfilment churn):**
+
+```sql
+INSERT INTO expected_filings (instrument_id, expected_filing_type, anchor_period_end,
+    expected_window_start, expected_window_end, poll_interval_minutes, baseline_accession)
+VALUES (...)
+ON CONFLICT (instrument_id) DO UPDATE
+SET expected_filing_type = EXCLUDED.expected_filing_type,
+    anchor_period_end     = EXCLUDED.anchor_period_end,
+    expected_window_start = EXCLUDED.expected_window_start,
+    expected_window_end   = EXCLUDED.expected_window_end,
+    baseline_accession    = EXCLUDED.baseline_accession,
+    last_polled_at = NULL, fulfilled_at = NULL, fulfilled_accession = NULL
+WHERE expected_filings.anchor_period_end IS DISTINCT FROM EXCLUDED.anchor_period_end;
+```
+
+A no-change re-seed (latest reported period unchanged) is a **no-op** — a fulfilled row
+stays fulfilled. The loop closes: poller detects the new filing → writes
+`sec_filing_manifest` + `run_force_refresh` re-normalizes `financial_periods` → a new
+`period_end_date` appears → the *next* daily seed derives the subsequent filing (form flips,
+`anchor_period_end` advances) → upsert rolls the row forward and resets for the next cycle.
+If companyfacts (XBRL) lags the filing and the new `financial_period` hasn't landed yet, the
+row stays fulfilled until the daily `daily_financial_facts` backstop normalizes it and the
+anchor advances — never-worse-than-status-quo.
+
+## Poller — `app/jobs/expected_filings_poller.py`
+
+`run_expected_filings_poller(conn, *, http_get, now, max_subjects=100) -> PollStats`
+
+1. Select due rows: `fulfilled_at IS NULL AND now::date BETWEEN expected_window_start AND
+   expected_window_end AND (last_polled_at IS NULL OR last_polled_at < now -
+   poll_interval_minutes)`, joined to the primary `sec.cik` external id, ordered
+   `last_polled_at NULLS FIRST` (most-stale first), `LIMIT max_subjects`.
+2. Commit the read tx before HTTP work (Part A commit discipline).
+3. Per row: `check_freshness(http_get, cik=cik, last_known_filing_id=baseline_accession,
+   sources={expected_source})` (`app/providers/implementations/sec_submissions.py`). The
+   `sources` filter pre-narrows; the load-bearing match is on the returned
+   `FilingIndexRow`: **`row.form == expected_filing_type AND not row.is_amendment`**
+   (exact form string — excludes `10-Q/A`/`10-K/A` mapping to the same `source`).
+4. On a match: `record_manifest_entry(conn, accession, cik=, form=, source=,
+   subject_type='issuer', subject_id=str(instrument_id), instrument_id=, filed_at=,
+   is_amendment=False)` (idempotent — `app/services/sec_manifest.py:226`), then
+   `run_force_refresh(conn, [symbol])`, then `UPDATE expected_filings SET fulfilled_at=now,
+   fulfilled_accession=accession, last_polled_at=now`. Commit.
+5. No match / empty: `UPDATE … SET last_polled_at = now`. A probe **exception** also bumps
+   `last_polled_at` (then `continue`) so a bad CIK / network failure respects
+   `poll_interval_minutes` instead of staying most-stale and re-firing every tick (which
+   would starve healthy due rows under the subject cap).
+
+Unconditional `check_freshness` (not `_conditional`) in v1 — the scope is small so the
+If-Modified-Since 304 path is negligible budget and adding it would reintroduce the
+date-window-wedge surface (prevention-log: holiday/304 wedge). Listed as a deferred perf
+optimisation. The 10 req/s SEC HTTP floor is enforced process-wide in `sec_edgar`
+regardless of lane; the poller adds its own lane `sec_expected_filings` for job-overlap
+serialisation.
+
+## Scheduler + seed wiring — `app/workers/scheduler.py`
+
+```python
+JOB_EXPECTED_FILINGS_POLLER = "expected_filings_poller"
+JOB_EXPECTED_FILINGS_SEED   = "expected_filings_seed"
+
+ScheduledJob(name=JOB_EXPECTED_FILINGS_POLLER, display_name="Expected-filings poller",
+    source="sec_expected_filings", cadence=Cadence.every_n_minutes(interval=15),
+    catch_up_on_boot=False, prerequisite=_bootstrap_complete, description="#1788 — ...")
+
+ScheduledJob(name=JOB_EXPECTED_FILINGS_SEED, display_name="Expected-filings seed",
+    source="db_fundamentals_raw", cadence=Cadence.daily(hour=6, minute=0),
+    catch_up_on_boot=True, prerequisite=_bootstrap_complete, description="#1788 — ...")
+```
+
+Body mirrors `sec_per_cik_poll` (`scheduler.py:6175`): `_tracked_job` + `connect_job` +
+`SecFilingsProvider` + `_make_sec_http_get(sec)` for the poller; the seed reads only
+`financial_periods` + `sec_filing_manifest` (no SEC HTTP).
+
+**Bootstrap posture:** the seed is a daily steady-state job with `catch_up_on_boot=True`
++ `prerequisite=_bootstrap_complete`, so it self-populates within one cycle of bootstrap
+completion (scope membership — watchlist/positions — is operator-mutable and changes daily,
+so a daily refresh is the correct shape; a heavier bootstrap-DAG stage with capability
+wiring is unnecessary and deferred). New lane → add `sec_expected_filings` to the `Lane`
+literal in `app/jobs/sources.py`; register both invokers in `app/jobs/runtime.py::_INVOKERS`.
+
+## Seed CLI — `scripts/seed_expected_filings.py`
+
+Wraps `seed_expected_filings(conn, *, now, only_symbol=None) -> int`. `--dry-run` prints the
+derived (instrument, form, window, baseline) rows; `--symbol SYM` force-seeds one
+instrument regardless of watchlist/position membership (dev verification + ad-hoc operator
+declaration → satisfies the #677 "operator UI/CLI to declare expected filings"). Richer
+admin FE CRUD deferred to a follow-up ticket.
+
+## Tests
+
+- Pure-logic (no DB): `next_form_and_window(latest_period_type, latest_period_end)` —
+  table-test the Q1/Q2→10-Q, **Q3→10-K**, Q4/FY→10-Q map and the window offsets.
+- Pure-logic: `match_filing(delta, expected_type)` — matching exact form + non-amendment
+  fulfils; `10-Q/A`, wrong form, empty, baseline-equal do **not**.
+- One DB test: migration applies; seed upsert idempotency (re-seed same baseline = no-op,
+  fulfilled survives; new baseline = window rolls + reset); due-row selection respects
+  window + `poll_interval_minutes`.
+
+## Dev-DB verification (DoD clauses 8-12)
+
+`scripts/seed_expected_filings.py --symbol AAPL` → inspect the row (form/window/baseline);
+run the poller once via the job invoker; confirm no false-fulfil (AAPL's last 10-Q is the
+baseline, so an unchanged poll leaves `fulfilled_at` NULL and bumps `last_polled_at`).
+Record figures in the PR.
+
+## Out of scope (follow-up ticket)
+
+Admin FE CRUD for expected_filings; per-instrument operator window override; ranking-top-N
+scope; 8-K-dividend / other event forms (this PR is 10-Q/10-K only); If-Modified-Since 304
+perf path.

--- a/scripts/seed_expected_filings.py
+++ b/scripts/seed_expected_filings.py
@@ -1,0 +1,82 @@
+"""Seed the expected-filings watchlist (#1788 / #677 Part B) — CLI wrapper.
+
+Derives the next expected periodic filing (10-Q / 10-K) per high-value
+instrument (watchlist + open positions) from ``financial_periods`` and
+upserts ``expected_filings``. The ``expected_filings_poller`` then
+force-refreshes fundamentals the moment that filing appears.
+
+Run from the repo root via the module form so ``app`` imports resolve:
+
+    uv run python -m scripts.seed_expected_filings --dry-run
+    uv run python -m scripts.seed_expected_filings --symbol AAPL
+
+``--dry-run`` prints the derived rows without writing. ``--symbol SYM``
+force-seeds one instrument regardless of watchlist/position membership
+(operator ad-hoc declaration + dev verification). With neither flag, the
+full high-value scope is upserted.
+
+The derive -> upsert core lives in ``app.jobs.expected_filings_poller`` so
+the CLI, the daily seed job, and the tests share one implementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+import psycopg
+
+from app.config import settings
+from app.jobs.expected_filings_poller import derive_seed_rows, seed_expected_filings
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--symbol",
+        default=None,
+        help="Force-seed a single symbol (e.g. AAPL), bypassing watchlist/position scope.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the derived (instrument, form, window, baseline) rows without writing.",
+    )
+    args = parser.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        if args.dry_run:
+            rows = derive_seed_rows(conn, only_symbol=args.symbol)
+            conn.commit()
+            if not rows:
+                logger.info("seed_expected_filings: scope is empty — nothing to seed")
+                return 0
+            for r in rows:
+                logger.info(
+                    "instrument_id=%d %s window=[%s..%s] anchor=%s baseline=%s",
+                    r.instrument_id,
+                    r.expected_filing_type,
+                    r.expected_window_start,
+                    r.expected_window_end,
+                    r.anchor_period_end,
+                    r.baseline_accession,
+                )
+            logger.info("seed_expected_filings: DRY-RUN — %d row(s); omit --dry-run to write", len(rows))
+            return 0
+
+        stats = seed_expected_filings(conn, only_symbol=args.symbol)
+
+    logger.info(
+        "seed_expected_filings: scoped=%d upserted=%d",
+        stats.instruments_scoped,
+        stats.rows_upserted,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sql/207_expected_filings.sql
+++ b/sql/207_expected_filings.sql
@@ -1,0 +1,59 @@
+-- #1788 (#677 Part B) — expected-filings watchlist for event-driven
+-- fundamentals catch-up. One row per instrument = its single *next*
+-- expected periodic filing (10-Q or 10-K); the expected_filings_poller
+-- force-refreshes fundamentals the moment that filing appears, ahead of
+-- the once-a-day daily_financial_facts backstop.
+--
+-- Source rule (SEC): periodic reports are mandated by Exchange Act
+-- Rule 13a-1 (annual 10-K) + Rule 13a-13 (quarterly 10-Q); a domestic
+-- issuer files three 10-Qs (fiscal Q1/Q2/Q3) and one 10-K per year — no
+-- Q4 10-Q. Statutory deadlines run from FISCAL PERIOD-END (Form 10-K
+-- Gen. Instr. A.(2): 60/75/90d; Form 10-Q Gen. Instr. A.(1): 40/45d).
+-- The seed derives form + window from financial_periods (period-end
+-- anchored), never from prior-filing-date arithmetic. WHEN-to-poll is an
+-- operational schedule, not a data-treatment decision — correctness is
+-- enforced by exact-form + non-amendment + baseline-accession matching
+-- in the poller, not by the window.
+--
+-- See docs/specs/etl/2026-06-28-expected-filings-poller.md.
+--
+-- New table name → no prior shape exists, so the prevention-log
+-- "pair CREATE with ALTER ADD COLUMN IF NOT EXISTS" self-review resolves
+-- clean (there is no earlier expected_filings to reconcile against).
+CREATE TABLE IF NOT EXISTS expected_filings (
+    id                    BIGSERIAL PRIMARY KEY,
+    instrument_id         INT  NOT NULL UNIQUE
+                              REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    -- Expected form for the *next* filing; flips '10-Q'<->'10-K' across
+    -- the fiscal year as the latest reported period advances.
+    expected_filing_type  TEXT NOT NULL CHECK (expected_filing_type IN ('10-Q', '10-K')),
+    -- Cycle key: the latest financial_periods.period_end_date the seed
+    -- used to derive this expectation. The conditional re-seed rolls the
+    -- row forward (and resets fulfilment) only when this advances.
+    anchor_period_end     DATE NOT NULL,
+    expected_window_start DATE NOT NULL,
+    expected_window_end   DATE NOT NULL,
+    poll_interval_minutes INT  NOT NULL DEFAULT 30 CHECK (poll_interval_minutes > 0),
+    -- Last known non-amendment accession of the expected form; passed to
+    -- check_freshness as last_known_filing_id so only a strictly-newer
+    -- accession counts as the expected filing (no false-fulfil on the
+    -- existing last filing).
+    baseline_accession    TEXT,
+    last_polled_at        TIMESTAMPTZ,
+    fulfilled_at          TIMESTAMPTZ,
+    fulfilled_accession   TEXT,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CHECK (expected_window_end >= expected_window_start)
+);
+
+-- Hot path: the poller selects unfulfilled rows whose window is open and
+-- whose poll interval has elapsed, most-stale first.
+CREATE INDEX IF NOT EXISTS idx_expected_filings_due
+    ON expected_filings (expected_window_end, last_polled_at)
+    WHERE fulfilled_at IS NULL;
+
+COMMENT ON TABLE expected_filings IS
+    '#1788 — per-instrument next-expected periodic filing (10-Q/10-K). '
+    'Seeded from financial_periods (period-end anchored) for the operator '
+    'high-value set (watchlist + open positions); the expected_filings_poller '
+    'force-refreshes fundamentals on the matching filing ahead of the daily path.';

--- a/tests/test_expected_filings_poller.py
+++ b/tests/test_expected_filings_poller.py
@@ -1,0 +1,99 @@
+"""Pure-logic tests for the expected-filings seed/poller (#1788).
+
+No DB: the form/window derivation and the filing-match decision are the
+risk-bearing logic and extract cleanly to pure functions. End-to-end seed
++ poll semantics (conditional re-seed, manifest write, force-refresh) are
+verified live on the dev DB per the PR's DoD clauses 8-12.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from app.jobs.expected_filings_poller import match_filing, next_form_and_window
+from app.providers.implementations.sec_submissions import FilingIndexRow
+
+
+def _row(form: str, *, is_amendment: bool = False, source: str | None = "sec_10q") -> FilingIndexRow:
+    return FilingIndexRow(
+        accession_number="0000320193-26-000001",
+        cik="0000320193",
+        form=form,
+        source=source,  # type: ignore[arg-type]
+        filed_at=datetime(2026, 8, 1, tzinfo=UTC),
+        accepted_at=None,
+        primary_document_url=None,
+        is_amendment=is_amendment,
+    )
+
+
+# --- next_form_and_window -------------------------------------------------
+
+
+def test_q1_q2_predict_next_10q():
+    # latest period-end 2026-03-31 → predicted next period-end +91d = 2026-06-30;
+    # 10-Q window = [+30, +55] off that = [2026-07-30, 2026-08-24].
+    for ptype in ("Q1", "Q2"):
+        form, start, end = next_form_and_window(ptype, date(2026, 3, 31))
+        assert form == "10-Q"
+        assert start == date(2026, 7, 30)
+        assert end == date(2026, 8, 24)
+
+
+def test_q3_predicts_10k_not_phantom_10q():
+    # The Q3→Q1 gap bug: a Q3 issuer's next filing is the FY 10-K, not a
+    # 10-Q ~91d after the Q3 10-Q.
+    form, start, end = next_form_and_window("Q3", date(2026, 9, 30))
+    assert form == "10-K"
+    # 10-K window is the wider [+50, +100] band off the predicted FY-end.
+    assert (end - start).days == 50
+
+
+def test_fy_and_q4_predict_next_10q():
+    for ptype in ("FY", "Q4"):
+        form, _start, _end = next_form_and_window(ptype, date(2025, 12, 31))
+        assert form == "10-Q"
+
+
+def test_unknown_period_type_defaults_to_10q():
+    form, _start, _end = next_form_and_window("STUB", date(2026, 3, 31))
+    assert form == "10-Q"
+
+
+def test_10q_window_offsets_are_30_to_55_off_predicted_period_end():
+    _form, start, end = next_form_and_window("Q1", date(2026, 3, 31))
+    # offsets are measured from the predicted next period-end (latest + 91d),
+    # so from the latest period-end they land at +121 and +146.
+    assert (start - date(2026, 3, 31)).days == 91 + 30
+    assert (end - date(2026, 3, 31)).days == 91 + 55
+
+
+# --- match_filing ---------------------------------------------------------
+
+
+def test_exact_form_non_amendment_matches():
+    match = match_filing([_row("10-Q")], "10-Q")
+    assert match is not None
+    assert match.form == "10-Q"
+
+
+def test_amendment_does_not_match():
+    # 10-Q/A maps to the same manifest source but must NOT fulfil an
+    # expected original 10-Q.
+    assert match_filing([_row("10-Q/A", is_amendment=True)], "10-Q") is None
+    assert match_filing([_row("10-Q", is_amendment=True)], "10-Q") is None
+
+
+def test_wrong_form_does_not_match():
+    assert match_filing([_row("8-K", source="sec_8k")], "10-Q") is None
+    assert match_filing([_row("10-K", source="sec_10k")], "10-Q") is None
+
+
+def test_empty_delta_no_match():
+    assert match_filing([], "10-Q") is None
+
+
+def test_returns_first_matching_when_mixed():
+    rows = [_row("10-Q/A", is_amendment=True), _row("8-K", source="sec_8k"), _row("10-Q")]
+    match = match_filing(rows, "10-Q")
+    assert match is not None and match.form == "10-Q" and not match.is_amendment

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -51,6 +51,10 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # watchdog kick hit the same lock and no-opped). Same shape as the
         # #1478 sec_manifest split. See app/jobs/sources.py::Lane.
         "sec_per_cik",
+        # #1788 — expected_filings_poller (15-min targeted submissions poll)
+        # own lane so its high cadence can't lose the JobLock race to the
+        # hourly per-CIK poll. See app/jobs/sources.py::Lane.
+        "sec_expected_filings",
         # #1540 — sec_filing_documents_ingest (@:35, ~96s/tick sole writer of
         # filing_documents) + sec_insider_transactions_backfill (@:45 tail
         # drainer) extracted from sec_rate into their own single-job lanes.


### PR DESCRIPTION
Closes #1788. Closes #677.

## What

A small, budget-bounded, high-frequency watchlist that force-refreshes fundamentals the moment an expected 10-Q/10-K appears, ahead of the once-a-day `daily_financial_facts` backstop. Part B of #677 (Part A — the `run_force_refresh` core — shipped in #1787).

- **`sql/207_expected_filings.sql`** — new table. **One row per instrument** = its single *next* expected periodic filing. `UNIQUE(instrument_id)`; `anchor_period_end` cycle key; `baseline_accession` correctness watermark; partial index for the poller's hot query.
- **`app/jobs/expected_filings_poller.py`** — period-end-anchored seed + budget-bounded poller (pure helpers `next_form_and_window`, `match_filing`).
- **`app/workers/scheduler.py`** — `expected_filings_seed` (daily, `catch_up_on_boot`) + `expected_filings_poller` (every 15 min) + own `sec_expected_filings` lane.
- **`scripts/seed_expected_filings.py`** — operator CLI (`--dry-run` / `--symbol`).

## Why (premise falsified → refined)

The handoff framed event-driven catch-up as *missing*. It isn't — `daily_financial_facts` → `plan_refresh` already polls submissions.json daily and refreshes companyfacts on new filings. The real gap is **latency** (≤24 h). So this is a *latency optimisation for a small high-value subset*, **strictly additive**: a missed window falls back to the daily path; the poller acts only on a strictly-newer, exact-form, non-amendment, baseline-watermarked accession — it can never false-fulfil or write wrong data.

## Source rule (SEC)

Periodic reports mandated by **Exchange Act Rule 13a-1** (10-K) / **Rule 13a-13** (10-Q); a domestic issuer files three 10-Qs (Q1/Q2/Q3) + one 10-K — **no Q4 10-Q**. Deadlines run from **fiscal period-end** (Form 10-K/10-Q Gen. Instr. A: 60/75/90d, 40/45d). The seed derives form by fiscal position (latest **Q3 → next 10-K**, not a phantom 10-Q) and anchors the window on the predicted next period-end + statutory deadline. WHEN-to-poll is operational, not a data-treatment decision — correctness is enforced by exact-form + non-amendment + baseline matching, not the window. Spec: `docs/specs/etl/2026-06-28-expected-filings-poller.md`.

## Seed model & scope

Scope = `watchlist ∪ positions(current_units>0)` with ≥1 non-superseded `financial_periods` row **and** a manifest baseline of the expected form (instruments without a baseline are skipped — a null watermark would false-fulfil on the existing last filing). Full-scope daily re-seed prunes rows for instruments that have left the set. Conditional upsert rolls a row forward + resets fulfilment **only** when `anchor_period_end` advances (no fulfilment churn); the loop closes because the poller writes the discovered filing to `sec_filing_manifest`, so the next seed observes the advanced period.

## Security / safety model

- Read-only against SEC + DB-write only via reviewed paths: `record_manifest_entry` (idempotent `ON CONFLICT`) and Part A's `run_force_refresh` (companyfacts re-fetch + `financial_periods` normalize — the same data treatment as the daily path, settled "Fundamentals provider posture" #532, SEC-XBRL-only). **No order/trade path touched.**
- All SQL parameterised. Shared 10 req/s SEC HTTP floor enforced process-wide in `sec_edgar` regardless of lane; the own `sec_expected_filings` lane only serialises job overlap.
- Budget-bounded: `max_subjects=100`/run, most-stale-first; probe failures bump `last_polled_at` so a bad CIK can't starve healthy rows.

## Review checkpoints

- **Codex ckpt-1** (spec): killed the naive filed-date+91d 10-Q model (Q3→Q1 gap), source-matching amendments, missing baseline watermark, missing manifest write on detection, and per-form vs single-next-filing schema inconsistency — all redesigned before coding.
- **Codex ckpt-2** (branch): 4 findings fixed before push — null-baseline false-fulfil (skip), out-of-scope rows not pruned (prune), missing `superseded_at IS NULL` (added), probe-error not bumping `last_polled_at` (added).

## Verification (DoD clauses 8-12) — at commit `0f49e4a5`

- **Migration applied on dev** via smoke lifespan; `expected_filings` present with all 12 columns.
- **Seed exercised on dev panel:** full-scope seed wrote 3 real position rows — `BBBY` 10-Q (anchor 2026-03-31, window 2026-07-30..08-24, baseline `0001130713-26-000038`), `GME` 10-Q (anchor 2026-05-02, window 2026-08-31..09-25, baseline `0001326380-26-000025`), `IEP` 10-Q (anchor 2026-03-31, window 2026-07-30..08-24). `--dry-run --symbol AAPL` → 10-Q, anchor 2026-03-28, window 2026-07-27..08-21, baseline `0000320193-26-000013` (cross-checks AAPL's real last 10-Q).
- **Poller exercised on live SEC** (forced AAPL in-window): `subjects_polled=1, fulfilled=0, poll_errors=0`; `last_polled_at` bumped, `fulfilled_at` stayed NULL — **no false-fulfil** with baseline = current last 10-Q. Test row cleaned up.
- Gates: `ruff check .`, `ruff format --check .`, `pyright` (0 errors), fast tier (4639 passed), smoke (129 passed), 10 new pure-logic tests.

## Tradeoffs / out of scope (follow-up)

- 10-Q/10-K only (highest-value fundamentals trigger). 8-K-dividend / other forms deferred.
- Operator CRUD is CLI (`--symbol`); richer admin FE deferred. Ranking-top-N scope extension deferred. If-Modified-Since 304 perf path deferred (small scope → negligible budget; avoids the date-window-wedge surface).
- DB-tier integration test omitted per repo policy (pure-logic + dev-verify); the `ebull_test_template` needs a rebuild to pick up migration 207 before any future db-marked test on this table runs (operator step, non-blocking — db tier is off the push path).

## Operator follow-up

After merge: restart the jobs daemon onto new main (new scheduled jobs + lane). No `sec_rebuild` needed (no parser-output change). The seed self-populates on the next daily cycle / boot catch-up.