### PR TITLE
fix(#1800): unique React keys for non-unique filer_cik in ownership UI

### DIFF
--- a/docs/specs/frontend/2026-06-28-ownership-holder-key-uniqueness.md
+++ b/docs/specs/frontend/2026-06-28-ownership-holder-key-uniqueness.md
@@ -1,0 +1,91 @@
+# Ownership holder key uniqueness (#1800)
+
+## Symptom
+
+`/instrument/AAPL` → Research → Ownership console warning:
+`Encountered two children with the same key, 0000036405`. React may drop/duplicate
+holder rows on re-render (operator-visible correctness).
+
+## Root cause
+
+Several React/DOM keys are derived from `filer_cik`, which is **not unique**: a
+*registrant* CIK fronts many distinct holder rows (N-PORT fund series under one
+registrant; a recurring insider). The reported warning is the funds overlay table.
+
+## Source rule + full-population verification
+
+Governing rule = the rollup payload's identity structure **and** React's key-uniqueness
+requirement. Verified on the live `/instruments/{AAPL,GME}/ownership-rollup` population
+(not a sample — the issue's and an earlier draft spec's AAPL-only checks both produced
+wrong fixes):
+
+| slice | maxCIKmult | dup(cik,name) | note |
+|---|---|---|---|
+| institutions / etfs | **1** | 0 | 13F deduped per filer — never collides |
+| insiders | 2 | **1–2** | same cik+name recurs; on GME the two rows share `winning_accession` too, and `Cheng Lawrence` is a **byte-identical** row |
+| funds (overlay) | 43 (AAPL) | 0 | collides on cik, unique on (cik,name) |
+| def14a_unmatched | 15 | 0 | collides on cik, unique on (cik,name) |
+
+**Conclusion: no combination of data fields is provably unique** — `Cheng Lawrence`
+proves two holder rows can be byte-identical. The only guaranteed-unique discriminator
+for a React key is the **array position (index)**. (This falsifies the earlier draft's
+`(filer_cik, filer_name, winning_accession)` key, which GME insiders collide on.)
+
+## Constraint — the `?filer=` drill contract (the trap)
+
+`filer_cik ?? \`name:${filer_name}\`` is **not just a React key** — it is the deep-link
+token:
+
+- sunburst leaf click → `params.set("filer", target.leaf_key)` (`OwnershipPanel.tsx:95`)
+  → `?filer=<key>`.
+- the L2 page resolves the highlighted row by `row.key === filerFilter`
+  (`OwnershipPage.tsx:515`) and drills history via `holderIdFromFilerKey(filerFilter)`
+  (`ownershipHistorySeries.ts:116`), which requires a **pure-digit CIK** (or
+  `name:`/`block:`/`baseline:`).
+- the executable invariant `rollupToFilerRows` keys === `rollupToSunburstInputs` leaf
+  keys is asserted by `OwnershipPage.test.ts` "wedge ↔ row key parity".
+
+Composing the **token** with name/accession/index (as the issue and the earlier draft
+proposed) breaks `holderIdFromFilerKey` → the institutions/insiders/blockholders history
+drill returns `no_cik`, and breaks the parity test.
+
+## Fix — decouple React/DOM keys from the drill token
+
+Token builders stay UNCHANGED (bare `filer_cik ?? name:` = drill token, parity preserved):
+`rollupToSunburstInputs` (`OwnershipPanel.tsx:178`) and `rollupToFilerRows`
+(`OwnershipPage.tsx:649`).
+
+Make the three **render sites** unique by appending the array index — React-reconciliation
+only, never navigated/parsed:
+
+1. `OwnershipPanel.tsx:513` — funds/def14a `OverlaySection <tr>` (the reported warning;
+   no navigation): `key={\`${cik??name:}:${i}\`}`.
+2. `OwnershipSunburst.tsx:396` — outer-ring `<Cell key={d.id}>` (`d.id =
+   leaf-<cat>-<leaf.key>`, collides on insider cik). `d.id` is React-key-only — keyboard
+   targeting reads `data-idx`, the drill rides `target.leaf_key` — so `key={\`${d.id}-${i}\`}`.
+3. `OwnershipPage.tsx:526` — L2 `<tr key={\`${category}-${row.key}\`}>` (collides on
+   insider cik). Append `-${i}`; keep `row.key === highlightFiler` (line 515) untouched.
+
+The legend (`OwnershipSunburst.tsx:609`) keys by **category** (`cat.key`, a
+`CategoryKey` enum) — never collides; the issue's claim it collides is wrong.
+
+## Out of scope (verified, untouched)
+
+- `ownershipMetrics.ts:173` — deliberate *latest-per-filer* aggregation key (a dedup;
+  index/accession would break it).
+- The byte-identical insider duplicate row itself is a data-quality concern (#788), not a
+  FE bug; the FE renders defensively whatever the rollup returns.
+
+## Tests
+
+- `OwnershipPage.test.ts` — existing "wedge ↔ row key parity" stays green (tokens
+  unchanged). New: two same-cik insider rows survive as distinct rows, each with the bare
+  cik drill key (the GME repro).
+- `holderIdFromFilerKey` coverage already asserts pure-digit/`name:` resolution
+  (`ownershipHistorySeries.test.ts:45`) — the contract the fix preserves.
+
+## Verification
+
+- `pnpm --dir frontend typecheck` + `test`.
+- Live: `/instrument/AAPL` → Research → Ownership, console clean; click a sunburst wedge,
+  confirm the L2 table highlights + drills the clicked filer.

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -506,11 +506,17 @@ function OverlaySection({ slice }: OverlaySectionProps): JSX.Element {
           </tr>
         </thead>
         <tbody>
-          {shown.map((h) => {
+          {shown.map((h, i) => {
             const hShares = parseShareCount(h.shares) ?? 0;
             const hPct = parseShareCount(h.pct_outstanding) ?? 0;
+            // filer_cik is NOT unique — a registrant CIK fronts many N-PORT
+            // series funds (#1800: Vanguard 0000036405 = 43 rows on AAPL). This
+            // overlay table never navigates, so the row key is a pure React
+            // reconciliation id: compose with the array index, the only
+            // guaranteed-unique discriminator (full-population check found
+            // byte-identical holder rows that no data field disambiguates).
             return (
-              <tr key={h.filer_cik ?? `name:${h.filer_name}`}>
+              <tr key={`${h.filer_cik ?? `name:${h.filer_name}`}:${i}`}>
                 <td className="py-1 text-slate-600 dark:text-slate-300">
                   {h.winning_edgar_url !== null ? (
                     <a

--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -393,7 +393,15 @@ export function OwnershipSunburst({
           >
             {outerData.map((d, i) => (
               <Cell
-                key={d.id}
+                // ``d.id`` (``leaf-<cat>-<leaf.key>``) is NOT unique: a
+                // registrant CIK fronts many holders and an insider can recur
+                // with a byte-identical row, so two leaves can share a key
+                // (#1800, full-population verified on GME insiders). The Cell
+                // key is React-reconciliation only (the drill token rides on
+                // ``d.target.leaf_key`` and keyboard targeting reads
+                // ``data-idx``), so the array index makes it unique without
+                // touching the ``?filer=`` contract.
+                key={`${d.id}-${i}`}
                 fill={d.is_residual ? `url(#${patternId})` : d.fill}
                 stroke={d.is_gap ? "transparent" : wedgeStroke}
                 data-known={d.is_gap ? "false" : "true"}

--- a/frontend/src/pages/OwnershipPage.test.ts
+++ b/frontend/src/pages/OwnershipPage.test.ts
@@ -208,6 +208,44 @@ describe("rollupToFilerRows — row shape and category mapping", () => {
     expect(new Set(rows.map((r) => r.category))).toEqual(new Set(["insiders", "def14a"]));
   });
 
+  it("keeps two same-CIK insider rows distinct, each with the bare-CIK drill key (#1800)", () => {
+    // filer_cik is NOT unique: an insider can recur within one category with
+    // the SAME cik+name (and even a byte-identical row) — verified on the live
+    // GME rollup (Wolf Kurt James / Cheng Lawrence). Both rows MUST survive
+    // (dropping one is operator-visible omission) and each row.key MUST stay
+    // the bare cik so the ``?filer=`` drill (holderIdFromFilerKey expects pure
+    // digits) and the wedge↔row parity hold. Row-key uniqueness for React is
+    // the render site's job (composes the array index), NOT the token.
+    const rollup = _baseRollup({
+      slices: [
+        _slice({
+          category: "insiders",
+          filer_count: 2,
+          holders: [
+            _holder({
+              filer_cik: "0001693906",
+              filer_name: "Wolf Kurt James",
+              shares: "406500",
+              winning_source: "form4",
+              winning_accession: "0001192482-20-000524",
+            }),
+            _holder({
+              filer_cik: "0001693906",
+              filer_name: "Wolf Kurt James",
+              shares: "21400",
+              winning_source: "form4",
+              winning_accession: "0001192482-20-000524",
+            }),
+          ],
+        }),
+      ],
+    });
+    const rows = rollupToFilerRows(rollup).filter((r) => r.category === "insiders");
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.key)).toEqual(["0001693906", "0001693906"]);
+    expect(rows.map((r) => r.shares).sort((a, b) => a - b)).toEqual([21400, 406500]);
+  });
+
   it("excludes the funds memo slice (N-PORT, non-additive)", () => {
     const rollup = _baseRollup({
       slices: [

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -511,7 +511,7 @@ function FilerTable({
           </tr>
         </thead>
         <tbody>
-          {rows.map((row) => {
+          {rows.map((row, i) => {
             const isHighlight = highlightFiler !== null && row.key === highlightFiler;
             // Logical-side ``border-t-*`` instead of all-sides shorthand
             // so an isHighlight row's ``border-l-sky-500`` can't be
@@ -523,7 +523,13 @@ function FilerTable({
               : "";
             return (
               <tr
-                key={`${row.category}-${row.key}`}
+                // ``row.key`` (the bare ``filer_cik``/``name:`` drill token,
+                // matched against ``?filer=`` for the highlight above) is NOT
+                // unique — an insider can recur with the same CIK (and even a
+                // byte-identical row) within a category (#1800, verified on GME
+                // insiders). Append the array index so the React row key is
+                // unique while ``row.key`` stays the clean ``?filer=`` token.
+                key={`${row.category}-${row.key}-${i}`}
                 ref={isHighlight ? highlightRef : null}
                 className={`${baseCls} ${highlightCls}`}
                 onClick={isHighlight ? onClearHighlight : undefined}


### PR DESCRIPTION
## What
`filer_cik` is **not unique** in the ownership rollup — a registrant CIK fronts many N-PORT fund-series rows (Vanguard `0000036405` = 43 rows on AAPL) and an insider can recur with a byte-identical row (GME `Cheng Lawrence`). Three React/DOM render sites keyed children off `filer_cik`, emitting `Encountered two children with the same key` and risking dropped/duplicated holder rows on re-render (operator-visible correctness).

## Fix
Decouple the React reconciliation key from the `?filer=` drill token by appending the array index at the three **render** sites — token builders stay UNCHANGED:
- `OwnershipPanel.tsx:513` — funds/def14a `OverlaySection <tr>` (the reported warning).
- `OwnershipSunburst.tsx:404` — outer-ring `<Cell>` (leaf ids `leaf-<cat>-<leaf.key>` collide on insider cik).
- `OwnershipPage.tsx:526` — L2 `FilerTable <tr>`.

`rollupToSunburstInputs` / `rollupToFilerRows` (the `?filer=` token + `holderIdFromFilerKey` pure-digit-CIK contract + wedge↔row parity test) are untouched.

## Source rule / full-population verification
Verified on the live `/instruments/{AAPL,GME}/ownership-rollup` population (not a sample): **no field combo is provably unique** — `Cheng Lawrence` is two byte-identical rows. The array index is the only guaranteed-unique discriminator, which falsifies both the issue's proposed `(filer_cik, filer_name, index)` token change and an earlier `(cik,name,accession)` draft (GME insiders collide on all three). Middle ring (`cat-<key>`) and legend (`cat.key` enum) are per-category → already unique, untouched (the issue's legend-collision claim is wrong).

## Out of scope
- The byte-identical insider duplicate row is a data-quality concern (#788), not a FE bug; FE renders defensively.
- `ownershipMetrics.ts:173` deliberate latest-per-filer dedup key — untouched.

## Tests / verification
- New `OwnershipPage.test.ts` case: two same-cik insider rows survive distinct, each keeping the bare-cik drill key (GME repro). Existing wedge↔row parity stays green.
- `pnpm --dir frontend typecheck` ✓ · `test:unit` 1161 passed ✓.
- Codex ckpt-2: no findings.

Spec: `docs/specs/frontend/2026-06-28-ownership-holder-key-uniqueness.md`.

Closes #1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
