### PR TITLE
fix(#2007): thesis writer output guards — band coherence + availability-claim mitigation

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -100,7 +101,9 @@ _MAX_TOKENS_CRITIC = 2048
 # Stamped onto every stored thesis row (theses.prompt_version). Bump
 # whenever _WRITER_SYSTEM / _CRITIC_SYSTEM or the _assemble_context shape
 # changes — memos from different prompt versions are not comparable.
-_PROMPT_VERSION = "v2"
+# v3 (#2007): _WRITER_SYSTEM gains the availability-claim mirror rule
+# (never disclaim a block the context marks available, then cite its figures).
+_PROMPT_VERSION = "v3"
 
 # thesis_runs.trigger — matches the table CHECK in sql/218.
 RunTrigger = Literal["manual", "cascade", "scheduled"]
@@ -166,13 +169,20 @@ def _to_float(val: object) -> float | None:
     output dict before persisting to the DB and returning in ThesisResult.
     Both sites must use the same conversion so the DB row and the returned
     struct are always consistent.
+
+    Non-finite floats (NaN / ±inf) map to None: an LLM can emit ``"nan"`` /
+    ``"inf"`` for a target field, and NaN silently defeats the #2007 ordering
+    guard (every ``>`` comparison against NaN is False) while persisting as a
+    non-numeric garbage target. Treat them as missing, consistently, at the one
+    coercion chokepoint both the guard and the INSERT share.
     """
     if val is None:
         return None
     try:
-        return float(val)  # type: ignore[arg-type]
+        result = float(val)  # type: ignore[arg-type]
     except TypeError, ValueError:
         return None
+    return result if math.isfinite(result) else None
 
 
 # ---------------------------------------------------------------------------
@@ -961,6 +971,12 @@ Rules:
   stance (an entry band is meaningless without a market price), and emit
   base/bull/bear_value only if fundamentals give a defensible per-share
   basis.
+- Data-availability language MUST mirror the block status fields verbatim
+  (#1632 evidence discipline). Never state a block is unavailable, missing, or
+  absent when its `available`/status field marks it present. When a block IS
+  unavailable or its status is non-`ok`, do not cite figures drawn from it —
+  omit the number or name the gap explicitly. Cited figures and availability
+  claims must both agree with the block statuses, never with each other.
 - Separate facts from judgement. Be explicit about what must go right.
 - Respond with ONLY valid JSON. No explanation outside the JSON object.
 """
@@ -1132,6 +1148,27 @@ def _validate_writer_output(data: dict[str, object]) -> None:
     memo = data.get("memo_markdown")
     if not isinstance(memo, str) or not memo.strip():
         raise ValueError("Writer output memo_markdown must be a non-empty string")
+
+    # Valuation-band coherence (#2007): the stored band must satisfy
+    # bear <= base <= bull, and the buy zone low <= high. Local writers
+    # intermittently emit mechanical copies (AMSC v1: bear=52w-low,
+    # bull=52w-high, base=book/share, so base < bear). Coerce through the
+    # SAME _to_float used at INSERT so we validate the values that actually
+    # persist; a null/garbage field coerces to None and drops out of its
+    # comparison. Raising ValueError rides the existing retry-once machinery.
+    bear = _to_float(data.get("bear_value"))
+    base = _to_float(data.get("base_value"))
+    bull = _to_float(data.get("bull_value"))
+    if bear is not None and base is not None and bear > base:
+        raise ValueError(f"Writer output incoherent targets: bear_value {bear} > base_value {base}")
+    if base is not None and bull is not None and base > bull:
+        raise ValueError(f"Writer output incoherent targets: base_value {base} > bull_value {bull}")
+    if bear is not None and bull is not None and bear > bull:
+        raise ValueError(f"Writer output incoherent targets: bear_value {bear} > bull_value {bull}")
+    zone_low = _to_float(data.get("buy_zone_low"))
+    zone_high = _to_float(data.get("buy_zone_high"))
+    if zone_low is not None and zone_high is not None and zone_low > zone_high:
+        raise ValueError(f"Writer output inverted buy zone: buy_zone_low {zone_low} > buy_zone_high {zone_high}")
 
 
 def _call_critic(client: LLMClient, memo_markdown: str, context: dict[str, object]) -> dict[str, object]:

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -194,6 +194,12 @@ class TestToFloat:
     def test_zero_converts(self) -> None:
         assert _to_float(0) == 0.0
 
+    @pytest.mark.parametrize("val", ["nan", "inf", "-inf", float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_returns_none(self, val: object) -> None:
+        # #2007: NaN silently defeats the ordering guard (nan > x is False) and
+        # persists as a non-numeric target. Non-finite floats map to None here.
+        assert _to_float(val) is None
+
 
 # ---------------------------------------------------------------------------
 # Stale detection
@@ -329,6 +335,56 @@ class TestValidateWriterOutput:
     @pytest.mark.parametrize("st", ["buy", "hold", "watch", "avoid"])
     def test_all_valid_stances_pass(self, st: str) -> None:
         _validate_writer_output({**_VALID_WRITER, "stance": st})
+
+    # --- valuation-band coherence (#2007) ---
+
+    def test_bear_above_base_raises(self) -> None:
+        bad = {**_VALID_WRITER, "bear_value": 210.0}  # > base 200
+        with pytest.raises(ValueError, match="incoherent targets"):
+            _validate_writer_output(bad)
+
+    def test_base_above_bull_raises(self) -> None:
+        bad = {**_VALID_WRITER, "base_value": 260.0}  # > bull 250
+        with pytest.raises(ValueError, match="incoherent targets"):
+            _validate_writer_output(bad)
+
+    def test_bear_above_bull_with_null_base_raises(self) -> None:
+        # base null breaks the transitive chain; the outer bear>bull bound catches it.
+        bad = {**_VALID_WRITER, "base_value": None, "bear_value": 300.0}  # > bull 250
+        with pytest.raises(ValueError, match="incoherent targets"):
+            _validate_writer_output(bad)
+
+    def test_inverted_buy_zone_raises(self) -> None:
+        bad = {**_VALID_WRITER, "buy_zone_low": 180.0, "buy_zone_high": 160.0}
+        with pytest.raises(ValueError, match="inverted buy zone"):
+            _validate_writer_output(bad)
+
+    def test_amsc_v1_incoherent_band_raises(self) -> None:
+        # Live regression: bear=52w-low, bull=52w-high, base=book/share → base < bear.
+        bad = {**_VALID_WRITER, "bear_value": 24.96, "base_value": 11.66, "bull_value": 69.98}
+        with pytest.raises(ValueError, match="incoherent targets"):
+            _validate_writer_output(bad)
+
+    def test_equal_band_values_pass(self) -> None:
+        # Degenerate but coherent: bear == base == bull is allowed (strict > only).
+        _validate_writer_output({**_VALID_WRITER, "bear_value": 200.0, "base_value": 200.0, "bull_value": 200.0})
+
+    def test_nan_band_value_treated_as_missing(self) -> None:
+        # NaN coerces to None (via _to_float), so it drops out of the ordering
+        # comparison rather than silently passing an incoherent band.
+        _validate_writer_output({**_VALID_WRITER, "bear_value": float("nan")})
+
+    def test_all_null_band_passes(self) -> None:
+        _validate_writer_output(
+            {
+                **_VALID_WRITER,
+                "buy_zone_low": None,
+                "buy_zone_high": None,
+                "base_value": None,
+                "bull_value": None,
+                "bear_value": None,
+            }
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2007.

## What changed
Two writer-output defects surfaced live on AMSC (instrument 9481) thesis v1, run 61, qwen3:14b.

### Defect 1 — incoherent valuation band stored + rendered
`_validate_writer_output` (app/services/thesis.py) previously checked required fields / enums / confidence range / types only — no band ordering. AMSC stored bear 24.96 / base 11.66 / bull 69.98 (base **below** bear — mechanical copies: bear=52w-low, bull=52w-high, base=book/share), and VerdictTab rendered it straight to the operator.

Now rejects when any of:
- `bear_value > base_value`
- `base_value > bull_value`
- `bear_value > bull_value` (outer bound — catches the base-null gap the adjacent-pair checks miss)
- `buy_zone_low > buy_zone_high`

Deterministic, no LLM judgement. Raising `ValueError` rides the existing retry-once machinery (`_call_with_one_retry`) — one re-roll, then the run fails and is recorded (thesis not stored incoherent).

### Defect 2 — writer fabricates data-availability claims
AMSC memo said "valuation metrics are unavailable" while the context block was `available: true` with full metrics — and then *used* that data (book/share, cash/share). `_WRITER_SYSTEM` gains a #1632 evidence-discipline rule: availability language must mirror block status fields; an unavailable/non-`ok` block's figures must be **omitted**, not cited under a false disclaimer.

This is a soft mitigation — structural validation can't catch prose. The durable check is the #2002 meta-thesis judge layer.

`_WRITER_SYSTEM` changed → `_PROMPT_VERSION` bumped v2 → v3 (settled invariant: memos from different prompt versions are not comparable).

## Full-population verification (falsify-the-premise)
Scanned all 61 stored theses on dev DB:
| check | violations |
|---|---|
| bear > base | **1** (the AMSC case) |
| base > bull | 0 |
| bear > bull | 0 |
| buy_zone inverted | 0 |

Guard is well-scoped — catches the reported case, zero false-positive risk against real stored data.

## Codex checkpoint-2 fixes (before first push)
- **NaN/inf bypass**: `_to_float("nan")` returned NaN (verified on py 3.14.4); `nan > x` is always False, so a NaN target silently passed the guard *and* persisted as a non-numeric garbage target. Fixed at the shared `_to_float` chokepoint with `math.isfinite` → both the guard and the INSERT now treat non-finite as missing (None), consistently.
- **Prompt wording**: original last line ("if you use a number, its source block is available — say so") could be satisfied by *claiming* availability to justify a bad citation. Reworded to force omission of figures from unavailable blocks.

## Source rule
#1632 evidence discipline (statuses verbatim, missing stays missing) governs Defect 2's mitigation. Defect 1 is a structural coherence invariant on the stored band — no external reg; the band's own ordering semantics (bear ≤ base ≤ bull) are the rule.

## Scope split
The "also noted" item (persist assembled writer context per run for auditability) is out of scope here — filed as #2017.

## Tests
- `TestValidateWriterOutput`: bear>base, base>bull, bear>bull-with-null-base, inverted buy zone, exact AMSC regression, equal-band pass, all-null pass, NaN-treated-as-missing.
- `TestToFloat`: non-finite (`nan`/`inf`/`-inf`, str + float forms) → None.
- Full thesis file: 102 passed.

## Checks
`ruff check` / `ruff format --check` / `pyright` clean on changed files; fast tier 4937 passed; smoke passed.

## Not applicable
DoD ETL clauses 8-12 (filings ETL / parser / schema) — this is thesis service logic + prompt, no schema/parser/ingest change, no backfill. No `model_version` concept for thesis output validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)