### PR TITLE
feat(#2051): thesis break alerts surface — /alerts/thesis-breaks + FE (PR-B of #2012)

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -22,6 +22,14 @@ Provides three independent alert feeds sharing the same dashboard strip shape:
    - POST /alerts/rank-moves/seen               (body: {seen_through_rank_event_id})
    - POST /alerts/rank-moves/dismiss-all
 
+5. Thesis changes — material re-thesis (#2013):
+   - GET  /alerts/thesis-changes
+   - POST /alerts/thesis-changes/seen           (body: {seen_through_thesis_id})
+
+6. Thesis break events — fired break predicates (#2051, PR-B of #2012):
+   - GET  /alerts/thesis-breaks
+   - POST /alerts/thesis-breaks/seen            (body: {seen_through_break_event_id})
+
 Each feed maintains its own BIGSERIAL cursor column on ``operators`` and a
 7-day window. Cursor semantics are identical across feeds: strict ``>``
 comparison, GREATEST+COALESCE monotonicity, LEAST clamp on /seen, MAX
@@ -40,7 +48,7 @@ use the ``m.max_id IS NOT NULL`` guard as dismiss-all to preserve
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from typing import Literal
 from uuid import UUID
@@ -192,6 +200,31 @@ class ThesisChangesResponse(BaseModel):
 
 class ThesisChangesMarkSeenRequest(BaseModel):
     seen_through_thesis_id: int = Field(gt=0)
+
+
+class ThesisBreakEvent(BaseModel):
+    break_event_id: int
+    thesis_id: int
+    instrument_id: int
+    symbol: str
+    predicate_index: int
+    metric: str
+    op: str  # '<' | '>' (DB CHECK on thesis_break_predicates; open string, #1808)
+    threshold: float | None  # NULL for the two regime metrics (migration 230)
+    observed_value: float
+    observed_as_of: date | None
+    source_text: str  # the writer's verbatim break condition
+    fired_at: datetime
+
+
+class ThesisBreaksResponse(BaseModel):
+    alerts_last_seen_break_event_id: int | None
+    unseen_count: int
+    breaks: list[ThesisBreakEvent]
+
+
+class ThesisBreaksMarkSeenRequest(BaseModel):
+    seen_through_break_event_id: int = Field(gt=0)
 
 
 class ThesisStalenessItem(BaseModel):
@@ -853,6 +886,134 @@ def mark_thesis_changes_seen(
             """,
             {
                 "seen_through_thesis_id": body.seen_through_thesis_id,
+                "op": operator_id,
+            },
+        )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# #2051 (PR-B of #2012) — thesis-break alert feed (a machine-checked break
+# predicate fired on a genuine false→true transition)
+#
+#   GET  /alerts/thesis-breaks
+#   POST /alerts/thesis-breaks/seen      (body: {seen_through_break_event_id})
+#
+# Same cursor semantics as the thesis-change feed: BIGSERIAL cursor
+# (thesis_break_events.break_event_id), strict '>' comparison,
+# GREATEST+COALESCE monotonicity, LEAST clamp on /seen, m.max_id IS NOT NULL
+# empty-window guard. Window = 14 days (thesis cadence, matching #2013).
+# No dismiss-all endpoint, matching #2013: the DESC list always contains the
+# newest event, so seen-through-the-max-listed-id clears everything older.
+#
+# Unlike thesis-changes there is NO Python materiality pass: every
+# thesis_break_events row is material by construction — the scan's
+# arm/baseline state machine (app/services/thesis_break.py) only fires from
+# 'armed', and premise conditions ('already_true*') can never fire. So this
+# is a pure SQL event log, coverage-drops shaped. The predicate join is an
+# INNER join — events carry a composite FK to thesis_break_predicates
+# (migration 230), so the row always exists; it supplies source_text (the
+# writer's verbatim condition) for the card.
+# ---------------------------------------------------------------------------
+
+# Canonical in-window predicate, shared by the GET count, the GET list and
+# /seen so the three can never drift (prevention-log divergence trap).
+# `e` = thesis_break_events alias.
+_THESIS_BREAK_WINDOW_WHERE = """
+    e.fired_at >= now() - INTERVAL '14 days'
+"""
+
+
+@router.get("/thesis-breaks", response_model=ThesisBreaksResponse)
+def get_thesis_breaks(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> ThesisBreaksResponse:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # 1. Read operator's cursor.
+        cur.execute(
+            "SELECT alerts_last_seen_break_event_id FROM operators WHERE operator_id = %(op)s",
+            {"op": operator_id},
+        )
+        op_row = cur.fetchone()
+        last_seen: int | None = op_row["alerts_last_seen_break_event_id"] if op_row else None
+
+        # 2. Count unseen in-window events (uncapped).
+        cur.execute(
+            f"""
+            SELECT COUNT(*) AS unseen_count
+            FROM thesis_break_events e
+            WHERE {_THESIS_BREAK_WINDOW_WHERE}
+              AND (%(last_id)s::BIGINT IS NULL OR e.break_event_id > %(last_id)s::BIGINT)
+            """,
+            {"last_id": last_seen},
+        )
+        count_row = cur.fetchone()
+        assert count_row is not None, "COUNT(*) always returns a row"
+        unseen_count: int = int(count_row["unseen_count"])
+
+        # 3. Fetch the list (capped at 500). ORDER BY break_event_id DESC —
+        # BIGSERIAL PK is the race-safe ordering (matches #394 rationale).
+        cur.execute(
+            f"""
+            SELECT
+                e.break_event_id,
+                e.thesis_id,
+                e.instrument_id,
+                i.symbol,
+                e.predicate_index,
+                e.metric,
+                e.op,
+                e.threshold,
+                e.observed_value,
+                e.observed_as_of,
+                p.source_text,
+                e.fired_at
+            FROM thesis_break_events e
+            JOIN instruments i ON i.instrument_id = e.instrument_id
+            JOIN thesis_break_predicates p
+              ON p.thesis_id = e.thesis_id
+             AND p.predicate_index = e.predicate_index
+            WHERE {_THESIS_BREAK_WINDOW_WHERE}
+            ORDER BY e.break_event_id DESC
+            LIMIT 500
+            """
+        )
+        rows = cur.fetchall()
+
+    return ThesisBreaksResponse(
+        alerts_last_seen_break_event_id=last_seen,
+        unseen_count=unseen_count,
+        breaks=[ThesisBreakEvent.model_validate(r) for r in rows],
+    )
+
+
+@router.post("/thesis-breaks/seen", status_code=status.HTTP_204_NO_CONTENT)
+def mark_thesis_breaks_seen(
+    body: ThesisBreaksMarkSeenRequest,
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> None:
+    operator_id = _resolve_operator(conn)
+    with conn.cursor() as cur:
+        # m.max_id IS NOT NULL guard preserves NULL cursor on empty window
+        # (coverage/position /seen shape, not guard's pre-#395).
+        cur.execute(
+            f"""
+            UPDATE operators AS op
+            SET alerts_last_seen_break_event_id = GREATEST(
+                COALESCE(op.alerts_last_seen_break_event_id, 0),
+                LEAST(%(seen_through_break_event_id)s, m.max_id)
+            )
+            FROM (
+                SELECT MAX(e.break_event_id) AS max_id
+                FROM thesis_break_events e
+                WHERE {_THESIS_BREAK_WINDOW_WHERE}
+            ) AS m
+            WHERE op.operator_id = %(op)s
+              AND m.max_id IS NOT NULL
+            """,
+            {
+                "seen_through_break_event_id": body.seen_through_break_event_id,
                 "op": operator_id,
             },
         )

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -141,6 +141,31 @@ def _diff_model(prev_row: dict[str, object], curr_row: dict[str, object]) -> The
     return ThesisDiffModel.model_validate(dataclasses.asdict(compute_thesis_diff(prev_row, curr_row)))
 
 
+class ThesisBreakPredicateModel(BaseModel):
+    """One machine-checkable break predicate for a thesis (#2012 PR-A tables,
+    surfaced by #2051 PR-B). ``predicate_index`` aligns with the thesis's
+    ``break_conditions_json`` array; conditions with no predicate row are
+    prose (unmonitored — the honest majority, ~95% of conditions).
+
+    ``baseline_state`` semantics (app/services/thesis_break.py state machine):
+    'pending' = input absent/stale, retries nightly; 'armed' = baselined
+    false, may fire; 'already_true' / 'already_true_after_gap' = the writer's
+    own premise (true at first evaluation) — NEVER fires, re-arms only if a
+    later scan observes false. ``fired_at``/``observed_value`` come from the
+    at-most-one thesis_break_events row (UNIQUE per predicate per thesis).
+    """
+
+    predicate_index: int
+    metric: str
+    op: str  # '<' | '>' (DB CHECK; open string in the response, #1808)
+    threshold: float | None  # NULL for the two regime metrics
+    unit: str
+    baseline_state: str
+    baselined_at: datetime | None
+    fired_at: datetime | None = None
+    observed_value: float | None = None
+
+
 class ThesisDetail(BaseModel):
     """Single thesis row with all columns including critic output.
 
@@ -178,6 +203,10 @@ class ThesisDetail(BaseModel):
     # #2013 — diff vs the (instrument_id, thesis_version - 1) predecessor.
     # None when thesis_version == 1 or the predecessor row is missing.
     diff: ThesisDiffModel | None = None
+    # #2051 — machine-checkable predicates extracted from
+    # break_conditions_json (index-aligned; conditions absent from this list
+    # are prose/unmonitored). Empty for pre-#2012 theses not yet scanned.
+    break_predicates: list[ThesisBreakPredicateModel] = []
 
 
 class ThesisHistoryResponse(BaseModel):
@@ -319,6 +348,41 @@ def _fetch_diffs(
         for version, curr in wanted.items()
         if version in predecessors
     }
+
+
+def _fetch_break_predicates(
+    conn: psycopg.Connection[object],
+    thesis_ids: list[int],
+) -> dict[int, list[ThesisBreakPredicateModel]]:
+    """thesis_id → break predicates (index-ordered), with fire evidence.
+
+    LEFT JOIN onto thesis_break_events: at most one event per predicate per
+    thesis version (UNIQUE, migration 230), so the join never fans out.
+    """
+    if not thesis_ids:
+        return {}
+    out: dict[int, list[ThesisBreakPredicateModel]] = {}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT
+                p.thesis_id, p.predicate_index, p.metric, p.op, p.threshold,
+                p.unit, p.baseline_state, p.baselined_at,
+                e.fired_at, e.observed_value
+            FROM thesis_break_predicates p
+            LEFT JOIN thesis_break_events e
+              ON e.thesis_id = p.thesis_id
+             AND e.predicate_index = p.predicate_index
+            WHERE p.thesis_id = ANY(%(ids)s)
+            ORDER BY p.thesis_id, p.predicate_index
+            """,
+            {"ids": thesis_ids},
+        )
+        for row in cur.fetchall():
+            out.setdefault(int(row["thesis_id"]), []).append(  # type: ignore[arg-type]
+                ThesisBreakPredicateModel.model_validate(row)
+            )
+    return out
 
 
 def _critic_verdict(critic_json: object) -> str | None:
@@ -734,6 +798,7 @@ def get_latest_thesis(
 
     thesis = _parse_thesis(row)
     thesis.diff = _fetch_diffs(conn, instrument_id, [row]).get(int(row["thesis_id"]))  # type: ignore[arg-type]
+    thesis.break_predicates = _fetch_break_predicates(conn, [thesis.thesis_id]).get(thesis.thesis_id, [])
     # Staleness single-source (#1902): the FE used to duplicate a 30-day
     # constant; the canonical predicate is find_stale_instruments
     # (coverage cadence + #273 filing-event triggers). reason=None means
@@ -808,8 +873,10 @@ def get_thesis_history(
 
     diffs = _fetch_diffs(conn, instrument_id, rows)
     items = [_parse_thesis(r) for r in rows]
+    predicates = _fetch_break_predicates(conn, [i.thesis_id for i in items])
     for item in items:
         item.diff = diffs.get(item.thesis_id)
+        item.break_predicates = predicates.get(item.thesis_id, [])
     return ThesisHistoryResponse(
         instrument_id=instrument_id,
         items=items,

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -4,6 +4,7 @@ import type {
   GuardRejectionsResponse,
   PositionAlertsResponse,
   RankMovesResponse,
+  ThesisBreaksResponse,
   ThesisChangesResponse,
   ThesisStalenessResponse,
 } from "@/api/types";
@@ -116,6 +117,26 @@ export function markThesisChangesSeen(seenThroughThesisId: number): Promise<void
   return apiFetch<void>("/alerts/thesis-changes/seen", {
     method: "POST",
     body: JSON.stringify({ seen_through_thesis_id: seenThroughThesisId }),
+  });
+}
+
+// --- #2051 thesis-break endpoints (PR-B of #2012) -----------------------------
+// Cursor feed on thesis_break_events.break_event_id; dismiss with the newest
+// listed id clears everything older, so there is no dismiss-all endpoint
+// (same contract as thesis-changes).
+
+export function fetchThesisBreaks(): Promise<ThesisBreaksResponse> {
+  return apiFetch<ThesisBreaksResponse>("/alerts/thesis-breaks");
+}
+
+export function markThesisBreaksSeen(
+  seenThroughBreakEventId: number,
+): Promise<void> {
+  return apiFetch<void>("/alerts/thesis-breaks/seen", {
+    method: "POST",
+    body: JSON.stringify({
+      seen_through_break_event_id: seenThroughBreakEventId,
+    }),
   });
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1272,6 +1272,23 @@ export interface ThesisDiff {
   summary: string;
 }
 
+/** #2051 — machine-checkable break predicate (#2012). `predicate_index`
+ *  aligns with `break_conditions_json`; conditions without a predicate row
+ *  are prose (unmonitored). `fired_at`/`observed_value` non-null iff the
+ *  predicate's at-most-one break event exists. */
+export interface ThesisBreakPredicate {
+  predicate_index: number;
+  metric: string;
+  op: string; // '<' | '>'
+  threshold: number | null; // null for the two regime metrics
+  unit: string;
+  /** 'pending' | 'armed' | 'already_true' | 'already_true_after_gap' */
+  baseline_state: string;
+  baselined_at: string | null;
+  fired_at: string | null;
+  observed_value: number | null;
+}
+
 export interface ThesisDetail {
   thesis_id: number;
   instrument_id: number;
@@ -1300,6 +1317,9 @@ export interface ThesisDetail {
   stale_reason?: string | null;
   /** #2013 — diff vs the version-1 predecessor; null on v1 rows. */
   diff?: ThesisDiff | null;
+  /** #2051 — index-aligned machine-checkable predicates; empty when the
+   *  thesis is unscanned or all conditions are prose. */
+  break_predicates?: ThesisBreakPredicate[];
 }
 
 export interface ThesisHistoryResponse {
@@ -1917,6 +1937,31 @@ export interface ThesisChangesResponse {
   alerts_last_seen_thesis_change_id: number | null;
   unseen_count: number;
   changes: ThesisChange[];
+}
+
+// ---------------------------------------------------------------------------
+// #2051 thesis-break alert feed (app/api/alerts.py, PR-B of #2012)
+// ---------------------------------------------------------------------------
+
+export interface ThesisBreakEventAlert {
+  break_event_id: number;
+  thesis_id: number;
+  instrument_id: number;
+  symbol: string;
+  predicate_index: number;
+  metric: string;
+  op: string; // '<' | '>'
+  threshold: number | null; // null for the two regime metrics
+  observed_value: number;
+  observed_as_of: string | null;
+  source_text: string; // the writer's verbatim break condition
+  fired_at: string;
+}
+
+export interface ThesisBreaksResponse {
+  alerts_last_seen_break_event_id: number | null;
+  unseen_count: number;
+  breaks: ThesisBreakEventAlert[];
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -13,6 +13,8 @@ import type {
   PositionAlertsResponse,
   RankMove,
   RankMovesResponse,
+  ThesisBreakEventAlert,
+  ThesisBreaksResponse,
   ThesisChange,
   ThesisChangesResponse,
   ThesisStalenessResponse,
@@ -34,6 +36,8 @@ vi.mock("@/api/alerts", () => ({
   fetchThesisStaleness: vi.fn(),
   fetchThesisChanges: vi.fn(),
   markThesisChangesSeen: vi.fn(),
+  fetchThesisBreaks: vi.fn(),
+  markThesisBreaksSeen: vi.fn(),
 }));
 
 import * as alertsApi from "@/api/alerts";
@@ -44,6 +48,8 @@ const mockedCoverageFetch = vi.mocked(alertsApi.fetchCoverageStatusDrops);
 const mockedRankFetch = vi.mocked(alertsApi.fetchRankMoves);
 const mockedThesisStaleFetch = vi.mocked(alertsApi.fetchThesisStaleness);
 const mockedThesisChangesFetch = vi.mocked(alertsApi.fetchThesisChanges);
+const mockedThesisBreaksFetch = vi.mocked(alertsApi.fetchThesisBreaks);
+const mockedMarkThesisBreaks = vi.mocked(alertsApi.markThesisBreaksSeen);
 
 const mockedMarkGuard = vi.mocked(alertsApi.markAlertsSeen);
 const mockedMarkPosition = vi.mocked(alertsApi.markPositionAlertsSeen);
@@ -83,6 +89,11 @@ const EMPTY_THESIS_CHANGES: ThesisChangesResponse = {
   unseen_count: 0,
   changes: [],
 };
+const EMPTY_THESIS_BREAKS: ThesisBreaksResponse = {
+  alerts_last_seen_break_event_id: null,
+  unseen_count: 0,
+  breaks: [],
+};
 
 function stubAll(
   overrides: {
@@ -92,6 +103,7 @@ function stubAll(
     rank?: Partial<RankMovesResponse> | Error;
     thesisStale?: Partial<ThesisStalenessResponse> | Error;
     thesisChanges?: Partial<ThesisChangesResponse> | Error;
+    thesisBreaks?: Partial<ThesisBreaksResponse> | Error;
   } = {},
 ) {
   if (overrides.guard instanceof Error) {
@@ -128,6 +140,14 @@ function stubAll(
     mockedThesisChangesFetch.mockResolvedValue({
       ...EMPTY_THESIS_CHANGES,
       ...overrides.thesisChanges,
+    });
+  }
+  if (overrides.thesisBreaks instanceof Error) {
+    mockedThesisBreaksFetch.mockRejectedValue(overrides.thesisBreaks);
+  } else {
+    mockedThesisBreaksFetch.mockResolvedValue({
+      ...EMPTY_THESIS_BREAKS,
+      ...overrides.thesisBreaks,
     });
   }
 }
@@ -192,6 +212,26 @@ function makeThesisChange(overrides: Partial<ThesisChange> = {}): ThesisChange {
     summary: "stance hold→avoid · type compounder→speculative",
     stance_from: "hold",
     stance_to: "avoid",
+    ...overrides,
+  };
+}
+
+function makeThesisBreak(
+  overrides: Partial<ThesisBreakEventAlert> = {},
+): ThesisBreakEventAlert {
+  return {
+    break_event_id: 9,
+    thesis_id: 316,
+    instrument_id: 46,
+    symbol: "LGND",
+    predicate_index: 2,
+    metric: "rsi_14",
+    op: ">",
+    threshold: 70,
+    observed_value: 74.2,
+    observed_as_of: "2026-07-15",
+    source_text: "RSI-14 rises above 70",
+    fired_at: new Date(Date.now() - 25 * 60 * 1000).toISOString(),
     ...overrides,
   };
 }
@@ -819,5 +859,79 @@ describe("AlertsStrip — thesis changes (#2013)", () => {
     const btn = await screen.findByRole("button", { name: /Mark all read/i });
     await userEvent.click(btn);
     expect(mockedMarkThesisChanges).toHaveBeenCalledWith(320);
+  });
+});
+
+describe("AlertsStrip — thesis breaks (#2051)", () => {
+  it("renders a BREAK card with condition + evidence, counted in the unseen pill", async () => {
+    stubAll({
+      thesisBreaks: { breaks: [makeThesisBreak()], unseen_count: 1 },
+    });
+    renderStrip();
+    expect(await screen.findByText("BREAK")).toBeInTheDocument();
+    expect(screen.getByText("LGND")).toBeInTheDocument();
+    expect(screen.getByText("RSI-14 rises above 70")).toBeInTheDocument();
+    expect(
+      screen.getByText("observed 74.2 (threshold > 70) · re-thesis queued"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 new")).toBeInTheDocument();
+    const link = screen.getByText("LGND").closest("a");
+    expect(link).toHaveAttribute("href", "/instruments/46");
+  });
+
+  it("regime metric (null threshold) shows observed value only", async () => {
+    stubAll({
+      thesisBreaks: {
+        breaks: [
+          makeThesisBreak({
+            metric: "sma_50_vs_sma_200",
+            threshold: null,
+            observed_value: -1,
+            source_text: "50-day SMA crosses below the 200-day SMA",
+          }),
+        ],
+        unseen_count: 1,
+      },
+    });
+    renderStrip();
+    expect(
+      await screen.findByText("observed -1 · re-thesis queued"),
+    ).toBeInTheDocument();
+  });
+
+  it("groups multiple in-window fires per instrument, latest shown", async () => {
+    stubAll({
+      thesisBreaks: {
+        breaks: [
+          makeThesisBreak({
+            break_event_id: 11,
+            predicate_index: 4,
+            source_text: "Days-to-cover exceeds 10",
+          }),
+          makeThesisBreak({ break_event_id: 9 }),
+        ],
+        unseen_count: 2,
+      },
+    });
+    renderStrip();
+    expect(await screen.findByText("Days-to-cover exceeds 10")).toBeInTheDocument();
+    expect(screen.getByText("×2")).toBeInTheDocument();
+  });
+
+  it("mark-all-read advances the break cursor to the max listed break_event_id", async () => {
+    mockedMarkThesisBreaks.mockResolvedValue(undefined);
+    stubAll({
+      thesisBreaks: {
+        breaks: [
+          makeThesisBreak({ break_event_id: 9 }),
+          makeThesisBreak({ break_event_id: 11, predicate_index: 4 }),
+        ],
+        unseen_count: 2,
+      },
+    });
+    renderStrip();
+    const btn = await screen.findByRole("button", { name: /Mark all read/i });
+    await userEvent.click(btn);
+    expect(mockedMarkThesisBreaks).toHaveBeenCalledWith(11);
   });
 });

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -9,6 +9,9 @@
  *   1. Guard rejections (#394) — grouped by leading rule code (informational).
  *   2. Position alerts — SL/TP/thesis breach episodes (#401) — per-instrument (actionable).
  *   3. Coverage status drops from 'analysable' (#402) — grouped by transition (housekeeping).
+ *   4. Rank moves on held instruments (#1922) — per-instrument (informational).
+ *   5. Material re-thesis (#2013) — per-instrument (informational).
+ *   6. Thesis break events (#2051) — per-instrument (informational).
  *
  * Seen/unseen + overflow accounting is UNCHANGED and operates on the RAW feed arrays by
  * BIGSERIAL id (clocks can skew): each feed keeps its own cursor column on `operators`,
@@ -29,12 +32,14 @@ import {
   fetchGuardRejections,
   fetchPositionAlerts,
   fetchRankMoves,
+  fetchThesisBreaks,
   fetchThesisChanges,
   fetchThesisStaleness,
   markAlertsSeen,
   markCoverageStatusDropsSeen,
   markPositionAlertsSeen,
   markRankMovesSeen,
+  markThesisBreaksSeen,
   markThesisChangesSeen,
 } from "@/api/alerts";
 import type {
@@ -43,6 +48,7 @@ import type {
   PositionAlert,
   PositionAlertsResponse,
   RankMovesResponse,
+  ThesisBreaksResponse,
   ThesisChangesResponse,
   ThesisStalenessResponse,
 } from "@/api/types";
@@ -55,6 +61,7 @@ import {
   type GuardGroupItem,
   type CoverageGroupItem,
   type RankMoveItem,
+  type ThesisBreakItem,
   type ThesisChangeItem,
   type ThesisStaleItem,
   type Tier,
@@ -317,6 +324,52 @@ function ThesisChangeCard({ item }: { item: ThesisChangeItem }) {
   );
 }
 
+function ThesisBreakCard({ item }: { item: ThesisBreakItem }) {
+  // Machine-checked break fired (#2051): a genuine false→true transition on
+  // a break condition — the break_fired stale rule has already queued a
+  // regeneration; this card says why. Shows observed vs threshold.
+  const evidence =
+    item.threshold !== null
+      ? `observed ${item.observedValue} (threshold ${item.op} ${item.threshold})`
+      : `observed ${item.observedValue}`;
+  return (
+    <Link
+      to={`/instruments/${item.instrumentId}`}
+      className="block hover:bg-slate-50 dark:hover:bg-slate-800/40"
+    >
+      <CardShell tier={item.tier} unseen={item.unseen} label="BREAK">
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex items-baseline gap-2">
+            <span className="font-semibold text-slate-800 dark:text-slate-100">
+              {item.symbol}
+            </span>
+            <span className="text-xs text-amber-700 dark:text-amber-300">
+              break condition fired
+            </span>
+            {item.count > 1 ? (
+              <span className="rounded-full bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:text-slate-300 tabular-nums">
+                ×{item.count}
+              </span>
+            ) : null}
+          </div>
+          <span
+            className="truncate text-xs text-slate-600 dark:text-slate-300"
+            title={`${item.sourceText} — ${evidence}`}
+          >
+            {item.sourceText}
+          </span>
+          <span className="text-xs tabular-nums text-slate-500 dark:text-slate-400">
+            {evidence} · re-thesis queued
+          </span>
+        </div>
+        <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500">
+          {formatRelativeTime(item.latestTs)}
+        </span>
+      </CardShell>
+    </Link>
+  );
+}
+
 function ThesisStaleCard({ item }: { item: ThesisStaleItem }) {
   // Standing condition (#1902): no unseen highlight, no dismiss — the card
   // clears when the theses regenerate. Links to the pre-filtered library.
@@ -353,6 +406,8 @@ function ItemView({ item }: { item: AlertItem }) {
       return <RankMoveCard item={item} />;
     case "thesisChange":
       return <ThesisChangeCard item={item} />;
+    case "thesisBreak":
+      return <ThesisBreakCard item={item} />;
     case "thesisStale":
       return <ThesisStaleCard item={item} />;
   }
@@ -381,6 +436,11 @@ export function AlertsStrip(): JSX.Element | null {
   >({
     status: "loading",
   });
+  const [thesisBreak, setThesisBreak] = useState<
+    FeedState<ThesisBreaksResponse>
+  >({
+    status: "loading",
+  });
   const [refetchKey, setRefetchKey] = useState(0);
 
   useEffect(() => {
@@ -391,6 +451,7 @@ export function AlertsStrip(): JSX.Element | null {
     setRank({ status: "loading" });
     setThesisStale({ status: "loading" });
     setThesisChange({ status: "loading" });
+    setThesisBreak({ status: "loading" });
 
     fetchGuardRejections()
       .then((d) => {
@@ -452,6 +513,16 @@ export function AlertsStrip(): JSX.Element | null {
           setThesisChange({ status: "err" });
         }
       });
+    fetchThesisBreaks()
+      .then((d) => {
+        if (!cancelled) setThesisBreak({ status: "ok", data: d });
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("[AlertsStrip] fetchThesisBreaks failed", err);
+          setThesisBreak({ status: "err" });
+        }
+      });
 
     return () => {
       cancelled = true;
@@ -466,7 +537,8 @@ export function AlertsStrip(): JSX.Element | null {
     coverage.status === "loading" ||
     rank.status === "loading" ||
     thesisStale.status === "loading" ||
-    thesisChange.status === "loading"
+    thesisChange.status === "loading" ||
+    thesisBreak.status === "loading"
   ) {
     return null;
   }
@@ -476,7 +548,8 @@ export function AlertsStrip(): JSX.Element | null {
     coverage.status === "err" &&
     rank.status === "err" &&
     thesisStale.status === "err" &&
-    thesisChange.status === "err"
+    thesisChange.status === "err" &&
+    thesisBreak.status === "err"
   ) {
     return null;
   }
@@ -493,6 +566,8 @@ export function AlertsStrip(): JSX.Element | null {
     thesisStale.status === "ok" ? thesisStale.data.items : [];
   const thesisChanges =
     thesisChange.status === "ok" ? thesisChange.data.changes : [];
+  const thesisBreaks =
+    thesisBreak.status === "ok" ? thesisBreak.data.breaks : [];
 
   const cursors: Cursors = {
     guard: guard.status === "ok" ? guard.data.alerts_last_seen_decision_id : null,
@@ -509,6 +584,10 @@ export function AlertsStrip(): JSX.Element | null {
       thesisChange.status === "ok"
         ? thesisChange.data.alerts_last_seen_thesis_change_id
         : null,
+    thesisBreak:
+      thesisBreak.status === "ok"
+        ? thesisBreak.data.alerts_last_seen_break_event_id
+        : null,
   };
 
   const items = buildAlertModel(
@@ -519,6 +598,7 @@ export function AlertsStrip(): JSX.Element | null {
     cursors,
     staleTheses,
     thesisChanges,
+    thesisBreaks,
   );
 
   if (items.length === 0) {
@@ -531,6 +611,8 @@ export function AlertsStrip(): JSX.Element | null {
   const unseenRank = rank.status === "ok" ? rank.data.unseen_count : 0;
   const unseenThesisChange =
     thesisChange.status === "ok" ? thesisChange.data.unseen_count : 0;
+  const unseenThesisBreak =
+    thesisBreak.status === "ok" ? thesisBreak.data.unseen_count : 0;
 
   // Overflow math compares backend unseen counts to RAW fetched row counts (each feed caps
   // at LIMIT 500; thesis changes at 50) — NOT to the grouped card count.
@@ -539,16 +621,23 @@ export function AlertsStrip(): JSX.Element | null {
   const renderedCoverage = drops.length;
   const renderedRank = moves.length;
   const renderedThesisChange = thesisChanges.length;
+  const renderedThesisBreak = thesisBreaks.length;
 
   const totalUnseen =
-    unseenGuard + unseenPosition + unseenCoverage + unseenRank + unseenThesisChange;
+    unseenGuard +
+    unseenPosition +
+    unseenCoverage +
+    unseenRank +
+    unseenThesisChange +
+    unseenThesisBreak;
 
   const anyOverflow =
     unseenGuard > renderedGuard ||
     unseenPosition > renderedPosition ||
     unseenCoverage > renderedCoverage ||
     unseenRank > renderedRank ||
-    unseenThesisChange > renderedThesisChange;
+    unseenThesisChange > renderedThesisChange ||
+    unseenThesisBreak > renderedThesisBreak;
 
   const overflowAck = anyOverflow;
   const normalAck = totalUnseen > 0 && !anyOverflow;
@@ -560,6 +649,7 @@ export function AlertsStrip(): JSX.Element | null {
     const coverageMax = Math.max(0, ...drops.map((r) => r.event_id));
     const rankMax = Math.max(0, ...moves.map((r) => r.score_id));
     const thesisChangeMax = Math.max(0, ...thesisChanges.map((r) => r.thesis_id));
+    const thesisBreakMax = Math.max(0, ...thesisBreaks.map((r) => r.break_event_id));
 
     const promises: Promise<void>[] = [];
     if (guardMax > 0) promises.push(markAlertsSeen(guardMax));
@@ -567,6 +657,7 @@ export function AlertsStrip(): JSX.Element | null {
     if (coverageMax > 0) promises.push(markCoverageStatusDropsSeen(coverageMax));
     if (rankMax > 0) promises.push(markRankMovesSeen(rankMax));
     if (thesisChangeMax > 0) promises.push(markThesisChangesSeen(thesisChangeMax));
+    if (thesisBreakMax > 0) promises.push(markThesisBreaksSeen(thesisBreakMax));
 
     const results = await Promise.allSettled(promises);
     for (const r of results) {
@@ -583,7 +674,8 @@ export function AlertsStrip(): JSX.Element | null {
       Math.max(0, unseenPosition - renderedPosition) +
       Math.max(0, unseenCoverage - renderedCoverage) +
       Math.max(0, unseenRank - renderedRank) +
-      Math.max(0, unseenThesisChange - renderedThesisChange);
+      Math.max(0, unseenThesisChange - renderedThesisChange) +
+      Math.max(0, unseenThesisBreak - renderedThesisBreak);
     const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
     if (!window.confirm(msg)) return;
 
@@ -592,11 +684,13 @@ export function AlertsStrip(): JSX.Element | null {
     if (position.status === "ok") promises.push(dismissAllPositionAlerts());
     if (coverage.status === "ok") promises.push(dismissAllCoverageStatusDrops());
     if (rank.status === "ok") promises.push(dismissAllRankMoves());
-    // No dismiss-all endpoint (#2013): the DESC list always contains the
-    // newest material change, so seen-through-the-max-listed-id clears all.
+    // No dismiss-all endpoint (#2013/#2051): the DESC list always contains
+    // the newest event, so seen-through-the-max-listed-id clears all.
     {
       const thesisChangeMax = Math.max(0, ...thesisChanges.map((r) => r.thesis_id));
       if (thesisChangeMax > 0) promises.push(markThesisChangesSeen(thesisChangeMax));
+      const thesisBreakMax = Math.max(0, ...thesisBreaks.map((r) => r.break_event_id));
+      if (thesisBreakMax > 0) promises.push(markThesisBreaksSeen(thesisBreakMax));
     }
 
     const results = await Promise.allSettled(promises);

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -676,7 +676,7 @@ export function AlertsStrip(): JSX.Element | null {
       Math.max(0, unseenRank - renderedRank) +
       Math.max(0, unseenThesisChange - renderedThesisChange) +
       Math.max(0, unseenThesisBreak - renderedThesisBreak);
-    const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations before dismissing if they might matter.`;
+    const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations (or /theses for thesis alerts) before dismissing if they might matter.`;
     if (!window.confirm(msg)) return;
 
     const promises: Promise<void>[] = [];

--- a/frontend/src/components/dashboard/alertModel.test.ts
+++ b/frontend/src/components/dashboard/alertModel.test.ts
@@ -23,6 +23,7 @@ const NO_CURSORS: Cursors = {
   coverage: null,
   rank: null,
   thesisChange: null,
+  thesisBreak: null,
 };
 
 function guard(o: Partial<GuardRejection> = {}): GuardRejection {

--- a/frontend/src/components/dashboard/alertModel.ts
+++ b/frontend/src/components/dashboard/alertModel.ts
@@ -21,6 +21,7 @@ import type {
   GuardRejection,
   PositionAlert,
   RankMove,
+  ThesisBreakEventAlert,
   ThesisChange,
   ThesisStalenessItem,
 } from "@/api/types";
@@ -39,6 +40,7 @@ export type Cursors = {
   coverage: number | null;
   rank: number | null;
   thesisChange: number | null;
+  thesisBreak: number | null;
 };
 
 export interface GuardReasonMeta {
@@ -270,12 +272,38 @@ export interface ThesisChangeItem {
   unseen: boolean;
 }
 
+/**
+ * Thesis break (#2051, PR-B of #2012) — one card per instrument whose thesis
+ * had a machine-checked break predicate fire (a genuine false→true
+ * transition; the writer's own premises can never fire). Event feed cursored
+ * on thesis_break_events.break_event_id. A break is a TRIGGER, not a
+ * verdict: the stale rule queues a regeneration and the resulting #2013
+ * RE-THESIS card carries the outcome — this card says why it was queued.
+ */
+export interface ThesisBreakItem {
+  kind: "thesisBreak";
+  tier: Tier;
+  id: string;
+  symbol: string;
+  instrumentId: number;
+  sourceText: string; // latest event's verbatim break condition
+  observedValue: number;
+  threshold: number | null;
+  op: string;
+  count: number;
+  latestTs: string;
+  sortKey: number;
+  maxId: number;
+  unseen: boolean;
+}
+
 export type AlertItem =
   | GuardGroupItem
   | PositionItem
   | CoverageGroupItem
   | RankMoveItem
   | ThesisChangeItem
+  | ThesisBreakItem
   | ThesisStaleItem;
 
 function uniqueSorted(values: (string | null)[]): string[] {
@@ -294,6 +322,7 @@ export function buildAlertModel(
   cursors: Cursors,
   staleTheses: ThesisStalenessItem[] = [],
   thesisChanges: ThesisChange[] = [],
+  thesisBreaks: ThesisBreakEventAlert[] = [],
 ): AlertItem[] {
   const items: AlertItem[] = [];
 
@@ -423,6 +452,40 @@ export function buildAlertModel(
       sortKey: Date.parse(latest.created_at),
       maxId,
       unseen: cursors.thesisChange === null || maxId > cursors.thesisChange,
+    });
+  }
+
+  // Thesis breaks (#2051) → one card per instrument (informational tier —
+  // the break has already queued a regeneration via the break_fired stale
+  // rule; the operator reviews, the engine acts). Multiple in-window fires
+  // on one instrument (distinct predicates) show the latest (highest
+  // break_event_id) and count the rest — same shape as thesis changes.
+  const thesisBreakGroups = new Map<number, ThesisBreakEventAlert[]>();
+  for (const b of thesisBreaks) {
+    const arr = thesisBreakGroups.get(b.instrument_id);
+    if (arr) arr.push(b);
+    else thesisBreakGroups.set(b.instrument_id, [b]);
+  }
+  for (const [instrumentId, members] of thesisBreakGroups) {
+    const maxId = Math.max(...members.map((m) => m.break_event_id));
+    const latest = members.reduce((a, b) =>
+      b.break_event_id > a.break_event_id ? b : a,
+    );
+    items.push({
+      kind: "thesisBreak",
+      tier: "informational",
+      id: `thesisBreak:${instrumentId}`,
+      symbol: latest.symbol,
+      instrumentId,
+      sourceText: latest.source_text,
+      observedValue: latest.observed_value,
+      threshold: latest.threshold,
+      op: latest.op,
+      count: members.length,
+      latestTs: latest.fired_at,
+      sortKey: Date.parse(latest.fired_at),
+      maxId,
+      unseen: cursors.thesisBreak === null || maxId > cursors.thesisBreak,
     });
   }
 

--- a/frontend/src/components/instrument/ThesisPane.test.tsx
+++ b/frontend/src/components/instrument/ThesisPane.test.tsx
@@ -200,3 +200,107 @@ describe("ThesisPane", () => {
     expect(screen.queryByTestId("thesis-diff")).not.toBeInTheDocument();
   });
 });
+
+describe("ThesisPane — break predicate rows (#2051)", () => {
+  const conditions = [
+    "Loss of key patents", // prose — no predicate row
+    "RSI-14 rises above 70",
+    "Altman Z-score crosses into distress (<1.8)",
+    "Days-to-cover exceeds 10",
+    "Price falls below the 200-day SMA",
+  ];
+  const predicates = [
+    {
+      predicate_index: 1,
+      metric: "rsi_14",
+      op: ">",
+      threshold: 70,
+      unit: "index",
+      baseline_state: "armed",
+      baselined_at: "2026-07-16T05:22:00+00:00",
+      fired_at: null,
+      observed_value: null,
+    },
+    {
+      predicate_index: 2,
+      metric: "altman_z",
+      op: "<",
+      threshold: 1.8,
+      unit: "zscore",
+      baseline_state: "already_true",
+      baselined_at: "2026-07-16T05:22:00+00:00",
+      fired_at: null,
+      observed_value: null,
+    },
+    {
+      predicate_index: 3,
+      metric: "short_interest_days_to_cover",
+      op: ">",
+      threshold: 10,
+      unit: "days",
+      baseline_state: "armed",
+      baselined_at: "2026-07-16T05:22:00+00:00",
+      fired_at: "2026-07-17T05:22:00+00:00",
+      observed_value: 12.4,
+    },
+    {
+      predicate_index: 4,
+      metric: "price_vs_sma200",
+      op: "<",
+      threshold: null,
+      unit: "regime",
+      baseline_state: "pending",
+      baselined_at: null,
+      fired_at: null,
+      observed_value: null,
+    },
+  ];
+  const withPredicates = {
+    ...FIXTURE,
+    break_conditions_json: conditions,
+    break_predicates: predicates,
+  } as unknown as ThesisDetail;
+
+  it("chips armed/pending muted, premise with writer-premise tooltip, prose bare", () => {
+    render(<ThesisPane thesis={withPredicates} errored={false} />);
+    expect(screen.getByText("armed")).toBeInTheDocument();
+    expect(screen.getByText("pending")).toBeInTheDocument();
+    const premise = screen.getByText("premise");
+    expect(premise).toHaveAttribute("title", expect.stringContaining("Writer premise, not a trigger"));
+    // Prose condition renders without any chip in its row.
+    const prose = screen.getByText(/Loss of key patents/);
+    expect(prose.querySelector("span")).toBeNull();
+  });
+
+  it("fired predicate renders amber with evidence tooltip", () => {
+    render(<ThesisPane thesis={withPredicates} errored={false} />);
+    const fired = screen.getByText("fired");
+    expect(fired).toHaveAttribute(
+      "title",
+      expect.stringContaining("observed 12.4 vs threshold > 10"),
+    );
+    const row = fired.closest("li");
+    expect(row).toHaveClass("text-amber-700");
+  });
+
+  it("distinguishes already_true_after_gap from already_true", () => {
+    const gapped = {
+      ...withPredicates,
+      break_predicates: [
+        { ...predicates[1], baseline_state: "already_true_after_gap" },
+      ],
+    } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={gapped} errored={false} />);
+    const chip = screen.getByText("premise (gap)");
+    expect(chip).toHaveAttribute("title", expect.stringContaining("unobserved gap"));
+  });
+
+  it("renders plain conditions when break_predicates is absent (older payloads)", () => {
+    const bare = {
+      ...FIXTURE,
+      break_conditions_json: ["Lose 50% market share"],
+    } as unknown as ThesisDetail;
+    render(<ThesisPane thesis={bare} errored={false} />);
+    expect(screen.getByText("Lose 50% market share")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/instrument/ThesisPane.tsx
+++ b/frontend/src/components/instrument/ThesisPane.tsx
@@ -3,7 +3,7 @@ import { CriticVerdictBadge } from "@/components/theses/CriticVerdictBadge";
 import { MemoMarkdown } from "@/components/theses/MemoMarkdown";
 import { StanceBadge } from "@/components/theses/StanceBadge";
 import { EmptyState } from "@/components/states/EmptyState";
-import type { ThesisDetail, ThesisDiff } from "@/api/types";
+import type { ThesisBreakPredicate, ThesisDetail, ThesisDiff } from "@/api/types";
 
 export interface ThesisPaneProps {
   readonly thesis: ThesisDetail | null;
@@ -130,6 +130,60 @@ function DiffBlock({ diff }: { diff: ThesisDiff }): JSX.Element | null {
   );
 }
 
+/** #2051 — status chip for a machine-checkable break condition. States from
+ *  the arm/baseline machine (app/services/thesis_break.py): only 'armed'
+ *  predicates can ever fire; 'already_true*' is the writer's own premise
+ *  (true at first evaluation) and is deliberately muted — surfacing it as a
+ *  break would alert on the thesis's own starting assumption. The two
+ *  premise labels are never merged (spec: after_gap is an honest "cannot
+ *  tell premise from missed transition", counted separately). */
+function BreakPredicateChip({ pred }: { pred: ThesisBreakPredicate }): JSX.Element {
+  const muted =
+    "rounded border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/60 px-1 py-0.5 text-[10px] font-medium text-slate-500 dark:text-slate-400";
+  if (pred.fired_at !== null) {
+    const evidence =
+      pred.threshold !== null
+        ? `observed ${pred.observed_value ?? "?"} vs threshold ${pred.op} ${pred.threshold}`
+        : `observed ${pred.observed_value ?? "?"}`;
+    return (
+      <span
+        className="rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 px-1 py-0.5 text-[10px] font-semibold uppercase text-amber-700 dark:text-amber-300"
+        title={`Break fired ${formatDate(pred.fired_at)} — ${evidence}. Regeneration queued via the break_fired stale rule.`}
+      >
+        fired
+      </span>
+    );
+  }
+  switch (pred.baseline_state) {
+    case "armed":
+      return (
+        <span className={muted} title="Monitored nightly — baselined false; fires on a genuine false→true transition.">
+          armed
+        </span>
+      );
+    case "pending":
+      return (
+        <span className={muted} title="Awaiting evaluable input (absent or stale data) — retries at the next nightly scan.">
+          pending
+        </span>
+      );
+    case "already_true":
+      return (
+        <span className={muted} title="Writer premise, not a trigger — already true when first evaluated, so it can never fire. Re-arms only if a later scan observes it false.">
+          premise
+        </span>
+      );
+    case "already_true_after_gap":
+      return (
+        <span className={muted} title="Writer premise, not a trigger — true at a first evaluation that came after an unobserved gap, so a premise cannot be distinguished from a missed transition. Never fires; re-arms if a later scan observes it false.">
+          premise (gap)
+        </span>
+      );
+    default:
+      return <span className={muted}>{pred.baseline_state}</span>;
+  }
+}
+
 interface BodyProps {
   readonly thesis: ThesisDetail;
   readonly currentPrice: string | null;
@@ -138,6 +192,9 @@ interface BodyProps {
 
 function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element {
   const breaks = thesis.break_conditions_json ?? [];
+  const predicateByIndex = new Map(
+    (thesis.break_predicates ?? []).map((p) => [p.predicate_index, p]),
+  );
   const critic = thesis.critic_json;
   const criticSummary = critic ? criticString(critic, "summary") : null;
   const criticRisks = critic ? criticList(critic, "key_risks") : [];
@@ -266,9 +323,27 @@ function ThesisBody({ thesis, currentPrice, currency }: BodyProps): JSX.Element 
             Break conditions
           </div>
           <ul className="list-inside list-disc space-y-0.5 text-xs text-slate-600 dark:text-slate-400">
-            {breaks.map((b, i) => (
-              <li key={i}>{b}</li>
-            ))}
+            {breaks.map((b, i) => {
+              // #2051 — predicates are index-aligned with the conditions
+              // array; a condition without a predicate row is prose
+              // (unmonitored) and renders without a chip.
+              const pred = predicateByIndex.get(i);
+              const fired = pred !== undefined && pred.fired_at !== null;
+              return (
+                <li
+                  key={i}
+                  className={fired ? "text-amber-700 dark:text-amber-300" : undefined}
+                >
+                  {b}
+                  {pred !== undefined && (
+                    <>
+                      {" "}
+                      <BreakPredicateChip pred={pred} />
+                    </>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}

--- a/sql/231_operators_alerts_break_event_cursor.sql
+++ b/sql/231_operators_alerts_break_event_cursor.sql
@@ -1,0 +1,23 @@
+-- #2051 — thesis-break alert feed cursor (PR-B of #2012).
+--
+-- A sixth dashboard alert feed (AlertsStrip): a machine-checked break
+-- predicate fired on a genuine false→true transition (thesis_break_events,
+-- migration 230). Every event is material by construction — the scan's
+-- arm/baseline state machine only fires from 'armed' — so this feed is a
+-- pure SQL event log with no Python materiality pass (contrast #2013's
+-- thesis-changes feed).
+--
+-- `thesis_break_events.break_event_id` (BIGSERIAL PK, monotonic, unique)
+-- is the cursor — same rationale as migration 044's decision_id / 047's
+-- event_id / 213's score_id / 227's thesis_id: strict `>` comparison over
+-- a monotonic PK, immune to timestamp skew.
+--
+-- NULL = never acknowledged (all in-window events unseen), matching the
+-- other five cursor columns on `operators`.
+--
+-- No supporting index: the feed scans a 14-day fired_at window and
+-- idx_thesis_break_events_instrument_fired (migration 230) plus the tiny
+-- table (0 rows on dev at rollout; fires are rare by design) make any
+-- dedicated cursor index premature.
+ALTER TABLE operators
+    ADD COLUMN IF NOT EXISTS alerts_last_seen_break_event_id BIGINT;

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1941,7 +1941,7 @@ def test_thesis_staleness_reports_stale_held_instrument(client: TestClient) -> N
     # monthly cadence + past thesis timestamp is deterministically stale.
     conn = cur._parent_conn
     conn.execute.return_value.fetchall.return_value = [
-        (5, "GME", "monthly", stale_at, None, None),
+        (5, "GME", "monthly", stale_at, None, None, False),
     ]
     resp = client.get("/alerts/thesis-staleness")
     assert resp.status_code == 200
@@ -2072,3 +2072,139 @@ def test_thesis_changes_post_seen_rejects_non_positive(client: TestClient) -> No
         _install_conn()
         resp = client.post("/alerts/thesis-changes/seen", json={"seen_through_thesis_id": 0})
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# #2051 (PR-B of #2012) — thesis-break alert feed (cursor on
+# thesis_break_events.break_event_id; pure SQL event log, no Python
+# materiality pass — every event is material by construction)
+# ---------------------------------------------------------------------------
+
+
+def _break_event_row(
+    break_event_id: int = 7,
+    thesis_id: int = 316,
+    instrument_id: int = 46,
+    symbol: str = "LGND",
+    predicate_index: int = 2,
+    metric: str = "rsi_14",
+    op: str = ">",
+    threshold: float | None = 70.0,
+    observed_value: float = 74.2,
+) -> dict[str, object]:
+    return {
+        "break_event_id": break_event_id,
+        "thesis_id": thesis_id,
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "predicate_index": predicate_index,
+        "metric": metric,
+        "op": op,
+        "threshold": Decimal(str(threshold)) if threshold is not None else None,
+        "observed_value": Decimal(str(observed_value)),
+        "observed_as_of": datetime(2026, 7, 15, tzinfo=UTC).date(),
+        "source_text": "RSI-14 rises above 70",
+        "fired_at": datetime(2026, 7, 16, 5, 22, 0, tzinfo=UTC),
+    }
+
+
+def test_thesis_breaks_get_empty_state(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_break_event_id": None},
+                {"unseen_count": 0},
+            ],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/thesis-breaks")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "alerts_last_seen_break_event_id": None,
+        "unseen_count": 0,
+        "breaks": [],
+    }
+
+
+def test_thesis_breaks_get_lists_events_with_cursor(client: TestClient) -> None:
+    rows = [
+        _break_event_row(break_event_id=9),
+        _break_event_row(
+            break_event_id=8,
+            instrument_id=48,
+            symbol="GME",
+            metric="sma_50_vs_sma_200",
+            threshold=None,
+            observed_value=-1.0,
+        ),
+    ]
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_break_event_id": 8},
+                {"unseen_count": 1},
+            ],
+            fetchall_returns=rows,
+        )
+        resp = client.get("/alerts/thesis-breaks")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["alerts_last_seen_break_event_id"] == 8
+    assert body["unseen_count"] == 1
+    assert [b["break_event_id"] for b in body["breaks"]] == [9, 8]
+    lgnd = body["breaks"][0]
+    assert lgnd["symbol"] == "LGND"
+    assert lgnd["threshold"] == 70.0
+    assert lgnd["observed_value"] == 74.2
+    assert lgnd["source_text"] == "RSI-14 rises above 70"
+    # Regime metric: threshold is honestly null, never coerced.
+    assert body["breaks"][1]["threshold"] is None
+
+
+def test_thesis_breaks_get_unseen_query_uses_cursor_and_window(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn(
+            fetchone_returns=[
+                {"alerts_last_seen_break_event_id": 8},
+                {"unseen_count": 0},
+            ],
+            fetchall_returns=[],
+        )
+        resp = client.get("/alerts/thesis-breaks")
+    assert resp.status_code == 200
+    count_sql = cur.execute.call_args_list[1].args[0]
+    list_sql = cur.execute.call_args_list[2].args[0]
+    # Shared canonical window fragment in BOTH queries (drift guard) + strict
+    # '>' cursor comparison in the count only.
+    assert "fired_at >= now() - INTERVAL '14 days'" in count_sql
+    assert "fired_at >= now() - INTERVAL '14 days'" in list_sql
+    assert "e.break_event_id > %(last_id)s::BIGINT" in count_sql
+    assert "ORDER BY e.break_event_id DESC" in list_sql
+
+
+def test_thesis_breaks_post_seen_writes_clamped_update(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        cur = _install_conn()
+        resp = client.post("/alerts/thesis-breaks/seen", json={"seen_through_break_event_id": 9})
+    assert resp.status_code == 204
+    sql = cur.execute.call_args_list[-1].args[0]
+    assert "alerts_last_seen_break_event_id" in sql
+    assert "GREATEST" in sql
+    assert "LEAST" in sql
+    assert "m.max_id IS NOT NULL" in sql
+    assert "fired_at >= now() - INTERVAL '14 days'" in sql
+    cur._parent_conn.commit.assert_called_once()
+
+
+def test_thesis_breaks_post_seen_rejects_non_positive(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", return_value=_OP_ID):
+        _install_conn()
+        resp = client.post("/alerts/thesis-breaks/seen", json={"seen_through_break_event_id": 0})
+    assert resp.status_code == 422
+
+
+def test_thesis_breaks_get_503_when_no_operator(client: TestClient) -> None:
+    with patch("app.api.alerts.sole_operator_id", side_effect=NoOperatorError()):
+        _install_conn()
+        resp = client.get("/alerts/thesis-breaks")
+    assert resp.status_code == 503

--- a/tests/test_api_theses.py
+++ b/tests/test_api_theses.py
@@ -79,7 +79,11 @@ def _mock_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
     result_iter = iter(cursor_results)
 
     def _on_execute(*_args: Any, **_kwargs: Any) -> None:
-        rows = next(result_iter)
+        # Exhausted → empty set, not StopIteration: ancillary read-path
+        # lookups (#2013 diff predecessors, #2051 break predicates) run on
+        # every detail/history call and default to honest-empty results;
+        # tests that care about them supply explicit result sets in order.
+        rows = next(result_iter, [])
         cur.fetchone.return_value = rows[0] if rows else None
         cur.fetchall.return_value = rows
 
@@ -396,7 +400,7 @@ class TestGetLatestThesisStaleness:
         # monthly cadence + a past created_at is deterministically stale
         # against the real clock.
         conn.execute.return_value.fetchall.return_value = [
-            (100, "AAPL", "monthly", _EARLIER, None, None),
+            (100, "AAPL", "monthly", _EARLIER, None, None, False),
         ]
         resp = client.get("/theses/100")
         _cleanup()
@@ -568,7 +572,7 @@ class TestListTheses:
         )
         conn = _with_conn([[], [row]])
         conn.execute.return_value.fetchall.return_value = [
-            (100, "AAPL", "monthly", _EARLIER, None, None),
+            (100, "AAPL", "monthly", _EARLIER, None, None, False),
         ]
         resp = client.get("/theses")
         _cleanup()
@@ -608,7 +612,7 @@ class TestListTheses:
         }
         conn = _with_conn([[gap_row], [_make_library_row(100, "AAPL")]])
         conn.execute.return_value.fetchall.return_value = [
-            (200, "GME", None, None, None, None),  # no_thesis via find_stale
+            (200, "GME", None, None, None, None, False),  # no_thesis via find_stale
         ]
         resp = client.get("/theses")
         _cleanup()


### PR DESCRIPTION
Closes #2051. Part of #2012 — PR-B of its spec (docs/proposals/thesis/2026-07-16-thesis-break-predicates.md, Shape 6). PR-A (#2049, merged) shipped the tables, scan, nightly job and `break_fired` stale rule; this PR is the operator-visible surface.

## What

- **sql/231** — `operators.alerts_last_seen_break_event_id` cursor column (BIGSERIAL cursor on `thesis_break_events.break_event_id`, NULL = never acknowledged; same rationale chain as 044/047/213/227). Additive, auto-applies at boot; no jobs restart needed.
- **`GET /alerts/thesis-breaks` + `POST /alerts/thesis-breaks/seen`** — mirrors #2013's thesis-changes feed exactly: shared canonical window fragment (`fired_at >= now() - 14 days`) across GET count / GET list / seen so they can never drift; strict `>` cursor comparison; uncapped `unseen_count`; list cap 500 DESC; `GREATEST(COALESCE(...), LEAST(posted, m.max_id))` with the `m.max_id IS NOT NULL` empty-window guard; **no dismiss-all endpoint** (DESC list always contains the newest event, so seen-through-max-listed-id clears all — #2013 contract). Unlike thesis-changes there is NO Python materiality pass: every event row is material by construction (the scan's arm/baseline machine only fires from `armed`), so this is a pure SQL event log. `source_text` comes via INNER join to `thesis_break_predicates` (composite FK guarantees the row).
- **`ThesisDetail.break_predicates`** (latest + history paths — sibling-model rule) — index-aligned with `break_conditions_json`; LEFT JOIN to the at-most-one event row supplies `fired_at`/`observed_value`. POST-generation payloads leave it empty (fresh thesis is unscanned — honest).
- **FE** — `AlertsStrip` BREAK card (per-instrument grouped ×N like RE-THESIS, informational tier, verbatim condition + `observed X (threshold > Y) · re-thesis queued` evidence line, participates in unseen/overflow/mark-all-read/dismiss accounting); `ThesisPane` break-condition rows now carry predicate chips — `armed`/`pending` muted, `fired` amber with evidence tooltip, `already_true` → muted `premise` chip with "Writer premise, not a trigger" tooltip, `already_true_after_gap` → distinct `premise (gap)` chip (the two premise states are never merged in any surface — spec acceptance rule). Prose conditions (no predicate row) render bare, as before.

## Why a break card when RE-THESIS exists

A break is a TRIGGER, not a verdict (#2012 Design 1): the event queues a regeneration via the `break_fired` stale rule, and #2013's RE-THESIS card carries the outcome. This card tells the operator *why* the regen was queued, with the machine-checked evidence.

## Fix-in-scope (pre-existing test rot)

`tests/test_api_theses.py` was broken on main since #2013: the mock connection raised `StopIteration` when the diff-predecessor query outgrew the supplied result sets (db-marked file, never re-run). Fixed by making the exhausted iterator yield empty sets (ancillary read-path lookups default honest-empty; tests that care supply sets in order). Also widened three 6-tuple `find_stale_instruments` fixtures predating PR-A's `break_fired` column (row[6]) in this file + `test_api_alerts.py`.

## Security model

Both new endpoints sit on the existing `/alerts` router with `require_session_or_service_token` (router-level dependency — same auth as the five sibling feeds). Operator resolution via `sole_operator_id` (503/501 contract shared with siblings). All SQL parameterised; the only f-string interpolation is the module-level constant window fragment (same pattern as `_RANK_MOVE_WHERE`). `ThesisDetail.break_predicates` rides the already-authed theses router. No new write paths beyond the operator's own cursor column.

## Codex ckpt-2 disposition

- Backend cursor semantics / SQL: **no findings**.
- "Break feed participates in strip dismiss-all, violating no-dismiss-all" — **REBUTTED**: #2051 specifies `dismiss = seen-through-max-listed-id`, the verbatim #2013 contract; "no dismiss-all" means no backend endpoint, not exclusion from the strip action (the DESC list's max id is the window max, and the confirm dialog discloses the hidden count).
- "Overflow confirm copy points only at /recommendations" — **FIXED be02433e**: copy now names /theses for thesis alerts.

## Verification

- `uv run ruff check` / `ruff format --check` / `pyright` — clean, 0 errors.
- Fast tier `-m "not db"`: 5,186 passed. Smoke: 153 passed.
- Targeted db files: `tests/test_api_alerts.py` + `tests/test_api_theses.py` — 119 passed (includes the real-DB integration tier for the sibling feeds; sql/231 applies cleanly).
- FE: `typecheck` clean; `test:unit` 1,358 passed (new: 4 BREAK-card strip tests, 4 ThesisPane predicate-chip tests, cursor fixture).
- Day-one data note: dev has 0 break events (spec-predicted — feed honestly empty until a genuine false→true transition). Post-merge FE-QA with a seeded fixture event + /theses `break` stale-chip exercise (owed from PR-A) will be recorded on this PR before the issue is considered operationally closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
