### PR TITLE
fix(#2086): decouple Item-402 exec comp from Item-403 ownership tombstone

### DIFF
--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -73,7 +73,10 @@ from app.services.sec_identity import siblings_for_issuer_cik
 # SCT-bearing bodies rewash + backfill comp automatically (no separate
 # backfill script). ``rewash_filings`` imports THIS literal for its ParserSpec
 # current_version so the two can't drift.
-_PARSER_VERSION_DEF14A = "def14a-v2"
+# v3 (#2086): Item 402 exec comp now runs on the ownership-tombstone path
+# too — the tombstoned-with-stored-raw cohort must rewash to pick up SCTs
+# the 402↔403 coupling previously skipped (GME class).
+_PARSER_VERSION_DEF14A = "def14a-v3"
 
 logger = logging.getLogger(__name__)
 

--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -333,21 +333,41 @@ def _parse_def14a(
         # Compensation Table. Comp stays a savepoint-isolated
         # best-effort augment that never changes this ParseOutcome —
         # the row still tombstones for Item 403 accounting.
+        # Belt-and-braces try around the whole comp attempt: the callee
+        # already savepoint-isolates and swallows parse/upsert failures,
+        # but the tombstone ingest-log write below MUST happen regardless
+        # — comp can never be allowed to block the Item-403 accounting
+        # it was just decoupled from (review round 1). Failures are
+        # logged with traceback, never silent.
         try:
-            comp_siblings = _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik)
-        except Exception:  # noqa: BLE001 — best-effort: fall back to the primary
+            try:
+                comp_siblings = _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik)
+            except Exception:  # noqa: BLE001 — logged fallback to the primary instrument
+                logger.exception(
+                    "def14a manifest parser: sibling resolve failed pre-comp accession=%s",
+                    accession,
+                )
+                comp_siblings = [instrument_id]
+            apply_exec_comp_best_effort(
+                conn,
+                accession_number=accession,
+                issuer_cik=issuer_cik,
+                body=body,
+                instrument_ids=comp_siblings,
+            )
+        except Exception:  # noqa: BLE001 — comp is an augment; tombstone accounting proceeds
             logger.exception(
-                "def14a manifest parser: sibling resolve failed pre-comp accession=%s",
+                "def14a manifest parser: exec-comp augment raised on tombstone path accession=%s",
                 accession,
             )
