### PR TITLE
feat(#961): ESOP holdings as their own ownership-rollup memo overlay slice

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4550,7 +4550,7 @@ class _HolderModel(BaseModel):
 
 
 class _SliceModel(BaseModel):
-    category: Literal["insiders", "blockholders", "institutions", "etfs", "def14a_unmatched", "funds"]
+    category: Literal["insiders", "blockholders", "institutions", "etfs", "def14a_unmatched", "funds", "esop"]
     label: str
     total_shares: Decimal
     pct_outstanding: Decimal
@@ -5155,7 +5155,7 @@ def get_instrument_ownership_rollup(
 # not a holders slice. Treated as a valid filter value below: it
 # scopes the CSV to the treasury memo + residual rows only.
 _ROLLUP_CSV_SLICE_CATEGORIES: frozenset[str] = frozenset(
-    {"insiders", "blockholders", "institutions", "etfs", "def14a_unmatched", "funds"},
+    {"insiders", "blockholders", "institutions", "etfs", "def14a_unmatched", "funds", "esop"},
 )
 _ROLLUP_CSV_CATEGORIES: frozenset[str] = _ROLLUP_CSV_SLICE_CATEGORIES | {"treasury"}
 
@@ -5190,13 +5190,14 @@ def get_instrument_ownership_rollup_csv(
         default=None,
         description=(
             "Optional category filter: insiders | blockholders | institutions "
-            "| etfs | def14a_unmatched | funds | treasury. Slice categories "
-            "scope the export to that slice's holders; ``treasury`` drops all "
-            "slice holders and emits only the treasury + residual memo rows. "
-            "``funds`` is a memo-overlay slice — its rows render with the "
-            "``__memo:funds__`` category prefix in the output CSV so they are "
-            "outside the additive (treasury + residual + Σ pie-wedge) "
-            "reconciliation. Without ``category``, every slice is exported."
+            "| etfs | def14a_unmatched | funds | esop | treasury. Slice "
+            "categories scope the export to that slice's holders; ``treasury`` "
+            "drops all slice holders and emits only the treasury + residual "
+            "memo rows. ``funds`` and ``esop`` are memo-overlay slices — their "
+            "rows render with the ``__memo:<category>__`` prefix in the output "
+            "CSV so they are outside the additive (treasury + residual + "
+            "Σ pie-wedge) reconciliation. Without ``category``, every slice "
+            "is exported."
         ),
     ),
     conn: psycopg.Connection[object] = Depends(get_conn),

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-SliceCategory = Literal["insiders", "blockholders", "institutions", "etfs", "def14a_unmatched", "funds"]
+SliceCategory = Literal["insiders", "blockholders", "institutions", "etfs", "def14a_unmatched", "funds", "esop"]
 SourceTag = Literal["form4", "form3", "13d", "13g", "def14a", "13f", "nport"]
 CoverageState = Literal["no_data", "red", "unknown_universe", "amber", "green"]
 
@@ -69,17 +69,20 @@ CoverageState = Literal["no_data", "red", "unknown_universe", "amber", "green"]
 # §"Target chart decomposition". `pie_wedge` slices contribute to the
 # residual / concentration math (sum to ≤ shares_outstanding). Memo
 # overlays render as additional surface area without affecting the
-# pie — used by the funds slice today (N-PORT rows are fund-level
-# detail INSIDE the 13F-HR institutional aggregate; counting them
-# additively would double-count). Future ESOP / DRS / short-interest
-# overlays land here too (#961, etc.).
+# pie — used by the funds slice (N-PORT rows are fund-level detail
+# INSIDE the 13F-HR institutional aggregate; counting them additively
+# would double-count) and the esop slice (#961; DEF 14A plan-trustee
+# rows are a Rule 13d-3 deemed-ownership disclosure, same basis as
+# def14a_unmatched — not a distinct institutional holding). Future
+# DRS / short-interest overlays land here too.
 #   * ``institution_subset`` — fund-level detail inside the 13F-HR
 #     institutional aggregate (funds / N-PORT, #919).
 #   * ``proxy_disclosure`` — DEF 14A "Security Ownership of Certain
-#     Beneficial Owners" rows (#1659). A Rule 13d-3 deemed-ownership
-#     disclosure (SEC Item 403) where the same securities are listed
-#     under multiple owners (control groups, parent/sub, spouse
-#     attribution, "all officers as a group" aggregates) — overlapping,
+#     Beneficial Owners" rows (#1659), including ESOP/employee-benefit-
+#     plan rows (#961). A Rule 13d-3 deemed-ownership disclosure (SEC
+#     Item 403) where the same securities are listed under multiple
+#     owners (control groups, parent/sub, spouse attribution, "all
+#     officers as a group" aggregates, plan trustees) — overlapping,
 #     NOT additive. The real holders are already counted + de-duplicated
 #     via 13D/G, 13F, Form 4; the proxy is a cross-check, not a wedge
 #     (reverses #1627's additive treatment — see data-engineer I14/I16).
@@ -947,6 +950,61 @@ def _collect_funds_from_current(conn: psycopg.Connection[Any], instrument_id: in
     return holders
 
 
+def _collect_esop_from_current(conn: psycopg.Connection[Any], instrument_id: int) -> list[Holder]:
+    """Build the esop-slice holder set from ``ownership_esop_current`` (#961).
+
+    Each row is one (instrument, plan_name) DEF 14A-disclosed ESOP /
+    employee-benefit-plan holding — PK-deduped at the table level
+    (``ownership_esop_current`` PK is ``(instrument_id, plan_name)``),
+    same shape as :func:`_collect_funds_from_current`.
+
+    #843's spec (`docs/proposals/etl/def14a-bene-table-extension.md`)
+    originally called for tagging matching ``ownership_funds_current``
+    rows via ``plan_trustee_cik = fund_filer_cik``. Full-population
+    check (2026-07-03, all 15 populated rows) found ``plan_trustee_cik``
+    is NULL on every row — the DEF 14A beneficial-ownership table gives
+    free-text trustee names ("Kearny Bank ESOP Trust c/o Pentegra
+    Services, Inc."), never a resolvable CIK, so that join can never
+    match. Rendering ESOP as its own memo-overlay slice (mirroring
+    funds/def14a_unmatched) surfaces the same already-validated data
+    without depending on a join key that doesn't exist.
+
+    Holders surface ``filer_name = plan_name`` (the operator-visible
+    plan identity) with ``filer_cik=None`` (no resolvable trustee CIK)
+    and ``winning_source='def14a'`` (the schema's fixed source value).
+    ``pct_outstanding`` is filled in by :func:`_build_slice`.
+    """
+    holders: list[Holder] = []
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT plan_name, shares, source_accession, period_end
+            FROM ownership_esop_current
+            WHERE instrument_id = %s
+              AND shares IS NOT NULL
+              AND shares > 0
+            """,
+            (instrument_id,),
+        )
+        for row in cur.fetchall():
+            accession = str(row.get("source_accession") or "")
+            holders.append(
+                Holder(
+                    filer_cik=None,
+                    filer_name=str(row["plan_name"]),
+                    shares=Decimal(row["shares"]),
+                    pct_outstanding=Decimal(0),  # filled by _build_slice
+                    winning_source="def14a",
+                    winning_accession=accession,
+                    winning_edgar_url=edgar_archive_url(accession),
+                    as_of_date=row.get("period_end"),  # type: ignore[arg-type]
+                    filer_type=None,
+                    dropped_sources=(),
+                )
+            )
+    return holders
+
+
 def _read_treasury_from_current(
     conn: psycopg.Connection[Any], instrument_id: int
 ) -> tuple[Decimal | None, date | None]:
@@ -1153,6 +1211,7 @@ _SLICE_LABELS: dict[SliceCategory, str] = {
     "etfs": "ETFs",
     "def14a_unmatched": "Proxy-only (DEF 14A)",
     "funds": "Mutual funds (N-PORT)",
+    "esop": "Employee benefit plans (ESOP)",
 }
 
 
@@ -2137,6 +2196,7 @@ def _bucket_into_slices(
     outstanding: Decimal,
     *,
     funds_holders: list[Holder] | None = None,
+    esop_holders: list[Holder] | None = None,
 ) -> list[OwnershipSlice]:
     """Build slices from the per-category holder lists produced by
     :func:`_reconcile_owner_once` (each owner already in exactly one
@@ -2148,7 +2208,14 @@ def _bucket_into_slices(
     slice but does NOT contribute to residual / concentration math —
     N-PORT rows are fund-level detail of holdings already aggregated
     in the institutions slice via 13F-HR, so additive accounting would
-    double-count."""
+    double-count.
+
+    ``esop_holders`` (#961) arrives pre-deduped from
+    :func:`_collect_esop_from_current` (PK-deduped at table level) and
+    lands in its own ``esop`` memo-overlay slice, ``denominator_basis=
+    "proxy_disclosure"`` — same basis as ``def14a_unmatched``, since
+    ESOP rows are DEF 14A beneficial-ownership disclosure (SEC Item
+    403), not a distinct institutional holding."""
     slices: list[OwnershipSlice] = []
     for category in _CATEGORY_ORDER:
         holders = by_category.get(category)
@@ -2193,6 +2260,16 @@ def _bucket_into_slices(
                 list(funds_holders),
                 outstanding,
                 denominator_basis="institution_subset",
+            )
+        )
+
+    if esop_holders:
+        slices.append(
+            _build_slice(
+                "esop",
+                list(esop_holders),
+                outstanding,
+                denominator_basis="proxy_disclosure",
             )
         )
     return slices
@@ -3274,6 +3351,9 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     # so no cross-source dedup needed; lands in a memo-overlay slice
     # via _bucket_into_slices.
     funds_holders = _collect_funds_from_current(conn, instrument_id)
+    # DEF-14A-disclosed ESOP / employee-benefit-plan holdings (#961). PK-deduped
+    # at the table level; lands in its own memo-overlay slice via _bucket_into_slices.
+    esop_holders = _collect_esop_from_current(conn, instrument_id)
 
     # Dedup in two stages: (1) per-source winner selection — Form 4 amendment
     # chains and 13D/G amendment chains each collapse to their latest filing;
@@ -3341,9 +3421,9 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     class_row = _read_class_shares_outstanding(conn, instrument_id)
     if class_row is not None:
         # Largest single pie-wedge holder. Only ADDITIVE pie wedges (the
-        # by_category holders) count: funds (institution_subset) and DEF 14A
-        # (proxy_disclosure, #1659) are non-additive memo overlays — a deemed /
-        # overlapping figure must not veto the per-class denominator.
+        # by_category holders) count: funds (institution_subset) and DEF 14A /
+        # esop (proxy_disclosure, #1659/#961) are non-additive memo overlays —
+        # a deemed / overlapping figure must not veto the per-class denominator.
         # Denominator-independent.
         _pie_shares = [h.shares for _hs in by_category.values() for h in _hs]
         max_pie_holder_shares = max(_pie_shares, default=Decimal(0))
@@ -3389,6 +3469,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
         unmatched_def14a,
         effective_outstanding,
         funds_holders=funds_holders,
+        esop_holders=esop_holders,
     )
     residual = _compute_residual(effective_outstanding, slices, treasury)
     concentration = _compute_concentration(effective_outstanding, slices)
@@ -3495,7 +3576,7 @@ def build_rollup_csv(rollup: OwnershipRollup) -> str:
 
     # Emit pie-wedge slices first so the additive-sum invariant holds
     # against (treasury_shares + residual.shares + Σ pie-wedge holders)
-    # = shares_outstanding. Memo-overlay slices (funds, future ESOP /
+    # = shares_outstanding. Memo-overlay slices (funds, esop, future
     # DRS / short-interest) are emitted in a trailing block with the
     # ``__memo:<category>__`` prefix so spreadsheet consumers can
     # filter them OUT of any SUM(shares) reconciliation. Codex

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -41,7 +41,8 @@ export type OwnershipSliceCategory =
   | "institutions"
   | "etfs"
   | "def14a_unmatched"
-  | "funds";
+  | "funds"
+  | "esop";
 
 /**
  * Tags whether a slice contributes to the pie wedges that sum to

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -480,6 +480,7 @@ function OverlaySection({ slice }: OverlaySectionProps): JSX.Element {
   const { shown, remaining } = topHoldersByShares(slice.holders, _OVERLAY_TOP_N);
   const isFunds = slice.category === "funds";
   const isProxy = slice.category === "def14a_unmatched";
+  const isEsop = slice.category === "esop";
   const unit = isFunds ? "fund series" : "holders";
   return (
     <div
@@ -492,7 +493,9 @@ function OverlaySection({ slice }: OverlaySectionProps): JSX.Element {
           ? "fund-level detail of positions already counted in Institutions via 13F-HR. "
           : isProxy
             ? "DEF 14A beneficial ownership (Rule 13d-3): the same shares may be listed under multiple owners (control groups, parent/sub, “all officers as a group”), so it is shown as a cross-check, not added to the pie. The real holders are counted via 13D/G, 13F and Form 4. "
-            : "non-additive overlay. "}
+            : isEsop
+              ? "ESOP / employee-benefit-plan holdings disclosed in DEF 14A (Rule 13d-3, SEC Item 403) — a proxy cross-check, not added to the pie. "
+              : "non-additive overlay. "}
         Does not contribute to the pie or residual math.
       </p>
       <table className="w-full">

--- a/frontend/src/pages/OwnershipPage.tsx
+++ b/frontend/src/pages/OwnershipPage.tsx
@@ -100,9 +100,9 @@ const CATEGORY_LABELS: Record<CategoryKey, string> = {
 
 /** Rollup slice category → chart/table category. ``def14a_unmatched``
  *  is its own ``def14a`` category (#1627 — un-folded from insiders so
- *  the L2 filer rows match the un-folded wedges 1:1); ``funds`` is a
- *  non-additive N-PORT memo overlay (#919) and is excluded from the
- *  filer table entirely. */
+ *  the L2 filer rows match the un-folded wedges 1:1); ``funds`` and
+ *  ``esop`` (#961) are non-additive memo overlays and are excluded
+ *  from the filer table entirely. */
 const SLICE_TO_TABLE_CATEGORY: Record<
   OwnershipSliceCategory,
   CategoryKey | null
@@ -113,6 +113,7 @@ const SLICE_TO_TABLE_CATEGORY: Record<
   blockholders: "blockholders",
   def14a_unmatched: "def14a",
   funds: null,
+  esop: null,
 };
 
 export function OwnershipPage(): JSX.Element {

--- a/tests/test_ownership_rollup.py
+++ b/tests/test_ownership_rollup.py
@@ -24,12 +24,14 @@ from app.services import ownership_rollup
 from app.services.ownership_observations import (
     record_blockholder_observation,
     record_def14a_observation,
+    record_esop_observation,
     record_fund_observation,
     record_insider_observation,
     record_institution_observation,
     record_treasury_observation,
     refresh_blockholders_current,
     refresh_def14a_current,
+    refresh_esop_current,
     refresh_funds_current,
     refresh_insiders_current,
     refresh_institutions_current,
@@ -1517,6 +1519,41 @@ def _seed_funds_holding(
     refresh_funds_current(conn, instrument_id=instrument_id)
 
 
+def _seed_esop_holding(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int,
+    plan_name: str,
+    accession: str,
+    shares: str,
+    percent_of_class: str | None = None,
+    plan_trustee_name: str | None = None,
+    period_end: date = date(2026, 3, 31),
+) -> None:
+    """Seed a DEF-14A ESOP / employee-benefit-plan holding via the
+    canonical write-through helpers — mirrors what
+    ``app.services.def14a_ingest`` does in production for a
+    ``holder_role='esop'`` row. Used by #961 esop-slice tests."""
+    record_esop_observation(
+        conn,
+        instrument_id=instrument_id,
+        plan_name=plan_name,
+        plan_trustee_name=plan_trustee_name,
+        plan_trustee_cik=None,
+        source_document_id=accession,
+        source_accession=accession,
+        source_field=None,
+        source_url=None,
+        filed_at=datetime(period_end.year, period_end.month, 1, tzinfo=UTC),
+        period_start=None,
+        period_end=period_end,
+        ingest_run_id=uuid4(),
+        shares=Decimal(shares),
+        percent_of_class=Decimal(percent_of_class) if percent_of_class is not None else None,
+    )
+    refresh_esop_current(conn, instrument_id=instrument_id)
+
+
 class TestFundsSlice:
     """Funds slice (#919): N-PORT mutual-fund holdings render as a
     memo-overlay slice with ``denominator_basis='institution_subset'``.
@@ -1744,6 +1781,130 @@ class TestFundsSlice:
             "Vanguard 500 Index Fund",
             "iShares Core S&P 500",
         ]
+
+
+class TestEsopSlice:
+    """ESOP / employee-benefit-plan slice (#961): DEF 14A-disclosed plan
+    holdings render as their own memo-overlay slice with
+    ``denominator_basis='proxy_disclosure'`` — same basis as
+    ``def14a_unmatched`` (SEC Item 403 beneficial-ownership disclosure),
+    NOT ``institution_subset``. #843's original spec called for tagging
+    ``ownership_funds_current`` rows via a ``plan_trustee_cik =
+    fund_filer_cik`` join, but a full-population check of every
+    populated ``ownership_esop_current`` row (2026-07-03) found
+    ``plan_trustee_cik`` is NULL on all of them — the DEF 14A table
+    gives free-text trustee names, never a resolvable CIK, so that join
+    can never match. Rendering ESOP as its own slice (this class)
+    surfaces the same data without depending on that dead join."""
+
+    def test_esop_slice_renders_with_memo_overlay_basis(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_070, symbol="ESOP1")
+        _seed_outstanding(conn, instrument_id=789_070, shares="10000000")
+        _seed_esop_holding(
+            conn,
+            instrument_id=789_070,
+            plan_name="ESOP1 Employee Stock Ownership Plan",
+            accession="0001234500-26-000200",
+            shares="500000",
+            percent_of_class="5.0000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(
+            conn,
+            symbol="ESOP1",
+            instrument_id=789_070,
+        )
+
+        esop = [s for s in rollup.slices if s.category == "esop"]
+        assert len(esop) == 1, "esop slice must surface when DEF 14A ESOP data exists"
+        esop_slice = esop[0]
+        assert esop_slice.denominator_basis == "proxy_disclosure"
+        assert esop_slice.label == "Employee benefit plans (ESOP)"
+        assert esop_slice.total_shares == Decimal("500000")
+        assert esop_slice.filer_count == 1
+        holder = esop_slice.holders[0]
+        assert holder.filer_name == "ESOP1 Employee Stock Ownership Plan"
+        assert holder.filer_cik is None
+        assert holder.winning_source == "def14a"
+        assert holder.shares == Decimal("500000")
+
+    def test_esop_slice_excluded_from_residual_math(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Critical invariant: esop slice is a memo overlay, NOT
+        additive in the pie. Residual must equal outstanding minus
+        pie-wedge slices only (insiders here), with the esop total NOT
+        subtracted."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_071, symbol="ESOP2")
+        _seed_outstanding(conn, instrument_id=789_071, shares="10000000")
+        _seed_form4(
+            conn,
+            accession="0001234500-26-000201",
+            instrument_id=789_071,
+            filer_cik="0001234569",
+            filer_name="Founder Holder",
+            txn_date=date(2026, 2, 1),
+            post_transaction_shares="1000000",
+        )
+        _seed_esop_holding(
+            conn,
+            instrument_id=789_071,
+            plan_name="ESOP2 Employee Stock Ownership Plan",
+            accession="0001234500-26-000202",
+            shares="500000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(
+            conn,
+            symbol="ESOP2",
+            instrument_id=789_071,
+        )
+
+        esop = [s for s in rollup.slices if s.category == "esop"]
+        assert len(esop) == 1
+        assert esop[0].total_shares == Decimal("500000")
+
+        # Residual = outstanding - insiders only. Esop slice NOT subtracted.
+        assert rollup.residual.shares == Decimal("9000000")
+        assert not rollup.residual.oversubscribed
+        assert rollup.concentration.pct_outstanding_known == Decimal("0.1")
+
+    def test_no_esop_slice_when_no_def14a_esop_data(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Esop slice is omitted entirely (not zero-row) when no DEF
+        14A ESOP data exists — ``if esop_holders:`` in the bucket
+        router means an empty list yields no slice in the payload."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_072, symbol="ESOP3")
+        _seed_outstanding(conn, instrument_id=789_072, shares="5000000")
+        _seed_form4(
+            conn,
+            accession="0001234500-26-000203",
+            instrument_id=789_072,
+            filer_cik="0001234570",
+            filer_name="Lone Insider",
+            txn_date=date(2026, 2, 1),
+            post_transaction_shares="100000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(
+            conn,
+            symbol="ESOP3",
+            instrument_id=789_072,
+        )
+        esop = [s for s in rollup.slices if s.category == "esop"]
+        assert esop == [], "no esop slice when DEF 14A ESOP data is empty"
 
 
 class TestEmptyStates:


### PR DESCRIPTION
## What

Exposes `ownership_esop_current` (already populated by #843/PR12's DEF 14A ESOP parser + write-through) as its own memo-overlay slice (`category="esop"`) in the ownership rollup, mirroring the existing `funds` slice pattern. No schema change — the table already exists and is populated; this wires the read path + frontend rendering that was never built.

## Why the design differs from #961's original text

#961 as filed called for tagging matching `ownership_funds_current` rows via `plan_trustee_cik = fund_filer_cik` (per `docs/proposals/etl/def14a-bene-table-extension.md` §"Rollup integration"). Before implementing, I ran the required full-population check: **all 15 populated `ownership_esop_current` rows (14 instruments) have `plan_trustee_cik = NULL`.** The DEF 14A beneficial-ownership table gives free-text trustee names ("Kearny Bank ESOP Trust c/o Pentegra Services, Inc.", "Employee Stock Ownership Plan") — never a resolvable CIK — so the specced join can never match on real data. Shipping it as specced would render zero badges, failing #961's own acceptance criterion #1.

Instead: render ESOP as its own memo-overlay slice, `denominator_basis="proxy_disclosure"` (same basis as `def14a_unmatched` — SEC Item 403 beneficial-ownership disclosure, not a distinct institutional holding; NOT `institution_subset`, which is specifically for N-PORT fund-level detail inside the 13F-HR aggregate). This surfaces the same already-validated data (source-rule + cross-source verified at #843 landing time) without depending on a join key that doesn't exist.

## Source rule

SEC Item 403 (Regulation S-K) / Rule 13d-3 governs the underlying DEF 14A beneficial-ownership disclosure — same basis already established for `def14a_unmatched` (#1659). The ESOP-specific classification (which DEF 14A rows are plan-trustee holdings) was fixed by #843's parser + spec; this PR does not change that classification, only the read/render path.

## Full-population verification

Queried dev DB (2026-07-03): `ownership_esop_current` has 15 rows across 14 instruments, all with `plan_trustee_cik IS NULL` (0/15). Spot-checked rows (Kearny Bank ESOP Trust, Hawkins ESOP, Sound Financial Bancorp ESOP, etc.) — all genuine ESOP/401(k)/profit-sharing plan disclosures, no false positives from the underlying #843 regex.

## Changes

- **Backend** (`app/services/ownership_rollup.py`): `_collect_esop_from_current` (mirrors `_collect_funds_from_current`), wired into `_bucket_into_slices` + `get_ownership_rollup`. `"esop"` added to `SliceCategory` and `_SLICE_LABELS`.
- **API** (`app/api/instruments.py`): `"esop"` added to `_SliceModel.category` and `_ROLLUP_CSV_SLICE_CATEGORIES` (CSV export filter).
- **Frontend**: `OwnershipSliceCategory` union (`api/ownership.ts`); `SLICE_TO_TABLE_CATEGORY` excludes `esop` from the L2 filer table like `funds` (`OwnershipPage.tsx`); `OverlaySection` gets ESOP-specific memo copy (`OwnershipPanel.tsx`) — the overlay renderer is already `denominator_basis`-driven, so no new UI structure was needed.
- **Tests**: `TestEsopSlice` in `tests/test_ownership_rollup.py` — renders with correct basis/label/holder identity, excluded from residual/concentration math (critical non-additive invariant), absent when no data. Mirrors `TestFundsSlice`'s shape for the parallel mechanism.

## Verification

- `uv run pytest tests/test_ownership_rollup.py -k "Esop or Funds"` — 8/8 pass.
- `uv run pytest -m "not db"` (fast tier) + `uv run pytest tests/smoke` — pass.
- `uv run pyright`, `uv run ruff check .`, `uv run ruff format --check .` — clean.
- Frontend: `pnpm typecheck`, `pnpm exec vitest run` on touched files (23/23), full `pnpm test:unit` (114 files / 1190 tests) — pass.
- Codex `codex exec review --uncommitted` pre-push: no issues found.
- **Not applicable**: this PR does not touch ETL/parser/schema/migration code (no new ingest path, no schema change — `ownership_esop_current` was built and populated by #843/PR12), so the ETL-specific Definition-of-Done clauses (smoke panel backfill, `sec_rebuild`, live `:8000` verification) don't apply. The dev API/vite dev-stack (`:8000`/`:5173`) runs from a separate checkout (`~/Dev/eBull`) outside this autonomy worktree, so live-endpoint verification isn't available pre-merge from here; correctness is established via the integration tests above, which exercise the real `ownership_esop_current` schema/data shape end-to-end.

## Conscious tradeoffs

- `filer_cik` is always `None` on esop holders (no resolvable trustee CIK exists in the data) — the frontend/CSV already handle `filer_cik: null` for other slices, no special-casing needed.
- Left `plan_trustee_cik` unused in the read path rather than deleting the column — it's schema-populated infrastructure for a future identity-resolution effort (matching free-text trustee names to a CIK), out of scope here.

Closes #961.