### PR TITLE
fix(#1963): rebase underwater drawdown chart to selected window's peak

### DIFF
--- a/frontend/src/lib/riskView.test.ts
+++ b/frontend/src/lib/riskView.test.ts
@@ -6,6 +6,7 @@ import {
   pickWindow,
   rangeDays,
   rangeToWindowKey,
+  rebaseDrawdownToWindowPeak,
   riskStatusCopy,
   sliceByRange,
 } from "./riskView";
@@ -108,6 +109,59 @@ describe("sliceByRange", () => {
   });
   it("returns the whole series when asOf is null", () => {
     expect(sliceByRange(points, null, "1Y")).toHaveLength(4);
+  });
+});
+
+describe("rebaseDrawdownToWindowPeak", () => {
+  const dp = (date: string, drawdown: string) => ({ date, drawdown });
+
+  it("returns [] for an empty slice", () => {
+    expect(rebaseDrawdownToWindowPeak([])).toEqual([]);
+  });
+
+  it("re-anchors to the window peak; the least-negative point becomes 0", () => {
+    // Slice opens 40% underwater relative to the all-time peak, recovers to
+    // −30% (the window's own high-water mark), then falls to the trough.
+    const sliced = [dp("d1", "-0.40"), dp("d2", "-0.30"), dp("d3", "-0.55")];
+    const out = rebaseDrawdownToWindowPeak(sliced);
+    const v = out.map((p) => Number(p.drawdown));
+    // Window peak = d2 (−0.30). d'(d2) = (1−0.30)/(1−0.30) − 1 = 0.
+    expect(v[1]).toBeCloseTo(0, 10);
+    // d'(d1) = (1−0.40)/(1−0.40) − 1 = 0 (d1 is the running peak until d2).
+    expect(v[0]).toBeCloseTo(0, 10);
+    // d'(d3) = (1−0.55)/(1−0.30) − 1 = 0.45/0.70 − 1 ≈ −0.357143.
+    expect(v[2]).toBeCloseTo(0.45 / 0.7 - 1, 10);
+  });
+
+  it("matches the GME 1Y trough example from #1963 (−0.2798)", () => {
+    // Curve minimum sits at −0.5940 against an all-time peak; the window's own
+    // high-water mark within the slice is −0.4364, so re-basing the trough
+    // yields −0.2798 == the Max drawdown tile.
+    const sliced = [dp("a", "-0.4364"), dp("b", "-0.5940")];
+    const out = rebaseDrawdownToWindowPeak(sliced);
+    expect(Number(out[1]!.drawdown)).toBeCloseTo(
+      (1 - 0.594) / (1 - 0.4364) - 1,
+      6,
+    );
+    expect(Number(out[1]!.drawdown)).toBeCloseTo(-0.2798, 3);
+  });
+
+  it("resets the anchor at a fresh all-time high (drawdown returns to 0)", () => {
+    const sliced = [dp("a", "-0.20"), dp("b", "0"), dp("c", "-0.10")];
+    const out = rebaseDrawdownToWindowPeak(sliced).map((p) =>
+      Number(p.drawdown),
+    );
+    expect(out[0]).toBeCloseTo(0, 10); // running peak until the true high
+    expect(out[1]).toBeCloseTo(0, 10); // new all-time high resets the anchor
+    expect(out[2]).toBeCloseTo(-0.1, 10); // −10% below that fresh peak
+  });
+
+  it("passes unparseable points through unchanged without advancing the peak", () => {
+    const sliced = [dp("a", "-0.30"), dp("b", "nope"), dp("c", "-0.50")];
+    const out = rebaseDrawdownToWindowPeak(sliced);
+    expect(out[1]!.drawdown).toBe("nope");
+    // Peak is still −0.30 (the bad point did not advance it).
+    expect(Number(out[2]!.drawdown)).toBeCloseTo((1 - 0.5) / (1 - 0.3) - 1, 10);
   });
 });
 

--- a/frontend/src/lib/riskView.ts
+++ b/frontend/src/lib/riskView.ts
@@ -7,7 +7,7 @@
  * pick and slice the already-computed payload for presentation.
  */
 
-import type { RiskStatus, RiskWindowMetrics } from "@/api/types";
+import type { DrawdownPoint, RiskStatus, RiskWindowMetrics } from "@/api/types";
 
 /** The range picker tokens. 5Y ≡ full given the ~4yr data ceiling, so both
  *  5Y and All map to the persisted `full` window (spec: no separate 5Y row). */
