### PR TITLE
feat(#1922): rank-move alert feed on the dashboard AlertsStrip

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -17,6 +17,11 @@ Provides three independent alert feeds sharing the same dashboard strip shape:
    - POST /alerts/coverage-status-drops/seen    (body: {seen_through_event_id})
    - POST /alerts/coverage-status-drops/dismiss-all
 
+4. Rank moves on held instruments (#1922):
+   - GET  /alerts/rank-moves
+   - POST /alerts/rank-moves/seen               (body: {seen_through_rank_event_id})
+   - POST /alerts/rank-moves/dismiss-all
+
 Each feed maintains its own BIGSERIAL cursor column on ``operators`` and a
 7-day window. Cursor semantics are identical across feeds: strict ``>``
 comparison, GREATEST+COALESCE monotonicity, LEAST clamp on /seen, MAX
@@ -49,6 +54,7 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.db.snapshot import snapshot_read
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
+from app.services.scoring import _DEFAULT_MODEL_VERSION
 
 router = APIRouter(
     prefix="/alerts",
@@ -57,6 +63,31 @@ router = APIRouter(
 )
 
 GuardAction = Literal["BUY", "ADD", "HOLD", "EXIT"]
+
+# #1922 — a HELD instrument's rank must move by at least this many places
+# between scoring runs to surface as a dashboard alert. Product threshold
+# (not a source rule): tuned so only material moves on a position break
+# through, not the ±1-2 rank jitter every re-score produces. `rank_delta`
+# is `prior_rank - new_rank` (positive = moved up), computed within a single
+# model_version (app/services/scoring.py:1820), so the feed is scoped to
+# _DEFAULT_MODEL_VERSION to avoid double-counting cross-model rows.
+_RANK_MOVE_THRESHOLD = 20
+
+# Canonical in-window rank-move predicate, shared verbatim by the GET count,
+# the GET list, /seen and /dismiss-all so the four can never drift (the
+# divergence trap called out in docs/review-prevention-log.md). Parameters:
+# %(mv)s model_version, %(threshold)s magnitude. `s` = scores alias.
+_RANK_MOVE_WHERE = """
+    s.model_version = %(mv)s
+    AND s.rank_delta IS NOT NULL
+    AND abs(s.rank_delta) >= %(threshold)s
+    AND s.scored_at >= now() - INTERVAL '7 days'
+    AND EXISTS (
+        SELECT 1 FROM positions p
+        WHERE p.instrument_id = s.instrument_id
+          AND p.current_units > 0
+    )
+"""
 
 
 class GuardRejection(BaseModel):
@@ -119,6 +150,25 @@ class CoverageStatusDropsResponse(BaseModel):
 
 class CoverageStatusDropsMarkSeenRequest(BaseModel):
     seen_through_event_id: int = Field(gt=0)
+
+
+class RankMove(BaseModel):
+    score_id: int
+    instrument_id: int
+    symbol: str
+    scored_at: datetime
+    rank: int
+    rank_delta: int  # prior_rank - new_rank: positive = moved up the board
+
+
+class RankMovesResponse(BaseModel):
+    alerts_last_seen_rank_event_id: int | None
+    unseen_count: int
+    moves: list[RankMove]
+
+
+class RankMovesMarkSeenRequest(BaseModel):
+    seen_through_rank_event_id: int = Field(gt=0)
 
 
 def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
@@ -500,5 +550,151 @@ def dismiss_all_coverage_status_drops(
               AND m.max_id IS NOT NULL
             """,
             {"op": operator_id},
+        )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# #1922 — rank-move alert feed (held instrument's rank moved materially)
+#
+#   GET  /alerts/rank-moves
+#   POST /alerts/rank-moves/seen         (body: {seen_through_rank_event_id})
+#   POST /alerts/rank-moves/dismiss-all
+#
+# Same cursor semantics as the coverage feed: BIGSERIAL cursor (score_id),
+# strict '>' comparison, 7-day window, GREATEST+COALESCE monotonicity, LEAST
+# clamp on /seen, MAX advance on /dismiss-all, m.max_id IS NOT NULL empty-
+# window guard (preserves NULL = never acknowledged). The window predicate is
+# the single shared _RANK_MOVE_WHERE fragment so GET/seen/dismiss cannot drift.
+#
+# Two accepted properties of a DERIVED feed (vs the coverage feed's immutable
+# event log), both by design:
+#   1. The predicate reads live position state (current_units > 0). Closing a
+#      held position removes its moves from GET/seen/dismiss alike — you no
+#      longer hold it, so the alert legitimately disappears. If reopened within
+#      the 7-day window its recent rank trajectory resurfaces as unseen, which
+#      is the desired "here's how it moved while you were out" behaviour, not a
+#      leak (GET/seen share the predicate, so you never ack what you can't see).
+#   2. The cursor is global but the feed is scoped to _DEFAULT_MODEL_VERSION.
+#      A default-model change is an operator-gated deploy event (#1815/#1822)
+#      whose fresh scoring run inserts the NEWEST score_ids, so post-bump moves
+#      always sort above any week-old cursor and surface normally.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/rank-moves", response_model=RankMovesResponse)
+def get_rank_moves(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> RankMovesResponse:
+    operator_id = _resolve_operator(conn)
+    params = {"mv": _DEFAULT_MODEL_VERSION, "threshold": _RANK_MOVE_THRESHOLD}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # 1. Read operator's cursor.
+        cur.execute(
+            "SELECT alerts_last_seen_rank_event_id FROM operators WHERE operator_id = %(op)s",
+            {"op": operator_id},
+        )
+        op_row = cur.fetchone()
+        last_seen: int | None = op_row["alerts_last_seen_rank_event_id"] if op_row else None
+
+        # 2. Count unseen in-window moves (uncapped).
+        cur.execute(
+            f"""
+            SELECT COUNT(*) AS unseen_count
+            FROM scores s
+            WHERE {_RANK_MOVE_WHERE}
+              AND (%(last_id)s::BIGINT IS NULL OR s.score_id > %(last_id)s::BIGINT)
+            """,
+            {**params, "last_id": last_seen},
+        )
+        count_row = cur.fetchone()
+        assert count_row is not None, "COUNT(*) always returns a row"
+        unseen_count: int = int(count_row["unseen_count"])
+
+        # 3. Fetch list capped at 500, newest first. score_id is a monotonic
+        # BIGSERIAL PK so ORDER BY score_id DESC is race-safe.
+        cur.execute(
+            f"""
+            SELECT
+                s.score_id,
+                s.instrument_id,
+                i.symbol,
+                s.scored_at,
+                s.rank,
+                s.rank_delta
+            FROM scores s
+            JOIN instruments i ON i.instrument_id = s.instrument_id
+            WHERE {_RANK_MOVE_WHERE}
+            ORDER BY s.score_id DESC
+            LIMIT 500
+            """,
+            params,
+        )
+        rows = cur.fetchall()
+
+    return RankMovesResponse(
+        alerts_last_seen_rank_event_id=last_seen,
+        unseen_count=unseen_count,
+        moves=[RankMove.model_validate(r) for r in rows],
+    )
+
+
+@router.post("/rank-moves/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_rank_moves_seen(
+    body: RankMovesMarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    params = {"mv": _DEFAULT_MODEL_VERSION, "threshold": _RANK_MOVE_THRESHOLD}
+    with conn.cursor() as cur:
+        # m.max_id IS NOT NULL guard preserves NULL cursor on empty window
+        # (matches the coverage / position /seen shape, not guard's pre-#395).
+        cur.execute(
+            f"""
+            UPDATE operators AS op
+            SET alerts_last_seen_rank_event_id = GREATEST(
+                COALESCE(op.alerts_last_seen_rank_event_id, 0),
+                LEAST(%(seen_through_rank_event_id)s, m.max_id)
+            )
+            FROM (
+                SELECT MAX(s.score_id) AS max_id
+                FROM scores s
+                WHERE {_RANK_MOVE_WHERE}
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {
+                **params,
+                "seen_through_rank_event_id": body.seen_through_rank_event_id,
+                "op": operator_id,
+            },
+        )
+    conn.commit()
+
+
+@router.post("/rank-moves/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)
+def dismiss_all_rank_moves(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    params = {"mv": _DEFAULT_MODEL_VERSION, "threshold": _RANK_MOVE_THRESHOLD}
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            UPDATE operators AS op
+            SET alerts_last_seen_rank_event_id = GREATEST(
+                COALESCE(op.alerts_last_seen_rank_event_id, 0),
+                m.max_id
+            )
+            FROM (
+                SELECT MAX(s.score_id) AS max_id
+                FROM scores s
+                WHERE {_RANK_MOVE_WHERE}
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {**params, "op": operator_id},
         )
     conn.commit()

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -3,6 +3,7 @@ import type {
   CoverageStatusDropsResponse,
   GuardRejectionsResponse,
   PositionAlertsResponse,
+  RankMovesResponse,
 } from "@/api/types";
 
 /**
@@ -80,4 +81,23 @@ export function dismissAllCoverageStatusDrops(): Promise<void> {
   return apiFetch<void>("/alerts/coverage-status-drops/dismiss-all", {
     method: "POST",
   });
+}
+
+// --- #1922 rank-move endpoints ----------------------------------------------
+
+export function fetchRankMoves(): Promise<RankMovesResponse> {
+  return apiFetch<RankMovesResponse>("/alerts/rank-moves");
+}
+
+export function markRankMovesSeen(
+  seenThroughRankEventId: number,
+): Promise<void> {
+  return apiFetch<void>("/alerts/rank-moves/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_rank_event_id: seenThroughRankEventId }),
+  });
+}
+
+export function dismissAllRankMoves(): Promise<void> {
+  return apiFetch<void>("/alerts/rank-moves/dismiss-all", { method: "POST" });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1670,6 +1670,25 @@ export interface CoverageStatusDropsResponse {
 }
 
 // ---------------------------------------------------------------------------
+// #1922 rank moves on held instruments (app/api/alerts.py)
+// ---------------------------------------------------------------------------
+
+export interface RankMove {
+  score_id: number;
+  instrument_id: number;
+  symbol: string;
+  scored_at: string;
+  rank: number;
+  rank_delta: number; // prior_rank - new_rank: positive = moved up the board
+}
+
+export interface RankMovesResponse {
+  alerts_last_seen_rank_event_id: number | null;
+  unseen_count: number;
+  moves: RankMove[];
+}
+
+// ---------------------------------------------------------------------------
 // #1076 / #1064 admin control hub (app/api/processes.py)
 // ---------------------------------------------------------------------------
 //

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -587,15 +587,18 @@ describe("AlertsStrip — Mark all read", () => {
         unseen_count: 2,
       },
       position: { alerts: [makePosition({ alert_id: 710 })], unseen_count: 1 },
+      rank: { moves: [makeRankMove({ score_id: 104061 })], unseen_count: 1 },
     });
     mockedMarkGuard.mockResolvedValue(undefined);
     mockedMarkPosition.mockResolvedValue(undefined);
+    mockedMarkRank.mockResolvedValue(undefined);
     renderStrip();
     const btn = await screen.findByRole("button", { name: /Mark all read/i });
     await userEvent.click(btn);
     await vi.waitFor(() => {
       expect(mockedMarkGuard).toHaveBeenCalledWith(510);
       expect(mockedMarkPosition).toHaveBeenCalledWith(710);
+      expect(mockedMarkRank).toHaveBeenCalledWith(104061);
     });
     expect(mockedMarkCoverage).not.toHaveBeenCalled();
   });
@@ -631,6 +634,7 @@ describe("AlertsStrip — Dismiss all", () => {
     });
     mockedDismissPosition.mockResolvedValue(undefined);
     mockedDismissCoverage.mockResolvedValue(undefined);
+    mockedDismissRank.mockResolvedValue(undefined);
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     renderStrip();
@@ -641,6 +645,8 @@ describe("AlertsStrip — Dismiss all", () => {
     });
     expect(mockedDismissGuard).not.toHaveBeenCalled();
     expect(mockedDismissCoverage).toHaveBeenCalled();
+    // rank feed loaded ok (empty) → dismiss fans out to it too
+    expect(mockedDismissRank).toHaveBeenCalled();
     confirmSpy.mockRestore();
     errSpy.mockRestore();
   });

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -11,6 +11,8 @@ import type {
   GuardRejectionsResponse,
   PositionAlert,
   PositionAlertsResponse,
+  RankMove,
+  RankMovesResponse,
 } from "@/api/types";
 
 vi.mock("@/api/alerts", () => ({
@@ -23,6 +25,9 @@ vi.mock("@/api/alerts", () => ({
   fetchCoverageStatusDrops: vi.fn(),
   markCoverageStatusDropsSeen: vi.fn(),
   dismissAllCoverageStatusDrops: vi.fn(),
+  fetchRankMoves: vi.fn(),
+  markRankMovesSeen: vi.fn(),
+  dismissAllRankMoves: vi.fn(),
 }));
 
 import * as alertsApi from "@/api/alerts";
@@ -30,14 +35,17 @@ import * as alertsApi from "@/api/alerts";
 const mockedGuardFetch = vi.mocked(alertsApi.fetchGuardRejections);
 const mockedPositionFetch = vi.mocked(alertsApi.fetchPositionAlerts);
 const mockedCoverageFetch = vi.mocked(alertsApi.fetchCoverageStatusDrops);
+const mockedRankFetch = vi.mocked(alertsApi.fetchRankMoves);
 
 const mockedMarkGuard = vi.mocked(alertsApi.markAlertsSeen);
 const mockedMarkPosition = vi.mocked(alertsApi.markPositionAlertsSeen);
 const mockedMarkCoverage = vi.mocked(alertsApi.markCoverageStatusDropsSeen);
+const mockedMarkRank = vi.mocked(alertsApi.markRankMovesSeen);
 
 const mockedDismissGuard = vi.mocked(alertsApi.dismissAllAlerts);
 const mockedDismissPosition = vi.mocked(alertsApi.dismissAllPositionAlerts);
 const mockedDismissCoverage = vi.mocked(alertsApi.dismissAllCoverageStatusDrops);
+const mockedDismissRank = vi.mocked(alertsApi.dismissAllRankMoves);
 
 const EMPTY_GUARD: GuardRejectionsResponse = {
   alerts_last_seen_decision_id: null,
@@ -54,12 +62,18 @@ const EMPTY_COVERAGE: CoverageStatusDropsResponse = {
   unseen_count: 0,
   drops: [],
 };
+const EMPTY_RANK: RankMovesResponse = {
+  alerts_last_seen_rank_event_id: null,
+  unseen_count: 0,
+  moves: [],
+};
 
 function stubAll(
   overrides: {
     guard?: Partial<GuardRejectionsResponse> | Error;
     position?: Partial<PositionAlertsResponse> | Error;
     coverage?: Partial<CoverageStatusDropsResponse> | Error;
+    rank?: Partial<RankMovesResponse> | Error;
   } = {},
 ) {
   if (overrides.guard instanceof Error) {
@@ -76,6 +90,11 @@ function stubAll(
     mockedCoverageFetch.mockRejectedValue(overrides.coverage);
   } else {
     mockedCoverageFetch.mockResolvedValue({ ...EMPTY_COVERAGE, ...overrides.coverage });
+  }
+  if (overrides.rank instanceof Error) {
+    mockedRankFetch.mockRejectedValue(overrides.rank);
+  } else {
+    mockedRankFetch.mockResolvedValue({ ...EMPTY_RANK, ...overrides.rank });
   }
 }
 
@@ -117,6 +136,18 @@ function makeCoverage(overrides: Partial<CoverageStatusDrop> = {}): CoverageStat
   };
 }
 
+function makeRankMove(overrides: Partial<RankMove> = {}): RankMove {
+  return {
+    score_id: 104061,
+    instrument_id: 45,
+    symbol: "BBBY",
+    scored_at: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+    rank: 3679,
+    rank_delta: -43, // moved down 43 places
+    ...overrides,
+  };
+}
+
 function renderStrip() {
   return render(
     <MemoryRouter>
@@ -127,6 +158,10 @@ function renderStrip() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default the rank feed empty so tests that stub the other three feeds
+  // individually (not via stubAll) don't hit an unmocked fetch. Tests that
+  // exercise rank moves override this.
+  mockedRankFetch.mockResolvedValue(EMPTY_RANK);
 });
 
 // ---------------------------------------------------------------------------
@@ -281,11 +316,42 @@ describe("AlertsStrip — per-kind rendering", () => {
       guard: { rejections: [makeGuard()], unseen_count: 1 },
       position: { alerts: [makePosition()], unseen_count: 1 },
       coverage: { drops: [makeCoverage()], unseen_count: 1 },
+      rank: { moves: [makeRankMove()], unseen_count: 1 },
     });
     renderStrip();
     expect(await screen.findByText("ACTION")).toBeInTheDocument();
     expect(screen.getByText("GUARD")).toBeInTheDocument();
     expect(screen.getByText("COVERAGE")).toBeInTheDocument();
+    expect(screen.getByText("RANK")).toBeInTheDocument();
+  });
+
+  it("rank card shows symbol, direction arrow, magnitude and new rank; links to instrument", async () => {
+    stubAll({
+      rank: {
+        moves: [makeRankMove({ instrument_id: 45, symbol: "BBBY", rank: 3679, rank_delta: -43 })],
+        unseen_count: 1,
+      },
+    });
+    renderStrip();
+    const row = await screen.findByTestId("alerts-row");
+    expect(row.textContent).toContain("BBBY");
+    expect(row.textContent).toContain("▼43"); // moved down
+    expect(row.textContent).toContain("rank #3679");
+    const links = screen.getAllByRole("link").map((l) => l.getAttribute("href"));
+    expect(links).toContain("/instruments/45");
+  });
+
+  it("rank card shows an up arrow for a positive (improved) move", async () => {
+    stubAll({
+      rank: {
+        moves: [makeRankMove({ symbol: "GME", rank: 12, rank_delta: 30 })],
+        unseen_count: 1,
+      },
+    });
+    renderStrip();
+    const row = await screen.findByTestId("alerts-row");
+    expect(row.textContent).toContain("▲30");
+    expect(row.textContent).toContain("rank #12");
   });
 
   it("position card links to /instruments/<id>", async () => {

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -24,18 +24,22 @@ import {
   dismissAllAlerts,
   dismissAllCoverageStatusDrops,
   dismissAllPositionAlerts,
+  dismissAllRankMoves,
   fetchCoverageStatusDrops,
   fetchGuardRejections,
   fetchPositionAlerts,
+  fetchRankMoves,
   markAlertsSeen,
   markCoverageStatusDropsSeen,
   markPositionAlertsSeen,
+  markRankMovesSeen,
 } from "@/api/alerts";
 import type {
   CoverageStatusDropsResponse,
   GuardRejectionsResponse,
   PositionAlert,
   PositionAlertsResponse,
+  RankMovesResponse,
 } from "@/api/types";
 import { formatRelativeTime } from "@/lib/format";
 
@@ -45,6 +49,7 @@ import {
   type Cursors,
   type GuardGroupItem,
   type CoverageGroupItem,
+  type RankMoveItem,
   type Tier,
 } from "./alertModel";
 
@@ -77,12 +82,16 @@ function tierBorder(tier: Tier, unseen: boolean): string {
   return "border-l-4 border-slate-200 dark:border-slate-800";
 }
 
-function TierPill({ tier }: { tier: Tier }) {
+// `label` overrides the tier-derived pill text. The pill doubles as a
+// kind/category badge (ACTION/GUARD/COVERAGE), so a feed that shares a tier
+// with another kind (rank moves are informational, like guard) must supply its
+// own label to stay legible.
+function TierPill({ tier, label }: { tier: Tier; label?: string }) {
   return (
     <span
       className={`w-20 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase ${TIER_PILL[tier]}`}
     >
-      {TIER_LABEL[tier]}
+      {label ?? TIER_LABEL[tier]}
     </span>
   );
 }
@@ -90,10 +99,12 @@ function TierPill({ tier }: { tier: Tier }) {
 function CardShell({
   tier,
   unseen,
+  label,
   children,
 }: {
   tier: Tier;
   unseen: boolean;
+  label?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -102,7 +113,7 @@ function CardShell({
       role="listitem"
       className={`flex items-start gap-3 px-3 py-2 text-sm ${tierBorder(tier, unseen)} bg-white dark:bg-slate-900`}
     >
-      <TierPill tier={tier} />
+      <TierPill tier={tier} label={label} />
       {children}
     </div>
   );
@@ -221,6 +232,49 @@ function CoverageGroupCard({ item }: { item: CoverageGroupItem }) {
   );
 }
 
+function RankMoveCard({ item }: { item: RankMoveItem }) {
+  // rankDelta: positive = moved UP the board (better), negative = down.
+  const up = item.rankDelta > 0;
+  const magnitude = Math.abs(item.rankDelta);
+  return (
+    <Link
+      to={`/instruments/${item.instrumentId}`}
+      className="block hover:bg-slate-50 dark:hover:bg-slate-800/40"
+    >
+      <CardShell tier={item.tier} unseen={item.unseen} label="RANK">
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex items-baseline gap-2">
+            <span className="font-semibold text-slate-800 dark:text-slate-100">
+              {item.symbol}
+            </span>
+            <span
+              className={`tabular-nums font-medium ${
+                up
+                  ? "text-emerald-600 dark:text-emerald-400"
+                  : "text-red-600 dark:text-red-400"
+              }`}
+            >
+              {up ? "▲" : "▼"}
+              {magnitude}
+            </span>
+            {item.count > 1 ? (
+              <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:text-slate-300 tabular-nums">
+                ×{item.count}
+              </span>
+            ) : null}
+          </div>
+          <span className="text-xs text-slate-500 dark:text-slate-400 tabular-nums">
+            {up ? "Up" : "Down"} {magnitude} to rank #{item.rank}
+          </span>
+        </div>
+        <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+          {formatRelativeTime(item.latestTs)}
+        </span>
+      </CardShell>
+    </Link>
+  );
+}
+
 function ItemView({ item }: { item: AlertItem }) {
   switch (item.kind) {
     case "guardGroup":
@@ -229,6 +283,8 @@ function ItemView({ item }: { item: AlertItem }) {
       return <PositionCard row={item.row} unseen={item.unseen} />;
     case "coverageGroup":
       return <CoverageGroupCard item={item} />;
+    case "rankMove":
+      return <RankMoveCard item={item} />;
   }
 }
 
@@ -242,6 +298,9 @@ export function AlertsStrip(): JSX.Element | null {
   const [coverage, setCoverage] = useState<FeedState<CoverageStatusDropsResponse>>({
     status: "loading",
   });
+  const [rank, setRank] = useState<FeedState<RankMovesResponse>>({
+    status: "loading",
+  });
   const [refetchKey, setRefetchKey] = useState(0);
 
   useEffect(() => {
@@ -249,6 +308,7 @@ export function AlertsStrip(): JSX.Element | null {
     setGuard({ status: "loading" });
     setPosition({ status: "loading" });
     setCoverage({ status: "loading" });
+    setRank({ status: "loading" });
 
     fetchGuardRejections()
       .then((d) => {
@@ -280,6 +340,16 @@ export function AlertsStrip(): JSX.Element | null {
           setCoverage({ status: "err" });
         }
       });
+    fetchRankMoves()
+      .then((d) => {
+        if (!cancelled) setRank({ status: "ok", data: d });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AlertsStrip] fetchRankMoves failed", err);
+          setRank({ status: "err" });
+        }
+      });
 
     return () => {
       cancelled = true;
@@ -291,14 +361,16 @@ export function AlertsStrip(): JSX.Element | null {
   if (
     guard.status === "loading" ||
     position.status === "loading" ||
-    coverage.status === "loading"
+    coverage.status === "loading" ||
+    rank.status === "loading"
   ) {
     return null;
   }
   if (
     guard.status === "err" &&
     position.status === "err" &&
-    coverage.status === "err"
+    coverage.status === "err" &&
+    rank.status === "err"
   ) {
     return null;
   }
@@ -308,6 +380,7 @@ export function AlertsStrip(): JSX.Element | null {
   const rejections = guard.status === "ok" ? guard.data.rejections : [];
   const positionAlerts = position.status === "ok" ? position.data.alerts : [];
   const drops = coverage.status === "ok" ? coverage.data.drops : [];
+  const moves = rank.status === "ok" ? rank.data.moves : [];
 
   const cursors: Cursors = {
     guard: guard.status === "ok" ? guard.data.alerts_last_seen_decision_id : null,
@@ -319,9 +392,10 @@ export function AlertsStrip(): JSX.Element | null {
       coverage.status === "ok"
         ? coverage.data.alerts_last_seen_coverage_event_id
         : null,
+    rank: rank.status === "ok" ? rank.data.alerts_last_seen_rank_event_id : null,
   };
 
-  const items = buildAlertModel(rejections, positionAlerts, drops, cursors);
+  const items = buildAlertModel(rejections, positionAlerts, drops, moves, cursors);
 
   if (items.length === 0) {
     return null;
@@ -330,19 +404,22 @@ export function AlertsStrip(): JSX.Element | null {
   const unseenGuard = guard.status === "ok" ? guard.data.unseen_count : 0;
   const unseenPosition = position.status === "ok" ? position.data.unseen_count : 0;
   const unseenCoverage = coverage.status === "ok" ? coverage.data.unseen_count : 0;
+  const unseenRank = rank.status === "ok" ? rank.data.unseen_count : 0;
 
   // Overflow math compares backend unseen counts to RAW fetched row counts (each feed caps
   // at LIMIT 500) — NOT to the grouped card count.
   const renderedGuard = rejections.length;
   const renderedPosition = positionAlerts.length;
   const renderedCoverage = drops.length;
+  const renderedRank = moves.length;
 
-  const totalUnseen = unseenGuard + unseenPosition + unseenCoverage;
+  const totalUnseen = unseenGuard + unseenPosition + unseenCoverage + unseenRank;
 
   const anyOverflow =
     unseenGuard > renderedGuard ||
     unseenPosition > renderedPosition ||
-    unseenCoverage > renderedCoverage;
+    unseenCoverage > renderedCoverage ||
+    unseenRank > renderedRank;
 
   const overflowAck = anyOverflow;
   const normalAck = totalUnseen > 0 && !anyOverflow;
@@ -352,11 +429,13 @@ export function AlertsStrip(): JSX.Element | null {
     const guardMax = Math.max(0, ...rejections.map((r) => r.decision_id));
     const positionMax = Math.max(0, ...positionAlerts.map((r) => r.alert_id));
     const coverageMax = Math.max(0, ...drops.map((r) => r.event_id));
+    const rankMax = Math.max(0, ...moves.map((r) => r.score_id));
 
     const promises: Promise<void>[] = [];
     if (guardMax > 0) promises.push(markAlertsSeen(guardMax));
     if (positionMax > 0) promises.push(markPositionAlertsSeen(positionMax));
     if (coverageMax > 0) promises.push(markCoverageStatusDropsSeen(coverageMax));
+    if (rankMax > 0) promises.push(markRankMovesSeen(rankMax));
 
     const results = await Promise.allSettled(promises);
     for (const r of results) {
@@ -371,7 +450,8 @@ export function AlertsStrip(): JSX.Element | null {
     const hiddenCount =
       Math.max(0, unseenGuard - renderedGuard) +
       Math.max(0, unseenPosition - renderedPosition) +
-      Math.max(0, unseenCoverage - renderedCoverage);
+      Math.max(0, unseenCoverage - renderedCoverage) +
+      Math.max(0, unseenRank - renderedRank);
     const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
     if (!window.confirm(msg)) return;
 
@@ -379,6 +459,7 @@ export function AlertsStrip(): JSX.Element | null {
     if (guard.status === "ok") promises.push(dismissAllAlerts());
     if (position.status === "ok") promises.push(dismissAllPositionAlerts());
     if (coverage.status === "ok") promises.push(dismissAllCoverageStatusDrops());
+    if (rank.status === "ok") promises.push(dismissAllRankMoves());
 
     const results = await Promise.allSettled(promises);
     for (const r of results) {

--- a/frontend/src/components/dashboard/alertModel.test.ts
+++ b/frontend/src/components/dashboard/alertModel.test.ts
@@ -4,6 +4,7 @@ import type {
   CoverageStatusDrop,
   GuardRejection,
   PositionAlert,
+  RankMove,
 } from "@/api/types";
 
 import {
@@ -13,9 +14,15 @@ import {
   type Cursors,
   type CoverageGroupItem,
   type GuardGroupItem,
+  type RankMoveItem,
 } from "./alertModel";
 
-const NO_CURSORS: Cursors = { guard: null, position: null, coverage: null };
+const NO_CURSORS: Cursors = {
+  guard: null,
+  position: null,
+  coverage: null,
+  rank: null,
+};
 
 function guard(o: Partial<GuardRejection> = {}): GuardRejection {
   return {
@@ -51,6 +58,18 @@ function coverage(o: Partial<CoverageStatusDrop> = {}): CoverageStatusDrop {
     changed_at: "2026-07-04T10:00:00Z",
     old_status: "analysable",
     new_status: "insufficient",
+    ...o,
+  };
+}
+
+function rankMove(o: Partial<RankMove> = {}): RankMove {
+  return {
+    score_id: 1,
+    instrument_id: 4,
+    symbol: "GME",
+    scored_at: "2026-07-04T10:00:00Z",
+    rank: 40,
+    rank_delta: -30, // moved down 30 places
     ...o,
   };
 }
@@ -96,7 +115,7 @@ describe("buildAlertModel — guard grouping", () => {
         rejections.push(guard({ decision_id: id++, symbol: s }));
       }
     }
-    const items = buildAlertModel(rejections, [], [], NO_CURSORS);
+    const items = buildAlertModel(rejections, [], [], [], NO_CURSORS);
     expect(items).toHaveLength(1);
     const g = items[0] as GuardGroupItem;
     expect(g.kind).toBe("guardGroup");
@@ -116,6 +135,7 @@ describe("buildAlertModel — guard grouping", () => {
       ],
       [],
       [],
+      [],
       NO_CURSORS,
     );
     expect(items).toHaveLength(2);
@@ -131,6 +151,7 @@ describe("buildAlertModel — guard grouping", () => {
       ],
       [],
       [],
+      [],
       NO_CURSORS,
     );
     const g = items[0] as GuardGroupItem;
@@ -141,6 +162,7 @@ describe("buildAlertModel — guard grouping", () => {
   it("group is seen when maxId <= cursor", () => {
     const items = buildAlertModel(
       [guard({ decision_id: 400 }), guard({ decision_id: 399 })],
+      [],
       [],
       [],
       { ...NO_CURSORS, guard: 400 },
@@ -159,6 +181,7 @@ describe("buildAlertModel — coverage grouping", () => {
         coverage({ event_id: 2, symbol: "NIO", new_status: "insufficient" }),
         coverage({ event_id: 3, symbol: "F", new_status: null }),
       ],
+      [],
       NO_CURSORS,
     );
     const cov = items.filter((i) => i.kind === "coverageGroup") as CoverageGroupItem[];
@@ -172,12 +195,50 @@ describe("buildAlertModel — coverage grouping", () => {
   });
 });
 
+describe("buildAlertModel — rank moves", () => {
+  it("groups moves by instrument; latest (highest score_id) drives display, rest counted", () => {
+    const items = buildAlertModel(
+      [],
+      [],
+      [],
+      [
+        rankMove({ score_id: 10, instrument_id: 4, symbol: "GME", rank: 40, rank_delta: -30 }),
+        rankMove({ score_id: 12, instrument_id: 4, symbol: "GME", rank: 55, rank_delta: -25 }),
+        rankMove({ score_id: 11, instrument_id: 7, symbol: "BBBY", rank: 8, rank_delta: 22 }),
+      ],
+      NO_CURSORS,
+    );
+    const ranks = items.filter((i) => i.kind === "rankMove") as RankMoveItem[];
+    expect(ranks).toHaveLength(2);
+    const gme = ranks.find((r) => r.symbol === "GME")!;
+    expect(gme.count).toBe(2);
+    expect(gme.maxId).toBe(12); // highest score_id
+    expect(gme.rank).toBe(55); // latest row's rank
+    expect(gme.rankDelta).toBe(-25); // latest row's delta
+    expect(gme.tier).toBe("informational");
+    expect(gme.id).toBe("rank:4");
+    expect(gme.unseen).toBe(true); // cursor null
+  });
+
+  it("card is seen when maxId <= rank cursor", () => {
+    const items = buildAlertModel(
+      [],
+      [],
+      [],
+      [rankMove({ score_id: 500 }), rankMove({ score_id: 499 })],
+      { ...NO_CURSORS, rank: 500 },
+    );
+    expect((items[0] as RankMoveItem).unseen).toBe(false);
+  });
+});
+
 describe("buildAlertModel — severity ordering", () => {
   it("orders actionable → informational → housekeeping regardless of timestamp", () => {
     const items = buildAlertModel(
       [guard({ decision_time: "2026-07-04T12:00:00Z" })], // newest, but informational
       [position({ opened_at: "2026-07-04T09:00:00Z" })], // oldest, but actionable
       [coverage({ changed_at: "2026-07-04T11:00:00Z" })],
+      [],
       NO_CURSORS,
     );
     expect(items.map((i) => i.tier)).toEqual([
@@ -193,6 +254,7 @@ describe("buildAlertModel — severity ordering", () => {
         guard({ decision_id: 1, explanation: "FAIL — kill_switch: x", decision_time: "2026-07-04T08:00:00Z" }),
         guard({ decision_id: 2, explanation: "FAIL — auto_trading: y", decision_time: "2026-07-04T12:00:00Z" }),
       ],
+      [],
       [],
       [],
       NO_CURSORS,

--- a/frontend/src/components/dashboard/alertModel.ts
+++ b/frontend/src/components/dashboard/alertModel.ts
@@ -20,6 +20,7 @@ import type {
   CoverageStatusDrop,
   GuardRejection,
   PositionAlert,
+  RankMove,
 } from "@/api/types";
 
 export type Tier = "actionable" | "informational" | "housekeeping";
@@ -34,6 +35,7 @@ export type Cursors = {
   guard: number | null;
   position: number | null;
   coverage: number | null;
+  rank: number | null;
 };
 
 export interface GuardReasonMeta {
@@ -211,7 +213,26 @@ export interface CoverageGroupItem {
   unseen: boolean;
 }
 
-export type AlertItem = GuardGroupItem | PositionItem | CoverageGroupItem;
+export interface RankMoveItem {
+  kind: "rankMove";
+  tier: Tier;
+  id: string;
+  symbol: string;
+  instrumentId: number;
+  rank: number;
+  rankDelta: number; // latest move; positive = moved up
+  count: number;
+  latestTs: string;
+  sortKey: number;
+  maxId: number;
+  unseen: boolean;
+}
+
+export type AlertItem =
+  | GuardGroupItem
+  | PositionItem
+  | CoverageGroupItem
+  | RankMoveItem;
 
 function uniqueSorted(values: (string | null)[]): string[] {
   return Array.from(new Set(values.filter((v): v is string => !!v))).sort();
@@ -225,6 +246,7 @@ export function buildAlertModel(
   rejections: GuardRejection[],
   positions: PositionAlert[],
   drops: CoverageStatusDrop[],
+  moves: RankMove[],
   cursors: Cursors,
 ): AlertItem[] {
   const items: AlertItem[] = [];
@@ -297,6 +319,35 @@ export function buildAlertModel(
       sortKey: Date.parse(latest.changed_at),
       maxId,
       unseen: cursors.coverage === null || maxId > cursors.coverage,
+    });
+  }
+
+  // Rank moves → one card per held instrument (informational tier). A single
+  // instrument may have several in-window move rows (one per re-score); show
+  // the latest (highest score_id) and count the rest. maxId drives the unseen
+  // highlight, consistent with the BIGSERIAL cursor accounting.
+  const rankGroups = new Map<number, RankMove[]>();
+  for (const m of moves) {
+    const arr = rankGroups.get(m.instrument_id);
+    if (arr) arr.push(m);
+    else rankGroups.set(m.instrument_id, [m]);
+  }
+  for (const [instrumentId, members] of rankGroups) {
+    const maxId = Math.max(...members.map((m) => m.score_id));
+    const latest = members.reduce((a, b) => (b.score_id > a.score_id ? b : a));
+    items.push({
+      kind: "rankMove",
+      tier: "informational",
+      id: `rank:${instrumentId}`,
+      symbol: latest.symbol,
+      instrumentId,
+      rank: latest.rank,
+      rankDelta: latest.rank_delta,
+      count: members.length,
+      latestTs: latest.scored_at,
+      sortKey: Date.parse(latest.scored_at),
+      maxId,
+      unseen: cursors.rank === null || maxId > cursors.rank,
     });
   }
 

--- a/sql/213_operators_alerts_rank_move_cursor.sql
+++ b/sql/213_operators_alerts_rank_move_cursor.sql
@@ -1,0 +1,22 @@
+-- #1922 — rank-move alert feed cursor.
+--
+-- A fourth dashboard alert feed (AlertsStrip #1898/#399): a HELD instrument
+-- whose deterministic rank moved materially between scoring runs. The
+-- "event" is a row in `scores` (append-only, one row per instrument per
+-- compute_rankings run) whose `rank_delta` magnitude clears the threshold.
+-- `scores.score_id` (BIGSERIAL PK, monotonic, unique) is the cursor — same
+-- rationale as migration 044's decision_id / migration 047's event_id: a
+-- TIMESTAMPTZ cursor (scored_at) is microsecond-resolution and NOT unique
+-- within a run (every instrument in a run shares one scored_at), which would
+-- leave a tie-break race; score_id closes it under strict `>` comparison.
+--
+-- NULL = never acknowledged (all in-window moves unseen), matching the other
+-- three cursor columns on `operators`.
+--
+-- No supporting index: the feed predicate gates on held instruments
+-- (EXISTS over `positions` WHERE current_units > 0 — a handful of rows), and
+-- the existing idx_scores_instrument_scored (instrument_id, scored_at DESC)
+-- covers the per-instrument recent-row lookup. The score_id > cursor bound is
+-- a cheap residual filter over that already-tiny row set.
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_rank_event_id BIGINT;

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1778,3 +1778,140 @@ class TestCoverageStatusDropsDismissAll:
             from app.db import get_conn
 
             app.dependency_overrides.pop(get_conn, None)
+
+
+# ---------------------------------------------------------------------------
+# #1922 — rank-move alert feed (held instrument's rank moved materially)
+# ---------------------------------------------------------------------------
+
+
+def _rank_move_row(
+    score_id: int = 104061,
+    instrument_id: int = 45,
+    symbol: str = "BBBY",
+    rank: int = 3679,
+    rank_delta: int = -43,
+) -> dict[str, object]:
+    return {
+        "score_id": score_id,
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "scored_at": datetime(2026, 7, 4, 1, 44, 23, tzinfo=UTC),
+        "rank": rank,
+        "rank_delta": rank_delta,
+    }
+
+
+def test_rank_moves_get_returns_shape_and_unseen_count(client: TestClient) -> None:
+    rows = [
+        _rank_move_row(score_id=104061, symbol="BBBY", rank=3679, rank_delta=-43),
+        _rank_move_row(score_id=104000, symbol="GME", instrument_id=44, rank=12, rank_delta=30),
+    ]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_rank_event_id": 103000},
+                {"unseen_count": 2},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/rank-moves")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alerts_last_seen_rank_event_id"] == 103000
+    assert body["unseen_count"] == 2
+    assert len(body["moves"]) == 2
+    assert body["moves"][0]["symbol"] == "BBBY"
+    assert body["moves"][0]["rank_delta"] == -43
+    assert body["moves"][1]["rank_delta"] == 30
+
+
+def test_rank_moves_get_null_cursor_serialises(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_rank_event_id": None},
+                {"unseen_count": 0},
+            ],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/rank-moves")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alerts_last_seen_rank_event_id"] is None
+    assert body["moves"] == []
+
+
+def test_rank_moves_get_sql_shape_pins_predicate(client: TestClient) -> None:
+    """The window predicate must pin the invariants the contract depends on:
+    - held-instrument scope (EXISTS positions WHERE current_units > 0)
+    - materiality threshold (abs(rank_delta) >= threshold, rank_delta NOT NULL)
+    - single model_version scope + 7-day window
+    - ORDER BY score_id DESC, LIMIT 500
+    - unseen count uses strict > on score_id
+    """
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_rank_event_id": None},
+                {"unseen_count": 0},
+            ],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/rank-moves")
+    assert resp.status_code == 200
+    list_sql = next(c.args[0] for c in cur.execute.call_args_list if "JOIN instruments i" in c.args[0])
+    assert "current_units > 0" in list_sql
+    assert "abs(s.rank_delta) >= %(threshold)s" in list_sql
+    assert "s.rank_delta IS NOT NULL" in list_sql
+    assert "s.model_version = %(mv)s" in list_sql
+    assert "INTERVAL '7 days'" in list_sql
+    assert "ORDER BY s.score_id DESC" in list_sql
+    assert "LIMIT 500" in list_sql
+    count_sql = next(c.args[0] for c in cur.execute.call_args_list if "COUNT(*) AS unseen_count" in c.args[0])
+    assert "s.score_id > %(last_id)s" in count_sql
+    # threshold + model_version bound in the params, not string-interpolated
+    params = next(c.args[1] for c in cur.execute.call_args_list if "JOIN instruments i" in c.args[0])
+    assert params["threshold"] == 20
+    assert params["mv"]
+
+
+def test_rank_moves_post_seen_writes_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/rank-moves/seen", json={"seen_through_rank_event_id": 104061})
+    assert resp.status_code == 204
+    calls = cur.execute.call_args_list
+    sql = next(c.args[0] for c in calls if "UPDATE operators" in c.args[0])
+    assert "GREATEST" in sql
+    assert "LEAST" in sql
+    assert "SELECT MAX(s.score_id)" in sql
+    assert "current_units > 0" in sql
+    params = next(c.args[1] for c in calls if "UPDATE operators" in c.args[0])
+    assert params["seen_through_rank_event_id"] == 104061
+    assert params["op"] == _OP_ID
+    cur._parent_conn.commit.assert_called_once()
+
+
+def test_rank_moves_post_seen_rejects_non_positive(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/rank-moves/seen", json={"seen_through_rank_event_id": 0})
+    assert resp.status_code == 422
+
+
+def test_rank_moves_post_dismiss_all_issues_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(rowcount=1)
+        resp = client.post("/alerts/rank-moves/dismiss-all")
+    assert resp.status_code == 204
+    calls = cur.execute.call_args_list
+    assert any("UPDATE operators" in c.args[0] and "SELECT MAX(s.score_id)" in c.args[0] for c in calls)
+    cur._parent_conn.commit.assert_called_once()
+
+
+def test_rank_moves_get_returns_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.get("/alerts/rank-moves")
+    assert resp.status_code == 503


### PR DESCRIPTION
Part of #1922 (follow-up to #1898 item 4). Adds the **rank-move** alert type; the two other listed types are deferred with reasons (see below + issue comment).

## What
A fourth AlertsStrip feed: a **held** instrument whose deterministic rank moved materially (`|rank_delta| >= 20`) between scoring runs.

**Backend** (`app/api/alerts.py` + migration 213):
- `operators.alerts_last_seen_rank_event_id` cursor (BIGINT, NULL = never acked), cursored over `scores.score_id`.
- `GET /alerts/rank-moves`, `POST /alerts/rank-moves/{seen,dismiss-all}` — identical cursor semantics to the coverage feed (strict `>`, 7-day window, `GREATEST+COALESCE+LEAST`, `m.max_id IS NOT NULL` empty-window guard).
- Single shared `_RANK_MOVE_WHERE` predicate across GET-count / GET-list / seen / dismiss so they can't drift.

**Frontend**: types + fetchers; `alertModel` gains a `rankMove` kind (grouped by instrument, latest `score_id` drives display, informational tier, `×N` for repeats); `AlertsStrip` wires the feed into loading/err guards, cursors, unseen/overflow math, mark-all-read, dismiss-all. `TierPill`/`CardShell` gain an optional label override so the card shows a `RANK` pill (informational tier is shared with guard).

## Source rule / data treatment
Not a data-treatment decision — an integrity/UX surface over the existing `scores.rank_delta` (`prior_rank - new_rank`, positive = moved up; computed within a `model_version` at `scoring.py:1820`). Threshold `20` is a documented product default. Feed scoped to `_DEFAULT_MODEL_VERSION` (single source of truth, imported) since `rank_delta` is model-scoped.

## Why the cursor is `score_id`
Every instrument in a run shares one `scored_at` (`run_at`, `scoring.py:1812`), so a timestamp cursor is non-unique within a run and leaves a tie-break race. `score_id` (BIGSERIAL PK) is monotonic + unique — same rationale as migration 044 (`decision_id`) / 047 (`event_id`).

## Conscious tradeoffs (Codex ckpt-2)
1. **Live held-predicate in seen/dismiss.** The predicate reads live `positions.current_units > 0`. Closing a held position removes its moves from GET/seen/dismiss alike (you no longer hold it); a reopen within 7d resurfaces its recent trajectory as unseen — desired "how it moved while you were out", not a leak (GET/seen share the predicate → you never ack what you can't see). Documented in code.
2. **Global cursor, model-scoped feed.** A default-model change is an operator-gated deploy (#1815/#1822) whose fresh run inserts the newest `score_id`s, so post-bump moves always sort above a week-old cursor. Documented in code.
3. **Group-by-instrument collapse.** Multiple in-window moves for one held instrument collapse to latest + `×N` (matches the coverage feed's group-latest design); the latest rank is the operator-relevant state.

## Deferred (documented on #1922)
- **Completeness-tier drops**: needs a derived last-two-runs diff (or an events table + trigger like migration 047) — separate design, next PR.
- **Thesis staleness**: a snapshot query (no append-stream cursor) and blocked on thesis-engine-live (#1919 / theses populated).

## Verification (DoD)
- Migration applied clean to **dev DB** (`run_migrations()` → column present).
- Dev-verified in-proc (TestClient vs dev DB): `GET /alerts/rank-moves` → **9 real in-window moves** for held **BBBY** (rank 3679, `rank_delta -43`), cursor NULL, seen/dismiss → 204. Operator cursor reset to NULL afterward (no pre-acked alerts left on dev).
- Backend tests (mock-cursor, `tests/test_api_alerts.py`, 7): response shape, SQL-shape pins (held `EXISTS` + threshold + `model_version` + 7d + `ORDER BY score_id DESC` + strict `>`), seen/dismiss UPDATE shape, validation (422), 503-no-operator.
- FE tests: `alertModel` grouping + seen; `AlertsStrip` RANK pill + up/down arrow + magnitude + instrument link.
- Gates: `ruff check` / `pyright` / fast tier (4760 passed) / smoke (141) / FE typecheck + `dark:check` + unit (1266 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)