### PR TITLE
feat(#1987): thesis context enrichment — price anchor + valuation + IAR evidence + TA state

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -612,6 +612,9 @@ def _shape_ta_state(price_row: tuple[object, ...] | None) -> dict[str, object] |
 
     price_vs_sma200: str | None = None
     if close is not None and sma_200 is not None:
+        # Tie (close == sma_200) is "below" by design — strict >, mirroring
+        # technical_analysis.py compute_indicators so the two derivations
+        # can never disagree on the same row.
         price_vs_sma200 = "above" if close > sma_200 else "below"
 
     regime: str | None = None

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -52,6 +52,11 @@ import psycopg
 from psycopg import sql as psql
 from psycopg.types.json import Jsonb
 
+# Safe at module scope: instrument_analytics has no app-module imports at
+# top level (its insider_transactions read is function-lazy), so this does
+# NOT re-enter the risk_metrics -> scheduler -> refresh_cascade cycle that
+# forces the lazy import inside _assemble_context.
+from app.services.instrument_analytics import SCHEMA_VERSION as _IAR_SCHEMA_VERSION
 from app.services.llm_client import LLMClient, LLMCompletion
 
 logger = logging.getLogger(__name__)
@@ -526,6 +531,13 @@ def _shape_analytics_evidence(
         return None
     if not isinstance(analytics, dict):
         return dict(_MALFORMED)
+    schema = analytics.get("schema")
+    if schema != _IAR_SCHEMA_VERSION:
+        # A future iar_v2 must not be silently compacted under v1
+        # assumptions — surface it as unsupported (absent evidence to the
+        # writer) until this shaper is deliberately migrated (bot review
+        # NITPICK, PR #1999).
+        return {"reason": "unsupported_schema", "schema": schema}
 
     out: dict[str, object] = {
         "schema": analytics.get("schema"),

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -11,13 +11,18 @@ Responsibilities:
   - Update coverage.last_reviewed_at on success.
   - Identify stale instruments (no thesis, or thesis older than review_frequency).
 
-Context caps (v1 hard limits):
+Context caps (v2 — settled-decisions "Thesis prompt budget", amended #1987):
   - prior thesis:         latest 1
   - filing events:        latest 3
   - fundamentals:         latest snapshot + up to 4 prior snapshots
   - earnings events:      latest 4 quarters (confirmed only)
   - analyst estimates:    latest 1 snapshot
   - news events:          latest 10 from last 30 days, importance desc → recency desc
+  - risk metrics (#1632): instrument_risk_metrics_current scalars, statused
+  - price anchor (#1987): latest price_daily close (native ccy) + 52w range + returns
+  - valuation (#1987):    instrument_valuation row when present; statused absence
+  - analytics (#1987):    latest scores.analytics_json, shaped compact, scored_at-stamped
+  - ta_state (#1987):     latest price_daily indicators + derived regime signals
 
 LLM provider: resolved from `runtime_config` via
 `app.services.llm_client.make_llm_client` (#1919 — local-first default;
@@ -40,7 +45,7 @@ import json
 import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any, Literal
 
 import psycopg
@@ -81,12 +86,15 @@ _REVIEW_FREQUENCY_DAYS: dict[str, int] = {
 # ---------------------------------------------------------------------------
 
 _MAX_TOKENS_WRITER = 2048
-_MAX_TOKENS_CRITIC = 1024
+# 1024 length-failed live on IEP (2026-07-10, thesis stored without critic_json);
+# the #1987 context growth makes recurrence more likely. Local-first default
+# makes the cost delta negligible.
+_MAX_TOKENS_CRITIC = 2048
 
 # Stamped onto every stored thesis row (theses.prompt_version). Bump
 # whenever _WRITER_SYSTEM / _CRITIC_SYSTEM or the _assemble_context shape
 # changes — memos from different prompt versions are not comparable.
-_PROMPT_VERSION = "v1"
+_PROMPT_VERSION = "v2"
 
 # thesis_runs.trigger — matches the table CHECK in sql/218.
 RunTrigger = Literal["manual", "cascade", "scheduled"]
@@ -100,6 +108,10 @@ _MAX_FILING_EVENTS = 3
 _MAX_FUNDAMENTALS_SNAPSHOTS = 5  # latest + 4 prior
 _MAX_NEWS_EVENTS = 10
 _NEWS_LOOKBACK_DAYS = 30
+# 52w range window for the price anchor (#1987), measured back from the
+# LATEST close's price_date (not today) so a stale price series yields an
+# honest historical range rather than a shrunken one.
+_PRICE_ANCHOR_LOOKBACK_DAYS = 365
 
 # ---------------------------------------------------------------------------
 # Public result types
@@ -379,6 +391,233 @@ def _shape_risk_metrics(
     }
 
 
+# ---------------------------------------------------------------------------
+# #1987 context blocks — pure row-shaping (spec:
+# docs/specs/thesis/2026-07-10-thesis-context-enrichment.md). All four follow
+# the #1632 evidence discipline: statuses verbatim, as-of stamps, missing data
+# stays missing (None, never a fabricated zero).
+# ---------------------------------------------------------------------------
+
+# Column order of the shared price_daily latest-row SELECT (13 cols), consumed
+# by _shape_price_anchor (0-6) and _shape_ta_state (0, 7-12):
+#   0 close, 1 price_date, 2 return_1w, 3 return_1m, 4 return_3m,
+#   5 return_6m, 6 return_1y, 7 sma_50, 8 sma_200, 9 rsi_14,
+#   10 macd_histogram, 11 atr_14, 12 volatility_30d
+
+
+def _shape_price_anchor(
+    price_row: tuple[object, ...] | None,
+    agg_row: tuple[object, ...] | None,
+    currency: object,
+) -> dict[str, object] | None:
+    """Block A: latest native-currency close + 52w range + persisted returns.
+
+    agg_row = (high_52w, low_52w, window_days) over the trailing
+    _PRICE_ANCHOR_LOOKBACK_DAYS from the latest price_date. No price history
+    -> None (never a fabricated anchor); NULL returns stay None.
+    """
+    if price_row is None:
+        return None
+    high_52w = low_52w = None
+    window_days = 0
+    if agg_row is not None:
+        high_52w = _to_float(agg_row[0])
+        low_52w = _to_float(agg_row[1])
+        window_count = _to_float(agg_row[2])
+        window_days = int(window_count) if window_count is not None else 0
+    return {
+        "close": _to_float(price_row[0]),
+        "price_date": str(price_row[1]) if price_row[1] is not None else None,
+        "currency": currency,
+        "high_52w": high_52w,
+        "low_52w": low_52w,
+        "window_days_52w": window_days,
+        "return_1w": _to_float(price_row[2]),
+        "return_1m": _to_float(price_row[3]),
+        "return_3m": _to_float(price_row[4]),
+        "return_6m": _to_float(price_row[5]),
+        "return_1y": _to_float(price_row[6]),
+    }
+
+
+# Column order of the instrument_valuation SELECT (18 cols):
+#   0 current_price, 1 price_as_of, 2 market_cap_live, 3 enterprise_value,
+#   4 pe_ratio, 5 pb_ratio, 6 p_fcf_ratio, 7 fcf_yield, 8 ev_revenue,
+#   9 ev_ebitda, 10 debt_equity_ratio, 11 net_margin, 12 gross_margin,
+#   13 operating_margin, 14 roa, 15 roe, 16 dividend_yield, 17 is_complete_ttm
+_VALUATION_FIELDS: tuple[str, ...] = (
+    "current_price",
+    "price_as_of",
+    "market_cap_live",
+    "enterprise_value",
+    "pe_ratio",
+    "pb_ratio",
+    "p_fcf_ratio",
+    "fcf_yield",
+    "ev_revenue",
+    "ev_ebitda",
+    "debt_equity_ratio",
+    "net_margin",
+    "gross_margin",
+    "operating_margin",
+    "roa",
+    "roe",
+    "dividend_yield",
+    "is_complete_ttm",
+)
+
+
+def _shape_valuation(row: tuple[object, ...] | None) -> dict[str, object]:
+    """Block B: instrument_valuation row, statused absence.
+
+    The view is quotes-gated (sql/201 `priced` CTE reads FROM quotes; #1857
+    class) so a missing row is STRUCTURAL for most of the universe — statused,
+    not an error. #1664 dual-class NULLs pass through as None (honest
+    suppression).
+    """
+    if row is None:
+        return {"available": False, "reason": "no_live_quote"}
+    shaped: dict[str, object] = {"available": True}
+    for idx, field_name in enumerate(_VALUATION_FIELDS):
+        val = row[idx]
+        if field_name == "price_as_of":
+            shaped[field_name] = val.isoformat() if isinstance(val, (datetime, date)) else None
+        elif field_name == "is_complete_ttm":
+            shaped[field_name] = bool(val) if val is not None else None
+        else:
+            shaped[field_name] = _to_float(val)
+    return shaped
+
+
+def _signal_entry_ok(entry: object) -> bool:
+    """A positioning entry is forwardable iff it is a dict whose `signal` is
+    None or a number in [0, 1] — grounded by the 2026-07-10 full-population
+    shape scan (3,906/3,906 conforming). Anything else fails closed."""
+    if not isinstance(entry, dict):
+        return False
+    sig = entry.get("signal")
+    if sig is None:
+        return True
+    # bool is an int subclass — {"signal": true} is malformed, not 1.0.
+    if isinstance(sig, bool):
+        return False
+    return isinstance(sig, (int, float)) and 0.0 <= float(sig) <= 1.0
+
+
+_MALFORMED: dict[str, object] = {"reason": "malformed"}
+
+
+def _shape_analytics_evidence(
+    analytics: object,
+    scored_at: datetime | None,
+    model_version: object,
+) -> dict[str, object] | None:
+    """Block C: latest scores.analytics_json (#1823 iar_v1) shaped compact.
+
+    None analytics (scores row exists, analytics_json NULL) -> None (absent
+    evidence). Present-but-non-dict -> {"reason": "malformed"} — the
+    absent-vs-malformed distinction is deliberate (spec §Block C). Fail-closed
+    per sub-block: unexpected types are dropped to {"reason": "malformed"},
+    never forwarded. Drops piotroski.components + peer families' `absolute`
+    (token noise); positioning passes verbatim (`asof` optional upstream —
+    818/3,906 undated insider signals on dev).
+    """
+    if analytics is None:
+        return None
+    if not isinstance(analytics, dict):
+        return dict(_MALFORMED)
+
+    out: dict[str, object] = {
+        "schema": analytics.get("schema"),
+        "as_of": scored_at.isoformat() if scored_at is not None else None,
+        "model_version": model_version,
+    }
+
+    piotroski = analytics.get("piotroski")
+    if isinstance(piotroski, dict):
+        out["piotroski"] = {
+            k: piotroski.get(k) for k in ("score", "band", "components_available", "suppressed", "reason")
+        }
+    else:
+        out["piotroski"] = dict(_MALFORMED)
+
+    altman = analytics.get("altman_z")
+    out["altman_z"] = dict(altman) if isinstance(altman, dict) else dict(_MALFORMED)
+
+    positioning = analytics.get("positioning")
+    if isinstance(positioning, dict):
+        out["positioning"] = {
+            key: (dict(entry) if _signal_entry_ok(entry) else dict(_MALFORMED)) for key, entry in positioning.items()
+        }
+    else:
+        out["positioning"] = dict(_MALFORMED)
+
+    peer = analytics.get("peer_grade")
+    if isinstance(peer, dict):
+        # `families` may be legitimately EMPTY ({} — absolute_only rows
+        # persisted outside a run cohort) but must be a dict; a non-dict
+        # families or family entry is corruption, not missing evidence —
+        # mark it malformed rather than silently degrading to {} (Codex
+        # ckpt-2, 2026-07-10).
+        families = peer.get("families")
+        if isinstance(families, dict):
+            shaped_families: dict[str, object] = {
+                fam: (
+                    {"hybrid": grades.get("hybrid"), "percentile": grades.get("percentile")}
+                    if isinstance(grades, dict)
+                    else dict(_MALFORMED)
+                )
+                for fam, grades in families.items()
+            }
+            out["peer_grade"] = {
+                "peer_key": peer.get("peer_key"),
+                "peer_n": peer.get("peer_n"),
+                "basis": peer.get("basis"),
+                "families": shaped_families,
+            }
+        else:
+            out["peer_grade"] = dict(_MALFORMED)
+    else:
+        out["peer_grade"] = dict(_MALFORMED)
+
+    return out
+
+
+def _shape_ta_state(price_row: tuple[object, ...] | None) -> dict[str, object] | None:
+    """Block D: latest persisted TA indicators + derived-at-read signals.
+
+    `sma_50_200_regime` is the CURRENT 50-vs-200 relation (golden/death), NOT
+    a crossover event — same comparison as technical_analysis.py
+    compute_indicators, but equal-or-missing SMAs yield None (missing
+    evidence, not a third regime; the internal "none" string is not
+    forwarded). #1989 will persist the derived signals; the context key stays.
+    """
+    if price_row is None:
+        return None
+    close = _to_float(price_row[0])
+    sma_50 = _to_float(price_row[7])
+    sma_200 = _to_float(price_row[8])
+
+    price_vs_sma200: str | None = None
+    if close is not None and sma_200 is not None:
+        price_vs_sma200 = "above" if close > sma_200 else "below"
+
+    regime: str | None = None
+    if sma_50 is not None and sma_200 is not None and sma_50 != sma_200:
+        regime = "golden" if sma_50 > sma_200 else "death"
+
+    return {
+        "sma_50": sma_50,
+        "sma_200": sma_200,
+        "rsi_14": _to_float(price_row[9]),
+        "macd_histogram": _to_float(price_row[10]),
+        "atr_14": _to_float(price_row[11]),
+        "volatility_30d": _to_float(price_row[12]),
+        "price_vs_sma200": price_vs_sma200,
+        "sma_50_200_regime": regime,
+    }
+
+
 def _assemble_context(
     conn: psycopg.Connection[Any],
     instrument_id: int,
@@ -540,6 +779,78 @@ def _assemble_context(
     ).fetchall()
     risk_metrics = _shape_risk_metrics(risk_rows, RISK_METRICS_VERSION)
 
+    # #1987 Block A + D: one price_daily latest-row read serves both the
+    # price anchor and the TA state. Native currency close — matches the
+    # writer's targets-in-instrument-currency contract (#1845/#1906).
+    # Quotes are deliberately NOT read here (85 rows on dev; a second
+    # price source/currency would undermine the anchor contract).
+    price_row = conn.execute(
+        """
+        SELECT close, price_date, return_1w, return_1m, return_3m,
+               return_6m, return_1y, sma_50, sma_200, rsi_14,
+               macd_histogram, atr_14, volatility_30d
+        FROM price_daily
+        WHERE instrument_id = %(id)s
+          AND close IS NOT NULL
+        ORDER BY price_date DESC
+        LIMIT 1
+        """,
+        {"id": instrument_id},
+    ).fetchone()
+    agg_row: tuple[object, ...] | None = None
+    if price_row is not None and price_row[1] is not None:
+        # 52w window measured back from the LATEST price_date (not today)
+        # so a stale series yields an honest historical range.
+        agg_row = conn.execute(
+            """
+            SELECT MAX(COALESCE(high, close)) AS high_52w,
+                   MIN(COALESCE(low, close)) AS low_52w,
+                   COUNT(*) AS window_days
+            FROM price_daily
+            WHERE instrument_id = %(id)s
+              AND close IS NOT NULL
+              AND price_date >= %(cutoff)s
+            """,
+            {
+                "id": instrument_id,
+                "cutoff": price_row[1] - timedelta(days=_PRICE_ANCHOR_LOOKBACK_DAYS),
+            },
+        ).fetchone()
+    price_anchor = _shape_price_anchor(price_row, agg_row, instrument.get("currency"))
+    ta_state = _shape_ta_state(price_row)
+
+    # #1987 Block B: quotes-gated view (#1857 class) — absence is
+    # structural for most of the universe, statused not errored.
+    val_row = conn.execute(
+        """
+        SELECT current_price, price_as_of, market_cap_live, enterprise_value,
+               pe_ratio, pb_ratio, p_fcf_ratio, fcf_yield, ev_revenue,
+               ev_ebitda, debt_equity_ratio, net_margin, gross_margin,
+               operating_margin, roa, roe, dividend_yield, is_complete_ttm
+        FROM instrument_valuation
+        WHERE instrument_id = %(id)s
+        """,
+        {"id": instrument_id},
+    ).fetchone()
+    valuation = _shape_valuation(val_row)
+
+    # #1987 Block C: latest persisted IAR evidence (#1823). Refreshes only
+    # on compute_rankings — staleness is allowed and stamped (scored_at),
+    # mirroring risk_v1's as_of_date discipline.
+    score_row = conn.execute(
+        """
+        SELECT analytics_json, scored_at, model_version
+        FROM scores
+        WHERE instrument_id = %(id)s
+        ORDER BY scored_at DESC
+        LIMIT 1
+        """,
+        {"id": instrument_id},
+    ).fetchone()
+    analytics_evidence: dict[str, object] | None = None
+    if score_row is not None:
+        analytics_evidence = _shape_analytics_evidence(score_row[0], score_row[1], score_row[2])
+
     # #539: earnings_events + analyst_estimates retired with FMP. The
     # writer prompt's optional contextual fields fall back to None;
     # the writer system prompt already tolerates absent enrichment.
@@ -550,6 +861,10 @@ def _assemble_context(
         "news": news,
         "prior_thesis": prior_thesis,
         "risk_metrics": risk_metrics,
+        "price_anchor": price_anchor,
+        "valuation": valuation,
+        "analytics_evidence": analytics_evidence,
+        "ta_state": ta_state,
         "earnings_history": [],
         "analyst_estimates": None,
     }
@@ -574,6 +889,32 @@ You will be given a research context including:
   not percent); drawdown / var_5 / worst_day are SIGNED losses (negative). Basis
   is PRICE-RETURN (no dividends) — do not over-read CAGR for high-yield names.
   May be null when no metrics are computed.
+- `price_anchor`: latest persisted daily close in the instrument's NATIVE
+  currency (the same currency your per-share targets must use), its as-of
+  date (`price_date` — may lag; treat a stale anchor as approximate), the
+  trailing-52-week high/low with the observed window size
+  (`window_days_52w` — a small window means a short history; treat the
+  range as partial), and persisted simple returns (1w/1m/3m/6m/1y,
+  fractions). Null when no price history exists.
+- `valuation`: fundamentals-derived multiples (P/E, P/B, P/FCF, FCF yield,
+  EV/revenue, EV/EBITDA, margins, ROA/ROE, dividend yield) with their own
+  `price_as_of`. `available: false` with a reason means the surface is
+  structurally absent for this instrument — not a data error. Null fields
+  inside an available row are honest gaps (e.g. dual-class suppression) —
+  never invent multiples.
+- `analytics_evidence`: quality + positioning evidence — Piotroski F
+  (score/band), Altman Z (z/band), positioning signals (insider net 90d,
+  institutional 13F QoQ, short interest) and a sector peer grade — stamped
+  `as_of` (the scoring-run date; may lag — treat stale stamps as
+  approximate). `signal` fields are 0-1 normalized (higher = more
+  supportive of a long). A positioning entry without `asof` is undated —
+  cite it only as approximate. Any sub-block with `reason: "malformed"` is
+  absent evidence.
+- `ta_state`: latest persisted technical indicators (SMA 50/200, RSI-14,
+  MACD histogram, ATR-14, 30d volatility) plus `price_vs_sma200` and
+  `sma_50_200_regime`. The regime is the CURRENT 50d-vs-200d SMA relation
+  ("golden" = 50d above 200d), NOT a recent crossover event. Null
+  indicators mean insufficient history.
 
 Produce a JSON object with EXACTLY these fields:
 
@@ -605,6 +946,18 @@ Rules:
   number (a `benchmark_missing` beta is absent, not 0; a `partial_window` CAGR
   is provisional). When you cite a risk figure, name its {window_key,
   as_of_date, metric_version} so the claim stays reproducible.
+- Sanity-check buy_zone_low/high and base/bull/bear_value against
+  `price_anchor.close` and the 52-week range. State the implied
+  upside/downside from the current price to base_value explicitly in the
+  memo. A "buy" stance whose buy zone lies wholly above the current price,
+  or targets far outside the 52-week range, must be corrected or explicitly
+  justified in the memo.
+- Do NOT mechanically anchor targets to the current price — the anchor
+  grounds your numbers; valuation judgement produces them.
+- When `price_anchor` is null: leave buy_zone_low/high null regardless of
+  stance (an entry band is meaningless without a market price), and emit
+  base/bull/bear_value only if fundamentals give a defensible per-share
+  basis.
 - Separate facts from judgement. Be explicit about what must go right.
 - Respond with ONLY valid JSON. No explanation outside the JSON object.
 """
@@ -645,6 +998,14 @@ Rules:
   basis is price-return. Respect status flags (a non-`ok` metric is not precise;
   `benchmark_missing` beta is absent, not 0) and cite {window_key, as_of_date,
   metric_version}.
+- Attack target-vs-price inconsistency: a buy zone away from the current
+  `price_anchor.close`, an implied upside to base_value that is implausible
+  against the 52-week range, or targets that ignore the anchor entirely.
+- Flag adverse `analytics_evidence` (weak Piotroski or Altman band,
+  distressed positioning signals, poor peer grade) and adverse `ta_state`
+  (death regime, price below the 200d SMA) that the memo glossed over.
+  Respect the as-of stamps — stale evidence is approximate, and a
+  `reason: "malformed"` sub-block is absent, not adverse.
 - verdict must be exactly one of: "Strong challenge", "Moderate challenge", "Weak challenge"
 - Respond with ONLY valid JSON. No explanation outside the JSON object.
 """

--- a/docs/wiki/byo-llm.md
+++ b/docs/wiki/byo-llm.md
@@ -63,6 +63,18 @@ default always runs. Manual fire: Admin → Processes → Run now, or
 - A failed generation records `finish_reason` in `thesis_runs.error` —
   `length` means truncation (context/output window too small), `stop`
   with a JSON error means the model can't hold the schema.
+- **⚠ Ollama serves a 4,096-token context by default** — far below the
+  #1987 enriched writer input (~3-3.5k prompt tokens + ~1.2k system +
+  2,048 output budget), and with `--context-shift` it silently DROPS the
+  oldest prompt tokens instead of erroring: the writer loses the context
+  head with `finish_reason: stop` and no visible failure. Set
+  `OLLAMA_CONTEXT_LENGTH=16384` on the serve process (brew launchd:
+  `EnvironmentVariables` in `~/Library/LaunchAgents/homebrew.mxcl.ollama.plist`,
+  then `launchctl unload`/`load` — NOT `brew services restart`, which
+  regenerates the plist and wipes custom env). Verify live via
+  `curl -s localhost:11434/api/ps` → `context_length` after any request
+  (found 2026-07-10: llama-server ran `-c 4096` while fixtures already
+  exceeded it pre-#1987).
 - **deepseek-r1 needs the fence normalization** (benchmark 2026-07-09,
   #1919 PR-C): Ollama does not enforce `response_format=json_object`
   for it, and it often wraps otherwise schema-valid JSON in a

--- a/scripts/llm_eval_thesis.py
+++ b/scripts/llm_eval_thesis.py
@@ -119,6 +119,11 @@ class ModelReport:
     critic_rounds: int = 0
     critic_pass_first: int = 0
     critic_pass_retry: int = 0
+    # #1987 gate: critic truncations counted per-role — the shared
+    # finish_reasons Counter aggregates writer+critic and cannot gate on
+    # a critic-only "length" (a truncated critic stores a thesis WITHOUT
+    # critic_json in production, silently degrading the audit trail).
+    critic_length_failures: int = 0
     finish_reasons: Counter[str] = field(default_factory=Counter)
     enum_checked: int = 0
     enum_ok: int = 0
@@ -130,7 +135,11 @@ class ModelReport:
         return self.writer_pass_retry / self.writer_rounds if self.writer_rounds else 0.0
 
     def gate_passes(self) -> bool:
-        return self.writer_rounds >= GATE_MIN_ROUNDS and self.writer_pass_retry_rate >= GATE_MIN_PASS_RATE
+        return (
+            self.writer_rounds >= GATE_MIN_ROUNDS
+            and self.writer_pass_retry_rate >= GATE_MIN_PASS_RATE
+            and self.critic_length_failures == 0
+        )
 
 
 def _writer_enums_ok(data: dict[str, object]) -> bool:
@@ -277,6 +286,7 @@ def aggregate(model: str, rounds: list[RoundResult]) -> ModelReport:
             report.critic_rounds += 1
             report.critic_pass_first += rnd.pass_first
             report.critic_pass_retry += rnd.pass_with_retry
+            report.critic_length_failures += sum(1 for a in rnd.attempts if a.finish_reason == "length")
         for attempt in rnd.attempts:
             if attempt.finish_reason is not None:
                 report.finish_reasons[attempt.finish_reason] += 1
@@ -411,6 +421,7 @@ def print_report(report: ModelReport) -> None:
     print(f"critic pass (with retry):    {_fmt_rate(report.critic_pass_retry, report.critic_rounds)}")
     print(f"enum validity (parsed outputs): {_fmt_rate(report.enum_ok, report.enum_checked)}")
     print(f"finish_reason mix: {dict(report.finish_reasons)}")
+    print(f"critic length-failures: {report.critic_length_failures}")
     if report.durations_s:
         print(
             f"wall-clock per call: mean {statistics.mean(report.durations_s):.0f}s, "
@@ -422,7 +433,12 @@ def print_report(report: ModelReport) -> None:
     gate = "PASS" if report.gate_passes() else "FAIL"
     if report.writer_rounds < GATE_MIN_ROUNDS:
         gate = f"FAIL (insufficient sample: {report.writer_rounds} < {GATE_MIN_ROUNDS} writer rounds)"
-    print(f"go-live gate (writer with-retry >= {GATE_MIN_PASS_RATE:.0%} over >= {GATE_MIN_ROUNDS} rounds): {gate}")
+    elif report.critic_length_failures > 0:
+        gate = f"FAIL ({report.critic_length_failures} critic length-failure(s))"
+    print(
+        f"go-live gate (writer with-retry >= {GATE_MIN_PASS_RATE:.0%} over >= {GATE_MIN_ROUNDS} rounds"
+        f" AND critic length-failures == 0): {gate}"
+    )
 
 
 def _round_to_json(rnd: RoundResult) -> dict[str, object]:
@@ -484,6 +500,7 @@ def main(argv: list[str] | None = None) -> int:
                     "critic_rounds": r.critic_rounds,
                     "critic_pass_first": r.critic_pass_first,
                     "critic_pass_retry": r.critic_pass_retry,
+                    "critic_length_failures": r.critic_length_failures,
                     "finish_reasons": dict(r.finish_reasons),
                     "enum_ok": r.enum_ok,
                     "enum_checked": r.enum_checked,
@@ -497,7 +514,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"\nfull results -> {args.json_out}")
 
     if args.gate_model is not None and not reports[args.gate_model].gate_passes():
-        print(f"\nGATE FAIL: {args.gate_model} writer with-retry below {GATE_MIN_PASS_RATE:.0%}")
+        gate_report = reports[args.gate_model]
+        if gate_report.critic_length_failures > 0:
+            reason = f"{gate_report.critic_length_failures} critic length-failure(s)"
+        else:
+            reason = f"writer with-retry below {GATE_MIN_PASS_RATE:.0%}"
+        print(f"\nGATE FAIL: {args.gate_model} — {reason}")
         return 1
     return 0
 

--- a/tests/fixtures/llm_eval/AAPL.json
+++ b/tests/fixtures/llm_eval/AAPL.json
@@ -117,6 +117,125 @@
         }
       ]
     },
+    "price_anchor": {
+      "close": 291.22,
+      "price_date": "2026-06-12",
+      "currency": "USD",
+      "high_52w": 317.3,
+      "low_52w": 194.7873,
+      "window_days_52w": 248,
+      "return_1w": -0.054235,
+      "return_1m": -0.02514,
+      "return_3m": 0.1653,
+      "return_6m": 0.046531,
+      "return_1y": 0.46488
+    },
+    "valuation": {
+      "available": true,
+      "current_price": 315.85,
+      "price_as_of": "2026-07-09T20:16:31.212471+00:00",
+      "market_cap_live": 4632789254800.0,
+      "enterprise_value": 4671914254800.0,
+      "pe_ratio": 38.238498789346245,
+      "pb_ratio": 43.50404498783935,
+      "p_fcf_ratio": 89.86633408597145,
+      "fcf_yield": 0.011127637620594837,
+      "ev_revenue": 10.348869300596755,
+      "ev_ebitda": 31.026127339620135,
+      "debt_equity_ratio": 0.7953442074917129,
+      "net_margin": 0.2715188219084622,
+      "gross_margin": 0.47862405358827936,
+      "operating_margin": 0.32643396050876966,
+      "roa": 0.3303178273265747,
+      "roe": 1.1510362378041337,
+      "dividend_yield": 0.3292702232072186,
+      "is_complete_ttm": true
+    },
+    "analytics_evidence": {
+      "schema": "iar_v1",
+      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "model_version": "v1.3-balanced",
+      "piotroski": {
+        "score": 8,
+        "band": "strong",
+        "components_available": 9,
+        "suppressed": false,
+        "reason": null
+      },
+      "altman_z": {
+        "z": 2.3078,
+        "band": "grey",
+        "reason": null,
+        "suppressed": false
+      },
+      "positioning": {
+        "inst_13f_qoq": {
+          "asof": "2026-06-30",
+          "caveat": "<=135d stale",
+          "signal": 0.0,
+          "source": "ownership_institutions_observations",
+          "delta_shares_pct": -0.9959
+        },
+        "short_interest": {
+          "asof": "2026-06-15",
+          "caveat": "% shares outstanding (public float not ingested); bi-monthly",
+          "signal": 1.0,
+          "source": "finra_short_interest_current",
+          "falling": true,
+          "short_pct": 0.0098,
+          "days_to_cover": 2.76
+        },
+        "insider_net_90d": {
+          "asof": "2026-06-16",
+          "caveat": null,
+          "signal": 0.4897,
+          "source": "insider_transactions",
+          "net_shares": -302924.0,
+          "shares_outstanding": 14667688000.0
+        }
+      },
+      "peer_grade": {
+        "peer_key": "3",
+        "peer_n": 936,
+        "basis": "run_eligible_sector",
+        "families": {
+          "value": {
+            "hybrid": 0.1616,
+            "percentile": 0.0016
+          },
+          "quality": {
+            "hybrid": 0.8674,
+            "percentile": 0.9439
+          },
+          "momentum": {
+            "hybrid": 0.5935,
+            "percentile": 0.6255
+          },
+          "sentiment": {
+            "hybrid": 0.4846,
+            "percentile": 0.4487
+          },
+          "confidence": {
+            "hybrid": 0.5,
+            "percentile": 0.5
+          },
+          "turnaround": {
+            "hybrid": 0.478,
+            "percentile": 0.4268
+          }
+        }
+      }
+    },
+    "ta_state": {
+      "sma_50": 285.245202,
+      "sma_200": 266.077624,
+      "rsi_14": 43.9262,
+      "macd_histogram": -3.496412,
+      "atr_14": 7.751069,
+      "volatility_30d": 0.245026,
+      "price_vs_sma200": "above",
+      "sma_50_200_regime": "golden"
+    },
     "earnings_history": [],
     "analyst_estimates": null
   }

--- a/tests/fixtures/llm_eval/GME.json
+++ b/tests/fixtures/llm_eval/GME.json
@@ -119,7 +119,26 @@
         "importance_score": 0.5628
       }
     ],
-    "prior_thesis": null,
+    "prior_thesis": {
+      "version": 2,
+      "thesis_type": "turnaround",
+      "stance": "watch",
+      "confidence_score": 0.75,
+      "buy_zone_low": 20.0,
+      "buy_zone_high": 25.0,
+      "base_value": 22.5,
+      "bull_value": 30.0,
+      "bear_value": 15.0,
+      "break_conditions": [
+        "Failure to achieve FY26 EBITDA guidance (>$1.5B)",
+        "Material delay or underperformance in eBay integration",
+        "Sony PlayStation 5 launch cannibalizing digital content revenues",
+        "Shareholder approval not secured for $8B merger",
+        "3Y volatility exceeds 100% annualized"
+      ],
+      "memo_markdown": "### Business Quality & Catalysts\nGameStop's FY25 results demonstrate a structural turnaround, with revenue (+75% YoY) and EBITDA ($1.05B) nearing FY26 guidance. The merger with eBay, now shareholder-approved, positions the company to dominate physical-digital convergence. Management's focus on optimizing 20K+ stores while leveraging eBay's 200M active buyers creates a dual-channel growth engine. Improved gross margin (37% vs 18% in 2022) and operating margin (12% vs -60% in 2022) signal operational discipline.\n\n### Valuation & Metrics\nWith shares currently trading at 1.2x FY26 EBITDA (vs 0.4x in early 2023), the stock appears fairly valued relative to its earnings trajectory. Risk metrics highlight extreme volatility (3Y annualized vol: 97%, beta: 1.14), with 5% VaR at -32% (3Y window). Historical max drawdown of -78% (2022) remains a critical risk, though current fundamentals suggest improved resiliency versus the 2022-2023 collapse. Free cash flow of $1.2B and $2.1B net cash provide downside protection.\n\n### Risks & Stance\nDespite progress, execution risks remain: eBay integration (Q1 2025 target), PlayStation 5 lifecycle risks (2025-2026), and potential regulatory scrutiny of the merger. The 3Y volatility and 16% Calmar ratio (annualized return of 22%) suggest high-risk/high-reward dynamics. We maintain a 'watch' stance, with a tighter buy zone ($20-25) reflecting recent strength. Conviction increases to 75% from 65% due to EBITDA upgrades and merger approval, but we await Q1 2025 results before escalating to 'buy' status.",
+      "created_at": "2026-07-10T09:10:48.587112+00:00"
+    },
     "risk_metrics": {
       "metric_version": "risk_v1",
       "basis_note": "All returns/ratios are fractions (0.10 = 10%, not percent). Drawdown, var_5 and worst_day are signed losses (negative is a loss). Basis is price-return (no dividend reinvestment; total-return is future work), so do not over-read CAGR for high-yield names. A non-'ok' status means the metric is NOT a precise number: treat insufficient_history / partial_window as provisional, and benchmark_missing beta/excess as absent, not zero. Cite a risk figure as {window_key, as_of_date, metric_version}.",
@@ -191,6 +210,125 @@
           "calmar_status": "ok"
         }
       ]
+    },
+    "price_anchor": {
+      "close": 21.89,
+      "price_date": "2026-07-10",
+      "currency": "USD",
+      "high_52w": 29.65,
+      "low_52w": 19.8501,
+      "window_days_52w": 252,
+      "return_1w": -0.038647,
+      "return_1m": -0.020143,
+      "return_3m": -0.05809,
+      "return_6m": 0.03264,
+      "return_1y": -0.050544
+    },
+    "valuation": {
+      "available": true,
+      "current_price": 21.89,
+      "price_as_of": "2026-07-10T10:34:34.447923+00:00",
+      "market_cap_live": 9822043000.0,
+      "enterprise_value": 2424443000.0,
+      "pe_ratio": 16.33582089552239,
+      "pb_ratio": 1.6812521182451516,
+      "p_fcf_ratio": 29.504484830279363,
+      "fcf_yield": 0.03389315237166036,
+      "ev_revenue": 0.6494971603086155,
+      "ev_ebitda": 6.277687726566546,
+      "debt_equity_ratio": 0.0,
+      "net_margin": 0.20445777968281184,
+      "gross_margin": 0.3438705529361337,
+      "operating_margin": 0.1034612087441063,
+      "roa": 0.0695442989530084,
+      "roe": 0.13063795552968965,
+      "dividend_yield": null,
+      "is_complete_ttm": true
+    },
+    "analytics_evidence": {
+      "schema": "iar_v1",
+      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "model_version": "v1.3-balanced",
+      "piotroski": {
+        "score": 6,
+        "band": "neutral",
+        "components_available": 9,
+        "suppressed": false,
+        "reason": null
+      },
+      "altman_z": {
+        "z": 7.2796,
+        "band": "safe",
+        "reason": null,
+        "suppressed": false
+      },
+      "positioning": {
+        "inst_13f_qoq": {
+          "asof": "2026-06-30",
+          "caveat": "<=135d stale",
+          "signal": 0.0,
+          "source": "ownership_institutions_observations",
+          "delta_shares_pct": -0.9996
+        },
+        "short_interest": {
+          "asof": "2026-06-15",
+          "caveat": "% shares outstanding (public float not ingested); bi-monthly",
+          "signal": 0.7914,
+          "source": "finra_short_interest_current",
+          "falling": true,
+          "short_pct": 0.1272,
+          "days_to_cover": 8.34
+        },
+        "insider_net_90d": {
+          "asof": "2026-04-13",
+          "caveat": null,
+          "signal": 0.4956,
+          "source": "insider_transactions",
+          "net_shares": -3912.0,
+          "shares_outstanding": 448700000.0
+        }
+      },
+      "peer_grade": {
+        "peer_key": "7",
+        "peer_n": 312,
+        "basis": "run_eligible_sector",
+        "families": {
+          "value": {
+            "hybrid": 0.7302,
+            "percentile": 0.9984
+          },
+          "quality": {
+            "hybrid": 0.6516,
+            "percentile": 0.7099
+          },
+          "momentum": {
+            "hybrid": 0.4983,
+            "percentile": 0.4952
+          },
+          "sentiment": {
+            "hybrid": 0.6608,
+            "percentile": 0.8798
+          },
+          "confidence": {
+            "hybrid": 0.5,
+            "percentile": 0.5
+          },
+          "turnaround": {
+            "hybrid": 0.2613,
+            "percentile": 0.0545
+          }
+        }
+      }
+    },
+    "ta_state": {
+      "sma_50": 22.2382,
+      "sma_200": 22.882361,
+      "rsi_14": 48.1195,
+      "macd_histogram": 0.044977,
+      "atr_14": 0.664324,
+      "volatility_30d": 0.268541,
+      "price_vs_sma200": "below",
+      "sma_50_200_regime": "death"
     },
     "earnings_history": [],
     "analyst_estimates": null

--- a/tests/fixtures/llm_eval/HD.json
+++ b/tests/fixtures/llm_eval/HD.json
@@ -99,6 +99,108 @@
         }
       ]
     },
+    "price_anchor": {
+      "close": 317.48,
+      "price_date": "2026-06-09",
+      "currency": "USD",
+      "high_52w": 425.8402,
+      "low_52w": 289.0,
+      "window_days_52w": 248,
+      "return_1w": 0.021296,
+      "return_1m": -0.00022,
+      "return_3m": -0.108202,
+      "return_6m": -0.078466,
+      "return_1y": -0.129171
+    },
+    "valuation": {
+      "available": false,
+      "reason": "no_live_quote"
+    },
+    "analytics_evidence": {
+      "schema": "iar_v1",
+      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "model_version": "v1.3-balanced",
+      "piotroski": {
+        "score": 4,
+        "band": "neutral",
+        "components_available": 9,
+        "suppressed": false,
+        "reason": null
+      },
+      "altman_z": {
+        "z": 4.5368,
+        "band": "safe",
+        "reason": null,
+        "suppressed": false
+      },
+      "positioning": {
+        "inst_13f_qoq": {
+          "asof": "2026-06-30",
+          "caveat": "<=135d stale",
+          "signal": 0.0,
+          "source": "ownership_institutions_observations",
+          "delta_shares_pct": -0.9954
+        },
+        "short_interest": {
+          "asof": "2026-06-15",
+          "caveat": "% shares outstanding (public float not ingested); bi-monthly",
+          "signal": 1.0,
+          "source": "finra_short_interest_current",
+          "falling": false,
+          "short_pct": 0.0136,
+          "days_to_cover": 3.05
+        },
+        "insider_net_90d": {
+          "asof": "2026-05-21",
+          "caveat": null,
+          "signal": 0.5,
+          "source": "insider_transactions",
+          "net_shares": 0.0,
+          "shares_outstanding": 997000000.0
+        }
+      },
+      "peer_grade": {
+        "peer_key": "7",
+        "peer_n": 312,
+        "basis": "run_eligible_sector",
+        "families": {
+          "value": {
+            "hybrid": 0.5043,
+            "percentile": 0.5144
+          },
+          "quality": {
+            "hybrid": 0.6647,
+            "percentile": 0.726
+          },
+          "momentum": {
+            "hybrid": 0.4175,
+            "percentile": 0.367
+          },
+          "sentiment": {
+            "hybrid": 0.4779,
+            "percentile": 0.4263
+          },
+          "confidence": {
+            "hybrid": 0.5,
+            "percentile": 0.5
+          },
+          "turnaround": {
+            "hybrid": 0.4865,
+            "percentile": 0.4551
+          }
+        }
+      }
+    },
+    "ta_state": {
+      "sma_50": 321.9824,
+      "sma_200": 360.491066,
+      "rsi_14": 52.4555,
+      "macd_histogram": 1.222096,
+      "atr_14": 8.762203,
+      "volatility_30d": 0.263767,
+      "price_vs_sma200": "below",
+      "sma_50_200_regime": "death"
+    },
     "earnings_history": [],
     "analyst_estimates": null
   }

