### PR TITLE
fix(#1957): de-dupe SEC-profile exchanges for venue display

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1360,6 +1360,20 @@ class InstrumentSecProfile(BaseModel):
     has_insider_owner: bool | None
 
 
+def _distinct_ordered(items: list[str]) -> list[str]:
+    """Order-preserving de-dup for display lists.
+
+    SEC ``submissions.json`` publishes ``exchanges[]`` index-aligned with
+    ``tickers[]`` — one entry per listed security, NOT a distinct-venue list
+    (GME: tickers ``['GME','GME-WT']`` → exchanges ``['NYSE','NYSE']``). We
+    drop the parallel ``tickers`` array, so the per-security alignment carries
+    no meaning downstream and the raw array renders as a duplicated venue list
+    (#1957). The service layer stays faithful to the raw SEC payload; the
+    API boundary presents distinct venues for display.
+    """
+    return list(dict.fromkeys(items))
+
+
 @router.get("/{symbol}/sec_profile", response_model=InstrumentSecProfile)
 def get_instrument_sec_profile(
     symbol: str,
@@ -1431,7 +1445,7 @@ def get_instrument_sec_profile(
         state_of_incorporation_desc=profile.state_of_incorporation_desc,
         fiscal_year_end=profile.fiscal_year_end,
         category=profile.category,
-        exchanges=profile.exchanges,
+        exchanges=_distinct_ordered(profile.exchanges),
         former_names=[
             FormerNameModel(
                 name=str(fn["name"]),

--- a/tests/api/test_instruments_sec_profile_endpoint.py
+++ b/tests/api/test_instruments_sec_profile_endpoint.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.api.instruments import _distinct_ordered
 from app.api.instruments import router as instruments_router
 from app.db import get_conn
 from app.services.sec_entity_profile import SecEntityProfile
@@ -114,3 +116,32 @@ def test_sec_profile_endpoint_blank_symbol_rejected() -> None:
     # FastAPI path-param routing treats " " as a valid symbol, so the
     # 400 short-circuit inside the handler fires.
     assert resp.status_code == 400
+
+
+# --- #1957: SEC submissions ``exchanges[]`` is per-ticker, not per-venue ------
+# Pure-logic test (no DB / no TestClient → fast tier). GME lists common stock
+# + a warrant on the same venue, so EDGAR returns ['NYSE','NYSE']; the display
+# list must collapse to distinct venues while preserving first-seen order.
+def test_distinct_ordered_dedupes_preserving_order() -> None:
+    assert _distinct_ordered(["NYSE", "NYSE"]) == ["NYSE"]
+    assert _distinct_ordered(["NYSE", "NASDAQ", "NYSE"]) == ["NYSE", "NASDAQ"]
+    assert _distinct_ordered(["NASDAQ"]) == ["NASDAQ"]
+    assert _distinct_ordered([]) == []
+
+
+def test_sec_profile_endpoint_dedupes_exchanges() -> None:
+    """Boundary wiring: a per-ticker duplicate venue (GME-shape) collapses."""
+    conn = MagicMock()
+    conn.cursor.return_value = _cursor_with([{"instrument_id": 1, "symbol": "GME"}])
+    app = _build_app(conn)
+
+    profile = replace(_sample_profile(), exchanges=["NYSE", "NYSE"])
+    with (
+        patch("app.services.sec_entity_profile.get_entity_profile", return_value=profile),
+        patch("app.services.business_summary.get_business_summary", return_value=None),
+        TestClient(app) as client,
+    ):
+        resp = client.get("/instruments/GME/sec_profile")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["exchanges"] == ["NYSE"]


### PR DESCRIPTION
## What
Company Profile on `/instrument/<sym>` rendered **`NYSE, NYSE`** for GME. Fixed to show distinct venues.

## Root cause / source rule
SEC EDGAR `submissions.json` publishes `exchanges[]` **index-aligned with `tickers[]`** — one entry per listed security, NOT a distinct-venue list. Verified live (data.sec.gov CIK0001326380, 2026-07-04):
```
tickers:   ['GME', 'GME-WT']   # common stock + warrant
exchanges: ['NYSE', 'NYSE']    # both on NYSE
```
`InstrumentSecProfile.exchanges` is consumed **display-only** (`SecProfilePanel.tsx:98` → `profile.exchanges.join(", ")`); we drop the parallel `tickers` array, so the positional alignment carries no downstream meaning. Rendering the raw array duplicates the venue.

## Fix
Order-preserving de-dup (`list(dict.fromkeys(...))`) at the API presentation boundary in `get_instrument_sec_profile`. Service / storage / change-log paths keep the raw SEC array faithful — a consumer that ever needs SEC fidelity can read below the endpoint.

## Security model
No auth/authz change. Read-only endpoint, display transform only. No user input flows into the change.

## Tradeoffs
De-dup at the API boundary, not ingest: keeps the stored value faithful to SEC and fixes every existing row instantly with **no backfill / no schema / no ingest change**.

## Tests
- `test_distinct_ordered_dedupes_preserving_order` — pure logic (fast tier): dupes collapse, order preserved, distinct venues both kept, empty-safe.
- `test_sec_profile_endpoint_dedupes_exchanges` — endpoint wiring: GME-shape `['NYSE','NYSE']` → `['NYSE']`.

## Verification
- Confirmed live API returned `exchanges: ['NYSE','NYSE']` for GME before fix (via cookie-authed proxy).
- `dict.fromkeys` collapse proven by tests; 6 passed.
- Live `:8000` endpoint verify not run here: the running dev stack serves `~/Dev/eBull`, not this worktree branch (known worktree-shadow). Change is display-only + unit-proven; renders correctly once merged to main.

Closes #1957