### PR TITLE
feat(#1791): mid-run drift-heal OpenFIGI key nudge

### DIFF
--- a/docs/specs/frontend/2026-06-28-openfigi-key-driftheal-nudge.md
+++ b/docs/specs/frontend/2026-06-28-openfigi-key-driftheal-nudge.md
@@ -1,0 +1,108 @@
+# OpenFIGI key drift-heal nudge (#1791, follow-up to #1344)
+
+Follow-up to the pre-flight nudge (`2026-06-28-openfigi-key-nudge.md`,
+PR #1790). Acceptance bullet 3 of #1344 was deferred here: re-surface the
+nudge **mid-run** if bootstrap stage S13 (`cusip_resolver_post_bulk_sweep`)
+is crawling with no key — catching the operator who dismissed/missed the
+pre-flight nudge and is now watching S13 run slowly.
+
+## Premise verification (full-path, dev)
+No data-treatment / SEC rule — UX surface. The two facts the banner relies
+on are both verified on the running dev stack, not assumed:
+- `bootstrap_stages.started_at` is `TIMESTAMPTZ` (`sql/129`), set to
+  `now()` the instant a stage flips to `running`
+  (`bootstrap_state.py:534-547`). The API serializes it with a `Z`
+  suffix (verified live: `'2026-06-03T18:56:03.770819Z'`), so the client
+  `Date.now() - new Date(started_at).getTime()` elapsed calc is correct
+  in UTC — NOT a naive-datetime parsed in the browser's local zone
+  (prevention-log naive-`datetime` class, line 297). No backend change.
+- `openfigi_key_present` already on `BootstrapStatusResponse` (#1344) and
+  the FE type. The S13 stage status + `started_at` are already on
+  `BootstrapStageResponse`. The FE has everything; this is pure FE.
+
+## Show condition
+Mid-run, all must hold:
+- `openfigi_key_present === false`, AND
+- top-level `data.status === "running"` (defends against a stale/projected
+  S13 row leaking from a non-running snapshot — Codex ckpt-1), AND
+- the S13 stage (`cusip_resolver_post_bulk_sweep`) is found in `stages[]`
+  with `status === "running"` and a non-null `started_at` that parses to a
+  finite epoch (NaN → hidden — Codex ckpt-1), AND
+- `Date.now() - new Date(started_at).getTime() > 5 min`, AND
+- not dismissed for this run (sessionStorage keyed by `current_run_id` — see
+  below).
+
+The S13 stage being `running` implies bootstrap is mid-run, so this window
+is disjoint from the pre-flight nudge's `pending`/`partial_error` window —
+the two banners never show together. Negative / NaN elapsed (clock skew,
+future or unparseable `started_at`) → hidden (the `> 5min` test fails).
+
+### Threshold = 5 min, NOT the issue's "2 min" — deliberate (Codex ckpt-1)
+The issue suggested ">2 min". Aligned instead to the orchestrator's
+`_REAPER_GRACE_SECONDS = 300` (`bootstrap_orchestrator.py:2669`). Rationale:
+`reap_orphaned_running_stages` resets a `running` stage ONLY when its
+worker is **provably dead** (the `openfigi` lane advisory lock is not held
+in any PG session). A genuinely-slow keyless S13 sweep (~48 min,
+`config.py`) holds that lock the whole time, so the reaper never resets it.
+Therefore a stage still `running` *past the 5-min grace* is provably a
+LIVE, slow worker — exactly the "no key" cause. Below 5 min a `running` S13
+is ambiguous (could be a just-crashed worker awaiting the reaper); firing
+there would mis-attribute a dead stage to "missing key". 5 min eliminates
+that false positive at the cost of ~3 min extra latency on an advisory
+nudge whose underlying run lasts ~48 min — a good trade.
+
+Detection latency: the 60 s poll (mirrors the sibling banners) drives the
+re-render, so the banner appears within ≤60 s of the 5-min mark. No
+separate `setInterval` timer for the clock — the poll IS the tick.
+
+## Dismiss semantics — per-run, session-scoped (distinct from pre-flight)
+sessionStorage (`openfigiKeyDriftHealDismissedRunId` = the dismissed
+`current_run_id`), NOT localStorage. Show only when
+`current_run_id !== <dismissed run id>`. The operator can't fix this
+mid-run without restarting the API, so a dismiss should silence the
+*current run's* nag but genuinely re-arm on the NEXT run (a fresh
+`current_run_id`) — plain sessionStorage `"1"` would wrongly suppress
+later runs in the same tab session too (Codex ckpt-1). Contrast the
+pre-flight nudge's persistent localStorage dismiss (a deliberate "no key"
+choice that sticks across reloads).
+
+## Component + shared constants
+New `OpenFigiKeyDriftHealBanner.tsx` (sibling in `components/dashboard/`,
+rendered in `AppShell` after `OpenFigiKeyNudgeBanner`). Self-contained
+poll-effect like the two existing nudge banners (repo convention: one
+banner component per concern).
+
+`S13_STAGE_KEY` and `OPENFIGI_KEY_URL` are currently private to
+`OpenFigiKeyNudgeBanner.tsx`. Extract to a shared
+`components/dashboard/openfigiNudge.ts` and import from both — single
+source of truth (the S13 stage key MUST NOT drift between the two banners).
+
+Copy (amber tone to read as "running slow", distinct from the indigo
+advisory pre-flight): "⏳ OpenFIGI CUSIP resolution (S13) has been running
+several minutes with no `OPENFIGI_API_KEY` — it runs ~10× faster with a
+(free) key. Set the key and restart the API to speed up the next run."
+Link https://www.openfigi.com/api. Dismissible.
+
+## Tests
+Frontend (`OpenFigiKeyDriftHealBanner.test.tsx`). Drive the clock with a
+fixed fake timer / explicit `started_at` offset so the threshold is
+deterministic:
+- shows when S13 `running` + `started_at` > 5 min ago + top-level running +
+  no key + not dismissed;
+- hidden when key present;
+- hidden when top-level `status !== "running"` even with a stale S13
+  `running` row;
+- hidden when S13 `running` but `started_at` < 5 min ago (threshold);
+- hidden at exactly 5 min (condition is strict `>`);
+- hidden when S13 `running` but `started_at` is in the future;
+- hidden when `started_at` is unparseable (NaN);
+- hidden when S13 not `running` (pending/success);
+- hidden when S13 stage absent;
+- dismiss writes `current_run_id` to sessionStorage and hides;
+- pre-seeded dismiss for the SAME `current_run_id` → hidden on mount;
+- pre-seeded dismiss for a DIFFERENT run id → shown (re-armed next run).
+
+## Verification
+- Unit tests green. Dev currently has the key set (`openfigi_key_present:
+  true`) so the banner is correctly invisible on dev — assert the logic via
+  unit tests + a manual `openfigi_key_present:false` mock walkthrough.

--- a/frontend/src/components/dashboard/OpenFigiKeyDriftHealBanner.test.tsx
+++ b/frontend/src/components/dashboard/OpenFigiKeyDriftHealBanner.test.tsx
@@ -1,0 +1,212 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OpenFigiKeyDriftHealBanner } from "@/components/dashboard/OpenFigiKeyDriftHealBanner";
+import type {
+  BootstrapStageResponse,
+  BootstrapStageStatus,
+  BootstrapStatusResponse,
+} from "@/api/bootstrap";
+
+vi.mock("@/api/bootstrap", () => ({
+  fetchBootstrapStatus: vi.fn(),
+}));
+
+import * as bootstrapApi from "@/api/bootstrap";
+
+const mockedFetch = vi.mocked(bootstrapApi.fetchBootstrapStatus);
+
+// Frozen clock — fake ONLY Date so async/promises + the 60s poll interval
+// still run on real timers, but Date.now()/argless new Date() are pinned.
+// new Date(isoString) parsing is unaffected (only argless construction is
+// faked), so the component's elapsed calc is deterministic.
+const NOW = Date.UTC(2026, 5, 28, 12, 0, 0);
+
+function minutesAgo(mins: number): string {
+  return new Date(NOW - mins * 60_000).toISOString();
+}
+
+function status(
+  overrides: Partial<BootstrapStatusResponse>,
+): BootstrapStatusResponse {
+  return {
+    status: "running",
+    current_run_id: 42,
+    last_completed_at: null,
+    stages: [],
+    bulk_manifest: null,
+    openfigi_key_present: false,
+    ...overrides,
+  };
+}
+
+function s13Stage(
+  stageStatus: BootstrapStageStatus,
+  startedAt: string | null,
+): BootstrapStageResponse {
+  return {
+    stage_key: "cusip_resolver_post_bulk_sweep",
+    stage_order: 13,
+    lane: "openfigi",
+    job_name: "cusip_resolver_post_bulk_sweep",
+    status: stageStatus,
+    started_at: startedAt,
+    completed_at: null,
+    rows_processed: null,
+    expected_units: null,
+    units_done: null,
+    last_error: null,
+    attempt_count: 1,
+    archive_results: [],
+  };
+}
+
+const DISMISS_RUN_KEY = "openfigiKeyDriftHealDismissedRunId";
+const NUDGE = /has been running several minutes/;
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+  window.sessionStorage.clear();
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("OpenFigiKeyDriftHealBanner", () => {
+  it("shows when S13 running >5 min, mid-run, no key, not dismissed", async () => {
+    mockedFetch.mockResolvedValue(
+      status({ stages: [s13Stage("running", minutesAgo(6))] }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    expect(await screen.findByText(NUDGE)).toBeInTheDocument();
+  });
+
+  it("hidden when key already present", async () => {
+    mockedFetch.mockResolvedValue(
+      status({
+        openfigi_key_present: true,
+        stages: [s13Stage("running", minutesAgo(6))],
+      }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden when top-level status is not running (stale S13 row)", async () => {
+    mockedFetch.mockResolvedValue(
+      status({
+        status: "partial_error",
+        stages: [s13Stage("running", minutesAgo(6))],
+      }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden when S13 running but only 4 min in (below threshold)", async () => {
+    mockedFetch.mockResolvedValue(
+      status({ stages: [s13Stage("running", minutesAgo(4))] }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden at exactly 5 min (condition is strict >)", async () => {
+    mockedFetch.mockResolvedValue(
+      status({ stages: [s13Stage("running", minutesAgo(5))] }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden when started_at is in the future", async () => {
+    mockedFetch.mockResolvedValue(
+      status({ stages: [s13Stage("running", minutesAgo(-1))] }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden when started_at is unparseable (NaN)", async () => {
+    mockedFetch.mockResolvedValue(
+      status({ stages: [s13Stage("running", "not-a-date")] }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden when S13 not running (pending / success)", async () => {
+    mockedFetch.mockResolvedValue(
+      status({ stages: [s13Stage("pending", minutesAgo(6))] }),
+    );
+    const { unmount } = render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+    unmount();
+
+    mockedFetch.mockResolvedValue(
+      status({ stages: [s13Stage("success", minutesAgo(6))] }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("hidden when S13 stage absent", async () => {
+    mockedFetch.mockResolvedValue(status({ stages: [] }));
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("dismiss writes current_run_id to sessionStorage and hides", async () => {
+    mockedFetch.mockResolvedValue(
+      status({
+        current_run_id: 42,
+        stages: [s13Stage("running", minutesAgo(6))],
+      }),
+    );
+    const user = userEvent.setup();
+    render(<OpenFigiKeyDriftHealBanner />);
+    expect(await screen.findByText(NUDGE)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+    expect(window.sessionStorage.getItem(DISMISS_RUN_KEY)).toBe("42");
+  });
+
+  it("pre-seeded dismiss for the SAME run id → hidden on mount", async () => {
+    window.sessionStorage.setItem(DISMISS_RUN_KEY, "42");
+    mockedFetch.mockResolvedValue(
+      status({
+        current_run_id: 42,
+        stages: [s13Stage("running", minutesAgo(6))],
+      }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    await waitFor(() => expect(mockedFetch).toHaveBeenCalled());
+    expect(screen.queryByText(NUDGE)).not.toBeInTheDocument();
+  });
+
+  it("pre-seeded dismiss for a DIFFERENT run id → shown (re-armed)", async () => {
+    window.sessionStorage.setItem(DISMISS_RUN_KEY, "41");
+    mockedFetch.mockResolvedValue(
+      status({
+        current_run_id: 42,
+        stages: [s13Stage("running", minutesAgo(6))],
+      }),
+    );
+    render(<OpenFigiKeyDriftHealBanner />);
+    expect(await screen.findByText(NUDGE)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/OpenFigiKeyDriftHealBanner.tsx
+++ b/frontend/src/components/dashboard/OpenFigiKeyDriftHealBanner.tsx
@@ -1,0 +1,162 @@
+/**
+ * Mid-run drift-heal nudge to set ``OPENFIGI_API_KEY`` (#1791, follow-up to
+ * #1344). Re-surfaces the key recommendation when bootstrap stage S13
+ * (``cusip_resolver_post_bulk_sweep``) is *still running* several minutes
+ * in with no key — catching the operator who dismissed/missed the
+ * pre-flight nudge (``OpenFigiKeyNudgeBanner``) and is now watching S13
+ * crawl. Spec: docs/specs/frontend/2026-06-28-openfigi-key-driftheal-nudge.md.
+ *
+ * Show condition (ALL): no key, top-level ``status === "running"``, the S13
+ * stage is ``running`` with a finite ``started_at`` more than ``THRESHOLD``
+ * ago, and not dismissed for this ``current_run_id``.
+ *
+ * Threshold = 5 min, deliberately aligned to the orchestrator's
+ * ``_REAPER_GRACE_SECONDS`` (bootstrap_orchestrator.py:2669), NOT the
+ * issue's "2 min". ``reap_orphaned_running_stages`` resets a ``running``
+ * stage only when its worker is provably dead (the ``openfigi`` lane
+ * advisory lock is unheld). A genuinely-slow keyless sweep (~48 min) holds
+ * that lock the whole time, so the reaper never touches it — meaning a
+ * stage still ``running`` past the 5-min grace is provably a LIVE, slow
+ * worker, i.e. exactly the "no key" cause. Firing before 5 min would
+ * mis-attribute a just-crashed-but-not-yet-reaped stage to "missing key".
+ *
+ * Dismiss is per-run (sessionStorage, keyed by ``current_run_id``): silence
+ * the current run's nag but re-arm on the next run (a fresh run id). Plain
+ * sessionStorage ``"1"`` would wrongly suppress later runs in the same tab
+ * session. Distinct from the pre-flight nudge's persistent localStorage
+ * dismiss (a deliberate "no key" choice that sticks across reloads).
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  fetchBootstrapStatus,
+  type BootstrapStatusResponse,
+} from "@/api/bootstrap";
+import {
+  OPENFIGI_KEY_URL,
+  S13_STAGE_KEY,
+} from "@/components/dashboard/openfigiNudge";
+
+const DISMISS_RUN_KEY = "openfigiKeyDriftHealDismissedRunId";
+// Aligned to bootstrap_orchestrator.py::_REAPER_GRACE_SECONDS (300s) — see
+// module docstring for why this, not the issue's 2 min.
+const THRESHOLD_MS = 5 * 60_000;
+
+/** sessionStorage run id the operator last dismissed for, or null. */
+function readDismissedRunId(): number | null {
+  try {
+    const raw = window.sessionStorage.getItem(DISMISS_RUN_KEY);
+    if (raw === null) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether the mid-run drift-heal nudge applies to this snapshot. */
+function nudgeApplies(
+  data: BootstrapStatusResponse,
+  dismissedRunId: number | null,
+  nowMs: number,
+): boolean {
+  if (data.openfigi_key_present) return false;
+  // Top-level guard: only when bootstrap is genuinely mid-run. Defends
+  // against a stale/projected S13 row leaking from a non-running snapshot.
+  if (data.status !== "running") return false;
+  // Per-run dismiss: hidden only while the dismissed id matches the live
+  // run. A new run (fresh current_run_id) re-arms the nudge.
+  if (
+    data.current_run_id !== null &&
+    data.current_run_id === dismissedRunId
+  ) {
+    return false;
+  }
+  const s13 = data.stages.find((s) => s.stage_key === S13_STAGE_KEY);
+  if (s13 === undefined || s13.status !== "running") return false;
+  if (s13.started_at === null) return false;
+  const startedMs = new Date(s13.started_at).getTime();
+  if (!Number.isFinite(startedMs)) return false; // unparseable → hidden
+  // Strict ``>``: at exactly the threshold the nudge is still hidden.
+  return nowMs - startedMs > THRESHOLD_MS;
+}
+
+export function OpenFigiKeyDriftHealBanner() {
+  const [data, setData] = useState<BootstrapStatusResponse | null>(null);
+  const [dismissedRunId, setDismissedRunId] = useState<number | null>(() =>
+    readDismissedRunId(),
+  );
+  // Monotonic request id: a slower older poll must not overwrite a newer
+  // snapshot (out-of-order resolution would briefly re-show a stale banner).
+  const latestReqRef = useRef(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      const reqId = ++latestReqRef.current;
+      try {
+        const result = await fetchBootstrapStatus();
+        // Ignore if unmounted or a newer poll already resolved.
+        if (!cancelled && reqId === latestReqRef.current) setData(result);
+      } catch {
+        // Best-effort banner — a fetch failure (no session, network
+        // hiccup) just leaves it hidden, no user-facing error.
+      }
+    };
+    void load();
+    const id = window.setInterval(() => void load(), 60_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  if (data === null) return null;
+  if (!nudgeApplies(data, dismissedRunId, Date.now())) return null;
+
+  const handleDismiss = () => {
+    if (data.current_run_id !== null) {
+      try {
+        window.sessionStorage.setItem(
+          DISMISS_RUN_KEY,
+          String(data.current_run_id),
+        );
+      } catch {
+        // sessionStorage unavailable — fall through to in-state dismiss.
+      }
+      setDismissedRunId(data.current_run_id);
+    }
+  };
+
+  return (
+    <div
+      role="status"
+      className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/40 px-6 py-2 text-sm text-amber-900 dark:text-amber-100"
+    >
+      <span>
+        ⏳ OpenFIGI CUSIP resolution (S13) has been running several minutes
+        with no <code className="font-mono">OPENFIGI_API_KEY</code> — it runs
+        ~10× faster with a (free) key. Set the key and restart the API to
+        speed up the next run.
+      </span>
+      <div className="flex items-center gap-3">
+        <a
+          href={OPENFIGI_KEY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded bg-white/60 dark:bg-slate-900/60 px-2 py-1 text-xs font-medium hover:bg-white dark:hover:bg-slate-900"
+        >
+          Get a free key
+        </a>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="text-xs underline hover:no-underline"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.tsx
+++ b/frontend/src/components/dashboard/OpenFigiKeyNudgeBanner.tsx
@@ -40,13 +40,12 @@ import {
   fetchBootstrapStatus,
   type BootstrapStatusResponse,
 } from "@/api/bootstrap";
+import {
+  OPENFIGI_KEY_URL,
+  S13_STAGE_KEY,
+} from "@/components/dashboard/openfigiNudge";
 
 const DISMISS_KEY = "openfigiKeyNudgeDismissed";
-const OPENFIGI_KEY_URL = "https://www.openfigi.com/api";
-// S13 — the OpenFIGI CUSIP post-bulk sweep stage (the key only speeds
-// this one stage). Mirrors app/services/bootstrap_orchestrator.py
-// JOB_CUSIP_RESOLVER_POST_BULK_SWEEP.
-const S13_STAGE_KEY = "cusip_resolver_post_bulk_sweep";
 
 /** Whether a (re-)run may still execute S13 without a key — the only
  *  state in which setting the key still helps. */

--- a/frontend/src/components/dashboard/openfigiNudge.ts
+++ b/frontend/src/components/dashboard/openfigiNudge.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared constants for the OpenFIGI key nudge banners (#1344 pre-flight,
+ * #1791 mid-run drift-heal). Single source of truth — the S13 stage key
+ * MUST NOT drift between the two banners.
+ */
+
+// S13 — the OpenFIGI CUSIP post-bulk sweep stage (the key only speeds this
+// one stage). Mirrors app/services/bootstrap_orchestrator.py
+// JOB_CUSIP_RESOLVER_POST_BULK_SWEEP.
+export const S13_STAGE_KEY = "cusip_resolver_post_bulk_sweep";
+
+export const OPENFIGI_KEY_URL = "https://www.openfigi.com/api";

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from "react-router-dom";
 import { BootstrapNudgeBanner } from "@/components/dashboard/BootstrapNudgeBanner";
 import { OpenFigiKeyNudgeBanner } from "@/components/dashboard/OpenFigiKeyNudgeBanner";
+import { OpenFigiKeyDriftHealBanner } from "@/components/dashboard/OpenFigiKeyDriftHealBanner";
 import { Sidebar } from "@/layout/Sidebar";
 import { Header } from "@/layout/Header";
 
@@ -21,6 +22,12 @@ export function AppShell() {
             bootstrap leaves the pending/partial_error window, or when
             dismissed (persistent localStorage). */}
         <OpenFigiKeyNudgeBanner />
+        {/* #1791 — mid-run drift-heal sibling of the pre-flight nudge.
+            Re-surfaces (amber) when bootstrap stage S13 is still running
+            5+ min with no key — disjoint window from the pre-flight nudge
+            above (which only shows pending/partial_error), so they never
+            stack. Per-run sessionStorage dismiss. */}
+        <OpenFigiKeyDriftHealBanner />
         {/* No top padding: pages with sticky headers (e.g. SummaryStrip
             on the instrument page) must be able to flush with the
             <Header> bar above. Pages that need top breathing room add


### PR DESCRIPTION
Closes #1791.

Follow-up to #1344 (PR #1790) — acceptance bullet 3, deferred there.

## What
Re-surface the `OPENFIGI_API_KEY` recommendation **mid-bootstrap** when stage S13 (`cusip_resolver_post_bulk_sweep`) is still running with no key — catching the operator who dismissed/missed the pre-flight nudge and is now watching S13 crawl.

Pure frontend. No backend change: `openfigi_key_present` (#1344) and per-stage `started_at`/`status` are already on `BootstrapStatusResponse`/`BootstrapStageResponse`.

## Premise verification (dev, full-path)
- `bootstrap_stages.started_at` is `TIMESTAMPTZ` (`sql/129`), set to `now()` on stage→running (`bootstrap_state.py:534-547`), and the API serializes it **with a `Z` suffix** (verified live on dev: `'2026-06-03T18:56:03.770819Z'`). So the client `Date.now() - new Date(started_at).getTime()` elapsed calc is correct in UTC — not a naive datetime parsed in browser-local time.
- Dev currently has the key set (`openfigi_key_present: true`), so the banner is correctly invisible on dev; the logic is exercised by 12 unit tests with a frozen clock.

## Key decisions
- **Threshold = 5 min, NOT the issue's 2 min** — deliberately aligned to the orchestrator's `_REAPER_GRACE_SECONDS` (300s, `bootstrap_orchestrator.py:2669`). `reap_orphaned_running_stages` resets a `running` stage only when its worker is *provably dead* (the `openfigi` lane advisory lock is unheld). A genuinely-slow keyless sweep (~48 min) holds that lock the whole time, so a stage still `running` past 5 min is provably a **live, slow** worker = the genuine "no key" cause. Firing earlier could mis-attribute a just-crashed-not-yet-reaped stage to "missing key" (Codex ckpt-1).
- **Per-run dismiss**: sessionStorage keyed by `current_run_id`. A dismiss silences the current run but re-arms on the next run (fresh run id) — plain sessionStorage `"1"` would suppress later same-session runs too (Codex ckpt-1). Distinct from the pre-flight nudge's persistent localStorage dismiss.
- **Disjoint window**: the drift-heal banner only shows when top-level `status === "running"`; the pre-flight nudge only shows `pending`/`partial_error`. They never stack.
- NaN/future `started_at` → hidden. Monotonic request-id guard so an out-of-order poll can't overwrite a newer snapshot (Codex ckpt-2).
- Extracted shared `S13_STAGE_KEY` + `OPENFIGI_KEY_URL` to `openfigiNudge.ts` — single source of truth (the stage key must not drift between the two banners).

## Security
No new data surface. `openfigi_key_present` remains presence-only (ADR 0001) — the banner never reads the key value.

## Tests
`OpenFigiKeyDriftHealBanner.test.tsx` — 12 cases: shows at >5min mid-run/no-key/not-dismissed; hidden for key-present, non-running top-level (stale S13 row), <5min, exactly 5min (strict `>`), future/NaN `started_at`, S13 not-running, S13 absent; dismiss writes `current_run_id`; pre-seeded same-run dismiss hides; different-run dismiss re-arms.

## Gates
`pnpm typecheck` ✅ · `pnpm test:unit` (1165 ✅) · dark-class gate ✅ (231 files, no violations). No backend change → Python gates N/A. Codex ckpt-1 (spec) + ckpt-2 (diff) run; all findings actioned.

Spec: `docs/specs/frontend/2026-06-28-openfigi-key-driftheal-nudge.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)