### PR TITLE
feat(#2012): machine-checkable thesis break predicates — PR-A (core + scan + stale rule)

### DIFF
--- a/.claude/skills/engineering/sql-correctness.md
+++ b/.claude/skills/engineering/sql-correctness.md
@@ -189,3 +189,15 @@ return null so the UI shows "—"/"unavailable", never `0`. Same
 "no-data ≠ zero" rule the risk layer encodes as `benchmark_missing`.
 Verify on a window the data does NOT cover, not just a healthy one.
 (#1817 `_benchmark_closes`.)
+
+## SQL/JSON path wildcards: `[*]` is array-only — against an object it is silently false
+
+`jsonb_path_exists(col, '$.multiples[*].peer_ids')` returns FALSE for every
+row when `multiples` is an OBJECT keyed by name (`{"pe": {...}, "ps": {...}}`)
+— `[*]` matches array elements only; the member wildcard is `.*`
+(`'$.multiples.*.peer_ids'`). No error is raised, so "0 rows have X" from a
+jsonpath probe is indistinguishable from "wrong wildcard": before concluding
+a jsonb feature is absent, `SELECT jsonb_pretty(col) … LIMIT 1` and check the
+actual container shape. (2026-07-16 #2012 session: a `[*]` probe on
+fair_value_band `basis_json.multiples` read shipped #2031 peer_ids provenance
+as missing — a `.*` re-probe found 448/553.)

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -123,6 +123,7 @@ from app.workers.scheduler import (
     JOB_SEC_N_PORT_INGEST,
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
+    JOB_THESIS_BREAK_SCAN,
     JOB_THESIS_DQ_AUDIT,
     JOB_THESIS_REFRESH,
     JOB_WEEKLY_REPORT,
@@ -182,6 +183,7 @@ from app.workers.scheduler import (
     sec_n_port_ingest,
     sec_nport_filer_directory_sync,
     seed_cost_models,
+    thesis_break_scan,
     thesis_dq_audit,
     thesis_refresh,
     weekly_report,
@@ -305,6 +307,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # #1919 PR-B — hourly scheduled + Admin "Run now". The body carries its
     # own provider-resolvable PREREQ_SKIP guard so the manual path (which
     # bypasses ScheduledJob.prerequisite) is equally gated.
+    JOB_THESIS_BREAK_SCAN: _adapt_zero_arg(thesis_break_scan),
     JOB_THESIS_DQ_AUDIT: _adapt_zero_arg(thesis_dq_audit),
     JOB_THESIS_REFRESH: _adapt_zero_arg(thesis_refresh),
     JOB_PORTFOLIO_EOD_SNAPSHOT: _adapt_zero_arg(portfolio_eod_snapshot_job),

--- a/app/services/instrument_analytics.py
+++ b/app/services/instrument_analytics.py
@@ -433,23 +433,25 @@ def compute_peer_grades(
 # ---------------------------------------------------------------------------
 def _read_latest_two_fy_facts(
     conn: psycopg.Connection[Any], instrument_id: int
-) -> tuple[dict[str, float] | None, dict[str, float] | None]:
+) -> tuple[dict[str, float] | None, dict[str, float] | None, date | None]:
     """Latest two fiscal years of annual (10-K, fiscal_period='FY') us-gaap facts
-    for the F/Z concepts, one ``{concept: float}`` dict per FY (current, prior).
+    for the F/Z concepts, one ``{concept: float}`` dict per FY (current, prior),
+    plus the current FY's canonical period_end (the as-of for freshness bounds,
+    #2012 — never the scoring timestamp, which would make stale facts look fresh).
 
     DISTINCT ON (concept, fiscal_year) collapses to ONE value per concept per FY,
     preferring the canonical FY-end (``period_end DESC``) then the latest filing
     (``filed_date DESC``). The period_end tie-break guards against a comparative
     prior-year line carried in a later 10-K being mistaken for the FY value.
-    Returns (None, None) when no annual facts are on file.
+    Returns (None, None, None) when no annual facts are on file.
     """
-    rows: list[tuple[int, str, float]]
+    rows: list[tuple[int, str, float, date]]
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT fiscal_year, concept, val FROM (
+            SELECT fiscal_year, concept, val, period_end FROM (
                 SELECT DISTINCT ON (concept, fiscal_year)
-                    fiscal_year, concept, val
+                    fiscal_year, concept, val, period_end
                 FROM financial_facts_raw
                 WHERE instrument_id = %(iid)s
                   AND taxonomy = 'us-gaap'
@@ -474,16 +476,30 @@ def _read_latest_two_fy_facts(
             """,
             {"iid": instrument_id, "concepts": list(PIOTROSKI_ALTMAN_CONCEPTS)},
         )
-        rows = [(int(r[0]), str(r[1]), float(r[2])) for r in cur.fetchall()]
+        rows = [(int(r[0]), str(r[1]), float(r[2]), r[3]) for r in cur.fetchall()]
 
     if not rows:
-        return None, None
-    years = sorted({fy for fy, _, _ in rows}, reverse=True)
+        return None, None, None
+    years = sorted({fy for fy, _, _, _ in rows}, reverse=True)
     curr_year = years[0]
     prior_year = years[1] if len(years) > 1 else None
-    curr = {c: v for fy, c, v in rows if fy == curr_year}
-    prior = {c: v for fy, c, v in rows if fy == prior_year} if prior_year is not None else None
-    return curr, prior
+    curr = {c: v for fy, c, v, _ in rows if fy == curr_year}
+    prior = {c: v for fy, c, v, _ in rows if fy == prior_year} if prior_year is not None else None
+    curr_pes = [pe for fy, _, _, pe in rows if fy == curr_year and pe is not None]
+    return curr, prior, (max(curr_pes) if curr_pes else None)
+
+
+def read_latest_fy_altman(conn: psycopg.Connection[Any], instrument_id: int) -> tuple[AltmanResult, date | None]:
+    """Latest-FY Altman Z″ plus the FY period_end it was computed from.
+
+    The as-of for #2012's freshness bound is the FACT period end — a
+    filing-derived date — never a scoring/scan timestamp. Sector gating
+    (financial firms are outside the Z″ model) is the CALLER's job:
+    this reader computes for whatever instrument it is given."""
+    curr, _prior, period_end = _read_latest_two_fy_facts(conn, instrument_id)
+    if curr is None:
+        return AltmanResult(None, None, reason="no_annual_facts"), None
+    return altman_z2(curr), period_end
 
 
 def _read_13f_delta(conn: psycopg.Connection[Any], instrument_id: int) -> tuple[float | None, date | None]:
@@ -557,7 +573,7 @@ def assemble_instrument_analytics(
         curr = prior = None
         try:
             with conn.transaction():
-                curr, prior = _read_latest_two_fy_facts(conn, instrument_id)
+                curr, prior, _fy_end = _read_latest_two_fy_facts(conn, instrument_id)
         except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
             curr = prior = None
         if curr is None:

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -227,10 +227,10 @@ def find_stale_instruments(
       3. filing_events row newer than latest thesis, filing_type in
          ('10-K', '10-K/A', '10-Q', '10-Q/A', '8-K', '8-K/A') → stale
          (reason: "event_new_{10k,10q,8k}")
-      4. now >= latest_thesis.created_at + interval(review_frequency) → stale (reason: "stale")
-      5. a thesis_break_events row exists for the LATEST thesis (#2012,
+      4. a thesis_break_events row exists for the LATEST thesis (#2012,
          thesis_id equality — never a timestamp filter) → stale
          (reason: "break_fired")
+      5. now >= latest_thesis.created_at + interval(review_frequency) → stale (reason: "stale")
 
     Every returned instrument must have ``coverage.filings_status =
     'analysable'`` (#268 Chunk J gate). Non-analysable instruments are
@@ -359,21 +359,23 @@ def find_stale_instruments(
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason=reason))
             continue
 
-        threshold = latest_thesis_at + timedelta(days=_REVIEW_FREQUENCY_DAYS[review_frequency])
-        if now >= threshold:
-            stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="stale"))
-            continue
-
         # Rule 5 (#2012): a thesis_break_events row exists for the LATEST
         # thesis — a machine-checkable break condition transitioned
         # false→true after arming. Keyed by thesis_id EQUALITY in the
         # SELECT above (never a fired_at timestamp filter: a delayed scan
         # can stamp an OLD thesis's event after its replacement was
         # created, which would re-stale the new thesis forever). Ordered
-        # after the filing-event rules so a break never masks a 10-K/10-Q
-        # trigger in the reason telemetry; both paths regenerate.
+        # after the filing-event rules (a break never masks a 10-K/10-Q
+        # trigger) but BEFORE the generic cadence rule — a fired break is
+        # the more specific reason and must not be shadowed by mere age
+        # (Codex ckpt-2); every path regenerates either way.
         if break_fired:
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="break_fired"))
+            continue
+
+        threshold = latest_thesis_at + timedelta(days=_REVIEW_FREQUENCY_DAYS[review_frequency])
+        if now >= threshold:
+            stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="stale"))
 
     return stale
 

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -90,6 +90,7 @@ StaleReason = Literal[
     "event_new_10k",
     "event_new_10q",
     "event_new_8k",
+    "break_fired",
 ]
 
 _VALID_THESIS_TYPES: frozenset[str] = frozenset({"compounder", "value", "turnaround", "speculative"})
@@ -227,6 +228,9 @@ def find_stale_instruments(
          ('10-K', '10-K/A', '10-Q', '10-Q/A', '8-K', '8-K/A') → stale
          (reason: "event_new_{10k,10q,8k}")
       4. now >= latest_thesis.created_at + interval(review_frequency) → stale (reason: "stale")
+      5. a thesis_break_events row exists for the LATEST thesis (#2012,
+         thesis_id equality — never a timestamp filter) → stale
+         (reason: "break_fired")
 
     Every returned instrument must have ``coverage.filings_status =
     'analysable'`` (#268 Chunk J gate). Non-analysable instruments are
@@ -282,7 +286,16 @@ def find_stale_instruments(
             c.review_frequency,
             MAX(t.created_at)                        AS latest_thesis_at,
             le.created_at                            AS latest_event_created_at,
-            le.filing_type                           AS latest_event_filing_type
+            le.filing_type                           AS latest_event_filing_type,
+            EXISTS (
+                SELECT 1 FROM thesis_break_events e
+                WHERE e.thesis_id = (
+                    SELECT t2.thesis_id FROM theses t2
+                    WHERE t2.instrument_id = i.instrument_id
+                    ORDER BY t2.created_at DESC, t2.thesis_version DESC, t2.thesis_id DESC
+                    LIMIT 1
+                )
+            )                                        AS break_fired
         FROM instruments i
         JOIN coverage c ON c.instrument_id = i.instrument_id
         LEFT JOIN theses t ON t.instrument_id = i.instrument_id
@@ -319,6 +332,7 @@ def find_stale_instruments(
         latest_thesis_at: datetime | None = row[3]
         latest_event_created_at: datetime | None = row[4]
         latest_event_filing_type: str | None = row[5]
+        break_fired: bool = bool(row[6])
 
         if latest_thesis_at is None:
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="no_thesis"))
@@ -348,6 +362,18 @@ def find_stale_instruments(
         threshold = latest_thesis_at + timedelta(days=_REVIEW_FREQUENCY_DAYS[review_frequency])
         if now >= threshold:
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="stale"))
+            continue
+
+        # Rule 5 (#2012): a thesis_break_events row exists for the LATEST
+        # thesis — a machine-checkable break condition transitioned
+        # false→true after arming. Keyed by thesis_id EQUALITY in the
+        # SELECT above (never a fired_at timestamp filter: a delayed scan
+        # can stamp an OLD thesis's event after its replacement was
+        # created, which would re-stale the new thesis forever). Ordered
+        # after the filing-event rules so a break never masks a 10-K/10-Q
+        # trigger in the reason telemetry; both paths regenerate.
+        if break_fired:
+            stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="break_fired"))
 
     return stale
 

--- a/app/services/thesis_break.py
+++ b/app/services/thesis_break.py
@@ -1,0 +1,391 @@
+"""Machine-checkable thesis break predicates — pure layer (#2012 PR-A).
+
+``break_conditions_json`` is free prose. This module extracts the subset
+that maps onto a CLOSED, trust-verified metric vocabulary (whole-string,
+precision-gated — recall is explicitly not a goal; anything ambiguous,
+composite, duration-qualified or naming a denominator we do not ingest
+stays prose, fail-open) and evaluates predicates against supplied
+observations with per-input freshness bounds (fail-closed: absent or
+stale input can never fire, and can never arm a baseline).
+
+Arm/baseline model (spec Design 5): a predicate's first CONTEMPORANEOUS
+evaluation is its baseline. Baseline true → the writer's own premise
+(``already_true``) — never fires. Baseline true after any unobserved gap
+(the row was ever ``pending``, or the first scan ran > grace after thesis
+creation) → ``already_true_after_gap`` — indistinguishable from a break
+missed during the gap, so still never fires, but counted separately.
+Baseline false → ``armed``; only armed predicates fire, on the first
+observed false→true transition. An already-true premise that later
+resolves (observed false) RE-ARMS — a subsequent true is then a genuine
+transition.
+
+Pure: no DB, no I/O, no import from ``thesis`` (no cycle). The DB-facing
+scan lives in ``thesis_break_scan.py``.
+
+Spec: docs/proposals/thesis/2026-07-16-thesis-break-predicates.md.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Vocabulary
+# ---------------------------------------------------------------------------
+
+# Regime metrics compare two live columns; they carry no threshold.
+REGIME_METRICS: frozenset[str] = frozenset({"price_vs_sma200", "sma_50_vs_sma_200"})
+
+# Per-input freshness bounds (spec "Closed vocabulary"). A metric evaluates
+# only when EVERY listed input is present and within its own bound — a ratio
+# is only as fresh as its stalest input.
+#   finra_settlement  ≤ 45d  — two missed bimonthly cycles (skill finra.md:11)
+#   share_count_filed ≤ 183d — dei shares outstanding is stated on every
+#                              10-K/10-Q cover (quarterly cadence; 2 missed)
+#   fy_period_end     ≤ 456d — annual cadence + 10-K filing lag (15 months)
+#   price_date        ≤ 10d  — calendar days; holidays covered
+FRESHNESS_BOUNDS: dict[str, dict[str, timedelta]] = {
+    "short_interest_pct_shares_out": {
+        "finra_settlement": timedelta(days=45),
+        "share_count_filed": timedelta(days=183),
+    },
+    "short_interest_days_to_cover": {"finra_settlement": timedelta(days=45)},
+    "short_interest_change_pct": {"finra_settlement": timedelta(days=45)},
+    "altman_z": {"fy_period_end": timedelta(days=456)},
+    "rsi_14": {"price_date": timedelta(days=10)},
+    "price_vs_sma200": {"price_date": timedelta(days=10)},
+    "sma_50_vs_sma_200": {"price_date": timedelta(days=10)},
+}
+
+# already_true (premise) requires the baseline to be contemporaneous with
+# thesis creation: first evaluation on the scan that created the row AND
+# within this grace of created_at (one nightly cadence + slack). Anything
+# later — ever-pending or rollout — is already_true_after_gap.
+BASELINE_GRACE = timedelta(hours=48)
+
+
+@dataclass(frozen=True)
+class BreakPredicate:
+    """One machine-checkable condition. ``threshold`` is None iff regime."""
+
+    metric: str
+    op: Literal["<", ">"]
+    threshold: float | None
+    unit: str
+    source_text: str
+
+
+@dataclass(frozen=True)
+class MetricInput:
+    """One named input feeding an observation (evidence unit for inputs_json)."""
+
+    value: float
+    as_of: date | None
+    source: str
+
+
+@dataclass(frozen=True)
+class MetricObservation:
+    """A metric's current reading, freshness-classified via ``observe``.
+
+    ``value`` is the scalar the predicate compares (for regime metrics: the
+    signed LHS−RHS gap, so op '<' means gap < 0). ``as_of`` is the STALEST
+    contributing input's as-of. ``status`` other than 'ok' can never fire
+    and can never baseline.
+    """
+
+    metric: str
+    status: Literal["ok", "no_input", "stale_input"]
+    value: float | None = None
+    as_of: date | None = None
+    inputs: dict[str, MetricInput] = field(default_factory=dict)
+
+
+def observe(
+    metric: str,
+    inputs: dict[str, MetricInput | None],
+    value: float | None,
+    *,
+    today: date,
+) -> MetricObservation:
+    """Freshness-classify raw inputs into a MetricObservation (fail-closed).
+
+    Every input named in FRESHNESS_BOUNDS[metric] must be present (else
+    ``no_input``) and within its own bound (else ``stale_input``); each
+    input's bound is checked independently — never a collapsed scalar.
+    """
+    bounds = FRESHNESS_BOUNDS[metric]
+    present: dict[str, MetricInput] = {k: v for k, v in inputs.items() if v is not None}
+    if value is None or any(name not in present for name in bounds):
+        return MetricObservation(metric=metric, status="no_input", inputs=present)
+    for name, bound in bounds.items():
+        inp = present[name]
+        if inp.as_of is None or (today - inp.as_of) > bound:
+            return MetricObservation(metric=metric, status="stale_input", inputs=present)
+    as_of = min(inp.as_of for name, inp in present.items() if name in bounds and inp.as_of is not None)
+    return MetricObservation(metric=metric, status="ok", value=value, as_of=as_of, inputs=present)
+
+
+EvalResult = Literal["true", "false", "no_input", "stale_input"]
+
+
+def evaluate_predicate(pred: BreakPredicate, obs: MetricObservation) -> EvalResult:
+    """Pure compare. Regime metrics compare the signed gap against zero."""
+    if obs.status != "ok":
+        return obs.status
+    assert obs.value is not None
+    threshold = 0.0 if pred.threshold is None else pred.threshold
+    hit = obs.value < threshold if pred.op == "<" else obs.value > threshold
+    return "true" if hit else "false"
+
+
+# ---------------------------------------------------------------------------
+# Baseline state machine (spec Design 5)
+# ---------------------------------------------------------------------------
+
+BaselineState = Literal["pending", "armed", "already_true", "already_true_after_gap"]
+
+
+def next_baseline_state(
+    state: BaselineState,
+    result: EvalResult,
+    *,
+    newly_inserted: bool,
+    thesis_created_at: datetime,
+    now: datetime,
+) -> tuple[BaselineState, bool]:
+    """(new_state, fire). Fires ONLY from ``armed`` on an observed true.
+
+    ``newly_inserted`` = the predicate row was created by THIS scan (it was
+    never left pending by a prior scan). Non-ok results change nothing —
+    a predicate cannot arm, fire, or re-arm on data we do not have.
+    """
+    if result in ("no_input", "stale_input"):
+        return state, False
+    if state == "pending":
+        if result == "false":
+            return "armed", False
+        contemporaneous = newly_inserted and (now - thesis_created_at) <= BASELINE_GRACE
+        return ("already_true" if contemporaneous else "already_true_after_gap"), False
+    if state == "armed":
+        return "armed", result == "true"
+    # already_true / already_true_after_gap: premise resolved → re-arm.
+    if result == "false":
+        return "armed", False
+    return state, False
+
+
+# ---------------------------------------------------------------------------
+# Extractor — whole-string, precision-gated (spec Designs 3, 4, 7)
+# ---------------------------------------------------------------------------
+
+# Fail-open pre-filter. Composites (a substring match would evaluate a WEAKER
+# condition than written), illustrative "(e.g., …)" wrappers (the head is the
+# real, broader condition), duration/persistence qualifiers (not expressible
+# as a single-scan edge trigger), deadline semantics ("within N months",
+# "fails to …" = failure-to-achieve), and eToro-context metadata leaks.
+_REJECT = re.compile(
+    r"\b(?:and|or|with|while|plus|alongside|amid|versus|vs)\b"
+    r"|e\.g\."
+    r"|\bfor\s+(?:[>≥]?\s*\d|a\b|an\b|two|three|four|several|consecutive|sustained|prolonged|extended)"
+    r"|\b(?:sustained|persistent|prolonged|consecutive|consistently)\b"
+    r"|\bwithin\s+\d"
+    r"|\bfail(?:s|ure|ing)?\s+to\b"
+    r"|\{"
+)
+
+_NUM = r"(?P<num>-?\d+(?:\.\d+)?)"
+# One trailing annotation parenthetical: "(current 1.805)", "(oversold
+# territory)", "(death cross confirmation)". Composite/e.g. content inside
+# a parenthetical is already killed by _REJECT (it scans the whole string).
+_ANNOT = r"(?:\s*\([^()]*\))?"
+
+# Verb families carry direction; the explicit preposition decides, but a
+# non-neutral verb that CONTRADICTS the preposition ("improves below -1.5")
+# is a writer error → fail open.
+_POSITIVE_VERBS = frozenset(
+    {
+        "improves",
+        "improve",
+        "improving",
+        "improvement",
+        "recovers",
+        "recovery",
+        "rises",
+        "rising",
+        "rise",
+        "climbs",
+        "increase",
+        "increases",
+    }
+)
+_NEGATIVE_VERBS = frozenset(
+    {
+        "falls",
+        "fall",
+        "falling",
+        "drops",
+        "drop",
+        "dropping",
+        "declines",
+        "decline",
+        "declining",
+        "deteriorates",
+        "deterioration",
+        "worsens",
+        "worsening",
+        "reduction",
+        "decrease",
+        "decreases",
+    }
+)
+
+_DIR_UP = frozenset({"above", ">", "exceeds"})
+_DIR_DOWN = frozenset({"below", "<"})
+
+
+def _direction(verb: str | None, prep: str) -> Literal["<", ">"] | None:
+    """Resolve op from preposition, vetoed by a contradicting verb family."""
+    op: Literal["<", ">"] = ">" if prep in _DIR_UP else "<"
+    if verb:
+        verb = verb.strip().lower()
+        if verb in _POSITIVE_VERBS and op == "<":
+            return None
+        if verb in _NEGATIVE_VERBS and op == ">":
+            return None
+    return op
+
+
+# altman: optional possessive company prefix ("dropbox's altman z-score").
+_ALTMAN_HEAD = r"(?:[a-z][\w.&-]*'s\s+)?altman\s+z[\s-]?score"
+_QUAL = r"(?:(?:material|significant|major|notable)\s+)?"
+
+# Form A: "<qual> improvement/decline in altman z-score (to) above/below N"
+_ALTMAN_A = re.compile(
+    rf"^{_QUAL}(?P<verb>improvement|recovery|reduction|decline|drop|deterioration|decrease)\s+in\s+"
+    rf"{_ALTMAN_HEAD}\s+(?:to\s+)?(?P<prep>above|below)\s+{_NUM}{_ANNOT}$"
+)
+# Form B: "altman z-score falls/improves/crosses/moves (to/into) above|below|>|< N"
+_ALTMAN_B = re.compile(
+    rf"^{_ALTMAN_HEAD}\s+"
+    r"(?P<verb>falls|falling|drops|dropping|declines|declining|deteriorates|worsens|worsening|"
+    r"crosses|crossing|moves|moving|rises|rising|improves|improving|improvement|recovers)\s+"
+    rf"(?:to\s+|into\s+)?(?P<prep>above|below|>|<)\s*{_NUM}{_ANNOT}$"
+)
+# Form C: "altman z-score crosses into bankruptcy/'non-distress' territory (<N)"
+# — threshold lives in the parenthetical.
+_ALTMAN_C = re.compile(
+    rf"^{_ALTMAN_HEAD}\s+(?:crosses|crossing)\s+into\s+"
+    r"(?:'?non-distress'?\s+(?:territory|band|levels?)|bankruptcy\s+territory)\s+"
+    rf"\((?P<prep>[<>])\s*{_NUM}\)$"
+)
+
+# rsi: "rsi-14 crosses above 70 (overbought territory)"
+_RSI = re.compile(
+    r"^rsi[\s-]?(?:14\s+)?(?P<verb>crosses|drops|falls|rises|moves)\s+(?P<prep>above|below)\s+"
+    rf"{_NUM}{_ANNOT}$"
+)
+
+# short interest, EXPLICIT shares-outstanding denominator ONLY (spec Design 4:
+# float and bare percentages fail open — shares_out ≥ float, so substituting
+# our denominator systematically under-reports the writer's condition).
+_SI_SHARES_OUT = re.compile(
+    rf"^{_QUAL}short\s+interest\s+"
+    r"(?P<verb>rises|increases|climbs|exceeds|falls|drops|declines)\s+"
+    rf"(?:above\s+|below\s+)?{_NUM}%\s+of\s+(?:total\s+)?shares\s+outstanding{_ANNOT}\.?$"
+)
+# Prefix-verb form: "material increase in short interest above 20% of shares
+# outstanding" — the event noun leads, the preposition still carries direction.
+_SI_SHARES_OUT_PREFIX = re.compile(
+    rf"^{_QUAL}(?P<verb>increase|rise|reduction|decline|decrease|drop)\s+in\s+short\s+interest\s+"
+    rf"(?:to\s+)?(?P<prep>above|below)\s+{_NUM}%\s+of\s+(?:total\s+)?shares\s+outstanding{_ANNOT}\.?$"
+)
+
+# Regime: price below its 200-day SMA. The corpus pins write-time dollar
+# levels ("below 116.05 (200-day sma)") — the semantic condition is the
+# MOVING sma, so all forms evaluate as the regime close < sma_200; the
+# stamped number stays in source_text.
+_PRICE_SMA_FORMS = (
+    re.compile(rf"^(?:technical\s+)?break(?:down)?\s+below\s+(?:the\s+)?200[\s-]?day\s+sma{_ANNOT}$"),
+    re.compile(rf"^technical\s+breakdown\s+below\s+{_NUM}\s+\(200[\s-]?day\s+sma\)$"),
+    re.compile(rf"^technical\s+breakdown\s+below\s+sma[\s_]?200\s+\(\$?{_NUM}\)$"),
+    re.compile(rf"^price\s+(?:breaks?|drops?|closes?|falls?)\s+below\s+(?:the\s+)?200[\s-]?day\s+sma{_ANNOT}$"),
+)
+
+# Regime: sma_50 vs sma_200. "crosses below" extracts as the REGIME (spec
+# Design 5: a cross already holding at arm baselines already_true; armed →
+# a later regime flip IS the cross event). Bare-parenthetical definition
+# forms allowed; "(e.g., …)" illustrative forms are killed by _REJECT.
+_SMA_CROSS_FORMS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(rf"^sma[\s_]?50\s+(?:crosses\s+)?(?P<prep>below|above)\s+sma[\s_]?200{_ANNOT}$"), "prep"),
+    (
+        re.compile(
+            rf"^50[\s-]?day\s+sma\s+(?:crosses\s+)?(?P<prep>below|above)\s+(?:the\s+)?200[\s-]?day\s+sma{_ANNOT}$"
+        ),
+        "prep",
+    ),
+    (
+        re.compile(
+            r"^technical\s+indicators\s+(?:confirm|show)\s+(?:a\s+)?bearish\s+(?:regime|crossover|reversal)\s+"
+            r"\(sma[\s_]?50\s+(?:crosses\s+below|below|<)\s+sma[\s_]?200\)$"
+        ),
+        "<",
+    ),
+)
+
+
+def _extract_one(condition: str) -> BreakPredicate | None:
+    text = " ".join(condition.split()).lower().rstrip()
+    if not text or _REJECT.search(text):
+        return None
+
+    for pattern in (_ALTMAN_A, _ALTMAN_B, _ALTMAN_C):
+        m = pattern.match(text)
+        if m:
+            op = _direction(m.groupdict().get("verb"), m.group("prep"))
+            if op is None:
+                return None
+            return BreakPredicate("altman_z", op, float(m.group("num")), "zscore", condition)
+
+    m = _RSI.match(text)
+    if m:
+        op = _direction(m.group("verb"), m.group("prep"))
+        if op is None:
+            return None
+        return BreakPredicate("rsi_14", op, float(m.group("num")), "index", condition)
+
+    m = _SI_SHARES_OUT.match(text)
+    if m:
+        verb = m.group("verb")
+        prep = "above" if ("above" in m.group(0) or verb in ("rises", "increases", "climbs", "exceeds")) else "below"
+        op = _direction(verb if verb != "exceeds" else None, prep)
+        if op is None:
+            return None
+        return BreakPredicate("short_interest_pct_shares_out", op, float(m.group("num")), "pct_shares_out", condition)
+
+    m = _SI_SHARES_OUT_PREFIX.match(text)
+    if m:
+        op = _direction(m.group("verb"), m.group("prep"))
+        if op is None:
+            return None
+        return BreakPredicate("short_interest_pct_shares_out", op, float(m.group("num")), "pct_shares_out", condition)
+
+    for pattern in _PRICE_SMA_FORMS:
+        if pattern.match(text):
+            return BreakPredicate("price_vs_sma200", "<", None, "regime", condition)
+
+    for pattern, op_spec in _SMA_CROSS_FORMS:
+        m = pattern.match(text)
+        if m:
+            op = (">" if m.group("prep") == "above" else "<") if op_spec == "prep" else op_spec
+            return BreakPredicate("sma_50_vs_sma_200", op, None, "regime", condition)  # type: ignore[arg-type]
+
+    return None
+
+
+def extract_predicates(conditions: list[str]) -> list[BreakPredicate | None]:
+    """Index-aligned with break_conditions_json; None = prose (fail-open)."""
+    return [_extract_one(c) if isinstance(c, str) else None for c in conditions]

--- a/app/services/thesis_break.py
+++ b/app/services/thesis_break.py
@@ -28,6 +28,7 @@ Spec: docs/proposals/thesis/2026-07-16-thesis-break-predicates.md.
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from typing import Literal
@@ -386,6 +387,9 @@ def _extract_one(condition: str) -> BreakPredicate | None:
     return None
 
 
-def extract_predicates(conditions: list[str]) -> list[BreakPredicate | None]:
-    """Index-aligned with break_conditions_json; None = prose (fail-open)."""
+def extract_predicates(conditions: Sequence[object]) -> list[BreakPredicate | None]:
+    """Index-aligned with break_conditions_json; None = prose (fail-open).
+
+    Accepts the RAW jsonb array — non-string elements map to None in place
+    so a malformed element can never shift later predicate indexes."""
     return [_extract_one(c) if isinstance(c, str) else None for c in conditions]

--- a/app/services/thesis_break_scan.py
+++ b/app/services/thesis_break_scan.py
@@ -240,7 +240,11 @@ def run_thesis_break_scan(conn: psycopg.Connection[Any], *, now: datetime | None
         if not isinstance(conditions, list):
             continue
         iid = int(t["instrument_id"])
-        for idx, pred in enumerate(extract_predicates([c for c in conditions if isinstance(c, str)])):
+        # Pass the RAW array — extract_predicates None-maps non-string
+        # elements itself, keeping predicate_index aligned with the
+        # original break_conditions_json slots (a pre-filter would shift
+        # every index after a malformed element).
+        for idx, pred in enumerate(extract_predicates(list(conditions))):
             if pred is None:
                 continue
             if pred.metric in _ALTMAN_METRICS and iid in financial:

--- a/app/services/thesis_break_scan.py
+++ b/app/services/thesis_break_scan.py
@@ -1,0 +1,378 @@
+"""Nightly thesis-break scan — DB-facing side of #2012 (PR-A).
+
+One read assembling the closed-vocabulary observations for the fire
+population (LATEST thesis per instrument), then pure calls into
+``thesis_break`` (extract → observe → evaluate → state machine), then
+writes: predicate upserts, baseline-state transitions, and at most one
+``thesis_break_events`` row per predicate per thesis version.
+
+Altman sector gate (spec "Closed vocabulary"): Altman Z″ excludes
+financial firms (Altman 2000), and the upstream ``gics_sector ==
+"Financials"`` suppression misses Real Estate (GICS split it out of
+Financials in 2016 — sector_classification.py maps SIC 65xx/6798 to
+XLRE). Gated here at PREDICATE INSERT on SIC division H (60-67: finance,
+insurance, real estate) — a superset of the spec's named 60-64/65xx/6798,
+aligned to the SIC division the source rule actually excludes. Gated
+conditions stay prose; a permanently-unevaluable pending row would lie.
+
+Mirrors thesis_dq_audit's split (#2014 precedent): pure predicates in
+``thesis_break.py``, one DB reader/writer here.
+
+Spec: docs/proposals/thesis/2026-07-16-thesis-break-predicates.md.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import Any
+
+import psycopg
+import psycopg.rows
+from psycopg.types.json import Jsonb
+
+from app.services.instrument_analytics import read_latest_fy_altman
+from app.services.thesis_break import (
+    BaselineState,
+    BreakPredicate,
+    MetricInput,
+    MetricObservation,
+    evaluate_predicate,
+    extract_predicates,
+    next_baseline_state,
+    observe,
+)
+
+# SIC division H — finance, insurance, and real estate (Altman gate).
+_FINANCIAL_SIC2 = frozenset({"60", "61", "62", "63", "64", "65", "66", "67"})
+
+_ALTMAN_METRICS = frozenset({"altman_z"})
+_PRICE_METRICS = frozenset({"rsi_14", "price_vs_sma200", "sma_50_vs_sma_200"})
+_SI_METRICS = frozenset({"short_interest_pct_shares_out", "short_interest_days_to_cover", "short_interest_change_pct"})
+
+
+@dataclass(frozen=True)
+class ThesisBreakScanReport:
+    scanned_theses: int
+    predicates_total: int
+    predicates_inserted: int
+    sector_gated: int
+    fired: int
+    state_counts: dict[str, int]
+    eval_counts: dict[str, int]
+
+
+def _latest_theses(conn: psycopg.Connection[Any]) -> list[dict[str, Any]]:
+    """Latest thesis per instrument — the #2014 tiebreak (created_at DESC,
+    thesis_version DESC, thesis_id DESC), deterministic under same-second
+    inserts."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (t.instrument_id)
+                t.instrument_id, t.thesis_id, t.created_at, t.break_conditions_json
+            FROM theses t
+            ORDER BY t.instrument_id, t.created_at DESC, t.thesis_version DESC, t.thesis_id DESC
+            """
+        )
+        return cur.fetchall()
+
+
+def _financial_instruments(conn: psycopg.Connection[Any], instrument_ids: list[int]) -> set[int]:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id FROM instrument_sec_profile
+            WHERE instrument_id = ANY(%(ids)s) AND sic2 = ANY(%(sic2s)s)
+            """,
+            {"ids": instrument_ids, "sic2s": sorted(_FINANCIAL_SIC2)},
+        )
+        return {int(r[0]) for r in cur.fetchall()}
+
+
+def _price_observations(
+    conn: psycopg.Connection[Any], instrument_ids: list[int], today: date
+) -> dict[int, dict[str, MetricObservation]]:
+    """rsi_14 / price_vs_sma200 / sma_50_vs_sma_200 from the latest
+    price_daily row. Regime values are signed gaps (op '<' ⇒ gap < 0);
+    a structurally-absent sma (needs 200 trading days) is no_input."""
+    out: dict[int, dict[str, MetricObservation]] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT ON (instrument_id)
+                instrument_id, price_date, close, sma_50, sma_200, rsi_14
+            FROM price_daily
+            WHERE instrument_id = ANY(%(ids)s)
+            ORDER BY instrument_id, price_date DESC
+            """,
+            {"ids": instrument_ids},
+        )
+        for iid, price_date, close, sma_50, sma_200, rsi in cur.fetchall():
+            obs: dict[str, MetricObservation] = {}
+            obs["rsi_14"] = observe(
+                "rsi_14",
+                {"price_date": None if rsi is None else MetricInput(float(rsi), price_date, "price_daily")},
+                None if rsi is None else float(rsi),
+                today=today,
+            )
+            gap_price = None if close is None or sma_200 is None else float(close) - float(sma_200)
+            obs["price_vs_sma200"] = observe(
+                "price_vs_sma200",
+                {"price_date": None if gap_price is None else MetricInput(gap_price, price_date, "price_daily")},
+                gap_price,
+                today=today,
+            )
+            gap_sma = None if sma_50 is None or sma_200 is None else float(sma_50) - float(sma_200)
+            obs["sma_50_vs_sma_200"] = observe(
+                "sma_50_vs_sma_200",
+                {"price_date": None if gap_sma is None else MetricInput(gap_sma, price_date, "price_daily")},
+                gap_sma,
+                today=today,
+            )
+            out[int(iid)] = obs
+    return out
+
+
+def _short_interest_observations(
+    conn: psycopg.Connection[Any], instrument_ids: list[int], today: date
+) -> dict[int, dict[str, MetricObservation]]:
+    """FINRA bimonthly current snapshot + dei/gaap shares outstanding.
+    days_to_cover and change_percent are computed BY FINRA (no denominator
+    of ours); the pct metric divides by share_count_history.shares_outstanding
+    — the settled short_interest_signal denominator — with BOTH inputs
+    independently freshness-bounded."""
+    out: dict[int, dict[str, MetricObservation]] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT si.instrument_id, si.settlement_date, si.current_short_interest,
+                   si.days_to_cover, si.change_percent,
+                   sc.shares_outstanding, sc.latest_filed_date
+            FROM finra_short_interest_current si
+            LEFT JOIN LATERAL (
+                SELECT h.shares_outstanding, h.latest_filed_date
+                FROM share_count_history h
+                WHERE h.instrument_id = si.instrument_id AND h.shares_outstanding IS NOT NULL
+                ORDER BY h.period_end DESC
+                LIMIT 1
+            ) sc ON TRUE
+            WHERE si.instrument_id = ANY(%(ids)s)
+            """,
+            {"ids": instrument_ids},
+        )
+        for iid, settle, si_shares, dtc, chg, shares_out, filed in cur.fetchall():
+            finra = None if settle is None else MetricInput(float(si_shares), settle, "finra_short_interest_current")
+            obs: dict[str, MetricObservation] = {}
+            obs["short_interest_days_to_cover"] = observe(
+                "short_interest_days_to_cover",
+                {
+                    "finra_settlement": None
+                    if dtc is None
+                    else MetricInput(float(dtc), settle, "finra_short_interest_current")
+                },
+                None if dtc is None else float(dtc),
+                today=today,
+            )
+            obs["short_interest_change_pct"] = observe(
+                "short_interest_change_pct",
+                {
+                    "finra_settlement": None
+                    if chg is None
+                    else MetricInput(float(chg), settle, "finra_short_interest_current")
+                },
+                None if chg is None else float(chg),
+                today=today,
+            )
+            pct = (
+                None
+                if si_shares is None or shares_out is None or float(shares_out) <= 0
+                else 100.0 * float(si_shares) / float(shares_out)
+            )
+            obs["short_interest_pct_shares_out"] = observe(
+                "short_interest_pct_shares_out",
+                {
+                    "finra_settlement": finra,
+                    "share_count_filed": (
+                        None if shares_out is None else MetricInput(float(shares_out), filed, "share_count_history")
+                    ),
+                },
+                pct,
+                today=today,
+            )
+            out[int(iid)] = obs
+    return out
+
+
+def _altman_observation(conn: psycopg.Connection[Any], instrument_id: int, today: date) -> MetricObservation:
+    result, period_end = read_latest_fy_altman(conn, instrument_id)
+    z = result.z
+    return observe(
+        "altman_z",
+        {"fy_period_end": None if z is None else MetricInput(float(z), period_end, "financial_facts_raw")},
+        None if z is None else float(z),
+        today=today,
+    )
+
+
+def _inputs_payload(obs: MetricObservation) -> dict[str, dict[str, Any]]:
+    return {
+        name: {"value": inp.value, "as_of": None if inp.as_of is None else inp.as_of.isoformat(), "source": inp.source}
+        for name, inp in obs.inputs.items()
+    }
+
+
+def run_thesis_break_scan(conn: psycopg.Connection[Any], *, now: datetime | None = None) -> ThesisBreakScanReport:
+    now = now or datetime.now(tz=UTC)
+    today = now.date()
+
+    theses = _latest_theses(conn)
+    if not theses:
+        return ThesisBreakScanReport(0, 0, 0, 0, 0, {}, {})
+    financial = _financial_instruments(conn, [int(t["instrument_id"]) for t in theses])
+
+    # -- extract + upsert predicate rows for the latest theses ------------
+    sector_gated = 0
+    to_insert: list[tuple[int, int, int, BreakPredicate]] = []
+    for t in theses:
+        conditions = t["break_conditions_json"]
+        if not isinstance(conditions, list):
+            continue
+        iid = int(t["instrument_id"])
+        for idx, pred in enumerate(extract_predicates([c for c in conditions if isinstance(c, str)])):
+            if pred is None:
+                continue
+            if pred.metric in _ALTMAN_METRICS and iid in financial:
+                sector_gated += 1
+                continue
+            to_insert.append((int(t["thesis_id"]), idx, iid, pred))
+
+    inserted_keys: set[tuple[int, int]] = set()
+    with conn.transaction():
+        for thesis_id, idx, iid, pred in to_insert:
+            row = conn.execute(
+                """
+                INSERT INTO thesis_break_predicates
+                    (thesis_id, predicate_index, instrument_id, metric, op, threshold, unit, source_text)
+                VALUES (%(tid)s, %(idx)s, %(iid)s, %(metric)s, %(op)s, %(threshold)s, %(unit)s, %(src)s)
+                ON CONFLICT (thesis_id, predicate_index) DO NOTHING
+                RETURNING thesis_id, predicate_index
+                """,
+                {
+                    "tid": thesis_id,
+                    "idx": idx,
+                    "iid": iid,
+                    "metric": pred.metric,
+                    "op": pred.op,
+                    "threshold": pred.threshold,
+                    "unit": pred.unit,
+                    "src": pred.source_text,
+                },
+            ).fetchone()
+            if row is not None:
+                inserted_keys.add((int(row[0]), int(row[1])))
+
+    # -- load live predicate rows for the fire population -----------------
+    latest_ids = [int(t["thesis_id"]) for t in theses]
+    created_by_thesis = {int(t["thesis_id"]): t["created_at"] for t in theses}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT thesis_id, predicate_index, instrument_id, metric, op, threshold, unit,
+                   source_text, baseline_state
+            FROM thesis_break_predicates
+            WHERE thesis_id = ANY(%(ids)s)
+            """,
+            {"ids": latest_ids},
+        )
+        rows = cur.fetchall()
+
+    # -- observations, per metric family, only where needed ---------------
+    price_ids = sorted({int(r["instrument_id"]) for r in rows if r["metric"] in _PRICE_METRICS})
+    si_ids = sorted({int(r["instrument_id"]) for r in rows if r["metric"] in _SI_METRICS})
+    altman_ids = sorted({int(r["instrument_id"]) for r in rows if r["metric"] in _ALTMAN_METRICS})
+    price_obs = _price_observations(conn, price_ids, today) if price_ids else {}
+    si_obs = _short_interest_observations(conn, si_ids, today) if si_ids else {}
+    altman_obs = {iid: _altman_observation(conn, iid, today) for iid in altman_ids}
+
+    def _observation(iid: int, metric: str) -> MetricObservation:
+        if metric in _PRICE_METRICS:
+            return price_obs.get(iid, {}).get(metric, MetricObservation(metric=metric, status="no_input"))
+        if metric in _SI_METRICS:
+            return si_obs.get(iid, {}).get(metric, MetricObservation(metric=metric, status="no_input"))
+        return altman_obs.get(iid, MetricObservation(metric=metric, status="no_input"))
+
+    # -- evaluate + state machine + writes ---------------------------------
+    fired = 0
+    state_counts: Counter[str] = Counter()
+    eval_counts: Counter[str] = Counter()
+    with conn.transaction():
+        for r in rows:
+            key = (int(r["thesis_id"]), int(r["predicate_index"]))
+            iid = int(r["instrument_id"])
+            pred = BreakPredicate(
+                metric=str(r["metric"]),
+                op=r["op"],  # type: ignore[arg-type]
+                threshold=None if r["threshold"] is None else float(r["threshold"]),
+                unit=str(r["unit"]),
+                source_text=str(r["source_text"]),
+            )
+            obs = _observation(iid, pred.metric)
+            result = evaluate_predicate(pred, obs)
+            eval_counts[result] += 1
+            state: BaselineState = r["baseline_state"]
+            new_state, fire = next_baseline_state(
+                state,
+                result,
+                newly_inserted=key in inserted_keys,
+                thesis_created_at=created_by_thesis[key[0]],
+                now=now,
+            )
+            if new_state != state:
+                conn.execute(
+                    """
+                    UPDATE thesis_break_predicates
+                    SET baseline_state = %(state)s,
+                        baselined_at = COALESCE(baselined_at, %(now)s)
+                    WHERE thesis_id = %(tid)s AND predicate_index = %(idx)s
+                    """,
+                    {"state": new_state, "now": now, "tid": key[0], "idx": key[1]},
+                )
+            if fire:
+                assert obs.value is not None  # fire implies an ok observation
+                row = conn.execute(
+                    """
+                    INSERT INTO thesis_break_events
+                        (thesis_id, predicate_index, instrument_id, metric, op, threshold,
+                         observed_value, observed_as_of, inputs_json)
+                    VALUES (%(tid)s, %(idx)s, %(iid)s, %(metric)s, %(op)s, %(threshold)s,
+                            %(value)s, %(as_of)s, %(inputs)s)
+                    ON CONFLICT (thesis_id, predicate_index) DO NOTHING
+                    RETURNING break_event_id
+                    """,
+                    {
+                        "tid": key[0],
+                        "idx": key[1],
+                        "iid": iid,
+                        "metric": pred.metric,
+                        "op": pred.op,
+                        "threshold": pred.threshold,
+                        "value": obs.value,
+                        "as_of": obs.as_of,
+                        "inputs": Jsonb(_inputs_payload(obs)),
+                    },
+                ).fetchone()
+                if row is not None:
+                    fired += 1
+            state_counts[new_state] += 1
+
+    return ThesisBreakScanReport(
+        scanned_theses=len(theses),
+        predicates_total=len(rows),
+        predicates_inserted=len(inserted_keys),
+        sector_gated=sector_gated,
+        fired=fired,
+        state_counts=dict(state_counts),
+        eval_counts=dict(eval_counts),
+    )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -328,6 +328,7 @@ JOB_DAILY_NEWS_REFRESH = "daily_news_refresh"
 # re-registration. Hourly, held ∪ top-ranked scope, batch-bounded.
 JOB_THESIS_REFRESH = "thesis_refresh"
 JOB_THESIS_DQ_AUDIT = "thesis_dq_audit"
+JOB_THESIS_BREAK_SCAN = "thesis_break_scan"
 JOB_MORNING_CANDIDATE_REVIEW = "morning_candidate_review"
 JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
 JOB_DAILY_PORTFOLIO_SYNC = "daily_portfolio_sync"
@@ -832,6 +833,28 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # shares the db lane and fires on the :00/:05 grid — an aligned slot
         # silently loses the lane-acquire race every night, #1707 class).
         cadence=Cadence.daily(hour=5, minute=12),
+        # A missed night is re-covered next night; nothing accumulates.
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_THESIS_BREAK_SCAN,
+        display_name="Thesis break scan",
+        source="db",
+        description=(
+            "Nightly evaluation of machine-checkable thesis break "
+            "predicates (#2012): extract closed-vocabulary predicates "
+            "from the latest thesis per instrument, baseline/arm them, "
+            "and emit at most one break event per predicate per thesis "
+            "version on a genuine false→true transition. Fired events "
+            "mark the thesis stale (break_fired) for the existing "
+            "thesis_refresh drain. row_count = events emitted."
+        ),
+        # 05:22 UTC — same reasoning as thesis_dq_audit's 05:12 slot
+        # (post-fundamentals window, NOT 5-min-aligned per the #1707
+        # tick-race), offset so the two nightly thesis scans never
+        # contend for the db lane at the same minute.
+        cadence=Cadence.daily(hour=5, minute=22),
         # A missed night is re-covered next night; nothing accumulates.
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
@@ -4920,6 +4943,35 @@ def thesis_dq_audit() -> None:
             )
         else:
             logger.info("thesis_dq_audit: clean — scanned=%d (%s)", report.scanned, summary)
+
+
+def thesis_break_scan() -> None:
+    """Nightly machine-checkable break-predicate scan (#2012).
+
+    Thin wrapper around
+    :func:`app.services.thesis_break_scan.run_thesis_break_scan`.
+    ``row_count`` is the number of break events EMITTED this run (0 on a
+    healthy night — every fire costs a re-thesis, so a quiet scan is the
+    steady state). The full census (baseline states, eval statuses,
+    sector-gated count) lands in the tracker note for /system/jobs.
+    """
+    from app.services.thesis_break_scan import run_thesis_break_scan
+
+    with _tracked_job(JOB_THESIS_BREAK_SCAN) as tracker:
+        with connect_job() as conn:
+            report = run_thesis_break_scan(conn)
+        tracker.row_count = report.fired
+        states = ", ".join(f"{k}={v}" for k, v in sorted(report.state_counts.items())) or "none"
+        evals = ", ".join(f"{k}={v}" for k, v in sorted(report.eval_counts.items())) or "none"
+        tracker.note = (
+            f"theses={report.scanned_theses} predicates={report.predicates_total} "
+            f"inserted={report.predicates_inserted} sector_gated={report.sector_gated} "
+            f"fired={report.fired}; states: {states}; evals: {evals}"
+        )
+        if report.fired:
+            logger.warning("thesis_break_scan: %d break event(s) fired — states: %s", report.fired, states)
+        else:
+            logger.info("thesis_break_scan: no fires — predicates=%d (%s)", report.predicates_total, states)
 
 
 def financial_facts_retention_sweep() -> None:

--- a/docs/proposals/thesis/2026-07-16-thesis-break-predicates.md
+++ b/docs/proposals/thesis/2026-07-16-thesis-break-predicates.md
@@ -229,7 +229,9 @@ Coverage = fire population (282 latest theses), dev 2026-07-16.
    (Codex ckpt-1 BLOCKING). A `fired_at > latest_thesis.created_at` timestamp filter is NOT an
    acceptable substitute and must not be used: a delayed scan can stamp an OLD thesis's event with
    a `fired_at` later than its replacement's `created_at`, re-staling the new thesis (Codex ckpt-1
-   rev2 HIGH). Ordered AFTER the filing-event rules so a break never masks a 10-K trigger.
+   rev2 HIGH). Ordered AFTER the filing-event rules so a break never masks a 10-K trigger, but
+   BEFORE the generic cadence rule — a fired break is the more specific reason and must not be
+   shadowed by mere age (Codex ckpt-2); every path regenerates either way.
 5. Nightly job `thesis_break_scan` in `SCHEDULED_JOBS`, `db` lane, **NOT 5-min-aligned** (#1707
    tick-race; #2014 used 05:12 → use 05:22). `row_count` = events emitted.
 6. `GET /alerts/thesis-breaks` — event feed + `POST /seen` cursor mirroring #2013's

--- a/docs/proposals/thesis/2026-07-16-thesis-break-predicates.md
+++ b/docs/proposals/thesis/2026-07-16-thesis-break-predicates.md
@@ -1,0 +1,273 @@
+# Machine-checkable thesis break predicates (#2012)
+
+Status: proposal (rev 4 — Codex ckpt-1 rounds 1-3 folded; operator-approved 2026-07-16, split
+blessed). Ships as two PRs: **PR-A** = Shape 1-5 (pure core, schema, scan, stale rule, job);
+**PR-B** = Shape 6 (alerts endpoint + FE). Parent: #2002 (meta-thesis epic).
+Siblings: #2013 (re-thesis diff, SHIPPED), #2014 (DQ audit, SHIPPED), #2010 (prompt v3 —
+writer-native predicates, follow-on), #1988 (staleness v2 — trigger semantics reconciled below).
+
+Purpose: `break_conditions_json` is prose. A closed, trust-verified metric vocabulary lets a
+nightly deterministic job evaluate the subset that IS machine-checkable, arm it against a
+baseline, and emit a break event on a genuine transition → re-thesis. No LLM in the gate.
+
+## Premise falsification (FULL population, dev 2026-07-16)
+
+The issue's premise is substantially wrong. Verified over ALL 325 theses / 1,343 conditions /
+282 latest-per-instrument ("fire population") — never a sample.
+
+1. **"nothing evaluates it" — HALF-FALSE.** `app/services/portfolio.py:617` already reads
+   `break_conditions_json` in EXIT rule 1: `if break_conditions and max_red_flag >=
+   EXIT_RED_FLAG_THRESHOLD` — as a *boolean presence flag*. 325/325 theses have a non-empty
+   array → the term is a **tautology**; EXIT rule 1 reduces to `max_red_flag >= threshold`.
+   Latent; see "Out of scope".
+
+2. **Break ≠ bearish.** A break condition invalidates ITS OWN thesis, so direction tracks stance:
+
+   | stance | conditions | upside | upside % |
+   | --- | --- | --- | --- |
+   | avoid | 452 | 100 | **22.1%** |
+   | watch | 671 | 35 | 5.2% |
+   | buy | 126 | 5 | 4.0% |
+   | hold | 94 | 1 | **1.1%** |
+
+   Monotonic across stance — not noise. The issue's "feeds EXIT evaluation" would fire EXIT on
+   `Altman Z-score improves to >2.99` for an `avoid` thesis. Unsafe → Design 1.
+
+3. **The EXIT target barely exists.** 5 held names have a thesis (1 buy, 1 hold, 2 watch, 1
+   avoid). EXIT wiring has ~no surface; the payoff is re-thesis triggering over 282 names.
+
+4. **Prose ceiling.** 905/1,343 conditions contain a number; 626 have operator+number; 318 have
+   no metric keyword at all ("Loss of key patents", "Key product trials fail to meet clinical
+   endpoints"). No vocabulary reaches those — fail-open-to-prose is correct.
+
+5. **The flagship example is not connectable as stated.** Of 75 threshold-bearing short-interest
+   conditions, **57 name "float" / "public float"**; only 5 say "shares outstanding". Float is not
+   ingested (source rules 1-3) → Design 4.
+
+6. **⚠ Break conditions are predominantly ALREADY TRUE at write time.** Altman conditions on the
+   latest thesis per instrument, joined to that instrument's CURRENT Altman band:
+
+   | current band | altman conditions | worded "crosses into distress / <1.8" |
+   | --- | --- | --- |
+   | **distress** | **48** | **35** |
+   | safe | 8 | 2 |
+   | grey | 6 | 4 |
+   | (no z) | 2 | 1 |
+
+   35 conditions say "Altman Z-score crosses into bankruptcy territory (<1.8)" for names whose Z
+   is ALREADY ≈ −16. A level-triggered evaluator emits ~35 false events on night one, each
+   costing a wasted re-thesis (~300s LLM queue). **This makes the arm/baseline mechanism
+   mandatory, not an optimisation** → Design 5. It is also a NEW writer-defect class for #2014.
+
+## Source rules
+
+1. **FINRA bimonthly Equity Short Interest file** — `.claude/skills/data-sources/finra.md:11,25`.
+   Cadence: 15th + last business day. Exact 14-column pipe-delimited header (empirically verified
+   2026-05-18 against `shrt20260430.csv`): `accountingYearMonthNumber|symbolCode|issueName|
+   issuerServicesGroupExchangeCode|marketClassCode|currentShortPositionQuantity|
+   previousShortPositionQuantity|stockSplitFlag|averageDailyVolumeQuantity|daysToCoverQuantity|
+   revisionFlag|changePercent|changePreviousNumber|settlementDate`. **No float. No shares
+   outstanding.** `daysToCoverQuantity` + `changePercent` are computed BY FINRA → they need no
+   denominator of ours and carry zero imputation risk. Mirrored 1:1 in
+   `finra_short_interest_current` (#915).
+2. **Settled invariant — `app/services/instrument_analytics.py:325`**: "`short_pct` =
+   current_short_interest / shares_outstanding (**public float is not ingested**, so the
+   denominator is shares outstanding — caveat carried)". Module header (line 18): "Missing inputs
+   are reported as missing — **NEVER imputed**." This spec REUSES that denominator decision; it
+   does not re-decide it, and it does not extend it to prose that names a different denominator.
+3. **SEC Form 10-K cover page** — the aggregate market value of common equity held by
+   **non-affiliates** is stated as of the last business day of the registrant's most recently
+   completed **second fiscal quarter**; shares outstanding is stated separately as of the latest
+   practicable date. So `dei:EntityPublicFloat` (→ `financial_periods.public_float_usd`, present
+   for 279/282 fire names) is (a) USD not shares, (b) up to ~18 months stale, (c) a different
+   population (non-affiliate) than shares outstanding. NOT a live float denominator. Not used.
+4. **Altman Z″ non-manufacturer recalibration (Altman 2000)** — cited at
+   `instrument_analytics.py:16-17`; financial firms are outside the model. Code suppresses via
+   `suppress_fz = gics_sector == "Financials"` (line 549).
+5. **prevention-log:2158/2159** (#2043): "A predicate's INPUT COLUMNS must be trust-verified for
+   the affected population — a correct concept keyed on a correlate inherits that correlate's data
+   weakness." `financial_periods.revenue` is under-captured for banks/REITs (UDR $2.5M quarterly
+   vs real ~$420M). Applied per-metric below.
+6. **settled-decisions "EXIT rule in portfolio manager"**: EXIT for thesis break / severe risk
+   event / valuation target achieved. Preserved — Design 1.
+7. **settled-decisions "Thesis versioning"**: append-only, new row per generation. Supplies the
+   event model's idempotency — Design 5.
+8. **#2013 `app/services/thesis_diff.py`**: materiality is single-sourced there. NOT re-defined
+   here; a break event is a distinct kind (pre-generation trigger) from a diff event
+   (post-generation observation).
+
+## Design
+
+1. **A break is a TRIGGER, not a VERDICT.** Break fires → thesis stale (new reason `break_fired`)
+   → `thesis_refresh` regenerates → the regenerated stance/targets drive the portfolio through the
+   EXISTING EXIT path, surfaced by the shipped #2013 diff. Break events are NOT wired to EXIT.
+   This dissolves finding 2 (the regenerated thesis speaks for itself — no stance-aware EXIT
+   logic), preserves source rule 6 ("thesis break" still reaches EXIT, via regeneration), and
+   keeps execution deterministic + gated. It is the #1988 reconciliation the issue asks for:
+   break = a 5th rule in `find_stale_instruments` beside `event_new_10k/10q/8k` (#273) — same
+   trigger bus, same drain, same batch limits.
+2. **Closed vocabulary = trust-verified columns only.** A metric earns a slot only with a
+   full-population coverage figure, an explicit freshness bound, AND an input-column trust verdict
+   (source rule 5).
+3. **Extractor is minimal + precision-only; #2010 owns the real fix.** Writer-native predicates
+   need a prompt change → `_PROMPT_VERSION` v4→v5 → eval re-gate = #2010's pass. The extractor
+   bridges that with the *durable* model: #2010 emits INTO this same `BreakPredicate` vocabulary,
+   so nothing here is throwaway but ~40 lines of regex. **Recall is explicitly not a goal.**
+4. **"of float" AND bare-denominator conditions FAIL-OPEN.** 57 conditions name a denominator we
+   do not ingest; a further ~12 state a bare percentage. Evaluating either against
+   shares-outstanding answers a *different question* and systematically under-reports (shares_out
+   ≥ float always ⇒ SI%shares_out ≤ SI%float; a "10% of float" break could fire at 4% of shares
+   outstanding and we would miss it). Source rule 2 forbids the substitution — and the writer's
+   own qualified usage is 57 float : 5 shares-outstanding, so the *unqualified* prior is
+   overwhelmingly float. Only conditions EXPLICITLY naming "shares outstanding" extract
+   (Codex ckpt-1 BLOCKING). **The real fix is upstream**: `app/services/thesis.py:557` passes
+   `positioning` verbatim, so the writer IS handed the caveat "% shares outstanding (public float
+   not ingested)" and writes "of float" anyway — a fabrication class (#2014 family). #2010 kills
+   it at source.
+5. **Arm/baseline; edge-triggered; idempotent; no hysteresis.** Mandatory per finding 6.
+   - On a predicate's FIRST evaluable scan, record its evaluation as the BASELINE and emit NO
+     event. Baseline `true` → `already_true` (the writer's own premise, not a break) → **never
+     fires**. Baseline `false` → `armed`. Fire on the first subsequent `false → true` transition.
+   - **Ever-pending guard + rollout grace.** `already_true` is justified ONLY when the baseline is
+     contemporaneous with thesis creation: the predicate evaluated on its FIRST scan (never
+     `pending`) AND `baselined_at − thesis.created_at ≤ 48h` (grace = one nightly cadence + slack).
+     Otherwise a first-`true` evaluation has **no prior false baseline**, so "writer's premise" and
+     "transition missed during the unobserved gap" are indistinguishable *regardless of how short
+     the pending gap was* — label it `already_true_after_gap`: operator-visible, counted
+     separately, still non-firing (we cannot prove a break). NB two independent gap sources, both
+     guarded: (a) ever-`pending` (stale input at first scan — NOT a lag-vs-freshness-bound
+     comparison: a 3-day gap under a 10-day bound conflates just as badly, Codex ckpt-1 rev3 HIGH;
+     dev has 194/282 names on stale prices); (b) the scan job simply not existing yet — at ROLLOUT
+     every pre-existing thesis baselines days-to-weeks late, so the first scan lands existing
+     theses in `after_gap`, honestly. Steady-state (nightly scan, theses ≤24h old at first scan)
+     lands in `already_true`.
+   - **Re-arm.** An `already_true` / `already_true_after_gap` predicate whose LATER scan observes
+     `false` re-arms (state → `armed`): the premise has genuinely resolved, so a subsequent
+     `false → true` is a REAL transition and may fire. Fires still originate only from `armed`.
+   - **Accepted residual gap:** even a never-pending in-grace baseline reads CURRENT data at the
+     first scan, up to 48h after thesis creation (the grace bound), so a transition inside that
+     window is attributed to the premise. Bounded and documented; closing it would need
+     point-in-time reads of `price_daily`/FINRA archives, which v1 declines.
+   - `UNIQUE (thesis_id, predicate_index)` on the event table. Theses are immutable + append-only
+     (source rule 7) and a break begets a NEW thesis with fresh predicates, so a fire happens at
+     most once per predicate per thesis version. Level-triggered would re-fire nightly on
+     oscillators (RSI-14 around 70). Cohort hysteresis was refuted on the full population in
+     #2031 — no state machine beyond the baseline flag.
+   - This subsumes Codex's "regime vs cross" finding: `sma_50_vs_sma_200` is a REGIME predicate; a
+     regime already holding at arm baselines to `already_true` and cannot fire on the writer's own
+     premise. Cross-EVENT wording is not modelled — it extracts as the regime or not at all.
+6. **Fail-closed on stale/missing input, with an explicit bound per INPUT (not per metric).** A
+   predicate whose input is absent or stale evaluates to `no_input` / `stale_input` — never
+   `false`, never a fire, and never a baseline (a predicate cannot arm on data we do not have; it
+   retries next scan). Distinguish permanently-absent (`sma_200` needs 200 trading days —
+   structurally absent for 72/282) from transiently-stale (dev has only 88/282 fire names with
+   price fresher than 10d — the known eToro-unreachable artifact, same class as #2014's
+   `stale_price_anchor` 145).
+   - **Per-input evidence.** A metric may be a RATIO of independently-bounded inputs
+     (`short_interest_pct_shares_out` = FINRA ≤45d ÷ share count ≤6mo). A single scalar
+     `observed_as_of` cannot audit a conjunctive freshness invariant (Codex ckpt-1 rev3 MED), so
+     `MetricObservation` carries `inputs: {name: {value, as_of, source}}` and the event persists it
+     as `inputs_json`. Follows the `fair_value_band_observations.basis_json` precedent and CLAUDE.md
+     repo discipline ("persist enough structured evidence for auditability").
+   - Scalar `observed_as_of` is retained as the **stalest** contributing input's as-of — one
+     sortable field the acceptance gate can assert against the bound; `inputs_json` proves it.
+7. **Whole-string match only — composites fail open.** The extractor anchors on the FULL condition
+   string. Any residual content, conjunction or disjunction (`and`/`or`/`with`/`while`/`plus`)
+   → prose. "Short interest exceeds 12% of float **with rising days-to-cover**" must never extract
+   as the weaker "SI > 12%" (Codex ckpt-1 HIGH). Measured cost: 17 RSI + 20 SMA conditions drop.
+   A composite expression model is explicitly out of scope for v1.
+8. **FINRA in-place revisions.** `revisionFlag='Y'` corrections land within 1-2 cycles
+   (`finra.md:116`). A fired event records `observed_value` + `observed_as_of` as evidence at fire
+   time; a later revision does NOT retract the event (append-only, auditable). Noted, not fixed.
+
+## Closed vocabulary (v1)
+
+Coverage = fire population (282 latest theses), dev 2026-07-16.
+
+| metric | source | coverage | freshness bound | trust verdict |
+| --- | --- | --- | --- | --- |
+| `short_interest_days_to_cover` | `finra_short_interest_current.days_to_cover` | 271 (96%) | `settlement_date` ≤ 45d (2 missed bimonthly cycles) | **Accept** — computed BY FINRA; no denominator of ours (source rule 1) |
+| `short_interest_change_pct` | `finra_short_interest_current.change_percent` | 271 (96%) | `settlement_date` ≤ 45d | **Accept** — computed BY FINRA; period-over-period |
+| `short_interest_pct_shares_out` | `current_short_interest / share_count_history.shares_outstanding` | 251 (89%) | **BOTH inputs bounded**: FINRA `settlement_date` ≤ 45d AND `share_count_history.latest_filed_date` ≤ 6 months | **Accept, narrow** — reuses the settled denominator (source rule 2). Extracts ONLY for conditions explicitly naming "shares outstanding" (5). Float + bare → fail-open (Design 4). The DENOMINATOR needs its own bound (Codex ckpt-1 rev2 MED): a ratio is only as fresh as its stalest input, and a stale share count mis-evaluates across splits/issuance. `dei:EntityCommonStockSharesOutstanding` is stated on EVERY 10-K/10-Q cover as of the latest practicable date (source rule 3) → quarterly cadence → 6 months = 2 missed filings. NB FINRA carries `stockSplitFlag` (source rule 1) — a split between share-count filings is the concrete hazard |
+| `altman_z` / `altman_band` | `_read_latest_two_fy_facts` + `altman_z2()` (REUSED pure fn) — **NOT** `scores.analytics_json` | 2,211/3,084 non-financial scored | fact `period_end` ≤ 15 months (annual cadence + 10-K filing lag) | **Accept, sector-gated.** Sourced from FY facts, not `analytics_json`, because that blob carries no fact `as_of` — `scores.scored_at` would make stale annual facts look fresh (Codex ckpt-1 BLOCKING). `observed_as_of` = fact `period_end`. Financials suppressed upstream (584/594). **Real Estate NOT suppressed (0/224)**: GICS split Real Estate out of Financials in 2016, so `sector_classification.py:84,87` maps SIC 65xx/6798 → XLRE → "Real Estate" and the line-549 guard misses them. Altman Z″ excludes financial firms (source rule 4) → this spec ALSO gates SIC 65xx/6798. Gate applied at PREDICATE INSERT: `altman_*` predicate rows are never created for SIC 60-64 / 65xx / 6798 instruments (condition stays prose) — a permanently-unevaluable `pending` row would be a lie. NB: REIT distress rate is 46.2% vs 48.8% for Other (n=26) — the exclusion is a source-rule call, NOT a demonstrated artifact. |
+| `rsi_14` | `price_daily.rsi_14` (latest) | 281 (99.6%) | `price_date` ≤ 10 calendar days | **Accept, freshness-gated** (Design 6) |
+| `price_vs_sma200` | `price_daily.close` vs `sma_200` | 210 (74%) | `price_date` ≤ 10 calendar days | **Accept, freshness-gated**; 72 structurally absent (<200d history) |
+| `sma_50_vs_sma_200` | `price_daily.sma_50` vs `sma_200` | 210 (74%) | `price_date` ≤ 10 calendar days | **Accept as REGIME** (Design 5); the #1989 `derive_trend_signals` regime, read-derived |
+
+### Rejected from the issue's proposed vocabulary
+
+| metric | why rejected |
+| --- | --- |
+| `revenue_ttm_yoy` | prevention-log:2159 — `financial_periods.revenue` under-captured for banks/REITs. **50/282 (18%) of the fire population is Financial/REIT.** A "revenue collapsed" break would false-fire on exactly that class. Reinstate only if the revenue-capture defect is fixed. |
+| `short_interest_pct` (of float) | Float not ingested (source rules 1-3); imputing shares-outstanding is banned by source rule 2. 57 conditions → fail-open; fixed at source by #2010. |
+| `insider_net_shares_90d` | **Deferred.** `get_insider_summary` exists, but #828 (7,569 stray `insider_filings`, high-blast, unimplemented) is an open DQ overhang on precisely this table. Source rule 5 requires input-column trust first. Follow-up, gated on #828. |
+
+## Shape
+
+1. `app/services/thesis_break.py` — pure, no DB, no `thesis` import (no cycle):
+   - `extract_predicates(conditions: list[str]) -> list[BreakPredicate | None]` — whole-string,
+     precision-gated (Design 7). Index-aligned with `break_conditions_json` (None = prose).
+     Frozen `BreakPredicate(metric, op, threshold, unit, source_text)`.
+   - `evaluate_predicate(pred, observation) -> BreakEval` — pure compare over a supplied
+     `MetricObservation(value, as_of, status, inputs)` where `inputs` is the per-input evidence map
+     (Design 6); returns `fired` / `not_fired` / `no_input` / `stale_input`. Table-tested.
+2. `app/services/thesis_break_scan.py` — DB-facing: one read assembling vocabulary observations
+   for the fire population, then pure calls; applies arm/baseline (Design 5) + freshness bounds
+   (Design 6). Mirrors `thesis_dq_audit.compute_thesis_dq_report`'s split (#2014 precedent).
+3. `sql/230_thesis_break_predicates.sql` (228/229 taken by fvb) — two tables:
+   - `thesis_break_predicates(thesis_id, predicate_index, metric, op, threshold, unit,
+     source_text, baseline_state, baselined_at)`, PK `(thesis_id, predicate_index)`, FK → `theses`.
+     `baseline_state` ∈ `pending` (awaiting evaluable input) | `armed` | `already_true` |
+     `already_true_after_gap` (Design 5 lag guard). Only `armed` can ever fire.
+   - `thesis_break_events(break_event_id, thesis_id, instrument_id, predicate_index, metric, op,
+     threshold, observed_value, observed_as_of, inputs_json, fired_at)`, **UNIQUE (thesis_id,
+     predicate_index)** (Design 5), FK → `thesis_break_predicates`. `observed_as_of` = stalest
+     input; `inputs_json` = per-input evidence (Design 6). Additive; auto-applies at boot.
+4. `find_stale_instruments` rule 5 → `break_fired` (`StaleReason` widened). **Must key the event to
+   the LATEST thesis by thesis_id equality** — join `event.thesis_id = latest_thesis.thesis_id`,
+   and ONLY that. An `instrument_id`-only join would re-stale every regenerated thesis forever
+   (Codex ckpt-1 BLOCKING). A `fired_at > latest_thesis.created_at` timestamp filter is NOT an
+   acceptable substitute and must not be used: a delayed scan can stamp an OLD thesis's event with
+   a `fired_at` later than its replacement's `created_at`, re-staling the new thesis (Codex ckpt-1
+   rev2 HIGH). Ordered AFTER the filing-event rules so a break never masks a 10-K trigger.
+5. Nightly job `thesis_break_scan` in `SCHEDULED_JOBS`, `db` lane, **NOT 5-min-aligned** (#1707
+   tick-race; #2014 used 05:12 → use 05:22). `row_count` = events emitted.
+6. `GET /alerts/thesis-breaks` — event feed + `POST /seen` cursor mirroring #2013's
+   `/alerts/thesis-changes` (`operators.alerts_last_seen_*_id`, rank-moves cursor semantics).
+   FE: `AlertsStrip` BREAK card + `ThesisPane` predicate rows (fired = amber, `already_true` =
+   muted with a "premise, not trigger" tooltip).
+
+## Out of scope (surfaced, not silently absorbed)
+
+- **The `portfolio.py:617` tautology** (finding 1) — real, but an EXIT-path change on a 5-name
+  population, and Design 1 deliberately does not touch EXIT. Follow-up: EXIT rule 1's
+  `break_conditions` term should be dropped as dead, or replaced by "an unfired-but-armed →
+  fired `thesis_break_events` row exists for the latest thesis".
+- **Writer defects for #2010 + #2014**: "of float" fabrication against a supplied caveat (57);
+  already-true-at-write conditions (~35). Both are prompt problems; this spec's censuses are their
+  empirical brief.
+
+## Full-population verification / acceptance gate
+
+Measured over the SAME population the prediction names (prevention-log:2155).
+
+- **Extractor precision: EVERY match on the full 1,343 hand-audited pre-merge; target 100%
+  precision.** Recall is explicitly NOT a gate.
+- **Day one delivers predicate STATUS, not events.** Expected: ~0 events on the first scan (every
+  predicate baselines). ~106/282 latest theses (38%) carry ≥1 extracted predicate under the
+  pre-Codex rules; the tightened rules (Design 4 + 7) cut this — the post-tightening figure is
+  measured and recorded on the PR before merge, over the 282 fire population.
+- **Premise census recorded on the PR** — the expected ~35 Altman premise-conditions land across
+  `already_true` + `already_true_after_gap` COMBINED (reported split). At rollout the grace rule
+  puts pre-existing theses in `after_gap` by construction (Design 5); steady-state new theses land
+  in `already_true`. This census is the headline day-one operator-visible number and #2010's brief.
+- `already_true_after_gap` is never merged into `already_true` in any surface. A non-trivial count
+  on dev is EXPECTED (rollout + 194/282 stale prices) — an honest "cannot tell", not a defect.
+- Per-metric `fired`/`not_fired`/`no_input`/`stale_input` census over the 282 fire population.
+- Sector gate: 0 `altman_*` predicates evaluated for SIC 60-64 or 65xx/6798.
+- Fail-closed: 0 events with a stale input, asserted **per input from `inputs_json`** against that
+  input's own bound — NOT via the scalar `observed_as_of`. For `short_interest_pct_shares_out`
+  that means FINRA `settlement_date` ≤45d AND `share_count_history.latest_filed_date` ≤6mo checked
+  independently (Design 6; a conjunctive invariant is not provable from one collapsed field).
+- Stale-rule join: a regenerated thesis with no NEW break must NOT report `break_fired`
+  (regression test — Codex ckpt-1 BLOCKING 1).

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -73,6 +73,7 @@ function staleLabel(reason: string): string {
   }
   if (reason === "missing_frequency") return "no cadence";
   if (reason === "no_thesis") return "missing";
+  if (reason === "break_fired") return "break";
   return "stale";
 }
 

--- a/sql/230_thesis_break_predicates.sql
+++ b/sql/230_thesis_break_predicates.sql
@@ -1,0 +1,70 @@
+-- 230_thesis_break_predicates.sql
+--
+-- #2012 — machine-checkable thesis break predicates (PR-A).
+-- Spec: docs/proposals/thesis/2026-07-16-thesis-break-predicates.md.
+--
+-- Two tables:
+--   thesis_break_predicates — one row per machine-checkable condition extracted
+--     from a thesis's break_conditions_json (index-aligned; prose conditions get
+--     no row). baseline_state implements the arm/baseline model: a predicate
+--     that is TRUE at its contemporaneous first evaluation is the writer's own
+--     premise ('already_true') and can never fire; only 'armed' predicates fire,
+--     on a genuine false→true transition.
+--   thesis_break_events — at most ONE event per predicate per thesis version
+--     (UNIQUE (thesis_id, predicate_index)); theses are append-only, so a break
+--     begets a new thesis with fresh predicates. inputs_json carries per-input
+--     {value, as_of, source} evidence — a ratio metric has independently
+--     bounded inputs, and a single scalar as-of cannot audit a conjunctive
+--     freshness invariant.
+--
+-- threshold is NULL exactly for the two REGIME metrics (column-vs-column
+-- comparisons: price_vs_sma200, sma_50_vs_sma_200); every threshold metric
+-- carries a number.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS thesis_break_predicates (
+    thesis_id        BIGINT      NOT NULL REFERENCES theses (thesis_id) ON DELETE CASCADE,
+    predicate_index  SMALLINT    NOT NULL,
+    instrument_id    BIGINT      NOT NULL REFERENCES instruments (instrument_id),
+    metric           TEXT        NOT NULL CHECK (metric IN
+        ('short_interest_pct_shares_out', 'short_interest_days_to_cover',
+         'short_interest_change_pct', 'altman_z', 'rsi_14',
+         'price_vs_sma200', 'sma_50_vs_sma_200')),
+    op               TEXT        NOT NULL CHECK (op IN ('<', '>')),
+    threshold        NUMERIC(18, 6),
+    unit             TEXT        NOT NULL,
+    source_text      TEXT        NOT NULL,
+    baseline_state   TEXT        NOT NULL DEFAULT 'pending' CHECK (baseline_state IN
+        ('pending', 'armed', 'already_true', 'already_true_after_gap')),
+    baselined_at     TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (thesis_id, predicate_index),
+    CHECK ((threshold IS NULL) = (metric IN ('price_vs_sma200', 'sma_50_vs_sma_200')))
+);
+
+CREATE INDEX IF NOT EXISTS idx_thesis_break_predicates_instrument
+    ON thesis_break_predicates (instrument_id);
+
+CREATE TABLE IF NOT EXISTS thesis_break_events (
+    break_event_id   BIGSERIAL   PRIMARY KEY,
+    thesis_id        BIGINT      NOT NULL,
+    predicate_index  SMALLINT    NOT NULL,
+    instrument_id    BIGINT      NOT NULL REFERENCES instruments (instrument_id),
+    metric           TEXT        NOT NULL,
+    op               TEXT        NOT NULL,
+    threshold        NUMERIC(18, 6),
+    observed_value   NUMERIC(18, 6) NOT NULL,
+    observed_as_of   DATE,
+    inputs_json      JSONB       NOT NULL,
+    fired_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (thesis_id, predicate_index),
+    FOREIGN KEY (thesis_id, predicate_index)
+        REFERENCES thesis_break_predicates (thesis_id, predicate_index)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_thesis_break_events_instrument_fired
+    ON thesis_break_events (instrument_id, fired_at DESC);
+
+COMMIT;

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -297,6 +297,16 @@ class TestFindStaleInstruments:
         assert len(result) == 1
         assert result[0].reason == "break_fired"
 
+    def test_break_beats_cadence_stale(self) -> None:
+        # Aged past cadence AND break fired → the specific reason wins
+        # (Codex ckpt-2: break must not be shadowed by mere age).
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=30), None, None, True)]
+        conn = _make_conn(stale_rows=rows)
+        with patch("app.services.thesis._utcnow", return_value=_NOW):
+            result = find_stale_instruments(conn, tier=1)
+        assert len(result) == 1
+        assert result[0].reason == "break_fired"
+
     def test_break_never_masks_filing_event(self) -> None:
         # Rule ordering: a new 10-K and a fired break both present → the
         # filing-event reason wins (spec: break ordered AFTER event rules).

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -209,8 +209,8 @@ class TestToFloat:
 class TestFindStaleInstruments:
     def test_no_thesis_is_stale(self) -> None:
         # (instrument_id, symbol, review_frequency, latest_thesis_at,
-        #  latest_event_filing_date, latest_event_filing_type)
-        rows = [(1, "AAPL", "weekly", None, None, None)]
+        #  latest_event_filing_date, latest_event_filing_type, break_fired)
+        rows = [(1, "AAPL", "weekly", None, None, None, False)]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
@@ -218,14 +218,14 @@ class TestFindStaleInstruments:
         assert result[0].symbol == "AAPL"
 
     def test_unknown_frequency_is_stale(self) -> None:
-        rows = [(1, "AAPL", "biannual", _NOW - timedelta(days=1), None, None)]
+        rows = [(1, "AAPL", "biannual", _NOW - timedelta(days=1), None, None, False)]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
         assert result[0].reason == "missing_frequency"
 
     def test_null_frequency_is_stale(self) -> None:
-        rows = [(1, "AAPL", None, _NOW - timedelta(days=1), None, None)]
+        rows = [(1, "AAPL", None, _NOW - timedelta(days=1), None, None, False)]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
@@ -233,7 +233,7 @@ class TestFindStaleInstruments:
 
     def test_past_weekly_threshold_is_stale(self) -> None:
         # thesis created 8 days ago, weekly frequency → stale
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=8), None, None)]
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=8), None, None, False)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -242,7 +242,7 @@ class TestFindStaleInstruments:
 
     def test_within_weekly_threshold_is_fresh(self) -> None:
         # thesis created 3 days ago, weekly frequency → fresh
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None)]
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None, False)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -250,7 +250,7 @@ class TestFindStaleInstruments:
 
     def test_daily_threshold(self) -> None:
         # thesis created 25 hours ago, daily frequency → stale
-        rows = [(1, "MSFT", "daily", _NOW - timedelta(hours=25), None, None)]
+        rows = [(1, "MSFT", "daily", _NOW - timedelta(hours=25), None, None, False)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -259,7 +259,7 @@ class TestFindStaleInstruments:
 
     def test_monthly_threshold(self) -> None:
         # thesis created 31 days ago, monthly frequency → stale
-        rows = [(1, "TSLA", "monthly", _NOW - timedelta(days=31), None, None)]
+        rows = [(1, "TSLA", "monthly", _NOW - timedelta(days=31), None, None, False)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -267,9 +267,9 @@ class TestFindStaleInstruments:
 
     def test_multiple_instruments_mixed(self) -> None:
         rows = [
-            (1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None),  # fresh
-            (2, "MSFT", "weekly", _NOW - timedelta(days=8), None, None),  # stale
-            (3, "GOOG", "weekly", None, None, None),  # no thesis
+            (1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None, False),  # fresh
+            (2, "MSFT", "weekly", _NOW - timedelta(days=8), None, None, False),  # stale
+            (3, "GOOG", "weekly", None, None, None, False),  # no thesis
         ]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
@@ -281,12 +281,31 @@ class TestFindStaleInstruments:
 
     def test_exactly_at_threshold_is_stale(self) -> None:
         # now == created_at + 7 days exactly → stale (>= boundary)
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=7), None, None)]
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=7), None, None, False)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
         assert result[0].reason == "stale"
+
+    def test_break_fired_on_fresh_thesis(self) -> None:
+        # #2012 rule 5: fresh thesis + a break event for the LATEST thesis.
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=1), None, None, True)]
+        conn = _make_conn(stale_rows=rows)
+        with patch("app.services.thesis._utcnow", return_value=_NOW):
+            result = find_stale_instruments(conn, tier=1)
+        assert len(result) == 1
+        assert result[0].reason == "break_fired"
+
+    def test_break_never_masks_filing_event(self) -> None:
+        # Rule ordering: a new 10-K and a fired break both present → the
+        # filing-event reason wins (spec: break ordered AFTER event rules).
+        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=1), _NOW, "10-K", True)]
+        conn = _make_conn(stale_rows=rows)
+        with patch("app.services.thesis._utcnow", return_value=_NOW):
+            result = find_stale_instruments(conn, tier=1)
+        assert len(result) == 1
+        assert result[0].reason == "event_new_10k"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_thesis_break.py
+++ b/tests/test_thesis_break.py
@@ -135,6 +135,14 @@ def test_index_alignment_and_non_strings() -> None:
     assert out[2] is not None and out[2].metric == "rsi_14"
 
 
+def test_non_string_element_never_shifts_later_indexes() -> None:
+    # Codex ckpt-2: a malformed (non-string) element must map to None IN
+    # PLACE so predicate_index stays aligned with break_conditions_json.
+    out = extract_predicates([42, "RSI-14 crosses above 70"])
+    assert out[0] is None
+    assert out[1] is not None and out[1].metric == "rsi_14"
+
+
 # ---------------------------------------------------------------------------
 # observe() — per-input freshness bounds, fail-closed
 # ---------------------------------------------------------------------------

--- a/tests/test_thesis_break.py
+++ b/tests/test_thesis_break.py
@@ -1,0 +1,290 @@
+"""Pure-logic tests for the #2012 break-predicate layer (fast tier, no DB).
+
+Extractor strings are REAL dev-corpus break conditions (2026-07-16 census)
+— the table pins the precision contract: everything ambiguous, composite,
+duration-qualified, float-denominated or direction-conflicted fails OPEN.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+
+import pytest
+
+from app.services.thesis_break import (
+    BASELINE_GRACE,
+    BreakPredicate,
+    MetricInput,
+    evaluate_predicate,
+    extract_predicates,
+    next_baseline_state,
+    observe,
+)
+
+# ---------------------------------------------------------------------------
+# Extractor — corpus table
+# ---------------------------------------------------------------------------
+
+EXTRACTS = [
+    # altman numeric — verb families + prepositions + annotations
+    ("Altman Z-score falls below 1.8", ("altman_z", "<", 1.8)),
+    ("Altman Z-score falls below 1.8 (current 1.805)", ("altman_z", "<", 1.8)),
+    ("Altman Z-score drops below 2.0", ("altman_z", "<", 2.0)),
+    ("Altman Z-score rises above 2.99 (indicating reduced distress risk)", ("altman_z", ">", 2.99)),
+    ("Altman Z-score moves above 2.99 (indicating reduced distress)", ("altman_z", ">", 2.99)),
+    ("Altman Z-score improves to >2.99 (non-distress)", ("altman_z", ">", 2.99)),
+    ("Altman Z-score improvement to >2.99 (indicating non-distress)", ("altman_z", ">", 2.99)),
+    ("Altman Z-score crosses below -1.8 (indicating severe distress)", ("altman_z", "<", -1.8)),
+    ("Altman Z-score crossing into bankruptcy territory (<1.8)", ("altman_z", "<", 1.8)),
+    ("Altman Z-score crosses into 'non-distress' territory (>2.99)", ("altman_z", ">", 2.99)),
+    ("improvement in Altman Z-score above 1.23", ("altman_z", ">", 1.23)),
+    ("material improvement in Altman Z-score above -2.99 (distress threshold)", ("altman_z", ">", -2.99)),
+    ("reduction in Altman Z-score below -16.2 (unlikely without drastic restructuring)", ("altman_z", "<", -16.2)),
+    ("Altman Z-score deteriorates below 1.8 (distress threshold)", ("altman_z", "<", 1.8)),
+    ("Altman Z-score worsens below -1.0", ("altman_z", "<", -1.0)),
+    ("Dropbox's Altman Z-score deteriorates below -5 (indicating heightened bankruptcy risk)", ("altman_z", "<", -5.0)),
+    # rsi
+    ("RSI-14 crosses above 70 (overbought territory)", ("rsi_14", ">", 70.0)),
+    ("RSI-14 drops below 30 (oversold territory)", ("rsi_14", "<", 30.0)),
+    # short interest — EXPLICIT shares-outstanding denominator only
+    ("Short interest rises above 5% of shares outstanding", ("short_interest_pct_shares_out", ">", 5.0)),
+    (
+        "Short interest rises above 5% of shares outstanding (current: 4.21%)",
+        ("short_interest_pct_shares_out", ">", 5.0),
+    ),
+    ("Short interest exceeds 20% of shares outstanding", ("short_interest_pct_shares_out", ">", 20.0)),
+    (
+        "Material increase in short interest above 20% of shares outstanding",
+        ("short_interest_pct_shares_out", ">", 20.0),
+    ),
+    ("Short interest falls below 5% of shares outstanding", ("short_interest_pct_shares_out", "<", 5.0)),
+    # price vs sma200 regime
+    ("Technical breakdown below 200-day SMA", ("price_vs_sma200", "<", None)),
+    ("Technical breakdown below 116.05 (200-day SMA)", ("price_vs_sma200", "<", None)),
+    ("Technical breakdown below SMA 200 ($354.40)", ("price_vs_sma200", "<", None)),
+    ("Price drops below 200-day SMA (current: $26.29)", ("price_vs_sma200", "<", None)),
+    # sma 50/200 regime (cross wording extracts as the regime, spec Design 5)
+    ("SMA 50 crosses below SMA 200 (death cross confirmation)", ("sma_50_vs_sma_200", "<", None)),
+    ("sma50 crosses below sma200 (current 'death' regime)", ("sma_50_vs_sma_200", "<", None)),
+    ("Technical indicators confirm bearish regime (sma_50 below sma_200)", ("sma_50_vs_sma_200", "<", None)),
+    ("Technical indicators show bearish crossover (sma_50 below sma_200)", ("sma_50_vs_sma_200", "<", None)),
+]
+
+FAIL_OPEN = [
+    # float / bare denominator (spec Design 4 — never substitute shares_out)
+    "Short interest exceeds 10% of float",
+    "Material increase in short interest above 10% of float",
+    "Short interest increases above 15% (current: 12.99%)",
+    "Increase in short interest above 10%",
+    # composite / disjunction / conjunction (Design 7)
+    "Short interest above 12% of float or days-to-cover >5",
+    "Short interest falls below 5% of shares outstanding with a 50% decline in days-to-cover",
+    "RSI-14 drops below 30 with confirmed bearish crossover",
+    "Altman Z-score transitions to 'safe' or 'cautious' band",
+    # illustrative e.g. wrappers — the head is the real, broader condition
+    "Technical indicators confirm bearish regime (e.g., sma 50 crosses below sma 200)",
+    "Reversal of negative technical indicators (e.g., rsi above 50, sma 50 crosses above sma 200)",
+    # duration / persistence — not a single-scan edge trigger
+    "Sustained RSI below 40 (oversold) for 2+ weeks",
+    "RSI-14 falls below 40 for 30 days",
+    "RSI-14 crosses below 30 for 2+ weeks",
+    "Price closes below 200-day SMA ($120.20) for 20+ days",
+    "Price breaks below 200-day SMA ($22.30) for sustained period",
+    "Technical indicators confirm bearish regime (sma 50 < sma 200 for 60+ days)",
+    "EPS remains negative for consecutive quarters",
+    # deadline / failure-to-achieve semantics
+    "Altman Z-score improves to >2.99 (non-distress) within 12 months",
+    "Failure to secure partnership or financing within 6 months",
+    "failure to improve altman z-score above 1.8 (distress band)",
+    # direction conflict (verb says up, preposition says down) — writer error
+    "Altman Z-score improves below -1.5 (current: -2.1853)",
+    # band-only wording — writer band vocabulary ≠ our band cut, fail open
+    "Downgrade in Altman Z score below 'safe' band",
+    "Altman Z-score confirms insolvency risk",
+    "Altman Z-score improves to non-distress levels",
+    # metric not in vocabulary / leaked context metadata
+    "Net debt exceeds $700 million",
+    "Piotroski F-score falls below 5",
+    "beta exceeding 1.6 {window_key: '1y', as_of_date: '2026-07-07', metric_version: 'risk_v1'}",
+    "Loss of key intellectual property",
+    "",
+]
+
+
+@pytest.mark.parametrize(("text", "expected"), EXTRACTS)
+def test_extracts(text: str, expected: tuple[str, str, float | None] | None) -> None:
+    (pred,) = extract_predicates([text])
+    if expected is None:
+        assert pred is None
+        return
+    assert pred is not None, text
+    assert (pred.metric, pred.op, pred.threshold) == expected
+    assert pred.source_text == text
+
+
+@pytest.mark.parametrize("text", FAIL_OPEN)
+def test_fail_open(text: str) -> None:
+    (pred,) = extract_predicates([text])
+    assert pred is None, text
+
+
+def test_index_alignment_and_non_strings() -> None:
+    out = extract_predicates(["Altman Z-score falls below 1.8", "prose only", "RSI-14 crosses above 70"])
+    assert out[0] is not None and out[0].metric == "altman_z"
+    assert out[1] is None
+    assert out[2] is not None and out[2].metric == "rsi_14"
+
+
+# ---------------------------------------------------------------------------
+# observe() — per-input freshness bounds, fail-closed
+# ---------------------------------------------------------------------------
+
+TODAY = date(2026, 7, 16)
+
+
+def _inp(value: float, age_days: int, source: str = "s") -> MetricInput:
+    return MetricInput(value, TODAY - timedelta(days=age_days), source)
+
+
+def test_observe_ok_takes_stalest_as_of() -> None:
+    obs = observe(
+        "short_interest_pct_shares_out",
+        {"finra_settlement": _inp(1e6, 10), "share_count_filed": _inp(1e8, 100)},
+        1.0,
+        today=TODAY,
+    )
+    assert obs.status == "ok"
+    assert obs.as_of == TODAY - timedelta(days=100)  # stalest bounded input
+
+
+def test_observe_each_input_bounded_independently() -> None:
+    # FINRA fresh but share count beyond ITS OWN 183d bound → stale_input,
+    # even though 200d would be inside a 456d-style collapsed bound.
+    obs = observe(
+        "short_interest_pct_shares_out",
+        {"finra_settlement": _inp(1e6, 10), "share_count_filed": _inp(1e8, 200)},
+        1.0,
+        today=TODAY,
+    )
+    assert obs.status == "stale_input"
+
+
+def test_observe_missing_input_and_missing_value() -> None:
+    assert (
+        observe(
+            "short_interest_pct_shares_out",
+            {"finra_settlement": _inp(1e6, 10), "share_count_filed": None},
+            1.0,
+            today=TODAY,
+        ).status
+        == "no_input"
+    )
+    assert observe("rsi_14", {"price_date": _inp(50.0, 1)}, None, today=TODAY).status == "no_input"
+
+
+def test_observe_stale_price() -> None:
+    assert observe("rsi_14", {"price_date": _inp(75.0, 11)}, 75.0, today=TODAY).status == "stale_input"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_predicate — thresholds + regime gap
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_threshold_ops() -> None:
+    below = BreakPredicate("altman_z", "<", 1.8, "zscore", "t")
+    obs = observe("altman_z", {"fy_period_end": _inp(1.5, 100)}, 1.5, today=TODAY)
+    assert evaluate_predicate(below, obs) == "true"
+    obs = observe("altman_z", {"fy_period_end": _inp(1.9, 100)}, 1.9, today=TODAY)
+    assert evaluate_predicate(below, obs) == "false"
+
+
+def test_evaluate_regime_gap_against_zero() -> None:
+    death = BreakPredicate("sma_50_vs_sma_200", "<", None, "regime", "t")
+    obs = observe("sma_50_vs_sma_200", {"price_date": _inp(-2.5, 1)}, -2.5, today=TODAY)
+    assert evaluate_predicate(death, obs) == "true"
+    obs = observe("sma_50_vs_sma_200", {"price_date": _inp(2.5, 1)}, 2.5, today=TODAY)
+    assert evaluate_predicate(death, obs) == "false"
+
+
+def test_evaluate_passes_through_non_ok() -> None:
+    pred = BreakPredicate("rsi_14", ">", 70.0, "index", "t")
+    stale = observe("rsi_14", {"price_date": _inp(80.0, 30)}, 80.0, today=TODAY)
+    assert evaluate_predicate(pred, stale) == "stale_input"
+
+
+# ---------------------------------------------------------------------------
+# Baseline state machine (spec Design 5)
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 7, 16, 5, 22, tzinfo=UTC)
+FRESH = NOW - timedelta(hours=6)  # thesis created inside grace
+OLD = NOW - BASELINE_GRACE - timedelta(days=5)  # rollout / late first scan
+
+
+def test_pending_false_arms() -> None:
+    assert next_baseline_state("pending", "false", newly_inserted=True, thesis_created_at=FRESH, now=NOW) == (
+        "armed",
+        False,
+    )
+
+
+def test_pending_true_contemporaneous_is_premise() -> None:
+    assert next_baseline_state("pending", "true", newly_inserted=True, thesis_created_at=FRESH, now=NOW) == (
+        "already_true",
+        False,
+    )
+
+
+def test_pending_true_rollout_is_after_gap() -> None:
+    # Never pending, but the first scan ran > grace after thesis creation.
+    assert next_baseline_state("pending", "true", newly_inserted=True, thesis_created_at=OLD, now=NOW) == (
+        "already_true_after_gap",
+        False,
+    )
+
+
+def test_pending_true_ever_pending_is_after_gap_even_inside_grace() -> None:
+    # Row left pending by a prior scan → gap is unobserved REGARDLESS of size.
+    assert next_baseline_state("pending", "true", newly_inserted=False, thesis_created_at=FRESH, now=NOW) == (
+        "already_true_after_gap",
+        False,
+    )
+
+
+def test_armed_true_fires_once_per_transition() -> None:
+    assert next_baseline_state("armed", "true", newly_inserted=False, thesis_created_at=FRESH, now=NOW) == (
+        "armed",
+        True,
+    )
+
+
+def test_armed_false_holds() -> None:
+    assert next_baseline_state("armed", "false", newly_inserted=False, thesis_created_at=FRESH, now=NOW) == (
+        "armed",
+        False,
+    )
+
+
+@pytest.mark.parametrize("state", ["already_true", "already_true_after_gap"])
+def test_premise_rearms_on_observed_false(state: str) -> None:
+    assert next_baseline_state(state, "false", newly_inserted=False, thesis_created_at=OLD, now=NOW) == (  # type: ignore[arg-type]
+        "armed",
+        False,
+    )
+
+
+@pytest.mark.parametrize("state", ["pending", "armed", "already_true", "already_true_after_gap"])
+@pytest.mark.parametrize("result", ["no_input", "stale_input"])
+def test_non_ok_input_never_moves_state_or_fires(state: str, result: str) -> None:
+    assert next_baseline_state(state, result, newly_inserted=False, thesis_created_at=OLD, now=NOW) == (  # type: ignore[arg-type]
+        state,
+        False,
+    )
+
+
+def test_premise_true_stays() -> None:
+    assert next_baseline_state("already_true", "true", newly_inserted=False, thesis_created_at=FRESH, now=NOW) == (
+        "already_true",
+        False,
+    )

--- a/tests/test_thesis_break_scan_db.py
+++ b/tests/test_thesis_break_scan_db.py
@@ -163,7 +163,5 @@ def test_altman_sector_gate_blocks_insert(ebull_test_conn: psycopg.Connection[tu
 
     report = run_thesis_break_scan(conn)
     assert report.sector_gated >= 1
-    row = conn.execute(
-        "SELECT COUNT(*) FROM thesis_break_predicates WHERE instrument_id = %s", (iid,)
-    ).fetchone()
+    row = conn.execute("SELECT COUNT(*) FROM thesis_break_predicates WHERE instrument_id = %s", (iid,)).fetchone()
     assert row is not None and int(row[0]) == 0

--- a/tests/test_thesis_break_scan_db.py
+++ b/tests/test_thesis_break_scan_db.py
@@ -1,0 +1,169 @@
+"""Integration test for the #2012 break-predicate scan (one DB-tier file
+for the genuinely-new SQL mechanism, house rule).
+
+Pins: predicate upsert + arm → fire on a genuine false→true transition →
+UNIQUE-dedup on re-scan → find_stale_instruments rule 5 keys the event to
+the LATEST thesis by thesis_id equality (a regenerated thesis with no new
+break must NOT report break_fired — Codex ckpt-1 BLOCKING), plus the
+already_true premise path.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import psycopg
+import pytest
+
+from app.services.thesis import find_stale_instruments
+from app.services.thesis_break_scan import run_thesis_break_scan
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+_IID = 910_001
+_NOW = datetime.now(tz=UTC)
+
+
+def _seed(conn: psycopg.Connection[tuple], *, rsi: float, created_at: datetime | None = None) -> int:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'BRKT', 'Break Test Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (_IID,),
+    )
+    conn.execute(
+        "INSERT INTO coverage (instrument_id, coverage_tier, review_frequency, filings_status) "
+        "VALUES (%s, 1, 'monthly', 'analysable') ON CONFLICT (instrument_id) DO NOTHING",
+        (_IID,),
+    )
+    row = conn.execute(
+        """
+        INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance, memo_markdown,
+                            break_conditions_json, created_at)
+        VALUES (%s, (SELECT COALESCE(MAX(thesis_version), 0) + 1 FROM theses WHERE instrument_id = %s),
+                'value', 'watch', 'memo',
+                '["RSI-14 crosses above 70 (overbought territory)", "Loss of key patents"]'::jsonb,
+                %s)
+        RETURNING thesis_id
+        """,
+        (_IID, _IID, created_at or _NOW),
+    ).fetchone()
+    assert row is not None
+    _set_rsi(conn, rsi)
+    conn.commit()
+    return int(row[0])
+
+
+def _event_count(conn: psycopg.Connection[tuple], thesis_id: int) -> int:
+    row = conn.execute("SELECT COUNT(*) FROM thesis_break_events WHERE thesis_id = %s", (thesis_id,)).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _set_rsi(conn: psycopg.Connection[tuple], rsi: float) -> None:
+    conn.execute(
+        """
+        INSERT INTO price_daily (instrument_id, price_date, close, rsi_14)
+        VALUES (%s, %s, 100.0, %s)
+        ON CONFLICT (instrument_id, price_date) DO UPDATE SET rsi_14 = EXCLUDED.rsi_14
+        """,
+        (_IID, date.today(), rsi),
+    )
+    conn.commit()
+
+
+def test_scan_arm_fire_dedup_and_stale_rule(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    thesis_id = _seed(conn, rsi=50.0)
+
+    # Scan 1: predicate extracted (prose sibling gets no row), baseline false → armed.
+    report = run_thesis_break_scan(conn)
+    assert report.predicates_inserted == 1
+    assert report.fired == 0
+    assert report.state_counts.get("armed") == 1
+    row = conn.execute(
+        "SELECT metric, op, threshold, baseline_state FROM thesis_break_predicates WHERE thesis_id = %s",
+        (thesis_id,),
+    ).fetchone()
+    assert row is not None
+    assert (row[0], row[1], float(row[2])) == ("rsi_14", ">", 70.0)
+    assert row[3] == "armed"
+
+    # No event, no stale flag yet.
+    assert _event_count(conn, thesis_id) == 0
+    stale = {s.instrument_id: s.reason for s in find_stale_instruments(conn, tier=None, instrument_ids=[_IID])}
+    assert _IID not in stale
+
+    # Scan 2 after a genuine transition: armed → fire, exactly one event.
+    _set_rsi(conn, 75.0)
+    report = run_thesis_break_scan(conn)
+    assert report.fired == 1
+    events = conn.execute(
+        "SELECT observed_value, inputs_json FROM thesis_break_events WHERE thesis_id = %s", (thesis_id,)
+    ).fetchall()
+    assert len(events) == 1
+    assert float(events[0][0]) == 75.0
+    assert "price_date" in events[0][1]  # per-input evidence persisted
+
+    # Rule 5: latest thesis now reports break_fired.
+    stale = {s.instrument_id: s.reason for s in find_stale_instruments(conn, tier=None, instrument_ids=[_IID])}
+    assert stale.get(_IID) == "break_fired"
+
+    # Scan 3: UNIQUE(thesis_id, predicate_index) dedups — no second event.
+    report = run_thesis_break_scan(conn)
+    assert report.fired == 0
+    assert _event_count(conn, thesis_id) == 1
+
+    # Regenerated thesis (the break→re-thesis outcome): the OLD event must NOT
+    # re-stale the NEW thesis — event keyed by thesis_id equality, never
+    # instrument_id or fired_at (Codex ckpt-1 BLOCKING regression).
+    _seed(conn, rsi=75.0)
+    stale = {s.instrument_id: s.reason for s in find_stale_instruments(conn, tier=None, instrument_ids=[_IID])}
+    assert stale.get(_IID) != "break_fired"
+
+    # The new thesis's predicate baselines already_true (contemporaneous,
+    # rsi=75 at first evaluation = the writer's premise) — and can never fire.
+    report = run_thesis_break_scan(conn)
+    assert report.fired == 0
+    assert report.state_counts.get("already_true") == 1
+
+
+def test_altman_sector_gate_blocks_insert(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """Altman Z″ excludes financial firms (Altman 2000): a SIC-division-H
+    instrument's altman condition must produce NO predicate row (spec: gate
+    at insert — a permanently-unevaluable pending row would lie)."""
+    conn = ebull_test_conn
+    iid = 910_002
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'FINT', 'Fin Test REIT', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (iid,),
+    )
+    conn.execute(
+        "INSERT INTO instrument_sec_profile (instrument_id, cik, sic) VALUES (%s, '0009100002', '6798') "
+        "ON CONFLICT (instrument_id) DO NOTHING",
+        (iid,),
+    )
+    conn.execute(
+        """
+        INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance, memo_markdown,
+                            break_conditions_json)
+        VALUES (%s, 1, 'value', 'watch', 'memo',
+                '["Altman Z-score falls below 1.8"]'::jsonb)
+        """,
+        (iid,),
+    )
+    conn.commit()
+
+    report = run_thesis_break_scan(conn)
+    assert report.sector_gated >= 1
+    row = conn.execute(
+        "SELECT COUNT(*) FROM thesis_break_predicates WHERE instrument_id = %s", (iid,)
+    ).fetchone()
+    assert row is not None and int(row[0]) == 0


### PR DESCRIPTION
Closes #2012 (PR-A of 2 — PR-B adds /alerts/thesis-breaks + FE surface).

Spec: docs/proposals/thesis/2026-07-16-thesis-break-predicates.md (rev 4, operator-approved; Codex ckpt-1 ×4 rounds folded).

## What

`break_conditions_json` is prose; nothing evaluated it (the one existing reader, portfolio.py EXIT rule 1, uses it as a boolean flag that is true for 325/325 theses — a tautology, documented out-of-scope). This PR makes the machine-checkable subset fire deterministically:

- **sql/230**: `thesis_break_predicates` (baseline_state: pending/armed/already_true/already_true_after_gap) + `thesis_break_events` (UNIQUE (thesis_id, predicate_index) — at most one event per predicate per thesis version; `inputs_json` per-input {value, as_of, source} evidence).
- **app/services/thesis_break.py** (pure): whole-string precision-gated extractor over a closed vocabulary (altman_z, rsi_14, short_interest_pct_shares_out, price_vs_sma200, sma_50_vs_sma_200 + evaluator-only days_to_cover/change_pct for #2010); per-input freshness bounds (fail-closed: absent/stale input never fires, never baselines); edge-trigger state machine (ever-pending + 48h-grace guards, premise re-arm).
- **app/services/thesis_break_scan.py**: nightly scan — extract → upsert predicates (altman sector-gated AT INSERT for SIC division H 60-67) → observe → state machine → events.
- **find_stale_instruments rule**: `break_fired`, keyed to the LATEST thesis by thesis_id EQUALITY only (never fired_at — a delayed scan could re-stale a replacement thesis); ordered after filing-event rules, before the cadence rule.
- **Job**: `thesis_break_scan` nightly 05:22 UTC db lane (offset from thesis_dq_audit 05:12; NOT 5-min-aligned, #1707) + `POST /jobs/thesis_break_scan/run`.
- FE: `break_fired` stale-chip label (ThesesPage).

## Why break = trigger, not verdict

Full-population falsification (spec §Premise): break-condition direction tracks stance — 22.1% of avoid-thesis conditions are UPSIDE triggers ("Altman Z improves to >2.99") vs 1.1% for hold. Wiring breaks to EXIT would sell on good news. A fired break marks the thesis stale → thesis_refresh regenerates → the regenerated stance drives the portfolio through the EXISTING EXIT path (settled EXIT rule preserved). This is also the #1988 trigger reconciliation (same bus as event_new_10k/10q/8k).

## Why arm/baseline is mandatory (not an optimisation)

35 Altman conditions worded "crosses into bankruptcy territory" sit on names ALREADY at z≈−16 (writer premise). A level-triggered evaluator emits ~35 false re-thesis triggers night one (~3h wasted LLM queue). Baseline-true → premise (never fires); fires only on an observed false→true transition after arming.

## Security model

No new external I/O (DB-only job). No user-controlled input reaches SQL (predicates derive from our own writer's stored text; all queries parameterised). New endpoint surface: none (invoker is the existing service-token-gated /jobs path). FE change is a label branch.

## Trust decisions (source rules — spec §Source rules)

- `revenue_ttm_yoy` REJECTED: prevention-log:2159 — financial_periods.revenue under-captured for banks/REITs (18% of fire population).
- Short interest "% of float" (57 conditions) + bare-% (12) FAIL OPEN: FINRA ships no float (skill finra.md:25); imputing shares_outstanding is banned (instrument_analytics.py:325 "NEVER imputed") and systematically under-reports (shares_out ≥ float). Only explicit "shares outstanding" wording extracts.
- Altman gated at insert for SIC division H (60-67): Altman 2000 excludes financials; the upstream gics=="Financials" guard misses Real Estate (GICS 2016 split; sector_classification.py:84,87).
- `insider_net_shares_90d` deferred pending #828.

## Verification (recorded per DoD)

- **Extractor precision — 100% on the FULL population**: 81/81 matches over all 1,585 dev conditions hand-audited (dump reviewed line-by-line; scratchpad extractor_matches.txt). 5.1% extraction rate — precision-first by design; recall is #2010's job (writer-native predicates into this same model).
- **Dev day-one scan (dev DB, post-migration)**: 335 latest theses → 74 predicates, **0 fired** (spec-predicted), armed 53, already_true 6, already_true_after_gap 5, pending 10 (known dev stale-price artifact). sector_gated 0 on current dev population — gate exercised by DB test instead.
- **Premise spot-checks vs stored FY facts** (input-column trust, prevention-log:2158): PANW z=1.0899 (FY-end 2025-07-31; deferred-revenue Z″ artifact class, faithful to facts), DELL 0.2556, BJRI 1.1044, AIRT 1.7515 — all genuinely below their thresholds.
- **Gates**: ruff + format + pyright clean; fast tier 5,184 passed; smoke 153 passed (applied sql/230 to dev); FE typecheck + 1,350 unit tests passed.
- **DB tier**: change-scoped files all pass (test_thesis_break_scan_db.py — arm→fire→dedup→stale-rule regression + sector gate; test_thesis_event_driven_integration.py; test_thesis_refresh_candidates.py; test_thesis_runs_db.py; test_theses_library_db.py — 29 tests). Full bare `-m db` tier wedged locally (known feedback_full_db_tier_wedges_locally class) and was interrupted; not on the push gate.
- **Codex ckpt-2** found 2 real bugs, both fixed in 69809467: raw-array index alignment (a malformed element shifted predicate_index); break_fired shadowed by the cadence rule.

## Conscious tradeoffs

- Day one delivers predicate STATUS + censuses, ~0 events — events accrue on genuine transitions. The already_true census is #2010's empirical brief.
- Rollout baselines land in `already_true_after_gap` by construction (48h grace); honest "cannot tell", counted separately, never merged.
- Composites/durations/"(e.g., …)"/float-denominator conditions stay prose (fail-open) — measured cost in spec; no expression model in v1.
- Re-thesis on break is bounded by thesis_refresh's existing held ∪ top-20 scope — same contract as filing-event triggers; alert surface for the rest arrives in PR-B.
- Change-coupled FE-QA deferred to PR-B: the new label is unreachable on dev today (0 events) and the real break FE surface ships there.

## Operator follow-up (after merge)

Jobs daemon restart registers the 05:22 nightly (VS Code task shadow — same as #2014's note). No backfill needed: first scheduled scan performs the rollout baseline pass idempotently (dev already baselined by the dev-verify run; re-scan is ON CONFLICT DO NOTHING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)