@@ -75,6 +75,45 @@ export function sliceByRange<T extends { readonly date: string }>(
   end.setUTCDate(end.getUTCDate() - days);
   const cutoff = end.toISOString().slice(0, 10);
   return points.filter((p) => p.date >= cutoff);
+}
+
+/**
+ * Re-baseline a range-sliced underwater curve to the SELECTED window's own
+ * high-water mark, so the chart agrees with the window-local `max_drawdown` /
+ * `current_drawdown` tiles.
+ *
+ * The backend emits ONE full-history curve keyed to the ALL-TIME running peak
+ * (`risk_metrics.py::drawdown_curve`); {@link sliceByRange} only cuts the
+ * x-axis, so a window that opens below the all-time high shows all-time-relative
+ * drawdown while the scalar tiles reset their peak at the window start. This
+ * pure transform re-anchors the sliced series to the window peak using ONLY the
+ * drawdown series — prices cancel:
+ *
+ *   d'(t) = (1 + d(t)) / (1 + max_{s≤t} d(s)) − 1
+ *
+ * `max_{s≤t} d(s)` is the running maximum (least-negative) drawdown so far in
+ * the slice — the point closest to the window's own peak. It resets to 0 at
+ * each fresh all-time high (where d(t)=0), so this reproduces the window-local
+ * peak/trough math exactly. Display-only normalization, NOT a new estimator
+ * (settled-decisions §Risk-metrics: `instrument_risk_metrics` is display/
+ * evidence, no `metric_version` bump for presentation).
+ *
+ * Points whose drawdown fails to parse pass through unchanged and do not
+ * advance the running peak. The denominator `1 + peak` is always > 0: the
+ * backend curve only includes valid closes (> 0, `risk_metrics.py::_valid_close`)
+ * so every `d = close/peak − 1 > −1`, hence the running max `peak > −1`.
+ */
+export function rebaseDrawdownToWindowPeak(
+  points: ReadonlyArray<DrawdownPoint>,
+): DrawdownPoint[] {
+  let peak: number | null = null; // running max of parsed drawdown (≤ 0)
+  return points.map((p) => {
+    const d = parseDecimal(p.drawdown);
+    if (d === null) return p;
+    if (peak === null || d > peak) peak = d;
+    const rebased = (1 + d) / (1 + peak) - 1;
+    return { ...p, drawdown: String(rebased) };
+  });
 }
 
 /**

--- a/frontend/src/pages/RiskPage.tsx
+++ b/frontend/src/pages/RiskPage.tsx
@@ -41,6 +41,7 @@ import { formatNumber, formatPct, formatUnsignedPct } from "@/lib/format";
 import {
   parseDecimal,
   pickWindow,
+  rebaseDrawdownToWindowPeak,
   RISK_RANGES,
   type RiskRange,
   riskStatusCopy,
@@ -314,10 +315,11 @@ export function RiskPage(): JSX.Element {
 
   // Time-series charts slice the full series to the picked range; the
   // histogram + scatter are full-history (no date axis to slice).
-  const ddPoints = sliceByRange(
-    series?.drawdown_curve ?? [],
-    data?.as_of_date ?? null,
-    range,
+  // Slice to the range, then re-anchor the underwater curve to the window's
+  // own peak so it agrees with the window-local max/current drawdown tiles
+  // (#1963). The backend emits one all-time-anchored curve for every range.
+  const ddPoints = rebaseDrawdownToWindowPeak(
+    sliceByRange(series?.drawdown_curve ?? [], data?.as_of_date ?? null, range),
   );
   const volPoints = sliceByRange(
     series?.rolling_vol ?? [],


### PR DESCRIPTION
## Problem
On `/instrument/<symbol>/risk`, the **Drawdown (underwater)** chart disagreed with the headline **Max drawdown** / **now** tiles for the same selected range. GME 1Y: tile `Max drawdown −27.98%`, `now −20.71%`, but the chart's underwater band sat at −40% to −60%, ending ~−55%. Reads as "perpetually 40–60% underwater" while the tile says −28%.

## Root cause (verified)
- `app/api/instruments.py:5839` builds ONE display series over the **full** price history: `drawdown_curve(inst_closes)`, whose peak is the **all-time** running high-water mark (`risk_metrics.py:408`).
- The frontend (`RiskPage.tsx` → `sliceByRange`) only cuts the x-axis to the selected range — it never re-anchors. A window opening below the all-time high (GME's 2021/2024 meme peaks) therefore shows all-time-relative drawdown.
- The scalar `max_drawdown` / `current_drawdown` tiles ARE window-local (backend resets the HWM per window). So chart and tile are computed against different peaks.

## Fix
Add pure `rebaseDrawdownToWindowPeak` to `frontend/src/lib/riskView.ts`, applied after `sliceByRange` in `RiskPage.tsx`. Re-anchors the sliced underwater curve to the window's own peak using ONLY the drawdown series (prices cancel):

```
d'(t) = (1 + d(t)) / (1 + max_{s≤t} d(s)) − 1
```

`max_{s≤t} d(s)` is the running maximum (least-negative) drawdown in the slice — the point closest to the window's own peak. It resets to 0 at each fresh all-time high (where `d=0`), so the transform reproduces the window-local peak/trough math exactly.

Denominator `1 + peak` is always > 0: the backend curve only includes valid closes (> 0, `risk_metrics.py::_valid_close`), so every `d > −1`.

## Verification
- Unit tests (`riskView.test.ts`) reproduce the issue's figures: the 1Y slice trough re-bases to `−0.2798` == the Max drawdown tile (exact via formula-equality assert; ≈ within 3dp of the operator's −0.2798). Fresh-ATH reset, empty, and unparseable-passthrough cases covered.
- `pnpm typecheck` ✓, `pnpm test:unit` (1288 pass) ✓, `pnpm dark:check` ✓.
- Visual eyeball on the live chart deferred to post-merge on `main` (the dev stack serves `~/Dev/eBull`, not this worktree branch); the transform is unit-verified against the issue's own confirmed numbers.

## Scope
Frontend-only, display-only. No backend/schema/backfill change. `instrument_risk_metrics` is a settled display/evidence layer (settled-decisions §Risk-metrics) → no `metric_version` bump.

Closes #1963.