### PR TITLE
fix(#2050): EXIT rule 1 — drop tautologous break_conditions term

### DIFF
--- a/app/services/portfolio.py
+++ b/app/services/portfolio.py
@@ -604,22 +604,29 @@ def _evaluate_exit(
     Return (should_exit, reason).
 
     EXIT if any of:
-      1. break_conditions present AND max_red_flag >= EXIT_RED_FLAG_THRESHOLD
-         (thesis break / severe risk event)
+      1. max_red_flag >= EXIT_RED_FLAG_THRESHOLD (severe risk event)
       2. current_price >= thesis.base_value (valuation target achieved)
+
+    Rule 1 deliberately does NOT consult ``break_conditions_json`` (#2050):
+    the old ``break_conditions and …`` term was a tautology on the full
+    population (345/345 latest theses carry a non-empty array) whose only
+    reachable effect was DANGEROUS — a thesis with an empty/missing array and
+    a severe red flag would silently HOLD, gating the severe-risk exit on
+    memo formatting. ADD/BUY already apply the same threshold
+    unconditionally. Thesis BREAKS reach EXIT via regeneration, not here
+    (#2012 Design 1: break event → ``break_fired`` stale → thesis_refresh →
+    the regenerated stance/targets drive this evaluator).
     """
     thesis = details.get("thesis")
     if thesis is None:
         return False, ""
 
-    # Rule 1 — thesis break / severe red flag
+    # Rule 1 — severe risk event
     max_red_flag: float | None = details.get("max_red_flag")
-    break_conditions = thesis.get("break_conditions_json")
-    if break_conditions and max_red_flag is not None and max_red_flag >= EXIT_RED_FLAG_THRESHOLD:
+    if max_red_flag is not None and max_red_flag >= EXIT_RED_FLAG_THRESHOLD:
         return (
             True,
-            f"Thesis break triggered: max_red_flag={max_red_flag:.2f} "
-            f">= threshold={EXIT_RED_FLAG_THRESHOLD}; break conditions present",
+            f"Severe risk event: max_red_flag={max_red_flag:.2f} >= threshold={EXIT_RED_FLAG_THRESHOLD}",
         )
 
     # Rule 2 — valuation target achieved

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -100,7 +100,7 @@ class TestEvaluateExit:
         should_exit, _ = _evaluate_exit(pos, {}, current_price=150.0)
         assert should_exit is False
 
-    def test_break_conditions_with_high_red_flag_triggers_exit(self) -> None:
+    def test_high_red_flag_triggers_exit(self) -> None:
         pos = _pos()
         details: dict[str, Any] = {
             "thesis": _thesis(break_conditions_json=["Revenue declines >20%"]),
@@ -108,9 +108,24 @@ class TestEvaluateExit:
         }
         should_exit, reason = _evaluate_exit(pos, details, current_price=150.0)
         assert should_exit is True
-        assert "break" in reason.lower()
+        assert "risk" in reason.lower()
 
-    def test_break_conditions_below_threshold_no_exit(self) -> None:
+    def test_high_red_flag_triggers_exit_without_break_conditions(self) -> None:
+        """#2050 — the previously-dead edge: a severe red flag must EXIT even
+        when the thesis carries no break_conditions (the old tautologous
+        ``break_conditions and`` term silently HELD this case, gating the
+        severe-risk exit on memo formatting)."""
+        pos = _pos()
+        for bc in (None, []):
+            details: dict[str, Any] = {
+                "thesis": _thesis(break_conditions_json=bc),
+                "max_red_flag": EXIT_RED_FLAG_THRESHOLD,
+            }
+            should_exit, reason = _evaluate_exit(pos, details, current_price=150.0)
+            assert should_exit is True, f"break_conditions_json={bc!r} must not gate the severe-risk exit"
+            assert "risk" in reason.lower()
+
+    def test_red_flag_below_threshold_no_exit(self) -> None:
         pos = _pos()
         details: dict[str, Any] = {
             "thesis": _thesis(break_conditions_json=["Revenue declines >20%"]),
@@ -119,7 +134,7 @@ class TestEvaluateExit:
         should_exit, _ = _evaluate_exit(pos, details, current_price=150.0)
         assert should_exit is False
 
-    def test_break_conditions_no_red_flag_no_exit(self) -> None:
+    def test_no_red_flag_no_exit(self) -> None:
         pos = _pos()
         details: dict[str, Any] = {
             "thesis": _thesis(break_conditions_json=["Revenue declines >20%"]),
@@ -885,9 +900,11 @@ class TestRunPortfolioReview:
         recs = {r.instrument_id: r for r in result.recommendations}
         assert recs[1].action == "HOLD"
 
-    def test_exit_on_thesis_break(self) -> None:
+    def test_exit_on_severe_risk(self) -> None:
         """
-        Held position with break conditions and high red flag → EXIT.
+        Held position with a red flag at/above threshold → EXIT (#2050:
+        break_conditions no longer consulted; thesis breaks reach EXIT via
+        regeneration per #2012 Design 1).
         """
         cursors = [
             _make_cursor(
@@ -943,7 +960,7 @@ class TestRunPortfolioReview:
 
         recs = {r.instrument_id: r for r in result.recommendations}
         assert recs[1].action == "EXIT"
-        assert "break" in recs[1].rationale.lower()
+        assert "risk" in recs[1].rationale.lower()
 
     def test_hold_not_in_ranked_list(self) -> None:
         """


### PR DESCRIPTION
Closes #2050.

## What

Fixes #2050: `_evaluate_exit` rule 1 read `break_conditions and max_red_flag >= EXIT_RED_FLAG_THRESHOLD`. The first term is dropped; rule 1 is now the unconditional severe-risk check, reason string `"Severe risk event: …"`.

## Why option (a) (drop) and not option (b) (key to fired break events)

The issue offers both; the settled-decisions re-read it mandates decides it:

- **#2012 Design 1 (merged in #2049, yesterday) explicitly settles option (b) out**: "Break events are NOT wired to EXIT… break fires → thesis stale (`break_fired`) → `thesis_refresh` regenerates → the regenerated stance/targets drive the portfolio through the EXISTING EXIT path." Joining `thesis_break_events` into `_evaluate_exit` would reverse that merged design — and the #2012 evidence shows why it was settled that way (35 premise-conditions already true at arm; avoid-stance theses carry 22.1%-upside conditions: mechanical EXIT-on-fire exits on wrong signals).
- **settled-decisions "EXIT rule in portfolio manager"** (v1 EXIT for: thesis break / severe risk event / valuation target) stays fully honoured: thesis break reaches EXIT via regeneration, severe risk = rule 1, valuation target = rule 2.
- **The dropped term's only reachable effect was dangerous**: a thesis with an empty/missing `break_conditions_json` and a severe red flag would silently HOLD — the severe-risk exit was gated on memo formatting. Removal is fail-safe-direction.
- **Consistency**: ADD (`portfolio.py:681`) and BUY (`portfolio.py:795`) already apply `max_red_flag >= EXIT_RED_FLAG_THRESHOLD` unconditionally. EXIT was the only evaluator gating it.

## Full-population verification (dev, 2026-07-16)

- 345/345 latest theses (one per instrument) have non-empty `break_conditions_json` (0 NULL, 0 empty) — tautology re-confirmed on today's population, not the issue's 325 snapshot.
- All 5 held names (GME/IEP/BBBY/VOO/QQQ) have non-empty arrays (5/3/4/4/4) → **zero behaviour delta today** on the held population and the full population. The only behaviour change is the future empty-conditions edge, which now EXITs instead of silently holding.

## Security model / trade-path invariants

- `_evaluate_exit` produces recommendations only; the execution guard is untouched and consumes `recommendation_id` (re-evaluates internally per settled decisions — it parses neither `rationale` nor `break_conditions_json`; grep-verified zero hits). `decision_audit` coverage unchanged.
- EXIT-never-blocked guard invariants untouched (no guard files in diff).
- No SQL changes, no new inputs; reason string is display-only (`trade_recommendations.rationale`) — no consumer parses the old wording (repo-wide grep: only portfolio.py + its tests).

## Tests

- `test_high_red_flag_triggers_exit_without_break_conditions` — the previously-dead edge (None and `[]`), now EXITs.
- Renamed `test_exit_on_thesis_break` → `test_exit_on_severe_risk`, break-condition unit tests renamed to risk semantics (assert "risk" in reason).
- `pytest tests/test_portfolio.py`: 48 passed; fast tier: 5192 passed; smoke: 132 passed; ruff + format + pyright clean.
- Codex ckpt-2 on branch: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)