### PR TITLE
feat(#2010): thesis writer prompt v5 — valuation scaffold + break-condition authoring contract + re-gate

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -1323,13 +1323,19 @@ def _validate_writer_output(data: dict[str, object], *, require_buy_zone: bool =
     if zone_low is not None and zone_high is not None and zone_low > zone_high:
         raise ValueError(f"Writer output inverted buy zone: buy_zone_low {zone_low} > buy_zone_high {zone_high}")
 
-    # #2010: a buy with a live price anchor must be actionable — base target
-    # plus both zone bounds. Anchor-less contexts keep the v4 rule (zones are
+    # #2010: a buy with a live price anchor must be actionable — the full
+    # bear/base/bull target set plus both zone bounds (issue wording:
+    # "targets/zone REQUIRED for buy"; Codex ckpt-2 — base alone is not
+    # "targets"). Anchor-less contexts keep the v4 rule (zones are
     # meaningless without a market price), so the call site gates this.
-    # Current pop at ship time: 13/13 v4 buys already comply.
-    if require_buy_zone and stance == "buy" and (base is None or zone_low is None or zone_high is None):
+    # Current pop at ship time: 13/13 v4 buys already carry all five.
+    if (
+        require_buy_zone
+        and stance == "buy"
+        and (bear is None or base is None or bull is None or zone_low is None or zone_high is None)
+    ):
         raise ValueError(
-            "Writer output buy stance requires base_value and buy_zone_low/high when price_anchor is present"
+            "Writer output buy stance requires bear/base/bull values and buy_zone_low/high when price_anchor is present"
         )
 
 
@@ -1405,7 +1411,7 @@ def _insert_thesis_atomic(
     # #2010: writer-native structured predicates — soft-validated, best-effort
     # recall channel. Invalid entries (or a malformed top-level field) are
     # dropped with a warning, NEVER a retry-fail; prose stays canonical.
-    break_predicates, dropped = sanitize_writer_break_predicates(writer.get("break_predicates"), len(break_conditions))
+    break_predicates, dropped = sanitize_writer_break_predicates(writer.get("break_predicates"), break_conditions)
     if dropped:
         logger.warning(
             "Writer break_predicates dropped %d invalid entr%s for instrument_id=%s: %s",

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -135,7 +135,12 @@ _MAX_TOKENS_CRITIC = 2048
 # writer output field break_predicates — structured twins of prose conditions
 # in the #2012 closed vocabulary, soft-validated (never retry-fails), stored
 # in theses.break_predicates_json as a purely-additive recall channel for
-# the nightly break scan. Context shape unchanged.
+# the nightly break scan. Context shape unchanged. Re-gate round 2 (judge A
+# 0-4-7 loss vs v4 exposed three numeric-defect classes in round 1):
+# worked example abstracted to placeholders (the literal "12 x EPS 3.10 =
+# 37.20" leaked verbatim into a MSFT memo), derived arithmetic must END in a
+# per-share price + band sanity cross-check (a $52.8B P/S "target" shipped),
+# cited figures verbatim-or-show-inputs (fabricated 13.1% gross margin).
 _PROMPT_VERSION = "v5"
 
 # thesis_runs.trigger — matches the table CHECK in sql/218.
@@ -1080,13 +1085,21 @@ Rules:
        multiple / the context's current multiple), using a non-null ratio
        from `valuation` (pe_ratio, pb_ratio, p_fcf_ratio, ev_ebitda, ...).
      Justify the multiple you chose (own history or peer judgement) and SHOW
-     THE ARITHMETIC in the memo's valuation section, e.g.
-     "base = 12 x EPS 3.10 = 37.20". Derive bear/bull from the SAME basis
+     THE ARITHMETIC in the memo's valuation section, in the form
+     "base = <your multiple> x EPS <the eps from THIS context> = <product>"
+     — computed from THIS context's numbers, never illustrative ones.
+     Derive bear/bull from the SAME basis
      under stated downside/upside assumptions — never copy context landmarks
      (52-week high/low, book value) into target slots. NEVER derive
      per-share targets from absolute-dollar fields (`fcf`, `revenue_ttm`,
      `cash`, `debt`): share count is not in the context, so any such
-     per-share figure would be fabricated.
+     per-share figure would be fabricated. Your arithmetic must END in a
+     per-share price comparable to `price_anchor.close`; if it produces a
+     $B-scale figure (a market cap, a revenue) the basis is invalid —
+     discard it, do not write it into the memo. When a `fair_value_band` is
+     present at ANY quality, sanity-check your derived base against the
+     band's base/bull — an order-of-magnitude disagreement means your
+     arithmetic is wrong, not the band.
   3. Only when NO basis has its inputs (no eps, no book_value, no usable
      ratio+price): null targets are allowed, but the memo MUST then contain
      an explicit abstention line naming the missing input, e.g.
@@ -1117,6 +1130,10 @@ Rules:
     condition. Conditions outside the vocabulary (filing events, guidance
     cuts, competitive losses) are still good break conditions — they simply
     get no twin.
+- Every figure you cite must either be copied VERBATIM (digit-for-digit)
+  from the context, or be a derived number whose inputs are shown inline
+  (e.g. "price 390.10 vs 52w high 524.00 = 25.5% below"). Never state a
+  rounded or recalled approximation as if it were a context figure.
 - Data-availability language MUST mirror the block status fields verbatim
   (#1632 evidence discipline). Never state a block is unavailable, missing, or
   absent when its `available`/status field marks it present. When a block IS

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -73,6 +73,10 @@ from app.services.fair_value_band import (
 from app.services.instrument_analytics import SCHEMA_VERSION as _IAR_SCHEMA_VERSION
 from app.services.llm_client import LLMClient, LLMClientPair, LLMCompletion
 from app.services.technical_analysis import derive_trend_signals
+
+# Safe at module scope: thesis_break is pure (stdlib only, no app imports) —
+# no cycle risk by construction (its module docstring pins that contract).
+from app.services.thesis_break import sanitize_writer_break_predicates
 from app.services.thesis_context_audit import hash_context, summarize_context
 
 logger = logging.getLogger(__name__)
@@ -123,7 +127,16 @@ _MAX_TOKENS_CRITIC = 2048
 # "You will be given" bullet + a passive grounding rule (band is the primary
 # valuation anchor when available+high quality; price_anchor/52w range remain
 # the fallback). Scoring and _validate_writer_output are untouched.
-_PROMPT_VERSION = "v4"
+# v5 (#2010): valuation scaffold — three-tier target procedure (band-primary /
+# derived-basis with shown arithmetic / justified abstention); buy stance
+# requires targets + zone when a price anchor exists (validator-enforced,
+# rides retry-once); break-condition authoring contract (single metric,
+# false-at-write-time, shares-outstanding denominator only); NEW optional
+# writer output field break_predicates — structured twins of prose conditions
+# in the #2012 closed vocabulary, soft-validated (never retry-fails), stored
+# in theses.break_predicates_json as a purely-additive recall channel for
+# the nightly break scan. Context shape unchanged.
+_PROMPT_VERSION = "v5"
 
 # thesis_runs.trigger — matches the table CHECK in sql/218.
 RunTrigger = Literal["manual", "cascade", "scheduled"]
@@ -1011,6 +1024,9 @@ Produce a JSON object with EXACTLY these fields:
   "bull_value": <float or null>,
   "bear_value": <float or null>,
   "break_conditions": ["<condition 1>", "<condition 2>", ...],
+  "break_predicates": [
+    {"condition_index": <int>, "metric": "<metric>", "op": "<" or ">", "threshold": <float or null>}
+  ],
   "memo_markdown": "<full investment memo in markdown>"
 }
 
@@ -1018,9 +1034,18 @@ Rules:
 - thesis_type must be one of: compounder, value, turnaround, speculative
 - stance must be one of: buy, hold, watch, avoid
 - confidence_score in [0.0, 1.0] — higher means more conviction
-- buy_zone_low/high: only populate when stance is "buy"; null otherwise
-- base/bull/bear_value: per-share price targets in the instrument currency; null if insufficient data
-- break_conditions: list of concrete, specific events that would invalidate the thesis
+- buy_zone_low/high: only populate when stance is "buy"; null otherwise.
+  A "buy" stance with `price_anchor` present MUST carry base_value AND both
+  buy-zone bounds — a buy with no entry band is not actionable and will be
+  rejected.
+- base/bull/bear_value: per-share price targets in the instrument currency.
+  Produce them by the valuation procedure below; null only under its
+  abstention rule.
+- break_conditions: list of concrete, specific events that would invalidate
+  the thesis, written under the authoring contract below.
+- break_predicates: structured twins of break_conditions entries that map
+  onto the machine-checkable vocabulary (rules below). Omit the field, or
+  emit [], when nothing maps.
 - memo_markdown: full structured memo covering: business quality, key financials, recent news
   impact, valuation, risks, stance rationale. Min 3 paragraphs.
 - Use `risk_metrics` to ground the risk section: deep max drawdown, high beta,
@@ -1041,14 +1066,57 @@ Rules:
   stance (an entry band is meaningless without a market price), and emit
   base/bull/bear_value only if fundamentals give a defensible per-share
   basis.
-- `fair_value_band` is deterministic valuation-band evidence — a mechanical
-  prior, not a constraint. When it is available AND `quality_status` is
-  `high`, it is your PRIMARY valuation anchor: ground bear/base/bull against
-  it and explain any large gap; `price_anchor.close` and the 52-week range
-  are the fallback grounding in that case, not a second "justify if outside"
-  test. When it is absent, or `quality_status` is `medium`/`low`, treat it as
-  weak or no evidence and rely on your own judgement grounded in
-  `price_anchor`/fundamentals instead.
+- Valuation procedure — produce bear/base/bull in this priority order:
+  1. `fair_value_band` available AND `quality_status` `high`: it is your
+     PRIMARY valuation anchor — ground bear/base/bull against it and explain
+     any large gap in the memo; `price_anchor.close` and the 52-week range
+     are fallback grounding in that case, not a second "justify if outside"
+     test. (`medium`/`low` bands are weak evidence — fall to tier 2.)
+  2. Otherwise DERIVE the targets from ONE stated basis whose inputs the
+     context actually supplies:
+     - a multiple × `fundamentals` `eps` (per-share), or
+     - a multiple × `fundamentals` `book_value` (per-share), or
+     - re-rating arithmetic: `valuation.current_price` × (your target
+       multiple / the context's current multiple), using a non-null ratio
+       from `valuation` (pe_ratio, pb_ratio, p_fcf_ratio, ev_ebitda, ...).
+     Justify the multiple you chose (own history or peer judgement) and SHOW
+     THE ARITHMETIC in the memo's valuation section, e.g.
+     "base = 12 x EPS 3.10 = 37.20". Derive bear/bull from the SAME basis
+     under stated downside/upside assumptions — never copy context landmarks
+     (52-week high/low, book value) into target slots. NEVER derive
+     per-share targets from absolute-dollar fields (`fcf`, `revenue_ttm`,
+     `cash`, `debt`): share count is not in the context, so any such
+     per-share figure would be fabricated.
+  3. Only when NO basis has its inputs (no eps, no book_value, no usable
+     ratio+price): null targets are allowed, but the memo MUST then contain
+     an explicit abstention line naming the missing input, e.g.
+     "No per-share targets: eps and book_value absent". Silent null targets
+     are not valid output.
+- break_conditions authoring contract (each condition is machine-checked
+  nightly — write them to be checkable):
+  - ONE metric, ONE direction, ONE numeric threshold per condition. (Regime
+    conditions — price vs the 200-day SMA, 50-day vs 200-day SMA — carry no
+    threshold.) Each must be checkable on a single scan: NO composites
+    ("and"/"or"), NO duration or persistence qualifiers ("for 2+ weeks",
+    "sustained"), NO deadlines ("within 6 months", "fails to achieve").
+  - Every condition must be FALSE at write time. A break is a future
+    transition, not a restatement of the present — check the current values
+    in `analytics_evidence` (Altman Z, short interest) and `ta_state` (RSI,
+    SMA regime) first; if the condition already holds today it is your
+    premise, and belongs in the memo, not in break_conditions.
+  - Short interest conditions: denominate ONLY as a percent "of shares
+    outstanding". Float is not in the research context and cannot be
+    checked — never write "of float".
+  - When a condition maps onto the machine vocabulary, ALSO emit a
+    structured twin in `break_predicates`: metric one of [altman_z, rsi_14,
+    short_interest_pct_shares_out, short_interest_days_to_cover,
+    short_interest_change_pct, price_vs_sma200, sma_50_vs_sma_200]; op "<"
+    or ">"; threshold a number — null exactly for the two regime metrics
+    (price_vs_sma200, sma_50_vs_sma_200); condition_index = the 0-based
+    index of the prose condition it mirrors. At most one twin per prose
+    condition. Conditions outside the vocabulary (filing events, guidance
+    cuts, competitive losses) are still good break conditions — they simply
+    get no twin.
 - Data-availability language MUST mirror the block status fields verbatim
   (#1632 evidence discipline). Never state a block is unavailable, missing, or
   absent when its `available`/status field marks it present. When a block IS
@@ -1178,17 +1246,24 @@ def _call_writer(client: LLMClient, context: dict[str, object]) -> tuple[dict[st
     Raises ValueError on unparseable or schema-invalid response
     (after one retry).
     """
+    # Buy-zone enforcement is anchor-gated (#2010): the validator stays
+    # output-only; the context decides whether the rule applies.
+    require_buy_zone = context.get("price_anchor") is not None
+
+    def _validate(data: dict[str, object]) -> None:
+        _validate_writer_output(data, require_buy_zone=require_buy_zone)
+
     return _call_with_one_retry(
         client,
         label="Writer",
         system=_WRITER_SYSTEM,
         user=_build_writer_prompt(context),
         max_tokens=_MAX_TOKENS_WRITER,
-        validate=_validate_writer_output,
+        validate=_validate,
     )
 
 
-def _validate_writer_output(data: dict[str, object]) -> None:
+def _validate_writer_output(data: dict[str, object], *, require_buy_zone: bool = False) -> None:
     required = {
         "thesis_type",
         "confidence_score",
@@ -1247,6 +1322,15 @@ def _validate_writer_output(data: dict[str, object]) -> None:
     zone_high = _to_float(data.get("buy_zone_high"))
     if zone_low is not None and zone_high is not None and zone_low > zone_high:
         raise ValueError(f"Writer output inverted buy zone: buy_zone_low {zone_low} > buy_zone_high {zone_high}")
+
+    # #2010: a buy with a live price anchor must be actionable — base target
+    # plus both zone bounds. Anchor-less contexts keep the v4 rule (zones are
+    # meaningless without a market price), so the call site gates this.
+    # Current pop at ship time: 13/13 v4 buys already comply.
+    if require_buy_zone and stance == "buy" and (base is None or zone_low is None or zone_high is None):
+        raise ValueError(
+            "Writer output buy stance requires base_value and buy_zone_low/high when price_anchor is present"
+        )
 
 
 def _call_critic(client: LLMClient, memo_markdown: str, context: dict[str, object]) -> dict[str, object]:
@@ -1314,7 +1398,22 @@ def _insert_thesis_atomic(
 
     Must be called inside an open transaction.
     """
-    break_conditions = writer.get("break_conditions") or []
+    break_conditions_raw = writer.get("break_conditions")
+    # Validator guarantees a list; the isinstance narrows for the type checker.
+    break_conditions: list[object] = break_conditions_raw if isinstance(break_conditions_raw, list) else []
+
+    # #2010: writer-native structured predicates — soft-validated, best-effort
+    # recall channel. Invalid entries (or a malformed top-level field) are
+    # dropped with a warning, NEVER a retry-fail; prose stays canonical.
+    break_predicates, dropped = sanitize_writer_break_predicates(writer.get("break_predicates"), len(break_conditions))
+    if dropped:
+        logger.warning(
+            "Writer break_predicates dropped %d invalid entr%s for instrument_id=%s: %s",
+            len(dropped),
+            "y" if len(dropped) == 1 else "ies",
+            instrument_id,
+            "; ".join(dropped),
+        )
 
     row = conn.execute(
         """
@@ -1323,7 +1422,7 @@ def _insert_thesis_atomic(
             thesis_type, confidence_score, stance,
             buy_zone_low, buy_zone_high,
             base_value, bull_value, bear_value,
-            break_conditions_json, memo_markdown, critic_json,
+            break_conditions_json, break_predicates_json, memo_markdown, critic_json,
             model, provider, prompt_version
         )
         VALUES (
@@ -1333,7 +1432,7 @@ def _insert_thesis_atomic(
             %(thesis_type)s, %(confidence_score)s, %(stance)s,
             %(buy_zone_low)s, %(buy_zone_high)s,
             %(base_value)s, %(bull_value)s, %(bear_value)s,
-            %(break_conditions_json)s, %(memo_markdown)s, %(critic_json)s,
+            %(break_conditions_json)s, %(break_predicates_json)s, %(memo_markdown)s, %(critic_json)s,
             %(model)s, %(provider)s, %(prompt_version)s
         )
         RETURNING thesis_id, thesis_version
@@ -1349,6 +1448,7 @@ def _insert_thesis_atomic(
             "bull_value": _to_float(writer.get("bull_value")),
             "bear_value": _to_float(writer.get("bear_value")),
             "break_conditions_json": Jsonb(break_conditions),
+            "break_predicates_json": Jsonb(break_predicates) if break_predicates else None,
             "memo_markdown": writer["memo_markdown"],
             "critic_json": Jsonb(critic) if critic else None,
             "model": model,

--- a/app/services/thesis_break.py
+++ b/app/services/thesis_break.py
@@ -27,6 +27,7 @@ Spec: docs/proposals/thesis/2026-07-16-thesis-break-predicates.md.
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -128,6 +129,80 @@ def observe(
             return MetricObservation(metric=metric, status="stale_input", inputs=present)
     as_of = min(inp.as_of for name, inp in present.items() if name in bounds and inp.as_of is not None)
     return MetricObservation(metric=metric, status="ok", value=value, as_of=as_of, inputs=present)
+
+
+# Display units per metric — the writer channel (#2010) has no regex match
+# to derive a unit from, so the vocabulary carries one per metric. The
+# extractor's constructors stay authoritative for their own rows.
+METRIC_UNITS: dict[str, str] = {
+    "altman_z": "zscore",
+    "rsi_14": "index",
+    "short_interest_pct_shares_out": "pct_shares_out",
+    "short_interest_days_to_cover": "days",
+    "short_interest_change_pct": "pct_change",
+    "price_vs_sma200": "regime",
+    "sma_50_vs_sma_200": "regime",
+}
+
+
+def sanitize_writer_break_predicates(
+    raw: object,
+    n_conditions: int,
+) -> tuple[list[dict[str, object]], list[str]]:
+    """Soft-validate the writer's OPTIONAL structured ``break_predicates`` (#2010).
+
+    Returns ``(survivors, drop_reasons)`` — NEVER raises. This channel is
+    best-effort recall: prose ``break_conditions`` stay canonical, and a
+    malformed field (top-level or per-entry) must not retry-fail the thesis.
+    Survivor shape is storage-ready:
+    ``{"condition_index": int, "metric": str, "op": "<"|">", "threshold": float|None}``.
+    ``condition_index`` validates against the RAW ``break_conditions`` array
+    bounds (index-alignment contract, PR-A).
+    """
+    if raw is None:
+        return [], []
+    if not isinstance(raw, list):
+        return [], [f"break_predicates is not a list: {type(raw).__name__}"]
+    survivors: list[dict[str, object]] = []
+    reasons: list[str] = []
+    seen: set[int] = set()
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            reasons.append(f"[{i}] not an object")
+            continue
+        metric = entry.get("metric")
+        if not isinstance(metric, str) or metric not in FRESHNESS_BOUNDS:
+            reasons.append(f"[{i}] unknown metric {metric!r}")
+            continue
+        op = entry.get("op")
+        if op not in ("<", ">"):
+            reasons.append(f"[{i}] invalid op {op!r}")
+            continue
+        idx = entry.get("condition_index")
+        if isinstance(idx, bool) or not isinstance(idx, int) or not (0 <= idx < n_conditions):
+            reasons.append(f"[{i}] condition_index out of range: {idx!r}")
+            continue
+        if idx in seen:
+            reasons.append(f"[{i}] duplicate condition_index {idx}")
+            continue
+        threshold_raw = entry.get("threshold")
+        threshold: float | None
+        if metric in REGIME_METRICS:
+            if threshold_raw is not None:
+                reasons.append(f"[{i}] regime metric {metric} carries threshold {threshold_raw!r}")
+                continue
+            threshold = None
+        else:
+            if isinstance(threshold_raw, bool) or not isinstance(threshold_raw, (int, float)):
+                reasons.append(f"[{i}] non-numeric threshold {threshold_raw!r}")
+                continue
+            threshold = float(threshold_raw)
+            if not math.isfinite(threshold):
+                reasons.append(f"[{i}] non-finite threshold {threshold_raw!r}")
+                continue
+        seen.add(idx)
+        survivors.append({"condition_index": idx, "metric": metric, "op": op, "threshold": threshold})
+    return survivors, reasons
 
 
 EvalResult = Literal["true", "false", "no_input", "stale_input"]

--- a/app/services/thesis_break.py
+++ b/app/services/thesis_break.py
@@ -147,7 +147,7 @@ METRIC_UNITS: dict[str, str] = {
 
 def sanitize_writer_break_predicates(
     raw: object,
-    n_conditions: int,
+    conditions: Sequence[object],
 ) -> tuple[list[dict[str, object]], list[str]]:
     """Soft-validate the writer's OPTIONAL structured ``break_predicates`` (#2010).
 
@@ -157,8 +157,11 @@ def sanitize_writer_break_predicates(
     Survivor shape is storage-ready:
     ``{"condition_index": int, "metric": str, "op": "<"|">", "threshold": float|None}``.
     ``condition_index`` validates against the RAW ``break_conditions`` array
-    bounds (index-alignment contract, PR-A).
+    (index-alignment contract, PR-A) and must point at a STRING slot — a
+    predicate is a structured twin of a prose condition; a twin of a
+    malformed non-string element has no prose to mirror (Codex ckpt-2).
     """
+    n_conditions = len(conditions)
     if raw is None:
         return [], []
     if not isinstance(raw, list):
@@ -181,6 +184,9 @@ def sanitize_writer_break_predicates(
         idx = entry.get("condition_index")
         if isinstance(idx, bool) or not isinstance(idx, int) or not (0 <= idx < n_conditions):
             reasons.append(f"[{i}] condition_index out of range: {idx!r}")
+            continue
+        if not isinstance(conditions[idx], str):
+            reasons.append(f"[{i}] condition_index {idx} points at a non-string condition")
             continue
         if idx in seen:
             reasons.append(f"[{i}] duplicate condition_index {idx}")

--- a/app/services/thesis_break_scan.py
+++ b/app/services/thesis_break_scan.py
@@ -34,6 +34,7 @@ from psycopg.types.json import Jsonb
 
 from app.services.instrument_analytics import read_latest_fy_altman
 from app.services.thesis_break import (
+    METRIC_UNITS,
     BaselineState,
     BreakPredicate,
     MetricInput,
@@ -42,6 +43,7 @@ from app.services.thesis_break import (
     extract_predicates,
     next_baseline_state,
     observe,
+    sanitize_writer_break_predicates,
 )
 
 # SIC division H — finance, insurance, and real estate (Altman gate).
@@ -71,7 +73,8 @@ def _latest_theses(conn: psycopg.Connection[Any]) -> list[dict[str, Any]]:
         cur.execute(
             """
             SELECT DISTINCT ON (t.instrument_id)
-                t.instrument_id, t.thesis_id, t.created_at, t.break_conditions_json
+                t.instrument_id, t.thesis_id, t.created_at, t.break_conditions_json,
+                t.break_predicates_json
             FROM theses t
             ORDER BY t.instrument_id, t.created_at DESC, t.thesis_version DESC, t.thesis_id DESC
             """
@@ -234,32 +237,57 @@ def run_thesis_break_scan(conn: psycopg.Connection[Any], *, now: datetime | None
 
     # -- extract + upsert predicate rows for the latest theses ------------
     sector_gated = 0
-    to_insert: list[tuple[int, int, int, BreakPredicate]] = []
+    to_insert: list[tuple[int, int, int, BreakPredicate, str]] = []
     for t in theses:
         conditions = t["break_conditions_json"]
         if not isinstance(conditions, list):
             continue
         iid = int(t["instrument_id"])
+        # #2010 writer-native channel — PURELY ADDITIVE recall: a validated
+        # writer predicate fills an index ONLY where the extractor returned
+        # None. The 100%-precision extractor channel is never overridden, so
+        # a hallucinated writer twin can never suppress a correct extraction.
+        # Re-sanitize on read (fail-open): rows written before sql/232, or a
+        # hand-edited jsonb, must not crash the scan.
+        writer_preds, _ = sanitize_writer_break_predicates(t["break_predicates_json"], len(conditions))
+        # Sanitizer guarantees condition_index is an int; the isinstance
+        # narrows for the type checker without an assert in the prod path.
+        writer_by_idx = {idx: p for p in writer_preds if isinstance(idx := p["condition_index"], int)}
         # Pass the RAW array — extract_predicates None-maps non-string
         # elements itself, keeping predicate_index aligned with the
         # original break_conditions_json slots (a pre-filter would shift
         # every index after a malformed element).
-        for idx, pred in enumerate(extract_predicates(list(conditions))):
+        for idx, extracted in enumerate(extract_predicates(list(conditions))):
+            origin = "extractor"
+            pred = extracted
             if pred is None:
-                continue
+                wp = writer_by_idx.get(idx)
+                if wp is None:
+                    continue
+                threshold = wp["threshold"]
+                pred = BreakPredicate(
+                    metric=str(wp["metric"]),
+                    op="<" if wp["op"] == "<" else ">",
+                    threshold=float(threshold) if threshold is not None else None,  # type: ignore[arg-type]
+                    unit=METRIC_UNITS[str(wp["metric"])],
+                    source_text=str(conditions[idx]),
+                )
+                origin = "writer"
             if pred.metric in _ALTMAN_METRICS and iid in financial:
                 sector_gated += 1
                 continue
-            to_insert.append((int(t["thesis_id"]), idx, iid, pred))
+            to_insert.append((int(t["thesis_id"]), idx, iid, pred, origin))
 
     inserted_keys: set[tuple[int, int]] = set()
     with conn.transaction():
-        for thesis_id, idx, iid, pred in to_insert:
+        for thesis_id, idx, iid, pred, origin in to_insert:
             row = conn.execute(
                 """
                 INSERT INTO thesis_break_predicates
-                    (thesis_id, predicate_index, instrument_id, metric, op, threshold, unit, source_text)
-                VALUES (%(tid)s, %(idx)s, %(iid)s, %(metric)s, %(op)s, %(threshold)s, %(unit)s, %(src)s)
+                    (thesis_id, predicate_index, instrument_id, metric, op, threshold, unit,
+                     source_text, origin)
+                VALUES (%(tid)s, %(idx)s, %(iid)s, %(metric)s, %(op)s, %(threshold)s, %(unit)s,
+                        %(src)s, %(origin)s)
                 ON CONFLICT (thesis_id, predicate_index) DO NOTHING
                 RETURNING thesis_id, predicate_index
                 """,
@@ -272,6 +300,7 @@ def run_thesis_break_scan(conn: psycopg.Connection[Any], *, now: datetime | None
                     "threshold": pred.threshold,
                     "unit": pred.unit,
                     "src": pred.source_text,
+                    "origin": origin,
                 },
             ).fetchone()
             if row is not None:

--- a/app/services/thesis_break_scan.py
+++ b/app/services/thesis_break_scan.py
@@ -249,7 +249,7 @@ def run_thesis_break_scan(conn: psycopg.Connection[Any], *, now: datetime | None
         # a hallucinated writer twin can never suppress a correct extraction.
         # Re-sanitize on read (fail-open): rows written before sql/232, or a
         # hand-edited jsonb, must not crash the scan.
-        writer_preds, _ = sanitize_writer_break_predicates(t["break_predicates_json"], len(conditions))
+        writer_preds, _ = sanitize_writer_break_predicates(t["break_predicates_json"], conditions)
         # Sanitizer guarantees condition_index is an int; the isinstance
         # narrows for the type checker without an assert in the prod path.
         writer_by_idx = {idx: p for p in writer_preds if isinstance(idx := p["condition_index"], int)}
@@ -281,6 +281,15 @@ def run_thesis_break_scan(conn: psycopg.Connection[Any], *, now: datetime | None
     inserted_keys: set[tuple[int, int]] = set()
     with conn.transaction():
         for thesis_id, idx, iid, pred, origin in to_insert:
+            # DO NOTHING preserves the arm/baseline state on re-scan — with
+            # ONE exception (Codex ckpt-2): if an extractor-vocabulary
+            # improvement now parses a condition a WRITER row filled with a
+            # DIFFERENT predicate, the precision channel takes the slot over
+            # and the baseline resets to pending (the old baseline graded a
+            # different predicate; the gap-uncertainty machinery then applies
+            # — already_true_after_gap if true at next evaluation). Identical
+            # (metric, op, threshold) leaves the row untouched. A writer row
+            # is never allowed to shadow the extractor.
             row = conn.execute(
                 """
                 INSERT INTO thesis_break_predicates
@@ -288,7 +297,20 @@ def run_thesis_break_scan(conn: psycopg.Connection[Any], *, now: datetime | None
                      source_text, origin)
                 VALUES (%(tid)s, %(idx)s, %(iid)s, %(metric)s, %(op)s, %(threshold)s, %(unit)s,
                         %(src)s, %(origin)s)
-                ON CONFLICT (thesis_id, predicate_index) DO NOTHING
+                ON CONFLICT (thesis_id, predicate_index) DO UPDATE SET
+                    metric = EXCLUDED.metric,
+                    op = EXCLUDED.op,
+                    threshold = EXCLUDED.threshold,
+                    unit = EXCLUDED.unit,
+                    source_text = EXCLUDED.source_text,
+                    origin = EXCLUDED.origin,
+                    baseline_state = 'pending',
+                    baselined_at = NULL
+                WHERE thesis_break_predicates.origin = 'writer'
+                  AND EXCLUDED.origin = 'extractor'
+                  AND (thesis_break_predicates.metric, thesis_break_predicates.op,
+                       thesis_break_predicates.threshold)
+                      IS DISTINCT FROM (EXCLUDED.metric, EXCLUDED.op, EXCLUDED.threshold)
                 RETURNING thesis_id, predicate_index
                 """,
                 {

--- a/docs/proposals/thesis/2026-07-16-thesis-prompt-v5-valuation-scaffold.md
+++ b/docs/proposals/thesis/2026-07-16-thesis-prompt-v5-valuation-scaffold.md
@@ -1,0 +1,251 @@
+# Thesis writer prompt v5 — valuation scaffold + break-condition authoring contract (#2010)
+
+Status: proposal (pre-implementation). Closes the last #2012 sibling.
+
+## Problem — full-population evidence (dev, 2026-07-16, 345 latest theses)
+
+The issue's 2026-07-11 numbers (20/27 no-targets, 2/7 zoneless buys) predate
+prompt v3 (#2007) and v4 (#2009 PR-B). Re-scan of the CURRENT population:
+
+1. **Abstention is a band-absence problem, not a stance problem.** v4 latest
+   theses joined to `fair_value_band_current` (fvb_v5, base non-null):
+   band present → 4/42 no-targets (10%); band absent → 194/205 (95%). The v4
+   "band is your primary anchor" rule works; there is NO procedure for the
+   band-absent majority, so the writer abstains.
+2. **Buys already comply.** v4 buys: 13/13 carry targets AND zones (emergent,
+   not enforced). Enforcement is now cheap — zero retro friction.
+3. **"of float" fabrication is alive in v4: 58 conditions** (v3: 20, v2: 3 —
+   scales with population). The writer is handed the caveat
+   "% shares outstanding (public float not ingested)" verbatim
+   (`analytics_evidence` positioning block) and still writes "of float".
+   Float is not ingested; those conditions are machine-uncheckable forever
+   (#2012 extractor Design 4 correctly fails them open).
+4. **Premise conditions**: ~11 conditions evaluate true at baseline; 35 match
+   distress keywords on names already distressed (#2012 census — e.g. "Altman
+   Z crosses into bankruptcy territory (<1.8)" written at z≈−16). The #2012
+   arm/baseline machinery quarantines these (`already_true`), but they are
+   dead recall — the writer stated its own premise.
+5. **Extractor recall is 5.1%** (81/1,585 conditions; 100% precision by
+   hand-audit). Recall was explicitly deferred to #2010: durations
+   ("for 2+ weeks"), composites ("or days-to-cover >5"), and free phrasing
+   all fail open by design.
+
+## Source rules
+
+- Short-interest denominator: shares outstanding, never float. Source
+  authority: FINRA's bimonthly equity short interest files publish SHARES
+  SHORT (a count), no float (`.claude/skills/data-sources/` FINRA notes,
+  #915 ingest); our percent denominator is the EDGAR dei cover-page shares
+  outstanding (stated on every 10-K/10-Q cover — the same source the #2012
+  freshness bound `share_count_filed ≤ 183d` is built on). Neither source
+  publishes float, so float-denominated conditions are uncheckable;
+  imputation is banned (`app/services/instrument_analytics.py:325`) and
+  #2012 spec Design 4 has the extractor accept EXPLICIT "% of shares
+  outstanding" only (shares_out ≥ float ⇒ substituting our denominator
+  systematically under-reports the writer's condition).
+- Break = TRIGGER not verdict; breaks reach EXIT only via regeneration
+  (#2012 spec Design 1, merged). Nothing here touches EXIT.
+- Arm/baseline semantics (#2012 spec Design 5): baseline-true = premise,
+  never fires. v5's "false at write time" prompt rule is the AUTHORING-side
+  complement, not a replacement — the scan-side quarantine stays.
+- Prompt budget (settled decisions "Thesis prompt budget", #1987 v2):
+  context shape unchanged in v5; system-prompt additions must hold the
+  0-length-fail eval gate at the 16k serve window.
+- Closed metric vocabulary (#2012, trust-verified per prevention-log):
+  `altman_z`, `rsi_14`, `short_interest_pct_shares_out`,
+  `short_interest_days_to_cover`, `short_interest_change_pct`,
+  `price_vs_sma200`, `sma_50_vs_sma_200`. v5 emits into this vocabulary and
+  adds nothing to it.
+
+## Design
+
+### 1. `_WRITER_SYSTEM` v5 — valuation scaffold
+
+Replace the v4 band-grounding rule with a three-tier procedure:
+
+- **Tier 1 (band available + quality high)**: unchanged v4 rule — band is the
+  primary anchor; explain any large gap.
+- **Tier 2 (band absent / medium / low)**: NEW — derive bear/base/bull from a
+  stated basis, restricted to bases whose required inputs the context
+  actually supplies (per-basis matrix — Codex ckpt-1 Medium: share count is
+  NOT in the context, so any basis needing it is forbidden):
+  - `multiple × eps` — needs `fundamentals.eps` (per-share, verified);
+  - `multiple × book_value` — needs `fundamentals.book_value` (per-share,
+    verified: AAPL 7.26 vs eps 8.26 on dev);
+  - re-rating arithmetic `current_price × (target_multiple /
+    current_multiple)` — needs `valuation.current_price` + the named ratio
+    non-null (`pe_ratio`, `pb_ratio`, `p_fcf_ratio`, `ev_ebitda`, …); the
+    algebra cancels share count;
+  - FORBIDDEN: bases requiring share count or float (`fcf` and
+    `revenue_ttm` are ABSOLUTE dollars in `fundamentals` — a per-share
+    target from them cannot be derived from context and would be
+    fabricated).
+  Justify the multiple chosen (own-history or peer judgement) and SHOW THE
+  ARITHMETIC in the memo's valuation section (e.g. "base = 12× EPS 3.10 =
+  37.20"). Bear/bull = same basis under stated downside/upside assumptions,
+  not copied context landmarks (AMSC #2007 defect).
+- **Tier 3 (no defensible basis)**: abstention allowed ONLY with an explicit
+  memo line naming the missing input ("No per-share targets: `X` absent").
+  Silent null targets are no longer conformant.
+- **Buy stance**: targets AND buy zone REQUIRED when `price_anchor` is
+  present (validator-enforced, below). `price_anchor` null keeps the v4 rule
+  (zones meaningless without a market price).
+
+### 2. `_WRITER_SYSTEM` v5 — break-condition authoring contract
+
+New rules block replacing nothing (additive):
+
+- Every break condition: ONE metric, ONE direction, ONE numeric threshold
+  (regime conditions — price vs 200d SMA, 50d vs 200d SMA — carry no
+  threshold), checkable on a single scan. No composites ("or"/"and"), no
+  duration/persistence qualifiers ("for 2+ weeks", "sustained"), no
+  deadlines ("within 6 months", "fails to").
+- Conditions must be FALSE at write time — a break is a future transition,
+  not a restatement of the current state. Check against the context's
+  current values (`analytics_evidence` altman/short interest, `ta_state`
+  RSI/SMA regime) before writing one.
+- Short interest denominators: "% of shares outstanding" ONLY. Float is not
+  in the research context and never will be — a float-denominated condition
+  can never be checked.
+- Where a condition maps onto the machine vocabulary, ALSO emit it in the
+  new `break_predicates` output field (schema below). Prose stays canonical
+  for humans; the structured twin is what the nightly scan consumes.
+
+### 3. Writer output schema — `break_predicates` (writer-native recall)
+
+New OPTIONAL output field (operator brief on #2010, item 4):
+
+```json
+"break_predicates": [
+  {"condition_index": 0, "metric": "altman_z", "op": "<", "threshold": 1.8}
+]
+```
+
+- `condition_index` references the `break_conditions` array (0-based).
+- `metric` ∈ closed vocabulary; `op` ∈ {"<", ">"}; `threshold` float, or
+  null for the two regime metrics (`price_vs_sma200`, `sma_50_vs_sma_200`).
+- **Soft-validated at INSERT, never retry-fails the thesis**: entries with
+  unknown metric / bad op / non-numeric threshold (or missing threshold on a
+  non-regime metric, or non-null threshold on a regime metric) / out-of-range
+  `condition_index` / duplicate `condition_index` are DROPPED with a
+  `logger.warning`. A malformed TOP-LEVEL field (non-list, or absent — the
+  field is optional) is likewise dropped whole with a warning, never a
+  schema retry (Codex ckpt-1 High: the retry-once machinery must not fire
+  on this channel). Prose is the canonical record; the structured channel
+  is best-effort recall — same posture as the critic.
+- Stored in new column `theses.break_predicates_json` (sql/232, additive).
+  Only validated survivors are stored.
+
+### 4. Scan merge — writer channel is PURELY ADDITIVE recall
+
+(Codex ckpt-1 High: naive writer-wins would let a hallucinated
+`{metric: "rsi_14"}` attached to an Altman prose condition SUPPRESS the
+extractor's correct predicate — a false scan channel.)
+
+`run_thesis_break_scan` per latest thesis, per raw `break_conditions` index:
+
+- extractor result for that index non-None → **extractor wins,
+  unconditionally** (the 100%-precision channel is never overridden);
+- extractor None AND a validated writer predicate exists for that index →
+  writer predicate fills the slot (`source_text` = the prose condition);
+- neither → no predicate row (unchanged).
+
+The writer channel can therefore only ADD predicates the precision channel
+missed — it can never suppress or contradict one. Upsert into
+`thesis_break_predicates` unchanged (PK `thesis_id, predicate_index` where
+`predicate_index` = raw array index — same alignment contract as PR-A;
+prevention-log raw-array-index lesson applies to the writer channel too:
+`condition_index` validates against the RAW array bounds, not a filtered
+view). New column `thesis_break_predicates.origin`
+(`'extractor'`/`'writer'`, default `'extractor'`) records provenance.
+
+Everything downstream is untouched: freshness bounds, arm/baseline,
+already_true quarantine, altman sector gate (applies at insert regardless of
+origin), event fire path, alerts.
+
+### 5. Validator — buy-stance enforcement
+
+`_validate_writer_output` gains an anchor-gated rule, threaded from the call
+site (the validator itself stays output-only; the writer call passes
+`require_buy_zone=price_anchor is not None`):
+
+- stance == "buy" AND anchor present AND (base_value null OR zone_low null
+  OR zone_high null) → ValueError → rides the existing retry-once.
+
+Current pop: 13/13 v4 buys already comply → expected live failure rate ≈ 0.
+
+**Harness plumbing (Codex ckpt-1 High)**: `scripts/llm_eval_thesis.py`
+`classify_attempt` calls the imported validator directly — it MUST pass
+`require_buy_zone` derived from each fixture's `context["price_anchor"]`,
+or the re-gate silently under-enforces the exact rule it is gating.
+
+### 6. Version + provenance
+
+`_PROMPT_VERSION` "v4" → "v5" (writer system prompt + output schema change;
+context shape unchanged). Version comment documents v5 the same way v3/v4
+are documented.
+
+## Re-gate plan (issue requirement + carried #1995 action)
+
+Fixtures are #1987-era (no `fair_value_band` block) — re-capture first.
+
+1. **Re-capture** `tests/fixtures/llm_eval/` on current dev: panel AAPL, GME,
+   MSFT, JPM, HD (AAPL/JPM/MSFT carry medium bands, GME low, HD absent) + ONE
+   high-band symbol (e.g. FSLR) so Tier 1 is exercised. 6 fixtures.
+2. **Structure gate (v5, qwen3:14b writer+critic)**: ≥10 rounds, gate ≥9/10
+   with retry, 0 critic length-fails — same bar as #1987.
+3. **v4 baseline run (qwen3:14b)** on the SAME new fixtures (old runs are not
+   comparable — different fixtures), for the prompt-regression judge.
+4. **Judge A — v5 vs v4 (qwen3:14b writers)**: content judge; v5 must not
+   lose (win or tie). Checks the scaffold didn't buy targets at the cost of
+   numeric grounding / fabrication.
+5. **Judge B — phi4:14b vs qwen3:14b, both on v5** (MANDATORY carried action
+   from #1995): phi4 content-parity ON THE 6-FIXTURE PANEL — sample
+   evidence, not a full-population claim (Codex ckpt-1 flag) — → recommend
+   promotion (backfill ~2.8d vs 5.6d). Model default flip stays
+   OPERATOR-GATED (PATCH /config) — this PR only posts the recommendation
+   with the sample caveat.
+6. **New measured metric (informational, not a pass/fail gate)**: predicate
+   recall over harness outputs — % of emitted break_conditions covered by a
+   valid machine predicate (writer-native or extracted), plus of-float count
+   (target: 0) and premise-true count vs fixture context values (hand-audit).
+   These are SAMPLE checks — live safety is verified post-merge (below).
+
+All runs on a QUIET Ollama queue (no stale backlog, hourly refresh no-oping,
+`pgrep -f llm_eval_thesis` clean).
+
+## Full-population verification
+
+- Scans in "Problem" above: 345 latest theses (247 v4), band-presence join
+  against fvb_v5, of-float counts by version — full population, not samples.
+- Post-merge: no backfill (prompt change applies to FUTURE generations;
+  theses append-only). Existing wide-backfill gate (#1919 item 12) consumes
+  this PR's gate results.
+- **Post-merge full-population census (Codex ckpt-1 Medium)**: once live v5
+  theses accumulate (~1 week of hourly refresh, before the wide backfill),
+  re-run the of-float / premise-true / abstention census over
+  `prompt_version = 'v5'` rows. The harness numbers are the gate; the live
+  census is the safety claim. Recorded as an operator follow-up on #2010's
+  close-out comment.
+
+## Non-goals
+
+- No EXIT wiring changes (#2012 Design 1; #2050 settled).
+- No extractor pattern changes (precision-gated set stays as PR-A shipped).
+- No model default flip (operator-gated; Judge B produces the evidence).
+- No `_MAX_TOKENS_WRITER` change unless the gate shows length-fails.
+- No live regen wave (issue: re-gate BEFORE any live regen; regen rides the
+  existing staleness machinery + the gated wide backfill).
+
+## Files
+
+- sql/232_thesis_break_predicates_writer_native.sql — `theses.break_predicates_json jsonb`,
+  `thesis_break_predicates.origin text NOT NULL DEFAULT 'extractor' CHECK (origin IN ('extractor','writer'))`
+- app/services/thesis.py — `_WRITER_SYSTEM` v5, `_PROMPT_VERSION`,
+  `_validate_writer_output(require_buy_zone=…)`, INSERT stores validated
+  `break_predicates_json`, soft-validation helper
+- app/services/thesis_break_scan.py — writer-native precedence + origin
+- scripts/llm_eval_thesis.py — only if a measured-metric helper is needed
+  (prefer a scratchpad script; harness stays benchmark-stable)
+- tests: validator table-tests (buy enforcement, predicate soft-validation),
+  scan precedence test, migration listed in test manifest

--- a/docs/proposals/thesis/2026-07-16-thesis-prompt-v5-valuation-scaffold.md
+++ b/docs/proposals/thesis/2026-07-16-thesis-prompt-v5-valuation-scaffold.md
@@ -121,7 +121,9 @@ New OPTIONAL output field (operator brief on #2010, item 4):
 ]
 ```
 
-- `condition_index` references the `break_conditions` array (0-based).
+- `condition_index` references the `break_conditions` array (0-based) and
+  must point at a STRING slot — a twin of a malformed non-string element
+  has no prose to mirror (Codex ckpt-2), so it is dropped.
 - `metric` ∈ closed vocabulary; `op` ∈ {"<", ">"}; `threshold` float, or
   null for the two regime metrics (`price_vs_sma200`, `sma_50_vs_sma_200`).
 - **Soft-validated at INSERT, never retry-fails the thesis**: entries with
@@ -163,16 +165,33 @@ Everything downstream is untouched: freshness bounds, arm/baseline,
 already_true quarantine, altman sector gate (applies at insert regardless of
 origin), event fire path, alerts.
 
+**Re-scan takeover (Codex ckpt-2)**: the upsert's DO NOTHING preserves
+baseline state EXCEPT when an extractor-vocabulary improvement now parses a
+condition a writer-origin row filled with a DIFFERENT (metric, op,
+threshold) — the extractor takes the slot over and the baseline resets to
+pending (the old baseline graded a different predicate; gap-uncertainty
+machinery then applies). Identical predicates leave the row untouched. A
+writer row never shadows the extractor in either direction. Known edge
+(accepted, documented): if the stale writer predicate had already FIRED its
+event, UNIQUE(thesis_id, predicate_index) suppresses a second fire for the
+taken-over predicate on that thesis version — rare (requires a fired writer
+twin AND a vocabulary change that reparses it differently), self-heals on
+the next thesis version.
+
 ### 5. Validator — buy-stance enforcement
 
 `_validate_writer_output` gains an anchor-gated rule, threaded from the call
 site (the validator itself stays output-only; the writer call passes
 `require_buy_zone=price_anchor is not None`):
 
-- stance == "buy" AND anchor present AND (base_value null OR zone_low null
-  OR zone_high null) → ValueError → rides the existing retry-once.
+- stance == "buy" AND anchor present AND (bear/base/bull null OR zone_low
+  null OR zone_high null) → ValueError → rides the existing retry-once.
+  Full target set, not base alone (Codex ckpt-2: issue wording is
+  "targets/zone", and the tier-2 procedure derives bear/bull from the same
+  basis anyway).
 
-Current pop: 13/13 v4 buys already comply → expected live failure rate ≈ 0.
+Current pop: 13/13 v4 buys already carry all five → expected live failure
+rate ≈ 0.
 
 **Harness plumbing (Codex ckpt-1 High)**: `scripts/llm_eval_thesis.py`
 `classify_attempt` calls the imported validator directly — it MUST pass

--- a/scripts/llm_eval_thesis.py
+++ b/scripts/llm_eval_thesis.py
@@ -180,6 +180,7 @@ def classify_attempt(
     duration_s: float,
     *,
     call: str,
+    require_buy_zone: bool = False,
 ) -> tuple[AttemptResult, dict[str, object] | None]:
     """Classify one completion against the production validators.
 
@@ -188,8 +189,18 @@ def classify_attempt(
     (production validator rejected) then pass. ``enum_ok`` is computed
     independently on every PARSED output so the spec's "enum validity"
     metric is reportable even when the schema fails on another field.
+
+    ``require_buy_zone`` mirrors production's anchor-gated buy enforcement
+    (#2010): the harness derives it from each fixture's ``price_anchor``,
+    or the gate silently under-enforces the very rule it is gating.
     """
-    validate = _validate_writer_output if call == "writer" else _validate_critic_output
+    if call == "writer":
+
+        def validate(data: dict[str, object]) -> None:
+            _validate_writer_output(data, require_buy_zone=require_buy_zone)
+
+    else:
+        validate = _validate_critic_output
     enums_ok = _writer_enums_ok if call == "writer" else _critic_enums_ok
 
     try:
@@ -263,6 +274,7 @@ def run_round(
     user: str,
     max_tokens: int,
     iteration: int = 1,
+    require_buy_zone: bool = False,
 ) -> RoundResult:
     """One production-shaped round: attempt, retry ONCE on parse/schema failure.
 
@@ -292,7 +304,9 @@ def run_round(
                 )
             )
             break  # prod does not retry transport errors
-        result, data = classify_attempt(completion, time.monotonic() - start, call=call)
+        result, data = classify_attempt(
+            completion, time.monotonic() - start, call=call, require_buy_zone=require_buy_zone
+        )
         attempts.append(result)
         if result.ok:
             parsed = data
@@ -408,6 +422,7 @@ def run_model(
                 user=_build_writer_prompt(context),
                 max_tokens=_MAX_TOKENS_WRITER,
                 iteration=iteration,
+                require_buy_zone=context.get("price_anchor") is not None,
             )
             rounds.append(writer)
             _print_round(model, iteration, writer)

--- a/sql/232_thesis_writer_native_break_predicates.sql
+++ b/sql/232_thesis_writer_native_break_predicates.sql
@@ -1,0 +1,24 @@
+-- 232_thesis_writer_native_break_predicates.sql
+--
+-- #2010 — thesis writer prompt v5: writer-native break predicates.
+-- Spec: docs/proposals/thesis/2026-07-16-thesis-prompt-v5-valuation-scaffold.md.
+--
+-- theses.break_predicates_json — the writer's OWN structured twins of its
+--   prose break_conditions ([{condition_index, metric, op, threshold}, ...]).
+--   Soft-validated at INSERT (invalid entries dropped, never a retry-fail);
+--   only validated survivors are stored. Prose stays canonical.
+-- thesis_break_predicates.origin — provenance of the scan's predicate row:
+--   'extractor' (the PR-A precision channel) or 'writer' (v5 recall channel).
+--   The writer channel is purely ADDITIVE: it fills only indexes the
+--   extractor returned None for, and can never override the extractor.
+
+BEGIN;
+
+ALTER TABLE theses
+    ADD COLUMN IF NOT EXISTS break_predicates_json JSONB;
+
+ALTER TABLE thesis_break_predicates
+    ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT 'extractor'
+        CHECK (origin IN ('extractor', 'writer'));
+
+COMMIT;

--- a/tests/fixtures/llm_eval/AAPL.json
+++ b/tests/fixtures/llm_eval/AAPL.json
@@ -13,37 +13,168 @@
     "fundamentals": [
       {
         "as_of_date": "2026-03-28",
+        "revenue_ttm": 451442000000.0,
+        "gross_margin": 0.4786,
+        "operating_margin": 0.3264,
+        "fcf": 129174000000.0,
+        "cash": 45572000000.0,
+        "debt": 84697000000.0,
+        "net_debt": 39125000000.0,
+        "eps": 8.26,
+        "book_value": 7.2602
+      },
+      {
+        "as_of_date": "2025-12-27",
+        "revenue_ttm": 435617000000.0,
+        "gross_margin": 0.4733,
+        "operating_margin": 0.3238,
+        "fcf": 123324000000.0,
+        "cash": 45317000000.0,
+        "debt": 90497000000.0,
+        "net_debt": 45180000000.0,
+        "eps": 7.9,
+        "book_value": 5.9982
+      },
+      {
+        "as_of_date": "2025-09-27",
         "revenue_ttm": 416161000000.0,
         "gross_margin": 0.4691,
         "operating_margin": 0.3197,
         "fcf": 98767000000.0,
-        "cash": 45572000000.0,
-        "debt": 82700000000.0,
-        "net_debt": 37128000000.0,
+        "cash": 35934000000.0,
+        "debt": 98657000000.0,
+        "net_debt": 62723000000.0,
         "eps": 7.46,
-        "book_value": 7.2602
+        "book_value": 4.991
+      },
+      {
+        "as_of_date": "2025-06-28",
+        "revenue_ttm": 408625000000.0,
+        "gross_margin": 0.4668,
+        "operating_margin": 0.3187,
+        "fcf": 96184000000.0,
+        "cash": 36269000000.0,
+        "debt": 101723000000.0,
+        "net_debt": 65454000000.0,
+        "eps": 6.59,
+        "book_value": 4.431
+      },
+      {
+        "as_of_date": "2025-03-29",
+        "revenue_ttm": 400366000000.0,
+        "gross_margin": 0.4663,
+        "operating_margin": 0.3181,
+        "fcf": 98486000000.0,
+        "cash": 28162000000.0,
+        "debt": 98182000000.0,
+        "net_debt": 70020000000.0,
+        "eps": 6.42,
+        "book_value": 4.4712
       }
     ],
     "filings": [],
-    "news": [],
+    "news": [
+      {
+        "event_time": "2026-07-16T10:40:27+00:00",
+        "source": "Yahoo Finance",
+        "headline": "AI Weekly: SK Hynix shares jump up and down, Apple sues OpenAI",
+        "category": "earnings",
+        "sentiment_score": 1.0,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-16T10:31:16+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Stock market today: Dow, S&P 500, Nasdaq futures mixed ahead of Netflix earnings",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-16T10:00:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "$3.2 trillion rotation from chips to the 'Magnificent 7' has left the S&P 500 going nowhere: Chart of the Day",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-16T08:31:08+00:00",
+        "source": "Yahoo Finance",
+        "headline": "TSMC scores record profit, eyes on retail sales, earnings - What\u2019s moving markets",
+        "category": "earnings",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-14T12:47:19+00:00",
+        "source": "Yahoo Finance",
+        "headline": "What Could Push GOOGL Stock Higher From Here?",
+        "category": "earnings",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-14T12:12:53+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Berkshire Hathaway (BRK.B) Stock May Be A Bargain After AI Portfolio Shift",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-14T10:54:11+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Buy Apple stock ahead of expected $200 iPhone price hikes: Morgan Stanley",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-13T05:37:56+00:00",
+        "source": "Yahoo Finance",
+        "headline": "TSMC posts record revenue in second quarter on AI demand",
+        "category": "earnings",
+        "sentiment_score": 1.0,
+        "importance_score": 0.8333
+      },
+      {
+        "event_time": "2026-07-16T03:12:22+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Dow Jones Futures: Apple, Google Mask Dell, Sandisk, Micron Sell-Off; J.B. Hunt Jumps Late",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.8141
+      },
+      {
+        "event_time": "2026-07-10T22:12:42+00:00",
+        "source": "Yahoo Finance",
+        "headline": "I\u2019d Put $25,000 in These 2 ETFs Before the Next Earnings Season",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8085
+      }
+    ],
     "prior_thesis": {
-      "version": 1,
+      "version": 5,
       "thesis_type": "compounder",
-      "stance": "buy",
-      "confidence_score": 0.9,
+      "stance": "hold",
+      "confidence_score": 0.75,
       "buy_zone_low": null,
       "buy_zone_high": null,
-      "base_value": null,
-      "bull_value": null,
-      "bear_value": null,
+      "base_value": 309.85,
+      "bull_value": 752.74,
+      "bear_value": 202.32,
       "break_conditions": [
-        "Material disruption in iPhone demand due to macroeconomic collapse",
-        "Regulatory clampdown on AI innovation (core growth driver)",
-        "Breakdown in supply chain resilience (Taiwan/China)",
-        "Sustained failure to innovate in wearables/cloud services"
+        "iPhone demand collapse due to macroeconomic downturn",
+        "Regulatory barriers to AI integration in products",
+        "Geopolitical disruptions in supply chain networks",
+        "Failure to maintain innovation leadership in wearables/cloud",
+        "Valuation multiples (P/E=38.2, P/B=43.5) exceeding historical norms without commensurate growth delivery",
+        "Legal risks from OpenAI trade secrets lawsuit impacting product roadmap or reputation"
       ],
-      "memo_markdown": "### Business Quality\nApple (AAPL) demonstrates textbook compounder attributes with $416B TTM revenue, 46.9% gross margins, and $98.8B free cash flow. Strong balance sheet (net debt/EBITDA < 1x) supports reinvestment. Innovation moats in hardware-software integration and ecosystem lock-in remain intact despite saturation risks in core markets.\n\n### Key Financials\nRecent fundamental snapshot shows 31.97% operating margin, $45.6B cash reserves, and robust 7.46 EPS. While 1Y CAGR appears inflated by partial_window data, 3Y and full-window metrics show 16.7% CAGR vs S&P 500 (benchmark_symbol: SPY). Beta of 1.06 (3Y) reflects moderate volatility, though max drawdown of -33% underscores tail risk exposure.\n\n### Valuation & Risks\nAbsence of current price data limits precise valuation analysis, but book value of $7.26 provides a floor. Risk profile shows 25.5% annualized volatility (3Y) and 2.57% VaR_5, with worst daily loss of -9.4%. While Calmar ratio of 0.51 suggests underperformance during drawdowns, the 1Y window (status: partial_window) shows exceptional risk-adjusted returns (3.36x). Thesis hinges on sustained margin power and services growth, with critical break conditions centered on innovation stagnation or regulatory overreach.",
-      "created_at": "2026-07-09T20:14:19.817578+00:00"
+      "memo_markdown": "### Business Quality\nApple maintains strong compounder characteristics with $451B TTM revenue, 47.86% gross margins, and $45.6B cash reserves. Operating margin of 32.64% and ROA of 33.03% reflect durable profitability. However, rising net debt ($39.1B) and margin pressures from global supply chains pose challenges. The recent lawsuit against OpenAI introduces legal risks that could disrupt AI integration in products.\n\n### Key Financials\nCurrent price of $316.14 is slightly above the fair value band's base value of $309.85 (quality_status: medium). Valuation appears rich (P/E=38.2, P/B=43.5) but fundamentals remain robust with EPS of $8.26 and book value of $7.26. Risk metrics show 16.7% 3Y CAGR (window_key: 3y, as_of_date: 2026-06-12, metric_version: risk_v1), but 25.5% annualized volatility and -33% max drawdown (3Y window) highlight downside risks. Technicals are bullish: price above SMA200 ($272.70), RSI-14=64.6 (neutral), and golden SMA50/200 regime. However, 13F institutional inflows declined 99.6% YoY, and insider net selling (-302,924 shares) raises near-term caution.\n\n### Valuation & Risks\nRich valuations reflect aggressive growth expectations, though dividend yield of 32.9% suggests payout pressure. Fair value band (quality_status: medium) shows a $202.32 to $752.74 range, with current price near the base value. Risk profile includes 25.5% 3Y volatility, -33% max drawdown, and 0.505 Calmar ratio (window_key: 3y). While fundamentals remain strong, valuation stretchedness, legal risks (e.g., AI trade secrets lawsuit), and sector peer grade (quality percentile 95.9%) justify a hold. Break conditions remain critical, and upside requires margin expansion or earnings acceleration without valuation compression.",
+      "created_at": "2026-07-13T13:28:41.010152+00:00"
     },
     "risk_metrics": {
       "metric_version": "risk_v1",
@@ -118,17 +249,17 @@
       ]
     },
     "price_anchor": {
-      "close": 291.22,
-      "price_date": "2026-06-12",
+      "close": 327.91,
+      "price_date": "2026-07-16",
       "currency": "USD",
-      "high_52w": 317.3,
-      "low_52w": 194.7873,
-      "window_days_52w": 248,
-      "return_1w": -0.054235,
-      "return_1m": -0.02514,
-      "return_3m": 0.1653,
-      "return_6m": 0.046531,
-      "return_1y": 0.46488
+      "high_52w": 328.67,
+      "low_52w": 201.1977,
+      "window_days_52w": 252,
+      "return_1w": 0.039664,
+      "return_1m": 0.097607,
+      "return_3m": 0.243733,
+      "return_6m": 0.272829,
+      "return_1y": 0.562483
     },
     "valuation": {
       "available": true,
@@ -138,10 +269,10 @@
       "enterprise_value": 4671914254800.0,
       "pe_ratio": 38.238498789346245,
       "pb_ratio": 43.50404498783935,
-      "p_fcf_ratio": 89.86633408597145,
-      "fcf_yield": 0.011127637620594837,
+      "p_fcf_ratio": 35.86471933051543,
+      "fcf_yield": 0.02788255474089691,
       "ev_revenue": 10.348869300596755,
-      "ev_ebitda": 31.026127339620135,
+      "ev_ebitda": 29.20384466920038,
       "debt_equity_ratio": 0.7953442074917129,
       "net_margin": 0.2715188219084622,
       "gross_margin": 0.47862405358827936,
@@ -151,9 +282,140 @@
       "dividend_yield": 0.3292702232072186,
       "is_complete_ttm": true
     },
+    "fair_value_band": {
+      "available": true,
+      "reason": "ok",
+      "quality_status": "medium",
+      "bear": 151.882286,
+      "base": 298.783697,
+      "bull": 510.862816,
+      "as_of_date": "2026-07-15",
+      "ttm_end": "2026-03-28",
+      "price_as_of": "2026-07-15",
+      "basis": {
+        "ttm_end": "2026-03-28",
+        "selected": [
+          "pe",
+          "ps",
+          "ev_ebitda"
+        ],
+        "multiples": {
+          "pe": {
+            "own": {
+              "p25": 32.3293136790246,
+              "p50": 34.52030379746835,
+              "p75": 36.113523323495656
+            },
+            "peer": {
+              "p25": 33.46023025,
+              "p50": 37.824417,
+              "p75": 61.8477985
+            },
+            "cohort_n": 24,
+            "peer_ids": [
+              1013,
+              1129,
+              4124,
+              4294,
+              4346,
+              4391,
+              6809,
+              10794
+            ],
+            "sic_level": 3,
+            "base_value": 298.78369689354423,
+            "capped_low": false,
+            "own_points": 7,
+            "capped_high": false,
+            "precap_low_mult": 32.3293136790246,
+            "excluded_stale_n": 13,
+            "precap_high_mult": 61.8477985
+          },
+          "ps": {
+            "own": {
+              "p25": 8.213320118154327,
+              "p50": 8.790084298905214,
+              "p75": 9.127707906229334
+            },
+            "peer": {
+              "p25": 4.934768999999999,
+              "p50": 7.6509635,
+              "p75": 11.855698499999999
+            },
+            "screen": {
+              "sic_level": 2,
+              "width_tier": 2,
+              "survivors_n": 15
+            },
+            "cohort_n": 89,
+            "peer_ids": [
+              4273,
+              4294,
+              4346,
+              4391,
+              6456,
+              8912,
+              8946,
+              9589
+            ],
+            "sic_level": 2,
+            "base_value": 253.01122782381816,
+            "capped_low": false,
+            "own_points": 7,
+            "capped_high": false,
+            "cohort_screened": true,
+            "precap_low_mult": 4.934768999999999,
+            "excluded_stale_n": 63,
+            "precap_high_mult": 11.855698499999999
+          },
+          "ev_ebitda": {
+            "own": {
+              "p25": null,
+              "p50": null,
+              "p75": null
+            },
+            "peer": {
+              "p25": 15.9163655,
+              "p50": 31.001234500000002,
+              "p75": 39.65474125
+            },
+            "screen": {
+              "sic_level": 2,
+              "width_tier": 2,
+              "survivors_n": 11
+            },
+            "cohort_n": 45,
+            "net_debt": 39125000000.0,
+            "peer_ids": [
+              4294,
+              4346,
+              4391,
+              6456,
+              8912,
+              8946,
+              9504,
+              9589
+            ],
+            "sic_level": 2,
+            "base_value": 335.4535827576916,
+            "capped_low": true,
+            "ebitda_ttm": 159976000000.0,
+            "own_points": 0,
+            "capped_high": false,
+            "cohort_screened": true,
+            "precap_low_mult": 15.9163655,
+            "excluded_stale_n": 26,
+            "precap_high_mult": 39.65474125
+          }
+        },
+        "price_as_of": "2026-07-15",
+        "own_capped_total": 0,
+        "cross_leg_base_ratio": 1.3258446498322254
+      }
+    },
     "analytics_evidence": {
       "schema": "iar_v1",
-      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "as_of": "2026-07-15T12:43:49.910179+00:00",
       "model_version": "v1.3-balanced",
       "piotroski": {
         "score": 8,
@@ -174,16 +436,16 @@
           "caveat": "<=135d stale",
           "signal": 0.0,
           "source": "ownership_institutions_observations",
-          "delta_shares_pct": -0.9959
+          "delta_shares_pct": -0.9879
         },
         "short_interest": {
-          "asof": "2026-06-15",
+          "asof": "2026-06-30",
           "caveat": "% shares outstanding (public float not ingested); bi-monthly",
           "signal": 1.0,
           "source": "finra_short_interest_current",
           "falling": true,
-          "short_pct": 0.0098,
-          "days_to_cover": 2.76
+          "short_pct": 0.0096,
+          "days_to_cover": 1.73
         },
         "insider_net_90d": {
           "asof": "2026-06-16",
@@ -196,43 +458,43 @@
       },
       "peer_grade": {
         "peer_key": "3",
-        "peer_n": 936,
+        "peer_n": 937,
         "basis": "run_eligible_sector",
         "families": {
           "value": {
-            "hybrid": 0.1616,
-            "percentile": 0.0016
+            "hybrid": 0.0513,
+            "percentile": 0.0069
           },
           "quality": {
-            "hybrid": 0.8674,
-            "percentile": 0.9439
+            "hybrid": 0.7702,
+            "percentile": 0.9589
           },
           "momentum": {
-            "hybrid": 0.5935,
-            "percentile": 0.6255
+            "hybrid": 0.7866,
+            "percentile": 0.8575
           },
           "sentiment": {
-            "hybrid": 0.4846,
-            "percentile": 0.4487
+            "hybrid": 0.6295,
+            "percentile": 0.8746
           },
           "confidence": {
-            "hybrid": 0.5,
-            "percentile": 0.5
+            "hybrid": 0.8239,
+            "percentile": 0.9963
           },
           "turnaround": {
-            "hybrid": 0.478,
-            "percentile": 0.4268
+            "hybrid": 0.7667,
+            "percentile": 0.8058
           }
         }
       }
     },
     "ta_state": {
-      "sma_50": 285.245202,
-      "sma_200": 266.077624,
-      "rsi_14": 43.9262,
-      "macd_histogram": -3.496412,
-      "atr_14": 7.751069,
-      "volatility_30d": 0.245026,
+      "sma_50": 302.0902,
+      "sma_200": 273.739931,
+      "rsi_14": 70.4633,
+      "macd_histogram": 2.699571,
+      "atr_14": 7.855479,
+      "volatility_30d": 0.33448,
       "price_vs_sma200": "above",
       "sma_50_200_regime": "golden"
     },

--- a/tests/fixtures/llm_eval/FSLR.json
+++ b/tests/fixtures/llm_eval/FSLR.json
@@ -1,0 +1,467 @@
+{
+  "symbol": "FSLR",
+  "instrument_id": 1117,
+  "context": {
+    "instrument": {
+      "symbol": "FSLR",
+      "company_name": "First Solar, Inc.",
+      "sector": "8",
+      "industry": null,
+      "country": "US",
+      "currency": "USD"
+    },
+    "fundamentals": [
+      {
+        "as_of_date": "2026-03-31",
+        "revenue_ttm": 5419048000.0,
+        "gross_margin": 0.4174,
+        "operating_margin": 0.3176,
+        "fcf": 1667783000.0,
+        "cash": 2362979000.0,
+        "debt": 237182000.0,
+        "net_debt": -2125797000.0,
+        "eps": 15.48,
+        "book_value": 91.9338
+      },
+      {
+        "as_of_date": "2025-12-31",
+        "revenue_ttm": 5219376000.0,
+        "gross_margin": 0.4062,
+        "operating_margin": 0.3059,
+        "fcf": 1187230000.0,
+        "cash": 2803514000.0,
+        "debt": 282593000.0,
+        "net_debt": -2520921000.0,
+        "eps": 14.21,
+        "book_value": 88.8828
+      },
+      {
+        "as_of_date": "2025-09-30",
+        "revenue_ttm": 5050625000.0,
+        "gross_margin": 0.4005,
+        "operating_margin": 0.2981,
+        "fcf": 614521000.0,
+        "cash": 1992173000.0,
+        "debt": 282565000.0,
+        "net_debt": -1709608000.0,
+        "eps": 13.03,
+        "book_value": 84.0134
+      },
+      {
+        "as_of_date": "2025-06-30",
+        "revenue_ttm": 4343437000.0,
+        "gross_margin": 0.4276,
+        "operating_margin": 0.3135,
+        "fcf": -942701000.0,
+        "cash": 1124740000.0,
+        "debt": 327972000.0,
+        "net_debt": -796768000.0,
+        "eps": 11.7,
+        "book_value": 79.6862
+      },
+      {
+        "as_of_date": "2025-03-31",
+        "revenue_ttm": 4256749000.0,
+        "gross_margin": 0.4361,
+        "operating_margin": 0.3224,
+        "fcf": -976292000.0,
+        "cash": 837641000.0,
+        "debt": 327942000.0,
+        "net_debt": -509699000.0,
+        "eps": 11.77,
+        "book_value": 76.3429
+      }
+    ],
+    "filings": [],
+    "news": [
+      {
+        "event_time": "2026-07-08T15:54:27+00:00",
+        "source": "Yahoo Finance",
+        "headline": "First Solar's Quarterly Earnings Preview: What You Need to Know",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.7776
+      },
+      {
+        "event_time": "2026-07-06T20:36:01+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Why Is First Solar (FSLR) Stock Soaring Today",
+        "category": "analyst_note",
+        "sentiment_score": 0.6667,
+        "importance_score": 0.6672
+      },
+      {
+        "event_time": "2026-07-06T16:26:27+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Wall Street Believes This Solar Stock Could Climb 36% Due To A Potential Tariff Decision Next Month",
+        "category": "analyst_note",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.6469
+      },
+      {
+        "event_time": "2026-07-06T23:24:01+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Why Enphase (ENPH) Stock Is Up Today",
+        "category": "general",
+        "sentiment_score": 1.0,
+        "importance_score": 0.581
+      },
+      {
+        "event_time": "2026-07-08T21:50:03+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Here's Why First Solar (FSLR) Fell More Than Broader Market",
+        "category": "general",
+        "sentiment_score": -0.3333,
+        "importance_score": 0.5733
+      },
+      {
+        "event_time": "2026-07-08T21:05:41+00:00",
+        "source": "Yahoo Finance",
+        "headline": "What The Market Refuses To Pay For FSLR",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.5697
+      },
+      {
+        "event_time": "2026-07-07T22:09:06+00:00",
+        "source": "Yahoo Finance",
+        "headline": "First Solar (FSLR) Draws Tariff Backed Upgrades, Is It Fairly Valued?",
+        "category": "analyst_note",
+        "sentiment_score": 0.0,
+        "importance_score": 0.5572
+      },
+      {
+        "event_time": "2026-07-06T17:42:55+00:00",
+        "source": "Yahoo Finance",
+        "headline": "First Solar Climbs 5% on Bullish Wells Fargo Note, SolarEdge Jumps 8%, Canadian Solar Gains 7%, Enphase Rises 5%",
+        "category": "general",
+        "sentiment_score": 1.0,
+        "importance_score": 0.5531
+      },
+      {
+        "event_time": "2026-07-08T17:11:32+00:00",
+        "source": "Yahoo Finance",
+        "headline": "First Solar (FSLR) Faces New Securities Fraud Lawsuits As August Investor Deadlines Near",
+        "category": "general",
+        "sentiment_score": -0.6667,
+        "importance_score": 0.5505
+      },
+      {
+        "event_time": "2026-07-06T15:40:02+00:00",
+        "source": "Yahoo Finance",
+        "headline": "FSLR or SHLS: Which Is the Better Value Stock Right Now?",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.5431
+      }
+    ],
+    "prior_thesis": null,
+    "risk_metrics": {
+      "metric_version": "risk_v1",
+      "basis_note": "All returns/ratios are fractions (0.10 = 10%, not percent). Drawdown, var_5 and worst_day are signed losses (negative is a loss). Basis is price-return (no dividend reinvestment; total-return is future work), so do not over-read CAGR for high-yield names. A non-'ok' status means the metric is NOT a precise number: treat insufficient_history / partial_window as provisional, and benchmark_missing beta/excess as absent, not zero. Cite a risk figure as {window_key, as_of_date, metric_version}.",
+      "windows": [
+        {
+          "window_key": "1y",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.34129811624017725,
+          "excess_cagr_vs_spy": 0.13540630975342005,
+          "vol_annualized": 0.5371349159254007,
+          "beta": 1.5207065674959175,
+          "beta_r2": 0.13402492617042183,
+          "calmar": 0.9544189478811728,
+          "max_drawdown": -0.35759780020908555,
+          "current_drawdown": -0.24647081266692103,
+          "var_5": -0.04674754,
+          "worst_day": -0.11318835050235279,
+          "cagr_status": "partial_window",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "partial_window"
+        },
+        {
+          "window_key": "3y",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.0756355269503971,
+          "excess_cagr_vs_spy": -0.11893934735072177,
+          "vol_annualized": 0.5631114662416223,
+          "beta": 1.2595629389455592,
+          "beta_r2": 0.10498117805790112,
+          "calmar": 0.12627502594141654,
+          "max_drawdown": -0.5989745508782321,
+          "current_drawdown": -0.24647081266692103,
+          "var_5": -0.04796281,
+          "worst_day": -0.17834324665603912,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        },
+        {
+          "window_key": "full",
+          "as_of_date": "2026-07-07",
+          "benchmark_symbol": "SPY",
+          "cagr": 0.33013167231652385,
+          "excess_cagr_vs_spy": 0.1896580285604142,
+          "vol_annualized": 0.5624926529966506,
+          "beta": 1.1094512234018015,
+          "beta_r2": 0.10562180979536702,
+          "calmar": 0.5511614338747383,
+          "max_drawdown": -0.5989745508782321,
+          "current_drawdown": -0.24647081266692103,
+          "var_5": -0.04655788,
+          "worst_day": -0.17834324665603912,
+          "cagr_status": "ok",
+          "excess_cagr_status": "ok",
+          "vol_status": "ok",
+          "beta_status": "ok",
+          "drawdown_status": "ok",
+          "distribution_status": "ok",
+          "calmar_status": "ok"
+        }
+      ]
+    },
+    "price_anchor": {
+      "close": 227.84,
+      "price_date": "2026-07-10",
+      "currency": "USD",
+      "high_52w": 320.21,
+      "low_52w": 159.6102,
+      "window_days_52w": 252,
+      "return_1w": 0.017143,
+      "return_1m": -0.082585,
+      "return_3m": 0.120819,
+      "return_6m": -0.04302,
+      "return_1y": 0.383427
+    },
+    "valuation": {
+      "available": false,
+      "reason": "no_live_quote"
+    },
+    "fair_value_band": {
+      "available": true,
+      "reason": "ok",
+      "quality_status": "high",
+      "bear": 208.449644,
+      "base": 511.101609,
+      "bull": 1314.435806,
+      "as_of_date": "2026-07-15",
+      "ttm_end": "2026-03-31",
+      "price_as_of": "2026-07-10",
+      "basis": {
+        "ttm_end": "2026-03-31",
+        "selected": [
+          "pe",
+          "ps",
+          "ev_ebitda"
+        ],
+        "multiples": {
+          "pe": {
+            "own": {
+              "p25": 15.758005211319585,
+              "p50": 20.087678571428572,
+              "p75": 37.54231178175662
+            },
+            "peer": {
+              "p25": 28.76029225,
+              "p50": 54.9485305,
+              "p75": 84.91187375
+            },
+            "cohort_n": 37,
+            "peer_ids": [
+              1634,
+              1706,
+              2484,
+              4121,
+              4160,
+              4313,
+              4358,
+              6471
+            ],
+            "sic_level": 4,
+            "base_value": 580.7802582128571,
+            "capped_low": false,
+            "own_points": 15,
+            "capped_high": false,
+            "precap_low_mult": 15.758005211319585,
+            "excluded_stale_n": 14,
+            "precap_high_mult": 84.91187375
+          },
+          "ps": {
+            "own": {
+              "p25": 4.3807146157846075,
+              "p50": 5.406771264039974,
+              "p75": 6.163873485542802
+            },
+            "peer": {
+              "p25": 4.133298,
+              "p50": 8.66183,
+              "p75": 15.53497225
+            },
+            "screen": {
+              "sic_level": 3,
+              "width_tier": 2,
+              "survivors_n": 9
+            },
+            "cohort_n": 81,
+            "peer_ids": [
+              4264,
+              4408,
+              6037,
+              6471,
+              8867,
+              9434,
+              9832,
+              1047933
+            ],
+            "sic_level": 3,
+            "base_value": 354.75241926320706,
+            "capped_low": false,
+            "own_points": 16,
+            "capped_high": false,
+            "cohort_screened": true,
+            "precap_low_mult": 4.133298,
+            "excluded_stale_n": 53,
+            "precap_high_mult": 15.53497225
+          },
+          "ev_ebitda": {
+            "own": {
+              "p25": null,
+              "p50": null,
+              "p75": null
+            },
+            "peer": {
+              "p25": 13.376655750000001,
+              "p50": 23.240141,
+              "p75": 46.3777135
+            },
+            "screen": {
+              "sic_level": 3,
+              "width_tier": 2,
+              "survivors_n": 9
+            },
+            "cohort_n": 37,
+            "net_debt": -2125797000.0,
+            "peer_ids": [
+              4264,
+              4408,
+              6037,
+              6471,
+              8867,
+              9434,
+              9832,
+              1047933
+            ],
+            "sic_level": 3,
+            "base_value": 511.1016091704389,
+            "capped_low": false,
+            "ebitda_ttm": 2271656000.0,
+            "own_points": 0,
+            "capped_high": false,
+            "cohort_screened": true,
+            "precap_low_mult": 13.376655750000001,
+            "excluded_stale_n": 15,
+            "precap_high_mult": 46.3777135
+          }
+        },
+        "price_as_of": "2026-07-10",
+        "own_capped_total": 0,
+        "cross_leg_base_ratio": 1.6371424877639795
+      }
+    },
+    "analytics_evidence": {
+      "schema": "iar_v1",
+      "as_of": "2026-07-15T12:43:49.910179+00:00",
+      "model_version": "v1.3-balanced",
+      "piotroski": {
+        "score": 7,
+        "band": "strong",
+        "components_available": 9,
+        "suppressed": false,
+        "reason": null
+      },
+      "altman_z": {
+        "z": 6.9735,
+        "band": "safe",
+        "reason": null,
+        "suppressed": false
+      },
+      "positioning": {
+        "inst_13f_qoq": {
+          "asof": "2026-06-30",
+          "caveat": "<=135d stale",
+          "signal": 0.0,
+          "source": "ownership_institutions_observations",
+          "delta_shares_pct": -0.9834
+        },
+        "short_interest": {
+          "asof": "2026-06-30",
+          "caveat": "% shares outstanding (public float not ingested); bi-monthly",
+          "signal": 0.9939,
+          "source": "finra_short_interest_current",
+          "falling": true,
+          "short_pct": 0.0765,
+          "days_to_cover": 4.21
+        },
+        "insider_net_90d": {
+          "asof": "2026-06-02",
+          "caveat": null,
+          "signal": 0.4,
+          "source": "insider_transactions",
+          "net_shares": -46265.0,
+          "shares_outstanding": 107453003.0
+        }
+      },
+      "peer_grade": {
+        "peer_key": "8",
+        "peer_n": 348,
+        "basis": "run_eligible_sector",
+        "families": {
+          "value": {
+            "hybrid": 0.5047,
+            "percentile": 0.5158
+          },
+          "quality": {
+            "hybrid": 0.822,
+            "percentile": 0.9698
+          },
+          "momentum": {
+            "hybrid": 0.4136,
+            "percentile": 0.4009
+          },
+          "sentiment": {
+            "hybrid": 0.7125,
+            "percentile": 0.8894
+          },
+          "confidence": {
+            "hybrid": 0.5,
+            "percentile": 0.5
+          },
+          "turnaround": {
+            "hybrid": 0.8855,
+            "percentile": 0.9684
+          }
+        }
+      }
+    },
+    "ta_state": {
+      "sma_50": 249.624,
+      "sma_200": 234.297072,
+      "rsi_14": 41.1635,
+      "macd_histogram": -2.030663,
+      "atr_14": 12.941832,
+      "volatility_30d": 0.592072,
+      "price_vs_sma200": "below",
+      "sma_50_200_regime": "golden"
+    },
+    "earnings_history": [],
+    "analyst_estimates": null
+  }
+}

--- a/tests/fixtures/llm_eval/GME.json
+++ b/tests/fixtures/llm_eval/GME.json
@@ -13,14 +13,14 @@
     "fundamentals": [
       {
         "as_of_date": "2026-05-02",
-        "revenue_ttm": 3629900000.0,
-        "gross_margin": 0.3295,
-        "operating_margin": 0.0639,
-        "fcf": 597300000.0,
+        "revenue_ttm": 3732800000.0,
+        "gross_margin": 0.3439,
+        "operating_margin": 0.1035,
+        "fcf": 740600000.0,
         "cash": 7397600000.0,
-        "debt": 4164300000.0,
-        "net_debt": -3233300000.0,
-        "eps": 0.77,
+        "debt": null,
+        "net_debt": null,
+        "eps": 1.34,
         "book_value": 13.0201
       },
       {
@@ -34,10 +34,54 @@
         "net_debt": -2140400000.0,
         "eps": 0.77,
         "book_value": 12.1445
+      },
+      {
+        "as_of_date": "2025-11-01",
+        "revenue_ttm": 3808200000.0,
+        "gross_margin": 0.3079,
+        "operating_margin": 0.0464,
+        "fcf": 568700000.0,
+        "cash": 7842700000.0,
+        "debt": null,
+        "net_debt": null,
+        "eps": 0.89,
+        "book_value": 11.8397
+      },
+      {
+        "as_of_date": "2025-08-02",
+        "revenue_ttm": 3847500000.0,
+        "gross_margin": 0.3006,
+        "operating_margin": 0.0265,
+        "fcf": 481700000.0,
+        "cash": 8694400000.0,
+        "debt": null,
+        "net_debt": null,
+        "eps": 0.8,
+        "book_value": 11.5648
+      },
+      {
+        "as_of_date": "2025-05-03",
+        "revenue_ttm": 3673600000.0,
+        "gross_margin": 0.3055,
+        "operating_margin": 0.0037,
+        "fcf": 433900000.0,
+        "cash": 6385800000.0,
+        "debt": null,
+        "net_debt": null,
+        "eps": 0.53,
+        "book_value": 11.15
       }
     ],
     "filings": [],
     "news": [
+      {
+        "event_time": "2026-07-14T12:38:01+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Best Buy vs. GameStop: What Their Revenue Trends Tell Investors About These Specialty Retailers",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.8333
+      },
       {
         "event_time": "2026-06-27T00:01:54+00:00",
         "source": "Yahoo Finance",
@@ -53,6 +97,22 @@
         "category": "earnings",
         "sentiment_score": 0.0,
         "importance_score": 0.7723
+      },
+      {
+        "event_time": "2026-07-16T09:12:01+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Uber Eats expands retail offering with GameStop partnership",
+        "category": "general",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.6
+      },
+      {
+        "event_time": "2026-07-15T12:00:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "GameStop Joins Uber Eats to Deliver Video Games, Collectibles, and Electronics to Customers Nationwide",
+        "category": "general",
+        "sentiment_score": 0.0,
+        "importance_score": 0.6
       },
       {
         "event_time": "2026-06-28T04:15:16+00:00",
@@ -93,42 +153,18 @@
         "category": "general",
         "sentiment_score": 0.0,
         "importance_score": 0.5655
-      },
-      {
-        "event_time": "2026-07-07T20:05:00+00:00",
-        "source": "Yahoo Finance",
-        "headline": "GameStop Stockholders Approve Proposals at 2026 Annual Meeting, Including Increased Share Authorization",
-        "category": "general",
-        "sentiment_score": 0.3333,
-        "importance_score": 0.5647
-      },
-      {
-        "event_time": "2026-07-01T20:01:24+00:00",
-        "source": "Yahoo Finance",
-        "headline": "Is The Jack In The Box Short Squeeze Back On?",
-        "category": "general",
-        "sentiment_score": 0.0,
-        "importance_score": 0.5644
-      },
-      {
-        "event_time": "2026-07-01T19:41:56+00:00",
-        "source": "Yahoo Finance",
-        "headline": "Musk Meme Traders Rush Back Into Tesla When the Stock Hits $420",
-        "category": "general",
-        "sentiment_score": 0.0,
-        "importance_score": 0.5628
       }
     ],
     "prior_thesis": {
-      "version": 2,
+      "version": 3,
       "thesis_type": "turnaround",
-      "stance": "watch",
-      "confidence_score": 0.75,
+      "stance": "buy",
+      "confidence_score": 0.82,
       "buy_zone_low": 20.0,
       "buy_zone_high": 25.0,
-      "base_value": 22.5,
-      "bull_value": 30.0,
-      "bear_value": 15.0,
+      "base_value": 24.0,
+      "bull_value": 32.0,
+      "bear_value": 18.0,
       "break_conditions": [
         "Failure to achieve FY26 EBITDA guidance (>$1.5B)",
         "Material delay or underperformance in eBay integration",
@@ -136,8 +172,8 @@
         "Shareholder approval not secured for $8B merger",
         "3Y volatility exceeds 100% annualized"
       ],
-      "memo_markdown": "### Business Quality & Catalysts\nGameStop's FY25 results demonstrate a structural turnaround, with revenue (+75% YoY) and EBITDA ($1.05B) nearing FY26 guidance. The merger with eBay, now shareholder-approved, positions the company to dominate physical-digital convergence. Management's focus on optimizing 20K+ stores while leveraging eBay's 200M active buyers creates a dual-channel growth engine. Improved gross margin (37% vs 18% in 2022) and operating margin (12% vs -60% in 2022) signal operational discipline.\n\n### Valuation & Metrics\nWith shares currently trading at 1.2x FY26 EBITDA (vs 0.4x in early 2023), the stock appears fairly valued relative to its earnings trajectory. Risk metrics highlight extreme volatility (3Y annualized vol: 97%, beta: 1.14), with 5% VaR at -32% (3Y window). Historical max drawdown of -78% (2022) remains a critical risk, though current fundamentals suggest improved resiliency versus the 2022-2023 collapse. Free cash flow of $1.2B and $2.1B net cash provide downside protection.\n\n### Risks & Stance\nDespite progress, execution risks remain: eBay integration (Q1 2025 target), PlayStation 5 lifecycle risks (2025-2026), and potential regulatory scrutiny of the merger. The 3Y volatility and 16% Calmar ratio (annualized return of 22%) suggest high-risk/high-reward dynamics. We maintain a 'watch' stance, with a tighter buy zone ($20-25) reflecting recent strength. Conviction increases to 75% from 65% due to EBITDA upgrades and merger approval, but we await Q1 2025 results before escalating to 'buy' status.",
-      "created_at": "2026-07-10T09:10:48.587112+00:00"
+      "memo_markdown": "### Business Quality & Catalysts\nGameStop has executed a clear turnaround, evidenced by FY25 revenue growth of 75% YoY, strong EBITDA performance ($1.05B), and a revised FY26 EBITDA outlook of $600M (nearly double FY25). The shareholder-approved merger with eBay represents a transformative catalyst, positioning the company to dominate physical-digital retail convergence. Operational improvements are evident: gross margin has expanded to 37% (vs. 18% in 2022), operating margin to 12% (vs. -60% in 2022), and free cash flow reached $1.2B with $2.1B in net cash. The company\u2019s 20K+ store network and eBay\u2019s 200M active buyers create a dual-channel growth engine.\n\n### Valuation & Metrics\nWith shares trading at 1.2x FY26 EBITDA (vs. 0.4x in early 2023), the stock appears fairly valued relative to its earnings trajectory. Valuation metrics highlight a compelling mix of strength and risk: P/E of 16.36, P/B of 1.68, and EV/EBITDA of 6.31. Strong fundamentals include 20.45% net margin, 13.06% ROE, and a 3.38% free cash flow yield. However, risk metrics underscore volatility: 3Y annualized volatility of 97%, beta of 1.15, and a max drawdown of -62.65% (3Y window). The 5% VaR of -5.37% and worst-day loss of -38.89% remain critical downside risks, though current cash reserves offer some downside protection.\n\n### Risks & Stance\nExecution risks persist: eBay integration (Q1 2025 target), PlayStation 5 lifecycle risks (2025\u20132026), and regulatory scrutiny of the merger. The 3Y volatility and low Calmar ratio (-0.03) indicate high-risk/high-reward dynamics. However, improved fundamentals, merger approval, and EBITDA upgrades increase confidence to 82% from 75%. The current price ($21.89) aligns with the $20\u201325 buy zone, suggesting a $24 base target (11% upside) and $32 bull case (46% upside). We upgrade to 'buy' as the thesis gains momentum, but caution remains around integration risks and market volatility.",
+      "created_at": "2026-07-10T12:47:14.742746+00:00"
     },
     "risk_metrics": {
       "metric_version": "risk_v1",
@@ -212,30 +248,30 @@
       ]
     },
     "price_anchor": {
-      "close": 21.89,
-      "price_date": "2026-07-10",
+      "close": 22.15,
+      "price_date": "2026-07-16",
       "currency": "USD",
       "high_52w": 29.65,
       "low_52w": 19.8501,
       "window_days_52w": 252,
-      "return_1w": -0.038647,
-      "return_1m": -0.020143,
-      "return_3m": -0.05809,
-      "return_6m": 0.03264,
-      "return_1y": -0.050544
+      "return_1w": 0.010493,
+      "return_1m": 0.0365,
+      "return_3m": -0.11753,
+      "return_6m": 0.041471,
+      "return_1y": -0.063203
     },
     "valuation": {
       "available": true,
-      "current_price": 21.89,
-      "price_as_of": "2026-07-10T10:34:34.447923+00:00",
-      "market_cap_live": 9822043000.0,
-      "enterprise_value": 2424443000.0,
-      "pe_ratio": 16.33582089552239,
-      "pb_ratio": 1.6812521182451516,
-      "p_fcf_ratio": 29.504484830279363,
-      "fcf_yield": 0.03389315237166036,
-      "ev_revenue": 0.6494971603086155,
-      "ev_ebitda": 6.277687726566546,
+      "current_price": 22.14,
+      "price_as_of": "2026-07-16T11:52:57.307982+00:00",
+      "market_cap_live": 9934218000.0,
+      "enterprise_value": 2536618000.0,
+      "pe_ratio": 16.52238805970149,
+      "pb_ratio": 1.700453261669605,
+      "p_fcf_ratio": 13.413742911153118,
+      "fcf_yield": 0.07455040749055436,
+      "ev_revenue": 0.6795483283326189,
+      "ev_ebitda": 6.568146038322113,
       "debt_equity_ratio": 0.0,
       "net_margin": 0.20445777968281184,
       "gross_margin": 0.3438705529361337,
@@ -245,9 +281,73 @@
       "dividend_yield": null,
       "is_complete_ttm": true
     },
+    "fair_value_band": {
+      "available": true,
+      "reason": "ok",
+      "quality_status": "low",
+      "bear": 9.297443,
+      "base": 15.270444,
+      "bull": 22.733538,
+      "as_of_date": "2026-07-15",
+      "ttm_end": "2026-05-02",
+      "price_as_of": "2026-07-15",
+      "basis": {
+        "ttm_end": "2026-05-02",
+        "selected": [
+          "pe",
+          "ps"
+        ],
+        "multiples": {
+          "pe": {
+            "own": {
+              "p25": 21.898977272727272,
+              "p50": 30.99233766233766,
+              "p75": 124.20222222222223
+            },
+            "peer": {
+              "p25": null,
+              "p50": null,
+              "p75": null
+            },
+            "cohort_n": 4,
+            "sic_level": 0,
+            "own_points": 13,
+            "earnings_nonrep": "G3_spiked",
+            "excluded_stale_n": 3
+          },
+          "ps": {
+            "own": {
+              "p25": 1.1175961093449838,
+              "p50": 1.8355786749335818,
+              "p75": 2.732677480231836
+            },
+            "peer": {
+              "p25": null,
+              "p50": null,
+              "p75": null
+            },
+            "screen": {
+              "reason": "no_screened_cohort"
+            },
+            "cohort_n": 4,
+            "sic_level": 0,
+            "base_value": 15.270443676826552,
+            "capped_low": false,
+            "own_points": 16,
+            "capped_high": false,
+            "cohort_screened": false,
+            "precap_low_mult": 1.1175961093449838,
+            "excluded_stale_n": 3,
+            "precap_high_mult": 2.732677480231836
+          }
+        },
+        "price_as_of": "2026-07-15",
+        "own_capped_total": 0
+      }
+    },
     "analytics_evidence": {
       "schema": "iar_v1",
-      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "as_of": "2026-07-15T12:43:49.910179+00:00",
       "model_version": "v1.3-balanced",
       "piotroski": {
         "score": 6,
@@ -268,65 +368,64 @@
           "caveat": "<=135d stale",
           "signal": 0.0,
           "source": "ownership_institutions_observations",
-          "delta_shares_pct": -0.9996
+          "delta_shares_pct": -0.9985
         },
         "short_interest": {
-          "asof": "2026-06-15",
+          "asof": "2026-06-30",
           "caveat": "% shares outstanding (public float not ingested); bi-monthly",
-          "signal": 0.7914,
+          "signal": 0.8021,
           "source": "finra_short_interest_current",
           "falling": true,
-          "short_pct": 0.1272,
-          "days_to_cover": 8.34
+          "short_pct": 0.1245,
+          "days_to_cover": 10.75
         },
         "insider_net_90d": {
-          "asof": "2026-04-13",
           "caveat": null,
-          "signal": 0.4956,
+          "signal": 0.5,
           "source": "insider_transactions",
-          "net_shares": -3912.0,
+          "net_shares": 0.0,
           "shares_outstanding": 448700000.0
         }
       },
       "peer_grade": {
         "peer_key": "7",
-        "peer_n": 312,
+        "peer_n": 313,
         "basis": "run_eligible_sector",
         "families": {
           "value": {
-            "hybrid": 0.7302,
-            "percentile": 0.9984
+            "hybrid": 0.2336,
+            "percentile": 0.0144
           },
           "quality": {
-            "hybrid": 0.6516,
-            "percentile": 0.7099
+            "hybrid": 0.4762,
+            "percentile": 0.647
           },
           "momentum": {
-            "hybrid": 0.4983,
-            "percentile": 0.4952
+            "hybrid": 0.464,
+            "percentile": 0.4425
           },
           "sentiment": {
-            "hybrid": 0.6608,
-            "percentile": 0.8798
+            "hybrid": 0.6618,
+            "percentile": 0.8802
           },
           "confidence": {
-            "hybrid": 0.5,
-            "percentile": 0.5
+            "hybrid": 0.8735,
+            "percentile": 0.9984
           },
           "turnaround": {
-            "hybrid": 0.2613,
-            "percentile": 0.0545
+            "hybrid": 0.534,
+            "percentile": 0.4968
           }
         }
       }
     },
     "ta_state": {
-      "sma_50": 22.2382,
-      "sma_200": 22.882361,
-      "rsi_14": 48.1195,
-      "macd_histogram": 0.044977,
-      "atr_14": 0.664324,
-      "volatility_30d": 0.268541,
+      "sma_50": 22.0246,
+      "sma_200": 22.802097,
+      "rsi_14": 51.3394,
+      "macd_histogram": 0.040576,
+      "atr_14": 0.64445,
+      "volatility_30d": 0.235094,
       "price_vs_sma200": "below",
       "sma_50_200_regime": "death"
     },

--- a/tests/fixtures/llm_eval/HD.json
+++ b/tests/fixtures/llm_eval/HD.json
@@ -13,15 +13,63 @@
     "fundamentals": [
       {
         "as_of_date": "2026-05-03",
+        "revenue_ttm": 166592000000.0,
+        "gross_margin": 0.3313,
+        "operating_margin": 0.1245,
+        "fcf": 18032000000.0,
+        "cash": 1601000000.0,
+        "debt": 3503000000.0,
+        "net_debt": 1902000000.0,
+        "eps": 14.08,
+        "book_value": 13.9157
+      },
+      {
+        "as_of_date": "2026-02-01",
         "revenue_ttm": 164683000000.0,
         "gross_margin": 0.3332,
         "operating_margin": 0.1268,
         "fcf": 16325000000.0,
-        "cash": 1601000000.0,
-        "debt": 49397000000.0,
-        "net_debt": 47796000000.0,
+        "cash": 1389000000.0,
+        "debt": 53861000000.0,
+        "net_debt": 52472000000.0,
         "eps": 14.23,
-        "book_value": 13.9157
+        "book_value": 12.8645
+      },
+      {
+        "as_of_date": "2025-11-02",
+        "revenue_ttm": 166189000000.0,
+        "gross_margin": 0.3336,
+        "operating_margin": 0.1296,
+        "fcf": 17649000000.0,
+        "cash": 1684000000.0,
+        "debt": 3200000000.0,
+        "net_debt": 1516000000.0,
+        "eps": 14.66,
+        "book_value": 12.1769
+      },
+      {
+        "as_of_date": "2025-08-03",
+        "revenue_ttm": 165054000000.0,
+        "gross_margin": 0.3335,
+        "operating_margin": 0.1309,
+        "fcf": 17872000000.0,
+        "cash": 2804000000.0,
+        "debt": 0.0,
+        "net_debt": -2804000000.0,
+        "eps": 14.71,
+        "book_value": 10.7186
+      },
+      {
+        "as_of_date": "2025-05-04",
+        "revenue_ttm": 162952000000.0,
+        "gross_margin": 0.3334,
+        "operating_margin": 0.1324,
+        "fcf": 18638000000.0,
+        "cash": 1369000000.0,
+        "debt": 38000000.0,
+        "net_debt": -1331000000.0,
+        "eps": 14.73,
+        "book_value": 7.995
       }
     ],
     "filings": [],
@@ -116,9 +164,13 @@
       "available": false,
       "reason": "no_live_quote"
     },
+    "fair_value_band": {
+      "available": false,
+      "reason": "stale_price"
+    },
     "analytics_evidence": {
       "schema": "iar_v1",
-      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "as_of": "2026-07-15T12:43:49.910179+00:00",
       "model_version": "v1.3-balanced",
       "piotroski": {
         "score": 4,
@@ -139,16 +191,16 @@
           "caveat": "<=135d stale",
           "signal": 0.0,
           "source": "ownership_institutions_observations",
-          "delta_shares_pct": -0.9954
+          "delta_shares_pct": -0.9871
         },
         "short_interest": {
-          "asof": "2026-06-15",
+          "asof": "2026-06-30",
           "caveat": "% shares outstanding (public float not ingested); bi-monthly",
           "signal": 1.0,
           "source": "finra_short_interest_current",
-          "falling": false,
-          "short_pct": 0.0136,
-          "days_to_cover": 3.05
+          "falling": true,
+          "short_pct": 0.0133,
+          "days_to_cover": 2.11
         },
         "insider_net_90d": {
           "asof": "2026-05-21",
@@ -161,32 +213,32 @@
       },
       "peer_grade": {
         "peer_key": "7",
-        "peer_n": 312,
+        "peer_n": 313,
         "basis": "run_eligible_sector",
         "families": {
           "value": {
-            "hybrid": 0.5043,
-            "percentile": 0.5144
+            "hybrid": 0.501,
+            "percentile": 0.5032
           },
           "quality": {
-            "hybrid": 0.6647,
-            "percentile": 0.726
+            "hybrid": 0.5671,
+            "percentile": 0.762
           },
           "momentum": {
-            "hybrid": 0.4175,
-            "percentile": 0.367
+            "hybrid": 0.4162,
+            "percentile": 0.3626
           },
           "sentiment": {
-            "hybrid": 0.4779,
-            "percentile": 0.4263
+            "hybrid": 0.4751,
+            "percentile": 0.4169
           },
           "confidence": {
-            "hybrid": 0.5,
-            "percentile": 0.5
+            "hybrid": 0.5029,
+            "percentile": 0.5096
           },
           "turnaround": {
-            "hybrid": 0.4865,
-            "percentile": 0.4551
+            "hybrid": 0.4065,
+            "percentile": 0.3051
           }
         }
       }

--- a/tests/fixtures/llm_eval/JPM.json
+++ b/tests/fixtures/llm_eval/JPM.json
@@ -12,16 +12,64 @@
     },
     "fundamentals": [
       {
-        "as_of_date": "2018-12-31",
-        "revenue_ttm": 182447000000.0,
+        "as_of_date": "2026-03-31",
+        "revenue_ttm": null,
+        "gross_margin": null,
+        "operating_margin": null,
+        "fcf": -107704000000.0,
+        "cash": null,
+        "debt": 68048000000.0,
+        "net_debt": null,
+        "eps": 20.89,
+        "book_value": null
+      },
+      {
+        "as_of_date": "2025-12-31",
+        "revenue_ttm": null,
         "gross_margin": null,
         "operating_margin": null,
         "fcf": -147782000000.0,
-        "cash": 278793000000.0,
-        "debt": 269929000000.0,
-        "net_debt": -8864000000.0,
+        "cash": null,
+        "debt": 64776000000.0,
+        "net_debt": null,
         "eps": 20.02,
-        "book_value": 135.0189
+        "book_value": 134.4255
+      },
+      {
+        "as_of_date": "2025-09-30",
+        "revenue_ttm": null,
+        "gross_margin": null,
+        "operating_margin": null,
+        "fcf": -119748000000.0,
+        "cash": null,
+        "debt": 69355000000.0,
+        "net_debt": null,
+        "eps": 20.2,
+        "book_value": null
+      },
+      {
+        "as_of_date": "2025-06-30",
+        "revenue_ttm": null,
+        "gross_margin": null,
+        "operating_margin": null,
+        "fcf": -148615000000.0,
+        "cash": null,
+        "debt": 65293000000.0,
+        "net_debt": null,
+        "eps": 19.5,
+        "book_value": null
+      },
+      {
+        "as_of_date": "2025-03-31",
+        "revenue_ttm": null,
+        "gross_margin": null,
+        "operating_margin": null,
+        "fcf": -139693000000.0,
+        "cash": null,
+        "debt": 64980000000.0,
+        "net_debt": null,
+        "eps": 20.38,
+        "book_value": null
       }
     ],
     "filings": [],
@@ -35,12 +83,28 @@
         "importance_score": 0.8333
       },
       {
+        "event_time": "2026-07-11T02:39:48+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Dow Jones Futures: Watch Nvidia, Micron, Sandisk, Robinhood As Market Sets Up; Big Earnings Due",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8303
+      },
+      {
         "event_time": "2026-07-08T22:45:00+00:00",
         "source": "Yahoo Finance",
         "headline": "A Positive Outlook as Q2 Earnings Season Gets Underway",
         "category": "earnings",
         "sentiment_score": 0.0,
         "importance_score": 0.8111
+      },
+      {
+        "event_time": "2026-07-10T22:32:00+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Q2 Earnings Season Arrives: Can Results Match Upbeat Expectations?",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.81
       },
       {
         "event_time": "2026-07-01T21:53:03+00:00",
@@ -67,6 +131,14 @@
         "importance_score": 0.799
       },
       {
+        "event_time": "2026-07-10T20:11:38+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Meta Leads Again as Markets Look Forward to Earnings: Stock Market Today",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.7986
+      },
+      {
         "event_time": "2026-07-01T20:09:00+00:00",
         "source": "Yahoo Finance",
         "headline": "Wells Fargo Stock Has Lagged Other Banks. Earnings Can Change That.",
@@ -81,30 +153,6 @@
         "category": "earnings",
         "sentiment_score": 0.3333,
         "importance_score": 0.7948
-      },
-      {
-        "event_time": "2026-07-06T18:35:00+00:00",
-        "source": "Yahoo Finance",
-        "headline": "Navigating the Prospects for Bank ETFs as Q2 Earnings Season Kicks Off",
-        "category": "earnings",
-        "sentiment_score": 0.3333,
-        "importance_score": 0.7907
-      },
-      {
-        "event_time": "2026-07-08T17:12:11+00:00",
-        "source": "Yahoo Finance",
-        "headline": "Wise (LSE:WISE) Stock Sees Split Analyst Revisions As Growth Outlook Improves",
-        "category": "earnings",
-        "sentiment_score": 0.6667,
-        "importance_score": 0.7839
-      },
-      {
-        "event_time": "2026-06-29T16:52:42+00:00",
-        "source": "Yahoo Finance",
-        "headline": "Major Banks Poised for Strong Quarterly Results, Outlook, Deutsche Bank Says",
-        "category": "earnings",
-        "sentiment_score": 0.6667,
-        "importance_score": 0.7823
       }
     ],
     "prior_thesis": null,
@@ -181,25 +229,25 @@
       ]
     },
     "price_anchor": {
-      "close": 331.2,
-      "price_date": "2026-07-09",
+      "close": 336.07,
+      "price_date": "2026-07-10",
       "currency": "USD",
       "high_52w": 343.16,
       "low_52w": 279.0,
       "window_days_52w": 252,
-      "return_1w": -0.007284,
-      "return_1m": 0.064952,
-      "return_3m": 0.070459,
-      "return_6m": 0.005662,
-      "return_1y": 0.171911
+      "return_1w": 0.007313,
+      "return_1m": 0.087605,
+      "return_3m": 0.085007,
+      "return_6m": 0.022434,
+      "return_1y": 0.168501
     },
     "valuation": {
       "available": true,
-      "current_price": 336.12,
-      "price_as_of": "2026-07-10T10:34:30.970861+00:00",
+      "current_price": 345.3,
+      "price_as_of": "2026-07-16T11:51:10.487126+00:00",
       "market_cap_live": null,
       "enterprise_value": null,
-      "pe_ratio": 16.089995213020583,
+      "pe_ratio": 16.52943992340833,
       "pb_ratio": null,
       "p_fcf_ratio": null,
       "fcf_yield": null,
@@ -211,12 +259,64 @@
       "operating_margin": null,
       "roa": 0.012019038970712022,
       "roe": 0.16179354902510176,
-      "dividend_yield": 1.7553254789955968,
+      "dividend_yield": 1.7086591369823343,
       "is_complete_ttm": true
+    },
+    "fair_value_band": {
+      "available": true,
+      "reason": "ok",
+      "quality_status": "medium",
+      "bear": 262.945479,
+      "base": 298.550091,
+      "bull": 365.115953,
+      "as_of_date": "2026-07-15",
+      "ttm_end": "2026-03-31",
+      "price_as_of": "2026-07-10",
+      "basis": {
+        "ttm_end": "2026-03-31",
+        "selected": [
+          "pe"
+        ],
+        "multiples": {
+          "pe": {
+            "own": {
+              "p25": 12.587145935612096,
+              "p50": 14.416306347043733,
+              "p75": 15.375777240416351
+            },
+            "peer": {
+              "p25": 12.819856000000001,
+              "p50": 14.1667565,
+              "p75": 17.4780255
+            },
+            "cohort_n": 72,
+            "peer_ids": [
+              1011,
+              1037,
+              1837,
+              2201,
+              7957,
+              8941,
+              9126,
+              10403
+            ],
+            "sic_level": 4,
+            "base_value": 298.5500914373718,
+            "capped_low": false,
+            "own_points": 6,
+            "capped_high": false,
+            "precap_low_mult": 12.587145935612096,
+            "excluded_stale_n": 52,
+            "precap_high_mult": 17.4780255
+          }
+        },
+        "price_as_of": "2026-07-10",
+        "own_capped_total": 0
+      }
     },
     "analytics_evidence": {
       "schema": "iar_v1",
-      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "as_of": "2026-07-15T12:43:49.910179+00:00",
       "model_version": "v1.3-balanced",
       "piotroski": {
         "score": null,
@@ -236,65 +336,58 @@
           "caveat": "<=135d stale",
           "signal": 0.0,
           "source": "ownership_institutions_observations",
-          "delta_shares_pct": -0.997
+          "delta_shares_pct": -0.988
         },
         "short_interest": {
-          "asof": "2026-06-15",
-          "caveat": "% shares outstanding (public float not ingested); bi-monthly",
-          "signal": 1.0,
-          "source": "finra_short_interest_current",
-          "falling": false,
-          "short_pct": 0.0112,
-          "days_to_cover": 3.55
+          "reason": "no_short_interest_or_shares",
+          "signal": null
         },
         "insider_net_90d": {
           "asof": "2026-06-02",
-          "caveat": null,
-          "signal": 0.4593,
-          "source": "insider_transactions",
-          "net_shares": -219769.0,
-          "shares_outstanding": 2696200000.0
+          "reason": "no_insider_or_shares",
+          "signal": null,
+          "net_shares": -39378.0
         }
       },
       "peer_grade": {
         "peer_key": "4",
-        "peer_n": 616,
+        "peer_n": 619,
         "basis": "run_eligible_sector",
         "families": {
           "value": {
-            "hybrid": 0.8953,
+            "hybrid": 0.8932,
             "percentile": 0.9992
           },
           "quality": {
-            "hybrid": 0.2913,
-            "percentile": 0.1542
+            "hybrid": 0.3818,
+            "percentile": 0.5727
           },
           "momentum": {
-            "hybrid": 0.5855,
-            "percentile": 0.5544
+            "hybrid": 0.6438,
+            "percentile": 0.6438
           },
           "sentiment": {
-            "hybrid": 0.6528,
-            "percentile": 0.8693
+            "hybrid": 0.6589,
+            "percentile": 0.8635
           },
           "confidence": {
-            "hybrid": 0.5,
-            "percentile": 0.5
+            "hybrid": 0.4981,
+            "percentile": 0.4935
           },
           "turnaround": {
-            "hybrid": 0.6876,
-            "percentile": 0.892
+            "hybrid": 0.459,
+            "percentile": 0.3635
           }
         }
       }
     },
     "ta_state": {
-      "sma_50": 314.925,
-      "sma_200": 308.435779,
-      "rsi_14": 56.8793,
-      "macd_histogram": -0.694331,
-      "atr_14": 7.800537,
-      "volatility_30d": 0.212164,
+      "sma_50": 315.4574,
+      "sma_200": 308.574969,
+      "rsi_14": 61.346,
+      "macd_histogram": -0.484935,
+      "atr_14": 7.927335,
+      "volatility_30d": 0.213133,
       "price_vs_sma200": "above",
       "sma_50_200_regime": "golden"
     },

--- a/tests/fixtures/llm_eval/MSFT.json
+++ b/tests/fixtures/llm_eval/MSFT.json
@@ -13,15 +13,63 @@
     "fundamentals": [
       {
         "as_of_date": "2026-03-31",
+        "revenue_ttm": 318273000000.0,
+        "gross_margin": 0.6831,
+        "operating_margin": 0.468,
+        "fcf": 72916000000.0,
+        "cash": 32105000000.0,
+        "debt": 40262000000.0,
+        "net_debt": 8157000000.0,
+        "eps": 16.8,
+        "book_value": 55.777
+      },
+      {
+        "as_of_date": "2025-12-31",
+        "revenue_ttm": 305453000000.0,
+        "gross_margin": 0.6859,
+        "operating_margin": 0.4667,
+        "fcf": 77412000000.0,
+        "cash": 24296000000.0,
+        "debt": 40262000000.0,
+        "net_debt": 15966000000.0,
+        "eps": 15.99,
+        "book_value": 52.6148
+      },
+      {
+        "as_of_date": "2025-09-30",
+        "revenue_ttm": 293812000000.0,
+        "gross_margin": 0.6876,
+        "operating_margin": 0.4627,
+        "fcf": 78017000000.0,
+        "cash": 28849000000.0,
+        "debt": 43208000000.0,
+        "net_debt": 14359000000.0,
+        "eps": 14.06,
+        "book_value": 48.8399
+      },
+      {
+        "as_of_date": "2025-06-30",
         "revenue_ttm": 281724000000.0,
         "gross_margin": 0.6882,
         "operating_margin": 0.4562,
         "fcf": 71611000000.0,
-        "cash": 32105000000.0,
-        "debt": 40262000000.0,
-        "net_debt": 8157000000.0,
+        "cash": 30242000000.0,
+        "debt": 43151000000.0,
+        "net_debt": 12909000000.0,
         "eps": 13.64,
-        "book_value": 55.777
+        "book_value": 46.2038
+      },
+      {
+        "as_of_date": "2025-03-31",
+        "revenue_ttm": 270010000000.0,
+        "gross_margin": 0.6907,
+        "operating_margin": 0.4523,
+        "fcf": 69365000000.0,
+        "cash": 28828000000.0,
+        "debt": 42881000000.0,
+        "net_debt": 14053000000.0,
+        "eps": 12.93,
+        "book_value": 43.2998
       }
     ],
     "filings": [],
@@ -43,12 +91,36 @@
         "importance_score": 0.8233
       },
       {
+        "event_time": "2026-07-11T00:13:16+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Why tech investors are reevaluating AI investments",
+        "category": "earnings",
+        "sentiment_score": 0.3333,
+        "importance_score": 0.8183
+      },
+      {
+        "event_time": "2026-07-10T22:12:42+00:00",
+        "source": "Yahoo Finance",
+        "headline": "I\u2019d Put $25,000 in These 2 ETFs Before the Next Earnings Season",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.8085
+      },
+      {
         "event_time": "2026-06-29T20:26:15+00:00",
         "source": "Yahoo Finance",
         "headline": "Consumer Internet Stocks Q1 Teardown: Expedia (NASDAQ:EXPE) Vs The Rest",
         "category": "earnings",
         "sentiment_score": 0.0,
         "importance_score": 0.7998
+      },
+      {
+        "event_time": "2026-07-10T20:16:34+00:00",
+        "source": "Yahoo Finance",
+        "headline": "Amazon, Microsoft and Meta Among HSBC Earnings Picks",
+        "category": "earnings",
+        "sentiment_score": 0.0,
+        "importance_score": 0.799
       },
       {
         "event_time": "2026-07-08T20:14:46+00:00",
@@ -75,36 +147,12 @@
         "importance_score": 0.798
       },
       {
-        "event_time": "2026-07-04T13:16:18+00:00",
+        "event_time": "2026-07-10T19:13:26+00:00",
         "source": "Yahoo Finance",
-        "headline": "Meta (META) Launches Meta Compute To Sell AI Power Beyond Advertising",
+        "headline": "Microsoft (MSFT) Stock Looks Cheap On Earnings While Cash Flow Drives Debate",
         "category": "earnings",
         "sentiment_score": 0.3333,
-        "importance_score": 0.7646
-      },
-      {
-        "event_time": "2026-06-30T01:08:41+00:00",
-        "source": "Yahoo Finance",
-        "headline": "Wall Street Tech Analyst: Micron Could 4x If the AI Cycle Lasts Through 2030",
-        "category": "analyst_note",
-        "sentiment_score": 0.0,
-        "importance_score": 0.6895
-      },
-      {
-        "event_time": "2026-07-06T19:41:19+00:00",
-        "source": "Yahoo Finance",
-        "headline": "JPMorgan Cuts Wix.com (WIX) Target to $62 in a Sector-Wide Recalibration",
-        "category": "analyst_note",
-        "sentiment_score": -0.6667,
-        "importance_score": 0.6628
-      },
-      {
-        "event_time": "2026-07-08T15:35:24+00:00",
-        "source": "Yahoo Finance",
-        "headline": "Microsoft (MSFT) Unifies Copilot Strategy to Challenge ChatGPT and Claude",
-        "category": "analyst_note",
-        "sentiment_score": 0.0,
-        "importance_score": 0.6427
+        "importance_score": 0.7938
       }
     ],
     "prior_thesis": null,
@@ -181,17 +229,17 @@
       ]
     },
     "price_anchor": {
-      "close": 383.74,
-      "price_date": "2026-07-09",
+      "close": 384.94,
+      "price_date": "2026-07-10",
       "currency": "USD",
       "high_52w": 560.8874,
       "low_52w": 349.21,
       "window_days_52w": 252,
-      "return_1w": -0.016304,
-      "return_1m": -0.050149,
-      "return_3m": 0.027086,
-      "return_6m": -0.196176,
-      "return_1y": -0.236255
+      "return_1w": -0.013227,
+      "return_1m": -0.031597,
+      "return_3m": 0.03819,
+      "return_6m": -0.195546,
+      "return_1y": -0.231009
     },
     "valuation": {
       "available": true,
@@ -204,7 +252,7 @@
       "p_fcf_ratio": 39.74508886938395,
       "fcf_yield": 0.025160341276033987,
       "ev_revenue": 9.131185805896196,
-      "ev_ebitda": 19.510394946192527,
+      "ev_ebitda": 15.738422588908083,
       "debt_equity_ratio": 0.09716507347351502,
       "net_margin": 0.39342325613545603,
       "gross_margin": 0.6830928165442874,
@@ -214,9 +262,140 @@
       "dividend_yield": 0.9125865162778775,
       "is_complete_ttm": true
     },
