### PR TITLE
fix(#2118): 13f Official List fetch — follow SEC's -txt.txt rename, legacy fallback, honest raw-store URL

### DIFF
--- a/app/services/sec_13f_securities_list.py
+++ b/app/services/sec_13f_securities_list.py
@@ -3,7 +3,10 @@
 The Official List is the canonical free regulated source for
 CUSIP↔issuer mapping for US-listed equities and ADRs. SEC publishes
 it quarterly as a fixed-width TXT under
-``https://www.sec.gov/files/investment/13flist{year}q{quarter}.txt``.
+``https://www.sec.gov/files/investment/13flist{year}q{quarter}-txt.txt``
+(renamed from ``13flist{year}q{quarter}.txt`` at 2026q2 — #2118; the
+fetcher tries the current name first and falls back to the legacy one
+for older quarters).
 
 Why this matters: eBull's settled "free regulated-source-only"
 posture (#532) means we cannot license CUSIPs from CGS. The eToro
@@ -52,6 +55,7 @@ from __future__ import annotations
 
 import logging
 import re
+import urllib.error
 import urllib.request
 from collections import defaultdict
 from collections.abc import Callable, Iterator
@@ -74,7 +78,14 @@ from app.services.sec_13f_filer_directory import _last_completed_quarter
 logger = logging.getLogger(__name__)
 
 
-_LIST_URL = "https://www.sec.gov/files/investment/13flist{year}q{quarter}.txt"
+# SEC renamed the TXT at 2026q2 (#2118): the pre-rename name 404s for
+# 2026q2+. Try the current name first, fall back to the legacy name so
+# re-fetches of older quarters keep working. Same class as
+# prevention-log #1769 — SEC renames break pinned constants.
+_LIST_URL_PATTERNS = (
+    "https://www.sec.gov/files/investment/13flist{year}q{quarter}-txt.txt",
+    "https://www.sec.gov/files/investment/13flist{year}q{quarter}.txt",
+)
 
 # CUSIP shape: 9 alphanumeric. SEC uses CUSIP for US issuers and
 # CINS (CUSIP International Numbering System — same shape, alpha
@@ -109,16 +120,29 @@ class CusipCoverageBackfillResult:
     sweep: SweepReport
 
 
-def fetch_13f_list_txt(year: int, quarter: int) -> str:
-    """Fetch one quarterly Official List TXT. Raises on network or
-    decode failure — caller decides whether to retry or surface."""
-    url = _LIST_URL.format(year=year, quarter=quarter)
-    req = urllib.request.Request(url, headers={"User-Agent": settings.sec_user_agent})
-    with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 — fixed SEC URL
-        # SEC ships the list as ASCII; latin-1 decode is the safe
-        # fallback for the rare row with extended chars in issuer
-        # name (e.g. accented letters in foreign filer names).
-        return resp.read().decode("latin-1")
+def fetch_13f_list_txt(year: int, quarter: int) -> tuple[str, str]:
+    """Fetch one quarterly Official List TXT. Returns ``(payload,
+    source_url)`` — the URL that actually served the body, so the raw
+    store's audit trail stays honest across the #2118 rename. Tries the
+    current ``-txt.txt`` name first, falls back to the legacy name on
+    404; raises on network or decode failure (and re-raises the LAST
+    404 if every candidate misses) — caller decides whether to retry."""
+    last_err: urllib.error.HTTPError | None = None
+    for pattern in _LIST_URL_PATTERNS:
+        url = pattern.format(year=year, quarter=quarter)
+        req = urllib.request.Request(url, headers={"User-Agent": settings.sec_user_agent})
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:  # noqa: S310 — fixed SEC URL
+                # SEC ships the list as ASCII; latin-1 decode is the safe
+                # fallback for the rare row with extended chars in issuer
+                # name (e.g. accented letters in foreign filer names).
+                return resp.read().decode("latin-1"), url
+        except urllib.error.HTTPError as err:
+            if err.code != 404:
+                raise
+            last_err = err
+    assert last_err is not None  # loop body always runs: patterns is non-empty
+    raise last_err
 
 
 def _store_raw_list(
@@ -127,13 +151,16 @@ def _store_raw_list(
     year: int,
     quarter: int,
     payload: str,
+    source_url: str,
 ) -> None:
     """Persist the raw SEC TXT body to ``sec_reference_documents``
     BEFORE the parse step runs. Implements the eBull
     raw-payload-before-normalisation non-negotiable. Idempotent:
     re-fetching the same quarter overwrites the body and refreshes
-    ``fetched_at``. Codex / Claude review BLOCKING for #914."""
-    url = _LIST_URL.format(year=year, quarter=quarter)
+    ``fetched_at``. Codex / Claude review BLOCKING for #914.
+    ``source_url`` is the URL the fetch actually served (#2118 — the
+    current-vs-legacy name differs by quarter)."""
+    url = source_url
     conn.execute(
         """
         INSERT INTO sec_reference_documents (
@@ -461,7 +488,7 @@ def backfill_cusip_coverage(
     *,
     year: int | None = None,
     quarter: int | None = None,
-    fetch: Callable[[int, int], str] = fetch_13f_list_txt,
+    fetch: Callable[[int, int], tuple[str, str]] = fetch_13f_list_txt,
     today: date | None = None,
     threshold: float = MATCH_THRESHOLD,
 ) -> CusipCoverageBackfillResult:
@@ -481,12 +508,12 @@ def backfill_cusip_coverage(
         year = year if year is not None else y
         quarter = quarter if quarter is not None else q
 
-    payload = fetch(year, quarter)
+    payload, source_url = fetch(year, quarter)
     # Persist the raw SEC body BEFORE parsing — eBull non-negotiable
     # (Claude review BLOCKING #914). Re-wash workflows can replay
     # against the stored body without re-fetching from SEC; the
     # operator gets a "what did SEC say last quarter" audit trail.
-    _store_raw_list(conn, year=year, quarter=quarter, payload=payload)
+    _store_raw_list(conn, year=year, quarter=quarter, payload=payload, source_url=source_url)
     raw_securities = list(parse_13f_list(payload))
     # Skip deleted-this-quarter rows so a new mapping doesn't anchor
     # on a CUSIP the SEC just removed from the 13(f)-eligible list.

--- a/tests/test_sec_13f_securities_list.py
+++ b/tests/test_sec_13f_securities_list.py
@@ -205,7 +205,7 @@ class TestBackfillCusipCoverage:
             year=2025,
             quarter=4,
             today=date(2026, 5, 5),
-            fetch=lambda *_: payload,
+            fetch=lambda *_: (payload, "test://13flist"),
         )
 
         assert result.list_rows == 2
@@ -241,8 +241,12 @@ class TestBackfillCusipCoverage:
         conn.commit()
         payload = _line("037833100", "APPLE INC", "COM")
 
-        first = backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
-        second = backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
+        first = backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
+        second = backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
 
         assert first.inserted == 1
         # Second run: the instrument is now mapped, so it's not in
@@ -270,7 +274,9 @@ class TestBackfillCusipCoverage:
         # Synthesise a backfill that matches Apple Hospitality REIT
         # to the same CUSIP (engineered ambiguity for test clarity).
         payload = _line("037833100", "APPLE HOSPITALITY REIT", "COM")
-        result = backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
+        result = backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
 
         assert result.tombstoned_conflict == 1
         assert result.inserted == 0
@@ -289,7 +295,9 @@ class TestBackfillCusipCoverage:
         _seed_instrument(conn, iid=914_030, symbol="WIDGET", company_name="Acme Widget Manufacturing Co")
         conn.commit()
         payload = _line("999999999", "ENTIRELY DIFFERENT NAME LLC", "COM")
-        result = backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
+        result = backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
         assert result.inserted == 0
         assert result.tombstoned_unresolvable >= 1
 
@@ -305,7 +313,9 @@ class TestBackfillCusipCoverage:
         # Two distinct CUSIPs, both normalise to "ALPHABET" after
         # share-class strip.
         payload = _line("02079K305", "ALPHABET INC", "CL A") + _line("02079K107", "ALPHABET INC", "CL C")
-        result = backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
+        result = backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
         assert result.tombstoned_ambiguous == 1
         assert result.inserted == 0
 
@@ -319,7 +329,9 @@ class TestBackfillCusipCoverage:
         _seed_instrument(conn, iid=914_060, symbol="DEL", company_name="Deleted Issuer Corp")
         conn.commit()
         payload = _line("999999999", "DELETED ISSUER CORP", "COM", status="E", per_row_flag="D")
-        result = backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
+        result = backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
         # 'D' status is a deleted row; backfill skips it as
         # unresolvable to avoid mapping to a stale CUSIP.
         assert result.inserted == 0
@@ -383,7 +395,9 @@ class TestBackfillCusipCoverage:
         conn.commit()
         payload = _line("037833100", "APPLE INC", "COM")
 
-        backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
+        backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
 
         with conn.cursor() as cur:
             cur.execute(
@@ -396,7 +410,10 @@ class TestBackfillCusipCoverage:
         assert rows[0][0] == 2025
         assert rows[0][1] == 4
         assert rows[0][2] == payload
-        assert "13flist2025q4.txt" in rows[0][3]
+        # #2118: source_url records the URL the fetch actually served
+        # (current-vs-legacy name differs by quarter), not a formatted
+        # constant.
+        assert rows[0][3] == "test://13flist"
 
     def test_raw_payload_upsert_idempotent(
         self,
@@ -411,8 +428,12 @@ class TestBackfillCusipCoverage:
         first = _line("037833100", "APPLE INC", "COM")
         second = _line("037833100", "APPLE INC", "COM NEW")
 
-        backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: first)
-        backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: second)
+        backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (first, "test://13flist")
+        )
+        backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (second, "test://13flist")
+        )
 
         with conn.cursor() as cur:
             cur.execute(
@@ -434,7 +455,9 @@ class TestBackfillCusipCoverage:
         _seed_instrument(conn, iid=914_100, symbol="AAPL", company_name="Apple Inc.")
         conn.commit()
         payload = _line("037833100", "APPLE INC", "COM") + _line("999999999", "DELETED CORP", "COM", per_row_flag="D")
-        result = backfill_cusip_coverage(conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: payload)
+        result = backfill_cusip_coverage(
+            conn, year=2025, quarter=4, today=date(2026, 5, 5), fetch=lambda *_: (payload, "test://13flist")
+        )
         # 2 raw rows, 1 after deleted-status filter; list_rows is RAW.
         assert result.list_rows == 2
 
@@ -449,9 +472,9 @@ class TestBackfillCusipCoverage:
         conn.commit()
         captured: dict[str, tuple[int, int]] = {}
 
-        def _fake(year: int, quarter: int) -> str:
+        def _fake(year: int, quarter: int) -> tuple[str, str]:
             captured["q"] = (year, quarter)
-            return _line("037833100", "APPLE INC", "COM")
+            return _line("037833100", "APPLE INC", "COM"), "test://13flist"
 
         backfill_cusip_coverage(conn, today=date(2026, 5, 5), fetch=_fake)
         # 2026-05-05 → most recent closed quarter is 2026 Q1.
@@ -566,3 +589,79 @@ class TestParseDateNPORT:
         ts = _parse_filing_date("25-FEB-2026")
         assert ts is not None
         assert ts.date().isoformat() == "2026-02-25"
+
+
+class TestFetchUrlFallback:
+    """#2118: SEC renamed the TXT to ``13flist{y}q{q}-txt.txt`` at
+    2026q2. Fetch must try the current name first, fall back to the
+    legacy name on 404, and re-raise when every candidate 404s."""
+
+    @staticmethod
+    def _fake_urlopen(responses: dict[str, str]):
+        import io
+        import urllib.error
+
+        def _opener(req, timeout=0):  # noqa: ANN001, ANN202
+            url = req.full_url
+            if url in responses:
+                # BytesIO is already a context manager, like the real
+                # http.client.HTTPResponse.
+                return io.BytesIO(responses[url].encode("latin-1"))
+            raise urllib.error.HTTPError(url, 404, "Not Found", None, None)  # type: ignore[arg-type]
+
+        return _opener
+
+    def test_current_name_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import urllib.request
+
+        from app.services import sec_13f_securities_list as mod
+
+        current = "https://www.sec.gov/files/investment/13flist2026q2-txt.txt"
+        monkeypatch.setattr(urllib.request, "urlopen", self._fake_urlopen({current: "BODY-NEW"}))
+        payload, url = mod.fetch_13f_list_txt(2026, 2)
+        assert payload == "BODY-NEW"
+        assert url == current
+
+    def test_legacy_fallback_on_404(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import urllib.request
+
+        from app.services import sec_13f_securities_list as mod
+
+        legacy = "https://www.sec.gov/files/investment/13flist2025q4.txt"
+        monkeypatch.setattr(urllib.request, "urlopen", self._fake_urlopen({legacy: "BODY-OLD"}))
+        payload, url = mod.fetch_13f_list_txt(2025, 4)
+        assert payload == "BODY-OLD"
+        assert url == legacy
+
+    def test_all_404_reraises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import urllib.error
+        import urllib.request
+
+        from app.services import sec_13f_securities_list as mod
+
+        monkeypatch.setattr(urllib.request, "urlopen", self._fake_urlopen({}))
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            mod.fetch_13f_list_txt(2026, 3)
+        # The re-raised error is the LAST candidate's 404 (legacy name),
+        # so the operator log names the final URL tried.
+        assert exc_info.value.code == 404
+        assert exc_info.value.url == "https://www.sec.gov/files/investment/13flist2026q3.txt"
+
+    def test_non_404_http_error_raises_immediately(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import urllib.error
+        import urllib.request
+
+        from app.services import sec_13f_securities_list as mod
+
+        attempted: list[str] = []
+
+        def _opener(req, timeout=0):  # noqa: ANN001, ANN202
+            attempted.append(req.full_url)
+            raise urllib.error.HTTPError(req.full_url, 503, "Service Unavailable", None, None)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(urllib.request, "urlopen", _opener)
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            mod.fetch_13f_list_txt(2026, 2)
+        assert exc_info.value.code == 503
+        # Non-404 aborts immediately — no legacy-name fallback attempt.
+        assert attempted == ["https://www.sec.gov/files/investment/13flist2026q2-txt.txt"]


### PR DESCRIPTION
Closes #2118

## What

`cusip_universe_backfill` dead since 2026-07-05 (404 daily, attempt=5): SEC renamed the Official List TXT from `13flist{y}q{q}.txt` to `13flist{y}q{q}-txt.txt` at 2026q2 (verified on the live SEC staff-guidance page; old name 404s for 2026q2+, older quarters keep the legacy name).

- `_LIST_URL` → `_LIST_URL_PATTERNS` tuple: current `-txt.txt` name first, legacy fallback on 404. Non-404 raises immediately; all-404 re-raises the last candidate's 404.
- `fetch_13f_list_txt` returns `(payload, source_url)` — `_store_raw_list` records the URL that actually served the body (audit trail honest across the rename). Injectable `fetch` callable signature updated at its single production call site + all test fakes.
- Prevention lineage: same class as prevention-log #1769 (SEC rename breaks pinned constant); noted in module docstring.

## Security model

No auth/authz surface. Fetch is a fixed-pattern SEC URL (no user input in URL construction); `User-Agent` from settings unchanged. Files outside diff unaffected.

## Verification

- Gates (worktree @ 3ccacd59 base): ruff check/format clean, pyright 0 errors, fast tier `-m "not db"` exit 0, `tests/test_sec_13f_securities_list.py` 28 passed (DB tier, postgres-test), smoke 153 passed.
- **Backfill executed on dev DB** (definition-of-done clause 10): `backfill_cusip_coverage(conn)` run live from the branch — fetched 2026q2 via new URL, `list_rows=25333 inserted=154 sweep_promoted=143` (143 previously-stranded 13F holdings promoted into institutional_holdings).
- **Cross-source** (clause 9): source IS SEC direct — `sec_reference_documents` now carries 2026q2 with `source_url=.../13flist2026q2-txt.txt` (2,051,973 bytes) alongside 2026q1's legacy URL; both URL shapes probed live (`curl`: old name 404, new name 200).
- Codex ckpt-2: no correctness defects; one Low (assertion tightness) fixed in-commit — all-404 test pins last-candidate 404+URL, non-404 test pins immediate abort.

## Tradeoffs

- Legacy fallback retained indefinitely (2 URLs max per fetch, only on 404) — protects historical-quarter re-fetches; cost negligible.
- 2026q3 not yet published by SEC — job targets last completed quarter (q2), so no q3 dependency.

## Operator follow-up

Jobs daemon restarted 13:54 BST today WITHOUT this fix — next scheduled 05:00 run still 404s until a restart after merge. Will handle restart post-merge (owner: session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)