### PR TITLE
chore(#2014): standing thesis DQ audit — nightly full-population scan

### DIFF
--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -472,6 +472,55 @@ def list_theses(
     return ThesisLibraryResponse(items=items, total=total, offset=offset, limit=limit)
 
 
+class ThesisDqFindingModel(BaseModel):
+    instrument_id: int
+    symbol: str
+    thesis_id: int
+    dq_class: str
+    severity: str
+    detail: str
+
+
+class ThesisDqReportResponse(BaseModel):
+    scanned: int
+    total_violations: int
+    class_counts: dict[str, int]
+    findings: list[ThesisDqFindingModel]
+    truncated: bool
+
+
+# Registered BEFORE /{instrument_id}: that path param is typed int, so a
+# later-registered literal path would 422 ("dq-audit" fails int parse) —
+# FastAPI matches in registration order with no fall-through.
+@router.get("/dq-audit", response_model=ThesisDqReportResponse)
+def get_thesis_dq_audit(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ThesisDqReportResponse:
+    """Standing thesis DQ audit (#2014) — compute-on-read, same report the
+    nightly ``thesis_dq_audit`` job logs. Findings are operator-triage
+    candidates (no auto-regen)."""
+    from app.services.thesis_dq_audit import compute_thesis_dq_report
+
+    report = compute_thesis_dq_report(conn)
+    return ThesisDqReportResponse(
+        scanned=report.scanned,
+        total_violations=report.total_violations,
+        class_counts=report.class_counts,
+        findings=[
+            ThesisDqFindingModel(
+                instrument_id=f.instrument_id,
+                symbol=f.symbol,
+                thesis_id=f.thesis_id,
+                dq_class=f.dq_class,
+                severity=f.severity,
+                detail=f.detail,
+            )
+            for f in report.findings
+        ],
+        truncated=report.truncated,
+    )
+
+
 @router.get("/{instrument_id}", response_model=ThesisDetail | None)
 def get_latest_thesis(
     instrument_id: int,

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -123,6 +123,7 @@ from app.workers.scheduler import (
     JOB_SEC_N_PORT_INGEST,
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
+    JOB_THESIS_DQ_AUDIT,
     JOB_THESIS_REFRESH,
     JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
@@ -181,6 +182,7 @@ from app.workers.scheduler import (
     sec_n_port_ingest,
     sec_nport_filer_directory_sync,
     seed_cost_models,
+    thesis_dq_audit,
     thesis_refresh,
     weekly_report,
 )
@@ -303,6 +305,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # #1919 PR-B — hourly scheduled + Admin "Run now". The body carries its
     # own provider-resolvable PREREQ_SKIP guard so the manual path (which
     # bypasses ScheduledJob.prerequisite) is equally gated.
+    JOB_THESIS_DQ_AUDIT: _adapt_zero_arg(thesis_dq_audit),
     JOB_THESIS_REFRESH: _adapt_zero_arg(thesis_refresh),
     JOB_PORTFOLIO_EOD_SNAPSHOT: _adapt_zero_arg(portfolio_eod_snapshot_job),
     JOB_FX_HISTORY_BACKFILL: _adapt_zero_arg(fx_history_backfill_job),

--- a/app/services/thesis_dq_audit.py
+++ b/app/services/thesis_dq_audit.py
@@ -1,0 +1,322 @@
+"""Standing thesis DQ audit — nightly full-population scan (#2014).
+
+Stored theses do not re-validate themselves; insert-time guards (#2007)
+evolve while rows stay frozen. This module scans the LATEST thesis per
+instrument and surfaces violations as operator-triage CANDIDATES (the
+``scripts/dq_audit.py`` board-feeder posture: findings are candidates,
+not asserted bugs). No auto-regen — the operator / #2010 staleness path
+decides.
+
+Predicates are pure functions over plain values (table-testable, no DB);
+``compute_thesis_dq_report`` is the one DB reader. Availability truth per
+run is ``thesis_runs.context_summary.blocks`` (#2017, persisted PRE-LLM):
+claim-lint compares the memo's unavailability claims against the run's
+OWN summary — never against freshly rebuilt context (drift-vs-now is
+#2010's staleness concern, not DQ).
+
+Spec: docs/proposals/thesis/2026-07-15-thesis-dq-audit.md.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+# Same coercion chokepoint as the #2007 insert-time guard — NaN/±inf → None
+# so a garbage target drops out of comparisons instead of defeating them.
+from app.services.thesis import _to_float
+
+# Findings payload cap — bounds the endpoint response on a large population
+# (mirrors compute_cik_gap_report's bounded per-row payload).
+_MAX_FINDINGS = 200
+
+# base more than ±60% from the close the writer anchored on (issue #2014).
+_BASE_CLOSE_TOLERANCE = 0.60
+
+# price anchor older than this vs created_at = wrote on a stale anchor.
+_STALE_ANCHOR_DAYS = 7
+
+# Memo keywords per context block (claim-lint). The writer prompt's
+# availability rule applies to EVERY block's status fields
+# (app/services/thesis.py — "Data-availability language MUST mirror the
+# block status fields verbatim"), so all summarized blocks are covered.
+_BLOCK_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "news": ("news",),
+    "filings": ("filings", "filing data"),
+    "earnings_history": ("earnings history", "earnings data"),
+    "analyst_estimates": ("analyst estimates", "analyst coverage", "analyst data"),
+    "fundamentals": ("fundamentals", "fundamental data", "financial statements"),
+    "valuation": ("valuation data", "valuation metrics"),
+    "fair_value_band": ("fair value band", "fair-value band"),
+    "risk_metrics": ("risk metrics", "risk data"),
+    "ta_state": ("technical", "ta state"),
+    "price_anchor": ("price anchor", "market price", "price data"),
+    "analytics_evidence": ("analytics evidence", "analytics data"),
+}
+
+# Clause-bounded windows: no crossing of , ; . or newline, and tight spans.
+# The 60-char sentence-wide window was FP-dominant on the dev population
+# ("valuation multiples unavailable due to no live quote, we rely on
+# FUNDAMENTALS" flagged fundamentals; "neutral fundamentals, while the
+# ALTMAN Z-SCORE is unavailable" flagged fundamentals). A fabricated claim
+# names the block and its unavailability in ONE clause ("no recent news
+# coverage", "fundamentals data is unavailable") — cross-clause proximity
+# is coincidence, not a claim.
+# Negation-first form: word-bounded negation then AT MOST TWO words before
+# the block keyword ("no recent news coverage", "missing filings data").
+# Bare {0,25}-char windows matched "no" inside "noted"/"not supported by …
+# fundamentals" and causal "unavailable due to a stale price anchor".
+_NEG_BEFORE = r"(?i)\b(?:no|missing|unavailable|not\s+available|lack\s+of)\s+(?:[\w'-]+\s+){0,2}"
+_NEG_AFTER = r"[^.,;\n]{0,30}\b(?:unavailable|not\s+available|missing|non-existent)"
+
+
+@dataclass(frozen=True)
+class ThesisDqFinding:
+    instrument_id: int
+    symbol: str
+    thesis_id: int
+    dq_class: str
+    severity: str  # violation | flag | candidate
+    detail: str
+
+
+# Info-only classes: counted, never emitted as findings rows.
+_INFO_CLASSES: frozenset[str] = frozenset(
+    {"target_abstention", "zoneless_buy_no_anchor", "no_run", "no_context_summary"}
+)
+
+
+@dataclass(frozen=True)
+class ThesisDqReport:
+    scanned: int
+    class_counts: dict[str, int]
+    findings: list[ThesisDqFinding] = field(default_factory=list)
+    truncated: bool = False
+
+    @property
+    def total_violations(self) -> int:
+        """Violation + flag + candidate counts (info classes excluded)."""
+        return sum(v for k, v in self.class_counts.items() if k not in _INFO_CLASSES)
+
+
+def check_ordering(bear: object, base: object, bull: object) -> str | None:
+    """#2007 `_validate_writer_output` semantics: bear<=base<=bull over
+    non-null pairs after `_to_float` coercion."""
+    b, m, u = _to_float(bear), _to_float(base), _to_float(bull)
+    if b is not None and m is not None and b > m:
+        return f"bear {b} > base {m}"
+    if m is not None and u is not None and m > u:
+        return f"base {m} > bull {u}"
+    if b is not None and u is not None and b > u:
+        return f"bear {b} > bull {u}"
+    return None
+
+
+def check_zone(zone_low: object, zone_high: object) -> str | None:
+    lo, hi = _to_float(zone_low), _to_float(zone_high)
+    if lo is not None and hi is not None and lo > hi:
+        return f"buy_zone_low {lo} > buy_zone_high {hi}"
+    return None
+
+
+def classify_zoneless_buy(
+    stance: object, zone_low: object, zone_high: object, anchor_available: bool | None
+) -> str | None:
+    """Return 'zoneless_buy' (violation) or 'zoneless_buy_no_anchor' (info).
+
+    The writer prompt DOCUMENTS null zones when price_anchor is null
+    ("When `price_anchor` is null: leave buy_zone_low/high null regardless
+    of stance") — so a zoneless buy is only a violation when the run's
+    summary says the anchor WAS available. Unknown anchor state (no usable
+    summary) is exempt too — honest absence, not a violation.
+    """
+    if stance != "buy":
+        return None
+    if _to_float(zone_low) is not None or _to_float(zone_high) is not None:
+        return None
+    if anchor_available is True:
+        return "zoneless_buy"
+    return "zoneless_buy_no_anchor"
+
+
+def check_base_vs_anchor_close(base: object, anchor_close: object) -> str | None:
+    """base >60% away from the close the writer anchored on (write-time
+    sanity — latest-close drift belongs to #2010, not DQ)."""
+    b, c = _to_float(base), _to_float(anchor_close)
+    if b is None or c is None or c <= 0:
+        return None
+    rel = abs(b / c - 1.0)
+    if rel > _BASE_CLOSE_TOLERANCE:
+        return f"base {b} is {rel:.0%} from anchor-date close {c}"
+    return None
+
+
+def check_stale_anchor(anchor_as_of: date | None, created_at: datetime) -> str | None:
+    if anchor_as_of is None:
+        return None
+    gap = created_at.date() - anchor_as_of
+    if gap > timedelta(days=_STALE_ANCHOR_DAYS):
+        return f"price_anchor as_of {anchor_as_of} is {gap.days}d older than thesis created_at"
+    return None
+
+
+def is_target_abstention(bear: object, base: object, bull: object) -> bool:
+    return _to_float(bear) is None and _to_float(base) is None and _to_float(bull) is None
+
+
+def claim_lint(memo: str, blocks: dict[str, Any]) -> list[str]:
+    """Blocks the memo claims unavailable while the run's own summary says
+    available=True (#2007 Defect 2 fabrication class). Candidate severity —
+    the bounded-window regex tolerates false positives by posture."""
+    hits: list[str] = []
+    for block, keywords in _BLOCK_KEYWORDS.items():
+        info = blocks.get(block)
+        if not isinstance(info, dict) or info.get("available") is not True:
+            continue
+        for kw in keywords:
+            kw_re = re.escape(kw).replace(r"\ ", r"\s+")
+            if re.search(_NEG_BEFORE + kw_re, memo) or re.search(r"(?i)" + kw_re + _NEG_AFTER, memo):
+                hits.append(block)
+                break
+    return hits
+
+
+def _parse_iso_date(raw: object) -> date | None:
+    if not isinstance(raw, str):
+        return None
+    try:
+        return date.fromisoformat(raw[:10])
+    except ValueError:
+        return None
+
+
+def _anchor_block(summary: object) -> dict[str, Any] | None:
+    if not isinstance(summary, dict):
+        return None
+    blocks = summary.get("blocks")
+    if not isinstance(blocks, dict):
+        return None
+    anchor = blocks.get("price_anchor")
+    return anchor if isinstance(anchor, dict) else None
+
+
+def _close_at_or_before(conn: psycopg.Connection[Any], instrument_id: int, as_of: date) -> float | None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT close FROM price_daily
+            WHERE instrument_id = %(iid)s AND price_date <= %(as_of)s
+            ORDER BY price_date DESC LIMIT 1
+            """,
+            {"iid": instrument_id, "as_of": as_of},
+        )
+        row = cur.fetchone()
+    return _to_float(row[0]) if row else None
+
+
+_LATEST_THESES_SQL = """
+WITH latest AS (
+    SELECT DISTINCT ON (t.instrument_id) t.*
+    FROM theses t
+    ORDER BY t.instrument_id,
+             t.created_at DESC, t.thesis_version DESC, t.thesis_id DESC
+)
+SELECT l.thesis_id, l.instrument_id, i.symbol, l.stance, l.created_at,
+       l.bear_value, l.base_value, l.bull_value,
+       l.buy_zone_low, l.buy_zone_high, l.memo_markdown,
+       r.run_id, r.context_summary
+FROM latest l
+JOIN instruments i ON i.instrument_id = l.instrument_id
+LEFT JOIN LATERAL (
+    SELECT run_id, context_summary
+    FROM thesis_runs r
+    WHERE r.thesis_id = l.thesis_id
+    ORDER BY r.run_id DESC
+    LIMIT 1
+) r ON TRUE
+ORDER BY l.instrument_id
+"""
+
+
+def compute_thesis_dq_report(conn: psycopg.Connection[Any]) -> ThesisDqReport:
+    """Full-population scan of the latest thesis per instrument.
+
+    Latest-row selection mirrors the API tiebreak (created_at DESC,
+    thesis_version DESC, thesis_id DESC). Run linkage is LATERAL-latest by
+    run_id: ``thesis_runs.thesis_id`` is a nullable NON-unique FK, so a
+    plain join could duplicate findings on bad historical multi-links.
+    """
+    counts: dict[str, int] = {}
+    findings: list[ThesisDqFinding] = []
+
+    def add(row: dict[str, Any], dq_class: str, severity: str, detail: str) -> None:
+        counts[dq_class] = counts.get(dq_class, 0) + 1
+        if len(findings) < _MAX_FINDINGS:
+            findings.append(
+                ThesisDqFinding(
+                    instrument_id=row["instrument_id"],
+                    symbol=row["symbol"],
+                    thesis_id=row["thesis_id"],
+                    dq_class=dq_class,
+                    severity=severity,
+                    detail=detail,
+                )
+            )
+
+    scanned = 0
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_LATEST_THESES_SQL)
+        rows = cur.fetchall()
+
+    for row in rows:
+        scanned += 1
+        summary = row["context_summary"]
+        blocks = summary.get("blocks") if isinstance(summary, dict) else None
+        anchor = _anchor_block(summary)
+        anchor_available = anchor.get("available") is True if anchor is not None else None
+
+        if detail := check_ordering(row["bear_value"], row["base_value"], row["bull_value"]):
+            add(row, "ordering", "violation", detail)
+        if detail := check_zone(row["buy_zone_low"], row["buy_zone_high"]):
+            add(row, "zone_inverted", "violation", detail)
+
+        zoneless = classify_zoneless_buy(row["stance"], row["buy_zone_low"], row["buy_zone_high"], anchor_available)
+        if zoneless == "zoneless_buy":
+            add(row, "zoneless_buy", "violation", "stance=buy with no buy zone despite available price anchor")
+        elif zoneless == "zoneless_buy_no_anchor":
+            counts["zoneless_buy_no_anchor"] = counts.get("zoneless_buy_no_anchor", 0) + 1
+
+        if is_target_abstention(row["bear_value"], row["base_value"], row["bull_value"]):
+            counts["target_abstention"] = counts.get("target_abstention", 0) + 1
+
+        if row["run_id"] is None:
+            counts["no_run"] = counts.get("no_run", 0) + 1
+            continue
+        if not isinstance(blocks, dict):
+            counts["no_context_summary"] = counts.get("no_context_summary", 0) + 1
+            continue
+
+        anchor_as_of = _parse_iso_date(anchor.get("as_of")) if anchor else None
+        if detail := check_stale_anchor(anchor_as_of, row["created_at"]):
+            add(row, "stale_price_anchor", "flag", detail)
+
+        if anchor_as_of is not None:
+            anchor_close = _close_at_or_before(conn, row["instrument_id"], anchor_as_of)
+            if detail := check_base_vs_anchor_close(row["base_value"], anchor_close):
+                add(row, "base_far_from_close", "flag", detail)
+
+        memo = row["memo_markdown"] or ""
+        for block in claim_lint(memo, blocks):
+            add(row, "claim_lint", "candidate", f"memo claims '{block}' unavailable; run summary says available")
+
+    return ThesisDqReport(
+        scanned=scanned,
+        class_counts=counts,
+        findings=findings,
+        truncated=sum(v for k, v in counts.items() if k not in _INFO_CLASSES) > len(findings),
+    )

--- a/app/services/thesis_dq_audit.py
+++ b/app/services/thesis_dq_audit.py
@@ -285,21 +285,24 @@ def compute_thesis_dq_report(conn: psycopg.Connection[Any]) -> ThesisDqReport:
         if detail := check_zone(row["buy_zone_low"], row["buy_zone_high"]):
             add(row, "zone_inverted", "violation", detail)
 
-        zoneless = classify_zoneless_buy(row["stance"], row["buy_zone_low"], row["buy_zone_high"], anchor_available)
-        if zoneless == "zoneless_buy":
-            add(row, "zoneless_buy", "violation", "stance=buy with no buy zone despite available price anchor")
-        elif zoneless == "zoneless_buy_no_anchor":
-            counts["zoneless_buy_no_anchor"] = counts.get("zoneless_buy_no_anchor", 0) + 1
-
         if is_target_abstention(row["bear_value"], row["base_value"], row["bull_value"]):
             counts["target_abstention"] = counts.get("target_abstention", 0) + 1
 
+        # Anchor-gated predicates (zoneless-buy, stale anchor, base-vs-close,
+        # claim-lint) need a usable run summary — a thesis without one is
+        # counted ONLY via no_run / no_context_summary (spec; Codex ckpt-2).
         if row["run_id"] is None:
             counts["no_run"] = counts.get("no_run", 0) + 1
             continue
         if not isinstance(blocks, dict):
             counts["no_context_summary"] = counts.get("no_context_summary", 0) + 1
             continue
+
+        zoneless = classify_zoneless_buy(row["stance"], row["buy_zone_low"], row["buy_zone_high"], anchor_available)
+        if zoneless == "zoneless_buy":
+            add(row, "zoneless_buy", "violation", "stance=buy with no buy zone despite available price anchor")
+        elif zoneless == "zoneless_buy_no_anchor":
+            counts["zoneless_buy_no_anchor"] = counts.get("zoneless_buy_no_anchor", 0) + 1
 
         anchor_as_of = _parse_iso_date(anchor.get("as_of")) if anchor else None
         if detail := check_stale_anchor(anchor_as_of, row["created_at"]):

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -827,9 +827,11 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "Read-only; findings are operator-triage candidates (no "
             "auto-regen). row_count = total violations."
         ),
-        # 05:10 UTC — after the 02:30 fundamentals_sync + 03:30 ownership
-        # repair window; a pure read on the db lane, cheap at any hour.
-        cadence=Cadence.daily(hour=5, minute=10),
+        # 05:12 UTC — after the 02:30 fundamentals_sync + 03:30 ownership
+        # repair window; NOT 5-min-aligned (orchestrator_high_frequency_sync
+        # shares the db lane and fires on the :00/:05 grid — an aligned slot
+        # silently loses the lane-acquire race every night, #1707 class).
+        cadence=Cadence.daily(hour=5, minute=12),
         # A missed night is re-covered next night; nothing accumulates.
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -327,6 +327,7 @@ JOB_DAILY_NEWS_REFRESH = "daily_news_refresh"
 # SCHEDULED_JOBS/_INVOKERS, zero job_runs rows ever recorded), renamed at
 # re-registration. Hourly, held ∪ top-ranked scope, batch-bounded.
 JOB_THESIS_REFRESH = "thesis_refresh"
+JOB_THESIS_DQ_AUDIT = "thesis_dq_audit"
 JOB_MORNING_CANDIDATE_REVIEW = "morning_candidate_review"
 JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
 JOB_DAILY_PORTFOLIO_SYNC = "daily_portfolio_sync"
@@ -813,6 +814,25 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # would fire a multi-minute LLM batch on every dev-stack restart.
         catch_up_on_boot=False,
         prerequisite=_llm_provider_resolvable,
+    ),
+    ScheduledJob(
+        name=JOB_THESIS_DQ_AUDIT,
+        display_name="Thesis DQ audit",
+        source="db",
+        description=(
+            "Nightly full-population DQ scan of the latest stored thesis "
+            "per instrument (#2014): target ordering, buy-zone sanity, "
+            "zoneless buys, base-vs-anchor-close distance, availability "
+            "claim-lint vs the run's context summary, stale price anchors. "
+            "Read-only; findings are operator-triage candidates (no "
+            "auto-regen). row_count = total violations."
+        ),
+        # 05:10 UTC — after the 02:30 fundamentals_sync + 03:30 ownership
+        # repair window; a pure read on the db lane, cheap at any hour.
+        cadence=Cadence.daily(hour=5, minute=10),
+        # A missed night is re-covered next night; nothing accumulates.
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
     ),
     ScheduledJob(
         name=JOB_PORTFOLIO_EOD_SNAPSHOT,
@@ -4869,6 +4889,35 @@ def raw_payload_retention_sweep(params: Mapping[str, Any]) -> None:
             dict(sorted(summary.by_source.items(), key=lambda kv: kv[1], reverse=True)),
             summary.dry_run,
         )
+
+
+def thesis_dq_audit() -> None:
+    """Nightly full-population DQ scan of stored theses (#2014).
+
+    Thin wrapper around
+    :func:`app.services.thesis_dq_audit.compute_thesis_dq_report` —
+    read-only, no writes beyond job_runs telemetry. ``row_count`` is the
+    total violation+flag+candidate count (info classes excluded) so ops
+    health / /system/jobs surfaces the number without a new table.
+    Findings themselves are served compute-on-read via
+    ``GET /theses/dq-audit``.
+    """
+    from app.services.thesis_dq_audit import compute_thesis_dq_report
+
+    with _tracked_job(JOB_THESIS_DQ_AUDIT) as tracker:
+        with connect_job() as conn:
+            report = compute_thesis_dq_report(conn)
+        tracker.row_count = report.total_violations
+        summary = ", ".join(f"{k}={v}" for k, v in sorted(report.class_counts.items())) or "clean"
+        if report.total_violations:
+            logger.warning(
+                "thesis_dq_audit: %d violation(s) across %d theses — %s",
+                report.total_violations,
+                report.scanned,
+                summary,
+            )
+        else:
+            logger.info("thesis_dq_audit: clean — scanned=%d (%s)", report.scanned, summary)
 
 
 def financial_facts_retention_sweep() -> None:

--- a/docs/proposals/thesis/2026-07-15-thesis-dq-audit.md
+++ b/docs/proposals/thesis/2026-07-15-thesis-dq-audit.md
@@ -1,0 +1,93 @@
+# Standing thesis DQ audit — nightly full-population scan (#2014)
+
+Status: proposal. Small; self-merge shape. Parent: #2007 (insert-time guards), #2008 (audit slot precedent).
+Purpose: stored theses do not re-validate themselves; guards evolve. A nightly scan of the
+LATEST thesis per instrument surfaces violations as operator-triage candidates. No auto-regen
+(operator / #2010 staleness path decides).
+
+## Source rules / precedents
+
+- Thesis rows are append-only; freshness = latest `created_at` (settled-decisions "thesis" §§).
+  Audit scans `DISTINCT ON (instrument_id) … ORDER BY created_at DESC, thesis_version DESC,
+  thesis_id DESC` — the API's own tiebreak (`app/api/theses.py:293`), deterministic under
+  same-timestamp inserts (Codex ckpt-1).
+- Run linkage: `thesis_runs.thesis_id` is a NULLABLE, NON-unique FK (sql/218) — join via
+  `LEFT JOIN LATERAL (… WHERE r.thesis_id = t.thesis_id ORDER BY r.run_id DESC LIMIT 1)`
+  so bad historical multi-links can't duplicate findings. Two absence states counted
+  SEPARATELY: `no_run` (no linked run row) vs `no_context_summary` (run row, NULL audit
+  columns — nullable by design, sql/223).
+- Ordering/zone invariants = exactly #2007's `_validate_writer_output` semantics
+  (`bear<=base<=bull` over non-null pairs, `zone_low<=zone_high`, `_to_float` NaN/±inf→None).
+  Predicates extracted into the audit module as pure functions; `_validate_writer_output`
+  keeps raising ValueError on the same conditions (no behavior change at insert time).
+- Availability truth per run = `thesis_runs.context_summary.blocks` (#2017): per-block
+  `available` + as-of stamps, persisted PRE-LLM. The claim-lint class compares the MEMO's
+  unavailability claims against the run's OWN summary (fabrication class, #2007 Defect 2) —
+  NOT against freshly rebuilt context (rebuilding per block would duplicate
+  `_assemble_context`'s queries; drift-vs-now is #2010's staleness concern, not DQ).
+- Candidate-not-assertion posture: same contract as `scripts/dq_audit.py` (board-feeder) —
+  findings are triage candidates; the operator confirms before filing.
+
+## Violation classes (latest thesis per instrument)
+
+| class | predicate (pure, after `_to_float` coercion) | severity |
+| --- | --- | --- |
+| `ordering` | NOT bear<=base<=bull over non-null pairs | violation |
+| `zone_inverted` | zone_low > zone_high (both non-null) | violation |
+| `zoneless_buy` | stance == "buy" AND both zones NULL AND the run's `price_anchor.available` is True — the writer prompt DOCUMENTS null zones when no anchor (`app/services/thesis.py:1012`), so anchor-less buys are exempt (counted `zoneless_buy_no_anchor`, info) | violation |
+| `base_far_from_close` | close AT THE ANCHOR DATE (`price_daily.close` at max `price_date <= price_anchor.as_of`) present AND \|base/close − 1\| > 0.60 — write-time sanity vs the price the writer SAW; latest-close drift is #2010's staleness concern, not DQ (Codex ckpt-1 HIGH) | flag |
+| `claim_lint` | memo claims a block unavailable (regex per block keyword) while the run's `context_summary.blocks[b].available` is True | candidate |
+| `stale_price_anchor` | run summary `price_anchor.as_of` more than 7d older than thesis `created_at` (wrote on a stale anchor) | flag |
+| `target_abstention` | bear, base, bull ALL NULL | info count |
+
+`claim_lint` scope: ALL summarized blocks — the writer prompt's availability rule applies to
+every block's status fields (`app/services/thesis.py:1024`), so the keyword map covers
+{news, filings, earnings_history, analyst_estimates, fundamentals, valuation,
+fair_value_band, risk_metrics, ta_state, price_anchor, analytics_evidence} with per-block
+keywords (e.g. "fair value band", "risk metrics", "technical"). Regex per block — tuned on
+the FULL dev population (82 → 28 → 8 findings across three rounds of snippet audits):
+negation-first `(?i)\b(no|missing|unavailable|not available|lack of)\s+(\w+\s+){0,2}<keyword>`
+(word-bounded — bare windows matched "no" inside "noted"/"not supported"; ≤2-word gap kills
+cross-clause "unavailable due to a stale `<keyword>`"), or keyword-first
+`<keyword>[^.,;\n]{0,30}\b(unavailable|not available|missing|non-existent)` (clause-bounded —
+never crosses `, ; .`). Candidate severity — residual qualitative FPs ("no strong
+fundamentals") tolerated by posture. Theses without a usable summary skip claim_lint +
+stale_price_anchor + the anchor-gated predicates (counted via `no_run` / `no_context_summary`).
+
+## Shape
+
+1. `app/services/thesis_dq_audit.py` — pure predicate functions (table-testable, no DB) +
+   `compute_thesis_dq_report(conn) -> ThesisDqReport` (frozen dataclasses): one read joining
+   latest thesis per instrument ← latest matching `thesis_runs` row (by `thesis_id`) ← latest
+   `price_daily` close; per-class counts + bounded per-violation rows (symbol, thesis_id,
+   class, detail; cap 200 rows like `compute_cik_gap_report`'s bounded payload).
+2. `GET /theses/dq-audit` on the existing authed `theses` router (compute-on-read, mirrors
+   `/coverage/manifest-parsers` pattern). Pydantic response mirror in `frontend/src/api/types.ts`
+   NOT needed (no FE consumer in v1 — manifest/cik audits are likewise API-only; the admin "DQ
+   panel" for these audits does not exist yet — explicitly out of scope, matches precedent).
+3. Nightly `ScheduledJob` `thesis_dq_audit` (source `db`, 05:10 UTC, `catch_up_on_boot=False`,
+   gated `_bootstrap_complete`): runs the compute, logs one WARN per non-zero class,
+   `job_runs.row_count` = total violations (ops health reads job_runs; /system/jobs shows it).
+   Standard triangle + registry-shape test entries.
+
+No schema change. No FE change. No model_version/scoring impact (read-only over stored rows).
+
+## Baseline (dev, run at PR time)
+
+2026-07-11 manual scan: 27 theses — 1 ordering, 2 zoneless buys, 20 target-abstentions.
+Stored rows have since evolved (#2007 shipped 07-12; regens). PR records the day-one numbers
+from `compute_thesis_dq_report` on dev and reconciles against those classes. Baseline is a
+PR-time reference for the dev population ONLY — predicate safety rests on the pure
+table-tests + the documented rules above, not on this count (Codex ckpt-1).
+
+## Tests
+
+- Pure predicate table-tests per class (incl. NaN/None coercion edges, no-run-summary skip).
+- One db-tier test driving the REAL query into the real reader (projection-gap class,
+  prevention-log #2021 lesson).
+
+## Out of scope
+
+- Auto-regen / staleness-vs-now (belongs to #2010 re-thesis path).
+- FE panel (no admin DQ panel exists for the audit family; API-only like siblings).
+- Rebuilding context per block for "current" availability.

--- a/tests/test_thesis_dq_audit.py
+++ b/tests/test_thesis_dq_audit.py
@@ -1,0 +1,226 @@
+"""Pure predicate tests for the standing thesis DQ audit (#2014).
+
+Spec: docs/proposals/thesis/2026-07-15-thesis-dq-audit.md. The predicates
+mirror #2007's `_validate_writer_output` semantics through the same
+`_to_float` coercion chokepoint (NaN/±inf → None).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from app.services.thesis_dq_audit import (
+    _BLOCK_KEYWORDS,
+    check_base_vs_anchor_close,
+    check_ordering,
+    check_stale_anchor,
+    check_zone,
+    claim_lint,
+    classify_zoneless_buy,
+    is_target_abstention,
+)
+
+
+class TestOrdering:
+    @pytest.mark.parametrize(
+        ("bear", "base", "bull", "violates"),
+        [
+            (10, 20, 30, False),
+            (30, 20, 10, True),  # fully inverted
+            (25, 20, 30, True),  # bear > base
+            (10, 35, 30, True),  # base > bull
+            (None, 20, 10, True),  # base > bull with bear absent
+            (None, None, None, False),  # abstention is not an ordering violation
+            ("nan", 20, 10, True),  # NaN coerces to None; base>bull still caught
+            (float("inf"), 20, 30, False),  # inf coerces to None, drops out
+            ("10", "20", "30", False),  # numeric strings coerce
+        ],
+    )
+    def test_table(self, bear: object, base: object, bull: object, violates: bool) -> None:
+        assert (check_ordering(bear, base, bull) is not None) is violates
+
+
+class TestZone:
+    def test_inverted(self) -> None:
+        assert check_zone(50, 40) is not None
+
+    def test_ordered_and_nulls(self) -> None:
+        assert check_zone(40, 50) is None
+        assert check_zone(None, 50) is None
+        assert check_zone("nan", 40) is None
+
+
+class TestZonelessBuy:
+    def test_violation_when_anchor_available(self) -> None:
+        assert classify_zoneless_buy("buy", None, None, True) == "zoneless_buy"
+
+    def test_info_when_anchor_unavailable(self) -> None:
+        """Writer prompt documents null zones when price_anchor is null —
+        anchor-less buys are exempt (Codex ckpt-1 HIGH)."""
+        assert classify_zoneless_buy("buy", None, None, False) == "zoneless_buy_no_anchor"
+
+    def test_info_when_anchor_state_unknown(self) -> None:
+        assert classify_zoneless_buy("buy", None, None, None) == "zoneless_buy_no_anchor"
+
+    def test_not_buy_or_zoned(self) -> None:
+        assert classify_zoneless_buy("hold", None, None, True) is None
+        assert classify_zoneless_buy("buy", 10, 12, True) is None
+        assert classify_zoneless_buy("buy", 10, None, True) is None  # partial zone != zoneless
+
+
+class TestBaseVsAnchorClose:
+    def test_far(self) -> None:
+        assert check_base_vs_anchor_close(200, 100) is not None  # +100%
+
+    def test_within(self) -> None:
+        assert check_base_vs_anchor_close(150, 100) is None  # +50% <= 60%
+
+    def test_missing_or_nonpositive_close(self) -> None:
+        assert check_base_vs_anchor_close(200, None) is None
+        assert check_base_vs_anchor_close(200, 0) is None
+        assert check_base_vs_anchor_close(None, 100) is None
+
+
+class TestStaleAnchor:
+    _created = datetime(2026, 7, 15, 12, 0, tzinfo=UTC)
+
+    def test_stale(self) -> None:
+        assert check_stale_anchor(date(2026, 7, 1), self._created) is not None
+
+    def test_fresh_and_absent(self) -> None:
+        assert check_stale_anchor(date(2026, 7, 10), self._created) is None
+        assert check_stale_anchor(None, self._created) is None
+
+
+class TestAbstention:
+    def test_all_null(self) -> None:
+        assert is_target_abstention(None, "nan", None)
+
+    def test_any_present(self) -> None:
+        assert not is_target_abstention(None, 10, None)
+
+
+class TestClaimLint:
+    _blocks = {
+        "news": {"available": True, "count": 4},
+        "filings": {"available": False, "count": 0},
+        "fair_value_band": {"available": True, "status": "high"},
+    }
+
+    def test_fabricated_claim_flagged(self) -> None:
+        memo = "There is no recent news coverage for this name."
+        assert claim_lint(memo, self._blocks) == ["news"]
+
+    def test_honest_claim_not_flagged(self) -> None:
+        """Filings genuinely unavailable — claiming so is correct."""
+        memo = "Filings data is unavailable for this issuer."
+        assert claim_lint(memo, self._blocks) == []
+
+    def test_multiword_keyword(self) -> None:
+        memo = "A fair value band is not available, so anchoring uses fundamentals."
+        assert claim_lint(memo, self._blocks) == ["fair_value_band"]
+
+    def test_window_bounded(self) -> None:
+        """Negation and keyword in different sentences do not match."""
+        memo = "There is no debt on the balance sheet. The news flow is strong."
+        assert claim_lint(memo, self._blocks) == []
+
+    def test_no_claims(self) -> None:
+        assert claim_lint("Solid quarter; strong news momentum.", self._blocks) == []
+
+    def test_keyword_map_covers_all_summarized_blocks(self) -> None:
+        """Writer prompt's availability rule applies to every block —
+        keep the keyword map aligned with summarize_context's block set."""
+        summarized = {
+            "news",
+            "filings",
+            "ta_state",
+            "valuation",
+            "fundamentals",
+            "price_anchor",
+            "prior_thesis",
+            "risk_metrics",
+            "fair_value_band",
+            "earnings_history",
+            "analyst_estimates",
+            "analytics_evidence",
+            "instrument",
+        }
+        # prior_thesis / instrument carry no "data availability" language a
+        # writer would fabricate about; every other block must be covered.
+        assert summarized - set(_BLOCK_KEYWORDS) == {"prior_thesis", "instrument"}
+
+
+@pytest.fixture
+def conn(ebull_test_conn):
+    return ebull_test_conn
+
+
+class TestComputeReportRealQuery:
+    """One db-tier drive of the REAL query into the real reader — a
+    projection gap fails here, not in production (prevention-log #2021
+    dict-row lesson)."""
+
+    def _seed(self, conn) -> int:
+        iid = 9014
+        conn.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)"
+            " VALUES (%s, 'DQT', 'DQ Test Co', TRUE)",
+            (iid,),
+        )
+        conn.execute(
+            "INSERT INTO price_daily (instrument_id, price_date, open, high, low, close, volume)"
+            " VALUES (%s, '2026-07-01', 10, 10, 10, 10, 0)",
+            (iid,),
+        )
+        # Inverted targets + zoneless buy; older superseded row proves
+        # latest-per-instrument selection.
+        conn.execute(
+            """
+            INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance, memo_markdown,
+                                bear_value, base_value, bull_value, model, provider, prompt_version, created_at)
+            VALUES (%s, 1, 'value', 'hold', 'old clean memo', 1, 2, 3, 'm', 'p', 'v4', now() - interval '2 days')
+            """,
+            (iid,),
+        )
+        thesis_id = conn.execute(
+            """
+            INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance, memo_markdown,
+                                bear_value, base_value, bull_value, model, provider, prompt_version)
+            VALUES (%s, 2, 'value', 'buy', 'there is no recent news coverage.', 30, 20, 10, 'm', 'p', 'v4')
+            RETURNING thesis_id
+            """,
+            (iid,),
+        ).fetchone()[0]
+        conn.execute(
+            """
+            INSERT INTO thesis_runs (instrument_id, trigger, status, thesis_id, context_summary)
+            VALUES (%s, 'manual', 'ok', %s,
+                    '{"blocks": {"news": {"available": true, "count": 3},
+                                 "price_anchor": {"available": true, "as_of": "2026-07-01"}},
+                      "prompt_version": "v4"}'::jsonb)
+            """,
+            (iid, thesis_id),
+        )
+        conn.commit()
+        return thesis_id
+
+    def test_report_classes(self, conn) -> None:
+        from app.services.thesis_dq_audit import compute_thesis_dq_report
+
+        thesis_id = self._seed(conn)
+        report = compute_thesis_dq_report(conn)
+        assert report.scanned >= 1
+        by_class: dict[str, list] = {}
+        for f in report.findings:
+            if f.thesis_id == thesis_id:
+                by_class.setdefault(f.dq_class, []).append(f)
+        assert "ordering" in by_class
+        assert "zoneless_buy" in by_class
+        assert "claim_lint" in by_class
+        # base 20 vs anchor-date close 10 = 100% off -> flagged
+        assert "base_far_from_close" in by_class
+        # v1 (clean, ordered) row was NOT scanned — latest-per-instrument only.
+        assert report.class_counts["ordering"] == 1


### PR DESCRIPTION
Closes #2014

## What

Standing net for stored theses (#2007 guards are insert-time only; stored rows never re-validate). Read-only; findings are operator-triage candidates — no auto-regen (#2010 staleness path owns regeneration).

- `app/services/thesis_dq_audit.py`: pure predicates + `compute_thesis_dq_report` (latest thesis per instrument, API tiebreak `created_at DESC, thesis_version DESC, thesis_id DESC`; LATERAL-latest run join — `thesis_runs.thesis_id` is a nullable non-unique FK).
- `GET /theses/dq-audit` — compute-on-read on the authed theses router, registered BEFORE `/{instrument_id}` (typed int path param, no fall-through).
- Nightly `ScheduledJob thesis_dq_audit` (db lane, 05:12 UTC — deliberately not 5-min-aligned, #1707 tick-race class; `catch_up_on_boot=False`; `row_count` = total violations so /system/jobs + ops health surface the number with no new table).

Spec: `docs/proposals/thesis/2026-07-15-thesis-dq-audit.md`.

## Predicates (source-ruled, not invented)

| class | rule source |
|---|---|
| ordering / zone_inverted | #2007 `_validate_writer_output` semantics via the SAME `_to_float` chokepoint (NaN/±inf → None) |
| zoneless_buy | violation ONLY when the run's `price_anchor.available` is True — the writer prompt documents null zones when no anchor (`thesis.py` prompt rule); anchor-less/unknown exempt |
| base_far_from_close | vs close AT THE ANCHOR DATE (write-time sanity) — latest-close drift deliberately excluded (belongs to #2010) |
| claim_lint | memo unavailability claims vs the run's OWN `context_summary.blocks` (#2017, pre-LLM persisted) — the #1632/# 2007 "availability language must mirror block statuses" rule; ALL summarized blocks covered |
| stale_price_anchor | anchor as_of >7d older than `created_at` |
| target_abstention / no_run / no_context_summary / zoneless_buy_no_anchor | info counts, never findings rows |

Claim-lint precision tuned on the FULL dev population with three snippet-audit rounds (82 → 28 → 8 findings): word-bounded negation (bare `no` matched inside "noted"/"not supported"), ≤2-word negation-to-keyword gap (kills causal "unavailable due to a stale price anchor"), clause-bounded keyword-first window (never crosses `, ; .`). Residual FPs are qualitative ("no strong fundamentals") — accepted under candidate posture.

## Verification (dev, at caf01ea1/HEAD)

- Baseline: scanned **282**, total violations **160** — ordering 1, zone_inverted 0, zoneless_buy 0, base_far_from_close 6, claim_lint 8, stale_price_anchor 145, target_abstention 237 (info), no_context_summary 100 (pre-#2017 rows), no_run 0.
- Reconciles with the 2026-07-11 manual scan (27 theses): ordering 1 → still exactly 1; the 2 "zoneless buys" were anchor-less writes, now correctly exempt per the writer prompt's documented rule; abstention share ~74% → ~84% (same shape, population grew 27→282 with the T1 backfill).
- `stale_price_anchor` 145 is dominated by the dev-env stale-price artifact (eToro market data unreachable → `price_daily` old at write time) — true per predicate, expected to be rare on fresh-price data.
- Live endpoint verified: `GET /theses/dq-audit` returns the same report (snippet in PR checks).
- Claim-lint spot-audit of all 8 survivors: ~6 genuine fabrication candidates (e.g. EMAT "lack of fundamental data" with fundamentals available=True; BAND.US "no live fundamentals"; COHN "lack of price anchoring"), 2 qualitative boundary FPs.

Tests: 29 (28 pure predicate table-tests + 1 db-tier REAL-query drive — projection-gap class, prevention-log #2021 lesson). Registry + runtime triangle tests pass. `ruff` / `format` / `pyright` / fast tier / smoke all green.

## Security model

Endpoint rides the existing `require_session_or_service_token` router dependency; read-only; no user input beyond auth; SQL parameterised; no new tables.

## Tradeoffs (conscious)

- Claim-lint tolerates residual qualitative FPs rather than growing a phrase blocklist (candidate posture, operator triage).
- `stale_price_anchor` will read high on dev until market data is reachable in the loop env — documented, not suppressed.
- No FE panel: the audit family (manifest-parsers, cik-gaps) is API-only today; a shared DQ panel is a separate ticket if wanted.

## Codex

- Ckpt-1 (spec): 7 findings (mutable-close predicate, zoneless-buy prompt-rule exemption, claim-lint scope, tiebreak, non-unique run FK, absence-state split, baseline posture) — all fixed in spec before implementation.
- Ckpt-2 (diff): 2 findings (05:10 db-lane tick-race → 05:12; anchor-gated predicates ran before the summary gate) — fixed in `HEAD`.

## Operator runbook (post-merge)

Restart the VS Code jobs task when convenient — the new nightly job registers only on daemon restart. Nothing else; endpoint is live immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)