### PR TITLE
chore(#2087): drop retired cascade_retry_queue table

### DIFF
--- a/sql/235_drop_cascade_retry_queue.sql
+++ b/sql/235_drop_cascade_retry_queue.sql
@@ -1,0 +1,12 @@
+-- 235_drop_cascade_retry_queue.sql
+--
+-- #2087 (#2065 follow-up) — drop the retired cascade retry queue.
+--
+-- PR #2085 removed every reader/writer of ``cascade_retry_queue`` but kept
+-- the table so the still-running pre-merge daemon could not error against a
+-- dropped relation (retired-writer ordering, #2008 lesson). Gate cleared
+-- 2026-07-18: first post-restart fundamentals_sync run succeeded in 4m56s
+-- (cascade-free), zero trigger='cascade' thesis_runs since the restart, and
+-- the queue held 0 rows at drop time.
+
+DROP TABLE IF EXISTS cascade_retry_queue;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -134,7 +134,6 @@ def _hash_cache_path() -> Path:
 # (review-prevention-log entry "Test-teardown list missing new FK-child
 # tables").
 _PLANNER_TABLES: tuple[str, ...] = (
-    "cascade_retry_queue",
     "cik_upsert_timing",
     "financial_facts_raw",
     # #554 — dimensional XBRL facts (segments / product / geographic).


### PR DESCRIPTION
Closes #2087

## What

`sql/235_drop_cascade_retry_queue.sql` — `DROP TABLE IF EXISTS cascade_retry_queue;` + the `_PLANNER_TABLES` truncate-list entry removed from `tests/fixtures/ebull_test_db.py` (same PR, per the fixture's own comment rule).

## Why now (gate evidence, 2026-07-18 03:31 UTC, on #2087)

PR #2085 (#2065) removed every reader/writer but retained the table so the pre-merge daemon could not error on a dropped relation (retired-writer ordering, #2008). Gate cleared:

- first cascade-free `fundamentals_sync` (02:30 UTC) = success, wall **4m56s** (prior run: failure at 11h02m);
- `thesis_runs` `trigger='cascade'` after 2026-07-17T20:03Z = 0 (30 'scheduled' only);
- queue held 0 rows; live daemon (`e59dc5af`) postdates the writer removal (`09e10937`) — no retired writer can touch the relation.

## Verification

- grep: zero `cascade_retry_queue` references in `app/` / `tests/` / `scripts/` (only sql/ history).
- Gates green: ruff / format / pyright / fast tier 5,315 passed / smoke 153 passed.
- Smoke applied the migration to dev — `to_regclass('cascade_retry_queue')` now NULL.
- Codex ckpt-2: no findings (order fine, idempotent, no FK/view/index dependency).

## Security model

No runtime surface — drops an orphaned relation with no readers/writers; migration runner applies lexicographically at lifespan as with every prior migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)