### PR TITLE
fix(#2066): detect price-series adjustment cliffs on future splits at the incremental-fetch overlap and heal same-run

### DIFF
--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -274,6 +274,7 @@ def refresh_market_data(
             fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=today)
         upserted = 0
         computed = 0
+        adjustment_detected = False
         try:
             with conn.transaction():
                 bars = provider.get_daily_candles(instrument_id, fetch_count)
@@ -289,7 +290,7 @@ def refresh_market_data(
                     stored = _stored_overlap_closes(conn, instrument_id, [b.price_date for b in bars])
                     ratio = detect_adjustment_event(stored, bars)
                     if ratio is not None:
-                        adjustment_refetches += 1
+                        adjustment_detected = True
                         logger.warning(
                             "Adjustment event detected for %s (id=%d): overlap close ratio %s — "
                             "re-fetching full %d-bar history to heal the series",
@@ -309,6 +310,10 @@ def refresh_market_data(
             # — and that same instrument is also counted in ``candles_failed``.
             candle_rows_upserted += upserted
             features_computed += computed
+            # Counted only after a clean commit (same #1293 rule as the row
+            # totals) — a heal whose re-fetch or write failed did NOT happen.
+            if adjustment_detected:
+                adjustment_refetches += 1
             # A clean fetch proves the provider + DB are reachable → reset.
             consecutive_systemic_failures = 0
         except Exception as exc:

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -290,7 +290,6 @@ def refresh_market_data(
                     stored = _stored_overlap_closes(conn, instrument_id, [b.price_date for b in bars])
                     ratio = detect_adjustment_event(stored, bars)
                     if ratio is not None:
-                        adjustment_detected = True
                         logger.warning(
                             "Adjustment event detected for %s (id=%d): overlap close ratio %s — "
                             "re-fetching full %d-bar history to heal the series",
@@ -300,6 +299,9 @@ def refresh_market_data(
                             lookback_days,
                         )
                         bars = provider.get_daily_candles(instrument_id, lookback_days)
+                        # An empty heal re-fetch wrote nothing — a heal is
+                        # only a heal if the series was actually rewritten.
+                        adjustment_detected = bool(bars)
                 if bars:
                     upserted = _upsert_candles(conn, instrument_id, bars)
                     computed = _compute_and_store_features(conn, instrument_id)

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -186,6 +186,10 @@ class MarketRefreshSummary:
     # both report 0 candles written.
     candles_skipped: int = 0
     candles_failed: int = 0
+    # #2066 — instruments whose incremental overlap showed a ratio-scale
+    # close mismatch (split/adjustment event) and were healed with an
+    # in-run full-history re-fetch.
+    adjustment_refetches: int = 0
 
 
 def refresh_market_data(
@@ -258,6 +262,7 @@ def refresh_market_data(
     total = len(instruments)
     # #1833 batch circuit-breaker — consecutive systemic failures.
     consecutive_systemic_failures = 0
+    adjustment_refetches = 0
     for idx, (instrument_id, symbol) in enumerate(instruments, start=1):
         if not force_backfill and _candles_are_fresh(conn, instrument_id, today):
             candles_skipped += 1
@@ -272,6 +277,28 @@ def refresh_market_data(
         try:
             with conn.transaction():
                 bars = provider.get_daily_candles(instrument_id, fetch_count)
+                # #2066 split-cliff guard: provider history is back-adjusted
+                # at fetch time, so a future split re-bases every bar — but an
+                # incremental fetch only rewrites the overlap window, leaving
+                # all older rows on the old basis (a permanent cliff at the
+                # buffer edge). The overlap re-fetch is the one place the two
+                # bases meet: a ratio-scale close mismatch on an already-stored
+                # date = adjustment event → heal same-day with an in-run
+                # full-history re-fetch (idempotent upsert rewrites the series).
+                if bars and not force_backfill and fetch_count == _INCREMENTAL_FETCH_BARS:
+                    stored = _stored_overlap_closes(conn, instrument_id, [b.price_date for b in bars])
+                    ratio = detect_adjustment_event(stored, bars)
+                    if ratio is not None:
+                        adjustment_refetches += 1
+                        logger.warning(
+                            "Adjustment event detected for %s (id=%d): overlap close ratio %s — "
+                            "re-fetching full %d-bar history to heal the series",
+                            symbol,
+                            instrument_id,
+                            ratio,
+                            lookback_days,
+                        )
+                        bars = provider.get_daily_candles(instrument_id, lookback_days)
                 if bars:
                     upserted = _upsert_candles(conn, instrument_id, bars)
                     computed = _compute_and_store_features(conn, instrument_id)
@@ -364,6 +391,7 @@ def refresh_market_data(
         spread_flags_set=spread_flags_set,
         candles_skipped=candles_skipped,
         candles_failed=candles_failed,
+        adjustment_refetches=adjustment_refetches,
     )
 
 
@@ -459,6 +487,62 @@ def _candles_fetch_count(
         # Gap wider than the incremental window — backfill to close it.
         return default
     return _INCREMENTAL_FETCH_BARS
+
+
+# #2066 — smallest overlap close ratio that reads as an adjustment event
+# rather than a late correction. Splits re-base by the split ratio (2x,
+# 3x, 10x; smallest common uneven split 5:4 = 1.25x); exchange corrections
+# to a finalized close are single-digit percent. 1.2 sits between the two
+# with margin, and a false positive only costs one idempotent full-history
+# re-fetch, so the threshold errs low.
+_ADJUSTMENT_RATIO_THRESHOLD = Decimal("1.2")
+
+
+def detect_adjustment_event(
+    stored_closes: dict[date, Decimal],
+    bars: list[OHLCVBar],
+) -> Decimal | None:
+    """Ratio-scale mismatch between stored and re-fetched overlap closes (#2066).
+
+    Provider candles are back-adjusted at fetch time, so after a split every
+    re-fetched bar is on the new basis while stored rows outside the fetch
+    window keep the old one. Comparing the re-fetched bars against what is
+    already stored for the SAME dates exposes the re-basing: returns the
+    largest direction-normalised close ratio (max(r, 1/r)) at or above
+    ``_ADJUSTMENT_RATIO_THRESHOLD``, or None when the overlap is consistent.
+
+    Non-positive closes on either side are skipped — ``price_daily`` holds
+    zero-close sentinels and a garbage quote must not fake a split. Dates
+    absent from ``stored_closes`` (new rows) carry no signal.
+    """
+    worst: Decimal | None = None
+    for bar in bars:
+        stored = stored_closes.get(bar.price_date)
+        if stored is None or stored <= 0 or bar.close <= 0:
+            continue
+        ratio = bar.close / stored
+        normalised = max(ratio, Decimal(1) / ratio)
+        if normalised >= _ADJUSTMENT_RATIO_THRESHOLD and (worst is None or normalised > worst):
+            worst = normalised
+    return worst
+
+
+def _stored_overlap_closes(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    instrument_id: int,
+    dates: list[date],
+) -> dict[date, Decimal]:
+    """Stored ``price_daily`` closes for the given dates (#2066 overlap read)."""
+    if not dates:
+        return {}
+    rows = conn.execute(
+        """
+        SELECT price_date, close FROM price_daily
+        WHERE instrument_id = %(instrument_id)s AND price_date = ANY(%(dates)s)
+        """,
+        {"instrument_id": instrument_id, "dates": dates},
+    ).fetchall()
+    return {row[0]: row[1] for row in rows}
 
 
 def _upsert_candles(

--- a/docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md
+++ b/docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md
@@ -185,6 +185,42 @@ HERE so the capture schema provably supports them:
   stores `price_as_of` but NOT the anchor close → re-read contract above
   is required, not optional.
 
+## Adjustment-event defect rows — remediation runbook (#2066)
+
+Provider candle history is back-adjusted at fetch time, but the daily
+incremental refresh only rewrites the overlap window — a FUTURE split
+re-bases the fetched bars while rows older than the buffer keep the old
+basis, leaving a permanent cliff at (split_date − buffer). The market-data
+layer detects this at the incremental-fetch overlap (stored-vs-fetched
+ratio-scale close mismatch, `detect_adjustment_event` in
+`app/services/market_data.py`) and heals the series same-day with an
+in-run full-history re-fetch.
+
+The exposure window for this ledger: an outcome row captured BETWEEN the
+split taking effect and the heal (same run, so in practice only rows
+minted by a capture job racing the candle refresh, or captured while
+detection was broken) mixes bases — `anchor_close` on one basis,
+`realized_close` on the other — and insert-once means the defect row is
+frozen. `method_version` covers method changes, NOT data defects.
+
+**Append-only ≠ never-delete-defects.** Remediation for rows straddling a
+detected adjustment event:
+
+1. Identify: instrument + detection date from the refresh log line
+   ("Adjustment event detected"). Defect candidates are
+   `thesis_outcomes` rows for that instrument whose `(anchor_date,
+   realized_date)` straddle the event date AND whose `captured_at` is
+   before the heal.
+2. `DELETE FROM thesis_outcomes` for exactly those rows (record thesis_ids
+   in the ops note).
+3. Re-run `capture_thesis_outcomes` (nightly job re-mints them from the
+   healed series; insert-once makes the re-capture idempotent).
+
+`price_move`/`band_exit` staleness triggers (#1988) need no remediation:
+the heal lands the same night, so the worst case is a one-night false
+fire (a 2:1 split reads as −50% until healed) — a spurious regen, not a
+corrupted record. Documented as accepted.
+
 ## Non-goals (this slice)
 
 - No scoreboard endpoint / dashboard panel / conviction frontier / rec

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1320,10 +1320,11 @@ class TestDetectAdjustmentEvent:
         assert detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "104")]) is None
 
     def test_threshold_boundary_fires_inclusive(self) -> None:
-        """5:4 split (1.25x) sits above the 1.2 threshold and fires."""
+        """Exactly 1.2 fires (threshold is inclusive); just below does not."""
         from app.services.market_data import detect_adjustment_event
 
-        assert detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "80")]) == Decimal("1.25")
+        assert detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "120")]) == Decimal("1.2")
+        assert detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "119")]) is None
 
     def test_zero_close_sentinel_skipped(self) -> None:
         """price_daily zero-close sentinels must not fake a split."""

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1285,3 +1285,66 @@ class TestRefreshMarketDataCircuitBreaker:
         )
         assert provider.get_daily_candles.call_count == 25
         assert summary.candles_failed == 25
