### PR TITLE
fix(#1951): reports use canonical GICS sector, not coarse eToro label

### DIFF
--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -24,6 +24,7 @@ from psycopg.types.json import Jsonb
 
 from app.services.budget import FxRateUnavailable, compute_budget_state
 from app.services.fx import FxRateNotFound, convert
+from app.services.sector_classification import resolve_sector_spdr
 from app.services.valuation import PortfolioValuation, compute_portfolio_valuation
 
 logger = logging.getLogger(__name__)
@@ -1260,11 +1261,42 @@ def _cover_and_performance(
     return cover, performance
 
 
+def _gics_sectors(
+    conn: psycopg.Connection[Any],
+    instrument_ids: list[int],
+) -> dict[int, str]:
+    """Resolve each instrument's canonical GICS sector from its SEC SIC.
+
+    The report holdings/exposure surface must show the same sector as the
+    rest of the app — the instrument page, watchlist, and rankings all
+    prefer the SIC-derived GICS label over eToro's coarse numeric-industry
+    name (#1634/#1851; e.g. AAPL eToro="Consumer Goods" → GICS="Information
+    Technology"; GME eToro="Services" → "Consumer Discretionary"). SIC lives
+    in `instrument_sec_profile`, not `instruments`. Instruments with no SIC
+    (ETFs, non-SEC lines) are absent from the map so callers fall back to
+    the eToro label — matching the app-wide convention.
+    """
+    if not instrument_ids:
+        return {}
+    out: dict[int, str] = {}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT instrument_id, sic FROM instrument_sec_profile WHERE instrument_id = ANY(%(ids)s)",
+            {"ids": instrument_ids},
+        )
+        for r in cur.fetchall():
+            cls = resolve_sector_spdr(r["sic"])
+            if cls is not None:
+                out[int(r["instrument_id"])] = cls.gics_sector
+    return out
+
+
 def _holdings_section(
     valuation: PortfolioValuation,
     prior_positions: list[dict[str, Any]] | None,
     realized_now: dict[int, dict[str, Any]],
     opening_value: Decimal | None,
+    gics_by_id: dict[int, str],
 ) -> list[dict[str, Any]]:
     """Holdings-at-generation table rows (spec §4.5).
 
@@ -1300,10 +1332,12 @@ def _holdings_section(
                 "instrument_id": h.instrument_id,
                 "symbol": h.symbol,
                 "company_name": h.company_name,
-                # Resolved name, not the raw numeric industry id (#1598).
-                # None when the instrument has no sector or the id is
-                # unmapped — the FE renders its nil treatment.
-                "sector": h.sector_name,
+                # Canonical GICS sector (SIC-derived) to match the instrument
+                # page / watchlist / rankings (#1634/#1851); falls back to the
+                # resolved eToro industry name (#1598) when no SIC → no GICS
+                # (ETFs, non-SEC lines). None when neither is available — the
+                # FE renders its nil treatment.
+                "sector": gics_by_id.get(h.instrument_id) or h.sector_name,
                 "units": _dec_f(h.current_units),
                 "price": _dec_f(h.current_price),
                 "market_value": _dec_f(h.market_value),
@@ -1412,6 +1446,7 @@ def _risk_section(
     current_period_return: Decimal | None,
     *,
     observation_label: str,
+    gics_by_id: dict[int, str],
 ) -> dict[str, Any]:
     """Concentration + sector exposure (point-in-time, always
     computable) and volatility / max drawdown over the FULL snapshot
@@ -1426,17 +1461,20 @@ def _risk_section(
 
     sector_weights: dict[str, Decimal] = {}
     for h in valuation.holdings:
-        # instruments.sector stores eToro's numeric industry id; the name
-        # is resolved in the valuation query via etoro_stocks_industries
-        # (#1598). An id with no catalogue row folds into "Unknown" — warn
-        # so catalogue drift surfaces before it skews the exposure table.
-        if h.sector is not None and h.sector_name is None:
+        # Group by the canonical GICS sector (SIC-derived) so exposure bars
+        # match the holdings table and the instrument page (#1634/#1851).
+        # Fall back to the eToro industry name resolved in the valuation
+        # query via etoro_stocks_industries (#1598) when no SIC → no GICS
+        # (ETFs, non-SEC lines). An eToro id with no catalogue row folds into
+        # "Unknown" — warn so catalogue drift surfaces before it skews the
+        # exposure table.
+        if h.instrument_id not in gics_by_id and h.sector is not None and h.sector_name is None:
             logger.warning(
                 "sector id %s on %s has no etoro_stocks_industries row; grouped as Unknown",
                 h.sector,
                 h.symbol,
             )
-        sector = h.sector_name or "Unknown"
+        sector = gics_by_id.get(h.instrument_id) or h.sector_name or "Unknown"
         sector_weights[sector] = sector_weights.get(sector, Decimal(0)) + Decimal(str(h.market_value))
     sector_exposure = (
         {s: _dec_q(w / total_aum) for s, w in sorted(sector_weights.items(), key=lambda kv: kv[1], reverse=True)}
@@ -1633,11 +1671,13 @@ def generate_weekly_report(
         period_start=period_start,
         period_end=period_end,
     )
+    gics_by_id = _gics_sectors(conn, [h.instrument_id for h in valuation.holdings])
     holdings = _holdings_section(
         valuation,
         prior_positions,
         realized_now,
         _parse_dec(cover["opening_value"]),
+        gics_by_id,
     )
 
     return {
@@ -1720,11 +1760,13 @@ def generate_monthly_report(
         period_start=period_start,
         period_end=period_end,
     )
+    gics_by_id = _gics_sectors(conn, [h.instrument_id for h in valuation.holdings])
     holdings = _holdings_section(
         valuation,
         prior_positions,
         realized_now,
         _parse_dec(cover["opening_value"]),
+        gics_by_id,
     )
     current_period_return = _parse_dec(cover["period_return"])
     risk = _risk_section(
@@ -1732,6 +1774,7 @@ def generate_monthly_report(
         chain,
         current_period_return,
         observation_label="since inception, monthly observations",
+        gics_by_id=gics_by_id,
     )
     rolling_returns = _rolling_returns(
         conn,

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -818,7 +818,7 @@ class TestThesisSummary:
 class TestRiskSection:
     def test_insufficient_history_below_min_observations(self) -> None:
         val = _valuation_with((_holding(),))
-        risk = _risk_section(val, [], Decimal("0.05"), observation_label="test")
+        risk = _risk_section(val, [], Decimal("0.05"), observation_label="test", gics_by_id={})
         assert risk["insufficient_history"] is True
         assert risk["volatility"] is None
         assert risk["max_drawdown"] is None
@@ -831,7 +831,7 @@ class TestRiskSection:
             _holding(instrument_id=3, symbol="XOM", market_value=100.0, sector=None, sector_name=None),
         )
         val = _valuation_with(holdings, cash=0.0)
-        risk = _risk_section(val, [], None, observation_label="test")
+        risk = _risk_section(val, [], None, observation_label="test", gics_by_id={})
         assert risk["holding_count"] == 3
         # 3 holdings → top-5 = everything = 100%.
         assert Decimal(risk["concentration_top5_pct"]) == Decimal("1")
@@ -844,9 +844,41 @@ class TestRiskSection:
         holdings = (_holding(sector="99", sector_name=None),)
         val = _valuation_with(holdings, cash=0.0)
         with caplog.at_level(logging.WARNING, logger="app.services.reporting"):
-            risk = _risk_section(val, [], None, observation_label="test")
+            risk = _risk_section(val, [], None, observation_label="test", gics_by_id={})
         assert Decimal(risk["sector_exposure"]["Unknown"]) == Decimal("1")
         assert any("no etoro_stocks_industries row" in r.getMessage() for r in caplog.records)
+
+    def test_gics_sector_preferred_over_etoro_label_in_exposure(self) -> None:
+        """Exposure groups by the canonical GICS sector (#1634/#1851), not
+        the coarse eToro label. AAPL eToro="Consumer Goods" → GICS groups it
+        under "Information Technology"; an instrument absent from the GICS
+        map (ETF, no SIC) falls back to its eToro label."""
+        holdings = (
+            _holding(instrument_id=1, symbol="AAPL", market_value=600.0, sector_name="Consumer Goods"),
+            _holding(instrument_id=2, symbol="VOO", market_value=400.0, sector_name="Financial"),
+        )
+        val = _valuation_with(holdings, cash=0.0)
+        risk = _risk_section(
+            val,
+            [],
+            None,
+            observation_label="test",
+            gics_by_id={1: "Information Technology"},
+        )
+        assert Decimal(risk["sector_exposure"]["Information Technology"]) == Decimal("0.6")
+        # VOO has no GICS mapping → keeps its eToro label.
+        assert Decimal(risk["sector_exposure"]["Financial"]) == Decimal("0.4")
+        assert "Consumer Goods" not in risk["sector_exposure"]
+
+    def test_gics_present_suppresses_unmapped_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When GICS resolves, an unmapped eToro id must NOT warn — the row
+        is correctly grouped by GICS, not "Unknown"."""
+        holdings = (_holding(instrument_id=7, sector="99", sector_name=None),)
+        val = _valuation_with(holdings, cash=0.0)
+        with caplog.at_level(logging.WARNING, logger="app.services.reporting"):
+            risk = _risk_section(val, [], None, observation_label="test", gics_by_id={7: "Health Care"})
+        assert Decimal(risk["sector_exposure"]["Health Care"]) == Decimal("1")
+        assert not any("no etoro_stocks_industries row" in r.getMessage() for r in caplog.records)
 
     def test_drawdown_and_volatility_over_full_chain(self) -> None:
         chain = [
@@ -854,7 +886,7 @@ class TestRiskSection:
             for v in ("0.10", "-0.20", "0.05", "0.05", "0.05")
         ]
         val = _valuation_with((_holding(),))
-        risk = _risk_section(val, chain, Decimal("0.05"), observation_label="test")
+        risk = _risk_section(val, chain, Decimal("0.05"), observation_label="test", gics_by_id={})
         assert risk["observations"] == 6
         assert risk["insufficient_history"] is False
         # Max drawdown: peak after +10% = 1.1, trough after −20% = 0.88
@@ -868,7 +900,7 @@ class TestRiskSection:
             for _ in range(10)
         ]
         val = _valuation_with((_holding(),))
-        risk = _risk_section(val, chain, None, observation_label="test")
+        risk = _risk_section(val, chain, None, observation_label="test", gics_by_id={})
         assert risk["observations"] == 0
         assert risk["insufficient_history"] is True
 
@@ -962,7 +994,7 @@ class TestHoldingsSection:
             }
         ]
         realized_now = {1: {"symbol": "AAPL", "realized_pnl": Decimal("0")}}
-        rows = _holdings_section(val, prior_positions, realized_now, Decimal("1000"))
+        rows = _holdings_section(val, prior_positions, realized_now, Decimal("1000"), {})
         assert [r["symbol"] for r in rows] == ["AAPL", "JPM"]
         aapl = rows[0]
         assert aapl["weight_pct"] == "0.900000"
@@ -977,10 +1009,25 @@ class TestHoldingsSection:
     def test_no_prior_and_zero_cost_are_null_safe(self) -> None:
         holdings = (_holding(cost_basis=0.0, market_value=0.0, units=0.0),)
         val = _valuation_with(holdings, cash=0.0)
-        rows = _holdings_section(val, None, {}, None)
+        rows = _holdings_section(val, None, {}, None, {})
         assert rows[0]["since_entry_return_pct"] is None
         assert rows[0]["weight_pct"] is None
         assert rows[0]["period_contribution"] is None
+
+    def test_holdings_sector_prefers_gics_then_falls_back(self) -> None:
+        """Row `sector` is the GICS label when resolved (#1634/#1851),
+        else the eToro name, else None."""
+        holdings = (
+            _holding(instrument_id=1, symbol="GME", sector_name="Services"),
+            _holding(instrument_id=2, symbol="VOO", sector_name="Financial"),
+            _holding(instrument_id=3, symbol="X", sector=None, sector_name=None),
+        )
+        val = _valuation_with(holdings, cash=0.0)
+        rows = _holdings_section(val, None, {}, None, {1: "Consumer Discretionary"})
+        by_sym = {r["symbol"]: r["sector"] for r in rows}
+        assert by_sym["GME"] == "Consumer Discretionary"  # GICS wins over "Services"
+        assert by_sym["VOO"] == "Financial"  # no GICS → eToro label
+        assert by_sym["X"] is None  # neither → nil
 
 
 class TestRollingWindowContiguity:

--- a/tests/test_reporting_v2_db.py
+++ b/tests/test_reporting_v2_db.py
@@ -64,6 +64,18 @@ def _seed_portfolio(conn: psycopg.Connection[tuple]) -> None:
         ON CONFLICT (instrument_id) DO NOTHING
         """
     )
+    # Reports show the canonical SIC-derived GICS sector, not the coarse
+    # eToro label (#1634/#1851/#1951). SIC 3571 (Electronic Computers)
+    # crosswalks to GICS "Information Technology" — so the report must emit
+    # that, NOT the eToro id-42 "Technology" name (which is the fallback
+    # only when no SIC → no GICS).
+    conn.execute(
+        """
+        INSERT INTO instrument_sec_profile (instrument_id, cik, sic)
+        VALUES (789801, '0000789801', '3571')
+        ON CONFLICT (instrument_id) DO UPDATE SET sic = EXCLUDED.sic
+        """
+    )
     conn.execute(
         """
         INSERT INTO positions (instrument_id, open_date, avg_cost, current_units,
@@ -289,11 +301,15 @@ def test_v2_fixture_is_backend_emitted(ebull_test_conn: psycopg.Connection[tuple
         (_FIXTURE_DIR / "weekly.json").write_text(json.dumps(weekly, indent=2, sort_keys=True) + "\n")
         (_FIXTURE_DIR / "monthly.json").write_text(json.dumps(monthly, indent=2, sort_keys=True) + "\n")
 
-    # The id→name join must actually resolve (#1598): a broken
-    # etoro_stocks_industries lookup would silently emit sector=None /
-    # group everything as "Unknown" while the key-structure checks pass.
-    assert monthly["holdings"][0]["sector"] == "Technology"
-    assert "Technology" in monthly["risk"]["sector_exposure"]
+    # Sector must resolve to the canonical SIC-derived GICS label
+    # (#1634/#1851/#1951) end-to-end through the real generator + the
+    # `_gics_sectors` query, NOT the coarse eToro id-42 "Technology" name
+    # (which the seed keeps as the fallback source). A broken
+    # instrument_sec_profile join or crosswalk would regress to
+    # "Technology"/"Unknown" while the key-structure checks still pass.
+    assert monthly["holdings"][0]["sector"] == "Information Technology"
+    assert "Information Technology" in monthly["risk"]["sector_exposure"]
+    assert weekly["holdings"][0]["sector"] == "Information Technology"
 
     for name, generated in (("weekly", weekly), ("monthly", monthly)):
         fixture = json.loads((_FIXTURE_DIR / f"{name}.json").read_text())


### PR DESCRIPTION
Closes #1951. Item-5 of #1903, isolated as a self-contained DQ fix.

## What changed
Weekly/monthly period-statement **holdings** (`holdings[].sector`) and **sector exposure** (`risk.sector_exposure`) were labelled/grouped by eToro's coarse numeric-industry name (`GME = "Services"`), while the instrument page, dashboard watchlist and rankings all show the SIC-derived **GICS** sector (`GME = "Consumer Discretionary"`) per settled decisions #1634/#1851. Reports was the last straggler.

`reporting._gics_sectors(conn, ids)` batch-resolves each held instrument's GICS from `instrument_sec_profile.sic` via `app/services/sector_classification.resolve_sector_spdr`; `_holdings_section` and `_risk_section` prefer it, falling back to the resolved eToro label (`#1598`) when no SIC → no GICS (ETFs, non-SEC lines), then to nil.

## Source rule
Settled #1634/#1851: GICS (SIC-derived) is the canonical display sector everywhere; eToro label is fallback only. No first-principles reasoning — the crosswalk (`resolve_sector_spdr`) and preference order are the same ones the rest of the app already uses.

## Security / blast model
Display-only. Report `holdings[].sector` + `risk.sector_exposure` are consumed **only** by `frontend/src/components/reports/HoldingsSection.tsx`; no decision logic reads them (grep-verified). Execution-guard's sector-exposure **cap** (`_load_sector_exposure`) is a **separate path** and is untouched — the concentration safety invariant is unchanged. Not a scoring/`model_version`/`metric_version` input. Report snapshots are immutable point-in-time records, so the fix is **forward-only**: historical snapshots keep their stored labels; new snapshots emit GICS.

## Verification
- **Dev DB** (live generator, read-only rollback, weekly 29 Jun–5 Jul): `GME → Consumer Discretionary`, `BBBY → Consumer Discretionary`, `IEP → Energy`, `QQQ/VOO → Financial` (eToro fallback, no SIC). Matches the instrument page.
- **Full-population spot check**: `GME` SIC 5734→Consumer Discretionary, `AAPL` SIC 3571→Information Technology (the #1851 example), `IEP` SIC 2911→Energy.
- **Tests**: pure-logic — holdings-row + exposure GICS preference + eToro fallback + warn-suppression (`tests/test_reporting.py`). DB integration — `tests/test_reporting_v2_db.py` now seeds `instrument_sec_profile.sic=3571` and asserts the real weekly/monthly generator emits `Information Technology`, pinning the new `_gics_sectors` SQL end-to-end (Codex ckpt-2 gap).
- Gates green: `ruff check` / `format --check` / `pyright` clean; fast tier 4790 passed; smoke 141 passed; `test_reporting*` 68 passed.

## Tradeoffs
Resolved via a small batch query in `reporting.py` rather than threading `sic` through the shared `HoldingValuation` dataclass — keeps the blast radius to report generation and leaves the dashboard/portfolio valuation path untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)