### PR TITLE
feat(#2031): refute fvb cohort-hysteresis premise on full population; add peer_ids provenance

### DIFF
--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -612,6 +612,12 @@ def compute_band(
         if "cohort_screened" in meta:
             entry["cohort_screened"] = meta["cohort_screened"]
             entry["screen"] = meta.get("screen", {})
+        # #2031 chosen-member provenance, present iff a peer cohort was found
+        # (absent on peer-absent legs — the walk never chose anyone). Kept even
+        # when the leg ends non-contributing (synth-None / dropped), matching
+        # the peer-stats-stay-auditable rule above.
+        if "peer_ids" in meta:
+            entry["peer_ids"] = meta["peer_ids"]
         synth = synth_multiple(peer, own)
         if synth is None:
             basis["multiples"][m] = entry
@@ -1020,7 +1026,10 @@ def peer_pct_for(
 
     INVARIANT (A4 review): never returns a partial some-None triple — percentiles()
     yields all three, and the MIN_PEERS-unmet path returns PeerPct(None,None,None).
-    Returns (PeerPct, {"cohort_n","excluded_stale_n","sic_level"[,"cohort_screened","screen"]})."""
+    Returns (PeerPct, {"cohort_n","excluded_stale_n","sic_level"
+    [,"peer_ids","cohort_screened","screen"]}); peer_ids (#2031 provenance) is the
+    sorted chosen member set, present iff the walk found a cohort (never on the
+    comparator-absent fallback_meta path)."""
     keep_dual = multiple == "pe"
     cutoff = as_of_date - _dt.timedelta(days=PEER_STALE_DAYS)
 
@@ -1051,8 +1060,10 @@ def peer_pct_for(
                     rows_cache[level] = cur.fetchall()
         return rows_cache[level]
 
-    def _refine(fresh: list[dict[str, Any]]) -> list[float]:
+    def _refine(fresh: list[dict[str, Any]]) -> list[tuple[int, float]]:
         """Size-refine fresh rows to the nearest PEER_LIMIT positive multiples.
+        Returns (instrument_id, mult) pairs — the ids feed the #2031 peer_ids
+        provenance so the chosen-8 is reconstructable from the stored row.
 
         F1 (High): _rank_peers DROPS members with missing/non-positive
         total_assets, so a set with >= MIN_PEERS FRESH members can still
@@ -1083,11 +1094,13 @@ def peer_pct_for(
                 self_total_assets=float(target_total_assets),
                 limit=PEER_LIMIT,
             )
-            chosen = [mult_by_id[pr.instrument_id] for pr in ranked if pr.instrument_id in mult_by_id]
+            chosen = [
+                (pr.instrument_id, mult_by_id[pr.instrument_id]) for pr in ranked if pr.instrument_id in mult_by_id
+            ]
             if not chosen:  # every fresh member lacked a positive total_assets
-                chosen = list(mult_by_id.values())
+                chosen = list(mult_by_id.items())
         else:
-            chosen = list(mult_by_id.values())
+            chosen = list(mult_by_id.items())
         return chosen
 
     # --- v4 screened pass (width-major, spec §4.1) ---
@@ -1110,11 +1123,15 @@ def peer_pct_for(
                     chosen = _refine(survivors)
                     if len(chosen) < MIN_PEERS:
                         continue
-                    p25, p50, p75 = percentiles(chosen, (0.25, 0.5, 0.75))
+                    p25, p50, p75 = percentiles([v for _, v in chosen], (0.25, 0.5, 0.75))
                     return PeerPct(p25=p25, p50=p50, p75=p75), {
                         "cohort_n": len(rows),
                         "excluded_stale_n": len(rows) - len(fresh),
                         "sic_level": level,
+                        # #2031 provenance: the chosen member set, sorted for
+                        # determinism (rank order reconstructable by joining
+                        # fair_value_cohort_members at as_of_date).
+                        "peer_ids": sorted(i for i, _ in chosen),
                         "cohort_screened": True,
                         "screen": {
                             "sic_level": level,
@@ -1159,13 +1176,15 @@ def peer_pct_for(
         chosen = _refine(fresh)
         if len(chosen) < MIN_PEERS:
             continue
-        p25, p50, p75 = percentiles(chosen, (0.25, 0.5, 0.75))
+        p25, p50, p75 = percentiles([v for _, v in chosen], (0.25, 0.5, 0.75))
         result = (
             PeerPct(p25=p25, p50=p50, p75=p75),
             {
                 "cohort_n": len(rows),
                 "excluded_stale_n": excluded_stale_n,
                 "sic_level": level,
+                # #2031 provenance (same contract as the screened pass).
+                "peer_ids": sorted(i for i, _ in chosen),
             },
         )
         break

--- a/docs/proposals/valuation/2026-07-15-fvb-cohort-hysteresis-falsification.md
+++ b/docs/proposals/valuation/2026-07-15-fvb-cohort-hysteresis-falsification.md
@@ -1,0 +1,66 @@
+# fair_value_band cohort-membership hysteresis (#2031) — premise unsupported on every stored night; ship chosen-member provenance instead
+
+**Status:** research verdict + minimal implementation, 2026-07-15.
+**Resolves:** #2031 (v2 spec §4 part 3, Phase 1b — [`2026-07-13-fair-value-band-v2-robustness.md`](./2026-07-13-fair-value-band-v2-robustness.md)).
+**Method version:** unchanged (`fvb_v4`) — band outputs (bear/base/bull/quality/reason) are byte-identical; only `basis_json` gains audit keys.
+
+---
+
+## 1. The premise under test
+
+v2 §4 part 3: "the size-refined 8-nearest cohort is re-picked every recompute; membership churn jitters `peer.p50` → the audited base — add hysteresis (stored prior membership, retain unless material change)."
+
+Scope constraint fixed at handoff (2026-07-15): a genuine cohort change (delist, screen re-tier, fresh fundamentals, freshness exit) MUST flow through; **only size-refine jitter at the nearest-8 boundary may damp**. So the premise stands or falls on one measurable: how often does the nearest-8 boundary churn WITHOUT a genuine-class cause?
+
+## 2. Source rule / structural analysis (code, not memory)
+
+Membership selection is deterministic and (almost) price-independent:
+
+- Ranking key = `|ln(total_assets) − ln(target_total_assets)|`, tie-break `instrument_id` (`peer_comparison.py:262-264`). `total_assets` moves only on a new filing.
+- Pool gates: SIC prefix (filing-driven), `close_date` freshness (`fair_value_band.py` `peer_pct_for`), `mult_value > 0` — price-independent for pe/ps/pb (`close > 0` always; sign is eps/revenue/equity), price-dependent only for the negative-EV ev edge (2/532 full-pop, #2021), dual-class routing (filing-driven), v4 companion screen (quarterly companions, sql/228).
+- No RNG, no wall-clock, no dict-order dependence anywhere in the walk.
+
+Therefore a chosen-8 change REQUIRES one of (Codex ckpt-1 MED: list is exhaustive over the walk's inputs): a member OR TARGET `total_assets` update/restatement re-ranking the pool (new filing → genuine; the target-side case re-ranks against an unchanged pool and is covered by the same displacement-margin measurement below), freshness flip (genuine exit — and a retained-but-stale member would put stale-price multiples into `peer.p50`, violating the §4.6 freshness invariant, so hysteresis could never legally retain it), universe/delist change (genuine), screen re-tier (genuine per handoff), EV-sign flip or `_MAX_SANE_MULTIPLE` crossing (price-dependent pool exits — genuine: the multiple stops being meaningful). Nightly `peer.p50` variance between filings is member VALUE drift (prices move, membership constant) — which hysteresis explicitly does not damp (membership pinned, values refresh; damping ≠ freezing).
+
+## 3. Full-population verification (dev, 2026-07-15)
+
+**Population (named, prevention-log "gate populations must match"):** the 868 peer-backed legs of the 569 `fvb_v4 reason='ok'` `fair_value_band_current` rows — the legs whose `peer.p50` feeds the audited base — replayed with the EXACT v4 walk (screened width-major + unscreened fallback, real `_rank_peers`, real `percentiles`) over every consecutive stored `fair_value_cohort_members` night-pair: 07-10→07-13, 07-13→07-14, 07-14→07-15 (~2,595 leg-nights). Harness: `#2032` validated sim pattern ([[project-2032-sim-harness]]); script `fvb_churn_measure.py` (session scratchpad; regenerate from the memory pattern).
+
+Measurement notes (Codex ckpt-1 MEDs, stated as design choices with their effect on the class under test):
+
+- **Companions = ONE current map applied to all dates** (derivation identical to the v4 rule — [`2026-07-15-fvb-v4-companion-screen.md`](./2026-07-15-fvb-v4-companion-screen.md) §4.5 / `companion_vars()`; sql/228 member cols are NULL pre-07-15 so per-night stored values do not exist). Holding the map constant makes the screen predicate IDENTICAL across each pair by construction → the measurement injects zero spurious screen churn and under-counts only screen-TIER churn (quarterly companion drift), which is genuine-class per the handoff and outside the dampable class. Size-refine jitter — the class under test — is measured EXACTLY: it depends on per-night `total_assets`/freshness/pool rows, all taken from each night's real stored member rows.
+- **Dev's frozen closes** are conservative for the stale-exit class (staleness exits fire as `as_of` advances while closes don't; prod daily bars keep members fresh). They SUPPRESS the price-dependent negative-EV-flip and `_MAX_SANE_MULTIPLE`-crossing churn (a confound, not a blanket bias) — but both are pool EXITS classified genuine (§2), so their suppression cannot hide dampable size-refine jitter.
+
+| Night pair | Result |
+| --- | --- |
+| 07-13→07-14 (quiet adjacent night) | **727/727 legs identical — zero churn of any kind** |
+| 07-10→07-13 (3-day gap) | 7/726 swapped (pe), all materially-closer newcomer arrivals |
+| 07-14→07-15 (#2036 D&A backfill, +405 members — max-churn night on record) | pe/ps/pb: 40 swapped legs, exit cause **stale ×40 (100%)** — hysteresis cannot retain (violates freshness), counterfactual `d_hyst ≡ d_fresh` exactly. ev: 30/42 legs re-tiered + 34 newcomers = the genuine fresh-fundamentals wave the backfill was FOR |
+
+**The dampable class is empirically absent.** Of 128 pairwise rerank displacements (outgoing still eligible), the log-distance improvement of incoming over outgoing: min 0.048, **only 2 < 0.10**, 4 < 0.25, p50 1.62 (incoming ~5× closer in asset-ratio space), incoming-farther 0/128. Under the issue's own admit rule ("a materially-closer-by-assets name appears") every displacement above any sane threshold admits — hysteresis fires on ≤2 of ~2,595 leg-nights (0.08%), both inside the genuine backfill wave.
+
+**Counterfactual hysteresis (retain-survivors + fill-vacancies, values from current night):** on every pe/ps/pb swapped leg, `d_hyst == d_fresh` (exits are undampable). The ONLY damping it produced was on ev during the #2036 backfill (Δp50 median 20.8% → 0%) — i.e. its only measured effect is **blocking a genuine data improvement**, exactly what the handoff constraint forbids.
+
+## 4. Verdict
+
+**Do not build stateful hysteresis.** No sql/229 state table, no `fvb_v5`, no backfill, no acceptance wave.
+
+Precise claim (Codex ckpt-1 HIGH: scoped, not overclaimed): the premise ("re-pick jitters the base") is **unsupported in every stored night-pair** (the complete temporal population that exists, including the highest-churn night on record) AND **structurally confined** — §2 shows every membership-changing input moves only on filing/universe/freshness/sign events, all genuine-class under the handoff constraint. The decision does not require "jitter can never exist"; it requires "no evidence it exists + the machinery is a standing risk (its only measured effect was blocking a genuine data improvement) + §5 makes any future occurrence cheaply detectable on real fresh-price nights before any state machinery is built". Same falsified-premise family as #1645 / #1662 / #2022-winsorization (question the MODEL, not the case).
+
+## 5. Deliverable instead — chosen-member provenance (`peer_ids`)
+
+The measurement above required a full replay harness because the chosen-8 IDs are not stored — `basis_json` carries peer percentiles and screen provenance but not membership. That is both an auditability gap ("persist enough structured evidence for auditability") and the reason the hysteresis question could not be answered from stored rows.
+
+Change (pure, additive, base-neutral):
+
+1. `peer_pct_for` returns the chosen member `instrument_id`s in its meta dict (`peer_ids`, sorted ascending for determinism — rank order is NOT stored; it is reconstructable by joining `fair_value_cohort_members` at the row's `as_of_date`, Codex ckpt-1 LOW), on BOTH the screened and unscreened paths.
+2. `compute_band` copies `meta["peer_ids"]` into the per-leg basis entry (same pattern as `cohort_screened`/`screen`).
+3. Tests (pure tier): `compute_band` carries `peer_ids` into `basis["multiples"][m]`; absent when the leg is peer-absent.
+
+Size: ≤ 8 ints per peer-backed leg (~908 legs universe-wide) — negligible. `METHOD_VERSION` unchanged (`own_capped_total` precedent: basis-key additions without value changes do not bump). No jobs-restart urgency (no #2008 clobber class — old code simply writes rows without the key until restart); no backfill (fills forward nightly).
+
+## 6. Revisit trigger
+
+Reopen hysteresis iff a stored-provenance churn scan over a **fresh-price population** (post market-data restoration; population = peer-backed legs of `ok` bands, consecutive nightly observations) shows small-margin rerank displacement (log-distance improvement < 0.25, outgoing still eligible) on **> 1% of leg-nights**.
+
+Scan mechanics (Codex ckpt-1 HIGH: `peer_ids` alone is not sufficient): diff `peer_ids` across consecutive `fair_value_band_observations` rows per (instrument, multiple), then join each night's ids to `fair_value_cohort_members` ON `(as_of_date, instrument_id, multiple)` to recover `total_assets` (log-distance + margins), `close_date` (freshness/eligibility) and companion cols (screen eligibility) — every gate input is a stored member column, so the scan is SQL + a leg-classifier over stored rows, no walk replay. Retention assumption this rests on: `materialize_cohort_members` deletes only its OWN `as_of_date` (`fair_value_band.py::materialize_cohort_members`); no code path prunes historical nights (4 nights currently retained). If a member-table retention policy is ever added, it must keep ≥ the scan window.

--- a/tests/test_fair_value_band_io.py
+++ b/tests/test_fair_value_band_io.py
@@ -279,6 +279,11 @@ def test_two_pass_cohort_excludes_dual_class_member(ebull_test_conn: psycopg.Con
     assert pe_pct.p50 == pytest.approx(23.5, abs=0.05)  # dual (pe=100) pulls the p50 up
     assert abs(pe_pct.p50 - 23.0) > 0.25  # NOT the 23.0 of the dual-excluded 7-member set
 
+    # 5. #2031 peer_ids provenance mirrors the routing at the ID level: the
+    #    dual member is absent from the P/S chosen set, present in the P/E one.
+    assert ps_meta["peer_ids"] == sorted(_SINGLE)
+    assert pe_meta["peer_ids"] == sorted([*(i for i in _SINGLE if _SINGLE[i][2] is not None), _DUAL])
+
 
 def test_single_name_run_anchors_to_materialized_cohort(ebull_test_conn: psycopg.Connection[tuple]) -> None:  # noqa: F811
     """A7 fix I1: a single-name cascade run anchors to the materialized cohort
@@ -544,6 +549,9 @@ def test_companion_screen_end_to_end(ebull_test_conn: psycopg.Connection[tuple])
     assert ps_entry["cohort_screened"] is True
     assert ps_entry["screen"] == {"sic_level": 4, "width_tier": 0, "survivors_n": len(_SCR_NEAR)}
     assert ps_entry["sic_level"] == 4
+    # #2031 provenance on the SCREENED path: exactly the 8 near survivors,
+    # sorted — the far peers never enter the chosen set.
+    assert ps_entry["peer_ids"] == sorted(_SCR_NEAR)
     # Screened p50 = median of the 8 near multiples {10..17} = 13.5; the far
     # 100x members never reach the percentiles.
     assert ps_entry["peer"]["p50"] == pytest.approx(13.5, abs=0.01)
@@ -567,6 +575,10 @@ def test_companion_screen_end_to_end(ebull_test_conn: psycopg.Connection[tuple])
     assert ps_entry["cohort_screened"] is False
     assert ps_entry["screen"] == {"reason": "target_companion_missing"}
     assert ps_entry["peer"]["p75"] > 17.0  # far 100x members present unscreened
+    # #2031 provenance on the UNSCREENED-fallback path, alongside the flag
+    # (Codex ckpt-2 coverage gap): nearest-8 by |ln TA| with id tie-break =
+    # the six 5e9 names (dist 0) + the two lowest-id 1e9 near peers.
+    assert ps_entry["peer_ids"] == sorted([_SCR_TARGET, _SCR_UNMATCHED, *_SCR_FAR, 8301, 8302])
 
     # 4. FALLBACK no_screened_cohort: companions present but margin 0.60 matches
     #    neither the 8 near (0.10) nor enough far peers at any tier.

--- a/tests/test_fair_value_band_policy.py
+++ b/tests/test_fair_value_band_policy.py
@@ -918,6 +918,33 @@ def test_compute_band_screen_provenance_and_knock():
     assert held_entry["screen"] == {"sic_level": 4, "width_tier": 1, "survivors_n": 11}
 
 
+def test_compute_band_peer_ids_provenance_carried_and_absent_when_peerless():
+    # #2031: peer_ids from cohort_meta lands in the basis entry verbatim; a
+    # peer-absent (own-only) leg's meta has no peer_ids and the entry stays
+    # keyless — provenance never claims a cohort the walk didn't find.
+    t = _t(revenue_ttm=1000.0, net_income_ttm=100.0, eps_diluted_ttm=10.0)
+    res = compute_band(
+        t,
+        peer_by_multiple={
+            "pe": PeerPct(p25=6.0, p50=8.0, p75=12.0),
+            "ps": PeerPct(None, None, None),  # peer-absent: own-only leg
+        },
+        own_by_multiple={
+            "pe": OwnPct(None, None, None),
+            "ps": OwnPct(p25=4.0, p50=6.0, p75=9.0),
+        },
+        own_points_by_multiple={"pe": 0, "ps": 8},
+        cohort_meta={
+            "pe": {"cohort_n": 40, "excluded_stale_n": 0, "sic_level": 4, "peer_ids": [11, 22, 33, 44, 55, 66, 77, 88]},
+            "ps": {"cohort_n": 3, "excluded_stale_n": 0, "sic_level": 0},
+        },
+        sic_level=4,
+    )
+    assert res.reason == "ok"
+    assert res.basis["multiples"]["pe"]["peer_ids"] == [11, 22, 33, 44, 55, 66, 77, 88]
+    assert "peer_ids" not in res.basis["multiples"]["ps"]
+
+
 def test_compute_band_own_only_screenable_leg_does_not_knock():
     # ps leg with NO peer side (own-only) marked cohort_screened=False: the knock
     # must NOT fire — there is no peer cohort to screen (spec §4.3). Quality here


### PR DESCRIPTION
Closes #2031

## What

Resolves #2031 (fvb v2 §4 part 3, cohort-membership hysteresis) with a research verdict + minimal provenance change:

1. **Hysteresis NOT built** — the premise ("nightly re-pick of the nearest-8 jitters `peer.p50` → the audited base") is refuted on the full population (evidence table on the issue; spec `docs/proposals/valuation/2026-07-15-fvb-cohort-hysteresis-falsification.md`). Every membership change across all stored night-pairs (~2,595 leg-nights over 868 peer-backed `ok`-band legs, incl. the max-churn #2036-backfill night) was genuine-class (stale exit / newcomer arrival / re-tier) — the class the handoff constraint says MUST flow through. The dampable size-refine-jitter class: ≤2 events (0.08%), and the counterfactual damped nothing on pe/ps/pb (`d_hyst ≡ d_fresh`; exits are unretainable under the freshness invariant). No sql/229 state table, no fvb_v5.
2. **`peer_ids` provenance shipped** — `peer_pct_for` now returns the chosen member ids (sorted) in its meta on BOTH the screened and unscreened walks (`_refine` returns `(id, mult)` pairs); `compute_band` copies them into `basis_json.multiples[m].peer_ids`. The falsification required a replay harness precisely because the chosen-8 was never stored; with this key the spec §6 revisit trigger is a SQL diff over observations + join to `fair_value_cohort_members` at `as_of_date`.

## Base-neutrality / method version

Band outputs are byte-identical: the percentiles input multiset is unchanged in every `_refine` branch (ranked / unranked / all-TA-missing fallback). `METHOD_VERSION` stays `fvb_v4` (basis-key-only addition; `own_capped_total` precedent). Codex ckpt-2 confirmed the pair-refactor across all call sites and branches.

## Security model

No new external inputs, no SQL text changes (member/target queries untouched), no new endpoints. `peer_ids` are server-derived ints from `fair_value_cohort_members`, serialized via the existing `Jsonb(band.basis)` write path. Files outside the diff: none affected; read consumers (`thesis.py` band block, rollup endpoint) pass `basis_json` through opaquely.

## Verification (DoD 8/11-style, run pre-merge on dev)

- Gates: `ruff check` ✓, `ruff format --check` ✓, `pyright` 0 errors ✓, fast tier 5093 passed ✓, smoke 153 passed (`-n 0`) ✓, targeted db tier `test_fair_value_band_io.py` + policy 85 passed ✓.
- **Panel recompute (branch code, dev DB, single-name cascade):** AAPL / GME / MSFT / JPM byte-identical `(bear, base, bull, quality, reason)` before/after; AAPL `298.783697` base unchanged, `peer_ids` n=8 on pe/ps/ev legs; GME `ok` with own-only pe/ps legs correctly carries NO `peer_ids`; JPM pe n=8; HD `stale_price` (known dev px artifact). JPM's missing pb leg pre-exists this PR (change is add-only).
- Tests pin: screened path (`peer_ids == sorted(_SCR_NEAR)`), unscreened-fallback path (`peer_ids` alongside `cohort_screened:false`, exact nearest-8-with-tie-break set — Codex ckpt-2 coverage gap), dual-class routing at id level (dual absent from ps set, present in pe set), pure carry + peerless-absent.

## Tradeoffs (conscious)

- `peer_ids` sorted ascending, not rank-ordered — determinism for diffing; rank order reconstructable by joining `fair_value_cohort_members` at the row's `as_of_date` (Codex ckpt-1 LOW).
- Falsification claim scoped to "every stored night-pair + structural confinement", not "jitter can never exist" (Codex ckpt-1 HIGH); the revisit trigger + provenance make any future occurrence detectable on real fresh-price nights before state machinery is ever built.
- No jobs-restart urgency: old daemon code writes rows without the key until the next restart — additive, no #2008 clobber class.

## Codex checkpoints

- ckpt-1 (spec): 6 findings (2 HIGH, 3 MED, 1 LOW) — all folded (claim scoping, revisit-scan join mechanics, companion-map measurement-design note, dev-confound naming, target-TA rerank class, rank-order wording).
- ckpt-2 (branch diff): no blocking findings; the one coverage gap (fallback-path `peer_ids` pin) added as a db-tier assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
