### PR TITLE
fix(#788): de-double-count insider ownership_nature dual-pipeline collision

### DIFF
--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -199,6 +199,11 @@ class Holder:
     # Constituent rows of a collapsed institutional family (#1644 + #1649);
     # display-only breakdown, NOT additive. Empty for ordinary holders.
     family_members: tuple[FamilyMember, ...] = ()
+    # Form 4/3 ownership nature (``direct`` / ``indirect`` / ``beneficial``);
+    # carried so :func:`_source_rows_and_total` can apply the within-source
+    # additive-vs-overlapping regime (#905 / prevention-log 1835). ``None`` for
+    # holders where nature is not meaningful (13F / family reps / treasury).
+    ownership_nature: str | None = None
 
 
 @dataclass(frozen=True)
@@ -707,13 +712,36 @@ def _collect_canonical_holders_from_current(conn: psycopg.Connection[Any], instr
 
     # Insiders.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Dual-pipeline de-collision (#788): the same Form 4/3 accession is
+        # written by BOTH the XML manifest parser (plain ``source_document_id`` =
+        # the bare accession, nature from Table II Direct/Indirect) AND the bulk
+        # SEC insider dataset (``<accn>:NDT:<sk>`` for Form-4 transactions /
+        # ``<accn>:NDH:<sk>`` for Form-3 holdings, nature relabelled from the
+        # reporting person's relationship — ``_map_relationship``). Since
+        # ``ownership_nature`` is in the MERGE key the two coexist, so the same
+        # stake is counted under two natures (direct+beneficial, direct+indirect).
+        # Drop the dataset row (its id carries a ``:NDT:`` / ``:NDH:`` marker)
+        # whenever an XML-manifest row exists for the same ``(holder_cik,
+        # source_accession)`` — the manifest parse is the authoritative
+        # full-Table-II view of that filing; the dataset only fills accessions the
+        # manifest never parsed.
         cur.execute(
             """
             SELECT holder_cik, holder_name, ownership_nature,
                    source, source_accession, shares, period_end
-            FROM ownership_insiders_current
+            FROM ownership_insiders_current oc
             WHERE instrument_id = %s
               AND shares IS NOT NULL
+              AND NOT (
+                oc.source_document_id ~ ':(NDT|NDH):'
+                AND EXISTS (
+                    SELECT 1 FROM ownership_insiders_current x
+                    WHERE x.instrument_id = oc.instrument_id
+                      AND x.holder_cik IS NOT DISTINCT FROM oc.holder_cik
+                      AND x.source_accession = oc.source_accession
+                      AND x.source_document_id !~ ':(NDT|NDH):'
+                )
+              )
             """,
             (instrument_id,),
         )
@@ -1097,6 +1125,7 @@ def _dedup_by_priority(candidates: Iterable[_Candidate]) -> list[Holder]:
                 winning_edgar_url=edgar_archive_url(winner.accession_number),
                 as_of_date=winner.as_of_date,
                 filer_type=winner.filer_type,
+                ownership_nature=winner.ownership_nature,
                 dropped_sources=tuple(
                     DroppedSource(
                         source=loser.source,
@@ -1170,6 +1199,7 @@ def _dedup_within_source(candidates: Iterable[_Candidate]) -> list[Holder]:
                 winning_edgar_url=edgar_archive_url(winner.accession_number),
                 as_of_date=winner.as_of_date,
                 filer_type=winner.filer_type,
+                ownership_nature=winner.ownership_nature,
                 dropped_sources=tuple(
                     DroppedSource(
                         source=loser.source,  # type: ignore[arg-type]
@@ -1204,6 +1234,15 @@ _INSIDER_SOURCES: Final[frozenset[SourceTag]] = frozenset({"form4", "form3", "de
 # single 13D/G beneficial figure, a single 13F economic position) and so are
 # collapsed to their largest representative, never summed (Codex #1640 ckpt-2).
 _ADDITIVE_SOURCES: Final[frozenset[SourceTag]] = frozenset({"form4", "form3"})
+# Within an additive source, only these natures are the distinct Section-16
+# holdings that SUM (#905). A ``beneficial`` / ``voting`` / ``economic`` row is an
+# OVERLAPPING restatement of the owner's total (Rule 13d-3, prevention-log 1835)
+# and must MAX against the additive sum, never add to it. The bulk SEC insider
+# dataset (`sec_insider_dataset_ingest._map_relationship`) relabels a 10%-owner's
+# directly-held lot ``beneficial`` purely from the relationship flag, so the same
+# Form-4 position lands under BOTH a ``direct``/``indirect`` (XML) and a
+# ``beneficial`` (dataset) row; summing them double-counts one stake.
+_ADDITIVE_NATURES: Final[frozenset[str]] = frozenset({"direct", "indirect"})
 
 
 def _argmax_source(sources: Iterable[SourceTag], src_total: dict[SourceTag, Decimal]) -> SourceTag:
@@ -1216,15 +1255,69 @@ def _argmax_source(sources: Iterable[SourceTag], src_total: dict[SourceTag, Deci
 def _source_rows_and_total(source: SourceTag, rows: list[Holder]) -> tuple[list[Holder], Decimal]:
     """The display rows + owner subtotal for one ``(owner, source)``.
 
-    Additive sources (Form 4 / Form 3): keep every nature row, sum them
-    (direct + indirect = the Section-16 total, #905). Overlapping sources
-    (DEF 14A beneficial/voting, 13D/G, 13F): keep only the largest row — the
-    others restate the same shares through a different lens and summing them
-    would double-count the owner (Codex #1640 ckpt-2 F3)."""
-    if source in _ADDITIVE_SOURCES:
-        return rows, sum((h.shares for h in rows), Decimal(0))
-    rep = max(rows, key=lambda h: h.shares)
+    Additive sources (Form 4 / Form 3): the ``direct`` + ``indirect`` nature rows
+    are distinct Section-16 holdings and SUM (#905); a ``beneficial`` (or
+    ``voting`` / ``economic``) row is an OVERLAPPING restatement of the owner's
+    total (Rule 13d-3, prevention-log 1835) and MAXes against that sum rather than
+    adding to it — the within-source half of the regime the earlier source-level
+    code missed (the dual-pipeline ``direct`` vs dataset-``beneficial`` collision,
+    #788). Owner subtotal = ``MAX(additive_sum, overlap_max)``; this is monotone —
+    it can only remove or hold counted shares vs the old blanket sum, never add
+    (verified on the full dev population, all 1,206 same-accession both-nature
+    groups). Overlapping sources (DEF 14A beneficial/voting, 13D/G, 13F): keep
+    only the largest row — the others restate the same shares through a different
+    lens (Codex #1640 ckpt-2 F3)."""
+    if source not in _ADDITIVE_SOURCES:
+        rep = max(rows, key=lambda h: h.shares)
+        return [rep], rep.shares
+
+    additive = [h for h in rows if (h.ownership_nature or "direct") in _ADDITIVE_NATURES]
+    overlap = [h for h in rows if (h.ownership_nature or "direct") not in _ADDITIVE_NATURES]
+    additive_sum = sum((h.shares for h in additive), Decimal(0))
+    overlap_max = max((h.shares for h in overlap), default=Decimal(0))
+
+    if additive and additive_sum >= overlap_max:
+        # Additive lots dominate: keep them, fold the subsumed overlap
+        # restatement(s) into the largest additive row's provenance.
+        keep = list(additive)
+        if overlap:
+            primary_idx = max(range(len(keep)), key=lambda i: keep[i].shares)
+            keep[primary_idx] = _fold_overlap_into(keep[primary_idx], overlap)
+        return keep, additive_sum
+
+    # Overlap exceeds the additive sum (XML under-captured the position) or no
+    # additive row exists (dataset-only owner): the beneficial restatement is the
+    # better total. Keep its largest row, fold the additive lots as provenance.
+    rep = max(overlap, key=lambda h: h.shares)
+    if additive:
+        rep = _fold_overlap_into(rep, additive)
     return [rep], rep.shares
+
+
+def _fold_overlap_into(rep: Holder, folded: list[Holder]) -> Holder:
+    """Append ``folded`` rows to ``rep``'s ``dropped_sources`` (provenance only),
+    de-duped on ``(source, accession, shares)`` against what is already recorded —
+    so the subsumed same-source restatement (e.g. the dataset ``:NDT:`` beneficial
+    row) stays auditable instead of vanishing. ``shares`` is in the key so two
+    distinct lots on ONE accession (a folded ``direct`` + ``indirect`` when the
+    overlap row wins) are BOTH preserved, not collapsed to one (Codex ckpt-2)."""
+    dropped = list(rep.dropped_sources)
+    seen = {(d.source, d.accession_number, d.shares) for d in dropped}
+    for h in folded:
+        key = (h.winning_source, h.winning_accession, h.shares)
+        if key in seen:
+            continue
+        seen.add(key)
+        dropped.append(
+            DroppedSource(
+                source=h.winning_source,
+                accession_number=h.winning_accession,
+                shares=h.shares,
+                as_of_date=h.as_of_date,
+                edgar_url=h.winning_edgar_url,
+            )
+        )
+    return replace(rep, dropped_sources=tuple(dropped))
 
 
 def _reconcile_owner_once(holders: list[Holder]) -> dict[SliceCategory, list[Holder]]:

--- a/docs/specs/etl/2026-06-28-insider-nature-overlap-double-count.md
+++ b/docs/specs/etl/2026-06-28-insider-nature-overlap-double-count.md
@@ -1,0 +1,200 @@
+# Insider `ownership_nature` overlap double-count (#788 / #1764 residual)
+
+## Problem
+
+A Section-16 owner's `beneficial` figure is summed on top of the same owner's
+`direct` + `indirect` Form 4/3 holdings in the operator-visible ownership pie,
+double-counting one beneficial position.
+
+Concretely (RNTX, instrument 1050230, accession `0001019231-24-000026`):
+
+| nature | source | source_document_id | shares |
+|--------|--------|--------------------|--------|
+| direct | form4 | `0001019231-24-000026` (plain) | 1,746,549 |
+| beneficial | form4 | `0001019231-24-000026:NDT:7168180` | 1,746,549 |
+
+Both rows are UTIMCO (CIK 0001019231), the same accession, the same share
+count. The rollup renders the owner **twice** at 1,746,549 (= 3,493,098), an
+exact 2× overcount of one position.
+
+### Root cause — two ingest pipelines, two `ownership_nature` vocabularies
+
+`ownership_insiders_current` is MERGE-keyed on `ownership_nature`
+(`app/services/ownership_observations.py:308` etc.), so two rows for one owner
+under different natures coexist. Two pipelines populate it for the **same**
+Form 4 accession under **different** nature taxonomies:
+
+- **XML manifest parser** (`insider_transactions.py:1567`): nature from Form 4
+  Table II **ownership form** — `direct` (D) / `indirect` (I). `source_document_id`
+  = the plain accession.
+- **Bulk SEC insider dataset** (`sec_insider_dataset_ingest.py:_map_relationship`,
+  line 184): nature from the reporting person's **relationship** —
+  officer/director → `direct`, ten-percent-owner → `beneficial`.
+  `source_document_id` = `<accession>:NDT:<rownum>`.
+
+The rollup's per-owner subtotal (`_source_rows_and_total`,
+`ownership_rollup.py:1216`) treats **all** natures under an additive source
+(`form4`/`form3` ∈ `_ADDITIVE_SOURCES`) as additive and **sums** them. The
+dataset's `beneficial` row is therefore added to the XML `direct`/`indirect`
+rows instead of being recognised as a restatement of the same stake.
+
+## Source rule
+
+Settled, already in the repo — `docs/review-prevention-log.md` line 1835 (#905 /
+Rule 13d-3):
+
+> Aggregation has TWO regimes that must not be conflated: **additive** natures
+> (Form 4 / Form 3 `direct` + `indirect` are distinct Section-16 holdings → SUM,
+> the #905 rule) vs **overlapping** restatements (DEF 14A beneficial/voting, a
+> 13D/G beneficial figure, a 13F economic position, and the same owner's figures
+> across channels → all the SAME shares → MAX, never SUM)… check it BOTH within a
+> source's nature rows and across sources for the same identity.
+
+SEC basis: Form 4 Table II reports "Amount of Securities Beneficially Owned
+Following Reported Transaction(s)" per **ownership form** (Direct/Indirect) —
+the additive Section-16 holdings. The reporting person's **relationship**
+(Rule 16a-1 officer/director/10%-owner) is an orthogonal dimension that does
+**not** create an additional holding. A `beneficial` row is the owner's total
+beneficial figure (an overlapping restatement), never a third additive lot.
+
+The current code honours the regime at the **source** level but not the
+**nature** level — exactly the "check it BOTH within a source's nature rows"
+clause it misses.
+
+### Why `beneficial` is never a separate additive lot
+
+The bulk dataset row carries its own `DIRECT_INDIRECT_OWNERSHIP` flag, but the
+ingester derives `ownership_nature` from the reporting person's **relationship**
+flags (`_map_relationship`), not from D/I, and writes the per-transaction
+`SHRS_OWND_FOLWNG_TRANS`. So a 10 %-owner's directly-held lot is **relabelled**
+`beneficial` purely because of the filer's relationship — it is the same
+post-transaction holding the XML path records as `direct`/`indirect`, viewed
+through the relationship lens. It is therefore an overlapping restatement of the
+owner's beneficial total (Rule 13d-3), never a third additive lot. `MAX`, not
+`SUM`, is the rule-defined treatment.
+
+## Full-population verification (dev DB, 2026-06-28)
+
+`ownership_insiders_current`, same `(instrument, accession, shares)`, one CIK,
+≥2 natures:
+
+- **1,581** dup groups (all magnitudes). Nature-pair split:
+  `(direct, indirect)` 1,071 · `(beneficial, direct)` 363 · `(beneficial, indirect)` 147.
+- **1,336 / 1,581** are **dual-pipeline** (both a plain-accession doc AND an
+  `:NDT:` doc present) — the double-ingest collision. 245 are plain-only
+  (XML's own genuine direct+indirect two-axis rows); 0 NDT-only.
+- Operator-visible (rendered through `get_ownership_rollup`, insider slice, a
+  residual same-`(accession, shares)` holder pair) across the 253 audit-candidate
+  instruments: **65 groups / 46 instruments**, **every one** same-CIK
+  cross-nature (Type B). **Zero** were distinct-CIK control groups — `#1764`'s
+  same-accession pass already collapses 100 % of those on the read path, so the
+  `scripts/dq_audit.py` "317 LIVE" distinct-CIK figure is a **false alarm** (it
+  scans the raw write-through table and models only `#1652`'s 1 M floor, not
+  `#1764`'s no-floor same-accession collapse).
+
+### Direction of the fix is monotone (full population, all magnitudes)
+
+Same-`(instrument, cik, accession)` form4/3 groups carrying **both** an additive
+(`direct`/`indirect`) and an overlapping (`beneficial`) nature: **1,206** groups.
+`MAX(additive_sum, overlap_max)` vs the current `additive_sum + overlap_max`:
+
+| relation | groups | new owner subtotal |
+|----------|--------|--------------------|
+| `over == add_sum` | 871 | `add_sum` (drops the doubled restatement) |
+| `over < add_sum` | 141 | `add_sum` (additive rows are the fuller figure) |
+| `over > add_sum` | 194 | `over` (Rule 13d-3 total; XML under-captured) |
+
+In **all 1,206** cases the new subtotal `MAX(add_sum, over)` is **strictly less
+than** the current `add_sum + over`, so the change can only **remove or hold**
+counted shares, never add — it cannot inflate any wedge. The 194 `over > add_sum`
+cases take the larger `beneficial` figure, which is the Rule 13d-3 total
+beneficial ownership (and still < the current sum). This grounds the
+`direct(100)+beneficial(250)->250` rule on the full population, not an example.
+
+## Fix (read-path, no stored-data change)
+
+Match the existing read-path reconciliation pattern (#1640 / #1652 / #1764 —
+collapse at read time, never mutate storage).
+
+1. **Propagate `ownership_nature` onto `Holder`** (currently dropped at
+   `_dedup_by_priority`). New defaulted field `ownership_nature:
+   OwnershipNature | None = None`; set only on the form4/form3 candidate→Holder
+   paths. Frozen-dataclass `replace()` calls preserve it.
+
+2. **Make `_source_rows_and_total` nature-aware for additive sources.** Split an
+   owner's rows for an additive source into:
+   - additive natures `{direct, indirect}` → SUM (preserves #905),
+   - overlapping natures `{beneficial, voting, economic}` → MAX.
+   Owner subtotal = `MAX(additive_sum, overlap_max)`. Display rows = the
+   additive rows when they dominate; else the single overlap representative
+   (dataset-only owners with no XML rows). The subsumed overlap row is **folded
+   into the kept rep's `dropped_sources`** (not silently dropped) so the `:NDT:`
+   dataset provenance stays auditable — the existing read-path passes
+   (#1652/#1764) preserve folded members the same way. Non-additive sources
+   (`def14a`/`13d`/`13g`/`13f`) are unchanged (already MAX via the existing
+   `else` branch).
+
+3. **`scripts/dq_audit.py`** — stop crying wolf: re-point the insider check from
+   the already-`#1764`-collapsed distinct-CIK signature to the genuine same-CIK
+   cross-nature overlap signature this fix addresses, so the feeder tracks the
+   real residual.
+
+### Why read-path, not ingest
+
+The dataset/XML redundancy (same accession written by both pipelines) is a
+latent storage smell, but the nature-vocabulary mismatch would remain a trap
+even after de-duping ingest, and an ingest fix needs a backfill + carries
+parser risk. The read-path regime fix is correct regardless of how many
+pipelines wrote, reversible, and immediately operator-visible. Ingest
+de-duplication is filed as a follow-up.
+
+## Tests
+
+Pure-logic table tests on `_source_rows_and_total` / `_reconcile_owner_once`:
+
+- form4 `direct`(100) + `indirect`(50) → 150 (additive, #905 preserved).
+- form4 `direct`(100) + `beneficial`(100) → 100 (overlap MAX, the bug).
+- form4 `beneficial`(200) only → 200 (dataset-only owner).
+- form4 `direct`(100) + `beneficial`(250) → 250 (overlap exceeds; XML under-captured),
+  with the additive `direct` row preserved in `dropped_sources`.
+- form4 `direct`(100) + `indirect`(50) + `beneficial`(120) → MAX(150, 120) = 150.
+
+Read-path test through the **lossy candidate→Holder boundary** (Codex ckpt-1):
+build `_Candidate` rows mirroring the RNTX collision (one `direct` + one
+`beneficial`, same cik/accession/shares) and assert
+`_dedup_by_priority` → `_reconcile_owner_once` yields ONE insiders contribution
+at the single share value — not a hand-built `Holder` set, so the
+`ownership_nature` propagation through `_dedup_by_priority` is actually exercised.
+- form4 `direct`(100) + `beneficial`(250) → 250 (overlap exceeds; XML under-captured).
+- form4 `direct`(100) + `indirect`(50) + `beneficial`(120) → MAX(150, 120) = 150.
+
+## Verification (DoD 8–11) — executed 2026-06-28
+
+- **Full-population render** (`get_ownership_rollup` over all 253 audit-candidate
+  instruments, residual same-`(accession, shares)` insider holder pairs):
+  **65 → 0** dual-pipeline collisions. The only 2 remaining same-`(accession,
+  shares)` pairs (FWRD) are genuine **same-pipeline** XML `direct`+`indirect`
+  lots (#905-correct SUM, not a collision; 48 such groups exist population-wide).
+- **Both fixes exercised:** B (pipeline de-collision) removes 2,054 dual-pipeline
+  collisions at the candidate read; A (nature regime) does independent work on
+  646 owners with a B-surviving dataset `beneficial` row + a `direct`/`indirect`
+  row.
+- **Live API** (`/instruments/{sym}/ownership-rollup`, uvicorn `--reload`):
+  affected MANE, PVLA + default-panel AAPL, JPM all render insider slices with
+  0 residual pairs. MANE `CHILDS JOHN W` now renders once at 294,117 (was 2×).
+- **#905 regression:** `test_form4_direct_plus_indirect_preserved_single_source`
+  + `test_nature_direct_plus_indirect_sums` green — direct+indirect still SUM.
+- Gates: ruff + pyright clean; fast tier 4688 passed; smoke 135 passed; db-tier
+  ownership suites (owner-reconcile, drillthrough, observations, rollup, 13f-nt,
+  sweep) 95 passed.
+- No backfill (read-path only, raw storage unchanged); no daemon restart (no
+  jobs/parser change).
+
+## Follow-ups (not in scope)
+
+- Ingest redundancy: the bulk dataset and XML manifest both write the same
+  accession (2,723 raw-storage collision groups). The read path now de-collides,
+  but ingest could skip the dataset write when the manifest covers an accession.
+- 48 same-pipeline XML `direct`+`indirect` rows at an exactly-equal share value
+  (e.g. FWRD) — #905 says SUM, but exact equality may hint at a latent XML
+  Table-II parse artifact worth a separate look.

--- a/scripts/dq_audit.py
+++ b/scripts/dq_audit.py
@@ -10,15 +10,20 @@ rollups — within one instrument, a single ``source_accession`` emitting ≥2 r
 with the SAME non-zero ``shares`` but different holders is one beneficial
 position reported by a control chain and counted N times. (Found #1764 this way.)
 
-IMPORTANT — audit the OPERATOR-VISIBLE layer, not just the raw table. The
-``/ownership-rollup`` endpoint already collapses LARGE same-value control groups
-via ``ownership_rollup._reconcile_insider_control_groups`` (#1652), but only
-ABOVE a magnitude floor (``_INSIDER_GROUP_MIN_SHARES`` = 1,000,000). So a raw
-``*_current`` scan over-reports massively (≥1M groups are fixed downstream); the
-genuine live bug is the SUB-floor tail. We split the count on that floor and flag
-only the sub-floor subset as the operator-visible candidate. (Lesson: a feeder
-that scans the wrong layer cries wolf — #1764 first looked like 74.5B shares;
-the real operator-visible figure is ~387M.)
+IMPORTANT — this raw ``*_current`` scan groups by ``source_accession``, which is
+exactly the signature the read path collapses with NO floor: ``#1764``
+(insiders + blockholders, same-accession control chain) and ``#788`` (insiders,
+dual-pipeline same-cik nature collision). So for insiders/blockholders the raw
+"LIVE" figure is structurally a FALSE ALARM — every same-accession dup is
+collapsed before the operator sees it. (Post-mortem: a 2026-06-28 full-population
+investigation found the raw scan's 317 insider "LIVE" groups were 100% collapsed
+by ``#1764``; the genuine residual was a DIFFERENT, dual-pipeline signature, fixed
+by ``#788``.) A non-zero raw count for those tables is therefore reported as
+``read-path-collapsed`` and MUST be confirmed by RENDERING the rollup
+(``get_ownership_rollup`` → a residual same-``(accession, shares)`` insider holder
+pair that is NOT a genuine ``#905`` direct+indirect lot) before it is filed.
+The ``_INSIDER_GROUP_MIN_SHARES`` = 1,000,000 floor is ``#1652``'s (the fuzzy
+cross-accession pass); ``#1764``/``#788`` have no floor.
 
 Run::
 
@@ -90,34 +95,99 @@ def _control_group_dup(
     }
 
 
+def _dual_pipeline_insider_collision(conn: psycopg.Connection[object]) -> dict[str, object]:
+    """Raw-storage sentinel for the #788 dual-pipeline insider collision.
+
+    The same Form 4/3 ``(holder_cik, source_accession)`` written by BOTH the XML
+    manifest parser (bare-accession ``source_document_id``) AND the bulk SEC
+    insider dataset (``:NDT:`` / ``:NDH:`` marker) coexists under two
+    ``ownership_nature`` values because nature is in the MERGE key — one stake
+    stored 2×. The read-path rollup now de-collides this (#788,
+    ``_collect_canonical_holders_from_current``: drop the dataset row when an XML
+    row shares the accession), so this is a STORAGE-redundancy metric, NOT an
+    operator-visible bug — useful only to watch the raw redundancy trend / spot
+    an ingest path that should stop double-writing."""
+    sql = """
+        SELECT count(*) AS groups, count(DISTINCT instrument_id) AS instruments
+        FROM (
+            SELECT instrument_id, holder_cik, source_accession
+            FROM ownership_insiders_current
+            WHERE source IN ('form4', 'form3') AND shares > 0 AND holder_cik IS NOT NULL
+            GROUP BY 1, 2, 3
+            HAVING bool_or(source_document_id ~ ':(NDT|NDH):')
+               AND bool_or(source_document_id !~ ':(NDT|NDH):')
+               AND count(DISTINCT ownership_nature) > 1
+        ) g
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql)
+        row = cur.fetchone() or {}
+    return {
+        "check": "dual_pipeline_insider_collision",
+        "groups": int(row.get("groups", 0)),
+        "instruments": int(row.get("instruments", 0)),
+    }
+
+
 def main() -> int:
     assert_dev_environment()  # read-only, but dev scripts never touch a remote DB (#1765)
     findings: list[dict[str, object]] = []
     # autocommit so one check's error (e.g. a missing column on a schema change)
     # doesn't poison the transaction for the remaining checks.
+    dual_pipeline: dict[str, object] = {}
     with psycopg.connect(settings.database_url, autocommit=True) as conn:
         for table, holder_col, share_col in _OWNERSHIP_CURRENT:
             try:
                 findings.append(_control_group_dup(conn, table, holder_col, share_col))
             except psycopg.Error as exc:
                 findings.append({"check": "control_group_dup", "table": table, "error": str(exc)})
+        try:
+            dual_pipeline = _dual_pipeline_insider_collision(conn)
+        except psycopg.Error as exc:
+            dual_pipeline = {"check": "dual_pipeline_insider_collision", "error": str(exc)}
 
     print("=== DQ audit — control-group double-count in ownership rollups ===")
-    print("(live = operator-visible, below the #1652 collapse floor; total = raw table incl. downstream-collapsed)")
+    print("(raw-table scan; the read-path rollup collapses same-accession dups — see note below)")
+    # The same-accession distinct-holder signature these checks count is exactly
+    # what the read path collapses with NO floor: #1764 (insiders + blockholders,
+    # same accession) and #788 (insiders, dual-pipeline same cik). So a non-zero
+    # raw figure here is NOT operator-visible — it must be confirmed by RENDERING
+    # the rollup (residual same-(accession, shares) holder pair), never filed off
+    # the raw count. (#1764 post-mortem: the raw scan reported 317 phantom insider
+    # "LIVE" groups that the render showed were 100% collapsed.)
     for f in findings:
         if "error" in f:
             print(f"  {f['table']}: ERROR {f['error']}")
             continue
         live = int(f["live_groups"])  # type: ignore[call-overload]
-        flag = "  ⚠ CANDIDATE" if live > 0 else "  ok"
+        # insiders + blockholders same-accession dups are read-path collapsed
+        # (#1764/#788); only institutions (no same-accession collapse pass) is a
+        # direct candidate signal.
+        collapsed = f["table"] in ("ownership_insiders_current", "ownership_blockholders_current")
+        if collapsed:
+            flag = "  read-path-collapsed"
+        else:
+            flag = "  ⚠ CANDIDATE" if live > 0 else "  ok"
         print(
-            f"{flag}  {f['table']}: LIVE {live} groups / "
+            f"{flag}  {f['table']}: sub-1M {live} groups / "
             f"{f['live_instruments']} instruments / {f['live_overcount']:,.0f} shares "
-            f"(total incl. collapsed: {f['total_groups']} groups / {f['total_overcount']:,.0f})"
+            f"(raw incl. ≥1M: {f['total_groups']} groups / {f['total_overcount']:,.0f})"
         )
+
+    if "error" in dual_pipeline:
+        print(f"  dual_pipeline_insider_collision: ERROR {dual_pipeline['error']}")
+    else:
+        print(
+            f"  storage-sentinel  dual-pipeline insider collision (read-path collapsed by #788): "
+            f"{dual_pipeline['groups']} groups / {dual_pipeline['instruments']} instruments "
+            f"(raw redundancy; not operator-visible)"
+        )
+
     print(
-        "\nNon-zero LIVE groups = a candidate ticket. Confirm the signature on the "
-        "full population + cite the source rule before filing (see #1764)."
+        "\nFor insiders/blockholders: confirm any candidate by RENDERING the rollup "
+        "(get_ownership_rollup → residual same-(accession, shares) insider holders that "
+        "are NOT genuine #905 direct+indirect) and cite the source rule before filing "
+        "(see #1764, #788)."
     )
     return 0
 

--- a/tests/test_ownership_owner_reconcile.py
+++ b/tests/test_ownership_owner_reconcile.py
@@ -12,8 +12,11 @@ from datetime import date
 from decimal import Decimal
 
 from app.services.ownership_rollup import (
+    _PRIORITY_RANK,
     Holder,
     SourceTag,
+    _Candidate,
+    _dedup_by_priority,
     _reconcile_owner_once,
     _source_rows_and_total,
 )
@@ -27,6 +30,7 @@ def _h(
     *,
     filer_type: str | None = None,
     accession: str = "0000000000-00-000000",
+    nature: str | None = None,
 ) -> Holder:
     return Holder(
         filer_cik=cik,
@@ -39,6 +43,7 @@ def _h(
         as_of_date=date(2026, 1, 1),
         filer_type=filer_type,
         dropped_sources=(),
+        ownership_nature=nature,
     )
 
 
@@ -214,6 +219,96 @@ def test_source_rows_and_total_helper() -> None:
     d14 = [_h("c", "n", "def14a", "5000000"), _h("c", "n", "def14a", "4000000")]
     rows, total = _source_rows_and_total("def14a", d14)
     assert len(rows) == 1 and total == Decimal("5000000")  # overlapping → MAX rep only
+
+
+# --- #788: within-source additive (direct/indirect) vs overlapping (beneficial)
+#     nature regime. ``beneficial`` is a Rule-13d-3 restatement (MAX), never a
+#     third additive Section-16 lot (prevention-log 1835 / #905). ----------------
+
+
+def test_nature_direct_plus_indirect_sums() -> None:
+    """#905 preserved: direct + indirect are distinct lots → SUM."""
+    rows, total = _source_rows_and_total(
+        "form4", [_h("c", "n", "form4", "100", nature="direct"), _h("c", "n", "form4", "50", nature="indirect")]
+    )
+    assert total == Decimal("150")
+    assert sum((h.shares for h in rows), Decimal(0)) == Decimal("150")
+
+
+def test_nature_beneficial_equal_to_direct_not_doubled() -> None:
+    """The bug: dataset ``beneficial`` == XML ``direct`` for one stake → counted
+    ONCE (MAX), the beneficial restatement folded as provenance, not summed."""
+    rows, total = _source_rows_and_total(
+        "form4", [_h("c", "n", "form4", "100", nature="direct"), _h("c", "n", "form4", "100", nature="beneficial")]
+    )
+    assert total == Decimal("100")
+    assert len(rows) == 1 and rows[0].ownership_nature == "direct"
+    # beneficial restatement preserved for audit, not dropped silently.
+    assert any(d.source == "form4" for d in rows[0].dropped_sources)
+
+
+def test_nature_beneficial_only_is_the_figure() -> None:
+    """Dataset-only owner (no XML rows): the sole ``beneficial`` row stands."""
+    rows, total = _source_rows_and_total("form4", [_h("c", "n", "form4", "200", nature="beneficial")])
+    assert total == Decimal("200") and len(rows) == 1
+
+
+def test_nature_beneficial_exceeds_additive_wins_and_folds() -> None:
+    """``beneficial`` (250) > direct (100): XML under-captured → take the
+    Rule-13d-3 total, fold the additive lot as provenance."""
+    rows, total = _source_rows_and_total(
+        "form4", [_h("c", "n", "form4", "100", nature="direct"), _h("c", "n", "form4", "250", nature="beneficial")]
+    )
+    assert total == Decimal("250")
+    assert len(rows) == 1 and rows[0].shares == Decimal("250")
+    assert any(d.shares == Decimal("100") for d in rows[0].dropped_sources)
+
+
+def test_nature_additive_sum_beats_smaller_beneficial() -> None:
+    """direct(100) + indirect(50) = 150 dominates a 120 beneficial restatement."""
+    rows, total = _source_rows_and_total(
+        "form4",
+        [
+            _h("c", "n", "form4", "100", nature="direct"),
+            _h("c", "n", "form4", "50", nature="indirect"),
+            _h("c", "n", "form4", "120", nature="beneficial"),
+        ],
+    )
+    assert total == Decimal("150")
+
+
+def _cand(cik: str, source: SourceTag, shares: str, *, nature: str, accession: str, row_id: int) -> _Candidate:
+    return _Candidate(
+        source=source,
+        priority_rank=_PRIORITY_RANK[source],
+        filer_cik=cik,
+        filer_name="Insider Same",
+        filer_type=None,
+        shares=Decimal(shares),
+        as_of_date=date(2026, 1, 1),
+        accession_number=accession,
+        source_row_id=row_id,
+        ownership_nature=nature,
+    )
+
+
+def test_readpath_candidate_to_owner_once_collapses_cross_nature() -> None:
+    """Read-path test through the lossy candidate→Holder boundary (Codex ckpt-1):
+    a dual-pipeline collision (one ``direct`` + one ``beneficial`` row, same cik /
+    accession / shares — the RNTX signature) must resolve to ONE insiders
+    contribution at the single value, not a summed 2×. Exercises
+    ``ownership_nature`` propagation through ``_dedup_by_priority``."""
+    cands = [
+        _cand("0001019231", "form4", "1746549", nature="direct", accession="acc-1", row_id=1),
+        _cand("0001019231", "form4", "1746549", nature="beneficial", accession="acc-1", row_id=2),
+    ]
+    holders = _dedup_by_priority(cands)
+    # _dedup_by_priority keeps both natures (key includes nature) and carries it.
+    assert {h.ownership_nature for h in holders} == {"direct", "beneficial"}
+    out = _reconcile_owner_once(holders)
+    insiders = out["insiders"]
+    assert len(insiders) == 1
+    assert insiders[0].shares == Decimal("1746549")
 
 
 def test_pure_blockholder_unchanged() -> None:


### PR DESCRIPTION
## Problem

The operator-visible insider ownership pie counted one Section-16 beneficial position **2×** for **65 instruments / 46 owners** (e.g. RNTX `UNIVERSITY OF TEXAS/TEXAS AM INVESTMENT MANAGEMENT CO` at 1,746,549 → 3,493,098; MANE `CHILDS JOHN W` at 294,117 → 588,234).

## Root cause

`ownership_insiders_current` is MERGE-keyed on `ownership_nature`, and **two ingest pipelines write the SAME Form 4/3 accession under different nature vocabularies**:
- **XML manifest parser** (`insider_transactions.py`): nature from Form 4 Table II ownership form — `direct`/`indirect`. `source_document_id` = bare accession.
- **Bulk SEC insider dataset** (`sec_insider_dataset_ingest._map_relationship`): nature from the reporting person's relationship — officer/director→`direct`, 10%-owner→`beneficial`. `source_document_id` = `<accn>:NDT:<sk>` (Form-4 txn) / `<accn>:NDH:<sk>` (Form-3 holding).

Both rows survive (nature is in the MERGE key) and `_source_rows_and_total` summed all natures under an additive source → one stake counted twice.

## Source rule

`docs/review-prevention-log.md:1835` / #905 / Rule 13d-3: `direct`+`indirect` are distinct **additive** Section-16 holdings (SUM); a `beneficial` figure for the same shares is an **overlapping** restatement (MAX, never SUM). The bulk dataset relabels a 10%-owner's directly-held lot `beneficial` purely from the relationship flag — never a separate lot.

## Fix (read-path only — no stored-data change, no backfill)

Two independent layers, both matching the established read-path reconciliation pattern (#1640/#1652/#1764):

- **B — dual-pipeline de-collision** (`_collect_canonical_holders_from_current`): drop the dataset row (`:NDT:`/`:NDH:`) when an XML-manifest row shares `(holder_cik, source_accession)`. The manifest is the authoritative full-Table-II parse; the dataset only fills accessions the manifest never parsed. Removes **2,054** same-accession collisions.
- **A — within-source nature regime** (`_source_rows_and_total`): SUM `direct`+`indirect`, MAX an overlapping `beneficial`/`voting`/`economic` row. Propagates `ownership_nature` onto `Holder` (was dropped at dedup). Owner subtotal = `MAX(additive_sum, overlap_max)` — **monotone**: full-population-verified it can only remove or hold a count, never inflate. Fires on **646** cross-accession owners. Subsumed restatements fold into `dropped_sources` (auditable).

Also `scripts/dq_audit.py`: its same-accession raw scan is fully read-path-collapsed (#1764 + #788), so the **317 insider "LIVE" figure was a false alarm**. Reframed to `read-path-collapsed` + a dual-pipeline storage sentinel + a render-before-file instruction.

## Full-population verification (dev DB, 2026-06-28)

| check | before | after |
|-------|--------|-------|
| dual-pipeline collisions (render, 253 candidates) | 65 groups / 46 instr | **0** |
| remaining same-(accession,shares) pairs | — | 2 (FWRD), genuine same-pipeline #905 direct+indirect |
| monotonicity (1,206 both-nature groups) | — | `MAX(add,over) < add+over` in **all** |

- Live API: MANE, PVLA, AAPL, JPM render insider slices with 0 residual pairs; MANE `CHILDS JOHN W` once at 294,117.
- #905 SUM preserved (`test_form4_direct_plus_indirect_preserved_single_source`, `test_nature_direct_plus_indirect_sums`).
- Gates: ruff + pyright clean; fast tier 4688 passed; smoke 135 passed; db-tier ownership suites 95 passed.
- Codex ckpt-1 (spec) + ckpt-2 (branch) run; 2 LOWs fixed (provenance dedupe key incl. shares; audit label).

## Security model

Read-path only; no new endpoints, no auth surface, no user-controlled input. SQL uses parameterised `instrument_id`; the `~ ':(NDT|NDH):'` regex is a static literal. Raw storage is untouched (reversible).

## Tradeoffs / follow-ups (not in scope)

- Ingest redundancy (2,723 raw collision groups) — the read path de-collides; an ingest-side skip is a possible follow-up.
- 48 same-pipeline XML `direct`+`indirect` rows at exactly-equal share value (FWRD) — #905 says SUM, but exact equality may hint at a latent Table-II parse artifact worth a separate look.

Spec: `docs/specs/etl/2026-06-28-insider-nature-overlap-double-count.md`

Part of #788 (insider double-count residual) — partial fix, epic stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)