### PR TITLE
feat(#1902): Theses library — global thesis surface (list, status, staleness, critic verdicts)

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -55,6 +55,7 @@ from app.db import get_conn
 from app.db.snapshot import snapshot_read
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
 from app.services.scoring import _DEFAULT_MODEL_VERSION
+from app.services.thesis import find_stale_instruments
 
 router = APIRouter(
     prefix="/alerts",
@@ -169,6 +170,17 @@ class RankMovesResponse(BaseModel):
 
 class RankMovesMarkSeenRequest(BaseModel):
     seen_through_rank_event_id: int = Field(gt=0)
+
+
+class ThesisStalenessItem(BaseModel):
+    instrument_id: int
+    symbol: str
+    reason: str  # find_stale_instruments StaleReason (open string, #1808)
+    latest_thesis_at: datetime | None  # None = no thesis at all
+
+
+class ThesisStalenessResponse(BaseModel):
+    items: list[ThesisStalenessItem]
 
 
 def _resolve_operator(conn: psycopg.Connection[object]) -> UUID:
@@ -671,6 +683,72 @@ def mark_rank_moves_seen(
             },
         )
     conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# #1902 (folding in #1922 item 3) — thesis-staleness snapshot feed
+#
+#   GET /alerts/thesis-staleness
+#
+# Deliberately NOT a cursor feed: staleness is a STANDING CONDITION, not an
+# event. There is no BIGSERIAL to cursor on and "mark seen" has no meaning —
+# the card clears when the thesis regenerates (thesis_refresh drains it at
+# ≤5/hour, or per-row force from the library). The FE renders it as one
+# grouped card outside the unseen/dismiss accounting. Scope = HELD
+# instruments only (current_units > 0): the operator's money is where a
+# stale thesis is an actionable gap; the full queue lives at /theses?stale.
+# Staleness truth = find_stale_instruments (single source, #1902).
+# ---------------------------------------------------------------------------
+
+
+@router.get("/thesis-staleness", response_model=ThesisStalenessResponse)
+def get_thesis_staleness(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ThesisStalenessResponse:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT p.instrument_id
+            FROM positions p
+            WHERE p.current_units > 0
+            """
+        )
+        held_ids = [int(r["instrument_id"]) for r in cur.fetchall()]  # type: ignore[arg-type]
+
+    if not held_ids:
+        return ThesisStalenessResponse(items=[])
+
+    stale = find_stale_instruments(conn, tier=None, instrument_ids=held_ids)
+    if not stale:
+        return ThesisStalenessResponse(items=[])
+
+    stale_ids = [s.instrument_id for s in stale]
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, MAX(created_at) AS latest_thesis_at
+            FROM theses
+            WHERE instrument_id = ANY(%(ids)s)
+            GROUP BY instrument_id
+            """,
+            {"ids": stale_ids},
+        )
+        latest_at = {
+            int(r["instrument_id"]): r["latest_thesis_at"]  # type: ignore[arg-type]
+            for r in cur.fetchall()
+        }
+
+    return ThesisStalenessResponse(
+        items=[
+            ThesisStalenessItem(
+                instrument_id=s.instrument_id,
+                symbol=s.symbol,
+                reason=s.reason,
+                latest_thesis_at=latest_at.get(s.instrument_id),
+            )
+            for s in stale
+        ]
+    )
 
 
 @router.post("/rank-moves/dismiss-all", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -220,6 +220,22 @@ def _critic_verdict(critic_json: object) -> str | None:
     return verdict if isinstance(verdict, str) else None
 
 
+def library_order_key(row: dict[str, object]) -> tuple[int, float, int]:
+    """Deterministic library ordering, independent of per-query ORDER BYs.
+
+    Gap rows (held, no thesis — ``created_at`` is None) sort first: a
+    missing memo on money is the most actionable row. Thesis rows follow
+    newest-first, thesis_id tiebreak. One sort key in one place so the
+    page order can't silently change if either SQL constant's ORDER BY
+    is edited independently (review NITPICK).
+    """
+    created = row.get("created_at")
+    if not isinstance(created, datetime):
+        return (0, 0.0, 0)
+    thesis_id = row.get("thesis_id")
+    return (1, -created.timestamp(), -int(thesis_id) if isinstance(thesis_id, int) else 0)
+
+
 def filter_and_page_library(
     rows: list[dict[str, object]],
     stale_reasons: dict[int, str],
@@ -244,8 +260,10 @@ def filter_and_page_library(
     """
     filtered: list[dict[str, object]] = []
     for row in rows:
-        instrument_id = row["instrument_id"]
-        assert isinstance(instrument_id, int)
+        # int() cast, not assert — asserts are stripped under `python -O`
+        # so they can't gate response shape (review WARNING; same rule as
+        # python-hygiene.md "never assert production invariants").
+        instrument_id = int(row["instrument_id"])  # type: ignore[arg-type]
         row["stale_reason"] = stale_reasons.get(instrument_id)
         if held_only and not row["is_held"]:
             continue
@@ -389,12 +407,15 @@ def list_theses(
     in-memory filter + slice — see ``filter_and_page_library``).
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        # Held-but-thesis-less rows first: a missing memo on money is the
-        # most actionable gap the library can show (Codex ckpt-2).
+        # Held-but-thesis-less gap rows + latest-thesis rows (Codex ckpt-2),
+        # merged under ONE explicit sort key (gap rows first, then newest
+        # thesis) so page order never depends on concat order of the two
+        # queries. Stable sort preserves each query's own tiebreak order.
         cur.execute(_HELD_NO_THESIS_SQL, {"mv": _DEFAULT_MODEL_VERSION})
         rows: list[dict[str, object]] = list(cur.fetchall())
         cur.execute(_LIBRARY_SQL, {"mv": _DEFAULT_MODEL_VERSION})
         rows.extend(cur.fetchall())
+        rows.sort(key=library_order_key)
 
     stale_reasons: dict[int, str] = {}
     if rows:

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -123,6 +123,12 @@ class ThesisLibraryItem(BaseModel):
     plus display context (held flag, latest score, latest generation-run
     status, server-computed staleness).
 
+    HELD instruments WITHOUT any thesis also get a row (thesis fields
+    null, ``stale_reason='no_thesis'`` when analysable) — the dashboard
+    staleness alert includes them, so the library it links to must too
+    (Codex ckpt-2 finding 1). Unheld instruments without theses stay out:
+    the library is a thesis surface, not the instrument universe.
+
     ``run_status`` is the latest ``thesis_runs`` row for the instrument —
     'running' | 'ok' | 'failed' (DB CHECK-constrained), None when the
     instrument predates thesis_runs (#1919). ``stale_reason`` is None when
@@ -137,14 +143,14 @@ class ThesisLibraryItem(BaseModel):
     instrument_id: int
     symbol: str
     company_name: str
-    thesis_id: int
-    thesis_version: int
-    thesis_type: str
-    stance: str
+    thesis_id: int | None
+    thesis_version: int | None
+    thesis_type: str | None
+    stance: str | None
     confidence_score: float | None
     buy_zone_low: float | None
     buy_zone_high: float | None
-    created_at: datetime
+    created_at: datetime | None
     critic_verdict: str | None
     stale_reason: str | None
     is_held: bool
@@ -309,6 +315,59 @@ _LIBRARY_SQL = """
     ORDER BY t.created_at DESC, t.thesis_id DESC
 """
 
+# Held instruments with NO thesis at all — the actionable gap the dashboard
+# staleness alert surfaces, so the library must show them too (Codex ckpt-2).
+# Same LATERAL context as _LIBRARY_SQL; thesis columns are typed NULLs so both
+# result sets share one row shape. Prepended above the thesis rows by the
+# endpoint: a missing memo on money outranks any existing memo's age.
+_HELD_NO_THESIS_SQL = """
+    SELECT
+        NULL::bigint      AS thesis_id,
+        i.instrument_id,
+        NULL::int         AS thesis_version,
+        NULL::text        AS thesis_type,
+        NULL::text        AS stance,
+        NULL::numeric     AS confidence_score,
+        NULL::numeric     AS buy_zone_low,
+        NULL::numeric     AS buy_zone_high,
+        NULL::jsonb       AS critic_json,
+        NULL::timestamptz AS created_at,
+        i.symbol, i.company_name,
+        TRUE AS is_held,
+        s.total_score AS latest_score,
+        s.rank        AS latest_rank,
+        r.status      AS run_status,
+        r.error       AS run_error,
+        r.trigger     AS run_trigger,
+        r.started_at  AS run_started_at
+    FROM instruments i
+    LEFT JOIN LATERAL (
+        SELECT s.total_score, s.rank
+        FROM scores s
+        WHERE s.instrument_id = i.instrument_id
+          AND s.model_version = %(mv)s
+        ORDER BY s.scored_at DESC
+        LIMIT 1
+    ) s ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT r.status, r.error, r.trigger, r.started_at
+        FROM thesis_runs r
+        WHERE r.instrument_id = i.instrument_id
+        ORDER BY r.started_at DESC, r.run_id DESC
+        LIMIT 1
+    ) r ON TRUE
+    WHERE EXISTS (
+            SELECT 1 FROM positions p
+            WHERE p.instrument_id = i.instrument_id
+              AND p.current_units > 0
+          )
+      AND NOT EXISTS (
+            SELECT 1 FROM theses t
+            WHERE t.instrument_id = i.instrument_id
+          )
+    ORDER BY i.symbol
+"""
+
 
 @router.get("", response_model=ThesisLibraryResponse)
 def list_theses(
@@ -330,8 +389,12 @@ def list_theses(
     in-memory filter + slice — see ``filter_and_page_library``).
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Held-but-thesis-less rows first: a missing memo on money is the
+        # most actionable gap the library can show (Codex ckpt-2).
+        cur.execute(_HELD_NO_THESIS_SQL, {"mv": _DEFAULT_MODEL_VERSION})
+        rows: list[dict[str, object]] = list(cur.fetchall())
         cur.execute(_LIBRARY_SQL, {"mv": _DEFAULT_MODEL_VERSION})
-        rows = cur.fetchall()
+        rows.extend(cur.fetchall())
 
     stale_reasons: dict[int, str] = {}
     if rows:
@@ -341,7 +404,7 @@ def list_theses(
         }
 
     total, page = filter_and_page_library(
-        list(rows),
+        rows,
         stale_reasons,
         held_only=held_only,
         stale_only=stale,

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -30,7 +30,8 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.services.llm_client import LLMClient, LLMProviderNotConfigured, make_llm_client
 from app.services.runtime_config import RuntimeConfigCorrupt
-from app.services.thesis import generate_thesis
+from app.services.scoring import _DEFAULT_MODEL_VERSION
+from app.services.thesis import find_stale_instruments, generate_thesis
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,15 @@ MAX_PAGE_LIMIT = 200
 
 
 class ThesisDetail(BaseModel):
-    """Single thesis row with all columns including critic output."""
+    """Single thesis row with all columns including critic output.
+
+    ``is_stale`` / ``stale_reason`` are populated ONLY by the latest-thesis
+    GET (#1902 staleness single-source — the canonical predicate is
+    ``find_stale_instruments``, coverage.review_frequency-based, NOT a
+    client-side day constant). History rows and the POST response leave
+    them null: a history row is inherently historical and the POST just
+    generated the thesis.
+    """
 
     thesis_id: int
     instrument_id: int
@@ -97,11 +106,58 @@ class ThesisDetail(BaseModel):
     memo_markdown: str
     critic_json: dict[str, object] | None
     created_at: datetime
+    is_stale: bool | None = None
+    stale_reason: str | None = None
 
 
 class ThesisHistoryResponse(BaseModel):
     instrument_id: int
     items: list[ThesisDetail]
+    total: int
+    offset: int
+    limit: int
+
+
+class ThesisLibraryItem(BaseModel):
+    """One row of the Theses library (#1902): latest thesis per instrument
+    plus display context (held flag, latest score, latest generation-run
+    status, server-computed staleness).
+
+    ``run_status`` is the latest ``thesis_runs`` row for the instrument —
+    'running' | 'ok' | 'failed' (DB CHECK-constrained), None when the
+    instrument predates thesis_runs (#1919). ``stale_reason`` is None when
+    the thesis is fresh OR the instrument is outside the refresh engine's
+    scope (not tradable / not analysable — regeneration would never fire,
+    so flagging it stale would nag forever with no cure).
+    ``critic_verdict`` stays an open string: validated at write time
+    against the critic enum, but the column is free JSON — no response
+    Literal over open text (#1808 class).
+    """
+
+    instrument_id: int
+    symbol: str
+    company_name: str
+    thesis_id: int
+    thesis_version: int
+    thesis_type: str
+    stance: str
+    confidence_score: float | None
+    buy_zone_low: float | None
+    buy_zone_high: float | None
+    created_at: datetime
+    critic_verdict: str | None
+    stale_reason: str | None
+    is_held: bool
+    latest_score: float | None
+    latest_rank: int | None
+    run_status: str | None
+    run_error: str | None
+    run_trigger: str | None
+    run_started_at: datetime | None
+
+
+class ThesisLibraryResponse(BaseModel):
+    items: list[ThesisLibraryItem]
     total: int
     offset: int
     limit: int
@@ -150,9 +206,176 @@ _THESIS_COLUMNS = """
 """
 
 
+def _critic_verdict(critic_json: object) -> str | None:
+    """Extract the critic's verdict string from a critic_json payload."""
+    if not isinstance(critic_json, dict):
+        return None
+    verdict = critic_json.get("verdict")
+    return verdict if isinstance(verdict, str) else None
+
+
+def filter_and_page_library(
+    rows: list[dict[str, object]],
+    stale_reasons: dict[int, str],
+    *,
+    held_only: bool,
+    stale_only: bool,
+    stance: str | None,
+    offset: int,
+    limit: int,
+) -> tuple[int, list[dict[str, object]]]:
+    """Apply library filters + pagination to the latest-per-instrument rows.
+
+    Pure (table-tested without a DB). All filtering is post-SQL so the
+    query stays one static shape and staleness — which only exists as
+    the canonical Python predicate ``find_stale_instruments`` — composes
+    with the other filters in one place. Row volume is bounded by the
+    number of instruments that have a thesis (hundreds under the #1919
+    batch-bounded refresh), so in-memory filtering is fine.
+
+    Returns ``(total_after_filters, page_slice)``. Mutates each row with
+    its ``stale_reason`` so callers get one enriched shape.
+    """
+    filtered: list[dict[str, object]] = []
+    for row in rows:
+        instrument_id = row["instrument_id"]
+        assert isinstance(instrument_id, int)
+        row["stale_reason"] = stale_reasons.get(instrument_id)
+        if held_only and not row["is_held"]:
+            continue
+        if stale_only and row["stale_reason"] is None:
+            continue
+        if stance is not None and row["stance"] != stance:
+            continue
+        filtered.append(row)
+    return len(filtered), filtered[offset : offset + limit]
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
+
+
+# Latest thesis per instrument + display context. DISTINCT ON picks the
+# newest (created_at, thesis_version) row per instrument — same tiebreak
+# as the per-instrument latest read. The scores LATERAL is deliberately
+# per-instrument-latest, NOT run-coherent MAX(scored_at): this is a
+# per-row display column, the same divergence get_verdict documents
+# (app/api/scores.py) — an instrument dropped from the very latest run
+# still shows its most recent analysis, with staleness visible via rank.
+# The thesis_runs LATERAL rides idx_thesis_runs_instrument_started;
+# run_id DESC breaks same-timestamp ties deterministically.
+_LIBRARY_SQL = """
+    SELECT
+        t.thesis_id, t.instrument_id, t.thesis_version, t.thesis_type,
+        t.stance, t.confidence_score, t.buy_zone_low, t.buy_zone_high,
+        t.critic_json, t.created_at,
+        i.symbol, i.company_name,
+        EXISTS (
+            SELECT 1 FROM positions p
+            WHERE p.instrument_id = t.instrument_id
+              AND p.current_units > 0
+        ) AS is_held,
+        s.total_score AS latest_score,
+        s.rank        AS latest_rank,
+        r.status      AS run_status,
+        r.error       AS run_error,
+        r.trigger     AS run_trigger,
+        r.started_at  AS run_started_at
+    FROM (
+        SELECT DISTINCT ON (instrument_id)
+            thesis_id, instrument_id, thesis_version, thesis_type,
+            stance, confidence_score, buy_zone_low, buy_zone_high,
+            critic_json, created_at
+        FROM theses
+        ORDER BY instrument_id, created_at DESC, thesis_version DESC
+    ) t
+    JOIN instruments i ON i.instrument_id = t.instrument_id
+    LEFT JOIN LATERAL (
+        SELECT s.total_score, s.rank
+        FROM scores s
+        WHERE s.instrument_id = t.instrument_id
+          AND s.model_version = %(mv)s
+        ORDER BY s.scored_at DESC
+        LIMIT 1
+    ) s ON TRUE
+    LEFT JOIN LATERAL (
+        SELECT r.status, r.error, r.trigger, r.started_at
+        FROM thesis_runs r
+        WHERE r.instrument_id = t.instrument_id
+        ORDER BY r.started_at DESC, r.run_id DESC
+        LIMIT 1
+    ) r ON TRUE
+    ORDER BY t.created_at DESC, t.thesis_id DESC
+"""
+
+
+@router.get("", response_model=ThesisLibraryResponse)
+def list_theses(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+    held_only: bool = Query(default=False),
+    stale: bool = Query(default=False),
+    stance: str | None = Query(default=None, pattern="^(buy|hold|watch|avoid)$"),
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=MAX_PAGE_LIMIT),
+) -> ThesisLibraryResponse:
+    """Theses library (#1902): latest thesis per instrument, newest first.
+
+    Staleness is computed server-side via ``find_stale_instruments`` —
+    the single canonical predicate (coverage.review_frequency cadence +
+    #273 filing-event triggers) shared with the ``thesis_refresh``
+    scheduler, so the library column, the instrument-page chip and the
+    refresh engine can never disagree. Row volume is bounded by the
+    number of instruments holding a thesis (unpaginated scan, then
+    in-memory filter + slice — see ``filter_and_page_library``).
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_LIBRARY_SQL, {"mv": _DEFAULT_MODEL_VERSION})
+        rows = cur.fetchall()
+
+    stale_reasons: dict[int, str] = {}
+    if rows:
+        instrument_ids = [int(r["instrument_id"]) for r in rows]  # type: ignore[arg-type]
+        stale_reasons = {
+            s.instrument_id: s.reason for s in find_stale_instruments(conn, tier=None, instrument_ids=instrument_ids)
+        }
+
+    total, page = filter_and_page_library(
+        list(rows),
+        stale_reasons,
+        held_only=held_only,
+        stale_only=stale,
+        stance=stance,
+        offset=offset,
+        limit=limit,
+    )
+
+    items = [
+        ThesisLibraryItem(
+            instrument_id=row["instrument_id"],  # type: ignore[arg-type]
+            symbol=row["symbol"],  # type: ignore[arg-type]
+            company_name=row["company_name"],  # type: ignore[arg-type]
+            thesis_id=row["thesis_id"],  # type: ignore[arg-type]
+            thesis_version=row["thesis_version"],  # type: ignore[arg-type]
+            thesis_type=row["thesis_type"],  # type: ignore[arg-type]
+            stance=row["stance"],  # type: ignore[arg-type]
+            confidence_score=_parse_optional_float(row, "confidence_score"),
+            buy_zone_low=_parse_optional_float(row, "buy_zone_low"),
+            buy_zone_high=_parse_optional_float(row, "buy_zone_high"),
+            created_at=row["created_at"],  # type: ignore[arg-type]
+            critic_verdict=_critic_verdict(row["critic_json"]),
+            stale_reason=row["stale_reason"],  # type: ignore[arg-type]
+            is_held=bool(row["is_held"]),
+            latest_score=_parse_optional_float(row, "latest_score"),
+            latest_rank=row["latest_rank"],  # type: ignore[arg-type]
+            run_status=row["run_status"],  # type: ignore[arg-type]
+            run_error=row["run_error"],  # type: ignore[arg-type]
+            run_trigger=row["run_trigger"],  # type: ignore[arg-type]
+            run_started_at=row["run_started_at"],  # type: ignore[arg-type]
+        )
+        for row in page
+    ]
+    return ThesisLibraryResponse(items=items, total=total, offset=offset, limit=limit)
 
 
 @router.get("/{instrument_id}", response_model=ThesisDetail | None)
@@ -198,7 +421,16 @@ def get_latest_thesis(
                 )
             return None
 
-    return _parse_thesis(row)
+    thesis = _parse_thesis(row)
+    # Staleness single-source (#1902): the FE used to duplicate a 30-day
+    # constant; the canonical predicate is find_stale_instruments
+    # (coverage cadence + #273 filing-event triggers). reason=None means
+    # fresh OR outside refresh scope (not tradable / not analysable) —
+    # both render as not-stale because regeneration would never fire.
+    stale = find_stale_instruments(conn, tier=None, instrument_ids=[instrument_id])
+    thesis.stale_reason = stale[0].reason if stale else None
+    thesis.is_stale = bool(stale)
+    return thesis
 
 
 @router.get("/{instrument_id}/history", response_model=ThesisHistoryResponse)

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -359,8 +359,8 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 ### `assert` as a runtime guard in service code
 - First seen in: #109
 - Symptom: A service function used `assert row is not None` after a `RETURNING` INSERT (or after a transaction block) to enforce a DB-contract invariant. `python -O` strips assertions, so the guard vanishes in any optimised build and the next line crashes with a confusing `TypeError: 'NoneType' object is not subscriptable` (or similar) instead of the intended structured error.
-- Prevention: In service code, every guard that enforces a DB-contract or post-commit invariant must be `if x is None: raise RuntimeError(...)` (or a typed exception), not `assert`. `assert` is acceptable only for in-test fixtures and developer-only invariants that are clearly not on a production code path. Grep `^\s*assert ` in `app/services/` during pre-flight review.
-- Enforced in: this prevention log
+- Prevention: In service code, every guard that enforces a DB-contract or post-commit invariant must be `if x is None: raise RuntimeError(...)` (or a typed exception), not `assert`. `assert` is acceptable only for in-test fixtures and developer-only invariants that are clearly not on a production code path. Grep `^\s*assert ` in `app/` (services AND api — a request-serving type-narrowing assert recurred in `app/api/theses.py`, PR #1997 review) during pre-flight review.
+- Enforced in: this prevention log; `.claude/skills/engineering/python-hygiene.md` ("Never use `assert` for a condition that must hold in production")
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { PeersPage } from "@/pages/PeersPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { TaxPage } from "@/pages/TaxPage";
 import { RecommendationsPage } from "@/pages/RecommendationsPage";
+import { ThesesPage } from "@/pages/ThesesPage";
 import { AdminPage } from "@/pages/AdminPage";
 import { AdminJobDetailPage } from "@/pages/AdminJobDetailPage";
 import { ProcessDetailPage } from "@/pages/ProcessDetailPage";
@@ -132,6 +133,7 @@ export function App() {
             element={<PeersPage />}
           />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
+          <Route path="theses" element={<ThesesPage />} />
           <Route path="recommendations" element={<RecommendationsPage />} />
           <Route path="reports" element={<ReportsPage />} />
           <Route path="tax" element={<TaxPage />} />

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -4,6 +4,7 @@ import type {
   GuardRejectionsResponse,
   PositionAlertsResponse,
   RankMovesResponse,
+  ThesisStalenessResponse,
 } from "@/api/types";
 
 /**
@@ -100,4 +101,12 @@ export function markRankMovesSeen(
 
 export function dismissAllRankMoves(): Promise<void> {
   return apiFetch<void>("/alerts/rank-moves/dismiss-all", { method: "POST" });
+}
+
+// --- #1902 thesis-staleness snapshot ----------------------------------------
+// Standing condition, no cursor endpoints — clears when the thesis
+// regenerates, not when acknowledged.
+
+export function fetchThesisStaleness(): Promise<ThesisStalenessResponse> {
+  return apiFetch<ThesisStalenessResponse>("/alerts/thesis-staleness");
 }

--- a/frontend/src/api/theses.ts
+++ b/frontend/src/api/theses.ts
@@ -3,7 +3,30 @@ import type {
   GenerateThesisResponse,
   ThesisDetail,
   ThesisHistoryResponse,
+  ThesisLibraryResponse,
 } from "@/api/types";
+
+// #1902 — GET /theses (latest thesis per instrument + display context)
+export interface ThesesLibraryParams {
+  heldOnly?: boolean;
+  stale?: boolean;
+  stance?: string;
+  offset?: number;
+  limit?: number;
+}
+
+export function fetchThesesLibrary(
+  params: ThesesLibraryParams = {},
+): Promise<ThesisLibraryResponse> {
+  const search = new URLSearchParams();
+  if (params.heldOnly) search.set("held_only", "true");
+  if (params.stale) search.set("stale", "true");
+  if (params.stance) search.set("stance", params.stance);
+  if (params.offset !== undefined) search.set("offset", String(params.offset));
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
+  const qs = search.toString();
+  return apiFetch<ThesisLibraryResponse>(`/theses${qs ? `?${qs}` : ""}`);
+}
 
 export function fetchLatestThesis(
   instrumentId: number,
@@ -29,9 +52,12 @@ export function fetchThesisHistory(
 
 export function generateInstrumentThesis(
   symbol: string,
+  force = false,
 ): Promise<GenerateThesisResponse> {
+  // force=true (#1919) bypasses the 24h cache — used by the library's
+  // per-row "request fresh" action (#1902).
   return apiFetch<GenerateThesisResponse>(
-    `/instruments/${encodeURIComponent(symbol)}/thesis`,
+    `/instruments/${encodeURIComponent(symbol)}/thesis${force ? "?force=true" : ""}`,
     { method: "POST" },
   );
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1255,19 +1255,21 @@ export interface ThesisHistoryResponse {
   limit: number;
 }
 
-// #1902 — GET /theses (library: latest thesis per instrument + context)
+// #1902 — GET /theses (library: latest thesis per instrument + context).
+// Thesis fields are null on the "held but no thesis yet" rows the library
+// prepends so the dashboard staleness alert always lands on visible rows.
 export interface ThesisLibraryItem {
   instrument_id: number;
   symbol: string;
   company_name: string;
-  thesis_id: number;
-  thesis_version: number;
-  thesis_type: string;
-  stance: string;
+  thesis_id: number | null;
+  thesis_version: number | null;
+  thesis_type: string | null;
+  stance: string | null;
   confidence_score: number | null;
   buy_zone_low: number | null;
   buy_zone_high: number | null;
-  created_at: string;
+  created_at: string | null;
   critic_verdict: string | null;
   /** null = fresh, or outside refresh scope (not tradable / not analysable). */
   stale_reason: string | null;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1241,11 +1241,47 @@ export interface ThesisDetail {
   memo_markdown: string;
   critic_json: Record<string, unknown> | null;
   created_at: string;
+  /** Server-computed staleness (#1902 single source: find_stale_instruments).
+   *  Populated only on the latest-thesis GET; null on history/POST payloads. */
+  is_stale?: boolean | null;
+  stale_reason?: string | null;
 }
 
 export interface ThesisHistoryResponse {
   instrument_id: number;
   items: ThesisDetail[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+// #1902 — GET /theses (library: latest thesis per instrument + context)
+export interface ThesisLibraryItem {
+  instrument_id: number;
+  symbol: string;
+  company_name: string;
+  thesis_id: number;
+  thesis_version: number;
+  thesis_type: string;
+  stance: string;
+  confidence_score: number | null;
+  buy_zone_low: number | null;
+  buy_zone_high: number | null;
+  created_at: string;
+  critic_verdict: string | null;
+  /** null = fresh, or outside refresh scope (not tradable / not analysable). */
+  stale_reason: string | null;
+  is_held: boolean;
+  latest_score: number | null;
+  latest_rank: number | null;
+  run_status: string | null; // 'running' | 'ok' | 'failed' (DB CHECK) | null pre-#1919
+  run_error: string | null;
+  run_trigger: string | null;
+  run_started_at: string | null;
+}
+
+export interface ThesisLibraryResponse {
+  items: ThesisLibraryItem[];
   total: number;
   offset: number;
   limit: number;
@@ -1772,6 +1808,23 @@ export interface RankMovesResponse {
   alerts_last_seen_rank_event_id: number | null;
   unseen_count: number;
   moves: RankMove[];
+}
+
+// ---------------------------------------------------------------------------
+// #1902 thesis-staleness snapshot (app/api/alerts.py)
+// ---------------------------------------------------------------------------
+
+/** Standing-condition snapshot — no cursor/seen semantics. The card clears
+ *  when the thesis regenerates, not when the operator acknowledges it. */
+export interface ThesisStalenessItem {
+  instrument_id: number;
+  symbol: string;
+  reason: string; // find_stale_instruments StaleReason (open string)
+  latest_thesis_at: string | null; // null = held instrument has no thesis at all
+}
+
+export interface ThesisStalenessResponse {
+  items: ThesisStalenessItem[];
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -13,6 +13,7 @@ import type {
   PositionAlertsResponse,
   RankMove,
   RankMovesResponse,
+  ThesisStalenessResponse,
 } from "@/api/types";
 
 vi.mock("@/api/alerts", () => ({
@@ -28,6 +29,7 @@ vi.mock("@/api/alerts", () => ({
   fetchRankMoves: vi.fn(),
   markRankMovesSeen: vi.fn(),
   dismissAllRankMoves: vi.fn(),
+  fetchThesisStaleness: vi.fn(),
 }));
 
 import * as alertsApi from "@/api/alerts";
@@ -36,6 +38,7 @@ const mockedGuardFetch = vi.mocked(alertsApi.fetchGuardRejections);
 const mockedPositionFetch = vi.mocked(alertsApi.fetchPositionAlerts);
 const mockedCoverageFetch = vi.mocked(alertsApi.fetchCoverageStatusDrops);
 const mockedRankFetch = vi.mocked(alertsApi.fetchRankMoves);
+const mockedThesisStaleFetch = vi.mocked(alertsApi.fetchThesisStaleness);
 
 const mockedMarkGuard = vi.mocked(alertsApi.markAlertsSeen);
 const mockedMarkPosition = vi.mocked(alertsApi.markPositionAlertsSeen);
@@ -67,6 +70,9 @@ const EMPTY_RANK: RankMovesResponse = {
   unseen_count: 0,
   moves: [],
 };
+const EMPTY_THESIS_STALE: ThesisStalenessResponse = {
+  items: [],
+};
 
 function stubAll(
   overrides: {
@@ -74,6 +80,7 @@ function stubAll(
     position?: Partial<PositionAlertsResponse> | Error;
     coverage?: Partial<CoverageStatusDropsResponse> | Error;
     rank?: Partial<RankMovesResponse> | Error;
+    thesisStale?: Partial<ThesisStalenessResponse> | Error;
   } = {},
 ) {
   if (overrides.guard instanceof Error) {
@@ -95,6 +102,14 @@ function stubAll(
     mockedRankFetch.mockRejectedValue(overrides.rank);
   } else {
     mockedRankFetch.mockResolvedValue({ ...EMPTY_RANK, ...overrides.rank });
+  }
+  if (overrides.thesisStale instanceof Error) {
+    mockedThesisStaleFetch.mockRejectedValue(overrides.thesisStale);
+  } else {
+    mockedThesisStaleFetch.mockResolvedValue({
+      ...EMPTY_THESIS_STALE,
+      ...overrides.thesisStale,
+    });
   }
 }
 
@@ -158,10 +173,11 @@ function renderStrip() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // Default the rank feed empty so tests that stub the other three feeds
-  // individually (not via stubAll) don't hit an unmocked fetch. Tests that
-  // exercise rank moves override this.
+  // Default the rank + thesis-staleness feeds empty so tests that stub the
+  // other three feeds individually (not via stubAll) don't hit an unmocked
+  // fetch. Tests that exercise those feeds override this.
   mockedRankFetch.mockResolvedValue(EMPTY_RANK);
+  mockedThesisStaleFetch.mockResolvedValue(EMPTY_THESIS_STALE);
 });
 
 // ---------------------------------------------------------------------------
@@ -681,5 +697,45 @@ describe("AlertsStrip — Dismiss all", () => {
     expect(errSpy).toHaveBeenCalled();
     confirmSpy.mockRestore();
     errSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1902 thesis-staleness card (standing condition, no cursor)
+// ---------------------------------------------------------------------------
+
+describe("AlertsStrip — thesis staleness", () => {
+  it("renders one grouped card with count + symbols, linking to the library", async () => {
+    stubAll({
+      thesisStale: {
+        items: [
+          { instrument_id: 1, symbol: "GME", reason: "stale", latest_thesis_at: "2026-06-01T00:00:00Z" },
+          { instrument_id: 2, symbol: "AAPL", reason: "event_new_10k", latest_thesis_at: "2026-06-02T00:00:00Z" },
+        ],
+      },
+    });
+    renderStrip();
+    expect(
+      await screen.findByText("2 held instruments have a stale thesis"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/AAPL, GME/)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /Review in Theses/i });
+    expect(link).toHaveAttribute("href", "/theses?held=true&stale=true");
+    // Standing condition: never counted as unseen — no "new" pill.
+    expect(screen.queryByText(/new$/)).not.toBeInTheDocument();
+  });
+
+  it("does not participate in the unseen count or mark-all-read", async () => {
+    stubAll({
+      guard: { rejections: [makeGuard()], unseen_count: 1 },
+      thesisStale: {
+        items: [
+          { instrument_id: 1, symbol: "GME", reason: "stale", latest_thesis_at: null },
+        ],
+      },
+    });
+    renderStrip();
+    // Pill counts only the cursor feeds (guard's 1), not the stale thesis.
+    expect(await screen.findByText("1 new")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -29,6 +29,7 @@ import {
   fetchGuardRejections,
   fetchPositionAlerts,
   fetchRankMoves,
+  fetchThesisStaleness,
   markAlertsSeen,
   markCoverageStatusDropsSeen,
   markPositionAlertsSeen,
@@ -40,6 +41,7 @@ import type {
   PositionAlert,
   PositionAlertsResponse,
   RankMovesResponse,
+  ThesisStalenessResponse,
 } from "@/api/types";
 import { formatRelativeTime } from "@/lib/format";
 
@@ -50,6 +52,7 @@ import {
   type GuardGroupItem,
   type CoverageGroupItem,
   type RankMoveItem,
+  type ThesisStaleItem,
   type Tier,
 } from "./alertModel";
 
@@ -275,6 +278,30 @@ function RankMoveCard({ item }: { item: RankMoveItem }) {
   );
 }
 
+function ThesisStaleCard({ item }: { item: ThesisStaleItem }) {
+  // Standing condition (#1902): no unseen highlight, no dismiss — the card
+  // clears when the theses regenerate. Links to the pre-filtered library.
+  const noun = item.count === 1 ? "instrument has" : "instruments have";
+  return (
+    <CardShell tier={item.tier} unseen={false} label="THESIS">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="font-semibold text-slate-800 dark:text-slate-100">
+          {item.count} held {noun} a stale thesis
+        </span>
+        <SymbolSummary symbols={item.symbols} count={item.count} />
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        <Link
+          to="/theses?held=true&stale=true"
+          className="text-xs font-medium text-sky-600 dark:text-sky-400 underline hover:text-sky-800 dark:hover:text-sky-300"
+        >
+          Review in Theses
+        </Link>
+      </div>
+    </CardShell>
+  );
+}
+
 function ItemView({ item }: { item: AlertItem }) {
   switch (item.kind) {
     case "guardGroup":
@@ -285,6 +312,8 @@ function ItemView({ item }: { item: AlertItem }) {
       return <CoverageGroupCard item={item} />;
     case "rankMove":
       return <RankMoveCard item={item} />;
+    case "thesisStale":
+      return <ThesisStaleCard item={item} />;
   }
 }
 
@@ -301,6 +330,11 @@ export function AlertsStrip(): JSX.Element | null {
   const [rank, setRank] = useState<FeedState<RankMovesResponse>>({
     status: "loading",
   });
+  const [thesisStale, setThesisStale] = useState<
+    FeedState<ThesisStalenessResponse>
+  >({
+    status: "loading",
+  });
   const [refetchKey, setRefetchKey] = useState(0);
 
   useEffect(() => {
@@ -309,6 +343,7 @@ export function AlertsStrip(): JSX.Element | null {
     setPosition({ status: "loading" });
     setCoverage({ status: "loading" });
     setRank({ status: "loading" });
+    setThesisStale({ status: "loading" });
 
     fetchGuardRejections()
       .then((d) => {
@@ -350,6 +385,16 @@ export function AlertsStrip(): JSX.Element | null {
           setRank({ status: "err" });
         }
       });
+    fetchThesisStaleness()
+      .then((d) => {
+        if (!cancelled) setThesisStale({ status: "ok", data: d });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AlertsStrip] fetchThesisStaleness failed", err);
+          setThesisStale({ status: "err" });
+        }
+      });
 
     return () => {
       cancelled = true;
@@ -362,7 +407,8 @@ export function AlertsStrip(): JSX.Element | null {
     guard.status === "loading" ||
     position.status === "loading" ||
     coverage.status === "loading" ||
-    rank.status === "loading"
+    rank.status === "loading" ||
+    thesisStale.status === "loading"
   ) {
     return null;
   }
@@ -370,7 +416,8 @@ export function AlertsStrip(): JSX.Element | null {
     guard.status === "err" &&
     position.status === "err" &&
     coverage.status === "err" &&
-    rank.status === "err"
+    rank.status === "err" &&
+    thesisStale.status === "err"
   ) {
     return null;
   }
@@ -381,6 +428,10 @@ export function AlertsStrip(): JSX.Element | null {
   const positionAlerts = position.status === "ok" ? position.data.alerts : [];
   const drops = coverage.status === "ok" ? coverage.data.drops : [];
   const moves = rank.status === "ok" ? rank.data.moves : [];
+  // Standing-condition snapshot (#1902): no cursor, so it participates in
+  // the grouped body only — never in unseen/overflow/dismiss accounting.
+  const staleTheses =
+    thesisStale.status === "ok" ? thesisStale.data.items : [];
 
   const cursors: Cursors = {
     guard: guard.status === "ok" ? guard.data.alerts_last_seen_decision_id : null,
@@ -395,7 +446,14 @@ export function AlertsStrip(): JSX.Element | null {
     rank: rank.status === "ok" ? rank.data.alerts_last_seen_rank_event_id : null,
   };
 
-  const items = buildAlertModel(rejections, positionAlerts, drops, moves, cursors);
+  const items = buildAlertModel(
+    rejections,
+    positionAlerts,
+    drops,
+    moves,
+    cursors,
+    staleTheses,
+  );
 
   if (items.length === 0) {
     return null;

--- a/frontend/src/components/dashboard/alertModel.ts
+++ b/frontend/src/components/dashboard/alertModel.ts
@@ -21,6 +21,7 @@ import type {
   GuardRejection,
   PositionAlert,
   RankMove,
+  ThesisStalenessItem,
 } from "@/api/types";
 
 export type Tier = "actionable" | "informational" | "housekeeping";
@@ -228,11 +229,28 @@ export interface RankMoveItem {
   unseen: boolean;
 }
 
+/**
+ * Thesis-staleness (#1902) — ONE grouped card for all held instruments whose
+ * thesis is stale. Standing condition, not an event: there is no cursor, no
+ * unseen highlight and no dismiss — the card clears when theses regenerate
+ * (thesis_refresh drains at ≤5/hour, or per-row force from /theses).
+ */
+export interface ThesisStaleItem {
+  kind: "thesisStale";
+  tier: Tier;
+  id: string;
+  symbols: string[];
+  count: number;
+  sortKey: number;
+  unseen: boolean; // always false — excluded from unseen/dismiss accounting
+}
+
 export type AlertItem =
   | GuardGroupItem
   | PositionItem
   | CoverageGroupItem
-  | RankMoveItem;
+  | RankMoveItem
+  | ThesisStaleItem;
 
 function uniqueSorted(values: (string | null)[]): string[] {
   return Array.from(new Set(values.filter((v): v is string => !!v))).sort();
@@ -248,6 +266,7 @@ export function buildAlertModel(
   drops: CoverageStatusDrop[],
   moves: RankMove[],
   cursors: Cursors,
+  staleTheses: ThesisStalenessItem[] = [],
 ): AlertItem[] {
   const items: AlertItem[] = [];
 
@@ -348,6 +367,22 @@ export function buildAlertModel(
       sortKey: Date.parse(latest.scored_at),
       maxId,
       unseen: cursors.rank === null || maxId > cursors.rank,
+    });
+  }
+
+  // Thesis staleness (#1902) → ONE card for all stale held instruments
+  // (informational tier — research hygiene, not an immediate trade action).
+  // sortKey 0: with no event timestamp of its own, a standing condition
+  // sorts below fresh events within its tier rather than pinning to top.
+  if (staleTheses.length > 0) {
+    items.push({
+      kind: "thesisStale",
+      tier: "informational",
+      id: "thesisStale",
+      symbols: uniqueSorted(staleTheses.map((t) => t.symbol)),
+      count: staleTheses.length,
+      sortKey: 0,
+      unseen: false,
     });
   }
 

--- a/frontend/src/components/instrument/SummaryStrip.test.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.test.tsx
@@ -92,13 +92,22 @@ function freshThesis(): ThesisDetail {
     memo_markdown: "Fresh thesis memo.",
     critic_json: null,
     created_at: now.toISOString(),
+    is_stale: false,
+    stale_reason: null,
   };
 }
 
 function staleThesis(): ThesisDetail {
+  // Staleness single-source (#1902): the server verdict drives the strip;
+  // created_at is display-only. An old date alone must NOT read as stale.
   const old = new Date();
   old.setDate(old.getDate() - 45);
-  return { ...freshThesis(), created_at: old.toISOString() };
+  return {
+    ...freshThesis(),
+    created_at: old.toISOString(),
+    is_stale: true,
+    stale_reason: "stale",
+  };
 }
 
 function heldPosition(): InstrumentPositionDetail {
@@ -412,7 +421,7 @@ describe("SummaryStrip — action gating", () => {
     expect(screen.getByTestId("thesis-badge-missing")).toBeInTheDocument();
   });
 
-  it("shows Generate thesis + (stale) marker when thesis is > 30d old", () => {
+  it("shows Generate thesis + (stale) marker when the server marks the thesis stale", () => {
     render(
       <SummaryStrip
         summary={summary()}
@@ -423,6 +432,21 @@ describe("SummaryStrip — action gating", () => {
     );
     expect(screen.getByTestId("action-generate-thesis")).toBeInTheDocument();
     expect(screen.getByTestId("thesis-badge").textContent).toContain("stale");
+  });
+
+  it("does NOT mark an old thesis stale unless the server says so (#1902 single source)", () => {
+    const old = new Date();
+    old.setDate(old.getDate() - 45);
+    render(
+      <SummaryStrip
+        summary={summary()}
+        thesis={{ ...freshThesis(), created_at: old.toISOString() }}
+        position={null}
+        {...noopProps()}
+      />,
+    );
+    expect(screen.getByTestId("thesis-badge").textContent).not.toContain("stale");
+    expect(screen.queryByTestId("action-generate-thesis")).not.toBeInTheDocument();
   });
 
   it("labels the action Buy when unheld and Add when held (#316)", () => {

--- a/frontend/src/components/instrument/SummaryStrip.tsx
+++ b/frontend/src/components/instrument/SummaryStrip.tsx
@@ -29,8 +29,6 @@ import {
   useLiveQuote,
 } from "@/lib/useLiveQuote";
 
-const THESIS_STALE_DAYS = 30;
-
 function formatPrice(
   value: string | null | undefined,
   currency: string | null | undefined,
@@ -71,12 +69,14 @@ function formatPct(value: string | null | undefined, signed = false): string {
   return `${sign}${pct}%`;
 }
 
+// Staleness single-source (#1902): the latest-thesis GET carries the
+// server verdict (`is_stale` via find_stale_instruments — coverage
+// cadence + filing-event triggers). The FE never re-derives it from a
+// local day constant; a missing thesis is trivially stale (nothing to
+// act on), which is an existence check, not a threshold.
 function isThesisStale(thesis: ThesisDetail | null): boolean {
   if (thesis === null) return true;
-  const created = new Date(thesis.created_at);
-  if (Number.isNaN(created.getTime())) return true;
-  const ageDays = (Date.now() - created.getTime()) / (1000 * 60 * 60 * 24);
-  return ageDays > THESIS_STALE_DAYS;
+  return thesis.is_stale === true;
 }
 
 function thesisTone(stance: string): string {

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -33,4 +33,42 @@ describe("ThesisPane", () => {
     render(<ThesisPane thesis={null} errored={true} />);
     expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
   });
+
+  it("renders the buy zone alongside bear/base/bull (#1902)", () => {
+    const thesis = {
+      ...FIXTURE,
+      buy_zone_low: 15,
+      buy_zone_high: 18,
+    } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.getByText("Buy zone")).toBeInTheDocument();
+    expect(screen.getByText("15 – 18")).toBeInTheDocument();
+  });
+
+  it("renders the critic verdict, summary and key risks (#1902)", () => {
+    const thesis = {
+      ...FIXTURE,
+      critic_json: {
+        verdict: "Strong challenge",
+        summary: "Margins are cyclical, not structural.",
+        key_risks: ["Customer concentration", "Refinancing wall in 2027"],
+      },
+    } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.getByText("Critic")).toBeInTheDocument();
+    expect(screen.getByText("Strong challenge")).toBeInTheDocument();
+    expect(
+      screen.getByText("Margins are cyclical, not structural."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Customer concentration")).toBeInTheDocument();
+  });
+
+  it("says 'no critic' when critic_json exists without a verdict", () => {
+    const thesis = {
+      ...FIXTURE,
+      critic_json: { summary: "partial payload" },
+    } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.getByText("no critic")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -1,4 +1,5 @@
 import { Pane } from "@/components/instrument/Pane";
+import { CriticVerdictBadge } from "@/components/theses/CriticVerdictBadge";
 import { EmptyState } from "@/components/states/EmptyState";
 import type { ThesisDetail } from "@/api/types";
 
@@ -27,8 +28,26 @@ export function ThesisPane({
   );
 }
 
+/** Safe string extraction from the open critic_json payload. */
+function criticString(critic: Record<string, unknown>, key: string): string | null {
+  const v = critic[key];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+/** Safe string-array extraction from the open critic_json payload. */
+function criticList(critic: Record<string, unknown>, key: string): string[] {
+  const v = critic[key];
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string");
+}
+
 function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
   const breaks = thesis.break_conditions_json ?? [];
+  const critic = thesis.critic_json;
+  const criticSummary = critic ? criticString(critic, "summary") : null;
+  const criticRisks = critic ? criticList(critic, "key_risks") : [];
+  const hasBuyZone =
+    thesis.buy_zone_low !== null || thesis.buy_zone_high !== null;
   return (
     <div className="space-y-3 text-sm">
       <div className="max-w-prose whitespace-pre-wrap text-slate-700">
@@ -36,8 +55,9 @@ function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
       </div>
       {(thesis.base_value !== null ||
         thesis.bull_value !== null ||
-        thesis.bear_value !== null) && (
-        <dl className="grid grid-cols-3 gap-2 rounded bg-slate-50 dark:bg-slate-900/40 p-3 text-xs">
+        thesis.bear_value !== null ||
+        hasBuyZone) && (
+        <dl className="grid grid-cols-4 gap-2 rounded bg-slate-50 dark:bg-slate-900/40 p-3 text-xs">
           <div>
             <dt className="text-slate-500">Bear</dt>
             <dd className="font-medium tabular-nums">
@@ -56,6 +76,14 @@ function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
               {thesis.bull_value !== null ? thesis.bull_value : "—"}
             </dd>
           </div>
+          <div>
+            <dt className="text-slate-500">Buy zone</dt>
+            <dd className="font-medium tabular-nums">
+              {hasBuyZone
+                ? `${thesis.buy_zone_low ?? "—"} – ${thesis.buy_zone_high ?? "—"}`
+                : "—"}
+            </dd>
+          </div>
         </dl>
       )}
       {breaks.length > 0 && (
@@ -68,6 +96,30 @@ function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
               <li key={i}>{b}</li>
             ))}
           </ul>
+        </div>
+      )}
+      {critic !== null && critic !== undefined && (
+        <div className="rounded border border-slate-200 dark:border-slate-800 p-3">
+          <div className="mb-1 flex items-center gap-2">
+            <span className="text-xs font-medium uppercase tracking-wider text-slate-500">
+              Critic
+            </span>
+            <CriticVerdictBadge
+              verdict={criticString(critic, "verdict")}
+            />
+          </div>
+          {criticSummary !== null && (
+            <p className="max-w-prose text-xs text-slate-600 dark:text-slate-300">
+              {criticSummary}
+            </p>
+          )}
+          {criticRisks.length > 0 && (
+            <ul className="mt-1 list-inside list-disc space-y-0.5 text-xs text-slate-600 dark:text-slate-400">
+              {criticRisks.map((r, i) => (
+                <li key={i}>{r}</li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/instrument/VerdictTab.test.tsx
+++ b/frontend/src/components/instrument/VerdictTab.test.tsx
@@ -132,7 +132,9 @@ describe("VerdictTab", () => {
     );
     // headline
     expect(await screen.findByText("0.82")).toBeInTheDocument();
-    expect(screen.getByText(/buy/i)).toBeInTheDocument();
+    // Exact match: the ThesisPane now also renders a "Buy zone" label
+    // (#1902), so a loose /buy/i regex would double-match.
+    expect(screen.getByText("buy")).toBeInTheDocument();
     expect(screen.getByText(/rank #5/)).toBeInTheDocument();
     // Piotroski 7/9 strong + Altman safe
     expect(screen.getByText("7")).toBeInTheDocument();

--- a/frontend/src/components/theses/CriticVerdictBadge.tsx
+++ b/frontend/src/components/theses/CriticVerdictBadge.tsx
@@ -1,0 +1,46 @@
+/**
+ * CriticVerdictBadge — pill for the adversarial critic's verdict (#1902).
+ *
+ * Verdict vocabulary is written by app/services/thesis.py::_validate_critic_output
+ * ("Strong challenge" | "Moderate challenge" | "Weak challenge"). Colour
+ * semantics follow the operator convention (red = risk): a STRONG challenge
+ * means the critic found a strong case AGAINST the thesis, so it renders red;
+ * a weak challenge means the thesis survived scrutiny → emerald. Unknown /
+ * legacy strings fall back to slate rather than being hidden (#1808 class —
+ * the column is open text; never let an unexpected value blank the cell).
+ */
+
+const TONE: Record<string, string> = {
+  "Strong challenge":
+    "bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 border-red-300 dark:border-red-700",
+  "Moderate challenge":
+    "bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-700",
+  "Weak challenge":
+    "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700",
+};
+
+const FALLBACK_TONE =
+  "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-700";
+
+export function CriticVerdictBadge({
+  verdict,
+}: {
+  readonly verdict: string | null;
+}): JSX.Element {
+  if (verdict === null) {
+    // Stored-without-critic is a legitimate state (critic is best-effort,
+    // e.g. length-failure on a large context) — say so instead of blank.
+    return (
+      <span className="text-xs text-slate-400 dark:text-slate-500">
+        no critic
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-medium ${TONE[verdict] ?? FALLBACK_TONE}`}
+    >
+      {verdict}
+    </span>
+  );
+}

--- a/frontend/src/components/theses/StanceBadge.tsx
+++ b/frontend/src/components/theses/StanceBadge.tsx
@@ -1,0 +1,34 @@
+/**
+ * StanceBadge — pill for the thesis stance enum (#1902).
+ *
+ * Vocabulary is the settled thesis-semantics set (docs/settled-decisions.md):
+ * buy | hold | watch | avoid. Colour follows the operator convention:
+ * buy → emerald, hold → slate, watch → amber (attention, not action),
+ * avoid → red. Unknown strings fall back to slate rather than hiding.
+ */
+
+const TONE: Record<string, string> = {
+  buy: "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700",
+  hold: "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-700",
+  watch:
+    "bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-700",
+  avoid:
+    "bg-red-50 dark:bg-red-950/40 text-red-700 dark:text-red-300 border-red-300 dark:border-red-700",
+};
+
+const FALLBACK =
+  "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-700";
+
+export function StanceBadge({
+  stance,
+}: {
+  readonly stance: string;
+}): JSX.Element {
+  return (
+    <span
+      className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-medium uppercase ${TONE[stance.toLowerCase()] ?? FALLBACK}`}
+    >
+      {stance}
+    </span>
+  );
+}

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ const NAV_ITEMS: { to: string; label: string; end?: boolean }[] = [
   { to: "/calendar", label: "Calendar" },
   { to: "/instruments", label: "Instruments" },
   { to: "/rankings", label: "Rankings" },
+  { to: "/theses", label: "Theses" },
   { to: "/recommendations", label: "Recommendations" },
   { to: "/reports", label: "Reports" },
   { to: "/tax", label: "Tax" },

--- a/frontend/src/pages/ThesesPage.test.tsx
+++ b/frontend/src/pages/ThesesPage.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { ThesesPage } from "@/pages/ThesesPage";
+import type { ThesisLibraryItem, ThesisLibraryResponse } from "@/api/types";
+
+vi.mock("@/api/theses", () => ({
+  fetchThesesLibrary: vi.fn(),
+  generateInstrumentThesis: vi.fn(),
+}));
+
+import * as thesesApi from "@/api/theses";
+
+const mockedFetch = vi.mocked(thesesApi.fetchThesesLibrary);
+const mockedGenerate = vi.mocked(thesesApi.generateInstrumentThesis);
+
+function makeItem(overrides: Partial<ThesisLibraryItem> = {}): ThesisLibraryItem {
+  return {
+    instrument_id: 42,
+    symbol: "AAPL",
+    company_name: "Apple Inc.",
+    thesis_id: 1,
+    thesis_version: 2,
+    thesis_type: "compounder",
+    stance: "buy",
+    confidence_score: 0.9,
+    buy_zone_low: 180,
+    buy_zone_high: 210,
+    created_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    critic_verdict: "Weak challenge",
+    stale_reason: null,
+    is_held: true,
+    latest_score: 0.61,
+    latest_rank: 7,
+    run_status: "ok",
+    run_error: null,
+    run_trigger: "manual",
+    run_started_at: null,
+    ...overrides,
+  };
+}
+
+function respond(items: ThesisLibraryItem[], total = items.length): ThesisLibraryResponse {
+  return { items, total, offset: 0, limit: 50 };
+}
+
+function renderPage(initialEntry = "/theses") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <ThesesPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedGenerate.mockResolvedValue({
+    cached: false,
+    thesis: {} as never,
+  });
+});
+
+describe("ThesesPage", () => {
+  it("renders library rows with stance, critic verdict, held pill and score", async () => {
+    mockedFetch.mockResolvedValue(
+      respond([
+        makeItem(),
+        makeItem({
+          instrument_id: 43,
+          symbol: "GME",
+          company_name: "GameStop",
+          stance: "watch",
+          critic_verdict: null,
+          is_held: false,
+          stale_reason: "event_new_10k",
+          run_status: "failed",
+          run_error: "writer schema error",
+          latest_score: null,
+          latest_rank: null,
+        }),
+      ]),
+    );
+    renderPage();
+
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
+    expect(screen.getByText("Weak challenge")).toBeInTheDocument();
+    expect(screen.getByText("held")).toBeInTheDocument();
+    expect(screen.getByText("#7")).toBeInTheDocument();
+    // Second row: no critic, stale from a new filing, failed run.
+    expect(screen.getByText("no critic")).toBeInTheDocument();
+    expect(screen.getByText("new 10-K")).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    // Symbol links to the instrument's Verdict tab.
+    expect(screen.getByRole("link", { name: "AAPL" })).toHaveAttribute(
+      "href",
+      "/instrument/AAPL?tab=verdict",
+    );
+  });
+
+  it("shows the guiding empty state when no theses exist", async () => {
+    mockedFetch.mockResolvedValue(respond([]));
+    renderPage();
+    expect(await screen.findByText("No theses")).toBeInTheDocument();
+    expect(screen.getByText(/thesis_refresh/)).toBeInTheDocument();
+  });
+
+  it("reads filters from the URL and passes them to the API", async () => {
+    mockedFetch.mockResolvedValue(respond([]));
+    renderPage("/theses?held=true&stale=true&stance=buy");
+    await screen.findByText("No theses match these filters.");
+    expect(mockedFetch).toHaveBeenCalledWith({
+      heldOnly: true,
+      stale: true,
+      stance: "buy",
+      offset: 0,
+      limit: 50,
+    });
+  });
+
+  it("fires a forced regeneration from the per-row Refresh button", async () => {
+    mockedFetch.mockResolvedValue(respond([makeItem()]));
+    renderPage();
+    const btn = await screen.findByRole("button", { name: "Refresh" });
+    await userEvent.click(btn);
+    expect(mockedGenerate).toHaveBeenCalledWith("AAPL", true);
+  });
+
+  it("disables the row action while a run is in flight", async () => {
+    mockedFetch.mockResolvedValue(
+      respond([makeItem({ run_status: "running" })]),
+    );
+    renderPage();
+    const btn = await screen.findByRole("button", { name: "Generating…" });
+    expect(btn).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/ThesesPage.test.tsx
+++ b/frontend/src/pages/ThesesPage.test.tsx
@@ -128,6 +128,20 @@ describe("ThesesPage", () => {
     expect(mockedGenerate).toHaveBeenCalledWith("AAPL", true);
   });
 
+  it("shows a fixed-phrase notice when the regeneration request fails", async () => {
+    mockedFetch.mockResolvedValue(respond([makeItem()]));
+    mockedGenerate.mockRejectedValue(new Error("boom"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    renderPage();
+    await userEvent.click(await screen.findByRole("button", { name: "Refresh" }));
+    expect(
+      await screen.findByText(/Generation request for AAPL failed/),
+    ).toBeInTheDocument();
+    // Fixed phrase only — never exception text in the DOM.
+    expect(screen.queryByText(/boom/)).not.toBeInTheDocument();
+    errSpy.mockRestore();
+  });
+
   it("disables the row action while a run is in flight", async () => {
     mockedFetch.mockResolvedValue(
       respond([makeItem({ run_status: "running" })]),

--- a/frontend/src/pages/ThesesPage.test.tsx
+++ b/frontend/src/pages/ThesesPage.test.tsx
@@ -136,4 +136,43 @@ describe("ThesesPage", () => {
     const btn = await screen.findByRole("button", { name: "Generating…" });
     expect(btn).toBeDisabled();
   });
+
+  it("renders a held-no-thesis gap row with a Generate action", async () => {
+    mockedFetch.mockResolvedValue(
+      respond([
+        makeItem({
+          thesis_id: null,
+          thesis_version: null,
+          thesis_type: null,
+          stance: null,
+          confidence_score: null,
+          buy_zone_low: null,
+          buy_zone_high: null,
+          created_at: null,
+          critic_verdict: null,
+          stale_reason: "no_thesis",
+          latest_score: null,
+          latest_rank: null,
+          run_status: null,
+        }),
+      ]),
+    );
+    renderPage();
+    expect(await screen.findByText("no thesis yet")).toBeInTheDocument();
+    expect(screen.getByText("missing")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Generate" })).toBeEnabled();
+  });
+
+  it("clamps an out-of-range offset back to page one instead of stranding an empty state", async () => {
+    // offset=9999 with total=1: server returns an empty page — the page
+    // must reset offset and refetch rather than show a dead empty state.
+    mockedFetch
+      .mockResolvedValueOnce({ items: [], total: 1, offset: 9999, limit: 50 })
+      .mockResolvedValue(respond([makeItem()]));
+    renderPage("/theses?offset=9999");
+    expect(await screen.findByText("AAPL")).toBeInTheDocument();
+    expect(mockedFetch).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 0 }),
+    );
+  });
 });

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -72,6 +72,7 @@ function staleLabel(reason: string): string {
     return `new ${reason.slice("event_new_".length).replace("10k", "10-K").replace("10q", "10-Q").replace("8k", "8-K")}`;
   }
   if (reason === "missing_frequency") return "no cadence";
+  if (reason === "no_thesis") return "missing";
   return "stale";
 }
 
@@ -146,6 +147,27 @@ export function ThesesPage(): JSX.Element {
     const t = setInterval(() => refetch(), POLL_MS);
     return () => clearInterval(t);
   }, [anyRunning, refetch]);
+
+  // A stale deep-link (?offset beyond the filtered total) lands on an empty
+  // page whose controls live in the table branch — clamp back to page one
+  // instead of stranding the operator on a misleading empty state (Codex
+  // ckpt-2). setSearchParams is stable; data settles before this fires.
+  const emptyBeyondTotal =
+    state.data !== null &&
+    state.data.items.length === 0 &&
+    state.data.total > 0 &&
+    filters.offset > 0;
+  useEffect(() => {
+    if (!emptyBeyondTotal) return;
+    setSearchParams(
+      (prev) => {
+        const out = new URLSearchParams(prev);
+        out.delete("offset");
+        return out;
+      },
+      { replace: true },
+    );
+  }, [emptyBeyondTotal, setSearchParams]);
 
   function setFilters(next: Partial<LibraryFilters>): void {
     // Any filter change resets pagination — offset only survives paging.
@@ -289,10 +311,16 @@ export function ThesesPage(): JSX.Element {
                         </div>
                       </td>
                       <td className="px-2 py-2">
-                        <StanceBadge stance={row.stance} />
+                        {row.stance !== null ? (
+                          <StanceBadge stance={row.stance} />
+                        ) : (
+                          <span className="text-xs text-slate-400 dark:text-slate-500">
+                            —
+                          </span>
+                        )}
                       </td>
                       <td className="px-2 py-2 text-xs text-slate-600 dark:text-slate-300">
-                        {row.thesis_type}
+                        {row.thesis_type ?? "—"}
                       </td>
                       <td className="px-2 py-2 text-right tabular-nums">
                         {row.confidence_score !== null
@@ -319,10 +347,18 @@ export function ThesesPage(): JSX.Element {
                         )}
                       </td>
                       <td className="px-2 py-2">
-                        <CriticVerdictBadge verdict={row.critic_verdict} />
+                        {row.thesis_id !== null ? (
+                          <CriticVerdictBadge verdict={row.critic_verdict} />
+                        ) : (
+                          <span className="text-xs text-slate-400 dark:text-slate-500">
+                            —
+                          </span>
+                        )}
                       </td>
                       <td className="px-2 py-2 text-xs text-slate-600 dark:text-slate-300">
-                        {formatRelativeTime(row.created_at)}
+                        {row.created_at !== null
+                          ? formatRelativeTime(row.created_at)
+                          : "no thesis yet"}
                         {row.stale_reason !== null ? (
                           <span
                             title={`Stale: ${row.stale_reason}`}
@@ -349,7 +385,9 @@ export function ThesesPage(): JSX.Element {
                           {busyIds.has(row.instrument_id) ||
                           row.run_status === "running"
                             ? "Generating…"
-                            : "Refresh"}
+                            : row.thesis_id === null
+                              ? "Generate"
+                              : "Refresh"}
                         </button>
                       </td>
                     </tr>

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -1,0 +1,398 @@
+/**
+ * /theses — Theses library (#1902): the global surface for thesis reports.
+ *
+ * Latest thesis per instrument with stance / confidence / buy zone / critic
+ * verdict / staleness / held flag / latest score, plus the latest
+ * generation-run status from thesis_runs (#1919). Filter state lives in the
+ * URL query string (held / stale / stance / offset) so deep-links work —
+ * the dashboard AlertsStrip links straight to ?held=true&stale=true.
+ *
+ * Detail view = the instrument page's Verdict tab (existing rendering);
+ * this page deliberately adds no second memo renderer (and no markdown
+ * dependency — memo_markdown stays plain-text there, decision on #1902).
+ *
+ * Status column: server truth from thesis_runs. While any row is
+ * 'running' the page polls (POLL_MS) so completion/failure lands without
+ * a manual reload — the transient skeleton on each poll tick is the
+ * documented useAsync default (preserveOnRefetch would leak stale rows
+ * into filter changes after the first poll tick; see useAsync contract).
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+
+import { fetchThesesLibrary, generateInstrumentThesis } from "@/api/theses";
+import type { ThesisLibraryItem, ThesisLibraryResponse } from "@/api/types";
+import {
+  Section,
+  SectionError,
+  SectionSkeleton,
+} from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { CriticVerdictBadge } from "@/components/theses/CriticVerdictBadge";
+import { StanceBadge } from "@/components/theses/StanceBadge";
+import { formatNumber, formatRelativeTime } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+const PAGE_SIZE = 50;
+const POLL_MS = 20_000;
+
+const STANCES = ["buy", "hold", "watch", "avoid"] as const;
+
+interface LibraryFilters {
+  held: boolean;
+  stale: boolean;
+  stance: string;
+  offset: number;
+}
+
+function readFilters(p: URLSearchParams): LibraryFilters {
+  const stance = p.get("stance") ?? "";
+  const offset = Number(p.get("offset") ?? "0");
+  return {
+    held: p.get("held") === "true",
+    stale: p.get("stale") === "true",
+    stance: (STANCES as readonly string[]).includes(stance) ? stance : "",
+    offset: Number.isInteger(offset) && offset > 0 ? offset : 0,
+  };
+}
+
+function writeFilters(f: LibraryFilters): URLSearchParams {
+  const out = new URLSearchParams();
+  if (f.held) out.set("held", "true");
+  if (f.stale) out.set("stale", "true");
+  if (f.stance !== "") out.set("stance", f.stance);
+  if (f.offset > 0) out.set("offset", String(f.offset));
+  return out;
+}
+
+/** Human label for a find_stale_instruments reason code. */
+function staleLabel(reason: string): string {
+  if (reason.startsWith("event_new_")) {
+    return `new ${reason.slice("event_new_".length).replace("10k", "10-K").replace("10q", "10-Q").replace("8k", "8-K")}`;
+  }
+  if (reason === "missing_frequency") return "no cadence";
+  return "stale";
+}
+
+function RunStatusCell({ row }: { row: ThesisLibraryItem }) {
+  if (row.run_status === "running") {
+    return (
+      <span
+        className="inline-block rounded border border-blue-300 dark:border-blue-700 bg-blue-50 dark:bg-blue-950/40 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-300"
+        title={`trigger: ${row.run_trigger ?? "—"}, started ${formatRelativeTime(row.run_started_at)}`}
+      >
+        running
+      </span>
+    );
+  }
+  if (row.run_status === "failed") {
+    return (
+      <span
+        className="inline-block rounded border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-950/40 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:text-red-300"
+        title={row.run_error ?? "generation failed"}
+      >
+        failed
+      </span>
+    );
+  }
+  if (row.run_status === "ok") {
+    return (
+      <span className="text-xs text-slate-400 dark:text-slate-500">ok</span>
+    );
+  }
+  return <span className="text-xs text-slate-400 dark:text-slate-500">—</span>;
+}
+
+export function ThesesPage(): JSX.Element {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = readFilters(searchParams);
+
+  // useAsync captures fn via a ref — fresh arrow per render is fine.
+  const state = useAsync<ThesisLibraryResponse>(
+    () =>
+      fetchThesesLibrary({
+        heldOnly: filters.held,
+        stale: filters.stale,
+        stance: filters.stance || undefined,
+        offset: filters.offset,
+        limit: PAGE_SIZE,
+      }),
+    [filters.held, filters.stale, filters.stance, filters.offset],
+  );
+
+  // Per-row "request fresh" in-flight ids. Transient button state only —
+  // the durable status is the server's thesis_runs row (#1902 scope note:
+  // FE-local generation state dies on navigation, so nothing beyond the
+  // button disable relies on this).
+  const [busyIds, setBusyIds] = useState<ReadonlySet<number>>(new Set());
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refetch = state.refetch;
+
+  // Poll while any visible run is in-flight so completion/failure lands
+  // without a manual reload. Local generation takes minutes (qwen3:14b
+  // ~5-8 min/thesis) — 20s keeps the page honest without hammering.
+  const anyRunning =
+    state.data?.items.some((r) => r.run_status === "running") ?? false;
+  useEffect(() => {
+    if (!anyRunning) return;
+    const t = setInterval(() => refetch(), POLL_MS);
+    return () => clearInterval(t);
+  }, [anyRunning, refetch]);
+
+  function setFilters(next: Partial<LibraryFilters>): void {
+    // Any filter change resets pagination — offset only survives paging.
+    const merged: LibraryFilters = {
+      ...filters,
+      offset: 0,
+      ...next,
+    };
+    setSearchParams(writeFilters(merged), { replace: true });
+  }
+
+  async function onRequestFresh(row: ThesisLibraryItem): Promise<void> {
+    setBusyIds((prev) => new Set(prev).add(row.instrument_id));
+    // Surface the server's 'running' row shortly after firing — the POST
+    // itself only resolves when generation completes (minutes on a local
+    // model), and the poll loop only starts once a running row is visible.
+    setTimeout(() => {
+      if (mountedRef.current) refetch();
+    }, 1_500);
+    try {
+      await generateInstrumentThesis(row.symbol, true);
+    } catch (err) {
+      // Failure detail lands in the row's status column via thesis_runs;
+      // log the transport error for the console trail.
+      console.error("[ThesesPage] force generation failed", err);
+    } finally {
+      if (mountedRef.current) {
+        setBusyIds((prev) => {
+          const next = new Set(prev);
+          next.delete(row.instrument_id);
+          return next;
+        });
+        refetch();
+      }
+    }
+  }
+
+  const data = state.data;
+  const items = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const pageStart = total === 0 ? 0 : filters.offset + 1;
+  const pageEnd = filters.offset + items.length;
+
+  return (
+    <div className="mx-auto max-w-screen-2xl space-y-3 p-4 pt-6">
+      <Section title="Theses">
+        <div className="flex flex-wrap items-center gap-4 text-xs text-slate-600 dark:text-slate-300">
+          <label className="flex items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={filters.held}
+              onChange={(e) => setFilters({ held: e.target.checked })}
+            />
+            Held only
+          </label>
+          <label className="flex items-center gap-1.5">
+            <input
+              type="checkbox"
+              checked={filters.stale}
+              onChange={(e) => setFilters({ stale: e.target.checked })}
+            />
+            Stale only
+          </label>
+          <label className="flex items-center gap-1.5">
+            Stance
+            <select
+              className="rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-1.5 py-0.5"
+              value={filters.stance}
+              onChange={(e) => setFilters({ stance: e.target.value })}
+            >
+              <option value="">all</option>
+              {STANCES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        {state.loading ? (
+          <div className="mt-3">
+            <SectionSkeleton rows={6} />
+          </div>
+        ) : state.error !== null ? (
+          <div className="mt-3">
+            <SectionError onRetry={state.refetch} />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="mt-3">
+            <EmptyState
+              title="No theses"
+              description={
+                total === 0 && !filters.held && !filters.stale && filters.stance === ""
+                  ? "Theses are generated hourly by the thesis_refresh job (held + top-ranked instruments), or on demand from an instrument page via Generate thesis."
+                  : "No theses match these filters."
+              }
+            />
+          </div>
+        ) : (
+          <>
+            <div className="mt-3 overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-800 text-left text-xs text-slate-500">
+                    <th className="px-2 py-2">Symbol</th>
+                    <th className="px-2 py-2">Stance</th>
+                    <th className="px-2 py-2">Type</th>
+                    <th className="px-2 py-2 text-right">Confidence</th>
+                    <th className="px-2 py-2 text-right">Buy zone</th>
+                    <th className="px-2 py-2 text-right">Score</th>
+                    <th className="px-2 py-2">Critic</th>
+                    <th className="px-2 py-2">Age</th>
+                    <th className="px-2 py-2">Status</th>
+                    <th className="px-2 py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((row) => (
+                    <tr
+                      key={row.instrument_id}
+                      className="border-b border-slate-100 dark:border-slate-800/60 hover:bg-slate-50 dark:hover:bg-slate-800/40"
+                    >
+                      <td className="px-2 py-2">
+                        <Link
+                          to={`/instrument/${encodeURIComponent(row.symbol)}?tab=verdict`}
+                          className="font-medium text-sky-700 dark:text-sky-400 hover:underline"
+                        >
+                          {row.symbol}
+                        </Link>
+                        {row.is_held ? (
+                          <span
+                            title="Held position"
+                            className="ml-1.5 rounded bg-blue-100 dark:bg-blue-900/40 px-1 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-300"
+                          >
+                            held
+                          </span>
+                        ) : null}
+                        <div className="max-w-[16rem] truncate text-xs text-slate-500 dark:text-slate-400">
+                          {row.company_name}
+                        </div>
+                      </td>
+                      <td className="px-2 py-2">
+                        <StanceBadge stance={row.stance} />
+                      </td>
+                      <td className="px-2 py-2 text-xs text-slate-600 dark:text-slate-300">
+                        {row.thesis_type}
+                      </td>
+                      <td className="px-2 py-2 text-right tabular-nums">
+                        {row.confidence_score !== null
+                          ? `${Math.round(row.confidence_score * 100)}%`
+                          : "—"}
+                      </td>
+                      <td className="px-2 py-2 text-right tabular-nums text-xs">
+                        {row.buy_zone_low !== null || row.buy_zone_high !== null
+                          ? `${formatNumber(row.buy_zone_low, 2)} – ${formatNumber(row.buy_zone_high, 2)}`
+                          : "—"}
+                      </td>
+                      <td className="px-2 py-2 text-right tabular-nums text-xs">
+                        {row.latest_score !== null ? (
+                          <>
+                            {formatNumber(row.latest_score, 3)}
+                            {row.latest_rank !== null ? (
+                              <span className="ml-1 text-slate-400 dark:text-slate-500">
+                                #{row.latest_rank}
+                              </span>
+                            ) : null}
+                          </>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                      <td className="px-2 py-2">
+                        <CriticVerdictBadge verdict={row.critic_verdict} />
+                      </td>
+                      <td className="px-2 py-2 text-xs text-slate-600 dark:text-slate-300">
+                        {formatRelativeTime(row.created_at)}
+                        {row.stale_reason !== null ? (
+                          <span
+                            title={`Stale: ${row.stale_reason}`}
+                            className="ml-1.5 rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 px-1 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300"
+                          >
+                            {staleLabel(row.stale_reason)}
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="px-2 py-2">
+                        <RunStatusCell row={row} />
+                      </td>
+                      <td className="px-2 py-2 text-right">
+                        <button
+                          type="button"
+                          disabled={
+                            busyIds.has(row.instrument_id) ||
+                            row.run_status === "running"
+                          }
+                          onClick={() => void onRequestFresh(row)}
+                          className="rounded border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-2 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+                          title="Regenerate this thesis now (bypasses the 24h cache)"
+                        >
+                          {busyIds.has(row.instrument_id) ||
+                          row.run_status === "running"
+                            ? "Generating…"
+                            : "Refresh"}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-3 flex items-center justify-between text-xs text-slate-500 dark:text-slate-400">
+              <span className="tabular-nums">
+                {pageStart}–{pageEnd} of {total}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  disabled={filters.offset === 0}
+                  onClick={() =>
+                    setFilters({
+                      ...filters,
+                      offset: Math.max(0, filters.offset - PAGE_SIZE),
+                    })
+                  }
+                  className="rounded border border-slate-300 dark:border-slate-700 px-2 py-1 font-medium disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  ← Prev
+                </button>
+                <button
+                  type="button"
+                  disabled={pageEnd >= total}
+                  onClick={() =>
+                    setFilters({
+                      ...filters,
+                      offset: filters.offset + PAGE_SIZE,
+                    })
+                  }
+                  className="rounded border border-slate-300 dark:border-slate-700 px-2 py-1 font-medium disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Next →
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </Section>
+    </div>
+  );
+}

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -127,6 +127,10 @@ export function ThesesPage(): JSX.Element {
   // FE-local generation state dies on navigation, so nothing beyond the
   // button disable relies on this).
   const [busyIds, setBusyIds] = useState<ReadonlySet<number>>(new Set());
+  // Fixed-phrase notice for a failed regeneration REQUEST (transport /
+  // HTTP error) — the durable failure state still comes from thesis_runs,
+  // but that can lag a poll cycle behind the click (review NITPICK).
+  const [actionError, setActionError] = useState<string | null>(null);
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -181,6 +185,7 @@ export function ThesesPage(): JSX.Element {
 
   async function onRequestFresh(row: ThesisLibraryItem): Promise<void> {
     setBusyIds((prev) => new Set(prev).add(row.instrument_id));
+    setActionError(null);
     // Surface the server's 'running' row shortly after firing — the POST
     // itself only resolves when generation completes (minutes on a local
     // model), and the poll loop only starts once a running row is visible.
@@ -190,9 +195,15 @@ export function ThesesPage(): JSX.Element {
     try {
       await generateInstrumentThesis(row.symbol, true);
     } catch (err) {
-      // Failure detail lands in the row's status column via thesis_runs;
-      // log the transport error for the console trail.
+      // Fixed phrase to the surface, full detail to the console (never
+      // exception text in the DOM); the durable per-row failure state
+      // arrives via thesis_runs on the next poll.
       console.error("[ThesesPage] force generation failed", err);
+      if (mountedRef.current) {
+        setActionError(
+          `Generation request for ${row.symbol} failed — check the browser console; the row's status column carries the server-side failure detail.`,
+        );
+      }
     } finally {
       if (mountedRef.current) {
         setBusyIds((prev) => {
@@ -248,6 +259,14 @@ export function ThesesPage(): JSX.Element {
           </label>
         </div>
 
+        {actionError !== null ? (
+          <div
+            role="status"
+            className="mt-3 rounded border border-red-200 dark:border-red-900/60 bg-red-50 dark:bg-red-950/40 px-3 py-1.5 text-xs text-red-700 dark:text-red-300"
+          >
+            {actionError}
+          </div>
+        ) : null}
         {state.loading ? (
           <div className="mt-3">
             <SectionSkeleton rows={6} />

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1915,3 +1915,49 @@ def test_rank_moves_get_returns_503_when_no_operator(client: TestClient) -> None
         _install_conn()
         resp = client.get("/alerts/rank-moves")
     assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# #1902 — thesis-staleness snapshot feed (standing condition, no cursor)
+# ---------------------------------------------------------------------------
+
+
+def test_thesis_staleness_empty_when_nothing_held(client: TestClient) -> None:
+    _install_conn(fetchall_returns=[])
+    resp = client.get("/alerts/thesis-staleness")
+    assert resp.status_code == 200
+    assert resp.json() == {"items": []}
+
+
+def test_thesis_staleness_reports_stale_held_instrument(client: TestClient) -> None:
+    cur = _install_conn()
+    # cursor fetchalls in call order: held ids, then latest-thesis timestamps.
+    stale_at = datetime(2026, 4, 1, tzinfo=UTC)
+    cur.fetchall.side_effect = [
+        [{"instrument_id": 5}],
+        [{"instrument_id": 5, "latest_thesis_at": stale_at}],
+    ]
+    # find_stale_instruments reads via conn.execute(...).fetchall() — a
+    # monthly cadence + past thesis timestamp is deterministically stale.
+    conn = cur._parent_conn
+    conn.execute.return_value.fetchall.return_value = [
+        (5, "GME", "monthly", stale_at, None, None),
+    ]
+    resp = client.get("/alerts/thesis-staleness")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["instrument_id"] == 5
+    assert items[0]["symbol"] == "GME"
+    assert items[0]["reason"] == "stale"
+    assert items[0]["latest_thesis_at"] is not None
+
+
+def test_thesis_staleness_empty_when_held_theses_fresh(client: TestClient) -> None:
+    cur = _install_conn()
+    cur.fetchall.side_effect = [[{"instrument_id": 5}]]
+    conn = cur._parent_conn
+    conn.execute.return_value.fetchall.return_value = []
+    resp = client.get("/alerts/thesis-staleness")
+    assert resp.status_code == 200
+    assert resp.json() == {"items": []}

--- a/tests/test_api_theses.py
+++ b/tests/test_api_theses.py
@@ -666,3 +666,24 @@ class TestListTheses:
 
         assert resp.status_code == 200
         assert resp.json() == {"items": [], "total": 0, "offset": 0, "limit": 50}
+
+
+class TestLibraryOrderKey:
+    def test_gap_rows_first_then_newest_thesis(self) -> None:
+        from app.api.theses import library_order_key
+
+        gap = {"created_at": None, "thesis_id": None}
+        older = {"created_at": _EARLIER, "thesis_id": 1}
+        newer = {"created_at": _NOW, "thesis_id": 2}
+        rows = [older, newer, gap]
+        rows.sort(key=library_order_key)
+        assert rows == [gap, newer, older]
+
+    def test_same_timestamp_breaks_on_thesis_id_desc(self) -> None:
+        from app.api.theses import library_order_key
+
+        first = {"created_at": _NOW, "thesis_id": 5}
+        second = {"created_at": _NOW, "thesis_id": 9}
+        rows = [first, second]
+        rows.sort(key=library_order_key)
+        assert rows == [second, first]

--- a/tests/test_api_theses.py
+++ b/tests/test_api_theses.py
@@ -381,3 +381,216 @@ class TestGetThesisHistory:
         assert "order by" in sql_lower
         assert "created_at desc" in sql_lower
         assert "thesis_version desc" in sql_lower
+
+
+# ---------------------------------------------------------------------------
+# #1902 — staleness single-source on the latest-thesis GET
+# ---------------------------------------------------------------------------
+
+
+class TestGetLatestThesisStaleness:
+    def test_stale_thesis_carries_server_verdict(self) -> None:
+        """find_stale_instruments (via conn.execute) drives is_stale."""
+        conn = _with_conn([[_make_thesis_row(created_at=_EARLIER)]])
+        # find_stale_instruments reads via conn.execute(...).fetchall() —
+        # monthly cadence + a past created_at is deterministically stale
+        # against the real clock.
+        conn.execute.return_value.fetchall.return_value = [
+            (100, "AAPL", "monthly", _EARLIER, None, None),
+        ]
+        resp = client.get("/theses/100")
+        _cleanup()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_stale"] is True
+        assert body["stale_reason"] == "stale"
+
+    def test_fresh_thesis_reports_not_stale(self) -> None:
+        conn = _with_conn([[_make_thesis_row()]])
+        conn.execute.return_value.fetchall.return_value = []
+        resp = client.get("/theses/100")
+        _cleanup()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_stale"] is False
+        assert body["stale_reason"] is None
+
+
+# ---------------------------------------------------------------------------
+# #1902 — theses library: pure helpers + list endpoint
+# ---------------------------------------------------------------------------
+
+
+def _make_library_row(
+    instrument_id: int = 100,
+    symbol: str = "AAPL",
+    stance: str = "buy",
+    is_held: bool = False,
+    critic_json: dict[str, object] | None = None,
+    run_status: str | None = None,
+    created_at: datetime = _NOW,
+) -> dict[str, Any]:
+    return {
+        "thesis_id": instrument_id * 10,
+        "instrument_id": instrument_id,
+        "thesis_version": 1,
+        "thesis_type": "value",
+        "stance": stance,
+        "confidence_score": 0.7,
+        "buy_zone_low": 10.0,
+        "buy_zone_high": 12.0,
+        "critic_json": critic_json,
+        "created_at": created_at,
+        "symbol": symbol,
+        "company_name": f"{symbol} Co",
+        "is_held": is_held,
+        "latest_score": 0.61,
+        "latest_rank": 7,
+        "run_status": run_status,
+        "run_error": None,
+        "run_trigger": None,
+        "run_started_at": None,
+    }
+
+
+class TestFilterAndPageLibrary:
+    """Table tests for the pure filter/pagination helper."""
+
+    def _rows(self) -> list[dict[str, Any]]:
+        from app.api.theses import filter_and_page_library  # noqa: F401
+
+        return [
+            _make_library_row(1, "AAA", stance="buy", is_held=True),
+            _make_library_row(2, "BBB", stance="hold"),
+            _make_library_row(3, "CCC", stance="buy"),
+            _make_library_row(4, "DDD", stance="avoid", is_held=True),
+        ]
+
+    def test_no_filters_returns_all(self) -> None:
+        from app.api.theses import filter_and_page_library
+
+        total, page = filter_and_page_library(
+            self._rows(), {}, held_only=False, stale_only=False, stance=None, offset=0, limit=50
+        )
+        assert total == 4
+        assert [r["instrument_id"] for r in page] == [1, 2, 3, 4]
+
+    def test_stale_reason_merged_onto_every_row(self) -> None:
+        from app.api.theses import filter_and_page_library
+
+        _, page = filter_and_page_library(
+            self._rows(),
+            {1: "stale", 3: "event_new_10k"},
+            held_only=False,
+            stale_only=False,
+            stance=None,
+            offset=0,
+            limit=50,
+        )
+        by_id = {r["instrument_id"]: r["stale_reason"] for r in page}
+        assert by_id == {1: "stale", 2: None, 3: "event_new_10k", 4: None}
+
+    def test_held_only_filter(self) -> None:
+        from app.api.theses import filter_and_page_library
+
+        total, page = filter_and_page_library(
+            self._rows(), {}, held_only=True, stale_only=False, stance=None, offset=0, limit=50
+        )
+        assert total == 2
+        assert [r["instrument_id"] for r in page] == [1, 4]
+
+    def test_stale_only_filter(self) -> None:
+        from app.api.theses import filter_and_page_library
+
+        total, page = filter_and_page_library(
+            self._rows(), {2: "stale"}, held_only=False, stale_only=True, stance=None, offset=0, limit=50
+        )
+        assert total == 1
+        assert page[0]["instrument_id"] == 2
+
+    def test_stance_filter(self) -> None:
+        from app.api.theses import filter_and_page_library
+
+        total, page = filter_and_page_library(
+            self._rows(), {}, held_only=False, stale_only=False, stance="buy", offset=0, limit=50
+        )
+        assert total == 2
+        assert [r["instrument_id"] for r in page] == [1, 3]
+
+    def test_filters_compose_and_total_counts_pre_pagination(self) -> None:
+        from app.api.theses import filter_and_page_library
+
+        rows = [_make_library_row(i, f"S{i}", stance="buy", is_held=True) for i in range(1, 8)]
+        stale = {i: "stale" for i in range(1, 8)}
+        total, page = filter_and_page_library(
+            rows, stale, held_only=True, stale_only=True, stance="buy", offset=2, limit=3
+        )
+        assert total == 7
+        assert [r["instrument_id"] for r in page] == [3, 4, 5]
+
+    def test_offset_beyond_total_returns_empty_page(self) -> None:
+        from app.api.theses import filter_and_page_library
+
+        total, page = filter_and_page_library(
+            self._rows(), {}, held_only=False, stale_only=False, stance=None, offset=10, limit=5
+        )
+        assert total == 4
+        assert page == []
+
+
+class TestCriticVerdictExtraction:
+    def test_extracts_verdict_string(self) -> None:
+        from app.api.theses import _critic_verdict
+
+        assert _critic_verdict({"verdict": "Strong challenge"}) == "Strong challenge"
+
+    def test_non_dict_and_missing_and_non_string_return_none(self) -> None:
+        from app.api.theses import _critic_verdict
+
+        assert _critic_verdict(None) is None
+        assert _critic_verdict("nope") is None
+        assert _critic_verdict({}) is None
+        assert _critic_verdict({"verdict": 3}) is None
+
+
+class TestListTheses:
+    def test_returns_enriched_items(self) -> None:
+        row = _make_library_row(
+            100,
+            "AAPL",
+            is_held=True,
+            critic_json={"verdict": "Moderate challenge"},
+            run_status="failed",
+        )
+        conn = _with_conn([[row]])
+        conn.execute.return_value.fetchall.return_value = [
+            (100, "AAPL", "monthly", _EARLIER, None, None),
+        ]
+        resp = client.get("/theses")
+        _cleanup()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        item = body["items"][0]
+        assert item["symbol"] == "AAPL"
+        assert item["critic_verdict"] == "Moderate challenge"
+        assert item["stale_reason"] == "stale"
+        assert item["is_held"] is True
+        assert item["run_status"] == "failed"
+        assert item["latest_rank"] == 7
+
+    def test_stance_param_validated(self) -> None:
+        resp = client.get("/theses?stance=exit")
+        assert resp.status_code == 422
+
+    def test_empty_library_returns_empty_page(self) -> None:
+        conn = _with_conn([[]])
+        conn.execute.return_value.fetchall.return_value = []
+        resp = client.get("/theses")
+        _cleanup()
+
+        assert resp.status_code == 200
+        assert resp.json() == {"items": [], "total": 0, "offset": 0, "limit": 50}

--- a/tests/test_api_theses.py
+++ b/tests/test_api_theses.py
@@ -556,6 +556,8 @@ class TestCriticVerdictExtraction:
 
 
 class TestListTheses:
+    # Cursor result sets in execute order: [held-no-thesis rows], [library rows].
+
     def test_returns_enriched_items(self) -> None:
         row = _make_library_row(
             100,
@@ -564,7 +566,7 @@ class TestListTheses:
             critic_json={"verdict": "Moderate challenge"},
             run_status="failed",
         )
-        conn = _with_conn([[row]])
+        conn = _with_conn([[], [row]])
         conn.execute.return_value.fetchall.return_value = [
             (100, "AAPL", "monthly", _EARLIER, None, None),
         ]
@@ -582,12 +584,82 @@ class TestListTheses:
         assert item["run_status"] == "failed"
         assert item["latest_rank"] == 7
 
+    def test_held_no_thesis_row_prepended(self) -> None:
+        gap_row = {
+            "thesis_id": None,
+            "instrument_id": 200,
+            "thesis_version": None,
+            "thesis_type": None,
+            "stance": None,
+            "confidence_score": None,
+            "buy_zone_low": None,
+            "buy_zone_high": None,
+            "critic_json": None,
+            "created_at": None,
+            "symbol": "GME",
+            "company_name": "GameStop",
+            "is_held": True,
+            "latest_score": None,
+            "latest_rank": None,
+            "run_status": None,
+            "run_error": None,
+            "run_trigger": None,
+            "run_started_at": None,
+        }
+        conn = _with_conn([[gap_row], [_make_library_row(100, "AAPL")]])
+        conn.execute.return_value.fetchall.return_value = [
+            (200, "GME", None, None, None, None),  # no_thesis via find_stale
+        ]
+        resp = client.get("/theses")
+        _cleanup()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 2
+        # Gap row first — a held name without a memo outranks memo age.
+        assert body["items"][0]["symbol"] == "GME"
+        assert body["items"][0]["thesis_id"] is None
+        assert body["items"][0]["stale_reason"] == "no_thesis"
+        assert body["items"][1]["symbol"] == "AAPL"
+
+    def test_stance_filter_excludes_thesis_less_rows(self) -> None:
+        gap_row = {
+            "thesis_id": None,
+            "instrument_id": 200,
+            "thesis_version": None,
+            "thesis_type": None,
+            "stance": None,
+            "confidence_score": None,
+            "buy_zone_low": None,
+            "buy_zone_high": None,
+            "critic_json": None,
+            "created_at": None,
+            "symbol": "GME",
+            "company_name": "GameStop",
+            "is_held": True,
+            "latest_score": None,
+            "latest_rank": None,
+            "run_status": None,
+            "run_error": None,
+            "run_trigger": None,
+            "run_started_at": None,
+        }
+        conn = _with_conn([[gap_row], [_make_library_row(100, "AAPL", stance="buy")]])
+        conn.execute.return_value.fetchall.return_value = []
+        resp = client.get("/theses?stance=buy")
+        _cleanup()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert body["items"][0]["symbol"] == "AAPL"
+
     def test_stance_param_validated(self) -> None:
         resp = client.get("/theses?stance=exit")
         assert resp.status_code == 422
 
     def test_empty_library_returns_empty_page(self) -> None:
-        conn = _with_conn([[]])
+        conn = _with_conn([[], []])
         conn.execute.return_value.fetchall.return_value = []
         resp = client.get("/theses")
         _cleanup()

--- a/tests/test_theses_library_db.py
+++ b/tests/test_theses_library_db.py
@@ -1,0 +1,107 @@
+"""DB-tier test for the #1902 theses-library SQL mechanism.
+
+One integration test for the genuinely-new SQL shape (test-quality
+skill): ``_LIBRARY_SQL`` — DISTINCT ON latest-per-instrument over the
+versioned theses table, plus the held-EXISTS, latest-score LATERAL and
+latest-thesis_runs LATERAL joins. Filters/pagination are pure Python
+(``filter_and_page_library``) and are table-tested in
+tests/test_api_theses.py without a DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import psycopg.rows
+import pytest
+
+from app.api.theses import _LIBRARY_SQL
+from app.services.scoring import _DEFAULT_MODEL_VERSION
+
+_T1 = datetime(2026, 6, 1, tzinfo=UTC)
+_T2 = datetime(2026, 6, 20, tzinfo=UTC)
+
+
+@pytest.fixture
+def conn(ebull_test_conn):
+    return ebull_test_conn
+
+
+def _seed(conn) -> tuple[int, int]:
+    a, b = 8101, 8102
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)"
+        " VALUES (%s, 'LIBA', 'Library A Co', TRUE), (%s, 'LIBB', 'Library B Co', TRUE)",
+        (a, b),
+    )
+    # A: two thesis versions — DISTINCT ON must pick the newer one.
+    conn.execute(
+        """
+        INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance,
+                            confidence_score, memo_markdown, critic_json, created_at)
+        VALUES (%(a)s, 1, 'value', 'watch', 0.4, 'old memo', NULL, %(t1)s),
+               (%(a)s, 2, 'value', 'buy', 0.8, 'new memo',
+                '{"verdict": "Weak challenge"}'::jsonb, %(t2)s),
+               (%(b)s, 1, 'turnaround', 'avoid', 0.2, 'b memo', NULL, %(t1)s)
+        """,
+        {"a": a, "b": b, "t1": _T1, "t2": _T2},
+    )
+    # A is held; B is not.
+    conn.execute(
+        "INSERT INTO positions (instrument_id, current_units, cost_basis, source) VALUES (%s, 10, 100, 'broker_sync')",
+        (a,),
+    )
+    # A: two runs — the LATERAL must surface the newer (failed) one.
+    conn.execute(
+        """
+        INSERT INTO thesis_runs (instrument_id, trigger, started_at, status, error)
+        VALUES (%(a)s, 'manual', %(t1)s, 'ok', NULL),
+               (%(a)s, 'scheduled', %(t2)s, 'failed', 'writer schema error (finish_reason=stop)')
+        """,
+        {"a": a, "t1": _T1, "t2": _T2},
+    )
+    # A: two scores at the default model version — LATERAL picks the newer.
+    conn.execute(
+        """
+        INSERT INTO scores (instrument_id, scored_at, total_score, model_version, rank)
+        VALUES (%(a)s, %(t1)s, 0.40, %(mv)s, 50),
+               (%(a)s, %(t2)s, 0.75, %(mv)s, 3)
+        """,
+        {"a": a, "t1": _T1, "t2": _T2, "mv": _DEFAULT_MODEL_VERSION},
+    )
+    conn.commit()
+    return a, b
+
+
+class TestLibrarySql:
+    def test_latest_per_instrument_with_context(self, conn) -> None:
+        a, b = _seed(conn)
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(_LIBRARY_SQL, {"mv": _DEFAULT_MODEL_VERSION})
+            rows = {r["instrument_id"]: r for r in cur.fetchall() if r["instrument_id"] in (a, b)}
+
+        assert set(rows) == {a, b}
+
+        row_a = rows[a]
+        # DISTINCT ON picked v2, not v1.
+        assert row_a["thesis_version"] == 2
+        assert row_a["stance"] == "buy"
+        assert row_a["critic_json"] == {"verdict": "Weak challenge"}
+        assert row_a["is_held"] is True
+        # LATERALs picked the newest score and the newest (failed) run.
+        assert float(row_a["latest_score"]) == 0.75
+        assert row_a["latest_rank"] == 3
+        assert row_a["run_status"] == "failed"
+        assert row_a["run_trigger"] == "scheduled"
+
+        row_b = rows[b]
+        assert row_b["thesis_version"] == 1
+        assert row_b["is_held"] is False
+        assert row_b["latest_score"] is None
+        assert row_b["run_status"] is None
+
+        # Global ordering: newest thesis first — A (T2) before B (T1).
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(_LIBRARY_SQL, {"mv": _DEFAULT_MODEL_VERSION})
+            ordered = [r["instrument_id"] for r in cur.fetchall() if r["instrument_id"] in (a, b)]
+        assert ordered == [a, b]

--- a/tests/test_theses_library_db.py
+++ b/tests/test_theses_library_db.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 import psycopg.rows
 import pytest
 
-from app.api.theses import _LIBRARY_SQL
+from app.api.theses import _HELD_NO_THESIS_SQL, _LIBRARY_SQL
 from app.services.scoring import _DEFAULT_MODEL_VERSION
 
 _T1 = datetime(2026, 6, 1, tzinfo=UTC)
@@ -105,3 +105,37 @@ class TestLibrarySql:
             cur.execute(_LIBRARY_SQL, {"mv": _DEFAULT_MODEL_VERSION})
             ordered = [r["instrument_id"] for r in cur.fetchall() if r["instrument_id"] in (a, b)]
         assert ordered == [a, b]
+
+    def test_held_without_thesis_surfaces_as_gap_row(self, conn) -> None:
+        a, b = _seed(conn)
+        # C: held, but no thesis row at all — must come back from the
+        # gap query with typed-NULL thesis columns, and must NOT appear
+        # in the library query.
+        c = 8103
+        conn.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)"
+            " VALUES (%s, 'LIBC', 'Library C Co', TRUE)",
+            (c,),
+        )
+        conn.execute(
+            "INSERT INTO positions (instrument_id, current_units, cost_basis, source)"
+            " VALUES (%s, 5, 50, 'broker_sync')",
+            (c,),
+        )
+        conn.commit()
+
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(_HELD_NO_THESIS_SQL, {"mv": _DEFAULT_MODEL_VERSION})
+            gap_rows = {r["instrument_id"]: r for r in cur.fetchall() if r["instrument_id"] in (a, b, c)}
+            cur.execute(_LIBRARY_SQL, {"mv": _DEFAULT_MODEL_VERSION})
+            lib_ids = {r["instrument_id"] for r in cur.fetchall() if r["instrument_id"] in (a, b, c)}
+
+        # A is held WITH a thesis → library only. C is held WITHOUT → gap only.
+        assert set(gap_rows) == {c}
+        assert lib_ids == {a, b}
+        row_c = gap_rows[c]
+        assert row_c["thesis_id"] is None
+        assert row_c["stance"] is None
+        assert row_c["created_at"] is None
+        assert row_c["is_held"] is True
+        assert row_c["symbol"] == "LIBC"


### PR DESCRIPTION
Implements #1902 (per its 2026-07-09 scope comment; folds in #1922 item 3 thesis-staleness alerts). Display side of the #1919 thesis go-live: the substrate (`thesis_runs`, force param, router auth, 6 real theses on dev) landed in PRs #1991/#1993/#1994.

## What changed

**Backend**
- `GET /theses` (existing auth-gated router): latest thesis per instrument via `DISTINCT ON (instrument_id) … ORDER BY created_at DESC, thesis_version DESC` (same tiebreak as the per-instrument read), joined with:
  - held flag (`EXISTS positions.current_units > 0` — same predicate as the rank-moves feed),
  - latest score at `_DEFAULT_MODEL_VERSION` via LATERAL (per-instrument-latest, NOT run-coherent — deliberately the same divergence `get_verdict` documents for single-instrument display),
  - latest `thesis_runs` row via LATERAL (`started_at DESC, run_id DESC`, rides `idx_thesis_runs_instrument_started`) → status column (`running`/`ok`/`failed` + error + trigger),
  - `critic_json->>'verdict'` extracted server-side (open string in the response model — thesis_runs.status is DB-CHECKed but critic verdict is free JSON; #1808 class).
- **Held instruments with NO thesis get gap rows** (`_HELD_NO_THESIS_SQL`, typed-NULL thesis columns, prepended): the dashboard alert includes them, so the library it links to must too (Codex ckpt-2 finding). Unheld thesis-less instruments stay out.
- Filters `held_only` / `stale` / `stance` (422-validated against the settled stance enum) + offset/limit pagination. Stance/held/stale filtering + paging is one pure function (`filter_and_page_library`, table-tested) over an unpaginated scan — row volume is bounded by instruments-with-theses (hundreds under the #1919 batch-bounded refresh).
- **Staleness single-source**: per-row `stale_reason` and `GET /theses/{id}`'s new `is_stale`/`stale_reason` both come from the canonical `find_stale_instruments` predicate (coverage cadence + #273 filing-event triggers) — the same function the `thesis_refresh` scheduler uses, so library column, instrument-page chip and refresh engine can never disagree. `stale_reason=None` also covers out-of-refresh-scope instruments (not tradable/analysable) — flagging those stale would nag forever with no cure. #1988 staleness-v2 upgrades propagate everywhere automatically.
- `GET /alerts/thesis-staleness`: standing-condition snapshot (held ∩ stale). Deliberately NOT a cursor feed — no BIGSERIAL to cursor on, "mark seen" has no meaning; the card clears when theses regenerate.

**Frontend**
- New `/theses` page + "Theses" nav entry: table (symbol→Verdict tab link, stance pill, type, confidence, buy zone, score+rank, critic verdict badge, age + stale pill with reason, held pill, run-status pill, per-row force Refresh via `?force=true`). Filter state in URL (deep-links; AlertsStrip links `?held=true&stale=true`). Polls every 20s only while a run is in-flight. Out-of-range `?offset=` clamps to page one (Codex ckpt-2).
- `CriticVerdictBadge` + `StanceBadge` (new `components/theses/`); ThesisPane now renders buy zone (4th column of the bear/base/bull grid) + critic verdict/summary/key-risks — `critic_json` and `buy_zone_*` were typed but rendered nowhere.
- SummaryStrip: module-private `THESIS_STALE_DAYS=30` deleted; the chip + Generate-gating use the server verdict. Test pins that an old `created_at` alone no longer reads as stale.
- AlertsStrip: 5th feed → one grouped informational "N held instruments have a stale thesis" card, excluded from unseen/overflow/dismiss accounting (no cursor).

**Decision recorded (scope item 7):** `memo_markdown` stays plain-text; the library's detail view is the existing instrument Verdict tab (linked per row). No markdown dependency added.

## Security model
- Both new endpoints sit on routers already gated by `require_session_or_service_token` (#1919 PR-A); no new unauthenticated surface. No new write paths.
- `run_error` in the list response is the persisted `thesis_runs.error` audit column (purpose-built for this surface in the #1919 spec), not echoed live exception text. Alerts/list SQL is parameterised throughout; the only f-string SQL uses module-level constants (pre-existing pattern).

## Conscious tradeoffs
- Unpaginated scan then in-memory filter/page: keeps one SQL shape and lets staleness (Python-only predicate) compose with SQL-derived filters in one tested function. Bounded by thesis count; revisit only if a full-universe backfill (~12k) makes it measurable.
- Poll (20s, only-while-running) instead of SSE: one in-flight generation at a time under the provider semaphore; SSE plumbing isn't warranted.
- `GET /theses/{id}` gained one extra bounded query (single-instrument staleness) per instrument-page load.

## Tests
- Pure: `filter_and_page_library` table tests (compose, totals pre-pagination, offset-beyond-total), `_critic_verdict` extraction, endpoint tests for enrichment/gap-row/stance-422/empty.
- DB-tier (one per new SQL mechanism): `tests/test_theses_library_db.py` pins DISTINCT ON version pick, both LATERALs, held EXISTS, gap-row query disjointness, global ordering.
- FE: ThesesPage (7), AlertsStrip (+2 for the thesis card + unseen exclusion), ThesisPane (+3 buy zone/critic/no-verdict), SummaryStrip (+1 single-source pin), VerdictTab regex tightened (new "Buy zone" label double-matched `/buy/i`).

## Gates
`ruff check` + `format --check` clean, `pyright` 0 errors, `pytest -m "not db"` green, smoke 147 passed, DB-tier file 2 passed, `pnpm typecheck` clean, `test:unit` 123 files / 1321 passed. Codex ckpt-2 run pre-push; both P2 findings fixed (`a25ab680`).

## ETL clauses
Not applicable — read-only display feature; no parser/schema/ingest changes, no migration (thesis_runs shipped in sql/218, PR #1991). Dev-verify after merge: `/theses` renders the 6 live theses (AAPL/BBBY/GME/IEP/ENVA/PLTR) + instrument-page FE-QA, recorded here.

Refs #1902. Closes #1902 after dev-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)