### PR TITLE
fix(#316): correct BUY/ADD action labeling on manual order entry

### DIFF
--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -26,6 +26,7 @@ import type {
   FilingsListResponse,
   NewsListResponse,
   RankingsListResponse,
+  RecommendationsListResponse,
 } from "@/api/types";
 
 vi.mock("@/api/filings", () => ({ fetchFilings: vi.fn() }));
@@ -35,16 +36,19 @@ vi.mock("@/api/rankings", () => ({
   RANKINGS_PAGE_SIZE: 50,
 }));
 vi.mock("@/api/copyTrading", () => ({ fetchCopyTrading: vi.fn() }));
+vi.mock("@/api/recommendations", () => ({ fetchRecommendations: vi.fn() }));
 
 import { fetchFilings } from "@/api/filings";
 import { fetchNews } from "@/api/news";
 import { fetchRankings } from "@/api/rankings";
 import { fetchCopyTrading } from "@/api/copyTrading";
+import { fetchRecommendations } from "@/api/recommendations";
 
 const mockedFilings = vi.mocked(fetchFilings);
 const mockedNews = vi.mocked(fetchNews);
 const mockedRankings = vi.mocked(fetchRankings);
 const mockedCopyTrading = vi.mocked(fetchCopyTrading);
+const mockedRecommendations = vi.mocked(fetchRecommendations);
 
 function filingsEmpty(instrumentId: number): FilingsListResponse {
   return {
@@ -172,15 +176,48 @@ function copyTradingEmpty(): CopyTradingResponse {
   };
 }
 
+function recommendationsEmpty(): RecommendationsListResponse {
+  return { items: [], total: 0, offset: 0, limit: 5 };
+}
+
+function recommendationsWith(instrumentId: number): RecommendationsListResponse {
+  return {
+    items: [
+      {
+        recommendation_id: 1,
+        instrument_id: instrumentId,
+        symbol: "AAPL",
+        company_name: "Apple Inc.",
+        action: "BUY",
+        status: "executed",
+        rationale: "Strong momentum.",
+        score_id: 1,
+        model_version: "v1.2-balanced",
+        suggested_size_pct: 5,
+        target_entry: null,
+        cash_balance_known: true,
+        data_completeness: 0.9,
+        completeness_tier: "full",
+        created_at: "2026-06-01T00:00:00Z",
+      },
+    ],
+    total: 1,
+    offset: 0,
+    limit: 5,
+  };
+}
+
 beforeEach(() => {
   mockedFilings.mockReset();
   mockedNews.mockReset();
   mockedRankings.mockReset();
   mockedCopyTrading.mockReset();
+  mockedRecommendations.mockReset();
   mockedFilings.mockResolvedValue(filingsEmpty(42));
   mockedNews.mockResolvedValue(newsEmpty(42));
   mockedRankings.mockResolvedValue(rankingsEmpty());
   mockedCopyTrading.mockResolvedValue(copyTradingEmpty());
+  mockedRecommendations.mockResolvedValue(recommendationsEmpty());
 });
 
 function renderRail(props: {
@@ -209,13 +246,14 @@ function renderRail(props: {
 }
 
 describe("RightRail", () => {
-  it("renders all three section headers", async () => {
+  it("renders all section headers", async () => {
     renderRail();
     expect(
       await screen.findByText(/Recent filings/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/Peer snapshot/i)).toBeInTheDocument();
     expect(screen.getByText(/Recent news/i)).toBeInTheDocument();
+    expect(screen.getByText(/Recommendation history/i)).toBeInTheDocument();
   });
 
   it("renders filing rows when data arrives", async () => {
@@ -312,6 +350,37 @@ describe("RightRail", () => {
     const [query, limit] = mockedRankings.mock.calls[0]!;
     expect(query).toMatchObject({ sector_spdr: "XLV" });
     expect(limit).toBe(6);
+  });
+});
+
+describe("RightRail — recommendation history (#316)", () => {
+  it("shows an empty state when the instrument has no recommendations", async () => {
+    renderRail();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No recommendations for this instrument yet/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders action + status badges when recommendations exist", async () => {
+    mockedRecommendations.mockResolvedValue(recommendationsWith(42));
+    renderRail({ instrumentId: 42 });
+    await waitFor(() => {
+      expect(screen.getByText("BUY")).toBeInTheDocument();
+    });
+    expect(screen.getByText("executed")).toBeInTheDocument();
+  });
+
+  it("scopes the fetch to instrument_id", async () => {
+    renderRail({ instrumentId: 99 });
+    await waitFor(() => {
+      expect(mockedRecommendations).toHaveBeenCalledWith(
+        { action: null, status: null, instrument_id: 99 },
+        0,
+        5,
+      );
+    });
   });
 });
 

--- a/frontend/src/components/instrument/RightRail.tsx
+++ b/frontend/src/components/instrument/RightRail.tsx
@@ -11,6 +11,9 @@
  *      exposure. Placeholder scaffold; deeper design deferred to a
  *      follow-up spec if scope grows.
  *   4. Recent news (last 3) — headline + sentiment badge
+ *   5. Recommendation history (last 5) — action/status badges + date;
+ *      remaining slice of #316 (portfolio-manager output for this
+ *      instrument, alongside the thesis/score already on the strip)
  */
 import { Link } from "react-router-dom";
 
@@ -18,11 +21,13 @@ import { fetchCopyTrading } from "@/api/copyTrading";
 import { fetchFilings } from "@/api/filings";
 import { fetchNews } from "@/api/news";
 import { fetchRankings } from "@/api/rankings";
+import { fetchRecommendations } from "@/api/recommendations";
 import type {
   CopyTraderSummary,
   FilingItem,
   NewsItem,
   RankingItem,
+  RecommendationListItem,
 } from "@/api/types";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { useAsync } from "@/lib/useAsync";
@@ -67,6 +72,7 @@ export function RightRail({
       />
       <CopyExposure instrumentId={instrumentId} />
       <RecentNews instrumentId={instrumentId} />
+      <RecommendationHistory instrumentId={instrumentId} />
     </aside>
   );
 }
@@ -367,6 +373,69 @@ function NewsRow({ n }: { n: NewsItem }) {
         <span>{new Date(n.event_time).toLocaleDateString()}</span>
         {n.source ? <span>· {n.source}</span> : null}
       </div>
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recommendation history
+// ---------------------------------------------------------------------------
+
+const RECOMMENDATION_ACTION_TONE: Record<string, string> = {
+  BUY: "bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300",
+  ADD: "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300",
+  HOLD: "bg-slate-100 dark:bg-slate-800 text-slate-600",
+  EXIT: "bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300",
+  CONSIDERED: "bg-slate-100 dark:bg-slate-800 text-slate-600",
+};
+
+function RecommendationHistory({ instrumentId }: { instrumentId: number }) {
+  const { data, error, loading, refetch } = useAsync(
+    () =>
+      fetchRecommendations(
+        { action: null, status: null, instrument_id: instrumentId },
+        0,
+        5,
+      ),
+    [instrumentId],
+  );
+  return (
+    <Section title="Recommendation history">
+      {loading && <SectionSkeleton rows={3} />}
+      {error !== null && <SectionError onRetry={refetch} />}
+      {!loading && error === null && (data?.items.length ?? 0) === 0 && (
+        <div className="text-xs text-slate-500">
+          No recommendations for this instrument yet.
+        </div>
+      )}
+      {!loading && error === null && (data?.items.length ?? 0) > 0 && (
+        <ul className="space-y-1.5 text-xs">
+          {(data?.items ?? []).map((r) => (
+            <RecommendationRow key={r.recommendation_id} r={r} />
+          ))}
+        </ul>
+      )}
+    </Section>
+  );
+}
+
+function RecommendationRow({ r }: { r: RecommendationListItem }) {
+  const tone =
+    RECOMMENDATION_ACTION_TONE[r.action] ??
+    "bg-slate-100 dark:bg-slate-800 text-slate-600";
+  return (
+    <li className="flex items-baseline justify-between gap-2">
+      <span className="flex items-baseline gap-2 truncate">
+        <span
+          className={`inline-block min-w-[40px] rounded px-1 py-0.5 text-center text-[10px] font-semibold ${tone}`}
+        >
+          {r.action}
+        </span>
+        <span className="truncate text-slate-600">{r.status}</span>
+      </span>
+      <span className="shrink-0 text-[10px] text-slate-500">
+        {new Date(r.created_at).toLocaleDateString()}
+      </span>
     </li>
   );
 }

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -270,6 +270,52 @@ describe("SummaryStrip — action gating", () => {
     expect(screen.getByTestId("thesis-badge").textContent).toContain("stale");
   });
 
+  it("labels the action Buy when unheld and Add when held (#316)", () => {
+    const { rerender } = render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByTestId("action-add").textContent).toBe("Buy");
+
+    rerender(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={heldPosition()}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByTestId("action-add").textContent).toBe("Add");
+  });
+
+  it("defaults the action label to Add (not Buy) while position state is loading or errored (#316)", () => {
+    const { rerender } = render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+        positionLoaded={false}
+      />,
+    );
+    expect(screen.getByTestId("action-add").textContent).toBe("Add");
+
+    rerender(
+      <SummaryStrip
+        summary={summary()}
+        thesis={freshThesis()}
+        position={null}
+        {...noopProps()}
+        positionError={true}
+      />,
+    );
+    expect(screen.getByTestId("action-add").textContent).toBe("Add");
+  });
+
   it("hides Add when instrument is not tradable", () => {
     render(
       <SummaryStrip

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -10,7 +10,11 @@
  * Action gating:
  *   - Close — only when `heldUnits > 0`.
  *   - Generate thesis — when no thesis, or thesis is > 30d old.
- *   - Add — always enabled on tradable instruments.
+ *   - Add/Buy — always enabled on tradable instruments. Labeled "Buy" only
+ *     once the position fetch has resolved and confirmed no holding;
+ *     "Add" is the default (loading, error, or held), matching the action
+ *     OrderEntryModal actually submits (#316) and avoiding a wrong CTA
+ *     flash while position state is still unknown.
  */
 import type {
   InstrumentSummary,
@@ -253,7 +257,7 @@ export function SummaryStrip({
               onClick={onAdd}
               className="rounded border border-blue-300 bg-white dark:bg-slate-900 px-3 py-1 text-xs font-medium text-blue-700 hover:bg-blue-50"
             >
-              Add
+              {positionLoaded && !positionError && !isHeld ? "Buy" : "Add"}
             </button>
           ) : null}
           {canCloseFromStrip ? (

--- a/frontend/src/components/orders/OrderEntryModal.test.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for OrderEntryModal (#313).
+ * Tests for OrderEntryModal (#313, #316).
  *
  * Pins the contract defined in the spec:
  *   - Happy path: valid amount -> onFilled -> onRequestClose (in that order)
@@ -9,6 +9,7 @@
  *   - Network error: fixed phrase surfaced
  *   - Price-source flag: amber rendering when valuation_source != "quote"
  *   - Unmount-during-submit: no unhandled rejection
+ *   - Action selection: BUY when total_units=0, ADD when total_units>0 (#316)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
@@ -87,6 +88,22 @@ function detailFor(instrumentId: number): InstrumentPositionDetail {
         total_fees: 0,
       },
     ],
+  };
+}
+
+function unheldDetailFor(instrumentId: number): InstrumentPositionDetail {
+  return {
+    instrument_id: instrumentId,
+    symbol: "MSFT",
+    company_name: "Microsoft Corp.",
+    currency: "USD",
+    current_price: 400,
+    total_units: 0,
+    avg_entry: null,
+    total_invested: 0,
+    total_value: 0,
+    total_pnl: 0,
+    trades: [],
   };
 }
 
@@ -284,6 +301,77 @@ describe("OrderEntryModal", () => {
     expect(
       screen.getByText(/may not reflect fill price/i),
     ).toBeInTheDocument();
+  });
+
+  it("submits action=BUY (not ADD) and shows a Buy title when the instrument has no existing position", async () => {
+    mockedFetchDetail.mockReset();
+    // Not `.mockResolvedValueOnce` — handleSubmit re-fetches the position
+    // right before submit (#316 TOCTOU fix), so both the mount-time load
+    // and the submit-time refetch must resolve unheld here.
+    mockedFetchDetail.mockResolvedValue(unheldDetailFor(9));
+    mockedPlaceOrder.mockResolvedValueOnce(orderFilled());
+    const user = userEvent.setup();
+    renderModal({ instrumentId: 9, symbol: "MSFT", companyName: "Microsoft Corp." });
+
+    await waitFor(() => screen.getByText(/Latest price:/));
+    expect(screen.getByRole("heading", { name: "Buy — MSFT" })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/Notional/), "500");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => expect(mockedPlaceOrder).toHaveBeenCalled());
+    expect(mockedPlaceOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "BUY" }),
+    );
+  });
+
+  it("re-fetches the position at submit time and uses the fresh action, not the mount-time snapshot (#316 TOCTOU)", async () => {
+    // Instrument was unheld when the modal mounted (title says "Buy"),
+    // but a fill lands elsewhere while the operator is still looking at
+    // the modal — by submit time the instrument IS held. The submitted
+    // action must be ADD (matching reality), not the stale BUY.
+    mockedFetchDetail.mockReset();
+    mockedFetchDetail.mockResolvedValueOnce(unheldDetailFor(9));
+    mockedFetchDetail.mockResolvedValueOnce(detailFor(9)); // held by submit time
+    mockedPlaceOrder.mockResolvedValueOnce(orderFilled());
+    const user = userEvent.setup();
+    renderModal({ instrumentId: 9, symbol: "MSFT", companyName: "Microsoft Corp." });
+
+    await waitFor(() => screen.getByText(/Latest price:/));
+    expect(screen.getByRole("heading", { name: "Buy — MSFT" })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/Notional/), "500");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => expect(mockedPlaceOrder).toHaveBeenCalled());
+    expect(mockedPlaceOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "ADD" }),
+    );
+    expect(mockedFetchDetail).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to the last-known action if the submit-time re-fetch fails", async () => {
+    mockedFetchDetail.mockReset();
+    mockedFetchDetail.mockResolvedValueOnce(unheldDetailFor(9));
+    mockedFetchDetail.mockRejectedValueOnce(new Error("network blip"));
+    mockedPlaceOrder.mockResolvedValueOnce(orderFilled());
+    const user = userEvent.setup();
+    renderModal({ instrumentId: 9, symbol: "MSFT", companyName: "Microsoft Corp." });
+
+    await waitFor(() => screen.getByText(/Latest price:/));
+    await user.type(screen.getByLabelText(/Notional/), "500");
+    await user.click(screen.getByRole("button", { name: /Place demo order/ }));
+
+    await waitFor(() => expect(mockedPlaceOrder).toHaveBeenCalled());
+    expect(mockedPlaceOrder).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "BUY" }),
+    );
+  });
+
+  it("shows an Add title when the instrument has an existing position", async () => {
+    renderModal();
+    await waitFor(() => screen.getByText(/Latest price:/));
+    expect(screen.getByRole("heading", { name: "Add — AAPL" })).toBeInTheDocument();
   });
 
   it("still calls onFilled when unmounted mid-submit if the order actually filled", async () => {

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -75,6 +75,10 @@ export function OrderEntryModal({
   const [rawInput, setRawInput] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Set from the submit-time re-fetch so the title can't say "Buy" while
+  // the order actually submitted is ADD (or vice versa) — see handleSubmit.
+  const [resolvedAction, setResolvedAction] =
+    useState<PlaceOrderRequest["action"] | null>(null);
 
   // mountedRef: guard setState against the "user escapes the modal
   // mid-submit then the parent unmounts us" race (prevention #127).
@@ -116,6 +120,7 @@ export function OrderEntryModal({
       // than blocking submission on a transient network hiccup.
       action = isAdd ? "ADD" : "BUY";
     }
+    if (mountedRef.current) setResolvedAction(action);
     const body: PlaceOrderRequest = {
       instrument_id: instrumentId,
       action,
@@ -161,7 +166,8 @@ export function OrderEntryModal({
     }
   }
 
-  const title = `${isAdd ? "Add" : "Buy"} — ${symbol}`;
+  const displayIsAdd = resolvedAction === null ? isAdd : resolvedAction === "ADD";
+  const title = `${displayIsAdd ? "Add" : "Buy"} — ${symbol}`;
 
   return (
     <Modal isOpen={isOpen} onRequestClose={onRequestClose} label={title}>

--- a/frontend/src/components/orders/OrderEntryModal.tsx
+++ b/frontend/src/components/orders/OrderEntryModal.tsx
@@ -1,14 +1,19 @@
 /**
- * OrderEntryModal — ADD-to-existing-position flow (issue #313).
+ * OrderEntryModal — BUY / ADD order-entry flow (issues #313, #316).
  *
- * Launches from PortfolioPage. Renders:
+ * Launches from PortfolioPage and InstrumentPage. Renders:
  *   - DemoLivePill (safety-state-ui pattern)
  *   - Native-currency price context from /portfolio/instruments/:id
  *   - Amount / Units toggle + numeric input with live preview
- *   - Submit -> POST /portfolio/orders with action=ADD
+ *   - Submit -> POST /portfolio/orders with action=BUY (no existing position)
+ *     or action=ADD (position.total_units > 0) — the position fetch this
+ *     modal already makes for price context also decides the action, so the
+ *     audit trail (orders/decision_audit) correctly distinguishes a new
+ *     position from a top-up, matching the BUY/ADD split the execution
+ *     guard and portfolio manager already use (docs/settled-decisions.md
+ *     "Action-specific behaviour").
  *
  * Intentionally minimal vs the spec:
- *   - Action is always "ADD" in this PR (new-instrument BUY ships in #316).
  *   - No SL / TP / TSL / leverage UI. Payload sends the backend defaults
  *     explicitly for readability.
  *
@@ -85,6 +90,7 @@ export function OrderEntryModal({
   const priceIsUsable =
     detail.data?.current_price != null && detail.data.current_price > 0;
   const detailLoaded = detail.data !== null;
+  const isAdd = (detail.data?.total_units ?? 0) > 0;
   const canSubmit =
     detailLoaded &&
     !detail.loading &&
@@ -96,9 +102,23 @@ export function OrderEntryModal({
     if (parsedValue === null) return;
     setSubmitting(true);
     setErrorMessage(null);
+    // Re-fetch the position right before submit rather than trusting the
+    // snapshot from mount time — the operator may sit on an open modal
+    // while another order fills elsewhere, and a stale BUY/ADD call here
+    // would mislabel the audit trail (orders / decision_audit) even
+    // though the backend fills identically either way.
+    let action: PlaceOrderRequest["action"];
+    try {
+      const fresh = await fetchInstrumentPositions(instrumentId);
+      action = fresh.total_units > 0 ? "ADD" : "BUY";
+    } catch {
+      // Re-fetch failure: fall back to the last-known snapshot rather
+      // than blocking submission on a transient network hiccup.
+      action = isAdd ? "ADD" : "BUY";
+    }
     const body: PlaceOrderRequest = {
       instrument_id: instrumentId,
-      action: "ADD",
+      action,
       amount: mode === "amount" ? parsedValue : null,
       units: mode === "units" ? parsedValue : null,
       stop_loss_rate: null,
@@ -141,7 +161,7 @@ export function OrderEntryModal({
     }
   }
 
-  const title = `Add — ${symbol}`;
+  const title = `${isAdd ? "Add" : "Buy"} — ${symbol}`;
 
   return (
     <Modal isOpen={isOpen} onRequestClose={onRequestClose} label={title}>


### PR DESCRIPTION
## What

`OrderEntryModal` always submitted `action="ADD"`, even for a brand-new position with no prior holding, mislabeling the audit trail (`orders`, `decision_audit`). The system elsewhere distinguishes `BUY` (new position) from `ADD` (top-up) — see `docs/settled-decisions.md` "Action-specific behaviour" (execution guard) and `app/api/orders.py:56` (`PlaceOrderRequest.action: Literal["BUY", "ADD"]`). Backend fill/persist logic already treats both identically (`action in ("BUY", "ADD")` throughout `app/api/orders.py`), so this is a UI-only correctness fix — no backend change.

This closes out the remaining scope of #316 "P1-4: Instrument terminal" per the issue's own rescope comments:
- "Right rail" was already shipped via the #585 chart-redesign epic — not a stub, confirmed by reading `RightRail.tsx` (373 lines, 4 live sections).
- "New-instrument BUY on the instrument page" already mounted (`OrderEntryModal` is reachable from both `PortfolioPage` and `InstrumentPage`), just mislabeled — that's the fix here.
- "Recommendations history" was genuinely unbuilt — added as a 5th `RightRail` section.

## Changes

- **`OrderEntryModal.tsx`**: derives `action` from the position snapshot (`total_units > 0` → `ADD`, else `BUY`); title/button text follow (`"Buy — SYMBOL"` / `"Add — SYMBOL"`). Re-fetches the position immediately before submit (not just at mount) so a fill landing elsewhere while the modal sits open doesn't stale-label the submitted order — closes a TOCTOU window Codex flagged in review. Falls back to the mount-time snapshot if the re-fetch itself fails (doesn't block submission on a transient network hiccup).
- **`SummaryStrip.tsx`**: the strip's own Add/Buy button mirrors the same label. Defaults to `"Add"` (the pre-existing, safe label) while position state is loading or errored, only switching to `"Buy"` once the fetch has positively confirmed no holding — Codex flagged the naive version as flashing the wrong CTA during load/error.
- **`RightRail.tsx`**: new "Recommendation history" section (last 5 recommendations, action + status badges, date) wiring the existing `fetchRecommendations({instrument_id})` API — same independent-fetch pattern as the sibling `RecentFilings`/`RecentNews` sections in the same file.

## Security / safety model

No new write paths. `OrderEntryModal` still posts to the existing gated `POST /portfolio/orders` (kill-switch check, `enable_live_trading` demo/live gate, auth via `require_session_or_service_token`) — this PR only changes which of the two already-legal `action` values gets sent, and adds a read-only recommendation-history fetch. No trade was executed, approved, or simulated by me while building/testing this (all local dev-DB reads via mocked API calls in tests; no live order endpoint hit).

## Testing

- `pnpm typecheck` — clean.
- `pnpm test:unit` — 1199/1199 pass (114 files), including 4 new/updated tests: BUY-vs-ADD action selection, TOCTOU re-fetch-at-submit, re-fetch-failure fallback, SummaryStrip label gating on loading/error state, and 3 new RightRail recommendation-history tests (empty state, populated state, query scoping).
- `uv run ruff check . && ruff format --check .` — clean (no Python changed).
- Full repo pre-push gate (fast pytest tier + smoke + dark-mode class check) — green.

No backend/schema/parser changes, so the ETL "additional clauses" (smoke panel, cross-source verify, backfill, rollup-figure check) in `.claude/CLAUDE.md` don't apply — this PR is frontend-only.

## Tradeoffs

- Re-fetching position at submit time adds one extra network round-trip to the submit path. Accepted: correctness of the audit trail outweighs the latency, and the fetch is cheap (single-instrument lookup already used for price context).
- Recommendation history has no "view all" link / detail route — `fetchRecommendation(id)` and a `/recommendations/:id` detail page don't exist yet. Kept to a plain read-only list matching the rail's existing minimal-card style; a follow-up can add drill-through if the operator wants it.

Closes #316.