+    "fair_value_band": {
+      "available": true,
+      "reason": "ok",
+      "quality_status": "medium",
+      "bear": 132.712965,
+      "base": 340.814296,
+      "bull": 994.563704,
+      "as_of_date": "2026-07-15",
+      "ttm_end": "2026-03-31",
+      "price_as_of": "2026-07-10",
+      "basis": {
+        "ttm_end": "2026-03-31",
+        "selected": [
+          "pe",
+          "ps",
+          "ev_ebitda"
+        ],
+        "multiples": {
+          "pe": {
+            "own": {
+              "p25": 28.352392490052054,
+              "p50": 32.54409265325059,
+              "p75": 35.70961616114273
+            },
+            "peer": {
+              "p25": 16.673696,
+              "p50": 25.560779,
+              "p75": 59.2002205
+            },
+            "cohort_n": 70,
+            "peer_ids": [
+              1124,
+              1126,
+              1134,
+              1777,
+              1839,
+              1967,
+              4329,
+              5964
+            ],
+            "sic_level": 4,
+            "base_value": 488.0809218873049,
+            "capped_low": false,
+            "own_points": 16,
+            "capped_high": false,
+            "precap_low_mult": 16.673696,
+            "excluded_stale_n": 47,
+            "precap_high_mult": 59.2002205
+          },
+          "ps": {
+            "own": {
+              "p25": 10.141685540636797,
+              "p50": 11.737075169932414,
+              "p75": 12.679731363806818
+            },
+            "peer": {
+              "p25": 3.0977324999999998,
+              "p50": 4.1732245,
+              "p75": 7.98830025
+            },
+            "screen": {
+              "sic_level": 3,
+              "width_tier": 2,
+              "survivors_n": 9
+            },
+            "cohort_n": 185,
+            "peer_ids": [
+              1126,
+              1777,
+              4378,
+              5653,
+              8851,
+              8939,
+              10198,
+              15235
+            ],
+            "sic_level": 3,
+            "base_value": 340.81429579003895,
+            "capped_low": false,
+            "own_points": 16,
+            "capped_high": false,
+            "cohort_screened": true,
+            "precap_low_mult": 3.0977324999999998,
+            "excluded_stale_n": 158,
+            "precap_high_mult": 12.679731363806818
+          },
+          "ev_ebitda": {
+            "own": {
+              "p25": null,
+              "p50": null,
+              "p75": null
+            },
+            "peer": {
+              "p25": 8.9578515,
+              "p50": 10.5242025,
+              "p75": 26.82634675
+            },
+            "screen": {
+              "sic_level": 3,
+              "width_tier": 2,
+              "survivors_n": 9
+            },
+            "cohort_n": 75,
+            "net_debt": 8157000000.0,
+            "peer_ids": [
+              1126,
+              1777,
+              4378,
+              5653,
+              8851,
+              8939,
+              10198,
+              15235
+            ],
+            "sic_level": 3,
+            "base_value": 260.49409894232065,
+            "capped_low": false,
+            "ebitda_ttm": 184657000000.0,
+            "own_points": 0,
+            "capped_high": false,
+            "cohort_screened": true,
+            "precap_low_mult": 8.9578515,
+            "excluded_stale_n": 56,
+            "precap_high_mult": 26.82634675
+          }
+        },
+        "price_as_of": "2026-07-10",
+        "own_capped_total": 0,
+        "cross_leg_base_ratio": 1.8736736220476808
+      }
+    },
     "analytics_evidence": {
       "schema": "iar_v1",
-      "as_of": "2026-07-09T03:37:43.108188+00:00",
+      "as_of": "2026-07-15T12:43:49.910179+00:00",
       "model_version": "v1.3-balanced",
       "piotroski": {
         "score": 6,
@@ -237,16 +416,16 @@
           "caveat": "<=135d stale",
           "signal": 0.0,
           "source": "ownership_institutions_observations",
-          "delta_shares_pct": -0.9957
+          "delta_shares_pct": -0.987
         },
         "short_interest": {
-          "asof": "2026-06-15",
+          "asof": "2026-06-30",
           "caveat": "% shares outstanding (public float not ingested); bi-monthly",
           "signal": 1.0,
           "source": "finra_short_interest_current",
-          "falling": false,
-          "short_pct": 0.0128,
-          "days_to_cover": 2.61
+          "falling": true,
+          "short_pct": 0.012,
+          "days_to_cover": 1.47
         },
         "insider_net_90d": {
           "asof": "2026-06-15",
@@ -259,43 +438,43 @@
       },
       "peer_grade": {
         "peer_key": "8",
-        "peer_n": 347,
+        "peer_n": 348,
         "basis": "run_eligible_sector",
         "families": {
           "value": {
-            "hybrid": 0.3561,
-            "percentile": 0.0389
+            "hybrid": 0.3569,
+            "percentile": 0.0417
           },
           "quality": {
-            "hybrid": 0.9149,
-            "percentile": 0.9496
+            "hybrid": 0.9291,
+            "percentile": 0.9971
           },
           "momentum": {
-            "hybrid": 0.4566,
-            "percentile": 0.4568
+            "hybrid": 0.4679,
+            "percentile": 0.4641
           },
           "sentiment": {
-            "hybrid": 0.6032,
-            "percentile": 0.7795
+            "hybrid": 0.609,
+            "percentile": 0.7773
           },
           "confidence": {
             "hybrid": 0.5,
             "percentile": 0.5
           },
           "turnaround": {
-            "hybrid": 0.4767,
-            "percentile": 0.4222
+            "hybrid": 0.7414,
+            "percentile": 0.7213
           }
         }
       }
     },
     "ta_state": {
-      "sma_50": 402.6666,
-      "sma_200": 440.919094,
-      "rsi_14": 46.7925,
-      "macd_histogram": 2.493489,
-      "atr_14": 11.504433,
-      "volatility_30d": 0.372588,
+      "sma_50": 402.1618,
+      "sma_200": 440.271361,
+      "rsi_14": 47.5761,
+      "macd_histogram": 2.402335,
+      "atr_14": 12.075691,
+      "volatility_30d": 0.337049,
       "price_vs_sma200": "below",
       "sma_50_200_regime": "death"
     },

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -398,6 +398,41 @@ class TestValidateWriterOutput:
         # Degenerate but coherent: bear == base == bull is allowed (strict > only).
         _validate_writer_output({**_VALID_WRITER, "bear_value": 200.0, "base_value": 200.0, "bull_value": 200.0})
 
