### PR TITLE
feat(#1344): pre-bootstrap OPENFIGI_API_KEY nudge

### DIFF
--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -30,6 +30,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
 
 from app.api.auth import require_session_or_service_token
+from app.config import settings
 from app.db import get_conn
 from app.services.bootstrap_orchestrator import (
     JOB_BOOTSTRAP_ORCHESTRATOR,
@@ -141,6 +142,14 @@ class BootstrapStatusResponse(BaseModel):
     last_completed_at: datetime | None
     stages: list[BootstrapStageResponse]
     bulk_manifest: BulkManifestResponse | None = None
+    # #1344 — whether ``OPENFIGI_API_KEY`` is configured (presence only,
+    # never the value — ADR 0001 "the UI sees metadata only"). The CUSIP
+    # resolver (S13 ``cusip_resolver_post_bulk_sweep``) runs ~10× faster
+    # wall-clock with a key (app/config.py). The frontend surfaces a
+    # pre-bootstrap nudge when this is False and bootstrap has not yet
+    # completed S13. Reflects the key as of API process start —
+    # ``settings`` is process-global and not hot-reloaded.
+    openfigi_key_present: bool = False
 
 
 class BootstrapRunQueuedResponse(BaseModel):
@@ -265,6 +274,7 @@ def _build_status_response(conn: psycopg.Connection[object]) -> BootstrapStatusR
                         completed_at=completed_at,
                     )
                 )
+    openfigi_key_present = bool(settings.openfigi_api_key)
     if snap is None:
         return BootstrapStatusResponse(
             status=state.status,
@@ -272,6 +282,7 @@ def _build_status_response(conn: psycopg.Connection[object]) -> BootstrapStatusR
             last_completed_at=state.last_completed_at,
             stages=[],
             bulk_manifest=_read_bulk_manifest_response(),
+            openfigi_key_present=openfigi_key_present,
         )
 
     stages = [
@@ -298,6 +309,7 @@ def _build_status_response(conn: psycopg.Connection[object]) -> BootstrapStatusR
         last_completed_at=state.last_completed_at,
         stages=stages,
         bulk_manifest=_read_bulk_manifest_response(),
+        openfigi_key_present=openfigi_key_present,
     )
 
 

