### PR TITLE
fix(#340): retire dead check_row_count_spike/SpikeResult ops_monitor shim

### DIFF
--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -4,9 +4,12 @@ Ops monitor.
 Responsibilities:
   - Check staleness of each data layer against expected refresh frequency.
   - Track job executions (start, finish, success/failure, row count).
-  - Detect row-count spikes (broken-source indicator).
   - Manage the kill switch (activate / deactivate).
   - Produce per-layer and per-job health checks consumed by /system/status.
+
+Row-count spike detection moved to
+``app.services.sync_orchestrator.row_count_spikes`` (#328 chunk 7); the
+backward-compat shim that re-exported it from here was retired in #340.
 
 Data layers monitored:
   - universe   — instruments.last_seen_at
@@ -55,11 +58,6 @@ if TYPE_CHECKING:
     # cycle if we import at module level. Guarding under TYPE_CHECKING breaks
     # the cycle; pyright still resolves the annotation correctly.
     from app.services.sync_orchestrator.layer_types import FailureCategory
-
-    # SpikeResult moved to row_count_spikes in chunk 7.  Import here so
-    # pyright resolves annotations that reference it from this module.
-    # No runtime import — the lazy shim below handles call-time resolution.
-    from app.services.sync_orchestrator.row_count_spikes import SpikeResult
 
 logger = logging.getLogger(__name__)
 
@@ -718,31 +716,6 @@ def fetch_latest_successful_runs(
         )
         rows = cur.fetchall()
     return {row["job_name"]: row["started_at"] for row in rows}
-
-
-# ---------------------------------------------------------------------------
-# Row-count spike detection — lazy shim (backward compat for one release)
-# ---------------------------------------------------------------------------
-
-
-# check_row_count_spike moved to app.services.sync_orchestrator.row_count_spikes.
-# A direct module-level re-export would trigger the sync_orchestrator.__init__
-# which creates a circular import (adapters → ops_monitor). A lazy wrapper
-# breaks the cycle while keeping the old call path working.
-# Remove this shim and its callers in the tech-debt cleanup (see linked issue).
-def check_row_count_spike(  # type: ignore[no-redef]
-    conn: Any,
-    job_name: str,
-    current_count: int,
-    *,
-    exclude_run_id: int | None = None,
-) -> SpikeResult:
-    """Shim: delegates to sync_orchestrator.row_count_spikes.check_row_count_spike."""
-    from app.services.sync_orchestrator.row_count_spikes import (
-        check_row_count_spike as _real,
-    )
-
-    return _real(conn, job_name, current_count, exclude_run_id=exclude_run_id)  # type: ignore[return-value]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/sync_orchestrator/test_row_count_spikes.py
+++ b/tests/services/sync_orchestrator/test_row_count_spikes.py
@@ -60,12 +60,50 @@ def test_imports_resolve_from_new_path() -> None:
     assert hasattr(row_count_spikes, "check_row_count_spike")
 
 
-def test_backcompat_shim_from_ops_monitor() -> None:
-    # The old import path must still resolve via the shim so existing
-    # callers / tests outside this chunk keep working.
-    from app.services.ops_monitor import check_row_count_spike as legacy_fn
+# Boundary cases moved from tests/test_ops_monitor.py::TestCheckRowCountSpike
+# when the ops_monitor back-compat shim was retired (#340). They guard the
+# 50%-of-prior threshold edges (prevention-log §"check_row_count_spike compared
+# the run against itself").
 
-    # Same object identity or at minimum same callable semantics.
-    conn = _mock_conn_with_prior(None)
-    result = legacy_fn(conn, "jobname", current_count=100)
+
+def test_count_above_threshold_not_flagged() -> None:
+    # Previous: 100, current: 80 → ratio 0.8 > 0.5 threshold.
+    conn = _mock_conn_with_prior({"row_count": 100})
+    result = check_row_count_spike(conn, "jobname", current_count=80)
     assert result.flagged is False
+    assert result.previous_count == 100
+
+
+def test_drop_detail_names_the_drop() -> None:
+    conn = _mock_conn_with_prior({"row_count": 100})
+    result = check_row_count_spike(conn, "jobname", current_count=40)
+    assert result.flagged is True
+    assert "dropped" in result.detail
+
+
+def test_zero_current_flagged() -> None:
+    # Previous: 50, current: 0 → ratio 0.0 < 0.5 threshold.
+    conn = _mock_conn_with_prior({"row_count": 50})
+    result = check_row_count_spike(conn, "jobname", current_count=0)
+    assert result.flagged is True
+
+
+def test_zero_previous_not_flagged() -> None:
+    # Previous: 0 → skip comparison (avoid divide by zero).
+    conn = _mock_conn_with_prior({"row_count": 0})
+    result = check_row_count_spike(conn, "jobname", current_count=0)
+    assert result.flagged is False
+
+
+def test_exactly_at_threshold_not_flagged() -> None:
+    # Previous: 100, current: 50 → ratio 0.5 == threshold (not strictly less).
+    conn = _mock_conn_with_prior({"row_count": 100})
+    result = check_row_count_spike(conn, "jobname", current_count=50)
+    assert result.flagged is False
+
+
+def test_just_below_threshold_flagged() -> None:
+    # Previous: 100, current: 49 → ratio 0.49 < 0.5 threshold.
+    conn = _mock_conn_with_prior({"row_count": 100})
+    result = check_row_count_spike(conn, "jobname", current_count=49)
+    assert result.flagged is True

--- a/tests/services/sync_orchestrator/test_row_count_spikes.py
+++ b/tests/services/sync_orchestrator/test_row_count_spikes.py
@@ -64,6 +64,12 @@ def test_imports_resolve_from_new_path() -> None:
 # when the ops_monitor back-compat shim was retired (#340). They guard the
 # 50%-of-prior threshold edges (prevention-log §"check_row_count_spike compared
 # the run against itself").
+#
+# The retired class's no-prior-run and counts-match cases are NOT re-added here:
+# they were already covered above by test_returns_not_flagged_when_no_prior_runs
+# (asserts the "no prior row_count" detail) and test_returns_not_flagged_when_
+# counts_match. Only the threshold-boundary and zero-handling cases were unique
+# to the old class, so only those are migrated below — no branch loses coverage.
 
 
 def test_count_above_threshold_not_flagged() -> None:

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -29,7 +29,6 @@ from app.services.ops_monitor import (
     check_all_layers,
     check_job_health,
     check_layer_staleness,
-    check_row_count_spike,
     deactivate_kill_switch,
     get_kill_switch_status,
     record_job_finish,
@@ -473,57 +472,11 @@ class TestFetchLatestSuccessfulRuns:
         assert result == {}
 
 
-# ---------------------------------------------------------------------------
-# TestCheckRowCountSpike
-# ---------------------------------------------------------------------------
-
-
-class TestCheckRowCountSpike:
-    """Test row-count spike detection."""
-
-    def test_no_prior_run_not_flagged(self) -> None:
-        conn = _make_conn([_make_cursor([])])
-        result = check_row_count_spike(conn, "test_job", 100)
-        assert not result.flagged
-        assert "no prior" in result.detail
-
-    def test_count_above_threshold_not_flagged(self) -> None:
-        # Previous: 100, current: 80 → ratio 0.8 > 0.5 threshold
-        conn = _make_conn([_make_cursor([{"row_count": 100}])])
-        result = check_row_count_spike(conn, "test_job", 80)
-        assert not result.flagged
-        assert result.previous_count == 100
-
-    def test_count_below_threshold_flagged(self) -> None:
-        # Previous: 100, current: 40 → ratio 0.4 < 0.5 threshold
-        conn = _make_conn([_make_cursor([{"row_count": 100}])])
-        result = check_row_count_spike(conn, "test_job", 40)
-        assert result.flagged
-        assert "dropped" in result.detail
-
-    def test_zero_current_flagged(self) -> None:
-        # Previous: 50, current: 0 → ratio 0.0 < 0.5 threshold
-        conn = _make_conn([_make_cursor([{"row_count": 50}])])
-        result = check_row_count_spike(conn, "test_job", 0)
-        assert result.flagged
-
-    def test_zero_previous_not_flagged(self) -> None:
-        # Previous: 0 → skip comparison (avoid divide by zero).
-        conn = _make_conn([_make_cursor([{"row_count": 0}])])
-        result = check_row_count_spike(conn, "test_job", 0)
-        assert not result.flagged
-
-    def test_exactly_at_threshold_not_flagged(self) -> None:
-        # Previous: 100, current: 50 → ratio 0.5 == threshold (not strictly less)
-        conn = _make_conn([_make_cursor([{"row_count": 100}])])
-        result = check_row_count_spike(conn, "test_job", 50)
-        assert not result.flagged
-
-    def test_just_below_threshold_flagged(self) -> None:
-        # Previous: 100, current: 49 → ratio 0.49 < 0.5 threshold
-        conn = _make_conn([_make_cursor([{"row_count": 100}])])
-        result = check_row_count_spike(conn, "test_job", 49)
-        assert result.flagged
+# Row-count spike detection moved to
+# app.services.sync_orchestrator.row_count_spikes (#328 chunk 7); its tests
+# (incl. the boundary cases formerly here) now live in
+# tests/services/sync_orchestrator/test_row_count_spikes.py. The ops_monitor
+# back-compat shim was retired in #340.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Retires the dead `check_row_count_spike` / `SpikeResult` back-compat shim from `app/services/ops_monitor.py` — the one genuinely-removable remnant of #340.

## Why

The lazy shim (added in #328 chunk 7 when spike detection moved to `app/services/sync_orchestrator/row_count_spikes.py`) has **zero production callers**: `app/workers/scheduler.py:82` already imports `check_row_count_spike` from the canonical module. Only tests referenced the shim. It was kept "for one release" — that release is long past.

## Changes

- **`ops_monitor.py`**: delete the shim function + its `SpikeResult` TYPE_CHECKING import; update the module docstring (spike detection lives in `row_count_spikes` now).
- **`tests/test_ops_monitor.py`**: drop the orphaned `TestCheckRowCountSpike` class + the shim import (the function it tested no longer lives in this module).
- **`tests/services/sync_orchestrator/test_row_count_spikes.py`**: drop `test_backcompat_shim_from_ops_monitor` (its subject is gone); move the boundary cases (50%-threshold edges, zero handling) here so coverage is **collocated with the code and nothing is lost** (prevention-log §"check_row_count_spike compared the run against itself").

## Scope note — the rest of #340 is not actionable as written

The issue listed many retirement targets. On inspection of current `main`:
- `/health/data`, `get_system_health`, `SystemHealth`, `evaluate_staleness` — **already gone**.
- The "legacy" staleness layer (`check_all_layers` / `check_layer_staleness` / `LayerHealth` / `LayerStatus` / `_LAYER_QUERIES` / `ALL_LAYERS` / `_STALENESS_THRESHOLDS`) and the `/system/status` endpoint are **still live** — `app/api/system.py` imports and serves them, and the #330 admin redesign (now closed) kept `/system/status`. Retiring them would remove a live, consumed endpoint — out of scope for a dead-code cleanup, and not currently desired.

So the shim is the only removable item; this closes #340 on it.

## Verification

- `pytest tests/services/sync_orchestrator/test_row_count_spikes.py tests/test_ops_monitor.py` → 57 passed.
- Fast tier (`-m "not db"`) → 4682 passed, 10 skipped.
- Smoke → 135 passed, 3 skipped.
- ruff check / format / pyright clean on changed files.
- Codex ckpt-2: no findings (verified no live shim refs, scheduler still imports canonical module, import-cycle clean).

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)