### PR TITLE
fix(#1835): bind FY/quarter flow columns by XBRL context duration, not Frames label

### DIFF
--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -242,3 +242,23 @@ not a cross-day pair that passes before the closed check is ever reached.
 
 Origin: PR #1763 (#1754) review WARNING — the "closed window" gap test passed
 because the two bars were different NY dates, never reaching the closed guard.
+
+### Vacuous `all(pred for x in seq)` when the empty case is the expected outcome
+
+`assert all(pred for p in seq)` is `True` for an empty `seq` — so when the
+DOCUMENTED expected outcome is "no rows are produced", the `all(...)` proves
+nothing (it passes whether the bad row was rejected or was simply never built).
+When emptiness is the expected result, assert it directly:
+
+```python
+assert fy == []            # not: assert all(p.revenue is None for p in fy)
+```
+
+If a non-empty result is also valid (some rows survive, none carrying the bad
+value), pair an emptiness/length assertion with a value assertion that does not
+quantify over a possibly-empty set — e.g. `assert all(p.revenue != BAD for p in periods)`
+guarded by a prior `assert len(periods) >= 1`.
+
+Origin: PR #1837 (#1835) review WARNING — `test_fy_rejects_quarter_duration_mislabeled_fy`
+asserted `all(p.revenue is None for p in fy)` where the expected outcome was an
+empty `fy`, so the assertion was vacuously true and did not cover the rejection.

--- a/app/services/fundamentals/__init__.py
+++ b/app/services/fundamentals/__init__.py
@@ -857,6 +857,25 @@ _FP_MAP: dict[str, tuple[str, int | None]] = {
     "FY": ("FY", None),
 }
 
+# #1835 — canonical XBRL context-duration window (days, inclusive) per period
+# type, used to admit a duration fact's value to that period's flow columns.
+# This is the authoritative YTD-disambiguation signal: the SEC Frames-API
+# ``frame`` label is a cross-sectional "one fact per filer, last filed"
+# comparability tag (data.sec.gov/api/xbrl/frames), NOT a per-issuer period
+# key — 43% of genuine annual flow facts carry ``frame=NULL`` (full-pop scan
+# 2026-06-29) and were wrongly dropped, while quarter-duration facts mislabeled
+# fp=FY carried a quarterly frame and polluted FY rows. Quarter window
+# [60,120] is the settled convention (sec_fundamentals._ttm_from_quarters);
+# annual 365±30 = [335,395] is the SEC frames annual tolerance — together they
+# reject 3mo (~91d), 6mo Q2-YTD (~182d) and 9mo Q3-YTD (~273d) durations.
+_FLOW_DURATION_DAYS: dict[str, tuple[int, int]] = {
+    "FY": (335, 395),
+    "Q1": (60, 120),
+    "Q2": (60, 120),
+    "Q3": (60, 120),
+    "Q4": (60, 120),
+}
+
 
 @dataclass
 class PeriodRow:
@@ -979,13 +998,18 @@ def _derive_periods_from_facts(
         if fp not in _FP_MAP:
             continue  # skip unknown periods (e.g. 'H1', '9M')
 
-        is_instant = fact.period_start is None
-        is_duration = not is_instant
-
-        # YTD disambiguation: for duration items, require frame to be set.
-        # Entries without frame are YTD cumulative -- exclude them.
-        if is_duration and fact.frame is None:
-            continue
+        # #1835 — YTD disambiguation by XBRL context DURATION, not the SEC
+        # Frames ``frame`` label (see _FLOW_DURATION_DAYS). For a duration fact
+        # (period_start set), admit it to this fiscal period only when its span
+        # matches the period's canonical window; this drops 6mo/9mo YTD
+        # cumulatives and quarter-duration facts mislabeled fp=FY, while keeping
+        # the genuine annual fact regardless of whether SEC framed it. Instant
+        # (balance-sheet) facts carry no duration and are always kept.
+        if fact.period_start is not None:
+            lo, hi = _FLOW_DURATION_DAYS[_FP_MAP[fp][0]]
+            days = (fact.period_end - fact.period_start).days
+            if not (lo <= days <= hi):
+                continue
 
         grouped[(fact.fiscal_year, fp)].append(fact)
 
@@ -1466,6 +1490,38 @@ def _canonical_merge_instrument(
         {"iid": instrument_id},
     )
 
+    # Phase B2 (#1835): drop STRUCTURALLY-INVALID FY canonical rows — a
+    # ``period_type='FY'`` row whose ``months_covered`` is sub-annual
+    # (< 11 months) can never be a real annual period; it is a 3-month
+    # fact that the pre-fix derivation mislabeled fp=FY (≈2,270 such rows
+    # full-population). The duration guard prevents NEW ones, but the
+    # already-persisted ones must be removed here; the Step-3 periods_raw
+    # rewash guarantees ``best_source`` below will not re-create them
+    # (FY periods_raw rows now always span ≥335 days).
+    #
+    # The predicate is intentionally STRUCTURAL, not "absent from raw":
+    # ``financial_facts_raw`` is retention-swept (only the latest few
+    # 10-K/10-Q accessions survive — financial_facts_retention.py), so a
+    # legitimate older annual row's facts age out of raw while the
+    # canonical row is the durable history. Deleting "labels absent from
+    # raw" would truncate that history; deleting only ``months_covered <
+    # 11`` FY rows touches only the impossible-duration rows and never a
+    # valid ``months_covered≈12`` annual row. (Wrong-VALUE but
+    # correct-duration rows for aged-out years are corrected when a full
+    # ``sec_rebuild`` re-ingests their facts and re-derives — see runbook.)
+    # Scoped to source='sec_edgar' (the only writer of this canonical path).
+    conn.execute(
+        """
+        DELETE FROM financial_periods fp
+        WHERE fp.instrument_id = %(iid)s
+          AND fp.source = 'sec_edgar'
+          AND fp.period_type = 'FY'
+          AND fp.months_covered IS NOT NULL
+          AND fp.months_covered < 11
+        """,
+        {"iid": instrument_id},
+    )
+
     cur = conn.execute(
         """
         WITH best_source AS (
@@ -1761,7 +1817,20 @@ def normalize_financial_periods(
                 # Step 2: Derive periods from facts
                 periods = _derive_periods_from_facts(fact_rows, reported_currency)
 
-                # Step 3: Upsert into financial_periods_raw
+                # Step 3: Rewash financial_periods_raw for this instrument.
+                # #1835 — DELETE-then-INSERT (the established rewash pattern,
+                # cf. refresh_*_current / 13F / DEF14A) so re-normalization is
+                # idempotent-REPLACING, not merely additive. Without this, raw
+                # rows from a superseded derivation (e.g. a 3-month fact
+                # mislabeled fp=FY, now dropped by the duration guard) would
+                # linger in periods_raw and keep re-feeding the canonical merge.
+                # Every row this path writes is source='sec_edgar'; scope the
+                # delete to that source so a future companies_house fundamentals
+                # path is untouched.
+                conn.execute(
+                    "DELETE FROM financial_periods_raw WHERE instrument_id = %(iid)s AND source = 'sec_edgar'",
+                    {"iid": iid},
+                )
                 raw_count = 0
                 for period in periods:
                     if _upsert_period_raw(conn, instrument_id=iid, period=period):

--- a/docs/specs/fundamentals/2026-06-29-fy-flow-duration-guard.md
+++ b/docs/specs/fundamentals/2026-06-29-fy-flow-duration-guard.md
@@ -1,0 +1,186 @@
+# FY/quarter flow binding by XBRL context duration, not Frames-API `frame` (#1835)
+
+## Problem
+
+`financial_periods` FY rows have flow columns (revenue/net_income/operating_income)
+largely NULL (80–88%) or bound to a wrong-duration value. Full-population (dev DB
+2026-06-29): of 46,992 FY rows only 46.4% have `months_covered=12`; 2,270 FY rows
+(1,613 instruments) are 3-month windows mislabeled `period_type='FY'`. Downstream
+`revenue_growth_yoy` computable for only 8.8% of instruments.
+
+## Root cause (verified, not inferred)
+
+`app/services/fundamentals/__init__.py::_derive_periods_from_facts` (L987):
+
+```python
+# YTD disambiguation: for duration items, require frame to be set.
+if is_duration and fact.frame is None:
+    continue
+```
+
+This uses the SEC **Frames-API `frame` label** as the discriminator for "real period
+flow vs YTD-cumulative duplicate." That is the wrong signal.
+
+- AAPL `(fy=2024, fp=FY)` revenue facts in `financial_facts_raw`:
+  - `pe=2022-09-24 mo=12 frame=CY2022` → kept (2-yr comparative)
+  - `pe=2023-09-30 mo=12 frame=None` → **dropped**
+  - `pe=2024-09-28 mo=12 frame=None val=391,035M` → **dropped** ← the real FY2024 annual
+  FY2025 works only because its `pe=2025-09-27` fact happens to carry `frame=CY2025`.
+- Old `SalesRevenueNet` facts are mislabeled `fp=FY` with **3-month durations** and a
+  quarterly frame (e.g. `CY2010Q4`) → they survive the frame filter and pollute FY rows
+  (failure mode 2 — a quarter-magnitude value in a 12-month FY column).
+
+Full-population: of 35,800 annual-duration (330–380 day) FY-context revenue facts,
+**15,477 (43%) have `frame=NULL`** → currently dropped though they ARE the genuine
+annual fact. **5,445** quarter-duration facts are mislabeled `fp=FY`.
+
+## Source rule
+
+SEC EDGAR XBRL.
+
+**Documented rule (SEC).** The **Frames API**
+(`data.sec.gov/api/xbrl/frames/{taxonomy}/{tag}/{unit}/{period}.json`,
+[SEC EDGAR APIs](https://www.sec.gov/search-filings/edgar-application-programming-interfaces))
+"aggregates **one fact for each reporting entity** that is **last filed** for a given
+period." The `frame` key in companyfacts is therefore the Frames-API selection — populated
+on the single, *last-filed* instance per (concept, calendar period: `CY{year}` annual /
+`CY{year}Q{n}` quarterly). It is a **cross-sectional comparability tag, not a per-issuer
+period-identity key**, and must not be used to select an issuer's own flow facts.
+
+**Full-population-observed consequence (dev DB 2026-06-29, not inferred).** Because the
+Frames selection is the *last-filed* instance, the issuer's own original annual fact (the
+one filed in the year it closes) frequently lacks a `frame` — the frame lands on a later
+filing's comparative re-stamp of the same period. Of 40,004 annual-duration
+(335–395 day) FY-context revenue facts, **17,132 (43%) carry `frame=NULL`** and were being
+dropped by the old filter though they are the genuine annual fact. **5,835** quarter-
+duration (60–120 day) facts are mislabeled `fp=FY` (legacy 8-K facts) and carried a
+quarterly frame, so they survived the old filter and polluted FY flow columns.
+
+**Authoritative signal: XBRL context duration** (`endDate − startDate` in days). Settled
+codebase convention already filters quarters by duration to `[60, 120]` days
+(`app/providers/implementations/sec_fundamentals.py::_ttm_from_quarters`, "60 and 120 days
+to avoid picking up YTD or annual values"). The annual analog is the SEC-frames annual
+tolerance 365 ± 30 days → `[335, 395]`, which cleanly separates the 12-month annual fact
+from the 6-month (≈182d, Q2 YTD), 9-month (≈273d, Q3 YTD) and 3-month (≈91d) durations.
+
+## Fix
+
+Replace the frame-based YTD filter with a **day-duration guard** keyed to the fiscal
+period's canonical length, applied to **every duration fact** (flow, EPS, weighted-average
+shares, dividends-per-share — all duration-tagged concepts; gating them all is intentional,
+each has the same annual-vs-YTD ambiguity). In the grouping loop:
+
+```python
+# days inclusive: quarter [60,120] (settled, _ttm_from_quarters);
+# annual 365±30 = [335,395] (SEC frames annual tolerance)
+_FLOW_DURATION_DAYS = {"FY": (335, 395), "Q1": (60, 120), "Q2": (60, 120),
+                       "Q3": (60, 120), "Q4": (60, 120)}
+...
+if is_duration:
+    lo, hi = _FLOW_DURATION_DAYS[_FP_MAP[fp][0]]
+    days = (fact.period_end - fact.period_start).days
+    if not (lo <= days <= hi):
+        continue  # YTD cumulative (6mo/9mo) or wrong-duration (3mo tagged FY)
+```
+
+Instant (balance-sheet, `period_start is None`) facts carry no duration and are always
+kept (unchanged). The existing `canonical_facts = [f for f in mapped_facts if f.period_end
+== period_end]` + `filed_date DESC` priority continue to resolve the #682 comparative
+re-stamp (multiple same-duration annual facts at different period_ends → latest period_end
+wins).
+
+`months_covered` for FY flow rows is then computed from ~12-month duration facts (→ 12).
+Note an FY group whose `period_end` is anchored by a mislabeled-`fp=FY` *instant* fact (no
+duration to gate) and which has no 12-month duration fact at that end still yields a row,
+but with `period_start=NULL → months_covered=NULL` and NULL flow columns — not a 3-month
+value.
+
+### Stale-row cleanup (required — the derivation fix alone is not enough)
+
+The derivation change stops *creating* bad FY rows, but the ~2,270 already-persisted
+mislabeled 3-month FY rows (and the NULL-flow orphans) would survive a re-normalize:
+`normalize_financial_periods` upserts `financial_periods_raw` additively, and the canonical
+merge (`_canonical_merge_instrument`) only deletes rows whose fiscal label *collides* with a
+raw winner. A fiscal label whose only raw fact is now dropped by the duration guard has **no
+raw winner**, so the stale canonical row is invisible to the collision delete and persists —
+and even the full `POST /jobs/sec_rebuild/run` path does not clear periods (it only resets
+manifest rows to re-ingest facts). Verified: both `financial_periods_raw` and
+`financial_periods` are 100% `source='sec_edgar'`, written exclusively through this module,
+so idempotent-replace is safe.
+
+Two changes make re-normalization clean up the persisted bad rows:
+
+1. **Step 3 periods_raw rewash** — `DELETE FROM financial_periods_raw WHERE instrument_id=%s
+   AND source='sec_edgar'` before re-inserting the freshly derived rows, so `periods_raw` is
+   authoritative for the current derivation and `best_source` cannot re-create a mislabeled
+   3-month FY row from a stale staging row. (`periods_raw` is staging, not history — safe to
+   replace.)
+2. **Phase B2 structural-invalid delete** — in `_canonical_merge_instrument`, `DELETE FROM
+   financial_periods fp WHERE fp.instrument_id=%s AND fp.source='sec_edgar' AND
+   fp.period_type='FY' AND fp.months_covered IS NOT NULL AND fp.months_covered < 11` —
+   removes the ≈2,270 already-persisted FY rows whose duration is impossibly sub-annual.
+
+**Why the predicate is STRUCTURAL, not "absent from raw" (Codex ckpt-2 catch).**
+`financial_facts_raw` is itself retention-swept — only the latest few 10-K/10-Q accessions
+survive (`app/services/financial_facts_retention.py`, daily). So a *legitimate* older annual
+row's facts age out of raw while its canonical row is the durable history. A "delete labels
+absent from raw" predicate would therefore truncate real history on every steady-state
+normalize. Deleting only `months_covered < 11` FY rows touches exactly the impossible-
+duration rows and never a valid `months_covered≈12` annual row, in any retention state.
+`best_source` never produces an FY `periods_raw` row with `months_covered < 11` (the duration
+guard requires ≥335-day facts), so this delete never fights the re-insert.
+
+**Aged-out wrong-VALUE rows** (a `months_covered≈12` row a pre-fix derivation bound to a
+quarter-magnitude value, whose facts have since aged out) are *not* caught by the structural
+predicate. They are corrected when a full `POST /jobs/sec_rebuild/run` re-ingests their
+filings (temporarily repopulating `facts_raw` with full history) and re-derives — the rewash
++ `best_source` upsert then overwrites them with the correct annual value. This is the
+operator backfill step (clause 10), documented in the runbook.
+
+Both deletes are scoped to `source='sec_edgar'` so a future companies_house fundamentals
+path (no rows today) is preserved.
+
+### Why this is strictly correct, not just better
+
+- **Annual fact recovered regardless of frame** — the 43% `frame=NULL` annual facts now
+  bind (fixes failure mode 1).
+- **Quarter-duration facts rejected from FY columns** — 3-month durations tagged `fp=FY`
+  no longer populate FY flow columns (fixes failure mode 2).
+- **YTD cumulatives still excluded** — 6-month (Q2) and 9-month (Q3) durations fall outside
+  the ±1 band for a quarter, exactly as the old frame filter intended.
+- **53-week years / 14-week Q4 tolerated** — 371 days → round(371/30.44)=12; 98 days →
+  round(98/30.44)=3; both inside the band.
+- **No quarterly regression** — quarterly rows previously bound the frame-bearing 3-month
+  fact; the same 3-month fact is now selected by duration (now also catching `frame=NULL`
+  standalone quarters that the old filter wrongly dropped).
+
+## Tolerance edge cases (full-population quantified)
+
+- Annual facts with a context just **below** the window (300–334 days, e.g. a short
+  transition fiscal year after a fiscal-year-end change) are dropped → FY flow NULL for that
+  rare year. Full-pop count of such FY-context revenue facts = **28** (vs 40,004 in-window).
+  Just-**above** (396–430 days) = **0**; >430 days = 3 (junk). Binding a non-annual value to
+  an annual column is worse than NULL, so dropping these 28 is acceptable. (No special-casing
+  — KISS.)
+
+## Verification (full-population)
+
+1. **Pre-merge harness** — for the panel (AAPL, MSFT, HD, GME, JPM) pull raw facts and run
+   `_derive_periods_from_facts`; assert each FY row binds the correct ~12-month annual
+   revenue and `months_covered==12`, cross-check AAPL FY2024 revenue = $391.035B against
+   SEC EDGAR.
+2. **Backfill** — `POST /jobs/sec_rebuild/run` scoped `{"source":"sec_edgar"}` fundamentals
+   on dev DB; re-run the full-population scan and confirm: (a) FY revenue/net_income/
+   operating_income NULL rate drops sharply, (b) FY rows with `months_covered=3` reach ~0,
+   (c) **no quarterly regression** — Q-row count and a sampled set of Q revenue values are
+   retained or increased (the guard now also admits `frame=NULL` standalone quarters),
+   (d) `revenue_growth_yoy`-computable instrument fraction rises well above the 8.8% baseline.
+3. **Operator-visible** — `GET /instrument/AAPL/peers` "Revenue growth YoY" renders for the
+   panel (was `—`).
+
+## Out of scope
+
+- `fiscal_period` mislabeling upstream (8-K facts tagged `fp=FY` with quarterly durations)
+  is left as-is; the duration guard makes the FY builder robust to it. Re-tagging raw facts
+  is a separate, higher-blast change.
+- #1836 (peers UX missingness disclosure) is the front-end follow-up, gated separately.

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -143,22 +143,72 @@ class TestDerivePeriodsFromFacts:
         assert q4.fiscal_quarter == 4
 
     def test_skips_ytd_entries(self) -> None:
-        """Entries without frame (YTD cumulative) are excluded -- we only want
-        standalone quarterly or annual values identified by frame."""
+        """#1835 — YTD cumulatives are excluded by DURATION, not by frame. A
+        6-month (Q1+Q2 cumulative) duration fact tagged fp=Q2 falls outside the
+        quarter window [60,120] days and is dropped; the standalone 3-month Q1
+        fact is kept."""
         facts = [
-            _fact(frame="CY2024Q1"),  # standalone quarter -- include
+            _fact(frame="CY2024Q1"),  # standalone 3mo quarter (~90d) -- include
             _fact(
-                frame=None,
+                frame="CY2024Q2",  # frame present, but 6mo duration -- still excluded
                 period_end="2024-06-30",
                 period_start="2024-01-01",
                 fiscal_period="Q2",
                 accession_number="ytd-q2",
-            ),  # YTD Q1+Q2 cumulative -- exclude
+            ),  # YTD Q1+Q2 cumulative (~181d) -- exclude by duration
         ]
         periods = _derive_periods_from_facts(facts, reported_currency="USD")
-        # Only the framed Q1 should produce a period
+        # Only the 3-month Q1 should produce a period
         assert len(periods) == 1
         assert periods[0].period_type == "Q1"
+
+    def test_fy_binds_annual_fact_without_frame(self) -> None:
+        """#1835 regression — an annual (~12-month) flow fact with frame=None is
+        bound to the FY row (the SEC Frames label lands on the next year's
+        comparative re-stamp, so 43% of genuine annual facts carry frame=NULL
+        and were previously dropped, leaving FY revenue NULL)."""
+        facts = [
+            _fact(
+                concept="Revenues",
+                val=Decimal("391035000000"),
+                fiscal_period="FY",
+                fiscal_year=2024,
+                period_start="2023-10-01",
+                period_end="2024-09-28",  # ~363 days
+                frame=None,
+                form_type="10-K",
+                accession_number="fy2024",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        assert len(periods) == 1
+        assert periods[0].period_type == "FY"
+        assert periods[0].revenue == Decimal("391035000000")
+        assert periods[0].months_covered == 12
+
+    def test_fy_rejects_quarter_duration_mislabeled_fy(self) -> None:
+        """#1835 regression (failure mode 2) — a 3-month flow fact mislabeled
+        fp=FY (legacy 8-K facts carry a quarterly frame) must NOT populate the FY
+        flow column. With no annual-duration fact in the group, no FY row with a
+        bound revenue is produced."""
+        facts = [
+            _fact(
+                concept="Revenues",
+                val=Decimal("64698000000"),  # a single-quarter magnitude
+                fiscal_period="FY",
+                fiscal_year=2020,
+                period_start="2020-06-28",
+                period_end="2020-09-26",  # ~90 days, mislabeled FY
+                frame="CY2020Q4",
+                form_type="10-K",
+                accession_number="q4-as-fy",
+            ),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        # The quarter-duration fact is rejected for the FY group; with only that
+        # fact present there is no mapped fact left to anchor an FY row.
+        fy = [p for p in periods if p.period_type == "FY"]
+        assert all(p.revenue is None for p in fy)
 
     def test_dei_fact_does_not_pollute_period_end(self) -> None:
         """Regression for #558.

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -209,10 +209,13 @@ class TestDerivePeriodsFromFacts:
         # fact, so no FY row is anchored at all. Assert emptiness explicitly — a
         # vacuous `all(... for p in fy)` over an empty list would pass even if the
         # quarter fact had wrongly bound, proving nothing about the rejection.
-        fy = [p for p in periods if p.period_type == "FY"]
-        assert fy == []
-        # And the quarter magnitude must never surface as revenue on any period.
-        assert all(p.revenue != Decimal("64698000000") for p in periods)
+        # The lone quarter-duration fact is rejected for the FY group and there
+        # is no other fact to anchor any row, so NO period is produced at all.
+        # Assert the full emptiness (not a vacuous `all(... for p in periods)`
+        # over an empty list, which would pass even if the quarter magnitude had
+        # wrongly bound). This also proves the 64698000000 magnitude never
+        # surfaces as revenue, since there is no period to carry it.
+        assert periods == []
 
     def test_dei_fact_does_not_pollute_period_end(self) -> None:
         """Regression for #558.

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -205,10 +205,14 @@ class TestDerivePeriodsFromFacts:
             ),
         ]
         periods = _derive_periods_from_facts(facts, reported_currency="USD")
-        # The quarter-duration fact is rejected for the FY group; with only that
-        # fact present there is no mapped fact left to anchor an FY row.
+        # The quarter-duration fact is rejected for the FY group; it was the only
+        # fact, so no FY row is anchored at all. Assert emptiness explicitly — a
+        # vacuous `all(... for p in fy)` over an empty list would pass even if the
+        # quarter fact had wrongly bound, proving nothing about the rejection.
         fy = [p for p in periods if p.period_type == "FY"]
-        assert all(p.revenue is None for p in fy)
+        assert fy == []
+        # And the quarter magnitude must never surface as revenue on any period.
+        assert all(p.revenue != Decimal("64698000000") for p in periods)
 
     def test_dei_fact_does_not_pollute_period_end(self) -> None:
         """Regression for #558.

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -205,10 +205,6 @@ class TestDerivePeriodsFromFacts:
             ),
         ]
         periods = _derive_periods_from_facts(facts, reported_currency="USD")
-        # The quarter-duration fact is rejected for the FY group; it was the only
-        # fact, so no FY row is anchored at all. Assert emptiness explicitly — a
-        # vacuous `all(... for p in fy)` over an empty list would pass even if the
-        # quarter fact had wrongly bound, proving nothing about the rejection.
         # The lone quarter-duration fact is rejected for the FY group and there
         # is no other fact to anchor any row, so NO period is produced at all.
         # Assert the full emptiness (not a vacuous `all(... for p in periods)`

--- a/tests/test_fundamentals_upsert_integration.py
+++ b/tests/test_fundamentals_upsert_integration.py
@@ -26,6 +26,7 @@ import pytest
 
 from app.providers.fundamentals import XbrlFact
 from app.services.fundamentals import (
+    normalize_financial_periods,
     start_ingestion_run,
     upsert_facts_for_instrument,
 )
@@ -239,3 +240,113 @@ def test_batches_across_chunk_boundary(
     ).fetchone()
     assert row is not None
     assert row[0] == 1500
+
+
+def test_normalize_binds_frameless_annual_and_cleans_invalid_fy(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#1835 end-to-end through the real canonical pipeline.
+
+    1. A 12-month annual revenue fact with ``frame=None`` binds the FY revenue
+       (the old Frames-label YTD filter dropped every frameless duration fact,
+       leaving FY revenue NULL for ~43% of annual facts).
+    2. A stale STRUCTURALLY-INVALID FY row (``months_covered=3`` — a 3-month
+       fact mislabeled fp=FY) is removed by the Phase-B2 cleanup.
+    3. SAFETY: a valid ``months_covered=12`` annual row whose facts have aged
+       out of retention-swept ``financial_facts_raw`` is PRESERVED — Phase-B2
+       must not truncate durable canonical history.
+    """
+    _seed_instrument(ebull_test_conn)
+    run_id = start_ingestion_run(
+        ebull_test_conn,
+        source="sec_edgar",
+        endpoint="/test",
+        instrument_count=1,
+    )
+    ebull_test_conn.commit()
+
+    annual = XbrlFact(
+        concept="Revenues",
+        taxonomy="us-gaap",
+        unit="USD",
+        period_start=date(2023, 10, 1),
+        period_end=date(2024, 9, 28),  # ~363 days — inside the [335,395] FY window
+        val=Decimal("391035000000"),
+        frame=None,  # #1835 — frameless annual must still bind
+        accession_number="acc-fy24",
+        form_type="10-K",
+        filed_date=date(2024, 11, 1),
+        fiscal_year=2024,
+        fiscal_period="FY",
+        decimals="-3",
+    )
+    cash = XbrlFact(
+        concept="CashAndCashEquivalentsAtCarryingValue",
+        taxonomy="us-gaap",
+        unit="USD",
+        period_start=None,
+        period_end=date(2024, 9, 28),
+        val=Decimal("30000000000"),
+        frame=None,
+        accession_number="acc-fy24",
+        form_type="10-K",
+        filed_date=date(2024, 11, 1),
+        fiscal_year=2024,
+        fiscal_period="FY",
+        decimals="-3",
+    )
+    upsert_facts_for_instrument(
+        ebull_test_conn,
+        instrument_id=_INSTRUMENT_ID,
+        facts=[annual, cash],
+        ingestion_run_id=run_id,
+    )
+
+    # Stale mislabeled 3-month FY row (months_covered=3) — must be deleted.
+    ebull_test_conn.execute(
+        "INSERT INTO financial_periods (instrument_id, period_end_date, "
+        "period_type, fiscal_year, fiscal_quarter, months_covered, source, "
+        "source_ref, reported_currency, is_restated, is_derived, "
+        "normalization_status) "
+        "VALUES (%s, '2020-09-26', 'FY', 2020, NULL, 3, 'sec_edgar', 'stale', "
+        "'USD', FALSE, FALSE, 'normalized')",
+        (_INSTRUMENT_ID,),
+    )
+    # Valid annual row whose facts have aged out of raw (months_covered=12) —
+    # must be PRESERVED (Phase-B2 must not truncate durable history).
+    ebull_test_conn.execute(
+        "INSERT INTO financial_periods (instrument_id, period_end_date, "
+        "period_type, fiscal_year, fiscal_quarter, months_covered, revenue, "
+        "source, source_ref, reported_currency, is_restated, is_derived, "
+        "normalization_status) "
+        "VALUES (%s, '2015-09-26', 'FY', 2015, NULL, 12, 233715000000, "
+        "'sec_edgar', 'aged-out', 'USD', FALSE, FALSE, 'normalized')",
+        (_INSTRUMENT_ID,),
+    )
+    ebull_test_conn.commit()
+
+    normalize_financial_periods(ebull_test_conn, instrument_ids=[_INSTRUMENT_ID])
+    ebull_test_conn.commit()
+
+    bound = ebull_test_conn.execute(
+        "SELECT revenue, months_covered FROM financial_periods "
+        "WHERE instrument_id = %s AND period_type = 'FY' AND fiscal_year = 2024",
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert bound is not None
+    assert bound[0] == Decimal("391035000000")
+    assert bound[1] == 12
+
+    invalid = ebull_test_conn.execute(
+        "SELECT COUNT(*) FROM financial_periods WHERE instrument_id = %s AND fiscal_year = 2020",
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert invalid is not None
+    assert invalid[0] == 0  # mislabeled 3-month FY row removed
+
+    preserved = ebull_test_conn.execute(
+        "SELECT revenue FROM financial_periods WHERE instrument_id = %s AND fiscal_year = 2015 AND period_type = 'FY'",
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert preserved is not None  # valid aged-out annual history NOT truncated
+    assert preserved[0] == Decimal("233715000000")


### PR DESCRIPTION
Closes #1835.

## Problem
`financial_periods` FY rows had flow columns largely NULL or wrong-duration. Full-population (dev DB 2026-06-29, n=46,992 FY rows): revenue 80% NULL, net_income 87%, op_income 88%; only 46% had `months_covered=12`; 2,270 FY rows (1,613 instruments) were 3-month windows mislabeled `period_type='FY'`. `revenue_growth_yoy` computable for only 8.8% of instruments (`/instrument/AAPL/peers` showed `—` for AAPL + 7/8 peers).

## Root cause (verified, not inferred)
`_derive_periods_from_facts` (L987) used the SEC **Frames-API `frame` label** as the YTD discriminator:
```python
if is_duration and fact.frame is None: continue
```
The Frames API is *"one fact per reporting entity, last filed"* per **calendar** period (`CY{year}`/`CY{year}Q{n}`) — a cross-sectional comparability tag, **not** a per-issuer period key. Full-pop: of 40,004 annual-duration (335–395d) FY-context revenue facts, **17,132 (43%) carry `frame=NULL`** and were dropped though they are the genuine annual fact; **5,835** quarter-duration facts mislabeled `fp=FY` carried a quarterly frame and polluted FY rows.

AAPL `(fy=2024, fp=FY)` revenue: `pe=2024-09-28 mo=12 frame=None val=391,035M` (the real FY2024) was dropped; FY2025 worked only because its fact happened to carry `frame=CY2025`.

## Source rule
SEC EDGAR XBRL. The authoritative period-length signal is the **XBRL context duration** (`endDate − startDate`), not `frame`. Quarter window `[60,120]`d is the settled codebase convention (`sec_fundamentals._ttm_from_quarters`); annual `365±30=[335,395]`d is the SEC Frames annual tolerance. Together they reject 3mo (~91d), 6mo Q2-YTD (~182d), 9mo Q3-YTD (~273d).

## Fix
1. **Duration guard** (`_FLOW_DURATION_DAYS`) replaces the frame filter — binds the annual fact regardless of frame, rejects YTD/wrong-duration. Instant (balance-sheet) facts always kept.
2. **Idempotent cleanup of persisted bad rows:**
   - Step-3 `financial_periods_raw` rewash (DELETE-then-INSERT, `sec_edgar`-scoped) so stale staging rows can't re-feed the canonical merge.
   - Phase-B2 delete of **structurally-invalid** FY rows (`period_type='FY' AND months_covered IS NOT NULL AND months_covered < 11`).

### Why the predicate is structural, not "absent from raw" (Codex ckpt-2 catch)
`financial_facts_raw` is retention-swept (latest few 10-K/10-Q accessions only), so a legitimate older annual row's facts age out while its canonical row is the durable history. A "delete labels absent from raw" predicate would truncate that history on every steady-state normalize. `months_covered < 11` touches only impossible-duration FY rows and never a valid `~12`-month row, in any retention state. Aged-out **wrong-value** `mo=12` rows are corrected by the operator `sec_rebuild` re-ingest (clause 10).

## Verification
- **Full-pop**: duration histogram confirms `[335,395]` captures 40,004 annual facts; only 28 legit stubs just below, 0 just above.
- **Panel** (AAPL/MSFT/HD/GME/JPM) via real raw facts + dev-DB re-normalize: every FY row binds revenue, 0 three-month FY rows. AAPL FY2024 = **$391.035B** (cross-checked vs SEC EDGAR), MSFT FY2024 = $245.122B, **JPM 1→4** FY rows with revenue. Q4 derivation correct (FY2025 Q4 = 416,161 − 313,695 = 102,466M).
- **Operator-visible (clause 11)**: `GET /instruments/AAPL/peer-comparison` → `revenue_growth_yoy = 0.0643` (6.43% = (416,161−391,035)/391,035), was `—`.
- Tests: 2 unit regressions (`test_fy_binds_annual_fact_without_frame`, `test_fy_rejects_quarter_duration_mislabeled_fy`) + 1 DB integration (`test_normalize_binds_frameless_annual_and_cleans_invalid_fy`, asserts the mo=12 aged-out row is **preserved**). Fast tier (4698) + smoke (135) + db fundamentals tier green; ruff/pyright clean.

## Operator follow-up
After merge: restart jobs daemon onto new main, then `POST /jobs/sec_rebuild/run {"source":"sec_edgar"}` to re-ingest full history and re-derive all instruments with the fixed binding (corrects aged-out wrong-value rows). #1836 (peers UX missingness disclosure) is the gated FE follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)