### PR TITLE
fix(#1810): key BusinessSectionsTeaser cards by section_order, not the non-unique section_key bucket

### DIFF
--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -753,6 +753,14 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 
 ---
 
+### React list keys must be a guaranteed-unique identifier, not a classification / category field that repeats per parent
+
+- First seen in: #1800 (`filer_cik` — one registrant CIK fronts N N-PORT series; insider rows are byte-identical) and again #1810 (`section_key` — a 10-K Item 1 classification bucket; GME has `other` ×12 in one filing). Both keyed `.map()` rows by a field that *looks* like an id but is a non-unique grouping label → React "Encountered two children with the same key" → reconciliation is unsupported, so cards/rows are silently dropped or reused.
+- Prevention: before keying a `.map()` by `x.foo_key` / `x.foo_id`, confirm the field is unique **within the rendered list**, not just "looks like an identifier". Classification buckets, category enums, group labels, and shared-parent foreign keys repeat by design. Prefer a field whose uniqueness is **backed by a DB constraint over the rendered scope** (grep before cite — e.g. `sql/059` carries `UNIQUE (instrument_id, source_accession, section_order)` and the response is single-accession → `section_order` is safe), or compose/append the array index (#1800). Self-review prompt: "can two rows in this list legitimately share this field?" — if yes, the key is wrong.
+- Enforced in: `frontend/src/components/instrument/BusinessSectionsTeaser.tsx::pickCards` (`key: String(s.section_order)`); `frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx` ("keys cards by section_order so colliding section_key buckets don't drop cards or warn (#1810)"); the three #1800 ownership render sites append the array index.
+
+---
+
 ### Infinity/out-of-range numeric inputs bypass `Number.isNaN` guards
 
 - First seen in: #236 (review WARNING 4)

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.test.tsx
@@ -192,6 +192,59 @@ describe("BusinessSectionsTeaser", () => {
     expect(screen.getByText(/retail and institutional/)).toBeInTheDocument();
   });
 
+  it("keys cards by section_order so colliding section_key buckets don't drop cards or warn (#1810)", async () => {
+    // `section_key` is a classification bucket — GME's leading Item-1
+    // subsections collapse to "other". Keying by it gave React duplicate
+    // keys, which make reconciliation unsupported (cards can be omitted or
+    // reused). `section_order` is unique per filing.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
+      symbol: "GME",
+      source_accession: null,
+      cik: null,
+      sections: [
+        {
+          section_order: 5,
+          section_key: "other",
+          section_label: "Business Priorities",
+          body: "We prioritise the long-term transformation of the business.",
+          cross_references: [],
+          tables: [],
+        },
+        {
+          section_order: 6,
+          section_key: "other",
+          section_label: "Capital Deployment",
+          body: "We deploy capital toward high-return initiatives.",
+          cross_references: [],
+          tables: [],
+        },
+        {
+          section_order: 7,
+          section_key: "other",
+          section_label: "Retail Business",
+          body: "Our retail footprint spans thousands of stores.",
+          cross_references: [],
+          tables: [],
+        },
+      ],
+    } as never);
+    render(
+      <MemoryRouter>
+        <BusinessSectionsTeaser symbol="GME" />
+      </MemoryRouter>,
+    );
+    // All three distinct cards render despite the shared "other" bucket.
+    expect(await screen.findByText("Business Priorities")).toBeInTheDocument();
+    expect(screen.getByText("Capital Deployment")).toBeInTheDocument();
+    expect(screen.getByText("Retail Business")).toBeInTheDocument();
+    // No "two children with the same key" warning was emitted.
+    const sameKeyWarning = errorSpy.mock.calls.some((args) =>
+      args.some((a) => typeof a === "string" && a.includes("same key")),
+    );
+    expect(sameKeyWarning).toBe(false);
+  });
+
   it("renders a loading skeleton (not parse-failed copy) for the deferred state (#1343)", async () => {
     vi.spyOn(api, "fetchBusinessSections").mockResolvedValueOnce({
       symbol: "GME",

--- a/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
+++ b/frontend/src/components/instrument/BusinessSectionsTeaser.tsx
@@ -61,7 +61,16 @@ function teaseBody(body: string): string {
 /** Pick the first up-to-MAX_CARDS sections that have a non-empty
  *  body. `section_order` from the API is already authoritative — the
  *  ingester emits sections in 10-K presentation order — so a simple
- *  prefix is what we want. */
+ *  prefix is what we want.
+ *
+ *  Key cards by `section_order`, NOT `section_key` (#1810): `section_key`
+ *  is a classification bucket and collides (a 10-K's leading subsections
+ *  often share `"other"`), which gave React duplicate keys — reconciliation
+ *  is then unsupported (cards can be omitted or reused). `section_order`
+ *  is unique per filing — `sql/059_instrument_business_summary_sections.sql`
+ *  carries `UNIQUE (instrument_id, source_accession, section_order)` and the
+ *  response is single-accession — so it is a safe, stable, authoritative key
+ *  (the #1800 precedent for non-unique identifiers). */
 function pickCards(
   sections: ReadonlyArray<BusinessSection>,
 ): Array<{ key: string; label: string; teaser: string }> {
@@ -70,7 +79,7 @@ function pickCards(
     if (out.length >= MAX_CARDS) break;
     const t = teaseBody(s.body);
     if (t.length === 0) continue;
-    out.push({ key: s.section_key, label: s.section_label, teaser: t });
+    out.push({ key: String(s.section_order), label: s.section_label, teaser: t });
   }
   return out;
 }


### PR DESCRIPTION
## Problem
`/instrument/<sym>` → "Company narrative" teaser logged React's *"Encountered two children with the same key"* (`SectionCardGrid`). `pickCards` keyed each card by `section_key`, but that is a **classification bucket**, not an identifier — a 10-K's leading Item-1 subsections often collapse to `"other"`. With duplicate keys, React reconciliation is unsupported (cards can be omitted or reused). Same class as #1800.

**Confirmed on full row** (`GET /instruments/GME/business_sections`): 20 sections, `section_order` unique, `section_key="other"` ×12.

## Fix
Key cards by `String(section_order)`. `section_order` is unique per filing — `sql/059_instrument_business_summary_sections.sql` carries `UNIQUE (instrument_id, source_accession, section_order)` and the teaser response is single-accession — so it is a stable, authoritative sibling key.

## Source rule
`section_order` uniqueness is a DB invariant (`sql/059` UNIQUE constraint). Read path (`get_business_sections`) returns one accession (explicit `accession=` arg, or latest mode picks one `source_accession` first), so order is unique within the rendered list. React requires only sibling uniqueness.

## Test
Regression: 3 sections sharing `section_key="other"` with distinct `section_order` render all three cards and emit no "same key" console warning.

## Verification
- `pnpm typecheck` clean.
- `BusinessSectionsTeaser.test.tsx` 10/10 pass; full FE unit suite 1162/1162 pass.
- Codex ckpt-2: no findings; independently confirmed `section_order` uniqueness via sql/059 + single-accession read path.

FE-only; no daemon/API restart needed.

Closes #1810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)