### PR TITLE
feat(#2024): bootstrap-stage fair_value_band first-load (S28)

### DIFF
--- a/app/api/bootstrap.py
+++ b/app/api/bootstrap.py
@@ -83,6 +83,9 @@ LaneApi = Literal[
     # Mirrored from ``app/jobs/sources.py::Lane`` + sql/165's
     # ``bootstrap_stages.lane`` CHECK constraint extension.
     "openfigi",
+    # #2024 — terminal fair-value-band first-load lane (S28). Mirrored
+    # from ``app/jobs/sources.py::Lane`` + sql/225's CHECK extension.
+    "fair_value_band",
 ]
 StageApiStatus = Literal["pending", "running", "success", "error", "skipped", "blocked", "cancelled"]
 

--- a/app/services/bootstrap_orchestrator.py
+++ b/app/services/bootstrap_orchestrator.py
@@ -106,6 +106,7 @@ JOB_BOOTSTRAP_ORCHESTRATOR = "bootstrap_orchestrator"
 # Constants imported from the scheduler so the bootstrap-stage entries
 # below carry the canonical names and a future rename is single-site.
 from app.workers.scheduler import (  # noqa: E402  (after dataclass to avoid cycle)
+    JOB_FAIR_VALUE_BAND_REFRESH,
     JOB_SEC_FIRST_INSTALL_DRAIN,
     JOB_SEC_MASTER_IDX_GAP_CLOSE,
 )
@@ -198,6 +199,14 @@ _LANE_MAX_CONCURRENCY: Final[dict[str, int]] = {
     # canonical budget gate. Disjoint from every SEC lane by host —
     # see ``app/jobs/sources.py::Lane`` docstring for SD-1 cross-ref.
     "openfigi": 1,
+    # #2024 — terminal fair-value-band derivation (S28). Own single-stage
+    # lane matching the JobLock source lane ``fair_value_band``
+    # (``MANUAL_TRIGGER_JOB_SOURCES``, sources.py) so every registry path
+    # resolves the ``fair_value_band_refresh`` job to the SAME lane
+    # (test_job_registry::test_real_registry_has_no_conflicting_lane_duplicates).
+    # Write-disjoint (sole writer of the band tables) → cap=1, runs
+    # parallel to the ``db``-lane validation stage.
+    "fair_value_band": 1,
 }
 
 
@@ -644,6 +653,13 @@ _STAGE_REQUIRES_CAPS: Final[dict[str, CapRequirement]] = {
             "class_id_mapping_ready",
         ),
     ),
+    # #2024 — terminal fair-value-band first-load. Reads financial_periods_ttm
+    # (normalised by S25 ``fundamentals_sync`` → ``fundamentals_synced``) +
+    # price_daily (S2 ``candle_refresh``, long-terminalised by the time S25
+    # completes; provides no cap to gate on, and the batch is fail-soft on empty
+    # prices). Single ``fundamentals_synced`` gate is the minimal correct
+    # dependency — the band uses no ownership/filings data.
+    "fair_value_band": CapRequirement(all_of=("fundamentals_synced",)),
 }
 
 
@@ -1231,6 +1247,23 @@ _BOOTSTRAP_STAGE_SPECS: tuple[StageSpec, ...] = (
     # ``finalize_run`` → ``partial_error`` (gate stays closed). Soft warnings →
     # success + ``bootstrap_runs.validation_gate_status`` verdict (sql/180).
     _spec("bootstrap_validation", 27, "db", JOB_BOOTSTRAP_VALIDATION),
+    # #2024 — terminal fair-value-band first-load (#2009 A8). New-surface
+    # rule: a data surface ships bulk/bootstrap first-load, not per-filing
+    # drain only (feedback-backfills-belong-in-bootstrap). The steady-state
+    # ``fair_value_band`` DAG layer (24h cadence, depends candles+fundamentals)
+    # gives full-universe recompute on the FIRST morning sync — but a fresh
+    # install has no bands until then. This stage closes that gap: the
+    # existing ``fair_value_band_refresh`` job (full-universe bootstrap path,
+    # ``refresh_fair_value_band_batch(conn, instrument_ids=None)``) runs once
+    # at load time. Own lane ``fair_value_band`` matches the JobLock source
+    # so the registry resolves the job to one lane (no conflict). Gated on
+    # ``fundamentals_synced`` (S25): the band reads ``financial_periods_ttm``
+    # + ``price_daily``; candles (S2) are long-terminalised by S25, and the
+    # batch is fail-soft on empty prices (statuses absence, no crash). Terminal
+    # derivation → provides NO capability (like ``candle_refresh``); the
+    # validation gate does not wait on it (it validates core data, not the
+    # derived read layer).
+    _spec("fair_value_band", 28, "fair_value_band", JOB_FAIR_VALUE_BAND_REFRESH),
 )
 
 