--- a/tests/fixtures/llm_eval/JPM.json
+++ b/tests/fixtures/llm_eval/JPM.json
@@ -180,6 +180,124 @@
         }
       ]
     },
+    "price_anchor": {
+      "close": 331.2,
+      "price_date": "2026-07-09",
+      "currency": "USD",
+      "high_52w": 343.16,
+      "low_52w": 279.0,
+      "window_days_52w": 252,
+      "return_1w": -0.007284,
+      "return_1m": 0.064952,
+      "return_3m": 0.070459,
+      "return_6m": 0.005662,
+      "return_1y": 0.171911
+    },
+    "valuation": {
+      "available": true,
+      "current_price": 336.12,
+      "price_as_of": "2026-07-10T10:34:30.970861+00:00",
+      "market_cap_live": null,
+      "enterprise_value": null,
+      "pe_ratio": 16.089995213020583,
+      "pb_ratio": null,
+      "p_fcf_ratio": null,
+      "fcf_yield": null,
+      "ev_revenue": null,
+      "ev_ebitda": null,
+      "debt_equity_ratio": 0.1869255407402524,
+      "net_margin": null,
+      "gross_margin": null,
+      "operating_margin": null,
+      "roa": 0.012019038970712022,
+      "roe": 0.16179354902510176,
+      "dividend_yield": 1.7553254789955968,
+      "is_complete_ttm": true
+    },
+    "analytics_evidence": {
+      "schema": "iar_v1",
+      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "model_version": "v1.3-balanced",
+      "piotroski": {
+        "score": null,
+        "band": null,
+        "components_available": null,
+        "suppressed": true,
+        "reason": "quality_signal_na_financials"
+      },
+      "altman_z": {
+        "z": null,
+        "reason": "quality_signal_na_financials",
+        "suppressed": true
+      },
+      "positioning": {
+        "inst_13f_qoq": {
+          "asof": "2026-06-30",
+          "caveat": "<=135d stale",
+          "signal": 0.0,
+          "source": "ownership_institutions_observations",
+          "delta_shares_pct": -0.997
+        },
+        "short_interest": {
+          "asof": "2026-06-15",
+          "caveat": "% shares outstanding (public float not ingested); bi-monthly",
+          "signal": 1.0,
+          "source": "finra_short_interest_current",
+          "falling": false,
+          "short_pct": 0.0112,
+          "days_to_cover": 3.55
+        },
+        "insider_net_90d": {
+          "asof": "2026-06-02",
+          "caveat": null,
+          "signal": 0.4593,
+          "source": "insider_transactions",
+          "net_shares": -219769.0,
+          "shares_outstanding": 2696200000.0
+        }
+      },
+      "peer_grade": {
+        "peer_key": "4",
+        "peer_n": 616,
+        "basis": "run_eligible_sector",
+        "families": {
+          "value": {
+            "hybrid": 0.8953,
+            "percentile": 0.9992
+          },
+          "quality": {
+            "hybrid": 0.2913,
+            "percentile": 0.1542
+          },
+          "momentum": {
+            "hybrid": 0.5855,
+            "percentile": 0.5544
+          },
+          "sentiment": {
+            "hybrid": 0.6528,
+            "percentile": 0.8693
+          },
+          "confidence": {
+            "hybrid": 0.5,
+            "percentile": 0.5
+          },
+          "turnaround": {
+            "hybrid": 0.6876,
+            "percentile": 0.892
+          }
+        }
+      }
+    },
+    "ta_state": {
+      "sma_50": 314.925,
+      "sma_200": 308.435779,
+      "rsi_14": 56.8793,
+      "macd_histogram": -0.694331,
+      "atr_14": 7.800537,
+      "volatility_30d": 0.212164,
+      "price_vs_sma200": "above",
+      "sma_50_200_regime": "golden"
+    },
     "earnings_history": [],
     "analyst_estimates": null
   }

