### PR TITLE
feat(#1919): PR-C thesis LLM eval harness — replayable fixtures + gate benchmark

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -84,6 +84,16 @@ _NO_THINK_SUFFIX = "\n/no_think"
 # recorded finish_reason distinguishes truncation from malformed output.
 _THINK_BLOCK_RE = re.compile(r"\A\s*<think>.*?</think>\s*", re.DOTALL)
 
+# Markdown code fence wrapping the ENTIRE completion (```json ... ``` or
+# bare ```). Empirical (#1919 PR-C tilt-check, 2026-07-09): deepseek-r1
+# intermittently fences an otherwise schema-valid JSON object — Ollama
+# does not enforce response_format=json_object for it. Stripping is
+# lossless for compliant output (no-op unless the fence wraps everything)
+# and model-neutral, same class as the <think> strip. A truncated fence
+# (no closing ```) intentionally does NOT match — the parse failure +
+# finish_reason stay honest.
+_CODE_FENCE_RE = re.compile(r"\A```[a-zA-Z]*\s*\n?(.*?)\n?\s*```\s*\Z", re.DOTALL)
+
 # Per-process serialisation of LLM calls (spec §1 concurrency layer (a)).
 _LLM_CALL_SEMAPHORE = threading.Semaphore(1)
 
@@ -104,6 +114,10 @@ class LLMCompletion:
     text: str  # leading <think>...</think> stripped defensively
     finish_reason: str  # "stop" | "length" | provider-mapped passthrough
     model: str  # as reported by the provider response
+    # Provider-reported token usage; None when the provider omits it.
+    # Consumed by the eval harness (scripts/llm_eval_thesis.py) for tok/s.
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
 
 
 class LLMClient(Protocol):
@@ -118,6 +132,21 @@ class LLMClient(Protocol):
 def strip_think_block(text: str) -> str:
     """Strip one leading ``<think>...</think>`` block and surrounding whitespace."""
     return _THINK_BLOCK_RE.sub("", text, count=1).strip()
+
+
+def strip_code_fence(text: str) -> str:
+    """Unwrap one markdown code fence when it wraps the whole text."""
+    match = _CODE_FENCE_RE.match(text.strip())
+    return match.group(1).strip() if match else text
+
+
+def normalize_completion_text(text: str) -> str:
+    """Defensive normalization applied to every provider completion.
+
+    Order matters: thinking models emit the ``<think>`` block first, so
+    strip it before checking for a whole-text code fence.
+    """
+    return strip_code_fence(strip_think_block(text))
 
 
 class OpenAICompatProvider:
@@ -167,10 +196,13 @@ class OpenAICompatProvider:
         choice = choices[0]
         text = (choice.get("message") or {}).get("content") or ""
         finish_reason = choice.get("finish_reason") or "unknown"
+        usage = body.get("usage") or {}
         return LLMCompletion(
-            text=strip_think_block(text),
+            text=normalize_completion_text(text),
             finish_reason=finish_reason,
             model=body.get("model") or self.model,
+            prompt_tokens=usage.get("prompt_tokens"),
+            completion_tokens=usage.get("completion_tokens"),
         )
 
 
@@ -206,9 +238,11 @@ class AnthropicProvider:
             raise ValueError(f"Anthropic: unexpected content block type {type(block)!r}")
         stop_reason = message.stop_reason or "unknown"
         return LLMCompletion(
-            text=strip_think_block(text),
+            text=normalize_completion_text(text),
             finish_reason=self._FINISH_REASON_MAP.get(stop_reason, stop_reason),
             model=message.model,
+            prompt_tokens=message.usage.input_tokens,
+            completion_tokens=message.usage.output_tokens,
         )
 
 

--- a/docs/wiki/byo-llm.md
+++ b/docs/wiki/byo-llm.md
@@ -35,11 +35,32 @@ curl -s -X POST -H "Authorization: Bearer $EBULL_SERVICE_TOKEN" \
 - **qwen3 thinking mode** burns the whole completion budget
   (`finish_reason=length`, empty content). The provider layer appends
   `/no_think` to the system prompt and strips any `<think>…</think>`
-  block defensively — but pick models with the eval harness (#1919
-  PR-C) before switching `llm_model`.
+  block defensively — but pick models with the eval harness before
+  switching `llm_model`:
+
+  ```bash
+  # Replay the house-panel fixtures (AAPL/GME/MSFT/JPM/HD) against a
+  # candidate model; go-live gate = >=9/10 writer passes with retry.
+  PYTHONPATH=. uv run python scripts/llm_eval_thesis.py run \
+    --models qwen3:14b <candidate-model> --gate-model <candidate-model>
+  # Re-capture fixtures from the dev DB (dev-guarded):
+  PYTHONPATH=. uv run python scripts/llm_eval_thesis.py capture
+  ```
+
 - A failed generation records `finish_reason` in `thesis_runs.error` —
   `length` means truncation (context/output window too small), `stop`
   with a JSON error means the model can't hold the schema.
+- **deepseek-r1 needs the fence normalization** (benchmark 2026-07-09,
+  #1919 PR-C): Ollama does not enforce `response_format=json_object`
+  for it, and it often wraps otherwise schema-valid JSON in a
+  ` ```json ` fence. Since PR-C the provider strips one whole-text code
+  fence (model-neutral, lossless — same class as the `<think>` strip),
+  which flipped deepseek-r1:14b's writer gate from 4/10 FAIL to 10/10
+  PASS. It also intermittently answers with a free-prose markdown memo
+  (no JSON at all) — deliberately NOT recovered; the retry absorbs it.
+  qwen3:14b stays the default: critic reliability 10/10 vs 9/10 and
+  enum validity 100% vs 87%, though deepseek is ~2.5× faster on this
+  hardware (7.9 vs 3.1 tok/s).
 
 The full operator guide (model choice, Ollama install, context-window
 sizing, quantisation tips) lives outside this repo — seeded from the

--- a/scripts/llm_eval_thesis.py
+++ b/scripts/llm_eval_thesis.py
@@ -1,0 +1,506 @@
+"""Thesis LLM eval harness (#1919 PR-C, spec §7).
+
+Benchmarks the PRODUCTION writer+critic path (prompts, validators, token
+budgets imported from ``app.services.thesis`` — never copied, so the
+benchmark cannot drift from what ``generate_thesis`` actually sends)
+against an OpenAI-compatible endpoint, replaying fixed
+``_assemble_context`` fixtures so every model sees identical prompts.
+
+Two subcommands:
+
+* ``capture`` — snapshot ``_assemble_context`` output from the dev DB for
+  the house panel (AAPL, GME, MSFT, JPM, HD) into
+  ``tests/fixtures/llm_eval/<symbol>.json``. Dev-guarded (#1765): refuses
+  to run outside a local dev environment.
+* ``run`` — for each fixture x ``--iterations``: writer attempt, one
+  retry on failure (mirrors ``_call_with_one_retry``), then a critic
+  round against the successful memo. Reports JSON-schema pass rate
+  (first-attempt and with-retry), enum validity, finish_reason mix,
+  tok/s + wall-clock per call.
+
+Go-live gate (spec §7): >=9/10 writer passes WITH retry on the chosen
+local model. ``--gate-model <model>`` makes the exit code enforce it.
+
+Usage:
+    PYTHONPATH=. uv run python scripts/llm_eval_thesis.py capture
+    PYTHONPATH=. uv run python scripts/llm_eval_thesis.py run \
+        --models qwen3:14b deepseek-r1:14b --gate-model qwen3:14b \
+        --json-out /tmp/llm_eval_results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from app.services.llm_client import LLMClient, LLMCompletion, OpenAICompatProvider
+from app.services.thesis import (
+    _CRITIC_SYSTEM,
+    _MAX_TOKENS_CRITIC,
+    _MAX_TOKENS_WRITER,
+    _VALID_STANCES,
+    _VALID_THESIS_TYPES,
+    _VALID_VERDICTS,
+    _WRITER_SYSTEM,
+    _build_critic_prompt,
+    _build_writer_prompt,
+    _validate_critic_output,
+    _validate_writer_output,
+)
+
+PANEL_SYMBOLS = ("AAPL", "GME", "MSFT", "JPM", "HD")
+FIXTURES_DIR = Path("tests/fixtures/llm_eval")
+DEFAULT_BASE_URL = "http://localhost:11434/v1"
+# Spec §7 go-live gate: >=9/10 writer passes with retry. The rate alone
+# is not enough — 5/5 must NOT pass the gate, so a minimum sample size is
+# enforced (Codex ckpt-2 finding, 2026-07-09).
+GATE_MIN_PASS_RATE = 0.9
+GATE_MIN_ROUNDS = 10
+
+
+# ---------------------------------------------------------------------------
+# Attempt / round records (pure data; aggregation is unit-tested)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AttemptResult:
+    """One LLM call, classified."""
+
+    ok: bool
+    # "pass" | "transport" | "invalid_json" | "schema_fail"
+    category: str
+    # Enum membership among PARSED outputs (None when JSON never parsed).
+    enum_ok: bool | None
+    finish_reason: str | None
+    duration_s: float
+    completion_tokens: int | None
+    error: str | None = None
+
+    @property
+    def tok_s(self) -> float | None:
+        if self.completion_tokens is None or self.duration_s <= 0:
+            return None
+        return self.completion_tokens / self.duration_s
+
+
+@dataclass(frozen=True)
+class RoundResult:
+    """One fixture round: up to two attempts (prod retry-once shape)."""
+
+    symbol: str
+    call: str  # "writer" | "critic"
+    attempts: list[AttemptResult]
+    parsed: dict[str, object] | None = None
+
+    @property
+    def pass_first(self) -> bool:
+        return bool(self.attempts) and self.attempts[0].ok
+
+    @property
+    def pass_with_retry(self) -> bool:
+        return any(a.ok for a in self.attempts)
+
+
+@dataclass
+class ModelReport:
+    """Aggregate for one model."""
+
+    model: str
+    writer_rounds: int = 0
+    writer_pass_first: int = 0
+    writer_pass_retry: int = 0
+    critic_rounds: int = 0
+    critic_pass_first: int = 0
+    critic_pass_retry: int = 0
+    finish_reasons: Counter[str] = field(default_factory=Counter)
+    enum_checked: int = 0
+    enum_ok: int = 0
+    durations_s: list[float] = field(default_factory=list)
+    tok_s: list[float] = field(default_factory=list)
+
+    @property
+    def writer_pass_retry_rate(self) -> float:
+        return self.writer_pass_retry / self.writer_rounds if self.writer_rounds else 0.0
+
+    def gate_passes(self) -> bool:
+        return self.writer_rounds >= GATE_MIN_ROUNDS and self.writer_pass_retry_rate >= GATE_MIN_PASS_RATE
+
+
+def _writer_enums_ok(data: dict[str, object]) -> bool:
+    return data.get("thesis_type") in _VALID_THESIS_TYPES and data.get("stance") in _VALID_STANCES
+
+
+def _critic_enums_ok(data: dict[str, object]) -> bool:
+    return data.get("verdict") in _VALID_VERDICTS
+
+
+def classify_attempt(
+    completion: LLMCompletion,
+    duration_s: float,
+    *,
+    call: str,
+) -> tuple[AttemptResult, dict[str, object] | None]:
+    """Classify one completion against the production validators.
+
+    Pure — no I/O; unit-tested. Categories are disjoint stages:
+    invalid_json (never parsed to a JSON object) then schema_fail
+    (production validator rejected) then pass. ``enum_ok`` is computed
+    independently on every PARSED output so the spec's "enum validity"
+    metric is reportable even when the schema fails on another field.
+    """
+    validate = _validate_writer_output if call == "writer" else _validate_critic_output
+    enums_ok = _writer_enums_ok if call == "writer" else _critic_enums_ok
+
+    try:
+        data: object = json.loads(completion.text)
+    except json.JSONDecodeError as exc:
+        # Keep the head of the raw output: "unparseable" alone cannot
+        # distinguish a markdown-fenced payload / tag leak (fixable by
+        # provider normalization) from genuinely broken JSON.
+        head = completion.text[:200].replace("\n", "\\n")
+        return (
+            AttemptResult(
+                ok=False,
+                category="invalid_json",
+                enum_ok=None,
+                finish_reason=completion.finish_reason,
+                duration_s=duration_s,
+                completion_tokens=completion.completion_tokens,
+                error=f"unparseable JSON: {exc}; head={head!r}",
+            ),
+            None,
+        )
+    if not isinstance(data, dict):
+        return (
+            AttemptResult(
+                ok=False,
+                category="invalid_json",
+                enum_ok=None,
+                finish_reason=completion.finish_reason,
+                duration_s=duration_s,
+                completion_tokens=completion.completion_tokens,
+                error=f"JSON is not an object: {type(data).__name__}",
+            ),
+            None,
+        )
+
+    enum_ok = enums_ok(data)
+    try:
+        validate(data)
+    except ValueError as exc:
+        return (
+            AttemptResult(
+                ok=False,
+                category="schema_fail",
+                enum_ok=enum_ok,
+                finish_reason=completion.finish_reason,
+                duration_s=duration_s,
+                completion_tokens=completion.completion_tokens,
+                error=str(exc),
+            ),
+            None,
+        )
+    return (
+        AttemptResult(
+            ok=True,
+            category="pass",
+            enum_ok=enum_ok,
+            finish_reason=completion.finish_reason,
+            duration_s=duration_s,
+            completion_tokens=completion.completion_tokens,
+        ),
+        data,
+    )
+
+
+def run_round(
+    client: LLMClient,
+    *,
+    symbol: str,
+    call: str,
+    system: str,
+    user: str,
+    max_tokens: int,
+) -> RoundResult:
+    """One production-shaped round: attempt, retry ONCE on parse/schema failure.
+
+    Mirrors ``_call_with_one_retry`` exactly: production retries only the
+    ``ValueError`` class (parse/schema); a transport error (connect/read/
+    HTTP status) propagates immediately with NO retry. So here a transport
+    failure is recorded and ENDS the round — the benchmark must survive a
+    flaky model server, but must not credit a recovery production would
+    never perform (Codex ckpt-2 finding, 2026-07-09).
+    """
+    attempts: list[AttemptResult] = []
+    parsed: dict[str, object] | None = None
+    for _attempt in range(2):
+        start = time.monotonic()
+        try:
+            completion = client.complete(system=system, user=user, max_tokens=max_tokens)
+        except Exception as exc:  # httpx transport / HTTP status / provider error
+            attempts.append(
+                AttemptResult(
+                    ok=False,
+                    category="transport",
+                    enum_ok=None,
+                    finish_reason=None,
+                    duration_s=time.monotonic() - start,
+                    completion_tokens=None,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+            )
+            break  # prod does not retry transport errors
+        result, data = classify_attempt(completion, time.monotonic() - start, call=call)
+        attempts.append(result)
+        if result.ok:
+            parsed = data
+            break
+    return RoundResult(symbol=symbol, call=call, attempts=attempts, parsed=parsed)
+
+
+def aggregate(model: str, rounds: list[RoundResult]) -> ModelReport:
+    """Fold round results into the per-model report. Pure; unit-tested."""
+    report = ModelReport(model=model)
+    for rnd in rounds:
+        if rnd.call == "writer":
+            report.writer_rounds += 1
+            report.writer_pass_first += rnd.pass_first
+            report.writer_pass_retry += rnd.pass_with_retry
+        else:
+            report.critic_rounds += 1
+            report.critic_pass_first += rnd.pass_first
+            report.critic_pass_retry += rnd.pass_with_retry
+        for attempt in rnd.attempts:
+            if attempt.finish_reason is not None:
+                report.finish_reasons[attempt.finish_reason] += 1
+            if attempt.enum_ok is not None:
+                report.enum_checked += 1
+                report.enum_ok += attempt.enum_ok
+            report.durations_s.append(attempt.duration_s)
+            if attempt.tok_s is not None:
+                report.tok_s.append(attempt.tok_s)
+    return report
+
+
+# ---------------------------------------------------------------------------
+# capture
+# ---------------------------------------------------------------------------
+
+
+def capture(symbols: list[str], out_dir: Path) -> int:
+    """Snapshot _assemble_context for each symbol into a replayable fixture."""
+    # Deferred imports: `run` must work without DB config / psycopg present.
+    import psycopg
+
+    from app.config import settings
+    from app.services.thesis import _assemble_context
+    from scripts._dev_guard import assert_dev_environment
+
+    assert_dev_environment()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with psycopg.connect(settings.database_url) as conn:
+        for symbol in symbols:
+            # symbol is NOT unique (sql/043) — pin the lowest instrument_id so
+            # repeat captures always snapshot the same row.
+            row = conn.execute(
+                "SELECT instrument_id FROM instruments WHERE symbol = %(s)s AND is_tradable"
+                " ORDER BY instrument_id LIMIT 1",
+                {"s": symbol},
+            ).fetchone()
+            if row is None:
+                print(f"SKIP {symbol}: no tradable instrument row")
+                continue
+            instrument_id = row[0]
+            context = _assemble_context(conn, instrument_id)
+            # Same default=str transform _build_writer_prompt applies, so a
+            # replayed fixture is byte-equivalent in prompt space.
+            fixture = {
+                "symbol": symbol,
+                "instrument_id": instrument_id,
+                "context": json.loads(json.dumps(context, default=str)),
+            }
+            path = out_dir / f"{symbol}.json"
+            path.write_text(json.dumps(fixture, indent=2) + "\n")
+            print(f"captured {symbol} -> {path} ({path.stat().st_size:,} bytes)")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def load_fixtures(fixtures_dir: Path) -> list[dict[str, Any]]:
+    paths = sorted(fixtures_dir.glob("*.json"))
+    if not paths:
+        raise SystemExit(f"no fixtures under {fixtures_dir} — run `capture` first (needs dev DB)")
+    return [json.loads(p.read_text()) for p in paths]
+
+
+def run_model(
+    model: str,
+    fixtures: list[dict[str, Any]],
+    *,
+    base_url: str,
+    iterations: int,
+) -> tuple[ModelReport, list[RoundResult]]:
+    client = OpenAICompatProvider(base_url=base_url, model=model)
+    rounds: list[RoundResult] = []
+    for iteration in range(1, iterations + 1):
+        for fixture in fixtures:
+            symbol = fixture["symbol"]
+            context = fixture["context"]
+            writer = run_round(
+                client,
+                symbol=symbol,
+                call="writer",
+                system=_WRITER_SYSTEM,
+                user=_build_writer_prompt(context),
+                max_tokens=_MAX_TOKENS_WRITER,
+            )
+            rounds.append(writer)
+            _print_round(model, iteration, writer)
+            if writer.parsed is None:
+                continue  # prod path: no memo, no critic call
+            memo = writer.parsed.get("memo_markdown")
+            if not isinstance(memo, str):  # unreachable post-validate; keep pyright honest
+                continue
+            critic = run_round(
+                client,
+                symbol=symbol,
+                call="critic",
+                system=_CRITIC_SYSTEM,
+                user=_build_critic_prompt(memo, context),
+                max_tokens=_MAX_TOKENS_CRITIC,
+            )
+            rounds.append(critic)
+            _print_round(model, iteration, critic)
+    return aggregate(model, rounds), rounds
+
+
+def _print_round(model: str, iteration: int, rnd: RoundResult) -> None:
+    for i, attempt in enumerate(rnd.attempts, start=1):
+        tok_s = f"{attempt.tok_s:.1f} tok/s" if attempt.tok_s is not None else "tok/s n/a"
+        detail = "" if attempt.ok else f" [{attempt.category}: {attempt.error}]"
+        print(
+            f"  {model} it{iteration} {rnd.symbol} {rnd.call} a{i}: "
+            f"{'PASS' if attempt.ok else 'FAIL'} "
+            f"finish={attempt.finish_reason} {attempt.duration_s:.0f}s {tok_s}{detail}",
+            flush=True,
+        )
+
+
+def _fmt_rate(numerator: int, denominator: int) -> str:
+    if not denominator:
+        return "n/a"
+    return f"{numerator}/{denominator} ({numerator / denominator:.0%})"
+
+
+def print_report(report: ModelReport) -> None:
+    print(f"\n=== {report.model} ===")
+    print(f"writer pass (first attempt): {_fmt_rate(report.writer_pass_first, report.writer_rounds)}")
+    print(f"writer pass (with retry):    {_fmt_rate(report.writer_pass_retry, report.writer_rounds)}")
+    print(f"critic pass (first attempt): {_fmt_rate(report.critic_pass_first, report.critic_rounds)}")
+    print(f"critic pass (with retry):    {_fmt_rate(report.critic_pass_retry, report.critic_rounds)}")
+    print(f"enum validity (parsed outputs): {_fmt_rate(report.enum_ok, report.enum_checked)}")
+    print(f"finish_reason mix: {dict(report.finish_reasons)}")
+    if report.durations_s:
+        print(
+            f"wall-clock per call: mean {statistics.mean(report.durations_s):.0f}s, "
+            f"median {statistics.median(report.durations_s):.0f}s, "
+            f"max {max(report.durations_s):.0f}s"
+        )
+    if report.tok_s:
+        print(f"throughput: mean {statistics.mean(report.tok_s):.1f} tok/s")
+    gate = "PASS" if report.gate_passes() else "FAIL"
+    if report.writer_rounds < GATE_MIN_ROUNDS:
+        gate = f"FAIL (insufficient sample: {report.writer_rounds} < {GATE_MIN_ROUNDS} writer rounds)"
+    print(f"go-live gate (writer with-retry >= {GATE_MIN_PASS_RATE:.0%} over >= {GATE_MIN_ROUNDS} rounds): {gate}")
+
+
+def _round_to_json(rnd: RoundResult) -> dict[str, object]:
+    return {
+        "symbol": rnd.symbol,
+        "call": rnd.call,
+        "attempts": [asdict(a) | {"tok_s": a.tok_s} for a in rnd.attempts],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_capture = sub.add_parser("capture", help="snapshot _assemble_context fixtures from the dev DB")
+    p_capture.add_argument("--symbols", nargs="+", default=list(PANEL_SYMBOLS))
+    p_capture.add_argument("--out", type=Path, default=FIXTURES_DIR)
+
+    p_run = sub.add_parser("run", help="replay fixtures against one or more models")
+    p_run.add_argument("--fixtures-dir", type=Path, default=FIXTURES_DIR)
+    p_run.add_argument("--models", nargs="+", required=True)
+    p_run.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    p_run.add_argument("--iterations", type=int, default=2, help="rounds per fixture (5 fixtures x 2 = 10 gate rounds)")
+    p_run.add_argument("--json-out", type=Path, default=None, help="write full per-attempt records + aggregates")
+    p_run.add_argument(
+        "--gate-model",
+        default=None,
+        help="model whose spec-§7 go-live gate decides the exit code (others are report-only)",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "capture":
+        return capture(args.symbols, args.out)
+
+    fixtures = load_fixtures(args.fixtures_dir)
+    print(f"{len(fixtures)} fixtures x {args.iterations} iterations x {len(args.models)} models")
+    if args.gate_model is not None and args.gate_model not in args.models:
+        raise SystemExit(f"--gate-model {args.gate_model!r} not in --models {args.models}")
+
+    reports: dict[str, ModelReport] = {}
+    all_rounds: dict[str, list[RoundResult]] = {}
+    for model in args.models:
+        print(f"\n--- benchmarking {model} ---", flush=True)
+        report, rounds = run_model(model, fixtures, base_url=args.base_url, iterations=args.iterations)
+        reports[model] = report
+        all_rounds[model] = rounds
+
+    for report in reports.values():
+        print_report(report)
+
+    if args.json_out is not None:
+        payload = {
+            model: {
+                "aggregate": {
+                    "writer_rounds": r.writer_rounds,
+                    "writer_pass_first": r.writer_pass_first,
+                    "writer_pass_retry": r.writer_pass_retry,
+                    "critic_rounds": r.critic_rounds,
+                    "critic_pass_first": r.critic_pass_first,
+                    "critic_pass_retry": r.critic_pass_retry,
+                    "finish_reasons": dict(r.finish_reasons),
+                    "enum_ok": r.enum_ok,
+                    "enum_checked": r.enum_checked,
+                    "gate_passes": r.gate_passes(),
+                },
+                "rounds": [_round_to_json(rnd) for rnd in all_rounds[model]],
+            }
+            for model, r in reports.items()
+        }
+        args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
+        print(f"\nfull results -> {args.json_out}")
+
+    if args.gate_model is not None and not reports[args.gate_model].gate_passes():
+        print(f"\nGATE FAIL: {args.gate_model} writer with-retry below {GATE_MIN_PASS_RATE:.0%}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/llm_eval/AAPL.json
+++ b/tests/fixtures/llm_eval/AAPL.json
@@ -1,0 +1,123 @@
+{
+  "symbol": "AAPL",
+  "instrument_id": 1001,
+  "context": {
+    "instrument": {
+      "symbol": "AAPL",
+      "company_name": "Apple",
+      "sector": "3",
+      "industry": null,
+      "country": "US",
+      "currency": "USD"
+    },
+    "fundamentals": [
+      {
+        "as_of_date": "2026-03-28",
+        "revenue_ttm": 416161000000.0,
+        "gross_margin": 0.4691,
+        "operating_margin": 0.3197,
+        "fcf": 98767000000.0,
+        "cash": 45572000000.0,
+        "debt": 82700000000.0,
+        "net_debt": 37128000000.0,
+        "eps": 7.46,
+        "book_value": 7.2602
+      }
+    ],
+    "filings": [],
+    "news": [],
+    "prior_thesis": {
+      "version": 1,
+      "thesis_type": "compounder",
+      "stance": "buy",
+      "confidence_score": 0.9,
+      "buy_zone_low": null,
+      "buy_zone_high": null,
+      "base_value": null,
+      "bull_value": null,
+      "bear_value": null,
+      "break_conditions": [
+        "Material disruption in iPhone demand due to macroeconomic collapse",
+        "Regulatory clampdown on AI innovation (core growth driver)",
+        "Breakdown in supply chain resilience (Taiwan/China)",
+        "Sustained failure to innovate in wearables/cloud services"
+      ],
+      "memo_markdown": "### Business Quality\nApple (AAPL) demonstrates textbook compounder attributes with $416B TTM revenue, 46.9% gross margins, and $98.8B free cash flow. Strong balance sheet (net debt/EBITDA < 1x) supports reinvestment. Innovation moats in hardware-software integration and ecosystem lock-in remain intact despite saturation risks in core markets.\n\n### Key Financials\nRecent fundamental snapshot shows 31.97% operating margin, $45.6B cash reserves, and robust 7.46 EPS. While 1Y CAGR appears inflated by partial_window data, 3Y and full-window metrics show 16.7% CAGR vs S&P 500 (benchmark_symbol: SPY). Beta of 1.06 (3Y) reflects moderate volatility, though max drawdown of -33% underscores tail risk exposure.\n\n### Valuation & Risks\nAbsence of current price data limits precise valuation analysis, but book value of $7.26 provides a floor. Risk profile shows 25.5% annualized volatility (3Y) and 2.57% VaR_5, with worst daily loss of -9.4%. While Calmar ratio of 0.51 suggests underperformance during drawdowns, the 1Y window (status: partial_window) shows exceptional risk-adjusted returns (3.36x). Thesis hinges on sustained margin power and services growth, with critical break conditions centered on innovation stagnation or regulatory overreach.",
+      "created_at": "2026-07-09T20:14:19.817578+00:00"
+    },
+    "risk_metrics": {
+      "metric_version": "risk_v1",
+      "basis_note": "All returns/ratios are fractions (0.10 = 10%, not percent). Drawdown, var_5 and worst_day are signed losses (negative is a loss). Basis is price-return (no dividend reinvestment; total-return is future work), so do not over-read CAGR for high-yield names. A non-'ok' status means the metric is NOT a precise number: treat insufficient_history / partial_window as provisional, and benchmark_missing beta/excess as absent, not zero. Cite a risk figure as {window_key, as_of_date, metric_version}.",
+      "windows": [
+        {
+          "window_key": "1y",
+          "as_of_date": "2026-06-12",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.46487975682251576,
+          "excess_cagr_vs_spy": 0.23383038558839503,
+          "vol_annualized": 0.2383939836441898,
+          "beta": 0.8059824016272022,
+          "beta_r2": 0.19153537264563955,
+          "calmar": 3.3644804893634817,
+          "max_drawdown": -0.13817281993228775,
+          "current_drawdown": -0.07508098837578607,
+          "var_5": -0.02018961,
+          "worst_day": -0.050552377910690435,
+          "cagr_status": "partial_window",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "partial_window",
+          "calmar_status": "partial_window"
+        },
+        {
+          "window_key": "3y",
+          "as_of_date": "2026-06-12",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.1673613024549521,
+          "excess_cagr_vs_spy": -0.026443618506396416,
+          "vol_annualized": 0.25512502230697137,
+          "beta": 1.056877999461826,
+          "beta_r2": 0.35953079703056423,
+          "calmar": 0.5056743820657363,
+          "max_drawdown": -0.33096654367038025,
+          "current_drawdown": -0.07508098837578607,
+          "var_5": -0.02566866,
+          "worst_day": -0.0941561519132231,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        },
+        {
+          "window_key": "full",
+          "as_of_date": "2026-06-12",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.15835160261821715,
+          "excess_cagr_vs_spy": 0.003998661510856258,
+          "vol_annualized": 0.275704522361128,
+          "beta": 1.1582279625633967,
+          "beta_r2": 0.49093652466569204,
+          "calmar": 0.4784519935523283,
+          "max_drawdown": -0.33096654367038025,
+          "current_drawdown": -0.07508098837578607,
+          "var_5": -0.02798701,
+          "worst_day": -0.0941561519132231,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        }
+      ]
+    },
+    "earnings_history": [],
+    "analyst_estimates": null
+  }
+}

--- a/tests/fixtures/llm_eval/GME.json
+++ b/tests/fixtures/llm_eval/GME.json
@@ -1,0 +1,198 @@
+{
+  "symbol": "GME",
+  "instrument_id": 1699,
+  "context": {
+    "instrument": {
+      "symbol": "GME",
+      "company_name": "GameStop Corp.",
+      "sector": "7",
+      "industry": null,
+      "country": "US",
+      "currency": "USD"
+    },
+    "fundamentals": [
+      {
+        "as_of_date": "2026-05-02",
+        "revenue_ttm": 3629900000.0,
+        "gross_margin": 0.3295,
+        "operating_margin": 0.0639,
+        "fcf": 597300000.0,
+        "cash": 7397600000.0,
+        "debt": 4164300000.0,
+        "net_debt": -3233300000.0,
+        "eps": 0.77,
+        "book_value": 13.0201
+      },
+      {
+        "as_of_date": "2026-01-31",
+        "revenue_ttm": 3629900000.0,
+        "gross_margin": 0.3295,
+        "operating_margin": 0.0639,
+        "fcf": 597300000.0,
+        "cash": 6304700000.0,
+        "debt": 4164300000.0,
+        "net_debt": -2140400000.0,
+        "eps": 0.77,
+        "book_value": 12.1445
+      }
+    ],
+    "filings": [],
+    "news": [
+      {
+        "event_time": "2026-06-27T00:01:54+00:00",
+        "source": "Yahoo Finance",
+        "headline": "GME Stock Jumps After-Hours \u2014 GameStop Hikes FY26 EBITDA Outlook To $600M, Nearly Double Of FY25",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.7826
+      },
+      {
+        "event_time": "2026-07-03T19:15:48+00:00",
+        "source": "Yahoo Finance",
+        "headline": "GameStop (GME) Stock Looks Undervalued On Earnings But Mixed On Fair Value",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.7723
+      },
+      {
+        "event_time": "2026-06-28T04:15:16+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Ryan Cohen passes on GameStop payday to keep pushing one acquisition",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.6
+      },
+      {
+        "event_time": "2026-06-27T11:30:01+00:00",
+        "source": "Yahoo Finance",
+        "headline": "eBay vs. Macy's: Which Consumer Stock Is a Better Buy in 2026?",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.6
+      },
+      {
+        "event_time": "2026-07-04T05:07:24+00:00",
+        "source": "Yahoo Finance",
+        "headline": "GameStop (GME) Keeps Chasing EBay As Ryan Cohen Drops Award And Targets Rise",
+        "category": "general",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.5873
+      },
+      {
+        "event_time": "2026-07-07T21:41:20+00:00",
+        "source": "Yahoo Finance",
+        "headline": "GME Stock Rises After Hours \u2014 GameStop Shareholders Back Bigger Share Count To Support Proposed eBay Acquisition",
+        "category": "general",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.5726
+      },
+      {
+        "event_time": "2026-07-01T20:15:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Sony to cease physical PlayStation disc production in 2028",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.5655
+      },
+      {
+        "event_time": "2026-07-07T20:05:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "GameStop Stockholders Approve Proposals at 2026 Annual Meeting, Including Increased Share Authorization",
+        "category": "general",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.5647
+      },
+      {
+        "event_time": "2026-07-01T20:01:24+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Is The Jack In The Box Short Squeeze Back On?",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.5644
+      },
+      {
+        "event_time": "2026-07-01T19:41:56+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Musk Meme Traders Rush Back Into Tesla When the Stock Hits $420",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.5628
+      }
+    ],
+    "prior_thesis": null,
+    "risk_metrics": {
+      "metric_version": "risk_v1",
+      "basis_note": "All returns/ratios are fractions (0.10 = 10%, not percent). Drawdown, var_5 and worst_day are signed losses (negative is a loss). Basis is price-return (no dividend reinvestment; total-return is future work), so do not over-read CAGR for high-yield names. A non-'ok' status means the metric is NOT a precise number: treat insufficient_history / partial_window as provisional, and benchmark_missing beta/excess as absent, not zero. Cite a risk figure as {window_key, as_of_date, metric_version}.",
+      "windows": [
+        {
+          "window_key": "1y",
+          "as_of_date": "2026-07-08",
+          "benchmark_symbol": "SPY",
+          "cagr": -0.027536984396588898,
+          "excess_cagr_vs_spy": -0.23430709787736095,
+          "vol_annualized": 0.3573222522612717,
+          "beta": 0.8706198671839803,
+          "beta_r2": 0.09926023083103817,
+          "calmar": -0.09840719988059501,
+          "max_drawdown": -0.27982692760287486,
+          "current_drawdown": -0.19981172040480114,
+          "var_5": -0.03146602,
+          "worst_day": -0.11542814032440589,
+          "cagr_status": "partial_window",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "partial_window"
+        },
+        {
+          "window_key": "3y",
+          "as_of_date": "2026-07-08",
+          "benchmark_symbol": "SPY",
+          "cagr": -0.02007152584554343,
+          "excess_cagr_vs_spy": -0.2146655247426728,
+          "vol_annualized": 0.9699439723267196,
+          "beta": 1.1457343658656036,
+          "beta_r2": 0.02923732520893266,
+          "calmar": -0.0320399984667502,
+          "max_drawdown": -0.6264521475047147,
+          "current_drawdown": -0.5489464532088072,
+          "var_5": -0.05366101,
+          "worst_day": -0.388901451569417,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        },
+        {
+          "window_key": "full",
+          "as_of_date": "2026-07-08",
+          "benchmark_symbol": "SPY",
+          "cagr": -0.06920117231217202,
+          "excess_cagr_vs_spy": -0.1755267342882932,
+          "vol_annualized": 0.9471661519822387,
+          "beta": 1.4054810780076457,
+          "beta_r2": 0.059746805881421665,
+          "calmar": -0.08994326183595776,
+          "max_drawdown": -0.7693869546157218,
+          "current_drawdown": -0.5489464532088072,
+          "var_5": -0.06505815,
+          "worst_day": -0.388901451569417,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        }
+      ]
+    },
+    "earnings_history": [],
+    "analyst_estimates": null
+  }
+}

--- a/tests/fixtures/llm_eval/HD.json
+++ b/tests/fixtures/llm_eval/HD.json
@@ -1,0 +1,105 @@
+{
+  "symbol": "HD",
+  "instrument_id": 1018,
+  "context": {
+    "instrument": {
+      "symbol": "HD",
+      "company_name": "Home Depot Inc",
+      "sector": "7",
+      "industry": null,
+      "country": "US",
+      "currency": "USD"
+    },
+    "fundamentals": [
+      {
+        "as_of_date": "2026-05-03",
+        "revenue_ttm": 164683000000.0,
+        "gross_margin": 0.3332,
+        "operating_margin": 0.1268,
+        "fcf": 16325000000.0,
+        "cash": 1601000000.0,
+        "debt": 49397000000.0,
+        "net_debt": 47796000000.0,
+        "eps": 14.23,
+        "book_value": 13.9157
+      }
+    ],
+    "filings": [],
+    "news": [],
+    "prior_thesis": null,
+    "risk_metrics": {
+      "metric_version": "risk_v1",
+      "basis_note": "All returns/ratios are fractions (0.10 = 10%, not percent). Drawdown, var_5 and worst_day are signed losses (negative is a loss). Basis is price-return (no dividend reinvestment; total-return is future work), so do not over-read CAGR for high-yield names. A non-'ok' status means the metric is NOT a precise number: treat insufficient_history / partial_window as provisional, and benchmark_missing beta/excess as absent, not zero. Cite a risk figure as {window_key, as_of_date, metric_version}.",
+      "windows": [
+        {
+          "window_key": "1y",
+          "as_of_date": "2026-06-09",
+          "benchmark_symbol": "SPY",
+          "cagr": -0.12917136052300188,
+          "excess_cagr_vs_spy": -0.3598954596444884,
+          "vol_annualized": 0.2338787766064057,
+          "beta": 0.6604808091368554,
+          "beta_r2": 0.12846312141311686,
+          "calmar": -0.4370623924078255,
+          "max_drawdown": -0.29554444117550915,
+          "current_drawdown": -0.24795537571673776,
+          "var_5": -0.02229095,
+          "worst_day": -0.05844735526178898,
+          "cagr_status": "partial_window",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "partial_window",
+          "calmar_status": "partial_window"
+        },
+        {
+          "window_key": "3y",
+          "as_of_date": "2026-06-09",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.01876443997184751,
+          "excess_cagr_vs_spy": -0.17532923017420582,
+          "vol_annualized": 0.22098294458018697,
+          "beta": 0.7497327975566291,
+          "beta_r2": 0.2392361968719255,
+          "calmar": 0.06061411328199549,
+          "max_drawdown": -0.3095721269492068,
+          "current_drawdown": -0.2629306932440034,
+          "var_5": -0.02205912,
+          "worst_day": -0.05844735526178898,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        },
+        {
+          "window_key": "full",
+          "as_of_date": "2026-06-09",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.01893171732419339,
+          "excess_cagr_vs_spy": -0.14062210119102275,
+          "vol_annualized": 0.2387681998153244,
+          "beta": 0.8490812457929523,
+          "beta_r2": 0.34425117553936596,
+          "calmar": 0.06115446345497255,
+          "max_drawdown": -0.3095721269492068,
+          "current_drawdown": -0.2629306932440034,
+          "var_5": -0.02320607,
+          "worst_day": -0.07089362804433208,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        }
+      ]
+    },
+    "earnings_history": [],
+    "analyst_estimates": null
+  }
+}

--- a/tests/fixtures/llm_eval/JPM.json
+++ b/tests/fixtures/llm_eval/JPM.json
@@ -1,0 +1,186 @@
+{
+  "symbol": "JPM",
+  "instrument_id": 1023,
+  "context": {
+    "instrument": {
+      "symbol": "JPM",
+      "company_name": "JPMorgan Chase & Co",
+      "sector": "4",
+      "industry": null,
+      "country": "US",
+      "currency": "USD"
+    },
+    "fundamentals": [
+      {
+        "as_of_date": "2018-12-31",
+        "revenue_ttm": 182447000000.0,
+        "gross_margin": null,
+        "operating_margin": null,
+        "fcf": -147782000000.0,
+        "cash": 278793000000.0,
+        "debt": 269929000000.0,
+        "net_debt": -8864000000.0,
+        "eps": 20.02,
+        "book_value": 135.0189
+      }
+    ],
+    "filings": [],
+    "news": [
+      {
+        "event_time": "2026-06-30T04:30:55+00:00",
+        "source": "Yahoo Finance",
+        "headline": "NKE Stock In Focus: JPMorgan Doubts Nike\u2019s Turnaround Potential, But Retail Disagrees",
+        "category": "earnings",
+        "sentiment_score": -0.6667,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-08T22:45:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "A Positive Outlook as Q2 Earnings Season Gets Underway",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8111
+      },
+      {
+        "event_time": "2026-07-01T21:53:03+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Cboe Seeks to List Prediction Market Type Options on Earnings Metrics",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8069
+      },
+      {
+        "event_time": "2026-07-06T20:28:42+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Bank Stocks Rally Ahead Of Earnings. Why Bullishness Is Growing.",
+        "category": "earnings",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.8
+      },
+      {
+        "event_time": "2026-06-29T20:17:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "UBS, JPMorgan Lower Lennar (LEN) Targets on Softer Housing Demand and Revised Guidance",
+        "category": "earnings",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.799
+      },
+      {
+        "event_time": "2026-07-01T20:09:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Wells Fargo Stock Has Lagged Other Banks. Earnings Can Change That.",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.7984
+      },
+      {
+        "event_time": "2026-07-01T19:24:53+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Passive Indexers Are Shuffling Billions Into the Russell 2000 Just in Time for a Brutal Fed Reality Check",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.7948
+      },
+      {
+        "event_time": "2026-07-06T18:35:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Navigating the Prospects for Bank ETFs as Q2 Earnings Season Kicks Off",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.7907
+      },
+      {
+        "event_time": "2026-07-08T17:12:11+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Wise (LSE:WISE) Stock Sees Split Analyst Revisions As Growth Outlook Improves",
+        "category": "earnings",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.7839
+      },
+      {
+        "event_time": "2026-06-29T16:52:42+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Major Banks Poised for Strong Quarterly Results, Outlook, Deutsche Bank Says",
+        "category": "earnings",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.7823
+      }
+    ],
+    "prior_thesis": null,
+    "risk_metrics": {
+      "metric_version": "risk_v1",
+      "basis_note": "All returns/ratios are fractions (0.10 = 10%, not percent). Drawdown, var_5 and worst_day are signed losses (negative is a loss). Basis is price-return (no dividend reinvestment; total-return is future work), so do not over-read CAGR for high-yield names. A non-'ok' status means the metric is NOT a precise number: treat insufficient_history / partial_window as provisional, and benchmark_missing beta/excess as absent, not zero. Cite a risk figure as {window_key, as_of_date, metric_version}.",
+      "windows": [
+        {
+          "window_key": "1y",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.15894761297354207,
+          "excess_cagr_vs_spy": -0.04694419351321514,
+          "vol_annualized": 0.21814391192250301,
+          "beta": 0.80103831921444,
+          "beta_r2": 0.22546643179207818,
+          "calmar": 1.0327470319636198,
+          "max_drawdown": -0.15390759600763615,
+          "current_drawdown": 0.0,
+          "var_5": -0.02323215,
+          "worst_day": -0.04707043563508619,
+          "cagr_status": "partial_window",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "partial_window"
+        },
+        {
+          "window_key": "3y",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.32644104783713007,
+          "excess_cagr_vs_spy": 0.13186617353601118,
+          "vol_annualized": 0.22615820942406473,
+          "beta": 0.8821838436161393,
+          "beta_r2": 0.3192669193195257,
+          "calmar": 1.3158817442863586,
+          "max_drawdown": -0.24807779973736824,
+          "current_drawdown": 0.0,
+          "var_5": -0.01977911,
+          "worst_day": -0.0800965227368612,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        },
+        {
+          "window_key": "full",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.2853130357289001,
+          "excess_cagr_vs_spy": 0.1224524189882053,
+          "vol_annualized": 0.24101433606305742,
+          "beta": 0.8976909370165466,
+          "beta_r2": 0.3760669303947472,
+          "calmar": 1.1500949945176535,
+          "max_drawdown": -0.24807779973736824,
+          "current_drawdown": 0.0,
+          "var_5": -0.02158441,
+          "worst_day": -0.0800965227368612,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        }
+      ]
+    },
+    "earnings_history": [],
+    "analyst_estimates": null
+  }
+}

--- a/tests/fixtures/llm_eval/MSFT.json
+++ b/tests/fixtures/llm_eval/MSFT.json
@@ -1,0 +1,186 @@
+{
+  "symbol": "MSFT",
+  "instrument_id": 1004,
+  "context": {
+    "instrument": {
+      "symbol": "MSFT",
+      "company_name": "Microsoft",
+      "sector": "8",
+      "industry": null,
+      "country": "US",
+      "currency": "USD"
+    },
+    "fundamentals": [
+      {
+        "as_of_date": "2026-03-31",
+        "revenue_ttm": 281724000000.0,
+        "gross_margin": 0.6882,
+        "operating_margin": 0.4562,
+        "fcf": 71611000000.0,
+        "cash": 32105000000.0,
+        "debt": 40262000000.0,
+        "net_debt": 8157000000.0,
+        "eps": 13.64,
+        "book_value": 55.777
+      }
+    ],
+    "filings": [],
+    "news": [
+      {
+        "event_time": "2026-06-28T02:32:14+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Capex boom threatens to crowd out buybacks, key equity demand driver",
+        "category": "earnings",
+        "sentiment_score": 1.0,
+        "importance_score": 0.8297
+      },
+      {
+        "event_time": "2026-07-09T01:14:34+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Commvault (CVLT) Stock Has Cheap Cash Flow But Expensive Earnings",
+        "category": "earnings",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.8233
+      },
+      {
+        "event_time": "2026-06-29T20:26:15+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Consumer Internet Stocks Q1 Teardown: Expedia (NASDAQ:EXPE) Vs The Rest",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.7998
+      },
+      {
+        "event_time": "2026-07-08T20:14:46+00:00",
+        "source": "Yahoo Finance",
+        "headline": "SAP (XTRA:SAP) Stock Looks Below Fair Value Despite AI Hopes",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.7988
+      },
+      {
+        "event_time": "2026-07-08T20:05:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Microsoft announces quarterly earnings release date",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.798
+      },
+      {
+        "event_time": "2026-06-29T20:05:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Big tech faces AI spending scrutiny ahead of Q2 earnings: Wedbush",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.798
+      },
+      {
+        "event_time": "2026-07-04T13:16:18+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Meta (META) Launches Meta Compute To Sell AI Power Beyond Advertising",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.7646
+      },
+      {
+        "event_time": "2026-06-30T01:08:41+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Wall Street Tech Analyst: Micron Could 4x If the AI Cycle Lasts Through 2030",
+        "category": "analyst_note",
+        "sentiment_score": 0.0,
+        "importance_score": 0.6895
+      },
+      {
+        "event_time": "2026-07-06T19:41:19+00:00",
+        "source": "Yahoo Finance",
+        "headline": "JPMorgan Cuts Wix.com (WIX) Target to $62 in a Sector-Wide Recalibration",
+        "category": "analyst_note",
+        "sentiment_score": -0.6667,
+        "importance_score": 0.6628
+      },
+      {
+        "event_time": "2026-07-08T15:35:24+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Microsoft (MSFT) Unifies Copilot Strategy to Challenge ChatGPT and Claude",
+        "category": "analyst_note",
+        "sentiment_score": 0.0,
+        "importance_score": 0.6427
+      }
+    ],
+    "prior_thesis": null,
+    "risk_metrics": {
+      "metric_version": "risk_v1",
+      "basis_note": "All returns/ratios are fractions (0.10 = 10%, not percent). Drawdown, var_5 and worst_day are signed losses (negative is a loss). Basis is price-return (no dividend reinvestment; total-return is future work), so do not over-read CAGR for high-yield names. A non-'ok' status means the metric is NOT a precise number: treat insufficient_history / partial_window as provisional, and benchmark_missing beta/excess as absent, not zero. Cite a risk figure as {window_key, as_of_date, metric_version}.",
+      "windows": [
+        {
+          "window_key": "1y",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": -0.220326848336744,
+          "excess_cagr_vs_spy": -0.42621865482350124,
+          "vol_annualized": 0.26751618485012296,
+          "beta": 0.9095865680948223,
+          "beta_r2": 0.19330783397713108,
+          "calmar": -0.6163412625157717,
+          "max_drawdown": -0.35747541457376625,
+          "current_drawdown": -0.2959310108538488,
+          "var_5": -0.0275769,
+          "worst_day": -0.05007533492259659,
+          "cagr_status": "partial_window",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "partial_window"
+        },
+        {
+          "window_key": "3y",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.05360041083669935,
+          "excess_cagr_vs_spy": -0.14097446346441952,
+          "vol_annualized": 0.24388012420342062,
+          "beta": 1.012192288353806,
+          "beta_r2": 0.3614378826660817,
+          "calmar": 0.14994153066612842,
+          "max_drawdown": -0.35747541457376625,
+          "current_drawdown": -0.2959310108538488,
+          "var_5": -0.02523972,
+          "worst_day": -0.06250042430778993,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        },
+        {
+          "window_key": "full",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.09127375757342471,
+          "excess_cagr_vs_spy": -0.07158685916727008,
+          "vol_annualized": 0.268805583128706,
+          "beta": 1.1227676649426084,
+          "beta_r2": 0.4727346440628069,
+          "calmar": 0.25532876906305413,
+          "max_drawdown": -0.35747541457376625,
+          "current_drawdown": -0.2959310108538488,
+          "var_5": -0.02619969,
+          "worst_day": -0.08009421298459037,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        }
+      ]
+    },
+    "earnings_history": [],
+    "analyst_estimates": null
+  }
+}

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -21,6 +21,8 @@ from app.services.llm_client import (
     LLMProviderNotConfigured,
     OpenAICompatProvider,
     make_llm_client,
+    normalize_completion_text,
+    strip_code_fence,
     strip_think_block,
 )
 
@@ -65,6 +67,45 @@ class TestStripThinkBlock:
         # A <think> string INSIDE the JSON payload must survive.
         text = '<think>x</think>{"memo": "<think>quoted</think>"}'
         assert strip_think_block(text) == '{"memo": "<think>quoted</think>"}'
+
+
+class TestStripCodeFence:
+    def test_plain_json_unchanged(self) -> None:
+        assert strip_code_fence('{"a": 1}') == '{"a": 1}'
+
+    def test_json_fence_unwrapped(self) -> None:
+        assert strip_code_fence('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_bare_fence_unwrapped(self) -> None:
+        assert strip_code_fence('```\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_unclosed_fence_not_stripped(self) -> None:
+        # Truncated at max_tokens mid-payload: parse failure +
+        # finish_reason='length' must stay honest (same contract as the
+        # unclosed <think> case).
+        text = '```json\n{"a": 1}'
+        assert strip_code_fence(text) == text
+
+    def test_fence_not_wrapping_whole_text_not_stripped(self) -> None:
+        text = "prose then ```json\n{}\n```"
+        assert strip_code_fence(text) == text
+
+    def test_backticks_inside_json_string_survive(self) -> None:
+        # \Z anchor forces the match to the LAST fence, so a fenced code
+        # block INSIDE memo_markdown survives the unwrap.
+        text = '```json\n{"memo": "use ``` for code"}\n```'
+        assert strip_code_fence(text) == '{"memo": "use ``` for code"}'
+
+
+class TestNormalizeCompletionText:
+    def test_think_then_fence_both_stripped(self) -> None:
+        # deepseek-r1 shape (#1919 PR-C tilt-check): think block first,
+        # then a fenced JSON object.
+        text = '<think>reasoning</think>\n```json\n{"a": 1}\n```'
+        assert normalize_completion_text(text) == '{"a": 1}'
+
+    def test_plain_json_passthrough(self) -> None:
+        assert normalize_completion_text('{"a": 1}') == '{"a": 1}'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm_eval_thesis.py
+++ b/tests/test_llm_eval_thesis.py
@@ -1,0 +1,255 @@
+"""Pure-logic tests for the thesis LLM eval harness (#1919 PR-C).
+
+No DB, no network: a fake ``LLMClient`` drives the retry/classification
+path; aggregation is table-tested on synthetic rounds.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.services.llm_client import LLMCompletion
+from scripts.llm_eval_thesis import (
+    AttemptResult,
+    RoundResult,
+    aggregate,
+    classify_attempt,
+    run_round,
+)
+
+_VALID_WRITER = {
+    "thesis_type": "compounder",
+    "confidence_score": 0.7,
+    "stance": "buy",
+    "buy_zone_low": 100.0,
+    "buy_zone_high": 120.0,
+    "base_value": 150.0,
+    "bull_value": 200.0,
+    "bear_value": 90.0,
+    "break_conditions": ["margin collapse"],
+    "memo_markdown": "## Memo\nthree paragraphs...",
+}
+
+_VALID_CRITIC = {
+    "summary": "Overpriced compounder.",
+    "key_risks": ["multiple compression"],
+    "hidden_assumptions": ["margins hold"],
+    "evidence_gaps": ["no channel checks"],
+    "thesis_breakers": ["guidance cut"],
+    "verdict": "Moderate challenge",
+}
+
+
+def _completion(text: str, finish_reason: str = "stop", completion_tokens: int | None = 100) -> LLMCompletion:
+    return LLMCompletion(
+        text=text,
+        finish_reason=finish_reason,
+        model="test-model",
+        prompt_tokens=1000,
+        completion_tokens=completion_tokens,
+    )
+
+
+class FakeClient:
+    """Scripted LLMClient: pops one canned completion (or exception) per call."""
+
+    provider_name = "openai_compatible"
+    model = "test-model"
+
+    def __init__(self, script: list[LLMCompletion | Exception]) -> None:
+        self._script = list(script)
+        self.calls = 0
+
+    def complete(self, *, system: str, user: str, max_tokens: int) -> LLMCompletion:
+        self.calls += 1
+        item = self._script.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+# ---------------------------------------------------------------------------
+# classify_attempt
+# ---------------------------------------------------------------------------
+
+
+def test_classify_valid_writer_passes() -> None:
+    result, parsed = classify_attempt(_completion(json.dumps(_VALID_WRITER)), 10.0, call="writer")
+    assert result.ok
+    assert result.category == "pass"
+    assert result.enum_ok is True
+    assert parsed == _VALID_WRITER
+    assert result.tok_s == 10.0  # 100 tokens / 10s
+
+
+def test_classify_unparseable_json() -> None:
+    result, parsed = classify_attempt(_completion("not json {", finish_reason="length"), 5.0, call="writer")
+    assert not result.ok
+    assert result.category == "invalid_json"
+    assert result.enum_ok is None  # never parsed -> excluded from enum metric
+    assert result.finish_reason == "length"
+    assert parsed is None
+
+
+def test_classify_json_array_is_invalid_json_category() -> None:
+    result, parsed = classify_attempt(_completion("[1, 2]"), 5.0, call="writer")
+    assert result.category == "invalid_json"
+    assert parsed is None
+
+
+def test_classify_bad_enum_is_schema_fail_with_enum_flag() -> None:
+    bad = dict(_VALID_WRITER, thesis_type="moonshot")
+    result, parsed = classify_attempt(_completion(json.dumps(bad)), 5.0, call="writer")
+    assert not result.ok
+    assert result.category == "schema_fail"
+    assert result.enum_ok is False
+    assert parsed is None
+
+
+def test_classify_missing_field_valid_enums() -> None:
+    incomplete = {k: v for k, v in _VALID_WRITER.items() if k != "memo_markdown"}
+    result, _ = classify_attempt(_completion(json.dumps(incomplete)), 5.0, call="writer")
+    assert result.category == "schema_fail"
+    # enums themselves were fine; the spec's enum-validity metric must see that
+    assert result.enum_ok is True
+
+
+def test_classify_critic_verdict_enum() -> None:
+    result, _ = classify_attempt(_completion(json.dumps(_VALID_CRITIC)), 5.0, call="critic")
+    assert result.ok and result.enum_ok is True
+    bad = dict(_VALID_CRITIC, verdict="Devastating challenge")
+    result, _ = classify_attempt(_completion(json.dumps(bad)), 5.0, call="critic")
+    assert result.category == "schema_fail" and result.enum_ok is False
+
+
+def test_tok_s_none_without_usage() -> None:
+    result, _ = classify_attempt(_completion(json.dumps(_VALID_WRITER), completion_tokens=None), 5.0, call="writer")
+    assert result.tok_s is None
+
+
+# ---------------------------------------------------------------------------
+# run_round (retry-once shape)
+# ---------------------------------------------------------------------------
+
+
+def test_round_first_attempt_pass_stops() -> None:
+    client = FakeClient([_completion(json.dumps(_VALID_WRITER))])
+    rnd = run_round(client, symbol="AAPL", call="writer", system="s", user="u", max_tokens=64)
+    assert client.calls == 1
+    assert rnd.pass_first and rnd.pass_with_retry
+    assert rnd.parsed == _VALID_WRITER
+
+
+def test_round_retry_recovers() -> None:
+    client = FakeClient([_completion("garbage"), _completion(json.dumps(_VALID_WRITER))])
+    rnd = run_round(client, symbol="AAPL", call="writer", system="s", user="u", max_tokens=64)
+    assert client.calls == 2
+    assert not rnd.pass_first
+    assert rnd.pass_with_retry
+    assert rnd.parsed == _VALID_WRITER
+
+
+def test_round_both_attempts_fail() -> None:
+    client = FakeClient([_completion("garbage"), _completion("{}")])
+    rnd = run_round(client, symbol="AAPL", call="writer", system="s", user="u", max_tokens=64)
+    assert client.calls == 2
+    assert not rnd.pass_with_retry
+    assert rnd.parsed is None
+    assert [a.category for a in rnd.attempts] == ["invalid_json", "schema_fail"]
+
+
+def test_round_transport_error_ends_round_without_retry() -> None:
+    # Prod _call_with_one_retry retries only ValueError (parse/schema);
+    # transport errors propagate with NO retry — the harness must not
+    # credit a recovery production would never perform.
+    client = FakeClient([RuntimeError("connection refused"), _completion(json.dumps(_VALID_WRITER))])
+    rnd = run_round(client, symbol="AAPL", call="writer", system="s", user="u", max_tokens=64)
+    assert client.calls == 1
+    assert len(rnd.attempts) == 1
+    assert rnd.attempts[0].category == "transport"
+    assert "connection refused" in (rnd.attempts[0].error or "")
+    assert not rnd.pass_with_retry
+    assert rnd.parsed is None
+
+
+# ---------------------------------------------------------------------------
+# aggregate
+# ---------------------------------------------------------------------------
+
+
+def _attempt(
+    ok: bool, *, category: str = "pass", enum_ok: bool | None = True, finish: str | None = "stop"
+) -> AttemptResult:
+    return AttemptResult(
+        ok=ok,
+        category=category if not ok or category != "pass" else "pass",
+        enum_ok=enum_ok,
+        finish_reason=finish,
+        duration_s=10.0,
+        completion_tokens=50,
+    )
+
+
+def test_aggregate_gate_math() -> None:
+    # 10 writer rounds: 8 pass first, 1 recovers on retry, 1 dead -> 9/10 with retry = gate PASS
+    rounds = (
+        [RoundResult("AAPL", "writer", [_attempt(True)])] * 8
+        + [RoundResult("GME", "writer", [_attempt(False, category="invalid_json", enum_ok=None), _attempt(True)])]
+        + [
+            RoundResult(
+                "HD",
+                "writer",
+                [
+                    _attempt(False, category="schema_fail", enum_ok=False, finish="length"),
+                    _attempt(False, category="schema_fail", enum_ok=False, finish="length"),
+                ],
+            )
+        ]
+    )
+    report = aggregate("m", rounds)
+    assert report.writer_rounds == 10
+    assert report.writer_pass_first == 8
+    assert report.writer_pass_retry == 9
+    assert report.gate_passes()
+    # 8 first-pass stops + round-9's two attempts (stop, stop) + round-10's two lengths
+    assert report.finish_reasons == {"stop": 10, "length": 2}
+    # enum metric: 9 passes (True) + 2 schema_fails (False); invalid_json excluded
+    assert report.enum_checked == 11
+    assert report.enum_ok == 9
+
+
+def test_aggregate_gate_fails_below_nine_of_ten() -> None:
+    rounds = [RoundResult("AAPL", "writer", [_attempt(True)])] * 8 + [
+        RoundResult("GME", "writer", [_attempt(False, category="schema_fail")]) for _ in range(2)
+    ]
+    report = aggregate("m", rounds)
+    assert report.writer_pass_retry == 8
+    assert not report.gate_passes()
+
+
+def test_aggregate_separates_writer_and_critic() -> None:
+    rounds = [
+        RoundResult("AAPL", "writer", [_attempt(True)]),
+        RoundResult("AAPL", "critic", [_attempt(False, category="schema_fail"), _attempt(True)]),
+    ]
+    report = aggregate("m", rounds)
+    assert (report.writer_rounds, report.critic_rounds) == (1, 1)
+    assert report.critic_pass_first == 0
+    assert report.critic_pass_retry == 1
+    # writer pass rate unaffected by critic failures
+    assert report.writer_pass_retry_rate == 1.0
+
+
+def test_aggregate_empty_rounds_no_gate() -> None:
+    report = aggregate("m", [])
+    assert report.writer_rounds == 0
+    assert not report.gate_passes()
+
+
+def test_gate_requires_minimum_sample() -> None:
+    # 5/5 (100%) must NOT pass the gate — spec §7 is >=9/10, so fewer than
+    # 10 writer rounds is an insufficient sample regardless of rate.
+    rounds = [RoundResult("AAPL", "writer", [_attempt(True)])] * 5
+    report = aggregate("m", rounds)
+    assert report.writer_pass_retry_rate == 1.0
+    assert not report.gate_passes()


### PR DESCRIPTION
Refs #1919 (closes via PR-B). PR-C of #1919 (spec `docs/specs/thesis/2026-07-09-byo-llm-thesis-live.md` §7, merged PR #1990). Third of 3 PRs: A core (merged #1991) → **C eval** → B scheduling.

## What

- **`scripts/llm_eval_thesis.py`** — thesis LLM eval harness, two subcommands:
  - `capture`: snapshots `_assemble_context` output from the dev DB into `tests/fixtures/llm_eval/<symbol>.json` for the house panel (AAPL/GME/MSFT/JPM/HD). Dev-guarded (`scripts/_dev_guard.assert_dev_environment`, #1765 pattern). Serialization uses the same `json.dumps(..., default=str)` transform as `_build_writer_prompt`, so replay is byte-equivalent in prompt space.
  - `run`: replays fixtures against one or more models on an OpenAI-compatible endpoint. Prompts, validators, and token budgets are **imported from `app.services.thesis`** (`_WRITER_SYSTEM`, `_validate_writer_output`, etc.) — never copied, so the benchmark cannot drift from the production path. Rounds mirror `_call_with_one_retry` exactly: retry ONCE on parse/schema failure; transport errors end the round with NO retry (prod propagates them).
  - Reports: writer/critic pass rate (first attempt + with retry), enum validity among parsed outputs, `finish_reason` mix, wall-clock + tok/s per call, raw-output head on parse failures. Spec §7 go-live gate: ≥9/10 writer passes with retry, enforced via `--gate-model` exit code with a ≥10-round minimum sample.
- **`app/services/llm_client.py`** — two additive changes:
  1. `LLMCompletion` gains optional `prompt_tokens`/`completion_tokens` (provider-reported usage; both providers populate). Needed for tok/s.
  2. **Whole-text code-fence normalization** (`strip_code_fence`, composed with the existing think-strip as `normalize_completion_text`): benchmark tilt-check caught deepseek-r1 emitting schema-valid JSON wrapped in ` ```json ` fences (Ollama does not enforce `response_format=json_object` for it). Stripping is lossless (no-op unless one fence wraps the entire completion), model-neutral, and an unclosed fence deliberately does NOT match so truncation stays honest — the exact contract of the think-strip.
- **`tests/`** — 16 pure-logic harness tests (classification stages, retry-once shape, transport-no-retry, aggregation + gate math, minimum-sample gate) + 8 new provider tests (fence-strip edge cases incl. backticks inside `memo_markdown`, think+fence composition).
- **`docs/wiki/byo-llm.md`** — harness invocation + deepseek-r1 verdict recorded in the model-gotchas section.
- **Fixtures** — house panel captured 2026-07-09, ~30KB total (kept small deliberately; PR1973 precedent on fixture size inflating review input). AAPL fixture includes prior thesis v1 → exercises the prior-thesis context path.

## Benchmark (recorded per spec §7) — qwen3:14b vs deepseek-r1:14b

House panel × 2 iterations = 10 writer rounds/model, identical replayed prompts, Ollama `http://localhost:11434/v1`, dev machine. Commit `2a275e11`.

| metric | qwen3:14b | deepseek-r1:14b |
|---|---|---|
| writer pass, first attempt | 8/10 (80%) | 8/10 (80%) |
| writer pass, with retry | **10/10 (100%)** | **10/10 (100%)** |
| critic pass, with retry | 10/10 (100%) | 9/10 (90%) |
| enum validity (parsed outputs) | 22/22 (100%) | 20/23 (87%) |
| finish_reason mix | stop ×22 | stop ×24, length ×1 |
| wall-clock/call (mean / median / max) | 151s / 149s / 203s | 116s / 119s / 152s |
| throughput | 3.1 tok/s | 7.9 tok/s |
| **go-live gate (≥9/10 with retry)** | **PASS** | **PASS** (post-normalization; was FAIL 4/10 pre-fix) |

**Verdict: both models pass the writer gate on the shipped code; qwen3:14b stays the default** (no config change) on critic reliability (10/10 vs 9/10 with retry) and enum validity (100% vs 87%). deepseek-r1:14b is a viable, ~2.5× faster alternative post fence-normalization. qwen3's two first-attempt failures were both GME missing-fields schema fails, recovered on retry — the failure class the retry-once design exists for.

### Tilt-check (was the benchmark biased against deepseek-r1?)

Deliberately audited after run 1 showed deepseek failing 6/10 writer rounds at JSON char 0 despite `finish=stop`:

- Probe with raw-output capture found **two distinct failure modes**: (a) free-prose markdown memo, no JSON at all — a genuine contract failure (and proof Ollama ignores `response_format=json_object` for r1); (b) schema-valid JSON wrapped in a markdown fence — an interaction-layer artifact, ours to fix.
- Mode (b) fixed in this PR at the **provider layer** (production benefit, all models), then deepseek re-benchmarked on the shipped code. The table above shows the post-normalization numbers.
- What the gate claims stays narrow: "can this model serve `generate_thesis` as shipped" — it selects the `llm_model` config value; it is not a general capability claim.

## Security model

No new attack surface: the harness is a local dev script (never imported by `app/`), talks only to the operator-configured endpoint through the existing bounded-timeout `OpenAICompatProvider` (600s read, #1479 class), and `capture` refuses non-dev environments via `assert_dev_environment` (checks `app_env` AND localhost DB host). No auth change, no endpoint change, no schema change. Keys stay env-only as in PR-A. `check_llm_chokepoint.sh` stays green — the harness constructs no raw `chat/completions` call. Fence normalization cannot smuggle content past validation: it only unwraps, never rewrites, and all output still passes the production validators.

## Settled decisions / prevention log

- Thesis semantics (settled-decisions "Thesis semantics"): untouched — prompts/validators imported, not modified; no `theses` writes anywhere in the harness.
- #1479 bounded outbound I/O: all calls via `OpenAICompatProvider` (bounded timeout + per-process semaphore).
- Test tiering: pure-logic only; no new SQL mechanism → no DB-tier test needed.
- Prevention log: compact fixtures (PR1973 lesson); no `assert` guards outside tests; `fetchone()` in capture pinned with `ORDER BY instrument_id LIMIT 1` (symbol NOT unique, sql/043).

## Codex checkpoint 2 (pre-push)

Two P2 findings, both FIXED before push:
1. Gate could pass on <10 rounds (e.g. 5/5) → `GATE_MIN_ROUNDS = 10` + test.
2. Transport-error retry credited a recovery prod never performs (`_call_with_one_retry` retries only `ValueError`) → transport now ends the round + test.

## Conscious tradeoffs

- Fixtures are a point-in-time snapshot of dev-DB context (AAPL news/filings arrays empty — real dev state, same context PR-A generated from). Model comparison needs identical inputs, not fresh ones; `capture` re-runs in one command.
- `--iterations 2` × 5 fixtures = exactly the spec's 10-round gate sample; larger samples are a CLI flag away.
- Harness imports private members of `app.services.thesis` (`_WRITER_SYSTEM` et al.). Deliberate: a public re-export layer for a dev script is surface without benefit; drift-proofing (import > copy) wins.
- Free-prose failure mode (deepseek mode (a)) is NOT papered over with a JSON-extraction heuristic — pulling a `{...}` substring out of prose risks accepting a hallucinated skeleton. Strict contract + retry stands.

## Verification

- `uv run ruff check .` / `ruff format --check .` / `pyright` — clean (0 errors)
- `uv run pytest -m "not db"` — 4884+ passed; `tests/smoke` — 147 passed (app boots against dev DB)
- Harness smoke: HD/qwen3 single round end-to-end → writer PASS, critic PASS, report + `--json-out` + exit code correct
- Full benchmark above ran on this branch (raw per-attempt JSON retained locally)

ETL clauses 8–12: N/A — no parser/schema/ingest change (dev script + additive provider normalization). The benchmark itself IS the panel smoke (AAPL/GME/MSFT/JPM/HD exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
