### PR TITLE
feat(#1824): per-instrument Verdict tab — render the IAR (P3 of #1815)

### DIFF
--- a/app/api/scores.py
+++ b/app/api/scores.py
@@ -106,6 +106,48 @@ class ScoreHistoryResponse(BaseModel):
     items: list[ScoreHistoryItem]
 
 
+class VerdictScore(BaseModel):
+    scored_at: datetime
+    model_version: str
+    rank: int | None
+    rank_delta: int | None
+    total_score: float | None
+    raw_total: float | None
+    quality_score: float | None
+    value_score: float | None
+    turnaround_score: float | None
+    momentum_score: float | None
+    sentiment_score: float | None
+    confidence_score: float | None
+    data_completeness: float | None
+    completeness_tier: str | None
+    penalties_json: list[dict[str, object]] | None
+    explanation: str | None
+    analytics_json: dict[str, object] | None
+
+
+class VerdictResponse(BaseModel):
+    """Latest score row for a single instrument — the per-instrument Verdict
+    payload (#1824, P3 of #1815).
+
+    ``score`` is ``None`` when the instrument has never been scored (200 +
+    null, mirroring the instrument-404→200+null convention of #1813). When
+    present it carries the full headline breakdown plus the Instrument
+    Analytical Record (``analytics_json``, #1823) passed through verbatim.
+
+    ``analytics_json`` is typed loosely as a passthrough dict: the ``iar_v1``
+    shape is self-describing and every signal is independently nullable/sparse
+    (a suppressed F/Z emits only ``{suppressed, reason}``; a standalone
+    ``peer_grade`` omits ``peer_key``/``peer_n``). Strict Pydantic modelling
+    would hit the validation cliff (#932) and couple the read endpoint to the
+    evidence schema; the FE owns the display-side typing. Pre-#1823 score rows
+    keep ``analytics_json = null`` — the headline still renders.
+    """
+
+    instrument_id: int
+    score: VerdictScore | None
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -356,3 +398,70 @@ def get_score_history(
 
     items = [_parse_history_item(r) for r in rows]
     return ScoreHistoryResponse(instrument_id=instrument_id, items=items)
+
+
+@router.get("/verdict/{instrument_id}", response_model=VerdictResponse)
+def get_verdict(
+    instrument_id: int,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    model_version: str = Query(default=_DEFAULT_MODEL_VERSION),
+) -> VerdictResponse:
+    """Latest score row for a single instrument — the Verdict tab payload (#1824).
+
+    Returns *this instrument's* most recent score (``ORDER BY scored_at DESC
+    LIMIT 1``), including the IAR (``analytics_json``, #1823). This deliberately
+    diverges from the run-coherent ``MAX(scored_at)`` semantics of the rankings
+    list: the list is a cross-sectional ranking that must be coherent within one
+    run, whereas a single-instrument verdict wants this instrument's most recent
+    analysis even if it was dropped from the very latest run. Staleness is made
+    visible by returning ``scored_at``.
+
+    200 with ``score = null`` when the instrument has never been scored
+    (mirrors the instrument-404→200+null convention of #1813). Pre-#1823 rows
+    keep ``analytics_json = null`` — the headline still renders.
+    """
+    sql = """
+        SELECT s.scored_at, s.model_version,
+               s.rank, s.rank_delta,
+               s.total_score, s.raw_total,
+               s.quality_score, s.value_score, s.turnaround_score,
+               s.momentum_score, s.sentiment_score, s.confidence_score,
+               s.data_completeness, s.completeness_tier,
+               s.penalties_json, s.explanation, s.analytics_json
+        FROM scores s
+        WHERE s.instrument_id = %(instrument_id)s
+          AND s.model_version = %(mv)s
+        ORDER BY s.scored_at DESC
+        LIMIT 1
+    """
+    params = {"instrument_id": instrument_id, "mv": model_version}
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, params)
+        row = cur.fetchone()
+
+    if row is None:
+        return VerdictResponse(instrument_id=instrument_id, score=None)
+
+    return VerdictResponse(
+        instrument_id=instrument_id,
+        score=VerdictScore(
+            scored_at=row["scored_at"],  # type: ignore[arg-type]
+            model_version=row["model_version"],  # type: ignore[arg-type]
+            rank=_parse_optional_int(row, "rank"),
+            rank_delta=_parse_optional_int(row, "rank_delta"),
+            total_score=_parse_optional_float(row, "total_score"),
+            raw_total=_parse_optional_float(row, "raw_total"),
+            quality_score=_parse_optional_float(row, "quality_score"),
+            value_score=_parse_optional_float(row, "value_score"),
+            turnaround_score=_parse_optional_float(row, "turnaround_score"),
+            momentum_score=_parse_optional_float(row, "momentum_score"),
+            sentiment_score=_parse_optional_float(row, "sentiment_score"),
+            confidence_score=_parse_optional_float(row, "confidence_score"),
+            data_completeness=_parse_optional_float(row, "data_completeness"),
+            completeness_tier=row["completeness_tier"],  # type: ignore[arg-type]
+            penalties_json=row["penalties_json"],  # type: ignore[arg-type]
+            explanation=row["explanation"],  # type: ignore[arg-type]
+            analytics_json=row["analytics_json"],  # type: ignore[arg-type]
+        ),
+    )

--- a/docs/specs/ui/2026-06-29-1824-verdict-tab.md
+++ b/docs/specs/ui/2026-06-29-1824-verdict-tab.md
@@ -1,0 +1,100 @@
+# #1824 — Per-instrument Verdict tab (P3 of #1815)
+
+**Status:** spec · **Type:** FE + one thin read endpoint · **Risk:** read-only; no schema, no scoring change.
+
+## Goal
+
+New read-only **Verdict** tab on `/instrument/:symbol` (beside Research / Financials /
+Positions / News / Filings) that renders the **Instrument Analytical Record (IAR)** —
+the `scores.analytics_json` shipped by #1823 (P2) — plus the score-history sparkline
+and the existing thesis verdict/valuation. Per #1815 §7 surface 3.
+
+## Source rule
+
+- IAR shape = `iar_v1` (#1823 spec, `docs/specs/ranking/2026-06-29-1823-iar-evidence-signals.md`):
+  `piotroski` / `altman_z` / `positioning.{insider_net_90d,inst_13f_qoq,short_interest}`
+  / `peer_grade`. Every signal self-describes presence; a missing one is present with
+  `null` + `reason`, never omitted, never neutral-filled. The tab renders that honesty
+  verbatim (no imputation, no "0.00" for absent).
+- **Settled decision — no cohort-relative normalization** (`docs/settled-decisions.md`).
+  The peer percentile is **EVIDENCE-ONLY (headline weight 0)**. UI shows the absolute
+  family score as the headline; the hybrid/percentile is labelled "evidence-only — not
+  in the live score". Rendering percentile as the headline would silently reverse the
+  settled decision.
+- Valuation bear/base/bull + buy-zone + stance + narrative come from the **thesis**
+  (`ThesisDetail` already carries `stance`, `base/bull/bear_value`, `buy_zone_*`,
+  `memo_markdown`) — reuse, do not recompute.
+
+## Backend — `GET /rankings/verdict/{instrument_id}` (app/api/scores.py)
+
+Returns the **latest** `scores` row **for this instrument** (`WHERE instrument_id = …
+AND model_version = … ORDER BY scored_at DESC LIMIT 1`), including `analytics_json`.
+200 with `null` payload when the instrument has never been scored (mirrors the existing
+instrument-404→200+null convention, #1813).
+
+**Deliberate divergence from the list endpoint's run-coherent `MAX(scored_at)`
+semantics** (Codex ckpt-1): the `/rankings` list is a cross-sectional ranking that must
+be coherent within one run; a single-instrument verdict wants *this instrument's most
+recent analysis*, even if it was dropped from the very latest run (became ineligible).
+Staleness is made honest by surfacing `scored_at` prominently in the headline — the
+operator sees exactly how old the verdict is, never a silently-stale number.
+
+Response model `VerdictResponse`:
+- `instrument_id, scored_at, model_version`
+- `rank, rank_delta, total_score, raw_total`
+- the 6 family sub-scores (`quality_score` … `confidence_score`)
+- `data_completeness, completeness_tier`
+- `penalties_json, explanation`
+- `analytics_json: dict | None` — **pass through verbatim** (typed loosely as
+  `dict[str, object] | None`). Strict Pydantic modelling of the self-describing,
+  every-field-nullable IAR risks the validation cliff (#932) and brittle coupling; the
+  column is append-only and self-describing, so a passthrough is correct. FE owns the
+  display-side TS interface.
+
+Reuses `_DEFAULT_MODEL_VERSION` + the existing latest-run query shape. No new query
+mechanism beyond a single `WHERE instrument_id = … AND model_version = … ORDER BY
+scored_at DESC LIMIT 1`.
+
+## Frontend
+
+- `src/api/types.ts`: `IarAnalytics` (display interface for the known iar_v1 fields)
+  + `VerdictResponse`. **Nested fields are OPTIONAL (`?:`), not merely nullable**
+  (Codex ckpt-1): the real `iar_v1` branches are sparse — a suppressed F/Z emits only
+  `{suppressed, reason}` (no `score`/`components`/`components_available`); a standalone
+  `peer_grade` omits `peer_key`/`peer_n`. The renderer guards each field's *presence*,
+  not just non-null.
+- `src/api/verdict.ts`: `fetchScoreVerdict(instrumentId)` → `/rankings/verdict/{id}`.
+- `src/components/instrument/VerdictTab.tsx`: composes three fetches —
+  `fetchScoreVerdict` (IAR + headline), `fetchScoreHistory` (existing, sparkline via the
+  existing `Sparkline.tsx`), `fetchLatestThesis` (stance/valuation/narrative). Sections:
+  1. **Headline** — stance badge + total_score + rank + completeness tier.
+  2. **Six graded families** — absolute sub-score (headline) + the hybrid/percentile
+     beside it, explicitly tagged "evidence-only".
+  3. **Quality** — Piotroski F (show `score`, and `components_available/9` ONLY when
+     `components_available` is present — never `score/9`, which would overstate partial
+     coverage; Codex ckpt-1) + Altman Z″ (band); honest about suppression
+     (`suppressed`/`reason`, e.g. `quality_signal_na_financials`) / missing inputs
+     (`{z:null, reason}`).
+  4. **Positioning** — insider net 90d / 13F QoQ / short-interest, each with its caveat.
+  5. **Valuation** — buy-zone + bear/base/bull from the thesis.
+  6. **Score history** — sparkline of `total_score` over the append-only run series.
+  7. **Thesis narrative** — `memo_markdown`.
+  Each section renders honest loading / empty / error / null states; no fabricated
+  neutral values for absent signals.
+- `src/pages/InstrumentPage.tsx`: add `{ id: "verdict", label: "Verdict" }` to
+  `ALL_TABS` (after Research), render `<VerdictTab>` in the non-research tab switch.
+  Always visible (every instrument can be scored; empty state covers the never-scored
+  case).
+- Tests: `VerdictTab.test.tsx` — loading / never-scored-empty / error / fully-populated
+  / **scored-but-no-IAR** (pre-#1823 row: `analytics_json` NULL — headline + absolute
+  family sub-scores render, signal sections show "evidence not yet computed — populates
+  on the next scoring run"; Codex ckpt-1) / sparse-IAR (suppressed F/Z, partial
+  Piotroski, standalone peer_grade). Asserts null/absent signals render honestly and the
+  percentile carries the evidence-only tag.
+
+## Verification (change-coupled FE-QA, #1824 done-criterion)
+
+After build: run `compute_rankings` once on dev DB to populate `analytics_json`, then
+exercise the tab in the running site for a panel (AAPL populated-financials, JPM
+suppressed-Financials, a never-scored name) — screenshot, confirm numbers match the
+endpoint, dark mode clean, honest null/empty states. Record in the PR.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1075,6 +1075,102 @@ export interface ScoreHistoryResponse {
 }
 
 // ---------------------------------------------------------------------------
+// /rankings/verdict/{instrument_id} (app/api/scores.py — #1824, P3 of #1815)
+//
+// The Instrument Analytical Record (IAR, `iar_v1`) shipped by #1823 as the
+// nullable JSONB `scores.analytics_json`. EVERY field below is OPTIONAL, not
+// merely nullable: the real branches are sparse — a suppressed F/Z emits only
+// `{suppressed, reason}` (no `score`/`components`), a missing-input F/Z emits
+// `{score:null, reason}`, a standalone `peer_grade` omits `peer_key`/`peer_n`.
+// The renderer guards each field's PRESENCE, never assumes a key. Absent /
+// null signals render honestly ("not available") — never neutral-filled.
+// ---------------------------------------------------------------------------
+
+export interface IarPiotroski {
+  score?: number | null;
+  components_available?: number;
+  band?: string | null;
+  components?: Record<string, boolean>;
+  suppressed?: boolean;
+  reason?: string | null;
+}
+
+export interface IarAltmanZ {
+  z?: number | null;
+  band?: string | null;
+  suppressed?: boolean;
+  reason?: string | null;
+}
+
+export interface IarPositioningSignal {
+  signal?: number | null;
+  reason?: string | null;
+  caveat?: string | null;
+  source?: string;
+  asof?: string;
+  // insider
+  net_shares?: number | null;
+  shares_outstanding?: number;
+  // 13F
+  delta_shares_pct?: number;
+  // short interest
+  short_pct?: number;
+  days_to_cover?: number;
+  falling?: boolean;
+}
+
+export interface IarPeerFamily {
+  absolute?: number;
+  percentile?: number | null;
+  hybrid?: number;
+}
+
+export interface IarPeerGrade {
+  peer_key?: string;
+  peer_n?: number;
+  basis?: string;
+  reason?: string;
+  families?: Record<string, IarPeerFamily>;
+}
+
+export interface IarAnalytics {
+  schema?: string;
+  piotroski?: IarPiotroski;
+  altman_z?: IarAltmanZ;
+  positioning?: {
+    insider_net_90d?: IarPositioningSignal;
+    inst_13f_qoq?: IarPositioningSignal;
+    short_interest?: IarPositioningSignal;
+  };
+  peer_grade?: IarPeerGrade;
+}
+
+export interface VerdictScore {
+  scored_at: string;
+  model_version: string;
+  rank: number | null;
+  rank_delta: number | null;
+  total_score: number | null;
+  raw_total: number | null;
+  quality_score: number | null;
+  value_score: number | null;
+  turnaround_score: number | null;
+  momentum_score: number | null;
+  sentiment_score: number | null;
+  confidence_score: number | null;
+  data_completeness: number | null;
+  completeness_tier: string | null;
+  penalties_json: Record<string, unknown>[] | null;
+  explanation: string | null;
+  analytics_json: IarAnalytics | null;
+}
+
+export interface VerdictResponse {
+  instrument_id: number;
+  score: VerdictScore | null;
+}
+
+// ---------------------------------------------------------------------------
 // /theses/{instrument_id} (app/api/theses.py)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/api/verdict.ts
+++ b/frontend/src/api/verdict.ts
@@ -1,0 +1,11 @@
+import { apiFetch } from "@/api/client";
+import type { VerdictResponse } from "@/api/types";
+
+/**
+ * Latest per-instrument score + Instrument Analytical Record (#1824, P3 of
+ * #1815). Returns `score: null` when the instrument has never been scored
+ * (200 + null). Pre-#1823 rows return `score` with `analytics_json: null`.
+ */
+export function fetchScoreVerdict(instrumentId: number): Promise<VerdictResponse> {
+  return apiFetch<VerdictResponse>(`/rankings/verdict/${instrumentId}`);
+}

--- a/frontend/src/components/instrument/VerdictTab.test.tsx
+++ b/frontend/src/components/instrument/VerdictTab.test.tsx
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { VerdictTab } from "@/components/instrument/VerdictTab";
+import * as verdictApi from "@/api/verdict";
+import * as historyApi from "@/api/scoreHistory";
+import type {
+  IarAnalytics,
+  ThesisDetail,
+  VerdictResponse,
+} from "@/api/types";
+
+function makeVerdict(
+  overrides: Partial<VerdictResponse["score"]> = {},
+  analytics: IarAnalytics | null = null,
+): VerdictResponse {
+  return {
+    instrument_id: 1,
+    score: {
+      scored_at: "2026-06-29T09:00:00Z",
+      model_version: "v1.2-balanced",
+      rank: 5,
+      rank_delta: -2,
+      total_score: 0.82,
+      raw_total: 0.87,
+      quality_score: 0.9,
+      value_score: 0.75,
+      turnaround_score: 0.6,
+      momentum_score: 0.7,
+      sentiment_score: 0.5,
+      confidence_score: 0.85,
+      data_completeness: 0.91,
+      completeness_tier: "high",
+      penalties_json: null,
+      explanation: "Strong quality + value",
+      analytics_json: analytics,
+      ...overrides,
+    },
+  };
+}
+
+const FULL_IAR: IarAnalytics = {
+  schema: "iar_v1",
+  piotroski: { score: 7, components_available: 9, band: "strong", suppressed: false },
+  altman_z: { z: 5.81, band: "safe", suppressed: false },
+  positioning: {
+    insider_net_90d: { signal: 0.62, net_shares: 120000, source: "insider_transactions" },
+    inst_13f_qoq: { signal: 0.55, delta_shares_pct: 0.04, caveat: "<=135d stale" },
+    short_interest: {
+      signal: 0.8,
+      short_pct: 0.03,
+      days_to_cover: 1.2,
+      falling: true,
+      caveat: "% shares outstanding (public float not ingested); bi-monthly",
+    },
+  },
+  peer_grade: {
+    peer_key: "4",
+    peer_n: 412,
+    basis: "run_eligible_sector",
+    families: {
+      quality: { absolute: 0.9, percentile: 0.88, hybrid: 0.76 },
+    },
+  },
+};
+
+const THESIS: ThesisDetail = {
+  thesis_id: 1,
+  instrument_id: 1,
+  thesis_version: 1,
+  thesis_type: "full",
+  stance: "buy",
+  confidence_score: 0.8,
+  buy_zone_low: 100,
+  buy_zone_high: 120,
+  base_value: 150,
+  bull_value: 200,
+  bear_value: 90,
+  break_conditions_json: ["margin compression"],
+  memo_markdown: "The bull case rests on services.",
+  critic_json: null,
+  created_at: "2026-06-29T09:00:00Z",
+};
+
+function mockHistoryEmpty() {
+  vi.spyOn(historyApi, "fetchScoreHistory").mockResolvedValue({
+    instrument_id: 1,
+    items: [],
+  });
+}
+
+describe("VerdictTab", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockHistoryEmpty();
+  });
+
+  it("renders never-scored empty state when score is null", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue({
+      instrument_id: 1,
+      score: null,
+    });
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={null} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/not yet scored/i)).toBeInTheDocument();
+  });
+
+  it("renders error state on fetch failure", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockRejectedValue(
+      new Error("boom"),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={null} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(/boom/i)).toBeInTheDocument();
+  });
+
+  it("renders headline + populated IAR signals", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict({}, FULL_IAR),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={THESIS} />
+      </MemoryRouter>,
+    );
+    // headline
+    expect(await screen.findByText("0.82")).toBeInTheDocument();
+    expect(screen.getByText(/buy/i)).toBeInTheDocument();
+    expect(screen.getByText(/rank #5/)).toBeInTheDocument();
+    // Piotroski 7/9 strong + Altman safe
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("strong")).toBeInTheDocument();
+    expect(screen.getByText("safe")).toBeInTheDocument();
+    // peer percentile labelled evidence-only (appears in the family header)
+    expect(screen.getAllByText(/evidence-only/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("88%")).toBeInTheDocument();
+    // thesis narrative reused
+    expect(screen.getByText(/bull case rests on services/i)).toBeInTheDocument();
+  });
+
+  it("renders scored-but-no-IAR honestly (pre-#1823 row)", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict({}, null),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={null} />
+      </MemoryRouter>,
+    );
+    // headline still renders
+    expect(await screen.findByText("0.82")).toBeInTheDocument();
+    // signal sections honest about missing evidence
+    expect(
+      screen.getAllByText(/evidence not yet computed/i).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders sparse IAR honestly: suppressed F/Z + unavailable positioning", async () => {
+    const sparse: IarAnalytics = {
+      schema: "iar_v1",
+      piotroski: { score: null, suppressed: true, reason: "quality_signal_na_financials" },
+      altman_z: { z: null, suppressed: true, reason: "quality_signal_na_financials" },
+      positioning: {
+        insider_net_90d: { signal: null, reason: "no_insider_or_shares" },
+        inst_13f_qoq: { signal: null, reason: "insufficient_periods" },
+        short_interest: { signal: null, reason: "no_short_interest_or_shares" },
+      },
+      peer_grade: { basis: "absolute_only", reason: "no_run_context", families: {} },
+    };
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict({}, sparse),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={null} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("0.82")).toBeInTheDocument();
+    // financials-suppressed quality signals
+    expect(screen.getAllByText(/n\/a — financials/i).length).toBe(2);
+    // unavailable positioning (3 cards)
+    expect(screen.getAllByText(/unavailable/i).length).toBeGreaterThanOrEqual(3);
+    // peer cohort pending note (no peer_key)
+    expect(screen.getByText(/peer percentile pending/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/VerdictTab.tsx
+++ b/frontend/src/components/instrument/VerdictTab.tsx
@@ -1,0 +1,475 @@
+/**
+ * VerdictTab — the per-instrument Verdict surface (#1824, P3 of #1815).
+ *
+ * Renders the Instrument Analytical Record (IAR, `scores.analytics_json`,
+ * shipped evidence-only by #1823) plus the score-history sparkline and the
+ * existing thesis verdict/valuation. Read-only.
+ *
+ * Honesty rules (per #1815 §7 + the "no cohort-relative normalization" settled
+ * decision):
+ *   - The headline family score is the ABSOLUTE sub-score. The hybrid/percentile
+ *     peer grade is shown beside it but labelled EVIDENCE-ONLY — it is weight 0
+ *     in the live score and must never read as the headline.
+ *   - Absent / null / suppressed signals render their reason ("not available",
+ *     "n/a — financials", "evidence not yet computed"), never a neutral 0.00.
+ *   - `scored_at` is surfaced so a stale verdict (instrument dropped from the
+ *     latest run) is visibly stale, not silently old.
+ */
+
+import { type JSX } from "react";
+
+import { fetchScoreHistory } from "@/api/scoreHistory";
+import { fetchScoreVerdict } from "@/api/verdict";
+import type {
+  IarAltmanZ,
+  IarPiotroski,
+  IarPositioningSignal,
+  ScoreHistoryResponse,
+  ThesisDetail,
+  VerdictResponse,
+} from "@/api/types";
+import { Section, SectionSkeleton } from "@/components/dashboard/Section";
+import { Sparkline } from "@/components/instrument/Sparkline";
+import { ThesisPane } from "@/components/instrument/ThesisPane";
+import { EmptyState } from "@/components/states/EmptyState";
+import { useAsync } from "@/lib/useAsync";
+
+export interface VerdictTabProps {
+  readonly instrumentId: number;
+  readonly thesis: ThesisDetail | null;
+  readonly thesisErrored?: boolean;
+}
+
+const FAMILIES: { key: string; label: string; scoreKey: keyof FamilyScores }[] = [
+  { key: "quality", label: "Quality", scoreKey: "quality_score" },
+  { key: "value", label: "Value", scoreKey: "value_score" },
+  { key: "turnaround", label: "Turnaround", scoreKey: "turnaround_score" },
+  { key: "momentum", label: "Momentum", scoreKey: "momentum_score" },
+  { key: "sentiment", label: "Sentiment", scoreKey: "sentiment_score" },
+  { key: "confidence", label: "Confidence", scoreKey: "confidence_score" },
+];
+
+interface FamilyScores {
+  quality_score: number | null;
+  value_score: number | null;
+  turnaround_score: number | null;
+  momentum_score: number | null;
+  sentiment_score: number | null;
+  confidence_score: number | null;
+}
+
+function fmt2(v: number | null | undefined): string {
+  return v === null || v === undefined ? "—" : v.toFixed(2);
+}
+
+function ErrorBox({ message }: { message: string }): JSX.Element {
+  return (
+    <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
+      {message}
+    </div>
+  );
+}
+
+function stanceClass(stance: string): string {
+  const s = stance.toLowerCase();
+  if (s === "buy")
+    return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300";
+  if (s === "avoid")
+    return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300";
+  if (s === "watch")
+    return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300";
+  return "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300";
+}
+
+/** Evidence-only tag — peer percentile is weight 0 in the live score. */
+function EvidenceTag(): JSX.Element {
+  return (
+    <span
+      className="rounded bg-slate-100 px-1 py-0.5 text-[9px] uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-400"
+      title="Evidence-only — weight 0 in the live score (no cohort-relative normalization)"
+    >
+      evidence-only
+    </span>
+  );
+}
+
+export function VerdictTab({
+  instrumentId,
+  thesis,
+  thesisErrored = false,
+}: VerdictTabProps): JSX.Element {
+  const verdict = useAsync<VerdictResponse>(
+    () => fetchScoreVerdict(instrumentId),
+    [instrumentId],
+  );
+  const history = useAsync<ScoreHistoryResponse>(
+    () => fetchScoreHistory(instrumentId, 30),
+    [instrumentId],
+  );
+
+  if (verdict.loading) return <SectionSkeleton rows={5} />;
+  if (verdict.error !== null)
+    return (
+      <ErrorBox
+        message={
+          verdict.error instanceof Error
+            ? verdict.error.message
+            : "Failed to load the verdict."
+        }
+      />
+    );
+
+  const score = verdict.data?.score ?? null;
+  if (score === null) {
+    return (
+      <Section title="Verdict">
+        <EmptyState
+          title="Not yet scored"
+          description="This instrument has no scoring run yet. The verdict appears once the deterministic engine has scored it."
+        />
+      </Section>
+    );
+  }
+
+  const iar = score.analytics_json;
+  const peer = iar?.peer_grade;
+
+  // Score-history sparkline values, oldest→newest (the API returns newest first).
+  const historyValues = (history.data?.items ?? [])
+    .map((it) => it.total_score)
+    .filter((v): v is number => v !== null)
+    .reverse();
+
+  return (
+    <div className="space-y-5">
+      {/* 1. Headline */}
+      <Section title="Verdict">
+        <div className="flex flex-wrap items-center gap-3">
+          {thesis !== null && (
+            <span
+              className={`rounded px-2 py-0.5 text-sm font-semibold uppercase tracking-wide ${stanceClass(thesis.stance)}`}
+            >
+              {thesis.stance}
+            </span>
+          )}
+          <div className="flex items-baseline gap-1">
+            <span className="text-2xl font-semibold tabular-nums text-slate-800 dark:text-slate-100">
+              {fmt2(score.total_score)}
+            </span>
+            <span className="text-xs text-slate-500">total score</span>
+          </div>
+          {score.rank !== null && (
+            <span className="text-xs text-slate-500">
+              rank #{score.rank}
+              {score.rank_delta !== null && score.rank_delta !== 0 && (
+                <span
+                  className={
+                    score.rank_delta < 0
+                      ? "ml-1 text-emerald-600 dark:text-emerald-400"
+                      : "ml-1 text-red-600 dark:text-red-400"
+                  }
+                >
+                  {score.rank_delta < 0 ? "▲" : "▼"}
+                  {Math.abs(score.rank_delta)}
+                </span>
+              )}
+            </span>
+          )}
+          {score.completeness_tier !== null && (
+            <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600 dark:bg-slate-800 dark:text-slate-400">
+              completeness: {score.completeness_tier}
+              {score.data_completeness !== null &&
+                ` (${(score.data_completeness * 100).toFixed(0)}%)`}
+            </span>
+          )}
+          <span className="ml-auto text-[10px] text-slate-400">
+            as of {score.scored_at.slice(0, 10)} · {score.model_version}
+          </span>
+        </div>
+        {score.explanation !== null && (
+          <p className="mt-2 max-w-prose text-xs text-slate-600 dark:text-slate-400">
+            {score.explanation}
+          </p>
+        )}
+      </Section>
+
+      {/* 2. Six graded families */}
+      <Section title="Graded families">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left text-[11px] uppercase tracking-wide text-slate-500">
+              <th className="py-1 pr-4 font-medium">Family</th>
+              <th className="py-1 pr-4 font-medium">Score</th>
+              <th className="py-1 pr-2 font-medium">
+                Peer percentile <EvidenceTag />
+              </th>
+              <th className="py-1 font-medium">
+                Hybrid <EvidenceTag />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {FAMILIES.map((f) => {
+              const absolute = score[f.scoreKey];
+              const pf = peer?.families?.[f.key];
+              return (
+                <tr
+                  key={f.key}
+                  className="border-t border-slate-100 dark:border-slate-800"
+                >
+                  <td className="py-1 pr-4 text-slate-700 dark:text-slate-300">
+                    {f.label}
+                  </td>
+                  <td className="py-1 pr-4 font-medium tabular-nums">
+                    {fmt2(absolute)}
+                  </td>
+                  <td className="py-1 pr-2 tabular-nums text-slate-500">
+                    {pf?.percentile !== null && pf?.percentile !== undefined
+                      ? `${(pf.percentile * 100).toFixed(0)}%`
+                      : "—"}
+                  </td>
+                  <td className="py-1 tabular-nums text-slate-500">
+                    {fmt2(pf?.hybrid)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {peer?.peer_key !== undefined ? (
+          <p className="mt-1.5 text-[10px] text-slate-400">
+            Peer cohort: {peer.peer_key} (n={peer.peer_n ?? "—"}, {peer.basis})
+          </p>
+        ) : (
+          <p className="mt-1.5 text-[10px] text-slate-400">
+            Peer percentile pending — populates on the next ranking run with run
+            context.
+          </p>
+        )}
+      </Section>
+
+      {/* 3. Quality signals */}
+      <Section title="Quality signals">
+        {iar === null ? (
+          <EvidencePending />
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <PiotroskiCard p={iar.piotroski} />
+            <AltmanCard z={iar.altman_z} />
+          </div>
+        )}
+      </Section>
+
+      {/* 4. Positioning */}
+      <Section title="Positioning">
+        {iar === null ? (
+          <EvidencePending />
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-3">
+            <PositioningCard
+              label="Insider net 90d"
+              sig={iar.positioning?.insider_net_90d}
+            />
+            <PositioningCard
+              label="13F QoQ"
+              sig={iar.positioning?.inst_13f_qoq}
+            />
+            <PositioningCard
+              label="Short interest"
+              sig={iar.positioning?.short_interest}
+            />
+          </div>
+        )}
+      </Section>
+
+      {/* 5. Score history */}
+      <Section title="Score history">
+        {history.loading ? (
+          <SectionSkeleton rows={1} />
+        ) : history.error !== null ? (
+          <ErrorBox message="Failed to load score history." />
+        ) : historyValues.length < 2 ? (
+          <p className="text-xs text-slate-500">
+            Not enough runs yet to chart a trend.
+          </p>
+        ) : (
+          <div className="flex items-center gap-3">
+            <Sparkline
+              values={historyValues}
+              width={240}
+              height={48}
+              className="text-blue-600 dark:text-blue-400"
+            />
+            <span className="text-[10px] text-slate-400">
+              {historyValues.length} runs · total score
+            </span>
+          </div>
+        )}
+      </Section>
+
+      {/* 6. Thesis narrative + valuation (reuses the existing pane) */}
+      <ThesisPane thesis={thesis} errored={thesisErrored} />
+    </div>
+  );
+}
+
+function EvidencePending(): JSX.Element {
+  return (
+    <p className="text-xs text-slate-500">
+      Evidence not yet computed — populates on the next scoring run.
+    </p>
+  );
+}
+
+function SignalRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): JSX.Element {
+  return (
+    <div className="flex items-baseline justify-between gap-2 text-xs">
+      <span className="text-slate-500">{label}</span>
+      <span className="font-medium tabular-nums text-slate-700 dark:text-slate-300">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function PiotroskiCard({ p }: { p: IarPiotroski | undefined }): JSX.Element {
+  return (
+    <div className="rounded border border-slate-200 p-3 dark:border-slate-800">
+      <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+        Piotroski F
+      </div>
+      {p === undefined ? (
+        <span className="text-xs text-slate-400">—</span>
+      ) : p.suppressed ? (
+        <span className="text-xs text-slate-400">n/a — financials</span>
+      ) : p.score === null || p.score === undefined ? (
+        <span className="text-xs text-slate-400">
+          unavailable{p.reason ? ` (${p.reason})` : ""}
+        </span>
+      ) : (
+        <div className="flex items-baseline gap-2">
+          <span className="text-xl font-semibold tabular-nums text-slate-800 dark:text-slate-100">
+            {p.score}
+            {p.components_available !== undefined && (
+              <span className="text-sm text-slate-400">
+                /{p.components_available}
+              </span>
+            )}
+          </span>
+          {p.band && <Band band={p.band} />}
+        </div>
+      )}
+      {p?.components_available !== undefined &&
+        p.components_available < 9 &&
+        p.score !== null &&
+        p.score !== undefined && (
+          <p className="mt-1 text-[10px] text-slate-400">
+            {p.components_available}/9 components evaluable (rest lack prior-year
+            data)
+          </p>
+        )}
+    </div>
+  );
+}
+
+function AltmanCard({ z }: { z: IarAltmanZ | undefined }): JSX.Element {
+  return (
+    <div className="rounded border border-slate-200 p-3 dark:border-slate-800">
+      <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+        Altman Z″
+      </div>
+      {z === undefined ? (
+        <span className="text-xs text-slate-400">—</span>
+      ) : z.suppressed ? (
+        <span className="text-xs text-slate-400">n/a — financials</span>
+      ) : z.z === null || z.z === undefined ? (
+        <span className="text-xs text-slate-400">
+          unavailable{z.reason ? ` (${z.reason})` : ""}
+        </span>
+      ) : (
+        <div className="flex items-baseline gap-2">
+          <span className="text-xl font-semibold tabular-nums text-slate-800 dark:text-slate-100">
+            {z.z.toFixed(2)}
+          </span>
+          {z.band && <Band band={z.band} />}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Band({ band }: { band: string }): JSX.Element {
+  const cls =
+    band === "strong" || band === "safe"
+      ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+      : band === "weak" || band === "distress"
+        ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300"
+        : "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300";
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}>
+      {band}
+    </span>
+  );
+}
+
+function PositioningCard({
+  label,
+  sig,
+}: {
+  label: string;
+  sig: IarPositioningSignal | undefined;
+}): JSX.Element {
+  return (
+    <div className="rounded border border-slate-200 p-3 dark:border-slate-800">
+      <div className="mb-1 text-[11px] font-medium uppercase tracking-wide text-slate-500">
+        {label}
+      </div>
+      {sig === undefined || sig.signal === null || sig.signal === undefined ? (
+        <span className="text-xs text-slate-400">
+          unavailable{sig?.reason ? ` (${sig.reason})` : ""}
+        </span>
+      ) : (
+        <>
+          <div className="text-xl font-semibold tabular-nums text-slate-800 dark:text-slate-100">
+            {sig.signal.toFixed(2)}
+          </div>
+          <div className="mt-1 space-y-0.5">
+            {sig.delta_shares_pct !== undefined && (
+              <SignalRow
+                label="Δ shares QoQ"
+                value={`${(sig.delta_shares_pct * 100).toFixed(1)}%`}
+              />
+            )}
+            {sig.short_pct !== undefined && (
+              <SignalRow
+                label="short %"
+                value={`${(sig.short_pct * 100).toFixed(1)}%`}
+              />
+            )}
+            {sig.days_to_cover !== undefined && (
+              <SignalRow
+                label="days to cover"
+                value={sig.days_to_cover.toFixed(1)}
+              />
+            )}
+            {sig.net_shares !== null && sig.net_shares !== undefined && (
+              <SignalRow
+                label="net shares"
+                value={sig.net_shares.toLocaleString()}
+              />
+            )}
+          </div>
+          {sig.caveat && (
+            <p className="mt-1 text-[10px] text-slate-400">{sig.caveat}</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -47,6 +47,7 @@ import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
 import { Section, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { ResearchTab } from "@/components/instrument/ResearchTab";
+import { VerdictTab } from "@/components/instrument/VerdictTab";
 import { RightRail } from "@/components/instrument/RightRail";
 import { SummaryStrip } from "@/components/instrument/SummaryStrip";
 import { useAsync } from "@/lib/useAsync";
@@ -69,10 +70,17 @@ function ErrorView({ error, onRetry }: { error: unknown; onRetry?: () => void })
   );
 }
 
-type TabId = "research" | "financials" | "positions" | "news" | "filings";
+type TabId =
+  | "research"
+  | "verdict"
+  | "financials"
+  | "positions"
+  | "news"
+  | "filings";
 
 const ALL_TABS: { id: TabId; label: string }[] = [
   { id: "research", label: "Research" },
+  { id: "verdict", label: "Verdict" },
   { id: "financials", label: "Financials" },
   { id: "positions", label: "Positions" },
   { id: "news", label: "News" },
@@ -719,6 +727,13 @@ function InstrumentPageBody({
               ))}
             </nav>
 
+            {activeTab === "verdict" && (
+              <VerdictTab
+                instrumentId={summary.instrument_id}
+                thesis={thesisAsync.data}
+                thesisErrored={thesisErrSticky}
+              />
+            )}
             {activeTab === "financials" && <FinancialsTab symbol={symbol} />}
             {activeTab === "positions" && (
               <PositionsTab symbol={symbol} instrumentId={summary.instrument_id} />

--- a/tests/test_api_scores.py
+++ b/tests/test_api_scores.py
@@ -110,6 +110,47 @@ def _make_history_row(
     }
 
 
+def _make_verdict_row(
+    scored_at: datetime = _NOW,
+    model_version: str = "v1.1-balanced",
+    rank: int | None = 1,
+    rank_delta: int | None = -2,
+    total_score: float | None = 0.82,
+    raw_total: float | None = 0.87,
+    quality_score: float | None = 0.90,
+    value_score: float | None = 0.75,
+    turnaround_score: float | None = 0.60,
+    momentum_score: float | None = 0.70,
+    sentiment_score: float | None = 0.50,
+    confidence_score: float | None = 0.85,
+    data_completeness: float | None = 0.91,
+    completeness_tier: str | None = "high",
+    penalties_json: list[dict[str, object]] | None = None,
+    explanation: str | None = "Strong quality + value",
+    analytics_json: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a dict matching the single-instrument verdict query shape."""
+    return {
+        "scored_at": scored_at,
+        "model_version": model_version,
+        "rank": rank,
+        "rank_delta": rank_delta,
+        "total_score": total_score,
+        "raw_total": raw_total,
+        "quality_score": quality_score,
+        "value_score": value_score,
+        "turnaround_score": turnaround_score,
+        "momentum_score": momentum_score,
+        "sentiment_score": sentiment_score,
+        "confidence_score": confidence_score,
+        "data_completeness": data_completeness,
+        "completeness_tier": completeness_tier,
+        "penalties_json": penalties_json,
+        "explanation": explanation,
+        "analytics_json": analytics_json,
+    }
+
+
 def _mock_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
     """Build a mock psycopg.Connection.
 
@@ -483,3 +524,101 @@ class TestGetScoreHistory:
         cur = conn.cursor.return_value
         sql: str = cur.execute.call_args_list[0][0][0]
         assert "order by s.scored_at desc" in sql.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestGetVerdict
+# ---------------------------------------------------------------------------
+
+
+class TestGetVerdict:
+    """GET /rankings/verdict/{instrument_id} — latest per-instrument score + IAR."""
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_happy_path_returns_score_with_analytics(self) -> None:
+        iar = {
+            "schema": "iar_v1",
+            "piotroski": {"score": 7, "components_available": 9, "band": "strong"},
+            "altman_z": {"z": 5.81, "band": "safe", "suppressed": False},
+            "positioning": {"insider_net_90d": {"signal": 0.62}},
+            "peer_grade": {
+                "peer_key": "4",
+                "peer_n": 412,
+                "basis": "run_eligible_sector",
+                "families": {"quality": {"absolute": 0.71, "percentile": 0.88, "hybrid": 0.76}},
+            },
+        }
+        row = _make_verdict_row(analytics_json=iar)
+        _with_conn([[row]])
+        resp = client.get("/rankings/verdict/1")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["instrument_id"] == 1
+        score = body["score"]
+        assert score is not None
+        assert score["total_score"] == 0.82
+        assert score["rank"] == 1
+        assert score["completeness_tier"] == "high"
+        # analytics_json passed through verbatim.
+        assert score["analytics_json"]["piotroski"]["score"] == 7
+        assert score["analytics_json"]["peer_grade"]["peer_n"] == 412
+
+    def test_never_scored_returns_null_score(self) -> None:
+        _with_conn([[]])
+        resp = client.get("/rankings/verdict/999")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["instrument_id"] == 999
+        assert body["score"] is None
+
+    def test_scored_but_no_iar_returns_null_analytics(self) -> None:
+        # Pre-#1823 row: headline present, analytics_json NULL.
+        row = _make_verdict_row(analytics_json=None)
+        _with_conn([[row]])
+        resp = client.get("/rankings/verdict/1")
+
+        assert resp.status_code == 200
+        score = resp.json()["score"]
+        assert score is not None
+        assert score["total_score"] == 0.82
+        assert score["analytics_json"] is None
+
+    def test_nullable_headline_fields_returned_as_null(self) -> None:
+        row = _make_verdict_row(
+            rank=None,
+            rank_delta=None,
+            total_score=None,
+            data_completeness=None,
+            completeness_tier=None,
+            explanation=None,
+        )
+        _with_conn([[row]])
+        resp = client.get("/rankings/verdict/1")
+
+        assert resp.status_code == 200
+        score = resp.json()["score"]
+        assert score["rank"] is None
+        assert score["total_score"] is None
+        assert score["completeness_tier"] is None
+
+    def test_query_orders_by_scored_at_desc_limit_one(self) -> None:
+        conn = _with_conn([[]])
+        client.get("/rankings/verdict/1")
+
+        cur = conn.cursor.return_value
+        sql: str = cur.execute.call_args_list[0][0][0]
+        lowered = sql.lower()
+        assert "order by s.scored_at desc" in lowered
+        assert "limit 1" in lowered
+
+    def test_custom_model_version(self) -> None:
+        conn = _with_conn([[]])
+        client.get("/rankings/verdict/1", params={"model_version": "v1-conservative"})
+
+        cur = conn.cursor.return_value
+        params = cur.execute.call_args_list[0][0][1]
+        assert params["mv"] == "v1-conservative"


### PR DESCRIPTION
## What

New read-only **Verdict** tab on `/instrument/:symbol` (beside Research / Financials / Positions / News / Filings), rendering the **Instrument Analytical Record** (IAR — `scores.analytics_json`, shipped evidence-only by #1823) plus the score-history sparkline and the existing thesis verdict/valuation. P3 of #1815, §7 surface 3.

## Why

The IAR signals (#1823) and the score-history series existed but had no operator-facing surface. This is the deep, evidence-backed per-instrument view: F-score / Z / insider / 13F / short-interest / hybrid peer grade / valuation / thesis, with a track-over-time sparkline.

## Backend — `GET /rankings/verdict/{instrument_id}` (`app/api/scores.py`)

- Returns **this instrument's** latest score row (`ORDER BY scored_at DESC LIMIT 1`), including `analytics_json`.
- **Deliberate divergence** from the list endpoint's run-coherent `MAX(scored_at)` semantics: the list is a cross-sectional ranking that must be coherent within one run; a single-instrument verdict wants this instrument's most recent analysis even if it was dropped from the very latest run. Staleness is made honest by surfacing `scored_at`.
- `200 + score=null` when never scored (mirrors the instrument-404→200+null convention, #1813). Pre-#1823 rows keep `analytics_json=null` and still render the headline.
- `analytics_json` typed as a **passthrough dict**: the `iar_v1` shape is self-describing and every signal is independently sparse/nullable; strict Pydantic modelling would hit the validation cliff (#932) and couple the read endpoint to the evidence schema. FE owns the display typing.

## Frontend

- `IarAnalytics` / `VerdictScore` / `VerdictResponse` types — nested fields **OPTIONAL** (`?:`), not merely nullable (Codex ckpt-1): a suppressed F/Z emits only `{suppressed,reason}`; a standalone `peer_grade` omits `peer_key`/`peer_n`. The renderer guards each field's presence.
- `VerdictTab.tsx` sections: headline (stance / total score / rank±Δ / completeness / as-of) · 6 graded families (absolute = headline; hybrid + percentile beside it, **labelled EVIDENCE-ONLY** so it never reads as the headline — preserves the settled "no cohort-relative normalization" decision) · Piotroski F + Altman Z″ (honest suppression `n/a — financials` + missing-input) · insider / 13F / short positioning with caveats · score-history sparkline (reuses `Sparkline.tsx`) · thesis narrative + valuation (reuses `ThesisPane`).
- Piotroski shows `components_available/9` only when present, never `score/9` (Codex ckpt-1).
- Wired into `InstrumentPage` (always visible).

## Security model

Read-only. No new writes, no schema change, no scoring change. The endpoint is a `SELECT` on `scores` filtered by `instrument_id` + `model_version` (parameterised). Auth/session unchanged (same router as the existing rankings reads). No user input reaches raw SQL.

## Tests

- `TestGetVerdict` — happy / never-scored-null / scored-but-no-IAR / nullable-headline / query-shape (`ORDER BY scored_at DESC LIMIT 1`) / custom model_version.
- `VerdictTab.test.tsx` — loading / never-scored-empty / error / fully-populated (evidence-only tag asserted) / scored-but-no-IAR / sparse-IAR (suppressed F/Z + unavailable positioning + peer-pending).

## Verification (change-coupled FE-QA done-criterion, commit 06d5c612)

Ran `compute_rankings` on dev DB to populate `analytics_json` (3,896 rows, `v1.3-balanced`). Exercised the live tab against `/rankings/verdict/{id}`:
- **AAPL** (id 1001): F=8/9 strong, Z=2.31 grey, peer cohort 3 (n=938), positioning + sparkline (9 runs) render; numbers match the endpoint.
- **JPM** (id 1023): F/Z both **"n/a — financials"** (correct SIC-financials suppression per #1823 source rule), positioning still computed, `thin_data` completeness honest.
- **EURUSD** (id 1): **"Not yet scored"** empty state.
- Dark mode clean; no console errors.

Local gates green: ruff / format / pyright / smoke / fast-tier (182 passed) / `pnpm typecheck` / `pnpm test:unit` (1181 passed) / dark-class gate.

Part of #1815. Closes #1824.