### PR TITLE
feat(#2032): fvb_v4 companion-variable peer screen (margin+growth / ROE)

### DIFF
--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -1131,13 +1131,12 @@ def peer_pct_for(
             # that had no inputs. (Values are unaffected either way: the
             # unscreened fallback below IS the pre-v4 walk.) The screened pass
             # visits every ladder level before landing here, so rows_cache holds
-            # the full member set this walk can ever see.
-            if not any(
-                target_screenable(multiple, _member_companions(r))
-                for cached in rows_cache.values()
-                if cached
-                for r in cached
-            ):
+            # the full member set this walk can ever see; empty-but-valid
+            # cohorts ([] or unresolved-SIC None levels) contribute no rows, so
+            # the override requires member rows to EXIST — a zero-member cohort
+            # keeps no_screened_cohort (PR #2045 review WARNING).
+            cached_rows = [r for cached in rows_cache.values() if cached for r in cached]
+            if cached_rows and not any(target_screenable(multiple, _member_companions(r)) for r in cached_rows):
                 screen_reason = "cohort_companions_missing"
 
     # --- unscreened walk (pre-v4 semantics, unchanged) ---

--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from statistics import median
 from typing import Any, LiteralString
 
-METHOD_VERSION = "fvb_v3"
+METHOD_VERSION = "fvb_v4"
 MIN_PEERS = 8
 PEER_LIMIT = 8
 MIN_OWN_POINTS = 6
@@ -48,6 +48,124 @@ _FINANCIAL_SIC_LO, _FINANCIAL_SIC_HI = 60, 67
 # Re-validate via the acceptance gate on the post-backfill fvb_v3 population.
 _R_UP: dict[str, float] = {"pe": 2.6, "ps": 3.1, "pb": 4.1, "ev_ebitda": 2.8}
 _R_DN: dict[str, float] = {"pe": 2.7, "ps": 4.3, "pb": 2.4, "ev_ebitda": 1.9}
+
+
+@dataclass(frozen=True)
+class CompanionVars:
+    """#2032 (fvb_v4) companion variables — the fundamentals a multiple is a
+    function of (Damodaran: P/S = f(net margin, growth); P/B = f(ROE))."""
+
+    net_margin: float | None
+    rev_growth_yoy: float | None
+    roe: float | None
+
+
+@dataclass(frozen=True)
+class ScreenTier:
+    """One width tier of the companion screen: a peer passes iff, for every
+    non-None width here, BOTH sides have the companion and |peer - target| <=
+    width. None = companion not screened at this tier."""
+
+    net_margin: float | None = None
+    rev_growth_yoy: float | None = None
+    roe: float | None = None
+
+
+# v4 (#2032) companion-screen width tiers, tight -> wide. FROZEN ABSOLUTES —
+# never cohort-relative percentiles (settled no-cohort-relative-normalization
+# invariant; same freeze discipline as _R_UP/_R_DN). Calibrated by the #2032
+# full-population sim (issue comments, 2026-07-15; spec
+# docs/proposals/valuation/2026-07-15-fvb-v4-companion-screen.md §3/§4.1).
+# pe is EXCLUDED: its canonical companion is (forward) EARNINGS growth — no
+# usable source exists, and revenue-YoY as proxy was full-pop tested and
+# refuted (nil tail compression, 505/908 live legs re-anchored = churn without
+# calibration benefit; spec §4.2). Revisit trigger: a forward/normalized
+# earnings-growth source landing in the fundamentals layer.
+_SCREEN_TIERS: dict[str, tuple[ScreenTier, ...]] = {
+    "ps": (
+        ScreenTier(net_margin=0.05, rev_growth_yoy=0.10),
+        ScreenTier(net_margin=0.10, rev_growth_yoy=0.20),
+        ScreenTier(net_margin=0.20, rev_growth_yoy=0.40),
+    ),
+    "ev_ebitda": (
+        ScreenTier(net_margin=0.05, rev_growth_yoy=0.10),
+        ScreenTier(net_margin=0.10, rev_growth_yoy=0.20),
+        ScreenTier(net_margin=0.20, rev_growth_yoy=0.40),
+    ),
+    "pb": (
+        ScreenTier(roe=0.05),
+        ScreenTier(roe=0.10),
+        ScreenTier(roe=0.20),
+    ),
+}
+
+
+def companion_vars(
+    *,
+    revenue_ttm: float | None,
+    net_income_ttm: float | None,
+    shareholders_equity: float | None,
+    rev_prior_ttm: float | None,
+    ttm_start: _dt.date | None,
+    prior_end: _dt.date | None,
+) -> CompanionVars:
+    """§4.5 target-side companion derivation — mirrors the member-side SQL and
+    the validated #2032 sim exactly. Growth requires the prior strict TTM window
+    ADJACENT to the current one: ttm_start - prior_end in [1, 120] days
+    (consecutive quarter-ends sit ~90d apart; >=1 excludes overlap, <=120
+    tolerates a 53-week calendar while excluding a skipped quarter)."""
+    net_margin = None
+    if revenue_ttm is not None and revenue_ttm > 0 and net_income_ttm is not None:
+        net_margin = net_income_ttm / revenue_ttm
+    growth = None
+    if (
+        revenue_ttm is not None
+        and rev_prior_ttm is not None
+        and rev_prior_ttm != 0
+        and ttm_start is not None
+        and prior_end is not None
+        and 1 <= (ttm_start - prior_end).days <= 120
+    ):
+        growth = (revenue_ttm - rev_prior_ttm) / abs(rev_prior_ttm)
+    roe = None
+    if net_income_ttm is not None and shareholders_equity is not None and shareholders_equity > 0:
+        roe = net_income_ttm / shareholders_equity
+    return CompanionVars(net_margin=net_margin, rev_growth_yoy=growth, roe=roe)
+
+
+def screen_passes(tier: ScreenTier, target: CompanionVars, peer: CompanionVars) -> bool:
+    """§4.1 predicate. A NULL companion on EITHER side fails the peer — absence
+    is a data gap, never imputed (two degenerate values must not accidentally
+    match each other; the materialize side additionally NULLs |value| >=
+    _MAX_SANE_MULTIPLE). Boundary |delta| == width passes (the sim used <=)."""
+    for width, tv, pv in (
+        (tier.net_margin, target.net_margin, peer.net_margin),
+        (tier.rev_growth_yoy, target.rev_growth_yoy, peer.rev_growth_yoy),
+        (tier.roe, target.roe, peer.roe),
+    ):
+        if width is None:
+            continue
+        if tv is None or pv is None or abs(pv - tv) > width:
+            return False
+    return True
+
+
+def target_screenable(multiple: str, target: CompanionVars | None) -> bool:
+    """True iff the screen applies to ``multiple`` AND the target carries every
+    companion the tightest tier screens on (tiers screen the same field set at
+    every width, so tier 0 is representative)."""
+    tiers = _SCREEN_TIERS.get(multiple)
+    if tiers is None or target is None:
+        return False
+    t0 = tiers[0]
+    for width, tv in (
+        (t0.net_margin, target.net_margin),
+        (t0.rev_growth_yoy, target.rev_growth_yoy),
+        (t0.roe, target.roe),
+    ):
+        if width is not None and tv is None:
+            return False
+    return True
 
 
 @dataclass(frozen=True)
@@ -335,6 +453,10 @@ class QualityInputs:
     excluded_stale_n: int
     sic_level: int
     cross_multiple_spread: float
+    # v4 (#2032): true iff any CONTRIBUTING peer-backed screenable leg fell
+    # back to the unscreened cohort (spec §4.3). Defaulted so pre-v4
+    # constructors are untouched.
+    screen_fallback: bool = False
 
 
 def band_quality_status(q: QualityInputs) -> str:
@@ -347,6 +469,9 @@ def band_quality_status(q: QualityInputs) -> str:
     score += {4: 2, 3: 1}.get(q.sic_level, 0)
     score += 1 if q.n_selected >= 2 else 0
     score -= 1 if q.cross_multiple_spread > 0.5 else 0
+    # v4 (#2032) §4.3 knock: an unscreened comparability cohort carries less
+    # confidence than a companion-matched one.
+    score -= 1 if q.screen_fallback else 0
     if score >= 7:
         return "high"
     if score >= 4:
@@ -462,11 +587,33 @@ def compute_band(
     max_excluded_stale_n = 0
     max_cohort_n = 0
     contributing_own_points = 0
+    screen_fallback = False
     for m in selected:
         peer = peer_by_multiple.get(m, PeerPct(None, None, None))
         own = own_by_multiple.get(m, OwnPct(None, None, None))
+        meta = cohort_meta.get(m, {})
+        cn, esn = meta.get("cohort_n", 0), meta.get("excluded_stale_n", 0)
+        # Basis entry built BEFORE the synth-None / leg-drop decisions (spec
+        # #2021 §3.4 + v4 spec §4.4): a non-contributing leg's peer stats AND
+        # screen provenance stay auditable on the stored row.
+        entry: dict = {
+            "peer": {"p25": peer.p25, "p50": peer.p50, "p75": peer.p75},
+            "own": {"p25": own.p25, "p50": own.p50, "p75": own.p75},
+            "cohort_n": cn,
+            "excluded_stale_n": esn,
+            "own_points": own_points_by_multiple.get(m, 0),
+            # v4 (#2032) §4.4: per-leg cohort level — the band-level
+            # sic_level=max(...) quality input is not per-leg reconstructable.
+            "sic_level": meta.get("sic_level", 0),
+        }
+        # v4 (#2032) §4.4 screen provenance, present iff the leg is screenable:
+        # held -> {sic_level, width_tier, survivors_n}; fallback -> {reason}.
+        if "cohort_screened" in meta:
+            entry["cohort_screened"] = meta["cohort_screened"]
+            entry["screen"] = meta.get("screen", {})
         synth = synth_multiple(peer, own)
         if synth is None:
+            basis["multiples"][m] = entry
             continue
         low_mult, base_mult, high_mult = synth
         precap_low, precap_high = low_mult, high_mult
@@ -483,23 +630,12 @@ def compute_band(
             ebitda=ev_ebitda_value,
             net_debt_value=ev_net_debt,
         )
-        meta = cohort_meta.get(m, {})
-        cn, esn = meta.get("cohort_n", 0), meta.get("excluded_stale_n", 0)
-        # Basis entry built BEFORE the leg-drop decision (spec #2021 §3.4) so a
-        # dropped leg's peer stats stay auditable on the stored row.
-        entry: dict = {
-            "peer": {"p25": peer.p25, "p50": peer.p50, "p75": peer.p75},
-            "own": {"p25": own.p25, "p50": own.p50, "p75": own.p75},
-            "cohort_n": cn,
-            "excluded_stale_n": esn,
-            "own_points": own_points_by_multiple.get(m, 0),
-            # v2 (#2022) cap audit: the pre-cap wing multiples + whether each was
-            # clamped, so the base*_R_UP/_R_DN clamp is reconstructable from the row.
-            "capped_low": capped_low,
-            "capped_high": capped_high,
-            "precap_low_mult": precap_low,
-            "precap_high_mult": precap_high,
-        }
+        # v2 (#2022) cap audit: the pre-cap wing multiples + whether each was
+        # clamped, so the base*_R_UP/_R_DN clamp is reconstructable from the row.
+        entry["capped_low"] = capped_low
+        entry["capped_high"] = capped_high
+        entry["precap_low_mult"] = precap_low
+        entry["precap_high_mult"] = precap_high
         if m == "ev_ebitda":
             # Conversion inputs — the affine transform is reconstructable from
             # the stored row (mult * ebitda_ttm - net_debt) / shares.
@@ -519,6 +655,11 @@ def compute_band(
         entry["base_value"] = triple[1]
         basis["multiples"][m] = entry
         per_share_triples.append(triple)
+        # v4 (#2032) §4.3: only a CONTRIBUTING peer-backed screenable leg that
+        # fell back unscreened knocks quality (own-only legs have no peer cohort
+        # to screen; dropped/synth-None legs never reach this line).
+        if meta.get("cohort_screened") is False and peer.p50 is not None:
+            screen_fallback = True
         sides = (1 if peer.p50 is not None else 0) + (1 if own.p50 is not None else 0)
         max_sides = max(max_sides, sides)
         max_cohort_n = max(max_cohort_n, cn)
@@ -541,6 +682,7 @@ def compute_band(
             excluded_stale_n=max_excluded_stale_n,
             sic_level=sic_level,
             cross_multiple_spread=spread,
+            screen_fallback=screen_fallback,
         )
     )
     return BandResult(bear, base, bull, quality, "ok", t.target_basis, len(selected), basis)
@@ -626,7 +768,8 @@ def resolve_cohort_members_as_of_date(conn: psycopg.Connection[Any]) -> _dt.date
 _MATERIALIZE_SQL = """
 INSERT INTO fair_value_cohort_members
     (as_of_date, instrument_id, multiple, mult_value, sic, sic3, sic2,
-     total_assets, close_date, dual_class_suppressed)
+     total_assets, close_date, dual_class_suppressed,
+     net_margin, rev_growth_yoy, roe)
 WITH asof_price AS (
     SELECT DISTINCT ON (pd.instrument_id)
            pd.instrument_id,
@@ -647,6 +790,36 @@ dual_class AS (
       AND ei.identifier_type = 'cik'
       AND ei.is_primary = TRUE
 ),
+prior_ttm AS (
+    -- v4 (#2032) §4.5 growth denominator: the PRIOR strict TTM window (quarters
+    -- rn 5-8 of the same deduped/ranked series sql/220 builds its rn 1-4 from).
+    -- Same strictness: 4 rows, span <= 330d, revenue present in all 4.
+    SELECT instrument_id,
+           CASE WHEN count(*) = 4
+                     AND (max(period_end_date) - min(period_end_date)) <= 330
+                     AND count(revenue) = 4
+                THEN sum(revenue) END AS rev_prior_ttm,
+           max(period_end_date) AS prior_end
+    FROM (
+        SELECT instrument_id, period_end_date, revenue,
+               ROW_NUMBER() OVER (
+                   PARTITION BY instrument_id
+                   ORDER BY period_end_date DESC
+               ) AS rn
+        FROM (
+            -- dedup mirror of sql/220 deduped_quarters (latest-filed wins).
+            SELECT DISTINCT ON (instrument_id, period_end_date)
+                   instrument_id, period_end_date, revenue
+            FROM financial_periods
+            WHERE period_type IN ('Q1','Q2','Q3','Q4')
+              AND superseded_at IS NULL
+              AND normalization_status = 'normalized'
+            ORDER BY instrument_id, period_end_date, filed_date DESC NULLS LAST
+        ) dq
+    ) rq
+    WHERE rq.rn BETWEEN 5 AND 8
+    GROUP BY instrument_id
+),
 base AS (
     SELECT
         ap.instrument_id,
@@ -658,6 +831,8 @@ base AS (
         ttm.total_assets,
         ttm.eps_diluted_ttm,
         ttm.revenue_ttm,
+        ttm.net_income_ttm,
+        ttm.ttm_start,
         ttm.shareholders_equity,
         ttm.shares_outstanding,
         ttm.operating_income_ttm,
@@ -666,6 +841,8 @@ base AS (
         ttm.short_term_debt,
         ttm.cash,
         ttm.interest_expense_ttm,
+        pt.rev_prior_ttm,
+        pt.prior_end,
         (dc.instrument_id IS NOT NULL) AS dual_class_suppressed
     FROM asof_price ap
     JOIN financial_periods_ttm ttm
@@ -674,25 +851,53 @@ base AS (
       ON sp.instrument_id = ap.instrument_id
     LEFT JOIN dual_class dc
       ON dc.instrument_id = ap.instrument_id
+    LEFT JOIN prior_ttm pt
+      ON pt.instrument_id = ap.instrument_id
+),
+-- v4 (#2032) §4.5 member companions, identical derivation to the Python-side
+-- companion_vars(). Each NULLed when |value| >= %(max_mult)s: a tiny-denominator
+-- ratio is a degenerate artifact — NULLing guarantees degenerate PAIRS cannot
+-- accidentally screen-match, and keeps numeric(18,6) unreachable by overflow.
+companions AS (
+    SELECT b.*,
+        CASE WHEN b.revenue_ttm > 0 AND b.net_income_ttm IS NOT NULL
+                  AND abs(b.net_income_ttm / b.revenue_ttm) < %(max_mult)s
+             THEN b.net_income_ttm / b.revenue_ttm END AS net_margin,
+        CASE WHEN b.revenue_ttm IS NOT NULL
+                  AND b.rev_prior_ttm IS NOT NULL AND b.rev_prior_ttm <> 0
+                  AND b.ttm_start IS NOT NULL AND b.prior_end IS NOT NULL
+                  -- cross-window adjacency (§4.5): consecutive quarter-ends sit
+                  -- ~90d apart; >=1 excludes overlap, <=120 tolerates a 53-week
+                  -- calendar while excluding a skipped quarter.
+                  AND (b.ttm_start - b.prior_end) BETWEEN 1 AND 120
+                  AND abs((b.revenue_ttm - b.rev_prior_ttm) / abs(b.rev_prior_ttm)) < %(max_mult)s
+             THEN (b.revenue_ttm - b.rev_prior_ttm) / abs(b.rev_prior_ttm) END AS rev_growth_yoy,
+        CASE WHEN b.net_income_ttm IS NOT NULL AND b.shareholders_equity > 0
+                  AND abs(b.net_income_ttm / b.shareholders_equity) < %(max_mult)s
+             THEN b.net_income_ttm / b.shareholders_equity END AS roe
+    FROM base b
 ),
 per_multiple AS (
     SELECT instrument_id, 'pe'::text AS multiple,
            (close / eps_diluted_ttm) AS mult_value,
-           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed
-    FROM base WHERE eps_diluted_ttm > 0
+           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed,
+           net_margin, rev_growth_yoy, roe
+    FROM companions WHERE eps_diluted_ttm > 0
     UNION ALL
     -- P/S = price*shares/revenue (mirrors sql/201 price_sales); target conversion
     -- mult*(revenue/shares) recovers price => one shared multiple definition.
     SELECT instrument_id, 'ps'::text,
            ((close * shares_outstanding) / revenue_ttm),
-           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed
-    FROM base WHERE revenue_ttm > 0 AND shares_outstanding > 0
+           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed,
+           net_margin, rev_growth_yoy, roe
+    FROM companions WHERE revenue_ttm > 0 AND shares_outstanding > 0
     UNION ALL
     -- P/B = price*shares/equity (mirrors sql/201 pb_ratio = price/(equity/shares)).
     SELECT instrument_id, 'pb'::text,
            ((close * shares_outstanding) / shareholders_equity),
-           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed
-    FROM base WHERE shareholders_equity > 0 AND shares_outstanding > 0
+           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed,
+           net_margin, rev_growth_yoy, roe
+    FROM companions WHERE shareholders_equity > 0 AND shares_outstanding > 0
     UNION ALL
     -- EV/EBITDA (#2021) = (close*shares + debt - cash) / (OpInc + D&A) —
     -- mirrors sql/201:128-135. Strict EBITDA: a NULL op/d&a propagates and the
@@ -705,8 +910,9 @@ per_multiple AS (
            ((close * shares_outstanding)
             + COALESCE(long_term_debt, 0) + COALESCE(short_term_debt, 0) - cash)
            / (operating_income_ttm + depreciation_amort_ttm),
-           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed
-    FROM base
+           sic, sic3, sic2, total_assets, close_date, dual_class_suppressed,
+           net_margin, rev_growth_yoy, roe
+    FROM companions
     WHERE (operating_income_ttm + depreciation_amort_ttm) > 0
       AND shares_outstanding > 0
       AND cash IS NOT NULL
@@ -714,7 +920,8 @@ per_multiple AS (
                AND COALESCE(interest_expense_ttm, 0) > 0)
 )
 SELECT %(as_of)s, instrument_id, multiple, mult_value, sic, sic3, sic2,
-       total_assets, close_date, dual_class_suppressed
+       total_assets, close_date, dual_class_suppressed,
+       net_margin, rev_growth_yoy, roe
 FROM per_multiple
 -- mult_value > 0 gates junk; < %(max_mult)s prevents a tiny-denominator garbage
 -- multiple from overflowing numeric(18,6) and aborting the whole batch INSERT
@@ -743,21 +950,24 @@ def materialize_cohort_members(conn: psycopg.Connection[Any], as_of_date: _dt.da
 # curated-oracle members drop out of those medians, mirroring sql/201:254).
 _MEMBER_SQL: dict[int, LiteralString] = {
     4: """
-        SELECT instrument_id, mult_value, total_assets, close_date, dual_class_suppressed
+        SELECT instrument_id, mult_value, total_assets, close_date, dual_class_suppressed,
+               net_margin, rev_growth_yoy, roe
         FROM fair_value_cohort_members
         WHERE as_of_date = %(as_of)s AND multiple = %(m)s AND sic = %(prefix)s
           AND instrument_id <> %(target)s
           AND (%(keep_dual)s OR NOT dual_class_suppressed)
         """,
     3: """
-        SELECT instrument_id, mult_value, total_assets, close_date, dual_class_suppressed
+        SELECT instrument_id, mult_value, total_assets, close_date, dual_class_suppressed,
+               net_margin, rev_growth_yoy, roe
         FROM fair_value_cohort_members
         WHERE as_of_date = %(as_of)s AND multiple = %(m)s AND sic3 = %(prefix)s
           AND instrument_id <> %(target)s
           AND (%(keep_dual)s OR NOT dual_class_suppressed)
         """,
     2: """
-        SELECT instrument_id, mult_value, total_assets, close_date, dual_class_suppressed
+        SELECT instrument_id, mult_value, total_assets, close_date, dual_class_suppressed,
+               net_margin, rev_growth_yoy, roe
         FROM fair_value_cohort_members
         WHERE as_of_date = %(as_of)s AND multiple = %(m)s AND sic2 = %(prefix)s
           AND instrument_id <> %(target)s
@@ -772,6 +982,15 @@ def _sic_prefix(sic: str | None, level: int) -> str | None:
     return sic[:level]
 
 
+def _member_companions(r: dict[str, Any]) -> CompanionVars:
+    """Member-row companion view (Decimal -> float)."""
+    return CompanionVars(
+        net_margin=_f(r["net_margin"]),
+        rev_growth_yoy=_f(r["rev_growth_yoy"]),
+        roe=_f(r["roe"]),
+    )
+
+
 def peer_pct_for(
     conn: psycopg.Connection[Any],
     target_id: int,
@@ -779,6 +998,7 @@ def peer_pct_for(
     target_total_assets: float | None,
     multiple: str,
     as_of_date: _dt.date,
+    target_companions: CompanionVars | None = None,
 ) -> tuple[PeerPct, dict]:
     """Pass-2 comparator (a) (§4.3): read the member set for ``multiple`` at
     ``as_of_date``; walk SIC-4->3->2 to the first prefix with >= MIN_PEERS FRESH
@@ -787,49 +1007,61 @@ def peer_pct_for(
     percentiles(mults, (0.25,0.5,0.75)) in PURE Python (the SAME percentiles() as
     own-history -> guaranteed agreement).
 
+    v4 (#2032): when ``multiple`` is screenable AND the target carries its
+    companions, a SCREENED pass runs first — width-major (the validated sim's
+    frozen semantics, v4 spec §4.1): for each width tier tight->wide, walk the
+    full SIC ladder 4->3->2 filtering fresh members by the companion predicate;
+    the first (width, level) whose screened survivors clear MIN_PEERS both
+    pre- and post-size-refine wins, with screen provenance in the meta. Screen
+    exhausted (or target companion missing) -> the UNSCREENED walk below runs
+    unchanged, with ``cohort_screened: False`` + the reason in the meta.
+    Non-screenable multiples (pe) skip the screened pass and carry no screen keys.
+
     INVARIANT (A4 review): never returns a partial some-None triple — percentiles()
     yields all three, and the MIN_PEERS-unmet path returns PeerPct(None,None,None).
-    Returns (PeerPct, {"cohort_n","excluded_stale_n","sic_level"})."""
+    Returns (PeerPct, {"cohort_n","excluded_stale_n","sic_level"[,"cohort_screened","screen"]})."""
     keep_dual = multiple == "pe"
     cutoff = as_of_date - _dt.timedelta(days=PEER_STALE_DAYS)
-    fallback_meta = {"cohort_n": 0, "excluded_stale_n": 0, "sic_level": 0}
 
-    for level in (4, 3, 2):
-        prefix = _sic_prefix(target_sic, level)
-        if prefix is None:
-            continue
-        with conn.cursor(row_factory=dict_row) as cur:
-            cur.execute(
-                _MEMBER_SQL[level],
-                {
-                    "as_of": as_of_date,
-                    "m": multiple,
-                    "prefix": prefix,
-                    "target": target_id,
-                    "keep_dual": keep_dual,
-                },
-            )
-            rows = cur.fetchall()
-        if not rows:
-            continue
-        fresh = [r for r in rows if r["close_date"] >= cutoff]
-        excluded_stale_n = len(rows) - len(fresh)
-        # Widest cohort we saw, in case no level clears MIN_PEERS.
-        fallback_meta = {
-            "cohort_n": len(rows),
-            "excluded_stale_n": excluded_stale_n,
-            "sic_level": 0,
-        }
-        if len(fresh) < MIN_PEERS:
-            continue
+    # One member fetch per SIC level, shared by the screened pass (which may
+    # touch every level per width tier) and the unscreened fallback walk.
+    rows_cache: dict[int, list[dict[str, Any]] | None] = {}
 
+    def _rows(level: int) -> list[dict[str, Any]] | None:
+        if level not in rows_cache:
+            prefix = _sic_prefix(target_sic, level)
+            if prefix is None:
+                rows_cache[level] = None
+            else:
+                with conn.cursor(row_factory=dict_row) as cur:
+                    cur.execute(
+                        _MEMBER_SQL[level],
+                        {
+                            "as_of": as_of_date,
+                            "m": multiple,
+                            "prefix": prefix,
+                            "target": target_id,
+                            "keep_dual": keep_dual,
+                        },
+                    )
+                    rows_cache[level] = cur.fetchall()
+        return rows_cache[level]
+
+    def _refine(fresh: list[dict[str, Any]]) -> list[float]:
+        """Size-refine fresh rows to the nearest PEER_LIMIT positive multiples.
+
+        F1 (High): _rank_peers DROPS members with missing/non-positive
+        total_assets, so a set with >= MIN_PEERS FRESH members can still
+        size-refine to < MIN_PEERS asset-usable peers. Callers re-check the
+        MIN_PEERS invariant AFTER size-ranking; if it fails they widen (same as
+        the pre-rank check) and go comparator-absent (all-None, fallback_meta)
+        if nothing clears it. This also subsumes the empty-chosen case and
+        preserves the all-None-or-all-three partial-triple invariant."""
         mult_by_id: dict[int, float] = {}
         for r in fresh:
             v = _f(r["mult_value"])
             if v is not None and v > 0:
                 mult_by_id[int(r["instrument_id"])] = v
-
-        chosen: list[float]
         if target_total_assets and target_total_assets > 0 and len(mult_by_id) > PEER_LIMIT:
             rank_rows = [
                 {
@@ -852,29 +1084,86 @@ def peer_pct_for(
                 chosen = list(mult_by_id.values())
         else:
             chosen = list(mult_by_id.values())
+        return chosen
 
-        # F1 (High): _rank_peers DROPS members with missing/non-positive
-        # total_assets, so a level with >= MIN_PEERS FRESH members can still
-        # size-refine to < MIN_PEERS asset-usable peers. Re-check the MIN_PEERS
-        # invariant AFTER size-ranking; if it fails, widen the SIC ladder (same
-        # as the pre-rank fresh check) and go comparator-absent (all-None,
-        # fallback_meta) if no wider level clears it. This also subsumes the
-        # empty-chosen case. Preserves the all-None-or-all-three partial-triple
-        # invariant (percentiles() below always yields all three).
-        if len(chosen) < MIN_PEERS:
+    # --- v4 screened pass (width-major, spec §4.1) ---
+    tiers = _SCREEN_TIERS.get(multiple)
+    screen_reason: str | None = None
+    if tiers is not None:
+        tc = target_companions
+        if tc is None or not target_screenable(multiple, tc):
+            screen_reason = "target_companion_missing"
+        else:
+            for width_tier, tier in enumerate(tiers):
+                for level in (4, 3, 2):
+                    rows = _rows(level)
+                    if not rows:
+                        continue
+                    fresh = [r for r in rows if r["close_date"] >= cutoff]
+                    survivors = [r for r in fresh if screen_passes(tier, tc, _member_companions(r))]
+                    if len(survivors) < MIN_PEERS:
+                        continue
+                    chosen = _refine(survivors)
+                    if len(chosen) < MIN_PEERS:
+                        continue
+                    p25, p50, p75 = percentiles(chosen, (0.25, 0.5, 0.75))
+                    return PeerPct(p25=p25, p50=p50, p75=p75), {
+                        "cohort_n": len(rows),
+                        "excluded_stale_n": len(rows) - len(fresh),
+                        "sic_level": level,
+                        "cohort_screened": True,
+                        "screen": {
+                            "sic_level": level,
+                            "width_tier": width_tier,
+                            "survivors_n": len(survivors),
+                        },
+                    }
+            screen_reason = "no_screened_cohort"
+
+    # --- unscreened walk (pre-v4 semantics, unchanged) ---
+    fallback_meta: dict[str, Any] = {"cohort_n": 0, "excluded_stale_n": 0, "sic_level": 0}
+    result: tuple[PeerPct, dict] | None = None
+    for level in (4, 3, 2):
+        rows = _rows(level)
+        if not rows:
             continue
-
-        p25, p50, p75 = percentiles(chosen, (0.25, 0.5, 0.75))
-        return PeerPct(p25=p25, p50=p50, p75=p75), {
+        fresh = [r for r in rows if r["close_date"] >= cutoff]
+        excluded_stale_n = len(rows) - len(fresh)
+        # Widest cohort we saw, in case no level clears MIN_PEERS.
+        fallback_meta = {
             "cohort_n": len(rows),
             "excluded_stale_n": excluded_stale_n,
-            "sic_level": level,
+            "sic_level": 0,
         }
+        if len(fresh) < MIN_PEERS:
+            continue
+        chosen = _refine(fresh)
+        if len(chosen) < MIN_PEERS:
+            continue
+        p25, p50, p75 = percentiles(chosen, (0.25, 0.5, 0.75))
+        result = (
+            PeerPct(p25=p25, p50=p50, p75=p75),
+            {
+                "cohort_n": len(rows),
+                "excluded_stale_n": excluded_stale_n,
+                "sic_level": level,
+            },
+        )
+        break
 
-    return PeerPct(None, None, None), fallback_meta
+    pct, meta = result if result is not None else (PeerPct(None, None, None), fallback_meta)
+    if screen_reason is not None:
+        # v4 §4.4: an attempted-but-unheld screen leaves its audit trail even
+        # when the unscreened walk is also peer-absent.
+        meta["cohort_screened"] = False
+        meta["screen"] = {"reason": screen_reason}
+    return pct, meta
 
 
 # Target inputs: strict-TTM denominators + SIC + reporting/instrument currency.
+# v4 (#2032): + ttm_start and the prior strict-TTM revenue window (LATERAL,
+# sql/220 dedup/strictness mirror — same shape as _MATERIALIZE_SQL's prior_ttm
+# CTE) so companion_vars() can derive the target-side growth companion.
 _TARGET_SQL = """
     SELECT
         ttm.eps_diluted_ttm,
@@ -891,6 +1180,9 @@ _TARGET_SQL = """
         ttm.reported_currency,
         ttm.total_assets,
         ttm.ttm_end,
+        ttm.ttm_start,
+        prior.rev_prior_ttm,
+        prior.prior_end,
         sp.sic          AS sic,
         i.currency      AS instrument_currency
     FROM instruments i
@@ -898,6 +1190,28 @@ _TARGET_SQL = """
       ON ttm.instrument_id = i.instrument_id AND ttm.is_complete_ttm = TRUE
     LEFT JOIN instrument_sec_profile sp
       ON sp.instrument_id = i.instrument_id
+    LEFT JOIN LATERAL (
+        SELECT
+            CASE WHEN count(*) = 4
+                      AND (max(period_end_date) - min(period_end_date)) <= 330
+                      AND count(revenue) = 4
+                 THEN sum(revenue) END AS rev_prior_ttm,
+            max(period_end_date) AS prior_end
+        FROM (
+            SELECT period_end_date, revenue,
+                   ROW_NUMBER() OVER (ORDER BY period_end_date DESC) AS rn
+            FROM (
+                SELECT DISTINCT ON (period_end_date) period_end_date, revenue
+                FROM financial_periods
+                WHERE instrument_id = i.instrument_id
+                  AND period_type IN ('Q1','Q2','Q3','Q4')
+                  AND superseded_at IS NULL
+                  AND normalization_status = 'normalized'
+                ORDER BY period_end_date, filed_date DESC NULLS LAST
+            ) dq
+        ) rq
+        WHERE rq.rn BETWEEN 5 AND 8
+    ) prior ON TRUE
     WHERE i.instrument_id = %(iid)s
 """
 
@@ -1053,6 +1367,17 @@ def compute_band_for_instrument(conn: psycopg.Connection[Any], instrument_id: in
         reason = "multiclass_unavailable" if target_basis == "multiclass_unavailable" else "no_multiple"
         return _stamp(_absent(t, reason), ttm_end, price_as_of)
 
+    # v4 (#2032): target-side companions, derived from the SAME strict-TTM row +
+    # prior-TTM lateral the members use (spec §4.5) — one shared definition.
+    target_cv = companion_vars(
+        revenue_ttm=t.revenue_ttm,
+        net_income_ttm=t.net_income_ttm,
+        shareholders_equity=t.shareholders_equity,
+        rev_prior_ttm=_f(trow["rev_prior_ttm"]),
+        ttm_start=trow["ttm_start"],
+        prior_end=trow["prior_end"],
+    )
+
     own_all, own_capped_total = _own_series(conn, instrument_id, as_of_date)
     own_by_multiple: dict[str, OwnPct] = {}
     own_points_by_multiple: dict[str, int] = {}
@@ -1062,7 +1387,15 @@ def compute_band_for_instrument(conn: psycopg.Connection[Any], instrument_id: in
     for m in selected:
         own_by_multiple[m] = own_range(own_all[m])
         own_points_by_multiple[m] = len(own_all[m])
-        peer, meta = peer_pct_for(conn, instrument_id, target_sic, target_total_assets, m, as_of_date)
+        peer, meta = peer_pct_for(
+            conn,
+            instrument_id,
+            target_sic,
+            target_total_assets,
+            m,
+            as_of_date,
+            target_companions=target_cv,
+        )
         peer_by_multiple[m] = peer
         cohort_meta[m] = meta
         sic_level = max(sic_level, int(meta.get("sic_level", 0)))

--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -1026,6 +1026,9 @@ def peer_pct_for(
 
     # One member fetch per SIC level, shared by the screened pass (which may
     # touch every level per width tier) and the unscreened fallback walk.
+    # Keyed by level ONLY: every other query param (multiple, keep_dual,
+    # as_of_date, target) is fixed for the lifetime of this call — the cache
+    # must not outlive it (review NITPICK, PR #2045).
     rows_cache: dict[int, list[dict[str, Any]] | None] = {}
 
     def _rows(level: int) -> list[dict[str, Any]] | None:

--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -151,9 +151,10 @@ def screen_passes(tier: ScreenTier, target: CompanionVars, peer: CompanionVars) 
 
 
 def target_screenable(multiple: str, target: CompanionVars | None) -> bool:
-    """True iff the screen applies to ``multiple`` AND the target carries every
-    companion the tightest tier screens on (tiers screen the same field set at
-    every width, so tier 0 is representative)."""
+    """True iff the screen applies to ``multiple`` AND the given side carries
+    every companion the tightest tier screens on (tiers screen the same field
+    set at every width, so tier 0 is representative). Used for the target gate
+    AND the member-side companions-present check (deploy-window guard)."""
     tiers = _SCREEN_TIERS.get(multiple)
     if tiers is None or target is None:
         return False
@@ -1119,6 +1120,22 @@ def peer_pct_for(
                         },
                     }
             screen_reason = "no_screened_cohort"
+            # Deploy-window guard (Codex ckpt-2 P2): a single-name cascade may
+            # anchor to a cohort materialized BEFORE the sql/228 backfill, whose
+            # companion columns are all NULL — that is "the cohort carries no
+            # companion data", not "no comparable peers exist at any width".
+            # Annotate distinctly so the stored provenance never claims a screen
+            # that had no inputs. (Values are unaffected either way: the
+            # unscreened fallback below IS the pre-v4 walk.) The screened pass
+            # visits every ladder level before landing here, so rows_cache holds
+            # the full member set this walk can ever see.
+            if not any(
+                target_screenable(multiple, _member_companions(r))
+                for cached in rows_cache.values()
+                if cached
+                for r in cached
+            ):
+                screen_reason = "cohort_companions_missing"
 
     # --- unscreened walk (pre-v4 semantics, unchanged) ---
     fallback_meta: dict[str, Any] = {"cohort_n": 0, "excluded_stale_n": 0, "sic_level": 0}

--- a/docs/proposals/valuation/2026-07-15-fvb-v4-companion-screen.md
+++ b/docs/proposals/valuation/2026-07-15-fvb-v4-companion-screen.md
@@ -1,0 +1,118 @@
+# Fair-value band v4 — companion-variable peer screen (#2032)
+
+**Status:** proposal, 2026-07-15. Operator GO + domain-subagent verdict GO confirmed 2026-07-15 (both on issue #2032). Three binding verdict modifications folded (§4.2, §5, §7).
+**Extends:** [`2026-07-13-fair-value-band-v2-robustness.md`](./2026-07-13-fair-value-band-v2-robustness.md) §4 part 4 / §5 Phase 2 (the root-cause fix), [`2026-07-15-fair-value-band-ev-ebitda.md`](./2026-07-15-fair-value-band-ev-ebitda.md) (ev leg joins the screen).
+**Method version:** `fvb_v3` → **`fvb_v4`** (base changes for re-screened cohorts). **Not a scoring `model_version`** — the band is not a scoring input.
+
+---
+
+## 1. Problem
+
+The pass-2 peer cohort (`peer_pct_for`) is matched on SIC + size only. A multiple is a function of its **companion variables** (§2); a cohort unmatched on them mixes regimes — AAPL (27% net margin, mature) draws ANET (38% margin, high-growth, P/S 24×) and FTNT (16×) as "peers", inflating `peer.p75` and the bull wing. The v2 cap bounds the tail ratio but cannot fix comparability (v2 spec §6.2 honesty note). This is the root-cause fix deferred as Phase 2.
+
+## 2. Source rule
+
+- **Damodaran** ([ps.pdf](https://pages.stern.nyu.edu/~adamodar/pdfiles/eqnotes/ps.pdf)): `P/S = net margin · payout · (1+g)/(r−g)` — P/S is a function of **net margin AND growth**. P/B ↔ **ROE**; P/E ↔ **(forward) earnings growth**. EV/Sales-class multiples share the margin+growth companions; EV/EBITDA screened on the same pair.
+- **McKinsey/Koller**, *The right role for multiples*: match peers on ROIC & growth, not industry membership alone. **Alford 1992 / Bhojraj & Lee 2002**: fundamental-matched comparables beat pure-industry cohorts.
+- **Screen constants are frozen absolutes**, not cohort-relative percentiles — required by the settled no-cohort-relative-normalization invariant (`docs/settled-decisions.md`) and the R_UP/R_DN freeze discipline (v2 spec §6.2). The domain verdict explicitly disqualified quantile/bucket widths and nearest-k-on-companion (silently hands back the least-bad-8 — the ANET/FTNT failure mode).
+
+## 3. Full-population verification (dev, 2026-07-15 — issue #2032 comments)
+
+Standalone sim replicating `peer_pct_for` exactly (SIC 4→3→2 walk, 7d fresh gate, MIN_PEERS=8, real `_rank_peers`, same `percentiles()`), **validated against the stored AAPL fvb_v3 basis to 6dp**. Two variants: `fresh7` (live semantics on stale-censored dev) and `nogate` (proxy for first fresh-price population). Harness preserved in memory `project_2032_sim_harness.md`.
+
+- Companion availability (of members): margin 92.8–93.5%, growth 74.7–85.1%, ROE 93.0%. Real but not fatal.
+- Screen effect, `ratio_up p95` (peer p75/p50, the wing-tail metric), nogate: **ps 4.95→3.15, pb 2.54→1.79 (fresh7 3.56→1.38), ev 3.86→2.84**. Held-of-screenable: ps 50.5% fresh7 / 63.2% nogate; pb 93.5/90.2; ev ~83/85.
+- **pe: nil** (fresh7 2.27→2.29; nogate 2.78→2.63) while re-anchoring 505/908 live legs both directions (AAPL improves, MSFT widens) → manufactured churn by the judge-by-calibration principle (v2 spec §2) → **excluded** (§4.2).
+- AAPL (fresh7 = exact live cohorts): ps peer p75 24.46→11.86; band bear 202→152, base 321→299 (−6.9%), bull 753→511, bull/base 2.35→1.71.
+- **DCTH-class NOT fixed** (no screened cohort at any width → falls back + flag). Its defect is cross-leg base disagreement (36.8×) → **#2043, separate ticket**, not bundled.
+
+## 4. Design
+
+### 4.1 Screen semantics
+
+Companion screen on the **fresh** member set, per multiple:
+
+| leg | companions | width tiers (tight → wide, frozen absolutes) |
+| --- | --- | --- |
+| `ps` | net margin + revenue growth YoY | (±0.05, ±0.10) → (±0.10, ±0.20) → (±0.20, ±0.40) |
+| `ev_ebitda` | net margin + revenue growth YoY | same as ps |
+| `pb` | ROE | ±0.05 → ±0.10 → ±0.20 |
+| `pe` | — excluded (§4.2) | — |
+
+Predicate: peer passes iff every companion in the tier is non-NULL on **both** sides and `|peer − target| ≤ width`. NULL companion on either side fails the peer (no imputation — absence is a data gap, not a zero).
+
+**Walk order — width-major (the validated sim's semantics):** for each width tier tight→wide, walk the full SIC ladder 4→3→2; at each level, screen the fresh members; if screened survivors ≥ `MIN_PEERS`, size-refine (nearest-8 `_rank_peers`) and re-check ≥ `MIN_PEERS` post-refine (the F1 invariant); first (width, level) that clears wins. All tiers exhausted → fallback (§4.3).
+
+> **Walk-order decision (full-population verified, Codex ckpt-1 MED-1):** the issue GO comment labels the walk "D1 level-outer" but its prose (level-outer, widths inner) and the validated sim harness (width-major: each width walks the full ladder) implement two different orders. A dedicated full-pop comparison of BOTH orders over all 569 stored fvb_v3 `ok` bands (fresh7, dev 2026-07-15, `fvb_order_compare.py`) found: **hold/fallback identical by construction** (both scan the same (width, level) cells; fallback ⇔ none clears); chosen cell differs on ps 62/152, ev 29/113, pb 4/85 held legs; **width-major compresses the wing tail better where they diverge** (`ratio_up p95`: ps 2.21 vs 2.42, ev 2.57 vs 2.78, pb identical 1.42) at slightly higher leg-p50 churn (ps |Δp50| med 28.1% vs 25.2%); **band-level base shifts statistically indistinguishable** (|Δbase| p50 0.000 both, >10% movers 96 vs 91 of 569). **v4 freezes width-major** — it wins the calibration metric (tail compression), matches every number in §3 and the §7 gate predictions, and is the Damodaran/Alford direction (fundamental comparability dominates industry membership).
+
+Target lacking a required companion for the leg ⇒ screen not attempted; unscreened walk + `cohort_screened: false`, screen reason `target_companion_missing`.
+
+### 4.2 pe exclusion — wrong-companion / data-gated (verdict binding mod 1)
+
+P/E's canonical companion is **(forward) earnings growth** (Damodaran). We have no usable forward or normalized earnings-growth source; revenue-YoY as proxy was full-pop tested and **refuted** (nil tail compression, 505/908 legs re-anchored — churn without calibration benefit). This is NOT "P/E screening unnecessary": it is the wrong companion + a data gap. **Revisit trigger:** a forward or normalized earnings-growth source landing in the fundamentals layer reopens pe screening as its own ticket. P/E meanwhile keeps the strongest existing discipline (most two-sided legs; tightest R-caps).
+
+### 4.3 Fallback + quality knock
+
+Screen exhausted (or target companion missing) ⇒ the **current unscreened walk, unchanged** (same ladder, same fresh gate, same size refine, same `fallback_meta`), plus:
+
+- `cohort_screened: false` + screen reason in the leg's basis entry (§4.4);
+- quality knock (Codex ckpt-1 MED-4, made precise): `QualityInputs` gains `screen_fallback: bool = False`; `band_quality_status` subtracts 1 point when it is true. `compute_band` sets it true iff any **contributing** leg (appended to `per_share_triples` — synth-None legs and `dropped_nonpositive` ev legs are non-contributing and never knock) is screenable (`m ∈ {ps, pb, ev_ebitda}`), peer-backed (`peer.p50` present), and `cohort_screened` false. Own-only legs are not knocked — there is no peer cohort to screen; they are already handicapped via `n_comparator_sides`.
+
+A high fallback rate is the finding, not mis-design (verdict): no comparable set exists ⇒ truthful flag beats a vacuous screen.
+
+### 4.4 Screen provenance in stored basis (verdict binding mod 2)
+
+Per screenable leg, `basis_json.multiples[m]` gains (same reconstructability discipline as `precap_*`/`capped_*`):
+
+- held: `"cohort_screened": true, "screen": {"sic_level": L, "width_tier": i, "survivors_n": n}` (`width_tier` = 0-based index into the frozen tier table; `survivors_n` = post-screen fresh count pre-refine);
+- fallback: `"cohort_screened": false, "screen": {"reason": "no_screened_cohort" | "target_companion_missing"}`.
+
+`pe` legs carry neither key (screen not applicable). Width constants live in code under `METHOD_VERSION` pinning — (tier index, method_version) fully reconstructs the widths.
+
+**Per-leg cohort level (Codex ckpt-1 re-pass #1):** every leg's basis entry additionally records `"sic_level"` from its own cohort meta (held legs: the screened walk's level, duplicating `screen.sic_level`; fallback/unscreened/pe legs: the unscreened walk's level, 0 when peer-absent) — the band-level `sic_level = max(...)` quality input is not per-leg reconstructable, and a fallback leg's contributing cohort level would otherwise be lost.
+
+**Provenance survives non-contribution (Codex ckpt-1 MED-3):** `compute_band` today skips the basis entry entirely when `synth_multiple` returns None (both comparator sides absent). v4 builds the basis entry for **every selected leg** — peer/own percentile stats (possibly all-None) + cohort meta + screen provenance — before the synth-None continue, so a screened-leg fallback whose peer side then failed MIN_PEERS everywhere still leaves its screen audit trail on the stored row. Legs without a synth contribute nothing (no `base_value` key), same as the dropped-ev precedent.
+
+### 4.5 Companion variable definitions (sql/220 strictness mirror — the validated sim's exact derivation)
+
+**Source rule (Codex ckpt-1 MED-5 — explicit deferral):** every treatment below defers to the settled repo rule set, not first principles: quarter selection (`period_type IN (Q1..Q4)`, `superseded_at IS NULL`, `normalization_status='normalized'`, latest-`filed_date` wins per `period_end_date`), strict 4-quarter flow sums, the ≤330d window-span adjacency bound, and latest-quarter stock items are all `sql/220_ttm_strict_flow_sums.sql` + its spec `docs/specs/fundamentals/2026-07-12-2008-ttm-reconciliation.md` (#2008; interim-period treatment grounded in Reg S-X Art. 10, 17 CFR 210.10-01(c) — see also #2036's 10-01(c)(3) YTD de-cumulation). The one NEW rule this spec adds is the **cross-window adjacency bound** `ttm_start − prior_end ∈ [1, 120]` days: consecutive quarter-ends sit ~90d apart (the sql/220 comment's own 91–92d arithmetic); ≥1 excludes overlapping/duplicate windows, ≤120 tolerates a 53-week fiscal calendar while excluding a skipped quarter (~180d+). Full-pop validated: growth coverage 74.7–85.1% of members (§3) under this bound.
+
+- **net margin** = `net_income_ttm / revenue_ttm`, requires `revenue_ttm > 0`, `net_income_ttm` non-NULL.
+- **revenue growth YoY** = `(revenue_ttm − rev_prior_ttm) / abs(rev_prior_ttm)`; prior TTM = quarters rn 5–8 of the same deduped/ranked series (`DISTINCT ON (instrument_id, period_end_date)`, latest-filed wins, `period_type IN (Q1..Q4)`, not superseded, normalized), strict: COUNT(*)=4 AND span ≤ 330d AND COUNT(revenue)=4; **window adjacency**: `ttm_start − prior_end ∈ [1, 120]` days; `rev_prior ≠ 0`.
+- **ROE** = `net_income_ttm / shareholders_equity` (latest-quarter stock item, rn=1 — same row the ttm view reads), requires equity > 0.
+
+## 5. Schema + write path
+
+- **sql/228** (additive; sql/221/226 immutable per migration-content-drift rule): `ALTER TABLE fair_value_cohort_members ADD COLUMN IF NOT EXISTS net_margin numeric(18,6), rev_growth_yoy numeric(18,6), roe numeric(18,6)` — nullable; pre-v4 as_of rows stay NULL (never re-read: each materialize DELETE+INSERTs its as_of).
+- **`_MATERIALIZE_SQL`**: prior-TTM CTE (dedup+rank mirror of sql/220, rn 5–8, strict window, `prior_end`) LEFT-joined into `base`; companions computed per §4.5 and written on every member row of the name. Each companion NULLed when `abs(value) ≥ _MAX_SANE_MULTIPLE` (1e6). Rationale (Codex ckpt-1 LOW, corrected): `numeric(18,6)` overflows at 1e12, so overflow alone needs only `< 1e12`; 1e6 is a **degenerate-ratio sanity bound** reusing the existing constant for symmetry with the member multiples — a |margin| or |growth| ≥ 1e6 is a tiny-denominator artifact; NULLing it guarantees degenerate-ratio PAIRS cannot accidentally screen-match each other (two garbage values within ±width would otherwise pass). Population-loss check rides the acceptance gate: count companions NULLed by the bound post-backfill (expected ≈ 0).
+- **`_MEMBER_SQL`**: project the 3 companion columns (dict-row key + projection in the SAME diff, real-query db test — prevention log #2021).
+- **`_TARGET_SQL`**: LEFT JOIN LATERAL prior-TTM (same strictness) + project `ttm_start`, `rev_prior`, `prior_end`, `net_income_ttm` (already projected); target companions computed in a pure `companion_vars()` mirroring §4.5 exactly.
+
+## 6. Method version + backfill
+
+- `METHOD_VERSION = "fvb_v4"`. Consumers (`thesis.py`, `freshness.py`, `fundamentals_admin.py`) import the constant — transparent. Deploy→backfill window: `fair_value_band_current` has no fvb_v4 rows, thesis band block reads `available:false` (same accepted class as v2→v3); `freshness.py` detects the empty method_version and reschedules; we run the refresh immediately anyway.
+- Backfill = operator restarts the jobs task (retired-writer rule — restart BEFORE re-backfill), then `fair_value_band_refresh` full-universe.
+- Expect a **one-time #2013 re-thesis alert wave** (base moves >10% on ~500–800 legs; damped at band level by median-of-bases + own-blend) — anticipated, fine.
+- **#2031 hysteresis sequenced AFTER v4** (screen adds nightly membership churn at band edges; hysteresis should damp the re-based cohorts). **#2043 leg-coherence separate** (own source-rule research).
+
+## 7. Acceptance gate (verdict binding mod 3)
+
+Same-day controlled v3-vs-v4 (**never cross-day** — #2021/#2022 lesson: input drift masquerades as method drift). v3 fresh from a main-code worktree, v4 from the branch, same dev DB, same day; rows coexist under distinct `method_version`.
+
+1. **Tail compression ≈ sim:** per-leg `ratio_up p95` compression in line with the ok-band-leg predictions (fresh7, `fvb_order_compare.py`, width-major): **ps 2.74→2.21, pb 3.33→1.42, ev 3.36→2.57**. Materially below ⇒ **NO-GO flip**.
+2. **Fallback rates ≈ sim:** compare like-with-like. Ok-band-leg predictions (the direct v3-vs-v4 comparable, fresh7): held-of-screenable **ps 152/182 = 83.5%, pb 85/90 = 94.4%, ev 113/127 = 89.0%** (target-companion-missing: ps 32/214, pb 12/102, ev 14/141 of peer-backed legs). The verdict's member-population figure (ps held 50.5% fresh7 — its "materially below ~37% falsifies" trigger) applies to the all-members population, which the stored-band comparison does not sample; both recorded here so the gate reads the right prediction for the right population.
+3. **Base damping (full-pop prediction, Codex ckpt-1 MED-2):** predicted band-level |Δbase| over all 569 ok bands: **p50 = 0.000, p90 ≈ 0.20, p95 ≈ 0.32, >10% movers 96 (16.9%), >25% movers 43** — the median band is unmoved (median-of-bases + own-blend damping confirmed full-pop; the ~7% AAPL figure was one case, superseded by this distribution). **NO-GO flip** if observed p50 materially exceeds ~0 (e.g. > 5%) or >10%-movers far exceed ~17%.
+4. **Margin-only degrade-stage variant** (harness variant, not shipped code): insert a margin-only intermediate stage for ps/ev; adopt in a follow-up ONLY if it compresses tails without pe-style churn; otherwise record the negative on #2032.
+5. Standard panel: AAPL/GME/MSFT/JPM/HD via the rollup endpoint; AAPL cross-checked against §3 sim figures (its cohorts were 6dp-validated).
+6. #2021's deferred R_UP/R_DN retune + cap-hit gate still ride the first fresh-price population — unchanged by this spec.
+
+## 8. Tests
+
+- Pure tier (`test_fair_value_band_policy.py`): `companion_vars` derivations + adjacency boundaries (0/1/120/121d, `rev_prior=0`, negative prior abs-denominator); screen predicate per leg (NULL either side fails; boundary `|Δ| = width` passes — sim used `≤`); frozen tier table shape (pe absent); quality knock fires only for contributing peer-backed screenable legs.
+- DB tier (`test_fair_value_band_io.py`): real `_MATERIALIZE_SQL` writes companions; real `_MEMBER_SQL`/`_TARGET_SQL` projections drive the screen end-to-end (held path with provenance in `basis_json`, fallback path with flag); prior-TTM adjacency exercised through seeded quarters.
+
+## 9. Limitations
+
+- DCTH-class cross-leg disagreement is **not** addressed (→ #2043).
+- Growth companion is **revenue** YoY — correct for ps/ev (Damodaran's P/S companion), unavailable-in-the-right-form for pe (§4.2).
+- Dev acceptance runs on a stale-price-censored population (fresh7); full effect lands at the first fresh-price population alongside the deferred #2021 cap gate.

--- a/docs/proposals/valuation/2026-07-15-fvb-v4-companion-screen.md
+++ b/docs/proposals/valuation/2026-07-15-fvb-v4-companion-screen.md
@@ -65,7 +65,7 @@ A high fallback rate is the finding, not mis-design (verdict): no comparable set
 Per screenable leg, `basis_json.multiples[m]` gains (same reconstructability discipline as `precap_*`/`capped_*`):
 
 - held: `"cohort_screened": true, "screen": {"sic_level": L, "width_tier": i, "survivors_n": n}` (`width_tier` = 0-based index into the frozen tier table; `survivors_n` = post-screen fresh count pre-refine);
-- fallback: `"cohort_screened": false, "screen": {"reason": "no_screened_cohort" | "target_companion_missing"}`.
+- fallback: `"cohort_screened": false, "screen": {"reason": "no_screened_cohort" | "target_companion_missing" | "cohort_companions_missing"}`. The third reason (Codex ckpt-2 P2) marks a member set that carries NO companion data for this multiple at any ladder level — chiefly the deploy→backfill window, where a single-name cascade anchors to a cohort materialized before the sql/228 columns were populated; the provenance must not claim a width-exhausted screen that never had inputs. Values are unaffected (the fallback IS the pre-v4 walk); the knock applies to all three (an unscreened cohort carries less comparability confidence regardless of why).
 
 `pe` legs carry neither key (screen not applicable). Width constants live in code under `METHOD_VERSION` pinning — (tier index, method_version) fully reconstructs the widths.
 

--- a/sql/228_fair_value_cohort_companion_vars.sql
+++ b/sql/228_fair_value_cohort_companion_vars.sql
@@ -1,0 +1,26 @@
+-- 228_fair_value_cohort_companion_vars.sql
+--
+-- #2032 (#2009 v2 Phase 2, fvb_v4) — companion-variable columns on
+-- fair_value_cohort_members for the peer comparability screen
+-- (spec: docs/proposals/valuation/2026-07-15-fvb-v4-companion-screen.md §5).
+--
+-- Written by _MATERIALIZE_SQL (fair_value_band.py) per §4.5: net margin =
+-- net_income_ttm / revenue_ttm; revenue growth YoY = strict current TTM vs
+-- strict prior TTM (rn 5-8, span <= 330d, windows adjacent 1-120d); ROE =
+-- net_income_ttm / latest-quarter shareholders_equity. Each NULLed at
+-- materialize time when |value| >= _MAX_SANE_MULTIPLE (degenerate-ratio
+-- guard). Read back by _MEMBER_SQL for the pass-2 screen predicate.
+--
+-- Additive + nullable: pre-v4 as_of_date rows stay NULL and are never
+-- re-read (each materialize DELETE+INSERTs its own as_of_date). sql/221 and
+-- sql/226 are not edited (applied migrations are immutable —
+-- migration-content-drift rule).
+
+BEGIN;
+
+ALTER TABLE fair_value_cohort_members
+    ADD COLUMN IF NOT EXISTS net_margin     numeric(18,6),
+    ADD COLUMN IF NOT EXISTS rev_growth_yoy numeric(18,6),
+    ADD COLUMN IF NOT EXISTS roe            numeric(18,6);
+
+COMMIT;

--- a/tests/test_fair_value_band_io.py
+++ b/tests/test_fair_value_band_io.py
@@ -580,3 +580,34 @@ def test_companion_screen_end_to_end(ebull_test_conn: psycopg.Connection[tuple])
     ps_entry = basis[0]["multiples"]["ps"]
     assert ps_entry["cohort_screened"] is False
     assert ps_entry["screen"] == {"reason": "no_screened_cohort"}
+
+
+def test_companion_screen_pre_v4_cohort_annotates_companions_missing(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:  # noqa: F811
+    """Codex ckpt-2 P2 (deploy->backfill window): a single-name cascade anchored
+    to a cohort materialized BEFORE the sql/228 backfill (companion columns all
+    NULL) must annotate the fallback as cohort_companions_missing — never the
+    misleading no_screened_cohort — while producing the identical unscreened
+    (pre-v4) peer stats."""
+    conn = ebull_test_conn
+    _seed_screen_cohort(conn)
+    materialize_cohort_members(conn, _AS_OF)
+    # Simulate the pre-v4 member set: strip every companion column.
+    conn.execute("UPDATE fair_value_cohort_members SET net_margin = NULL, rev_growth_yoy = NULL, roe = NULL")
+    conn.commit()
+
+    result = refresh_fair_value_band_batch(conn, [_SCR_TARGET])
+    conn.commit()
+    assert result == {"written": 1, "statused": 0, "failed": 0}
+    basis = conn.execute(
+        "SELECT basis_json FROM fair_value_band_current WHERE instrument_id = %s",
+        (_SCR_TARGET,),
+    ).fetchone()
+    assert basis is not None
+    ps_entry = basis[0]["multiples"]["ps"]
+    assert ps_entry["cohort_screened"] is False
+    assert ps_entry["screen"] == {"reason": "cohort_companions_missing"}
+    # Unscreened stats: all 14 sibling members (near 8 + far 4 + 2 co-targets)
+    # feed the walk; the far 100x members reach the tail unscreened.
+    assert ps_entry["peer"]["p75"] > 17.0

--- a/tests/test_fair_value_band_io.py
+++ b/tests/test_fair_value_band_io.py
@@ -68,6 +68,7 @@ def _seed_member(
     ev: dict[str, float | None] | None = None,
     margin: float = 0.1,
     prior_revenue_ttm: float | None = None,
+    sic: str = _SIC,
 ) -> None:
     """Seed one instrument so its as-of multiples are exactly (ps, pb, pe).
 
@@ -98,7 +99,7 @@ def _seed_member(
     )
     conn.execute(
         "INSERT INTO instrument_sec_profile (instrument_id, cik, sic) VALUES (%s, %s, %s)",
-        (iid, cik, _SIC),
+        (iid, cik, sic),
     )
     conn.execute(
         "INSERT INTO price_daily (instrument_id, price_date, close) VALUES (%s, %s, %s)",
@@ -611,3 +612,45 @@ def test_companion_screen_pre_v4_cohort_annotates_companions_missing(
     # Unscreened stats: all 14 sibling members (near 8 + far 4 + 2 co-targets)
     # feed the walk; the far 100x members reach the tail unscreened.
     assert ps_entry["peer"]["p75"] > 17.0
+
+
+def test_companion_screen_zero_member_cohort_stays_no_screened_cohort(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:  # noqa: F811
+    """PR #2045 review PREVENTION: a screen-capable target whose SIC has ZERO
+    member rows at every ladder level must fall back with no_screened_cohort —
+    the cohort_companions_missing override requires member rows to EXIST (it
+    flags companion-column absence, not cohort absence)."""
+    conn = ebull_test_conn
+    _seed_screen_cohort(conn)
+    # Lone SIC "9911": no sibling members at SIC-4/3/2 (others are 35xx).
+    _seed_member(
+        conn,
+        8340,
+        ps=8.0,
+        pb=1.5,
+        pe=18.0,
+        total_assets=5.0e9,
+        cik=str(1_000_000_000 + 8340),
+        margin=0.10,
+        prior_revenue_ttm=(_CLOSE * _SHARES / 8.0) / 1.25,
+        sic="9911",
+    )
+    conn.commit()
+    materialize_cohort_members(conn, _AS_OF)
+    conn.commit()
+
+    result = refresh_fair_value_band_batch(conn, [8340])
+    conn.commit()
+    # No peers anywhere + no own history -> statused thin_cohort; the v4 basis
+    # entry still records the screen audit trail (provenance survives
+    # non-contribution, spec §4.4).
+    assert result == {"written": 0, "statused": 1, "failed": 0}
+    row = conn.execute(
+        "SELECT reason, basis_json FROM fair_value_band_current WHERE instrument_id = %s",
+        (8340,),
+    ).fetchone()
+    assert row is not None and row[0] == "thin_cohort"
+    ps_entry = row[1]["multiples"]["ps"]
+    assert ps_entry["cohort_screened"] is False
+    assert ps_entry["screen"] == {"reason": "no_screened_cohort"}

--- a/tests/test_fair_value_band_io.py
+++ b/tests/test_fair_value_band_io.py
@@ -66,6 +66,8 @@ def _seed_member(
     total_assets: float,
     cik: str,
     ev: dict[str, float | None] | None = None,
+    margin: float = 0.1,
+    prior_revenue_ttm: float | None = None,
 ) -> None:
     """Seed one instrument so its as-of multiples are exactly (ps, pb, pe).
 
@@ -81,6 +83,13 @@ def _seed_member(
     ``ltd``/``std``/``cash`` in the latest quarter only. None keys stay NULL —
     letting a test exercise the strict/coherence gates. Omitted entirely ->
     every EV column NULL -> no ev_ebitda cohort row (the pre-#2021 shape).
+
+    v4 (#2032): ``margin`` fixes net_income_q = revenue_q * margin (the
+    net-margin companion); ``prior_revenue_ttm`` seeds 4 ADDITIONAL 2023
+    quarters (rn 5-8) carrying prior_revenue_ttm/4 each, so rev_growth_yoy =
+    (revenue_ttm - prior_revenue_ttm)/prior_revenue_ttm with the adjacent
+    2023-12-31 -> 2024-03-31 window gap (91d, inside [1,120]). Omitted ->
+    growth companion NULL (the pre-v4 shape).
     """
     conn.execute(
         "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
@@ -100,9 +109,21 @@ def _seed_member(
     equity = _CLOSE * _SHARES / pb
     eps_ttm = (_CLOSE / pe) if pe is not None else -4.0  # <=0 -> no P/E cohort row
     revenue_q = revenue_ttm / 4.0
-    net_income_q = revenue_q * 0.1  # positive -> select_multiples sees profit
+    net_income_q = revenue_q * margin  # positive -> select_multiples sees profit
     eps_q = eps_ttm / 4.0
     ev = ev or {}
+
+    if prior_revenue_ttm is not None:
+        for end, qt in zip(("2023-03-31", "2023-06-30", "2023-09-30", "2023-12-31"), _Q_TYPES, strict=True):
+            conn.execute(
+                """
+                INSERT INTO financial_periods
+                  (instrument_id, period_end_date, period_type, fiscal_year, source, source_ref,
+                   reported_currency, revenue, superseded_at, normalization_status)
+                VALUES (%s, %s, %s, 2023, 'test', %s, 'USD', %s, NULL, 'normalized')
+                """,
+                (iid, end, qt, f"fvb{iid}{qt}p", prior_revenue_ttm / 4.0),
+            )
 
     def _q(key: str) -> float | None:
         v = ev.get(key)
@@ -400,3 +421,162 @@ def test_two_pass_ev_ebitda_arm_gates_and_anti_join(ebull_test_conn: psycopg.Con
     assert ev_meta["cohort_n"] == len(_EV_SINGLE)  # dual + gated never in the member set
     assert ev_pct.p50 is not None and ev_pct.p50 == pytest.approx(22.5)
     assert ev_pct.p75 is not None and ev_pct.p75 < 100.0  # dual's 100x never reaches the tail
+
+
+# --- #2032 (fvb_v4): companion-variable peer screen, end-to-end ---
+# One integration test for the genuinely-new SQL mechanism (test-quality skill):
+# the pass-1 companion columns + the pass-2 screened walk + the real _TARGET_SQL
+# prior-TTM lateral (dict-row key + projection in the same diff — prevention
+# log #2021), covering the held path, the target-companion-missing fallback,
+# and the no-screened-cohort fallback.
+
+_SCR_TARGET = 8300  # margin 0.10, growth 0.25 — screen holds at tier 0 / SIC-4
+_SCR_NO_COMP = 8320  # no prior quarters -> growth NULL -> target_companion_missing
+_SCR_UNMATCHED = 8330  # margin 0.60 vs near peers' 0.10 -> no_screened_cohort
+# 8 near peers (margin 0.10, growth 0.25) + 4 far peers (margin 0.60, growth
+# 3.0, off-distribution ps=100) the screen must exclude at every tier.
+_SCR_NEAR = {8301: 10.0, 8302: 11.0, 8303: 12.0, 8304: 13.0, 8305: 14.0, 8306: 15.0, 8307: 16.0, 8308: 17.0}
+_SCR_FAR = (8311, 8312, 8313, 8314)
+
+
+def _seed_screen_cohort(conn: psycopg.Connection[tuple]) -> None:
+    _clear_band_tables(conn)
+    _seed_member(
+        conn,
+        _SCR_TARGET,
+        ps=8.0,
+        pb=1.5,
+        pe=18.0,
+        total_assets=5.0e9,
+        cik=str(1_000_000_000 + _SCR_TARGET),
+        margin=0.10,
+        prior_revenue_ttm=(_CLOSE * _SHARES / 8.0) / 1.25,
+    )
+    _seed_member(
+        conn,
+        _SCR_NO_COMP,
+        ps=8.0,
+        pb=1.5,
+        pe=18.0,
+        total_assets=5.0e9,
+        cik=str(1_000_000_000 + _SCR_NO_COMP),
+        margin=0.10,
+    )
+    _seed_member(
+        conn,
+        _SCR_UNMATCHED,
+        ps=8.0,
+        pb=1.5,
+        pe=18.0,
+        total_assets=5.0e9,
+        cik=str(1_000_000_000 + _SCR_UNMATCHED),
+        margin=0.60,
+        prior_revenue_ttm=(_CLOSE * _SHARES / 8.0) / 1.25,
+    )
+    for iid, ps in _SCR_NEAR.items():
+        _seed_member(
+            conn,
+            iid,
+            ps=ps,
+            pb=2.0,
+            pe=20.0,
+            total_assets=1.0e9,
+            cik=str(1_000_000_000 + iid),
+            margin=0.10,
+            prior_revenue_ttm=(_CLOSE * _SHARES / ps) / 1.25,
+        )
+    for iid in _SCR_FAR:
+        # total_assets matches the targets' 5e9 so the UNSCREENED size-refine
+        # keeps the far peers (nearest-8 by |ln assets|) — the screened/held
+        # path must exclude them by COMPANION distance, not by size.
+        _seed_member(
+            conn,
+            iid,
+            ps=100.0,
+            pb=2.0,
+            pe=20.0,
+            total_assets=5.0e9,
+            cik=str(1_000_000_000 + iid),
+            margin=0.60,
+            prior_revenue_ttm=(_CLOSE * _SHARES / 100.0) / 4.0,
+        )
+    conn.commit()
+
+
+def test_companion_screen_end_to_end(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
+    conn = ebull_test_conn
+    _seed_screen_cohort(conn)
+
+    materialize_cohort_members(conn, _AS_OF)
+    conn.commit()
+
+    # 1. Pass-1 wrote the companion columns (near peer: margin .1, growth .25).
+    row = conn.execute(
+        "SELECT net_margin, rev_growth_yoy, roe FROM fair_value_cohort_members "
+        "WHERE as_of_date = %s AND multiple = 'ps' AND instrument_id = %s",
+        (_AS_OF, 8301),
+    ).fetchone()
+    assert row is not None
+    assert float(row[0]) == pytest.approx(0.10, abs=1e-6)
+    assert float(row[1]) == pytest.approx(0.25, abs=1e-6)
+    assert row[2] is not None  # roe = ni_ttm/equity, positive here
+    # No-prior name: growth NULL, margin still present.
+    row = conn.execute(
+        "SELECT net_margin, rev_growth_yoy FROM fair_value_cohort_members "
+        "WHERE as_of_date = %s AND multiple = 'ps' AND instrument_id = %s",
+        (_AS_OF, _SCR_NO_COMP),
+    ).fetchone()
+    assert row is not None and row[0] is not None and row[1] is None
+
+    # 2. HELD: the batch path (real _TARGET_SQL incl. the prior-TTM lateral ->
+    #    companion_vars -> screened peer walk) screens the 4 far peers out at
+    #    tier 0 / SIC-4 with full provenance in basis_json.
+    result = refresh_fair_value_band_batch(conn, [_SCR_TARGET])
+    conn.commit()
+    assert result == {"written": 1, "statused": 0, "failed": 0}
+    basis = conn.execute(
+        "SELECT basis_json FROM fair_value_band_current WHERE instrument_id = %s",
+        (_SCR_TARGET,),
+    ).fetchone()
+    assert basis is not None
+    ps_entry = basis[0]["multiples"]["ps"]
+    assert ps_entry["cohort_screened"] is True
+    assert ps_entry["screen"] == {"sic_level": 4, "width_tier": 0, "survivors_n": len(_SCR_NEAR)}
+    assert ps_entry["sic_level"] == 4
+    # Screened p50 = median of the 8 near multiples {10..17} = 13.5; the far
+    # 100x members never reach the percentiles.
+    assert ps_entry["peer"]["p50"] == pytest.approx(13.5, abs=0.01)
+    assert ps_entry["peer"]["p75"] < 100.0
+    # pe leg is never screened — no screen keys (spec §4.2).
+    pe_entry = basis[0]["multiples"]["pe"]
+    assert "cohort_screened" not in pe_entry and "screen" not in pe_entry
+
+    # 3. FALLBACK target_companion_missing: growth NULL on the target -> the
+    #    unscreened cohort (far peers INCLUDED: 12 members, p75 pulled above the
+    #    near-only tail) + the flag.
+    result = refresh_fair_value_band_batch(conn, [_SCR_NO_COMP])
+    conn.commit()
+    assert result == {"written": 1, "statused": 0, "failed": 0}
+    basis = conn.execute(
+        "SELECT basis_json FROM fair_value_band_current WHERE instrument_id = %s",
+        (_SCR_NO_COMP,),
+    ).fetchone()
+    assert basis is not None
+    ps_entry = basis[0]["multiples"]["ps"]
+    assert ps_entry["cohort_screened"] is False
+    assert ps_entry["screen"] == {"reason": "target_companion_missing"}
+    assert ps_entry["peer"]["p75"] > 17.0  # far 100x members present unscreened
+
+    # 4. FALLBACK no_screened_cohort: companions present but margin 0.60 matches
+    #    neither the 8 near (0.10) nor enough far peers at any tier.
+    result = refresh_fair_value_band_batch(conn, [_SCR_UNMATCHED])
+    conn.commit()
+    assert result == {"written": 1, "statused": 0, "failed": 0}
+    basis = conn.execute(
+        "SELECT basis_json FROM fair_value_band_current WHERE instrument_id = %s",
+        (_SCR_UNMATCHED,),
+    ).fetchone()
+    assert basis is not None
+    ps_entry = basis[0]["multiples"]["ps"]
+    assert ps_entry["cohort_screened"] is False
+    assert ps_entry["screen"] == {"reason": "no_screened_cohort"}

--- a/tests/test_fair_value_band_policy.py
+++ b/tests/test_fair_value_band_policy.py
@@ -4,7 +4,9 @@ from typing import Any
 import pytest
 
 from app.services.fair_value_band import (
+    _SCREEN_TIERS,
     MIN_OWN_POINTS,
+    CompanionVars,
     OwnPct,
     PeerPct,
     QualityInputs,
@@ -13,14 +15,17 @@ from app.services.fair_value_band import (
     band_quality_status,
     cap_envelope,
     combine_across,
+    companion_vars,
     compute_band,
     compute_divergence,
     currency_coherent,
     filter_dual_class,
     own_range,
     percentiles,
+    screen_passes,
     select_multiples,
     synth_multiple,
+    target_screenable,
     to_per_share,
 )
 
@@ -727,3 +732,227 @@ def test_golden_hd_ev_leg():
     assert round(res.bull, 1) == 388.2  # (16*24.307e9 - 1.902e9) / 997e6
     assert res.basis["multiples"]["ev_ebitda"]["ebitda_ttm"] == 24_307e6
     assert res.basis["multiples"]["ev_ebitda"]["net_debt"] == 1_902e6
+
+
+# --- #2032 (fvb_v4) companion-variable peer screen — pure policy ---
+
+
+def test_companion_vars_derivations():
+    cv = companion_vars(
+        revenue_ttm=10_000.0,
+        net_income_ttm=1_000.0,
+        shareholders_equity=50_000.0,
+        rev_prior_ttm=8_000.0,
+        ttm_start=_d.date(2024, 3, 31),
+        prior_end=_d.date(2023, 12, 31),  # 91d — the normal adjacent-quarter gap
+    )
+    assert cv.net_margin == pytest.approx(0.10)
+    assert cv.rev_growth_yoy == pytest.approx(0.25)
+    assert cv.roe == pytest.approx(0.02)
+
+
+def test_companion_vars_growth_adjacency_boundaries():
+    # Spec §4.5: ttm_start - prior_end in [1, 120] days. 0d (overlap) and 121d
+    # (skipped quarter) fail; the 1d and 120d boundaries pass.
+    def growth(days: int) -> float | None:
+        return companion_vars(
+            revenue_ttm=10.0,
+            net_income_ttm=None,
+            shareholders_equity=None,
+            rev_prior_ttm=8.0,
+            ttm_start=_d.date(2024, 1, 1) + _d.timedelta(days=days),
+            prior_end=_d.date(2024, 1, 1),
+        ).rev_growth_yoy
+
+    assert growth(0) is None
+    assert growth(1) is not None
+    assert growth(120) is not None
+    assert growth(121) is None
+
+
+def test_companion_vars_growth_gates():
+    # rev_prior == 0 -> None (no denominator); negative prior uses abs() so a
+    # contra-revenue prior still yields a signed, finite growth.
+    base: dict[str, Any] = dict(
+        revenue_ttm=10.0,
+        net_income_ttm=None,
+        shareholders_equity=None,
+        ttm_start=_d.date(2024, 3, 31),
+        prior_end=_d.date(2023, 12, 31),
+    )
+    assert companion_vars(rev_prior_ttm=0.0, **base).rev_growth_yoy is None
+    assert companion_vars(rev_prior_ttm=None, **base).rev_growth_yoy is None
+    assert companion_vars(rev_prior_ttm=-5.0, **base).rev_growth_yoy == pytest.approx(3.0)
+
+
+def test_companion_vars_margin_and_roe_gates():
+    # margin requires revenue > 0 AND net income present; roe requires equity > 0.
+    cv = companion_vars(
+        revenue_ttm=0.0,
+        net_income_ttm=1.0,
+        shareholders_equity=-5.0,
+        rev_prior_ttm=None,
+        ttm_start=None,
+        prior_end=None,
+    )
+    assert cv.net_margin is None and cv.roe is None
+    cv = companion_vars(
+        revenue_ttm=10.0,
+        net_income_ttm=None,
+        shareholders_equity=5.0,
+        rev_prior_ttm=None,
+        ttm_start=None,
+        prior_end=None,
+    )
+    assert cv.net_margin is None and cv.roe is None  # ni absent gates BOTH
+
+
+def test_screen_tiers_frozen_shape():
+    # pe EXCLUDED (wrong companion — spec §4.2); ps/ev share the margin+growth
+    # tiers; pb is ROE-only; every schedule widens monotonically.
+    assert set(_SCREEN_TIERS) == {"ps", "pb", "ev_ebitda"}
+    assert _SCREEN_TIERS["ps"] == _SCREEN_TIERS["ev_ebitda"]
+    for tiers in _SCREEN_TIERS.values():
+        for field in ("net_margin", "rev_growth_yoy", "roe"):
+            widths = [getattr(t, field) for t in tiers]
+            assert all(w is None for w in widths) or all(w is not None for w in widths)
+            present = [w for w in widths if w is not None]
+            assert present == sorted(present)  # monotone widening
+    assert _SCREEN_TIERS["pb"][0].roe == 0.05 and _SCREEN_TIERS["pb"][0].net_margin is None
+
+
+def test_screen_passes_boundary_and_nulls():
+    tier = _SCREEN_TIERS["ps"][0]  # margin +/-0.05, growth +/-0.10
+    tgt = CompanionVars(net_margin=0.10, rev_growth_yoy=0.20, roe=None)
+    # Boundary |delta| == width passes (sim used <=).
+    assert screen_passes(tier, tgt, CompanionVars(0.15, 0.30, None)) is True
+    assert screen_passes(tier, tgt, CompanionVars(0.151, 0.30, None)) is False
+    assert screen_passes(tier, tgt, CompanionVars(0.15, 0.301, None)) is False
+    # NULL companion on the peer side fails (never imputed).
+    assert screen_passes(tier, tgt, CompanionVars(None, 0.20, None)) is False
+    assert screen_passes(tier, tgt, CompanionVars(0.10, None, None)) is False
+    # roe irrelevant for ps (width None) — a peer without roe still passes.
+    pb_tier = _SCREEN_TIERS["pb"][2]  # roe +/-0.20
+    tgt_fin = CompanionVars(net_margin=None, rev_growth_yoy=None, roe=0.10)
+    assert screen_passes(pb_tier, tgt_fin, CompanionVars(None, None, 0.30)) is True
+    assert screen_passes(pb_tier, tgt_fin, CompanionVars(None, None, 0.31)) is False
+
+
+def test_target_screenable():
+    both = CompanionVars(net_margin=0.1, rev_growth_yoy=0.2, roe=0.05)
+    no_growth = CompanionVars(net_margin=0.1, rev_growth_yoy=None, roe=0.05)
+    assert target_screenable("ps", both) is True
+    assert target_screenable("ps", no_growth) is False  # ps needs margin AND growth
+    assert target_screenable("pb", no_growth) is True  # pb needs roe only
+    assert target_screenable("pb", CompanionVars(0.1, 0.2, None)) is False
+    assert target_screenable("pe", both) is False  # pe excluded
+    assert target_screenable("ps", None) is False
+
+
+def test_quality_screen_fallback_knock():
+    # Boundary case: score 7 (sides 2 + own 12 + stale 0 + sic3 1) = high;
+    # the v4 screen-fallback knock drops it to 6 = medium.
+    kw: dict[str, Any] = dict(
+        n_selected=1,
+        n_comparator_sides=2,
+        own_points=12,
+        cohort_n=20,
+        excluded_stale_n=0,
+        sic_level=3,
+        cross_multiple_spread=0.0,
+    )
+    assert band_quality_status(QualityInputs(**kw)) == "high"
+    assert band_quality_status(QualityInputs(**kw, screen_fallback=True)) == "medium"
+
+
+def _screen_meta(*, screened: bool, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    meta: dict[str, Any] = {"cohort_n": 40, "excluded_stale_n": 0, "sic_level": 4}
+    meta["cohort_screened"] = screened
+    meta["screen"] = extra if extra is not None else {"reason": "no_screened_cohort"}
+    return meta
+
+
+def test_compute_band_screen_provenance_and_knock():
+    # A contributing peer-backed ps leg that fell back unscreened: provenance
+    # lands in the basis entry AND the quality knock fires.
+    t = _t(revenue_ttm=1000.0, net_income_ttm=100.0, eps_diluted_ttm=10.0)
+    res = compute_band(
+        t,
+        peer_by_multiple={
+            "pe": PeerPct(p25=6.0, p50=8.0, p75=12.0),
+            "ps": PeerPct(p25=5.0, p50=10.0, p75=20.0),
+        },
+        own_by_multiple={"pe": OwnPct(None, None, None), "ps": OwnPct(None, None, None)},
+        own_points_by_multiple={"pe": 0, "ps": 0},
+        cohort_meta={
+            "pe": {"cohort_n": 40, "excluded_stale_n": 0, "sic_level": 4},
+            "ps": _screen_meta(screened=False),
+        },
+        sic_level=4,
+    )
+    assert res.reason == "ok"
+    ps_entry = res.basis["multiples"]["ps"]
+    assert ps_entry["cohort_screened"] is False
+    assert ps_entry["screen"] == {"reason": "no_screened_cohort"}
+    assert ps_entry["sic_level"] == 4  # per-leg cohort level (v4 §4.4)
+    pe_entry = res.basis["multiples"]["pe"]
+    assert "cohort_screened" not in pe_entry and "screen" not in pe_entry  # pe: N/A
+    # Knock: identical shape with the ps leg SCREENED must score one tier higher
+    # or equal — assert via the explicit flag path instead of tier arithmetic.
+    res_screened = compute_band(
+        t,
+        peer_by_multiple={
+            "pe": PeerPct(p25=6.0, p50=8.0, p75=12.0),
+            "ps": PeerPct(p25=5.0, p50=10.0, p75=20.0),
+        },
+        own_by_multiple={"pe": OwnPct(None, None, None), "ps": OwnPct(None, None, None)},
+        own_points_by_multiple={"pe": 0, "ps": 0},
+        cohort_meta={
+            "pe": {"cohort_n": 40, "excluded_stale_n": 0, "sic_level": 4},
+            "ps": _screen_meta(screened=True, extra={"sic_level": 4, "width_tier": 1, "survivors_n": 11}),
+        },
+        sic_level=4,
+    )
+    held_entry = res_screened.basis["multiples"]["ps"]
+    assert held_entry["cohort_screened"] is True
+    assert held_entry["screen"] == {"sic_level": 4, "width_tier": 1, "survivors_n": 11}
+
+
+def test_compute_band_own_only_screenable_leg_does_not_knock():
+    # ps leg with NO peer side (own-only) marked cohort_screened=False: the knock
+    # must NOT fire — there is no peer cohort to screen (spec §4.3). Quality here
+    # equals the identical no-screen-keys case.
+    def run(meta_ps: dict[str, Any]) -> str | None:
+        res = compute_band(
+            _t(revenue_ttm=1000.0),
+            peer_by_multiple={"ps": PeerPct(None, None, None)},
+            own_by_multiple={"ps": OwnPct(p25=4.0, p50=5.0, p75=6.0)},
+            own_points_by_multiple={"ps": 12},
+            cohort_meta={"ps": meta_ps},
+            sic_level=0,
+        )
+        assert res.reason == "ok"
+        return res.quality_status
+
+    knocked = run(_screen_meta(screened=False))
+    plain = run({"cohort_n": 40, "excluded_stale_n": 0, "sic_level": 4})  # same meta, no screen keys
+    assert knocked == plain
+
+
+def test_compute_band_synth_none_leg_keeps_screen_provenance():
+    # v4 §4.4 (Codex ckpt-1 MED-3): a selected screenable leg with BOTH
+    # comparator sides absent still records its basis entry (screen audit trail
+    # survives non-contribution); the band statuses thin_cohort.
+    res = compute_band(
+        _t(revenue_ttm=1000.0),
+        peer_by_multiple={"ps": PeerPct(None, None, None)},
+        own_by_multiple={"ps": OwnPct(None, None, None)},
+        own_points_by_multiple={"ps": 0},
+        cohort_meta={"ps": _screen_meta(screened=False)},
+        sic_level=0,
+    )
+    assert res.reason == "thin_cohort"
+    entry = res.basis["multiples"]["ps"]
+    assert entry["cohort_screened"] is False
+    assert entry["screen"] == {"reason": "no_screened_cohort"}
+    assert "base_value" not in entry and "capped_high" not in entry


### PR DESCRIPTION
Closes #2032.

## What

Root-cause fix for AAPL-class comps width (fair-value band v2 spec §4 part 4, Phase 2): the pass-2 peer cohort gains a **companion-variable screen** — `ps`/`ev_ebitda` matched on net margin + revenue growth YoY, `pb` on ROE, `pe` **excluded** (wrong companion / data-gated: canonical P/E companion is forward EARNINGS growth, no usable source; revenue-YoY proxy full-pop refuted — nil tail compression, 505/908 live legs re-anchored). `METHOD_VERSION` → `fvb_v4`. **Not a scoring `model_version`** (band is not a scoring input).

Spec: `docs/proposals/valuation/2026-07-15-fvb-v4-companion-screen.md` — operator GO + domain-subagent verdict (both on #2032, 2026-07-15), all 3 binding verdict mods folded (pe framing + revisit trigger; per-leg screen provenance; acceptance-gate additions).

## How

- **sql/228** (additive, nullable): `net_margin`, `rev_growth_yoy`, `roe` on `fair_value_cohort_members`. Applied migrations untouched.
- **`_MATERIALIZE_SQL`**: prior-TTM CTE (sql/220 dedup/strictness mirror: rn 5–8, span ≤330d, COUNT(revenue)=4) + companion computation with cross-window adjacency `ttm_start − prior_end ∈ [1,120]d`; each companion NULLed at `|value| ≥ _MAX_SANE_MULTIPLE` (degenerate-ratio guard).
- **`_TARGET_SQL`**: prior-TTM LATERAL + `ttm_start`; target companions derived in pure `companion_vars()` — one shared definition with the member side (projection lands with its dict-row reads in the same diff; real-query db test drives both — prevention-log #2021 rule).
- **`peer_pct_for`**: screened pass first — **width-major** walk (each width tier tight→wide walks the full SIC 4→3→2 ladder; MIN_PEERS re-checked pre- and post-size-refine). Frozen width tiers: ps/ev (±.05,±.10)→(±.10,±.20)→(±.20,±.40); pb ±.05→±.10→±.20 — absolutes, never cohort-relative (settled invariant). Fallback = the unchanged pre-v4 unscreened walk + `cohort_screened:false` + reason (`no_screened_cohort` | `target_companion_missing` | `cohort_companions_missing`).
- **Provenance** (verdict mod 2): held legs store `screen{sic_level, width_tier, survivors_n}`; every leg stores per-leg `sic_level`; provenance survives synth-None/non-contributing legs.
- **Quality**: `QualityInputs.screen_fallback` knocks 1 point when a contributing peer-backed screenable leg fell back unscreened (own-only legs never knock).

## Source rule

Damodaran (ps.pdf: P/S = f(net margin, growth); P/B↔ROE; P/E↔earnings growth); McKinsey/Koller, Alford 1992, Bhojraj & Lee 2002 (fundamental-matched comparables beat industry-only). Companion derivations defer to the settled sql/220 + `docs/specs/fundamentals/2026-07-12-2008-ttm-reconciliation.md` treatment (Reg S-X Art. 10 / 17 CFR 210.10-01(c)).

## Full-population verification

- #2032 sim (exact `peer_pct_for` replica, validated vs stored AAPL fvb_v3 basis to 6dp): ps ratio_up p95 4.95→3.15, pb 2.54→1.79, ev 3.86→2.84 (nogate); pe nil → excluded.
- **Walk-order decision full-pop verified** (spec §4.1): width-major vs level-outer over all 569 stored ok bands — hold/fallback identical by construction; width-major wins tail compression where orders diverge (ps 2.21 vs 2.42, ev 2.57 vs 2.78); band-level |Δbase| indistinguishable (p50 0.000 both).
- Predicted band-base shift distribution (569 ok bands): p50 0.000, p90 ≈0.20, >10% movers 96 (16.9%) — the #2013 re-thesis wave is expected and damped.

## Verification (dev, this branch)

- `uv run ruff check .` / `format --check` ✓; `uv run pyright` 0 errors ✓; `pytest -m "not db"` exit 0 ✓; `pytest tests/smoke` 153 passed ✓.
- DB tier: `tests/test_fair_value_band_io.py` 5 passed (held path with provenance; `target_companion_missing` fallback; `no_screened_cohort` fallback; pre-v4-cohort `cohort_companions_missing` window; both pre-existing blocking guards) + `tests/test_fair_value_band_policy.py` 78 passed + thesis db suites 45 passed.
- Codex ckpt-1 ×2 on spec+plan (6 findings folded, incl. full-pop order comparison + population base-shift gate); Codex ckpt-2 on the diff (P2 deploy-window provenance → fixed `083b2cf5` + db test).

## Operator loop (after merge — same as #2021/#2036)

1. Restart the jobs task (retired-writer rule) → `fair_value_band_refresh` full-universe (backfills fvb_v4 + companions).
2. Acceptance gate (spec §7): SAME-DAY controlled v3-vs-v4 (v3 from a main worktree), fallback-rates vs sim (ok-band-leg predictions: ps 83.5%, pb 94.4%, ev 89.0% held), tail compression, base-damping distribution, margin-only degrade-stage harness variant (verdict mod 3), AAPL/GME/MSFT/JPM/HD rollup panel.
3. Deploy→backfill window: thesis band block reads available:false until refresh (accepted v2→v3 class); single-name cascades in the window annotate `cohort_companions_missing` (tested).

## Tradeoffs

- Width-major beats the issue prose's "level-outer" label — full-pop justified in spec §4.1 (calibration + Damodaran direction); flagged explicitly rather than silently chosen.
- P/S fallback ~50% of screenable member-population targets on stale dev is the finding, not mis-design (domain verdict): truthful flag beats vacuous screen. DCTH-class cross-leg disagreement is #2043 (separate, not bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)