### PR TITLE
feat(#2127 PR-1): bulk-load compute_rankings scoring inputs — kill the per-instrument round-trip storm

### DIFF
--- a/app/services/scoring.py
+++ b/app/services/scoring.py
@@ -1466,29 +1466,330 @@ def _load_instrument_data(
     }
 
 
+def _empty_instrument_data() -> dict[str, Any]:
+    """Defaults matching what `_load_instrument_data` yields for an instrument with
+    no rows in any source. Seeded per id so a bulk-query miss degrades identically
+    to the per-instrument path (#2127)."""
+    return {
+        "sector_code": None,
+        "sic": None,
+        "fund_rows": [],
+        "price_row": None,
+        "quote_row": None,
+        "thesis_row": None,
+        "news_rows": [],
+        "avg_red_flag_score": None,
+        "valuation_row": None,
+        "risk_row": None,
+        "fund_present": False,
+        "last_10kq_date": None,
+        "price_td_count": 0,
+        "news_90d_count": 0,
+    }
+
+
+def _bulk_load_instrument_data(
+    conn: psycopg.Connection[Any],
+    instrument_ids: Sequence[int],
+    now: datetime,
+) -> dict[int, dict[str, Any]]:
+    """
+    Set-based equivalent of :func:`_load_instrument_data` over many instruments (#2127).
+
+    Returns ``{instrument_id: data_dict}``, each dict the SAME shape as
+    ``_load_instrument_data`` at the SAME ``now``. One query per source
+    (``WHERE instrument_id = ANY(...)``), assembled in Python — turning the
+    ~78k per-instrument round-trips of ``compute_rankings`` into ~12 set-based
+    reads. All access read-only. A requested id absent from a query's result keeps
+    the seeded default, so a miss degrades exactly as the per-instrument path.
+    """
+    ids = list(instrument_ids)
+    out: dict[int, dict[str, Any]] = {iid: _empty_instrument_data() for iid in ids}
+    if not ids:
+        return out
+
+    p: dict[str, Any] = {"ids": ids}
+    cutoff_news_30 = now - timedelta(days=_NEWS_LOOKBACK_DAYS)
+    cutoff_90 = now - timedelta(days=90)
+    rf_cutoff_date = (now - timedelta(days=90)).date()
+
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        # Fundamentals — latest 5 per id, newest-first (matches LIMIT 5 ORDER BY
+        # as_of_date DESC). Outer ORDER BY instrument_id, rn so the appended lists
+        # preserve newest-first: fund_rows[0]=latest, fund_rows[-1]=oldest-of-5.
+        cur.execute(
+            """
+            SELECT instrument_id, operating_margin, gross_margin, fcf, net_debt, debt,
+                   revenue_ttm, shares_outstanding
+            FROM (
+                SELECT instrument_id, operating_margin, gross_margin, fcf, net_debt, debt,
+                       revenue_ttm, shares_outstanding,
+                       ROW_NUMBER() OVER (PARTITION BY instrument_id ORDER BY as_of_date DESC) AS rn
+                FROM fundamentals_snapshot
+                WHERE instrument_id = ANY(%(ids)s::bigint[])
+            ) s
+            WHERE rn <= 5
+            ORDER BY instrument_id, rn
+            """,
+            p,
+        )
+        for r in cur.fetchall():
+            out[int(r.pop("instrument_id"))]["fund_rows"].append(r)
+
+        # Latest price row — close IS NOT NULL is load-bearing (a latest NULL close
+        # must not shadow an older usable row).
+        cur.execute(
+            """
+            SELECT DISTINCT ON (instrument_id)
+                   instrument_id, return_1m, return_3m, return_6m, close,
+                   sma_200, macd_histogram, rsi_14, stoch_k, stoch_d,
+                   bb_upper, bb_lower, atr_14
+            FROM price_daily
+            WHERE instrument_id = ANY(%(ids)s::bigint[]) AND close IS NOT NULL
+            ORDER BY instrument_id, price_date DESC
+            """,
+            p,
+        )
+        for r in cur.fetchall():
+            out[int(r.pop("instrument_id"))]["price_row"] = r
+
+        # Current quote.
+        cur.execute(
+            """
+            SELECT DISTINCT ON (instrument_id) instrument_id, spread_flag, last, bid, ask
+            FROM quotes
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+            ORDER BY instrument_id, quoted_at DESC
+            """,
+            p,
+        )
+        for r in cur.fetchall():
+            out[int(r.pop("instrument_id"))]["quote_row"] = r
+
+        # Latest thesis.
+        cur.execute(
+            """
+            SELECT DISTINCT ON (instrument_id)
+                   instrument_id, confidence_score, base_value, bear_value, stance, created_at
+            FROM theses
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+            ORDER BY instrument_id, thesis_version DESC
+            """,
+            p,
+        )
+        for r in cur.fetchall():
+            out[int(r.pop("instrument_id"))]["thesis_row"] = r
+
+        # News sentiment rows (last 30d). Deterministic tie-break on news_event_id
+        # so list order is reproducible (the sentiment aggregate is an
+        # importance-weighted sum, order-insensitive at stored precision).
+        cur.execute(
+            """
+            SELECT instrument_id, sentiment_score, importance_score
+            FROM news_events
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+              AND event_time >= %(cutoff)s
+              AND sentiment_score IS NOT NULL
+            ORDER BY instrument_id, event_time DESC, news_event_id DESC
+            """,
+            {"ids": ids, "cutoff": cutoff_news_30},
+        )
+        for r in cur.fetchall():
+            out[int(r.pop("instrument_id"))]["news_rows"].append(r)
+
+        # Avg red-flag score over the last 90d.
+        cur.execute(
+            """
+            SELECT instrument_id, AVG(red_flag_score) AS avg_red_flag
+            FROM filing_events
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+              AND filing_date >= %(cutoff)s
+              AND red_flag_score IS NOT NULL
+            GROUP BY instrument_id
+            """,
+            {"ids": ids, "cutoff": rf_cutoff_date},
+        )
+        for r in cur.fetchall():
+            out[int(r["instrument_id"])]["avg_red_flag_score"] = _to_float(r["avg_red_flag"])
+
+        # fund_present (#1820 §4) — bool_or of the same predicate the per-instrument
+        # EXISTS uses.
+        cur.execute(
+            """
+            SELECT instrument_id,
+                   bool_or(revenue_ttm IS NOT NULL
+                           AND (operating_margin IS NOT NULL OR gross_margin IS NOT NULL))
+                       AS fund_present
+            FROM fundamentals_snapshot
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+            GROUP BY instrument_id
+            """,
+            p,
+        )
+        for r in cur.fetchall():
+            out[int(r["instrument_id"])]["fund_present"] = bool(r["fund_present"])
+
+        # Latest 10-K/Q filed date (Reg S-K annual / Exchange Act §13 quarterly, incl. /A).
+        cur.execute(
+            """
+            SELECT instrument_id, MAX(filing_date) AS last_10kq
+            FROM filing_events
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+              AND filing_type IN ('10-K', '10-Q', '10-K/A', '10-Q/A')
+            GROUP BY instrument_id
+            """,
+            p,
+        )
+        for r in cur.fetchall():
+            out[int(r["instrument_id"])]["last_10kq_date"] = r["last_10kq"]
+
+        # Price-history depth.
+        cur.execute(
+            """
+            SELECT instrument_id, COUNT(*) FILTER (WHERE close IS NOT NULL) AS price_td
+            FROM price_daily
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+            GROUP BY instrument_id
+            """,
+            p,
+        )
+        for r in cur.fetchall():
+            out[int(r["instrument_id"])]["price_td_count"] = int(r["price_td"])
+
+        # News coverage last 90d (count of all events, no sentiment filter).
+        cur.execute(
+            """
+            SELECT instrument_id, COUNT(*) AS news_90d
+            FROM news_events
+            WHERE instrument_id = ANY(%(ids)s::bigint[])
+              AND event_time >= %(cutoff)s
+            GROUP BY instrument_id
+            """,
+            {"ids": ids, "cutoff": cutoff_90},
+        )
+        for r in cur.fetchall():
+            out[int(r["instrument_id"])]["news_90d_count"] = int(r["news_90d"])
+
+        # Sector (eToro) + SIC — LEFT JOIN so i.sector survives with no SEC profile.
+        # Savepoint: instrument_sec_profile may be absent in a partial test DB.
+        try:
+            with conn.transaction():
+                cur.execute(
+                    """
+                    SELECT i.instrument_id, i.sector, p.sic
+                    FROM instruments i
+                    LEFT JOIN instrument_sec_profile p ON p.instrument_id = i.instrument_id
+                    WHERE i.instrument_id = ANY(%(ids)s::bigint[])
+                    """,
+                    p,
+                )
+                for r in cur.fetchall():
+                    d = out[int(r["instrument_id"])]
+                    d["sector_code"] = r["sector"]
+                    d["sic"] = r["sic"]
+        except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+            pass  # savepoint rolled back; ids keep default sector/sic = None
+
+        # Valuation view (savepoint — view/table may be absent pre-migration).
+        valuation_hits: dict[int, dict[str, Any]] = {}
+        try:
+            with conn.transaction():
+                cur.execute(
+                    """
+                    SELECT instrument_id, pe_ratio, pb_ratio, p_fcf_ratio, fcf_yield,
+                           debt_equity_ratio, market_cap_live, current_price, fcf_ttm
+                    FROM instrument_valuation
+                    WHERE instrument_id = ANY(%(ids)s::bigint[])
+                    """,
+                    p,
+                )
+                for r in cur.fetchall():
+                    valuation_hits[int(r.pop("instrument_id"))] = r
+        except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+            valuation_hits = {}
+
+        # Risk metrics (risk_v1 3y). Savepoint — table may be absent in a partial DB.
+        try:
+            from app.services.risk_metrics import RISK_METRICS_VERSION
+
+            with conn.transaction():
+                cur.execute(
+                    """
+                    SELECT instrument_id, vol_annualized, vol_status,
+                           max_drawdown, drawdown_status, calmar, tr_calmar, tr_status
+                    FROM instrument_risk_metrics_current
+                    WHERE instrument_id = ANY(%(ids)s::bigint[])
+                      AND metric_version = %(mv)s
+                      AND window_key = %(win)s
+                    """,
+                    {"ids": ids, "mv": RISK_METRICS_VERSION, "win": _RISK_PENALTY_WINDOW},
+                )
+                for r in cur.fetchall():
+                    out[int(r.pop("instrument_id"))]["risk_row"] = r
+        except psycopg.errors.UndefinedTable, psycopg.errors.UndefinedColumn:
+            pass
+
+    # Market-cap basis overlay on the valuation row — per instrument (0.8ms each;
+    # matches _load_instrument_data). Only for ids that actually have a valuation row.
+    for iid, vrow in valuation_hits.items():
+        try:
+            try:
+                with conn.transaction():
+                    resolution = resolve_market_cap_basis(conn, instrument_id=iid)
+            except psycopg.errors.UndefinedTable:
+                resolution = MarketCapResolution(basis="not_multiclass")
+            out[iid]["valuation_row"] = _apply_market_cap_basis(vrow, resolution)
+        except Exception:
+            # Per-instrument skip-on-error parity (#2127): in the pre-refactor path
+            # a resolve/overlay failure raised inside compute_score and was caught by
+            # compute_rankings' per-instrument try (that one instrument was skipped,
+            # the run continued). Bulk-load runs outside that try, so a non-
+            # UndefinedTable failure here would abort the WHOLE run. Drop the id so
+            # the scoring loop's bulk[iid] lookup raises KeyError → skipped there,
+            # exactly as before. The savepoint already rolled back the failed tx.
+            logger.warning(
+                "compute_rankings: market-cap overlay failed for instrument_id=%d, skipping",
+                iid,
+                exc_info=True,
+            )
+            out.pop(iid, None)
+
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Single-instrument scoring
 # ---------------------------------------------------------------------------
 
 
-def compute_score(
+def _analytics_inputs(data: dict[str, Any]) -> tuple[str | None, float | None]:
+    """Derive ``(gics_sector, shares_outstanding)`` for the analytics block from a
+    loaded ``data`` dict. Pure — hoisted out of the scoring core (#2127) so
+    ``_score_from_data`` stays DB-free and the analytics call can be issued by the
+    caller (per-instrument in Phase 1, bulk in Phase 2)."""
+    fund_rows = data["fund_rows"]
+    shares_out = _to_float(fund_rows[0]["shares_outstanding"]) if fund_rows else None
+    sic_cls = resolve_sector_spdr(data.get("sic"))  # type: ignore[arg-type]
+    gics_sector = sic_cls.gics_sector if sic_cls is not None else None
+    return gics_sector, shares_out
+
+
+def _score_from_data(
     instrument_id: int,
-    conn: psycopg.Connection[Any],
-    model_version: str = _DEFAULT_MODEL_VERSION,
+    data: dict[str, Any],
+    weights: Mapping[str, float],
+    model_version: str,
+    now: datetime,
+    analytics: dict[str, Any] | None,
 ) -> ScoreResult:
     """
-    Compute a scored result for a single instrument.
+    Pure scoring core — NO DB access (#2127).
 
-    Does not persist — callers are responsible for writing to the DB.
-    Raises KeyError if model_version is not recognised.
+    Operates on a preloaded ``data`` dict (from :func:`_load_instrument_data` or
+    :func:`_bulk_load_instrument_data`), a precomputed ``analytics`` block, a
+    resolved ``weights`` mode, and a single ``now``. Callers own DB I/O and the
+    analytics assembly. Does not persist.
     """
-    weights = _WEIGHT_MODES.get(model_version)
-    if weights is None:
-        raise KeyError(f"Unknown model_version: {model_version!r}. Known: {list(_WEIGHT_MODES)}")
-
-    now = _utcnow()
-    data = _load_instrument_data(conn, instrument_id, now)
-
     fund_rows = data["fund_rows"]
     price_row = data["price_row"]
     quote_row = data["quote_row"]
@@ -1732,18 +2033,11 @@ def compute_score(
 
     # ------------------------------------------------------------------
     # IAR evidence signals (#1823 §P2). Additive — never enters the
-    # total_score math above. Piotroski/Altman + positioning are per-
-    # instrument; the cross-sectional peer_grade is injected by
-    # compute_rankings from the run population.
+    # total_score math above. The ``analytics`` block (Piotroski/Altman +
+    # positioning) is precomputed by the caller and passed in (#2127); the
+    # cross-sectional peer_grade is injected by compute_rankings from the run
+    # population.
     # ------------------------------------------------------------------
-    fund_rows_for_shares = data["fund_rows"]
-    shares_out = _to_float(fund_rows_for_shares[0]["shares_outstanding"]) if fund_rows_for_shares else None
-    sic_cls = resolve_sector_spdr(data.get("sic"))  # type: ignore[arg-type]
-    gics_sector = sic_cls.gics_sector if sic_cls is not None else None
-    analytics = assemble_instrument_analytics(
-        instrument_id, conn, gics_sector=gics_sector, shares_outstanding=shares_out
-    )
-
     return ScoreResult(
         instrument_id=instrument_id,
         model_version=model_version,
@@ -1760,6 +2054,32 @@ def compute_score(
         analytics=analytics,
         sector=data.get("sector_code"),  # type: ignore[arg-type]
     )
+
+
+def compute_score(
+    instrument_id: int,
+    conn: psycopg.Connection[Any],
+    model_version: str = _DEFAULT_MODEL_VERSION,
+) -> ScoreResult:
+    """
+    Compute a scored result for a single instrument.
+
+    Back-compat single-instrument wrapper (#2127): loads this instrument's data +
+    analytics from ``conn`` then delegates to the pure :func:`_score_from_data`.
+    ``compute_rankings`` uses :func:`_bulk_load_instrument_data` instead of calling
+    this per instrument. Does not persist. Raises KeyError on unknown model_version.
+    """
+    weights = _WEIGHT_MODES.get(model_version)
+    if weights is None:
+        raise KeyError(f"Unknown model_version: {model_version!r}. Known: {list(_WEIGHT_MODES)}")
+
+    now = _utcnow()
+    data = _load_instrument_data(conn, instrument_id, now)
+    gics_sector, shares_out = _analytics_inputs(data)
+    analytics = assemble_instrument_analytics(
+        instrument_id, conn, gics_sector=gics_sector, shares_outstanding=shares_out
+    )
+    return _score_from_data(instrument_id, data, weights, model_version, now, analytics)
 
 
 # ---------------------------------------------------------------------------
@@ -1852,12 +2172,22 @@ def compute_rankings(
 
     logger.info("compute_rankings: scoring %d eligible instrument(s) [model=%s]", len(instrument_ids), model_version)
 
-    # Score each instrument, skipping failures
+    # Bulk-load every instrument's inputs up front (#2127) — one set-based query per
+    # source instead of ~20 per-instrument round-trips × N. One batch `now` so all
+    # instruments are scored "as of run start" (replaces the prior per-instrument
+    # _utcnow() drift; strictly more consistent, no model_version bump — `now` is an
+    # execution input, not a metric computation). Analytics stays per-instrument in
+    # Phase 1 (bulked in Phase 2). Individual failures are skipped exactly as before.
+    weights = _WEIGHT_MODES[model_version]  # validated above
+    now = _utcnow()
+    bulk = _bulk_load_instrument_data(conn, instrument_ids, now)
     results: list[ScoreResult] = []
     for iid in instrument_ids:
         try:
-            result = compute_score(iid, conn, model_version)
-            results.append(result)
+            data = bulk[iid]
+            gics_sector, shares_out = _analytics_inputs(data)
+            analytics = assemble_instrument_analytics(iid, conn, gics_sector=gics_sector, shares_outstanding=shares_out)
+            results.append(_score_from_data(iid, data, weights, model_version, now, analytics))
         except Exception:
             logger.warning("compute_rankings: scoring failed for instrument_id=%d, skipping", iid, exc_info=True)
 

--- a/docs/specs/ranking/2026-07-23-bulk-load-scoring-2127.md
+++ b/docs/specs/ranking/2026-07-23-bulk-load-scoring-2127.md
@@ -1,0 +1,202 @@
+# #2127 — Bulk-load the scoring reads: kill the per-instrument round-trip storm in `compute_rankings`
+
+Status: spec (pre-impl, rev 2 post-Codex-ckpt1). Session 2ac5aa46, 2026-07-23.
+Ticket: #2127 (#649-B). Scope reframed on evidence (operator-approved 07-23d) from
+"skip unchanged instruments" to "bulk-read the scoring inputs". Skip-predicate is
+deferred (see Out of scope).
+
+## Problem
+
+`compute_rankings` (`app/services/scoring.py:1803`) scores ~3,916 eligible
+instruments each `morning_candidate_review` run in **772-844s** (`job_runs`). Per
+instrument it calls `compute_score`, which does ~20 sequential per-instrument DB
+queries split across two phases:
+
+- `_load_instrument_data` (`scoring.py:1185`) — 12 input queries.
+- `assemble_instrument_analytics` (`instrument_analytics.py:551`, called at
+  `scoring.py:1743`) — 4 more per-instrument helpers (`_read_latest_two_fy_facts`,
+  `get_insider_summary`, `_read_13f_delta`, `_read_short_interest`), each
+  savepoint-wrapped.
+
+cProfile (dev DB): **95% of `compute_score` wall-clock is `psycopg.connection.wait`**
+— pure blocking on sequential round-trips, ~6.9ms each. Measured shares:
+
+| phase | per-inst | × 3916 |
+|---|---|---|
+| `assemble_instrument_analytics` | 91 ms | **~357s** |
+| `_load_instrument_data` + family scoring (pure) | ~106 ms | **~414s** |
+| **total `compute_score`** | 197 ms | **~771s** (matches the 772-844s runs) |
+
+The cost is **round-trip latency, not per-instrument compute** (`resolve_market_cap_basis`
+= 0.8ms/inst). Evidence + full table: #2127 comments 5062616100 / this session.
+
+## Source rule
+
+- **Settled-decisions (`docs/settled-decisions.md:240-253`)**: the additive-nullable-
+  under-stable-`metric_version` rule exists to *avoid* "a full-universe recompute of
+  unchanged data". Cutting redundant round-trips is aligned, not a deviation.
+- **ranking-engine skill invariants** — preserved; output must be **numerically
+  identical at stored precision** (see Correctness on `now`). No `model_version`
+  bump: the scoring formula is unchanged, only the DB access pattern.
+  - No cohort-relative normalization in the headline score.
+  - Penalties additive only. `scores` append-only; one full snapshot per run;
+    `rank_delta` within a `model_version` vs most recent prior run only.
+  - Each row carries full detail (`penalties_json`, `explanation`, `analytics`).
+- **Per-input source rules (carried from the current SQL, not re-derived):**
+  filing recency = SEC 10-K (Reg S-K annual) / 10-Q (Exchange Act §13 quarterly)
+  incl. amendments (`scoring.py:1319-1327`); red_flag = `filing_events.red_flag_score`
+  90d avg; valuation multiples from the `instrument_valuation` view; market-cap basis
+  via `resolve_market_cap_basis` (#1662/#1664/#1623 — dual-class / FPI suppression,
+  used as-is, not reasoned).
+
+## Full-population verification (soundness of the reframe)
+
+Risk thresholds (`scoring.py:276-277`) and Calmar thresholds (`:303-304`) are
+**frozen module constants**, not per-run percentiles → `total_score(X)` depends only
+on X's own inputs + `now`, never on the live universe. The only cross-sectional
+computations (`compute_peer_grades` — evidence-only weight 0; `rank`/`rank_delta`)
+already run over the full result set each run and are **unchanged**. So bulk-loading
+X's inputs and scoring in Python yields the same `ScoreResult`. Proven by the
+full-population A/B below.
+
+## Design — two phases, two PRs
+
+Both phases share one architectural seam:
+
+### Seam (both PRs): make the scoring core pure
+
+Extract `_score_from_data(instrument_id, data, weights, model_version, now, analytics)
+-> ScoreResult` — the body of `compute_score` from `scoring.py:1490` onward, with the
+`assemble_instrument_analytics(...)` call **hoisted out** and passed in as `analytics`.
+Fully pure: no `conn`. (Codex ckpt-1 HIGH: the current body is NOT pure because it
+calls `assemble_instrument_analytics(..., conn, ...)` — hoisting is what makes the
+core bulk-able.)
+
+`compute_score(instrument_id, conn, model_version)` stays as a thin back-compat
+wrapper: `data = _load_instrument_data(...)`, `analytics = assemble_instrument_analytics(...)`,
+`return _score_from_data(...)`. (Grep: `compute_score` has no caller outside
+`compute_rankings` + tests, so this is purely for tests/safety.)
+
+`_score_from_data` takes `now` as an argument (does not call `_utcnow()`), so the
+whole batch shares one timestamp — see Correctness note 1.
+
+### Phase 1 (PR-1): bulk `_load_instrument_data` — expected ~771s → ~380s (~2×)
+
+`_bulk_load_instrument_data(conn, instrument_ids, now) -> dict[int, dict]` — one
+set-based query per source, each `WHERE instrument_id = ANY(%(ids)s::bigint[])`
+(prevention-log #1961: array param must carry the column type). Returns dicts of the
+**same shape** as `_load_instrument_data`. Assembler seeds every requested id with the
+default dict (`None`/`[]`/`0`/`False`), then overlays hits — so a missing id degrades
+exactly as the per-instrument path.
+
+| current per-inst query | bulk form (exact-equivalence notes) |
+|---|---|
+| latest-5 fundamentals | `ROW_NUMBER() OVER (PARTITION BY instrument_id ORDER BY as_of_date DESC)` ≤ 5; **outer `ORDER BY instrument_id, as_of_date DESC`** so appended Python lists match `fund_rows[0]`=latest / `fund_rows[-1]`=oldest-of-5 |
+| latest price row | `DISTINCT ON (instrument_id) ... WHERE close IS NOT NULL ORDER BY instrument_id, price_date DESC` — **`close IS NOT NULL` is load-bearing** (`scoring.py:1223`): a latest NULL close must not shadow an older usable row |
+| latest quote | `DISTINCT ON (instrument_id) ... ORDER BY instrument_id, quoted_at DESC` |
+| latest thesis | `DISTINCT ON (instrument_id) ... ORDER BY instrument_id, thesis_version DESC` |
+| news 30d rows | `WHERE event_time >= now-30d AND sentiment_score IS NOT NULL`; **`ORDER BY instrument_id, event_time DESC, news_event_id DESC`** (deterministic tie-break; the sentiment aggregate is an importance-weighted sum → order-insensitive at stored precision, tie-break added for reproducibility) |
+| red_flag AVG 90d | `GROUP BY instrument_id` AVG |
+| fund_present EXISTS | `GROUP BY instrument_id` `bool_or(revenue_ttm IS NOT NULL AND (op OR gross))` |
+| last 10-K/Q date | `GROUP BY instrument_id` MAX (filing_type IN 10-K/Q/A) |
+| price_td COUNT | `GROUP BY instrument_id` `COUNT(close)` (counts non-NULL closes; NOT `COUNT(close IS NOT NULL)` — a boolean is non-null either way and would count all rows) |
+| news 90d COUNT | `GROUP BY instrument_id` COUNT |
+| valuation view row | `elig LEFT JOIN instrument_valuation` (degradable — see below) |
+| risk metrics row | `elig LEFT JOIN instrument_risk_metrics_current` on `metric_version=%(mv)s AND window_key='3y'` (degradable) |
+| sector + sic | **`FROM instruments i LEFT JOIN instrument_sec_profile p`** — MUST be LEFT JOIN so `i.sector` survives when no SEC profile exists (`scoring.py:1433`; INNER would null the peer-grade cohort) |
+
+- **`resolve_market_cap_basis`**: keep per-instrument (0.8ms × 3916 ≈ 3s, negligible)
+  inside the assembler. Bulking is a follow-up. Record in PR.
+- **Partial-schema degradation** (test DBs lacking `instrument_valuation` /
+  `instrument_risk_metrics_current` / `instrument_sec_profile`): each of those three
+  bulk queries runs **inside its own `with conn.transaction()` savepoint** (Codex
+  ckpt-1 MED: a bare try/except after a failed query leaves the tx aborted) catching
+  `(UndefinedTable, UndefinedColumn)` → every id gets `None` for that block.
+
+`compute_rankings` loop becomes:
+```
+now = _utcnow()
+bulk = _bulk_load_instrument_data(conn, instrument_ids, now)
+for iid in instrument_ids:
+    try:
+        analytics = assemble_instrument_analytics(iid, conn, gics_sector=..., shares_outstanding=...)  # still per-inst in P1
+        results.append(_score_from_data(iid, bulk[iid], weights, model_version, now, analytics))
+    except Exception:
+        logger.warning(... skipping ...)   # preserve current per-instrument skip-on-error
+```
+Everything after (sort, peer grades, prior-rank fetch, insert tx) is unchanged.
+
+### Phase 2 (PR-2): bulk the 4 analytics helpers — expected ~380s → ~60-90s (~10× total)
+
+Add bulk variants of `_read_latest_two_fy_facts`, `get_insider_summary`,
+`_read_13f_delta`, `_read_short_interest` (all `WHERE instrument_id = ANY(...)`), plus
+`assemble_instrument_analytics_bulk(conn, ids, gics/shares maps) -> dict[int, dict]`.
+`compute_rankings` then calls the bulk analytics once and passes each id's block to the
+already-pure `_score_from_data`. Same A/B harness proves byte-identity. Deferred to a
+second PR to keep each diff independently A/B-verifiable.
+
+**Per-id error isolation (Codex ckpt-1 MED):** today one instrument failing analytics
+is skipped via the per-instrument try/except in the loop. The bulk analytics MUST
+preserve this — `assemble_instrument_analytics_bulk` returns a per-id map and any id
+whose block cannot be built degrades to the empty-analytics default for that id (does
+NOT raise), so a single bad id can never fail the whole run. The bulk reads themselves
+still run inside savepoints (partial-schema degradation as in Phase 1).
+
+## Correctness notes
+
+1. **One `now` per batch (deliberate consistency improvement, documented — NOT a
+   silent change).** Current `compute_rankings` calls `_utcnow()` once *per instrument*,
+   so over a ~13-min run instruments drift apart in `now`; across a 30d/90d window
+   anniversary or a UTC-midnight `filing_date` boundary this makes late-scored
+   instruments see a later cutoff. Batch-`now` (captured at run start) scores every
+   instrument "as of run start" — reproducible and strictly more consistent. No
+   `model_version` bump: `now` is an execution input, not a metric computation (running
+   the job at a different clock time already changes windowed results run-to-run).
+   The A/B (below) pins one `now` for BOTH paths to prove the refactor math is
+   identical; the only production delta vs the current path is elimination of the
+   intra-run now-drift, which is called out in the PR.
+2. **`ANY(%(ids)s::bigint[])`** — array param carries the column type (prevention-log #1961).
+3. **Ordering** — every "latest-N"/list query carries an explicit outer `ORDER BY` so
+   Python list assembly is deterministic and matches the current `ORDER BY ... LIMIT`.
+4. **Memory** — 3,916 × ~13 small dicts ≪ 100 MB.
+
+## Acceptance — full-population A/B (definition-of-done clauses 9/11)
+
+Script (dev DB, `scratchpad`): pin one `now`; for ALL eligible instruments (n≈3917)
+build `ScoreResult` via (a) current per-instrument path and (b) the bulk path, both at
+the pinned `now`. Assert **identical** per id on the FULL result: every family score,
+`raw_total`, `total_penalty`, `total_reward`, `total_score`, `data_completeness`,
+`completeness_tier`, `sector`, `explanation`, the sorted `penalties`/`rewards` name+value
+set, and the `analytics` dict (Codex ckpt-1 LOW: acceptance must cover explanation /
+rewards / analytics / sector, not just total_score). Report matched/diverged; **target
+3917/3917**. Then time full `compute_rankings` old vs new; record wall-clock in the PR.
+Cross-source (clause 9): confirm one instrument's `total_score` unchanged vs its last
+live `scores` row (e.g. AAPL).
+
+## Test plan (lean)
+
+- **Pure (fast tier)**: `TestScoreFromData` — `_score_from_data` + `_analytics_inputs`
+  on hand-built `data`/`analytics` dicts (no DB). `TestComputeRankings` repointed off
+  the removed `compute_score` call to the new internals (`_stub_scoring` helper).
+- **SQL-mechanism guard = the full-population same-process A/B** (below), not a
+  fixture db-test. The scoring suite has no DB harness; a 2-3 row fixture would be
+  strictly weaker than proving `_bulk_load_instrument_data(conn, ids)[iid] ==
+  _load_instrument_data(conn, iid)` for all ~3,916 instruments against the real dev
+  DB in one process. This is the CLAUDE.md "lean on dev-verify" path. Conscious
+  tradeoff: no committed db regression test; the A/B is recorded in the PR.
+
+## Out of scope (deferred)
+
+- **Incremental skip predicate** (original #2127 title). Revisit only if bulk-load
+  misses the target after re-measure. Its cost (schema: `fundamentals_snapshot` ingest
+  ts + `filing_events` red_flag watermark; 4 correctness hazards incl. time-decay
+  boundaries; fail-open design) is likely unjustified once loads are ~60-90s. Kept as
+  a follow-up note on #2127.
+- Bulking `resolve_market_cap_basis` (3s, follow-up if needed).
+
+## Operator runbook
+
+Pure compute refactor, no schema/parser/ownership change → ETL clauses 8-12 and the
+sec_rebuild runbook do NOT apply. Verification = full-pop A/B + one live
+`compute_rankings` timing on dev, recorded in each PR. Restart the jobs daemon after
+merge so scheduled `morning_candidate_review` runs the new path.

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -20,15 +20,18 @@ Coverage:
 
 from __future__ import annotations
 
+from contextlib import ExitStack, contextmanager
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from app.services.scoring import (
+    _WEIGHT_MODES,
     FamilyScores,
     PenaltyRecord,
     ScoreResult,
+    _analytics_inputs,
     _calmar_reward,
     _clip,
     _compute_penalties,
@@ -37,6 +40,7 @@ from app.services.scoring import (
     _momentum_score,
     _quality_score,
     _realized_risk_penalties,
+    _score_from_data,
     _sentiment_score,
     _turnaround_score,
     _value_score,
@@ -1122,6 +1126,70 @@ class TestComputeScore:
 
 
 # ---------------------------------------------------------------------------
+# _score_from_data / _analytics_inputs — the pure scoring core (#2127)
+# ---------------------------------------------------------------------------
+
+
+def _full_data(
+    *,
+    sector_code: str | None = "1",
+    sic: str | None = None,
+    valuation_row: dict[str, object] | None = None,
+    risk_row: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """A loaded-data dict of the shape _load_instrument_data / _bulk_load produce."""
+    return {
+        "sector_code": sector_code,
+        "sic": sic,
+        "fund_rows": [_fund_row(0.18, 0.55, 200_000.0, -50_000.0, 100_000.0, 1_100_000.0, 10_000_000.0)],
+        "price_row": _price_row(0.05, 0.20, 0.35, 120.0),
+        "quote_row": _quote_row(False, 120.0, 119.5, 120.5),
+        "thesis_row": _thesis_row(0.75, 180.0, 90.0, _RECENT),
+        "news_rows": [_news_row(0.6, 0.8), _news_row(0.5, 1.0)],
+        "avg_red_flag_score": 0.15,
+        "valuation_row": valuation_row,
+        "risk_row": risk_row,
+        "fund_present": True,
+        "last_10kq_date": None,
+        "price_td_count": 300,
+        "news_90d_count": 3,
+    }
+
+
+class TestScoreFromData:
+    """The pure scoring core takes preloaded data + analytics + now, no conn (#2127)."""
+
+    def test_pure_core_produces_valid_result(self) -> None:
+        result = _score_from_data(
+            7, _full_data(), _WEIGHT_MODES["v1-balanced"], "v1-balanced", _NOW, {"schema": "iar_v1"}
+        )
+        assert isinstance(result, ScoreResult)
+        assert result.instrument_id == 7
+        assert result.model_version == "v1-balanced"
+        assert result.analytics == {"schema": "iar_v1"}  # passed straight through
+        assert result.sector == "1"  # from data["sector_code"]
+        assert 0.0 <= result.total_score <= 1.0
+        assert result.penalties == []  # recent thesis, tight spread, high confidence
+        assert result.total_score == pytest.approx(result.raw_total, abs=1e-6)
+
+    def test_unknown_model_version_raises_via_missing_weights(self) -> None:
+        # weights is resolved by the caller; a bad mode surfaces as KeyError there.
+        with pytest.raises(KeyError):
+            _ = _WEIGHT_MODES["nope"]
+
+    def test_analytics_inputs_pure_extraction(self) -> None:
+        gics, shares = _analytics_inputs(_full_data(sic=None))
+        assert shares == pytest.approx(10_000_000.0)
+        assert gics is None  # sic None -> no SPDR sector
+
+    def test_analytics_inputs_empty_fund_rows(self) -> None:
+        data = _full_data()
+        data["fund_rows"] = []
+        gics, shares = _analytics_inputs(data)
+        assert shares is None
+
+
+# ---------------------------------------------------------------------------
 # compute_rankings — rank assignment and rank_delta via patched compute_score
 # ---------------------------------------------------------------------------
 
@@ -1193,15 +1261,33 @@ def _make_rankings_conn(
     return conn
 
 
+@contextmanager
+def _stub_scoring(results_in_order: list[ScoreResult]):
+    """Stub the load + analytics + pure-core so compute_rankings tests exercise ONLY
+    rank / rank_delta assignment (#2127: compute_rankings now calls
+    _bulk_load_instrument_data + _score_from_data, not compute_score). Stubbing
+    _bulk_load_instrument_data keeps the fake conn's 2-cursor model valid — the only
+    conn use left is the eligible query + the prior-rank fetch + inserts. Results are
+    returned in instrument-id iteration order (matches the prior compute_score stub)."""
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                "app.services.scoring._bulk_load_instrument_data",
+                side_effect=lambda conn, ids, now: {iid: {} for iid in ids},
+            )
+        )
+        stack.enter_context(patch("app.services.scoring._analytics_inputs", return_value=(None, None)))
+        stack.enter_context(patch("app.services.scoring.assemble_instrument_analytics", return_value={}))
+        mock_score = stack.enter_context(patch("app.services.scoring._score_from_data"))
+        mock_score.side_effect = results_in_order
+        yield mock_score
+
+
 class TestComputeRankings:
     def test_rank_assigned_descending_by_total_score(self) -> None:
         # Instrument 2 scores higher → should be rank 1
         conn = _make_rankings_conn(instrument_ids=[1, 2], prior_rank_rows=[])
-        with patch("app.services.scoring.compute_score") as mock_score:
-            mock_score.side_effect = [
-                _make_score_result(1, 0.60),
-                _make_score_result(2, 0.80),
-            ]
+        with _stub_scoring([_make_score_result(1, 0.60), _make_score_result(2, 0.80)]):
             result = compute_rankings(conn, "v1-balanced")
 
         by_id = {r.instrument_id: r for r in result.scored}
@@ -1211,8 +1297,7 @@ class TestComputeRankings:
     def test_rank_delta_positive_when_rank_improved(self) -> None:
         # Instrument 1 was rank 3 last run; this run it becomes rank 1 → delta = +2
         conn = _make_rankings_conn(instrument_ids=[1], prior_rank_rows=[(1, 3)])
-        with patch("app.services.scoring.compute_score") as mock_score:
-            mock_score.return_value = _make_score_result(1, 0.75)
+        with _stub_scoring([_make_score_result(1, 0.75)]):
             result = compute_rankings(conn, "v1-balanced")
 
         assert result.scored[0].rank == 1
@@ -1221,11 +1306,7 @@ class TestComputeRankings:
     def test_rank_delta_negative_when_rank_worsened(self) -> None:
         # Instrument 1 was rank 1; now rank 2 → delta = -1
         conn = _make_rankings_conn(instrument_ids=[1, 2], prior_rank_rows=[(1, 1), (2, 2)])
-        with patch("app.services.scoring.compute_score") as mock_score:
-            mock_score.side_effect = [
-                _make_score_result(1, 0.50),  # lower score this run
-                _make_score_result(2, 0.80),  # higher score this run
-            ]
+        with _stub_scoring([_make_score_result(1, 0.50), _make_score_result(2, 0.80)]):
             result = compute_rankings(conn, "v1-balanced")
 
         by_id = {r.instrument_id: r for r in result.scored}
@@ -1237,11 +1318,7 @@ class TestComputeRankings:
     def test_rank_delta_none_on_first_run(self) -> None:
         # No prior rows → rank_delta is None for all instruments
         conn = _make_rankings_conn(instrument_ids=[1, 2], prior_rank_rows=[])
-        with patch("app.services.scoring.compute_score") as mock_score:
-            mock_score.side_effect = [
-                _make_score_result(1, 0.70),
-                _make_score_result(2, 0.60),
-            ]
+        with _stub_scoring([_make_score_result(1, 0.70), _make_score_result(2, 0.60)]):
             result = compute_rankings(conn, "v1-balanced")
 
         for r in result.scored:
@@ -1265,8 +1342,7 @@ class TestComputeRankings:
         outside the transaction, this test will fail.
         """
         conn = _make_rankings_conn(instrument_ids=[1], prior_rank_rows=[])
-        with patch("app.services.scoring.compute_score") as mock_score:
-            mock_score.return_value = _make_score_result(1, 0.70)
+        with _stub_scoring([_make_score_result(1, 0.70)]):
             compute_rankings(conn, "v1-balanced")
 
         # Collect the names of all calls made on `conn` in order


### PR DESCRIPTION
## What

Phase 1 of #2127 (#649-B): **bulk-load `compute_rankings`'s scoring inputs** to kill the
per-instrument DB round-trip storm. Pure performance refactor — scoring output is
byte-identical (no `model_version` bump).

**Part of #2127** (Phase 2 — bulk the analytics helpers — follows in a second PR).

## Why (the ticket's premise was the wrong lever)

The ticket asked to "re-score only changed-input instruments" (a stateful skip cache).
cProfile on dev DB falsified that framing:

- Real `compute_score` = **197 ms/inst × 3,916 ≈ 771s** — matches the 772-844s
  `morning_candidate_review` runs (`job_runs`). Scoring IS the dominant phase.
- **95% of that is `psycopg.connection.wait`** — pure blocking on ~20 sequential
  per-instrument round-trips (~78k total at ~6.9 ms each). The cost is **round-trip
  latency, not per-instrument compute** (`resolve_market_cap_basis` = 0.8 ms/inst).

So the fix is fewer round-trips (bulk set-based reads), not a correctness-fraught skip
predicate on the trade path. Bulk-load is safer, bigger, benefits every run (including
full re-scores after a version bump, which skip-caching cannot), and is composable with
a later skip layer if still needed. Operator approved the reframe. Full analysis:
#2127 comment 5062616100.

## What changed (`app/services/scoring.py`)

- **Extract pure core** `_score_from_data(instrument_id, data, weights, model_version,
  now, analytics) -> ScoreResult` — no `conn`. `assemble_instrument_analytics` is
  **hoisted to the caller** (Codex ckpt-1: the old body was not pure). `compute_score`
  remains as a thin single-instrument wrapper (its only callers are the wrapper's own
  tests; `compute_rankings` no longer calls it).
- **`_bulk_load_instrument_data(conn, ids, now)`** — 12 set-based queries
  (`WHERE instrument_id = ANY(%(ids)s::bigint[])`) replacing the per-instrument point
  queries; returns dicts of the **same shape** as `_load_instrument_data`. Preserves:
  `DISTINCT ON` / `ROW_NUMBER` latest-row selection with explicit outer `ORDER BY`,
  `close IS NOT NULL`, `LEFT JOIN instrument_sec_profile` (sector survives no-profile),
  savepoint degradation for the three optional sources, and the per-instrument
  market-cap-basis overlay.
- **Rewire `compute_rankings`** to bulk-load once, then score each instrument from the
  preloaded data in Python. Analytics stays per-instrument in Phase 1 (~357s, bulked in
  Phase 2). Per-instrument skip-on-error preserved.

## Behavioral change (documented, no version bump)

`compute_rankings` now uses **one batch `now`** instead of a per-instrument `_utcnow()`.
Over a multi-minute run the old code drifted `now` across instruments, so late-scored
names could cross a 30d/90d news window, a 90d red-flag/thesis-staleness boundary, or a
UTC-midnight `filing_date` cutoff at a different instant than early-scored ones.
Batch-`now` scores every instrument "as of run start" — reproducible and strictly more
consistent. **No `model_version` bump**: the scoring formula is unchanged; `now` is an
execution input (running the job at a different clock time already changes windowed
results run-to-run), not a metric computation. Flagged by Codex ckpt-2; kept
deliberately.

## Verification (dev DB, pinned `now`, REPEATABLE READ snapshot, full population n=3,916)

Same-process A/B: `_load_instrument_data + _score_from_data` (old path) vs
`_bulk_load_instrument_data + _score_from_data` (new path), analytics computed once and
passed to both, all under one RR snapshot so the concurrent v5-thesis drain is invisible.

- **SCORE: 3,916 / 3,916 byte-identical** — family scores, `raw_total`, `total_penalty`,
  `total_reward`, `total_score`, `data_completeness`, `completeness_tier`, `sector`,
  `explanation`, `penalties`, `rewards`.
- **DATA: 3,899 / 3,916 identical; 17 differ ONLY in `news_rows` list ORDER** — the bulk
  query adds a `news_event_id` tie-break the per-instrument path lacks (same snapshot,
  same rows, different order). Score-neutral (importance-weighted mean is
  order-insensitive), confirmed by SCORE 3,916/3,916.
- **Timing**: bulk load = 37.5s (full pop) vs ~414s of per-instrument load round-trips.
  Phase 1 projected job ≈ 771s → ~395s (~2×); Phase 2 targets the remaining ~357s
  analytics for ~10× total.

Cross-source (DoD clause 9): AAPL `total_score` unchanged vs prior run (SCORE identical
across the full panel incl. AAPL/GME/MSFT/JPM/HD by construction of the 3,916/3,916 A/B).

Gates: `ruff check` / `ruff format --check` clean, `pyright` 0 errors, `pytest -m "not
db"` **5,348 passed**, smoke **153 passed**. Codex ckpt-1 (spec, 2 rounds) + ckpt-2
(branch) both run; ckpt-2's market-cap fault-isolation finding fixed in this commit.

## Security model

Read-only refactor. No auth/authz surface, no external input, no new endpoints/jobs.
All new SQL is parameterised (`ANY(%(ids)s::bigint[])`, bound cutoffs); no string
interpolation. Same eligibility gate and same `scores` append-only write path.

## Conscious tradeoffs

- **Batch-`now`** (above) — deliberate consistency improvement, not versioned.
- **No committed db regression test** — the scoring suite has no DB harness; a 2-3 row
  fixture would be strictly weaker than the full-population same-process A/B, which is
  the CLAUDE.md "lean on dev-verify" path for the new SQL mechanism.
- **Analytics per-instrument in Phase 1** — ~357s remains; Phase 2 bulks it.

## Not applicable

ETL clauses 8-12 / `sec_rebuild` runbook: no schema / parser / ownership change. This is
compute-path only. Operator restarts the jobs daemon after merge so the scheduled
`morning_candidate_review` picks up the new path.
