### PR TITLE
fix(#1849): honest below-buffer state on dashboard deployment card

### DIFF
--- a/frontend/src/components/dashboard/SummaryCards.test.ts
+++ b/frontend/src/components/dashboard/SummaryCards.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { BudgetStateResponse } from "@/api/types";
+import { classifyDeployment } from "@/components/dashboard/SummaryCards";
+
+function budget(overrides: Partial<BudgetStateResponse>): BudgetStateResponse {
+  return {
+    cash_balance: 1000,
+    deployed_capital: 0,
+    mirror_equity: 0,
+    working_budget: 100000,
+    estimated_tax_gbp: 0,
+    estimated_tax_usd: 0,
+    gbp_usd_rate: null,
+    cash_buffer_reserve: 5000,
+    available_for_deployment: 50000,
+    cash_buffer_pct: 0.05,
+    cgt_scenario: "higher",
+    tax_year: "2026/27",
+    ...overrides,
+  };
+}
+
+describe("classifyDeployment", () => {
+  it("flags unknown cash distinctly", () => {
+    expect(classifyDeployment(budget({ available_for_deployment: null }))).toEqual({
+      tone: undefined,
+      hint: "Cash unknown",
+      isNull: true,
+    });
+  });
+
+  it("labels a negative budget as below cash buffer, not merely low (the bug)", () => {
+    // Real dev figures: cash below the 5%-of-AUM reserve floor → guard blocks.
+    expect(
+      classifyDeployment(budget({ available_for_deployment: -3569.43, working_budget: 105457.84 })),
+    ).toEqual({ tone: "negative", hint: "At or below cash buffer reserve", isNull: false });
+  });
+
+  it("treats zero as below buffer too (mirrors the guard's <= 0 threshold)", () => {
+    expect(classifyDeployment(budget({ available_for_deployment: 0 })).hint).toBe(
+      "At or below cash buffer reserve",
+    );
+  });
+
+  it("labels a small positive budget (<5% of working) as low", () => {
+    expect(
+      classifyDeployment(budget({ available_for_deployment: 100, working_budget: 100000 })),
+    ).toEqual({ tone: "negative", hint: "Low deployment capital", isNull: false });
+  });
+
+  it("leaves a healthy budget with positive tone and no hint", () => {
+    expect(
+      classifyDeployment(budget({ available_for_deployment: 50000, working_budget: 100000 })),
+    ).toEqual({ tone: "positive", hint: undefined, isNull: false });
+  });
+
+  it("does not flag a positive budget as low when working_budget is unknown", () => {
+    expect(
+      classifyDeployment(budget({ available_for_deployment: 100, working_budget: null })),
+    ).toEqual({ tone: "positive", hint: undefined, isNull: false });
+  });
+});

--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -77,6 +77,41 @@ export function SummaryCards({
   );
 }
 
+/**
+ * Classify the deployment-budget state for display. Pure so it can be
+ * table-tested without React.
+ *
+ * The key honesty distinction: a NEGATIVE `available_for_deployment` is not
+ * "low" — it means cash has fallen below the cash-buffer reserve floor
+ * (`app/services/budget.py`), and the execution guard then blocks every
+ * order as "budget exhausted" the moment `available_for_deployment <= 0`
+ * (`app/services/execution_guard.py`). Surface that buffer-breach distinctly
+ * from a merely-low-but-still-deployable budget.
+ */
+export function classifyDeployment(budget: BudgetStateResponse): {
+  tone: "positive" | "negative" | undefined;
+  hint: string | undefined;
+  isNull: boolean;
+} {
+  const available = budget.available_for_deployment;
+  if (available === null) {
+    return { tone: undefined, hint: "Cash unknown", isNull: true };
+  }
+  // Mirror the execution guard's threshold (`<= 0` → budget exhausted).
+  const isExhausted = available <= 0;
+  const isLow =
+    !isExhausted &&
+    budget.working_budget !== null &&
+    budget.working_budget > 0 &&
+    available / budget.working_budget < 0.05;
+  const hint = isExhausted
+    ? "At or below cash buffer reserve"
+    : isLow
+      ? "Low deployment capital"
+      : undefined;
+  return { tone: isExhausted || isLow ? "negative" : "positive", hint, isNull: false };
+}
+
 function DeploymentCard({
   budget,
   budgetError,
@@ -99,25 +134,13 @@ function DeploymentCard({
   }
 
   const available = budget.available_for_deployment;
-  const isNull = available === null;
-  const isLow =
-    !isNull &&
-    budget.working_budget !== null &&
-    budget.working_budget > 0 &&
-    available / budget.working_budget < 0.05;
-  const isNegative = !isNull && available < 0;
-
-  const tone: "positive" | "negative" | undefined = isNull
-    ? undefined
-    : isNegative || isLow
-      ? "negative"
-      : "positive";
+  const { tone, hint, isNull } = classifyDeployment(budget);
 
   return (
     <StatTile
       label="Available for deployment"
       value={isNull ? "—" : formatMoney(available, currency)}
-      hint={isNull ? "Cash unknown" : isLow ? "Low deployment capital" : undefined}
+      hint={hint}
       tone={tone}
     />
   );


### PR DESCRIPTION
## What
The Dashboard "Available for deployment" card showed a **negative** value (`-£3,566.32` on dev) with the hint **"Low deployment capital"** — understating a fully-blocked state.

## Why it's wrong
A negative `available_for_deployment` is correct by design (`app/services/budget.py:623`: `cash_balance − estimated_tax − cash_buffer_reserve`, where the reserve is 5% of total AUM). It means cash has fallen **at/below the cash-buffer reserve floor**. The execution guard then **blocks every order** as "budget exhausted" the moment `available_for_deployment <= 0` (`app/services/execution_guard.py:531`). The card communicated this with the same hint as a merely-low-but-positive budget, and the `isNegative` local was redundant (it only fed tone — every negative is also `< 5%`, so `isLow` already covered it).

## Change
Extract a pure `classifyDeployment(budget)` that mirrors the guard's `<= 0` threshold and surfaces a distinct hint **"At or below cash buffer reserve"** (boundary-accurate at exactly 0, where the guard also blocks), keeping "Low deployment capital" for `0 < available < 5%`. FE-only, no API change.

## Tests
New pure table-test (fast tier, no React) — `SummaryCards.test.ts`, 6 cases: null / below-buffer (real dev figures) / exact-zero / low-positive / healthy / unknown-working_budget. `pnpm typecheck` + `dark:check` clean; full `test:unit` (1175) green.

## Verification
Dev render after HMR: card now reads `-£3,568.81` · **"At or below cash buffer reserve"** (was "Low deployment capital"). Route `/`, endpoint `/api/budget`.

Closes #1849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)