### PR TITLE
fix(#1845): label instrument price chart with native currency

### DIFF
--- a/.claude/skills/frontend/operator-ui-conventions.md
+++ b/.claude/skills/frontend/operator-ui-conventions.md
@@ -20,7 +20,7 @@ All formatting goes through `frontend/src/lib/format.ts`. Adding parallel format
 
 Rules:
 
-- Currency is GBP for v1. Multi-currency is out of scope until a non-GBP account exists.
+- Currency is GBP for v1. Multi-currency is out of scope until a non-GBP account exists. **Exception — price charts render the instrument's NATIVE currency** (the OHLC candle endpoints return native, un-FX'd OHLC; spot-converting historical candles would misrepresent past prices). The header price beside the chart IS FX-converted to the operator display currency, so a native chart + converted header disagree numerically (GME: header `GBP 16.64`, axis `~22.10` USD). Any price chart must therefore carry a native-currency label so the two numbers reconcile (#1845: `PriceChart` `currency` prop fed from `summary.identity.currency`).
 - Percentages are **always** computed from fractions, not pre-multiplied numbers. Backend returns `0.0123`, not `1.23`.
 - Aggregate percentages are **capital-weighted** (`Σ pnl / Σ cost_basis`), never an average of per-row percentages.
 - Timestamps are en-GB, short month, 24h. Never raw ISO in the DOM.

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -106,7 +106,12 @@ export function DensityGrid({
   // "Open →" button is the only drill affordance now.
   const ChartPane = (
     <Pane title="Price chart" onExpand={drillToWorkspace} fillHeight>
-      <PriceChart symbol={symbol} instrumentId={instrumentId} sessionProfile={summary.session_profile} />
+      <PriceChart
+        symbol={symbol}
+        instrumentId={instrumentId}
+        sessionProfile={summary.session_profile}
+        currency={summary.identity.currency}
+      />
       <div className="mt-2">
         <Link
           to={`/instrument/${encodeURIComponent(symbol)}/risk`}

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -241,6 +241,29 @@ describe("PriceChart — type toggle (#587)", () => {
   });
 });
 
+describe("PriceChart — native-currency label (#1845)", () => {
+  it("renders the native-currency label when a currency is provided", async () => {
+    mockedFetch.mockResolvedValue(bars([]));
+    render(
+      <MemoryRouter>
+        <PriceChart symbol="AAPL" currency="USD" />
+      </MemoryRouter>,
+    );
+    const label = screen.getByTestId("chart-native-currency");
+    expect(label).toHaveTextContent("USD");
+  });
+
+  it("omits the label when currency is null (default)", async () => {
+    mockedFetch.mockResolvedValue(bars([]));
+    render(
+      <MemoryRouter>
+        <PriceChart symbol="AAPL" />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("chart-native-currency")).not.toBeInTheDocument();
+  });
+});
+
 describe("PriceChart — log scale toggle (#587)", () => {
   it("renders a Log toggle button defaulting to off", async () => {
     mockedFetch.mockResolvedValue(bars([]));

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -136,6 +136,13 @@ export interface PriceChartProps {
    *  Defaults to `us_equity` (the charted-intraday-dominant case, and the
    *  prior hardcoded behaviour) when the caller has no profile yet. */
   sessionProfile?: SessionProfile;
+  /** Instrument NATIVE currency (`summary.identity.currency`, e.g. "USD").
+   *  The chart always renders native-currency OHLC candles — unlike the
+   *  header price, which is FX-converted to the operator display currency
+   *  (#1845). Labelling the axis with the native currency keeps the chart
+   *  honest where header (e.g. GBP) and axis (e.g. USD) disagree. We do NOT
+   *  spot-convert historical OHLC — that would misrepresent past prices. */
+  currency?: string | null;
 }
 
 export function PriceChart({
@@ -143,6 +150,7 @@ export function PriceChart({
   instrumentId = null,
   initialRange = "1m",
   sessionProfile = "us_equity",
+  currency = null,
 }: PriceChartProps): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawChart = searchParams.get("chart");
@@ -366,6 +374,22 @@ export function PriceChart({
                 AH
               </button>
             </>
+          ) : null}
+          {/*
+            Native-currency label (#1845). The chart renders the
+            instrument's native-currency OHLC (USD for US equities); the
+            header price beside it is FX-converted to the operator display
+            currency (e.g. GBP). Without this label the two numbers read as
+            a contradiction. Muted, read-only — not a control.
+          */}
+          {currency ? (
+            <span
+              className="text-xs font-medium text-slate-500 dark:text-slate-400"
+              data-testid="chart-native-currency"
+              title={`Chart prices are in ${currency} (instrument native currency); the header price is converted to your display currency`}
+            >
+              {currency}
+            </span>
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
Closes #1845.

## Problem

On the instrument page (`/instrument/<symbol>`), the header price and the price chart show two different numbers for the same instrument with nothing to reconcile them:

- **Header** (`SummaryStrip`) renders the live price FX-converted to the operator display currency — GME shows `GBP 16.64` (live SSE tick carries a `display` leg converted to `config.runtime.display_currency`, default GBP; `liveTickDisplayPrice()` in `useLiveQuote.ts:155-166`).
- **Price chart** (`PriceChart` → lightweight-charts) renders the instrument's **native-currency** OHLC candles with no currency label — GME axis reads `~22.10` (USD). `/api/instruments/<symbol>/intraday-candles` returns native OHLCV, no currency field.

Verified empirically: `GET /instruments/GME/summary` → `identity.currency="USD"`, native close `≈22.10`; header rendered `GBP 16.64` (16.64 × ~1.33 ≈ 22.1). Everything else (dashboard/portfolio) is GBP per the `operator-ui-conventions` "GBP for v1" convention; the native-USD unlabeled chart is the outlier.

## Why label, not convert

Spot-converting historical OHLC by the current FX rate misrepresents past prices (a 5Y candle scaled by today's GBP/USD is wrong), and per-candle historical FX is out of scope. The honest minimal fix is to **label the chart with its native currency**.

## Change (FE-only, additive)

- `PriceChart.tsx`: new `currency?: string | null` prop; renders a muted, read-only currency label in the toolbar (right side, by the right price axis), with an explanatory `title`. Omitted when null. No lightweight-charts API change → avoids the #1841 `vi.mock` trap.
- `DensityGrid.tsx`: thread `summary.identity.currency` into `PriceChart`.
- `PriceChart.test.tsx`: label-present (`currency="USD"`) + label-absent (default) tests.
- `operator-ui-conventions.md`: document the native-chart-vs-converted-header rule.

## Scope note

The full chart workspace (`/instrument/:symbol/chart`, `ChartWorkspaceCanvas`) already shows the native price WITH a currency prefix in its header (`USD 22`), so header and axis agree there — self-consistent, unaffected. (Raised by Codex ckpt-2; verified in-browser.)

## Verification (commit 32b7f35e)

- `pnpm typecheck` ✅ · `pnpm dark:check` ✅ (229 files) · `pnpm test` ✅ (1171 passed, incl. 2 new) · pre-push gate ✅
- **Live (Playwright, dev stack):** `/instrument/GME` overview now renders `USD` in the chart toolbar beside the `GBP 16.64` header + `~22` axis — reconciled. Workspace `/instrument/GME/chart` confirmed already self-labeled (`USD 22`).
- Codex ckpt-2: no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)