+    # --- anchor-gated buy enforcement (#2010) ---
+
+    def test_buy_with_anchor_requires_base(self) -> None:
+        bad = {**_VALID_WRITER, "base_value": None, "bear_value": None, "bull_value": None}
+        with pytest.raises(ValueError, match="buy stance requires"):
+            _validate_writer_output(bad, require_buy_zone=True)
+
+    def test_buy_with_anchor_requires_zone(self) -> None:
+        bad = {**_VALID_WRITER, "buy_zone_high": None}
+        with pytest.raises(ValueError, match="buy stance requires"):
+            _validate_writer_output(bad, require_buy_zone=True)
+
+    def test_buy_with_anchor_complete_passes(self) -> None:
+        _validate_writer_output(_VALID_WRITER, require_buy_zone=True)
+
+    def test_non_buy_with_anchor_null_targets_passes(self) -> None:
+        # Only the buy stance is gated — watch/hold/avoid may abstain
+        # (tier-3 justification is a prompt rule, not a schema rule).
+        ok = {
+            **_VALID_WRITER,
+            "stance": "watch",
+            "buy_zone_low": None,
+            "buy_zone_high": None,
+            "base_value": None,
+            "bull_value": None,
+            "bear_value": None,
+        }
+        _validate_writer_output(ok, require_buy_zone=True)
+
+    def test_buy_without_anchor_null_zone_passes(self) -> None:
+        # Anchor-less contexts keep the v4 rule: zones are meaningless
+        # without a market price, so nulls remain valid.
+        ok = {**_VALID_WRITER, "buy_zone_low": None, "buy_zone_high": None, "base_value": None}
+        _validate_writer_output(ok, require_buy_zone=False)
+
     def test_nan_band_value_treated_as_missing(self) -> None:
         # NaN coerces to None (via _to_float), so it drops out of the ordering
         # comparison rather than silently passing an incoherent band.

