### PR TITLE
fix(#1817): null-out benchmark return when no close falls inside the period

### DIFF
--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -957,12 +957,12 @@ def _benchmark_closes(
             "return_pct": None,
         }
 
-    def _close(on_or_before: date, *, strict_before: bool) -> Decimal | None:
+    def _close(on_or_before: date, *, strict_before: bool) -> tuple[date, Decimal] | None:
         op = "<" if strict_before else "<="
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(
                 f"""
-                SELECT close FROM price_daily
+                SELECT price_date, close FROM price_daily
                 WHERE instrument_id = %(iid)s
                   AND close IS NOT NULL
                   AND price_date {op} %(day)s
@@ -972,12 +972,30 @@ def _benchmark_closes(
                 {"iid": inst["instrument_id"], "day": on_or_before},
             )
             row = cur.fetchone()
-        return row["close"] if row else None
+        return (row["price_date"], row["close"]) if row else None
 
-    close_start = _close(period_start, strict_before=True)
-    close_end = _close(period_end, strict_before=False)
+    start_row = _close(period_start, strict_before=True)
+    end_row = _close(period_end, strict_before=False)
+    close_start = start_row[1] if start_row is not None else None
+    close_end = end_row[1] if end_row is not None else None
     return_pct: Decimal | None = None
-    if close_start is not None and close_end is not None and close_start > 0:
+    # Honest coverage: a return is only real when the benchmark actually
+    # has a close INSIDE [period_start, period_end]. If the latest
+    # available close predates the whole window (stale/missing data —
+    # e.g. an index symbol the price provider can't refresh, #1818),
+    # `end_row` collapses onto the same pre-period row as `start_row`
+    # and `close_end / close_start - 1 == 0` — a SPURIOUS "benchmark was
+    # flat", not a real 0%. Leave return_pct null so the FE renders "—"
+    # / "benchmark unavailable" rather than a fabricated 0.00% + excess
+    # (#1817). Matches the docstring contract: null on missing closes.
+    if (
+        start_row is not None
+        and end_row is not None
+        and end_row[0] >= period_start
+        and close_start is not None
+        and close_end is not None
+        and close_start > 0
+    ):
         return_pct = close_end / close_start - 1
     return {
         "symbol": BENCHMARK_SYMBOL,

--- a/tests/test_reporting_v2_db.py
+++ b/tests/test_reporting_v2_db.py
@@ -198,6 +198,80 @@ def test_benchmark_resolved_by_symbol(ebull_test_conn: psycopg.Connection[tuple]
     assert Decimal(benchmark["return_pct"]) == Decimal("0.02")
 
 
+def test_benchmark_stale_no_in_window_close_returns_null(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """When the latest benchmark close predates the whole period (stale
+    data — #1818), close_end collapses onto the pre-period baseline and
+    close_end/close_start - 1 == 0. That 0 is a fabricated "flat", not a
+    real return: return_pct must be null so the FE shows "—" (#1817)."""
+    conn = ebull_test_conn
+    _seed_portfolio(conn)
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (789802, 'SPX500', 'S&P 500 Index', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    # Both closes land BEFORE _PERIOD_B (06-01 .. 06-07): no close inside
+    # the window. close_start (strict < 06-01) and close_end (<= 06-07)
+    # both resolve to the 05-29 row.
+    conn.execute(
+        """
+        INSERT INTO price_daily (instrument_id, price_date, close)
+        VALUES (789802, '2026-05-22', 5000), (789802, '2026-05-29', 5100)
+        ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close
+        """
+    )
+    conn.commit()
+
+    report = generate_weekly_report(conn, period_start=_PERIOD_B[0], period_end=_PERIOD_B[1])
+    benchmark = report["performance"]["benchmark"]
+    assert benchmark["symbol"] == "SPX500"
+    # Closes still reported for transparency (both the stale 05-29 row)…
+    assert Decimal(benchmark["close_start"]) == Decimal("5100")
+    assert Decimal(benchmark["close_end"]) == Decimal("5100")
+    # …but the return is null, NOT a spurious 0.00%.
+    assert benchmark["return_pct"] is None
+    # Cover + excess null-out too (no fabricated excess vs a flat line).
+    assert report["cover"]["benchmark_return"] is None
+    assert report["cover"]["excess_return"] is None
+
+
+def test_benchmark_close_exactly_on_period_start_computes(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """Boundary: a benchmark close landing exactly on period_start IS
+    inside the window — the `end_row.date >= period_start` guard is
+    inclusive, so the return computes (locks against a `>` regression)."""
+    conn = ebull_test_conn
+    _seed_portfolio(conn)
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, exchange, currency, is_tradable)
+        VALUES (789802, 'SPX500', 'S&P 500 Index', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """
+    )
+    # baseline before the window, plus a close ON period_start (06-01).
+    conn.execute(
+        """
+        INSERT INTO price_daily (instrument_id, price_date, close)
+        VALUES (789802, '2026-05-29', 5000), (789802, %(start)s, 5100)
+        ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close
+        """,
+        {"start": _PERIOD_B[0]},
+    )
+    conn.commit()
+
+    report = generate_weekly_report(conn, period_start=_PERIOD_B[0], period_end=_PERIOD_B[1])
+    benchmark = report["performance"]["benchmark"]
+    assert Decimal(benchmark["close_start"]) == Decimal("5000")
+    assert Decimal(benchmark["close_end"]) == Decimal("5100")
+    assert Decimal(benchmark["return_pct"]) == Decimal("0.02")
+
+
 def test_v2_fixture_is_backend_emitted(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
     """The SnapshotV2 fixture for child 2's FE type test is generated
     by the real builders. ``REPORT_FIXTURE_WRITE=1`` regenerates the


### PR DESCRIPTION
Closes #1817.

## What

`app/services/reporting.py::_benchmark_closes` computed
`return_pct = close_end / close_start - 1` where `close_start` = latest close
strictly before `period_start` and `close_end` = latest close at-or-before
`period_end`. When the benchmark has **no close inside the period** (stale/
missing data), `close_end` resolves to the *same pre-period row* as
`close_start`, so the ratio is exactly **0** — the report then renders a
fabricated "S&P 500 0.00%" + a bogus excess, instead of "no benchmark data".

This contradicts the helper's own docstring (lines 936–938): *null when closes
are missing → FE renders portfolio-only with a notice.* The case
`close_end.date < period_start` slipped through as a real 0%.

Found via FE-QA on `/reports` (weekly 22–28 Jun): benchmark return 0.00% +
flat S&P line across 3 weeks, yet YTD benchmark +9.92%. API confirmed
`benchmark_return=0`, `benchmark_si_return=0`, `benchmark_ytd_return=0.099229`.
Root data cause (SPX500 stale at 2026-06-04, exactly 1000 rows) tracked
separately as #1818 — this PR is the display-honesty fix, correct regardless
of the data freshness gap.

## Fix

Resolve each benchmark close **with its `price_date`**; compute `return_pct`
only when the end close's date `>= period_start` (a close actually fell inside
the window), else leave it null. One helper change → covers all three callers
(period / since-inception / rolling-windows) uniformly.

## Why it's safe / honest

- The "missing vs zero" conflation is the same class the codebase already
  names `benchmark_missing` for risk metrics (settled-decisions §risk-metrics).
- FE already renders null correctly: `formatPct(null)` → "—"
  (`AccountSummary.tsx`), `PerformanceChart` → "Benchmark unavailable for this
  window". No FE change needed.
- `close_start`/`close_end` are still reported in the dict for transparency
  (operator can see both legs resolved to the same stale row) — only
  `return_pct` nulls.
- Report snapshots are idempotent (`persist_report_snapshot` ON CONFLICT DO
  UPDATE) → reflects on next weekly regen.

## Tests (`tests/test_reporting_v2_db.py`, db tier)

- `test_benchmark_stale_no_in_window_close_returns_null` — both closes before
  `period_start` → `return_pct` null, cover `benchmark_return`/`excess_return`
  null (no fabricated 0% or excess).
- `test_benchmark_close_exactly_on_period_start_computes` — boundary: close ON
  `period_start` computes (locks the inclusive `>=` guard against a `>` regression).
- `test_benchmark_resolved_by_symbol` (existing in-window positive) — unchanged.

## Verification

- `uv run ruff check` / `ruff format --check` / `uv run pyright app/services/reporting.py` — clean.
- `uv run pytest tests/test_reporting_v2_db.py -m db` — 5 passed (commit 138cba1b).
- `uv run pytest tests/test_reporting.py -m "not db"` — 59 passed; `tests/smoke` — 135 passed.
- Codex ckpt-2: no findings; guard confirmed correct for all 3 callers.

## Tradeoffs

YTD benchmark still computes (Jan 1 → last available close) — it has in-window
data, just stale-bounded; that understatement is the freshness bug (#1818), not
the spurious-zero bug fixed here.
