### PR TITLE
fix(#1839): guard YoY growth against non-adjacent periods

### DIFF
--- a/frontend/src/lib/fundamentalsMetrics.test.ts
+++ b/frontend/src/lib/fundamentalsMetrics.test.ts
@@ -188,6 +188,63 @@ describe("buildYoyGrowth", () => {
     expect(yoy[1]!.eps_yoy_pct).toBe(150);
   });
 
+  it("nulls annual YoY across a multi-year gap instead of fabricating a spike (#1839)", () => {
+    // AAPL-shaped: FY2012 then FY2023 (FY2013-2022 aged out). The positional
+    // prior is 11 years back, so (383285-156508)/156508 ≈ +145% — bogus.
+    const periods = joinStatements(
+      [
+        row("2012-09-29", { revenue: "156508", eps_diluted: "1" }, "FY"),
+        row("2023-09-30", { revenue: "383285", eps_diluted: "6" }, "FY"),
+        row("2024-09-28", { revenue: "391035", eps_diluted: "6.5" }, "FY"),
+      ],
+      [],
+      [],
+    );
+    const yoy = buildYoyGrowth(periods, "annual");
+    expect(yoy[0]!.revenue_yoy_pct).toBeNull(); // no prior
+    expect(yoy[1]!.revenue_yoy_pct).toBeNull(); // 11-year gap → not adjacent
+    expect(yoy[1]!.eps_yoy_pct).toBeNull();
+    // 2024 vs 2023 is a real consecutive year → computes normally.
+    expect(yoy[2]!.revenue_yoy_pct).toBeCloseTo(2.02, 1);
+  });
+
+  it("nulls quarterly YoY when the prior-year quarter is missing (#1839)", () => {
+    // 4 lags back lands on a quarter ~2 years away (a year of quarters is
+    // missing), so the 300-430 day guard rejects it.
+    const periods = joinStatements(
+      [
+        row("2023-03-31", { revenue: "100" }, "Q1"),
+        row("2023-06-30", { revenue: "100" }, "Q2"),
+        row("2023-09-30", { revenue: "100" }, "Q3"),
+        row("2023-12-31", { revenue: "100" }, "Q4"),
+        row("2025-03-31", { revenue: "150" }, "Q1"),
+      ],
+      [],
+      [],
+    );
+    const yoy = buildYoyGrowth(periods, "quarterly");
+    // periods[4] vs periods[0]: 2025-03-31 − 2023-03-31 ≈ 731 days → nulled.
+    expect(yoy[4]!.revenue_yoy_pct).toBeNull();
+  });
+
+  it("accepts a 53-week fiscal quarterly gap (~371 days) within the guard (#1839)", () => {
+    // 53-week filers shift the prior-year quarter ~371 days back — must stay
+    // inside the 300-430 window so legit YoY still computes.
+    const periods = joinStatements(
+      [
+        row("2024-02-03", { revenue: "100" }, "Q1"),
+        row("2024-05-04", { revenue: "100" }, "Q2"),
+        row("2024-08-03", { revenue: "100" }, "Q3"),
+        row("2024-11-02", { revenue: "100" }, "Q4"),
+        row("2025-02-08", { revenue: "120" }, "Q1"), // 371 days after 2024-02-03
+      ],
+      [],
+      [],
+    );
+    const yoy = buildYoyGrowth(periods, "quarterly");
+    expect(yoy[4]!.revenue_yoy_pct).toBe(20);
+  });
+
   it("computes FCF-YoY from operating_cf - capex", () => {
     const cashflow = [
       row("2025-12-31", { operating_cf: "100", capex: "30" }, "FY"),

--- a/frontend/src/lib/fundamentalsMetrics.ts
+++ b/frontend/src/lib/fundamentalsMetrics.ts
@@ -228,6 +228,25 @@ export interface YoyRow {
   readonly fcf_yoy_pct: number | null;
 }
 
+// A YoY comparison is only valid when the prior row is ~1 calendar year back:
+// both annual (lag 1) and quarterly (lag 4, prior-year same quarter) span ~365
+// days. When the history has a gap the positional prior is years away and
+// `(cur - prior) / prior` is a fabricated jump — e.g. AAPL's FY rows skip from
+// 2012 to 2023 once older raw facts age out (#1835), yielding a bogus +145%
+// "YoY". Mirror peer_comparison's consecutive-year guard (sql/services use
+// 300-430 days) and null the YoY across non-adjacent periods so the chart shows
+// a gap, not a fabricated spike (#1839).
+const _YOY_GAP_DAYS_MIN = 300;
+const _YOY_GAP_DAYS_MAX = 430;
+const _MS_PER_DAY = 86_400_000;
+
+/** True when `priorEnd` is ~1 calendar year before `curEnd` (300-430 days).
+ *  ISO date-only strings parse as UTC midnight, so the diff is exact. */
+function isYearApart(curEnd: string, priorEnd: string): boolean {
+  const days = (Date.parse(curEnd) - Date.parse(priorEnd)) / _MS_PER_DAY;
+  return days >= _YOY_GAP_DAYS_MIN && days <= _YOY_GAP_DAYS_MAX;
+}
+
 /** Year-over-year growth. Lag is determined by the page-level period
  *  the rows were fetched for: quarterly → 4 lag (prior-year quarter),
  *  annual → 1 lag (prior fiscal year). Looking at row-level
@@ -235,14 +254,19 @@ export interface YoyRow {
  *  `Q1`/`Q2`/`Q3`/`Q4` and `FY`, never the literal string `"annual"`,
  *  so a row-level check would silently fall back to the quarterly
  *  branch on annual data. The first `lag` rows are still emitted with
- *  null values so the time axis stays aligned with the other charts. */
+ *  null values so the time axis stays aligned with the other charts.
+ *  A non-adjacent prior (history gap) is also nulled — see the guard above. */
 export function buildYoyGrowth(
   periods: ReadonlyArray<JoinedPeriod>,
   period: "quarterly" | "annual" = "quarterly",
 ): YoyRow[] {
   const lag = period === "annual" ? 1 : 4;
   return periods.map((p, i) => {
-    const prior = i >= lag ? periods[i - lag] : undefined;
+    const candidate = i >= lag ? periods[i - lag] : undefined;
+    const prior =
+      candidate !== undefined && isYearApart(p.period_end, candidate.period_end)
+        ? candidate
+        : undefined;
     const fcf = (cur: JoinedPeriod): number | null => {
       if (cur.operating_cf === null || cur.capex === null) return null;
       // capex is XBRL `us-gaap:PaymentsToAcquirePropertyPlantAndEquipment`,


### PR DESCRIPTION
Closes #1839.

## Problem
`buildYoyGrowth` (`frontend/src/lib/fundamentalsMetrics.ts`) compared each period to a **positional** lag (annual `i-1`, quarterly `i-4`) with no check the prior row was ~1 year back. When the FY history has a gap — AAPL's rows skip **2012 → 2023** after older raw facts age out (#1835's known residual) — it computed `(383285−156508)/156508 ≈ +145%` and rendered it as a single Revenue spike, rescaling the whole YoY chart to 105%.

## Fix
Add a consecutive-period day-gap guard (**300–430 days**) mirroring `peer_comparison`'s yoy CTE (#1835): a YoY is valid only when the prior row is ~1 calendar year back — annual lag-1 and quarterly lag-4 both span ~365d — else null it so the chart shows a gap, not a fabricated jump. 52/53-week filers (364/371d) stay inside the window. Pure lib (`isYearApart`), no behaviour change for adjacent periods.

## Source rule
Display-honesty fix; the guard window (300–430d) is the same settled invariant `peer_comparison.py` uses for the consecutive-FY check (#1835). The underlying FY2013–2022 absence is a separate data-completeness residual (operator `sec_rebuild {"source":"sec_edgar"}` per #1835) — out of scope.

## Tests (pure, table-tested)
- annual multi-year gap (2012→2023) → null (was +145%); 2024 vs 2023 computes
- quarterly missing-prior-year (lag-4 ≈ 731d) → null
- 53-week (~371d) acceptance → computes (52/53-week not wrongly nulled)
- existing 365d annual/quarterly cases preserved
FE typecheck + 1167 unit tests pass.

## Verification
Live `/instrument/AAPL/fundamentals?period=annual`: the +145% Sep'23 spike is gone (gap), Sep'24/'25 compute normally, YoY y-axis rescaled **105% → 30%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)