### PR TITLE
fix(#2105): def14a comp rewash refreshes ALL sibling share-class instruments

### DIFF
--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -697,7 +697,20 @@ def _rewash_exec_comp_all_instruments(
     # #1731 manifest_parsers init-order trap).
     from app.services.manifest_parsers.def14a import _resolve_siblings
 
-    instrument_ids = set(_resolve_siblings(conn, instrument_id=resolved_instrument_id, issuer_cik=issuer_cik))
+    try:
+        instrument_ids = set(_resolve_siblings(conn, instrument_id=resolved_instrument_id, issuer_cik=issuer_cik))
+    except ValueError:
+        # Garbage non-numeric CIK (siblings_for_issuer_cik fail-fast).
+        # Surface the DQ issue in the log but still refresh the rows we
+        # KNOW about — total failure would freeze them on the old parser,
+        # which is the exact bug this helper exists to fix (Codex ckpt-2).
+        logger.warning(
+            "def14a rewash: non-numeric issuer_cik=%r for accession=%s; "
+            "sibling resolution skipped, refreshing known comp instruments only",
+            issuer_cik,
+            raw_doc.accession_number,
+        )
+        instrument_ids = set()
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -719,6 +732,22 @@ def _rewash_exec_comp_all_instruments(
             issuer_cik=issuer_cik,
             instrument_id=iid,
         )
+
+    if total > 0:
+        # Belt-and-braces: comp.instrument_id is nullable by schema
+        # (CIK-resolved post-parse, mirror 097) and the per-instrument
+        # DELETE above can never reach a NULL-keyed row — it would
+        # survive every rewash and get version-pinned. Live population
+        # is 0 (dev full-pop check 2026-07-22), so this is a latent
+        # guard, not a data path (Codex ckpt-2).
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DELETE FROM def14a_exec_compensation
+                WHERE accession_number = %s AND instrument_id IS NULL
+                """,
+                (raw_doc.accession_number,),
+            )
     return total
 
 

--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -603,11 +603,11 @@ def _apply_def14a(
         # meaningfully rewashed at v3 → True (bumps parser_version).
         # No comp either → keep the pre-existing rescue semantics:
         # skip without bumping so a future improved parser re-tries.
-        comp_written = _rewash_exec_comp(
+        comp_written = _rewash_exec_comp_all_instruments(
             conn,
             raw_doc=raw_doc,
             issuer_cik=str(issuer_cik),
-            instrument_id=int(instrument_id),
+            resolved_instrument_id=int(instrument_id),
         )
         return comp_written > 0
 
@@ -649,13 +649,77 @@ def _apply_def14a(
 
     # Item 402(c) exec-comp rewash (#1945; helper shared with the
     # rescue-cohort branch above since #2086).
-    _rewash_exec_comp(
+    _rewash_exec_comp_all_instruments(
         conn,
         raw_doc=raw_doc,
         issuer_cik=str(issuer_cik),
-        instrument_id=int(instrument_id),
+        resolved_instrument_id=int(instrument_id),
     )
     return True
+
+
+def _rewash_exec_comp_all_instruments(
+    conn: psycopg.Connection[Any],
+    *,
+    raw_doc: RawFilingDocument,
+    issuer_cik: str,
+    resolved_instrument_id: int,
+) -> int:
+    """#2105 — comp rewash must cover every sibling share-class instrument.
+
+    One DEF 14A accession legitimately owns exec-comp rows under EVERY
+    sibling instrument of the issuer (Reg S-K Item 402 SCT is
+    registrant-level disclosure; first ingest writes it once per sibling
+    as each sibling's manifest row ingests the accession independently).
+    ``_apply_def14a``'s accession resolution picks ONE sibling
+    (``LIMIT 1``), so a single-instrument comp rewash froze the other
+    siblings' rows on the old parser (#2105: GOOG 'Sundar' stale next to
+    GOOGL 'Sundar Pichai' clean, 89 accessions full-pop). Re-apply the
+    comp rewash for every instrument that already has comp rows for this
+    accession, plus the resolved one.
+
+    Sibling set = ``_resolve_siblings`` (the SAME resolver the live
+    manifest ingest fans out with, so rewash output converges to what a
+    fresh first-ingest under the current parser would write) UNION every
+    instrument that already has comp rows for the accession (so a
+    historical row under an instrument that has since left the sibling
+    set is refreshed rather than frozen on the old parser).
+
+    Per-sibling ``_rewash_exec_comp`` calls re-parse the same body
+    (2-5 siblings, offline rewash cadence — accepted over threading a
+    parsed table through the SAVEPOINT-per-instrument isolation).
+    ``RewashParseError`` from any sibling propagates → the whole
+    accession fails + retries, matching the single-instrument contract.
+
+    Returns total comp rows written across siblings.
+    """
+    # Function-local import per this file's def14a convention (and the
+    # #1731 manifest_parsers init-order trap).
+    from app.services.manifest_parsers.def14a import _resolve_siblings
+
+    instrument_ids = set(_resolve_siblings(conn, instrument_id=resolved_instrument_id, issuer_cik=issuer_cik))
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT DISTINCT instrument_id
+            FROM def14a_exec_compensation
+            WHERE accession_number = %s
+              AND instrument_id IS NOT NULL
+            """,
+            (raw_doc.accession_number,),
+        )
+        instrument_ids.update(int(row[0]) for row in cur.fetchall())
+    instrument_ids.add(resolved_instrument_id)
+
+    total = 0
+    for iid in sorted(instrument_ids):
+        total += _rewash_exec_comp(
+            conn,
+            raw_doc=raw_doc,
+            issuer_cik=issuer_cik,
+            instrument_id=iid,
+        )
+    return total
 
 
 def _rewash_exec_comp(

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -1051,8 +1051,9 @@ def test_def14a_rewash_refreshes_comp_on_all_sibling_instruments(
     conn = ebull_test_conn
     resolved_id = 950_090
     sibling_id = 950_091
+    resolver_only_id = 950_092  # in the CIK sibling set, NO existing comp rows
     accession = "0001234567-26-000004"
-    for iid, sym in ((resolved_id, "D14SA"), (sibling_id, "D14SB")):
+    for iid, sym in ((resolved_id, "D14SA"), (sibling_id, "D14SB"), (resolver_only_id, "D14SC")):
         conn.execute(
             """
             INSERT INTO instruments (
@@ -1062,6 +1063,17 @@ def test_def14a_rewash_refreshes_comp_on_all_sibling_instruments(
             """,
             (iid, sym),
         )
+    # The _resolve_siblings half of the union: resolver_only_id co-binds the
+    # issuer CIK in external_identifiers, proving a row-less current sibling
+    # gets comp written fresh (rewash converges to first-ingest fan-out).
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (
+            instrument_id, provider, identifier_type, identifier_value, is_primary
+        ) VALUES (%s, 'sec', 'cik', '0000999002', FALSE)
+        """,
+        (resolver_only_id,),
+    )
     # Happy-path resolution: holdings row under the RESOLVED instrument only.
     conn.execute(
         """
@@ -1072,8 +1084,10 @@ def test_def14a_rewash_refreshes_comp_on_all_sibling_instruments(
         """,
         (resolved_id, accession),
     )
-    # Stale truncated-name comp rows under BOTH siblings (old-parser output).
-    for iid in (resolved_id, sibling_id):
+    # Stale truncated-name comp rows under BOTH siblings (old-parser output),
+    # plus a NULL-instrument legacy row the per-instrument DELETE can never
+    # reach — the post-rewash sweep must clear it.
+    for iid in (resolved_id, sibling_id, None):
         conn.execute(
             """
             INSERT INTO def14a_exec_compensation (
@@ -1148,10 +1162,13 @@ def test_def14a_rewash_refreshes_comp_on_all_sibling_instruments(
             (accession,),
         )
         rows = cur.fetchall()
-    # BOTH siblings refreshed to the new parse; no stale 'Sundar' anywhere.
+    # ALL siblings refreshed to the new parse — including the row-less
+    # resolver-only sibling — and neither the stale 'Sundar' rows nor the
+    # NULL-instrument legacy row survive.
     assert rows == [
         (resolved_id, "Sundar Pichai"),
         (sibling_id, "Sundar Pichai"),
+        (resolver_only_id, "Sundar Pichai"),
     ]
 
 

--- a/tests/test_rewash_filings.py
+++ b/tests/test_rewash_filings.py
@@ -1029,6 +1029,132 @@ def test_def14a_rescue_with_no_ownership_table_still_rewashes_exec_comp(
     assert holdings_count is not None and holdings_count[0] == 0
 
 
+def test_def14a_rewash_refreshes_comp_on_all_sibling_instruments(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_registry: None,
+) -> None:
+    """#2105 — one DEF 14A accession owns exec-comp rows under EVERY
+    share-class sibling instrument (live ingest fans out via
+    ``_resolve_siblings``), but ``_apply_def14a`` resolves ONE
+    instrument (``LIMIT 1``). The comp rewash must refresh ALL
+    instruments holding comp rows for the accession, not just the
+    resolved one — GOOG kept stale truncated 'Sundar' rows while
+    GOOGL got the repaired 'Sundar Pichai' (89 accessions full-pop)."""
+    from app.providers.implementations.sec_def14a import (
+        Def14ABeneficialHolder,
+        Def14ABeneficialOwnershipTable,
+        Def14AExecCompRow,
+        Def14ASummaryCompTable,
+    )
+
+    conn = ebull_test_conn
+    resolved_id = 950_090
+    sibling_id = 950_091
+    accession = "0001234567-26-000004"
+    for iid, sym in ((resolved_id, "D14SA"), (sibling_id, "D14SB")):
+        conn.execute(
+            """
+            INSERT INTO instruments (
+                instrument_id, symbol, company_name, exchange, currency, is_tradable
+            ) VALUES (%s, %s, 'DEF 14A Sibling', '4', 'USD', TRUE)
+            ON CONFLICT (instrument_id) DO NOTHING
+            """,
+            (iid, sym),
+        )
+    # Happy-path resolution: holdings row under the RESOLVED instrument only.
+    conn.execute(
+        """
+        INSERT INTO def14a_beneficial_holdings (
+            instrument_id, accession_number, issuer_cik,
+            holder_name, holder_role, shares, percent_of_class, as_of_date
+        ) VALUES (%s, %s, '0000999002', 'Holder A', 'officer', 100, 5.0, '2025-01-01')
+        """,
+        (resolved_id, accession),
+    )
+    # Stale truncated-name comp rows under BOTH siblings (old-parser output).
+    for iid in (resolved_id, sibling_id):
+        conn.execute(
+            """
+            INSERT INTO def14a_exec_compensation (
+                instrument_id, accession_number, issuer_cik,
+                executive_name, fiscal_year, total_comp
+            ) VALUES (%s, %s, '0000999002', 'Sundar', 2024, 1.00)
+            """,
+            (iid, accession),
+        )
+    _seed_raw(conn, accession=accession, kind="def14a_body", parser_version="def14a-v0")
+    conn.commit()
+
+    ownership = Def14ABeneficialOwnershipTable(
+        as_of_date=None,
+        rows=[
+            Def14ABeneficialHolder(
+                holder_name="Holder A",
+                holder_role="officer",
+                shares=Decimal("100"),
+                percent_of_class=Decimal("5.0"),
+            ),
+        ],
+        raw_table_score=10,
+    )
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_def14a.parse_beneficial_ownership_table",
+        lambda _html: ownership,
+    )
+    sct = Def14ASummaryCompTable(
+        rows=(
+            Def14AExecCompRow(
+                executive_name="Sundar Pichai",
+                principal_position="Chief Executive Officer",
+                fiscal_year=2024,
+                salary=Decimal("650000"),
+                bonus=None,
+                stock_awards=None,
+                option_awards=None,
+                non_equity_incentive=None,
+                pension_nqdc=None,
+                other_comp=None,
+                total_comp=Decimal("650000"),
+            ),
+        ),
+        raw_table_score=20,
+    )
+    monkeypatch.setattr(
+        "app.providers.implementations.sec_def14a.parse_summary_compensation_table",
+        lambda _html: sct,
+    )
+
+    rewash_filings._REGISTRY.clear()
+    register_parser(
+        ParserSpec(
+            document_kind="def14a_body",
+            current_version="def14a-v1",
+            apply_fn=rewash_filings._apply_def14a,
+        )
+    )
+
+    result = rewash_filings.run_rewash(conn, document_kind="def14a_body")
+    assert result.rows_reparsed == 1
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT instrument_id, executive_name
+            FROM def14a_exec_compensation
+            WHERE accession_number = %s
+            ORDER BY instrument_id
+            """,
+            (accession,),
+        )
+        rows = cur.fetchall()
+    # BOTH siblings refreshed to the new parse; no stale 'Sundar' anywhere.
+    assert rows == [
+        (resolved_id, "Sundar Pichai"),
+        (sibling_id, "Sundar Pichai"),
+    ]
+
+
 def test_blockholders_apply_raises_on_parse_failure(
     ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #2105.

## What
`_apply_def14a` resolves ONE `(issuer_cik, instrument_id)` per accession (`LIMIT 1`), but live ingest fans exec-comp to every share-class sibling via `_resolve_siblings` (schema-documented model, sql/215). The comp rewash therefore refreshed only the resolved sibling — dual-class siblings kept old-parser rows frozen: GOOG served stale 'Sundar' next to GOOGL's repaired 'Sundar Pichai'; METCB operator-visibly served bare first names. 89 accessions full-pop (dev, 2026-07-22).

New `_rewash_exec_comp_all_instruments` (both call sites — happy + rescue):
- sibling set = `_resolve_siblings` (SAME resolver as live ingest → rewash converges to fresh-first-ingest output) UNION instruments already holding comp rows for the accession (historical strays refresh rather than freeze)
- per-sibling `_rewash_exec_comp` — SAVEPOINT isolation, regression-raise, accession write lock unchanged
- rescue-branch parser_version bump now counts comp written across ALL siblings
- garbage non-numeric `issuer_cik`: log warning + refresh known instruments (fail-fast would freeze rows on the old parser — the exact bug being fixed)
- post-rewash sweep DELETEs NULL-instrument legacy comp rows (unreachable by per-instrument DELETE; live population 0 — latent guard)

## Source rule
Reg S-K Item 402 SCT is **registrant-level** disclosure — one proxy covers the issuer, identical comp for every share class. Storage model (sql/215 comment): comp fans out per sibling instrument via `_resolve_siblings`. Rewash must mirror that fan-out; refreshing one sibling violates the documented model.

## Full-population verification
- 89 accessions hold comp under ≥2 instruments (`GROUP BY accession HAVING COUNT(DISTINCT instrument_id)>1`)
- 11 of 27 distinct single-token `executive_name` values on the live table are this class (GOOG×6, METCB×5) — see #2100 verification comment on PR #2103
- NULL-instrument comp rows: 0 live (latent guard only)

## Tradeoffs
- Per-sibling body re-parse (2-5×, offline rewash cadence) accepted over threading a parsed table through the SAVEPOINT-per-instrument isolation — KISS.
- A sibling with existing rows whose re-parse yields zero comp now raises (regression surfacing) where the old code silently skipped that sibling — consistent with the single-instrument contract.

## Security model
No new external input. Rewash reads stored SEC bodies (already-ingested, parser hardened per #1967 bounded-modifier entry); SQL parameterised throughout; no endpoint changes.

## Tests
- New db-tier `test_def14a_rewash_refreshes_comp_on_all_sibling_instruments`: stale rows under resolved+sibling+NULL, row-less resolver-only CIK sibling → all three instruments get fresh rows, stale + NULL rows gone.
- Gates: ruff ✓ format ✓ pyright 0 errors ✓ fast tier 5337 passed ✓ smoke 153 passed ✓ db-tier def14a rewash tests 5 passed ✓. Codex ckpt-2 run — both Mediums + test gap fixed (commit 2).

## ETL clauses 8-12 (post-merge)
Targeted re-rewash of the 89 accessions (reset their `parser_version` → rerun `scripts/rewash.py --kind def14a_body`) + endpoint verify METCB/GOOG/panel — will comment invocation + figures here after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)