### PR TITLE
feat(#844 PR-1): unvested RSU/PSU counts via DERA FSNDS notes loader — award_type axis + ownership memo line

### DIFF
--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -670,6 +670,36 @@ So `financial_facts_raw` (sourced from companyfacts JSON, NO dimension/member co
 
 **Rule:** when a task assumes a per-class / per-segment / per-dimension XBRL fact "exists but isn't selected", verify it is actually reachable via our companyfacts ingest BEFORE designing — for multi-class share counts and any other dimensional fact, it is NOT. The combined-vs-per-class detection that ships meanwhile (#1646 `_detect_dual_class_denominator`) keys on the multi-class fingerprint: **the denominator falling back to us-gaap** `CommonStockSharesOutstanding` (taxonomy `us-gaap`, not `dei`) because every per-class DEI cover value was stripped. See data-engineer §Q15 + invariant I18.
 
+### 7.18 Note-level XBRL facts: plain FSDS is FACE-STATEMENTS-ONLY — the notes live in FSNDS (#844)
+
+DERA ships TWO products with near-identical names. The plain **Financial
+Statement Data Sets** (`/files/dera/data/financial-statement-data-sets/{y}q{n}.zip`,
+what #1590/#1623 consume) carries face financials + cover/parenthetical only —
+a note-level fact (RSU rollforward, ASC 718 tables) appears in ~10 filings a
+quarter (odd face-presenters), NOT the population. The full note tagging is in
+**Financial Statement and Notes Data Sets** (FSNDS,
+`/files/dera/data/financial-statement-notes-data-sets/…`). Empirically pinned
+2026-07-23 (nonvested-RSU tag): plain FSDS 2026q1 → 12 filings; FSNDS 2026_03
+→ 1,388.
+
+FSNDS specifics (vs FSDS):
+
+- **Monthly** `{YYYY}_{MM}_notes.zip` for ~the last 12 months, then DERA
+  **consolidates into quarterly** `{y}q{n}_notes.zip` — a rolling-12-monthlies
+  fetch alone leaves months 13-24 unreachable on a fresh install.
+- `num.tsv` keys dimensions by **`dimh`** (hash) → resolve via `dim.tsv`
+  (`dimhash` → `segments`); the null dimension is `dimh='0x00000000'` /
+  `dimn=0` / `segments=''`. An UNRESOLVED dimh is NOT the default — never
+  conflate.
+- `iprx` disambiguates otherwise-identical facts (primary presentation =
+  `iprx=0`); `version` is taxonomy-versioned per row (`us-gaap/2025`) —
+  prefix-match, never equality.
+- Consumer: `app/services/fsnds_notes_facts.py` (award_type axis,
+  spec docs/specs/etl/2026-07-23-drs-rsu-issuer-disclosures.md). The award
+  axis (`AwardTypeAndPlanNameAxis`) is NON-additive — members mix award types
+  with plan names (full-pop 2026_03: 58/91 default-vs-Σmembers disagreements);
+  never sum its members.
+
 ## 8. Operator checklist for new SEC integrations
 
 Before writing code that hits SEC EDGAR:

--- a/.claude/skills/metrics-analyst/SKILL.md
+++ b/.claude/skills/metrics-analyst/SKILL.md
@@ -113,6 +113,7 @@ description: eBull metrics analyst — what we measure, where it comes from, whe
 | TTM DPS | Capital returns | `instrument_dividend_summary.ttm_dps` | `/instruments/{symbol}/dividends` |
 | Universe coverage banner | Ownership | rollup `coverage.state` | `/instruments/{symbol}/ownership-rollup` |
 | Unrealised P&L (per position) | Risk + portfolio | derived from `quotes.last` | `/portfolio` |
+| Unvested RSU/PSU memo (#844) | Ownership | `instrument_dimensional_facts` axis `award_type` (FSNDS notes loader) → rollup `nonvested_awards` — no-sum read rule (default → single-std member → RSU-of-many → abstain), 548d staleness, overlay only (never a wedge) | `/instruments/{symbol}/ownership-rollup` |
 | Volume (daily) | Market data | `price_daily.volume` | `/instruments/{symbol}/candles` |
 | VWAP | Market data | (deferred) | — |
 | Yield-on-cost | Capital returns | derived FE | dividends drilldown |

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4783,6 +4783,17 @@ class _Def14ADriftModel(BaseModel):
     holders: list[str]
 
 
+class _NonvestedAwardsModel(BaseModel):
+    """Unvested RSU/PSU memo line (#844) — absolute count from the latest
+    10-K ASC 718 note (FSNDS ``award_type`` facts). Overlay only, never a
+    pie wedge. ``label`` is server-owned copy the FE renders verbatim."""
+
+    shares: Decimal
+    label: str
+    period_end: date
+    source_accession: str
+
+
 class _HistoricalSymbolModel(BaseModel):
     symbol: str
     effective_from: date
@@ -4919,6 +4930,9 @@ class OwnershipRollupResponse(BaseModel):
     # warning/critical drift alerts. Present on the no_data path too — the
     # coverage-integrity signal is denominator-independent.
     def14a_drift: _Def14ADriftModel | None = None
+    # Unvested RSU/PSU memo (#844). Null when no award facts, when the
+    # read rule abstains, or when the note is stale (548d bound).
+    nonvested_awards: _NonvestedAwardsModel | None = None
     computed_at: datetime
 
 
@@ -5039,6 +5053,16 @@ def _rollup_to_response(
                 holders=list(rollup.def14a_drift.holders),
             )
             if rollup.def14a_drift is not None
+            else None
+        ),
+        nonvested_awards=(
+            _NonvestedAwardsModel(
+                shares=rollup.nonvested_awards.shares,
+                label=rollup.nonvested_awards.label,
+                period_end=rollup.nonvested_awards.period_end,
+                source_accession=rollup.nonvested_awards.source_accession,
+            )
+            if rollup.nonvested_awards is not None
             else None
         ),
         historical_symbols=[

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -562,6 +562,9 @@ _INVOKERS[_bulk_jobs.JOB_SEC_FSDS_CLASS_SHARES_INGEST] = _tracked_zero_arg(
 _INVOKERS[_bulk_jobs.JOB_SEC_FSDS_DIMENSIONAL_INGEST] = _tracked_zero_arg(
     _bulk_jobs.JOB_SEC_FSDS_DIMENSIONAL_INGEST, _bulk_jobs.sec_fsds_dimensional_ingest_job
 )
+_INVOKERS[_bulk_jobs.JOB_SEC_FSNDS_NOTES_INGEST] = _tracked_zero_arg(
+    _bulk_jobs.JOB_SEC_FSNDS_NOTES_INGEST, _bulk_jobs.sec_fsnds_notes_ingest_job
+)
 _INVOKERS[_files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK] = _tracked_zero_arg(
     _files_walk.JOB_SEC_SUBMISSIONS_FILES_WALK, _files_walk.sec_submissions_files_walk_job
 )

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -83,6 +83,7 @@ Lane = Literal[
     "db_cusip",
     "db_ownership_obs",
     "db_raw_sweep",
+    "db_fsnds_notes",
     "db_size_sample",
     "db_thesis_dq",
     "db_thesis_break",
@@ -248,6 +249,10 @@ when one overruns). Scheduled-only, so NOT added to the
   bounded batches and holds its lane for minutes; on the catch-all
   ``db`` lane it would starve ``orchestrator_high_frequency_sync``
   (every-5-min, same lane) — the #1526/#1527 starvation class.
+* ``db_fsnds_notes`` — ``sec_fsnds_notes_ingest`` (#844, manual-only)
+  only. Streams up to 12 FSNDS monthly TSV archives (minutes) — same
+  starvation rationale as ``db_raw_sweep``; no SEC HTTP (archives
+  pre-fetched by ``sec_bulk_download``).
   Write-safety: sole writer of ``payload_sha256``/``payload_swept_at``;
   the raw-row UPDATE re-checks ``payload IS NOT NULL`` under its row
   lock, so concurrent ``store_raw`` upserts (sec_rate / sec_manifest
@@ -433,6 +438,13 @@ class JobSourceRegistryError(RuntimeError):
 #    ``docs/superpowers/specs/2026-05-17-orchestrator-inner-lock-removal.md``).
 
 MANUAL_TRIGGER_JOB_SOURCES: dict[str, Lane] = {
+    # sec_fsnds_notes_ingest — #844 unvested RSU/PSU counts from the cached
+    # FSNDS monthly archives. Streaming TSV parse + per-accession commits
+    # over ~12 monthlies (minutes) → own lane, NOT the catch-all ``db``
+    # (long-running; the raw_payload_retention_sweep precedent). No SEC
+    # HTTP (archives pre-fetched by sec_bulk_download). Invoker in
+    # app/jobs/runtime.py::_INVOKERS; not a bootstrap stage in v1.
+    "sec_fsnds_notes_ingest": "db_fsnds_notes",
     # filing_events_skip_tier_cleanup — one-shot retroactive delete
     # (#1013). Pure DB operation (no SEC HTTP) → ``db`` lane, matching
     # the other retention sweeps (financial_facts / raw_data). Companion

--- a/app/services/dimensional_facts.py
+++ b/app/services/dimensional_facts.py
@@ -49,8 +49,15 @@ from app.services.xbrl_instance import (
 
 logger = logging.getLogger(__name__)
 
-DimensionalAxis = Literal["business_segment", "product_service", "geographic"]
-DimensionalMetric = Literal["revenue", "operating_income", "assets"]
+DimensionalAxis = Literal["business_segment", "product_service", "geographic", "award_type"]
+DimensionalMetric = Literal["revenue", "operating_income", "assets", "nonvested_awards"]
+
+# Axes the #554 per-filing extractor (and the #1590 FSDS bulk loader) own.
+# The FSNDS notes loader (#844) owns ``award_type`` EXCLUSIVELY — the
+# per-filing rewash's delete-then-insert and the FSDS bulk existence
+# check are BOTH scoped to this tuple so neither wipes nor blocks the
+# other family's rows for the same 10-K accession.
+PER_FILING_AXES: tuple[DimensionalAxis, ...] = ("business_segment", "product_service", "geographic")
 
 # Period sanity window (prevention log §1455 — same bounds as the
 # sec_fundamentals parser guard).
@@ -71,11 +78,12 @@ _CONCEPT_TO_METRIC: dict[str, tuple[DimensionalMetric, int]] = {
 # carry instant contexts. Anything else for that metric is skipped.
 _INSTANT_METRICS: frozenset[str] = frozenset({"assets"})
 
-# Metrics allowed per axis route (spec §D3 table).
+# Metrics allowed per axis route (spec §D3 table; award_type per #844).
 _AXIS_METRICS: dict[DimensionalAxis, frozenset[str]] = {
     "business_segment": frozenset({"revenue", "operating_income", "assets"}),
     "product_service": frozenset({"revenue"}),
     "geographic": frozenset({"revenue"}),
+    "award_type": frozenset({"nonvested_awards"}),
 }
 
 _XSI_NIL = "{http://www.w3.org/2001/XMLSchema-instance}nil"

--- a/app/services/dimensional_facts.py
+++ b/app/services/dimensional_facts.py
@@ -359,6 +359,20 @@ def prettify_member(member_qname: str) -> str:
     return _CAMEL_BOUNDARY.sub(" ", local).strip()
 
 
+def prettify_localname(localname: str) -> str:
+    """Quick-tier member label for the DERA TSV loaders (no label linkbase
+    in FSDS/FSNDS): split camelCase on lower/digit→upper boundaries.
+    ``SpecialtyDiagnostics`` → ``Specialty Diagnostics``; ``US`` → ``US``.
+    Shared by the FSDS bulk + FSNDS notes loaders (review NITPICK on
+    PR #2122 — was duplicated verbatim)."""
+    out: list[str] = []
+    for i, ch in enumerate(localname):
+        if i > 0 and ch.isupper() and (localname[i - 1].islower() or localname[i - 1].isdigit()):
+            out.append(" ")
+        out.append(ch)
+    return "".join(out)
+
+
 def _label_for(member_qname: str, labels: Mapping[str, str]) -> str:
     hit = labels.get(_member_fragment(member_qname)) if ":" in member_qname else None
     if hit:

--- a/app/services/dimensional_facts_store.py
+++ b/app/services/dimensional_facts_store.py
@@ -26,6 +26,7 @@ import psycopg
 from psycopg.rows import dict_row
 
 from app.services.dimensional_facts import (
+    PER_FILING_AXES,
     DimensionalAxis,
     DimensionalFact,
     DimensionalMetric,
@@ -67,9 +68,14 @@ def replace_accession_rows(
         "SELECT pg_advisory_xact_lock(hashtext(%s::text || ':' || %s::text)::bigint)",
         (instrument_id, source_accession),
     )
+    # Axis-scoped delete (#844): this writer owns ONLY the segment-family
+    # axes. The FSNDS notes loader writes ``award_type`` rows for the SAME
+    # 10-K accessions — an unscoped delete would silently wipe them on
+    # every rewash.
     conn.execute(
-        "DELETE FROM instrument_dimensional_facts WHERE instrument_id = %s AND source_accession = %s",
-        (instrument_id, source_accession),
+        "DELETE FROM instrument_dimensional_facts"
+        " WHERE instrument_id = %s AND source_accession = %s AND axis = ANY(%s)",
+        (instrument_id, source_accession, list(PER_FILING_AXES)),
     )
     if not facts:
         return 0

--- a/app/services/fsds_class_shares.py
+++ b/app/services/fsds_class_shares.py
@@ -141,9 +141,11 @@ def parse_class_member(segments: str) -> str | None:
     return member
 
 
-def read_fsds_sub(zf: zipfile.ZipFile) -> dict[str, FsdsSub]:
-    """``sub.txt`` -> ``{adsh: FsdsSub}``. sub.txt is small (~2 MB)."""
-    name = "sub.txt"
+def read_fsds_sub(zf: zipfile.ZipFile, *, name: str = "sub.txt") -> dict[str, FsdsSub]:
+    """``sub.txt`` -> ``{adsh: FsdsSub}``. sub.txt is small (~2 MB).
+
+    FSNDS monthly archives (#844) carry the same columns as ``sub.tsv`` —
+    pass ``name="sub.tsv"``."""
     if name not in zf.namelist():
         candidates = [n for n in zf.namelist() if n.endswith("/" + name) or n == name]
         if not candidates:
@@ -172,11 +174,13 @@ def read_fsds_sub(zf: zipfile.ZipFile) -> dict[str, FsdsSub]:
     return out
 
 
-def iter_fsds_num(zf: zipfile.ZipFile) -> Iterator[dict[str, str]]:
+def iter_fsds_num(zf: zipfile.ZipFile, *, name: str = "num.txt") -> Iterator[dict[str, str]]:
     """Stream ``num.txt`` rows as dicts (header-keyed). 530 MB/quarter — never
     materialised. Manual tab-split (DERA num.txt is a flat TSV with NO quoting;
-    csv.reader's quote handling could misfire on a stray ``"`` in a footnote)."""
-    name = "num.txt"
+    csv.reader's quote handling could misfire on a stray ``"`` in a footnote).
+
+    FSNDS monthly archives (#844) share the row shape — pass ``name="num.tsv"``
+    (or ``"dim.tsv"``, same flat-TSV encoding)."""
     if name not in zf.namelist():
         candidates = [n for n in zf.namelist() if n.endswith("/" + name) or n == name]
         if not candidates:

--- a/app/services/fsds_dimensional_facts.py
+++ b/app/services/fsds_dimensional_facts.py
@@ -43,6 +43,7 @@ from app.services.dimensional_facts import (
     _AXIS_METRICS,
     _CONCEPT_TO_METRIC,
     _INSTANT_METRICS,
+    PER_FILING_AXES,
     DimensionalAxis,
     DimensionalFact,
     DimensionalMetric,
@@ -218,9 +219,13 @@ def _write_bulk_accession(
         "SELECT pg_advisory_xact_lock(hashtext(%s::text || ':' || %s::text)::bigint)",
         (instrument_id, accession),
     )
+    # Axis-scoped existence check (#844): the FSNDS notes loader writes
+    # ``award_type`` rows for the same 10-K accessions — an unscoped check
+    # would see them and permanently skip this accession's segment facts.
     existing = conn.execute(
-        "SELECT 1 FROM instrument_dimensional_facts WHERE instrument_id = %s AND source_accession = %s LIMIT 1",
-        (instrument_id, accession),
+        "SELECT 1 FROM instrument_dimensional_facts"
+        " WHERE instrument_id = %s AND source_accession = %s AND axis = ANY(%s) LIMIT 1",
+        (instrument_id, accession, list(PER_FILING_AXES)),
     ).fetchone()
     if existing is not None or not facts:
         return 0

--- a/app/services/fsds_dimensional_facts.py
+++ b/app/services/fsds_dimensional_facts.py
@@ -48,6 +48,7 @@ from app.services.dimensional_facts import (
     DimensionalFact,
     DimensionalMetric,
     mark_value_overage_subtotals,
+    prettify_localname,
 )
 from app.services.fsds_class_shares import iter_fsds_num, read_fsds_sub
 from app.services.sec_identity import siblings_for_issuer_cik
@@ -109,17 +110,9 @@ def _classify_fsds_segments(segments_cell: str) -> tuple[DimensionalAxis, str] |
     return None
 
 
-def _prettify_member(localname: str) -> str:
-    """Quick-tier member label: split camelCase to spaced words (no label linkbase in
-    FSDS). ``SpecialtyDiagnostics`` → ``Specialty Diagnostics``; ``US`` → ``US``;
-    ``FoodAndBeverage`` → ``Food And Beverage``. The per-filing rewash replaces this
-    with the real linkbase label on convergence."""
-    out: list[str] = []
-    for i, ch in enumerate(localname):
-        if i > 0 and ch.isupper() and (localname[i - 1].islower() or localname[i - 1].isdigit()):
-            out.append(" ")
-        out.append(ch)
-    return "".join(out)
+# Quick-tier member label (shared with the FSNDS notes loader). The
+# per-filing rewash replaces it with the real linkbase label on convergence.
+_prettify_member = prettify_localname
 
 
 def _subtract_months(d: date, months: int) -> date:

--- a/app/services/fsnds_notes_facts.py
+++ b/app/services/fsnds_notes_facts.py
@@ -1,0 +1,362 @@
+"""DERA FSNDS (Financial Statement and Notes) monthly loader — unvested
+RSU/PSU counts (#844).
+
+Note-level XBRL facts are reachable through NO other pipeline: companyfacts
+strips dimensional facts (sec-edgar §7.17) and plain FSDS is
+face-statements-only. FSNDS monthlies (``{YYYY}_{MM}_notes.zip``) carry the
+full note tagging: ``num.tsv`` (facts, ``dimh``-keyed) + ``dim.tsv``
+(dimension-hash → segments) + ``sub.tsv`` (filings index, same columns as
+FSDS ``sub.txt``).
+
+Scope (spec docs/specs/etl/2026-07-23-drs-rsu-issuer-disclosures.md):
+ONE tag — the ASC 718-10-50-2(c)(2) nonvested-award count — routed to
+``instrument_dimensional_facts`` axis ``award_type``. The award axis is
+NON-ADDITIVE by construction (it mixes award types with plan names; full-pop
+2026_03: 58/91 default-vs-member-sum disagreements) so this loader stores
+rows verbatim and NEVER sums; the read rule picks default-total /
+single-standard-member / RSU-member, else abstains.
+
+Convergence: the segment-family writers (#554 per-filing, #1590 FSDS bulk)
+and this loader share the per-(instrument, accession) advisory lock but are
+axis-scoped on delete/existence (``PER_FILING_AXES`` vs ``award_type``) so
+neither wipes nor blocks the other's rows for the same 10-K accession.
+"""
+
+from __future__ import annotations
+
+import logging
+import zipfile
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, time
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from app.services.dimensional_facts import DimensionalFact
+from app.services.fsds_class_shares import iter_fsds_num, read_fsds_sub
+from app.services.sec_identity import siblings_for_issuer_cik
+
+logger = logging.getLogger(__name__)
+
+PARSER_VERSION = "fsnds_notes_v1"
+_TENK_FORMS = frozenset({"10-K", "10-K/A"})
+
+NONVESTED_TAG = (
+    "ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsNonvestedNumber"
+)
+
+# FSNDS null-dimension hash (dim.tsv row ``0x00000000`` / segments='') —
+# empirically pinned 2026_03. Default rows are ALSO detectable via
+# ``dimn=0``; both are checked (belt + braces: an unresolved dimh must
+# NEVER be mistaken for the default).
+_NULL_DIMH = "0x00000000"
+
+# member_qname stored for the dimensionless (all-award-types) total. The
+# axis domain localname, per the us-gaap taxonomy's AwardTypeAndPlanName
+# domain; the read rule prefers this row outright.
+DEFAULT_MEMBER = "AwardTypeDomain"
+DEFAULT_LABEL = "All award types"
+
+
+# Standard us-gaap award-type members whose scope is company-wide-for-that-
+# type by construction. A single NON-standard member (usually a plan name)
+# has unknowable scope → abstain. Spec "Read rule".
+STANDARD_AWARD_MEMBERS: frozenset[str] = frozenset(
+    {
+        "RestrictedStockUnitsRSU",
+        "RestrictedStock",
+        "PerformanceShares",
+        "PhantomShareUnitsPhantomStockUnits",
+        "StockAppreciationRightsSARS",
+        "DeferredStockUnits",
+    }
+)
+
+_RSU_MEMBER = "RestrictedStockUnitsRSU"
+
+
+@dataclass(frozen=True)
+class NonvestedMemo:
+    """The one figure the ownership memo line renders (absolute count —
+    never a pie wedge, never a Σ over members: the award axis mixes award
+    types with plan names and is non-additive by design, full-pop
+    2026_03 58/91 default-vs-member-sum disagreements)."""
+
+    shares: Decimal
+    label: str  # server-owned memo copy fragment, e.g. "unvested RSUs"
+    member_qname: str
+
+
+def select_nonvested_memo(rows: list[tuple[str, str, Decimal]]) -> NonvestedMemo | None:
+    """Pick the honest figure from one accession's latest-period award rows
+    (``(member_qname, member_label, val)``), or ``None`` to abstain.
+
+    Priority: default total → the single standard member → the RSU member
+    among many (definitionally the RSU-typed count; scope named in the
+    label) → abstain. NEVER sums members."""
+    by_member = {qname: (label, val) for qname, label, val in rows}
+    default = by_member.get(DEFAULT_MEMBER)
+    if default is not None:
+        return NonvestedMemo(shares=default[1], label="unvested awards", member_qname=DEFAULT_MEMBER)
+    members = {q: lv for q, lv in by_member.items() if q != DEFAULT_MEMBER}
+    if len(members) == 1:
+        (qname, (label, val)) = next(iter(members.items()))
+        if qname in STANDARD_AWARD_MEMBERS:
+            memo_label = "unvested RSUs" if qname == _RSU_MEMBER else f"unvested {label.lower()}"
+            return NonvestedMemo(shares=val, label=memo_label, member_qname=qname)
+        return None
+    rsu = members.get(_RSU_MEMBER)
+    if rsu is not None:
+        return NonvestedMemo(shares=rsu[1], label="unvested RSUs", member_qname=_RSU_MEMBER)
+    return None
+
+
+def _prettify_member(localname: str) -> str:
+    """CamelCase → spaced words (no label linkbase in FSNDS); same quick
+    tier as the FSDS loader."""
+    out: list[str] = []
+    for i, ch in enumerate(localname):
+        if i > 0 and ch.isupper() and (localname[i - 1].islower() or localname[i - 1].isdigit()):
+            out.append(" ")
+        out.append(ch)
+    return "".join(out)
+
+
+def _parse_value(raw: str) -> Decimal | None:
+    try:
+        return Decimal(raw)
+    except InvalidOperation, ValueError, TypeError:
+        return None
+
+
+def read_award_dim_map(zf: zipfile.ZipFile) -> dict[str, str]:
+    """``dim.tsv`` → {dimhash: member_localname} for SINGLE-axis
+    ``AwardType=<member>`` cells only. Cross-dimensional cells (e.g.
+    ``AwardType=…;Range=…``) are simply absent from the map, so num rows
+    carrying them fall through unrouted — the exact-set rejection comes
+    for free."""
+    out: dict[str, str] = {}
+    for row in iter_fsds_num(zf, name="dim.tsv"):
+        seg = (row.get("segments") or "").strip()
+        if not seg:
+            continue
+        axis, eq, member = seg.rstrip(";").partition("=")
+        if not eq or axis != "AwardType" or not member or ";" in member:
+            continue
+        dimhash = row.get("dimhash", "")
+        if dimhash:
+            out[dimhash] = member
+    return out
+
+
+# (ddate, dimh) → chosen row within one accession. iprx arbitration: DERA
+# defines iprx as the disambiguator for otherwise-identical facts; the
+# primary presentation is iprx=0, so the LOWEST iprx wins. A same-iprx
+# value conflict drops the key (conservative; mirrors the FSDS loader).
+_FactKey = tuple[date, str]
+
+
+@dataclass
+class _AccBuf:
+    facts: dict[_FactKey, tuple[int, Decimal, str | None]] = field(default_factory=dict)
+    conflicted: set[_FactKey] = field(default_factory=set)
+
+
+@dataclass
+class FsndsNotesResult:
+    rows_written: int = 0
+    accessions_written: int = 0
+    accessions_skipped_existing: int = 0
+    accessions_no_instrument: int = 0
+    instruments_written: int = 0
+
+
+def _accumulate(per_adsh: dict[str, _AccBuf], row: dict[str, str], award_map: dict[str, str]) -> None:
+    """Route one gated num.tsv row into its accession buffer."""
+    if (row.get("coreg") or "").strip():
+        return  # co-registrant facts belong to a different entity
+    if row.get("uom") != "shares" or row.get("qtrs") != "0":
+        return  # the count is an instant share figure — anything else is noise
+    if not (row.get("version") or "").startswith("us-gaap/"):
+        return  # reject filer-extension homonyms (DERA versions per row, e.g. us-gaap/2025)
+    dimh = row.get("dimh", "")
+    dimn = (row.get("dimn") or "").strip()
+    is_default = dimn == "0" or dimh == _NULL_DIMH
+    if not is_default and dimh not in award_map:
+        return  # cross-dimensional / non-award cell — unrouted by design
+    raw_ddate = row.get("ddate", "")
+    if len(raw_ddate) != 8:
+        return  # strptime("%Y%m%d") greedily accepts 7-char inputs — gate length first
+    try:
+        ddate = datetime.strptime(raw_ddate, "%Y%m%d").date()
+    except ValueError:
+        return
+    value = _parse_value(row.get("value", ""))
+    if value is None:
+        return
+    try:
+        iprx = int(row.get("iprx") or 0)
+    except ValueError:
+        return
+    dcml = (row.get("dcml") or "").strip() or None
+
+    buf = per_adsh.setdefault(row["adsh"], _AccBuf())
+    # Default rows normalise to ONE key regardless of how the source
+    # encoded "no dimension" (dimn=0 vs the null hash) — two default rows
+    # for one ddate must arbitrate here, or they collide on the identity
+    # index (same member_qname + period_end) and fail the insert batch.
+    key: _FactKey = (ddate, _NULL_DIMH if is_default else dimh)
+    if key in buf.conflicted:
+        return
+    incumbent = buf.facts.get(key)
+    if incumbent is None:
+        buf.facts[key] = (iprx, value, dcml)
+        return
+    inc_iprx, inc_value, _inc_dcml = incumbent
+    if iprx < inc_iprx:
+        buf.facts[key] = (iprx, value, dcml)
+    elif iprx == inc_iprx and value != inc_value:
+        del buf.facts[key]
+        buf.conflicted.add(key)
+
+
+def _write_award_accession(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    accession: str,
+    form_type: str,
+    filed_at: datetime,
+    facts: list[DimensionalFact],
+) -> int:
+    """Insert one accession's award facts for one instrument — ONLY if no
+    ``award_type`` row exists for ``(instrument, accession)`` yet. Takes the
+    SAME advisory lock key as the segment-family writers so all
+    check-then-insert paths on one accession serialize; the existence check
+    is axis-scoped so their segment rows never block this write."""
+    conn.execute(
+        "SELECT pg_advisory_xact_lock(hashtext(%s::text || ':' || %s::text)::bigint)",
+        (instrument_id, accession),
+    )
+    existing = conn.execute(
+        "SELECT 1 FROM instrument_dimensional_facts"
+        " WHERE instrument_id = %s AND source_accession = %s AND axis = 'award_type' LIMIT 1",
+        (instrument_id, accession),
+    ).fetchone()
+    if existing is not None or not facts:
+        return 0
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO instrument_dimensional_facts (
+                instrument_id, axis, member_qname, member_label, metric,
+                unit, is_subtotal, period_start, period_end, val, decimals,
+                source_accession, form_type, filed_at, parser_version
+            ) VALUES (
+                %(instrument_id)s, 'award_type', %(member_qname)s, %(member_label)s,
+                'nonvested_awards', 'shares', FALSE, NULL,
+                %(period_end)s, %(val)s, %(decimals)s, %(source_accession)s,
+                %(form_type)s, %(filed_at)s, %(parser_version)s
+            )
+            """,
+            [
+                {
+                    "instrument_id": instrument_id,
+                    "member_qname": f.member_qname,
+                    "member_label": f.member_label,
+                    "period_end": f.period_end,
+                    "val": f.val,
+                    "decimals": f.decimals,
+                    "source_accession": accession,
+                    "form_type": form_type,
+                    "filed_at": filed_at,
+                    "parser_version": PARSER_VERSION,
+                }
+                for f in facts
+            ],
+        )
+        # psycopg3 executemany rowcount is cumulative across the batch.
+        return cur.rowcount
+
+
+def ingest_fsnds_notes_archive(
+    conn: psycopg.Connection[Any],
+    *,
+    archive_path: Path,
+    fsnds_month: str,
+) -> FsndsNotesResult:
+    """Stream one ``{YYYY}_{MM}_notes.zip`` and load nonvested-award facts.
+    Commits per accession (advisory locks release promptly); the caller need
+    not wrap this in a transaction."""
+    result = FsndsNotesResult()
+    with zipfile.ZipFile(archive_path) as zf:
+        award_map = read_award_dim_map(zf)
+        subs = read_fsds_sub(zf, name="sub.tsv")
+        tenk = {adsh: sub for adsh, sub in subs.items() if sub.form in _TENK_FORMS and sub.filed is not None}
+        per_adsh: dict[str, _AccBuf] = {}
+        for row in iter_fsds_num(zf, name="num.tsv"):
+            if row.get("tag") == NONVESTED_TAG and row.get("adsh", "") in tenk:
+                _accumulate(per_adsh, row, award_map)
+
+    for adsh, buf in per_adsh.items():
+        if not buf.facts:
+            continue
+        sub = tenk[adsh]
+        siblings = siblings_for_issuer_cik(conn, sub.cik)
+        if not siblings:
+            result.accessions_no_instrument += 1
+            conn.commit()  # close the read txn opened by the lookup above
+            continue
+        facts: list[DimensionalFact] = []
+        for (ddate, dimh), (_iprx, value, dcml) in buf.facts.items():
+            member = award_map.get(dimh)
+            facts.append(
+                DimensionalFact(
+                    axis="award_type",
+                    member_qname=member if member is not None else DEFAULT_MEMBER,
+                    member_label=_prettify_member(member) if member is not None else DEFAULT_LABEL,
+                    metric="nonvested_awards",
+                    unit="shares",
+                    is_subtotal=False,
+                    period_start=None,
+                    period_end=ddate,
+                    val=value,
+                    decimals=dcml,
+                )
+            )
+        assert sub.filed is not None  # tenk filter guarantees this
+        filed_at = datetime.combine(sub.filed, time.min, tzinfo=UTC)
+        wrote_any = False
+        with conn.transaction():
+            for instrument_id in siblings:
+                n = _write_award_accession(
+                    conn,
+                    instrument_id=instrument_id,
+                    accession=adsh,
+                    form_type=sub.form,
+                    filed_at=filed_at,
+                    facts=facts,
+                )
+                if n > 0:
+                    result.rows_written += n
+                    result.instruments_written += 1
+                    wrote_any = True
+        # Explicit top-level commit per accession: persists rows AND releases
+        # the advisory xact lock (see the FSDS loader's identical note).
+        conn.commit()
+        if wrote_any:
+            result.accessions_written += 1
+        else:
+            result.accessions_skipped_existing += 1
+
+    logger.info(
+        "sec_fsnds_notes_ingest: month=%s rows=%d accessions_written=%d skipped_existing=%d no_instrument=%d",
+        fsnds_month,
+        result.rows_written,
+        result.accessions_written,
+        result.accessions_skipped_existing,
+        result.accessions_no_instrument,
+    )
+    return result

--- a/app/services/fsnds_notes_facts.py
+++ b/app/services/fsnds_notes_facts.py
@@ -34,7 +34,7 @@ from typing import Any
 
 import psycopg
 
-from app.services.dimensional_facts import DimensionalFact
+from app.services.dimensional_facts import DimensionalFact, prettify_localname
 from app.services.fsds_class_shares import iter_fsds_num, read_fsds_sub
 from app.services.sec_identity import siblings_for_issuer_cik
 
@@ -61,18 +61,19 @@ DEFAULT_LABEL = "All award types"
 
 
 # Standard us-gaap award-type members whose scope is company-wide-for-that-
-# type by construction. A single NON-standard member (usually a plan name)
+# type by construction, mapped to fixed server-owned memo copy (a generic
+# ``label.lower()`` mangles acronym members — "…rights sars"; review
+# NITPICK on PR #2122). A single NON-standard member (usually a plan name)
 # has unknowable scope → abstain. Spec "Read rule".
-STANDARD_AWARD_MEMBERS: frozenset[str] = frozenset(
-    {
-        "RestrictedStockUnitsRSU",
-        "RestrictedStock",
-        "PerformanceShares",
-        "PhantomShareUnitsPhantomStockUnits",
-        "StockAppreciationRightsSARS",
-        "DeferredStockUnits",
-    }
-)
+_STANDARD_MEMBER_COPY: dict[str, str] = {
+    "RestrictedStockUnitsRSU": "unvested RSUs",
+    "RestrictedStock": "unvested restricted stock",
+    "PerformanceShares": "unvested performance shares",
+    "PhantomShareUnitsPhantomStockUnits": "unvested phantom share units",
+    "StockAppreciationRightsSARS": "unvested stock appreciation rights",
+    "DeferredStockUnits": "unvested deferred stock units",
+}
+STANDARD_AWARD_MEMBERS: frozenset[str] = frozenset(_STANDARD_MEMBER_COPY)
 
 _RSU_MEMBER = "RestrictedStockUnitsRSU"
 
@@ -102,10 +103,10 @@ def select_nonvested_memo(rows: list[tuple[str, str, Decimal]]) -> NonvestedMemo
         return NonvestedMemo(shares=default[1], label="unvested awards", member_qname=DEFAULT_MEMBER)
     members = {q: lv for q, lv in by_member.items() if q != DEFAULT_MEMBER}
     if len(members) == 1:
-        (qname, (label, val)) = next(iter(members.items()))
-        if qname in STANDARD_AWARD_MEMBERS:
-            memo_label = "unvested RSUs" if qname == _RSU_MEMBER else f"unvested {label.lower()}"
-            return NonvestedMemo(shares=val, label=memo_label, member_qname=qname)
+        (qname, (_label, val)) = next(iter(members.items()))
+        copy = _STANDARD_MEMBER_COPY.get(qname)
+        if copy is not None:
+            return NonvestedMemo(shares=val, label=copy, member_qname=qname)
         return None
     rsu = members.get(_RSU_MEMBER)
     if rsu is not None:
@@ -113,15 +114,9 @@ def select_nonvested_memo(rows: list[tuple[str, str, Decimal]]) -> NonvestedMemo
     return None
 
 
-def _prettify_member(localname: str) -> str:
-    """CamelCase → spaced words (no label linkbase in FSNDS); same quick
-    tier as the FSDS loader."""
-    out: list[str] = []
-    for i, ch in enumerate(localname):
-        if i > 0 and ch.isupper() and (localname[i - 1].islower() or localname[i - 1].isdigit()):
-            out.append(" ")
-        out.append(ch)
-    return "".join(out)
+# CamelCase → spaced-words quick-tier label, shared with the FSDS loader
+# (review NITPICK on PR #2122 — was duplicated verbatim).
+_prettify_member = prettify_localname
 
 
 def _parse_value(raw: str) -> Decimal | None:

--- a/app/services/fsnds_notes_facts.py
+++ b/app/services/fsnds_notes_facts.py
@@ -122,7 +122,10 @@ _prettify_member = prettify_localname
 def _parse_value(raw: str) -> Decimal | None:
     try:
         return Decimal(raw)
-    except InvalidOperation, ValueError, TypeError:
+    except InvalidOperation:
+        # raw is always a str here (TSV field) — Decimal(str) raises only
+        # InvalidOperation (review NITPICK round 4: ValueError/TypeError
+        # were dead branches).
         return None
 
 

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -1196,7 +1196,7 @@ def _read_nonvested_awards(
             WITH winner AS (
                 SELECT f.source_accession
                   FROM instrument_dimensional_facts f
-                 WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type'
+                 WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type' AND NOT f.is_subtotal
                  ORDER BY f.filed_at DESC, f.source_accession DESC
                  LIMIT 1
             ),
@@ -1204,14 +1204,14 @@ def _read_nonvested_awards(
                 SELECT MAX(f.period_end) AS period_end
                   FROM instrument_dimensional_facts f
                   JOIN winner w ON w.source_accession = f.source_accession
-                 WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type'
+                 WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type' AND NOT f.is_subtotal
             )
             SELECT f.member_qname, f.member_label, f.val,
                    f.period_end, f.source_accession
               FROM instrument_dimensional_facts f
               JOIN winner w ON w.source_accession = f.source_accession
               JOIN latest l ON l.period_end = f.period_end
-             WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type'
+             WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type' AND NOT f.is_subtotal
             """,
             {"iid": instrument_id},
         )

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -337,6 +337,22 @@ class Def14ADriftInfo:
 
 
 @dataclass(frozen=True)
+class NonvestedAwardsInfo:
+    """Unvested RSU/PSU memo line (#844) — absolute count from the latest
+    10-K's ASC 718 note via the FSNDS loader (axis ``award_type``). Overlay
+    ONLY: RSUs are not outstanding until vested, so this never joins the
+    pie/residual/concentration. ``label`` is server-owned copy
+    ("unvested RSUs" / "unvested awards" / "unvested <member>") chosen by
+    ``select_nonvested_memo`` — the axis is non-additive (award types mix
+    with plan names) so the figure is a single row, never a Σ."""
+
+    shares: Decimal
+    label: str
+    period_end: date
+    source_accession: str
+
+
+@dataclass(frozen=True)
 class SanityChecks:
     """Raw plausibility facts over the pie-wedge slices (#1647 part 4).
 
@@ -572,6 +588,10 @@ class OwnershipRollup:
     # when the rollup is otherwise degraded. Last field with a default so
     # existing constructors need no change.
     def14a_drift: Def14ADriftInfo | None = None
+    # Unvested RSU/PSU memo (#844). None when no award facts, when the read
+    # rule abstains, or when the latest note is staler than the 548-day
+    # bound. Main assembly only (a no_data page has no chart to memo).
+    nonvested_awards: NonvestedAwardsInfo | None = None
 
     @classmethod
     def no_data(
@@ -1157,6 +1177,58 @@ def _read_def14a_drift(conn: psycopg.Connection[Any], instrument_id: int) -> Def
         alert_count=n,
         chip=chip,
         holders=tuple(str(r["holder_name"]) for r in rows[:3]),
+    )
+
+
+def _read_nonvested_awards(
+    conn: psycopg.Connection[Any], instrument_id: int, *, today: date
+) -> NonvestedAwardsInfo | None:
+    """Unvested-award memo (#844): winner accession = latest filed
+    ``award_type`` filing; figure = the read-rule pick over the winner's
+    latest-period rows (``select_nonvested_memo`` — never a Σ; the axis is
+    non-additive). None on no data, read-rule abstention, or a note staler
+    than the shared 548-day bound."""
+    from app.services.fsnds_notes_facts import select_nonvested_memo
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            WITH winner AS (
+                SELECT f.source_accession
+                  FROM instrument_dimensional_facts f
+                 WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type'
+                 ORDER BY f.filed_at DESC, f.source_accession DESC
+                 LIMIT 1
+            ),
+            latest AS (
+                SELECT MAX(f.period_end) AS period_end
+                  FROM instrument_dimensional_facts f
+                  JOIN winner w ON w.source_accession = f.source_accession
+                 WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type'
+            )
+            SELECT f.member_qname, f.member_label, f.val,
+                   f.period_end, f.source_accession
+              FROM instrument_dimensional_facts f
+              JOIN winner w ON w.source_accession = f.source_accession
+              JOIN latest l ON l.period_end = f.period_end
+             WHERE f.instrument_id = %(iid)s AND f.axis = 'award_type'
+            """,
+            {"iid": instrument_id},
+        )
+        rows = cur.fetchall()
+    if not rows:
+        return None
+    period_end: date = rows[0]["period_end"]
+    if _denominator_too_stale(period_end, today):
+        return None
+    memo = select_nonvested_memo([(str(r["member_qname"]), str(r["member_label"]), Decimal(r["val"])) for r in rows])
+    if memo is None:
+        return None
+    return NonvestedAwardsInfo(
+        shares=memo.shares,
+        label=memo.label,
+        period_end=period_end,
+        source_accession=str(rows[0]["source_accession"]),
     )
 
 
@@ -3645,6 +3717,9 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
             def14a_drift=def14a_drift,
         )
     treasury, treasury_as_of = _read_treasury_from_current(conn, instrument_id)
+    # Unvested-award memo (#844) — overlay only, denominator-independent,
+    # but rendered only on the main (charted) path.
+    nonvested_awards = _read_nonvested_awards(conn, instrument_id, today=_snapshot_today(conn))
     sql_candidates = _collect_canonical_holders_from_current(conn, instrument_id)
     def14a_rows = _read_def14a_unmatched_from_current(conn, instrument_id)
     matched, unmatched_def14a = _enrich_and_union_def14a(conn, instrument_id, sql_candidates, def14a_rows=def14a_rows)
@@ -3824,6 +3899,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
         denominator_cross_check=denominator_cross_check,
         computed_at=datetime.now(tz=UTC),
         def14a_drift=def14a_drift,
+        nonvested_awards=nonvested_awards,
     )
 
 

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -278,6 +278,10 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
     # the manual-only triangle (source + metadata + invoker) and documents
     # zero-param-by-design (vs the bootstrap-only fallback, also empty).
     "sec_manifest_tombstone_stale": (),
+    # sec_fsnds_notes_ingest — #844 unvested RSU/PSU counts from the cached
+    # FSNDS monthlies. No operator-tunable params (archives on disk are the
+    # input; re-run is idempotent via the axis-scoped convergence guard).
+    "sec_fsnds_notes_ingest": (),
     # raw_payload_retention_sweep — #1014 payload-null sweep.
     # ``batch_size`` stays internal (implementation knob, same call as
     # #1013); ``dry_run`` is operator-facing and DEFAULTS TRUE so a

--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -193,6 +193,21 @@ def last_n_quarters(n: int, *, today: date | None = None) -> list[str]:
     return out
 
 
+def last_n_months(n: int, *, today: date | None = None) -> list[str]:
+    """Return ``YYYY_MM`` labels of the last ``n`` completed months,
+    newest-first (excludes the in-progress month — DERA publishes the
+    FSNDS monthly weeks after month end)."""
+    today = today or date.today()
+    year, month = today.year, today.month
+    out: list[str] = []
+    for _ in range(n):
+        month -= 1
+        if month == 0:
+            year, month = year - 1, 12
+        out.append(f"{year}_{month:02d}")
+    return out
+
+
 _FORM13F_START_MONTHS: Final[tuple[int, ...]] = (3, 6, 9, 12)
 """Form 13F rolling-3-month windows start on the 1st of these months.
 
@@ -258,6 +273,7 @@ def build_bulk_archive_inventory(
     n_quarters_insider: int = 8,
     n_quarters_nport: int = 4,
     n_quarters_fsds: int = 4,
+    n_months_fsnds: int = 12,
     today: date | None = None,
 ) -> list[BulkArchive]:
     """Return the full inventory of archives Phase A3 downloads."""
@@ -308,6 +324,20 @@ def build_bulk_archive_inventory(
             BulkArchive(
                 name=f"fsds_{q}.zip",
                 url=f"{SEC_BASE_URL}/files/dera/data/financial-statement-data-sets/{q}.zip",
+                optional=(idx == 0),
+            )
+        )
+    # DERA Financial Statement AND NOTES Data Sets (#844) — the ONLY
+    # pipeline-reachable source for note-level facts (unvested RSU/PSU
+    # counts): companyfacts strips dimensional facts, plain FSDS is
+    # face-statements-only. Monthly; published weeks after month close, so
+    # the newest is optional (mirrors the FSDS #1423 posture). NOTE the
+    # path segment differs from FSDS: financial-statement-notes-data-sets.
+    for idx, m in enumerate(last_n_months(n_months_fsnds, today=today)):
+        archives.append(
+            BulkArchive(
+                name=f"fsnds_{m}_notes.zip",
+                url=f"{SEC_BASE_URL}/files/dera/data/financial-statement-notes-data-sets/{m}_notes.zip",
                 optional=(idx == 0),
             )
         )

--- a/app/services/sec_bulk_download.py
+++ b/app/services/sec_bulk_download.py
@@ -341,6 +341,23 @@ def build_bulk_archive_inventory(
                 optional=(idx == 0),
             )
         )
+    # DERA serves only ~12 months as monthlies, then consolidates into
+    # QUARTERLY {y}q{n}_notes.zip (page-verified 2026-07-23: monthlies
+    # 2025_07→2026_06, quarterlies 2025q2 and older). Quarters 5-8 back
+    # cover the note-freshness window (548d on period_end + filing lag)
+    # for a fresh install — without them a 13-18-month-old 10-K note is
+    # policy-fresh but never ingested (codex ckpt-2 finding). The newest
+    # of the four sits on the consolidation boundary (may still be
+    # monthly-only) → optional; its months are then covered by the
+    # monthly set above.
+    for idx, q in enumerate(last_n_quarters(8, today=today)[4:8]):
+        archives.append(
+            BulkArchive(
+                name=f"fsnds_{q}_notes.zip",
+                url=f"{SEC_BASE_URL}/files/dera/data/financial-statement-notes-data-sets/{q}_notes.zip",
+                optional=(idx == 0),
+            )
+        )
     return archives
 
 

--- a/app/services/sec_bulk_orchestrator_jobs.py
+++ b/app/services/sec_bulk_orchestrator_jobs.py
@@ -46,6 +46,7 @@ JOB_SEC_INSIDER_INGEST_FROM_DATASET: Final[str] = "sec_insider_ingest_from_datas
 JOB_SEC_NPORT_INGEST_FROM_DATASET: Final[str] = "sec_nport_ingest_from_dataset"
 JOB_SEC_FSDS_CLASS_SHARES_INGEST: Final[str] = "sec_fsds_class_shares_ingest"
 JOB_SEC_FSDS_DIMENSIONAL_INGEST: Final[str] = "sec_fsds_dimensional_ingest"
+JOB_SEC_FSNDS_NOTES_INGEST: Final[str] = "sec_fsnds_notes_ingest"
 
 
 # Post-ingest batched _current refresh chunk size (PR-4 spec §8).
@@ -1062,4 +1063,43 @@ def sec_fsds_dimensional_ingest_job() -> None:
     if failed_archives:
         raise RuntimeError(
             f"sec_fsds_dimensional_ingest: {len(failed_archives)} archives failed: " + "; ".join(failed_archives)
+        )
+
+
+def sec_fsnds_notes_ingest_job() -> None:
+    """Stream the cached ``fsnds_*_notes.zip`` monthlies and load unvested
+    RSU/PSU counts (axis ``award_type``) into ``instrument_dimensional_facts``
+    (#844, spec docs/specs/etl/2026-07-23-drs-rsu-issuer-disclosures.md).
+
+    Operator-invokable (not a bootstrap stage in v1 — the stage-slot wiring is
+    a follow-up); standalone-safe: ingests whatever ``fsnds_*_notes.zip`` is
+    cached, skips quietly when none. Archives are NOT deleted (deterministic
+    names — a re-download overwrites, same posture as fsds_*.zip)."""
+    archives = _list_archives_matching("fsnds_")
+    if not archives:
+        logger.info("sec_fsnds_notes_ingest: no fsnds_*_notes.zip cached, skipping")
+        return
+
+    from app.services.fsnds_notes_facts import ingest_fsnds_notes_archive
+
+    failed_archives: list[str] = []
+    total_written = 0
+    n_ok = 0
+    for archive in archives:
+        fsnds_month = archive.name.removeprefix("fsnds_").removesuffix("_notes.zip")
+        with psycopg.connect(settings.database_url) as conn:
+            try:
+                # The ingester commits per accession (advisory-lock hygiene); no outer txn.
+                result = ingest_fsnds_notes_archive(conn=conn, archive_path=archive, fsnds_month=fsnds_month)
+            except Exception as exc:  # noqa: BLE001
+                conn.rollback()
+                logger.exception("sec_fsnds_notes_ingest: archive=%s failed", archive.name)
+                failed_archives.append(f"{archive.name}: {exc}")
+                continue
+        total_written += result.rows_written
+        n_ok += 1
+    logger.info("sec_fsnds_notes_ingest: total_rows_written=%d archives=%d", total_written, n_ok)
+    if failed_archives:
+        raise RuntimeError(
+            f"sec_fsnds_notes_ingest: {len(failed_archives)} archives failed: " + "; ".join(failed_archives)
         )

--- a/docs/specs/etl/2026-07-23-drs-rsu-issuer-disclosures.md
+++ b/docs/specs/etl/2026-07-23-drs-rsu-issuer-disclosures.md
@@ -1,0 +1,217 @@
+# DRS + restricted/RSU issuer disclosures (#844, #788 Phase 5)
+
+Status: spec (codex ckpt-1 findings incorporated). Issue: #844. Parent: #788.
+
+## Goal
+
+Two operator-visible overlay metrics on the ownership panel, both issuer-disclosed only:
+
+1. **Unvested award count** (RSU/PSU, company-wide) — memo line below the chart,
+   e.g. "151.6M unvested RSUs" (AAPL). Never a pie wedge (RSUs are not
+   outstanding until vested); absolute count only (see "DenominatorBasis" note).
+2. **DRS / registered-share split** (curated cohort) — overlay chip,
+   e.g. "66.2M shares (15%) registered with transfer agent @ 2026-03-18" (GME).
+
+## Source rule
+
+1. **Unvested RSU/PSU counts:** ASC 718-10-50-2(c)(2)(i)/(ii) (the SEC
+   taxonomy's own reference for the tag) mandates the nonvested-award
+   rollforward in the share-based-compensation note. iXBRL-tagged
+   `us-gaap:ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsNonvestedNumber`
+   (uom=shares, instant), dimensioned by
+   `ShareBasedCompensationArrangementsByShareBasedPaymentAwardAwardTypeAndPlanNameAxis`
+   (FSNDS `segments` label `AwardType=<member>`). Served structurally by DERA
+   **Financial Statement and Notes Data Sets** (FSNDS, monthly
+   `num.tsv` + `dim.tsv` + `sub.tsv`,
+   `https://www.sec.gov/files/dera/data/financial-statement-notes-data-sets/{YYYY}_{MM}_notes.zip`).
+   Note-level facts are reachable through NO other pipeline we have:
+   companyfacts strips dimensional facts (sec-edgar §7.17) and plain FSDS is
+   face-statements-only (new gotcha — extracted to sec-edgar skill in this PR).
+2. **Award-type axis is non-additive BY NAME:** the axis mixes award *types*
+   with *plan names* — a plan member and an award-type member can tag the same
+   units. Σ-over-members is therefore forbidden (overlapping-by-design, the
+   #1916 class). Read rule below never sums.
+3. **Issue premise correction (acceptance 2):** the issue sourced the AAPL RSU
+   memo from the "DEF 14A vesting table". Reg S-K Item 402(f) (Outstanding
+   Equity Awards at Fiscal Year-End) is **per-NEO only** — no company-wide
+   unvested total exists in DEF 14A. Corrected source = 10-K note, per rule 1.
+4. **DRS / registered split:** Reg S-K Item 201(b)(1) mandates only the
+   *approximate number of holders of record* (10-K Item 5). The
+   registered-vs-street **share** split is voluntary narrative — no XBRL tag,
+   no mandated location (extraction therefore searches the whole primary doc,
+   not an Item-5 anchor). Issuer-disclosed-only with a curated cohort (issue
+   scope + original Codex pushback). Absence ≠ zero; non-cohort issuers
+   surface no DRS figure at all.
+5. **Options excluded from v1** (conscious tradeoff): the source tag covers
+   equity instruments *other than* options; options disclose
+   outstanding/exercisable (different tags, different dilution semantics).
+   Memo copy names the member ("unvested RSUs"), never "all unvested equity".
+
+## Full-population verification
+
+### RSU route selection (probes 2026-07-23, scripts in session scratchpad)
+
+| Route | Full-pop probe | Verdict |
+| --- | --- | --- |
+| companyfacts non-dimensional | 2,985 / 20,087 CIK files ever carried the tag; only ~460 with latest-end ≥ 2025 (AAPL's non-dimensional tagging stopped 2014) | REJECTED |
+| FSDS quarterly `num.txt` | 10 filings (2025q4) / 12 (2026q1) — face-statement product, notes absent | REJECTED |
+| FSNDS monthly `num.tsv` | **409 filings (2025_10) / 1,388 (2026_03)**; AAPL 10-K `0000320193-25-000079`: **151,574,000** @ 2025-09-30 (`AwardType=RestrictedStockUnitsRSU`); GME 10-K `0001326380-26-000013`: **2,257,883** @ 2026-01-31 | **ADOPTED** |
+
+### Member-sum additivity (falsified — drives the read rule)
+
+Per (adsh, latest ddate), filings carrying BOTH a default (no-dimension) total
+and AwardType member rows: 2025_10 → 11/34 disagree; 2026_03 → **58/91
+disagree** (>0.5% relative). Σ-members is unsafe on the full population.
+
+Read-rule coverage under the no-sum policy (latest ddate per adsh, iprx=0,
+qtrs=0, uom=shares):
+
+| month | filings | default_total | single_std_member | rsu_member_of_many | suppressed |
+| --- | --- | --- | --- | --- | --- |
+| 2025_10 | 409 | 55 | 104 | 95 | 155 (38%) |
+| 2026_03 | 1,388 | 138 | 577 | 264 | 409 (29%) |
+
+62-71% of tag-bearing filings render with zero fabrication; the rest are
+honest absences (multi-member sets with no default and no RSU member, or a
+single NON-standard member whose scope is unknowable).
+
+### DRS cohort corpus (34 era-filings fetched + scanned 2026-07-23)
+
+| Issuer | Disclosing | Era | Shape |
+| --- | --- | --- | --- |
+| GME | every 10-K/10-K/A/10-Q from `0001326380-23-000019` (10-K filed 2023-03-28) through `0001326380-26-000025` (10-Q 2026-06-11) — 15/15 | 2023-03 → present | "approximately X million … held by Cede & Co … and approximately Y million shares … held by registered holders with our transfer agent[, Computershare]" (order varies; per-sentence as-of date present in 10-Qs) |
+| AMC | `0001411579-25-000073` (10-Q 2025-11-05), `…26-000016` (10-K), `…26-000051` (10-Q) — 3/3 since start; ZERO in 2017-2025-08 filings | 2025-11 → present | "…were held by N registered holders with our transfer agent and approximately Z … held by Cede & Co …" ("million" sometimes omitted; registered-holder count inline) |
+
+Latest verified figures: GME 66.2M (15%) registered / 382.4M (85%) Cede,
+177,522 record holders @ 2026-03-18; AMC ~2.0M (0.4%) registered by 14,021
+holders / ~527.5M (99.6%) Cede @ 2026-02-18. The issue's "~75M historically"
+(GME) has decayed to 66.2M — every stored row carries `as_of_date`; the read
+path serves the latest disclosure, never a remembered constant.
+
+Two extraction landmines the corpus surfaced (both encoded as fixture tests):
+
+- **Decimal split:** "382.4 million" — naive sentence-split on "." severs the
+  figure. Extraction runs regex windows over normalized whole-text, never
+  sentence-splits.
+- **iXBRL word fragmentation:** GME 10-Qs render "approxim ately",
+  "sh ares", "o utstandi ng" after naive tag-strip. Normalization replaces
+  *inline* tags (span, ix:*, a, b, i, font) with "" and *block* tags
+  (p, div, td, tr, br, li) with " " before whitespace collapse.
+
+## Design
+
+### RSU — structured (FSNDS)
+
+- **Bulk download:** add FSNDS monthly archives to
+  `sec_bulk_download.build_archives` — rolling 12 months, newest marked
+  optional (publication lags month close; mirrors the FSDS #1423 posture).
+  Archives deleted after ingest (same lifecycle as FSDS quarterlies).
+- **Loader** `app/services/fsnds_notes_facts.py` (sibling of
+  `fsds_dimensional_facts.py`): stream `num.tsv`; keep rows with the nonvested
+  tag AND `uom='shares'` AND `qtrs='0'` (instant — DERA readme) AND
+  `version` prefix `us-gaap/` (DERA versions the taxonomy per row,
+  e.g. `us-gaap/2024` — never equality-match) AND `iprx=0` (primary
+  presentation; if an
+  (adsh, ddate, dimh) has only iprx>0 rows, take the lowest iprx —
+  DERA defines iprx as the disambiguator for otherwise-identical facts);
+  10-K/10-K/A adsh set from `sub.tsv`; resolve `dimh` against `dim.tsv`
+  (preload only hashes seen for the tag); accept the empty-segment (default)
+  row and single-axis `AwardType=<member>` cells; reject cross-dimensional
+  cells (exact-set rule, same posture as FSDS `_classify_fsds_segments`);
+  sibling-CIK fanout (data-engineer fan-out rule).
+- **Store:** `instrument_dimensional_facts`. Migration: `axis` CHECK +=
+  `'award_type'`, `metric` CHECK += `'nonvested_awards'`; `DimensionalAxis`
+  Literal += `'award_type'`; concept→metric + per-route metric maps extended.
+  Default-total rows store member_qname/member_label = the domain default
+  (`AwardTypeDomain` / label "All award types"). Instant fact
+  (`period_start` NULL, `period_end` = ddate). Existing identity index,
+  convergence guard + advisory lock reused as-is (the #554 per-filing path may
+  later replace bulk rows per accession unchanged).
+- **Read rule (no summing, in priority order per instrument's latest 10-K
+  accession, `is_subtotal` excluded):**
+  1. default-total row present → render it, label "unvested awards";
+  2. exactly one AwardType member AND member ∈ standard us-gaap award-type
+     member set (`RestrictedStockUnitsRSU`, `RestrictedStock`,
+     `PerformanceShares`, `PhantomShareUnitsPhantomStockUnits`,
+     `StockAppreciationRightsSARS`, `DeferredStockUnits`) → render with
+     member label;
+  3. multiple members incl. `RestrictedStockUnitsRSU` → render the RSU member
+     alone, labelled "unvested RSUs" (definitionally that member's count;
+     scope visible in the label);
+  4. else → no memo (honest absence).
+  Staleness: accession's `period_end` older than the existing 548-day
+  denominator-staleness bound → suppress.
+- **Overlay only:** contributes nothing to pie/residual/concentration
+  (prevention-log additive-vs-overlay rule).
+- **DenominatorBasis note (issue supersession):** the issue's
+  `denominator_basis='shares_outstanding_plus_unvested'` predates the current
+  `DenominatorBasis` contract (`pie_wedge|institution_subset|proxy_disclosure`,
+  `ownership_rollup.py` + API + FE types). The memo renders an **absolute
+  count** — no percentage, no denominator claim — so v1 adds NO new basis
+  value and touches no existing contract. If a %-of-diluted rendering is ever
+  wanted, that's a separate contract migration.
+
+### DRS — curated text
+
+- **Allowlist:** `DRS_DISCLOSURE_CIKS` single-source constant
+  ({GME `0001326380`, AMC `0001411579`} at v1); expand as issuers surface.
+- **Forms:** 10-K, 10-K/A, 10-Q (corpus: GME's freshest figures are
+  quarterly). Manifest-parser hook for allowlisted CIKs only.
+- **Extraction:** normalized whole-doc text (inline/block tag rule above);
+  regex family covering both corpus shapes (Cede-first / registered-first,
+  "million" suffix optional, parenthesised percent optional, optional
+  "as of <date>" per sentence, optional inline registered-holder count).
+  Captures: registered_shares, registered_pct, street_shares, street_pct,
+  holders_of_record, as_of_date (falls back to period end when the sentence
+  carries no date — AMC's shape dates the outstanding sentence, not the
+  split). Fail-open: no match → no row + one log line, never blocks the
+  filing's other parsers.
+- **Sanity:** when both sides present, registered + street within 2% of
+  the disclosed outstanding (or each side's pct within 3pp of its implied
+  share) else drop the row (log, don't guess).
+- **Store:** `ownership_drs_observations` — instrument_id (sibling fanout),
+  source_accession, form_type, filed_at, as_of_date, registered_shares,
+  registered_pct, street_shares, street_pct, holders_of_record,
+  parser_version; UNIQUE (instrument_id, source_accession).
+- **Read path + staleness policy (ckpt-1 finding 7):** latest row per
+  instrument by (as_of_date, filed_at) → `drs` overlay object on the rollup
+  payload (shares, pct, as_of_date, accession). Chip renders ONLY when
+  `as_of_date` is within **400 days** (annual 10-K cadence + slack); staler
+  rows surface only in the category-coverage drilldown as
+  "issuer disclosure stale (as of <date>)". A parser miss on a newer filing
+  therefore degrades to visible staleness, never a silently-wrong "current"
+  figure. Non-cohort instruments: no DRS object at all — no fabricated
+  "0 DRS" state. The 5-state coverage banner machine (settled #840/#923) is
+  untouched.
+
+### FE
+
+- Memo line (unvested awards) + DRS chip on the ownership panel, reusing the
+  existing overlay/memo row pattern. Change-coupled FE-QA: eyeball GME
+  (DRS chip + RSU memo) and AAPL (RSU memo, no DRS chip) live pages.
+
+## Backfill
+
+- FSNDS rolling-12 fetch + loader run over each month (10-K rows only) —
+  records the universe-overlap figure in the PR (definition-of-done clause 8).
+- DRS: run the parser over the full cohort era corpus (GME 15 + AMC 3
+  filings) — the corpus IS the full population; hit table goes in the PR.
+- Smoke panel (clause 8): GME, AAPL, AMC + MSFT/JPM for
+  no-DRS/no-regression checks; operator figure via
+  `/instruments/{symbol}/ownership-rollup`.
+
+## Out of scope (unchanged from issue + new)
+
+- Universe-wide DRS inference; Computershare bulk feed; short interest (P6).
+- Unvested options (tradeoff above).
+- FSNDS `txt.tsv` text facts; 10-Q RSU facts (annual grain matches FSDS).
+- Per-NEO vesting detail from DEF 14A (exec-comp owns it).
+- Per-member multi-line memo for the suppressed 29-38% (future extension).
+
+## Risks / sizing
+
+- FSNDS monthlies are 100-700MB each; loader streams; disk transient.
+- Award-member vocabulary variance is absorbed by the standard-member
+  allowlist + suppress default — never a fabricated total.
+- GME/AMC may reword — fail-open extraction + 400d staleness policy degrade
+  to visible staleness, never a wrong number.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "autoprefixer": "^10.4.20",
     "jsdom": "^25.0.1",
-    "postcss": "^8.4.47",
+    "postcss": "^8.5.22",
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
     "vite": "^6.4.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -55,13 +55,13 @@ importers:
         version: 4.7.0(vite@6.4.3(@types/node@22.19.17)(jiti@1.21.7))
       autoprefixer:
         specifier: ^10.4.20
-        version: 10.4.27(postcss@8.5.8)
+        version: 10.4.27(postcss@8.5.22)
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
       postcss:
-        specifier: ^8.4.47
-        version: 8.5.8
+        specifier: ^8.5.22
+        version: 8.5.22
       tailwindcss:
         specifier: ^3.4.13
         version: 3.4.19
@@ -92,6 +92,10 @@ packages:
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/compat-data@7.29.0':
@@ -136,6 +140,10 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -163,6 +171,10 @@ packages:
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -1145,8 +1157,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1243,8 +1255,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -1621,6 +1633,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
@@ -1683,6 +1701,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-identifier@7.29.7': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.29.2':
@@ -1705,6 +1725,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.29.2': {}
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -1948,8 +1970,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.29.2
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -2129,13 +2151,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.4.27(postcss@8.5.8):
+  autoprefixer@10.4.27(postcss@8.5.22):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001786
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.8
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
 
   axe-core@4.11.4: {}
@@ -2552,7 +2574,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.16: {}
 
   node-releases@2.0.37: {}
 
@@ -2584,28 +2606,28 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  postcss-import@15.1.0(postcss@8.5.8):
+  postcss-import@15.1.0(postcss@8.5.22):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.22
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.8):
+  postcss-js@4.1.0(postcss@8.5.22):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.8
+      postcss: 8.5.22
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.22):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.8
+      postcss: 8.5.22
 
-  postcss-nested@6.2.0(postcss@8.5.8):
+  postcss-nested@6.2.0(postcss@8.5.22):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.22
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -2615,9 +2637,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2815,11 +2837,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.8
-      postcss-import: 15.1.0(postcss@8.5.8)
-      postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)
-      postcss-nested: 6.2.0(postcss@8.5.8)
+      postcss: 8.5.22
+      postcss-import: 15.1.0(postcss@8.5.22)
+      postcss-js: 4.1.0(postcss@8.5.22)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.22)
+      postcss-nested: 6.2.0(postcss@8.5.22)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -2902,7 +2924,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.22
       rollup: 4.60.1
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -233,6 +233,19 @@ export interface OwnershipDef14ADrift {
   readonly holders: readonly string[];
 }
 
+/** Unvested RSU/PSU memo line (#844) — absolute count from the latest
+ *  10-K ASC 718 note. Overlay only (never a pie wedge — RSUs are not
+ *  outstanding until vested). ``label`` is server-owned copy rendered
+ *  verbatim (e.g. "unvested RSUs"). */
+export interface OwnershipNonvestedAwards {
+  /** Decimal-as-string share count. */
+  readonly shares: string;
+  readonly label: string;
+  /** ISO ``YYYY-MM-DD`` — the note's balance date. */
+  readonly period_end: string;
+  readonly source_accession: string;
+}
+
 /** One row of ``instrument_symbol_history``, oldest-first. Frontend
  *  renders a "Filed as X" callout when the chain includes any symbol
  *  other than the current one (Batch 7 of #788). */
@@ -399,6 +412,10 @@ export interface OwnershipRollupResponse {
    *  drift alerts; present on the no_data path too (denominator-
    *  independent). Optional for back-compat. */
   readonly def14a_drift?: OwnershipDef14ADrift | null;
+  /** Unvested RSU/PSU memo (#844). Null when no award facts, when the
+   *  server read-rule abstains, or when the note is stale. Optional for
+   *  back-compat. */
+  readonly nonvested_awards?: OwnershipNonvestedAwards | null;
   readonly computed_at: string;
 }
 

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -39,6 +39,7 @@ import { useNavigate } from "react-router-dom";
 import { fetchOwnershipRollup } from "@/api/ownership";
 import type {
   OwnershipDef14ADrift,
+  OwnershipNonvestedAwards,
   OwnershipRollupResponse,
   OwnershipSlice,
   OwnershipSliceCategory,
@@ -321,6 +322,7 @@ function PanelBody({ rollup, onWedgeClick }: PanelBodyProps): JSX.Element {
           </p>
           <SliceTable rollup={rollup} />
           <ResidualLine rollup={rollup} />
+          <NonvestedAwardsMemo memo={rollup.nonvested_awards ?? null} />
           <p className="mt-2 text-xs text-slate-400 dark:text-slate-500">
             Click any colored wedge for the per-filer drilldown.
           </p>
@@ -368,6 +370,31 @@ function Def14ADriftChip({
         <span className="opacity-80"> Worst: {drift.holders.join(", ")}.</span>
       )}
     </div>
+  );
+}
+
+function NonvestedAwardsMemo({
+  memo,
+}: {
+  readonly memo: OwnershipNonvestedAwards | null;
+}): JSX.Element | null {
+  // #844 — unvested RSU/PSU memo. Absolute count only (RSUs are not
+  // outstanding until vested — never a wedge); server-owned label.
+  if (memo === null) {
+    return null;
+  }
+  const shares = parseShareCount(memo.shares);
+  if (shares === null || shares <= 0) {
+    return null;
+  }
+  return (
+    <p
+      className="mt-1 text-xs text-slate-500 dark:text-slate-400"
+      data-test="nonvested-awards-memo"
+    >
+      +{formatShares(shares)} {memo.label} (not outstanding until vested; as of{" "}
+      {memo.period_end}).
+    </p>
   );
 }
 

--- a/sql/238_dimensional_facts_award_type.sql
+++ b/sql/238_dimensional_facts_award_type.sql
@@ -1,0 +1,25 @@
+-- 238_dimensional_facts_award_type.sql
+--
+-- #844 (spec docs/specs/etl/2026-07-23-drs-rsu-issuer-disclosures.md)
+-- — extend instrument_dimensional_facts with the award-type axis +
+-- nonvested-awards metric for the FSNDS notes loader (unvested RSU/PSU
+-- counts from the ASC 718-10-50-2(c)(2) rollforward, 10-K note level).
+--
+-- Constraint names verified against dev pg_constraint 2026-07-23
+-- (auto-named by the sql/193 column CHECKs).
+
+BEGIN;
+
+ALTER TABLE instrument_dimensional_facts
+    DROP CONSTRAINT instrument_dimensional_facts_axis_check;
+ALTER TABLE instrument_dimensional_facts
+    ADD CONSTRAINT instrument_dimensional_facts_axis_check CHECK (axis IN
+        ('business_segment', 'product_service', 'geographic', 'award_type'));
+
+ALTER TABLE instrument_dimensional_facts
+    DROP CONSTRAINT instrument_dimensional_facts_metric_check;
+ALTER TABLE instrument_dimensional_facts
+    ADD CONSTRAINT instrument_dimensional_facts_metric_check CHECK (metric IN
+        ('revenue', 'operating_income', 'assets', 'nonvested_awards'));
+
+COMMIT;

--- a/tests/test_fsds_dimensional_facts.py
+++ b/tests/test_fsds_dimensional_facts.py
@@ -221,9 +221,11 @@ def test_lock_templates_byte_identical() -> None:
 
     bulk = _lock_sql("app/services/fsds_dimensional_facts.py")
     store = _lock_sql("app/services/dimensional_facts_store.py")
+    notes = _lock_sql("app/services/fsnds_notes_facts.py")
     assert bulk, "no pg_advisory_xact_lock template found in fsds_dimensional_facts.py"
     assert store, "no pg_advisory_xact_lock template found in dimensional_facts_store.py"
-    assert bulk == store, f"advisory-lock templates desynced: bulk={bulk} store={store}"
+    assert notes, "no pg_advisory_xact_lock template found in fsnds_notes_facts.py"
+    assert bulk == store == notes, f"advisory-lock templates desynced: bulk={bulk} store={store} notes={notes}"
 
 
 # --- DB integration: convergence guard + CIK fan-out + 10-K filter --------------

--- a/tests/test_fsnds_notes_facts.py
+++ b/tests/test_fsnds_notes_facts.py
@@ -1,0 +1,310 @@
+"""FSNDS notes loader (#844): read-rule policy, row routing, axis-scoped
+convergence against the segment-family writers."""
+
+from __future__ import annotations
+
+import zipfile
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import psycopg
+import pytest
+
+from app.services.dimensional_facts_store import replace_accession_rows
+from app.services.fsnds_notes_facts import (
+    _NULL_DIMH,
+    DEFAULT_MEMBER,
+    NonvestedMemo,
+    _AccBuf,
+    _accumulate,
+    ingest_fsnds_notes_archive,
+    read_award_dim_map,
+    select_nonvested_memo,
+)
+from app.services.ownership_rollup import _read_nonvested_awards
+
+# --- select_nonvested_memo: the no-sum read rule --------------------------------
+
+_RSU = "RestrictedStockUnitsRSU"
+
+
+def _row(qname: str, val: int, label: str | None = None) -> tuple[str, str, Decimal]:
+    return (qname, label or qname, Decimal(val))
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected"),
+    [
+        # Default total present → wins outright, even over members.
+        (
+            [_row(DEFAULT_MEMBER, 500), _row(_RSU, 300), _row("PerformanceShares", 100)],
+            NonvestedMemo(shares=Decimal(500), label="unvested awards", member_qname=DEFAULT_MEMBER),
+        ),
+        # Exactly one standard member → renders with member label.
+        (
+            [_row(_RSU, 151_574_000)],
+            NonvestedMemo(shares=Decimal(151_574_000), label="unvested RSUs", member_qname=_RSU),
+        ),
+        (
+            [_row("PerformanceShares", 42, "Performance Shares")],
+            NonvestedMemo(shares=Decimal(42), label="unvested performance shares", member_qname="PerformanceShares"),
+        ),
+        # Single NON-standard member (plan name — unknowable scope) → abstain.
+        ([_row("TwoThousandTwentyPlan", 42)], None),
+        # Multiple members incl. RSU → RSU member alone (never a Σ).
+        (
+            [_row(_RSU, 300), _row("PerformanceShares", 100)],
+            NonvestedMemo(shares=Decimal(300), label="unvested RSUs", member_qname=_RSU),
+        ),
+        # Multiple members, no RSU, no default → abstain (non-additive axis).
+        ([_row("RestrictedStock", 10), _row("PerformanceShares", 20)], None),
+        ([], None),
+    ],
+)
+def test_select_nonvested_memo(rows: list[tuple[str, str, Decimal]], expected: NonvestedMemo | None) -> None:
+    assert select_nonvested_memo(rows) == expected
+
+
+# --- _accumulate: row gating + iprx arbitration ---------------------------------
+
+
+def _num(
+    adsh: str = "acc-1",
+    ddate: str = "20250930",
+    qtrs: str = "0",
+    uom: str = "shares",
+    dimh: str = "0xaaa",
+    dimn: str = "1",
+    iprx: str = "0",
+    value: str = "100",
+    version: str = "us-gaap/2025",
+    coreg: str = "",
+    dcml: str = "0",
+) -> dict[str, str]:
+    return {
+        "adsh": adsh,
+        "ddate": ddate,
+        "qtrs": qtrs,
+        "uom": uom,
+        "dimh": dimh,
+        "dimn": dimn,
+        "iprx": iprx,
+        "value": value,
+        "version": version,
+        "coreg": coreg,
+        "dcml": dcml,
+    }
+
+
+_AWARD_MAP = {"0xaaa": _RSU}
+
+
+def _run(rows: list[dict[str, str]]) -> dict[str, _AccBuf]:
+    per: dict[str, _AccBuf] = {}
+    for r in rows:
+        _accumulate(per, r, _AWARD_MAP)
+    return per
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        _num(uom="USD"),  # not a share count
+        _num(qtrs="4"),  # duration — the count is an instant
+        _num(version="acme/2025"),  # filer-extension homonym
+        _num(coreg="SubCo"),  # co-registrant entity
+        _num(dimh="0xzzz", dimn="2"),  # cross/non-award dims, unrouted
+        _num(value="notanumber"),
+        _num(ddate="2025093"),  # malformed date
+    ],
+)
+def test_accumulate_rejects(row: dict[str, str]) -> None:
+    assert _run([row]) == {}
+
+
+def test_accumulate_iprx_lowest_wins() -> None:
+    per = _run([_num(iprx="1", value="200"), _num(iprx="0", value="100")])
+    ((iprx, value, _dcml),) = per["acc-1"].facts.values()
+    assert (iprx, value) == (0, Decimal(100))
+
+
+def test_accumulate_same_iprx_conflict_drops() -> None:
+    per = _run([_num(value="100"), _num(value="200")])
+    assert per["acc-1"].facts == {}
+    assert per["acc-1"].conflicted
+
+
+def test_accumulate_default_rows_normalise_to_one_key() -> None:
+    # dimn=0 with an unexpected dimh and the null hash MUST collapse to one
+    # key, or two default rows collide on the identity index at insert.
+    per = _run(
+        [
+            _num(dimh=_NULL_DIMH, dimn="0", value="500"),
+            _num(dimh="0xother", dimn="0", value="500"),
+        ]
+    )
+    assert list(per["acc-1"].facts.keys()) == [(datetime(2025, 9, 30, tzinfo=UTC).date(), _NULL_DIMH)]
+
+
+# --- read_award_dim_map ---------------------------------------------------------
+
+
+def test_read_award_dim_map_single_axis_only(tmp_path: Path) -> None:
+    dim = "\n".join(
+        [
+            "dimhash\tsegments\tsegt",
+            "0x00000000\t\t0",
+            f"0xaaa\tAwardType={_RSU};\t0",
+            "0xbbb\tAwardType=PerformanceShares\t0",  # no trailing ';' — still routed
+            "0xccc\tAwardType=X;Range=Minimum;\t0",  # cross-dimensional — excluded
+            "0xddd\tBusinessSegments=Cloud;\t0",  # different axis — excluded
+        ]
+    )
+    path = tmp_path / "fsnds_2026_03_notes.zip"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("dim.tsv", dim)
+    with zipfile.ZipFile(path) as zf:
+        got = read_award_dim_map(zf)
+    assert got == {"0xaaa": _RSU, "0xbbb": "PerformanceShares"}
+
+
+# --- DB integration: ingest + axis-scoped convergence + read rule ---------------
+
+_NONVESTED = "ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsNonvestedNumber"
+
+_NUM_HEADER = (
+    "adsh\ttag\tversion\tddate\tqtrs\tuom\tdimh\tiprx\tvalue\tfootnote\tfootlen\tdimn\tcoreg\tdurp\tdatp\tdcml"
+)
+_SUB_HEADER = "adsh\tcik\tform\tperiod\tfiled"
+_DIM_HEADER = "dimhash\tsegments\tsegt"
+
+
+def _num_line(adsh: str, ddate: str, dimh: str, dimn: str, value: str, *, form_tag: str = _NONVESTED) -> str:
+    return f"{adsh}\t{form_tag}\tus-gaap/2025\t{ddate}\t0\tshares\t{dimh}\t0\t{value}\t\t0\t{dimn}\t\t0\t0\t0"
+
+
+def _build_zip(path: Path) -> None:
+    sub = "\n".join(
+        [
+            _SUB_HEADER,
+            "acc-tenk\t111111\t10-K\t20250930\t20251120",
+            "acc-tenq\t111111\t10-Q\t20250630\t20250801",
+        ]
+    )
+    dim = "\n".join(
+        [
+            _DIM_HEADER,
+            "0x00000000\t\t0",
+            f"0xaaa\tAwardType={_RSU};\t0",
+        ]
+    )
+    num = "\n".join(
+        [
+            _NUM_HEADER,
+            # 10-K: prior + current balances, member + default rows.
+            _num_line("acc-tenk", "20240930", "0xaaa", "1", "163326000.0000"),
+            _num_line("acc-tenk", "20250930", "0xaaa", "1", "151574000.0000"),
+            _num_line("acc-tenk", "20250930", "0x00000000", "0", "155000000.0000"),
+            # 10-Q accession — must be skipped (10-K grain).
+            _num_line("acc-tenq", "20250630", "0xaaa", "1", "999.0000"),
+        ]
+    )
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("sub.tsv", sub)
+        zf.writestr("num.tsv", num)
+        zf.writestr("dim.tsv", dim)
+
+
+_NEXT_IID = [917400]  # high base, isolated from other suites' seeds
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, symbol: str) -> int:
+    _NEXT_IID[0] += 1
+    iid = _NEXT_IID[0]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable) "
+            "VALUES (%s, %s, %s, 'USD', TRUE)",
+            (iid, symbol, f"{symbol} Inc."),
+        )
+        cur.execute(
+            "INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary) "
+            "VALUES (%s, 'sec', 'cik', %s, TRUE)",
+            (iid, "0000111111"),
+        )
+    conn.commit()
+    return iid
+
+
+@pytest.mark.db
+class TestFsndsIngest:
+    def test_ingest_convergence_and_read_rule(self, ebull_test_conn: psycopg.Connection[tuple], tmp_path: Path) -> None:
+        iid = _seed_instrument(ebull_test_conn, symbol="NVAWD")
+        zip_path = tmp_path / "fsnds_2025_11_notes.zip"
+        _build_zip(zip_path)
+
+        result = ingest_fsnds_notes_archive(ebull_test_conn, archive_path=zip_path, fsnds_month="2025_11")
+        assert result.accessions_written == 1  # acc-tenq (10-Q) skipped
+        assert result.rows_written == 3
+
+        # Read rule: default-total row wins over the RSU member.
+        info = _read_nonvested_awards(ebull_test_conn, iid, today=datetime(2026, 7, 1, tzinfo=UTC).date())
+        assert info is not None
+        assert info.shares == Decimal("155000000.0000")
+        assert info.label == "unvested awards"
+        assert info.source_accession == "acc-tenk"
+
+        # Staleness bound: a far-future today suppresses the memo.
+        assert _read_nonvested_awards(ebull_test_conn, iid, today=datetime(2028, 1, 1, tzinfo=UTC).date()) is None
+
+        # Idempotence: second run skips (award rows exist).
+        result2 = ingest_fsnds_notes_archive(ebull_test_conn, archive_path=zip_path, fsnds_month="2025_11")
+        assert result2.rows_written == 0
+        assert result2.accessions_skipped_existing == 1
+
+    def test_axis_scoped_convergence(self, ebull_test_conn: psycopg.Connection[tuple], tmp_path: Path) -> None:
+        # (1) A pre-existing per-filing SEGMENT row for the same accession must
+        # NOT block the award write; (2) a segment-family rewash of that
+        # accession must NOT delete the award rows.
+        iid = _seed_instrument(ebull_test_conn, symbol="NVAXS")
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO instrument_dimensional_facts (
+                    instrument_id, axis, member_qname, member_label, metric, unit,
+                    is_subtotal, period_start, period_end, val, decimals, source_accession,
+                    form_type, filed_at, parser_version
+                ) VALUES (%s, 'geographic', 'country:US', 'United States', 'revenue', 'USD',
+                    FALSE, '2024-10-01', '2025-09-30', 123, NULL, 'acc-tenk', '10-K',
+                    '2025-11-20T00:00:00Z', 'sec_10k_dimensional_v1')
+                """,
+                (iid,),
+            )
+        ebull_test_conn.commit()
+        zip_path = tmp_path / "fsnds_2025_11_notes.zip"
+        _build_zip(zip_path)
+
+        result = ingest_fsnds_notes_archive(ebull_test_conn, archive_path=zip_path, fsnds_month="2025_11")
+        assert result.rows_written == 3  # segment row did not block the award write
+
+        # Segment rewash (empty per-filing extraction) deletes ONLY its axes.
+        with ebull_test_conn.transaction():
+            replace_accession_rows(
+                ebull_test_conn,
+                instrument_id=iid,
+                source_accession="acc-tenk",
+                form_type="10-K",
+                filed_at=datetime(2025, 11, 20, tzinfo=UTC),
+                parser_version="sec_10k_dimensional_v1",
+                facts=[],
+            )
+        ebull_test_conn.commit()
+        with ebull_test_conn.cursor() as cur:
+            cur.execute(
+                "SELECT axis, count(*) FROM instrument_dimensional_facts "
+                "WHERE instrument_id = %s AND source_accession = 'acc-tenk' GROUP BY axis",
+                (iid,),
+            )
+            by_axis = dict(cur.fetchall())
+        assert by_axis == {"award_type": 3}  # geographic row gone, award rows intact

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -463,6 +463,7 @@ class TestProductionInvokerRegistry:
             "sec_nport_ingest_from_dataset",
             "sec_fsds_class_shares_ingest",  # #788 — bootstrap Phase-C stage + standalone operator trigger
             "sec_fsds_dimensional_ingest",  # #1590 — bootstrap dimensional-facts stage + standalone operator trigger
+            "sec_fsnds_notes_ingest",  # #844 — FSNDS unvested-award counts, standalone operator trigger
             # #1155 — manual-trigger-only operator triage. Registered in
             # _INVOKERS so POST /jobs/sec_rebuild/run works; intentionally
             # NOT in SCHEDULED_JOBS (no cadence). Params declared in

--- a/tests/test_sec_bulk_download.py
+++ b/tests/test_sec_bulk_download.py
@@ -143,12 +143,19 @@ class TestInventory:
         assert fsds[0].optional is True, "newest FSDS quarter must be optional"
         for a in fsds[1:]:
             assert a.optional is False, f"{a.name} must stay required"
-        # FSNDS monthlies (#844) mirror the same posture: newest month
-        # published weeks late → optional; the rest required.
-        fsnds = [a for a in inventory if a.name.startswith("fsnds_")]
-        assert fsnds, "FSNDS monthlies missing from inventory"
-        assert fsnds[0].optional is True, "newest FSNDS month must be optional"
-        for a in fsnds[1:]:
+        # FSNDS (#844): monthlies mirror the same posture (newest month
+        # published weeks late → optional; the rest required); the
+        # quarterly consolidations cover months 13-24, with the newest
+        # quarterly on the consolidation boundary → optional.
+        fsnds_m = [a for a in inventory if a.name.startswith("fsnds_") and "q" not in a.name.split("_notes")[0][-7:]]
+        fsnds_q = [a for a in inventory if a.name.startswith("fsnds_") and "q" in a.name.split("_notes")[0][-7:]]
+        assert len(fsnds_m) == 12, "FSNDS monthlies missing from inventory"
+        assert len(fsnds_q) == 4, "FSNDS quarterly consolidations missing from inventory"
+        assert fsnds_m[0].optional is True, "newest FSNDS month must be optional"
+        for a in fsnds_m[1:]:
+            assert a.optional is False, f"{a.name} must stay required"
+        assert fsnds_q[0].optional is True, "boundary FSNDS quarter must be optional"
+        for a in fsnds_q[1:]:
             assert a.optional is False, f"{a.name} must stay required"
         # Every non-13F, non-FSDS, non-FSNDS archive stays required.
         for a in inventory:

--- a/tests/test_sec_bulk_download.py
+++ b/tests/test_sec_bulk_download.py
@@ -143,9 +143,16 @@ class TestInventory:
         assert fsds[0].optional is True, "newest FSDS quarter must be optional"
         for a in fsds[1:]:
             assert a.optional is False, f"{a.name} must stay required"
-        # Every non-13F, non-FSDS archive stays required.
+        # FSNDS monthlies (#844) mirror the same posture: newest month
+        # published weeks late → optional; the rest required.
+        fsnds = [a for a in inventory if a.name.startswith("fsnds_")]
+        assert fsnds, "FSNDS monthlies missing from inventory"
+        assert fsnds[0].optional is True, "newest FSNDS month must be optional"
+        for a in fsnds[1:]:
+            assert a.optional is False, f"{a.name} must stay required"
+        # Every non-13F, non-FSDS, non-FSNDS archive stays required.
         for a in inventory:
-            if not a.name.startswith(("form13f_", "fsds_")):
+            if not a.name.startswith(("form13f_", "fsds_", "fsnds_")):
                 assert a.optional is False, f"{a.name} must stay required"
 
     def test_archive_urls_use_correct_path_prefixes(self) -> None:


### PR DESCRIPTION
Part of #844 (#788 P5) — PR-1, the structured half. DRS (curated Item-5 text extraction) follows as PR-2 on the same spec.

**Spec:** docs/specs/etl/2026-07-23-drs-rsu-issuer-disclosures.md (this PR). Codex ckpt-1 ran twice on the spec; ckpt-2 fresh-agent review ran on the branch — its one finding (monthlies-only leaves months 13-24 unreachable) FIXED in `HEAD` (quarterly consolidations added).

## Source rule
ASC 718-10-50-2(c)(2)(i)/(ii) nonvested-award rollforward, tagged `us-gaap:…EquityInstrumentsOtherThanOptionsNonvestedNumber` under the AwardTypeAndPlanName axis. Reachable ONLY via DERA **FSNDS** (notes product): companyfacts strips dimensional facts (sec-edgar §7.17), plain FSDS is face-statements-only (NEW §7.18, extracted this PR). Issue premise corrected: DEF 14A Item 402(f) is per-NEO — no company-wide unvested total exists there; the 10-K note is the source.

## Full-population verification (spec §)
- Route probes: companyfacts ~460 recent /20,087 CIKs (REJECTED); FSDS 10-12/quarter (REJECTED); FSNDS 409-1,388/month (ADOPTED).
- **Member-sum additivity FALSIFIED**: 58/91 default-vs-Σmembers disagreements (2026_03) — the axis mixes award types with plan names. Read rule NEVER sums: default-total → single-standard-member → RSU-of-many → abstain (62-71% render, rest honest absence).

## What changed
- `sql/238`: axis CHECK += `award_type`, metric CHECK += `nonvested_awards`.
- `app/services/fsnds_notes_facts.py` (NEW): monthly/quarterly `*_notes.zip` loader — num/dim/sub TSVs, 10-K/10-K/A grain, `qtrs=0`, `iprx` arbitration (lowest wins, same-iprx conflict drops), `version` prefix `us-gaap/`, null-dimh (`0x00000000`/`dimn=0`) default normalisation, sibling-CIK fanout; `select_nonvested_memo` pure read rule.
- **Axis-scoped convergence** (the cross-cutting invariant): `replace_accession_rows` DELETE + FSDS bulk existence check scoped to `PER_FILING_AXES`; FSNDS existence check scoped to `award_type`; shared advisory-lock template unchanged (byte-identity test extended to 3 writers). Without this, any 10-K segment rewash silently wiped award rows and vice versa.
- Bulk inventory: `fsnds_{YYYY}_{MM}_notes.zip` rolling-12 (newest optional) + quarterly consolidations 5-8 back (boundary optional).
- Job `sec_fsnds_notes_ingest`: manual-only, own `db_fsnds_notes` lane (starvation precedent `db_raw_sweep`), params registered.
- Rollup: `NonvestedAwardsInfo` + `_read_nonvested_awards` (winner accession → latest period → read rule; 548d staleness on period_end). API `_NonvestedAwardsModel`; FE memo line under the ownership chart (absolute count, server-owned label).
- **DenominatorBasis supersession** (conscious): issue's `shares_outstanding_plus_unvested` basis value NOT added — memo is an absolute count, no denominator claim, no contract migration.

## Security model
No new HTTP surface; the job is operator-invokable via the existing authenticated `/jobs/*/run` path. Loader consumes pre-fetched local archives only (no SEC HTTP at ingest). No user-controlled SQL interpolation (parameterised throughout).

## Verification (DoD clauses 8-12, at 71a0c806+2 commits)
- **Clause 8 (smoke panel):** AAPL **151,574,000 unvested RSUs @ 2025-09-30**; GME 2,257,883 @ 2026-01-31; MSFT 82,000,000 unvested restricted stock @ 2025-06-30; HD 3,115,000 @ 2026-01-31; AMC 4,573,078 @ 2025-12-31; JPM = honest abstention (multi-member, no RSU member, no default — read rule as specced).
- **Clause 9 (cross-source):** AAPL 151,574,000 EXACT vs SEC EDGAR direct 10-K `0000320193-25-000079` ASC 718 note (prior-yr 163,326,000 also matches); GME EXACT vs `0001326380-26-000013`.
- **Clause 10 (backfill executed):** 14 archives ingested on dev (12 monthlies 2025_07→2026_06 + quarterlies 2025q1/2025q2) → **22,772 rows / 2,939 tradable instruments / ~2,903 accessions**. Job body exercised directly (`sec_fsnds_notes_ingest_job()` over the cached archives).
- **Clause 11 (operator figure):** `_read_nonvested_awards` verified for the panel above against dev DB. Live `/instruments/{symbol}/ownership-rollup` + FE memo eyeball happens post-merge (dev :8000 serves origin/main; --reload picks up the merge) — recorded as the operator follow-up.
- Gates: ruff + format + pyright clean; fast tier 5,344 passed; smoke 132 passed; targeted `-m db` suites (fsnds/fsds) passed; FE typecheck + 1,361 unit tests passed.

## Tradeoffs
- Unvested options excluded (different tags/semantics) — memo copy never claims 'all unvested equity'.
- Not a bootstrap stage in v1 (stage-slot wiring deferred; job is operator-invokable and archives ride the existing bulk download).
- 29-38% of tag-bearing filings render no memo (honest abstention under the no-sum rule); per-member multi-line memo is a listed future extension.

Closes nothing yet — #844 closes with PR-2 (DRS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
