### PR TITLE
feat(#1945): DEF 14A Item 402(c) exec-compensation extraction over def14a_body

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -5288,6 +5288,120 @@ def get_instrument_ownership_rollup(
     return _rollup_to_response(rollup)
 
 
+class ExecCompRow(BaseModel):
+    """One (executive, fiscal_year) row of the Item 402(c) Summary
+    Compensation Table (#1945). Dollar fields are ``None`` when the column
+    is absent (SRC scaled table) or the cell was an explicit null."""
+
+    executive_name: str
+    principal_position: str | None
+    fiscal_year: int
+    salary: Decimal | None
+    bonus: Decimal | None
+    stock_awards: Decimal | None
+    option_awards: Decimal | None
+    non_equity_incentive: Decimal | None
+    pension_nqdc: Decimal | None
+    other_comp: Decimal | None
+    total_comp: Decimal | None
+
+
+class ExecCompensationResponse(BaseModel):
+    """Response for GET /instruments/{symbol}/exec-compensation. ``rows`` is
+    the latest proxy's SCT (all NEOs, up to three fiscal years each), ordered
+    fiscal_year DESC then total_comp DESC. Empty ``rows`` (no SCT parsed for
+    this issuer yet) renders 200 with the source accession null."""
+
+    symbol: str
+    accession_number: str | None
+    rows: list[ExecCompRow]
+
+
+@router.get(
+    "/{symbol}/exec-compensation",
+    response_model=ExecCompensationResponse,
+)
+def get_instrument_exec_compensation(
+    symbol: str,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ExecCompensationResponse:
+    """Executive compensation (DEF 14A Item 402(c) SCT) for an instrument.
+
+    Returns the LATEST proxy's Summary Compensation Table — the accession
+    with the most recent fiscal year — so the operator/thesis engine reads
+    one coherent snapshot rather than an interleaving of multiple proxies.
+    404 for an unknown symbol; 200 + empty rows when no SCT has been parsed
+    for the issuer yet (many issuers file no comp-voting proxy).
+    """
+    symbol_clean = symbol.strip().upper()
+    if not symbol_clean:
+        raise HTTPException(status_code=400, detail="symbol is required")
+
+    with snapshot_read(conn):
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                """
+                SELECT instrument_id FROM instruments
+                WHERE UPPER(symbol) = %(s)s
+                ORDER BY is_primary_listing DESC, instrument_id ASC
+                LIMIT 1
+                """,
+                {"s": symbol_clean},
+            )
+            inst_row = cur.fetchone()
+            if inst_row is None:
+                raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+            instrument_id = int(inst_row["instrument_id"])  # type: ignore[arg-type]
+
+            cur.execute(
+                """
+                WITH latest AS (
+                    -- Tie-break on accession_number (stable, roughly
+                    -- chronological) NOT fetched_at: _upsert_comp refreshes
+                    -- fetched_at on every reparse, so a rewashed older proxy
+                    -- would otherwise masquerade as the latest.
+                    SELECT accession_number
+                    FROM def14a_exec_compensation
+                    WHERE instrument_id = %(iid)s
+                    ORDER BY fiscal_year DESC, accession_number DESC
+                    LIMIT 1
+                )
+                SELECT executive_name, principal_position, fiscal_year,
+                       salary, bonus, stock_awards, option_awards,
+                       non_equity_incentive, pension_nqdc, other_comp, total_comp,
+                       accession_number
+                FROM def14a_exec_compensation
+                WHERE instrument_id = %(iid)s
+                  AND accession_number = (SELECT accession_number FROM latest)
+                ORDER BY fiscal_year DESC, total_comp DESC NULLS LAST
+                """,
+                {"iid": instrument_id},
+            )
+            comp_rows = cur.fetchall()
+
+    accession = str(comp_rows[0]["accession_number"]) if comp_rows else None
+    return ExecCompensationResponse(
+        symbol=symbol_clean,
+        accession_number=accession,
+        rows=[
+            ExecCompRow(
+                executive_name=str(r["executive_name"]),
+                principal_position=r["principal_position"],
+                fiscal_year=int(r["fiscal_year"]),
+                salary=r["salary"],
+                bonus=r["bonus"],
+                stock_awards=r["stock_awards"],
+                option_awards=r["option_awards"],
+                non_equity_incentive=r["non_equity_incentive"],
+                pension_nqdc=r["pension_nqdc"],
+                other_comp=r["other_comp"],
+                total_comp=r["total_comp"],
+            )
+            for r in comp_rows
+        ],
+    )
+
+
 # Slice categories present on ``OwnershipSlice.category``. The
 # frontend's ``CATEGORY_LABELS`` set also includes ``treasury`` —
 # treasury is a memo row in the CSV (additive wedge on the chart),

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -931,3 +931,441 @@ def parse_beneficial_ownership_table(html_text: str) -> Def14ABeneficialOwnershi
         rows=rows,
         raw_table_score=best_score,
     )
+
+
+# ===========================================================================
+# Item 402(c) — Summary Compensation Table (exec comp) — #1945
+# ===========================================================================
+#
+# Governed by Regulation S-K Item 402 (17 CFR § 229.402). The Summary
+# Compensation Table (SCT) columns are prescribed and ORDERED by
+# § 229.402(c)(2)(i)–(x); the scaled SRC variant (§ 229.402(n)) simply omits
+# some columns but preserves the order. We therefore resolve the PRESENT
+# dollar columns from the header (by matched text, never fixed positional
+# index) into their reg order, then zip data-row values against that ordered
+# subset. This survives the wildly heterogeneous real-world markup (verified
+# on AAPL / HD / JPM / MSFT full-proxy fixtures):
+#   * name-cell ``rowspan`` → continuation-year rows are index-shifted (AAPL/MSFT)
+#   * year folded into the name column, ``—`` for null bonus (HD)
+#   * lone ``$`` spacer cells + a bare footnote-superscript cell mid-row (JPM)
+#   * empty layout-spacer columns interleaved between values (AAPL/MSFT)
+# Positional header→column mapping cannot survive these; token classification
+# + reg-fixed ordering can.
+
+
+@dataclass(frozen=True)
+class Def14AExecCompRow:
+    """One (executive, fiscal_year) row of the Item 402(c) SCT.
+
+    Dollar fields are ``None`` when the column is absent (SRC scaled
+    table drops pension/NQDC) OR the cell is an explicit ``—`` / ``N/A``
+    null. ``principal_position`` is stored raw free-text (v1; the
+    thesis consumer canonicalises CEO/CFO — open-question #1 in the spec).
+    """
+
+    executive_name: str
+    principal_position: str | None
+    fiscal_year: int
+    salary: Decimal | None
+    bonus: Decimal | None
+    stock_awards: Decimal | None
+    option_awards: Decimal | None
+    non_equity_incentive: Decimal | None
+    pension_nqdc: Decimal | None
+    other_comp: Decimal | None
+    total_comp: Decimal | None
+
+
+@dataclass(frozen=True)
+class Def14ASummaryCompTable:
+    """Parsed Item 402(c) SCT payload. ``rows`` empty = no SCT
+    confidently identified (log, don't guess). ``raw_table_score`` is
+    the chosen table's header score for audit diagnostics (mirror
+    :class:`Def14ABeneficialOwnershipTable`)."""
+
+    rows: tuple[Def14AExecCompRow, ...]
+    raw_table_score: int
+
+
+# Section anchor for the SCT. Kept SEPARATE from ``_SECTION_HEADING_RE`` so
+# the ownership parser is unaffected; passed into ``_find_section_windows``.
+_SCT_SECTION_HEADING_RE: Final[re.Pattern[str]] = re.compile(r"Summary\s+Compensation\s+Table", re.IGNORECASE)
+
+# Header keywords that identify the SCT specifically (vs the Director
+# Compensation table 402(k) or Grants-of-Plan-Based-Awards table, which
+# share layout but lack the salary+total+name/position combination).
+_SCT_HEADER_KEYWORDS: Final[tuple[tuple[str, int], ...]] = (
+    ("name and principal position", 4),
+    ("named executive", 3),
+    ("principal position", 3),
+    ("salary", 3),
+    ("stock award", 3),
+    ("option award", 3),
+    ("all other compensation", 3),
+    ("non-equity", 2),
+    ("nonequity", 2),
+    ("non equity", 2),
+    ("bonus", 2),
+    ("change in pension", 2),
+    ("total", 1),
+    ("year", 1),
+)
+
+# SCT dollar fields in reg (c)(2)(iii)–(x) order. Each carries the header
+# substrings that identify its column. Matchers are tested per header cell
+# in THIS order (most specific first) so e.g. "Change in Pension Value and
+# Nonqualified Deferred Compensation Earnings" claims ``pension_nqdc`` and
+# never leaks into ``other_comp``. ``total`` is last (most generic).
+_SCT_FIELD_MATCHERS: Final[tuple[tuple[str, tuple[str, ...]], ...]] = (
+    ("pension_nqdc", ("change in pension", "pension value", "nqdc", "deferred compensation earnings")),
+    ("non_equity_incentive", ("non-equity", "nonequity", "non equity")),
+    ("stock_awards", ("stock award",)),
+    ("option_awards", ("option award",)),
+    ("other_comp", ("all other compensation", "all other")),
+    ("bonus", ("bonus",)),
+    ("salary", ("salary",)),
+    ("total_comp", ("total",)),
+)
+
+_SCT_ALL_FIELDS: Final[tuple[str, ...]] = tuple(f for f, _ in _SCT_FIELD_MATCHERS)
+
+# Zero-width chars (ZWSP/ZWNJ/ZWJ/WORD-JOINER/BOM) used as layout spacers in
+# iXBRL-rendered proxies — Python ``str.strip()`` does NOT treat these as
+# whitespace, so a ``​``-filled spacer cell reads as "non-empty" and
+# hides the real name/value cells unless scrubbed first.
+_ZERO_WIDTH_RE: Final[re.Pattern[str]] = re.compile("[\u200b\u200c\u200d\u2060\ufeff]")
+# Non-breaking / unicode spaces normalised to a plain space so tokenisation
+# (year detection, dash-null detection) is uniform.
+_UNICODE_SPACE_RE: Final[re.Pattern[str]] = re.compile(
+    "[\xa0\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000]"
+)
+
+
+def _sct_norm(cell: str) -> str:
+    """Normalise an SCT cell: drop zero-width spacers, fold unicode spaces
+    to plain spaces, collapse inline whitespace. Preserves ``\\n`` so the
+    name/title split (line 1 = name, line 2 = title) still works."""
+    s = _ZERO_WIDTH_RE.sub("", cell)
+    s = _UNICODE_SPACE_RE.sub(" ", s)
+    return _INLINE_WHITESPACE_RE.sub(" ", s).strip()
+
+
+_YEAR_RE: Final[re.Pattern[str]] = re.compile(r"^(?:19|20)\d{2}$")
+# Bare 1–2 digit non-zero integer = footnote superscript in its own cell
+# (JPM's stray ``'6'``), never a real dollar amount (no exec is paid $6).
+# ``0`` is preserved (legitimate zero salary/bonus/option — MSFT's bonus).
+_BARE_FOOTNOTE_INT_RE: Final[re.Pattern[str]] = re.compile(r"^[1-9]\d?$")
+_DASH_NULLS: Final[frozenset[str]] = frozenset({"-", "—", "–", "n/a", "na"})
+
+# Role keywords marking where a position title begins inside a combined
+# "Name  Title" cell (used to split executive_name from principal_position
+# when no newline delimiter is present). Ordered longest-first so
+# "executive vice president" wins over "president".
+_POSITION_ROLE_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b("
+    r"chief\s+\w+|"
+    r"executive\s+vice\s+president|senior\s+vice\s+president|vice\s+president|"
+    r"president|chair(?:man|woman|person)?|"
+    r"general\s+counsel|chief|ceo|cfo|coo|cto|"
+    r"executive\s+officer|principal\s+\w+|treasurer|secretary|"
+    r"director|founder"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _score_sct_headers(headers: tuple[str, ...]) -> int:
+    """Score a candidate table by SCT header keywords. Higher = better."""
+    if not headers:
+        return 0
+    joined = " ".join(headers).lower()
+    return sum(weight for keyword, weight in _SCT_HEADER_KEYWORDS if keyword in joined)
+
+
+def _resolve_sct_fields(headers: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the PRESENT dollar fields in HEADER (document) order.
+
+    Walk header cells left→right; map each to at most one field (first
+    matcher wins per cell). Dedup keeping first occurrence. For a
+    reg-compliant filing this equals reg (c)(2) order because
+    § 229.402(c)(2) fixes the column ORDER; the parser's correctness in the
+    equal-length zip relies on header order == data-row order (always true
+    within one table), NOT on reg order per se. Only :func:`_map_sct_values`'s
+    Total anchor (mismatch branch) assumes the reg's Total-is-last rule, and it
+    guards for it explicitly.
+    """
+    ordered: list[str] = []
+    for cell in headers:
+        low = cell.lower()
+        for field, needles in _SCT_FIELD_MATCHERS:
+            if field in ordered:
+                continue
+            if any(n in low for n in needles):
+                ordered.append(field)
+                break
+    return tuple(ordered)
+
+
+def _parse_dollar(raw: str) -> Decimal | None:
+    """Parse an SCT dollar cell. Strips footnote markers, ``$``,
+    thousands separators, NBSP; ``()`` → negative; dash/``N/A``/empty →
+    ``None``. (Share parser strips commas but not ``$`` — hence a
+    dedicated dollar variant per the spec.)"""
+    if not raw:
+        return None
+    cleaned = _FOOTNOTE_RE.sub("", raw).replace("$", "").replace("\xa0", "").replace(",", "").strip()
+    negative = False
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        negative = True
+        cleaned = cleaned[1:-1].strip()
+    if cleaned == "" or cleaned.lower() in _DASH_NULLS:
+        return None
+    try:
+        value = Decimal(cleaned)
+    except InvalidOperation:
+        return None
+    if value.is_nan() or value.is_infinite():
+        return None
+    return -value if negative else value
+
+
+def _split_name_position(cell: str) -> tuple[str, str | None]:
+    """Split a "Name / Title" SCT first cell into (name, position).
+
+    Prefers a newline delimiter (AAPL/MSFT put the name on line 1, the
+    title on line 2 — ``_strip_inline_html`` preserves ``\\n``). Falls
+    back to splitting at the first position-role keyword (JPM/HD render
+    "James Dimon Chairman and CEO" on one line). Footnote markers are
+    stripped from the name. Position is raw free-text (v1)."""
+    text = _clean_holder_name(cell).replace("\xa0", " ").strip()
+    text = _INLINE_WHITESPACE_RE.sub(" ", text)
+    if not text:
+        return "", None
+    # Newline delimiter → line 1 is the name, remainder is the title.
+    if "\n" in text:
+        name, _, position = text.partition("\n")
+        pos = _INLINE_WHITESPACE_RE.sub(" ", position.replace("\n", " ")).strip()
+        return name.strip(), (pos or None)
+    # Otherwise split at the first role keyword.
+    m = _POSITION_ROLE_RE.search(text)
+    if m and m.start() > 0:
+        return text[: m.start()].strip().rstrip(",").strip(), text[m.start() :].strip() or None
+    return text, None
+
+
+def _looks_like_name_cell(cell: str) -> bool:
+    """True when a cell is a NEO name/title (has letters, is not a bare
+    year or a pure number/footnote)."""
+    stripped = _clean_holder_name(cell).strip()
+    if not stripped:
+        return False
+    if _YEAR_RE.match(stripped):
+        return False
+    # Needs an alphabetic run of 2+ (filters "$", "(1)", "2,500,000").
+    return bool(re.search(r"[A-Za-z]{2,}", stripped))
+
+
+def _extract_sct_row_values(cells_after_year: list[str]) -> list[Decimal | None]:
+    """Compact the post-year cells into ordered value slots.
+
+    Drops layout spacers ('' / lone '$' / footnote-only / bare
+    footnote-superscript integers) but KEEPS explicit ``—``/``N/A`` nulls
+    (they are real columns with no value). Returns the value list to zip
+    against the reg-ordered present fields."""
+    values: list[Decimal | None] = []
+    for cell in cells_after_year:
+        s = cell.strip()
+        if s == "" or s == "$":
+            continue
+        # Footnote-only cell (e.g. "(3)(4)") strips to empty → spacer.
+        stripped_fn = _FOOTNOTE_RE.sub("", s).strip()
+        if stripped_fn == "":
+            continue
+        low = stripped_fn.lower()
+        if low in _DASH_NULLS:
+            values.append(None)  # explicit null column
+            continue
+        # Bare footnote superscript ('6') — not a dollar amount.
+        if _BARE_FOOTNOTE_INT_RE.match(stripped_fn):
+            continue
+        parsed = _parse_dollar(s)
+        if parsed is not None:
+            values.append(parsed)
+    return values
+
+
+def _map_sct_values(fields: tuple[str, ...], values: list[Decimal | None]) -> dict[str, Decimal | None]:
+    """Map extracted values onto the reg-ordered present fields.
+
+    Clean case (``len(values) == len(fields)``) zips directly. When the
+    counts differ — a filer rendered an interior null column as a BLANK
+    cell (dropped as a spacer) rather than ``—``, or emitted an extra
+    stray cell — the interior mapping is ambiguous. Rather than emit
+    WRONG middle components, trust only the reg-anchored ends: Total is
+    always the last SCT column (§ 229.402(c)(2)(x)) and Salary the first
+    dollar column ((c)(2)(iii)), so those two are read off the ends and
+    the ambiguous middle is left NULL. This keeps the headline thesis
+    figure (total_comp) correct on every emitted row."""
+    mapped: dict[str, Decimal | None] = dict.fromkeys(_SCT_ALL_FIELDS, None)
+    if not values:
+        return mapped
+    if len(values) == len(fields):
+        for field, value in zip(fields, values, strict=True):
+            mapped[field] = value
+        return mapped
+    mapped[fields[0]] = values[0]
+    # Anchor Total to the last value ONLY when Total is the last resolved field
+    # — reg § 229.402(c)(2)(x) mandates Total as the rightmost SCT column, so a
+    # compliant header resolves total_comp last. If a non-compliant header put
+    # Total elsewhere, we do NOT mis-anchor (leave total NULL) rather than emit
+    # a wrong figure.
+    if fields[-1] == "total_comp":
+        mapped["total_comp"] = values[-1]
+    return mapped
+
+
+def _find_sct_windows(html_text: str) -> list[tuple[int, int]]:
+    """Candidate byte windows for the SCT — ONE per "Summary Compensation
+    Table" heading occurrence (not inside a table), each capped to
+    ``_SECTION_SCAN_BYTES``, with overlapping/adjacent windows merged into
+    contiguous ranges. Occurrences arrive in document order (finditer), so a
+    single left-to-right merge pass suffices. Falls back to the whole document
+    only when the phrase never appears (a non-SCT proxy — parse returns 0 rows
+    fast anyway)."""
+    windows: list[tuple[int, int]] = []
+    for match in _SCT_SECTION_HEADING_RE.finditer(html_text):
+        start = match.start()
+        if _is_inside_table(html_text, start):
+            continue
+        end = min(start + _SECTION_SCAN_BYTES, len(html_text))
+        if windows and start <= windows[-1][1]:
+            windows[-1] = (windows[-1][0], max(windows[-1][1], end))
+        else:
+            windows.append((start, end))
+    if not windows:
+        windows.append((0, len(html_text)))
+    return windows
+
+
+# Score floor: a genuine SCT (name/position + salary + stock/option + total)
+# scores well above this; the director-comp / plan-awards look-alikes lack
+# the salary keyword and score below it.
+_SCT_SCORE_FLOOR: Final[int] = 6
+
+
+def parse_summary_compensation_table(html_text: str) -> Def14ASummaryCompTable:
+    """Parse a DEF 14A body and extract the Item 402(c) Summary
+    Compensation Table.
+
+    Returns empty rows when no candidate table scores above the floor
+    (many proxies carry no SCT — DEFA14A soliciting material, merger
+    proxies, notice-only meetings; expected, not a defect). Best-effort:
+    does not raise on malformed HTML."""
+    if not html_text:
+        return Def14ASummaryCompTable(rows=(), raw_table_score=0)
+
+    # The phrase "Summary Compensation Table" recurs MANY times in a proxy
+    # (TOC, CD&A cross-references, Pay-vs-Performance footnotes, the table
+    # caption itself) — HD's proxy has 22 hits. The real table sits at an
+    # arbitrary MIDDLE occurrence, so first/last-window heuristics miss it.
+    # Evaluate a window at EVERY occurrence (merged; each capped to
+    # _SECTION_SCAN_BYTES) and pick the GLOBAL highest-scoring table that is a
+    # VALID SCT (has both the mandatory Salary § 229.402(c)(2)(iii) and Total
+    # (c)(2)(x) columns). Folding the salary+total requirement into SELECTION
+    # — not just a post-hoc gate — is what stops a higher-scoring
+    # Pay-versus-Performance look-alike (Total but no Salary; negative
+    # "Compensation Actually Paid" values) from beating the real SCT.
+    best_score = 0
+    best_table: _RawTable | None = None
+    for window_start, window_end in _find_sct_windows(html_text):
+        for start, end in _scan_outer_tables(html_text, start=window_start, end=window_end):
+            parsed = _parse_table_html(html_text[start:end])
+            if parsed is None:
+                continue
+            score = _score_sct_headers(parsed.score_headers)
+            if score < _SCT_SCORE_FLOOR or score <= best_score:
+                continue
+            # Require a NAME column header (§ 229.402(c)(2)(i) "Name and
+            # Principal Position") — some filers header it just "Name" with the
+            # title shown inline in the data cells, so match the broad "name"
+            # substring rather than the full phrase (requiring "principal
+            # position" cost ~14pp of real yield). Combined with the
+            # salary+total requirement below this discriminates the SCT from
+            # adjacent look-alikes: the Pay-vs-Performance table has no "name"
+            # column (Year / PEO / Non-PEO), and the Director Compensation table
+            # has no Salary column.
+            header_join = " ".join(parsed.score_headers).lower()
+            if "name" not in header_join:
+                continue
+            candidate_fields = _resolve_sct_fields(parsed.column_headers)
+            if "salary" not in candidate_fields or "total_comp" not in candidate_fields:
+                continue
+            best_score = score
+            best_table = parsed
+
+    if best_table is None:
+        logger.debug("DEF 14A: no valid SCT met score floor; best_score=%d", best_score)
+        return Def14ASummaryCompTable(rows=(), raw_table_score=best_score)
+
+    fields = _resolve_sct_fields(best_table.column_headers)
+
+    rows: list[Def14AExecCompRow] = []
+    current_name = ""
+    current_position: str | None = None
+
+    for raw_row in best_table.rows:
+        cells = [_sct_norm(c) for c in raw_row]
+        if not any(cells):
+            continue
+
+        # Leading name cell? (present on the first row per NEO; absent on
+        # rowspan continuation rows.)
+        first_nonempty_idx = next((i for i, c in enumerate(cells) if c), None)
+        if first_nonempty_idx is None:
+            continue
+        if _looks_like_name_cell(cells[first_nonempty_idx]):
+            current_name, current_position = _split_name_position(cells[first_nonempty_idx])
+
+        # Locate the fiscal-year token.
+        year_idx = None
+        for i, c in enumerate(cells):
+            if _YEAR_RE.match(_FOOTNOTE_RE.sub("", c).strip()):
+                year_idx = i
+                break
+        if year_idx is None:
+            # Name-only header row (HD) or a prose row — nothing to emit.
+            continue
+        if not current_name:
+            continue  # values with no NEO context yet — skip defensively.
+
+        fiscal_year = int(_FOOTNOTE_RE.sub("", cells[year_idx]).strip())
+        values = _extract_sct_row_values(cells[year_idx + 1 :])
+        if not values:
+            continue
+
+        mapped = _map_sct_values(fields, values)
+
+        # Defensive: an SCT total is non-negative by construction. A negative
+        # here means a Pay-vs-Performance "Compensation Actually Paid" row
+        # slipped through — drop it rather than store a wrong figure.
+        total = mapped["total_comp"]
+        if total is not None and total < 0:
+            continue
+
+        rows.append(
+            Def14AExecCompRow(
+                executive_name=current_name,
+                principal_position=current_position,
+                fiscal_year=fiscal_year,
+                salary=mapped["salary"],
+                bonus=mapped["bonus"],
+                stock_awards=mapped["stock_awards"],
+                option_awards=mapped["option_awards"],
+                non_equity_incentive=mapped["non_equity_incentive"],
+                pension_nqdc=mapped["pension_nqdc"],
+                other_comp=mapped["other_comp"],
+                total_comp=mapped["total_comp"],
+            )
+        )
+
+    return Def14ASummaryCompTable(rows=tuple(rows), raw_table_score=best_score)

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -44,8 +44,10 @@ import psycopg.rows
 from app.providers.implementations.sec_def14a import (
     Def14ABeneficialHolder,
     Def14ABeneficialOwnershipTable,
+    Def14AExecCompRow,
     extract_plan_name_and_trustee,
     parse_beneficial_ownership_table,
+    parse_summary_compensation_table,
 )
 from app.services import raw_filings
 from app.services.bootstrap_state import (
@@ -63,7 +65,15 @@ from app.services.ownership_observations import (
 )
 from app.services.sec_identity import siblings_for_issuer_cik
 
-_PARSER_VERSION_DEF14A = "def14a-v1"
+# v2 (#1945): body pass now also extracts the Item 402(c) Summary
+# Compensation Table into def14a_exec_compensation, alongside the Item 403
+# beneficial-ownership holdings. Bumping this string is the backfill vehicle:
+# per settled-decisions.md:96 it flows through known_to supersession so the
+# manifest re-evaluates the def14a_body cohort against the new version and the
+# SCT-bearing bodies rewash + backfill comp automatically (no separate
+# backfill script). ``rewash_filings`` imports THIS literal for its ParserSpec
+# current_version so the two can't drift.
+_PARSER_VERSION_DEF14A = "def14a-v2"
 
 logger = logging.getLogger(__name__)
 
@@ -671,6 +681,149 @@ def _upsert_holding(
     return "inserted" if row["inserted"] else "updated"
 
 
+def _upsert_comp(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession_number: str,
+    issuer_cik: str,
+    instrument_id: int,
+    row: Def14AExecCompRow,
+) -> str:
+    """UPSERT one ``def14a_exec_compensation`` row (#1945).
+
+    Returns ``'inserted'`` / ``'updated'``. The UNIQUE index is keyed on
+    ``(instrument_id, accession_number, executive_name, fiscal_year)`` and
+    excludes ``principal_position`` (heuristic free-text, like
+    ``holder_role`` in :func:`_upsert_holding`) so a re-parse with better
+    title inference flows through the conflict path cleanly.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO def14a_exec_compensation (
+                instrument_id, accession_number, issuer_cik,
+                executive_name, principal_position, fiscal_year,
+                salary, bonus, stock_awards, option_awards,
+                non_equity_incentive, pension_nqdc, other_comp, total_comp
+            ) VALUES (
+                %(iid)s, %(accession)s, %(cik)s,
+                %(name)s, %(position)s, %(fy)s,
+                %(salary)s, %(bonus)s, %(stock)s, %(option)s,
+                %(neq)s, %(pension)s, %(other)s, %(total)s
+            )
+            ON CONFLICT (instrument_id, accession_number, executive_name, fiscal_year) DO UPDATE SET
+                issuer_cik = EXCLUDED.issuer_cik,
+                principal_position = EXCLUDED.principal_position,
+                salary = EXCLUDED.salary,
+                bonus = EXCLUDED.bonus,
+                stock_awards = EXCLUDED.stock_awards,
+                option_awards = EXCLUDED.option_awards,
+                non_equity_incentive = EXCLUDED.non_equity_incentive,
+                pension_nqdc = EXCLUDED.pension_nqdc,
+                other_comp = EXCLUDED.other_comp,
+                total_comp = EXCLUDED.total_comp,
+                fetched_at = NOW()
+            RETURNING (xmax = 0) AS inserted
+            """,
+            {
+                "iid": instrument_id,
+                "accession": accession_number,
+                "cik": issuer_cik,
+                "name": row.executive_name,
+                "position": row.principal_position,
+                "fy": row.fiscal_year,
+                "salary": row.salary,
+                "bonus": row.bonus,
+                "stock": row.stock_awards,
+                "option": row.option_awards,
+                "neq": row.non_equity_incentive,
+                "pension": row.pension_nqdc,
+                "other": row.other_comp,
+                "total": row.total_comp,
+            },
+        )
+        result = cur.fetchone()
+    assert result is not None
+    return "inserted" if result["inserted"] else "updated"
+
+
+# A plausible-SCT score floor used only for the "addressable but unparsed"
+# yield-gap log (mirrors the provider's internal ``_SCT_SCORE_FLOOR``): a best
+# table scoring at/above this that still produced zero rows is a real
+# extraction gap worth surfacing; below it there was simply no SCT (a
+# non-comp-voting proxy), which is expected and not logged.
+_SCT_PLAUSIBLE_SCORE: int = 6
+
+
+def apply_exec_comp_best_effort(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession_number: str,
+    issuer_cik: str,
+    body: str,
+    instrument_ids: list[int],
+) -> int:
+    """Parse the Item 402(c) Summary Compensation Table from ``body`` and
+    upsert one ``def14a_exec_compensation`` row per (instrument, exec, FY),
+    fanned out across share-class siblings (#1945).
+
+    SAVEPOINT-isolated + best-effort: the entire parse+upsert runs inside its
+    own ``conn.transaction()`` so a comp failure rolls back comp ONLY and
+    never poisons the caller's connection or aborts the already-applied Item
+    403 holdings write (#1700 per-section failure isolation). Comp is a v1
+    augment, not a gate on the holdings outcome. Comp absence is EXPECTED for
+    many bodies (non-comp-voting proxies carry no SCT) — not an error.
+
+    Returns the number of comp rows written. Emits a structured ``log()`` of
+    the yield so the parsed-vs-addressable gap is never silent (spec).
+    """
+    try:
+        comp = parse_summary_compensation_table(body)
+    except Exception:  # noqa: BLE001 — best-effort augment; never propagate
+        logger.exception("def14a exec-comp: parse raised accession=%s", accession_number)
+        return 0
+
+    if not comp.rows:
+        if comp.raw_table_score >= _SCT_PLAUSIBLE_SCORE:
+            # A plausible SCT scored but no rows extracted — the real yield
+            # gap against heterogeneous HTML. Surface it (no silent truncation).
+            logger.info(
+                "def14a exec-comp: addressable body yielded 0 SCT rows accession=%s (score=%d)",
+                accession_number,
+                comp.raw_table_score,
+            )
+        return 0
+
+    written = 0
+    try:
+        with conn.transaction():
+            # Serialise against a concurrent rewash DELETE+INSERT on the same
+            # accession (same xact-lock key the holdings writers use).
+            raw_filings.acquire_filing_accession_write_lock(conn, accession_number)
+            for instrument_id in instrument_ids:
+                for comp_row in comp.rows:
+                    _upsert_comp(
+                        conn,
+                        accession_number=accession_number,
+                        issuer_cik=issuer_cik,
+                        instrument_id=instrument_id,
+                        row=comp_row,
+                    )
+                    written += 1
+    except Exception:  # noqa: BLE001 — savepoint rolls back comp; holdings survive
+        logger.exception("def14a exec-comp: upsert raised accession=%s", accession_number)
+        return 0
+
+    logger.info(
+        "def14a exec-comp: wrote %d comp rows accession=%s (%d execs x %d instruments)",
+        written,
+        accession_number,
+        len(comp.rows),
+        len(instrument_ids),
+    )
+    return written
+
+
 # ---------------------------------------------------------------------------
 # Per-accession driver
 # ---------------------------------------------------------------------------
@@ -838,6 +991,16 @@ def _ingest_single_accession(
             )
             if esop_rows_written > 0:
                 refresh_esop_current(conn, instrument_id=sibling_iid)
+
+    # Item 402(c) exec-comp augment (#1945). Best-effort + savepoint-isolated
+    # so a comp failure cannot abort the holdings write above.
+    apply_exec_comp_best_effort(
+        conn,
+        accession_number=ref.accession_number,
+        issuer_cik=issuer_cik,
+        body=body,
+        instrument_ids=siblings,
+    )
 
     return _AccessionOutcome(
         status="success",

--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -69,6 +69,7 @@ from app.services.def14a_ingest import (
     _record_ingest_attempt,
     _resolve_issuer_cik,
     _upsert_holding,
+    apply_exec_comp_best_effort,
     def14a_within_cap,
 )
 from app.services.manifest_parsers._classify import (
@@ -450,6 +451,21 @@ def _parse_def14a(
             raw_status="stored",
             error=format_upsert_error(exc),
         )
+
+    # Item 402(c) exec-comp augment (#1945) — runs AFTER the holdings txn has
+    # committed, in its OWN savepoint (inside apply_exec_comp_best_effort), so
+    # a comp parse/upsert failure rolls back comp only; the committed holdings
+    # write + this accession's fairness tick are unaffected. ``siblings`` is
+    # bound here because the holdings try-block succeeded (a failure would have
+    # returned above). Comp is a best-effort augment — its outcome never
+    # changes the ParseOutcome (still ``parsed``).
+    apply_exec_comp_best_effort(
+        conn,
+        accession_number=accession,
+        issuer_cik=issuer_cik,
+        body=body,
+        instrument_ids=siblings,
+    )
 
     return ParseOutcome(
         status="parsed",

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -49,6 +49,7 @@ import psycopg
 import psycopg.rows
 
 from app.services import raw_filings
+from app.services.def14a_ingest import _PARSER_VERSION_DEF14A
 from app.services.institutional_holdings import acquire_13f_accession_write_lock
 from app.services.raw_filings import DocumentKind, RawFilingDocument
 
@@ -635,13 +636,72 @@ def _apply_def14a(
         holders=parsed.rows,
     )
     refresh_def14a_current(conn, instrument_id=int(instrument_id))
+
+    # Item 402(c) exec-comp rewash (#1945). Replace-then-insert for THIS
+    # instrument (scoped, unlike the holdings DELETE which clears by accession —
+    # comp is written per resolved instrument so we never nuke a sibling's comp
+    # rows). The whole comp block runs in its OWN SAVEPOINT so that an
+    # UNEXPECTED comp parse/upsert failure rolls back comp only and cannot
+    # collateral-damage the already-applied Item 403 holdings rewash (#1700
+    # per-section isolation). The INTENTIONAL regression signal — a re-parse
+    # that yields zero comp rows for an accession that PREVIOUSLY had them — is
+    # deliberately re-raised as RewashParseError, mirroring the holdings
+    # contract, so the accession fails + retries instead of silently zeroing
+    # typed rows. (Comp absence on an accession that never had comp is expected
+    # — many bodies carry no SCT — so the first-time v1→v2 backfill never
+    # raises.)
+    from app.providers.implementations.sec_def14a import parse_summary_compensation_table
+    from app.services.def14a_ingest import _upsert_comp
+
+    try:
+        with conn.transaction():
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM def14a_exec_compensation WHERE accession_number = %s AND instrument_id = %s LIMIT 1",
+                    (raw_doc.accession_number, int(instrument_id)),
+                )
+                had_comp_rows = cur.fetchone() is not None
+
+            comp = parse_summary_compensation_table(raw_doc.require_payload())
+            if not comp.rows and had_comp_rows:
+                raise RewashParseError(
+                    f"DEF 14A re-parse produced zero exec-comp rows for accession="
+                    f"{raw_doc.accession_number} (best_score={comp.raw_table_score}); "
+                    f"previous parser found comp rows"
+                )
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM def14a_exec_compensation WHERE accession_number = %s AND instrument_id = %s",
+                    (raw_doc.accession_number, int(instrument_id)),
+                )
+            for comp_row in comp.rows:
+                _upsert_comp(
+                    conn,
+                    accession_number=raw_doc.accession_number,
+                    issuer_cik=str(issuer_cik),
+                    instrument_id=int(instrument_id),
+                    row=comp_row,
+                )
+    except RewashParseError:
+        # Intentional regression — propagate to fail + retry this accession
+        # (the savepoint has already rolled comp back).
+        raise
+    except Exception:  # noqa: BLE001 — unexpected comp failure must not sink the holdings rewash
+        logger.exception(
+            "def14a rewash: exec-comp augment failed accession=%s (holdings rewash preserved)",
+            raw_doc.accession_number,
+        )
     return True
 
 
 register_parser(
     ParserSpec(
         document_kind="def14a_body",
-        current_version="def14a-v1",
+        # Imported from def14a_ingest (single source of truth) so the rewash
+        # spec version and the live/legacy parser version can never drift
+        # (#1945). Bumping _PARSER_VERSION_DEF14A there drives this cohort's
+        # rewash automatically.
+        current_version=_PARSER_VERSION_DEF14A,
         apply_fn=_apply_def14a,
     )
 )

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -650,6 +650,13 @@ def _apply_def14a(
     # typed rows. (Comp absence on an accession that never had comp is expected
     # — many bodies carry no SCT — so the first-time v1→v2 backfill never
     # raises.)
+    # Function-local imports match this file's convention for the def14a
+    # parser/upsert helpers (see the Item 403 holdings path at the
+    # parse_beneficial_ownership_table / _upsert_holding imports above): the
+    # heavy sec_def14a + def14a_ingest modules are pulled in only when a
+    # def14a_body actually reaches rewash, keeping this module's import graph
+    # light. _PARSER_VERSION_DEF14A stays module-level because register_parser
+    # consumes it at import time.
     from app.providers.implementations.sec_def14a import parse_summary_compensation_table
     from app.services.def14a_ingest import _upsert_comp
 
@@ -669,6 +676,11 @@ def _apply_def14a(
                     f"{raw_doc.accession_number} (best_score={comp.raw_table_score}); "
                     f"previous parser found comp rows"
                 )
+            # DELETE before the per-row upserts (not upsert-only): _upsert_comp's
+            # ON CONFLICT replaces rows still present in the new parse, but a
+            # named-exec-officer/year row that DROPPED OUT of the re-parsed SCT
+            # would otherwise linger. The scoped DELETE clears those stale execs
+            # so the stored comp set exactly mirrors the latest parse.
             with conn.cursor() as cur:
                 cur.execute(
                     "DELETE FROM def14a_exec_compensation WHERE accession_number = %s AND instrument_id = %s",

--- a/sql/215_def14a_exec_compensation.sql
+++ b/sql/215_def14a_exec_compensation.sql
@@ -1,0 +1,61 @@
+-- 215_def14a_exec_compensation.sql
+--
+-- Issue #1945 (child of #1913 raw-store extraction-completeness audit).
+-- Extract-more decision: fund an Item 402 executive-compensation parser
+-- over the retained ``def14a_body`` payload rather than sweep it.
+--
+-- Item 402 of Regulation S-K (17 CFR § 229.402) prescribes the Summary
+-- Compensation Table (SCT): one row per named executive officer per
+-- fiscal year, up to the last three completed fiscal years
+-- (§ 229.402(c)(1)). The column set is fixed and ORDERED by
+-- § 229.402(c)(2)(i)–(x); the scaled smaller-reporting-company variant
+-- (§ 229.402(n)) simply omits some columns but preserves the order.
+--
+-- Grain: one row per (accession, executive, fiscal_year) — the SCT's
+-- natural grain. Mirrors the ``def14a_beneficial_holdings`` (sql/097)
+-- conventions:
+--
+--   * ``instrument_id`` is nullable in the DDL for audit parity with
+--     097, but in practice the manifest parser resolves CIK→instrument
+--     before writing (dev: 0/38,607 holdings rows have a NULL
+--     instrument_id), so the UNIQUE index below — not a partial index —
+--     matches live behaviour and the upsert's ON CONFLICT target.
+--   * ``principal_position`` is stored raw free-text (no CHECK), like
+--     097's ``holder_role`` — CEO/CFO canonicalisation is deferred to
+--     the reader (thesis engine, #1919). A re-parse with better role
+--     inference then UPSERTs the same identity row.
+--   * Dollar amounts are NUMERIC(18, 2): Item 402 reports whole dollars
+--     but 2 dp keeps aggregation arithmetic-clean. Never float.
+
+CREATE TABLE IF NOT EXISTS def14a_exec_compensation (
+    comp_id              BIGSERIAL PRIMARY KEY,
+    instrument_id        BIGINT REFERENCES instruments(instrument_id),  -- nullable, CIK-resolved post-parse (mirror 097)
+    accession_number     TEXT NOT NULL,
+    issuer_cik           TEXT NOT NULL,
+    executive_name       TEXT NOT NULL,
+    principal_position   TEXT,                 -- (c)(2)(i) role portion, free-text
+    fiscal_year          INTEGER NOT NULL,     -- (c)(2)(ii)
+    salary               NUMERIC(18, 2),       -- (c)(2)(iii)
+    bonus                NUMERIC(18, 2),       -- (c)(2)(iv)
+    stock_awards         NUMERIC(18, 2),       -- (c)(2)(v)   grant-date FV per FASB ASC 718
+    option_awards        NUMERIC(18, 2),       -- (c)(2)(vi)  grant-date FV per FASB ASC 718
+    non_equity_incentive NUMERIC(18, 2),       -- (c)(2)(vii)
+    pension_nqdc         NUMERIC(18, 2),       -- (c)(2)(viii) — NULL for SRC scaled SCT
+    other_comp           NUMERIC(18, 2),       -- (c)(2)(ix)
+    total_comp           NUMERIC(18, 2),       -- (c)(2)(x)
+    fetched_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Identity: (instrument_id, accession, executive, fiscal_year). Mirrors the
+-- LIVE holdings key (instrument_id, accession_number, holder_name):
+-- instrument_id is included because a DEF 14A fans out to share-class
+-- sibling instruments via _resolve_siblings (manifest_parsers/def14a.py) —
+-- omitting it would collapse a dual-class issuer's comp rows into one. The
+-- position is EXCLUDED from the key (heuristic free-text, like holder_role
+-- in 097) so a re-parse with better title inference UPSERTs in place.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_def14a_comp_iid_acc_exec_fy
+    ON def14a_exec_compensation (instrument_id, accession_number, executive_name, fiscal_year);
+
+-- Hot path: latest comp for one instrument (read endpoint / thesis input).
+CREATE INDEX IF NOT EXISTS idx_def14a_comp_instrument_fy
+    ON def14a_exec_compensation (instrument_id, fiscal_year DESC);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -192,6 +192,7 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "def14a_drift_alerts",
     "def14a_ingest_log",
     "def14a_beneficial_holdings",
+    "def14a_exec_compensation",
     "filing_events",
     "instrument_cik_history",
     "instrument_symbol_history",

--- a/tests/test_def14a_ingest.py
+++ b/tests/test_def14a_ingest.py
@@ -357,7 +357,7 @@ class TestIngestDef14a:
             document_kind="def14a_body",
         )
         assert doc is not None
-        assert doc.parser_version == "def14a-v1"
+        assert doc.parser_version == "def14a-v2"
         assert doc.source_url == url
         assert len(doc.require_payload()) > 0
 
@@ -782,3 +782,101 @@ class TestBootstrapDef14a:
         # Loop body never executed (deadline was 0); no work done.
         assert summary.accessions_seen == 0
         assert summary.exit_reason == "deadline"
+
+
+class TestExecCompensation:
+    """Item 402(c) Summary Compensation Table write path (#1945) —
+    ``apply_exec_comp_best_effort`` + ``_upsert_comp`` against the real DB.
+    Covers the one genuinely-new SQL mechanism (the def14a_exec_compensation
+    table + its ON CONFLICT upsert + sibling fan-out); the parser itself is
+    covered by pure tests in test_sec_def14a_sct_parser.py."""
+
+    # Minimal real-shape SCT: name-rowspan first row + a continuation year row.
+    _SCT_HTML = (
+        "<html><body><h2>Summary Compensation Table</h2><table>"
+        "<tr><td>Name and Principal Position</td><td>Year</td><td>Salary ($)</td>"
+        "<td>Bonus ($)</td><td>Stock Awards ($)</td><td>Total ($)</td></tr>"
+        "<tr><td>Jane Roe\nChief Executive Officer</td><td>2025</td><td>1,000,000</td>"
+        "<td>500,000</td><td>4,000,000</td><td>5,500,000</td></tr>"
+        "<tr><td>2024</td><td>950,000</td><td>400,000</td><td>3,500,000</td><td>4,850,000</td></tr>"
+        "</table></body></html>"
+    )
+
+    def test_apply_exec_comp_inserts_then_upserts(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.def14a_ingest import apply_exec_comp_best_effort
+
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=1_945_001, symbol="COMP")
+        acc = "0001945001-26-000001"
+
+        written = apply_exec_comp_best_effort(
+            conn,
+            accession_number=acc,
+            issuer_cik="0001945001",
+            body=self._SCT_HTML,
+            instrument_ids=[1_945_001],
+        )
+        assert written == 2  # two fiscal-year rows for the one NEO
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(
+                "SELECT executive_name, principal_position, fiscal_year, salary, "
+                "total_comp FROM def14a_exec_compensation "
+                "WHERE accession_number = %s ORDER BY fiscal_year DESC",
+                (acc,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2
+        assert rows[0]["executive_name"] == "Jane Roe"
+        assert rows[0]["principal_position"] == "Chief Executive Officer"
+        assert rows[0]["fiscal_year"] == 2025
+        assert rows[0]["salary"] == Decimal("1000000")
+        assert rows[0]["total_comp"] == Decimal("5500000")
+        assert rows[1]["fiscal_year"] == 2024
+        assert rows[1]["total_comp"] == Decimal("4850000")
+
+        # Re-apply: the (instrument, accession, exec, fiscal_year) unique key
+        # UPSERTs in place — no duplicate rows.
+        again = apply_exec_comp_best_effort(
+            conn,
+            accession_number=acc,
+            issuer_cik="0001945001",
+            body=self._SCT_HTML,
+            instrument_ids=[1_945_001],
+        )
+        assert again == 2
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM def14a_exec_compensation WHERE accession_number = %s",
+                (acc,),
+            )
+            count = cur.fetchone()
+        assert count is not None and count[0] == 2  # still 2, not 4
+
+    def test_apply_exec_comp_no_sct_writes_nothing(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        from app.services.def14a_ingest import apply_exec_comp_best_effort
+
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=1_945_002, symbol="NOSCT")
+        acc = "0001945002-26-000001"
+        written = apply_exec_comp_best_effort(
+            conn,
+            accession_number=acc,
+            issuer_cik="0001945002",
+            body="<html><body><h2>Notice of Meeting</h2><p>Vote.</p></body></html>",
+            instrument_ids=[1_945_002],
+        )
+        assert written == 0
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM def14a_exec_compensation WHERE accession_number = %s",
+                (acc,),
+            )
+            count = cur.fetchone()
+        assert count is not None and count[0] == 0

--- a/tests/test_manifest_parser_def14a.py
+++ b/tests/test_manifest_parser_def14a.py
@@ -192,7 +192,7 @@ def test_happy_path_parses_and_stores_raw_and_holdings(
     assert row is not None
     assert row.ingest_status == "parsed"
     assert row.raw_status == "stored"
-    assert row.parser_version == "def14a-v1"
+    assert row.parser_version == "def14a-v2"
 
     # def14a_beneficial_holdings rows exist for the parsed table.
     with ebull_test_conn.cursor() as cur:

--- a/tests/test_sec_def14a_sct_parser.py
+++ b/tests/test_sec_def14a_sct_parser.py
@@ -1,0 +1,444 @@
+"""Unit tests for the DEF 14A Item 402(c) Summary Compensation Table parser
+(#1945 — ``parse_summary_compensation_table``).
+
+Fixture HTML is hand-built to reproduce the exact structural traps observed
+on real full-population proxies (AAPL / HD / JPM / MSFT and a 400-body dev-DB
+scan) without pulling production payloads into the repo. Each scenario pins a
+distinct hazard the reg-fixed-order parser must survive:
+
+  * name-cell ``rowspan`` → continuation-year rows are index-shifted (AAPL)
+  * year folded into the name column, ``—`` for a null bonus (HD)
+  * lone ``$`` spacer cells + a bare footnote-superscript cell mid-row (JPM)
+  * wide empty layout-spacer columns + a legitimate ``0`` bonus (MSFT)
+  * zero-width-space (``​``) spacer cells from iXBRL rendering
+  * an interior null rendered BLANK (not ``—``) → the ends stay anchored
+  * SRC scaled table (§ 229.402(n)) — fewer columns resolve, no special-case
+  * Pay-versus-Performance table rejected (Total but no Salary; negative CAP)
+  * a proxy with no SCT → empty rows, no guess
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.providers.implementations.sec_def14a import (
+    _parse_dollar,
+    _resolve_sct_fields,
+    _split_name_position,
+    parse_summary_compensation_table,
+)
+
+
+def _sct_doc(table_rows_html: str, *, heading: str = "Summary Compensation Table") -> str:
+    """Wrap SCT rows in a minimal proxy doc with the section heading."""
+    return f"<html><body><h2>{heading}</h2>{table_rows_html}</body></html>"
+
+
+def _row(*cells: str) -> str:
+    return "<tr>" + "".join(f"<td>{c}</td>" for c in cells) + "</tr>"
+
+
+# ---------------------------------------------------------------------------
+# Real-layout regression scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_aapl_rowspan_continuation_shift() -> None:
+    """Name in a rowspan cell → continuation-year rows have one fewer cell
+    and every column shifts. Reg-order zip + name carry-forward must keep
+    each year's Total correct. AAPL layout: no Bonus/Option columns."""
+    header = _row(
+        "Name and Principal Position",
+        "",
+        "Year",
+        "",
+        "Salary ($)",
+        "",
+        "Stock Awards ($)",
+        "",
+        "Non-Equity Incentive Plan Compensation ($)",
+        "",
+        "All Other Compensation ($)",
+        "",
+        "Total ($)",
+    )
+    # First row carries the name; continuation rows omit it (rowspan collapse).
+    r2025 = _row(
+        "Tim Cook\nChief Executive Officer",
+        "",
+        "2025",
+        "",
+        "3,000,000",
+        "",
+        "57,535,293",
+        "",
+        "12,000,000",
+        "",
+        "1,759,518",
+        "",
+        "74,294,811",
+    )
+    r2024 = _row("", "2024", "", "3,000,000", "", "58,088,946", "", "12,000,000", "", "1,520,856", "", "74,609,802")
+    table = f"<table>{header}{r2025}{r2024}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert len(result.rows) == 2
+    cook_2025 = result.rows[0]
+    assert cook_2025.executive_name == "Tim Cook"
+    assert cook_2025.principal_position == "Chief Executive Officer"
+    assert cook_2025.fiscal_year == 2025
+    assert cook_2025.salary == Decimal("3000000")
+    assert cook_2025.stock_awards == Decimal("57535293")
+    assert cook_2025.non_equity_incentive == Decimal("12000000")
+    assert cook_2025.other_comp == Decimal("1759518")
+    assert cook_2025.total_comp == Decimal("74294811")
+    assert cook_2025.bonus is None  # column absent
+    assert cook_2025.option_awards is None
+    # Continuation row carries the name forward and stays aligned.
+    cook_2024 = result.rows[1]
+    assert cook_2024.executive_name == "Tim Cook"
+    assert cook_2024.fiscal_year == 2024
+    assert cook_2024.total_comp == Decimal("74609802")
+    assert cook_2024.salary == Decimal("3000000")
+
+
+def test_hd_folded_year_and_dash_null() -> None:
+    """Separate name-only row; year folded into the value stream; ``—`` bonus
+    is an explicit null (kept as a slot, not dropped). Full 8-column table."""
+    header = _row(
+        "Name, Principal Position and Year",
+        "Salary ($)",
+        "Bonus ($)",
+        "Stock Awards ($)",
+        "Option Awards ($)",
+        "Non-Equity Incentive Plan Compensation ($)",
+        "Change in Pension Value and Nonqualified Deferred Compensation Earnings ($)",
+        "All Other Compensation ($)",
+        "Total ($)",
+    )
+    name_row = _row("Edward P. Decker Chair, President and Chief Executive Officer")
+    y2025 = _row("2025", "1,400,000", "—", "9,612,251", "2,369,917", "2,657,631", "—", "151,328", "16,191,127")
+    table = f"<table>{header}{name_row}{y2025}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.executive_name == "Edward P. Decker"
+    assert row.principal_position == "Chair, President and Chief Executive Officer"
+    assert row.fiscal_year == 2025
+    assert row.salary == Decimal("1400000")
+    assert row.bonus is None  # explicit em-dash null
+    assert row.stock_awards == Decimal("9612251")
+    assert row.option_awards == Decimal("2369917")
+    assert row.pension_nqdc is None  # explicit em-dash null
+    assert row.other_comp == Decimal("151328")
+    assert row.total_comp == Decimal("16191127")
+
+
+def test_jpm_dollar_spacers_and_footnote_cell() -> None:
+    """Inline lone ``$`` spacer cells + a bare footnote-superscript cell
+    (``6``) must both be dropped without shifting the value mapping. JPM
+    layout: no Option/Non-Equity columns."""
+    header = _row(
+        "Name and principal position",
+        "Year",
+        "Salary ($) 1",
+        "Bonus ($) 2",
+        "Stock awards ($) 3",
+        "Change in pension value and non-qualified deferred compensation earnings ($) 4",
+        "All other compensation ($) 5",
+        "Total ($)",
+    )
+    r = _row(
+        "James Dimon Chairman and CEO",
+        "2025",
+        "$",
+        "1,500,000",
+        "$",
+        "5,000,000",
+        "$",
+        "32,500,000",
+        "$",
+        "44,872",
+        "$",
+        "1,587,852",
+        "6",
+        "$",
+        "40,632,724",
+    )
+    table = f"<table>{header}{r}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.executive_name == "James Dimon"
+    assert row.principal_position == "Chairman and CEO"
+    assert row.fiscal_year == 2025
+    assert row.salary == Decimal("1500000")
+    assert row.bonus == Decimal("5000000")
+    assert row.stock_awards == Decimal("32500000")
+    assert row.pension_nqdc == Decimal("44872")
+    assert row.other_comp == Decimal("1587852")
+    assert row.total_comp == Decimal("40632724")  # stray '6' footnote dropped
+    assert row.option_awards is None
+    assert row.non_equity_incentive is None
+
+
+def test_msft_wide_spacers_and_zero_bonus() -> None:
+    """Many empty layout-spacer columns; a legitimate ``0`` bonus must be
+    KEPT (not mistaken for a footnote/spacer)."""
+    header = _row(
+        "Named Executive and Principal Position",
+        "",
+        "Year",
+        "",
+        "",
+        "Salary ($)",
+        "",
+        "",
+        "Bonus ($)",
+        "",
+        "",
+        "Stock Awards ($)",
+        "",
+        "",
+        "Non-equity Incentive Plan Compensation ($)",
+        "",
+        "",
+        "All Other Compensation ($)",
+        "",
+        "",
+        "Total ($)",
+    )
+    r = _row(
+        "Satya Nadella Chairman and Chief Executive Officer",
+        "",
+        "",
+        "2025",
+        "",
+        "",
+        "",
+        "2,500,000",
+        "",
+        "",
+        "",
+        "0",
+        "",
+        "",
+        "",
+        "84,245,496",
+        "",
+        "",
+        "",
+        "9,555,000",
+        "",
+        "",
+        "",
+        "196,294",
+        "",
+        "",
+        "",
+        "96,496,790",
+    )
+    table = f"<table>{header}{r}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.executive_name == "Satya Nadella"
+    assert row.salary == Decimal("2500000")
+    assert row.bonus == Decimal("0")  # legit zero kept
+    assert row.stock_awards == Decimal("84245496")
+    assert row.total_comp == Decimal("96496790")
+
+
+def test_zero_width_space_spacers() -> None:
+    """iXBRL proxies use ``​`` (zero-width space) cells as spacers.
+    Python str.strip() does NOT treat these as whitespace, so they must be
+    scrubbed or they hide the name/value cells."""
+    zw = "​"
+    header = _row(
+        zw,
+        "Name and Principal Position",
+        zw,
+        "Year",
+        zw,
+        "Salary ($)",
+        zw,
+        "Stock Awards ($)",
+        zw,
+        "All Other Compensation ($)",
+        zw,
+        "Total ($)",
+    )
+    r = _row(
+        zw,
+        "Jane Roe\nChief Executive Officer",
+        zw,
+        "2025",
+        zw,
+        "$1,000,000",
+        zw,
+        "$5,000,000",
+        zw,
+        "$250,000",
+        zw,
+        "$6,250,000",
+    )
+    table = f"<table>{header}{r}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.executive_name == "Jane Roe"
+    assert row.fiscal_year == 2025
+    assert row.salary == Decimal("1000000")
+    assert row.total_comp == Decimal("6250000")
+
+
+def test_interior_blank_null_keeps_total_correct() -> None:
+    """When a filer renders an interior null column as BLANK (not ``—``) so
+    it is dropped as a spacer, the value count is short by one. The parser
+    must NOT left-shift the Total into another column: it anchors Total to the
+    reg's last column and Salary to the first, leaving the ambiguous middle
+    NULL rather than emitting a wrong figure."""
+    header = _row(
+        "Name and Principal Position",
+        "Year",
+        "Salary ($)",
+        "Bonus ($)",
+        "Stock Awards ($)",
+        "Option Awards ($)",
+        "Non-Equity Incentive Plan Compensation ($)",
+        "Change in Pension Value ($)",
+        "All Other Compensation ($)",
+        "Total ($)",
+    )
+    # Pension column is BLANK here (dropped as spacer) → 7 values for 8 fields.
+    r = _row(
+        "John Doe Chief Executive Officer",
+        "2024",
+        "598,026",
+        "—",
+        "1,037,401",
+        "165,030",
+        "723,400",
+        "",
+        "105,009",
+        "2,628,866",
+    )
+    table = f"<table>{header}{r}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    # Anchored ends are always correct:
+    assert row.total_comp == Decimal("2628866")
+    assert row.salary == Decimal("598026")
+    # Ambiguous middle is left NULL rather than mis-mapped:
+    assert row.other_comp is None
+    assert row.pension_nqdc is None
+
+
+def test_src_scaled_table_fewer_columns() -> None:
+    """§ 229.402(n) scaled SCT: two years, no Option/Non-Equity/Pension
+    columns. Strict header-text resolution simply yields a smaller field set —
+    no special-casing, absent columns resolve NULL."""
+    header = _row(
+        "Name and Principal Position",
+        "Year",
+        "Salary ($)",
+        "Bonus ($)",
+        "Stock Awards ($)",
+        "All Other Compensation ($)",
+        "Total ($)",
+    )
+    r2024 = _row("Mary Small Chief Executive Officer", "2024", "400,000", "50,000", "600,000", "10,000", "1,060,000")
+    r2023 = _row("", "2023", "380,000", "40,000", "500,000", "9,000", "929,000")
+    table = f"<table>{header}{r2024}{r2023}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    fields = _resolve_sct_fields(
+        (
+            "Name and Principal Position",
+            "Year",
+            "Salary ($)",
+            "Bonus ($)",
+            "Stock Awards ($)",
+            "All Other Compensation ($)",
+            "Total ($)",
+        )
+    )
+    assert fields == ("salary", "bonus", "stock_awards", "other_comp", "total_comp")
+    assert len(result.rows) == 2
+    assert result.rows[0].total_comp == Decimal("1060000")
+    assert result.rows[0].option_awards is None
+    assert result.rows[0].pension_nqdc is None
+    assert result.rows[1].fiscal_year == 2023
+    assert result.rows[1].total_comp == Decimal("929000")
+
+
+def test_pay_versus_performance_table_rejected() -> None:
+    """The Pay-versus-Performance table (Item 402(v)) carries a "Summary
+    Compensation Table Total" header (so it scores) and negative
+    "Compensation Actually Paid" values, but NO Salary column. Requiring both
+    Salary and Total rejects it — no negative totals leak in."""
+    header = _row(
+        "Year",
+        "Summary Compensation Table Total for PEO ($)",
+        "Compensation Actually Paid to PEO ($)",
+        "Average SCT Total for Non-PEO NEOs ($)",
+        "Average CAP to Non-PEO NEOs ($)",
+        "Total Shareholder Return ($)",
+    )
+    r = _row("2022", "10,000,000", "-1,803,086", "3,000,000", "-500,000", "95")
+    table = f"<table>{header}{r}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+    assert result.rows == ()
+
+
+def test_no_sct_returns_empty() -> None:
+    """A proxy with no SCT (notice-only / soliciting material) returns empty
+    rows — the parser logs and does not guess."""
+    body = "<html><body><h2>Notice of Annual Meeting</h2><p>Please vote.</p></body></html>"
+    result = parse_summary_compensation_table(body)
+    assert result.rows == ()
+
+
+def test_empty_input() -> None:
+    assert parse_summary_compensation_table("").rows == ()
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_dollar_variants() -> None:
+    assert _parse_dollar("$1,234,567") == Decimal("1234567")
+    assert _parse_dollar("450,000(3)") == Decimal("450000")  # trailing footnote
+    assert _parse_dollar("1,234,567 ") == Decimal("1234567")  # nbsp
+    assert _parse_dollar("(1,234)") == Decimal("-1234")  # parenthesised negative
+    assert _parse_dollar("0") == Decimal("0")
+    assert _parse_dollar("—") is None
+    assert _parse_dollar("N/A") is None
+    assert _parse_dollar("") is None
+    assert _parse_dollar("   ") is None
+
+
+def test_split_name_position_newline() -> None:
+    name, pos = _split_name_position("Tim Cook \nChief Executive Officer")
+    assert name == "Tim Cook"
+    assert pos == "Chief Executive Officer"
+
+
+def test_split_name_position_role_keyword() -> None:
+    name, pos = _split_name_position("James Dimon Chairman and CEO")
+    assert name == "James Dimon"
+    assert pos == "Chairman and CEO"
+
+
+def test_split_name_position_no_title() -> None:
+    name, pos = _split_name_position("Jane Doe")
+    assert name == "Jane Doe"
+    assert pos is None


### PR DESCRIPTION
Closes #1945 (child of #1913 raw-store extraction-completeness audit).

## What
Extract-more decision: parse the **Item 402(c) Summary Compensation Table (SCT)** out of the retained `def14a_body` payload into a new typed store + read endpoint, feeding exec-comp/pay signals to the thesis engine (#1919). No sweep — `def14a_body` stays KEEP-RAW.

## Source rule
**Regulation S-K Item 402 (17 CFR §229.402).** SCT columns are prescribed and **ordered** by §229.402(c)(2)(iii)–(x); the scaled SRC variant §229.402(n) omits columns but preserves order. The parser resolves the *present* dollar columns from the header **by matched text (never positional index)** into reg order, then zips data-row values against that ordered subset. `total_comp` is anchored to the reg's last column, `salary` to the first.

## Full-population verification (dev DB)
- 42,289 `def14a_body` rows; **8,001** contain an SCT (18.9%) — coverage is naturally bounded to comp-voting proxies, expected not a defect (spec §Full-population).
- 300-body random parse scan: **80% first-pass yield**, **0 negatives, 0 absurd totals**, 1.7% null-total. Misses (year-less single-year tables, packed multi-year cells) are logged, HTML-bounded.

## Parser (`app/providers/implementations/sec_def14a.py`)
Reuses the Item 403 engine (table scan/scoring/section windows). Survives real markup heterogeneity verified on the AAPL/HD/JPM/MSFT panel:
- name-cell `rowspan` → shifted continuation-year rows (carry-forward name)
- year folded into the name column; `—` explicit-null columns
- lone `$` spacer cells + bare footnote-superscript cells (e.g. JPM's stray `6`)
- zero-width-space (`​`) iXBRL spacer cells; unicode spaces
- interior blank-nulls → anchored ends keep `total_comp` correct even when the middle misaligns
- **table selection** requires a `name` header + `salary` + `total` columns → rejects the Pay-vs-Performance look-alike (Total but no Salary; negative CAP) and Director Comp (no Salary)
- window scan at **every** heading occurrence (the real SCT sits at a middle occurrence, not first/last)

## Schema
`sql/215_def14a_exec_compensation` — grain `(accession, exec, fiscal_year)`, UNIQUE `(instrument_id, accession, exec, fiscal_year)`, mirrors `sql/097`. Registered in `_PLANNER_TABLES`.

## Integration — one body pass, THREE call-sites, ONE version bump
`_PARSER_VERSION_DEF14A` v1→v2 (rewash imports the literal — can't drift). Version bump is the backfill vehicle (`known_to` supersession, settled-decisions.md:96).
1. **Manifest primary path** — comp parse+upsert in its **own savepoint AFTER** the holdings txn commits (#1700 isolation); best-effort, never changes the holdings ParseOutcome. Logs parsed-vs-addressable yield (no silent truncation).
2. **Rewash** — scoped DELETE+INSERT in its own savepoint; intentional regression (had comp, now zero) raises `RewashParseError`, unexpected errors are swallowed so the holdings rewash survives.
3. **Legacy first-ingest** — best-effort fold via `apply_exec_comp_best_effort`.

## Read endpoint
`GET /instruments/{symbol}/exec-compensation` — latest proxy's SCT (all NEOs, up to 3 FYs), tie-broken on `accession_number` (stable; `fetched_at` mutates on rewash).

## Verification (DoD clauses 8–12, at commit `20471640`)
- **Panel + endpoint (TestClient, dev DB)** — CEO latest-FY `total_comp`: **AAPL** Tim Cook FY2025 **$74,294,811** · **JPM** Jamie Dimon **$40,632,724** · **HD** Decker **$16,191,127** · **MSFT** Nadella **$96,496,790** · **GME** → 200 + empty (honest empty state).
- **Cross-source (clause 9)** — figures parsed directly from the stored SEC proxy bodies (SEC EDGAR direct = authoritative); match the as-filed proxies.
- **Backfill (clause 10)** — panel populated via the real writer path (`apply_exec_comp_best_effort`) at this commit; **full `POST /jobs/sec_rebuild/run {"source":"sec_def14a"}` + jobs-daemon restart is the post-merge operator runbook** (the running daemon must be on v2 first).

## Tests
- `tests/test_sec_def14a_sct_parser.py` — 14 pure tests, one per structural trap (rowspan shift, folded year, `$`/footnote spacers, ZWSP, interior blank-null anchor, SRC scaled, PvP rejection, no-SCT).
- `tests/test_def14a_ingest.py::TestExecCompensation` — 2 DB tests (insert→upsert idempotency, no-SCT no-op).
- Existing def14a version-stamp assertions bumped to v2.

## Gates
`ruff` + `ruff format` + `pyright` clean; fast tier 4804 passed; smoke 122 passed; def14a DB tier 87 passed. Codex ckpt-2 run pre-push (5 findings: 4 fixed — rewash savepoint isolation, total-anchor guard, name-header selection, endpoint tie-break; 1 rebutted — same-name-exec unique-key collapse mirrors settled `sql/097` holder_name identity).

## Tradeoffs
- v1 stores `principal_position` raw free-text; CEO/CFO canonicalisation deferred to the reader (thesis engine). Open q#1.
- Pay-vs-Performance (Item 402(v)) deferred to a child ticket. Open q#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)