### PR TITLE
feat(#1899): surface per-trade rows on the instrument Positions tab

### DIFF
--- a/frontend/src/components/instrument/InstrumentTradesTable.test.tsx
+++ b/frontend/src/components/instrument/InstrumentTradesTable.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for InstrumentTradesTable (#1899 slice 1 — per-trade rows on the
+ * instrument Positions tab).
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+
+import { InstrumentTradesTable } from "@/components/instrument/InstrumentTradesTable";
+import type { NativeTradeItem } from "@/api/types";
+
+function trade(overrides: Partial<NativeTradeItem> = {}): NativeTradeItem {
+  return {
+    position_id: 1,
+    is_buy: true,
+    units: 10,
+    amount: 1855.0,
+    open_rate: 185.5,
+    open_date_time: "2026-03-15T09:30:00Z",
+    current_price: 190.0,
+    market_value: 1900.0,
+    unrealized_pnl: 45.0,
+    stop_loss_rate: null,
+    take_profit_rate: null,
+    is_tsl_enabled: false,
+    leverage: 1,
+    total_fees: 1.25,
+    ...overrides,
+  };
+}
+
+describe("InstrumentTradesTable", () => {
+  it("renders one row per trade with the open date and side", () => {
+    render(
+      <InstrumentTradesTable
+        currency="USD"
+        trades={[
+          trade({ position_id: 1, is_buy: true }),
+          trade({ position_id: 2, is_buy: false, open_date_time: "2026-04-01T14:00:00Z" }),
+        ]}
+      />,
+    );
+    // Header (Open trades (2)) plus a labelled table.
+    expect(screen.getByText("Open trades (2)")).toBeInTheDocument();
+    const rows = screen.getAllByRole("row");
+    // header row + 2 data rows
+    expect(rows).toHaveLength(3);
+    expect(screen.getByText("2026-03-15")).toBeInTheDocument();
+    expect(screen.getByText("2026-04-01")).toBeInTheDocument();
+    expect(screen.getByText("Buy")).toBeInTheDocument();
+    expect(screen.getByText("Sell")).toBeInTheDocument();
+  });
+
+  it("shows a signed, currency-formatted P&L", () => {
+    render(
+      <InstrumentTradesTable
+        currency="USD"
+        trades={[trade({ unrealized_pnl: 45 }), trade({ position_id: 2, unrealized_pnl: -12.5 })]}
+      />,
+    );
+    const table = screen.getByRole("table");
+    // formatMoney uses en-GB, so USD renders as "US$" (disambiguated).
+    expect(within(table).getByText("+US$45.00")).toBeInTheDocument();
+    expect(within(table).getByText("-US$12.50")).toBeInTheDocument();
+  });
+
+  it("renders a dash for a missing current price", () => {
+    render(
+      <InstrumentTradesTable currency="USD" trades={[trade({ current_price: null })]} />,
+    );
+    // formatMoney(null) → "—"
+    expect(screen.getByRole("table").textContent).toContain("—");
+  });
+
+  it("renders nothing when there are no trades", () => {
+    const { container } = render(
+      <InstrumentTradesTable currency="USD" trades={[]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/components/instrument/InstrumentTradesTable.tsx
+++ b/frontend/src/components/instrument/InstrumentTradesTable.tsx
@@ -1,0 +1,97 @@
+/**
+ * Per-trade table for the instrument Positions tab (#1899, slice 1).
+ *
+ * The instrument drill-through endpoint (GET /portfolio/instruments/:id)
+ * already returns the individual broker trades behind the aggregate
+ * position — but the Positions tab only rendered "Trades: N". This
+ * surfaces each open trade (entry date, side, units, entry price, current
+ * price, per-trade P&L, fees) so the operator can see the round-trips that
+ * make up their holding, not just the blended total.
+ *
+ * All figures are in the instrument's NATIVE currency (the tab shows the
+ * currency code once); this table therefore takes `currency` and formats
+ * money consistently via `formatMoney`.
+ */
+
+import type { NativeTradeItem } from "@/api/types";
+import { formatMoney, formatNumber } from "@/lib/format";
+
+function SideBadge({ isBuy }: { isBuy: boolean }) {
+  return (
+    <span
+      className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${
+        isBuy
+          ? "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300"
+          : "bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300"
+      }`}
+    >
+      {isBuy ? "Buy" : "Sell"}
+    </span>
+  );
+}
+
+export function InstrumentTradesTable({
+  trades,
+  currency,
+}: {
+  trades: NativeTradeItem[];
+  currency: string;
+}) {
+  if (trades.length === 0) return null;
+
+  return (
+    <div className="mt-4 overflow-x-auto">
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+        Open trades ({trades.length})
+      </h3>
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            <th className="py-2 pr-4">Opened</th>
+            <th className="py-2 pr-4">Side</th>
+            <th className="py-2 pr-4 text-right">Units</th>
+            <th className="py-2 pr-4 text-right">Entry</th>
+            <th className="py-2 pr-4 text-right">Price</th>
+            <th className="py-2 pr-4 text-right">P&amp;L</th>
+            <th className="py-2 pr-0 text-right">Fees</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          {trades.map((t) => {
+            const pnlColor =
+              t.unrealized_pnl > 0
+                ? "text-emerald-600 dark:text-emerald-400"
+                : t.unrealized_pnl < 0
+                  ? "text-red-600 dark:text-red-400"
+                  : "text-slate-600 dark:text-slate-300";
+            return (
+              <tr key={t.position_id} className="text-slate-700 dark:text-slate-200">
+                <td className="py-2 pr-4 text-xs text-slate-500">
+                  {t.open_date_time.slice(0, 10)}
+                </td>
+                <td className="py-2 pr-4">
+                  <SideBadge isBuy={t.is_buy} />
+                </td>
+                <td className="py-2 pr-4 text-right tabular-nums">
+                  {formatNumber(t.units)}
+                </td>
+                <td className="py-2 pr-4 text-right tabular-nums">
+                  {formatMoney(t.open_rate, currency)}
+                </td>
+                <td className="py-2 pr-4 text-right tabular-nums">
+                  {formatMoney(t.current_price, currency)}
+                </td>
+                <td className={`py-2 pr-4 text-right tabular-nums ${pnlColor}`}>
+                  {`${t.unrealized_pnl >= 0 ? "+" : ""}${formatMoney(t.unrealized_pnl, currency)}`}
+                </td>
+                <td className="py-2 pr-0 text-right tabular-nums text-slate-500">
+                  {formatMoney(t.total_fees, currency)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/InstrumentTradesTable.tsx
+++ b/frontend/src/components/instrument/InstrumentTradesTable.tsx
@@ -67,7 +67,7 @@ export function InstrumentTradesTable({
             return (
               <tr key={t.position_id} className="text-slate-700 dark:text-slate-200">
                 <td className="py-2 pr-4 text-xs text-slate-500">
-                  {t.open_date_time.slice(0, 10)}
+                  {t.open_date_time ? t.open_date_time.slice(0, 10) : "—"}
                 </td>
                 <td className="py-2 pr-4">
                   <SideBadge isBuy={t.is_buy} />

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -41,6 +41,7 @@ import type {
   NewsListResponse,
   ThesisDetail,
 } from "@/api/types";
+import { InstrumentTradesTable } from "@/components/instrument/InstrumentTradesTable";
 import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
@@ -314,9 +315,10 @@ function PositionsTab({ symbol, instrumentId }: { symbol: string; instrumentId: 
           {data.total_pnl >= 0 ? "+" : ""}
           {data.total_pnl.toFixed(2)}
         </dd>
-        <dt className="text-slate-500">Trades</dt>
-        <dd>{data.trades.length}</dd>
       </dl>
+      {/* #1899 slice 1: the individual trades behind the aggregate, not just
+          a count. Data already loaded above — no extra fetch. */}
+      <InstrumentTradesTable trades={data.trades} currency={data.currency} />
     </Section>
   );
 }


### PR DESCRIPTION
## Problem (#1899, slice 1)
Operator: "why can't I see a history of my trades?" The instrument **Positions** tab fetched the individual broker trades behind a holding (`data.trades` from `GET /portfolio/instruments/:id`) but rendered only an aggregate + `Trades: 2` — the trades themselves were invisible.

## Change
- New pure, presentational **`InstrumentTradesTable`** renders each open trade: opened date, side (Buy/Sell), units, entry, current price, per-trade unrealised P&L (signed, coloured), fees — all in the instrument's **native currency** (the tab already shows the currency code once).
- Wired into `PositionsTab`; the redundant aggregate "Trades" count is removed (the table header shows the count).
- **No API change, no extra fetch** — the per-trade data was already in the loaded payload.
- Units rendered via `formatNumber` (4dp, matching `PositionsTable`) so fractional / crypto positions aren't rounded away (Codex ckpt-2 catch — `toLocaleString`'s 3dp default would drop small quantities).

## Scope / deferred
Slice 1 only. Deferred (separate work — need endpoint/UX changes): closed round-trip history per instrument (needs a `?symbol` filter on `/portfolio/activity`); URL-driven Activity tab + per-symbol filter + pagination; Activity currency display-convert. Noted on #1899.

## Security model
Read-only presentational component; no new endpoint, no writes, no trade actions, no auth surface. Renders data the Positions tab already fetched.

## Verification
- `InstrumentTradesTable.test.tsx` — 4 cases (one row per trade + date/side; signed currency-formatted P&L; dash for missing current price; renders nothing when empty).
- Full FE unit suite **1218 pass**; `pnpm typecheck` clean; dark-mode class gate clean.
- Live-stack visual QA not possible from this worktree — dev stack serves `~/Dev/eBull` (main), not the in-flight branch.

Part of #1899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)