### PR TITLE
fix(#1861): add SVG favicon — kill /favicon.ico 404 on every page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,6 +10,7 @@
       modes for native form-control rendering.
     -->
     <meta name="color-scheme" content="light dark" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>eBull</title>
   </head>
   <body class="bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100">

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="eBull">
+  <!-- Monochrome slate mark coherent with the eBull wordmark (Sidebar.tsx).
+       Three ascending bars = bullish/markets-up. Geometric (no <text>) so it
+       renders crisp at 16px with no font dependency. -->
+  <rect width="32" height="32" rx="7" fill="#0f172a" />
+  <rect x="7" y="18" width="4" height="7" rx="1" fill="#f8fafc" />
+  <rect x="14" y="13" width="4" height="12" rx="1" fill="#f8fafc" />
+  <rect x="21" y="7" width="4" height="18" rx="1" fill="#f8fafc" />
+</svg>


### PR DESCRIPTION
## What
`frontend/index.html` declared no `<link rel="icon">` and there was no `frontend/public/` asset, so every route 404'd on the browser's default `/favicon.ico` lookup (tab showed a blank/globe icon).

Adds `frontend/public/favicon.svg` — a self-contained monochrome-slate mark (rounded slate-900 rect + 3 ascending white bars = bullish), coherent with the `eBull` wordmark (`Sidebar.tsx:20`) and the terminal aesthetic. Links it from `index.html`.

## Why these choices
- **SVG over .ico:** single scalable asset, modern-browser standard, no binary blob in the tree.
- **Geometric shapes over SVG `<text>`:** favicon `<text>` rendering is inconsistent across browsers at 16px and depends on font availability; `<rect>`s render crisp at any size with zero font dependency.
- **Static, same-origin, self-authored:** no XSS surface (the SVG-favicon risk applies to user-uploaded inline SVG, not a static dev asset).

## Verification
- `GET http://localhost:5173/favicon.svg` → **200**, `content-type: image/svg+xml`.
- Served `index.html` carries `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />`.
- `pnpm typecheck` clean; `pnpm test:unit` → **1190 passed**.
- Codex ckpt-2: no correctness/security issue.

## Scope
FE-only (one HTML line + one new static asset). No daemon restart, no API/schema change. Cosmetic polish under #559.

Closes #1861. Part of #559.