### PR TITLE
feat(#1898): group + severity-tier the dashboard AlertsStrip

### DIFF
--- a/docs/specs/ui/2026-07-04-alerts-strip-grouping.md
+++ b/docs/specs/ui/2026-07-04-alerts-strip-grouping.md
@@ -1,0 +1,73 @@
+# AlertsStrip grouping + severity tiers (#1898)
+
+## Problem (verified on live dev)
+`GET /alerts/guard-rejections` returns 18 rows, 15 identical `kill_switch` (4 symbols ×
+several days) + 3 `auto_trading`. The strip renders one row per `(symbol × day)` for the
+same root cause → "18 new, zero information", and real actionable alerts would be buried.
+Position + coverage feeds are empty in dev but the same emission-per-row shape applies.
+
+## Scope
+FE-only. Regroup the three existing feeds by root cause + tier by severity. No backend /
+schema change. Items 1–3 of the ticket. Item 4 (new alert types: rank moves, thesis
+staleness) needs new backend data → deferred to a follow-up ticket.
+
+## Source-grounded group key
+`app/services/execution_guard.py::_build_explanation` builds
+`explanation = "FAIL — " + "; ".join(f"{rule}: {detail}")`. A `detail` may itself contain
+`; ` (e.g. `auto_trading`), so re-splitting the whole string is ambiguous. The ONLY
+unambiguous key is the **leading rule code**: strip the `FAIL — ` prefix, take the substring
+before the first `:`. This groups the real flood correctly (`kill_switch`, `auto_trading`).
+Multi-rule failures group under their first (primary) rule — acceptable for a summary card.
+
+## Design
+New pure module `frontend/src/components/dashboard/alertModel.ts`:
+
+- `parseGuardReason(explanation): string` — leading rule code (fallback: full string).
+- `GUARD_REASON_META: Record<code, {label, consequence, action:{label,to}}>` — known codes
+  (`kill_switch`, `auto_trading`); unknown → humanized code, generic consequence,
+  action → `/recommendations`.
+- `buildAlertModel(guard, position, coverage, cursors): AlertItem[]` returning tiered items:
+  - **actionable** (tier 0): position alerts (SL/TP/thesis breach) — kept per-instrument,
+    each links to its instrument. These are the alerts that must never be buried.
+  - **informational** (tier 1): guard rejections grouped by reason code →
+    `{ id:"guard:"+code, label, symbols:string[] (unique, sorted), count, latestTs,
+       unseen:boolean (any member decision_id > cursor.guard), consequence, action }`.
+  - **housekeeping** (tier 2): coverage drops grouped by transition. Group key uses a `∅`
+    sentinel for SQL NULL `new_status` (`"analysable→∅"`) so NULL cannot collide with a
+    literal status string; display renders `old → —`. One summary card per transition.
+- `GUARD_REASON_META` covers all 17 `RuleName` codes (execution_guard.py:89-107) with label +
+  consequence; unknown codes fall back to humanized code + generic consequence +
+  `/recommendations`. All guard groups sit in the informational tier (a blocked trade is a
+  policy rejection, not a position-level action); the actionable tier is position alerts.
+  - Sort: tier ASC, then `latestTs` DESC within tier.
+
+React keys: group cards keyed by `id` (`guard:<code>` / `coverage:<transition>`), unique
+within the rendered list **by construction** (Map key) — satisfies prevention-log #758/#759
+(never key `.map()` by a non-unique group label). Position rows keyed by `alert_id`.
+
+## Preserved behavior (unchanged accounting) — Codex ckpt-1 resolutions
+- Header `{totalUnseen} new` pill stays = sum of per-feed backend `unseen_count` (honest count
+  of unseen emissions). Grouping changes the BODY, not the count.
+- **Overflow (H1):** `renderedGuard/Position/Coverage` stay = the raw fetched array lengths
+  (`guard.data.rejections.length`, etc.), NOT the grouped-card count. `anyOverflow` compares
+  backend `unseen_count` to raw fetched length exactly as today → unchanged. Grouping never
+  feeds the overflow math.
+- **Cursor advancement (H2):** `Mark all read` / `Dismiss all` compute per-feed max ids from
+  the RAW feed arrays (`guard.data.rejections` → max `decision_id`, coverage → max `event_id`,
+  position → max `alert_id`), never from grouped `latestTs`. BIGSERIAL-id ordering preserved
+  (clocks can skew). Groups carry `maxId` ONLY to drive the unseen highlight.
+- Unseen highlight: a guard/coverage group is "unseen" if any member id > that feed's cursor;
+  position rows keep current per-alert `alert_id > cursor.position` semantics.
+- Backend feeds/cursors/`snapshot_read` (guard-only today) are untouched — no backend change.
+
+## Hard-safety deviation from ticket
+Ticket direction 1 shows a `[Deactivate]` button on the kill-switch card. Wiring a
+kill-switch mutation is forbidden (autonomy hard-safety rule). The kill-switch card instead
+links to **/admin** ("Manage in Admin"), where the operator deactivates. Documented in PR.
+
+## Tests
+- `alertModel.test.ts` (pure, no DB): `parseGuardReason` cases (prefix present/absent,
+  detail-with-semicolon, multi-rule); `buildAlertModel` collapses the 18-row fixture → 2
+  guard cards with correct symbol sets/counts; tier ordering; unseen propagation.
+- Update `AlertsStrip.test.tsx`: assert N identical guard rows render as ONE card with a
+  symbols summary + count, actionable position alert sorts above informational guard group.

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -85,8 +85,8 @@ function makeGuard(overrides: Partial<GuardRejection> = {}): GuardRejection {
     decision_time: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
     instrument_id: 42,
     symbol: "AAPL",
-    action: "BUY",
-    explanation: "FAIL — cash_available: need £200, have £50",
+    action: "HOLD",
+    explanation: "FAIL — kill_switch: kill switch active since 2026-06-28",
     ...overrides,
   };
 }
