### PR TITLE
feat(#1924): muted "No coverage yet" treatment for uncovered instrument rows

### DIFF
--- a/frontend/src/pages/InstrumentsPage.test.tsx
+++ b/frontend/src/pages/InstrumentsPage.test.tsx
@@ -407,3 +407,88 @@ describe("InstrumentsPage — exchange label", () => {
     expect(within(screen.getByRole("table")).getByText("99")).toBeInTheDocument();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Uncovered-row treatment (#1924 dir #3)
+// ---------------------------------------------------------------------------
+
+describe("InstrumentsPage — uncovered rows", () => {
+  function uncoveredItem(overrides = {}) {
+    return {
+      instrument_id: 42,
+      symbol: "ZZZ",
+      company_name: "Unmapped Co.",
+      exchange: "12",
+      exchange_name: null,
+      currency: "USD",
+      sector: null,
+      gics_sector: null,
+      sector_spdr: null,
+      is_tradable: true,
+      coverage_tier: null,
+      latest_quote: null,
+      ...overrides,
+    };
+  }
+
+  it("collapses an all-dashes row into a muted 'No coverage yet' note", async () => {
+    mockedFetch.mockResolvedValue(
+      makeResponse({ items: [uncoveredItem()], total: 1 }),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("ZZZ")).toBeInTheDocument();
+    });
+    // Symbol still links; the trailing columns collapse to one note.
+    expect(screen.getByText("No coverage yet")).toBeInTheDocument();
+    expect(screen.getByText("ZZZ").closest("a")).toHaveAttribute(
+      "href",
+      "/instrument/ZZZ",
+    );
+  });
+
+  it("treats a persisted last=0 quote as no usable price (prevention-log #1428)", async () => {
+    mockedFetch.mockResolvedValue(
+      makeResponse({
+        items: [
+          uncoveredItem({
+            latest_quote: {
+              bid: 0,
+              ask: 0,
+              last: 0,
+              spread_pct: null,
+              quoted_at: "2026-04-08T12:00:00Z",
+            },
+          }),
+        ],
+        total: 1,
+      }),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("ZZZ")).toBeInTheDocument();
+    });
+    // A non-null zero must not render a fake "US$0.00"; the row is uncovered.
+    expect(screen.getByText("No coverage yet")).toBeInTheDocument();
+    expect(screen.queryByText(/0\.00/)).not.toBeInTheDocument();
+  });
+
+  it("does NOT collapse a row that still has a sector (partial coverage)", async () => {
+    mockedFetch.mockResolvedValue(
+      makeResponse({
+        items: [
+          uncoveredItem({ gics_sector: "Financials", sector_spdr: "XLF" }),
+        ],
+        total: 1,
+      }),
+    );
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("ZZZ")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("No coverage yet")).not.toBeInTheDocument();
+    expect(
+      within(screen.getByRole("table")).getByText("Financials"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -86,8 +86,31 @@ function sortValue(item: InstrumentListItem, key: SortKey): unknown {
     case "coverage_tier":
       return item.coverage_tier;
     case "last":
-      return item.latest_quote?.last ?? null;
+      // A usable mark is strictly positive (prevention-log #1428): eToro
+      // persists `quotes.last = 0.00` for un-freshly-traded instruments, so a
+      // non-null zero must sort with the blanks, not ahead of them.
+      return isUsablePrice(item.latest_quote?.last) ? item.latest_quote!.last : null;
   }
+}
+
+/** A displayable last price: present and strictly positive (prevention-log #1428). */
+function isUsablePrice(last: number | null | undefined): last is number {
+  return last != null && last > 0;
+}
+
+/**
+ * An "uncovered" row — an unmapped instrument (typically non-US) with no
+ * sector, no coverage tier, and no usable price. Rather than render a row of
+ * bare "—" cells, collapse the trailing columns into a single muted
+ * "No coverage yet" note (#1924 dir #3). Tier-first ordering already sinks
+ * these to the back of the list.
+ */
+function isUncovered(item: InstrumentListItem): boolean {
+  return (
+    item.gics_sector == null &&
+    item.coverage_tier == null &&
+    !isUsablePrice(item.latest_quote?.last)
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -480,33 +503,59 @@ function InstrumentsTable({
             )}
         </thead>
         <tbody className="divide-y divide-slate-100">
-          {items.map((item) => (
- <tr key={item.instrument_id} className="align-top hover:bg-slate-50 dark:hover:bg-slate-800/40">
-              <td className="py-2 pr-4">
-                <Link
-                  to={`/instrument/${encodeURIComponent(item.symbol)}`}
-                  className="text-blue-600 hover:underline"
+          {items.map((item) =>
+            isUncovered(item) ? (
+              <tr
+                key={item.instrument_id}
+                className="align-top text-slate-400 hover:bg-slate-50 dark:text-slate-500 dark:hover:bg-slate-800/40"
+              >
+                <td className="py-2 pr-4">
+                  <Link
+                    to={`/instrument/${encodeURIComponent(item.symbol)}`}
+                    className="hover:underline"
+                  >
+                    <span className="font-medium">{item.symbol}</span>
+                  </Link>
+                  <div className="text-xs">{item.company_name}</div>
+                </td>
+                <td
+                  colSpan={COLUMNS.length - 1}
+                  className="py-2 pr-0 text-xs italic"
                 >
-                  <span className="font-medium">{item.symbol}</span>
-                </Link>
-                <div className="text-xs text-slate-500">{item.company_name}</div>
-              </td>
-              <td className="py-2 pr-4 text-xs text-slate-600">
-                {item.gics_sector ?? "—"}
-              </td>
-              <td className="py-2 pr-4 text-xs text-slate-600">
-                {item.exchange_name ?? item.exchange ?? "—"}
-              </td>
-              <td className="py-2 pr-4">
-                <TierBadge tier={item.coverage_tier} />
-              </td>
-              <td className="py-2 pr-0 text-right text-xs tabular-nums text-slate-600">
-                {item.latest_quote?.last != null
-                  ? formatMoney(item.latest_quote.last, item.currency ?? "USD")
-                  : "—"}
-              </td>
-            </tr>
-          ))}
+                  No coverage yet
+                </td>
+              </tr>
+            ) : (
+              <tr
+                key={item.instrument_id}
+                className="align-top hover:bg-slate-50 dark:hover:bg-slate-800/40"
+              >
+                <td className="py-2 pr-4">
+                  <Link
+                    to={`/instrument/${encodeURIComponent(item.symbol)}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    <span className="font-medium">{item.symbol}</span>
+                  </Link>
+                  <div className="text-xs text-slate-500">{item.company_name}</div>
+                </td>
+                <td className="py-2 pr-4 text-xs text-slate-600">
+                  {item.gics_sector ?? "—"}
+                </td>
+                <td className="py-2 pr-4 text-xs text-slate-600">
+                  {item.exchange_name ?? item.exchange ?? "—"}
+                </td>
+                <td className="py-2 pr-4">
+                  <TierBadge tier={item.coverage_tier} />
+                </td>
+                <td className="py-2 pr-0 text-right text-xs tabular-nums text-slate-600">
+                  {isUsablePrice(item.latest_quote?.last)
+                    ? formatMoney(item.latest_quote.last, item.currency ?? "USD")
+                    : "—"}
+                </td>
+              </tr>
+            ),
+          )}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Part of #1924 (deferred slice of #1904).

## What changed
Frontend only (`InstrumentsPage.tsx`). Rows where **sector + coverage tier + a usable last price are all absent** — typically unmapped non-US instruments — previously rendered a full row of bare `—` cells. They now collapse the trailing columns into a single muted, italic **"No coverage yet"** note; the symbol remains a link. Tier-first ordering (#1904) already sinks these to the back of the list, so this is low-urgency polish.

Also folds in **prevention-log #1428** on this surface: a usable last price is now **strictly positive**, not merely non-null. eToro persists `quotes.last = 0.00` for un-freshly-traded instruments, so the old `last != null` check rendered a fake `US$0.00`. Such rows now show `—`, classify as uncovered, and sort with the blanks (`sortValue` updated too).

Helpers added: `isUsablePrice` (type-guard) + `isUncovered`.

## Scope / deferred
**Day-change column (dir #4) stays deferred on #1924.** It needs prev-close plumbing; sourcing it from `price_daily` (5,196 instruments) while "Last price" stays on the thin `quotes` table (~69 positive rows) produces a "% with no price" UX, and fixing that means re-sourcing the list price from `price_daily.close` — which overlaps the **operator-gated #1857** value-source decision. Not pre-empting that gate. Analysis posted on #1924.

## Verification
- `pnpm --dir frontend typecheck` — clean.
- `pnpm --dir frontend test:unit` — 117 files / 1248 tests pass, incl. 3 new tests: all-dashes → note; `last=0` → uncovered (prevention-log #1428); partial-coverage (has sector) → NOT collapsed.
- `pnpm --dir frontend dark:check` — 238 files, no violations.
- Codex ckpt-2: LGTM (type-guard sound, colSpan layout consistent, no `isUncovered` misclassification).
- Note: the running vite dev server serves `~/Dev/eBull`, not this worktree branch, so live-browser verify cannot reach the change — covered by unit tests.

## Security
No auth/authorization surface; read-only list rendering. No SQL, no new endpoint.