### PR TITLE
fix(#2000): ThesisPane polish — anchored value band, provenance line, memo typography

### DIFF
--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -106,6 +106,12 @@ class ThesisDetail(BaseModel):
     memo_markdown: str
     critic_json: dict[str, object] | None
     created_at: datetime
+    # Provenance (#2000): stamped at insert since #1919 PR-A; nullable —
+    # pre-#1919 rows have no attribution. Surfaced so the operator can
+    # tell an anchored v2 memo from a blind-priced v1 on the page.
+    prompt_version: str | None = None
+    model: str | None = None
+    provider: str | None = None
     is_stale: bool | None = None
     stale_reason: str | None = None
 
@@ -199,6 +205,9 @@ def _parse_thesis(row: dict[str, object]) -> ThesisDetail:
         memo_markdown=row["memo_markdown"],  # type: ignore[arg-type]
         critic_json=row["critic_json"],  # type: ignore[arg-type]
         created_at=row["created_at"],  # type: ignore[arg-type]
+        prompt_version=row.get("prompt_version"),  # type: ignore[arg-type]
+        model=row.get("model"),  # type: ignore[arg-type]
+        provider=row.get("provider"),  # type: ignore[arg-type]
     )
 
 
@@ -208,7 +217,7 @@ _THESIS_COLUMNS = """
     t.buy_zone_low, t.buy_zone_high,
     t.base_value, t.bull_value, t.bear_value,
     t.break_conditions_json, t.memo_markdown, t.critic_json,
-    t.created_at
+    t.created_at, t.prompt_version, t.model, t.provider
 """
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1241,6 +1241,12 @@ export interface ThesisDetail {
   memo_markdown: string;
   critic_json: Record<string, unknown> | null;
   created_at: string;
+  /** Provenance (#2000): stamped at insert since #1919 PR-A; null on
+   *  pre-#1919 rows. prompt_version "v1" memos priced targets with NO
+   *  current price in context (#1987) — the pane surfaces this. */
+  prompt_version?: string | null;
+  model?: string | null;
+  provider?: string | null;
   /** Server-computed staleness (#1902 single source: find_stale_instruments).
    *  Populated only on the latest-thesis GET; null on history/POST payloads. */
   is_stale?: boolean | null;

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -310,11 +310,11 @@ export function DensityGrid({
       {(thesis !== null || thesisErrored) && (
         <div className="col-span-12 lg:col-span-4">
           <ThesisPane
-              thesis={thesis}
-              errored={thesisErrored}
-              currentPrice={summary.price?.current ?? null}
-              currency={summary.identity.currency}
-            />
+            thesis={thesis}
+            errored={thesisErrored}
+            currentPrice={summary.price?.current ?? null}
+            currency={summary.identity.currency}
+          />
         </div>
       )}
       {dividendProviders.length > 0 && (

--- a/frontend/src/components/instrument/DensityGrid.tsx
+++ b/frontend/src/components/instrument/DensityGrid.tsx
@@ -226,7 +226,12 @@ export function DensityGrid({
         {/* Zone F — Operator */}
         {thesis !== null || thesisErrored ? (
           <div className="col-span-12">
-            <ThesisPane thesis={thesis} errored={thesisErrored} />
+            <ThesisPane
+              thesis={thesis}
+              errored={thesisErrored}
+              currentPrice={summary.price?.current ?? null}
+              currency={summary.identity.currency}
+            />
           </div>
         ) : null}
       </div>
@@ -281,7 +286,12 @@ export function DensityGrid({
         {/* Zone E — Operator */}
         {thesis !== null || thesisErrored ? (
           <div className="col-span-12">
-            <ThesisPane thesis={thesis} errored={thesisErrored} />
+            <ThesisPane
+              thesis={thesis}
+              errored={thesisErrored}
+              currentPrice={summary.price?.current ?? null}
+              currency={summary.identity.currency}
+            />
           </div>
         ) : null}
       </div>
@@ -299,7 +309,12 @@ export function DensityGrid({
       </div>
       {(thesis !== null || thesisErrored) && (
         <div className="col-span-12 lg:col-span-4">
-          <ThesisPane thesis={thesis} errored={thesisErrored} />
+          <ThesisPane
+              thesis={thesis}
+              errored={thesisErrored}
+              currentPrice={summary.price?.current ?? null}
+              currency={summary.identity.currency}
+            />
         </div>
       )}
       {dividendProviders.length > 0 && (

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -107,6 +107,13 @@ describe("ThesisPane", () => {
     expect(screen.getByText("pre-anchor memo")).toBeInTheDocument();
   });
 
+  it("does NOT flag future prompt versions (v3+) as pre-anchor", () => {
+    // Blind-list is explicit {null, v1}; later versions inherit the anchor.
+    const thesis = { ...FIXTURE, prompt_version: "v3" } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.queryByText("pre-anchor memo")).not.toBeInTheDocument();
+  });
+
   it("shows current price with currency and implied upside to base", () => {
     render(
       <ThesisPane thesis={FIXTURE} errored={false} currentPrice="16.00" currency="USD" />,

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -7,11 +7,22 @@ import type { ThesisDetail } from "@/api/types";
 const FIXTURE = {
   thesis_id: 1,
   instrument_id: 1,
-  memo_markdown: "Buy on weakness.",
-  bear_value: "10",
-  base_value: "20",
-  bull_value: "30",
+  thesis_version: 3,
+  thesis_type: "turnaround",
+  stance: "watch",
+  confidence_score: 0.65,
+  buy_zone_low: null,
+  buy_zone_high: null,
+  bear_value: 10,
+  base_value: 20,
+  bull_value: 30,
   break_conditions_json: ["Lose 50% market share"],
+  memo_markdown: "Buy on weakness.",
+  critic_json: null,
+  created_at: "2026-07-10T12:00:00+00:00",
+  prompt_version: "v2",
+  model: "qwen3:14b",
+  provider: "openai_compatible",
 } as unknown as ThesisDetail;
 
 describe("ThesisPane", () => {
@@ -37,12 +48,13 @@ describe("ThesisPane", () => {
   it("renders the buy zone alongside bear/base/bull (#1902)", () => {
     const thesis = {
       ...FIXTURE,
+      stance: "buy",
       buy_zone_low: 15,
       buy_zone_high: 18,
     } as unknown as ThesisDetail;
     render(<ThesisPane thesis={thesis} errored={false} />);
     expect(screen.getByText("Buy zone")).toBeInTheDocument();
-    expect(screen.getByText("15 – 18")).toBeInTheDocument();
+    expect(screen.getByText("15.00 – 18.00")).toBeInTheDocument();
   });
 
   it("renders the critic verdict, summary and key risks (#1902)", () => {
@@ -70,5 +82,78 @@ describe("ThesisPane", () => {
     } as unknown as ThesisDetail;
     render(<ThesisPane thesis={thesis} errored={false} />);
     expect(screen.getByText("no critic")).toBeInTheDocument();
+  });
+
+  // --- #2000 polish: provenance, price anchor, blind-memo flag ------------
+
+  it("renders stance badge, provenance line and no pre-anchor chip on v2", () => {
+    render(<ThesisPane thesis={FIXTURE} errored={false} />);
+    expect(screen.getByText("watch")).toBeInTheDocument();
+    expect(screen.getByText("turnaround")).toBeInTheDocument();
+    expect(screen.getByText(/conf 65%/)).toBeInTheDocument();
+    expect(screen.getByText(/v3 · 10 Jul 2026 · qwen3:14b · prompt v2/)).toBeInTheDocument();
+    expect(screen.queryByText("pre-anchor memo")).not.toBeInTheDocument();
+  });
+
+  it("flags v1 memos as pre-anchor (targets priced blind, #1987)", () => {
+    const thesis = { ...FIXTURE, prompt_version: "v1" } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.getByText("pre-anchor memo")).toBeInTheDocument();
+  });
+
+  it("flags unstamped (pre-#1919) memos as pre-anchor too", () => {
+    const thesis = { ...FIXTURE, prompt_version: null } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.getByText("pre-anchor memo")).toBeInTheDocument();
+  });
+
+  it("shows current price with currency and implied upside to base", () => {
+    render(
+      <ThesisPane thesis={FIXTURE} errored={false} currentPrice="16.00" currency="USD" />,
+    );
+    expect(screen.getByText("Price now")).toBeInTheDocument();
+    expect(screen.getByText("16.00 USD")).toBeInTheDocument();
+    // base 20 vs price 16 -> +25.0%
+    expect(screen.getByText("+25.0%")).toBeInTheDocument();
+  });
+
+  it("warns when price sits outside the buy zone on a buy stance", () => {
+    const thesis = {
+      ...FIXTURE,
+      stance: "buy",
+      buy_zone_low: 15,
+      buy_zone_high: 18,
+    } as unknown as ThesisDetail;
+    render(
+      <ThesisPane thesis={thesis} errored={false} currentPrice="22.50" currency="USD" />,
+    );
+    expect(screen.getByText(/outside the buy zone/)).toBeInTheDocument();
+  });
+
+  it("no outside-zone warning when price is inside the zone", () => {
+    const thesis = {
+      ...FIXTURE,
+      stance: "buy",
+      buy_zone_low: 15,
+      buy_zone_high: 18,
+    } as unknown as ThesisDetail;
+    render(
+      <ThesisPane thesis={thesis} errored={false} currentPrice="16.20" currency="USD" />,
+    );
+    expect(screen.queryByText(/outside the buy zone/)).not.toBeInTheDocument();
+  });
+
+  it("renders memo headings and bullets typographically (MemoMarkdown)", () => {
+    const thesis = {
+      ...FIXTURE,
+      memo_markdown:
+        "### Valuation\nTrading at **fair value** today.\n\n- upside catalyst\n- downside risk",
+    } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.getByRole("heading", { name: "Valuation" })).toBeInTheDocument();
+    expect(screen.getByText("fair value")).toBeInTheDocument();
+    expect(screen.getByText("upside catalyst")).toBeInTheDocument();
+    // The literal "### Valuation" raw line must NOT appear.
+    expect(screen.queryByText(/### Valuation/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -100,10 +100,14 @@ function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element 
     thesis.buy_zone_high !== null &&
     ((price as number) < thesis.buy_zone_low || (price as number) > thesis.buy_zone_high);
 
-  // prompt_version "v1" (or unstamped pre-#1919) memos priced targets with
-  // no current price in context — flag them rather than letting stale blind
-  // numbers pass as considered output (#1987/#2000).
-  const blindPricing = thesis.prompt_version !== "v2";
+  // Explicit blind-list: prompt "v1" and unstamped pre-#1919 rows priced
+  // targets with no current price in context (#1987) — flag those, and only
+  // those. Future prompt versions (v3+) inherit the anchor; an allowlist of
+  // "anchored" versions would mis-flag them (review WARNING, PR #2001).
+  const blindPricing =
+    thesis.prompt_version === null ||
+    thesis.prompt_version === undefined ||
+    thesis.prompt_version === "v1";
 
   return (
     <div className="space-y-3 text-sm">

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -1,16 +1,25 @@
 import { Pane } from "@/components/instrument/Pane";
 import { CriticVerdictBadge } from "@/components/theses/CriticVerdictBadge";
+import { MemoMarkdown } from "@/components/theses/MemoMarkdown";
+import { StanceBadge } from "@/components/theses/StanceBadge";
 import { EmptyState } from "@/components/states/EmptyState";
 import type { ThesisDetail } from "@/api/types";
 
 export interface ThesisPaneProps {
   readonly thesis: ThesisDetail | null;
   readonly errored: boolean;
+  /** Native listing price from the instrument header (#1906 primary) —
+   *  anchors the value band so a zone far from the market reads as
+   *  obviously off, not merely confusing (#2000). */
+  readonly currentPrice?: string | null;
+  readonly currency?: string | null;
 }
 
 export function ThesisPane({
   thesis,
   errored,
+  currentPrice = null,
+  currency = null,
 }: ThesisPaneProps): JSX.Element | null {
   if (thesis === null && !errored) return null;
 
@@ -22,7 +31,11 @@ export function ThesisPane({
           description="Failed to fetch the latest thesis. Retry via the Generate thesis button in the strip above."
         />
       ) : (
-        <ThesisBody thesis={thesis as ThesisDetail} />
+        <ThesisBody
+          thesis={thesis as ThesisDetail}
+          currentPrice={currentPrice}
+          currency={currency}
+        />
       )}
     </Pane>
   );
@@ -41,57 +54,151 @@ function criticList(critic: Record<string, unknown>, key: string): string[] {
   return v.filter((x): x is string => typeof x === "string");
 }
 
-function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
+function fmt(value: number | null, currency: string | null): string {
+  if (value === null) return "—";
+  const num = value.toFixed(2);
+  return currency !== null && currency !== "" ? `${num} ${currency}` : num;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  // en-GB pinned — matches the app money/date convention (formatBigMoney,
+  // Calendar) and keeps tests locale-independent.
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+}
+
+interface BodyProps {
+  readonly thesis: ThesisDetail;
+  readonly currentPrice: string | null;
+  readonly currency: string | null;
+}
+
+function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element {
   const breaks = thesis.break_conditions_json ?? [];
   const critic = thesis.critic_json;
   const criticSummary = critic ? criticString(critic, "summary") : null;
   const criticRisks = critic ? criticList(critic, "key_risks") : [];
-  const hasBuyZone =
-    thesis.buy_zone_low !== null || thesis.buy_zone_high !== null;
+  const hasBuyZone = thesis.buy_zone_low !== null || thesis.buy_zone_high !== null;
+  const hasBand =
+    thesis.base_value !== null ||
+    thesis.bull_value !== null ||
+    thesis.bear_value !== null ||
+    hasBuyZone;
+
+  const price = currentPrice !== null && currentPrice !== "" ? Number(currentPrice) : null;
+  const priceValid = price !== null && Number.isFinite(price) && price > 0;
+  const upsideToBase =
+    priceValid && thesis.base_value !== null
+      ? ((thesis.base_value - (price as number)) / (price as number)) * 100
+      : null;
+  const outsideZone =
+    priceValid &&
+    thesis.stance === "buy" &&
+    thesis.buy_zone_low !== null &&
+    thesis.buy_zone_high !== null &&
+    ((price as number) < thesis.buy_zone_low || (price as number) > thesis.buy_zone_high);
+
+  // prompt_version "v1" (or unstamped pre-#1919) memos priced targets with
+  // no current price in context — flag them rather than letting stale blind
+  // numbers pass as considered output (#1987/#2000).
+  const blindPricing = thesis.prompt_version !== "v2";
+
   return (
     <div className="space-y-3 text-sm">
-      <div className="max-w-prose whitespace-pre-wrap text-slate-700">
-        {thesis.memo_markdown}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <StanceBadge stance={thesis.stance} />
+        <span className="text-xs capitalize text-slate-600 dark:text-slate-400">
+          {thesis.thesis_type}
+        </span>
+        {thesis.confidence_score !== null && (
+          <span className="text-xs tabular-nums text-slate-500">
+            conf {(thesis.confidence_score * 100).toFixed(0)}%
+          </span>
+        )}
+        <span
+          className="ml-auto text-[10px] text-slate-400 dark:text-slate-500"
+          title={
+            thesis.provider !== null && thesis.provider !== undefined
+              ? `provider: ${thesis.provider}`
+              : undefined
+          }
+        >
+          v{thesis.thesis_version} · {formatDate(thesis.created_at)}
+          {thesis.model !== null && thesis.model !== undefined ? ` · ${thesis.model}` : ""}
+          {thesis.prompt_version !== null && thesis.prompt_version !== undefined
+            ? ` · prompt ${thesis.prompt_version}`
+            : ""}
+        </span>
+        {blindPricing && (
+          <span
+            className="rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300"
+            title="Generated before the price anchor (#1987): targets were written without the current market price in context. Regenerate for anchored numbers."
+          >
+            pre-anchor memo
+          </span>
+        )}
       </div>
-      {(thesis.base_value !== null ||
-        thesis.bull_value !== null ||
-        thesis.bear_value !== null ||
-        hasBuyZone) && (
-        <dl className="grid grid-cols-4 gap-2 rounded bg-slate-50 dark:bg-slate-900/40 p-3 text-xs">
-          <div>
-            <dt className="text-slate-500">Bear</dt>
-            <dd className="font-medium tabular-nums">
-              {thesis.bear_value !== null ? thesis.bear_value : "—"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-slate-500">Base</dt>
-            <dd className="font-medium tabular-nums">
-              {thesis.base_value !== null ? thesis.base_value : "—"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-slate-500">Bull</dt>
-            <dd className="font-medium tabular-nums">
-              {thesis.bull_value !== null ? thesis.bull_value : "—"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-slate-500">Buy zone</dt>
-            <dd className="font-medium tabular-nums">
-              {hasBuyZone
-                ? `${thesis.buy_zone_low ?? "—"} – ${thesis.buy_zone_high ?? "—"}`
-                : "—"}
-            </dd>
-          </div>
-        </dl>
+
+      {hasBand && (
+        <div className="rounded bg-slate-50 dark:bg-slate-900/40 p-3">
+          <dl className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-5">
+            <div>
+              <dt className="text-slate-500">Bear</dt>
+              <dd className="font-medium tabular-nums">{fmt(thesis.bear_value, currency)}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Base</dt>
+              <dd className="font-medium tabular-nums">
+                {fmt(thesis.base_value, currency)}
+                {upsideToBase !== null && (
+                  <span
+                    className={`ml-1 ${upsideToBase >= 0 ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}`}
+                  >
+                    {upsideToBase >= 0 ? "+" : ""}
+                    {upsideToBase.toFixed(1)}%
+                  </span>
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Bull</dt>
+              <dd className="font-medium tabular-nums">{fmt(thesis.bull_value, currency)}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Buy zone</dt>
+              <dd className="font-medium tabular-nums">
+                {hasBuyZone
+                  ? `${thesis.buy_zone_low !== null ? thesis.buy_zone_low.toFixed(2) : "—"} – ${
+                      thesis.buy_zone_high !== null ? thesis.buy_zone_high.toFixed(2) : "—"
+                    }`
+                  : "—"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-slate-500">Price now</dt>
+              <dd className="font-medium tabular-nums">
+                {priceValid ? fmt(price as number, currency) : "—"}
+              </dd>
+            </div>
+          </dl>
+          {outsideZone && (
+            <p className="mt-2 text-[11px] text-amber-700 dark:text-amber-300">
+              Current price is outside the buy zone — entry conditions not met at market.
+            </p>
+          )}
+        </div>
       )}
+
+      <MemoMarkdown memo={thesis.memo_markdown} />
+
       {breaks.length > 0 && (
         <div>
           <div className="mb-1 text-xs font-medium uppercase tracking-wider text-slate-500">
             Break conditions
           </div>
-          <ul className="list-inside list-disc space-y-0.5 text-xs text-slate-600">
+          <ul className="list-inside list-disc space-y-0.5 text-xs text-slate-600 dark:text-slate-400">
             {breaks.map((b, i) => (
               <li key={i}>{b}</li>
             ))}
@@ -104,9 +211,7 @@ function ThesisBody({ thesis }: { thesis: ThesisDetail }): JSX.Element {
             <span className="text-xs font-medium uppercase tracking-wider text-slate-500">
               Critic
             </span>
-            <CriticVerdictBadge
-              verdict={criticString(critic, "verdict")}
-            />
+            <CriticVerdictBadge verdict={criticString(critic, "verdict")} />
           </div>
           {criticSummary !== null && (
             <p className="max-w-prose text-xs text-slate-600 dark:text-slate-300">

--- a/frontend/src/components/instrument/VerdictTab.test.tsx
+++ b/frontend/src/components/instrument/VerdictTab.test.tsx
@@ -132,9 +132,10 @@ describe("VerdictTab", () => {
     );
     // headline
     expect(await screen.findByText("0.82")).toBeInTheDocument();
-    // Exact match: the ThesisPane now also renders a "Buy zone" label
-    // (#1902), so a loose /buy/i regex would double-match.
-    expect(screen.getByText("buy")).toBeInTheDocument();
+    // Exact match: the ThesisPane also renders a "Buy zone" label (#1902)
+    // AND a stance badge with the literal stance (#2000) — assert presence,
+    // not uniqueness.
+    expect(screen.getAllByText("buy").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText(/rank #5/)).toBeInTheDocument();
     // Piotroski 7/9 strong + Altman safe
     expect(screen.getByText("7")).toBeInTheDocument();

--- a/frontend/src/components/instrument/VerdictTab.test.tsx
+++ b/frontend/src/components/instrument/VerdictTab.test.tsx
@@ -146,6 +146,22 @@ describe("VerdictTab", () => {
     expect(screen.getByText("88%")).toBeInTheDocument();
     // thesis narrative reused
     expect(screen.getByText(/bull case rests on services/i)).toBeInTheDocument();
+    // thesis created_at == scored_at -> no lag hint
+    expect(screen.queryByText(/postdates this score/)).not.toBeInTheDocument();
+  });
+
+  it("flags a thesis newer than the score row (#2000 lag hint)", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict({}, FULL_IAR),
+    );
+    const fresher = { ...THESIS, created_at: "2026-07-10T12:00:00Z" };
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={fresher} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("0.82")).toBeInTheDocument();
+    expect(screen.getByText(/postdates this score/)).toBeInTheDocument();
   });
 
   it("renders scored-but-no-IAR honestly (pre-#1823 row)", async () => {

--- a/frontend/src/components/instrument/VerdictTab.tsx
+++ b/frontend/src/components/instrument/VerdictTab.tsx
@@ -197,6 +197,12 @@ export function VerdictTab({
             {score.explanation}
           </p>
         )}
+        {thesis !== null && new Date(thesis.created_at) > new Date(score.scored_at) && (
+          <p className="mt-2 text-[11px] text-amber-700 dark:text-amber-300">
+            The latest thesis (v{thesis.thesis_version}) postdates this score — thesis-fed
+            families (value, confidence) refresh on the next ranking run.
+          </p>
+        )}
       </Section>
 
       {/* 2. Six graded families */}

--- a/frontend/src/components/instrument/VerdictTab.tsx
+++ b/frontend/src/components/instrument/VerdictTab.tsx
@@ -38,6 +38,10 @@ export interface VerdictTabProps {
   readonly instrumentId: number;
   readonly thesis: ThesisDetail | null;
   readonly thesisErrored?: boolean;
+  /** Native header price + currency, forwarded to the ThesisPane value
+   *  band (#2000). Optional — older callers degrade to "—". */
+  readonly currentPrice?: string | null;
+  readonly currency?: string | null;
 }
 
 const FAMILIES: { key: string; label: string; scoreKey: keyof FamilyScores }[] = [
@@ -97,6 +101,8 @@ export function VerdictTab({
   instrumentId,
   thesis,
   thesisErrored = false,
+  currentPrice = null,
+  currency = null,
 }: VerdictTabProps): JSX.Element {
   const verdict = useAsync<VerdictResponse>(
     () => fetchScoreVerdict(instrumentId),
@@ -308,7 +314,12 @@ export function VerdictTab({
       </Section>
 
       {/* 6. Thesis narrative + valuation (reuses the existing pane) */}
-      <ThesisPane thesis={thesis} errored={thesisErrored} />
+      <ThesisPane
+        thesis={thesis}
+        errored={thesisErrored}
+        currentPrice={currentPrice}
+        currency={currency}
+      />
     </div>
   );
 }

--- a/frontend/src/components/theses/MemoMarkdown.test.tsx
+++ b/frontend/src/components/theses/MemoMarkdown.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MemoMarkdown, parseMemoBlocks } from "./MemoMarkdown";
+
+describe("parseMemoBlocks", () => {
+  it("splits headings, paragraphs and lists", () => {
+    const memo = "## Quality\nStrong moat.\nGrowing share.\n\n- risk one\n- risk two\n\nFinal note.";
+    expect(parseMemoBlocks(memo)).toEqual([
+      { kind: "heading", text: "Quality" },
+      { kind: "para", text: "Strong moat. Growing share." },
+      { kind: "list", items: ["risk one", "risk two"] },
+      { kind: "para", text: "Final note." },
+    ]);
+  });
+
+  it("heading terminates a paragraph without a blank line", () => {
+    expect(parseMemoBlocks("intro line\n### Risks\nbody")).toEqual([
+      { kind: "para", text: "intro line" },
+      { kind: "heading", text: "Risks" },
+      { kind: "para", text: "body" },
+    ]);
+  });
+
+  it("supports * bullets and empty input", () => {
+    expect(parseMemoBlocks("* a\n* b")).toEqual([{ kind: "list", items: ["a", "b"] }]);
+    expect(parseMemoBlocks("")).toEqual([]);
+  });
+
+  it("tolerates #### headings (writer contract is #-###; level 4 renders as heading, not literal)", () => {
+    expect(parseMemoBlocks("#### Deep dive")).toEqual([{ kind: "heading", text: "Deep dive" }]);
+  });
+});
+
+describe("MemoMarkdown", () => {
+  it("renders bold inline without literal asterisks", () => {
+    render(<MemoMarkdown memo="This is **key** context." />);
+    expect(screen.getByText("key")).toBeInTheDocument();
+    expect(screen.queryByText(/\*\*key\*\*/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/theses/MemoMarkdown.tsx
+++ b/frontend/src/components/theses/MemoMarkdown.tsx
@@ -1,10 +1,12 @@
 /**
  * Minimal renderer for the thesis writer's prompt-constrained markdown
  * subset (#2000): #/##/### headings, `- `/`* ` bullet lists, **bold**
- * inline, blank-line paragraphs. Deliberately in-house — the memo format
- * is our own prompt contract, not arbitrary markdown, so a dependency
- * (and its sanitisation surface) buys nothing. Everything renders as
- * text nodes; no HTML injection path exists.
+ * inline, blank-line paragraphs. The parser deliberately tolerates ####
+ * (one level beyond the prompt contract) — a model that over-nests should
+ * render a heading, not a literal "####" line. Deliberately in-house —
+ * the memo format is our own prompt contract, not arbitrary markdown, so
+ * a dependency (and its sanitisation surface) buys nothing. Everything
+ * renders as text nodes; no HTML injection path exists.
  */
 
 const BOLD_SPLIT = /(\*\*[^*]+\*\*)/g;

--- a/frontend/src/components/theses/MemoMarkdown.tsx
+++ b/frontend/src/components/theses/MemoMarkdown.tsx
@@ -1,0 +1,100 @@
+/**
+ * Minimal renderer for the thesis writer's prompt-constrained markdown
+ * subset (#2000): #/##/### headings, `- `/`* ` bullet lists, **bold**
+ * inline, blank-line paragraphs. Deliberately in-house — the memo format
+ * is our own prompt contract, not arbitrary markdown, so a dependency
+ * (and its sanitisation surface) buys nothing. Everything renders as
+ * text nodes; no HTML injection path exists.
+ */
+
+const BOLD_SPLIT = /(\*\*[^*]+\*\*)/g;
+
+function renderInline(text: string): (string | JSX.Element)[] {
+  return text.split(BOLD_SPLIT).map((part, i) =>
+    part.startsWith("**") && part.endsWith("**") && part.length > 4 ? (
+      <strong key={i} className="font-semibold text-slate-800 dark:text-slate-200">
+        {part.slice(2, -2)}
+      </strong>
+    ) : (
+      part
+    ),
+  );
+}
+
+type Block =
+  | { kind: "heading"; text: string }
+  | { kind: "list"; items: string[] }
+  | { kind: "para"; text: string };
+
+export function parseMemoBlocks(memo: string): Block[] {
+  const blocks: Block[] = [];
+  let list: string[] | null = null;
+  let para: string[] = [];
+
+  const flushPara = () => {
+    if (para.length > 0) {
+      blocks.push({ kind: "para", text: para.join(" ") });
+      para = [];
+    }
+  };
+  const flushList = () => {
+    if (list !== null) {
+      blocks.push({ kind: "list", items: list });
+      list = null;
+    }
+  };
+
+  for (const raw of memo.split("\n")) {
+    const line = raw.trim();
+    const headingText = /^#{1,4}\s+(.*)$/.exec(line)?.[1];
+    const bulletText = /^[-*]\s+(.*)$/.exec(line)?.[1];
+    if (line === "") {
+      flushPara();
+      flushList();
+    } else if (headingText !== undefined) {
+      flushPara();
+      flushList();
+      blocks.push({ kind: "heading", text: headingText });
+    } else if (bulletText !== undefined) {
+      flushPara();
+      list = list ?? [];
+      list.push(bulletText);
+    } else {
+      flushList();
+      para.push(line);
+    }
+  }
+  flushPara();
+  flushList();
+  return blocks;
+}
+
+export function MemoMarkdown({ memo }: { readonly memo: string }): JSX.Element {
+  const blocks = parseMemoBlocks(memo);
+  return (
+    <div className="max-w-prose space-y-2 text-sm text-slate-700 dark:text-slate-300">
+      {blocks.map((block, i) => {
+        if (block.kind === "heading") {
+          return (
+            <h4
+              key={i}
+              className="pt-1 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400"
+            >
+              {block.text}
+            </h4>
+          );
+        }
+        if (block.kind === "list") {
+          return (
+            <ul key={i} className="list-inside list-disc space-y-0.5">
+              {block.items.map((item, j) => (
+                <li key={j}>{renderInline(item)}</li>
+              ))}
+            </ul>
+          );
+        }
+        return <p key={i}>{renderInline(block.text)}</p>;
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -786,6 +786,8 @@ function InstrumentPageBody({
                 instrumentId={summary.instrument_id}
                 thesis={thesisAsync.data}
                 thesisErrored={thesisErrSticky}
+                currentPrice={summary.price?.current ?? null}
+                currency={summary.identity.currency}
               />
             )}
             {activeTab === "financials" && <FinancialsTab symbol={symbol} />}


### PR DESCRIPTION
## What

Operator design challenge (2026-07-10): the thesis surfaces shipped functional but rough — raw-text memo dump (`## headings` literal), decision numbers buried under the text wall, no current price beside the buy zone (blind v1 zones read as confusing rather than obviously wrong), zero provenance.

- **API**: `ThesisDetail` exposes `prompt_version`/`model`/`provider` (columns exist since #1919 PR-A; single `_parse_thesis` construction site — POST, latest-GET, history all flow through it).
- **ThesisPane reorder**: stance badge + type + confidence + provenance line (`v3 · 10 Jul 2026 · qwen3:14b · prompt v2`, provider in tooltip) → **price-anchored value band** → memo → break conditions → critic.
- **`pre-anchor memo` amber chip** when `prompt_version != v2`: those targets were priced with NO market price in context (#1987) — the operator can now tell blind memos from anchored ones at a glance.
- **Value band**: 2dp + currency label, current native price (#1906 primary) with implied % to base, amber warning when a buy-stance price sits outside the buy zone.
- **MemoMarkdown**: in-house renderer for the writer's prompt-constrained subset (#–#### headings, `-`/`*` bullets, `**bold**`, paragraphs). Text nodes only — no HTML injection surface, no new dependency (memo format is our own prompt contract).
- Price wired through BOTH render paths (DensityGrid + VerdictTab→InstrumentPage) — the #1955 sibling-wiring class, caught in FE-QA when 'Price now' rendered '—' on the Verdict tab.

## Security model

No new endpoints; three nullable read-only columns added to an existing authed response. MemoMarkdown renders exclusively React text nodes (no dangerouslySetInnerHTML) — LLM output cannot inject markup.

## Verification

- `pnpm typecheck` + `test:unit` **1,334 passed** (7 new pane cases, 4 parser table-tests, full-shape fixture replacing the old string-cast one); backend ruff/format/pyright clean; fast tier 4,923 + smoke 147 passed; dark-class gate 252 files clean.
- **Change-coupled FE-QA live on dev**: GME (v2, buy) — provenance line, band 18/24/32 USD + zone 20–25 + price 21.88 + '+9.7%' to base, typographic headings, critic block; WTS (v1) — 'pre-anchor memo' chip renders. Dark + light both clean, 0 console errors.
- Codex ckpt-2: 2 findings (provenance dropped provider/prompt_version; `####` tolerance undocumented) — both addressed in `a80deecd`.

## Tradeoffs

- `provider` in a tooltip, not the line — `model` already identifies the runtime for the operator; the line stays scannable.
- Library page (/theses) untouched this PR — pane + verdict tab were the operator-flagged surfaces; library columns already carry stance/critic badges.

Closes #2000

🤖 Generated with [Claude Code](https://claude.com/claude-code)