### PR TITLE
fix(#1893): add Prev/Next pagination to instrument Filings tab

### DIFF
--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -416,10 +416,13 @@ function redFlagBadge(score: number | null) {
   );
 }
 
+const FILINGS_PAGE_SIZE = 25;
+
 function FilingsTab({ instrumentId }: { instrumentId: number }) {
+  const [offset, setOffset] = useState(0);
   const { data, error, loading } = useAsync<FilingsListResponse>(
-    () => fetchFilings(instrumentId, 0, 25),
-    [instrumentId],
+    () => fetchFilings(instrumentId, offset, FILINGS_PAGE_SIZE),
+    [instrumentId, offset],
   );
 
   if (loading) return <SectionSkeleton rows={5} />;
@@ -434,6 +437,13 @@ function FilingsTab({ instrumentId }: { instrumentId: number }) {
       </Section>
     );
   }
+
+  const total = data.total;
+  const pageCount = data.items.length;
+  const rangeStart = total === 0 ? 0 : offset + 1;
+  const rangeEnd = offset + pageCount;
+  const hasPrev = offset > 0;
+  const hasNext = offset + FILINGS_PAGE_SIZE < total;
 
   return (
     <Section title={`Filings (${data.total})`}>
@@ -476,6 +486,29 @@ function FilingsTab({ instrumentId }: { instrumentId: number }) {
           </li>
         ))}
       </ul>
+      <div className="mt-3 flex items-center justify-between border-t border-slate-100 dark:border-slate-800 pt-3 text-xs text-slate-500">
+        <span className="tabular-nums">
+          Showing {rangeStart}–{rangeEnd} of {total}
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setOffset((o) => Math.max(0, o - FILINGS_PAGE_SIZE))}
+            disabled={!hasPrev}
+            className="rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1 font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            ‹ Prev
+          </button>
+          <button
+            type="button"
+            onClick={() => setOffset((o) => o + FILINGS_PAGE_SIZE)}
+            disabled={!hasNext}
+            className="rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-1 font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next ›
+          </button>
+        </div>
+      </div>
     </Section>
   );
 }

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -420,6 +420,9 @@ const FILINGS_PAGE_SIZE = 25;
 
 function FilingsTab({ instrumentId }: { instrumentId: number }) {
   const [offset, setOffset] = useState(0);
+  useEffect(() => {
+    setOffset(0);
+  }, [instrumentId]);
   const { data, error, loading } = useAsync<FilingsListResponse>(
     () => fetchFilings(instrumentId, offset, FILINGS_PAGE_SIZE),
     [instrumentId, offset],


### PR DESCRIPTION
## What

`FilingsTab` (`frontend/src/pages/InstrumentPage.tsx`) fetched a single
`offset=0/limit=25` page regardless of the real total. Any instrument with
>25 `filing_events` rows had the rest permanently inaccessible — AAPL:
"Filings (792)" heading, only 24 ever rendered, no pagination control.
Found via automated FE-QA sweep (2026-07-04), root-caused to `InstrumentPage.tsx`
line ~421 (`useAsync(() => fetchFilings(instrumentId, 0, 25), [instrumentId])`,
never reading `data.total` or advancing offset) — introduced flat/one-shot in
`e12d081e` (#366), not a regression.

## Changes

`FilingsTab` now carries `offset` React state (mirrors `RankingsPage.tsx`'s
proven server-authoritative pagination shape exactly): `fetchFilings` is
called with `offset` in its dep array, and a "Showing X–Y of N" + Prev/Next
footer renders below the list, Prev disabled at offset 0, Next disabled once
`offset + pageSize >= total`. `fetchFilings` / `/filings/{id}` already
supported `offset`/`limit` and returned `total` — no API change needed.

## Security / safety model

Frontend-only, read-only GET already gated by the existing route auth. No new
write paths, no backend change.

## Testing

- `pnpm typecheck` — clean.
- `pnpm test:unit` — 1190/1190 pass (114 files). No new test file added: this
  page has no existing test harness (unlike `RankingsPage.test.tsx`) and
  stands alongside `SetupPage.test.tsx` as a heavy-integration mount (mounts
  `SummaryStrip`, `ResearchTab`, `LiveQuoteProvider`, `RightRail` unconditionally);
  adding a first-ever test scaffold for the whole page is out of scope for
  this bounded fix. Per the lean-testing guidance in `.claude/CLAUDE.md`
  ("lean on the dev-verify step for operator-visible behaviour"), verification
  leans on live dev-verify below + the existing full suite passing.
- `node scripts/check-dark-classes.mjs` — clean (234 files, no violations).
- Full pre-push gate (fast pytest tier + smoke + all chokepoint lints) — green.
- **Live browser dev-verify not reachable in this environment**: the running
  dev stack (`:5173`) serves `~/Dev/eBull`, a separate checkout from this
  autonomy-loop worktree (`.ebull-autonomy`) — an in-flight branch change here
  isn't visible to it without either restarting the shared stack (forbidden)
  or writing into the operator's other checkout out-of-band (out of scope).
  Confirmed empirically: `curl`ing the live-served module showed the OLD
  unpatched `FilingsTab` body. Operator should re-verify live at
  `/instrument/AAPL?tab=filings` after this merges to main and their `eBull`
  checkout picks it up (`pnpm --dir frontend dev` picks up the change on
  next reload — no restart needed since it's a fresh `git pull`, not a
  running-process file change).

## Tradeoffs

- No test scaffold added for `InstrumentPage.tsx` (see Testing above) — the
  page-level component is heavy to mount in isolation; a future ticket could
  extract `FilingsTab` (and siblings) into independently-testable components
  if this class of bug recurs.

Closes #1893.