--- a/docs/specs/frontend/2026-06-28-openfigi-key-nudge.md
+++ b/docs/specs/frontend/2026-06-28-openfigi-key-nudge.md
@@ -1,0 +1,91 @@
+# OpenFIGI key pre-flight nudge (#1344)
+
+## Problem
+OpenFIGI CUSIP resolution is materially faster when `OPENFIGI_API_KEY` is
+set. The resolver already adapts batch size to key presence
+(`openfigi_resolver.py:266,316`), so the code path is correct. The gap is
+UX: operators don't learn the key matters until bootstrap stage S13
+(`cusip_resolver_post_bulk_sweep`) crawls.
+
+## Source rule / cited numbers
+Not a data-treatment decision — no SEC reg applies. Two distinct figures,
+both already documented; cite the correct one for the correct claim:
+- **Rate limit = 100×** (250 vs 25,000 mappings/min — settled-decision 635).
+- **Wall-clock ≈ 10×** on a real backlog (`app/config.py:88-92` comment:
+  unkeyed ~48 min vs keyed ~5 min on a ~12k unresolved-CUSIP backlog).
+Operator-facing copy cites the **wall-clock** figure ("~10× faster CUSIP
+resolution"), the honest end-to-end number, NOT the 100× rate limit.
+This is a quote of an existing documented estimate, not a new measured
+perf claim → does not trip perf-claim-lint (no `perf` label / no
+`## Performance impact` header in the PR).
+
+## Placement decision
+The issue offers "first-install setup page **or** pre-bootstrap checklist".
+`/setup` is pre-auth and cannot read env state; `/system/bootstrap/status`
+needs a session. The honest home is the post-auth dashboard pre-bootstrap
+surface (`AppShell`, beside the existing `BootstrapNudgeBanner`), shown only
+while bootstrap has not started — exactly when setting the key still helps.
+
+## Backend
+`BootstrapStatusResponse` (app/api/bootstrap.py) gains
+`openfigi_key_present: bool = bool(settings.openfigi_api_key)`.
+**Boolean only — never the key value.** Citation: ADR 0001
+("Decryption is server-side only. Plaintext never leaves the backend …
+the UI sees metadata only", lines 142–148). Presence is metadata; the
+secret stays server-side. Computed once in `_build_status_response`, set
+on both return paths (snap-None and snap-present).
+
+Config-read semantics: `settings = Settings()` is process-global at import;
+`.env`/env changes are NOT live-reloaded. So `openfigi_key_present`
+reflects the key as of **API process start**. Crucially the resolver reads
+the *same* process-global `settings.openfigi_api_key` (`from_env`), so the
+banner's "no key" exactly predicts what S13 will run with — no false nudge.
+After adding the key the operator restarts the API; banner copy says so.
+
+Frontend `BootstrapStatusResponse` interface gains the same field.
+
+## Frontend
+New `OpenFigiKeyNudgeBanner.tsx` (sibling of `BootstrapNudgeBanner`,
+rendered in `AppShell`). Shows when ALL hold:
+- `openfigi_key_present === false`, AND
+- a (re-)run may still execute S13 (`cusip_resolver_post_bulk_sweep`)
+  without a key:
+  - `pending` — fresh install, full run ahead; OR
+  - `partial_error` AND S13 has not terminally succeeded. A
+    `partial_error` can originate in a different/later lane while S13
+    already finished; retry reruns only failed + later-same-lane stages,
+    so a succeeded S13 will NOT rerun and the key can no longer help
+    (Codex ckpt-2). Read the S13 stage from `stages[]` and hide when its
+    status is `success`/`skipped`.
+  `running` (mid-run, too late this run) and `complete` (re-run from a
+  healthy system is a deliberate operator action) are excluded, AND
+- not dismissed (localStorage, persistent — advisory nudge; a deliberate
+  operator "no key" choice should stick across reloads; distinct from the
+  bootstrap banner's intentionally non-permanent sessionStorage dismiss).
+
+Copy: recommends setting `OPENFIGI_API_KEY` **and restarting the API**
+before bootstrap; "~10× faster CUSIP resolution" (wall-clock, per
+`config.py`); link to https://www.openfigi.com/api. Dismissible.
+Polls /system/bootstrap/status at 60s (mirrors sibling) so it self-hides
+when bootstrap leaves the pending/partial_error window; a newly-set key is
+reflected after the operator restarts the API (config is not hot-reloaded).
+
+## Out of scope (deferred)
+- Drift-heal re-surface if S13 runs >2 min with no key (acceptance bullet 3).
+  Requires hooking live stage-timing; file as tech-debt follow-up. The
+  pre-flight nudge covers the primary "operator never knew" gap.
+
+## Tests
+- Backend: status endpoint returns `openfigi_key_present` reflecting
+  `settings.openfigi_api_key`. Assert BOTH return paths carry the field —
+  `snap is None` (no run yet) and `snap` present (run exists) — and both
+  true/false via monkeypatch on the settings singleton.
+- Frontend: banner renders when (pending|partial_error) + no key + not
+  dismissed; hidden when key present, when status running/complete, and
+  when dismissed; dismiss persists to localStorage. Add the new field to
+  any shared bootstrap-status test fixture/type so stale mocked payloads
+  fail loudly (schema backcompat).
+
+## Verification
+- Hit `/system/bootstrap/status` on dev, confirm new field renders.
+- Load dashboard with key unset → nudge shows; dismiss → gone on reload.

--- a/frontend/src/api/bootstrap.ts
+++ b/frontend/src/api/bootstrap.ts
@@ -88,6 +88,11 @@ export interface BootstrapStatusResponse {
   last_completed_at: string | null;
   stages: BootstrapStageResponse[];
   bulk_manifest: BulkManifestResponse | null;
+  // #1344 — whether OPENFIGI_API_KEY is configured server-side (presence
+  // only, never the value — ADR 0001). Drives the pre-bootstrap
+  // OpenFigiKeyNudgeBanner. Reflects the key as of API process start
+  // (backend `settings` is process-global, not hot-reloaded).
+  openfigi_key_present: boolean;
 }
 
 export interface BootstrapRunQueuedResponse {

--- a/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.test.tsx
+++ b/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenFigiKeyNudgeBanner } from "@/components/dashboard/OpenFigiKeyNudgeBanner";
+import type {
+  BootstrapStageResponse,
+  BootstrapStageStatus,
+  BootstrapStatusResponse,
+} from "@/api/bootstrap";
+
+vi.mock("@/api/bootstrap", () => ({
+  fetchBootstrapStatus: vi.fn(),
+}));
+
+import * as bootstrapApi from "@/api/bootstrap";
+
+const mockedFetch = vi.mocked(bootstrapApi.fetchBootstrapStatus);
+
+function status(
+  overrides: Partial<BootstrapStatusResponse>,
+): BootstrapStatusResponse {
+  return {
+    status: "pending",
+    current_run_id: null,
+    last_completed_at: null,
+    stages: [],
+    bulk_manifest: null,
+    openfigi_key_present: false,
+    ...overrides,
+  };
+}
+
+function s13Stage(status: BootstrapStageStatus): BootstrapStageResponse {
+  return {
+    stage_key: "cusip_resolver_post_bulk_sweep",
+    stage_order: 13,
+    lane: "openfigi",
+    job_name: "cusip_resolver_post_bulk_sweep",
+    status,
+    started_at: null,
+    completed_at: null,
+    rows_processed: null,
+    expected_units: null,
+    units_done: null,
+    last_error: null,
+    attempt_count: 1,
+    archive_results: [],
+  };
+}
+
+const NUDGE = /OPENFIGI_API_KEY/;
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+describe("OpenFigiKeyNudgeBanner", () => {
+  it("shows when bootstrap pending and no key", async () => {
+    mockedFetch.mockResolvedValue(status({ status: "pending", openfigi_key_present: false }));
+    render(<OpenFigiKeyNudgeBanner />);
+    expect(await screen.findByText(NUDGE)).toBeInTheDocument();
+  });
+
+  it("shows on partial_error when S13 failed and no key (retry may rerun it)", async () => {
+    mockedFetch.mockResolvedValue(
+      status({
+        status: "partial_error",
+        openfigi_key_present: false,
+        stages: [s13Stage("error")],
+      }),
+    );
+    render(<OpenFigiKeyNudgeBanner />);
+    expect(await screen.findByText(NUDGE)).toBeInTheDocument();
+  });
+
+  it("hidden on partial_error when S13 already succeeded (retry won't rerun it)", async () => {
+    mockedFetch.mockResolvedValue(
+      status({
+        status: "partial_error",
+        openfigi_key_present: false,
+        stages: [s13Stage("success")],
+      }),
+    );
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden when key already present", async () => {
+    mockedFetch.mockResolvedValue(status({ status: "pending", openfigi_key_present: true }));
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden mid-run (status running) and when complete", async () => {
+    mockedFetch.mockResolvedValue(status({ status: "running", openfigi_key_present: false }));
+    const { unmount } = render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+    unmount();
+
+    mockedFetch.mockResolvedValue(status({ status: "complete", openfigi_key_present: false }));
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("dismiss persists to localStorage and stays hidden on remount", async () => {
+    mockedFetch.mockResolvedValue(status({ status: "pending", openfigi_key_present: false }));
+    const user = userEvent.setup();
+    const { unmount } = render(<OpenFigiKeyNudgeBanner />);
+    expect(await screen.findByText(NUDGE)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+    expect(window.localStorage.getItem("openfigiKeyNudgeDismissed")).toBe("1");
+
+    // Remount — persistent dismiss keeps it hidden.
+    unmount();
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.tsx
+++ b/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.tsx
@@ -1,0 +1,138 @@
+/**
+ * Pre-bootstrap nudge to set ``OPENFIGI_API_KEY`` (#1344).
+ *
+ * OpenFIGI CUSIP resolution (bootstrap stage S13,
+ * ``cusip_resolver_post_bulk_sweep``) runs ~10× faster wall-clock with a
+ * key configured (app/config.py: ~48 min → ~5 min on a ~12k unresolved
+ * backlog). Operators don't learn this until S13 crawls — this banner
+ * surfaces the recommendation *before* bootstrap runs.
+ *
+ * Source numbers: rate limit is 100× (250 vs 25,000 mappings/min,
+ * settled-decision 635); the operator-facing figure is the ~10×
+ * wall-clock estimate, the honest end-to-end number.
+ *
+ * Behaviour:
+ *  * Polls /system/bootstrap/status at 60s (mirrors BootstrapNudgeBanner).
+ *  * Shown only when ``openfigi_key_present === false`` AND a (re-)run may
+ *    still execute S13 (``cusip_resolver_post_bulk_sweep``) without a key:
+ *      - ``pending`` — fresh install, full run ahead.
+ *      - ``partial_error`` — BUT only if S13 has not already terminally
+ *        succeeded. A ``partial_error`` can originate in a different/later
+ *        lane while S13 already finished; retry reruns only failed +
+ *        later-same-lane stages, so a succeeded S13 will NOT rerun and the
+ *        key can no longer help — hide the nudge (Codex ckpt-2).
+ *    ``running`` (mid-run, too late) and ``complete`` (re-run is a
+ *    deliberate operator action) are excluded.
+ *  * ``openfigi_key_present`` reflects the key as of API process start —
+ *    backend ``settings`` is process-global and not hot-reloaded, so a
+ *    newly-set key shows only after the operator restarts the API. The
+ *    same ``settings`` value drives the S13 resolver, so "no key" here
+ *    truthfully predicts what the sweep will run with.
+ *  * Dismiss is persistent (localStorage): an advisory env nudge, not an
+ *    action-required gate — a deliberate "no key" choice should stick
+ *    across reloads. (Contrast BootstrapNudgeBanner's intentionally
+ *    non-permanent sessionStorage dismiss.)
+ */
+
+import { useEffect, useState } from "react";
+
+import {
+  fetchBootstrapStatus,
+  type BootstrapStatusResponse,
+} from "@/api/bootstrap";
+
+const DISMISS_KEY = "openfigiKeyNudgeDismissed";
+const OPENFIGI_KEY_URL = "https://www.openfigi.com/api";
+// S13 — the OpenFIGI CUSIP post-bulk sweep stage (the key only speeds
+// this one stage). Mirrors app/services/bootstrap_orchestrator.py
+// JOB_CUSIP_RESOLVER_POST_BULK_SWEEP.
+const S13_STAGE_KEY = "cusip_resolver_post_bulk_sweep";
+
+/** Whether a (re-)run may still execute S13 without a key — the only
+ *  state in which setting the key still helps. */
+function nudgeApplies(data: BootstrapStatusResponse): boolean {
+  if (data.openfigi_key_present) return false;
+  if (data.status === "pending") return true;
+  if (data.status === "partial_error") {
+    // Hide if S13 already terminally succeeded — retry won't rerun it,
+    // so the key can no longer help.
+    const s13 = data.stages.find((s) => s.stage_key === S13_STAGE_KEY);
+    const s13Done = s13?.status === "success" || s13?.status === "skipped";
+    return !s13Done;
+  }
+  // running (too late this run) / complete (deliberate re-run) → no nudge.
+  return false;
+}
+
+export function OpenFigiKeyNudgeBanner() {
+  const [data, setData] = useState<BootstrapStatusResponse | null>(null);
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    try {
+      return window.localStorage.getItem(DISMISS_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const result = await fetchBootstrapStatus();
+        if (!cancelled) setData(result);
+      } catch {
+        // Best-effort banner — a fetch failure (no session, network
+        // hiccup) just leaves it hidden, no user-facing error.
+      }
+    };
+    void load();
+    const id = window.setInterval(() => void load(), 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  if (dismissed) return null;
+  if (data === null) return null;
+  if (!nudgeApplies(data)) return null;
+
+  const handleDismiss = () => {
+    try {
+      window.localStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      // localStorage unavailable — fall through to in-state dismiss only.
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div
+      role="status"
+      className="flex flex-wrap items-center justify-between gap-3 border-b border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/40 px-6 py-2 text-sm text-indigo-900 dark:text-indigo-100"
+    >
+      <span>
+        💡 Recommended: set <code className="font-mono">OPENFIGI_API_KEY</code>{" "}
+        and restart the API before bootstrap — CUSIP resolution runs ~10×
+        faster with a (free) key.
+      </span>
+      <div className="flex items-center gap-3">
+        <a
+          href={OPENFIGI_KEY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded bg-white/60 dark:bg-slate-900/60 px-2 py-1 text-xs font-medium hover:bg-white dark:hover:bg-slate-900"
+        >
+          Get a free key
+        </a>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="text-xs underline hover:no-underline"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router-dom";
 import { BootstrapNudgeBanner } from "@/components/dashboard/BootstrapNudgeBanner";
+import { OpenFigiKeyNudgeBanner } from "@/components/dashboard/OpenFigiKeyNudgeBanner";
 import { Sidebar } from "@/layout/Sidebar";
 import { Header } from "@/layout/Header";
 
@@ -15,6 +16,11 @@ export function AppShell() {
             bootstrap is complete or the operator dismisses it for
             the current session. */}
         <BootstrapNudgeBanner />
+        {/* #1344 — pre-bootstrap nudge to set OPENFIGI_API_KEY (faster
+            CUSIP resolution). Self-hides when a key is configured, once
+            bootstrap leaves the pending/partial_error window, or when
+            dismissed (persistent localStorage). */}
+        <OpenFigiKeyNudgeBanner />
         {/* No top padding: pages with sticky headers (e.g. SummaryStrip
             on the instrument page) must be able to flush with the
             <Header> bar above. Pages that need top breathing room add

--- a/tests/test_api_bootstrap.py
+++ b/tests/test_api_bootstrap.py
@@ -69,6 +69,8 @@ def test_get_status_with_no_runs(client: TestClient) -> None:
     assert body["current_run_id"] is None
     assert body["last_completed_at"] is None
     assert body["stages"] == []
+    # #1344 — field present on the snap-None return path (schema backcompat).
+    assert "openfigi_key_present" in body
 
 
 def test_get_status_with_running_run(client: TestClient) -> None:
@@ -136,6 +138,42 @@ def test_get_status_with_running_run(client: TestClient) -> None:
     assert body["stages"][1]["status"] == "running"
     assert body["stages"][1]["expected_units"] == 9000
     assert body["stages"][1]["units_done"] == 4500
+    # #1344 — field present on the snap-present return path too.
+    assert "openfigi_key_present" in body
+
+
+@pytest.mark.parametrize(
+    ("key_value", "expected"),
+    [("test-figi-key", True), (None, False), ("", False)],
+)
+def test_get_status_reports_openfigi_key_presence(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    key_value: str | None,
+    expected: bool,
+) -> None:
+    """#1344 — ``openfigi_key_present`` mirrors ``settings.openfigi_api_key``
+    as a boolean (presence only, never the value — ADR 0001). Empty string
+    is absent, matching the resolver's ``settings.openfigi_api_key or None``."""
+    from app.services.bootstrap_state import BootstrapState
+
+    _install_conn()
+    monkeypatch.setattr("app.api.bootstrap.settings.openfigi_api_key", key_value)
+    with (
+        patch(
+            "app.api.bootstrap.read_state",
+            return_value=BootstrapState(status="pending", last_run_id=None, last_completed_at=None),
+        ),
+        patch("app.api.bootstrap.read_latest_run_with_stages", return_value=None),
+    ):
+        resp = client.get("/system/bootstrap/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["openfigi_key_present"] is expected
+    # The secret value itself never appears in the payload.
+    if key_value:
+        assert key_value not in resp.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1344.

## What
Pre-bootstrap UX nudge: recommend setting `OPENFIGI_API_KEY` before running first-install bootstrap. OpenFIGI CUSIP resolution (bootstrap stage S13 `cusip_resolver_post_bulk_sweep`) runs ~10× faster wall-clock with a key (`app/config.py:88-92`: ~48 min → ~5 min on a ~12k unresolved-CUSIP backlog). The resolver already adapts batch size to key presence (`openfigi_resolver.py:266,316`) — the gap was purely UX: operators didn't learn the key mattered until S13 crawled.

## Why this placement (not the SetupPage)
The issue offers "first-install setup page **or** pre-bootstrap checklist". `/setup` is pre-auth and `/system/bootstrap/status` requires a session, so env state can't be read there. The honest home is the post-auth dashboard pre-bootstrap surface (`AppShell`, beside the existing `BootstrapNudgeBanner`) — exactly when setting the key still helps.

## Backend
`BootstrapStatusResponse` gains `openfigi_key_present: bool`.
- **Boolean only — never the key value.** Citation: ADR 0001 ("Decryption is server-side only. Plaintext never leaves the backend … the UI sees metadata only"). Presence is metadata.
- Computed from `settings.openfigi_api_key` on **both** status return paths (snap-None and snap-present).
- `settings` is process-global (not hot-reloaded), so the field reflects the key as of API process start. The S13 resolver reads the *same* `settings`, so "no key" truthfully predicts what the sweep runs with.

## Frontend
New `OpenFigiKeyNudgeBanner` (sibling of `BootstrapNudgeBanner`). Shows only when `!openfigi_key_present` AND a (re-)run may still execute S13 without a key:
- `pending` — fresh run ahead; OR
- `partial_error` AND S13 has not terminally succeeded. A `partial_error` can come from a different/later lane while S13 already finished; retry reruns only failed + later-same-lane stages, so a succeeded S13 won't rerun and the key can't help → hidden (**Codex ckpt-2 catch**).

`running` (too late this run) and `complete` (re-run is a deliberate operator action) are excluded. Dismiss is persistent (localStorage) — advisory nudge, deliberate "no key" choice should stick (distinct from the bootstrap banner's intentionally non-permanent sessionStorage dismiss).

## Source numbers
Rate limit is 100× (250 vs 25,000 mappings/min, settled-decision 635); operator copy cites the **wall-clock** ~10× figure (the honest end-to-end number, `config.py`). Quote of an existing documented estimate, not a new measured claim → no perf-claim-lint trigger.

## Out of scope (deferred → follow-up filed)
Drift-heal re-surface if S13 runs >2 min with no key (acceptance bullet 3) — needs live stage-timing hooks. Tracked separately; the pre-flight nudge covers the primary "operator never knew" gap.

## Tests
- Backend (`tests/test_api_bootstrap.py`): field present on both return paths (schema backcompat) + `true`/`false`/empty-string via monkeypatch on the settings singleton; asserts the secret value never appears in the payload.
- Frontend (`OpenFigiKeyNudgeBanner.test.tsx`, 6 cases): shows on pending+no-key and partial_error+S13-failed; hidden when key present, status running/complete, partial_error+S13-succeeded, or dismissed; dismiss persists to localStorage across remount.

## Verification
- Local: ruff check/format clean, pyright 0 errors, `tests/test_api_bootstrap.py` 19 passed, FE typecheck clean, banner test 6 passed, smoke 129 passed, pre-push gate green.
- Live: `GET /system/bootstrap/status` on dev returns `openfigi_key_present: true` (bool); dev has the key set + status `complete`, so the banner correctly stays hidden.

Spec: `docs/specs/frontend/2026-06-28-openfigi-key-nudge.md`.