### PR TITLE
feat(#1926): closed round-trip trade history on the instrument Positions tab

### DIFF
--- a/app/api/portfolio.py
+++ b/app/api/portfolio.py
@@ -1193,6 +1193,7 @@ class ActivityResponse(BaseModel):
 def get_activity(
     limit: int = Query(default=100, ge=1, le=500),
     include_mirrors: bool = False,
+    instrument_id: int | None = Query(default=None, ge=1),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> ActivityResponse:
     """Trade ledger feed, newest first.
@@ -1200,6 +1201,11 @@ def get_activity(
     Mirror-originated rows (``social_trade_id != 0``) are excluded by
     default, consistent with the value-history chart's own-portfolio
     basis; ``include_mirrors=true`` widens the filter.
+
+    ``instrument_id`` scopes the ledger to a single instrument (its internal
+    ``instruments.instrument_id``) — used by the per-instrument Positions tab
+    to render that symbol's closed round-trips (#1926). ``total`` reflects the
+    same filter.
 
     ``fees`` / ``realized_pnl`` are FX-converted from their at-rest USD
     figures (``trade_events.fees_usd`` / ``.realized_pnl_usd``) to the
@@ -1234,9 +1240,10 @@ def get_activity(
             """
             SELECT COUNT(*) AS total
             FROM trade_events
-            WHERE %(include_mirrors)s OR COALESCE(social_trade_id, 0) = 0
+            WHERE (%(include_mirrors)s OR COALESCE(social_trade_id, 0) = 0)
+              AND (%(instrument_id)s IS NULL OR instrument_id = %(instrument_id)s)
             """,
-            {"include_mirrors": include_mirrors},
+            {"include_mirrors": include_mirrors, "instrument_id": instrument_id},
         ).fetchone()
         total = int(total_row["total"]) if total_row else 0
 
@@ -1260,11 +1267,12 @@ def get_activity(
                 FROM trade_events
                 WHERE event_kind = 'open'
             ) o ON o.position_id = te.position_id AND te.event_kind = 'close'
-            WHERE %(include_mirrors)s OR COALESCE(te.social_trade_id, 0) = 0
+            WHERE (%(include_mirrors)s OR COALESCE(te.social_trade_id, 0) = 0)
+              AND (%(instrument_id)s IS NULL OR te.instrument_id = %(instrument_id)s)
             ORDER BY te.executed_at DESC, te.event_id DESC
             LIMIT %(limit)s
             """,
-            {"include_mirrors": include_mirrors, "limit": limit},
+            {"include_mirrors": include_mirrors, "limit": limit, "instrument_id": instrument_id},
         ).fetchall()
 
     events = []

--- a/frontend/src/api/portfolio.ts
+++ b/frontend/src/api/portfolio.ts
@@ -28,7 +28,15 @@ export function fetchValueHistory(
   );
 }
 
