### PR TITLE
fix(#1880): bump PR review bot effort low -> medium

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -274,13 +274,17 @@ jobs:
           # Adaptive thinking gives the model room to triage findings (reject
           # hallucinations, rebutted-already, code-not-in-diff) before
           # emitting. Sonnet 5 dropped the fixed budget_tokens knob in favor
-          # of output_config.effort — "low" mirrors the modest ~3k-token
-          # thinking budget the prior (Sonnet 4.6) config used.
+          # of output_config.effort — "medium" is the closer match to the
+          # prior (Sonnet 4.6) budget_tokens=3000/max_tokens=5000 config;
+          # per Anthropic's migration notes, Sonnet 5 at "medium" is roughly
+          # comparable in depth to Sonnet 4.6 at "high". "low" undershot the
+          # triage work this bot needs to do (catching hallucinated/
+          # already-rebutted/out-of-diff findings before posting).
           payload = {
               "model": "claude-sonnet-5",
               "max_tokens": 5000,
               "thinking": {"type": "adaptive"},
-              "output_config": {"effort": "low"},
+              "output_config": {"effort": "medium"},
               "system": [
                   {
                       "type": "text",


### PR DESCRIPTION
## What
Follow-up to #1878 (PR #1879). Bumps `output_config.effort` on the Claude PR review workflow from `"low"` to `"medium"`.

## Why
Operator feedback after #1879 shipped: `"low"` was a guess at matching the old `budget_tokens=3000`/`max_tokens=5000` config and likely undershoots — the review bot's job (triaging hallucinated findings, already-rebutted findings, out-of-diff findings before posting) benefits from more reasoning depth. Per Anthropic's Sonnet 5 migration notes, Sonnet 5 at `"medium"` is roughly comparable in depth to Sonnet 4.6 at `"high"`, which is a closer analogue to the prior config than `"low"` was.

Considered leaving `effort` unset to let it "fully adapt" — rejected: `effort` defaults to `"high"` when omitted, which is the most expensive setting and would undercut the cost-evaluation goal from #1878 entirely.

## Change
One field: `output_config.effort`: `"low"` → `"medium"`. Comment updated to explain the reasoning.

## Security model
No change — same as #1879 (no new untrusted-input interpolation).

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- All local pre-push gates green.
- This PR's own `review` check exercises the real Sonnet 5 + `effort: medium` call against this diff — see CI results below for whether it posts cleanly.

Closes #1880.