### PR TITLE
feat(#2071): staleness reason detail strings + refactor(#2074): find_stale dict_row

### DIFF
--- a/app/api/alerts.py
+++ b/app/api/alerts.py
@@ -231,6 +231,7 @@ class ThesisStalenessItem(BaseModel):
     instrument_id: int
     symbol: str
     reason: str  # find_stale_instruments StaleReason (open string, #1808)
+    detail: str | None = None  # #2071 — magnitude for data-driven reasons
     latest_thesis_at: datetime | None  # None = no thesis at all
 
 
@@ -1079,6 +1080,7 @@ def get_thesis_staleness(
                 instrument_id=s.instrument_id,
                 symbol=s.symbol,
                 reason=s.reason,
+                detail=s.detail,
                 latest_thesis_at=latest_at.get(s.instrument_id),
             )
             for s in stale

--- a/app/api/theses.py
+++ b/app/api/theses.py
@@ -200,6 +200,9 @@ class ThesisDetail(BaseModel):
     provider: str | None = None
     is_stale: bool | None = None
     stale_reason: str | None = None
+    # #2071 — magnitude string for the data-driven staleness reasons
+    # (price_move/band_exit/news_spike); None otherwise.
+    stale_detail: str | None = None
     # #2013 — diff vs the (instrument_id, thesis_version - 1) predecessor.
     # None when thesis_version == 1 or the predecessor row is missing.
     diff: ThesisDiffModel | None = None
@@ -252,6 +255,7 @@ class ThesisLibraryItem(BaseModel):
     created_at: datetime | None
     critic_verdict: str | None
     stale_reason: str | None
+    stale_detail: str | None  # #2071 — magnitude for data-driven reasons
     is_held: bool
     latest_score: float | None
     latest_rank: int | None
@@ -413,6 +417,7 @@ def filter_and_page_library(
     rows: list[dict[str, object]],
     stale_reasons: dict[int, str],
     *,
+    stale_details: dict[int, str | None] | None = None,
     held_only: bool,
     stale_only: bool,
     stance: str | None,
@@ -438,6 +443,7 @@ def filter_and_page_library(
         # python-hygiene.md "never assert production invariants").
         instrument_id = int(row["instrument_id"])  # type: ignore[arg-type]
         row["stale_reason"] = stale_reasons.get(instrument_id)
+        row["stale_detail"] = (stale_details or {}).get(instrument_id)
         if held_only and not row["is_held"]:
             continue
         if stale_only and row["stale_reason"] is None:
@@ -657,15 +663,17 @@ def list_theses(
         rows.sort(key=library_order_key)
 
     stale_reasons: dict[int, str] = {}
+    stale_details: dict[int, str | None] = {}
     if rows:
         instrument_ids = [int(r["instrument_id"]) for r in rows]  # type: ignore[arg-type]
-        stale_reasons = {
-            s.instrument_id: s.reason for s in find_stale_instruments(conn, tier=None, instrument_ids=instrument_ids)
-        }
+        stale_hits = find_stale_instruments(conn, tier=None, instrument_ids=instrument_ids)
+        stale_reasons = {s.instrument_id: s.reason for s in stale_hits}
+        stale_details = {s.instrument_id: s.detail for s in stale_hits}
 
     total, page = filter_and_page_library(
         rows,
         stale_reasons,
+        stale_details=stale_details,
         held_only=held_only,
         stale_only=stale,
         stance=stance,
@@ -691,6 +699,7 @@ def list_theses(
             created_at=row["created_at"],  # type: ignore[arg-type]
             critic_verdict=_critic_verdict(row["critic_json"]),
             stale_reason=row["stale_reason"],  # type: ignore[arg-type]
+            stale_detail=row["stale_detail"],  # type: ignore[arg-type]
             is_held=bool(row["is_held"]),
             latest_score=_parse_optional_float(row, "latest_score"),
             latest_rank=row["latest_rank"],  # type: ignore[arg-type]
@@ -866,6 +875,7 @@ def get_latest_thesis(
     # both render as not-stale because regeneration would never fire.
     stale = find_stale_instruments(conn, tier=None, instrument_ids=[instrument_id])
     thesis.stale_reason = stale[0].reason if stale else None
+    thesis.stale_detail = stale[0].detail if stale else None
     thesis.is_stale = bool(stale)
     return thesis
 

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -312,21 +312,33 @@ def _band_exit_fired(
     return minted_inside and now_outside
 
 
-def _news_spike_fired(m7: float, m30: float) -> bool:
-    """Trailing-7d importance-mass rate >= ratio x prior-23d baseline rate,
-    over an absolute mass floor.
+def _news_spike_ratio(m7: float, m30: float) -> float | None:
+    """The fired spike ratio (>= ``_NEWS_SPIKE_RATIO``), or None when the
+    predicate does not fire.
+
+    Trailing-7d importance-mass rate vs the prior-23d baseline rate, over
+    an absolute mass floor. Baseline-less names (baseline <= 0 — includes
+    a spike fully concentrated in the 7d window, m30 == m7) are not
+    evaluated, so the division is guarded by construction; the #2071
+    detail string consumes THIS return value, never re-derives it (PR
+    #2082 review — fire decision and reported ratio cannot desync).
 
     Self-rearming without state: stored importance scores are static but
     window membership rolls a spike's stories out of the 7d window and
     into the baseline, so the ratio subsides ~a week after the storm.
-    Baseline-less names (baseline <= 0) are not evaluated.
     """
     baseline = (m30 - m7) / _NEWS_BASELINE_DAYS
     if baseline <= 0:
-        return False
+        return None
     if m7 < _NEWS_SPIKE_MASS_FLOOR:
-        return False
-    return (m7 / _NEWS_WINDOW_DAYS) >= _NEWS_SPIKE_RATIO * baseline
+        return None
+    ratio = (m7 / _NEWS_WINDOW_DAYS) / baseline
+    return ratio if ratio >= _NEWS_SPIKE_RATIO else None
+
+
+def _news_spike_fired(m7: float, m30: float) -> bool:
+    """Boolean face of ``_news_spike_ratio`` (kept for the table tests)."""
+    return _news_spike_ratio(m7, m30) is not None
 
 
 def find_stale_instruments(
@@ -595,15 +607,13 @@ def find_stale_instruments(
         # Rule 7 (#1988): news storm on a name with a real news baseline.
         # Independent of price evaluability — a stale price series must not
         # mask a news trigger.
-        if _news_spike_fired(m7, m30):
-            baseline = (m30 - m7) / _NEWS_BASELINE_DAYS
-            ratio = (m7 / _NEWS_WINDOW_DAYS) / baseline
+        if (spike_ratio := _news_spike_ratio(m7, m30)) is not None:
             stale.append(
                 StaleInstrument(
                     instrument_id=instrument_id,
                     symbol=symbol,
                     reason="news_spike",
-                    detail=f"7d news mass {m7:.1f} at {ratio:.1f}x 30d baseline",
+                    detail=f"7d news mass {m7:.1f} at {spike_ratio:.1f}x 30d baseline",
                 )
             )
             continue

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -52,6 +52,7 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Any, Literal
 
 import psycopg
+import psycopg.rows
 from psycopg import sql as psql
 from psycopg.types.json import Jsonb
 
@@ -214,6 +215,11 @@ class StaleInstrument:
     instrument_id: int
     symbol: str
     reason: StaleReason
+    # #2071 — operator-facing magnitude for the data-driven v2 reasons
+    # (price_move / band_exit / news_spike; formats fixed in
+    # docs/specs/thesis/2026-07-16-thesis-staleness-v2.md). None for the
+    # cadence/event reasons, whose name is the whole story.
+    detail: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -484,26 +490,31 @@ def find_stale_instruments(
         """
         )
     )
-    rows = conn.execute(query, params).fetchall()
+    # #2074 — dict_row: rows are keyed by the SELECT aliases, so a column
+    # addition can never silently shift positional reads (the #1988
+    # _V2_TAIL churn class) or break mocks that name their columns.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(query, params)
+        rows = cur.fetchall()
 
     now = _utcnow()
     stale: list[StaleInstrument] = []
 
     for row in rows:
-        instrument_id: int = row[0]
-        symbol: str = row[1]
-        review_frequency: str | None = row[2]
-        latest_thesis_at: datetime | None = row[3]
-        latest_event_created_at: datetime | None = row[4]
-        latest_event_filing_type: str | None = row[5]
-        break_fired: bool = bool(row[6])
-        bear_value = _to_float(row[7])
-        bull_value = _to_float(row[8])
-        close_now = _to_float(row[9])
-        close_now_date: date | None = row[10]
-        close_at_mint = _to_float(row[11])
-        m7 = _to_float(row[12]) or 0.0
-        m30 = _to_float(row[13]) or 0.0
+        instrument_id: int = row["instrument_id"]
+        symbol: str = row["symbol"]
+        review_frequency: str | None = row["review_frequency"]
+        latest_thesis_at: datetime | None = row["latest_thesis_at"]
+        latest_event_created_at: datetime | None = row["latest_event_created_at"]
+        latest_event_filing_type: str | None = row["latest_event_filing_type"]
+        break_fired: bool = bool(row["break_fired"])
+        bear_value = _to_float(row["bear_value"])
+        bull_value = _to_float(row["bull_value"])
+        close_now = _to_float(row["close_now"])
+        close_now_date: date | None = row["close_now_date"]
+        close_at_mint = _to_float(row["close_at_mint"])
+        m7 = _to_float(row["m7"]) or 0.0
+        m30 = _to_float(row["m30"]) or 0.0
 
         if latest_thesis_at is None:
             stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="no_thesis"))
@@ -554,17 +565,47 @@ def find_stale_instruments(
         if prices is not None:
             now_px, mint_px = prices
             if _price_move_fired(now_px, mint_px):
-                stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="price_move"))
+                pct = (now_px - mint_px) / mint_px
+                stale.append(
+                    StaleInstrument(
+                        instrument_id=instrument_id,
+                        symbol=symbol,
+                        reason="price_move",
+                        detail=f"close {now_px:g} vs {mint_px:g} at mint ({pct:+.0%})",
+                    )
+                )
                 continue
-            if _band_exit_fired(now_px, mint_px, bear_value, bull_value):
-                stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="band_exit"))
+            if (
+                bear_value is not None
+                and bull_value is not None
+                and _band_exit_fired(now_px, mint_px, bear_value, bull_value)
+            ):
+                stale.append(
+                    StaleInstrument(
+                        instrument_id=instrument_id,
+                        symbol=symbol,
+                        reason="band_exit",
+                        detail=(
+                            f"close {now_px:g} outside [{bear_value:g}, {bull_value:g}] (minted inside at {mint_px:g})"
+                        ),
+                    )
+                )
                 continue
 
         # Rule 7 (#1988): news storm on a name with a real news baseline.
         # Independent of price evaluability — a stale price series must not
         # mask a news trigger.
         if _news_spike_fired(m7, m30):
-            stale.append(StaleInstrument(instrument_id=instrument_id, symbol=symbol, reason="news_spike"))
+            baseline = (m30 - m7) / _NEWS_BASELINE_DAYS
+            ratio = (m7 / _NEWS_WINDOW_DAYS) / baseline
+            stale.append(
+                StaleInstrument(
+                    instrument_id=instrument_id,
+                    symbol=symbol,
+                    reason="news_spike",
+                    detail=f"7d news mass {m7:.1f} at {ratio:.1f}x 30d baseline",
+                )
+            )
             continue
 
         threshold = latest_thesis_at + timedelta(days=_REVIEW_FREQUENCY_DAYS[review_frequency])

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -285,10 +285,25 @@ def _evaluable_prices(
     return (close_now, close_at_mint)
 
 
+def _price_move_pct(close_now: float, close_at_mint: float) -> float | None:
+    """Signed move since mint when the price_move rule fires, else None.
+
+    Symmetric: a +30% melt-up invalidates a buy-zone as surely as a -30%
+    crash invalidates a bear floor. ``close_at_mint > 0`` is already
+    guaranteed by ``_evaluable_prices`` at the only call site, but the
+    guard is repeated here so the helper is safe standalone and the #2071
+    detail string consumes THIS return value (same single-source shape as
+    ``_news_spike_ratio``; PR #2082 review).
+    """
+    if close_at_mint <= 0:
+        return None
+    pct = (close_now - close_at_mint) / close_at_mint
+    return pct if abs(pct) >= _PRICE_MOVE_THRESHOLD else None
+
+
 def _price_move_fired(close_now: float, close_at_mint: float) -> bool:
-    """|move since mint| >= threshold. Symmetric: a +30% melt-up invalidates
-    a buy-zone as surely as a -30% crash invalidates a bear floor."""
-    return abs(close_now - close_at_mint) / close_at_mint >= _PRICE_MOVE_THRESHOLD
+    """Boolean face of ``_price_move_pct`` (kept for the table tests)."""
+    return _price_move_pct(close_now, close_at_mint) is not None
 
 
 def _band_exit_fired(
@@ -576,14 +591,13 @@ def find_stale_instruments(
         prices = _evaluable_prices(close_now, close_at_mint, close_now_date, now.date())
         if prices is not None:
             now_px, mint_px = prices
-            if _price_move_fired(now_px, mint_px):
-                pct = (now_px - mint_px) / mint_px
+            if (move_pct := _price_move_pct(now_px, mint_px)) is not None:
                 stale.append(
                     StaleInstrument(
                         instrument_id=instrument_id,
                         symbol=symbol,
                         reason="price_move",
-                        detail=f"close {now_px:g} vs {mint_px:g} at mint ({pct:+.0%})",
+                        detail=f"close {now_px:g} vs {mint_px:g} at mint ({move_pct:+.0%})",
                     )
                 )
                 continue

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1315,6 +1315,8 @@ export interface ThesisDetail {
    *  Populated only on the latest-thesis GET; null on history/POST payloads. */
   is_stale?: boolean | null;
   stale_reason?: string | null;
+  /** #2071 — magnitude for data-driven reasons (price_move/band_exit/news_spike). */
+  stale_detail?: string | null;
   /** #2013 — diff vs the version-1 predecessor; null on v1 rows. */
   diff?: ThesisDiff | null;
   /** #2051 — index-aligned machine-checkable predicates; empty when the
@@ -1348,6 +1350,8 @@ export interface ThesisLibraryItem {
   critic_verdict: string | null;
   /** null = fresh, or outside refresh scope (not tradable / not analysable). */
   stale_reason: string | null;
+  /** #2071 — magnitude for data-driven reasons; null otherwise. */
+  stale_detail: string | null;
   is_held: boolean;
   latest_score: number | null;
   latest_rank: number | null;
@@ -1974,6 +1978,7 @@ export interface ThesisStalenessItem {
   instrument_id: number;
   symbol: string;
   reason: string; // find_stale_instruments StaleReason (open string)
+  detail: string | null; // #2071 — magnitude for data-driven reasons
   latest_thesis_at: string | null; // null = held instrument has no thesis at all
 }
 

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -783,8 +783,8 @@ describe("AlertsStrip — thesis staleness", () => {
     stubAll({
       thesisStale: {
         items: [
-          { instrument_id: 1, symbol: "GME", reason: "stale", latest_thesis_at: "2026-06-01T00:00:00Z" },
-          { instrument_id: 2, symbol: "AAPL", reason: "event_new_10k", latest_thesis_at: "2026-06-02T00:00:00Z" },
+          { instrument_id: 1, symbol: "GME", reason: "stale", detail: null, latest_thesis_at: "2026-06-01T00:00:00Z" },
+          { instrument_id: 2, symbol: "AAPL", reason: "event_new_10k", detail: null, latest_thesis_at: "2026-06-02T00:00:00Z" },
         ],
       },
     });
@@ -804,7 +804,7 @@ describe("AlertsStrip — thesis staleness", () => {
       guard: { rejections: [makeGuard()], unseen_count: 1 },
       thesisStale: {
         items: [
-          { instrument_id: 1, symbol: "GME", reason: "stale", latest_thesis_at: null },
+          { instrument_id: 1, symbol: "GME", reason: "stale", detail: null, latest_thesis_at: null },
         ],
       },
     });

--- a/frontend/src/pages/ThesesPage.test.tsx
+++ b/frontend/src/pages/ThesesPage.test.tsx
@@ -31,6 +31,7 @@ function makeItem(overrides: Partial<ThesisLibraryItem> = {}): ThesisLibraryItem
     created_at: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
     critic_verdict: "Weak challenge",
     stale_reason: null,
+    stale_detail: null,
     is_held: true,
     latest_score: 0.61,
     latest_rank: 7,

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -400,7 +400,7 @@ export function ThesesPage(): JSX.Element {
                           : "no thesis yet"}
                         {row.stale_reason !== null ? (
                           <span
-                            title={`Stale: ${row.stale_reason}`}
+                            title={`Stale: ${row.stale_reason}${row.stale_detail ? ` — ${row.stale_detail}` : ""}`}
                             className="ml-1.5 rounded border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40 px-1 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300"
                           >
                             {staleLabel(row.stale_reason)}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,0 +1,1 @@
+{"version":"4.1.8","results":[[":frontend/src/pages/ThesesPage.test.tsx",{"duration":0,"failed":true}],[":frontend/src/components/dashboard/AlertsStrip.test.tsx",{"duration":0,"failed":true}]]}

--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.8","results":[[":frontend/src/pages/ThesesPage.test.tsx",{"duration":0,"failed":true}],[":frontend/src/components/dashboard/AlertsStrip.test.tsx",{"duration":0,"failed":true}]]}

--- a/tests/test_api_alerts.py
+++ b/tests/test_api_alerts.py
@@ -1931,17 +1931,34 @@ def test_thesis_staleness_empty_when_nothing_held(client: TestClient) -> None:
 
 def test_thesis_staleness_reports_stale_held_instrument(client: TestClient) -> None:
     cur = _install_conn()
-    # cursor fetchalls in call order: held ids, then latest-thesis timestamps.
+    # Cursor fetchalls in call order: held ids, then the
+    # find_stale_instruments read (dict_row cursor since #2074 — a
+    # monthly cadence + past thesis timestamp is deterministically
+    # stale), then latest-thesis timestamps. This mock was broken on
+    # main since #1988 (7-tuple vs the 14-column row); the dict shape
+    # fixes it (#2074 fix-in-scope).
     stale_at = datetime(2026, 4, 1, tzinfo=UTC)
     cur.fetchall.side_effect = [
         [{"instrument_id": 5}],
+        [
+            {
+                "instrument_id": 5,
+                "symbol": "GME",
+                "review_frequency": "monthly",
+                "latest_thesis_at": stale_at,
+                "latest_event_created_at": None,
+                "latest_event_filing_type": None,
+                "break_fired": False,
+                "bear_value": None,
+                "bull_value": None,
+                "close_now": None,
+                "close_now_date": None,
+                "close_at_mint": None,
+                "m7": 0,
+                "m30": 0,
+            }
+        ],
         [{"instrument_id": 5, "latest_thesis_at": stale_at}],
-    ]
-    # find_stale_instruments reads via conn.execute(...).fetchall() — a
-    # monthly cadence + past thesis timestamp is deterministically stale.
-    conn = cur._parent_conn
-    conn.execute.return_value.fetchall.return_value = [
-        (5, "GME", "monthly", stale_at, None, None, False),
     ]
     resp = client.get("/alerts/thesis-staleness")
     assert resp.status_code == 200
@@ -1955,9 +1972,8 @@ def test_thesis_staleness_reports_stale_held_instrument(client: TestClient) -> N
 
 def test_thesis_staleness_empty_when_held_theses_fresh(client: TestClient) -> None:
     cur = _install_conn()
-    cur.fetchall.side_effect = [[{"instrument_id": 5}]]
-    conn = cur._parent_conn
-    conn.execute.return_value.fetchall.return_value = []
+    # held ids, then an empty find_stale read (fresh).
+    cur.fetchall.side_effect = [[{"instrument_id": 5}], []]
     resp = client.get("/alerts/thesis-staleness")
     assert resp.status_code == 200
     assert resp.json() == {"items": []}

--- a/tests/test_api_theses.py
+++ b/tests/test_api_theses.py
@@ -426,7 +426,7 @@ class TestGetLatestThesisStaleness:
         # for a v1 row), then the find_stale_instruments read (dict_row
         # cursor since #2074) — monthly cadence + a past created_at is
         # deterministically stale against the real clock.
-        conn = _with_conn(
+        _with_conn(
             [
                 [_make_thesis_row(created_at=_EARLIER)],
                 [],
@@ -443,7 +443,7 @@ class TestGetLatestThesisStaleness:
 
     def test_fresh_thesis_reports_not_stale(self) -> None:
         # find_stale (second cursor read) defaults to the honest-empty set.
-        conn = _with_conn([[_make_thesis_row()]])
+        _with_conn([[_make_thesis_row()]])
         resp = client.get("/theses/100")
         _cleanup()
 
@@ -602,7 +602,7 @@ class TestListTheses:
             critic_json={"verdict": "Moderate challenge"},
             run_status="failed",
         )
-        conn = _with_conn([[], [row], [_stale_query_row(100, "AAPL", "monthly", _EARLIER)]])
+        _with_conn([[], [row], [_stale_query_row(100, "AAPL", "monthly", _EARLIER)]])
         resp = client.get("/theses")
         _cleanup()
 
@@ -639,7 +639,7 @@ class TestListTheses:
             "run_trigger": None,
             "run_started_at": None,
         }
-        conn = _with_conn(
+        _with_conn(
             [
                 [gap_row],
                 [_make_library_row(100, "AAPL")],
@@ -680,7 +680,7 @@ class TestListTheses:
             "run_trigger": None,
             "run_started_at": None,
         }
-        conn = _with_conn([[gap_row], [_make_library_row(100, "AAPL", stance="buy")]])
+        _with_conn([[gap_row], [_make_library_row(100, "AAPL", stance="buy")]])
         resp = client.get("/theses?stance=buy")
         _cleanup()
 
@@ -694,7 +694,7 @@ class TestListTheses:
         assert resp.status_code == 422
 
     def test_empty_library_returns_empty_page(self) -> None:
-        conn = _with_conn([[], []])
+        _with_conn([[], []])
         resp = client.get("/theses")
         _cleanup()
 

--- a/tests/test_api_theses.py
+++ b/tests/test_api_theses.py
@@ -68,6 +68,32 @@ def _make_thesis_row(
     }
 
 
+def _stale_query_row(
+    instrument_id: int,
+    symbol: str,
+    review_frequency: str | None,
+    latest_thesis_at: object,
+) -> dict[str, object]:
+    """One find_stale_instruments dict row (#2074 — keyed by SELECT alias;
+    neutral v2 tail so only the cadence rules evaluate)."""
+    return {
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "review_frequency": review_frequency,
+        "latest_thesis_at": latest_thesis_at,
+        "latest_event_created_at": None,
+        "latest_event_filing_type": None,
+        "break_fired": False,
+        "bear_value": None,
+        "bull_value": None,
+        "close_now": None,
+        "close_now_date": None,
+        "close_at_mint": None,
+        "m7": 0,
+        "m30": 0,
+    }
+
+
 def _mock_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
     """Build a mock psycopg.Connection.
 
@@ -395,13 +421,18 @@ class TestGetThesisHistory:
 class TestGetLatestThesisStaleness:
     def test_stale_thesis_carries_server_verdict(self) -> None:
         """find_stale_instruments (via conn.execute) drives is_stale."""
-        conn = _with_conn([[_make_thesis_row(created_at=_EARLIER)]])
-        # find_stale_instruments reads via conn.execute(...).fetchall() —
-        # monthly cadence + a past created_at is deterministically stale
-        # against the real clock.
-        conn.execute.return_value.fetchall.return_value = [
-            (100, "AAPL", "monthly", _EARLIER, None, None, False),
-        ]
+        # Cursor result sets in execute order: latest-thesis row, the #2051
+        # break-predicates read (the #2013 diff-predecessor read is skipped
+        # for a v1 row), then the find_stale_instruments read (dict_row
+        # cursor since #2074) — monthly cadence + a past created_at is
+        # deterministically stale against the real clock.
+        conn = _with_conn(
+            [
+                [_make_thesis_row(created_at=_EARLIER)],
+                [],
+                [_stale_query_row(100, "AAPL", "monthly", _EARLIER)],
+            ]
+        )
         resp = client.get("/theses/100")
         _cleanup()
 
@@ -411,8 +442,8 @@ class TestGetLatestThesisStaleness:
         assert body["stale_reason"] == "stale"
 
     def test_fresh_thesis_reports_not_stale(self) -> None:
+        # find_stale (second cursor read) defaults to the honest-empty set.
         conn = _with_conn([[_make_thesis_row()]])
-        conn.execute.return_value.fetchall.return_value = []
         resp = client.get("/theses/100")
         _cleanup()
 
@@ -560,7 +591,8 @@ class TestCriticVerdictExtraction:
 
 
 class TestListTheses:
-    # Cursor result sets in execute order: [held-no-thesis rows], [library rows].
+    # Cursor result sets in execute order: [held-no-thesis rows], [library rows],
+    # then the find_stale_instruments read (dict_row cursor, #2074).
 
     def test_returns_enriched_items(self) -> None:
         row = _make_library_row(
@@ -570,10 +602,7 @@ class TestListTheses:
             critic_json={"verdict": "Moderate challenge"},
             run_status="failed",
         )
-        conn = _with_conn([[], [row]])
-        conn.execute.return_value.fetchall.return_value = [
-            (100, "AAPL", "monthly", _EARLIER, None, None, False),
-        ]
+        conn = _with_conn([[], [row], [_stale_query_row(100, "AAPL", "monthly", _EARLIER)]])
         resp = client.get("/theses")
         _cleanup()
 
@@ -610,10 +639,13 @@ class TestListTheses:
             "run_trigger": None,
             "run_started_at": None,
         }
-        conn = _with_conn([[gap_row], [_make_library_row(100, "AAPL")]])
-        conn.execute.return_value.fetchall.return_value = [
-            (200, "GME", None, None, None, None, False),  # no_thesis via find_stale
-        ]
+        conn = _with_conn(
+            [
+                [gap_row],
+                [_make_library_row(100, "AAPL")],
+                [_stale_query_row(200, "GME", None, None)],  # no_thesis via find_stale
+            ]
+        )
         resp = client.get("/theses")
         _cleanup()
 
@@ -649,7 +681,6 @@ class TestListTheses:
             "run_started_at": None,
         }
         conn = _with_conn([[gap_row], [_make_library_row(100, "AAPL", stance="buy")]])
-        conn.execute.return_value.fetchall.return_value = []
         resp = client.get("/theses?stance=buy")
         _cleanup()
 
@@ -664,7 +695,6 @@ class TestListTheses:
 
     def test_empty_library_returns_empty_page(self) -> None:
         conn = _with_conn([[], []])
-        conn.execute.return_value.fetchall.return_value = []
         resp = client.get("/theses")
         _cleanup()
 

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -1484,3 +1484,19 @@ class TestNewsSpikeRatioGuard:
         # m7=7, m30=8.5 (baseline ≈0.065) → ratio ≈15.3 over floor → fires
         ratio = _news_spike_ratio(7.0, 8.5)
         assert ratio is not None and ratio == pytest.approx(15.33, abs=0.01)
+
+
+class TestPriceMovePctGuard:
+    """PR #2082 review round-2 — same single-source shape as news_spike."""
+
+    def test_nonpositive_mint_close_returns_none(self) -> None:
+        from app.services.thesis import _price_move_pct
+
+        assert _price_move_pct(50.0, 0.0) is None
+        assert _price_move_pct(50.0, -1.0) is None
+
+    def test_fired_pct_matches_detail_math(self) -> None:
+        from app.services.thesis import _price_move_pct
+
+        assert _price_move_pct(65.0, 100.0) == pytest.approx(-0.35)
+        assert _price_move_pct(105.0, 100.0) is None  # +5% under threshold

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -1464,3 +1464,23 @@ class TestShapeTaState:
         assert out["sma_50_200_regime"] is None
         assert out["price_vs_sma200"] is None
         assert out["sma_50"] is None
+
+
+class TestNewsSpikeRatioGuard:
+    """PR #2082 review — a spike fully concentrated in the 7d window
+    (m30 == m7 → baseline 0) must not fire and must not divide."""
+
+    def test_concentrated_spike_no_baseline_returns_none(self) -> None:
+        from app.services.thesis import _news_spike_ratio
+
+        assert _news_spike_ratio(10.0, 10.0) is None
+        assert _news_spike_ratio(10.0, 9.0) is None  # negative baseline
+
+    def test_fired_ratio_matches_detail_math(self) -> None:
+        from app.services.thesis import _news_spike_ratio
+
+        # m7=7, m30=30 → baseline 1/day, 7d rate 1/day → ratio 1 < 3 → None
+        assert _news_spike_ratio(7.0, 30.0) is None
+        # m7=7, m30=8.5 (baseline ≈0.065) → ratio ≈15.3 over floor → fires
+        ratio = _news_spike_ratio(7.0, 8.5)
+        assert ratio is not None and ratio == pytest.approx(15.33, abs=0.01)

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -50,11 +50,46 @@ from app.services.thesis import (
 
 _NOW = datetime(2026, 4, 4, 12, 0, 0, tzinfo=UTC)
 
-# #1988 v2 columns appended to the find_stale row: (bear_value, bull_value,
-# close_now, close_now_date, close_at_mint, m7, m30). This neutral tail
-# keeps pre-v2 rule tests exactly as they were: no prices → price rules
-# not evaluated; zero news mass → news_spike not evaluated.
-_V2_TAIL = (None, None, None, None, None, 0, 0)
+
+def _stale_row(
+    instrument_id: int = 1,
+    symbol: str = "AAPL",
+    review_frequency: str | None = "weekly",
+    latest_thesis_at: datetime | None = None,
+    latest_event_created_at: datetime | None = None,
+    latest_event_filing_type: str | None = None,
+    break_fired: bool = False,
+    bear_value: float | None = None,
+    bull_value: float | None = None,
+    close_now: float | None = None,
+    close_now_date: date | None = None,
+    close_at_mint: float | None = None,
+    m7: float = 0,
+    m30: float = 0,
+) -> dict[str, object]:
+    """One find_stale row keyed by its SELECT aliases (#2074).
+
+    A column addition touches THIS factory only — never the test call
+    sites (the #1988 positional-tail churn class). Defaults are the
+    neutral v2 tail: no prices -> price rules not evaluated; zero news
+    mass -> news_spike not evaluated."""
+    return {
+        "instrument_id": instrument_id,
+        "symbol": symbol,
+        "review_frequency": review_frequency,
+        "latest_thesis_at": latest_thesis_at,
+        "latest_event_created_at": latest_event_created_at,
+        "latest_event_filing_type": latest_event_filing_type,
+        "break_fired": break_fired,
+        "bear_value": bear_value,
+        "bull_value": bull_value,
+        "close_now": close_now,
+        "close_now_date": close_now_date,
+        "close_at_mint": close_at_mint,
+        "m7": m7,
+        "m30": m30,
+    }
+
 
 _VALID_WRITER = {
     "thesis_type": "compounder",
@@ -81,7 +116,7 @@ _VALID_CRITIC = {
 
 def _make_conn(
     *,
-    stale_rows: list[tuple] | None = None,
+    stale_rows: list[dict[str, object]] | None = None,
     insert_returns_version: int = 1,
     insert_returns_thesis_id: int = 901,
     inst_row: tuple | None = None,
@@ -148,6 +183,26 @@ def _make_conn(
         return cursor
 
     conn.execute.side_effect = execute_side_effect
+
+    # #2074 — find_stale_instruments reads through
+    # conn.cursor(row_factory=dict_row); route the cursor's execute into
+    # the same dispatch so both access styles share one mock brain.
+    def cursor_factory(*_args: object, **_kwargs: object) -> MagicMock:
+        cm = MagicMock()
+        cur = MagicMock()
+
+        def cursor_execute(sql, params=None):  # type: ignore[no-untyped-def]
+            result = execute_side_effect(sql, params)
+            cur.fetchall = result.fetchall
+            cur.fetchone = result.fetchone
+            return cur
+
+        cur.execute.side_effect = cursor_execute
+        cm.__enter__ = MagicMock(return_value=cur)
+        cm.__exit__ = MagicMock(return_value=False)
+        return cm
+
+    conn.cursor.side_effect = cursor_factory
     conn.transaction.return_value.__enter__ = MagicMock(return_value=None)
     conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
     return conn
@@ -223,7 +278,7 @@ class TestFindStaleInstruments:
         #  latest_event_filing_date, latest_event_filing_type, break_fired,
         #  bear_value, bull_value, close_now, close_now_date, close_at_mint,
         #  m7, m30)
-        rows = [(1, "AAPL", "weekly", None, None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency="weekly", latest_thesis_at=None)]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
@@ -231,14 +286,14 @@ class TestFindStaleInstruments:
         assert result[0].symbol == "AAPL"
 
     def test_unknown_frequency_is_stale(self) -> None:
-        rows = [(1, "AAPL", "biannual", _NOW - timedelta(days=1), None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency="biannual", latest_thesis_at=_NOW - timedelta(days=1))]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
         assert result[0].reason == "missing_frequency"
 
     def test_null_frequency_is_stale(self) -> None:
-        rows = [(1, "AAPL", None, _NOW - timedelta(days=1), None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency=None, latest_thesis_at=_NOW - timedelta(days=1))]
         conn = _make_conn(stale_rows=rows)
         result = find_stale_instruments(conn, tier=1)
         assert len(result) == 1
@@ -246,7 +301,7 @@ class TestFindStaleInstruments:
 
     def test_past_weekly_threshold_is_stale(self) -> None:
         # thesis created 8 days ago, weekly frequency → stale
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=8), None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency="weekly", latest_thesis_at=_NOW - timedelta(days=8))]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -255,7 +310,7 @@ class TestFindStaleInstruments:
 
     def test_within_weekly_threshold_is_fresh(self) -> None:
         # thesis created 3 days ago, weekly frequency → fresh
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency="weekly", latest_thesis_at=_NOW - timedelta(days=3))]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -263,7 +318,7 @@ class TestFindStaleInstruments:
 
     def test_daily_threshold(self) -> None:
         # thesis created 25 hours ago, daily frequency → stale
-        rows = [(1, "MSFT", "daily", _NOW - timedelta(hours=25), None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(symbol="MSFT", review_frequency="daily", latest_thesis_at=_NOW - timedelta(hours=25))]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -272,7 +327,7 @@ class TestFindStaleInstruments:
 
     def test_monthly_threshold(self) -> None:
         # thesis created 31 days ago, monthly frequency → stale
-        rows = [(1, "TSLA", "monthly", _NOW - timedelta(days=31), None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(symbol="TSLA", review_frequency="monthly", latest_thesis_at=_NOW - timedelta(days=31))]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -280,9 +335,11 @@ class TestFindStaleInstruments:
 
     def test_multiple_instruments_mixed(self) -> None:
         rows = [
-            (1, "AAPL", "weekly", _NOW - timedelta(days=3), None, None, False, *_V2_TAIL),  # fresh
-            (2, "MSFT", "weekly", _NOW - timedelta(days=8), None, None, False, *_V2_TAIL),  # stale
-            (3, "GOOG", "weekly", None, None, None, False, *_V2_TAIL),  # no thesis
+            _stale_row(review_frequency="weekly", latest_thesis_at=_NOW - timedelta(days=3)),  # fresh
+            _stale_row(
+                instrument_id=2, symbol="MSFT", review_frequency="weekly", latest_thesis_at=_NOW - timedelta(days=8)
+            ),  # stale
+            _stale_row(instrument_id=3, symbol="GOOG", review_frequency="weekly", latest_thesis_at=None),  # no thesis
         ]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
@@ -294,7 +351,7 @@ class TestFindStaleInstruments:
 
     def test_exactly_at_threshold_is_stale(self) -> None:
         # now == created_at + 7 days exactly → stale (>= boundary)
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=7), None, None, False, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency="weekly", latest_thesis_at=_NOW - timedelta(days=7))]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -303,7 +360,7 @@ class TestFindStaleInstruments:
 
     def test_break_fired_on_fresh_thesis(self) -> None:
         # #2012 rule 5: fresh thesis + a break event for the LATEST thesis.
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=1), None, None, True, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency="weekly", latest_thesis_at=_NOW - timedelta(days=1), break_fired=True)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -313,7 +370,7 @@ class TestFindStaleInstruments:
     def test_break_beats_cadence_stale(self) -> None:
         # Aged past cadence AND break fired → the specific reason wins
         # (Codex ckpt-2: break must not be shadowed by mere age).
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=30), None, None, True, *_V2_TAIL)]
+        rows = [_stale_row(review_frequency="weekly", latest_thesis_at=_NOW - timedelta(days=30), break_fired=True)]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -323,7 +380,15 @@ class TestFindStaleInstruments:
     def test_break_never_masks_filing_event(self) -> None:
         # Rule ordering: a new 10-K and a fired break both present → the
         # filing-event reason wins (spec: break ordered AFTER event rules).
-        rows = [(1, "AAPL", "weekly", _NOW - timedelta(days=1), _NOW, "10-K", True, *_V2_TAIL)]
+        rows = [
+            _stale_row(
+                review_frequency="weekly",
+                latest_thesis_at=_NOW - timedelta(days=1),
+                latest_event_created_at=_NOW,
+                latest_event_filing_type="10-K",
+                break_fired=True,
+            )
+        ]
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             result = find_stale_instruments(conn, tier=1)
@@ -444,27 +509,24 @@ class TestFindStaleInstrumentsV2Rules:
         event_at: datetime | None = None,
         event_form: str | None = None,
         break_fired: bool = False,
-    ) -> list[tuple[object, ...]]:
+    ) -> list[dict[str, object]]:
         return [
-            (
-                1,
-                "AAPL",
-                "weekly",
-                _NOW - timedelta(days=created_days_ago),
-                event_at,
-                event_form,
-                break_fired,
-                bear,
-                bull,
-                close_now,
-                (_NOW - timedelta(days=close_age_days)).date() if close_now is not None else None,
-                close_at_mint,
-                m7,
-                m30,
+            _stale_row(
+                latest_thesis_at=_NOW - timedelta(days=created_days_ago),
+                latest_event_created_at=event_at,
+                latest_event_filing_type=event_form,
+                break_fired=break_fired,
+                bear_value=bear,
+                bull_value=bull,
+                close_now=close_now,
+                close_now_date=(_NOW - timedelta(days=close_age_days)).date() if close_now is not None else None,
+                close_at_mint=close_at_mint,
+                m7=m7,
+                m30=m30,
             )
         ]
 
-    def _run(self, rows: list[tuple[object, ...]]) -> list[StaleInstrument]:
+    def _run(self, rows: list[dict[str, object]]) -> list[StaleInstrument]:
         conn = _make_conn(stale_rows=rows)
         with patch("app.services.thesis._utcnow", return_value=_NOW):
             return find_stale_instruments(conn, tier=1)


### PR DESCRIPTION
## What (two bundled retrospective tickets — #2074 says "bundle with the next find_stale-touching ticket"; #2071 is it)

**#2071 — detail strings.** `StaleInstrument.detail: str | None = None`, populated for the data-driven v2 reasons with the formats FIXED in `docs/specs/thesis/2026-07-16-thesis-staleness-v2.md`:
- `price_move` → `close {now} vs {mint} at mint ({pct:+.0%})`
- `band_exit` → `close {now} outside [{bear}, {bull}] (minted inside at {mint})`
- `news_spike` → `7d news mass {m7:.1f} at {ratio:.1f}x 30d baseline`

Surfaced on ALL sibling models carrying stale_reason (#1955 sibling-completeness rule): `/alerts/thesis-staleness` `item.detail`, `ThesisDetail.stale_detail`, `ThesisLibraryItem.stale_detail`, FE types + ThesesPage stale-badge tooltip.

Conscious scope cut: the ticket's "thesis_runs trigger detail" needs a migration (`trigger` is CHECK-constrained manual/cascade/scheduled; regen path never threads reasons) — outside the ticket's own "additive, no behaviour change" envelope. Noted on the issue for a follow-up if regen-audit demand materialises.

**#2074 — dict_row refactor.** `find_stale_instruments` reads via a `dict_row` cursor keyed by the SELECT aliases; the 14 positional test call sites become `_stale_row(**overrides)` factory calls — column additions now touch ONE factory (the #1988 `_V2_TAIL` + mock-rekey churn class ends). Behaviour-preserving; the existing test suite pins it.

**Fix-in-scope:** `test_api_alerts.py::test_thesis_staleness_reports_stale_held_instrument` was broken on main since #1988 (7-tuple mock into a 14-column unpack — same broken-on-main class as #2051's find). Dict rows fix it.

## Security model

No new inputs/endpoints; additive response fields on already-authed routes; parameterised SQL unchanged.

## Verification

- Backend: test_thesis.py, test_api_theses.py, test_api_alerts.py, db-tier test_theses_library_db.py + test_thesis_refresh_candidates.py (`-n 0`) — exit 0.
- FE: `pnpm typecheck` 0; `test:unit` 1361 passed (fixtures updated for new fields).
- ruff + format + pyright clean; fast tier 0; smoke `-n 0` 0.
- Codex ckpt-2: no findings (spec-format match, band_exit narrowing behaviour-preserving, mock wiring correct, sibling completeness confirmed; independently ran backend + FE suites).
- FE-QA: tooltip-only change; dev has zero data-driven fires today (detail null → render identical); post-merge eyeball of /theses with the merge.

Closes #2071
Closes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)