### PR TITLE
feat(#1791): drift-heal re-surface OpenFIGI key nudge when S13 runs slow

### DIFF
--- a/docs/specs/frontend/2026-06-28-openfigi-drift-heal-nudge.md
+++ b/docs/specs/frontend/2026-06-28-openfigi-drift-heal-nudge.md
@@ -1,0 +1,114 @@
+# OpenFIGI key drift-heal nudge (#1791, follow-up to #1344)
+
+## Problem
+The pre-flight `OpenFigiKeyNudgeBanner` (#1790) recommends setting
+`OPENFIGI_API_KEY` *before* bootstrap. It explicitly hides once status is
+`running` (too late this run). Gap (#1344 acceptance bullet 3, deferred):
+the operator who dismissed/missed the pre-flight nudge is now watching
+S13 (`cusip_resolver_post_bulk_sweep`) crawl with no key — and gets no
+reminder. Re-surface a *drift-heal* nudge mid-run when S13 has been
+`running` > 2 min without a key.
+
+## Premise check (falsified on the data path, not assumed)
+The issue framed this as "needs live per-stage timing exposed to the
+frontend". **False — the data already rides in the existing response.**
+`BootstrapStageResponse` (app/api/bootstrap.py:104-118) already carries
+`stage_key`, `status`, and `started_at`; the FE type mirrors it
+(frontend/src/api/bootstrap.ts:60,65). So this is **frontend-only** — no
+backend field, no migration, no daemon restart.
+
+## Source rule / cited numbers
+Not a data-treatment decision — no SEC reg. Reuses the same two documented
+figures as #1790: rate limit 100× (settled-decision 635); operator-facing
+wall-clock ~10× (app/config.py:88-92). Copy cites the **wall-clock** figure
+only → no perf-claim-lint trip (no `perf` label, no `## Performance impact`).
+
+## Timing computation — clock-skew posture (prevention-log #822)
+`bootstrap_stages.started_at` is `TIMESTAMPTZ` (sql/129_bootstrap_state.sql:88)
+→ psycopg yields a tz-aware UTC `datetime` → FastAPI serializes ISO-8601 with
+offset → `new Date(started_at)` parses an unambiguous absolute instant. So
+there is **no naive-datetime local-time trap** (the #822 / DetailPanel-type
+mistake). Elapsed = `Date.now() - new Date(started_at).getTime()`.
+
+The one residual skew is browser wall-clock vs server clock. Accepted, not
+fixed with a server-now field, because:
+- This is an **advisory** banner, not a correctness predicate (#822 burned
+  on freshness *flipping*; here a false +/- just shows/hides a harmless
+  "set your key" reminder).
+- The poll interval is 60 s, so the threshold is already ±60 s fuzzy;
+  normal NTP browser skew (seconds) is well inside that noise floor.
+- A multi-minute browser clock skew is pathological and breaks far more
+  than this banner.
+Documented in the component so a future reviewer sees the tradeoff was
+conscious, not missed.
+
+## Design — one component, two modes
+Extend `OpenFigiKeyNudgeBanner` (do not add a second polling component —
+both would hit `/system/bootstrap/status` every 60 s for the same data).
+`nudgeMode(data, nowMs)` returns `"preflight" | "driftheal" | null`:
+- `preflight` (unchanged): `pending`, or `partial_error` with S13 not
+  terminally `success`/`skipped`.
+- `driftheal` (new): `status === "running"` AND the S13 stage is itself
+  `running` AND `Date.now() - started_at > 2 min`.
+- The two are mutually exclusive by top-level status, so at most one shows.
+
+### Dismiss scope (acceptance bullet: distinct from pre-flight)
+- preflight: persistent `localStorage` (`openfigiKeyNudgeDismissed`) —
+  unchanged. A deliberate "no key" choice sticks across reloads.
+- driftheal: **run-scoped** `sessionStorage`, keyed by `current_run_id`
+  (`openfigiKeyDriftHealDismissed:<run_id>`) — Codex ckpt-1 fix. A plain
+  session key would stay dismissed across a *next* bootstrap run in the same
+  browser session, contradicting "re-reminded on the next run". Keying by
+  `current_run_id` means a new run = new key = the nudge returns. The
+  operator can't fix the *current* run anyway; the reminder is for the next.
+- The two dismiss states are **independent** (separate keys, separate React
+  state, mode-specific checks): dismissing the pre-flight nudge must NOT
+  pre-dismiss the drift-heal one — catching the operator who dismissed
+  pre-flight is the whole point.
+
+### Threshold vs poll latency + stale-data safety (Codex ckpt-1 + ckpt-2)
+ckpt-1: crossing 2:00 must render promptly, not wait a full poll. ckpt-2: a
+naive standalone "now" tick can surface the nudge from **stale** data — if
+S13 finished between fetches, an independent tick still crosses the threshold
+against the last-seen `running` snapshot until the next fetch corrects it.
+
+Resolution that satisfies both: **drive the clock from the fetch.** Poll at
+30 s and store `{data, fetchedAtMs}` together; `nudgeMode(data, fetchedAtMs)`
+computes the threshold against the moment the snapshot was true. Then:
+- appears within ≈one 30 s interval of crossing 2 min (ckpt-1), and
+- every appearance is backed by a fetch that just confirmed S13 `running`
+  (ckpt-2) — a later re-render with a newer `Date.now()` cannot resurrect a
+  stale `running` snapshot, because the clock is pinned to fetch-time.
+30 s polling is cheap: bootstrap is a rare, bounded operator event.
+
+### Guards
+- driftheal hides if the S13 stage is absent, not `running`, has null
+  `started_at`, or an unparseable `started_at` (`Number.isNaN(getTime())`).
+
+### Drift-heal dismiss — storage-failure resilience (Codex ckpt-2)
+Dismiss writes run-scoped `sessionStorage` AND sets in-memory React state
+(`driftHealDismissedRun`). The in-memory state guarantees the banner hides
+this mount even if `sessionStorage.setItem` throws; sessionStorage carries
+the dismiss across remounts within the session. Render hides on either.
+
+### Copy (honest, mode-specific — conscious deviation from "same copy")
+Literal "same copy" would say "before bootstrap" mid-run, which is false:
+S13 is already running unkeyed; setting the key now helps **future runs**
+(after a restart), not this one. So drift-heal copy is honest about that:
+> ⏳ CUSIP resolution (S13) has been running over 2 minutes without
+> `OPENFIGI_API_KEY`. Setting a (free) key and restarting the API speeds
+> future runs ~10×. — [Get a free key]
+Same link (`https://www.openfigi.com/api`), same ~10× wall-clock figure.
+
+## Tests (frontend, vitest, fake timers for the 2-min threshold)
+- driftheal shows: running + S13 running + started_at 3 min ago + no key.
+- driftheal hidden: S13 running but started_at 1 min ago (under threshold).
+- driftheal hidden: running but S13 stage absent / not running.
+- driftheal hidden when key present.
+- driftheal dismiss → sessionStorage set, hidden; survives remount within
+  session; independent of the localStorage preflight key.
+- existing preflight tests unchanged and still green.
+
+## Out of scope
+- Server-now field for absolute skew-immunity (see posture above — not
+  warranted for an advisory banner).

--- a/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.test.tsx
+++ b/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.test.tsx
@@ -51,13 +51,26 @@ function s13Stage(status: BootstrapStageStatus): BootstrapStageResponse {
 
 const NUDGE = /OPENFIGI_API_KEY/;
 
+function runningS13(startedAt: string | null): BootstrapStatusResponse {
+  return status({
+    status: "running",
+    current_run_id: 42,
+    openfigi_key_present: false,
+    stages: [{ ...s13Stage("running"), started_at: startedAt }],
+  });
+}
+
+const DRIFTHEAL = /running over 2 minutes/;
+
 beforeEach(() => {
   mockedFetch.mockReset();
   window.localStorage.clear();
+  window.sessionStorage.clear();
 });
 
 afterEach(() => {
   vi.clearAllTimers();
+  vi.useRealTimers();
 });
 
 describe("OpenFigiKeyNudgeBanner", () => {
@@ -127,5 +140,100 @@ describe("OpenFigiKeyNudgeBanner", () => {
     render(<OpenFigiKeyNudgeBanner />);
     await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
     expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  // --- drift-heal mode (#1791) ---
+
+  it("drift-heal shows when S13 has run > 2 min with no key", async () => {
+    const startedAt = new Date(Date.now() - 3 * 60_000).toISOString();
+    mockedFetch.mockResolvedValue(runningS13(startedAt));
+    render(<OpenFigiKeyNudgeBanner />);
+    expect(await screen.findByText(DRIFTHEAL)).toBeInTheDocument();
+  });
+
+  it("drift-heal hidden when S13 under the 2-min threshold", async () => {
+    const startedAt = new Date(Date.now() - 60_000).toISOString();
+    mockedFetch.mockResolvedValue(runningS13(startedAt));
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(DRIFTHEAL)).not.toBeInTheDocument();
+  });
+
+  it("drift-heal hidden when running but S13 stage is not running", async () => {
+    mockedFetch.mockResolvedValue(
+      status({
+        status: "running",
+        current_run_id: 42,
+        openfigi_key_present: false,
+        stages: [s13Stage("success")],
+      }),
+    );
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(DRIFTHEAL)).not.toBeInTheDocument();
+  });
+
+  it("drift-heal hidden when started_at is null (no parseable clock)", async () => {
+    mockedFetch.mockResolvedValue(runningS13(null));
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(DRIFTHEAL)).not.toBeInTheDocument();
+  });
+
+  it("drift-heal hidden when key already present", async () => {
+    const startedAt = new Date(Date.now() - 3 * 60_000).toISOString();
+    mockedFetch.mockResolvedValue({
+      ...runningS13(startedAt),
+      openfigi_key_present: true,
+    });
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(DRIFTHEAL)).not.toBeInTheDocument();
+  });
+
+  it("drift-heal dismiss is run-scoped (sessionStorage) and survives remount, but a new run re-surfaces it", async () => {
+    const startedAt = new Date(Date.now() - 3 * 60_000).toISOString();
+    mockedFetch.mockResolvedValue(runningS13(startedAt));
+    const user = userEvent.setup();
+    const { unmount } = render(<OpenFigiKeyNudgeBanner />);
+    expect(await screen.findByText(DRIFTHEAL)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByText(DRIFTHEAL)).not.toBeInTheDocument();
+    expect(
+      window.sessionStorage.getItem("openfigiKeyDriftHealDismissed:42"),
+    ).toBe("1");
+    // Pre-flight localStorage key untouched — independent dismiss state.
+    expect(window.localStorage.getItem("openfigiKeyNudgeDismissed")).toBeNull();
+
+    // Same run, remount — run-scoped dismiss keeps it hidden.
+    unmount();
+    render(<OpenFigiKeyNudgeBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText(DRIFTHEAL)).not.toBeInTheDocument();
+
+    // A new bootstrap run (different current_run_id) re-surfaces the nudge.
+    mockedFetch.mockResolvedValue({
+      ...runningS13(startedAt),
+      current_run_id: 99,
+    });
+    const next = render(<OpenFigiKeyNudgeBanner />);
+    expect(await next.findByText(DRIFTHEAL)).toBeInTheDocument();
+  });
+
+  it("pre-flight dismiss does NOT suppress a later drift-heal nudge", async () => {
+    // Operator dismisses the pre-flight nudge…
+    mockedFetch.mockResolvedValue(status({ status: "pending" }));
+    const user = userEvent.setup();
+    const { unmount } = render(<OpenFigiKeyNudgeBanner />);
+    expect(await screen.findByText(NUDGE)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    unmount();
+
+    // …then S13 crawls mid-run: the drift-heal nudge still shows.
+    const startedAt = new Date(Date.now() - 3 * 60_000).toISOString();
+    mockedFetch.mockResolvedValue(runningS13(startedAt));
+    render(<OpenFigiKeyNudgeBanner />);
+    expect(await screen.findByText(DRIFTHEAL)).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.tsx
+++ b/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.tsx
@@ -28,10 +28,27 @@
  *    newly-set key shows only after the operator restarts the API. The
  *    same ``settings`` value drives the S13 resolver, so "no key" here
  *    truthfully predicts what the sweep will run with.
- *  * Dismiss is persistent (localStorage): an advisory env nudge, not an
- *    action-required gate — a deliberate "no key" choice should stick
- *    across reloads. (Contrast BootstrapNudgeBanner's intentionally
- *    non-permanent sessionStorage dismiss.)
+ *  * Pre-flight dismiss is persistent (localStorage): an advisory env
+ *    nudge, not an action-required gate — a deliberate "no key" choice
+ *    should stick across reloads. (Contrast BootstrapNudgeBanner's
+ *    intentionally non-permanent sessionStorage dismiss.)
+ *
+ * Drift-heal mode (#1791): re-surface the nudge mid-run when S13 has been
+ * ``running`` over 2 min with no key — catching the operator who
+ * dismissed/missed the pre-flight nudge and is now watching S13 crawl.
+ * Distinct from pre-flight:
+ *  * Fires only on ``status === "running"`` with the S13 stage itself
+ *    ``running`` and ``now - started_at > 2 min``.
+ *  * ``started_at`` is a TIMESTAMPTZ (sql/129_bootstrap_state.sql) → ISO
+ *    string with offset → ``new Date()`` is an unambiguous absolute instant
+ *    (no naive-local trap, prevention-log #822). The only residual skew is
+ *    browser-vs-server clock; accepted for an advisory banner whose poll is
+ *    already ±60 s fuzzy (normal NTP skew is seconds).
+ *  * Dismiss is run-scoped sessionStorage (keyed by ``current_run_id``):
+ *    the operator can't fix the current run, but a *new* run = new key = the
+ *    reminder returns. Independent of the pre-flight localStorage dismiss.
+ *  * Copy is honest about "future runs" — setting the key now can't help the
+ *    in-flight unkeyed sweep, only the next (post-restart) run.
  */
 
 import { useEffect, useState } from "react";
@@ -41,69 +58,142 @@ import {
   type BootstrapStatusResponse,
 } from "@/api/bootstrap";
 
-const DISMISS_KEY = "openfigiKeyNudgeDismissed";
+const PREFLIGHT_DISMISS_KEY = "openfigiKeyNudgeDismissed";
+const DRIFTHEAL_DISMISS_PREFIX = "openfigiKeyDriftHealDismissed";
 const OPENFIGI_KEY_URL = "https://www.openfigi.com/api";
 // S13 — the OpenFIGI CUSIP post-bulk sweep stage (the key only speeds
 // this one stage). Mirrors app/services/bootstrap_orchestrator.py
 // JOB_CUSIP_RESOLVER_POST_BULK_SWEEP.
 const S13_STAGE_KEY = "cusip_resolver_post_bulk_sweep";
+// Drift-heal threshold: S13 running this long without a key → re-surface.
+const DRIFTHEAL_THRESHOLD_MS = 2 * 60 * 1000;
+// Poll cadence. 30 s (vs the sibling's 60 s) so the drift-heal nudge
+// surfaces within ≈one interval of crossing the 2-min threshold. Bootstrap
+// is a rare, bounded operator event, so a status read every 30 s is cheap.
+const POLL_MS = 30_000;
 
-/** Whether a (re-)run may still execute S13 without a key — the only
- *  state in which setting the key still helps. */
-function nudgeApplies(data: BootstrapStatusResponse): boolean {
-  if (data.openfigi_key_present) return false;
-  if (data.status === "pending") return true;
+type NudgeMode = "preflight" | "driftheal";
+
+/** Run-scoped sessionStorage key for the drift-heal dismiss. */
+function driftHealDismissKey(runId: number | null): string {
+  return `${DRIFTHEAL_DISMISS_PREFIX}:${runId ?? "none"}`;
+}
+
+/** Which nudge (if any) applies for a single status snapshot.
+ *  ``nowMs`` is the moment the snapshot was *fetched* (not render time):
+ *  pinning the clock to fetch-time keeps the drift-heal threshold a pure
+ *  function of one consistent snapshot, so a later re-render can never
+ *  surface the nudge from stale data (Codex ckpt-2). Mutually exclusive by
+ *  top-level status, so at most one mode is returned. */
+function nudgeMode(
+  data: BootstrapStatusResponse,
+  nowMs: number,
+): NudgeMode | null {
+  if (data.openfigi_key_present) return null;
+
+  // Pre-flight: a (re-)run may still execute S13 without a key.
+  if (data.status === "pending") return "preflight";
   if (data.status === "partial_error") {
     // Hide if S13 already terminally succeeded — retry won't rerun it,
     // so the key can no longer help.
     const s13 = data.stages.find((s) => s.stage_key === S13_STAGE_KEY);
     const s13Done = s13?.status === "success" || s13?.status === "skipped";
-    return !s13Done;
+    return s13Done ? null : "preflight";
   }
-  // running (too late this run) / complete (deliberate re-run) → no nudge.
-  return false;
+
+  // Drift-heal: S13 crawling unkeyed mid-run.
+  if (data.status === "running") {
+    const s13 = data.stages.find((s) => s.stage_key === S13_STAGE_KEY);
+    if (s13?.status !== "running" || !s13.started_at) return null;
+    const startedMs = new Date(s13.started_at).getTime();
+    if (Number.isNaN(startedMs)) return null;
+    if (nowMs - startedMs > DRIFTHEAL_THRESHOLD_MS) return "driftheal";
+  }
+
+  return null;
 }
 
 export function OpenFigiKeyNudgeBanner() {
-  const [data, setData] = useState<BootstrapStatusResponse | null>(null);
-  const [dismissed, setDismissed] = useState<boolean>(() => {
+  // Snapshot + the clock reading at fetch time, set together so the
+  // drift-heal threshold is computed against the moment the data was true.
+  const [snapshot, setSnapshot] = useState<{
+    data: BootstrapStatusResponse;
+    fetchedAtMs: number;
+  } | null>(null);
+  const [preflightDismissed, setPreflightDismissed] = useState<boolean>(() => {
     try {
-      return window.localStorage.getItem(DISMISS_KEY) === "1";
+      return window.localStorage.getItem(PREFLIGHT_DISMISS_KEY) === "1";
     } catch {
       return false;
     }
   });
+  // In-memory run-scoped drift-heal dismiss. sessionStorage carries it across
+  // remounts within the session; this state guarantees the dismiss still hides
+  // the banner this mount even when sessionStorage.setItem throws (Codex
+  // ckpt-2). `undefined` = nothing dismissed yet this mount.
+  const [driftHealDismissedRun, setDriftHealDismissedRun] = useState<
+    number | null | undefined
+  >(undefined);
 
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
       try {
         const result = await fetchBootstrapStatus();
-        if (!cancelled) setData(result);
+        if (!cancelled) setSnapshot({ data: result, fetchedAtMs: Date.now() });
       } catch {
         // Best-effort banner — a fetch failure (no session, network
         // hiccup) just leaves it hidden, no user-facing error.
       }
     };
     void load();
-    const id = window.setInterval(() => void load(), 60_000);
+    const id = window.setInterval(() => void load(), POLL_MS);
     return () => {
       cancelled = true;
       window.clearInterval(id);
     };
   }, []);
 
-  if (dismissed) return null;
-  if (data === null) return null;
-  if (!nudgeApplies(data)) return null;
+  if (snapshot === null) return null;
+  const { data, fetchedAtMs } = snapshot;
+
+  const mode = nudgeMode(data, fetchedAtMs);
+  if (mode === null) return null;
+  if (mode === "preflight" && preflightDismissed) return null;
+
+  const isDriftHeal = mode === "driftheal";
+  const runId = data.current_run_id;
+  if (isDriftHeal) {
+    // Hidden if dismissed in-memory this mount (covers sessionStorage write
+    // failures) OR persisted in run-scoped sessionStorage (survives remount).
+    if (driftHealDismissedRun === runId) return null;
+    let persisted = false;
+    try {
+      persisted =
+        window.sessionStorage.getItem(driftHealDismissKey(runId)) === "1";
+    } catch {
+      persisted = false;
+    }
+    if (persisted) return null;
+  }
 
   const handleDismiss = () => {
+    if (isDriftHeal) {
+      try {
+        window.sessionStorage.setItem(driftHealDismissKey(runId), "1");
+      } catch {
+        // sessionStorage unavailable — the in-memory state below still hides
+        // it for this mount (just not across a remount).
+      }
+      setDriftHealDismissedRun(runId);
+      return;
+    }
     try {
-      window.localStorage.setItem(DISMISS_KEY, "1");
+      window.localStorage.setItem(PREFLIGHT_DISMISS_KEY, "1");
     } catch {
       // localStorage unavailable — fall through to in-state dismiss only.
     }
-    setDismissed(true);
+    setPreflightDismissed(true);
   };
 
   return (
@@ -112,9 +202,20 @@ export function OpenFigiKeyNudgeBanner() {
       className="flex flex-wrap items-center justify-between gap-3 border-b border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-950/40 px-6 py-2 text-sm text-indigo-900 dark:text-indigo-100"
     >
       <span>
-        💡 Recommended: set <code className="font-mono">OPENFIGI_API_KEY</code>{" "}
-        and restart the API before bootstrap — CUSIP resolution runs ~10×
-        faster with a (free) key.
+        {isDriftHeal ? (
+          <>
+            ⏳ CUSIP resolution (S13) has been running over 2 minutes without{" "}
+            <code className="font-mono">OPENFIGI_API_KEY</code>. Setting a
+            (free) key and restarting the API speeds future runs ~10×.
+          </>
+        ) : (
+          <>
+            💡 Recommended: set{" "}
+            <code className="font-mono">OPENFIGI_API_KEY</code> and restart the
+            API before bootstrap — CUSIP resolution runs ~10× faster with a
+            (free) key.
+          </>
+        )}
       </span>
       <div className="flex items-center gap-3">
         <a


### PR DESCRIPTION
Closes #1791.

Follow-up to #1344 (PR #1790), acceptance bullet 3 (deferred). Re-surface the `OPENFIGI_API_KEY` nudge **mid-run** when bootstrap stage S13 (`cusip_resolver_post_bulk_sweep`) has been `running` over 2 minutes with no key — catching the operator who dismissed/missed the pre-flight nudge and is now watching S13 crawl.

## Premise falsified → frontend-only
The issue framed this as "needs live per-stage timing exposed to the frontend". **False** — `stage_key` + `status` + `started_at` already ride in `BootstrapStageResponse` (`app/api/bootstrap.py:104-118`), mirrored in the FE type (`frontend/src/api/bootstrap.ts:60,65`). No backend field, no migration, **no daemon restart**.

## Design — one component, two modes
`nudgeMode(data, fetchedAtMs)` → `"preflight" | "driftheal" | null`, mutually exclusive by top-level status:
- **preflight** (unchanged): `pending`, or `partial_error` with S13 not terminally `success`/`skipped`.
- **driftheal** (new): `status==="running"` + S13 stage `running` + `fetchedAtMs - started_at > 2min` + key absent.

## Correctness notes
- **Timing (prevention-log #822):** `bootstrap_stages.started_at` is `TIMESTAMPTZ` (`sql/129_bootstrap_state.sql:88`) → serialized ISO+offset → `new Date()` is an unambiguous absolute instant. No naive-local-time trap. Guards: S13 absent / not running / null / unparseable `started_at` all hide.
- **Clock pinned to fetch-time (Codex ckpt-2):** the clock is captured *with* each fetch (`fetchedAtMs`), not read at render. A later re-render with a newer `Date.now()` cannot resurrect a stale `running` snapshot. 30s poll → surfaces within ≈30s of crossing 2min (Codex ckpt-1).
- **Dismiss (Codex ckpt-1 + ckpt-2):** run-scoped `sessionStorage` keyed by `current_run_id` + in-memory React state. A new run = new key = reminder returns. In-memory state hides the banner this mount even if `sessionStorage.setItem` throws. Fully independent of the pre-flight `localStorage` dismiss.
- **Copy** is honest about "future runs" — setting the key now can't help the in-flight unkeyed sweep, only the next post-restart run. Cites the documented ~10× wall-clock figure (no perf-claim-lint trip).

## Verification
- `pnpm --dir frontend typecheck` — clean.
- `pnpm --dir frontend exec vitest run OpenFigiKeyNudgeBanner.test.tsx` — **13 passed** (6 existing + 7 new).
- `pnpm --dir frontend dark:check` — 229 files, no violations.
- Pre-push gate green.

7 new tests: shows >2min; hidden under threshold / S13 not running / null `started_at` / key present; run-scoped dismiss survives remount but a new run re-surfaces; pre-flight dismiss does not suppress drift-heal.

## Tradeoff
Browser-vs-server clock skew is accepted (not fixed with a server-now field) — advisory banner, poll already ±30s fuzzy, normal NTP skew is seconds. Documented in the component + spec.

Spec: `docs/specs/frontend/2026-06-28-openfigi-drift-heal-nudge.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)