### PR TITLE
fix(#531): capability-overrides admin page + repair 500-ing endpoint

### DIFF
--- a/app/api/capability_overrides_admin.py
+++ b/app/api/capability_overrides_admin.py
@@ -67,6 +67,72 @@ def _seed_for(asset_class: str) -> dict[str, list[str]]:
     return _SEED_BY_ASSET_CLASS.get(asset_class, _EMPTY_SEED)
 
 
+def _dedup(items: list[str]) -> list[str]:
+    """Order-preserving de-duplication. The resolver dedups providers
+    at runtime (``resolve_capabilities``), so a repeated provider is
+    not meaningful drift — collapse it here too, both for the set
+    comparison and so the rendered chips carry unique React keys."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for it in items:
+        if it not in seen:
+            seen.add(it)
+            out.append(it)
+    return out
+
+
+def diff_capabilities(asset_class: str | None, current_raw: Any) -> list[CapabilityCellDiff]:
+    """Pure per-exchange diff: the capabilities whose provider *set*
+    diverges from the seed default for ``asset_class``.
+
+    Ordering and duplicates are not drift — provider order is meaningful
+    at runtime (the resolver renders panels in declared order) but a
+    pure reorder, a JSONB array round-trip reorder, or a repeated
+    provider is not a useful drift signal, so the comparison is
+    set-based (Codex review #531). ``current_raw`` is whatever the JSONB
+    column deserialised to; non-dict / non-list-of-str shapes are
+    treated as empty.
+
+    Capability keys present in the override but absent from the V1
+    schema (operator typos / extra keys the resolver silently ignores)
+    are surfaced as drift against an empty seed so they don't accumulate
+    invisibly — that is exactly the silent-divergence this page exists
+    to catch.
+    """
+    seed = _seed_for(asset_class) if asset_class is not None else _EMPTY_SEED
+    current: dict[str, list[str]] = {}
+    if isinstance(current_raw, dict):
+        for cap_name, cap_value in current_raw.items():
+            if isinstance(cap_value, list):
+                current[str(cap_name)] = _dedup([str(v) for v in cap_value if isinstance(v, str)])
+
+    diffs: list[CapabilityCellDiff] = []
+    for cap in V1_CAPABILITIES:
+        seed_list = list(seed.get(cap, []))
+        current_list = list(current.get(cap, []))
+        if set(seed_list) != set(current_list):
+            diffs.append(
+                CapabilityCellDiff(
+                    capability=cap,
+                    seed_providers=seed_list,
+                    current_providers=current_list,
+                )
+            )
+    # Unknown keys with actual providers — schema drift the seed loop
+    # above cannot see. Empty unknown keys have no runtime effect and
+    # nothing to display, so they are not flagged.
+    for cap, providers in current.items():
+        if cap not in V1_CAPABILITIES and providers:
+            diffs.append(
+                CapabilityCellDiff(
+                    capability=cap,
+                    seed_providers=[],
+                    current_providers=providers,
+                )
+            )
+    return diffs
+
+
 class CapabilityCellDiff(BaseModel):
     """One per-capability diff for an exchange row."""
 
@@ -107,7 +173,7 @@ def list_overrides(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT exchange_id, name, asset_class, capabilities
+            SELECT exchange_id, description, asset_class, capabilities
               FROM exchanges
              ORDER BY exchange_id
             """
@@ -115,42 +181,14 @@ def list_overrides(
         for r in cur.fetchall():
             asset_class_raw = r["asset_class"]
             asset_class = str(asset_class_raw) if asset_class_raw is not None else None
-            seed = _seed_for(asset_class) if asset_class is not None else _EMPTY_SEED
-            current_raw: Any = r["capabilities"]
-            current: dict[str, list[str]] = {}
-            if isinstance(current_raw, dict):
-                for cap_name, cap_value in current_raw.items():
-                    if isinstance(cap_value, list):
-                        current[str(cap_name)] = [str(v) for v in cap_value if isinstance(v, str)]
-
-            diffs: list[CapabilityCellDiff] = []
-            for cap in V1_CAPABILITIES:
-                seed_list = list(seed.get(cap, []))
-                current_list = list(current.get(cap, []))
-                # Drift compares the *set* of providers, not the
-                # ordering. Provider order is meaningful at runtime
-                # (resolver renders panels in declared order), but
-                # reordering without changing the set isn't useful
-                # drift signal — an operator who reordered
-                # intentionally doesn't want to see it as drift, and
-                # JSONB array round-trips can in principle reorder.
-                # Codex review on #531.
-                if sorted(seed_list) != sorted(current_list):
-                    diffs.append(
-                        CapabilityCellDiff(
-                            capability=cap,
-                            seed_providers=seed_list,
-                            current_providers=current_list,
-                        )
-                    )
-
+            diffs = diff_capabilities(asset_class, r["capabilities"])
             if not diffs:
                 continue
 
             rows.append(
                 ExchangeOverrideRow(
                     exchange_id=str(r["exchange_id"]),
-                    exchange_name=str(r["name"]) if r["name"] is not None else None,
+                    exchange_name=str(r["description"]) if r["description"] is not None else None,
                     asset_class=asset_class,
                     diffs=diffs,
                 )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { AdminJobDetailPage } from "@/pages/AdminJobDetailPage";
 import { ProcessDetailPage } from "@/pages/ProcessDetailPage";
 import { IngestHealthPage } from "@/pages/IngestHealthPage";
 import { CoverageInsufficientPage } from "@/pages/CoverageInsufficientPage";
+import { CapabilityOverridesPage } from "@/pages/CapabilityOverridesPage";
 import { SettingsPage } from "@/pages/SettingsPage";
 import { NotFoundPage } from "@/pages/NotFoundPage";
 import { BrokerSetupPage } from "@/pages/BrokerSetupPage";
@@ -142,6 +143,10 @@ export function App() {
           <Route
             path="admin/coverage/insufficient"
             element={<CoverageInsufficientPage />}
+          />
+          <Route
+            path="admin/capability-overrides"
+            element={<CapabilityOverridesPage />}
           />
           <Route path="operators" element={<OperatorsPage />} />
           <Route path="settings" element={<SettingsPage />} />

--- a/frontend/src/api/capabilityOverrides.ts
+++ b/frontend/src/api/capabilityOverrides.ts
@@ -1,0 +1,17 @@
+/**
+ * Capability-override admin API client (#531).
+ *
+ * fetchCapabilityOverrides() — exchange rows whose ``capabilities`` JSONB
+ * diverges from the migration-071 seed default for their asset_class.
+ * Powers the AdminPage "Capability overrides" card + the
+ * /admin/capability-overrides drill page. Wraps
+ * GET /admin/capability-overrides. Read-only; revert-to-seed is a
+ * future write endpoint (out of scope for #531).
+ */
+
+import { apiFetch } from "@/api/client";
+import type { OverridesListResponse } from "@/api/types";
+
+export function fetchCapabilityOverrides(): Promise<OverridesListResponse> {
+  return apiFetch<OverridesListResponse>("/admin/capability-overrides");
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1459,6 +1459,28 @@ export interface InsufficientListResponse {
   rows: InsufficientRow[];
 }
 
+// Capability-override drift (#531). Wraps GET /admin/capability-overrides —
+// exchange rows whose ``capabilities`` JSONB diverges from the migration-071
+// seed default for their asset_class.
+export interface CapabilityCellDiff {
+  capability: string;
+  seed_providers: string[];
+  current_providers: string[];
+}
+
+export interface ExchangeOverrideRow {
+  exchange_id: string;
+  exchange_name: string | null;
+  asset_class: string | null;
+  diffs: CapabilityCellDiff[];
+}
+
+export interface OverridesListResponse {
+  checked_at: string;
+  total_overrides: number;
+  rows: ExchangeOverrideRow[];
+}
+
 // ---------------------------------------------------------------------------
 // /sync/layers/v2 (app/api/sync.py — A.5 chunk 0+)
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { fetchBootstrapStatus } from "@/api/bootstrap";
+import { fetchCapabilityOverrides } from "@/api/capabilityOverrides";
 import { fetchCoverageSummary } from "@/api/coverage";
 import { fetchJobsOverview, runJob } from "@/api/jobs";
 import { fetchRecommendations } from "@/api/recommendations";
@@ -58,6 +59,7 @@ export function AdminPage() {
   const v2 = useAsync(fetchSyncLayersV2, []);
   const status = useAsync(fetchSyncStatus, []);
   const coverage = useAsync(fetchCoverageSummary, []);
+  const capabilityOverrides = useAsync(fetchCapabilityOverrides, []);
   const jobs = useAsync(fetchJobsOverview, []);
   // /system/status carries the operator credential health summary used
   // by the Problems banner (#979 / #974/E). Fetched alongside the
@@ -92,6 +94,7 @@ export function AdminPage() {
   const refetchV2 = v2.refetch;
   const refetchStatus = status.refetch;
   const refetchCoverage = coverage.refetch;
+  const refetchCapabilityOverrides = capabilityOverrides.refetch;
   const refetchJobs = jobs.refetch;
   const refetchRecs = recs.refetch;
   // PR3a #1064 — re-poll bootstrap status on every refresh so a
@@ -104,6 +107,7 @@ export function AdminPage() {
     refetchV2();
     refetchStatus();
     refetchCoverage();
+    refetchCapabilityOverrides();
     refetchJobs();
     refetchRecs();
     refetchBootstrap();
@@ -111,6 +115,7 @@ export function AdminPage() {
     refetchV2,
     refetchStatus,
     refetchCoverage,
+    refetchCapabilityOverrides,
     refetchJobs,
     refetchRecs,
     refetchBootstrap,
@@ -270,6 +275,43 @@ export function AdminPage() {
           <SectionError onRetry={coverage.refetch} />
         ) : coverage.data ? (
           <CoverageSummaryCard summary={coverage.data} />
+        ) : null}
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title="Capability overrides"
+        summary={
+          capabilityOverrides.data
+            ? capabilityOverrides.data.total_overrides === 0
+              ? "all at seed default"
+              : `${capabilityOverrides.data.total_overrides} exchange${
+                  capabilityOverrides.data.total_overrides === 1 ? "" : "s"
+                } diverging`
+            : undefined
+        }
+      >
+        {capabilityOverrides.loading ? (
+          <SectionSkeleton rows={1} />
+        ) : capabilityOverrides.error !== null ? (
+          <SectionError onRetry={capabilityOverrides.refetch} />
+        ) : capabilityOverrides.data ? (
+          capabilityOverrides.data.total_overrides === 0 ? (
+            <p className="text-xs text-slate-500">
+              Every exchange is at its seed default — no capability overrides
+              in effect.
+            </p>
+          ) : (
+            <p className="text-xs text-slate-600 dark:text-slate-300">
+              <Link
+                to="/admin/capability-overrides"
+                className="font-medium text-blue-700 hover:underline"
+              >
+                Review {capabilityOverrides.data.total_overrides} exchange
+                {capabilityOverrides.data.total_overrides === 1 ? "" : "s"}{" "}
+                diverging from seed defaults →
+              </Link>
+            </p>
+          )
         ) : null}
       </CollapsibleSection>
     </div>

--- a/frontend/src/pages/CapabilityOverridesPage.test.tsx
+++ b/frontend/src/pages/CapabilityOverridesPage.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { CapabilityOverridesPage } from "@/pages/CapabilityOverridesPage";
+import * as api from "@/api/capabilityOverrides";
+
+const driftResponse = {
+  checked_at: "2026-06-29T10:00:00+00:00",
+  total_overrides: 1,
+  rows: [
+    {
+      exchange_id: "33",
+      exchange_name: "Regular Trading Hours - RTH",
+      asset_class: "us_equity",
+      diffs: [
+        {
+          capability: "filings",
+          seed_providers: ["sec_edgar"],
+          current_providers: [],
+        },
+        {
+          capability: "ownership",
+          seed_providers: ["sec_13f", "sec_13d_13g"],
+          current_providers: ["sec_13f", "custom_provider"],
+        },
+      ],
+    },
+  ],
+} as never;
+
+function renderPage() {
+  render(
+    <MemoryRouter initialEntries={["/admin/capability-overrides"]}>
+      <CapabilityOverridesPage />
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CapabilityOverridesPage", () => {
+  it("renders one row per diverging capability with seed + current providers", async () => {
+    vi.spyOn(api, "fetchCapabilityOverrides").mockResolvedValue(driftResponse);
+
+    renderPage();
+
+    // Exchange identity surfaces — one cell per diverging capability
+    // (flat table repeats the exchange across its diff rows).
+    expect(
+      await screen.findAllByText("Regular Trading Hours - RTH"),
+    ).toHaveLength(2);
+    expect(screen.getAllByText("#33")).toHaveLength(2);
+
+    // Both diverging capabilities render as rows.
+    expect(screen.getByText("filings")).toBeInTheDocument();
+    expect(screen.getByText("ownership")).toBeInTheDocument();
+
+    // Seed providers shown; the missing-from-current one is the drift.
+    expect(screen.getByText("sec_edgar")).toBeInTheDocument();
+    // A provider present on both sides appears in both cells.
+    expect(screen.getAllByText("sec_13f").length).toBeGreaterThanOrEqual(1);
+    // An operator-added provider (not in seed) surfaces on the current side.
+    expect(screen.getByText("custom_provider")).toBeInTheDocument();
+
+    // Empty current set renders an explicit none marker, not a blank cell.
+    expect(screen.getByText("— (none)")).toBeInTheDocument();
+  });
+
+  it("shows the all-at-seed empty state when nothing diverges", async () => {
+    vi.spyOn(api, "fetchCapabilityOverrides").mockResolvedValue({
+      checked_at: "2026-06-29T10:00:00+00:00",
+      total_overrides: 0,
+      rows: [],
+    } as never);
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/Every exchange is at its seed default/),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a retry control when the fetch fails", async () => {
+    vi.spyOn(api, "fetchCapabilityOverrides").mockRejectedValue(
+      new Error("500"),
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByRole("button", { name: /retry/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/CapabilityOverridesPage.tsx
+++ b/frontend/src/pages/CapabilityOverridesPage.tsx
@@ -1,0 +1,171 @@
+/**
+ * Capability-override drift view (#531, PR 3c of #515).
+ *
+ * Operators can edit ``exchanges.capabilities`` JSONB to adjust which
+ * providers a venue uses. Without a drift view, those edits silently
+ * accumulate and a future seed-default change can land on top of an
+ * operator override unnoticed. This page diffs every exchange's current
+ * capabilities against the migration-071 seed default and surfaces only
+ * the divergences.
+ *
+ * Read-only — there is no revert-to-seed action here. Reverting requires
+ * a mutating endpoint that does not yet exist (tracked as a #531
+ * follow-up); the operator edits via SQL until then. The drift signal
+ * itself — the core need in the issue's "Why" — is fully served here.
+ */
+
+import { Link } from "react-router-dom";
+
+import { fetchCapabilityOverrides } from "@/api/capabilityOverrides";
+import type { ExchangeOverrideRow } from "@/api/types";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { useAsync } from "@/lib/useAsync";
+
+export function CapabilityOverridesPage() {
+  const overrides = useAsync(fetchCapabilityOverrides, []);
+
+  return (
+    <div className="space-y-4 pt-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">
+          Capability overrides
+        </h1>
+        <Link to="/admin" className="text-xs text-blue-700 hover:underline">
+          ← Back to admin
+        </Link>
+      </div>
+
+      <Section title="Exchanges diverging from seed defaults">
+        {overrides.loading ? (
+          <SectionSkeleton rows={5} />
+        ) : overrides.error !== null ? (
+          <SectionError onRetry={overrides.refetch} />
+        ) : overrides.data ? (
+          <OverridesTable rows={overrides.data.rows} />
+        ) : null}
+      </Section>
+    </div>
+  );
+}
+
+function OverridesTable({ rows }: { rows: ExchangeOverrideRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-slate-500">
+        Every exchange is at its seed default — no capability overrides in
+        effect.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <p className="mb-3 text-xs text-slate-500">
+        Each row is one capability whose provider set differs from the
+        migration-071 seed default for that exchange&apos;s asset class.
+        Providers are compared as a set (ordering is not drift).
+      </p>
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            <th className="py-2 pr-4">Exchange</th>
+            <th className="py-2 pr-4">Asset class</th>
+            <th className="py-2 pr-4">Capability</th>
+            <th className="py-2 pr-4">Seed default</th>
+            <th className="py-2 pr-4">Current</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          {rows.flatMap((row) =>
+            row.diffs.map((diff) => (
+              <tr
+                key={`${row.exchange_id}:${diff.capability}`}
+                className="align-top"
+              >
+                <td className="py-2 pr-4">
+                  <div className="font-medium text-slate-700 dark:text-slate-200">
+                    {row.exchange_name ?? "—"}
+                  </div>
+                  <div className="font-mono text-xs text-slate-500">
+                    #{row.exchange_id}
+                  </div>
+                </td>
+                <td className="py-2 pr-4 text-xs text-slate-500">
+                  {row.asset_class ?? "—"}
+                </td>
+                <td className="py-2 pr-4 text-xs font-medium text-slate-700 dark:text-slate-200">
+                  {diff.capability}
+                </td>
+                <td className="py-2 pr-4">
+                  <ProviderChips
+                    providers={diff.seed_providers}
+                    against={diff.current_providers}
+                    tone="seed"
+                  />
+                </td>
+                <td className="py-2 pr-4">
+                  <ProviderChips
+                    providers={diff.current_providers}
+                    against={diff.seed_providers}
+                    tone="current"
+                  />
+                </td>
+              </tr>
+            )),
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * Render a provider set as chips. Providers absent from the comparison
+ * set are highlighted as the drift: a seed provider missing from current
+ * (a removal) and a current provider absent from seed (an addition) both
+ * get a tinted chip so the operator can spot the exact change.
+ */
+function ProviderChips({
+  providers,
+  against,
+  tone,
+}: {
+  providers: string[];
+  against: string[];
+  tone: "seed" | "current";
+}) {
+  if (providers.length === 0) {
+    return <span className="text-xs text-slate-400">— (none)</span>;
+  }
+  const againstSet = new Set(against);
+  // seed side: highlight providers missing from current (removed).
+  // current side: highlight providers not in seed (added).
+  const drifted = tone === "seed" ? "text-red-700 dark:text-red-300" : "text-amber-700 dark:text-amber-300";
+  const driftedBg =
+    tone === "seed"
+      ? "bg-red-50 dark:bg-red-950/40"
+      : "bg-amber-50 dark:bg-amber-950/40";
+  return (
+    <div className="flex flex-wrap gap-1">
+      {providers.map((p) => {
+        const isDrift = !againstSet.has(p);
+        return (
+          <span
+            key={p}
+            className={
+              isDrift
+                ? `rounded px-1.5 py-0.5 font-mono text-xs ${drifted} ${driftedBg}`
+                : "rounded px-1.5 py-0.5 font-mono text-xs text-slate-600 dark:text-slate-300 bg-slate-100 dark:bg-slate-800"
+            }
+          >
+            {p}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/tests/test_capability_overrides_diff.py
+++ b/tests/test_capability_overrides_diff.py
@@ -1,0 +1,117 @@
+"""Pure-logic tests for the capability-override diff (#531).
+
+``diff_capabilities`` is the decision the admin endpoint renders: which
+capabilities of one exchange diverge from the seed default for its asset
+class. Kept DB-free (fast tier) — the endpoint's SQL/schema wiring is
+guarded separately by the DB-backed test_capability_overrides_endpoint.
+"""
+
+from __future__ import annotations
+
+from app.api.capability_overrides_admin import (
+    _EMPTY_SEED,
+    _SEED_BY_ASSET_CLASS,
+    diff_capabilities,
+)
+
+
+def _seed_us_equity() -> dict[str, list[str]]:
+    return dict(_SEED_BY_ASSET_CLASS["us_equity"])
+
+
+def test_at_seed_default_yields_no_diff() -> None:
+    diffs = diff_capabilities("us_equity", _seed_us_equity())
+    assert diffs == []
+
+
+def test_provider_reorder_is_not_drift() -> None:
+    # ownership seed is ["sec_13f", "sec_13d_13g"]; reversed set is equal.
+    current = _seed_us_equity()
+    current["ownership"] = ["sec_13d_13g", "sec_13f"]
+    assert diff_capabilities("us_equity", current) == []
+
+
+def test_duplicate_provider_is_not_drift() -> None:
+    # A repeated provider resolves identically at runtime (resolver
+    # dedups), so it must not register as drift (Codex review #531).
+    current = _seed_us_equity()
+    current["filings"] = ["sec_edgar", "sec_edgar"]
+    assert diff_capabilities("us_equity", current) == []
+
+
+def test_duplicate_provider_is_deduped_in_output() -> None:
+    current = _seed_us_equity()
+    current["ownership"] = ["sec_13f", "sec_13f", "extra_provider"]
+    diffs = diff_capabilities("us_equity", current)
+    assert len(diffs) == 1
+    # Output carries each provider once → unique React keys downstream.
+    assert diffs[0].current_providers == ["sec_13f", "extra_provider"]
+
+
+def test_unknown_capability_key_with_providers_surfaces_as_drift() -> None:
+    # An operator typo / extra key the resolver ignores must not hide.
+    current = _seed_us_equity()
+    current["filngs"] = ["sec_edgar"]  # typo of "filings"
+    diffs = diff_capabilities("us_equity", current)
+    assert len(diffs) == 1
+    assert diffs[0].capability == "filngs"
+    assert diffs[0].seed_providers == []
+    assert diffs[0].current_providers == ["sec_edgar"]
+
+
+def test_unknown_empty_capability_key_is_not_flagged() -> None:
+    # An empty unknown key has no runtime effect and nothing to show.
+    current = _seed_us_equity()
+    current["bogus"] = []
+    assert diff_capabilities("us_equity", current) == []
+
+
+def test_removed_provider_surfaces_as_drift() -> None:
+    current = _seed_us_equity()
+    current["filings"] = []
+    diffs = diff_capabilities("us_equity", current)
+    assert len(diffs) == 1
+    d = diffs[0]
+    assert d.capability == "filings"
+    assert d.seed_providers == ["sec_edgar"]
+    assert d.current_providers == []
+
+
+def test_added_provider_surfaces_as_drift() -> None:
+    current = _seed_us_equity()
+    current["ownership"] = ["sec_13f", "sec_13d_13g", "custom_provider"]
+    diffs = diff_capabilities("us_equity", current)
+    assert len(diffs) == 1
+    assert diffs[0].capability == "ownership"
+    assert "custom_provider" in diffs[0].current_providers
+
+
+def test_unknown_asset_class_uses_empty_seed() -> None:
+    # An exchange whose asset_class has no seed entry is compared against
+    # the empty-but-correctly-shaped default — any provider is drift.
+    diffs = diff_capabilities("crypto", {"filings": ["some_provider"]})
+    assert len(diffs) == 1
+    assert diffs[0].capability == "filings"
+    assert diffs[0].seed_providers == []
+    assert diffs[0].current_providers == ["some_provider"]
+
+
+def test_empty_capabilities_against_us_equity_seed_flags_every_seeded_cap() -> None:
+    # An exchange whose capabilities were wiped to {} diverges on every
+    # capability the seed populates (the live exchange-33 case).
+    diffs = diff_capabilities("us_equity", {})
+    seeded_nonempty = {cap for cap, providers in _SEED_BY_ASSET_CLASS["us_equity"].items() if providers}
+    assert {d.capability for d in diffs} == seeded_nonempty
+
+
+def test_non_dict_capabilities_is_treated_as_empty() -> None:
+    # Defensive: a malformed JSONB value (not an object) must not 500;
+    # it reads as "no providers" → diverges from any non-empty seed.
+    diffs = diff_capabilities("us_equity", None)
+    assert {d.capability for d in diffs} == {
+        cap for cap, providers in _SEED_BY_ASSET_CLASS["us_equity"].items() if providers
+    }
+
+
+def test_none_asset_class_uses_empty_seed() -> None:
+    assert diff_capabilities(None, _EMPTY_SEED) == []

--- a/tests/test_capability_overrides_endpoint.py
+++ b/tests/test_capability_overrides_endpoint.py
@@ -1,0 +1,129 @@
+"""DB-backed test for GET /admin/capability-overrides (#531).
+
+Guards the SQL/schema wiring the mock-based pattern cannot: the handler
+shipped selecting a nonexistent ``exchanges.name`` column (the table's
+human label is ``description``), 500-ing in production because no test
+ever ran the real query against the real schema. This exercises the
+endpoint end-to-end against the migrated test DB.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+from psycopg.types.json import Jsonb
+
+from app.api.auth import require_service_token, require_session_or_service_token
+from app.db import get_conn
+from app.main import app
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+
+@pytest.fixture
+def client(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> Iterator[TestClient]:
+    def _conn_override() -> Iterator[psycopg.Connection[tuple]]:
+        yield ebull_test_conn
+
+    def _bypass_auth() -> None:
+        return None
+
+    app.dependency_overrides[require_session_or_service_token] = _bypass_auth
+    app.dependency_overrides[require_service_token] = _bypass_auth
+    app.dependency_overrides[get_conn] = _conn_override
+    try:
+        with TestClient(app) as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(require_session_or_service_token, None)
+        app.dependency_overrides.pop(require_service_token, None)
+        app.dependency_overrides.pop(get_conn, None)
+
+
+def _insert_exchange(
+    conn: psycopg.Connection[tuple],
+    *,
+    exchange_id: str,
+    description: str,
+    asset_class: str,
+    capabilities: dict[str, list[str]],
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO exchanges (exchange_id, description, asset_class, capabilities)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (exchange_id) DO UPDATE
+          SET description = EXCLUDED.description,
+              asset_class = EXCLUDED.asset_class,
+              capabilities = EXCLUDED.capabilities
+        """,
+        (exchange_id, description, asset_class, Jsonb(capabilities)),
+    )
+    conn.commit()
+
+
+def test_endpoint_runs_real_sql_and_surfaces_drift(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    # A us_equity exchange with wiped capabilities diverges from the seed.
+    _insert_exchange(
+        ebull_test_conn,
+        exchange_id="ZZTESTX",
+        description="Drift Test Exchange",
+        asset_class="us_equity",
+        capabilities={},
+    )
+
+    resp = client.get("/admin/capability-overrides")
+
+    # The original bug 500'd here (SELECT name FROM exchanges).
+    assert resp.status_code == 200
+    body = resp.json()
+
+    seeded = {row["exchange_id"]: row for row in body["rows"]}
+    assert "ZZTESTX" in seeded, "wiped-capabilities exchange should surface as drift"
+    row = seeded["ZZTESTX"]
+    assert row["exchange_name"] == "Drift Test Exchange"
+    assert row["asset_class"] == "us_equity"
+
+    caps = {d["capability"]: d for d in row["diffs"]}
+    # filings seed is ["sec_edgar"]; current wiped to [].
+    assert "filings" in caps
+    assert caps["filings"]["seed_providers"] == ["sec_edgar"]
+    assert caps["filings"]["current_providers"] == []
+
+
+def test_endpoint_excludes_exchange_at_seed_default(
+    client: TestClient,
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    _insert_exchange(
+        ebull_test_conn,
+        exchange_id="ZZSEED",
+        description="At-Seed Exchange",
+        asset_class="us_equity",
+        capabilities={
+            "filings": ["sec_edgar"],
+            "fundamentals": ["sec_xbrl"],
+            "dividends": ["sec_dividend_summary"],
+            "insider": ["sec_form4"],
+            "analyst": [],
+            "ratings": [],
+            "esg": [],
+            "ownership": ["sec_13f", "sec_13d_13g"],
+            "corporate_events": ["sec_8k_events"],
+            "business_summary": ["sec_10k_item1"],
+            "officers": [],
+        },
+    )
+
+    resp = client.get("/admin/capability-overrides")
+
+    assert resp.status_code == 200
+    ids = {row["exchange_id"] for row in resp.json()["rows"]}
+    assert "ZZSEED" not in ids, "an exchange at seed default must not surface as drift"


### PR DESCRIPTION
## What

PR 3c of #515 — the last deliverable: an admin **capability-overrides drift page**, plus a fix for the endpoint that backs it (which was 500-ing in production).

## The bug it also fixes

`GET /admin/capability-overrides` was written, registered (`app/main.py`), but **never exercised against the real schema** — its `SELECT` queried `exchanges.name`, a column that does not exist (the table's human label is `description`). It 500'd on every call. No test caught it because the only tests were a migration-shape test and a resolver test; nothing ran the real query. Verified the fix live: `200`, 1 exchange / 7 diffs.

## Changes

**Backend** (`app/api/capability_overrides_admin.py`)
- `name` → `description` in the SELECT + the `exchange_name` mapping.
- Extracted `diff_capabilities()` — a pure, table-tested helper.
- **Set-based comparison** (was sorted-list): a provider reorder or a duplicate is not drift (the resolver dedups at runtime); output is order-preserving deduped so the rendered chips carry unique React keys.
- **Unknown / typo'd capability keys** carrying providers now surface as drift against an empty seed — schema divergence the seed loop could not otherwise see (e.g. `{"filngs": ["sec_edgar"]}`). Empty unknown keys (no runtime effect) are not flagged.

**Frontend**
- New read-only page `/admin/capability-overrides`: per-capability diff table; missing-from-current providers highlighted red, operator-added providers amber; loading / empty / error states; dark-mode clean (passes the dark-class gate).
- AdminPage **"Capability overrides"** collapsible card: divergence count summary + drill link; wired into `refetchAll` so it refreshes on the normal admin poll.

## Scope / tradeoff

Read-only **drift visibility** — the issue's core "Why" ("overrides silently accumulate … without anyone noticing"). The acceptance list's **revert-to-seed** action needs a mutating endpoint that does not exist yet; deferred as a #531 follow-up rather than introducing a config-write surface in this PR.

## Security model

Read-only. Endpoint guarded by `require_session_or_service_token` (operator session or service token) — unchanged. No new write paths. The page consumes only the diff endpoint.

## Tests

- `tests/test_capability_overrides_diff.py` — pure-logic, **fast tier**: at-seed, reorder, duplicate (not drift + deduped output), removed/added provider, unknown key (flagged / empty-not-flagged), malformed JSONB, unknown asset class.
- `tests/test_capability_overrides_endpoint.py` — **DB-backed**: runs the real SQL against the migrated schema (the regression guard for the `name`-column bug) + excludes at-seed exchanges.
- `frontend/.../CapabilityOverridesPage.test.tsx` — rows render with seed/current providers, all-at-seed empty state, fetch-error retry.

## Verification

- ruff check · ruff format · pyright · fast tier (4730 passed) · smoke (135 passed) · FE typecheck · dark-class gate · FE unit (1187 passed) · DB tier for this PR (2 passed) — all green.
- Dev-verified live: `GET /admin/capability-overrides` → 200, exchange 33 / 7 diffs.
- Browser FE-QA (dev session cookie): page + AdminPage card render correctly in dark mode; only console error is the pre-existing favicon 404.

Part of #515. Closes #531.
