### PR TITLE
fix(#1976): raise Claude review max_tokens 5000→16000 — adaptive thinking starved text block on large PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -280,9 +280,15 @@ jobs:
           # comparable in depth to Sonnet 4.6 at "high". "low" undershot the
           # triage work this bot needs to do (catching hallucinated/
           # already-rebutted/out-of-diff findings before posting).
+          #
+          # max_tokens must leave headroom for thinking + text: adaptive
+          # thinking shares the max_tokens budget, and on a large diff
+          # (PR #1973, 279k input tokens) it consumed all 5000 tokens as
+          # thinking, emitting NO text block at all (#1976). 16000 is a
+          # cap, not a spend — billing is on actual output tokens only.
           payload = {
               "model": "claude-sonnet-5",
-              "max_tokens": 5000,
+              "max_tokens": 16000,
               "thinking": {"type": "adaptive"},
               "output_config": {"effort": "medium"},
               "system": [
@@ -333,7 +339,11 @@ jobs:
           # are internal and must not be posted to the PR.
           text_blocks = [b for b in data['content'] if b.get('type') == 'text']
           if not text_blocks:
-              print('No text block in response content:', json.dumps(data, indent=2))
+              if stop_reason == 'max_tokens':
+                  usage = data.get('usage', {})
+                  print(f'Thinking consumed the entire max_tokens budget before any text was emitted (usage={usage}). Raise max_tokens in claude-review.yml (#1976).')
+              else:
+                  print('No text block in response content:', json.dumps(data, indent=2))
               sys.exit(1)
           text = text_blocks[0]['text']
           with open('stop_reason.txt', 'w') as f:


### PR DESCRIPTION
Closes #1976.

## What
`.github/workflows/claude-review.yml` only:
- `max_tokens` 5000 → 16000 in the review API call.
- Distinct diagnostic when the response has no text block AND `stop_reason=max_tokens` (prints usage + points at the cap) instead of the generic dump.

## Why
Review workflow failed twice on PR #1973 (424B parser, 279k input tokens): adaptive thinking consumed the entire 5000-token output budget (`thinking_tokens: 5000`), API returned a thinking block and **no text block**, extraction exited 1 — review never posts, and the merge gate (bot APPROVE on latest SHA) can never be satisfied. Evidence: run 28724980118.

## Security model
No new interpolation of untrusted input: the change is a numeric cap + comment, and a diagnostic that prints the API `usage` object (server-generated), not PR-controlled content. Existing env-var quoting patterns untouched.

## Tradeoffs
- 16000 is a ceiling, not a spend — Anthropic bills actual output tokens only. The existing "Fail workflow on truncated review" step still hard-fails if the new cap is ever hit, so truncation remains loud.
- Effort left at `medium` — thinking depth was doing its triage job; the bug was only the shared budget starving the text.

## Verification
- YAML parses (`yaml.safe_load`).
- Full pre-push gate green (ruff, pyright, 23 chokepoint lints, fast tier, smoke, dark-mode check).
- Codex review of the branch diff: no findings (checked shell-quoting hazards inside the `python3 -c` block + workflow-injection surface).

## Follow-up after merge
Push an empty commit to PR #1973 so its `pull_request` merge ref picks up the updated workflow from main and the review re-runs under the new cap.