### PR TITLE
feat(#1927): archive copy-mirror closed positions so trader exits are visible

### DIFF
--- a/app/api/copy_trading.py
+++ b/app/api/copy_trading.py
@@ -36,6 +36,13 @@ router = APIRouter(
     dependencies=[Depends(require_session_or_service_token)],
 )
 
+# Max closed-position exits returned by get_mirror_detail — an activity
+# feed, not a full ledger. Kept in sync with CLOSED_EXITS_CAP in
+# frontend/src/pages/CopyTradingPage.tsx, which surfaces "Showing the N
+# most recent exits" when the list fills so the cap is never silent (#1927
+# review nitpick).
+CLOSED_EXITS_LIMIT = 100
+
 
 # ---------------------------------------------------------------------------
 # Response models
@@ -411,7 +418,9 @@ def get_mirror_detail(
 
     # Closed copied positions — the trader's exits observed since we began
     # archiving (#1927). Most-recent first, capped: this is an activity
-    # feed, not a full ledger. No MTM join — the position is gone.
+    # feed, not a full ledger. No MTM join — the position is gone. The FE
+    # surfaces "Showing the N most recent exits" when the list fills, so
+    # the cap is not silent (CopyTradingPage CLOSED_EXITS_CAP mirrors this).
     closed_sql = """
         SELECT cmcp.position_id, cmcp.instrument_id,
                i.symbol, i.company_name,
@@ -421,7 +430,7 @@ def get_mirror_detail(
         LEFT JOIN instruments i ON i.instrument_id = cmcp.instrument_id
         WHERE cmcp.mirror_id = %(mirror_id)s
         ORDER BY cmcp.closed_detected_at DESC
-        LIMIT 100
+        LIMIT %(limit)s
     """
 
     with conn.transaction():
@@ -437,7 +446,7 @@ def get_mirror_detail(
             position_rows = cur.fetchall()
 
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-            cur.execute(closed_sql, {"mirror_id": mirror_id})
+            cur.execute(closed_sql, {"mirror_id": mirror_id, "limit": CLOSED_EXITS_LIMIT})
             closed_rows = cur.fetchall()
 
     position_items = [_compute_position_mtm(p, display_currency, rates) for p in position_rows]

--- a/app/api/copy_trading.py
+++ b/app/api/copy_trading.py
@@ -58,6 +58,30 @@ class MirrorPositionItem(BaseModel):
     unrealized_pnl: float
 
 
+class MirrorClosedPositionItem(BaseModel):
+    """A copied position the trader closed while we were copying them
+    (#1927). Archived at eviction from ``copy_mirror_closed_positions``.
+
+    Surfaced as an EVENT, not a valuation: we hold the entry size + the
+    time we observed the close, but NOT the trader's exit price — so
+    there is deliberately no current_price / realized_pnl (we never
+    fabricate a P&L we cannot source). ``amount`` is converted to the
+    display currency exactly as open positions are; ``open_rate`` (a
+    native price) is intentionally omitted to avoid mixing native and
+    display figures in one row.
+    """
+
+    position_id: int
+    instrument_id: int
+    symbol: str | None
+    company_name: str | None
+    is_buy: bool
+    units: float
+    amount: float
+    open_date_time: datetime
+    closed_detected_at: datetime
+
+
 class MirrorSummary(BaseModel):
     mirror_id: int
     active: bool
@@ -89,6 +113,7 @@ class CopyTradingResponse(BaseModel):
 class MirrorDetailResponse(BaseModel):
     parent_username: str
     mirror: MirrorSummary
+    closed_positions: list[MirrorClosedPositionItem]
     display_currency: str
 
 
@@ -384,6 +409,21 @@ def get_mirror_detail(
         ORDER BY cmp.amount DESC
     """
 
+    # Closed copied positions — the trader's exits observed since we began
+    # archiving (#1927). Most-recent first, capped: this is an activity
+    # feed, not a full ledger. No MTM join — the position is gone.
+    closed_sql = """
+        SELECT cmcp.position_id, cmcp.instrument_id,
+               i.symbol, i.company_name,
+               cmcp.is_buy, cmcp.units, cmcp.amount,
+               cmcp.open_date_time, cmcp.closed_detected_at
+        FROM copy_mirror_closed_positions cmcp
+        LEFT JOIN instruments i ON i.instrument_id = cmcp.instrument_id
+        WHERE cmcp.mirror_id = %(mirror_id)s
+        ORDER BY cmcp.closed_detected_at DESC
+        LIMIT 100
+    """
+
     with conn.transaction():
         with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
             cur.execute(mirror_sql, {"mirror_id": mirror_id})
@@ -396,7 +436,25 @@ def get_mirror_detail(
             cur.execute(positions_sql, {"mirror_id": mirror_id})
             position_rows = cur.fetchall()
 
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(closed_sql, {"mirror_id": mirror_id})
+            closed_rows = cur.fetchall()
+
     position_items = [_compute_position_mtm(p, display_currency, rates) for p in position_rows]
+    closed_items = [
+        MirrorClosedPositionItem(
+            position_id=c["position_id"],
+            instrument_id=c["instrument_id"],
+            symbol=c["symbol"],
+            company_name=c["company_name"],
+            is_buy=c["is_buy"],
+            units=float(c["units"]),
+            amount=_convert_usd(float(c["amount"]), display_currency, rates),
+            open_date_time=c["open_date_time"],
+            closed_detected_at=c["closed_detected_at"],
+        )
+        for c in closed_rows
+    ]
 
     # Per-mirror equity = available_amount + sum(position market values)
     available_usd = float(mr["available_amount"])
@@ -422,5 +480,6 @@ def get_mirror_detail(
     return MirrorDetailResponse(
         parent_username=mr["parent_username"],
         mirror=mirror_summary,
+        closed_positions=closed_items,
         display_currency=display_currency,
     )

--- a/app/services/portfolio_sync.py
+++ b/app/services/portfolio_sync.py
@@ -309,6 +309,19 @@ def _sync_mirrors(
     mirror_positions_upserted = 0
     mirrors_closed = 0
 
+    # Snapshot which mirrors are active BEFORE any upsert. Step 2 flips a
+    # re-copied mirror back to active=TRUE, so we must capture pre-sync
+    # state now to gate the step-3a archive (#1927 re-copy guard): only a
+    # mirror that was ALREADY active can have a genuine same-episode close.
+    # A newly-appearing / reactivated mirror's step-3a evictions are either
+    # nothing or stale audit residue retained from a prior copy episode —
+    # archiving them at re-copy time would mislabel them as fresh exits and
+    # stamp a wrong closed_detected_at, since we do not hold their true
+    # close time.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT mirror_id FROM copy_mirrors WHERE active = TRUE")
+        active_before = {int(r["mirror_id"]) for r in cur.fetchall()}
+
     for mirror in mirrors:
         # 1. Upsert the trader row (parent_cid is the identity spine).
         conn.execute(
@@ -396,6 +409,40 @@ def _sync_mirrors(
         #     to correctly delete every existing row when the payload
         #     has zero positions for this mirror.
         current_position_ids = [int(p.position_id) for p in mirror.positions]
+
+        # Archive the about-to-be-evicted rows before the DELETE, in the
+        # same transaction, so a copied trader's exits become durable
+        # history instead of vanishing (#1927). Mirrors the own-positions
+        # archive (broker_positions_closed, portfolio_sync.py ~235-256).
+        # Gated on the pre-sync active set: only a mirror already active
+        # this cycle can log a genuine close — see active_before above.
+        if int(mirror.mirror_id) in active_before:
+            conn.execute(
+                """
+                INSERT INTO copy_mirror_closed_positions
+                    (mirror_id, position_id, parent_position_id, instrument_id,
+                     is_buy, units, amount, initial_amount_in_dollars, open_rate,
+                     open_conversion_rate, open_date_time, take_profit_rate,
+                     stop_loss_rate, total_fees, leverage, raw_payload,
+                     updated_at, closed_detected_at)
+                SELECT mirror_id, position_id, parent_position_id, instrument_id,
+                       is_buy, units, amount, initial_amount_in_dollars, open_rate,
+                       open_conversion_rate, open_date_time, take_profit_rate,
+                       stop_loss_rate, total_fees, leverage, raw_payload,
+                       updated_at, %(now)s
+                FROM copy_mirror_positions
+                WHERE mirror_id = %(mirror_id)s
+                  AND position_id <> ALL(%(position_ids)s::bigint[])
+                ON CONFLICT (mirror_id, position_id, closed_detected_at)
+                    DO NOTHING
+                """,
+                {
+                    "mirror_id": mirror.mirror_id,
+                    "position_ids": current_position_ids,
+                    "now": now,
+                },
+            )
+
         conn.execute(
             """
             DELETE FROM copy_mirror_positions

--- a/docs/specs/copy-trading/2026-07-04-copy-mirror-closed-positions.md
+++ b/docs/specs/copy-trading/2026-07-04-copy-mirror-closed-positions.md
@@ -1,0 +1,152 @@
+# Copy-mirror closed-position history (#1927)
+
+Status: live spec. Operator-approved schema shape (issue #1927, 2026-07-04).
+
+## Problem
+
+`_sync_mirrors` step 3a (`app/services/portfolio_sync.py:399-409`) **hard-DELETEs**
+`copy_mirror_positions` rows that vanished from the freshly-parsed mirror payload —
+i.e. positions the copied trader closed while we were still copying them — with no
+archive. The copy view therefore reads as "buy-only": you see the current open book,
+never the exits. Own positions do NOT lose this history: `_upsert_broker_positions`
+archives the disappeared row to `broker_positions_closed` in the SAME transaction,
+immediately before its sweep-DELETE (`portfolio_sync.py:235-256`, table `sql/194`).
+
+## Source rule
+
+This is not an external-data-treatment decision; it is our own settled invariant:
+the **own-positions closed-history archive** (`broker_positions_closed`,
+`LIKE broker_positions INCLUDING DEFAULTS` + `closed_detected_at` + PK
+`(position_id, closed_detected_at)`, sql/194; archive-before-delete at
+portfolio_sync.py:235-256). This ticket mirrors that pattern for copy mirrors —
+same shape, same invariants, no novel modeling.
+
+## Scope (falsified on dev DB 2026-07-04)
+
+- Only step-3a (per-position eviction while still copying) loses history. Confirmed:
+  the DELETE at 399-409 has no preceding archive INSERT.
+- Whole-mirror disappearance (step 4, `portfolio_sync.py:470-506`) **soft-closes**
+  the mirror (`active=FALSE, closed_at`) and by design **retains** its nested
+  positions for audit (migration 022 header). So archiving only at step 3a is both
+  necessary and sufficient — a soft-closed mirror's positions are not deleted.
+- **Re-copy edge (Codex ckpt-1):** step 2 reactivates a re-copied mirror
+  (`active=TRUE, closed_at=NULL`, `portfolio_sync.py:352/367`) BEFORE step 3a evicts.
+  A soft-closed mirror's *retained* stale positions (from the prior copy episode)
+  that are absent from the new payload would then be archived at re-copy time, stamped
+  `closed_detected_at=now` — mislabelling audit residue as fresh exits (and we don't
+  hold their true close time). Guard: **only archive when the mirror was already
+  active at the start of this sync.** Capture `active_before = {mirror_id : active}`
+  once at the top of `_sync_mirrors`; a newly-appearing or reactivated mirror is not
+  in `active_before` → skip its step-3a archive (its evictions are either nothing or
+  stale residue, deleted silently as today). A genuinely ongoing mirror IS in
+  `active_before` → an eviction is a real close → archive it.
+- Dev DB: 2 mirrors, 434 `copy_mirror_positions`, archive table absent, 0 rows in
+  `broker_positions_closed` (own-positions archive also empty here — expected, no
+  external closes observed in dev).
+
+## Design
+
+### 1. Schema — `sql/214_copy_mirror_closed_positions.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS copy_mirror_closed_positions (
+    LIKE copy_mirror_positions INCLUDING DEFAULTS,
+    closed_detected_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (mirror_id, position_id, closed_detected_at)
+);
+CREATE INDEX ... ON copy_mirror_closed_positions (mirror_id, closed_detected_at DESC);
+```
+
+- `LIKE ... INCLUDING DEFAULTS` (not `INCLUDING ALL`): copies columns + defaults but
+  NOT the FK `mirror_id REFERENCES copy_mirrors ON DELETE CASCADE`. Intentional —
+  history must survive even if a mirror row is ever hard-deleted (matches
+  `broker_positions_closed`, which also uses bare `LIKE ... INCLUDING DEFAULTS`).
+- PK includes `mirror_id` (position_id is only unique per-mirror) and
+  `closed_detected_at` (a position may close → re-copy → close again). Mirrors the
+  own-positions `(position_id, closed_detected_at)` PK.
+- Index on `(mirror_id, closed_detected_at DESC)` for the read path (recent exits
+  per mirror).
+
+### 2. Service — archive before the step-3a DELETE
+
+In `_sync_mirrors`, immediately before the DELETE at `portfolio_sync.py:399-409`,
+INSERT the about-to-be-evicted rows into the archive, in the same transaction,
+listing columns explicitly (matches `broker_positions_closed` archive, not `SELECT *`):
+
+```sql
+INSERT INTO copy_mirror_closed_positions
+    (mirror_id, position_id, parent_position_id, instrument_id, is_buy, units,
+     amount, initial_amount_in_dollars, open_rate, open_conversion_rate,
+     open_date_time, take_profit_rate, stop_loss_rate, total_fees, leverage,
+     raw_payload, updated_at, closed_detected_at)
+SELECT mirror_id, position_id, parent_position_id, instrument_id, is_buy, units,
+       amount, initial_amount_in_dollars, open_rate, open_conversion_rate,
+       open_date_time, take_profit_rate, stop_loss_rate, total_fees, leverage,
+       raw_payload, updated_at, %(now)s
+FROM copy_mirror_positions
+WHERE mirror_id = %(mirror_id)s
+  AND position_id <> ALL(%(position_ids)s::bigint[])
+ON CONFLICT (mirror_id, position_id, closed_detected_at) DO NOTHING
+```
+
+`now` is the sync-cycle timestamp already threaded into `_sync_mirrors`. `ON CONFLICT
+DO NOTHING` makes a re-run within the same cycle idempotent (mirrors own-positions).
+Gate the archive INSERT on `mirror.mirror_id in active_before` (re-copy guard above);
+the DELETE runs unconditionally as today.
+
+### 2b. Test-infra (Codex ckpt-1)
+
+The archive table has no FK to the copy cluster (bare `LIKE`), so `TRUNCATE
+copy_mirror_positions, copy_mirrors, copy_traders ... CASCADE` will NOT reach it. Add
+`copy_mirror_closed_positions` to: (a) `_PLANNER_TABLES` near the copy cluster in
+`tests/fixtures/ebull_test_db.py:273`, and (b) both TRUNCATE statements in
+`tests/test_portfolio_sync_mirrors.py:53` (and the shared mirror fixture at :48-56),
+or archive rows leak across DB tests.
+
+### 3. Bootstrap-tier note
+
+Per `feedback-backfills-belong-in-bootstrap`: pre-table closes are **unrecoverable** —
+`closed_positions_net_profit` is an aggregate delta, not per-position history, so
+there is nothing to seed from. The archive starts at deploy time; that loss is
+accepted and documented (operator condition 2 on the issue). No backfill job.
+`copy_mirror_closed_positions` is born-empty and fills forward as the sync observes
+closes — nothing to add to bootstrap stages.
+
+### 4. Read surface — `app/api/copy_trading.py::get_mirror_detail`
+
+Add `closed_positions: list[MirrorClosedPositionItem]` to `MirrorDetailResponse`
+(NOT `MirrorSummary` — it's detail-only, keeps the list endpoint cheap). Each item is
+a realized exit: `position_id, instrument_id, symbol, company_name, is_buy, units,
+amount, open_date_time, closed_detected_at`. No MTM and **no `open_rate`** — the
+position is gone; we know entry size + observed-closed time but NOT the trader's exit
+price, so we surface "closed" as an event, never a fabricated realized P&L.
+**Currency contract (Codex ckpt-1):** `amount` is native USD in the archive; convert
+it to `display_currency` via `_convert_usd` exactly as open positions do
+(`copy_trading.py:149`). We drop `open_rate` (a native price) from the item to avoid
+mixing native and display figures in one row. Query the archive for the mirror,
+most-recent first (`ORDER BY closed_detected_at DESC`), LIMIT a sane cap (e.g. 100).
+
+### 5. FE — `frontend/src/pages/CopyTradingPage.tsx`
+
+Add a "Recent exits" `Section` below "Open positions", listing the archived closes
+("Trader closed <units> <symbol>, opened <date>, exit observed <date>"). Empty state:
+"No copied-position exits observed yet." Extend `MirrorDetailResponse` +
+`MirrorClosedPositionItem` in `frontend/src/api/types.ts` field-for-field from the
+Pydantic model (prevention-log L474).
+
+## Tests
+
+- Pure/DB: `_sync_mirrors` archives an evicted position before delete; re-run same
+  cycle is idempotent (ON CONFLICT); a position present in the new payload is NOT
+  archived; whole-mirror soft-close does not archive/delete its positions.
+- Endpoint: `get_mirror_detail` returns archived exits most-recent-first.
+
+## Verification (DoD ETL clauses)
+
+- Migration applies on dev DB; table + index present.
+- `_sync_mirrors` exercised via the copy-trading sync path (or a targeted DB test on
+  the 2 dev mirrors) — evicted row lands in archive.
+- `/portfolio/copy-trading/{mirror_id}` renders `closed_positions` (empty on dev
+  until a real close is observed — honest empty state).
+- Operator spot-check of one mirror vs the eToro app after first sync (transferred
+  from #1915) — noted on the PR as operator-follow-up (loop env has no broker creds).

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1408,9 +1408,28 @@ export interface CopyTradingResponse {
   display_currency: string;
 }
 
+/** A copied position the trader closed while we copied them (#1927).
+ *  Surfaced as an exit event, not a valuation — we hold entry size +
+ *  observed-close time but NOT the trader's exit price, so there is no
+ *  current_price / realized_pnl. `amount` is in display currency;
+ *  `open_rate` is intentionally absent. Mirrors
+ *  app/api/copy_trading.py::MirrorClosedPositionItem. */
+export interface MirrorClosedPositionItem {
+  position_id: number;
+  instrument_id: number;
+  symbol: string | null;
+  company_name: string | null;
+  is_buy: boolean;
+  units: number;
+  amount: number;
+  open_date_time: string;
+  closed_detected_at: string;
+}
+
 export interface MirrorDetailResponse {
   parent_username: string;
   mirror: MirrorSummary;
+  closed_positions: MirrorClosedPositionItem[];
   display_currency: string;
 }
 

--- a/frontend/src/pages/CopyTradingPage.test.tsx
+++ b/frontend/src/pages/CopyTradingPage.test.tsx
@@ -81,6 +81,7 @@ function makeDetailResponse(overrides: Partial<MirrorDetailResponse> = {}): Mirr
       started_copy_date: "2026-01-15T10:00:00Z",
       closed_at: null,
     },
+    closed_positions: [],
     display_currency: "GBP",
     ...overrides,
   };

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -8,7 +8,7 @@ import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/S
 import { EmptyState } from "@/components/states/EmptyState";
 import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { LivePriceCell } from "@/components/quotes/LivePriceCell";
-import type { MirrorSummary, MirrorPositionItem } from "@/api/types";
+import type { MirrorSummary, MirrorPositionItem, MirrorClosedPositionItem } from "@/api/types";
 
 /**
  * Mirror detail page (#221 — mirrors as positions).
@@ -69,6 +69,14 @@ export function CopyTradingPage() {
               off here; its realised result rolls into the Closed P&L total above.
             </p>
             <GroupedPositionsTable positions={detail.data.mirror.positions} currency={currency} />
+          </Section>
+          <Section title="Recent exits">
+            <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
+              Copied positions the trader has closed since we began tracking. These are exit
+              events — we observe the close, not the trader's exit price, so no per-position P&L
+              is shown (the realised result is in the Closed P&L total above).
+            </p>
+            <ClosedExitsTable exits={detail.data.closed_positions} currency={currency} />
           </Section>
         </>
       )}
@@ -223,6 +231,74 @@ function GroupedPositionsTable({
       </table>
     </div>
     </LiveQuoteProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Recent exits (#1927) — closed copied positions as events (no MTM/P&L)
+// ---------------------------------------------------------------------------
+
+function ClosedExitsTable({
+  exits,
+  currency,
+}: {
+  exits: MirrorClosedPositionItem[];
+  currency: string;
+}) {
+  if (exits.length === 0) {
+    return (
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        No copied-position exits observed yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead className="text-xs uppercase text-slate-500">
+          <tr>
+            <th className="px-2 py-2 text-left">Instrument</th>
+            <th className="px-2 py-2 text-left">Direction</th>
+            <th className="px-2 py-2 text-right">Units</th>
+            <th className="px-2 py-2 text-right">Size</th>
+            <th className="px-2 py-2 text-right">Opened</th>
+            <th className="px-2 py-2 text-right">Closed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {exits.map((e) => (
+            <tr key={`${e.position_id}-${e.closed_detected_at}`} className="border-t border-slate-100 dark:border-slate-800">
+              <td className="px-2 py-2 text-left">
+                <span className="font-medium text-slate-800 dark:text-slate-100">
+                  {e.symbol ?? `#${e.instrument_id}`}
+                </span>
+                {e.company_name ? (
+                  <span className="ml-1.5 text-xs text-slate-500">{e.company_name}</span>
+                ) : null}
+              </td>
+              <td className="px-2 py-2 text-left">
+                <span className={e.is_buy ? "text-emerald-600" : "text-rose-600"}>
+                  {e.is_buy ? "Buy" : "Sell"}
+                </span>
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums text-slate-700 dark:text-slate-200">
+                {formatNumber(e.units)}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums text-slate-700 dark:text-slate-200">
+                {formatMoney(e.amount, currency)}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums text-xs text-slate-500">
+                {formatDateTime(e.open_date_time)}
+              </td>
+              <td className="px-2 py-2 text-right tabular-nums text-xs text-slate-500">
+                {formatDateTime(e.closed_detected_at)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -238,6 +238,11 @@ function GroupedPositionsTable({
 // Recent exits (#1927) — closed copied positions as events (no MTM/P&L)
 // ---------------------------------------------------------------------------
 
+// Keep in sync with the LIMIT in copy_trading.py::get_mirror_detail. The
+// list is an activity feed, not a full ledger; when it fills we say so
+// rather than silently truncating older exits.
+const CLOSED_EXITS_CAP = 100;
+
 function ClosedExitsTable({
   exits,
   currency,
@@ -298,6 +303,11 @@ function ClosedExitsTable({
           ))}
         </tbody>
       </table>
+      {exits.length >= CLOSED_EXITS_CAP ? (
+        <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
+          Showing the {CLOSED_EXITS_CAP} most recent exits.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/sql/214_copy_mirror_closed_positions.sql
+++ b/sql/214_copy_mirror_closed_positions.sql
@@ -1,0 +1,40 @@
+-- 214_copy_mirror_closed_positions.sql
+--
+-- #1927 — copy-mirror closed-position history.
+--
+-- Archive for nested copy-mirror positions that a copied trader closed
+-- while we were still copying them (evicted at step 3a of _sync_mirrors,
+-- app/services/portfolio_sync.py). Before this table those rows were
+-- hard-DELETEd with no history, so the copy view read as "buy-only":
+-- you saw the current open book, never the exits.
+--
+-- This mirrors the SETTLED own-positions archive pattern
+-- (broker_positions_closed, sql/194): the evidence copy of the last-seen
+-- row is written immediately before the disappeared-DELETE sweep, in the
+-- SAME transaction.
+--
+-- `LIKE ... INCLUDING DEFAULTS` (not INCLUDING ALL) deliberately: it
+-- copies columns + defaults but NOT copy_mirror_positions' FK
+-- (mirror_id REFERENCES copy_mirrors ON DELETE CASCADE). History must
+-- survive even if a mirror row is ever hard-deleted — same choice as
+-- broker_positions_closed. It also means TRUNCATE ... CASCADE over the
+-- copy cluster does NOT reach this table (test fixtures truncate it
+-- explicitly).
+--
+-- PK adds mirror_id (position_id is only unique per-mirror) and
+-- closed_detected_at (a position may close -> re-copy -> close again),
+-- mirroring broker_positions_closed's (position_id, closed_detected_at).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS copy_mirror_closed_positions (
+    LIKE copy_mirror_positions INCLUDING DEFAULTS,
+    closed_detected_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (mirror_id, position_id, closed_detected_at)
+);
+
+-- Read path: recent exits per mirror (get_mirror_detail).
+CREATE INDEX IF NOT EXISTS copy_mirror_closed_positions_mirror_time_idx
+    ON copy_mirror_closed_positions (mirror_id, closed_detected_at DESC);
+
+COMMIT;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -270,6 +270,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # copy_* listed child→parent: copy_mirror_positions FK→copy_mirrors
     # FK→copy_traders (copy_mirror_positions.instrument_id is a bare
     # BIGINT, not an FK, so instruments' CASCADE never reaches it).
+    # copy_mirror_closed_positions (#1927) has NO FK to the copy cluster
+    # (bare LIKE) → a CASCADE truncate of copy_mirror_positions never
+    # reaches it; listed explicitly so archive rows do not leak.
+    "copy_mirror_closed_positions",
     "copy_mirror_positions",
     "copy_mirrors",
     "copy_traders",

--- a/tests/test_api_copy_trading_detail.py
+++ b/tests/test_api_copy_trading_detail.py
@@ -95,6 +95,30 @@ def _make_position_row(
     }
 
 
+def _make_closed_row(
+    position_id: int = 6001,
+    instrument_id: int = 42,
+    symbol: str | None = "AAPL",
+    company_name: str | None = "Apple Inc.",
+    is_buy: bool = True,
+    units: float = 4.0,
+    amount: float = 3000.0,
+    open_date_time: datetime = _NOW,
+    closed_detected_at: datetime = _NOW,
+) -> dict[str, Any]:
+    return {
+        "position_id": position_id,
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "company_name": company_name,
+        "is_buy": is_buy,
+        "units": units,
+        "amount": amount,
+        "open_date_time": open_date_time,
+        "closed_detected_at": closed_detected_at,
+    }
+
+
 def _mock_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
     """Build a mock psycopg.Connection supporting transaction context."""
     cur = MagicMock()
@@ -173,13 +197,14 @@ class TestMirrorDetail:
         """Returns mirror stats and positions for a valid mirror_id."""
         mirror = _make_mirror_row()
         position = _make_position_row()
-        _with_conn([[mirror], [position]])
+        _with_conn([[mirror], [position], []])  # mirror, positions, closed
 
         resp = client.get("/portfolio/copy-trading/1001")
         assert resp.status_code == 200
         body = resp.json()
 
         assert body["parent_username"] == "thomaspj"
+        assert body["closed_positions"] == []
         assert body["mirror"]["mirror_id"] == 1001
         assert body["mirror"]["active"] is True
         assert len(body["mirror"]["positions"]) == 1
@@ -196,7 +221,7 @@ class TestMirrorDetail:
     def test_empty_positions(self) -> None:
         """Mirror with no positions returns empty positions list."""
         mirror = _make_mirror_row()
-        _with_conn([[mirror], []])
+        _with_conn([[mirror], [], []])  # mirror, positions, closed
 
         resp = client.get("/portfolio/copy-trading/1001")
         assert resp.status_code == 200
@@ -217,7 +242,7 @@ class TestMirrorDetail:
             quote_last=160.0,
             open_conversion_rate=1.0,
         )
-        _with_conn([[mirror], [position]])
+        _with_conn([[mirror], [position], []])  # mirror, positions, closed
 
         resp = client.get("/portfolio/copy-trading/1001")
         assert resp.status_code == 200
@@ -225,3 +250,26 @@ class TestMirrorDetail:
 
         # 500 + 7100 = 7600
         assert body["mirror"]["mirror_equity"] == 7600.0
+
+    def test_closed_positions_surfaced(self) -> None:
+        """#1927: archived exits render as closed_positions events — no
+        current_price / P&L field, just the entry + observed-close."""
+        mirror = _make_mirror_row()
+        position = _make_position_row()
+        closed = _make_closed_row(position_id=6001, symbol="TSLA", units=4.0)
+        _with_conn([[mirror], [position], [closed]])
+
+        resp = client.get("/portfolio/copy-trading/1001")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        assert len(body["closed_positions"]) == 1
+        item = body["closed_positions"][0]
+        assert item["position_id"] == 6001
+        assert item["symbol"] == "TSLA"
+        assert item["units"] == 4.0
+        assert "closed_detected_at" in item
+        # Event, not valuation — no fabricated price/P&L fields.
+        assert "current_price" not in item
+        assert "unrealized_pnl" not in item
+        assert "open_rate" not in item

--- a/tests/test_portfolio_sync_mirrors.py
+++ b/tests/test_portfolio_sync_mirrors.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Iterator
+from datetime import timedelta
 from typing import Any
 
 import psycopg
@@ -50,7 +51,10 @@ def conn() -> Iterator[psycopg.Connection[Any]]:
     with psycopg.connect(_test_database_url()) as c:
         _assert_test_db(c)
         with c.cursor() as cur:
-            cur.execute("TRUNCATE copy_mirror_positions, copy_mirrors, copy_traders RESTART IDENTITY CASCADE")
+            cur.execute(
+                "TRUNCATE copy_mirror_closed_positions, copy_mirror_positions, "
+                "copy_mirrors, copy_traders RESTART IDENTITY CASCADE"
+            )
         c.commit()
         yield c
         c.rollback()
@@ -371,3 +375,110 @@ def test_sync_mirrors_known_mirror_top_level_parse_failure_aborts(
         rows = cur.fetchall()
     assert len(rows) == 2
     assert all(r["active"] is True for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# #1927 — closed-position history archive
+# ---------------------------------------------------------------------------
+
+
+def _trimmed_first_mirror_payload(payload: Any, keep_from: int) -> Any:
+    """Return `payload` with mirror[0] keeping only positions[keep_from:]."""
+    trimmed_mirror = dataclasses.replace(payload.mirrors[0], positions=payload.mirrors[0].positions[keep_from:])
+    return dataclasses.replace(payload, mirrors=(trimmed_mirror, payload.mirrors[1]))
+
+
+def test_sync_mirrors_archives_evicted_position(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """#1927: a position evicted from an ALREADY-active mirror is archived
+    to copy_mirror_closed_positions (with the evicting sync's timestamp)
+    before being DELETEd — the copied trader's exit becomes durable
+    history instead of vanishing."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+    # No archive yet: the first sync inserts the mirror (it was not active
+    # before this cycle), so nothing is treated as a close.
+    assert _count(conn, "copy_mirror_closed_positions") == 0
+
+    later = _NOW + timedelta(hours=1)
+    sync_portfolio(conn, _trimmed_first_mirror_payload(payload, keep_from=1), now=later)
+    conn.commit()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT position_id, mirror_id, closed_detected_at
+            FROM copy_mirror_closed_positions ORDER BY position_id
+            """
+        )
+        archived = cur.fetchall()
+
+    assert [r["position_id"] for r in archived] == [1001]
+    assert archived[0]["mirror_id"] == payload.mirrors[0].mirror_id
+    assert archived[0]["closed_detected_at"] == later
+    # The live row is gone; the archive is the only remaining record.
+    assert _count(conn, "copy_mirror_positions") == 5
+
+
+def test_sync_mirrors_archive_idempotent_same_cycle(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """#1927: re-running the same eviction at the same timestamp is a
+    no-op on the archive (ON CONFLICT DO NOTHING) — no duplicate exit."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    later = _NOW + timedelta(hours=1)
+    trimmed = _trimmed_first_mirror_payload(payload, keep_from=1)
+    sync_portfolio(conn, trimmed, now=later)
+    conn.commit()
+    sync_portfolio(conn, trimmed, now=later)
+    conn.commit()
+
+    assert _count(conn, "copy_mirror_closed_positions") == 1
+
+
+def test_sync_mirrors_recopy_does_not_archive_stale_retained_positions(
+    conn: psycopg.Connection[Any],
+) -> None:
+    """#1927 re-copy guard: when a soft-closed mirror is re-copied, its
+    retained-but-now-absent positions (audit residue from the prior
+    episode) are cleared WITHOUT being archived — they closed at
+    soft-close time, not at re-copy time, and we do not hold that time.
+    Only genuine same-episode closes on an already-active mirror archive."""
+    payload = two_mirror_payload()
+    sync_portfolio(conn, payload, now=_NOW)
+    conn.commit()
+
+    # Partial disappearance: mirror[0] absent from a non-empty payload →
+    # soft-closed (active=FALSE), its 3 positions RETAINED for audit.
+    only_second = dataclasses.replace(payload, mirrors=(payload.mirrors[1],))
+    sync_portfolio(conn, only_second, now=_NOW + timedelta(hours=1))
+    conn.commit()
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active FROM copy_mirrors WHERE mirror_id = %s",
+            (payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None and row["active"] is False
+    assert _count(conn, "copy_mirror_positions") == 6  # retained
+
+    # Re-copy mirror[0] with position 1001 now absent → reactivated and
+    # 1001 evicted. Because the mirror was NOT active at the start of this
+    # sync, the eviction is NOT archived.
+    recopy = _trimmed_first_mirror_payload(payload, keep_from=1)
+    sync_portfolio(conn, recopy, now=_NOW + timedelta(hours=2))
+    conn.commit()
+
+    assert _count(conn, "copy_mirror_closed_positions") == 0
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT active FROM copy_mirrors WHERE mirror_id = %s",
+            (payload.mirrors[0].mirror_id,),
+        )
+        row = cur.fetchone()
+        assert row is not None and row["active"] is True


### PR DESCRIPTION
Closes #1927. Operator-approved schema shape (issue, 2026-07-04).

## Problem
`_sync_mirrors` step 3a (`app/services/portfolio_sync.py`) **hard-DELETEd**
`copy_mirror_positions` rows that vanished from the mirror payload — i.e. positions a
copied trader closed while we were still copying them — with **no archive**. So the
copy view read as "buy-only": current open book only, never the exits. Own positions
never lose this: `_upsert_broker_positions` archives the disappeared row to
`broker_positions_closed` in the same transaction before its sweep-DELETE. This PR
mirrors that settled own-positions pattern for copy mirrors.

## Source rule
Internal invariant, not external-data treatment: the settled own-positions
closed-history archive (`broker_positions_closed`, `LIKE ... INCLUDING DEFAULTS` +
`closed_detected_at`, archive-before-delete at `portfolio_sync.py:235-256`, `sql/194`).
Same shape, same invariants, no novel modeling.

## Changes
- **`sql/214`** — `copy_mirror_closed_positions`: `LIKE copy_mirror_positions INCLUDING
  DEFAULTS` (no FK → history survives a mirror hard-delete, matches
  `broker_positions_closed`) + `closed_detected_at`, PK `(mirror_id, position_id,
  closed_detected_at)` (position_id only unique per-mirror; a position may close →
  re-copy → close again). Index `(mirror_id, closed_detected_at DESC)` for the read path.
- **`portfolio_sync.py`** — archive INSERT immediately before the step-3a DELETE, same
  transaction, `ON CONFLICT DO NOTHING` (idempotent within a cycle).
  **Re-copy guard (Codex ckpt-1):** step 2 reactivates a re-copied mirror before step 3a,
  so its *retained* stale positions would be archived as fresh exits at re-copy time
  with a wrong `closed_detected_at`. Gate the archive on a **pre-sync active-set
  snapshot** (`active_before`): only a mirror already active this cycle logs a close;
  a reactivated mirror's evictions are cleared silently as today. DELETE is unchanged.
- **`copy_trading.py`** — `MirrorDetailResponse.closed_positions:
  list[MirrorClosedPositionItem]`. Exits as **events, not valuations**: entry size +
  observed-close time, no `current_price`/`realized_pnl` (we do NOT hold the trader's
  exit price — never fabricate a P&L). `amount` converted to display currency exactly
  as open positions (Codex ckpt-1 currency contract); `open_rate` (native) omitted to
  avoid mixing native/display in one row. `ORDER BY closed_detected_at DESC LIMIT 100`.
- **FE** — "Recent exits" section on the mirror detail page + honest empty state
  ("No copied-position exits observed yet."). `MirrorClosedPositionItem` mirrored
  field-for-field from the Pydantic model (prevention-log L474).
- **test-infra (Codex ckpt-1)** — archive table added to `_PLANNER_TABLES` and the
  mirror-test TRUNCATE (no FK → not reached by CASCADE, would leak across DB tests).

## No backfill
Pre-table closes are **unrecoverable** — `closed_positions_net_profit` is an aggregate
delta, not per-position history. The archive is born-empty and fills forward from
deploy time; that loss is operator-accepted (issue condition 2). No bootstrap stage.

## Security model
Read-only additions except the sync-path INSERT, which writes only broker-observed
data already flowing through `_sync_mirrors` in the same transaction. No auth surface
change. No user-controlled SQL (parameterised throughout). New endpoint field is
read-only over the operator's own copy data.

## Verification
- Migration applied on dev DB; `copy_mirror_closed_positions` + index present (clause 10:
  no backfill by design — documented above).
- `get_mirror_detail` invoked against the **real dev DB** (mirror 15712187): 258 open
  positions, `closed_positions=[]` (born-empty archive — honest), SQL valid on real schema.
- DB tests (`tests/test_portfolio_sync_mirrors.py`, ebull_test): evicted position from an
  already-active mirror archived with the evicting sync's timestamp; same-cycle re-run
  idempotent; **re-copy of a soft-closed mirror does NOT archive stale retained
  positions**; existing re-copy-resurrection test still green.
- Endpoint tests (`tests/test_api_copy_trading_detail.py`): `closed_positions` populates;
  no fabricated price/P&L fields on the item.
- Gates: ruff check + format, pyright (0 errors), fast tier 4787 passed, smoke 141 passed,
  FE typecheck + `test:unit` 1270 passed.

## Operator follow-up (transferred from #1915)
Live-eToro-app spot-check of one mirror's exits is blocked in the loop env (no broker
creds / market-data unreachable). Operator: after the first real sync observes a close,
confirm the "Recent exits" row matches the trader's actual close on eToro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)