### PR TITLE
feat(#1933): UNIQUE(instrument_id, model_version, scored_at) on scores

### DIFF
--- a/sql/212_scores_unique_triple.sql
+++ b/sql/212_scores_unique_triple.sql
@@ -1,0 +1,32 @@
+-- #1933 (split from #1918 review, Codex ckpt-2) — enforce uniqueness of
+-- (instrument_id, model_version, scored_at) on `scores`.
+--
+-- Today the invariant holds by the WRITE PATH, not the schema:
+-- `compute_rankings` (app/services/scoring.py:1812) captures a single
+-- `run_at` per run and calls `_insert_score` exactly once per instrument,
+-- so every (instrument_id, model_version, scored_at) triple is unique by
+-- construction. But there was no DB-level guard, so `GET /rankings` counts
+-- rows with COUNT(*) while `GET /rankings/coverage` (#1918) uses
+-- COUNT(DISTINCT instrument_id); they agree today only by luck. A future
+-- retry/concurrency bug that double-inserted a run would silently diverge
+-- the coverage banner from the table and page a duplicate instrument.
+--
+-- Full-population verification (dev DB, 2026-07-04): 104,285 score rows,
+-- 0 duplicate (instrument_id, model_version, scored_at) triples, 0 rows
+-- with NULL model_version/scored_at (both are NOT NULL). Backfill-safe —
+-- the index builds without violating any existing row.
+--
+-- A UNIQUE INDEX (not ALTER TABLE ... ADD CONSTRAINT) is used deliberately:
+-- Postgres has no `IF NOT EXISTS` on ADD CONSTRAINT, so the index form is
+-- the idempotent one the migration runner (re-run on partial apply) needs.
+-- Built non-CONCURRENTLY because the runner wraps each file in a
+-- transaction (app/db/migrations.py:194); on ~104k rows the ACCESS
+-- EXCLUSIVE lock is sub-second and `scores` is written only in bursts by
+-- compute_rankings, never continuously.
+--
+-- Kept alongside the existing idx_scores_instrument_scored
+-- (instrument_id, scored_at DESC) which serves latest-per-instrument reads;
+-- this index leads with (instrument_id, model_version) and does not replace
+-- that ordering.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_scores_instrument_model_scored
+    ON scores (instrument_id, model_version, scored_at);

--- a/tests/test_scores_unique_triple.py
+++ b/tests/test_scores_unique_triple.py
@@ -1,0 +1,80 @@
+"""Migration 212 — UNIQUE(instrument_id, model_version, scored_at) on ``scores``.
+
+Structural (index exists + is unique + covers the right columns) + behaviour
+(a second row with the same triple is rejected; varying any key member is
+allowed). Guards the #1918 invariant that ``GET /rankings`` COUNT(*) can never
+diverge from ``GET /rankings/coverage`` COUNT(DISTINCT instrument_id).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn as ebull_test_conn  # noqa: F401
+
+_INSTRUMENT_ID = 9_333_001
+_MODEL = "test-model-v1"
+_SCORED_AT = datetime(2026, 7, 4, 12, 0, 0, tzinfo=UTC)
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple]) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (_INSTRUMENT_ID, "UQ1933", "Unique Triple Co"),
+        )
+    conn.commit()
+
+
+def _insert_score(
+    conn: psycopg.Connection[tuple],
+    *,
+    instrument_id: int = _INSTRUMENT_ID,
+    model_version: str = _MODEL,
+    scored_at: datetime = _SCORED_AT,
+) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO scores (instrument_id, scored_at, model_version, total_score) VALUES (%s, %s, %s, 1.0)",
+            (instrument_id, scored_at, model_version),
+        )
+    conn.commit()
+
+
+def test_unique_index_exists_and_covers_triple(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT indexdef FROM pg_indexes WHERE indexname = 'uq_scores_instrument_model_scored'")
+        row = cur.fetchone()
+    ebull_test_conn.commit()
+    assert row is not None, "migration 212 unique index missing"
+    indexdef = row[0]
+    assert "UNIQUE INDEX" in indexdef
+    # Column set (order-independent assertion is enough for the invariant).
+    for col in ("instrument_id", "model_version", "scored_at"):
+        assert col in indexdef, f"{col} not covered by uq_scores_instrument_model_scored"
+
+
+def test_duplicate_triple_rejected(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _seed_instrument(ebull_test_conn)
+    _insert_score(ebull_test_conn)
+    with pytest.raises(psycopg.errors.UniqueViolation):
+        _insert_score(ebull_test_conn)
+
+
+def test_varying_any_key_member_is_allowed(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _seed_instrument(ebull_test_conn)
+    _insert_score(ebull_test_conn)
+    # Different scored_at (the normal multi-run case) — allowed.
+    _insert_score(ebull_test_conn, scored_at=datetime(2026, 7, 4, 13, 0, 0, tzinfo=UTC))
+    # Different model_version at the same instant — allowed.
+    _insert_score(ebull_test_conn, model_version="test-model-v2")
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM scores WHERE instrument_id = %s", (_INSTRUMENT_ID,))
+        row = cur.fetchone()
+    ebull_test_conn.commit()
+    assert row is not None
+    assert row[0] == 3


### PR DESCRIPTION
Closes #1933. Split from #1918 review (Codex ckpt-2).

## What
Migration `212_scores_unique_triple.sql` adds unique index
`uq_scores_instrument_model_scored ON scores (instrument_id, model_version, scored_at)`.

## Why
`scores` had only `score_id` as PK — no DB-level uniqueness on the score
triple. Today the invariant holds only by the write path: `compute_rankings`
(`app/services/scoring.py:1812`) captures one `run_at` per run and calls
`_insert_score` exactly once per instrument, so the triple is unique by
construction. But `GET /rankings` counts rows with `COUNT(*)` while
`GET /rankings/coverage` (#1918) uses `COUNT(DISTINCT instrument_id)`; they
agree today only by luck. A future retry/concurrency double-insert would
silently diverge the coverage banner from the table and page a duplicate
instrument. The constraint makes that fail loud at the source.

## Source rule / invariant
Not an ownership/filings/metric data-treatment decision — it's a structural
integrity guard on scoring output. The uniqueness key mirrors the write
identity (`run_at` per run × one insert per instrument × model_version).

## Full-population verification (dev, 2026-07-04)
104,285 score rows · **0 duplicate `(instrument_id, model_version, scored_at)`
triples** · 0 rows with NULL `model_version`/`scored_at` (both `NOT NULL`).
Backfill-safe — the index built without violating any existing row.

## Migration mechanics
- `CREATE UNIQUE INDEX IF NOT EXISTS` (not `ALTER TABLE ... ADD CONSTRAINT`):
  Postgres has no `IF NOT EXISTS` on `ADD CONSTRAINT`, so the index form is the
  idempotent one the runner (re-run on partial apply) needs.
- Non-`CONCURRENTLY`: the runner wraps each file in a transaction
  (`app/db/migrations.py:194`); on ~104k rows the `ACCESS EXCLUSIVE` lock is
  sub-second and `scores` is written only in bursts by `compute_rankings`.
- Kept alongside `idx_scores_instrument_scored (instrument_id, scored_at DESC)`
  which serves latest-per-instrument reads; the new index leads with
  `(instrument_id, model_version)` and does not replace that ordering.

## Verification (DoD)
- Migration applied clean to **dev DB** via `run_migrations()` → index present,
  `schema_migrations` row recorded with `content_sha256`.
- DB-tier test `tests/test_scores_unique_triple.py` (3 passed): index exists +
  unique + covers the triple; duplicate triple rejected (`UniqueViolation`);
  varying any key member (scored_at / model_version) allowed.
- Read paths unaffected (purely additive index).
- Codex ckpt-2: no blocking findings.

## Tradeoffs
Read-path `COUNT(*)` in `GET /rankings` is left as-is; the constraint now makes
it provably equal to `COUNT(DISTINCT)` so no read change is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)