### PR TITLE
fix(#1857): value family prices off latest price_daily close — 0.5 default drops from 97% to 19% (model v1.4, operator-gated)

### DIFF
--- a/.claude/skills/engineering/sql-correctness.md
+++ b/.claude/skills/engineering/sql-correctness.md
@@ -121,6 +121,18 @@ When a query selects an anchor in one CTE (a winner accession, a target period, 
 
 Self-check: for each CTE that computes a `MAX(...)`/`ORDER BY ... LIMIT 1` anchor, diff its WHERE clause against the final SELECT's — any predicate present in one and not the other needs a reason in a comment. Origin: PR #1588 review WARNING (`target` CTE missing `NOT is_subtotal` carried by winner + main query).
 
+## View recreate — diff the outer SELECT column list old vs new
+
+A `DROP VIEW` + `CREATE VIEW` migration replaces the reader contract wholesale; an accidentally dropped (or reordered-and-renamed) output column breaks every consumer silently at read time, not at migrate time. Before committing a view recreate, diff the two files' outer SELECT lists mechanically, e.g.:
+
+```bash
+for f in sql/OLD_view.sql sql/NEW_view.sql; do
+  sed -n '/^SELECT$/,/^FROM (/p' "$f" | grep -oE "AS [a-z_]+|v\.[a-z_]+" | sed 's/AS //; s/v\.//' | tr '\n' ' '; echo "<- $f"
+done
+```
+
+Identical output ⇒ contract preserved; any delta needs a stated reason in the migration header. Inner-CTE columns (UNION-shape padding like `NULL::numeric AS x`) are NOT part of the contract — a reviewer flagging one as "dropped" is refutable by exactly this diff (PR #2115 review WARNING, sql/236). Origin: PR #2115.
+
 ## Never edit an applied migration — bump to a new NNN+1 file
 
 The runner records each applied file's SHA-256 in `schema_migrations.content_sha256` (#1333) and **raises at boot** if an applied file's content changed. Editing `sql/NNN_*.sql` after any DB recorded it (dev included — drafts applied during PR development count) is therefore a boot-breaker, not a silent no-op. All follow-up changes go into a new `NNN+1` file. If you knowingly replayed an edited file manually (idempotent), reset its hash: `UPDATE schema_migrations SET content_sha256 = NULL WHERE filename = '<file>'` — never DELETE the row. Full RCA in `docs/review-prevention-log.md` ("Migration content drift").

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -327,7 +327,7 @@ class PeerFactor(BaseModel):
     instrument_value: float | None
     cohort_median: float | None
     cohort_n: int  # # cohort members with a non-null value for this factor
-    dev_limited: bool  # True when thin: price-gated (P/E) OR cohort coverage <20% (#1836)
+    dev_limited: bool  # True when thin: cohort coverage <20% (#1836; P/E price gate lifted by sql/236)
     better_when: Literal["higher", "lower"]
 
 
@@ -987,8 +987,9 @@ def get_instrument_peer_comparison(
     size-proximity peer set — all derived server-side from existing fundamentals
     (no new ingest). Cohort = SEC SIC walked 4→3→2 to the narrowest level with
     ``MIN_COHORT`` peers (``cohort_sic_level``; 0 = SIC-2 fallback, thin). A
-    factor is ``dev_limited`` (thin: greyed + ⚠) when price-gated (P/E) OR its
-    cohort coverage is <20% (#1836). 404 when the instrument has no SIC
+    factor is ``dev_limited`` (thin: greyed + ⚠) when its cohort coverage is
+    <20% (#1836; the P/E structural price gate was lifted by sql/236, #1857).
+    404 when the instrument has no SIC
     classification or no complete-TTM fundamentals. Policy lives in
     app/services/peer_comparison.py (``resolve_sic_level``, ``is_factor_thin``).
     """

--- a/app/services/peer_comparison.py
+++ b/app/services/peer_comparison.py
@@ -6,8 +6,9 @@ operating margin, debt/equity, net margin), their cohort medians, and a peer
 set — entirely from EXISTING tables (no new ingest):
 
   * price-free factors from ``financial_periods_ttm`` (is_complete_ttm),
-  * ``pe_ratio`` from the ``instrument_valuation`` view (price-gated → thin on
-    dev; flagged ``dev_limited`` by the caller),
+  * ``pe_ratio`` from the ``instrument_valuation`` view (universe-wide since
+    sql/236 priced the view off the latest ``price_daily`` close, #1857;
+    thinness is governed by the ordinary coverage ratio like any factor),
   * ``revenue_growth_yoy`` from the two most recent canonical FY rows in
     ``financial_periods``, with a consecutive-year day-gap guard,
   * cohort medians via ``percentile_cont`` over the SIC cohort's complete-TTM set,
@@ -23,9 +24,10 @@ sql/221). Unlike the band (which goes comparator-absent under threshold),
 peer_comparison is a DISCLOSURE surface: under threshold it widens to SIC-2 and
 renders thin (``cohort_sic_level == 0``), never absent.
 
-Factor formulas MIRROR ``instrument_valuation`` (sql/201) — do not re-derive.
-The view's ~32-row ceiling is its live-price join; bypassed here by reading
-``financial_periods_ttm`` directly for the price-free factors.
+Factor formulas MIRROR ``instrument_valuation`` (sql/236) — do not re-derive.
+The price-free factors still read ``financial_periods_ttm`` directly (no view
+dependency for figures that need no price; the historical ~32-row live-price
+ceiling was lifted by sql/236's price_daily fallback).
 """
 
 from __future__ import annotations
@@ -100,9 +102,12 @@ FACTOR_BETTER_WHEN: dict[str, str] = {
     "debt_equity_ratio": "lower",
     "net_margin": "higher",
 }
-# pe_ratio is price-gated (instrument_valuation live-price join) → structurally
-# thin on dev regardless of how many sector members exist.
-DEV_LIMITED_FACTORS: frozenset[str] = frozenset({"pe_ratio"})
+# Empty since #1857 (sql/236): pe_ratio was structurally price-gated while
+# instrument_valuation joined only the live-quote snapshot; the price_daily
+# fallback lifted that, so its thinness is now governed by the ordinary
+# coverage-ratio test below. Kept as the hook for any future factor whose
+# source is structurally absent on dev.
+DEV_LIMITED_FACTORS: frozenset[str] = frozenset()
 
 # A factor is "thin" (greyed + ⚠ in the UI, its sector median read as noisy) when
 # it is either structurally dev-limited OR its sector coverage is below this

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -44,15 +44,18 @@ from app.services.xbrl_derived_stats import (
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL_VERSION = "v1.3-balanced"
+_DEFAULT_MODEL_VERSION = "v1.4-balanced"
 
 # Model-version prefix gates (single source — the next version is a one-line add,
 # not a scattered string edit). TA-enhanced momentum applies from v1.1; the
 # realized-risk penalty from v1.2; both carry forward to v1.3 (which only ADDS the
 # Calmar reward on top — Codex ckpt-1 HIGH: v1.3 must inherit v1.2 behavior).
-_TA_MOMENTUM_PREFIXES: tuple[str, ...] = ("v1.1", "v1.2", "v1.3")
-_RISK_PENALTY_PREFIXES: tuple[str, ...] = ("v1.2", "v1.3")
-_CALMAR_REWARD_PREFIXES: tuple[str, ...] = ("v1.3",)
+# v1.4 inherits ALL v1.3 behavior — the bump marks the #1857 value-input change
+# (instrument_valuation priced off price_daily fallback, sql/236), not a
+# scoring-code change.
+_TA_MOMENTUM_PREFIXES: tuple[str, ...] = ("v1.1", "v1.2", "v1.3", "v1.4")
+_RISK_PENALTY_PREFIXES: tuple[str, ...] = ("v1.2", "v1.3", "v1.4")
+_CALMAR_REWARD_PREFIXES: tuple[str, ...] = ("v1.3", "v1.4")
 
 # ---------------------------------------------------------------------------
 # Weight modes  (must sum to 1.0)
@@ -159,6 +162,37 @@ _WEIGHT_MODES: dict[str, dict[str, float]] = {
         "turnaround": 0.05,
     },
     "v1.3-speculative": {
+        "turnaround": 0.30,
+        "value": 0.25,
+        "momentum": 0.15,
+        "confidence": 0.15,
+        "sentiment": 0.10,
+        "quality": 0.05,
+    },
+    # v1.4 — identical family weights to v1.3. The bump marks the #1857
+    # value-INPUT change (sql/236: instrument_valuation prices off the
+    # latest price_daily close when no live quote exists, so pe_ratio /
+    # fcf_yield populate for ~3,900 names instead of ~60 and the value
+    # family stops returning the 0.5 empty-components default for 97% of
+    # the universe). rank_delta only ever compares within a model_version,
+    # so v1.3 history stays internally consistent.
+    "v1.4-balanced": {
+        "quality": 0.25,
+        "value": 0.25,
+        "turnaround": 0.20,
+        "confidence": 0.15,
+        "momentum": 0.10,
+        "sentiment": 0.05,
+    },
+    "v1.4-conservative": {
+        "quality": 0.35,
+        "value": 0.25,
+        "confidence": 0.20,
+        "momentum": 0.10,
+        "sentiment": 0.05,
+        "turnaround": 0.05,
+    },
+    "v1.4-speculative": {
         "turnaround": 0.30,
         "value": 0.25,
         "momentum": 0.15,

--- a/sql/236_instrument_valuation_price_daily_fallback.sql
+++ b/sql/236_instrument_valuation_price_daily_fallback.sql
@@ -1,0 +1,300 @@
+-- 236_instrument_valuation_price_daily_fallback.sql
+--
+-- #1857: the instrument_valuation VIEW (sql/080, recreated sql/201) gated
+-- its ``priced`` CTE on the ``quotes`` live snapshot — ~69-97 rows (only
+-- quote-subscribed instruments), while ``price_daily`` carries a strictly
+-- positive daily close for ~5,200 instruments and financial_periods_ttm
+-- has ~3,900 complete-TTM rows. Value was the ONLY scoring family priced
+-- off the live snapshot; the resulting empty-components path returned the
+-- 0.5 neutral default for 97% of the scored universe (full-pop verified
+-- 2026-06-29 and re-verified 2026-07-23: 3,804/3,920 latest v1.3-balanced
+-- value_score exactly 0.5) — precisely the "papered-over neutral" the
+-- ranking-engine failure-mode clause forbids.
+--
+-- Fix: FULL OUTER JOIN the live quote with the latest strictly-positive
+-- ``price_daily`` close and pick by RECENCY: the quote wins iff its
+-- quoted_at date is >= the close's price_date (a same-day quote is the
+-- fresher intraday figure), otherwise the daily close wins. NOT a
+-- blind quote-first COALESCE — the quotes snapshot only refreshes for
+-- subscribed instruments, and dev-verify showed weeks-stale quotes
+-- (AAPL quoted 07-09 vs close 07-23) shadowing fresher closes across
+-- most of the smoke panel. For a long-horizon engine the latest daily
+-- close is a correct valuation denominator. The as-of stamp follows the
+-- price actually chosen (quote → quoted_at; daily close → its
+-- price_date, data-anchored per the market-data skill — never
+-- wall-clock). Both sources are eToro-native prices (#1906), so the
+-- currency basis of every ratio is unchanged.
+--
+-- Scoring impact: value-family inputs (pe_ratio, fcf_yield) become
+-- non-NULL for ~3,900 names → headline ranks shift → model_version bump
+-- to v1.4 rides in the same PR (ranking-engine invariant: bump when an
+-- EXISTING metric's computation changes).
+--
+-- #1664 dual-class suppression is preserved verbatim (the dc CTE and the
+-- CASE suppression of shares-distorted columns are untouched).
+--
+-- View recreate only — no data backfill. Idempotent (DROP VIEW IF EXISTS).
+
+BEGIN;
+
+DROP VIEW IF EXISTS instrument_valuation;
+
+CREATE VIEW instrument_valuation AS
+WITH dual_class AS (
+    -- Curated dual-class instruments: primary SEC CIK present in the
+    -- #1623 per-class FSDS table. Both share-class siblings of a covered
+    -- CIK appear (the table is keyed per sibling instrument_id).
+    SELECT DISTINCT ei.instrument_id
+    FROM external_identifiers ei
+    JOIN instrument_class_shares_outstanding c
+      ON c.source_cik = lpad(ei.identifier_value, 10, '0')
+    WHERE ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+      AND ei.is_primary = TRUE
+),
+priced AS (
+    -- #1857: freshest price wins. The quote is used iff it is at least
+    -- as recent (by date) as the latest strictly-positive daily close —
+    -- a stale snapshot quote must not shadow a fresher close. The
+    -- strictly-positive close filter mirrors compute_day_change's rule
+    -- (a non-positive close is a sentinel, not a price). The as-of
+    -- stamp pairs with the price actually used.
+    SELECT
+        instrument_id,
+        CASE WHEN q.price IS NOT NULL
+                  AND (pd.price_date IS NULL OR q.quoted_at::date >= pd.price_date)
+             THEN q.price
+             ELSE pd.close
+        END AS price,
+        CASE WHEN q.price IS NOT NULL
+                  AND (pd.price_date IS NULL OR q.quoted_at::date >= pd.price_date)
+             THEN q.quoted_at
+             ELSE pd.price_date::timestamptz
+        END AS quoted_at
+    FROM (
+        SELECT instrument_id,
+               COALESCE(
+                   NULLIF(GREATEST(last, 0), 0),
+                   CASE WHEN bid > 0 AND ask > 0 THEN (bid + ask) / 2 END
+               )                    AS price,
+               quoted_at
+        FROM quotes
+    ) q
+    FULL OUTER JOIN (
+        SELECT DISTINCT ON (instrument_id)
+               instrument_id,
+               close,
+               price_date
+        FROM price_daily
+        WHERE close > 0
+        ORDER BY instrument_id, price_date DESC
+    ) pd USING (instrument_id)
+),
+new_pipeline AS (
+    SELECT
+        p.instrument_id,
+        p.price,
+        p.quoted_at,
+        ttm.revenue_ttm,
+        ttm.net_income_ttm,
+        ttm.operating_income_ttm,
+        ttm.gross_profit_ttm,
+        ttm.depreciation_amort_ttm,
+        ttm.operating_cf_ttm,
+        ttm.capex_ttm,
+        ttm.dps_declared_ttm,
+        ttm.is_complete_ttm,
+        ttm.eps_diluted_ttm,
+        ttm.total_assets,
+        ttm.total_liabilities,
+        ttm.shareholders_equity,
+        ttm.cash,
+        ttm.long_term_debt,
+        ttm.short_term_debt,
+        ttm.shares_outstanding,
+        CASE WHEN p.price > 0 AND ttm.shares_outstanding > 0
+             THEN p.price * ttm.shares_outstanding
+        END AS market_cap_live,
+        CASE WHEN p.price > 0 AND ttm.shares_outstanding > 0
+             THEN p.price * ttm.shares_outstanding
+                  + COALESCE(ttm.long_term_debt, 0)
+                  + COALESCE(ttm.short_term_debt, 0)
+                  - COALESCE(ttm.cash, 0)
+        END AS enterprise_value,
+        CASE WHEN ttm.eps_diluted_ttm > 0
+             THEN p.price / ttm.eps_diluted_ttm
+        END AS pe_ratio,
+        CASE WHEN ttm.shareholders_equity > 0 AND ttm.shares_outstanding > 0
+             THEN p.price / (ttm.shareholders_equity / ttm.shares_outstanding)
+        END AS pb_ratio,
+        CASE WHEN ttm.revenue_ttm > 0 AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding) / ttm.revenue_ttm
+        END AS price_sales,
+        CASE WHEN (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0))) > 0
+                  AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding)
+                  / (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)))
+        END AS p_fcf_ratio,
+        CASE WHEN p.price > 0 AND ttm.shares_outstanding > 0
+                  AND (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0))) IS NOT NULL
+             THEN (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)))
+                  / (p.price * ttm.shares_outstanding)
+        END AS fcf_yield,
+        CASE WHEN ttm.shareholders_equity > 0
+             THEN (COALESCE(ttm.long_term_debt, 0) + COALESCE(ttm.short_term_debt, 0))
+                  / ttm.shareholders_equity
+        END AS debt_equity_ratio,
+        CASE WHEN ttm.revenue_ttm > 0 AND p.price > 0 AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding
+                   + COALESCE(ttm.long_term_debt, 0)
+                   + COALESCE(ttm.short_term_debt, 0)
+                   - COALESCE(ttm.cash, 0))
+                  / ttm.revenue_ttm
+        END AS ev_revenue,
+        CASE WHEN (ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0)) > 0
+                  AND p.price > 0 AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding
+                   + COALESCE(ttm.long_term_debt, 0)
+                   + COALESCE(ttm.short_term_debt, 0)
+                   - COALESCE(ttm.cash, 0))
+                  / (ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0))
+        END AS ev_ebitda,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.net_income_ttm / ttm.revenue_ttm
+        END AS net_margin,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.gross_profit_ttm / ttm.revenue_ttm
+        END AS gross_margin,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.operating_income_ttm / ttm.revenue_ttm
+        END AS operating_margin,
+        CASE WHEN ttm.total_assets > 0
+             THEN ttm.net_income_ttm / ttm.total_assets
+        END AS roa,
+        CASE WHEN ttm.shareholders_equity > 0
+             THEN ttm.net_income_ttm / ttm.shareholders_equity
+        END AS roe,
+        CASE WHEN p.price > 0 AND ttm.dps_declared_ttm > 0
+             THEN ttm.dps_declared_ttm / p.price * 100
+        END AS dividend_yield,
+        ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0) AS ebitda_ttm,
+        ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)) AS fcf_ttm
+    FROM priced p
+    JOIN financial_periods_ttm ttm USING (instrument_id)
+    WHERE ttm.is_complete_ttm = TRUE
+),
+legacy AS (
+    SELECT DISTINCT ON (fs.instrument_id)
+        p.instrument_id,
+        p.price,
+        p.quoted_at,
+        NULL::numeric AS revenue_ttm,
+        NULL::numeric AS net_income_ttm,
+        NULL::numeric AS operating_income_ttm,
+        NULL::numeric AS gross_profit_ttm,
+        NULL::numeric AS depreciation_amort_ttm,
+        NULL::numeric AS operating_cf_ttm,
+        NULL::numeric AS capex_ttm,
+        NULL::numeric AS dps_declared_ttm,
+        NULL::boolean AS is_complete_ttm,
+        NULL::numeric AS eps_diluted_ttm,
+        NULL::numeric AS total_assets,
+        NULL::numeric AS total_liabilities,
+        NULL::numeric AS shareholders_equity,
+        fs.cash,
+        fs.debt AS long_term_debt,
+        NULL::numeric AS short_term_debt,
+        fs.shares_outstanding,
+        CASE WHEN p.price > 0 AND fs.shares_outstanding > 0
+             THEN p.price * fs.shares_outstanding
+        END AS market_cap_live,
+        NULL::numeric AS enterprise_value,
+        CASE WHEN p.price > 0 AND fs.eps > 0
+             THEN p.price / fs.eps
+        END AS pe_ratio,
+        CASE WHEN p.price > 0 AND fs.book_value > 0
+             THEN p.price / fs.book_value
+        END AS pb_ratio,
+        NULL::numeric AS price_sales,
+        CASE WHEN p.price > 0 AND fs.shares_outstanding > 0 AND fs.fcf > 0
+             THEN (p.price * fs.shares_outstanding) / fs.fcf
+        END AS p_fcf_ratio,
+        CASE WHEN p.price > 0 AND fs.shares_outstanding > 0
+             THEN fs.fcf / (p.price * fs.shares_outstanding)
+        END AS fcf_yield,
+        CASE WHEN fs.book_value > 0 AND fs.shares_outstanding > 0
+             THEN fs.debt / (fs.book_value * fs.shares_outstanding)
+        END AS debt_equity_ratio,
+        NULL::numeric AS ev_revenue,
+        NULL::numeric AS ev_ebitda,
+        NULL::numeric AS net_margin,
+        fs.gross_margin,
+        fs.operating_margin,
+        NULL::numeric AS roa,
+        NULL::numeric AS roe,
+        NULL::numeric AS dividend_yield,
+        NULL::numeric AS ebitda_ttm,
+        fs.fcf AS fcf_ttm
+    FROM priced p
+    JOIN fundamentals_snapshot fs USING (instrument_id)
+    WHERE NOT EXISTS (
+        SELECT 1 FROM financial_periods_ttm ttm
+        WHERE ttm.instrument_id = p.instrument_id
+          AND ttm.is_complete_ttm = TRUE
+    )
+    ORDER BY fs.instrument_id, fs.as_of_date DESC
+)
+SELECT
+    v.instrument_id,
+    v.price              AS current_price,
+    v.quoted_at          AS price_as_of,
+    v.revenue_ttm,
+    v.net_income_ttm,
+    v.operating_income_ttm,
+    v.gross_profit_ttm,
+    v.depreciation_amort_ttm,
+    v.operating_cf_ttm,
+    v.capex_ttm,
+    v.dps_declared_ttm,
+    v.is_complete_ttm,
+    v.total_assets,
+    v.total_liabilities,
+    v.shareholders_equity,
+    v.cash,
+    v.long_term_debt,
+    v.short_term_debt,
+    v.shares_outstanding,
+    -- #1664: NULL the shares-distorted columns for curated dual-class
+    -- issuers (combined-shares × one-class-price is structurally wrong).
+    -- The correct total-company figure is sourced in Python by the
+    -- decision-grade consumer via resolve_market_cap_basis.
+    CASE WHEN dc.instrument_id IS NULL THEN v.market_cap_live END   AS market_cap_live,
+    CASE WHEN dc.instrument_id IS NULL THEN v.enterprise_value END  AS enterprise_value,
+    v.pe_ratio,
+    CASE WHEN dc.instrument_id IS NULL THEN v.pb_ratio END          AS pb_ratio,
+    CASE WHEN dc.instrument_id IS NULL THEN v.price_sales END       AS price_sales,
+    CASE WHEN dc.instrument_id IS NULL THEN v.p_fcf_ratio END       AS p_fcf_ratio,
+    CASE WHEN dc.instrument_id IS NULL THEN v.fcf_yield END         AS fcf_yield,
+    v.debt_equity_ratio,
+    CASE WHEN dc.instrument_id IS NULL THEN v.ev_revenue END        AS ev_revenue,
+    CASE WHEN dc.instrument_id IS NULL THEN v.ev_ebitda END         AS ev_ebitda,
+    v.net_margin,
+    v.gross_margin,
+    v.operating_margin,
+    v.roa,
+    v.roe,
+    -- forward_pe always NULL: source (analyst_estimates) dropped in
+    -- sql/080. Column retained for shape compatibility with any external
+    -- (operator-curated SQL, BI tool) reader.
+    NULL::numeric AS forward_pe,
+    v.dividend_yield,
+    v.ebitda_ttm,
+    v.fcf_ttm
+FROM (
+    SELECT * FROM new_pipeline
+    UNION ALL
+    SELECT * FROM legacy
+) v
+LEFT JOIN dual_class dc USING (instrument_id);
+
+COMMIT;

