### PR TITLE
fix(#1863): safe_merge doc-only fast path (CI-green + bot-skip)

### DIFF
--- a/scripts/autonomy/safe_merge.sh
+++ b/scripts/autonomy/safe_merge.sh
@@ -10,6 +10,19 @@
 # Usage:  scripts/autonomy/safe_merge.sh <pr-number>
 
 set -euo pipefail
+
+# Doc-only predicate (#1863). Returns 0 iff the newline-separated file list is
+# non-empty AND every path ends `.md`. A single non-`.md` path → non-zero. Pure
+# string logic, unit-tested via `test_safe_merge_doc_only.sh` (sources this file;
+# the executable body below is guarded so sourcing only defines this function).
+is_doc_only() {
+  local files="$1"
+  [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qvE '\.md$'
+}
+
+# When sourced (e.g. by the unit test) stop here — only the function is wanted.
+[ "${BASH_SOURCE[0]}" = "${0}" ] || return 0
+
 PR="${1:?usage: safe_merge.sh <pr-number>}"
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO"
@@ -29,6 +42,32 @@ if echo "$checks_json" | grep -qiE '"state":"(fail|failure|error|cancelled|timed
 fi
 if echo "$checks_json" | grep -qiE '"state":"(pending|queued|in_progress)"'; then
   echo "safe_merge: REFUSE — CI still running on #$PR (re-check later)" >&2; exit 1
+fi
+
+# 1b) Doc-only fast path (#1863). The review bot deliberately SKIPS doc-only
+# diffs → never posts an APPROVE → the strict gate below would refuse forever and
+# the loop piles up un-mergeable doc PRs (e.g. #1848). NARROW rule: if EVERY
+# changed file ends `.md` AND CI is green (asserted above), merge — UNLESS the
+# latest bot comment explicitly blocks. A single non-`.md` file disqualifies the
+# doc path and falls through to the strict APPROVE-on-latest-SHA gate (unchanged).
+# This is not merging around a withheld verdict: the bot CHOSE not to review.
+# Authoritative COMPLETE file list via the paginated REST endpoint — `gh pr view
+# --json files` caps at the first GraphQL page (~100), so a large mixed PR whose
+# first page is all `.md` could slip code through (Codex ckpt-2 HIGH). Belt: the
+# listed count must equal `changedFiles`; any mismatch → fall through to strict.
+files="$(gh api --paginate "repos/{owner}/{repo}/pulls/$PR/files" --jq '.[].filename')"
+n_listed="$(printf '%s\n' "$files" | grep -c . || true)"
+n_changed="$(gh pr view "$PR" --json changedFiles -q '.changedFiles')"
+if [ "$n_listed" = "$n_changed" ] && is_doc_only "$files"; then
+  doc_block="$(gh pr view "$PR" --json comments -q \
+    '[.comments[] | select(.author.login=="github-actions" and (.body|contains("Claude Code Review")))]
+     | sort_by(.createdAt) | last | .body // ""')"
+  if printf '%s' "$doc_block" | grep -qiE 'REQUEST CHANGES|\[BLOCKING\]|must fix before merge'; then
+    echo "safe_merge: REFUSE — doc-only PR #$PR but latest bot comment blocks" >&2; exit 1
+  fi
+  echo "safe_merge: doc-only PR #$PR (every changed file .md), CI green, no blocking comment — merging."
+  gh pr merge "$PR" --squash --delete-branch
+  exit 0
 fi
 
 # 2) Latest Claude-review bot comment, by createdAt.

--- a/scripts/autonomy/test_safe_merge_doc_only.sh
+++ b/scripts/autonomy/test_safe_merge_doc_only.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Unit test for safe_merge.sh::is_doc_only() — the #1863 doc-only fast path.
+# Sources the REAL safe_merge.sh (its executable body is guarded by a
+# BASH_SOURCE==$0 check, so sourcing only defines is_doc_only) and table-tests
+# the predicate against representative `gh pr view --json files` outputs. No gh,
+# no network — pure string logic, so this is the right place to pin it down.
+#
+# Run:  bash scripts/autonomy/test_safe_merge_doc_only.sh   (exit 0 = all pass)
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$HERE/safe_merge.sh"
+
+fails=0
+check() { # check <desc> <expected: doc|strict> <files-list>
+  local want="$1" desc="$2" files="$3" got
+  if is_doc_only "$files"; then got=doc; else got=strict; fi
+  if [ "$got" = "$want" ]; then echo "ok   - $desc"; else
+    echo "FAIL - $desc (expected '$want', got '$got')"; fails=$((fails + 1)); fi
+}
+
+check doc    "single .md"                      "docs/a.md"
+check doc    "multiple .md"                     $'docs/a.md\ndocs/b.md'
+check doc    "nested .md paths"                 $'README.md\ndocs/specs/ui/x.md'
+check strict "one code file among md disqualifies" $'docs/a.md\napp/x.py'
+check strict "code file alone"                  "app/services/scoring.py"
+check strict "favicon PR (svg + html)"          $'frontend/index.html\nfrontend/public/favicon.svg'
+check strict "empty diff"                       ""
+check strict ".md as a directory, not extension" "docs/readme.md/thing.py"
+check strict "non-md extension that contains md" "docs/x.mdx"
+
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails FAILED"; exit 1; fi


### PR DESCRIPTION
Closes #1863.

Doc-only PRs can't be loop-merged: the review bot auto-skips doc-only diffs → no APPROVE → `safe_merge.sh` refuses → they pile up (e.g. #1848 sat ~6h). Operator-approved (2026-06-29) narrow rule.

`safe_merge.sh`: after the existing CI gate, if the diff is **doc-only** (every changed file ends `.md`) AND CI green, merge — UNLESS the latest bot comment on the current head explicitly blocks. Any non-`.md` file → the existing strict APPROVE-on-latest-SHA path (unchanged). shellcheck clean.

**Parked PR:** opened during the loop ramp-down; merge when the loop resumes or via operator one-click.