### PR TITLE
docs(#1845): record native-currency price-chart exception in operator-ui-conventions skill

### DIFF
--- a/.claude/skills/frontend/operator-ui-conventions.md
+++ b/.claude/skills/frontend/operator-ui-conventions.md
@@ -20,7 +20,7 @@ All formatting goes through `frontend/src/lib/format.ts`. Adding parallel format
 
 Rules:
 
-- Currency is GBP for v1. Multi-currency is out of scope until a non-GBP account exists.
+- Currency is GBP for v1. Multi-currency is out of scope until a non-GBP account exists. **Exception — price charts render the instrument's NATIVE currency** (the OHLC candle endpoints return native, un-FX'd OHLC; spot-converting historical candles would misrepresent past prices). The header price beside the chart IS FX-converted to the operator display currency, so a native chart + converted header disagree numerically (GME: header `GBP 16.64`, axis `~22.10` USD). Any price chart must therefore carry a native-currency label so the two numbers reconcile (#1845: `PriceChart` `currency` prop fed from `summary.identity.currency`).
 - Percentages are **always** computed from fractions, not pre-multiplied numbers. Backend returns `0.0123`, not `1.23`.
 - Aggregate percentages are **capital-weighted** (`Σ pnl / Σ cost_basis`), never an average of per-row percentages.
 - Timestamps are en-GB, short month, 24h. Never raw ISO in the DOM.


### PR DESCRIPTION
## What

One-line addition to `.claude/skills/frontend/operator-ui-conventions.md`: documents the **native-currency price-chart exception** to the GBP-for-v1 rule.

Price charts render the instrument's NATIVE currency (the OHLC candle endpoints return un-FX'd OHLC; spot-converting historical candles would misrepresent past prices). The header price beside the chart IS FX-converted to the operator display currency, so a native chart + converted header disagree numerically (GME: header `GBP 16.64`, axis `~22.10` USD). Any price chart must therefore carry a native-currency label so the two reconcile.

## Why

Skill-ownership: #1845 (`427fa7c2`, PR #1847) shipped the `PriceChart` `currency` prop + label but omitted the skill note. The lesson belongs in the skill, not only the merged PR, so a future agent doesn't re-introduce chart FX-conversion or re-derive the native-label decision.

## Scope

Doc-only; no code change. The implementation already landed in #1847.

Refs #1845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)