### PR TITLE
fix(#1808): execution audit trail 500 — type read API by the open decision_audit vocabulary

### DIFF
--- a/app/api/audit.py
+++ b/app/api/audit.py
@@ -41,8 +41,25 @@ router = APIRouter(
 
 MAX_PAGE_LIMIT = 200
 
-PassFail = Literal["PASS", "FAIL"]
-Stage = Literal["execution_guard", "order_client"]
+# decision_audit.stage / .pass_fail are open, append-only TEXT columns written
+# by SIX independent subsystems — the read API has no authority over the set:
+#   stage:     execution_guard (execution_guard.py), order_client (order_client.py),
+#              manual_order (orders.py), liveness_kick (job_liveness_act.py),
+#              retry_backoff (job_retry.py), entry_timing (scheduler.py)
+#   pass_fail: PASS / FAIL (guards), KICK (liveness), RETRY (retry), DEFER (timing)
+# These Literals are used ONLY for the filter Query params (input validation, per
+# the prevention-log "closed value set" rule). The RESPONSE models (#1808) type
+# stage/pass_fail as bare ``str`` so the audit DISPLAY never rejects a row a writer
+# legitimately logged — a stale response Literal here 500s the whole trail.
+PassFail = Literal["PASS", "FAIL", "KICK", "RETRY", "DEFER"]
+Stage = Literal[
+    "execution_guard",
+    "order_client",
+    "manual_order",
+    "liveness_kick",
+    "retry_backoff",
+    "entry_timing",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -57,9 +74,11 @@ class AuditListItem(BaseModel):
     symbol: str | None
     company_name: str | None
     recommendation_id: int | None
-    stage: Stage
+    # str, not Stage/PassFail: an audit DISPLAY mirrors the storage column and
+    # must render any value a writer logged — never reject it (#1808).
+    stage: str
     model_version: str | None
-    pass_fail: PassFail
+    pass_fail: str
     explanation: str
 
 
@@ -77,9 +96,10 @@ class AuditDetail(BaseModel):
     symbol: str | None
     company_name: str | None
     recommendation_id: int | None
-    stage: Stage
+    # str, not Stage/PassFail — see AuditListItem (#1808).
+    stage: str
     model_version: str | None
-    pass_fail: PassFail
+    pass_fail: str
     explanation: str
     evidence_json: object | None
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -744,6 +744,15 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ---
 
+### Audit / event-log DISPLAY response fields type by the storage column (`str`), not a curated `Literal`
+
+- First seen in: #1808 (found via FE-QA, 2026-06-28). `app/api/audit.py` response models declared `stage: Literal["execution_guard","order_client"]` / `pass_fail: Literal["PASS","FAIL"]`, but `decision_audit.stage`/`.pass_fail` are open, append-only `TEXT` columns written by **six independent subsystems** (execution_guard, order_client, manual_order, liveness_kick, retry_backoff, entry_timing × PASS/FAIL/KICK/RETRY/DEFER). FastAPI validates the response against the model → any row outside the stale subset raised `ResponseValidationError` → **500**. Because the newest rows were all new-vocabulary, the entire execution audit trail (a compliance surface) was unviewable.
+- Distinction from the §"Loose `string` on API response fields" rule above: that rule applies to **reader-owned, closed domains** (currency USD/GBP, cgt_scenario) where the API controls the value set. An **audit / event-log display** is a *passive mirror of an append-only log* whose vocabulary is owned by N independent WRITERS and grows freely — the reader has no authority over the set and **must never reject a row a writer legitimately logged** (rejecting logged history is a category error for an audit surface). For these endpoints, type the response field by the storage column (`str`).
+- Prevention: For a read endpoint over a multi-writer log/audit/event table, type **response** `stage`/`status`/`kind`-style fields as `str`; keep `Literal` only on the **filter Query params** (input validation per §"closed value set"), and widen that Literal to the *full* writer vocabulary (grep every `INSERT INTO <table> (... stage ...)` writer for its literal). Self-review prompt: "does any writer outside this file insert a value this response Literal would reject?" If yes → `str` on the response.
+- Enforced in: `app/api/audit.py` (response `stage`/`pass_fail` → `str`; filter `Stage`/`PassFail` Literals widened to all 6/5 values); `tests/test_api_audit.py::TestOpenVocabulary` (new-vocab + unforeseen-value rows return 200, not 500); FE `frontend/src/components/recommendations/AuditTrail.tsx` + `AuditFilters.tsx` use `Record<string,…>` label/tone maps with raw-key fallback.
+
+---
+
 ### Infinity/out-of-range numeric inputs bypass `Number.isNaN` guards
 
 - First seen in: #236 (review WARNING 4)

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -941,8 +941,20 @@ export interface RecommendationDetail {
 // /audit (app/api/audit.py)
 // ---------------------------------------------------------------------------
 
-export type AuditPassFail = "PASS" | "FAIL";
-export type AuditStage = "execution_guard" | "order_client";
+// decision_audit.stage / .pass_fail are written by six independent subsystems
+// (#1808). These unions enumerate the known vocabulary for the FILTER inputs
+// (AuditQuery) + the label/tone maps only. The RESPONSE fields below are typed
+// `string` to mirror the BE (which sends them as bare `str`) — the audit display
+// must render any value a writer logged, so callers must never assume a closed
+// set. The row renderer falls back to the raw string for unknown values.
+export type AuditPassFail = "PASS" | "FAIL" | "KICK" | "RETRY" | "DEFER";
+export type AuditStage =
+  | "execution_guard"
+  | "order_client"
+  | "manual_order"
+  | "liveness_kick"
+  | "retry_backoff"
+  | "entry_timing";
 
 export interface AuditListItem {
   decision_id: number;
@@ -951,9 +963,9 @@ export interface AuditListItem {
   symbol: string | null;
   company_name: string | null;
   recommendation_id: number | null;
-  stage: AuditStage;
+  stage: string;
   model_version: string | null;
-  pass_fail: AuditPassFail;
+  pass_fail: string;
   explanation: string;
 }
 
@@ -964,9 +976,9 @@ export interface AuditDetail {
   symbol: string | null;
   company_name: string | null;
   recommendation_id: number | null;
-  stage: AuditStage;
+  stage: string;
   model_version: string | null;
-  pass_fail: AuditPassFail;
+  pass_fail: string;
   explanation: string;
   evidence_json: Record<string, unknown> | Record<string, unknown>[] | null;
 }

--- a/frontend/src/components/recommendations/AuditFilters.tsx
+++ b/frontend/src/components/recommendations/AuditFilters.tsx
@@ -1,8 +1,26 @@
 import type { AuditQuery } from "@/api/audit";
 import type { AuditPassFail, AuditStage } from "@/api/types";
 
-const PASS_FAIL_OPTIONS: AuditPassFail[] = ["PASS", "FAIL"];
-const STAGE_OPTIONS: AuditStage[] = ["execution_guard", "order_client"];
+const PASS_FAIL_OPTIONS: AuditPassFail[] = ["PASS", "FAIL", "KICK", "RETRY", "DEFER"];
+const STAGE_OPTIONS: AuditStage[] = [
+  "execution_guard",
+  "order_client",
+  "manual_order",
+  "liveness_kick",
+  "retry_backoff",
+  "entry_timing",
+];
+
+// Full-vocabulary labels (#1808) — a lookup, not a binary ternary, so every
+// stage reads correctly. Unknown values fall back to the raw key.
+const STAGE_FILTER_LABEL: Record<string, string> = {
+  execution_guard: "Execution guard",
+  order_client: "Order client",
+  manual_order: "Manual order",
+  liveness_kick: "Liveness kick",
+  retry_backoff: "Retry backoff",
+  entry_timing: "Entry timing",
+};
 
 export interface AuditFiltersProps {
   query: AuditQuery;
@@ -61,7 +79,7 @@ export function AuditFilters({
           <option value="">All</option>
           {STAGE_OPTIONS.map((s) => (
             <option key={s} value={s}>
-              {s === "execution_guard" ? "Execution guard" : "Order client"}
+              {STAGE_FILTER_LABEL[s] ?? s}
             </option>
           ))}
         </select>

--- a/frontend/src/components/recommendations/AuditTrail.tsx
+++ b/frontend/src/components/recommendations/AuditTrail.tsx
@@ -8,14 +8,23 @@ import { SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { EvidencePanel } from "@/components/recommendations/EvidencePanel";
 
+// Full decision_audit vocabulary (#1808). Both maps fall back at the call site
+// (`?? raw`), so an unknown writer value still renders — never blanks or crashes.
 const PASS_FAIL_TONE: Record<string, string> = {
   PASS: "text-emerald-600",
   FAIL: "text-red-600",
+  KICK: "text-sky-600",
+  RETRY: "text-amber-600",
+  DEFER: "text-amber-600",
 };
 
 const STAGE_LABEL: Record<string, string> = {
   execution_guard: "Guard",
   order_client: "Order",
+  manual_order: "Manual",
+  liveness_kick: "Liveness",
+  retry_backoff: "Retry",
+  entry_timing: "Timing",
 };
 
 export type AuditView =

--- a/frontend/src/components/recommendations/EvidencePanel.tsx
+++ b/frontend/src/components/recommendations/EvidencePanel.tsx
@@ -1,5 +1,3 @@
-import type { AuditStage } from "@/api/types";
-
 interface GuardRule {
   rule: string;
   passed: boolean;
@@ -23,7 +21,9 @@ export function EvidencePanel({
   stage,
   evidence,
 }: {
-  stage: AuditStage;
+  // `string`, not AuditStage: the audit display mirrors the open BE vocabulary
+  // (#1808). Unknown stages fall through to GenericEvidence below.
+  stage: string;
   evidence: Record<string, unknown> | Record<string, unknown>[] | null;
 }) {
   if (evidence === null) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -323,6 +323,13 @@ _DB_SOURCE_MARKERS: tuple[str, ...] = (
     "ebull_test_conn",
     "test_database_url",
     "run_migrations(",
+    # Ephemeral-DB helpers from tests/fixtures/ebull_test_db.py: a module that
+    # builds an admin DB or applies migrations against the 5433 cluster IS a DB
+    # test. Missing these let test_migration_156 / test_dev_test_db_reaper leak
+    # into the fast tier, breaking the "no DB ⇒ no xdist contention" invariant
+    # the pre-push gate relies on (#1808 follow-up).
+    "_admin_database_url",
+    "_apply_migrations(",
     "settings.database_url",
     "TestClient",
 )

--- a/tests/test_api_audit.py
+++ b/tests/test_api_audit.py
@@ -319,3 +319,66 @@ class TestFilterValidation:
     def test_invalid_stage_returns_422(self) -> None:
         resp = client.get("/audit?stage=unknown_stage")
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# TestOpenVocabulary (#1808)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenVocabulary:
+    """decision_audit.stage / .pass_fail are open, append-only TEXT columns
+    written by six independent subsystems. A stale response-model Literal here
+    500s the whole audit trail (it did — every newest row was new-vocabulary).
+    The display must faithfully render any value a writer logged."""
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    # (stage, pass_fail) pairs from writers OUTSIDE the original
+    # {execution_guard, order_client} × {PASS, FAIL} subset.
+    _NEW_VOCAB = [
+        ("liveness_kick", "KICK"),
+        ("retry_backoff", "RETRY"),
+        ("manual_order", "PASS"),
+        ("entry_timing", "DEFER"),
+    ]
+
+    def test_list_renders_new_vocabulary_without_500(self) -> None:
+        for stage, pf in self._NEW_VOCAB:
+            row = _make_audit_row(stage=stage, pass_fail=pf)
+            _with_conn([[{"cnt": 1}], [row]])
+
+            resp = client.get("/audit")
+            assert resp.status_code == 200, f"{stage}/{pf} 500'd the list"
+            item = resp.json()["items"][0]
+            assert item["stage"] == stage
+            assert item["pass_fail"] == pf
+
+    def test_detail_renders_new_vocabulary_without_500(self) -> None:
+        for stage, pf in self._NEW_VOCAB:
+            row = _make_audit_row(stage=stage, pass_fail=pf)
+            _with_conn([[row]])
+
+            resp = client.get("/audit/1")
+            assert resp.status_code == 200, f"{stage}/{pf} 500'd the detail"
+            body = resp.json()
+            assert body["stage"] == stage
+            assert body["pass_fail"] == pf
+
+    def test_unforeseen_value_still_renders(self) -> None:
+        """Even a stage/pass_fail no writer uses today must not 500 — the
+        reader has no authority over the column, so it never rejects a row."""
+        row = _make_audit_row(stage="future_stage_v9", pass_fail="WAT")
+        _with_conn([[{"cnt": 1}], [row]])
+
+        resp = client.get("/audit")
+        assert resp.status_code == 200
+        assert resp.json()["items"][0]["stage"] == "future_stage_v9"
+
+    def test_filter_accepts_new_vocabulary(self) -> None:
+        for stage, pf in self._NEW_VOCAB:
+            _with_conn([[{"cnt": 0}], []])
+            assert client.get(f"/audit?stage={stage}").status_code == 200
+            _with_conn([[{"cnt": 0}], []])
+            assert client.get(f"/audit?pass_fail={pf}").status_code == 200


### PR DESCRIPTION
## Problem
`/recommendations` → **EXECUTION AUDIT TRAIL** panel rendered "Failed to load" (Retry). `GET /api/audit` returned **500** on every load — the entire execution audit trail (a compliance surface) was unviewable. Found via FE-QA walk (authenticated dev session).

## Root cause
`app/api/audit.py` response models declared `stage: Literal["execution_guard","order_client"]` / `pass_fail: Literal["PASS","FAIL"]`. But `decision_audit.stage`/`.pass_fail` are open, append-only **`text`** columns written by **six independent subsystems**:

| stage | writer | pass_fail |
|---|---|---|
| execution_guard | execution_guard.py | PASS/FAIL |
| order_client | order_client.py | PASS/FAIL |
| manual_order | orders.py | PASS |
| liveness_kick | job_liveness_act.py | KICK |
| retry_backoff | job_retry.py | RETRY |
| entry_timing | scheduler.py | PASS/DEFER |

FastAPI validates the response against the model → any row outside the stale subset → `ResponseValidationError` → 500. Since the newest rows are all new-vocabulary, the whole page 500s.

## Source rule
An audit / event-log **display** must never reject a row a writer legitimately logged — type response fields by the storage column, not a curated enum. This **refines** (does not contradict) the prevention-log "loose `string` on response fields" rule, which governs *reader-owned closed domains* (currency, cgt_scenario); an append-only multi-writer log is the documented exception. New prevention-log entry added.

## Changes
- **`app/api/audit.py`**: response `stage`/`pass_fail` → `str` (the 500 fix). Filter Query `Stage`/`PassFail` Literals **widened** to the full 6-stage / 5-result vocabulary (keeps input validation per the "closed value set" rule).
- **FE**: `AuditStage`/`AuditPassFail` unions widened (used for **filter options + label maps only**); **response** fields + `EvidencePanel.stage` typed `string` to mirror the BE (Codex ckpt-2 — full BE/FE contract symmetry); `AuditTrail`/`AuditFilters` label+tone maps cover all 6/5 with raw-key fallback; replaced the binary stage-label ternary that mislabelled every non-guard stage as "Order client".
- **`tests/test_api_audit.py::TestOpenVocabulary`**: new-vocab + unforeseen-value rows return 200 (not 500); filters accept the new values.

## Gate-integrity fix (exposed by this push)
`tests/conftest.py` auto-`db`-marker missed the `_admin_database_url` / `_apply_migrations(` entrypoints, so `test_migration_156_partition_swap` + `test_dev_test_db_reaper` (real DB tests) leaked into the fast tier and flaked under xdist contention on the 5433 cluster ("server closed connection unexpectedly"). Added both markers → the two modules now classify `db`, restoring the gate's "no DB in fast tier ⇒ no xdist contention" invariant. Blast radius: exactly those 2 modules flip; zero pure tests reclassified.

## Verification
- `GET /api/audit?limit=50` → **200** (was 500) on dev; returns all live stages/results; console 0 errors.
- Audit panel renders **1–50 of 95** with Guard/FAIL (red) + Retry/RETRY (amber) labels; dark mode clean. Filter dropdowns list all 6 stages / 5 results. (screenshots in session)
- Fast tier **4678 passed** (flake gone), smoke 135, FE **1161 passed** + typecheck clean, ruff/pyright clean. Codex ckpt-2 run (one finding — FE response-field symmetry — fixed at commit b3224a7f).

Closes #1808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)