### PR TITLE
feat(#2009): fair-value band thesis consumer — PR-B (passive evidence + divergence audit)

### DIFF
--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -248,7 +248,9 @@ def band_quality_status(q: QualityInputs) -> str:
 
 
 def compute_divergence(
-    llm_base: float | None, band_base: float | None, threshold: float,
+    llm_base: float | None,
+    band_base: float | None,
+    threshold: float,
 ) -> tuple[float | None, bool | None]:
     """NULL-safe (#1632). Non-finite/absent operand or band_base<=0 => (None, None).
 
@@ -268,7 +270,18 @@ def compute_divergence(
 
 
 def _shape_fair_value_band(
-    row: tuple[float | None, float | None, float | None, str, str | None, _dt.date | None, _dt.date | None, _dt.date | None, dict[str, Any]] | None,
+    row: tuple[
+        float | None,
+        float | None,
+        float | None,
+        str,
+        str | None,
+        _dt.date | None,
+        _dt.date | None,
+        _dt.date | None,
+        dict[str, Any],
+    ]
+    | None,
 ) -> dict[str, object]:
     """Passive thesis context block. Absent => {available:false, reason}.
 
@@ -284,8 +297,12 @@ def _shape_fair_value_band(
     if bear is None or base is None or bull is None:
         return {"available": False, "reason": reason or "no_band"}
     return {
-        "available": True, "reason": reason, "quality_status": quality,
-        "bear": float(bear), "base": float(base), "bull": float(bull),
+        "available": True,
+        "reason": reason,
+        "quality_status": quality,
+        "bear": float(bear),
+        "base": float(base),
+        "bull": float(bull),
         "as_of_date": as_of_date.isoformat() if as_of_date else None,
         "ttm_end": ttm_end.isoformat() if ttm_end else None,
         "price_as_of": price_as_of.isoformat() if price_as_of else None,

--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -11,6 +11,7 @@ Spec: docs/proposals/valuation/2026-07-12-deterministic-fair-value-band.md
 from __future__ import annotations
 
 import datetime as _dt
+import math
 from dataclasses import dataclass
 from statistics import median
 from typing import Any, LiteralString
@@ -244,6 +245,52 @@ def band_quality_status(q: QualityInputs) -> str:
     if score >= 4:
         return "medium"
     return "low"
+
+
+def compute_divergence(
+    llm_base: float | None, band_base: float | None, threshold: float,
+) -> tuple[float | None, bool | None]:
+    """NULL-safe (#1632). Non-finite/absent operand or band_base<=0 => (None, None).
+
+    Both operands checked with math.isfinite BEFORE the positivity test: nan<=0
+    is False, so a NaN band_base would otherwise slip through to (nan, False)
+    (Codex ckpt-1 PR-B MED). Never raises — divergence is measure-only and must
+    not gate the atomic thesis insert.
+    """
+    if band_base is None or llm_base is None:
+        return (None, None)
+    if not (math.isfinite(band_base) and math.isfinite(llm_base)):
+        return (None, None)
+    if band_base <= 0:
+        return (None, None)
+    pct = abs(llm_base - band_base) / band_base
+    return (pct, pct > threshold)
+
+
+def _shape_fair_value_band(
+    row: tuple[float | None, float | None, float | None, str, str | None, _dt.date | None, _dt.date | None, _dt.date | None, dict[str, Any]] | None,
+) -> dict[str, object]:
+    """Passive thesis context block. Absent => {available:false, reason}.
+
+    row cols (B3 SELECT order):
+      (bear, base, bull, quality_status, reason, as_of_date, ttm_end, price_as_of, basis_json)
+    available:true ONLY when bear+base+bull all non-null — the storage CHECK
+    permits a partial triple, so a partial row fails closed rather than crashing
+    float(None) (Codex ckpt-1 PR-B LOW).
+    """
+    if row is None:
+        return {"available": False, "reason": "no_band"}
+    bear, base, bull, quality, reason, as_of_date, ttm_end, price_as_of, basis = row
+    if bear is None or base is None or bull is None:
+        return {"available": False, "reason": reason or "no_band"}
+    return {
+        "available": True, "reason": reason, "quality_status": quality,
+        "bear": float(bear), "base": float(base), "bull": float(bull),
+        "as_of_date": as_of_date.isoformat() if as_of_date else None,
+        "ttm_end": ttm_end.isoformat() if ttm_end else None,
+        "price_as_of": price_as_of.isoformat() if price_as_of else None,
+        "basis": basis,
+    }
 
 
 @dataclass(frozen=True)

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -59,7 +59,12 @@ from psycopg.types.json import Jsonb
 # peer_comparison and xbrl_derived_stats, neither of which imports thesis (or
 # anything that transitively reaches back here via scheduler/refresh_cascade) —
 # verified by grep, unlike risk_metrics below which genuinely cycles.
-from app.services.fair_value_band import METHOD_VERSION, _shape_fair_value_band
+from app.services.fair_value_band import (
+    DIVERGENCE_THRESHOLD,
+    METHOD_VERSION,
+    _shape_fair_value_band,
+    compute_divergence,
+)
 
 # Safe at module scope: instrument_analytics has no app-module imports at
 # top level (its insider_transactions read is function-lazy), so this does
@@ -1328,6 +1333,50 @@ def _insert_thesis_atomic(
     return int(row[0]), int(row[1])
 
 
+def _insert_thesis_valuation_audit(
+    conn: psycopg.Connection[Any],
+    thesis_id: int,
+    *,
+    band_base: float | None,
+    band_quality_status: str | None,
+    price_as_of: str | None,
+    llm_base: float | None,
+    divergence_pct: float | None,
+    divergence_flag: bool | None,
+) -> None:
+    """Insert-once band-vs-LLM divergence snapshot (#2009 PR-B, sql/222).
+
+    Best-effort-correct but runs INSIDE the atomic thesis-insert transaction
+    (must be called after the ``theses`` row exists, so the FK is valid).
+    ``band_base``/``divergence_pct``/``divergence_flag`` are all nullable —
+    the no-band path (and any ``available:false``) writes NULL, never
+    0/false (#1632). Never raises on the absent-band path: all params are
+    plain scalars or None, all target columns nullable.
+    """
+    conn.execute(
+        """
+        INSERT INTO thesis_valuation_audit (
+            thesis_id, band_method_version, band_base, band_quality_status,
+            price_as_of, llm_base, divergence_pct, divergence_flag
+        )
+        VALUES (
+            %(thesis_id)s, %(band_method_version)s, %(band_base)s, %(band_quality_status)s,
+            %(price_as_of)s, %(llm_base)s, %(divergence_pct)s, %(divergence_flag)s
+        )
+        """,
+        {
+            "thesis_id": thesis_id,
+            "band_method_version": METHOD_VERSION,
+            "band_base": band_base,
+            "band_quality_status": band_quality_status,
+            "price_as_of": price_as_of,
+            "llm_base": llm_base,
+            "divergence_pct": divergence_pct,
+            "divergence_flag": divergence_flag,
+        },
+    )
+
+
 def _update_last_reviewed(
     conn: psycopg.Connection[Any],
     instrument_id: int,
@@ -1520,6 +1569,27 @@ def generate_thesis(
                 critic_output if critic_output else None,
                 model=writer_completion.model,
                 provider=clients.writer.provider_name,
+            )
+            # #2009 PR-B: snapshot band-vs-LLM divergence in the same atomic
+            # txn as the thesis insert (FK requires thesis_id to exist first).
+            # Snapshot from the passive context block only — never re-read
+            # the mutable band from the DB (Codex ckpt-1 PR-B LOW).
+            fvb: dict[str, Any] = context.get("fair_value_band") or {}  # type: ignore[assignment]
+            band_available = fvb.get("available") is True
+            band_base = fvb.get("base") if band_available else None
+            band_quality_status = fvb.get("quality_status") if band_available else None
+            price_as_of = fvb.get("price_as_of") if band_available else None
+            llm_base = _to_float(writer_output.get("base_value"))
+            divergence_pct, divergence_flag = compute_divergence(llm_base, band_base, DIVERGENCE_THRESHOLD)
+            _insert_thesis_valuation_audit(
+                conn,
+                thesis_id,
+                band_base=band_base,
+                band_quality_status=band_quality_status,
+                price_as_of=price_as_of,
+                llm_base=llm_base,
+                divergence_pct=divergence_pct,
+                divergence_flag=divergence_flag,
             )
             _update_last_reviewed(conn, instrument_id)
             _finish_thesis_run_ok(conn, run_id, thesis_id)

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -21,6 +21,8 @@ Context caps (v2 — settled-decisions "Thesis prompt budget", amended #1987):
   - risk metrics (#1632): instrument_risk_metrics_current scalars, statused
   - price anchor (#1987): latest price_daily close (native ccy) + 52w range + returns
   - valuation (#1987):    instrument_valuation row when present; statused absence
+  - fair_value_band (#2009): fair_value_band_current row (fvb_v1) when present;
+                          statused absence (passive evidence, not gating)
   - analytics (#1987):    latest scores.analytics_json, shaped compact, scored_at-stamped
   - ta_state (#1987):     latest price_daily indicators + derived regime signals
 
@@ -52,6 +54,12 @@ from typing import Any, Literal
 import psycopg
 from psycopg import sql as psql
 from psycopg.types.json import Jsonb
+
+# Safe at module scope (#2009 B3): fair_value_band's only app-internal deps are
+# peer_comparison and xbrl_derived_stats, neither of which imports thesis (or
+# anything that transitively reaches back here via scheduler/refresh_cascade) —
+# verified by grep, unlike risk_metrics below which genuinely cycles.
+from app.services.fair_value_band import METHOD_VERSION, _shape_fair_value_band
 
 # Safe at module scope: instrument_analytics has no app-module imports at
 # top level (its insider_transactions read is function-lazy), so this does
@@ -103,7 +111,12 @@ _MAX_TOKENS_CRITIC = 2048
 # changes — memos from different prompt versions are not comparable.
 # v3 (#2007): _WRITER_SYSTEM gains the availability-claim mirror rule
 # (never disclaim a block the context marks available, then cite its figures).
-_PROMPT_VERSION = "v3"
+# v4 (#2009 PR-B): _assemble_context gains the passive fair_value_band block
+# (deterministic bear/base/bull evidence); _WRITER_SYSTEM gains the matching
+# "You will be given" bullet + a passive grounding rule (band is the primary
+# valuation anchor when available+high quality; price_anchor/52w range remain
+# the fallback). Scoring and _validate_writer_output are untouched.
+_PROMPT_VERSION = "v4"
 
 # thesis_runs.trigger — matches the table CHECK in sql/218.
 RunTrigger = Literal["manual", "cascade", "scheduled"]
@@ -847,6 +860,22 @@ def _assemble_context(
     ).fetchone()
     valuation = _shape_valuation(val_row)
 
+    # #2009 PR-B: passive fair-value-band evidence (fvb_v1). PR-A write-through
+    # only; this block is READ-ONLY here — no scoring/gating touch. Absence is
+    # structural for most of the universe (thin cohort, no fundamentals, stale
+    # price) and is statused, not errored — same discipline as `valuation`.
+    # Column order MUST match _shape_fair_value_band's unpack order exactly.
+    band_row = conn.execute(
+        """
+        SELECT bear_value, base_value, bull_value, quality_status, reason,
+               as_of_date, ttm_end, price_as_of, basis_json
+        FROM fair_value_band_current
+        WHERE instrument_id = %(id)s AND method_version = %(mv)s
+        """,
+        {"id": instrument_id, "mv": METHOD_VERSION},
+    ).fetchone()
+    fair_value_band = _shape_fair_value_band(band_row)
+
     # #1987 Block C: latest persisted IAR evidence (#1823). Refreshes only
     # on compute_rankings — staleness is allowed and stamped (scored_at),
     # mirroring risk_v1's as_of_date discipline.
@@ -876,6 +905,7 @@ def _assemble_context(
         "risk_metrics": risk_metrics,
         "price_anchor": price_anchor,
         "valuation": valuation,
+        "fair_value_band": fair_value_band,
         "analytics_evidence": analytics_evidence,
         "ta_state": ta_state,
         "earnings_history": [],
@@ -928,6 +958,12 @@ You will be given a research context including:
   `sma_50_200_regime`. The regime is the CURRENT 50d-vs-200d SMA relation
   ("golden" = 50d above 200d), NOT a recent crossover event. Null
   indicators mean insufficient history.
+- `fair_value_band`: deterministic valuation-band evidence — mechanically
+  synthesized bear/base/bull per-share values from peer + own-history
+  multiples, with a `quality_status` (high/medium/low) and `as_of_date`.
+  `available: false` with a `reason` (e.g. `thin_cohort`, `stale_price`,
+  `no_multiple`) means the surface is structurally absent for this
+  instrument — most of the universe — not a data error.
 
 Produce a JSON object with EXACTLY these fields:
 
@@ -971,6 +1007,14 @@ Rules:
   stance (an entry band is meaningless without a market price), and emit
   base/bull/bear_value only if fundamentals give a defensible per-share
   basis.
+- `fair_value_band` is deterministic valuation-band evidence — a mechanical
+  prior, not a constraint. When it is available AND `quality_status` is
+  `high`, it is your PRIMARY valuation anchor: ground bear/base/bull against
+  it and explain any large gap; `price_anchor.close` and the 52-week range
+  are the fallback grounding in that case, not a second "justify if outside"
+  test. When it is absent, or `quality_status` is `medium`/`low`, treat it as
+  weak or no evidence and rely on your own judgement grounded in
+  `price_anchor`/fundamentals instead.
 - Data-availability language MUST mirror the block status fields verbatim
   (#1632 evidence discipline). Never state a block is unavailable, missing, or
   absent when its `available`/status field marks it present. When a block IS

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -1574,7 +1574,8 @@ def generate_thesis(
             # txn as the thesis insert (FK requires thesis_id to exist first).
             # Snapshot from the passive context block only — never re-read
             # the mutable band from the DB (Codex ckpt-1 PR-B LOW).
-            fvb: dict[str, Any] = context.get("fair_value_band") or {}  # type: ignore[assignment]
+            fvb_raw = context.get("fair_value_band")
+            fvb: dict[str, Any] = fvb_raw if isinstance(fvb_raw, dict) else {}
             band_available = fvb.get("available") is True
             band_base = fvb.get("base") if band_available else None
             band_quality_status = fvb.get("quality_status") if band_available else None

--- a/docs/superpowers/plans/2026-07-12-fair-value-band.md
+++ b/docs/superpowers/plans/2026-07-12-fair-value-band.md
@@ -1155,7 +1155,13 @@ CREATE TABLE IF NOT EXISTS thesis_valuation_audit (
     band_quality_status  text,
     price_as_of          date,
     llm_base             numeric(18,6),
-    divergence_pct       numeric(10,6),   -- NULL when band_base NULL
+    divergence_pct       numeric,          -- NULL when band_base NULL. UNCONSTRAINED numeric
+                                           -- (NOT numeric(10,6)): a tiny positive band_base with a
+                                           -- large llm_base yields pct >> 9999, and a bounded type
+                                           -- would raise numeric_value_out_of_range INSIDE the
+                                           -- atomic thesis txn -> abort the whole thesis. Divergence
+                                           -- is MEASURE-ONLY and must never gate the insert
+                                           -- (Codex ckpt-1 PR-B HIGH).
     divergence_flag      boolean,          -- NULL when band_base NULL
     created_at           timestamptz NOT NULL DEFAULT now(),
     PRIMARY KEY (thesis_id)
@@ -1182,8 +1188,8 @@ git commit -m "feat(#2009): thesis_valuation_audit divergence table"
 
 **Interfaces:**
 - Produces:
-  - `compute_divergence(llm_base: float | None, band_base: float | None, threshold: float) -> tuple[float | None, bool | None]` — returns `(divergence_pct, divergence_flag)`; `(None, None)` when `band_base` is None or non-positive, or `llm_base` is None/NaN (no ZeroDivisionError, #1632).
-  - `_shape_fair_value_band(row: tuple | None) -> dict` — the passive context block: `{available, reason, quality_status, bear, base, bull, as_of_date, ttm_end, basis}` or `{available: False, reason}` when absent (context reason enum distinct from storage enum).
+  - `compute_divergence(llm_base: float | None, band_base: float | None, threshold: float) -> tuple[float | None, bool | None]` — returns `(divergence_pct, divergence_flag)`; `(None, None)` when EITHER operand is None or non-finite (NaN/±inf via `math.isfinite`), or `band_base <= 0` (no ZeroDivisionError, no `(nan, False)` leak, #1632). **Codex ckpt-1 PR-B MED:** guard `band_base` for NaN too — `nan <= 0` is False, so a NaN `band_base` would otherwise slip past the positivity check and return `(nan, False)`.
+  - `_shape_fair_value_band(row: tuple | None) -> dict` — the passive context block: `{available, reason, quality_status, bear, base, bull, as_of_date, ttm_end, price_as_of, basis}` or `{available: False, reason}` when absent (context reason enum distinct from storage enum). **`available: True` ONLY when bear AND base AND bull are all non-null** — the storage CHECK permits a partial triple (`bear NULL OR base NULL OR bull NULL OR ordered`), so a base-present/bear-null row must fail closed to absent rather than crash `float(None)` (Codex ckpt-1 PR-B LOW). `price_as_of` is carried (parallel to `valuation.price_as_of`, `thesis.py:499`) so B4's audit row can snapshot it.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -1215,9 +1221,35 @@ def test_divergence_llm_nan_is_null():
     assert compute_divergence(float("nan"), 100.0, 0.30) == (None, None)
 
 
+def test_divergence_band_base_nan_is_null():
+    # nan <= 0 is False — a NaN band_base must NOT slip past to (nan, False).
+    assert compute_divergence(120.0, float("nan"), 0.30) == (None, None)
+
+
+def test_divergence_llm_inf_is_null():
+    assert compute_divergence(float("inf"), 100.0, 0.30) == (None, None)
+
+
 def test_shape_absent_row():
     out = _shape_fair_value_band(None)
     assert out == {"available": False, "reason": "no_band"}
+
+
+def test_shape_partial_triple_fails_closed():
+    # base present but bull NULL (storage CHECK permits it) -> absent, no crash.
+    import datetime as _d
+    row = (100.0, 110.0, None, "medium", "ok", _d.date(2026, 7, 13), _d.date(2026, 6, 30), _d.date(2026, 7, 11), {})
+    out = _shape_fair_value_band(row)
+    assert out["available"] is False
+
+
+def test_shape_present_row_carries_price_as_of():
+    import datetime as _d
+    row = (100.0, 110.0, 130.0, "high", "ok", _d.date(2026, 7, 13), _d.date(2026, 6, 30), _d.date(2026, 7, 11), {"selected": ["pe"]})
+    out = _shape_fair_value_band(row)
+    assert out["available"] is True
+    assert out["price_as_of"] == "2026-07-11"
+    assert out["base"] == 110.0
 ```
 
 Add `import pytest` at the top of the test module if not present.
@@ -1236,30 +1268,48 @@ import math
 def compute_divergence(
     llm_base: float | None, band_base: float | None, threshold: float,
 ) -> tuple[float | None, bool | None]:
-    """NULL-safe (#1632). Absent/zero band or NaN llm => (None, None)."""
-    if band_base is None or band_base <= 0:
+    """NULL-safe (#1632). Non-finite/absent operand or band_base<=0 => (None, None).
+
+    Both operands checked with math.isfinite BEFORE the positivity test: nan<=0
+    is False, so a NaN band_base would otherwise slip through to (nan, False)
+    (Codex ckpt-1 PR-B MED). Never raises — divergence is measure-only and must
+    not gate the atomic thesis insert.
+    """
+    if band_base is None or llm_base is None:
         return (None, None)
-    if llm_base is None or math.isnan(llm_base):
+    if not (math.isfinite(band_base) and math.isfinite(llm_base)):
+        return (None, None)
+    if band_base <= 0:
         return (None, None)
     pct = abs(llm_base - band_base) / band_base
     return (pct, pct > threshold)
 
 
 def _shape_fair_value_band(row: tuple[object, ...] | None) -> dict[str, object]:
-    """Passive thesis context block. Absent => {available:false, reason}."""
+    """Passive thesis context block. Absent => {available:false, reason}.
+
+    row cols (B3 SELECT order):
+      (bear, base, bull, quality_status, reason, as_of_date, ttm_end, price_as_of, basis_json)
+    available:true ONLY when bear+base+bull all non-null — the storage CHECK
+    permits a partial triple, so a partial row fails closed rather than crashing
+    float(None) (Codex ckpt-1 PR-B LOW).
+    """
     if row is None:
         return {"available": False, "reason": "no_band"}
-    # row cols: (bear, base, bull, quality_status, reason, as_of_date, ttm_end, basis_json)
-    bear, base, bull, quality, reason, as_of_date, ttm_end, basis = row
-    if base is None:
+    bear, base, bull, quality, reason, as_of_date, ttm_end, price_as_of, basis = row
+    if bear is None or base is None or bull is None:
         return {"available": False, "reason": reason or "no_band"}
     return {
         "available": True, "reason": reason, "quality_status": quality,
         "bear": float(bear), "base": float(base), "bull": float(bull),
         "as_of_date": as_of_date.isoformat() if as_of_date else None,
-        "ttm_end": ttm_end.isoformat() if ttm_end else None, "basis": basis,
+        "ttm_end": ttm_end.isoformat() if ttm_end else None,
+        "price_as_of": price_as_of.isoformat() if price_as_of else None,
+        "basis": basis,
     }
 ```
+
+> **Plan note:** `import math` goes at the MODULE TOP of `app/services/fair_value_band.py` (python-hygiene — no import inside the function body), alongside the existing `from __future__ import annotations` / dataclass imports.
 
 - [ ] **Step 4: Run to verify pass + commit**
 
@@ -1282,7 +1332,7 @@ git commit -m "feat(#2009): NULL-safe divergence + passive context-block shape"
 
 - [ ] **Step 1: Read the band in `_assemble_context`**
 
-Add a `SELECT bear_value, base_value, bull_value, quality_status, reason, as_of_date, ttm_end, basis_json FROM fair_value_band_current WHERE instrument_id = %s AND method_version = %s` (params `(instrument_id, "fvb_v1")`), shape it via `_shape_fair_value_band`, and add `context["fair_value_band"] = fair_value_band` alongside `context["price_anchor"]` (~`thesis.py:877`).
+Add a `SELECT bear_value, base_value, bull_value, quality_status, reason, as_of_date, ttm_end, price_as_of, basis_json FROM fair_value_band_current WHERE instrument_id = %s AND method_version = %s` (params `(instrument_id, METHOD_VERSION)` — import `METHOD_VERSION` from `app.services.fair_value_band`, do NOT hard-code the `"fvb_v1"` string; single-source per global CLAUDE.md "no magic strings for identifiers with a typed counterpart"), shape it via `_shape_fair_value_band`, and add `context["fair_value_band"] = fair_value_band` alongside `context["price_anchor"]` (~`thesis.py:877`). **Column order in the SELECT MUST match `_shape_fair_value_band`'s unpack order** (bear, base, bull, quality, reason, as_of_date, ttm_end, price_as_of, basis) — `price_as_of` sits between `ttm_end` and `basis_json`.
 
 - [ ] **Step 2: Add the passive writer rule**
 
@@ -1316,15 +1366,46 @@ git commit -m "feat(#2009): passive fair-value-band context block + prompt-versi
 
 - [ ] **Step 1: Insert the audit row in the same txn**
 
-In `generate_thesis`, after the validated writer output is inserted into `theses` and its `thesis_id` is available (write-once; no post-hoc UPDATE of the append-only row), compute `divergence_pct, divergence_flag = compute_divergence(llm_base, band_base, DIVERGENCE_THRESHOLD)` where `band_base` is the base pulled from `context["fair_value_band"]` (None when absent) and `llm_base` is the writer's `base_value`. INSERT one `thesis_valuation_audit` row snapshotting `band_method_version="fvb_v1"`, `band_base`, `band_quality_status`, `price_as_of`, `llm_base`, `divergence_pct`, `divergence_flag`. The band snapshot makes a past thesis's divergence reconstructable though the live band is mutable. `_validate_writer_output` stays a **coherence-only hard gate** — divergence does NOT raise (soft signal for QA + critic).
+In `generate_thesis`, INSIDE the existing `with conn.transaction():` block (`thesis.py:1470`), immediately AFTER `_insert_thesis_atomic(...)` returns `thesis_id` and BEFORE the `with` block closes (so the two writes commit atomically and the FK to `theses(thesis_id)` is valid), insert the audit row. Do NOT thread `context` into `_insert_thesis_atomic` — insert directly in `generate_thesis` where both `context` and `thesis_id` are in scope, and do NOT re-read the mutable band (snapshot from `context["fair_value_band"]`, Codex ckpt-1 PR-B LOW).
+
+Read the band block once: `fvb = context.get("fair_value_band") or {}`; `band_available = fvb.get("available") is True`. Then:
+- `band_base = fvb.get("base") if band_available else None`
+- `band_quality_status = fvb.get("quality_status") if band_available else None`
+- `price_as_of = fvb.get("price_as_of") if band_available else None` (an ISO string — the column is `date`; pass it through, psycopg casts, or `None`)
+- `llm_base = _to_float(writer_output.get("base_value"))`
+- `divergence_pct, divergence_flag = compute_divergence(llm_base, band_base, DIVERGENCE_THRESHOLD)`
+
+INSERT one `thesis_valuation_audit` row: `band_method_version=METHOD_VERSION` (imported, not the literal), `band_base`, `band_quality_status`, `price_as_of`, `llm_base`, `divergence_pct`, `divergence_flag`. The band snapshot makes a past thesis's divergence reconstructable though the live band is mutable. `_validate_writer_output` stays a **coherence-only hard gate** — divergence does NOT raise (soft signal for QA + critic).
 
 - [ ] **Step 2: Verify the block is conditioned on availability**
 
 `band_base` None (the common ~8,700 path) → `compute_divergence` returns `(None, None)` → the row stores NULL divergence, never 0/false. Confirm no branch writes 0/false on absence.
 
-- [ ] **Step 3: Smoke + a targeted test**
+- [ ] **Step 3: Smoke + a db-tier transaction test**
 
-Add a pure test asserting the audit values for (a) a present band and (b) an absent band via `compute_divergence` (already covered in B2 — extend if a `generate_thesis`-level pure helper is extracted). Run: `uv run pytest tests/smoke -q`.
+Pure `compute_divergence` tests (B2) do NOT prove the audit row is actually inserted, inserted in-txn, or that the snapshot fields are correct (Codex ckpt-1 PR-B MED). Add ONE db-tier integration test in `tests/test_thesis_valuation_audit.py` (auto-`db`-marked — DB fixture):
+
+```python
+# tests/test_thesis_valuation_audit.py — one db-tier test for the audit-row invariant.
+import pytest
+
+pytestmark = pytest.mark.db
+
+
+def test_audit_row_present_band(db_conn):
+    """Seed a fair_value_band_current row (base present) + a theses row in ONE
+    txn; assert exactly one thesis_valuation_audit row keyed on the returned
+    thesis_id with band_base snapshotted and divergence computed (non-NULL)."""
+    ...
+
+
+def test_audit_row_absent_band_null_divergence(db_conn):
+    """No band row (or base NULL) -> audit row still written, divergence_pct and
+    divergence_flag both NULL (never 0/false, #1632)."""
+    ...
+```
+
+Exercise the real `generate_thesis` atomic path if a seedable fixture exists (grep `tests/` for an existing thesis-insert helper / `_insert_thesis_atomic` usage in tests to reuse — do NOT hand-roll a parallel insert path that could drift from production). If `generate_thesis` needs live LLM clients that the test env can't provide, drive the narrower seam instead: call `_insert_thesis_atomic` + the new audit-insert helper inside one `with db_conn.transaction():`, then assert the row. Keep the pure module (`tests/test_fair_value_band_policy.py`) DB-free — this test lives in its own db-tier module. Run: `docker compose --profile test up -d postgres-test && uv run pytest tests/test_thesis_valuation_audit.py -m db -v` and `uv run pytest tests/smoke -q`.
 
 - [ ] **Step 4: Commit**
 

--- a/sql/222_thesis_valuation_audit.sql
+++ b/sql/222_thesis_valuation_audit.sql
@@ -1,0 +1,23 @@
+-- 222_thesis_valuation_audit.sql
+-- #2009 PR-B / #2007 divergence measurement. Insert-once per thesis; the
+-- append-only home for band-vs-LLM divergence signals (keeps `theses` clean).
+-- band_base NULL (the ~8,700 no-band path) => divergence_pct/flag NULL, never
+-- 0/false (#1632).
+CREATE TABLE IF NOT EXISTS thesis_valuation_audit (
+    thesis_id            bigint      NOT NULL REFERENCES theses(thesis_id),
+    band_method_version  text,
+    band_base            numeric(18,6),
+    band_quality_status  text,
+    price_as_of          date,
+    llm_base             numeric(18,6),
+    divergence_pct       numeric,          -- NULL when band_base NULL. UNCONSTRAINED numeric
+                                           -- (NOT numeric(10,6)): a tiny positive band_base with a
+                                           -- large llm_base yields pct >> 9999, and a bounded type
+                                           -- would raise numeric_value_out_of_range INSIDE the
+                                           -- atomic thesis txn -> abort the whole thesis. Divergence
+                                           -- is MEASURE-ONLY and must never gate the insert
+                                           -- (Codex ckpt-1 PR-B HIGH).
+    divergence_flag      boolean,          -- NULL when band_base NULL
+    created_at           timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (thesis_id)
+);

--- a/tests/test_fair_value_band_policy.py
+++ b/tests/test_fair_value_band_policy.py
@@ -1,4 +1,7 @@
+import datetime as _d
 from typing import Any
+
+import pytest
 
 from app.services.fair_value_band import (
     MIN_OWN_POINTS,
@@ -6,9 +9,11 @@ from app.services.fair_value_band import (
     PeerPct,
     QualityInputs,
     TargetInputs,
+    _shape_fair_value_band,
     band_quality_status,
     combine_across,
     compute_band,
+    compute_divergence,
     currency_coherent,
     filter_dual_class,
     own_range,
@@ -270,3 +275,58 @@ def test_compute_band_thin_cohort_when_all_comparators_absent():
     )
     assert res.reason == "thin_cohort"
     assert res.base is None
+
+
+def test_divergence_normal():
+    pct, flag = compute_divergence(120.0, 100.0, 0.30)
+    assert pct == pytest.approx(0.20)
+    assert flag is False
+
+
+def test_divergence_flagged():
+    pct, flag = compute_divergence(150.0, 100.0, 0.30)
+    assert flag is True
+
+
+def test_divergence_band_base_none_is_null_not_zero():
+    assert compute_divergence(120.0, None, 0.30) == (None, None)
+
+
+def test_divergence_band_base_zero_is_null():
+    assert compute_divergence(120.0, 0.0, 0.30) == (None, None)
+
+
+def test_divergence_llm_nan_is_null():
+    assert compute_divergence(float("nan"), 100.0, 0.30) == (None, None)
+
+
+def test_divergence_band_base_nan_is_null():
+    # nan <= 0 is False — a NaN band_base must NOT slip past to (nan, False).
+    assert compute_divergence(120.0, float("nan"), 0.30) == (None, None)
+
+
+def test_divergence_llm_inf_is_null():
+    assert compute_divergence(float("inf"), 100.0, 0.30) == (None, None)
+
+
+def test_shape_absent_row():
+    out = _shape_fair_value_band(None)
+    assert out == {"available": False, "reason": "no_band"}
+
+
+def test_shape_partial_triple_fails_closed():
+    # base present but bull NULL (storage CHECK permits it) -> absent, no crash.
+    row = (100.0, 110.0, None, "medium", "ok", _d.date(2026, 7, 13), _d.date(2026, 6, 30), _d.date(2026, 7, 11), {})
+    out = _shape_fair_value_band(row)
+    assert out["available"] is False
+
+
+def test_shape_present_row_carries_price_as_of():
+    row = (
+        100.0, 110.0, 130.0, "high", "ok", _d.date(2026, 7, 13),
+        _d.date(2026, 6, 30), _d.date(2026, 7, 11), {"selected": ["pe"]},
+    )
+    out = _shape_fair_value_band(row)
+    assert out["available"] is True
+    assert out["price_as_of"] == "2026-07-11"
+    assert out["base"] == 110.0

--- a/tests/test_fair_value_band_policy.py
+++ b/tests/test_fair_value_band_policy.py
@@ -323,8 +323,15 @@ def test_shape_partial_triple_fails_closed():
 
 def test_shape_present_row_carries_price_as_of():
     row = (
-        100.0, 110.0, 130.0, "high", "ok", _d.date(2026, 7, 13),
-        _d.date(2026, 6, 30), _d.date(2026, 7, 11), {"selected": ["pe"]},
+        100.0,
+        110.0,
+        130.0,
+        "high",
+        "ok",
+        _d.date(2026, 7, 13),
+        _d.date(2026, 6, 30),
+        _d.date(2026, 7, 11),
+        {"selected": ["pe"]},
     )
     out = _shape_fair_value_band(row)
     assert out["available"] is True

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -509,11 +509,11 @@ def _pair(client: _FakeLLMClient, critic: _FakeLLMClient | None = None) -> LLMCl
 
 
 class TestAssembleContextEnrichment:
-    """#1987: the four new context keys must be present with honest defaults
+    """#1987 + #2009: the five new context keys must be present with honest defaults
     when the underlying surfaces are empty (the _make_conn mock returns no
-    rows for price_daily / instrument_valuation / scores). The populated
-    paths are covered by the shaper table-tests above; the real queries are
-    exercised on dev by the eval-harness fixture recapture (spec §Eval gate).
+    rows for price_daily / instrument_valuation / scores / fair_value_band_current).
+    The populated paths are covered by the shaper table-tests above; the real
+    queries are exercised on dev by the eval-harness fixture recapture (spec §Eval gate).
     """
 
     def test_empty_surfaces_yield_honest_absences(self) -> None:
@@ -524,6 +524,7 @@ class TestAssembleContextEnrichment:
         assert context["price_anchor"] is None
         assert context["ta_state"] is None
         assert context["valuation"] == {"available": False, "reason": "no_live_quote"}
+        assert context["fair_value_band"] == {"available": False, "reason": "no_band"}
         assert context["analytics_evidence"] is None
 
 

--- a/tests/test_thesis_valuation_audit.py
+++ b/tests/test_thesis_valuation_audit.py
@@ -15,6 +15,8 @@ fields (Codex ckpt-1 PR-B MED).
 
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
 from app.services.fair_value_band import DIVERGENCE_THRESHOLD, METHOD_VERSION, compute_divergence
@@ -95,6 +97,7 @@ def test_audit_row_present_band(conn) -> None:
     assert row[1] == METHOD_VERSION
     assert float(row[2]) == band_base
     assert row[3] == "high"
+    assert row[4] == datetime.date(2026, 7, 10)
     assert row[5] is not None and float(row[5]) == llm_base
     assert row[6] is not None  # divergence_pct
     assert row[7] is not None  # divergence_flag
@@ -136,7 +139,7 @@ def test_audit_row_absent_band_null_divergence(conn) -> None:
 
     rows = conn.execute(
         """
-        SELECT band_base, divergence_pct, divergence_flag
+        SELECT band_base, band_quality_status, price_as_of, divergence_pct, divergence_flag
         FROM thesis_valuation_audit
         WHERE thesis_id = %s
         """,
@@ -145,6 +148,8 @@ def test_audit_row_absent_band_null_divergence(conn) -> None:
 
     assert len(rows) == 1
     row = rows[0]
-    assert row[0] is None
-    assert row[1] is None
-    assert row[2] is None
+    assert row[0] is None  # band_base
+    assert row[1] is None  # band_quality_status
+    assert row[2] is None  # price_as_of
+    assert row[3] is None  # divergence_pct
+    assert row[4] is None  # divergence_flag

--- a/tests/test_thesis_valuation_audit.py
+++ b/tests/test_thesis_valuation_audit.py
@@ -1,0 +1,150 @@
+"""DB-tier tests for the #2009 PR-B divergence audit-row invariant (sql/222).
+
+Drives the narrower seam rather than the full ``generate_thesis`` path
+(which needs live LLM clients unavailable in the test env): seed a
+``theses`` row via ``_insert_thesis_atomic``, then call
+``_insert_thesis_valuation_audit`` inside the SAME transaction (mirroring
+how ``generate_thesis`` calls them back-to-back inside its
+``with conn.transaction():`` block), and assert the resulting row.
+
+Keeps ``tests/test_fair_value_band_policy.py`` (pure ``compute_divergence``
+table tests) DB-free — this module is the one db-tier proof that the row
+is actually inserted, inserted in-txn, and carries the right snapshot
+fields (Codex ckpt-1 PR-B MED).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.fair_value_band import DIVERGENCE_THRESHOLD, METHOD_VERSION, compute_divergence
+from app.services.thesis import _insert_thesis_atomic, _insert_thesis_valuation_audit, _to_float
+
+pytestmark = pytest.mark.db
+
+_VALID_WRITER = {
+    "thesis_type": "compounder",
+    "confidence_score": 0.75,
+    "stance": "buy",
+    "buy_zone_low": 150.0,
+    "buy_zone_high": 170.0,
+    "base_value": 200.0,
+    "bull_value": 250.0,
+    "bear_value": 120.0,
+    "break_conditions": ["Revenue growth falls below 10% for two consecutive quarters"],
+    "memo_markdown": "## Test\n\nMemo body.",
+}
+
+
+@pytest.fixture
+def conn(ebull_test_conn):
+    return ebull_test_conn
+
+
+def _seed_instrument(conn, instrument_id: int = 9101) -> int:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (instrument_id, "TVA", "Thesis Valuation Audit Test Co"),
+    )
+    conn.commit()
+    return instrument_id
+
+
+def test_audit_row_present_band(conn) -> None:
+    """Band present (base non-null) -> exactly one audit row, band_base
+    snapshotted, divergence_pct non-NULL."""
+    iid = _seed_instrument(conn)
+
+    band_base = 180.0
+    llm_base = _to_float(_VALID_WRITER["base_value"])  # 200.0
+    divergence_pct, divergence_flag = compute_divergence(llm_base, band_base, DIVERGENCE_THRESHOLD)
+
+    with conn.transaction():
+        thesis_id, _version = _insert_thesis_atomic(
+            conn,
+            iid,
+            _VALID_WRITER,
+            None,
+            model="qwen3:14b",
+            provider="openai_compatible",
+        )
+        _insert_thesis_valuation_audit(
+            conn,
+            thesis_id,
+            band_base=band_base,
+            band_quality_status="high",
+            price_as_of="2026-07-10",
+            llm_base=llm_base,
+            divergence_pct=divergence_pct,
+            divergence_flag=divergence_flag,
+        )
+
+    rows = conn.execute(
+        """
+        SELECT thesis_id, band_method_version, band_base, band_quality_status,
+               price_as_of, llm_base, divergence_pct, divergence_flag
+        FROM thesis_valuation_audit
+        WHERE thesis_id = %s
+        """,
+        (thesis_id,),
+    ).fetchall()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row[0] == thesis_id
+    assert row[1] == METHOD_VERSION
+    assert float(row[2]) == band_base
+    assert row[3] == "high"
+    assert row[5] is not None and float(row[5]) == llm_base
+    assert row[6] is not None  # divergence_pct
+    assert row[7] is not None  # divergence_flag
+    # (200 - 180) / 180 ≈ 0.1111 <= threshold 0.30 -> not divergent
+    assert float(row[6]) == pytest.approx(divergence_pct)
+    assert row[7] is False
+
+
+def test_audit_row_absent_band_null_divergence(conn) -> None:
+    """No band (available:false) -> audit row still written, divergence_pct
+    AND divergence_flag both NULL (never 0/false, #1632)."""
+    iid = _seed_instrument(conn, 9102)
+
+    llm_base = _to_float(_VALID_WRITER["base_value"])
+    band_base = None
+    divergence_pct, divergence_flag = compute_divergence(llm_base, band_base, DIVERGENCE_THRESHOLD)
+    assert divergence_pct is None
+    assert divergence_flag is None
+
+    with conn.transaction():
+        thesis_id, _version = _insert_thesis_atomic(
+            conn,
+            iid,
+            _VALID_WRITER,
+            None,
+            model="qwen3:14b",
+            provider="openai_compatible",
+        )
+        _insert_thesis_valuation_audit(
+            conn,
+            thesis_id,
+            band_base=band_base,
+            band_quality_status=None,
+            price_as_of=None,
+            llm_base=llm_base,
+            divergence_pct=divergence_pct,
+            divergence_flag=divergence_flag,
+        )
+
+    rows = conn.execute(
+        """
+        SELECT band_base, divergence_pct, divergence_flag
+        FROM thesis_valuation_audit
+        WHERE thesis_id = %s
+        """,
+        (thesis_id,),
+    ).fetchall()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row[0] is None
+    assert row[1] is None
+    assert row[2] is None

--- a/uv.lock
+++ b/uv.lock
@@ -177,14 +177,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

PR-B of #2009 — the **thesis consumer** of the deterministic fair-value valuation-evidence band. PR-A (merged `8a499015`) computes and stores a per-instrument bear/base/bull band in `fair_value_band_current` (`method_version='fvb_v1'`). PR-B makes the thesis writer *see* the band as **passive evidence** and records a NULL-safe divergence measurement per thesis — no scoring change, no gating.

Invert the 2026-07-11 finding that the 14B thesis writer is the least reliable fundamentals→price link: code computes a deterministic prior; the LLM reasons against it and its divergence is measured (not enforced). v1 is passive evidence + measurement; the "anchor unless justified" tightening is a data-driven v2 fast-follow.

## Changes (5 tasks, hard-ordered)

- **B1** `sql/222_thesis_valuation_audit.sql` — insert-once audit table (PK `thesis_id`, FK `theses(thesis_id)`), the append-only home for band-vs-LLM divergence signals. Keeps `theses` append-only/clean (no new columns). `divergence_pct` is **unconstrained `numeric`** (a bounded type would overflow on a tiny `band_base` and abort the atomic thesis txn — divergence is measure-only).
- **B2** pure `compute_divergence` + `_shape_fair_value_band` in `app/services/fair_value_band.py` — NULL-safe (#1632): either operand None/non-finite (`math.isfinite` guards both, before the `band_base<=0` test) or `band_base<=0` ⇒ `(None, None)`, never `0/false`, never raises. `_shape_fair_value_band` is `available:true` only when bear+base+bull all non-null (storage CHECK permits a partial triple → fail closed).
- **B3** `app/services/thesis.py` — passive `fair_value_band` context block in `_assemble_context` (reuses `_shape_fair_value_band`; SELECT column order matches its unpack order incl. `price_as_of`); a passive `_WRITER_SYSTEM` rule conditioned on `available:true` (mirrors the #1632 availability rule, states a hierarchy — band primary when present+high, `price_anchor`/52-week the fallback — **not** "stay within it"); `_PROMPT_VERSION` `v3`→**`v4`**.
- **B4** one `thesis_valuation_audit` row inside the existing atomic thesis txn, after `_insert_thesis_atomic` returns `thesis_id` — snapshots `band_method_version`/`band_base`/`band_quality_status`/`price_as_of`/`llm_base` + `compute_divergence(...)`. Absent band ⇒ NULL divergence. `_validate_writer_output` stays a coherence-only hard gate (divergence never raises/gates).
- **B5** gates + reviews (this PR).

## Security model

- Read-only band consumption (`SELECT` from `fair_value_band_current`); no user-controlled input reaches SQL. All SQL parameterized (named `%(...)s`), no f-string interpolation.
- The audit `INSERT` is inside the pre-existing atomic thesis transaction — a rolled-back thesis leaves no orphan audit row; the FK to `theses(thesis_id)` is satisfied because the insert runs after `_insert_thesis_atomic` returns.
- No auth/authorization surface touched; `_validate_writer_output`, scoring, and the `theses` schema are unchanged.

## `_PROMPT_VERSION` collision with #2010

PR-B claims **`v4`**. #2010 also intended `v4`; #2010 is currently unmerged, so PR-B legitimately takes `v4` and **#2010 must rebase to `v5`** on merge so memos stay version-comparable.

## Testing

- Pure tier (`tests/test_fair_value_band_policy.py`, DB-free): `compute_divergence` normal/flagged/NaN-both-operands/±inf/zero-band; `_shape_fair_value_band` absent/partial-triple-fail-closed/present-carries-`price_as_of`.
- db tier (`tests/test_thesis_valuation_audit.py`): present band ⇒ exactly one row, `band_base` + `price_as_of` snapshotted, divergence non-NULL; absent band ⇒ row written, all of `band_base`/`band_quality_status`/`price_as_of`/`divergence_pct`/`divergence_flag` NULL (#1632).
- `tests/test_thesis.py` — extended the #1987 `TestAssembleContextEnrichment` honest-absence discipline to the new `fair_value_band` key.
- Gates green: `ruff check` + `ruff format --check` clean, `pyright` 0 errors, `pytest -m "not db"` pass, `tests/smoke` pass, db-tier audit + fvb-io pass.
- Dev exercise: `_assemble_context` for AAPL returns `available=true, quality=medium, bear=202.32, base=309.85, bull=752.74` (matches PR-A's recorded dev band) — confirms SELECT/unpack column order.

## Rollout (operator — hard-ordered)

Merge B → **apply `sql/222`** → **restart the VS Code jobs task** so `thesis_refresh` picks up `_PROMPT_VERSION=v4` + band consumption. **No band backfill** (theses are versioned; existing memos are superseded on their next natural refresh). Operational note: because the audit insert is (by design) inside the thesis txn, `generate_thesis` aborts until `sql/222` is applied — apply the migration + restart before the next `thesis_refresh` so a generation outage isn't mistaken for a regression. Verify one freshly-regenerated thesis reads the band + wrote an audit row.

## Reviews before push

- Whole-branch review (opus): READY-TO-PUSH, 0 blocking, 11 cross-file invariants verified.
- Codex ckpt-2: (recorded in-thread).

Closes #2009