+
+
+class TestDetectAdjustmentEvent:
+    """#2066 — ratio-scale overlap mismatch = split/adjustment event."""
+
+    @staticmethod
+    def _bar(price_date: date, close: str) -> OHLCVBar:
+        c = Decimal(close)
+        return OHLCVBar(price_date=price_date, open=c, high=c, low=c, close=c, volume=1000)
+
+    _D1 = date(2026, 7, 15)
+    _D2 = date(2026, 7, 16)
+
+    def test_forward_split_fires(self) -> None:
+        """2:1 split — stored old-basis 100, re-fetched back-adjusted 50."""
+        from app.services.market_data import detect_adjustment_event
+
+        ratio = detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "50")])
+        assert ratio == Decimal("2")
+
+    def test_reverse_split_fires(self) -> None:
+        """1:10 reverse split — stored 12, re-fetched 120; ratio is
+        direction-normalised so both directions read as the same event."""
+        from app.services.market_data import detect_adjustment_event
+
+        ratio = detect_adjustment_event({self._D1: Decimal("12")}, [self._bar(self._D1, "120")])
+        assert ratio == Decimal("10")
+
+    def test_small_correction_does_not_fire(self) -> None:
+        """A late exchange correction (single-digit %) is not an event."""
+        from app.services.market_data import detect_adjustment_event
+
+        assert detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "104")]) is None
+
+    def test_threshold_boundary_fires_inclusive(self) -> None:
+        """5:4 split (1.25x) sits above the 1.2 threshold and fires."""
+        from app.services.market_data import detect_adjustment_event
+
+        assert detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "80")]) == Decimal("1.25")
+
+    def test_zero_close_sentinel_skipped(self) -> None:
+        """price_daily zero-close sentinels must not fake a split."""
+        from app.services.market_data import detect_adjustment_event
+
+        assert detect_adjustment_event({self._D1: Decimal("0")}, [self._bar(self._D1, "50")]) is None
+
+    def test_nonpositive_fetched_close_skipped(self) -> None:
+        from app.services.market_data import detect_adjustment_event
+
+        assert detect_adjustment_event({self._D1: Decimal("100")}, [self._bar(self._D1, "0")]) is None
+
+    def test_no_overlap_no_signal(self) -> None:
+        """Dates absent from the store are new rows — no basis to compare."""
+        from app.services.market_data import detect_adjustment_event
+
+        assert detect_adjustment_event({}, [self._bar(self._D1, "50")]) is None
+
+    def test_worst_ratio_of_multiple_overlaps_returned(self) -> None:
+        from app.services.market_data import detect_adjustment_event
+
+        stored = {self._D1: Decimal("100"), self._D2: Decimal("300")}
+        bars = [self._bar(self._D1, "50"), self._bar(self._D2, "100")]
+        assert detect_adjustment_event(stored, bars) == Decimal("3")

