### PR TITLE
spec(#1982): tender/going-private parser — SC TO-T/TO-I/14D9/13E3 → tender_offer_events

### DIFF
--- a/docs/specs/filings/2026-07-05-tender-going-private-parser.md
+++ b/docs/specs/filings/2026-07-05-tender-going-private-parser.md
@@ -1,0 +1,370 @@
+# Tender / going-private parser (Schedule TO + 14D-9 + 13E-3 → structured)
+
+Issue #1982 (child of #1015 item-4; items 1–2 shipped: NT PR1793, 424B PR1973/PR1981).
+Promotes the tender-offer / going-private Schedule family from metadata-only to
+PARSE+RAW: a new manifest source `sec_tender` that fetches the primary document
++ the SGML filing header and extracts the **Reg M-A cover disclosures** — subject
+company, offeror(s), transaction-type checkboxes, offer price, class/CUSIP,
+board recommendation (14D-9) — into a structured table `tender_offer_events`.
+Subject-vs-offeror attribution comes from the EDGAR SGML header CIK blocks, not
+from which instrument row happened to seed the manifest.
+
+## Source rule
+
+- **SC TO-T — Rule 14d-1(g) / Schedule TO (17 CFR 240.14d-100)**: third-party
+  tender offer statement. Content items defined by **Reg M-A (17 CFR
+  229.1000–1016)**: Item 1002 subject company, Item 1003 identity of filing
+  persons, **Item 1004(a) material terms** (consideration, expiration). The
+  cover carries subject company, offeror(s), title of class, CUSIP, and the
+  transaction-type checkboxes (verified on live NUVL/GSK `0001193125-26-280246`
+  and DSX/Genco `0001104659-26-079410` covers).
+- **SC TO-I — Rule 13e-4**: issuer self-tender on the same Schedule TO shell
+  (same cover; "issuer tender offer subject to Rule 13e-4" box checked —
+  verified on IQ `0001193125-26-043648`). Different thesis signal (capital
+  return / note repurchase, not takeout) — hence the checkbox booleans are
+  stored, not collapsed into one "tender" flag.
+- **SC 14D9 — Rule 14d-9 / Schedule 14D-9 (17 CFR 240.14d-101)**: subject
+  company's solicitation/recommendation statement. **Reg M-A Item 1012(a) (17
+  CFR 229.1012(a))** is the high-signal field and — critically — the rule
+  itself enumerates the only permitted positions: the subject company either
+  **recommends acceptance or rejection**, **expresses no opinion and is
+  remaining neutral**, or **is unable to take a position**. That closed
+  enumeration is what makes `board_recommendation` a deterministic pattern
+  extraction (4-state enum + NULL), NOT free-text classification (prevention
+  #1659 does not apply to a reg-enumerated vocabulary; anything not matching
+  the enumerated formulas stays NULL).
+- **SC 13E3 — Rule 13e-3 (17 CFR 240.13e-3) / Schedule 13E-3 (Rule 13e-100)**:
+  going-private transaction statement; Reg M-A Item 1014 fairness
+  determination. Cover carries subject/filing-persons/class/CUSIP + its own
+  transaction-context checkboxes (verified on BALY `0001213900-24-073431`).
+- **Attribution — EDGAR SGML filing header**: every accession's
+  `<acc>.hdr.sgml` (also embedded in the `<acc>.txt` envelope) carries
+  structured `SUBJECT COMPANY:` and `FILED BY:` blocks, each with a
+  `CENTRAL INDEX KEY`. Verified on `0001193125-26-280246.hdr.sgml` (1.6 KB:
+  SUBJECT=Nuvalent `0001861560`, FILED BY=GSK plc `0001131399`). This is the
+  documented EDGAR dissemination structure and the ONLY deterministic
+  subject-vs-offeror source — the master index attributes the accession to
+  BOTH CIKs, and cover name-matching is fuzzy.
+- **Offer price + expiration — Reg M-A Item 1004(a)(1) (17 CFR
+  229.1004(a)(1))**: Schedule TO Item 4 ("Terms of the Transaction") REQUIRES
+  disclosure of the material terms, including **(ii) the type and amount of
+  consideration offered** and **(v) the scheduled expiration date**. So the
+  CONTENT is rule-mandated; the *presentation* is not standardized (no cover
+  table analogous to Item 501(b)(3)) — it appears in body prose in a
+  conventional formula: "for **$124.00 per Share, net** to the seller in cash"
+  (NUVL). The anchored regex targets that observed convention and is
+  **empirical until the full-population dry-run proves it** (acceptance gate
+  below reports price + expiration hit-rate by form; nullable on no-match).
+
+## Premise check + full-population scoping (dev DB, 2026-07-05)
+
+Full-population counts (this session, `filing_events`):
+
+| form | rows | instruments | span | with URL |
+|---|---:|---:|---|---|
+| SC TO-T / TO-T/A | 207 / 1,055 | 135 / 139 | 2016–2026 | 100% |
+| SC 14D9 / 14D9/A | 69 / 235 | 44 / 33 | 2016–2026 | 100% |
+| SC TO-I / TO-I/A | 28 / 68 | 17 / 20 | 2016–2026 | 100% |
+| SC 13E3 / 13E3/A | 4 / 27 | 3 / 10 | 2019–2026 | 100% |
+| PREM14C / DEFM14C | 30 / 30 | 26 / 27 | 2016–2026 | 100% (out of parse scope — see Deferred) |
+
+- **Dual attribution is systemic, not an oddity**: 113 SC TO-T(/A) accessions
+  (plus 2 M14C) land on **more than one instrument** via the master-index path
+  — e.g. `0001193125-26-280246` exists as a NUVL row AND a GSK row, each with
+  its own CIK in the archive URL. Verified full-pop: all 1,753 URL-bearing
+  rows' archive-directory CIK == that instrument's own `external_identifiers`
+  CIK (`identifier_type='cik'`; 201/201 instruments have one). So each
+  `filing_events` row is "this instrument is a party"; WHICH party comes only
+  from the header blocks.
+- **Manifest constraint**: `sec_filing_manifest.accession_number` is the
+  **PRIMARY KEY** (sql/118) — one accession = ONE manifest row = one
+  `instrument_id`. Discovery from either party's submissions feed upserts the
+  row **last-discovery-wins**: `record_manifest_entry`
+  (sec_manifest.py:315) refreshes `cik`/`subject_id`/`instrument_id` on every
+  conflict. Therefore the manifest row's `instrument_id` is **arbitrary
+  between the parties** (and can flip between re-discoveries) and the parser
+  must derive roles for BOTH from the header, writing typed rows independent
+  of which party owns the manifest row.
+- **Self-filed forms carry both header blocks**: LPRO 14D-9
+  `0001193125-26-286952.hdr.sgml` has `SUBJECT-COMPANY` AND `FILED-BY` blocks
+  both = Open Lending `0001806201` — so role derivation needs no
+  missing-block fallback; a CIK matching both blocks collapses to `subject`.
+  The dry-run reports header-block presence by form to catch any variant.
+- **Offer-price phrasing**: naive `$X per share` matching false-positives on
+  **par value** ("Common Stock, par value $0.01 per share" — every cover).
+  The true price appears in the conventional offer formula "for $124.00 per Share,
+  net to the seller in cash" (NUVL), "at a purchase price of $3.15 per Share,
+  net to the holder thereof, in cash" (LPRO 14D-9). Extraction must anchor on
+  the `per <unit>, net` / `purchase price of` formulas and hard-exclude `par
+  value` contexts.
+- **Checkbox glyph drift**: modern filings use `☒`/`☐`; older/other filer
+  agents emit `x`/`¨` (Wingdings — DSX 2026 amendment still does). The NUVL
+  cover also carries a filer typo (the "Third-party tender offer" line appears
+  twice, one checked one not) → checkbox mapping must anchor each box on its
+  own LABEL text and tolerate duplicate labels (checked-anywhere wins), never
+  on box position.
+- **Keep-list drift (live data-loss hazard)**: `SEC_METADATA_ONLY`
+  (`app/services/filings.py:278`) lists **`DEF 13E-3`** — a dead string, 0
+  rows ever (EDGAR emits `SC 13E3`(/A)). `SC TO-I(/A)` and `SC 13E3(/A)` (227
+  rows) are in `filing_events` via the master-index path but **absent from
+  `SEC_INGEST_KEEP_FORMS`** — `filing_events_cleanup` (#1013) deletes SEC rows
+  not in that union, so an operator cleanup run would silently destroy the
+  going-private/self-tender history (prevention: "allow-list must cover every
+  naming convention the ingest path accepts before a delete keys on it").
+  Fixed in this PR by moving the real form strings into `SEC_PARSE_AND_RAW`
+  and deleting the dead string.
+- **14D9 recommendation phrasing**: LPRO renders the Item 1012(a) position as
+  "…recommends that the stockholders **accept the Offer and tender their
+  Shares**…" — the reg-enumerated vocabulary, repeatably phrased.
+
+## Extracted fields (`tender_offer_events`)
+
+One row per **(accession, instrument)** — PK `(accession_number,
+instrument_id)`. `role` is an attribute of that pair, not a key dimension: a
+dual-attributed accession yields a `subject` row for the target and an
+`offeror` row for the acquirer when both are in universe; a CIK appearing in
+BOTH header blocks (the self-filed case: TO-I, 14D-9, most 13E3) collapses to
+a single row with `role='subject'` (explicit collapse rule — there is never a
+per-instrument role conflict).
+
+| column | source | null? |
+|--------|--------|-------|
+| `accession_number` (PK1) | manifest | no |
+| `instrument_id` (PK2, BIGINT) | header CIK → `external_identifiers.identifier_type='cik'` | no |
+| `role` (TEXT CHECK `subject`/`offeror`) | header block the instrument's CIK matched (`SUBJECT COMPANY` vs `FILED BY`; both-blocks ⇒ `subject` per the collapse rule above) | no |
+| `form` (TEXT) | manifest form (raw, incl. `/A`) | no |
+| `subject_company_name` (TEXT) | header `SUBJECT COMPANY` conformed name | no |
+| `subject_cik` (TEXT) | header | no |
+| `offeror_names` (JSONB array) | header `FILED BY` conformed names (may be multiple blocks) | yes (self-filed forms may have no separate FILED BY) |
+| `is_third_party_tender` / `is_issuer_tender` / `is_going_private` / `amends_13d` (BOOL) | Schedule TO / 13E-3 cover transaction-type checkboxes, label-anchored | **yes** (nullable-checkbox discipline — unreadable/absent ⇒ NULL, never guessed; 14D9 has no such boxes ⇒ all NULL) |
+| `is_final_amendment` (BOOL) | "final amendment reporting the results" cover checkbox | yes |
+| `amendment_no` (INT) | cover "(Amendment No. N)" | yes |
+| `offer_price_per_unit` (NUMERIC) | Item 1004(a)(1)(ii) consideration, via the anchored body formula (see parser) | yes |
+| `unit_label` (TEXT) | the matched per-unit word ("Share"/"ADS"/"Note"/"Unit") | yes |
+| `currency` (TEXT CHECK enum) | the currency glyph AT the matched price (`$`/`US$` ⇒ USD, `€` ⇒ EUR, `£` ⇒ GBP) | **yes** (NULL whenever `offer_price_per_unit` is NULL — never defaulted without a matched price) |
+| `expiration_date` (DATE) | Item 1004(a)(1)(v) scheduled expiration, via best-effort "expire(s) … on <date>" body formula; hit-rate gated in the dry-run | yes |
+| `board_recommendation` (TEXT CHECK `accept`/`reject`/`neutral`/`unable`) | 14D-9 Item 1012(a) enumerated formulas | yes (non-14D9 forms and unmatched prose ⇒ NULL) |
+| `security_class_title` (TEXT) | cover "(Title of Class of Securities)" | yes |
+| `cusip` (TEXT) | cover "(CUSIP Number of Class of Securities)" | yes |
+| `parser_version` (INT) | const | no |
+| `parsed_at` (TIMESTAMPTZ) | NOW() | no |
+
+Every extracted field nullable-when-unresolved, never guessed (NT/424B
+discipline). A row with NULL price but resolved roles is a valid outcome —
+"a tender event exists, parties known" is itself the thesis signal. Do NOT
+compute transaction value (price × shares): share counts in fee tables are
+as-of dates that drift; storing a fabricated total repeats the 424B
+no-multiply rule.
+
+Amendments are their own rows (form carries `/A`; manifest chains via
+`amends_accession`). The amendment stream IS the signal evolution (price
+bumps, extensions, `is_final_amendment` results row) — readers wanting
+"current state" take the latest row per (instrument, base accession chain).
+
+## Deferred (explicit — not silently dropped)
+
+1. **PREM14C / DEFM14C parsing** — Schedule 14C (17 CFR 240.14c-101) Item 1
+   incorporates the Schedule 14A items; merger consideration lives in Schedule
+   14A **Item 14 prose** (which cross-references Reg M-A items but mandates no
+   cover-page terms presentation analogous to the Schedule TO cover). Prose
+   extraction = the prevention #1659 trap. Rows stay `SEC_METADATA_ONLY`; the
+   going-private signal for those transactions is carried by the companion SC
+   13E3 (which IS parsed). Revisit only with a documented source rule for 14C
+   merger-consideration extraction.
+2. **SC TO-C** (38 rows) — filed under **Rule 14d-2(b)(1) / Rule
+   13e-4(c)(1)** for **pre-commencement written communications** (the Schedule
+   TO cover's own first checkbox: "filing relates solely to preliminary
+   communications made before the commencement of a tender offer"). Item
+   1004 terms attach to the Schedule TO on commencement, not to these
+   communications — nothing structured to extract. Stays out of keep-list
+   scope; noted here so the exclusion is deliberate.
+3. **Offer-to-Purchase exhibit fetch** — when the Schedule TO body carries no
+   price (incorporation-by-reference into exhibit (a)(1)(A)), we do NOT chase
+   the exhibit in v1; price stays NULL. If the full-pop dry-run shows a
+   material NULL-price share traceable to exhibit-only pricing, that is a
+   child ticket (exhibit URL resolution is its own fetch-pipeline shape).
+4. **Premium-vs-market signal** (offer price vs pre-announcement close) —
+   feeds scoring → `model_version` bump, operator-gated (class of
+   #1857/#1939/#1660). Display/evidence only in this PR.
+
+## Schema
+
+- `sql/218_tender_offer_events.sql` — new table as above; composite PK
+  `(accession_number, instrument_id)`, index on `instrument_id`. FK-free
+  instrument_id (mirrors `nt_filing_notices`/`prospectus_offerings`). Same
+  migration (each CHECK verified present on dev before widening — prevention
+  "grep CREATE+ALTER constraints"):
+  - `filing_raw_documents_document_kind_check` += `'tender_body'`.
+  - `sec_filing_manifest_source_check` += `'sec_tender'`.
+  - `data_freshness_index_source_check` += `'sec_tender'`.
+  - `tender_offer_events_role_check`, `_recommendation_check`,
+    `_currency_check` enums per the table above.
+- Bodies are mixed-size (13 KB Schedule TOs … 518 KB 14D-9s) and the
+  population is tiny (~1,783 + trickle) → `tender_body` goes to
+  **`SWEPT_DOCUMENT_KINDS`** (mirror 424B: structured row is the durable
+  artifact; a rewash re-fetches — the full population re-fetches in ~3 min at
+  10 req/s, so sweeping costs nothing operationally). The hdr.sgml header is
+  parsed in-memory and never stored raw (1–2 KB, rehydratable; its durable
+  facts land as `subject_cik`/`offeror_names` columns).
+
+## Parser
+
+- `app/services/tender_offers.py` — **pure** extractor
+  `parse_tender_offer(body_html, header_sgml, form) -> TenderOfferParse | None`
+  (None ⇒ header unusable / body not a recognizable schedule ⇒ tombstone)
+  returning the cover/body fields + the header party blocks
+  (`subject: (cik, name)`, `filed_by: [(cik, name), …]`); plus
+  `upsert_tender_offer_events(conn, rows)`. Pure-fn table-tested on the five
+  real fixtures fetched this session (NUVL TO-T, DSX TO-T/A, IQ TO-I, LPRO
+  14D-9, BALY 13E3). Extraction rules grounded on those fixtures, then gated
+  by the full-population dry-run (below):
+  - **Header**: parse `SUBJECT COMPANY:`/`FILED BY:` SGML blocks →
+    `(CONFORMED NAME, CIK)` pairs. Multiple FILED BY blocks allowed.
+  - **Checkboxes**: per-box label anchoring ("third-party tender offer subject
+    to Rule 14d-1" / "issuer tender offer subject to Rule 13e-4" /
+    "going-private transaction subject to Rule 13e-3" / "amendment to Schedule
+    13D under Rule 13d-2" / "final amendment reporting the results"); checked
+    glyphs `☒`/`x`/`X` adjacent to the label, unchecked `☐`/`¨`/`o`;
+    duplicate labels → checked-anywhere wins; no glyph resolvable → NULL.
+  - **Price** (Item 1004(a)(1)(ii) consideration; the REGEX is empirical
+    convention, gated by the full-pop dry-run): anchored formulas only —
+    `(?:for|at|of)\s+\$AMOUNT per <unit>[^.]{0,40}(?:net|in cash)` and
+    `(?:purchase price|Offer Price)[^$]{0,80}\$AMOUNT` — with a hard
+    exclusion window around `par value`. First match wins; conflicting
+    distinct amounts across matches → NULL (ambiguous).
+  - **Recommendation** (14D-9 only): Item 1012(a) enumerated formulas —
+    `recommend … accept` ⇒ `accept`; `recommend … reject` ⇒ `reject`;
+    `no opinion … remaining neutral` ⇒ `neutral`; `unable to take a position`
+    ⇒ `unable`; else NULL.
+  - **Role rows**: map subject CIK + each filed-by CIK through
+    `external_identifiers` (`identifier_type='cik'`) → instruments; emit one
+    row per matched instrument. CIK in both blocks ⇒ `subject`. Zero matched
+    instruments ⇒ tombstone (event concerns nothing in universe — can happen
+    only if identifiers churned after seeding).
+- `app/services/manifest_parsers/sec_tender.py` — `_parse_tender(conn, row) ->
+  ParseOutcome` mirroring `sec_nt.py`: pre-fetch gates (missing
+  url/instrument_id → tombstone) → fetch body via
+  `SecFilingsProvider.fetch_document_text` → empty/non-200 → tombstone,
+  fetch-exception → failed(retry) → fetch `<acc>.hdr.sgml` (URL derived from
+  the primary-document archive directory; small, same rate-limit budget;
+  fetch-exception → failed(retry)) → `store_raw(document_kind='tender_body')`
+  in a savepoint → parse → None → tombstone → else upsert rows.
+  `_tender_fetch_url` prefetch hook + `register("sec_tender", …,
+  requires_raw_payload=True)`; registered in `manifest_parsers/__init__.py`.
+
+  **`raw_status` invariant (#938):** after `store_raw` succeeds every
+  subsequent outcome carries `raw_status="stored"` (prevention "bare call
+  after committed savepoint splits raw/manifest status").
+
+  Rewash: register the spec in `rewash_filings.registered_specs()` — bodies
+  are swept, so the rewash path re-fetches (documented there; tiny
+  population).
+
+## Chokepoint registrations (source-to-sink smoke `tests/smoke/test_etl_source_to_sink.py`)
+
+Mirror of the 424B/NT checklist — every `ManifestSource` chokepoint:
+
+1. `app/services/filings.py` — `SC TO-T(/A)`, `SC 14D9(/A)` move
+   `SEC_METADATA_ONLY` → `SEC_PARSE_AND_RAW`; `SC TO-I(/A)`, `SC 13E3(/A)`
+   **added** to `SEC_PARSE_AND_RAW` (previously missing from the union —
+   cleanup-delete hazard above); dead `DEF 13E-3` string **removed**.
+   PREM14C/DEFM14C stay `SEC_METADATA_ONLY` (documented inline).
+2. `app/services/sec_manifest.py` — `ManifestSource` Literal += `"sec_tender"`;
+   `_FORM_TO_SOURCE` += the eight in-scope form codes → `sec_tender`.
+3. `app/services/capability_manifest_mapping.py` — `sec_tender` →
+   `_UNMAPPED_MANIFEST_SOURCES` (episodic event, no standing per-instrument
+   coverage expectation — NT/424B rationale; documented inline).
+4. `app/services/data_freshness.py` — episodic; generous staleness cap so a
+   never-tendered name never reads "stale".
+5. `app/services/processes/param_metadata.py` — `sec_rebuild` source enum +=
+   `sec_tender`.
+6. `app/jobs/sec_first_install_drain.py` — population is tiny → seed
+   `initial_ingest_status="pending"` (like NT; NOT deferred like heavy
+   10-K/8-K bodies — ~1.8k bodies drain in minutes).
+7. `scripts/_etl_source_inventory.py` — `MANIFEST_SOURCE_SINKS["sec_tender"]
+   = (("tender_offer_events",), "tender_offer_event")`.
+8. `app/services/raw_filings.py` — `DocumentKind` += `"tender_body"`, classed
+   in `SWEPT_DOCUMENT_KINDS` (above; `test_every_document_kind_is_classified`
+   enforces).
+9. `tests/test_fetch_document_text_callers.py` — allow
+   `app/services/manifest_parsers/sec_tender.py` (SQL-normalisation path =
+   `tender_offer_events`; prevention "no disk-only persistence").
+10. `tests/smoke/test_etl_source_to_sink.py` — `_PARSER_MODULE_BY_SOURCE` +=
+    `sec_tender`.
+11. `docs/etl/sources/sec_tender.md` — the 13 required source-doc sections.
+12. `app/services/processes/bootstrap_coverage.py` — NOT bootstrap-covered
+    (episodic; going-forward discovery + the backfill drive seed it — NT/424B
+    treatment, documented inline).
+
+Also grep'd `KNOWN_FILING_AGENT_CIKS` (sec_edgar.py:142) per prevention #1233:
+not applicable to the URL path here — all 1,753 URLs verified to live under
+the instrument's own CIK directory (full-pop check above), and the parser
+takes `primary_document_url` from the manifest rather than reconstructing
+archive URLs.
+
+## Operator surface
+
+`tender_offer_events` LEFT JOINed in `GET /filings/{instrument_id}`
+(`app/api/filings.py`): attach a `tender` object to matching rows (`role`,
+`form`, `offer_price_per_unit`, `unit_label`, `currency`,
+`board_recommendation`, `is_final_amendment`, `is_going_private`,
+`is_issuer_tender`, `subject_company_name`, `offeror_names`,
+`expiration_date`). FE render on the Filings tab = follow-up FE child ticket
+(the #1978 OfferingBlock pattern). Scoring-neutral — no `model_version` bump.
+
+## Backfill (split)
+
+Going-forward discovery wired by this PR (`_FORM_TO_SOURCE` → submissions
+ingest). Historical backfill: population is only ~1,783 accessions → unlike
+424B this does NOT need a dedicated drive ticket; the impl PR seeds the
+manifest from existing `filing_events` and drains it on dev as part of DoD
+clauses 8–11 (drain ≈ 2 fetches/accession ≈ 3,600 requests, well under an
+hour at the shared 10 req/s). **Full-population dry-run acceptance (impl
+gate, prevention #1659):** report, by form: header-parse rate + block
+presence (SUBJECT/FILED-BY), role-row yield, checkbox NULL-rate, price
+hit-rate (TO-T target: verified across ALL 207 TO-T + 1,055 TO-T/A, per the
+issue), expiration hit-rate, recommendation distribution over all 69+235
+14D-9(/A). A form mostly unparseable = a finding to file, not a silent
+0%-yield ship. Operator runbook: restart jobs daemon (VS Code task —
+operator-owned), then `sec_rebuild {"source": "sec_tender"}` if any parser
+change lands after the dev drain.
+
+## Tests
+
+- `tests/test_tender_offers_parser.py` — pure, real fixtures: NUVL TO-T
+  (subject+offeror roles, $124.00/Share, third-party box checked, no
+  recommendation), DSX TO-T/A (legacy `x`/`¨` glyphs, Amendment No. 18,
+  amends_13d box), IQ TO-I (issuer-tender box, self-filed ⇒ role=subject,
+  "Notes" unit), LPRO 14D-9 (recommendation=accept, $3.15, self-filed), BALY
+  13E3 (multi-filer FILED BY blocks, going-private context); par-value-only
+  body ⇒ price NULL; conflicting prices ⇒ NULL; duplicate checkbox label ⇒
+  checked-wins; unmatched recommendation prose ⇒ NULL; unusable header ⇒
+  None (tombstone).
+- `tests/test_manifest_parser_sec_tender.py` — ONE integration test per new
+  mechanism (lean-tier policy): happy path (fetch body → fetch header →
+  store_raw → parse → upsert rows for both parties), header-fetch failure →
+  failed(retry) with `raw_status` honest, parse-None → tombstone.
+
+## Settled decisions / prevention log
+
+- Settled "filing_events stores metadata + canonical link, raw text out of
+  scope" — preserved; body lands in `filing_raw_documents` (swept) + typed
+  table, filing_events untouched.
+- Settled "raw-payload retention #1617" — `tender_body` classed swept;
+  rewash-by-refetch documented in `registered_specs()`.
+- Settled "filing dedupe: provider filing identity stable/idempotent" —
+  accession-keyed PK; re-parse upserts.
+- Prevention #1659 (free-text not machine-extractable / full population not a
+  sample) — recommendation extraction restricted to the Item 1012(a)
+  reg-enumerated vocabulary; price restricted to the anchored Item 1004(a)(1)(ii) consideration formula (empirical, dry-run gated);
+  BOTH gated by the full-population dry-run; use-of-consideration prose NOT
+  classified.
+- Prevention "manifest CHECK constraints before row shapes" — read sql/118 +
+  `record_manifest_entry`; the accession-PK ⇒ typed-table-resolves-roles
+  design is a direct consequence.
+- Prevention "allow-list covers every ingest variant before deletes key on
+  it" — the keep-list fix is scoped INTO this PR because
+  `filing_events_cleanup` deletes on the union today.
+- Prevention "single chokepoint" / "new ManifestSource registers everywhere" /
+  "#938 raw invariant" / "no disk-only fetch_document_text callers" — per the
+  checklist above.


### PR DESCRIPTION
Doc-only spec for #1982 (child of #1015 item-4). Design-first per the #1816/#1975 pattern — implementation is a follow-up dedicated session.

## What
`docs/specs/filings/2026-07-05-tender-going-private-parser.md` — new manifest source `sec_tender` parsing SC TO-T(/A), SC TO-I(/A), SC 14D9(/A), SC 13E3(/A) covers + SGML headers into `tender_offer_events` (roles, transaction-type checkboxes, offer price, expiration, board recommendation, class/CUSIP).

## Source rules (cited in spec)
- Schedule TO (Rule 14d-1(g)/13e-4, 17 CFR 240.14d-100) + Reg M-A Items 1002/1003/1004(a)(1)(ii)+(v) — terms/consideration/expiration content is rule-mandated; presentation is prose, so price/expiration regexes are explicitly empirical, gated by a full-population dry-run at impl.
- Reg M-A Item 1012(a) — the reg itself enumerates the only four board-recommendation states (accept/reject/neutral/unable) → deterministic pattern set + NULL, not free-text NLP.
- EDGAR SGML header SUBJECT-COMPANY/FILED-BY CIK blocks — deterministic subject-vs-offeror attribution (verified NUVL/GSK + self-filed LPRO headers live).

## Full-population verification (dev DB, this session)
- 1,783 rows / 201 instruments; 100% have primary_document_url.
- Dual attribution is systemic: 113 TO-T(/A) accessions on >1 instrument; manifest PK is accession → roles must resolve in the typed table (PK (accession, instrument), role attribute, both-blocks⇒subject collapse).
- 1,753/1,753 URL-dir CIK == instrument's own CIK; 201/201 instruments have `external_identifiers` CIKs.
- Live data-loss hazard fixed in scope: dead `DEF 13E-3` keep-list string (0 rows ever); `SC TO-I(/A)`/`SC 13E3(/A)` (227 rows) absent from `SEC_INGEST_KEEP_FORMS` while `filing_events_cleanup` deletes SEC rows off that union.
- Price-regex hazards verified on real bodies: par-value false positives; NUVL "$124.00 per Share, net"; legacy `x`/`¨` checkbox glyphs (DSX); duplicate-label cover typo (NUVL).

## Security model
Doc-only. No code paths touched. The specced parser fetches only public SEC EDGAR documents via the existing rate-limited provider.

## Codex ckpt-1
Ran; all 8 findings incorporated (role/PK collapse made explicit, currency nullable-with-price, Item 1004(a)(1) citations for price/expiration, last-discovery-wins manifest semantics corrected, TO-C Rule 14d-2(b) + 14C Schedule-14A-Item-14 deferral citations, self-filed header shape verified empirically).

Refs #1982 — spec only; implementation follows in a dedicated session (issue stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)