### PR TITLE
fix(#1845): label instrument price chart with its native currency

### DIFF
--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -106,7 +106,12 @@ export function DensityGrid({
   // "Open →" button is the only drill affordance now.
   const ChartPane = (
     <Pane title="Price chart" onExpand={drillToWorkspace} fillHeight>
-      <PriceChart symbol={symbol} instrumentId={instrumentId} sessionProfile={summary.session_profile} />
+      <PriceChart
+        symbol={symbol}
+        instrumentId={instrumentId}
+        sessionProfile={summary.session_profile}
+        currency={summary.identity.currency}
+      />
       <div className="mt-2">
         <Link
           to={`/instrument/${encodeURIComponent(symbol)}/risk`}

--- a/frontend/src/components/instrument/PriceChart.test.tsx
+++ b/frontend/src/components/instrument/PriceChart.test.tsx
@@ -191,6 +191,28 @@ describe("PriceChart — range picker", () => {
   });
 });
 
+describe("PriceChart — native-currency label (#1845)", () => {
+  it("renders the native currency when provided", async () => {
+    mockedFetch.mockResolvedValue(bars([]));
+    render(
+      <MemoryRouter>
+        <PriceChart symbol="GME" currency="USD" />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("chart-currency")).toHaveTextContent("USD");
+  });
+
+  it("omits the label when no currency is provided", async () => {
+    mockedFetch.mockResolvedValue(bars([]));
+    render(
+      <MemoryRouter>
+        <PriceChart symbol="GME" />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByTestId("chart-currency")).not.toBeInTheDocument();
+  });
+});
+
 describe("PriceChart — type toggle (#587)", () => {
   it("renders three type buttons defaulting to Candle", async () => {
     mockedFetch.mockResolvedValue(bars([]));

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -136,6 +136,13 @@ export interface PriceChartProps {
    *  Defaults to `us_equity` (the charted-intraday-dominant case, and the
    *  prior hardcoded behaviour) when the caller has no profile yet. */
   sessionProfile?: SessionProfile;
+  /** Native currency of the charted OHLC candles (#1845), e.g. `"USD"`.
+   *  Rendered as a muted toolbar label so the operator can see the chart
+   *  axis is denominated in the instrument's native currency — distinct
+   *  from the GBP-converted header price (`SummaryStrip`). The candles are
+   *  NOT FX-converted (today's spot would misrepresent historical prices),
+   *  so labelling is the honest minimal fix. Omitted → no label. */
+  currency?: string | null;
 }
 
 export function PriceChart({
@@ -143,6 +150,7 @@ export function PriceChart({
   instrumentId = null,
   initialRange = "1m",
   sessionProfile = "us_equity",
+  currency = null,
 }: PriceChartProps): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const rawChart = searchParams.get("chart");
@@ -366,6 +374,21 @@ export function PriceChart({
                 AH
               </button>
             </>
+          ) : null}
+          {/*
+            Native-currency label (#1845), aligned with the right price
+            axis. The candles are raw native OHLC (no FX conversion), so
+            the axis can differ from the GBP-converted header price; the
+            label reconciles the two for the operator.
+          */}
+          {currency ? (
+            <span
+              className="text-xs font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500"
+              data-testid="chart-currency"
+              title={`Chart axis in the instrument's native currency (${currency}); the header price is converted to your display currency`}
+            >
+              {currency}
+            </span>
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Problem

On `/instrument/<symbol>` the header price and the price chart show two different numbers for the same instrument with nothing to reconcile them:

- **Header** (`SummaryStrip`) renders the live price FX-converted to the operator display currency (GBP default) — GME shows **`GBP 16.64`** via `liveTickDisplayPrice()` (`useLiveQuote.ts`).
- **Price chart** (`PriceChart`) renders native-currency OHLC candles with **no currency label** — GME axis reads ~`22.10` (USD).

Operator sees `GBP 16.64` above `~22.10` with no indication the chart is in a different (native) currency.

## Why label, not convert

Converting historical OHLC by today's spot FX misrepresents history (a 5Y chart scaled by today's GBP/USD is wrong); per-candle historical FX is out of scope. The honest minimal fix is to **label** the chart with its native currency.

## Change (FE-only, additive)

- `PriceChart.tsx`: new optional `currency?: string | null` prop; renders a muted, uppercase currency label far-right in the chart toolbar, aligned with the right price axis.
- `DensityGrid.tsx`: threads `currency={summary.identity.currency}` at the single mount.
- `PriceChart.test.tsx`: renders-when-provided / omitted-when-absent.

Pure-DOM label — **no new lightweight-charts API call**, so it avoids the #1841 `vi.mock`/`test:unit` trap (prevention-log #2071).

## Scope note (Codex ckpt-2 finding, rebutted with evidence)

Codex flagged the `/instrument/<symbol>/chart` workspace as having the same gap. Verified empirically it does not: the workspace header renders the **native** price (`summary.price.current` + `summary.price.currency` → `USD 22.0`), not the GBP live-tick leg, so it is already self-consistent and labelled. The mismatch is unique to the overview's `SummaryStrip` (live SSE display leg) — exactly #1845's scope.

## Verification (commit 44885a1a)

- Premise confirmed via API: `/instruments/GME/summary` → `identity.currency="USD"`, `price.current=22.0`, `price.currency="USD"`; header rendered `GBP 16.64`.
- Live (Playwright, GME): overview chart toolbar now shows muted `USD` far-right; header `GBP 16.64`, axis ~22 USD reconciled. Workspace header `USD 22` (already consistent).
- Gates: full `pnpm --dir frontend test` (1171 pass) + `typecheck` + `dark:check` (no violations) green.

Closes #1845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)