### PR TITLE
fix(#1871): supervisor sleeps until API-reported rate-limit reset, not blind exponential

### DIFF
--- a/app/jobs/sec_per_cik_poll.py
+++ b/app/jobs/sec_per_cik_poll.py
@@ -16,8 +16,11 @@ when the caller supplies the richer ``http_get_with_meta`` callable
 this job rounds the SEC ``Last-Modified`` header through
 ``external_data_watermarks`` under source-key
 ``sec.last_modified.per_cik_poll`` and short-circuits on HTTP 304 —
-skipping payload parse + scheduler UPSERT entirely while bumping
-``watermark_at`` so the watermark row stays fresh.
+skipping the manifest UPSERT + payload parse, but STILL writing a
+scheduler outcome (``current``/``never``) and re-stamping
+``watermark_at`` so the recheck timing rolls forward and the
+watermark row stays fresh. A 304 is a budget-conserving success,
+not a noop.
 
 Distinct source-key namespace from ``sec.submissions`` (which stores
 top-accession at ``app/services/fundamentals/__init__.py:2030``) to
@@ -93,11 +96,19 @@ def _probe_subject(
     Item 7 (#1233): when ``http_get_with_meta`` is supplied, this
     function reads any prior ``sec.last_modified.per_cik_poll`` /
     ``<cik>`` watermark, sends it as ``If-Modified-Since``, and on
-    HTTP 304 short-circuits without scheduler-outcome write (the
-    payload didn't change so neither did the freshness state). On
-    200 with a ``Last-Modified`` header the watermark is upserted
-    inside the same transaction as the manifest writes so a crash
-    mid-ingest cannot leave the watermark ahead of the data.
+    HTTP 304 short-circuits the PAYLOAD work — skips manifest writes
+    + parse — but STILL writes a scheduler outcome inside one
+    transaction: ``current`` (rolls ``expected_next_at`` forward) for
+    a filer, or ``never`` (next recheck at now+cadence) for a
+    ``never_filed`` subject; and re-stamps ``watermark_at`` when a
+    prior ``If-Modified-Since`` exists. So a 304 advances
+    freshness/recheck state with zero upserts — a budget-conserving
+    success, not a noop — and it does NOT touch ``attempt_count``
+    (see the ``delta.not_modified`` branch in the body). On 200 with
+    a ``Last-Modified``
+    header the watermark is upserted inside the same transaction as
+    the manifest writes so a crash mid-ingest cannot leave the
+    watermark ahead of the data.
 
     Backwards compat: ``http_get`` legacy path is preserved for
     existing tests (``tests/test_sec_per_cik_poll.py``) that don't

--- a/scripts/autonomy/supervisor.sh
+++ b/scripts/autonomy/supervisor.sh
@@ -183,7 +183,7 @@ PY
 # by the bash caller (compute_limit_wait), not here.
 extract_reset_epoch() {
   python3 - "$1" <<'PY'
-import json, sys, time
+import json, math, sys, time
 from datetime import datetime, timezone
 
 def to_epoch(v):
@@ -192,6 +192,8 @@ def to_epoch(v):
         return None
     if isinstance(v, (int, float)):
         x = float(v)
+        if not math.isfinite(x):              # inf/nan → int() would OverflowError
+            return None
         if x > 1e12:      # milliseconds
             x /= 1000.0
         return int(x) if x > 1e9 else None   # plausibly an absolute epoch
@@ -201,10 +203,11 @@ def to_epoch(v):
             return None
         try:                                  # bare numeric string?
             x = float(s)
-            if x > 1e12:
-                x /= 1000.0
-            if x > 1e9:
-                return int(x)
+            if math.isfinite(x):
+                if x > 1e12:
+                    x /= 1000.0
+                if x > 1e9:
+                    return int(x)
         except ValueError:
             pass
         try:                                  # ISO-8601 (tolerate trailing Z)
@@ -240,7 +243,7 @@ for line in open(sys.argv[1], errors="replace"):
                     secs = float(val.strip())
                 except ValueError:
                     secs = None
-            if secs is not None:
+            if secs is not None and math.isfinite(secs):
                 reset = int(time.time() + secs)
         elif "reset" in kl:
             e = to_epoch(val)

--- a/scripts/autonomy/supervisor.sh
+++ b/scripts/autonomy/supervisor.sh
@@ -5,8 +5,14 @@
 #
 # Loop: check the board → run ONE fresh headless `claude` session (drains as many
 # tickets as fit in its context) → classify the outcome → wait → repeat, forever:
-#   - usage/rate limit hit  → back off (exponential, capped ~5h ≈ the usage
-#                             window) then retry when capacity returns.
+#   - usage/rate limit hit  → sleep until the API-reported reset time (parsed
+#                             from the rejected rate_limit_event, persisted to
+#                             disk so a later no-event fast-fail still wakes at
+#                             the right moment); exponential backoff is only the
+#                             fallback when no reset signal is available. NOTE:
+#                             the supervisor is plain bash — only the `claude`
+#                             CHILD is rate-limited; the parent that decides when
+#                             to wake never is, so it always survives to retry.
 #   - other error           → exponential backoff (capped 1h).
 #   - clean finish          → short pace, next session.
 #   - board empty           → idle-poll every 30 min.
@@ -27,12 +33,18 @@ LOCK="$REPO/var/autonomy-supervisor.lock"
 LOGDIR="$REPO/var/autonomy-logs"
 mkdir -p "$LOGDIR"
 SUPLOG="$LOGDIR/supervisor.log"
+RESET_STATE="$LOGDIR/.last_usage_reset"   # epoch secs of the last API-reported rate-limit reset
 
 # --- timing knobs (seconds) ---
 PACE=120                    # gap between back-to-back clean sessions
 EMPTY_IDLE=1800            # board empty → poll every 30 min
 ERR_BACKOFF_START=300; ERR_BACKOFF_MAX=3600
-LIMIT_BACKOFF_START=1800; LIMIT_BACKOFF_MAX=18000   # 30 min → cap 5 h (usage window)
+# Exponential backoff is now only the FALLBACK for a usage-limit hit with no
+# parseable reset time (see compute_limit_wait). When the API reports a reset we
+# sleep until it directly — which also handles the WEEKLY window (>5h), where the
+# old 5h cap below would wake too early, fail, and sleep again.
+LIMIT_BACKOFF_START=1800; LIMIT_BACKOFF_MAX=18000   # 30 min → cap 5 h (fallback only)
+LIMIT_RESET_MAX_HORIZON=691200   # 8 days: reject implausibly-far reset epochs as parse garbage
 PREFLIGHT_RECOVERY_AFTER=2  # consecutive dirty-tree skips before stashing WIP + proceeding (#1801)
 dirty_skips=0               # supervisor-global counter (reset on any clean-tree observation)
 
@@ -107,6 +119,22 @@ run_session() {
   # not covered by overage. A successful session was never blocked, whatever
   # literals its content carried.
   if is_usage_limit_hit "$log_file"; then
+    # Persist the API-reported reset time (if the rejected event carried one) so
+    # the main loop can sleep until exactly then.
+    local epoch; epoch="$(extract_reset_epoch "$log_file")"
+    if [ -n "$epoch" ]; then
+      printf '%s\n' "$epoch" >"$RESET_STATE"
+    fi
+    return 3
+  fi
+  # No structured rejection in THIS log, but the child failed AND a sane future
+  # reset marker still stands (no clean session has cleared it since the last
+  # block). That's almost certainly the same ongoing limit window emitting no
+  # event this time — classify as a usage-limit hit so the loop waits until the
+  # recorded reset instead of burning the generic-error backoff. The marker
+  # self-expires (compute_limit_wait rejects a past/garbage epoch), so a genuine
+  # post-reset error falls through to normal error handling.
+  if [ "$rc" -ne 0 ] && compute_limit_wait >/dev/null; then
     return 3
   fi
   return $rc
@@ -147,6 +175,94 @@ sys.exit(0 if (rejected and not succeeded) else 1)
 PY
 }
 
+# Extract the API-reported reset time from the LAST rejected rate_limit_event in
+# the session log and print it as epoch-seconds (nothing if absent/unparseable).
+# Defensive on field name + format — the stream-json envelope is not contract-
+# stable, so accept any "*reset*" key (ISO-8601 or epoch s/ms) plus a relative
+# "retry_after"/"retryAfter" seconds value. Sanity-bounding (future, <8d) is done
+# by the bash caller (compute_limit_wait), not here.
+extract_reset_epoch() {
+  python3 - "$1" <<'PY'
+import json, sys, time
+from datetime import datetime, timezone
+
+def to_epoch(v):
+    """Coerce a value to absolute epoch-seconds, or None."""
+    if isinstance(v, bool):
+        return None
+    if isinstance(v, (int, float)):
+        x = float(v)
+        if x > 1e12:      # milliseconds
+            x /= 1000.0
+        return int(x) if x > 1e9 else None   # plausibly an absolute epoch
+    if isinstance(v, str):
+        s = v.strip()
+        if not s:
+            return None
+        try:                                  # bare numeric string?
+            x = float(s)
+            if x > 1e12:
+                x /= 1000.0
+            if x > 1e9:
+                return int(x)
+        except ValueError:
+            pass
+        try:                                  # ISO-8601 (tolerate trailing Z)
+            dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return int(dt.timestamp())
+        except ValueError:
+            return None
+    return None
+
+reset = None
+for line in open(sys.argv[1], errors="replace"):
+    if '"type"' not in line:
+        continue
+    try:
+        o = json.loads(line)
+    except Exception:
+        continue
+    if o.get("type") != "rate_limit_event":
+        continue
+    rli = o.get("rate_limit_info") or {}
+    if rli.get("status") != "rejected" or rli.get("isUsingOverage"):
+        continue
+    for k, val in rli.items():
+        kl = k.lower()
+        if kl in ("retryafter", "retry_after"):
+            if isinstance(val, (int, float)) and not isinstance(val, bool):
+                reset = int(time.time() + float(val))
+        elif "reset" in kl:
+            e = to_epoch(val)
+            if e is not None:
+                reset = e
+
+if reset is not None:
+    print(reset)
+PY
+}
+
+# Seconds to sleep on a usage-limit hit, derived from the persisted API reset
+# time. Prints the wait + exits 0 when a SANE future reset is on record
+# (now < reset <= now + 8d); exits 1 otherwise so the caller uses exponential
+# backoff. Bounding here guards against a stale/garbage epoch sleeping forever.
+compute_limit_wait() {
+  [ -f "$RESET_STATE" ] || return 1
+  local reset now
+  reset="$(cat "$RESET_STATE" 2>/dev/null)"
+  case "$reset" in
+    ''|*[!0-9]*) return 1 ;;   # must be a bare integer epoch
+  esac
+  now="$(date +%s)"
+  if [ "$reset" -gt "$now" ] && [ "$reset" -le "$((now + LIMIT_RESET_MAX_HORIZON))" ]; then
+    echo "$((reset - now))"
+    return 0
+  fi
+  return 1
+}
+
 # --- main loop (skipped when this file is SOURCED, e.g. by test_preflight_recovery.sh) ---
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
   # single-instance lock (atomic mkdir; stale = dead pid; supervisor is long-lived)
@@ -175,11 +291,19 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     case $outcome in
       0) log "session clean (open issues ~$open_count). pace ${PACE}s"
          err_backoff=$ERR_BACKOFF_START; limit_backoff=$LIMIT_BACKOFF_START
+         rm -f "$RESET_STATE"   # capacity confirmed back — drop any stale reset marker
          sleep "$PACE" ;;
       3) jitter=$((RANDOM % 120))
-         log "USAGE LIMIT — backoff $((limit_backoff + jitter))s then retry"
-         sleep $((limit_backoff + jitter))
-         limit_backoff=$(( limit_backoff*2 < LIMIT_BACKOFF_MAX ? limit_backoff*2 : LIMIT_BACKOFF_MAX )) ;;
+         if reset_wait="$(compute_limit_wait)"; then
+           reset_wait=$((reset_wait + jitter))
+           log "USAGE LIMIT — sleeping ${reset_wait}s until API-reported reset, then retry"
+           sleep "$reset_wait"
+           limit_backoff=$LIMIT_BACKOFF_START   # precise wake — reset the fallback ladder
+         else
+           log "USAGE LIMIT (no reset signal) — exp backoff $((limit_backoff + jitter))s then retry"
+           sleep $((limit_backoff + jitter))
+           limit_backoff=$(( limit_backoff*2 < LIMIT_BACKOFF_MAX ? limit_backoff*2 : LIMIT_BACKOFF_MAX ))
+         fi ;;
       2) log "preflight skip — wait ${ERR_BACKOFF_START}s"; sleep "$ERR_BACKOFF_START" ;;
       *) log "session error (rc=$outcome) — backoff ${err_backoff}s"
          sleep "$err_backoff"

