### PR TITLE
feat(#1927): copy-mirror positions as trader's open book + drop-off caption

### DIFF
--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -63,7 +63,11 @@ export function CopyTradingPage() {
       ) : (
         <>
           <MirrorStats mirror={detail.data.mirror} currency={currency} />
-          <Section title="Positions">
+          <Section title="Open positions">
+            <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
+              Mirrors the trader's current open book. When they close a copied position it drops
+              off here; its realised result rolls into the Closed P&L total above.
+            </p>
             <GroupedPositionsTable positions={detail.data.mirror.positions} currency={currency} />
           </Section>
         </>


### PR DESCRIPTION
Ships the standalone UX clarification from #1927 (folded out of the operator-gated schema fix).

## What changed
`frontend/src/pages/CopyTradingPage.tsx` — mirror detail page:
- Section title `Positions` → `Open positions`.
- New one-line caption under the title: closed copies drop off here; their realised result rolls into the `Closed P&L` total (already rendered in `MirrorStats` immediately above).

## Why
Per the #1915 investigation verdict: copied-trader closes **are** synced, but `portfolio_sync._sync_mirrors` step-3a **hard-DELETEs** the `copy_mirror_positions` row with no archival (unlike own positions, which archive to `broker_positions` history before delete). So the mirror view shows only the live open book and reads as "buy-only". This copy makes the surface honest about what it lists and where realised exits land — no data-model change.

## Scope / what is deliberately NOT here
The durable fix — a `copy_mirror_closed_positions` history table + bootstrap-tier backfill to surface exits as events — is a schema/model decision and **stays operator-gated on #1927**. This PR is the interim perception fix the issue explicitly authorised shipping standalone.

## Verification
- `pnpm typecheck` — clean.
- `pnpm test:unit` — 117 files / 1248 tests pass (incl. `CopyTradingPage.test.tsx` 12/12; no assertion depended on the old title; caption text does not collide with the `Closed P&L:` stat matcher).
- Codex review (checkpoint 2): no findings.
- Live browser verify not possible in-loop (dev stack serves `~/Dev/eBull`, not this worktree); change is copy-only, no runtime path touched.

Part of #1927. #1927 stays open for the operator-gated history-table fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)