### PR TITLE
fix(#1955): render exchange name in instrument header, not raw numeric id

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -201,7 +201,14 @@ class InstrumentIdentity(BaseModel):
     # the TS `string | null` exactly (Codex ckpt-2).
     gics_sector: str | None
     sector_spdr: str | None
+    # Raw eToro numeric exchange id (filter key); NEVER render directly — use
+    # ``exchange_name`` (#1904/#1955). Kept for back-compat with the list model.
     exchange: str | None
+    # Human exchange label from ``exchanges.description`` (join on ``exchange``);
+    # null only if the id has no row. Required-nullable to mirror the TS
+    # ``string | null`` exactly. #1955: the summary header must render this, not
+    # the opaque numeric ``exchange``.
+    exchange_name: str | None
     country: str | None
     currency: str | None
     market_cap: Decimal | None
@@ -3660,6 +3667,7 @@ def get_instrument_summary(
         # ORDER BY / LIMIT needed.
         lookup_sql = f"""
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
+                   e.description AS exchange_name,
                    i.currency, i.sector, esi.name AS sector_name,
                    i.industry, i.country,
                    i.is_tradable, c.coverage_tier,
@@ -3682,6 +3690,7 @@ def get_instrument_summary(
     else:
         lookup_sql = f"""
             SELECT i.instrument_id, i.symbol, i.company_name, i.exchange,
+                   e.description AS exchange_name,
                    i.currency, i.sector, esi.name AS sector_name,
                    i.industry, i.country,
                    i.is_tradable, c.coverage_tier,
@@ -3724,6 +3733,7 @@ def get_instrument_summary(
         gics_sector=sector_cls.gics_sector if sector_cls is not None else None,
         sector_spdr=sector_cls.spdr_symbol if sector_cls is not None else None,
         exchange=row["exchange"],  # type: ignore[arg-type]
+        exchange_name=row["exchange_name"],  # type: ignore[arg-type]
         country=row["country"],  # type: ignore[arg-type]
         currency=row["currency"],  # type: ignore[arg-type]
         market_cap=None,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -309,7 +309,12 @@ export interface InstrumentIdentity {
    * no SIC (ETFs / non-filers) or no confident mapping. */
   gics_sector: string | null;
   sector_spdr: string | null;
+  /** Raw eToro numeric exchange id (filter key); NEVER render — use
+   * `exchange_name` (#1904/#1955). */
   exchange: string | null;
+  /** #1955: human exchange label from `exchanges.description`; the summary
+   * header renders this, never the opaque numeric `exchange`. */
+  exchange_name: string | null;
   country: string | null;
   currency: string | null;
   market_cap: string | null;

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -34,7 +34,8 @@ function summary(
       industry: "Consumer Electronics",
       gics_sector: null,
       sector_spdr: null,
-      exchange: "NMS",
+      exchange: "4",
+      exchange_name: "Nasdaq",
       country: "United States",
       currency: "USD",
       market_cap: "3000000000000",
@@ -159,6 +160,38 @@ describe("SummaryStrip — action gating", () => {
     expect(screen.getByText("AAPL")).toBeInTheDocument();
     expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
     expect(screen.getByText(/Technology/)).toBeInTheDocument();
+  });
+
+  it("renders the exchange name, never the raw numeric id (#1955)", () => {
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    const strip = screen.getByTestId("summary-strip");
+    expect(strip).toHaveTextContent("Nasdaq");
+    // The opaque numeric exchange id ("4") must not leak into the sector strip.
+    expect(strip).not.toHaveTextContent(/·\s*4\s*·/);
+  });
+
+  it("drops the exchange segment when exchange_name is null (#1955)", () => {
+    render(
+      <SummaryStrip
+        summary={summary({
+          identity: { ...summary().identity, exchange_name: null },
+        })}
+        thesis={null}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    // Falls back to nothing, never the raw id.
+    expect(screen.getByTestId("summary-strip")).not.toHaveTextContent(
+      /·\s*4\s*·/,
+    );
   });
 
   it("shows native price primary + display-currency companion (#1906)", () => {

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -255,7 +255,9 @@ export function SummaryStrip({
           ? ` (${identity.sector_spdr})`
           : ""}
         {identity.industry ? ` · ${identity.industry}` : ""}
-        {identity.exchange ? ` · ${identity.exchange}` : ""}
+        {/* #1955: render the human exchange label, never the opaque numeric
+            `exchange` id (which leaked as "· 4 ·"). */}
+        {identity.exchange_name ? ` · ${identity.exchange_name}` : ""}
         {identity.country ? ` · ${identity.country}` : ""}
       </div>
 

--- a/tests/test_api_instrument_summary.py
+++ b/tests/test_api_instrument_summary.py
@@ -118,6 +118,7 @@ def test_happy_path_with_quote_and_no_sec(client: TestClient) -> None:
         "symbol": "BTC",
         "company_name": "Bitcoin",
         "exchange": "8",
+        "exchange_name": "Digital Currency",
         "currency": "USD",
         "sector": None,
         "sector_name": None,
@@ -144,6 +145,10 @@ def test_happy_path_with_quote_and_no_sec(client: TestClient) -> None:
     assert body["identity"]["symbol"] == "BTC"
     assert body["identity"]["display_name"] == "Bitcoin"
     assert body["identity"]["currency"] == "USD"
+    # #1955: the human exchange label (exchanges.description) rides on the
+    # identity so the header renders it instead of the raw numeric id.
+    assert body["identity"]["exchange"] == "8"
+    assert body["identity"]["exchange_name"] == "Digital Currency"
     # No yfinance fill-in for sector/industry/country.
     assert body["identity"]["sector"] is None
     assert body["identity"]["sector_name"] is None
@@ -172,6 +177,7 @@ def test_no_quote_returns_null_price_block(client: TestClient) -> None:
         "symbol": "LRC",
         "company_name": "Loopring",
         "exchange": "8",
+        "exchange_name": "Digital Currency",
         "currency": "USD",
         "sector": None,
         "sector_name": None,
@@ -207,6 +213,7 @@ def test_bid_ask_mid_when_last_missing(client: TestClient) -> None:
         "symbol": "FOO",
         "company_name": "Foo Inc",
         "exchange": "NYSE",
+        "exchange_name": "NYSE",
         "currency": "USD",
         "sector": None,
         "sector_name": None,
@@ -241,6 +248,7 @@ def test_zero_last_uses_bid_ask_mid(client: TestClient) -> None:
         "symbol": "VOO",
         "company_name": "Vanguard S&P 500 ETF",
         "exchange": "NYSE",
+        "exchange_name": "NYSE",
         "currency": "USD",
         "sector": None,
         "sector_name": None,
@@ -274,6 +282,7 @@ def test_local_company_name_authoritative(client: TestClient) -> None:
         "symbol": "AAPL",
         "company_name": "Apple Inc.",
         "exchange": "NMS",
+        "exchange_name": "Nasdaq",
         "currency": "USD",
         "sector": "8",
         "sector_name": "Technology",
@@ -400,6 +409,7 @@ def test_id_override_pinned_lookup(client: TestClient) -> None:
         "symbol": "BTC.US",
         "company_name": "Grayscale Bitcoin Mini Trust",
         "exchange": "5",
+        "exchange_name": "NYSE",
         "currency": "USD",
         # #1599: prove the ?id= lookup branch also carries the resolved
         # sector_name (raw eToro id preserved, name resolved via the join).
@@ -451,6 +461,7 @@ def test_dividend_only_partial_stats_surface(client: TestClient) -> None:
         "symbol": "DIV",
         "company_name": "Dividend Co",
         "exchange": "NYSE",
+        "exchange_name": "NYSE",
         "currency": "USD",
         "sector": None,
         "sector_name": None,
@@ -518,6 +529,7 @@ def test_canonical_symbol_surfaced_for_rth_variant(client: TestClient) -> None:
         "symbol": "AAPL.RTH",
         "company_name": "Apple (RTH)",
         "exchange": "33",
+        "exchange_name": "Regular Trading Hours - RTH",
         "currency": None,
         "sector": None,
         "sector_name": None,
@@ -553,6 +565,7 @@ def test_canonical_symbol_null_for_canonical_instrument(client: TestClient) -> N
         "symbol": "AAPL",
         "company_name": "Apple Inc",
         "exchange": "4",
+        "exchange_name": "Nasdaq",
         "currency": "USD",
         "sector": "8",  # eToro numeric industry id (provider contract)
         "sector_name": "Technology",
@@ -588,6 +601,7 @@ def test_price_native_primary_with_display_companion(client: TestClient) -> None
         "symbol": "GME",
         "company_name": "GameStop Corp",
         "exchange": "4",
+        "exchange_name": "Nasdaq",
         "currency": "USD",
         "sector": None,
         "sector_name": None,
@@ -643,6 +657,7 @@ def test_price_companion_null_when_fx_rate_missing(client: TestClient) -> None:
         "symbol": "GME",
         "company_name": "GameStop Corp",
         "exchange": "4",
+        "exchange_name": "Nasdaq",
         "currency": "USD",
         "sector": None,
         "sector_name": None,


### PR DESCRIPTION
## What
The instrument-page header (`SummaryStrip`) rendered `identity.exchange` — the opaque eToro numeric exchange id — so AAPL's sector strip read:

```
Information Technology (XLK) · 4 · US
```

instead of `... · Nasdaq · US`. The SEC company-profile panel on the same page already shows "Nasdaq", so the header was internally inconsistent.

## Why
`#1904` added `exchange_name` (from `exchanges.description`) to the **list** model (`InstrumentListItem`) with an explicit contract — `app/api/instruments.py:152`: *"NEVER render directly — use `exchange_name`."* But the **summary** identity path never got it:
- `InstrumentIdentity` exposed only raw `exchange`.
- The summary lookup SQL already `LEFT JOIN exchanges e ON e.exchange_id = i.exchange` but never selected `e.description`.
- `SummaryStrip.tsx` rendered the raw id, violating #1904's own rule.

## Change
- **Backend** (`app/api/instruments.py`): add `exchange_name: str | None` to `InstrumentIdentity`; `SELECT e.description AS exchange_name` in both summary lookup branches; populate it.
- **Frontend** (`types.ts`, `SummaryStrip.tsx`): add `exchange_name` to the identity type; render `identity.exchange_name`, never the raw numeric `exchange`. Falls back to nothing (not the raw id) if ever null.
- **Tests**: SummaryStrip render + null-drop regression guards; summary-endpoint mock fixtures updated with `exchange_name` + a serialization assertion.

## Full-population verification
```sql
SELECT count(*) total, count(*) FILTER (WHERE e.description IS NULL) missing
FROM instruments i LEFT JOIN exchanges e ON e.exchange_id=i.exchange WHERE i.is_tradable;
-- (12597, 0)
```
Every one of the 12,597 tradable instruments resolves to an exchange description (AAPL "4"→"Nasdaq"). No instrument loses the line; none shows a raw id.

## Scope / safety
FE + API display only. No schema, parser, ingest, or backfill. No settled-decision touched. Operator-visible figure: instrument header exchange label.

## Verification
- FE: `pnpm typecheck` clean; `test:unit` 1275 pass (incl. new #1955 guards).
- Backend: `ruff`/`pyright` clean; fast tier 4790 pass; smoke 141 pass; `tests/test_api_instrument_summary.py` 16 pass.
- Codex ckpt-2 caught the stale summary-endpoint fixtures pre-push (now fixed).
- Live end-to-end validates after merge (dev API serves the `~/Dev/eBull` checkout; header already confirmed rendering `Nasdaq` off the branch source).

Closes #1955