--- a/scripts/autonomy/supervisor.sh
+++ b/scripts/autonomy/supervisor.sh
@@ -232,8 +232,16 @@ for line in open(sys.argv[1], errors="replace"):
     for k, val in rli.items():
         kl = k.lower()
         if kl in ("retryafter", "retry_after"):
+            secs = None
             if isinstance(val, (int, float)) and not isinstance(val, bool):
-                reset = int(time.time() + float(val))
+                secs = float(val)
+            elif isinstance(val, str):
+                try:                              # string-valued seconds, e.g. "1800"
+                    secs = float(val.strip())
+                except ValueError:
+                    secs = None
+            if secs is not None:
+                reset = int(time.time() + secs)
         elif "reset" in kl:
             e = to_epoch(val)
             if e is not None:

--- a/scripts/autonomy/test_usage_limit_reset.sh
+++ b/scripts/autonomy/test_usage_limit_reset.sh
@@ -48,6 +48,12 @@ between "relative 'retryAfter' (number) → now+secs" "$((now + 1790))" "$((now 
 f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","retryAfter":"1800"}}')"
 between "relative 'retryAfter' (string) → now+secs" "$((now + 1790))" "$((now + 1815))" "$(extract_reset_epoch "$f")"
 
+# Non-finite values must yield no reset (not crash int() with OverflowError).
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","retryAfter":"inf"}}')"
+check "non-finite 'retryAfter' inf → no reset (no crash)" "" "$(extract_reset_epoch "$f" 2>/dev/null)"
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","reset":"NaN"}}')"
+check "non-finite 'reset' NaN → no reset" "" "$(extract_reset_epoch "$f" 2>/dev/null)"
+
 # --- extract_reset_epoch: must IGNORE non-blocking / irrelevant events ---
 f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","isUsingOverage":true,"resetsAt":"2030-06-30T12:00:00Z"}}')"
 check "overage-covered rejection yields no reset" "" "$(extract_reset_epoch "$f")"

