### PR TITLE
feat(#2002): calibration-ledger core — thesis_outcomes schema + nightly outcome capture

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -125,6 +125,7 @@ from app.workers.scheduler import (
     JOB_SEED_COST_MODELS,
     JOB_THESIS_BREAK_SCAN,
     JOB_THESIS_DQ_AUDIT,
+    JOB_THESIS_OUTCOME_CAPTURE,
     JOB_THESIS_REFRESH,
     JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
@@ -185,6 +186,7 @@ from app.workers.scheduler import (
     seed_cost_models,
     thesis_break_scan,
     thesis_dq_audit,
+    thesis_outcome_capture,
     thesis_refresh,
     weekly_report,
 )
@@ -309,6 +311,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # bypasses ScheduledJob.prerequisite) is equally gated.
     JOB_THESIS_BREAK_SCAN: _adapt_zero_arg(thesis_break_scan),
     JOB_THESIS_DQ_AUDIT: _adapt_zero_arg(thesis_dq_audit),
+    JOB_THESIS_OUTCOME_CAPTURE: _adapt_zero_arg(thesis_outcome_capture),
     JOB_THESIS_REFRESH: _adapt_zero_arg(thesis_refresh),
     JOB_PORTFOLIO_EOD_SNAPSHOT: _adapt_zero_arg(portfolio_eod_snapshot_job),
     JOB_FX_HISTORY_BACKFILL: _adapt_zero_arg(fx_history_backfill_job),

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -86,6 +86,7 @@ Lane = Literal[
     "db_size_sample",
     "db_thesis_dq",
     "db_thesis_break",
+    "db_thesis_outcomes",
     "llm_thesis",
     "risk_metrics",
     "fair_value_band",

--- a/app/services/thesis_outcomes.py
+++ b/app/services/thesis_outcomes.py
@@ -29,14 +29,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, timedelta
+from decimal import Decimal
 from typing import Any
 
 import psycopg
 import psycopg.rows
 
-# Same coercion chokepoint as the DQ audit — psycopg numerics arrive as
-# Decimal; NaN/±inf coerce to None instead of poisoning comparisons.
-from app.services.thesis import _to_float
 from app.services.thesis_dq_audit import _anchor_block, _parse_iso_date
 
 HORIZONS: tuple[int, ...] = (30, 90, 365)
@@ -121,12 +119,17 @@ def classify_immature(
     return "immature_series_stalled"
 
 
-def close_row_at_or_before(conn: psycopg.Connection[Any], instrument_id: int, as_of: date) -> tuple[date, float] | None:
+def close_row_at_or_before(
+    conn: psycopg.Connection[Any], instrument_id: int, as_of: date
+) -> tuple[date, Decimal] | None:
     """(price_date, close) of the last print at or before ``as_of``.
 
     Same read as ``thesis_dq_audit._close_at_or_before`` but the ledger
     also needs the trading day actually used (``realized_date``), hence
-    the widened return shape rather than a shared helper.
+    the widened return shape rather than a shared helper. The close stays
+    ``Decimal`` end-to-end (NUMERIC in, NUMERIC out — no binary-float
+    round-trip; PR #2061 review); a non-finite NUMERIC (NaN) maps to None
+    the same way the ``_to_float`` chokepoint would.
     """
     with conn.cursor() as cur:
         cur.execute(
@@ -140,8 +143,8 @@ def close_row_at_or_before(conn: psycopg.Connection[Any], instrument_id: int, as
         row = cur.fetchone()
     if row is None:
         return None
-    close = _to_float(row[1])
-    if close is None:
+    close = row[1]
+    if not isinstance(close, Decimal) or not close.is_finite():
         return None
     return (row[0], close)
 

--- a/app/services/thesis_outcomes.py
+++ b/app/services/thesis_outcomes.py
@@ -1,0 +1,280 @@
+"""Calibration-ledger outcome capture — nightly deterministic job (#2002).
+
+Theses are versioned, dated forecasts; nothing ever scored them against
+what the market subsequently did. This module captures realized returns
+per THESIS VERSION at fixed horizons (30/90/365d) into the append-only
+``thesis_outcomes`` ledger. Passive measurement only: no LLM, no scoring
+feed, no trade-path contact, zero cloud spend.
+
+Contracts (spec: docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md):
+
+* Anchor semantics = #2014/#2017: the write-time reference is the minting
+  run's ``context_summary.blocks.price_anchor`` (persisted PRE-LLM); the
+  trusted close is re-read deterministically from ``price_daily`` at or
+  before ``as_of`` — never taken from a JSON copy.
+* Maturity is DATA-anchored, not wall-clock: a (thesis, horizon) pair is
+  mature when ``max(price_date) >= anchor_date + horizon``. A stale
+  series defers capture; it can never mint a wrong-horizon row.
+* Insert-once: PK (thesis_id, horizon_days) + ON CONFLICT DO NOTHING.
+  Re-runs insert nothing. Rows are never updated.
+* Honest missingness: anchorless theses (pre-#2017 rows, unavailable or
+  unparseable anchors) get NO rows — a queryable gap, never a neutral
+  value. Non-positive closes are skipped and counted, never written.
+
+Pure predicates are module-level functions (table-testable, no DB);
+``capture_thesis_outcomes`` is the one DB reader+writer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+# Same coercion chokepoint as the DQ audit — psycopg numerics arrive as
+# Decimal; NaN/±inf coerce to None instead of poisoning comparisons.
+from app.services.thesis import _to_float
+from app.services.thesis_dq_audit import _anchor_block, _parse_iso_date
+
+HORIZONS: tuple[int, ...] = (30, 90, 365)
+
+METHOD_VERSION = "oc_v1"
+
+# A never-matured pair whose price series ended more than this many days
+# before the horizon due date is a dead series (delisted/acquired/halted),
+# not temporarily stale data. No outcome row is ever written for it — a
+# return against a halted print is not a market outcome.
+_SERIES_DEAD_GRACE_DAYS = 30
+
+
+@dataclass(frozen=True)
+class ThesisOutcomeCaptureReport:
+    """Census of one capture run. ``inserted`` is the job row_count
+    (0 = healthy steady state on quiet days); everything else is honest
+    missingness, first-class by spec."""
+
+    scanned_theses: int = 0
+    anchorless: int = 0
+    inserted: int = 0
+    mature_pairs: int = 0
+    immature_data_current: int = 0
+    immature_series_stalled: int = 0
+    series_dead: int = 0
+    skipped_missing_close: int = 0
+    skipped_nonpositive_close: int = 0
+
+
+def anchor_date_from_summary(summary: object) -> date | None:
+    """The usable anchor date of a minting run, or None.
+
+    Usable = ``price_anchor.available`` is True AND ``as_of`` parses as an
+    ISO date. Anything else (no summary, no block, available false,
+    unparseable as_of) is anchorless — the thesis gets no ledger rows.
+    """
+    anchor = _anchor_block(summary)
+    if anchor is None or anchor.get("available") is not True:
+        return None
+    return _parse_iso_date(anchor.get("as_of"))
+
+
+def is_mature(anchor_date: date, horizon_days: int, max_price_date: date | None) -> bool:
+    """DATA-anchored maturity: the series has printed at or past the due
+    date. Wall-clock never participates."""
+    if max_price_date is None:
+        return False
+    return max_price_date >= anchor_date + timedelta(days=horizon_days)
+
+
+def classify_immature(
+    *,
+    is_tradable: bool,
+    max_price_date: date | None,
+    due_date: date,
+    today: date,
+) -> str:
+    """Split never-matured pairs so a dead series is not indistinguishable
+    from temporarily stale data (spec, Codex ckpt-1 Medium).
+
+    * ``immature_data_current`` — series is alive (tradable, printed within
+      the grace window of today): the pair simply isn't due yet.
+    * ``series_dead`` — the series ended more than the grace window before
+      the due date: the print this pair needs will never come. A rowless
+      series is dead only when the instrument is also untradable — for a
+      tradable instrument, no rows is absent data (ingest gap / fresh
+      listing), never a terminal verdict (Codex ckpt-2 Medium).
+    * ``immature_series_stalled`` — series has stopped (untradable, no
+      recent print, or no rows yet while tradable) but not provably dead.
+
+    ``today`` participates only in the alive-vs-stopped liveness split —
+    the counters are telemetry; row insertion is purely data-anchored.
+    """
+    ended = not is_tradable or max_price_date is None or (today - max_price_date).days > _SERIES_DEAD_GRACE_DAYS
+    if not ended:
+        return "immature_data_current"
+    if max_price_date is None:
+        return "series_dead" if not is_tradable else "immature_series_stalled"
+    if (due_date - max_price_date).days > _SERIES_DEAD_GRACE_DAYS:
+        return "series_dead"
+    return "immature_series_stalled"
+
+
+def close_row_at_or_before(conn: psycopg.Connection[Any], instrument_id: int, as_of: date) -> tuple[date, float] | None:
+    """(price_date, close) of the last print at or before ``as_of``.
+
+    Same read as ``thesis_dq_audit._close_at_or_before`` but the ledger
+    also needs the trading day actually used (``realized_date``), hence
+    the widened return shape rather than a shared helper.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT price_date, close FROM price_daily
+            WHERE instrument_id = %(iid)s AND price_date <= %(as_of)s
+            ORDER BY price_date DESC LIMIT 1
+            """,
+            {"iid": instrument_id, "as_of": as_of},
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    close = _to_float(row[1])
+    if close is None:
+        return None
+    return (row[0], close)
+
+
+# All thesis versions with at least one horizon uncaptured. The run
+# LATERAL takes the latest context_summary-BEARING run per thesis (spec:
+# availability truth is the persisted PRE-LLM summary, #2017); theses
+# whose runs all lack a summary come back with NULL and count as
+# anchorless. cardinality < n_horizons keeps the scan bounded to
+# unfinished theses without repeating the horizon list in SQL.
+_CANDIDATES_SQL = """
+SELECT t.thesis_id, t.instrument_id, i.is_tradable,
+       r.context_summary,
+       p.max_price_date,
+       COALESCE(o.done, '{}') AS horizons_done
+FROM theses t
+JOIN instruments i ON i.instrument_id = t.instrument_id
+LEFT JOIN LATERAL (
+    SELECT context_summary
+    FROM thesis_runs r
+    WHERE r.thesis_id = t.thesis_id AND r.context_summary IS NOT NULL
+    ORDER BY r.run_id DESC
+    LIMIT 1
+) r ON TRUE
+LEFT JOIN LATERAL (
+    SELECT max(price_date) AS max_price_date
+    FROM price_daily p
+    WHERE p.instrument_id = t.instrument_id
+) p ON TRUE
+LEFT JOIN LATERAL (
+    SELECT array_agg(o.horizon_days) AS done
+    FROM thesis_outcomes o
+    WHERE o.thesis_id = t.thesis_id
+) o ON TRUE
+WHERE COALESCE(cardinality(o.done), 0) < %(n_horizons)s
+ORDER BY t.thesis_id
+"""
+
+_INSERT_SQL = """
+INSERT INTO thesis_outcomes
+    (thesis_id, horizon_days, anchor_date, anchor_close,
+     realized_date, realized_close, realized_return, method_version)
+VALUES
+    (%(thesis_id)s, %(horizon_days)s, %(anchor_date)s, %(anchor_close)s,
+     %(realized_date)s, %(realized_close)s, %(realized_return)s, %(method_version)s)
+ON CONFLICT (thesis_id, horizon_days) DO NOTHING
+"""
+
+
+def capture_thesis_outcomes(conn: psycopg.Connection[Any]) -> ThesisOutcomeCaptureReport:
+    """Insert realized outcomes for every mature, uncaptured
+    (thesis, horizon) pair. Idempotent; deterministic; append-only."""
+    today = date.today()
+    scanned = anchorless = inserted = mature_pairs = 0
+    immature_current = immature_stalled = dead = 0
+    missing_close = nonpositive = 0
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_CANDIDATES_SQL, {"n_horizons": len(HORIZONS)})
+        candidates = cur.fetchall()
+
+    with conn.transaction():
+        for row in candidates:
+            scanned += 1
+            anchor_date = anchor_date_from_summary(row["context_summary"])
+            if anchor_date is None:
+                anchorless += 1
+                continue
+            done = set(row["horizons_done"] or ())
+            max_price_date = row["max_price_date"]
+            mature_missing: list[int] = []
+            for horizon in HORIZONS:
+                if horizon in done:
+                    continue
+                if is_mature(anchor_date, horizon, max_price_date):
+                    mature_missing.append(horizon)
+                    continue
+                kind = classify_immature(
+                    is_tradable=bool(row["is_tradable"]),
+                    max_price_date=max_price_date,
+                    due_date=anchor_date + timedelta(days=horizon),
+                    today=today,
+                )
+                if kind == "immature_data_current":
+                    immature_current += 1
+                elif kind == "series_dead":
+                    dead += 1
+                else:
+                    immature_stalled += 1
+            if not mature_missing:
+                continue
+            mature_pairs += len(mature_missing)
+            anchor_row = close_row_at_or_before(conn, row["instrument_id"], anchor_date)
+            if anchor_row is None:
+                missing_close += len(mature_missing)
+                continue
+            anchor_close = anchor_row[1]
+            if anchor_close <= 0:
+                nonpositive += len(mature_missing)
+                continue
+            for horizon in mature_missing:
+                realized = close_row_at_or_before(conn, row["instrument_id"], anchor_date + timedelta(days=horizon))
+                if realized is None:
+                    missing_close += 1
+                    continue
+                realized_date, realized_close = realized
+                if realized_close <= 0:
+                    nonpositive += 1
+                    continue
+                with conn.cursor() as cur:
+                    cur.execute(
+                        _INSERT_SQL,
+                        {
+                            "thesis_id": row["thesis_id"],
+                            "horizon_days": horizon,
+                            "anchor_date": anchor_date,
+                            "anchor_close": anchor_close,
+                            "realized_date": realized_date,
+                            "realized_close": realized_close,
+                            "realized_return": (realized_close - anchor_close) / anchor_close,
+                            "method_version": METHOD_VERSION,
+                        },
+                    )
+                    inserted += cur.rowcount
+
+    return ThesisOutcomeCaptureReport(
+        scanned_theses=scanned,
+        anchorless=anchorless,
+        inserted=inserted,
+        mature_pairs=mature_pairs,
+        immature_data_current=immature_current,
+        immature_series_stalled=immature_stalled,
+        series_dead=dead,
+        skipped_missing_close=missing_close,
+        skipped_nonpositive_close=nonpositive,
+    )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -334,6 +334,7 @@ JOB_DAILY_NEWS_REFRESH = "daily_news_refresh"
 JOB_THESIS_REFRESH = "thesis_refresh"
 JOB_THESIS_DQ_AUDIT = "thesis_dq_audit"
 JOB_THESIS_BREAK_SCAN = "thesis_break_scan"
+JOB_THESIS_OUTCOME_CAPTURE = "thesis_outcome_capture"
 JOB_MORNING_CANDIDATE_REVIEW = "morning_candidate_review"
 JOB_DAILY_TAX_RECONCILIATION = "daily_tax_reconciliation"
 JOB_DAILY_PORTFOLIO_SYNC = "daily_portfolio_sync"
@@ -869,6 +870,29 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # thesis_dq_audit's 05:12 slot; the stagger is layout hygiene only
         # since #2052 (each scan owns its lane, so they cannot contend).
         cadence=Cadence.daily(hour=5, minute=22),
+        # A missed night is re-covered next night; nothing accumulates.
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_THESIS_OUTCOME_CAPTURE,
+        display_name="Thesis outcome capture",
+        # Own single-job lane per the #2052/#1526 lesson (boot catch-up /
+        # manual triggers co-fire the 05:1x-05:3x scans despite the
+        # stagger). Sole writer of thesis_outcomes; see
+        # app/jobs/sources.py::Lane.
+        source="db_thesis_outcomes",
+        description=(
+            "Nightly calibration-ledger capture (#2002): insert realized "
+            "returns per thesis version at 30/90/365d horizons into the "
+            "append-only thesis_outcomes table. Maturity is data-anchored "
+            "(max price_date >= anchor + horizon), anchors re-read from "
+            "price_daily — deterministic, no LLM. row_count = outcome rows "
+            "inserted (0 = healthy steady state)."
+        ),
+        # 05:32 UTC — post-fundamentals data-readiness window, offset from
+        # dq_audit 05:12 / break_scan 05:22, non-5-minute-aligned (#1707).
+        cadence=Cadence.daily(hour=5, minute=32),
         # A missed night is re-covered next night; nothing accumulates.
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
@@ -4987,6 +5011,34 @@ def thesis_break_scan() -> None:
             logger.warning("thesis_break_scan: %d break event(s) fired — states: %s", report.fired, states)
         else:
             logger.info("thesis_break_scan: no fires — predicates=%d (%s)", report.predicates_total, states)
+
+
+def thesis_outcome_capture() -> None:
+    """Nightly calibration-ledger outcome capture (#2002).
+
+    Thin wrapper around
+    :func:`app.services.thesis_outcomes.capture_thesis_outcomes`.
+    ``row_count`` is the number of outcome rows INSERTED this run (0 is
+    the healthy steady state — pairs mature slowly by design). The full
+    census (anchorless, immature split, dead series, skips) lands in the
+    tracker note for /system/jobs.
+    """
+    from app.services.thesis_outcomes import capture_thesis_outcomes
+
+    with _tracked_job(JOB_THESIS_OUTCOME_CAPTURE) as tracker:
+        with connect_job() as conn:
+            report = capture_thesis_outcomes(conn)
+        tracker.row_count = report.inserted
+        tracker.note = (
+            f"theses={report.scanned_theses} anchorless={report.anchorless} "
+            f"mature={report.mature_pairs} inserted={report.inserted} "
+            f"immature_current={report.immature_data_current} "
+            f"immature_stalled={report.immature_series_stalled} "
+            f"series_dead={report.series_dead} "
+            f"missing_close={report.skipped_missing_close} "
+            f"nonpositive_close={report.skipped_nonpositive_close}"
+        )
+        logger.info("thesis_outcome_capture: %s", tracker.note)
 
 
 def financial_facts_retention_sweep() -> None:

--- a/sql/234_thesis_outcomes.sql
+++ b/sql/234_thesis_outcomes.sql
@@ -1,0 +1,45 @@
+-- 234_thesis_outcomes.sql
+--
+-- #2002 — calibration-ledger core: realized outcomes per thesis version.
+-- Spec: docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md.
+--
+-- One row per (thesis_id, horizon_days) — append-only, insert-once
+-- (ON CONFLICT DO NOTHING; rows are never updated). The ledger scores
+-- THESIS VERSIONS, not instruments: theses are append-only dated
+-- forecasts, so supersession does not cancel measurement.
+--
+-- anchor_date is the minting run's price_anchor.as_of (#2017, persisted
+-- PRE-LLM); anchor_close is re-read deterministically from price_daily
+-- at-or-before that date (never trusted from a JSON copy — the #2014
+-- contract). realized_date is the actual trading day used
+-- (max price_date <= anchor_date + horizon).
+--
+-- method_version is provenance, deliberately NOT part of the identity:
+-- v1 is a single-method table ('oc_v1'). A definition change ships as
+-- its own migration with an explicit recompute-or-new-table decision.
+--
+-- Positive-close CHECKs guard the realized_return division and the
+-- read-side MAPE denominator at write time; a zero/negative close in
+-- price_daily is a data defect, never a ledger row.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS thesis_outcomes (
+    thesis_id       BIGINT      NOT NULL REFERENCES theses(thesis_id),
+    horizon_days    SMALLINT    NOT NULL CHECK (horizon_days IN (30, 90, 365)),
+    anchor_date     DATE        NOT NULL,
+    anchor_close    NUMERIC(18,6) NOT NULL,
+    realized_date   DATE        NOT NULL,
+    realized_close  NUMERIC(18,6) NOT NULL,
+    realized_return NUMERIC     NOT NULL,
+    method_version  TEXT        NOT NULL,
+    computed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (thesis_id, horizon_days),
+    CHECK (anchor_close > 0),
+    CHECK (realized_close > 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_thesis_outcomes_horizon
+    ON thesis_outcomes (horizon_days);
+
+COMMIT;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -164,6 +164,8 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "quotes",
     # #1919 — thesis generation attempts (FK → instruments + theses).
     "thesis_runs",
+    # #2002 — calibration-ledger realized outcomes (FK → theses).
+    "thesis_outcomes",
     "instruments",
     "job_runs",
     "financial_periods_raw",

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -136,6 +136,9 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # See app/jobs/sources.py::Lane.
         "db_thesis_dq",
         "db_thesis_break",
+        # #2002 — thesis_outcome_capture single-job lane (same #2052/#1526
+        # rationale); sole writer of thesis_outcomes.
+        "db_thesis_outcomes",
     }
 )
 

--- a/tests/test_thesis_outcomes.py
+++ b/tests/test_thesis_outcomes.py
@@ -1,0 +1,92 @@
+"""Pure-logic tests for the #2002 calibration-ledger capture predicates.
+
+No DB: anchor parsing, data-anchored maturity, and the immature-pair
+split (data_current / series_stalled / series_dead) are plain functions
+over values — the house lean-test rule."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.thesis_outcomes import (
+    HORIZONS,
+    anchor_date_from_summary,
+    classify_immature,
+    is_mature,
+)
+
+_TODAY = date(2026, 7, 16)
+
+
+def _summary(available: object = True, as_of: object = "2026-07-01") -> dict:
+    return {"blocks": {"price_anchor": {"available": available, "as_of": as_of}}}
+
+
+@pytest.mark.parametrize(
+    ("summary", "expected"),
+    [
+        (_summary(), date(2026, 7, 1)),
+        # ISO timestamp: only the date prefix is read (same as the DQ audit).
+        (_summary(as_of="2026-07-01T12:00:00Z"), date(2026, 7, 1)),
+        (_summary(available=False), None),
+        (_summary(available=None), None),
+        (_summary(as_of=None), None),
+        (_summary(as_of="not-a-date"), None),
+        ({"blocks": {}}, None),
+        ({}, None),
+        (None, None),
+        ("price_anchor", None),
+    ],
+)
+def test_anchor_date_from_summary(summary: object, expected: date | None) -> None:
+    assert anchor_date_from_summary(summary) == expected
+
+
+@pytest.mark.parametrize(
+    ("anchor", "horizon", "max_price", "expected"),
+    [
+        # Maturity is data-anchored: the series must have printed AT or
+        # PAST the due date; wall-clock never participates.
+        (date(2026, 1, 5), 30, date(2026, 2, 4), True),
+        (date(2026, 1, 5), 30, date(2026, 2, 5), True),
+        (date(2026, 1, 5), 30, date(2026, 2, 3), False),
+        (date(2026, 1, 5), 30, None, False),
+        (date(2026, 1, 5), 365, date(2027, 1, 4), False),
+        (date(2026, 1, 5), 365, date(2027, 1, 5), True),
+    ],
+)
+def test_is_mature(anchor: date, horizon: int, max_price: date | None, expected: bool) -> None:
+    assert is_mature(anchor, horizon, max_price) is expected
+
+
+@pytest.mark.parametrize(
+    ("tradable", "max_price", "due", "expected"),
+    [
+        # Live series, pair simply not due yet — the normal young-thesis case.
+        (True, _TODAY, date(2027, 7, 1), "immature_data_current"),
+        (True, date(2026, 7, 15), date(2026, 8, 8), "immature_data_current"),
+        # Series stopped recently (delisted 5d ago), due within grace of the
+        # last print — not yet provably dead.
+        (False, date(2026, 7, 11), date(2026, 7, 18), "immature_series_stalled"),
+        # Tradable but series stale just past grace, due still near last
+        # print — stalled, recovers to data_current if ingest resumes.
+        (True, date(2026, 6, 14), date(2026, 6, 20), "immature_series_stalled"),
+        # Series ended far before the due print — dead; the print this pair
+        # needs will never come.
+        (False, date(2026, 4, 1), date(2026, 7, 1), "series_dead"),
+        (True, date(2026, 6, 1), date(2027, 6, 1), "series_dead"),
+        # No price series at all: absent data is a terminal verdict only
+        # when the instrument is also untradable (Codex ckpt-2 Medium).
+        (True, None, date(2026, 8, 1), "immature_series_stalled"),
+        (False, None, date(2026, 8, 1), "series_dead"),
+    ],
+)
+def test_classify_immature(tradable: bool, max_price: date | None, due: date, expected: str) -> None:
+    assert classify_immature(is_tradable=tradable, max_price_date=max_price, due_date=due, today=_TODAY) == expected
+
+
+def test_horizons_are_the_spec_set() -> None:
+    """Schema CHECK pins (30, 90, 365); the constant must match."""
+    assert HORIZONS == (30, 90, 365)

--- a/tests/test_thesis_outcomes_db.py
+++ b/tests/test_thesis_outcomes_db.py
@@ -1,0 +1,113 @@
+"""Integration test for the #2002 thesis_outcomes ledger (one DB-tier
+file for the genuinely-new SQL mechanism, house rule).
+
+Pins: candidate scan → data-anchored maturity → anchor/realized closes
+re-read from price_daily (at-or-before semantics) → insert-once
+idempotency (PK + ON CONFLICT DO NOTHING), plus the anchorless-thesis
+gap (no rows, counted — never neutral values)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import psycopg
+import pytest
+
+from app.services.thesis_outcomes import METHOD_VERSION, capture_thesis_outcomes
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+_IID = 920_001
+_NOW = datetime.now(tz=UTC)
+_ANCHOR = date(2026, 1, 5)
+
+
+def _seed_thesis(conn: psycopg.Connection[tuple], *, with_run: bool) -> int:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'OUTC', 'Outcome Test Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (_IID,),
+    )
+    row = conn.execute(
+        """
+        INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance, memo_markdown)
+        VALUES (%s, (SELECT COALESCE(MAX(thesis_version), 0) + 1 FROM theses WHERE instrument_id = %s),
+                'value', 'watch', 'memo')
+        RETURNING thesis_id
+        """,
+        (_IID, _IID),
+    ).fetchone()
+    assert row is not None
+    thesis_id = int(row[0])
+    if with_run:
+        conn.execute(
+            """
+            INSERT INTO thesis_runs (instrument_id, trigger, status, thesis_id, context_summary)
+            VALUES (%s, 'manual', 'ok', %s,
+                    '{"blocks": {"price_anchor": {"available": true, "as_of": "2026-01-05"}}}'::jsonb)
+            """,
+            (_IID, thesis_id),
+        )
+    conn.commit()
+    return thesis_id
+
+
+def _seed_prices(conn: psycopg.Connection[tuple]) -> None:
+    # Anchor print, then a gap around the 30d due date (2026-02-04): the
+    # at-or-before read must pick 2026-02-02 as realized_date while the
+    # 2026-02-05 print is what makes the pair mature.
+    for d, close in ((date(2026, 1, 5), 100.0), (date(2026, 2, 2), 110.0), (date(2026, 2, 5), 111.0)):
+        conn.execute(
+            "INSERT INTO price_daily (instrument_id, price_date, close) VALUES (%s, %s, %s) "
+            "ON CONFLICT (instrument_id, price_date) DO UPDATE SET close = EXCLUDED.close",
+            (_IID, d, close),
+        )
+    conn.commit()
+
+
+def test_capture_inserts_once_and_only_mature_horizons(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    thesis_id = _seed_thesis(conn, with_run=True)
+    anchorless_id = _seed_thesis(conn, with_run=False)
+    _seed_prices(conn)
+
+    report = capture_thesis_outcomes(conn)
+
+    assert report.inserted == 1  # 30d mature; 90d/365d not printed yet
+    assert report.anchorless >= 1  # the run-less thesis is a gap, not a row
+    row = conn.execute(
+        """
+        SELECT horizon_days, anchor_date, anchor_close, realized_date,
+               realized_close, realized_return, method_version
+        FROM thesis_outcomes WHERE thesis_id = %s
+        """,
+        (thesis_id,),
+    ).fetchone()
+    assert row is not None
+    horizon, anchor_date, anchor_close, realized_date, realized_close, ret, method = row
+    assert horizon == 30
+    assert anchor_date == _ANCHOR
+    assert float(anchor_close) == pytest.approx(100.0)
+    # due = 2026-02-04 (no print): trading day used = last print at-or-before.
+    assert realized_date == date(2026, 2, 2)
+    assert float(realized_close) == pytest.approx(110.0)
+    assert float(ret) == pytest.approx(0.10)
+    assert method == METHOD_VERSION
+
+    # Insert-once: a re-run inserts nothing and rewrites nothing.
+    rerun = capture_thesis_outcomes(conn)
+    assert rerun.inserted == 0
+    count = conn.execute(
+        "SELECT COUNT(*) FROM thesis_outcomes WHERE thesis_id IN (%s, %s)",
+        (thesis_id, anchorless_id),
+    ).fetchone()
+    assert count is not None and int(count[0]) == 1


### PR DESCRIPTION
Implements the #2002 core slice per merged spec docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md (PR #2058). Schema + deterministic capture job only — scoreboard/frontier surfaces are epic follow-ups.

## What
- **sql/234_thesis_outcomes.sql** — append-only insert-once ledger: PK (thesis_id, horizon_days), horizons CHECK (30/90/365), positive-close CHECKs, method_version='oc_v1' provenance (single-method table by spec). Numbered 234: 232 is reserved by the open #2010 branch, 233 taken by #1996.
- **app/services/thesis_outcomes.py** — pure predicates (anchor_date_from_summary, is_mature, classify_immature) + capture_thesis_outcomes (one DB reader/writer). Anchor re-read from price_daily at-or-before as_of (#2014 contract, never the JSON copy); maturity DATA-anchored (max price_date >= anchor+horizon — wall-clock never mints a row); realized_date = actual trading day used; ON CONFLICT DO NOTHING, inserted counted via rowcount.
- **Scheduler/lane/invoker** — thesis_outcome_capture nightly 05:32 UTC, own db_thesis_outcomes lane (#2052/#1526 lesson: co-firing on boot/manual despite stagger), catch_up_on_boot=False, _INVOKERS row (generic POST /jobs/thesis_outcome_capture/run). row_count = inserted (0 = healthy steady state); full census in tracker note.
- **Tests** — pure table tests (26) + ONE db-tier insert-once integration test; thesis_outcomes appended to fixture truncate list (house rule: new FK-child tables same PR); test_job_registry allowed-sources updated.

## Security model
No new auth surface. The job invoker rides the existing registry-gated POST /jobs/{name}/run (validates against _INVOKERS); service reads/writes dev-internal tables only; no user input anywhere in the path (job takes no params). No FE changes.

## Settled decisions / prevention log
Append-only theses, NULL-never-0 (#1632), single-job-lane discipline (#2052/#1526/#1707), no-ML/evidence-only, data-anchored maturity (EOD-snapshot precedent) — all cited in-spec and preserved. Anchorless theses get NO rows (queryable gap). Typed non-null SQL params only (#1961 n/a beyond that).

## Codex checkpoints
- ckpt-1: ran on the spec (PR #2058) — findings folded into spec (positive-close guard, single-method identity, series_dead split, MAPE-form caveat, lane registration).
- ckpt-2 (this branch): 1 Medium FIXED — tradable instrument with zero price rows now classifies immature_series_stalled, not series_dead (absent data is not a terminal verdict); test updated. 1 Low REBUTTED: today-dependence is confined to the alive-vs-stopped telemetry split; row insertion is purely data-anchored — a liveness notion without a today reference would misreport a frozen-but-tradable series as data_current forever.

## Verification (commit 4a09004b)
- Gates: ruff clean, format clean, pyright 0 errors, fast tier 5225 passed, smoke 12/12, targeted db-tier test green (insert-once + at-or-before semantics + anchorless gap).
- sql/234 applied to dev DB via run_migrations (lifespan during smoke); to_regclass confirms table.
- Dev-verify (job body on dev DB): scanned=399 anchorless=133 inserted=0 mature=0 immature split 186/204/408 (sums to 266 anchor-joinable x 3 horizons — matches spec full-population verification exactly). inserted=0 expected: oldest thesis 2026-07-09 mints its first 30d outcome ~2026-08-08. High stalled/dead is the known dev stale-price artifact (eToro unreachable in this env), same class as #2014's stale_anchor=145 baseline note.
- Tradability caveat: is_tradable=FALSE on dev also reflects the stale universe sync; the split self-corrects as series resume.

## Operator follow-up
None required at merge. Job registers on next jobs-daemon restart (restart already owed since #2049/#2052/#1996 — one restart covers all). First non-zero capture expected ~2026-08-08.

Closes #2002

🤖 Generated with [Claude Code](https://claude.com/claude-code)
