### PR TITLE
feat(#1969): render DEF 14A Item 402(c) exec-compensation on the instrument grid

### DIFF
--- a/frontend/src/api/instruments.ts
+++ b/frontend/src/api/instruments.ts
@@ -391,6 +391,44 @@ export function fetchInsiderTransactions(
   );
 }
 
+/** One (executive, fiscal_year) row of the DEF 14A Item 402(c) Summary
+ *  Compensation Table (#1945). Mirrors app/api/instruments.py::ExecCompRow.
+ *  Dollar fields are Decimal-as-string, or null when the SCT column is
+ *  absent (scaled SRC table) or the cell was an explicit null. Figures
+ *  are USD (SEC proxy filings are USD-denominated). */
+export interface ExecCompRow {
+  executive_name: string;
+  principal_position: string | null;
+  fiscal_year: number;
+  salary: string | null;
+  bonus: string | null;
+  stock_awards: string | null;
+  option_awards: string | null;
+  non_equity_incentive: string | null;
+  pension_nqdc: string | null;
+  other_comp: string | null;
+  total_comp: string | null;
+}
+
+/** GET /instruments/{symbol}/exec-compensation — the latest proxy's SCT
+ *  (all NEOs, up to three fiscal years each), ordered fiscal_year DESC
+ *  then total_comp DESC. Empty `rows` (no SCT parsed for this issuer yet)
+ *  is a 200 with `accession_number` null. Mirrors
+ *  app/api/instruments.py::ExecCompensationResponse. */
+export interface ExecCompensationResponse {
+  symbol: string;
+  accession_number: string | null;
+  rows: ExecCompRow[];
+}
+
+export function fetchExecCompensation(
+  symbol: string,
+): Promise<ExecCompensationResponse> {
+  return apiFetch<ExecCompensationResponse>(
+    `/instruments/${encodeURIComponent(symbol)}/exec-compensation`,
+  );
+}
+
 
 export interface InstrumentHeadcount {
   symbol: string;

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -47,6 +47,7 @@ import { activeProviders } from "@/lib/capabilityProviders";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { BusinessSectionsTeaser } from "@/components/instrument/BusinessSectionsTeaser";
 import { DividendsPanel } from "@/components/instrument/DividendsPanel";
+import { ExecCompensationPanel } from "@/components/instrument/ExecCompensationPanel";
 import { FilingsPane } from "@/components/instrument/FilingsPane";
 import { FundamentalsPane } from "@/components/instrument/FundamentalsPane";
 import { InsiderActivitySummary } from "@/components/instrument/InsiderActivitySummary";
@@ -215,6 +216,13 @@ export function DensityGrid({
         <div className="col-span-12">
           <OwnershipPanel symbol={symbol} />
         </div>
+        {/* Zone E2 — Governance: executive compensation (#1969). Sits
+            next to Ownership — both are proxy-derived (DEF 14A)
+            governance surfaces. Self-gates to an honest empty state for
+            issuers with no parsed SCT, so it's harmless pre-backfill. */}
+        <div className="col-span-12">
+          <ExecCompensationPanel symbol={symbol} />
+        </div>
         {/* Zone F — Operator */}
         {thesis !== null || thesisErrored ? (
           <div className="col-span-12">
@@ -264,6 +272,12 @@ export function DensityGrid({
         ) : null}
         {/* Zone D — Activity (Insider + Recent news 6+6) */}
         {ActivityRow}
+        {/* Zone D2 — Governance: executive compensation (#1969). DEF 14A
+            proxy data is available to any SEC filer; self-gates to an
+            honest empty state when no SCT is parsed for the issuer. */}
+        <div className="col-span-12">
+          <ExecCompensationPanel symbol={symbol} />
+        </div>
         {/* Zone E — Operator */}
         {thesis !== null || thesisErrored ? (
           <div className="col-span-12">

--- a/frontend/src/components/instrument/ExecCompensationPanel.tsx
+++ b/frontend/src/components/instrument/ExecCompensationPanel.tsx
@@ -1,0 +1,145 @@
+/**
+ * ExecCompensationPanel — DEF 14A Item 402(c) Summary Compensation Table
+ * on the instrument Research grid (#1969, backend #1945).
+ *
+ * Renders the latest proxy's SCT grouped by executive (name + position
+ * once, up to three fiscal-year rows beneath, latest first), highest-paid
+ * NEO first. Figures are the filing's USD amounts, shown compact
+ * (`formatBigNumber`) so the eight SCT columns fit a full-width tile; the
+ * Total column is emphasised. Self-gates to an honest empty state when the
+ * issuer has no parsed SCT yet (many issuers file no comp-voting proxy),
+ * so the tile is harmless before the #1945 production backfill lands.
+ *
+ * Source rule: 17 CFR §229.402(c). Backend table def14a_exec_compensation.
+ */
+
+import { Fragment } from "react";
+import { useCallback } from "react";
+
+import { fetchExecCompensation } from "@/api/instruments";
+import type { ExecCompensationResponse } from "@/api/instruments";
+import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { Pane } from "@/components/instrument/Pane";
+import { EmptyState } from "@/components/states/EmptyState";
+import { groupExecComp, parseComp } from "@/components/instrument/execCompensation";
+import { formatBigNumber } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+export interface ExecCompensationPanelProps {
+  readonly symbol: string;
+}
+
+/** Compact USD magnitude for a Decimal-as-string comp cell; "—" when
+ *  the column is absent/null (matches the SCT convention of blank cells). */
+function money(value: string | null): string {
+  return formatBigNumber(parseComp(value));
+}
+
+export function ExecCompensationPanel({
+  symbol,
+}: ExecCompensationPanelProps): JSX.Element {
+  const state = useAsync<ExecCompensationResponse>(
+    // useAsync captures fn via a ref — fresh arrow per render is fine.
+    useCallback(() => fetchExecCompensation(symbol), [symbol]),
+    [symbol],
+  );
+
+  return (
+    <Pane title="Executive compensation" source={{ providers: ["sec_def14a"] }}>
+      {state.loading ? (
+        <SectionSkeleton rows={4} />
+      ) : state.error !== null || state.data === null ? (
+        <SectionError onRetry={state.refetch} />
+      ) : state.data.rows.length === 0 ? (
+        <EmptyState
+          title="No proxy compensation on file"
+          description="Populated from DEF 14A proxy Summary Compensation Tables (Item 402(c)). Not every issuer files a compensation-voting proxy."
+        />
+      ) : (
+        <PanelBody data={state.data} />
+      )}
+    </Pane>
+  );
+}
+
+function PanelBody({ data }: { data: ExecCompensationResponse }): JSX.Element {
+  const groups = groupExecComp(data.rows);
+  return (
+    <div>
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          <tr>
+            <th className="pb-1 pr-2 text-left font-medium">Fiscal year</th>
+            <th className="pb-1 px-2 text-right font-medium">Salary</th>
+            <th className="pb-1 px-2 text-right font-medium">Bonus</th>
+            <th className="pb-1 px-2 text-right font-medium">Stock</th>
+            <th className="pb-1 px-2 text-right font-medium">Option</th>
+            <th className="pb-1 px-2 text-right font-medium">Non-equity</th>
+            <th className="pb-1 px-2 text-right font-medium">Pension/NQDC</th>
+            <th className="pb-1 px-2 text-right font-medium">Other</th>
+            <th className="pb-1 pl-2 text-right font-medium">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map((group) => (
+            <Fragment key={group.executive_name}>
+              <tr className="border-t border-t-slate-200 dark:border-t-slate-700">
+                <td
+                  colSpan={9}
+                  className="pt-2 pb-1 text-slate-800 dark:text-slate-100"
+                >
+                  <span className="font-semibold">{group.executive_name}</span>
+                  {group.principal_position !== null ? (
+                    <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
+                      {group.principal_position}
+                    </span>
+                  ) : null}
+                </td>
+              </tr>
+              {group.years.map((year) => (
+                <tr
+                  key={year.fiscal_year}
+                  className="text-slate-700 dark:text-slate-200"
+                >
+                  <td className="py-1 pr-2 tabular-nums">
+                    FY {year.fiscal_year}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {money(year.salary)}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {money(year.bonus)}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {money(year.stock_awards)}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {money(year.option_awards)}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {money(year.non_equity_incentive)}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {money(year.pension_nqdc)}
+                  </td>
+                  <td className="py-1 px-2 text-right tabular-nums">
+                    {money(year.other_comp)}
+                  </td>
+                  <td className="py-1 pl-2 text-right font-semibold tabular-nums text-slate-900 dark:text-slate-100">
+                    {money(year.total_comp)}
+                  </td>
+                </tr>
+              ))}
+            </Fragment>
+          ))}
+        </tbody>
+      </table>
+      <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+        Summary Compensation Table · 17 CFR §229.402(c) · figures in USD
+        {data.accession_number !== null
+          ? ` · latest proxy ${data.accession_number}`
+          : ""}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/instrument/execCompensation.test.ts
+++ b/frontend/src/components/instrument/execCompensation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecCompRow } from "@/api/instruments";
+import { groupExecComp, parseComp } from "./execCompensation";
+
+function row(over: Partial<ExecCompRow>): ExecCompRow {
+  return {
+    executive_name: "Jane Doe",
+    principal_position: "Chief Executive Officer",
+    fiscal_year: 2025,
+    salary: "1000000.00",
+    bonus: null,
+    stock_awards: null,
+    option_awards: null,
+    non_equity_incentive: null,
+    pension_nqdc: null,
+    other_comp: null,
+    total_comp: "1000000.00",
+    ...over,
+  };
+}
+
+describe("parseComp", () => {
+  it("returns null for a null cell", () => {
+    expect(parseComp(null)).toBeNull();
+  });
+  it("parses a Decimal-as-string cell", () => {
+    expect(parseComp("74294811.00")).toBe(74294811);
+  });
+  it("returns null for a non-numeric string (never NaN)", () => {
+    expect(parseComp("n/a")).toBeNull();
+  });
+});
+
+describe("groupExecComp", () => {
+  it("groups rows by executive with years ordered fiscal_year DESC", () => {
+    const groups = groupExecComp([
+      row({ executive_name: "A", fiscal_year: 2024, total_comp: "50" }),
+      row({ executive_name: "A", fiscal_year: 2025, total_comp: "60" }),
+      row({ executive_name: "A", fiscal_year: 2023, total_comp: "40" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.years.map((y) => y.fiscal_year)).toEqual([
+      2025, 2024, 2023,
+    ]);
+  });
+
+  it("takes the position from the executive's most-recent year", () => {
+    const groups = groupExecComp([
+      row({
+        executive_name: "A",
+        fiscal_year: 2024,
+        principal_position: "SVP",
+      }),
+      row({
+        executive_name: "A",
+        fiscal_year: 2025,
+        principal_position: "CEO",
+      }),
+    ]);
+    expect(groups[0]!.principal_position).toBe("CEO");
+  });
+
+  it("orders executives by latest-FY total_comp DESC (highest-paid first)", () => {
+    const groups = groupExecComp([
+      row({ executive_name: "CFO", fiscal_year: 2025, total_comp: "20000000" }),
+      row({ executive_name: "CEO", fiscal_year: 2025, total_comp: "74000000" }),
+      row({ executive_name: "COO", fiscal_year: 2025, total_comp: "27000000" }),
+    ]);
+    expect(groups.map((g) => g.executive_name)).toEqual(["CEO", "COO", "CFO"]);
+  });
+
+  it("sorts an executive whose latest total is null to the end", () => {
+    const groups = groupExecComp([
+      row({ executive_name: "NoTotal", fiscal_year: 2025, total_comp: null }),
+      row({ executive_name: "Paid", fiscal_year: 2025, total_comp: "5000000" }),
+    ]);
+    expect(groups.map((g) => g.executive_name)).toEqual(["Paid", "NoTotal"]);
+  });
+
+  it("breaks ties on first-appearance order (stable, deterministic)", () => {
+    const groups = groupExecComp([
+      row({ executive_name: "First", fiscal_year: 2025, total_comp: "1000" }),
+      row({ executive_name: "Second", fiscal_year: 2025, total_comp: "1000" }),
+    ]);
+    expect(groups.map((g) => g.executive_name)).toEqual(["First", "Second"]);
+  });
+
+  it("returns [] for no rows", () => {
+    expect(groupExecComp([])).toEqual([]);
+  });
+});

--- a/frontend/src/components/instrument/execCompensation.ts
+++ b/frontend/src/components/instrument/execCompensation.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure presentation helpers for the ExecCompensationPanel (#1969).
+ *
+ * The /exec-compensation endpoint returns a FLAT list of (executive,
+ * fiscal_year) SCT rows ordered fiscal_year DESC, total_comp DESC
+ * (17 CFR §229.402(c)). The panel renders them GROUPED by executive —
+ * name + position once, up to three fiscal-year sub-rows beneath — which
+ * is the conventional proxy Summary-Compensation-Table layout. This
+ * module owns that grouping (pure, table-tested; the panel stays a thin
+ * render wrapper).
+ */
+
+import type { ExecCompRow } from "@/api/instruments";
+
+export interface ExecCompGroup {
+  readonly executive_name: string;
+  /** Position from the executive's most-recent fiscal-year row. */
+  readonly principal_position: string | null;
+  /** The executive's rows, one per fiscal year, ordered fiscal_year DESC. */
+  readonly years: readonly ExecCompRow[];
+}
+
+/** Parse a Decimal-as-string comp cell to a finite number, or null.
+ *  Empty/absent cells and non-numeric strings both collapse to null so
+ *  callers render the "—" sentinel rather than "NaN"/"$0". */
+export function parseComp(value: string | null): number | null {
+  if (value === null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Group flat SCT rows by executive.
+ *
+ * - Within each executive: rows ordered fiscal_year DESC (latest first).
+ * - Executives ordered by their most-recent-fiscal-year total_comp DESC
+ *   (highest-paid NEO first — typically the CEO), matching the SCT's own
+ *   ordering intent. Executives whose latest row has a null total sort
+ *   last; ties fall back to first-appearance order in `rows` (stable),
+ *   so the ordering is deterministic regardless of Map iteration nuances.
+ */
+export function groupExecComp(rows: readonly ExecCompRow[]): ExecCompGroup[] {
+  const byExec = new Map<string, ExecCompRow[]>();
+  const firstSeen = new Map<string, number>();
+  rows.forEach((row, index) => {
+    const bucket = byExec.get(row.executive_name);
+    if (bucket !== undefined) {
+      bucket.push(row);
+    } else {
+      byExec.set(row.executive_name, [row]);
+      firstSeen.set(row.executive_name, index);
+    }
+  });
+
+  const groups = Array.from(byExec, ([name, execRows]) => {
+    const years = [...execRows].sort((a, b) => b.fiscal_year - a.fiscal_year);
+    return {
+      executive_name: name,
+      principal_position: years[0]?.principal_position ?? null,
+      years,
+    };
+  });
+
+  return groups.sort((a, b) => {
+    const ta = parseComp(a.years[0]?.total_comp ?? null);
+    const tb = parseComp(b.years[0]?.total_comp ?? null);
+    if (ta !== null && tb !== null && ta !== tb) return tb - ta;
+    if ((ta === null) !== (tb === null)) return ta === null ? 1 : -1;
+    return (
+      (firstSeen.get(a.executive_name) ?? 0) -
+      (firstSeen.get(b.executive_name) ?? 0)
+    );
+  });
+}


### PR DESCRIPTION
## What & why
Closes #1969. #1945 (PR #1966) shipped the backend `GET /instruments/{symbol}/exec-compensation`, but nothing in the frontend consumed it — the extracted governance/comp data was invisible to the operator. This adds the FE tile.

## Change
New **Executive compensation** governance tile on the instrument Research density grid, rendering the latest proxy's Summary Compensation Table (17 CFR §229.402(c)) grouped by executive.

- **`api/instruments.ts`** — `ExecCompRow` + `ExecCompensationResponse` interfaces (hand-mirror the Pydantic `response_model` in `app/api/instruments.py`; Decimal → `string | null`, `principal_position: string | null`) + `fetchExecCompensation`.
- **`execCompensation.ts`** — pure `groupExecComp` (years FY DESC; executives ordered by latest-FY `total_comp` DESC = highest-paid NEO first; null-total last; stable first-appearance tie-break) + `parseComp` (Decimal-string → finite number | null, never NaN). Table-tested.
- **`ExecCompensationPanel.tsx`** — `Pane` + `useAsync`; loading (`SectionSkeleton`) / error (`SectionError`) / empty (`EmptyState`) / data branches per the `loading-error-empty-states` skill. Eight SCT columns, Total emphasised, compact USD via `formatBigNumber`, caption cites §229.402(c) + latest proxy accession.
- **`DensityGrid.tsx`** — full-width tile next to Ownership (Zone E2) in `full-sec`, after Activity in `partial-filings`; skipped in `minimal` (no CIK → no proxy ever).

## Operator decisions (both taken per the issue's own recommendations)
1. **Placement** — governance zone adjacent to Ownership (both are DEF 14A / proxy-derived). Full-width.
2. **Coverage gate** — option (b): the panel **self-gates on empty `rows`** (endpoint returns 200 + `rows:[]` for non-filers) and renders an honest empty state. No new `has_exec_comp` summary flag added. Harmless before the #1945 production backfill.

Deviation from the issue's proposed column list: it omitted Bonus and Pension/NQDC; I render the **full eight-column SCT** so no filed data is dropped (faithful to §229.402(c); AAPL happens to have both null).

## Currency
Comp figures are the filing's own **USD** amounts (SEC proxies are USD-denominated) — not converted to display-currency (that would misrepresent a disclosed figure, and no FX applies here). Caption states "figures in USD".

## Verification
FE-QA against the dev DB (throwaway `vite --port 5199` from this worktree → same `:8000` backend; protected `:5173`/`:8000` tasks untouched):
- **AAPL** — 6 NEOs, FY2023-25, ordered Cook **74.29M** → O'Brien 27.05M → … → Maestri (Former CFO) 15.48M; null cells render "—"; Total bold; caption `17 CFR §229.402(c) · figures in USD · latest proxy 0001308179-26-000008`. Figure matches endpoint.
- **GME** (0 parsed rows) — renders the honest empty state.
- **Dark mode** — text `slate-100/200` on transparent-over-`slate-950` (computed-style verified).
- **Layout (#1858)** — `scrollTop + clientHeight == scrollHeight`; only `pb-6` padding below the last element, no dead scroll void; tall 1440×1400 viewport.
- **0 console errors** on both routes.

Gates: `pnpm typecheck` clean · `pnpm test:unit` 1297 passed (incl. 9 new `groupExecComp`/`parseComp` cases) · dark-class gate clean. FE-only (no API/jobs/schema change → no daemon restart, no backfill in this PR; production backfill remains operator-gated on #1945).

🤖 Generated with [Claude Code](https://claude.com/claude-code)