### PR TITLE
feat(#1905): Tax & CGT read endpoints over the settled tax engine (PR1 of 2)

### DIFF
--- a/app/api/tax.py
+++ b/app/api/tax.py
@@ -1,0 +1,201 @@
+"""Tax & CGT read API (#1905).
+
+Passive read surface over the UK tax engine (``app/services/tax_ledger.py``).
+The engine owns every CGT treatment (same-day / bed-&-breakfast / s104
+matching, era-dependent scenario rates, £3,000 annual exempt); these handlers
+only shape its output for the UI — no tax logic lives here.
+
+Endpoints (all operator-auth):
+  - GET /tax/summary?tax_year=YYYY/YY   — tax-year totals + CGT scenario estimates
+  - GET /tax/disposals?tax_year=YYYY/YY — disposal-match rows for the year
+  - GET /tax/pools                      — current s104 pool state per instrument
+  - GET /tax/tax-years                  — {current, available[]} for the UI selector
+
+``tax_year`` defaults to the current UK tax year and is validated by
+``tax_ledger.valid_tax_year`` (shape + suffix arithmetic) — a malformed or
+impossible label is a 422, never a silently-empty summary.
+
+Read-only: no writes, no commit boundary. Each handler wraps its (multi-query)
+read in ``snapshot_read`` for a consistent snapshot.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import psycopg
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.db.snapshot import snapshot_read
+from app.services.tax_ledger import (
+    available_tax_years,
+    current_tax_year,
+    disposals_for_tax_year,
+    s104_pool_rows,
+    tax_year_summary,
+    valid_tax_year,
+)
+
+router = APIRouter(
+    prefix="/tax",
+    tags=["tax"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class TaxSummaryResponse(BaseModel):
+    tax_year: str
+    total_gains_gbp: float
+    total_losses_gbp: float
+    net_gain_gbp: float
+    dividend_total_gbp: float
+    disposals_same_day: int
+    disposals_bed_and_breakfast: int
+    disposals_s104: int
+    annual_exempt_gbp: float
+    exempt_remaining_gbp: float
+    estimated_cgt_basic_scenario: float
+    estimated_cgt_higher_scenario: float
+
+
+class TaxDisposalResponse(BaseModel):
+    match_id: int
+    instrument_id: int
+    symbol: str
+    matching_rule: str
+    matched_units: float
+    acquisition_cost_gbp: float
+    disposal_proceeds_gbp: float
+    gain_or_loss_gbp: float
+    disposal_uk_date: date
+    tax_year: str
+    disposal_tax_lot_id: int
+    acquisition_tax_lot_id: int | None
+    matched_at: datetime
+
+
+class S104PoolResponse(BaseModel):
+    instrument_id: int
+    symbol: str
+    pool_units: float
+    pool_cost_gbp: float
+    pool_avg_cost_gbp: float
+    updated_at: datetime
+
+
+class TaxYearsResponse(BaseModel):
+    current: str
+    available: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _f(d: Decimal) -> float:
+    return float(d)
+
+
+def _resolve_tax_year(tax_year: str | None) -> str:
+    """Default to the current UK tax year; 422 on a malformed/impossible label."""
+    ty = tax_year or current_tax_year()
+    if not valid_tax_year(ty):
+        raise HTTPException(
+            status_code=422,
+            detail=f"invalid tax_year '{ty}'; expected UK tax-year label like '2026/27'",
+        )
+    return ty
+
+
+@router.get("/summary", response_model=TaxSummaryResponse)
+def get_tax_summary(
+    tax_year: str | None = Query(default=None),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> TaxSummaryResponse:
+    """Tax-year gains/losses, dividends, exempt-remaining and CGT scenario estimates."""
+    ty = _resolve_tax_year(tax_year)
+    with snapshot_read(conn):
+        s = tax_year_summary(conn, ty)
+    return TaxSummaryResponse(
+        tax_year=s.tax_year,
+        total_gains_gbp=_f(s.total_gains_gbp),
+        total_losses_gbp=_f(s.total_losses_gbp),
+        net_gain_gbp=_f(s.net_gain_gbp),
+        dividend_total_gbp=_f(s.dividend_total_gbp),
+        disposals_same_day=s.disposals_same_day,
+        disposals_bed_and_breakfast=s.disposals_bed_and_breakfast,
+        disposals_s104=s.disposals_s104,
+        annual_exempt_gbp=_f(s.annual_exempt_gbp),
+        exempt_remaining_gbp=_f(s.exempt_remaining_gbp),
+        estimated_cgt_basic_scenario=_f(s.estimated_cgt_basic_scenario),
+        estimated_cgt_higher_scenario=_f(s.estimated_cgt_higher_scenario),
+    )
+
+
+@router.get("/disposals", response_model=list[TaxDisposalResponse])
+def get_tax_disposals(
+    tax_year: str | None = Query(default=None),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> list[TaxDisposalResponse]:
+    """Every disposal match in the tax year (disposal → matched acquisition, rule, gain/loss)."""
+    ty = _resolve_tax_year(tax_year)
+    with snapshot_read(conn):
+        rows = disposals_for_tax_year(conn, ty)
+    return [
+        TaxDisposalResponse(
+            match_id=r.match_id,
+            instrument_id=r.instrument_id,
+            symbol=r.symbol,
+            matching_rule=r.matching_rule,
+            matched_units=_f(r.matched_units),
+            acquisition_cost_gbp=_f(r.acquisition_cost_gbp),
+            disposal_proceeds_gbp=_f(r.disposal_proceeds_gbp),
+            gain_or_loss_gbp=_f(r.gain_or_loss_gbp),
+            disposal_uk_date=r.disposal_uk_date,
+            tax_year=r.tax_year,
+            disposal_tax_lot_id=r.disposal_tax_lot_id,
+            acquisition_tax_lot_id=r.acquisition_tax_lot_id,
+            matched_at=r.matched_at,
+        )
+        for r in rows
+    ]
+
+
+@router.get("/pools", response_model=list[S104PoolResponse])
+def get_tax_pools(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> list[S104PoolResponse]:
+    """Current s104 (section-104) pool state per instrument, largest cost first."""
+    with snapshot_read(conn):
+        rows = s104_pool_rows(conn)
+    return [
+        S104PoolResponse(
+            instrument_id=r.instrument_id,
+            symbol=r.symbol,
+            pool_units=_f(r.pool_units),
+            pool_cost_gbp=_f(r.pool_cost_gbp),
+            pool_avg_cost_gbp=_f(r.pool_avg_cost_gbp),
+            updated_at=r.updated_at,
+        )
+        for r in rows
+    ]
+
+
+@router.get("/tax-years", response_model=TaxYearsResponse)
+def get_tax_years(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> TaxYearsResponse:
+    """Tax years with data (newest first) + the current year, for the UI selector."""
+    with snapshot_read(conn):
+        available = available_tax_years(conn)
+    return TaxYearsResponse(current=current_tax_year(), available=available)

--- a/app/main.py
+++ b/app/main.py
@@ -56,6 +56,7 @@ from app.api.scores import router as scores_router
 from app.api.sse_quotes import router as sse_quotes_router
 from app.api.sync import router as sync_router
 from app.api.system import router as system_router
+from app.api.tax import router as tax_router
 from app.api.theses import instrument_thesis_router
 from app.api.theses import router as theses_router
 from app.api.watchlist import router as watchlist_router
@@ -556,6 +557,7 @@ app.include_router(scores_router)
 app.include_router(sse_quotes_router)
 app.include_router(sync_router)
 app.include_router(system_router)
+app.include_router(tax_router)
 app.include_router(bootstrap_router)
 app.include_router(theses_router)
 app.include_router(instrument_thesis_router)

--- a/app/services/tax_ledger.py
+++ b/app/services/tax_ledger.py
@@ -49,6 +49,11 @@ _CGT_RATE_PERIODS: list[tuple[date, date, Decimal, Decimal]] = [
     (date(2025, 4, 6), date(2099, 4, 5), _D("0.18"), _D("0.24")),
 ]
 
+# First tax-year the engine can price a disposal for — derived from the CGT
+# rate table so the API's accepted-year floor tracks rate coverage (a request
+# for an earlier year is a 422, never a 500 from ``_cgt_rates_for_disposal``).
+_MIN_SUPPORTED_TAX_YEAR_START = _CGT_RATE_PERIODS[0][0].year
+
 # Annual exempt amount, 2024/25 onwards
 ANNUAL_EXEMPT = _D("3000")
 
@@ -139,6 +144,11 @@ class TaxYearSummary:
     disposals_same_day: int
     disposals_bed_and_breakfast: int
     disposals_s104: int
+    # Annual exempt amount (£3,000) and how much of it is unused after this
+    # year's net gain. Computed here — never in the API handler — so the CGT
+    # treatment stays owned by the engine (source rule).
+    annual_exempt_gbp: Decimal
+    exempt_remaining_gbp: Decimal
     # Scenario estimates — actual CGT depends on taxpayer's income and band
     estimated_cgt_basic_scenario: Decimal
     estimated_cgt_higher_scenario: Decimal
@@ -158,6 +168,41 @@ class DisposalMatchDetail:
     disposal_uk_date: date
     tax_year: str
     matched_at: datetime
+
+
+@dataclass(frozen=True)
+class TaxDisposalRow:
+    """A disposal match for a whole tax year, with the instrument symbol.
+
+    Same engine output as ``DisposalMatchDetail`` but tax-year-scoped (not
+    per-instrument) and carrying ``symbol`` for the disposal table UI.
+    """
+
+    match_id: int
+    instrument_id: int
+    symbol: str
+    matching_rule: str
+    matched_units: Decimal
+    acquisition_cost_gbp: Decimal
+    disposal_proceeds_gbp: Decimal
+    gain_or_loss_gbp: Decimal
+    disposal_uk_date: date
+    tax_year: str
+    disposal_tax_lot_id: int
+    acquisition_tax_lot_id: int | None
+    matched_at: datetime
+
+
+@dataclass(frozen=True)
+class S104PoolRow:
+    """Current s104 pool state for an instrument, with the symbol."""
+
+    instrument_id: int
+    symbol: str
+    pool_units: Decimal
+    pool_cost_gbp: Decimal
+    pool_avg_cost_gbp: Decimal
+    updated_at: datetime
 
 
 # ---------------------------------------------------------------------------
@@ -878,6 +923,10 @@ def tax_year_summary(
         est_basic = _D("0")
         est_higher = _D("0")
 
+    # Unused annual exemption: the allowance offsets positive net gains only
+    # (losses do not restore it). Complement of ``taxable_net``.
+    exempt_remaining = max(ANNUAL_EXEMPT - max(net_gain, _D("0")), _D("0"))
+
     return TaxYearSummary(
         tax_year=tax_year,
         total_gains_gbp=total_gains,
@@ -887,6 +936,8 @@ def tax_year_summary(
         disposals_same_day=int(agg["cnt_same_day"]),
         disposals_bed_and_breakfast=int(agg["cnt_bnb"]),
         disposals_s104=int(agg["cnt_s104"]),
+        annual_exempt_gbp=ANNUAL_EXEMPT,
+        exempt_remaining_gbp=exempt_remaining,
         estimated_cgt_basic_scenario=est_basic,
         estimated_cgt_higher_scenario=est_higher,
     )
@@ -930,6 +981,130 @@ def disposal_audit_trail(
             disposal_uk_date=row["disposal_uk_date"],
             tax_year=row["tax_year"],
             matched_at=row["matched_at"],
+        )
+        for row in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tax-year helpers + tax-year-scoped read surface (#1905 — Tax & CGT API)
+# ---------------------------------------------------------------------------
+
+
+def current_tax_year() -> str:
+    """The UK tax year containing the current instant, e.g. ``2026/27``."""
+    return _compute_tax_year(_to_uk_date(_utcnow()))
+
+
+def valid_tax_year(tax_year: str) -> bool:
+    """True iff ``tax_year`` is a well-formed, engine-priceable UK tax-year label.
+
+    Shape ``\\d{4}/\\d{2}`` alone is not enough — the two-digit suffix must be
+    the arithmetic successor ``(start_year + 1) % 100`` (rejects impossible
+    labels like ``2026/99``). ``start_year`` must be in
+    ``[MIN_SUPPORTED_TAX_YEAR_START, current+1]``: the lower bound is the first
+    year the engine has CGT rate coverage for (``_CGT_RATE_PERIODS[0]``), so a
+    year the engine cannot price is a clean rejection rather than a later
+    ``_cgt_rates_for_disposal`` RuntimeError (→ 500) on any positive-gain row.
+    """
+    parts = tax_year.split("/")
+    if len(parts) != 2 or len(parts[0]) != 4 or len(parts[1]) != 2:
+        return False
+    start_s, suffix_s = parts
+    if not (start_s.isdigit() and suffix_s.isdigit()):
+        return False
+    start_year = int(start_s)
+    if int(suffix_s) != (start_year + 1) % 100:
+        return False
+    current_start = int(current_tax_year().split("/")[0])
+    return _MIN_SUPPORTED_TAX_YEAR_START <= start_year <= current_start + 1
+
+
+def available_tax_years(conn: psycopg.Connection[Any]) -> list[str]:
+    """Distinct tax years with any tax data, newest first.
+
+    Union across ``tax_lots`` and ``disposal_matches`` so a year with only
+    dividend lots (no disposals) still appears. The current tax year is always
+    included so the UI selector is never empty on a fresh account.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT tax_year FROM tax_lots
+            UNION
+            SELECT DISTINCT tax_year FROM disposal_matches
+            """
+        )
+        years = {row["tax_year"] for row in cur.fetchall()}
+    years.add(current_tax_year())
+    return sorted(years, reverse=True)
+
+
+def disposals_for_tax_year(
+    conn: psycopg.Connection[Any],
+    tax_year: str,
+) -> list[TaxDisposalRow]:
+    """Read-only: every disposal match in a tax year, with instrument symbol."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT dm.match_id, dm.instrument_id, i.symbol,
+                   dm.disposal_tax_lot_id, dm.acquisition_tax_lot_id,
+                   dm.matching_rule, dm.matched_units,
+                   dm.acquisition_cost_gbp, dm.disposal_proceeds_gbp,
+                   dm.gain_or_loss_gbp, dm.disposal_uk_date, dm.tax_year,
+                   dm.matched_at
+            FROM disposal_matches dm
+            JOIN instruments i ON i.instrument_id = dm.instrument_id
+            WHERE dm.tax_year = %(ty)s
+            ORDER BY dm.disposal_uk_date ASC, dm.match_id ASC
+            """,
+            {"ty": tax_year},
+        )
+        rows = cur.fetchall()
+
+    return [
+        TaxDisposalRow(
+            match_id=row["match_id"],
+            instrument_id=row["instrument_id"],
+            symbol=row["symbol"],
+            matching_rule=row["matching_rule"],
+            matched_units=Decimal(str(row["matched_units"])),
+            acquisition_cost_gbp=Decimal(str(row["acquisition_cost_gbp"])),
+            disposal_proceeds_gbp=Decimal(str(row["disposal_proceeds_gbp"])),
+            gain_or_loss_gbp=Decimal(str(row["gain_or_loss_gbp"])),
+            disposal_uk_date=row["disposal_uk_date"],
+            tax_year=row["tax_year"],
+            disposal_tax_lot_id=row["disposal_tax_lot_id"],
+            acquisition_tax_lot_id=row["acquisition_tax_lot_id"],
+            matched_at=row["matched_at"],
+        )
+        for row in rows
+    ]
+
+
+def s104_pool_rows(conn: psycopg.Connection[Any]) -> list[S104PoolRow]:
+    """Read-only: current s104 pool state per instrument, largest cost first."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT sp.instrument_id, i.symbol, sp.pool_units,
+                   sp.pool_cost_gbp, sp.pool_avg_cost_gbp, sp.updated_at
+            FROM s104_pool sp
+            JOIN instruments i ON i.instrument_id = sp.instrument_id
+            ORDER BY sp.pool_cost_gbp DESC, i.symbol ASC
+            """
+        )
+        rows = cur.fetchall()
+
+    return [
+        S104PoolRow(
+            instrument_id=row["instrument_id"],
+            symbol=row["symbol"],
+            pool_units=Decimal(str(row["pool_units"])),
+            pool_cost_gbp=Decimal(str(row["pool_cost_gbp"])),
+            pool_avg_cost_gbp=Decimal(str(row["pool_avg_cost_gbp"])),
+            updated_at=row["updated_at"],
         )
         for row in rows
     ]

--- a/docs/specs/api/2026-07-04-tax-cgt-endpoints.md
+++ b/docs/specs/api/2026-07-04-tax-cgt-endpoints.md
@@ -1,0 +1,71 @@
+# Tax & CGT read endpoints (#1905, PR1 of 2)
+
+Build priority #8. The UK tax engine (`app/services/tax_ledger.py`) is fully built —
+`ingest_tax_events` → `tax_lots`, `run_disposal_matching` → `disposal_matches` +
+`s104_pool`, HMRC same-day / bed-&-breakfast / s104 matching, era-dependent CGT
+scenario rates (owned by `_cgt_rates_for_disposal`; do NOT restate them here),
+£3,000 annual exempt (`ANNUAL_EXEMPT`) — but has **zero API and zero UI**. This PR ships
+the read endpoints; the page (#1905 PR2) consumes them.
+
+## Scope (PR1 — backend only)
+
+Four read-only endpoints under a new `/tax` router, operator-auth (mirror `app/api/budget.py`).
+All wrap existing / thin-new service functions. No writes, no commit boundary.
+
+- `GET /tax/summary?tax_year=YYYY/YY` — wraps `tax_year_summary`. The exempt maths lives in
+  the **service** (source-rule: no tax treatment in the handler): `TaxYearSummary` gains
+  `annual_exempt_gbp` (= `ANNUAL_EXEMPT`) + `exempt_remaining_gbp`
+  (= `max(0, annual_exempt - max(net_gain, 0))`), computed in `tax_year_summary`.
+- `GET /tax/disposals?tax_year=YYYY/YY` — new `disposals_for_tax_year(conn, ty)`:
+  every `disposal_matches` row for the year INNER-joined to `instruments.symbol`,
+  ordered `disposal_uk_date ASC, match_id ASC`. Keeps full engine provenance
+  (`disposal_tax_lot_id`, nullable `acquisition_tax_lot_id`, `matched_at`).
+- `GET /tax/pools` — new `s104_pool_rows(conn)`: every `s104_pool` row INNER-joined to
+  `instruments.symbol`, ordered `pool_cost_gbp DESC`.
+- `GET /tax/tax-years` — `{current, available[]}` for the FE selector.
+  `available_tax_years(conn)` = `DISTINCT tax_year` across `tax_lots ∪ disposal_matches`,
+  sorted DESC, with the current year always included. Empty tables ⇒ `[current]`.
+
+`tax_year` query param: default = current UK tax year. Validation is **two-stage**:
+`^\d{4}/\d{2}$` shape (422 on malformed) **and** semantic — the two-digit suffix must equal
+`(start_year + 1) % 100` (rejects impossible years like `2026/99`), start_year in
+`[MIN_SUPPORTED, current+1]` where `MIN_SUPPORTED` is derived from the engine's CGT rate
+table (`_CGT_RATE_PERIODS[0]` = 2024/25). A year the engine can't price is a clean 422, not a
+later `_cgt_rates_for_disposal` 500. `valid_tax_year(ty) -> bool` lives in the service; the
+handler raises 422.
+New public helper `current_tax_year()` wraps `_compute_tax_year(_to_uk_date(_utcnow()))`.
+
+Each handler wraps its (multi-query) read in `snapshot_read(conn)` for a consistent snapshot.
+
+## New service surface (`tax_ledger.py`)
+
+- `current_tax_year() -> str`
+- `valid_tax_year(tax_year: str) -> bool`
+- `available_tax_years(conn) -> list[str]`
+- `TaxYearSummary` gains `annual_exempt_gbp`, `exempt_remaining_gbp`.
+- `@dataclass(frozen) TaxDisposalRow` (match_id, instrument_id, symbol, matching_rule,
+  matched_units, acquisition_cost_gbp, disposal_proceeds_gbp, gain_or_loss_gbp,
+  disposal_uk_date, tax_year, disposal_tax_lot_id, acquisition_tax_lot_id, matched_at)
+  + `disposals_for_tax_year(conn, tax_year) -> list[...]`
+- `@dataclass(frozen) S104PoolRow` (instrument_id, symbol, pool_units, pool_cost_gbp,
+  pool_avg_cost_gbp, updated_at) + `s104_pool_rows(conn) -> list[...]`
+
+## Source rule
+
+CGT figures come **only** from the settled engine — no re-derivation. Same-day / B&B / s104
+priority, 18/24 % rates, £3,000 exempt, YYYY/YY tax-year convention are all owned by
+`tax_ledger.py` (per `docs/tax-engine.md`). Endpoints are a passive read of engine output.
+
+## Data reality in dev (verification note)
+
+Dev DB currently has 1 fill / 1 order and **empty** `tax_lots`/`disposal_matches`/`s104_pool`:
+`daily_tax_reconciliation` can't ingest because there is no `fx_rates` USD→GBP row for the
+fill date (FX unreachable in-loop). So dev verification confirms **well-formed empty/zero
+payloads** (correct behaviour for a demo account with no completed disposals): `/tax/summary`
+returns an all-zero `TaxYearSummary` for `2026/27` (crash-safe via COALESCE), `/tax/disposals`
+and `/tax/pools` return `[]`. Non-zero figure verification is deferred to when a disposal +
+FX rate exist (tracked in the PR + on #1905).
+
+## Out of scope (PR2)
+
+Tax page (year selector, exempt gauge, disposal table, s104 table), CSV export.

--- a/tests/test_tax_ledger.py
+++ b/tests/test_tax_ledger.py
@@ -17,9 +17,14 @@ from app.services.tax_ledger import (
     _compute_tax_year,
     _match_disposals_for_instrument,
     _to_uk_date,
+    available_tax_years,
+    current_tax_year,
+    disposals_for_tax_year,
     ingest_tax_events,
     run_disposal_matching,
+    s104_pool_rows,
     tax_year_summary,
+    valid_tax_year,
 )
 
 _D = Decimal
@@ -1036,6 +1041,10 @@ class TestTaxYearSummary:
         assert result.disposals_bed_and_breakfast == 1
         assert result.disposals_s104 == 3
 
+        # Annual exempt fully consumed: net 4000 > 3000 allowance -> 0 left.
+        assert result.annual_exempt_gbp == _D("3000")
+        assert result.exempt_remaining_gbp == _D("0")
+
         # CGT: net=4000, taxable=4000-3000=1000
         # Weighted basic: 3000*0.18 + 2000*0.18 = 900
         # Scale: 1000/5000 = 0.2
@@ -1067,6 +1076,8 @@ class TestTaxYearSummary:
         assert result.net_gain_gbp == _D("0")
         assert result.estimated_cgt_basic_scenario == _D("0")
         assert result.estimated_cgt_higher_scenario == _D("0")
+        # No gains -> the full £3,000 allowance is unused.
+        assert result.exempt_remaining_gbp == _D("3000")
 
     def test_2024_25_split_year_cgt_estimate(self) -> None:
         """Disposals spanning the 30 Oct 2024 rate change use different rates."""
@@ -1107,3 +1118,128 @@ class TestTaxYearSummary:
         # Weighted higher: 5000*0.20 + 5000*0.24 = 1000+1200 = 2200
         # est_higher = 2200 * 0.7 = 1540
         assert result.estimated_cgt_higher_scenario == _D("1540")
+
+
+# ===========================================================================
+# TestTaxYearHelpers (#1905) — pure, fast tier
+# ===========================================================================
+
+
+class TestValidTaxYear:
+    def test_current_and_supported_floor_valid(self) -> None:
+        assert valid_tax_year(current_tax_year()) is True
+        # 2024/25 is the first year the engine has CGT rate coverage for.
+        assert valid_tax_year("2024/25") is True
+
+    def test_impossible_suffix_rejected(self) -> None:
+        # Shape passes \d{4}/\d{2} but 99 != (2026+1) % 100.
+        assert valid_tax_year("2026/99") is False
+        assert valid_tax_year("2026/28") is False
+
+    def test_malformed_shape_rejected(self) -> None:
+        for bad in ["202627", "26/27", "2026/7", "abcd/ef", "2026-27", "2026/2027", ""]:
+            assert valid_tax_year(bad) is False
+
+    def test_out_of_range_start_rejected(self) -> None:
+        # Suffix arithmetic is correct, but the start year is out of bounds.
+        assert valid_tax_year("2023/24") is False  # below the engine's rate-coverage floor
+        assert valid_tax_year("1999/00") is False  # far below
+        assert valid_tax_year("2099/00") is False  # far future
+
+
+class TestCurrentTaxYear:
+    def test_format_and_self_consistency(self) -> None:
+        ty = current_tax_year()
+        assert valid_tax_year(ty) is True
+        start, suffix = ty.split("/")
+        assert len(start) == 4 and len(suffix) == 2
+        assert int(suffix) == (int(start) + 1) % 100
+
+
+class TestDisposalsForTaxYear:
+    def test_maps_rows_with_symbol_and_null_acquisition(self) -> None:
+        cur = _make_cursor(
+            [
+                {
+                    "match_id": 7,
+                    "instrument_id": 100,
+                    "symbol": "AAPL",
+                    "disposal_tax_lot_id": 55,
+                    "acquisition_tax_lot_id": 40,
+                    "matching_rule": "s104_pool",
+                    "matched_units": _D("10"),
+                    "acquisition_cost_gbp": _D("800"),
+                    "disposal_proceeds_gbp": _D("1200"),
+                    "gain_or_loss_gbp": _D("400"),
+                    "disposal_uk_date": date(2025, 7, 1),
+                    "tax_year": "2025/26",
+                    "matched_at": datetime(2025, 7, 2, 9, 0, 0, tzinfo=UTC),
+                },
+                {
+                    "match_id": 8,
+                    "instrument_id": 101,
+                    "symbol": "TSLA",
+                    "disposal_tax_lot_id": 56,
+                    "acquisition_tax_lot_id": None,  # s104 disposal with no single acquisition lot
+                    "matching_rule": "s104_pool",
+                    "matched_units": _D("5"),
+                    "acquisition_cost_gbp": _D("500"),
+                    "disposal_proceeds_gbp": _D("450"),
+                    "gain_or_loss_gbp": _D("-50"),
+                    "disposal_uk_date": date(2025, 8, 1),
+                    "tax_year": "2025/26",
+                    "matched_at": datetime(2025, 8, 2, 9, 0, 0, tzinfo=UTC),
+                },
+            ]
+        )
+        conn = _make_conn([cur])
+        rows = disposals_for_tax_year(conn, "2025/26")
+
+        assert [r.symbol for r in rows] == ["AAPL", "TSLA"]
+        assert rows[0].gain_or_loss_gbp == _D("400")
+        assert rows[0].acquisition_tax_lot_id == 40
+        assert rows[1].acquisition_tax_lot_id is None
+        assert rows[1].gain_or_loss_gbp == _D("-50")
+
+    def test_empty_year_returns_empty_list(self) -> None:
+        conn = _make_conn([_make_cursor([])])
+        assert disposals_for_tax_year(conn, "2025/26") == []
+
+
+class TestS104PoolRows:
+    def test_maps_pool_rows(self) -> None:
+        cur = _make_cursor(
+            [
+                {
+                    "instrument_id": 100,
+                    "symbol": "AAPL",
+                    "pool_units": _D("30"),
+                    "pool_cost_gbp": _D("2400"),
+                    "pool_avg_cost_gbp": _D("80"),
+                    "updated_at": datetime(2025, 9, 1, 12, 0, 0, tzinfo=UTC),
+                }
+            ]
+        )
+        conn = _make_conn([cur])
+        rows = s104_pool_rows(conn)
+        assert len(rows) == 1
+        assert rows[0].symbol == "AAPL"
+        assert rows[0].pool_avg_cost_gbp == _D("80")
+
+    def test_empty_returns_empty_list(self) -> None:
+        conn = _make_conn([_make_cursor([])])
+        assert s104_pool_rows(conn) == []
+
+
+class TestAvailableTaxYears:
+    def test_union_includes_current_and_sorts_desc(self) -> None:
+        cur = _make_cursor([{"tax_year": "2024/25"}, {"tax_year": "2023/24"}])
+        conn = _make_conn([cur])
+        years = available_tax_years(conn)
+        assert years == sorted(set(years), reverse=True)  # sorted desc, deduped
+        assert current_tax_year() in years  # current always present
+        assert "2024/25" in years and "2023/24" in years
+
+    def test_empty_tables_yield_current_only(self) -> None:
+        conn = _make_conn([_make_cursor([])])
+        assert available_tax_years(conn) == [current_tax_year()]


### PR DESCRIPTION
The UK tax engine (`app/services/tax_ledger.py`) is fully built + tested — same-day / bed-&-breakfast / s104 matching, era-dependent CGT scenario rates, £3,000 annual exempt — but had **zero API and zero UI** (build priority #8, currently invisible). This PR ships the read endpoints; the Tax page + CSV export follow in PR2.

## New `/tax` router (operator-auth, read-only, `snapshot_read` per handler)
- `GET /tax/summary?tax_year=YYYY/YY` — tax-year gains/losses, dividends, unused annual exempt, CGT basic/higher scenario estimates.
- `GET /tax/disposals?tax_year=YYYY/YY` — every `disposal_matches` row for the year + `instruments.symbol` + full engine provenance (disposal/acquisition lot ids, rule, `matched_at`).
- `GET /tax/pools` — current `s104_pool` state per instrument + symbol, largest cost first.
- `GET /tax/tax-years` — `{current, available[]}` for the UI year selector.

## Service additions (`tax_ledger.py`) — all CGT treatment stays engine-owned
- `TaxYearSummary` gains `annual_exempt_gbp` + `exempt_remaining_gbp` (`max(0, exempt − max(net_gain, 0))`), computed **in the service, never the handler** (source-rule: no tax logic in the API layer).
- `current_tax_year()`, `valid_tax_year()`, `available_tax_years()`, `disposals_for_tax_year()`, `s104_pool_rows()` + two frozen row dataclasses.

## Source rule
CGT figures are a **passive read** of the settled engine — no re-derivation. Same-day/B&B/s104 priority, scenario rates, £3,000 exempt and the `YYYY/YY` convention are all owned by `tax_ledger.py` (`docs/tax-engine.md`). Spec: `docs/specs/api/2026-07-04-tax-cgt-endpoints.md`.

## Tax-year validation (two-stage)
`^\d{4}/\d{2}$` shape **and** semantic: the suffix must equal `(start+1) % 100` (rejects impossible labels like `2026/99`), and `start_year ∈ [2024, current+1]` where the floor is **derived from the engine’s CGT rate table** (`_CGT_RATE_PERIODS[0]` = 2024/25). A year the engine cannot price is a clean **422**, not a later `_cgt_rates_for_disposal` **500**. Malformed/impossible/pre-floor → 422.

## Codex (mandatory checkpoints)
- ckpt-1 (spec) + ckpt-2 (diff): all findings folded in — exempt maths moved to the service, semantic tax-year validation, disposal provenance retained, `snapshot_read` per handler, rate-coverage-derived year floor.
- Codex LOW (money serialized as `float`): **deliberate** — matches the established API money convention (`app/api/budget.py` serializes money as `float`; the FE `formatMoney` consumes numbers). Diverging one endpoint to Decimal-strings would break FE parity. Accountant-grade exactness belongs in PR2’s CSV export, sourced directly from the `Decimal` engine output. Not changed.

## Verification (clauses 8–12)
Running `:8000` serves the other worktree (main), so verified **in-process** (`TestClient` + lifespan) against the real dev DB:
- All endpoints **200** with well-formed empty/zero payloads. `/tax/summary` → all-zero for `2026/27` with `annual_exempt_gbp=3000`, `exempt_remaining_gbp=3000`; `/tax/disposals` & `/tax/pools` → `[]`; `/tax/tax-years` → `{current:"2026/27", available:["2026/27"]}`.
- **422** on `2026/99`, `abc`, `2023/24` / `2020/21` (below floor); **200** on `2024/25`.
- Tax tables are **empty** in dev (1 fill / 1 order): `daily_tax_reconciliation` cannot ingest because there is no `fx_rates` USD→GBP row for the fill date (FX unreachable in-loop). Empty-but-correct is the honest state for a demo account pre-disposals; non-zero-figure + cross-source verification is deferred to when a disposal + FX rate exist (noted on #1905).
- Tests: fast-tier mocked-cursor coverage for the new reads + a `valid_tax_year` table test (52 pass). Endpoint wiring covered by the smoke test (app boots with the router).

## Data note for the operator
To populate the tax view in dev: add the missing `fx_rates` USD→GBP row(s) for the fill dates, then run `daily_tax_reconciliation` (idempotent). Until then the endpoints return correct empty/zero shapes.

Part of #1905. #1905 stays open for PR2 (Tax page: year selector, exempt gauge, disposal table, s104 table, CSV export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)