### PR TITLE
fix: add merge_gate.doc_only_paths to unblock safe_merge (silent abort)

### DIFF
--- a/.autonomy/config.yaml
+++ b/.autonomy/config.yaml
@@ -16,3 +16,13 @@ merge_gate:
   author_login: github-actions
   marker: "Claude Code Review"
   doc_only_extensions: [".md"]
+  # Required by safe_merge.sh's bot_comment gate: it computes
+  # doc_only_paths="$(CONFIG_GET merge_gate.doc_only_paths | paste -sd, -)"
+  # under `set -euo pipefail`, so a MISSING key makes CONFIG_GET exit
+  # non-zero, the pipeline fail, and the whole merge gate abort silently
+  # (exit 1, no message) BEFORE the `:-docs/` default or any gate check
+  # runs — blocking every merge. Set it explicitly to the engine's
+  # intended default. Only affects the doc-only fast-path classification
+  # (a PR whose every file is doc-only); non-doc PRs still require the
+  # full bot-APPROVE-on-latest-commit gate.
+  doc_only_paths: ["docs/"]


### PR DESCRIPTION
## Problem
`safe_merge.sh` (autonomy-engine merge gate) has been **silently blocking every merge** on this repo.

Its `bot_comment` dispatch runs, under `set -euo pipefail`:
```sh
doc_only_paths="$(CONFIG_GET merge_gate.doc_only_paths | paste -sd, -)"; doc_only_paths="${doc_only_paths:-docs/}"
```
`merge_gate.doc_only_paths` was **absent** from `.autonomy/config.yaml`, so `CONFIG_GET` exits non-zero → `pipefail` propagates it to the assignment → `set -e` aborts the entire script **before** the `${…:-docs/}` default (or any gate check) can run. The abort is silent: exit 1, nothing on stdout/stderr. Observed while trying to merge PR #1970.

## Fix
Set the key explicitly to the engine's own intended default:
```yaml
doc_only_paths: ["docs/"]
```

## Why this doesn't weaken the merge gate
`doc_only_paths` only feeds the **doc-only fast-path** (`is_doc_only`), which requires *every* changed file in a PR to match `.md` / a doc path. Non-doc PRs (code, config, this PR itself — `.yaml`) never take that path; they still require the full **bot-APPROVE-on-latest-commit + CI-green** gate. The value chosen is exactly what the engine defaults to when the key is present, so behaviour is unchanged from the engine's design intent — this only removes the crash.

## Verification
```
# before: CONFIG_GET merge_gate.doc_only_paths → exit 1; the pipefail assignment aborts set -e (silent)
# after:
$ python3 lib/config_parser.py .autonomy/config.yaml merge_gate.doc_only_paths  → "docs/" (exit 0)
$ set -euo pipefail; v="$(... | paste -sd, -)"; echo "[${v:-docs/}]"                → [docs/] (exit 0)
```

## Follow-up (engine-side, out of scope here)
Root cause is also a **latent fragility in `autonomy-engine/bin/safe_merge.sh`**: a missing optional config key should not be fatal. The engine should compute this tolerantly (e.g. `CONFIG_GET … || true`, or have `config_parser.py` exit 0 with empty for a missing key). Recommend hardening engine-side in a separate change so no other consumer repo can hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)