@@ -183,14 +183,71 @@ describe("AlertsStrip — basic rendering", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Merge + ordering
+// #1898 grouping — collapse the flood
 // ---------------------------------------------------------------------------
 
-describe("AlertsStrip — merge + ordering", () => {
-  it("merges three feeds into a single list DESC by timestamp", async () => {
+describe("AlertsStrip — grouping (#1898)", () => {
+  it("collapses many same-reason guard rejections into ONE card with a symbol summary", async () => {
+    // The real dev flood: kill_switch across 4 symbols on several days.
+    const symbols = ["BBBY", "IEP", "GME", "VOO"];
+    const rejections: GuardRejection[] = [];
+    let id = 600;
+    for (let day = 0; day < 3; day += 1) {
+      for (const s of symbols) {
+        rejections.push(
+          makeGuard({
+            decision_id: id++,
+            symbol: s,
+            explanation: "FAIL — kill_switch: kill switch active since 2026-06-28",
+          }),
+        );
+      }
+    }
+    stubAll({ guard: { rejections, unseen_count: rejections.length } });
+    renderStrip();
+    const rows = await screen.findAllByTestId("alerts-row");
+    // 12 emissions → a single grouped card.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.textContent).toContain("Kill switch active");
+    expect(rows[0]!.textContent).toContain("×12");
+    // All four affected symbols surfaced once each.
+    expect(rows[0]!.textContent).toContain("4 symbols:");
+    for (const s of symbols) expect(rows[0]!.textContent).toContain(s);
+  });
+
+  it("splits guard rejections into one card per distinct reason code", async () => {
+    stubAll({
+      guard: {
+        rejections: [
+          makeGuard({ decision_id: 611, symbol: "GME", explanation: "FAIL — kill_switch: active" }),
+          makeGuard({ decision_id: 610, symbol: "IEP", explanation: "FAIL — kill_switch: active" }),
+          makeGuard({
+            decision_id: 609,
+            symbol: "GME",
+            explanation: "FAIL — auto_trading: enable_auto_trading is False",
+          }),
+        ],
+        unseen_count: 3,
+      },
+    });
+    renderStrip();
+    const rows = await screen.findAllByTestId("alerts-row");
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText("Kill switch active")).toBeInTheDocument();
+    expect(screen.getByText("Auto-trading disabled")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Severity-tier ordering
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — severity ordering", () => {
+  it("orders actionable (position) above informational (guard) above housekeeping (coverage), regardless of timestamp", async () => {
+    // Give the LOWEST-priority feed the NEWEST timestamp to prove tier wins over time.
     const coverage = makeCoverage({
       symbol: "TSLA",
-      changed_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      changed_at: new Date(Date.now() - 1 * 60 * 1000).toISOString(), // newest
     });
     const guard = makeGuard({
       symbol: "AAPL",
@@ -198,7 +255,7 @@ describe("AlertsStrip — merge + ordering", () => {
     });
     const position = makePosition({
       symbol: "MSFT",
-      opened_at: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+      opened_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(), // oldest
     });
     stubAll({
       guard: { rejections: [guard], unseen_count: 1 },
@@ -208,9 +265,9 @@ describe("AlertsStrip — merge + ordering", () => {
     renderStrip();
     const rows = await screen.findAllByTestId("alerts-row");
     expect(rows).toHaveLength(3);
-    expect(rows[0]!.textContent).toContain("AAPL"); // 5 min ago (newest)
-    expect(rows[1]!.textContent).toContain("MSFT"); // 15 min ago
-    expect(rows[2]!.textContent).toContain("TSLA"); // 30 min ago
+    expect(rows[0]!.textContent).toContain("MSFT"); // actionable
+    expect(rows[1]!.textContent).toContain("Kill switch active"); // informational
+    expect(rows[2]!.textContent).toContain("Coverage analysable → insufficient"); // housekeeping
   });
 });
 
@@ -219,54 +276,51 @@ describe("AlertsStrip — merge + ordering", () => {
 // ---------------------------------------------------------------------------
 
 describe("AlertsStrip — per-kind rendering", () => {
-  it("renders kind pill badge for each row type", async () => {
+  it("renders the tier pill for each kind", async () => {
     stubAll({
       guard: { rejections: [makeGuard()], unseen_count: 1 },
       position: { alerts: [makePosition()], unseen_count: 1 },
       coverage: { drops: [makeCoverage()], unseen_count: 1 },
     });
     renderStrip();
-    expect(await screen.findByText("GUARD")).toBeInTheDocument();
-    expect(screen.getByText("POSITION")).toBeInTheDocument();
+    expect(await screen.findByText("ACTION")).toBeInTheDocument();
+    expect(screen.getByText("GUARD")).toBeInTheDocument();
     expect(screen.getByText("COVERAGE")).toBeInTheDocument();
   });
 
-  it("links rows with non-null instrument_id to /instruments/<id>", async () => {
+  it("position card links to /instruments/<id>", async () => {
     stubAll({
-      guard: { rejections: [makeGuard({ instrument_id: 42 })], unseen_count: 1 },
       position: { alerts: [makePosition({ instrument_id: 43 })], unseen_count: 1 },
-      coverage: { drops: [makeCoverage({ instrument_id: 44 })], unseen_count: 1 },
     });
     renderStrip();
     await screen.findAllByTestId("alerts-row");
-    const links = screen
-      .getAllByRole("link")
-      .map((l) => l.getAttribute("href"));
-    expect(links).toEqual(
-      expect.arrayContaining(["/instruments/42", "/instruments/43", "/instruments/44"]),
-    );
+    const links = screen.getAllByRole("link").map((l) => l.getAttribute("href"));
+    expect(links).toContain("/instruments/43");
   });
 
-  it("renders guard row with null instrument_id inline (no link)", async () => {
+  it("guard card links to its remediation action (kill-switch → /admin, not deactivate)", async () => {
     stubAll({
       guard: {
-        rejections: [makeGuard({ instrument_id: null, symbol: null })],
+        rejections: [makeGuard({ explanation: "FAIL — kill_switch: active" })],
         unseen_count: 1,
       },
     });
     renderStrip();
-    const row = await screen.findByTestId("alerts-row");
-    expect(row.closest("a")).toBeNull();
+    await screen.findAllByTestId("alerts-row");
+    const link = screen.getByRole("link", { name: /Manage in Admin/i });
+    expect(link.getAttribute("href")).toBe("/admin");
   });
 
-  it("guard row shows symbol / action / explanation", async () => {
+  it("guard card shows the human label + consequence, not the raw rule string", async () => {
     stubAll({
-      guard: { rejections: [makeGuard()], unseen_count: 1 },
+      guard: {
+        rejections: [makeGuard({ explanation: "FAIL — kill_switch: active since 2026-06-28" })],
+        unseen_count: 1,
+      },
     });
     renderStrip();
-    expect(await screen.findByText("AAPL")).toBeInTheDocument();
-    expect(screen.getByText("BUY")).toBeInTheDocument();
-    expect(screen.getByText(/cash_available: need £200/)).toBeInTheDocument();
+    expect(await screen.findByText("Kill switch active")).toBeInTheDocument();
+    expect(screen.getByText(/All order paths blocked/)).toBeInTheDocument();
   });
 
   it("position row shows symbol / alert_type label / detail", async () => {
@@ -282,49 +336,72 @@ describe("AlertsStrip — per-kind rendering", () => {
     expect(screen.getByText("bid=320 < sl=330")).toBeInTheDocument();
   });
 
-  it("coverage row shows symbol and old → new transition", async () => {
+  it("coverage card shows the transition and affected symbols", async () => {
     stubAll({
       coverage: {
-        drops: [makeCoverage({ old_status: "analysable", new_status: "insufficient" })],
+        drops: [
+          makeCoverage({ symbol: "TSLA", old_status: "analysable", new_status: "insufficient" }),
+          makeCoverage({
+            event_id: 302,
+            symbol: "NIO",
+            old_status: "analysable",
+            new_status: "insufficient",
+          }),
+        ],
+        unseen_count: 2,
+      },
+    });
+    renderStrip();
+    expect(await screen.findByText("Coverage analysable → insufficient")).toBeInTheDocument();
+    const row = screen.getByTestId("alerts-row");
+    expect(row.textContent).toContain("TSLA");
+    expect(row.textContent).toContain("NIO");
+  });
+
+  it("coverage card renders a null new_status as a dash", async () => {
+    stubAll({
+      coverage: {
+        drops: [makeCoverage({ old_status: "analysable", new_status: null })],
         unseen_count: 1,
       },
     });
     renderStrip();
-    expect(await screen.findByText("TSLA")).toBeInTheDocument();
-    expect(screen.getByText("analysable → insufficient")).toBeInTheDocument();
+    expect(await screen.findByText("Coverage analysable → —")).toBeInTheDocument();
   });
 });
 
 // ---------------------------------------------------------------------------
-// Unseen cursor math (per-kind)
+// Unseen cursor math (group-level)
 // ---------------------------------------------------------------------------
 
-describe("AlertsStrip — per-kind unseen cursor", () => {
-  it("applies amber border for unseen guard rows and slate for seen", async () => {
+describe("AlertsStrip — unseen cursor", () => {
+  it("guard group is unseen when its MAX member id exceeds the cursor, seen otherwise", async () => {
     stubAll({
       guard: {
         alerts_last_seen_decision_id: 500,
         unseen_count: 1,
         rejections: [
-          makeGuard({ decision_id: 501 }), // unseen
-          makeGuard({ decision_id: 499 }), // seen
+          // unseen group: max id 501 > 500
+          makeGuard({ decision_id: 501, explanation: "FAIL — kill_switch: active" }),
+          // seen group: max id 499 < 500 (distinct reason so it forms its own card)
+          makeGuard({ decision_id: 499, explanation: "FAIL — auto_trading: off" }),
         ],
       },
     });
     renderStrip();
     const rows = await screen.findAllByTestId("alerts-row");
-    expect(rows[0]!.className).toMatch(/border-amber/);
-    expect(rows[1]!.className).toMatch(/border-slate/);
+    const killRow = rows.find((r) => r.textContent?.includes("Kill switch active"))!;
+    const autoRow = rows.find((r) => r.textContent?.includes("Auto-trading disabled"))!;
+    expect(killRow.className).toMatch(/border-amber/);
+    expect(autoRow.className).toMatch(/border-slate/);
   });
 
-  it("per-kind cursor: position cursor only affects position rows", async () => {
+  it("per-kind cursor: position + coverage cursors drive their own rows", async () => {
     stubAll({
       position: {
         alerts_last_seen_position_alert_id: 700,
         unseen_count: 1,
-        alerts: [
-          makePosition({ alert_id: 701 }), // unseen (701 > 700)
-        ],
+        alerts: [makePosition({ alert_id: 701 })], // unseen (701 > 700)
       },
       coverage: {
         alerts_last_seen_coverage_event_id: null,
@@ -335,7 +412,8 @@ describe("AlertsStrip — per-kind unseen cursor", () => {
     renderStrip();
     const rows = await screen.findAllByTestId("alerts-row");
     for (const r of rows) {
-      expect(r.className).toMatch(/border-amber/);
+      // unseen position → red accent; unseen coverage (null cursor) → slate accent.
+      expect(r.className).toMatch(/border-(red|slate)-/);
     }
   });
 });
@@ -345,7 +423,7 @@ describe("AlertsStrip — per-kind unseen cursor", () => {
 // ---------------------------------------------------------------------------
 
 describe("AlertsStrip — header totals", () => {
-  it("header badge is sum of per-feed unseen_count", async () => {
+  it("header badge is sum of per-feed unseen_count (honest emission count)", async () => {
     stubAll({
       guard: { rejections: [makeGuard()], unseen_count: 3 },
       position: { alerts: [makePosition()], unseen_count: 2 },
@@ -364,7 +442,7 @@ describe("AlertsStrip — header totals", () => {
       },
     });
     renderStrip();
-    await screen.findByText("AAPL");
+    await screen.findByText("Kill switch active");
     expect(screen.queryByText(/\bnew\b/)).toBeNull();
   });
 
@@ -378,17 +456,29 @@ describe("AlertsStrip — header totals", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Per-feed overflow + ack-button gating
+// Per-feed overflow + ack-button gating (raw counts, not grouped)
 // ---------------------------------------------------------------------------
 
 describe("AlertsStrip — per-feed overflow", () => {
-  it("shows Dismiss-all when any feed has unseen > rendered (per-feed overflow)", async () => {
+  it("shows Dismiss-all when a feed's backend unseen_count exceeds its RAW fetched rows", async () => {
+    // unseen_count 2 > rejections.length 1 → overflow, even though the card collapses.
     stubAll({
-      guard: { rejections: [makeGuard()], unseen_count: 2 }, // overflow (2 > 1)
+      guard: { rejections: [makeGuard()], unseen_count: 2 },
     });
     renderStrip();
     expect(await screen.findByRole("button", { name: /Dismiss all/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Mark all read/i })).toBeNull();
+  });
+
+  it("grouping alone (unseen_count == raw rows) does NOT trigger overflow", async () => {
+    // 12 collapsed emissions, all fetched (unseen_count == 12 == rejections.length): normal ack.
+    const rejections = Array.from({ length: 12 }, (_, i) =>
+      makeGuard({ decision_id: 600 + i, explanation: "FAIL — kill_switch: active" }),
+    );
+    stubAll({ guard: { rejections, unseen_count: 12 } });
+    renderStrip();
+    expect(await screen.findByRole("button", { name: /Mark all read/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Dismiss all/i })).toBeNull();
   });
 
   it("shows Mark-all-read when no feed overflows and totalUnseen > 0", async () => {
@@ -410,20 +500,26 @@ describe("AlertsStrip — per-feed overflow", () => {
       },
     });
     renderStrip();
-    await screen.findByText("AAPL");
+    await screen.findByText("Kill switch active");
     expect(screen.queryByRole("button", { name: /Mark all read/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /Dismiss all/i })).toBeNull();
   });
 });
 
 // ---------------------------------------------------------------------------
-// Mark-all-read fan-out
+// Mark-all-read fan-out (raw feed MAX id, not group latestTs)
 // ---------------------------------------------------------------------------
 
 describe("AlertsStrip — Mark all read", () => {
-  it("fans out to each non-empty feed with its MAX id", async () => {
+  it("fans out to each non-empty feed with its MAX raw id", async () => {
     stubAll({
-      guard: { rejections: [makeGuard({ decision_id: 510 })], unseen_count: 1 },
+      guard: {
+        rejections: [
+          makeGuard({ decision_id: 505, explanation: "FAIL — kill_switch: active" }),
+          makeGuard({ decision_id: 510, explanation: "FAIL — kill_switch: active" }),
+        ],
+        unseen_count: 2,
+      },
       position: { alerts: [makePosition({ alert_id: 710 })], unseen_count: 1 },
     });
     mockedMarkGuard.mockResolvedValue(undefined);

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -1,20 +1,21 @@
 /**
- * AlertsStrip — unified dashboard alert feed (#399).
+ * AlertsStrip — unified dashboard alert feed (#399), grouped + severity-tiered (#1898).
  *
- * Renders three independent alert streams in a single timestamp-sorted list:
+ * Renders three independent alert streams collapsed to root-cause groups and ordered by
+ * severity tier (actionable → informational → housekeeping), so a shared root cause
+ * (e.g. kill-switch active) shows as ONE card with the affected symbols instead of N×M
+ * near-identical rows. Grouping lives in ./alertModel (pure, unit-tested).
  *
- *   1. Guard rejections (#394)
- *   2. Position alerts — SL/TP/thesis breach episodes (#401)
- *   3. Coverage status drops from 'analysable' (#402)
+ *   1. Guard rejections (#394) — grouped by leading rule code (informational).
+ *   2. Position alerts — SL/TP/thesis breach episodes (#401) — per-instrument (actionable).
+ *   3. Coverage status drops from 'analysable' (#402) — grouped by transition (housekeeping).
  *
- * Each feed keeps its own BIGSERIAL cursor column on `operators`. Partial
- * failure is tolerated: one feed GET erroring does not hide the others; one
- * POST failing does not block the siblings (Promise.allSettled).
- *
- * Overflow math is per-feed — each backend query caps at LIMIT 500 so
- * global `totalUnseen > merged.length` would conflate feed-A hidden rows
- * with feed-B seen padding. See spec
- * docs/superpowers/specs/2026-04-22-alerts-strip-unified.md for rationale.
+ * Seen/unseen + overflow accounting is UNCHANGED and operates on the RAW feed arrays by
+ * BIGSERIAL id (clocks can skew): each feed keeps its own cursor column on `operators`,
+ * the header pill counts backend `unseen_count`, and mark-read/dismiss use per-feed max ids.
+ * Partial failure is tolerated (Promise.allSettled). See spec
+ * docs/specs/ui/2026-07-04-alerts-strip-grouping.md and the original
+ * docs/superpowers/specs/2026-04-22-alerts-strip-unified.md.
  */
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -31,205 +32,203 @@ import {
   markPositionAlertsSeen,
 } from "@/api/alerts";
 import type {
-  CoverageStatusDrop,
   CoverageStatusDropsResponse,
-  GuardRejection,
   GuardRejectionsResponse,
   PositionAlert,
   PositionAlertsResponse,
 } from "@/api/types";
 import { formatRelativeTime } from "@/lib/format";
 
+import {
+  buildAlertModel,
+  type AlertItem,
+  type Cursors,
+  type GuardGroupItem,
+  type CoverageGroupItem,
+  type Tier,
+} from "./alertModel";
+
 type FeedState<T> =
   | { status: "loading" }
   | { status: "ok"; data: T }
   | { status: "err" };
 
-type AlertRow =
-  | { kind: "guard"; ts: string; sortKey: number; row: GuardRejection }
-  | { kind: "position"; ts: string; sortKey: number; row: PositionAlert }
-  | { kind: "coverage"; ts: string; sortKey: number; row: CoverageStatusDrop };
-
-type Cursors = {
-  guard: number | null;
-  position: number | null;
-  coverage: number | null;
+const TIER_LABEL: Record<Tier, string> = {
+  actionable: "ACTION",
+  informational: "GUARD",
+  housekeeping: "COVERAGE",
 };
 
-function buildRows(
-  guard: FeedState<GuardRejectionsResponse>,
-  position: FeedState<PositionAlertsResponse>,
-  coverage: FeedState<CoverageStatusDropsResponse>,
-): AlertRow[] {
-  const rows: AlertRow[] = [];
-  if (guard.status === "ok") {
-    for (const r of guard.data.rejections) {
-      rows.push({
-        kind: "guard",
-        ts: r.decision_time,
-        sortKey: Date.parse(r.decision_time),
-        row: r,
-      });
-    }
+const TIER_PILL: Record<Tier, string> = {
+  actionable: "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200",
+  informational:
+    "bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200",
+  housekeeping: "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300",
+};
+
+function tierBorder(tier: Tier, unseen: boolean): string {
+  if (unseen) {
+    return {
+      actionable: "border-l-4 border-red-400",
+      informational: "border-l-4 border-amber-400",
+      housekeeping: "border-l-4 border-slate-300 dark:border-slate-600",
+    }[tier];
   }
-  if (position.status === "ok") {
-    for (const r of position.data.alerts) {
-      rows.push({
-        kind: "position",
-        ts: r.opened_at,
-        sortKey: Date.parse(r.opened_at),
-        row: r,
-      });
-    }
-  }
-  if (coverage.status === "ok") {
-    for (const r of coverage.data.drops) {
-      rows.push({
-        kind: "coverage",
-        ts: r.changed_at,
-        sortKey: Date.parse(r.changed_at),
-        row: r,
-      });
-    }
-  }
-  rows.sort((a, b) => b.sortKey - a.sortKey);
-  return rows;
+  return "border-l-4 border-slate-200 dark:border-slate-800";
 }
 
-function isUnseen(r: AlertRow, c: Cursors): boolean {
-  switch (r.kind) {
-    case "guard":
-      return c.guard === null || r.row.decision_id > c.guard;
-    case "position":
-      return c.position === null || r.row.alert_id > c.position;
-    case "coverage":
-      return c.coverage === null || r.row.event_id > c.coverage;
-  }
-}
-
-function KindPill({ kind }: { kind: AlertRow["kind"] }) {
-  const style = {
-    guard: "bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200",
-    position: "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200",
-    coverage: "bg-slate-100 dark:bg-slate-800 text-slate-700",
-  }[kind];
-  const label = { guard: "GUARD", position: "POSITION", coverage: "COVERAGE" }[kind];
+function TierPill({ tier }: { tier: Tier }) {
   return (
     <span
-      className={`w-20 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase ${style}`}
+      className={`w-20 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase ${TIER_PILL[tier]}`}
     >
-      {label}
+      {TIER_LABEL[tier]}
     </span>
   );
 }
 
-function RowShell({
-  kind,
+function CardShell({
+  tier,
   unseen,
-  instrumentId,
   children,
 }: {
-  kind: AlertRow["kind"];
+  tier: Tier;
   unseen: boolean;
-  instrumentId: number | null;
   children: React.ReactNode;
 }) {
-  const border = unseen
-    ? "border-l-4 border-amber-400"
-    : "border-l-4 border-slate-200 dark:border-slate-800";
-  const content = (
+  return (
     <div
       data-testid="alerts-row"
       role="listitem"
-      className={`flex items-center gap-3 px-3 py-2 text-sm ${border} bg-white dark:bg-slate-900`}
+      className={`flex items-start gap-3 px-3 py-2 text-sm ${tierBorder(tier, unseen)} bg-white dark:bg-slate-900`}
     >
-      <KindPill kind={kind} />
+      <TierPill tier={tier} />
       {children}
     </div>
   );
-  if (instrumentId !== null) {
-    return (
-      <Link
-        to={`/instruments/${instrumentId}`}
- className="block hover:bg-slate-50 dark:hover:bg-slate-800/40"
-      >
-        {content}
-      </Link>
-    );
-  }
-  return content;
 }
 
-function GuardRow({ row, unseen }: { row: GuardRejection; unseen: boolean }) {
+function SymbolSummary({ symbols, count }: { symbols: string[]; count: number }) {
+  if (symbols.length === 0) {
+    return (
+      <span className="text-xs text-slate-500 dark:text-slate-400">
+        {count} {count === 1 ? "occurrence" : "occurrences"}
+      </span>
+    );
+  }
+  const noun = symbols.length === 1 ? "symbol" : "symbols";
   return (
-    <RowShell kind="guard" unseen={unseen} instrumentId={row.instrument_id}>
-      <span className="w-16 font-semibold tabular-nums">{row.symbol ?? "—"}</span>
-      <span className="w-16 text-xs uppercase text-slate-500 dark:text-slate-400">{row.action ?? "—"}</span>
-      <span className="flex-1 truncate text-slate-700" title={row.explanation}>
-        {row.explanation}
+    <span className="text-xs text-slate-600 dark:text-slate-300">
+      <span className="text-slate-400 dark:text-slate-500">
+        {symbols.length} {noun}:{" "}
       </span>
-      <span className="w-20 text-right text-xs text-slate-400 dark:text-slate-500">
-        {formatRelativeTime(row.decision_time)}
-      </span>
-    </RowShell>
+      {symbols.join(", ")}
+    </span>
   );
 }
 
-function PositionRow({ row, unseen }: { row: PositionAlert; unseen: boolean }) {
+function GuardGroupCard({ item }: { item: GuardGroupItem }) {
+  return (
+    <CardShell tier={item.tier} unseen={item.unseen}>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-baseline gap-2">
+          <span className="font-semibold text-slate-800 dark:text-slate-100">
+            {item.label}
+          </span>
+          {item.count > 1 ? (
+            <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:text-slate-300 tabular-nums">
+              ×{item.count}
+            </span>
+          ) : null}
+        </div>
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          {item.consequence}
+        </span>
+        <SymbolSummary symbols={item.symbols} count={item.count} />
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        <span className="text-xs text-slate-400 dark:text-slate-500">
+          {formatRelativeTime(item.latestTs)}
+        </span>
+        <Link
+          to={item.action.to}
+          className="text-xs font-medium text-sky-600 dark:text-sky-400 underline hover:text-sky-800 dark:hover:text-sky-300"
+        >
+          {item.action.label}
+        </Link>
+      </div>
+    </CardShell>
+  );
+}
+
+function PositionCard({
+  row,
+  unseen,
+}: {
+  row: PositionAlert;
+  unseen: boolean;
+}) {
   const alertLabel = {
     sl_breach: "SL",
     tp_breach: "TP",
     thesis_break: "THESIS",
   }[row.alert_type];
   return (
-    <RowShell kind="position" unseen={unseen} instrumentId={row.instrument_id}>
-      <span className="w-16 font-semibold tabular-nums">{row.symbol}</span>
-      <span className="w-16 text-xs uppercase text-slate-500 dark:text-slate-400">{alertLabel}</span>
-      <span className="flex-1 truncate text-slate-700" title={row.detail}>
-        {row.detail}
-      </span>
-      <span className="w-20 text-right text-xs text-slate-400 dark:text-slate-500">
-        {formatRelativeTime(row.opened_at)}
-      </span>
-    </RowShell>
+    <Link
+      to={`/instruments/${row.instrument_id}`}
+      className="block hover:bg-slate-50 dark:hover:bg-slate-800/40"
+    >
+      <CardShell tier="actionable" unseen={unseen}>
+        <div className="flex min-w-0 flex-1 items-baseline gap-2">
+          <span className="w-16 shrink-0 font-semibold tabular-nums">
+            {row.symbol}
+          </span>
+          <span className="w-16 shrink-0 text-xs uppercase text-slate-500 dark:text-slate-400">
+            {alertLabel}
+          </span>
+          <span className="flex-1 truncate text-slate-700 dark:text-slate-200" title={row.detail}>
+            {row.detail}
+          </span>
+        </div>
+        <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+          {formatRelativeTime(row.opened_at)}
+        </span>
+      </CardShell>
+    </Link>
   );
 }
 
-function CoverageRow({ row, unseen }: { row: CoverageStatusDrop; unseen: boolean }) {
-  const transition = `${row.old_status} → ${row.new_status ?? "—"}`;
+function CoverageGroupCard({ item }: { item: CoverageGroupItem }) {
   return (
-    <RowShell kind="coverage" unseen={unseen} instrumentId={row.instrument_id}>
-      <span className="w-16 font-semibold tabular-nums">{row.symbol}</span>
-      <span className="flex-1 truncate text-slate-700" title={transition}>
-        {transition}
+    <CardShell tier={item.tier} unseen={item.unseen}>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-baseline gap-2">
+          <span className="font-semibold text-slate-800 dark:text-slate-100">
+            Coverage {item.transition}
+          </span>
+          {item.count > 1 ? (
+            <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:text-slate-300 tabular-nums">
+              ×{item.count}
+            </span>
+          ) : null}
+        </div>
+        <SymbolSummary symbols={item.symbols} count={item.count} />
+      </div>
+      <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+        {formatRelativeTime(item.latestTs)}
       </span>
-      <span className="w-20 text-right text-xs text-slate-400 dark:text-slate-500">
-        {formatRelativeTime(row.changed_at)}
-      </span>
-    </RowShell>
+    </CardShell>
   );
 }
 
-function RowView({ row, cursors }: { row: AlertRow; cursors: Cursors }) {
-  const unseen = isUnseen(row, cursors);
-  switch (row.kind) {
-    case "guard":
-      return <GuardRow row={row.row} unseen={unseen} />;
+function ItemView({ item }: { item: AlertItem }) {
+  switch (item.kind) {
+    case "guardGroup":
+      return <GuardGroupCard item={item} />;
     case "position":
-      return <PositionRow row={row.row} unseen={unseen} />;
-    case "coverage":
-      return <CoverageRow row={row.row} unseen={unseen} />;
-  }
-}
-
-function rowId(row: AlertRow): number {
-  switch (row.kind) {
-    case "guard":
-      return row.row.decision_id;
-    case "position":
-      return row.row.alert_id;
-    case "coverage":
-      return row.row.event_id;
+      return <PositionCard row={item.row} unseen={item.unseen} />;
+    case "coverageGroup":
+      return <CoverageGroupCard item={item} />;
   }
 }
 
@@ -304,29 +303,11 @@ export function AlertsStrip(): JSX.Element | null {
     return null;
   }
 
-  const merged = buildRows(guard, position, coverage);
-
-  if (merged.length === 0) {
-    return null;
-  }
-
-  const unseenGuard = guard.status === "ok" ? guard.data.unseen_count : 0;
-  const unseenPosition = position.status === "ok" ? position.data.unseen_count : 0;
-  const unseenCoverage = coverage.status === "ok" ? coverage.data.unseen_count : 0;
-
-  const renderedGuard = guard.status === "ok" ? guard.data.rejections.length : 0;
-  const renderedPosition = position.status === "ok" ? position.data.alerts.length : 0;
-  const renderedCoverage = coverage.status === "ok" ? coverage.data.drops.length : 0;
-
-  const totalUnseen = unseenGuard + unseenPosition + unseenCoverage;
-
-  const anyOverflow =
-    unseenGuard > renderedGuard ||
-    unseenPosition > renderedPosition ||
-    unseenCoverage > renderedCoverage;
-
-  const overflowAck = anyOverflow;
-  const normalAck = totalUnseen > 0 && !anyOverflow;
+  // Raw feed arrays — the source of truth for BOTH the grouped body and the
+  // seen/unseen + overflow accounting (grouping never feeds the counts).
+  const rejections = guard.status === "ok" ? guard.data.rejections : [];
+  const positionAlerts = position.status === "ok" ? position.data.alerts : [];
+  const drops = coverage.status === "ok" ? coverage.data.drops : [];
 
   const cursors: Cursors = {
     guard: guard.status === "ok" ? guard.data.alerts_last_seen_decision_id : null,
@@ -340,25 +321,37 @@ export function AlertsStrip(): JSX.Element | null {
         : null,
   };
 
+  const items = buildAlertModel(rejections, positionAlerts, drops, cursors);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const unseenGuard = guard.status === "ok" ? guard.data.unseen_count : 0;
+  const unseenPosition = position.status === "ok" ? position.data.unseen_count : 0;
+  const unseenCoverage = coverage.status === "ok" ? coverage.data.unseen_count : 0;
+
+  // Overflow math compares backend unseen counts to RAW fetched row counts (each feed caps
+  // at LIMIT 500) — NOT to the grouped card count.
+  const renderedGuard = rejections.length;
+  const renderedPosition = positionAlerts.length;
+  const renderedCoverage = drops.length;
+
+  const totalUnseen = unseenGuard + unseenPosition + unseenCoverage;
+
+  const anyOverflow =
+    unseenGuard > renderedGuard ||
+    unseenPosition > renderedPosition ||
+    unseenCoverage > renderedCoverage;
+
+  const overflowAck = anyOverflow;
+  const normalAck = totalUnseen > 0 && !anyOverflow;
+
   async function onMarkAllRead() {
-    const guardMax = Math.max(
-      0,
-      ...merged
-        .filter((r): r is Extract<AlertRow, { kind: "guard" }> => r.kind === "guard")
-        .map((r) => r.row.decision_id),
-    );
-    const positionMax = Math.max(
-      0,
-      ...merged
-        .filter((r): r is Extract<AlertRow, { kind: "position" }> => r.kind === "position")
-        .map((r) => r.row.alert_id),
-    );
-    const coverageMax = Math.max(
-      0,
-      ...merged
-        .filter((r): r is Extract<AlertRow, { kind: "coverage" }> => r.kind === "coverage")
-        .map((r) => r.row.event_id),
-    );
+    // Advance each cursor to the max id in its RAW feed array (BIGSERIAL id, not timestamp).
+    const guardMax = Math.max(0, ...rejections.map((r) => r.decision_id));
+    const positionMax = Math.max(0, ...positionAlerts.map((r) => r.alert_id));
+    const coverageMax = Math.max(0, ...drops.map((r) => r.event_id));
 
     const promises: Promise<void>[] = [];
     if (guardMax > 0) promises.push(markAlertsSeen(guardMax));
@@ -446,10 +439,10 @@ export function AlertsStrip(): JSX.Element | null {
         tabIndex={0}
         role="list"
         aria-labelledby="alerts-strip-heading"
-        className="max-h-96 overflow-y-auto divide-y divide-slate-100"
+        className="max-h-96 overflow-y-auto divide-y divide-slate-100 dark:divide-slate-800"
       >
-        {merged.map((row) => (
-          <RowView key={`${row.kind}-${rowId(row)}`} row={row} cursors={cursors} />
+        {items.map((item) => (
+          <ItemView key={item.id} item={item} />
         ))}
       </div>
     </section>

--- a/frontend/src/components/dashboard/alertModel.test.ts
+++ b/frontend/src/components/dashboard/alertModel.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  CoverageStatusDrop,
+  GuardRejection,
+  PositionAlert,
+} from "@/api/types";
+
+import {
+  buildAlertModel,
+  guardReasonMeta,
+  parseGuardReason,
+  type Cursors,
+  type CoverageGroupItem,
+  type GuardGroupItem,
+} from "./alertModel";
+
+const NO_CURSORS: Cursors = { guard: null, position: null, coverage: null };
+
+function guard(o: Partial<GuardRejection> = {}): GuardRejection {
+  return {
+    decision_id: 1,
+    decision_time: "2026-07-04T10:00:00Z",
+    instrument_id: 1,
+    symbol: "AAPL",
+    action: "HOLD",
+    explanation: "FAIL — kill_switch: kill switch active since 2026-06-28",
+    ...o,
+  };
+}
+
+function position(o: Partial<PositionAlert> = {}): PositionAlert {
+  return {
+    alert_id: 1,
+    alert_type: "sl_breach",
+    instrument_id: 2,
+    symbol: "MSFT",
+    opened_at: "2026-07-04T10:00:00Z",
+    resolved_at: null,
+    detail: "bid < sl",
+    current_bid: "1",
+    ...o,
+  };
+}
+
+function coverage(o: Partial<CoverageStatusDrop> = {}): CoverageStatusDrop {
+  return {
+    event_id: 1,
+    instrument_id: 3,
+    symbol: "TSLA",
+    changed_at: "2026-07-04T10:00:00Z",
+    old_status: "analysable",
+    new_status: "insufficient",
+    ...o,
+  };
+}
+
+describe("parseGuardReason", () => {
+  it.each([
+    ["FAIL — kill_switch: active since 2026-06-28", "kill_switch"],
+    ["FAIL — auto_trading: enable_auto_trading is False; live_trading off", "auto_trading"],
+    ["FAIL — concentration_breach: sector tech 0.42 > 0.30", "concentration_breach"],
+    // detail contains a colon — only the leading segment's first colon counts
+    ["FAIL — thesis_stale: age=45d; note: regenerate", "thesis_stale"],
+    // no FAIL prefix — fall back to leading-token-before-colon
+    ["kill_switch: raw", "kill_switch"],
+    // no colon at all
+    ["mystery_rule", "mystery_rule"],
+    ["", "unknown"],
+  ])("parses %j → %j", (input, expected) => {
+    expect(parseGuardReason(input)).toBe(expected);
+  });
+});
+
+describe("guardReasonMeta", () => {
+  it("returns curated meta for a known code", () => {
+    const m = guardReasonMeta("kill_switch");
+    expect(m.label).toBe("Kill switch active");
+    expect(m.action.to).toBe("/admin");
+  });
+
+  it("falls back to a humanized label + triage action for an unknown code", () => {
+    const m = guardReasonMeta("some_new_rule");
+    expect(m.label).toBe("Some new rule");
+    expect(m.action.to).toBe("/recommendations");
+  });
+});
+
+describe("buildAlertModel — guard grouping", () => {
+  it("collapses the dev flood (12 kill_switch emissions × 4 symbols) into one card", () => {
+    const symbols = ["BBBY", "IEP", "GME", "VOO"];
+    const rejections: GuardRejection[] = [];
+    let id = 100;
+    for (let day = 0; day < 3; day += 1) {
+      for (const s of symbols) {
+        rejections.push(guard({ decision_id: id++, symbol: s }));
+      }
+    }
+    const items = buildAlertModel(rejections, [], [], NO_CURSORS);
+    expect(items).toHaveLength(1);
+    const g = items[0] as GuardGroupItem;
+    expect(g.kind).toBe("guardGroup");
+    expect(g.code).toBe("kill_switch");
+    expect(g.count).toBe(12);
+    expect(g.symbols).toEqual(["BBBY", "GME", "IEP", "VOO"]); // unique + sorted
+    expect(g.maxId).toBe(111); // 100..111
+    expect(g.unseen).toBe(true); // cursor null
+  });
+
+  it("one card per distinct reason code", () => {
+    const items = buildAlertModel(
+      [
+        guard({ decision_id: 1, explanation: "FAIL — kill_switch: active" }),
+        guard({ decision_id: 2, explanation: "FAIL — auto_trading: off" }),
+        guard({ decision_id: 3, explanation: "FAIL — kill_switch: active" }),
+      ],
+      [],
+      [],
+      NO_CURSORS,
+    );
+    expect(items).toHaveLength(2);
+    const codes = (items as GuardGroupItem[]).map((i) => i.code).sort();
+    expect(codes).toEqual(["auto_trading", "kill_switch"]);
+  });
+
+  it("drops null symbols from the summary but still counts the emission", () => {
+    const items = buildAlertModel(
+      [
+        guard({ decision_id: 1, symbol: null }),
+        guard({ decision_id: 2, symbol: "GME" }),
+      ],
+      [],
+      [],
+      NO_CURSORS,
+    );
+    const g = items[0] as GuardGroupItem;
+    expect(g.count).toBe(2);
+    expect(g.symbols).toEqual(["GME"]);
+  });
+
+  it("group is seen when maxId <= cursor", () => {
+    const items = buildAlertModel(
+      [guard({ decision_id: 400 }), guard({ decision_id: 399 })],
+      [],
+      [],
+      { ...NO_CURSORS, guard: 400 },
+    );
+    expect((items[0] as GuardGroupItem).unseen).toBe(false);
+  });
+});
+
+describe("buildAlertModel — coverage grouping", () => {
+  it("groups by transition; null new_status uses a ∅ key and — display, no collision", () => {
+    const items = buildAlertModel(
+      [],
+      [],
+      [
+        coverage({ event_id: 1, symbol: "TSLA", new_status: "insufficient" }),
+        coverage({ event_id: 2, symbol: "NIO", new_status: "insufficient" }),
+        coverage({ event_id: 3, symbol: "F", new_status: null }),
+      ],
+      NO_CURSORS,
+    );
+    const cov = items.filter((i) => i.kind === "coverageGroup") as CoverageGroupItem[];
+    expect(cov).toHaveLength(2); // insufficient group + null group
+    const insufficient = cov.find((c) => c.transition.includes("insufficient"))!;
+    expect(insufficient.count).toBe(2);
+    expect(insufficient.symbols).toEqual(["NIO", "TSLA"]);
+    const nullGroup = cov.find((c) => c.transition.endsWith("—"))!;
+    expect(nullGroup.transition).toBe("analysable → —");
+    expect(nullGroup.id).toBe("coverage:analysable→∅");
+  });
+});
+
+describe("buildAlertModel — severity ordering", () => {
+  it("orders actionable → informational → housekeeping regardless of timestamp", () => {
+    const items = buildAlertModel(
+      [guard({ decision_time: "2026-07-04T12:00:00Z" })], // newest, but informational
+      [position({ opened_at: "2026-07-04T09:00:00Z" })], // oldest, but actionable
+      [coverage({ changed_at: "2026-07-04T11:00:00Z" })],
+      NO_CURSORS,
+    );
+    expect(items.map((i) => i.tier)).toEqual([
+      "actionable",
+      "informational",
+      "housekeeping",
+    ]);
+  });
+
+  it("within a tier, newest-first by latest emission", () => {
+    const items = buildAlertModel(
+      [
+        guard({ decision_id: 1, explanation: "FAIL — kill_switch: x", decision_time: "2026-07-04T08:00:00Z" }),
+        guard({ decision_id: 2, explanation: "FAIL — auto_trading: y", decision_time: "2026-07-04T12:00:00Z" }),
+      ],
+      [],
+      [],
+      NO_CURSORS,
+    );
+    expect((items as GuardGroupItem[]).map((i) => i.code)).toEqual([
+      "auto_trading", // 12:00 newer
+      "kill_switch", // 08:00
+    ]);
+  });
+});

--- a/frontend/src/components/dashboard/alertModel.ts
+++ b/frontend/src/components/dashboard/alertModel.ts
@@ -1,0 +1,303 @@
+/**
+ * alertModel — pure grouping + severity-tiering for the dashboard AlertsStrip (#1898).
+ *
+ * The three raw feeds emit one row per (subject × emission). For a shared root cause
+ * (e.g. kill-switch active since 28 Jun) that means N×M near-identical rows — "18 new,
+ * zero information", burying genuinely actionable alerts. This module collapses each feed
+ * to root-cause groups and orders them by severity tier so the operator learns something.
+ *
+ * Grouping is FE-only and source-grounded. Guard `explanation` is built by
+ * app/services/execution_guard.py::_build_explanation as
+ *   "FAIL — " + "; ".join(f"{rule}: {detail}")
+ * A `detail` may itself contain "; ", so only the LEADING rule code (the substring after the
+ * "FAIL — " prefix, before the first ":") is unambiguously parseable — that is the group key.
+ *
+ * Cursor/overflow accounting is NOT done here (see AlertsStrip): the strip keeps operating
+ * mark-read/dismiss on the RAW feed arrays by BIGSERIAL id. Groups carry `maxId` only to
+ * drive the unseen highlight.
+ */
+import type {
+  CoverageStatusDrop,
+  GuardRejection,
+  PositionAlert,
+} from "@/api/types";
+
+export type Tier = "actionable" | "informational" | "housekeeping";
+
+const TIER_ORDER: Record<Tier, number> = {
+  actionable: 0,
+  informational: 1,
+  housekeeping: 2,
+};
+
+export type Cursors = {
+  guard: number | null;
+  position: number | null;
+  coverage: number | null;
+};
+
+export interface GuardReasonMeta {
+  label: string;
+  consequence: string;
+  action: { label: string; to: string };
+}
+
+const ADMIN = { label: "Manage in Admin", to: "/admin" };
+const TRIAGE = { label: "Triage", to: "/recommendations" };
+
+/**
+ * One entry per execution-guard RuleName (app/services/execution_guard.py:89-107).
+ * Config / safety-layer rejections point at /admin (where the operator acts — e.g. the
+ * kill switch is deactivated there, NOT from this strip). Data / per-instrument rejections
+ * point at /recommendations for triage. Unknown codes fall back to a humanized label.
+ */
+export const GUARD_REASON_META: Record<string, GuardReasonMeta> = {
+  kill_switch: {
+    label: "Kill switch active",
+    consequence: "All order paths blocked — no trades will place.",
+    action: ADMIN,
+  },
+  kill_switch_config_corrupt: {
+    label: "Kill-switch config corrupt",
+    consequence: "Guard fails closed — orders blocked until the config is repaired.",
+    action: ADMIN,
+  },
+  runtime_config_corrupt: {
+    label: "Runtime config corrupt",
+    consequence: "Guard fails closed — orders blocked until the config is repaired.",
+    action: ADMIN,
+  },
+  auto_trading: {
+    label: "Auto-trading disabled",
+    consequence: "Orders are not placed automatically (manual approval required).",
+    action: ADMIN,
+  },
+  live_trading: {
+    label: "Live trading disabled",
+    consequence: "Live order path off — running in demo / blocked mode.",
+    action: ADMIN,
+  },
+  coverage_not_tier1: {
+    label: "Coverage below Tier 1",
+    consequence: "Instrument not analysable enough to trade.",
+    action: TRIAGE,
+  },
+  no_coverage_row: {
+    label: "No coverage data",
+    consequence: "Instrument has no coverage row — cannot assess.",
+    action: TRIAGE,
+  },
+  thesis_stale: {
+    label: "Thesis stale",
+    consequence: "Thesis too old to act on — regenerate before trading.",
+    action: TRIAGE,
+  },
+  no_thesis: {
+    label: "No thesis",
+    consequence: "No thesis on file — nothing to justify a trade.",
+    action: TRIAGE,
+  },
+  spread_wide: {
+    label: "Spread too wide",
+    consequence: "Bid/ask spread exceeds the limit — execution deferred.",
+    action: TRIAGE,
+  },
+  spread_unavailable: {
+    label: "Spread unavailable",
+    consequence: "No live quote — spread cannot be checked.",
+    action: TRIAGE,
+  },
+  transaction_cost_prohibitive: {
+    label: "Transaction cost prohibitive",
+    consequence: "Estimated cost exceeds the limit — trade skipped.",
+    action: TRIAGE,
+  },
+  budget_available: {
+    label: "Insufficient budget",
+    consequence: "Not enough allocatable capital for this order.",
+    action: TRIAGE,
+  },
+  instrument_missing: {
+    label: "Instrument missing",
+    consequence: "Instrument not in the universe — cannot trade.",
+    action: TRIAGE,
+  },
+  sector_missing: {
+    label: "Sector missing",
+    consequence: "No sector classification — concentration checks blocked.",
+    action: TRIAGE,
+  },
+  concentration_breach: {
+    label: "Concentration limit breach",
+    consequence: "Would exceed the sector / position concentration cap.",
+    action: TRIAGE,
+  },
+  safety_layers_enabled: {
+    label: "Safety layers enabled",
+    consequence: "A required safety layer blocked the order.",
+    action: ADMIN,
+  },
+};
+
+const GUARD_PREFIX = "FAIL — ";
+
+/**
+ * Leading execution-guard rule code from an `explanation`. Strips the literal "FAIL — "
+ * prefix then takes the substring before the first ":". Robust to a detail that itself
+ * contains ":" or "; " (only the first ":" of the leading segment is consulted).
+ */
+export function parseGuardReason(explanation: string): string {
+  let s = explanation.trim();
+  if (s.startsWith(GUARD_PREFIX)) s = s.slice(GUARD_PREFIX.length);
+  const colon = s.indexOf(":");
+  const code = (colon === -1 ? s : s.slice(0, colon)).trim();
+  return code || "unknown";
+}
+
+function humanize(code: string): string {
+  if (!code || code === "unknown") return "Guard rejection";
+  return code.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+}
+
+export function guardReasonMeta(code: string): GuardReasonMeta {
+  return (
+    GUARD_REASON_META[code] ?? {
+      label: humanize(code),
+      consequence: "Order blocked by the execution guard.",
+      action: TRIAGE,
+    }
+  );
+}
+
+export interface GuardGroupItem {
+  kind: "guardGroup";
+  tier: Tier;
+  id: string;
+  code: string;
+  label: string;
+  consequence: string;
+  action: { label: string; to: string };
+  symbols: string[];
+  count: number;
+  latestTs: string;
+  sortKey: number;
+  maxId: number;
+  unseen: boolean;
+}
+
+export interface PositionItem {
+  kind: "position";
+  tier: Tier;
+  id: string;
+  sortKey: number;
+  unseen: boolean;
+  row: PositionAlert;
+}
+
+export interface CoverageGroupItem {
+  kind: "coverageGroup";
+  tier: Tier;
+  id: string;
+  transition: string;
+  symbols: string[];
+  count: number;
+  latestTs: string;
+  sortKey: number;
+  maxId: number;
+  unseen: boolean;
+}
+
+export type AlertItem = GuardGroupItem | PositionItem | CoverageGroupItem;
+
+function uniqueSorted(values: (string | null)[]): string[] {
+  return Array.from(new Set(values.filter((v): v is string => !!v))).sort();
+}
+
+/**
+ * Collapse the three raw feeds into severity-tiered, root-cause-grouped display items.
+ * Ordering: tier ASC (actionable → informational → housekeeping), then latest emission DESC.
+ */
+export function buildAlertModel(
+  rejections: GuardRejection[],
+  positions: PositionAlert[],
+  drops: CoverageStatusDrop[],
+  cursors: Cursors,
+): AlertItem[] {
+  const items: AlertItem[] = [];
+
+  // Guard rejections → one card per leading rule code (informational tier).
+  const guardGroups = new Map<string, GuardRejection[]>();
+  for (const r of rejections) {
+    const code = parseGuardReason(r.explanation);
+    const arr = guardGroups.get(code);
+    if (arr) arr.push(r);
+    else guardGroups.set(code, [r]);
+  }
+  for (const [code, members] of guardGroups) {
+    const meta = guardReasonMeta(code);
+    const maxId = Math.max(...members.map((m) => m.decision_id));
+    const latest = members.reduce((a, b) =>
+      Date.parse(b.decision_time) > Date.parse(a.decision_time) ? b : a,
+    );
+    items.push({
+      kind: "guardGroup",
+      tier: "informational",
+      id: `guard:${code}`,
+      code,
+      label: meta.label,
+      consequence: meta.consequence,
+      action: meta.action,
+      symbols: uniqueSorted(members.map((m) => m.symbol)),
+      count: members.length,
+      latestTs: latest.decision_time,
+      sortKey: Date.parse(latest.decision_time),
+      maxId,
+      unseen: cursors.guard === null || maxId > cursors.guard,
+    });
+  }
+
+  // Position alerts → per-instrument, kept individual (actionable tier — never bury these).
+  for (const a of positions) {
+    items.push({
+      kind: "position",
+      tier: "actionable",
+      id: `position:${a.alert_id}`,
+      sortKey: Date.parse(a.opened_at),
+      unseen: cursors.position === null || a.alert_id > cursors.position,
+      row: a,
+    });
+  }
+
+  // Coverage drops → one card per transition (housekeeping tier). A `∅` sentinel keeps a
+  // SQL NULL new_status from colliding with a literal status string in the group key.
+  const coverageGroups = new Map<string, CoverageStatusDrop[]>();
+  for (const d of drops) {
+    const key = `${d.old_status}→${d.new_status ?? "∅"}`;
+    const arr = coverageGroups.get(key);
+    if (arr) arr.push(d);
+    else coverageGroups.set(key, [d]);
+  }
+  for (const [key, members] of coverageGroups) {
+    const maxId = Math.max(...members.map((m) => m.event_id));
+    const latest = members.reduce((a, b) =>
+      Date.parse(b.changed_at) > Date.parse(a.changed_at) ? b : a,
+    );
+    items.push({
+      kind: "coverageGroup",
+      tier: "housekeeping",
+      id: `coverage:${key}`,
+      transition: `${latest.old_status} → ${latest.new_status ?? "—"}`,
+      symbols: uniqueSorted(members.map((m) => m.symbol)),
+      count: members.length,
+      latestTs: latest.changed_at,
+      sortKey: Date.parse(latest.changed_at),
+      maxId,
+      unseen: cursors.coverage === null || maxId > cursors.coverage,
+    });
+  }
+
+  items.sort(
+    (a, b) => TIER_ORDER[a.tier] - TIER_ORDER[b.tier] || b.sortKey - a.sortKey,
+  );
+  return items;
+}

--- a/frontend/src/components/dashboard/alertModel.ts
+++ b/frontend/src/components/dashboard/alertModel.ts
@@ -139,6 +139,10 @@ export const GUARD_REASON_META: Record<string, GuardReasonMeta> = {
   },
 };
 
+// Must match the literal the backend emits: `app/services/execution_guard.py:593`
+// `return "FAIL — " + "; ".join(parts)` (note the em-dash, U+2014). If that
+// format ever changes, `parseGuardReason` still degrades gracefully — it just
+// skips the strip and reads the code before the first ":".
 const GUARD_PREFIX = "FAIL — ";
 
 /**


### PR DESCRIPTION
Closes #1898.

## Problem (verified on live dev)
`GET /alerts/guard-rejections` returned **18 rows that were really 2 conditions**: 15
`kill_switch` (4 symbols × several days) + 3 `auto_trading`. The strip rendered one row per
`(subject × emission)` → header "19 new", nineteen near-identical rows, zero information, and
any genuinely actionable alert buried underneath.

## Change (FE-only)
Collapse each of the three feeds to root-cause groups, ordered by severity tier:
- **actionable** (position SL/TP/thesis breach) — kept per-instrument, never buried; links to the instrument.
- **informational** (guard rejections) — one card per leading rule code, showing the affected
  symbols, a plain-English consequence, and a remediation link.
- **housekeeping** (coverage drops) — one card per `old → new` transition.

Result on live data: **19-row flood → 2 guard cards + 1 coverage card**.

### Source rule (grouping key)
`app/services/execution_guard.py::_build_explanation` emits
`"FAIL — " + "; ".join(f"{rule}: {detail}")`. A `detail` may itself contain `"; "`, so
re-splitting the whole string is ambiguous — the **only** unambiguous key is the leading rule
code (substring after `"FAIL — "`, before the first `":"`). That is the group key. All 17
`RuleName` codes (execution_guard.py:89-107) get a curated label + consequence; unknown codes
fall back to a humanized label + `/recommendations`.

### Preserved accounting (unchanged)
Seen/unseen + overflow still operate on the **raw feed arrays by BIGSERIAL id**:
mark-read / dismiss use per-feed max ids (not group `latestTs` — clocks can skew), the header
pill keeps the honest emission count (`19 new`), and overflow compares backend `unseen_count`
to raw fetched row counts. Grouping never feeds the counts. `snapshot_read`, partial-failure
tolerance, cursors — all untouched. No backend / schema change.

### Prevention-log #758/#759
Group cards are keyed by a Map key (`guard:<code>` / `coverage:<transition>`), unique within
the rendered list **by construction** — no non-unique group label used as a React key.

### Security model
No auth/authorization change. Read-only dashboard component; no new endpoints; no writes.

## Conscious tradeoffs / deviations
- **Hard-safety:** the ticket direction shows a `[Deactivate]` button on the kill-switch card.
  Wiring a kill-switch mutation is out of scope (and forbidden for the unattended loop). The
  card links to **/admin** ("Manage in Admin") where the operator deactivates.
- **Deferred:** item 4 (new alert types — score-rank moves, completeness drops, thesis
  staleness) needs new backend data; tracked as a follow-up, not bundled here.

## Verification
- `alertModel.test.ts` (pure, no DB) — 16 cases: `parseGuardReason` (prefix present/absent,
  detail-with-colon, multi-rule), the 12-emission flood → 1 card, per-reason splitting, null
  symbol handling, null `new_status` `∅` key vs `—` display, tier ordering, unseen propagation.
- `AlertsStrip.test.tsx` — 28 cases updated for grouped/tiered markup incl. "grouping alone
  does NOT trigger overflow" and mark-all-read uses raw MAX id.
- `pnpm typecheck`, `pnpm dark:check`, full `pnpm test:unit` (1231) — green.
- **Live FE-verify** on a worktree build against the running API (:8000): 19-row flood → 2
  guard cards (Kill switch active ×15 / Auto-trading disabled ×3) + 1 coverage card (LFCR);
  light + dark mode clean; `scrollHeight == innerHeight` (no dead scroll-space).
- Codex ckpt-1 (spec) + ckpt-2 (branch): no real issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)