### PR TITLE
feat(#2068): calibration-scoreboard read surface over the thesis_outcomes ledger

### DIFF
--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -753,6 +753,66 @@ def get_thesis_dq_audit(
     )
 
 
+class CalibrationCohortModel(BaseModel):
+    model: str | None
+    prompt_version: str | None
+    horizon_days: int
+    total_theses: int
+    anchorless: int
+    immature_data_current: int
+    immature_series_stalled: int
+    series_dead: int
+    outcome_rows: int
+    targets_absent: int
+    confidence_absent: int
+    direction_claims: int
+    target_distance_mape: float | None
+    stance_hit_rate: float | None
+    conviction_brier: float | None
+
+
+class CalibrationScoreboardResponse(BaseModel):
+    method_version: str
+    cohorts: list[CalibrationCohortModel]
+
+
+# Also registered BEFORE /{instrument_id} — same literal-vs-int rule as
+# /dq-audit above.
+@router.get("/calibration-scoreboard", response_model=CalibrationScoreboardResponse)
+def get_calibration_scoreboard(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CalibrationScoreboardResponse:
+    """Calibration scoreboard (#2068) — compute-on-read over the #2002
+    ``thesis_outcomes`` ledger, per (model, prompt_version, horizon)
+    cohort. Metric definitions are fixed in the calibration-ledger spec;
+    coverage counters are first-class (honest missingness)."""
+    from app.services.thesis_outcomes import METHOD_VERSION, compute_calibration_scoreboard
+
+    return CalibrationScoreboardResponse(
+        method_version=METHOD_VERSION,
+        cohorts=[
+            CalibrationCohortModel(
+                model=c.model,
+                prompt_version=c.prompt_version,
+                horizon_days=c.horizon_days,
+                total_theses=c.total_theses,
+                anchorless=c.anchorless,
+                immature_data_current=c.immature_data_current,
+                immature_series_stalled=c.immature_series_stalled,
+                series_dead=c.series_dead,
+                outcome_rows=c.outcome_rows,
+                targets_absent=c.targets_absent,
+                confidence_absent=c.confidence_absent,
+                direction_claims=c.direction_claims,
+                target_distance_mape=c.target_distance_mape,
+                stance_hit_rate=c.stance_hit_rate,
+                conviction_brier=c.conviction_brier,
+            )
+            for c in compute_calibration_scoreboard(conn)
+        ],
+    )
+
+
 @router.get("/{instrument_id}", response_model=ThesisDetail | None)
 def get_latest_thesis(
     instrument_id: int,

--- a/app/services/thesis_outcomes.py
+++ b/app/services/thesis_outcomes.py
@@ -333,6 +333,13 @@ def aggregate_scoreboard(
     "does conviction behave like a calibrated probability?"). A mature
     pair the nightly capture has not yet minted counts as immature here
     (compute-on-read never classifies ahead of the ledger).
+
+    Scoping (Codex ckpt-2 Medium): the COVERAGE counters (targets_absent,
+    confidence_absent, direction_claims) are POPULATION-scoped — counted
+    over every thesis in the cohort, matured or not, matching the spec's
+    own full-population verification framing ("78/399 carry base_value",
+    "direction-claim cohort today = 180"). METRIC denominators stay
+    outcome-scoped (a hit-rate needs a realized return).
     """
     acc: dict[tuple[str | None, str | None, int], dict[str, Any]] = {}
 
@@ -351,15 +358,24 @@ def aggregate_scoreboard(
                 "direction_claims": 0,
                 "mape_terms": [],
                 "hits": 0,
+                "direction_outcomes": 0,
                 "brier_terms": [],
             }
         return acc[key]
 
     for row in thesis_rows:
         anchor_date = anchor_date_from_summary(row["context_summary"])
+        direction = row["stance"] in _DIRECTION_STANCES
         for horizon in HORIZONS:
             b = bucket(row["model"], row["prompt_version"], horizon)
             b["total_theses"] += 1
+            # Population-scoped coverage — counted before any maturity gate.
+            if row["base_value"] is None:
+                b["targets_absent"] += 1
+            if direction:
+                b["direction_claims"] += 1
+                if row["confidence_score"] is None:
+                    b["confidence_absent"] += 1
             if anchor_date is None:
                 b["anchorless"] += 1
                 continue
@@ -375,20 +391,15 @@ def aggregate_scoreboard(
                 continue
             realized_close, realized_return = outcome
             b["outcome_rows"] += 1
-            base_value = row["base_value"]
-            if base_value is None:
-                b["targets_absent"] += 1
-            else:
-                b["mape_terms"].append(abs(Decimal(base_value) - realized_close) / realized_close)
-            if row["stance"] in _DIRECTION_STANCES:
-                b["direction_claims"] += 1
+            if row["base_value"] is not None:
+                b["mape_terms"].append(abs(Decimal(row["base_value"]) - realized_close) / realized_close)
+            if direction:
+                b["direction_outcomes"] += 1
                 hit = realized_return > 0 if row["stance"] == "buy" else realized_return < 0
                 if hit:
                     b["hits"] += 1
                 confidence = row["confidence_score"]
-                if confidence is None:
-                    b["confidence_absent"] += 1
-                else:
+                if confidence is not None:
                     b["brier_terms"].append((Decimal(confidence) - (1 if hit else 0)) ** 2)
 
     def _mean(terms: list[Decimal]) -> float | None:
@@ -409,7 +420,7 @@ def aggregate_scoreboard(
             confidence_absent=b["confidence_absent"],
             direction_claims=b["direction_claims"],
             target_distance_mape=_mean(b["mape_terms"]),
-            stance_hit_rate=(b["hits"] / b["direction_claims"]) if b["direction_claims"] else None,
+            stance_hit_rate=(b["hits"] / b["direction_outcomes"]) if b["direction_outcomes"] else None,
             conviction_brier=_mean(b["brier_terms"]),
         )
         for (model, pv, horizon), b in sorted(acc.items(), key=lambda kv: (kv[0][0] or "", kv[0][1] or "", kv[0][2]))

--- a/app/services/thesis_outcomes.py
+++ b/app/services/thesis_outcomes.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date, timedelta
+from decimal import Decimal
 from typing import Any
 
 import psycopg
@@ -250,3 +251,179 @@ def capture_thesis_outcomes(conn: psycopg.Connection[Any]) -> ThesisOutcomeCaptu
         skipped_missing_close=missing_close,
         skipped_nonpositive_close=nonpositive,
     )
+
+
+# --- Calibration scoreboard (#2068) — read-side over the ledger ----------
+#
+# Metric definitions are FIXED in the spec ("Metric definitions" section,
+# docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md); this is
+# an implementation, not a redesign. Cohort = (model, prompt_version,
+# horizon_days) over ALL thesis versions (the ledger scores versions, not
+# instruments). Coverage counters are first-class output — honest
+# missingness, never imputation.
+
+_DIRECTION_STANCES = frozenset({"buy", "avoid"})
+
+_SCOREBOARD_THESES_SQL = """
+SELECT t.thesis_id, t.model, t.prompt_version, t.stance,
+       t.base_value, t.confidence_score, i.is_tradable,
+       r.context_summary, p.max_price_date
+FROM theses t
+JOIN instruments i ON i.instrument_id = t.instrument_id
+LEFT JOIN LATERAL (
+    SELECT context_summary
+    FROM thesis_runs r
+    WHERE r.thesis_id = t.thesis_id AND r.context_summary IS NOT NULL
+    ORDER BY r.run_id DESC
+    LIMIT 1
+) r ON TRUE
+LEFT JOIN LATERAL (
+    SELECT max(price_date) AS max_price_date
+    FROM price_daily p
+    WHERE p.instrument_id = t.instrument_id
+) p ON TRUE
+ORDER BY t.thesis_id
+"""
+
+_SCOREBOARD_OUTCOMES_SQL = """
+SELECT thesis_id, horizon_days, realized_close, realized_return
+FROM thesis_outcomes
+"""
+
+
+@dataclass(frozen=True)
+class CohortScore:
+    """One (model, prompt_version, horizon) scoreboard row."""
+
+    model: str | None
+    prompt_version: str | None
+    horizon_days: int
+    # Coverage counters (spec item 4 — always reported).
+    total_theses: int
+    anchorless: int
+    immature_data_current: int
+    immature_series_stalled: int
+    series_dead: int
+    outcome_rows: int
+    targets_absent: int
+    confidence_absent: int
+    direction_claims: int
+    # Metrics (None when the contributing set is empty — never imputed).
+    target_distance_mape: float | None
+    stance_hit_rate: float | None
+    conviction_brier: float | None
+
+
+def aggregate_scoreboard(
+    thesis_rows: list[dict[str, Any]],
+    outcomes: dict[tuple[int, int], tuple[Decimal, Decimal]],
+    today: date,
+) -> list[CohortScore]:
+    """Pure aggregation over plain values (table-testable, no DB).
+
+    ``thesis_rows``: one dict per thesis version (keys: thesis_id, model,
+    prompt_version, stance, base_value, confidence_score, is_tradable,
+    context_summary, max_price_date). ``outcomes``: (thesis_id, horizon)
+    -> (realized_close, realized_return).
+
+    Per spec: MAPE-form target distance over base_value-bearing outcome
+    rows; stance hit-rate over direction claims (buy hit <=> return > 0,
+    avoid hit <=> return < 0; watch/hold make no claim); conviction Brier
+    over direction claims with non-null confidence_score (diagnostic —
+    "does conviction behave like a calibrated probability?"). A mature
+    pair the nightly capture has not yet minted counts as immature here
+    (compute-on-read never classifies ahead of the ledger).
+    """
+    acc: dict[tuple[str | None, str | None, int], dict[str, Any]] = {}
+
+    def bucket(model: str | None, pv: str | None, horizon: int) -> dict[str, Any]:
+        key = (model, pv, horizon)
+        if key not in acc:
+            acc[key] = {
+                "total_theses": 0,
+                "anchorless": 0,
+                "immature_data_current": 0,
+                "immature_series_stalled": 0,
+                "series_dead": 0,
+                "outcome_rows": 0,
+                "targets_absent": 0,
+                "confidence_absent": 0,
+                "direction_claims": 0,
+                "mape_terms": [],
+                "hits": 0,
+                "brier_terms": [],
+            }
+        return acc[key]
+
+    for row in thesis_rows:
+        anchor_date = anchor_date_from_summary(row["context_summary"])
+        for horizon in HORIZONS:
+            b = bucket(row["model"], row["prompt_version"], horizon)
+            b["total_theses"] += 1
+            if anchor_date is None:
+                b["anchorless"] += 1
+                continue
+            outcome = outcomes.get((int(row["thesis_id"]), horizon))
+            if outcome is None:
+                kind = classify_immature(
+                    is_tradable=bool(row["is_tradable"]),
+                    max_price_date=row["max_price_date"],
+                    due_date=anchor_date + timedelta(days=horizon),
+                    today=today,
+                )
+                b[kind] += 1
+                continue
+            realized_close, realized_return = outcome
+            b["outcome_rows"] += 1
+            base_value = row["base_value"]
+            if base_value is None:
+                b["targets_absent"] += 1
+            else:
+                b["mape_terms"].append(abs(Decimal(base_value) - realized_close) / realized_close)
+            if row["stance"] in _DIRECTION_STANCES:
+                b["direction_claims"] += 1
+                hit = realized_return > 0 if row["stance"] == "buy" else realized_return < 0
+                if hit:
+                    b["hits"] += 1
+                confidence = row["confidence_score"]
+                if confidence is None:
+                    b["confidence_absent"] += 1
+                else:
+                    b["brier_terms"].append((Decimal(confidence) - (1 if hit else 0)) ** 2)
+
+    def _mean(terms: list[Decimal]) -> float | None:
+        return float(sum(terms) / len(terms)) if terms else None
+
+    return [
+        CohortScore(
+            model=model,
+            prompt_version=pv,
+            horizon_days=horizon,
+            total_theses=b["total_theses"],
+            anchorless=b["anchorless"],
+            immature_data_current=b["immature_data_current"],
+            immature_series_stalled=b["immature_series_stalled"],
+            series_dead=b["series_dead"],
+            outcome_rows=b["outcome_rows"],
+            targets_absent=b["targets_absent"],
+            confidence_absent=b["confidence_absent"],
+            direction_claims=b["direction_claims"],
+            target_distance_mape=_mean(b["mape_terms"]),
+            stance_hit_rate=(b["hits"] / b["direction_claims"]) if b["direction_claims"] else None,
+            conviction_brier=_mean(b["brier_terms"]),
+        )
+        for (model, pv, horizon), b in sorted(acc.items(), key=lambda kv: (kv[0][0] or "", kv[0][1] or "", kv[0][2]))
+    ]
+
+
+def compute_calibration_scoreboard(conn: psycopg.Connection[Any]) -> list[CohortScore]:
+    """The one DB reader for the scoreboard endpoint (#2068)."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_SCOREBOARD_THESES_SQL)
+        thesis_rows = cur.fetchall()
+    outcomes: dict[tuple[int, int], tuple[Decimal, Decimal]] = {}
+    with conn.cursor() as cur:
+        cur.execute(_SCOREBOARD_OUTCOMES_SQL)
+        for thesis_id, horizon_days, realized_close, realized_return in cur.fetchall():
+            outcomes[(int(thesis_id), int(horizon_days))] = (realized_close, realized_return)
+    return aggregate_scoreboard(thesis_rows, outcomes, date.today())

--- a/tests/test_thesis_outcomes.py
+++ b/tests/test_thesis_outcomes.py
@@ -7,6 +7,7 @@ over values — the house lean-test rule."""
 from __future__ import annotations
 
 from datetime import date
+from decimal import Decimal
 
 import pytest
 
@@ -90,3 +91,120 @@ def test_classify_immature(tradable: bool, max_price: date | None, due: date, ex
 def test_horizons_are_the_spec_set() -> None:
     """Schema CHECK pins (30, 90, 365); the constant must match."""
     assert HORIZONS == (30, 90, 365)
+
+
+class TestAggregateScoreboard:
+    """#2068 — pure cohort aggregation over plain values."""
+
+    @staticmethod
+    def _row(
+        thesis_id: int = 1,
+        model: str | None = "qwen3:14b",
+        prompt_version: str | None = "v5",
+        stance: str = "buy",
+        base_value: Decimal | None = Decimal("110"),
+        confidence_score: Decimal | None = Decimal("0.8"),
+        is_tradable: bool = True,
+        context_summary: object = None,
+        max_price_date: date | None = date(2026, 7, 1),
+    ) -> dict:
+        return {
+            "thesis_id": thesis_id,
+            "model": model,
+            "prompt_version": prompt_version,
+            "stance": stance,
+            "base_value": base_value,
+            "confidence_score": confidence_score,
+            "is_tradable": is_tradable,
+            "context_summary": context_summary if context_summary is not None else _summary(),
+            "max_price_date": max_price_date,
+        }
+
+    _TODAY = date(2026, 7, 10)
+
+    def test_anchorless_thesis_counts_per_horizon(self) -> None:
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        rows = [self._row(context_summary=_summary(available=False))]
+        cohorts = aggregate_scoreboard(rows, {}, self._TODAY)
+        assert len(cohorts) == 3
+        assert all(c.total_theses == 1 and c.anchorless == 1 for c in cohorts)
+        assert all(c.target_distance_mape is None for c in cohorts)
+
+    def test_buy_hit_mape_and_brier(self) -> None:
+        """base 110 vs realized 100 → MAPE 0.10; buy + positive return =
+        hit; Brier (0.8 − 1)² = 0.04."""
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        outcomes = {(1, 30): (Decimal("100"), Decimal("0.05"))}
+        cohorts = aggregate_scoreboard([self._row()], outcomes, self._TODAY)
+        c30 = next(c for c in cohorts if c.horizon_days == 30)
+        assert c30.outcome_rows == 1
+        assert c30.direction_claims == 1
+        assert c30.stance_hit_rate == 1.0
+        assert c30.target_distance_mape == pytest.approx(0.10)
+        assert c30.conviction_brier == pytest.approx(0.04)
+
+    def test_avoid_hit_on_negative_return(self) -> None:
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        outcomes = {(1, 30): (Decimal("50"), Decimal("-0.2"))}
+        cohorts = aggregate_scoreboard([self._row(stance="avoid", base_value=None)], outcomes, self._TODAY)
+        c30 = next(c for c in cohorts if c.horizon_days == 30)
+        assert c30.stance_hit_rate == 1.0
+        assert c30.targets_absent == 1
+        assert c30.target_distance_mape is None
+
+    def test_zero_return_misses_both_directions(self) -> None:
+        """Spec is strict > / < — a flat print is a miss for buy AND avoid."""
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        outcomes = {(1, 30): (Decimal("100"), Decimal("0"))}
+        for stance in ("buy", "avoid"):
+            cohorts = aggregate_scoreboard([self._row(stance=stance)], outcomes, self._TODAY)
+            c30 = next(c for c in cohorts if c.horizon_days == 30)
+            assert c30.stance_hit_rate == 0.0
+
+    def test_watch_excluded_from_direction_metrics_but_mape_counted(self) -> None:
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        outcomes = {(1, 30): (Decimal("100"), Decimal("0.05"))}
+        cohorts = aggregate_scoreboard([self._row(stance="watch")], outcomes, self._TODAY)
+        c30 = next(c for c in cohorts if c.horizon_days == 30)
+        assert c30.direction_claims == 0
+        assert c30.stance_hit_rate is None
+        assert c30.conviction_brier is None
+        assert c30.target_distance_mape == pytest.approx(0.10)
+
+    def test_null_confidence_counted_and_excluded_from_brier(self) -> None:
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        outcomes = {(1, 30): (Decimal("100"), Decimal("0.05"))}
+        cohorts = aggregate_scoreboard([self._row(confidence_score=None)], outcomes, self._TODAY)
+        c30 = next(c for c in cohorts if c.horizon_days == 30)
+        assert c30.confidence_absent == 1
+        assert c30.conviction_brier is None
+        assert c30.stance_hit_rate == 1.0  # hit-rate needs no confidence
+
+    def test_uncaptured_pair_classified_immature(self) -> None:
+        """Anchored thesis with no outcome row and a current series →
+        immature_data_current (never classified ahead of the ledger)."""
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        rows = [self._row(max_price_date=self._TODAY)]
+        cohorts = aggregate_scoreboard(rows, {}, self._TODAY)
+        assert all(c.immature_data_current == 1 for c in cohorts)
+
+    def test_cohorts_split_by_model_and_prompt_version(self) -> None:
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        rows = [
+            self._row(thesis_id=1, model="qwen3:14b", prompt_version="v4"),
+            self._row(thesis_id=2, model="qwen3:14b", prompt_version="v5"),
+            self._row(thesis_id=3, model=None, prompt_version=None),
+        ]
+        cohorts = aggregate_scoreboard(rows, {}, self._TODAY)
+        keys = {(c.model, c.prompt_version) for c in cohorts}
+        assert keys == {("qwen3:14b", "v4"), ("qwen3:14b", "v5"), (None, None)}
+        assert len(cohorts) == 9  # 3 cohorts x 3 horizons
+        assert all(c.total_theses == 1 for c in cohorts)

--- a/tests/test_thesis_outcomes.py
+++ b/tests/test_thesis_outcomes.py
@@ -208,3 +208,21 @@ class TestAggregateScoreboard:
         assert keys == {("qwen3:14b", "v4"), ("qwen3:14b", "v5"), (None, None)}
         assert len(cohorts) == 9  # 3 cohorts x 3 horizons
         assert all(c.total_theses == 1 for c in cohorts)
+
+    def test_coverage_counters_are_population_scoped(self) -> None:
+        """Codex ckpt-2: targets_absent / confidence_absent /
+        direction_claims count the whole cohort population — an immature
+        thesis with no outcome row still contributes coverage."""
+        from app.services.thesis_outcomes import aggregate_scoreboard
+
+        rows = [
+            self._row(thesis_id=1, stance="avoid", base_value=None, confidence_score=None, max_price_date=self._TODAY)
+        ]
+        cohorts = aggregate_scoreboard(rows, {}, self._TODAY)
+        c30 = next(c for c in cohorts if c.horizon_days == 30)
+        assert c30.outcome_rows == 0
+        assert c30.direction_claims == 1
+        assert c30.targets_absent == 1
+        assert c30.confidence_absent == 1
+        assert c30.immature_data_current == 1
+        assert c30.stance_hit_rate is None


### PR DESCRIPTION
## What

#2002 shipped capture-only; the scoreboard intent lived only in merged-spec prose (write-only table = orphaned-intent risk). This slice: `GET /theses/calibration-scoreboard` — per (model, prompt_version, horizon) cohort over ALL thesis versions.

Metric definitions implemented VERBATIM from `docs/proposals/thesis/2026-07-16-calibration-ledger-schema.md` "Metric definitions" (fixed there; not redesigned):
1. Target distance (MAPE-form) over base_value-bearing outcome rows.
2. Stance hit-rate — buy hit ⇔ return > 0, avoid ⇔ return < 0 (strict; flat = miss both), watch/hold excluded.
3. Conviction Brier (diagnostic) over direction-claim outcome rows with non-null confidence.
4. Full coverage counters: total / anchorless / immature_data_current / immature_series_stalled / series_dead / targets_absent / confidence_absent / direction_claims — previously visible only in the capture job's tracker.note.

Scoping decision (Codex ckpt-2 Medium, fixed in-branch): coverage counters are POPULATION-scoped (matches the spec's own full-population verification framing — "78/399 carry base_value", "direction-claim cohort today = 180"); metric denominators stay outcome-scoped (internal `direction_outcomes`).

## Shape

- `aggregate_scoreboard` — pure, table-tested (9 tests); `compute_calibration_scoreboard` — the one DB reader (two reads: theses+LATERALs reusing the #2002 candidate shape, thesis_outcomes full scan; no N+1).
- Endpoint in `app/api/theses.py` next to `/dq-audit`, registered BEFORE `/{instrument_id}` (literal-vs-int route rule), same auth (router-level session/service token).
- Immature classification reuses `classify_immature` / `anchor_date_from_summary` — no duplicated semantics. A mature-but-uncaptured pair reads as immature (compute-on-read never classifies ahead of the ledger).
- FE panel = follow-up slice per ticket.

## Security model

Read-only; router-level auth (`require_session_or_service_token`) covers the new route; parameterised/static SQL; no new inputs.

## Verification

- Pure tests: 9 table tests (buy-hit MAPE+Brier arithmetic, avoid-hit, flat-return strict miss, watch exclusion, null-target/null-confidence counting, anchorless, immature pass-through, cohort split incl NULL model/pv, population-scoped coverage).
- Dev-verify (direct service run against dev DB): 12 cohorts — v1 25 / v2 36 / v3 71 all-anchorless (pre-#2017, matches the spec's 133-gap), v4 332 with anchorless 1, immature split rendering, dir_claims 149, targets_absent 271, 0 outcome rows (first maturities ~2026-08-08 — this ships BEFORE they land, per ticket sequencing). Cross-checked against direct SQL `GROUP BY prompt_version` on dev: counts identical.
- ruff + format + pyright clean; fast tier exit 0; smoke `-n 0` exit 0.
- Codex ckpt-2: 1 Medium (counter scoping) FIXED in-branch; formulas/Decimal/None-handling/auth/route-order/SQL-shape all confirmed OK.
- No schema change, no job change, no backfill — ETL clauses N/A.

Closes #2068

🤖 Generated with [Claude Code](https://claude.com/claude-code)