### PR TITLE
fix(#1894): sticky Metric column in instrument Financials tab table

### DIFF
--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -221,7 +221,9 @@ function FinancialsTab({ symbol }: { symbol: string }) {
           <table className="min-w-full text-sm">
             <thead>
               <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-xs text-slate-500">
-                <th className="px-2 py-1">Metric</th>
+                <th className="sticky left-0 z-20 border-r border-slate-200 bg-white px-2 py-1 dark:border-slate-800 dark:bg-slate-950">
+                  Metric
+                </th>
                 {rows.map((row) => (
                   <th key={row.period_end} className="px-2 py-1 text-right">
                     {row.period_type}
@@ -233,8 +235,10 @@ function FinancialsTab({ symbol }: { symbol: string }) {
             </thead>
             <tbody>
               {columns.map((col) => (
-                <tr key={col} className="border-b border-slate-100 last:border-0">
-                  <td className="px-2 py-1 font-medium">{col}</td>
+                <tr key={col} className="border-b border-slate-100 last:border-0 dark:border-slate-800">
+                  <td className="sticky left-0 z-10 border-r border-slate-200 bg-white px-2 py-1 font-medium dark:border-slate-800 dark:bg-slate-950">
+                    {col}
+                  </td>
                   {rows.map((row) => (
                     <td key={row.period_end} className="px-2 py-1 text-right">
                       {formatDecimal(row.values[col] ?? null)}


### PR DESCRIPTION
## Summary
- Fixes #1894: `/instrument/<symbol>?tab=financials` statement table lost the row-label ("Metric") column when scrolled horizontally, making numbers unreadable once past the first screen of periods.
- Freezes the first column with `position: sticky; left: 0` on both header and body cells so it stays visible during horizontal scroll.
- Added a right-border divider on the frozen column (Codex review: without it, scrolled numeric columns visually merge with the sticky column) and a dark-mode row border on `<tbody>` rows (pre-existing gap, only visible once the sticky background masked the light-mode border).

## Security model
None — presentational-only change to a client-rendered table, no data path touched.

## Scope
`frontend/src/pages/InstrumentPage.tsx` only (`FinancialsTab`). No backend/schema/API changes; not an ETL/parser/schema-migration PR so DoD clauses 8-12 don't apply.

## Verification
- `pnpm typecheck` — clean
- `pnpm run dark:check` — clean (234 files, no violations)
- `pnpm run test:unit` — 1199/1199 passed (no dedicated test added: this is a pure CSS/layout change, jsdom doesn't compute `position: sticky` visual effects, and no existing table in the codebase has a test asserting sticky-column classes — same precedent as `PeriodHeader.tsx`'s sticky header)
- Full pre-push gate (ruff/pyright/shellcheck/chokepoint lints/fast pytest tier/smoke) green

## Codex checkpoint (pre-push)
Ran `codex exec` review on the diff. Findings addressed:
- Missing dark-mode row border under the sticky column → added `dark:border-slate-800` to body `<tr>`.
- No visual divider between sticky column and scrolled content → added `border-r`.
- Header sticky z-index should exceed body sticky z-index → header `z-20`, body `z-10`.

## Conscious tradeoff
Issue also suggested "widen the table card to use the available page width" as an alternative/additional fix. Not done: the Financials tab shares the page's `lg:grid-cols-12` (8/4) layout with the `RightRail` sidebar (recent filings / peer snapshot), and widening the tab content column would mean restructuring that shared grid — larger blast radius for a UX-only ticket. The sticky column directly resolves the worse of the two reported effects (losing the row-label while scrolling); the reported clipping of exact figures is inherent to any horizontal-scroll table and the issue itself confirms the data is present via scroll, not missing.