### PR TITLE
fix(#1953): format instrument-header day-change to 2dp price precision

### DIFF
--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -190,6 +190,81 @@ describe("SummaryStrip — action gating", () => {
     );
   });
 
+  it("formats the day-change to 2dp price precision, not the raw native value (#1953)", () => {
+    render(
+      <SummaryStrip
+        summary={summary({
+          price: {
+            current: "22.77",
+            // native feed carries 6dp; must render as +0.13, not +0.130000
+            day_change: "0.130000",
+            day_change_pct: "0.0057",
+            day_change_as_of: "2026-07-03",
+            week_52_high: "40.00",
+            week_52_low: "10.00",
+            currency: "USD",
+            display_current: null,
+            display_currency: null,
+          },
+        })}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByText("+0.13 (+0.57%)")).toBeInTheDocument();
+    expect(screen.queryByText(/0\.130000/)).not.toBeInTheDocument();
+  });
+
+  it("renders a negative day-change with a single leading sign at 2dp (#1953)", () => {
+    render(
+      <SummaryStrip
+        summary={summary({
+          price: {
+            current: "22.77",
+            day_change: "-0.250000",
+            day_change_pct: "-0.011",
+            day_change_as_of: "2026-07-03",
+            week_52_high: "40.00",
+            week_52_low: "10.00",
+            currency: "USD",
+            display_current: null,
+            display_currency: null,
+          },
+        })}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByText("-0.25 (-1.10%)")).toBeInTheDocument();
+  });
+
+  it("renders a negative change that rounds to zero as +0.00, not -0.00 (#1953)", () => {
+    render(
+      <SummaryStrip
+        summary={summary({
+          price: {
+            current: "22.77",
+            day_change: "-0.004",
+            day_change_pct: "-0.0001",
+            day_change_as_of: "2026-07-03",
+            week_52_high: "40.00",
+            week_52_low: "10.00",
+            currency: "USD",
+            display_current: null,
+            display_currency: null,
+          },
+        })}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByText(/\+0\.00 \(/)).toBeInTheDocument();
+    expect(screen.queryByText(/-0\.00/)).not.toBeInTheDocument();
+  });
+
   it("omits the companion when there is no display-currency conversion (#1906)", () => {
     render(
       <SummaryStrip

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -45,6 +45,23 @@ function formatPrice(
   return currency ? `${currency} ${formatted}` : formatted;
 }
 
+// Absolute day-change, formatted to the same 2dp precision as the price
+// (formatPrice) with an explicit sign. The native price triple (#1906) can
+// carry >2dp, so rendering day_change raw leaks e.g. `+0.130000` (#1953).
+function formatChange(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "—";
+  // Sign off the rounded value so a magnitude that rounds to zero
+  // (e.g. -0.004 → -0.00) reads as "+0.00", not a bare "-0.00".
+  const rounded = Number(num.toFixed(2));
+  const formatted = Math.abs(rounded).toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+  });
+  return `${rounded >= 0 ? "+" : "-"}${formatted}`;
+}
+
 function formatPct(value: string | null | undefined, signed = false): string {
   if (value === null || value === undefined) return "—";
   const num = Number(value);
@@ -212,10 +229,7 @@ export function SummaryStrip({
               </span>
             ) : null}
             <span className={`text-sm tabular-nums ${changeColor}`}>
-              {price?.day_change != null && Number(price.day_change) >= 0
-                ? "+"
-                : ""}
-              {price?.day_change ?? "—"} (
+              {formatChange(price?.day_change)} (
               {formatPct(price?.day_change_pct, true)})
             </span>
             {/* #1924: stamp the day-change with its close date so a stale close


### PR DESCRIPTION
Closes #1953.

## Problem
On `/instrument/<symbol>` the header day-change absolute value rendered the raw native feed value — GME showed **`USD 22.77 … +0.130000 (+0.57%)`**. The price is formatted to 2 dp (`22.77`); the absolute change beside it leaked all 6 decimals.

## Root cause
`SummaryStrip.tsx` rendered `price.day_change` verbatim (manual `+` sign prefix, no numeric formatter), whereas the adjacent price goes through `formatPrice()` (`min/maxFractionDigits: 2`). The native price triple (#1906) can carry >2 dp, so the raw change leaked precision. Only render site (grep `.day_change`, one non-test block).

## Fix
Add `formatChange()` — same 2 dp precision as `formatPrice`, explicit sign, no currency prefix (it sits in parens next to the price). Sign is derived from the **rounded** value so a negative that rounds to zero (`-0.004`) reads `+0.00` not a bare `-0.00` (Codex ckpt-2 edge). Collapses the old manual sign logic. Null render unchanged (`—`).

FE-only; no backend / data-path change.

## Tests
`SummaryStrip.test.tsx` — 3 new cases: 6dp native value → `+0.13`, negative → `-0.25`, round-to-zero-negative → `+0.00`. Full unit suite green (1272 passing).

## Verify
Live dev vite serves the `~/Dev/eBull` checkout (not this worktree branch), so the header `+0.130000` I screenshotted **is** the live/main bug; it verifies once this merges and that checkout pulls. Unit tests gate the behaviour meanwhile.

Gates: `pnpm typecheck` ✓, `pnpm test:unit` ✓ (1272), `dark:check` ✓, skip-count ✓, Codex ckpt-2 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)