### PR TITLE
feat(#2013): re-thesis diff surface — structured what-changed vs prior version + alert feed

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -56,6 +56,7 @@ from app.db.snapshot import snapshot_read
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
 from app.services.scoring import _DEFAULT_MODEL_VERSION
 from app.services.thesis import find_stale_instruments
+from app.services.thesis_diff import compute_thesis_diff
 
 router = APIRouter(
     prefix="/alerts",
@@ -170,6 +171,27 @@ class RankMovesResponse(BaseModel):
 
 class RankMovesMarkSeenRequest(BaseModel):
     seen_through_rank_event_id: int = Field(gt=0)
+
+
+class ThesisChange(BaseModel):
+    thesis_id: int
+    instrument_id: int
+    symbol: str
+    thesis_version: int
+    created_at: datetime
+    summary: str
+    stance_from: str | None
+    stance_to: str | None
+
+
+class ThesisChangesResponse(BaseModel):
+    alerts_last_seen_thesis_change_id: int | None
+    unseen_count: int
+    changes: list[ThesisChange]
+
+
+class ThesisChangesMarkSeenRequest(BaseModel):
+    seen_through_thesis_id: int = Field(gt=0)
 
 
 class ThesisStalenessItem(BaseModel):
@@ -679,6 +701,158 @@ def mark_rank_moves_seen(
             {
                 **params,
                 "seen_through_rank_event_id": body.seen_through_rank_event_id,
+                "op": operator_id,
+            },
+        )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# #2013 — thesis-change alert feed (a thesis regenerated with a MATERIAL
+# change vs its prior version)
+#
+#   GET  /alerts/thesis-changes
+#   POST /alerts/thesis-changes/seen     (body: {seen_through_thesis_id})
+#
+# Same cursor semantics as the rank-move feed: BIGSERIAL cursor
+# (theses.thesis_id), strict '>' comparison, GREATEST+COALESCE monotonicity,
+# LEAST clamp on /seen, m.max_id IS NOT NULL empty-window guard. Window =
+# 14 days (thesis cadence is slower than scoring's 7-day rank window).
+#
+# The MATERIALITY predicate deliberately lives in Python
+# (thesis_diff.compute_thesis_diff — the same single source the theses API
+# and the library summary use), NOT in the SQL fragment: duplicating the
+# stance/null-transition/≥5%-move logic in SQL is exactly the predicate
+# drift the prevention log warns about. Consequences, both accepted:
+#   1. GET scans every windowed version>1 pair and filters in Python. Cheap
+#      by construction — theses holds 325 rows total on dev and regen
+#      throughput is ≤5/hour, so the window is dozens of pairs, not
+#      thousands. The response list cap (50) applies AFTER materiality;
+#      unseen_count is computed over ALL material windowed pairs, never
+#      truncated (Codex ckpt-1 finding 1).
+#   2. /seen's LEAST clamp bounds against MAX(thesis_id) over the SQL
+#      window WITHOUT materiality (SQL can't compute it). A cursor may
+#      therefore advance past a non-material id — harmless: non-material
+#      changes never surface and unseen_count only counts material ids
+#      above the cursor.
+# Predecessor pairing is an explicit version-1 self-join (versions are
+# unique per instrument); memo/break columns are omitted — the feed needs
+# stance/type/target materiality + the compact summary, not section diffs.
+# ---------------------------------------------------------------------------
+
+_THESIS_CHANGE_WINDOW_WHERE = """
+    t.thesis_version > 1
+    AND t.created_at >= now() - INTERVAL '14 days'
+"""
+
+_THESIS_CHANGES_LIST_CAP = 50
+
+_THESIS_CHANGE_DIFF_FIELDS = (
+    "stance",
+    "thesis_type",
+    "confidence_score",
+    "buy_zone_low",
+    "buy_zone_high",
+    "base_value",
+    "bull_value",
+    "bear_value",
+)
+
+
+@router.get("/thesis-changes", response_model=ThesisChangesResponse)
+def get_thesis_changes(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ThesisChangesResponse:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT alerts_last_seen_thesis_change_id FROM operators WHERE operator_id = %(op)s",
+            {"op": operator_id},
+        )
+        op_row = cur.fetchone()
+        last_seen: int | None = op_row["alerts_last_seen_thesis_change_id"] if op_row else None
+
+        prev_cols = ",\n                ".join(f"p.{f} AS prev_{f}" for f in _THESIS_CHANGE_DIFF_FIELDS)
+        curr_cols = ",\n                ".join(f"t.{f}" for f in _THESIS_CHANGE_DIFF_FIELDS)
+        cur.execute(
+            f"""
+            SELECT
+                t.thesis_id, t.instrument_id, i.symbol, t.thesis_version,
+                t.created_at,
+                {curr_cols},
+                {prev_cols}
+            FROM theses t
+            JOIN theses p
+              ON p.instrument_id = t.instrument_id
+             AND p.thesis_version = t.thesis_version - 1
+            JOIN instruments i ON i.instrument_id = t.instrument_id
+            WHERE {_THESIS_CHANGE_WINDOW_WHERE}
+            ORDER BY t.thesis_id DESC
+            """,
+        )
+        rows = cur.fetchall()
+
+    changes: list[ThesisChange] = []
+    unseen_count = 0
+    for row in rows:
+        curr = {f: row[f] for f in _THESIS_CHANGE_DIFF_FIELDS}
+        prev = {f: row[f"prev_{f}"] for f in _THESIS_CHANGE_DIFF_FIELDS}
+        version = int(row["thesis_version"])  # type: ignore[arg-type]
+        curr["thesis_version"], prev["thesis_version"] = version, version - 1
+        diff = compute_thesis_diff(prev, curr)
+        if not diff.material:
+            continue
+        thesis_id = int(row["thesis_id"])  # type: ignore[arg-type]
+        if last_seen is None or thesis_id > last_seen:
+            unseen_count += 1
+        if len(changes) < _THESIS_CHANGES_LIST_CAP:
+            changes.append(
+                ThesisChange(
+                    thesis_id=thesis_id,
+                    instrument_id=int(row["instrument_id"]),  # type: ignore[arg-type]
+                    symbol=str(row["symbol"]),
+                    thesis_version=version,
+                    created_at=row["created_at"],  # type: ignore[arg-type]
+                    summary=diff.summary,
+                    stance_from=diff.stance.from_value if diff.stance else None,
+                    stance_to=diff.stance.to_value if diff.stance else None,
+                )
+            )
+
+    return ThesisChangesResponse(
+        alerts_last_seen_thesis_change_id=last_seen,
+        unseen_count=unseen_count,
+        changes=changes,
+    )
+
+
+@router.post("/thesis-changes/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_thesis_changes_seen(
+    body: ThesisChangesMarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        # m.max_id IS NOT NULL guard preserves NULL cursor on empty window
+        # (coverage/position /seen shape). Clamp bound is the SQL window max
+        # WITHOUT materiality — see the section comment, consequence 2.
+        cur.execute(
+            f"""
+            UPDATE operators AS op
+            SET alerts_last_seen_thesis_change_id = GREATEST(
+                COALESCE(op.alerts_last_seen_thesis_change_id, 0),
+                LEAST(%(seen_through_thesis_id)s, m.max_id)
+            )
+            FROM (
+                SELECT MAX(t.thesis_id) AS max_id
+                FROM theses t
+                WHERE {_THESIS_CHANGE_WINDOW_WHERE}
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {
+                "seen_through_thesis_id": body.seen_through_thesis_id,
                 "op": operator_id,
             },
         )

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -18,6 +18,7 @@ has ``confidence_score``.  This module uses the actual schema column name.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from datetime import UTC, datetime, timedelta
 
@@ -32,6 +33,7 @@ from app.services.llm_client import LLMClientPair, LLMProviderNotConfigured, mak
 from app.services.runtime_config import RuntimeConfigCorrupt
 from app.services.scoring import _DEFAULT_MODEL_VERSION
 from app.services.thesis import find_stale_instruments, generate_thesis
+from app.services.thesis_diff import compute_thesis_diff
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +83,55 @@ MAX_PAGE_LIMIT = 200
 # ---------------------------------------------------------------------------
 
 
+class FieldChangeModel(BaseModel):
+    from_value: str | None
+    to_value: str | None
+
+
+class ConfidenceChangeModel(BaseModel):
+    from_value: float | None
+    to_value: float | None
+    delta: float | None
+
+
+class TargetChangeModel(BaseModel):
+    field: str
+    from_value: float | None
+    to_value: float | None
+    kind: str  # added | removed | moved (thesis_diff.TargetChange contract)
+    rel_move: float | None
+
+
+class ThesisDiffModel(BaseModel):
+    """Structured what-changed vs the prior version (#2013).
+
+    Mirrors ``app.services.thesis_diff.ThesisDiff`` 1:1 — the diff (and its
+    materiality predicate) is computed on read from the two append-only rows,
+    never stored.
+    """
+
+    prev_version: int
+    curr_version: int
+    stance: FieldChangeModel | None
+    thesis_type: FieldChangeModel | None
+    confidence: ConfidenceChangeModel | None
+    targets: list[TargetChangeModel]
+    break_conditions_added: list[str]
+    break_conditions_removed: list[str]
+    memo_sections_added: list[str]
+    memo_sections_removed: list[str]
+    memo_sections_changed: list[str]
+    prompt_version: FieldChangeModel | None
+    model: FieldChangeModel | None
+    material: bool
+    summary: str
+
+
+def _diff_model(prev_row: dict[str, object], curr_row: dict[str, object]) -> ThesisDiffModel:
+    """Compute the pure diff and lift it into the response model."""
+    return ThesisDiffModel.model_validate(dataclasses.asdict(compute_thesis_diff(prev_row, curr_row)))
+
+
 class ThesisDetail(BaseModel):
     """Single thesis row with all columns including critic output.
 
@@ -115,6 +166,9 @@ class ThesisDetail(BaseModel):
     provider: str | None = None
     is_stale: bool | None = None
     stale_reason: str | None = None
+    # #2013 — diff vs the (instrument_id, thesis_version - 1) predecessor.
+    # None when thesis_version == 1 or the predecessor row is missing.
+    diff: ThesisDiffModel | None = None
 
 
 class ThesisHistoryResponse(BaseModel):
@@ -167,6 +221,11 @@ class ThesisLibraryItem(BaseModel):
     run_error: str | None
     run_trigger: str | None
     run_started_at: datetime | None
+    # #2013 — compact field-level what-changed vs the predecessor version
+    # (stance/type/target moves only; no memo compare on the list path).
+    # None/False when the latest thesis is v1 or the predecessor is missing.
+    last_change_summary: str | None = None
+    last_change_material: bool = False
 
 
 class ThesisLibraryResponse(BaseModel):
@@ -220,6 +279,37 @@ _THESIS_COLUMNS = """
     t.break_conditions_json, t.memo_markdown, t.critic_json,
     t.created_at, t.prompt_version, t.model, t.provider
 """
+
+
+def _fetch_diffs(
+    conn: psycopg.Connection[object],
+    instrument_id: int,
+    rows: list[dict[str, object]],
+) -> dict[int, ThesisDiffModel]:
+    """thesis_id → diff vs predecessor, for one instrument's thesis rows.
+
+    Predecessors are fetched by an explicit ``thesis_version - 1`` lookup
+    (NOT page adjacency — the ``created_at DESC`` page order does not
+    guarantee version contiguity). Rows at version 1, or whose predecessor
+    row is missing, simply have no entry.
+    """
+    wanted = {int(r["thesis_version"]) - 1: r for r in rows if int(r["thesis_version"]) > 1}  # type: ignore[arg-type]
+    if not wanted:
+        return {}
+    sql = f"""
+        SELECT {_THESIS_COLUMNS}
+        FROM theses t
+        WHERE t.instrument_id = %(instrument_id)s
+          AND t.thesis_version = ANY(%(versions)s)
+    """  # safe: _THESIS_COLUMNS is a module-level constant, not user input
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, {"instrument_id": instrument_id, "versions": list(wanted)})
+        predecessors = {int(p["thesis_version"]): p for p in cur.fetchall()}  # type: ignore[arg-type]
+    return {
+        int(curr["thesis_id"]): _diff_model(predecessors[version], curr)  # type: ignore[arg-type]
+        for version, curr in wanted.items()
+        if version in predecessors
+    }
 
 
 def _critic_verdict(critic_json: object) -> str | None:
@@ -303,6 +393,7 @@ _LIBRARY_SQL = """
     SELECT
         t.thesis_id, t.instrument_id, t.thesis_version, t.thesis_type,
         t.stance, t.confidence_score, t.buy_zone_low, t.buy_zone_high,
+        t.base_value, t.bull_value, t.bear_value,
         t.critic_json, t.created_at,
         i.symbol, i.company_name,
         EXISTS (
@@ -315,11 +406,21 @@ _LIBRARY_SQL = """
         r.status      AS run_status,
         r.error       AS run_error,
         r.trigger     AS run_trigger,
-        r.started_at  AS run_started_at
+        r.started_at  AS run_started_at,
+        pv.thesis_id  AS prev_thesis_id,
+        pv.stance     AS prev_stance,
+        pv.thesis_type AS prev_thesis_type,
+        pv.confidence_score AS prev_confidence_score,
+        pv.buy_zone_low  AS prev_buy_zone_low,
+        pv.buy_zone_high AS prev_buy_zone_high,
+        pv.base_value    AS prev_base_value,
+        pv.bull_value    AS prev_bull_value,
+        pv.bear_value    AS prev_bear_value
     FROM (
         SELECT DISTINCT ON (instrument_id)
             thesis_id, instrument_id, thesis_version, thesis_type,
             stance, confidence_score, buy_zone_low, buy_zone_high,
+            base_value, bull_value, bear_value,
             critic_json, created_at
         FROM theses
         ORDER BY instrument_id, created_at DESC, thesis_version DESC
@@ -340,6 +441,18 @@ _LIBRARY_SQL = """
         ORDER BY r.started_at DESC, r.run_id DESC
         LIMIT 1
     ) r ON TRUE
+    -- #2013: predecessor row by explicit version-1 lookup (unique per
+    -- instrument via UNIQUE(instrument_id, thesis_version)); memo/break
+    -- columns deliberately omitted — the library summary is field-level
+    -- only, the full diff lives on the per-instrument endpoints.
+    LEFT JOIN LATERAL (
+        SELECT p.thesis_id, p.stance, p.thesis_type, p.confidence_score,
+               p.buy_zone_low, p.buy_zone_high,
+               p.base_value, p.bull_value, p.bear_value
+        FROM theses p
+        WHERE p.instrument_id = t.instrument_id
+          AND p.thesis_version = t.thesis_version - 1
+    ) pv ON TRUE
     ORDER BY t.created_at DESC, t.thesis_id DESC
 """
 
@@ -358,6 +471,9 @@ _HELD_NO_THESIS_SQL = """
         NULL::numeric     AS confidence_score,
         NULL::numeric     AS buy_zone_low,
         NULL::numeric     AS buy_zone_high,
+        NULL::numeric     AS base_value,
+        NULL::numeric     AS bull_value,
+        NULL::numeric     AS bear_value,
         NULL::jsonb       AS critic_json,
         NULL::timestamptz AS created_at,
         i.symbol, i.company_name,
@@ -367,7 +483,16 @@ _HELD_NO_THESIS_SQL = """
         r.status      AS run_status,
         r.error       AS run_error,
         r.trigger     AS run_trigger,
-        r.started_at  AS run_started_at
+        r.started_at  AS run_started_at,
+        NULL::bigint  AS prev_thesis_id,
+        NULL::text    AS prev_stance,
+        NULL::text    AS prev_thesis_type,
+        NULL::numeric AS prev_confidence_score,
+        NULL::numeric AS prev_buy_zone_low,
+        NULL::numeric AS prev_buy_zone_high,
+        NULL::numeric AS prev_base_value,
+        NULL::numeric AS prev_bull_value,
+        NULL::numeric AS prev_bear_value
     FROM instruments i
     LEFT JOIN LATERAL (
         SELECT s.total_score, s.rank
@@ -395,6 +520,37 @@ _HELD_NO_THESIS_SQL = """
           )
     ORDER BY i.symbol
 """
+
+
+# Value fields forwarded from a library row into the diff module. Field-level
+# only (no memo/break columns on the list path — see _LIBRARY_SQL comment).
+_LIBRARY_DIFF_FIELDS = (
+    "stance",
+    "thesis_type",
+    "confidence_score",
+    "buy_zone_low",
+    "buy_zone_high",
+    "base_value",
+    "bull_value",
+    "bear_value",
+)
+
+
+def _library_change_fields(row: dict[str, object]) -> tuple[str | None, bool]:
+    """(last_change_summary, last_change_material) for one library row (#2013).
+
+    (None, False) for v1 / gap rows / missing predecessor. The materiality
+    predicate + summary come from the shared ``thesis_diff`` module — never
+    re-derived here.
+    """
+    if row.get("prev_thesis_id") is None or row.get("thesis_version") is None:
+        return None, False
+    version = int(row["thesis_version"])  # type: ignore[arg-type]
+    curr: dict[str, object] = {f: row.get(f) for f in _LIBRARY_DIFF_FIELDS}
+    prev: dict[str, object] = {f: row.get(f"prev_{f}") for f in _LIBRARY_DIFF_FIELDS}
+    curr["thesis_version"], prev["thesis_version"] = version, version - 1
+    diff = compute_thesis_diff(prev, curr)
+    return diff.summary or None, diff.material
 
 
 @router.get("", response_model=ThesisLibraryResponse)
@@ -444,9 +600,12 @@ def list_theses(
         limit=limit,
     )
 
+    change_fields = [_library_change_fields(row) for row in page]
     items = [
         ThesisLibraryItem(
             instrument_id=row["instrument_id"],  # type: ignore[arg-type]
+            last_change_summary=change_fields[idx][0],
+            last_change_material=change_fields[idx][1],
             symbol=row["symbol"],  # type: ignore[arg-type]
             company_name=row["company_name"],  # type: ignore[arg-type]
             thesis_id=row["thesis_id"],  # type: ignore[arg-type]
@@ -467,7 +626,7 @@ def list_theses(
             run_trigger=row["run_trigger"],  # type: ignore[arg-type]
             run_started_at=row["run_started_at"],  # type: ignore[arg-type]
         )
-        for row in page
+        for idx, row in enumerate(page)
     ]
     return ThesisLibraryResponse(items=items, total=total, offset=offset, limit=limit)
 
@@ -565,6 +724,7 @@ def get_latest_thesis(
             return None
 
     thesis = _parse_thesis(row)
+    thesis.diff = _fetch_diffs(conn, instrument_id, [row]).get(int(row["thesis_id"]))  # type: ignore[arg-type]
     # Staleness single-source (#1902): the FE used to duplicate a 30-day
     # constant; the canonical predicate is find_stale_instruments
     # (coverage cadence + #273 filing-event triggers). reason=None means
@@ -637,7 +797,10 @@ def get_thesis_history(
         cur.execute(data_sql, data_params)
         rows = cur.fetchall()
 
+    diffs = _fetch_diffs(conn, instrument_id, rows)
     items = [_parse_thesis(r) for r in rows]
+    for item in items:
+        item.diff = diffs.get(item.thesis_id)
     return ThesisHistoryResponse(
         instrument_id=instrument_id,
         items=items,

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from datetime import UTC, datetime, timedelta
+from typing import Literal
 
 import psycopg
 import psycopg.rows
@@ -98,7 +99,9 @@ class TargetChangeModel(BaseModel):
     field: str
     from_value: float | None
     to_value: float | None
-    kind: str  # added | removed | moved (thesis_diff.TargetChange contract)
+    # Closed set emitted by thesis_diff._target_changes — code-constrained,
+    # not open JSON, so a response Literal is safe here (#1808 carve-out).
+    kind: Literal["added", "removed", "moved"]
     rel_move: float | None
 
 
@@ -128,7 +131,13 @@ class ThesisDiffModel(BaseModel):
 
 
 def _diff_model(prev_row: dict[str, object], curr_row: dict[str, object]) -> ThesisDiffModel:
-    """Compute the pure diff and lift it into the response model."""
+    """Compute the pure diff and lift it into the response model.
+
+    COUPLING: ``ThesisDiffModel`` (and its nested models) must mirror
+    ``thesis_diff.ThesisDiff`` field-for-field — ``dataclasses.asdict``
+    round-trips by exact name. Renaming a field in one without the other
+    fails model_validate at request time, not at import time.
+    """
     return ThesisDiffModel.model_validate(dataclasses.asdict(compute_thesis_diff(prev_row, curr_row)))
 
 

--- a/app/services/thesis_diff.py
+++ b/app/services/thesis_diff.py
@@ -1,0 +1,286 @@
+"""Pure structured diff between two consecutive thesis versions (#2013).
+
+``theses`` is append-only and versioned by insert (settled-decisions "Thesis
+semantics"), so the diff of version N vs N-1 is a pure function of two
+immutable rows — computed on read, never stored. Callers pair rows via an
+explicit ``(instrument_id, thesis_version - 1)`` join; a missing predecessor
+means "no diff", never an error.
+
+Null semantics follow #2007: a NULL target is an *abstention*, so null↔value
+transitions are first-class ``added``/``removed`` events, never numeric moves
+from/to zero.
+
+The materiality predicate lives ONLY here (single source — the alert feed,
+the library summary and the pane all call this module; SQL only pairs rows).
+Full-population verification (dev 2026-07-15, all 43 N>1 pairs): the
+predicate marks 22 pairs material — identical to the 22 with ANY field
+change; all 21 observed numeric moves are ≥5% (median 50%), so the threshold
+loses nothing today and only guards future small-jitter regens (#2010).
+
+Pure: no DB, no I/O, no imports from ``thesis`` (no cycle).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+# A numeric target/zone move below this relative magnitude is not material
+# on its own (full-pop verified: zero current events fall under it).
+_MATERIAL_REL_MOVE = 0.05
+
+# Diffed value fields, in render order. Keep in sync with the theses columns
+# consumed by _validate_writer_output (app/services/thesis.py).
+_TARGET_FIELDS: tuple[str, ...] = (
+    "buy_zone_low",
+    "buy_zone_high",
+    "base_value",
+    "bull_value",
+    "bear_value",
+)
+
+# Compact display labels for summary strings.
+_FIELD_LABELS: dict[str, str] = {
+    "buy_zone_low": "zone low",
+    "buy_zone_high": "zone high",
+    "base_value": "base",
+    "bull_value": "bull",
+    "bear_value": "bear",
+}
+
+# Memo bodies with no ### heading fall into one pseudo-section so heading-less
+# memos (15/325 on dev) still diff as a unit.
+_PREAMBLE_SECTION = "(body)"
+
+_HEADING_RE = re.compile(r"^###\s+(.*\S)\s*$")
+
+
+@dataclass(frozen=True)
+class FieldChange:
+    """One changed enum/string field: stance, thesis_type, prompt_version, model."""
+
+    from_value: str | None
+    to_value: str | None
+
+
+@dataclass(frozen=True)
+class ConfidenceChange:
+    from_value: float | None
+    to_value: float | None
+    delta: float | None  # None when either side is None
+
+
+@dataclass(frozen=True)
+class TargetChange:
+    """One changed numeric target/zone field.
+
+    ``kind``: 'added' (null→value), 'removed' (value→null), 'moved'
+    (value→different value). ``rel_move`` = |new−old|/|old|; None unless
+    kind == 'moved' with a nonzero old value.
+    """
+
+    field: str
+    from_value: float | None
+    to_value: float | None
+    kind: str
+    rel_move: float | None
+
+
+@dataclass(frozen=True)
+class ThesisDiff:
+    prev_version: int
+    curr_version: int
+    stance: FieldChange | None
+    thesis_type: FieldChange | None
+    confidence: ConfidenceChange | None
+    targets: tuple[TargetChange, ...]
+    break_conditions_added: tuple[str, ...]
+    break_conditions_removed: tuple[str, ...]
+    memo_sections_added: tuple[str, ...]
+    memo_sections_removed: tuple[str, ...]
+    memo_sections_changed: tuple[str, ...]
+    prompt_version: FieldChange | None = None
+    model: FieldChange | None = None
+    material: bool = False
+    summary: str = ""
+
+
+def _num(value: object) -> float | None:
+    """Nullable DB numeric (Decimal | float | int | None) → float | None."""
+    if value is None:
+        return None
+    return float(value)  # type: ignore[arg-type]
+
+
+def _str_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _fmt(value: float) -> str:
+    """Compact number for summary strings: trim trailing zeros."""
+    return f"{value:g}"
+
+
+def _target_changes(prev: Mapping[str, object], curr: Mapping[str, object]) -> tuple[TargetChange, ...]:
+    changes: list[TargetChange] = []
+    for name in _TARGET_FIELDS:
+        old = _num(prev.get(name))
+        new = _num(curr.get(name))
+        if old is None and new is None:
+            continue
+        if old is None:
+            changes.append(TargetChange(name, None, new, "added", None))
+        elif new is None:
+            changes.append(TargetChange(name, old, None, "removed", None))
+        elif new != old:
+            rel = abs(new - old) / abs(old) if old != 0 else None
+            changes.append(TargetChange(name, old, new, "moved", rel))
+    return tuple(changes)
+
+
+def _normalize_condition(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+def _break_condition_diff(
+    prev: Mapping[str, object], curr: Mapping[str, object]
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Set diff on normalized condition strings; originals kept for display."""
+
+    def conditions(row: Mapping[str, object]) -> list[str]:
+        raw = row.get("break_conditions_json")
+        if not isinstance(raw, list):
+            return []
+        return [item for item in raw if isinstance(item, str)]
+
+    prev_list, curr_list = conditions(prev), conditions(curr)
+    prev_keys = {_normalize_condition(c) for c in prev_list}
+    curr_keys = {_normalize_condition(c) for c in curr_list}
+    added = tuple(c for c in curr_list if _normalize_condition(c) not in prev_keys)
+    removed = tuple(c for c in prev_list if _normalize_condition(c) not in curr_keys)
+    return added, removed
+
+
+def _split_sections(memo: str) -> dict[str, str]:
+    """memo_markdown → {heading: whitespace-normalized body}.
+
+    Splits on ###-prefixed heading lines (the only level the writer emits —
+    full-pop survey 2026-07-15: 942/942 headings). Duplicate headings within
+    one memo are collapsed (bodies concatenated) so heading text is a unique
+    key — 0 duplicates exist on dev; this is a guard. Content before the
+    first heading (or a heading-less memo) becomes the ``(body)``
+    pseudo-section; an empty preamble is dropped.
+    """
+    sections: dict[str, list[str]] = {}
+    current = _PREAMBLE_SECTION
+    for line in memo.splitlines():
+        match = _HEADING_RE.match(line)
+        if match:
+            current = match.group(1)
+            sections.setdefault(current, [])
+        else:
+            sections.setdefault(current, []).append(line)
+    normalized = {heading: " ".join(" ".join(lines).split()) for heading, lines in sections.items()}
+    if normalized.get(_PREAMBLE_SECTION) == "":
+        del normalized[_PREAMBLE_SECTION]
+    return normalized
+
+
+def _memo_section_diff(
+    prev: Mapping[str, object], curr: Mapping[str, object]
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    prev_sections = _split_sections(str(prev.get("memo_markdown") or ""))
+    curr_sections = _split_sections(str(curr.get("memo_markdown") or ""))
+    added = tuple(h for h in curr_sections if h not in prev_sections)
+    removed = tuple(h for h in prev_sections if h not in curr_sections)
+    changed = tuple(h for h in curr_sections if h in prev_sections and curr_sections[h] != prev_sections[h])
+    return added, removed, changed
+
+
+def _string_change(prev: Mapping[str, object], curr: Mapping[str, object], key: str) -> FieldChange | None:
+    old, new = _str_or_none(prev.get(key)), _str_or_none(curr.get(key))
+    if old == new:
+        return None
+    return FieldChange(from_value=old, to_value=new)
+
+
+def _summary(
+    stance: FieldChange | None,
+    thesis_type: FieldChange | None,
+    targets: tuple[TargetChange, ...],
+) -> str:
+    """Deterministic one-liner over the material-class fields.
+
+    Confidence, break conditions, memo sections and provenance never appear:
+    they never make a diff material, and the pane's expandable detail carries
+    them.
+    """
+    parts: list[str] = []
+    if stance is not None:
+        parts.append(f"stance {stance.from_value}→{stance.to_value}")
+    if thesis_type is not None:
+        parts.append(f"type {thesis_type.from_value}→{thesis_type.to_value}")
+    for t in targets:
+        label = _FIELD_LABELS[t.field]
+        if t.kind == "added":
+            assert t.to_value is not None
+            parts.append(f"{label} added ({_fmt(t.to_value)})")
+        elif t.kind == "removed":
+            parts.append(f"{label} removed")
+        else:
+            assert t.from_value is not None and t.to_value is not None
+            move = ""
+            if t.rel_move is not None:
+                signed = (t.to_value - t.from_value) / abs(t.from_value)
+                move = f" ({signed:+.0%})"
+            parts.append(f"{label} {_fmt(t.from_value)}→{_fmt(t.to_value)}{move}")
+    return " · ".join(parts)
+
+
+def compute_thesis_diff(prev: Mapping[str, object], curr: Mapping[str, object]) -> ThesisDiff:
+    """Structured diff of thesis row ``curr`` vs its predecessor ``prev``.
+
+    Both mappings carry the theses columns (stance, thesis_type,
+    confidence_score, the five target/zone fields, break_conditions_json,
+    memo_markdown, thesis_version, and optionally prompt_version / model).
+    Numeric values may be Decimal (raw DB row) or float (parsed API row).
+    """
+    stance = _string_change(prev, curr, "stance")
+    thesis_type = _string_change(prev, curr, "thesis_type")
+
+    old_conf, new_conf = _num(prev.get("confidence_score")), _num(curr.get("confidence_score"))
+    confidence: ConfidenceChange | None = None
+    if old_conf != new_conf:
+        delta = (new_conf - old_conf) if old_conf is not None and new_conf is not None else None
+        confidence = ConfidenceChange(from_value=old_conf, to_value=new_conf, delta=delta)
+
+    targets = _target_changes(prev, curr)
+    bc_added, bc_removed = _break_condition_diff(prev, curr)
+    memo_added, memo_removed, memo_changed = _memo_section_diff(prev, curr)
+
+    # Material: stance/type change, any target null-transition, any move ≥5%,
+    # or a move from a zero base (unbounded relative move — treat as material).
+    material = (
+        stance is not None
+        or thesis_type is not None
+        or any(t.kind != "moved" or t.rel_move is None or t.rel_move >= _MATERIAL_REL_MOVE for t in targets)
+    )
+
+    return ThesisDiff(
+        prev_version=int(prev["thesis_version"]),  # type: ignore[arg-type]
+        curr_version=int(curr["thesis_version"]),  # type: ignore[arg-type]
+        stance=stance,
+        thesis_type=thesis_type,
+        confidence=confidence,
+        targets=targets,
+        break_conditions_added=bc_added,
+        break_conditions_removed=bc_removed,
+        memo_sections_added=memo_added,
+        memo_sections_removed=memo_removed,
+        memo_sections_changed=memo_changed,
+        prompt_version=_string_change(prev, curr, "prompt_version"),
+        model=_string_change(prev, curr, "model"),
+        material=material,
+        summary=_summary(stance, thesis_type, targets),
+    )

--- a/docs/specs/thesis/2026-07-15-rethesis-diff-surface.md
+++ b/docs/specs/thesis/2026-07-15-rethesis-diff-surface.md
@@ -1,0 +1,166 @@
+# Re-thesis diff surface — structured what-changed vs prior version + alert (#2013)
+
+**Status:** spec (pre-implementation). **Issue:** #2013. **Related:** #1902 (theses library,
+shipped), #1988 (regen triggers, open — orthogonal, see Source rule), #2010 (prompt v3 — will
+mint many N>1 versions; this surface pays immediately when it lands), #2017 (context audit,
+merged — unblocked this).
+
+## Source rule
+
+No SEC/external data treatment — every input is an already-persisted internal surface. Governing
+internal contracts:
+
+- **settled-decisions "Thesis semantics" (:143-185):** theses are append-only, versioned by
+  insert, never overwritten. Therefore `diff(N, N-1)` is a **pure function of two immutable
+  rows** → computed on read, never stored. No second copy of truth, no backfill, and it works
+  retroactively for every existing N>1 pair (43 on dev today).
+- **#2007 field semantics (PR #2008):** `_to_float` keeps NULL as None — a NULL target is an
+  *abstention*, never 0. Diff must treat null↔value transitions as first-class events
+  (`added`/`removed`), not as numeric moves from/to zero.
+- **Alert-feed precedent (sql/044/045/047/213 + `app/api/alerts.py`):** the repo has exactly two
+  alert shapes — (a) *standing condition*, computed on read, clears when the condition resolves
+  (`/alerts/thesis-staleness`); (b) *event feed*, cursored on a BIGSERIAL id with
+  `operators.alerts_last_seen_<x>_id` mark-seen (decisions, position alerts, coverage events,
+  rank-moves). A thesis change is a discrete post-generation **fact** — it does not "resolve" —
+  so it is shape (b), cursored on `theses.thesis_id` (BIGSERIAL PK, insert-ordered). This
+  answers the issue's "decide in spec vs #1988": #1988 is about *pre-generation regen triggers*
+  (when data changes, regenerate); #2013 alerts are *post-generation facts* (regen happened,
+  here is what moved). Orthogonal; no shared semantics to reconcile.
+- **Version pairing:** `_insert_thesis_atomic` computes `thesis_version` as
+  `COALESCE(MAX(thesis_version),0)+1` under `UNIQUE(instrument_id, thesis_version)`. The design
+  does NOT assume gaplessness or timestamp ordering: every predecessor lookup is an explicit
+  join on `(instrument_id, thesis_version - 1)` per row; a missing predecessor yields
+  `diff = None`, never an error.
+
+## Full-population verification (dev, 2026-07-15)
+
+All 43 existing N>1 pairs scanned (join on `thesis_version - 1`):
+
+| signal                                  | count                                               |
+| --------------------------------------- | --------------------------------------------------- |
+| stance change                           | 14                                                  |
+| thesis_type change                      | 3                                                   |
+| any target/zone change                  | 17                                                  |
+| null-transition (target added/removed)  | 12                                                  |
+| numeric moves (n=21)                    | **all ≥5%**; median 50%, p25 20%, p75 70%, max 180% |
+
+The EXACT design predicate — **stance change OR thesis_type change OR null-transition OR
+relative move ≥5%** — was run verbatim on all 43 pairs: **22 material, identical to the 22
+pairs with ANY field change**. Zero events lost; the 5% threshold guards against future
+small-jitter regens once #2010 v3 starts minting versions. thesis_type is in the predicate by
+design (a type reclassification is material per se); it changes alone in 0 current pairs.
+
+Memo survey, FULL population (all 325 memos): writer emits `###`-level headings only
+(942 headings, no other level), **0 memos with duplicate headings**, 15 memos with NO headings
+at all. Heading TEXT drifts between generations ("Valuation & Fair Value Context" vs
+"Valuation & Technical Analysis") → memo section diff is **informational only**, never part of
+the material predicate.
+
+## Design
+
+### 1. Pure diff module — `app/services/thesis_diff.py` (no DB, no LLM)
+
+Pattern sibling of `thesis_context_audit.py` (#2017). One entry point:
+
+```python
+compute_thesis_diff(prev: Mapping, curr: Mapping) -> ThesisDiff
+```
+
+`ThesisDiff` (dataclass → dict for JSON):
+
+- `stance: {from, to} | None` — set when changed.
+- `thesis_type: {from, to} | None`.
+- `confidence: {from, to, delta} | None` — when changed (either side may be None).
+- `targets: list[{field, from, to, rel_move | None, kind}]` — one entry per changed field among
+  `buy_zone_low/high`, `base_value`, `bull_value`, `bear_value`; `kind ∈ added|removed|moved`
+  (null-transition vs numeric move); `rel_move = |new−old|/|old|` (None when old is 0/None).
+- `break_conditions: {added: [str], removed: [str]}` — set diff on whitespace-normalized,
+  case-folded condition strings from `break_conditions_json`.
+- `memo_sections: {added: [str], removed: [str], changed: [str]}` — split `memo_markdown` on
+  `###`-prefixed heading lines; `changed` = same heading text, different whitespace-normalized
+  body.
+  Duplicate headings within one memo are collapsed (bodies concatenated) so heading text is a
+  unique key — 0 duplicates exist in the full population, this is a guard, not a feature. A
+  memo with no headings (15/325 exist) is treated as one pseudo-section `"(body)"`.
+  Informational only.
+- `provenance: {prompt_version: {from,to} | None, model: {from,to} | None}`.
+- `material: bool` — stance changed OR thesis_type changed OR any target `kind != moved` OR any
+  `rel_move ≥ _MATERIAL_REL_MOVE` (module constant, `0.05`). Confidence/memo/provenance never
+  make a diff material.
+- `summary: str` — deterministic compact one-liner built from the material fields
+  (e.g. `"stance buy→hold · base 120→98 (−18%) · bear target removed"`); empty-string when
+  nothing changed. This is the v1 "one-liner"; the issue's optional LLM one-liner is
+  **descoped** (deterministic string is sufficient and free; revisit post-#2010 if operator
+  wants prose).
+
+The material predicate lives ONLY here — SQL pairs rows, Python decides. No dual predicate to
+drift.
+
+### 2. API
+
+- **`GET /theses/{instrument_id}`** (`ThesisDetail`): new `diff: ThesisDiffModel | None` — None
+  when `thesis_version == 1`. Implementation: when version > 1, fetch the `version - 1` row and
+  call the module.
+- **`GET /theses/{instrument_id}/history`**: each item gains the same `diff` field, paired
+  against its predecessor via an explicit `(instrument_id, thesis_version - 1)` join per row
+  (LATERAL) — NOT page adjacency, which the `created_at DESC` ordering does not guarantee.
+- **`GET /theses`** (library, `ThesisLibraryItem`): new `last_change_summary: str | None` +
+  `last_change_material: bool` — field-level summary only (no memo section compare on the list
+  path). Prior row via `LEFT JOIN LATERAL` on `(instrument_id, thesis_version - 1)`; NULL →
+  summary None, material false.
+- **`GET /alerts/thesis-changes`** (rank-moves semantics exactly): window = ALL pairs with
+  `curr.thesis_version > 1 AND curr.created_at >= now() - interval '14 days'`; every windowed
+  pair is diffed in Python and filtered to `material` — the cap (50) applies to the RESPONSE
+  list only, AFTER materiality, newest first; `unseen_count` = count of material windowed
+  changes with `thesis_id > COALESCE(alerts_last_seen_thesis_change_id, 0)` (never truncated
+  by the list cap). Scanning the full window is cheap: `theses` holds 325 rows total today and
+  regen throughput is ≤5/hour. Response: `{alerts_last_seen_thesis_change_id, unseen_count,
+  changes: [{instrument_id, symbol, thesis_id, thesis_version, created_at, summary,
+  stance_from, stance_to}]}`.
+- **`POST /alerts/thesis-changes/seen`** body `{seen_through_thesis_id}` — advances the cursor
+  via the standard `GREATEST(COALESCE(...))` idiom.
+
+### 3. Migration — `sql/227_operators_alerts_thesis_change_cursor.sql`
+
+```sql
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_thesis_change_id BIGINT;
+```
+
+Mirror of sql/213 (rank-move cursor). NULL = never acknowledged. No new tables; diffs are not
+stored (Source rule).
+
+### 4. Frontend
+
+- **ThesisPane provenance area** (`ThesisPane.tsx:132-135`): when `diff` present and material,
+  a `Δ vs v{n-1}` line rendering `summary`; expandable detail (targets table, break-condition
+  add/removes, memo section names). Non-material diff → muted "minor changes vs v{n-1}".
+  Version 1 → nothing.
+- **ThesesPage run-status column**: compact change chip (`Δ stance buy→hold`) when
+  `last_change_material`; tooltip = `last_change_summary`.
+- **AlertsStrip**: thesis-changes group card following the rank-moves card pattern (unseen
+  count badge, per-row summary, mark-seen on dismiss).
+
+### 5. Out of scope
+
+- LLM one-liner (descoped, see §1).
+- Regen triggers / staleness predicates (#1988).
+- Meta-thesis aggregation (#2002).
+- Any change to writer/critic prompts, scoring, or portfolio consumption — this is a pure
+  read-surface + alert feature; `theses` writes are untouched.
+
+## Tests
+
+Pure-logic table tests for `thesis_diff.py` (fast tier, no DB): every field class, null
+transitions both directions, materiality boundary (4.9% vs 5.1% move), zero/None `old` rel_move,
+break-condition normalization, memo split edges (no headings, duplicate headings, heading-only
+rename). ONE db-tier test for the alerts cursor semantics (unseen → seen → new insert reopens),
+mirroring the existing rank-moves test shape. API field presence covered by extending existing
+theses API tests (TestClient, auto-db-marked).
+
+## Verification plan (definition of done)
+
+Not an ETL/parser/schema-affecting-data change (operators cursor column only), so clauses 8-11
+apply in spirit: exercise `GET /theses/{id}` + `/theses` + `/alerts/thesis-changes` on dev
+against known multi-version instruments (31 exist), eyeball ThesisPane + ThesesPage + AlertsStrip
+per change-coupled FE-QA, and record the observed figures in the PR description.

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -4,6 +4,7 @@ import type {
   GuardRejectionsResponse,
   PositionAlertsResponse,
   RankMovesResponse,
+  ThesisChangesResponse,
   ThesisStalenessResponse,
 } from "@/api/types";
 
@@ -101,6 +102,21 @@ export function markRankMovesSeen(
 
 export function dismissAllRankMoves(): Promise<void> {
   return apiFetch<void>("/alerts/rank-moves/dismiss-all", { method: "POST" });
+}
+
+// --- #2013 thesis-change endpoints -------------------------------------------
+// Cursor feed on theses.thesis_id; a dismiss with the newest listed id clears
+// everything older, so there is no separate dismiss-all endpoint.
+
+export function fetchThesisChanges(): Promise<ThesisChangesResponse> {
+  return apiFetch<ThesisChangesResponse>("/alerts/thesis-changes");
+}
+
+export function markThesisChangesSeen(seenThroughThesisId: number): Promise<void> {
+  return apiFetch<void>("/alerts/thesis-changes/seen", {
+    method: "POST",
+    body: JSON.stringify({ seen_through_thesis_id: seenThroughThesisId }),
+  });
 }
 
 // --- #1902 thesis-staleness snapshot ----------------------------------------

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1232,6 +1232,46 @@ export interface VerdictResponse {
 // /theses/{instrument_id} (app/api/theses.py)
 // ---------------------------------------------------------------------------
 
+// #2013 — structured what-changed vs the prior thesis version. Mirrors
+// app/services/thesis_diff.ThesisDiff via ThesisDiffModel (app/api/theses.py);
+// computed on read from the two append-only rows, never stored.
+export interface ThesisFieldChange {
+  from_value: string | null;
+  to_value: string | null;
+}
+
+export interface ThesisConfidenceChange {
+  from_value: number | null;
+  to_value: number | null;
+  delta: number | null;
+}
+
+export interface ThesisTargetChange {
+  field: string;
+  from_value: number | null;
+  to_value: number | null;
+  kind: string; // 'added' | 'removed' | 'moved'
+  rel_move: number | null;
+}
+
+export interface ThesisDiff {
+  prev_version: number;
+  curr_version: number;
+  stance: ThesisFieldChange | null;
+  thesis_type: ThesisFieldChange | null;
+  confidence: ThesisConfidenceChange | null;
+  targets: ThesisTargetChange[];
+  break_conditions_added: string[];
+  break_conditions_removed: string[];
+  memo_sections_added: string[];
+  memo_sections_removed: string[];
+  memo_sections_changed: string[];
+  prompt_version: ThesisFieldChange | null;
+  model: ThesisFieldChange | null;
+  material: boolean;
+  summary: string;
+}
+
 export interface ThesisDetail {
   thesis_id: number;
   instrument_id: number;
@@ -1258,6 +1298,8 @@ export interface ThesisDetail {
    *  Populated only on the latest-thesis GET; null on history/POST payloads. */
   is_stale?: boolean | null;
   stale_reason?: string | null;
+  /** #2013 — diff vs the version-1 predecessor; null on v1 rows. */
+  diff?: ThesisDiff | null;
 }
 
 export interface ThesisHistoryResponse {
@@ -1293,6 +1335,10 @@ export interface ThesisLibraryItem {
   run_error: string | null;
   run_trigger: string | null;
   run_started_at: string | null;
+  /** #2013 — compact field-level what-changed vs the predecessor version;
+   *  null/false on v1 rows, gap rows, or an unchanged regen. */
+  last_change_summary: string | null;
+  last_change_material: boolean;
 }
 
 export interface ThesisLibraryResponse {
@@ -1850,6 +1896,27 @@ export interface RankMovesResponse {
   alerts_last_seen_rank_event_id: number | null;
   unseen_count: number;
   moves: RankMove[];
+}
+
+// ---------------------------------------------------------------------------
+// #2013 thesis-change alert feed (app/api/alerts.py)
+// ---------------------------------------------------------------------------
+
+export interface ThesisChange {
+  thesis_id: number;
+  instrument_id: number;
+  symbol: string;
+  thesis_version: number;
+  created_at: string;
+  summary: string; // deterministic one-liner from thesis_diff (stance/type/targets)
+  stance_from: string | null;
+  stance_to: string | null;
+}
+
+export interface ThesisChangesResponse {
+  alerts_last_seen_thesis_change_id: number | null;
+  unseen_count: number;
+  changes: ThesisChange[];
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1250,7 +1250,7 @@ export interface ThesisTargetChange {
   field: string;
   from_value: number | null;
   to_value: number | null;
-  kind: string; // 'added' | 'removed' | 'moved'
+  kind: "added" | "removed" | "moved";
   rel_move: number | null;
 }
 

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -13,6 +13,8 @@ import type {
   PositionAlertsResponse,
   RankMove,
   RankMovesResponse,
+  ThesisChange,
+  ThesisChangesResponse,
   ThesisStalenessResponse,
 } from "@/api/types";
 
@@ -30,6 +32,8 @@ vi.mock("@/api/alerts", () => ({
   markRankMovesSeen: vi.fn(),
   dismissAllRankMoves: vi.fn(),
   fetchThesisStaleness: vi.fn(),
+  fetchThesisChanges: vi.fn(),
+  markThesisChangesSeen: vi.fn(),
 }));
 
 import * as alertsApi from "@/api/alerts";
@@ -39,6 +43,7 @@ const mockedPositionFetch = vi.mocked(alertsApi.fetchPositionAlerts);
 const mockedCoverageFetch = vi.mocked(alertsApi.fetchCoverageStatusDrops);
 const mockedRankFetch = vi.mocked(alertsApi.fetchRankMoves);
 const mockedThesisStaleFetch = vi.mocked(alertsApi.fetchThesisStaleness);
+const mockedThesisChangesFetch = vi.mocked(alertsApi.fetchThesisChanges);
 
 const mockedMarkGuard = vi.mocked(alertsApi.markAlertsSeen);
 const mockedMarkPosition = vi.mocked(alertsApi.markPositionAlertsSeen);
@@ -73,6 +78,11 @@ const EMPTY_RANK: RankMovesResponse = {
 const EMPTY_THESIS_STALE: ThesisStalenessResponse = {
   items: [],
 };
+const EMPTY_THESIS_CHANGES: ThesisChangesResponse = {
+  alerts_last_seen_thesis_change_id: null,
+  unseen_count: 0,
+  changes: [],
+};
 
 function stubAll(
   overrides: {
@@ -81,6 +91,7 @@ function stubAll(
     coverage?: Partial<CoverageStatusDropsResponse> | Error;
     rank?: Partial<RankMovesResponse> | Error;
     thesisStale?: Partial<ThesisStalenessResponse> | Error;
+    thesisChanges?: Partial<ThesisChangesResponse> | Error;
   } = {},
 ) {
   if (overrides.guard instanceof Error) {
@@ -109,6 +120,14 @@ function stubAll(
     mockedThesisStaleFetch.mockResolvedValue({
       ...EMPTY_THESIS_STALE,
       ...overrides.thesisStale,
+    });
+  }
+  if (overrides.thesisChanges instanceof Error) {
+    mockedThesisChangesFetch.mockRejectedValue(overrides.thesisChanges);
+  } else {
+    mockedThesisChangesFetch.mockResolvedValue({
+      ...EMPTY_THESIS_CHANGES,
+      ...overrides.thesisChanges,
     });
   }
 }
@@ -163,6 +182,20 @@ function makeRankMove(overrides: Partial<RankMove> = {}): RankMove {
   };
 }
 
+function makeThesisChange(overrides: Partial<ThesisChange> = {}): ThesisChange {
+  return {
+    thesis_id: 316,
+    instrument_id: 46,
+    symbol: "LGND",
+    thesis_version: 3,
+    created_at: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+    summary: "stance hold→avoid · type compounder→speculative",
+    stance_from: "hold",
+    stance_to: "avoid",
+    ...overrides,
+  };
+}
+
 function renderStrip() {
   return render(
     <MemoryRouter>
@@ -178,6 +211,7 @@ beforeEach(() => {
   // fetch. Tests that exercise those feeds override this.
   mockedRankFetch.mockResolvedValue(EMPTY_RANK);
   mockedThesisStaleFetch.mockResolvedValue(EMPTY_THESIS_STALE);
+  mockedThesisChangesFetch.mockResolvedValue(EMPTY_THESIS_CHANGES);
 });
 
 // ---------------------------------------------------------------------------
@@ -737,5 +771,53 @@ describe("AlertsStrip — thesis staleness", () => {
     renderStrip();
     // Pill counts only the cursor feeds (guard's 1), not the stale thesis.
     expect(await screen.findByText("1 new")).toBeInTheDocument();
+  });
+});
+
+describe("AlertsStrip — thesis changes (#2013)", () => {
+  it("renders a RE-THESIS card with the summary, counted in the unseen pill", async () => {
+    stubAll({
+      thesisChanges: { changes: [makeThesisChange()], unseen_count: 1 },
+    });
+    renderStrip();
+    expect(await screen.findByText("RE-THESIS")).toBeInTheDocument();
+    expect(screen.getByText("LGND")).toBeInTheDocument();
+    expect(
+      screen.getByText("stance hold→avoid · type compounder→speculative"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 new")).toBeInTheDocument();
+    // Card links to the instrument page.
+    const link = screen.getByText("LGND").closest("a");
+    expect(link).toHaveAttribute("href", "/instruments/46");
+  });
+
+  it("groups multiple in-window changes per instrument, latest shown", async () => {
+    stubAll({
+      thesisChanges: {
+        changes: [
+          makeThesisChange({ thesis_id: 320, thesis_version: 4, summary: "base 100→120 (+20%)" }),
+          makeThesisChange({ thesis_id: 316 }),
+        ],
+        unseen_count: 2,
+      },
+    });
+    renderStrip();
+    expect(await screen.findByText("base 100→120 (+20%)")).toBeInTheDocument();
+    expect(screen.getByText("×2")).toBeInTheDocument();
+  });
+
+  it("mark-all-read advances the thesis-change cursor to the max listed thesis_id", async () => {
+    const mockedMarkThesisChanges = vi.mocked(alertsApi.markThesisChangesSeen);
+    mockedMarkThesisChanges.mockResolvedValue(undefined);
+    stubAll({
+      thesisChanges: {
+        changes: [makeThesisChange({ thesis_id: 316 }), makeThesisChange({ thesis_id: 320, thesis_version: 4 })],
+        unseen_count: 2,
+      },
+    });
+    renderStrip();
+    const btn = await screen.findByRole("button", { name: /Mark all read/i });
+    await userEvent.click(btn);
+    expect(mockedMarkThesisChanges).toHaveBeenCalledWith(320);
   });
 });

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -29,11 +29,13 @@ import {
   fetchGuardRejections,
   fetchPositionAlerts,
   fetchRankMoves,
+  fetchThesisChanges,
   fetchThesisStaleness,
   markAlertsSeen,
   markCoverageStatusDropsSeen,
   markPositionAlertsSeen,
   markRankMovesSeen,
+  markThesisChangesSeen,
 } from "@/api/alerts";
 import type {
   CoverageStatusDropsResponse,
@@ -41,6 +43,7 @@ import type {
   PositionAlert,
   PositionAlertsResponse,
   RankMovesResponse,
+  ThesisChangesResponse,
   ThesisStalenessResponse,
 } from "@/api/types";
 import { formatRelativeTime } from "@/lib/format";
@@ -52,6 +55,7 @@ import {
   type GuardGroupItem,
   type CoverageGroupItem,
   type RankMoveItem,
+  type ThesisChangeItem,
   type ThesisStaleItem,
   type Tier,
 } from "./alertModel";
@@ -278,6 +282,41 @@ function RankMoveCard({ item }: { item: RankMoveItem }) {
   );
 }
 
+function ThesisChangeCard({ item }: { item: ThesisChangeItem }) {
+  // Material re-thesis (#2013): deterministic summary from thesis_diff —
+  // stance/type changes, targets added/removed, moves ≥5%.
+  return (
+    <Link
+      to={`/instruments/${item.instrumentId}`}
+      className="block hover:bg-slate-50 dark:hover:bg-slate-800/40"
+    >
+      <CardShell tier={item.tier} unseen={item.unseen} label="RE-THESIS">
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex items-baseline gap-2">
+            <span className="font-semibold text-slate-800 dark:text-slate-100">
+              {item.symbol}
+            </span>
+            {item.count > 1 ? (
+              <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:text-slate-300 tabular-nums">
+                ×{item.count}
+              </span>
+            ) : null}
+          </div>
+          <span
+            className="truncate text-xs text-slate-600 dark:text-slate-300"
+            title={item.summary}
+          >
+            {item.summary}
+          </span>
+        </div>
+        <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+          {formatRelativeTime(item.latestTs)}
+        </span>
+      </CardShell>
+    </Link>
+  );
+}
+
 function ThesisStaleCard({ item }: { item: ThesisStaleItem }) {
   // Standing condition (#1902): no unseen highlight, no dismiss — the card
   // clears when the theses regenerate. Links to the pre-filtered library.
@@ -312,6 +351,8 @@ function ItemView({ item }: { item: AlertItem }) {
       return <CoverageGroupCard item={item} />;
     case "rankMove":
       return <RankMoveCard item={item} />;
+    case "thesisChange":
+      return <ThesisChangeCard item={item} />;
     case "thesisStale":
       return <ThesisStaleCard item={item} />;
   }
@@ -335,6 +376,11 @@ export function AlertsStrip(): JSX.Element | null {
   >({
     status: "loading",
   });
+  const [thesisChange, setThesisChange] = useState<
+    FeedState<ThesisChangesResponse>
+  >({
+    status: "loading",
+  });
   const [refetchKey, setRefetchKey] = useState(0);
 
   useEffect(() => {
@@ -344,6 +390,7 @@ export function AlertsStrip(): JSX.Element | null {
     setCoverage({ status: "loading" });
     setRank({ status: "loading" });
     setThesisStale({ status: "loading" });
+    setThesisChange({ status: "loading" });
 
     fetchGuardRejections()
       .then((d) => {
@@ -395,6 +442,16 @@ export function AlertsStrip(): JSX.Element | null {
           setThesisStale({ status: "err" });
         }
       });
+    fetchThesisChanges()
+      .then((d) => {
+        if (!cancelled) setThesisChange({ status: "ok", data: d });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AlertsStrip] fetchThesisChanges failed", err);
+          setThesisChange({ status: "err" });
+        }
+      });
 
     return () => {
       cancelled = true;
@@ -408,7 +465,8 @@ export function AlertsStrip(): JSX.Element | null {
     position.status === "loading" ||
     coverage.status === "loading" ||
     rank.status === "loading" ||
-    thesisStale.status === "loading"
+    thesisStale.status === "loading" ||
+    thesisChange.status === "loading"
   ) {
     return null;
   }
@@ -417,7 +475,8 @@ export function AlertsStrip(): JSX.Element | null {
     position.status === "err" &&
     coverage.status === "err" &&
     rank.status === "err" &&
-    thesisStale.status === "err"
+    thesisStale.status === "err" &&
+    thesisChange.status === "err"
   ) {
     return null;
   }
@@ -432,6 +491,8 @@ export function AlertsStrip(): JSX.Element | null {
   // the grouped body only — never in unseen/overflow/dismiss accounting.
   const staleTheses =
     thesisStale.status === "ok" ? thesisStale.data.items : [];
+  const thesisChanges =
+    thesisChange.status === "ok" ? thesisChange.data.changes : [];
 
   const cursors: Cursors = {
     guard: guard.status === "ok" ? guard.data.alerts_last_seen_decision_id : null,
@@ -444,6 +505,10 @@ export function AlertsStrip(): JSX.Element | null {
         ? coverage.data.alerts_last_seen_coverage_event_id
         : null,
     rank: rank.status === "ok" ? rank.data.alerts_last_seen_rank_event_id : null,
+    thesisChange:
+      thesisChange.status === "ok"
+        ? thesisChange.data.alerts_last_seen_thesis_change_id
+        : null,
   };
 
   const items = buildAlertModel(
@@ -453,6 +518,7 @@ export function AlertsStrip(): JSX.Element | null {
     moves,
     cursors,
     staleTheses,
+    thesisChanges,
   );
 
   if (items.length === 0) {
@@ -463,21 +529,26 @@ export function AlertsStrip(): JSX.Element | null {
   const unseenPosition = position.status === "ok" ? position.data.unseen_count : 0;
   const unseenCoverage = coverage.status === "ok" ? coverage.data.unseen_count : 0;
   const unseenRank = rank.status === "ok" ? rank.data.unseen_count : 0;
+  const unseenThesisChange =
+    thesisChange.status === "ok" ? thesisChange.data.unseen_count : 0;
 
   // Overflow math compares backend unseen counts to RAW fetched row counts (each feed caps
-  // at LIMIT 500) — NOT to the grouped card count.
+  // at LIMIT 500; thesis changes at 50) — NOT to the grouped card count.
   const renderedGuard = rejections.length;
   const renderedPosition = positionAlerts.length;
   const renderedCoverage = drops.length;
   const renderedRank = moves.length;
+  const renderedThesisChange = thesisChanges.length;
 
-  const totalUnseen = unseenGuard + unseenPosition + unseenCoverage + unseenRank;
+  const totalUnseen =
+    unseenGuard + unseenPosition + unseenCoverage + unseenRank + unseenThesisChange;
 
   const anyOverflow =
     unseenGuard > renderedGuard ||
     unseenPosition > renderedPosition ||
     unseenCoverage > renderedCoverage ||
-    unseenRank > renderedRank;
+    unseenRank > renderedRank ||
+    unseenThesisChange > renderedThesisChange;
 
   const overflowAck = anyOverflow;
   const normalAck = totalUnseen > 0 && !anyOverflow;
@@ -488,12 +559,14 @@ export function AlertsStrip(): JSX.Element | null {
     const positionMax = Math.max(0, ...positionAlerts.map((r) => r.alert_id));
     const coverageMax = Math.max(0, ...drops.map((r) => r.event_id));
     const rankMax = Math.max(0, ...moves.map((r) => r.score_id));
+    const thesisChangeMax = Math.max(0, ...thesisChanges.map((r) => r.thesis_id));
 
     const promises: Promise<void>[] = [];
     if (guardMax > 0) promises.push(markAlertsSeen(guardMax));
     if (positionMax > 0) promises.push(markPositionAlertsSeen(positionMax));
     if (coverageMax > 0) promises.push(markCoverageStatusDropsSeen(coverageMax));
     if (rankMax > 0) promises.push(markRankMovesSeen(rankMax));
+    if (thesisChangeMax > 0) promises.push(markThesisChangesSeen(thesisChangeMax));
 
     const results = await Promise.allSettled(promises);
     for (const r of results) {
@@ -509,7 +582,8 @@ export function AlertsStrip(): JSX.Element | null {
       Math.max(0, unseenGuard - renderedGuard) +
       Math.max(0, unseenPosition - renderedPosition) +
       Math.max(0, unseenCoverage - renderedCoverage) +
-      Math.max(0, unseenRank - renderedRank);
+      Math.max(0, unseenRank - renderedRank) +
+      Math.max(0, unseenThesisChange - renderedThesisChange);
     const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
     if (!window.confirm(msg)) return;
 
@@ -518,6 +592,12 @@ export function AlertsStrip(): JSX.Element | null {
     if (position.status === "ok") promises.push(dismissAllPositionAlerts());
     if (coverage.status === "ok") promises.push(dismissAllCoverageStatusDrops());
     if (rank.status === "ok") promises.push(dismissAllRankMoves());
+    // No dismiss-all endpoint (#2013): the DESC list always contains the
+    // newest material change, so seen-through-the-max-listed-id clears all.
+    {
+      const thesisChangeMax = Math.max(0, ...thesisChanges.map((r) => r.thesis_id));
+      if (thesisChangeMax > 0) promises.push(markThesisChangesSeen(thesisChangeMax));
+    }
 
     const results = await Promise.allSettled(promises);
     for (const r of results) {

--- a/frontend/src/components/dashboard/alertModel.test.ts
+++ b/frontend/src/components/dashboard/alertModel.test.ts
@@ -22,6 +22,7 @@ const NO_CURSORS: Cursors = {
   position: null,
   coverage: null,
   rank: null,
+  thesisChange: null,
 };
 
 function guard(o: Partial<GuardRejection> = {}): GuardRejection {

--- a/frontend/src/components/dashboard/alertModel.ts
+++ b/frontend/src/components/dashboard/alertModel.ts
@@ -21,6 +21,7 @@ import type {
   GuardRejection,
   PositionAlert,
   RankMove,
+  ThesisChange,
   ThesisStalenessItem,
 } from "@/api/types";
 
@@ -37,6 +38,7 @@ export type Cursors = {
   position: number | null;
   coverage: number | null;
   rank: number | null;
+  thesisChange: number | null;
 };
 
 export interface GuardReasonMeta {
@@ -245,11 +247,35 @@ export interface ThesisStaleItem {
   unseen: boolean; // always false — excluded from unseen/dismiss accounting
 }
 
+/**
+ * Thesis change (#2013) — one card per instrument whose thesis regenerated
+ * with a MATERIAL change (stance/type change, target added/removed, or a
+ * target move ≥5% — predicate: app/services/thesis_diff.py). Event feed
+ * cursored on theses.thesis_id; an instrument regenerated several times
+ * in-window shows the latest change and counts the rest, like rank moves.
+ */
+export interface ThesisChangeItem {
+  kind: "thesisChange";
+  tier: Tier;
+  id: string;
+  symbol: string;
+  instrumentId: number;
+  summary: string;
+  stanceFrom: string | null;
+  stanceTo: string | null;
+  count: number;
+  latestTs: string;
+  sortKey: number;
+  maxId: number;
+  unseen: boolean;
+}
+
 export type AlertItem =
   | GuardGroupItem
   | PositionItem
   | CoverageGroupItem
   | RankMoveItem
+  | ThesisChangeItem
   | ThesisStaleItem;
 
 function uniqueSorted(values: (string | null)[]): string[] {
@@ -267,6 +293,7 @@ export function buildAlertModel(
   moves: RankMove[],
   cursors: Cursors,
   staleTheses: ThesisStalenessItem[] = [],
+  thesisChanges: ThesisChange[] = [],
 ): AlertItem[] {
   const items: AlertItem[] = [];
 
@@ -367,6 +394,35 @@ export function buildAlertModel(
       sortKey: Date.parse(latest.scored_at),
       maxId,
       unseen: cursors.rank === null || maxId > cursors.rank,
+    });
+  }
+
+  // Thesis changes (#2013) → one card per instrument (informational tier).
+  // Multiple in-window material regens on one instrument show the latest
+  // (highest thesis_id) and count the rest — same shape as rank moves.
+  const thesisChangeGroups = new Map<number, ThesisChange[]>();
+  for (const c of thesisChanges) {
+    const arr = thesisChangeGroups.get(c.instrument_id);
+    if (arr) arr.push(c);
+    else thesisChangeGroups.set(c.instrument_id, [c]);
+  }
+  for (const [instrumentId, members] of thesisChangeGroups) {
+    const maxId = Math.max(...members.map((m) => m.thesis_id));
+    const latest = members.reduce((a, b) => (b.thesis_id > a.thesis_id ? b : a));
+    items.push({
+      kind: "thesisChange",
+      tier: "informational",
+      id: `thesisChange:${instrumentId}`,
+      symbol: latest.symbol,
+      instrumentId,
+      summary: latest.summary,
+      stanceFrom: latest.stance_from,
+      stanceTo: latest.stance_to,
+      count: members.length,
+      latestTs: latest.created_at,
+      sortKey: Date.parse(latest.created_at),
+      maxId,
+      unseen: cursors.thesisChange === null || maxId > cursors.thesisChange,
     });
   }
 

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -163,4 +163,40 @@ describe("ThesisPane", () => {
     // The literal "### Valuation" raw line must NOT appear.
     expect(screen.queryByText(/### Valuation/)).not.toBeInTheDocument();
   });
+
+  it("renders the material diff block with summary + expandable detail (#2013)", () => {
+    const thesis = {
+      ...FIXTURE,
+      diff: {
+        prev_version: 2,
+        curr_version: 3,
+        stance: { from_value: "buy", to_value: "watch" },
+        thesis_type: null,
+        confidence: { from_value: 0.8, to_value: 0.65, delta: -0.15 },
+        targets: [],
+        break_conditions_added: ["New CEO departs"],
+        break_conditions_removed: [],
+        memo_sections_added: [],
+        memo_sections_removed: [],
+        memo_sections_changed: ["Valuation"],
+        prompt_version: null,
+        model: null,
+        material: true,
+        summary: "stance buy→watch",
+      },
+    } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    const block = screen.getByTestId("thesis-diff");
+    expect(block).toHaveTextContent("Δ vs v2:");
+    expect(block).toHaveTextContent("stance buy→watch");
+    expect(block).toHaveTextContent("conf -15pp");
+    expect(block).toHaveTextContent("break condition added: New CEO departs");
+    expect(block).toHaveTextContent("memo section revised: Valuation");
+  });
+
+  it("omits the diff block on v1 rows (diff null)", () => {
+    const thesis = { ...FIXTURE, diff: null } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={thesis} errored={false} />);
+    expect(screen.queryByTestId("thesis-diff")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -3,7 +3,7 @@ import { CriticVerdictBadge } from "@/components/theses/CriticVerdictBadge";
 import { MemoMarkdown } from "@/components/theses/MemoMarkdown";
 import { StanceBadge } from "@/components/theses/StanceBadge";
 import { EmptyState } from "@/components/states/EmptyState";
-import type { ThesisDetail } from "@/api/types";
+import type { ThesisDetail, ThesisDiff } from "@/api/types";
 
 export interface ThesisPaneProps {
   readonly thesis: ThesisDetail | null;
@@ -67,6 +67,67 @@ function formatDate(iso: string): string {
   return Number.isNaN(d.getTime())
     ? iso
     : d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+}
+
+/** #2013 — what changed vs the prior version. Material changes (stance/type/
+ *  target moves, from the server-computed thesis_diff) get a prominent line;
+ *  informational-only diffs (memo/break-condition/provenance drift) get a
+ *  muted one. Expandable detail lists break-condition and memo-section churn. */
+function DiffBlock({ diff }: { diff: ThesisDiff }): JSX.Element | null {
+  const hasDetail =
+    diff.break_conditions_added.length > 0 ||
+    diff.break_conditions_removed.length > 0 ||
+    diff.memo_sections_added.length > 0 ||
+    diff.memo_sections_removed.length > 0 ||
+    diff.memo_sections_changed.length > 0;
+  const hasAnything = diff.summary !== "" || hasDetail || diff.confidence !== null;
+  if (!hasAnything) return null;
+
+  const confidenceNote =
+    diff.confidence !== null && diff.confidence.delta !== null
+      ? `conf ${diff.confidence.delta >= 0 ? "+" : ""}${(diff.confidence.delta * 100).toFixed(0)}pp`
+      : null;
+  const headline = [diff.summary !== "" ? diff.summary : null, confidenceNote]
+    .filter((s): s is string => s !== null)
+    .join(" · ");
+
+  return (
+    <div
+      data-testid="thesis-diff"
+      className={`rounded border px-2 py-1.5 text-xs ${
+        diff.material
+          ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 text-amber-800 dark:text-amber-200"
+          : "border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900/40 text-slate-500 dark:text-slate-400"
+      }`}
+    >
+      <span className="font-medium">Δ vs v{diff.prev_version}:</span>{" "}
+      {headline !== "" ? headline : "minor changes (memo/break conditions)"}
+      {hasDetail && (
+        <details className="mt-1">
+          <summary className="cursor-pointer select-none text-[11px] opacity-80">
+            details
+          </summary>
+          <ul className="mt-1 list-inside list-disc space-y-0.5 text-[11px]">
+            {diff.break_conditions_added.map((c) => (
+              <li key={`bc+${c}`}>break condition added: {c}</li>
+            ))}
+            {diff.break_conditions_removed.map((c) => (
+              <li key={`bc-${c}`}>break condition removed: {c}</li>
+            ))}
+            {diff.memo_sections_added.map((s) => (
+              <li key={`ms+${s}`}>memo section added: {s}</li>
+            ))}
+            {diff.memo_sections_removed.map((s) => (
+              <li key={`ms-${s}`}>memo section removed: {s}</li>
+            ))}
+            {diff.memo_sections_changed.map((s) => (
+              <li key={`ms~${s}`}>memo section revised: {s}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
 }
 
 interface BodyProps {
@@ -144,6 +205,8 @@ function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element 
           </span>
         )}
       </div>
+
+      {thesis.diff !== null && thesis.diff !== undefined && <DiffBlock diff={thesis.diff} />}
 
       {hasBand && (
         <div className="rounded bg-slate-50 dark:bg-slate-900/40 p-3">

--- a/frontend/src/pages/ThesesPage.test.tsx
+++ b/frontend/src/pages/ThesesPage.test.tsx
@@ -38,6 +38,8 @@ function makeItem(overrides: Partial<ThesisLibraryItem> = {}): ThesisLibraryItem
     run_error: null,
     run_trigger: "manual",
     run_started_at: null,
+    last_change_summary: null,
+    last_change_material: false,
     ...overrides,
   };
 }

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -76,6 +76,25 @@ function staleLabel(reason: string): string {
   return "stale";
 }
 
+/** #2013 — compact what-changed chip next to the run status. Amber when the
+ *  change is material (stance/type/target move per thesis_diff); muted for
+ *  a non-material tweak. Absent for v1 / gap rows / unchanged regens. */
+function ChangeChip({ row }: { row: ThesisLibraryItem }) {
+  if (row.last_change_summary === null) return null;
+  const cls = row.last_change_material
+    ? "border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300"
+    : "border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 text-slate-500 dark:text-slate-400";
+  return (
+    <span
+      data-testid="thesis-change-chip"
+      className={`inline-block max-w-48 truncate rounded border px-1.5 py-0.5 align-bottom text-[10px] font-medium ${cls}`}
+      title={row.last_change_summary}
+    >
+      Δ {row.last_change_summary}
+    </span>
+  );
+}
+
 function RunStatusCell({ row }: { row: ThesisLibraryItem }) {
   if (row.run_status === "running") {
     return (
@@ -388,7 +407,10 @@ export function ThesesPage(): JSX.Element {
                         ) : null}
                       </td>
                       <td className="px-2 py-2">
-                        <RunStatusCell row={row} />
+                        <div className="flex items-center gap-1.5">
+                          <RunStatusCell row={row} />
+                          <ChangeChip row={row} />
+                        </div>
                       </td>
                       <td className="px-2 py-2 text-right">
                         <button

--- a/sql/227_operators_alerts_thesis_change_cursor.sql
+++ b/sql/227_operators_alerts_thesis_change_cursor.sql
@@ -1,0 +1,22 @@
+-- #2013 — thesis-change alert feed cursor.
+--
+-- A fifth dashboard alert feed (AlertsStrip): a thesis regenerated with a
+-- MATERIAL change vs its prior version (stance / thesis_type change, target
+-- null-transition, or a target/zone move >= 5% — predicate lives in
+-- app/services/thesis_diff.py, single source). The "event" is a `theses` row
+-- with thesis_version > 1 (append-only, one row per generation);
+-- `theses.thesis_id` (BIGSERIAL PK, monotonic, unique) is the cursor — same
+-- rationale as migration 044's decision_id / 047's event_id / 213's
+-- score_id: created_at is not guaranteed unique, thesis_id closes the
+-- tie-break race under strict `>` comparison.
+--
+-- NULL = never acknowledged (all in-window material changes unseen),
+-- matching the other four cursor columns on `operators`.
+--
+-- No supporting index: the feed scans a 14-day created_at window over
+-- `theses` (325 rows total on dev today, regen throughput <= 5/hour) and
+-- idx_theses_instrument_created already covers the per-instrument
+-- predecessor lookup. The thesis_id > cursor bound is a cheap residual
+-- filter over that already-tiny row set.
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_thesis_change_id BIGINT;

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1961,3 +1961,114 @@ def test_thesis_staleness_empty_when_held_theses_fresh(client: TestClient) -> No
     resp = client.get("/alerts/thesis-staleness")
     assert resp.status_code == 200
     assert resp.json() == {"items": []}
+
+
+# ---------------------------------------------------------------------------
+# #2013 — thesis-change alert feed (cursor on theses.thesis_id, materiality
+# decided in Python by thesis_diff.compute_thesis_diff)
+# ---------------------------------------------------------------------------
+
+
+def _thesis_change_row(
+    thesis_id: int = 316,
+    instrument_id: int = 46,
+    symbol: str = "LGND",
+    thesis_version: int = 3,
+    stance: str = "avoid",
+    prev_stance: str = "hold",
+    base_value: float | None = 100.0,
+    prev_base_value: float | None = 100.0,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "thesis_id": thesis_id,
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "thesis_version": thesis_version,
+        "created_at": datetime(2026, 7, 15, 10, 0, 0, tzinfo=UTC),
+        "stance": stance,
+        "thesis_type": "value",
+        "confidence_score": 0.6,
+        "buy_zone_low": None,
+        "buy_zone_high": None,
+        "base_value": base_value,
+        "bull_value": None,
+        "bear_value": None,
+        "prev_stance": prev_stance,
+        "prev_thesis_type": "value",
+        "prev_confidence_score": 0.6,
+        "prev_buy_zone_low": None,
+        "prev_buy_zone_high": None,
+        "prev_base_value": prev_base_value,
+        "prev_bull_value": None,
+        "prev_bear_value": None,
+    }
+    return row
+
+
+def test_thesis_changes_get_filters_non_material_and_counts_unseen_above_cursor(
+    client: TestClient,
+) -> None:
+    rows = [
+        # Material (stance change), above the cursor → listed + unseen.
+        _thesis_change_row(thesis_id=320),
+        # Non-material (2% base move, no stance change) → dropped entirely.
+        _thesis_change_row(
+            thesis_id=318,
+            instrument_id=47,
+            symbol="AAPL",
+            stance="hold",
+            prev_stance="hold",
+            base_value=102.0,
+            prev_base_value=100.0,
+        ),
+        # Material but at/below the cursor → listed (in-window) yet NOT unseen.
+        _thesis_change_row(thesis_id=310, instrument_id=48, symbol="GME"),
+    ]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[{"alerts_last_seen_thesis_change_id": 315}],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/thesis-changes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alerts_last_seen_thesis_change_id"] == 315
+    assert body["unseen_count"] == 1
+    listed = {c["symbol"]: c for c in body["changes"]}
+    assert set(listed) == {"LGND", "GME"}  # AAPL's 2% move is non-material
+    assert listed["LGND"]["summary"] == "stance hold→avoid"
+    assert listed["LGND"]["stance_from"] == "hold"
+    assert listed["LGND"]["stance_to"] == "avoid"
+
+
+def test_thesis_changes_get_null_cursor_counts_all_material(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[{"alerts_last_seen_thesis_change_id": None}],
+            fetchall_returns=[_thesis_change_row()],
+        )
+        resp = client.get("/alerts/thesis-changes")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alerts_last_seen_thesis_change_id"] is None
+    assert body["unseen_count"] == 1
+    assert len(body["changes"]) == 1
+
+
+def test_thesis_changes_post_seen_writes_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn()
+        resp = client.post("/alerts/thesis-changes/seen", json={"seen_through_thesis_id": 320})
+    assert resp.status_code == 204
+    sql = cur.execute.call_args_list[-1].args[0]
+    assert "alerts_last_seen_thesis_change_id" in sql
+    assert "GREATEST" in sql
+    assert "m.max_id IS NOT NULL" in sql
+    cur._parent_conn.commit.assert_called_once()
+
+
+def test_thesis_changes_post_seen_rejects_non_positive(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/thesis-changes/seen", json={"seen_through_thesis_id": 0})
+    assert resp.status_code == 422

--- a/tests/test_thesis_diff.py
+++ b/tests/test_thesis_diff.py
@@ -1,0 +1,211 @@
+"""Fast-tier tests for the pure thesis-diff module (#2013).
+
+No DB: field-class coverage, null transitions both directions, the
+materiality boundary, memo section split edges, break-condition
+normalization, and Decimal/float input parity.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.thesis_diff import (
+    _MATERIAL_REL_MOVE,
+    ThesisDiff,
+    compute_thesis_diff,
+)
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "thesis_version": 1,
+        "stance": "buy",
+        "thesis_type": "value",
+        "confidence_score": 0.6,
+        "buy_zone_low": 90.0,
+        "buy_zone_high": 100.0,
+        "base_value": 120.0,
+        "bull_value": 150.0,
+        "bear_value": 80.0,
+        "break_conditions_json": ["Margin collapse below 20%", "Debt/EBITDA > 1.5x"],
+        "memo_markdown": "### Business\nSolid moat.\n### Valuation\nCheap vs peers.",
+        "prompt_version": "v4",
+        "model": "claude-sonnet-4-6",
+    }
+    base.update(overrides)
+    return base
+
+
+def _diff(prev_overrides: dict[str, object], curr_overrides: dict[str, object]) -> ThesisDiff:
+    prev = _row(thesis_version=1, **prev_overrides)
+    curr = _row(thesis_version=2, **curr_overrides)
+    return compute_thesis_diff(prev, curr)
+
+
+class TestNoChange:
+    def test_identical_rows_not_material_empty_summary(self) -> None:
+        d = _diff({}, {})
+        assert d.material is False
+        assert d.summary == ""
+        assert d.stance is None
+        assert d.thesis_type is None
+        assert d.confidence is None
+        assert d.targets == ()
+        assert d.break_conditions_added == ()
+        assert d.break_conditions_removed == ()
+        assert d.memo_sections_changed == ()
+        assert d.prev_version == 1
+        assert d.curr_version == 2
+
+
+class TestStanceAndType:
+    def test_stance_change_is_material_and_summarized(self) -> None:
+        d = _diff({"stance": "buy"}, {"stance": "hold"})
+        assert d.stance is not None
+        assert (d.stance.from_value, d.stance.to_value) == ("buy", "hold")
+        assert d.material is True
+        assert "stance buy→hold" in d.summary
+
+    def test_thesis_type_change_alone_is_material(self) -> None:
+        d = _diff({"thesis_type": "value"}, {"thesis_type": "turnaround"})
+        assert d.thesis_type is not None
+        assert d.material is True
+        assert "type value→turnaround" in d.summary
+
+
+class TestTargets:
+    def test_null_to_value_is_added_and_material(self) -> None:
+        d = _diff({"base_value": None}, {"base_value": 110.0})
+        (t,) = d.targets
+        assert (t.field, t.kind, t.from_value, t.to_value) == ("base_value", "added", None, 110.0)
+        assert t.rel_move is None
+        assert d.material is True
+        assert "base added (110)" in d.summary
+
+    def test_value_to_null_is_removed_and_material(self) -> None:
+        d = _diff({"bear_value": 80.0}, {"bear_value": None})
+        (t,) = d.targets
+        assert (t.field, t.kind) == ("bear_value", "removed")
+        assert d.material is True
+        assert "bear removed" in d.summary
+
+    def test_move_below_threshold_not_material(self) -> None:
+        # 4.9% < _MATERIAL_REL_MOVE (5%)
+        d = _diff({"base_value": 100.0}, {"base_value": 104.9})
+        (t,) = d.targets
+        assert t.kind == "moved"
+        assert t.rel_move is not None and t.rel_move < _MATERIAL_REL_MOVE
+        assert d.material is False
+        # Summary still reports the (non-material) move for the pane detail.
+        assert "base 100→104.9" in d.summary
+
+    def test_move_at_threshold_is_material(self) -> None:
+        d = _diff({"base_value": 100.0}, {"base_value": 105.1})
+        assert d.material is True
+        assert "(+5%)" in d.summary
+
+    def test_move_from_zero_base_is_material_with_none_rel_move(self) -> None:
+        d = _diff({"base_value": 0.0}, {"base_value": 10.0})
+        (t,) = d.targets
+        assert t.kind == "moved"
+        assert t.rel_move is None
+        assert d.material is True
+
+    def test_downward_move_signed_percentage(self) -> None:
+        d = _diff({"base_value": 120.0}, {"base_value": 98.0})
+        assert "base 120→98 (-18%)" in d.summary
+
+    def test_both_null_is_no_change(self) -> None:
+        d = _diff({"bull_value": None}, {"bull_value": None})
+        assert d.targets == ()
+        assert d.material is False
+
+
+class TestConfidence:
+    def test_confidence_delta_never_material(self) -> None:
+        d = _diff({"confidence_score": 0.6}, {"confidence_score": 0.2})
+        assert d.confidence is not None
+        assert d.confidence.delta == pytest.approx(-0.4)
+        assert d.material is False
+        assert d.summary == ""
+
+    def test_confidence_null_side_yields_none_delta(self) -> None:
+        d = _diff({"confidence_score": None}, {"confidence_score": 0.5})
+        assert d.confidence is not None
+        assert d.confidence.delta is None
+
+
+class TestBreakConditions:
+    def test_added_and_removed_with_normalization(self) -> None:
+        d = _diff(
+            {"break_conditions_json": ["Margin  collapse below 20%"]},
+            {"break_conditions_json": ["margin collapse below 20%", "New CEO departs"]},
+        )
+        # Whitespace/case-normalized match: the margin condition is unchanged.
+        assert d.break_conditions_added == ("New CEO departs",)
+        assert d.break_conditions_removed == ()
+        assert d.material is False  # break conditions are informational
+
+    def test_null_payload_tolerated(self) -> None:
+        d = _diff({"break_conditions_json": None}, {"break_conditions_json": ["X breaks"]})
+        assert d.break_conditions_added == ("X breaks",)
+
+
+class TestMemoSections:
+    def test_added_removed_changed(self) -> None:
+        d = _diff(
+            {"memo_markdown": "### Business\nSolid moat.\n### Valuation\nCheap."},
+            {"memo_markdown": "### Business\nMoat eroding.\n### Risks\nNew risks."},
+        )
+        assert d.memo_sections_added == ("Risks",)
+        assert d.memo_sections_removed == ("Valuation",)
+        assert d.memo_sections_changed == ("Business",)
+        assert d.material is False  # memo sections are informational
+
+    def test_whitespace_only_body_change_not_changed(self) -> None:
+        d = _diff(
+            {"memo_markdown": "### Business\nSolid  moat.\n"},
+            {"memo_markdown": "### Business\nSolid moat."},
+        )
+        assert d.memo_sections_changed == ()
+
+    def test_headingless_memo_diffs_as_body_pseudo_section(self) -> None:
+        d = _diff(
+            {"memo_markdown": "Plain memo without headings."},
+            {"memo_markdown": "Different plain memo."},
+        )
+        assert d.memo_sections_changed == ("(body)",)
+
+    def test_duplicate_headings_collapse_to_one_key(self) -> None:
+        d = _diff(
+            {"memo_markdown": "### Risks\nA.\n### Risks\nB."},
+            {"memo_markdown": "### Risks\nA.\n### Risks\nB."},
+        )
+        assert d.memo_sections_changed == ()
+        assert d.memo_sections_added == ()
+
+
+class TestProvenanceAndInputTypes:
+    def test_prompt_version_and_model_change_not_material(self) -> None:
+        d = _diff(
+            {"prompt_version": "v3", "model": "claude-sonnet-4-5"},
+            {"prompt_version": "v4", "model": "claude-sonnet-4-6"},
+        )
+        assert d.prompt_version is not None
+        assert d.model is not None
+        assert d.material is False
+
+    def test_decimal_inputs_match_float_inputs(self) -> None:
+        d_dec = _diff(
+            {"base_value": Decimal("120.000000")},
+            {"base_value": Decimal("98.000000")},
+        )
+        d_flt = _diff({"base_value": 120.0}, {"base_value": 98.0})
+        assert d_dec.targets == d_flt.targets
+        assert d_dec.material is d_flt.material is True
+
+    def test_decimal_equal_values_no_change(self) -> None:
+        d = _diff({"base_value": Decimal("120.000000")}, {"base_value": 120.0})
+        assert d.targets == ()


### PR DESCRIPTION
Closes #2013.

Spec: `docs/specs/thesis/2026-07-15-rethesis-diff-surface.md` (Codex ckpt-1 reviewed; 2 BLOCKING + 4 WARNING + 1 NIT all addressed in the spec before implementation).

## What

The operator now sees WHAT MOVED when a thesis regenerates, not just a new memo:

- **`app/services/thesis_diff.py`** — pure module (no DB/LLM/IO): structured diff of thesis version N vs N−1 (stance, thesis_type, confidence, the five target/zone fields, break-conditions set diff, memo `###`-section diff, provenance) + a deterministic one-line `summary` + a `material` flag. The materiality predicate lives ONLY here — SQL pairs rows, Python decides — so the alert feed, the library chip and the pane can never drift.
- **Diff computed on read, never stored.** `theses` is append-only (settled-decisions "Thesis semantics"), so diff(N, N−1) is a pure function of two immutable rows. No new data table, no backfill; works retroactively for all 43 existing N>1 pairs.
- **API**: `ThesisDetail.diff` on `GET /theses/{id}` + `/history` (predecessor via explicit `(instrument_id, thesis_version−1)` join — NOT page adjacency); `ThesisLibraryItem.last_change_summary/material` (field-level only, no memo columns on the list path); `GET /alerts/thesis-changes` + `POST /alerts/thesis-changes/seen` (rank-moves cursor semantics: BIGSERIAL `thesis_id` cursor, 14-day window, GREATEST/LEAST clamp, empty-window NULL guard).
- **Migration `sql/227`**: `operators.alerts_last_seen_thesis_change_id BIGINT` (mirror of sql/213). Additive, no data change.
- **FE**: ThesisPane Δ-vs-vN−1 block (amber when material, expandable break-condition/memo detail), ThesesPage change chip in the run-status column, AlertsStrip RE-THESIS card group (per-instrument grouping, ×N count, mark-all-read/dismiss wired into existing cursor accounting).

## Source rule / full-population verification

- No SEC/external data treatment — internal contracts only (settled-decisions thesis versioning, #2007 null-as-abstention semantics, the operators-cursor alert-feed precedent sql/044/045/047/213).
- Materiality predicate run verbatim on ALL 43 dev N>1 pairs: **22 material = 22 with any field change** (zero events lost by the ≥5% threshold; all 21 observed numeric moves ≥5%, median 50%). Memo survey on ALL 325 memos: `###`-only headings, 0 duplicate headings, 15 heading-less (handled as one `(body)` pseudo-section). thesis_type kept in the predicate by design (changes alone in 0 current pairs).
- Design decision recorded in spec: the issue's "staleness-feed standing condition vs event alert" question → **event feed** (a stance flip is a discrete fact that never "resolves"); orthogonal to #1988 (regen *triggers*, pre-generation).

## Security model

- All new/changed endpoints sit behind the existing `require_session_or_service_token` router dependencies (`/theses`, `/alerts` routers — unchanged).
- No user-controlled SQL interpolation: the only f-string SQL fragments are module-level constants (`_THESIS_COLUMNS`, `_THESIS_CHANGE_WINDOW_WHERE`, column lists built from a module-level tuple); all values are parameterised.
- Authorisation unchanged: single-operator model; the cursor column is per-operator on `operators`, resolved via `sole_operator_id` like the four existing cursors.
- Write surface: only the new cursor column (monotonic GREATEST update). `theses` writes untouched; scoring/portfolio/guard untouched.

## Conscious tradeoffs

- `/seen`'s LEAST clamp bounds against the SQL-window max WITHOUT materiality (SQL can't run the Python predicate). A cursor may advance past a non-material id — harmless: non-material changes never surface and `unseen_count` counts only material ids above the cursor. Documented at the endpoint.
- The alerts GET scans every windowed version>1 pair and filters in Python (theses = 325 rows total, regen ≤5/hour) — chosen over duplicating the materiality predicate in SQL (predicate-drift class from the prevention log). List cap (50) applies AFTER materiality; `unseen_count` is never truncated (spec ckpt-1 BLOCKING finding 1).
- No dismiss-all endpoint for thesis-changes: the DESC list always contains the newest material change, so seen-through-max-listed-id clears everything; AlertsStrip's Dismiss-all uses that.
- LLM one-liner summary descoped (issue marked optional): the deterministic summary is free and auditable; revisit post-#2010 if prose is wanted.

## Verification (all at 21e32c6c1be1512be814ea8a5c1c607f65f8a379)

- `uv run pytest tests/test_thesis_diff.py` — 21 pure-logic tests pass (field classes, null transitions both ways, 4.9%/5.1% materiality boundary, zero-base move, memo split edges, Decimal/float parity).
- `uv run pytest tests/test_api_alerts.py tests/test_api_instrument_thesis.py` (db tier, postgres-test) — 79 + previously-passing suite green; 4 new thesis-changes tests (material filter + cursor counting, null cursor, /seen SQL shape + commit, 422 on non-positive).
- Full gates: `ruff check` + `ruff format --check` + `pyright` clean; `pytest -m "not db"` 5081 passed; `tests/smoke` 153 passed; `pnpm --dir frontend typecheck` + `test:unit` 1350 passed.
- **Dev live verification** (uvicorn :8000 on this branch, sql/227 applied):
  - `GET /theses/9932` (LGND v3) → diff renders: stance hold→avoid, type compounder→speculative, conf −15pp, 4 break conditions added / 3 removed, 3 memo sections revised.
  - `GET /alerts/thesis-changes` → 22 unseen material changes (matches the full-pop scan exactly); `POST /seen` with max id → 204, unseen 0, list still 22 (in-window); cursor then reset to NULL on dev so the operator sees the day-one feed.
  - `GET /theses` → `last_change_summary` populated (e.g. BAC: "stance watch→hold · base 65→53.84 (-17%) · bull 75→70.26 (-6%) · bear 50→43.61 (-13%)").
- **Change-coupled FE-QA** (Playwright on :5173, real session): dashboard AlertsStrip shows 16 grouped RE-THESIS cards (22 changes grouped per instrument) interleaved correctly with GUARD/RANK by tier+recency; /theses shows the Δ chip; instrument page shows the Δ block with expandable detail. 0 console errors on all three pages.
- Codex ckpt-2 (`codex exec review --base origin/main`): no findings.

Not an ownership/fundamentals ETL change — no `sec_rebuild` scope; the only operator follow-up is nothing (read-path + additive cursor column; migration auto-applies at app boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)