### PR TITLE
feat(#1865): supervise the jobs daemon under launchd (KeepAlive)

### DIFF
--- a/scripts/autonomy/com.ebull.jobs-daemon.plist
+++ b/scripts/autonomy/com.ebull.jobs-daemon.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd LaunchAgent for the JOBS DAEMON (the ETL / ingest + scheduler runner,
+  `python -m app.jobs`). Independent of the autonomy loop supervisor — this keeps
+  DATA fresh unattended (SEC manifest worker, per-CIK poll, orchestrator sync,
+  fundamentals, portfolio sync) with the AI loop OFF.
+
+  KeepAlive + RunAtLoad: starts on load, restarted if it ever exits (crash,
+  reboot, OOM) — so ingestion survives a machine restart while you're away
+  (#1865). Config is read from the repo `.env` via WorkingDirectory; only PATH
+  (for `uv`) + HOME (uv cache) are injected. The daemon's own PG advisory lock
+  prevents a duplicate if a manual daemon is still running — stop that first.
+
+  Install: substitute __REPO__ with the repo root, copy to
+  ~/Library/LaunchAgents/, `launchctl load` it. See scripts/autonomy/setup.md.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.ebull.jobs-daemon</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/uv</string>
+    <string>run</string>
+    <string>python</string>
+    <string>-m</string>
+    <string>app.jobs</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__REPO__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HOME</key>
+    <string>__HOME__</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <key>StandardOutPath</key>
+  <string>__REPO__/var/autonomy-logs/launchd.jobs-daemon.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>__REPO__/var/autonomy-logs/launchd.jobs-daemon.err.log</string>
+</dict>
+</plist>

--- a/scripts/autonomy/setup.md
+++ b/scripts/autonomy/setup.md
@@ -35,6 +35,30 @@ Stop:
 launchctl unload ~/Library/LaunchAgents/com.ebull.autonomy.supervisor.plist
 ```
 
+## Data daemon — keep ETL fresh with the loop OFF (#1865)
+The jobs daemon (`python -m app.jobs`: SEC manifest worker, per-CIK poll,
+orchestrator sync, fundamentals, portfolio sync) is **independent of the AI
+loop**. Run it under launchd so ingestion survives reboot/crash and data stays
+current while the loop is paused. Config is read from the repo `.env` via the
+plist's `WorkingDirectory`; only PATH (for `uv`) + HOME are injected.
+```bash
+mkdir -p var/autonomy-logs
+# stop any manual `nohup … python -m app.jobs` first (avoid a duplicate; the
+# daemon's PG advisory lock would otherwise idle the second one).
+sed "s#__REPO__#$(pwd)#g; s#__HOME__#$HOME#g" scripts/autonomy/com.ebull.jobs-daemon.plist \
+  > ~/Library/LaunchAgents/com.ebull.jobs-daemon.plist
+launchctl load ~/Library/LaunchAgents/com.ebull.jobs-daemon.plist
+launchctl list | grep jobs-daemon                       # confirm loaded
+tail -f var/autonomy-logs/launchd.jobs-daemon.err.log   # scheduler ticks (stderr)
+```
+Stop:
+```bash
+launchctl unload ~/Library/LaunchAgents/com.ebull.jobs-daemon.plist
+```
+Safe to run this daemon WITHOUT the AI loop and with the kill switch ON — the
+kill switch gates only the trade jobs (`morning_candidate_review`,
+`retry_deferred`), not data ingestion.
+
 ## Simpler alternative: hourly run_loop (no continuous supervisor)
 One fresh session per hour (lock = no overlap). Less tight than the supervisor
 and no smart limit-backoff (a limited hour just retries next hour), but minimal.


### PR DESCRIPTION
Closes #1865.

Puts the ETL/ingest daemon (`python -m app.jobs`) under launchd `KeepAlive` so it survives reboot/crash and keeps data fresh **with the AI loop off** — the "stay up to date, loops or not" goal.

- `com.ebull.jobs-daemon.plist` — RunAtLoad + KeepAlive; `uv run python -m app.jobs`, WorkingDirectory=repo (config via `.env`), PATH+HOME injected; path-agnostic (`__REPO__`/`__HOME__`).
- `setup.md` — install/stop steps; notes the kill switch gates only trade jobs, so daemon is safe with the loop off + switch on.

**Verified live:** loaded, PID stable under launchd, scheduler ticking (`sec_filing_documents_ingest` / `orchestrator_high_frequency_sync` / `sec_atom_fast_lane` upserting filings). Independent of the autonomy-loop supervisor; the loop stays operator-gated.