--- a/tests/test_thesis_break.py
+++ b/tests/test_thesis_break.py
@@ -307,25 +307,25 @@ def test_premise_true_stays() -> None:
 
 
 def test_sanitize_none_is_empty_ok() -> None:
-    assert sanitize_writer_break_predicates(None, 3) == ([], [])
+    assert sanitize_writer_break_predicates(None, ["a", "b", "c"]) == ([], [])
 
 
 def test_sanitize_non_list_dropped_whole() -> None:
-    survivors, reasons = sanitize_writer_break_predicates({"metric": "rsi_14"}, 3)
+    survivors, reasons = sanitize_writer_break_predicates({"metric": "rsi_14"}, ["a", "b", "c"])
     assert survivors == []
     assert reasons == ["break_predicates is not a list: dict"]
 
 
 def test_sanitize_valid_threshold_entry_survives_normalized() -> None:
     raw = [{"condition_index": 1, "metric": "altman_z", "op": "<", "threshold": 2}]
-    survivors, reasons = sanitize_writer_break_predicates(raw, 2)
+    survivors, reasons = sanitize_writer_break_predicates(raw, ["c0", "c1"])
     assert reasons == []
     assert survivors == [{"condition_index": 1, "metric": "altman_z", "op": "<", "threshold": 2.0}]
 
 
 def test_sanitize_valid_regime_entry_survives() -> None:
     raw = [{"condition_index": 0, "metric": "price_vs_sma200", "op": "<", "threshold": None}]
