### PR TITLE
feat(#2022): fair_value_band v2 Phase 1 — interior quantiles + envelope cap

### DIFF
--- a/.claude/skills/valuation-analyst/SKILL.md
+++ b/.claude/skills/valuation-analyst/SKILL.md
@@ -22,6 +22,18 @@ surface* consumed downstream. Owning skills: `thesis-writer` (produces),
 `app/services/valuation.py` is unrelated — it is portfolio AUM
 (`compute_portfolio_valuation`), NOT bear/base/bull.
 
+Also distinct: **`fair_value_band`** (#2009, `app/services/fair_value_band.py`)
+is a *deterministic comps evidence band* (bear/base/bull per-share from P/E,
+P/S, P/B percentiles) that feeds the thesis writer as passive evidence + a
+**base-to-base** divergence audit — NOT the thesis bear/base/bull. Synthesis
+rules: peer + own percentiles, blend base, **outer-envelope wings clamped by a
+fixed per-leg cap** (`_R_UP`/`_R_DN`, v2 #2022), own history uses **interior
+quantiles p25/p75** (not p20/p80 — a near-max of ~6 quarters is unreproducible).
+**Winsorization is refuted** as a width fix (can't move a genuine peer quartile;
+question the model, not the case); the root width cause is cohort comparability —
+P/S needs **net-margin + growth** matching (Damodaran), Phase 2 #2032. Spec:
+`docs/proposals/valuation/2026-07-13-fair-value-band-v2-robustness.md`.
+
 ## What it is
 
 **Produced by the thesis writer.** The Claude thesis prompt

--- a/app/api/fundamentals_admin.py
+++ b/app/api/fundamentals_admin.py
@@ -168,7 +168,7 @@ def fair_value_band_rollup(
     """Count ``fair_value_band_current`` rows grouped by ``reason`` then
     ``quality_status`` for the live method version.
 
-    Scoped to the current ``fvb_v1`` method version so a stale prior-version
+    Scoped to the current ``fvb_v2`` method version so a stale prior-version
     row (left behind by a ``method_version`` bump before the operator runs
     the ``fair_value_band_refresh`` recompute) never inflates the counts.
     """

--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from statistics import median
 from typing import Any, LiteralString
 
-METHOD_VERSION = "fvb_v1"
+METHOD_VERSION = "fvb_v2"
 MIN_PEERS = 8
 PEER_LIMIT = 8
 MIN_OWN_POINTS = 6
@@ -32,6 +32,16 @@ DIVERGENCE_THRESHOLD = 0.30  # consumed in PR-B (thesis divergence flag)
 _MAX_SANE_MULTIPLE = 1_000_000.0
 
 _FINANCIAL_SIC_LO, _FINANCIAL_SIC_HI = 60, 67
+
+# v2 (#2022) per-leg envelope-ratio cap — the ONLY deterministic bound on the
+# peer-only tail (names with no own-history to discipline peer.p75). Clamps
+# high_mult <= base_mult * _R_UP[m] and low_mult >= base_mult / _R_DN[m] in
+# multiple-space, before per-share conversion. base-neutral (wings only).
+# Frozen, source-ruled from the full-pop p95 of the v1 leg envelope ratio
+# (docs/proposals/valuation/2026-07-13-fair-value-band-v2-robustness.md §3/§6.2).
+# Re-validate on the fvb_v2 distribution post-backfill (DoD clause 11).
+_R_UP: dict[str, float] = {"pe": 2.6, "ps": 3.1, "pb": 4.1}
+_R_DN: dict[str, float] = {"pe": 2.7, "ps": 4.3, "pb": 2.4}
 
 
 @dataclass(frozen=True)
@@ -126,9 +136,10 @@ class PeerPct:
 
 @dataclass(frozen=True)
 class OwnPct:
-    p20: float | None
+    # v2 (#2022): INTERIOR quantiles p25/p75 (was p20/p80). See own_range.
+    p25: float | None
     p50: float | None
-    p80: float | None
+    p75: float | None
 
 
 def synth_multiple(peer: PeerPct, own: OwnPct) -> tuple[float, float, float] | None:
@@ -146,20 +157,38 @@ def synth_multiple(peer: PeerPct, own: OwnPct) -> tuple[float, float, float] | N
         else None
     )
     own_full = (
-        (own.p20, own.p50, own.p80) if own.p20 is not None and own.p50 is not None and own.p80 is not None else None
+        (own.p25, own.p50, own.p75) if own.p25 is not None and own.p50 is not None and own.p75 is not None else None
     )
     if peer_full is not None and own_full is not None:
         p25, p50, p75 = peer_full
-        o20, o50, o80 = own_full
+        o25, o50, o75 = own_full
         base = (p50 + o50) / 2
-        low = min(p25, o20)
-        high = max(p75, o80)
+        low = min(p25, o25)
+        high = max(p75, o75)
         return (low, base, high)
     if peer_full is not None:
         return peer_full
     if own_full is not None:
         return own_full
     return None
+
+
+def cap_envelope(m: str, low: float, base: float, high: float) -> tuple[float, float, bool, bool]:
+    """v2 (#2022) §6.2: clamp the wing multiples to base*_R_UP[m] / base/_R_DN[m].
+
+    Returns (low, high, capped_low, capped_high). base > 0 always (positive-denominator
+    §4.1 gate + median of positive multiples), so base*R (R>=1) straddles base and the
+    low <= base <= high invariant is preserved. Peer-only / own-only / two-sided all pass
+    through the same clamp — the peer-only tail (no own-history to discipline peer.p75) is
+    the target. base-neutral: base is not touched. Unknown multiple or non-positive base =>
+    no-op (defensive; the batch handler would otherwise statuse the row)."""
+    r_up = _R_UP.get(m)
+    r_dn = _R_DN.get(m)
+    if r_up is None or r_dn is None or base <= 0:
+        return (low, high, False, False)
+    cap_lo = base / r_dn
+    cap_hi = base * r_up
+    return (max(low, cap_lo), min(high, cap_hi), low < cap_lo, high > cap_hi)
 
 
 def to_per_share(
@@ -206,12 +235,19 @@ def combine_across(triples: list[tuple[float, float, float]]) -> tuple[float, fl
 
 
 def own_range(multiple_values: list[float]) -> OwnPct:
-    """§4.4 own trailing range. Positive values only; MIN_OWN_POINTS floor."""
+    """§4.4 own trailing range. Positive values only; MIN_OWN_POINTS floor.
+
+    v2 (#2022): INTERIOR quantiles p25/p75, not p20/p80. own.p80 over the ~6-quarter
+    floor is a near-max order statistic of a tiny sample (76% of own-legs have <=6
+    points; Hyndman & Fan 1996) — it injected small-sample noise into the outer-envelope
+    wing and was the dominant reproducibility risk. p25/p75 match the peer side and are
+    markedly stabler across recomputes. base uses p50 only, so this is base-neutral.
+    See docs/proposals/valuation/2026-07-13-fair-value-band-v2-robustness.md §6.1."""
     pos = [v for v in multiple_values if v > 0]
     if len(pos) < MIN_OWN_POINTS:
         return OwnPct(None, None, None)
-    p20, p50, p80 = percentiles(pos, (0.20, 0.50, 0.80))
-    return OwnPct(p20=p20, p50=p50, p80=p80)
+    p25, p50, p75 = percentiles(pos, (0.25, 0.50, 0.75))
+    return OwnPct(p25=p25, p50=p50, p75=p75)
 
 
 def filter_dual_class(rows: list[tuple[int, float]], dual_class_ids: set[int]) -> list[float]:
@@ -359,6 +395,8 @@ def compute_band(
         if synth is None:
             continue
         low_mult, base_mult, high_mult = synth
+        precap_low, precap_high = low_mult, high_mult
+        low_mult, high_mult, capped_low, capped_high = cap_envelope(m, low_mult, base_mult, high_mult)
         triple = to_per_share(
             m,
             low_mult,
@@ -380,11 +418,17 @@ def compute_band(
             contributing_own_points = max(contributing_own_points, own_points_by_multiple.get(m, 0))
         basis["multiples"][m] = {
             "peer": {"p25": peer.p25, "p50": peer.p50, "p75": peer.p75},
-            "own": {"p20": own.p20, "p50": own.p50, "p80": own.p80},
+            "own": {"p25": own.p25, "p50": own.p50, "p75": own.p75},
             "base_value": triple[1],
             "cohort_n": cn,
             "excluded_stale_n": esn,
             "own_points": own_points_by_multiple.get(m, 0),
+            # v2 (#2022) cap audit: the pre-cap wing multiples + whether each was
+            # clamped, so the base*_R_UP/_R_DN clamp is reconstructable from the row.
+            "capped_low": capped_low,
+            "capped_high": capped_high,
+            "precap_low_mult": precap_low,
+            "precap_high_mult": precap_high,
         }
 
     if not per_share_triples:

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -21,7 +21,7 @@ Context caps (v2 — settled-decisions "Thesis prompt budget", amended #1987):
   - risk metrics (#1632): instrument_risk_metrics_current scalars, statused
   - price anchor (#1987): latest price_daily close (native ccy) + 52w range + returns
   - valuation (#1987):    instrument_valuation row when present; statused absence
-  - fair_value_band (#2009): fair_value_band_current row (fvb_v1) when present;
+  - fair_value_band (#2009): fair_value_band_current row (fvb_v2) when present;
                           statused absence (passive evidence, not gating)
   - analytics (#1987):    latest scores.analytics_json, shaped compact, scored_at-stamped
   - ta_state (#1987):     latest price_daily indicators + derived regime signals
@@ -866,7 +866,7 @@ def _assemble_context(
     ).fetchone()
     valuation = _shape_valuation(val_row)
 
-    # #2009 PR-B: passive fair-value-band evidence (fvb_v1). PR-A write-through
+    # #2009 PR-B: passive fair-value-band evidence (fvb_v2). PR-A write-through
     # only; this block is READ-ONLY here — no scoring/gating touch. Absence is
     # structural for most of the universe (thin cohort, no fundamentals, stale
     # price) and is statused, not errored — same discipline as `valuation`.

--- a/docs/proposals/valuation/2026-07-13-fair-value-band-v2-robustness.md
+++ b/docs/proposals/valuation/2026-07-13-fair-value-band-v2-robustness.md
@@ -1,0 +1,108 @@
+# Fair-value band v2 — reproducibility + tail-robustness
+
+**Status:** proposal, 2026-07-13.
+**Extends (does not replace):** [`2026-07-12-deterministic-fair-value-band.md`](./2026-07-12-deterministic-fair-value-band.md) §4.5 synthesis (the "blend + outer envelope" operator decision, 2026-07-12).
+**Supersedes:** #2022 ("P/S band-envelope winsorization"). Winsorization is **empirically refuted** as the fix — see §2. #2022 to be re-scoped/closed.
+**Method version:** `fvb_v1` → **`fvb_v2`** (wing outputs change; base unchanged — see §5).
+
+---
+
+## 1. Problem
+
+Two coupled requirements on the deterministic comps band (`app/services/fair_value_band.py`):
+
+1. **The P/S bull is too wide for a minority** (AAPL bull ≈ 752 vs base ≈ 310; universe bull/base median ≈ 1.6). #2022 proposed cohort-level P/S winsorization.
+2. **The band must be reproducible** — "results we can trust time and time again" across nightly recomputes as prices/peers drift (operator requirement, 2026-07-13). The band feeds the LLM thesis writer as evidence + a **base-to-base** divergence audit (`compute_divergence` compares `band_base`, never `bull`).
+
+## 2. Research + source rule (why #2022 winsorization is the wrong fix)
+
+Four independent reviews (Codex methodology; a cited literature sweep; an unbiased cold-start methodologist; an adversarial red-team) + three empirical tests on the dev full population. Convergent findings:
+
+- **Member-winsorization cannot move `peer.p75`** — *proven on AAPL's real cohort*. Fresh SIC-357 P/S members: `0.8, 1.0, 3.6, 4.6, 7.6, 7.9, 16.3, 24.3, 25.1, 25.1`. The high values are a **genuine cluster of 4 peers, not outliers**. Every principled clip (95th, 90th, Tukey `p75+1.5·IQR`=50, `p50+1.5·IQR`=35) leaves p75 unmoved. The one true outlier (731×) is already stale-excluded. Order-statistic arithmetic: clipping above p75 cannot change p75 (Hyndman & Fan 1996, sample-quantile definitions).
+- **A 50/50 mean-blend of the wings is worse, not better.** `own.p80` is a near-max order statistic of ~6 quarters (dev full-pop: 76% of own-legs have ≤6 points, median depth = 6). Under the current `max()`, `own.p80` binds only ~24% of two-sided P/S legs (defers to the stable large-sample `peer.p75` otherwise); a 50/50 blend gives it permanent half-weight → **less** reproducible. Inverse-variance weighting (Gauss–Markov) says the noisier small-sample statistic should be weighted *down*, not equally. Baker & Ruback (1999): arithmetic averaging of multiples is upward-biased (harmonic mean is minimum-variance).
+- **`max()`/`min()` outer envelope is not the defect.** The base is a *location* estimator; the wings are a *dispersion/support* estimator — using different operators is correct, not "inconsistent" (adversarial red-team; resolves the Codex "regime-selector" objection). Judge an uncertainty band by **calibration, not width** (Mauboussin) — narrowing 45% of bands with zero calibration evidence manufactures false precision.
+- **The root cause is peer comparability.** P/S is a function of **net margin *and growth*** (Damodaran: `P/S = margin · payout · (1+g)/(r−g)`); a SIC+size cohort is neither margin- nor growth-matched. *Proven partial-fix limit:* margin-matching AAPL (27.2% net margin) still retains ANET (38.3%, P/S 24×) and FTNT (27.5%, P/S 16×) — margin-matched but **high-growth**; AAPL is mature, so its own P/S is ~9×. Matching margin **and** growth would starve the cohort below `MIN_PEERS`. **AAPL's wide bull is a genuine comps-comparability limit for a unique mega-cap — not cleanly removable by any single synthesis change** without distorting the majority or starving the cohort. The band already labels this via `quality_status`.
+
+**Sources:** Damodaran — P/S↔margin ([ps.pdf](https://pages.stern.nyu.edu/~adamodar/pdfiles/eqnotes/ps.pdf)), relative-valuation skew→median ([relval](https://pages.stern.nyu.edu/~adamodar/pdfiles/country/relval.pdf)); Baker & Ruback 1999 *Estimating Industry Multiples* (harmonic mean min-variance); Hyndman & Fan 1996 *Sample Quantiles in Statistical Packages*; McKinsey/Koller *The right role for multiples* (match peers on ROIC & growth); Mauboussin (calibration over width); inverse-variance weighting (Gauss–Markov).
+
+## 3. Full-population verification (dev, 567 `ok` bands, 2026-07-13)
+
+- Per-leg envelope ratio (`high_mult/base_mult`): **P/S** (n=291) median 1.63, p90 2.79, p95 **3.08**, max 7.18; **P/E** (n=498) median 1.39, p95 2.62; **P/B** (n=119) median 1.33, p95 **4.08**, max 7.44.
+- **Widest names are peer-only** (no own-history): `mean`/`cap`/`winsor` against own-history cannot touch them; only a peer-relative fixed cap bounds them.
+- P/S coverage: 153/291 two-sided, 64 peer-only, 74 own-only. Own-binds-under-max: 37/153 (24%).
+- Down-side ratio (`base_mult/low_mult`) p95: P/S 4.29, P/E 2.70, P/B 2.41.
+
+## 4. Design — v2 (four parts)
+
+Keep the level/dispersion split and the `min/max` outer-envelope operator (§2). Fix the **inputs and guards**, not the operator.
+
+| # | Change | Fixes | Base-neutral? |
+|---|--------|-------|:-:|
+| **1** | **Interior quantiles**: own history uses **p25/p75**, never p20/p80 (matches the peer side, which already uses p25/p50/p75) | small-sample wing noise → reproducibility | ✅ base uses p50 only |
+| **2** | **Fixed per-leg cap**: `high_mult ≤ base_mult · R_up[m]`, `low_mult ≥ base_mult / R_dn[m]`; `R` frozen, calibrated from full-pop | the **peer-only tail** (max 7×) nothing else bounds | ✅ affects wings only |
+| **3** | **Cohort membership hysteresis**: don't re-pick the size-refined 8-nearest each night unless membership changes materially | residual base jitter across recomputes | ⚠ can nudge base |
+| **4** | **Companion-variable peer screen**: P/S→net-margin **+ growth** band, P/B→ROE, P/E→growth; widen monotonically only to hold `MIN_PEERS` | the **root cause** of AAPL-class width | ⚠ changes base |
+
+**Parts 1+2 are base-neutral** (they change only bull/bear, never the audited `base_value`), so the base-to-base divergence audit is undisturbed. Parts 3+4 touch the base and are heavier.
+
+## 5. Phasing + gating
+
+- **Phase 1 (this spec's implementation): parts 1 + 2.** Base-neutral wing hardening — interior quantiles + fixed cap + a deterministic-interpolation regression test. `fvb_v1→v2` (wing outputs change; observations audit integrity). Full recompute is orchestrator-driven (`freshness.py` detects "no rows for current method_version" → reschedules the 24 h `fair_value_band_refresh`); operator can force via the recompute trigger. **Not a scoring `model_version`** — the band is not a scoring input.
+- **Phase 1b (follow-up ticket): part 3** — cohort hysteresis. Deferred from Phase 1 because it is stateful (needs stored prior membership) and its marginal reproducibility value is lower than parts 1+2 (the audited base already uses medians, robust to 1–2 member swaps). Sequenced by risk/complexity, **not dropped**.
+- **Phase 2 (follow-up ticket): part 4** — companion-variable peer screen. The root-cause fix; heaviest, data-gated (needs per-peer margin/growth). Partial for AAPL (growth mismatch persists at `MIN_PEERS`).
+
+## 6. Phase 1 — detailed spec
+
+### 6.1 Interior quantiles (part 1)
+
+`own_range` (`fair_value_band.py:208`) computes `percentiles(pos, (0.20, 0.50, 0.80))` → `OwnPct(p20, p50, p80)`. Change to `(0.25, 0.50, 0.75)`, rename the `OwnPct` fields to `p25/p50/p75`, and update `synth_multiple` to read `own.p25`/`own.p75`. **Base unchanged** (`base_mult = mean(peer.p50, own.p50)`). Only `low_mult = min(peer.p25, own.p25)` and `high_mult = max(peer.p75, own.p75)` shift (own side slightly inward).
+
+### 6.2 Fixed per-leg cap (part 2)
+
+After `synth_multiple` yields `(low_mult, base_mult, high_mult)` for multiple `m`, clamp **in multiple-space, before per-share conversion**:
+
+```text
+high_mult = min(high_mult, base_mult * R_UP[m])
+low_mult  = max(low_mult,  base_mult / R_DN[m])
+```
+
+Preserves `low ≤ base ≤ high` (base·R with R≥1 straddles base). Applies identically to peer-only, own-only, and two-sided names — the **peer-only** tail is the primary target, but **own-only** legs are intentionally bounded too (an undisciplined own-history p75 is no more trustworthy than an undisciplined peer p75). Record `capped_high`/`capped_low` booleans **and the pre-cap wing multiples** (`precap_low_mult`/`precap_high_mult`) into `basis["multiples"][m]` so the clamp is fully reconstructable from the stored row.
+
+**Guards (Codex ckpt-1):** `base_mult ≤ 0` ⇒ no-op (impossible under the §4.1 positive-denominator gate + median-of-positives, but defended so a degenerate row falls through rather than dividing by zero); an unknown multiple (e.g. a future `ev_ebitda`) ⇒ no-op. Inputs are finite by construction (the `_MAX_SANE_MULTIPLE` pass-1 gate + positive-only percentiles bound every multiple), so no `nan/inf` reaches the clamp; `combine_across`'s fail-closed order check is the final backstop regardless.
+
+**Constants — `R_UP` / `R_DN`, frozen, source-ruled from §3 full-pop p95** (the "healthy" upper bound; clips only the top ~5% pathological/peerless tail, leaves the two-sided majority — median ≈1.6 — untouched). Provisional (v1-calibrated; **re-validate on the fvb_v2 distribution post-backfill**, per DoD clause 11):
+
+```text
+R_UP = {"pe": 2.6, "ps": 3.1, "pb": 4.1}   # ≈ full-pop p95 of high/base
+R_DN = {"pe": 2.7, "ps": 4.3, "pb": 2.4}   # ≈ full-pop p95 of base/low
+```
+
+**Honesty note (vs §2):** this cap is a percentile-derived clamp on the envelope *ratio* — the mechanism Codex/the literature warned against *as a standalone AAPL fix*. Its role here is narrow and legitimate: the **only deterministic bound for peer-only names** (which have no own-history to discipline them). It is calibrated to **not** distort the two-sided majority and it does **not** claim to fix AAPL (AAPL p84, ratio 2.35 < R_UP[ps] → uncapped; AAPL is Phase 2). Stated explicitly so the guard is not mistaken for the root fix.
+
+### 6.3 Deterministic interpolation (part of reproducibility core)
+
+`percentiles()` (`fair_value_band.py:92`) is already pure-Python continuous interpolation matching Postgres `percentile_cont` (deterministic, no RNG, stable tie-break by sort). **No change** — add a regression test asserting fixed inputs → fixed outputs (locks the interpolation convention against future drift; Hyndman & Fan document 9 divergent definitions).
+
+### 6.4 Tests (pure tier — `tests/test_fair_value_band_policy.py`)
+
+- `own_range` returns p25/p50/p75 (boundary: n=6 floor; interior quantiles).
+- Cap clamps `high_mult` to `base_mult·R_UP[m]` when it exceeds; no-op when within; symmetric low.
+- Cap preserves `low ≤ base ≤ high`.
+- Peer-only leg (own absent) is cap-bounded (the tail case).
+- `capped_high`/`capped_low` audit flags set correctly.
+- `percentiles()` fixed-input regression (interpolation lock).
+
+### 6.5 Method version + backfill
+
+- Bump `METHOD_VERSION = "fvb_v2"`. Consumers import the constant (`thesis.py`, `freshness.py`, `fundamentals_admin.py`) → transparent.
+- **Operator backfill after merge:** restart the VS Code jobs task, then force the full-universe recompute (`fair_value_band_recompute` trigger) — do not wait for the 24 h cron. Verify per DoD 8–12: AAPL/GME/MSFT/JPM/HD render; cross-check one figure; confirm `/instruments/{symbol}` band.
+- **Cap re-validation — explicit acceptance gate (Codex ckpt-1 #4).** The v1-calibrated `R` constants are *provisional*: p25/p75 narrow own-driven ratios, so the v1 caps are likely *looser* post-change — "clips the top ~5%" is **not** guaranteed. Re-run the per-leg envelope-ratio scan on the post-backfill fvb_v2 population and ACCEPT only if, per multiple `m`:
+  1. **Tail bounded:** `max(high_mult/base_mult) ≤ R_UP[m] + ε` — the cap actually binds the peer-only tail.
+  2. **Majority untouched:** the median envelope ratio shifts `< 2%` vs the v1 distribution — the cap does not distort the bulk.
+  3. **Cap-hit rate sane:** the `capped_high` fraction, reviewed per multiple **and** per comparator-side (peer-only vs two-sided), sits in the expected ~2–8% band; a spike flags a mis-calibrated `R_UP[m]`.
+  If any leg fails, retune `R_UP[m]`/`R_DN[m]` to the fvb_v2 p95 and re-backfill before declaring done.
+
+## 7. Limitations
+
+- **AAPL is only partially addressable** (Phase 2, and even then bounded by `MIN_PEERS` growth-matching). Phase 1 does **not** narrow AAPL's bull — by design; the cap targets the peerless tail, not p84 names.
+- Cap constants are v1-calibrated; must be re-validated on the fvb_v2 distribution (interior quantiles narrow ratios slightly → cap bites marginally less).

--- a/tests/test_fair_value_band_policy.py
+++ b/tests/test_fair_value_band_policy.py
@@ -284,6 +284,21 @@ def test_compute_band_cap_two_legs_base_unchanged_when_nonbase_leg_capped():
     assert res.basis["multiples"]["pe"]["capped_high"] is False
 
 
+def test_cap_constants_cover_all_multiples_and_are_valid():
+    # PR #2033 review NITPICK: lock the cap constants against a silent bad edit /
+    # doc drift. Guards the cap invariant — every synthesizable multiple {pe,ps,pb}
+    # has an R_UP AND R_DN, and each R >= 1 (R < 1 makes cap_hi < base / cap_lo > base,
+    # inverting low <= base <= high and tripping combine_across's fail-closed order
+    # check). A new multiple added without a cap entry (e.g. Phase-2 ev_ebitda) fails
+    # here, forcing a conscious calibration + spec §6.2 update.
+    from app.services.fair_value_band import _R_DN, _R_UP
+
+    multiples = {"pe", "ps", "pb"}
+    assert set(_R_UP) == multiples and set(_R_DN) == multiples
+    assert all(v >= 1.0 for v in _R_UP.values()), _R_UP
+    assert all(v >= 1.0 for v in _R_DN.values()), _R_DN
+
+
 def test_percentiles_deterministic_regression():
     # Interpolation-convention lock (Hyndman & Fan 1996: 9 divergent definitions).
     # Fixed input -> fixed output; guards the wing/own-history stability contract.

--- a/tests/test_fair_value_band_policy.py
+++ b/tests/test_fair_value_band_policy.py
@@ -11,6 +11,7 @@ from app.services.fair_value_band import (
     TargetInputs,
     _shape_fair_value_band,
     band_quality_status,
+    cap_envelope,
     combine_across,
     compute_band,
     compute_divergence,
@@ -99,24 +100,24 @@ def test_currency_coherent():
 
 def test_synth_blend_and_envelope_both_present():
     peer = PeerPct(p25=10.0, p50=20.0, p75=30.0)
-    own = OwnPct(p20=12.0, p50=24.0, p80=28.0)
+    own = OwnPct(p25=12.0, p50=24.0, p75=28.0)
     result = synth_multiple(peer, own)
     assert result is not None
     low, base, high = result
     assert base == 22.0  # mean(20, 24)
-    assert low == 10.0  # min(peer_p25=10, own_p20=12)
-    assert high == 30.0  # max(peer_p75=30, own_p80=28)
+    assert low == 10.0  # min(peer_p25=10, own_p25=12)
+    assert high == 30.0  # max(peer_p75=30, own_p75=28)
 
 
 def test_synth_degrades_to_peer_only():
     peer = PeerPct(p25=10.0, p50=20.0, p75=30.0)
-    own = OwnPct(p20=None, p50=None, p80=None)
+    own = OwnPct(p25=None, p50=None, p75=None)
     assert synth_multiple(peer, own) == (10.0, 20.0, 30.0)
 
 
 def test_synth_degrades_to_own_only():
     peer = PeerPct(p25=None, p50=None, p75=None)
-    own = OwnPct(p20=12.0, p50=24.0, p80=28.0)
+    own = OwnPct(p25=12.0, p50=24.0, p75=28.0)
     assert synth_multiple(peer, own) == (12.0, 24.0, 28.0)
 
 
@@ -170,6 +171,126 @@ def test_own_range_drops_nonpositive():
     assert r.p50 == 35.0
 
 
+def test_own_range_interior_quantiles_v2():
+    # v2 (#2022): own_range emits p25/p50/p75 (interior), not p20/p80.
+    r = own_range([10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0])
+    assert r.p25 == 27.5  # continuous p25 of 8 points
+    assert r.p50 == 45.0
+    assert r.p75 == 62.5
+
+
+# --- v2 (#2022) envelope-ratio cap (cap_envelope) ---
+
+
+def test_cap_envelope_clamps_high():
+    # ps R_UP=3.1: high 40 > base 10 * 3.1 = 31 -> clamped; low 5 within -> untouched.
+    low, high, capped_low, capped_high = cap_envelope("ps", 5.0, 10.0, 40.0)
+    assert (low, high) == (5.0, 31.0)
+    assert capped_high is True and capped_low is False
+
+
+def test_cap_envelope_clamps_low():
+    # ps R_DN=4.3: low 1 < base 10 / 4.3 = 2.326 -> clamped; high 15 within -> untouched.
+    low, high, capped_low, capped_high = cap_envelope("ps", 1.0, 10.0, 15.0)
+    assert round(low, 3) == 2.326 and high == 15.0
+    assert capped_low is True and capped_high is False
+
+
+def test_cap_envelope_noop_within_bounds():
+    # pe R_UP=2.6 / R_DN=2.7: 8 and 20 both inside [10/2.7, 10*2.6] -> no-op, flags false.
+    assert cap_envelope("pe", 8.0, 10.0, 20.0) == (8.0, 20.0, False, False)
+
+
+def test_cap_envelope_preserves_order():
+    # Extreme peer-only wings still yield low <= base <= high after the clamp.
+    low, high, _, _ = cap_envelope("ps", 0.1, 10.0, 1000.0)
+    assert low <= 10.0 <= high
+
+
+def test_cap_envelope_unknown_multiple_is_noop():
+    # A multiple not in the cap table (e.g. future ev_ebitda) passes through unclamped.
+    assert cap_envelope("ev_ebitda", 1.0, 10.0, 1000.0) == (1.0, 1000.0, False, False)
+
+
+def test_cap_envelope_nonpositive_base_is_noop():
+    assert cap_envelope("ps", 1.0, 0.0, 100.0) == (1.0, 100.0, False, False)
+
+
+def test_compute_band_cap_bounds_peer_only_tail_base_neutral():
+    # Peer-only P/S leg with a fat peer.p75 (the widest-tail case). The cap bounds the
+    # BULL to base*_R_UP["ps"] while leaving the audited BASE untouched (base-neutral).
+    res = compute_band(
+        TargetInputs(
+            eps_diluted_ttm=None,
+            revenue_ttm=1000.0,
+            shareholders_equity=None,
+            net_income_ttm=None,
+            shares_outstanding=100.0,
+            sic="3571",
+            reported_currency="USD",
+            instrument_currency="USD",
+            target_basis="not_multiclass",
+        ),
+        peer_by_multiple={"ps": PeerPct(p25=5.0, p50=10.0, p75=100.0)},
+        own_by_multiple={"ps": OwnPct(None, None, None)},
+        own_points_by_multiple={"ps": 0},
+        cohort_meta={"ps": {"cohort_n": 40, "excluded_stale_n": 0}},
+        sic_level=3,
+    )
+    assert res.reason == "ok"
+    per_share = 1000.0 / 100.0  # revenue / shares
+    assert res.base == 10.0 * per_share  # 100.0 — UNCHANGED by the cap
+    assert res.bull is not None and round(res.bull, 6) == 310.0  # high 100 clamped to base*3.1=31
+    assert res.bear == 5.0 * per_share  # 50.0 — within bounds, uncapped
+    assert res.basis["multiples"]["ps"]["capped_high"] is True
+    assert res.basis["multiples"]["ps"]["capped_low"] is False
+    assert res.basis["multiples"]["ps"]["precap_high_mult"] == 100.0  # pre-cap audit
+
+
+def test_compute_band_cap_two_legs_base_unchanged_when_nonbase_leg_capped():
+    # Codex ckpt-1 #3: two selected legs (pe + ps); the ps leg's HIGH is capped, pe
+    # is not. The cross-multiple base = median([pe_base, ps_base]) must be UNCHANGED
+    # by the cap — the challenged non-base-determining-leg case.
+    res = compute_band(
+        TargetInputs(
+            eps_diluted_ttm=10.0,
+            revenue_ttm=1000.0,
+            shareholders_equity=None,
+            net_income_ttm=500.0,
+            shares_outstanding=100.0,
+            sic="3571",
+            reported_currency="USD",
+            instrument_currency="USD",
+            target_basis="not_multiclass",
+        ),
+        peer_by_multiple={
+            "pe": PeerPct(p25=6.0, p50=8.0, p75=12.0),  # base_mult 8 -> base 80, ratio 1.5 uncapped
+            "ps": PeerPct(p25=5.0, p50=10.0, p75=100.0),  # base_mult 10 -> base 100, high 100 capped to 31
+        },
+        own_by_multiple={"pe": OwnPct(None, None, None), "ps": OwnPct(None, None, None)},
+        own_points_by_multiple={"pe": 0, "ps": 0},
+        cohort_meta={
+            "pe": {"cohort_n": 40, "excluded_stale_n": 0},
+            "ps": {"cohort_n": 40, "excluded_stale_n": 0},
+        },
+        sic_level=3,
+    )
+    assert res.reason == "ok"
+    # pe per_share=eps=10 -> base 80; ps per_share=rev/shares=10 -> base 100.
+    assert res.base == 90.0  # median([80, 100]) — UNCHANGED though ps.high was capped
+    assert res.bull is not None and round(res.bull, 6) == 310.0  # ps 100 -> 31 -> 310
+    assert res.bear == 50.0  # min(pe low 60, ps low 50)
+    assert res.basis["multiples"]["ps"]["capped_high"] is True
+    assert res.basis["multiples"]["pe"]["capped_high"] is False
+
+
+def test_percentiles_deterministic_regression():
+    # Interpolation-convention lock (Hyndman & Fan 1996: 9 divergent definitions).
+    # Fixed input -> fixed output; guards the wing/own-history stability contract.
+    assert percentiles([1.0, 2.0, 3.0, 4.0, 5.0], (0.25, 0.5, 0.75)) == [2.0, 3.0, 4.0]
+    assert percentiles([10.0, 20.0, 30.0, 40.0], (0.25, 0.5, 0.75)) == [17.5, 25.0, 32.5]
+
+
 def test_filter_dual_class_anti_join():
     rows = [(1, 10.0), (2, 20.0), (3, 30.0)]
     assert filter_dual_class(rows, {2}) == [10.0, 30.0]
@@ -220,12 +341,13 @@ def _aapl() -> TargetInputs:
 
 
 def test_golden_aapl_pe_band():
-    # §3 worked fixture: own trailing P/E p20/p50/p80 = 31.2/34.5/36.9, peer absent.
-    # Band = 31.2*8.26 / 34.5*8.26 / 36.9*8.26 ~= 257.7 / 285.0 / 304.8.
+    # §3 worked fixture: own trailing P/E p25/p50/p75 = 31.2/34.5/36.9, peer absent.
+    # Band = 31.2*8.26 / 34.5*8.26 / 36.9*8.26 ~= 257.7 / 285.0 / 304.8
+    # (cap no-op: high 36.9 < base 34.5 * _R_UP["pe"] 2.6 = 89.7).
     res = compute_band(
         _aapl(),
         peer_by_multiple={"pe": PeerPct(None, None, None)},
-        own_by_multiple={"pe": OwnPct(p20=31.2, p50=34.5, p80=36.9)},
+        own_by_multiple={"pe": OwnPct(p25=31.2, p50=34.5, p75=36.9)},
         own_points_by_multiple={"pe": 7},
         cohort_meta={"pe": {"cohort_n": 0, "excluded_stale_n": 0}},
         sic_level=4,


### PR DESCRIPTION
## What & why

#2022 asked for P/S winsorization. A full research pass (Codex methodology + a cited literature sweep + an unbiased cold-start methodologist + an adversarial red-team + 3 full-population empirical tests on dev) proved winsorization is the **wrong fix**: on AAPL's real SIC-357 cohort the high P/S (`peer.p75 ≈ 24×`) is a *genuine cluster of 4 peers, not outliers* — no principled clip (95th, 90th, Tukey `p75+1.5·IQR`, `p50+1.5·IQR`) moves p75; AAPL is p84 of the envelope-ratio distribution, not a tail. The real defects are the synthesis **inputs and guards**, not the `max()`/`min()` aggregation. Re-scoped to a `fair_value_band` v2 robustness pass — spec: `docs/proposals/valuation/2026-07-13-fair-value-band-v2-robustness.md`.

### Phase 1 (this PR) — base-neutral wing hardening

1. **Interior quantiles** — own history now uses **p25/p75**, not p20/p80. `own.p80` over the 6-quarter floor is a near-max order statistic of a tiny sample (76% of own-legs have ≤6 points; Hyndman & Fan 1996) — the dominant reproducibility risk. Base uses p50 only ⇒ **unchanged**.
2. **Fixed per-leg envelope cap** — `high_mult ≤ base_mult·R_UP[m]`, `low_mult ≥ base_mult/R_DN[m]`; frozen constants source-ruled from the full-pop p95 of the v1 leg ratio. The **only deterministic bound on the peer-only tail** (max envelope ratio 7×, which no own-history or blend can touch).

**Base-neutral:** cap + interior quantiles change only bear/bull (wings); `base_value` is byte-identical ⇒ the base-to-base LLM divergence audit is undisturbed. **Not a scoring input** ⇒ no scoring `model_version` change. `METHOD_VERSION` → `fvb_v2` (observation-audit integrity for the wing change; consumers import the constant, so transparent).

### Does NOT fix AAPL — by design

AAPL (p84, ratio 2.35 < `R_UP["ps"]`) is uncapped. Its wide bull is a genuine comps-comparability limit (P/S needs margin **and** growth matching; margin-matching alone keeps high-growth peers) — Phase 2 (#2032), carried by `quality_status` meanwhile.

### Follow-ups

- Phase 1b cohort hysteresis #2031
- Phase 2 margin+growth-matched peer screen (root fix) #2032

## Review

- **Codex ckpt-1 (spec):** folded 3 findings — pre-cap wing multiples (`precap_low_mult`/`precap_high_mult`) into the basis audit; a 2-leg test proving the base is unchanged when the non-base-determining leg is capped; an explicit post-backfill acceptance gate (spec §6.5).
- **Codex ckpt-2 (pre-push):** "No real issues found" — independently ran the pure tests (pass) and verified the cap math/guards/order-preservation, base-path untouched, quantile rename fully propagated, and no executable `fvb_v1` literals.

## Verification

- **Pure-tier** `tests/test_fair_value_band_policy.py` (48 pass): cap clamp/no-op/order-preservation/peer-only-tail/2-leg-base-neutral/interior-quantiles/interpolation-lock. Golden-AAPL band unchanged (cap no-op on that fixture). ruff + `ruff format --check` + pyright clean; fast tier (`-m "not db"`) + `tests/smoke` green.
- **Operator backfill (post-merge, per spec §6.5 + runbook):** restart the VS Code jobs task → `fair_value_band_recompute` full-universe → re-validate the cap **acceptance gate** (tail bounded `≤ R_UP[m]`, median envelope ratio shift `< 2%`, `capped_high` rate 2–8% per multiple/comparator-side) on the fvb_v2 population; smoke `/instruments/{AAPL,GME,MSFT,JPM,HD}` band render. Dev market-data is unreachable in the loop env (bands status `stale_price`), so this step runs operator-side — not claimed done here.

Closes #2022
