### PR TITLE
feat(#2028): tender/going-private FE render — TenderBlock on Filings tab

### DIFF
--- a/docs/specs/filings/2026-07-13-tender-fe-render.md
+++ b/docs/specs/filings/2026-07-13-tender-fe-render.md
@@ -1,0 +1,150 @@
+# Tender/going-private FE render — TenderBlock on the Filings tab
+
+Issue: #2028 (follow-up child of #1982). Branch: `feature/2028-tender-fe-render`.
+
+## Goal
+
+Render the already-shipped `tender` object inline on the Filings tab, one block per
+filing row that carries a non-null `tender`, mirroring the OfferingBlock (424B, #1978)
+precedent. FE-only; the backend contract, serializer, and data path shipped in #1982 / PR #2027.
+
+## Source rule
+
+No data-treatment decision here — the parser already classified role, transaction type, and
+board recommendation; the FE is a passive render of the shipped `TenderEventSummary` contract.
+The one source-anchored *display* choice is `board_recommendation`: its DB enum
+(`accept`/`reject`/`neutral`/`unable`, `sql/224:76-77`) encodes the SEC **Item 1012(a)**
+position vocabulary (parser spec `docs/specs/filings/2026-07-05-tender-going-private-parser.md:116-118`),
+so the operator-facing phrasing must read as accept/reject/neutral/unable, not invented wording.
+
+## Settled decisions
+
+None apply — `grep -niE 'filings tab|tender|offering block|frontend render|per-form|filing detail' docs/settled-decisions.md` returns nothing. This render introduces no new settled decision (scoring-neutral, no `model_version` bump — parser spec `:313`).
+
+## Prevention-log entries that apply
+
+- **FE↔BE type parity, same PR** (`review-prevention-log.md:473-474`, `.claude/skills/frontend/api-shape-and-types.md`): `types.ts` mirrors the Pydantic class field-for-field, nullability exact, snake_case on the wire. `apiFetch<T>` does no runtime validation, so a wrong type deserializes silently to `undefined`.
+- **Nullable-checkbox discipline** (parser spec `:138-139`): the transaction-type flags are `bool | None`; `null ≠ false`. The type-label helper picks the first flag that is `=== true` and falls to a neutral label when all are null — never inferred from a null/false.
+- **Loading/empty/error owned by the parent** (`.claude/skills/frontend/loading-error-empty-states.md`): `FilingsTab` already answers all three (`InstrumentPage.tsx:448-459`). The block is a pure presentational leaf mounted only behind a `!== null` guard — no own skeleton/error surface.
+
+## Backend contract (already shipped — no change)
+
+`GET /filings/{instrument_id}` → `FilingsListResponse.items[].tender: TenderEventSummary | None`
+(`app/api/filings.py:90-113,148`, serializer `_parse_tender` `:254-279`, LEFT JOIN on the table PK
+`(accession_number, instrument_id)` `:412-415` → at most one tender row per item). `TenderEventSummary`,
+14 fields, only `role` + `subject_company_name` non-null:
+
+| # | field | TS type |
+|---|-------|---------|
+| 1 | `role` | `"subject" \| "offeror"` |
+| 2 | `subject_company_name` | `string` |
+| 3 | `offeror_names` | `string[] \| null` |
+| 4 | `is_third_party_tender` | `boolean \| null` |
+| 5 | `is_issuer_tender` | `boolean \| null` |
+| 6 | `is_going_private` | `boolean \| null` |
+| 7 | `amends_13d` | `boolean \| null` |
+| 8 | `is_final_amendment` | `boolean \| null` |
+| 9 | `amendment_no` | `number \| null` |
+| 10 | `offer_price_per_unit` | `number \| null` |
+| 11 | `unit_label` | `string \| null` |
+| 12 | `currency` | `string \| null` |
+| 13 | `expiration_date` | `string \| null` (ISO `YYYY-MM-DD`) |
+| 14 | `board_recommendation` | `string \| null` (`accept`/`reject`/`neutral`/`unable`) |
+
+## FE changes
+
+### 1. `frontend/src/api/types.ts`
+Add `TenderEventSummary` in the `/filings/{instrument_id}` section (beside `OfferingSummary`, `:1335`),
+mirroring the table above in declaration order (name matches the Pydantic class exactly, as
+`OfferingSummary` does). Add `tender: TenderEventSummary | null` on `FilingItem` after `offering` (`:1372`),
+with the standard `null otherwise` comment. **Divergence from OfferingSummary to mirror exactly:**
+`currency` is `string | null` here (OfferingSummary's is non-null `string`).
+
+`board_recommendation` stays `string | null` (Codex ckpt-1 NIT REBUTTED): the Pydantic field is
+`str | None`, not a `Literal`, and `api-shape-and-types.md` mandates an exact mirror (narrowing the FE
+past the BE type is drift). `boardRecLabel`'s `default` branch handles any value outside the 4-state
+enum defensively.
+
+### 2. `frontend/src/components/instrument/TenderBlock.tsx` (new)
+Pure presentational leaf, prop `readonly tender: TenderEventSummary`. Copy OfferingBlock's markup
+verbatim — outer bordered `div` (`OfferingBlock.tsx:58`), header row (`:59-66`), `dl`/`dt`/`dd` KV grid
+(`:68-77`). Reuse `formatMoney` + `formatDate` from `@/lib/format` (no new formatter).
+
+Null-safe label helpers (mirror `offeringKindLabel`):
+```ts
+// Codex ckpt-1 BLOCKING: the 4 transaction-type checkboxes are ORTHOGONAL and stored
+// uncollapsed by design (parser spec :21-25 — a TO-T can also be going-private / 13D-amending).
+// Render ALL true flags — never collapse to one priority label. null/false → no flag
+// (nullable-checkbox discipline). All-null/false → neutral "Tender offer".
+function typeLabels(t: TenderEventSummary): string[] {
+  const out: string[] = [];
+  if (t.is_third_party_tender === true) out.push("Third-party tender");
+  if (t.is_issuer_tender === true) out.push("Issuer self-tender");
+  if (t.is_going_private === true) out.push("Going-private");
+  if (t.amends_13d === true) out.push("13D amendment");
+  return out.length > 0 ? out : ["Tender offer"];
+}
+// Source-faithful role term: `role` is the SGML SUBJECT-COMPANY vs FILED-BY block the
+// instrument's CIK matched (parser spec :133-134) — "offeror", NOT "acquirer" (a mini-tender
+// offeror is not necessarily an acquirer). Use the reg vocabulary.
+function roleLabel(role: "subject" | "offeror"): string {
+  return role === "offeror" ? "Offeror" : "Subject";
+}
+function boardRecLabel(v: string): string {
+  switch (v) {
+    case "accept": return "Recommends accepting";
+    case "reject": return "Recommends rejecting";
+    case "neutral": return "Neutral / no position";
+    case "unable": return "Unable to take position";
+    default: return v; // defensive — DB CHECK bounds this to the 4 above
+  }
+}
+```
+
+Header: `{typeLabels(tender).join(" · ")}` (font-medium) + `{roleLabel(tender.role)}` (muted),
+mirroring OfferingBlock's two-span header. If `is_final_amendment === true` append muted
+"· final amendment"; else if `amendment_no !== null` append muted `· amendment ${amendment_no}`.
+(`is_final_amendment` / `amendment_no` are amendment STATUS, orthogonal to the type flags — kept
+separate, not folded into `typeLabels`.)
+
+KV rows (push only when present; `subject_company_name` is always present so the grid is never empty —
+**no all-null one-liner branch is needed, unlike OfferingBlock**, because `subject_company_name` is
+non-null by contract):
+- `Subject` → `tender.subject_company_name` (always)
+- `Offeror` → `tender.offeror_names.join(", ")` — only if `offeror_names !== null && length > 0`
+- `Price` → only if `offer_price_per_unit !== null`. Value: `tender.currency !== null ? formatMoney(price, tender.currency) : formatNumber(price, 2)` — **never `currency ?? undefined`** (Codex ckpt-1 WARNING: that fabricates a GBP symbol when currency is null; render the bare number instead). Append ` / ${unit_label}` when `unit_label !== null`.
+- `Expires` → `formatDate(tender.expiration_date)` — only if `expiration_date !== null`
+- `Board` → `boardRecLabel(tender.board_recommendation)` — only if `board_recommendation !== null`
+
+Color: keep OfferingBlock's neutral slate palette (no new color job per `operator-ui-conventions.md` — the "Going-private transaction" label carries the signal in text; KISS).
+
+### 3. `frontend/src/pages/InstrumentPage.tsx`
+Import `TenderBlock` (beside the OfferingBlock import, `:44`). Slot
+`{f.tender !== null && <TenderBlock tender={f.tender} />}` immediately after the OfferingBlock slot
+(`:484`), same guard shape.
+
+### 4. `frontend/src/components/instrument/TenderBlock.test.tsx` (new)
+Mirror `OfferingBlock.test.tsx` (real verified dev fixtures). Cases:
+- (a) third-party offeror with price + target + offeror + expiry → "Third-party tender", role "Offeror", Subject "NETSUITE INC", Offeror "ORACLE CORP", Price "US$109.00 / Share" render. Fixture: ORCL/NetSuite `0001193125-16-684804`.
+- (b) subject 14D9 with `board_recommendation: "reject"`, `offer_price_per_unit: 8.61`, all checkbox flags null → neutral label "Tender offer", role "Subject", Board "Recommends rejecting", Expires, no Offeror row. Fixture: NHP/Comrit `0001104659-20-031431`.
+- (c) **combo** (Codex ckpt-1): `is_third_party_tender: true` AND `is_going_private: true` → BOTH "Third-party tender" AND "Going-private" render (no collapse).
+- (d) `is_final_amendment: true` → "· final amendment" suffix.
+- (e) price present + `currency: null` → bare number (no fabricated currency symbol).
+
+### 5. Existing FilingItem fixtures (Codex ckpt-1 WARNING)
+`FilingItem.tender` is a new **required** field, so every existing `FilingItem` literal must add
+`tender: null` or `pnpm typecheck` breaks. Affected fixtures (grep `offering:` under `frontend/src`):
+`frontend/src/components/instrument/FilingsPane.test.tsx`,
+`frontend/src/components/instrument/RightRail.test.tsx`.
+
+## Out of scope
+
+No backend/serializer change; no new fetcher (`tender` flows on `FilingItem` through the existing
+`fetchFilings`); no scoring / `model_version` impact.
+
+## Verification / DoD
+
+- `pnpm --dir frontend typecheck` + `pnpm --dir frontend test:unit` green.
+- FE-QA eyeball the Filings tab on **ORCL** (offeror, multi-event: NetSuite $109 / Textura $26 /
+  Opower $10.30) and **NHP** (subject, SC TO-T + SC 14D9 board recommendation). Requires the
+  `sec_tender` re-drain (in progress) complete first.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1345,6 +1345,30 @@ export interface OfferingSummary {
   security_type: string | null;
 }
 
+/** Parsed tender-offer / going-private event (Reg M-A: Schedule TO / 14D-9 / 13E-3) — #1982.
+ *  Mirrors app/api/filings.py TenderEventSummary. One row per (accession, instrument); only
+ *  `role` + `subject_company_name` are non-null. The four transaction-type checkboxes are
+ *  orthogonal tri-state flags (true/false/null) stored uncollapsed by design — null means the
+ *  cover box was unresolvable, never a guessed value. `board_recommendation` is the SEC Item
+ *  1012(a) position (accept/reject/neutral/unable); kept `string | null` to mirror the Pydantic
+ *  `str | None` exactly. */
+export interface TenderEventSummary {
+  role: "subject" | "offeror";
+  subject_company_name: string;
+  offeror_names: string[] | null;
+  is_third_party_tender: boolean | null;
+  is_issuer_tender: boolean | null;
+  is_going_private: boolean | null;
+  amends_13d: boolean | null;
+  is_final_amendment: boolean | null;
+  amendment_no: number | null;
+  offer_price_per_unit: number | null;
+  unit_label: string | null;
+  currency: string | null;
+  expiration_date: string | null;
+  board_recommendation: string | null;
+}
+
 export interface FilingItem {
   filing_event_id: number;
   instrument_id: number;
@@ -1370,6 +1394,9 @@ export interface FilingItem {
   pre14a_signal: Pre14aSignalSummary | null;
   /** Parsed 424B cover offering for tier-1 424B rows (#1816); null otherwise. */
   offering: OfferingSummary | null;
+  /** Parsed tender-offer / going-private event for Schedule TO / 14D-9 / 13E-3 rows (#1982);
+   *  null otherwise. */
+  tender: TenderEventSummary | null;
 }
 
 export interface FilingsListResponse {

--- a/frontend/src/components/instrument/FilingsPane.test.tsx
+++ b/frontend/src/components/instrument/FilingsPane.test.tsx
@@ -121,6 +121,7 @@ describe("FilingsPane", () => {
         nt_notice: null,
         pre14a_signal: null,
         offering: null,
+        tender: null,
       })),
     });
     render(
@@ -175,6 +176,7 @@ describe("FilingsPane", () => {
           nt_notice: null,
           pre14a_signal: null,
           offering: null,
+          tender: null,
         },
         {
           filing_event_id: 2,
@@ -191,6 +193,7 @@ describe("FilingsPane", () => {
           nt_notice: null,
           pre14a_signal: null,
           offering: null,
+          tender: null,
         },
       ],
     });
@@ -244,6 +247,7 @@ describe("FilingsPane", () => {
           nt_notice: null,
           pre14a_signal: null,
           offering: null,
+          tender: null,
         },
         {
           filing_event_id: 2,
@@ -260,6 +264,7 @@ describe("FilingsPane", () => {
           nt_notice: null,
           pre14a_signal: null,
           offering: null,
+          tender: null,
         },
       ],
     });

--- a/frontend/src/components/instrument/RightRail.test.tsx
+++ b/frontend/src/components/instrument/RightRail.test.tsx
@@ -81,6 +81,7 @@ function filingsWith(instrumentId: number): FilingsListResponse {
         nt_notice: null,
         pre14a_signal: null,
         offering: null,
+        tender: null,
       },
     ],
     total: 1,

--- a/frontend/src/components/instrument/TenderBlock.test.tsx
+++ b/frontend/src/components/instrument/TenderBlock.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TenderBlock } from "@/components/instrument/TenderBlock";
+import type { TenderEventSummary } from "@/api/types";
+
+// Live dev fixture: Oracle's third-party tender for NetSuite, SC TO-T
+// 0001193125-16-684804 — $109.00/share, offeror ORACLE CORP.
+function oracleNetsuite(): TenderEventSummary {
+  return {
+    role: "offeror",
+    subject_company_name: "NETSUITE INC",
+    offeror_names: ["ORACLE CORP"],
+    is_third_party_tender: true,
+    is_issuer_tender: false,
+    is_going_private: false,
+    amends_13d: false,
+    is_final_amendment: false,
+    amendment_no: null,
+    offer_price_per_unit: 109.0,
+    unit_label: "Share",
+    currency: "USD",
+    expiration_date: null,
+    board_recommendation: null,
+  };
+}
+
+// Live dev fixture: Healthcare Trust's SC 14D9 0001104659-20-031431 responding to
+// the Comrit $8.61 mini-tender — board recommends rejecting; no transaction-type
+// checkboxes on a 14D-9 (all null); expires 2020-04-30.
+function nhpComrit14d9(): TenderEventSummary {
+  return {
+    role: "subject",
+    subject_company_name: "Healthcare Trust, Inc.",
+    offeror_names: null,
+    is_third_party_tender: null,
+    is_issuer_tender: null,
+    is_going_private: null,
+    amends_13d: null,
+    is_final_amendment: null,
+    amendment_no: null,
+    offer_price_per_unit: 8.61,
+    unit_label: null,
+    currency: "USD",
+    expiration_date: "2020-04-30",
+    board_recommendation: "reject",
+  };
+}
+
+describe("TenderBlock", () => {
+  it("renders a priced third-party offeror tender with parties + price", () => {
+    render(<TenderBlock tender={oracleNetsuite()} />);
+    expect(screen.getByText(/Third-party tender/)).toBeInTheDocument();
+    expect(screen.getByText("offeror")).toBeInTheDocument(); // lowercase muted role
+    expect(screen.getByText("Subject")).toBeInTheDocument();
+    expect(screen.getByText("NETSUITE INC")).toBeInTheDocument();
+    expect(screen.getByText("Offeror")).toBeInTheDocument();
+    expect(screen.getByText("ORACLE CORP")).toBeInTheDocument();
+    expect(screen.getByText(/109\.00 \/ Share/)).toBeInTheDocument(); // formatMoney(USD)
+  });
+
+  it("renders a subject 14D9 with board recommendation + expiry, neutral type, no offeror", () => {
+    render(<TenderBlock tender={nhpComrit14d9()} />);
+    // all transaction-type checkboxes null → neutral label, never guessed
+    expect(screen.getByText("Tender offer")).toBeInTheDocument();
+    expect(screen.getByText("subject")).toBeInTheDocument();
+    expect(screen.getByText("Healthcare Trust, Inc.")).toBeInTheDocument();
+    expect(screen.getByText("Recommends rejecting")).toBeInTheDocument();
+    expect(screen.getByText("30 Apr 2020")).toBeInTheDocument();
+    expect(screen.getByText(/8\.61/)).toBeInTheDocument();
+    expect(screen.queryByText("Offeror")).not.toBeInTheDocument(); // offeror_names null
+  });
+
+  it("renders ALL true transaction-type flags — never collapses orthogonal checkboxes", () => {
+    render(
+      <TenderBlock
+        tender={{ ...oracleNetsuite(), is_going_private: true }}
+      />,
+    );
+    // both flags true → both render in the header, not just a priority pick
+    expect(screen.getByText(/Third-party tender/)).toBeInTheDocument();
+    expect(screen.getByText(/Going-private/)).toBeInTheDocument();
+  });
+
+  it("appends a final-amendment status suffix", () => {
+    render(
+      <TenderBlock
+        tender={{ ...oracleNetsuite(), is_final_amendment: true }}
+      />,
+    );
+    expect(screen.getByText(/final amendment/)).toBeInTheDocument();
+  });
+
+  it("renders a bare number (no fabricated currency) when currency is null", () => {
+    render(<TenderBlock tender={{ ...oracleNetsuite(), currency: null }} />);
+    // formatNumber fallback — no "US$"/"£" symbol invented from a null currency
+    expect(screen.getByText("109 / Share")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/TenderBlock.tsx
+++ b/frontend/src/components/instrument/TenderBlock.tsx
@@ -1,0 +1,113 @@
+/**
+ * TenderBlock — parsed tender-offer / going-private event (Reg M-A: Schedule TO /
+ * 14D-9 / 13E-3) rendered inline on a Filings-tab row (#1982, data path PR #2027).
+ *
+ * The four transaction-type checkbox flags are orthogonal and stored uncollapsed by
+ * design — a third-party tender can also be going-private / 13D-amending. Every flag
+ * that is `true` renders; null/false does not (nullable-checkbox discipline: null is
+ * an unresolved cover box, never a guessed value). `role` and `subject_company_name`
+ * are non-null by contract, so the block always has content — no empty-grid fallback
+ * (unlike OfferingBlock, whose every field is nullable).
+ */
+
+import type { TenderEventSummary } from "@/api/types";
+import { formatDate, formatMoney, formatNumber } from "@/lib/format";
+
+// Orthogonal tri-state flags — render ALL that are true, never collapse to one label.
+function typeLabels(t: TenderEventSummary): string[] {
+  const out: string[] = [];
+  if (t.is_third_party_tender === true) out.push("Third-party tender");
+  if (t.is_issuer_tender === true) out.push("Issuer self-tender");
+  if (t.is_going_private === true) out.push("Going-private");
+  if (t.amends_13d === true) out.push("13D amendment");
+  return out.length > 0 ? out : ["Tender offer"];
+}
+
+// Source-faithful role term (SGML SUBJECT-COMPANY vs FILED-BY block) — "offeror", not
+// "acquirer". Lowercase to match OfferingBlock's muted secondary-label convention and to
+// avoid colliding with the capitalised "Subject"/"Offeror" KV row labels below.
+function roleLabel(role: "subject" | "offeror"): string {
+  return role === "offeror" ? "offeror" : "subject";
+}
+
+// SEC Item 1012(a) board position (DB CHECK enum accept/reject/neutral/unable).
+function boardRecLabel(v: string): string {
+  switch (v) {
+    case "accept":
+      return "Recommends accepting";
+    case "reject":
+      return "Recommends rejecting";
+    case "neutral":
+      return "Neutral / no position";
+    case "unable":
+      return "Unable to take position";
+    default:
+      return v; // defensive — DB CHECK bounds this to the 4 above
+  }
+}
+
+// Amendment STATUS (orthogonal to the transaction-type flags).
+function amendmentSuffix(t: TenderEventSummary): string | null {
+  if (t.is_final_amendment === true) return "final amendment";
+  if (t.amendment_no !== null) return `amendment ${t.amendment_no}`;
+  return null;
+}
+
+export interface TenderBlockProps {
+  readonly tender: TenderEventSummary;
+}
+
+export function TenderBlock({ tender }: TenderBlockProps): JSX.Element {
+  const rows: Array<{ label: string; value: string }> = [];
+  rows.push({ label: "Subject", value: tender.subject_company_name });
+  if (tender.offeror_names !== null && tender.offeror_names.length > 0) {
+    rows.push({ label: "Offeror", value: tender.offeror_names.join(", ") });
+  }
+  if (tender.offer_price_per_unit !== null) {
+    // Never fabricate a currency: formatMoney's default is GBP, so fall back to a bare
+    // number when currency is null rather than pass `currency ?? undefined` (Codex ckpt-1).
+    const price =
+      tender.currency !== null
+        ? formatMoney(tender.offer_price_per_unit, tender.currency)
+        : formatNumber(tender.offer_price_per_unit, 2);
+    rows.push({
+      label: "Price",
+      value: tender.unit_label !== null ? `${price} / ${tender.unit_label}` : price,
+    });
+  }
+  if (tender.expiration_date !== null) {
+    rows.push({ label: "Expires", value: formatDate(tender.expiration_date) });
+  }
+  if (tender.board_recommendation !== null) {
+    rows.push({
+      label: "Board",
+      value: boardRecLabel(tender.board_recommendation),
+    });
+  }
+
+  const suffix = amendmentSuffix(tender);
+
+  return (
+    <div className="mt-1 rounded border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 px-2 py-1.5 text-xs">
+      <div className="flex items-baseline gap-2">
+        <span className="font-medium text-slate-700 dark:text-slate-200">
+          {typeLabels(tender).join(" · ")}
+        </span>
+        <span className="text-slate-500 dark:text-slate-400">
+          {roleLabel(tender.role)}
+          {suffix !== null ? ` · ${suffix}` : ""}
+        </span>
+      </div>
+      <dl className="mt-1 flex flex-wrap gap-x-4 gap-y-0.5">
+        {rows.map((r) => (
+          <div key={r.label} className="flex items-baseline gap-1">
+            <dt className="text-slate-500 dark:text-slate-400">{r.label}</dt>
+            <dd className="font-medium tabular-nums text-slate-700 dark:text-slate-200">
+              {r.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}

--- a/frontend/src/pages/InstrumentPage.tsx
+++ b/frontend/src/pages/InstrumentPage.tsx
@@ -42,6 +42,7 @@ import type {
   ThesisDetail,
 } from "@/api/types";
 import { OfferingBlock } from "@/components/instrument/OfferingBlock";
+import { TenderBlock } from "@/components/instrument/TenderBlock";
 import { InstrumentTradesTable } from "@/components/instrument/InstrumentTradesTable";
 import { InstrumentTradeHistory } from "@/components/instrument/InstrumentTradeHistory";
 import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
@@ -482,6 +483,7 @@ function FilingsTab({ instrumentId }: { instrumentId: number }) {
               <p className="mt-1 text-xs text-slate-600">{f.extracted_summary}</p>
             )}
             {f.offering !== null && <OfferingBlock offering={f.offering} />}
+            {f.tender !== null && <TenderBlock tender={f.tender} />}
             <div className="mt-1 flex gap-3 text-xs">
               {f.primary_document_url && (
                 <a


### PR DESCRIPTION
## What

Render the tender/going-private object inline on the Filings tab (one block per filing row that carries a non-null `tender`), completing #1982's operator-visible payoff. New `TenderBlock` component mirrors the OfferingBlock (#1978) precedent.

## Why

#1982 (PR #2027) shipped the tender parser and the `tender` object on `GET /filings/{instrument_id}` `items[]`, but no frontend consumed it. This is the FE follow-up child scoped in the parser spec (`docs/specs/filings/2026-07-05-tender-going-private-parser.md:312-313`) — scoring-neutral, **no `model_version` bump**.

## Scope (FE-only, additive — no backend change)

- `frontend/src/api/types.ts` — `TenderEventSummary` interface + `tender: TenderEventSummary | null` on `FilingItem`.
- `frontend/src/components/instrument/TenderBlock.tsx` — presentational leaf mounted behind a `!== null` guard (parent `FilingsTab` owns loading/error/empty).
- `frontend/src/pages/InstrumentPage.tsx` — `FilingsTab` slot next to OfferingBlock.
- `frontend/src/components/instrument/TenderBlock.test.tsx` — 5 real-dev-fixture cases.
- `FilingsPane.test.tsx` / `RightRail.test.tsx` — existing `FilingItem` fixtures get `tender: null` (new required field).

Backend contract + serializer (`app/api/filings.py` `TenderEventSummary` / `_parse_tender`) shipped in #2027 — unchanged here.

## Design decisions (surfaced by Codex spec review)

- **Orthogonal transaction-type flags render uncollapsed.** The four checkbox flags (`is_third_party_tender` / `is_issuer_tender` / `is_going_private` / `amends_13d`) are independent and the parser stores them uncollapsed by design — a TO-T can also be going-private. `typeLabels` renders every flag that is `=== true`, never a single priority pick. Tri-state discipline: `null`/`false` render nothing (never inferred).
- **Source-faithful role term.** `role` is the SGML SUBJECT-COMPANY vs FILED-BY block — rendered as lowercase "offeror"/"subject", not "acquirer" (an offeror is not necessarily an acquirer).
- **Currency-null-safe price.** `offer_price_per_unit` with a null `currency` renders via `formatNumber` (bare number), never `formatMoney(..., currency ?? undefined)` which would fabricate a GBP symbol.
- **`board_recommendation` kept `string | null`** to mirror the Pydantic `str | None` exactly (`api-shape-and-types.md` — narrowing the FE past the BE type is drift); `boardRecLabel`'s `default` branch handles any out-of-enum value defensively.

## Type parity

`TenderEventSummary` mirrors `app/api/filings.py` `TenderEventSummary` (`:90-113`) field-for-field, in declaration order, nullability exact (only `role` + `subject_company_name` non-null). Per `.claude/skills/frontend/api-shape-and-types.md`.

## Security model

No new data access, no mutation, no auth surface, no user input interpolated. Pure passive render of filing-detail data the operator already fetches on the Filings tab (`GET /filings/{instrument_id}`, cookie-auth via `apiFetch`). Files outside the diff: none touched.

## Verification

- `pnpm --dir frontend typecheck` — green (validates the whole project, confirming no other `FilingItem` literal is missing the new required `tender`).
- `pnpm --dir frontend test:unit` — green, 125 files / 1345 tests; 5 new `TenderBlock` cases including the orthogonal-flags combo and the null-currency fallback.
- FE-QA: Filings tab eyeballed on **ORCL** (offeror, 57 tender rows incl. Oracle/NetSuite $109) + **NHP** (subject, 7 rows incl. SC 14D9 board-reject). _[recorded at review-resolution time]_

Closes #2028.
