### PR TITLE
fix(#2094): SCT wrapped first-column cells no longer clobber executive_name

### DIFF
--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1081,7 +1081,7 @@ _POSITION_ROLE_RE: Final[re.Pattern[str]] = re.compile(
     r"executive\s+vice\s+president|senior\s+vice\s+president|vice\s+president|"
     r"vice\s+chair(?:man|woman|person)?|"
     r"president|chair(?:man|woman|person)?|"
-    r"general\s+counsel|chief|ceo|cfo|coo|cto|"
+    r"general\s+counsel|chief|ceo|cfo|coo|cto|evp|svp|"
     r"executive\s+officer|principal\s+\w+|treasurer|secretary|"
     r"director|founder"
     r")"
@@ -1178,8 +1178,12 @@ def _split_name_position(cell: str) -> tuple[str, str | None]:
 
 def _clean_name_footnote(name: str) -> str:
     """Strip a trailing inline footnote reference digit from an executive name
-    (JPM's "Daniel Pinto 11" → "Daniel Pinto")."""
-    return _TRAILING_FOOTNOTE_RE.sub("", name.strip()).strip()
+    (JPM's "Daniel Pinto 11" → "Daniel Pinto") and any trailing connector
+    punctuation left by a split mid-phrase ("Adolphus B. Baker," → same
+    without the comma; #2094). Periods are kept — "Jr." / "M.D." are real
+    name endings."""
+    cleaned = _TRAILING_FOOTNOTE_RE.sub("", name.strip()).strip()
+    return re.sub(r"[,;&–—/-]+\s*$", "", cleaned).strip()
 
 
 def _looks_like_name_cell(cell: str) -> bool:
@@ -1194,6 +1198,12 @@ def _looks_like_name_cell(cell: str) -> bool:
     return bool(re.search(r"[A-Za-z]{2,}", stripped))
 
 
+def _normalize_first_cell(cell: str) -> str:
+    """Flatten an SCT first-column cell to single-line, single-spaced text."""
+    text = _clean_holder_name(cell).replace("\xa0", " ").replace("\n", " ").strip()
+    return _INLINE_WHITESPACE_RE.sub(" ", text)
+
+
 def _position_only_cell(cell: str) -> str | None:
     """Return the cleaned title text when CELL is a position-only fragment,
     else ``None``.
@@ -1204,14 +1214,111 @@ def _position_only_cell(cell: str) -> str | None:
     ``_looks_like_name_cell`` and clobber the carried NEO name (#2088). A
     cell is position-only when the first role keyword matches at offset 0 —
     a genuine "Name [Title]" cell always LEADS with the person's name."""
-    text = _clean_holder_name(cell).replace("\xa0", " ").replace("\n", " ").strip()
-    text = _INLINE_WHITESPACE_RE.sub(" ", text)
+    text = _normalize_first_cell(cell)
     if not text:
         return None
     m = _POSITION_ROLE_RE.search(text)
     if m is not None and m.start() == 0:
         return text
     return None
+
+
+# Words that appear in SCT title text but essentially never inside a person's
+# legal name. Used as NEGATIVE evidence when deciding whether a year-descending
+# first cell opens a new NEO block (#2094 Codex ckpt-2 High): a candidate name
+# containing any of these is a wrapped-title fragment, not a person. A negative
+# vocabulary on the NAME side is robust where positive enumeration of every
+# possible fragment START word is impossible.
+_TITLE_VOCAB: Final[frozenset[str]] = frozenset(
+    {
+        "officer",
+        "counsel",
+        "secretary",
+        "treasurer",
+        "president",
+        "chair",
+        "chairman",
+        "chairwoman",
+        "chairperson",
+        "chief",
+        "executive",
+        "vice",
+        "senior",
+        "principal",
+        "general",
+        "director",
+        "founder",
+        "ceo",
+        "cfo",
+        "coo",
+        "cto",
+        "evp",
+        "svp",
+        "vp",
+        "former",
+        "interim",
+        "acting",
+        "division",
+        "group",
+        "university",
+        "system",
+        "company",
+        "corporation",
+        "bank",
+        "banking",
+        "operations",
+        "operating",
+        "financial",
+        "finance",
+        "technology",
+        "administrative",
+        "administration",
+        "compliance",
+        "accounting",
+        "marketing",
+        "commercial",
+        "resources",
+        "human",
+        "legal",
+        "global",
+        "strategy",
+        "and",
+        "of",
+        "the",
+    }
+)
+
+_TRAILING_CONNECTOR_RE: Final[re.Pattern[str]] = re.compile(r"[,&–—/-]\s*$")
+
+
+def _plausible_person_name(text: str) -> bool:
+    """True when TEXT plausibly is a person's name (not a title fragment).
+
+    Person names have 2+ tokens, never end in a connector, and contain no
+    title vocabulary. Only consulted on year-descending rows (#2094) to let
+    a genuine new NEO whose block starts below the previous row's fiscal
+    year (e.g. a departed exec listed after a current-year-only NEO) open a
+    fresh block instead of being absorbed as a title continuation."""
+    stripped = text.strip()
+    if not stripped or _TRAILING_CONNECTOR_RE.search(stripped):
+        return False
+    tokens = [t for t in re.split(r"[\s,]+", stripped) if t]
+    if len(tokens) < 2:
+        return False
+    return not any(t.lower().strip(".&/") in _TITLE_VOCAB for t in tokens)
+
+
+def _backfill_position(rows: list[Def14AExecCompRow], name: str, position: str) -> None:
+    """Rewrite the position on the carried NEO's already-emitted rows.
+
+    Walks back over the contiguous tail of ROWS belonging to NAME and
+    replaces the position outright — earlier rows may hold either ``None``
+    (name row emitted before any title row, #2088) or a partial prefix of a
+    title that wrapped over several physical rows (#2094)."""
+    for i in range(len(rows) - 1, -1, -1):
+        if rows[i].executive_name != name:
+            break
+        rows[i] = replace(rows[i], principal_position=position)
 
 
 def _extract_sct_row_values(cells_after_year: list[str]) -> list[Decimal | None]:
@@ -1361,47 +1468,85 @@ def parse_summary_compensation_table(html_text: str) -> Def14ASummaryCompTable:
     rows: list[Def14AExecCompRow] = []
     current_name = ""
     current_position: str | None = None
+    prev_row_year: int | None = None
 
     for raw_row in best_table.rows:
         cells = [_sct_norm(c) for c in raw_row]
         if not any(cells):
             continue
 
-        # Leading name cell? (present on the first row per NEO; absent on
-        # rowspan continuation rows.)
         first_nonempty_idx = next((i for i, c in enumerate(cells) if c), None)
         if first_nonempty_idx is None:
             continue
-        if _looks_like_name_cell(cells[first_nonempty_idx]):
-            position_fragment = _position_only_cell(cells[first_nonempty_idx])
-            if position_fragment is not None and current_name:
-                # Stacked name/position layout (GME, #2088): the title rides
-                # the NEXT physical row — it belongs to the carried NEO, it is
-                # not a new name. The name row was already emitted with a NULL
-                # position, so backfill this NEO's earlier rows too.
-                if current_position is None:
-                    current_position = position_fragment
-                    for i in range(len(rows) - 1, -1, -1):
-                        if rows[i].executive_name != current_name:
-                            break
-                        if rows[i].principal_position is None:
-                            rows[i] = replace(rows[i], principal_position=position_fragment)
-            else:
-                current_name, current_position = _split_name_position(cells[first_nonempty_idx])
 
-        # Locate the fiscal-year token.
+        # Fiscal-year token first — the name-cell decision below needs THIS
+        # row's year to detect wrapped-title continuations (#2094).
         year_idx = None
         for i, c in enumerate(cells):
             if _YEAR_RE.match(_FOOTNOTE_RE.sub("", c).strip()):
                 year_idx = i
                 break
-        if year_idx is None:
+        row_year = int(_FOOTNOTE_RE.sub("", cells[year_idx]).strip()) if year_idx is not None else None
+
+        # Leading name cell? (present on the first row per NEO; absent on
+        # rowspan continuation rows.)
+        if _looks_like_name_cell(cells[first_nonempty_idx]):
+            first_cell = cells[first_nonempty_idx]
+            cleaned = _normalize_first_cell(first_cell)
+            position_fragment = _position_only_cell(first_cell)
+            # #2094 — wrapped first-column layouts (PRDO/HBNC) spread ONE
+            # logical name+title cell across the NEO block's physical
+            # per-fiscal-year rows. A new NEO's block always restarts at a
+            # NEWER year (§ 229.402(c)(2)(ii) rows render newest-first), so a
+            # name-like cell on a year-DESCENDING row is a continuation
+            # fragment of the carried NEO's title, whatever word it starts
+            # with — a role lexicon cannot enumerate mid-title fragments
+            # ("Officer", "EVP,", "Technical University").
+            year_descends = (
+                bool(current_name) and row_year is not None and prev_row_year is not None and row_year < prev_row_year
+            )
+            restated_name = bool(current_name) and (cleaned == current_name or cleaned.startswith(current_name + " "))
+            if restated_name:
+                # Per-year name repeat (no rowspan) — same NEO, keep the carry.
+                pass
+            elif position_fragment is not None and current_name:
+                # Stacked name/position layout (GME, #2088): the title rides
+                # a LATER physical row — it belongs to the carried NEO, it is
+                # not a new name. Earlier emitted rows get the position
+                # backfilled; a lexicon-matching TAIL of a wrapped title
+                # (#2094 "…Chief Financial Officer") appends instead.
+                if current_position is None:
+                    current_position = position_fragment
+                    _backfill_position(rows, current_name, current_position)
+                elif year_descends:
+                    current_position = f"{current_position} {position_fragment}"
+                    _backfill_position(rows, current_name, current_position)
+                # else: repeated full-title row — drop, keep the carry.
+            elif year_descends:
+                # A genuine NEW NEO may still open on a descending year — a
+                # departed exec's block starts below a current-year-only
+                # NEO's row (Codex ckpt-2 High). Escape when the cell splits
+                # into a plausible person name + a title; otherwise it is a
+                # wrapped-title fragment and appends to the carry.
+                cand_name, cand_pos = _split_name_position(first_cell)
+                if cand_pos is not None and _plausible_person_name(cand_name):
+                    current_name, current_position = cand_name, cand_pos
+                else:
+                    current_position = f"{current_position} {cleaned}" if current_position else cleaned
+                    _backfill_position(rows, current_name, current_position)
+            else:
+                current_name, current_position = _split_name_position(first_cell)
+
+        if row_year is not None:
+            prev_row_year = row_year
+
+        if year_idx is None or row_year is None:
             # Name-only header row (HD) or a prose row — nothing to emit.
             continue
         if not current_name:
             continue  # values with no NEO context yet — skip defensively.
 
-        fiscal_year = int(_FOOTNOTE_RE.sub("", cells[year_idx]).strip())
+        fiscal_year = row_year
         values = _extract_sct_row_values(cells[year_idx + 1 :])
         if not values:
             continue

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -76,7 +76,7 @@ from app.services.sec_identity import siblings_for_issuer_cik
 # v3 (#2086): Item 402 exec comp now runs on the ownership-tombstone path
 # too — the tombstoned-with-stored-raw cohort must rewash to pick up SCTs
 # the 402↔403 coupling previously skipped (GME class).
-_PARSER_VERSION_DEF14A = "def14a-v3"
+_PARSER_VERSION_DEF14A = "def14a-v4"
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_sec_def14a_sct_parser.py
+++ b/tests/test_sec_def14a_sct_parser.py
@@ -139,6 +139,157 @@ def test_gme_stacked_name_position_rows() -> None:
     assert result.rows[3].salary == Decimal("200000")
 
 
+def test_prdo_wrapped_title_fragments() -> None:
+    """Wrapped first-column layout (#2094 — PRDO): the logical name+title cell
+    wraps across the NEO block's three physical year rows. Row-2 fragments may
+    match the role lexicon at offset 0, but row-3 tails start with arbitrary
+    words ('Officer', 'Technical University') no lexicon can enumerate. The
+    fiscal-year descent (2024 → 2023 → 2022 inside a block; a new NEO restarts
+    at a newer year) must keep the fragments attached to the carried NEO and
+    concatenate the full title, backfilled onto every emitted row."""
+    header = _row(
+        "Name and Principal Position",
+        "Year",
+        "Salary ($)",
+        "Stock Awards ($)",
+        "Total ($)",
+    )
+    nelson_2024 = _row("Todd S. Nelson", "2024", "1,057,491", "3,323,796", "6,725,760")
+    nelson_2023 = _row("President and Chief Executive", "2023", "1,036,756", "2,138,972", "4,504,386")
+    nelson_2022 = _row("Officer", "2022", "1,011,469", "2,148,140", "4,512,179")
+    baskel_2024 = _row("Elise L. Baskel", "2024", "494,846", "515,919", "1,495,528")
+    baskel_2023 = _row("Senior Vice President – Colorado", "2023", "480,433", "434,439", "1,534,471")
+    baskel_2022 = _row("Technical University", "2022", "465,000", "381,145", "1,229,324")
+    table = f"<table>{header}{nelson_2024}{nelson_2023}{nelson_2022}{baskel_2024}{baskel_2023}{baskel_2022}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.principal_position, r.fiscal_year) for r in result.rows] == [
+        ("Todd S. Nelson", "President and Chief Executive Officer", 2024),
+        ("Todd S. Nelson", "President and Chief Executive Officer", 2023),
+        ("Todd S. Nelson", "President and Chief Executive Officer", 2022),
+        ("Elise L. Baskel", "Senior Vice President – Colorado Technical University", 2024),
+        ("Elise L. Baskel", "Senior Vice President – Colorado Technical University", 2023),
+        ("Elise L. Baskel", "Senior Vice President – Colorado Technical University", 2022),
+    ]
+    assert result.rows[2].total_comp == Decimal("4512179")
+    assert result.rows[5].total_comp == Decimal("1229324")
+
+
+def test_hbnc_non_lexicon_second_row_fragment() -> None:
+    """Wrapped-title variant (#2094 — HBNC): even the SECOND row's fragment
+    starts with a non-lexicon word ('EVP,'), so no position has been captured
+    yet when it arrives. Year descent must still classify it as a title
+    continuation, and a later lexicon-matching tail appends to it."""
+    header = _row("Name and Principal Position", "Year", "Salary ($)", "Total ($)")
+    secor_2024 = _row("Mark E. Secor", "2024", "430,000", "672,269")
+    secor_2023 = _row("EVP,", "2023", "415,000", "630,000")
+    secor_2022 = _row("Chief Financial Officer", "2022", "400,000", "610,000")
+    table = f"<table>{header}{secor_2024}{secor_2023}{secor_2022}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.principal_position, r.fiscal_year) for r in result.rows] == [
+        ("Mark E. Secor", "EVP, Chief Financial Officer", 2024),
+        ("Mark E. Secor", "EVP, Chief Financial Officer", 2023),
+        ("Mark E. Secor", "EVP, Chief Financial Officer", 2022),
+    ]
+
+
+def test_former_exec_block_starts_below_table_max_year() -> None:
+    """A departed NEO's block may start BELOW the table's newest year (no
+    FY2024 row). The block boundary is a year INCREASE relative to the
+    previous physical row — not equality with the table max — so the new
+    name must open a fresh block, not be absorbed as a title fragment."""
+    header = _row("Name and Principal Position", "Year", "Salary ($)", "Total ($)")
+    ceo_2024 = _row("Ann Incumbent\nChief Executive Officer", "2024", "900,000", "3,000,000")
+    ceo_2023 = _row("", "2023", "850,000", "2,800,000")
+    ceo_2022 = _row("", "2022", "800,000", "2,600,000")
+    former_2023 = _row("Jane Q. Departed\nFormer Chief Financial Officer", "2023", "600,000", "1,900,000")
+    former_2022 = _row("", "2022", "580,000", "1,700,000")
+    table = f"<table>{header}{ceo_2024}{ceo_2023}{ceo_2022}{former_2023}{former_2022}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.fiscal_year) for r in result.rows] == [
+        ("Ann Incumbent", 2024),
+        ("Ann Incumbent", 2023),
+        ("Ann Incumbent", 2022),
+        ("Jane Q. Departed", 2023),
+        ("Jane Q. Departed", 2022),
+    ]
+    assert result.rows[3].principal_position == "Former Chief Financial Officer"
+
+
+def test_new_neo_opens_below_previous_rows_year() -> None:
+    """Codex ckpt-2 (#2094): a departed NEO's block can start BELOW the
+    previous physical row's year (current-year-only NEO first). A cell that
+    splits into a plausible person name + title must open a new block even
+    on a year-descending row; a title fragment ('Financial Officer &
+    Treasurer') must not."""
+    header = _row("Name and Principal Position", "Year", "Salary ($)", "Total ($)")
+    alice_2024 = _row("Alice A. Alpha\nChief Executive Officer", "2024", "500,000", "2,000,000")
+    bob_2023 = _row("Bob B. Beta\nFormer Chief Financial Officer", "2023", "400,000", "1,500,000")
+    bob_2022 = _row("", "2022", "380,000", "1,400,000")
+    table = f"<table>{header}{alice_2024}{bob_2023}{bob_2022}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.principal_position, r.fiscal_year) for r in result.rows] == [
+        ("Alice A. Alpha", "Chief Executive Officer", 2024),
+        ("Bob B. Beta", "Former Chief Financial Officer", 2023),
+        ("Bob B. Beta", "Former Chief Financial Officer", 2022),
+    ]
+
+
+def test_fragment_with_interior_role_keyword_still_continues() -> None:
+    """A wrapped-title tail containing a role keyword at offset > 0
+    ('Financial Officer & Treasurer' — PRDO/Ghia) splits into a title-vocab
+    prefix, NOT a person name, so it must append to the carried NEO rather
+    than open a bogus block."""
+    header = _row("Name and Principal Position", "Year", "Salary ($)", "Total ($)")
+    ghia_2024 = _row("Ashish R. Ghia", "2024", "530,000", "3,405,287")
+    ghia_2023 = _row("Senior Vice President, Chief", "2023", "515,000", "2,290,706")
+    ghia_2022 = _row("Financial Officer & Treasurer", "2022", "500,000", "1,842,560")
+    table = f"<table>{header}{ghia_2024}{ghia_2023}{ghia_2022}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.principal_position, r.fiscal_year) for r in result.rows] == [
+        ("Ashish R. Ghia", "Senior Vice President, Chief Financial Officer & Treasurer", 2024),
+        ("Ashish R. Ghia", "Senior Vice President, Chief Financial Officer & Treasurer", 2023),
+        ("Ashish R. Ghia", "Senior Vice President, Chief Financial Officer & Treasurer", 2022),
+    ]
+
+
+def test_single_year_table_new_neo_on_equal_year() -> None:
+    """One row per NEO, all the same fiscal year: equal years are NOT a
+    descent, so every name-like cell opens a new block."""
+    header = _row("Name and Principal Position", "Year", "Salary ($)", "Total ($)")
+    r1 = _row("Alice A. Alpha\nChief Executive Officer", "2024", "500,000", "2,000,000")
+    r2 = _row("Bob B. Beta\nChief Financial Officer", "2024", "400,000", "1,500,000")
+    table = f"<table>{header}{r1}{r2}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.fiscal_year) for r in result.rows] == [
+        ("Alice A. Alpha", 2024),
+        ("Bob B. Beta", 2024),
+    ]
+
+
+def test_name_repeated_on_each_year_row() -> None:
+    """Some filers repeat the NEO's name (or full name+title) on every year
+    row instead of using rowspan. A repeated first cell inside a descending
+    block must neither clobber the position nor be appended to it."""
+    header = _row("Name and Principal Position", "Year", "Salary ($)", "Total ($)")
+    r_2024 = _row("Carol C. Gamma\nChief Executive Officer", "2024", "700,000", "2,500,000")
+    r_2023 = _row("Carol C. Gamma", "2023", "650,000", "2,200,000")
+    r_2022 = _row("Carol C. Gamma\nChief Executive Officer", "2022", "600,000", "2,000,000")
+    table = f"<table>{header}{r_2024}{r_2023}{r_2022}</table>"
+    result = parse_summary_compensation_table(_sct_doc(table))
+
+    assert [(r.executive_name, r.principal_position, r.fiscal_year) for r in result.rows] == [
+        ("Carol C. Gamma", "Chief Executive Officer", 2024),
+        ("Carol C. Gamma", "Chief Executive Officer", 2023),
+        ("Carol C. Gamma", "Chief Executive Officer", 2022),
+    ]
+
+
 def test_hd_folded_year_and_dash_null() -> None:
     """Separate name-only row; year folded into the value stream; ``—`` bonus
     is an explicit null (kept as a slot, not dropped). Full 8-column table."""


