### PR TITLE
fix(#2131): kill coverage tier flap — drop the T2→T3 "no thesis" demotion trigger

### DIFF
--- a/app/services/coverage.py
+++ b/app/services/coverage.py
@@ -456,8 +456,12 @@ def _evaluate_demotion(snap: InstrumentSnapshot, now: datetime) -> TierChange | 
         if snap.total_score is not None and snap.total_score < DEMOTE_T2_TO_T3_SCORE:
             triggers_t3.append(f"score={snap.total_score:.3f} < {DEMOTE_T2_TO_T3_SCORE}")
 
-        if snap.thesis_created_at is None:
-            triggers_t3.append("no thesis")
+        # NB (#2131): thesis absence is deliberately NOT a T2→T3 trigger.
+        # T3→T2 promotion is thesis-optional (score>=0.55 alone, L348-352), so
+        # demoting on "no thesis" made every score-worthy-but-thesis-less name
+        # ping-pong T2↔T3 daily. T2 = "analysable + score-worthy"; a thesis is a
+        # held/top-20 concern (wide first-mint is operator-gated) and only gates
+        # the T2→T1 promotion. Do not re-add a thesis-absence demotion here.
 
         if not snap.is_tradable:
             triggers_t3.append("instrument not tradable")

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -470,7 +470,10 @@ class TestDemotionT2ToT3:
         snap = _snap(current_tier=2, total_score=DEMOTE_T2_TO_T3_SCORE)
         assert _evaluate_demotion(snap, _NOW) is None
 
-    def test_no_thesis_triggers(self) -> None:
+    def test_no_thesis_does_not_trigger(self) -> None:
+        """#2131: a score-worthy (>=0.45) thesis-less name rests at T2 — it does
+        NOT demote for thesis absence. T3→T2 promotion is thesis-optional, so a
+        "no thesis" demotion trigger made such names flap T2↔T3 daily."""
         snap = InstrumentSnapshot(
             instrument_id=1,
             symbol="X",
@@ -485,9 +488,7 @@ class TestDemotionT2ToT3:
             has_quote=True,
             spread_flag=False,
         )
-        result = _evaluate_demotion(snap, _NOW)
-        assert result is not None
-        assert "no thesis" in result.rationale
+        assert _evaluate_demotion(snap, _NOW) is None
 
     def test_not_tradable_triggers(self) -> None:
         snap = _snap(current_tier=2, is_tradable=False)


### PR DESCRIPTION
## What

Kill the coverage-tier flap: drop the `no thesis` trigger from the T2→T3 demotion evaluator (`app/services/coverage.py::_evaluate_demotion`, formerly L459-460). Closes #2131.

## Why

The two tier rules encoded **incompatible T2 semantics**:

- `_evaluate_promotion` T3→T2 (`coverage.py:348-352`): promotes on `total_score >= 0.55` **alone** — thesis explicitly NOT required.
- `_evaluate_demotion` T2→T3 (old `coverage.py:459-460`): demoted when `thesis_created_at is None`.

So every score-worthy-but-thesis-less name promoted to T2, then demoted on the next daily `review_coverage` run (`fundamentals_sync` Phase-3, 02:30 UTC), forever. Full-pop scan (prior session): **963 flappers / 14d** (top ones changed tier 9×); T2=1333 of which **1189 (89%) thesis-less**. Wide first-mint of the thesis-less population is a deliberate operator gate, so cadence auto-mint (`thesis_refresh`, held∪top-20, ≤5/run) can never give them theses — the flap was **permanent**.

## Fix

Remove the `no thesis` T2→T3 trigger. T2 = "analysable + score-worthy"; a thesis stays a held/top-20 concern and only gates **T2→T1** promotion (untouched). Score-axis hysteresis (demote `<0.45` / promote `>=0.55`) already keeps T2 stable. A guard comment is left in place so the trigger is not silently re-introduced.

**Untouched (intentionally):** T1→T2 demotion still fires on thesis staleness/absence (T1 requires a fresh thesis — `_has_tier1_required_data`), and T2→T1 promotion still requires a fresh, confident thesis. Only the T2↔T3 boundary changes.

## Source rule

No settled decision requires a T2 thesis. `docs/settled-decisions.md` §794 (#1996) fixes only `review_frequency` (T1=weekly, T2/T3=monthly). The `no thesis` T2→T3 trigger was a code choice, not a settled invariant.

## Full-population verification

Read-only pure-eval of `_evaluate_demotion` over **12,625 live dev snapshots** (`_load_instruments_for_review`, no writes):

| metric | value |
|---|---|
| T2 total | 1333 |
| T2 thesis-less | 1186 (89%) |
| T2→T3 demotions **post-fix** | **5** (all `score<0.45`: 0.345/0.360/0.390/0.414/0.434) |
| …of which cite `no thesis` | **0** |
| former `no thesis`-only demotes now resting at T2 | **1185** |

The 5 remaining demotions are legitimate score-floor drops. Flap eliminated.

## Load note (FLAG, not a blocker)

`select_tier12_instruments` (daily news refresh) fetches all analysable tradable T1+T2. Post-fix T2 stabilises at ~1333 — this equals the **current promotion-day peak** (07-24 promoted 1232), so it is not a new ceiling, just a consistent one. If per-fetch Yahoo-RSS latency at ~1333/day proves heavy, tuning the `0.55` promote threshold or adding a T2 cap is a separate ticket — out of scope here.

## Tests

- Inverts `test_no_thesis_triggers` → `test_no_thesis_does_not_trigger` (score-worthy thesis-less T2 now returns `None`).
- `tests/test_coverage.py`: 102 passed. Full fast tier: 5376 passed. Smoke: 153 passed.

## Checks

`ruff check` ✓ · `ruff format --check` ✓ · `pyright` (changed files) 0 errors ✓ · `pytest -m "not db"` 5376 ✓ · `pytest tests/smoke` 153 ✓ · Codex pre-push review: no findings.

## Operator follow-up

Engineering-only, no LLM cost, no schema change. Change takes effect on the next scheduled `review_coverage` after the jobs daemon (VS Code `stack: jobs`) is restarted; until then the flap continues harmlessly (audit rows only).
