### PR TITLE
fix(#1833): batch circuit-breaker for daily_candle_refresh — fast-fail on whole-batch outage

### DIFF
--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -16,10 +16,47 @@ from decimal import Decimal
 import psycopg
 
 from app.providers.market_data import MarketDataProvider, OHLCVBar, Quote
+from app.services.sync_orchestrator.exception_classifier import classify_exception
+from app.services.sync_orchestrator.layer_types import FailureCategory, UpstreamUnreachableError
 from app.services.sync_orchestrator.progress import report_progress
 from app.services.technical_analysis import OHLCVRow, compute_indicators
 
 logger = logging.getLogger(__name__)
+
+# Batch circuit-breaker (#1833). When the eToro market-data API is
+# unreachable, every per-instrument candle fetch hits the provider's 30s
+# timeout and raises — walking all ~775 scoped instruments would burn
+# ≈6.5h grinding through dead requests for a job that normally finishes in
+# ~1 minute. After this many CONSECUTIVE *systemic* failures the candle
+# loop aborts the whole batch with a clear terminal status instead.
+# "Consecutive" counts ATTEMPTED fetches: a freshness-skipped instrument
+# is neutral (no fetch, no reachability evidence) and neither increments
+# nor resets the counter. The counter resets on any fetch that proves the
+# server is still reachable — a clean fetch OR a per-instrument fault that
+# still got a response (e.g. a 404 for a delisted symbol) — so a few
+# genuinely-delisted instruments never trip it.
+_CANDLE_BATCH_ABORT_LIMIT = 10
+
+# Failure categories that indicate a WHOLE-BATCH outage (the next
+# instrument will fail the same way), as opposed to a per-instrument fault
+# (404 delisted → INTERNAL_ERROR, a unique-constraint clash → DB_CONSTRAINT,
+# a feature-compute bug → INTERNAL_ERROR). Sourced from the single failure
+# taxonomy in ``classify_exception`` so this never drifts from it:
+#   * SOURCE_DOWN   — httpx.TransportError (DNS / connect / read timeout),
+#                     5xx after retries, or a psycopg.OperationalError raised
+#                     mid-fetch (transient DB blip inside the transaction).
+#                     A HARD DB outage trips the freshness probe on the first
+#                     instrument (outside the per-item try) and fails the run
+#                     fast on its own — no grind to break.
+#   * AUTH_EXPIRED  — 401/403: the broker session is dead for every call
+#   * RATE_LIMITED  — 429 after the retry budget is exhausted
+_SYSTEMIC_FAILURE_CATEGORIES = frozenset(
+    {
+        FailureCategory.SOURCE_DOWN,
+        FailureCategory.AUTH_EXPIRED,
+        FailureCategory.RATE_LIMITED,
+    }
+)
 
 # Default spread threshold from trading-policy.md.
 # An instrument is flagged if (ask - bid) / mid > this value.
@@ -68,6 +105,7 @@ def refresh_market_data(
     *,
     skip_quotes: bool = False,
     force_backfill: bool = False,
+    consecutive_failure_limit: int = _CANDLE_BATCH_ABORT_LIMIT,
 ) -> MarketRefreshSummary:
     """
     For each instrument: fetch candles, upsert to price_daily, compute
@@ -86,6 +124,15 @@ def refresh_market_data(
 
     instruments is a list of (instrument_id, symbol) tuples — instrument_id
     must already exist in the instruments table. symbol is used for logging.
+
+    ``consecutive_failure_limit`` (#1833) is the batch circuit-breaker
+    threshold: after this many CONSECUTIVE systemic candle-fetch failures
+    (provider unreachable, session dead, rate-limited) the loop raises
+    ``UpstreamUnreachableError`` and aborts the rest of the batch instead
+    of grinding through hundreds of per-instrument 30s timeouts. "Consecutive"
+    counts attempted fetches — a freshness-skipped instrument is neutral; a
+    reachable response (clean fetch or a 404) resets the counter. Pass
+    ``<= 0`` to disable the breaker (walk every instrument regardless).
 
     Raw provider responses are persisted by the provider before being returned.
     """
@@ -117,6 +164,8 @@ def refresh_market_data(
     # rows). The 1000-bar default only fires on initial seed,
     # gap-detect, or the one-shot ``force_backfill=True`` deepening.
     total = len(instruments)
+    # #1833 batch circuit-breaker — consecutive systemic failures.
+    consecutive_systemic_failures = 0
     for idx, (instrument_id, symbol) in enumerate(instruments, start=1):
         if not force_backfill and _candles_are_fresh(conn, instrument_id, today):
             candles_skipped += 1
@@ -141,9 +190,32 @@ def refresh_market_data(
             # — and that same instrument is also counted in ``candles_failed``.
             candle_rows_upserted += upserted
             features_computed += computed
-        except Exception:
+            # A clean fetch proves the provider + DB are reachable → reset.
+            consecutive_systemic_failures = 0
+        except Exception as exc:
             candles_failed += 1
             logger.warning("Failed to refresh candles for %s (id=%d), skipping", symbol, instrument_id, exc_info=True)
+            category = classify_exception(exc)
+            if category in _SYSTEMIC_FAILURE_CATEGORIES:
+                consecutive_systemic_failures += 1
+                if 0 < consecutive_failure_limit <= consecutive_systemic_failures:
+                    # Whole-batch outage — fail FAST with the triggering
+                    # category instead of walking the remaining instruments
+                    # through the same 30s-timeout grind (#1833). report_progress
+                    # the partial position first so the run's last heartbeat
+                    # reflects where it stopped.
+                    report_progress(idx, total, force=True)
+                    raise UpstreamUnreachableError(
+                        category,
+                        f"{consecutive_systemic_failures} consecutive systemic candle-fetch "
+                        f"failures (aborted batch of {total} after {idx} instruments; "
+                        f"last failure on {symbol} id={instrument_id})",
+                    ) from exc
+            else:
+                # A per-instrument fault (404 delisted, DB-constraint clash,
+                # feature-compute bug) proves the server still responds →
+                # reset so a sprinkling of dead symbols never trips the breaker.
+                consecutive_systemic_failures = 0
         report_progress(idx, total)
 
     # Final force-tick so items_done lands at the loop boundary even

--- a/app/services/sync_orchestrator/exception_classifier.py
+++ b/app/services/sync_orchestrator/exception_classifier.py
@@ -12,7 +12,11 @@ import psycopg
 import psycopg.errors
 
 from app.security.secrets_crypto import MasterKeyNotLoadedError
-from app.services.sync_orchestrator.layer_types import FailureCategory, LayerRefreshFailed
+from app.services.sync_orchestrator.layer_types import (
+    FailureCategory,
+    LayerRefreshFailed,
+    UpstreamUnreachableError,
+)
 
 
 def classify_exception(exc: BaseException) -> FailureCategory:
@@ -29,6 +33,12 @@ def classify_exception(exc: BaseException) -> FailureCategory:
     # in LayerRefreshFailed(SCHEMA_DRIFT, ...) has strictly more
     # information than this helper can recover from the exception type.
     if isinstance(exc, LayerRefreshFailed):
+        return exc.category
+    # UpstreamUnreachableError (#1833) is a batch circuit-breaker trip that
+    # carries the category of the triggering systemic failure — honour it
+    # so an AUTH_EXPIRED trip stays operator-actionable rather than being
+    # flattened to the catch-all INTERNAL_ERROR.
+    if isinstance(exc, UpstreamUnreachableError):
         return exc.category
     # #643 — broker-encryption key not loaded. Distinct from the
     # generic AUTH_EXPIRED (which means the credential decrypted but

--- a/app/services/sync_orchestrator/layer_types.py
+++ b/app/services/sync_orchestrator/layer_types.py
@@ -281,6 +281,25 @@ class LayerRefreshFailed(Exception):
         self.detail = detail
 
 
+class UpstreamUnreachableError(Exception):
+    """Batch circuit-breaker trip — a whole-batch upstream/systemic outage.
+
+    Raised by a per-instrument batch loop (e.g. ``refresh_market_data``)
+    after K consecutive *systemic* failures (provider unreachable, session
+    rejected, rate-limited, or DB down) so the run fails FAST with a clear
+    terminal status instead of grinding through hundreds of per-item 30s
+    timeouts (#1833). Carries the category of the triggering failure so
+    ``classify_exception`` records the honest taxonomy — an AUTH_EXPIRED
+    trip stays operator-actionable (``self_heal=False``) rather than being
+    flattened to a retriable SOURCE_DOWN.
+    """
+
+    def __init__(self, category: FailureCategory, detail: str) -> None:
+        super().__init__(f"{category.value}: {detail}")
+        self.category = category
+        self.detail = detail
+
+
 def cadence_display_string(cadence: Cadence) -> str:
     """Short human label used by dashboards where a one-liner is enough."""
     if cadence.calendar_months is not None:

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1101,3 +1101,161 @@ class TestRefreshMarketDataForceBackfill:
 
         assert summary.candle_rows_upserted == 0  # the 5 rolled back — not counted
         assert summary.candles_failed == 1
+
+
+class TestRefreshMarketDataCircuitBreaker:
+    """#1833 — batch circuit-breaker: K consecutive *systemic* candle-fetch
+    failures abort the whole batch with a clear terminal status instead of
+    grinding every instrument through the provider's 30s timeout."""
+
+    @staticmethod
+    def _not_fresh_conn() -> MagicMock:
+        """Conn whose freshness check returns an old date → every instrument
+        attempts a fetch; transaction is a passthrough context manager."""
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.fetchone.return_value = (date(2020, 1, 1),)  # ancient → not fresh
+        conn.execute.return_value = cursor
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=ctx)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.transaction.return_value = ctx
+        return conn
+
+    @staticmethod
+    def _http_error(status: int) -> httpx.HTTPStatusError:
+        request = httpx.Request("GET", "https://public-api.etoro.com/x")
+        response = httpx.Response(status, request=request)
+        return httpx.HTTPStatusError(f"{status}", request=request, response=response)
+
+    @staticmethod
+    def _instruments(n: int) -> list[tuple[int, str]]:
+        return [(i, f"SYM{i}") for i in range(1, n + 1)]
+
+    def test_trips_after_limit_consecutive_transport_failures(self) -> None:
+        """eToro unreachable → every fetch is a TransportError (SOURCE_DOWN).
+        The breaker raises after `limit` and does NOT walk the remainder."""
+        from app.services.market_data import refresh_market_data
+        from app.services.sync_orchestrator.layer_types import (
+            FailureCategory,
+            UpstreamUnreachableError,
+        )
+
+        conn = self._not_fresh_conn()
+        provider = MagicMock()
+        provider.get_daily_candles.side_effect = httpx.ConnectTimeout("eToro unreachable")
+
+        with pytest.raises(UpstreamUnreachableError) as excinfo:
+            refresh_market_data(
+                provider,
+                conn,
+                instruments=self._instruments(100),
+                skip_quotes=True,
+                consecutive_failure_limit=10,
+            )
+        # Tripped at exactly the limit — only 10 fetches attempted, not 100.
+        assert provider.get_daily_candles.call_count == 10
+        assert excinfo.value.category == FailureCategory.SOURCE_DOWN
+
+    def test_404s_never_trip_the_breaker(self) -> None:
+        """A 404 (delisted) proves the server responded → per-instrument,
+        not systemic. A whole batch of 404s walks every instrument."""
+        from app.services.market_data import refresh_market_data
+
+        conn = self._not_fresh_conn()
+        provider = MagicMock()
+        provider.get_daily_candles.side_effect = self._http_error(404)
+
+        summary = refresh_market_data(
+            provider,
+            conn,
+            instruments=self._instruments(30),
+            skip_quotes=True,
+            consecutive_failure_limit=10,
+        )
+        assert provider.get_daily_candles.call_count == 30
+        assert summary.candles_failed == 30
+
+    def test_interspersed_success_resets_counter(self) -> None:
+        """A reachable success (empty bars) between failures resets the
+        consecutive counter, so the breaker never trips."""
+        from app.services.market_data import refresh_market_data
+
+        conn = self._not_fresh_conn()
+        provider = MagicMock()
+        # 9 fails, 1 success (empty bars), repeated — never 10 in a row.
+        cycle = [httpx.ConnectError("down")] * 9 + [[]]
+        provider.get_daily_candles.side_effect = cycle * 5  # 50 instruments
+
+        summary = refresh_market_data(
+            provider,
+            conn,
+            instruments=self._instruments(50),
+            skip_quotes=True,
+            consecutive_failure_limit=10,
+        )
+        assert provider.get_daily_candles.call_count == 50
+        assert summary.candles_failed == 45
+
+    def test_404_between_failures_resets_counter(self) -> None:
+        """A per-instrument fault (404) also proves reachability → resets."""
+        from app.services.market_data import refresh_market_data
+
+        conn = self._not_fresh_conn()
+        provider = MagicMock()
+        cycle = [httpx.ConnectError("down")] * 9 + [self._http_error(404)]
+        provider.get_daily_candles.side_effect = cycle * 5
+
+        summary = refresh_market_data(
+            provider,
+            conn,
+            instruments=self._instruments(50),
+            skip_quotes=True,
+            consecutive_failure_limit=10,
+        )
+        assert provider.get_daily_candles.call_count == 50
+        assert summary.candles_failed == 50
+
+    def test_trip_carries_triggering_category_auth(self) -> None:
+        """A 401 trip stays AUTH_EXPIRED (operator-actionable, self_heal=False)
+        rather than being flattened to SOURCE_DOWN."""
+        from app.services.market_data import refresh_market_data
+        from app.services.sync_orchestrator.layer_types import (
+            FailureCategory,
+            UpstreamUnreachableError,
+        )
+
+        conn = self._not_fresh_conn()
+        provider = MagicMock()
+        provider.get_daily_candles.side_effect = self._http_error(401)
+
+        with pytest.raises(UpstreamUnreachableError) as excinfo:
+            refresh_market_data(
+                provider,
+                conn,
+                instruments=self._instruments(20),
+                skip_quotes=True,
+                consecutive_failure_limit=3,
+            )
+        assert excinfo.value.category == FailureCategory.AUTH_EXPIRED
+        assert provider.get_daily_candles.call_count == 3
+
+    def test_limit_zero_disables_breaker(self) -> None:
+        """`consecutive_failure_limit <= 0` walks every instrument even when
+        all fail systemically (matches pre-#1833 behaviour for callers that
+        opt out)."""
+        from app.services.market_data import refresh_market_data
+
+        conn = self._not_fresh_conn()
+        provider = MagicMock()
+        provider.get_daily_candles.side_effect = httpx.ConnectTimeout("down")
+
+        summary = refresh_market_data(
+            provider,
+            conn,
+            instruments=self._instruments(25),
+            skip_quotes=True,
+            consecutive_failure_limit=0,
+        )
+        assert provider.get_daily_candles.call_count == 25
+        assert summary.candles_failed == 25


### PR DESCRIPTION
Closes #1833.

## Problem
When the eToro market-data API is unreachable, `daily_candle_refresh` walked all ~775 scoped instruments, each hitting the provider's **30s** per-request timeout (`app/providers/implementations/etoro.py:93`) and writing nothing — **≈6.5h** of dead grinding for a job that normally finishes in ~1 min (all candles fresh → skipped). A daemon restart mid-grind orphan-reaps the run (`status=failure`, `orphaned: reaped at boot…`), so the operator only learns of it on the next restart.

`ResilientClient` does **not** catch transport-level faults (timeouts/connect errors propagate raw from `client.send`; it only retries 429/5xx), so each unreachable fetch raises after the full 30s.

## Fix — batch circuit-breaker (`refresh_market_data`)
After **K consecutive systemic** candle-fetch failures (default `_CANDLE_BATCH_ABORT_LIMIT = 10`) the candle loop raises `UpstreamUnreachableError` and aborts the rest of the batch instead of grinding the remaining hundreds.

- **Systemic vs per-instrument** is decided by reusing `classify_exception` (single source of the failure taxonomy — no re-encoding). Systemic = `SOURCE_DOWN` (TransportError / 5xx / mid-fetch DB blip), `AUTH_EXPIRED` (401/403 session dead), `RATE_LIMITED` (429 after retries).
- **Counter resets** on any fetch that proves the server is still reachable — a clean fetch **or** a per-instrument fault that still got a response (404 delisted → `INTERNAL_ERROR`, DB-constraint clash → `DB_CONSTRAINT`). So a sprinkling of delisted symbols never trips it.
- **"Consecutive" counts attempted fetches** — a freshness-skipped instrument is neutral (no fetch, no reachability signal).
- **Honest taxonomy on trip:** `UpstreamUnreachableError` carries the triggering category; `classify_exception` honours it (mirrors `LayerRefreshFailed`), so an `AUTH_EXPIRED` trip stays operator-actionable (`self_heal=False`) instead of being flattened to a retriable `SOURCE_DOWN`. `_tracked_job` records that category as the job's `error_category`.
- `consecutive_failure_limit <= 0` disables the breaker (pre-#1833 walk-everything behaviour). Only caller is `daily_candle_refresh` (`scheduler.py:2442`); behaviour change is contained to that job.

A hard DB outage already fast-fails on the freshness probe (instrument 1, outside the per-item try) — no grind to break there.

## Deferred — item 2 (progress heartbeat)
The ticket's second ask (per-instrument `processed_count`/`last_progress_at` heartbeat to distinguish wedged-from-slow) is deferred: the breaker removes the 6.5h zombie that made the distinction necessary, and stamping a heartbeat on the **direct-APScheduler** path needs the orchestrator's `report_progress` callback plumbed into that path (it's currently a no-op there) — a separate, cross-cutting change.

## Tests (fast tier, no DB)
`tests/test_market_data.py::TestRefreshMarketDataCircuitBreaker` — 6 cases:
- trips after exactly K consecutive TransportErrors → `SOURCE_DOWN`, remainder not fetched
- a whole batch of 404s never trips (walks all)
- interspersed clean success resets → no trip
- interspersed 404 resets → no trip
- 401 trip carries `AUTH_EXPIRED`
- `limit <= 0` disables the breaker

## Local gates
- `ruff check` / `ruff format --check` ✅
- `pyright` ✅
- fast tier `pytest -m "not db"` → 4696 passed, 10 skipped ✅
- smoke → 135 passed ✅
- Codex ckpt-2 reviewed the branch — two wording nitpicks (fresh-skip neutrality; DB-outage fails on the probe) folded into the comments/docstring.

## Operator note
Pure failure-handling robustness; no schema/parser/migration change, no data-path change. Live verification against a real outage is environment-specific (the autonomy loop runs without a live broker session by design — exactly the condition that surfaced this); covered by the unit cases above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)