--- a/scripts/autonomy/test_usage_limit_reset.sh
+++ b/scripts/autonomy/test_usage_limit_reset.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Unit test for supervisor.sh reset-aware usage-limit backoff.
+# Sources the REAL supervisor.sh (main loop guarded by BASH_SOURCE==$0, so
+# sourcing only defines functions) and exercises:
+#   - extract_reset_epoch():  parse the API reset time from a rejected
+#                             rate_limit_event, across field-name/format variants.
+#   - is_usage_limit_hit():   the blocked/not-blocked classifier (overage + a
+#                             successful terminal result are NOT blocks).
+#   - compute_limit_wait():   sane-future bounding of the persisted reset marker.
+#
+# Run:  bash scripts/autonomy/test_usage_limit_reset.sh   (exit 0 = all pass)
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=/dev/null
+source "$HERE/supervisor.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+RESET_STATE="$tmp/.last_usage_reset"   # override: don't touch the real marker
+
+fails=0
+check() { # check <desc> <expected> <actual>
+  if [ "$2" = "$3" ]; then echo "ok   - $1"; else echo "FAIL - $1 (expected '$2', got '$3')"; fails=$((fails + 1)); fi
+}
+between() { # between <desc> <lo> <hi> <actual>
+  if [ -n "$4" ] && [ "$4" -ge "$2" ] && [ "$4" -le "$3" ]; then echo "ok   - $1"; else echo "FAIL - $1 (want [$2,$3], got '$4')"; fails=$((fails + 1)); fi
+}
+
+mklog() { printf '%s\n' "$1" > "$tmp/log.jsonl"; echo "$tmp/log.jsonl"; }
+ISO_EPOCH="$(python3 -c 'from datetime import datetime,timezone;print(int(datetime(2030,6,30,12,0,0,tzinfo=timezone.utc).timestamp()))')"
+
+# --- extract_reset_epoch: field-name / format variants (defensive parse) ---
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":"2030-06-30T12:00:00Z"}}')"
+check "ISO-8601 'resetsAt' → epoch" "$ISO_EPOCH" "$(extract_reset_epoch "$f")"
+
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","reset":4102444800}}')"
+check "epoch-seconds 'reset'" 4102444800 "$(extract_reset_epoch "$f")"
+
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetAt":4102444800000}}')"
+check "epoch-millis 'resetAt' → seconds" 4102444800 "$(extract_reset_epoch "$f")"
+
+now="$(date +%s)"
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","retryAfter":1800}}')"
+between "relative 'retryAfter' → now+secs" "$((now + 1790))" "$((now + 1815))" "$(extract_reset_epoch "$f")"
+
+# --- extract_reset_epoch: must IGNORE non-blocking / irrelevant events ---
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","isUsingOverage":true,"resetsAt":"2030-06-30T12:00:00Z"}}')"
+check "overage-covered rejection yields no reset" "" "$(extract_reset_epoch "$f")"
+
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":"2030-06-30T12:00:00Z"}}')"
+check "non-rejected event yields no reset" "" "$(extract_reset_epoch "$f")"
+
+f="$(mklog '{"type":"assistant","message":{"content":"rate limit reset at 9999999999"}}')"
+check "content text is never parsed (#1770)" "" "$(extract_reset_epoch "$f")"
+
+# --- is_usage_limit_hit: classifier sanity (blocked vs not) ---
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected"}}')"
+if is_usage_limit_hit "$f"; then r=blocked; else r=ok; fi
+check "rejected + no terminal result = blocked" blocked "$r"
+
+printf '%s\n%s\n' \
+  '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected"}}' \
+  '{"type":"result","is_error":false}' > "$tmp/log.jsonl"
+if is_usage_limit_hit "$tmp/log.jsonl"; then r=blocked; else r=ok; fi
+check "rejected BUT session succeeded = not blocked" ok "$r"
+
+# --- compute_limit_wait: bounding of the persisted marker ---
+now="$(date +%s)"
+echo "$((now + 600))" > "$RESET_STATE"
+if w="$(compute_limit_wait)"; then rc=0; else rc=1; fi
+check "future reset returns exit 0" 0 "$rc"
+between "future reset wait ≈ remaining" 590 600 "$w"
+
+echo "$((now - 60))" > "$RESET_STATE"
+if compute_limit_wait >/dev/null; then rc=0; else rc=1; fi
+check "past reset → fallback (exit 1)" 1 "$rc"
+
+echo "$((now + LIMIT_RESET_MAX_HORIZON + 3600))" > "$RESET_STATE"
+if compute_limit_wait >/dev/null; then rc=0; else rc=1; fi
+check "implausibly-far reset → fallback (exit 1)" 1 "$rc"
+
+echo "not-a-number" > "$RESET_STATE"
+if compute_limit_wait >/dev/null; then rc=0; else rc=1; fi
+check "garbage marker → fallback (exit 1)" 1 "$rc"
+
+rm -f "$RESET_STATE"
+if compute_limit_wait >/dev/null; then rc=0; else rc=1; fi
+check "missing marker → fallback (exit 1)" 1 "$rc"
+
+echo "---"
+if [ "$fails" -eq 0 ]; then echo "ALL PASS"; exit 0; else echo "$fails CHECK(S) FAILED"; exit 1; fi

