### PR TITLE
fix(#2124): trim trailing zeros on DRS chip percent

### DIFF
--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -410,7 +410,12 @@ function DrsMemo({ drs }: { readonly drs: OwnershipDrs | null }): JSX.Element | 
   if (registered === null || registered <= 0) {
     return null;
   }
-  const pct = drs.registered_pct !== null ? ` (${drs.registered_pct}%)` : "";
+  // #2124 — the server sends a raw NUMERIC(8,4) string ("14.0000"); parse
+  // to trim trailing zeros ("14", "99.6", "0.4"). formatPct is not reused:
+  // it expects a fraction and force-fixes 2 decimals ("14.00%").
+  const pctNum =
+    drs.registered_pct !== null ? Number.parseFloat(drs.registered_pct) : NaN;
+  const pct = Number.isFinite(pctNum) ? ` (${pctNum}%)` : "";
   const holders =
     drs.holders_of_record !== null
       ? `; ${drs.holders_of_record.toLocaleString()} holders of record`


### PR DESCRIPTION
Closes #2124.

FE-QA eyeball on #844 PR-2 (`5fbde020`) caught the DRS chip rendering the server's raw `NUMERIC(8,4)` percent verbatim: GME showed `(14.0000%)`.

**Fix:** `DrsMemo` now `Number.parseFloat`s `registered_pct` — trims trailing zeros (14.0000→14, 99.6000→99.6, 0.4000→0.4). `formatPct` deliberately not reused (it expects a fraction and force-fixes 2 decimals → "14.00%"). NaN suppressed via `Number.isFinite` (same omit-branch as null).

Cosmetic only — figure unchanged. Codex reviewed (no correctness issues; the parseFloat-looseness nit is unreachable given the `Decimal | null` server contract).

**Verify:** FE typecheck clean; 1,361 unit tests pass. Live eyeball post-merge (GME chip → `(14%)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)