### PR TITLE
fix(#2005): value-note names thesis stance when targets absent, not '(no thesis)'

### DIFF
--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -531,6 +531,7 @@ def _value_score(
     pe_ratio: float | None = None,
     fcf_yield: float | None = None,
     price_target_mean: float | None = None,
+    thesis_stance: str | None = None,
 ) -> tuple[float, list[str]]:
     """
     Thesis valuation upside as the primary value proxy.
@@ -542,6 +543,11 @@ def _value_score(
     Fallback path (fundamentals-derived): when base_value is None.
       Blends up to three signals — P/E attractiveness (35%), FCF yield (35%),
       and price-target upside (30%) — re-normalised across available components.
+
+    ``thesis_stance`` is the latest thesis' stance when one exists (None = no
+    thesis row). A thesis may legitimately decline per-share targets (e.g. an
+    ``avoid`` stance), so the fallback note must not report it as absent
+    (#2005).
 
     Returns (score, missing_components).
     """
@@ -574,8 +580,16 @@ def _value_score(
         return _clip(score), notes
 
     # ----------------------------------------------------------------------
-    # Fallback path: fundamentals-derived (no thesis)
+    # Fallback path: fundamentals-derived (no thesis, or thesis without
+    # per-share targets)
     # ----------------------------------------------------------------------
+    fallback_note = (
+        "fundamentals fallback (no thesis)"
+        if thesis_stance is None
+        # "without targets", not "declined": legacy/DQ rows also carry null
+        # targets — absence of targets is the fact, intent is not observable.
+        else f"fundamentals fallback (thesis without targets, stance: {thesis_stance})"
+    )
     notes.append("base_value missing")
     if bear_value is None:
         notes.append("bear_value missing")
@@ -599,12 +613,12 @@ def _value_score(
         components.append((pt_score, 0.30))
 
     if not components:
-        notes.append("fundamentals fallback (no thesis)")
+        notes.append(fallback_note)
         return 0.5, notes
 
     total_weight = sum(w for _, w in components)
     score = sum(s * w / total_weight for s, w in components)
-    notes.append("fundamentals fallback (no thesis)")
+    notes.append(fallback_note)
     return _clip(score), notes
 
 
@@ -1165,10 +1179,10 @@ def _load_instrument_data(
         )
         quote_row: dict[str, Any] | None = cur.fetchone()
 
-        # Latest thesis (confidence + valuation bands + created_at)
+        # Latest thesis (confidence + valuation bands + stance + created_at)
         cur.execute(
             """
-            SELECT confidence_score, base_value, bear_value, created_at
+            SELECT confidence_score, base_value, bear_value, stance, created_at
             FROM theses
             WHERE instrument_id = %(id)s
             ORDER BY thesis_version DESC
@@ -1510,6 +1524,7 @@ def compute_score(
         # value-score branch falls back to thesis base/bear and
         # multiples when this is None.
         price_target_mean=None,
+        thesis_stance=str(thesis_row["stance"]) if thesis_row and thesis_row["stance"] is not None else None,
     )
     if v_notes:
         explanation_parts.append("value: " + "; ".join(v_notes))

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -928,14 +928,16 @@ def _quote_row(spread_flag: bool, last: float, bid: float, ask: float) -> dict[s
 
 def _thesis_row(
     confidence_score: float,
-    base_value: float,
-    bear_value: float,
+    base_value: float | None,
+    bear_value: float | None,
     created_at: datetime,
+    stance: str = "buy",
 ) -> dict[str, object]:
     return {
         "confidence_score": confidence_score,
         "base_value": base_value,
         "bear_value": bear_value,
+        "stance": stance,
         "created_at": created_at,
     }
 
@@ -1083,6 +1085,21 @@ class TestComputeScore:
         # Missing thesis is no longer penalised (per #169 — T3→T2
         # promotion relies on deterministic signals, not thesis).
         assert "stale_thesis" not in penalty_names
+
+    def test_thesis_without_targets_notes_stance_not_absence(self) -> None:
+        # #2005: an avoid thesis with null targets must not be reported
+        # as "(no thesis)" in the value-family explanation.
+        conn = _make_fake_conn(
+            fund_rows=[_fund_row(0.18, 0.55, 200_000.0, -50_000.0, 100_000.0, 1_100_000.0, 10_000_000.0)],
+            price_row=_price_row(0.05, 0.20, 0.35, 120.0),
+            quote_row=_quote_row(False, 120.0, 119.5, 120.5),
+            thesis_row=_thesis_row(0.20, None, None, _RECENT, stance="avoid"),
+            news_rows=[],
+            avg_red_flag=0.0,
+        )
+        result = compute_score(1, conn, "v1-balanced")
+        assert "thesis without targets, stance: avoid" in result.explanation
+        assert "(no thesis)" not in result.explanation
 
     def test_unknown_model_version_raises(self) -> None:
         conn = MagicMock()

--- a/tests/test_scoring_enriched.py
+++ b/tests/test_scoring_enriched.py
@@ -101,6 +101,30 @@ class TestValueScoreEnriched:
         assert score == pytest.approx(0.5)
         assert any("fundamentals fallback" in n for n in notes)
 
+    def test_value_score_fallback_note_no_thesis(self) -> None:
+        """No thesis at all → note says 'no thesis' (#2005)."""
+        _, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=100.0,
+            pe_ratio=15.0,
+            thesis_stance=None,
+        )
+        assert "fundamentals fallback (no thesis)" in notes
+
+    def test_value_score_fallback_note_thesis_declined_targets(self) -> None:
+        """Thesis exists but declined targets (avoid, null base) → note names the
+        stance instead of misreporting the thesis as absent (#2005, BKTI class)."""
+        _, notes = _value_score(
+            base_value=None,
+            bear_value=None,
+            current_price=100.0,
+            pe_ratio=15.0,
+            thesis_stance="avoid",
+        )
+        assert "fundamentals fallback (thesis without targets, stance: avoid)" in notes
+        assert not any(n == "fundamentals fallback (no thesis)" for n in notes)
+
     def test_value_score_no_price(self) -> None:
         """current_price=None → neutral 0.5 regardless of other params."""
         score, notes = _value_score(


### PR DESCRIPTION
Fixes the #2005 confusion class: `_value_score`'s fallback note read 'fundamentals fallback (no thesis)' whenever `base_value` is null — but a thesis may legitimately carry null per-share targets (v2+ `avoid` declining targets; legacy/DQ rows), so the Verdict tab misreported an existing thesis as absent (operator hit it live on BKTI 2026-07-10).

## What changed
- `_value_score` gains `thesis_stance: str | None = None` (None = no thesis row). Fallback note splits:
  - no thesis row → `fundamentals fallback (no thesis)` (unchanged)
  - thesis row, null targets → `fundamentals fallback (thesis without targets, stance: <stance>)`
- Scoring's latest-thesis query selects `stance`; the single call site threads it.
- Wording: 'without targets' instead of the issue's 'declined targets' — Codex ckpt-2 flagged that legacy/DQ rows also carry null targets; absence is the observable fact, intent is not. Conscious deviation from the issue's literal copy.

## Explicitly NOT changed
- No scoring math change — note text only. No `model_version` bump (per issue).
- Primary (thesis-based) path untouched.

## Security model
Display-string change inside the scoring explanation; no new input paths, no SQL shape change beyond adding one column to an existing parameterised SELECT, no endpoint changes. Stance value comes from our own `theses.stance` column (enum-constrained at write).

## Verification (commit 4df73909)
- Panel check per issue, real dev rows via worktree `compute_score`:
  - BKTI (avoid, null base) → `value: … fundamentals fallback (thesis without targets, stance: avoid)`
  - GME (buy, populated targets) → primary path, no fallback note
- Tests: note-split table tests in `test_scoring_enriched.py` + one mocked `compute_score` row→explanation plumbing test (Codex ckpt-2 coverage gap) in `test_scoring.py`; `_thesis_row` helper carries `stance`.
- Gates: ruff check/format clean, pyright 0 errors, fast tier PASS, smoke PASS.
- Codex ckpt-2 run: 2 findings (wording overreach, plumbing-test gap) — both folded.

Note lands on operator surfaces at the next `compute_rankings` run after merge (explanations rebuild per run; no backfill needed).

Closes #2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)