### PR TITLE
fix(#1843): run the pre-push smoke tier serially (-n 0)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -280,8 +280,13 @@ uv run pytest -m "not db" --tb=short -q
 # drift) that mocked-cursor unit tests silently miss. Runs against the running
 # dev stack (ebull cluster); if the stack is down the gate fails loudly, which
 # is correct — a broken server should not ship.
+# -n 0 (serial): pyproject addopts forces -n 4 --dist=loadgroup, but the smoke
+# tier pulls real dev-DB fixtures (FastAPI lifespan) and 4 workers contend on DB
+# connections -> intermittent ERRORs on random parametrized cases (#1843). Smoke
+# is small (~135 tests, ~31s serial); the parallelism buys nothing and costs
+# determinism. The fast tier above keeps -n 4 (no DB => no contention).
 echo "==> Pre-push gate: smoke (app boots against dev DB)"
-uv run pytest tests/smoke --tb=short -q
+uv run pytest tests/smoke -n 0 --tb=short -q
 
 # Frontend dark-mode class hygiene (#708). Skipped if frontend/ is
 # absent (e.g. backend-only worktrees) or if `pnpm` is not on PATH —


### PR DESCRIPTION
Closes #1843.

## Problem
`git push` intermittently failed the pre-push gate's smoke step with `ERROR tests/smoke/test_etl_source_to_sink.py::test_manifest_source_has_sink_tables[<source>-specN]` — a different parametrized case each run; retry/solo passed. ~4 wasted push attempts in one session.

## Root cause
`pyproject.toml` `addopts = "… -n 4 --dist=loadgroup"` applies to every pytest invocation. The hook's smoke step (`.githooks/pre-push`) inherited `-n 4`, so the full smoke suite (135 tests, many pulling real **dev-DB** fixtures via the FastAPI lifespan) ran across 4 workers and contended on DB connections → nondeterministic ERRORs. A single smoke file under -n 4 passed; the full dir flaked. (CI doesn't run pytest, so only the local gate was affected.)

## Fix
Run the smoke tier serially: `uv run pytest tests/smoke -n 0 …`. The fast tier (`-m "not db"`, no DB) keeps `-n 4`.

## Verification
Serial smoke: **135 passed, 3 skipped, ~31s**, stable across 3 consecutive runs (vs intermittent ERRORs under -n 4). This very PR's push ran the patched gate and passed green on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)