-    survivors, reasons = sanitize_writer_break_predicates(raw, 1)
+    survivors, reasons = sanitize_writer_break_predicates(raw, ["c0"])
     assert reasons == []
     assert survivors == [{"condition_index": 0, "metric": "price_vs_sma200", "op": "<", "threshold": None}]
 
@@ -348,7 +348,7 @@ def test_sanitize_valid_regime_entry_survives() -> None:
     ],
 )
 def test_sanitize_invalid_entries_dropped(entry: object, reason_fragment: str) -> None:
-    survivors, reasons = sanitize_writer_break_predicates([entry], 2)
+    survivors, reasons = sanitize_writer_break_predicates([entry], ["c0", "c1"])
     assert survivors == []
     assert len(reasons) == 1 and reason_fragment in reasons[0]
 
@@ -358,7 +358,7 @@ def test_sanitize_duplicate_condition_index_second_dropped() -> None:
         {"condition_index": 0, "metric": "rsi_14", "op": "<", "threshold": 30},
         {"condition_index": 0, "metric": "altman_z", "op": "<", "threshold": 1.8},
     ]
-    survivors, reasons = sanitize_writer_break_predicates(raw, 1)
+    survivors, reasons = sanitize_writer_break_predicates(raw, ["c0"])
     assert [s["metric"] for s in survivors] == ["rsi_14"]
     assert len(reasons) == 1 and "duplicate condition_index" in reasons[0]
 