--- a/tests/test_market_data_split_adjustment_db.py
+++ b/tests/test_market_data_split_adjustment_db.py
@@ -1,0 +1,100 @@
+"""Integration test for the #2066 split-cliff heal (one DB-tier file for
+the genuinely-new SQL mechanism, house rule).
+
+Pins the end-to-end flow: incremental fetch whose overlap rows come back
+on a re-based (post-split) close → adjustment event detected against the
+stored closes → in-run full-history re-fetch → idempotent upsert rewrites
+the whole stored series onto the new basis, healing the cliff same-day.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.providers.market_data import OHLCVBar
+from app.services.market_data import _most_recent_trading_day, refresh_market_data
+from tests.fixtures.ebull_test_db import ebull_test_conn
+from tests.fixtures.ebull_test_db import test_db_available as _test_db_available
+
+__all__ = ["ebull_test_conn"]
+
+pytestmark = pytest.mark.skipif(
+    not _test_db_available(),
+    reason="ebull_test DB unavailable",
+)
+
+_IID = 920_066
+
+
+def _weekdays_back(end: date, n: int) -> list[date]:
+    """The n weekdays ending at ``end`` (inclusive), oldest-first."""
+    out: list[date] = []
+    d = end
+    while len(out) < n:
+        if d.weekday() < 5:
+            out.append(d)
+        d -= timedelta(days=1)
+    return list(reversed(out))
+
+
+def _bar(price_date: date, close: str) -> OHLCVBar:
+    c = Decimal(close)
+    return OHLCVBar(price_date=price_date, open=c, high=c, low=c, close=c, volume=1000)
+
+
+def test_split_overlap_mismatch_triggers_full_refetch_and_heals_series(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (%s, 'SPLT', 'Split Test Co', TRUE) ON CONFLICT (instrument_id) DO NOTHING",
+        (_IID,),
+    )
+
+    # 11 weekdays ending at the most recent trading day; the LAST one is
+    # deliberately NOT seeded so the freshness skip does not fire and the
+    # run enters incremental mode (gap of 1 trading day <= 3-bar window).
+    days = _weekdays_back(_most_recent_trading_day(date.today()), 11)
+    history, fetch_day = days[:-1], days[-1]
+    for d in history:
+        conn.execute(
+            "INSERT INTO price_daily (instrument_id, price_date, open, high, low, close, volume) "
+            "VALUES (%s, %s, 100, 100, 100, 100, 1000) ON CONFLICT DO NOTHING",
+            (_IID, d),
+        )
+
+    # 2:1 split effective on fetch_day: the provider back-adjusts, so the
+    # incremental window (last 3 trading days) comes back at close=50 while
+    # the two overlap dates are stored at close=100.
+    incremental_bars = [_bar(d, "50") for d in days[-3:]]
+    full_history_bars = [_bar(d, "50") for d in days]
+    provider = MagicMock()
+    provider.get_daily_candles.side_effect = [incremental_bars, full_history_bars]
+
+    summary = refresh_market_data(
+        provider,
+        conn,
+        instruments=[(_IID, "SPLT")],
+        lookback_days=1000,
+        skip_quotes=True,
+    )
+
+    assert summary.adjustment_refetches == 1
+    assert summary.candles_failed == 0
+    # Second provider call is the full-lookback heal.
+    assert provider.get_daily_candles.call_count == 2
+    assert provider.get_daily_candles.call_args_list[1].args == (_IID, 1000)
+    # Every stored row — including the pre-buffer history that an
+    # incremental fetch alone would never touch — is on the new basis.
+    rows = conn.execute(
+        "SELECT close FROM price_daily WHERE instrument_id = %s ORDER BY price_date",
+        (_IID,),
+    ).fetchall()
+    assert len(rows) == len(days)
+    assert all(row[0] == Decimal("50") for row in rows)

--- a/tests/test_market_data_split_adjustment_db.py
+++ b/tests/test_market_data_split_adjustment_db.py
@@ -61,7 +61,7 @@ def test_split_overlap_mismatch_triggers_full_refetch_and_heals_series(
     # deliberately NOT seeded so the freshness skip does not fire and the
     # run enters incremental mode (gap of 1 trading day <= 3-bar window).
     days = _weekdays_back(_most_recent_trading_day(date.today()), 11)
-    history, fetch_day = days[:-1], days[-1]
+    history = days[:-1]
     for d in history:
         conn.execute(
             "INSERT INTO price_daily (instrument_id, price_date, open, high, low, close, volume) "


### PR DESCRIPTION
## Problem (PRE-BACKFILL BLOCKER, 07-17 retrospective)

Provider candle history is back-adjusted at fetch time (verified on dev: NVDA 10:1 2024-06 ~120 flat, WMT 3:1 ~58 flat — no cliffs in stored history). But the daily incremental refresh fetches only `_INCREMENTAL_FETCH_BARS = 3` bars, so a FUTURE split re-bases the fetched bars while every row older than the buffer keeps the old basis — a permanent cliff at (split_date − buffer). Blast radius: #1988 `price_move` (2:1 split reads as −50% → false regen) and `band_exit`, #2002 `thesis_outcomes` realized returns (insert-once = corrupted row frozen), momentum/risk windows.

## Change

- `detect_adjustment_event` (pure, table-tested): compares re-fetched overlap closes against stored closes for the same dates; fires at direction-normalised ratio ≥ 1.2 (`_ADJUSTMENT_RATIO_THRESHOLD`); zero/non-positive closes (price_daily sentinels) skipped; returns worst ratio for logging.
  - Threshold rationale: splits re-base ≥1.25x (5:4 smallest common); finalized-close corrections are single-digit %. False positive cost = one idempotent full-history re-fetch, so the threshold errs low.
- Detection sits at the existing chokepoint in `refresh_market_data` incremental path only (backfill mode already rewrites full history). On detect: in-run re-fetch of the full `lookback_days` (1000) window inside the same per-instrument transaction; the idempotent upsert rewrites the series onto the new basis — heals same-day.
- `MarketRefreshSummary.adjustment_refetches` counter (additive, default 0), incremented only after clean commit — same #1293 rule as the row totals (Codex ckpt-2 Medium, fixed in-branch).
- Calibration-ledger spec (`docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md`): new "Adjustment-event defect rows — remediation runbook" section — identify straddling `thesis_outcomes` rows → DELETE → recapture (append-only ≠ never-delete-defects); documents the accepted one-night false-fire window for price_move/band_exit (no code change there, per ticket).

## Security model

No new inputs or endpoints; parameterised SQL only; detection consumes provider data already trusted by the upsert path. No auth surface touched.

## Verification

- Pure predicate: 8 table tests (2:1, 1:10 reverse, correction no-fire, 1.25 boundary, zero-sentinel skip both sides, no-overlap, worst-of-multiple).
- db-tier: `tests/test_market_data_split_adjustment_db.py` — simulated 2:1 overlap mismatch on seeded old-basis history → second provider call with full 1000 lookback asserted, all stored rows rewritten to new basis, `adjustment_refetches == 1`. Ran against test DB (`-n 0`): passed (0.04s call, not skipped).
- Existing mocked refresh tests unaffected (they use ancient latest-dates → default/backfill mode, which bypasses detection by design).
- ruff + format + pyright: clean. Fast tier exit 0, smoke `-n 0` exit 0.
- Codex ckpt-2: 1 Medium (premature counter increment) — FIXED in-branch; notes confirm Decimal math, breaker interaction, and gap>buffer bypass are sound.
- ETL clauses 8-12: N/A-adapted — detection is dormant until a real future split occurs (ticket: "smoke on a real future split when one occurs"); the db-tier simulated-split fixture is the ticket's stated acceptance. No schema change, no backfill required (dev history verified already back-adjusted).

## Conscious tradeoffs

- Threshold 1.2 misses sub-1.2 re-basings (e.g. 6:5 = 1.2 exactly fires; below that, large special dividends) — acceptable: sub-threshold re-basings are also sub-threshold distortions for the consumers this protects.
- Heal re-fetch counts against eToro call weight only on detection (rare event).

Closes #2066

🤖 Generated with [Claude Code](https://claude.com/claude-code)