### PR TITLE
infra(#2073): serialize concurrent pre-push smoke stages with an ownership-safe mkdir lock

### DIFF
--- a/.claude/skills/engineering/pre-push-checklist.md
+++ b/.claude/skills/engineering/pre-push-checklist.md
@@ -30,6 +30,20 @@ uv run pytest -m db                                  # full integration tier
 
 Fix failures before pushing. If `uv` is not on PATH, run `where uv` to find it and add to shell config.
 
+**Never pipe `git push` (#2073):** `git push | tail` (or any pipe) makes the
+shell report the PIPE's exit status, silently masking a pre-push hook
+failure — the push looks green while nothing left the machine. Run
+`git push` unpiped (redirect to a file if the output is long) and verify
+with `git status -sb` after EVERY push: the branch must show
+`...origin/<branch>` with no `[ahead N]`.
+
+**Concurrent worktree pushes (#2073):** the hook's smoke stage holds a
+mkdir lock (`$TMPDIR/ebull-prepush-smoke.lock`) so two pushes queue
+instead of colliding on the shared dev DB. A push that waits with
+"smoke lock held by a concurrent push — queuing" is healthy; a stale
+lock (>10 min) is stolen automatically. Fast tier ~60-90s under load
+(the ~25s figure above is quiet-machine).
+
 ## Then read `git diff origin/main...HEAD` top to bottom
 
 Adopt the reviewer's posture: read what is there, not what you intended.

--- a/.claude/skills/engineering/pre-push-checklist.md
+++ b/.claude/skills/engineering/pre-push-checklist.md
@@ -40,9 +40,11 @@ with `git status -sb` after EVERY push: the branch must show
 **Concurrent worktree pushes (#2073):** the hook's smoke stage holds a
 mkdir lock (`$TMPDIR/ebull-prepush-smoke.lock`) so two pushes queue
 instead of colliding on the shared dev DB. A push that waits with
-"smoke lock held by a concurrent push — queuing" is healthy; a stale
-lock (>10 min) is stolen automatically. Fast tier ~60-90s under load
-(the ~25s figure above is quiet-machine).
+"smoke lock held by a concurrent push — queuing" is healthy. Stealing
+is liveness-based: only a lock whose owner pid is dead (or whose pid
+marker stays absent ~15s) is stolen; a live owner is waited on
+indefinitely. Fast tier ~60-90s under load (the ~25s figure above is
+quiet-machine).
 
 ## Then read `git diff origin/main...HEAD` top to bottom
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -300,19 +300,46 @@ uv run pytest -m "not db" --tb=short -q
 # ONLY the smoke stage: the fast tier above touches no DB and the
 # stages below are read-only probes.
 SMOKE_LOCK_DIR="${TMPDIR:-/tmp}/ebull-prepush-smoke.lock"
-_release_smoke_lock() { rmdir "${SMOKE_LOCK_DIR}" 2>/dev/null || true; }
-smoke_lock_waits=0
+# Ownership-safe release (Codex ckpt-2 High): only the pid that wrote the
+# marker may remove the dir, so a slow owner can never delete a lock a
+# later push now holds.
+_release_smoke_lock() {
+  if [[ "$(cat "${SMOKE_LOCK_DIR}/pid" 2>/dev/null)" == "$$" ]]; then
+    rm -rf "${SMOKE_LOCK_DIR}" 2>/dev/null || true
+  fi
+}
+# A lock whose owner pid is dead (SIGKILLed push — trap cannot run on
+# KILL) or absent for ~15s (crash inside the mkdir→pid-write window) is
+# leaked. Steal via atomic mv so exactly ONE waiter wins the steal; the
+# loser's mv fails and it re-loops into a fresh mkdir race.
+_smoke_lock_owner_alive() {
+  local owner
+  owner="$(cat "${SMOKE_LOCK_DIR}/pid" 2>/dev/null || true)"
+  [[ "${owner}" =~ ^[0-9]+$ ]] && kill -0 "${owner}" 2>/dev/null
+}
+smoke_lock_polls=0
+smoke_dead_polls=0
 until mkdir "${SMOKE_LOCK_DIR}" 2>/dev/null; do
-  if [[ "${smoke_lock_waits}" -eq 0 ]]; then
+  if [[ "${smoke_lock_polls}" -eq 0 ]]; then
     echo "==> Pre-push gate: smoke lock held by a concurrent push — queuing"
   fi
-  smoke_lock_waits=$((smoke_lock_waits + 1))
-  if [[ "${smoke_lock_waits}" -gt 120 ]]; then
-    echo "==> Pre-push gate: smoke lock stale (>10 min) — stealing"
-    _release_smoke_lock
+  smoke_lock_polls=$((smoke_lock_polls + 1))
+  if _smoke_lock_owner_alive; then
+    smoke_dead_polls=0
+  else
+    smoke_dead_polls=$((smoke_dead_polls + 1))
+    if [[ "${smoke_dead_polls}" -gt 3 ]]; then
+      stale="${SMOKE_LOCK_DIR}.stale.$$"
+      if mv "${SMOKE_LOCK_DIR}" "${stale}" 2>/dev/null; then
+        echo "==> Pre-push gate: smoke lock owner dead — stole leaked lock"
+        rm -rf "${stale}"
+      fi
+      continue
+    fi
   fi
   sleep 5
 done
+echo "$$" > "${SMOKE_LOCK_DIR}/pid"
 trap _release_smoke_lock EXIT
 
 echo "==> Pre-push gate: smoke (app boots against dev DB)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -291,8 +291,37 @@ uv run pytest -m "not db" --tb=short -q
 # connections -> intermittent ERRORs on random parametrized cases (#1843). Smoke
 # is small (~135 tests, ~31s serial); the parallelism buys nothing and costs
 # determinism. The fast tier above keeps -n 4 (no DB => no contention).
+# #2073 — two worktrees pushing concurrently run this smoke tier against
+# the SAME dev DB and collide (test_etl_source_to_sink ERRORs, 07-16,
+# twice). Serialize with a mkdir lock — macOS ships bash 3.2 and no
+# flock(1), and mkdir is atomic on every POSIX filesystem. A waiting
+# hook queues (5s poll); a lock older than 10 min is presumed leaked
+# (SIGKILLed push — trap can't run on KILL) and stolen. The lock wraps
+# ONLY the smoke stage: the fast tier above touches no DB and the
+# stages below are read-only probes.
+SMOKE_LOCK_DIR="${TMPDIR:-/tmp}/ebull-prepush-smoke.lock"
+_release_smoke_lock() { rmdir "${SMOKE_LOCK_DIR}" 2>/dev/null || true; }
+smoke_lock_waits=0
+until mkdir "${SMOKE_LOCK_DIR}" 2>/dev/null; do
+  if [[ "${smoke_lock_waits}" -eq 0 ]]; then
+    echo "==> Pre-push gate: smoke lock held by a concurrent push — queuing"
+  fi
+  smoke_lock_waits=$((smoke_lock_waits + 1))
+  if [[ "${smoke_lock_waits}" -gt 120 ]]; then
+    echo "==> Pre-push gate: smoke lock stale (>10 min) — stealing"
+    _release_smoke_lock
+  fi
+  sleep 5
+done
+trap _release_smoke_lock EXIT
+
 echo "==> Pre-push gate: smoke (app boots against dev DB)"
 uv run pytest tests/smoke -n 0 --tb=short -q
+
+# Release promptly so a queued push can start while the non-DB stages
+# below finish; the EXIT trap still covers every failure path above.
+_release_smoke_lock
+trap - EXIT
 
 # Frontend dark-mode class hygiene (#708). Skipped if frontend/ is
 # absent (e.g. backend-only worktrees) or if `pnpm` is not on PATH —

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -295,10 +295,12 @@ uv run pytest -m "not db" --tb=short -q
 # the SAME dev DB and collide (test_etl_source_to_sink ERRORs, 07-16,
 # twice). Serialize with a mkdir lock — macOS ships bash 3.2 and no
 # flock(1), and mkdir is atomic on every POSIX filesystem. A waiting
-# hook queues (5s poll); a lock older than 10 min is presumed leaked
-# (SIGKILLed push — trap can't run on KILL) and stolen. The lock wraps
-# ONLY the smoke stage: the fast tier above touches no DB and the
-# stages below are read-only probes.
+# hook queues (5s poll). Stealing is LIVENESS-based, not age-based: a
+# lock whose owner pid is dead (SIGKILLed push — trap can't run on
+# KILL) or absent ~15s is leaked and stolen; a live owner is never
+# stolen — it is running the smoke tier and the waiter's whole job is
+# to wait for it. The lock wraps ONLY the smoke stage: the fast tier
+# above touches no DB and the stages below are read-only probes.
 SMOKE_LOCK_DIR="${TMPDIR:-/tmp}/ebull-prepush-smoke.lock"
 # Ownership-safe release (Codex ckpt-2 High): only the pid that wrote the
 # marker may remove the dir, so a slow owner can never delete a lock a


### PR DESCRIPTION
## What

Two worktrees pushing concurrently run the pre-push smoke tier against the SAME dev DB and collide (`tests/smoke/test_etl_source_to_sink*` ERRORs — observed 07-16, second occurrence of the class, ~15min lost).

- `.githooks/pre-push`: mkdir lock (macOS ships bash 3.2 and no flock(1); mkdir is atomic) around ONLY the smoke stage — the fast tier touches no DB and the tail stages are read-only probes. Waiting hooks queue on a 5s poll.
- **Ownership-safe** (Codex ckpt-2 High, fixed in-branch): a pid marker inside the lockdir; release only by the writing pid, so a slow owner can never delete a lock a later push now holds. Stealing happens only for a DEAD owner (`kill -0` probe; ~15s grace for the mkdir→pid-write window) via atomic `mv` so exactly one waiter wins the steal. The wait-timer steal was removed entirely (Codex ckpt-2 Medium: it measured queue time, not lock age) — a live owner queues indefinitely; a SIGKILL leak is detected within one poll.
- `.claude/skills/engineering/pre-push-checklist.md`: `git push | tail` pipe-exit masking warning + `git status -sb` post-push verification rule; concurrent-push queuing note; fast-tier timing caveat.

## Security model

Local dev hook only; lockdir under `$TMPDIR`; no network, no DB writes, no repo code paths.

## Verification

- `shellcheck -S warning .githooks/pre-push`: clean; `bash -n`: ok.
- Functional (scripted): live-lock queues; dead-owner (pid 99999999) steal fires once via mv; wrong-pid release blocked; owner release removes lock.
- The push of this very branch exercised the hook end-to-end (lock acquire/release inline): gates green, push exit 0.
- Codex ckpt-2: High (steal race) + Medium (timer semantics) both fixed as above; set-e/trap/TMPDIR-quoting confirmed clean.

Closes #2073

🤖 Generated with [Claude Code](https://claude.com/claude-code)