@@ -3127,14 +3160,16 @@ __all__ = [
 # removes a spec deliberately surfaces in code review and doesn't
 # silently break the tests + frontend + runbook that hardcode the
 # current stage shape.
-assert len(_BOOTSTRAP_STAGE_SPECS) == 23, (
-    f"_BOOTSTRAP_STAGE_SPECS expected 23 stages, got {len(_BOOTSTRAP_STAGE_SPECS)}; "
-    "update the spec, frontend, runbook, and stage_count tests in lockstep. "
+assert len(_BOOTSTRAP_STAGE_SPECS) == 24, (
+    f"_BOOTSTRAP_STAGE_SPECS expected 24 stages, got {len(_BOOTSTRAP_STAGE_SPECS)}; "
+    "update the spec, runbook, and stage_count tests in lockstep (the frontend "
+    "renders stages dynamically from the API — no FE count to bump). "
     "#1233 PR-1b inserted S13 cusip_resolver_post_bulk_sweep; "
     "#1413 (bulk-only bootstrap) dropped 8 per-CIK HTTP stages "
     "(S14/S15/S17/S19/S20/S22/S23 + S27 sec_n_csr_bootstrap_drain): 27 - 8 = 19; "
     "#1415 (P3) added the S15-slot master.idx recent-window gap-close: 19 + 1 = 20; "
     "#1419 (P4) added the terminal bootstrap_validation stage: 20 + 1 = 21; "
     "#788 added S14 sec_fsds_class_shares_ingest (per-class denominator): 21 + 1 = 22; "
-    "#1590 added S17-slot sec_fsds_dimensional_ingest (bulk dimensional facts): 22 + 1 = 23."
+    "#1590 added S17-slot sec_fsds_dimensional_ingest (bulk dimensional facts): 22 + 1 = 23; "
+    "#2024 added S28 fair_value_band (terminal first-load derivation): 23 + 1 = 24."
 )

--- a/app/services/bootstrap_state.py
+++ b/app/services/bootstrap_state.py
@@ -62,6 +62,9 @@ Lane = Literal[
     "db_ownership_insider",
     "db_ownership_funds",
     "openfigi",
+    # #2024 — terminal fair-value-band first-load lane (S28). Mirrored
+    # from ``app/jobs/sources.py::Lane`` + sql/225's CHECK extension.
+    "fair_value_band",
 ]
 """Row-shape Literal for ``bootstrap_stages.lane`` reads. Mirrors
 ``app/jobs/sources.py::Lane`` plus the legacy ``"sec"`` catch-all

--- a/app/services/processes/bootstrap_coverage.py
+++ b/app/services/processes/bootstrap_coverage.py
@@ -81,6 +81,10 @@ _BOOTSTRAP_STAGE_FRESHNESS_SOURCES: Final[dict[str, frozenset[ManifestSource]]] 
     # is deliberately NOT covered (steady-state manifest-worker discovers it).
     "mf_directory_sync": frozenset(),
     "bootstrap_validation": frozenset(),
+    # #2024 — terminal fair-value-band first-load. Derived read layer (writes
+    # fair_value_band_observations/_current from financial_periods_ttm + price_daily),
+    # NOT a manifest source → no freshness sink (like fundamentals_sync above).
+    "fair_value_band": frozenset(),
 }
 
 # Union of every covered source. Excluded by construction (NOT bootstrap-

--- a/sql/225_bootstrap_stages_lane_fair_value_band.sql
+++ b/sql/225_bootstrap_stages_lane_fair_value_band.sql
@@ -1,0 +1,50 @@
+-- 225_bootstrap_stages_lane_fair_value_band.sql
+--
+-- #2024 (#2009 A8) — register the ``fair_value_band`` lane for the terminal
+-- fair-value-band first-load stage (S28).
+--
+-- The lane CHECK constraint on ``bootstrap_stages.lane`` was last widened by
+-- sql/165 (``openfigi``, #1233 PR-1b). This migration adds
+-- ``'fair_value_band'`` so the new S28 ``fair_value_band`` stage
+-- (``_BOOTSTRAP_STAGE_SPECS`` insertion in
+-- ``app/services/bootstrap_orchestrator.py``) can be persisted.
+--
+-- Why a dedicated lane (not ``db``): the ``fair_value_band_refresh`` job is
+-- already source-locked to the ``fair_value_band`` JobLock lane
+-- (``MANUAL_TRIGGER_JOB_SOURCES``, app/jobs/sources.py — it is the sole writer
+-- of ``fair_value_band_observations`` / ``fair_value_band_current``, so it runs
+-- write-disjoint from every other lane). The registry invariant
+-- (``test_job_registry::test_real_registry_has_no_conflicting_lane_duplicates``)
+-- requires every source path for a job_name to resolve to the SAME lane, so the
+-- bootstrap StageSpec lane MUST also be ``fair_value_band``.
+--
+-- The legacy ``'sec'`` lane stays valid (carried since migration 132) for
+-- pre-#1020 run history rows — sql/147 + sql/165 preserve it the same way.
+--
+-- Idempotent: DROP CONSTRAINT IF EXISTS + ADD CONSTRAINT under BEGIN/COMMIT.
+-- Re-running this migration is a no-op once applied.
+
+BEGIN;
+
+ALTER TABLE bootstrap_stages
+    DROP CONSTRAINT IF EXISTS bootstrap_stages_lane_check;
+
+ALTER TABLE bootstrap_stages
+    ADD CONSTRAINT bootstrap_stages_lane_check
+    CHECK (lane IN (
+        'init',
+        'etoro',
+        'sec',
+        'sec_rate',
+        'sec_bulk_download',
+        'db',
+        'db_filings',
+        'db_fundamentals_raw',
+        'db_ownership_inst',
+        'db_ownership_insider',
+        'db_ownership_funds',
+        'openfigi',
+        'fair_value_band'
+    ));
+
+COMMIT;

--- a/tests/test_bootstrap_flow_integration.py
+++ b/tests/test_bootstrap_flow_integration.py
@@ -124,8 +124,9 @@ def test_bootstrap_end_to_end(
     assert met is False
     assert "first-install bootstrap not complete" in reason
 
-    # 2. start_run seeds 20 stages atomically (#1413 dropped 8 per-CIK HTTP
-    # stages + #1415 added the master.idx gap-close: 27 - 8 + 1 = 20).
+    # 2. start_run seeds the full stage catalogue atomically (see the
+    # count arithmetic in bootstrap_orchestrator.py's _BOOTSTRAP_STAGE_SPECS
+    # assertion; currently 24 after #2024's fair_value_band first-load).
     run_id = start_run(
         ebull_test_conn,
         operator_id=None,
@@ -136,7 +137,8 @@ def test_bootstrap_end_to_end(
     snap = read_latest_run_with_stages(ebull_test_conn)
     assert snap is not None
     assert snap.run_id == run_id
-    assert len(snap.stages) == 23  # #1419 bootstrap_validation; #788 fsds_class_shares; #1590 fsds_dimensional
+    # #1419 bootstrap_validation; #788 fsds_class_shares; #1590 fsds_dimensional; #2024 fair_value_band
+    assert len(snap.stages) == 24
     assert all(s.status == "pending" for s in snap.stages)
 
     # 3. State is running, gate stays closed.
@@ -148,10 +150,13 @@ def test_bootstrap_end_to_end(
     # 4. Orchestrator drives Phase A → B → C with the stubbed invokers.
     run_bootstrap_orchestrator()
 
-    # 5. Every fake invoker fired once (23 stages post-#1413/#1415/#1419/#788/#1590 —
-    # incl. the terminal bootstrap_validation stage).
-    assert len(calls["order"]) == 23
+    # 5. Every fake invoker fired once (24 stages post-#1413/#1415/#1419/#788/
+    # #1590/#2024 — incl. the terminal bootstrap_validation + fair_value_band
+    # first-load stages).
+    assert len(calls["order"]) == 24
     assert "bootstrap_validation" in calls["order"]
+    # calls["order"] records job_name (fair_value_band stage → fair_value_band_refresh).
+    assert "fair_value_band_refresh" in calls["order"]
 
     # 6. State is complete; gate releases.
     state = read_state(ebull_test_conn)

--- a/tests/test_bootstrap_orchestrator.py
+++ b/tests/test_bootstrap_orchestrator.py
@@ -116,13 +116,14 @@ def test_stage_catalogue_cardinality() -> None:
     #1415 (P3) added the master.idx gap-close → 20; #1419 (P4) added the
     terminal bootstrap_validation stage → 21; #788 added
     sec_fsds_class_shares_ingest → 22; #1590 added
-    sec_fsds_dimensional_ingest → 23.
+    sec_fsds_dimensional_ingest → 23; #2024 added the terminal
+    fair_value_band first-load derivation → 24.
 
-    23 = 1 init + 1 etoro + 9 sec_rate + 1 sec_bulk_download + 9 db
-    + 1 db_fundamentals_raw + 1 openfigi.
+    24 = 1 init + 1 etoro + 9 sec_rate + 1 sec_bulk_download + 9 db
+    + 1 db_fundamentals_raw + 1 openfigi + 1 fair_value_band.
     """
     specs = get_bootstrap_stage_specs()
-    assert len(specs) == 23
+    assert len(specs) == 24
 
 
 def test_stage_catalogue_lane_composition() -> None:
@@ -134,12 +135,14 @@ def test_stage_catalogue_lane_composition() -> None:
     # drain) = 8; #1415 + 1 master.idx gap-close = 9. #1419 (P4) + 1 db stage
     # (bootstrap_validation); #788 + 1 db stage (sec_fsds_class_shares_ingest);
     # #1590 + 1 db stage (sec_fsds_dimensional_ingest) → db = 9.
-    # Total 1 + 1 + 9 + 1 + 9 + 1 + 1 = 23.
+    # #2024 + 1 fair_value_band stage (own lane) → total 24.
+    # Total 1 + 1 + 9 + 1 + 9 + 1 + 1 + 1 = 24.
     # ``db`` = 9 (5 bulk ingesters + sec_fsds_class_shares_ingest +
     # sec_fsds_dimensional_ingest + ownership_observations_backfill +
     # bootstrap_validation);
     # ``db_fundamentals_raw`` = 1 (S25 fundamentals_sync);
-    # ``openfigi`` = 1 (S13 cusip_resolver_post_bulk_sweep).
+    # ``openfigi`` = 1 (S13 cusip_resolver_post_bulk_sweep);
+    # ``fair_value_band`` = 1 (S28 fair_value_band terminal first-load).
     assert by_lane == {
         "init": 1,
         "etoro": 1,
@@ -148,6 +151,7 @@ def test_stage_catalogue_lane_composition() -> None:
         "db": 9,
         "db_fundamentals_raw": 1,
         "openfigi": 1,
+        "fair_value_band": 1,
     }
 
 

--- a/tests/test_cusip_resolver_openfigi.py
+++ b/tests/test_cusip_resolver_openfigi.py
@@ -910,8 +910,9 @@ def test_stage_orders_are_unique_and_ascending() -> None:
     assert len(set(orders)) == len(orders), f"duplicate stage_orders: {orders}"
     # Pin the post-collapse count (27 - 8 per-CIK HTTP stages + 1 master.idx
     # gap-close (#1415) + 1 terminal bootstrap_validation (#1419) + 1
-    # fsds_class_shares (#788) + 1 fsds_dimensional (#1590) = 23).
-    assert len(_BOOTSTRAP_STAGE_SPECS) == 23
+    # fsds_class_shares (#788) + 1 fsds_dimensional (#1590) + 1 terminal
+    # fair_value_band first-load (#2024) = 24).
+    assert len(_BOOTSTRAP_STAGE_SPECS) == 24
 
 
 def test_openfigi_lane_in_max_concurrency_map() -> None:


### PR DESCRIPTION
## What
Adds a 24th bootstrap-orchestrator stage (**S28 `fair_value_band`**) that runs the existing full-universe fair-value-band recompute once at load time. Closes #2024.

## Why
Deferred from #2009 PR-A (A8). The steady-state `fair_value_band` DAG layer only recomputes bands on the first *morning* sync — so a **fresh install has no fair-value bands until then**. New-surface rule (memory `feedback-backfills-belong-in-bootstrap`): a data surface ships a bulk/bootstrap first-load, not per-tick drain only. This stage closes that gap.

## How
- **Stage**: `_spec("fair_value_band", 28, "fair_value_band", JOB_FAIR_VALUE_BAND_REFRESH)`. The job body (`app/workers/scheduler.py::fair_value_band_refresh`) already calls `refresh_fair_value_band_batch(conn, instrument_ids=None)` — the full/bootstrap path — so no new service logic; the stage just wires the existing job into the catalogue.
- **Gate**: requires `fundamentals_synced` (S25). The band reads `financial_periods_ttm` + `price_daily`; candles (S2) are long-terminalised by S25, and the batch is fail-soft on empty prices (statuses absence, never crashes). No ownership/filings dependency → single-cap gate is minimal + correct.
- **Terminal derivation**: provides NO capability (like `candle_refresh`); `bootstrap_validation` does not gate on it (it validates core data, not the derived read layer). `finalize_run` still waits for it to terminalise before opening the completion gate — Codex-confirmed no early-gate bug.
- **Lane**: own lane `fair_value_band`, matching the JobLock source lane (`MANUAL_TRIGGER_JOB_SOURCES`) so every registry path resolves the `fair_value_band_refresh` job to ONE lane (no `JobSourceRegistryError`). Write-disjoint (sole writer of the band tables), cap=1.

## Lane-vocabulary parity (4 definitions + SQL)
`fair_value_band` was a JobLock source but never a *bootstrap* lane, so three of the four vocabularies lacked it:
- `app/jobs/sources.py::Lane` — already present.
- `app/api/bootstrap.py::LaneApi` — **added**.
- `app/services/bootstrap_state.py::Lane` — **added**.
- `bootstrap_stages_lane_check` CHECK — **added via sql/225** (idempotent DROP/ADD).

Guarded by `test_bootstrap_lane_consistency.py` (every writable lane ∈ all four).

## Count bookkeeping
Stage-count assertion 23→24; `test_bootstrap_orchestrator` (cardinality + lane composition), `test_cusip_resolver_openfigi` (order + count), `test_bootstrap_flow_integration` (seed + drive counts) updated in lockstep. **Frontend needs no change** — it renders stages dynamically from the API (verified: no hardcoded count in `frontend/src`).

## Verification
- Migration 225 applied to dev DB; `bootstrap_stages_lane_check` now includes `fair_value_band`.
- Fast tier + smoke: green (pre-push hook passed).
- DB-tier: `test_bootstrap_flow_integration` (e2e drives all 24 stages, `fair_value_band_refresh` fires), `test_job_registry` (no lane conflict + covers-every-stage), `test_bootstrap_lane_consistency` (4 vocabularies + SQL CHECK), `test_bootstrap_coverage` (freshness classification) — all pass.
- Job correctness proven live today: ran `fair_value_band_refresh` on dev → 567 real bands (#2022 gate close).
- Codex checkpoint-2 clean.

## Security model
No new external I/O, no user input. The stage runs a DB-only recompute under `JobLock`. The lane CHECK migration only *widens* an allow-list (idempotent). No auth surface touched.

## Tradeoffs
- Gate is `fundamentals_synced`-only, not `(candles ∧ fundamentals)` — there is no candle capability in the graph, and S2≪S25 ordering + fail-soft batch make it safe. Documented inline.
- Terminal stage failure does NOT fail the bootstrap (band is best-effort); a failed band stage marks `error`/`partial_error` like any stage but the core-data validation is independent.

## Note
Surfaced (not caused): pre-existing `test_db_lane_family_split::test_each_family_source_has_exactly_one_job` failure on `main` (`expected_filings_seed` on `db_fundamentals_raw`) — filed as #2034.

🤖 Generated with [Claude Code](https://claude.com/claude-code)