### PR TITLE
fix(#2038): CI supply-chain — replace pnpm audit with npm bulk advisory endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,14 +225,29 @@ jobs:
         # to catch).
         run: pnpm --dir frontend install --frozen-lockfile
 
-      - name: pnpm audit (frontend, all deps)
+      - name: npm bulk advisory audit (frontend, all deps)
         # Audit dev + prod deps. The frontend toolchain (vite,
         # vitest, typescript) executes during builds and tests, so
         # advisories there are still in the supply chain we ship
         # through CI. ``high`` floor matches what we'd accept as a
         # merge gate; ``moderate`` produced too many false alarms in
         # tooling chains we don't deploy.
-        run: pnpm --dir frontend audit --audit-level high
+        #
+        # #2038: was ``pnpm --dir frontend audit --audit-level high``.
+        # npm retired the classic audit endpoints on 2026-07-15 (410
+        # Gone) and pnpm (<=11.13.0) has not migrated to the bulk
+        # advisory endpoint, so ``pnpm audit`` fails on every run.
+        # scripts/audit_frontend_bulk.mjs POSTs the resolved package
+        # set to the bulk endpoint directly (server-side version
+        # filtering) with the same ``high`` floor, and fails CLOSED
+        # (exit 2) on an empty package set or endpoint error. Revert
+        # to ``pnpm audit`` once pnpm ships bulk-endpoint support.
+        # set -o pipefail: the default Actions shell is ``bash -e`` WITHOUT
+        # pipefail — a failing ``pnpm list`` would otherwise be masked by a
+        # passing audit script reading truncated-but-parseable JSON.
+        run: |
+          set -o pipefail
+          pnpm --dir frontend list --depth Infinity --json | node scripts/audit_frontend_bulk.mjs --audit-level high
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/scripts/audit_frontend_bulk.mjs
+++ b/scripts/audit_frontend_bulk.mjs
@@ -23,7 +23,12 @@
 
 const BULK_URL = "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk";
 const SEVERITY_ORDER = { low: 0, moderate: 1, high: 2, critical: 3 };
+// Observed constraint, not an assumption: the endpoint accepted 100-name
+// chunks for the real 327-package frontend tree (4 POSTs, all 2xx) — and
+// npm's own audit client batches its bulk requests similarly. Not a
+// documented registry limit; if a future tree trips a 413, lower this.
 const CHUNK_SIZE = 100;
+const RETRY_DELAY_MS = 2000;
 
 function parseArgs(argv) {
   const i = argv.indexOf("--audit-level");
@@ -70,7 +75,11 @@ async function postChunk(chunk, attempt = 1) {
     body: JSON.stringify(chunk),
   });
   if (!res.ok) {
-    if (res.status >= 500 && attempt === 1) return postChunk(chunk, 2);
+    if (res.status >= 500 && attempt === 1) {
+      // One retry with a short backoff — don't hammer a flaky registry.
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+      return postChunk(chunk, 2);
+    }
     throw new Error(`bulk advisory endpoint returned ${res.status}`);
   }
   return res.json();

--- a/scripts/audit_frontend_bulk.mjs
+++ b/scripts/audit_frontend_bulk.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// audit_frontend_bulk.mjs — #2038: `pnpm audit` replacement.
+//
+// On 2026-07-15 the npm registry retired BOTH classic audit endpoints
+// (/-/npm/v1/security/audits/quick and /audits -> 410 Gone) and pnpm
+// (verified on 10.33.0 / 11.0.6 / 11.13.0) has no bulk-endpoint support,
+// so `pnpm audit` fails on every CI run. This script POSTs the resolved
+// package set to the registry's bulk advisory endpoint instead. The
+// endpoint does SERVER-SIDE version filtering (verified empirically:
+// lodash@4.17.20 returns the <4.17.21 high advisory, 4.17.21 does not),
+// so no client-side semver matching is needed.
+//
+// Usage (CI):
+//   pnpm --dir frontend list --depth Infinity --json \
+//     | node scripts/audit_frontend_bulk.mjs --audit-level high
+//
+// Exit codes: 0 = no advisory at/above the floor; 1 = advisories found;
+// 2 = harness failure (empty package set, endpoint error) — fail-closed,
+// a broken audit must not pass as a clean one.
+//
+// Revert path: when pnpm ships bulk-advisory audit support, swap the CI
+// step back to `pnpm --dir frontend audit --audit-level high`.
+
+const BULK_URL = "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk";
+const SEVERITY_ORDER = { low: 0, moderate: 1, high: 2, critical: 3 };
+const CHUNK_SIZE = 100;
+
+function parseArgs(argv) {
+  const i = argv.indexOf("--audit-level");
+  const level = i >= 0 ? argv[i + 1] : "high";
+  if (!(level in SEVERITY_ORDER)) {
+    console.error(`unknown --audit-level ${level}; expected one of ${Object.keys(SEVERITY_ORDER)}`);
+    process.exit(2);
+  }
+  return level;
+}
+
+async function readStdin() {
+  let data = "";
+  for await (const chunk of process.stdin) data += chunk;
+  return data;
+}
+
+// Walk `pnpm list --json` output: an array of projects, each with
+// dependencies/devDependencies/optionalDependencies maps of
+// name -> {version, dependencies?: <nested same shape>}.
+function collectPackages(projects) {
+  const versions = new Map(); // name -> Set(version)
+  const visit = (deps) => {
+    if (!deps) return;
+    for (const [name, info] of Object.entries(deps)) {
+      if (!info || typeof info.version !== "string") continue;
+      if (!versions.has(name)) versions.set(name, new Set());
+      versions.get(name).add(info.version);
+      visit(info.dependencies);
+    }
+  };
+  for (const project of projects) {
+    visit(project.dependencies);
+    visit(project.devDependencies);
+    visit(project.optionalDependencies);
+  }
+  return versions;
+}
+
+async function postChunk(chunk, attempt = 1) {
+  const res = await fetch(BULK_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(chunk),
+  });
+  if (!res.ok) {
+    if (res.status >= 500 && attempt === 1) return postChunk(chunk, 2);
+    throw new Error(`bulk advisory endpoint returned ${res.status}`);
+  }
+  return res.json();
+}
+
+const floor = parseArgs(process.argv.slice(2));
+const raw = await readStdin();
+let projects;
+try {
+  projects = JSON.parse(raw);
+} catch {
+  console.error("stdin was not valid JSON — expected `pnpm list --depth Infinity --json` output");
+  process.exit(2);
+}
+const versions = collectPackages(Array.isArray(projects) ? projects : [projects]);
+if (versions.size === 0) {
+  // Fail-closed: an empty set means the list step broke, not a clean tree.
+  console.error("no packages collected from stdin — refusing to pass an empty audit");
+  process.exit(2);
+}
+
+const names = [...versions.keys()];
+const findings = [];
+for (let i = 0; i < names.length; i += CHUNK_SIZE) {
+  const chunk = Object.fromEntries(names.slice(i, i + CHUNK_SIZE).map((n) => [n, [...versions.get(n)]]));
+  let body;
+  try {
+    body = await postChunk(chunk);
+  } catch (err) {
+    console.error(`bulk advisory request failed: ${err.message}`);
+    process.exit(2);
+  }
+  for (const [name, advisories] of Object.entries(body)) {
+    for (const adv of advisories) {
+      findings.push({
+        name,
+        installed: [...versions.get(name)].join(", "),
+        severity: adv.severity,
+        title: adv.title,
+        url: adv.url,
+        range: adv.vulnerable_versions,
+      });
+    }
+  }
+}
+
+// Fail-closed on an unrecognized severity: a registry schema change must be
+// a harness failure, not a silently-ignored advisory (Codex review, #2038).
+const unknown = findings.filter((f) => !(f.severity in SEVERITY_ORDER));
+if (unknown.length > 0) {
+  console.error(`unrecognized severity values from the bulk endpoint: ${unknown.map((f) => `${f.name}:${f.severity}`).join(", ")}`);
+  process.exit(2);
+}
+const atOrAbove = findings.filter((f) => SEVERITY_ORDER[f.severity] >= SEVERITY_ORDER[floor]);
+const below = findings.length - atOrAbove.length;
+console.log(`audited ${versions.size} packages against the npm bulk advisory endpoint`);
+if (below > 0) console.log(`${below} advisories below the '${floor}' floor (ignored)`);
+if (atOrAbove.length === 0) {
+  console.log(`no advisories at or above '${floor}'`);
+  process.exit(0);
+}
+console.error(`\n${atOrAbove.length} advisories at or above '${floor}':`);
+for (const f of atOrAbove) {
+  console.error(`  [${f.severity}] ${f.name} (installed: ${f.installed}; vulnerable: ${f.range})`);
+  console.error(`    ${f.title} — ${f.url}`);
+}
+process.exit(1);


