### PR TITLE
skill+chore(#1989): ta-analyst skill — own chart-TA interpretation; centralize trend signals as read-derive

### DIFF
--- a/.claude/skills/ta-analyst/SKILL.md
+++ b/.claude/skills/ta-analyst/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ta-analyst
+description: eBull chart-TA interpretation — what each stored indicator means HERE (the encoded ramps and gates, not textbook generalities), where it is computed and stored, who consumes it (scoring momentum family, entry_timing, thesis context block D), and the derived trend signals contract.
+---
+
+# ta-analyst
+
+## When to use
+
+Any change to `app/services/technical_analysis.py`, the TA columns on
+`price_daily` (sql/025), `_compute_and_store_features` in
+`app/services/market_data.py`, the momentum family in
+`app/services/scoring.py::_momentum_score`, `app/services/entry_timing.py`,
+or the thesis TA context block (`app/services/thesis.py::_shape_ta_state`).
+Also read it before citing any TA figure in an operator-facing surface or
+prompt — the interpretation rules below are the encoded ones, not textbook
+defaults.
+
+## Where TA lives
+
+- **Computation** — `technical_analysis.py`: pure functions, no DB/IO.
+  `compute_indicators(bars)` takes oldest-first OHLCV bars and returns a dict
+  keyed by `price_daily` column names (floats or None).
+- **Persistence** — `market_data.py::_compute_and_store_features`, called on
+  every candle refresh: reads the newest **400 bars** (close-only for
+  returns/volatility; full-OHLCV subset for indicators), UPDATEs the latest
+  `price_daily` row. Candle history itself backfills at **1000 trading days**
+  (eToro per-request ceiling, #603) on first seed, incremental afterwards.
+  TA is written only when the newest complete OHLCV bar matches the row
+  being updated — partial candles produce NULL indicators, never
+  stale-by-one-day values.
+- **Columns** (sql/025): `sma_20/50/200`, `ema_12/26`,
+  `macd_line/signal/histogram`, `rsi_14`, `stoch_k/d`, `bb_upper/lower`,
+  `atr_14`. Returns (`return_1w..1y`) and `volatility_30d` ride the same
+  UPDATE but are computed separately from closes.
+- **Derived at read, never stored** — `derive_trend_signals(close, sma_50,
+  sma_200)` (#1989): `price_vs_sma200` ("above"/"below"; tie is "below" by
+  design, strict `>`), `sma_50_200_regime` ("golden"/"death" — the CURRENT
+  50-vs-200 relation, NOT a crossover event; equal-or-missing SMAs yield None:
+  missing evidence, not a third regime). Single source; the thesis context
+  keys are stable — the writer prompt and eval fixtures depend on them.
+  Persisting these was considered and rejected: two already-stored floats
+  derive them in O(1), and a stored copy could drift stale.
+
+## Who consumes what
+
+| Consumer | Uses | Encoding |
+|---|---|---|
+| scoring `_momentum_score` | sma_200, macd_histogram, rsi_14, stoch_k, bb_upper/lower, atr_14 + returns | blend below |
+| `entry_timing` | rsi_14, bb_upper/lower, atr_14 | defer/SL gates below |
+| thesis context block D | sma_50/200, rsi_14, macd_histogram, atr_14, volatility_30d + derived signals | statused, as-of-stamped (#1987) |
+
+## The encoded interpretation rules (v1.1+ momentum blend)
+
+Momentum family weight in the total score: **0.10** (balanced + conservative
+modes), 0.15 (speculative). Inside `_momentum_score`, sub-blend (missing
+components renormalize; ALL missing → 0.5 neutral + note):
+
+- **Returns 40%** — 1m (0.20): clip((r+0.10)/0.30); 3m (0.50):
+  clip((r+0.15)/0.45); 6m (0.30): clip((r+0.20)/0.60). No TA at all →
+  return-only fallback (v1 behaviour).
+- **Trend confirmation 25%** — price-vs-SMA200 distance (0.60):
+  clip(0.5 + pct_from_sma × 2.5), so ±20% from the 200-day saturates;
+  MACD histogram (0.40): normalized to price, clip(0.5 + macd_pct × 20) —
+  ±2.5% histogram saturates.
+- **Momentum quality 20%** — RSI (0.60), the encoded regime bands:
+  `<30` oversold warning (score rsi/60), `30–70` recovery→healthy ramp
+  (0.5 + (rsi−30)/80), `>70` overbought decay (1 − (rsi−70)/30).
+  Stochastic %K (0.40): same shape with 20/80 bands.
+- **Volatility regime 15%** — Bollinger position (0.60):
+  (close−lower)/(upper−lower); HIGH position reads as trend *strength* here,
+  deliberately opposite to the RSI/stoch overbought treatment which reads
+  *exhaustion* risk — do not "fix" one to match the other. ATR (0.40):
+  clip(1 − atr_pct × 10) — 10% daily true range zeroes it.
+
+## Entry-timing gates (BUY/ADD only)
+
+`entry_timing.evaluate_entry_conditions` — verdicts `pass`/`defer`/`skip`
+(the DB CHECK also allows `error`, written by the scheduler only):
+
+- **Defer** when RSI-14 > **75** (overbought — stricter than the scoring
+  band's 70) or price within **95%** of the Bollinger range (overextended).
+  Deferred recommendations retry via `deferred_retry`.
+- **Stop-loss** = entry − **2.0 × ATR(14)**, floored at 5% below entry
+  (`SL_FLOOR_PCT`) and at least 2% below (`SL_MIN_DISTANCE_PCT`) so spread
+  noise cannot stop out.
+
+## Thesis-writer usage (block D contract)
+
+`_shape_ta_state` forwards floats + the two derived signals with the price
+row's as-of stamp. Interpretation guidance the writer receives lives in
+`_WRITER_SYSTEM` — if you change a ramp or gate above, check whether the
+prompt's TA guidance still matches (#1632 evidence discipline: statuses
+verbatim, no citing absent metrics as numbers).
+
+## Invariants
+
+- `technical_analysis.py` stays pure — no DB, no IO, floats in/out.
+- Indicator column names == dict keys == `_TA_COLUMNS` in market_data.py;
+  a new indicator must land in all three plus sql migration.
+- `derive_trend_signals` is the ONLY producer of the trend-signal strings;
+  the context keys `price_vs_sma200` / `sma_50_200_regime` are frozen
+  (prompt + eval fixtures).
+- RSI/stoch/BB thresholds above are ENCODED behaviour — changing them is a
+  scoring-model change (model_version bump territory, operator-gated), not
+  a refactor.

--- a/app/services/technical_analysis.py
+++ b/app/services/technical_analysis.py
@@ -231,12 +231,15 @@ def stochastic(
 
 def compute_indicators(
     bars: Sequence[OHLCVRow],
-) -> dict[str, float | str | None] | None:
+) -> dict[str, float | None] | None:
     """Compute all technical indicators from OHLCV bars.
 
-    Returns a dict keyed by price_daily column names, plus derived
-    cross-signals (price_vs_sma200, trend_sma_cross).
+    Returns a dict keyed by price_daily column names.
     Returns None for empty bars.
+
+    Trend cross-signals (price-vs-SMA200, 50/200 regime) are NOT computed
+    here — they are derived at read time from the stored SMAs via
+    ``derive_trend_signals`` (#1989: single source, no extra columns).
     """
     if not bars:
         return None
@@ -273,26 +276,6 @@ def compute_indicators(
 
     atr_14 = atr(bars, 14)
 
-    # Derived cross-signals (not stored in DB)
-    latest_close = float(closes[-1])
-
-    price_vs_sma200: str | None
-    if sma_200 is not None:
-        price_vs_sma200 = "above" if latest_close > sma_200 else "below"
-    else:
-        price_vs_sma200 = None
-
-    trend_sma_cross: str
-    if sma_50 is not None and sma_200 is not None:
-        if sma_50 > sma_200:
-            trend_sma_cross = "golden"
-        elif sma_50 < sma_200:
-            trend_sma_cross = "death"
-        else:
-            trend_sma_cross = "none"
-    else:
-        trend_sma_cross = "none"
-
     return {
         "sma_20": sma_20,
         "sma_50": sma_50,
@@ -308,6 +291,38 @@ def compute_indicators(
         "bb_upper": bb_upper,
         "bb_lower": bb_lower,
         "atr_14": atr_14,
-        "price_vs_sma200": price_vs_sma200,
-        "trend_sma_cross": trend_sma_cross,
     }
+
+
+# ---------------------------------------------------------------------------
+# Derived trend signals (read-time, from stored SMAs)
+# ---------------------------------------------------------------------------
+
+
+def derive_trend_signals(
+    close: float | None,
+    sma_50: float | None,
+    sma_200: float | None,
+) -> dict[str, str | None]:
+    """Derive the human-readable trend-regime signals from stored values.
+
+    Single source for both signals (#1989) — previously computed (and then
+    dropped by the float-only persistence filter) in ``compute_indicators``
+    AND re-derived inline in the thesis context assembler; the two
+    derivations could have drifted.
+
+    - ``price_vs_sma200``: "above" / "below"; tie (close == sma_200) is
+      "below" by design — strict ``>``. None when either input is missing.
+    - ``sma_50_200_regime``: the CURRENT 50-vs-200 relation ("golden" /
+      "death"), NOT a crossover event. Equal-or-missing SMAs yield None
+      (missing evidence, not a third regime).
+    """
+    price_vs_sma200: str | None = None
+    if close is not None and sma_200 is not None:
+        price_vs_sma200 = "above" if close > sma_200 else "below"
+
+    regime: str | None = None
+    if sma_50 is not None and sma_200 is not None and sma_50 != sma_200:
+        regime = "golden" if sma_50 > sma_200 else "death"
+
+    return {"price_vs_sma200": price_vs_sma200, "sma_50_200_regime": regime}

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -58,6 +58,7 @@ from psycopg.types.json import Jsonb
 # forces the lazy import inside _assemble_context.
 from app.services.instrument_analytics import SCHEMA_VERSION as _IAR_SCHEMA_VERSION
 from app.services.llm_client import LLMClient, LLMClientPair, LLMCompletion
+from app.services.technical_analysis import derive_trend_signals
 
 logger = logging.getLogger(__name__)
 
@@ -598,28 +599,16 @@ def _shape_analytics_evidence(
 def _shape_ta_state(price_row: tuple[object, ...] | None) -> dict[str, object] | None:
     """Block D: latest persisted TA indicators + derived-at-read signals.
 
-    `sma_50_200_regime` is the CURRENT 50-vs-200 relation (golden/death), NOT
-    a crossover event — same comparison as technical_analysis.py
-    compute_indicators, but equal-or-missing SMAs yield None (missing
-    evidence, not a third regime; the internal "none" string is not
-    forwarded). #1989 will persist the derived signals; the context key stays.
+    The trend signals (`price_vs_sma200`, `sma_50_200_regime`) come from
+    ``technical_analysis.derive_trend_signals`` — the single source (#1989:
+    read-derive from stored SMAs, no extra price_daily columns). The context
+    keys are stable — the thesis prompt and eval fixtures depend on them.
     """
     if price_row is None:
         return None
     close = _to_float(price_row[0])
     sma_50 = _to_float(price_row[7])
     sma_200 = _to_float(price_row[8])
-
-    price_vs_sma200: str | None = None
-    if close is not None and sma_200 is not None:
-        # Tie (close == sma_200) is "below" by design — strict >, mirroring
-        # technical_analysis.py compute_indicators so the two derivations
-        # can never disagree on the same row.
-        price_vs_sma200 = "above" if close > sma_200 else "below"
-
-    regime: str | None = None
-    if sma_50 is not None and sma_200 is not None and sma_50 != sma_200:
-        regime = "golden" if sma_50 > sma_200 else "death"
 
     return {
         "sma_50": sma_50,
@@ -628,8 +617,7 @@ def _shape_ta_state(price_row: tuple[object, ...] | None) -> dict[str, object] |
         "macd_histogram": _to_float(price_row[10]),
         "atr_14": _to_float(price_row[11]),
         "volatility_30d": _to_float(price_row[12]),
-        "price_vs_sma200": price_vs_sma200,
-        "sma_50_200_regime": regime,
+        **derive_trend_signals(close, sma_50, sma_200),
     }
 
 

--- a/docs/specs/thesis/2026-07-10-thesis-context-enrichment.md
+++ b/docs/specs/thesis/2026-07-10-thesis-context-enrichment.md
@@ -50,8 +50,9 @@ valuation multiples, the #1823 IAR evidence block, and TA/trend state.
 - `_PROMPT_VERSION = "v1"` (thesis.py:89); `_MAX_TOKENS_CRITIC = 1024` (:84) — length-failed live
   on IEP 2026-07-10 (thesis stored without `critic_json`; harness fixtures never hit the limit).
 - TA indicators are persisted latest-row-only on `price_daily` (sql/025); `price_vs_sma200` /
-  `trend_sma_cross` are derived in `compute_indicators` (technical_analysis.py:279-294) and NOT
-  persisted (#1989 tracks persistence; this spec derives them read-side and does not depend on it).
+  `sma_50_200_regime` are derived at read time by `technical_analysis.derive_trend_signals`
+  (#1989 SETTLED read-derive over persistence: two stored floats derive them in O(1), a stored
+  copy could drift; the dead compute_indicators branch was removed).
 - `scores.analytics_json` (#1823, `iar_v1`) carries piotroski/altman/positioning/peer_grade;
   populated only by `compute_rankings` (GME sample: 1,561 chars).
 - `instrument_valuation` (sql/201) is quotes-gated: `priced` CTE reads `FROM quotes` only.
@@ -148,14 +149,13 @@ No scores row / NULL `analytics_json` → `None`. ⚠ `analytics_json` refreshes
 
 From the same latest `price_daily` row as Block A: `sma_50, sma_200, rsi_14, macd_histogram,
 atr_14, volatility_30d`, plus derived-at-read `price_vs_sma200` ("above"/"below"/null) and
-`sma_50_200_regime` ("golden"/"death"/null) — same comparison semantics as
-technical_analysis.py:279-294, but named honestly: the internal `trend_sma_cross` value is the
-CURRENT 50-vs-200 regime, not a recent crossover event, and the context key must not invite the
-writer to infer one (the prompt states this explicitly). Divergence from the internal column
-name is deliberate; when #1989 later persists the derived signals, the read-side derivation is
-replaced and the context key stays `sma_50_200_regime`. Where the internal fn emits "none"
-(either SMA null), the context uses `null` (missing evidence, not a third regime). NULL
-indicators stay null (<200d histories keep `sma_200 = None`).
+`sma_50_200_regime` ("golden"/"death"/null) — produced by
+`technical_analysis.derive_trend_signals`, the single source since #1989 (read-derive settled;
+the old compute_indicators `trend_sma_cross` branch is deleted). The value is the CURRENT
+50-vs-200 regime, not a recent crossover event, and the context key must not invite the writer
+to infer one (the prompt states this explicitly). The context key stays `sma_50_200_regime`.
+Equal-or-missing SMAs yield `null` (missing evidence, not a third regime). NULL indicators stay
+null (<200d histories keep `sma_200 = None`).
 
 ### Prompt changes (writer + critic) — `_PROMPT_VERSION` "v1" → "v2"
 

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -937,8 +937,9 @@ class TestComputeAndStoreFeaturesTA:
             assert params[col] is None, f"{col} should be None when dates misalign"
 
     def test_string_indicators_excluded_from_ta_params(self) -> None:
-        """compute_indicators returns price_vs_sma200 and trend_sma_cross as
-        strings — these must NOT appear in the numeric ta_params dict."""
+        """Regression guard: compute_indicators no longer emits the derived
+        trend-signal strings (#1989 — see derive_trend_signals); if they are
+        ever reintroduced they must still not reach the numeric UPDATE params."""
         n = 250
         price_rows = _generate_price_rows(n)
         close_rows = list(reversed(price_rows))

--- a/tests/test_technical_analysis.py
+++ b/tests/test_technical_analysis.py
@@ -12,6 +12,7 @@ from app.services.technical_analysis import (
     atr,
     bollinger_bands,
     compute_indicators,
+    derive_trend_signals,
     ema,
     macd,
     rsi,
@@ -315,23 +316,45 @@ class TestComputeIndicators:
     def test_empty_bars_returns_none(self) -> None:
         assert compute_indicators([]) is None
 
-    def test_price_above_sma200(self) -> None:
-        # Ascending bars — latest close well above SMA(200)
+    def test_no_derived_string_signals_emitted(self) -> None:
+        # #1989: trend signals moved to derive_trend_signals — the
+        # orchestrator emits price_daily column floats only.
         bars = self._make_ascending_bars(250)
         result = compute_indicators(bars)
         assert result is not None
-        assert result["price_vs_sma200"] == "above"
+        assert "price_vs_sma200" not in result
+        assert "trend_sma_cross" not in result
 
-    def test_trend_sma_cross_golden(self) -> None:
-        # Ascending data: SMA(50) > SMA(200) → golden cross
-        bars = self._make_ascending_bars(250)
-        result = compute_indicators(bars)
-        assert result is not None
-        assert result["trend_sma_cross"] == "golden"
 
-    def test_trend_sma_cross_none_when_insufficient(self) -> None:
-        # Not enough data for SMA(200) → cross signal should be "none"
-        bars = self._make_ascending_bars(100)
-        result = compute_indicators(bars)
-        assert result is not None
-        assert result["trend_sma_cross"] == "none"
+class TestDeriveTrendSignals:
+    """derive_trend_signals (#1989) — single source for read-time trend signals."""
+
+    @pytest.mark.parametrize(
+        ("close", "sma_50", "sma_200", "expected_pvs", "expected_regime"),
+        [
+            (24.5, 23.0, 21.0, "above", "golden"),
+            (18.0, 20.0, 22.0, "below", "death"),
+            # Tie close == sma_200 is "below" by design (strict >).
+            (21.0, 22.0, 21.0, "below", "golden"),
+            # Equal SMAs = missing evidence, not a third regime.
+            (25.0, 21.0, 21.0, "above", None),
+            # Missing inputs suppress only the signals they feed.
+            (None, 23.0, 21.0, None, "golden"),
+            (24.5, None, 21.0, "above", None),
+            (24.5, 23.0, None, None, None),
+            (None, None, None, None, None),
+        ],
+    )
+    def test_table(
+        self,
+        close: float | None,
+        sma_50: float | None,
+        sma_200: float | None,
+        expected_pvs: str | None,
+        expected_regime: str | None,
+    ) -> None:
+        out = derive_trend_signals(close, sma_50, sma_200)
+        assert out == {
+            "price_vs_sma200": expected_pvs,
+            "sma_50_200_regime": expected_regime,
+        }


### PR DESCRIPTION
Closes #1989.

## What

1. **New skill `.claude/skills/ta-analyst/SKILL.md`** — the encoded TA interpretation rules (not textbook generalities): momentum blend 40/25/20/15 with exact ramps (RSI 30/70 bands, stoch 20/80, SMA200-distance ×2.5, MACD/price ×20, BB-position dual reading, ATR ×10), entry_timing gates (RSI>75 defer, BB>95% defer, SL=2×ATR floored 2–5%), storage map (sql/025, 400-bar window, 1000-day backfill), consumers (scoring momentum family 0.10 weight, entry_timing, thesis context block D), invariants (thresholds are model_version territory).

2. **`derive_trend_signals` (technical_analysis.py)** — single source for `price_vs_sma200` + `sma_50_200_regime`. The dead branch in `compute_indicators` (computed both signals every candle refresh, then the float-only persistence filter dropped them — no consumer, ever) is deleted; `thesis._shape_ta_state` now consumes the helper instead of its own inline copy. Context keys unchanged — writer prompt and eval fixtures depend on them. Return type of `compute_indicators` tightens to `dict[str, float | None]`.

## Conscious tradeoff — read-derive over persist

Issue #1989 stated "persisting is preferred". That preference predates #1987, which shipped the read-derive consumer (thesis block D). Persisting now would create a second source of truth for a value two already-stored floats derive in O(1), plus a price_daily migration + backfill for zero information gain. Settled decision (docs/settled-decisions.md TA-state line) records read-derive as the shipped state; this PR preserves it. #1987 spec amended to match (was still describing the compute-side strings — Codex ckpt-2 caveat).

## Security model

No new endpoints, no auth surface, no SQL, no user input. Pure-function extraction + doc. Files outside the diff relying on this behaviour: `app/services/market_data.py` persistence filter (still filters by `_TA_COLUMNS` + float-only — regression test retained), eval fixtures `tests/fixtures/llm_eval/*.json` (frozen contexts carry the same keys; `_shape_ta_state` output is byte-identical, verified by unchanged `TestShapeTaState`).

## Verification

- Behaviour parity pinned: 8-case table test on `derive_trend_signals` covers strict-`>`, tie=below, equal-SMAs→None, each missing-input combination; `tests/test_thesis.py::TestShapeTaState` passes unchanged.
- Gates: ruff check ✓, format ✓, pyright 0 ✓, fast tier exit 0 ✓, smoke vs dev DB exit 0 ✓ (worktree, commit 1a68…; pre-push hook re-ran all).
- Codex ckpt-2: "Findings: none" — parity, no remaining callers of removed keys, no import cycle (technical_analysis stays pure), focused tests green.
- Not an ETL/parser/schema change — clauses 8–12 n/a (no schema, no ingest path, no operator-visible figure changes; thesis context values identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)