### PR TITLE
fix(#1904): resolve exchange name + tier-first default order on Instruments list

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -147,7 +147,14 @@ class InstrumentListItem(BaseModel):
     instrument_id: int
     symbol: str
     company_name: str
+    # Raw eToro exchangeId (opaque numeric text, e.g. "21"). Retained as the
+    # filter key; NEVER render directly — use ``exchange_name`` (#1904).
     exchange: str | None
+    # Human exchange label resolved from ``exchanges.description`` (the
+    # eToro-provided name, per settled decision "etoro/exchanges"). NULL when
+    # the id has no row yet (a newly-observed exchange not in the table); the
+    # FE then falls back to the raw id (#1904).
+    exchange_name: str | None
     currency: str | None
     sector: str | None
     # #1675: real GICS sector + its sector-SPDR, resolved on-read from the SEC
@@ -561,7 +568,11 @@ def list_instruments(
         quarters); False matches instruments with no such signal. Backed by
         the ``instrument_dividend_summary`` view (sql/050).
 
-    Ordering: symbol ASC, instrument_id ASC (deterministic tiebreak).
+    Ordering: coverage_tier ASC (NULLS LAST), then symbol ASC, instrument_id
+    ASC (deterministic tiebreak). Most-covered instruments surface first so
+    the default view opens on rich rows (Tier-1 US names) rather than the
+    empty non-US tail whose numeric symbols sort to the front alphabetically
+    (#1904).
     """
     # -- WHERE clause fragments (parameterised) ----------------------------
     where_clauses: list[str] = []
@@ -622,6 +633,7 @@ def list_instruments(
     # real GICS sector for display (#1675), independent of whether the
     # sector_spdr filter is active. PK join — trivial cost.
     items_sql = f"""SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
+               ex.description AS exchange_name,
                i.currency, i.sector, p.sic, i.is_tradable,
                c.coverage_tier,
                q.bid, q.ask, q.last, q.spread_pct, q.quoted_at
@@ -629,9 +641,10 @@ def list_instruments(
         LEFT JOIN quotes q USING (instrument_id)
         LEFT JOIN coverage c USING (instrument_id)
         LEFT JOIN instrument_sec_profile p USING (instrument_id)
+        LEFT JOIN exchanges ex ON ex.exchange_id = i.exchange
         {items_dividend_join}
         {where_sql}
-        ORDER BY i.symbol, i.instrument_id
+        ORDER BY c.coverage_tier ASC NULLS LAST, i.symbol ASC, i.instrument_id
         LIMIT %(limit)s OFFSET %(offset)s"""  # noqa: S608  — hardcoded fragments only
 
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
@@ -651,6 +664,7 @@ def list_instruments(
                 symbol=r["symbol"],  # type: ignore[arg-type]
                 company_name=r["company_name"],  # type: ignore[arg-type]
                 exchange=r["exchange"],  # type: ignore[arg-type]
+                exchange_name=r["exchange_name"],  # type: ignore[arg-type]
                 currency=r["currency"],  # type: ignore[arg-type]
                 sector=r["sector"],  # type: ignore[arg-type]
                 gics_sector=sc.gics_sector if sc is not None else None,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -244,7 +244,12 @@ export interface InstrumentListItem {
   instrument_id: number;
   symbol: string;
   company_name: string;
+  // Raw eToro exchangeId (opaque numeric text, e.g. "21"); the filter key.
+  // Render `exchange_name`, not this (#1904).
   exchange: string | null;
+  // Human exchange label from `exchanges.description`; null when the id has no
+  // row yet — fall back to the raw `exchange` (#1904).
+  exchange_name: string | null;
   currency: string | null;
   sector: string | null;
   // #1675: real GICS sector + sector-SPDR resolved on-read from the SEC SIC.

--- a/frontend/src/pages/InstrumentsPage.test.tsx
+++ b/frontend/src/pages/InstrumentsPage.test.tsx
@@ -38,7 +38,8 @@ function makeResponse(
         instrument_id: 1,
         symbol: "AAPL",
         company_name: "Apple Inc.",
-        exchange: "NASDAQ",
+        exchange: "4",
+        exchange_name: "Nasdaq",
         currency: "USD",
         sector: "Technology",
         gics_sector: "Information Technology",
@@ -57,7 +58,8 @@ function makeResponse(
         instrument_id: 2,
         symbol: "MSFT",
         company_name: "Microsoft Corp.",
-        exchange: "NASDAQ",
+        exchange: "4",
+        exchange_name: "Nasdaq",
         currency: "USD",
         sector: "Technology",
         gics_sector: "Information Technology",
@@ -76,7 +78,8 @@ function makeResponse(
         instrument_id: 3,
         symbol: "JPM",
         company_name: "JPMorgan Chase",
-        exchange: "NYSE",
+        exchange: "5",
+        exchange_name: "NYSE",
         currency: "USD",
         sector: "Financial Services",
         gics_sector: "Financials",
@@ -325,22 +328,82 @@ describe("InstrumentsPage — pagination", () => {
 // ---------------------------------------------------------------------------
 
 describe("InstrumentsPage — sorting", () => {
-  it("clicking a column header toggles sort direction", async () => {
+  it("defaults to coverage-tier order (#1904 — rich rows first)", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    // Default sort mirrors the server order: coverage_tier ASC, NULLs last.
+    // AAPL (tier 1) → MSFT (tier 2) → JPM (null).
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("AAPL");
+    expect(rows[2]).toHaveTextContent("MSFT");
+    expect(rows[3]).toHaveTextContent("JPM");
+  });
+
+  it("clicking a column header sorts asc then toggles to desc", async () => {
     renderPage();
     await waitFor(() => {
       expect(screen.getByText("AAPL")).toBeInTheDocument();
     });
 
     const user = userEvent.setup();
-    // Symbol column is default asc — click to toggle to desc
     const symbolHeader = screen.getByText("Instrument");
+    // First click on a non-active column → symbol ASC (AAPL, JPM, MSFT).
     await user.click(symbolHeader);
-
-    // After clicking default asc column, should be desc — MSFT first
     await waitFor(() => {
-      const rows = screen.getAllByRole("row");
-      // Row 0 is header; row 1 should be MSFT (desc order)
-      expect(rows[1]).toHaveTextContent("MSFT");
+      expect(screen.getAllByRole("row")[1]).toHaveTextContent("AAPL");
     });
+    // Second click toggles to DESC — MSFT first.
+    await user.click(symbolHeader);
+    await waitFor(() => {
+      expect(screen.getAllByRole("row")[1]).toHaveTextContent("MSFT");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exchange label (#1904)
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — exchange label", () => {
+  it("renders the human exchange name, not the raw eToro id", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    const table = screen.getByRole("table");
+    // exchange_name "Nasdaq" is shown; the raw id "4" never appears.
+    expect(within(table).getAllByText("Nasdaq").length).toBeGreaterThanOrEqual(1);
+    expect(within(table).queryByText("4")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the raw id when exchange_name is null", async () => {
+    mockedFetch.mockResolvedValue(
+      makeResponse({
+        items: [
+          {
+            instrument_id: 9,
+            symbol: "NEWX",
+            company_name: "Newly Listed Co.",
+            exchange: "99",
+            exchange_name: null,
+            currency: "USD",
+            sector: null,
+            gics_sector: null,
+            sector_spdr: null,
+            is_tradable: true,
+            coverage_tier: 3,
+            latest_quote: null,
+          },
+        ],
+        total: 1,
+      }),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("NEWX")).toBeInTheDocument();
+    });
+    expect(within(screen.getByRole("table")).getByText("99")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -53,6 +53,12 @@ const INITIAL_FILTERS: Filters = {
 type SortKey = "symbol" | "gics_sector" | "exchange" | "coverage_tier" | "last";
 type SortDir = "asc" | "desc";
 
+// The server's default ordering (#1904): coverage_tier ASC (NULLS LAST), then
+// symbol. The client's initial sort mirrors it exactly, so the default view is
+// globally tier-ordered (not page-scoped) and the "sorted within this page"
+// caveat is only shown once the operator picks a different column.
+const SERVER_SORT: { key: SortKey; dir: SortDir } = { key: "coverage_tier", dir: "asc" };
+
 function compare(a: unknown, b: unknown, dir: SortDir): number {
   if (a == null && b == null) return 0;
   if (a == null) return 1;
@@ -74,7 +80,9 @@ function sortValue(item: InstrumentListItem, key: SortKey): unknown {
     case "gics_sector":
       return item.gics_sector;
     case "exchange":
-      return item.exchange;
+      // Sort by the visible label, not the raw eToro id (#1904) — otherwise
+      // clicking "Exchange" orders by invisible numeric ids.
+      return item.exchange_name ?? item.exchange;
     case "coverage_tier":
       return item.coverage_tier;
     case "last":
@@ -113,10 +121,7 @@ function TierBadge({ tier }: { tier: number | null }) {
 export function InstrumentsPage() {
   const [filters, setFilters] = useState<Filters>(INITIAL_FILTERS);
   const [page, setPage] = useState(0);
-  const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>({
-    key: "symbol",
-    dir: "asc",
-  });
+  const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>(SERVER_SORT);
 
   // Debounced search: apply after 300ms of inactivity.
   const [searchInput, setSearchInput] = useState("");
@@ -146,8 +151,12 @@ export function InstrumentsPage() {
 
   // Sector dropdown uses the fixed 11 GICS sectors (#1675, SECTOR_OPTIONS), so
   // only exchange is still derived from the current page's data. A full enum
-  // endpoint would be better but is not in scope.
-  const [knownExchanges, setKnownExchanges] = useState<string[]>([]);
+  // endpoint would be better but is not in scope. Each option carries the raw
+  // exchangeId as `value` (the filter key) and the human name as `label`
+  // (#1904 — never surface the raw numeric id in the dropdown).
+  const [knownExchanges, setKnownExchanges] = useState<
+    { value: string; label: string }[]
+  >([]);
 
   // Reset accumulated exchange options when filters change (prevents stale
   // options from prior queries lingering in the dropdown).
@@ -158,11 +167,15 @@ export function InstrumentsPage() {
   useEffect(() => {
     if (!result.data) return;
     setKnownExchanges((prev) => {
-      const next = new Set(prev);
+      const byId = new Map(prev.map((o) => [o.value, o.label]));
       for (const item of result.data!.items) {
-        if (item.exchange) next.add(item.exchange);
+        if (item.exchange) {
+          byId.set(item.exchange, item.exchange_name ?? item.exchange);
+        }
       }
-      return Array.from(next).sort();
+      return Array.from(byId, ([value, label]) => ({ value, label })).sort(
+        (a, b) => a.label.localeCompare(b.label),
+      );
     });
   }, [result.data]);
 
@@ -345,7 +358,7 @@ function FilterSelect({
 }: {
   label: string;
   value: string;
-  options: string[];
+  options: { value: string; label: string }[];
   onChange: (value: string | null) => void;
 }) {
   return (
@@ -360,8 +373,8 @@ function FilterSelect({
       >
         <option value="">All</option>
         {options.map((opt) => (
-          <option key={opt} value={opt}>
-            {opt}
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
           </option>
         ))}
       </select>
@@ -381,12 +394,41 @@ const COLUMNS: { key: SortKey; label: string; align?: "right" }[] = [
   { key: "last", label: "Last price", align: "right" },
 ];
 
+// Inline chevron SVGs (#1904): the previous unicode arrows (↕ / ↑ / ↓)
+// rendered as tofu / "odd blue squares" in fonts lacking those glyphs. SVGs
+// render identically everywhere and inherit the header's text colour.
 function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
-  if (!active) return <span className="ml-1 text-slate-300">↕</span>;
+  if (!active) {
+    // Inactive: faint up/down stack so every column reads as sortable.
+    return (
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="ml-1 inline-block h-3 w-3 text-slate-300"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M5 6.5 8 3.5l3 3" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M5 9.5 8 12.5l3-3" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
   return (
-    <span className="ml-1 text-slate-600">
-      {dir === "asc" ? "↑" : "↓"}
-    </span>
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="ml-1 inline-block h-3 w-3 text-slate-600 dark:text-slate-300"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+    >
+      {dir === "asc" ? (
+        <path d="M4 10 8 6l4 4" strokeLinecap="round" strokeLinejoin="round" />
+      ) : (
+        <path d="M4 6l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
+      )}
+    </svg>
   );
 }
 
@@ -421,13 +463,15 @@ function InstrumentsTable({
               </th>
             ))}
           </tr>
-          {pageScopedSort && sort.key !== "symbol" && (
-            <tr>
-              <td colSpan={COLUMNS.length} className="pb-1 text-[10px] normal-case tracking-normal text-slate-400">
-                Sorted within this page only. Server order is by symbol.
-              </td>
-            </tr>
-          )}
+          {pageScopedSort &&
+            !(sort.key === SERVER_SORT.key && sort.dir === SERVER_SORT.dir) && (
+              <tr>
+                <td colSpan={COLUMNS.length} className="pb-1 text-[10px] normal-case tracking-normal text-slate-400">
+                  Sorted within this page only. Server order is by coverage
+                  tier, then symbol.
+                </td>
+              </tr>
+            )}
         </thead>
         <tbody className="divide-y divide-slate-100">
           {items.map((item) => (
@@ -445,7 +489,7 @@ function InstrumentsTable({
                 {item.gics_sector ?? "—"}
               </td>
               <td className="py-2 pr-4 text-xs text-slate-600">
-                {item.exchange ?? "—"}
+                {item.exchange_name ?? item.exchange ?? "—"}
               </td>
               <td className="py-2 pr-4">
                 <TierBadge tier={item.coverage_tier} />

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -169,8 +169,14 @@ export function InstrumentsPage() {
     setKnownExchanges((prev) => {
       const byId = new Map(prev.map((o) => [o.value, o.label]));
       for (const item of result.data!.items) {
-        if (item.exchange) {
-          byId.set(item.exchange, item.exchange_name ?? item.exchange);
+        if (!item.exchange) continue;
+        // Once a real name has been seen for an id, keep it — a later page
+        // whose row happens to carry a null exchange_name must not revert the
+        // dropdown label to the raw id (bot NITPICK, PR #1923).
+        if (item.exchange_name != null) {
+          byId.set(item.exchange, item.exchange_name);
+        } else if (!byId.has(item.exchange)) {
+          byId.set(item.exchange, item.exchange);
         }
       }
       return Array.from(byId, ([value, label]) => ({ value, label })).sort(

--- a/tests/test_api_instruments.py
+++ b/tests/test_api_instruments.py
@@ -52,7 +52,8 @@ def _make_instrument_row(
     instrument_id: int = 1,
     symbol: str = "AAPL",
     company_name: str = "Apple Inc",
-    exchange: str | None = "NASDAQ",
+    exchange: str | None = "4",
+    exchange_name: str | None = "Nasdaq",
     currency: str | None = "USD",
     sector: str | None = "Technology",
     industry: str | None = "Consumer Electronics",
@@ -73,6 +74,7 @@ def _make_instrument_row(
         "symbol": symbol,
         "company_name": company_name,
         "exchange": exchange,
+        "exchange_name": exchange_name,
         "currency": currency,
         "sector": sector,
         "industry": industry,
@@ -184,6 +186,22 @@ class TestListInstruments:
         assert item["coverage_tier"] == 1
         assert item["latest_quote"]["bid"] == 185.50
         assert item["latest_quote"]["ask"] == 185.60
+        # #1904: raw eToro exchangeId is echoed for the filter, but the human
+        # label from exchanges.description is surfaced separately.
+        assert item["exchange"] == "4"
+        assert item["exchange_name"] == "Nasdaq"
+
+    def test_exchange_name_null_when_unmapped(self) -> None:
+        # A newly-observed exchangeId with no exchanges row → NULL label; the
+        # FE falls back to the raw id (#1904).
+        row = _make_instrument_row(exchange="99", exchange_name=None)
+        _with_conn([[{"cnt": 1}], [row]])
+        resp = client.get("/instruments")
+
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["exchange"] == "99"
+        assert item["exchange_name"] is None
 
     def test_empty_table_returns_empty_list(self) -> None:
         _with_conn([[{"cnt": 0}], []])


### PR DESCRIPTION
## Problem (#1904, 2026-07-04 design audit)
`/instruments` default (alphabetical) opened on the non-US tail: numeric HK tickers (`00001.HK`…) sort first, so the first screen showed raw eToro `exchangeId` ("21"), blank sectors, no prices — "the worst data in the universe" as a first impression. Sort-header glyphs rendered as tofu/"odd blue squares".

## Change (the clear correctness slice)
**API (`app/api/instruments.py`)**
- `LEFT JOIN exchanges ex ON ex.exchange_id = i.exchange`; return `exchange_name` (`exchanges.description` — the eToro-provided label, per settled decision *etoro/exchanges*) alongside the raw `exchange` id (kept as the filter key).
- Default `ORDER BY coverage_tier ASC NULLS LAST, i.symbol ASC, i.instrument_id` so Tier-1 US names surface first.

**FE (`InstrumentsPage.tsx`, `types.ts`)**
- Render `exchange_name ?? exchange ?? "—"`; the Exchange filter dropdown shows names (value = id).
- Default client sort mirrors the server order (`coverage_tier` asc), so the default view is globally tier-ordered and the "sorted within this page" caveat only shows once the operator picks another column.
- Exchange column **sorts by the visible label** (`exchange_name ?? exchange`), not the raw id (Codex ckpt-2 catch).
- Sort-header glyphs → inline chevron SVGs (render identically everywhere; fix the missing-glyph "blue squares").

## Scope / deferred
Deferred (visual taste / bigger plumbing, not bundled): all-dashes "no coverage yet" row treatment (dir #3); day-change column (dir #4 — needs prev-close plumbing; sector + last-price already render).

## Security model
Read-only. No schema change, no migration, no writes, no auth/authorization surface touched, no trade path. `exchange_name` is a nullable additive response field; the `exchanges` FK-resolution table (sql/067) is operator-curated.

## Verification
- **Dev-DB SQL:** old alphabetical head `00001.HK` (dash tail) → new tier-first head `BBBY / GME / IEP / QQQ / VOO` (Tier-1 US); exchange `21` → "Hong Kong Exchanges"; **0** instruments have an exchange id with no `exchanges` row (LEFT JOIN + FE fallback covers future new ids).
- **Tests:** backend `TestListInstruments` (24) + 2 new `exchange_name` cases pass; FE `InstrumentsPage.test.tsx` 18 pass (default tier order, asc→desc toggle, name-render, null fallback). `pnpm typecheck`, ruff, `pyright` clean.
- Live-stack visual QA not possible from this worktree — the dev stack serves `~/Dev/eBull` (main), not the in-flight branch.
- Pre-existing (NOT this PR): `TestGetInstrumentDetail` fails on clean HEAD with `KeyError: 'session_profile'`; that module is auto-`db`-marked (via `TestClient`) and off the fast push gate.

Part of #1904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)