-            comp_siblings = [instrument_id]
-        apply_exec_comp_best_effort(
-            conn,
-            accession_number=accession,
-            issuer_cik=issuer_cik,
-            body=body,
-            instrument_ids=comp_siblings,
-        )
+            try:
+                conn.rollback()
+            except psycopg.Error:
+                logger.debug(
+                    "def14a manifest parser: rollback suppressed after comp failure accession=%s",
+                    accession,
+                    exc_info=True,
+                )
         try:
             with conn.transaction():
                 _record_ingest_attempt(

--- a/app/services/manifest_parsers/def14a.py
+++ b/app/services/manifest_parsers/def14a.py
@@ -324,6 +324,30 @@ def _parse_def14a(
         # tombstoned. Write the log row with status='partial' to
         # mirror legacy accounting so /coverage/def14a counts a
         # consistent figure.
+        #
+        # #2086 — Item 402(c) exec comp runs HERE too, before the
+        # tombstone return. Reg S-K Items 402 and 403 are independent
+        # items of Schedule 14A: a proxy whose beneficial-ownership
+        # table defeats the detector (GME: best_score 0-9 across all
+        # proxies) can still carry a perfectly standard Summary
+        # Compensation Table. Comp stays a savepoint-isolated
+        # best-effort augment that never changes this ParseOutcome —
+        # the row still tombstones for Item 403 accounting.
+        try:
+            comp_siblings = _resolve_siblings(conn, instrument_id=instrument_id, issuer_cik=issuer_cik)
+        except Exception:  # noqa: BLE001 — best-effort: fall back to the primary
+            logger.exception(
+                "def14a manifest parser: sibling resolve failed pre-comp accession=%s",
+                accession,
+            )
+            comp_siblings = [instrument_id]
+        apply_exec_comp_best_effort(
+            conn,
+            accession_number=accession,
+            issuer_cik=issuer_cik,
+            body=body,
+            instrument_ids=comp_siblings,
+        )
         try:
             with conn.transaction():
                 _record_ingest_attempt(

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -595,11 +595,21 @@ def _apply_def14a(
                 f"{raw_doc.accession_number} (best_score={parsed.raw_table_score}); "
                 f"previous parser found rows"
             )
-        # Rescue cohort with still-empty parse. Don't raise —
-        # parser hasn't improved enough yet. Skip without bumping
-        # parser_version so a future sweep with a better parser
-        # re-tries.
-        return False
+        # Rescue cohort with still-empty ownership parse. #2086: Item
+        # 402 is independent of Item 403 — attempt the exec-comp
+        # rewash BEFORE deciding the outcome (this is exactly the
+        # tombstoned-with-SCT cohort the v3 bump exists to backfill;
+        # Codex ckpt-2 P2). Comp written → the accession has been
+        # meaningfully rewashed at v3 → True (bumps parser_version).
+        # No comp either → keep the pre-existing rescue semantics:
+        # skip without bumping so a future improved parser re-tries.
+        comp_written = _rewash_exec_comp(
+            conn,
+            raw_doc=raw_doc,
+            issuer_cik=str(issuer_cik),
+            instrument_id=int(instrument_id),
+        )
+        return comp_written > 0
 
     # Replace-then-insert: clear all existing holders for the
     # accession so a holder dropped by the new parser cannot
@@ -637,35 +647,58 @@ def _apply_def14a(
     )
     refresh_def14a_current(conn, instrument_id=int(instrument_id))
 
-    # Item 402(c) exec-comp rewash (#1945). Replace-then-insert for THIS
-    # instrument (scoped, unlike the holdings DELETE which clears by accession —
-    # comp is written per resolved instrument so we never nuke a sibling's comp
-    # rows). The whole comp block runs in its OWN SAVEPOINT so that an
-    # UNEXPECTED comp parse/upsert failure rolls back comp only and cannot
-    # collateral-damage the already-applied Item 403 holdings rewash (#1700
-    # per-section isolation). The INTENTIONAL regression signal — a re-parse
-    # that yields zero comp rows for an accession that PREVIOUSLY had them — is
-    # deliberately re-raised as RewashParseError, mirroring the holdings
-    # contract, so the accession fails + retries instead of silently zeroing
-    # typed rows. (Comp absence on an accession that never had comp is expected
-    # — many bodies carry no SCT — so the first-time v1→v2 backfill never
-    # raises.)
-    # Function-local imports match this file's convention for the def14a
-    # parser/upsert helpers (see the Item 403 holdings path at the
-    # parse_beneficial_ownership_table / _upsert_holding imports above): the
-    # heavy sec_def14a + def14a_ingest modules are pulled in only when a
-    # def14a_body actually reaches rewash, keeping this module's import graph
-    # light. _PARSER_VERSION_DEF14A stays module-level because register_parser
-    # consumes it at import time.
+    # Item 402(c) exec-comp rewash (#1945; helper shared with the
+    # rescue-cohort branch above since #2086).
+    _rewash_exec_comp(
+        conn,
+        raw_doc=raw_doc,
+        issuer_cik=str(issuer_cik),
+        instrument_id=int(instrument_id),
+    )
+    return True
+
+
+def _rewash_exec_comp(
+    conn: psycopg.Connection[Any],
+    *,
+    raw_doc: RawFilingDocument,
+    issuer_cik: str,
+    instrument_id: int,
+) -> int:
+    """Item 402(c) exec-comp rewash (#1945, extracted for #2086).
+
+    Replace-then-insert for THIS instrument (scoped, unlike the holdings
+    DELETE which clears by accession — comp is written per resolved
+    instrument so we never nuke a sibling's comp rows). The whole comp
+    block runs in its OWN SAVEPOINT so that an UNEXPECTED comp
+    parse/upsert failure rolls back comp only and cannot
+    collateral-damage an already-applied Item 403 holdings rewash (#1700
+    per-section isolation). The INTENTIONAL regression signal — a
+    re-parse that yields zero comp rows for an accession that PREVIOUSLY
+    had them — is deliberately re-raised as RewashParseError, mirroring
+    the holdings contract, so the accession fails + retries instead of
+    silently zeroing typed rows. (Comp absence on an accession that
+    never had comp is expected — many bodies carry no SCT.)
+
+    Returns the number of comp rows written (0 on absence or on a
+    swallowed unexpected failure).
+
+    Function-local imports match this file's convention for the def14a
+    parser/upsert helpers: the heavy sec_def14a + def14a_ingest modules
+    are pulled in only when a def14a_body actually reaches rewash.
+    _PARSER_VERSION_DEF14A stays module-level because register_parser
+    consumes it at import time.
+    """
     from app.providers.implementations.sec_def14a import parse_summary_compensation_table
     from app.services.def14a_ingest import _upsert_comp
 
+    written = 0
     try:
         with conn.transaction():
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT 1 FROM def14a_exec_compensation WHERE accession_number = %s AND instrument_id = %s LIMIT 1",
-                    (raw_doc.accession_number, int(instrument_id)),
+                    (raw_doc.accession_number, instrument_id),
                 )
                 had_comp_rows = cur.fetchone() is not None
 
@@ -684,16 +717,17 @@ def _apply_def14a(
             with conn.cursor() as cur:
                 cur.execute(
                     "DELETE FROM def14a_exec_compensation WHERE accession_number = %s AND instrument_id = %s",
-                    (raw_doc.accession_number, int(instrument_id)),
+                    (raw_doc.accession_number, instrument_id),
                 )
             for comp_row in comp.rows:
                 _upsert_comp(
                     conn,
                     accession_number=raw_doc.accession_number,
-                    issuer_cik=str(issuer_cik),
-                    instrument_id=int(instrument_id),
+                    issuer_cik=issuer_cik,
+                    instrument_id=instrument_id,
                     row=comp_row,
                 )
+                written += 1
     except RewashParseError:
         # Intentional regression — propagate to fail + retry this accession
         # (the savepoint has already rolled comp back).
@@ -703,7 +737,8 @@ def _apply_def14a(
             "def14a rewash: exec-comp augment failed accession=%s (holdings rewash preserved)",
             raw_doc.accession_number,
         )
-    return True
+        return 0
+    return written
 
 
 register_parser(

--- a/tests/test_def14a_ingest.py
+++ b/tests/test_def14a_ingest.py
@@ -357,7 +357,7 @@ class TestIngestDef14a:
             document_kind="def14a_body",
         )
         assert doc is not None
-        assert doc.parser_version == "def14a-v2"
+        assert doc.parser_version == "def14a-v3"  # bumped by #2086 (402/403 decouple)
         assert doc.source_url == url
         assert len(doc.require_payload()) > 0
 

--- a/tests/test_manifest_parser_def14a.py
+++ b/tests/test_manifest_parser_def14a.py
@@ -26,6 +26,7 @@ without touching SEC.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from textwrap import dedent
 
 import psycopg
@@ -141,6 +142,31 @@ _NOTICE_ONLY_DEF14A_HTML = dedent("""
 """)
 
 
+# #2086 — a proxy whose ownership table defeats the detector but which
+# carries a standard Summary Compensation Table (the GME class). The
+# ownership parse yields rows == [] (tombstone path); Item 402 must
+# still extract.
+_NO_OWNERSHIP_WITH_SCT_HTML = dedent("""
+<!DOCTYPE html>
+<html><body>
+<h2>Notice of Annual Meeting</h2>
+<p>The annual meeting will ratify the auditor. No governance changes.</p>
+<h2>Summary Compensation Table</h2>
+<table>
+  <tr>
+    <td>Name and Principal Position</td><td>Year</td><td>Salary ($)</td>
+    <td>Stock Awards ($)</td><td>Non-Equity Incentive Plan Compensation ($)</td>
+    <td>All Other Compensation ($)</td><td>Total ($)</td>
+  </tr>
+  <tr>
+    <td>Jane Roe\nChief Executive Officer</td><td>2025</td><td>1,000,000</td>
+    <td>5,000,000</td><td>2,000,000</td><td>50,000</td><td>8,050,000</td>
+  </tr>
+</table>
+</body></html>
+""")
+
+
 @pytest.fixture(autouse=True)
 def _reset_registry_then_reload():
     """Wipe the worker parser registry before each test, then call
@@ -192,7 +218,7 @@ def test_happy_path_parses_and_stores_raw_and_holdings(
     assert row is not None
     assert row.ingest_status == "parsed"
     assert row.raw_status == "stored"
-    assert row.parser_version == "def14a-v2"
+    assert row.parser_version == "def14a-v3"  # bumped by #2086 (402/403 decouple)
 
     # def14a_beneficial_holdings rows exist for the parsed table.
     with ebull_test_conn.cursor() as cur:
@@ -309,6 +335,62 @@ def test_no_table_tombstones_with_stored_raw(
         cur.execute("SELECT status FROM def14a_ingest_log WHERE accession_number = '0000111111-26-000030'")
         log_row = cur.fetchone()
     assert log_row is not None and log_row[0] == "partial"
+
+
+def test_ownership_tombstone_still_extracts_exec_comp(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2086 — Item 402 exec comp is independent of Item 403: a proxy
+    whose ownership table defeats the detector (GME class) still writes
+    def14a_exec_compensation rows; the manifest row tombstones for the
+    ownership accounting exactly as before."""
+    import app.services.manifest_parsers  # noqa: F401 — register
+
+    iid = 8740006
+    _seed_instrument(ebull_test_conn, iid=iid, symbol="GMEX", cik="0000222333")
+    _seed_pending_def14a(
+        ebull_test_conn,
+        accession="0000222333-26-000040",
+        instrument_id=iid,
+        cik="0000222333",
+    )
+    ebull_test_conn.commit()
+
+    from app.providers.implementations import sec_edgar
+
+    monkeypatch.setattr(
+        sec_edgar.SecFilingsProvider,
+        "fetch_document_text",
+        lambda self, url: _NO_OWNERSHIP_WITH_SCT_HTML,
+    )
+
+    stats = run_manifest_worker(ebull_test_conn, source="sec_def14a", max_rows=10)
+    ebull_test_conn.commit()
+
+    # Ownership outcome unchanged: tombstoned with stored raw.
+    assert stats.tombstoned == 1
+    row = get_manifest_row(ebull_test_conn, "0000222333-26-000040")
+    assert row is not None
+    assert row.ingest_status == "tombstoned"
+    assert row.raw_status == "stored"
+
+    # Item 402 extracted despite the Item 403 tombstone.
+    with ebull_test_conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT executive_name, fiscal_year, total_comp
+            FROM def14a_exec_compensation
+            WHERE accession_number = '0000222333-26-000040' AND instrument_id = %s
+            """,
+            (iid,),
+        )
+        comp_rows = cur.fetchall()
+    assert len(comp_rows) == 1
+    name, fy, total = comp_rows[0]
+    assert name == "Jane Roe"
+    assert fy == 2025
+    assert total == Decimal("8050000")
 
 
 def test_fetch_exception_marks_failed_with_backoff(

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -926,6 +926,109 @@ def test_def14a_apply_rescues_tombstoned_accession(
     assert [r[0] for r in rows] == ["Rescued Holder"]
 
 
+def test_def14a_rescue_with_no_ownership_table_still_rewashes_exec_comp(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """#2086 — the tombstoned-with-SCT cohort (GME class): rescue path
+    where the ownership parse still finds nothing, but the body carries
+    a Summary Compensation Table. The rewash must write comp rows AND
+    count as reparsed (parser_version bumps) instead of skipping
+    forever (Codex ckpt-2 P2)."""
+    from app.providers.implementations.sec_def14a import (
+        Def14ABeneficialOwnershipTable,
+        Def14AExecCompRow,
+        Def14ASummaryCompTable,
+    )
+
+    conn = ebull_test_conn
+    instrument_id = 950_070
+    accession = "0001234567-26-000003"
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'D14C', 'DEF 14A Comp Rescue', '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO def14a_ingest_log (accession_number, issuer_cik, status)
+        VALUES (%s, '0000999001', 'partial')
+        """,
+        (accession,),
+    )
+    conn.execute(
+        """
+        INSERT INTO filing_events (
+            instrument_id, filing_date, filing_type, source_url,
+            provider, provider_filing_id, primary_document_url
+        ) VALUES (%s, '2025-03-01', 'DEF 14A', 'https://example.com/y',
+                  'sec', %s, 'https://example.com/y')
+        """,
+        (instrument_id, accession),
+    )
+    _seed_raw(conn, accession=accession, kind="def14a_body", parser_version="def14a-v0")
+    conn.commit()
+
+    empty_ownership = Def14ABeneficialOwnershipTable(as_of_date=None, rows=[], raw_table_score=3)
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_def14a.parse_beneficial_ownership_table",
+        lambda _html: empty_ownership,
+    )
+    sct = Def14ASummaryCompTable(
+        rows=(
+            Def14AExecCompRow(
+                executive_name="Jane Roe",
+                principal_position="Chief Executive Officer",
+                fiscal_year=2025,
+                salary=Decimal("1000000"),
+                bonus=None,
+                stock_awards=Decimal("5000000"),
+                option_awards=None,
+                non_equity_incentive=Decimal("2000000"),
+                pension_nqdc=None,
+                other_comp=Decimal("50000"),
+                total_comp=Decimal("8050000"),
+            ),
+        ),
+        raw_table_score=20,
+    )
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_def14a.parse_summary_compensation_table",
+        lambda _html: sct,
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="def14a_body",
+            current_version="def14a-v1",
+            apply_fn=rewash_filings._apply_def14a,
+        )
+    )
+
+    result = rewash_filings.run_rewash(conn, document_kind="def14a_body")
+    assert result.rows_reparsed == 1  # comp written → bumped, not skipped
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT executive_name, total_comp FROM def14a_exec_compensation WHERE accession_number = %s",
+            (accession,),
+        )
+        comp_rows = cur.fetchall()
+        cur.execute(
+            "SELECT count(*) FROM def14a_beneficial_holdings WHERE accession_number = %s",
+            (accession,),
+        )
+        holdings_count = cur.fetchone()
+    assert comp_rows == [("Jane Roe", Decimal("8050000.00"))]
+    assert holdings_count is not None and holdings_count[0] == 0
+
+
 def test_blockholders_apply_raises_on_parse_failure(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #2086.

## What
`apply_exec_comp_best_effort` previously ran only after a successful beneficial-ownership (Item 403) parse — on BOTH the live manifest path and the rewash path. A proxy whose ownership table defeats the detector never attempted the Summary Compensation Table (Item 402), despite the two being independent items of Schedule 14A (Reg S-K 402/403).

Changes:
1. Manifest parser (`manifest_parsers/def14a.py`): comp best-effort now also runs in the no-ownership-rows branch before the tombstone return. ParseOutcome unchanged (still tombstones for ownership accounting).
2. Rewash (`rewash_filings.py`, Codex ckpt-2 P2): comp block extracted into `_rewash_exec_comp` (same savepoint/regression contract) and called from the rescue-cohort branch too; rescue returns True (bumps parser_version) only when comp rows were written, else keeps skip-without-bump retry semantics.
3. `_PARSER_VERSION_DEF14A` def14a-v2 → def14a-v3 — the backfill vehicle: the tombstoned-with-stored-raw cohort rewashes automatically.

## Source rule
Reg S-K Item 402(c) (SCT) and Item 403 (beneficial ownership) are independent disclosure items of Schedule 14A; nothing in the form couples their presence. Coupling extraction to Item-403 success was an implementation accident (#1945 wired comp only into the success path).

## Full-population evidence
GME: every sec_def14a manifest row tombstoned `no beneficial-ownership table identified (best_score=0..9)`; zero exec-comp rows; stored bodies verified to contain the SCT verbatim. Class impact = the tombstoned-with-stored-raw def14a cohort (~60k rows pre-rebuild).

## Verification (ETL clauses)
- **Smoke panel**: post-#1945-backfill panel state AAPL 29 / HD 34 / JPM 34 / MSFT 31 / GME 0 → dev-verify of THIS change ran the new path on GME's real stored proxies: accession `0001193125-26-235130` wrote **9 comp rows** (was 0).
- **Cross-source**: GameStop DEF 14A (SEC, d937376ddef14a.htm) — FY2025 NEOs Ryan Cohen / Dan Moore / Mark Robinson match extracted rows exactly; Cohen no-salary + protection-program-only other-comp class confirmed. (AAPL cross-source in the #1945 close-out: Cook FY2025 total $74,294,811 EXACT.)
- **Known residual**: FY2024 continuation rows mis-carry the position sub-line as executive_name on stacked name/position layouts — pre-existing SCT parser bug, filed #2088 (not introduced here; measurable post-rewash).
- **Backfill**: operator step post-merge + daemon restart = `POST /jobs/sec_rebuild/run {"source":"sec_def14a"}` re-run; the in-flight 116k-row drain (started today for #1945) runs on pre-fix code, so the rebuild re-reset is required regardless. v3 rewash also picks up the cohort via the sweep.
- Tests: new DB-tier pins for both paths (`test_manifest_parser_def14a.py::test_ownership_tombstone_still_extracts_exec_comp`, `test_rewash_filings.py::test_def14a_rescue_with_no_ownership_table_still_rewashes_exec_comp`); full def14a suite 58+34 passed; ruff/format/pyright clean.

## Security model
No new inputs/endpoints; parses only SEC-fetched raw bodies already in the store, through existing chokepoints (`apply_exec_comp_best_effort`, `_upsert_comp` parameterised upserts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)