### PR TITLE
feat(#2023): re-key peer_comparison cohort eToro-sector → SEC SIC (4→3→2 walk)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -1032,7 +1032,12 @@ def get_instrument_peer_comparison(
                 instrument_value=result.self_factors.get(key),
                 cohort_median=result.medians[key].median,
                 cohort_n=result.medians[key].n,
-                dev_limited=is_factor_thin(key, result.medians[key].n, result.cohort_member_count),
+                dev_limited=is_factor_thin(
+                    key,
+                    result.medians[key].n,
+                    result.cohort_member_count,
+                    cohort_is_fallback=result.cohort_sic_level == 0,
+                ),
                 better_when=FACTOR_BETTER_WHEN[key],  # type: ignore[arg-type]
             )
             for key in FACTOR_KEYS

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -320,19 +320,19 @@ class FcfYieldSeries(BaseModel):
 
 
 class PeerFactor(BaseModel):
-    """One radar factor: the instrument's value vs its sector median (#1751)."""
+    """One radar factor: the instrument's value vs its SIC-cohort median (#1751; #2023)."""
 
     key: str
     label: str
     instrument_value: float | None
-    sector_median: float | None
-    sector_n: int  # # sector members with a non-null value for this factor
-    dev_limited: bool  # True when thin: price-gated (P/E) OR sector coverage <20% (#1836)
+    cohort_median: float | None
+    cohort_n: int  # # cohort members with a non-null value for this factor
+    dev_limited: bool  # True when thin: price-gated (P/E) OR cohort coverage <20% (#1836)
     better_when: Literal["higher", "lower"]
 
 
 class PeerInstrument(BaseModel):
-    """A sector peer with its factor row (for the #594 heatmap)."""
+    """A cohort peer with its factor row (for the #594 heatmap)."""
 
     instrument_id: int
     symbol: str
@@ -344,8 +344,10 @@ class PeerInstrument(BaseModel):
 class PeerComparison(BaseModel):
     symbol: str
     instrument_id: int
-    sector: str  # raw code "1".."9" (instruments.sector is TEXT; no lookup table)
-    sector_member_count: int  # complete-TTM members in the sector (median base)
+    cohort_sic: str  # the instrument's own 4-digit SEC SIC (#2023)
+    cohort_sic_label: str | None  # sic_description of that SIC (human-readable)
+    cohort_sic_level: int  # 4/3/2 = cleared MIN_COHORT at that granularity; 0 = SIC-2 fallback (thin)
+    cohort_member_count: int  # complete-TTM peers in the cohort (median base)
     factors: list[PeerFactor]
     peers: list[PeerInstrument]
 