--- a/scripts/autonomy/test_usage_limit_reset.sh
+++ b/scripts/autonomy/test_usage_limit_reset.sh
@@ -43,7 +43,10 @@ check "epoch-millis 'resetAt' → seconds" 4102444800 "$(extract_reset_epoch "$f
 
 now="$(date +%s)"
 f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","retryAfter":1800}}')"
-between "relative 'retryAfter' → now+secs" "$((now + 1790))" "$((now + 1815))" "$(extract_reset_epoch "$f")"
+between "relative 'retryAfter' (number) → now+secs" "$((now + 1790))" "$((now + 1815))" "$(extract_reset_epoch "$f")"
+
+f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","retryAfter":"1800"}}')"
+between "relative 'retryAfter' (string) → now+secs" "$((now + 1790))" "$((now + 1815))" "$(extract_reset_epoch "$f")"
 
 # --- extract_reset_epoch: must IGNORE non-blocking / irrelevant events ---
 f="$(mklog '{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","isUsingOverage":true,"resetsAt":"2030-06-30T12:00:00Z"}}')"


### PR DESCRIPTION
## Problem
`scripts/autonomy/supervisor.sh` parses the rejected `rate_limit_event` to DETECT a usage-limit block but discarded the reset time the event carries, sleeping on a blind exponential curve (`LIMIT_BACKOFF_START=1800` → cap `18000`=5h).

