### PR TITLE
fix(#1805): de-collide dual-pipeline insider rows at the _current refresh layer

### DIFF
--- a/app/services/ownership_observations.py
+++ b/app/services/ownership_observations.py
@@ -59,7 +59,7 @@ from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Any, Literal, TypeGuard
+from typing import Any, Final, Literal, TypeGuard
 from uuid import UUID
 
 import psycopg
@@ -229,6 +229,42 @@ def record_insider_observation(
         )
 
 
+# Dual-pipeline insider de-collision (#1805). The same Form 4/3 accession is written
+# to ``ownership_insiders_observations`` by BOTH the XML manifest parser
+# (bare-accession ``source_document_id``, Table-II ``direct``/``indirect``) AND the
+# bulk SEC insider dataset (``:NDT:``/``:NDH:`` marker, relationship-relabelled
+# nature). Because nature is in the DISTINCT-ON key the two survive as distinct
+# ``_current`` rows — one stake stored twice. This filter relocates #1804 read-path
+# fix B (``ownership_rollup._collect_canonical_holders_from_current``) to storage so
+# ``_current`` carries one authoritative row set instead of leaving every reader to
+# re-de-collide.
+#
+# CRITICAL: it filters the ``winners`` CTE — the post-DISTINCT-ON survivor set that
+# IS the future ``_current`` — NOT the raw observations. Fix B keys on the rows that
+# actually land in ``_current``; a pre-DISTINCT-ON filter on observations would also
+# drop a ``:NDT:`` row whose plain sibling LOST its own ``ownership_nature`` slot to a
+# newer filing (so the plain row is in observations but not ``_current``) — a row fix
+# B keeps and the rollup counts, changing operator figures in BOTH directions (dev:
+# JPM/PFE down, TM up). Mirrors fix B exactly (``holder_cik IS NOT DISTINCT FROM`` +
+# same accession), so the removed set is provably identical to fix B's read-path drop
+# (full-pop 3082 == 3082, symmetric diff 0). Source rule: prevention-log 1835 / #905 /
+# Rule 13d-3. Used in both refresh functions after a CTE named ``winners`` exposing
+# ``instrument_id, holder_cik, source_accession, source_document_id``.
+# Spec: docs/specs/etl/2026-06-28-insider-dual-pipeline-decollision-refresh.md.
+_INSIDER_DUAL_PIPELINE_DECOLLISION: Final[str] = """
+            WHERE NOT (
+                w.source_document_id ~ ':(NDT|NDH):'
+                AND EXISTS (
+                    SELECT 1 FROM winners p
+                     WHERE p.instrument_id = w.instrument_id
+                       AND p.holder_cik IS NOT DISTINCT FROM w.holder_cik
+                       AND p.source_accession = w.source_accession
+                       AND p.source_document_id !~ ':(NDT|NDH):'
+                )
+            )
+"""
+
+
 def refresh_insiders_current(
     conn: psycopg.Connection[Any],
     *,
@@ -272,36 +308,40 @@ def refresh_insiders_current(
         wm_row = cur.fetchone()
         watermark = wm_row[0] if wm_row else None
         cur.execute(
-            """
+            f"""
             MERGE INTO ownership_insiders_current AS tgt
             USING (
-                SELECT DISTINCT ON (holder_identity_key, ownership_nature)
-                    instrument_id, holder_cik, holder_name, holder_identity_key,
-                    ownership_nature, source, source_document_id, source_accession,
-                    source_url, filed_at, period_start, period_end, shares
-                FROM ownership_insiders_observations
-                WHERE instrument_id = %(iid)s AND known_to IS NULL
-                ORDER BY
-                    holder_identity_key,
-                    ownership_nature,
-                    CASE source
-                        WHEN 'form4'    THEN 1
-                        WHEN 'form3'    THEN 2
-                        WHEN '13d'      THEN 3
-                        WHEN '13g'      THEN 3
-                        WHEN 'def14a'   THEN 4
-                        WHEN '13f'      THEN 5
-                        WHEN 'nport'    THEN 6
-                        WHEN 'ncsr'     THEN 6
-                        WHEN 'xbrl_dei' THEN 7
-                        WHEN '10k_note' THEN 8
-                        WHEN 'finra_si' THEN 9
-                        ELSE 10
-                    END ASC,
-                    period_end DESC,
-                    filed_at DESC,
-                    source ASC,
-                    source_document_id ASC
+                WITH winners AS (
+                    SELECT DISTINCT ON (holder_identity_key, ownership_nature)
+                        instrument_id, holder_cik, holder_name, holder_identity_key,
+                        ownership_nature, source, source_document_id, source_accession,
+                        source_url, filed_at, period_start, period_end, shares
+                    FROM ownership_insiders_observations
+                    WHERE instrument_id = %(iid)s AND known_to IS NULL
+                    ORDER BY
+                        holder_identity_key,
+                        ownership_nature,
+                        CASE source
+                            WHEN 'form4'    THEN 1
+                            WHEN 'form3'    THEN 2
+                            WHEN '13d'      THEN 3
+                            WHEN '13g'      THEN 3
+                            WHEN 'def14a'   THEN 4
+                            WHEN '13f'      THEN 5
+                            WHEN 'nport'    THEN 6
+                            WHEN 'ncsr'     THEN 6
+                            WHEN 'xbrl_dei' THEN 7
+                            WHEN '10k_note' THEN 8
+                            WHEN 'finra_si' THEN 9
+                            ELSE 10
+                        END ASC,
+                        period_end DESC,
+                        filed_at DESC,
+                        source ASC,
+                        source_document_id ASC
+                )
+                SELECT w.* FROM winners w
+                {_INSIDER_DUAL_PIPELINE_DECOLLISION}
             ) AS src
             ON tgt.instrument_id = %(iid)s
                AND tgt.holder_identity_key = src.holder_identity_key
@@ -1933,37 +1973,41 @@ def refresh_insiders_current_batch(
         )
         watermarks: dict[int, datetime | None] = {int(r[0]): r[1] for r in cur.fetchall()}
         cur.execute(
-            """
+            f"""
             MERGE INTO ownership_insiders_current AS tgt
             USING (
-                SELECT DISTINCT ON (instrument_id, holder_identity_key, ownership_nature)
-                    instrument_id, holder_cik, holder_name, holder_identity_key,
-                    ownership_nature, source, source_document_id, source_accession,
-                    source_url, filed_at, period_start, period_end, shares
-                FROM ownership_insiders_observations
-                WHERE instrument_id = ANY(%(ids)s::bigint[]) AND known_to IS NULL
-                ORDER BY
-                    instrument_id,
-                    holder_identity_key,
-                    ownership_nature,
-                    CASE source
-                        WHEN 'form4'    THEN 1
-                        WHEN 'form3'    THEN 2
-                        WHEN '13d'      THEN 3
-                        WHEN '13g'      THEN 3
-                        WHEN 'def14a'   THEN 4
-                        WHEN '13f'      THEN 5
-                        WHEN 'nport'    THEN 6
-                        WHEN 'ncsr'     THEN 6
-                        WHEN 'xbrl_dei' THEN 7
-                        WHEN '10k_note' THEN 8
-                        WHEN 'finra_si' THEN 9
-                        ELSE 10
-                    END ASC,
-                    period_end DESC,
-                    filed_at DESC,
-                    source ASC,
-                    source_document_id ASC
+                WITH winners AS (
+                    SELECT DISTINCT ON (instrument_id, holder_identity_key, ownership_nature)
+                        instrument_id, holder_cik, holder_name, holder_identity_key,
+                        ownership_nature, source, source_document_id, source_accession,
+                        source_url, filed_at, period_start, period_end, shares
+                    FROM ownership_insiders_observations
+                    WHERE instrument_id = ANY(%(ids)s::bigint[]) AND known_to IS NULL
+                    ORDER BY
+                        instrument_id,
+                        holder_identity_key,
+                        ownership_nature,
+                        CASE source
+                            WHEN 'form4'    THEN 1
+                            WHEN 'form3'    THEN 2
+                            WHEN '13d'      THEN 3
+                            WHEN '13g'      THEN 3
+                            WHEN 'def14a'   THEN 4
+                            WHEN '13f'      THEN 5
+                            WHEN 'nport'    THEN 6
+                            WHEN 'ncsr'     THEN 6
+                            WHEN 'xbrl_dei' THEN 7
+                            WHEN '10k_note' THEN 8
+                            WHEN 'finra_si' THEN 9
+                            ELSE 10
+                        END ASC,
+                        period_end DESC,
+                        filed_at DESC,
+                        source ASC,
+                        source_document_id ASC
+                )
+                SELECT w.* FROM winners w
+                {_INSIDER_DUAL_PIPELINE_DECOLLISION}
             ) AS src
             ON tgt.instrument_id = src.instrument_id
                AND tgt.holder_identity_key = src.holder_identity_key

--- a/docs/specs/etl/2026-06-28-insider-dual-pipeline-decollision-refresh.md
+++ b/docs/specs/etl/2026-06-28-insider-dual-pipeline-decollision-refresh.md
@@ -1,0 +1,131 @@
+# Insider dual-pipeline de-collision — relocate #1804 fix B to the `_current` refresh layer (#1805)
+
+Follow-up to #1804 (merged). This does **not** introduce a new ownership
+data-treatment rule. It relocates #1804's already-shipped, already-verified
+same-accession de-collision (read-path fix B) from the read path to the
+`_current` refresh layer, so the stored snapshot no longer carries the redundant
+row. **Provably behaviour-equivalent** to current `main` (proof below).
+
+## Problem (stored redundancy only)
+
+The same Form 4/3 accession is written to `ownership_insiders_observations` by BOTH:
+- the XML manifest parser — bare-accession `source_document_id`, nature from Table II
+  (`direct` / `indirect`); and
+- the bulk SEC insider dataset (`sec_insider_dataset_ingest`) — `:NDT:`/`:NDH:`
+  marker, nature relabelled from the reporting person's relationship
+  (`officer/director→direct`, `10%-owner→beneficial`).
+
+`refresh_insiders_current` projects observations into `_current` with
+`DISTINCT ON (holder_identity_key, ownership_nature)`. The two pipelines emit
+**different** natures for the same stake, so both survive the DISTINCT ON and land
+as two `_current` rows. #1804's read-path fix B already de-collides this at read
+(the operator-visible figure is correct), but `_current` storage still carries both.
+
+Dev DB 2026-06-28: **2726 groups / 1508 instruments** (`scripts/dq_audit.py`
+dual-pipeline storage sentinel).
+
+## Source rule (unchanged from #1804)
+
+prevention-log 1835 / #905 / Rule 13d-3. For the **same accession**, the dataset's
+relationship-derived `beneficial` relabel restates the *same Table-II shares the XML
+parse already captured in full* — an overlapping restatement, not a second holding.
+#1804 fix B settled the treatment: drop the dataset (`:NDT:`/`:NDH:`) row when an
+XML-manifest row shares `(holder, accession)`; the XML parse is the authoritative
+full-Table-II view of **that filing**. This spec does not re-derive that rule — it
+moves where it is enforced. The **cross-accession** additive-vs-overlap regime
+(`MAX(additive_sum, overlap_max)`, fix A in `_source_rows_and_total`) is a separate,
+untouched code path that this change does not enter.
+
+## Fix — refresh layer, on the post-DISTINCT-ON winner set
+
+Both refresh functions wrap their DISTINCT-ON projection in a `winners` CTE (the rows
+that WILL become `_current`), then drop a `:NDT:`/`:NDH:` winner whenever a
+plain-accession (`!~ ':(NDT|NDH):'`) winner exists for the same
+`(holder_cik, source_accession)` — `holder_cik IS NOT DISTINCT FROM`, mirroring fix B
+exactly. Dropped rows never reach `_current`; existing `_current` collision rows are
+deleted by the MERGE's `WHEN NOT MATCHED BY SOURCE → DELETE` on the next refresh.
+
+Identical filter in both refresh functions → extracted to one module SQL constant
+(`_INSIDER_DUAL_PIPELINE_DECOLLISION`) applied as `SELECT w.* FROM winners w {filter}`.
+
+### Why the winner set, NOT raw observations (load-bearing)
+
+Fix B keys on `_current` — the **post-DISTINCT-ON survivors**. A pre-DISTINCT-ON
+filter on the raw observations is **stricter than fix B**: it also drops a `:NDT:`
+row whose same-accession plain sibling exists in observations but **lost its own
+`ownership_nature` DISTINCT-ON slot to a newer filing** (so the plain row is in
+observations but NOT `_current`). Fix B keeps that `:NDT:` row (no plain sibling in
+`_current`) and the rollup counts it. Dropping it changes operator-visible insider
+figures in BOTH directions — measured on dev: 506 such rows across hundreds of
+instruments, e.g. JPM 9,142,457 → 9,057,482, PFE 2,383,995 → 1,672,336, TM
+25,906,827 → 26,029,681 (holders 28 → 18). Filtering the `winners` CTE keyed on the
+future-`_current` rows reproduces fix B's drop set exactly (Codex ckpt-2 P2).
+
+### Why refresh, not ingest (conscious tradeoff)
+
+- **Ordering-independent.** The MERGE re-derives from the full current observation
+  set each run, so the result is the same whether the dataset or the XML manifest
+  landed first. An ingest-time "skip if XML exists" check leaks the redundant row
+  whenever the dataset lands first (historical bulk) and the XML manifest lands
+  later.
+- **No immutable-observation deletion.** `*_observations` stays a complete
+  append-only audit trail (both pipelines' rows preserved). The operative storage the
+  rollup reads is `_current`; that is what "one authoritative row set" means here.
+  Obs-level redundancy is benign (never read directly by the rollup) and is out of
+  scope.
+
+### Read path retained
+
+#1804's read-path fix B is **kept** as tested defense-in-depth — after this change it
+provably matches nothing new (the rows are gone from `_current`), but both layers are
+pinned by a test so neither can silently drift. Fix A (`_source_rows_and_total`) is
+untouched.
+
+## Full-population verification (dev DB 2026-06-28)
+
+**1. Behaviour-equivalence (the load-bearing proof).** The set of `_current`
+`:NDT:`/`:NDH:` rows the winner-set filter removes is **identical** to the set #1804
+fix B drops at read: **3082 == 3082, symmetric difference 0** (the `_current` rows
+that have a plain `_current` sibling on the same `(holder, accession)`). Because every
+removed row is already read-path-dropped on `main` today, it is counted in **no**
+rollup total — so removing it from storage changes no operator-visible figure. This
+holds the share-total invariant directly (not via row-existence): the rendered owner
+subtotal cannot move when the removed rows were never summed.
+
+**2. Fix A's cross-accession `beneficial` MAX cases are not in the removal set.** Those
+`beneficial` rows have no same-accession plain XML sibling (that is why fix B keeps
+them and fix A MAXes them), so the `(holder, accession)`-scoped predicate does not
+match them — they survive into `_current` unchanged.
+
+**3. Superseded-sibling rows preserved (the Codex ckpt-2 regression).** For a fresh
+sample of edge instruments (a `:NDT:` whose plain sibling is superseded out of
+`_current`) the full rollup is **identical** before/after a winner-set refresh
+(SMCI / LVS / EA). Five instruments mistakenly cleaned by the earlier
+observations-keyed prototype (JPM / MRK / PFE / C / TM) were restored by the
+winner-set refresh to their **exact** original insider figures.
+
+**4. Key.** The filter mirrors fix B's `holder_cik IS NOT DISTINCT FROM` + accession
+on the winner set. `(holder_cik, accession)` and `(holder_identity_key, accession)`
+partition the `_current` collision set identically (3082 rows each), so the choice is
+immaterial to the removed set.
+
+## Backfill
+
+`scripts/backfill_1805_insider_decollision.py` — re-runs
+`refresh_insiders_current_batch` over the instruments whose `_current` carries a
+collision (a `:NDT:`/`:NDH:` row with a plain `_current` sibling on the same
+`(holder_cik, accession)` — exactly the set the winner-set filter removes).
+Idempotent; no re-ingest, observations unchanged. The repair sweep would NOT pick
+these up (no new observations → watermark already current), so an explicit forced
+refresh is required. Target: sentinel → 0.
+
+## Tests
+
+- `test_ownership_refresh_writer_merge.py`:
+  - colliding `:NDT:` + plain pair on one accession → after refresh `_current` holds
+    only the plain row; a dataset-only `:NDT:` (distinct holder, no plain sibling) is
+    retained; the batch path behaves identically.
+  - **regression guard (Codex ckpt-2):** a `:NDT:` `beneficial` whose same-accession
+    plain `direct` sibling is superseded out of `_current` by a newer `direct` filing
+    is **kept** — pins the winner-set semantics so a future edit cannot silently
+    revert to the figure-changing observations-keyed filter.

--- a/scripts/backfill_1805_insider_decollision.py
+++ b/scripts/backfill_1805_insider_decollision.py
@@ -1,0 +1,103 @@
+"""Backfill: clean the dual-pipeline insider collision out of ``_current`` (#1805).
+
+#1804 fixed the operator-visible double-count at the read path; #1805 relocates the
+same-accession de-collision into ``refresh_insiders_current`` so ``ownership_insiders_current``
+stores ONE authoritative row set per ``(holder, accession)`` instead of leaving both
+the XML-manifest row and the bulk-dataset ``:NDT:``/``:NDH:`` row in place.
+
+Existing ``_current`` rows are only cleaned when an instrument is re-refreshed. The
+``ownership_observations_repair`` sweep will NOT pick these up on its own — no new
+observations landed, so each instrument's ``ownership_refresh_state`` watermark is
+already current. This script forces a refresh for every instrument that currently
+carries a dual-pipeline collision row, deleting the redundant rows via the MERGE's
+``WHEN NOT MATCHED BY SOURCE → DELETE``.
+
+Idempotent: re-running refreshes the same instruments; observations are unchanged, so a
+second run is a no-op (and re-running the WHOLE script after new ingest just cleans any
+newly-collided instruments).
+
+Usage:
+    uv run python scripts/backfill_1805_insider_decollision.py            # refresh affected
+    uv run python scripts/backfill_1805_insider_decollision.py --dry-run  # count only
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import psycopg
+
+from app.config import settings
+from app.services.ownership_observations import refresh_insiders_current_batch
+
+logger = logging.getLogger("backfill_1805")
+
+# Affected = instruments where a ``:NDT:``/``:NDH:`` row in ``_current`` has a
+# plain-accession (XML) sibling ALSO in ``_current`` for the same
+# ``(holder_cik, source_accession)``. This is exactly the set the refresh predicate
+# removes — it filters the post-DISTINCT-ON ``winners`` set (the future ``_current``)
+# keyed on ``holder_cik IS NOT DISTINCT FROM`` + accession, mirroring #1804 read-path
+# fix B. So scanning ``_current`` finds precisely the instruments a refresh would
+# change. (An observations-keyed scan would over-select: it flags rows whose plain
+# sibling was superseded out of ``_current`` within its ``ownership_nature`` slot —
+# rows the predicate correctly KEEPS, since dropping them changes operator figures.)
+_AFFECTED_SQL = """
+    SELECT DISTINCT oc.instrument_id
+      FROM ownership_insiders_current oc
+     WHERE oc.source_document_id ~ ':(NDT|NDH):'
+       AND EXISTS (
+           SELECT 1 FROM ownership_insiders_current x
+            WHERE x.instrument_id = oc.instrument_id
+              AND x.holder_cik IS NOT DISTINCT FROM oc.holder_cik
+              AND x.source_accession = oc.source_accession
+              AND x.source_document_id !~ ':(NDT|NDH):'
+       )
+     ORDER BY oc.instrument_id
+"""
+
+_CHUNK = 200
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="count affected instruments, do not refresh")
+    args = ap.parse_args()
+
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_AFFECTED_SQL)
+            ids = [int(r[0]) for r in cur.fetchall()]
+        logger.info("affected instruments: %d", len(ids))
+        if args.dry_run:
+            return 0
+
+        done = 0
+        for i in range(0, len(ids), _CHUNK):
+            chunk = ids[i : i + _CHUNK]
+            refresh_insiders_current_batch(conn, instrument_ids=chunk)
+            conn.commit()
+            done += len(chunk)
+            logger.info("refreshed %d / %d", done, len(ids))
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT count(*) FROM (
+                    SELECT 1 FROM ownership_insiders_current
+                     WHERE source IN ('form4', 'form3') AND shares > 0 AND holder_cik IS NOT NULL
+                     GROUP BY instrument_id, holder_cik, source_accession
+                    HAVING bool_or(source_document_id ~ ':(NDT|NDH):')
+                       AND bool_or(source_document_id !~ ':(NDT|NDH):')
+                       AND count(DISTINCT ownership_nature) > 1
+                ) g
+                """
+            )
+            residual = cur.fetchone()
+        logger.info("residual dual-pipeline collision groups: %s (target 0)", residual[0] if residual else "?")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_ownership_refresh_writer_pattern.sh
+++ b/scripts/check_ownership_refresh_writer_pattern.sh
@@ -442,7 +442,13 @@ for helper in $HELPERS; do
       if (!in_using) next
       if (!in_ob && index(stripped, "ORDER BY") == 1) { in_ob = 1 }
       if (!in_ob) next
-      if (index(stripped, ") AS src") == 1) exit
+      # Terminate at the first line that opens with ")": for helpers whose USING
+      # subquery is a bare SELECT this is ") AS src"; for insiders (#1805) the
+      # DISTINCT-ON is wrapped in a `winners` CTE so the ORDER BY is closed first
+      # by the CTE-closing ")" (then "SELECT w.* FROM winners w {filter} ) AS src"
+      # follows). No ORDER BY tuple line starts with ")", so this captures the
+      # full tuple in both shapes.
+      if (index(stripped, ")") == 1) exit
       print stripped
     }
   ')

--- a/tests/test_ownership_refresh_writer_merge.py
+++ b/tests/test_ownership_refresh_writer_merge.py
@@ -663,3 +663,164 @@ def test_known_to_expiry_watermark_alignment(conn, seeded_instrument_id, helper)
     conn.commit()
     drifted = _drifted_instruments(conn, helper.current_table, helper.observations_table, helper.category_literal)
     assert seeded_instrument_id not in drifted
+
+
+# ----------------------------------------------------------------------
+# #1805: dual-pipeline insider de-collision at the _current refresh layer.
+# ----------------------------------------------------------------------
+def _seed_insider_obs(
+    conn,
+    instrument_id: int,
+    *,
+    accession: str,
+    doc_id: str,
+    nature: oo.OwnershipNature,
+    period_end: date = date(2024, 12, 31),
+    holder_cik: str = "0000000042",
+    holder_name: str = "Decollision Holder",
+) -> None:
+    """Seed one insider observation through the production writer.
+
+    The colliding XML + dataset rows share ``holder_cik``/name (so they share
+    ``holder_identity_key``, the de-collision key); ``source_accession`` is the
+    de-collision's other key, so each row carries a real accession (the
+    PR12 ``_seed_one_observation`` passes None and cannot exercise this).
+    ``holder_cik`` is settable so a dataset-only row can use a DISTINCT holder —
+    else two ``beneficial`` rows for the same holder collapse into one DISTINCT-ON
+    slot before the de-collision even runs. ``period_end`` is settable so a test can
+    make one ``direct`` filing supersede another within its DISTINCT-ON slot."""
+    oo.record_insider_observation(
+        conn,
+        instrument_id=instrument_id,
+        holder_cik=holder_cik,
+        holder_name=holder_name,
+        ownership_nature=nature,
+        source="form4",
+        source_document_id=doc_id,
+        source_accession=accession,
+        source_field=None,
+        source_url=None,
+        filed_at=datetime(2025, 1, 1, tzinfo=UTC),
+        period_start=None,
+        period_end=period_end,
+        ingest_run_id=uuid4(),
+        shares=Decimal("100"),
+    )
+
+
+def _current_docs(conn, instrument_id: int) -> set[str]:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT source_document_id FROM ownership_insiders_current WHERE instrument_id = %s",
+            (instrument_id,),
+        )
+        return {r[0] for r in cur.fetchall()}
+
+
+def test_dual_pipeline_decollision_single(conn, seeded_instrument_id):
+    """A dataset ``:NDT:`` row collides with the XML (plain) row on the same
+    ``(holder, accession)``; refresh drops the dataset row from ``_current``. A
+    dataset-only ``:NDT:`` row (no plain sibling) is retained (#1805)."""
+    iid = seeded_instrument_id
+    # Collision: same accession A — XML 'direct' + dataset ':NDT:' 'beneficial'.
+    _seed_insider_obs(conn, iid, accession="0000000000-25-000001", doc_id="0000000000-25-000001", nature="direct")
+    _seed_insider_obs(
+        conn, iid, accession="0000000000-25-000001", doc_id="0000000000-25-000001:NDT:7", nature="beneficial"
+    )
+    # Dataset-only: a DIFFERENT holder, accession B, no XML sibling — must survive.
+    _seed_insider_obs(
+        conn,
+        iid,
+        accession="0000000000-25-000002",
+        doc_id="0000000000-25-000002:NDT:3",
+        nature="beneficial",
+        holder_cik="0000000099",
+        holder_name="Dataset Only Holder",
+    )
+    conn.commit()
+
+    oo.refresh_insiders_current(conn, instrument_id=iid)
+    conn.commit()
+
+    docs = _current_docs(conn, iid)
+    assert "0000000000-25-000001" in docs  # XML row kept
+    assert "0000000000-25-000001:NDT:7" not in docs  # colliding dataset row dropped
+    assert "0000000000-25-000002:NDT:3" in docs  # dataset-only row retained
+
+
+def test_dual_pipeline_decollision_batch_matches_single(conn, two_seeded_instrument_ids):
+    """The batch refresh applies the identical de-collision — pins both paths so
+    neither can drift from the read-path predicate (#1805)."""
+    a, b = two_seeded_instrument_ids
+    for iid in (a, b):
+        _seed_insider_obs(conn, iid, accession="0000000000-25-000001", doc_id="0000000000-25-000001", nature="direct")
+        _seed_insider_obs(
+            conn, iid, accession="0000000000-25-000001", doc_id="0000000000-25-000001:NDT:7", nature="beneficial"
+        )
+        _seed_insider_obs(
+            conn,
+            iid,
+            accession="0000000000-25-000002",
+            doc_id="0000000000-25-000002:NDT:3",
+            nature="beneficial",
+            holder_cik="0000000099",
+            holder_name="Dataset Only Holder",
+        )
+    conn.commit()
+
+    oo.refresh_insiders_current_batch(conn, instrument_ids=[a, b])
+    conn.commit()
+
+    for iid in (a, b):
+        docs = _current_docs(conn, iid)
+        assert "0000000000-25-000001" in docs
+        assert "0000000000-25-000001:NDT:7" not in docs
+        assert "0000000000-25-000002:NDT:3" in docs
+
+
+def test_dual_pipeline_decollision_keeps_ndt_when_plain_sibling_superseded(conn, seeded_instrument_id):
+    """REGRESSION (Codex ckpt-2): the de-collision filters the post-DISTINCT-ON
+    ``winners`` set (= the future ``_current``), NOT raw observations. A ``:NDT:``
+    ``beneficial`` row whose same-accession plain ``direct`` sibling lost its
+    DISTINCT-ON slot to a NEWER ``direct`` filing has no plain sibling IN ``_current``,
+    so it must be KEPT — exactly as #1804 read-path fix B keeps it. Dropping it (an
+    observations-keyed predicate would) changed real insider figures in both
+    directions on the dev population (#1805)."""
+    iid = seeded_instrument_id
+    # Accession A: plain 'direct' (older period) + dataset ':NDT:' 'beneficial'.
+    _seed_insider_obs(
+        conn,
+        iid,
+        accession="0000000000-24-000001",
+        doc_id="0000000000-24-000001",
+        nature="direct",
+        period_end=date(2024, 9, 30),
+    )
+    _seed_insider_obs(
+        conn,
+        iid,
+        accession="0000000000-24-000001",
+        doc_id="0000000000-24-000001:NDT:7",
+        nature="beneficial",
+        period_end=date(2024, 9, 30),
+    )
+    # Accession B: a NEWER plain 'direct' for the same holder — wins the 'direct'
+    # DISTINCT-ON slot, so accession A's plain 'direct' is NOT in _current.
+    _seed_insider_obs(
+        conn,
+        iid,
+        accession="0000000000-24-000002",
+        doc_id="0000000000-24-000002",
+        nature="direct",
+        period_end=date(2024, 12, 31),
+    )
+    conn.commit()
+
+    oo.refresh_insiders_current(conn, instrument_id=iid)
+    conn.commit()
+
+    docs = _current_docs(conn, iid)
+    assert "0000000000-24-000002" in docs  # newer plain 'direct' won its slot
+    assert "0000000000-24-000001" not in docs  # older plain 'direct' superseded out
+    # No plain sibling for accession A survives into _current → keep its ':NDT:'.
+    assert "0000000000-24-000001:NDT:7" in docs


### PR DESCRIPTION
## What

Relocate the insider dual-pipeline de-collision from the read path (#1804) into the
`ownership_insiders_current` refresh, so storage carries one authoritative row set
per `(holder, accession)`. Closes #1805.

The bulk SEC insider dataset (`sec_insider_dataset_ingest`: `:NDT:`/`:NDH:`
`source_document_id`, relationship-relabelled nature) and the XML manifest parser
(bare-accession, Table-II `direct`/`indirect`) both write the same Form 4/3 accession
to `ownership_insiders_observations`. `ownership_nature` is in the DISTINCT-ON key, so
both survive into `_current` — one stake stored 2× (dev: **2726 groups / 1508
instruments**, `scripts/dq_audit.py` sentinel). #1804 fixed the operator-visible
double-count at read; this kills the stored redundancy.

## How

- `refresh_insiders_current` + `refresh_insiders_current_batch`: wrap the DISTINCT-ON
  projection in a `winners` CTE and drop a `:NDT:`/`:NDH:` winner when a plain-accession
  winner shares its `(holder_cik, accession)`. Shared SQL constant
  (`_INSIDER_DUAL_PIPELINE_DECOLLISION`). Existing `_current` collisions are removed by
  the MERGE's `WHEN NOT MATCHED BY SOURCE → DELETE` on the next refresh.
- `scripts/backfill_1805_insider_decollision.py`: forced re-refresh of instruments whose
  `_current` carries a collision (the repair sweep won't — no new observations).

## Filters the WINNER set, not raw observations (Codex ckpt-2)

Fix B keys on `_current` (post-DISTINCT-ON survivors). A pre-DISTINCT-ON filter on raw
observations is **stricter** than fix B: it also drops a `:NDT:` row whose plain sibling
lost its `ownership_nature` slot to a newer filing (present in observations, not
`_current`) — a row fix B **keeps** and the rollup counts. Dropping it changed real
insider figures both ways on dev (JPM 9,142,457→9,057,482; PFE 2,383,995→1,672,336; TM
25,906,827→**26,029,681**, holders 28→18; 506 rows). The winner-set filter mirrors fix B
exactly (`holder_cik IS NOT DISTINCT FROM` + accession), so its removed set is provably
identical to fix B's read-path drop.

## Security model

No new external input, no auth surface, no schema change. SQL constant is static (no user
interpolation). Reads/writes confined to `ownership_insiders_current` via the existing
advisory-locked MERGE. Demo/long-only posture unaffected.

## Source rule

prevention-log 1835 / #905 / Rule 13d-3 — same-accession dataset `beneficial` relabel is
an overlapping restatement of the XML Table-II shares (drop, don't double-store); the XML
manifest parse is the authoritative full-Table-II view of the filing. Unchanged from #1804.

## Verification (dev DB, commit cf9c2346)

- **Equivalence (load-bearing):** winner-set removal set == fix B read-path drop set —
  **3082 == 3082, symmetric diff 0**. Every removed row is already read-path-dropped on
  `main`, counted in no rollup total → no operator-visible figure moves.
- **Backfill executed (clause 10):** full re-derive of 4905 insider instruments (7.5s);
  sentinel **2726 → 0**.
- **Operator-visible (clause 11):** `get_ownership_rollup` panel renders —
  AAPL/GME/MSFT/JPM/HD insider slices present.
- **Cross-check (clause 9):** JPM/PFE/TM insider figures **unchanged** vs `main`
  (9,142,457.8707 / 2,383,995 / 25,906,827); fresh edge instruments SMCI/LVS/EA rollup
  identical before/after refresh; 5 instruments mis-cleaned by the earlier
  observations-keyed prototype restored to exact figures.
- **Smoke panel (clause 8):** AAPL, GME, MSFT, JPM, HD.

## Tests

- `tests/test_ownership_refresh_writer_merge.py`: collision drop, dataset-only retain,
  batch parity, + **regression guard** pinning winner-set semantics (a `:NDT:` whose
  plain sibling is superseded out of `_current` is kept).
- Full PR12 writer-pattern file: 55 passed. Ownership db-tier (rollup/reconcile/refresh):
  211 passed. Fast 4688, smoke 117.
- `scripts/check_ownership_refresh_writer_pattern.sh` invariant H extractor updated to
  terminate the ORDER BY capture at the CTE-closing `)` (documented inline).

## Tradeoff

Chose the refresh layer over an ingest-time skip: ordering-independent (re-derives from
the full observation set each run) and leaves `*_observations` a complete append-only
audit. Obs-level redundancy is benign (never read directly by the rollup) and out of
scope. #1804 read-path fix B kept as tested defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
