### PR TITLE
feat(#2017): persist assembled thesis writer context per run (auditability)

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -1541,9 +1541,14 @@ def generate_thesis(
     """
     context = _assemble_context(conn, instrument_id)
     # #2017: fingerprint + summarize what the writer saw, persisted on the run
-    # row. Best-effort — audit compute must NEVER abort a valid generation
-    # (prevention-log line 2127; mirrors #2009 divergence "measure-only, never
-    # gate"). A failure degrades to NULL audit columns + a WARNING.
+    # row. Best-effort — this is forensic AUDIT metadata, not thesis data, so a
+    # compute bug must degrade (NULL columns + a WARNING), never abort a valid
+    # generation (mirrors #2009 divergence "measure-only, never gate"). The
+    # broad except is deliberate HERE precisely because prevention-log 2127
+    # forbids it for its case: 2127 is a per-row BATCH loop where a bug must
+    # fail loud; this is a single pre-LLM call site whose only failure mode is
+    # losing audit metadata. The pure module is fully fast-tier tested, and the
+    # WARNING + NULL columns surface the bug without sinking the thesis.
     try:
         context_sha256: str | None = hash_context(context)
         context_summary: dict[str, object] | None = summarize_context(context, _PROMPT_VERSION)

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -73,6 +73,7 @@ from app.services.fair_value_band import (
 from app.services.instrument_analytics import SCHEMA_VERSION as _IAR_SCHEMA_VERSION
 from app.services.llm_client import LLMClient, LLMClientPair, LLMCompletion
 from app.services.technical_analysis import derive_trend_signals
+from app.services.thesis_context_audit import hash_context, summarize_context
 
 logger = logging.getLogger(__name__)
 
@@ -1400,6 +1401,8 @@ def _insert_thesis_run(
     provider: str,
     model: str,
     critic_model: str,
+    context_sha256: str | None = None,
+    context_summary: dict[str, object] | None = None,
 ) -> int:
     """Insert a 'running' thesis_runs row and return its run_id.
 
@@ -1409,11 +1412,19 @@ def _insert_thesis_run(
     ``critic_json.model`` the critic's. Recording ``critic_model`` here
     is what keeps critic provenance auditable when the best-effort critic
     fails and no ``critic_json`` is stored (#1995).
+
+    ``context_sha256`` / ``context_summary`` (#2017) fingerprint + summarize
+    the assembled writer context. Written HERE — before the LLM call and the
+    pre-LLM commit — so failed/guard-rejected runs retain the audit. Both
+    nullable: a caller that omits them (or an audit-compute failure upstream)
+    leaves the columns NULL.
     """
     row = conn.execute(
         """
-        INSERT INTO thesis_runs (instrument_id, trigger, provider, model, critic_model)
-        VALUES (%(instrument_id)s, %(trigger)s, %(provider)s, %(model)s, %(critic_model)s)
+        INSERT INTO thesis_runs (instrument_id, trigger, provider, model, critic_model,
+                                 context_sha256, context_summary)
+        VALUES (%(instrument_id)s, %(trigger)s, %(provider)s, %(model)s, %(critic_model)s,
+                %(context_sha256)s, %(context_summary)s)
         RETURNING run_id
         """,
         {
@@ -1422,6 +1433,8 @@ def _insert_thesis_run(
             "provider": provider,
             "model": model,
             "critic_model": critic_model,
+            "context_sha256": context_sha256,
+            "context_summary": Jsonb(context_summary) if context_summary is not None else None,
         },
     ).fetchone()
     if row is None:
@@ -1527,6 +1540,16 @@ def generate_thesis(
     dedicated connection.
     """
     context = _assemble_context(conn, instrument_id)
+    # #2017: fingerprint + summarize what the writer saw, persisted on the run
+    # row. Best-effort — audit compute must NEVER abort a valid generation
+    # (prevention-log line 2127; mirrors #2009 divergence "measure-only, never
+    # gate"). A failure degrades to NULL audit columns + a WARNING.
+    try:
+        context_sha256: str | None = hash_context(context)
+        context_summary: dict[str, object] | None = summarize_context(context, _PROMPT_VERSION)
+    except Exception:
+        logger.warning("thesis context audit compute failed for instrument_id=%d", instrument_id, exc_info=True)
+        context_sha256, context_summary = None, None
     run_id = _insert_thesis_run(
         conn,
         instrument_id,
@@ -1534,6 +1557,8 @@ def generate_thesis(
         provider=clients.writer.provider_name,
         model=clients.writer.model,
         critic_model=clients.critic.model,
+        context_sha256=context_sha256,
+        context_summary=context_summary,
     )
     # Close the implicit read tx opened by _assemble_context SELECTs
     # (and publish the 'running' run row) BEFORE the LLM calls below.

--- a/app/services/thesis_context_audit.py
+++ b/app/services/thesis_context_audit.py
@@ -72,9 +72,13 @@ def summarize_context(context: Mapping[str, object], prompt_version: str) -> dic
 def _block_status(key: str, val: object) -> dict[str, object]:
     """Availability (+ optional status/as-of/count) for one context block.
 
-    Total by construction: ``.get()`` only, never raises, so the summary is
-    safe over any block shape. A block absent from the maps still gets an
-    ``available`` entry (drift-safe).
+    Total over the shapes ``_assemble_context`` actually produces (``.get()``
+    only — no bracket indexing, no attribute access): every as-of field it
+    emits is an ISO-8601 string, so ``max()`` over collected stamps is
+    well-defined there. Not a guarantee over arbitrary/malformed shapes —
+    heterogeneous non-orderable as-of values could make ``max()`` raise; the
+    caller wraps the compute defensively as the backstop. A block absent
+    from the maps still gets an ``available`` entry (drift-safe).
     """
     if val is None:
         return {"available": False}
@@ -116,5 +120,7 @@ def _block_status(key: str, val: object) -> dict[str, object]:
                 out["as_of"] = asof
         return out
 
-    # scalar / unexpected top-level type — defensive (not expected).
-    return {"available": val is not None}
+    # scalar / unexpected top-level type — defensive (not expected). The
+    # `val is None` branch above already returned, so val is always a
+    # non-None scalar here.
+    return {"available": True}

--- a/app/services/thesis_context_audit.py
+++ b/app/services/thesis_context_audit.py
@@ -44,9 +44,11 @@ def hash_context(context: Mapping[str, object]) -> str:
     Strict — no json ``default`` fallback. The thesis context is guaranteed
     JSON-shaped (shapers emit isoformat strings + float|None; ``_to_float``
     maps NaN/inf to None), so a non-serializable type is a bug to surface, not
-    silently stringify. The db-tier test hashes a real assembled context, and
-    the caller wraps this defensively so a raise degrades to NULL audit columns
-    rather than aborting a thesis.
+    silently stringify. The fast-tier test proves the strict raise against a
+    synthetic non-JSON input; ``tests/test_thesis.py::test_empty_surfaces_yield_honest_absences``
+    hashes a REAL ``_assemble_context`` output, so the helpers are exercised against the true shapes,
+    not just hand-built fixtures. At runtime the ``thesis.py`` call site wraps this so a raise degrades
+    to NULL audit columns + a WARNING — never silently stringified into the hash, never aborts a thesis.
 
     Note: this fingerprints the exact context bytes; it does NOT prove
     "sources unchanged" by later recomputation (``_assemble_context`` is

--- a/app/services/thesis_context_audit.py
+++ b/app/services/thesis_context_audit.py
@@ -1,0 +1,120 @@
+"""Pure helpers persisting what the thesis writer saw, per run (#2017).
+
+`_assemble_context` (:mod:`app.services.thesis`) builds the writer's research
+dict but does not persist it. These helpers derive compact, auditable
+metadata from that dict — a content hash and a per-block
+availability/status/as-of summary — stored on ``thesis_runs`` at run-insert.
+Enough to audit availability-claim fabrication (#2007 Defect 2 class) and to
+detect that sources moved, WITHOUT duplicating the source rows.
+
+Pure: no DB, no I/O. ``prompt_version`` is a parameter (not an import) so this
+module never depends on ``thesis`` — no import cycle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+# As-of field name per shaped context block (see thesis._assemble_context).
+# List blocks are date-carrying element lists; the summary reports max(stamp).
+_LIST_ASOF: dict[str, str] = {
+    "fundamentals": "as_of_date",
+    "filings": "filing_date",
+    "news": "event_time",
+}
+_DICT_ASOF: dict[str, str] = {
+    "prior_thesis": "created_at",
+    "price_anchor": "price_date",
+    "valuation": "price_as_of",
+    # the band's OWN vintage (fair_value_band_current.as_of_date), NOT the
+    # price leg (price_as_of) — the band is fundamentals-anchored (Codex ckpt-2).
+    "fair_value_band": "as_of_date",
+    "analytics_evidence": "as_of",
+}
+# A dict whose keys are ALL markers (no substantive payload) is "absent usable
+# evidence", not present — e.g. a malformed/unsupported analytics wrapper.
+_MARKER_KEYS: frozenset[str] = frozenset({"available", "reason", "status", "quality_status", "schema"})
+
+
+def hash_context(context: Mapping[str, object]) -> str:
+    """sha256 of the canonically-serialized context (stable key order, compact).
+
+    Strict — no json ``default`` fallback. The thesis context is guaranteed
+    JSON-shaped (shapers emit isoformat strings + float|None; ``_to_float``
+    maps NaN/inf to None), so a non-serializable type is a bug to surface, not
+    silently stringify. The db-tier test hashes a real assembled context, and
+    the caller wraps this defensively so a raise degrades to NULL audit columns
+    rather than aborting a thesis.
+
+    Note: this fingerprints the exact context bytes; it does NOT prove
+    "sources unchanged" by later recomputation (``_assemble_context`` is
+    non-reproducible — the news query uses a wall-clock 30d cutoff). Drift is
+    detected via the summary's as-of stamps, not by re-hashing.
+    """
+    blob = json.dumps(context, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def summarize_context(context: Mapping[str, object], prompt_version: str) -> dict[str, object]:
+    """Per-block availability/status/as-of summary of the writer context.
+
+    ``prompt_version`` is recorded (self-describing across future context-shape
+    changes) — recording is not a ``_PROMPT_VERSION`` bump.
+    """
+    return {
+        "prompt_version": prompt_version,
+        "blocks": {key: _block_status(key, val) for key, val in context.items()},
+    }
+
+
+def _block_status(key: str, val: object) -> dict[str, object]:
+    """Availability (+ optional status/as-of/count) for one context block.
+
+    Total by construction: ``.get()`` only, never raises, so the summary is
+    safe over any block shape. A block absent from the maps still gets an
+    ``available`` entry (drift-safe).
+    """
+    if val is None:
+        return {"available": False}
+
+    if isinstance(val, list):
+        out: dict[str, object] = {"available": bool(val), "count": len(val)}
+        asof_key = _LIST_ASOF.get(key)
+        if asof_key is not None:
+            stamps = [stamp for e in val if isinstance(e, Mapping) and (stamp := e.get(asof_key)) is not None]
+            if stamps:
+                # ISO date/timestamp strings sort lexicographically = chronologically.
+                out["as_of"] = max(stamps)
+        return out
+
+    if isinstance(val, Mapping):
+        if key == "risk_metrics":
+            windows = val.get("windows") or []
+            stamps = [stamp for w in windows if isinstance(w, Mapping) and (stamp := w.get("as_of_date")) is not None]
+            out = {"available": True, "metric_version": val.get("metric_version")}
+            if stamps:
+                out["as_of"] = max(stamps)
+            return out
+
+        if "available" in val:
+            available = bool(val["available"])
+        else:
+            # present iff it carries payload beyond status markers
+            available = bool(set(val) - _MARKER_KEYS)
+        out = {"available": available}
+        for status_key in ("quality_status", "reason"):
+            status = val.get(status_key)
+            if status is not None:
+                out["status"] = status
+                break
+        asof_key = _DICT_ASOF.get(key)
+        if asof_key is not None:
+            asof = val.get(asof_key)
+            if asof is not None:
+                out["as_of"] = asof
+        return out
+
+    # scalar / unexpected top-level type — defensive (not expected).
+    return {"available": val is not None}

--- a/docs/superpowers/plans/2026-07-13-thesis-context-audit.md
+++ b/docs/superpowers/plans/2026-07-13-thesis-context-audit.md
@@ -66,22 +66,15 @@ ALTER TABLE thesis_runs
 COMMIT;
 ```
 
-- [ ] **Step 2: Apply to the dev test DB and verify the columns exist**
+- [ ] **Step 2: Apply migrations and verify the columns exist**
 
-Run:
+`run_migrations()` (`app/db/migrations.py:115`) takes no args — it reads the configured DSN and applies every `sql/NNN_*.sql` in order. Apply against the dev DB and verify:
+
 ```bash
-docker compose --profile test up -d postgres-test
-uv run python -c "
-from app.db.migrations import run_migrations
-from tests.fixtures.db import test_dsn  # or the project's migration entrypoint
-"
-```
-If the repo has no scriptable single-migration apply, apply via the standard runner the smoke test uses, then verify:
-```bash
+uv run python -c "from app.db.migrations import run_migrations; print(run_migrations()[-3:])"
 uv run python - <<'PY'
-import psycopg, os
-dsn = os.environ.get("EBULL_TEST_DATABASE_URL") or os.environ["DATABASE_URL"]
-with psycopg.connect(dsn) as c:
+from app.db.pool import open_pool
+with open_pool() as pool, pool.connection() as c:
     cols = c.execute("""
         SELECT column_name, data_type, is_nullable FROM information_schema.columns
         WHERE table_name='thesis_runs' AND column_name IN ('context_sha256','context_summary')
@@ -90,9 +83,11 @@ with psycopg.connect(dsn) as c:
     print(cols)
 PY
 ```
-Expected: `[('context_sha256','text','YES'), ('context_summary','jsonb','YES')]`
+Expected: the migration list ends with `223_thesis_runs_context_audit.sql`, and the columns print as `[('context_sha256','text','YES'), ('context_summary','jsonb','YES')]`.
 
-> If migrations only apply via the FastAPI lifespan, running the smoke test in Task 3 applies sql/223; this step's manual apply is the verification path when iterating locally.
+> The db-tier tests (Task 3) apply sql/223 automatically: the `ebull_test_db` fixture rebuilds its template DB whenever `_migration_hash()` changes (`tests/fixtures/ebull_test_db.py`), and adding sql/223 changes that hash. No manual test-DB apply needed — this step is the dev-DB verification path.
+
+> If `open_pool()` is not the right dev entrypoint here, fall back to the smoke test (`uv run pytest tests/smoke`), which boots the FastAPI lifespan and runs migrations against dev — a green smoke run proves sql/223 applies cleanly.
 
 - [ ] **Step 3: Commit**
 
@@ -156,7 +151,14 @@ def _full_context() -> dict[str, object]:
         },
         "price_anchor": {"close": 210.0, "price_date": "2025-07-11", "currency": "USD"},
         "valuation": {"available": True, "current_price": 210.0, "price_as_of": "2025-07-11"},
-        "fair_value_band": {"available": True, "base": 200.0, "quality_status": "ok", "price_as_of": "2025-07-11"},
+        # representative _shape_fair_value_band output — as_of_date (band vintage)
+        # deliberately DISTINCT from price_as_of so the test proves we pick as_of_date.
+        "fair_value_band": {
+            "available": True, "reason": None, "quality_status": "ok",
+            "bear": 150.0, "base": 200.0, "bull": 250.0,
+            "as_of_date": "2025-06-30", "ttm_end": "2025-03-31", "price_as_of": "2025-07-11",
+            "basis": {},
+        },
         "analytics_evidence": {"schema": "iar_v1", "as_of": "2025-07-09T00:00:00+00:00", "piotroski": {"score": 7}},
         "ta_state": {"sma_50": 205.0, "sma_200": 190.0, "price_vs_sma200": "above"},
         "earnings_history": [],
@@ -209,7 +211,8 @@ def test_list_as_of_is_max_not_first_element() -> None:
 
 def test_explicit_available_blocks_mirror_flag_and_carry_status_asof() -> None:
     blocks = summarize_context(_full_context(), _PV)["blocks"]
-    assert blocks["fair_value_band"] == {"available": True, "status": "ok", "as_of": "2025-07-11"}
+    # fair_value_band as_of = the band's own as_of_date (2025-06-30), NOT price_as_of.
+    assert blocks["fair_value_band"] == {"available": True, "status": "ok", "as_of": "2025-06-30"}
     assert blocks["valuation"] == {"available": True, "as_of": "2025-07-11"}  # present → no status field
 
 
@@ -299,7 +302,9 @@ _DICT_ASOF: dict[str, str] = {
     "prior_thesis": "created_at",
     "price_anchor": "price_date",
     "valuation": "price_as_of",
-    "fair_value_band": "price_as_of",
+    # the band's OWN vintage (fair_value_band_current.as_of_date), NOT the
+    # price leg (price_as_of) — the band is fundamentals-anchored (Codex ckpt-2).
+    "fair_value_band": "as_of_date",
     "analytics_evidence": "as_of",
 }
 # A dict whose keys are ALL markers (no substantive payload) is "absent usable

--- a/docs/superpowers/plans/2026-07-13-thesis-context-audit.md
+++ b/docs/superpowers/plans/2026-07-13-thesis-context-audit.md
@@ -1,0 +1,682 @@
+# Thesis Context Audit (#2017) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist a content hash + per-block availability/status/as-of summary of the assembled thesis writer context onto `thesis_runs`, at run-insert time, so a memo's evidence is auditable from storage (incl. failed/guard-rejected runs).
+
+**Architecture:** New pure module (`thesis_context_audit.py`) computes `hash_context` + `summarize_context` from the context dict `_assemble_context` already builds. `generate_thesis` computes both right after assembly (defensively wrapped) and passes them into `_insert_thesis_run`, which writes two new nullable columns on `thesis_runs`. The insert commits before the LLM call, so the audit survives every downstream failure path.
+
+**Tech Stack:** Python 3.14, psycopg3, Postgres, pytest (fast tier + `db` tier).
+
+## Global Constraints
+
+- **No `_PROMPT_VERSION` bump.** Writer prompt is byte-identical; this only reads the context to write audit metadata to a different table. `_PROMPT_VERSION` (`app/services/thesis.py:124`, currently `"v4"`) is *recorded inside* the summary, not incremented.
+- **No backfill.** Both columns nullable; historical `thesis_runs` rows stay NULL (past contexts are non-reconstructable). Matches the sql/218/219 nullable-column precedent.
+- **Best-effort, never gate.** Audit compute must never abort a valid thesis (prevention-log line 2127; mirrors #2009 divergence "measure-only"). Defensive wrap at the call site → NULL columns + WARNING log on failure.
+- **Migration discipline.** New file `sql/223_*.sql` (never edit an applied migration — prevention-log content-drift rule). `ADD COLUMN IF NOT EXISTS` (prevention-log line 1121; mirrors sql/219's `critic_model` add).
+- **Pure module is `.get()`-only / total** — `_block_status` never raises on any block shape.
+- Spec: `docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md`.
+
+---
+
+## File Structure
+
+- Create `sql/223_thesis_runs_context_audit.sql` — the two nullable columns on `thesis_runs`.
+- Create `app/services/thesis_context_audit.py` — pure `hash_context` + `summarize_context` + `_block_status` + the as-of/marker maps.
+- Create `tests/test_thesis_context_audit.py` — fast-tier tests for the pure module.
+- Create `tests/test_thesis_context_audit_persist.py` — db-tier: the two columns persist on insert and survive a failed run.
+- Modify `app/services/thesis.py` — import the two functions; extend `_insert_thesis_run` (signature + INSERT); compute + pass in `generate_thesis`.
+
+---
+
+### Task 1: Migration — two nullable columns on `thesis_runs`
+
+**Files:**
+- Create: `sql/223_thesis_runs_context_audit.sql`
+
+**Interfaces:**
+- Consumes: existing `thesis_runs` table (sql/218).
+- Produces: `thesis_runs.context_sha256 TEXT`, `thesis_runs.context_summary JSONB` (both nullable) — consumed by Task 3.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- 223: persist assembled thesis writer context per run (#2017)
+--
+-- Spec: docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
+--
+-- Altered tables:
+--   thesis_runs — context_sha256 (content-identity fingerprint of the
+--                 assembled writer context) + context_summary (per-block
+--                 availability/status/as-of JSONB). Both nullable; written
+--                 at run-insert BEFORE the LLM call so failed/guard-rejected
+--                 runs are captured too (the #2007 AMSC debugging class).
+--                 Historical rows stay NULL — past contexts are
+--                 non-reconstructable, so there is no backfill.
+--
+-- Not a context-SHAPE change (the writer prompt is byte-identical), so
+-- _PROMPT_VERSION is NOT bumped; the version is recorded inside the summary.
+
+BEGIN;
+
+ALTER TABLE thesis_runs
+    ADD COLUMN IF NOT EXISTS context_sha256  TEXT,
+    ADD COLUMN IF NOT EXISTS context_summary JSONB;
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply to the dev test DB and verify the columns exist**
+
+Run:
+```bash
+docker compose --profile test up -d postgres-test
+uv run python -c "
+from app.db.migrations import run_migrations
+from tests.fixtures.db import test_dsn  # or the project's migration entrypoint
+"
+```
+If the repo has no scriptable single-migration apply, apply via the standard runner the smoke test uses, then verify:
+```bash
+uv run python - <<'PY'
+import psycopg, os
+dsn = os.environ.get("EBULL_TEST_DATABASE_URL") or os.environ["DATABASE_URL"]
+with psycopg.connect(dsn) as c:
+    cols = c.execute("""
+        SELECT column_name, data_type, is_nullable FROM information_schema.columns
+        WHERE table_name='thesis_runs' AND column_name IN ('context_sha256','context_summary')
+        ORDER BY column_name
+    """).fetchall()
+    print(cols)
+PY
+```
+Expected: `[('context_sha256','text','YES'), ('context_summary','jsonb','YES')]`
+
+> If migrations only apply via the FastAPI lifespan, running the smoke test in Task 3 applies sql/223; this step's manual apply is the verification path when iterating locally.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sql/223_thesis_runs_context_audit.sql
+git commit -m "feat(#2017): sql/223 — thesis_runs context-audit columns"
+```
+
+---
+
+### Task 2: Pure module — `hash_context` + `summarize_context`
+
+**Files:**
+- Create: `app/services/thesis_context_audit.py`
+- Test: `tests/test_thesis_context_audit.py`
+
+**Interfaces:**
+- Consumes: nothing (pure; takes `prompt_version` as a param so it never imports `thesis._PROMPT_VERSION`).
+- Produces:
+  - `hash_context(context: Mapping[str, object]) -> str`
+  - `summarize_context(context: Mapping[str, object], prompt_version: str) -> dict[str, object]`
+  Both consumed by Task 3.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_thesis_context_audit.py
+"""Fast-tier tests for the pure thesis context-audit helpers (#2017).
+
+No DB: hash determinism + per-block availability/status/as-of summary.
+"""
+
+from __future__ import annotations
+
+from app.services.thesis_context_audit import hash_context, summarize_context
+
+_PV = "v4"
+
+
+def _full_context() -> dict[str, object]:
+    """A representative _assemble_context-shaped dict (subset of real fields)."""
+    return {
+        "instrument": {"symbol": "AAPL", "company_name": "Apple", "currency": "USD"},
+        "fundamentals": [
+            {"as_of_date": "2025-03-31", "revenue_ttm": 4.0e11},
+            {"as_of_date": "2024-12-31", "revenue_ttm": 3.9e11},
+        ],
+        "filings": [{"filing_date": "2025-05-01", "filing_type": "10-Q", "summary": "…"}],
+        # news is ordered importance DESC, NOT recency — [0] is NOT the newest event.
+        "news": [
+            {"event_time": "2025-07-01T00:00:00+00:00", "headline": "high-importance older"},
+            {"event_time": "2025-07-10T00:00:00+00:00", "headline": "low-importance newer"},
+        ],
+        "prior_thesis": {"version": 3, "stance": "buy", "created_at": "2025-07-01T12:00:00+00:00"},
+        "risk_metrics": {
+            "metric_version": "risk_v1",
+            "windows": [
+                {"window_key": "1y", "as_of_date": "2025-07-11", "cagr_status": "ok"},
+                {"window_key": "3y", "as_of_date": "2025-07-11", "cagr_status": "thin_history"},
+            ],
+        },
+        "price_anchor": {"close": 210.0, "price_date": "2025-07-11", "currency": "USD"},
+        "valuation": {"available": True, "current_price": 210.0, "price_as_of": "2025-07-11"},
+        "fair_value_band": {"available": True, "base": 200.0, "quality_status": "ok", "price_as_of": "2025-07-11"},
+        "analytics_evidence": {"schema": "iar_v1", "as_of": "2025-07-09T00:00:00+00:00", "piotroski": {"score": 7}},
+        "ta_state": {"sma_50": 205.0, "sma_200": 190.0, "price_vs_sma200": "above"},
+        "earnings_history": [],
+        "analyst_estimates": None,
+    }
+
+
+# --- hash_context ---------------------------------------------------------
+
+def test_hash_is_deterministic_and_key_order_independent() -> None:
+    a = {"x": 1, "y": {"b": 2, "a": 3}, "z": [1, 2]}
+    b = {"z": [1, 2], "y": {"a": 3, "b": 2}, "x": 1}  # same content, keys reordered
+    assert hash_context(a) == hash_context(b)
+
+
+def test_hash_changes_on_nested_value_change() -> None:
+    a = _full_context()
+    b = _full_context()
+    b["price_anchor"] = {**a["price_anchor"], "close": 999.0}  # type: ignore[dict-item]
+    assert hash_context(a) != hash_context(b)
+
+
+def test_hash_is_64_hex_chars() -> None:
+    h = hash_context(_full_context())
+    assert len(h) == 64 and all(c in "0123456789abcdef" for c in h)
+
+
+# --- summarize_context ----------------------------------------------------
+
+def test_prompt_version_echoed() -> None:
+    s = summarize_context(_full_context(), _PV)
+    assert s["prompt_version"] == _PV
+
+
+def test_absent_blocks_marked_unavailable_never_fabricated() -> None:
+    ctx = {"analyst_estimates": None, "earnings_history": [], "empty_dict": {}}
+    blocks = summarize_context(ctx, _PV)["blocks"]
+    assert blocks["analyst_estimates"] == {"available": False}
+    assert blocks["earnings_history"] == {"available": False, "count": 0}
+    assert blocks["empty_dict"] == {"available": False}
+
+
+def test_list_as_of_is_max_not_first_element() -> None:
+    # Guards Codex HIGH-2: news[0] is the high-importance OLDER event; the
+    # summary as_of must be the newest event_time (max), 2025-07-10.
+    blocks = summarize_context(_full_context(), _PV)["blocks"]
+    assert blocks["news"] == {"available": True, "count": 2, "as_of": "2025-07-10T00:00:00+00:00"}
+    assert blocks["fundamentals"]["as_of"] == "2025-03-31"  # DESC-ordered, max = latest
+
+
+def test_explicit_available_blocks_mirror_flag_and_carry_status_asof() -> None:
+    blocks = summarize_context(_full_context(), _PV)["blocks"]
+    assert blocks["fair_value_band"] == {"available": True, "status": "ok", "as_of": "2025-07-11"}
+    assert blocks["valuation"] == {"available": True, "as_of": "2025-07-11"}  # present → no status field
+
+
+def test_valuation_absent_carries_reason() -> None:
+    ctx = {"valuation": {"available": False, "reason": "no_live_quote"}}
+    assert summarize_context(ctx, _PV)["blocks"]["valuation"] == {
+        "available": False,
+        "status": "no_live_quote",
+    }
+
+
+def test_malformed_analytics_is_unavailable() -> None:
+    # Codex MED-2: a status-only dict is absent usable evidence, not present.
+    ctx = {"analytics_evidence": {"reason": "malformed"}}
+    assert summarize_context(ctx, _PV)["blocks"]["analytics_evidence"] == {
+        "available": False,
+        "status": "malformed",
+    }
+
+
+def test_unsupported_schema_analytics_is_unavailable() -> None:
+    ctx = {"analytics_evidence": {"reason": "unsupported_schema", "schema": "iar_v2"}}
+    assert summarize_context(ctx, _PV)["blocks"]["analytics_evidence"] == {
+        "available": False,
+        "status": "unsupported_schema",
+    }
+
+
+def test_risk_metrics_carries_version_and_max_window_asof() -> None:
+    blocks = summarize_context(_full_context(), _PV)["blocks"]
+    assert blocks["risk_metrics"] == {
+        "available": True,
+        "metric_version": "risk_v1",
+        "as_of": "2025-07-11",
+    }
+
+
+def test_ta_state_and_instrument_available_only() -> None:
+    blocks = summarize_context(_full_context(), _PV)["blocks"]
+    assert blocks["ta_state"] == {"available": True}
+    assert blocks["instrument"] == {"available": True}
+    assert blocks["price_anchor"] == {"available": True, "as_of": "2025-07-11"}
+    assert blocks["prior_thesis"] == {"available": True, "as_of": "2025-07-01T12:00:00+00:00"}
+
+
+def test_unknown_block_gets_drift_safe_available_entry() -> None:
+    ctx = {"a_future_block": {"some": "payload"}}
+    assert summarize_context(ctx, _PV)["blocks"]["a_future_block"] == {"available": True}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_thesis_context_audit.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.thesis_context_audit'`.
+
+- [ ] **Step 3: Write the module**
+
+```python
+# app/services/thesis_context_audit.py
+"""Pure helpers persisting what the thesis writer saw, per run (#2017).
+
+`_assemble_context` (:mod:`app.services.thesis`) builds the writer's research
+dict but does not persist it. These helpers derive compact, auditable
+metadata from that dict — a content hash and a per-block
+availability/status/as-of summary — stored on ``thesis_runs`` at run-insert.
+Enough to audit availability-claim fabrication (#2007 Defect 2 class) and to
+detect that sources moved, WITHOUT duplicating the source rows.
+
+Pure: no DB, no I/O. ``prompt_version`` is a parameter (not an import) so this
+module never depends on ``thesis`` — no import cycle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+# As-of field name per shaped context block (see thesis._assemble_context).
+# List blocks are date-carrying element lists; the summary reports max(stamp).
+_LIST_ASOF: dict[str, str] = {
+    "fundamentals": "as_of_date",
+    "filings": "filing_date",
+    "news": "event_time",
+}
+_DICT_ASOF: dict[str, str] = {
+    "prior_thesis": "created_at",
+    "price_anchor": "price_date",
+    "valuation": "price_as_of",
+    "fair_value_band": "price_as_of",
+    "analytics_evidence": "as_of",
+}
+# A dict whose keys are ALL markers (no substantive payload) is "absent usable
+# evidence", not present — e.g. a malformed/unsupported analytics wrapper.
+_MARKER_KEYS: frozenset[str] = frozenset({"available", "reason", "status", "quality_status", "schema"})
+
+
+def hash_context(context: Mapping[str, object]) -> str:
+    """sha256 of the canonically-serialized context (stable key order, compact).
+
+    Strict — no json ``default`` fallback. The thesis context is guaranteed
+    JSON-shaped (shapers emit isoformat strings + float|None; ``_to_float``
+    maps NaN/inf to None), so a non-serializable type is a bug to surface, not
+    silently stringify. The db-tier test hashes a real assembled context, and
+    the caller wraps this defensively so a raise degrades to NULL audit columns
+    rather than aborting a thesis.
+
+    Note: this fingerprints the exact context bytes; it does NOT prove
+    "sources unchanged" by later recomputation (``_assemble_context`` is
+    non-reproducible — the news query uses a wall-clock 30d cutoff). Drift is
+    detected via the summary's as-of stamps, not by re-hashing.
+    """
+    blob = json.dumps(context, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def summarize_context(context: Mapping[str, object], prompt_version: str) -> dict[str, object]:
+    """Per-block availability/status/as-of summary of the writer context.
+
+    ``prompt_version`` is recorded (self-describing across future context-shape
+    changes) — recording is not a ``_PROMPT_VERSION`` bump.
+    """
+    return {
+        "prompt_version": prompt_version,
+        "blocks": {key: _block_status(key, val) for key, val in context.items()},
+    }
+
+
+def _block_status(key: str, val: object) -> dict[str, object]:
+    """Availability (+ optional status/as-of/count) for one context block.
+
+    Total by construction: ``.get()`` only, never raises, so the summary is
+    safe over any block shape. A block absent from the maps still gets an
+    ``available`` entry (drift-safe).
+    """
+    if val is None:
+        return {"available": False}
+
+    if isinstance(val, list):
+        out: dict[str, object] = {"available": bool(val), "count": len(val)}
+        asof_key = _LIST_ASOF.get(key)
+        if asof_key is not None:
+            stamps = [
+                e.get(asof_key) for e in val if isinstance(e, Mapping) and e.get(asof_key) is not None
+            ]
+            if stamps:
+                # ISO date/timestamp strings sort lexicographically = chronologically.
+                out["as_of"] = max(stamps)
+        return out
+
+    if isinstance(val, Mapping):
+        if key == "risk_metrics":
+            windows = val.get("windows") or []
+            stamps = [
+                w.get("as_of_date")
+                for w in windows
+                if isinstance(w, Mapping) and w.get("as_of_date") is not None
+            ]
+            out = {"available": True, "metric_version": val.get("metric_version")}
+            if stamps:
+                out["as_of"] = max(stamps)
+            return out
+
+        if "available" in val:
+            available = bool(val["available"])
+        else:
+            # present iff it carries payload beyond status markers
+            available = bool(set(val) - _MARKER_KEYS)
+        out = {"available": available}
+        for status_key in ("quality_status", "reason"):
+            status = val.get(status_key)
+            if status is not None:
+                out["status"] = status
+                break
+        asof_key = _DICT_ASOF.get(key)
+        if asof_key is not None:
+            asof = val.get(asof_key)
+            if asof is not None:
+                out["as_of"] = asof
+        return out
+
+    # scalar / unexpected top-level type — defensive (not expected).
+    return {"available": val is not None}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_thesis_context_audit.py -q`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Lint/type/format the new files**
+
+Run:
+```bash
+uv run ruff check app/services/thesis_context_audit.py tests/test_thesis_context_audit.py
+uv run ruff format --check app/services/thesis_context_audit.py tests/test_thesis_context_audit.py
+uv run pyright app/services/thesis_context_audit.py
+```
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/services/thesis_context_audit.py tests/test_thesis_context_audit.py
+git commit -m "feat(#2017): pure thesis context-audit helpers (hash + block summary)"
+```
+
+---
+
+### Task 3: Wire into `thesis.py` + db-tier persist tests
+
+**Files:**
+- Modify: `app/services/thesis.py` (import ~line 74; `_insert_thesis_run` at `app/services/thesis.py:1395`; `generate_thesis` at `app/services/thesis.py:1529`)
+- Test: `tests/test_thesis_context_audit_persist.py`
+
+**Interfaces:**
+- Consumes: `hash_context`, `summarize_context` (Task 2); `context_sha256`/`context_summary` columns (Task 1).
+- Produces: `_insert_thesis_run(..., context_sha256=None, context_summary=None)` — two new keyword-only params, both defaulting to None (existing single caller + the precedent tests stay valid).
+
+- [ ] **Step 1: Write the failing db-tier tests**
+
+```python
+# tests/test_thesis_context_audit_persist.py
+"""DB-tier proof that the #2017 context-audit columns persist on the run row
+and survive a failed run.
+
+Drives the narrow insert/failure seams (`_insert_thesis_run`,
+`_record_thesis_run_failure`) rather than the full `generate_thesis` path,
+which needs live LLM clients unavailable in the test env — same rationale as
+tests/test_thesis_valuation_audit.py. `generate_thesis` calls
+`_insert_thesis_run` (with the context audit) then commits BEFORE the LLM, and
+the failure path only UPDATEs status — so proving the columns are written at
+insert and untouched by `_record_thesis_run_failure` proves the failed-run
+capture end to end.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.thesis import _insert_thesis_run, _record_thesis_run_failure
+
+pytestmark = pytest.mark.db
+
+_SUMMARY = {
+    "prompt_version": "v4",
+    "blocks": {
+        "fundamentals": {"available": True, "count": 5, "as_of": "2025-03-31"},
+        "valuation": {"available": False, "status": "no_live_quote"},
+    },
+}
+
+
+@pytest.fixture
+def conn(ebull_test_conn):
+    return ebull_test_conn
+
+
+def _seed_instrument(conn, instrument_id: int) -> int:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (instrument_id, "TCA", "Thesis Context Audit Test Co"),
+    )
+    conn.commit()
+    return instrument_id
+
+
+def test_insert_persists_context_audit(conn) -> None:
+    iid = _seed_instrument(conn, 9151)
+    run_id = _insert_thesis_run(
+        conn, iid, "manual",
+        provider="openai_compatible", model="qwen3:14b", critic_model="qwen3:14b",
+        context_sha256="a" * 64, context_summary=_SUMMARY,
+    )
+    conn.commit()
+
+    row = conn.execute(
+        "SELECT context_sha256, context_summary FROM thesis_runs WHERE run_id = %s", (run_id,)
+    ).fetchone()
+    assert row[0] == "a" * 64
+    assert row[1] == _SUMMARY  # JSONB round-trips to the same dict
+
+
+def test_missing_context_audit_leaves_nulls(conn) -> None:
+    # Backward-compat: existing callers (and historical rows) leave both NULL.
+    iid = _seed_instrument(conn, 9152)
+    run_id = _insert_thesis_run(
+        conn, iid, "manual", provider="openai_compatible", model="qwen3:14b", critic_model="qwen3:14b"
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT context_sha256, context_summary FROM thesis_runs WHERE run_id = %s", (run_id,)
+    ).fetchone()
+    assert row == (None, None)
+
+
+def test_failed_run_retains_context_audit(conn) -> None:
+    # The #2017 core property: audit written at insert (before the LLM)
+    # survives the failure path (status-only UPDATE) — the #2007 AMSC class.
+    iid = _seed_instrument(conn, 9153)
+    run_id = _insert_thesis_run(
+        conn, iid, "scheduled",
+        provider="openai_compatible", model="qwen3:14b", critic_model="qwen3:14b",
+        context_sha256="b" * 64, context_summary=_SUMMARY,
+    )
+    conn.commit()
+
+    _record_thesis_run_failure(conn, run_id, ValueError("Writer: incoherent targets bear>base"))
+
+    row = conn.execute(
+        "SELECT status, context_sha256, context_summary FROM thesis_runs WHERE run_id = %s", (run_id,)
+    ).fetchone()
+    assert row[0] == "failed"
+    assert row[1] == "b" * 64
+    assert row[2] == _SUMMARY
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_thesis_context_audit_persist.py -q`
+Expected: FAIL — `_insert_thesis_run() got an unexpected keyword argument 'context_sha256'` (and/or `UndefinedColumn` if sql/223 already applied but the params aren't threaded).
+
+- [ ] **Step 3: Add the import in `thesis.py`**
+
+At `app/services/thesis.py`, in the `app.services` import group (after line 75, `from app.services.technical_analysis import derive_trend_signals`), add:
+
+```python
+from app.services.thesis_context_audit import hash_context, summarize_context
+```
+
+- [ ] **Step 4: Extend `_insert_thesis_run` (signature + INSERT)**
+
+Replace the function body at `app/services/thesis.py:1395` with the two new params threaded into the INSERT:
+
+```python
+def _insert_thesis_run(
+    conn: psycopg.Connection[Any],
+    instrument_id: int,
+    trigger: RunTrigger,
+    *,
+    provider: str,
+    model: str,
+    critic_model: str,
+    context_sha256: str | None = None,
+    context_summary: dict[str, object] | None = None,
+) -> int:
+    """Insert a 'running' thesis_runs row and return its run_id.
+
+    ``model`` (writer) and ``critic_model`` are the CONFIGURED models
+    (the run may fail before any provider response exists); the stored
+    thesis row carries the writer model as reported by the response, and
+    ``critic_json.model`` the critic's. Recording ``critic_model`` here
+    is what keeps critic provenance auditable when the best-effort critic
+    fails and no ``critic_json`` is stored (#1995).
+
+    ``context_sha256`` / ``context_summary`` (#2017) fingerprint + summarize
+    the assembled writer context. Written HERE — before the LLM call and the
+    pre-LLM commit — so failed/guard-rejected runs retain the audit. Both
+    nullable: a caller that omits them (or an audit-compute failure upstream)
+    leaves the columns NULL.
+    """
+    row = conn.execute(
+        """
+        INSERT INTO thesis_runs (instrument_id, trigger, provider, model, critic_model,
+                                 context_sha256, context_summary)
+        VALUES (%(instrument_id)s, %(trigger)s, %(provider)s, %(model)s, %(critic_model)s,
+                %(context_sha256)s, %(context_summary)s)
+        RETURNING run_id
+        """,
+        {
+            "instrument_id": instrument_id,
+            "trigger": trigger,
+            "provider": provider,
+            "model": model,
+            "critic_model": critic_model,
+            "context_sha256": context_sha256,
+            "context_summary": Jsonb(context_summary) if context_summary is not None else None,
+        },
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"INSERT INTO thesis_runs did not RETURN a row for instrument_id={instrument_id}")
+    return int(row[0])
+```
+
+- [ ] **Step 5: Compute + pass in `generate_thesis`**
+
+At `app/services/thesis.py:1529`, replace:
+
+```python
+    context = _assemble_context(conn, instrument_id)
+    run_id = _insert_thesis_run(
+        conn,
+        instrument_id,
+        trigger,
+        provider=clients.writer.provider_name,
+        model=clients.writer.model,
+        critic_model=clients.critic.model,
+    )
+```
+
+with:
+
+```python
+    context = _assemble_context(conn, instrument_id)
+    # #2017: fingerprint + summarize what the writer saw, persisted on the run
+    # row. Best-effort — audit compute must NEVER abort a valid generation
+    # (prevention-log line 2127; mirrors #2009 divergence "measure-only, never
+    # gate"). A failure degrades to NULL audit columns + a WARNING.
+    try:
+        context_sha256: str | None = hash_context(context)
+        context_summary: dict[str, object] | None = summarize_context(context, _PROMPT_VERSION)
+    except Exception:
+        logger.warning(
+            "thesis context audit compute failed for instrument_id=%d", instrument_id, exc_info=True
+        )
+        context_sha256, context_summary = None, None
+    run_id = _insert_thesis_run(
+        conn,
+        instrument_id,
+        trigger,
+        provider=clients.writer.provider_name,
+        model=clients.writer.model,
+        critic_model=clients.critic.model,
+        context_sha256=context_sha256,
+        context_summary=context_summary,
+    )
+```
+
+- [ ] **Step 6: Run the db-tier tests to verify they pass**
+
+Run:
+```bash
+docker compose --profile test up -d postgres-test   # if not already up
+uv run pytest tests/test_thesis_context_audit_persist.py -q
+```
+Expected: PASS (3 tests). This run applies sql/223 if the test harness runs migrations on connect; if the columns are missing, apply sql/223 first (Task 1 Step 2).
+
+- [ ] **Step 7: Guard against regressions in the existing thesis_runs suite**
+
+Run: `uv run pytest tests/test_thesis_runs_db.py -q`
+Expected: PASS — the new params default to None, so the precedent lifecycle/failure tests are unchanged.
+
+- [ ] **Step 8: Full pre-push gate**
+
+Run:
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run pytest -m "not db"
+uv run pytest tests/smoke
+uv run pytest -m db -k "thesis"
+```
+Expected: all clean. (`tests/smoke` boots the FastAPI lifespan against dev — proves sql/223 applies cleanly. The `-m db -k thesis` run exercises the new persist tests + the thesis_runs/valuation-audit precedents together.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/services/thesis.py tests/test_thesis_context_audit_persist.py
+git commit -m "feat(#2017): persist context hash + block summary on thesis_runs at run-insert"
+```
+
+---
+
+## Self-Review (completed at authoring)
+
+- **Spec coverage:** schema (Task 1) ✓; hash + summary pure module w/ all Codex-hardened rules — news max(), risk_metrics special-case, malformed→unavailable, strict hash (Task 2) ✓; persist-at-run-insert wiring + defensive wrap + no-bump (Task 3) ✓; fast-tier + db-tier incl. failed-run capture (Tasks 2/3) ✓; no backfill / nullable (Task 1 + Global Constraints) ✓.
+- **Placeholder scan:** none — every code step carries full code; the only ellipses are inside test-fixture string values (`"summary": "…"`), not plan steps.
+- **Type consistency:** `hash_context`/`summarize_context` signatures identical across Tasks 2↔3; `_insert_thesis_run` new params (`context_sha256: str | None`, `context_summary: dict[str, object] | None`) match the call site and the tests; `Jsonb` already imported in thesis.py (`app/services/thesis.py:56`).
+- **Deviation from spec (noted):** db-tier failed-run proof uses the `_insert_thesis_run` + `_record_thesis_run_failure` seams instead of a faked `LLMClientPair` (full `generate_thesis` needs live LLM — same rationale as the sql/222 test). Same property proven; the spec test section is updated to match.

--- a/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
+++ b/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
@@ -104,7 +104,7 @@ Maps + marker set (explicit, from the shaped-block keys in `_assemble_context`):
 ```python
 _LIST_ASOF = {"fundamentals": "as_of_date", "filings": "filing_date", "news": "event_time"}
 _DICT_ASOF = {"prior_thesis": "created_at", "price_anchor": "price_date",
-              "valuation": "price_as_of", "fair_value_band": "price_as_of",
+              "valuation": "price_as_of", "fair_value_band": "as_of_date",  # band's own vintage, not the price leg (Codex ckpt-2)
               "analytics_evidence": "as_of"}
 _MARKER_KEYS = frozenset({"available", "reason", "status", "quality_status", "schema"})
 ```

--- a/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
+++ b/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
@@ -1,0 +1,169 @@
+# Persist assembled thesis writer context per run (auditability) — #2017
+
+Split from #2007. Unblocks #2013 / #2010 / #2002.
+
+## Problem
+
+`_assemble_context` (`app/services/thesis.py`) builds the research dict the writer sees, but it is **not persisted**. Root-causing #2007's AMSC defect required rebuilding the context after the fact and *trusting nothing changed* — `fundamentals_snapshot`, `price_daily`, and the `instrument_valuation` view can all move, so no guarantee holds.
+
+Repo rule: *"persist enough structured evidence for auditability"* (settled-decisions §General engineering / Auditability). A thesis memo is a versioned, audited artifact; the evidence it was written from should be **auditable** from storage — specifically its per-block **availability, status, and vintage** — without re-deriving against sources that have since moved.
+
+### Scope of the goal (Codex ckpt-1 HIGH)
+
+This ticket persists **availability + drift-detection metadata**, *not* a faithful byte-reconstruction of the context. `_assemble_context` applies caps, per-block ordering, shaping, a wall-clock news cutoff, and reads mutable views — so the exact writer input is **not** reconstructable from source tables after drift, and a hash + summary does not claim to reconstruct it. Faithful reconstruction would require either the full context blob or per-row identity digests; both are rejected (see Decision) as cost/duplication out of proportion to the #2007-class debugging need. What we capture: *which blocks were present/absent/statused, and as-of when* — enough to audit availability-claim fabrication and to detect that sources moved.
+
+## Source rule
+
+Auditability is a **repo invariant**, not an external data-treatment rule:
+- `docs/settled-decisions.md` §Auditability: *"persist structured evidence where it matters; do not leave critical model / recommendation / execution paths unexplained."*
+- §Thesis semantics: thesis rows are **append-only** (each generation inserts; never overwrite). `thesis_runs` is the append-only per-attempt record (sql/218).
+- §Thesis prompt budget: *"Context-shape changes bump `_PROMPT_VERSION`."* This change does **not** alter context shape (see below) → **no bump**.
+
+No SEC/EDGAR reg governs this; the governing rule is the settled auditability invariant + the append-only `thesis_runs` shape.
+
+## Decision: hash + block-status summary (not full blob)
+
+Persist on `thesis_runs`, forward-only:
+- `context_sha256 TEXT` — content-identity fingerprint of the canonically-serialized context.
+- `context_summary JSONB` — per-block `{available, status?, as_of?, count?}`.
+
+**Full-blob rejected:** it would faithfully reconstruct the context, but at the cost of duplicating data already in source tables — `prior_thesis.memo_markdown` is a verbatim copy of another `theses` row; `filings[].summary`, `news[]`, and fundamentals all live in their own tables. Settled decision: *"full raw filing text is out of scope for v1."* **Per-row identity digests** (store the PKs + a per-row hash of the rows that fed each block) were also considered and rejected: substantially more machinery for row-level reconstruction that the #2002 judge and #2007-class debugging do not need — they need availability + vintage, not the exact figures. The summary + hash + the existing `thesis_valuation_audit` divergence row (sql/222, band_base vs llm_base) together cover the debugging need.
+
+### What each field proves (be honest)
+
+- **`context_summary`** is the auditability workhorse. Per block it records `available` (usable evidence present vs absent), the **top-level** `status`/`reason`/`quality_status`, and the `as_of` stamp. This directly supports auditing **availability-claim fabrication** (#2007 Defect 2 class): given a stored memo, an auditor/judge (#2002) can check whether the memo asserted data that the block said was `available:false`. The `as_of` stamps are the real **drift-detection** mechanism: "the fundamentals block was as_of 2025-03-31 at write time" — if the latest snapshot is now newer, the sources moved since the memo.
+  - **Deliberately not summarized (Codex ckpt-1 MED):** nested per-window statuses (`risk_metrics.windows[].*_status`) and analytics sub-block malformed markers are *not* rolled up into the summary — only the block's top-level availability + status + vintage are. The hash + the source tables cover the finer detail; the summary stays compact and its `status` field is not overclaimed as "every status verbatim."
+- **`context_sha256`** is a content-identity fingerprint (two runs with the same hash saw byte-identical context; lets #2013/#2010 tell "regenerated on identical inputs" from "inputs changed"). It **cannot** prove "sources unchanged" by later recomputation: `_assemble_context` is non-reproducible because the news query filters `event_time >= now() - 30d` (wall-clock cutoff moves). This limitation is documented, not worked around — the summary's as-of stamps are the drift signal, not hash recomputation.
+
+## Where to persist: at `_insert_thesis_run`, not on success
+
+`generate_thesis` flow:
+1. `_assemble_context` (line 1529) — context in hand.
+2. `_insert_thesis_run` (line 1530) — INSERT the 'running' row.
+3. `conn.commit()` (line 1542) — **before** the LLM call.
+4. LLM writer + critic; on failure → `_record_thesis_run_failure` (status='failed').
+
+Compute `hash_context` + `summarize_context` from the context between steps 1 and 2 and store them in the `_insert_thesis_run` INSERT. The columns therefore commit at step 3, **before** any LLM I/O, and survive every downstream failure path.
+
+**Why not on success (`_finish_thesis_run_ok`):** the #2007 AMSC case was a **guard-rejected** run — the writer emitted an incoherent band, `_validate_writer_output` raised, no `theses` row was stored, and the run row is `status='failed'`. Success-only persistence would have captured **nothing** for exactly the run we needed to debug. Persisting at run-start captures failed/rejected runs too.
+
+Per-thesis lookup on the success path still works via the existing `thesis_runs.thesis_id` FK: `SELECT context_summary FROM thesis_runs WHERE thesis_id = ?`.
+
+## Schema — `sql/223_thesis_runs_context_audit.sql`
+
+New migration file (never edit an applied migration — prevention-log content-drift rule). ALTER the existing table with `IF NOT EXISTS` (prevention-log line 1121; mirrors sql/219's `critic_model` add):
+
+```sql
+BEGIN;
+ALTER TABLE thesis_runs
+    ADD COLUMN IF NOT EXISTS context_sha256  TEXT,
+    ADD COLUMN IF NOT EXISTS context_summary JSONB;
+COMMIT;
+```
+
+Both nullable. Historical rows stay NULL — **no backfill**: past contexts are non-reconstructable (the ticket's whole premise), and reconstructing would re-derive against moved sources. Matches the sql/218/219 nullable-column precedent and the risk_v1 "additive nullable evidence, no version bump, pre-rows stay NULL" blessing.
+
+## Code — new pure module `app/services/thesis_context_audit.py`
+
+Kept out of the already-large `thesis.py`. Pure (no DB, no I/O), fast-tier testable. Takes `prompt_version` as a param so it never imports `thesis._PROMPT_VERSION` (no cycle).
+
+```python
+def hash_context(context: Mapping[str, object]) -> str:
+    """sha256 of canonically-serialized context (stable key order, compact).
+
+    Strict: NO json default fallback — context is guaranteed JSON-shaped
+    (shapers emit isoformat strings + float|None; _to_float kills NaN/inf).
+    A non-JSON type is a bug we want to surface, not silently stringify
+    (Codex ckpt-1 MED). The db-tier test hashes a REAL assembled context,
+    catching any future non-serializable block; the thesis.py call site
+    wraps this defensively so a raise degrades to NULL audit columns, never
+    aborts the thesis (prevention-log line 2127).
+    """
+    blob = json.dumps(context, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+def summarize_context(context: Mapping[str, object], prompt_version: str) -> dict[str, object]:
+    return {
+        "prompt_version": prompt_version,
+        "blocks": {key: _block_status(key, val) for key, val in context.items()},
+    }
+```
+
+`_block_status(key, val)` — total by construction (never raises; `.get()` only):
+- `None` → `{"available": False}`
+- `list` → `{"available": bool(val), "count": len(val)}` (+ `as_of` = `max(e[_LIST_ASOF[key]] for e in val)` — **MAX over elements, not `[0]`**: `news` is ordered `importance_score DESC`, so `[0]` is the highest-importance item, not the latest event (Codex ckpt-1 HIGH). ISO-date/timestamp strings sort lexicographically = chronologically, so `max()` is the newest datum the writer saw. The 30d news cutoff is derivable from the run's `started_at`, not stored separately.)
+- `dict`:
+  - **`risk_metrics`** (special-case, `.get()`-safe): `available` = True, `metric_version` = `val.get("metric_version")`, `as_of` = `max((w.get("as_of_date") for w in val.get("windows") or [] if w.get("as_of_date")), default=None)`. Per-window statuses are *not* rolled up (see "not summarized" above).
+  - otherwise:
+    - `available` = `bool(val["available"])` if an explicit `available` key exists; else **True iff the dict carries substantive payload** beyond status markers — `bool(set(val) - _MARKER_KEYS)`. This makes a malformed/unsupported analytics wrapper (`{"reason": "malformed"}` / `{"reason": "unsupported_schema", "schema": ...}`) → `available:false` (Codex ckpt-1 MED-2): a status-only dict is *absent usable evidence*, not present.
+    - `status` = first present-and-non-None of `("quality_status", "reason")`.
+    - `as_of` = `val[_DICT_ASOF[key]]` when present-and-non-None. (`ta_state` has no own stamp — it is derived from the same `price_row` as `price_anchor`, so its vintage is `price_anchor.as_of`; the summary leaves `ta_state` available-only and this sharing is documented here rather than duplicating the stamp.)
+- other/scalar → `{"available": val is not None}` (defensive; not expected at top level).
+
+Maps + marker set (explicit, from the shaped-block keys in `_assemble_context`):
+```python
+_LIST_ASOF = {"fundamentals": "as_of_date", "filings": "filing_date", "news": "event_time"}
+_DICT_ASOF = {"prior_thesis": "created_at", "price_anchor": "price_date",
+              "valuation": "price_as_of", "fair_value_band": "price_as_of",
+              "analytics_evidence": "as_of"}
+_MARKER_KEYS = frozenset({"available", "reason", "status", "quality_status", "schema"})
+```
+
+Drift-safe: iterating `context.items()` means a future block always gets at least an `available` entry even if the maps aren't updated. NaN/±inf cannot reach the hash — `_to_float` already maps them to None at assembly (#2007).
+
+### Wiring in `thesis.py`
+
+```python
+context = _assemble_context(conn, instrument_id)
+# Best-effort audit metadata — must never abort a valid generation
+# (prevention-log line 2127; mirrors #2009 divergence "measure-only, never gate").
+try:
+    context_sha256 = hash_context(context)
+    context_summary = summarize_context(context, _PROMPT_VERSION)
+except Exception:
+    logger.warning("thesis context audit compute failed for instrument_id=%d", instrument_id, exc_info=True)
+    context_sha256, context_summary = None, None
+run_id = _insert_thesis_run(conn, instrument_id, trigger,
+                           provider=..., model=..., critic_model=...,
+                           context_sha256=context_sha256, context_summary=context_summary)
+```
+
+`_insert_thesis_run` gains two params (both nullable); INSERT gains the two columns (`context_summary` wrapped in `Jsonb` when not None). No change to any other call site — the run insert has a single caller. The defensive wrap means a summarizer/hasher bug degrades to NULL audit columns (visible signal) rather than failing the thesis.
+
+## Not `_PROMPT_VERSION`-bumping
+
+The writer prompt is byte-identical: `_assemble_context` returns the same dict, `_build_writer_prompt` consumes it unchanged. We only *read* that dict to derive audit metadata written to a **different table** (`thesis_runs`, not the writer's input). Settled rule bumps `_PROMPT_VERSION` on context-**shape** changes (what the writer sees); this is not one. `_PROMPT_VERSION` is *recorded inside* `context_summary` (self-describing across future shape changes) — recording ≠ bumping. Consequence: no thesis re-gate, no LLM-eval, no thesis backfill.
+
+## Tests
+
+Fast-tier `tests/test_thesis_context_audit.py`:
+- `hash_context` determinism: same dict → same hash; key-order-independent (`sort_keys`); a changed nested value → different hash.
+- `summarize_context`:
+  - `available:false` for `None` / `{}` / empty-list blocks (never a fabricated present).
+  - explicit-`available` blocks (`valuation`, `fair_value_band`) mirror the flag + carry `status`/`as_of`.
+  - list blocks carry `count` + **`as_of` = the max dated element, proven with a `news` fixture whose `[0]` is NOT the latest event** (importance-ordered) — guards the Codex HIGH-2 regression.
+  - `risk_metrics` → `metric_version` + `as_of` = max window `as_of_date`.
+  - malformed analytics (`{"reason": "malformed"}`) → `available:false` + `status:"malformed"` (Codex MED-2).
+  - a synthetic unknown block → bare `available` entry (drift-safe fallback); `prompt_version` echoed.
+
+Db-tier `tests/test_thesis_context_audit_persist.py` (fake LLM), TWO cases:
+1. **Success:** after a successful generation, the `thesis_runs` row (joined via `thesis_id`) has non-null `context_sha256` and a `context_summary` whose `blocks` cover the assembled keys.
+2. **Failed/rejected run (the core requirement, Codex LOW):** a fake writer that fails `_validate_writer_output` (or raises) → the committed `thesis_runs` row has `status='failed'`, no `theses` row, **and non-null `context_sha256` + `context_summary`** — proving the audit is captured at run-start, before the LLM, for exactly the #2007 AMSC class of run.
+
+## Out of scope
+
+- Full context-blob storage (rejected above).
+- Any FE surface for the summary (no operator UI ticket here; #2002 judge consumes it programmatically).
+- Backfill of historical runs (non-reconstructable by design).
+- `_PROMPT_VERSION` bump / thesis re-gen.
+
+## Verification (dev)
+
+1. `sql/223` applies at lifespan (smoke test boots against dev DB).
+2. Fast + db-tier tests green.
+3. After operator restarts the VS Code jobs task (picks up the write path), force-regen one instrument: `POST /instruments/AAPL/thesis?force=true` (Bearer `EBULL_SERVICE_TOKEN`).
+4. Confirm the latest `thesis_runs` row for AAPL has non-null `context_sha256` and a `context_summary` with the expected block availabilities (e.g. `fair_value_band.available:true`, `valuation` reflecting its live-quote status).
+
+## Codex
+
+Codex ckpt-1 reviews this spec before operator sign-off (correctness gaps, invariant violations, missing edge cases; source-rule citation check).

--- a/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
+++ b/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
@@ -74,10 +74,13 @@ def hash_context(context: Mapping[str, object]) -> str:
     Strict: NO json default fallback — context is guaranteed JSON-shaped
     (shapers emit isoformat strings + float|None; _to_float kills NaN/inf).
     A non-JSON type is a bug we want to surface, not silently stringify
-    (Codex ckpt-1 MED). The db-tier test hashes a REAL assembled context,
-    catching any future non-serializable block; the thesis.py call site
-    wraps this defensively so a raise degrades to NULL audit columns, never
-    aborts the thesis (prevention-log line 2127).
+    (Codex ckpt-1 MED). The fast-tier test proves the strict raise against a
+    synthetic non-JSON input; tests/test_thesis.py::
+    test_empty_surfaces_yield_honest_absences hashes a REAL assembled
+    context, so the helpers are exercised against the true shapes, not just
+    hand-built fixtures. The thesis.py call site wraps this so a raise
+    degrades to NULL audit columns + a WARNING, never aborts the thesis
+    (prevention-log line 2127).
     """
     blob = json.dumps(context, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
+++ b/docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
@@ -146,9 +146,10 @@ Fast-tier `tests/test_thesis_context_audit.py`:
   - malformed analytics (`{"reason": "malformed"}`) → `available:false` + `status:"malformed"` (Codex MED-2).
   - a synthetic unknown block → bare `available` entry (drift-safe fallback); `prompt_version` echoed.
 
-Db-tier `tests/test_thesis_context_audit_persist.py` (fake LLM), TWO cases:
-1. **Success:** after a successful generation, the `thesis_runs` row (joined via `thesis_id`) has non-null `context_sha256` and a `context_summary` whose `blocks` cover the assembled keys.
-2. **Failed/rejected run (the core requirement, Codex LOW):** a fake writer that fails `_validate_writer_output` (or raises) → the committed `thesis_runs` row has `status='failed'`, no `theses` row, **and non-null `context_sha256` + `context_summary`** — proving the audit is captured at run-start, before the LLM, for exactly the #2007 AMSC class of run.
+Db-tier `tests/test_thesis_context_audit_persist.py`. Drives the narrow insert/failure seams (`_insert_thesis_run`, `_record_thesis_run_failure`), not full `generate_thesis` — which needs live LLM clients unavailable in the test env (same rationale as `tests/test_thesis_valuation_audit.py`). Since `generate_thesis` calls `_insert_thesis_run` (with the audit) then commits *before* the LLM, and the failure path only UPDATEs `status`, proving the columns are written at insert and untouched by `_record_thesis_run_failure` proves the failed-run capture end-to-end. Cases:
+1. **Insert persists:** `_insert_thesis_run(..., context_sha256=…, context_summary=…)` → the row has both columns (JSONB round-trips).
+2. **Backward-compat:** omitting the params leaves both columns NULL (historical rows / audit-compute-failure path).
+3. **Failed run retains audit (the core requirement, Codex LOW):** after `_record_thesis_run_failure`, the row is `status='failed'` **and still carries non-null `context_sha256` + `context_summary`** — the #2007 AMSC class.
 
 ## Out of scope
 

--- a/sql/223_thesis_runs_context_audit.sql
+++ b/sql/223_thesis_runs_context_audit.sql
@@ -1,0 +1,23 @@
+-- 223: persist assembled thesis writer context per run (#2017)
+--
+-- Spec: docs/superpowers/specs/2026-07-13-thesis-context-audit-design.md
+--
+-- Altered tables:
+--   thesis_runs — context_sha256 (content-identity fingerprint of the
+--                 assembled writer context) + context_summary (per-block
+--                 availability/status/as-of JSONB). Both nullable; written
+--                 at run-insert BEFORE the LLM call so failed/guard-rejected
+--                 runs are captured too (the #2007 AMSC debugging class).
+--                 Historical rows stay NULL — past contexts are
+--                 non-reconstructable, so there is no backfill.
+--
+-- Not a context-SHAPE change (the writer prompt is byte-identical), so
+-- _PROMPT_VERSION is NOT bumped; the version is recorded inside the summary.
+
+BEGIN;
+
+ALTER TABLE thesis_runs
+    ADD COLUMN IF NOT EXISTS context_sha256  TEXT,
+    ADD COLUMN IF NOT EXISTS context_summary JSONB;
+
+COMMIT;

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -517,7 +517,8 @@ class TestAssembleContextEnrichment:
     """
 
     def test_empty_surfaces_yield_honest_absences(self) -> None:
-        from app.services.thesis import _assemble_context
+        from app.services.thesis import _PROMPT_VERSION, _assemble_context
+        from app.services.thesis_context_audit import hash_context, summarize_context
 
         context = _assemble_context(_make_conn(), instrument_id=1)
 
@@ -526,6 +527,24 @@ class TestAssembleContextEnrichment:
         assert context["valuation"] == {"available": False, "reason": "no_live_quote"}
         assert context["fair_value_band"] == {"available": False, "reason": "no_band"}
         assert context["analytics_evidence"] is None
+
+        # #2017 final review (Important): this is the only place a REAL
+        # _assemble_context output flows into hash_context/summarize_context.
+        # Every other coverage either hashes a hand-built fixture
+        # (test_thesis_context_audit.py) or a literal dict (the db-tier
+        # persist test) — neither exercises the helpers against the true
+        # shapes _assemble_context actually produces.
+        digest = hash_context(context)
+        assert len(digest) == 64 and all(c in "0123456789abcdef" for c in digest)
+
+        summary = summarize_context(context, _PROMPT_VERSION)
+        assert summary["prompt_version"] == _PROMPT_VERSION
+        blocks = summary["blocks"]
+        assert isinstance(blocks, dict)
+        for name in ("price_anchor", "ta_state", "valuation", "fair_value_band", "analytics_evidence"):
+            entry = blocks[name]
+            assert isinstance(entry, dict)
+            assert entry["available"] is False
 
 
 class TestGenerateThesis:

--- a/tests/test_thesis_context_audit.py
+++ b/tests/test_thesis_context_audit.py
@@ -1,0 +1,169 @@
+"""Fast-tier tests for the pure thesis context-audit helpers (#2017).
+
+No DB: hash determinism + per-block availability/status/as-of summary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from app.services.thesis_context_audit import hash_context, summarize_context
+
+_PV = "v4"
+
+
+def _summary_blocks(context: Mapping[str, object]) -> dict[str, object]:
+    """Type-narrowing helper: ``summarize_context``'s "blocks" value is always
+    a dict by construction, but that's erased by the ``dict[str, object]``
+    return annotation after one subscript — narrow once here instead of an
+    ``isinstance`` assert scattered across every test.
+    """
+    blocks = summarize_context(context, _PV)["blocks"]
+    assert isinstance(blocks, dict)
+    return blocks
+
+
+def _full_context() -> dict[str, object]:
+    """A representative _assemble_context-shaped dict (subset of real fields)."""
+    return {
+        "instrument": {"symbol": "AAPL", "company_name": "Apple", "currency": "USD"},
+        "fundamentals": [
+            {"as_of_date": "2025-03-31", "revenue_ttm": 4.0e11},
+            {"as_of_date": "2024-12-31", "revenue_ttm": 3.9e11},
+        ],
+        "filings": [{"filing_date": "2025-05-01", "filing_type": "10-Q", "summary": "…"}],
+        # news is ordered importance DESC, NOT recency — [0] is NOT the newest event.
+        "news": [
+            {"event_time": "2025-07-01T00:00:00+00:00", "headline": "high-importance older"},
+            {"event_time": "2025-07-10T00:00:00+00:00", "headline": "low-importance newer"},
+        ],
+        "prior_thesis": {"version": 3, "stance": "buy", "created_at": "2025-07-01T12:00:00+00:00"},
+        "risk_metrics": {
+            "metric_version": "risk_v1",
+            "windows": [
+                {"window_key": "1y", "as_of_date": "2025-07-11", "cagr_status": "ok"},
+                {"window_key": "3y", "as_of_date": "2025-07-11", "cagr_status": "thin_history"},
+            ],
+        },
+        "price_anchor": {"close": 210.0, "price_date": "2025-07-11", "currency": "USD"},
+        "valuation": {"available": True, "current_price": 210.0, "price_as_of": "2025-07-11"},
+        # representative _shape_fair_value_band output — as_of_date (band vintage)
+        # deliberately DISTINCT from price_as_of so the test proves we pick as_of_date.
+        "fair_value_band": {
+            "available": True,
+            "reason": None,
+            "quality_status": "ok",
+            "bear": 150.0,
+            "base": 200.0,
+            "bull": 250.0,
+            "as_of_date": "2025-06-30",
+            "ttm_end": "2025-03-31",
+            "price_as_of": "2025-07-11",
+            "basis": {},
+        },
+        "analytics_evidence": {"schema": "iar_v1", "as_of": "2025-07-09T00:00:00+00:00", "piotroski": {"score": 7}},
+        "ta_state": {"sma_50": 205.0, "sma_200": 190.0, "price_vs_sma200": "above"},
+        "earnings_history": [],
+        "analyst_estimates": None,
+    }
+
+
+# --- hash_context ---------------------------------------------------------
+
+
+def test_hash_is_deterministic_and_key_order_independent() -> None:
+    a = {"x": 1, "y": {"b": 2, "a": 3}, "z": [1, 2]}
+    b = {"z": [1, 2], "y": {"a": 3, "b": 2}, "x": 1}  # same content, keys reordered
+    assert hash_context(a) == hash_context(b)
+
+
+def test_hash_changes_on_nested_value_change() -> None:
+    a = _full_context()
+    b = _full_context()
+    b["price_anchor"] = {**a["price_anchor"], "close": 999.0}  # type: ignore[dict-item]
+    assert hash_context(a) != hash_context(b)
+
+
+def test_hash_is_64_hex_chars() -> None:
+    h = hash_context(_full_context())
+    assert len(h) == 64 and all(c in "0123456789abcdef" for c in h)
+
+
+# --- summarize_context ----------------------------------------------------
+
+
+def test_prompt_version_echoed() -> None:
+    s = summarize_context(_full_context(), _PV)
+    assert s["prompt_version"] == _PV
+
+
+def test_absent_blocks_marked_unavailable_never_fabricated() -> None:
+    ctx = {"analyst_estimates": None, "earnings_history": [], "empty_dict": {}}
+    blocks = _summary_blocks(ctx)
+    assert blocks["analyst_estimates"] == {"available": False}
+    assert blocks["earnings_history"] == {"available": False, "count": 0}
+    assert blocks["empty_dict"] == {"available": False}
+
+
+def test_list_as_of_is_max_not_first_element() -> None:
+    # Guards Codex HIGH-2: news[0] is the high-importance OLDER event; the
+    # summary as_of must be the newest event_time (max), 2025-07-10.
+    blocks = _summary_blocks(_full_context())
+    assert blocks["news"] == {"available": True, "count": 2, "as_of": "2025-07-10T00:00:00+00:00"}
+    fundamentals = blocks["fundamentals"]
+    assert isinstance(fundamentals, dict)
+    assert fundamentals["as_of"] == "2025-03-31"  # DESC-ordered, max = latest
+
+
+def test_explicit_available_blocks_mirror_flag_and_carry_status_asof() -> None:
+    blocks = _summary_blocks(_full_context())
+    # fair_value_band as_of = the band's own as_of_date (2025-06-30), NOT price_as_of.
+    assert blocks["fair_value_band"] == {"available": True, "status": "ok", "as_of": "2025-06-30"}
+    assert blocks["valuation"] == {"available": True, "as_of": "2025-07-11"}  # present → no status field
+
+
+def test_valuation_absent_carries_reason() -> None:
+    ctx = {"valuation": {"available": False, "reason": "no_live_quote"}}
+    assert _summary_blocks(ctx)["valuation"] == {
+        "available": False,
+        "status": "no_live_quote",
+    }
+
+
+def test_malformed_analytics_is_unavailable() -> None:
+    # Codex MED-2: a status-only dict is absent usable evidence, not present.
+    ctx = {"analytics_evidence": {"reason": "malformed"}}
+    assert _summary_blocks(ctx)["analytics_evidence"] == {
+        "available": False,
+        "status": "malformed",
+    }
+
+
+def test_unsupported_schema_analytics_is_unavailable() -> None:
+    ctx = {"analytics_evidence": {"reason": "unsupported_schema", "schema": "iar_v2"}}
+    assert _summary_blocks(ctx)["analytics_evidence"] == {
+        "available": False,
+        "status": "unsupported_schema",
+    }
+
+
+def test_risk_metrics_carries_version_and_max_window_asof() -> None:
+    blocks = _summary_blocks(_full_context())
+    assert blocks["risk_metrics"] == {
+        "available": True,
+        "metric_version": "risk_v1",
+        "as_of": "2025-07-11",
+    }
+
+
+def test_ta_state_and_instrument_available_only() -> None:
+    blocks = _summary_blocks(_full_context())
+    assert blocks["ta_state"] == {"available": True}
+    assert blocks["instrument"] == {"available": True}
+    assert blocks["price_anchor"] == {"available": True, "as_of": "2025-07-11"}
+    assert blocks["prior_thesis"] == {"available": True, "as_of": "2025-07-01T12:00:00+00:00"}
+
+
+def test_unknown_block_gets_drift_safe_available_entry() -> None:
+    ctx = {"a_future_block": {"some": "payload"}}
+    assert _summary_blocks(ctx)["a_future_block"] == {"available": True}

--- a/tests/test_thesis_context_audit.py
+++ b/tests/test_thesis_context_audit.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+import pytest
+
 from app.services.thesis_context_audit import hash_context, summarize_context
 
 _PV = "v4"
@@ -41,7 +43,10 @@ def _full_context() -> dict[str, object]:
         "risk_metrics": {
             "metric_version": "risk_v1",
             "windows": [
-                {"window_key": "1y", "as_of_date": "2025-07-11", "cagr_status": "ok"},
+                # as_of_date deliberately DISTINCT, and the max is NOT the
+                # first element — discriminates max() from both min() and
+                # stamps[0], not just "some" as_of value is echoed.
+                {"window_key": "1y", "as_of_date": "2025-06-01", "cagr_status": "ok"},
                 {"window_key": "3y", "as_of_date": "2025-07-11", "cagr_status": "thin_history"},
             ],
         },
@@ -87,6 +92,13 @@ def test_hash_changes_on_nested_value_change() -> None:
 def test_hash_is_64_hex_chars() -> None:
     h = hash_context(_full_context())
     assert len(h) == 64 and all(c in "0123456789abcdef" for c in h)
+
+
+def test_hash_raises_on_non_json_serializable() -> None:
+    # Strict json.dumps (no default=) is deliberate — guards against a silent
+    # default=str regression that would stringify a bug instead of raising.
+    with pytest.raises(TypeError):
+        hash_context({"bad": {1, 2, 3}})
 
 
 # --- summarize_context ----------------------------------------------------
@@ -148,6 +160,8 @@ def test_unsupported_schema_analytics_is_unavailable() -> None:
 
 
 def test_risk_metrics_carries_version_and_max_window_asof() -> None:
+    # windows carry distinct as_of_date with the max NOT first in list order,
+    # so this fails if max(stamps) regressed to min(stamps) or stamps[0].
     blocks = _summary_blocks(_full_context())
     assert blocks["risk_metrics"] == {
         "available": True,

--- a/tests/test_thesis_context_audit_persist.py
+++ b/tests/test_thesis_context_audit_persist.py
@@ -1,0 +1,102 @@
+"""DB-tier proof that the #2017 context-audit columns persist on the run row
+and survive a failed run.
+
+Drives the narrow insert/failure seams (`_insert_thesis_run`,
+`_record_thesis_run_failure`) rather than the full `generate_thesis` path,
+which needs live LLM clients unavailable in the test env — same rationale as
+tests/test_thesis_valuation_audit.py. `generate_thesis` calls
+`_insert_thesis_run` (with the context audit) then commits BEFORE the LLM, and
+the failure path only UPDATEs status — so proving the columns are written at
+insert and untouched by `_record_thesis_run_failure` proves the failed-run
+capture end to end.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.thesis import _insert_thesis_run, _record_thesis_run_failure
+
+pytestmark = pytest.mark.db
+
+_SUMMARY = {
+    "prompt_version": "v4",
+    "blocks": {
+        "fundamentals": {"available": True, "count": 5, "as_of": "2025-03-31"},
+        "valuation": {"available": False, "status": "no_live_quote"},
+    },
+}
+
+
+@pytest.fixture
+def conn(ebull_test_conn):
+    return ebull_test_conn
+
+
+def _seed_instrument(conn, instrument_id: int) -> int:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, TRUE)",
+        (instrument_id, "TCA", "Thesis Context Audit Test Co"),
+    )
+    conn.commit()
+    return instrument_id
+
+
+def test_insert_persists_context_audit(conn) -> None:
+    iid = _seed_instrument(conn, 9151)
+    run_id = _insert_thesis_run(
+        conn,
+        iid,
+        "manual",
+        provider="openai_compatible",
+        model="qwen3:14b",
+        critic_model="qwen3:14b",
+        context_sha256="a" * 64,
+        context_summary=_SUMMARY,
+    )
+    conn.commit()
+
+    row = conn.execute(
+        "SELECT context_sha256, context_summary FROM thesis_runs WHERE run_id = %s", (run_id,)
+    ).fetchone()
+    assert row[0] == "a" * 64
+    assert row[1] == _SUMMARY  # JSONB round-trips to the same dict
+
+
+def test_missing_context_audit_leaves_nulls(conn) -> None:
+    # Backward-compat: existing callers (and historical rows) leave both NULL.
+    iid = _seed_instrument(conn, 9152)
+    run_id = _insert_thesis_run(
+        conn, iid, "manual", provider="openai_compatible", model="qwen3:14b", critic_model="qwen3:14b"
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT context_sha256, context_summary FROM thesis_runs WHERE run_id = %s", (run_id,)
+    ).fetchone()
+    assert row == (None, None)
+
+
+def test_failed_run_retains_context_audit(conn) -> None:
+    # The #2017 core property: audit written at insert (before the LLM)
+    # survives the failure path (status-only UPDATE) — the #2007 AMSC class.
+    iid = _seed_instrument(conn, 9153)
+    run_id = _insert_thesis_run(
+        conn,
+        iid,
+        "scheduled",
+        provider="openai_compatible",
+        model="qwen3:14b",
+        critic_model="qwen3:14b",
+        context_sha256="b" * 64,
+        context_summary=_SUMMARY,
+    )
+    conn.commit()
+
+    _record_thesis_run_failure(conn, run_id, ValueError("Writer: incoherent targets bear>base"))
+
+    row = conn.execute(
+        "SELECT status, context_sha256, context_summary FROM thesis_runs WHERE run_id = %s", (run_id,)
+    ).fetchone()
+    assert row[0] == "failed"
+    assert row[1] == "b" * 64
+    assert row[2] == _SUMMARY


### PR DESCRIPTION
## What & why

Closes #2017. Split from #2007; unblocks #2013 / #2010 / #2002.

`_assemble_context` builds the research dict the thesis writer sees, but it was **not persisted**. Root-causing #2007's AMSC defect meant rebuilding the context after the fact and *trusting nothing changed* — `fundamentals_snapshot`, `price_daily`, and the `instrument_valuation` view all move, so no guarantee held. This persists, per generation attempt, **what the writer saw** — enough to audit availability-claim fabrication and detect that sources drifted, without duplicating the source rows.

## Change (3 parts)

1. **`sql/223`** — two nullable columns on `thesis_runs`: `context_sha256 TEXT` + `context_summary JSONB`. Additive, `ADD COLUMN IF NOT EXISTS`, no backfill.
2. **`app/services/thesis_context_audit.py`** (new, pure) — `hash_context` (sha256 of the canonically-serialized context) + `summarize_context` (per-block `{available, status?, as_of?, count?}`).
3. **`app/services/thesis.py`** — `_insert_thesis_run` gains two nullable keyword-only params; `generate_thesis` computes both (defensively wrapped) right after `_assemble_context` and passes them in.

## Key design decisions

- **Persist at run-insert, before the LLM.** The columns are written by `_insert_thesis_run`, which commits before the writer/critic calls; `_record_thesis_run_failure` is a status-only UPDATE. So **failed/guard-rejected runs retain the audit** — exactly the #2007 AMSC case (a `status='failed'` run with no thesis row). Success-only persistence would have captured nothing for the run we needed to debug.
- **Hash + block summary, not full blob.** Full-blob would duplicate memos/filings/news already in source tables (settled "full raw filing text out of scope"). Scoped honestly to **availability + drift metadata**, not faithful reconstruction (`_assemble_context` is non-reproducible — wall-clock news cutoff). The summary's as-of stamps are the drift signal; the hash is a content-identity fingerprint.
- **No `_PROMPT_VERSION` bump.** The writer prompt is byte-identical — this only reads the context to write audit metadata to a *different* table. Version recorded *inside* the summary (data), not incremented → no re-gate, no LLM-eval, no thesis backfill.
- **Best-effort, never gate.** The compute is wrapped so any failure degrades to NULL columns + a WARNING, never aborting a valid thesis (prevention-log 2127; mirrors #2009 divergence "measure-only"). Broad `except` is deliberate here (single pre-LLM call, forensic metadata) — the comment states why, distinct from 2127's per-row batch case.

## Security model

- **SQL:** all writes parameterized (named params in the INSERT; `%s` in tests). `context_summary` bound via `Jsonb(...) if not None else None` so a missing summary is SQL NULL, not a JSONB scalar `null`.
- **Append-only:** `thesis_runs` stays append-only; the audit columns are write-once at insert.
- **No auth/authz surface change**; no new external calls; no user-controlled input path.
- **Ordering dependency:** the new code expects the columns, so `sql/223` must be applied before the new `generate_thesis` runs. A jobs-task restart boots → `run_migrations()` applies `sql/223` idempotently → then serves the new write path, so restart handles both atomically. (`sql/223` is already applied on dev.)

## Verification (at `eb1fd396`)

Full pre-push gate green:
- `ruff check .` + `ruff format --check .` clean; `pyright` 0 errors.
- Fast tier (`-m "not db"`): **4996 passed, 3 skipped**.
- Smoke (`tests/smoke`, boots FastAPI lifespan against dev → proves `sql/223` applies): **147 passed**.
- db-tier thesis (`-m db -k "thesis_context_audit or thesis_runs or thesis_valuation"`): **13 passed** — incl. the 3 new persist tests (insert persists both columns; omitting params → NULL; **failed run retains the audit** via `_record_thesis_run_failure`).
- Fast-tier pure module: 14 tests (hash determinism/strict-raise; per-block availability/status/as-of; news `max()`-not-`[0]`; malformed→`available:false`; `risk_metrics`/`fair_value_band` per real shapes).
- New integration assertion in `test_empty_surfaces_yield_honest_absences`: a **real** `_assemble_context` output flows through both helpers (non-raising hash; all absent blocks → `available:false`).

Reviews: Codex ckpt-1 (spec) + ckpt-2 (plan) + pre-push (branch); opus whole-branch review (1 Important — untested real-context integration path — fixed in `eb1fd396`).

## Tradeoffs (conscious)

- Summary is compact: top-level availability/status/as-of only; nested per-window statuses (`risk_metrics.windows[].*_status`) and analytics sub-block markers are **not** rolled up (hash + source tables cover the finer detail).
- The `generate_thesis` try/except is not exercised by an automated test (would need mocked LLM clients); the property is structurally guaranteed by the wrap (noted for follow-up).
- The two `max`-stamp comprehensions are structurally similar but left inline (a shared helper would force a pyright `type: ignore` for a case the shapers make impossible).

## Operator follow-up (post-merge, gated)

1. Restart the VS Code jobs task → boot applies `sql/223` (idempotent; already on dev) then serves the new write path; `thesis_refresh` starts recording the audit.
2. Force-regen one instrument (`POST /instruments/AAPL/thesis?force=true`, Bearer `EBULL_SERVICE_TOKEN`) and confirm the latest `thesis_runs` row carries a non-null `context_sha256` + a `context_summary` whose blocks reflect availability (e.g. `fair_value_band.available:true`, `valuation` per its live-quote status). No backfill — historical rows stay NULL by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