@@ -369,7 +369,7 @@ def test_sanitize_mixed_keeps_survivors() -> None:
         {"condition_index": 1, "metric": "made_up", "op": ">", "threshold": 5},
         {"condition_index": 2, "metric": "sma_50_vs_sma_200", "op": "<", "threshold": None},
     ]
-    survivors, reasons = sanitize_writer_break_predicates(raw, 3)
+    survivors, reasons = sanitize_writer_break_predicates(raw, ["c0", "c1", "c2"])
     assert [s["condition_index"] for s in survivors] == [0, 2]
     assert len(reasons) == 1 and "unknown metric" in reasons[0]
 
@@ -378,3 +378,12 @@ def test_metric_units_cover_full_vocabulary() -> None:
     # The writer channel derives its unit from METRIC_UNITS — every metric
     # the sanitizer can pass must have one (KeyError at scan time otherwise).
     assert set(METRIC_UNITS) == set(FRESHNESS_BOUNDS)
+
+
+def test_sanitize_non_string_condition_slot_dropped() -> None:
+    # Codex ckpt-2: a structured twin must mirror a PROSE condition — an
+    # index pointing at a malformed non-string element has nothing to mirror.
+    raw = [{"condition_index": 1, "metric": "rsi_14", "op": "<", "threshold": 30}]
+    survivors, reasons = sanitize_writer_break_predicates(raw, ["ok", 123])
+    assert survivors == []
+    assert len(reasons) == 1 and "non-string condition" in reasons[0]

