### PR TITLE
refactor(#2070): consolidate close-at-or-before price reads into one Decimal-contract helper

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -454,6 +454,9 @@ def find_stale_instruments(
             LIMIT 1
         ) pn ON TRUE
         LEFT JOIN LATERAL (
+            -- Mint-close read: SQL mirror of
+            -- thesis_dq_audit.close_row_at_or_before (#2070 — that helper
+            -- is the semantic source for close-at-or-before reads).
             SELECT p.close
             FROM price_daily p
             WHERE p.instrument_id = i.instrument_id

--- a/app/services/thesis_dq_audit.py
+++ b/app/services/thesis_dq_audit.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 from typing import Any
 
 import psycopg
@@ -205,18 +206,35 @@ def _anchor_block(summary: object) -> dict[str, Any] | None:
     return anchor if isinstance(anchor, dict) else None
 
 
-def _close_at_or_before(conn: psycopg.Connection[Any], instrument_id: int, as_of: date) -> float | None:
+def close_row_at_or_before(
+    conn: psycopg.Connection[Any], instrument_id: int, as_of: date
+) -> tuple[date, Decimal] | None:
+    """(price_date, close) of the last print at or before ``as_of``.
+
+    The single Python implementation of the close-at-or-before read
+    (#2070): this audit and the calibration ledger (``thesis_outcomes``)
+    both delegate here; ``find_stale_instruments``' mint-close LATERAL in
+    ``app/services/thesis.py`` mirrors it SQL-side. The close stays
+    ``Decimal`` end-to-end (NUMERIC in, NUMERIC out — no binary-float
+    round-trip; PR #2061 review); a non-finite NUMERIC (NaN) maps to
+    None the same way the ``_to_float`` chokepoint would.
+    """
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT close FROM price_daily
+            SELECT price_date, close FROM price_daily
             WHERE instrument_id = %(iid)s AND price_date <= %(as_of)s
             ORDER BY price_date DESC LIMIT 1
             """,
             {"iid": instrument_id, "as_of": as_of},
         )
         row = cur.fetchone()
-    return _to_float(row[0]) if row else None
+    if row is None:
+        return None
+    close = row[1]
+    if not isinstance(close, Decimal) or not close.is_finite():
+        return None
+    return (row[0], close)
 
 
 _LATEST_THESES_SQL = """
@@ -309,7 +327,8 @@ def compute_thesis_dq_report(conn: psycopg.Connection[Any]) -> ThesisDqReport:
             add(row, "stale_price_anchor", "flag", detail)
 
         if anchor_as_of is not None:
-            anchor_close = _close_at_or_before(conn, row["instrument_id"], anchor_as_of)
+            close_row = close_row_at_or_before(conn, row["instrument_id"], anchor_as_of)
+            anchor_close = _to_float(close_row[1]) if close_row else None
             if detail := check_base_vs_anchor_close(row["base_value"], anchor_close):
                 add(row, "base_far_from_close", "flag", detail)
 

--- a/app/services/thesis_outcomes.py
+++ b/app/services/thesis_outcomes.py
@@ -29,13 +29,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, timedelta
-from decimal import Decimal
 from typing import Any
 
 import psycopg
 import psycopg.rows
 
-from app.services.thesis_dq_audit import _anchor_block, _parse_iso_date
+from app.services.thesis_dq_audit import _anchor_block, _parse_iso_date, close_row_at_or_before
 
 HORIZONS: tuple[int, ...] = (30, 90, 365)
 
@@ -117,36 +116,6 @@ def classify_immature(
     if (due_date - max_price_date).days > _SERIES_DEAD_GRACE_DAYS:
         return "series_dead"
     return "immature_series_stalled"
-
-
-def close_row_at_or_before(
-    conn: psycopg.Connection[Any], instrument_id: int, as_of: date
-) -> tuple[date, Decimal] | None:
-    """(price_date, close) of the last print at or before ``as_of``.
-
-    Same read as ``thesis_dq_audit._close_at_or_before`` but the ledger
-    also needs the trading day actually used (``realized_date``), hence
-    the widened return shape rather than a shared helper. The close stays
-    ``Decimal`` end-to-end (NUMERIC in, NUMERIC out — no binary-float
-    round-trip; PR #2061 review); a non-finite NUMERIC (NaN) maps to None
-    the same way the ``_to_float`` chokepoint would.
-    """
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            SELECT price_date, close FROM price_daily
-            WHERE instrument_id = %(iid)s AND price_date <= %(as_of)s
-            ORDER BY price_date DESC LIMIT 1
-            """,
-            {"iid": instrument_id, "as_of": as_of},
-        )
-        row = cur.fetchone()
-    if row is None:
-        return None
-    close = row[1]
-    if not isinstance(close, Decimal) or not close.is_finite():
-        return None
-    return (row[0], close)
 
 
 # All thesis versions with at least one horizon uncaptured. The run


### PR DESCRIPTION
## What

Three implementations of the close-at-or-before price read existed (07-17 retrospective, #2070):

- `thesis_dq_audit._close_at_or_before` (float via `_to_float`)
- `thesis_outcomes.close_row_at_or_before` (Decimal + `is_finite` — the PR #2061 review contract)
- `thesis.py find_stale` inline mint-close LATERAL (SQL)

Two numeric contracts for the same quantity; any future price-semantics change (e.g. split-cliff #2066) needed three edits.

## Change

- `close_row_at_or_before` (Decimal contract, returns `(price_date, close) | None`, NaN→None) moves to `app/services/thesis_dq_audit.py` and becomes THE Python implementation. Placement follows the existing import direction — `thesis_outcomes` already imports `_anchor_block`/`_parse_iso_date` from `thesis_dq_audit`; the reverse would be a cycle.
- `thesis_dq_audit` deletes its float copy and delegates; its float consumer (`check_base_vs_anchor_close`) converts at the call site with the same `_to_float` chokepoint — behavior unchanged (Codex-confirmed).
- `thesis_outcomes` deletes its copy, imports the helper. Decimal end-to-end contract unchanged.
- `find_stale`'s mint-close LATERAL gets a SQL comment citing the helper as the semantic source (stays SQL-side per ticket).

Acceptance per issue: grep shows one Python implementation; existing tests green.

## Security model

No new inputs, endpoints, or query shapes — same parameterised `price_daily` read, same auth surface (none touched). Files outside the diff unaffected.

## Verification

- ruff check + format --check: clean
- pyright: 0 errors
- fast tier `-m "not db"`: exit 0
- smoke `tests/smoke -n 0`: exit 0
- targeted db tier `-n 0`: test_thesis_dq_audit.py, test_thesis_outcomes.py, test_thesis_outcomes_db.py, test_thesis_refresh_candidates.py — exit 0
- Codex ckpt-2 (`codex exec` on branch diff): **Findings: none** — Decimal contract preserved, NaN handling unchanged, no import cycle, dq_audit anchor-close path behaviourally identical
- No ETL/parser/schema change — clauses 8-12 N/A (pure refactor, no data-path or operator-visible figure change; no backfill needed)

Closes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)