### PR DESCRIPTION
Closes #2038. Unblocks every open PR (first hit: #2037).

## What / why

npm retired the classic audit endpoints on 2026-07-15 — `/-/npm/v1/security/audits/quick` and the `/audits` fallback both return **410 Gone** ("use the bulk advisory endpoint"). `pnpm audit` has not migrated (verified failing on 10.33.0 = CI pin, 11.0.6 local, 11.13.0 latest), so the `supply-chain` job fails on every PR.

Replacement: `scripts/audit_frontend_bulk.mjs` (zero-dep node, stdin = `pnpm list --depth Infinity --json`) POSTs the resolved package set to `/-/npm/v1/security/advisories/bulk`, chunked at 100 names. The endpoint does **server-side version filtering** — verified empirically: lodash@4.17.20 returns the `<4.17.21` high advisory; 4.17.21 does not. Same `high` floor as before.

## Fail-closed posture (no silent bypass)

- Empty package set → exit 2 (a broken `pnpm list` must not pass as a clean audit).
- Endpoint non-2xx after one 5xx retry → exit 2.
- Unrecognized severity value → exit 2 (registry schema change ≠ ignored advisory; Codex finding, fixed).
- `set -o pipefail` in the step (default Actions shell is `bash -e` WITHOUT pipefail — a failing `pnpm list` piping truncated JSON would otherwise be masked; Codex finding, fixed).

## Security model

CI-only change. The step runs static commands — no untrusted workflow context is interpolated. The script sends package names+versions (public lockfile data) to the npm registry — the same data `pnpm audit` sent. No secrets touched.

## Verification (at fa96ecd5, amended)

- Real tree: `audited 327 packages … no advisories at or above 'high'` → exit 0 (matches the last green pre-retirement run: 3 moderates ignored).
- Synthetic vulnerable (lodash 4.17.20): 2 high advisories reported → exit 1.
- Empty stdin: exit 2.
- Local gates: backend untouched (workflow + new script only); pre-push hook ran full gates on push.

## Tradeoffs / revert path

Direct registry call instead of a packaged tool — chosen over osv-scanner (new binary dep) and npm-audit (can't read pnpm lockfiles). Revert the step to `pnpm --dir frontend audit --audit-level high` when pnpm ships bulk-endpoint support (tracked in the step comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)