### PR TITLE
docs(#1947): position detail page spec + eToro API live-portal freshness skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -129,14 +129,14 @@ Codex runs at exactly three points in the workflow. Non-negotiable.
 1. **Before writing code** — two Codex passes:
    - **After spec is written, before user final-approves:** `codex exec "Review this spec for <feature>. Path: docs/specs/<area>/<topic>.md (live spec) OR docs/proposals/<area>/<topic>.md (unshipped). Focus on correctness gaps, invariant violations, missing edge cases. For any ownership/filings/metric data-treatment decision: FLAG it if the spec infers the treatment from first principles where a documented source rule exists (SEC reg/Item, EDGAR, form spec) and is not cited; FLAG any signal whose safety rests on a sample rather than a full-population check. Reply terse."` Fix issues before presenting spec to user for sign-off.
    - **After implementation plan is written, before first task dispatch:** same invocation against the plan doc. Catches plan-shape bugs (bad task decomposition, missing dependency, wrong contract) before any subagent starts coding.
-2. **Before first push** — after self-review + local gates pass, run `codex.cmd exec review` on the branch. Fix anything real before pushing.
+2. **Before first push** — after self-review + local gates pass, run `codex exec review` on the branch. Fix anything real before pushing.
 3. **Before merging on a rebuttal-only round** — if the latest review's findings are all rebuttals (no code changes pending), run Codex to confirm the rebuttals are sound. Without this step, rebuttals are unverified and may hide real bugs the review bot *did* catch in disguise.
 
 When Codex is NOT required:
 - Follow-up pushes that fix review comments (the review bot will re-check).
 - Routine edits after Codex already reviewed the plan + first diff and there is no rebuttal-only round pending.
 
-Invocation rule: always use `codex.cmd exec` (non-interactive). Never bare `codex` (requires terminal).
+Invocation rule: always use `codex exec` (non-interactive). Never bare `codex` with no subcommand (requires interactive terminal).
 
 ## Review decision tree — who to consult in what order
 
@@ -273,6 +273,7 @@ Read and apply these before pushing:
 ### Data foundation skills (read before SEC ingest / schema / parser / metric work)
 
 - `.claude/skills/data-sources/sec-edgar.md` — source-of-truth: endpoints, formats, identifiers, gotchas (DD-MMM-YYYY dates, 13F PRN/SH, VALUE-cutover 2023-01-03, 13D/G XML mandate, etc.), rate-limit discipline, reference impls.
+- `.claude/skills/data-sources/etoro-api.md` — MANDATORY before citing any eToro API capability: live-portal verification protocol (llms.txt + per-endpoint .md, WebFetch not curl), known spec drift. Never claim "not supported by the public API" from memory.
 - `.claude/skills/data-sources/edgartools.md` — library reference: coverage matrix, API cheat-sheet, Pydantic validation cliff (#932), version pinning, decision tree for use-vs-roll-our-own.
 - `.claude/skills/data-engineer/SKILL.md` — what we own: schema invariants, two-layer ownership model, write-through pattern, settled-decisions cross-reference, "where does X come from?" FAQ, admin-page operator UX FAQ. Discoverable as the `data-engineer` skill.
 - `.claude/skills/metrics-analyst/SKILL.md` — every operator-visible metric: source → transform → table → endpoint → chart, with caveats and validation steps. Discoverable as the `metrics-analyst` skill.

--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -1,0 +1,28 @@
+# eToro API — live-portal freshness discipline
+
+## When to use
+
+Before citing, speccing, or implementing against ANY eToro API capability (endpoints, auth, rate limits, request/response shapes) — and before claiming an operation is "not supported by the public API".
+
+## The rule
+
+**Never cite eToro API capabilities from memory, from `docs/etoro-api-reference.md` alone, or from a previously downloaded spec.** The portal ships continuously and capabilities appear between our snapshots. Proven drift: spec v1.158.0 had `putTradeRequest` as an orphaned schema (edit-TP/SL "deliberately excluded from public API" — we designed workarounds around that); by v1.279.0 (2026-07-04) it was a shipped public endpoint, `PATCH /api/v2/trading/positions/{positionId}`, demo variant included, plus `UnitsToDeduct` partial close. A design was nearly built on the stale fact.
+
+## Verification protocol
+
+1. **Index:** fetch `https://api-portal.etoro.com/llms.txt` — lists every doc page slug, grouped (trading-real, trading-demo, market-data, …).
+2. **Endpoint detail:** fetch the specific page as markdown: `https://api-portal.etoro.com/api-reference/<section>/<slug>.md` — full method/path/body/response/auth/rate-limit per page.
+3. **Spec version:** the api-reference index page states the current OpenAPI version — record it in anything you write ("verified against vX.Y.Z on DATE").
+4. **Tooling:** use WebFetch (or the running app's HTTP client). **`curl` from CLI gets Cloudflare-blocked (403 "Attention Required")** — the portal allows browser-agent fetches only.
+5. When our code disagrees with the live doc but works (e.g. close body: doc says `InstrumentID` required, `close_position()` omits it), note the discrepancy where you found it and verify empirically on demo before relying on either.
+
+## Stable facts (re-verify anything load-bearing; last verified 2026-07-04, spec v1.279.0)
+
+- Base URL `https://public-api.etoro.com`; auth headers `x-api-key` + `x-user-key` + `x-request-id` (UUID); demo endpoints carry `/demo/` in the path.
+- Rate limits: 60 GET/min shared; writes ~20/min shared across related endpoints. 429 → `{"errorCode": "TooManyRequests"}`, no guaranteed Retry-After.
+- Trading (verified live): open by-amount/by-units; close per position with optional `UnitsToDeduct` (partial); **`PATCH /api/v2/trading[/demo]/positions/{positionId}`** for TP/SL edit (`stopLossRate`, `takeProfitRate`, `stopLossType` fixed|trailing, `clearStopLoss`, `clearTakeProfit`; ≥1 field; **202 async** `{operationId, positionId, referenceId}`).
+- Write ops are asynchronous (202) — re-sync portfolio before treating them as landed.
+
+## Maintenance
+
+When you verify a NEW capability or find drift: update `docs/etoro-api-reference.md` + the memory reference files in the same session (skill-ownership rule — no "later").

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -2,10 +2,13 @@
 
 Source of truth for how eBull integrates with eToro. Derived from the
 official OpenAPI spec at `https://api-portal.etoro.com/api-reference/openapi.json`
-(v1.158.0, 57 paths, 128 schemas — last verified 2026-04-14).
+(v1.279.0 — last verified 2026-07-04; the portal drifts fast, re-verify
+before citing capabilities: `.claude/skills/data-sources/etoro-api.md`).
 
 Portal: `https://api-portal.etoro.com/`
-LLM index: `https://api-portal.etoro.com/llms.txt`
+LLM index: `https://api-portal.etoro.com/llms.txt` (per-endpoint markdown at
+`api-reference/<section>/<slug>.md`). Cloudflare-fronted — CLI `curl` gets
+403; fetch with a browser-agent tool (WebFetch).
 
 ---
 
@@ -138,8 +141,9 @@ GET+POST requests cannot exceed the API limit.
 | POST | `/api/v1/trading/execution/market-open-orders/by-amount` | Open position by USD amount | **Active** |
 | POST | `/api/v1/trading/execution/market-open-orders/by-units` | Open position by unit count | **Active** |
 | DELETE | `/api/v1/trading/execution/market-open-orders/{orderId}` | Cancel pending open order | Not used (v1) |
-| POST | `/api/v1/trading/execution/market-close-orders/positions/{positionId}` | Close position | **Active** |
+| POST | `/api/v1/trading/execution/market-close-orders/positions/{positionId}` | Close position — body `UnitsToDeduct` nullable → partial close (omit = full). Live doc also lists `InstrumentID` required; our impl omits it — verify on demo before relying | **Active** (full close; partial plumbed in provider, unexposed) |
 | DELETE | `/api/v1/trading/execution/market-close-orders/{orderId}` | Cancel pending close order | Not used (v1) |
+| PATCH | `/api/v2/trading/positions/{positionId}` | Edit TP/SL on open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). **202 async** `{operationId, positionId, referenceId}` — re-sync before treating as landed. Added between v1.158 and v1.279 (was orphaned `putTradeRequest` schema) | Planned — position detail page (spec 2026-07-04) |
 | POST | `/api/v1/trading/execution/limit-orders` | Limit/MIT order | Not used (v1 is market-only) |
 | DELETE | `/api/v1/trading/execution/limit-orders/{orderId}` | Cancel limit order | Not used (v1) |
 | GET | `/api/v1/trading/info/portfolio` | Full portfolio: positions, orders, mirrors, credit | **Active** — portfolio sync |
@@ -149,7 +153,7 @@ GET+POST requests cannot exceed the API limit.
 
 ### Trading — Demo
 
-Same operations as Real, all prefixed with `/demo/` (e.g., `/api/v1/trading/execution/demo/market-open-orders/by-amount`).
+Same operations as Real, all prefixed with `/demo/` (e.g., `/api/v1/trading/execution/demo/market-open-orders/by-amount`; v2 TP/SL edit: `/api/v2/trading/demo/positions/{positionId}`).
 
 ### Agent portfolios (copy-trading management)
 

--- a/docs/superpowers/specs/2026-07-04-position-detail-page-design.md
+++ b/docs/superpowers/specs/2026-07-04-position-detail-page-design.md
@@ -1,0 +1,78 @@
+# Position detail page — per-trade TP/SL edit, partial close, three-level IA
+
+**Date:** 2026-07-04 · **Status:** approved (operator, this session) · **Supersedes direction of:** #1900 (instrument-tab close buttons), instrument-page Positions tab (#1899/#1926 placement)
+
+## Problem
+
+Per-trade rows shipped on the instrument page Positions tab (#1899/#1926) are display-only. Operator cannot set TP, set SL, or close a trade from eBull — all of which the eToro app supports per trade. Separately, the operator direction is that trade interaction does NOT belong on the instrument page at all.
+
+## Source rule (fintech IA convention + live eToro API)
+
+Three-level hierarchy, consistent across eToro, Schwab, IBKR, Fidelity:
+
+1. **Portfolio** — aggregates only; one row per holding. "How is my book doing?"
+2. **Position/holding detail** — one instrument's holding: summary header + component trades (eToro: trades with per-trade TP/SL/close; US brokers: tax lots with per-lot cost basis). **All interaction lives here.** "How am I doing in THIS, what do I do about it?"
+3. **Instrument/market page** — research about the asset (chart, financials, filings, news, verdict). "What is this thing?"
+
+Rule: act on what you OWN at level 2; study what it IS at level 3.
+
+eToro API (live portal, spec v1.279.0, verified 2026-07-04 — see `.claude/skills/data-sources/etoro-api.md`):
+
+- **Edit TP/SL on open position (PUBLIC, demo + real):** `PATCH /api/v2/trading/demo/positions/{positionId}` (real: no `/demo`). Body: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`|`trailing`), `clearStopLoss`, `clearTakeProfit` — ≥1 field required. Response 202 Accepted `{operationId, positionId, referenceId}` — **asynchronous**. Auth: same `x-api-key`/`x-user-key`/`x-request-id` headers. 60 req/60s shared quota.
+- **Partial close:** `POST /api/v1/trading/execution/demo/market-close-orders/positions/{positionId}` body `UnitsToDeduct` (nullable; omit = full close). Provider `close_position()` already accepts `units_to_deduct` — never exposed above provider level. ⚠ Live doc also lists `InstrumentID` (required) in the close body; our implementation omits it and works today — verify against live behaviour at implementation time.
+- **TP/SL at open:** already plumbed (`_order_body_common`: `StopLossRate`/`TakeProfitRate`/`IsTslEnabled`).
+
+## Design
+
+### Route + page
+
+New page `/portfolio/holdings/:symbol` (level 2). Reached by clicking a holding row on Portfolio. Instrument name/icon in its header links on to `/instruments/:symbol` (level 3).
+
+Top → bottom:
+
+1. **Holding header** — symbol, company name, held units, avg entry, total invested, market value, unrealized P&L, day change. Same figures as the Portfolio row (no summary/detail divergence).
+2. **Open trades table** — one row per broker trade: opened date, units, entry, current price, per-trade P&L, TP, SL (trailing badge when `stopLossType=trailing`). Row actions:
+   - **Edit TP/SL** — modal: set/adjust/clear TP and SL, fixed vs trailing toggle. Submits `PATCH /portfolio/positions/{position_id}/sltp`.
+   - **Close** — modal: units input (default = full trade) → partial close via `units_to_deduct`; shows est. proceeds + est. realized P&L; confirm required.
+   - Table header: **Close all** — sequential per-trade closes behind one confirm summary (total units, est. proceeds, est. P&L).
+3. **Closed round-trips** — the #1926 table, relocated here unchanged.
+4. **Position alerts** — position_monitor breaches (`sl_breach`/`tp_breach`/`thesis_break`) scoped to this instrument.
+
+### What moves / what dies
+
+- Instrument page **Positions tab: REMOVED** (operator decision). #1899 per-trade table and #1926 closed round-trips move to this page. `Held: Nu` badge on the instrument page links to `/portfolio/holdings/:symbol`.
+- Portfolio page: holding rows become links to the new page; existing inline Close/Add buttons on Portfolio rows delegate there (Add flow unchanged).
+- Activity tab stays as the global cross-instrument ledger.
+
+### Backend contract
+
+- Provider: new `update_position(position_id, *, stop_loss_rate=None, take_profit_rate=None, stop_loss_type=None, clear_stop_loss=False, clear_take_profit=False) -> BrokerOrderResult` → PATCH v2 endpoint (demo/real path from env, mirroring `_exec_prefix` pattern).
+- API: new `PATCH /portfolio/positions/{position_id}/sltp` (session auth). Validation: ≥1 field; TP above / SL below current price for longs (v1 long-only); rejects on instruments without an open broker position.
+- API: existing close endpoint gains optional `units` body field → provider `units_to_deduct`. Bounds: `0 < units <= trade units`.
+- **Execution guard + audit:** both writes go through the execution guard like existing closes; every accepted request writes an audit row (operation, operationId from the 202, requested values, operator, timestamp).
+- **202-async handling:** after PATCH/close accepted, trigger a portfolio re-sync, then refresh UI from DB. No optimistic UI writes. If the operation hasn't landed after sync, surface "pending at broker" state (statusID from order-info endpoint where available).
+
+### Safety model (unchanged invariants)
+
+- Every close/TP/SL change is an explicit, confirmed operator action. No auto-close from eBull; position_monitor remains read-only alerting.
+- Broker-side TP/SL is a standing instruction executed by eToro — setting it is the explicit act.
+- Demo-first: all endpoints exercised on demo env; real env untouched until operator go-live.
+
+### Out of scope (v1)
+
+- Lot-matching strategies / tax-optimizer views (UK S.104 pooling lives in the Tax page, #1905; per-trade P&L here is the broker view, not the CGT view — label it so).
+- Opening new positions from this page.
+- WebSocket live updates (#274) — page uses existing quote polling.
+
+## Testing
+
+- Pure-logic: TP/SL validation rules (side/price bounds, ≥1-field, clear-vs-set exclusivity), units bounds for partial close — table tests.
+- Provider: request-shape tests for `update_position` (body/path/headers, demo vs real prefix), mocked transport.
+- ONE DB-backed integration test for the sltp endpoint happy path (guard + audit row).
+- FE: modal validation + submit wiring unit tests; change-coupled FE-QA on the live page (screenshot, per feedback-change-coupled-fe-qa) before done.
+
+## Tickets
+
+- Supersede/redirect #1900 → this design (close stays, but on the new page; per-trade close UI is part of the page build).
+- New feature ticket: position detail page (FE+BE per this doc).
+- #1899/#1926: no code revert; tables relocate as part of the page build.


### PR DESCRIPTION
Part of #1947.

## What
Doc-only PR — no runtime code.

1. **`docs/superpowers/specs/2026-07-04-position-detail-page-design.md`** — operator-approved design for the position detail page: three-level IA (Portfolio aggregates → `/portfolio/holdings/:symbol` interaction surface → instrument page research-only), per-trade TP/SL edit via `PATCH /api/v2/trading[/demo]/positions/{positionId}` (202 async), partial close via `UnitsToDeduct`, instrument Positions tab removal. Implementation ticket: #1947 (supersedes #1900, closed).
2. **`.claude/skills/data-sources/etoro-api.md`** (NEW) — mandatory live-portal verification before citing any eToro API capability: llms.txt index + per-endpoint `.md` pages via WebFetch (CLI curl gets Cloudflare 403). Motivated by real drift caught by the operator this session: spec v1.158.0 had TP/SL edit as an orphaned private schema; v1.279.0 ships it public — a soft-TP/SL workaround design was nearly built on the stale fact.
3. **`docs/etoro-api-reference.md`** — version bump v1.158.0→v1.279.0 (verified 2026-07-04), PATCH v2 TP/SL row, `UnitsToDeduct` partial-close note + `InstrumentID` body discrepancy flag, portal fetch guidance.
4. **`.claude/CLAUDE.md`** — register the new skill in the data-foundation list; finish the `codex.cmd`→`codex` invocation fix (macOS binary is `codex`; `.cmd` is the Windows shim — a crashed session left the edit half-done).

## Security model
No code paths changed. The spec DESIGNS broker-write capabilities (TP/SL edit, partial close) — all specified to run through the existing execution guard + audit rows, demo env only, explicit operator confirmation per action (preserves the never-close-without-explicit-operator-action invariant). Nothing in this PR enables them.

## Verification
- Endpoint facts verified against the live portal 2026-07-04 (spec v1.279.0): PATCH v2 demo+real pages, close-by-units page, llms.txt index.
- Pre-push gate green locally (ruff, format, pyright, fast-tier pytest, smoke, chokepoint lints, dark-mode gate).

## Tradeoffs
- Doc-only diff: the Claude review bot auto-SKIPs these — merge rides CI green + skip semantics (precedent: #1911/#1944).
- `codex.cmd`→`codex` bundled here rather than its own PR: two-line instruction fix, same doc-only class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)