### PR TITLE
fix(#1851): prefer GICS sector over coarse eToro label on dashboard watchlist

### DIFF
--- a/app/api/watchlist.py
+++ b/app/api/watchlist.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Field
 from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
+from app.services.sector_classification import resolve_sector_spdr
 
 router = APIRouter(
     prefix="/watchlist",
@@ -41,8 +42,14 @@ class WatchlistItem(BaseModel):
     currency: str | None
     sector: str | None  # eToro numeric industry id, as text (provider contract)
     # Resolved eToro industry name via etoro_stocks_industries (sql/070); None when
-    # sector is NULL or the id has no dictionary row. The operator-facing label.
+    # sector is NULL or the id has no dictionary row. The non-SEC fallback label.
     sector_name: str | None
+    # #1851: real GICS sector derived from the SEC SIC (resolve_sector_spdr, #1634),
+    # fail-closed None when no SIC / no confident mapping. Preferred display label so
+    # the watchlist agrees with the instrument page / rankings (which already prefer
+    # gics_sector). eToro sector_name is coarse + frequently wrong (AAPL → "Consumer
+    # Goods"); fall back to it only when gics_sector is None.
+    gics_sector: str | None
     added_at: datetime
     notes: str | None
 
@@ -50,6 +57,16 @@ class WatchlistItem(BaseModel):
 class WatchlistListResponse(BaseModel):
     items: list[WatchlistItem]
     total: int
+
+
+def _resolve_gics(sic: str | int | None) -> str | None:
+    """GICS sector label from the SEC SIC (#1634), fail-closed None.
+
+    Mirrors the /instruments/{symbol}/summary identity path so the watchlist
+    sector column agrees with the instrument page (#1851).
+    """
+    cls = resolve_sector_spdr(sic)
+    return cls.gics_sector if cls is not None else None
 
 
 class WatchlistAddRequest(BaseModel):
@@ -78,12 +95,13 @@ def list_watchlist(
         cur.execute(
             """
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
-                   i.currency, i.sector, esi.name AS sector_name,
+                   i.currency, i.sector, esi.name AS sector_name, p.sic,
                    w.added_at, w.notes
             FROM watchlist w
             JOIN instruments i USING (instrument_id)
             LEFT JOIN etoro_stocks_industries esi
               ON esi.industry_id::text = i.sector
+            LEFT JOIN instrument_sec_profile p USING (instrument_id)
             WHERE w.operator_id = %(op)s
             ORDER BY w.added_at DESC
             """,
@@ -99,6 +117,7 @@ def list_watchlist(
             currency=r["currency"],  # type: ignore[union-attr]
             sector=r["sector"],  # type: ignore[union-attr]
             sector_name=r["sector_name"],  # type: ignore[union-attr]
+            gics_sector=_resolve_gics(r["sic"]),  # type: ignore[arg-type]
             added_at=r["added_at"],  # type: ignore[arg-type]
             notes=r["notes"],  # type: ignore[union-attr]
         )
@@ -120,9 +139,10 @@ def add_to_watchlist(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             "SELECT i.instrument_id, i.symbol, i.company_name, i.exchange, "
-            "i.currency, i.sector, esi.name AS sector_name "
+            "i.currency, i.sector, esi.name AS sector_name, p.sic "
             "FROM instruments i "
             "LEFT JOIN etoro_stocks_industries esi ON esi.industry_id::text = i.sector "
+            "LEFT JOIN instrument_sec_profile p USING (instrument_id) "
             "WHERE UPPER(i.symbol) = %(s)s LIMIT 1",
             {"s": symbol_clean},
         )
@@ -162,6 +182,7 @@ def add_to_watchlist(
         currency=inst["currency"],  # type: ignore[union-attr]
         sector=inst["sector"],  # type: ignore[union-attr]
         sector_name=inst["sector_name"],  # type: ignore[union-attr]
+        gics_sector=_resolve_gics(inst["sic"]),  # type: ignore[arg-type]
         added_at=wl_row["added_at"],  # type: ignore[arg-type]
         notes=wl_row["notes"],  # type: ignore[union-attr]
     )

--- a/frontend/src/api/watchlist.ts
+++ b/frontend/src/api/watchlist.ts
@@ -7,7 +7,8 @@ export interface WatchlistItem {
   exchange: string | null;
   currency: string | null;
   sector: string | null; // eToro numeric industry id (provider contract)
-  sector_name: string | null; // resolved eToro industry name — the display label
+  sector_name: string | null; // resolved eToro industry name — non-SEC fallback label
+  gics_sector: string | null; // #1851: SEC-SIC-derived GICS sector — preferred label
   added_at: string;
   notes: string | null;
 }

--- a/frontend/src/components/dashboard/WatchlistPanel.test.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.test.tsx
@@ -14,6 +14,7 @@ function item(overrides: Partial<WatchlistItem> = {}): WatchlistItem {
     currency: "USD",
     sector: "8",
     sector_name: "Technology",
+    gics_sector: "Information Technology",
     added_at: "2026-04-15",
     notes: null,
     ...overrides,
@@ -21,21 +22,39 @@ function item(overrides: Partial<WatchlistItem> = {}): WatchlistItem {
 }
 
 describe("WatchlistPanel", () => {
-  it("renders the resolved sector name, never the raw eToro id (#1599)", () => {
+  it("prefers the GICS sector over the coarse eToro label (#1851)", () => {
+    // AAPL's eToro label is "Consumer Goods" (wrong); the SEC-SIC GICS sector
+    // is "Information Technology". The watchlist must agree with the instrument
+    // page, which already prefers gics_sector.
     render(
       <MemoryRouter>
-        <WatchlistPanel items={[item()]} />
+        <WatchlistPanel
+          items={[item({ sector_name: "Consumer Goods", gics_sector: "Information Technology" })]}
+        />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText("Information Technology")).toBeInTheDocument();
+    expect(screen.queryByText("Consumer Goods")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the eToro label when GICS is unavailable (#1851)", () => {
+    // Non-SEC instrument: no SIC → no GICS. Show the eToro label, not "—".
+    render(
+      <MemoryRouter>
+        <WatchlistPanel items={[item({ gics_sector: null, sector_name: "Technology" })]} />
       </MemoryRouter>,
     );
     expect(screen.getByText("Technology")).toBeInTheDocument();
-    // The opaque eToro numeric id must never reach the operator.
+    // The opaque eToro numeric id must never reach the operator (#1599).
     expect(screen.queryByText("8")).not.toBeInTheDocument();
   });
 
   it("falls back to em-dash when the sector is unmapped", () => {
     render(
       <MemoryRouter>
-        <WatchlistPanel items={[item({ sector: null, sector_name: null })]} />
+        <WatchlistPanel
+          items={[item({ sector: null, sector_name: null, gics_sector: null })]}
+        />
       </MemoryRouter>,
     );
     expect(screen.getByText("—")).toBeInTheDocument();

--- a/frontend/src/components/dashboard/WatchlistPanel.tsx
+++ b/frontend/src/components/dashboard/WatchlistPanel.tsx
@@ -54,7 +54,7 @@ export function WatchlistPanel({ items, onRemove }: Props) {
               </td>
               <td className="px-2 py-1">{item.company_name}</td>
               <td className="px-2 py-1 text-slate-500 dark:text-slate-400">
-                {item.sector_name ?? "—"}
+                {item.gics_sector ?? item.sector_name ?? "—"}
               </td>
               <td className="px-2 py-1 text-xs text-slate-500 dark:text-slate-400">
                 {item.notes ?? ""}

--- a/tests/test_api_watchlist.py
+++ b/tests/test_api_watchlist.py
@@ -68,6 +68,7 @@ def test_list_returns_items_sorted_newest_first(client: TestClient) -> None:
             "currency": "USD",
             "sector": "8",  # eToro numeric industry id (provider contract)
             "sector_name": "Technology",  # resolved via etoro_stocks_industries join
+            "sic": "3571",  # SEC SIC → GICS "Information Technology" (#1851)
             "added_at": datetime(2026, 4, 15),
             "notes": "core holding",
         },
@@ -81,6 +82,8 @@ def test_list_returns_items_sorted_newest_first(client: TestClient) -> None:
             # the join yields NULL; sector_name must surface as None, not the id.
             "sector": "99",
             "sector_name": None,
+            # Non-SEC instrument: no SIC row → gics_sector fails closed to None.
+            "sic": None,
             "added_at": datetime(2026, 4, 10),
             "notes": None,
         },
@@ -98,6 +101,9 @@ def test_list_returns_items_sorted_newest_first(client: TestClient) -> None:
     assert body["items"][0]["sector"] == "8"
     assert body["items"][0]["sector_name"] == "Technology"
     assert body["items"][1]["sector_name"] is None
+    # #1851: gics_sector resolved from the SEC SIC, fail-closed None for non-SEC.
+    assert body["items"][0]["gics_sector"] == "Information Technology"
+    assert body["items"][1]["gics_sector"] is None
 
 
 def test_add_happy_path(client: TestClient) -> None:
@@ -111,6 +117,7 @@ def test_add_happy_path(client: TestClient) -> None:
             "currency": "USD",
             "sector": "8",
             "sector_name": "Technology",
+            "sic": "3571",
         },
         {"added_at": datetime(2026, 4, 19), "notes": "watch for earnings"},
     ]
@@ -125,6 +132,7 @@ def test_add_happy_path(client: TestClient) -> None:
     assert body["symbol"] == "AAPL"
     assert body["notes"] == "watch for earnings"
     assert body["sector_name"] == "Technology"  # #1599 resolved on add
+    assert body["gics_sector"] == "Information Technology"  # #1851 resolved on add
 
 
 def test_add_without_notes_preserves_existing_notes(client: TestClient) -> None:
@@ -139,6 +147,7 @@ def test_add_without_notes_preserves_existing_notes(client: TestClient) -> None:
             "currency": "USD",
             "sector": "8",
             "sector_name": "Technology",
+            "sic": "3571",
         },
         # Server returns the PRESERVED note, not NULL.
         {"added_at": datetime(2026, 4, 10), "notes": "core holding"},


### PR DESCRIPTION
## What

The dashboard **Watchlist** panel (`WatchlistPanel.tsx`) rendered the raw eToro industry name (`sector_name`, resolved from `etoro_stocks_industries` via the numeric `instruments.sector` id) with no GICS fallback. That taxonomy is coarse and frequently wrong:

| symbol | watchlist label (before) | `gics_sector` (after, correct) |
|--------|------------------|--------------|
| AAPL | **Consumer Goods** | Information Technology |
| GME  | **Services** | Consumer Discretionary |
| HD   | **Services** | Consumer Discretionary |

Every other sector surface — the instrument page (`SummaryStrip` = `gics_sector ?? sector_name`), `RankingsTable`, `InstrumentsPage` — already prefers `gics_sector` (the #1634 SEC-SIC-derived label). The watchlist was the lone holdout, so the **same instrument showed two different sector labels across pages**, one factually wrong.

## Fix

- `/watchlist` GET + POST now resolve `gics_sector` from `instrument_sec_profile.sic` via `resolve_sector_spdr` (the same path `/instruments/{symbol}/summary` uses), expose it on `WatchlistItem`.
- `WatchlistPanel` renders `gics_sector ?? sector_name ?? "—"` (mirrors `SummaryStrip`).
- Fail-closed: no SIC → no GICS → eToro label → em-dash. Non-SEC instruments keep the eToro fallback, never regress to "—".

## Source rule

#1634: GICS sector is derived from the SEC SIC via `resolve_sector_spdr`, fail-closed `None` when no confident mapping. eToro numeric `sector` is a provider id, not a GICS classification.

## Correctness / cardinality

`instrument_sec_profile.instrument_id` is **PRIMARY KEY** (sql/051) → the new `LEFT JOIN … USING (instrument_id)` is strictly 1:1, no watchlist row fan-out. Verified on dev: 5312 rows / 5312 distinct instrument_id.

## Tests

- Backend (`tests/test_api_watchlist.py`): gics resolved on list + add (SIC 3571 → Information Technology); fail-closed `None` for non-SEC (sic `None`).
- Frontend (`WatchlistPanel.test.tsx`): prefers GICS over eToro label; falls back to eToro label when GICS unavailable; em-dash when both null.

## Gates

`ruff check`/`format --check` clean · `pyright` 0 errors · `pytest tests/test_api_watchlist.py` 8 passed · `pnpm typecheck` clean · `pnpm test:unit` 1176 passed · pre-push gate (fast tier + smoke + dark-mode + chokepoint) green.

## Codex ckpt-2

One finding raised — `except A, B:` at `sector_classification.py:155` (the module this PR newly imports). **REBUTTED:** verified empirically it compiles + runs correctly on the repo interpreter (py3.14.4, where the bare exception tuple is valid); `resolve_sector_spdr(None/'0000')` → `None` as expected. It is a pervasive established repo convention (~15 sites: passwords, sec_fundamentals, etoro, …), pre-existing, and outside this diff. Codex's `python3` was an older interpreter where it parses as a SyntaxError. No change.

## Scope

FE + API read-path only. No schema/migration, no parser, no ownership/metric data-treatment change. FE/API merge → no daemon restart needed.

Closes #1851.