### PR TITLE
fix(#1996): wire coverage.review_frequency writer + settle tier→frequency mapping

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -106,6 +106,24 @@ _REVIEW_FREQUENCY_DAYS: dict[str, int] = {
     "monthly": 30,
 }
 
+# Tier → review_frequency assignment (#1996, settled decision: T1=weekly,
+# T2=T3=monthly). Filing-event triggers (#273) cover real-news regen
+# instantly; the age window is only a drift catch-all, so the long-horizon
+# posture needs no daily rewrites. Single writer source: every path that
+# sets coverage_tier (seed, bootstrap gap-filler, promote/demote/override
+# via _apply_tier_change) assigns review_frequency from this mapping.
+TIER_REVIEW_FREQUENCY: dict[int, str] = {
+    1: "weekly",
+    2: "monthly",
+    3: "monthly",
+}
+
+
+def review_frequency_for_tier(tier: int) -> str:
+    """Return the settled review_frequency for a coverage tier (#1996)."""
+    return TIER_REVIEW_FREQUENCY[tier]
+
+
 # ---------------------------------------------------------------------------
 # Domain types
 # ---------------------------------------------------------------------------
@@ -536,8 +554,16 @@ def _apply_tier_change(
     """Update the coverage row and insert an audit record for a single tier change."""
     if change.old_tier != change.new_tier:
         conn.execute(
-            "UPDATE coverage SET coverage_tier = %(tier)s WHERE instrument_id = %(id)s",
-            {"tier": change.new_tier, "id": change.instrument_id},
+            """
+            UPDATE coverage
+            SET coverage_tier = %(tier)s, review_frequency = %(freq)s
+            WHERE instrument_id = %(id)s
+            """,
+            {
+                "tier": change.new_tier,
+                "freq": review_frequency_for_tier(change.new_tier),
+                "id": change.instrument_id,
+            },
         )
 
     conn.execute(
@@ -785,12 +811,13 @@ def seed_coverage(
 
         result = conn.execute(
             """
-            INSERT INTO coverage (instrument_id, coverage_tier)
-            SELECT instrument_id, 3
+            INSERT INTO coverage (instrument_id, coverage_tier, review_frequency)
+            SELECT instrument_id, 3, %(freq)s
             FROM instruments
             WHERE is_tradable = TRUE
             ON CONFLICT DO NOTHING
-            """
+            """,
+            {"freq": review_frequency_for_tier(3)},
         )
         if result.rowcount == -1:
             raise RuntimeError("seed_coverage INSERT INTO coverage: server did not report a command tag (rowcount=-1)")
@@ -838,15 +865,16 @@ def bootstrap_missing_coverage_rows(
     with conn.transaction():
         result = conn.execute(
             """
-            INSERT INTO coverage (instrument_id, coverage_tier, filings_status)
-            SELECT i.instrument_id, 3, 'unknown'
+            INSERT INTO coverage (instrument_id, coverage_tier, filings_status, review_frequency)
+            SELECT i.instrument_id, 3, 'unknown', %(freq)s
             FROM instruments i
             WHERE i.is_tradable = TRUE
               AND NOT EXISTS (
                   SELECT 1 FROM coverage c WHERE c.instrument_id = i.instrument_id
               )
             ON CONFLICT DO NOTHING
-            """
+            """,
+            {"freq": review_frequency_for_tier(3)},
         )
         if result.rowcount == -1:
             raise RuntimeError(

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -41,7 +41,12 @@ from app.providers.implementations.sec_edgar import SecFilingsProvider
 from app.providers.implementations.sec_fundamentals import SecFundamentalsProvider
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.canonical_instrument_redirects import JOB_POPULATE_CANONICAL_REDIRECTS
-from app.services.coverage import bootstrap_missing_coverage_rows, review_coverage, seed_coverage
+from app.services.coverage import (
+    bootstrap_missing_coverage_rows,
+    review_coverage,
+    review_frequency_for_tier,
+    seed_coverage,
+)
 from app.services.deferred_retry import retry_deferred_recommendations
 from app.services.entry_timing import evaluate_entry_conditions
 from app.services.etoro_lookups import refresh_etoro_lookups
@@ -2245,12 +2250,13 @@ def _promote_held_to_tier1(conn: psycopg.Connection[Any]) -> int:
     result = conn.execute(
         """
         UPDATE coverage
-        SET coverage_tier = 1
+        SET coverage_tier = 1, review_frequency = %(freq)s
         WHERE instrument_id IN (
             SELECT instrument_id FROM positions WHERE current_units > 0
         )
           AND coverage_tier != 1
-        """
+        """,
+        {"freq": review_frequency_for_tier(1)},
     )
     return result.rowcount
 

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -788,6 +788,23 @@ Rules:
 
 ---
 
+## Coverage tier → review_frequency assignment (#1996, settled 2026-07-16)
+
+`coverage.review_frequency` is ASSIGNED from the coverage tier, single
+mapping: **T1='weekly', T2='monthly', T3='monthly'**
+(`TIER_REVIEW_FREQUENCY` in `app/services/coverage.py` — the only writer
+source). Every path that sets `coverage_tier` (seed, bootstrap
+gap-filler, promote/demote/override via `_apply_tier_change`) writes the
+frequency in the same statement; sql/233 backfills pre-writer NULL rows.
+
+Rationale: filing-event triggers (#273) cover real-news regen instantly;
+the `review_frequency` age window is only a drift catch-all, and the
+long-horizon posture (not day-trading) needs no daily rewrites. The
+VALUE mapping (daily=1/weekly=7/monthly=30 days) was already settled;
+this fixes the ASSIGNMENT. Matches the 2026-07-10 interim dev seed.
+
+---
+
 ## Maintenance rule
 
 When a new repo-level decision is agreed and is likely to affect future implementation:

--- a/sql/233_coverage_review_frequency_backfill.sql
+++ b/sql/233_coverage_review_frequency_backfill.sql
@@ -1,0 +1,29 @@
+-- #1996 — backfill coverage.review_frequency for rows predating the writer.
+--
+-- The column exists since 001_init.sql:82 and is READ by thesis staleness
+-- (find_stale_instruments rule 2: missing → stale('missing_frequency')),
+-- the coverage freshness label, and the execution-guard freshness gate —
+-- but until #1996 NO code path wrote it. Every pre-existing row is NULL
+-- (12,607/12,607 on dev at discovery, 2026-07-10), which made every
+-- thesis permanently "stale" and churned the hourly thesis_refresh on
+-- held names.
+--
+-- Settled mapping (#1996, docs/settled-decisions.md): T1='weekly',
+-- T2='monthly', T3='monthly'. Filing-event triggers (#273) cover
+-- real-news regen instantly; the age window is only a drift catch-all.
+-- Values mirror TIER_REVIEW_FREQUENCY in app/services/coverage.py — the
+-- single writer source for all future assignments (seed, bootstrap
+-- gap-filler, promote/demote/override).
+--
+-- Realigns ALL rows disagreeing with the mapping, not just NULLs: the
+-- 2026-07-10 interim dev seed assigned by tier, but promotions since then
+-- had no writer, so a row promoted after the seed keeps its old frequency
+-- (full-pop dev check 2026-07-16: one T1 row carried 'monthly'). No other
+-- writer exists (no operator surface sets this column), so tier-derived
+-- realignment cannot clobber a deliberate per-instrument value.
+-- Idempotent: IS DISTINCT FROM makes re-runs no-ops.
+
+UPDATE coverage
+SET review_frequency = CASE WHEN coverage_tier = 1 THEN 'weekly' ELSE 'monthly' END
+WHERE review_frequency IS DISTINCT FROM
+      (CASE WHEN coverage_tier = 1 THEN 'weekly' ELSE 'monthly' END);

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -21,12 +21,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services.coverage import (
+    _REVIEW_FREQUENCY_DAYS,
     DEMOTE_T1_TO_T2_SCORE,
     DEMOTE_T2_TO_T3_SCORE,
     PROMOTE_T2_TO_T1_CONFIDENCE,
     PROMOTE_T2_TO_T1_SCORE,
     PROMOTE_T3_TO_T2_SCORE,
     TIER_1_CAP,
+    TIER_REVIEW_FREQUENCY,
     InstrumentSnapshot,
     ReviewResult,
     TierChange,
@@ -37,6 +39,7 @@ from app.services.coverage import (
     _is_thesis_fresh,
     override_tier,
     review_coverage,
+    review_frequency_for_tier,
     seed_coverage,
 )
 
@@ -834,6 +837,19 @@ class TestReviewCoverage:
         assert len(update_calls) == 1
         assert len(insert_calls) == 1
 
+    @patch("app.services.coverage._utcnow", return_value=_NOW)
+    def test_tier_change_writes_review_frequency(self, _mock_now: MagicMock) -> None:
+        """#1996: every tier write assigns review_frequency from the settled
+        mapping in the same UPDATE statement."""
+        snap = _snap(instrument_id=1, current_tier=3, total_score=0.60)  # promotes 3→2
+        conn = self._mock_conn_for_snapshots([snap])
+        review_coverage(conn)
+        update_calls = [(sql, params) for sql, params in self._writes if "UPDATE coverage" in sql]
+        assert len(update_calls) == 1
+        sql, params = update_calls[0]
+        assert "review_frequency" in sql
+        assert params["freq"] == "monthly"  # new tier 2 → monthly
+
 
 # ---------------------------------------------------------------------------
 # override_tier
@@ -938,6 +954,31 @@ class TestOverrideTier:
 
 
 # ---------------------------------------------------------------------------
+# Tier → review_frequency mapping (#1996)
+# ---------------------------------------------------------------------------
+
+
+class TestTierReviewFrequencyMapping:
+    def test_settled_mapping(self) -> None:
+        """Pins the settled decision (docs/settled-decisions.md 2026-07-16):
+        T1=weekly, T2=T3=monthly."""
+        assert TIER_REVIEW_FREQUENCY == {1: "weekly", 2: "monthly", 3: "monthly"}
+
+    def test_covers_every_tier(self) -> None:
+        assert set(TIER_REVIEW_FREQUENCY) == {1, 2, 3}
+
+    def test_values_are_known_frequencies(self) -> None:
+        """Every assigned frequency must resolve in the staleness lookup —
+        an unknown value would silently label theses 'freshness unknown'."""
+        assert set(TIER_REVIEW_FREQUENCY.values()) <= set(_REVIEW_FREQUENCY_DAYS)
+
+    def test_review_frequency_for_tier(self) -> None:
+        assert review_frequency_for_tier(1) == "weekly"
+        assert review_frequency_for_tier(2) == "monthly"
+        assert review_frequency_for_tier(3) == "monthly"
+
+
+# ---------------------------------------------------------------------------
 # seed_coverage
 # ---------------------------------------------------------------------------
 
@@ -980,6 +1021,8 @@ class TestSeedCoverage:
         sql = conn.execute.call_args[0][0]
         assert "INSERT INTO coverage" in sql
         assert "is_tradable = TRUE" in sql
+        assert "review_frequency" in sql  # #1996: seed assigns frequency
+        assert conn.execute.call_args[0][1] == {"freq": "monthly"}
 
     def test_noop_when_populated(self) -> None:
         """Non-empty coverage table skips seeding entirely."""
@@ -1048,13 +1091,15 @@ class TestBootstrapMissingCoverageRows:
         import re
 
         assert re.search(
-            r"INSERT INTO coverage \(instrument_id,\s*coverage_tier,\s*filings_status\)",
+            r"INSERT INTO coverage \(instrument_id,\s*coverage_tier,\s*filings_status,\s*review_frequency\)",
             sql,
-        ), "filings_status must appear in the INSERT column list"
+        ), "filings_status + review_frequency must appear in the INSERT column list"
         assert re.search(
-            r"SELECT i\.instrument_id,\s*3,\s*'unknown'",
+            r"SELECT i\.instrument_id,\s*3,\s*'unknown',\s*%\(freq\)s",
             sql,
-        ), "'unknown' literal must be the third SELECT projection value"
+        ), "'unknown' literal + freq param must follow the tier in the SELECT projection"
+        params = conn.execute.call_args[0][1]
+        assert params == {"freq": "monthly"}  # #1996: T3 → monthly
 
     def test_noop_when_no_gaps(self) -> None:
         """Every tradable instrument already has coverage → zero inserts."""

--- a/tests/test_promote_held.py
+++ b/tests/test_promote_held.py
@@ -22,6 +22,9 @@ class TestPromoteHeldToTier1:
         assert "coverage_tier = 1" in sql
         assert "current_units > 0" in sql
         assert "coverage_tier != 1" in sql
+        # #1996: every coverage_tier write assigns review_frequency
+        assert "review_frequency = %(freq)s" in sql
+        assert conn.execute.call_args[0][1] == {"freq": "weekly"}
 
     def test_zero_when_all_already_tier1(self) -> None:
         conn = MagicMock()


### PR DESCRIPTION
`coverage.review_frequency` existed since sql/001 and is READ by thesis staleness (`find_stale_instruments` rule 2), the coverage freshness label, and the execution-guard freshness gate — but NO code path wrote it. All 12,607 dev rows were NULL until a 2026-07-10 interim manual seed (#1919 PR-B fallout), and rows promoted since then drifted (no writer). Consequence of NULL: every thesis permanently 'stale', hourly thesis_refresh churn on held names.

## What changed
- **Settled mapping** (docs/settled-decisions.md, new entry): `TIER_REVIEW_FREQUENCY = {1: 'weekly', 2: 'monthly', 3: 'monthly'}` in `app/services/coverage.py` — the single writer source. Rationale: #273 filing-event triggers cover real-news regen instantly; the age window is only a drift catch-all; long-horizon posture needs no daily rewrites. Matches the interim seed.
- **Every `coverage_tier` write now assigns frequency in the same statement** (4 chokepoints, exhaustive-swept via `grep 'SET coverage_tier|UPDATE coverage'` over `app/`):
  - `_apply_tier_change` (promote/demote/override)
  - `seed_coverage` (first-run bootstrap)
  - `bootstrap_missing_coverage_rows` (post-bootstrap gap filler)
  - `scheduler._promote_held_to_tier1` (held-position auto-promote) — **Codex ckpt-2 High finding**; this bypasses `_apply_tier_change` and was almost certainly the source of the drifted row below
- **sql/233**: realigns ALL rows disagreeing with the mapping, not just NULLs — the full-population dev check found 1 T1 row still 'monthly' (promoted after the interim seed with no writer). `IS DISTINCT FROM` makes re-runs no-ops. No other writer exists (no operator surface sets this column), so tier-derived realignment cannot clobber a deliberate value.

## Security model
No new endpoints or input paths. All SQL parameterised; the frequency value comes from a code-level constant, never user input. Guard/staleness consumers are read-only beneficiaries.

## Verification (commit 864ac7d6)
- Dev DB (full population, 12,620 rows): sql/233 applied via the real runner; distribution after — T1=6 'weekly', T2=35 'monthly', T3=12,579 'monthly'; **0 rows disagreeing with the mapping** (was 1 drifted T1 pre-migration).
- Tests: mapping table tests (pins settled values, tier coverage, vocabulary membership), tier-change UPDATE params, seed/bootstrap column-list regexes, `_promote_held_to_tier1` params.
- Gates: ruff check+format clean, pyright 0 errors, fast tier PASS, smoke PASS (boot applies 233).
- Codex ckpt-2: 1 High (`_promote_held_to_tier1` missed path) — folded; sql/233 + chokepoints confirmed sound.

## Tradeoffs
- `_REVIEW_FREQUENCY_DAYS` stays duplicated coverage.py/thesis.py (pre-existing 'extract when touched' note) — the DAYS dict itself is untouched here; consolidation is out of scope.
- New coverage rows no longer regress to NULL; #1988 (staleness v2) can re-key trigger semantics later without schema change.

Closes #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)