@@ -978,15 +980,17 @@ def get_instrument_peer_comparison(
     symbol: str,
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> PeerComparison:
-    """Peer-comparison data for the #594 radar + sector heatmap (#1751).
+    """Peer-comparison data for the #594 radar + cohort heatmap (#1751; SIC #2023).
 
     Per instrument: the radar factors (P/E, ROE, revenue growth YoY, operating
-    margin, debt/equity, net margin), their sector medians, and a size-proximity
-    peer set — all derived server-side from existing fundamentals (no new
-    ingest). A factor is ``dev_limited`` (thin: greyed + ⚠) when price-gated
-    (P/E) OR its sector coverage is <20% (#1836). 404 when the instrument has no
-    sector classification or no complete-TTM fundamentals. Policy lives in
-    app/services/peer_comparison.py (``is_factor_thin``).
+    margin, debt/equity, net margin), their SIC-cohort medians, and a
+    size-proximity peer set — all derived server-side from existing fundamentals
+    (no new ingest). Cohort = SEC SIC walked 4→3→2 to the narrowest level with
+    ``MIN_COHORT`` peers (``cohort_sic_level``; 0 = SIC-2 fallback, thin). A
+    factor is ``dev_limited`` (thin: greyed + ⚠) when price-gated (P/E) OR its
+    cohort coverage is <20% (#1836). 404 when the instrument has no SIC
+    classification or no complete-TTM fundamentals. Policy lives in
+    app/services/peer_comparison.py (``resolve_sic_level``, ``is_factor_thin``).
     """
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
@@ -1011,22 +1015,24 @@ def get_instrument_peer_comparison(
     if result is None:
         raise HTTPException(
             status_code=404,
-            detail=f"No peer-comparison data for {symbol} (no sector classification or no complete-TTM fundamentals)",
+            detail=f"No peer-comparison data for {symbol} (no SIC classification or no complete-TTM fundamentals)",
         )
 
     return PeerComparison(
         symbol=result.symbol,
         instrument_id=result.instrument_id,
-        sector=result.sector,
-        sector_member_count=result.sector_member_count,
+        cohort_sic=result.cohort_sic,
+        cohort_sic_label=result.cohort_sic_label,
+        cohort_sic_level=result.cohort_sic_level,
+        cohort_member_count=result.cohort_member_count,
         factors=[
             PeerFactor(
                 key=key,
                 label=FACTOR_LABELS[key],
                 instrument_value=result.self_factors.get(key),
-                sector_median=result.medians[key].median,
-                sector_n=result.medians[key].n,
-                dev_limited=is_factor_thin(key, result.medians[key].n, result.sector_member_count),
+                cohort_median=result.medians[key].median,
+                cohort_n=result.medians[key].n,
+                dev_limited=is_factor_thin(key, result.medians[key].n, result.cohort_member_count),
                 better_when=FACTOR_BETTER_WHEN[key],  # type: ignore[arg-type]
             )
             for key in FACTOR_KEYS

--- a/app/services/peer_comparison.py
+++ b/app/services/peer_comparison.py
@@ -1,8 +1,8 @@
 """
-Peer-comparison data layer (#1751) — unblocks #594.
+Peer-comparison data layer (#1751; SIC re-key #2023) — unblocks #594.
 
 Derives, per instrument, the radar factors (P/E, ROE, revenue growth YoY,
-operating margin, debt/equity, net margin), their sector medians, and a peer
+operating margin, debt/equity, net margin), their cohort medians, and a peer
 set — entirely from EXISTING tables (no new ingest):
 
   * price-free factors from ``financial_periods_ttm`` (is_complete_ttm),
@@ -10,9 +10,18 @@ set — entirely from EXISTING tables (no new ingest):
     dev; flagged ``dev_limited`` by the caller),
   * ``revenue_growth_yoy`` from the two most recent canonical FY rows in
     ``financial_periods``, with a consecutive-year day-gap guard,
-  * sector medians via ``percentile_cont`` over the sector's complete-TTM set,
-  * peer set = same sector, nearest by size proximity (``total_assets``;
+  * cohort medians via ``percentile_cont`` over the SIC cohort's complete-TTM set,
+  * peer set = same SIC cohort, nearest by size proximity (``total_assets``;
     market cap is price-gated so unusable broadly).
+
+Cohort key (#2023): SEC SIC walked 4->3->2 to the narrowest level with
+``MIN_COHORT`` peers — the SAME key + walk as ``fair_value_band.peer_pct_for``
+(``fair_value_band.py:604-707``), replacing the old eToro ``instruments.sector``
+exact-match (9 opaque codes, 26% missing). SIC lives in
+``instrument_sec_profile`` (``sic`` + generated ``sic3``/``sic2`` STORED cols,
+sql/221). Unlike the band (which goes comparator-absent under threshold),
+peer_comparison is a DISCLOSURE surface: under threshold it widens to SIC-2 and
+renders thin (``cohort_sic_level == 0``), never absent.
 
 Factor formulas MIRROR ``instrument_valuation`` (sql/201) — do not re-derive.
 The view's ~32-row ceiling is its live-price join; bypassed here by reading
@@ -23,11 +32,46 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import LiteralString, cast
 
 import psycopg
 from psycopg.rows import dict_row
 
 _PEER_LIMIT = 8
+
+# Narrowest SIC cohort must hold >= MIN_COHORT PEERS (self already excluded) to
+# resolve at that granularity; else the walk widens. Matches fair_value_band
+# MIN_PEERS=8 so the two keys agree on walk philosophy.
+MIN_COHORT = 8
+
+# SIC column per walk level — a FROZEN whitelist, never interpolated from input
+# (injection-safe, same pattern as fair_value_band._MEMBER_SQL). sic = full
+# 4-digit; sic3/sic2 = generated STORED prefixes (sql/221).
+_SIC_COL: dict[int, str] = {4: "sp.sic", 3: "sp.sic3", 2: "sp.sic2"}
+
+
+def resolve_sic_level(n4: int, n3: int, n2: int, min_cohort: int) -> tuple[int, int]:
+    """
+    Pick the cohort SIC granularity from the three self-excluded peer counts.
+
+    Pure policy (no I/O) — table-tested. ``n4``/``n3``/``n2`` are the peer counts
+    (self already excluded) at SIC-4 / SIC-3 / SIC-2. Returns
+    ``(column_level, disclosure_marker)``:
+
+      * ``column_level`` ∈ {4, 3, 2} — which ``_SIC_COL`` to filter the cohort on.
+      * ``disclosure_marker`` ∈ {4, 3, 2, 0} — the value surfaced as
+        ``cohort_sic_level``. 4/3/2 = that granularity cleared ``min_cohort``;
+        **0** = none cleared, widened to SIC-2 (render thin), mirroring
+        ``fair_value_band``'s ``sic_level=0``.
+    """
+    if n4 >= min_cohort:
+        return 4, 4
+    if n3 >= min_cohort:
+        return 3, 3
+    if n2 >= min_cohort:
+        return 2, 2
+    return 2, 0  # widened SIC-2 fallback, below threshold → thin
+
 
 # Factor keys in #594 radar order. Each: (key, label, better_when).
 FACTOR_KEYS: tuple[str, ...] = (
@@ -86,10 +130,11 @@ def is_factor_thin(key: str, sector_n: int, sector_member_count: int) -> bool:
     return sector_n / sector_member_count < THIN_COVERAGE_RATIO
 
 
-# Per-instrument factor CTE, parameterised by ``%(sector)s``. Mirrors the
-# instrument_valuation formulas (sql/201) for the price-free factors; LEFT JOINs
-# instrument_valuation for pe_ratio and the YoY CTE for revenue growth.
-_FACTORS_CTE = """
+# Per-instrument factor CTE template, parameterised by ``%(sic_prefix)s`` with the
+# SIC column filled from ``_SIC_COL`` (frozen whitelist) via ``_factors_cte``.
+# Mirrors the instrument_valuation formulas (sql/201) for the price-free factors;
+# LEFT JOINs instrument_valuation for pe_ratio and the YoY CTE for revenue growth.
+_FACTORS_CTE_TEMPLATE = """
 WITH yoy AS (
     SELECT instrument_id,
            (cur_rev - prev_rev) / prev_rev AS revenue_growth_yoy
@@ -133,12 +178,22 @@ factors AS (
         y.revenue_growth_yoy
     FROM financial_periods_ttm t
     JOIN instruments i USING (instrument_id)
+    JOIN instrument_sec_profile sp USING (instrument_id)
     LEFT JOIN instrument_valuation v USING (instrument_id)
     LEFT JOIN yoy y ON y.instrument_id = t.instrument_id
     WHERE t.is_complete_ttm = TRUE
-      AND i.sector = %(sector)s
+      AND {sic_col} = %(sic_prefix)s
 )
 """
+
+
+def _factors_cte(column_level: int) -> LiteralString:
+    """Build the factor CTE for a walk level. ``sic_col`` comes from the frozen
+    ``_SIC_COL`` whitelist (never input) → injection-safe; the prefix VALUE is
+    bound as ``%(sic_prefix)s``. The cast is sound because both the template and
+    every ``_SIC_COL`` value are literals (same pattern as
+    ``fair_value_band._MEMBER_SQL: dict[int, LiteralString]``)."""
+    return cast(LiteralString, _FACTORS_CTE_TEMPLATE.format(sic_col=_SIC_COL[column_level]))
 
 
 @dataclass(frozen=True)
@@ -160,8 +215,10 @@ class FactorMedian:
 class PeerComparisonResult:
     instrument_id: int
     symbol: str
-    sector: str
-    sector_member_count: int
+    cohort_sic: str  # the instrument's own full 4-digit SIC
+    cohort_sic_label: str | None  # sic_description of that SIC
+    cohort_sic_level: int  # 4/3/2 = cleared MIN_COHORT at that granularity; 0 = SIC-2 fallback (thin)
+    cohort_member_count: int  # cohort peer count incl. self row (median base)
     self_factors: dict[str, float | None]
     medians: dict[str, FactorMedian]
     peers: list[PeerRow]
@@ -183,7 +240,7 @@ def _rank_peers(
     limit: int,
 ) -> list[PeerRow]:
     """
-    Pick the ``limit`` nearest same-sector peers by log-size proximity.
+    Pick the ``limit`` nearest same-cohort peers by log-size proximity.
 
     Pure (no I/O): excludes self, drops rows with non-positive ``total_assets``,
     orders by ``|ln(peer.total_assets) - ln(self_total_assets)|``. Ties break on
@@ -218,25 +275,48 @@ def compute_peer_comparison(
 ) -> PeerComparisonResult | None:
     """
     Build the peer-comparison payload, or ``None`` when the instrument has no
-    sector classification or no complete-TTM fundamentals (caller 404s).
+    SIC classification or no complete-TTM fundamentals (caller 404s).
     """
     with conn.cursor(row_factory=dict_row) as cur:
-        # 1. sector (TEXT code "1".."9"); None → no classification.
+        # 1. target SIC + label + the three candidate PEER counts (self-excluded,
+        #    so MIN_COHORT means N peers). None / null SIC → no classification.
         cur.execute(
-            "SELECT sector FROM instruments WHERE instrument_id = %(id)s",
+            """
+            WITH tgt AS (
+                SELECT sic, sic3, sic2, sic_description
+                FROM instrument_sec_profile WHERE instrument_id = %(id)s
+            )
+            SELECT t.sic, t.sic3, t.sic2, t.sic_description,
+              (SELECT count(*) FROM financial_periods_ttm f
+                 JOIN instrument_sec_profile p USING (instrument_id)
+                 WHERE f.is_complete_ttm AND p.sic  = t.sic  AND f.instrument_id <> %(id)s) AS n4,
+              (SELECT count(*) FROM financial_periods_ttm f
+                 JOIN instrument_sec_profile p USING (instrument_id)
+                 WHERE f.is_complete_ttm AND p.sic3 = t.sic3 AND f.instrument_id <> %(id)s) AS n3,
+              (SELECT count(*) FROM financial_periods_ttm f
+                 JOIN instrument_sec_profile p USING (instrument_id)
+                 WHERE f.is_complete_ttm AND p.sic2 = t.sic2 AND f.instrument_id <> %(id)s) AS n2
+            FROM tgt t
+            """,
             {"id": instrument_id},
         )
         srow = cur.fetchone()
-        if srow is None or srow["sector"] is None:
+        if srow is None or srow["sic"] is None:
             return None
-        sector = str(srow["sector"])
+        cohort_sic = str(srow["sic"])
+        cohort_sic_label = str(srow["sic_description"]) if srow["sic_description"] is not None else None
+        column_level, cohort_sic_level = resolve_sic_level(
+            int(srow["n4"] or 0), int(srow["n3"] or 0), int(srow["n2"] or 0), MIN_COHORT
+        )
+        sic_prefix = {4: srow["sic"], 3: srow["sic3"], 2: srow["sic2"]}[column_level]
+        cte = _factors_cte(column_level)
 
-        # 2. all complete-TTM factor rows in the sector (self + candidates).
+        # 2. all complete-TTM factor rows in the cohort (self + candidates).
         cur.execute(
-            _FACTORS_CTE + "SELECT instrument_id, symbol, company_name, total_assets, "
+            cte + "SELECT instrument_id, symbol, company_name, total_assets, "
             "operating_margin, net_margin, roe, debt_equity_ratio, pe_ratio, revenue_growth_yoy "
             "FROM factors",
-            {"sector": sector},
+            {"sic_prefix": sic_prefix},
         )
         rows = cur.fetchall()
         by_id = {int(r["instrument_id"]): r for r in rows}
@@ -247,13 +327,13 @@ def compute_peer_comparison(
             return None
         self_ta = float(self_raw["total_assets"])
 
-        # 3. sector medians + non-null counts, one pass over the factors CTE.
+        # 3. cohort medians + non-null counts, one pass over the factors CTE.
         median_select = ", ".join(
             f"percentile_cont(0.5) WITHIN GROUP (ORDER BY {k}) AS {k}_med, count({k}) AS {k}_n" for k in FACTOR_KEYS
         )
         # median_select is built only from the frozen FACTOR_KEYS constant — no
         # user input — so the dynamic SELECT is injection-safe.
-        cur.execute(_FACTORS_CTE + f"SELECT {median_select} FROM factors", {"sector": sector})  # type: ignore[arg-type]
+        cur.execute(cte + f"SELECT {median_select} FROM factors", {"sic_prefix": sic_prefix})  # type: ignore[arg-type]
         mrow = cur.fetchone() or {}
 
     medians = {
@@ -264,16 +344,19 @@ def compute_peer_comparison(
         for k in FACTOR_KEYS
     }
 
-    # 4. peer set: same sector, exclude self, total_assets>0, nearest by
-    #    log-size proximity. Ranking in Python over the already-fetched sector
-    #    rows (hundreds at most) — no extra query.
+    # 4. peer set: same SIC cohort, exclude self, total_assets>0, nearest by
+    #    log-size proximity. Ranking in Python over the already-fetched cohort
+    #    rows (hundreds at most) — no extra query. Best-effort: may be <8 after
+    #    the total_assets filter (peer_comparison does not gate on peer count).
     peers = _rank_peers(list(by_id.values()), self_id=instrument_id, self_total_assets=self_ta, limit=_PEER_LIMIT)
 
     return PeerComparisonResult(
         instrument_id=instrument_id,
         symbol=str(self_raw["symbol"]),
-        sector=sector,
-        sector_member_count=len(rows),
+        cohort_sic=cohort_sic,
+        cohort_sic_label=cohort_sic_label,
+        cohort_sic_level=cohort_sic_level,
+        cohort_member_count=len(rows),
         self_factors=_row_factors(self_raw),
         medians=medians,
         peers=peers,

--- a/app/services/peer_comparison.py
+++ b/app/services/peer_comparison.py
@@ -114,20 +114,25 @@ DEV_LIMITED_FACTORS: frozenset[str] = frozenset({"pe_ratio"})
 THIN_COVERAGE_RATIO: float = 0.20
 
 
-def is_factor_thin(key: str, sector_n: int, sector_member_count: int) -> bool:
+def is_factor_thin(key: str, cohort_n: int, cohort_member_count: int, *, cohort_is_fallback: bool = False) -> bool:
     """
-    True when a factor should be disclosed as thin/unreliable for a sector.
+    True when a factor should be disclosed as thin/unreliable for a cohort.
 
-    Pure policy (no I/O) — table-tested. ``sector_n`` is the count of sector
-    members with a non-null value for the factor; ``sector_member_count`` is the
-    complete-TTM sector base (the median denominator). Structurally dev-limited
+    Pure policy (no I/O) — table-tested. ``cohort_n`` is the count of cohort
+    members with a non-null value for the factor; ``cohort_member_count`` is the
+    complete-TTM cohort base (the median denominator). Structurally dev-limited
     factors are always thin; an empty base is treated as thin (no signal).
+    ``cohort_is_fallback`` (``cohort_sic_level == 0``, #2023) marks the whole
+    cohort thin: no SIC level cleared ``MIN_COHORT`` peers, so the medians rest
+    on a below-threshold ABSOLUTE base regardless of the relative coverage ratio.
     """
     if key in DEV_LIMITED_FACTORS:
         return True
-    if sector_member_count <= 0:
+    if cohort_is_fallback:
         return True
-    return sector_n / sector_member_count < THIN_COVERAGE_RATIO
+    if cohort_member_count <= 0:
+        return True
+    return cohort_n / cohort_member_count < THIN_COVERAGE_RATIO
 
 
 # Per-instrument factor CTE template, parameterised by ``%(sic_prefix)s`` with the

--- a/docs/specs/metrics/2026-07-13-2023-peer-comparison-sic-rekey.md
+++ b/docs/specs/metrics/2026-07-13-2023-peer-comparison-sic-rekey.md
@@ -1,0 +1,148 @@
+# #2023 — Re-key peer_comparison cohort: eToro-sector → SEC SIC (4→3→2 walk)
+
+Parent #2009 (fair-value band) §11.4. Sibling of #2021/#2022/#2024/#2025.
+
+## Problem
+
+Two cohort keys coexist and drift:
+- `fair_value_band.py` (#2009) keys peer cohorts on **SEC SIC**, walked SIC-4→3→2 to the first level with ≥`MIN_PEERS`.
+- `peer_comparison.py` (#1751) keys on **eToro `instruments.sector`** — 9 opaque codes `"1".."9"`, exact-match, **no walk, no min-cohort gate**.
+
+Peer grades (radar/heatmap) and band cohorts therefore disagree on which names are "peers".
+
+## Source rule
+
+Not an SEC-reg treatment decision — this is a **cohort-key choice** between two internal keys. The governing rule is our own settled invariant: **#2009 fixed SEC SIC (walked 4→3→2, MIN_PEERS=8) as the peer-cohort key** (`fair_value_band.py:604-707`, `peer_pct_for`). This ticket brings peer_comparison onto the **same SIC key + same 4→3→2 walk** — ending the eToro-vs-SIC drift. It does **not** claim value-identical cohorts: fair_value_band reads a per-multiple, freshness-filtered *materialized* member set and goes comparator-absent (`sic_level=0`) under threshold, whereas peer_comparison reads a live all-complete-TTM set and renders-thin under threshold (see Design step 2). Same key + walk philosophy, different downstream tolerance. SIC columns + indexes already exist: `instrument_sec_profile.sic` (sql/051), generated `sic3`/`sic2` (sql/221:102-107, `left(sic,3)`/`left(sic,2)` STORED + btree indexes).
+
+## Full-population verification (dev DB, complete-TTM eligible pop, N=3,927)
+
+Eligible pop = `financial_periods_ttm.is_complete_ttm = TRUE` (the population peer_comparison actually serves), **not** all 12,603 tradable (a first scan on all-tradable gave SIC 41.8% < eToro 73.6% because foreign/ETF names lack SIC and are not peer-eligible anyway — misleading).
+
+Coverage on the correct pop:
+| key | present | pct |
+|---|---|---|
+| eToro `sector` | 2,902 | 73.9% |
+| SEC `sic` | 3,867 | **98.5%** |
+
+Re-key **gains 1,012** names (null sector → SIC present; today 404) and **loses 47** (sector present → null SIC → now 404). `null_sic = 60` (1.5%) → 404, same failure mode as today's null-sector 404.
+
+Walk level distribution with `MIN_COHORT = 8`:
+| SIC level | targets | cohort n (min/avg/max) |
+|---|---|---|
+| 4 (finest) | 3,083 (79.7%) | 8 / 102 / 378 |
+| 3 | 293 (7.6%) | 8 / 30 / 231 |
+| 2 | 437 (11.3%) | 8 / 81 / 623 |
+| fallback (no level ≥8) | 54 (1.4%) | 1 / 6 / 7 |
+
+96.5% of eligible targets get a ≥8-peer cohort at some SIC level; the 1.4% tail (54 names) falls to the widest (SIC-2) cohort, `cohort_sic_level=0`, and renders **thin/greyed** (existing `is_factor_thin` disclosure path), never an error. Strictly better than eToro-sector, where 26% have no sector at all.
+
+**What the ≥8 threshold gates.** It gates the **median base** — every cohort member contributes to `percentile_cont` medians, and medians need only the factor value, **not** `total_assets`. `total_assets` coverage on complete-TTM is 99.3% (3,898/3,927), so the size-refine step (`_rank_peers`, which drops non-positive `total_assets`) removes at most a handful. The **peer SET** is separately best-effort: it may return <8 members after the `total_assets>0` filter, which is fine here — peer_comparison does not gate rendering on peer count (unlike `fair_value_band`, where <8 usable peers → no valid band number and it re-checks post-rank at `fair_value_band.py:691`). No post-rank re-walk is needed; the walk resolves the median-base granularity, the peer list is a nearest-N display.
+
+## Gating — SELF-MERGEABLE (no operator gate)
+
+- **Not scoring / not model_version.** `scoring.py` does NOT import `peer_comparison` (grep: 0 hits). Scoring's `peer_grade` comes from a separate path `instrument_analytics.compute_peer_grades` (`scoring.py:35,1805,1822`), also eToro-sector-keyed but INDEPENDENT and untouched here. Re-keying peer_comparison cannot move any score. (#1815/#1823 "walled out" confirmed.)
+- **No backfill.** peer_comparison is computed **on-demand** at `GET /{symbol}/peer-comparison` (`instruments.py:976`) — no stored table. Pure code change; dev-verify the endpoint, no DoD-8-12 backfill/rebuild.
+- **No band recompute.** fair_value_band only borrows `_rank_peers` (size-refine, pure), NOT peer_comparison's cohort key. Re-key does not perturb the 567 stored bands.
+
+## Design
+
+### Cohort resolution (new — replaces exact eToro-sector match)
+
+1. Fetch target SIC + label + the three candidate **peer** counts (self-excluded — `MIN_COHORT` means N peers, not N-1 peers + self, matching `fair_value_band._MEMBER_SQL`'s `instrument_id <> target`) in ONE query:
+   ```sql
+   WITH tgt AS (
+     SELECT sic, sic3, sic2, sic_description
+     FROM instrument_sec_profile WHERE instrument_id = %(id)s
+   )
+   SELECT t.sic, t.sic3, t.sic2, t.sic_description,
+     (SELECT count(*) FROM financial_periods_ttm f
+        JOIN instrument_sec_profile p USING (instrument_id)
+        WHERE f.is_complete_ttm AND p.sic  = t.sic  AND f.instrument_id <> %(id)s) AS n4,
+     (SELECT count(*) FROM financial_periods_ttm f
+        JOIN instrument_sec_profile p USING (instrument_id)
+        WHERE f.is_complete_ttm AND p.sic3 = t.sic3 AND f.instrument_id <> %(id)s) AS n3,
+     (SELECT count(*) FROM financial_periods_ttm f
+        JOIN instrument_sec_profile p USING (instrument_id)
+        WHERE f.is_complete_ttm AND p.sic2 = t.sic2 AND f.instrument_id <> %(id)s) AS n2
+   FROM tgt t
+   ```
+   `tgt` empty **or** `sic IS NULL` → return `None` → caller 404 (same as today's null-sector).
+2. Resolve level in Python: narrowest of `(4, 3, 2)` whose peer count ≥ `MIN_COHORT (=8)`. If none clears, **fall back to the SIC-2 prefix** (widest available cohort) and mark `cohort_sic_level = 0` — a below-threshold sentinel matching `fair_value_band.peer_pct_for`'s `sic_level=0`. The band goes comparator-absent there because it feeds a *number*; peer_comparison instead **still renders** the widened cohort (greyed via `is_factor_thin`), because it is a disclosure surface, not a scoring input — it must show *something*, flagged thin. `cohort_sic_level ∈ {4,3,2}` = cleared threshold at that granularity; `0` = widened SIC-2 fallback, thin. (Full-pop: 54 of 3,867 targets, 1.4%, land here.)
+3. `prefix = {4: sic, 3: sic3, 2: sic2}[level]`; `sic_col = {4: "sp.sic", 3: "sp.sic3", 2: "sp.sic2"}[level]` — column from a **frozen whitelist**, never interpolated from input (same injection-safe pattern as `fair_value_band._MEMBER_SQL`).
+
+### `_FACTORS_CTE` change
+
+Replace the `factors` CTE's sector filter:
+```
+-    JOIN instruments i USING (instrument_id)
+     ...
+-    WHERE t.is_complete_ttm = TRUE
+-      AND i.sector = %(sector)s
++    JOIN instruments i USING (instrument_id)
++    JOIN instrument_sec_profile sp USING (instrument_id)
+     ...
++    WHERE t.is_complete_ttm = TRUE
++      AND {sic_col} = %(sic_prefix)s
+```
+`_FACTORS_CTE` becomes a small builder `_factors_cte(level: int) -> str` (or `.format(sic_col=...)` on a template) so `sic_col` is substituted from the whitelist; the `%(sic_prefix)s` value is bound. The inner JOIN naturally drops null-SIC members from cohorts (correct — they belong to no SIC cohort). Used for both the rows SELECT and the medians SELECT with the same level/prefix.
+
+`i` join stays (still supplies `symbol`, `company_name`).
+
+### No shared-helper extraction
+
+The prefixes come directly from the target's generated `sic3`/`sic2` columns and the counts from the DB — the "walk" is Python-picking the narrowest level ≥ threshold. No `_sic_prefix` helper needed, and **no import from `fair_value_band`** (that module already imports `_rank_peers` FROM peer_comparison; a reverse import would risk a cycle). Neither extract nor duplicate — the generated columns are the single source of truth for the prefix ladder.
+
+### Contract change (`PeerComparisonResult` + `PeerComparison` model + endpoint)
+
+The `sector` value changes meaning (eToro code → SIC), so **rename** rather than leave a magic-meaning field:
+
+Both the container fields AND the per-factor median fields change meaning (eToro sector → SIC cohort), so **rename both** — a field named `sector_*` holding a SIC value is a magic-meaning trap (#1955 class):
+
+Container (`PeerComparisonResult` + `PeerComparison`):
+
+| old | new | meaning |
+|---|---|---|
+| `sector: str` | `cohort_sic: str` | the SIC prefix that defined the cohort (4/3/2 digits) |
+| — | `cohort_sic_label: str \| None` | `sic_description` of the target's full SIC (human-readable) |
+| — | `cohort_sic_level: int` | `4 \| 3 \| 2` cleared threshold at that granularity; `0` = SIC-2 fallback (thin) |
+| `sector_member_count: int` | `cohort_member_count: int` | cohort peer count (median base) |
+
+Per-factor (`PeerFactor`, `app/api/instruments.py:328`):
+
+| old | new |
+|---|---|
+| `sector_median: float \| None` | `cohort_median: float \| None` |
+| `sector_n: int` | `cohort_n: int` |
+
+`is_factor_thin(key, cohort_n, member_count)` signature unchanged (rename the passed variables only).
+
+### API (`app/api/instruments.py`)
+
+- `PeerFactor` model (:328): `sector_median`→`cohort_median`, `sector_n`→`cohort_n`.
+- `PeerComparison` model (:344): swap container fields per table above.
+- endpoint mapping (:1017): pass renamed fields through.
+- 404 detail string unchanged in spirit ("no SIC classification or no complete-TTM fundamentals").
+
+### Frontend (change-coupled FE-QA required)
+
+- `frontend/src/api/types.ts:490,492,511-512`: `sector_median`→`cohort_median`, `sector_n`→`cohort_n`; `sector`/`sector_member_count` → `cohort_sic` + `cohort_sic_label` + `cohort_sic_level` + `cohort_member_count`.
+- `frontend/src/lib/peerComparison.ts` (:78,83,86,88,132,139,270): map from the renamed `f.cohort_median`/`f.cohort_n`. Internal aliases (`sectorN`/`medianRaw`) → rename to `cohortN`/`cohortMedian` (small file, keep it honest).
+- `frontend/src/pages/PeersPage.tsx:120`: header `Sector {pc.sector} · {count} members` → `SIC {cohort_sic}{label ? ` · ${label}` : ""} · {cohort_member_count} peers` (show `SIC-{level}` or a "broad cohort" note when `cohort_sic_level===0`). UX upgrade: bare eToro `"3"` → e.g. `SIC 2834 · Pharmaceutical Preparations`.
+- `peerComparisonCharts.tsx:78,81,194`: user-facing copy "sector median" / "sector n=" → "cohort median" / "peer n=" (still a cohort median; the word "sector" now lies).
+
+## Tests
+
+- Pure-policy table test for the level-resolution function `resolve_sic_level(n4, n3, n2, min_cohort) -> (level, prefix)` (extract as a pure fn, no I/O). Cover the invariant-risk tail explicitly:
+  - `n4≥8` → `(4, sic)`; `n4<8, n3≥8` → `(3, sic3)`; `n4<8, n3<8, n2≥8` → `(2, sic2)`.
+  - **self-count boundary**: counts are peer counts (self already excluded upstream), so `n4=8` → level 4 = 8 real peers (regression guard against re-introducing self in the count).
+  - **no level ≥8 fallback**: `n4=n3=n2=3` → `(0, sic2)` sentinel (widened, thin), NOT a raise/None.
+- Keep existing `is_factor_thin` table tests (logic unchanged; arg rename only).
+- ONE DB-backed integration test (`-m db`): a known instrument resolves a non-empty cohort at the expected level, returns ≥1 peer, medians computed, `cohort_sic_level ∈ {4,3,2}`. Panel: AAPL (SIC 3571) or a pharma name for a clean SIC-4 cohort. (Peer set may be <8 after `total_assets` filtering — assert ≥1, not ≥8; peer count is best-effort, per Design.)
+
+## Dev-verify (DoD)
+
+`GET /instruments/AAPL/peer-comparison` (via vite `:5173/api/...` or `:8000/...` — note `:8000/api/...` returns empty, the `/api` prefix is vite-proxy only) → confirm `cohort_sic`, `cohort_sic_label`, `cohort_sic_level`, non-empty `peers`, medians render. Then FE-QA the Peers page header + radar for AAPL and one gained name (a null-eToro-sector instrument now resolving via SIC).
+
+## Out of scope
+
+Scoring's `compute_peer_grades` (separate eToro-sector path — its own ticket if ever re-keyed). fair_value_band (already SIC). The other #2009 v2 siblings.

--- a/docs/specs/metrics/2026-07-13-2023-peer-comparison-sic-rekey.md
+++ b/docs/specs/metrics/2026-07-13-2023-peer-comparison-sic-rekey.md
@@ -114,7 +114,7 @@ Per-factor (`PeerFactor`, `app/api/instruments.py:328`):
 | `sector_median: float \| None` | `cohort_median: float \| None` |
 | `sector_n: int` | `cohort_n: int` |
 
-`is_factor_thin(key, cohort_n, member_count)` signature unchanged (rename the passed variables only).
+`is_factor_thin` gains a keyword-only `cohort_is_fallback: bool = False` (Codex ckpt-2 P2): when `cohort_sic_level == 0`, the medians rest on a below-`MIN_COHORT` ABSOLUTE base, so **every** factor greys regardless of its relative coverage ratio (a 4-member fallback cohort with 100% coverage would otherwise read not-thin). The API passes `cohort_is_fallback=(result.cohort_sic_level == 0)`.
 
 ### API (`app/api/instruments.py`)
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -482,20 +482,20 @@ export interface InstrumentCandles {
 // /instruments/{symbol}/peer-comparison (app/api/instruments.py:277-305, #1751)
 // ---------------------------------------------------------------------------
 
-/** One radar factor: the instrument's value vs its sector median. */
+/** One radar factor: the instrument's value vs its SIC-cohort median. */
 export interface PeerFactor {
   key: string;
   label: string;
   instrument_value: number | null;
-  sector_median: number | null;
-  /** # sector members with a non-null value (low n → noisy median). */
-  sector_n: number;
-  /** True when thin (greyed + ⚠): price-gated (P/E) OR sector coverage <20% (#1836). */
+  cohort_median: number | null;
+  /** # cohort members with a non-null value (low n → noisy median). */
+  cohort_n: number;
+  /** True when thin (greyed + ⚠): price-gated (P/E) OR cohort coverage <20% (#1836). */
   dev_limited: boolean;
   better_when: "higher" | "lower";
 }
 
-/** A sector peer with its factor row (for the heatmap). */
+/** A cohort peer with its factor row (for the heatmap). */
 export interface PeerInstrument {
   instrument_id: number;
   symbol: string;
@@ -507,9 +507,14 @@ export interface PeerInstrument {
 export interface PeerComparison {
   symbol: string;
   instrument_id: number;
-  /** Raw SIC division code "1".."9" — no name lookup table. */
-  sector: string;
-  sector_member_count: number;
+  /** The instrument's own 4-digit SEC SIC (#2023). */
+  cohort_sic: string;
+  /** Human-readable sic_description of that SIC (null if unmapped). */
+  cohort_sic_label: string | null;
+  /** SIC granularity the cohort walk resolved to: 4/3/2 cleared MIN_COHORT; 0 = SIC-2 fallback (thin). */
+  cohort_sic_level: number;
+  /** Complete-TTM peers in the cohort (median base). */
+  cohort_member_count: number;
   factors: PeerFactor[];
   peers: PeerInstrument[];
 }

--- a/frontend/src/components/peers/peerComparisonCharts.test.tsx
+++ b/frontend/src/components/peers/peerComparisonCharts.test.tsx
@@ -24,11 +24,13 @@ import type { CandleBar, PeerComparison } from "@/api/types";
 const PC: PeerComparison = {
   symbol: "AAA",
   instrument_id: 1,
-  sector: "3",
-  sector_member_count: 951,
+  cohort_sic: "3571",
+  cohort_sic_label: "Electronic Computers",
+  cohort_sic_level: 4,
+  cohort_member_count: 951,
   factors: [
-    { key: "roe", label: "ROE", instrument_value: 0.9, sector_median: 0.1, sector_n: 800, dev_limited: false, better_when: "higher" },
-    { key: "pe", label: "P/E", instrument_value: 40, sector_median: 50, sector_n: 2, dev_limited: true, better_when: "lower" },
+    { key: "roe", label: "ROE", instrument_value: 0.9, cohort_median: 0.1, cohort_n: 800, dev_limited: false, better_when: "higher" },
+    { key: "pe", label: "P/E", instrument_value: 40, cohort_median: 50, cohort_n: 2, dev_limited: true, better_when: "lower" },
   ],
   peers: [{ instrument_id: 2, symbol: "BBB", company_name: "BBB Inc", size_proxy: 1e9, factors: { roe: 0.5, pe: 60 } }],
 };
@@ -36,8 +38,10 @@ const PC: PeerComparison = {
 const EMPTY_PC: PeerComparison = {
   symbol: "ZZZ",
   instrument_id: 9,
-  sector: "0",
-  sector_member_count: 0,
+  cohort_sic: "9999",
+  cohort_sic_label: null,
+  cohort_sic_level: 0,
+  cohort_member_count: 0,
   factors: [],
   peers: [],
 };

--- a/frontend/src/components/peers/peerComparisonCharts.tsx
+++ b/frontend/src/components/peers/peerComparisonCharts.tsx
@@ -75,10 +75,10 @@ function RadarTooltip({ active, payload, symbol }: RadarTooltipProps): JSX.Eleme
         {pt.devLimited ? " ⚠" : ""}
       </div>
       <div className="tabular-nums text-slate-600 dark:text-slate-300">
-        {symbol} {fmtRaw(pt.instrumentRaw)} · sector median {fmtRaw(pt.medianRaw)}
+        {symbol} {fmtRaw(pt.instrumentRaw)} · cohort median {fmtRaw(pt.medianRaw)}
       </div>
       <div className="text-slate-500 dark:text-slate-400">
-        better {pt.betterWhen} · n={pt.sectorN.toLocaleString()}
+        better {pt.betterWhen} · n={pt.cohortN.toLocaleString()}
         {pt.devLimited ? " · thin coverage" : ""}
       </div>
     </ChartTooltip>
@@ -151,8 +151,8 @@ export function PeerRadarChart({
         </RadarChart>
       </ResponsiveContainer>
       <p className="mt-1 px-2 text-[10px] text-slate-400">
-        Axes normalized per factor across the instrument + sector median + peers; outward = better
-        (orientation per factor). ⚠ = thin sector coverage (price-gated or &lt;20% of members) —
+        Axes normalized per factor across the instrument + cohort median + peers; outward = better
+        (orientation per factor). ⚠ = thin cohort coverage (price-gated or &lt;20% of members) —
         median is noisy; a missing vertex is a data gap, not worst-in-class. Hover for raw values.
       </p>
     </div>
@@ -191,7 +191,7 @@ export function SectorHeatmap({ heatmap }: { heatmap: Heatmap }): JSX.Element {
             className={`px-1 text-center leading-tight ${
               f.devLimited ? "text-slate-400" : "text-slate-600 dark:text-slate-300"
             }`}
-            title={`${f.label}${f.devLimited ? " (thin coverage)" : ""} · sector n=${f.sectorN}`}
+            title={`${f.label}${f.devLimited ? " (thin coverage)" : ""} · peer n=${f.cohortN}`}
           >
             {f.label}
             {f.devLimited ? " ⚠" : ""}

--- a/frontend/src/lib/peerComparison.test.ts
+++ b/frontend/src/lib/peerComparison.test.ts
@@ -13,8 +13,8 @@ function factor(p: Partial<PeerFactor> & { key: string; better_when: "higher" | 
     key: p.key,
     label: p.label ?? p.key,
     instrument_value: p.instrument_value ?? null,
-    sector_median: p.sector_median ?? null,
-    sector_n: p.sector_n ?? 100,
+    cohort_median: p.cohort_median ?? null,
+    cohort_n: p.cohort_n ?? 100,
     dev_limited: p.dev_limited ?? false,
     better_when: p.better_when,
   };
@@ -28,8 +28,10 @@ function pc(factors: PeerFactor[], peers: PeerInstrument[]): PeerComparison {
   return {
     symbol: "AAA",
     instrument_id: 1,
-    sector: "3",
-    sector_member_count: 951,
+    cohort_sic: "3571",
+    cohort_sic_label: "Electronic Computers",
+    cohort_sic_level: 4,
+    cohort_member_count: 951,
     factors,
     peers,
   };
@@ -43,7 +45,7 @@ describe("buildRadar", () => {
   it("normalizes outward=better for higher-is-better factors", () => {
     const r = buildRadar(
       pc(
-        [factor({ key: "roe", better_when: "higher", instrument_value: 0.9, sector_median: 0.1 })],
+        [factor({ key: "roe", better_when: "higher", instrument_value: 0.9, cohort_median: 0.1 })],
         [peer("F", { roe: 0.5 })],
       ),
     );
@@ -56,7 +58,7 @@ describe("buildRadar", () => {
   it("inverts for lower-is-better factors (low P/E scores outward)", () => {
     const r = buildRadar(
       pc(
-        [factor({ key: "pe", better_when: "lower", instrument_value: 40, sector_median: 50 })],
+        [factor({ key: "pe", better_when: "lower", instrument_value: 40, cohort_median: 50 })],
         [peer("F", { pe: 60 })],
       ),
     );
@@ -67,18 +69,18 @@ describe("buildRadar", () => {
 
   it("degenerate cohort (all equal) → 0.5 neutral", () => {
     const r = buildRadar(
-      pc([factor({ key: "x", better_when: "higher", instrument_value: 5, sector_median: 5 })], [peer("F", { x: 5 })]),
+      pc([factor({ key: "x", better_when: "higher", instrument_value: 5, cohort_median: 5 })], [peer("F", { x: 5 })]),
     );
     expect(r[0]!.instrument).toBeCloseTo(0.5, 6);
     expect(r[0]!.median).toBeCloseTo(0.5, 6);
   });
 
-  it("gaps a null instrument_value AND a null sector_median", () => {
+  it("gaps a null instrument_value AND a null cohort_median", () => {
     const r = buildRadar(
       pc(
         [
-          factor({ key: "g", better_when: "higher", instrument_value: null, sector_median: 2.6 }),
-          factor({ key: "h", better_when: "higher", instrument_value: 0.3, sector_median: null }),
+          factor({ key: "g", better_when: "higher", instrument_value: null, cohort_median: 2.6 }),
+          factor({ key: "h", better_when: "higher", instrument_value: 0.3, cohort_median: null }),
         ],
         [peer("F", { g: 0.1, h: 0.2 })],
       ),
@@ -94,7 +96,7 @@ describe("buildHeatmap", () => {
   it("pins the instrument as the first row and scores cells", () => {
     const h = buildHeatmap(
       pc(
-        [factor({ key: "roe", better_when: "higher", instrument_value: 0.9, sector_median: 0.1 })],
+        [factor({ key: "roe", better_when: "higher", instrument_value: 0.9, cohort_median: 0.1 })],
         [peer("F", { roe: 0.5 }), peer("GM", { roe: null })],
       ),
     );
@@ -152,18 +154,18 @@ describe("buildScatter", () => {
 });
 
 describe("peerCoverage", () => {
-  it("collects dev_limited keys and the min sector_n", () => {
+  it("collects dev_limited keys and the min cohort_n", () => {
     const cov = peerCoverage(
       pc(
         [
-          factor({ key: "pe", better_when: "lower", dev_limited: true, sector_n: 2 }),
-          factor({ key: "roe", better_when: "higher", sector_n: 813 }),
-          factor({ key: "rev", better_when: "higher", sector_n: 39 }),
+          factor({ key: "pe", better_when: "lower", dev_limited: true, cohort_n: 2 }),
+          factor({ key: "roe", better_when: "higher", cohort_n: 813 }),
+          factor({ key: "rev", better_when: "higher", cohort_n: 39 }),
         ],
         [],
       ),
     );
     expect(cov.devLimitedKeys).toEqual(["pe"]);
-    expect(cov.minSectorN).toBe(2);
+    expect(cov.minCohortN).toBe(2);
   });
 });

--- a/frontend/src/lib/peerComparison.ts
+++ b/frontend/src/lib/peerComparison.ts
@@ -1,6 +1,6 @@
 /**
  * Pure aggregation for the peer-comparison drill (#594). Consumes
- * `PeerComparison` (+ peer candles) and shapes the radar, sector heatmap, and
+ * `PeerComparison` (+ peer candles) and shapes the radar, cohort heatmap, and
  * return scatter. No DB, no render — table-tested in `peerComparison.test.ts`
  * (the "pure policy over real DB" prevention-log lesson).
  *
@@ -19,7 +19,7 @@ interface Cohort {
 }
 
 /**
- * Per-factor scale across the visible cohort: the instrument value, the sector
+ * Per-factor scale across the visible cohort: the instrument value, the cohort
  * median, and every peer's value (nulls excluded). Returns null when nothing is
  * available for that factor.
  */
@@ -27,11 +27,11 @@ function factorCohort(
   pc: PeerComparison,
   key: string,
   instrumentValue: number | null,
-  sectorMedian: number | null,
+  cohortMedian: number | null,
 ): Cohort | null {
   const vals: number[] = [];
   if (instrumentValue !== null) vals.push(instrumentValue);
-  if (sectorMedian !== null) vals.push(sectorMedian);
+  if (cohortMedian !== null) vals.push(cohortMedian);
   for (const p of pc.peers) {
     const v = p.factors[key];
     if (v !== null && v !== undefined) vals.push(v);
@@ -56,14 +56,14 @@ function orientedScore(
 }
 
 // ---------------------------------------------------------------------------
-// 1. Multi-factor radar — instrument vs sector median (2 overlays)
+// 1. Multi-factor radar — instrument vs cohort median (2 overlays)
 // ---------------------------------------------------------------------------
 
 export interface RadarPoint {
   readonly key: string;
   readonly label: string;
   readonly devLimited: boolean;
-  readonly sectorN: number;
+  readonly cohortN: number;
   readonly betterWhen: Orientation;
   /** Normalized scores [0,1], outward=better (recharts dataKeys). null = gap. */
   readonly instrument: number | null;
@@ -75,30 +75,30 @@ export interface RadarPoint {
 
 export function buildRadar(pc: PeerComparison): RadarPoint[] {
   return pc.factors.map((f) => {
-    const cohort = factorCohort(pc, f.key, f.instrument_value, f.sector_median);
+    const cohort = factorCohort(pc, f.key, f.instrument_value, f.cohort_median);
     return {
       key: f.key,
       label: f.label,
       devLimited: f.dev_limited,
-      sectorN: f.sector_n,
+      cohortN: f.cohort_n,
       betterWhen: f.better_when,
       instrument: orientedScore(f.instrument_value, cohort, f.better_when),
-      median: orientedScore(f.sector_median, cohort, f.better_when),
+      median: orientedScore(f.cohort_median, cohort, f.better_when),
       instrumentRaw: f.instrument_value,
-      medianRaw: f.sector_median,
+      medianRaw: f.cohort_median,
     };
   });
 }
 
 // ---------------------------------------------------------------------------
-// 2. Sector heatmap — (instrument + peers) rows × factor columns
+// 2. Cohort heatmap — (instrument + peers) rows × factor columns
 // ---------------------------------------------------------------------------
 
 export interface HeatFactor {
   readonly key: string;
   readonly label: string;
   readonly devLimited: boolean;
-  readonly sectorN: number;
+  readonly cohortN: number;
 }
 
 export interface HeatCell {
@@ -129,14 +129,14 @@ export function buildHeatmap(pc: PeerComparison): Heatmap {
     key: f.key,
     label: f.label,
     devLimited: f.dev_limited,
-    sectorN: f.sector_n,
+    cohortN: f.cohort_n,
   }));
 
   // Cohort + orientation per factor, computed once.
   const cohorts = new Map<string, { cohort: Cohort | null; betterWhen: Orientation }>();
   for (const f of pc.factors) {
     cohorts.set(f.key, {
-      cohort: factorCohort(pc, f.key, f.instrument_value, f.sector_median),
+      cohort: factorCohort(pc, f.key, f.instrument_value, f.cohort_median),
       betterWhen: f.better_when,
     });
   }
@@ -258,17 +258,17 @@ export function buildScatter(
 // ---------------------------------------------------------------------------
 
 export interface PeerCoverage {
-  /** Factors flagged thin (price-gated like P/E, or <20% sector coverage) — greyed in the UI. */
+  /** Factors flagged thin (price-gated like P/E, or <20% cohort coverage) — greyed in the UI. */
   readonly devLimitedKeys: string[];
-  /** Min sector_n across factors — low n means a noisy median. */
-  readonly minSectorN: number;
+  /** Min cohort_n across factors — low n means a noisy median. */
+  readonly minCohortN: number;
 }
 
 export function peerCoverage(pc: PeerComparison): PeerCoverage {
   const devLimitedKeys = pc.factors.filter((f) => f.dev_limited).map((f) => f.key);
-  const minSectorN = pc.factors.reduce(
-    (m, f) => Math.min(m, f.sector_n),
+  const minCohortN = pc.factors.reduce(
+    (m, f) => Math.min(m, f.cohort_n),
     pc.factors.length > 0 ? Infinity : 0,
   );
-  return { devLimitedKeys, minSectorN: Number.isFinite(minSectorN) ? minSectorN : 0 };
+  return { devLimitedKeys, minCohortN: Number.isFinite(minCohortN) ? minCohortN : 0 };
 }

--- a/frontend/src/pages/PeersPage.tsx
+++ b/frontend/src/pages/PeersPage.tsx
@@ -2,7 +2,7 @@
  * /instrument/:symbol/peers — peer-comparison drill (#594).
  *
  * Three charts over `/instruments/{symbol}/peer-comparison` (#1751) + peer
- * candles: a multi-factor radar (instrument vs sector median), a sector heatmap
+ * candles: a multi-factor radar (instrument vs cohort median), a cohort heatmap
  * (instrument + peers × factors), and a same-day peer-return scatter. Mirrors
  * the #592/#593 drill shells.
  *
@@ -77,7 +77,7 @@ export function PeersPage(): JSX.Element {
           </h1>
         </div>
         <p className="mt-1 text-xs text-slate-500">
-          How {symbol} sits against its sector peers across valuation, profitability, and leverage
+          How {symbol} sits against its SIC-cohort peers across valuation, profitability, and leverage
           factors, plus daily return co-movement. Factor axes are normalized per factor for
           comparison (display only).
         </p>
@@ -90,7 +90,7 @@ export function PeersPage(): JSX.Element {
       ) : pc === null || isEmpty ? (
         <EmptyState
           title="No peer data"
-          description="No sector peer set for this instrument — likely a non-US issuer, an instrument without a sector classification, or one lacking complete-TTM fundamentals."
+          description="No peer set for this instrument — likely a non-US issuer, an instrument without a SIC classification, or one lacking complete-TTM fundamentals."
         >
           <Link to={backHref} className="text-sm text-sky-700 hover:underline">
             ← Back to {symbol}
@@ -117,22 +117,27 @@ function PeersBody({ data }: { data: PeersData }): JSX.Element {
   return (
     <>
       <p className="text-[11px] text-slate-500 dark:text-slate-400">
-        Sector {pc.sector} · {pc.sector_member_count.toLocaleString()} members · {pc.peers.length}{" "}
-        size-matched peers.
+        SIC {pc.cohort_sic}
+        {pc.cohort_sic_label ? ` · ${pc.cohort_sic_label}` : ""} ·{" "}
+        {pc.cohort_sic_level === 0 ? "broad SIC-2 cohort" : `SIC-${pc.cohort_sic_level} cohort`} ·{" "}
+        {pc.cohort_member_count.toLocaleString()} peers · {pc.peers.length} size-matched.
+        {pc.cohort_sic_level === 0
+          ? " Cohort widened to the 2-digit SIC (few same-industry peers) — read medians as noisy."
+          : ""}
         {coverage.devLimitedKeys.length > 0
           ? ` ${coverage.devLimitedKeys.length} factor${coverage.devLimitedKeys.length === 1 ? "" : "s"} thin-coverage (greyed; median noisy).`
           : ""}
-        {coverage.minSectorN < 50
-          ? ` Some sector medians rest on as few as ${coverage.minSectorN.toLocaleString()} members — read them as noisy.`
+        {coverage.minCohortN < 50
+          ? ` Some cohort medians rest on as few as ${coverage.minCohortN.toLocaleString()} members — read them as noisy.`
           : ""}
       </p>
-      <Section title={`Multi-factor radar — ${pc.symbol} vs sector median`}>
+      <Section title={`Multi-factor radar — ${pc.symbol} vs cohort median`}>
         <PeerRadarChart radar={radar} symbol={pc.symbol} />
       </Section>
-      <Section title={`Sector heatmap — ${pc.symbol} + peers × factors`}>
+      <Section title={`Cohort heatmap — ${pc.symbol} + peers × factors`}>
         <SectorHeatmap heatmap={heatmap} />
       </Section>
-      <Section title="Peer return scatter — daily returns vs sector">
+      <Section title="Peer return scatter — daily returns vs cohort">
         <PeerReturnScatter data={scatter} />
       </Section>
     </>

--- a/tests/test_peer_comparison.py
+++ b/tests/test_peer_comparison.py
@@ -171,16 +171,17 @@ def test_compute_peer_comparison_db(ebull_test_conn: psycopg.Connection[tuple]) 
     assert result.medians["revenue_growth_yoy"].n == 1
     assert result.medians["revenue_growth_yoy"].median == pytest.approx(0.1)
 
-    # Thin-factor policy applied to the REAL result coverage (#1836): the API
-    # serializer feeds these exact fields to is_factor_thin. pe_ratio has no
-    # price on dev → n=0 → thin; revenue_growth_yoy n=1/4 (25%) clears the 20%
-    # cut in this tiny fixture → NOT thin (it is only thin on the full pop where
-    # coverage is ~4%). Guards the mapping from regressing to a static set.
+    # Thin-factor policy (#1836; #2023). Coverage branch in isolation (flag off):
+    # pe_ratio n=0 → thin; revenue_growth_yoy n=1/4 (25%) clears the 20% cut →
+    # NOT thin; roe full coverage → NOT thin. Guards the mapping from regressing.
     mc = result.cohort_member_count
     assert result.medians["pe_ratio"].n == 0
     assert is_factor_thin("pe_ratio", result.medians["pe_ratio"].n, mc) is True
     assert is_factor_thin("revenue_growth_yoy", result.medians["revenue_growth_yoy"].n, mc) is False
     assert is_factor_thin("roe", result.medians["roe"].n, mc) is False
+    # But this fixture is a below-threshold fallback cohort (level 0): the API
+    # passes cohort_is_fallback → EVERY factor greys, coverage notwithstanding.
+    assert is_factor_thin("roe", result.medians["roe"].n, mc, cohort_is_fallback=True) is True
 
 
 @pytest.mark.db

--- a/tests/test_peer_comparison.py
+++ b/tests/test_peer_comparison.py
@@ -1,6 +1,7 @@
-"""Peer-comparison data layer (#1751): DB integration — factor formulas,
-sector medians, and the YoY consecutive-year guard. Pure ranking tests live in
-test_peer_comparison_ranking.py (kept DB-free so they run in the fast tier)."""
+"""Peer-comparison data layer (#1751; SIC re-key #2023): DB integration —
+factor formulas, SIC-cohort medians, the YoY consecutive-year guard, and that
+the cohort key is SEC SIC (not eToro sector). Pure ranking + level-resolution
+tests live in test_peer_comparison_ranking.py (DB-free, fast tier)."""
 
 from __future__ import annotations
 
@@ -61,19 +62,43 @@ def _seed_quarters(
         )
 
 
+def _seed_sic(conn: psycopg.Connection[tuple], iid: int, sic: str | None, desc: str | None) -> None:
+    """One instrument_sec_profile row (sic3/sic2 are generated STORED cols)."""
+    conn.execute(
+        """
+        INSERT INTO instrument_sec_profile (instrument_id, cik, sic, sic_description)
+        VALUES (%s, %s, %s, %s)
+        """,
+        (iid, iid, sic, desc),
+    )
+
+
 def _seed(conn: psycopg.Connection[tuple]) -> None:
-    # instruments: self + 2 same-sector peers + 1 other-sector + 1 no-sector.
+    # eToro `sector` is set to DISAGREE with SIC on purpose, to prove the cohort
+    # keys off SEC SIC (#2023), not eToro sector:
+    #   9003 = same SIC, DIFFERENT eToro sector → still a peer (SIC wins).
+    #   9004 = SAME eToro sector, different SIC   → NOT a peer (SIC wins).
+    #   9006 = NULL eToro sector, same SIC        → a peer (the +1012 gain).
     conn.execute(
         """
         INSERT INTO instruments (instrument_id, symbol, company_name, sector, is_tradable)
         VALUES
           (9001, 'PCSELF', 'Self Co',   '99', TRUE),
           (9002, 'PCNEAR', 'Near Peer', '99', TRUE),
-          (9003, 'PCFAR',  'Far Peer',  '99', TRUE),
-          (9004, 'PCOTHER','Other Sec', '88', TRUE),
-          (9005, 'PCNOSEC','No Sector', NULL, TRUE)
+          (9003, 'PCFAR',  'Far Peer',  '88', TRUE),
+          (9004, 'PCOTHER','Other SIC', '99', TRUE),
+          (9005, 'PCNOSEC','No SIC',    NULL, TRUE),
+          (9006, 'PCGAIN', 'Gained',    NULL, TRUE)
         """
     )
+    # SIC profile — 9001/9002/9003/9006 share SIC 3571; 9004 is 2834 (diff sic2);
+    # 9005 has no SIC (target-None path + cohort-excluded).
+    _seed_sic(conn, 9001, "3571", "Electronic Computers")
+    _seed_sic(conn, 9002, "3571", "Electronic Computers")
+    _seed_sic(conn, 9003, "3571", "Electronic Computers")
+    _seed_sic(conn, 9004, "2834", "Pharmaceutical Preparations")
+    _seed_sic(conn, 9005, None, None)
+    _seed_sic(conn, 9006, "3571", "Electronic Computers")
     # self: ttm rev 1000, op 100, ni 80; equity 800, ta 1000, no debt.
     _seed_quarters(conn, 9001, revenue_q=250, op_income_q=25, net_income_q=20, equity=800, total_assets=1000)
     # near peer (ta 1100): ttm rev 500, op 50, ni 25; equity 250.
@@ -88,12 +113,14 @@ def _seed(conn: psycopg.Connection[tuple]) -> None:
         long_term_debt=50,
         short_term_debt=50,
     )
-    # far peer (ta 9e8): excluded from nearest only by distance, still a peer.
+    # far peer (ta 9e8): same SIC, far by size — last in peer order, still a peer.
     _seed_quarters(conn, 9003, revenue_q=100, op_income_q=5, net_income_q=2.5, equity=100, total_assets=9.0e8)
-    # other sector — must NOT appear as a peer.
+    # other SIC — same eToro sector as self, must NOT appear as a peer.
     _seed_quarters(conn, 9004, revenue_q=225, op_income_q=22.5, net_income_q=17.5, equity=700, total_assets=1050)
-    # no-sector — None path.
+    # no-SIC — target-None path; excluded from cohorts.
     _seed_quarters(conn, 9005, revenue_q=225, op_income_q=22.5, net_income_q=17.5, equity=700, total_assets=1050)
+    # gained name (ta 1050, nearest): NULL eToro sector but same SIC → a peer.
+    _seed_quarters(conn, 9006, revenue_q=225, op_income_q=22.5, net_income_q=17.5, equity=700, total_assets=1050)
     # FY revenue rows for YoY. self: consecutive (366d) → computable.
     # near peer: 5-year gap → guard rejects → None.
     conn.execute(
@@ -116,8 +143,13 @@ def test_compute_peer_comparison_db(ebull_test_conn: psycopg.Connection[tuple]) 
     _seed(ebull_test_conn)
     result = compute_peer_comparison(ebull_test_conn, instrument_id=9001)
     assert result is not None
-    assert result.sector == "99"
-    assert result.sector_member_count == 3  # 9001/9002/9003 (same sector, complete TTM)
+    assert result.cohort_sic == "3571"
+    assert result.cohort_sic_label == "Electronic Computers"
+    # 4 same-SIC members (9001/9002/9003/9006) < MIN_COHORT (8) at every level →
+    # walk widens to SIC-2, marker 0 (thin fallback). Level selection per
+    # granularity is covered exhaustively by the pure resolve_sic_level test.
+    assert result.cohort_sic_level == 0
+    assert result.cohort_member_count == 4  # 9001/9002/9003/9006; 9004 (diff SIC) + 9005 (no SIC) excluded
 
     sf = result.self_factors
     assert sf["operating_margin"] == pytest.approx(0.1)  # 100/1000
@@ -127,10 +159,13 @@ def test_compute_peer_comparison_db(ebull_test_conn: psycopg.Connection[tuple]) 
     assert sf["revenue_growth_yoy"] == pytest.approx(0.1)  # (1100-1000)/1000, consecutive FY
     assert sf["pe_ratio"] is None  # no price → instrument_valuation excludes it
 
-    # peer order: 9002 (ta 1100, near) before 9003 (ta 9e8, far); 9004/9005 excluded.
-    assert [p.instrument_id for p in result.peers] == [9002, 9003]
+    # peer order by size proximity to self (ta 1000): 9006 (1050) < 9002 (1100)
+    # < 9003 (9e8). Proves SIC drives the cohort: 9006 (null eToro sector) and
+    # 9003 (eToro sector '88') are peers; 9004 (same eToro sector '99', SIC 2834)
+    # and 9005 (no SIC) are NOT.
+    assert [p.instrument_id for p in result.peers] == [9006, 9002, 9003]
     near = result.peers[0]
-    assert near.factors["revenue_growth_yoy"] is None  # 5-year gap → guard rejects
+    assert near.factors["revenue_growth_yoy"] is None  # 9006 has no FY rows → None
 
     # median of revenue_growth_yoy: only self has a value → median 0.1, n=1.
     assert result.medians["revenue_growth_yoy"].n == 1
@@ -138,10 +173,10 @@ def test_compute_peer_comparison_db(ebull_test_conn: psycopg.Connection[tuple]) 
 
     # Thin-factor policy applied to the REAL result coverage (#1836): the API
     # serializer feeds these exact fields to is_factor_thin. pe_ratio has no
-    # price on dev → n=0 → thin; revenue_growth_yoy n=1/3 (33%) clears the 20%
+    # price on dev → n=0 → thin; revenue_growth_yoy n=1/4 (25%) clears the 20%
     # cut in this tiny fixture → NOT thin (it is only thin on the full pop where
     # coverage is ~4%). Guards the mapping from regressing to a static set.
-    mc = result.sector_member_count
+    mc = result.cohort_member_count
     assert result.medians["pe_ratio"].n == 0
     assert is_factor_thin("pe_ratio", result.medians["pe_ratio"].n, mc) is True
     assert is_factor_thin("revenue_growth_yoy", result.medians["revenue_growth_yoy"].n, mc) is False
@@ -151,7 +186,7 @@ def test_compute_peer_comparison_db(ebull_test_conn: psycopg.Connection[tuple]) 
 @pytest.mark.db
 def test_compute_peer_comparison_none_paths(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
     _seed(ebull_test_conn)
-    # No sector classification → None.
+    # No SIC classification → None.
     assert compute_peer_comparison(ebull_test_conn, instrument_id=9005) is None
     # Unknown instrument → None.
     assert compute_peer_comparison(ebull_test_conn, instrument_id=999999) is None

--- a/tests/test_peer_comparison_ranking.py
+++ b/tests/test_peer_comparison_ranking.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from app.services.peer_comparison import (
     FACTOR_KEYS,
+    MIN_COHORT,
     THIN_COVERAGE_RATIO,
     _rank_peers,
     _row_factors,
     is_factor_thin,
+    resolve_sic_level,
 )
 
 
@@ -76,3 +78,36 @@ def test_is_factor_thin_threshold_boundary() -> None:
 def test_is_factor_thin_empty_base_is_thin() -> None:
     # No complete-TTM members → no signal → thin (avoids div-by-zero).
     assert is_factor_thin("roe", sector_n=0, sector_member_count=0) is True
+
+
+# --- SIC cohort walk (#2023) — resolve_sic_level ----------------------------
+
+
+def test_resolve_sic_level_finest_wins() -> None:
+    # SIC-4 clears MIN_COHORT → level 4, marker 4 (narrowest granularity).
+    assert resolve_sic_level(n4=8, n3=50, n2=200, min_cohort=MIN_COHORT) == (4, 4)
+
+
+def test_resolve_sic_level_walks_to_sic3() -> None:
+    # SIC-4 short, SIC-3 clears → column level 3, marker 3.
+    assert resolve_sic_level(n4=7, n3=8, n2=200, min_cohort=MIN_COHORT) == (3, 3)
+
+
+def test_resolve_sic_level_walks_to_sic2() -> None:
+    # Only SIC-2 clears → column level 2, marker 2.
+    assert resolve_sic_level(n4=2, n3=5, n2=8, min_cohort=MIN_COHORT) == (2, 2)
+
+
+def test_resolve_sic_level_self_count_boundary() -> None:
+    # Counts are PEER counts (self already excluded upstream), so n4=8 = 8 real
+    # peers and clears. Regression guard against re-introducing self in the count
+    # (which would need 9 to clear). MIN_COHORT-1 does NOT clear at level 4.
+    assert resolve_sic_level(n4=MIN_COHORT, n3=0, n2=0, min_cohort=MIN_COHORT)[0] == 4
+    assert resolve_sic_level(n4=MIN_COHORT - 1, n3=MIN_COHORT - 1, n2=MIN_COHORT - 1, min_cohort=MIN_COHORT) == (2, 0)
+
+
+def test_resolve_sic_level_no_level_clears_falls_back_thin() -> None:
+    # No level reaches MIN_COHORT → widen to SIC-2 (column 2) but mark 0 (thin
+    # fallback), NOT a raise/None. peer_comparison must still render.
+    assert resolve_sic_level(n4=3, n3=3, n2=3, min_cohort=MIN_COHORT) == (2, 0)
+    assert resolve_sic_level(n4=0, n3=0, n2=0, min_cohort=MIN_COHORT) == (2, 0)

--- a/tests/test_peer_comparison_ranking.py
+++ b/tests/test_peer_comparison_ranking.py
@@ -55,29 +55,37 @@ def test_row_factors_maps_all_keys() -> None:
 
 def test_is_factor_thin_price_gated_always_thin() -> None:
     # pe_ratio is structurally dev-limited regardless of coverage.
-    assert is_factor_thin("pe_ratio", sector_n=1000, sector_member_count=1000) is True
+    assert is_factor_thin("pe_ratio", cohort_n=1000, cohort_member_count=1000) is True
 
 
 def test_is_factor_thin_low_coverage_flagged() -> None:
     # revenue_growth_yoy at ~5% coverage (dev DB: 3-12%) → thin.
-    assert is_factor_thin("revenue_growth_yoy", sector_n=40, sector_member_count=951) is True
+    assert is_factor_thin("revenue_growth_yoy", cohort_n=40, cohort_member_count=951) is True
 
 
 def test_is_factor_thin_healthy_coverage_not_flagged() -> None:
     # operating_margin floors at 24.6% on the dev DB — above the 20% cut.
-    assert is_factor_thin("operating_margin", sector_n=152, sector_member_count=617) is False
+    assert is_factor_thin("operating_margin", cohort_n=152, cohort_member_count=617) is False
 
 
 def test_is_factor_thin_threshold_boundary() -> None:
     # Exactly at the threshold is NOT thin (strict <); just below is thin.
     n = int(THIN_COVERAGE_RATIO * 100)
-    assert is_factor_thin("roe", sector_n=n, sector_member_count=100) is False
-    assert is_factor_thin("roe", sector_n=n - 1, sector_member_count=100) is True
+    assert is_factor_thin("roe", cohort_n=n, cohort_member_count=100) is False
+    assert is_factor_thin("roe", cohort_n=n - 1, cohort_member_count=100) is True
 
 
 def test_is_factor_thin_empty_base_is_thin() -> None:
     # No complete-TTM members → no signal → thin (avoids div-by-zero).
-    assert is_factor_thin("roe", sector_n=0, sector_member_count=0) is True
+    assert is_factor_thin("roe", 0, 0) is True
+
+
+def test_is_factor_thin_fallback_cohort_always_thin() -> None:
+    # cohort_sic_level==0 fallback: even a fully-covered factor is thin, because
+    # the ABSOLUTE base is below MIN_COHORT (coverage ratio would say otherwise).
+    assert is_factor_thin("roe", 100, 100, cohort_is_fallback=True) is True
+    # Non-fallback with the same full coverage is NOT thin.
+    assert is_factor_thin("roe", 100, 100, cohort_is_fallback=False) is False
 
 
 # --- SIC cohort walk (#2023) — resolve_sic_level ----------------------------


### PR DESCRIPTION
Closes #2023.

## What

Re-key `peer_comparison.py`'s peer cohort from eToro `instruments.sector` (9 opaque codes, 26% missing among flow-eligible names) to **SEC SIC walked 4→3→2** — the same cohort key + walk as `fair_value_band.peer_pct_for` (#2009). Ends the eToro-vs-SIC key drift between peer grades and band cohorts. Parent #2009 §11.4.

## Why it's safe to merge (self-mergeable, no operator gate)

- **Not scoring / not `model_version`.** `scoring.py` does **not** import `peer_comparison` (grep: 0 hits). Scoring's `peer_grade` comes from a separate, independent path `instrument_analytics.compute_peer_grades` (`scoring.py:35,1805,1822`). Re-keying peer_comparison cannot move any score. (#1815/#1823 "walled out" confirmed.)
- **No backfill.** peer_comparison is computed **on-demand** at `GET /{symbol}/peer-comparison` — no stored table. Pure code change; dev-verify the endpoint, no `sec_rebuild`.
- **No band recompute.** `fair_value_band` borrows only `_rank_peers` (pure size-refine), not peer_comparison's cohort key. The 567 stored bands are unperturbed.

## Source rule + full-population verification

**Source rule:** #2009 fixed SEC SIC (walked 4→3→2, `MIN_PEERS=8`) as the peer-cohort key (`fair_value_band.py:604-707`). This PR brings peer_comparison onto the same key. SIC columns/indexes already exist (`instrument_sec_profile.sic` + generated `sic3`/`sic2` STORED, sql/221).

**Full-pop (complete-TTM eligible, the population peer_comparison serves, N=3,927):**

| key | present | pct |
|-----|---------|-----|
| eToro `sector` | 2,902 | 73.9% |
| SEC `sic` | 3,867 | **98.5%** |

Re-key **+1,012** names (null eToro sector → SIC present; 404 today), **−47** (sector → null SIC), 60 null-SIC → 404 (same failure mode as today's null-sector).

Walk with `MIN_COHORT=8` (self-excluded peer counts):

| SIC level | targets | cohort n (min/avg/max) |
|-----------|---------|------------------------|
| 4 | 3,083 (79.7%) | 8 / 102 / 378 |
| 3 | 293 (7.6%) | 8 / 30 / 231 |
| 2 | 437 (11.3%) | 8 / 81 / 623 |
| fallback (`level=0`) | 54 (1.4%) | 1 / 6 / 7 |

96.5% get a ≥8-peer cohort; the 1.4% tail widens to SIC-2 and renders **thin** (`cohort_sic_level=0`), never absent. `total_assets` coverage on complete-TTM = 99.3%, so the ≥8 gate on the median base is not thinned by the size-refine step.

## Changes

- **service** (`app/services/peer_comparison.py`): `resolve_sic_level(n4,n3,n2,min_cohort)` pure fn returning `(column_level, disclosure_marker)`; `_factors_cte(level)` builder filling the SIC column from a frozen `_SIC_COL` whitelist (injection-safe, mirrors `fair_value_band._MEMBER_SQL`); one query computes target SIC + label + **self-excluded** peer counts at 4/3/2; result carries `cohort_sic`/`cohort_sic_label`/`cohort_sic_level`/`cohort_member_count`.
- **api** (`app/api/instruments.py`): `PeerFactor.sector_median`/`sector_n` → `cohort_median`/`cohort_n`; `PeerComparison.sector` → `cohort_sic` + `cohort_sic_label` + `cohort_sic_level` + `cohort_member_count`. `is_factor_thin` gains keyword-only `cohort_is_fallback` (Codex ckpt-2) — a `level=0` cohort greys every factor regardless of relative coverage.
- **frontend**: `types.ts`, `lib/peerComparison.ts`, `PeersPage` header (now `SIC 3571 · Electronic Computers · SIC-3 cohort · 43 peers`), chart copy ("cohort median" / "peer n=").
- **tests**: `resolve_sic_level` table test (finest / walk-to-3 / walk-to-2 / self-count boundary / fallback); fallback-greys-all pure test; DB integration reseeded to `instrument_sec_profile` SIC, proving **SIC drives the cohort over eToro sector** — a different-eToro-sector peer is included, a same-eToro-sector different-SIC name is excluded, a null-eToro-sector name is a gained peer.

## Codex

- **ckpt-1** (spec): 5 findings addressed — overstated "agree" softened to "same key+walk"; self-excluded counts; median-base-vs-peer-set reframe; factor-field rename; test tail cases.
- **ckpt-2** (branch): 1 finding [P2] — fallback cohort must grey all factors (fixed, commit `b2efb4f7`).

## Verification

- Gates: `ruff`, `ruff format --check`, `pyright` clean; `pytest -m "not db"` 5016 passed; `pytest tests/smoke` 132 passed; `pytest tests/test_peer_comparison*.py -m db` 2 passed; `pnpm --dir frontend typecheck` clean; `test:unit` 1345 passed.
- **Dev-verify (live `:8000`)**:
  - `AAPL` → `cohort_sic=3571` "Electronic Computers", `level=3` (walked from 4), 43 members, 8 peers; `pe_ratio` thin, rest healthy.
  - `JPM` → `cohort_sic=6021` "National Commercial Banks", `level=4`, 75 members, 8 peers; `operating_margin` correctly thin (n=2/75, banks don't report it).
  - `GLDM` (null eToro sector, was 404) → `cohort_sic=6221` "Commodity Contracts Brokers & Dealers", `level=4`, 28 members — the +1,012 gain is operator-visible.
- **FE-QA**: live-browser pass was **blocked** — the operator's active `chrome-devtools-mcp` session held the browser profile lock and I did not disrupt it. Verified instead via FE typecheck across all consumers + the component (`peerComparisonCharts.test.tsx`) and lib (`peerComparison.test.ts`) render tests updated to the new shape, plus the live API payload matching the TS `PeerComparison` interface exactly. The `PeersPage` header is a pure interpolation of those verified fields. Operator: a visual glance at `/instrument/AAPL/peers` recommended post-merge.

## Out of scope

Scoring's `compute_peer_grades` (separate eToro-sector path). `fair_value_band` (already SIC). Other #2009 v2 siblings (#2021/#2022/#2024/#2025).