### PR TITLE
fix(#1836): flag peer factors thin by sector coverage, not a static set

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -59,11 +59,11 @@ from app.services.operators import (
     sole_operator_id,
 )
 from app.services.peer_comparison import (
-    DEV_LIMITED_FACTORS,
     FACTOR_BETTER_WHEN,
     FACTOR_KEYS,
     FACTOR_LABELS,
     compute_peer_comparison,
+    is_factor_thin,
 )
 from app.services.portfolio_risk import (
     PortfolioRiskStatus,
@@ -286,7 +286,7 @@ class PeerFactor(BaseModel):
     instrument_value: float | None
     sector_median: float | None
     sector_n: int  # # sector members with a non-null value for this factor
-    dev_limited: bool  # True for price-gated factors (P/E) — thin on dev
+    dev_limited: bool  # True when thin: price-gated (P/E) OR sector coverage <20% (#1836)
     better_when: Literal["higher", "lower"]
 
 
@@ -928,9 +928,10 @@ def get_instrument_peer_comparison(
     Per instrument: the radar factors (P/E, ROE, revenue growth YoY, operating
     margin, debt/equity, net margin), their sector medians, and a size-proximity
     peer set — all derived server-side from existing fundamentals (no new
-    ingest). P/E is ``dev_limited`` (price-gated). 404 when the instrument has no
+    ingest). A factor is ``dev_limited`` (thin: greyed + ⚠) when price-gated
+    (P/E) OR its sector coverage is <20% (#1836). 404 when the instrument has no
     sector classification or no complete-TTM fundamentals. Policy lives in
-    app/services/peer_comparison.py.
+    app/services/peer_comparison.py (``is_factor_thin``).
     """
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -970,7 +971,7 @@ def get_instrument_peer_comparison(
                 instrument_value=result.self_factors.get(key),
                 sector_median=result.medians[key].median,
                 sector_n=result.medians[key].n,
-                dev_limited=key in DEV_LIMITED_FACTORS,
+                dev_limited=is_factor_thin(key, result.medians[key].n, result.sector_member_count),
                 better_when=FACTOR_BETTER_WHEN[key],  # type: ignore[arg-type]
             )
             for key in FACTOR_KEYS

--- a/app/services/peer_comparison.py
+++ b/app/services/peer_comparison.py
@@ -56,8 +56,35 @@ FACTOR_BETTER_WHEN: dict[str, str] = {
     "debt_equity_ratio": "lower",
     "net_margin": "higher",
 }
-# pe_ratio is price-gated (instrument_valuation live-price join) → dev-limited.
+# pe_ratio is price-gated (instrument_valuation live-price join) → structurally
+# thin on dev regardless of how many sector members exist.
 DEV_LIMITED_FACTORS: frozenset[str] = frozenset({"pe_ratio"})
+
+# A factor is "thin" (greyed + ⚠ in the UI, its sector median read as noisy) when
+# it is either structurally dev-limited OR its sector coverage is below this
+# fraction of the complete-TTM sector base. Below ~20% the median rests on too
+# small a non-null base to be meaningful (#1836). The cut is a visual-taste call
+# the operator pre-approved at ~20%; the dev DB separates cleanly — thin factors
+# (pe_ratio, revenue_growth_yoy) peak at 12.5% coverage, healthy factors floor at
+# 24.6%, so 0.20 flags the former without catching the latter.
+THIN_COVERAGE_RATIO: float = 0.20
+
+
+def is_factor_thin(key: str, sector_n: int, sector_member_count: int) -> bool:
+    """
+    True when a factor should be disclosed as thin/unreliable for a sector.
+
+    Pure policy (no I/O) — table-tested. ``sector_n`` is the count of sector
+    members with a non-null value for the factor; ``sector_member_count`` is the
+    complete-TTM sector base (the median denominator). Structurally dev-limited
+    factors are always thin; an empty base is treated as thin (no signal).
+    """
+    if key in DEV_LIMITED_FACTORS:
+        return True
+    if sector_member_count <= 0:
+        return True
+    return sector_n / sector_member_count < THIN_COVERAGE_RATIO
+
 
 # Per-instrument factor CTE, parameterised by ``%(sector)s``. Mirrors the
 # instrument_valuation formulas (sql/201) for the price-free factors; LEFT JOINs

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -457,7 +457,7 @@ export interface PeerFactor {
   sector_median: number | null;
   /** # sector members with a non-null value (low n → noisy median). */
   sector_n: number;
-  /** True for price-gated factors (P/E) — thin on dev. */
+  /** True when thin (greyed + ⚠): price-gated (P/E) OR sector coverage <20% (#1836). */
   dev_limited: boolean;
   better_when: "higher" | "lower";
 }

--- a/frontend/src/components/peers/peerComparisonCharts.tsx
+++ b/frontend/src/components/peers/peerComparisonCharts.tsx
@@ -79,7 +79,7 @@ function RadarTooltip({ active, payload, symbol }: RadarTooltipProps): JSX.Eleme
       </div>
       <div className="text-slate-500 dark:text-slate-400">
         better {pt.betterWhen} · n={pt.sectorN.toLocaleString()}
-        {pt.devLimited ? " · dev-limited" : ""}
+        {pt.devLimited ? " · thin coverage" : ""}
       </div>
     </ChartTooltip>
   );
@@ -152,7 +152,8 @@ export function PeerRadarChart({
       </ResponsiveContainer>
       <p className="mt-1 px-2 text-[10px] text-slate-400">
         Axes normalized per factor across the instrument + sector median + peers; outward = better
-        (orientation per factor). ⚠ = dev-limited (thin sector coverage). Hover for raw values.
+        (orientation per factor). ⚠ = thin sector coverage (price-gated or &lt;20% of members) —
+        median is noisy; a missing vertex is a data gap, not worst-in-class. Hover for raw values.
       </p>
     </div>
   );
@@ -190,7 +191,7 @@ export function SectorHeatmap({ heatmap }: { heatmap: Heatmap }): JSX.Element {
             className={`px-1 text-center leading-tight ${
               f.devLimited ? "text-slate-400" : "text-slate-600 dark:text-slate-300"
             }`}
-            title={`${f.label}${f.devLimited ? " (dev-limited)" : ""} · sector n=${f.sectorN}`}
+            title={`${f.label}${f.devLimited ? " (thin coverage)" : ""} · sector n=${f.sectorN}`}
           >
             {f.label}
             {f.devLimited ? " ⚠" : ""}
@@ -228,7 +229,7 @@ export function SectorHeatmap({ heatmap }: { heatmap: Heatmap }): JSX.Element {
       </div>
       <p className="mt-2 text-[10px] text-slate-400">
         Cell shade red→green by relative rank within each factor (green = better, per factor
-        orientation). Instrument row pinned on top. ⚠ = dev-limited factor.
+        orientation). Instrument row pinned on top. ⚠ = thin coverage; — = no data (not worst).
       </p>
     </div>
   );

--- a/frontend/src/lib/peerComparison.ts
+++ b/frontend/src/lib/peerComparison.ts
@@ -258,7 +258,7 @@ export function buildScatter(
 // ---------------------------------------------------------------------------
 
 export interface PeerCoverage {
-  /** Factors flagged dev_limited (e.g. P/E) — greyed in the UI. */
+  /** Factors flagged thin (price-gated like P/E, or <20% sector coverage) — greyed in the UI. */
   readonly devLimitedKeys: string[];
   /** Min sector_n across factors — low n means a noisy median. */
   readonly minSectorN: number;

--- a/frontend/src/pages/PeersPage.tsx
+++ b/frontend/src/pages/PeersPage.tsx
@@ -120,7 +120,7 @@ function PeersBody({ data }: { data: PeersData }): JSX.Element {
         Sector {pc.sector} · {pc.sector_member_count.toLocaleString()} members · {pc.peers.length}{" "}
         size-matched peers.
         {coverage.devLimitedKeys.length > 0
-          ? ` ${coverage.devLimitedKeys.length} factor${coverage.devLimitedKeys.length === 1 ? "" : "s"} dev-limited (greyed).`
+          ? ` ${coverage.devLimitedKeys.length} factor${coverage.devLimitedKeys.length === 1 ? "" : "s"} thin-coverage (greyed; median noisy).`
           : ""}
         {coverage.minSectorN < 50
           ? ` Some sector medians rest on as few as ${coverage.minSectorN.toLocaleString()} members — read them as noisy.`

--- a/tests/test_peer_comparison.py
+++ b/tests/test_peer_comparison.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import psycopg
 import pytest
 
-from app.services.peer_comparison import compute_peer_comparison
+from app.services.peer_comparison import compute_peer_comparison, is_factor_thin
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 (fixture re-export)
 
 __all__ = ["ebull_test_conn"]
@@ -135,6 +135,17 @@ def test_compute_peer_comparison_db(ebull_test_conn: psycopg.Connection[tuple]) 
     # median of revenue_growth_yoy: only self has a value → median 0.1, n=1.
     assert result.medians["revenue_growth_yoy"].n == 1
     assert result.medians["revenue_growth_yoy"].median == pytest.approx(0.1)
+
+    # Thin-factor policy applied to the REAL result coverage (#1836): the API
+    # serializer feeds these exact fields to is_factor_thin. pe_ratio has no
+    # price on dev → n=0 → thin; revenue_growth_yoy n=1/3 (33%) clears the 20%
+    # cut in this tiny fixture → NOT thin (it is only thin on the full pop where
+    # coverage is ~4%). Guards the mapping from regressing to a static set.
+    mc = result.sector_member_count
+    assert result.medians["pe_ratio"].n == 0
+    assert is_factor_thin("pe_ratio", result.medians["pe_ratio"].n, mc) is True
+    assert is_factor_thin("revenue_growth_yoy", result.medians["revenue_growth_yoy"].n, mc) is False
+    assert is_factor_thin("roe", result.medians["roe"].n, mc) is False
 
 
 @pytest.mark.db

--- a/tests/test_peer_comparison_ranking.py
+++ b/tests/test_peer_comparison_ranking.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from app.services.peer_comparison import FACTOR_KEYS, _rank_peers, _row_factors
+from app.services.peer_comparison import (
+    FACTOR_KEYS,
+    THIN_COVERAGE_RATIO,
+    _rank_peers,
+    _row_factors,
+    is_factor_thin,
+)
 
 
 def _row(iid: int, ta: float | None, **factors: float | None) -> dict[str, object]:
@@ -43,3 +49,30 @@ def test_row_factors_maps_all_keys() -> None:
     assert f["roe"] == 0.1
     assert f["pe_ratio"] == 15.0
     assert f["net_margin"] is None
+
+
+def test_is_factor_thin_price_gated_always_thin() -> None:
+    # pe_ratio is structurally dev-limited regardless of coverage.
+    assert is_factor_thin("pe_ratio", sector_n=1000, sector_member_count=1000) is True
+
+
+def test_is_factor_thin_low_coverage_flagged() -> None:
+    # revenue_growth_yoy at ~5% coverage (dev DB: 3-12%) → thin.
+    assert is_factor_thin("revenue_growth_yoy", sector_n=40, sector_member_count=951) is True
+
+
+def test_is_factor_thin_healthy_coverage_not_flagged() -> None:
+    # operating_margin floors at 24.6% on the dev DB — above the 20% cut.
+    assert is_factor_thin("operating_margin", sector_n=152, sector_member_count=617) is False
+
+
+def test_is_factor_thin_threshold_boundary() -> None:
+    # Exactly at the threshold is NOT thin (strict <); just below is thin.
+    n = int(THIN_COVERAGE_RATIO * 100)
+    assert is_factor_thin("roe", sector_n=n, sector_member_count=100) is False
+    assert is_factor_thin("roe", sector_n=n - 1, sector_member_count=100) is True
+
+
+def test_is_factor_thin_empty_base_is_thin() -> None:
+    # No complete-TTM members → no signal → thin (avoids div-by-zero).
+    assert is_factor_thin("roe", sector_n=0, sector_member_count=0) is True


### PR DESCRIPTION
Closes #1836.

## Problem
`PeerFactor.dev_limited` was hardcoded to `frozenset({"pe_ratio"})`, so the peer-comparison radar/heatmap only ever greyed P/E. `revenue_growth_yoy` — null for **~94% of complete-TTM instruments** (only 4.2% coverage in AAPL's sector even after #1835) — rendered with **no ⚠/greyed disclosure**. Result: missing read as worst-in-class, and an outlier-skewed median (AAPL sector: **251%**, n=40) was presented as fact. Contradicted the missingness-honest direction of #1815.

## Fix
A factor is now `dev_limited` (thin) when **price-gated OR sector coverage < `THIN_COVERAGE_RATIO` (0.20)** — `app/services/peer_comparison.py::is_factor_thin` (pure policy: empty-base/div-by-zero safe, strict `<`). The API serializer (`app/api/instruments.py`) feeds the real result coverage to it.

FE copy reworded **dev-limited → thin-coverage** (honest for both reasons); radar + heatmap captions now state "— = no data (**not worst**)". Wording only — greying already keyed off `dev_limited`.

## Source rule / threshold
Display-honesty, **not** an SEC data-treatment rule. Threshold is a visual-taste call the operator pre-approved at ~20%.

**Full-population verification** (dev DB, per-sector coverage): thin factors (`pe_ratio`, `revenue_growth_yoy`) peak at **12.5%** coverage; healthy factors (`roe`/`operating_margin`/`debt_equity`/`net_margin`) floor at **24.6%**. So 0.20 flags the former without catching the latter — clean margin.

## Conscious tradeoff
Median is **marked** (⚠ + n shown), not suppressed — preserves the only signal. The garbage median still distorts the radar's per-factor cohort scale, but that is disclosed; fixing cohort scaling is out of scope (the issue asked to disclose, not recompute).

## Gated on #1835 (merged)
#1835 populated `revenue_growth_yoy` for instruments with 2 consecutive FY rows; this is the honest-disclosure backstop for whatever remains sparse.

## Verification
- **Live endpoint** `GET /instruments/AAPL/peer-comparison`: `revenue_growth_yoy` `dev_limited=true` (4.2%), `pe_ratio` true, healthy factors false; AAPL value 6.43% (from #1835), median 251% now disclosed.
- **FE page** `/instrument/AAPL/peers` (Playwright, logged-in): banner "2 factors thin-coverage (greyed; median noisy)"; both P/E and Revenue growth YoY axes greyed + ⚠ on radar AND heatmap; peers render "—" not 0; dark mode clean.
- **Tests**: 6 pure `is_factor_thin` cases (price-gated, low/healthy coverage, threshold boundary, empty base) + DB test asserts the policy against real result coverage (guards against regressing to the static set). FE typecheck + 1164 unit tests pass.

## Files
`peer_comparison.py` (policy), `instruments.py` (serializer + docstring + field comment), `types.ts` (FE field comment), `peerComparisonCharts.tsx` / `PeersPage.tsx` / `peerComparison.ts` (copy), 2 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)