### PR TITLE
chore: autonomy loop primary model -> claude-opus-4-8

### DIFF
--- a/.autonomy/config.yaml
+++ b/.autonomy/config.yaml
@@ -8,7 +8,7 @@ engine:
 agent:
   type: claude
   model:
-    primary: claude-sonnet-5
+    primary: claude-opus-4-8
     fallback: claude-sonnet-4-6
 
 merge_gate:


### PR DESCRIPTION
One config value: `agent.model.primary` claude-sonnet-5 → claude-opus-4-8 (operator direction, 2026-07-04). Landed as a commit rather than the dashboard's save-default because that write path gets stash-swept in the loop worktree (tracked file — autonomy-engine#202). No code, no gate change; fallback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)