### PR TITLE
fix(#1813): 200+null for absent optional data instead of 404 (employees, latest-thesis)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1410,15 +1410,21 @@ class InstrumentHeadcount(BaseModel):
     source_accession: str
 
 
-@router.get("/{symbol}/employees", response_model=InstrumentHeadcount)
+@router.get("/{symbol}/employees", response_model=InstrumentHeadcount | None)
 def get_instrument_employees(
     symbol: str,
     conn: psycopg.Connection[object] = Depends(get_conn),
-) -> InstrumentHeadcount:
+) -> InstrumentHeadcount | None:
     """Latest ``dei:EntityNumberOfEmployees`` fact for an instrument.
 
-    Returns 404 when no fact is on file (non-SEC issuer, fundamentals
-    sync hasn't seeded yet, or DEI cover-page tagging absent).
+    Returns **200 with a null body** when the instrument exists but has
+    no headcount fact on file — which is the common case: only ~16 of
+    ~5,200 instruments XBRL-tag ``dei:EntityNumberOfEmployees`` (it is an
+    optional concept; AAPL/GME and most majors report headcount as 10-K
+    narrative text, not a structured fact — verified against SEC
+    companyfacts, #1813). A 404 is reserved for an *unknown* symbol, so
+    the FE can fetch this unconditionally without polluting the browser
+    console with an error on every instrument page (#1813).
     """
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -1454,7 +1460,10 @@ def get_instrument_employees(
         row = cur.fetchone()
 
     if row is None:
-        raise HTTPException(status_code=404, detail=f"No employee count on file for {symbol}")
+        # Known instrument, no headcount fact — absent optional datum, not
+        # an error. 200 + null keeps the instrument page console clean
+        # (#1813). Unknown-symbol still 404s above (line ~1439).
+        return None
 
     return InstrumentHeadcount(
         symbol=str(inst_row["symbol"]),  # type: ignore[arg-type]

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -136,12 +136,17 @@ _THESIS_COLUMNS = """
 # ---------------------------------------------------------------------------
 
 
-@router.get("/{instrument_id}", response_model=ThesisDetail)
+@router.get("/{instrument_id}", response_model=ThesisDetail | None)
 def get_latest_thesis(
     instrument_id: int,
     conn: psycopg.Connection[object] = Depends(get_conn),
-) -> ThesisDetail:
-    """Latest thesis for an instrument, ordered by created_at then version."""
+) -> ThesisDetail | None:
+    """Latest thesis for an instrument, ordered by created_at then version.
+
+    Returns **200 with a null body** when no thesis exists yet — the
+    normal pre-thesis state, not an error. The instrument page fetches
+    this on every load, so a 404 here meant a console error on every
+    not-yet-analysed instrument (#1813)."""
     sql = f"""
         SELECT {_THESIS_COLUMNS}
         FROM theses t
@@ -155,11 +160,24 @@ def get_latest_thesis(
         cur.execute(sql, params)
         row = cur.fetchone()
 
-    if row is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No thesis found for instrument {instrument_id}",
-        )
+        if row is None:
+            # Distinguish "unknown instrument" (404) from "known
+            # instrument, no thesis yet" (200 + null) — same contract as
+            # get_thesis_history. The null case is the normal pre-analysis
+            # state and lets the research page render its Generate-thesis
+            # affordance without a console error on every un-analysed
+            # instrument (#1813). Existence check only on the no-thesis
+            # path, so the common (thesis-present) read stays single-query.
+            cur.execute(
+                "SELECT 1 FROM instruments WHERE instrument_id = %(instrument_id)s",
+                {"instrument_id": instrument_id},
+            )
+            if cur.fetchone() is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Instrument {instrument_id} not found",
+                )
+            return None
 
     return _parse_thesis(row)
 

--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -406,7 +406,9 @@ export async function fetchInstrumentEmployees(
   symbol: string,
 ): Promise<InstrumentHeadcount | null> {
   try {
-    return await apiFetch<InstrumentHeadcount>(
+    // 200 + null when the instrument has no headcount fact (#1813); the
+    // 404 catch is retained for an unknown symbol.
+    return await apiFetch<InstrumentHeadcount | null>(
       `/instruments/${encodeURIComponent(symbol)}/employees`,
     );
   } catch (err) {

--- a/frontend/src/api/theses.ts
+++ b/frontend/src/api/theses.ts
@@ -7,8 +7,10 @@ import type {
 
 export function fetchLatestThesis(
   instrumentId: number,
-): Promise<ThesisDetail> {
-  return apiFetch<ThesisDetail>(`/theses/${instrumentId}`);
+): Promise<ThesisDetail | null> {
+  // Returns null when no thesis exists yet — the endpoint now answers
+  // 200 + null for the pre-analysis state instead of 404 (#1813).
+  return apiFetch<ThesisDetail | null>(`/theses/${instrumentId}`);
 }
 
 export function fetchThesisHistory(

--- a/tests/api/test_instruments_employees_endpoint.py
+++ b/tests/api/test_instruments_employees_endpoint.py
@@ -75,8 +75,12 @@ def test_employees_endpoint_404_unknown_symbol() -> None:
     assert resp.status_code == 404
 
 
-def test_employees_endpoint_404_when_no_fact() -> None:
-    """Instrument exists but has no DEI EntityNumberOfEmployees row."""
+def test_employees_endpoint_200_null_when_no_fact() -> None:
+    """Instrument exists but has no DEI EntityNumberOfEmployees row.
+
+    Absent optional datum → 200 + null body, not 404 (#1813): the FE
+    fetches this on every instrument page and a 404 polluted the console
+    for the ~99.7% of instruments that don't XBRL-tag headcount."""
     conn = MagicMock()
     conn.cursor.return_value = _cursor_with(
         [
@@ -87,4 +91,5 @@ def test_employees_endpoint_404_when_no_fact() -> None:
     app = _build_app(conn)
     with TestClient(app) as client:
         resp = client.get("/instruments/BTC/employees")
-    assert resp.status_code == 404
+    assert resp.status_code == 200
+    assert resp.json() is None

--- a/tests/test_api_theses.py
+++ b/tests/test_api_theses.py
@@ -152,12 +152,26 @@ class TestGetLatestThesis:
         assert body["critic_json"] == {"overall": "sound"}
         assert body["created_at"] is not None
 
-    def test_no_thesis_returns_404(self) -> None:
-        _with_conn([[]])
+    def test_known_instrument_no_thesis_returns_200_null(self) -> None:
+        """Known instrument, no thesis yet → 200 + null body, not 404
+        (#1813). The instrument page fetches this on every load; a 404
+        meant a console error on every un-analysed instrument. Two
+        queries: thesis (empty) then instrument-existence (present)."""
+        _with_conn([[], [{"exists": 1}]])
+        resp = client.get("/theses/100")
+
+        assert resp.status_code == 200
+        assert resp.json() is None
+
+    def test_unknown_instrument_returns_404(self) -> None:
+        """Unknown instrument → 404 (#1813 reserves 404 for an unknown
+        resource, distinct from the absent-optional-datum null case).
+        Two queries: thesis (empty) then instrument-existence (empty)."""
+        _with_conn([[], []])
         resp = client.get("/theses/999")
 
         assert resp.status_code == 404
-        assert "No thesis found" in resp.json()["detail"]
+        assert "not found" in resp.json()["detail"].lower()
 
     def test_nullable_numeric_fields_returned_as_null(self) -> None:
         """All nullable numeric fields can be None without crashing."""


### PR DESCRIPTION
Closes #1813.

## What
`/instruments/{symbol}/employees` and `/theses/{instrument_id}` returned **404** for the common "resource exists, optional datum absent" case. The instrument page fetches both on every load, so this logged a browser-console `404` error on essentially every instrument page view. The FE already swallowed the 404 into a clean empty state — the only artifact was console noise that buries real errors during debugging.

## Why it's a contract bug, not a data gap (falsification recorded)
Full-population check (dev DB) + SEC source verification:
- `EntityNumberOfEmployees` is present for only **16 of 5,211** instruments with any `financial_facts_raw` rows; siblings via the same ingest path are dense (`EntityCommonStockSharesOutstanding` 43,771, `EntityPublicFloat` 12,272).
- The 54 captured employee rows use units inside `_UNIT_PRIORITY` — the extractor works when the fact exists.
- SEC `companyfacts` for AAPL (320193) and GME (1326380): each `dei` section has only 2 concepts; `EntityNumberOfEmployees` is **absent**. Majors report headcount as 10-K narrative text, not a structured `dei:` fact.

→ Sparse coverage is **correct**. The fix is the 404-as-absent contract, not ingestion. (Recorded so a future console-404 sighting isn't re-investigated as a parser/unit bug.)

## Change
- `get_instrument_employees`: `200 + null` when a **known** instrument has no headcount fact; **404 still reserved for an unknown symbol** (existing existence check).
- `get_latest_thesis`: `200 + null` when a **known** instrument has no thesis yet; **adds an instrument-existence check on the no-thesis path** so an unknown instrument still `404`s — preserving the unknown-resource vs absent-datum distinction, matching `get_thesis_history`. *(Codex ckpt-2 caught that the first cut returned null for unknown instruments too.)* Existence query runs only on the no-thesis path; the common thesis-present read stays single-query.
- FE: `fetchInstrumentEmployees` / `fetchLatestThesis` typed `… | null` (no behavioural change — both already null-handled).
- Tests: flipped absent→`200+null`; added an unknown-instrument `404` thesis case; kept unknown-symbol `404` for employees.

## Security model
Read-only GET endpoints behind the existing operator session. No authz surface change. `response_model=Model | None` returning `None` serializes to JSON `null` with status 200 (FastAPI/pydantic v2) — confirmed live.

## Verification (commit 11a958f5)
- `uv run pytest tests/test_api_theses.py tests/api/test_instruments_employees_endpoint.py` → 19 passed.
- ruff check / format / pyright clean; `pnpm typecheck` clean; `pnpm test:unit` 1162 passed; smoke 135 passed; full pre-push gate green.
- Live (dev :8000 / via vite :5173): `/instrument/GME` loads with **0 console errors / 0 4xx**; `/theses/1699` (known, no thesis) → `200 null`; `/theses/999999999` → `404`; employees unknown symbol → `404`.
