### PR TITLE
fix(#2003): Verdict tab — thesis leads the page, stance dedupe, spacing rhythm

### DIFF
--- a/frontend/src/components/instrument/VerdictTab.test.tsx
+++ b/frontend/src/components/instrument/VerdictTab.test.tsx
@@ -210,3 +210,59 @@ describe("VerdictTab", () => {
     expect(screen.getByText(/peer percentile pending/i)).toBeInTheDocument();
   });
 });
+
+describe("VerdictTab #2003 — thesis leads the tab", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockHistoryEmpty();
+  });
+
+  it("renders the thesis pane ABOVE the score headline", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict({}, FULL_IAR),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={THESIS} />
+      </MemoryRouter>,
+    );
+    const memo = await screen.findByText(/bull case rests on services/i);
+    const totalScore = screen.getByText("0.82");
+    // DOM order pins the hierarchy: memo (thesis pane) precedes the score.
+    expect(
+      memo.compareDocumentPosition(totalScore) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("does not duplicate the stance in the score headline (dedupe)", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict({}, FULL_IAR),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={THESIS} />
+      </MemoryRouter>,
+    );
+    await screen.findByText("0.82");
+    // Exactly ONE stance element — the ThesisPane StanceBadge. The old
+    // headline chip is gone.
+    expect(screen.getAllByText("buy")).toHaveLength(1);
+  });
+
+  it("thesis pane still leads when the instrument is unscored", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue({
+      instrument_id: 1,
+      score: null,
+    });
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={THESIS} />
+      </MemoryRouter>,
+    );
+    const memo = await screen.findByText(/bull case rests on services/i);
+    const empty = screen.getByText(/not yet scored/i);
+    expect(
+      memo.compareDocumentPosition(empty) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/components/instrument/VerdictTab.tsx
+++ b/frontend/src/components/instrument/VerdictTab.tsx
@@ -74,17 +74,6 @@ function ErrorBox({ message }: { message: string }): JSX.Element {
   );
 }
 
