### PR TITLE
feat(#2072): standing threshold-calibration audit classes — fire-rate + v5 census telemetry in thesis_dq_audit

### DIFF
--- a/app/services/thesis_dq_audit.py
+++ b/app/services/thesis_dq_audit.py
@@ -30,7 +30,9 @@ import psycopg.rows
 
 # Same coercion chokepoint as the #2007 insert-time guard — NaN/±inf → None
 # so a garbage target drops out of comparisons instead of defeating them.
-from app.services.thesis import _to_float
+# find_stale_instruments: the canonical staleness predicate (#1902 single
+# source), consumed by the #2072 fire-rate telemetry.
+from app.services.thesis import _to_float, find_stale_instruments
 
 # Findings payload cap — bounds the endpoint response on a large population
 # (mirrors compute_cik_gap_report's bounded per-row payload).
@@ -88,8 +90,52 @@ class ThesisDqFinding:
 
 # Info-only classes: counted, never emitted as findings rows.
 _INFO_CLASSES: frozenset[str] = frozenset(
-    {"target_abstention", "zoneless_buy_no_anchor", "no_run", "no_context_summary"}
+    {
+        "target_abstention",
+        "zoneless_buy_no_anchor",
+        "no_run",
+        "no_context_summary",
+        # #2072 — standing-telemetry counters (visibility, not defects).
+        "fire_rate_price_move",
+        "fire_rate_band_exit",
+        "fire_rate_news_spike",
+        "v5_total",
+        "v5_abstention",
+        "v5_zoneless_buy",
+        "v5_of_float",
+        "v5_predicates",
+        "v5_premise_true",
+    }
 )
+
+# #2072 — staleness-trigger calibration band, 2-8%/month (thesis-staleness
+# v2 spec acceptance gate; #2063 is the dated re-verification this audit
+# automates). The nightly count of STANDING fires is the proxy for the
+# monthly rate: firing regenerates the thesis (self-rearming) and the
+# hourly refresh drains fires at <=5/hr, so a standing count that stays
+# outside the band IS the miscalibration signal the spec describes.
+_FIRE_RATE_BAND: tuple[float, float] = (0.02, 0.08)
+_FIRE_RATE_REASONS: tuple[str, ...] = ("price_move", "band_exit", "news_spike")
+
+
+def check_fire_rate(reason: str, fires: int, population: int) -> str | None:
+    """Above-band detail string, or None (#2072).
+
+    Only the ABOVE direction flags: a standing count over the band's top
+    is a regen storm forming regardless of drain speed — the pre-backfill
+    hazard this audit exists for. Below-band is silent: the hourly
+    refresh drains fires at <=5/hr, so a small standing count is the
+    HEALTHY steady state and cannot distinguish 'calibrated + drained'
+    from 'threshold too tight' — #2063's dated re-check (trailing 30d)
+    owns the under-firing judgement.
+    """
+    if population <= 0:
+        return None
+    rate = fires / population
+    lo, hi = _FIRE_RATE_BAND
+    if rate <= hi:
+        return None
+    return f"{reason} standing fire rate {rate:.1%} ({fires}/{population}) above the {lo:.0%}-{hi:.0%}/month band"
 
 
 @dataclass(frozen=True)
@@ -261,6 +307,36 @@ ORDER BY l.instrument_id
 """
 
 
+# #2072 — v5 prompt-health census over the latest v5 thesis per instrument
+# (same latest-row tiebreak as everywhere; 'of float' substring = the
+# #2010 authoring-contract violation the census watches for).
+_V5_CENSUS_SQL = """
+WITH v5 AS (
+    SELECT DISTINCT ON (instrument_id) *
+    FROM theses
+    WHERE prompt_version = 'v5'
+    ORDER BY instrument_id, created_at DESC, thesis_version DESC, thesis_id DESC
+)
+SELECT count(*) AS total,
+       count(*) FILTER (WHERE bear_value IS NULL AND base_value IS NULL AND bull_value IS NULL) AS abstention,
+       count(*) FILTER (WHERE stance = 'buy' AND buy_zone_low IS NULL AND buy_zone_high IS NULL) AS zoneless_buy,
+       count(*) FILTER (WHERE break_conditions_json::text ILIKE '%of float%') AS of_float
+FROM v5
+"""
+
+_V5_PREDICATES_SQL = """
+SELECT count(*) AS preds,
+       count(*) FILTER (WHERE p.baseline_state IN ('already_true', 'already_true_after_gap')) AS premise_true
+FROM thesis_break_predicates p
+JOIN (
+    SELECT DISTINCT ON (instrument_id) thesis_id
+    FROM theses
+    WHERE prompt_version = 'v5'
+    ORDER BY instrument_id, created_at DESC, thesis_version DESC, thesis_id DESC
+) v ON v.thesis_id = p.thesis_id
+"""
+
+
 def compute_thesis_dq_report(conn: psycopg.Connection[Any]) -> ThesisDqReport:
     """Full-population scan of the latest thesis per instrument.
 
@@ -335,6 +411,47 @@ def compute_thesis_dq_report(conn: psycopg.Connection[Any]) -> ThesisDqReport:
         memo = row["memo_markdown"] or ""
         for block in claim_lint(memo, blocks):
             add(row, "claim_lint", "candidate", f"memo claims '{block}' unavailable; run summary says available")
+
+    # --- #2072 — standing threshold-calibration telemetry -----------------
+    # (1) v2 staleness-trigger fire rates vs the 2-8%/month band. Uses the
+    # canonical predicate directly (single source, #1902); population =
+    # latest-thesis count scanned above. Out-of-band emits a POPULATION-
+    # level flag finding (instrument_id 0 — not a per-row defect).
+    fires: dict[str, int] = {}
+    for hit in find_stale_instruments(conn, tier=None):
+        fires[hit.reason] = fires.get(hit.reason, 0) + 1
+    for reason in _FIRE_RATE_REASONS:
+        n = fires.get(reason, 0)
+        counts[f"fire_rate_{reason}"] = n
+        if detail := check_fire_rate(reason, n, scanned):
+            counts["fire_rate_out_of_band"] = counts.get("fire_rate_out_of_band", 0) + 1
+            findings.append(
+                ThesisDqFinding(
+                    instrument_id=0,
+                    symbol="POPULATION",
+                    thesis_id=0,
+                    dq_class="fire_rate_out_of_band",
+                    severity="flag",
+                    detail=detail,
+                )
+            )
+
+    # (2) v5 prompt-health census (of-float / premise-true / abstention /
+    # zoneless-buy over the latest prompt_version='v5' thesis per
+    # instrument) — the one-shot #2010 census checks as standing counters.
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_V5_CENSUS_SQL)
+        census = cur.fetchone()
+        cur.execute(_V5_PREDICATES_SQL)
+        preds = cur.fetchone()
+    if census is not None:
+        counts["v5_total"] = int(census["total"])
+        counts["v5_abstention"] = int(census["abstention"])
+        counts["v5_zoneless_buy"] = int(census["zoneless_buy"])
+        counts["v5_of_float"] = int(census["of_float"])
+    if preds is not None:
+        counts["v5_predicates"] = int(preds["preds"])
+        counts["v5_premise_true"] = int(preds["premise_true"])
 
     return ThesisDqReport(
         scanned=scanned,

--- a/app/services/thesis_dq_audit.py
+++ b/app/services/thesis_dq_audit.py
@@ -417,6 +417,12 @@ def compute_thesis_dq_report(conn: psycopg.Connection[Any]) -> ThesisDqReport:
     # canonical predicate directly (single source, #1902); population =
     # latest-thesis count scanned above. Out-of-band emits a POPULATION-
     # level flag finding (instrument_id 0 — not a per-row defect).
+    # Denominator note (PR #2083 review): `scanned` counts latest theses
+    # while find_stale evaluates the coverage population — the two are
+    # assumed aligned for the v2 reasons, which is safe because
+    # price_move/band_exit/news_spike can only fire on an instrument
+    # whose latest thesis exists (mint-anchored predicates), i.e. the
+    # numerator is a subset of the denominator by construction.
     fires: dict[str, int] = {}
     for hit in find_stale_instruments(conn, tier=None):
         fires[hit.reason] = fires.get(hit.reason, 0) + 1

--- a/tests/test_thesis_dq_audit.py
+++ b/tests/test_thesis_dq_audit.py
@@ -224,3 +224,38 @@ class TestComputeReportRealQuery:
         assert "base_far_from_close" in by_class
         # v1 (clean, ordered) row was NOT scanned — latest-per-instrument only.
         assert report.class_counts["ordering"] == 1
+
+
+class TestCheckFireRate:
+    """#2072 — standing fire-rate band check (2-8%/month proxy)."""
+
+    def test_in_band_none(self) -> None:
+        from app.services.thesis_dq_audit import check_fire_rate
+
+        assert check_fire_rate("price_move", 5, 100) is None  # 5%
+
+    def test_above_band_flags(self) -> None:
+        from app.services.thesis_dq_audit import check_fire_rate
+
+        detail = check_fire_rate("price_move", 12, 100)
+        assert detail is not None and "above" in detail and "12.0%" in detail
+
+    def test_below_band_is_silent(self) -> None:
+        """A small standing count is the healthy drained steady state —
+        it cannot distinguish 'calibrated' from 'too tight'; #2063's
+        dated trailing-30d re-check owns the under-firing judgement."""
+        from app.services.thesis_dq_audit import check_fire_rate
+
+        assert check_fire_rate("band_exit", 1, 100) is None
+        assert check_fire_rate("news_spike", 0, 100) is None
+
+    def test_empty_population_none(self) -> None:
+        from app.services.thesis_dq_audit import check_fire_rate
+
+        assert check_fire_rate("price_move", 3, 0) is None
+
+    def test_band_edges_inclusive(self) -> None:
+        from app.services.thesis_dq_audit import check_fire_rate
+
+        assert check_fire_rate("price_move", 2, 100) is None  # 2% lower edge
+        assert check_fire_rate("price_move", 8, 100) is None  # 8% upper edge


### PR DESCRIPTION
## What

#2063 (price_move 30d fire-rate re-check, due ~08-16) and the pre-backfill v5 census were remember-to-do calendar items in a system that already runs a nightly full-pop DQ audit. This turns both into standing telemetry riding the existing #2014 chassis:

1. **Fire-rate classes** — per v2 staleness reason (price_move/band_exit/news_spike), standing fire counts from the canonical `find_stale_instruments` (single source, #1902) land as INFO counters (`fire_rate_<reason>`); a rate above the spec's 2-8%/month band top emits a POPULATION-level `fire_rate_out_of_band` flag finding (instrument_id 0, symbol `POPULATION` — a population property, not a per-row defect). **Below-band is silent by design**: the hourly refresh drains fires ≤5/hr, so a small standing count is the healthy steady state and cannot distinguish "calibrated" from "too tight" — #2063 stays open as the dated trailing-30d re-verification that owns the under-firing judgement (first implementation flagged 1/412 news_spike = perpetual noise; reworked before push).
2. **v5 prompt-health census counters** — `v5_total/abstention/zoneless_buy/of_float/predicates/premise_true` over the latest `prompt_version='v5'` thesis per instrument (`of_float` = the #2010 authoring-contract violation; `premise_true` from `thesis_break_predicates.baseline_state` per sql/230).

No new scheduler entry — rides the existing 05:12 `thesis_dq_audit` job + `GET /theses/dq-audit`. New counter keys are in `_INFO_CLASSES` so `total_violations`/`truncated` math is unchanged for them; only `fire_rate_out_of_band` counts as a violation.

## Security model

Read-only additions to an authed endpoint's compute; static SQL; no new inputs.

## Verification

- Pure table tests: `TestCheckFireRate` (in-band, above-band flags with rate string, below-band + zero silent, empty population, inclusive band edges).
- Full-pop dev run: scanned 412; counters `fire_rate_news_spike=1, price_move=0, band_exit=0`, `v5_* = 0` (v5 rows pending scheduled mints), POPULATION findings empty (healthy = silent — exactly the designed steady state).
- ruff + format + pyright clean; fast tier exit 0; smoke `-n 0` exit 0; db-tier `tests/test_thesis_dq_audit.py -n 0` exit 0.
- Codex ckpt-2: no blocking findings — no import cycle (dq_audit→thesis direction already existed), endpoint model serializes the synthetic ints, baseline_state values match sql/230, INFO-class math confirmed; perf note acknowledged (one additional canonical staleness scan per nightly run).
- ⚠ Operator note: enhanced audit output goes live in the nightly job on the next jobs-task restart (daemon holds old code); `GET /theses/dq-audit` computes on read and is live at merge.

Refs #2063
Closes #2072

🤖 Generated with [Claude Code](https://claude.com/claude-code)