### PR TITLE
fix(#1326): correct sec_per_cik_poll 304 docstrings — stale since commit 620e0afb

### DIFF
--- a/app/jobs/sec_per_cik_poll.py
+++ b/app/jobs/sec_per_cik_poll.py
@@ -16,8 +16,11 @@ when the caller supplies the richer ``http_get_with_meta`` callable
 this job rounds the SEC ``Last-Modified`` header through
 ``external_data_watermarks`` under source-key
 ``sec.last_modified.per_cik_poll`` and short-circuits on HTTP 304 —
-skipping payload parse + scheduler UPSERT entirely while bumping
-``watermark_at`` so the watermark row stays fresh.
+skipping the manifest UPSERT + payload parse, but STILL writing a
+scheduler outcome (``current``/``never``) and re-stamping
+``watermark_at`` so the recheck timing rolls forward and the
+watermark row stays fresh. A 304 is a budget-conserving success,
+not a noop.
 
 Distinct source-key namespace from ``sec.submissions`` (which stores
 top-accession at ``app/services/fundamentals/__init__.py:2030``) to
@@ -93,11 +96,19 @@ def _probe_subject(
     Item 7 (#1233): when ``http_get_with_meta`` is supplied, this
     function reads any prior ``sec.last_modified.per_cik_poll`` /
     ``<cik>`` watermark, sends it as ``If-Modified-Since``, and on
-    HTTP 304 short-circuits without scheduler-outcome write (the
-    payload didn't change so neither did the freshness state). On
-    200 with a ``Last-Modified`` header the watermark is upserted
-    inside the same transaction as the manifest writes so a crash
-    mid-ingest cannot leave the watermark ahead of the data.
+    HTTP 304 short-circuits the PAYLOAD work — skips manifest writes
+    + parse — but STILL writes a scheduler outcome inside one
+    transaction: ``current`` (rolls ``expected_next_at`` forward) for
+    a filer, or ``never`` (next recheck at now+cadence) for a
+    ``never_filed`` subject; and re-stamps ``watermark_at`` when a
+    prior ``If-Modified-Since`` exists. So a 304 advances
+    freshness/recheck state with zero upserts — a budget-conserving
+    success, not a noop — and it does NOT touch ``attempt_count``
+    (see the ``delta.not_modified`` branch in the body). On 200 with
+    a ``Last-Modified``
+    header the watermark is upserted inside the same transaction as
+    the manifest writes so a crash mid-ingest cannot leave the
+    watermark ahead of the data.
 
     Backwards compat: ``http_get`` legacy path is preserved for
     existing tests (``tests/test_sec_per_cik_poll.py``) that don't


### PR DESCRIPTION
## What
Both docstrings in `app/jobs/sec_per_cik_poll.py` (module-level + `_probe_subject`) claimed HTTP **304 "short-circuits without scheduler-outcome write"** / "skipping ... scheduler UPSERT entirely". The code at `L163-199` (landed in the **same commit** `620e0afb` / #1312) has always done the opposite. Corrected both to the verified behavior.

## Verified 304 behavior (read at write-time, `app/jobs/sec_per_cik_poll.py:157-200`)
On `delta.not_modified`, inside one transaction:
- **Writes a scheduler outcome** via `record_poll_outcome` — `current` (rolls `expected_next_at` forward) for a filer, or `never` (`next_recheck_at = now + cadence`) for a `never_filed` subject.
- **Re-stamps `watermark_at`** (when a prior `If-Modified-Since` exists).
- **Skips** the manifest UPSERT + payload parse. Returns `(0, False)`.
- **Never touches `attempt_count`** (grep-empty in both this file and `sec_submissions_files_walk.py`).

So a 304 is a budget-conserving success that advances freshness/recheck state with zero upserts — not a noop, and not "payload work was done".

## Why this resolves #1326
The ticket asked to add a §13 "304 = stage success" gotcha to every per-source spec whose §2 uses conditional-GET. Two prior autonomy passes (issue comments) established — and a fresh full check confirms — that:
1. **Acceptance targets an empty set.** Every SEC-form spec states "No conditional-GET" in §2; `company_tickers.md` is the only per-source 304 path and its §13 already carries the gotchas (#1056).
2. **The operator-facing intent is already documented accurately** at the right shared-infra level: `docs/specs/bootstrap/orchestration.md:117-131` ("a conditional-fetch 304-Not-Modified can mark the job success with zero upserts" → provenance + coverage invariants).
3. **The one real residual defect was the misleading docstring** — both prior passes read *it* (not the executable code) and mis-falsified the premise in opposite directions. Fixing it removes the trap.

No behavior change (docstring-only). Codex ckpt-2: confirmed the new text matches code; all three caveats folded in (conditional `watermark_at`, drift-prone line ref dropped, module docstring also corrected).

Closes #1326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)