-function stanceClass(stance: string): string {
-  const s = stance.toLowerCase();
-  if (s === "buy")
-    return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300";
-  if (s === "avoid")
-    return "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300";
-  if (s === "watch")
-    return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300";
-  return "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300";
-}
-
 /** Evidence-only tag — peer percentile is weight 0 in the live score. */
 function EvidenceTag(): JSX.Element {
   return (
@@ -127,13 +116,23 @@ export function VerdictTab({
 
   const score = verdict.data?.score ?? null;
   if (score === null) {
+    // Thesis still leads even when unscored (#2003) — a generated memo
+    // must not vanish behind the "Not yet scored" empty state.
     return (
-      <Section title="Verdict">
-        <EmptyState
-          title="Not yet scored"
-          description="This instrument has no scoring run yet. The verdict appears once the deterministic engine has scored it."
+      <div className="space-y-4">
+        <ThesisPane
+          thesis={thesis}
+          errored={thesisErrored}
+          currentPrice={currentPrice}
+          currency={currency}
         />
-      </Section>
+        <Section title="Verdict">
+          <EmptyState
+            title="Not yet scored"
+            description="This instrument has no scoring run yet. The verdict appears once the deterministic engine has scored it."
+          />
+        </Section>
+      </div>
     );
   }
 
@@ -147,17 +146,24 @@ export function VerdictTab({
     .reverse();
 
   return (
-    <div className="space-y-5">
-      {/* 1. Headline */}
+    <div className="space-y-4">
+      {/* 1. Thesis narrative + valuation leads the tab (#2003) — the memo
+          is the page's payoff; the deterministic score block reads as
+          supporting evidence below it. Renders nothing when no thesis
+          exists (and no fetch error), so unthesised names degrade to the
+          score-first layout. */}
+      <ThesisPane
+        thesis={thesis}
+        errored={thesisErrored}
+        currentPrice={currentPrice}
+        currency={currency}
+      />
+
+      {/* 2. Score headline. The stance chip that used to sit here is
+          gone (#2003 dedupe) — the ThesisPane directly above already
+          leads with the StanceBadge. */}
       <Section title="Verdict">
         <div className="flex flex-wrap items-center gap-3">
-          {thesis !== null && (
-            <span
-              className={`rounded px-2 py-0.5 text-sm font-semibold uppercase tracking-wide ${stanceClass(thesis.stance)}`}
-            >
-              {thesis.stance}
-            </span>
-          )}
           <div className="flex items-baseline gap-1">
             <span className="text-2xl font-semibold tabular-nums text-slate-800 dark:text-slate-100">
               {fmt2(score.total_score)}
@@ -205,7 +211,7 @@ export function VerdictTab({
         )}
       </Section>
 
-      {/* 2. Six graded families */}
+      {/* 3. Six graded families */}
       <Section title="Graded families">
         <table className="min-w-full text-sm">
           <thead>
@@ -260,7 +266,7 @@ export function VerdictTab({
         )}
       </Section>
 
-      {/* 3. Quality signals */}
+      {/* 4. Quality signals */}
       <Section title="Quality signals">
         {iar === null ? (
           <EvidencePending />
@@ -272,7 +278,7 @@ export function VerdictTab({
         )}
       </Section>
 
-      {/* 4. Positioning */}
+      {/* 5. Positioning */}
       <Section title="Positioning">
         {iar === null ? (
           <EvidencePending />
@@ -294,7 +300,7 @@ export function VerdictTab({
         )}
       </Section>
 
-      {/* 5. Score history */}
+      {/* 6. Score history */}
       <Section title="Score history">
         {history.loading ? (
           <SectionSkeleton rows={1} />
@@ -319,13 +325,6 @@ export function VerdictTab({
         )}
       </Section>
 
-      {/* 6. Thesis narrative + valuation (reuses the existing pane) */}
-      <ThesisPane
-        thesis={thesis}
-        errored={thesisErrored}
-        currentPrice={currentPrice}
-        currency={currency}
-      />
     </div>
   );
 }


### PR DESCRIPTION
Closes #2003 (operator design feedback 2026-07-10 on the merged #2000 pane).

## What

The thesis memo read as the Verdict tab's real payoff but rendered last, below five score/evidence sections — and the score explanation ("no thesis" / "bear_value missing") could contradict a fresh memo buried further down.

- **ThesisPane moves to slot 1** (stance + anchored value band + memo + break conditions + critic). Unthesised instruments degrade to the score-first layout unchanged (the pane renders nothing); the unscored-but-thesised edge keeps the memo above the "Not yet scored" empty state instead of vanishing behind it.
- **Stance dedupe**: the headline stance chip is removed — the StanceBadge in the pane directly above already carries it (`stanceClass` helper deleted). The #2001 score-lag hint stays beside the score explanation, where the contradiction it explains renders.
- **Spacing rhythm**: tab container `space-y-5` → `space-y-4`, matching the instrument-page convention (InstrumentPage/DensityGrid).

## Security model

FE-only presentational reorder inside an already-authenticated route; no API, data-flow, or auth changes. No files outside `frontend/src/components/instrument/` touched.

## Tradeoffs

- Full pane at top rather than a compact digest + pane (the issue offered either): one narrative surface avoids a third rendering of the same memo — the duplication the issue asked to reduce.
- Honesty ordering unchanged: the deterministic score block keeps its explanation + evidence-only labels; it now reads as supporting evidence below the narrative rather than the headline.

## Verification (commit 083d00ca)

- `pnpm typecheck` clean; `test:unit` **1,340 passed** (3 new tests pin DOM order, stance dedupe, unscored-with-thesis edge); dark-class gate clean (252 files).
- Codex review on the diff: no findings.
- Change-coupled FE-QA on live dev (GME, held + fresh v2 thesis): dark + light screenshots — thesis leads with anchored band (Bear 18 / Base 24 +10.8% / Bull 32 / zone 20–25 / price 21.66), critic "Strong challenge" block, then score 0.46 + families + signals. 0 console errors, no dead scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)