### PR TITLE
fix(#1810): unique React keys in BusinessSectionsTeaser — section_key is a bucket, not an id

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -744,6 +744,14 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ---
 
+### React list keys must be a unique identifier, not a classification / category field that repeats per parent
+
+- First seen in: #1800 (`filer_cik` — a registrant CIK fronts N series; insider rows are byte-identical) and again #1810 (`section_key` — a 10-K Item 1 classification bucket; GME has `other` ×12 in one filing). Both keyed `.map()` rows by a field that *looks* like an id but is a non-unique grouping label → React "Encountered two children with the same key" → cards/rows silently duplicated or omitted.
+- Prevention: before keying a `.map()` by `x.foo_key` / `x.foo_id`, confirm the field is unique **within the rendered list**, not just "looks like an identifier". Classification buckets, category enums, group labels, and shared-parent foreign keys repeat by design. Prefer a guaranteed-unique field (an ordinal like `section_order`, a surrogate row id) or compose one (`` `${x.key}-${x.order}` ``, or append the array index per #1800). Self-review prompt: "can two rows in this list legitimately share this field?" — if yes, the key is wrong.
+- Enforced in: `frontend/src/components/instrument/BusinessSectionsTeaser.tsx::pickCards` (`` key: `${section_key}-${section_order}` ``); `tests/.../BusinessSectionsTeaser.test.tsx` ("keys cards uniquely when section_key buckets repeat (#1810)" — asserts no `same key` console warning); the three #1800 ownership render sites append the array index.
+
+---
+
 ### Audit / event-log DISPLAY response fields type by the storage column (`str`), not a curated `Literal`
 
 - First seen in: #1808 (found via FE-QA, 2026-06-28). `app/api/audit.py` response models declared `stage: Literal["execution_guard","order_client"]` / `pass_fail: Literal["PASS","FAIL"]`, but `decision_audit.stage`/`.pass_fail` are open, append-only `TEXT` columns written by **six independent subsystems** (execution_guard, order_client, manual_order, liveness_kick, retry_backoff, entry_timing × PASS/FAIL/KICK/RETRY/DEFER). FastAPI validates the response against the model → any row outside the stale subset raised `ResponseValidationError` → **500**. Because the newest rows were all new-vocabulary, the entire execution audit trail (a compliance surface) was unviewable.

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
@@ -192,6 +192,58 @@ describe("BusinessSectionsTeaser", () => {
     expect(screen.getByText(/retail and institutional/)).toBeInTheDocument();
   });
 
+  it("keys cards uniquely when section_key buckets repeat (#1810)", async () => {
+    // section_key is a classification bucket, not an identifier — `other`
+    // repeats across subsections. Distinct section_order must keep React keys
+    // unique so no card is dropped and no duplicate-key warning fires.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      symbol: "GME",
+      source_accession: null,
+      cik: null,
+      sections: [
+        {
+          section_order: 1,
+          section_key: "other",
+          section_label: "Business Priorities",
+          body: "We focus on profitable growth in our core retail segment.",
+          cross_references: [],
+          tables: [],
+        },
+        {
+          section_order: 2,
+          section_key: "other",
+          section_label: "Capital Deployment",
+          body: "We allocate capital toward high-return investments.",
+          cross_references: [],
+          tables: [],
+        },
+        {
+          section_order: 3,
+          section_key: "other",
+          section_label: "Retail Business",
+          body: "Our stores sell games, hardware, and collectibles.",
+          cross_references: [],
+          tables: [],
+        },
+      ],
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    // All three same-bucket cards render — none omitted by a key collision.
+    expect(await screen.findByText("Business Priorities")).toBeInTheDocument();
+    expect(screen.getByText("Capital Deployment")).toBeInTheDocument();
+    expect(screen.getByText("Retail Business")).toBeInTheDocument();
+    // No React "two children with the same key" warning.
+    const dupKeyWarning = consoleError.mock.calls.some((args) =>
+      args.some((a) => typeof a === "string" && a.includes("same key")),
+    );
+    expect(dupKeyWarning).toBe(false);
+  });
+
   it("renders a loading skeleton (not parse-failed copy) for the deferred state (#1343)", async () => {
     vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
       symbol: "GME",

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
@@ -70,7 +70,10 @@ function pickCards(
     if (out.length >= MAX_CARDS) break;
     const t = teaseBody(s.body);
     if (t.length === 0) continue;
-    out.push({ key: s.section_key, label: s.section_label, teaser: t });
+    // section_key is a classification bucket (`other` repeats many times per
+    // filing), NOT an identifier — keying React rows by it collides (#1810).
+    // section_order is unique + authoritative (10-K presentation order).
+    out.push({ key: `${s.section_key}-${s.section_order}`, label: s.section_label, teaser: t });
   }
   return out;
 }


### PR DESCRIPTION
## Problem
Instrument page 10-K Item 1 "Business sections" teaser logged React warning *"Encountered two children with the same key"* (`SectionCardGrid`). Non-unique keys let React duplicate/omit cards — same class as #1800.

## Root cause
`pickCards` keyed each card by `s.section_key`, but `section_key` is a **classification bucket**, not an identifier — the section splitter maps many subsections to the same bucket. `GET /api/instruments/GME/business_sections` returns 20 sections of which **12 are `section_key="other"`** (Business Priorities, Capital Deployment, Retail Business, Merchandise, …). When the first MAX_CARDS non-empty sections include ≥2 `other`, keys collide. Systemic — any instrument whose leading Item-1 subsections share a bucket.

## Fix
Key by `` `${section_key}-${section_order}` ``. `section_order` is unique + authoritative: DB-enforced `UNIQUE (instrument_id, source_accession, section_order)` in `sql/059`, and the ingester emits sections in 10-K presentation order (per `pickCards`' own doc comment). Codex ckpt-2 confirmed the uniqueness constraint and found no other non-unique keying site in the component.

## Changes
- `frontend/src/components/instrument/BusinessSectionsTeaser.tsx::pickCards` — compose a unique key.
- `BusinessSectionsTeaser.test.tsx` — regression: repeated `other` bucket with distinct order renders all 3 cards + asserts no `same key` console warning (verified it **fails** on the old key).
- `docs/review-prevention-log.md` — extracted the recurring class (#1800 `filer_cik` + #1810 `section_key`): React list keys need a unique id, not a category/grouping field.

## Verification
Found via FE-QA on `/instrument/GME`. `section_keys` include `other` ×12 (confirmed duplicate). FE unit: BusinessSectionsTeaser 10 passed; typecheck clean; pre-push gate green. FE-only — no backend/daemon impact.

Closes #1810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)