--- a/tests/fixtures/llm_eval/MSFT.json
+++ b/tests/fixtures/llm_eval/MSFT.json
@@ -180,6 +180,125 @@
         }
       ]
     },
+    "price_anchor": {
+      "close": 383.74,
+      "price_date": "2026-07-09",
+      "currency": "USD",
+      "high_52w": 560.8874,
+      "low_52w": 349.21,
+      "window_days_52w": 252,
+      "return_1w": -0.016304,
+      "return_1m": -0.050149,
+      "return_3m": 0.027086,
+      "return_6m": -0.196176,
+      "return_1y": -0.236255
+    },
+    "valuation": {
+      "available": true,
+      "current_price": 390.1,
+      "price_as_of": "2026-07-02T23:49:52.079472+00:00",
+      "market_cap_live": 2898052900000.0,
+      "enterprise_value": 2906209900000.0,
+      "pe_ratio": 23.220238095238095,
+      "pb_ratio": 6.993927846570793,
+      "p_fcf_ratio": 39.74508886938395,
+      "fcf_yield": 0.025160341276033987,
+      "ev_revenue": 9.131185805896196,
+      "ev_ebitda": 19.510394946192527,
+      "debt_equity_ratio": 0.09716507347351502,
+      "net_margin": 0.39342325613545603,
+      "gross_margin": 0.6830928165442874,
+      "operating_margin": 0.4680164512855316,
+      "roa": 0.1803672568666202,
+      "roe": 0.30218622621975205,
+      "dividend_yield": 0.9125865162778775,
+      "is_complete_ttm": true
+    },
+    "analytics_evidence": {
+      "schema": "iar_v1",
+      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "model_version": "v1.3-balanced",
+      "piotroski": {
+        "score": 6,
+        "band": "neutral",
+        "components_available": 9,
+        "suppressed": false,
+        "reason": null
+      },
+      "altman_z": {
+        "z": 4.4853,
+        "band": "safe",
+        "reason": null,
+        "suppressed": false
+      },
+      "positioning": {
+        "inst_13f_qoq": {
+          "asof": "2026-06-30",
+          "caveat": "<=135d stale",
+          "signal": 0.0,
+          "source": "ownership_institutions_observations",
+          "delta_shares_pct": -0.9957
+        },
+        "short_interest": {
+          "asof": "2026-06-15",
+          "caveat": "% shares outstanding (public float not ingested); bi-monthly",
+          "signal": 1.0,
+          "source": "finra_short_interest_current",
+          "falling": false,
+          "short_pct": 0.0128,
+          "days_to_cover": 2.61
+        },
+        "insider_net_90d": {
+          "asof": "2026-06-15",
+          "caveat": null,
+          "signal": 0.4984,
+          "source": "insider_transactions",
+          "net_shares": -23762.312,
+          "shares_outstanding": 7429000000.0
+        }
+      },
+      "peer_grade": {
+        "peer_key": "8",
+        "peer_n": 347,
+        "basis": "run_eligible_sector",
+        "families": {
+          "value": {
+            "hybrid": 0.3561,
+            "percentile": 0.0389
+          },
+          "quality": {
+            "hybrid": 0.9149,
+            "percentile": 0.9496
+          },
+          "momentum": {
+            "hybrid": 0.4566,
+            "percentile": 0.4568
+          },
+          "sentiment": {
+            "hybrid": 0.6032,
+            "percentile": 0.7795
+          },
+          "confidence": {
+            "hybrid": 0.5,
+            "percentile": 0.5
+          },
+          "turnaround": {
+            "hybrid": 0.4767,
+            "percentile": 0.4222
+          }
+        }
+      }
+    },
+    "ta_state": {
+      "sma_50": 402.6666,
+      "sma_200": 440.919094,
+      "rsi_14": 46.7925,
+      "macd_histogram": 2.493489,
+      "atr_14": 11.504433,
+      "volatility_30d": 0.372588,
+      "price_vs_sma200": "below",
+      "sma_50_200_regime": "death"
+    },
     "earnings_history": [],
     "analyst_estimates": null
   }

