### PR TITLE
feat(#1823): evidence-only IAR scoring signals (P2 of #1815)

### DIFF
--- a/.claude/skills/engineering/python-hygiene.md
+++ b/.claude/skills/engineering/python-hygiene.md
@@ -213,3 +213,19 @@ Rule: widen the callee to `Connection[Any]`, and if it reads row values
 (not just `rowcount`), open its own cursor with an explicit
 `row_factory=psycopg.rows.tuple_row` / `dict_row` so the row shape is
 locally guaranteed.
+
+## Never bare `float(attr)` on a possibly-None field inside a narrow except
+
+In a savepoint-/try-guarded block whose `except` only catches a specific
+class (e.g. `psycopg.errors.UndefinedTable, UndefinedColumn`), a bare
+`float(some.attr)` where `attr`'s type includes `None` raises `TypeError`,
+which the narrow `except` does NOT catch — it escapes and crashes the whole
+caller. Even when the producing query COALESCEs the column to a non-null
+today, the field's annotation (`Decimal | None`) is the contract; a future
+change re-introduces the None.
+
+Rule: guard the cast — `v = some.attr; out = float(v) if v is not None else
+None` — or `assert v is not None`. Grep self-review: `float\(` / `int\(` /
+`Decimal\(` directly wrapping an attribute access inside a guarded block.
+
+Origin: PR #1853 (#1823) review BLOCKING on the IAR insider assembler.

--- a/app/services/instrument_analytics.py
+++ b/app/services/instrument_analytics.py
@@ -106,6 +106,14 @@ def _gross_profit(facts: dict[str, float]) -> float | None:
 # Piotroski F-score (0-9) — Piotroski (2000).
 # 7 of 9 points need a prior FY. A component whose inputs are absent is NOT
 # awarded AND NOT counted toward components_available — never imputed.
+#
+# Documented variant (evidence-only): ROA / asset-turnover use END-of-period
+# total assets, not Piotroski's beginning-of-year assets — the canonical
+# beginning-asset basis for ΔROA needs THREE consecutive FYs (TA_{t-2}); we read
+# two. `roa_positive` is denominator-sign-invariant (Assets>0 ⇒ sign(ROA)=sign(NI)),
+# so only the ΔROA / Δasset-turnover trend points use the end-asset basis — applied
+# consistently to both years. A common provider variant (Gray & Carlisle), not the
+# strict original; the sign rarely flips and this is non-headline evidence.
 # ---------------------------------------------------------------------------
 @dataclass(frozen=True)
 class PiotroskiResult:
@@ -239,6 +247,10 @@ def altman_z2(facts: dict[str, float]) -> AltmanResult:
     ca = _pick(facts, _ASSETS_CURRENT)
     cl = _pick(facts, _LIABILITIES_CURRENT)
     re = _pick(facts, _RETAINED_EARNINGS)
+    # X3 EBIT proxy = OperatingIncomeLoss. Operating income is the standard
+    # XBRL-available EBIT proxy (Damodaran / common screeners); it omits non-
+    # operating items, so it is a proxy, not exact EBIT. Acceptable for non-
+    # headline evidence — the result carries no claim of being exact EBIT.
     ebit = _pick(facts, _OPERATING_INCOME)
     equity = _pick(facts, _EQUITY)
 
@@ -425,9 +437,11 @@ def _read_latest_two_fy_facts(
     """Latest two fiscal years of annual (10-K, fiscal_period='FY') us-gaap facts
     for the F/Z concepts, one ``{concept: float}`` dict per FY (current, prior).
 
-    DISTINCT ON (concept, fiscal_year) ORDER BY filed_date DESC collapses
-    restatements/amendments to the latest filing. Returns (None, None) when no
-    annual facts are on file.
+    DISTINCT ON (concept, fiscal_year) collapses to ONE value per concept per FY,
+    preferring the canonical FY-end (``period_end DESC``) then the latest filing
+    (``filed_date DESC``). The period_end tie-break guards against a comparative
+    prior-year line carried in a later 10-K being mistaken for the FY value.
+    Returns (None, None) when no annual facts are on file.
     """
     rows: list[tuple[int, str, float]]
     with conn.cursor() as cur:
@@ -444,7 +458,7 @@ def _read_latest_two_fy_facts(
                   AND concept = ANY(%(concepts)s)
                   AND fiscal_year IS NOT NULL
                   AND val IS NOT NULL
-                ORDER BY concept, fiscal_year, filed_date DESC, accession_number DESC
+                ORDER BY concept, fiscal_year, period_end DESC, filed_date DESC, accession_number DESC
             ) latest
             WHERE fiscal_year IN (
                 SELECT DISTINCT fiscal_year

--- a/app/services/instrument_analytics.py
+++ b/app/services/instrument_analytics.py
@@ -1,0 +1,608 @@
+"""Instrument Analytical Record (IAR) evidence signals — #1823 (P2 of #1815).
+
+EVIDENCE-ONLY. None of these signals enter the headline scoring composite (they
+ride at weight 0 in the IAR until the #1822/P5 backtest + operator sign-off);
+``scoring.compute_score`` persists the assembled block on ``scores.analytics_json``
+without ever feeding ``raw_total`` / ``total_score``. See
+``docs/specs/ranking/2026-06-29-1823-iar-evidence-signals.md``.
+
+Design split (mirrors ``tests/test_scoring.py``):
+  * pure signal math here — table-tested, no DB;
+  * the DB-facing assembler (``assemble_instrument_analytics``) loads the inputs,
+    reusing the de-duped read paths (``get_insider_summary``,
+    ``get_ownership_category_totals``) and the new latest-2-FY concept reader,
+    then calls the pure functions.
+
+Source rules: Piotroski (J. Accounting Research 38, 2000); Altman Z" non-
+manufacturer recalibration (Altman 2000); SEC Item 403 / FINRA short-interest for
+positioning. Missing inputs are reported as missing — NEVER imputed.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+import psycopg
+
+# ---------------------------------------------------------------------------
+# us-gaap concept resolution (financial_facts_raw holds only the non-dimensional
+# default member — companyfacts strips dimensional facts, prevention-log 1879).
+# Revenue is ASC-606-fragmented, so it carries a fallback chain (full-population
+# verified 2026-06-29). LiabilitiesNoncurrent is absent from our data (0 rows) →
+# leverage uses LongTermDebt with a LongTermDebtNoncurrent fallback.
+# ---------------------------------------------------------------------------
+SCHEMA_VERSION = "iar_v1"
+
+# Single-concept inputs.
+_NET_INCOME = ("NetIncomeLoss",)
+_ASSETS = ("Assets",)
+_ASSETS_CURRENT = ("AssetsCurrent",)
+_LIABILITIES = ("Liabilities",)
+_LIABILITIES_CURRENT = ("LiabilitiesCurrent",)
+_RETAINED_EARNINGS = ("RetainedEarningsAccumulatedDeficit",)
+_OPERATING_INCOME = ("OperatingIncomeLoss",)
+_EQUITY = ("StockholdersEquity",)
+_CFO = ("NetCashProvidedByUsedInOperatingActivities",)
+_GROSS_PROFIT = ("GrossProfit",)
+_COST_OF_REVENUE = ("CostOfRevenue", "CostOfGoodsAndServicesSold")
+# Ordered fallback chains (most-preferred first).
+_REVENUE = (
+    "RevenueFromContractWithCustomerExcludingAssessedTax",
+    "Revenues",
+    "RevenueFromContractWithCustomerIncludingAssessedTax",
+    "SalesRevenueNet",
+)
+_LONG_TERM_DEBT = ("LongTermDebt", "LongTermDebtNoncurrent")
+_SHARES = ("WeightedAverageNumberOfDilutedSharesOutstanding", "CommonStockSharesOutstanding")
+
+#: Every concept the F/Z reader needs (one query, both FYs).
+PIOTROSKI_ALTMAN_CONCEPTS: tuple[str, ...] = (
+    *_NET_INCOME,
+    *_ASSETS,
+    *_ASSETS_CURRENT,
+    *_LIABILITIES,
+    *_LIABILITIES_CURRENT,
+    *_RETAINED_EARNINGS,
+    *_OPERATING_INCOME,
+    *_EQUITY,
+    *_CFO,
+    *_GROSS_PROFIT,
+    *_COST_OF_REVENUE,
+    *_REVENUE,
+    *_LONG_TERM_DEBT,
+    *_SHARES,
+)
+
+
+def _pick(facts: dict[str, float], chain: tuple[str, ...]) -> float | None:
+    """First present, non-None concept value in the fallback chain."""
+    for concept in chain:
+        v = facts.get(concept)
+        if v is not None:
+            return v
+    return None
+
+
+def _revenue(facts: dict[str, float]) -> float | None:
+    return _pick(facts, _REVENUE)
+
+
+def _gross_profit(facts: dict[str, float]) -> float | None:
+    """GrossProfit direct, else Revenue − CostOfRevenue when both present."""
+    gp = _pick(facts, _GROSS_PROFIT)
+    if gp is not None:
+        return gp
+    rev = _revenue(facts)
+    cor = _pick(facts, _COST_OF_REVENUE)
+    if rev is not None and cor is not None:
+        return rev - cor
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Piotroski F-score (0-9) — Piotroski (2000).
+# 7 of 9 points need a prior FY. A component whose inputs are absent is NOT
+# awarded AND NOT counted toward components_available — never imputed.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class PiotroskiResult:
+    score: int | None
+    components_available: int
+    band: str | None
+    components: dict[str, bool]
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "components_available": self.components_available,
+            "band": self.band,
+            "components": self.components,
+            "reason": self.reason,
+        }
+
+
+def _ratio(numer: float | None, denom: float | None) -> float | None:
+    if numer is None or denom is None or denom == 0:
+        return None
+    return numer / denom
+
+
+def _band_piotroski(score: int) -> str:
+    if score >= 7:
+        return "strong"
+    if score >= 4:
+        return "neutral"
+    return "weak"
+
+
+def piotroski_f(curr: dict[str, float], prior: dict[str, float] | None) -> PiotroskiResult:
+    """Compute the Piotroski F-score from one or two FY fact dicts.
+
+    ``components`` maps each evaluated signal to its boolean; only evaluated
+    signals count toward ``components_available`` and ``score``. ``band`` is read
+    off the raw score (a partial score is a lower bound). Returns an all-empty
+    result with ``reason`` when nothing can be evaluated.
+    """
+    components: dict[str, bool] = {}
+
+    ni = _pick(curr, _NET_INCOME)
+    assets = _pick(curr, _ASSETS)
+    cfo = _pick(curr, _CFO)
+    roa = _ratio(ni, assets)
+
+    # Profitability (4)
+    if roa is not None:
+        components["roa_positive"] = roa > 0
+    if cfo is not None:
+        components["cfo_positive"] = cfo > 0
+    if cfo is not None and ni is not None:
+        components["accrual_cfo_gt_ni"] = cfo > ni
+
+    # Prior-year-dependent signals
+    if prior is not None:
+        ni_p = _pick(prior, _NET_INCOME)
+        assets_p = _pick(prior, _ASSETS)
+        roa_p = _ratio(ni_p, assets_p)
+        if roa is not None and roa_p is not None:
+            components["droa_positive"] = roa > roa_p
+
+        # Leverage: long-term debt / total assets (lower is better)
+        ltd = _pick(curr, _LONG_TERM_DEBT)
+        ltd_p = _pick(prior, _LONG_TERM_DEBT)
+        lev = _ratio(ltd, assets)
+        lev_p = _ratio(ltd_p, assets_p)
+        if lev is not None and lev_p is not None:
+            components["dleverage_down"] = lev < lev_p
+
+        # Current ratio
+        cr = _ratio(_pick(curr, _ASSETS_CURRENT), _pick(curr, _LIABILITIES_CURRENT))
+        cr_p = _ratio(_pick(prior, _ASSETS_CURRENT), _pick(prior, _LIABILITIES_CURRENT))
+        if cr is not None and cr_p is not None:
+            components["dcurrent_ratio_up"] = cr > cr_p
+
+        # No new shares (dilution): shares_curr <= shares_prior
+        sh = _pick(curr, _SHARES)
+        sh_p = _pick(prior, _SHARES)
+        if sh is not None and sh_p is not None:
+            components["no_new_shares"] = sh <= sh_p
+
+        # Gross margin
+        gm = _ratio(_gross_profit(curr), _revenue(curr))
+        gm_p = _ratio(_gross_profit(prior), _revenue(prior))
+        if gm is not None and gm_p is not None:
+            components["dgross_margin_up"] = gm > gm_p
+
+        # Asset turnover
+        at = _ratio(_revenue(curr), assets)
+        at_p = _ratio(_revenue(prior), assets_p)
+        if at is not None and at_p is not None:
+            components["dasset_turnover_up"] = at > at_p
+
+    components_available = len(components)
+    if components_available == 0:
+        return PiotroskiResult(None, 0, None, {}, reason="no_inputs")
+    score = sum(1 for v in components.values() if v)
+    return PiotroskiResult(score, components_available, _band_piotroski(score), components)
+
+
+# ---------------------------------------------------------------------------
+# Altman Z" (non-manufacturer recalibration) — Altman (2000). Single-period.
+#   Z" = 6.56*X1 + 3.26*X2 + 6.72*X3 + 1.05*X4
+#   X1=(CA-CL)/TA  X2=RE/TA  X3=EBIT/TA  X4=Equity/TL
+# Every input is required; any absent (or TA<=0 / TL<=0) -> null + reason.
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class AltmanResult:
+    z: float | None
+    band: str | None
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"z": self.z, "band": self.band, "reason": self.reason}
+
+
+def _band_altman(z: float) -> str:
+    if z > 2.60:
+        return "safe"
+    if z >= 1.10:
+        return "grey"
+    return "distress"
+
+
+def altman_z2(facts: dict[str, float]) -> AltmanResult:
+    ta = _pick(facts, _ASSETS)
+    tl = _pick(facts, _LIABILITIES)
+    ca = _pick(facts, _ASSETS_CURRENT)
+    cl = _pick(facts, _LIABILITIES_CURRENT)
+    re = _pick(facts, _RETAINED_EARNINGS)
+    ebit = _pick(facts, _OPERATING_INCOME)
+    equity = _pick(facts, _EQUITY)
+
+    if ta is None or ta <= 0:
+        return AltmanResult(None, None, reason="no_total_assets")
+    if tl is None or tl <= 0:
+        return AltmanResult(None, None, reason="no_total_liabilities")
+    if any(v is None for v in (ca, cl, re, ebit, equity)):
+        return AltmanResult(None, None, reason="missing_input")
+
+    # mypy/pyright: the None-guard above narrows these.
+    assert ca is not None and cl is not None and re is not None and ebit is not None and equity is not None
+    x1 = (ca - cl) / ta
+    x2 = re / ta
+    x3 = ebit / ta
+    x4 = equity / tl
+    z = 6.56 * x1 + 3.26 * x2 + 6.72 * x3 + 1.05 * x4
+    return AltmanResult(round(z, 4), _band_altman(z))
+
+
+# ---------------------------------------------------------------------------
+# Positioning signals — normalized to [0,1], 0.5 neutral (#1815 §5).
+# ---------------------------------------------------------------------------
+def _clip(v: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, v))
+
+
+def insider_signal(net_shares: float | None, shares_outstanding: float | None) -> dict[str, Any]:
+    """0.5 + 0.5*tanh((net_shares/shares_out)/0.001); sells floored ~0.40.
+
+    ``net_$ / mktcap == net_shares / shares_outstanding`` (price cancels), so the
+    fraction of the company traded is computed directly from open-market net
+    shares. Buys signal, sells are noise -> a net-sell can dip to but not below
+    ~0.40.
+    """
+    if net_shares is None or shares_outstanding is None or shares_outstanding <= 0:
+        return {"signal": None, "net_shares": net_shares, "reason": "no_insider_or_shares"}
+    frac = net_shares / shares_outstanding
+    raw = 0.5 + 0.5 * math.tanh(frac / 0.001)
+    if net_shares < 0:
+        raw = max(raw, 0.40)
+    return {
+        "signal": round(_clip(raw, 0.0, 1.0), 4),
+        "net_shares": net_shares,
+        "shares_outstanding": shares_outstanding,
+        "caveat": None,
+        "source": "insider_transactions",
+    }
+
+
+def inst_13f_signal(delta_shares_pct: float | None) -> dict[str, Any]:
+    """0.5 + 0.5*clip(delta_shares_pct/0.10, -1, 1).
+
+    ``delta_shares_pct`` is the QoQ change in de-duped aggregate institutional
+    SHARES (not holder count — prevention-log 1866/1873: raw filer-CIK counts are
+    corrupted by manager sub-book fanout).
+    """
+    if delta_shares_pct is None:
+        return {"signal": None, "reason": "insufficient_periods"}
+    raw = 0.5 + 0.5 * _clip(delta_shares_pct / 0.10, -1.0, 1.0)
+    return {
+        "signal": round(raw, 4),
+        "delta_shares_pct": round(delta_shares_pct, 4),
+        "caveat": "<=135d stale",
+        "source": "ownership_institutions_observations",
+    }
+
+
+def short_interest_signal(short_pct: float | None, falling: bool | None) -> dict[str, Any]:
+    """1 - clip((short_pct - 0.05)/0.25, 0, 1); +0.1 if falling 2 periods.
+
+    ``short_pct`` = current_short_interest / shares_outstanding (public float is
+    not ingested, so the denominator is shares outstanding — caveat carried).
+    """
+    if short_pct is None:
+        return {"signal": None, "reason": "no_short_interest_or_shares"}
+    raw = 1.0 - _clip((short_pct - 0.05) / 0.25, 0.0, 1.0)
+    if falling:
+        raw += 0.1
+    return {
+        "signal": round(_clip(raw, 0.0, 1.0), 4),
+        "short_pct": round(short_pct, 4),
+        "falling": bool(falling),
+        "caveat": "% shares outstanding (public float not ingested); bi-monthly",
+        "source": "finra_short_interest_current",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hybrid peer grade — 0.70*absolute + 0.30*sector_percentile (#1815 §6).
+# Evidence-only; the headline family score stays absolute (pure percentile would
+# reverse scoring.py's banned cohort-relative normalization).
+# ---------------------------------------------------------------------------
+def percentile_rank(value: float, population: list[float]) -> float:
+    """Empirical percentile (fraction of the population strictly below ``value``,
+    plus half the ties — the standard mid-rank definition). Empty -> 0.5."""
+    n = len(population)
+    if n == 0:
+        return 0.5
+    below = sum(1 for p in population if p < value)
+    equal = sum(1 for p in population if p == value)
+    return (below + 0.5 * equal) / n
+
+
+def hybrid_grade(absolute: float, percentile: float) -> float:
+    return round(0.70 * absolute + 0.30 * percentile, 4)
+
+
+#: The six headline families graded relative to peers.
+PEER_GRADE_FAMILIES: tuple[str, ...] = (
+    "quality",
+    "value",
+    "turnaround",
+    "momentum",
+    "sentiment",
+    "confidence",
+)
+_MIN_SECTOR_PEERS = 8
+_MIN_UNIVERSE_PEERS = 5
+
+
+def compute_peer_grades(
+    run_items: list[tuple[int, str | None, dict[str, float]]],
+) -> dict[int, dict[str, Any]]:
+    """Cross-sectional hybrid peer grade for every instrument in a scoring run.
+
+    ``run_items`` = ``[(instrument_id, sector_key, {family: absolute_score})]``
+    over the RUN-ELIGIBLE population (NOT the full universe — ``basis`` records
+    this). Per family the percentile cohort is, in order of preference:
+      * the instrument's eToro sector (n>=8) -> ``run_eligible_sector``;
+      * the whole run-eligible universe (5<=n<8) -> ``run_eligible_universe``;
+      * else absolute-only -> ``peer_set_thin``.
+    Evidence-only: ``hybrid = 0.70*absolute + 0.30*percentile`` never replaces the
+    headline absolute family score.
+    """
+    # Per-family universe + per-sector populations.
+    universe: dict[str, list[float]] = {f: [] for f in PEER_GRADE_FAMILIES}
+    by_sector: dict[str | None, dict[str, list[float]]] = {}
+    for _iid, sector, fam in run_items:
+        sec_pop = by_sector.setdefault(sector, {f: [] for f in PEER_GRADE_FAMILIES})
+        for f in PEER_GRADE_FAMILIES:
+            v = fam.get(f)
+            if v is not None:
+                universe[f].append(v)
+                sec_pop[f].append(v)
+
+    universe_n = max((len(universe[f]) for f in PEER_GRADE_FAMILIES), default=0)
+
+    out: dict[int, dict[str, Any]] = {}
+    for iid, sector, fam in run_items:
+        sec_pop = by_sector.get(sector, {})
+        sector_n = max((len(sec_pop.get(f, [])) for f in PEER_GRADE_FAMILIES), default=0)
+        if sector_n >= _MIN_SECTOR_PEERS:
+            basis, pop_map, peer_n = "run_eligible_sector", sec_pop, sector_n
+        elif universe_n >= _MIN_UNIVERSE_PEERS:
+            basis, pop_map, peer_n = "run_eligible_universe", universe, universe_n
+        else:
+            basis, pop_map, peer_n = "peer_set_thin", None, sector_n
+
+        families: dict[str, Any] = {}
+        for f in PEER_GRADE_FAMILIES:
+            absolute = fam.get(f)
+            if absolute is None:
+                continue
+            if pop_map is None:
+                families[f] = {"absolute": round(absolute, 4), "percentile": None, "hybrid": round(absolute, 4)}
+            else:
+                pct = percentile_rank(absolute, pop_map.get(f, []))
+                families[f] = {
+                    "absolute": round(absolute, 4),
+                    "percentile": round(pct, 4),
+                    "hybrid": hybrid_grade(absolute, pct),
+                }
+        out[iid] = {"peer_key": sector, "peer_n": peer_n, "basis": basis, "families": families}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# DB-facing assembler
+# ---------------------------------------------------------------------------
+def _read_latest_two_fy_facts(
+    conn: psycopg.Connection[Any], instrument_id: int
+) -> tuple[dict[str, float] | None, dict[str, float] | None]:
+    """Latest two fiscal years of annual (10-K, fiscal_period='FY') us-gaap facts
+    for the F/Z concepts, one ``{concept: float}`` dict per FY (current, prior).
+
+    DISTINCT ON (concept, fiscal_year) ORDER BY filed_date DESC collapses
+    restatements/amendments to the latest filing. Returns (None, None) when no
+    annual facts are on file.
+    """
+    rows: list[tuple[int, str, float]]
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT fiscal_year, concept, val FROM (
+                SELECT DISTINCT ON (concept, fiscal_year)
+                    fiscal_year, concept, val
+                FROM financial_facts_raw
+                WHERE instrument_id = %(iid)s
+                  AND taxonomy = 'us-gaap'
+                  AND fiscal_period = 'FY'
+                  AND form_type LIKE '10-K%%'
+                  AND concept = ANY(%(concepts)s)
+                  AND fiscal_year IS NOT NULL
+                  AND val IS NOT NULL
+                ORDER BY concept, fiscal_year, filed_date DESC, accession_number DESC
+            ) latest
+            WHERE fiscal_year IN (
+                SELECT DISTINCT fiscal_year
+                FROM financial_facts_raw
+                WHERE instrument_id = %(iid)s
+                  AND taxonomy = 'us-gaap'
+                  AND fiscal_period = 'FY'
+                  AND form_type LIKE '10-K%%'
+                  AND fiscal_year IS NOT NULL
+                ORDER BY fiscal_year DESC
+                LIMIT 2
+            )
+            """,
+            {"iid": instrument_id, "concepts": list(PIOTROSKI_ALTMAN_CONCEPTS)},
+        )
+        rows = [(int(r[0]), str(r[1]), float(r[2])) for r in cur.fetchall()]
+
+    if not rows:
+        return None, None
+    years = sorted({fy for fy, _, _ in rows}, reverse=True)
+    curr_year = years[0]
+    prior_year = years[1] if len(years) > 1 else None
+    curr = {c: v for fy, c, v in rows if fy == curr_year}
+    prior = {c: v for fy, c, v in rows if fy == prior_year} if prior_year is not None else None
+    return curr, prior
+
+
+def _read_13f_delta(conn: psycopg.Connection[Any], instrument_id: int) -> tuple[float | None, date | None]:
+    """QoQ % change in de-duped aggregate 13F shares over the two most recent
+    quarters. Reuses the #922 dedup-before-sum series. (None, None) if <2 periods
+    or the prior aggregate is zero."""
+    from app.services.ownership_history import get_ownership_category_totals
+
+    points = get_ownership_category_totals(conn, instrument_id=instrument_id, category="institutions")
+    usable = [p for p in points if p.shares is not None]
+    if len(usable) < 2:
+        return None, None
+    latest, prior = usable[-1], usable[-2]
+    prior_sh = float(prior.shares) if prior.shares is not None else 0.0
+    latest_sh = float(latest.shares) if latest.shares is not None else 0.0
+    if prior_sh <= 0:
+        return None, latest.period_end
+    return (latest_sh - prior_sh) / prior_sh, latest.period_end
+
+
+def _read_short_interest(
+    conn: psycopg.Connection[Any], instrument_id: int, shares_outstanding: float | None
+) -> dict[str, Any]:
+    """short_pct + falling + days_to_cover from finra_short_interest_current."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT current_short_interest, previous_short_interest, days_to_cover, settlement_date
+            FROM finra_short_interest_current
+            WHERE instrument_id = %(iid)s
+            """,
+            {"iid": instrument_id},
+        )
+        row = cur.fetchone()
+    if row is None or row[0] is None or shares_outstanding is None or shares_outstanding <= 0:
+        return short_interest_signal(None, None)
+    current_si = float(row[0])
+    prev_si = float(row[1]) if row[1] is not None else None
+    short_pct = current_si / shares_outstanding
+    falling = prev_si is not None and current_si < prev_si
+    out = short_interest_signal(short_pct, falling)
+    if row[2] is not None:
+        out["days_to_cover"] = float(row[2])
+    if row[3] is not None:
+        out["asof"] = row[3].isoformat()
+    return out
+
+
+def assemble_instrument_analytics(
+    instrument_id: int,
+    conn: psycopg.Connection[Any],
+    *,
+    gics_sector: str | None,
+    shares_outstanding: float | None,
+) -> dict[str, Any]:
+    """Per-instrument IAR evidence block (everything except the cross-sectional
+    ``peer_grade``, which ``compute_rankings`` injects from the run population).
+
+    Every DB read is savepoint-guarded (catch UndefinedTable/UndefinedColumn,
+    prevention-log 1941) so a partial schema degrades the signal to null rather
+    than failing the score.
+    """
+    suppress_fz = gics_sector == "Financials"
+    block: dict[str, Any] = {"schema": SCHEMA_VERSION}
+
+    # Piotroski + Altman
+    if suppress_fz:
+        block["piotroski"] = {"score": None, "suppressed": True, "reason": "quality_signal_na_financials"}
+        block["altman_z"] = {"z": None, "suppressed": True, "reason": "quality_signal_na_financials"}
+    else:
+        curr = prior = None
+        try:
+            with conn.transaction():
+                curr, prior = _read_latest_two_fy_facts(conn, instrument_id)
+        except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+            curr = prior = None
+        if curr is None:
+            block["piotroski"] = {"score": None, "suppressed": False, "reason": "no_annual_facts"}
+            block["altman_z"] = {"z": None, "suppressed": False, "reason": "no_annual_facts"}
+        else:
+            p = piotroski_f(curr, prior).to_dict()
+            p["suppressed"] = False
+            z = altman_z2(curr).to_dict()
+            z["suppressed"] = False
+            block["piotroski"] = p
+            block["altman_z"] = z
+
+    # Positioning
+    positioning: dict[str, Any] = {}
+
+    # insider — reuse the open-market (P/S) de-duped summary
+    insider_net: float | None = None
+    insider_asof: date | None = None
+    try:
+        with conn.transaction():
+            # Prime manifest_parsers BEFORE insider_transactions to avoid the
+            # documented partial-init import cycle (review-prevention-log:
+            # insider_transactions -> manifest_parsers._classify -> insider_345 ->
+            # insider_form3_ingest -> insider_transactions). The app/test
+            # entrypoints import manifest_parsers first by side effect; a fresh
+            # import order (standalone scoring run) would otherwise re-enter.
+            import app.services.manifest_parsers  # noqa: F401
+            from app.services.insider_transactions import get_insider_summary
+
+            summary = get_insider_summary(conn, instrument_id=instrument_id)
+            insider_net = float(summary.open_market_net_shares_90d)
+            insider_asof = summary.latest_txn_date
+    except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+        insider_net = None
+    ins = insider_signal(insider_net, shares_outstanding)
+    if insider_asof is not None:
+        ins["asof"] = insider_asof.isoformat()
+    positioning["insider_net_90d"] = ins
+
+    # 13F QoQ aggregate-shares delta
+    delta_pct: float | None = None
+    inst_asof: date | None = None
+    try:
+        with conn.transaction():
+            delta_pct, inst_asof = _read_13f_delta(conn, instrument_id)
+    except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+        delta_pct = None
+    inst = inst_13f_signal(delta_pct)
+    if inst_asof is not None:
+        inst["asof"] = inst_asof.isoformat()
+    positioning["inst_13f_qoq"] = inst
+
+    # short interest
+    try:
+        with conn.transaction():
+            positioning["short_interest"] = _read_short_interest(conn, instrument_id, shares_outstanding)
+    except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+        positioning["short_interest"] = short_interest_signal(None, None)
+
+    block["positioning"] = positioning
+    return block

--- a/app/services/instrument_analytics.py
+++ b/app/services/instrument_analytics.py
@@ -589,7 +589,11 @@ def assemble_instrument_analytics(
             from app.services.insider_transactions import get_insider_summary
 
             summary = get_insider_summary(conn, instrument_id=instrument_id)
-            insider_net = float(summary.open_market_net_shares_90d)
+            # open_market_net_shares_90d is COALESCE'd to 0 by the query (never
+            # None today), but guard the cast: a bare float(None) would escape the
+            # psycopg-only except and crash the whole score.
+            net = summary.open_market_net_shares_90d
+            insider_net = float(net) if net is not None else None
             insider_asof = summary.latest_txn_date
     except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
         insider_net = None
@@ -619,4 +623,9 @@ def assemble_instrument_analytics(
         positioning["short_interest"] = short_interest_signal(None, None)
 
     block["positioning"] = positioning
+    # Default peer_grade so the persisted shape is consistent even when this
+    # assembler runs OUTSIDE compute_rankings (a standalone compute_score has no
+    # run cohort). compute_rankings overwrites this with the real cross-sectional
+    # grade for the batch path.
+    block["peer_grade"] = {"basis": "absolute_only", "reason": "no_run_context", "families": {}}
     return block

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -32,6 +32,11 @@ import psycopg
 import psycopg.rows
 from psycopg.types.json import Jsonb
 
+from app.services.instrument_analytics import (
+    assemble_instrument_analytics,
+    compute_peer_grades,
+)
+from app.services.sector_classification import resolve_sector_spdr
 from app.services.xbrl_derived_stats import (
     MarketCapResolution,
     resolve_market_cap_basis,
@@ -305,6 +310,12 @@ class ScoreResult:
     # total_score; surfaced to the action layer + LLM record as a gate.
     data_completeness: float | None = None
     completeness_tier: str | None = None
+    # IAR evidence block (#1823, P2 of #1815) — Piotroski/Altman/positioning +
+    # (injected by compute_rankings) the cross-sectional peer grade. Persisted to
+    # scores.analytics_json. EVIDENCE-ONLY: never enters raw_total/total_score.
+    analytics: dict[str, Any] | None = None
+    # eToro sector code, carried for the compute_rankings peer-grade pass.
+    sector: str | None = None
     # Set after ranking pass
     rank: int | None = None
     rank_delta: int | None = None
@@ -1326,7 +1337,29 @@ def _load_instrument_data(
             resolution = MarketCapResolution(basis="not_multiclass")
         valuation_row = _apply_market_cap_basis(valuation_row, resolution)
 
+    # Sector code (eToro, for the peer-grade cohort) + SEC SIC (→ GICS sector,
+    # for the F/Z financials suppression). #1823. Own cursor — the dict_row
+    # cursor above is closed by this point.
+    sector_code: str | None = None
+    sic: str | None = None
+    with conn.cursor() as sec_cur:
+        sec_cur.execute(
+            """
+            SELECT i.sector, p.sic
+            FROM instruments i
+            LEFT JOIN instrument_sec_profile p ON p.instrument_id = i.instrument_id
+            WHERE i.instrument_id = %(id)s
+            """,
+            {"id": instrument_id},
+        )
+        sec_row = sec_cur.fetchone()
+        if sec_row is not None:
+            sector_code = sec_row[0]
+            sic = sec_row[1]
+
     return {
+        "sector_code": sector_code,
+        "sic": sic,
         "fund_rows": fund_rows,
         "price_row": price_row,
         "quote_row": quote_row,
@@ -1608,6 +1641,20 @@ def compute_score(
         news_90d_count=int(data.get("news_90d_count", 0)),
     )
 
+    # ------------------------------------------------------------------
+    # IAR evidence signals (#1823 §P2). Additive — never enters the
+    # total_score math above. Piotroski/Altman + positioning are per-
+    # instrument; the cross-sectional peer_grade is injected by
+    # compute_rankings from the run population.
+    # ------------------------------------------------------------------
+    fund_rows_for_shares = data["fund_rows"]
+    shares_out = _to_float(fund_rows_for_shares[0]["shares_outstanding"]) if fund_rows_for_shares else None
+    sic_cls = resolve_sector_spdr(data.get("sic"))  # type: ignore[arg-type]
+    gics_sector = sic_cls.gics_sector if sic_cls is not None else None
+    analytics = assemble_instrument_analytics(
+        instrument_id, conn, gics_sector=gics_sector, shares_outstanding=shares_out
+    )
+
     return ScoreResult(
         instrument_id=instrument_id,
         model_version=model_version,
@@ -1621,6 +1668,8 @@ def compute_score(
         total_reward=total_reward,
         data_completeness=data_completeness,
         completeness_tier=completeness_tier,
+        analytics=analytics,
+        sector=data.get("sector_code"),  # type: ignore[arg-type]
     )
 
 
@@ -1726,6 +1775,27 @@ def compute_rankings(
     # Sort descending by total_score, assign rank (1 = best)
     results.sort(key=lambda r: r.total_score, reverse=True)
 
+    # Cross-sectional hybrid peer grade (#1823 §P2) — computed from this run's
+    # absolute family scores grouped by eToro sector. Evidence-only; injected into
+    # each instrument's analytics block. Percentile cohort is the run-eligible
+    # population (basis records this).
+    peer_run_items = [
+        (
+            r.instrument_id,
+            r.sector,
+            {
+                "quality": r.family_scores.quality,
+                "value": r.family_scores.value,
+                "turnaround": r.family_scores.turnaround,
+                "momentum": r.family_scores.momentum,
+                "sentiment": r.family_scores.sentiment,
+                "confidence": r.family_scores.confidence,
+            },
+        )
+        for r in results
+    ]
+    peer_grades = compute_peer_grades(peer_run_items)
+
     # Read prior ranks and write new rows inside a single transaction.
     # Keeping _fetch_prior_ranks inside the transaction prevents a TOCTOU race
     # where a concurrent scoring run commits between the prior-rank read and our
@@ -1740,6 +1810,8 @@ def compute_rankings(
         for position, result in enumerate(results, start=1):
             prior_rank = prior_ranks.get(result.instrument_id)
             rank_delta = (prior_rank - position) if prior_rank is not None else None
+            analytics = dict(result.analytics) if result.analytics is not None else {}
+            analytics["peer_grade"] = peer_grades.get(result.instrument_id)
             scored = ScoreResult(
                 instrument_id=result.instrument_id,
                 model_version=result.model_version,
@@ -1753,6 +1825,8 @@ def compute_rankings(
                 total_reward=result.total_reward,
                 data_completeness=result.data_completeness,
                 completeness_tier=result.completeness_tier,
+                analytics=analytics,
+                sector=result.sector,
                 rank=position,
                 rank_delta=rank_delta,
             )
@@ -1801,7 +1875,8 @@ def _insert_score(
             raw_total, total_score, model_version,
             penalties_json, explanation,
             rank, rank_delta,
-            data_completeness, completeness_tier
+            data_completeness, completeness_tier,
+            analytics_json
         )
         VALUES (
             %(instrument_id)s, %(scored_at)s,
@@ -1810,7 +1885,8 @@ def _insert_score(
             %(raw_total)s, %(total_score)s, %(model_version)s,
             %(penalties_json)s, %(explanation)s,
             %(rank)s, %(rank_delta)s,
-            %(data_completeness)s, %(completeness_tier)s
+            %(data_completeness)s, %(completeness_tier)s,
+            %(analytics_json)s
         )
         """,
         {
@@ -1831,5 +1907,6 @@ def _insert_score(
             "rank_delta": result.rank_delta,
             "data_completeness": result.data_completeness,
             "completeness_tier": result.completeness_tier,
+            "analytics_json": Jsonb(result.analytics) if result.analytics is not None else None,
         },
     )

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -1340,22 +1340,30 @@ def _load_instrument_data(
     # Sector code (eToro, for the peer-grade cohort) + SEC SIC (→ GICS sector,
     # for the F/Z financials suppression). #1823. Own cursor — the dict_row
     # cursor above is closed by this point.
+    # Savepoint-guarded: instrument_sec_profile may be absent in a partial schema
+    # (e.g. a thin test DB) → degrade to no sector/sic rather than failing the
+    # whole score, mirroring the valuation/risk savepoint pattern above.
     sector_code: str | None = None
     sic: str | None = None
-    with conn.cursor() as sec_cur:
-        sec_cur.execute(
-            """
-            SELECT i.sector, p.sic
-            FROM instruments i
-            LEFT JOIN instrument_sec_profile p ON p.instrument_id = i.instrument_id
-            WHERE i.instrument_id = %(id)s
-            """,
-            {"id": instrument_id},
-        )
-        sec_row = sec_cur.fetchone()
-        if sec_row is not None:
-            sector_code = sec_row[0]
-            sic = sec_row[1]
+    try:
+        with conn.transaction():
+            with conn.cursor() as sec_cur:
+                sec_cur.execute(
+                    """
+                    SELECT i.sector, p.sic
+                    FROM instruments i
+                    LEFT JOIN instrument_sec_profile p ON p.instrument_id = i.instrument_id
+                    WHERE i.instrument_id = %(id)s
+                    """,
+                    {"id": instrument_id},
+                )
+                sec_row = sec_cur.fetchone()
+                if sec_row is not None:
+                    sector_code = sec_row[0]
+                    sic = sec_row[1]
+    except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+        sector_code = None
+        sic = None
 
     return {
         "sector_code": sector_code,

--- a/docs/specs/ranking/2026-06-29-1823-iar-evidence-signals.md
+++ b/docs/specs/ranking/2026-06-29-1823-iar-evidence-signals.md
@@ -1,0 +1,216 @@
+# #1823 — Evidence-only scoring signals into the IAR (P2 of #1815)
+
+**Status:** spec · **Type:** backend analytics, evidence-only · **Risk:** zero to live scoring (all new signals enter the headline at **weight 0**; `total_score` math unchanged).
+
+## Goal
+
+Compute + persist five evidence signals per instrument per scoring run, each with
+presence / as-of / source flags and honest caveats, into the **Instrument
+Analytical Record (IAR)** — which is the append-only `scores` row (#1820), not a
+separate table. Signals: **Piotroski F**, **Altman Z″**, **insider net 90d**,
+**13F QoQ**, **short-interest**, plus the **hybrid peer grade**. No live-score
+change; promotion to a non-zero headline weight is #1822/P5 (gated on the §8
+backtest + operator sign-off).
+
+## Source rule
+
+- **Piotroski F (0–9):** Piotroski, *Value Investing: The Use of Historical
+  Financial Statement Information to Separate Winners from Losers*, J. Accounting
+  Research 38 (2000). 9 binary points across profitability (ROA>0, CFO>0, ΔROA>0,
+  CFO>NI), leverage/liquidity (ΔLeverage<0, ΔCurrentRatio>0, no new shares),
+  efficiency (ΔGrossMargin>0, ΔAssetTurnover>0). 7/9 need prior-year data. Bands:
+  ≥7 strong / 4–6 neutral / ≤3 weak.
+- **Altman Z″ (non-manufacturer / EM recalibration), Altman 2000:**
+  `Z″ = 6.56·X1 + 3.26·X2 + 6.72·X3 + 1.05·X4`, X1=(CA−CL)/TA, X2=RE/TA,
+  X3=EBIT/TA, X4=Equity/TL. Bands: >2.60 safe / 1.10–2.60 grey / <1.10 distress.
+  Single-period (no lag).
+- **Financials/insurance suppression:** F & Z assume a current/non-current split
+  and inventory turnover that banks/insurers do not report. Suppress when the
+  SEC-SIC-derived GICS sector (`resolve_sector_spdr`, #1634) is exactly
+  `Financials`. This is the precise signal: the crosswalk folds banks (60xx),
+  thrifts, P&C/life insurance (63xx–64xx) into `Financials` BUT carves managed-care
+  (SIC 6324) to Health Care — managed-care insurers DO report a current ratio, so
+  computing F/Z for them is correct. Flag `quality_signal_na_financials`. When SIC
+  is NULL (no `instrument_sec_profile` row) the name is not suppressed but degrades
+  honestly via the missing-input guard (a bank has no `AssetsCurrent` → Z″ null,
+  never a wrong number).
+- **Positioning signals** (SEC Item 403 / Reg disclosure; FINRA short-interest
+  reporting): normalized to [0,1], 0.5 neutral, lag-stamped, per #1815 §5. The §5
+  formulas are kept; the *inputs* are bound to the data we actually have
+  (full-population-verified below), reusing the de-duped read paths:
+  - **insider** `0.5 + 0.5·tanh((net_shares / shares_outstanding) / 0.001)`. Reuses
+    `insider_transactions.get_insider_summary` → `open_market_net_shares_90d`
+    (source-ruled: only Form 4 `txn_code='P'` buy / `'S'` sale — awards/option-
+    exercise/gift/tax-withholding excluded). Note `net_$ / mktcap ==
+    net_shares / shares_outstanding` (price cancels), so no price lookup is needed.
+  - **13F** `0.5 + 0.5·clip(Δaggregate_shares% / 0.10, −1, 1)` over the two most
+    recent `period_end`s (caveat: ≤135d stale). **Δ of de-duped aggregate
+    institutional SHARES, not raw holder-COUNT** — prevention-log 1866/1873 show
+    raw filer-CIK counts are corrupted by manager sub-book/family fanout. Reuses
+    `ownership_history.get_ownership_category_totals(..., "institutions")` (#922:
+    dedup-before-sum at `(period_end, filer_cik)`, amendments collapsed). <2
+    periods → unavailable.
+  - **short-interest** `1 − clip((short% − 0.05) / 0.25, 0, 1)`, +0.1 if
+    `current_short_interest < previous_short_interest` (falling). `short% =
+    current_short_interest / shares_outstanding` — `finra_short_interest_current`
+    stores short interest in **shares only, no public-float column**, so the
+    denominator is shares-outstanding with an explicit caveat `% shares
+    outstanding (public float not ingested); bi-monthly`. `days_to_cover` carried
+    as context.
+- **Hybrid peer grade** (#1815 §6, decision #2/#4): `0.70·absolute +
+  0.30·sector_percentile` per family. Peer key = eToro `instruments.sector`.
+  Min-peer fallback: n≥8 sector percentile; 5≤n<8 whole-universe percentile; n<5
+  absolute-only + `peer_set_thin`. **Evidence-only in the IAR — the headline
+  family score stays absolute** (pure percentile would reverse scoring.py's v1
+  "cohort-relative normalization banned" settled decision). The percentile is
+  computed over the **run-eligible** population (the same tradable + analysable +
+  has-data set `compute_rankings` scores), NOT the full instrument universe;
+  `basis` records this explicitly (`run_eligible_sector` /
+  `run_eligible_universe`) so the record never overstates the cohort.
+
+## Full-population verification (dev DB, 2026-06-29)
+
+- `financial_facts_raw` (companyfacts, **non-dimensional default member only** —
+  prevention-log 1879): 4,170 instruments have 10-K facts; core concepts
+  well-covered (Assets 4,741 · NetIncomeLoss 4,653 · CFO 4,725 · StockholdersEquity
+  4,584 · RetainedEarnings 4,609 · OperatingIncomeLoss 3,966 · AssetsCurrent/
+  LiabilitiesCurrent ~3,930 — the gap is exactly the financials we suppress).
+- **`LiabilitiesNoncurrent` = 0 rows** → Piotroski leverage uses `LongTermDebt`
+  (2,310) → `LongTermDebtNoncurrent` (1,889) fallback; if absent the ΔLeverage
+  component is unavailable (never imputed).
+- **Revenue is ASC-606-fragmented** → fallback chain
+  `RevenueFromContractWithCustomerExcludingAssessedTax` (2,672) → `Revenues`
+  (2,127) → `RevenueFromContractWithCustomerIncludingAssessedTax` (735) →
+  `SalesRevenueNet` (205). Revenue-dependent F components (ΔGrossMargin,
+  ΔAssetTurnover) are frequently unavailable → emit partial `components_available
+  = k/9`, never impute.
+- Suppression verified: JPM/C/BAC (SIC 6021) + BRK.B/AIG (SIC 6331 insurance) →
+  `Financials` → suppress; AAPL/MSFT/GME/HD → compute. MET (sic NULL) is not
+  suppressed but degrades honestly — Z″ needs AssetsCurrent which an insurer
+  lacks → null with reason, never a wrong number.
+- **Reuse (verified to exist):** `get_insider_summary` (open-market P/S net 90d,
+  CIK-deduped, tombstone-excluded), `get_ownership_category_totals("institutions")`
+  (#922 de-duped per-period 13F aggregate shares), `resolve_sector_spdr`/
+  `instrument_sec_profile.sic` (GICS), `resolve_market_cap_basis` +
+  `shares_outstanding`/`market_cap_live` already loaded in scoring's
+  `_load_instrument_data`. The only genuinely new DB read is the latest-2-FY
+  concept reader for F/Z.
+
+## Schema (sql/210)
+
+```sql
+ALTER TABLE scores ADD COLUMN IF NOT EXISTS analytics_json JSONB;
+```
+
+Single nullable JSONB evidence column under the **same `model_version`** —
+additive-nullable evidence is blessed (settled-decisions: do NOT bump the
+version; same blessing as the `risk_v1` / completeness layer). Pre-#1823 rows
+keep NULL. Append-only; never mutated.
+
+`analytics_json` shape (all fields nullable; each signal self-describes presence):
+```json
+{
+  "schema": "iar_v1",
+  "piotroski": {"score": 7, "components_available": 9, "band": "strong",
+                "components": {"roa_positive": true, ...},
+                "asof": "2025-09-28", "source": "financial_facts_raw",
+                "suppressed": false},
+  "altman_z": {"z": 5.81, "band": "safe", "asof": "2025-09-28",
+               "source": "financial_facts_raw", "suppressed": false},
+  "positioning": {
+    "insider_net_90d": {"signal": 0.62, "net_shares": 120000, "shares_outstanding": 1.5e10,
+                        "asof": "...", "caveat": null, "source": "insider_transactions"},
+    "inst_13f_qoq":   {"signal": 0.55, "delta_shares_pct": 0.04, "asof": "...",
+                        "caveat": "<=135d stale", "source": "ownership_institutions_observations"},
+    "short_interest": {"signal": 0.80, "short_pct": 0.03, "days_to_cover": 1.2, "falling": true,
+                        "asof": "...", "caveat": "% shares outstanding (float not ingested); bi-monthly",
+                        "source": "finra_short_interest_current"}
+  },
+  "peer_grade": {"peer_key": "4", "peer_n": 412, "basis": "run_eligible_sector",
+                 "families": {"quality": {"absolute": 0.71, "percentile": 0.88,
+                              "hybrid": 0.76}, ...}}
+}
+```
+When a signal can't be computed it is present with `null` value + a `reason`
+(e.g. `{"score": null, "reason": "no_prior_year", "components_available": 2}`),
+never omitted and never neutral-filled.
+
+## Service
+
+New pure module `app/services/instrument_analytics.py` — all signal math as pure,
+table-testable functions (mirrors the `tests/test_scoring.py` pure-logic pattern):
+
+- `piotroski_f(curr, prior) -> PiotroskiResult` — takes two FY fact dicts, returns
+  score / components / components_available / band; missing component → not
+  counted, never imputed.
+- `altman_z2(facts) -> AltmanResult` — single-period; returns z / band, or null +
+  reason if any of X1–X4 inputs absent.
+- `insider_signal(net_shares, shares_outstanding)`,
+  `inst_13f_signal(delta_shares_pct)`, `short_interest_signal(short_pct, falling)`
+  — the §5 formulas, each returning signal + the inputs it used.
+- `hybrid_grade(absolute, percentile)` — `0.70·abs + 0.30·pct`.
+- `percentile_rank(value, population)` — empirical percentile for the peer pass.
+
+DB-facing assembler `assemble_instrument_analytics(instrument_id, conn, *,
+gics_sector, shares_outstanding)` — loads the latest two FY annual facts via the
+new concept reader (fallback chains), and reuses `get_insider_summary` /
+`get_ownership_category_totals("institutions")` (last two periods) /
+`finra_short_interest_current`, calls the pure functions, returns the
+per-instrument `analytics` dict **without** `peer_grade`. Reads are
+savepoint-guarded (catch `UndefinedTable, UndefinedColumn`).
+
+### Integration into scoring.py
+
+1. `compute_score` calls `assemble_instrument_analytics(...)` after family scores,
+   stores the per-instrument dict on a new frozen `ScoreResult.analytics: dict |
+   None` field. The headline math is untouched (signals never enter `raw_total` /
+   `total_score`).
+2. `compute_rankings` post-pass (in-memory, no extra queries): group the run's
+   `ScoreResult`s by `instruments.sector`, compute per-family sector percentiles
+   from the run's own absolute family scores, inject `peer_grade` (with min-peer
+   fallback) into each instrument's `analytics` before `_insert_score`. Standalone
+   `compute_score` (no run context) emits `peer_grade = {"basis": "absolute_only",
+   "reason": "no_run_context"}`.
+3. `_insert_score` writes `analytics_json` (Jsonb).
+4. Eligibility query adds `i.sector`; `compute_score` is passed `sector`,
+   `gics_sector` (resolved from `instrument_sec_profile.sic`), and the
+   market-cap basis it already resolves (#1662/#1664) for the insider signal.
+
+DB reads for the assembler are savepoint-guarded (catch `UndefinedTable,
+UndefinedColumn` per prevention-log 1941) so a partial schema degrades the signal
+to null, never fails the score.
+
+## API
+
+No new endpoint in P2. `analytics_json` is persisted only — the per-instrument
+**Verdict** tab that renders it is P3 (#1824). Confirmed not surfaced in
+`/rankings` (matches the completeness-column being P4).
+
+## Tests
+
+- `tests/test_instrument_analytics.py` (pure, no DB): Piotroski full-9 / partial /
+  all-bands; Altman bands + missing-input null; each positioning formula incl.
+  neutral 0.5 + sells-floor + falling bonus; hybrid grade; percentile_rank;
+  financials suppression.
+- `tests/test_scoring.py`: assert `analytics` rides through `compute_score` →
+  `_insert_score` (one mocked-cursor case; pure-logic for the rest).
+
+## Definition of done (ETL/analytics clauses 8–12)
+
+- Smoke panel AAPL/GME/MSFT/JPM/HD: F + Z computed (JPM suppressed); figures
+  recorded in the PR.
+- Cross-source: one F-score (e.g. AAPL) reconciled against an independent source
+  (gurufocus / stockanalysis Piotroski).
+- Backfill: run `compute_rankings` (scoring recompute, not `sec_rebuild` — no
+  ingest path changed) on dev; confirm `analytics_json` populates.
+- Operator-visible: spot-check the stored `analytics_json` for the panel.
+
+## Settled-decisions / prevention-log preserved
+
+- Headline untouched, weight 0 → "no cohort-relative normalization in headline"
+  intact; hybrid grade evidence-only.
+- Additive-nullable evidence under stable `model_version` (no version bump).
+- `financial_facts_raw` = non-dimensional only (1879); concept reachability
+  verified on the full population before speccing (1880).
+- Savepoint guards catch UndefinedTable+UndefinedColumn (1941).
+- Never impute missing fundamentals — partial F with `components_available`.

--- a/docs/specs/ranking/2026-06-29-1823-iar-evidence-signals.md
+++ b/docs/specs/ranking/2026-06-29-1823-iar-evidence-signals.md
@@ -23,7 +23,14 @@ backtest + operator sign-off).
 - **Altman Z″ (non-manufacturer / EM recalibration), Altman 2000:**
   `Z″ = 6.56·X1 + 3.26·X2 + 6.72·X3 + 1.05·X4`, X1=(CA−CL)/TA, X2=RE/TA,
   X3=EBIT/TA, X4=Equity/TL. Bands: >2.60 safe / 1.10–2.60 grey / <1.10 distress.
-  Single-period (no lag).
+  Single-period (no lag). **X3 EBIT proxy = `OperatingIncomeLoss`** — the standard
+  XBRL-available EBIT proxy (Damodaran / common screeners); a proxy, not exact
+  EBIT, and labelled as such (non-headline evidence).
+- **Piotroski ROA basis (documented variant):** ROA / asset-turnover use END-of-
+  period total assets, not the strict beginning-of-year basis — canonical ΔROA
+  needs THREE consecutive FYs (TA_{t-2}); we read two. `roa_positive` is
+  denominator-sign-invariant, so only the trend points use the end-asset basis,
+  applied consistently to both years (Gray & Carlisle variant).
 - **Financials/insurance suppression:** F & Z assume a current/non-current split
   and inventory turnover that banks/insurers do not report. Suppress when the
   SEC-SIC-derived GICS sector (`resolve_sector_spdr`, #1634) is exactly

--- a/sql/210_scores_analytics_json.sql
+++ b/sql/210_scores_analytics_json.sql
@@ -1,0 +1,14 @@
+-- Migration 210: scores.analytics_json — IAR evidence signals (#1823, P2 of #1815)
+--
+-- One nullable JSONB column carrying the per-instrument-per-run Instrument
+-- Analytical Record evidence block: Piotroski F, Altman Z", insider/13F/short
+-- positioning signals, and the hybrid peer grade. All EVIDENCE-ONLY — these
+-- signals enter the headline composite at weight 0, so total_score is UNCHANGED
+-- and model_version is NOT bumped (the same additive-nullable-evidence blessing
+-- used for the risk_v1 layer and the #1820 completeness columns; see
+-- settled-decisions "Risk-metrics evidence layer").
+--
+-- Additive + nullable: pre-migration rows keep NULL ("not computed then").
+-- Append-only — never mutated, consistent with the scores table contract.
+ALTER TABLE scores
+    ADD COLUMN IF NOT EXISTS analytics_json JSONB;

--- a/tests/test_instrument_analytics.py
+++ b/tests/test_instrument_analytics.py
@@ -1,0 +1,199 @@
+"""Pure-logic tests for the IAR evidence signals (#1823). No DB — every signal
+is a pure function over fact dicts / populations."""
+
+from __future__ import annotations
+
+from app.services.instrument_analytics import (
+    altman_z2,
+    compute_peer_grades,
+    hybrid_grade,
+    insider_signal,
+    inst_13f_signal,
+    percentile_rank,
+    piotroski_f,
+    short_interest_signal,
+)
+
+# A clean two-FY pair that earns all 9 Piotroski points.
+_CURR = {
+    "NetIncomeLoss": 100.0,
+    "Assets": 1000.0,
+    "NetCashProvidedByUsedInOperatingActivities": 150.0,
+    "LongTermDebt": 200.0,
+    "AssetsCurrent": 500.0,
+    "LiabilitiesCurrent": 250.0,
+    "WeightedAverageNumberOfDilutedSharesOutstanding": 1000.0,
+    "GrossProfit": 400.0,
+    "Revenues": 1000.0,
+    "Liabilities": 400.0,
+    "RetainedEarningsAccumulatedDeficit": 300.0,
+    "OperatingIncomeLoss": 120.0,
+    "StockholdersEquity": 600.0,
+}
+_PRIOR = {
+    "NetIncomeLoss": 80.0,
+    "Assets": 1000.0,
+    "LongTermDebt": 250.0,
+    "AssetsCurrent": 400.0,
+    "LiabilitiesCurrent": 250.0,
+    "WeightedAverageNumberOfDilutedSharesOutstanding": 1000.0,
+    "GrossProfit": 350.0,
+    "Revenues": 900.0,
+}
+
+
+class TestPiotroski:
+    def test_full_nine(self) -> None:
+        r = piotroski_f(_CURR, _PRIOR)
+        assert r.components_available == 9
+        assert r.score == 9
+        assert r.band == "strong"
+        assert all(r.components.values())
+
+    def test_no_prior_only_profitability(self) -> None:
+        # Without a prior year only the 3 current-only profitability points
+        # (roa/cfo/accrual) are evaluable — never imputed.
+        r = piotroski_f(_CURR, None)
+        assert r.components_available == 3
+        assert set(r.components) == {"roa_positive", "cfo_positive", "accrual_cfo_gt_ni"}
+        assert r.score == 3
+
+    def test_weak_band(self) -> None:
+        bad = {"NetIncomeLoss": -50.0, "Assets": 1000.0, "NetCashProvidedByUsedInOperatingActivities": -100.0}
+        r = piotroski_f(bad, None)
+        # roa<0, cfo<0, and cfo(-100) < ni(-50) -> all three profitability points fail.
+        assert r.score == 0
+        assert r.band == "weak"
+
+    def test_revenue_fallback_chain(self) -> None:
+        # No 'Revenues'/'GrossProfit' but ASC-606 revenue + CostOfRevenue present.
+        curr = dict(_CURR)
+        del curr["Revenues"], curr["GrossProfit"]
+        curr["RevenueFromContractWithCustomerExcludingAssessedTax"] = 1000.0
+        curr["CostOfRevenue"] = 600.0
+        prior = dict(_PRIOR)
+        del prior["Revenues"], prior["GrossProfit"]
+        prior["RevenueFromContractWithCustomerExcludingAssessedTax"] = 900.0
+        prior["CostOfRevenue"] = 560.0
+        r = piotroski_f(curr, prior)
+        # gross-margin + asset-turnover are still evaluable via the fallback.
+        assert "dgross_margin_up" in r.components
+        assert "dasset_turnover_up" in r.components
+
+    def test_no_inputs(self) -> None:
+        r = piotroski_f({}, None)
+        assert r.score is None
+        assert r.components_available == 0
+        assert r.reason == "no_inputs"
+
+
+class TestAltman:
+    def test_safe_band(self) -> None:
+        r = altman_z2(_CURR)
+        assert r.z is not None and r.z > 2.60
+        assert r.band == "safe"
+
+    def test_distress_band(self) -> None:
+        distressed = {
+            "Assets": 1000.0,
+            "Liabilities": 1200.0,
+            "AssetsCurrent": 100.0,
+            "LiabilitiesCurrent": 800.0,
+            "RetainedEarningsAccumulatedDeficit": -500.0,
+            "OperatingIncomeLoss": -100.0,
+            "StockholdersEquity": -200.0,
+        }
+        r = altman_z2(distressed)
+        assert r.z is not None and r.z < 1.10
+        assert r.band == "distress"
+
+    def test_missing_input_null(self) -> None:
+        partial = dict(_CURR)
+        del partial["RetainedEarningsAccumulatedDeficit"]
+        r = altman_z2(partial)
+        assert r.z is None
+        assert r.reason == "missing_input"
+
+    def test_no_total_assets(self) -> None:
+        r = altman_z2({"Liabilities": 100.0})
+        assert r.z is None
+        assert r.reason == "no_total_assets"
+
+
+class TestPositioning:
+    def test_insider_buy_above_neutral(self) -> None:
+        s = insider_signal(net_shares=1_000_000, shares_outstanding=1_000_000_000)
+        assert s["signal"] is not None and s["signal"] > 0.5
+
+    def test_insider_sell_floored(self) -> None:
+        s = insider_signal(net_shares=-50_000_000, shares_outstanding=1_000_000_000)
+        assert s["signal"] == 0.40  # heavy net sell floored, never below 0.40
+
+    def test_insider_neutral_zero_net(self) -> None:
+        s = insider_signal(net_shares=0, shares_outstanding=1_000_000_000)
+        assert s["signal"] == 0.5
+
+    def test_insider_missing(self) -> None:
+        assert insider_signal(None, 1_000.0)["signal"] is None
+        assert insider_signal(100.0, None)["signal"] is None
+        assert insider_signal(100.0, 0)["signal"] is None
+
+    def test_13f_accumulation(self) -> None:
+        assert inst_13f_signal(0.10)["signal"] == 1.0  # +10% QoQ saturates high
+        assert inst_13f_signal(-0.10)["signal"] == 0.0  # -10% saturates low
+        assert inst_13f_signal(0.0)["signal"] == 0.5
+        assert inst_13f_signal(None)["signal"] is None
+
+    def test_short_interest(self) -> None:
+        assert short_interest_signal(0.02, False)["signal"] == 1.0  # ~no shorting
+        assert short_interest_signal(0.30, False)["signal"] == 0.0  # very heavily shorted
+        falling = short_interest_signal(0.30, True)["signal"]
+        assert falling == 0.1  # 0.0 + 0.1 falling bonus
+        assert short_interest_signal(None, None)["signal"] is None
+
+
+class TestPeerGrade:
+    def test_hybrid_and_percentile(self) -> None:
+        assert hybrid_grade(0.8, 1.0) == round(0.7 * 0.8 + 0.3 * 1.0, 4)
+        assert percentile_rank(0.5, []) == 0.5  # empty -> neutral
+        assert percentile_rank(10.0, [0.0, 5.0, 10.0]) == (2 + 0.5) / 3  # mid-rank tie
+
+    def _items(self, n: int, sector: str | None) -> list:
+        return [
+            (
+                i,
+                sector,
+                {
+                    "quality": i / n,
+                    "value": 0.5,
+                    "turnaround": 0.5,
+                    "momentum": 0.5,
+                    "sentiment": 0.5,
+                    "confidence": 0.5,
+                },
+            )
+            for i in range(1, n + 1)
+        ]
+
+    def test_sector_cohort(self) -> None:
+        grades = compute_peer_grades(self._items(10, "4"))
+        g = grades[10]
+        assert g["basis"] == "run_eligible_sector"
+        assert g["peer_n"] == 10
+        # top quality (i=10) -> high percentile -> hybrid > absolute
+        q = g["families"]["quality"]
+        assert q["percentile"] > 0.8
+        assert q["hybrid"] == hybrid_grade(q["absolute"], q["percentile"])
+
+    def test_universe_fallback(self) -> None:
+        # 6 items in one sector: <8 sector peers but >=5 universe -> universe basis.
+        grades = compute_peer_grades(self._items(6, "9"))
+        assert grades[6]["basis"] == "run_eligible_universe"
+
+    def test_thin_peer_set(self) -> None:
+        grades = compute_peer_grades(self._items(3, "2"))
+        g = grades[3]
+        assert g["basis"] == "peer_set_thin"
+        q = g["families"]["quality"]
+        assert q["percentile"] is None
+        assert q["hybrid"] == q["absolute"]  # absolute-only when thin

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -985,6 +985,9 @@ def _make_fake_conn(
         ("fetchone", {"news_90d": news_90d}),
         ("fetchone", valuation_row),
         ("fetchone", risk_row),  # #1633 realized-risk metrics (risk_v1 3y)
+        # #1823 sector/sic read (eToro sector code + SEC SIC -> GICS). Plain
+        # cursor, indexed access: (sector_code, sic).
+        ("fetchone", ("1", None)),
     ]
     response_iter = iter(responses)
 
@@ -1007,6 +1010,17 @@ def _make_fake_conn(
 
 
 class TestComputeScore:
+    @pytest.fixture(autouse=True)
+    def _stub_analytics(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The IAR evidence assembler (#1823) is exercised by the pure-logic suite
+        # (test_instrument_analytics.py) + the dev smoke; here it is stubbed so the
+        # MagicMock fake-conn (a fixed query sequence) doesn't have to model its
+        # extra savepoint-guarded reads. compute_score's scoring math is the SUT.
+        monkeypatch.setattr(
+            "app.services.scoring.assemble_instrument_analytics",
+            lambda *a, **k: {"schema": "iar_v1"},
+        )
+
     def test_full_fixture_produces_valid_result(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # compute_score reads wall-clock via scoring._utcnow(); pin it to
         # the fixture's anchor so thesis-age math is deterministic. Without


### PR DESCRIPTION
## What
Computes + persists five **evidence-only** analytical signals per scoring run into a new nullable `scores.analytics_json` JSONB column (the Instrument Analytical Record): **Piotroski F**, **Altman Z″**, **insider net 90d**, **13F QoQ**, **short-interest**, plus the **hybrid peer grade**.

P2 of the #1815 redesign. Unblocked by #1820 (P0/P1 foundation, `3e97cb4b`); operator-greenlit on the issue.

## Why it's zero-risk to live scoring
Every new signal enters the headline composite at **weight 0** — `raw_total` / `total_score` math and `model_version` are **unchanged**. This is the blessed additive-nullable-evidence pattern (settled-decisions "Risk-metrics evidence layer"; same as #1820's completeness columns). Promotion to a non-zero headline weight is #1822/P5, gated on the §8 backtest + operator sign-off. **No cohort-relative normalization enters the headline** (hybrid peer grade is evidence-only).

## Design
- **New pure module** `app/services/instrument_analytics.py` — Piotroski/Altman math + §5 positioning formulas + hybrid grade, all table-tested, no DB. **Never imputes**: partial F carries `components_available=k/9`; Z returns null + reason on any missing input.
- **Reuses de-duped read paths** (reuse > reinvent):
  - insider: `get_insider_summary` open-market net (Form 4 `txn_code='P'/'S'` only — awards/exercises/gifts/tax excluded). `net_$/mktcap == net_shares/shares_outstanding` (price cancels).
  - 13F: `get_ownership_category_totals("institutions")` (#922 dedup-before-sum) → **Δ of aggregate SHARES, not holder count** (prevention-log 1866/1873: raw filer-CIK counts are corrupted by manager sub-book fanout).
  - short: `finra_short_interest_current`; `short% = current_short_interest / shares_outstanding` (public float not ingested → caveat).
- **F/Z suppressed** for SEC-SIC-derived GICS `Financials` (`resolve_sector_spdr`, #1634) — correctly computes for managed-care (SIC 6324 → Health Care), suppresses banks/insurers.
- **Hybrid peer grade** computed cross-sectionally in `compute_rankings` from the run-eligible population; `basis` records `run_eligible_sector` / `run_eligible_universe` / `peer_set_thin` (no overstated cohort).
- Reads savepoint-guarded (UndefinedTable+UndefinedColumn, prevention 1941); `manifest_parsers` primed before `insider_transactions` (prevention 353/354 import cycle).

## Source rules
Piotroski (J. Accounting Research 38, 2000); Altman Z″ non-manufacturer recalibration (Altman 2000); SEC Item 403 / FINRA short-interest. Two deliberate, documented evidence-only variants: ROA on end-of-period assets (canonical ΔROA needs 3 FYs; `roa_positive` is sign-invariant); Altman X3 EBIT proxy = `OperatingIncomeLoss`.

## Full-population verification (dev DB, 2026-06-29)
- 4,170 instruments with 10-K facts; core concepts well-covered. `LiabilitiesNoncurrent`=0 rows → leverage uses `LongTermDebt`. Revenue ASC-606-fragmented → fallback chain.
- Codex ckpt-2 caught a real contamination: a single `(concept, fiscal_year)` bucket holds the current FY value AND the prior-year comparative the 10-K restates. Added `period_end DESC` to the dedup ordering — validated on AAPL: FY2025 Assets now $359.24B (was picking the $364.98B FY2024 comparative); NetIncome $112.01B / Revenue $416.16B **match Apple's actual FY2025 10-K**.

## DoD (ETL/analytics clauses 8–12)
- **Smoke panel** (compute_score, dev): AAPL F=8/9 Z=2.31 grey · MSFT F=6/9 Z=4.49 safe · HD F=7/9 Z=5.01 safe · GME shorted 13% DTC≈12 → short signal 0.67 · **JPM F/Z suppressed** (financials), positioning still computed.
- **Cross-source** (clause 9): AAPL FY2025 NetIncome $112.01B / Assets $359.24B / Revenue $416.16B reconcile against Apple's reported FY2025 10-K; AAPL Piotroski F=8 in the ~7-8 range external sources report.
- **Persisted path** (clause 11): verified `analytics_json` round-trips through `_insert_score` (rolled back — no history pollution). Backfill = a `compute_rankings` recompute (no ingest path changed); the scheduled scoring job repopulates after merge.
- **Migration**: sql/210 applied to dev DB, recorded in `schema_migrations`.

## Tests
- `tests/test_instrument_analytics.py` (pure, no DB): F full-9/partial/bands/revenue-fallback, Z bands + missing-input null, each positioning formula (neutral 0.5 + sells-floor + falling bonus), hybrid grade, percentile, peer-grade cohort/universe/thin fallbacks. 19 cases.
- `tests/test_scoring.py`: assembler stubbed for the mocked-cursor scoring-math suite (assembler covered by the pure suite + dev smoke); sector/sic response added to the fake conn.
- Gates green: ruff, ruff format, pyright, fast tier (4722), smoke (135).

Closes #1823.

Part of #1815.
