### PR TITLE
fix(#2088): SCT stacked name/position rows no longer clobber the carried NEO name

### DIFF
--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import html
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Final
@@ -1194,6 +1194,26 @@ def _looks_like_name_cell(cell: str) -> bool:
     return bool(re.search(r"[A-Za-z]{2,}", stripped))
 
 
+def _position_only_cell(cell: str) -> str | None:
+    """Return the cleaned title text when CELL is a position-only fragment,
+    else ``None``.
+
+    Stacked name/position SCT layouts (GME) render the title on its OWN
+    physical row below the name row, so the continuation row's first cell is
+    a bare title ("Chief Executive Officer") that would otherwise pass
+    ``_looks_like_name_cell`` and clobber the carried NEO name (#2088). A
+    cell is position-only when the first role keyword matches at offset 0 —
+    a genuine "Name [Title]" cell always LEADS with the person's name."""
+    text = _clean_holder_name(cell).replace("\xa0", " ").replace("\n", " ").strip()
+    text = _INLINE_WHITESPACE_RE.sub(" ", text)
+    if not text:
+        return None
+    m = _POSITION_ROLE_RE.search(text)
+    if m is not None and m.start() == 0:
+        return text
+    return None
+
+
 def _extract_sct_row_values(cells_after_year: list[str]) -> list[Decimal | None]:
     """Compact the post-year cells into ordered value slots.
 
@@ -1353,7 +1373,21 @@ def parse_summary_compensation_table(html_text: str) -> Def14ASummaryCompTable:
         if first_nonempty_idx is None:
             continue
         if _looks_like_name_cell(cells[first_nonempty_idx]):
-            current_name, current_position = _split_name_position(cells[first_nonempty_idx])
+            position_fragment = _position_only_cell(cells[first_nonempty_idx])
+            if position_fragment is not None and current_name:
+                # Stacked name/position layout (GME, #2088): the title rides
+                # the NEXT physical row — it belongs to the carried NEO, it is
+                # not a new name. The name row was already emitted with a NULL
+                # position, so backfill this NEO's earlier rows too.
+                if current_position is None:
+                    current_position = position_fragment
+                    for i in range(len(rows) - 1, -1, -1):
+                        if rows[i].executive_name != current_name:
+                            break
+                        if rows[i].principal_position is None:
+                            rows[i] = replace(rows[i], principal_position=position_fragment)
+            else:
+                current_name, current_position = _split_name_position(cells[first_nonempty_idx])
 
         # Locate the fiscal-year token.
         year_idx = None

--- a/tests/test_sec_def14a_sct_parser.py
+++ b/tests/test_sec_def14a_sct_parser.py
@@ -25,6 +25,7 @@ import pytest
 
 from app.providers.implementations.sec_def14a import (
     _parse_dollar,
+    _position_only_cell,
     _resolve_sct_fields,
     _split_name_position,
     parse_summary_compensation_table,
@@ -102,6 +103,40 @@ def test_aapl_rowspan_continuation_shift() -> None:
     assert cook_2024.fiscal_year == 2024
     assert cook_2024.total_comp == Decimal("74609802")
     assert cook_2024.salary == Decimal("3000000")
+
+
+def test_gme_stacked_name_position_rows() -> None:
+    """Stacked name/position layout (#2088 — GME): the title renders on its
+    OWN physical row (the second year-row per NEO) and the third year-row's
+    name cell is empty. The title row must not clobber the carried name, the
+    title attaches to the carried NEO, and the already-emitted name row gets
+    the position backfilled. A following NEO resets the carry."""
+    header = _row(
+        "Name and Principal Position",
+        "Year",
+        "Salary ($)",
+        "Bonus ($)",
+        "Stock Awards ($)",
+        "Total ($)",
+    )
+    r1_2025 = _row("Ryan Cohen", "2025", "—", "—", "1,760,467", "1,760,467")
+    r1_2024 = _row("Chief Executive Officer", "2024", "—", "—", "268,553", "268,553")
+    r1_2023 = _row("", "2023", "—", "—", "100", "100")
+    r2_2025 = _row("Dan Moore", "2025", "200,000", "—", "2,166,562", "2,366,562")
+    r2_2024 = _row("Principal Financial and Accounting Officer", "2024", "192,615", "—", "636,600", "829,215")
+    table = f"<table>{header}{r1_2025}{r1_2024}{r1_2023}{r2_2025}{r2_2024}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.principal_position, r.fiscal_year) for r in result.rows] == [
+        ("Ryan Cohen", "Chief Executive Officer", 2025),
+        ("Ryan Cohen", "Chief Executive Officer", 2024),
+        ("Ryan Cohen", "Chief Executive Officer", 2023),
+        ("Dan Moore", "Principal Financial and Accounting Officer", 2025),
+        ("Dan Moore", "Principal Financial and Accounting Officer", 2024),
+    ]
+    assert result.rows[0].total_comp == Decimal("1760467")
+    assert result.rows[0].salary is None  # Cohen draws no salary — explicit dash
+    assert result.rows[3].salary == Decimal("200000")
 
 
 def test_hd_folded_year_and_dash_null() -> None:
@@ -426,6 +461,19 @@ def test_parse_dollar_variants() -> None:
     assert _parse_dollar("N/A") is None
     assert _parse_dollar("") is None
     assert _parse_dollar("   ") is None
+
+
+def test_position_only_cell_detection() -> None:
+    """Position-only = first role keyword at offset 0 (#2088). A cell leading
+    with a person's name is NOT position-only, even with a title after."""
+    assert _position_only_cell("Chief Executive Officer") == "Chief Executive Officer"
+    assert _position_only_cell("Principal Financial and Accounting Officer") == (
+        "Principal Financial and Accounting Officer"
+    )
+    assert _position_only_cell("General Counsel and Secretary") == "General Counsel and Secretary"
+    assert _position_only_cell("James Dimon Chairman and CEO") is None
+    assert _position_only_cell("Tim Cook\nChief Executive Officer") is None
+    assert _position_only_cell("") is None
 
 
 def test_split_name_position_newline() -> None:


### PR DESCRIPTION
Closes #2088.

## What

`parse_summary_compensation_table` treated any alphabetic first cell as a new NEO name. Stacked name/position SCT layouts (GME) render the title on its **own physical row** below the name row, so the title fragment ("Chief Executive Officer") clobbered the carried name and every later-year row landed as a bogus separate "executive" under the `(instrument, executive_name, fiscal_year)` upsert key.

Fix: new `_position_only_cell` helper — a first cell whose **first role keyword matches at offset 0** (`_POSITION_ROLE_RE`, the #1967 keyword set) is a position fragment, not a name: it attaches as the carried NEO's `principal_position` and backfills the NEO's already-emitted rows' NULL position. Genuine name cells always lead with the person's name, so offset-0 anchoring cannot misfire on "James Dimon Chairman and CEO" one-liners.

## Source rule

Item 402(c)(2)(i) Reg S-K defines one combined "Name and Principal Position" column; the stacked layout is a filer rendering choice (rowspan collapse distributing name/title across physical `<tr>`s), so the treatment is fixed by the filing's actual structure: fragments in that column belong to the current NEO until a new name row starts.

## Verification (real filing, full fixture)

Repro + fix verified on the stored raw body of GME `0001193125-26-235130` (the #2088 fixture):

- before: FY2024/FY2023 rows named "Chief Executive Officer" / "Principal Financial and Accounting Officer" / "General Counsel and Secretary", all positions NULL;
- after: 9 rows, Cohen/Moore/Robinson × FY2023–2025, positions populated on every row, totals unchanged (Cohen FY2025 1,760,467; Moore 2,366,562; Robinson 2,609,200 — cross-checked against the proxy in #2086).

Tests: `test_gme_stacked_name_position_rows` (behavior incl. backfill + NEO reset) + `test_position_only_cell_detection`; full SCT suite 27/27.

## Rewash / rollout (no parser-version bump)

- The 13,721 v2-era comp-less def14a tombstones were reset to `pending` this session (session 727fc11f, targeted `last_attempted_at < 20:03:46Z` reset — not a full `sec_rebuild`); they re-fetch via the manifest worker and will parse with this fix once the jobs daemon restarts onto this commit (restart already owed).
- Bogus rows already persisted from `parsed` accessions (GME included) are purged by the raw-row rewash: `_rewash_exec_comp` is DELETE+INSERT and the raw cohort keys off `filing_raw_documents.parser_version` (GME raw row = `def14a-v1` ≠ v3) — operator step: `scripts/rewash.py --kind def14a_body` after merge (runs in its own process; no daemon restart needed for this leg).
- Rows drained between 20:03 UTC and the next daemon restart parse without this fix AND stamp their raw rows `def14a-v3`, so the version-mismatch rewash will NOT re-sweep them. Bounded residual class; the #2088 impact query (`executive_name ~* '(officer|counsel|secretary|president)$'`) quantifies it after the rewash progresses, and affected accessions get spot-reset.

## Tradeoffs

- Position footnote markers (e.g. "Chief Executive Officer (1)") are kept raw — `principal_position` is raw free-text in v1 per the model contract.
- Multi-row position continuations ("…Officer" / "and President" split across two title rows) are not legislated — no observed instance; the impact query will surface any.

Codex ckpt-2: "No correctness bugs found." Gates: ruff ✓ format ✓ pyright 0 ✓ SCT suite 27/27 ✓ fast tier ✓ (hook re-runs all).
