### PR TITLE
fix(#1939): FPI ADR/ADS cap-basis suppression — Rule 3b-4 fingerprint ∪ name marker, $3.45T fake cap-mass removed (model v1.5)

### DIFF
--- a/.claude/skills/ranking-engine/SKILL.md
+++ b/.claude/skills/ranking-engine/SKILL.md
@@ -98,6 +98,44 @@ backtest (#1815 §8) + operator sign-off promotes them.
   the most recent prior run only.
 - Each score row must carry enough detail to explain how it was produced.
 
+## Promotion decisions — model_version bumps are EVIDENCE-gated, not person-gated
+
+Operator direction (2026-07-23, #1857/PR2115): a ticket labelled
+"operator-gated (model_version)" does NOT wait for a human. The #1815 §8
+backtest machinery is unbuilt (#1822 blocked), so the gate's whole content is
+an evidence review — perform it, record it, merge. Bump + merge autonomously
+when ALL hold:
+
+1. **Invariants followed** — bump on an existing metric's input/computation
+   change; family weights + prefix gates carried forward; prior-version rows
+   untouched (append-only history = the rollback path).
+2. **Full-population A/B assembled** — run `compute_rankings` under the NEW
+   version label on dev (version-isolated: endpoints stay pinned to the
+   deployed default until merge). Report: score-distribution shift, median/max
+   |Δrank|, top-20 turnover, top-10 sanity eyeball.
+3. **Cross-source spot check EXACT** for at least one input figure
+   (e.g. #1857: AAPL EPS_ttm 8.26 vs stockanalysis.com 8.25).
+4. **Blast radius is rankings/research surfaces only.** Anything touching a
+   live-trade/capital path stays person-gated — that is the ONLY remaining
+   human gate ([[feedback_never_close_positions]]).
+
+Precedents: v1.4 (#1857 — value priced off price_daily; 78% un-freeze, 13/20
+top-20 turnover) and v1.5 (#1939 — FPI ADR/ADS basis suppression). When #1822
+lands a real backtest gate, it SUPERSEDES clauses 2-3 here.
+
+## Market-cap basis (what the value family may divide by)
+
+`resolve_market_cap_basis` (app/services/xbrl_derived_stats.py) is the single
+authority. Bases: `total_company` (curated dual-class Σ class×price),
+`multiclass_unavailable` (known dual-class, no clean total → suppress),
+`fpi_adr_unavailable` (#1939 — Rule 3b-4 FPI ADR/ADS, ordinary-share count vs
+per-ADS price, ratio not ingested → suppress ALL price-bearing ratios incl.
+pe_ratio/dividend_yield, wider than the dual-class list), `not_multiclass`
+(legacy shares×price, exact). FPI detection reuses
+`coverage.filings_status = 'fpi'` — never re-derive the form fingerprint.
+Known residual: domestic-form ADR filers (AKTX class) pass the fingerprint and
+stay wrong until ADS-ratio ingestion (#1939 step-2).
+
 ## Failure conditions
 
 - Missing critical source data, stale timestamps beyond threshold, or

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -3854,8 +3854,11 @@ def get_instrument_summary(
         cap_resolution = resolve_market_cap_basis(conn, instrument_id=instrument_id_int)
         if cap_resolution.basis == "total_company" and cap_resolution.total is not None:
             computed_cap_value: Decimal | None = cap_resolution.total.value
-        elif cap_resolution.basis == "multiclass_unavailable":
-            computed_cap_value = None  # fail closed: known dual-class, no clean total
+        elif cap_resolution.basis in ("multiclass_unavailable", "fpi_adr_unavailable"):
+            # fail closed: known dual-class with no clean total, or an FPI
+            # ADR/ADS whose ordinary-shares × per-ADS-price product is wrong
+            # by the un-ingested ADS ratio (#1939).
+            computed_cap_value = None
         else:
             single_cap = compute_market_cap(conn, instrument_id=instrument_id_int)
             computed_cap_value = single_cap.value if single_cap is not None else None

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -3848,10 +3848,12 @@ def get_instrument_summary(
     #     when only one class of a multi-class issuer is in our universe)
     # Returns None for instruments without SEC coverage; market cap then stays null
     # on the identity rather than reaching for a non-canonical source.
+    cap_basis: str = "not_multiclass"
     try:
         from app.services.xbrl_derived_stats import compute_market_cap, resolve_market_cap_basis
 
         cap_resolution = resolve_market_cap_basis(conn, instrument_id=instrument_id_int)
+        cap_basis = cap_resolution.basis
         if cap_resolution.basis == "total_company" and cap_resolution.total is not None:
             computed_cap_value: Decimal | None = cap_resolution.total.value
         elif cap_resolution.basis in ("multiclass_unavailable", "fpi_adr_unavailable"):
@@ -3916,6 +3918,24 @@ def get_instrument_summary(
     else:
         stats_block = None
         key_stats_source = "unavailable"
+
+    # #1939: FPI ADR/ADS — the locally derived P/E and P/B (per-ADS price ÷
+    # per-ordinary-share EPS/book) and the dividend yield (per-ordinary-share
+    # DPS ÷ per-ADS price) are wrong by the un-ingested ADS ratio. Null them
+    # here too — this path computes its own ratios and does NOT read the
+    # (already-suppressed) instrument_valuation view (Codex ckpt-2 #1939).
+    if stats_block is not None and cap_basis == "fpi_adr_unavailable":
+        fpi_sources: dict[str, KeyStatsFieldSource] = dict(stats_block.field_source or {})
+        for f in ("pe_ratio", "pb_ratio", "dividend_yield"):
+            fpi_sources[f] = "unavailable"
+        stats_block = stats_block.model_copy(
+            update={
+                "pe_ratio": None,
+                "pb_ratio": None,
+                "dividend_yield": None,
+                "field_source": fpi_sources,
+            }
+        )
 
     source = {
         "identity": "local_db",

--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -326,6 +326,12 @@ def select_multiples(t: TargetInputs) -> list[str]:
     else:
         selected = []
 
+    if t.target_basis == "fpi_adr_unavailable":
+        # #1939: FPI ADR/ADS — even the per-share pe leg is wrong (per-ADS
+        # price vs per-ordinary-share EPS differ by the un-ingested ADS
+        # ratio). No multiple is basis-safe; the band goes absent rather
+        # than publishing an ordinary-share target as an ADS target.
+        return []
     if t.target_basis != "not_multiclass":
         selected = [m for m in selected if m == "pe"]
 

--- a/app/services/fcf_yield.py
+++ b/app/services/fcf_yield.py
@@ -216,7 +216,11 @@ def fcf_yield_series(
     cap or FX rate can't be sourced cleanly gets a NULL yield (its absolute FCF
     still renders); the series itself is never suppressed (#1745)."""
     basis = resolve_market_cap_basis(conn, instrument_id=instrument_id).basis
-    is_multiclass = basis != "not_multiclass"
+    # #1939: FPI ADR/ADS — no clean cap under any basis (ordinary shares vs
+    # per-ADS price); every period's cap fails closed EXPLICITLY rather than
+    # by the accident of the curated class table not covering the CIK.
+    is_fpi_adr = basis == "fpi_adr_unavailable"
+    is_multiclass = basis != "not_multiclass" and not is_fpi_adr
     cik = _instrument_cik(conn, instrument_id) if is_multiclass else None
 
     trading_ccy = _trading_currency(conn, instrument_id)
@@ -239,8 +243,11 @@ def fcf_yield_series(
         fcf_ttm = r["fcf_ttm"]
 
         # Market cap: per-period total-company cap for a multi-class issuer (#1745),
-        # else the single-class period_end shares × close.
-        if is_multiclass:
+        # else the single-class period_end shares × close. FPI ADR/ADS: no cap
+        # (#1939) — the yield stays NULL, the absolute FCF still renders.
+        if is_fpi_adr:
+            market_cap = None
+        elif is_multiclass:
             cap = (
                 total_company_cap_at_period(conn, cik=cik, target_period_end=period_end, today=today)
                 if cik is not None

--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -44,7 +44,7 @@ from app.services.xbrl_derived_stats import (
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_MODEL_VERSION = "v1.4-balanced"
+_DEFAULT_MODEL_VERSION = "v1.5-balanced"
 
 # Model-version prefix gates (single source — the next version is a one-line add,
 # not a scattered string edit). TA-enhanced momentum applies from v1.1; the
@@ -52,10 +52,13 @@ _DEFAULT_MODEL_VERSION = "v1.4-balanced"
 # Calmar reward on top — Codex ckpt-1 HIGH: v1.3 must inherit v1.2 behavior).
 # v1.4 inherits ALL v1.3 behavior — the bump marks the #1857 value-input change
 # (instrument_valuation priced off price_daily fallback, sql/236), not a
-# scoring-code change.
-_TA_MOMENTUM_PREFIXES: tuple[str, ...] = ("v1.1", "v1.2", "v1.3", "v1.4")
-_RISK_PENALTY_PREFIXES: tuple[str, ...] = ("v1.2", "v1.3", "v1.4")
-_CALMAR_REWARD_PREFIXES: tuple[str, ...] = ("v1.3", "v1.4")
+# scoring-code change. v1.5 likewise inherits v1.4 — it marks the #1939 FPI
+# ADR/ADS basis suppression (sql/237: price-bearing ratios NULLed for Rule
+# 3b-4 fingerprinted instruments, whose ordinary-shares × per-ADS-price
+# inputs v1.4 had un-masked as garbage).
+_TA_MOMENTUM_PREFIXES: tuple[str, ...] = ("v1.1", "v1.2", "v1.3", "v1.4", "v1.5")
+_RISK_PENALTY_PREFIXES: tuple[str, ...] = ("v1.2", "v1.3", "v1.4", "v1.5")
+_CALMAR_REWARD_PREFIXES: tuple[str, ...] = ("v1.3", "v1.4", "v1.5")
 
 # ---------------------------------------------------------------------------
 # Weight modes  (must sum to 1.0)
@@ -193,6 +196,35 @@ _WEIGHT_MODES: dict[str, dict[str, float]] = {
         "turnaround": 0.05,
     },
     "v1.4-speculative": {
+        "turnaround": 0.30,
+        "value": 0.25,
+        "momentum": 0.15,
+        "confidence": 0.15,
+        "sentiment": 0.10,
+        "quality": 0.05,
+    },
+    # v1.5 — identical family weights to v1.4. The bump marks the #1939 FPI
+    # ADR/ADS suppression (sql/237): fingerprinted instruments lose their
+    # (structurally wrong) price-bearing value inputs, so their value
+    # sub-score honestly degrades to the empty-components default instead
+    # of an ADS-ratio-inflated garbage figure.
+    "v1.5-balanced": {
+        "quality": 0.25,
+        "value": 0.25,
+        "turnaround": 0.20,
+        "confidence": 0.15,
+        "momentum": 0.10,
+        "sentiment": 0.05,
+    },
+    "v1.5-conservative": {
+        "quality": 0.35,
+        "value": 0.25,
+        "confidence": 0.20,
+        "momentum": 0.10,
+        "sentiment": 0.05,
+        "turnaround": 0.05,
+    },
+    "v1.5-speculative": {
         "turnaround": 0.30,
         "value": 0.25,
         "momentum": 0.15,

--- a/app/services/xbrl_derived_stats.py
+++ b/app/services/xbrl_derived_stats.py
@@ -188,7 +188,7 @@ class TotalCompanyMarketCap:
     legs: tuple[_ClassLeg, ...]
 
 
-MarketCapBasis = Literal["total_company", "multiclass_unavailable", "not_multiclass"]
+MarketCapBasis = Literal["total_company", "multiclass_unavailable", "not_multiclass", "fpi_adr_unavailable"]
 
 
 @dataclass(frozen=True)
@@ -201,7 +201,11 @@ class MarketCapResolution:
       breach). FAIL CLOSED: the caller must suppress market cap (null), never fall
       back to the structurally-wrong combined×price for a known dual-class issuer.
     - ``not_multiclass`` — single-class (or not a curated dual-class issuer): the
-      caller uses the legacy ``compute_market_cap`` (combined × price, exact)."""
+      caller uses the legacy ``compute_market_cap`` (combined × price, exact).
+    - ``fpi_adr_unavailable`` — a Rule 3b-4 foreign-private-issuer ADR/ADS
+      (#1939): the SEC share count is ordinary shares, the price is per-ADS,
+      and the ADS ratio is not ingested. FAIL CLOSED: no cap basis exists;
+      the caller must suppress every ordinary-shares × ADS-price product."""
 
     basis: MarketCapBasis
     total: TotalCompanyMarketCap | None = None
@@ -549,8 +553,31 @@ def resolve_market_cap_basis(
     detector filters with CUSIP gates). For a detected multi-class issuer we either
     return the total-company cap or fail closed; everything else uses the legacy
     single-class product. PURE READ-PATH; see
-    docs/specs/etl/2026-06-17-per-class-market-cap.md."""
+    docs/specs/etl/2026-06-17-per-class-market-cap.md.
+
+    #1939: a Rule 3b-4 FPI ADR/ADS fails closed FIRST — the ordinary-share count
+    cannot meet the per-ADS price under ANY basis until the ADS ratio is ingested.
+    Detection reuses ``coverage.filings_status = 'fpi'`` (the coverage
+    classifier's form fingerprint — single source of truth, do not re-derive)."""
     with conn.cursor() as cur:
+        # Fingerprint ∪ ADR/ADS name marker — the marker catches domestic-form
+        # ADR filers (ONC/TEVA class) the Rule 3b-4 form set cannot. Mirrors
+        # the sql/237 fpi_adr CTE exactly; keep the two in sync.
+        cur.execute(
+            """
+            SELECT 1
+            WHERE EXISTS (
+                SELECT 1 FROM coverage
+                WHERE instrument_id = %(iid)s AND filings_status = 'fpi'
+            ) OR EXISTS (
+                SELECT 1 FROM instruments
+                WHERE instrument_id = %(iid)s AND company_name ~* '\\y(ADR|ADS)\\y'
+            )
+            """,
+            {"iid": instrument_id},
+        )
+        if cur.fetchone() is not None:
+            return MarketCapResolution(basis="fpi_adr_unavailable")
         cur.execute(
             """
             SELECT identifier_value

--- a/sql/237_instrument_valuation_fpi_adr_suppress.sql
+++ b/sql/237_instrument_valuation_fpi_adr_suppress.sql
@@ -1,0 +1,352 @@
+-- 237_instrument_valuation_fpi_adr_suppress.sql
+--
+-- #1939 step-1: suppress every price-bearing ratio for foreign-private-
+-- issuer ADR/ADS instruments. The SEC DEI share count is the issuer's
+-- ORDINARY-share count while the tradable price is PER-ADS (one ADS = N
+-- ordinary shares, ratio in the F-6 / depositary agreement — NOT
+-- ingested), so any ordinary-shares × ADS-price product overstates by
+-- ~the ADS ratio (dev full-pop: Toyota $2.28T, AKTX $1.43T). sql/236
+-- (#1857) un-masked this by pricing the view universe-wide.
+--
+-- Source rule: Exchange Act Rule 3b-4 defines FPI status; the documented
+-- consequence is the form set (20-F/40-F annuals + 6-K currents instead
+-- of 10-K/10-Q/8-K). Detection REUSES coverage.filings_status = 'fpi'
+-- (app/services/coverage.py::_classify — zero US base-or-amend filings
+-- AND >=1 20-F/40-F/6-K family filing; full-pop maintained by the
+-- coverage machinery; 1,086 tradable rows == an independent
+-- filing_events fingerprint scan exactly, verified 2026-07-23).
+--
+-- Suppressed for FPI (every column carrying a p.price term — the per-ADS
+-- price cannot meet a per-ordinary-share denominator): market_cap_live,
+-- enterprise_value, pe_ratio, pb_ratio, price_sales, p_fcf_ratio,
+-- fcf_yield, ev_revenue, ev_ebitda, dividend_yield. KEPT: current_price
+-- / price_as_of (the per-ADS price is itself real), margins, roa, roe,
+-- debt_equity_ratio, raw TTM figures. NOTE this is a WIDER list than the
+-- #1664 dual-class suppression: dual-class keeps pe_ratio and
+-- dividend_yield (combined-diluted EPS / declared DPS are per-share-basis
+-- consistent across classes), but for an ADS the price and the per-share
+-- figures differ by the ADS ratio, so both are wrong.
+--
+-- Known residual (step-2, ADS-ratio ingestion child ticket): ADR-class
+-- issuers that file DOMESTIC forms (AKTX — UK PLC filing 10-Ks) are not
+-- fingerprinted by Rule 3b-4 and remain wrong until the ratio lands.
+--
+-- Everything else (priced CTE recency rule + perf shape from sql/236,
+-- #1664 dual-class suppression) is preserved verbatim.
+--
+-- View recreate only — no data backfill. Idempotent (DROP VIEW IF EXISTS).
+
+BEGIN;
+
+DROP VIEW IF EXISTS instrument_valuation;
+
+CREATE VIEW instrument_valuation AS
+WITH dual_class AS (
+    -- Curated dual-class instruments: primary SEC CIK present in the
+    -- #1623 per-class FSDS table. Both share-class siblings of a covered
+    -- CIK appear (the table is keyed per sibling instrument_id).
+    SELECT DISTINCT ei.instrument_id
+    FROM external_identifiers ei
+    JOIN instrument_class_shares_outstanding c
+      ON c.source_cik = lpad(ei.identifier_value, 10, '0')
+    WHERE ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+      AND ei.is_primary = TRUE
+),
+fpi_adr AS (
+    -- #1939: Rule 3b-4 FPI fingerprint, reused from the coverage
+    -- classifier (single source of truth — do NOT re-derive from
+    -- filing_events here) ∪ the eToro ADR/ADS name marker, which catches
+    -- the DOMESTIC-form ADR filers the fingerprint cannot (BeiGene/ONC
+    -- files 10-Ks yet its ADS = 13 ordinary shares → $467B fake cap).
+    -- Full-pop scan 2026-07-23: 182 tradable marker hits, 0 harmful
+    -- false positives (the two Ads-* names are already fpi / no-CIK).
+    -- Known cost: a 1:1-ratio ADS (TEVA class) is over-suppressed —
+    -- fail-closed is correct while the ratio is not ingested (step-2).
+    SELECT instrument_id
+    FROM coverage
+    WHERE filings_status = 'fpi'
+    UNION
+    SELECT instrument_id
+    FROM instruments
+    WHERE company_name ~* '\y(ADR|ADS)\y'
+),
+priced AS NOT MATERIALIZED (
+    -- #1857: freshest price wins. The quote is used iff it is at least
+    -- as recent (by UTC date — the ::date cast is pinned so a session
+    -- timezone cannot flip the winner near midnight) as the latest
+    -- strictly-positive daily close — a stale snapshot quote must not
+    -- shadow a fresher close. The strictly-positive close filter mirrors
+    -- compute_day_change's rule (a non-positive close is a sentinel, not
+    -- a price). The as-of stamp pairs with the price actually used.
+    --
+    -- Shape: driving id-set (both sources' instrument ids, index-only
+    -- scans) + LEFT JOIN quotes + LEFT JOIN LATERAL latest-close. NOT a
+    -- FULL OUTER JOIN over a global DISTINCT ON — that shape rescanned
+    -- and sorted all of price_daily (~5M rows) on EVERY per-instrument
+    -- view query (Codex ckpt-2: 1.7s/instrument × ~3,900 = ~2h per
+    -- compute_rankings run). The LATERAL is a per-id backward index
+    -- scan on the (instrument_id, price_date) PK, and an instrument_id
+    -- predicate pushes into both UNION branches. NOT MATERIALIZED is
+    -- load-bearing: priced is referenced by BOTH pipelines, so PG would
+    -- otherwise materialize the CTE and the per-instrument predicate
+    -- could not reach inside it (EXPLAIN showed the full 3M-tuple merge
+    -- on every WHERE instrument_id query).
+    SELECT
+        ids.instrument_id,
+        CASE WHEN w.use_quote THEN q.price     ELSE pd.close                    END AS price,
+        CASE WHEN w.use_quote THEN q.quoted_at ELSE pd.price_date::timestamptz  END AS quoted_at
+    FROM (
+        SELECT instrument_id FROM quotes
+        UNION
+        SELECT instrument_id FROM price_daily
+    ) ids
+    LEFT JOIN (
+        SELECT instrument_id,
+               COALESCE(
+                   NULLIF(GREATEST(last, 0), 0),
+                   CASE WHEN bid > 0 AND ask > 0 THEN (bid + ask) / 2 END
+               )                    AS price,
+               quoted_at
+        FROM quotes
+    ) q USING (instrument_id)
+    LEFT JOIN LATERAL (
+        SELECT p.close, p.price_date
+        FROM price_daily p
+        WHERE p.instrument_id = ids.instrument_id
+          AND p.close > 0
+        ORDER BY p.price_date DESC
+        LIMIT 1
+    ) pd ON TRUE
+    -- Single source of truth for the recency verdict — referenced by both
+    -- CASE columns above so the price and its as-of stamp cannot drift.
+    CROSS JOIN LATERAL (
+        SELECT q.price IS NOT NULL
+               AND (pd.price_date IS NULL
+                    OR (q.quoted_at AT TIME ZONE 'UTC')::date >= pd.price_date)
+               AS use_quote
+    ) w
+),
+new_pipeline AS (
+    SELECT
+        p.instrument_id,
+        p.price,
+        p.quoted_at,
+        ttm.revenue_ttm,
+        ttm.net_income_ttm,
+        ttm.operating_income_ttm,
+        ttm.gross_profit_ttm,
+        ttm.depreciation_amort_ttm,
+        ttm.operating_cf_ttm,
+        ttm.capex_ttm,
+        ttm.dps_declared_ttm,
+        ttm.is_complete_ttm,
+        ttm.eps_diluted_ttm,
+        ttm.total_assets,
+        ttm.total_liabilities,
+        ttm.shareholders_equity,
+        ttm.cash,
+        ttm.long_term_debt,
+        ttm.short_term_debt,
+        ttm.shares_outstanding,
+        CASE WHEN p.price > 0 AND ttm.shares_outstanding > 0
+             THEN p.price * ttm.shares_outstanding
+        END AS market_cap_live,
+        CASE WHEN p.price > 0 AND ttm.shares_outstanding > 0
+             THEN p.price * ttm.shares_outstanding
+                  + COALESCE(ttm.long_term_debt, 0)
+                  + COALESCE(ttm.short_term_debt, 0)
+                  - COALESCE(ttm.cash, 0)
+        END AS enterprise_value,
+        CASE WHEN ttm.eps_diluted_ttm > 0
+             THEN p.price / ttm.eps_diluted_ttm
+        END AS pe_ratio,
+        CASE WHEN ttm.shareholders_equity > 0 AND ttm.shares_outstanding > 0
+             THEN p.price / (ttm.shareholders_equity / ttm.shares_outstanding)
+        END AS pb_ratio,
+        CASE WHEN ttm.revenue_ttm > 0 AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding) / ttm.revenue_ttm
+        END AS price_sales,
+        CASE WHEN (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0))) > 0
+                  AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding)
+                  / (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)))
+        END AS p_fcf_ratio,
+        CASE WHEN p.price > 0 AND ttm.shares_outstanding > 0
+                  AND (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0))) IS NOT NULL
+             THEN (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)))
+                  / (p.price * ttm.shares_outstanding)
+        END AS fcf_yield,
+        CASE WHEN ttm.shareholders_equity > 0
+             THEN (COALESCE(ttm.long_term_debt, 0) + COALESCE(ttm.short_term_debt, 0))
+                  / ttm.shareholders_equity
+        END AS debt_equity_ratio,
+        CASE WHEN ttm.revenue_ttm > 0 AND p.price > 0 AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding
+                   + COALESCE(ttm.long_term_debt, 0)
+                   + COALESCE(ttm.short_term_debt, 0)
+                   - COALESCE(ttm.cash, 0))
+                  / ttm.revenue_ttm
+        END AS ev_revenue,
+        CASE WHEN (ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0)) > 0
+                  AND p.price > 0 AND ttm.shares_outstanding > 0
+             THEN (p.price * ttm.shares_outstanding
+                   + COALESCE(ttm.long_term_debt, 0)
+                   + COALESCE(ttm.short_term_debt, 0)
+                   - COALESCE(ttm.cash, 0))
+                  / (ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0))
+        END AS ev_ebitda,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.net_income_ttm / ttm.revenue_ttm
+        END AS net_margin,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.gross_profit_ttm / ttm.revenue_ttm
+        END AS gross_margin,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.operating_income_ttm / ttm.revenue_ttm
+        END AS operating_margin,
+        CASE WHEN ttm.total_assets > 0
+             THEN ttm.net_income_ttm / ttm.total_assets
+        END AS roa,
+        CASE WHEN ttm.shareholders_equity > 0
+             THEN ttm.net_income_ttm / ttm.shareholders_equity
+        END AS roe,
+        CASE WHEN p.price > 0 AND ttm.dps_declared_ttm > 0
+             THEN ttm.dps_declared_ttm / p.price * 100
+        END AS dividend_yield,
+        ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0) AS ebitda_ttm,
+        ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)) AS fcf_ttm
+    FROM priced p
+    JOIN financial_periods_ttm ttm USING (instrument_id)
+    WHERE ttm.is_complete_ttm = TRUE
+),
+legacy AS (
+    -- LATERAL latest-snapshot rather than DISTINCT ON: a DISTINCT ON
+    -- subquery is not qual-pushdown-safe, which forced the per-instrument
+    -- view query to evaluate this branch's inlined ``priced`` copy over
+    -- the whole table (#1857 ckpt-2 perf finding).
+    SELECT
+        p.instrument_id,
+        p.price,
+        p.quoted_at,
+        NULL::numeric AS revenue_ttm,
+        NULL::numeric AS net_income_ttm,
+        NULL::numeric AS operating_income_ttm,
+        NULL::numeric AS gross_profit_ttm,
+        NULL::numeric AS depreciation_amort_ttm,
+        NULL::numeric AS operating_cf_ttm,
+        NULL::numeric AS capex_ttm,
+        NULL::numeric AS dps_declared_ttm,
+        NULL::boolean AS is_complete_ttm,
+        NULL::numeric AS eps_diluted_ttm,
+        NULL::numeric AS total_assets,
+        NULL::numeric AS total_liabilities,
+        NULL::numeric AS shareholders_equity,
+        fs.cash,
+        fs.debt AS long_term_debt,
+        NULL::numeric AS short_term_debt,
+        fs.shares_outstanding,
+        CASE WHEN p.price > 0 AND fs.shares_outstanding > 0
+             THEN p.price * fs.shares_outstanding
+        END AS market_cap_live,
+        NULL::numeric AS enterprise_value,
+        CASE WHEN p.price > 0 AND fs.eps > 0
+             THEN p.price / fs.eps
+        END AS pe_ratio,
+        CASE WHEN p.price > 0 AND fs.book_value > 0
+             THEN p.price / fs.book_value
+        END AS pb_ratio,
+        NULL::numeric AS price_sales,
+        CASE WHEN p.price > 0 AND fs.shares_outstanding > 0 AND fs.fcf > 0
+             THEN (p.price * fs.shares_outstanding) / fs.fcf
+        END AS p_fcf_ratio,
+        CASE WHEN p.price > 0 AND fs.shares_outstanding > 0
+             THEN fs.fcf / (p.price * fs.shares_outstanding)
+        END AS fcf_yield,
+        CASE WHEN fs.book_value > 0 AND fs.shares_outstanding > 0
+             THEN fs.debt / (fs.book_value * fs.shares_outstanding)
+        END AS debt_equity_ratio,
+        NULL::numeric AS ev_revenue,
+        NULL::numeric AS ev_ebitda,
+        NULL::numeric AS net_margin,
+        fs.gross_margin,
+        fs.operating_margin,
+        NULL::numeric AS roa,
+        NULL::numeric AS roe,
+        NULL::numeric AS dividend_yield,
+        NULL::numeric AS ebitda_ttm,
+        fs.fcf AS fcf_ttm
+    FROM priced p
+    JOIN LATERAL (
+        SELECT *
+        FROM fundamentals_snapshot fs0
+        WHERE fs0.instrument_id = p.instrument_id
+        ORDER BY fs0.as_of_date DESC
+        LIMIT 1
+    ) fs ON TRUE
+    WHERE NOT EXISTS (
+        SELECT 1 FROM financial_periods_ttm ttm
+        WHERE ttm.instrument_id = p.instrument_id
+          AND ttm.is_complete_ttm = TRUE
+    )
+)
+SELECT
+    v.instrument_id,
+    v.price              AS current_price,
+    v.quoted_at          AS price_as_of,
+    v.revenue_ttm,
+    v.net_income_ttm,
+    v.operating_income_ttm,
+    v.gross_profit_ttm,
+    v.depreciation_amort_ttm,
+    v.operating_cf_ttm,
+    v.capex_ttm,
+    v.dps_declared_ttm,
+    v.is_complete_ttm,
+    v.total_assets,
+    v.total_liabilities,
+    v.shareholders_equity,
+    v.cash,
+    v.long_term_debt,
+    v.short_term_debt,
+    v.shares_outstanding,
+    -- #1664: NULL the shares-distorted columns for curated dual-class
+    -- issuers (combined-shares × one-class-price is structurally wrong).
+    -- The correct total-company figure is sourced in Python by the
+    -- decision-grade consumer via resolve_market_cap_basis.
+    -- #1939: ALSO NULL every price-bearing column for Rule 3b-4 FPI
+    -- ADR/ADS instruments (per-ADS price × per-ordinary-share basis is
+    -- wrong by the un-ingested ADS ratio). FPI suppresses a WIDER list
+    -- than dual-class: pe_ratio and dividend_yield are per-share-basis
+    -- consistent across share classes but NOT across the ADS ratio.
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.market_cap_live END   AS market_cap_live,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.enterprise_value END  AS enterprise_value,
+    CASE WHEN fpi.instrument_id IS NULL THEN v.pe_ratio END                                       AS pe_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.pb_ratio END          AS pb_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.price_sales END       AS price_sales,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.p_fcf_ratio END       AS p_fcf_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.fcf_yield END         AS fcf_yield,
+    v.debt_equity_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.ev_revenue END        AS ev_revenue,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.ev_ebitda END         AS ev_ebitda,
+    v.net_margin,
+    v.gross_margin,
+    v.operating_margin,
+    v.roa,
+    v.roe,
+    -- forward_pe always NULL: source (analyst_estimates) dropped in
+    -- sql/080. Column retained for shape compatibility with any external
+    -- (operator-curated SQL, BI tool) reader.
+    NULL::numeric AS forward_pe,
+    CASE WHEN fpi.instrument_id IS NULL THEN v.dividend_yield END                                 AS dividend_yield,
+    v.ebitda_ttm,
+    v.fcf_ttm
+FROM (
+    SELECT * FROM new_pipeline
+    UNION ALL
+    SELECT * FROM legacy
+) v
+LEFT JOIN dual_class dc USING (instrument_id)
+LEFT JOIN fpi_adr fpi USING (instrument_id);
+
+COMMIT;

--- a/tests/test_instrument_valuation_fpi_suppress.py
+++ b/tests/test_instrument_valuation_fpi_suppress.py
@@ -1,0 +1,111 @@
+"""DB integration test for the #1939 FPI ADR/ADS suppression (sql/237).
+
+For a ``coverage.filings_status = 'fpi'`` instrument the view NULLs every
+price-bearing column — a WIDER list than the #1664 dual-class suppression
+(pe_ratio and dividend_yield are per-share-basis consistent across share
+classes but not across the ADS ratio). Price-free columns and the per-ADS
+price itself survive. ``resolve_market_cap_basis`` fails closed FIRST with
+``fpi_adr_unavailable``. Seeds via the legacy CTE (``fundamentals_snapshot``
+is a base table; ``financial_periods_ttm`` is a view).
+"""
+
+from __future__ import annotations
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.xbrl_derived_stats import resolve_market_cap_basis
+
+
+@pytest.fixture
+def _seed(ebull_test_conn: psycopg.Connection[tuple]) -> psycopg.Connection[tuple]:
+    conn = ebull_test_conn
+    # 21 = FPI ADR (coverage fpi, no name marker); 22 = domestic control
+    # (analysable, clean name); 23 = ONC-class: DOMESTIC-form ADR filer —
+    # coverage analysable but name carries the ADR marker.
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES "
+        "(21,'FADR','Foreign Issuer Co',TRUE),(22,'DOM','Domestic Co',TRUE),"
+        "(23,'DADR','Domestic Filer Ltd-ADR',TRUE)"
+    )
+    conn.execute(
+        "INSERT INTO external_identifiers "
+        "(instrument_id, provider, identifier_type, identifier_value, is_primary) VALUES "
+        "(21,'sec','cik','0009991939',TRUE),(22,'sec','cik','0009991940',TRUE),"
+        "(23,'sec','cik','0009991941',TRUE)"
+    )
+    conn.execute(
+        "INSERT INTO coverage (instrument_id, coverage_tier, filings_status) VALUES "
+        "(21, 3, 'fpi'), (22, 3, 'analysable'), (23, 3, 'analysable')"
+    )
+    for iid, last in ((21, 100), (22, 100), (23, 100)):
+        conn.execute(
+            "INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last, spread_flag) "
+            "VALUES (%s, now(), %s, %s, %s, FALSE)",
+            (iid, last - 1, last + 1, last),
+        )
+    for iid in (21, 22, 23):
+        conn.execute(
+            "INSERT INTO fundamentals_snapshot "
+            "(instrument_id, as_of_date, revenue_ttm, gross_margin, operating_margin, "
+            " fcf, cash, debt, net_debt, shares_outstanding, book_value, eps) "
+            "VALUES (%s, '2025-01-01', 1e11, 0.5, 0.3, 5e10, 1e10, 2e10, 1e10, 1e10, 30, 6)",
+            (iid,),
+        )
+    conn.commit()
+    return conn
+
+
+def _val(conn: psycopg.Connection[tuple], iid: int) -> dict[str, object]:
+    cur = conn.cursor(row_factory=psycopg.rows.dict_row)
+    cur.execute(
+        "SELECT current_price, market_cap_live, pe_ratio, pb_ratio, p_fcf_ratio, "
+        "fcf_yield, debt_equity_ratio, gross_margin "
+        "FROM instrument_valuation WHERE instrument_id = %s",
+        (iid,),
+    )
+    row = cur.fetchone()
+    assert row is not None
+    return row
+
+
+@pytest.mark.db
+def test_fpi_price_bearing_columns_suppressed(_seed: psycopg.Connection[tuple]) -> None:
+    row = _val(_seed, 21)
+    # Every ordinary-shares/per-share × per-ADS-price product is NULL —
+    # including pe_ratio, which dual-class suppression keeps.
+    assert row["market_cap_live"] is None
+    assert row["pe_ratio"] is None
+    assert row["pb_ratio"] is None
+    assert row["p_fcf_ratio"] is None
+    assert row["fcf_yield"] is None
+    # Price-free figures and the (real) per-ADS price survive.
+    assert row["current_price"] == 100
+    assert row["debt_equity_ratio"] is not None
+    assert row["gross_margin"] is not None
+
+
+@pytest.mark.db
+def test_domestic_control_unchanged(_seed: psycopg.Connection[tuple]) -> None:
+    row = _val(_seed, 22)
+    assert row["market_cap_live"] is not None
+    assert row["pe_ratio"] is not None
+    assert row["fcf_yield"] is not None
+
+
+@pytest.mark.db
+def test_name_marker_catches_domestic_form_adr(_seed: psycopg.Connection[tuple]) -> None:
+    # ONC class: files domestic forms (coverage 'analysable') but the eToro
+    # name carries the ADR marker — union catches it.
+    row = _val(_seed, 23)
+    assert row["market_cap_live"] is None
+    assert row["pe_ratio"] is None
+    assert row["current_price"] == 100
+
+
+@pytest.mark.db
+def test_resolver_fails_closed_fpi_first(_seed: psycopg.Connection[tuple]) -> None:
+    assert resolve_market_cap_basis(_seed, instrument_id=21).basis == "fpi_adr_unavailable"
+    assert resolve_market_cap_basis(_seed, instrument_id=22).basis == "not_multiclass"
+    assert resolve_market_cap_basis(_seed, instrument_id=23).basis == "fpi_adr_unavailable"


### PR DESCRIPTION
Closes #1939 (step-1; step-2 = ADS-ratio ingestion stays a research child).

## What

Market cap (and every `shares × price` / per-share-vs-price ratio) is structurally wrong for ADR/ADS instruments: the SEC DEI count is **ordinary shares**, the tradable price is **per-ADS** (1 ADS = N ordinary; ratio lives in the F-6/depositary agreement, not ingested). #1857's merge un-masked this universe-wide — exactly as this issue's coupling note predicted (dev: Toyota $2.62T, ONC/BeiGene $467B at P/E 950). sql/237 suppresses every price-bearing column for detected ADR/ADS instruments; all read paths fail closed; scoring bumps v1.4 → v1.5.

## Source rule

Exchange Act **Rule 3b-4** defines FPI status; the documented consequence is the form set (20-F/40-F annuals + 6-K currents instead of 10-K/10-Q). Detection **reuses `coverage.filings_status = 'fpi'`** (`coverage.py::_classify`: zero US base-or-amend filings AND ≥1 20-F/40-F/6-K) — single source of truth, not re-derived.

## Full-population verification

- Fingerprint: coverage `fpi` tradable = **1,086** == an independent `filing_events` form scan **exactly** (delta 0, 2026-07-23).
- Name marker `~* '\y(ADR|ADS)\y'`: **182 tradable hits, 0 harmful false positives** (full list scanned; the two `Ads-*` names are already fpi/no-CIK). Marker-only catches = the domestic-form ADR filers the fingerprint cannot see: **ONC, TEVA, CRTO, MREO, ZLAB**.
- Detection = fingerprint ∪ marker. Suppressed view rows: **306**. Fake cap-mass removed: **182 rows, $3.45T total, max $2.62T (Toyota)**.

## Design decisions

1. **Wider suppression list than dual-class (#1664)**: dual-class keeps `pe_ratio`/`dividend_yield` (per-share figures are basis-consistent across classes); for an ADS they differ by the ratio → both suppressed. Full list: market_cap_live, enterprise_value, pe_ratio, pb_ratio, price_sales, p_fcf_ratio, fcf_yield, ev_revenue, ev_ebitda, dividend_yield. Kept: current_price/price_as_of (the per-ADS price is itself real), margins, roa, roe, debt_equity, raw TTM.
2. **Fail-closed over precision**: a 1:1-ratio ADS (TEVA class) is over-suppressed — the ratio is unknowable until step-2 ingests it; honest absence beats a possible 13× lie (ONC).
3. **All four read paths**: `instrument_valuation` (view CTE), `resolve_market_cap_basis` (new first-checked basis `fpi_adr_unavailable`), instruments key-stats (computes its OWN price/eps, price/book, dps/price — Codex ckpt-2 catch), `fair_value_band.select_multiples` (returns no multiples → band absent `no_multiple` — Codex ckpt-2 catch; even the pe leg mixes bases).
4. **model v1.5** (weights identical; the bump marks the value-input suppression per the ranking-engine invariant). The new skill section "Promotion decisions" (rides this PR) records the operator's 2026-07-23 delegation: model_version bumps are EVIDENCE-gated, merged autonomously on assembled evidence; only live-trade/capital stays person-gated.

## Known residual (step-2)

Marker-less domestic-form ADR filers (AKTX class: "Akari Therapeutics PLC", files 10-Ks, no name marker, ADS = 2,000 ordinary) remain wrong until ADS-ratio ingestion.

## Security model

No new trust-boundary inputs; view reads internal tables; endpoint changes null fields only. Auth unchanged.

## Evidence (dev DB, 2026-07-23)

**Smoke panel (clause 8)**: AAPL control intact ($4,772.9B cap, P/E 39.4); TM/ONC/TEVA/CRTO — mcap + P/E all NULL post-237 (previously ONC $466.8B @ P/E 950.5). LYG/BSAC: no complete-TTM row → absent (pre-existing).

**Cross-source (clause 9)**: ONC/BeiGene real cap ≈ $40B (public figure) vs our pre-fix $466.8B — the 13:1 ADS ratio inflation, now suppressed to honest NULL. AAPL control cross-checked in PR2115 (EPS 8.26 vs stockanalysis 8.25).

**Backfill (clause 10)**: view recreate, no data backfill; migration applied to dev via smoke lifespan + replayed after each edit with `content_sha256` updated (#1333 replay path); test DBs apply the final file fresh (11 view DB tests + 105 fvb/fpi tests green).

**Rank-shift A/B (clause 11, version-isolated)**: `compute_rankings('v1.5-balanced')` — 3,916 scored in 304 s.
- Non-FPI (3,911): **2** value changes, mean |Δrank| **1.5** — the rest of the universe is untouched (surgical).
- FPI cohort in the scored set: **5 names** (ONC/TEVA/CRTO/MREO/ZLAB — the marker class; fingerprint FPIs never pass the `analysable` eligibility gate), 3 value changes, mean |Δrank| 447: their ADS-inflated garbage value inputs are gone and they degrade to the honest empty-components default.
- v1.3/v1.4 history untouched (append-only).

## Deploy window (conscious tradeoff)

sql/237 is live on dev (smoke lifespan). Until the jobs-daemon restart, scheduled v1.4 runs read the suppressed view under the old label — the error direction is strictly *better data* (garbage removed). Post-merge operator action: restart the `stack: jobs` VS Code task (already owed for v1.4 + this week's merges — one restart covers all).

## Checks

ruff ✓ format ✓ pyright 0 ✓ fast tier 5,344 ✓ targeted DB (fpi 4 + view 7 + fvb 105) ✓ smoke 153 ✓. Codex ckpt-2 run; both findings (key-stats leak, fvb pe-leg leak) confirmed real, fixed in `0a189272`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
