### PR TITLE
fix(#2052): thesis audit scans own lanes + lane_busy skip telemetry

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -62,7 +62,7 @@ from app.db.background_write import background_write_connection
 from app.jobs.background_pool import BackgroundConnectionPool
 from app.jobs.locks import JobAlreadyRunning, JobLock
 from app.jobs.sources import JobInvoker
-from app.services.ops_monitor import fetch_latest_successful_runs, record_job_skip
+from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX, fetch_latest_successful_runs, record_job_skip
 from app.services.process_stop import acquire_prelude_lock
 from app.services.processes.bootstrap_gate import check_bootstrap_state_gate
 from app.services.processes.param_metadata import (
@@ -654,6 +654,40 @@ def _lane_backoff_for(job_name: str) -> tuple[float, ...]:
     return _LANE_BUSY_RETRY_BACKOFF
 
 
+def _record_lane_busy_skip(
+    database_url: str,
+    job_name: str,
+    detail: str,
+    params: Mapping[str, Any] | None,
+) -> None:
+    """Best-effort ``status='skipped'`` job_runs row for a lane-busy skip (#2052).
+
+    Pre-#2052 both lane-busy exits in ``_fire_scheduled_with_lane_retry`` were
+    log-only — the ONLY silent skips on the scheduled-fire path (param/gate/
+    prereq blocks all write rows). ``thesis_dq_audit`` starved every night with
+    zero trace (#1707 class made worse by an unbounded db-lane holder). The
+    reason carries the machine-checkable ``LANE_BUSY_SKIP_PREFIX`` so the
+    Processes adapter can EXCLUDE these rows from the ``expected_fire_at``
+    anchor — a lane-busy skip is "work was due, couldn't start", and must not
+    reset the schedule-missed clock the way a benign prereq skip does.
+
+    Never raises: a telemetry write must not replace the skip's normal return
+    path (same posture as ``_wrap_invoker``'s param-validation skip writer).
+    Written only when the body never ran — outside any ``_tracked_job``
+    (prevention-log L848).
+    """
+    try:
+        with psycopg.connect(database_url, autocommit=True) as conn:
+            record_job_skip(
+                conn,
+                job_name,
+                LANE_BUSY_SKIP_PREFIX + detail,
+                params_snapshot=dict(params) if params is not None else None,
+            )
+    except Exception:
+        logger.exception("failed to record lane-busy skip for %r", job_name)
+
+
 def _fire_scheduled_with_lane_retry(
     database_url: str,
     job_name: str,
@@ -661,6 +695,7 @@ def _fire_scheduled_with_lane_retry(
     *,
     backoff: tuple[float, ...] = _LANE_BUSY_RETRY_BACKOFF,
     sleep: Callable[[float], None] = time.sleep,
+    params: Mapping[str, Any] | None = None,
 ) -> None:
     """Run a scheduled fire under its source-level ``JobLock``, retrying ONLY a
     failed lock ACQUIRE on lane contention (#1538).
@@ -679,9 +714,12 @@ def _fire_scheduled_with_lane_retry(
       * Worst case (lane held longer than the retry window, or no slot free) is
         the old skip exactly — no new failure mode.
 
-    Returns normally on a lane-contention skip (after logging). Propagates
+    Returns normally on a lane-contention skip — after logging AND a
+    best-effort ``lane_busy`` skip row (#2052; both skip exits were previously
+    the only silent skips on the scheduled path). Propagates
     ``JobAlreadyRunning`` ONLY when ``run`` itself raised it (body-origin), plus
     any exception ``run`` raises — the caller's existing handlers own those.
+    ``params`` is only used for the skip row's ``params_snapshot``.
     """
     slot_held = False
     try:
@@ -698,23 +736,20 @@ def _fire_scheduled_with_lane_retry(
                     raise
                 if attempt == 0:
                     if not _LANE_WAIT_SLOTS.acquire(blocking=False):
-                        logger.info(
-                            "scheduled fire of %r skipped: its lane is busy and all %d "
-                            "lane-retry slots are in use; will fire next cadence",
-                            job_name,
-                            _MAX_CONCURRENT_LANE_WAITERS,
+                        detail = (
+                            f"lane is busy and all {_MAX_CONCURRENT_LANE_WAITERS} "
+                            "lane-retry slots are in use; will fire next cadence"
                         )
+                        logger.info("scheduled fire of %r skipped: %s", job_name, detail)
+                        _record_lane_busy_skip(database_url, job_name, detail, params)
                         return
                     slot_held = True
                 if attempt < len(backoff):
                     sleep(backoff[attempt])
                     continue
-                logger.info(
-                    "scheduled fire of %r skipped: its lane stayed busy through the "
-                    "~%.2fs retry window; will fire next cadence",
-                    job_name,
-                    sum(backoff),
-                )
+                detail = f"lane stayed busy through the ~{sum(backoff):.2f}s retry window; will fire next cadence"
+                logger.info("scheduled fire of %r skipped: %s", job_name, detail)
+                _record_lane_busy_skip(database_url, job_name, detail, params)
                 return
     finally:
         if slot_held:
@@ -2083,6 +2118,7 @@ class JobRuntime:
                     job_name,
                     _run_scheduled_body,
                     backoff=_lane_backoff_for(job_name),
+                    params=params,
                 )
             except JobAlreadyRunning:
                 # The helper retries the ACQUIRE, so this is reached ONLY when

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -84,6 +84,8 @@ Lane = Literal[
     "db_ownership_obs",
     "db_raw_sweep",
     "db_size_sample",
+    "db_thesis_dq",
+    "db_thesis_break",
     "llm_thesis",
     "risk_metrics",
     "fair_value_band",
@@ -273,6 +275,23 @@ when one overruns). Scheduled-only, so NOT added to the
   for a once-daily job. Write-disjoint: sole writer of ``pg_size_sample``, no
   other job touches it. Scheduled-only, so NOT added to the
   ``bootstrap_stages.lane`` CHECK (matches ``db_liveness`` / ``db_raw_sweep``).
+
+* ``db_thesis_dq`` / ``db_thesis_break`` — ``thesis_dq_audit`` (daily 05:12,
+  #2014) and ``thesis_break_scan`` (daily 05:22, #2012), one single-job lane
+  each (#2052). Both sat on the catch-all ``db`` lane, whose 02:30
+  ``fundamentals_sync`` held the lock 6-11h+ FOUR consecutive nights
+  (07-13→07-16, released only by the next daemon restart) — the #1526/#1527
+  starvation class with an unbounded holder: ``thesis_dq_audit`` had ZERO
+  scheduled fires ever. SEPARATE lanes, not one shared audit lane (the
+  ``db_liveness``/``db_retry`` lesson above): boot catch-up and manual
+  triggers co-fire them despite the 05:12/05:22 stagger. Write-disjointness:
+  ``thesis_dq_audit`` is read-only (writes only ``job_runs``);
+  ``thesis_break_scan`` is the SOLE writer of ``thesis_break_predicates`` +
+  ``thesis_break_events`` (full-census 2026-07-16 — 3 write sites, all in
+  ``app/services/thesis_break_scan.py``; the ``break_fired`` stale-mark is a
+  read-side EXISTS in ``app/services/thesis.py``, not a write). Scheduled-only,
+  so NOT added to the ``bootstrap_stages.lane`` CHECK (matches
+  ``db_liveness`` / ``db_retry`` / ``db_size_sample``).
 
 * ``llm_thesis`` — ``thesis_refresh`` (#1919 PR-B) only. Hourly LLM
   thesis generation: a batch of ≤5 local-LLM generations holds the lane

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -31,7 +31,7 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal
 
 import psycopg
 import psycopg.rows
@@ -568,6 +568,17 @@ def reap_orphaned_job_runs(
             {"a": attempt, "n": next_retry_at, "id": int(run_id)},
         )
     return len(reaped)
+
+
+# #2052 — machine-checkable reason prefix for a scheduled fire skipped because
+# its lane stayed busy (``_fire_scheduled_with_lane_retry`` exhausted its
+# acquire-retry window, or no waiter slot was free). Delimiter included so a
+# future ``lane_busyX`` reason can never be misclassified. Consumed by the
+# writer (``app/jobs/runtime.py``) and by the ``expected_fire_at`` anchor
+# exclusion in ``app/services/processes/scheduled_adapter.py`` — a lane-busy
+# skip means "work was due, couldn't start", so unlike prereq/gate skips it
+# must NOT reset the schedule-missed clock.
+LANE_BUSY_SKIP_PREFIX: Final[str] = "lane_busy: "
 
 
 def record_job_skip(

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -34,6 +34,7 @@ import psycopg.rows
 
 from app.services.data_freshness import cadence_for
 from app.services.job_liveness import cadence_period
+from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX
 from app.services.processes import (
     ActiveRunSummary,
     ErrorClassSummary,
@@ -299,6 +300,47 @@ def _read_latest_terminal_run(conn: psycopg.Connection[Any], *, job_name: str) -
     # keyed on ``run_id``.
     row["terminal_kind"] = "job_run"
     return row
+
+
+def _is_lane_busy_skip(row: dict[str, Any] | None) -> bool:
+    """True when *row* is a ``lane_busy`` skip (#2052).
+
+    A lane-busy skip means "work was due, couldn't start" — unlike a benign
+    prereq/gate skip it must NOT anchor the ``expected_fire_at`` clock, or a
+    permanently-starved job would read green forever (each nightly skip row
+    resetting the schedule-missed threshold).
+    """
+    return (
+        row is not None
+        and row.get("status") == "skipped"
+        and str(row.get("error_msg") or "").startswith(LANE_BUSY_SKIP_PREFIX)
+    )
+
+
+def _read_latest_anchor_terminal_run(conn: psycopg.Connection[Any], *, job_name: str) -> dict[str, Any] | None:
+    """Latest terminal run eligible to anchor ``expected_fire_at`` (#2052).
+
+    Same population as ``_read_latest_terminal_run`` MINUS ``lane_busy`` skip
+    rows. Deliberately a SECOND resolver: the unfiltered latest terminal keeps
+    driving ``last_run`` / the status pill / the retry+cancel look-throughs,
+    and this one is only consulted when the latest terminal IS a lane-busy
+    skip (the rare starved path), so the extra query costs nothing on the
+    steady-state path. Only the columns the anchor math reads are selected.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT run_id, started_at, finished_at, status
+              FROM job_runs
+             WHERE job_name = %(name)s
+               AND status   IN ('success', 'failure', 'skipped', 'cancelled')
+               AND NOT (status = 'skipped' AND error_msg LIKE %(lane_busy_pat)s)
+             ORDER BY started_at DESC
+             LIMIT 1
+            """,
+            {"name": job_name, "lane_busy_pat": LANE_BUSY_SKIP_PREFIX + "%"},
+        )
+        return cur.fetchone()
 
 
 # #1474 Part 2 — orchestrator-driven jobs record completions in
@@ -855,13 +897,28 @@ def _build_row(
     # next fire from compute_next_run(cadence, now), so it could never
     # satisfy ``< now - threshold`` and the rule was unreachable.
     expected_fire_at: datetime | None = None
-    if terminal_row is not None and terminal_row.get("started_at") is not None:
+    # #2052 — a ``lane_busy`` skip must not anchor the overdue clock ("work
+    # was due, couldn't start" is not a completed cycle). When the latest
+    # terminal is one, re-resolve the anchor from the latest NON-lane-busy
+    # terminal; when the ENTIRE history is lane-busy skips, fall back to the
+    # persisted ``job_first_seen`` anchor (#1508 C6 — the ``terminal_row is
+    # None`` never-started path below cannot arm here because the skip rows
+    # make ``terminal_row`` non-null). Benign skips (prereq/gate) still
+    # anchor exactly as before.
+    anchor_row = terminal_row
+    if _is_lane_busy_skip(terminal_row) and terminal_row is not None and terminal_row.get("terminal_kind") == "job_run":
+        anchor_row = _read_latest_anchor_terminal_run(conn, job_name=job.name)
+        if anchor_row is None:
+            first_seen = _job_first_seen(conn, job_name=job.name)
+            if first_seen is not None:
+                expected_fire_at = compute_next_run(job.cadence, first_seen)
+    if anchor_row is not None and anchor_row.get("started_at") is not None:
         # C1 (#1508): anchor on the LATER of started_at / finished_at so a
         # run that just completed resets the overdue clock — a long run that
         # finishes after a nominal slot must not read overdue the instant it
         # ends.
-        anchor = terminal_row["started_at"]
-        finished = terminal_row.get("finished_at")
+        anchor = anchor_row["started_at"]
+        finished = anchor_row.get("finished_at")
         if finished is not None and finished > anchor:
             anchor = finished
         expected_fire_at = compute_next_run(job.cadence, anchor)

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -819,7 +819,12 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_THESIS_DQ_AUDIT,
         display_name="Thesis DQ audit",
-        source="db",
+        # #2052 — own single-job lane. On the catch-all ``db`` lane the 02:30
+        # fundamentals_sync held the lock 6-11h+ nightly (released only by the
+        # next daemon restart) and this job had ZERO scheduled fires ever —
+        # the patient acquire-retry window (~11.5s) is no match for an
+        # hours-long holder. Read-only body → write-disjoint by construction.
+        source="db_thesis_dq",
         description=(
             "Nightly full-population DQ scan of the latest stored thesis "
             "per instrument (#2014): target ordering, buy-zone sanity, "
@@ -829,9 +834,9 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "auto-regen). row_count = total violations."
         ),
         # 05:12 UTC — after the 02:30 fundamentals_sync + 03:30 ownership
-        # repair window; NOT 5-min-aligned (orchestrator_high_frequency_sync
-        # shares the db lane and fires on the :00/:05 grid — an aligned slot
-        # silently loses the lane-acquire race every night, #1707 class).
+        # repair window so the scan reads the freshest nightly data (the slot
+        # is data-readiness, not lane-contention: since #2052 the job owns its
+        # lane and no longer races the db-lane holders).
         cadence=Cadence.daily(hour=5, minute=12),
         # A missed night is re-covered next night; nothing accumulates.
         catch_up_on_boot=False,
@@ -840,7 +845,12 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
     ScheduledJob(
         name=JOB_THESIS_BREAK_SCAN,
         display_name="Thesis break scan",
-        source="db",
+        # #2052 — own single-job lane (same starvation as thesis_dq_audit;
+        # SEPARATE lane, not shared with it — boot catch-up / manual triggers
+        # co-fire the two scans despite the 05:12/05:22 stagger, the
+        # db_liveness/db_retry #1526 lesson). Sole writer of the
+        # thesis_break_* tables; see app/jobs/sources.py::Lane.
+        source="db_thesis_break",
         description=(
             "Nightly evaluation of machine-checkable thesis break "
             "predicates (#2012): extract closed-vocabulary predicates "
@@ -850,10 +860,9 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "mark the thesis stale (break_fired) for the existing "
             "thesis_refresh drain. row_count = events emitted."
         ),
-        # 05:22 UTC — same reasoning as thesis_dq_audit's 05:12 slot
-        # (post-fundamentals window, NOT 5-min-aligned per the #1707
-        # tick-race), offset so the two nightly thesis scans never
-        # contend for the db lane at the same minute.
+        # 05:22 UTC — same post-fundamentals data-readiness window as
+        # thesis_dq_audit's 05:12 slot; the stagger is layout hygiene only
+        # since #2052 (each scan owns its lane, so they cannot contend).
         cadence=Cadence.daily(hour=5, minute=22),
         # A missed night is re-covered next night; nothing accumulates.
         catch_up_on_boot=False,

--- a/docs/proposals/ops/2026-07-16-audit-lane-starvation.md
+++ b/docs/proposals/ops/2026-07-16-audit-lane-starvation.md
@@ -1,0 +1,155 @@
+# #2052 — nightly thesis audit scans starved on the db lane: own lanes + lane-skip telemetry
+
+Status: spec (pre-implementation)
+Issue: #2052. Related: #2014 (dq audit), #2012 (break scan), #1707/#1710 (silent daily skip class), #1594 (single-job lane precedent), #1538 (lane-acquire retry), #1526/#1527 (shared-lane starvation lessons).
+
+## Problem
+
+`thesis_dq_audit` (daily 05:12, lane `db`) and `thesis_break_scan` (daily 05:22, lane `db`)
+share the `db` lane with `fundamentals_sync` (daily 02:30), whose run has ended
+`orphaned: reaped at boot` 4/4 nights (07-13→07-16, 6.1h/10.9h/10.0h/8.6h holds — thesis
+cascade LLM calls dominate; each "duration" is start→daemon-restart-reap). The db lane is
+held from 02:30 until the next operator daemon restart, so both 05:1x/05:2x audit slots are
+starved every night.
+
+Fire path: `app/jobs/runtime.py::_wrap_invoker` → `_fire_scheduled_with_lane_retry`
+(`runtime.py:657`) retries the `JobLock` acquire (`app/jobs/locks.py::JobLock.__enter__`,
+`pg_try_advisory_lock(hashtext('job_source:db'))`) under the daily "patient" backoff —
+`_LANE_BACKOFF_DAILY_PATIENT ≈ 11.5s` (`runtime.py:635`) — then **returns with only a log
+line** (`runtime.py:700-718`). No `job_runs` row. The three earlier gates in the same path
+(param validation, bootstrap gate, prereq) all write `status='skipped'` rows; the lane-busy
+exits are the only silent ones.
+
+Full-population verification (dev DB, re-runnable):
+
+```sql
+SELECT job_name, status, started_at, finished_at, row_count, left(error_msg, 80)
+  FROM job_runs
+ WHERE job_name IN ('thesis_dq_audit', 'thesis_break_scan')
+ ORDER BY started_at;          -- ALL-TIME: 1 row total (break_scan manual 07-16 11:10)
+
+SELECT status, started_at, finished_at,
+       round(extract(epoch FROM (finished_at - started_at)) / 3600, 1) AS hours
+  FROM job_runs
+ WHERE job_name = 'fundamentals_sync' AND started_at > now() - interval '4 days'
+ ORDER BY started_at;          -- 4/4 nights failure, 6.1/10.9/10.0/8.6h, orphaned-reap
+```
+
+`thesis_dq_audit`: zero scheduled fires ever (2 registered nights, both silently skipped).
+`thesis_break_scan`: zero scheduled attempts yet (registered 07-16 11:08, first slot
+tonight); its one success row 07-16 11:10 is the operator's manual verification run.
+Evidence tables also on #2052.
+
+## Decision (option 1 + 3 from the issue, plus a verdict-integrity guard)
+
+### 1. Two single-job lanes (option 1)
+
+- `db_thesis_dq` — `thesis_dq_audit` only.
+- `db_thesis_break` — `thesis_break_scan` only.
+
+SEPARATE lanes, not one shared audit lane — the #1526 lesson (pinned in
+`app/jobs/sources.py` at the `db_liveness`/`db_retry` entry): a shared lane recreates
+starvation between its members when they co-fire, and boot catch-up / manual triggers DO
+co-fire them despite the 05:12/05:22 stagger.
+
+Write-disjointness (a lane is a job-overlap bucket, not a rate limiter):
+
+- `thesis_dq_audit` is read-only (`compute_thesis_dq_report`) — writes only `job_runs`
+  via `_tracked_job`. MVCC-safe vs every thesis writer.
+- `thesis_break_scan` writes `thesis_break_predicates` + `thesis_break_events` ONLY
+  (+ `job_runs`). Full-population writer census (2026-07-16):
+  `grep -rn "thesis_break_predicates|thesis_break_events" app/ | grep -iE "insert|update|delete"`
+  → 3 write sites, all in `app/services/thesis_break_scan.py`. The `break_fired`
+  stale-mark is NOT a write — `app/services/thesis.py:298` derives it read-side via
+  `EXISTS (thesis_break_events…)`. Source rule: #2012 design
+  (`docs/proposals/thesis/2026-07-16-thesis-break-predicates.md`, Design 1) +
+  `sql/230_thesis_break_predicates.sql` — `UNIQUE (thesis_id, predicate_index)` on
+  predicates and the events table's composite FK onto it make concurrent same-key writes
+  impossible to corrupt; the only other invocation path is the manual trigger of the SAME
+  job_name, which serialises on the same lane.
+
+Scheduled-only jobs → lanes NOT added to the `bootstrap_stages.lane` CHECK (precedent:
+`db_liveness` / `db_retry` / `db_positions` / `db_size_sample`).
+
+Settled-decisions check: #1064 (same-source serialise via one JobLock) preserved — this
+changes lane membership, the mechanism is untouched. #1594 single-job-lane precedent
+followed. No EXIT/execution-guard surface.
+
+### 2. Lane-busy skip telemetry (option 3)
+
+`_fire_scheduled_with_lane_retry` gains a best-effort skip-row write at BOTH silent exits
+(no-free-slot immediate skip; backoff-window exhausted). Row shape: existing
+`record_job_skip` (`app/services/ops_monitor.py:573`) — `status='skipped'`,
+`error_msg = "lane_busy: <detail>"`, `params_snapshot` threaded from the wrapped fire.
+Machine-checkable, delimiter-stable prefix constant `LANE_BUSY_SKIP_PREFIX = "lane_busy: "`
+(colon+space included, so a future `lane_busyX` reason can never be misclassified)
+exported from `app/services/ops_monitor.py` (single source of truth; consumed by the
+writer and the adapter below). Write failures are logged, never raised (same posture as the existing
+param-validation skip writer, `runtime.py:1953`). Prevention-log L848 honoured: the row is
+written only when the body never ran, outside any `_tracked_job`.
+
+### 3. Verdict-integrity guard (required by 2, else it green-washes)
+
+`app/services/processes/scheduled_adapter.py` anchors `expected_fire_at` on the latest
+TERMINAL run (`max(started_at, finished_at)`, line ~859) and `schedule_missed` fires only
+when that anchor is >1 full cadence overdue (`stale_detection.py:134-148`). A `skipped`
+row is terminal — so a nightly `lane_busy` skip row would reset the schedule-missed clock
+every night and render a permanently-starved job GREEN ("idle"/current). That inverts the
+telemetry's purpose.
+
+Fix (shape per Codex ckpt-1): a SECOND resolver, `_read_latest_anchor_terminal_run` —
+the latest terminal run that is NOT (`status='skipped'` AND `error_msg` starting with
+`LANE_BUSY_SKIP_PREFIX`). `_read_latest_terminal_run` is UNTOUCHED — it keeps driving
+`last_run`, the status pill, and the retry/cancel look-throughs. Only the
+`expected_fire_at` computation switches to the anchor resolver. Explicit fallback: when
+the anchor resolver returns no row while `terminal_row` is non-null (entire history is
+lane-busy skips — the existing `terminal_row is None` / never-started path at
+`scheduled_adapter.py:915` cannot arm because skip rows make `terminal_row` non-null),
+anchor on the persisted `job_first_seen` row (#1508 C6) so `schedule_missed` still arms.
+
+Rationale for class-based split: prereq/gate skips mean "decided the work needn't/mustn't
+run" (a completed decision — legitimate clock reset; e.g. `retry_deferred_recommendations`
+skips every cadence benignly). Lane-busy skips mean "work was due, couldn't start" — not a
+completed cycle, must not reset the miss clock.
+
+## Non-goals
+
+- Fixing `fundamentals_sync`'s multi-hour LLM-cascade hold (upstream disease; issue notes
+  it; the audit lanes remove its blast radius on these two jobs).
+- Reslotting (option 2) — fragile against a holder whose release time is "next daemon
+  restart"; superseded by option 1.
+- Touching `catch_up_on_boot=False` on the audit jobs — "re-covered next night" becomes
+  true once the lane is private.
+
+## Changes
+
+| file | change |
+| --- | --- |
+| `app/jobs/sources.py` | `Lane` literal + docstring entries for `db_thesis_dq`, `db_thesis_break` |
+| `app/workers/scheduler.py` | the two `ScheduledJob.source` values + slot-comment updates |
+| `app/jobs/runtime.py` | `_fire_scheduled_with_lane_retry`: optional `params` kwarg + `_record_lane_busy_skip` best-effort writer at both skip exits; `_wrap_invoker` threads `params` |
+| `app/services/ops_monitor.py` | export `LANE_BUSY_SKIP_PREFIX` |
+| `app/services/processes/scheduled_adapter.py` | second resolver `_read_latest_anchor_terminal_run` + `job_first_seen` fallback; `_read_latest_terminal_run` untouched |
+| `tests/test_job_registry.py` | add both lanes to the `_ALLOWED_SOURCES` mirror (line 37) |
+| tests | see below |
+
+## Tests (fast tier, pure-logic where possible)
+
+- `tests/test_lane_busy_retry.py` — extend the existing fake-JobLock harness: skip row
+  recorded (monkeypatched writer) on window-exhausted AND no-slot exits, with the
+  `lane_busy` prefix + params passthrough; NOT recorded when the body runs or when the
+  body itself raises `JobAlreadyRunning`.
+- Lane registry: `source_for('thesis_dq_audit') == 'db_thesis_dq'`,
+  `source_for('thesis_break_scan') == 'db_thesis_break'` (pattern of existing registry
+  tests), and the two lanes are disjoint from the bootstrap lane set.
+- `scheduled_adapter` anchor: a lane-busy skip as latest terminal does NOT advance
+  `expected_fire_at` (anchors on prior success); all-lane-busy history falls back to
+  `job_first_seen`; a prereq skip STILL advances it (regression pin for today's benign
+  behaviour). One DB-backed test only if the anchor is SQL-side (per test-quality skill:
+  one integration test per new SQL mechanism).
+
+## Operator note
+
+Scheduler/lane changes are inert until the jobs daemon restarts (VS Code `stack: jobs`
+task shadows launchd — check `ps -o ppid`). After merge: restart the jobs task, then
+confirm tonight's 05:12/05:22 rows exist (success OR a visible `lane_busy` skip).

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -127,6 +127,15 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # per-instrument via the K.3 instrument_lock, not the lane. See
         # app/jobs/sources.py::Lane.
         "llm_thesis",
+        # #2052 — thesis_dq_audit + thesis_break_scan single-job lanes. On the
+        # catch-all ``db`` lane the 02:30 fundamentals_sync held the lock
+        # 6-11h+ nightly (released only by the next daemon restart) and the
+        # 05:12/05:22 audit slots silently starved (dq_audit: zero scheduled
+        # fires ever). SEPARATE lanes (the #1526 db_liveness/db_retry lesson):
+        # boot catch-up / manual triggers co-fire them despite the stagger.
+        # See app/jobs/sources.py::Lane.
+        "db_thesis_dq",
+        "db_thesis_break",
     }
 )
 
@@ -237,6 +246,10 @@ class TestSourceRegistry:
         # sec_bulk_download is a bootstrap-only invoker mapped to its
         # own source bucket per _STAGE_LANE_OVERRIDES.
         assert source_for("sec_bulk_download") == "sec_bulk_download"
+        # #2052 — the two nightly thesis audit scans own single-job lanes so
+        # the 02:30 fundamentals_sync db-lane hold can no longer starve them.
+        assert source_for("thesis_dq_audit") == "db_thesis_dq"
+        assert source_for("thesis_break_scan") == "db_thesis_break"
 
 
 class TestOrchestratorAdapterSourceCoverage:

--- a/tests/test_lane_busy_retry.py
+++ b/tests/test_lane_busy_retry.py
@@ -248,3 +248,124 @@ def test_patient_backoff_rides_out_a_hold_the_default_would_skip(
     assert patient_ran == [1]  # patient window rides out the hold and runs
     assert patient_state["enter"] == 5  # 4 failed acquires + 1 success
     assert _slots_available(fresh_slots) == runtime._MAX_CONCURRENT_LANE_WAITERS  # slot released
+
+
+# ---------------------------------------------------------------------------
+# #2052 — both lane-busy skip exits write a job_runs skip row (telemetry).
+# ---------------------------------------------------------------------------
+
+
+def test_exhaust_skip_records_lane_busy_row(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    state = {"enter": 0, "fail_n": 99}  # always busy
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    recorded: list[tuple[str, str, str, object]] = []
+    monkeypatch.setattr(
+        runtime,
+        "_record_lane_busy_skip",
+        lambda url, name, detail, params: recorded.append((url, name, detail, params)),
+    )
+
+    runtime._fire_scheduled_with_lane_retry(
+        "db://x", "job", lambda: None, backoff=_BACKOFF, sleep=lambda _s: None, params={"k": 1}
+    )
+
+    assert len(recorded) == 1
+    url, name, detail, params = recorded[0]
+    assert (url, name) == ("db://x", "job")
+    assert "retry window" in detail
+    assert params == {"k": 1}
+
+
+def test_no_slot_skip_records_lane_busy_row(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    for _ in range(runtime._MAX_CONCURRENT_LANE_WAITERS):
+        assert fresh_slots.acquire(blocking=False)
+    state = {"enter": 0, "fail_n": 99}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    recorded: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        runtime,
+        "_record_lane_busy_skip",
+        lambda _url, name, detail, _params: recorded.append((name, detail)),
+    )
+
+    runtime._fire_scheduled_with_lane_retry("db://x", "job", lambda: None, backoff=_BACKOFF, sleep=lambda _s: None)
+
+    assert len(recorded) == 1
+    assert "lane-retry slots" in recorded[0][1]
+
+
+def test_successful_run_records_no_skip_row(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    state = {"enter": 0, "fail_n": 1}  # one lost acquire, then runs
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    recorded: list[str] = []
+    monkeypatch.setattr(
+        runtime,
+        "_record_lane_busy_skip",
+        lambda _url, name, _detail, _params: recorded.append(name),
+    )
+
+    runtime._fire_scheduled_with_lane_retry("db://x", "job", lambda: None, backoff=_BACKOFF, sleep=lambda _s: None)
+
+    assert recorded == []
+
+
+def test_body_origin_job_already_running_records_no_skip_row(
+    monkeypatch: pytest.MonkeyPatch, fresh_slots: threading.BoundedSemaphore
+) -> None:
+    state = {"enter": 0, "fail_n": 0}
+    monkeypatch.setattr(runtime, "JobLock", _fake_joblock_factory(state))
+    recorded: list[str] = []
+    monkeypatch.setattr(
+        runtime,
+        "_record_lane_busy_skip",
+        lambda _url, name, _detail, _params: recorded.append(name),
+    )
+
+    def _body() -> None:
+        raise JobAlreadyRunning("body-origin")
+
+    with pytest.raises(JobAlreadyRunning):
+        runtime._fire_scheduled_with_lane_retry("db://x", "job", _body, backoff=_BACKOFF, sleep=lambda _s: None)
+
+    assert recorded == []
+
+
+def test_record_lane_busy_skip_composes_prefix_and_swallows_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The writer prepends the machine-checkable prefix and never raises."""
+    from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX
+
+    calls: list[tuple[str, str, dict[str, object] | None]] = []
+
+    class _FakeConn:
+        def __enter__(self) -> _FakeConn:
+            return self
+
+        def __exit__(self, *_exc: object) -> bool:
+            return False
+
+    def _fake_record(
+        conn: object, job_name: str, reason: str, *, params_snapshot: dict[str, object] | None = None
+    ) -> int:
+        calls.append((job_name, reason, params_snapshot))
+        return 1
+
+    monkeypatch.setattr(runtime.psycopg, "connect", lambda *_a, **_k: _FakeConn())
+    monkeypatch.setattr(runtime, "record_job_skip", _fake_record)
+
+    runtime._record_lane_busy_skip("db://x", "job", "lane stayed busy", {"p": 2})
+    assert calls == [("job", LANE_BUSY_SKIP_PREFIX + "lane stayed busy", {"p": 2})]
+
+    # Writer failure is logged, never raised.
+    def _boom(*_a: object, **_k: object) -> int:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(runtime, "record_job_skip", _boom)
+    runtime._record_lane_busy_skip("db://x", "job", "lane stayed busy", None)  # must not raise

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -11,6 +11,7 @@ import psycopg
 import pytest
 from psycopg.types.json import Jsonb
 
+from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX
 from app.services.processes import scheduled_adapter
 from app.services.processes.param_metadata import ParamMetadata
 from app.workers.scheduler import JOB_FUNDAMENTALS_SYNC, JOB_RETRY_DEFERRED
@@ -928,3 +929,109 @@ def test_source_watermark_fresh_false_for_job_without_source(
     row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
     assert row is not None
     assert row.source_watermark_fresh is False
+
+
+# ---------------------------------------------------------------------------
+# #2052 — lane_busy skips must not reset the schedule-missed anchor.
+# ---------------------------------------------------------------------------
+
+
+def _insert_skip(
+    conn: psycopg.Connection[tuple],
+    *,
+    job_name: str,
+    error_msg: str,
+    age: str = "1 minute",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status, row_count, error_msg)
+        VALUES (%(n)s, now() - %(age)s::interval, now() - %(age)s::interval, 'skipped', 0, %(msg)s)
+        """,
+        {"n": job_name, "age": age, "msg": error_msg},
+    )
+
+
+def test_lane_busy_skip_does_not_reset_schedule_missed_anchor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A fresh ``lane_busy`` skip row must NOT green-wash a starved job: the
+    ``expected_fire_at`` anchor comes from the latest NON-lane-busy terminal
+    (the 2h-old success), so schedule_missed still surfaces. The status pill
+    keeps reading the true latest terminal (idle)."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status)
+        VALUES (%s, now() - interval '2 hours',
+                now() - interval '2 hours' + interval '30 seconds', 'success')
+        """,
+        (JOB_RETRY_DEFERRED,),
+    )
+    _insert_skip(
+        ebull_test_conn,
+        job_name=JOB_RETRY_DEFERRED,
+        error_msg=LANE_BUSY_SKIP_PREFIX + "lane stayed busy through the ~11.50s retry window",
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
+    assert row is not None
+    assert "schedule_missed" in row.stale_reasons
+    assert row.status == "idle"  # pill still reflects the true latest terminal
+    assert row.last_run is not None
+    assert row.last_run.status == "skipped"
+
+
+def test_all_lane_busy_history_falls_back_to_first_seen_anchor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """A job whose ENTIRE history is lane_busy skips anchors on the persisted
+    ``job_first_seen`` row (#1508 C6 anchor) — the never-started path cannot
+    arm because the skip rows make the terminal row non-null."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_first_seen (job_name, first_seen)
+        VALUES (%s, now() - interval '2 hours')
+        ON CONFLICT (job_name) DO UPDATE SET first_seen = now() - interval '2 hours'
+        """,
+        (JOB_RETRY_DEFERRED,),
+    )
+    _insert_skip(
+        ebull_test_conn,
+        job_name=JOB_RETRY_DEFERRED,
+        error_msg=LANE_BUSY_SKIP_PREFIX + "lane is busy and all 3 lane-retry slots are in use",
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
+    assert row is not None
+    assert "schedule_missed" in row.stale_reasons
+
+
+def test_prereq_skip_still_resets_schedule_missed_anchor(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Regression pin for today's benign behaviour: a prereq/gate skip means
+    "decided the work needn't run" and DOES reset the overdue clock (e.g.
+    retry_deferred_recommendations skips every cadence benignly)."""
+    _ensure_kill_switch_off(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status)
+        VALUES (%s, now() - interval '2 hours',
+                now() - interval '2 hours' + interval '30 seconds', 'success')
+        """,
+        (JOB_RETRY_DEFERRED,),
+    )
+    _insert_skip(
+        ebull_test_conn,
+        job_name=JOB_RETRY_DEFERRED,
+        error_msg="no timing_deferred BUY/ADD recommendations",
+    )
+    ebull_test_conn.commit()
+
+    row = scheduled_adapter.get_row(ebull_test_conn, process_id=JOB_RETRY_DEFERRED)
+    assert row is not None
+    assert "schedule_missed" not in row.stale_reasons


### PR DESCRIPTION
Closes #2052.

## What

Fixes #2052 nightly audit-scan starvation three ways (spec: `docs/proposals/ops/2026-07-16-audit-lane-starvation.md`, Codex ckpt-1 reviewed, all 6 findings addressed):

1. **Own single-job lanes** — `thesis_dq_audit` → `db_thesis_dq`, `thesis_break_scan` → `db_thesis_break`. On the catch-all `db` lane, the 02:30 `fundamentals_sync` held the advisory lock 6-11h+ four consecutive nights (released only by the next daemon restart); `thesis_dq_audit` had ZERO scheduled fires ever. SEPARATE lanes, not one shared audit lane — the #1526 `db_liveness`/`db_retry` lesson: boot catch-up and manual triggers co-fire the two scans despite the 05:12/05:22 stagger.
2. **Lane-busy skip telemetry** — both silent exits in `_fire_scheduled_with_lane_retry` (no-free-slot; backoff-window exhausted) now write a `status='skipped'` `job_runs` row with machine-checkable prefix `lane_busy: ` (`LANE_BUSY_SKIP_PREFIX`, exported from `ops_monitor`). Best-effort (never raises), written only when the body never ran — outside any `_tracked_job` (prevention-log L848). These were the ONLY skip paths on the scheduled fire path writing nothing (param/gate/prereq blocks all write rows).
3. **Verdict-integrity guard** — the Processes adapter's `expected_fire_at` anchors on the latest TERMINAL run, and `skipped` is terminal: a nightly `lane_busy` row would reset the schedule-missed clock and render a permanently starved job GREEN. New second resolver `_read_latest_anchor_terminal_run` excludes lane-busy skips from the anchor (unfiltered `_read_latest_terminal_run` still drives `last_run`/status pill/cancel look-throughs); when the ENTIRE history is lane-busy skips, falls back to the persisted `job_first_seen` anchor (#1508 C6). Benign prereq/gate skips anchor exactly as before (regression-pinned).

## Security model

No new external surface. Changes touch job scheduling (`app/jobs/runtime.py`, `app/jobs/sources.py`, `app/workers/scheduler.py`), ops telemetry write (`job_runs` INSERT via existing `record_job_skip`, parameterised), and the read-only admin Processes adapter. No user-controlled input reaches SQL: the LIKE pattern is a code constant. Trade path untouched; no execution-guard/EXIT surface.

## Write-disjointness (lane safety)

- `thesis_dq_audit`: read-only body; writes only `job_runs`.
- `thesis_break_scan`: sole writer of `thesis_break_predicates` + `thesis_break_events` — full census 2026-07-16: 3 write sites, all in `app/services/thesis_break_scan.py`; `break_fired` is a read-side `EXISTS` in `app/services/thesis.py:298`, not a write. Constraint shape: sql/230 `UNIQUE (thesis_id, predicate_index)` + composite FK.

Lanes are scheduled-only → NOT added to the `bootstrap_stages.lane` CHECK (precedent: `db_liveness`/`db_retry`/`db_size_sample`). No migration.

## Evidence (full population, dev)

`job_runs` all-time: `thesis_dq_audit` 0 scheduled fires (2 registered nights, both silently lane-skipped); `fundamentals_sync` 4/4 nights `orphaned: reaped at boot` (6.1h/10.9h/10.0h/8.6h, start→reap). Day-3 tables + code-path confirmation on #2052.

## Tradeoffs

- `fundamentals_sync`'s multi-hour hold is untouched (upstream disease, noted on #2052) — this PR removes its blast radius on the audit scans and makes any future starvation visible.
- A lane-busy skip renders the status pill `idle` until the miss threshold (~2 cadences) — same de-noise posture as existing schedule_missed semantics; the skip row itself is immediately visible in the run history.

## Verification

- `ruff check` ✓, `ruff format --check` ✓, `pyright` 0 errors ✓
- Fast tier `pytest -m "not db"`: 5191 passed ✓; smoke: 132 passed ✓
- Targeted db tier `tests/test_scheduled_adapter.py`: 40 passed (incl. 3 new anchor tests: lane-busy skip does not reset schedule_missed; all-lane-busy history falls back to `job_first_seen`; prereq skip still resets — regression pin) ✓
- `tests/test_lane_busy_retry.py`: 5 new telemetry tests (both exits record; success/body-origin do not; prefix composition + error swallow) ✓
- Codex ckpt-1 on spec (6 findings fixed) + ckpt-2 on branch: no issues ✓

## Operator follow-up (after merge)

Restart the jobs daemon (VS Code `stack: jobs` task shadows launchd — `launchctl kickstart` is a NO-OP; check `ps -o ppid`). Then confirm tonight's 05:12/05:22 slots produce rows: success, or a visible `lane_busy: …` skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)