### PR TITLE
feat(#1825): rankings real pagination + completeness column (P4 of #1815)

### DIFF
--- a/app/api/scores.py
+++ b/app/api/scores.py
@@ -40,6 +40,45 @@ MAX_PAGE_LIMIT = 200
 
 Stance = Literal["buy", "hold", "watch", "avoid"]
 
+# Server-side sort allowlist (#1825). The request value is a Literal (FastAPI
+# 422s anything off-list) AND only ever used as a dict KEY here — the SQL column
+# fragment comes exclusively from this hardcoded map, so the user value never
+# reaches the ORDER BY string. `gics_sector` is deliberately absent: the column
+# displays a Python-resolved GICS label while the only SQL expression is the
+# SPDR-symbol CASE, so a SQL sort would not match the visible order (sector is a
+# filter, not a sort).
+SortField = Literal[
+    "rank",
+    "rank_delta",
+    "symbol",
+    "coverage_tier",
+    "total_score",
+    "quality_score",
+    "value_score",
+    "turnaround_score",
+    "momentum_score",
+    "sentiment_score",
+    "confidence_score",
+    "data_completeness",
+]
+
+_SORT_COLUMNS: dict[str, str] = {
+    "rank": "s.rank",
+    "rank_delta": "s.rank_delta",
+    "symbol": "i.symbol",
+    "coverage_tier": "c.coverage_tier",
+    "total_score": "s.total_score",
+    "quality_score": "s.quality_score",
+    "value_score": "s.value_score",
+    "turnaround_score": "s.turnaround_score",
+    "momentum_score": "s.momentum_score",
+    "sentiment_score": "s.sentiment_score",
+    "confidence_score": "s.confidence_score",
+    "data_completeness": "s.data_completeness",
+}
+
+_SORT_DIR: dict[str, str] = {"asc": "ASC", "desc": "DESC"}
+
 # ---------------------------------------------------------------------------
 # Response models
 # ---------------------------------------------------------------------------
@@ -67,6 +106,10 @@ class RankingItem(BaseModel):
     momentum_score: float | None
     sentiment_score: float | None
     confidence_score: float | None
+    # #1825: data-completeness surfaced so a high-ranked thin-coverage name is
+    # visibly flagged (on `scores` since #1820).
+    data_completeness: float | None
+    completeness_tier: str | None
     penalties_json: list[dict[str, object]] | None
     explanation: str | None
     model_version: str
@@ -187,6 +230,8 @@ def _parse_ranking_item(row: dict[str, object]) -> RankingItem:
         momentum_score=_parse_optional_float(row, "momentum_score"),
         sentiment_score=_parse_optional_float(row, "sentiment_score"),
         confidence_score=_parse_optional_float(row, "confidence_score"),
+        data_completeness=_parse_optional_float(row, "data_completeness"),
+        completeness_tier=row.get("completeness_tier"),  # type: ignore[arg-type]
         penalties_json=row["penalties_json"],  # type: ignore[arg-type]
         explanation=row["explanation"],  # type: ignore[arg-type]
         model_version=row["model_version"],  # type: ignore[arg-type]
@@ -226,6 +271,10 @@ def list_rankings(
     sector: str | None = Query(default=None),
     sector_spdr: str | None = Query(default=None),
     stance: Stance | None = Query(default=None),
+    q: str | None = Query(default=None),
+    min_total_score: float | None = Query(default=None),
+    sort: SortField = Query(default="rank"),
+    sort_dir: Literal["asc", "desc"] = Query(default="asc"),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=50, ge=1, le=MAX_PAGE_LIMIT),
 ) -> RankingsListResponse:
@@ -244,6 +293,15 @@ def list_rankings(
       - sector: DEPRECATED — exact match on the opaque ``instruments.sector``
         1-9 code (no GICS meaning). Retained for back-compat; use ``sector_spdr``.
       - stance: latest thesis stance for each instrument (adds LATERAL join only when used)
+      - q: case-insensitive substring match on symbol OR company_name (#1825 search)
+      - min_total_score: keep only rows with ``total_score >= min_total_score`` (#1825)
+
+    Sorting (#1825): ``sort`` (column allowlist) + ``sort_dir`` (asc/desc), both
+    Literals resolved through hardcoded maps so the user value never reaches the
+    SQL string. A stable ``s.rank, s.instrument_id`` tiebreak makes every page a
+    deterministic, drift-free slice. Server-authoritative pagination
+    (``offset``/``limit``/``total``) lets the client page the WHOLE filtered,
+    sorted population — no client-side truncation.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         # Step 1: find the latest run timestamp for this model_version.
@@ -312,6 +370,18 @@ def list_rankings(
             where_clauses.append("lt.stance = %(stance)s")
             filter_params["stance"] = stance
 
+        # Search: case-insensitive substring on symbol OR company_name (#1825).
+        if q is not None and q.strip() != "":
+            where_clauses.append("(i.symbol ILIKE %(q)s OR i.company_name ILIKE %(q)s)")
+            filter_params["q"] = f"%{q.strip()}%"
+
+        # Minimum total score (#1825). NULL total_score rows are excluded by the
+        # >= comparison, which is correct — an unscored row has no score to clear
+        # the bar.
+        if min_total_score is not None:
+            where_clauses.append("s.total_score >= %(min_total_score)s")
+            filter_params["min_total_score"] = min_total_score
+
         where_sql = " WHERE " + " AND ".join(where_clauses)
         joins_sql = "\n".join(extra_joins)
 
@@ -333,12 +403,22 @@ def list_rankings(
             "limit": limit,
             "offset": offset,
         }
+        # ORDER BY: column + direction come ONLY from the hardcoded allowlist
+        # maps (the request values are Literals, used as dict keys), so the
+        # user-controlled value never reaches the SQL string. The
+        # ``s.rank, s.instrument_id`` suffix is a stable, unique tiebreak so
+        # every page is a deterministic slice even when the sort value (and
+        # rank) tie (#1825 / Codex ckpt-1).
+        order_col = _SORT_COLUMNS[sort]
+        order_dir = _SORT_DIR[sort_dir]
+        order_sql = f"ORDER BY {order_col} {order_dir} NULLS LAST, s.rank ASC NULLS LAST, s.instrument_id ASC"
         items_sql = f"""SELECT s.instrument_id, i.symbol, i.company_name, i.sector, p.sic,
                    c.coverage_tier,
                    s.rank, s.rank_delta,
                    s.total_score, s.raw_total,
                    s.quality_score, s.value_score, s.turnaround_score,
                    s.momentum_score, s.sentiment_score, s.confidence_score,
+                   s.data_completeness, s.completeness_tier,
                    s.penalties_json, s.explanation,
                    s.model_version, s.scored_at
             FROM scores s
@@ -346,7 +426,7 @@ def list_rankings(
             LEFT JOIN coverage c USING (instrument_id)
             {joins_sql}
             {where_sql}
-            ORDER BY s.rank ASC NULLS LAST, s.total_score DESC
+            {order_sql}
             LIMIT %(limit)s OFFSET %(offset)s"""  # noqa: S608  — hardcoded fragments only
 
         cur.execute(items_sql, items_params)  # type: ignore[arg-type]

--- a/docs/specs/ui/2026-06-29-1825-rankings-pagination.md
+++ b/docs/specs/ui/2026-06-29-1825-rankings-pagination.md
@@ -1,0 +1,95 @@
+# #1825 — Rankings polish: real pagination + completeness column (P4 of #1815)
+
+**Status:** spec · **Type:** FE + read endpoint extension · **Risk:** read-only; no
+schema, no scoring change.
+
+## Problem (verified, file:line)
+
+- `GET /rankings` already supports `offset`/`limit`/`total` server-side, but the FE
+  (`RankingsPage.tsx`) fetches a single page of `RANKINGS_PAGE_LIMIT = 200` and does
+  **search + min-score filter + column sort CLIENT-SIDE over that page**, with a
+  truncation banner (`api/rankings.ts:31`, `RankingsPage.tsx:64-88`). The scored
+  population is now ~3,896 (all tiers, #1823 verified), so names beyond rank 200 are
+  invisible and search/filter/sort silently operate on the first page only.
+- `RankingItem` (`app/api/scores.py`) omits `data_completeness` / `completeness_tier`
+  (on `scores` since #1820) — the operator can't see that a high-ranked name is
+  thin-coverage.
+
+## Fix — make the rankings list fully server-authoritative
+
+Move every control that the page applies (search, min-score, sort) to the server so a
+single page is a correct slice of the WHOLE ranked, filtered, sorted population. Add
+the completeness column. Real prev/next pagination.
+
+### Backend — extend `list_rankings` (`app/api/scores.py`)
+
+New query params (all optional, back-compat — existing callers unaffected):
+- `q: str | None` — case-insensitive `ILIKE %q%` on `i.symbol` OR `i.company_name`.
+- `min_total_score: float | None` — `s.total_score >= %(min)s`.
+- `sort: SortField` (Literal allowlist, default `"rank"`) — one of `rank`, `rank_delta`,
+  `symbol`, `coverage_tier`, `total_score`, `quality_score`, `value_score`,
+  `turnaround_score`, `momentum_score`, `sentiment_score`, `confidence_score`,
+  `data_completeness`. **`gics_sector` is NOT sortable** (Codex ckpt-1 #3): the column
+  displays the GICS *label* resolved in Python, while the only SQL expression is
+  `sector_spdr_case_sql()` returning the *SPDR symbol* (`XLK`) — sorting on it would not
+  match the visible order. Sector is a FILTER (`sector_spdr`), not a sort. The Sector
+  header is non-sortable (like the company-name column).
+- `sort_dir: Literal["asc", "desc"]` (default `"asc"`) — **also a Literal** (Codex
+  ckpt-1 #1); mapped to a hardcoded `"ASC"`/`"DESC"` string, never interpolated raw.
+
+**SQL-injection guard:** both `sort` and `sort_dir` are `Literal`s (FastAPI 422s
+off-list) AND both resolve through hardcoded maps (`_SORT_COLUMNS` → column SQL,
+`_SORT_DIR` → `ASC`/`DESC`) — neither request value reaches the SQL string. **Stable
+deterministic order** (Codex ckpt-1 #2): `ORDER BY <col> <dir> NULLS LAST, s.rank ASC
+NULLS LAST, s.instrument_id ASC` — the `instrument_id` final key makes every page a
+unique, drift-free slice even when the sort value (and rank) tie.
+
+Add `s.data_completeness, s.completeness_tier` to the SELECT, `RankingItem`, and
+`_parse_ranking_item`. The `q` / `min_total_score` predicates join the existing
+`where_clauses` list (parameterised) so COUNT + items stay consistent.
+
+`MAX_PAGE_LIMIT` stays 200 (a page cap, not a universe cap). Default page `limit`
+becomes 50.
+
+### Frontend
+
+- `api/rankings.ts`: `RankingsQuery` gains OPTIONAL `q`, `min_total_score`, `sort`,
+  `sort_dir` (optional so the `RightRail` caller's `{coverage_tier, sector_spdr, stance}`
+  literal still type-checks — Codex ckpt-1 #5). `fetchRankings` keeps its **positional**
+  `(query, limit = 50, offset = 0)` signature — `RightRail`'s `fetchRankings(q, 6)` is
+  unaffected. Drop the `RANKINGS_PAGE_LIMIT`-single-page assumption + the
+  contract-violation console.warn that policed it.
+- `RankingsPage.tsx`: page is now server-authoritative.
+  - State: `query` (filters + q + min-score + sort) and `offset`. ANY query change
+    resets `offset` to 0 **in the same event handler** (`setQuery(...)` + `setOffset(0)`
+    batched into one render → one fetch; never reset offset in a `useEffect` reacting to
+    `query`, which would double-fetch the new query at the stale offset — Codex ckpt-1
+    #4). The `useAsync` dep is the serialized `(query, offset)` pair.
+  - Debounced search feeds `query.q` (server-side) — the page-local search + truncation
+    banner + client `filteredItems`/`sortItems` are removed.
+  - Pagination footer: `‹ Prev` / `Next ›` + "showing X–Y of N", disabled at ends.
+  - Empty/loading/error/401 states preserved (the `computeView` discriminator stays, but
+    operates on the server page directly — no client filtering layer).
+- `RankingsTable.tsx`: header click calls an `onSortChange(field, dir)` prop (server
+  sort) instead of local `useState`; the active sort + direction come from props. Add a
+  **Completeness** column rendering `completeness_tier` as a tier chip
+  (`full` / `thin_data` / `insufficient_data`) with `data_completeness` % in the title.
+  Remove `sortItems` (server orders now).
+- The 6 sub-scores already render — spec §7 "surface sub-scores" already satisfied; the
+  per-family hybrid peer grade stays on the Verdict tab (#1824), not duplicated into the
+  dense ranking row.
+
+### Tests
+
+- Backend (`tests/test_api_scores.py::TestListRankings`): `q` predicate added,
+  `min_total_score` predicate added, `sort`/`sort_dir` map to the right ORDER BY column,
+  invalid `sort` → 422, completeness fields surfaced + nullable.
+- Frontend (`RankingsPage.test.tsx`, new): pagination advances offset + refetches; a
+  filter/search/sort change resets offset to 0; completeness chip renders; header click
+  drives server sort.
+
+## Verification (change-coupled FE-QA, #1825 done-criterion)
+
+`/rankings` already populated (#1824 ran `compute_rankings`, 3,896 rows). Exercise the
+live page: page through (Next/Prev), search a name beyond page 1, sort by a sub-score,
+confirm the completeness chip + numbers match `/rankings?...`. Screenshot in PR.

--- a/frontend/src/api/rankings.ts
+++ b/frontend/src/api/rankings.ts
@@ -2,36 +2,62 @@ import { apiFetch } from "@/api/client";
 import type { RankingsListResponse } from "@/api/types";
 
 /**
- * Server-side filter set for /rankings.
+ * Server-side query set for /rankings (#1825 — fully server-authoritative).
  *
- * Only the three filters that the backend understands live here. Sort
- * direction and the score-threshold filter are applied client-side in
- * RankingsPage and never reach the wire.
+ * Every control the Rankings page exposes now reaches the wire: the three
+ * filters (coverage_tier, sector_spdr, stance), free-text search (q),
+ * min-total-score, and sort (column + direction). The page no longer filters
+ * or sorts client-side over a truncated page, so a single page is a correct
+ * slice of the WHOLE filtered, sorted population.
  *
  * model_version is intentionally not exposed: per docs/settled-decisions.md
- * the v1 default is "v1-balanced" and the backend defaults to it. Adding a
- * frontend selector is a separate ticket.
+ * the backend defaults to the live version. A frontend selector is a separate
+ * ticket.
  */
+export type RankingsSortField =
+  | "rank"
+  | "rank_delta"
+  | "symbol"
+  | "coverage_tier"
+  | "total_score"
+  | "quality_score"
+  | "value_score"
+  | "turnaround_score"
+  | "momentum_score"
+  | "sentiment_score"
+  | "confidence_score"
+  | "data_completeness";
+
 export interface RankingsQuery {
   coverage_tier: number | null;
-  // #1675: real GICS sector-SPDR symbol (e.g. "XLF"); replaces the opaque
-  // instruments.sector code as the peer-grouping dimension.
+  // #1675: real GICS sector-SPDR symbol (e.g. "XLF"); the peer-grouping dimension.
   sector_spdr: string | null;
   stance: "buy" | "hold" | "watch" | "avoid" | null;
+  // #1825 — optional so existing callers (e.g. RightRail) that pass only the
+  // three filters still type-check.
+  q?: string | null;
+  min_total_score?: number | null;
+  sort?: RankingsSortField;
+  sort_dir?: "asc" | "desc";
 }
 
-// The backend caps `limit` at 200 (MAX_PAGE_LIMIT in app/api/scores.py).
-// The issue notes the Tier 1+2 universe is at most ~200 instruments, so a
-// single page is sufficient for v1. If `total > items.length` we surface a
-// console warning rather than silently truncating — see RankingsPage.
-export const RANKINGS_PAGE_LIMIT = 200;
+// A page of rankings. The backend caps `limit` at 200 (MAX_PAGE_LIMIT). This is
+// a PAGE size, not a universe cap — the page steps through the full population
+// via `offset` (#1825).
+export const RANKINGS_PAGE_SIZE = 50;
 
+/**
+ * Fetch one page of rankings. Positional `(query, limit, offset)` so the
+ * existing `fetchRankings(query, 6)` RightRail caller is unaffected.
+ */
 export async function fetchRankings(
   query: RankingsQuery,
-  limit: number = RANKINGS_PAGE_LIMIT,
+  limit: number = RANKINGS_PAGE_SIZE,
+  offset = 0,
 ): Promise<RankingsListResponse> {
   const params = new URLSearchParams();
   params.set("limit", String(limit));
+  params.set("offset", String(offset));
   if (query.coverage_tier !== null) {
     params.set("coverage_tier", String(query.coverage_tier));
   }
@@ -41,15 +67,24 @@ export async function fetchRankings(
   if (query.stance !== null) {
     params.set("stance", query.stance);
   }
+  if (query.q != null && query.q !== "") {
+    params.set("q", query.q);
+  }
+  if (query.min_total_score != null) {
+    params.set("min_total_score", String(query.min_total_score));
+  }
+  if (query.sort != null) {
+    params.set("sort", query.sort);
+  }
+  if (query.sort_dir != null) {
+    params.set("sort_dir", query.sort_dir);
+  }
   const response = await apiFetch<RankingsListResponse>(`/rankings?${params.toString()}`);
 
   // Backend invariant: scored_at is null only when there are zero rows in
   // `scores` for this model_version, which by construction means an empty
-  // items list (see app/api/scores.py list_rankings step 1). If a future
-  // backend change ever serves rows with a null scored_at, the page would
-  // hide them behind the "no runs yet" empty state — surface the drift
-  // loudly here so it is caught at the source rather than as a confused
-  // empty state on the page.
+  // items list (see app/api/scores.py list_rankings step 1). Surface any drift
+  // loudly so it is caught at the source rather than as a confused empty state.
   if (response.scored_at === null && response.items.length > 0) {
     console.error(
       "[rankings] backend contract violation: scored_at is null but items is non-empty",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1033,6 +1033,10 @@ export interface RankingItem {
   momentum_score: number | null;
   sentiment_score: number | null;
   confidence_score: number | null;
+  // #1825: data-completeness surfaced so high-ranked thin-coverage names are
+  // visibly flagged (on `scores` since #1820).
+  data_completeness: number | null;
+  completeness_tier: string | null;
   penalties_json: Record<string, unknown>[] | null;
   explanation: string | null;
   model_version: string;

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -32,7 +32,7 @@ vi.mock("@/api/filings", () => ({ fetchFilings: vi.fn() }));
 vi.mock("@/api/news", () => ({ fetchNews: vi.fn() }));
 vi.mock("@/api/rankings", () => ({
   fetchRankings: vi.fn(),
-  RANKINGS_PAGE_LIMIT: 200,
+  RANKINGS_PAGE_SIZE: 50,
 }));
 vi.mock("@/api/copyTrading", () => ({ fetchCopyTrading: vi.fn() }));
 
@@ -124,6 +124,8 @@ function rankingsWith(currentSymbol: string): RankingsListResponse {
         momentum_score: null,
         sentiment_score: null,
         confidence_score: null,
+        data_completeness: null,
+        completeness_tier: null,
         penalties_json: null,
         explanation: null,
         model_version: "v1",
@@ -146,6 +148,8 @@ function rankingsWith(currentSymbol: string): RankingsListResponse {
         momentum_score: null,
         sentiment_score: null,
         confidence_score: null,
+        data_completeness: null,
+        completeness_tier: null,
         penalties_json: null,
         explanation: null,
         model_version: "v1",
@@ -277,6 +281,8 @@ describe("RightRail", () => {
           momentum_score: null,
           sentiment_score: null,
           confidence_score: null,
+          data_completeness: null,
+          completeness_tier: null,
           penalties_json: null,
           explanation: null,
           model_version: "v1",

--- a/frontend/src/components/rankings/RankingsFilters.tsx
+++ b/frontend/src/components/rankings/RankingsFilters.tsx
@@ -4,15 +4,13 @@ import { SECTOR_OPTIONS } from "@/lib/sectors";
 /**
  * Filter bar for the rankings page.
  *
- * Server-side filters (sent to /rankings as query params):
+ * All filters are server-side query params (#1825 — fully server-authoritative):
  *   - coverage_tier (1 / 2 / 3)
  *   - sector_spdr (real GICS sector, #1675)
  *   - stance (buy / hold / watch / avoid)
+ *   - score threshold → query.min_total_score (sent to /rankings)
  *
- * Client-side filter (applied to the in-memory result set):
- *   - score threshold (minimum total_score)
- *
- * Sort is also client-side and lives on the table component, not here.
+ * Sort lives on the table header (also server-side now); pagination on the page.
  *
  * Sector options are the fixed 11 GICS sectors (#1675, SECTOR_OPTIONS) — value
  * is the SPDR symbol sent to the API, label is the GICS name. No longer derived

--- a/frontend/src/components/rankings/RankingsTable.tsx
+++ b/frontend/src/components/rankings/RankingsTable.tsx
@@ -1,62 +1,48 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { Link } from "react-router-dom";
+import type { RankingsSortField } from "@/api/rankings";
 import type { RankingItem } from "@/api/types";
 import { formatNumber } from "@/lib/format";
 import { RankDeltaCell } from "@/components/rankings/RankDeltaCell";
 
 /**
- * Rankings table.
+ * Rankings table (#1825 — server-authoritative sort + pagination).
  *
  * One component, five render branches, one stable `<table>` element. The
  * `<thead>` column set is defined exactly once in COLUMNS and rendered in
  * every branch so the layout does not shift between loading / empty /
- * error / data states (the loading-error-empty-states skill rule, plus
- * the #89 / #90 prevention finding).
+ * error / data states.
  *
- * Non-data branches render their content as a single `<tr><td colSpan>`
- * row inside the same `<tbody>` so the markup stays valid HTML — never a
- * `<div>` swapped in alongside the table.
- *
- * Sort state lives in this component, not the page. Sorting is purely
- * client-side; changing sort never triggers a refetch. The dataset is
- * capped at 200 rows by RANKINGS_PAGE_LIMIT so an in-memory sort is fine.
+ * Sorting is now SERVER-side: a header click calls `onSortChange(field, dir)`
+ * and the page refetches the WHOLE filtered population reordered — the table
+ * no longer sorts the current page in memory (which would only reorder the
+ * visible slice). `sort` / `sortDir` come from props (the page's query state).
  */
 
-type SortKey =
-  | "rank"
-  | "symbol"
-  | "gics_sector"
-  | "coverage_tier"
-  | "total_score"
-  | "quality_score"
-  | "value_score"
-  | "turnaround_score"
-  | "momentum_score"
-  | "sentiment_score"
-  | "rank_delta";
-
 interface ColumnDef {
-  key: SortKey;
+  // null = not server-sortable (display-only, like Company; or the GICS sector
+  // label which has no matching SQL sort expression — #1825 / Codex ckpt-1).
+  sortKey: RankingsSortField | null;
   label: string;
   align: "left" | "right";
-  // Default sort direction when this column is first clicked. For numeric
-  // score columns we want highest first; for rank we want best (lowest)
-  // first.
+  // Default sort direction when this column is first clicked. Numeric score
+  // columns want highest-first; rank/symbol/tier want ascending-first.
   defaultDir: "asc" | "desc";
 }
 
 const COLUMNS: ReadonlyArray<ColumnDef> = [
-  { key: "rank", label: "Rank", align: "right", defaultDir: "asc" },
-  { key: "rank_delta", label: "Δ", align: "right", defaultDir: "asc" },
-  { key: "symbol", label: "Symbol", align: "left", defaultDir: "asc" },
-  { key: "gics_sector", label: "Sector", align: "left", defaultDir: "asc" },
-  { key: "coverage_tier", label: "Tier", align: "right", defaultDir: "asc" },
-  { key: "total_score", label: "Total", align: "right", defaultDir: "desc" },
-  { key: "quality_score", label: "Quality", align: "right", defaultDir: "desc" },
-  { key: "value_score", label: "Value", align: "right", defaultDir: "desc" },
-  { key: "turnaround_score", label: "Turn.", align: "right", defaultDir: "desc" },
-  { key: "momentum_score", label: "Mom.", align: "right", defaultDir: "desc" },
-  { key: "sentiment_score", label: "Sent.", align: "right", defaultDir: "desc" },
+  { sortKey: "rank", label: "Rank", align: "right", defaultDir: "asc" },
+  { sortKey: "rank_delta", label: "Δ", align: "right", defaultDir: "asc" },
+  { sortKey: "symbol", label: "Symbol", align: "left", defaultDir: "asc" },
+  { sortKey: null, label: "Sector", align: "left", defaultDir: "asc" },
+  { sortKey: "coverage_tier", label: "Tier", align: "right", defaultDir: "asc" },
+  { sortKey: "total_score", label: "Total", align: "right", defaultDir: "desc" },
+  { sortKey: "quality_score", label: "Quality", align: "right", defaultDir: "desc" },
+  { sortKey: "value_score", label: "Value", align: "right", defaultDir: "desc" },
+  { sortKey: "turnaround_score", label: "Turn.", align: "right", defaultDir: "desc" },
+  { sortKey: "momentum_score", label: "Mom.", align: "right", defaultDir: "desc" },
+  { sortKey: "sentiment_score", label: "Sent.", align: "right", defaultDir: "desc" },
+  { sortKey: "data_completeness", label: "Compl.", align: "right", defaultDir: "desc" },
 ];
 
 const COLUMN_COUNT = COLUMNS.length + 1; // +1 for the company-name column
@@ -68,22 +54,26 @@ export type RankingsView =
   | { kind: "error401" }
   | { kind: "error"; onRetry: () => void };
 
-export function RankingsTable({ view }: { view: RankingsView }) {
-  const [sortKey, setSortKey] = useState<SortKey>("rank");
-  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+export interface RankingsTableProps {
+  readonly view: RankingsView;
+  readonly sort: RankingsSortField;
+  readonly sortDir: "asc" | "desc";
+  readonly onSortChange: (field: RankingsSortField, dir: "asc" | "desc") => void;
+}
 
-  const sortedItems = useMemo(() => {
-    if (view.kind !== "data") return [];
-    return sortItems(view.items, sortKey, sortDir);
-  }, [view, sortKey, sortDir]);
-
+export function RankingsTable({
+  view,
+  sort,
+  sortDir,
+  onSortChange,
+}: RankingsTableProps) {
   const onHeaderClick = (col: ColumnDef) => {
-    if (col.key === sortKey) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
-    } else {
-      setSortKey(col.key);
-      setSortDir(col.defaultDir);
-    }
+    if (col.sortKey === null) return;
+    // Toggle direction when re-clicking the active column; otherwise apply the
+    // column's default direction.
+    const nextDir =
+      col.sortKey === sort ? (sortDir === "asc" ? "desc" : "asc") : col.defaultDir;
+    onSortChange(col.sortKey, nextDir);
   };
 
   return (
@@ -92,23 +82,29 @@ export function RankingsTable({ view }: { view: RankingsView }) {
         <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
           <tr>
             {COLUMNS.map((col) => {
-              const active = col.key === sortKey;
+              const active = col.sortKey !== null && col.sortKey === sort;
               const indicator = active ? (sortDir === "asc" ? " ↑" : " ↓") : "";
               return (
                 <th
-                  key={col.key}
+                  key={col.label}
                   scope="col"
                   className={`px-2 py-2 ${col.align === "right" ? "text-right" : "text-left"}`}
                   aria-sort={active ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
                 >
-                  <button
-                    type="button"
-                    onClick={() => onHeaderClick(col)}
-                    className="font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
-                  >
-                    {col.label}
-                    {indicator}
-                  </button>
+                  {col.sortKey === null ? (
+                    <span className="font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {col.label}
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => onHeaderClick(col)}
+                      className="font-semibold uppercase tracking-wide text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+                    >
+                      {col.label}
+                      {indicator}
+                    </button>
+                  )}
                 </th>
               );
             })}
@@ -155,7 +151,7 @@ export function RankingsTable({ view }: { view: RankingsView }) {
               </div>
             </MessageRow>
           ) : (
-            sortedItems.map((item) => <RankingRow key={item.instrument_id} item={item} />)
+            view.items.map((item) => <RankingRow key={item.instrument_id} item={item} />)
           )}
         </tbody>
       </table>
@@ -218,46 +214,49 @@ function RankingRow({ item }: { item: RankingItem }) {
       <td className="px-2 py-2 text-right tabular-nums">{formatScore(item.turnaround_score)}</td>
       <td className="px-2 py-2 text-right tabular-nums">{formatScore(item.momentum_score)}</td>
       <td className="px-2 py-2 text-right tabular-nums">{formatScore(item.sentiment_score)}</td>
+      <td className="px-2 py-2 text-right">
+        <CompletenessChip tier={item.completeness_tier} pct={item.data_completeness} />
+      </td>
       <td className="px-2 py-2 text-slate-600">{item.company_name}</td>
     </tr>
   );
 }
 
-function formatScore(value: number | null): string {
-  // Scores are unitless heuristic numbers in the 0..100-ish range; show two
-  // decimals via the existing formatNumber helper rather than hand-rolling
-  // a toFixed (operator-ui-conventions: never hand-format numerics).
-  return formatNumber(value, 2);
+/**
+ * Completeness chip (#1825). Surfaces the scoring run's data-completeness tier
+ * so a high-ranked thin-coverage name is visibly flagged. `full` is muted
+ * (the expected good state); `thin_data` / `insufficient_data` are warning-
+ * coloured. The fraction sits in the title for the exact figure on hover.
+ */
+function CompletenessChip({
+  tier,
+  pct,
+}: {
+  tier: string | null;
+  pct: number | null;
+}) {
+  if (tier === null) return <span className="text-slate-400">—</span>;
+  const cls =
+    tier === "insufficient_data"
+      ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300"
+      : tier === "thin_data"
+        ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+        : "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400";
+  const label = tier.replace(/_/g, " ");
+  const title = pct === null ? label : `${label} · ${(pct * 100).toFixed(0)}% complete`;
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${cls}`}
+      title={title}
+    >
+      {label}
+    </span>
+  );
 }
 
-// ---------------------------------------------------------------------------
-// Sort
-// ---------------------------------------------------------------------------
-
-/**
- * Sort RankingItems by the given key. NULL values always sort to the end
- * regardless of direction — this matches the server's `ORDER BY rank ASC
- * NULLS LAST` and means an unscored instrument never displaces a scored
- * one to the top of the table.
- */
-function sortItems(
-  items: ReadonlyArray<RankingItem>,
-  key: SortKey,
-  dir: "asc" | "desc",
-): RankingItem[] {
-  const copy = items.slice();
-  const mult = dir === "asc" ? 1 : -1;
-  copy.sort((a, b) => {
-    const av = a[key];
-    const bv = b[key];
-    if (av === null && bv === null) return 0;
-    if (av === null) return 1;
-    if (bv === null) return -1;
-    if (typeof av === "number" && typeof bv === "number") {
-      return (av - bv) * mult;
-    }
-    // String compare for symbol / sector.
-    return String(av).localeCompare(String(bv)) * mult;
-  });
-  return copy;
+function formatScore(value: number | null): string {
+  // Scores are unitless heuristic numbers; show two decimals via the existing
+  // formatNumber helper rather than hand-rolling a toFixed (operator-ui-
+  // conventions: never hand-format numerics).
+  return formatNumber(value, 2);
 }

--- a/frontend/src/pages/RankingsPage.test.tsx
+++ b/frontend/src/pages/RankingsPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
@@ -24,6 +24,8 @@ function _item(overrides: Partial<RankingItem>): RankingItem {
     momentum_score: 40,
     sentiment_score: 30,
     confidence_score: 20,
+    data_completeness: 0.91,
+    completeness_tier: "full",
     penalties_json: null,
     explanation: null,
     model_version: "v1-balanced",
@@ -32,111 +34,138 @@ function _item(overrides: Partial<RankingItem>): RankingItem {
   };
 }
 
-describe("RankingsPage — #194 search", () => {
-  it("filters rows by symbol substring (debounced)", async () => {
-    const response: RankingsListResponse = {
-      items: [
-        _item({ instrument_id: 1, symbol: "AAA", company_name: "Alpha Co" }),
-        _item({ instrument_id: 2, symbol: "BBB", company_name: "Beta Inc" }),
-        _item({ instrument_id: 3, symbol: "CCC", company_name: "Charlie Ltd" }),
-      ],
-      total: 3,
-      offset: 0,
-      limit: 200,
-      model_version: "v1-balanced",
-      scored_at: "2026-04-28T12:00:00Z",
-    };
-    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(response);
+function _response(
+  items: RankingItem[],
+  total: number,
+  offset = 0,
+): RankingsListResponse {
+  return {
+    items,
+    total,
+    offset,
+    limit: 50,
+    model_version: "v1-balanced",
+    scored_at: "2026-04-28T12:00:00Z",
+  };
+}
 
+/** Last (query, limit, offset) the page passed to fetchRankings. */
+function lastCall(spy: ReturnType<typeof vi.spyOn>) {
+  const calls = spy.mock.calls;
+  return calls[calls.length - 1] as unknown as [rankingsApi.RankingsQuery, number, number];
+}
+
+describe("RankingsPage — server-authoritative (#1825)", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("renders rows + the completeness chip", async () => {
+    const spy = vi
+      .spyOn(rankingsApi, "fetchRankings")
+      .mockResolvedValue(_response([_item({ completeness_tier: "thin_data" })], 1));
     render(
       <MemoryRouter>
         <RankingsPage />
       </MemoryRouter>,
     );
-
-    // Initial render shows all three rows.
     expect(await screen.findByText("AAA")).toBeInTheDocument();
-    expect(screen.getByText("BBB")).toBeInTheDocument();
-    expect(screen.getByText("CCC")).toBeInTheDocument();
-
-    const searchInput = screen.getByLabelText(/search/i);
-    await userEvent.type(searchInput, "BBB");
-
-    // 300ms debounce — wait for filter to apply.
-    await waitFor(
-      () => {
-        expect(screen.queryByText("AAA")).not.toBeInTheDocument();
-      },
-      { timeout: 1000 },
-    );
-    expect(screen.getByText("BBB")).toBeInTheDocument();
-    expect(screen.queryByText("CCC")).not.toBeInTheDocument();
+    expect(screen.getByText(/thin data/i)).toBeInTheDocument();
+    expect(spy).toHaveBeenCalled();
   });
 
-  it("warns when search runs over a truncated page (#194 Codex)", async () => {
-    const response: RankingsListResponse = {
-      items: [_item({ instrument_id: 1, symbol: "AAA", company_name: "Alpha Co" })],
-      // total > items.length triggers the truncation banner once the
-      // user starts searching. Otherwise an out-of-page match would
-      // silently appear as "No instruments match the current filters".
-      total: 250,
-      offset: 0,
-      limit: 200,
-      model_version: "v1-balanced",
-      scored_at: "2026-04-28T12:00:00Z",
-    };
-    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(response);
-
+  it("search drives a server query param (q) and resets to offset 0", async () => {
+    const spy = vi
+      .spyOn(rankingsApi, "fetchRankings")
+      .mockResolvedValue(_response([_item({})], 1));
     render(
       <MemoryRouter>
         <RankingsPage />
       </MemoryRouter>,
     );
+    await screen.findByText("AAA");
 
-    expect(await screen.findByText("AAA")).toBeInTheDocument();
-    // No banner before search.
-    expect(screen.queryByText(/matches outside the page/i)).not.toBeInTheDocument();
-
-    await userEvent.type(screen.getByLabelText(/search/i), "foo");
+    await userEvent.type(screen.getByLabelText(/search/i), "BBB");
     await waitFor(
       () => {
-        expect(screen.getByText(/matches outside the page/i)).toBeInTheDocument();
+        expect(lastCall(spy)[0].q).toBe("BBB");
       },
       { timeout: 1000 },
     );
+    // offset (3rd positional arg) is 0 after a search.
+    expect(lastCall(spy)[2]).toBe(0);
   });
 
-  it("filters by company-name substring (case-insensitive)", async () => {
-    const response: RankingsListResponse = {
-      items: [
-        _item({ instrument_id: 1, symbol: "AAA", company_name: "Alpha Co" }),
-        _item({ instrument_id: 2, symbol: "BBB", company_name: "Beta Inc" }),
-      ],
-      total: 2,
-      offset: 0,
-      limit: 200,
-      model_version: "v1-balanced",
-      scored_at: "2026-04-28T12:00:00Z",
-    };
-    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(response);
-
+  it("pagination Next advances the server offset", async () => {
+    // 120 total, page size 50 → Next is enabled.
+    const spy = vi
+      .spyOn(rankingsApi, "fetchRankings")
+      .mockResolvedValue(_response([_item({})], 120));
     render(
       <MemoryRouter>
         <RankingsPage />
       </MemoryRouter>,
     );
+    await screen.findByText("AAA");
+    expect(screen.getByText(/showing 1–1 of 120/i)).toBeInTheDocument();
 
-    expect(await screen.findByText("AAA")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /next/i }));
+    await waitFor(() => {
+      expect(lastCall(spy)[2]).toBe(50);
+    });
+  });
 
-    const searchInput = screen.getByLabelText(/search/i);
-    await userEvent.type(searchInput, "alpha");
+  it("Prev is disabled on the first page", async () => {
+    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(
+      _response([_item({})], 120),
+    );
+    render(
+      <MemoryRouter>
+        <RankingsPage />
+      </MemoryRouter>,
+    );
+    await screen.findByText("AAA");
+    expect(screen.getByRole("button", { name: /prev/i })).toBeDisabled();
+  });
 
+  it("sort header click drives the server sort param", async () => {
+    const spy = vi
+      .spyOn(rankingsApi, "fetchRankings")
+      .mockResolvedValue(_response([_item({})], 1));
+    render(
+      <MemoryRouter>
+        <RankingsPage />
+      </MemoryRouter>,
+    );
+    await screen.findByText("AAA");
+
+    await userEvent.click(screen.getByRole("button", { name: /value/i }));
+    await waitFor(() => {
+      expect(lastCall(spy)[0].sort).toBe("value_score");
+      expect(lastCall(spy)[0].sort_dir).toBe("desc");
+    });
+  });
+
+  it("shows the dirty-filter empty state when a search returns nothing", async () => {
+    vi.spyOn(rankingsApi, "fetchRankings").mockResolvedValue(
+      _response([], 0),
+    );
+    render(
+      <MemoryRouter>
+        <RankingsPage />
+      </MemoryRouter>,
+    );
+    // No dirty filter yet → "produced no ranked instruments".
+    expect(
+      await screen.findByText(/produced no ranked instruments/i),
+    ).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/search/i), "zzz");
     await waitFor(
       () => {
-        expect(screen.queryByText("BBB")).not.toBeInTheDocument();
+        expect(
+          screen.getByText(/no instruments match the current filters/i),
+        ).toBeInTheDocument();
       },
       { timeout: 1000 },
     );
-    expect(screen.getByText("AAA")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -1,108 +1,113 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { ApiError } from "@/api/client";
-import { fetchRankings, RANKINGS_PAGE_LIMIT, type RankingsQuery } from "@/api/rankings";
+import {
+  fetchRankings,
+  RANKINGS_PAGE_SIZE,
+  type RankingsQuery,
+  type RankingsSortField,
+} from "@/api/rankings";
 import { useAsync } from "@/lib/useAsync";
 import { Section } from "@/components/dashboard/Section";
 import { RankingsFilters } from "@/components/rankings/RankingsFilters";
 import { RankingsTable, type RankingsView } from "@/components/rankings/RankingsTable";
 import { formatDateTime } from "@/lib/format";
-import type { RankingItem, RankingsListResponse } from "@/api/types";
+import type { RankingsListResponse } from "@/api/types";
 
 /**
- * Rankings / candidates view (#61).
+ * Rankings / candidates view (#61, #1825 server-authoritative).
  *
- * Single async source: GET /rankings. The endpoint already joins instrument
- * metadata server-side (symbol, company_name, sector, coverage_tier), so
- * this page does NOT call /instruments — calling it would be a redundant
- * round-trip for data already in hand.
+ * Single async source: GET /rankings. EVERY control — filters, search,
+ * min-score, sort, pagination — is a server query param, so one page is a
+ * correct slice of the whole filtered, sorted population. The page no longer
+ * filters/sorts/truncates a 200-row client buffer.
  *
- * Server-side filters: coverage_tier, sector_spdr (real GICS sector, #1675),
- * stance — included in the query string and therefore in the useAsync deps so
- * a refetch fires when they change.
- *
- * Client-side filters / controls: minimum total_score, column sort. These
- * never trigger a refetch.
- *
- * Auth (#58 backend exists; frontend login route does not yet):
- *   401 → render an "Authentication required" state on this page only.
- *   No global redirect — see follow-up issue linked in the PR description.
- *
- * Strictly read-only: no mutations, no write actions.
+ * Offset is reset to 0 in the same handler as any query change (never in a
+ * useEffect reacting to `query`, which would double-fetch the new query at the
+ * stale offset — #1825 / Codex ckpt-1).
  */
+
+const DEFAULT_QUERY: RankingsQuery = {
+  coverage_tier: null,
+  sector_spdr: null,
+  stance: null,
+  q: null,
+  min_total_score: null,
+  sort: "rank",
+  sort_dir: "asc",
+};
+
 export function RankingsPage() {
-  const [query, setQuery] = useState<RankingsQuery>({
-    coverage_tier: null,
-    sector_spdr: null,
-    stance: null,
-  });
-  const [scoreThreshold, setScoreThreshold] = useState<number | null>(null);
-  // #194 — debounced symbol/name search; client-side filter over the
-  // current response (server-side `search` is not supported on the
-  // rankings endpoint and the page caps at RANKINGS_PAGE_LIMIT rows).
+  const [query, setQuery] = useState<RankingsQuery>(DEFAULT_QUERY);
+  const [offset, setOffset] = useState(0);
+
+  // #194 — debounced symbol/name search. The debounced value feeds query.q
+  // (server-side); searchInput drives the controlled input + dirty state.
   const [searchInput, setSearchInput] = useState("");
-  const [search, setSearch] = useState("");
   useEffect(() => {
-    const timer = setTimeout(() => setSearch(searchInput.trim().toLowerCase()), 300);
+    const timer = setTimeout(() => {
+      const next = searchInput.trim() === "" ? null : searchInput.trim();
+      // No-op when q is unchanged so an identical-search settle doesn't refetch.
+      setQuery((q) => (q.q === next ? q : { ...q, q: next }));
+      // Reset to page 1 on a search (harmless no-op when already at offset 0).
+      setOffset(0);
+    }, 300);
     return () => clearTimeout(timer);
   }, [searchInput]);
 
-  // useAsync captures fn via a ref — fresh arrow per render is fine.
   const rankings = useAsync(
-    () => fetchRankings(query),
-    [query.coverage_tier, query.sector_spdr, query.stance],
+    () => fetchRankings(query, RANKINGS_PAGE_SIZE, offset),
+    [
+      query.coverage_tier,
+      query.sector_spdr,
+      query.stance,
+      query.q,
+      query.min_total_score,
+      query.sort,
+      query.sort_dir,
+      offset,
+    ],
   );
+
+  // Any query change resets paging to the first page (atomic with the change).
+  const updateQuery = (next: RankingsQuery) => {
+    setQuery(next);
+    setOffset(0);
+  };
+
+  const onSortChange = (field: RankingsSortField, dir: "asc" | "desc") => {
+    updateQuery({ ...query, sort: field, sort_dir: dir });
+  };
+
+  const onClearAll = () => {
+    setQuery(DEFAULT_QUERY);
+    setOffset(0);
+    setSearchInput("");
+  };
 
   const filtersDirty =
     query.coverage_tier !== null ||
     query.sector_spdr !== null ||
     query.stance !== null ||
-    scoreThreshold !== null ||
-    // Use the un-debounced searchInput so Clear All shows immediately
-    // on first keystroke rather than 300 ms later (#634 NITPICK).
-    searchInput !== "";
-
-  const filteredItems = useMemo(() => {
-    if (rankings.data === null) return [];
-    let items: ReadonlyArray<RankingItem> = rankings.data.items;
-    if (scoreThreshold !== null) {
-      items = items.filter((i) => i.total_score !== null && i.total_score >= scoreThreshold);
-    }
-    if (search !== "") {
-      items = items.filter(
-        (i) =>
-          i.symbol.toLowerCase().includes(search) ||
-          i.company_name.toLowerCase().includes(search),
-      );
-    }
-    return items;
-  }, [rankings.data, scoreThreshold, search]);
-
-  // Surface the single edge case where the universe outgrew our single-page
-  // assumption (>200 Tier 1+2 instruments). Loud in dev, harmless in prod.
-  useEffect(() => {
-    if (rankings.data !== null && rankings.data.total > rankings.data.items.length) {
-      console.warn(
-        `[rankings] total=${rankings.data.total} exceeds page limit ${RANKINGS_PAGE_LIMIT}; showing the first ${rankings.data.items.length} rows. Pagination is tracked as a follow-up.`,
-      );
-    }
-  }, [rankings.data]);
-
-  const onClearAll = () => {
-    setQuery({ coverage_tier: null, sector_spdr: null, stance: null });
-    setScoreThreshold(null);
-    setSearchInput("");
-    setSearch("");
-  };
+    query.min_total_score != null ||
+    searchInput !== "" ||
+    query.sort !== "rank" ||
+    query.sort_dir !== "asc";
 
   const view: RankingsView = computeView({
     loading: rankings.loading,
     error: rankings.error,
     data: rankings.data,
-    filteredItems,
     filtersDirty,
     onRetry: rankings.refetch,
     onClearFilters: onClearAll,
   });
+
+  const total = rankings.data?.total ?? 0;
+  const pageCount = rankings.data?.items.length ?? 0;
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = offset + pageCount;
+  const hasPrev = offset > 0;
+  const hasNext = offset + RANKINGS_PAGE_SIZE < total;
 
   return (
     <div className="flex h-full flex-col gap-6 pt-6">
@@ -128,36 +133,54 @@ export function RankingsPage() {
             placeholder="Symbol or company name…"
             className="w-full rounded border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-3 py-1.5 text-sm text-slate-700 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400"
           />
-          {/* Search is client-side over the page-bounded response.
-              When the universe outgrows RANKINGS_PAGE_LIMIT a match
-              outside the first page would silently fail to surface;
-              warn the operator so they don't read a false-negative
-              empty state as authoritative. Server-side search is the
-              proper fix and is tracked under the same paginated-
-              rankings follow-up referenced at line 92. */}
-          {search !== "" &&
-            rankings.data !== null &&
-            rankings.data.total > rankings.data.items.length && (
-              <p className="mt-1 text-xs text-amber-700">
-                Search covers the first {rankings.data.items.length} of {rankings.data.total} ranked
-                rows; matches outside the page are not shown.
-              </p>
-            )}
         </div>
 
         <RankingsFilters
           query={query}
-          onQueryChange={setQuery}
-          scoreThreshold={scoreThreshold}
-          onScoreThresholdChange={setScoreThreshold}
+          onQueryChange={updateQuery}
+          scoreThreshold={query.min_total_score ?? null}
+          onScoreThresholdChange={(next) =>
+            updateQuery({ ...query, min_total_score: next })
+          }
           onClearAll={onClearAll}
           filtersDirty={filtersDirty}
         />
       </div>
 
       <Section title="Candidates" scrollable>
-        <RankingsTable view={view} />
+        <RankingsTable
+          view={view}
+          sort={query.sort ?? "rank"}
+          sortDir={query.sort_dir ?? "asc"}
+          onSortChange={onSortChange}
+        />
       </Section>
+
+      {view.kind === "data" && (
+        <div className="flex flex-shrink-0 items-center justify-between border-t border-slate-200 dark:border-slate-800 pt-3 text-xs text-slate-500">
+          <span className="tabular-nums">
+            Showing {rangeStart}–{rangeEnd} of {total}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setOffset((o) => Math.max(0, o - RANKINGS_PAGE_SIZE))}
+              disabled={!hasPrev}
+              className="rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1 font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              ‹ Prev
+            </button>
+            <button
+              type="button"
+              onClick={() => setOffset((o) => o + RANKINGS_PAGE_SIZE)}
+              disabled={!hasNext}
+              className="rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1 font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Next ›
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -166,29 +189,27 @@ interface ComputeViewArgs {
   loading: boolean;
   error: unknown;
   data: RankingsListResponse | null;
-  filteredItems: ReadonlyArray<RankingItem>;
   filtersDirty: boolean;
   onRetry: () => void;
   onClearFilters: () => void;
 }
 
 /**
- * Map the {loading, error, data, filteredItems, filtersDirty} state set
- * to the discriminated `RankingsView` consumed by RankingsTable.
+ * Map the {loading, error, data} state set to the discriminated `RankingsView`.
+ * The server already filtered + sorted + paged, so this operates on
+ * `data.items` directly — no client filtering layer.
  *
- * Branch order matters and is enforced by the frontend skills:
+ * Branch order (enforced by the frontend skills):
  *   1. loading        — useAsync clears data to null on every refetch start
- *   2. error 401      — auth-required, no retry button (retry is pointless
- *                       without credentials; global redirect is a follow-up)
+ *   2. error 401      — auth-required, no retry button
  *   3. error other    — generic retryable error
- *   4. empty no data  — backend returned [] before any client filter applied
- *   5. empty filtered — server returned rows but the client-side score
- *                       threshold removed them all (or the server-side
- *                       filters did and the user can clear them)
- *   6. data           — render rows
+ *   4. empty no runs  — scored_at null (engine never ran)
+ *   5. empty filtered — server returned [] for a dirty filter/search set
+ *   6. empty run      — server returned [] with no dirty filters
+ *   7. data           — render the page
  */
 function computeView(args: ComputeViewArgs): RankingsView {
-  const { loading, error, data, filteredItems, filtersDirty, onRetry, onClearFilters } = args;
+  const { loading, error, data, filtersDirty, onRetry, onClearFilters } = args;
 
   if (loading) return { kind: "loading" };
 
@@ -200,21 +221,12 @@ function computeView(args: ComputeViewArgs): RankingsView {
   }
 
   if (data === null) {
-    // Should not happen post-loading without an error, but the type
-    // narrowing demands a branch — surface as a generic error.
     return { kind: "error", onRetry };
   }
 
-  // Distinguish "engine has never run" from "engine ran but produced
-  // nothing for this filter set". The backend sets scored_at=None only
-  // when MAX(scored_at) is NULL — i.e. there are zero rows in the
-  // `scores` table for this model_version (see app/api/scores.py
-  // list_rankings step 1). The `&& items.length === 0` belt-and-braces
-  // guard defends against a hypothetical malformed payload where the
-  // backend serves rows with a null scored_at — without it, real rows
-  // would be hidden behind the "no runs yet" message. fetchRankings
-  // also console.warns on the same invariant violation so contract
-  // drift surfaces immediately.
+  // "Engine never ran" vs "engine ran but this filter set is empty". The
+  // backend sets scored_at=None only when there are zero rows for this
+  // model_version (app/api/scores.py list_rankings step 1).
   if (data.scored_at === null && data.items.length === 0) {
     return {
       kind: "empty",
@@ -224,19 +236,7 @@ function computeView(args: ComputeViewArgs): RankingsView {
     };
   }
 
-  if (filteredItems.length === 0) {
-    // Two distinct sub-cases:
-    //   - filtersDirty: a filter combination produced zero rows. The
-    //     clear-filters button is the operator's escape hatch.
-    //     (The filter bar above already exposes the same control, but
-    //     the issue spec requires the affordance inside the empty
-    //     state itself so the operator never has to hunt for the next
-    //     action.)
-    //   - !filtersDirty: the unfiltered request returned zero rows
-    //     even though a scoring run exists (an unusual but possible
-    //     state — e.g. a run that scored every candidate as filtered
-    //     out by penalties). The title must NOT imply user action
-    //     caused the empty set, since no filter is dirty.
+  if (data.items.length === 0) {
     if (filtersDirty) {
       return {
         kind: "empty",
@@ -253,7 +253,7 @@ function computeView(args: ComputeViewArgs): RankingsView {
     };
   }
 
-  return { kind: "data", items: filteredItems.slice() };
+  return { kind: "data", items: data.items.slice() };
 }
 
 function ClearFiltersButton({ onClick }: { onClick: () => void }) {

--- a/tests/test_api_scores.py
+++ b/tests/test_api_scores.py
@@ -47,6 +47,8 @@ def _make_ranking_row(
     momentum_score: float | None = 0.70,
     sentiment_score: float | None = 0.50,
     confidence_score: float | None = 0.85,
+    data_completeness: float | None = 0.91,
+    completeness_tier: str | None = "full",
     penalties_json: list[dict[str, object]] | None = None,
     explanation: str | None = "Strong quality + value",
     model_version: str = "v1.1-balanced",
@@ -69,6 +71,8 @@ def _make_ranking_row(
         "momentum_score": momentum_score,
         "sentiment_score": sentiment_score,
         "confidence_score": confidence_score,
+        "data_completeness": data_completeness,
+        "completeness_tier": completeness_tier,
         "penalties_json": penalties_json,
         "explanation": explanation,
         "model_version": model_version,
@@ -342,6 +346,114 @@ class TestListRankings:
         items_params = cur.execute.call_args_list[2][0][1]
         assert items_params["offset"] == 10
         assert items_params["limit"] == 25
+
+    def test_search_q_adds_ilike_predicate(self) -> None:
+        conn = _with_conn(
+            [
+                [{"latest": _NOW}],
+                [{"cnt": 1}],
+                [_make_ranking_row()],
+            ]
+        )
+        resp = client.get("/rankings", params={"q": "appl"})
+        assert resp.status_code == 200
+
+        cur = conn.cursor.return_value
+        count_sql: str = cur.execute.call_args_list[1][0][0]
+        count_params = cur.execute.call_args_list[1][0][1]
+        assert "ilike" in count_sql.lower()
+        # Bound with %% wildcards, trimmed.
+        assert count_params["q"] == "%appl%"
+
+    def test_blank_q_omits_predicate(self) -> None:
+        conn = _with_conn(
+            [
+                [{"latest": _NOW}],
+                [{"cnt": 1}],
+                [_make_ranking_row()],
+            ]
+        )
+        resp = client.get("/rankings", params={"q": "   "})
+        assert resp.status_code == 200
+
+        cur = conn.cursor.return_value
+        count_sql: str = cur.execute.call_args_list[1][0][0]
+        count_params = cur.execute.call_args_list[1][0][1]
+        assert "ilike" not in count_sql.lower()
+        assert "q" not in count_params
+
+    def test_min_total_score_predicate(self) -> None:
+        conn = _with_conn(
+            [
+                [{"latest": _NOW}],
+                [{"cnt": 1}],
+                [_make_ranking_row()],
+            ]
+        )
+        resp = client.get("/rankings", params={"min_total_score": 0.5})
+        assert resp.status_code == 200
+
+        cur = conn.cursor.return_value
+        count_sql: str = cur.execute.call_args_list[1][0][0]
+        count_params = cur.execute.call_args_list[1][0][1]
+        assert "s.total_score >=" in count_sql.lower()
+        assert count_params["min_total_score"] == 0.5
+
+    def test_sort_maps_to_order_by_column(self) -> None:
+        conn = _with_conn(
+            [
+                [{"latest": _NOW}],
+                [{"cnt": 1}],
+                [_make_ranking_row()],
+            ]
+        )
+        resp = client.get("/rankings", params={"sort": "value_score", "sort_dir": "desc"})
+        assert resp.status_code == 200
+
+        cur = conn.cursor.return_value
+        # items query is execute index 2
+        items_sql: str = cur.execute.call_args_list[2][0][0].lower()
+        assert "order by s.value_score desc nulls last" in items_sql
+        # stable unique tiebreak preserved
+        assert "s.instrument_id asc" in items_sql
+
+    def test_default_sort_is_rank_asc(self) -> None:
+        conn = _with_conn(
+            [
+                [{"latest": _NOW}],
+                [{"cnt": 1}],
+                [_make_ranking_row()],
+            ]
+        )
+        resp = client.get("/rankings")
+        assert resp.status_code == 200
+
+        cur = conn.cursor.return_value
+        items_sql: str = cur.execute.call_args_list[2][0][0].lower()
+        assert "order by s.rank asc nulls last" in items_sql
+
+    def test_invalid_sort_rejected(self) -> None:
+        resp = client.get("/rankings", params={"sort": "; DROP TABLE scores"})
+        assert resp.status_code == 422
+
+    def test_invalid_sort_dir_rejected(self) -> None:
+        resp = client.get("/rankings", params={"sort_dir": "sideways"})
+        assert resp.status_code == 422
+
+    def test_completeness_fields_surfaced(self) -> None:
+        row = _make_ranking_row(data_completeness=0.42, completeness_tier="thin_data")
+        _with_conn(
+            [
+                [{"latest": _NOW}],
+                [{"cnt": 1}],
+                [row],
+            ]
+        )
+        resp = client.get("/rankings")
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["data_completeness"] == 0.42
+        assert item["completeness_tier"] == "thin_data"
 
     def test_count_query_receives_no_limit_offset(self) -> None:
         """COUNT query params must not contain limit/offset keys."""


### PR DESCRIPTION
## What

Makes the `/rankings` list **fully server-authoritative** so a single page is a correct slice of the whole filtered, sorted population, and adds a **data-completeness column**. P4 of #1815, §2(#5)/§7.

## Why

The scored universe is now ~3,896 (all tiers, #1823). The FE fetched a single 200-row page and did search + min-score filter + column sort **client-side over that page**, with a truncation banner — names beyond rank 200 were invisible and search/filter/sort silently operated on the first page only. `RankingItem` also omitted the completeness tier, so a high-ranked thin-coverage name wasn't visibly flagged.

## Backend — `list_rankings` (`app/api/scores.py`)

New optional params (back-compat — existing callers unaffected):
- `q` — case-insensitive `ILIKE` on symbol OR company_name.
- `min_total_score` — `total_score >=`.
- `sort` (column allowlist) + `sort_dir` (asc/desc).

**SQL-injection safety:** `sort`/`sort_dir` are `Literal`s (FastAPI 422s off-list) resolved through hardcoded maps (`_SORT_COLUMNS`, `_SORT_DIR`) — the request value is only ever a dict key, never reaches the SQL string. `gics_sector` is intentionally **not** sortable (the column shows a Python-resolved GICS label; the only SQL expression is the SPDR-symbol CASE, which wouldn't match the visible order — sector is a filter). **Deterministic paging:** `ORDER BY <col> <dir> NULLS LAST, s.rank ASC NULLS LAST, s.instrument_id ASC` — the `instrument_id` final key makes every page a drift-free slice even when the sort value (and rank) tie.

`data_completeness` + `completeness_tier` added to `RankingItem` + the SELECT. `q`/`min_total_score` predicates join the shared `where_clauses` so COUNT + items stay consistent. `MAX_PAGE_LIMIT` stays 200 (a page cap, not a universe cap); default page limit 50.

## Frontend

- `api/rankings.ts`: `RankingsQuery` gains **optional** `q`/`min_total_score`/`sort`/`sort_dir` (RightRail's 3-filter caller still type-checks); `fetchRankings` keeps its **positional** `(query, limit=50, offset=0)` signature (RightRail's `fetchRankings(q, 6)` unaffected). `RANKINGS_PAGE_LIMIT` → `RANKINGS_PAGE_SIZE`.
- `RankingsPage.tsx`: server-authoritative. Every control (filters, debounced search→`q`, min-score, sort) is a query param; offset resets to 0 in the **same handler** as any query change (batched — no effect-driven double-fetch). Prev/Next footer + "Showing X–Y of N". Removed the client filter/sort/truncation-banner layer.
- `RankingsTable.tsx`: header click drives server sort via `onSortChange` (no in-memory page sort); Sector + Company non-sortable; new **Completeness** column rendering the tier chip (`full` / `thin_data` / `insufficient_data`) with the % in the title.

## Security model

Read-only. No schema, no scoring change, no writes. The only attack surface is the dynamic ORDER BY, closed by the Literal + hardcoded-map design above (no user value reaches SQL). All predicates are parameterised.

## Tests

- `TestListRankings`: `q` predicate, blank-`q` omitted, `min_total_score` predicate, `sort`/`sort_dir` → correct ORDER BY column + stable tiebreak, default sort, invalid `sort`/`sort_dir` → 422, completeness fields surfaced.
- `RankingsPage.test.tsx` (rewritten): search→`q` + offset reset, Next→offset 50, Prev disabled on page 1, sort header→`value_score`/`desc`, completeness chip, dirty-filter empty state.
- RightRail fixtures updated for the new fields.

## Verification (change-coupled FE-QA done-criterion, commit c329b570)

`/rankings` populated (#1824 ran `compute_rankings`, 3,896 rows). Live page:
- Completeness chips render; footer "Showing 1–50 of 3896".
- **Next** → "Showing 51–100 of 3896", Prev enables.
- **Sort by Value desc** pulls KLAC (value 1.0) to the top from rank 2052 — whole-population sort, not page-local.
- **Search "Tesla"** → TSLA "Showing 1–1 of 1" (a name off page 1).
- Numbers match `/rankings?...`; dark mode clean; no console errors.

Local gates green: ruff / format / pyright / smoke / fast-tier (171 passed) / `pnpm typecheck` / `pnpm test:unit` (1184 passed) / dark-class gate.

Part of #1815. Closes #1825.