--- a/sql/236_instrument_valuation_price_daily_fallback.sql
+++ b/sql/236_instrument_valuation_price_daily_fallback.sql
@@ -52,26 +52,47 @@ WITH dual_class AS (
       AND ei.identifier_type = 'cik'
       AND ei.is_primary = TRUE
 ),
-priced AS (
+priced AS NOT MATERIALIZED (
     -- #1857: freshest price wins. The quote is used iff it is at least
-    -- as recent (by date) as the latest strictly-positive daily close —
-    -- a stale snapshot quote must not shadow a fresher close. The
-    -- strictly-positive close filter mirrors compute_day_change's rule
-    -- (a non-positive close is a sentinel, not a price). The as-of
-    -- stamp pairs with the price actually used.
+    -- as recent (by UTC date — the ::date cast is pinned so a session
+    -- timezone cannot flip the winner near midnight) as the latest
+    -- strictly-positive daily close — a stale snapshot quote must not
+    -- shadow a fresher close. The strictly-positive close filter mirrors
+    -- compute_day_change's rule (a non-positive close is a sentinel, not
+    -- a price). The as-of stamp pairs with the price actually used.
+    --
+    -- Shape: driving id-set (both sources' instrument ids, index-only
+    -- scans) + LEFT JOIN quotes + LEFT JOIN LATERAL latest-close. NOT a
+    -- FULL OUTER JOIN over a global DISTINCT ON — that shape rescanned
+    -- and sorted all of price_daily (~5M rows) on EVERY per-instrument
+    -- view query (Codex ckpt-2: 1.7s/instrument × ~3,900 = ~2h per
+    -- compute_rankings run). The LATERAL is a per-id backward index
+    -- scan on the (instrument_id, price_date) PK, and an instrument_id
+    -- predicate pushes into both UNION branches. NOT MATERIALIZED is
+    -- load-bearing: priced is referenced by BOTH pipelines, so PG would
+    -- otherwise materialize the CTE and the per-instrument predicate
+    -- could not reach inside it (EXPLAIN showed the full 3M-tuple merge
+    -- on every WHERE instrument_id query).
     SELECT
-        instrument_id,
+        ids.instrument_id,
         CASE WHEN q.price IS NOT NULL
-                  AND (pd.price_date IS NULL OR q.quoted_at::date >= pd.price_date)
+                  AND (pd.price_date IS NULL
+                       OR (q.quoted_at AT TIME ZONE 'UTC')::date >= pd.price_date)
              THEN q.price
              ELSE pd.close
         END AS price,
         CASE WHEN q.price IS NOT NULL
-                  AND (pd.price_date IS NULL OR q.quoted_at::date >= pd.price_date)
+                  AND (pd.price_date IS NULL
+                       OR (q.quoted_at AT TIME ZONE 'UTC')::date >= pd.price_date)
              THEN q.quoted_at
              ELSE pd.price_date::timestamptz
         END AS quoted_at
     FROM (
+        SELECT instrument_id FROM quotes
+        UNION
+        SELECT instrument_id FROM price_daily
+    ) ids
+    LEFT JOIN (
         SELECT instrument_id,
                COALESCE(
                    NULLIF(GREATEST(last, 0), 0),
@@ -79,16 +100,15 @@ priced AS (
                )                    AS price,
                quoted_at
         FROM quotes
-    ) q
-    FULL OUTER JOIN (
-        SELECT DISTINCT ON (instrument_id)
-               instrument_id,
-               close,
-               price_date
-        FROM price_daily
-        WHERE close > 0
-        ORDER BY instrument_id, price_date DESC
-    ) pd USING (instrument_id)
+    ) q USING (instrument_id)
+    LEFT JOIN LATERAL (
+        SELECT p.close, p.price_date
+        FROM price_daily p
+        WHERE p.instrument_id = ids.instrument_id
+          AND p.close > 0
+        ORDER BY p.price_date DESC
+        LIMIT 1
+    ) pd ON TRUE
 ),
 new_pipeline AS (
     SELECT
@@ -184,7 +204,11 @@ new_pipeline AS (
     WHERE ttm.is_complete_ttm = TRUE
 ),
 legacy AS (
-    SELECT DISTINCT ON (fs.instrument_id)
+    -- LATERAL latest-snapshot rather than DISTINCT ON: a DISTINCT ON
+    -- subquery is not qual-pushdown-safe, which forced the per-instrument
+    -- view query to evaluate this branch's inlined ``priced`` copy over
+    -- the whole table (#1857 ckpt-2 perf finding).
+    SELECT
         p.instrument_id,
         p.price,
         p.quoted_at,
@@ -236,13 +260,18 @@ legacy AS (
         NULL::numeric AS ebitda_ttm,
         fs.fcf AS fcf_ttm
     FROM priced p
-    JOIN fundamentals_snapshot fs USING (instrument_id)
+    JOIN LATERAL (
+        SELECT *
+        FROM fundamentals_snapshot fs0
+        WHERE fs0.instrument_id = p.instrument_id
+        ORDER BY fs0.as_of_date DESC
+        LIMIT 1
+    ) fs ON TRUE
     WHERE NOT EXISTS (
         SELECT 1 FROM financial_periods_ttm ttm
         WHERE ttm.instrument_id = p.instrument_id
           AND ttm.is_complete_ttm = TRUE
     )
-    ORDER BY fs.instrument_id, fs.as_of_date DESC
 )
 SELECT
     v.instrument_id,

--- a/sql/236_instrument_valuation_price_daily_fallback.sql
+++ b/sql/236_instrument_valuation_price_daily_fallback.sql
@@ -75,18 +75,8 @@ priced AS NOT MATERIALIZED (
     -- on every WHERE instrument_id query).
     SELECT
         ids.instrument_id,
-        CASE WHEN q.price IS NOT NULL
-                  AND (pd.price_date IS NULL
-                       OR (q.quoted_at AT TIME ZONE 'UTC')::date >= pd.price_date)
-             THEN q.price
-             ELSE pd.close
-        END AS price,
-        CASE WHEN q.price IS NOT NULL
-                  AND (pd.price_date IS NULL
-                       OR (q.quoted_at AT TIME ZONE 'UTC')::date >= pd.price_date)
-             THEN q.quoted_at
-             ELSE pd.price_date::timestamptz
-        END AS quoted_at
+        CASE WHEN w.use_quote THEN q.price     ELSE pd.close                    END AS price,
+        CASE WHEN w.use_quote THEN q.quoted_at ELSE pd.price_date::timestamptz  END AS quoted_at
     FROM (
         SELECT instrument_id FROM quotes
         UNION
@@ -109,6 +99,14 @@ priced AS NOT MATERIALIZED (
         ORDER BY p.price_date DESC
         LIMIT 1
     ) pd ON TRUE
+    -- Single source of truth for the recency verdict — referenced by both
+    -- CASE columns above so the price and its as-of stamp cannot drift.
+    CROSS JOIN LATERAL (
+        SELECT q.price IS NOT NULL
+               AND (pd.price_date IS NULL
+                    OR (q.quoted_at AT TIME ZONE 'UTC')::date >= pd.price_date)
+               AS use_quote
+    ) w
 ),
 new_pipeline AS (
     SELECT

--- a/tests/test_instrument_valuation_price_fallback.py
+++ b/tests/test_instrument_valuation_price_fallback.py
@@ -1,0 +1,116 @@
+"""DB integration test for the #1857 price_daily fallback in the
+``instrument_valuation`` view (sql/236).
+
+The ``priced`` CTE FULL OUTER JOINs the live-quote snapshot with the latest
+strictly-positive ``price_daily`` close, quote-first. One test per contract
+leg: daily-close fallback (with the non-positive-close sentinel skipped and
+the as-of stamp data-anchored to the close's price_date), quote preference
+when both exist, degenerate-quote fallthrough, and absence when neither
+source has a price. Seeds via the legacy CTE (``fundamentals_snapshot`` is a
+base table; ``financial_periods_ttm`` is a view).
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import psycopg
+import psycopg.rows
+import pytest
+
+
+@pytest.fixture
+def _seed(ebull_test_conn: psycopg.Connection[tuple]) -> psycopg.Connection[tuple]:
+    conn = ebull_test_conn
+    # 11 = daily-close only; 12 = fresh quote + older daily close; 13 =
+    # fundamentals only, no price anywhere; 14 = degenerate quote (NULL
+    # last, zero bid/ask) + daily close; 15 = STALE quote + fresher close.
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES "
+        "(11,'DLY','Daily Only',TRUE),(12,'QTE','Quote Wins',TRUE),"
+        "(13,'NOP','No Price',TRUE),(14,'DGN','Degenerate Quote',TRUE),"
+        "(15,'STL','Stale Quote',TRUE)"
+    )
+    # 11: older close 100, latest positive close 120, then a zero close the
+    # day after — the sentinel row must be skipped, not chosen.
+    conn.execute(
+        "INSERT INTO price_daily (instrument_id, price_date, close) VALUES "
+        "(11,'2026-07-01',100),(11,'2026-07-10',120),(11,'2026-07-11',0),"
+        "(12,'2026-07-10',140),"
+        "(14,'2026-07-10',90),"
+        "(15,'2026-07-20',110)"
+    )
+    conn.execute(
+        "INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last, spread_flag) VALUES "
+        "(12, now(), 149, 151, 150, FALSE),"
+        "(14, now(), 0, 0, NULL, FALSE),"
+        "(15, '2026-07-05T14:00:00Z', 99, 101, 100, FALSE)"
+    )
+    for iid in (11, 12, 13, 14, 15):
+        conn.execute(
+            "INSERT INTO fundamentals_snapshot "
+            "(instrument_id, as_of_date, revenue_ttm, gross_margin, operating_margin, "
+            " fcf, cash, debt, net_debt, shares_outstanding, book_value, eps) "
+            "VALUES (%s, '2025-01-01', 1e11, 0.5, 0.3, 5e10, 1e10, 2e10, 1e10, 1e10, 30, 6)",
+            (iid,),
+        )
+    conn.commit()
+    return conn
+
+
+def _val(conn: psycopg.Connection[tuple], iid: int) -> dict[str, object] | None:
+    cur = conn.cursor(row_factory=psycopg.rows.dict_row)
+    cur.execute(
+        "SELECT current_price, price_as_of, pe_ratio FROM instrument_valuation WHERE instrument_id = %s",
+        (iid,),
+    )
+    return cur.fetchone()
+
+
+@pytest.mark.db
+def test_daily_close_fallback_latest_positive(_seed: psycopg.Connection[tuple]) -> None:
+    row = _val(_seed, 11)
+    assert row is not None
+    # Latest strictly-positive close (120 @ 07-10); the 07-11 zero close is a
+    # sentinel, not a price. As-of is data-anchored to the close's price_date.
+    assert row["current_price"] == 120
+    as_of = row["price_as_of"]
+    assert isinstance(as_of, datetime.datetime)
+    assert as_of.date() == datetime.date(2026, 7, 10)
+    assert row["pe_ratio"] == 20  # 120 / eps 6
+
+
+@pytest.mark.db
+def test_fresh_quote_preferred_over_older_daily_close(_seed: psycopg.Connection[tuple]) -> None:
+    row = _val(_seed, 12)
+    assert row is not None
+    assert row["current_price"] == 150  # quote (today) beats close (07-10)
+
+
+@pytest.mark.db
+def test_stale_quote_loses_to_fresher_daily_close(_seed: psycopg.Connection[tuple]) -> None:
+    row = _val(_seed, 15)
+    assert row is not None
+    # Quote from 07-05 must not shadow the 07-20 close (the dev quotes
+    # snapshot only refreshes for subscribed instruments — recency wins).
+    assert row["current_price"] == 110
+    as_of = row["price_as_of"]
+    assert isinstance(as_of, datetime.datetime)
+    assert as_of.date() == datetime.date(2026, 7, 20)
+
+
+@pytest.mark.db
+def test_no_price_anywhere_row_absent(_seed: psycopg.Connection[tuple]) -> None:
+    assert _val(_seed, 13) is None  # absence, never a fabricated price
+
+
+@pytest.mark.db
+def test_degenerate_quote_falls_through_to_daily_close(_seed: psycopg.Connection[tuple]) -> None:
+    row = _val(_seed, 14)
+    assert row is not None
+    # NULL last + zero bid/ask derives no quote price → daily close, with the
+    # stamp paired to the price actually used (price_date, not quoted_at).
+    assert row["current_price"] == 90
+    as_of = row["price_as_of"]
+    assert isinstance(as_of, datetime.datetime)
+    assert as_of.date() == datetime.date(2026, 7, 10)

--- a/tests/test_peer_comparison_ranking.py
+++ b/tests/test_peer_comparison_ranking.py
@@ -53,9 +53,11 @@ def test_row_factors_maps_all_keys() -> None:
     assert f["net_margin"] is None
 
 
-def test_is_factor_thin_price_gated_always_thin() -> None:
-    # pe_ratio is structurally dev-limited regardless of coverage.
-    assert is_factor_thin("pe_ratio", cohort_n=1000, cohort_member_count=1000) is True
+def test_is_factor_thin_pe_ratio_governed_by_coverage() -> None:
+    # #1857 (sql/236): the structural price gate is lifted — pe_ratio follows
+    # the ordinary coverage-ratio test like any other factor.
+    assert is_factor_thin("pe_ratio", cohort_n=1000, cohort_member_count=1000) is False
+    assert is_factor_thin("pe_ratio", cohort_n=10, cohort_member_count=1000) is True
 
 
 def test_is_factor_thin_low_coverage_flagged() -> None:


### PR DESCRIPTION
Closes #1857.

## What

`instrument_valuation` (the value family's only price source) was gated on the `quotes` live snapshot — 97 rows — so `_value_score` returned the 0.5 empty-components neutral default for **3,804/3,916 (97.0%)** of the scored universe (re-verified full-pop 2026-07-23). sql/236 recreates the view's `priced` CTE to price off the latest strictly-positive `price_daily` close (~5,222 instruments) with a recency rule, and the scoring `model_version` bumps v1.3 → v1.4 in the same PR because a quarter-weight family's input changed (ranking-engine invariant).

## Design decisions

1. **Recency rule, not quote-first COALESCE** (deviation from the issue's literal fix, forced by dev-verify): the quotes snapshot only refreshes for subscribed instruments, and stale quotes were shadowing fresher closes across most of the smoke panel (AAPL quoted 07-09 vs close 07-23). Quote wins iff `(quoted_at AT TIME ZONE 'UTC')::date >= price_date` (UTC-pinned so session TZ cannot flip the winner near midnight — Codex ckpt-2). As-of stamp pairs with the price actually chosen; the daily-close path is data-anchored to `price_date` per the market-data skill.
2. **Currency basis unchanged**: both `quotes` and `price_daily` are eToro-native prices (#1906). Cross-currency-vs-USD-fundamentals distortion pre-exists on the quote path and is #1939's territory.
3. **#1664 dual-class suppression preserved verbatim** (dc CTE + CASE suppression untouched; dual-class DB test green).
4. **View shape is perf-load-bearing** (Codex ckpt-2 finding, empirically confirmed): the naive `FULL OUTER JOIN` over a global `DISTINCT ON` cost **1,722 ms per per-instrument query** (× ~3,900 = ~2 h per scoring run). Shipped shape: driving id-set + `LEFT JOIN LATERAL` latest-close, `NOT MATERIALIZED` (the CTE is referenced by both pipelines; PG would otherwise materialize it and block qual pushdown), and the legacy branch's `DISTINCT ON` replaced with a LATERAL latest-snapshot (DISTINCT ON subqueries are not qual-pushdown-safe). Measured after: **2.8 ms per instrument**; full `compute_rankings` run 307 s.
5. **peer_comparison**: `pe_ratio` leaves `DEV_LIMITED_FACTORS` — the structural price gate is gone; the ordinary <20% coverage-ratio test governs it now.

## Security model

No new inputs cross a trust boundary: the view reads existing internal tables; endpoints touched only in comments. Service-token auth on the scoring/rankings read paths unchanged.

## Evidence (dev DB, 2026-07-23)

**View population**: 61 → **4,516** rows; `pe_ratio` non-null 1,985.

**Smoke panel (clause 8)** — `instrument_valuation` after sql/236:

| sym | price | as-of | P/E |
|---|---|---|---|
| AAPL | 325.40 | 2026-07-23 (close; beat stale 07-09 quote) | 39.39 |
| GME | 21.55 | 2026-07-23 | 16.1 |
| MSFT | 397.15 | 2026-07-22 | 23.2 |
| JPM | 345.63 | 2026-07-22 (same-day quote wins) | 16.5 |
| HD | 317.48 | 2026-06-09 (quote; its latest close is older — dev candle gap, rule correct) | 22.5 |

**Cross-source (clause 9)**: AAPL EPS_ttm ours **8.26** vs stockanalysis.com **8.25** (P/E 39.39 vs 39.51, one-day price diff). EXACT.

**Backfill (clause 10)**: view recreate, no data backfill. Migration applied to dev (smoke lifespan) + manually replayed after each ckpt-2 edit with `schema_migrations.content_sha256` updated (#1333 replay path). Test DBs apply the final file from scratch — 24 targeted DB tests green.

**Rank-shift evidence (clause 11, version-isolated A/B)**: `compute_rankings(model_version='v1.4-balanced')` run on dev (append-only; endpoints stay pinned to the deployed default until merge). 3,916 scored in 307 s:

- **3,065/3,916 (78%) value scores un-froze** from 0.5; 736 (18.8%) legitimately remain 0.5 (no priceable fundamentals).
- v1.4 value distribution: 1,704 below 0.5 / 1,476 above / 736 at default — real spread, roughly balanced.
- Rank shift vs latest v1.3: median |Δ| 328, mean 440, max 2,124. **Top-20 turnover: 13/20 new.**
- Top-10: NVDA holds #1 (thesis-fed value already live); risers are un-frozen value names (FHI 35→2, CCSI 57→7, INVA 89→10); KO enters top-5.

## Operator gate (why this is not auto-mergeable)

Changing the value input shifts every headline rank (see turnover above). The #1815 §8 backtest machinery is not built (#1822 blocked), so the gate degrades to operator sign-off on this evidence. **Merge only on explicit operator approval.**

## Deploy window (conscious tradeoff)

sql/236 is already live on the dev DB (smoke lifespan applies migrations). Until the jobs daemon restarts on this merge, any scheduled v1.3 scoring run reads the widened view under the old label — same window every schema+behavior PR here has (precedent sql/201); scoring cadence is ~1 run/1-2 days so exposure is ≤1 run. **Post-merge operator action: restart the `stack: jobs` task** (routine; also owed for nothing else currently).

## Checks

ruff ✓ format ✓ pyright 0 ✓ fast tier 5,344 passed ✓ targeted DB tests 24 passed ✓ smoke 153 passed ✓. Codex ckpt-2 run; both findings (TZ cast, view perf shape) confirmed real and fixed in `9e94978f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
