### PR TITLE
fix(#1959): count /admin problems from the processes catalogue, not the legacy jobs list

### DIFF
--- a/docs/specs/frontend/2026-07-04-problems-panel-processes-source.md
+++ b/docs/specs/frontend/2026-07-04-problems-panel-processes-source.md
@@ -1,0 +1,42 @@
+# Spec: /admin ProblemsPanel — count problems from the processes catalogue, not the legacy jobs list (#1959)
+
+## Problem
+`/admin` shows two disagreeing problem counts on one page:
+- Top **ProblemsPanel** banner: "1 problem(s) need attention" — its failing-job sub-source is `/system/jobs` (`fetchJobsOverview`, 43 rows), filtered `health_verdict === "attention"`.
+- **Processes control hub** (`ProcessesTable` → `StaleBanner`): "2 need attention: fundamentals_sync, nport_sweep" — reads `/system/processes` (50 rows), counting `health_verdict === "attention"` over steady-state rows.
+
+`nport_sweep` (and the other `sec_*_sweep` ingest sweeps) are `mechanism = "ingest_sweep"` processes that the `/system/jobs` registry does not represent, so the top banner structurally cannot see their failures and under-reports.
+
+## Source rule / falsification (verified live @ 8357f1c9, service-token curl)
+- `/system/jobs` (43) is a **strict subset** of `/system/processes` (50): `set(jobs) - set(processes) == {}`. Delta = `bootstrap` + 6 `ingest_sweep` rows (`nport_sweep`, `sec_13f_sweep`, `sec_8k_sweep`, `sec_def14a_sweep`, `sec_form3_sweep`, `sec_form4_sweep`).
+- Processes attention set = `{fundamentals_sync (scheduled_job), nport_sweep (ingest_sweep)}`, both `role=steady_state`. Jobs attention set = `{fundamentals_sync}`.
+- Control-hub count is computed by `ProcessesTable` → `steadyStateRows` (`role === "steady_state" && mechanism !== "bootstrap"`) → `StaleBanner` filters `health_verdict === "attention"`.
+- v2 layers `action_needed`/`secret_missing` are keyed by `root_layer` at a different granularity; `orchestrator_full_sync` already appears in BOTH the jobs list and processes today, so switching the source introduces **no new** overlap-with-layers double-count class.
+- `health_verdict === "attention"` already excludes `stale_manual`/`paused`/`working`/`current` (#1689/#1831), so aged bootstrap/backfill one-shots do not false-red.
+
+## Change (FE only, display reconciliation — no health-verdict logic change)
+1. New shared helper `frontend/src/lib/processHealth.ts`:
+   - `isSteadyStateProcess(r)` = `r.role === "steady_state" && r.mechanism !== "bootstrap"` (the exact `!isBootstrapOrBackfill` predicate from `ProcessesTable`).
+   - `steadyStateAttentionRows(rows)` = `rows.filter(isSteadyStateProcess).filter(r => r.health_verdict === "attention")`.
+   - `ProcessesTable` imports `isSteadyStateProcess` (replacing its local `isBootstrapOrBackfill`) so the two surfaces share ONE predicate and cannot drift again (this is the bug's own lesson).
+2. `ProblemsPanel`:
+   - Replace props `jobs: JobsListResponse | null` / `jobsError` with `processes: ProcessListResponse | null` / `processesError`.
+   - Cache key `jobs` → `processes`; pending-source label `"jobs"` → `"processes"`.
+   - `failingProcesses = steadyStateAttentionRows(cache.processes?.rows ?? [])`.
+   - Row render uses `ProcessRowResponse` fields: label `display_name`, reason `verdict_reason`, failed-at `last_run?.finished_at`, drill link `/admin/processes/{process_id}` (the modern ProcessDetailPage; `nport_sweep` has no `/admin/jobs` route). "Clears when the next run of {display_name} succeeds."
+3. `AdminPage`: pass `processes={processes.data}` / `processesError={processes.error !== null}` (both already fetched via `useProcesses()`), drop the `jobs`/`jobsError` props to the panel. The separate "Background tasks" jobs table below is unchanged (still uses `jobs.data`).
+
+## Deliberate scope change (Codex ckpt-1)
+The old jobs source counted ANY `/system/jobs` row with `health_verdict === "attention"` — including `role="bootstrap"`/`role="backfill"` scheduled jobs. The new steady-state predicate intentionally excludes those, so a freshly-failed bootstrap/backfill one-shot no longer raises the TOP red banner. This is correct, not a regression: the control-hub (#1530 C7) already folds bootstrap/backfill into a separate collapsed section and excludes them from its "N need attention" count. Matching that scope is the entire objective (the two counts must agree; the control-hub scope is canonical). Bootstrap/backfill attention still surfaces in the Processes "Bootstrap & backfill" section. Live attention set today = `{fundamentals_sync, nport_sweep}` (both steady-state) → no live row is dropped. Codified by a test asserting a `role="backfill"` attention row is NOT counted by the top banner.
+
+## Non-goals
+- No backend change. No health-verdict semantics change. The layer/secret/coverage/credential sub-sources of ProblemsPanel are untouched.
+- No dedupe of existing layer↔process overlap. If a v2 `action_needed` root layer and a process attention row describe the same failure they still count twice, exactly as today — the swap only replaces the jobs sub-source with the superset processes source; it does not change overlap behaviour.
+
+## Tests
+- `ProblemsPanel.test.tsx`: swap the failing-job fixtures to `ProcessRowResponse` rows; assert an `ingest_sweep` attention row (nport_sweep) is counted + rendered with a `/admin/processes/nport_sweep` link; assert a `role !== "steady_state"` / `mechanism === "bootstrap"` attention row is NOT counted; assert `health_verdict !== "attention"` rows excluded.
+- `processHealth.test.ts`: unit-table the predicate + selector.
+- `AdminPage.test.tsx`: update prop wiring.
+
+## Verification (dev)
+- Load `/admin`, confirm top banner reads "2 problem(s) need attention" and lists fundamentals_sync + nport_sweep, matching the control hub below. Spot-check against `/system/processes`.

--- a/frontend/src/components/admin/ProblemsPanel.test.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.test.tsx
@@ -4,31 +4,12 @@ import { MemoryRouter } from "react-router-dom";
 
 import type {
   CoverageSummaryResponse,
-  JobOverviewResponse,
-  JobsListResponse,
+  ProcessListResponse,
   SyncLayersV2Response,
 } from "@/api/types";
 
+import { makeProcessList, makeProcessRow } from "./__fixtures__/processes";
 import { ProblemsPanel } from "./ProblemsPanel";
-
-// #1689 — JobOverviewResponse gained six verdict fields. These fixtures don't
-// exercise them; spread sane defaults so the literals stay type-complete.
-const JOB_VERDICT_DEFAULTS: Pick<
-  JobOverviewResponse,
-  | "health_verdict"
-  | "self_healing"
-  | "verdict_reason"
-  | "role"
-  | "attempt"
-  | "next_retry_at"
-> = {
-  health_verdict: "current",
-  self_healing: false,
-  verdict_reason: "",
-  role: "steady_state",
-  attempt: null,
-  next_retry_at: null,
-};
 
 
 function emptyV2(): SyncLayersV2Response {
@@ -47,8 +28,8 @@ function emptyV2(): SyncLayersV2Response {
 }
 
 
-function emptyJobs(): JobsListResponse {
-  return { checked_at: new Date().toISOString(), jobs: [] };
+function emptyProcesses(): ProcessListResponse {
+  return makeProcessList([]);
 }
 
 
@@ -72,10 +53,10 @@ function renderPanel(
 ): ReturnType<typeof render> {
   const defaults: React.ComponentProps<typeof ProblemsPanel> = {
     v2: emptyV2(),
-    jobs: emptyJobs(),
+    processes: emptyProcesses(),
     coverage: emptyCoverage(),
     v2Error: false,
-    jobsError: false,
+    processesError: false,
     coverageError: false,
     onOpenOrchestrator: () => {},
   };
@@ -270,7 +251,7 @@ describe("ProblemsPanel", () => {
   });
 
   it("renders Checking skeleton when v2 is null and has no cached snapshot", () => {
-    renderPanel({ v2: null, jobs: null, coverage: null });
+    renderPanel({ v2: null, processes: null, coverage: null });
     expect(screen.getByText(/Checking for problems/i)).toBeInTheDocument();
   });
 
@@ -293,10 +274,10 @@ describe("ProblemsPanel", () => {
       <MemoryRouter>
         <ProblemsPanel
           v2={v2}
-          jobs={emptyJobs()}
+          processes={emptyProcesses()}
           coverage={emptyCoverage()}
           v2Error={false}
-          jobsError={false}
+          processesError={false}
           coverageError={false}
           onOpenOrchestrator={() => {}}
         />
@@ -307,10 +288,10 @@ describe("ProblemsPanel", () => {
       <MemoryRouter>
         <ProblemsPanel
           v2={null}
-          jobs={emptyJobs()}
+          processes={emptyProcesses()}
           coverage={emptyCoverage()}
           v2Error={false}
-          jobsError={false}
+          processesError={false}
           coverageError={false}
           onOpenOrchestrator={() => {}}
         />
@@ -340,106 +321,98 @@ describe("ProblemsPanel", () => {
     expect(onOpen).toHaveBeenCalledWith("cik_mapping");
   });
 
-  it("carries over failing jobs from v1 behaviour", () => {
-    const jobs: JobsListResponse = {
-      checked_at: new Date().toISOString(),
-      jobs: [
-        {
-          name: "test_job",
-          display_name: null,
-          description: "test job",
-          cadence: "daily",
-          cadence_kind: "daily",
-          next_run_time: new Date().toISOString(),
-          next_run_time_source: "declared",
-          last_status: "failure",
-          last_started_at: null,
-          last_finished_at: new Date().toISOString(),
-          detail: "",
-          ...JOB_VERDICT_DEFAULTS,
-          // #1689 — a genuinely-failing job reads `attention`; that is what the
-          // ProblemsPanel now keys off (not raw last_status). verdict_reason
-          // carries the inline copy the panel renders.
-          health_verdict: "attention",
-          verdict_reason: "last run failed",
-        },
-      ],
-    };
-    renderPanel({ jobs });
-    // `test_job` now appears in both the alert title and the
-    // "Clears when the next run of test_job succeeds." line — use a
-    // non-greedy matcher scoped to the title row.
-    expect(screen.getByText(/test_job — last run failed/i)).toBeInTheDocument();
+  it("surfaces a failing steady-state process (attention verdict)", () => {
+    const processes = makeProcessList([
+      makeProcessRow({
+        process_id: "test_job",
+        display_name: "Test job",
+        status: "failed", // derives health_verdict "attention", reason "last run failed"
+      }),
+    ]);
+    renderPanel({ processes });
+    expect(screen.getByText(/Test job — last run failed/i)).toBeInTheDocument();
   });
 
-  it("renders a drill-through link to /admin/jobs/<name> for a failing job", () => {
-    const jobs: JobsListResponse = {
-      checked_at: new Date().toISOString(),
-      jobs: [
-        {
-          name: "fundamentals_sync",
-          display_name: null,
-          description: "",
-          cadence: "weekly",
-          cadence_kind: "weekly",
-          next_run_time: new Date().toISOString(),
-          next_run_time_source: "declared",
-          last_status: "failure",
-          last_started_at: null,
-          last_finished_at: new Date().toISOString(),
-          detail: "",
-          ...JOB_VERDICT_DEFAULTS,
-          // #1689 — a genuinely-failing job reads `attention`; that is what the
-          // ProblemsPanel now keys off (not raw last_status). verdict_reason
-          // carries the inline copy the panel renders.
-          health_verdict: "attention",
-          verdict_reason: "last run failed",
-        },
-      ],
-    };
-    renderPanel({ jobs });
+  it("counts an ingest_sweep process the legacy jobs list omitted (#1959)", () => {
+    // The whole point of #1959: nport_sweep is a `mechanism=ingest_sweep`
+    // steady-state process that /system/jobs never carried, so the top
+    // banner under-counted. It must now surface here.
+    const processes = makeProcessList([
+      makeProcessRow({
+        process_id: "nport_sweep",
+        display_name: "N-PORT (fund holdings) sweep",
+        mechanism: "ingest_sweep",
+        lane: "ownership",
+        role: "steady_state",
+        status: "failed",
+      }),
+    ]);
+    renderPanel({ processes });
+    expect(
+      screen.getByText(/N-PORT \(fund holdings\) sweep — last run failed/i),
+    ).toBeInTheDocument();
     const link = screen.getByRole("link", {
-      name: /View runs for fundamentals_sync/i,
+      name: /View runs for N-PORT \(fund holdings\) sweep/i,
     });
-    expect(link).toHaveAttribute("href", "/admin/jobs/fundamentals_sync");
+    expect(link).toHaveAttribute("href", "/admin/processes/nport_sweep");
   });
 
-  it("URL-encodes job names containing special characters in the drill link", () => {
-    // Defensive: job_name is a plain string in the DB; if an operator
-    // ever names a job with `/`, space, or `?`, the drill link must
-    // stay unambiguous. encodeURIComponent at link-construction time.
-    const jobs: JobsListResponse = {
-      checked_at: new Date().toISOString(),
-      jobs: [
-        {
-          name: "etl/fundamentals_sync",
-          display_name: null,
-          description: "",
-          cadence: "weekly",
-          cadence_kind: "weekly",
-          next_run_time: new Date().toISOString(),
-          next_run_time_source: "declared",
-          last_status: "failure",
-          last_started_at: null,
-          last_finished_at: new Date().toISOString(),
-          detail: "",
-          ...JOB_VERDICT_DEFAULTS,
-          // #1689 — a genuinely-failing job reads `attention`; that is what the
-          // ProblemsPanel now keys off (not raw last_status). verdict_reason
-          // carries the inline copy the panel renders.
-          health_verdict: "attention",
-          verdict_reason: "last run failed",
-        },
-      ],
-    };
-    renderPanel({ jobs });
+  it("does NOT count bootstrap / backfill attention rows (matches control-hub scope)", () => {
+    // #1530 C7 — the control-hub "N need attention" count operates on
+    // steady-state rows only; bootstrap/backfill one-shots fold into a
+    // separate section. The top banner now matches that scope so the two
+    // counts agree (#1959). A freshly-failed backfill must NOT raise the
+    // top red banner.
+    const processes = makeProcessList([
+      makeProcessRow({
+        process_id: "ownership_observations_backfill",
+        display_name: "Ownership observations backfill",
+        role: "backfill",
+        status: "failed",
+      }),
+      makeProcessRow({
+        process_id: "bootstrap",
+        display_name: "Bootstrap",
+        role: "bootstrap",
+        mechanism: "bootstrap",
+        status: "failed",
+      }),
+    ]);
+    const { container } = renderPanel({ processes });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does NOT count a non-attention steady-state process (self-healing / paused)", () => {
+    const processes = makeProcessList([
+      makeProcessRow({
+        process_id: "retrying_job",
+        display_name: "Retrying job",
+        status: "pending_retry", // → self_healing, not attention
+      }),
+      makeProcessRow({
+        process_id: "paused_job",
+        display_name: "Paused job",
+        status: "disabled", // → paused (kill switch), not attention
+      }),
+    ]);
+    const { container } = renderPanel({ processes });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a drill-through link to /admin/processes/<id> for a failing process", () => {
+    const processes = makeProcessList([
+      makeProcessRow({
+        process_id: "fundamentals_sync",
+        display_name: "Fundamentals research refresh",
+        lane: "fundamentals",
+        status: "failed",
+      }),
+    ]);
+    renderPanel({ processes });
     const link = screen.getByRole("link", {
-      name: /View runs for etl\/fundamentals_sync/i,
+      name: /View runs for Fundamentals research refresh/i,
     });
-    expect(link).toHaveAttribute(
-      "href",
-      "/admin/jobs/etl%2Ffundamentals_sync",
-    );
+    expect(link).toHaveAttribute("href", "/admin/processes/fundamentals_sync");
   });
 
   it("renders a 'Clears when' hint on each alert type", () => {
@@ -465,35 +438,19 @@ describe("ProblemsPanel", () => {
         operator_fix: "Set ANTHROPIC_API_KEY in Settings → Providers",
       },
     ];
-    const jobs: JobsListResponse = {
-      checked_at: new Date().toISOString(),
-      jobs: [
-        {
-          name: "fundamentals_sync",
-          display_name: null,
-          description: "",
-          cadence: "weekly",
-          cadence_kind: "weekly",
-          next_run_time: new Date().toISOString(),
-          next_run_time_source: "declared",
-          last_status: "failure",
-          last_started_at: null,
-          last_finished_at: new Date().toISOString(),
-          detail: "",
-          ...JOB_VERDICT_DEFAULTS,
-          // #1689 — a genuinely-failing job reads `attention`; that is what the
-          // ProblemsPanel now keys off (not raw last_status). verdict_reason
-          // carries the inline copy the panel renders.
-          health_verdict: "attention",
-          verdict_reason: "last run failed",
-        },
-      ],
-    };
+    const processes = makeProcessList([
+      makeProcessRow({
+        process_id: "fundamentals_sync",
+        display_name: "fundamentals_sync",
+        lane: "fundamentals",
+        status: "failed",
+      }),
+    ]);
     const coverage: CoverageSummaryResponse = {
       ...emptyCoverage(),
       null_rows: 7,
     };
-    renderPanel({ v2, jobs, coverage });
+    renderPanel({ v2, processes, coverage });
     expect(
       screen.getByText(/Clears when the next run of cik_mapping succeeds/i),
     ).toBeInTheDocument();
@@ -576,10 +533,10 @@ describe("ProblemsPanel", () => {
       <MemoryRouter>
         <ProblemsPanel
           v2={initialV2}
-          jobs={emptyJobs()}
+          processes={emptyProcesses()}
           coverage={initialCoverage}
           v2Error={false}
-          jobsError={false}
+          processesError={false}
           coverageError={false}
           onOpenOrchestrator={() => {}}
         />
@@ -609,10 +566,10 @@ describe("ProblemsPanel", () => {
       <MemoryRouter>
         <ProblemsPanel
           v2={updatedV2}
-          jobs={emptyJobs()}
+          processes={emptyProcesses()}
           coverage={initialCoverage}
           v2Error={false}
-          jobsError={false}
+          processesError={false}
           coverageError={true}
           onOpenOrchestrator={() => {}}
         />
@@ -623,33 +580,24 @@ describe("ProblemsPanel", () => {
     expect(screen.getByText(/5 instrument/)).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent(/coverage/i);
     expect(screen.getByRole("status")).not.toHaveTextContent(/layers/i);
-    expect(screen.getByRole("status")).not.toHaveTextContent(/jobs/i);
+    expect(screen.getByRole("status")).not.toHaveTextContent(/processes/i);
   });
 
   it("uses a combined-count header when carry-over rows contribute problems but v2 is clean", () => {
     // Regression guard: previously the header text came from
     // v2.system_summary ("All layers healthy") even when a failed
-    // job was rendered underneath. Must say "N problem(s) need
-    // attention" whenever jobs/coverage contribute.
-    const jobs: JobsListResponse = {
-      checked_at: new Date().toISOString(),
-      jobs: [
-        {
-          name: "test_job",
-          description: "test job",
-          cadence: "daily",
-          next_run_time: new Date().toISOString(),
-          next_run_time_source: "declared",
-          last_status: "failure",
-          last_finished_at: new Date().toISOString(),
-          // #1689 — genuine failure → attention is what the panel now counts.
-          health_verdict: "attention",
-        } as unknown as JobsListResponse["jobs"][number],
-      ],
-    };
-    renderPanel({ v2: emptyV2(), jobs });
+    // process was rendered underneath. Must say "N problem(s) need
+    // attention" whenever processes/coverage contribute.
+    const processes = makeProcessList([
+      makeProcessRow({
+        process_id: "test_job",
+        display_name: "test_job",
+        status: "failed",
+      }),
+    ]);
+    renderPanel({ v2: emptyV2(), processes });
     // v2 is clean; v2.system_summary = "All layers healthy".
-    // Header MUST reflect the one failed job, not parrot the v2 summary.
+    // Header MUST reflect the one failed process, not parrot the v2 summary.
     expect(screen.queryByText(/All layers healthy/)).toBeNull();
     expect(screen.getByText(/1 problem.*need.*attention/i)).toBeInTheDocument();
   });

--- a/frontend/src/components/admin/ProblemsPanel.tsx
+++ b/frontend/src/components/admin/ProblemsPanel.tsx
@@ -14,18 +14,25 @@ import type {
   ActionNeededItem,
   CoverageSummaryResponse,
   CredentialHealthSummary,
-  JobsListResponse,
+  ProcessListResponse,
   SecretMissingItem,
   SyncLayersV2Response,
 } from "@/api/types";
 import { formatDateTime } from "@/lib/format";
+import { steadyStateAttentionRows } from "@/lib/processHealth";
 
 
 export interface ProblemsPanelProps {
   /** v2 payload. Null on first mount + while refetch is in flight. */
   readonly v2: SyncLayersV2Response | null;
-  /** Jobs payload (unchanged from v1; failing jobs still surface here). */
-  readonly jobs: JobsListResponse | null;
+  /**
+   * Processes catalogue (#1959). Steady-state rows with
+   * `health_verdict === "attention"` surface here as failing processes.
+   * This replaced the legacy `/system/jobs` source, which omitted
+   * `ingest_sweep` processes (e.g. `nport_sweep`) and so under-counted
+   * problems relative to the Processes control-hub below.
+   */
+  readonly processes: ProcessListResponse | null;
   /** Coverage payload (unchanged from v1; null_rows still surface here). */
   readonly coverage: CoverageSummaryResponse | null;
   /**
@@ -41,7 +48,7 @@ export interface ProblemsPanelProps {
    */
   readonly credentialHealth?: CredentialHealthSummary | null;
   readonly v2Error: boolean;
-  readonly jobsError: boolean;
+  readonly processesError: boolean;
   readonly coverageError: boolean;
   /** Called with the root layer name when the operator clicks drill-through. */
   readonly onOpenOrchestrator: (layerName: string) => void;
@@ -72,7 +79,7 @@ const CREDENTIAL_REJECTED_BANNER: ActionNeededItem = {
 
 interface SourceCache {
   v2: SyncLayersV2Response | null;
-  jobs: JobsListResponse | null;
+  processes: ProcessListResponse | null;
   coverage: CoverageSummaryResponse | null;
 }
 
@@ -89,34 +96,34 @@ function mentionsSettings(text: string): boolean {
 
 export function ProblemsPanel({
   v2,
-  jobs,
+  processes,
   coverage,
   credentialHealth,
   v2Error,
-  jobsError,
+  processesError,
   coverageError,
   onOpenOrchestrator,
 }: ProblemsPanelProps): JSX.Element | null {
-  const [cache, setCache] = useState<SourceCache>({ v2: null, jobs: null, coverage: null });
+  const [cache, setCache] = useState<SourceCache>({ v2: null, processes: null, coverage: null });
 
   useEffect(() => {
     if (v2 !== null) setCache((prev) => ({ ...prev, v2 }));
   }, [v2]);
   useEffect(() => {
-    if (jobs !== null) setCache((prev) => ({ ...prev, jobs }));
-  }, [jobs]);
+    if (processes !== null) setCache((prev) => ({ ...prev, processes }));
+  }, [processes]);
   useEffect(() => {
     if (coverage !== null) setCache((prev) => ({ ...prev, coverage }));
   }, [coverage]);
 
   const pendingSources: string[] = [];
   if (cache.v2 === null) pendingSources.push("layers");
-  if (cache.jobs === null) pendingSources.push("jobs");
+  if (cache.processes === null) pendingSources.push("processes");
   if (cache.coverage === null) pendingSources.push("coverage");
 
   const erroredSources: string[] = [];
   if (v2Error && cache.v2 !== null) erroredSources.push("layers");
-  if (jobsError && cache.jobs !== null) erroredSources.push("jobs");
+  if (processesError && cache.processes !== null) erroredSources.push("processes");
   if (coverageError && cache.coverage !== null) erroredSources.push("coverage");
 
   const allPending = pendingSources.length === 3;
@@ -130,12 +137,17 @@ export function ProblemsPanel({
 
   const baseActionNeeded = cache.v2?.action_needed ?? [];
   const secretMissing = cache.v2?.secret_missing ?? [];
-  // #1689 — a job is a "problem" only when its COMPUTED verdict says the
-  // operator must act (`attention`). A retrying (`self_healing`), aged one-shot
-  // (`stale_manual`), `working`, or `current` job is NOT a problem. Keying off
-  // raw `last_status === "failure"` here re-introduced the exact false-red the
-  // verdict model exists to kill (a transient/reaped failure raised a red banner).
-  const failingJobs = (cache.jobs?.jobs ?? []).filter((j) => j.health_verdict === "attention");
+  // #1959 — count failing PROCESSES from the same catalogue + predicate the
+  // control-hub "N need attention" uses (steady-state rows with
+  // `health_verdict === "attention"`; see `steadyStateAttentionRows`). This
+  // replaced the legacy `/system/jobs` source, which omitted `ingest_sweep`
+  // processes (e.g. `nport_sweep`) so the top banner under-counted vs the
+  // Processes section below.
+  // #1689 — `attention` is the COMPUTED verdict: a retrying (`self_healing`),
+  // aged one-shot (`stale_manual`), kill-switch-disabled (`paused`, #1831),
+  // `working`, or `current` row is NOT a problem, so a transient/reaped
+  // failure does not raise a false red banner.
+  const failingProcesses = steadyStateAttentionRows(cache.processes?.rows ?? []);
   const coverageNullRows = cache.coverage?.null_rows ?? 0;
 
   // Inject the credential-rejected banner when the operator's aggregate
@@ -148,7 +160,7 @@ export function ProblemsPanel({
     ? [CREDENTIAL_REJECTED_BANNER, ...baseActionNeeded]
     : baseActionNeeded;
 
-  const totalProblems = actionNeeded.length + secretMissing.length + failingJobs.length + (coverageNullRows > 0 ? 1 : 0);
+  const totalProblems = actionNeeded.length + secretMissing.length + failingProcesses.length + (coverageNullRows > 0 ? 1 : 0);
 
   if (totalProblems === 0 && pendingSources.length === 0 && erroredSources.length === 0) {
     return null;
@@ -203,25 +215,26 @@ export function ProblemsPanel({
         {secretMissing.map((item) => (
           <SecretMissingRow key={item.layer} item={item} />
         ))}
-        {failingJobs.map((job) => {
-          const label = job.display_name ?? job.name;
+        {failingProcesses.map((proc) => {
+          const label = proc.display_name || proc.process_id;
+          const failedAt = proc.last_run?.finished_at ?? null;
           return (
-            <li key={`job-${job.name}`} className="px-4 py-2 text-sm">
+            <li key={`process-${proc.process_id}`} className="px-4 py-2 text-sm">
               <div className="flex items-start gap-2">
                 <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-red-500" />
                 <div className="flex-1">
                   <div className="font-medium text-red-800">
-                    {label} — {job.verdict_reason || "needs attention"}
+                    {label} — {proc.verdict_reason || "needs attention"}
                   </div>
-                  {job.last_finished_at !== null ? (
-                    <div className="text-xs text-slate-600">Failed at {formatDateTime(job.last_finished_at)}</div>
+                  {failedAt !== null ? (
+                    <div className="text-xs text-slate-600">Failed at {formatDateTime(failedAt)}</div>
                   ) : null}
                   <div className="text-xs text-slate-600">
                     Clears when the next run of {label} succeeds.
                   </div>
                 </div>
                 <Link
-                  to={`/admin/jobs/${encodeURIComponent(job.name)}`}
+                  to={`/admin/processes/${encodeURIComponent(proc.process_id)}`}
                   className="shrink-0 text-xs font-medium text-blue-700 hover:underline"
                   aria-label={`View runs for ${label}`}
                 >

--- a/frontend/src/components/admin/ProcessesTable.tsx
+++ b/frontend/src/components/admin/ProcessesTable.tsx
@@ -34,6 +34,7 @@ import {
   VERDICT_SORT_PRIORITY,
   reasonTooltip,
 } from "@/components/admin/processStatus";
+import { isSteadyStateProcess } from "@/lib/processHealth";
 
 export interface ProcessesTableProps {
   readonly snapshot: ProcessListResponse;
@@ -132,8 +133,9 @@ export function ProcessesTable({
     return snapshot.rows;
   }, [snapshot.rows, bootstrapOnly]);
 
-  const isBootstrapOrBackfill = (r: ProcessRowResponse) =>
-    r.role !== "steady_state" || r.mechanism === "bootstrap";
+  // #1959 — shared with ProblemsPanel so the top-banner attention count and
+  // the control-hub count derive from ONE scope predicate and cannot drift.
+  const isBootstrapOrBackfill = (r: ProcessRowResponse) => !isSteadyStateProcess(r);
 
   const steadyStateRows = useMemo(
     () => (bootstrapOnly ? baseRows : baseRows.filter((r) => !isBootstrapOrBackfill(r))),

--- a/frontend/src/lib/processHealth.test.ts
+++ b/frontend/src/lib/processHealth.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  makeProcessList,
+  makeProcessRow,
+} from "@/components/admin/__fixtures__/processes";
+import {
+  isSteadyStateProcess,
+  steadyStateAttentionRows,
+} from "@/lib/processHealth";
+
+describe("isSteadyStateProcess", () => {
+  it("accepts a steady-state scheduled job", () => {
+    expect(
+      isSteadyStateProcess(makeProcessRow({ role: "steady_state", mechanism: "scheduled_job" })),
+    ).toBe(true);
+  });
+
+  it("accepts a steady-state ingest_sweep (the #1959 case)", () => {
+    expect(
+      isSteadyStateProcess(
+        makeProcessRow({ process_id: "nport_sweep", role: "steady_state", mechanism: "ingest_sweep" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects backfill / bootstrap roles", () => {
+    expect(isSteadyStateProcess(makeProcessRow({ role: "backfill" }))).toBe(false);
+    expect(isSteadyStateProcess(makeProcessRow({ role: "bootstrap" }))).toBe(false);
+  });
+
+  it("rejects the one-time bootstrap-mechanism row", () => {
+    expect(
+      isSteadyStateProcess(makeProcessRow({ role: "steady_state", mechanism: "bootstrap" })),
+    ).toBe(false);
+  });
+});
+
+describe("steadyStateAttentionRows", () => {
+  it("returns only steady-state rows whose verdict is attention", () => {
+    const rows = makeProcessList([
+      makeProcessRow({ process_id: "fundamentals_sync", status: "failed" }), // attention
+      makeProcessRow({ process_id: "nport_sweep", mechanism: "ingest_sweep", status: "failed" }), // attention
+      makeProcessRow({ process_id: "healthy", status: "ok" }), // current
+      makeProcessRow({ process_id: "retrying", status: "pending_retry" }), // self_healing
+      makeProcessRow({ process_id: "paused", status: "disabled" }), // paused (kill switch)
+      makeProcessRow({ process_id: "backfill_fail", role: "backfill", status: "failed" }), // excluded by scope
+    ]).rows;
+
+    const attention = steadyStateAttentionRows(rows).map((r) => r.process_id);
+    expect(attention).toEqual(["fundamentals_sync", "nport_sweep"]);
+  });
+
+  it("returns an empty array when nothing needs attention", () => {
+    const rows = makeProcessList([makeProcessRow({ status: "ok" })]).rows;
+    expect(steadyStateAttentionRows(rows)).toEqual([]);
+  });
+});

--- a/frontend/src/lib/processHealth.ts
+++ b/frontend/src/lib/processHealth.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared process-health selectors (#1959).
+ *
+ * The /admin page surfaces "processes that need attention" in two
+ * places — the top ProblemsPanel banner and the Processes control-hub
+ * (`ProcessesTable` → `StaleBanner`). #1959: they drifted because each
+ * derived the set independently off a different payload (the top banner
+ * read the legacy `/system/jobs` list, which omits `ingest_sweep`
+ * processes like `nport_sweep`). These selectors are the single source
+ * of truth for the scope + attention predicate so the two surfaces
+ * cannot disagree again.
+ */
+import type { ProcessRowResponse } from "@/api/types";
+
+/**
+ * Steady-state scope — the rows the control-hub "N need attention" count
+ * operates on. Mirrors `ProcessesTable`'s `!isBootstrapOrBackfill`
+ * (#1530 C7): bootstrap / backfill one-shots legitimately sit idle or
+ * failed between runs and fold into a separate collapsed section rather
+ * than the steady-state attention count.
+ */
+export function isSteadyStateProcess(row: ProcessRowResponse): boolean {
+  return row.role === "steady_state" && row.mechanism !== "bootstrap";
+}
+
+/**
+ * Processes that genuinely need operator attention: steady-state rows
+ * whose computed `health_verdict` is `attention`. `attention` already
+ * excludes `self_healing` / `stale_manual` / `paused` / `working` /
+ * `current` (#1689 / #1831), so a transient or kill-switch-disabled row
+ * is not counted.
+ */
+export function steadyStateAttentionRows(
+  rows: readonly ProcessRowResponse[],
+): ProcessRowResponse[] {
+  return rows.filter(
+    (row) => isSteadyStateProcess(row) && row.health_verdict === "attention",
+  );
+}

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -80,6 +80,10 @@ import { fetchRecommendations } from "@/api/recommendations";
 import { fetchConfig } from "@/api/config";
 import { fetchSystemStatus } from "@/api/system";
 import { fetchProcesses } from "@/api/processes";
+import {
+  makeProcessList,
+  makeProcessRow,
+} from "@/components/admin/__fixtures__/processes";
 
 const mockedJobs = vi.mocked(fetchJobsOverview);
 const mockedRun = vi.mocked(runJob);
@@ -233,7 +237,19 @@ beforeEach(() => {
     },
     engine_down: false,
   });
-  mockedProcesses.mockResolvedValue({ rows: [], partial: false });
+  // #1959 — the ProblemsPanel now derives failing jobs from the processes
+  // catalogue (the superset that carries ingest_sweeps like nport_sweep), not
+  // the legacy /system/jobs list. Default snapshot carries one failing
+  // steady-state process so the "shows problems panel" case still fires.
+  mockedProcesses.mockResolvedValue(
+    makeProcessList([
+      makeProcessRow({
+        process_id: "attribution_summary",
+        display_name: "attribution_summary",
+        status: "failed", // → health_verdict "attention", reason "last run failed"
+      }),
+    ]),
+  );
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -261,30 +277,14 @@ describe("AdminPage — top-level composition", () => {
   });
 
   it("hides the problems panel when no sources surface any problem", async () => {
-    mockedJobs.mockReset();
-    mockedJobs.mockResolvedValue({
-      checked_at: "2026-04-16T01:00:00Z",
-      jobs: [
-        {
-          name: "execute_approved_orders",
-          display_name: "Execute approved orders",
-          description: "execute orders",
-          cadence: "every 1 minutes",
-          cadence_kind: "every_n_minutes",
-          next_run_time: "2026-04-20T00:00:00Z",
-          next_run_time_source: "declared",
-          last_status: "success",
-          last_started_at: null,
-          last_finished_at: null,
-          detail: "",
-          ...JOB_VERDICT_DEFAULTS,
-        },
-      ],
-    });
+    // Clean processes catalogue (#1959) → the ProblemsPanel's process
+    // sub-source contributes nothing; v2/coverage are healthy by default.
+    mockedProcesses.mockReset();
+    mockedProcesses.mockResolvedValue(makeProcessList([]));
     renderPage();
     await waitFor(() => {
       expect(mockedV2).toHaveBeenCalled();
-      expect(mockedJobs).toHaveBeenCalled();
+      expect(mockedProcesses).toHaveBeenCalled();
       expect(mockedCoverage).toHaveBeenCalled();
     });
     await waitFor(() => {
@@ -294,7 +294,7 @@ describe("AdminPage — top-level composition", () => {
     });
   });
 
-  it("shows problems panel when a job has failed", async () => {
+  it("shows problems panel when a process has failed", async () => {
     renderPage();
     expect(
       await screen.findByText(/attribution_summary — last run failed/),

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -188,11 +188,11 @@ export function AdminPage() {
 
       <ProblemsPanel
         v2={v2.data}
-        jobs={jobs.data}
+        processes={processes.data}
         coverage={coverage.data}
         credentialHealth={systemStatus.data?.credential_health ?? null}
         v2Error={v2.error !== null}
-        jobsError={jobs.error !== null}
+        processesError={processes.error !== null}
         coverageError={coverage.error !== null}
         onOpenOrchestrator={openOrchestratorFor}
       />


### PR DESCRIPTION
## What
The `/admin` top **ProblemsPanel** banner under-counted problems relative to the **Processes control hub** on the same page: banner read "1 problem(s) need attention" while the hub read "2 need attention: fundamentals_sync, nport_sweep".

## Root cause
The two surfaces derived their attention set from different registries:
- **Top banner** counted failing jobs from `/system/jobs` (`fetchJobsOverview`, 43 rows) filtered `health_verdict === "attention"`.
- **Control hub** (`ProcessesTable` → `StaleBanner`) counts `/system/processes` (50 rows, a superset) steady-state rows with `health_verdict === "attention"`.

`nport_sweep` and the `sec_*_sweep` sweeps are `mechanism = "ingest_sweep"` processes absent from the jobs registry, so the banner structurally could not see their failures.

## Falsification (live, service-token curl @ 8357f1c9)
- `set(/system/jobs) - set(/system/processes) == {}` → **jobs is a strict subset** of processes. Delta = `bootstrap` + 6 `ingest_sweep` rows (incl. `nport_sweep`). Swapping is lossless.
- Processes attention set = `{fundamentals_sync, nport_sweep}` (both steady-state); jobs attention = `{fundamentals_sync}`.
- `orchestrator_full_sync` is already in BOTH jobs and processes → the swap introduces **no new** overlap-with-v2-layers double-count class.
- `health_verdict === "attention"` already excludes `stale_manual`/`paused`/`self_healing`/`working`/`current` (#1689/#1831).

## Change (FE only — display reconciliation, no health-verdict logic change)
- New shared `frontend/src/lib/processHealth.ts`: `isSteadyStateProcess` + `steadyStateAttentionRows` — the single source of truth for the scope+attention predicate.
- `ProblemsPanel`: prop `jobs`/`jobsError` → `processes`/`processesError`; failing-process sub-source = `steadyStateAttentionRows(processes.rows)`; row renders `ProcessRowResponse` fields; drill link → `/admin/processes/{process_id}`.
- `ProcessesTable`: imports `isSteadyStateProcess` (replaces its local predicate) so the two surfaces cannot drift again.
- `AdminPage`: passes `processes` (already fetched via `useProcesses()`); the separate Background-tasks jobs table below is unchanged.

## Deliberate scope note
The old jobs source counted `role=bootstrap/backfill` scheduled jobs in attention; the new steady-state predicate excludes them — matching the control-hub scope (#1530 C7 folds bootstrap/backfill into a separate section). This is the objective (the two counts must agree). Live attention set has no bootstrap/backfill row, so no live row is dropped. Codified by a test asserting a `role="backfill"` attention row is not counted.

## Tests
- `processHealth.test.ts` — table-tests the predicate + selector.
- `ProblemsPanel.test.tsx` — ingest_sweep (nport_sweep) counted + `/admin/processes/nport_sweep` link; bootstrap/backfill attention NOT counted; non-attention (self_healing/paused) excluded.
- `AdminPage.test.tsx` — panel now fed from the processes mock.
- Full FE unit suite green (1283); typecheck + dark-class gate green; Codex ckpt-1 (spec) + ckpt-2 (diff) — no findings.

## Verification note
The shared dev stack serves `~/Dev/eBull` @ origin/main, so this branch can't be visually verified through the running vite pre-merge. Logic verified against live `/system/processes`: the panel now computes over `{fundamentals_sync, nport_sweep}` = 2 with the same predicate the hub uses. Post-merge + dev checkout refresh will render "2 problem(s) need attention".

Spec: `docs/specs/frontend/2026-07-04-problems-panel-processes-source.md`

Closes #1959.