--- a/tests/test_thesis_break.py
+++ b/tests/test_thesis_break.py
@@ -13,12 +13,15 @@ import pytest
 
 from app.services.thesis_break import (
     BASELINE_GRACE,
+    FRESHNESS_BOUNDS,
+    METRIC_UNITS,
     BreakPredicate,
     MetricInput,
     evaluate_predicate,
     extract_predicates,
     next_baseline_state,
     observe,
+    sanitize_writer_break_predicates,
 )
 
 # ---------------------------------------------------------------------------
@@ -296,3 +299,82 @@ def test_premise_true_stays() -> None:
         "already_true",
         False,
     )
+
+
+# ---------------------------------------------------------------------------
+# sanitize_writer_break_predicates — writer-native channel (#2010)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_none_is_empty_ok() -> None:
+    assert sanitize_writer_break_predicates(None, 3) == ([], [])
+
+
+def test_sanitize_non_list_dropped_whole() -> None:
+    survivors, reasons = sanitize_writer_break_predicates({"metric": "rsi_14"}, 3)
+    assert survivors == []
+    assert reasons == ["break_predicates is not a list: dict"]
+
+
+def test_sanitize_valid_threshold_entry_survives_normalized() -> None:
+    raw = [{"condition_index": 1, "metric": "altman_z", "op": "<", "threshold": 2}]
+    survivors, reasons = sanitize_writer_break_predicates(raw, 2)
+    assert reasons == []
+    assert survivors == [{"condition_index": 1, "metric": "altman_z", "op": "<", "threshold": 2.0}]
+
+
+def test_sanitize_valid_regime_entry_survives() -> None:
+    raw = [{"condition_index": 0, "metric": "price_vs_sma200", "op": "<", "threshold": None}]
+    survivors, reasons = sanitize_writer_break_predicates(raw, 1)
+    assert reasons == []
+    assert survivors == [{"condition_index": 0, "metric": "price_vs_sma200", "op": "<", "threshold": None}]
+
+
+@pytest.mark.parametrize(
+    "entry, reason_fragment",
+    [
+        ("not a dict", "not an object"),
+        ({"condition_index": 0, "metric": "float_pct", "op": "<", "threshold": 1.0}, "unknown metric"),
+        ({"condition_index": 0, "metric": "rsi_14", "op": "<=", "threshold": 30}, "invalid op"),
+        ({"condition_index": 2, "metric": "rsi_14", "op": "<", "threshold": 30}, "out of range"),
+        ({"condition_index": -1, "metric": "rsi_14", "op": "<", "threshold": 30}, "out of range"),
+        ({"condition_index": True, "metric": "rsi_14", "op": "<", "threshold": 30}, "out of range"),
+        ({"condition_index": "0", "metric": "rsi_14", "op": "<", "threshold": 30}, "out of range"),
+        ({"condition_index": 0, "metric": "rsi_14", "op": "<", "threshold": "30"}, "non-numeric threshold"),
+        ({"condition_index": 0, "metric": "rsi_14", "op": "<", "threshold": True}, "non-numeric threshold"),
+        ({"condition_index": 0, "metric": "rsi_14", "op": "<", "threshold": None}, "non-numeric threshold"),
+        ({"condition_index": 0, "metric": "rsi_14", "op": "<", "threshold": float("nan")}, "non-finite"),
+        ({"condition_index": 0, "metric": "sma_50_vs_sma_200", "op": "<", "threshold": 1.0}, "regime metric"),
+    ],
+)
+def test_sanitize_invalid_entries_dropped(entry: object, reason_fragment: str) -> None:
+    survivors, reasons = sanitize_writer_break_predicates([entry], 2)
+    assert survivors == []
+    assert len(reasons) == 1 and reason_fragment in reasons[0]
+
+
+def test_sanitize_duplicate_condition_index_second_dropped() -> None:
+    raw = [
+        {"condition_index": 0, "metric": "rsi_14", "op": "<", "threshold": 30},
+        {"condition_index": 0, "metric": "altman_z", "op": "<", "threshold": 1.8},
+    ]
+    survivors, reasons = sanitize_writer_break_predicates(raw, 1)
+    assert [s["metric"] for s in survivors] == ["rsi_14"]
+    assert len(reasons) == 1 and "duplicate condition_index" in reasons[0]
+
+
+def test_sanitize_mixed_keeps_survivors() -> None:
+    raw = [
+        {"condition_index": 0, "metric": "short_interest_pct_shares_out", "op": ">", "threshold": 20},
+        {"condition_index": 1, "metric": "made_up", "op": ">", "threshold": 5},
+        {"condition_index": 2, "metric": "sma_50_vs_sma_200", "op": "<", "threshold": None},
+    ]
+    survivors, reasons = sanitize_writer_break_predicates(raw, 3)
+    assert [s["condition_index"] for s in survivors] == [0, 2]
+    assert len(reasons) == 1 and "unknown metric" in reasons[0]
+
+
+def test_metric_units_cover_full_vocabulary() -> None:
+    # The writer channel derives its unit from METRIC_UNITS — every metric
+    # the sanitizer can pass must have one (KeyError at scan time otherwise).
+    assert set(METRIC_UNITS) == set(FRESHNESS_BOUNDS)

