### PR TITLE
fix(#1992): settings sections send authenticated operator as updated_by

### DIFF
--- a/frontend/src/components/settings/BudgetConfigSection.test.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.test.tsx
@@ -36,6 +36,10 @@ vi.mock("@/api/budget", () => ({
   createCapitalEvent: vi.fn(),
 }));
 
+// #1992: sections read the authenticated operator for audit attribution.
+const useSessionMock = vi.fn(() => ({ operator: { id: "1", username: "luke" } }));
+vi.mock("@/lib/session", () => ({ useSession: () => useSessionMock() }));
+
 const mockedFetchConfig = vi.mocked(fetchBudgetConfig);
 const mockedFetchEvents = vi.mocked(fetchCapitalEvents);
 const mockedUpdateConfig = vi.mocked(updateBudgetConfig);
@@ -173,7 +177,7 @@ describe("BudgetConfigSection — save", () => {
     expect(mockedUpdateConfig).toHaveBeenCalledWith({
       cash_buffer_pct: 0.1,
       cgt_scenario: undefined,
-      updated_by: "operator",
+      updated_by: "luke",
       reason: "increasing buffer",
     });
   });
@@ -199,7 +203,7 @@ describe("BudgetConfigSection — save", () => {
     expect(mockedUpdateConfig).toHaveBeenCalledWith({
       cash_buffer_pct: undefined,
       cgt_scenario: "basic",
-      updated_by: "operator",
+      updated_by: "luke",
       reason: "switching scenario",
     });
   });

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -10,8 +10,14 @@ import type { CapitalEventResponse } from "@/api/types";
 import { SectionSkeleton, SectionError } from "@/components/dashboard/Section";
 import { formatDateTime, formatMoney } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
+import { useSession } from "@/lib/session";
 
 export function BudgetConfigSection() {
+  const { operator } = useSession();
+  // Audit attribution must be a REAL identity — never a fabricated
+  // fallback string (KillSwitchSection precedent, #1992). Block the save
+  // instead when no operator is authenticated.
+  const operatorName = operator?.username ?? null;
   // ---- Config state ----
   const config = useAsync(fetchBudgetConfig, []);
   const [cashBufferPct, setCashBufferPct] = useState<number | null>(null);
@@ -38,6 +44,7 @@ export function BudgetConfigSection() {
 
   async function handleConfigSave(e: FormEvent) {
     e.preventDefault();
+    if (operatorName === null) return;
     setConfigSaving(true);
     setConfigError(false);
     setConfigSuccess(false);
@@ -51,7 +58,7 @@ export function BudgetConfigSection() {
         // Convert percentage (display) back to fraction (API).
         cash_buffer_pct: bufferChanged ? displayedBufferPct / 100 : undefined,
         cgt_scenario: scenarioChanged ? displayedCgtScenario : undefined,
-        updated_by: "operator",
+        updated_by: operatorName,
         reason: configReason,
       });
       setCashBufferPct(null);
@@ -199,7 +206,7 @@ export function BudgetConfigSection() {
 
               <button
                 type="submit"
-                disabled={configSaving || configReasonMissing || configNothingChanged}
+                disabled={configSaving || configReasonMissing || configNothingChanged || operatorName === null}
                 className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {configSaving ? "Saving..." : "Save config"}

--- a/frontend/src/components/settings/DisplayCurrencySection.test.tsx
+++ b/frontend/src/components/settings/DisplayCurrencySection.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * DisplayCurrencySection — audit attribution (#1992).
+ *
+ * Pins the PATCH /config body's updated_by to the authenticated
+ * operator's username (KillSwitchSection precedent) and the blocked-save
+ * behaviour when no operator is authenticated.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { DisplayCurrencySection } from "@/components/settings/DisplayCurrencySection";
+
+vi.mock("@/api/client", () => ({ apiFetch: vi.fn() }));
+
+// #1992: sections read the authenticated operator for audit attribution.
+const useSessionMock = vi.fn((): { operator: { id: string; username: string } | null } => ({
+  operator: { id: "1", username: "luke" },
+}));
+vi.mock("@/lib/session", () => ({ useSession: () => useSessionMock() }));
+
+import { apiFetch } from "@/api/client";
+
+const mockedApiFetch = vi.mocked(apiFetch);
+
+describe("DisplayCurrencySection", () => {
+  beforeEach(() => {
+    mockedApiFetch.mockReset();
+    useSessionMock.mockClear();
+  });
+
+  it("sends the authenticated operator as updated_by (#1992)", async () => {
+    mockedApiFetch.mockResolvedValue({});
+    const user = userEvent.setup();
+    render(<DisplayCurrencySection currentCurrency="GBP" onChanged={() => {}} />);
+
+    await user.selectOptions(screen.getByRole("combobox"), "USD");
+    await user.click(screen.getByRole("button", { name: /save currency/i }));
+
+    await waitFor(() => expect(mockedApiFetch).toHaveBeenCalledOnce());
+    const call = mockedApiFetch.mock.calls[0]!;
+    const init = call[1];
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      updated_by: "luke",
+      reason: "Changed display currency to USD",
+      display_currency: "USD",
+    });
+  });
+
+  it("blocks save when no operator is authenticated (#1992)", async () => {
+    useSessionMock.mockReturnValue({ operator: null });
+    const user = userEvent.setup();
+    render(<DisplayCurrencySection currentCurrency="GBP" onChanged={() => {}} />);
+
+    await user.selectOptions(screen.getByRole("combobox"), "USD");
+    // Real identity required for runtime_config_audit attribution — the
+    // save button is disabled rather than sending a fabricated fallback.
+    expect(screen.getByRole("button", { name: /save currency/i })).toBeDisabled();
+    expect(mockedApiFetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/settings/DisplayCurrencySection.tsx
+++ b/frontend/src/components/settings/DisplayCurrencySection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { apiFetch } from "@/api/client";
+import { useSession } from "@/lib/session";
 
 const SUPPORTED_CURRENCIES = ["GBP", "USD", "EUR"] as const;
 
@@ -9,6 +10,11 @@ interface Props {
 }
 
 export function DisplayCurrencySection({ currentCurrency, onChanged }: Props) {
+  const { operator } = useSession();
+  // Audit attribution must be a REAL identity — never a fabricated
+  // fallback string (KillSwitchSection precedent, #1992). Block the save
+  // instead when no operator is authenticated.
+  const operatorName = operator?.username ?? null;
   const [selected, setSelected] = useState(currentCurrency);
 
   // Sync local state when prop updates (e.g. after save + reload).
@@ -19,14 +25,14 @@ export function DisplayCurrencySection({ currentCurrency, onChanged }: Props) {
   const [error, setError] = useState<string | null>(null);
 
   async function handleSave() {
-    if (selected === currentCurrency) return;
+    if (selected === currentCurrency || operatorName === null) return;
     setSaving(true);
     setError(null);
     try {
       await apiFetch("/config", {
         method: "PATCH",
         body: JSON.stringify({
-          updated_by: "operator",
+          updated_by: operatorName,
           reason: `Changed display currency to ${selected}`,
           display_currency: selected,
         }),
@@ -66,7 +72,7 @@ export function DisplayCurrencySection({ currentCurrency, onChanged }: Props) {
           <button
             type="button"
             onClick={() => void handleSave()}
-            disabled={saving || selected === currentCurrency}
+            disabled={saving || selected === currentCurrency || operatorName === null}
             className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white disabled:bg-slate-400"
           >
             {saving ? "Saving..." : "Save currency"}

--- a/frontend/src/components/settings/LlmProviderSection.test.tsx
+++ b/frontend/src/components/settings/LlmProviderSection.test.tsx
@@ -24,6 +24,12 @@ vi.mock("@/api/config", () => ({
   patchConfig: vi.fn(),
 }));
 
+// #1992: sections read the authenticated operator for audit attribution.
+const useSessionMock = vi.fn((): { operator: { id: string; username: string } | null } => ({
+  operator: { id: "1", username: "luke" },
+}));
+vi.mock("@/lib/session", () => ({ useSession: () => useSessionMock() }));
+
 const mockedPatchConfig = vi.mocked(patchConfig);
 
 function configResponse(): ConfigResponse {
@@ -108,7 +114,7 @@ describe("LlmProviderSection", () => {
 
     await waitFor(() => expect(mockedPatchConfig).toHaveBeenCalledOnce());
     expect(mockedPatchConfig).toHaveBeenCalledWith({
-      updated_by: "operator",
+      updated_by: "luke",
       reason: "benchmarking",
       llm_provider: undefined,
       llm_base_url: undefined,
@@ -133,7 +139,7 @@ describe("LlmProviderSection", () => {
 
     await waitFor(() => expect(mockedPatchConfig).toHaveBeenCalledOnce());
     expect(mockedPatchConfig).toHaveBeenCalledWith({
-      updated_by: "operator",
+      updated_by: "luke",
       reason: "stricter critic",
       llm_provider: undefined,
       llm_base_url: undefined,
@@ -161,7 +167,7 @@ describe("LlmProviderSection", () => {
 
     await waitFor(() => expect(mockedPatchConfig).toHaveBeenCalledOnce());
     expect(mockedPatchConfig).toHaveBeenCalledWith({
-      updated_by: "operator",
+      updated_by: "luke",
       reason: "flip to cloud",
       llm_provider: "anthropic",
       llm_base_url: undefined,
@@ -180,6 +186,15 @@ describe("LlmProviderSection", () => {
     await user.click(screen.getByRole("button", { name: /save llm config/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/failed to save llm config/i);
+  });
+
+  it("blocks save when no operator is authenticated (#1992)", () => {
+    useSessionMock.mockReturnValueOnce({ operator: null });
+    renderSection();
+    // Real identity required for runtime_config_audit attribution — the
+    // save button is disabled rather than sending a fabricated fallback.
+    expect(screen.getByRole("button", { name: /save llm config/i })).toBeDisabled();
+    expect(mockedPatchConfig).not.toHaveBeenCalled();
   });
 
   it("renders the retry surface when config fetch errored", () => {

--- a/frontend/src/components/settings/LlmProviderSection.tsx
+++ b/frontend/src/components/settings/LlmProviderSection.tsx
@@ -17,12 +17,18 @@ import type { FormEvent } from "react";
 import { patchConfig } from "@/api/config";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { useConfig } from "@/lib/ConfigContext";
+import { useSession } from "@/lib/session";
 
 // Must match VALID_LLM_PROVIDERS in app/services/runtime_config.py.
 const LLM_PROVIDERS = ["openai_compatible", "anthropic"] as const;
 
 export function LlmProviderSection(): JSX.Element {
   const config = useConfig();
+  const { operator } = useSession();
+  // Audit attribution must be a REAL identity — never a fabricated
+  // fallback string (KillSwitchSection precedent, #1992). Block the save
+  // instead when no operator is authenticated.
+  const operatorName = operator?.username ?? null;
 
   // Local override > server value (BudgetConfigSection pattern): null
   // means "not edited", so a refetch cleanly repopulates from the server.
@@ -47,6 +53,7 @@ export function LlmProviderSection(): JSX.Element {
 
   async function handleSave(e: FormEvent) {
     e.preventDefault();
+    if (operatorName === null) return;
     setSaving(true);
     setError(false);
     setSuccess(false);
@@ -54,7 +61,7 @@ export function LlmProviderSection(): JSX.Element {
       // Only send fields that actually changed — the backend rejects
       // no-op patches with 422.
       await patchConfig({
-        updated_by: "operator",
+        updated_by: operatorName,
         reason,
         llm_provider: provider ?? undefined,
         llm_base_url: baseUrl ?? undefined,
@@ -184,7 +191,7 @@ export function LlmProviderSection(): JSX.Element {
 
             <button
               type="submit"
-              disabled={saving || reasonMissing || nothingChanged}
+              disabled={saving || reasonMissing || nothingChanged || operatorName === null}
               className="rounded bg-slate-800 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {saving ? "Saving..." : "Save LLM config"}


### PR DESCRIPTION
Closes the #1992 tech-debt: `LlmProviderSection`, `DisplayCurrencySection`, and `BudgetConfigSection` hardcoded `updated_by: "operator"` in config-mutating PATCHes, writing a literal string into `runtime_config_audit` instead of the real principal.

## What changed
- All three sections read `useSession().operator.username` and send it as `updated_by` — the exact KillSwitchSection precedent (`activated_by`), including its rule: **no fabricated fallback**. When no operator is authenticated the save button is disabled and the handler early-returns; a fallback literal would silently write a false audit row.
- Uniform one-pass fix per the issue; no other `updated_by` writers exist under `frontend/src` (Codex ckpt-2 swept — kill switch already correct).

## Security model
Attribution hardening only. The backend PATCH contract is unchanged (`updated_by` was already a required string); the session value comes from the authenticated `/auth/me` operator held in SessionProvider, not user-typed input. Single-operator deployment today — this makes the audit column truthful before multi-operator lands.

## Verification (commit on this branch)
- **FE-QA live** (change-coupled: worktree vite :5174 against the dev API + Playwright): Settings page loads authenticated, currency GBP→USD save → `runtime_config_audit.changed_by = 'ghasst'` (the real dev operator; previously would have been the literal 'operator'), reverted USD→GBP (second real-identity row), 0 console errors, dev config left unchanged.
- Tests: session mocked per KillSwitch pattern in all three section test files (Display gets its first test file — Codex ckpt-2 Low); assertions pin the real username; blocked-save tests for LLM + Display sections.
- Gates: `pnpm typecheck` clean, `test:unit` 126 files / 1361 tests pass.
- Codex ckpt-2: 1 Low (Display test gap) — folded; no missed call sites.

Closes #1992

🤖 Generated with [Claude Code](https://claude.com/claude-code)