- **Weekly-window mismatch:** the 5h cap is tuned to the *5h* usage window. A **weekly** block (reset > 5h out — e.g. operator at 94% weekly, resets in ~11h) wakes early, fails, sleeps again, repeatedly.
- **No-event fast-fail:** a session rejected instantly may exit nonzero with no structured event, so even the exponential start is uninformed.

## Fix
Sleep until the API-reported reset when we have it; exponential only as fallback.
- `extract_reset_epoch()` — defensive parse of the reset from the last rejected `rate_limit_event`: any `*reset*` key as ISO-8601 or epoch s/ms, plus relative `retry_after`. **Structured events only — never content text** (#1770 false-positive class).
- Persist to `var/autonomy-logs/.last_usage_reset`. `run_session` classifies a **nonzero child + a sane future marker** as a usage-limit hit, so a later no-event fast-fail still waits until reset. Marker self-expires (`compute_limit_wait` rejects past/garbage), so a genuine post-reset error falls through to normal error handling.
- `compute_limit_wait()` — sane-future bound (`now < reset ≤ now+8d`); out-of-bound/absent → exponential fallback (**unchanged behaviour**).
- Clear the marker on a clean session (capacity confirmed back).

## Why it's safe
The supervisor is plain bash; only the `claude` **child** is rate-limited. The parent deciding when to wake is never throttled, and the reset marker is a **file**, so both survive the child's death. Fallback path = today's exact behaviour, so worst case is no regression. No trade/order/kill-switch surface touched.

## Verification
- `scripts/autonomy/test_usage_limit_reset.sh` — 15 checks: field/format variants (ISO, epoch s/ms, relative retry_after), overage-covered + succeeded-session non-blocks, content-text-never-parsed, `compute_limit_wait` bounding (future/past/too-far/garbage/absent). **ALL PASS.**
- `test_preflight_recovery.sh` regression **green**; `shellcheck` **clean**; `bash -n` ok.
- Codex (pre-push): caught the marker was unused on the no-event path; `run_session` now consults it in the child-failure branch. Fixed before first push.

## Operator follow-up (required)
Pure-bash change to the supervisor itself — the **running launchd supervisor will NOT pick up its own edited script.** After merge, reload:
```
launchctl bootout gui/$(id -u)/com.ebull.autonomy.supervisor
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ebull.autonomy.supervisor.plist
```

Closes #1871.