--- a/tests/test_llm_eval_thesis.py
+++ b/tests/test_llm_eval_thesis.py
@@ -253,3 +253,29 @@ def test_gate_requires_minimum_sample() -> None:
     report = aggregate("m", rounds)
     assert report.writer_pass_retry_rate == 1.0
     assert not report.gate_passes()
+
+
+def test_gate_fails_on_critic_length_failure() -> None:
+    # #1987: a truncated critic stores a thesis WITHOUT critic_json in
+    # production — the gate must fail on ANY critic finish_reason == "length",
+    # even with a perfect writer score.
+    rounds = [RoundResult("AAPL", "writer", [_attempt(True)])] * 10 + [
+        RoundResult("IEP", "critic", [_attempt(False, category="schema_fail", finish="length")])
+    ]
+    report = aggregate("m", rounds)
+    assert report.writer_pass_retry_rate == 1.0
+    assert report.critic_length_failures == 1
+    assert not report.gate_passes()
+
+
+def test_writer_length_does_not_trip_critic_gate() -> None:
+    # Writer truncations are covered by the writer pass-rate gate; the
+    # critic-length counter must count CRITIC attempts only.
+    rounds = (
+        [RoundResult("AAPL", "writer", [_attempt(True)])] * 9
+        + [RoundResult("GME", "writer", [_attempt(False, category="schema_fail", finish="length"), _attempt(True)])]
+        + [RoundResult("AAPL", "critic", [_attempt(True)])]
+    )
+    report = aggregate("m", rounds)
+    assert report.critic_length_failures == 0
+    assert report.gate_passes()

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -27,7 +27,11 @@ from app.services.thesis import (
     ThesisResult,
     _call_critic,
     _call_writer,
+    _shape_analytics_evidence,
+    _shape_price_anchor,
     _shape_risk_metrics,
+    _shape_ta_state,
+    _shape_valuation,
     _to_float,
     _validate_critic_output,
     _validate_writer_output,
@@ -438,6 +442,25 @@ def _make_two_call_client(writer_json: dict, critic_json: dict) -> _FakeLLMClien
     return _FakeLLMClient([_completion(writer_json), _completion(critic_json)])
 
 
+class TestAssembleContextEnrichment:
+    """#1987: the four new context keys must be present with honest defaults
+    when the underlying surfaces are empty (the _make_conn mock returns no
+    rows for price_daily / instrument_valuation / scores). The populated
+    paths are covered by the shaper table-tests above; the real queries are
+    exercised on dev by the eval-harness fixture recapture (spec §Eval gate).
+    """
+
+    def test_empty_surfaces_yield_honest_absences(self) -> None:
+        from app.services.thesis import _assemble_context
+
+        context = _assemble_context(_make_conn(), instrument_id=1)
+
+        assert context["price_anchor"] is None
+        assert context["ta_state"] is None
+        assert context["valuation"] == {"available": False, "reason": "no_live_quote"}
+        assert context["analytics_evidence"] is None
+
+
 class TestGenerateThesis:
     """
     All tests in this class patch `_utcnow` to a fixed value so that
@@ -731,3 +754,282 @@ class TestShapeRiskMetrics:
     def test_as_of_none_tolerated(self) -> None:
         out = _shape_risk_metrics([_risk_row(as_of=None)], "risk_v1")
         assert _windows(out)[0]["as_of_date"] is None
+
+
+# ---------------------------------------------------------------------------
+# #1987 context blocks — pure row-shaping
+# (spec: docs/specs/thesis/2026-07-10-thesis-context-enrichment.md)
+# ---------------------------------------------------------------------------
+
+# Shared price_daily latest-row shape (13 cols) — see thesis.py column-order
+# comment: 0 close, 1 price_date, 2-6 returns 1w/1m/3m/6m/1y, 7 sma_50,
+# 8 sma_200, 9 rsi_14, 10 macd_histogram, 11 atr_14, 12 volatility_30d.
+
+
+def _price_row(
+    *,
+    close: object = 24.5,
+    price_date: object = date(2026, 7, 9),
+    sma_50: object = 23.0,
+    sma_200: object = 21.0,
+) -> tuple[object, ...]:
+    return (close, price_date, 0.01, 0.03, -0.05, 0.12, 0.40, sma_50, sma_200, 55.2, 0.4, 1.1, 0.02)
+
+
+class TestShapePriceAnchor:
+    def test_no_price_history_returns_none(self) -> None:
+        # No rows → None — never a fabricated anchor.
+        assert _shape_price_anchor(None, None, "USD") is None
+
+    def test_shapes_anchor_with_52w_range(self) -> None:
+        out = _shape_price_anchor(_price_row(), (30.0, 15.5, 251), "USD")
+        assert out is not None
+        assert out["close"] == pytest.approx(24.5)
+        assert out["price_date"] == "2026-07-09"
+        assert out["currency"] == "USD"
+        assert out["high_52w"] == pytest.approx(30.0)
+        assert out["low_52w"] == pytest.approx(15.5)
+        assert out["window_days_52w"] == 251
+        assert out["return_1y"] == pytest.approx(0.40)
+
+    def test_thin_window_stays_honest(self) -> None:
+        # 133-row history (WLYB class): range present, window size tells the
+        # writer the range is partial — never padded to a full year.
+        out = _shape_price_anchor(_price_row(), (12.0, 8.0, 133), "USD")
+        assert out is not None
+        assert out["window_days_52w"] == 133
+
+    def test_missing_agg_row_keeps_nulls(self) -> None:
+        out = _shape_price_anchor(_price_row(), None, "USD")
+        assert out is not None
+        assert out["high_52w"] is None
+        assert out["low_52w"] is None
+        assert out["window_days_52w"] == 0
+
+    def test_null_returns_stay_none(self) -> None:
+        row = (24.5, date(2026, 7, 9), None, None, None, None, None, None, None, None, None, None, None)
+        out = _shape_price_anchor(row, (25.0, 20.0, 40), "GBP")
+        assert out is not None
+        assert out["return_1w"] is None
+        assert out["return_1y"] is None
+
+
+# instrument_valuation row shape (18 cols) — see thesis.py _VALUATION_FIELDS.
+
+
+def _valuation_row(**overrides: object) -> tuple[object, ...]:
+    base: list[object] = [
+        212.4,  # current_price
+        datetime(2026, 7, 9, 20, 0, tzinfo=UTC),  # price_as_of
+        3.1e12,
+        3.2e12,
+        32.1,
+        45.0,
+        28.0,
+        0.035,
+        8.1,
+        24.0,
+        1.8,
+        0.25,
+        0.46,
+        0.30,
+        0.28,
+        1.5,
+        0.005,
+        True,  # is_complete_ttm
+    ]
+    row = dict(enumerate(base))
+    for name, val in overrides.items():
+        idx = {"current_price": 0, "pe_ratio": 4, "fcf_yield": 7, "market_cap_live": 2}[name]
+        row[idx] = val
+    return tuple(row[i] for i in range(18))
+
+
+class TestShapeValuation:
+    def test_absent_row_is_statused_not_errored(self) -> None:
+        # Quotes-gated view (#1857 class): absence is structural.
+        out = _shape_valuation(None)
+        assert out == {"available": False, "reason": "no_live_quote"}
+
+    def test_present_row_shapes_all_fields(self) -> None:
+        out = _shape_valuation(_valuation_row())
+        assert out["available"] is True
+        assert out["current_price"] == pytest.approx(212.4)
+        assert out["pe_ratio"] == pytest.approx(32.1)
+        assert out["price_as_of"] == "2026-07-09T20:00:00+00:00"
+        assert out["is_complete_ttm"] is True
+
+    def test_dual_class_nulls_pass_through(self) -> None:
+        # #1664 suppression: NULL shares-distorted columns stay None.
+        out = _shape_valuation(_valuation_row(market_cap_live=None, fcf_yield=None))
+        assert out["available"] is True
+        assert out["market_cap_live"] is None
+        assert out["fcf_yield"] is None
+
+
+# analytics_json (iar_v1) fixture mirroring the persisted shape.
+
+
+def _analytics() -> dict[str, Any]:
+    return {
+        "schema": "iar_v1",
+        "piotroski": {
+            "score": 6,
+            "band": "neutral",
+            "reason": None,
+            "suppressed": False,
+            "components_available": 9,
+            "components": {"cfo_positive": True},
+        },
+        "altman_z": {"z": 7.28, "band": "safe", "reason": None, "suppressed": False},
+        "positioning": {
+            "insider_net_90d": {"signal": 0.4956, "net_shares": -3912.0, "asof": "2026-04-13"},
+            "inst_13f_qoq": {"signal": 0.0, "delta_shares_pct": -0.9996, "asof": "2026-06-30"},
+            "short_interest": {"signal": 0.7914, "short_pct": 0.1272, "falling": True},
+        },
+        "peer_grade": {
+            "peer_key": "7",
+            "peer_n": 312,
+            "basis": "run_eligible_sector",
+            "families": {"value": {"hybrid": 0.73, "absolute": 0.62, "percentile": 0.99}},
+        },
+    }
+
+
+_SCORED_AT = datetime(2026, 7, 9, 3, 37, tzinfo=UTC)
+
+
+class TestShapeAnalyticsEvidence:
+    def test_null_analytics_is_absent_not_malformed(self) -> None:
+        # scores row exists, analytics_json NULL → absent evidence.
+        assert _shape_analytics_evidence(None, _SCORED_AT, "v1.3") is None
+
+    def test_non_dict_analytics_is_malformed_not_absent(self) -> None:
+        # Present-but-wrong-type ≠ absent (spec §Block C distinction).
+        assert _shape_analytics_evidence(["not", "a", "dict"], _SCORED_AT, "v1.3") == {"reason": "malformed"}
+
+    def test_compaction_drops_components_and_absolute(self) -> None:
+        out = _shape_analytics_evidence(_analytics(), _SCORED_AT, "v1.3-balanced")
+        assert out is not None
+        assert out["as_of"] == "2026-07-09T03:37:00+00:00"
+        assert out["model_version"] == "v1.3-balanced"
+        piotroski = out["piotroski"]
+        assert isinstance(piotroski, dict)
+        assert piotroski["score"] == 6
+        assert "components" not in piotroski
+        peer = out["peer_grade"]
+        assert isinstance(peer, dict)
+        families = peer["families"]
+        assert isinstance(families, dict)
+        assert families["value"] == {"hybrid": 0.73, "percentile": 0.99}
+
+    def test_undated_positioning_entry_kept(self) -> None:
+        # 818/3,906 dev rows: non-null insider signal, no asof — forwarded.
+        out = _shape_analytics_evidence(_analytics(), _SCORED_AT, "v1.3")
+        assert out is not None
+        positioning = out["positioning"]
+        assert isinstance(positioning, dict)
+        assert positioning["short_interest"]["signal"] == pytest.approx(0.7914)
+        assert "asof" not in positioning["short_interest"]
+
+    def test_out_of_range_signal_fails_closed(self) -> None:
+        analytics = _analytics()
+        analytics["positioning"]["insider_net_90d"]["signal"] = 1.2
+        out = _shape_analytics_evidence(analytics, _SCORED_AT, "v1.3")
+        assert out is not None
+        positioning = out["positioning"]
+        assert isinstance(positioning, dict)
+        assert positioning["insider_net_90d"] == {"reason": "malformed"}
+        # Sibling entries unaffected.
+        assert positioning["inst_13f_qoq"]["signal"] == pytest.approx(0.0)
+
+    def test_malformed_sub_block_fails_closed(self) -> None:
+        analytics = _analytics()
+        analytics["piotroski"] = "garbage"
+        analytics["peer_grade"] = 42
+        out = _shape_analytics_evidence(analytics, _SCORED_AT, "v1.3")
+        assert out is not None
+        assert out["piotroski"] == {"reason": "malformed"}
+        assert out["peer_grade"] == {"reason": "malformed"}
+        # Well-formed siblings still forwarded.
+        altman = out["altman_z"]
+        assert isinstance(altman, dict)
+        assert altman["band"] == "safe"
+
+    def test_scored_at_none_tolerated(self) -> None:
+        out = _shape_analytics_evidence(_analytics(), None, "v1.3")
+        assert out is not None
+        assert out["as_of"] is None
+
+    def test_bool_signal_fails_closed(self) -> None:
+        # bool is an int subclass — {"signal": true} must be malformed, not 1.0.
+        analytics = _analytics()
+        analytics["positioning"]["short_interest"]["signal"] = True
+        out = _shape_analytics_evidence(analytics, _SCORED_AT, "v1.3")
+        assert out is not None
+        positioning = out["positioning"]
+        assert isinstance(positioning, dict)
+        assert positioning["short_interest"] == {"reason": "malformed"}
+
+    def test_non_dict_families_marks_peer_grade_malformed(self) -> None:
+        # Corruption ≠ missing evidence: families must be a dict (empty OK).
+        analytics = _analytics()
+        analytics["peer_grade"]["families"] = "corrupt"
+        out = _shape_analytics_evidence(analytics, _SCORED_AT, "v1.3")
+        assert out is not None
+        assert out["peer_grade"] == {"reason": "malformed"}
+
+    def test_non_dict_family_entry_marked_malformed(self) -> None:
+        analytics = _analytics()
+        analytics["peer_grade"]["families"]["quality"] = 0.7
+        out = _shape_analytics_evidence(analytics, _SCORED_AT, "v1.3")
+        assert out is not None
+        peer = out["peer_grade"]
+        assert isinstance(peer, dict)
+        families = peer["families"]
+        assert isinstance(families, dict)
+        assert families["quality"] == {"reason": "malformed"}
+        assert families["value"] == {"hybrid": 0.73, "percentile": 0.99}
+
+    def test_empty_families_dict_is_not_malformed(self) -> None:
+        # absolute_only rows persisted outside a run cohort have families={}.
+        analytics = _analytics()
+        analytics["peer_grade"]["families"] = {}
+        out = _shape_analytics_evidence(analytics, _SCORED_AT, "v1.3")
+        assert out is not None
+        peer = out["peer_grade"]
+        assert isinstance(peer, dict)
+        assert peer["families"] == {}
+
+
+class TestShapeTaState:
+    def test_no_price_history_returns_none(self) -> None:
+        assert _shape_ta_state(None) is None
+
+    def test_golden_regime_and_price_above(self) -> None:
+        out = _shape_ta_state(_price_row(close=24.5, sma_50=23.0, sma_200=21.0))
+        assert out is not None
+        assert out["sma_50_200_regime"] == "golden"
+        assert out["price_vs_sma200"] == "above"
+        assert out["rsi_14"] == pytest.approx(55.2)
+
+    def test_death_regime_and_price_below(self) -> None:
+        out = _shape_ta_state(_price_row(close=18.0, sma_50=20.0, sma_200=22.0))
+        assert out is not None
+        assert out["sma_50_200_regime"] == "death"
+        assert out["price_vs_sma200"] == "below"
+
+    def test_equal_smas_yield_none_not_a_third_regime(self) -> None:
+        # Internal compute_indicators emits "none" here; the context contract
+        # is golden/death/null only (spec §Block D).
+        out = _shape_ta_state(_price_row(sma_50=21.0, sma_200=21.0))
+        assert out is not None
+        assert out["sma_50_200_regime"] is None
+
+    def test_missing_smas_yield_none_signals(self) -> None:
+        # <200d history: sma_200 NULL → both derived signals absent.
+        out = _shape_ta_state(_price_row(sma_50=None, sma_200=None))
+        assert out is not None
+        assert out["sma_50_200_regime"] is None
+        assert out["price_vs_sma200"] is None
+        assert out["sma_50"] is None

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -961,6 +961,13 @@ class TestShapeAnalyticsEvidence:
         assert out is not None
         assert out["as_of"] is None
 
+    def test_unknown_schema_fails_closed(self) -> None:
+        # A future iar_v2 must not be compacted under v1 assumptions.
+        analytics = _analytics()
+        analytics["schema"] = "iar_v2"
+        out = _shape_analytics_evidence(analytics, _SCORED_AT, "v1.3")
+        assert out == {"reason": "unsupported_schema", "schema": "iar_v2"}
+
     def test_bool_signal_fails_closed(self) -> None:
         # bool is an int subclass — {"signal": true} must be malformed, not 1.0.
         analytics = _analytics()


### PR DESCRIPTION
## What

Implements the #1987 spec (docs/specs/thesis/2026-07-10-thesis-context-enrichment.md, merged `426c955c` PR #1998, incl. the settled 'Thesis prompt budget' v2 amendment). The writer previously priced buy zones + bear/base/bull targets with NO current price in context (P0 correctness). Four new `_assemble_context` blocks, all following the #1632 evidence discipline (statuses verbatim, as-of stamps, missing data stays missing):

- **`price_anchor`** — latest `price_daily` close (native currency — matches the targets-in-instrument-currency contract), `price_date`, 52w high/low over trailing 365d from the LATEST price_date (`window_days_52w` keeps thin histories honest), persisted returns 1w-1y. Quotes deliberately excluded (85 rows dev; second price source/currency). No rows → null.
- **`valuation`** — `instrument_valuation` row; absent → `{available:false, reason:no_live_quote}` (view is quotes-gated, #1857 class — absence structural, fix NOT taken here). #1664 dual-class NULLs pass through.
- **`analytics_evidence`** — latest `scores.analytics_json` (iar_v1) compacted (piotroski sans 9 component booleans; peer families {hybrid, percentile} sans absolute), **fail-closed** per sub-block (`{reason:malformed}` ≠ absent; bool signals rejected; non-dict families/entries marked malformed), stamped `scored_at` + `model_version` (refreshes only on compute_rankings — staleness stamped, mirroring risk_v1).
- **`ta_state`** — latest persisted TA columns + derived `price_vs_sma200` and `sma_50_200_regime` (CURRENT 50-vs-200 relation, named regime NOT crossover; golden/death/null, equal SMAs → null).

Plus: `_PROMPT_VERSION` v1→v2 (new theses stamp v2); writer/critic prompt rules (target-vs-price sanity, implied-upside statement, no mechanical anchoring, no-anchor → buy zone null, undated/stale evidence approximate-only); `_MAX_TOKENS_CRITIC` 1024→2048 (length-failed live on IEP 2026-07-10, thesis stored without critic_json); eval harness gains per-role `critic_length_failures` in report + JSON + gate (== 0 required).

## Security model

No new endpoints/schema/outbound I/O. Read-only queries on existing tables inside `_assemble_context`, behind the existing auth-gated thesis routers (#1919 PR-A). #293 commit-before-LLM ordering preserved (assembly still precedes the commit; regression test untouched and green). #273 triggers untouched.

## Verification

- Gates: ruff + format + pyright (0 errors) + fast tier **4,918 passed** + smoke **127 passed**; targeted `test_thesis.py` + `test_llm_eval_thesis.py` **104 passed** (19 new: 4 shaper table-test classes incl. fail-closed/thin-window/equal-SMA/bool-signal cases + `_assemble_context` honest-absence test + 2 critic-gate tests).
- Fixtures recaptured on dev DB (real queries exercised): +49-79% chars — AAPL 5,670→9,068, GME 7,123→12,717, HD 3,777→6,474, JPM 6,757→10,044, MSFT 6,717→10,121 (≈+1-1.7k tokens; above the spec's ~+700 estimate — recorded honestly, the live eval gate below is the decider). GME fixture eyeballed: close 21.89 @2026-07-10, 52w 19.85-29.65 (252d), death regime + below-200d, P/E 16.3, compacted analytics — all sane.
- **Eval gate (spec §Eval gate): RUNNING on qwen3:14b** (writer ≥9/10 with retry + critic length-failures == 0 @2048). Results will be posted as a PR comment BEFORE merge — this PR must not merge without a recorded GATE PASS.
- Codex ckpt-2 run on the diff: 1 MED (bool-signal leak via int subclass + silent peer-families degrade) — FIXED in this commit with 4 regression tests.

## Tradeoffs

- Analytics staleness accepted + stamped (populates only on compute_rankings).
- Valuation block near-empty universe-wide until #1857 (operator-gated) — statused absence by design.
- `sma_50_200_regime` context key diverges from internal `trend_sma_cross` name deliberately (regime ≠ crossover event; #1989 will persist under the internal name).

Closes #1987

🤖 Generated with [Claude Code](https://claude.com/claude-code)