### PR TITLE
fix(#1867): correct inverted comment in safe_merge doc-only test helper

### DIFF
--- a/scripts/autonomy/test_safe_merge_doc_only.sh
+++ b/scripts/autonomy/test_safe_merge_doc_only.sh
@@ -13,7 +13,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/safe_merge.sh"
 
 fails=0
-check() { # check <desc> <expected: doc|strict> <files-list>
+check() { # check <expected: doc|strict> <desc> <files-list>
   local want="$1" desc="$2" files="$3" got
   if is_doc_only "$files"; then got=doc; else got=strict; fi
   if [ "$got" = "$want" ]; then echo "ok   - $desc"; else


### PR DESCRIPTION
## What
One-line comment fix in `scripts/autonomy/test_safe_merge_doc_only.sh`. The `check()` helper's doc comment listed its params as `<desc> <expected> <files-list>`, but the body assigns `want=$1 desc=$2 files=$3` — i.e. the real signature is `<expected> <desc> <files-list>`. Calls were always correct; only the comment misled.

## Why
Resolves the bot NITPICK raised on #1864 (APPROVE) so it isn't silently discarded (review-resolution contract).

## Verification
`bash scripts/autonomy/test_safe_merge_doc_only.sh` → `ALL PASS` (9/9). No logic change.

Closes #1867.

🤖 Generated with [Claude Code](https://claude.com/claude-code)