### PR TITLE
fix(#2034): allow expected_filings_seed as db_fundamentals_raw family sibling

### DIFF
--- a/tests/test_db_lane_family_split.py
+++ b/tests/test_db_lane_family_split.py
@@ -53,19 +53,23 @@ class TestSourceRegistry:
     def test_phase_c_job_resolves_to_family_source(self, job_name: str, expected_source: str) -> None:
         assert source_for(job_name) == expected_source
 
-    # Bootstrap-only siblings that legitimately SHARE a family source with
-    # their steady-state Phase C job. They write the same table family, so
+    # Known siblings that legitimately SHARE a family source with their
+    # steady-state Phase C job. They write/read the same table family, so
     # sharing the JobLock source is correct — it serialises them against the
     # steady-state job rather than re-introducing CROSS-family serialisation.
     # #1233 PR-C2 (#1397): ``fundamentals_sync_bootstrap`` (bootstrap-only,
     # _INVOKERS) shares ``db_fundamentals_raw`` with ``sec_companyfacts_ingest``.
-    _ALLOWED_BOOTSTRAP_SIBLINGS: dict[str, set[str]] = {
-        "db_fundamentals_raw": {"fundamentals_sync_bootstrap"},
+    # #1788 (#2034): ``expected_filings_seed`` (daily, DB-only, no SEC HTTP)
+    # deliberately runs on ``db_fundamentals_raw`` — it reads
+    # financial_periods + sec_filing_manifest only (SCHEDULED_JOBS entry,
+    # app/workers/scheduler.py; documented in app/jobs/sources.py).
+    _ALLOWED_FAMILY_SIBLINGS: dict[str, set[str]] = {
+        "db_fundamentals_raw": {"fundamentals_sync_bootstrap", "expected_filings_seed"},
     }
 
     def test_each_family_source_has_exactly_one_job(self) -> None:
         """Inverse check: each family source is owned by its Phase C job plus
-        at most the known bootstrap-only sibling(s).
+        at most the known same-family sibling(s).
 
         Catches accidental cross-wiring (e.g. two DIFFERENT Phase C stages on
         the same family source would re-introduce intra-family serialisation
@@ -76,10 +80,10 @@ class TestSourceRegistry:
         for source in family_sources:
             holders = {name for name, src in registry.items() if src == source}
             expected_job = next(name for name, expected in _FAMILY_ASSIGNMENTS if expected == source)
-            allowed = {expected_job} | self._ALLOWED_BOOTSTRAP_SIBLINGS.get(source, set())
+            allowed = {expected_job} | self._ALLOWED_FAMILY_SIBLINGS.get(source, set())
             assert holders == allowed, (
                 f"family source {source!r} owned by {sorted(holders)!r}; "
-                f"expected {sorted(allowed)!r} (Phase C job + known bootstrap siblings)"
+                f"expected {sorted(allowed)!r} (Phase C job + known family siblings)"
             )
 
 


### PR DESCRIPTION
## What

Fixes the pre-existing red test on main: `tests/test_db_lane_family_split.py::TestSourceRegistry::test_each_family_source_has_exactly_one_job` failed because `expected_filings_seed` (#1788) is registered on the `db_fundamentals_raw` source but was never added to the test's sibling allow-list. Test-only change: add it to the allow-list and rename `_ALLOWED_BOOTSTRAP_SIBLINGS` → `_ALLOWED_FAMILY_SIBLINGS` (the set now contains a daily scheduled job, so "bootstrap-only" no longer describes the class).

## Why allow-list, not re-lane (the #2034 "human call")

The issue asked whether the wiring is intended or accidental cross-wiring. It is intended — documented twice at the source:

- `app/workers/scheduler.py` `SCHEDULED_JOBS` entry: "Reads financial_periods + sec_filing_manifest only (no SEC HTTP) → the fundamentals-raw DB lane."
- `app/jobs/sources.py` (`sec_expected_filings` lane doc): "The companion `expected_filings_seed` runs on the existing `db_fundamentals_raw` lane — DB-only, no SEC HTTP."

The test guards against two DIFFERENT Phase C stages sharing a family source (re-introducing intra-family serialisation). `expected_filings_seed` is not a Phase C stage; it is a cheap daily DB-only job that deliberately serialises against the fundamentals family — exactly the sibling class the allow-list exists for (`fundamentals_sync_bootstrap` precedent, #1233 PR-C2/#1397).

## Security model

No runtime code touched; test-only. No new inputs, no SQL changes, no auth surface.

## Verification

- `uv run pytest tests/test_db_lane_family_split.py` — 17 passed (was 1 failed on main, stash-confirmed pre-existing in #2024).
- Full pre-push gate green: ruff, format, pyright (0), fast tier 5081 passed, smoke 145 passed.
- Codex ckpt-2 (`codex exec review --base origin/main`): "did not find any introduced correctness issues".

Not an ETL/parser/schema change → DoD clauses 8-12 N/A.

Closes #2034

🤖 Generated with [Claude Code](https://claude.com/claude-code)