### PR TITLE
feat(#1907): surface expected filings on the Calendar

### DIFF
--- a/app/api/calendar.py
+++ b/app/api/calendar.py
@@ -13,8 +13,16 @@ Scope of the data (premise-checked on dev, #1754):
     not assert an open/closed for it.
   * **Upcoming ex-dividends** — ``dividend_events.ex_date >= today``. Real
     (sparse) data.
-  * Forward earnings + filing dates are deliberately NOT here: we ingest no
-    forward earnings calendar and no filing-due dates (verified absent).
+  * **Expected filings** — ``expected_filings`` 10-Q/10-K due-windows for the
+    scope (#1788/#677 poller). An "expected" polling *window* anchored on the
+    SEC statutory filing deadlines, NOT a legal due-date and NOT an earnings
+    date (earnings often land earlier via a release / 8-K).
+  * Forward *earnings* dates are deliberately NOT here: we ingest no forward
+    earnings calendar (no new paid provider, #609 posture).
+
+Scope is OPEN holdings only — ``positions`` rows with ``current_units > 0``
+(a closed position persists with ``current_units = 0``) plus this operator's
+watchlist. This mirrors the expected_filings poller's own scope.
 
 ``is_open_now`` / the current intraday session is computed on the FRONTEND
 via the existing ``classifySession`` over these rows + the market specials
@@ -89,11 +97,27 @@ class UpcomingExDividend(BaseModel):
     pay_date: date | None
 
 
+class UpcomingExpectedFiling(BaseModel):
+    """A predicted upcoming periodic filing (10-Q / 10-K) for a scope instrument.
+
+    ``window_start``/``window_end`` bound the poller's expected filing *window*
+    (SEC-deadline-anchored heuristic, not a legal due-date). The UI renders it as
+    an "expected" date range, never an exact date.
+    """
+
+    symbol: str
+    instrument_id: int
+    filing_type: str
+    window_start: date
+    window_end: date
+
+
 class CalendarEvents(BaseModel):
     scope: CalendarScope
     as_of: date
     market_status: list[MarketStatusRow]
     ex_dividends: list[UpcomingExDividend]
+    expected_filings: list[UpcomingExpectedFiling]
 
 
 def _day_type(profile: str, d: date) -> DayType:
@@ -149,13 +173,17 @@ def _scope_instruments(conn: psycopg.Connection[object], scope: CalendarScope) -
                 detail="multiple operators present — calendar requires a per-session operator context",
             ) from exc
 
+    # Portfolio legs gate on current_units > 0: a closed position persists in
+    # `positions` with current_units = 0, and surfacing calendar events for a
+    # name you no longer hold is wrong. This mirrors the expected_filings
+    # poller's own scope (positions WHERE current_units > 0).
     if scope == "watchlist":
         source = "JOIN watchlist src ON src.instrument_id = i.instrument_id AND src.operator_id = %(op)s"
     elif scope == "portfolio":
-        source = "JOIN positions src ON src.instrument_id = i.instrument_id"
-    else:  # all — positions (global) ∪ this operator's watchlist
+        source = "JOIN positions src ON src.instrument_id = i.instrument_id AND src.current_units > 0"
+    else:  # all — open positions (global) ∪ this operator's watchlist
         source = (
-            "JOIN (SELECT instrument_id FROM positions "
+            "JOIN (SELECT instrument_id FROM positions WHERE current_units > 0 "
             "UNION SELECT instrument_id FROM watchlist WHERE operator_id = %(op)s"
             ") src ON src.instrument_id = i.instrument_id"
         )
@@ -223,4 +251,41 @@ def calendar_events(
                 for r in cur.fetchall()
             ]
 
-    return CalendarEvents(scope=scope, as_of=today_ny, market_status=market_status, ex_dividends=ex_dividends)
+    # Expected filings — unfulfilled 10-Q/10-K due-windows still open (window_end
+    # >= today), ordered by the earliest expected date. Unbounded by the `days`
+    # horizon (corporate events look weeks out; the horizon only governs the
+    # market-status grid), mirroring the ex-dividends behaviour.
+    expected_filings: list[UpcomingExpectedFiling] = []
+    if instrument_ids:
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT i.symbol, ef.instrument_id, ef.expected_filing_type,
+                       ef.expected_window_start, ef.expected_window_end
+                FROM expected_filings ef
+                JOIN instruments i ON i.instrument_id = ef.instrument_id
+                WHERE ef.instrument_id = ANY(%(ids)s)
+                  AND ef.fulfilled_at IS NULL
+                  AND ef.expected_window_end >= %(today)s
+                ORDER BY ef.expected_window_start, i.symbol, ef.instrument_id
+                """,
+                {"ids": instrument_ids, "today": today_ny},
+            )
+            expected_filings = [
+                UpcomingExpectedFiling(
+                    symbol=str(r["symbol"]),
+                    instrument_id=int(r["instrument_id"]),
+                    filing_type=str(r["expected_filing_type"]),
+                    window_start=r["expected_window_start"],
+                    window_end=r["expected_window_end"],
+                )
+                for r in cur.fetchall()
+            ]
+
+    return CalendarEvents(
+        scope=scope,
+        as_of=today_ny,
+        market_status=market_status,
+        ex_dividends=ex_dividends,
+        expected_filings=expected_filings,
+    )

--- a/docs/proposals/ui/2026-07-04-calendar-expected-filings.md
+++ b/docs/proposals/ui/2026-07-04-calendar-expected-filings.md
@@ -1,0 +1,83 @@
+# Calendar — surface expected filings (#1907)
+
+## Problem
+`/calendar` shows market-status pills + ex-dividends + a footnote saying filing
+dates aren't ingested. That footnote is **stale**: the `expected_filings` poller
+(#1788/#677) populates 10-Q/10-K due-windows per held/watched instrument, and the
+calendar doesn't read the table.
+
+## Full-population verification (dev DB, 2026-07-04)
+`expected_filings` has 3 unfulfilled upcoming rows, all for held positions:
+BBBY 10-Q (2026-07-30 → 08-24), IEP 10-Q (07-30 → 08-24), GME 10-Q
+(08-31 → 09-25). The poller scopes to relevant instruments, so 3 rows is honest,
+not thin. Ex-dividends for the 6 held names (WDC/BBBY/IEP/GME/QQQ/VOO): **0
+upcoming** — verified by replicating the endpoint query. Genuinely empty, NOT a
+filter bug (QQQ/VOO have 0 `dividend_events` rows at all — an ETF-dividend ingest
+gap, out of scope; filed separately).
+
+## Source rule
+`expected_window_start/end` is the poller's heuristic polling window
+(`app/jobs/expected_filings_poller.py` `_WINDOW_OFFSETS` / `next_form_and_window`):
+predicted next period-end + offsets anchored on SEC statutory filing deadlines
+(Form 10-Q ~40-45d after quarter-end; 10-K ~60-90d after FY-end), padded for
+fiscal drift. It is NOT a complete legal due-date (no NT/late-filing extensions),
+so the UI labels it "expected" as a date *range* ("expected 30 Jul – 24 Aug"),
+never a "deadline" or a fake exact date. `expected_filing_type` is the literal
+form ("10-Q"/"10-K").
+
+## Scope parity fix (Codex ckpt-1)
+`_scope_instruments` portfolio/all legs currently `JOIN positions` (ALL rows),
+but a closed position persists in `positions` with `current_units = 0` (dev:
+WDC). So the calendar leaks closed holdings into market-status + ex-dividends
+today, and would leak stale expected_filings too. The poller itself scopes to
+`positions WHERE current_units > 0` (`expected_filings_poller.py:148`). Tighten
+the portfolio + all legs to `current_units > 0` for parity — a pre-existing
+correctness fix that drops closed names from every calendar event type.
+
+## Scope (this PR)
+Items 1–3 of #1907, in the existing layout idiom:
+1. **Surface expected filings.** New `expected_filings` list on
+   `GET /calendar/events`, scope-filtered, `fulfilled_at IS NULL AND
+   expected_window_end >= today`, ordered by `expected_window_start`. Mirrors the
+   ex-dividends pattern (unbounded upcoming, independent of the `days` horizon —
+   the horizon governs only the market-status grid; corporate events look
+   further out, e.g. GME is ~8 weeks away).
+2. **Ex-dividends.** No code change — verified correct above. The footnote is
+   updated to reflect that filings now ARE shown.
+3. **Earnings.** Forward *earnings* dates remain unmodelled — expected filing
+   due-windows are NOT earnings dates (earnings often land earlier via a release
+   / 8-K). No new paid provider (settled #609 posture). The footnote keeps an
+   explicit earnings caveat.
+
+Item 4 (week-grid re-layout) defers to the visual-system ticket #1908 — this PR
+adds an "Expected filings" `Section` alongside the existing sections rather than
+re-architecting the page.
+
+### Backend — `app/api/calendar.py`
+- New model `UpcomingExpectedFiling { symbol, instrument_id, filing_type,
+  window_start, window_end }`.
+- Add `expected_filings: list[UpcomingExpectedFiling]` to `CalendarEvents`.
+- One query gated on the scope `instrument_ids` (same list already resolved for
+  ex-dividends), guarded by the `if instrument_ids:` block.
+- Update the module docstring (lines 16-17) — filing due-windows are now
+  surfaced; only forward *earnings* remain unmodelled.
+
+### Frontend
+- `types.ts`: `UpcomingExpectedFiling` + field on `CalendarEvents`.
+- `CalendarPage.tsx`: an "Expected filings" `Section` (empty-state honest),
+  rows `SYMBOL … 10-Q · expected 30 Jul – 24 Aug`. Footnote narrowed to earnings
+  only. Dark-mode + tabular-nums per conventions.
+
+## Tests
+- **db-tier gate test** (`ebull_test_conn`) pinning the exact SQL gate: seed one
+  open-position instrument with a valid upcoming row + a fulfilled row + a
+  past-window row, a closed-position (`current_units=0`) instrument with a valid
+  row, and an out-of-scope instrument with a valid row; call `calendar_events`
+  and assert ONLY the open-position valid row surfaces. Covers fulfilled_at,
+  window_end < today, closed-position, and out-of-scope exclusion in one test.
+- CalendarPage: extend the existing test's mock with `expected_filings` and
+  assert the section renders a row.
+
+## Out of scope
+Week-grid re-layout (#1908). ETF/dividend ingest coverage (separate ticket).
+Forward earnings source.

--- a/docs/specs/api/2026-06-28-calendar-closure-reason-horizon.md
+++ b/docs/specs/api/2026-06-28-calendar-closure-reason-horizon.md
@@ -64,9 +64,12 @@ the API just was not carrying a reason. Confirmed — the only gap is plumbing.
 
 ## Out of scope (no source / tracked elsewhere)
 
-Foreign-exchange holiday set, futures session model, forward earnings + filing
-dates. The on-page note already states earnings/filings are not ingested; leave
-it.
+Foreign-exchange holiday set, futures session model, forward earnings dates.
+
+> Update (#1907, 2026-07-04): expected **filing** dates ARE now surfaced — the
+> `expected_filings` poller (#1788/#677) 10-Q/10-K due-windows render as an
+> "Expected filings" section (expected date *range*, not an exact date). Only
+> forward *earnings* remain unmodelled; the on-page note reflects that.
 
 ## Tests (pure)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1327,11 +1327,20 @@ export interface UpcomingExDividend {
   pay_date: string | null;
 }
 
+export interface UpcomingExpectedFiling {
+  symbol: string;
+  instrument_id: number;
+  filing_type: string; // "10-Q" | "10-K"
+  window_start: string; // YYYY-MM-DD — expected-window start (not an exact date)
+  window_end: string; // YYYY-MM-DD
+}
+
 export interface CalendarEvents {
   scope: CalendarScope;
   as_of: string; // YYYY-MM-DD
   market_status: MarketStatusRow[];
   ex_dividends: UpcomingExDividend[];
+  expected_filings: UpcomingExpectedFiling[];
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/CalendarPage.test.tsx
+++ b/frontend/src/pages/CalendarPage.test.tsx
@@ -23,6 +23,15 @@ const sample: CalendarEvents = {
     },
   ],
   ex_dividends: [{ symbol: "FOO", instrument_id: 1, ex_date: "2026-07-01", pay_date: "2026-07-15" }],
+  expected_filings: [
+    {
+      symbol: "GME",
+      instrument_id: 2,
+      filing_type: "10-Q",
+      window_start: "2026-07-30",
+      window_end: "2026-08-24",
+    },
+  ],
 };
 
 vi.mock("@/api/calendar", () => ({
@@ -47,8 +56,12 @@ describe("CalendarPage", () => {
     // upcoming ex-dividend row.
     expect(screen.getByText("FOO")).toBeInTheDocument();
     expect(screen.getByText(/ex 2026-07-01/)).toBeInTheDocument();
-    // the honest "not ingested" note about earnings/filings.
-    expect(screen.getByText(/does not ingest forward earnings/i)).toBeInTheDocument();
+    // expected-filing row (#1907) renders as an "expected" date range.
+    expect(screen.getByText("Expected filings")).toBeInTheDocument();
+    expect(screen.getByText("GME")).toBeInTheDocument();
+    expect(screen.getByText(/expected .*Jul.*–.*Aug/)).toBeInTheDocument();
+    // the honest note: earnings still not ingested.
+    expect(screen.getByText(/ingests no forward earnings calendar/i)).toBeInTheDocument();
     // closure reason (#1766) renders on the closed tile.
     expect(screen.getByText("Independence Day")).toBeInTheDocument();
   });

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -7,8 +7,9 @@
  * modelled); continuous (crypto/FX/…) is not modelled. The live "now" session
  * is computed client-side via `classifySession` (no server duplication).
  *
- * Forward earnings + filing dates are intentionally absent — we ingest no
- * forward earnings calendar or filing-due dates (stated on-page, not faked).
+ * Expected filings (10-Q/10-K due-windows, #1788/#677 poller) ARE surfaced as
+ * "expected" date ranges. Forward earnings dates remain absent — we ingest no
+ * forward earnings calendar (stated on-page, not faked).
  */
 import { useCallback, useMemo, useState } from "react";
 
@@ -64,6 +65,14 @@ function weekdayShort(isoDate: string): string {
   });
 }
 
+function dayMonth(isoDate: string): string {
+  // Compact "30 Jul" — UTC noon avoids a TZ date-shift on the label.
+  return new Date(`${isoDate}T12:00:00Z`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
 function nowSession(
   profile: SessionProfile,
   epochSeconds: number,
@@ -99,7 +108,7 @@ export function CalendarPage(): JSX.Element {
       <header className="border-b border-slate-200 pb-3 dark:border-slate-800">
         <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Calendar</h1>
         <p className="mt-1 text-xs text-slate-500">
-          Market status for {windowLabel} + upcoming ex-dividends across your{" "}
+          Market status for {windowLabel} + expected filings and ex-dividends across your{" "}
           {scope === "all" ? "portfolio & watchlist" : scope}. US markets are NYSE-precise;
           foreign exchanges show weekday/weekend only (holidays not modelled).
         </p>
@@ -190,6 +199,30 @@ export function CalendarPage(): JSX.Element {
             </div>
           </Section>
 
+          <Section title="Expected filings">
+            {events.data.expected_filings.length === 0 ? (
+              <p className="px-2 py-4 text-xs text-slate-500">
+                No expected filings for instruments in scope.
+              </p>
+            ) : (
+              <ul className="divide-y divide-slate-100 text-sm dark:divide-slate-800">
+                {events.data.expected_filings.map((f) => (
+                  <li
+                    key={`${f.instrument_id}-${f.filing_type}-${f.window_start}`}
+                    className="flex items-baseline justify-between py-1.5"
+                  >
+                    <span className="font-medium text-slate-700 dark:text-slate-200">
+                      {f.symbol} <span className="text-slate-500">{f.filing_type}</span>
+                    </span>
+                    <span className="tabular-nums text-slate-500">
+                      expected {dayMonth(f.window_start)} – {dayMonth(f.window_end)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
           <Section title="Upcoming ex-dividends">
             {events.data.ex_dividends.length === 0 ? (
               <p className="px-2 py-4 text-xs text-slate-500">
@@ -211,8 +244,8 @@ export function CalendarPage(): JSX.Element {
           </Section>
 
           <p className="px-1 text-[10px] text-slate-400">
-            Earnings &amp; filing dates are not yet shown — eBull does not ingest forward earnings
-            calendars or filing-due dates.
+            Expected filings are SEC-deadline-anchored estimates, not exact dates. Forward earnings
+            dates are not shown — eBull ingests no forward earnings calendar.
           </p>
         </>
       )}

--- a/tests/test_calendar_expected_filings_db.py
+++ b/tests/test_calendar_expected_filings_db.py
@@ -1,0 +1,97 @@
+"""db-tier gate test for calendar expected-filings surfacing (#1907).
+
+Pins the exact SQL gate the feature depends on: only an *open*-position
+instrument's *unfulfilled*, *still-open-window* filing surfaces. Auto-marked
+``db`` (pulls ``ebull_test_conn``).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import psycopg
+
+from app.api.calendar import calendar_events
+
+_TODAY = date.today()
+_FUTURE = _TODAY + timedelta(days=30)
+_PAST = _TODAY - timedelta(days=10)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int, symbol: str) -> None:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_position(conn: psycopg.Connection[tuple], iid: int, units: float) -> None:
+    conn.execute(
+        "INSERT INTO positions (instrument_id, current_units, source) VALUES (%s, %s, 'ebull')",
+        (iid, units),
+    )
+
+
+def _seed_filing(
+    conn: psycopg.Connection[tuple],
+    iid: int,
+    *,
+    window_end: date,
+    fulfilled: bool,
+    window_start: date | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO expected_filings
+            (instrument_id, expected_filing_type, anchor_period_end,
+             expected_window_start, expected_window_end, fulfilled_at)
+        VALUES (%s, '10-Q', %s, %s, %s, %s)
+        """,
+        (
+            iid,
+            window_end - timedelta(days=55),
+            window_start or (window_end - timedelta(days=25)),
+            window_end,
+            _TODAY if fulfilled else None,
+        ),
+    )
+
+
+def test_only_open_position_unfulfilled_open_window_surfaces(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    # expected_filings is UNIQUE per instrument (one next-expected filing each),
+    # so each exclusion case gets its own instrument.
+
+    # iid 1 — OPEN position, unfulfilled, still-open window -> the ONLY surface.
+    _seed_instrument(conn, 1, "OPENCO")
+    _seed_position(conn, 1, 100.0)
+    _seed_filing(conn, 1, window_end=_FUTURE, fulfilled=False)
+
+    # iid 2 — OPEN position, FULFILLED filing -> excluded.
+    _seed_instrument(conn, 2, "FILEDCO")
+    _seed_position(conn, 2, 100.0)
+    _seed_filing(conn, 2, window_end=_FUTURE, fulfilled=True)
+
+    # iid 3 — OPEN position, PAST window (window_end < today) -> excluded.
+    _seed_instrument(conn, 3, "STALECO")
+    _seed_position(conn, 3, 100.0)
+    _seed_filing(conn, 3, window_end=_PAST, fulfilled=False)
+
+    # iid 4 — CLOSED position (current_units = 0), valid filing -> excluded.
+    _seed_instrument(conn, 4, "CLOSEDCO")
+    _seed_position(conn, 4, 0.0)
+    _seed_filing(conn, 4, window_end=_FUTURE, fulfilled=False)
+
+    # iid 5 — not held / not watched, valid filing -> out of scope, excluded.
+    _seed_instrument(conn, 5, "OTHERCO")
+    _seed_filing(conn, 5, window_end=_FUTURE, fulfilled=False)
+    conn.commit()
+
+    events = calendar_events(conn=conn, scope="portfolio", days=7)
+
+    surfaced = [(f.symbol, f.filing_type) for f in events.expected_filings]
+    assert surfaced == [("OPENCO", "10-Q")]
+    # The closed name must not leak into any event list either.
+    assert "CLOSEDCO" not in {d.symbol for d in events.ex_dividends}


### PR DESCRIPTION
## Problem
`/calendar` showed market-status pills + ex-dividends + a footnote saying filing dates aren't ingested. That footnote was **stale**: the `expected_filings` poller (#1788/#677) populates 10-Q/10-K due-windows per held/watched instrument, and the calendar never read the table. Closes #1907 (items 1-3).

## Full-population verification (dev DB, 2026-07-04)
- `expected_filings`: 3 unfulfilled upcoming rows, all held positions — BBBY 10-Q (30 Jul → 24 Aug), IEP 10-Q (30 Jul → 24 Aug), GME 10-Q (31 Aug → 25 Sep). A direct `calendar_events(scope="portfolio")` call renders all 3; closed **WDC** (`current_units=0`) is dropped.
- Ex-dividends for the 6 held names (WDC/BBBY/IEP/GME/QQQ/VOO): **0 upcoming** — replicated the endpoint query → genuinely empty, **not a filter bug**. (QQQ/VOO have 0 `dividend_events` rows at all — an ETF-dividend *ingest* gap, out of scope.)

## Changes
**Backend** (`app/api/calendar.py`)
- `GET /calendar/events` → new `expected_filings` list, scope-gated, `fulfilled_at IS NULL AND expected_window_end >= today`, ordered by `window_start`. Unbounded by the `days` horizon (corporate events look weeks out; horizon governs only the market-status grid) — mirrors the ex-dividends behaviour.
- **Scope parity fix (Codex ckpt-1):** `_scope_instruments` portfolio/all legs now gate on `current_units > 0`. A closed position persists in `positions` with `current_units=0` (dev: WDC) and was leaking into market-status + ex-dividends; the poller itself scopes to open positions. This drops closed names from **every** calendar event type. (`_scope_instruments` has no other callers; watchlist leg unaffected.)

**Frontend**
- "Expected filings" `Section` rendering `SYMBOL 10-Q · expected 30 Jul – 24 Aug`. Labelled an **"expected"** date *range* (a due-window), never an exact date. Footnote narrowed — forward *earnings* remain unmodelled (expected filings are NOT earnings dates; earnings often land earlier via a release/8-K).

## Source rule
`expected_window_start/end` = poller heuristic anchored on SEC statutory filing deadlines (Form 10-Q ~40-45d after quarter-end; 10-K ~60-90d after FY-end), padded — `app/jobs/expected_filings_poller.py` `_WINDOW_OFFSETS` / `next_form_and_window`. NOT a complete legal due-date (no NT/late-filing extension), hence the "expected range" framing. `expected_filings` is UNIQUE per instrument (one next-expected filing each).

## Security model
Read-only, no schema change. Endpoint already sits behind `require_session_or_service_token`; scope resolution (operator-scoped watchlist, global positions) unchanged except the `current_units > 0` tightening. No user input reaches SQL unparameterised (scope is a `Literal`; ids/today are bound params).

## Tradeoffs / deferred
- Week-grid re-layout (item 4) → #1908 (visual-system v2). This PR adds a section in the existing layout idiom.
- ETF/dividend ingest coverage (QQQ/VOO) — separate data-source gap, not this ticket.

## Verification
- Direct `calendar_events()` on dev DB (above). Live browser FE-QA of the branch isn't possible in-loop — the running dev stack serves the `~/Dev/eBull` main checkout, not this worktree branch — so behaviour is verified via the endpoint call + the db-tier gate test + the CalendarPage unit test.
- Backend: ruff/format/pyright clean; `db`-tier gate test passes (open+unfulfilled+open-window is the only surface; fulfilled / past-window / closed-position / out-of-scope all excluded).
- FE: `tsc -b` clean; full `test:unit` `1261 passed` (CalendarPage asserts the section + row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)