### PR DESCRIPTION
Closes #2094

## What

Post-#2088 def14a rewash (07-17 21:47–22:30 UTC, code `e59dc5af`) wrote ~10k bogus `def14a_exec_compensation` rows: the SCT's logical "Name and Principal Position" cell (Reg S-K § 229.402(c)(2)(i) — one column) wraps across the NEO block's physical per-fiscal-year rows in the PRDO/HBNC layout family. Mid-title fragments ('Officer', 'EVP,', 'Technical University') fail #2088's offset-0 role-keyword test, pass `_looks_like_name_cell`, and clobber the carried name — subsequent-year rows emit under the fragment. Full-pop damage measured pre-fix: ends-in-title-word 355 rows/233 accessions; single-token 2,377/792; trailing-connector 8,026/1,200 (of 65,479/6,039 total).

## Fix (structural, not lexical)

A new NEO block always restarts at a NEWER fiscal year (§ 229.402(c)(2)(ii) rows, newest-first convention), so in `parse_summary_compensation_table`:

- fiscal-year token is peeked BEFORE the name-cell decision;
- a name-like first cell on a year-DESCENDING row (`row_year < prev_row_year`, block open) is a title continuation: append to the carried position, `_backfill_position` replaces the NEO's already-emitted rows (partial prefixes included);
- escape hatch (Codex ckpt-2 High): if that cell splits into a plausible person name + title (`_plausible_person_name`: ≥2 tokens, no trailing connector, no `_TITLE_VOCAB` word), it opens a NEW block — covers a departed exec whose block starts below a current-year-only NEO's row;
- restated-name guard: per-year repeated name cells keep the carry;
- lexicon path kept for value-less title rows (GME, #2088) and appends lexicon-matching tails when descending;
- name hygiene: `_clean_name_footnote` strips trailing connector punctuation; `_POSITION_ROLE_RE` gains `evp|svp`.

`_PARSER_VERSION_DEF14A` v3 → v4 — the version-mismatch rewash cohort then covers every raw (incl. tonight's v3-stamped rows) as the repair vehicle.

## Source rule

Reg S-K § 229.402(c)(2)(i) (single Name-and-Principal-Position column) + (c)(2)(ii) (row per covered fiscal year; newest-first is rendering convention, not reg — see Full-population verification). Wrapping across sibling year rows is renderer artifact; the filing's actual structure verified on stored raw bodies.

## Full-population verification

- Deterministic repro pre-fix on stored raws: PRDO `0000950170-25-053361` ('Officer', 'Technical University', 'InterContinental University System' as names), HBNC `0000706129-25-000040` ('EVP,', 'Banking Officer').
- Post-fix re-parse of the same bodies: PRDO 15 rows/5 real names with full concatenated titles ('Senior Vice President, Chief Financial Officer & Treasurer'); HBNC 15 rows all real names; GME `0001193125-26-235130` unchanged 9 rows (no #2088 regression).
- 40 previously-impacted accessions re-parsed: 529 rows, flagged residual 12 (2.3%, was 185/35%) — all single-token block-START name wraps ('John', 'Gordon'): name truncation with CORRECT attribution; distinct smaller defect, counted at full-pop after the v4 rewash and ticketed if material.
- Ascending-year renderings would bypass the descent rule (fragments would clobber again, pre-fix behavior, no NEW failure mode); quantified by the post-rewash impact queries.

## Smoke panel (clauses 8–9)

AAPL/GME/MSFT/JPM/HD stored bodies parsed under the fix: 14/9/13/15/14 rows, all real names. AAPL Cook FY2025 total **$74,294,811** — exact match to the #1945 cross-source-verified figure (proxy + endpoint verified 07-17).

## Backfill (clauses 10–11)

Post-merge: detached `scripts/rewash.py --kind def14a_body` (46k raw cohort now version-mismatched at v4; local re-parse, no SEC fetch). Then: impact queries (position-suffix / single-token / trailing-connector) re-run full-pop — expect ≥95% reduction; GME + panel `/instruments/{symbol}/ownership-rollup` + exec-comp endpoints re-verified. Results posted on #2094 before close.

## Security model

No new inputs, endpoints, or SQL surfaces. Parser consumes already-stored `filing_raw_documents` payloads (untrusted SEC HTML) — regex changes keep bounded quantifiers (`{0,3}` modifier run, no unbounded backtracking added); `_TITLE_VOCAB` is a frozenset membership test. Rewash path unchanged (#2086 DELETE+INSERT semantics).

## Tradeoffs

- Single-token block-start name wraps ('John' 6/529 in the pre-flight) deferred — needs lookahead-merge, riskier than this bounded change.
- A real NEO legally named with a `_TITLE_VOCAB` word ('Mary President') would be absorbed as continuation on a descending row only — accepted (Codex: "theoretically possible, not material").
- Truncated titles where a tail fragment rode a row outside the block (HBNC Etzler 'EVP, Chief Legal and') — title free-text is v1 best-effort; name + attribution correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)