### PR TITLE
fix(#1878): switch PR review bot to claude-sonnet-5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -271,15 +271,16 @@ jobs:
 
           user_prompt += "## Full diff\n```diff\n" + diff + "\n```"
 
-          # Extended thinking with a mid budget — gives the model room to
-          # triage findings (reject hallucinations, rebutted-already, code-not-in-diff)
-          # before emitting. Cheap vs the cost of a bad review round.
-          # budget_tokens must be strictly less than max_tokens; keep a 2k
-          # response cap on top of 3k thinking so findings stay terse.
+          # Adaptive thinking gives the model room to triage findings (reject
+          # hallucinations, rebutted-already, code-not-in-diff) before
+          # emitting. Sonnet 5 dropped the fixed budget_tokens knob in favor
+          # of output_config.effort — "low" mirrors the modest ~3k-token
+          # thinking budget the prior (Sonnet 4.6) config used.
           payload = {
-              "model": "claude-sonnet-4-6",
+              "model": "claude-sonnet-5",
               "max_tokens": 5000,
-              "thinking": {"type": "enabled", "budget_tokens": 3000},
+              "thinking": {"type": "adaptive"},
+              "output_config": {"effort": "low"},
               "system": [
                   {
                       "type": "text",


### PR DESCRIPTION
## What
`.github/workflows/claude-review.yml` calls the Anthropic Messages API directly (raw `curl`) to post automated PR reviews. Swaps `model: "claude-sonnet-4-6"` → `"claude-sonnet-5"` to evaluate whether review quality holds at lower cost (Sonnet 5 intro pricing $2/$10 per MTok vs Sonnet 4.6's $3/$15, through 2026-08-31).

## Why
Per-PR-push API cost worth re-evaluating; Sonnet 5 is near-Opus quality on coding/review tasks per current model docs.

## Change
- `model`: `claude-sonnet-4-6` → `claude-sonnet-5`
- `thinking`: Sonnet 5 dropped the legacy `{type: "enabled", budget_tokens: N}` extended-thinking config (returns 400 on that model) → migrated to `{type: "adaptive"}` + `output_config: {effort: "low"}`. `"low"` chosen to mirror the prior config's modest ~3k-token thinking budget out of a 5k `max_tokens` cap — this is a CI cost-evaluation experiment, so kept conservative.
- No other workflow logic touched (system prompt, diff-fetching, comment posting, docs-only skip path all unchanged).

## Security model
No new untrusted-input interpolation — same `run_id`/diff/comment plumbing as before, all already routed through `gh` JSON output and Python `json.dumps`, never `${{ }}` interpolated into a shell string.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- Extracted and `py_compile`'d the embedded `build_prompt.py` heredoc — syntax valid.
- Confirmed `model: "claude-sonnet-5"` is a live, GA model ID against the real Anthropic API: this Claude Code session itself is currently running under that exact model ID (set via `/model sonnet`), which is direct evidence the string is accepted by the production API.
- Did not run a live curl smoke test against `api.anthropic.com` — no `ANTHROPIC_API_KEY` configured in this dev environment (checked `.env`, env var, and `ant auth status` — none present). First real exercise of this path is the live PR-review run this PR itself will trigger.
- All local pre-push gates green (ruff, pyright, shellcheck, lint chokepoints, fast pytest tier, smoke tier, frontend dark-mode gate).

## Codex pre-push review (checkpoint 2)
One finding, REBUTTED:
- **"claude-sonnet-5 not a valid model ID — absent from the repo's vendored anthropic Python SDK type list."** Codex grepped `.venv/lib/python3.14/site-packages/anthropic/types/model_param.py`, a pinned SDK version's `Literal[...]` type stub. This workflow never imports that SDK — it builds the request body with plain `json.dumps` and POSTs via `curl`, so the vendored type pin doesn't gate what the live API accepts. Independently verified the model ID is real per the Verification section above.

## Tradeoffs
This is explicitly a cost experiment, not a settled decision — if the bot's review quality regresses noticeably on real PRs, revert to `claude-sonnet-4-6`.

Closes #1878.