-export function fetchActivity(includeMirrors: boolean): Promise<ActivityResponse> {
+export function fetchActivity(
+  includeMirrors: boolean,
+  instrumentId?: number,
+  limit?: number,
+): Promise<ActivityResponse> {
   const params = new URLSearchParams({ include_mirrors: String(includeMirrors) });
+  // Scope the ledger to one instrument for the per-instrument Positions tab
+  // trade-history section (#1926).
+  if (instrumentId !== undefined) params.set("instrument_id", String(instrumentId));
+  if (limit !== undefined) params.set("limit", String(limit));
   return apiFetch<ActivityResponse>(`/portfolio/activity?${params}`);
 }

--- a/frontend/src/components/instrument/InstrumentTradeHistory.test.tsx
+++ b/frontend/src/components/instrument/InstrumentTradeHistory.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for InstrumentTradeHistory (#1926 slice 2 — closed round-trips on the
+ * instrument Positions tab). The component fetches the trade ledger scoped to
+ * one instrument, so `fetchActivity` is mocked.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+
+import { InstrumentTradeHistory } from "@/components/instrument/InstrumentTradeHistory";
+import { fetchActivity } from "@/api/portfolio";
+import type { ActivityEventItem, ActivityResponse } from "@/api/types";
+
+vi.mock("@/api/portfolio");
+
+function closeEvent(overrides: Partial<ActivityEventItem> = {}): ActivityEventItem {
+  return {
+    event_id: 1,
+    position_id: 100,
+    event_kind: "close",
+    side: "sell",
+    symbol: "AAPL",
+    etoro_instrument_id: 1,
+    units: 82.14,
+    price: 120.56,
+    executed_at: "2025-11-14T19:24:35Z",
+    fees: 0,
+    realized_pnl: 1490.17,
+    holding_period_days: 94.1,
+    source: "etoro_history",
+    is_mirror: false,
+    ...overrides,
+  };
+}
+
+function response(
+  events: ActivityEventItem[],
+  displayCurrency = "GBP",
+  total?: number,
+): ActivityResponse {
+  return {
+    events,
+    total: total ?? events.length,
+    include_mirrors: false,
+    display_currency: displayCurrency,
+  };
+}
+
+describe("InstrumentTradeHistory", () => {
+  beforeEach(() => {
+    vi.mocked(fetchActivity).mockReset();
+  });
+
+  it("renders one row per close with date, held days, and signed display-currency P&L", async () => {
+    vi.mocked(fetchActivity).mockResolvedValue(
+      response([
+        closeEvent({ event_id: 1 }),
+        closeEvent({
+          event_id: 2,
+          executed_at: "2025-10-01T10:00:00Z",
+          price: 100.0,
+          realized_pnl: -50.5,
+          holding_period_days: 3.4,
+        }),
+      ]),
+    );
+    render(<InstrumentTradeHistory instrumentId={4077} currency="USD" />);
+
+    const heading = await screen.findByText("Trade history (2)");
+    expect(heading).toBeInTheDocument();
+    const table = screen.getByRole("table");
+    expect(screen.getByText("14 Nov 2025")).toBeInTheDocument();
+    expect(screen.getByText("01 Oct 2025")).toBeInTheDocument();
+    // Exit price is native (USD → "US$"); realised P&L is display (GBP → "£").
+    expect(within(table).getByText("US$120.56")).toBeInTheDocument();
+    expect(within(table).getByText("+£1,490.17")).toBeInTheDocument();
+    expect(within(table).getByText("-£50.50")).toBeInTheDocument();
+    expect(within(table).getByText("94d")).toBeInTheDocument();
+    expect(within(table).getByText("3d")).toBeInTheDocument();
+  });
+
+  it("filters out open events — only closed round-trips render", async () => {
+    vi.mocked(fetchActivity).mockResolvedValue(
+      response([
+        closeEvent({ event_id: 1 }),
+        closeEvent({ event_id: 2, event_kind: "open", side: "buy", realized_pnl: null }),
+      ]),
+    );
+    render(<InstrumentTradeHistory instrumentId={4077} currency="USD" />);
+
+    await screen.findByText("Trade history (1)");
+    // header row + 1 close row only
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+  });
+
+  it("scopes the fetch to the instrument, excluding mirrors, at the max page", async () => {
+    vi.mocked(fetchActivity).mockResolvedValue(response([closeEvent()]));
+    render(<InstrumentTradeHistory instrumentId={4077} currency="USD" />);
+    await waitFor(() => expect(fetchActivity).toHaveBeenCalledWith(false, 4077, 500));
+  });
+
+  it("surfaces a truncation hint when the ledger page omits older rows", async () => {
+    // total (600) exceeds the returned events (1) → some rows were dropped.
+    vi.mocked(fetchActivity).mockResolvedValue(response([closeEvent()], "GBP", 600));
+    render(<InstrumentTradeHistory instrumentId={4077} currency="USD" />);
+    expect(
+      await screen.findByText(/older trades may be omitted/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no truncation hint when the full history fits", async () => {
+    vi.mocked(fetchActivity).mockResolvedValue(response([closeEvent()]));
+    render(<InstrumentTradeHistory instrumentId={4077} currency="USD" />);
+    await screen.findByText("Trade history (1)");
+    expect(screen.queryByText(/older trades may be omitted/i)).toBeNull();
+  });
+
+  it("renders nothing when there are no closed trades", async () => {
+    vi.mocked(fetchActivity).mockResolvedValue(response([]));
+    const { container } = render(
+      <InstrumentTradeHistory instrumentId={4077} currency="USD" />,
+    );
+    await waitFor(() => expect(fetchActivity).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a muted line on error", async () => {
+    vi.mocked(fetchActivity).mockRejectedValue(new Error("boom"));
+    render(<InstrumentTradeHistory instrumentId={4077} currency="USD" />);
+    expect(await screen.findByText("Trade history unavailable.")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/InstrumentTradeHistory.tsx
+++ b/frontend/src/components/instrument/InstrumentTradeHistory.tsx
@@ -1,0 +1,124 @@
+/**
+ * Closed round-trip history for the instrument Positions tab (#1926, slice 2
+ * of #1899).
+ *
+ * The trade ledger (GET /portfolio/activity) is filtered to this instrument;
+ * every `close` event is a realised round-trip — exit price, units, realised
+ * P&L and holding period. It renders below the open-trades table so the
+ * operator sees what they've already closed on this symbol, not just what's
+ * still open.
+ *
+ * Currency: exit `price` is the instrument's NATIVE currency (the `currency`
+ * prop, same as the open-trades table); realised P&L is the operator's DISPLAY
+ * currency (#1906 — account-level realised P&L is display currency). Each is
+ * self-labelled by `formatMoney`, so the mix is unambiguous.
+ *
+ * This is a supplementary section: it stays silent while loading, shows a muted
+ * line on error, and renders nothing when there are no closed trades (the
+ * caller always renders an anchor — open trades or the "Not held" state — so a
+ * blank section here is unambiguous).
+ *
+ * We request the ledger's max page (`LIMIT`) scoped to this one instrument, so
+ * a full trade history is fetched in a single call for all but pathological
+ * cases. If the instrument's row count still exceeds the page, `total` will
+ * exceed the returned events and we surface a "recent subset" hint rather than
+ * silently understating the history.
+ */
+
+import { fetchActivity } from "@/api/portfolio";
+import type { ActivityResponse } from "@/api/types";
+import { formatDate, formatMoney, formatNumber } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+// GET /portfolio/activity caps `limit` at 500 (le=500). One instrument almost
+// never has this many trade events, so a single max-page fetch is complete.
+const MAX_LEDGER_PAGE = 500;
+
+export function InstrumentTradeHistory({
+  instrumentId,
+  currency,
+}: {
+  instrumentId: number;
+  currency: string;
+}) {
+  const { data, error, loading } = useAsync<ActivityResponse>(
+    () => fetchActivity(false, instrumentId, MAX_LEDGER_PAGE),
+    [instrumentId],
+  );
+
+  if (loading) return null;
+  if (error !== null) {
+    return (
+      <p className="mt-4 text-xs text-slate-500">Trade history unavailable.</p>
+    );
+  }
+  if (!data) return null;
+
+  const closes = data.events.filter((e) => e.event_kind === "close");
+  if (closes.length === 0) return null;
+  // `total` counts every ledger row for this instrument (opens + closes); when
+  // it exceeds the returned page some rows — possibly older closes — were
+  // dropped. Be honest about it rather than implying the list is complete.
+  const truncated = data.total > data.events.length;
+
+  return (
+    <div className="mt-6 overflow-x-auto">
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+        Trade history ({closes.length})
+      </h3>
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500">
+          <tr>
+            <th className="py-2 pr-4">Closed</th>
+            <th className="py-2 pr-4 text-right">Units</th>
+            <th className="py-2 pr-4 text-right">Exit</th>
+            <th className="py-2 pr-4 text-right">Realised P&amp;L</th>
+            <th className="py-2 pr-0 text-right">Held</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          {closes.map((e) => {
+            const pnl = e.realized_pnl;
+            const pnlColor =
+              pnl === null
+                ? "text-slate-600 dark:text-slate-300"
+                : pnl > 0
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : pnl < 0
+                    ? "text-red-600 dark:text-red-400"
+                    : "text-slate-600 dark:text-slate-300";
+            return (
+              <tr key={e.event_id} className="text-slate-700 dark:text-slate-200">
+                <td className="py-2 pr-4 text-xs text-slate-500">
+                  {formatDate(e.executed_at)}
+                </td>
+                <td className="py-2 pr-4 text-right tabular-nums">
+                  {formatNumber(e.units)}
+                </td>
+                <td className="py-2 pr-4 text-right tabular-nums">
+                  {formatMoney(e.price, currency)}
+                </td>
+                <td className={`py-2 pr-4 text-right tabular-nums ${pnlColor}`}>
+                  {pnl === null
+                    ? "—"
+                    : `${pnl >= 0 ? "+" : ""}${formatMoney(pnl, data.display_currency)}`}
+                </td>
+                <td className="py-2 pr-0 text-right tabular-nums text-slate-500">
+                  {e.holding_period_days === null
+                    ? "—"
+                    : `${Math.round(e.holding_period_days)}d`}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {truncated && (
+        <p className="mt-2 text-xs text-slate-500">
+          Showing the most recent {data.events.length} events — older trades may
+          be omitted.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/InstrumentTradeHistory.tsx
+++ b/frontend/src/components/instrument/InstrumentTradeHistory.tsx
@@ -101,7 +101,11 @@ export function InstrumentTradeHistory({
                 <td className={`py-2 pr-4 text-right tabular-nums ${pnlColor}`}>
                   {pnl === null
                     ? "—"
-                    : `${pnl >= 0 ? "+" : ""}${formatMoney(pnl, data.display_currency)}`}
+                    : // `> 0` (not `>= 0`) so an exactly-zero P&L reads a plain
+                      // "US$0.00" — matching the neutral colour above — rather
+                      // than a misleading "+US$0.00". formatMoney supplies the
+                      // "-" for negatives itself.
+                      `${pnl > 0 ? "+" : ""}${formatMoney(pnl, data.display_currency)}`}
                 </td>
                 <td className="py-2 pr-0 text-right tabular-nums text-slate-500">
                   {e.holding_period_days === null

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -42,6 +42,7 @@ import type {
   ThesisDetail,
 } from "@/api/types";
 import { InstrumentTradesTable } from "@/components/instrument/InstrumentTradesTable";
+import { InstrumentTradeHistory } from "@/components/instrument/InstrumentTradeHistory";
 import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { ClosePositionModal } from "@/components/orders/ClosePositionModal";
 import { OrderEntryModal } from "@/components/orders/OrderEntryModal";
@@ -284,6 +285,12 @@ function PositionsTab({ symbol, instrumentId }: { symbol: string; instrumentId: 
           title="Not held"
           description={`You don't currently hold ${symbol}.`}
         />
+        {/* #1926: a fully closed-out instrument has no current holding but may
+            still have realised round-trips worth showing. `data.currency` is
+            the instrument's native currency (present even at zero units). */}
+        {data && (
+          <InstrumentTradeHistory instrumentId={instrumentId} currency={data.currency} />
+        )}
       </Section>
     );
   }
@@ -319,6 +326,9 @@ function PositionsTab({ symbol, instrumentId }: { symbol: string; instrumentId: 
       {/* #1899 slice 1: the individual trades behind the aggregate, not just
           a count. Data already loaded above — no extra fetch. */}
       <InstrumentTradesTable trades={data.trades} currency={data.currency} />
+      {/* #1926 slice 2: closed round-trips for this instrument (realised P&L,
+          holding period) from the trade ledger, scoped via ?instrument_id. */}
+      <InstrumentTradeHistory instrumentId={instrumentId} currency={data.currency} />
     </Section>
   );
 }

--- a/tests/test_api_portfolio.py
+++ b/tests/test_api_portfolio.py
@@ -824,6 +824,38 @@ class TestGetActivity:
             assert event["fees"] == 10.0
             assert event["realized_pnl"] == 1910.47
 
+    def test_instrument_id_filter_passed_to_both_queries(self) -> None:
+        """?instrument_id scopes the ledger to one instrument (#1926). The
+        filter must reach BOTH the COUNT and the SELECT so `total` and
+        `events` stay consistent — a filtered feed with an unfiltered total
+        would mislabel the row count."""
+        row = _make_activity_row(fees_usd=10.0, realized_pnl_usd=1910.47)
+        conn = _with_chained_conn([{"total": 1}, [row]])
+
+        resp = client.get("/portfolio/activity?instrument_id=4077")
+        assert resp.status_code == 200
+
+        # Two execute() calls: COUNT then SELECT. Both carry instrument_id.
+        cur = conn.cursor.return_value
+        calls = cur.execute.call_args_list
+        assert len(calls) == 2
+        for call in calls:
+            params = call.args[1]
+            assert params["instrument_id"] == 4077
+
+    def test_no_instrument_id_passes_none(self) -> None:
+        """Default (unfiltered) feed passes instrument_id=None so the SQL
+        `IS NULL` branch disables the filter."""
+        row = _make_activity_row()
+        conn = _with_chained_conn([{"total": 1}, [row]])
+
+        resp = client.get("/portfolio/activity")
+        assert resp.status_code == 200
+
+        cur = conn.cursor.return_value
+        for call in cur.execute.call_args_list:
+            assert call.args[1]["instrument_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # TestPortfolioMirrors — mirrors field in portfolio response (#221)


### PR DESCRIPTION
## What

Slice 2 of #1899. Closes #1926 (slice 2 — closed round-trips). The instrument **Positions tab** could only show *open* trades; there was no way to see what you'd already closed on a symbol. This adds a **Trade history** section listing that instrument's closed round-trips (exit price, units, realised P&L, holding period).

## Changes

**Backend** — `app/api/portfolio.py::get_activity`
- New optional query param `instrument_id: int | None` (its internal `instruments.instrument_id`). Applied to **both** the COUNT and the SELECT so `total` and `events` stay consistent under the filter. Passed as a psycopg named parameter (not interpolated); `IS NULL` branch disables the filter when unset.

**Frontend**
- `fetchActivity(includeMirrors, instrumentId?, limit?)` — appends `instrument_id` / `limit`.
- New `InstrumentTradeHistory.tsx` — fetches the ledger scoped to the instrument (max page, `limit=500`), renders each `close` event as a round-trip. Wired into `PositionsTab` below the open-trades table **and** on the "Not held" state.

## Currency (#1906)

Exit `price` is the instrument's **native** currency (same as the open-trades table); realised P&L is the operator's **display** currency. Each is self-labelled by `formatMoney`, so the mix is unambiguous.

## Codex ckpt-2 findings addressed

- **High** — trade history was unreachable when `total_units==0`: the Positions tab returned "Not held" before mounting the section, hiding round-trips for fully closed-out instruments. Now rendered in the not-held branch too (`data.currency` is the instrument's native currency, present even at zero units — `portfolio.py:557`).
- **Medium** — count reflected only the first ledger page: now fetches the max page (`limit=500`) scoped to one instrument, and shows a "recent subset" hint when `total > events.length` rather than silently understating.
- **Low** (conscious tradeoff) — loading renders `null` (not a skeleton). The caller always renders an anchor above (open trades, or the "Not held" empty state), so a blank section during the brief fetch is unambiguous; a loading label that resolves to nothing for the common no-history case would imply content that never arrives.

## Security

Read-only. No new writes, no order/trade paths. `instrument_id` is FastAPI-validated `int`, bound as a query parameter.

## Tests

- Backend (`tests/test_api_portfolio.py`, fast tier / mocked cursor): filter reaches both queries; unset passes `None`.
- FE (`InstrumentTradeHistory.test.tsx`): renders closes with native exit price + display-currency P&L + held days; filters out opens; scopes fetch to `(false, id, 500)`; truncation hint on/off; empty→nothing; error→muted line.

## Local verification

- `pnpm --dir frontend typecheck` ✓ · `test:unit` 1225 passed ✓
- `uv run ruff check .` / `ruff format --check .` ✓ · `pyright` (changed files) ✓
- `uv run pytest -m "not db"` 4737 passed ✓ · `pytest tests/smoke` 141 passed ✓
- Dev-DB premise check: 1 real close event exists (ILMN, `instrument_id=4077`, realised +\$1910.47) — feature exercises against live data; most instruments correctly render nothing.

## Dev-verify note

The running vite/API dev stack serves `~/Dev/eBull`, not this `.ebull-autonomy` worktree, so the in-flight branch can't be eyeballed live from the browser here (per prior operator note). Behaviour is covered by the component tests above; the only live close-event fixture (ILMN) is confirmed present in the dev DB.