### PR TITLE
feat(#1924): day-change column on instruments list + summary (part 2)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -54,6 +54,7 @@ from app.services.dimensional_facts_store import read_segments
 from app.services.fcf_yield import fcf_yield_series
 from app.services.fx import FxRateNotFound, convert, load_live_fx_rates
 from app.services.intraday_candles import fetch_intraday_candles
+from app.services.market_data import load_day_changes
 from app.services.operators import (
     AmbiguousOperatorError,
     NoOperatorError,
@@ -167,6 +168,14 @@ class InstrumentListItem(BaseModel):
     is_tradable: bool
     coverage_tier: int | None
     latest_quote: QuoteSnapshot | None
+    # #1924: close-to-close day-change from ``price_daily`` (last two positive
+    # closes), a SEPARATE source from ``latest_quote`` (the thin live-tick
+    # table). ``day_change_pct`` is a FRACTION (``-0.015`` = −1.5%);
+    # ``day_change_as_of`` is the latest close's date, stamped so a stale close
+    # reads honestly (settled-decisions.md:767). Both NULL when <2 positive
+    # closes exist.
+    day_change_pct: Decimal | None = None
+    day_change_as_of: date | None = None
 
 
 class InstrumentListResponse(BaseModel):
@@ -228,6 +237,10 @@ class InstrumentPrice(BaseModel):
     current: Decimal | None
     day_change: Decimal | None
     day_change_pct: Decimal | None
+    # #1924: date of the latest ``price_daily`` close the day-change is computed
+    # from — stamped so a stale close reads honestly rather than as "today"
+    # (settled-decisions.md:767). NULL when no day-change is available.
+    day_change_as_of: date | None = None
     week_52_high: Decimal | None
     week_52_low: Decimal | None
     currency: str | None
@@ -655,9 +668,14 @@ def list_instruments(
         cur.execute(items_sql, items_params)  # type: ignore[arg-type]  # SQL built from hardcoded fragments
         rows = cur.fetchall()
 
+    # #1924: batch day-change for only this page's instruments (not the whole
+    # universe) from ``price_daily`` last-two-positive-closes.
+    day_changes = load_day_changes(conn, [int(r["instrument_id"]) for r in rows])  # type: ignore[arg-type]
+
     items: list[InstrumentListItem] = []
     for r in rows:
         sc = resolve_sector_spdr(r.get("sic"))  # type: ignore[arg-type]
+        dc = day_changes.get(int(r["instrument_id"]))  # type: ignore[arg-type]
         items.append(
             InstrumentListItem(
                 instrument_id=r["instrument_id"],  # type: ignore[arg-type]
@@ -672,6 +690,8 @@ def list_instruments(
                 is_tradable=r["is_tradable"],  # type: ignore[arg-type]
                 coverage_tier=r["coverage_tier"],  # type: ignore[arg-type]
                 latest_quote=_parse_quote(r),
+                day_change_pct=dc.change_pct if dc is not None else None,
+                day_change_as_of=dc.as_of if dc is not None else None,
             )
         )
 
@@ -3715,8 +3735,8 @@ def get_instrument_summary(
     # live trade ``last`` (>0) → bid/ask mid → none — so the instrument
     # summary current price matches the position mark on the same
     # instrument. A non-positive last is not a valid price (eToro persists
-    # last=0.00 for un-freshly-traded instruments). Day change + 52w range
-    # stay null until a SEC-derived computation lands; the frontend renders "—".
+    # last=0.00 for un-freshly-traded instruments). 52w range stays null until
+    # a SEC-derived computation lands; the frontend renders "—".
     mark = resolve_quote_price(
         float(row["last"]) if row.get("last") is not None else None,
         float(row["bid"]) if row.get("bid") is not None else None,
@@ -3750,22 +3770,32 @@ def get_instrument_summary(
                     display_currency,
                     symbol_clean,
                 )
+    instrument_id_int = int(row["instrument_id"])  # type: ignore[arg-type]
+
+    # #1924: day-change from ``price_daily`` last-two-positive-closes — a
+    # SEPARATE source from the ``quotes`` mark above. Emit ``price_block`` when
+    # EITHER a quote price OR a day-change is present, so the detail page shows
+    # the change for the ~5k quote-less names too (list↔detail parity; the list
+    # surfaces it from the same helper). ``current`` stays quote-sourced and is
+    # ``None`` when there is no live quote — the frontend renders "—" for the
+    # price while still showing the dated change.
+    dc = load_day_changes(conn, [instrument_id_int]).get(instrument_id_int)
     price_block = (
         InstrumentPrice(
             current=current_price,
-            day_change=None,
-            day_change_pct=None,
+            day_change=dc.change_abs if dc is not None else None,
+            day_change_pct=dc.change_pct if dc is not None else None,
+            day_change_as_of=dc.as_of if dc is not None else None,
             week_52_high=None,
             week_52_low=None,
             currency=native_ccy,  # type: ignore[arg-type]
             display_current=display_price,
             display_currency=display_ccy_for_price,
         )
-        if current_price is not None
+        if current_price is not None or dc is not None
         else None
     )
 
-    instrument_id_int = int(row["instrument_id"])  # type: ignore[arg-type]
     local_fundamentals: dict[str, Decimal | None] = {}
     use_local_sec = _has_sec_cik(conn, instrument_id_int)
     if use_local_sec:

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, timedelta
 from decimal import Decimal
 
 import psycopg
+from psycopg.rows import dict_row
 
 from app.providers.market_data import MarketDataProvider, OHLCVBar, Quote
 from app.services.sync_orchestrator.exception_classifier import classify_exception
@@ -73,6 +75,92 @@ _RETURN_WINDOWS: dict[str, int] = {
     "return_1y": 365,
 }
 _VOLATILITY_WINDOW_DAYS = 30
+
+
+@dataclass(frozen=True)
+class DayChange:
+    """Close-to-close day-change for one instrument, from ``price_daily``.
+
+    Built from an instrument's two most recent **strictly-positive** closes.
+    ``as_of`` is the latest close's ``price_date`` — the metric is stamped with
+    it (settled-decisions.md:767 "latest closed session" as-of convention) so a
+    stale close reads honestly rather than as "today". ``change_pct`` is a
+    FRACTION (``-0.015`` = −1.5%), matching the ``formatPct`` frontend contract.
+    """
+
+    as_of: date
+    last_close: Decimal
+    prior_close: Decimal
+    change_abs: Decimal
+    change_pct: Decimal
+
+
+def compute_day_change(last_close: Decimal, prior_close: Decimal) -> Decimal | None:
+    """Fractional close-to-close change, or ``None`` when ``prior_close <= 0``.
+
+    A non-positive prior close is a non-price sentinel (``price_daily`` holds
+    real ``close = 0`` rows — the same cross-surface invariant prevention-log
+    #1428 documents for ``quotes.last``), so no meaningful change exists.
+    """
+    if prior_close <= 0:
+        return None
+    return (last_close - prior_close) / prior_close
+
+
+def load_day_changes(
+    conn: psycopg.Connection[object],
+    instrument_ids: Sequence[int],
+) -> dict[int, DayChange]:
+    """Batch day-change over an instrument's two most-recent positive closes.
+
+    One window query ranks ``close > 0`` rows per instrument (strictly-positive
+    skips ``price_daily``'s real zero-close sentinels) and keeps the top two.
+    Instruments with fewer than two positive closes are omitted (caller renders
+    "—"). Fan-out-safe: PK ``(instrument_id, price_date)`` guarantees one row
+    per date.
+    """
+    ids = list({int(i) for i in instrument_ids})
+    if not ids:
+        return {}
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            WITH ranked AS (
+                SELECT instrument_id, price_date, close,
+                       row_number() OVER (
+                           PARTITION BY instrument_id ORDER BY price_date DESC
+                       ) AS rn
+                FROM price_daily
+                WHERE instrument_id = ANY(%(ids)s) AND close > 0
+            )
+            SELECT instrument_id,
+                   max(close)      FILTER (WHERE rn = 1) AS last_close,
+                   max(price_date) FILTER (WHERE rn = 1) AS as_of,
+                   max(close)      FILTER (WHERE rn = 2) AS prior_close
+            FROM ranked
+            WHERE rn <= 2
+            GROUP BY instrument_id
+            HAVING count(*) = 2
+            """,
+            {"ids": ids},
+        )
+        rows = cur.fetchall()
+
+    out: dict[int, DayChange] = {}
+    for r in rows:
+        last_close = r["last_close"]  # type: ignore[assignment]
+        prior_close = r["prior_close"]  # type: ignore[assignment]
+        pct = compute_day_change(last_close, prior_close)
+        if pct is None:  # prior_close somehow non-positive — skip, don't emit noise
+            continue
+        out[int(r["instrument_id"])] = DayChange(  # type: ignore[arg-type]
+            as_of=r["as_of"],  # type: ignore[arg-type]
+            last_close=last_close,
+            prior_close=prior_close,
+            change_abs=last_close - prior_close,
+            change_pct=pct,
+        )
+    return out
 
 
 @dataclass(frozen=True)

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -150,8 +150,12 @@ def load_day_changes(
     for r in rows:
         last_close = r["last_close"]  # type: ignore[assignment]
         prior_close = r["prior_close"]  # type: ignore[assignment]
+        # ``prior_close > 0`` is guaranteed by the ``WHERE close > 0`` filter, so
+        # this is never None in practice — the guard narrows the type for the
+        # checker and routes the formula through the single tested source
+        # (``compute_day_change``) rather than duplicating it inline.
         pct = compute_day_change(last_close, prior_close)
-        if pct is None:  # prior_close somehow non-positive — skip, don't emit noise
+        if pct is None:  # pragma: no cover — defensive; filter guarantees prior_close > 0
             continue
         out[int(r["instrument_id"])] = DayChange(  # type: ignore[arg-type]
             as_of=r["as_of"],  # type: ignore[arg-type]

--- a/docs/specs/ui/2026-07-04-instruments-day-change.md
+++ b/docs/specs/ui/2026-07-04-instruments-day-change.md
@@ -1,0 +1,92 @@
+# Instruments list + summary: day-change column (#1924 part 2)
+
+## Problem
+Instruments list has no day-change. Per-instrument summary nulls `day_change`
+(`app/api/instruments.py:3756`, stale placeholder comment). #1924 part 1
+(all-dashes treatment) shipped in PR #1929.
+
+## Source rule
+Day-change = close-to-close **fractional** change (e.g. `-0.015` = −1.5%, NOT
+`-1.5`) between an instrument's two most recent **strictly-positive** closes in
+`price_daily`.
+- `price_daily` PK `(instrument_id, price_date)`; `close` is the native-currency
+  session close, stamped to `MAX(price_date)` per settled-decisions.md:767-768
+  ("latest closed session", data-anchored not wall-clock).
+- **Strictly-positive filter (full-pop verified, not extrapolated):** dev DB has
+  **137 real `close = 0` rows** in `price_daily` — a persisted zero is a
+  non-trade sentinel, not a price (the same eBull cross-surface invariant that
+  prevention-log #1428 documents for `quotes.last = 0.00`; here re-verified
+  directly against `price_daily`, not carried over by assumption). The window
+  ranks over `close > 0` only, so a zero day is skipped, never a −100% artefact.
+- **Two-close invariant:** the change is over an instrument's two most-recent
+  *valid* (positive) closes — normally two adjacent trading sessions. Full-pop:
+  4,628/5,196 are ≤1 calendar day apart, 564 are 2–4 days (weekends/holidays),
+  only **4** span >4 days (a data hole). No gap-guard warranted; the as-of date
+  is the honesty mechanism.
+- **Full-population verification (dev DB, 2026-07-04):** **5,196** instruments
+  have ≥2 positive closes (vs `quotes` ~69). Staleness of the latest close is
+  severe and widespread in the loop (eToro market-data unreachable →
+  `daily_candle_refresh` under-writes): buckets by `CURRENT_DATE − latest_close`
+  = {≤1d: 6, 2–3d: 721, 4–7d: 9, 8–30d: 4,225, >30d: 235, max 1,870d}. This is
+  exactly why the metric is **stamped with its close date** — an operator reads
+  "as of 12 Jun" and judges freshness; in production (fresh candles) the ≤1d
+  bucket dominates and it reads as a normal day-change. No hard staleness
+  suppression: an arbitrary cut would blank the feature in this known-broken
+  market-data env and misrepresent production; the date label is the settled
+  (line-767) as-of convention.
+
+## Not touched (boundary)
+- **#1857 (operator-gated):** the value sub-score gate is the *scoring model*
+  (`instrument_valuation` view COALESCE → `model_version` bump). This change is a
+  pure display read path — no scoring, no `model_version`, no migration.
+- **#1906 (native price primary):** the list/summary displayed price stays
+  quote-sourced. Day-change is a separate `price_daily` metric; the quote-sourced
+  "Last price" column is unchanged. Where a row has no live quote, price still
+  shows "—" while day-change renders — the as-of close date keeps this honest.
+  A quote→price_daily *display* fallback is deliberately left to #1857 de-gating.
+
+## Design
+Shared helper in `app/services/market_data.py`:
+- `compute_day_change(last_close, prior_close) -> Decimal | None` — pure;
+  `(last-prior)/prior`, `None` when `prior <= 0`.
+- `load_day_changes(conn, instrument_ids) -> dict[int, DayChange]` — one batched
+  window query (rn≤2 over positive closes), builds `DayChange(as_of, last_close,
+  prior_close, change_abs, change_pct)` only where both closes present.
+
+Wiring:
+- **List** (`list_instruments`): batch-load for the page's instrument_ids; add
+  `day_change_pct: Decimal | None`, `day_change_as_of: date | None` to
+  `InstrumentListItem`.
+- **Summary** (`get_instrument_summary`): populate `InstrumentPrice.day_change` /
+  `day_change_pct` from the helper; add `day_change_as_of: date | None`.
+  **Invariant fix (Codex HIGH):** `price_block` currently is `None` when there is
+  no quote-derived `current_price`, so day-change would silently vanish on the
+  detail page for the ~5k quote-less names while the list shows it —
+  list↔detail divergence. Build `InstrumentPrice(current=None, day_change=…,
+  day_change_pct=…, day_change_as_of=…)` when day-change is present even if the
+  quote price is absent, so both surfaces agree. `SummaryStrip` already renders
+  its price/change row whenever `price` is truthy and shows "—" for a null
+  price.
+
+Frontend:
+- `types.ts`: mirror new fields (`string | null` — dates serialize as ISO
+  strings; `day_change_pct` is a fraction, fed straight to `formatPct`). Update
+  existing `InstrumentPrice` / `InstrumentListItem` test fixtures
+  (`SummaryStrip.test.tsx`, `InstrumentsPage.test.tsx`, `ChartPage.test.tsx`) —
+  additive optional fields, so fixtures without them still typecheck, but the
+  new column/label assertions need fixtures that set them.
+- `InstrumentsPage`: new "Day change" column — colored pct + muted as-of date,
+  sortable (client-side, mirrors `last`); "—" when unavailable.
+- `SummaryStrip`: render the as-of close date next to the existing day-change so
+  it is never misread as "today".
+
+## Tests
+- Pure `compute_day_change`: positive/negative change, `prior<=0 → None`, zero
+  change. Table-test (no DB).
+- One db-tier test for `load_day_changes` (skips <2 closes, ignores non-positive,
+  picks two most recent).
+
+## Labeling decision (was operator-open)
+Rendered as a day-change **stamped with its close date** (e.g. "as of 12 Jun"),
+matching the line-767 as-of convention. Decisive per autonomy mandate: honest
+under the loop's staleness, normal day-change in production.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -60,14 +60,10 @@ export interface ConfigResponse {
 
 export type LayerStatus = "ok" | "stale" | "empty" | "error";
 export type OverallStatus = "ok" | "degraded" | "down";
-export type JobLastStatus = "running" | "success" | "failure" | "skipped" | null;
+export type JobLastStatus =
+  "running" | "success" | "failure" | "skipped" | null;
 export type CadenceKind =
-  | "hourly"
-  | "daily"
-  | "weekly"
-  | "monthly"
-  | "yearly"
-  | "every_n_minutes";
+  "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "every_n_minutes";
 
 export interface LayerHealthResponse {
   layer: string;
@@ -94,10 +90,7 @@ export interface JobHealthResponse {
 }
 
 export type CredentialHealthState =
-  | "valid"
-  | "untested"
-  | "rejected"
-  | "missing";
+  "valid" | "untested" | "rejected" | "missing";
 
 export interface CredentialHealthSummary {
   state: CredentialHealthState;
@@ -260,6 +253,13 @@ export interface InstrumentListItem {
   is_tradable: boolean;
   coverage_tier: number | null;
   latest_quote: QuoteSnapshot | null;
+  /** #1924: close-to-close day-change from `price_daily` (last two positive
+   *  closes) — a SEPARATE source from `latest_quote`. A FRACTION (-0.015 =
+   *  -1.5%), fed straight to `formatPct`. `day_change_as_of` is the latest
+   *  close's date (ISO), stamped so a stale close reads honestly. Both null
+   *  when <2 positive closes exist. */
+  day_change_pct: string | null;
+  day_change_as_of: string | null;
 }
 
 export interface InstrumentListResponse {
@@ -292,7 +292,8 @@ export interface InstrumentDetail {
 
 /** Session-shading profile for the intraday chart (#609 Phase A). Mirrors
  *  `app/api/instruments.py::SessionProfile`. */
-export type SessionProfile = "us_equity" | "us_equity_rth" | "foreign_equity" | "continuous";
+export type SessionProfile =
+  "us_equity" | "us_equity_rth" | "foreign_equity" | "continuous";
 
 // Phase 2.2 — per-ticker research summary
 export interface InstrumentIdentity {
@@ -332,6 +333,10 @@ export interface InstrumentPrice {
   current: string | null;
   day_change: string | null;
   day_change_pct: string | null;
+  /** #1924: date (ISO) of the latest `price_daily` close the day-change is
+   *  computed from — stamped so a stale close reads honestly, not as "today".
+   *  Null when no day-change is available. */
+  day_change_as_of: string | null;
   week_52_high: string | null;
   week_52_low: string | null;
   currency: string | null;
@@ -430,14 +435,7 @@ export interface InstrumentSummary {
 // for `5d` served by the intraday endpoint). Kept on the backend Literal
 // so any external consumer that still passes `?range=1w` keeps working.
 export type CandleRange =
-  | "1w"
-  | "1m"
-  | "3m"
-  | "6m"
-  | "ytd"
-  | "1y"
-  | "5y"
-  | "max";
+  "1w" | "1m" | "3m" | "6m" | "ytd" | "1y" | "5y" | "max";
 
 export interface CandleBar {
   date: string;
@@ -649,15 +647,7 @@ export interface PortfolioRelativeRisk {
 // boundary keeps two separate shapes; the chart consumes a unified
 // normalised stream.
 export type ChartRange =
-  | "1d"
-  | "5d"
-  | "1m"
-  | "3m"
-  | "6m"
-  | "ytd"
-  | "1y"
-  | "5y"
-  | "max";
+  "1d" | "5d" | "1m" | "3m" | "6m" | "ytd" | "1y" | "5y" | "max";
 
 // Phase 2.3 — financials
 export interface InstrumentFinancialRow {
@@ -904,7 +894,8 @@ export interface OrderResponse {
 // /recommendations (app/api/recommendations.py)
 // ---------------------------------------------------------------------------
 
-export type RecommendationAction = "BUY" | "ADD" | "HOLD" | "EXIT" | "CONSIDERED";
+export type RecommendationAction =
+  "BUY" | "ADD" | "HOLD" | "EXIT" | "CONSIDERED";
 export type RecommendationStatus =
   | "proposed"
   | "approved"
@@ -1623,7 +1614,7 @@ export type GuardRejectionAction = "BUY" | "ADD" | "HOLD" | "EXIT";
 
 export interface GuardRejection {
   decision_id: number;
-  decision_time: string;  // ISO TIMESTAMPTZ
+  decision_time: string; // ISO TIMESTAMPTZ
   instrument_id: number | null;
   symbol: string | null;
   action: GuardRejectionAction | null;
@@ -1734,11 +1725,7 @@ export type HealthVerdict =
   | "stale_manual";
 
 export type ProcessRunStatus =
-  | "success"
-  | "failure"
-  | "partial"
-  | "cancelled"
-  | "skipped";
+  "success" | "failure" | "partial" | "cancelled" | "skipped";
 
 export type CursorKind =
   | "filed_at"
@@ -1784,10 +1771,7 @@ export interface ActiveRunSummaryResponse {
  * means the row is not stale.
  */
 export type StaleReason =
-  | "schedule_missed"
-  | "watermark_gap"
-  | "queue_stuck"
-  | "mid_flight_stuck";
+  "schedule_missed" | "watermark_gap" | "queue_stuck" | "mid_flight_stuck";
 
 export interface ProcessWatermarkResponse {
   cursor_kind: CursorKind;
@@ -1904,11 +1888,7 @@ export type TriggerConflictReason =
 // so non-orchestrator detail pages never hit the endpoint.
 
 export type OrchestratorSyncRunStatus =
-  | "running"
-  | "complete"
-  | "partial"
-  | "failed"
-  | "cancelled";
+  "running" | "complete" | "partial" | "failed" | "cancelled";
 
 export type OrchestratorLayerStatus =
   | "pending"
@@ -1965,10 +1945,7 @@ export interface OrchestratorDagResponse {
 // detail pages never hit the endpoint.
 
 export type BootstrapRunStatus =
-  | "running"
-  | "complete"
-  | "partial_error"
-  | "cancelled";
+  "running" | "complete" | "partial_error" | "cancelled";
 
 export type BootstrapStageStatus =
   | "pending"

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -18,7 +18,9 @@ import type {
   ThesisDetail,
 } from "@/api/types";
 
-function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary {
+function summary(
+  overrides: Partial<InstrumentSummary> = {},
+): InstrumentSummary {
   return {
     instrument_id: 42,
     is_tradable: true,
@@ -43,6 +45,7 @@ function summary(overrides: Partial<InstrumentSummary> = {}): InstrumentSummary 
       current: "200.50",
       day_change: "1.50",
       day_change_pct: "0.00753",
+      day_change_as_of: "2026-04-08",
       week_52_high: "250.00",
       week_52_low: "140.00",
       currency: "USD",
@@ -166,6 +169,7 @@ describe("SummaryStrip — action gating", () => {
             current: "200.50",
             day_change: "1.50",
             day_change_pct: "0.00753",
+            day_change_as_of: "2026-04-08",
             week_52_high: "250.00",
             week_52_low: "140.00",
             currency: "USD",
@@ -501,8 +505,12 @@ describe("SummaryStrip — action gating", () => {
         position={{
           ...heldPosition(),
           trades: [
-            { position_id: 1 } as unknown as InstrumentPositionDetail["trades"][0],
-            { position_id: 2 } as unknown as InstrumentPositionDetail["trades"][0],
+            {
+              position_id: 1,
+            } as unknown as InstrumentPositionDetail["trades"][0],
+            {
+              position_id: 2,
+            } as unknown as InstrumentPositionDetail["trades"][0],
           ],
         }}
         {...noopProps()}
@@ -553,6 +561,7 @@ describe("SummaryStrip — live-tick currency sourcing (#1906)", () => {
             current: "100.00",
             day_change: null,
             day_change_pct: null,
+            day_change_as_of: null,
             week_52_high: null,
             week_52_low: null,
             currency: "USD",
@@ -594,6 +603,7 @@ describe("SummaryStrip — live-tick currency sourcing (#1906)", () => {
             current: "100.00",
             day_change: null,
             day_change_pct: null,
+            day_change_as_of: null,
             week_52_high: null,
             week_52_low: null,
             currency: "USD",
@@ -620,6 +630,8 @@ describe("SummaryStrip — live-tick currency sourcing (#1906)", () => {
       );
     });
     expect(screen.getByText("USD 110.00")).toBeInTheDocument();
-    expect(screen.getByTestId("price-companion")).toHaveTextContent("≈ GBP 86.00");
+    expect(screen.getByTestId("price-companion")).toHaveTextContent(
+      "≈ GBP 86.00",
+    );
   });
 });

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -53,6 +53,21 @@ function formatPct(value: string | null | undefined, signed = false): string {
   return `${sign}${pct}%`;
 }
 
+/** #1924: compact "as of" close date (e.g. "12 Jun") for the day-change stamp.
+ *  Returns null on an absent/unparseable date. */
+function formatDayChangeAsOf(iso: string | null): string | null {
+  if (iso === null) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  // Format in UTC: `new Date("YYYY-MM-DD")` is UTC midnight, so a local-TZ
+  // format would render the prior day west of UTC and shift the close date.
+  return d.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
+}
+
 function isThesisStale(thesis: ThesisDetail | null): boolean {
   if (thesis === null) return true;
   const created = new Date(thesis.created_at);
@@ -140,7 +155,9 @@ export function SummaryStrip({
     companion !== null &&
     primaryCurrency !== null &&
     companion.currency !== primaryCurrency;
-  const changeNum = price?.day_change_pct != null ? Number(price.day_change_pct) : null;
+  const changeNum =
+    price?.day_change_pct != null ? Number(price.day_change_pct) : null;
+  const dayChangeAsOf = formatDayChangeAsOf(price?.day_change_as_of ?? null);
   const changeColor =
     changeNum === null
       ? "text-slate-500"
@@ -212,8 +229,19 @@ export function SummaryStrip({
               {price?.day_change != null && Number(price.day_change) >= 0
                 ? "+"
                 : ""}
-              {price?.day_change ?? "—"} ({formatPct(price?.day_change_pct, true)})
+              {price?.day_change ?? "—"} (
+              {formatPct(price?.day_change_pct, true)})
             </span>
+            {/* #1924: stamp the day-change with its close date so a stale close
+                (common in the loop) reads honestly rather than as "today". */}
+            {dayChangeAsOf ? (
+              <span
+                className="text-xs tabular-nums text-slate-400 dark:text-slate-500"
+                title="Close-to-close change, as of this close"
+              >
+                as of {dayChangeAsOf}
+              </span>
+            ) : null}
           </>
         ) : null}
       </div>

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -22,6 +22,7 @@ import type {
   ThesisDetail,
 } from "@/api/types";
 import { Term } from "@/components/Term";
+import { formatCloseDate } from "@/lib/format";
 import {
   liveTickDisplayCompanion,
   liveTickNativePrice,
@@ -51,21 +52,6 @@ function formatPct(value: string | null | undefined, signed = false): string {
   const pct = (num * 100).toFixed(2);
   const sign = signed && num > 0 ? "+" : "";
   return `${sign}${pct}%`;
-}
-
-/** #1924: compact "as of" close date (e.g. "12 Jun") for the day-change stamp.
- *  Returns null on an absent/unparseable date. */
-function formatDayChangeAsOf(iso: string | null): string | null {
-  if (iso === null) return null;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return null;
-  // Format in UTC: `new Date("YYYY-MM-DD")` is UTC midnight, so a local-TZ
-  // format would render the prior day west of UTC and shift the close date.
-  return d.toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "short",
-    timeZone: "UTC",
-  });
 }
 
 function isThesisStale(thesis: ThesisDetail | null): boolean {
@@ -157,7 +143,7 @@ export function SummaryStrip({
     companion.currency !== primaryCurrency;
   const changeNum =
     price?.day_change_pct != null ? Number(price.day_change_pct) : null;
-  const dayChangeAsOf = formatDayChangeAsOf(price?.day_change_as_of ?? null);
+  const dayChangeAsOf = formatCloseDate(price?.day_change_as_of ?? null);
   const changeColor =
     changeNum === null
       ? "text-slate-500"

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -65,6 +65,21 @@ export function formatPct(fraction: number | null | undefined): string {
   return PCT.format(fraction);
 }
 
+/** Compact "day month" close date (e.g. "12 Jun") for as-of stamps (#1924).
+ *  Formatted in UTC: `new Date("YYYY-MM-DD")` is UTC midnight, so a local-TZ
+ *  format would render the prior day west of UTC and shift the close date.
+ *  Returns null on an absent/unparseable date. */
+export function formatCloseDate(iso: string | null | undefined): string | null {
+  if (iso === null || iso === undefined) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
+}
+
 const PCT_UNSIGNED = new Intl.NumberFormat("en-GB", {
   style: "percent",
   minimumFractionDigits: 2,
@@ -79,7 +94,10 @@ export function formatUnsignedPct(fraction: number | null | undefined): string {
   return PCT_UNSIGNED.format(fraction);
 }
 
-export function formatNumber(value: number | null | undefined, fractionDigits = 4): string {
+export function formatNumber(
+  value: number | null | undefined,
+  fractionDigits = 4,
+): string {
   if (value === null || value === undefined) return "—";
   return value.toLocaleString("en-GB", {
     minimumFractionDigits: 0,

--- a/frontend/src/pages/ChartPage.test.tsx
+++ b/frontend/src/pages/ChartPage.test.tsx
@@ -37,7 +37,15 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 
 // Stub RawOhlcvTable to avoid testing its internals in ChartPage tests.
 vi.mock("@/pages/components/RawOhlcvTable", () => ({
-  RawOhlcvTable: ({ rows, symbol, range }: { rows: unknown[]; symbol: string; range: string }) => (
+  RawOhlcvTable: ({
+    rows,
+    symbol,
+    range,
+  }: {
+    rows: unknown[];
+    symbol: string;
+    range: string;
+  }) => (
     <div
       data-testid="raw-ohlcv-table-stub"
       data-row-count={rows.length}
@@ -79,7 +87,8 @@ vi.mock("@/api/instruments", () => ({
 }));
 
 vi.mock("@/lib/chartData", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/chartData")>("@/lib/chartData");
+  const actual =
+    await vi.importActual<typeof import("@/lib/chartData")>("@/lib/chartData");
   return {
     ...actual,
     fetchChartCandles: vi.fn(),
@@ -88,7 +97,11 @@ vi.mock("@/lib/chartData", async () => {
 
 import { fetchInstrumentSummary } from "@/api/instruments";
 import type { InstrumentSummary, ChartRange } from "@/api/types";
-import { fetchChartCandles, type NormalisedBar, type NormalisedChartCandles } from "@/lib/chartData";
+import {
+  fetchChartCandles,
+  type NormalisedBar,
+  type NormalisedChartCandles,
+} from "@/lib/chartData";
 import { ChartPage } from "./ChartPage";
 
 const mockSummary = vi.mocked(fetchInstrumentSummary);
@@ -114,8 +127,23 @@ function makeSummary(): InstrumentSummary {
     instrument_id: 1,
     is_tradable: true,
     coverage_tier: 1,
-    identity: { symbol: "AAPL", display_name: "Apple Inc.", market_cap: null, sector: null },
-    price: { current: "189.50", day_change: null, day_change_pct: null, week_52_high: null, week_52_low: null, currency: "USD", display_current: null, display_currency: null },
+    identity: {
+      symbol: "AAPL",
+      display_name: "Apple Inc.",
+      market_cap: null,
+      sector: null,
+    },
+    price: {
+      current: "189.50",
+      day_change: null,
+      day_change_pct: null,
+      day_change_as_of: null,
+      week_52_high: null,
+      week_52_low: null,
+      currency: "USD",
+      display_current: null,
+      display_currency: null,
+    },
     key_stats: null,
     source: {},
     has_sec_cik: true,
@@ -282,7 +310,9 @@ describe("ChartPage — chart body", () => {
     mockCandles.mockRejectedValue(new Error("network down"));
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /retry/i }),
+      ).toBeInTheDocument();
     });
     expect(screen.queryByTestId("chart-canvas-stub")).not.toBeInTheDocument();
   });
@@ -321,11 +351,15 @@ describe("ChartPage — indicator toggles", () => {
     });
     await user.click(screen.getByTestId("indicator-sma20"));
     await waitFor(() => {
-      expect(screen.getByTestId("chart-canvas-stub").getAttribute("data-indicators")).toBe("sma20");
+      expect(
+        screen.getByTestId("chart-canvas-stub").getAttribute("data-indicators"),
+      ).toBe("sma20");
     });
     await user.click(screen.getByTestId("indicator-sma20"));
     await waitFor(() => {
-      expect(screen.getByTestId("chart-canvas-stub").getAttribute("data-indicators")).toBe("");
+      expect(
+        screen.getByTestId("chart-canvas-stub").getAttribute("data-indicators"),
+      ).toBe("");
     });
   });
 
@@ -443,11 +477,16 @@ describe("ChartPage — compare fetch error handling", () => {
     await waitFor(() => {
       expect(screen.getByTestId("compare-chip-MSFT")).toBeInTheDocument();
     });
-    expect(screen.getByTestId("compare-chip-MSFT")).not.toHaveAttribute("data-error");
+    expect(screen.getByTestId("compare-chip-MSFT")).not.toHaveAttribute(
+      "data-error",
+    );
 
     // BAD chip renders with error styling (data-error="true").
     expect(screen.getByTestId("compare-chip-BAD")).toBeInTheDocument();
-    expect(screen.getByTestId("compare-chip-BAD")).toHaveAttribute("data-error", "true");
+    expect(screen.getByTestId("compare-chip-BAD")).toHaveAttribute(
+      "data-error",
+      "true",
+    );
   });
 });
 
@@ -483,13 +522,17 @@ describe("ChartPage — Phase 3 trend toggles", () => {
     await user.click(screen.getByTestId("trend-regression"));
     await waitFor(() => {
       expect(
-        screen.getByTestId("chart-canvas-stub").getAttribute("data-show-regression"),
+        screen
+          .getByTestId("chart-canvas-stub")
+          .getAttribute("data-show-regression"),
       ).toBe("true");
     });
     await user.click(screen.getByTestId("trend-regression"));
     await waitFor(() => {
       expect(
-        screen.getByTestId("chart-canvas-stub").getAttribute("data-show-regression"),
+        screen
+          .getByTestId("chart-canvas-stub")
+          .getAttribute("data-show-regression"),
       ).toBe("false");
     });
   });
@@ -528,7 +571,9 @@ describe("ChartPage — Phase 4 view toggle", () => {
     await waitFor(() => {
       expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId("raw-ohlcv-table-stub")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("raw-ohlcv-table-stub"),
+    ).not.toBeInTheDocument();
   });
 
   it("clicking 'Raw data' button shows raw table and hides chart canvas", async () => {
@@ -554,7 +599,9 @@ describe("ChartPage — Phase 4 view toggle", () => {
     await waitFor(() => {
       expect(screen.getByTestId("chart-canvas-stub")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId("raw-ohlcv-table-stub")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("raw-ohlcv-table-stub"),
+    ).not.toBeInTheDocument();
   });
 
   it("pre-set ?view=raw renders raw table directly", async () => {

--- a/frontend/src/pages/InstrumentsPage.test.tsx
+++ b/frontend/src/pages/InstrumentsPage.test.tsx
@@ -53,6 +53,8 @@ function makeResponse(
           spread_pct: 0.054,
           quoted_at: "2026-04-08T12:00:00Z",
         },
+        day_change_pct: "0.0152",
+        day_change_as_of: "2026-04-08",
       },
       {
         instrument_id: 2,
@@ -73,6 +75,8 @@ function makeResponse(
           spread_pct: 0.024,
           quoted_at: "2026-04-08T12:00:00Z",
         },
+        day_change_pct: "-0.0093",
+        day_change_as_of: "2026-04-07",
       },
       {
         instrument_id: 3,
@@ -87,6 +91,10 @@ function makeResponse(
         is_tradable: true,
         coverage_tier: null,
         latest_quote: null,
+        // #1924: change present from price_daily while the live quote is
+        // absent — the list shows the % with a "—" price (as-of dated).
+        day_change_pct: "0.0021",
+        day_change_as_of: "2026-04-08",
       },
     ],
     total: 3,
@@ -127,6 +135,21 @@ describe("InstrumentsPage — data rendering", () => {
     expect(screen.getByText("MSFT")).toBeInTheDocument();
     expect(screen.getByText("Microsoft Corp.")).toBeInTheDocument();
     expect(screen.getByText("JPM")).toBeInTheDocument();
+  });
+
+  it("renders the day-change column with colored pct + as-of close date (#1924)", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("AAPL")).toBeInTheDocument();
+    });
+    // AAPL +1.52% (day_change_pct 0.0152), stamped with its close date.
+    expect(screen.getByText("+1.52%")).toBeInTheDocument();
+    // MSFT negative change.
+    expect(screen.getByText("-0.93%")).toBeInTheDocument();
+    // JPM has a change from price_daily but no live quote → the % shows while
+    // the price cell stays "—" (change is dated so it reads honestly).
+    expect(screen.getByText("+0.21%")).toBeInTheDocument();
+    expect(screen.getAllByText(/^as of /).length).toBeGreaterThanOrEqual(3);
   });
 
   it("renders coverage tier badges in the table", async () => {
@@ -374,7 +397,9 @@ describe("InstrumentsPage — exchange label", () => {
     });
     const table = screen.getByRole("table");
     // exchange_name "Nasdaq" is shown; the raw id "4" never appears.
-    expect(within(table).getAllByText("Nasdaq").length).toBeGreaterThanOrEqual(1);
+    expect(within(table).getAllByText("Nasdaq").length).toBeGreaterThanOrEqual(
+      1,
+    );
     expect(within(table).queryByText("4")).not.toBeInTheDocument();
   });
 
@@ -395,6 +420,8 @@ describe("InstrumentsPage — exchange label", () => {
             is_tradable: true,
             coverage_tier: 3,
             latest_quote: null,
+            day_change_pct: null,
+            day_change_as_of: null,
           },
         ],
         total: 1,
@@ -404,7 +431,9 @@ describe("InstrumentsPage — exchange label", () => {
     await waitFor(() => {
       expect(screen.getByText("NEWX")).toBeInTheDocument();
     });
-    expect(within(screen.getByRole("table")).getByText("99")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("table")).getByText("99"),
+    ).toBeInTheDocument();
   });
 });
 
@@ -427,6 +456,8 @@ describe("InstrumentsPage — uncovered rows", () => {
       is_tradable: true,
       coverage_tier: null,
       latest_quote: null,
+      day_change_pct: null,
+      day_change_as_of: null,
       ...overrides,
     };
   }

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -17,10 +17,14 @@ import {
   type InstrumentsQuery,
 } from "@/api/instruments";
 import type { InstrumentListItem } from "@/api/types";
-import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { Pagination } from "@/components/ui/Pagination";
-import { formatMoney } from "@/lib/format";
+import { formatMoney, formatPct } from "@/lib/format";
 import { SECTOR_OPTIONS } from "@/lib/sectors";
 import { useAsync } from "@/lib/useAsync";
 
@@ -50,14 +54,23 @@ const INITIAL_FILTERS: Filters = {
 // Sort state (client-side within the fetched page)
 // ---------------------------------------------------------------------------
 
-type SortKey = "symbol" | "gics_sector" | "exchange" | "coverage_tier" | "last";
+type SortKey =
+  | "symbol"
+  | "gics_sector"
+  | "exchange"
+  | "coverage_tier"
+  | "last"
+  | "day_change";
 type SortDir = "asc" | "desc";
 
 // The server's default ordering (#1904): coverage_tier ASC (NULLS LAST), then
 // symbol. The client's initial sort mirrors it exactly, so the default view is
 // globally tier-ordered (not page-scoped) and the "sorted within this page"
 // caveat is only shown once the operator picks a different column.
-const SERVER_SORT: { key: SortKey; dir: SortDir } = { key: "coverage_tier", dir: "asc" };
+const SERVER_SORT: { key: SortKey; dir: SortDir } = {
+  key: "coverage_tier",
+  dir: "asc",
+};
 
 function compare(a: unknown, b: unknown, dir: SortDir): number {
   if (a == null && b == null) return 0;
@@ -89,8 +102,30 @@ function sortValue(item: InstrumentListItem, key: SortKey): unknown {
       // A usable mark is strictly positive (prevention-log #1428): eToro
       // persists `quotes.last = 0.00` for un-freshly-traded instruments, so a
       // non-null zero must sort with the blanks, not ahead of them.
-      return isUsablePrice(item.latest_quote?.last) ? item.latest_quote!.last : null;
+      return isUsablePrice(item.latest_quote?.last)
+        ? item.latest_quote!.last
+        : null;
+    case "day_change":
+      // #1924: sort by the fractional close-to-close change; nulls (no
+      // day-change) sort with the blanks.
+      return item.day_change_pct != null ? Number(item.day_change_pct) : null;
   }
+}
+
+/** Compact "as of" close date, e.g. "12 Jun" (#1924). Honest under the loop's
+ *  uneven candle freshness — the day-change is stamped to its close date, not
+ *  "today". Returns null on an unparseable/absent date. */
+function formatAsOf(iso: string | null): string | null {
+  if (iso == null) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  // Format in UTC: `new Date("YYYY-MM-DD")` is UTC midnight, so a local-TZ
+  // format would render the prior day west of UTC and shift the close date.
+  return d.toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  });
 }
 
 /** A displayable last price: present and strictly positive (prevention-log #1428). */
@@ -127,13 +162,47 @@ function TierBadge({ tier }: { tier: number | null }) {
   if (tier === null) {
     return <span className="text-xs text-slate-400">—</span>;
   }
-  const tone = TIER_TONE[tier] ?? "bg-slate-50 dark:bg-slate-900/40 text-slate-600 border-slate-200 dark:border-slate-800";
+  const tone =
+    TIER_TONE[tier] ??
+    "bg-slate-50 dark:bg-slate-900/40 text-slate-600 border-slate-200 dark:border-slate-800";
   return (
     <span
       className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-medium ${tone}`}
     >
       Tier {tier}
     </span>
+  );
+}
+
+/**
+ * Day-change cell (#1924): colored fractional close-to-close change from
+ * `price_daily`, with a muted "as of <close date>" caption so a stale close
+ * (common in the loop when eToro candles under-write) reads honestly rather
+ * than as "today". Renders "—" when no day-change is available.
+ */
+function DayChangeCell({ item }: { item: InstrumentListItem }) {
+  const pct = item.day_change_pct != null ? Number(item.day_change_pct) : null;
+  if (pct == null || Number.isNaN(pct)) {
+    return (
+      <td className="py-2 pr-0 text-right text-xs tabular-nums text-slate-400">
+        —
+      </td>
+    );
+  }
+  const tone = pct >= 0 ? "text-emerald-600" : "text-red-600";
+  const asOf = formatAsOf(item.day_change_as_of);
+  return (
+    <td className="py-2 pr-0 text-right tabular-nums">
+      <div className={`text-xs ${tone}`}>{formatPct(pct)}</div>
+      {asOf ? (
+        <div
+          className="text-[10px] text-slate-400"
+          title="Close-to-close change, as of this close"
+        >
+          as of {asOf}
+        </div>
+      ) : null}
+    </td>
   );
 }
 
@@ -215,16 +284,13 @@ export function InstrumentsPage() {
     );
   }, [result.data, sort]);
 
-  const toggleSort = useCallback(
-    (key: SortKey) => {
-      setSort((prev) =>
-        prev.key === key
-          ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
-          : { key, dir: "asc" },
-      );
-    },
-    [],
-  );
+  const toggleSort = useCallback((key: SortKey) => {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: "asc" },
+    );
+  }, []);
 
   const totalPages = result.data
     ? Math.ceil(result.data.total / INSTRUMENTS_PAGE_LIMIT)
@@ -244,7 +310,9 @@ export function InstrumentsPage() {
   return (
     <div className="flex h-full flex-col gap-6 pt-6">
       <div className="flex flex-shrink-0 items-center justify-between">
-        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Instruments</h1>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">
+          Instruments
+        </h1>
         {result.data && (
           <span className="text-xs text-slate-500">
             {result.data.total.toLocaleString()} instruments
@@ -421,6 +489,7 @@ const COLUMNS: { key: SortKey; label: string; align?: "right" }[] = [
   { key: "exchange", label: "Exchange" },
   { key: "coverage_tier", label: "Tier" },
   { key: "last", label: "Last price", align: "right" },
+  { key: "day_change", label: "Day change", align: "right" },
 ];
 
 // Inline chevron SVGs (#1904): the previous unicode arrows (↕ / ↑ / ↓)
@@ -438,8 +507,16 @@ function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
         stroke="currentColor"
         strokeWidth="1.5"
       >
-        <path d="M5 6.5 8 3.5l3 3" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M5 9.5 8 12.5l3-3" strokeLinecap="round" strokeLinejoin="round" />
+        <path
+          d="M5 6.5 8 3.5l3 3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M5 9.5 8 12.5l3-3"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
       </svg>
     );
   }
@@ -482,20 +559,22 @@ function InstrumentsTable({
                 key={col.key}
                 className={`cursor-pointer select-none py-2 pr-4 ${col.align === "right" ? "text-right" : ""}`}
                 onClick={() => onToggleSort(col.key)}
-                title={pageScopedSort ? "Sorts within this page only" : undefined}
+                title={
+                  pageScopedSort ? "Sorts within this page only" : undefined
+                }
               >
                 {col.label}
-                <SortIndicator
-                  active={sort.key === col.key}
-                  dir={sort.dir}
-                />
+                <SortIndicator active={sort.key === col.key} dir={sort.dir} />
               </th>
             ))}
           </tr>
           {pageScopedSort &&
             !(sort.key === SERVER_SORT.key && sort.dir === SERVER_SORT.dir) && (
               <tr>
-                <td colSpan={COLUMNS.length} className="pb-1 text-[10px] normal-case tracking-normal text-slate-400">
+                <td
+                  colSpan={COLUMNS.length}
+                  className="pb-1 text-[10px] normal-case tracking-normal text-slate-400"
+                >
                   Sorted within this page only. Server order is by coverage
                   tier, then symbol.
                 </td>
@@ -537,7 +616,9 @@ function InstrumentsTable({
                   >
                     <span className="font-medium">{item.symbol}</span>
                   </Link>
-                  <div className="text-xs text-slate-500">{item.company_name}</div>
+                  <div className="text-xs text-slate-500">
+                    {item.company_name}
+                  </div>
                 </td>
                 <td className="py-2 pr-4 text-xs text-slate-600">
                   {item.gics_sector ?? "—"}
@@ -548,11 +629,15 @@ function InstrumentsTable({
                 <td className="py-2 pr-4">
                   <TierBadge tier={item.coverage_tier} />
                 </td>
-                <td className="py-2 pr-0 text-right text-xs tabular-nums text-slate-600">
+                <td className="py-2 pr-4 text-right text-xs tabular-nums text-slate-600">
                   {isUsablePrice(item.latest_quote?.last)
-                    ? formatMoney(item.latest_quote.last, item.currency ?? "USD")
+                    ? formatMoney(
+                        item.latest_quote.last,
+                        item.currency ?? "USD",
+                      )
                     : "—"}
                 </td>
+                <DayChangeCell item={item} />
               </tr>
             ),
           )}

--- a/frontend/src/pages/InstrumentsPage.tsx
+++ b/frontend/src/pages/InstrumentsPage.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
 import { Pagination } from "@/components/ui/Pagination";
-import { formatMoney, formatPct } from "@/lib/format";
+import { formatCloseDate, formatMoney, formatPct } from "@/lib/format";
 import { SECTOR_OPTIONS } from "@/lib/sectors";
 import { useAsync } from "@/lib/useAsync";
 
@@ -112,22 +112,6 @@ function sortValue(item: InstrumentListItem, key: SortKey): unknown {
   }
 }
 
-/** Compact "as of" close date, e.g. "12 Jun" (#1924). Honest under the loop's
- *  uneven candle freshness — the day-change is stamped to its close date, not
- *  "today". Returns null on an unparseable/absent date. */
-function formatAsOf(iso: string | null): string | null {
-  if (iso == null) return null;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return null;
-  // Format in UTC: `new Date("YYYY-MM-DD")` is UTC midnight, so a local-TZ
-  // format would render the prior day west of UTC and shift the close date.
-  return d.toLocaleDateString("en-GB", {
-    day: "numeric",
-    month: "short",
-    timeZone: "UTC",
-  });
-}
-
 /** A displayable last price: present and strictly positive (prevention-log #1428). */
 function isUsablePrice(last: number | null | undefined): last is number {
   return last != null && last > 0;
@@ -190,7 +174,7 @@ function DayChangeCell({ item }: { item: InstrumentListItem }) {
     );
   }
   const tone = pct >= 0 ? "text-emerald-600" : "text-red-600";
-  const asOf = formatAsOf(item.day_change_as_of);
+  const asOf = formatCloseDate(item.day_change_as_of);
   return (
     <td className="py-2 pr-0 text-right tabular-nums">
       <div className={`text-xs ${tone}`}>{formatPct(pct)}</div>

--- a/tests/test_load_day_changes_db.py
+++ b/tests/test_load_day_changes_db.py
@@ -1,0 +1,98 @@
+"""DB-tier test for ``load_day_changes`` (#1924).
+
+Exercises the window-query mechanism against a real Postgres: last-two
+strictly-positive closes per instrument, zero-close skipping, and omission of
+instruments with fewer than two positive closes. Auto-marked ``db`` (pulls
+``ebull_test_conn``).
+
+Synthetic instruments only (ids well outside any real-data range).
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import psycopg
+
+from app.services.market_data import load_day_changes
+
+_TWO_CLOSE_ID = 991001
+_ZERO_SKIP_ID = 991002
+_ONE_CLOSE_ID = 991003
+
+_END = date.today() - timedelta(days=3)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], iid: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, currency, country, is_tradable)
+        VALUES (%s, %s, %s, 'USD', 'US', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, f"DC{iid}", f"DayChange {iid}"),
+    )
+
+
+def _seed_series(conn: psycopg.Connection[tuple], iid: int, closes: list[float]) -> None:
+    """Insert ``closes`` ending at ``_END`` (one calendar day apart, ASC)."""
+    n = len(closes)
+    for i, close in enumerate(closes):
+        conn.execute(
+            """
+            INSERT INTO price_daily (instrument_id, price_date, close)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close
+            """,
+            (iid, _END - timedelta(days=(n - 1 - i)), close),
+        )
+
+
+def test_load_day_changes_two_positive_closes(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, _TWO_CLOSE_ID)
+    # prior 100 → latest 102 → +0.02, as_of = _END (the latest bar).
+    _seed_series(conn, _TWO_CLOSE_ID, [100.0, 102.0])
+
+    result = load_day_changes(conn, [_TWO_CLOSE_ID])
+
+    dc = result[_TWO_CLOSE_ID]
+    assert dc.as_of == _END
+    assert dc.last_close == Decimal("102.000000")
+    assert dc.prior_close == Decimal("100.000000")
+    assert dc.change_abs == Decimal("2.000000")
+    assert dc.change_pct == Decimal("0.02")
+
+
+def test_load_day_changes_skips_zero_close(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, _ZERO_SKIP_ID)
+    # A 0.00 sentinel sits between the two real closes; the window filters it
+    # out, so prior = 100 (not 0 → no -100% artefact), latest = 110 → +0.10.
+    _seed_series(conn, _ZERO_SKIP_ID, [100.0, 0.0, 110.0])
+
+    dc = load_day_changes(conn, [_ZERO_SKIP_ID])[_ZERO_SKIP_ID]
+
+    assert dc.prior_close == Decimal("100.000000")
+    assert dc.last_close == Decimal("110.000000")
+    assert dc.change_pct == Decimal("0.1")
+
+
+def test_load_day_changes_omits_fewer_than_two_positive(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    _seed_instrument(conn, _ONE_CLOSE_ID)
+    # Only one positive close (the other is a zero sentinel) → no day-change.
+    _seed_series(conn, _ONE_CLOSE_ID, [0.0, 55.0])
+
+    result = load_day_changes(conn, [_ONE_CLOSE_ID])
+
+    assert _ONE_CLOSE_ID not in result
+
+
+def test_load_day_changes_empty_ids_returns_empty(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    assert load_day_changes(ebull_test_conn, []) == {}

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -35,6 +35,7 @@ from app.services.market_data import (
     _compute_rolling_returns,
     _compute_volatility_30d,
     _most_recent_trading_day,
+    compute_day_change,
     compute_spread_pct,
 )
 
@@ -621,6 +622,30 @@ class TestComputeSpreadPct:
         spread = compute_spread_pct(Decimal("100"), Decimal("100.50"))
         assert spread is not None
         assert spread < DEFAULT_MAX_SPREAD_PCT
+
+
+class TestComputeDayChange:
+    """#1924 — close-to-close fractional day-change (pure)."""
+
+    def test_gain_is_positive_fraction(self) -> None:
+        # 102 from 100 → +0.02 (a fraction, not 2.0)
+        assert compute_day_change(Decimal("102"), Decimal("100")) == Decimal("0.02")
+
+    def test_loss_is_negative_fraction(self) -> None:
+        # AAPL 291.22 from 295.65 → ≈ -1.50%
+        pct = compute_day_change(Decimal("291.22"), Decimal("295.65"))
+        assert pct is not None
+        assert abs(float(pct) - (-0.014984)) < 1e-6
+
+    def test_flat_is_zero(self) -> None:
+        assert compute_day_change(Decimal("50"), Decimal("50")) == Decimal("0")
+
+    def test_zero_prior_close_returns_none(self) -> None:
+        # A zero close is a non-price sentinel — no meaningful change.
+        assert compute_day_change(Decimal("10"), Decimal("0")) is None
+
+    def test_negative_prior_close_returns_none(self) -> None:
+        assert compute_day_change(Decimal("10"), Decimal("-5")) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1924 (part 2 — day-change column; part 1 all-dashes treatment shipped in #1929).

## What
A close-to-close **day-change** from `price_daily` (last two strictly-positive closes), wired into BOTH the instruments list and the per-instrument summary, stamped with the close date so it reads honestly under the loop's uneven candle freshness.

## Source rule
`day_change_pct = (last_close − prior_close) / prior_close` (a **fraction**, `-0.015` = −1.5%) over an instrument's two most-recent **positive** closes in `price_daily.close`, stamped to `MAX(price_date)` (settled-decisions.md:767 latest-closed-session, data-anchored not wall-clock).

**Full-population verification (dev DB, 2026-07-04):**
- **5,196** instruments have ≥2 positive closes (vs `quotes` ~69) — this is why day-change must come from `price_daily`, not `quotes`.
- **137** real `close = 0` sentinel rows exist in `price_daily`; the strictly-positive window filter skips them (avoids a −100% artefact — the same cross-surface invariant prevention-log #1428 documents for `quotes.last`, here re-verified directly against `price_daily`).
- Staleness of the latest close is severe/widespread in the loop (eToro market-data unreachable → `daily_candle_refresh` under-writes): buckets by `CURRENT_DATE − latest_close` = {≤1d: 6, 2–3d: 721, 4–7d: 9, 8–30d: 4,225, >30d: 235, max 1,870d}. **This is exactly why the metric is stamped with its close date** — in production (fresh candles) the ≤1d bucket dominates and it reads as a normal day-change.
- Two-close gap: 4,628/5,196 ≤1 calendar day, 564 2–4d (weekends), only **4** span >4d — no gap-guard warranted.

## Boundary (what this does NOT touch)
- **#1857 (operator-gated):** that gate is the value **sub-score model** (`instrument_valuation` view COALESCE → `model_version` bump). This is a pure display read path — no scoring, no `model_version`, no migration.
- **#1906 (native price primary):** the displayed price stays quote-sourced; day-change is a separate `price_daily` metric. Where a row has no live quote, the price still shows "—" while the dated change renders. A quote→`price_daily` *display* price fallback is deliberately left to #1857 de-gating.

## Changes
- `app/services/market_data.py`: `compute_day_change` (pure) + `load_day_changes` (one batched window query, rn≤2 over positive closes, `HAVING count(*)=2`).
- `app/api/instruments.py`: `InstrumentListItem` gains `day_change_pct` + `day_change_as_of` (list batch-loads per page only). `InstrumentPrice` gains `day_change_as_of`; the summary now emits a price block with `current=None` when a day-change exists but there's no quote — so list↔detail agree (was a Codex ckpt-1 HIGH: `price_block` previously vanished without a quote).
- `frontend/`: new `DayChangeCell` column (colored fractional pct + muted "as of <close date>", sortable client-side); `SummaryStrip` shows the as-of stamp. Dates formatted in **UTC** to preserve `price_date` west of UTC (Codex ckpt-2 finding).

## Labeling decision (was operator-open)
Rendered as a day-change **stamped with its close date** (e.g. "as of 12 Jun"), matching the line-767 as-of convention. Decisive per autonomy mandate: honest under the loop's staleness, normal day-change in production. No hard staleness suppression — an arbitrary cut would blank the feature in this known-broken market-data env and misrepresent production; the date label is the honesty mechanism.

## Tests / verification
- Pure `compute_day_change` table test (gain/loss/flat/zero-prior/negative-prior).
- db-tier `load_day_changes` (two positive closes; zero-close skip; <2-positive omission; empty ids).
- FE: list column assertions (+1.52% / −0.93% / +0.21% with price "—"; "as of" stamps) + fixture updates.
- Gates: ruff/pyright clean; `pytest -m "not db"` 4760 passed; smoke 141 passed; FE typecheck + unit green; dark-class gate clean.
- **Dev-verify (real code path against dev DB):** AAPL −1.50% as-of 12 Jun (stale, honestly dated), GME +0.57% 03 Jul, HD +2.59% as-of 09 Jun, MSFT +0.25% 02 Jul, JPM +0.23% (change shown while price "—"). Cross-checks manual math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)