--- a/tests/test_thesis_break_scan_db.py
+++ b/tests/test_thesis_break_scan_db.py
@@ -219,3 +219,63 @@ def test_writer_native_predicates_additive_only(ebull_test_conn: psycopg.Connect
     assert rows[1][0] == 1
     assert (rows[1][1], rows[1][2], float(rows[1][3])) == ("rsi_14", ">", 70.0)
     assert rows[1][4] == "extractor"
+
+
+def test_extractor_takeover_of_stale_writer_row(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """#2010 re-scan takeover: an extractor parse that DIFFERS from an
+    existing writer-origin row takes the slot over and resets the baseline
+    (the old baseline graded a different predicate). Identical predicates
+    leave the row untouched (plain DO NOTHING path)."""
+    conn = ebull_test_conn
+    iid = 910_004
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'TKVR', 'Takeover Test Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (iid,),
+    )
+    row = conn.execute(
+        """
+        INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance, memo_markdown,
+                            break_conditions_json)
+        VALUES (%s, 1, 'value', 'watch', 'memo',
+                '["RSI-14 crosses above 70 (overbought territory)"]'::jsonb)
+        RETURNING thesis_id
+        """,
+        (iid,),
+    ).fetchone()
+    assert row is not None
+    thesis_id = int(row[0])
+    # Simulate a pre-improvement scan: a writer-origin row holds the slot the
+    # extractor NOW parses (as rsi_14 > 70) with a DIFFERENT predicate.
+    conn.execute(
+        """
+        INSERT INTO thesis_break_predicates
+            (thesis_id, predicate_index, instrument_id, metric, op, threshold, unit,
+             source_text, baseline_state, baselined_at, origin)
+        VALUES (%s, 0, %s, 'altman_z', '<', 1.8, 'zscore', 'stale writer twin', 'armed', now(), 'writer')
+        """,
+        (thesis_id, iid),
+    )
+    conn.execute(
+        """
+        INSERT INTO price_daily (instrument_id, price_date, close, rsi_14)
+        VALUES (%s, CURRENT_DATE, 100.0, 50.0)
+        ON CONFLICT (instrument_id, price_date) DO UPDATE SET rsi_14 = EXCLUDED.rsi_14
+        """,
+        (iid,),
+    )
+    conn.commit()
+
+    run_thesis_break_scan(conn)
+
+    row = conn.execute(
+        "SELECT metric, op, threshold, origin, baseline_state FROM thesis_break_predicates "
+        "WHERE thesis_id = %s AND predicate_index = 0",
+        (thesis_id,),
+    ).fetchone()
+    assert row is not None
+    assert (row[0], row[1], float(row[2]), row[3]) == ("rsi_14", ">", 70.0, "extractor")
+    # Baseline reset by the takeover, then re-baselined by the same scan
+    # (rsi 50 < 70 → false → armed; newly-taken-over rows re-enter the
+    # normal state machine).
+    assert row[4] == "armed"

--- a/tests/test_thesis_break_scan_db.py
+++ b/tests/test_thesis_break_scan_db.py
@@ -165,3 +165,57 @@ def test_altman_sector_gate_blocks_insert(ebull_test_conn: psycopg.Connection[tu
     assert report.sector_gated >= 1
     row = conn.execute("SELECT COUNT(*) FROM thesis_break_predicates WHERE instrument_id = %s", (iid,)).fetchone()
     assert row is not None and int(row[0]) == 0
+
+
+def test_writer_native_predicates_additive_only(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """#2010 writer channel: a validated writer predicate fills ONLY an
+    extractor-None slot (origin='writer'); on an index the extractor parsed,
+    the extractor wins unconditionally — a hallucinated writer twin must not
+    suppress or replace the precision channel."""
+    conn = ebull_test_conn
+    iid = 910_003
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'WRTN', 'Writer Native Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (iid,),
+    )
+    conn.execute(
+        """
+        INSERT INTO theses (instrument_id, thesis_version, thesis_type, stance, memo_markdown,
+                            break_conditions_json, break_predicates_json)
+        VALUES (%s, 1, 'value', 'watch', 'memo',
+                '["Short interest climbs past a fifth of the register",
+                  "RSI-14 crosses above 70 (overbought territory)"]'::jsonb,
+                '[{"condition_index": 0, "metric": "short_interest_pct_shares_out", "op": ">", "threshold": 20.0},
+                  {"condition_index": 1, "metric": "altman_z", "op": "<", "threshold": 1.8}]'::jsonb)
+        """,
+        (iid,),
+    )
+    conn.execute(
+        """
+        INSERT INTO price_daily (instrument_id, price_date, close, rsi_14)
+        VALUES (%s, CURRENT_DATE, 100.0, 50.0)
+        ON CONFLICT (instrument_id, price_date) DO UPDATE SET rsi_14 = EXCLUDED.rsi_14
+        """,
+        (iid,),
+    )
+    conn.commit()
+
+    run_thesis_break_scan(conn)
+
+    rows = conn.execute(
+        "SELECT predicate_index, metric, op, threshold, origin, source_text "
+        "FROM thesis_break_predicates WHERE instrument_id = %s ORDER BY predicate_index",
+        (iid,),
+    ).fetchall()
+    assert len(rows) == 2
+    # Index 0: extractor fails open (free phrasing) → writer twin fills the slot.
+    assert rows[0][0] == 0
+    assert (rows[0][1], rows[0][2], float(rows[0][3])) == ("short_interest_pct_shares_out", ">", 20.0)
+    assert rows[0][4] == "writer"
+    assert rows[0][5] == "Short interest climbs past a fifth of the register"
+    # Index 1: extractor parsed rsi > 70 → extractor wins; the writer's
+    # contradicting altman twin for the same index is ignored.
+    assert rows[1][0] == 1
+    assert (rows[1][1], rows[1][2], float(rows[1][3])) == ("rsi_14", ">", 70.0)
+    assert rows[1][4] == "extractor"


### PR DESCRIPTION
Ships as **v5**, not the issue's "v3" (#2007 took v3, #2009 PR-B took v4). Spec: docs/proposals/thesis/2026-07-16-thesis-prompt-v5-valuation-scaffold.md (Source rules + Full-population verification sections in-spec). Codex ckpt-1 (8 findings) + ckpt-2 (3) folded pre-gate.

## Problem (premise re-scanned on current population — spec "Problem")
- Abstention is a BAND-ABSENCE problem: band present → 10% no-targets; band absent → 95% (v4 pop 247).
- "of float" fabrication alive in v4: 58 conditions (machine-uncheckable forever — float not ingested).
- Buys 13/13 already carry full target sets → enforcement free.
- Extractor recall 5.1% (100% precision) — recall deferred to this ticket.

## What changed
- `_WRITER_SYSTEM` v5: 3-tier valuation procedure (band anchor → derived basis with SHOWN arithmetic, share-count-free bases only → justified abstention line); break authoring contract (single metric/direction/threshold, FALSE at write, shares-outstanding denominators only).
- Writer-native `break_predicates` output field → `theses.break_predicates_json` (sql/232) + `thesis_break_predicates.origin` — soft-validated at INSERT, never retry-fails the thesis.
- Scan merge PURELY ADDITIVE: the 100%-precision extractor channel is never overridden; writer fills only extractor-None slots; takeover clause resets baseline when a vocab improvement reparses a differing writer row.
- Anchor-gated buy enforcement in `_validate_writer_output` (FULL bear/base/bull + zone), `require_buy_zone` threaded from call site + harness `classify_attempt`.
- `_PROMPT_VERSION` → "v5".

## Re-gate (2 rounds, quiet queue, 6 re-captured fixtures incl. FSLR high-band, v4 baseline on the SAME fixtures)
- **Round 1: structure gate PASS** (qwen + phi4 both 12/12 FIRST-attempt, 0 critic length-fails, 0 truncations — `_MAX_TOKENS_WRITER` contingency not triggered) **but judge A FAIL: v5 0-4-7 vs v4.** All 4 losses swap-consistent + real: the prompt's literal worked example ("12 x EPS 3.10 = 37.20") leaked verbatim into a MSFT memo; a $52.8B non-per-share P/S "target"; a fabricated 13.1% gross margin. NOT pushed per spec contingency.
- **Round 2 (commit 6b964bec):** example abstracted to placeholders + "THIS context's numbers", arithmetic must END in a per-share price + band cross-check at any quality, verbatim-or-show-inputs figure rule. **Structure gate PASS again** (qwen 12/12 first-attempt; phi4 11/12 first + retry-recovered; 0 length-fails). **Judge A2: v5 WINS 4-2-6** (gate = must-not-lose), ahead on 5/6 dimensions (numeric_grounding 4.38 v 4.12, anchor_discipline 4.54 v 4.38, valuation_reasoning 4.54 v 4.25, specificity 4.75 v 4.29); both residual losses are per-sample transcription noise also present in v4's own memos, no new defect class.
- **Judge B (phi4 vs qwen, MANDATORY carried #1995 action): qwen 9-0-3, 75% swap-agreement, ahead on ALL six dims → phi4 flip REJECTED on content; rec posted on #2010** (model default flip stays OPERATOR-GATED; 6-fixture sample caveat). Round-2 judge B confirmation running — numbers added to the issue when it lands.
- **Measured metrics (informational): of_float_conditions 0/57** (v4 full-pop had 58 — authoring contract works), **machine-predicate coverage 68.4%** (extractor 21 + writer-native 18 of 57) vs 5.1% extractor-only baseline, 36/53 emitted predicates valid post-soft-validation.

## Security model
No new endpoints. Writer output channel is soft-validated before storage (closed metric vocabulary, op whitelist, numeric threshold checks, index-bounds against the RAW array); malformed entries dropped with warnings, never stored, never retry the thesis. Prose stays the canonical record. sql/232 is additive (new nullable column + origin column with CHECK).

## Verification (commit 6b964bec)
- Local gates: 263 targeted tests, full fast tier, smoke, pyright 0, ruff clean (re-run at push via hook).
- sql/232 applied to dev (idempotent).
- Post-merge follow-up (spec, recorded on #2010 close-out): live v5 census ~1 week of hourly refresh (of-float / premise-true / abstention over prompt_version='v5' rows) BEFORE the wide backfill.

Closes #2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)