### PR TITLE
feat(#1918): explicit ranked-vs-universe coverage on Rankings

### DIFF
--- a/app/api/scores.py
+++ b/app/api/scores.py
@@ -18,6 +18,8 @@ Latest-run semantics:
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Literal
 
@@ -33,6 +35,8 @@ from app.db import get_conn
 # rankings page shows stale rows of a version no longer produced.
 from app.services.scoring import _DEFAULT_MODEL_VERSION
 from app.services.sector_classification import resolve_sector_spdr, sector_spdr_case_sql
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/rankings", tags=["rankings"])
 
@@ -123,6 +127,120 @@ class RankingsListResponse(BaseModel):
     limit: int
     model_version: str
     scored_at: datetime | None
+
+
+class RankingsCoverageBucket(BaseModel):
+    """One rank-exclusion cause with its operator label and instrument count."""
+
+    reason: str
+    label: str
+    count: int
+
+
+class RankingsCoverage(BaseModel):
+    """Explicit ranked-vs-universe denominator for the Rankings header (#1918).
+
+    ``universe`` = tradable instruments. ``ranked`` = the exact count the
+    ``GET /rankings`` list returns unfiltered for this run. ``not_ranked`` is
+    a MECE breakdown of ``universe - ranked`` by cause, so an operator can tell
+    "not ranked" from "ranked low" instead of reading absence as a bug.
+    """
+
+    model_version: str
+    scored_at: datetime | None
+    universe: int
+    ranked: int
+    not_ranked: list[RankingsCoverageBucket]
+
+
+# Operator labels per rank-exclusion reason. The non-`analysable` keys are
+# `coverage.filings_status` values whose meaning is the classifier's own rule
+# (app/services/coverage.py — probe_status / _finalise / _is_structurally_young,
+# coverage.py:1844-1893), not inferred here. `analysable_unranked` and `other`
+# are computed buckets. Labels avoid the stronger "US-GAAP" claim: the
+# classifier keys on SEC form families/counts, not accounting basis.
+_NOT_RANKED_LABELS: dict[str, str] = {
+    "no_primary_sec_cik": "No SEC filer (non-US listing)",
+    "fpi": "Foreign private issuer (20-F/6-K filer)",
+    "insufficient": "Insufficient filing history",
+    "structurally_young": "Recently listed — too little history",
+    "analysable_unranked": "Analysable — not in latest ranking run",
+    "other": "Unclassified coverage",
+}
+
+# Emission order for not_ranked buckets: raw filing-status causes first (largest
+# classes), computed buckets last.
+_NOT_RANKED_ORDER: tuple[str, ...] = (
+    "no_primary_sec_cik",
+    "fpi",
+    "insufficient",
+    "structurally_young",
+    "analysable_unranked",
+    "other",
+)
+
+
+def build_coverage(
+    *,
+    model_version: str,
+    scored_at: datetime | None,
+    universe: int,
+    ranked: int,
+    status_counts: Mapping[str, int],
+) -> RankingsCoverage:
+    """Assemble the coverage breakdown from raw full-population counts.
+
+    Pure (no DB) so it is table-testable. ``status_counts`` maps
+    ``coverage.filings_status`` -> count over the *tradable* universe (a NULL /
+    missing status is simply absent from the map — it falls into ``other``).
+
+    Buckets are mutually exclusive; ``other`` is the residual
+    (``universe - Σ known statuses``, i.e. tradable rows with a NULL/unknown
+    coverage status), so ``ranked + Σ not_ranked == universe`` holds
+    definitionally. ``analysable`` splits into ``ranked`` +
+    ``analysable_unranked``. A negative computed bucket signals a data anomaly
+    (e.g. duplicate score rows making ranked > analysable); it is clamped to 0
+    and logged rather than shown as a nonsense negative.
+    """
+    analysable = status_counts.get("analysable", 0)
+    known_status_sum = sum(
+        status_counts.get(s, 0)
+        for s in ("analysable", "no_primary_sec_cik", "fpi", "insufficient", "structurally_young")
+    )
+
+    counts: dict[str, int] = {
+        "no_primary_sec_cik": status_counts.get("no_primary_sec_cik", 0),
+        "fpi": status_counts.get("fpi", 0),
+        "insufficient": status_counts.get("insufficient", 0),
+        "structurally_young": status_counts.get("structurally_young", 0),
+        "analysable_unranked": analysable - ranked,
+        "other": universe - known_status_sum,
+    }
+
+    for key in ("analysable_unranked", "other"):
+        if counts[key] < 0:
+            logger.warning(
+                "rankings coverage: negative %s bucket (%d) — clamping to 0; universe=%d ranked=%d status_counts=%s",
+                key,
+                counts[key],
+                universe,
+                ranked,
+                dict(status_counts),
+            )
+            counts[key] = 0
+
+    not_ranked = [
+        RankingsCoverageBucket(reason=r, label=_NOT_RANKED_LABELS[r], count=counts[r])
+        for r in _NOT_RANKED_ORDER
+        if counts[r] > 0
+    ]
+    return RankingsCoverage(
+        model_version=model_version,
+        scored_at=scored_at,
+        universe=universe,
+        ranked=ranked,
+        not_ranked=not_ranked,
+    )
 
 
 class ScoreHistoryItem(BaseModel):
@@ -329,9 +447,15 @@ def list_rankings(
         # rows for instruments that fell out of the analysable pool
         # between the last scoring run and now (e.g. audit regressed
         # them to insufficient / fpi / no_primary_sec_cik).
+        # is_tradable gate (#1918): a delisted/non-tradable instrument with a
+        # stale analysable score must never surface, and this makes the list
+        # `total` exactly equal the /rankings/coverage `ranked` count (both gate
+        # tradable+analysable over the latest run). Full-pop check 2026-07-04: 0
+        # ranked rows are non-tradable today, so a no-op now — a forward guard.
         where_clauses: list[str] = [
             "s.model_version = %(mv)s",
             "s.scored_at = %(scored_at)s",
+            "i.is_tradable = TRUE",
             "c.filings_status = 'analysable'",
         ]
         filter_params: dict[str, object] = {
@@ -440,6 +564,88 @@ def list_rankings(
         limit=limit,
         model_version=model_version,
         scored_at=latest_scored_at,  # type: ignore[arg-type]
+    )
+
+
+@router.get("/coverage", response_model=RankingsCoverage)
+def get_rankings_coverage(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    model_version: str = Query(default=_DEFAULT_MODEL_VERSION),
+) -> RankingsCoverage:
+    """Ranked-vs-universe denominator + why-not-ranked breakdown (#1918).
+
+    Makes the Rankings surface honest: it renders only the scored subset of a
+    ~12.6k tradable universe, and without this an operator reads the ~8.7k
+    absent instruments as a bug rather than a correct exclusion (no SEC
+    fundamentals to score).
+
+    ``ranked`` is gated identically to ``GET /rankings`` (latest run of
+    ``model_version``, ``is_tradable AND filings_status='analysable'``,
+    ``COUNT(DISTINCT instrument_id)``), so the header count equals the table
+    ``total``. The whole payload is computed in one SQL statement (atomic
+    snapshot — two READ COMMITTED reads would not be). If no scoring run exists,
+    ``scored_at`` is null and ``ranked`` is 0.
+    """
+    sql = """
+        WITH latest AS (
+            SELECT MAX(scored_at) AS scored_at
+            FROM scores
+            WHERE model_version = %(mv)s
+        ),
+        uni AS (
+            SELECT c.filings_status
+            FROM instruments i
+            LEFT JOIN coverage c ON c.instrument_id = i.instrument_id
+            WHERE i.is_tradable = TRUE
+        ),
+        ranked AS (
+            -- COUNT(DISTINCT instrument_id): defensive. Within one run
+            -- (a single scored_at) compute_rankings writes exactly one row per
+            -- distinct instrument, so this equals the list endpoint's COUNT(*)
+            -- today (full-pop check: 0 dup triples across all score rows). The
+            -- DB-level UNIQUE(instrument_id, model_version, scored_at) that would
+            -- make the equality unbreakable is tracked in #1933.
+            SELECT COUNT(DISTINCT s.instrument_id) AS n
+            FROM scores s
+            JOIN instruments i USING (instrument_id)
+            JOIN coverage c USING (instrument_id)
+            WHERE s.model_version = %(mv)s
+              AND s.scored_at = (SELECT scored_at FROM latest)
+              AND i.is_tradable = TRUE
+              AND c.filings_status = 'analysable'
+        )
+        SELECT
+            (SELECT scored_at FROM latest) AS scored_at,
+            (SELECT COUNT(*) FROM uni) AS universe,
+            (SELECT n FROM ranked) AS ranked,
+            COALESCE(
+                (
+                    SELECT jsonb_object_agg(filings_status, cnt)
+                    FROM (
+                        SELECT filings_status, COUNT(*) AS cnt
+                        FROM uni
+                        WHERE filings_status IS NOT NULL
+                        GROUP BY filings_status
+                    ) g
+                ),
+                '{}'::jsonb
+            ) AS status_counts
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, {"mv": model_version})
+        row = cur.fetchone()
+
+    # The SELECT always returns exactly one row (scalar subqueries).
+    assert row is not None  # noqa: S101 — narrows the dict_row Optional for type checkers
+    raw_status = row["status_counts"] or {}
+    status_counts = {str(k): int(v) for k, v in raw_status.items()}
+
+    return build_coverage(
+        model_version=model_version,
+        scored_at=row["scored_at"],
+        universe=int(row["universe"] or 0),
+        ranked=int(row["ranked"] or 0),
+        status_counts=status_counts,
     )
 
 

--- a/app/api/scores.py
+++ b/app/api/scores.py
@@ -635,8 +635,10 @@ def get_rankings_coverage(
         cur.execute(sql, {"mv": model_version})
         row = cur.fetchone()
 
-    # The SELECT always returns exactly one row (scalar subqueries).
-    assert row is not None  # noqa: S101 — narrows the dict_row Optional for type checkers
+    # The SELECT always returns exactly one row (scalar subqueries). Raise
+    # explicitly rather than assert (assert is stripped under `python -O`).
+    if row is None:  # pragma: no cover — unreachable given scalar-subquery SELECT
+        raise RuntimeError("rankings coverage query returned no row")
     raw_status = row["status_counts"] or {}
     status_counts = {str(k): int(v) for k, v in raw_status.items()}
 

--- a/docs/proposals/ui/2026-07-04-rankings-coverage-explicit.md
+++ b/docs/proposals/ui/2026-07-04-rankings-coverage-explicit.md
@@ -1,0 +1,128 @@
+# Rankings coverage — make the denominator explicit (#1918)
+
+## Problem
+Rankings renders only the scored subset (3,904 rows) of a 12,597-instrument
+tradable universe with no statement of what's excluded or why. Operator can't
+tell "not ranked" from "ranked low" from "missing data" — reads as a bug
+("missing 10k items").
+
+## Full-population verification (dev DB, model `v1.3-balanced`, 2026-07-04)
+Tradable = 12,597. `filings_status` partitions it MECE (every tradable
+instrument has exactly one coverage row + status; 0 NULL coverage rows):
+
+| filings_status        | count  | meaning |
+|-----------------------|--------|---------|
+| analysable            | 3,914  | enough SEC filings to fundamentally analyse |
+| no_primary_sec_cik    | 7,254  | no SEC CIK — non-US listing / no US filer |
+| fpi                   | 1,088  | foreign private issuer (20-F/6-K, no US-GAAP 10-K/10-Q) |
+| insufficient          | 185    | US filer, too few filings, backfill exhausted |
+| structurally_young    | 156    | insufficient because genuinely recently listed |
+
+Of the 3,914 analysable, **3,904 are ranked** (in the latest `compute_rankings`
+run and still analysable). The remaining **10** are analysable but fail
+eligibility's third clause — full-pop check: all 10 lack a thesis AND a
+fundamentals snapshot AND price history (`scoring.py:1757-1761`), so they have
+no scoring inputs. They are NOT merely "awaiting the next run"; the honest bucket
+is "analysable — not in the latest ranking run" (reason `analysable_unranked`),
+which covers no-input names today and would also cover a scoring failure or a
+between-runs insert in future without overclaiming.
+
+`ranked` counts `COUNT(DISTINCT s.instrument_id)` (defensive — `scores` has no
+uniqueness constraint on `(instrument_id, model_version, scored_at)`; full-pop
+today shows rows == distinct == 3,904, no dupes). Ranked ≤ analysable holds
+because ranked is a filtered subset of analysable instruments.
+
+**Verdict: not a bug.** Exclusion is correct — 8,683 instruments have no
+US-GAAP SEC fundamentals to score. The fix is to state it honestly, not to rank
+them. Matches settled decision (list endpoint gates on
+`coverage.filings_status='analysable'`, #268 Chunk J) + eligibility SQL
+(`scoring.py:1722` `compute_rankings`).
+
+## Source rule
+Rank-eligibility is code-defined at `app/services/scoring.py:1749-1764`:
+`is_tradable=TRUE AND coverage.filings_status='analysable' AND (thesis OR
+fundamentals_snapshot OR price_daily)`. The list endpoint
+(`app/api/scores.py:332-336`) re-gates on `filings_status='analysable'` so stale
+score rows for regressed instruments never surface. **This PR also adds
+`i.is_tradable = TRUE` to the list endpoint** (full-pop check: 0 ranked rows are
+non-tradable today, so a no-op now, but it guarantees `ranked` == the table's
+`total` and that a delisted instrument's stale score can never surface). The
+coverage endpoint reuses the SAME gate for `ranked`.
+
+`filings_status` meanings are the classifier's own documented rules, not
+inferred: `app/services/coverage.py` `probe_status` / `_finalise` /
+`_is_structurally_young` (`coverage.py:1844-1893`) — `fpi` = classifier detected
+a foreign-private-issuer form family (20-F/6-K), `no_primary_sec_cik` = no SEC
+CIK resolved, `insufficient` = US filer with too few filings after backfill
+exhausted, `structurally_young` = insufficient but genuinely recently listed.
+Labels below avoid the stronger "US-GAAP" claim (the classifier keys on SEC form
+families/counts, not accounting basis).
+
+## Scope (this PR — shippable slice)
+Items 1 + 2 of #1918. Item 3 (unranked reachable via explorer with a
+"not ranked — why" treatment) defers to the unified-explorer ticket #1917 — no
+explorer surface exists yet. Item 4 (interaction with #1857 value 0.5): the
+breakdown buckets by `filings_status`, orthogonal to the value sub-score gate,
+so it neither bundles nor masks #1857.
+
+### Backend — `GET /rankings/coverage`
+New read endpoint in `app/api/scores.py`. Response:
+```
+{
+  "model_version": "v1.3-balanced",
+  "scored_at": "2026-07-04T..." | null,
+  "universe": 12597,          // COUNT(*) instruments WHERE is_tradable
+  "ranked": 3904,             // == GET /rankings unfiltered total for this run
+  "not_ranked": [             // MECE over (universe - ranked), each a reason code + operator label
+    {"reason": "no_primary_sec_cik",  "label": "No SEC filer (non-US listing)", "count": 7254},
+    {"reason": "fpi",                 "label": "Foreign private issuer (20-F/6-K filer)", "count": 1088},
+    {"reason": "insufficient",        "label": "Insufficient filing history", "count": 185},
+    {"reason": "structurally_young",  "label": "Recently listed — too little history", "count": 156},
+    {"reason": "analysable_unranked", "label": "Analysable — not in latest ranking run", "count": 10}
+    // {"reason": "other", "label": "Unclassified coverage", "count": N} — only if residual > 0
+  ]
+}
+```
+Computation — **one CTE query** (atomic snapshot; two separate READ COMMITTED
+queries are not one snapshot):
+- `universe` = `COUNT(*) FROM instruments WHERE is_tradable`.
+- per-status counts = `GROUP BY coverage.filings_status` over tradable
+  (LEFT JOIN coverage, so a missing coverage row folds to NULL status → `other`).
+- `ranked` = `COUNT(DISTINCT s.instrument_id)` over the latest run of
+  `model_version` gated `i.is_tradable AND c.filings_status='analysable'`
+  (0 when no run exists → `scored_at=null`; then `analysable_unranked` = full
+  analysable count since nothing is ranked yet).
+
+Pure helper `build_coverage(universe, ranked, status_counts)` assembles buckets:
+- `analysable_unranked = analysable_count - ranked`
+- one bucket per known non-analysable status present
+- `other = universe - ranked - analysable_unranked - Σ(known non-analysable)` —
+  a catch-all absorbing NULL / `unknown` / missing-coverage / any future status,
+  so the invariant `ranked + Σ not_ranked == universe` holds **definitionally**.
+- `assert analysable_unranked >= 0 and other >= 0`; on a negative (a genuine data
+  anomaly — e.g. duplicate score rows making ranked > analysable), log a warning
+  and clamp the offending bucket to 0 while the `other` residual keeps the total
+  reconciled (prevention-log "bucket-arithmetic double-counting" — every bucket
+  mutually exclusive, residual explicit, never a silent negative).
+Zero-count buckets are omitted.
+
+### Frontend
+- `frontend/src/api/types.ts`: `RankingsCoverage` + `RankingsCoverageBucket`.
+- `frontend/src/api/rankings.ts`: `fetchRankingsCoverage(): Promise<RankingsCoverage>`.
+- `RankingsPage.tsx`: header line "Ranked {ranked} of {universe}" with an
+  expandable "coverage" disclosure listing each `not_ranked` bucket
+  (label + count). Loads independently of the table page query (its own
+  `useQuery`/async hook); a coverage fetch failure degrades to hiding the
+  denominator line, never blocks the table. Dark-mode + tabular-nums per
+  operator-ui conventions.
+
+## Tests
+- Pure: a `_coverage_from_counts(universe, ranked, status_counts)` helper builds
+  the response from raw counts — table-test MECE + invariant + awaiting math +
+  no-run (ranked=0) case. No DB.
+- One API test (auto-`db`) hitting `/rankings/coverage` on a seeded run to prove
+  wiring + `ranked == /rankings total`.
+
+## Out of scope
+Explorer "not ranked — why" per-instrument treatment (#1917). Model/value-gate
+change (#1857). Model-version selector.

--- a/frontend/src/api/rankings.ts
+++ b/frontend/src/api/rankings.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "@/api/client";
-import type { RankingsListResponse } from "@/api/types";
+import type { RankingsCoverage, RankingsListResponse } from "@/api/types";
 
 /**
  * Server-side query set for /rankings (#1825 — fully server-authoritative).
@@ -93,4 +93,13 @@ export async function fetchRankings(
   }
 
   return response;
+}
+
+/**
+ * Fetch the ranked-vs-universe coverage denominator (#1918). Independent of the
+ * table page query — the header renders "Ranked N of M" plus a why-not-ranked
+ * breakdown so absence reads as a correct exclusion, not a bug.
+ */
+export async function fetchRankingsCoverage(): Promise<RankingsCoverage> {
+  return apiFetch<RankingsCoverage>("/rankings/coverage");
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1066,6 +1066,27 @@ export interface RankingsListResponse {
 }
 
 // ---------------------------------------------------------------------------
+// /rankings/coverage (app/api/scores.py) — ranked-vs-universe denominator (#1918)
+// ---------------------------------------------------------------------------
+
+export interface RankingsCoverageBucket {
+  reason: string;
+  label: string;
+  count: number;
+}
+
+export interface RankingsCoverage {
+  model_version: string;
+  scored_at: string | null;
+  // Tradable universe.
+  universe: number;
+  // Exactly the count `GET /rankings` returns unfiltered for this run.
+  ranked: number;
+  // MECE breakdown of (universe - ranked) by exclusion cause.
+  not_ranked: RankingsCoverageBucket[];
+}
+
+// ---------------------------------------------------------------------------
 // /rankings/history/{instrument_id} (app/api/scores.py)
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/components/rankings/RankingsCoverageBanner.tsx
+++ b/frontend/src/components/rankings/RankingsCoverageBanner.tsx
@@ -1,0 +1,51 @@
+import type { RankingsCoverage } from "@/api/types";
+import { formatNumber } from "@/lib/format";
+
+/**
+ * "Ranked N of M — coverage" denominator for the Rankings header (#1918).
+ *
+ * The list only ever shows the scored subset of a ~12.6k tradable universe;
+ * without an explicit denominator the ~8.7k absent instruments read as a bug.
+ * This states the count and, on disclosure, the MECE why-not-ranked breakdown.
+ *
+ * Degrades to null while loading or on error — the header keeps working; the
+ * denominator is additive context, never a blocker (parent passes
+ * `coverage={null}` in those states).
+ */
+export function RankingsCoverageBanner({ coverage }: { coverage: RankingsCoverage | null }) {
+  if (!coverage) return null;
+
+  const { ranked, universe, not_ranked } = coverage;
+  const hasBreakdown = not_ranked.length > 0;
+
+  return (
+    <div className="text-xs text-slate-500 dark:text-slate-400">
+      <details className="group">
+        <summary className="flex cursor-pointer list-none items-center gap-1.5 select-none">
+          <span className="tabular-nums text-slate-600 dark:text-slate-300">
+            Ranked <span className="font-semibold">{formatNumber(ranked, 0)}</span> of{" "}
+            <span className="font-semibold">{formatNumber(universe, 0)}</span>
+          </span>
+          {hasBreakdown && (
+            <span className="text-slate-400 group-open:text-slate-600 dark:group-open:text-slate-200">
+              <span className="underline decoration-dotted underline-offset-2">why</span>
+              <span className="ml-0.5 inline-block transition-transform group-open:rotate-90">›</span>
+            </span>
+          )}
+        </summary>
+        {hasBreakdown && (
+          <ul className="mt-2 space-y-1 border-l border-slate-200 pl-3 dark:border-slate-800">
+            {not_ranked.map((b) => (
+              <li key={b.reason} className="flex items-baseline justify-between gap-4">
+                <span className="text-slate-600 dark:text-slate-300">{b.label}</span>
+                <span className="tabular-nums text-slate-500 dark:text-slate-400">
+                  {formatNumber(b.count, 0)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </details>
+    </div>
+  );
+}

--- a/frontend/src/pages/RankingsPage.test.tsx
+++ b/frontend/src/pages/RankingsPage.test.tsx
@@ -56,7 +56,18 @@ function lastCall(spy: ReturnType<typeof vi.spyOn>) {
 }
 
 describe("RankingsPage — server-authoritative (#1825)", () => {
-  beforeEach(() => vi.restoreAllMocks());
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    // #1918: the header's independent coverage fetch — stub so it never hits
+    // the network. Its failure/absence must not affect the table assertions.
+    vi.spyOn(rankingsApi, "fetchRankingsCoverage").mockResolvedValue({
+      model_version: "v1.3-balanced",
+      scored_at: null,
+      universe: 12597,
+      ranked: 1,
+      not_ranked: [{ reason: "no_primary_sec_cik", label: "No SEC filer (non-US listing)", count: 12596 }],
+    });
+  });
 
   it("renders rows + the completeness chip", async () => {
     const spy = vi

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from "react";
 import { ApiError } from "@/api/client";
 import {
   fetchRankings,
+  fetchRankingsCoverage,
   RANKINGS_PAGE_SIZE,
   type RankingsQuery,
   type RankingsSortField,
 } from "@/api/rankings";
 import { useAsync } from "@/lib/useAsync";
 import { Section } from "@/components/dashboard/Section";
+import { RankingsCoverageBanner } from "@/components/rankings/RankingsCoverageBanner";
 import { RankingsFilters } from "@/components/rankings/RankingsFilters";
 import { RankingsTable, type RankingsView } from "@/components/rankings/RankingsTable";
 import { formatDateTime } from "@/lib/format";
@@ -68,6 +70,10 @@ export function RankingsPage() {
     ],
   );
 
+  // Ranked-vs-universe denominator (#1918). Loaded once, independent of the
+  // table query — a coverage failure hides the line, never blocks the table.
+  const coverage = useAsync(() => fetchRankingsCoverage(), []);
+
   // Any query change resets paging to the first page (atomic with the change).
   const updateQuery = (next: RankingsQuery) => {
     setQuery(next);
@@ -111,8 +117,11 @@ export function RankingsPage() {
 
   return (
     <div className="flex h-full flex-col gap-6 pt-6">
-      <div className="flex flex-shrink-0 items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Rankings</h1>
+      <div className="flex flex-shrink-0 items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Rankings</h1>
+          <RankingsCoverageBanner coverage={coverage.data ?? null} />
+        </div>
         <span className="text-xs text-slate-500">
           {rankings.data?.scored_at
             ? `Latest run: ${formatDateTime(rankings.data.scored_at)}`

--- a/tests/test_api_scores.py
+++ b/tests/test_api_scores.py
@@ -547,6 +547,59 @@ class TestListRankings:
 
 
 # ---------------------------------------------------------------------------
+# TestGetRankingsCoverage
+# ---------------------------------------------------------------------------
+
+
+class TestGetRankingsCoverage:
+    """GET /rankings/coverage — ranked-vs-universe denominator (#1918)."""
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_happy_path_reconciles_and_labels(self) -> None:
+        # One coverage SELECT row: the single atomic snapshot query.
+        row = {
+            "scored_at": _NOW,
+            "universe": 12597,
+            "ranked": 3904,
+            "status_counts": {
+                "analysable": 3914,
+                "no_primary_sec_cik": 7254,
+                "fpi": 1088,
+                "insufficient": 185,
+                "structurally_young": 156,
+            },
+        }
+        _with_conn([[row]])
+        resp = client.get("/rankings/coverage")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["universe"] == 12597
+        assert body["ranked"] == 3904
+        # MECE: header count + every bucket reconciles to the universe.
+        assert body["ranked"] + sum(b["count"] for b in body["not_ranked"]) == 12597
+        by_reason = {b["reason"]: b for b in body["not_ranked"]}
+        assert by_reason["analysable_unranked"]["count"] == 10
+        assert by_reason["fpi"]["label"] == "Foreign private issuer (20-F/6-K filer)"
+
+    def test_no_run_returns_null_scored_at_zero_ranked(self) -> None:
+        row = {
+            "scored_at": None,
+            "universe": 12597,
+            "ranked": 0,
+            "status_counts": {"analysable": 3914, "no_primary_sec_cik": 8683},
+        }
+        _with_conn([[row]])
+        resp = client.get("/rankings/coverage")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["scored_at"] is None
+        assert body["ranked"] == 0
+        assert body["ranked"] + sum(b["count"] for b in body["not_ranked"]) == 12597
+
+
+# ---------------------------------------------------------------------------
 # TestGetScoreHistory
 # ---------------------------------------------------------------------------
 

--- a/tests/test_rankings_coverage.py
+++ b/tests/test_rankings_coverage.py
@@ -1,0 +1,126 @@
+"""Pure-logic tests for the Rankings coverage breakdown (#1918).
+
+``build_coverage`` assembles the ranked-vs-universe denominator + why-not-ranked
+buckets from raw full-population counts. No DB — table-tests the MECE invariant,
+the analysable split, the residual catch-all, and the no-run case.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.api.scores import build_coverage
+
+_TS = datetime(2026, 7, 4, 6, 0, 0, tzinfo=UTC)
+
+# The full-population dev snapshot (2026-07-04, model v1.3-balanced).
+_REAL_STATUS_COUNTS = {
+    "analysable": 3914,
+    "no_primary_sec_cik": 7254,
+    "fpi": 1088,
+    "insufficient": 185,
+    "structurally_young": 156,
+}
+
+
+def _bucket(cov, reason):
+    return next((b for b in cov.not_ranked if b.reason == reason), None)
+
+
+class TestBuildCoverage:
+    def test_real_snapshot_reconciles_to_universe(self) -> None:
+        cov = build_coverage(
+            model_version="v1.3-balanced",
+            scored_at=_TS,
+            universe=12597,
+            ranked=3904,
+            status_counts=_REAL_STATUS_COUNTS,
+        )
+        assert cov.ranked == 3904
+        assert cov.universe == 12597
+        # MECE: ranked + every not_ranked bucket sums back to the universe.
+        assert cov.ranked + sum(b.count for b in cov.not_ranked) == cov.universe
+
+    def test_analysable_splits_into_ranked_and_unranked(self) -> None:
+        cov = build_coverage(
+            model_version="m",
+            scored_at=_TS,
+            universe=12597,
+            ranked=3904,
+            status_counts=_REAL_STATUS_COUNTS,
+        )
+        unranked = _bucket(cov, "analysable_unranked")
+        assert unranked is not None
+        # 3914 analysable − 3904 ranked = 10 analysable-but-not-in-run.
+        assert unranked.count == 10
+        assert unranked.label == "Analysable — not in latest ranking run"
+
+    def test_status_buckets_pass_through_with_labels(self) -> None:
+        cov = build_coverage(
+            model_version="m",
+            scored_at=_TS,
+            universe=12597,
+            ranked=3904,
+            status_counts=_REAL_STATUS_COUNTS,
+        )
+        assert _bucket(cov, "no_primary_sec_cik").count == 7254  # type: ignore[union-attr]
+        assert _bucket(cov, "fpi").count == 1088  # type: ignore[union-attr]
+        assert _bucket(cov, "fpi").label == "Foreign private issuer (20-F/6-K filer)"  # type: ignore[union-attr]
+
+    def test_zero_count_buckets_omitted(self) -> None:
+        cov = build_coverage(
+            model_version="m",
+            scored_at=_TS,
+            universe=4000,
+            ranked=3904,
+            status_counts={"analysable": 3904, "no_primary_sec_cik": 96},
+        )
+        # analysable == ranked → no analysable_unranked bucket.
+        assert _bucket(cov, "analysable_unranked") is None
+        # fpi/insufficient/young absent from counts → no buckets.
+        assert {b.reason for b in cov.not_ranked} == {"no_primary_sec_cik"}
+        assert cov.ranked + sum(b.count for b in cov.not_ranked) == cov.universe
+
+    def test_no_run_ranks_zero_all_analysable_unranked(self) -> None:
+        cov = build_coverage(
+            model_version="m",
+            scored_at=None,
+            universe=12597,
+            ranked=0,
+            status_counts=_REAL_STATUS_COUNTS,
+        )
+        assert cov.scored_at is None
+        assert cov.ranked == 0
+        # Nothing ranked → all 3914 analysable land in analysable_unranked.
+        assert _bucket(cov, "analysable_unranked").count == 3914  # type: ignore[union-attr]
+        assert cov.ranked + sum(b.count for b in cov.not_ranked) == cov.universe
+
+    def test_unknown_status_folds_into_other(self) -> None:
+        # A tradable row with NULL/unknown coverage status is not in the known
+        # map; the residual `other` bucket absorbs it so the total reconciles.
+        cov = build_coverage(
+            model_version="m",
+            scored_at=_TS,
+            universe=100,
+            ranked=40,
+            status_counts={"analysable": 40, "no_primary_sec_cik": 50},
+        )
+        other = _bucket(cov, "other")
+        assert other is not None
+        assert other.count == 10  # 100 − 40 analysable − 50 no_sec
+        assert other.label == "Unclassified coverage"
+        assert cov.ranked + sum(b.count for b in cov.not_ranked) == cov.universe
+
+    def test_negative_bucket_clamped_not_shown_negative(self) -> None:
+        # Data anomaly: ranked (45) > analysable (40) — e.g. duplicate score
+        # rows. analysable_unranked would be −5; it must clamp to 0 (omitted),
+        # never surface a negative.
+        cov = build_coverage(
+            model_version="m",
+            scored_at=_TS,
+            universe=100,
+            ranked=45,
+            status_counts={"analysable": 40, "no_primary_sec_cik": 60},
+        )
+        assert _bucket(cov, "analysable_unranked") is None
+        assert all(b.count > 0 for b in cov.not_ranked)


### PR DESCRIPTION
## Problem
Rankings renders only the scored subset (3,904) of a 12,597-instrument tradable universe with **no denominator**. Operator can't tell "not ranked" from "ranked low" from "missing data" — the ~8.7k absent instruments read as a bug ("missing 10k items"). Closes #1918 (items 1+2).

## Full-population verification (dev DB, `v1.3-balanced`, 2026-07-04)
Tradable = 12,597. `coverage.filings_status` partitions it MECE (every tradable instrument has exactly one status; 0 NULL/missing coverage rows):

| bucket | count | why not ranked |
|---|---|---|
| **ranked** | **3,904** | in latest run, `is_tradable AND analysable` (== `GET /rankings` unfiltered total) |
| no_primary_sec_cik | 7,254 | no SEC CIK — non-US listing |
| fpi | 1,088 | foreign private issuer (20-F/6-K filer) |
| insufficient | 185 | US filer, too few filings, backfill exhausted |
| structurally_young | 156 | insufficient because genuinely recently listed |
| analysable_unranked | 10 | analysable but lacks thesis+fundamentals+price → fails eligibility clause 3 |

`3,904 + 7,254 + 1,088 + 185 + 156 + 10 = 12,597` ✓ (verified on the live endpoint). **Exclusion is correct, not a bug** — 8,683 instruments have no SEC fundamentals to score.

## Source rule
Rank-eligibility is code-defined (`app/services/scoring.py:1749-1764`): `is_tradable AND coverage.filings_status='analysable' AND (thesis OR fundamentals_snapshot OR price_daily)`. `filings_status` meanings are the classifier's own rules (`app/services/coverage.py` `probe_status`/`_finalise`/`_is_structurally_young`), not inferred — labels avoid the stronger "US-GAAP" claim (classifier keys on SEC form families/counts).

## Changes
**Backend** — `GET /rankings/coverage`: one atomic CTE query → `universe`, `ranked` (`COUNT(DISTINCT instrument_id)`, gated identically to the list endpoint so header == table), per-status counts. Pure `build_coverage()` assembles the MECE breakdown; an `other` residual absorbs any NULL/unknown status so `ranked + Σ not_ranked == universe` holds definitionally; a negative computed bucket clamps to 0 + logs (data-anomaly guard, prevention-log "bucket-arithmetic double-counting"). Also adds `i.is_tradable = TRUE` to the list endpoint gate (full-pop no-op today — 0 ranked rows are non-tradable — forward guard so a stale delisted score can never surface and header == table).

**Frontend** — `RankingsCoverageBanner`: "Ranked N of M" with a why-not-ranked `<details>` disclosure. Loads independently of the table query (`useAsync`), degrades to `null` on error/loading — additive context, never a blocker.

## Security model
Read-only. No user input reaches SQL — the endpoint takes only `model_version` (parameterised) and the query is fully static CTE text. No auth change (same posture as the existing `/rankings` reads).

## Tradeoffs / deferred
- **Item 3** (per-instrument "not ranked — why" in an explorer) defers to #1917 — no explorer surface exists yet.
- **#1857** (value sub-score 0.5, operator-gated model change) is orthogonal: buckets key on `filings_status`, so the breakdown neither bundles nor masks it.
- **Codex ckpt-2** flagged that the list endpoint's `COUNT(*)` and coverage's `COUNT(DISTINCT)` could diverge without a DB uniqueness constraint. Full-pop check: **0 duplicate `(instrument_id, model_version, scored_at)` triples across all 104,285 score rows** — the write path (`compute_rankings`, one row per instrument per run) makes them equal today. DB-level `UNIQUE` constraint filed as tech-debt **#1933** and referenced in a code comment.

## Verification
- `GET /rankings/coverage` on dev DB: `universe=12597 ranked=3904`, buckets reconcile exactly (above).
- Backend: `ruff check`/`format` clean, `pyright` 0 errors, fast tier `4755 passed`, smoke `141 passed`.
- FE: `tsc -b` clean, full `test:unit` `1261 passed` (incl. RankingsPage).
- Tests: pure `build_coverage` table-tests (fast tier — MECE, analysable split, residual, no-run, unknown-status, negative-clamp) + mocked endpoint tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)