### PR TITLE
feat(#2117): ADS-ratio ingestion — exact ADR market caps (curated ads_ratio table)

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -3856,10 +3856,14 @@ def get_instrument_summary(
         cap_basis = cap_resolution.basis
         if cap_resolution.basis == "total_company" and cap_resolution.total is not None:
             computed_cap_value: Decimal | None = cap_resolution.total.value
+        elif cap_resolution.basis == "fpi_adr_ratio":
+            # #2117: ADR/ADS with a curated ADS ratio — ordinary×ADS-price÷ratio
+            # is the corrected cap (None if a price/share input is missing).
+            computed_cap_value = cap_resolution.value
         elif cap_resolution.basis in ("multiclass_unavailable", "fpi_adr_unavailable"):
             # fail closed: known dual-class with no clean total, or an FPI
-            # ADR/ADS whose ordinary-shares × per-ADS-price product is wrong
-            # by the un-ingested ADS ratio (#1939).
+            # ADR/ADS with NO curated ratio, whose ordinary-shares × per-ADS-price
+            # product is wrong by the un-ingested ADS ratio (#1939).
             computed_cap_value = None
         else:
             single_cap = compute_market_cap(conn, instrument_id=instrument_id_int)

--- a/app/services/fair_value_band.py
+++ b/app/services/fair_value_band.py
@@ -326,11 +326,16 @@ def select_multiples(t: TargetInputs) -> list[str]:
     else:
         selected = []
 
-    if t.target_basis == "fpi_adr_unavailable":
+    if t.target_basis in ("fpi_adr_unavailable", "fpi_adr_ratio"):
         # #1939: FPI ADR/ADS — even the per-share pe leg is wrong (per-ADS
-        # price vs per-ordinary-share EPS differ by the un-ingested ADS
-        # ratio). No multiple is basis-safe; the band goes absent rather
-        # than publishing an ordinary-share target as an ADS target.
+        # price vs per-ordinary-share EPS differ by the ADS ratio). No multiple
+        # is basis-safe; the band goes absent rather than publishing an
+        # ordinary-share target as an ADS target.
+        # #2117: `fpi_adr_ratio` (a curated-ratio ADR) also fails closed here —
+        # `instrument_valuation` corrects the market-cap surface via metric_price,
+        # but FVB's current + own-history bases still use raw price_daily.close ×
+        # ordinary basis, so a band would reintroduce the ratio error. Tracked as
+        # #2136 (apply the ratio inside FVB, then drop it from this set).
         return []
     if t.target_basis != "not_multiclass":
         selected = [m for m in selected if m == "pe"]

--- a/app/services/xbrl_derived_stats.py
+++ b/app/services/xbrl_derived_stats.py
@@ -604,16 +604,37 @@ def resolve_market_cap_basis(
             is_multiclass = bool(exists_row and exists_row[0])
 
         if not is_multiclass:
-            # #2117: a curated ADS ratio corrects the ordinary×ADS-price product.
-            # Catches the domestic-form ADR filer (AKTX — not ``fpi``) AND
-            # un-suppresses the ratio-known fpi names (CRTO/ONC/TEVA/ZLAB).
-            cur.execute("SELECT 1 FROM ads_ratio WHERE instrument_id = %s", (instrument_id,))
-            if cur.fetchone() is not None:
-                # The corrected cap is exactly ``instrument_valuation.market_cap_live``
-                # for a ratio-known name: the view applies metric_price = price/ratio
-                # AND the same quote-else-daily-close price the rest of the identity
-                # uses. (``compute_market_cap`` is quotes-only and returns None for a
-                # daily-close-only ADR, e.g. AKTX.) Read it back so endpoint == view.
+            # #2117: one round-trip for both the curated-ratio flag and the
+            # fail-closed fpi fingerprint (this runs on the scoring path — keep
+            # the query count flat). fpi = Rule 3b-4 fingerprint ∪ ADR/ADS name
+            # marker (the marker catches domestic-form ADR filers the form set
+            # cannot); mirrors the sql/241 fpi_adr CTE — keep in sync.
+            cur.execute(
+                """
+                SELECT
+                    EXISTS (SELECT 1 FROM ads_ratio WHERE instrument_id = %(iid)s) AS has_ratio,
+                    (EXISTS (
+                        SELECT 1 FROM coverage
+                        WHERE instrument_id = %(iid)s AND filings_status = 'fpi'
+                     ) OR EXISTS (
+                        SELECT 1 FROM instruments
+                        WHERE instrument_id = %(iid)s AND company_name ~* '\\y(ADR|ADS)\\y'
+                     )) AS is_fpi_adr
+                """,
+                {"iid": instrument_id},
+            )
+            flags = cur.fetchone()
+            has_ratio = bool(flags and flags[0])
+            is_fpi_adr = bool(flags and flags[1])
+
+            if has_ratio:
+                # #2117: a curated ADS ratio corrects the ordinary×ADS-price product
+                # (catches AKTX — not ``fpi`` — and un-suppresses CRTO/ONC/TEVA/ZLAB).
+                # The corrected cap is exactly ``instrument_valuation.market_cap_live``:
+                # the view applies metric_price = price/ratio AND the same
+                # quote-else-daily-close price the rest of the identity uses
+                # (``compute_market_cap`` is quotes-only and returns None for a
+                # daily-close-only ADR, e.g. AKTX). Read it back so endpoint == view.
                 cur.execute(
                     "SELECT market_cap_live FROM instrument_valuation WHERE instrument_id = %s",
                     (instrument_id,),
@@ -621,23 +642,8 @@ def resolve_market_cap_basis(
                 mc_row = cur.fetchone()
                 return MarketCapResolution(basis="fpi_adr_ratio", value=mc_row[0] if mc_row is not None else None)
 
-            # #1939: Rule 3b-4 FPI ADR/ADS WITHOUT a ratio → fail closed. Fingerprint
-            # ∪ ADR/ADS name marker — the marker catches domestic-form ADR filers the
-            # Rule 3b-4 form set cannot. Mirrors the sql/241 fpi_adr CTE; keep in sync.
-            cur.execute(
-                """
-                SELECT 1
-                WHERE EXISTS (
-                    SELECT 1 FROM coverage
-                    WHERE instrument_id = %(iid)s AND filings_status = 'fpi'
-                ) OR EXISTS (
-                    SELECT 1 FROM instruments
-                    WHERE instrument_id = %(iid)s AND company_name ~* '\\y(ADR|ADS)\\y'
-                )
-                """,
-                {"iid": instrument_id},
-            )
-            if cur.fetchone() is not None:
+            if is_fpi_adr:
+                # #1939: Rule 3b-4 FPI ADR/ADS WITHOUT a ratio → fail closed.
                 return MarketCapResolution(basis="fpi_adr_unavailable")
 
             # Not a curated multiclass issuer and no ADS ratio → legacy single-class.

--- a/app/services/xbrl_derived_stats.py
+++ b/app/services/xbrl_derived_stats.py
@@ -188,7 +188,9 @@ class TotalCompanyMarketCap:
     legs: tuple[_ClassLeg, ...]
 
 
-MarketCapBasis = Literal["total_company", "multiclass_unavailable", "not_multiclass", "fpi_adr_unavailable"]
+MarketCapBasis = Literal[
+    "total_company", "multiclass_unavailable", "not_multiclass", "fpi_adr_unavailable", "fpi_adr_ratio"
+]
 
 
 @dataclass(frozen=True)
@@ -203,12 +205,19 @@ class MarketCapResolution:
     - ``not_multiclass`` — single-class (or not a curated dual-class issuer): the
       caller uses the legacy ``compute_market_cap`` (combined × price, exact).
     - ``fpi_adr_unavailable`` — a Rule 3b-4 foreign-private-issuer ADR/ADS
-      (#1939): the SEC share count is ordinary shares, the price is per-ADS,
-      and the ADS ratio is not ingested. FAIL CLOSED: no cap basis exists;
-      the caller must suppress every ordinary-shares × ADS-price product."""
+      (#1939) with NO curated ADS ratio: the SEC share count is ordinary shares,
+      the price is per-ADS, and the ADS ratio is not ingested. FAIL CLOSED: no
+      cap basis exists; the caller must suppress every ordinary-shares × ADS-price
+      product.
+    - ``fpi_adr_ratio`` — an ADR/ADS with a curated ADS ratio (#2117): use
+      ``value`` = ordinary-shares × ADS-price ÷ ratio (the corrected cap).
+      Catches the domestic-form ADR filers the ``fpi`` fingerprint misses."""
 
     basis: MarketCapBasis
     total: TotalCompanyMarketCap | None = None
+    # #2117: ratio-corrected market cap for the ``fpi_adr_ratio`` basis (a scalar
+    # ordinary×ADS-price÷ratio), distinct from the multiclass ``total`` structure.
+    value: Decimal | None = None
     # Per-class FLOAT value of the VIEWED instrument's own share class — its leg's
     # ``shares × price`` (#1665). A SEPARATE stat from ``total.value`` (the whole
     # company): GOOGL Class A ≈ $2.15T vs Alphabet total ≈ $4.45T. Set only for
@@ -555,29 +564,22 @@ def resolve_market_cap_basis(
     single-class product. PURE READ-PATH; see
     docs/specs/etl/2026-06-17-per-class-market-cap.md.
 
-    #1939: a Rule 3b-4 FPI ADR/ADS fails closed FIRST — the ordinary-share count
-    cannot meet the per-ADS price under ANY basis until the ADS ratio is ingested.
-    Detection reuses ``coverage.filings_status = 'fpi'`` (the coverage
-    classifier's form fingerprint — single source of truth, do not re-derive)."""
+    #1939/#2117: a Rule 3b-4 FPI ADR/ADS is corrected when a curated ADS ratio
+    exists (``fpi_adr_ratio``) and otherwise fails closed (``fpi_adr_unavailable``)
+    — the ordinary-share count cannot meet the per-ADS price under ANY basis
+    without the ratio. Detection reuses ``coverage.filings_status = 'fpi'`` (the
+    coverage classifier's form fingerprint — single source of truth, do not
+    re-derive) ∪ the ADR/ADS name marker ∪ curated ``ads_ratio`` membership.
+
+    Resolution order (Codex ckpt-1 #1: curated multiclass DOMINATES the ADS-ratio
+    correction — a same-CIK dual-class sibling must never get its price divided):
+    multiclass → ads_ratio → fpi(no ratio) → legacy."""
     with conn.cursor() as cur:
-        # Fingerprint ∪ ADR/ADS name marker — the marker catches domestic-form
-        # ADR filers (ONC/TEVA class) the Rule 3b-4 form set cannot. Mirrors
-        # the sql/237 fpi_adr CTE exactly; keep the two in sync.
-        cur.execute(
-            """
-            SELECT 1
-            WHERE EXISTS (
-                SELECT 1 FROM coverage
-                WHERE instrument_id = %(iid)s AND filings_status = 'fpi'
-            ) OR EXISTS (
-                SELECT 1 FROM instruments
-                WHERE instrument_id = %(iid)s AND company_name ~* '\\y(ADR|ADS)\\y'
-            )
-            """,
-            {"iid": instrument_id},
-        )
-        if cur.fetchone() is not None:
-            return MarketCapResolution(basis="fpi_adr_unavailable")
+        # Resolve the primary SEC CIK + curated-multiclass membership FIRST.
+        # Normalize to the 10-digit zero-padded form the rest of the SEC pipeline
+        # (and instrument_class_shares_outstanding.source_cik, #1623) stores, so an
+        # unpadded external_identifiers row can't silently miss the curated oracle and
+        # route a known dual-class issuer back to the broken legacy product.
         cur.execute(
             """
             SELECT identifier_value
@@ -590,22 +592,60 @@ def resolve_market_cap_basis(
             (instrument_id,),
         )
         cik_row = cur.fetchone()
-        if cik_row is None:
-            return MarketCapResolution(basis="not_multiclass")
-        # Normalize to the 10-digit zero-padded form the rest of the SEC pipeline
-        # (and instrument_class_shares_outstanding.source_cik, #1623) stores, so an
-        # unpadded external_identifiers row can't silently miss the curated oracle and
-        # route a known dual-class issuer back to the broken legacy product.
-        cik = str(cik_row[0]).zfill(10)
+        cik = str(cik_row[0]).zfill(10) if cik_row is not None else None
 
-        cur.execute(
-            "SELECT EXISTS (SELECT 1 FROM instrument_class_shares_outstanding WHERE source_cik = %s)",
-            (cik,),
-        )
-        exists_row = cur.fetchone()
-        if exists_row is None or not exists_row[0]:
+        is_multiclass = False
+        if cik is not None:
+            cur.execute(
+                "SELECT EXISTS (SELECT 1 FROM instrument_class_shares_outstanding WHERE source_cik = %s)",
+                (cik,),
+            )
+            exists_row = cur.fetchone()
+            is_multiclass = bool(exists_row and exists_row[0])
+
+        if not is_multiclass:
+            # #2117: a curated ADS ratio corrects the ordinary×ADS-price product.
+            # Catches the domestic-form ADR filer (AKTX — not ``fpi``) AND
+            # un-suppresses the ratio-known fpi names (CRTO/ONC/TEVA/ZLAB).
+            cur.execute("SELECT 1 FROM ads_ratio WHERE instrument_id = %s", (instrument_id,))
+            if cur.fetchone() is not None:
+                # The corrected cap is exactly ``instrument_valuation.market_cap_live``
+                # for a ratio-known name: the view applies metric_price = price/ratio
+                # AND the same quote-else-daily-close price the rest of the identity
+                # uses. (``compute_market_cap`` is quotes-only and returns None for a
+                # daily-close-only ADR, e.g. AKTX.) Read it back so endpoint == view.
+                cur.execute(
+                    "SELECT market_cap_live FROM instrument_valuation WHERE instrument_id = %s",
+                    (instrument_id,),
+                )
+                mc_row = cur.fetchone()
+                return MarketCapResolution(basis="fpi_adr_ratio", value=mc_row[0] if mc_row is not None else None)
+
+            # #1939: Rule 3b-4 FPI ADR/ADS WITHOUT a ratio → fail closed. Fingerprint
+            # ∪ ADR/ADS name marker — the marker catches domestic-form ADR filers the
+            # Rule 3b-4 form set cannot. Mirrors the sql/241 fpi_adr CTE; keep in sync.
+            cur.execute(
+                """
+                SELECT 1
+                WHERE EXISTS (
+                    SELECT 1 FROM coverage
+                    WHERE instrument_id = %(iid)s AND filings_status = 'fpi'
+                ) OR EXISTS (
+                    SELECT 1 FROM instruments
+                    WHERE instrument_id = %(iid)s AND company_name ~* '\\y(ADR|ADS)\\y'
+                )
+                """,
+                {"iid": instrument_id},
+            )
+            if cur.fetchone() is not None:
+                return MarketCapResolution(basis="fpi_adr_unavailable")
+
+            # Not a curated multiclass issuer and no ADS ratio → legacy single-class.
             return MarketCapResolution(basis="not_multiclass")
 
+    # Curated multiclass issuer → total-company cap (``cik`` is non-None here:
+    # is_multiclass can only be True when the CIK lookup succeeded).
+    assert cik is not None
     total = _build_total_company_cap(conn, instrument_id, cik)
     if total is not None:
         # Also surface the viewed instrument's OWN per-class float value (#1665) —

--- a/docs/specs/etl/2026-07-24-ads-ratio-adr-caps.md
+++ b/docs/specs/etl/2026-07-24-ads-ratio-adr-caps.md
@@ -1,0 +1,130 @@
+# ADS-ratio ingestion → exact ADR caps (#2117, #1939 step-2)
+
+**Status:** spec → Codex ckpt-1 → impl
+**Type:** schema migration (curated ref table) + view recreate + read-path change
+**Depends on:** #1939 step-1 (PR #2116 `bacef745`: FPI/ADR fail-closed suppression, sql/237, `resolve_market_cap_basis::fpi_adr_unavailable`)
+
+## Problem
+
+Step-1 SUPPRESSES rather than corrects. The SEC DEI share count is the issuer's
+**ordinary** count; the tradable price is **per-ADS** (1 ADS = N ordinary). So every
+ordinary-shares × ADS-price product overstates by the ADS ratio. Two residual cohorts:
+
+1. **AKTX class — still WRONG (not even detected).** Akari Therapeutics PLC files
+   DOMESTIC forms (10-K), so the Rule 3b-4 `fpi` fingerprint misses it, and its name
+   carries no ADR/ADS marker → it is NOT in the sql/237 suppress set and renders a fake
+   **$1,425,698,338,428.81** cap (91.6B ordinary × $15.57; iid 1050391, dev).
+2. **TEVA class — over-suppressed.** 1:1-ratio ADRs whose ordinary×price product is
+   already correct, hidden by fail-closed until the ratio proves it.
+
+## Source rule
+
+The ADS ratio (ordinary shares per 1 ADS) is fixed in the **Form F-6 registration
+statement / deposit agreement** (Securities Act Rule 466 / Form F-6 eligibility); the
+20-F cover restates it. **No XBRL tag exists** for it.
+
+**Standard-filing reuse check (mandated) — DONE, empirically:** edgartools 5.30.2 has
+**no F-6 form constant and no F-6 parser** (registration coverage stops at S-1/F-1/S-3/
+424B/497K). AKTX's F-6 POS confirms the ratio is deposit-agreement PROSE
+(*"the new ratio shall be one (1) American Depositary Share to two thousand ordinary
+shares"*), not a structured field. F-6 is also NOT linked to the scored ADR instruments
+in our `filing_events` (0 rows for iid 1050391; the 60 F-6 rows we hold are non-scored /
+depositary-entity CIKs). **→ curated per-instrument reference table, not a parser.**
+
+## Population (full-pop dev scan)
+
+Only **5 scored ADR instruments** render (or would render) a market cap:
+
+| sym | iid | ratio | source (primary) | current state |
+|---|---|---|---|---|
+| AKTX | 1050391 | 2000:1 | F-6 POS 2023-08-17 acc 0000919574-23-004884 (explicit ratio-change) | WRONG $1.43T (undetected) |
+| ONC (BeiGene) | 8692 | 13:1 | F-6 2025-05-01 (*"thirteen (13) ordinary shares"*) | suppressed |
+| TEVA | 4336 | 1:1 | F-6 2023-02-08 (*"one (1) ordinary share"*) | over-suppressed |
+| CRTO | 6185 | 1:1 | 20-F 2015-03-27 (*"Each ADS represents one ordinary share"*) | suppressed |
+| ZLAB | 8878 | 10:1 | 20-F + independent web; cap-math 1,110M/10=111M ADS ✓ | suppressed |
+
+Cross-source: each ratio also cap-math-checked (ordinary ÷ ratio = a plausible real ADS
+count). AKTX: 91.6B/2000 × $15.57 = **$713M** (matches ticket's ~$0.7B).
+⚠ Ratios CHANGE (AKTX 2023 change; ZLAB was 1:1 pre-2022) → table stores a
+`source_date` + accession per row; treat as periodically re-verified curated data.
+
+**Detection:** no clean auto-signal (F-6 unlinked; foreign-suffix over-includes
+directly-listed ordinaries like Luxfer/Prothena/ADC whose caps are correct).
+**Curated-table membership IS the detection** — it also catches the AKTX class the
+fingerprint/marker miss.
+
+## Design
+
+### Schema — `ads_ratio` (sql/240)
+```
+instrument_id BIGINT PRIMARY KEY REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+ratio          NUMERIC NOT NULL CHECK (ratio > 0),  -- ordinary shares per 1 ADS
+effective_date DATE,      -- when this ratio took effect (ratio-change aware)
+source_form    TEXT,      -- 'F-6 POS' / '20-F'
+source_accession TEXT,
+source_date    DATE,      -- filing date of the evidence
+note           TEXT,
+created_at / updated_at TIMESTAMPTZ DEFAULT now()
+```
+Keyed by **instrument_id** (not CIK): a ratio applies to the specific ADS listing, not
+all of an issuer's listings — CIK-keying would mis-apply to a same-CIK ordinary listing.
+Seed the 5 rows via symbol-resolution (`INSERT … SELECT instrument_id … WHERE symbol=…`,
+`ON CONFLICT DO UPDATE`) — portable (resolves per-DB), idempotent.
+**CURRENT-ratio contract (Codex ckpt-1 #3):** this table holds ONLY the ratio in force
+NOW; consumers compute only CURRENT figures (current price × current shares). Ratios
+change (AKTX 2023; ZLAB pre-2022) — `effective_date`/`source_date` support periodic manual
+re-verification. Do NOT use for historical-period recompute; a `valid_to`/history table is
+a future concern if historical ADR recompute is ever needed.
+
+### Correction — one substitution fixes every metric
+Effective per-ordinary price = `ADS_price / ratio`. Every price-bearing column pairs the
+per-ADS price with a per-ordinary basis (shares_outstanding is ordinary; eps/book/dps are
+per-ordinary), so replacing `price → price/ratio` in the metric math corrects
+market_cap, EV, pe, pb, ps, p_fcf, fcf_yield, ev_*, dividend_yield at once. The DISPLAYED
+`current_price` stays the raw per-ADS price (that is what trades).
+
+### View (sql/241, recreate `instrument_valuation`)
+- New `ratio_known` CTE = `ads_ratio` **EXCEPT `dual_class`** (Codex ckpt-1 #1: curated
+  multiclass dominates; a name that is both must NOT get its price divided — the `dc`
+  suppression owns it). `ratio_known` and `dual_class` are ⊥ by curation; the EXCEPT is
+  belt-and-suspenders.
+- `priced` CTE LEFT JOINs `ratio_known`; add `metric_price = price / COALESCE(ratio, 1)`.
+- `new_pipeline` / `legacy` compute all price-bearing columns from `metric_price`
+  (ratio absent → COALESCE→1 → identical to today; **no-op for all non-ADR names**).
+- Final SELECT `current_price` = raw `price` (unchanged).
+- Suppress CTE becomes `fpi_adr EXCEPT (SELECT instrument_id FROM ratio_known)` — ratio-known
+  names publish their (now-correct) metrics; ratio-absent fpi_adr still fail-closed.
+
+### Python read path (`resolve_market_cap_basis`, instruments.py endpoint)
+- New basis `fpi_adr_ratio` + scalar `value: Decimal | None` on `MarketCapResolution`
+  (ratio-corrected cap; distinct from the multiclass `total`).
+- **Ordering (Codex ckpt-1 #1): curated multiclass dominates.** Resolve in this order:
+  1. curated multiclass (`instrument_class_shares_outstanding` present) → existing
+     `total_company` / `multiclass_unavailable` logic (unchanged).
+  2. else `ads_ratio` row present → `fpi_adr_ratio`, `value = compute_market_cap / ratio`
+     (catches AKTX — not `fpi` — and un-suppresses CRTO/ONC/TEVA/ZLAB).
+  3. else `fpi`/marker → `fpi_adr_unavailable` (fail-closed, unchanged).
+  4. else `not_multiclass` → legacy `compute_market_cap` (unchanged).
+- Endpoint branch: `basis == "fpi_adr_ratio"` → `computed_cap_value = cap_resolution.value`.
+
+## Codex ckpt-1 resolutions
+1. **Multiclass dominance** — encoded above (view `ratio_known EXCEPT dual_class`; resolve
+   checks multiclass before `ads_ratio`).
+2. **EPS/DPS/book basis** — PROVEN per-ordinary on dev: `ni/eps ≈ shares_outstanding` for
+   ONC (1.045×, the decisive 13:1 case), TEVA (1.0×), ZLAB (0.94×); AKTX/ZLAB eps≤0 → pe
+   NULL; no seeded name pays a dividend (`dps` NULL → `dividend_yield` NULL). `shares_outstanding`
+   proven ordinary by cap-math. → the `price/ratio` substitution is correct for every
+   populated price-bearing column incl. `pe_ratio`.
+3. **Ratio-change validity** — `effective_date` added; CURRENT-only contract documented.
+
+## Full-population verification (post-impl, to record in PR — clauses 8-12)
+- Migration applied on dev; `ads_ratio` = 5 rows.
+- `instrument_valuation` for AKTX/ONC/TEVA/CRTO/ZLAB: market_cap_live now finite & correct
+  (AKTX ≈ $0.71B); non-ADR panel (AAPL/GME/MSFT/JPM/HD) byte-unchanged.
+- `/instruments/AKTX` endpoint market cap ≈ $0.71B (was $1.43T).
+- Cross-source: 4/5 ratios from EDGAR primary filings; ZLAB independent + cap-math.
+
+## Out of scope
+- Auto-detecting new AKTX-class names (curated additions are the maintenance path).
+- Ratio-change monitoring (source_date supports periodic manual re-verify).
+- MU's implausible $969 price (separate, not an ADR issue).

--- a/sql/240_ads_ratio.sql
+++ b/sql/240_ads_ratio.sql
@@ -1,0 +1,79 @@
+-- 240_ads_ratio.sql
+--
+-- #2117 (#1939 step-2): curated ADS-ratio reference table — ordinary shares
+-- per 1 American Depositary Share. Corrects the FPI/ADR market-cap residual
+-- that sql/237 (#1939 step-1) could only SUPPRESS: the SEC DEI share count is
+-- the issuer's ORDINARY count, the tradable price is PER-ADS, so any
+-- ordinary-shares × ADS-price product overstates by the ADS ratio.
+--
+-- Source rule: the ADS ratio is fixed in the Form F-6 registration statement /
+-- deposit agreement (Securities Act Rule 466 / Form F-6); the 20-F cover
+-- restates it. NO XBRL tag exists. Standard-filing reuse check (mandated):
+-- edgartools 5.30.2 has no F-6 parser (registration coverage stops at
+-- S-1/F-1/S-3/424B/497K) and F-6 is not linked to the scored ADR instruments
+-- in filing_events — so this is a CURATED reference table, not a parser
+-- (docs/specs/etl/2026-07-24-ads-ratio-adr-caps.md).
+--
+-- Keyed by instrument_id (not CIK): a ratio applies to the specific ADS
+-- listing, not all of an issuer's listings — CIK-keying would mis-apply to a
+-- same-CIK ordinary listing. Membership ALSO serves as detection: it catches
+-- the domestic-form ADR filers (AKTX) the Rule 3b-4 fpi fingerprint + name
+-- marker miss.
+--
+-- CURRENT-ratio contract: this table holds ONLY the ratio in force NOW.
+-- Consumers compute only CURRENT figures (current price × current shares).
+-- Ratios change over time (AKTX changed to 2000:1 in 2023; ZLAB was 1:1
+-- pre-2022) — effective_date / source_date support periodic manual
+-- re-verification. Do NOT use for historical-period recompute; a valid_to /
+-- history table is a future concern if historical ADR recompute is ever needed.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS ads_ratio (
+    instrument_id    BIGINT PRIMARY KEY REFERENCES instruments (instrument_id) ON DELETE CASCADE,
+    ratio            NUMERIC NOT NULL CHECK (ratio > 0),  -- ordinary shares per 1 ADS
+    effective_date   DATE,        -- when this ratio took effect
+    source_form      TEXT,        -- e.g. 'F-6 POS', '20-F'
+    source_accession TEXT,        -- EDGAR accession of the evidence
+    source_date      DATE,        -- filing date of the evidence
+    note             TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE ads_ratio IS
+    '#2117 curated CURRENT ADS ratio (ordinary shares per 1 ADS). CURRENT-only; '
+    'do not use for historical recompute. Membership also detects domestic-form ADR filers.';
+
+-- Seed the full-pop scored ADR population (dev scan: the only scored ADR
+-- instruments that render a market cap). Symbol-resolved so it is portable
+-- across DBs and a no-op where the instrument is absent. Idempotent.
+-- ``symbol`` is NOT unique (sql/043 documents collisions) — resolve to the
+-- PRIMARY listing only so a collision cannot divide a non-ADS sibling's price.
+INSERT INTO ads_ratio (instrument_id, ratio, effective_date, source_form, source_accession, source_date, note)
+SELECT instrument_id, v.ratio, v.effective_date, v.source_form, v.source_accession, v.source_date, v.note
+FROM instruments i
+JOIN (
+    VALUES
+        ('AKTX', 2000::numeric, DATE '2023-08-17', 'F-6 POS', '0000919574-23-004884', DATE '2023-08-17',
+         'Akari Therapeutics: 1 ADS = 2000 ordinary (F-6 POS ratio change, Deutsche Bank depositary)'),
+        ('ONC',    13::numeric, NULL,               'F-6',     NULL,                    DATE '2025-05-01',
+         'BeiGene/ONC: 1 ADS = 13 ordinary (F-6 "thirteen (13) ordinary shares")'),
+        ('ZLAB',   10::numeric, NULL,               '20-F',    NULL,                    NULL,
+         'Zai Lab: 1 ADS = 10 ordinary (was 1:1 pre-2022; cap-math 1,110M/10=111M ADS)'),
+        ('TEVA',    1::numeric, NULL,               'F-6',     NULL,                    DATE '2023-02-08',
+         'Teva: 1 ADS = 1 ordinary (F-6 "one (1) ordinary share")'),
+        ('CRTO',    1::numeric, NULL,               '20-F',    NULL,                    DATE '2015-03-27',
+         'Criteo: 1 ADS = 1 ordinary (20-F "Each ADS represents one ordinary share")')
+) AS v (symbol, ratio, effective_date, source_form, source_accession, source_date, note)
+  ON v.symbol = i.symbol AND i.is_primary_listing
+ON CONFLICT (instrument_id) DO UPDATE SET
+    ratio            = EXCLUDED.ratio,
+    effective_date   = EXCLUDED.effective_date,
+    source_form      = EXCLUDED.source_form,
+    source_accession = EXCLUDED.source_accession,
+    source_date      = EXCLUDED.source_date,
+    note             = EXCLUDED.note,
+    updated_at       = now();
+
+COMMIT;

--- a/sql/241_instrument_valuation_ads_ratio.sql
+++ b/sql/241_instrument_valuation_ads_ratio.sql
@@ -1,0 +1,360 @@
+-- 241_instrument_valuation_ads_ratio.sql
+--
+-- #2117 (#1939 step-2): correct FPI/ADR market caps using the curated
+-- ads_ratio table (sql/240) instead of only suppressing them (sql/237).
+--
+-- The SEC DEI share count is the issuer's ORDINARY count; the tradable price
+-- is PER-ADS (1 ADS = N ordinary). For a ratio-known ADR the effective
+-- per-ordinary price is price / ratio, and EVERY price-bearing column pairs
+-- the per-ADS price with a per-ordinary basis (shares_outstanding is ordinary;
+-- eps / book / dps are per-ordinary — proven on dev: ni/eps ~= ordinary
+-- shares for ONC 13:1 / TEVA / ZLAB). So a single substitution
+-- price -> price/ratio (metric_price) corrects market_cap, EV, pe, pb, ps,
+-- p_fcf, fcf_yield, ev_*, dividend_yield at once. The DISPLAYED current_price
+-- stays the raw per-ADS price (that is what trades).
+--
+-- ratio-known names are REMOVED from the fpi_adr suppression set and publish
+-- their now-correct metrics; ratio-ABSENT fpi_adr names still fail closed
+-- (sql/237 semantics preserved). Curated multiclass DOMINATES: ratio_known
+-- EXCLUDES dual_class so a same-CIK dual-class sibling never gets its price
+-- divided (the dc suppression owns it).
+--
+-- View recreate only — no data backfill (recomputed on read). Idempotent.
+-- Everything else (priced CTE #1857 recency rule, NOT MATERIALIZED, #1664
+-- dual-class suppression, sql/236 perf shape) is preserved verbatim from
+-- sql/237.
+
+BEGIN;
+
+DROP VIEW IF EXISTS instrument_valuation;
+
+CREATE VIEW instrument_valuation AS
+WITH dual_class AS (
+    -- Curated dual-class instruments: primary SEC CIK present in the
+    -- #1623 per-class FSDS table. Both share-class siblings of a covered
+    -- CIK appear (the table is keyed per sibling instrument_id).
+    SELECT DISTINCT ei.instrument_id
+    FROM external_identifiers ei
+    JOIN instrument_class_shares_outstanding c
+      ON c.source_cik = lpad(ei.identifier_value, 10, '0')
+    WHERE ei.provider = 'sec'
+      AND ei.identifier_type = 'cik'
+      AND ei.is_primary = TRUE
+),
+fpi_adr AS (
+    -- #1939: Rule 3b-4 FPI fingerprint, reused from the coverage
+    -- classifier (single source of truth — do NOT re-derive from
+    -- filing_events here) ∪ the eToro ADR/ADS name marker, which catches
+    -- the DOMESTIC-form ADR filers the fingerprint cannot (BeiGene/ONC
+    -- files 10-Ks yet its ADS = 13 ordinary shares → $467B fake cap).
+    -- Full-pop scan 2026-07-23: 182 tradable marker hits, 0 harmful
+    -- false positives (the two Ads-* names are already fpi / no-CIK).
+    SELECT instrument_id
+    FROM coverage
+    WHERE filings_status = 'fpi'
+    UNION
+    SELECT instrument_id
+    FROM instruments
+    WHERE company_name ~* '\y(ADR|ADS)\y'
+),
+ratio_known AS (
+    -- #2117: ADR instruments with a curated ADS ratio. EXCEPT dual_class so
+    -- curated multiclass dominates (a same-CIK dual-class sibling must not get
+    -- its price divided — the dc suppression below owns it; ⊥ by curation, the
+    -- EXCEPT is belt-and-suspenders).
+    SELECT instrument_id, ratio FROM ads_ratio
+    WHERE instrument_id NOT IN (SELECT instrument_id FROM dual_class)
+),
+fpi_adr_suppress AS (
+    -- #2117: still fail-closed for fpi_adr names WITHOUT a ratio; ratio-known
+    -- names are corrected (metric_price) and publish.
+    SELECT instrument_id FROM fpi_adr
+    EXCEPT
+    SELECT instrument_id FROM ratio_known
+),
+priced AS NOT MATERIALIZED (
+    -- #1857: freshest price wins. The quote is used iff it is at least
+    -- as recent (by UTC date — the ::date cast is pinned so a session
+    -- timezone cannot flip the winner near midnight) as the latest
+    -- strictly-positive daily close — a stale snapshot quote must not
+    -- shadow a fresher close. The strictly-positive close filter mirrors
+    -- compute_day_change's rule (a non-positive close is a sentinel, not
+    -- a price). The as-of stamp pairs with the price actually used.
+    --
+    -- #2117: metric_price = price / ratio (ordinary shares per 1 ADS) for a
+    -- ratio-known ADR, else price. Used by EVERY price-bearing metric below;
+    -- the raw price is kept for the displayed current_price.
+    --
+    -- Shape: driving id-set (both sources' instrument ids, index-only
+    -- scans) + LEFT JOIN quotes + LEFT JOIN LATERAL latest-close. NOT a
+    -- FULL OUTER JOIN over a global DISTINCT ON — that shape rescanned
+    -- and sorted all of price_daily (~5M rows) on EVERY per-instrument
+    -- view query (Codex ckpt-2: 1.7s/instrument × ~3,900 = ~2h per
+    -- compute_rankings run). The LATERAL is a per-id backward index
+    -- scan on the (instrument_id, price_date) PK, and an instrument_id
+    -- predicate pushes into both UNION branches. NOT MATERIALIZED is
+    -- load-bearing: priced is referenced by BOTH pipelines, so PG would
+    -- otherwise materialize the CTE and the per-instrument predicate
+    -- could not reach inside it (EXPLAIN showed the full 3M-tuple merge
+    -- on every WHERE instrument_id query).
+    SELECT
+        ids.instrument_id,
+        CASE WHEN w.use_quote THEN q.price     ELSE pd.close                    END AS price,
+        (CASE WHEN w.use_quote THEN q.price    ELSE pd.close                    END)
+            / COALESCE(rk.ratio, 1)                                                 AS metric_price,
+        CASE WHEN w.use_quote THEN q.quoted_at ELSE pd.price_date::timestamptz  END AS quoted_at
+    FROM (
+        SELECT instrument_id FROM quotes
+        UNION
+        SELECT instrument_id FROM price_daily
+    ) ids
+    LEFT JOIN (
+        SELECT instrument_id,
+               COALESCE(
+                   NULLIF(GREATEST(last, 0), 0),
+                   CASE WHEN bid > 0 AND ask > 0 THEN (bid + ask) / 2 END
+               )                    AS price,
+               quoted_at
+        FROM quotes
+    ) q USING (instrument_id)
+    LEFT JOIN LATERAL (
+        SELECT p.close, p.price_date
+        FROM price_daily p
+        WHERE p.instrument_id = ids.instrument_id
+          AND p.close > 0
+        ORDER BY p.price_date DESC
+        LIMIT 1
+    ) pd ON TRUE
+    LEFT JOIN ratio_known rk ON rk.instrument_id = ids.instrument_id
+    -- Single source of truth for the recency verdict — referenced by both
+    -- CASE columns above so the price and its as-of stamp cannot drift.
+    CROSS JOIN LATERAL (
+        SELECT q.price IS NOT NULL
+               AND (pd.price_date IS NULL
+                    OR (q.quoted_at AT TIME ZONE 'UTC')::date >= pd.price_date)
+               AS use_quote
+    ) w
+),
+new_pipeline AS (
+    SELECT
+        p.instrument_id,
+        p.price,
+        p.quoted_at,
+        ttm.revenue_ttm,
+        ttm.net_income_ttm,
+        ttm.operating_income_ttm,
+        ttm.gross_profit_ttm,
+        ttm.depreciation_amort_ttm,
+        ttm.operating_cf_ttm,
+        ttm.capex_ttm,
+        ttm.dps_declared_ttm,
+        ttm.is_complete_ttm,
+        ttm.eps_diluted_ttm,
+        ttm.total_assets,
+        ttm.total_liabilities,
+        ttm.shareholders_equity,
+        ttm.cash,
+        ttm.long_term_debt,
+        ttm.short_term_debt,
+        ttm.shares_outstanding,
+        CASE WHEN p.metric_price > 0 AND ttm.shares_outstanding > 0
+             THEN p.metric_price * ttm.shares_outstanding
+        END AS market_cap_live,
+        CASE WHEN p.metric_price > 0 AND ttm.shares_outstanding > 0
+             THEN p.metric_price * ttm.shares_outstanding
+                  + COALESCE(ttm.long_term_debt, 0)
+                  + COALESCE(ttm.short_term_debt, 0)
+                  - COALESCE(ttm.cash, 0)
+        END AS enterprise_value,
+        CASE WHEN ttm.eps_diluted_ttm > 0
+             THEN p.metric_price / ttm.eps_diluted_ttm
+        END AS pe_ratio,
+        CASE WHEN ttm.shareholders_equity > 0 AND ttm.shares_outstanding > 0
+             THEN p.metric_price / (ttm.shareholders_equity / ttm.shares_outstanding)
+        END AS pb_ratio,
+        CASE WHEN ttm.revenue_ttm > 0 AND ttm.shares_outstanding > 0
+             THEN (p.metric_price * ttm.shares_outstanding) / ttm.revenue_ttm
+        END AS price_sales,
+        CASE WHEN (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0))) > 0
+                  AND ttm.shares_outstanding > 0
+             THEN (p.metric_price * ttm.shares_outstanding)
+                  / (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)))
+        END AS p_fcf_ratio,
+        CASE WHEN p.metric_price > 0 AND ttm.shares_outstanding > 0
+                  AND (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0))) IS NOT NULL
+             THEN (ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)))
+                  / (p.metric_price * ttm.shares_outstanding)
+        END AS fcf_yield,
+        CASE WHEN ttm.shareholders_equity > 0
+             THEN (COALESCE(ttm.long_term_debt, 0) + COALESCE(ttm.short_term_debt, 0))
+                  / ttm.shareholders_equity
+        END AS debt_equity_ratio,
+        CASE WHEN ttm.revenue_ttm > 0 AND p.metric_price > 0 AND ttm.shares_outstanding > 0
+             THEN (p.metric_price * ttm.shares_outstanding
+                   + COALESCE(ttm.long_term_debt, 0)
+                   + COALESCE(ttm.short_term_debt, 0)
+                   - COALESCE(ttm.cash, 0))
+                  / ttm.revenue_ttm
+        END AS ev_revenue,
+        CASE WHEN (ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0)) > 0
+                  AND p.metric_price > 0 AND ttm.shares_outstanding > 0
+             THEN (p.metric_price * ttm.shares_outstanding
+                   + COALESCE(ttm.long_term_debt, 0)
+                   + COALESCE(ttm.short_term_debt, 0)
+                   - COALESCE(ttm.cash, 0))
+                  / (ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0))
+        END AS ev_ebitda,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.net_income_ttm / ttm.revenue_ttm
+        END AS net_margin,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.gross_profit_ttm / ttm.revenue_ttm
+        END AS gross_margin,
+        CASE WHEN ttm.revenue_ttm > 0
+             THEN ttm.operating_income_ttm / ttm.revenue_ttm
+        END AS operating_margin,
+        CASE WHEN ttm.total_assets > 0
+             THEN ttm.net_income_ttm / ttm.total_assets
+        END AS roa,
+        CASE WHEN ttm.shareholders_equity > 0
+             THEN ttm.net_income_ttm / ttm.shareholders_equity
+        END AS roe,
+        CASE WHEN p.metric_price > 0 AND ttm.dps_declared_ttm > 0
+             THEN ttm.dps_declared_ttm / p.metric_price * 100
+        END AS dividend_yield,
+        ttm.operating_income_ttm + COALESCE(ttm.depreciation_amort_ttm, 0) AS ebitda_ttm,
+        ttm.operating_cf_ttm - ABS(COALESCE(ttm.capex_ttm, 0)) AS fcf_ttm
+    FROM priced p
+    JOIN financial_periods_ttm ttm USING (instrument_id)
+    WHERE ttm.is_complete_ttm = TRUE
+),
+legacy AS (
+    -- LATERAL latest-snapshot rather than DISTINCT ON: a DISTINCT ON
+    -- subquery is not qual-pushdown-safe, which forced the per-instrument
+    -- view query to evaluate this branch's inlined ``priced`` copy over
+    -- the whole table (#1857 ckpt-2 perf finding).
+    SELECT
+        p.instrument_id,
+        p.price,
+        p.quoted_at,
+        NULL::numeric AS revenue_ttm,
+        NULL::numeric AS net_income_ttm,
+        NULL::numeric AS operating_income_ttm,
+        NULL::numeric AS gross_profit_ttm,
+        NULL::numeric AS depreciation_amort_ttm,
+        NULL::numeric AS operating_cf_ttm,
+        NULL::numeric AS capex_ttm,
+        NULL::numeric AS dps_declared_ttm,
+        NULL::boolean AS is_complete_ttm,
+        NULL::numeric AS eps_diluted_ttm,
+        NULL::numeric AS total_assets,
+        NULL::numeric AS total_liabilities,
+        NULL::numeric AS shareholders_equity,
+        fs.cash,
+        fs.debt AS long_term_debt,
+        NULL::numeric AS short_term_debt,
+        fs.shares_outstanding,
+        CASE WHEN p.metric_price > 0 AND fs.shares_outstanding > 0
+             THEN p.metric_price * fs.shares_outstanding
+        END AS market_cap_live,
+        NULL::numeric AS enterprise_value,
+        CASE WHEN p.metric_price > 0 AND fs.eps > 0
+             THEN p.metric_price / fs.eps
+        END AS pe_ratio,
+        CASE WHEN p.metric_price > 0 AND fs.book_value > 0
+             THEN p.metric_price / fs.book_value
+        END AS pb_ratio,
+        NULL::numeric AS price_sales,
+        CASE WHEN p.metric_price > 0 AND fs.shares_outstanding > 0 AND fs.fcf > 0
+             THEN (p.metric_price * fs.shares_outstanding) / fs.fcf
+        END AS p_fcf_ratio,
+        CASE WHEN p.metric_price > 0 AND fs.shares_outstanding > 0
+             THEN fs.fcf / (p.metric_price * fs.shares_outstanding)
+        END AS fcf_yield,
+        CASE WHEN fs.book_value > 0 AND fs.shares_outstanding > 0
+             THEN fs.debt / (fs.book_value * fs.shares_outstanding)
+        END AS debt_equity_ratio,
+        NULL::numeric AS ev_revenue,
+        NULL::numeric AS ev_ebitda,
+        NULL::numeric AS net_margin,
+        fs.gross_margin,
+        fs.operating_margin,
+        NULL::numeric AS roa,
+        NULL::numeric AS roe,
+        NULL::numeric AS dividend_yield,
+        NULL::numeric AS ebitda_ttm,
+        fs.fcf AS fcf_ttm
+    FROM priced p
+    JOIN LATERAL (
+        SELECT *
+        FROM fundamentals_snapshot fs0
+        WHERE fs0.instrument_id = p.instrument_id
+        ORDER BY fs0.as_of_date DESC
+        LIMIT 1
+    ) fs ON TRUE
+    WHERE NOT EXISTS (
+        SELECT 1 FROM financial_periods_ttm ttm
+        WHERE ttm.instrument_id = p.instrument_id
+          AND ttm.is_complete_ttm = TRUE
+    )
+)
+SELECT
+    v.instrument_id,
+    v.price              AS current_price,
+    v.quoted_at          AS price_as_of,
+    v.revenue_ttm,
+    v.net_income_ttm,
+    v.operating_income_ttm,
+    v.gross_profit_ttm,
+    v.depreciation_amort_ttm,
+    v.operating_cf_ttm,
+    v.capex_ttm,
+    v.dps_declared_ttm,
+    v.is_complete_ttm,
+    v.total_assets,
+    v.total_liabilities,
+    v.shareholders_equity,
+    v.cash,
+    v.long_term_debt,
+    v.short_term_debt,
+    v.shares_outstanding,
+    -- #1664: NULL the shares-distorted columns for curated dual-class
+    -- issuers (combined-shares × one-class-price is structurally wrong).
+    -- The correct total-company figure is sourced in Python by the
+    -- decision-grade consumer via resolve_market_cap_basis.
+    -- #1939/#2117: fpi_adr_suppress = FPI ADR/ADS instruments WITHOUT a
+    -- curated ratio (ratio-known names are already corrected via
+    -- metric_price and publish). FPI suppresses a WIDER list than
+    -- dual-class: pe_ratio and dividend_yield are per-share-basis
+    -- consistent across share classes but NOT across the ADS ratio.
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.market_cap_live END   AS market_cap_live,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.enterprise_value END  AS enterprise_value,
+    CASE WHEN fpi.instrument_id IS NULL THEN v.pe_ratio END                                       AS pe_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.pb_ratio END          AS pb_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.price_sales END       AS price_sales,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.p_fcf_ratio END       AS p_fcf_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.fcf_yield END         AS fcf_yield,
+    v.debt_equity_ratio,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.ev_revenue END        AS ev_revenue,
+    CASE WHEN dc.instrument_id IS NULL AND fpi.instrument_id IS NULL THEN v.ev_ebitda END         AS ev_ebitda,
+    v.net_margin,
+    v.gross_margin,
+    v.operating_margin,
+    v.roa,
+    v.roe,
+    -- forward_pe always NULL: source (analyst_estimates) dropped in
+    -- sql/080. Column retained for shape compatibility with any external
+    -- (operator-curated SQL, BI tool) reader.
+    NULL::numeric AS forward_pe,
+    CASE WHEN fpi.instrument_id IS NULL THEN v.dividend_yield END                                 AS dividend_yield,
+    v.ebitda_ttm,
+    v.fcf_ttm
+FROM (
+    SELECT * FROM new_pipeline
+    UNION ALL
+    SELECT * FROM legacy
+) v
+LEFT JOIN dual_class dc USING (instrument_id)
+LEFT JOIN fpi_adr_suppress fpi USING (instrument_id);
+
+COMMIT;

--- a/tests/test_fair_value_band_policy.py
+++ b/tests/test_fair_value_band_policy.py
@@ -78,6 +78,15 @@ def test_dual_class_financial_keeps_pe_drops_pb():
     assert select_multiples(t) == ["pe"]
 
 
+@pytest.mark.parametrize("basis", ["fpi_adr_unavailable", "fpi_adr_ratio"])
+def test_fpi_adr_bases_fail_closed_no_band(basis: str):
+    # #1939/#2117: an FPI ADR/ADS target yields NO multiples — even the pe leg
+    # is wrong (per-ADS price vs per-ordinary EPS differ by the ADS ratio) and
+    # FVB's own price bases are not ADS-adjusted (#2136). Band absent.
+    t = _t(net_income_ttm=500.0, eps_diluted_ttm=2.0, revenue_ttm=9_000.0, target_basis=basis)
+    assert select_multiples(t) == []
+
+
 def test_eligibility_gate_drops_multiple_with_nonpositive_denominator():
     # profitable but eps not positive -> pe dropped, ps kept
     t = _t(net_income_ttm=500.0, eps_diluted_ttm=0.0, revenue_ttm=9_000.0)

--- a/tests/test_instrument_valuation_fpi_suppress.py
+++ b/tests/test_instrument_valuation_fpi_suppress.py
@@ -11,6 +11,8 @@ is a base table; ``financial_periods_ttm`` is a view).
 
 from __future__ import annotations
 
+from typing import Any
+
 import psycopg
 import psycopg.rows
 import pytest
@@ -24,28 +26,34 @@ def _seed(ebull_test_conn: psycopg.Connection[tuple]) -> psycopg.Connection[tupl
     # 21 = FPI ADR (coverage fpi, no name marker); 22 = domestic control
     # (analysable, clean name); 23 = ONC-class: DOMESTIC-form ADR filer —
     # coverage analysable but name carries the ADR marker.
+    # #2117: 24 = ratio-known ADR (fpi + ads_ratio row, ratio=10) → corrected,
+    # not suppressed; 25 = multiclass issuer that ALSO has an ads_ratio row —
+    # curated multiclass must DOMINATE (price NOT divided; Codex ckpt-1 #1).
     conn.execute(
         "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES "
         "(21,'FADR','Foreign Issuer Co',TRUE),(22,'DOM','Domestic Co',TRUE),"
-        "(23,'DADR','Domestic Filer Ltd-ADR',TRUE)"
+        "(23,'DADR','Domestic Filer Ltd-ADR',TRUE),(24,'RADR','Ratio ADR Co',TRUE),"
+        "(25,'MCLS','Multiclass Issuer Co',TRUE)"
     )
     conn.execute(
         "INSERT INTO external_identifiers "
         "(instrument_id, provider, identifier_type, identifier_value, is_primary) VALUES "
         "(21,'sec','cik','0009991939',TRUE),(22,'sec','cik','0009991940',TRUE),"
-        "(23,'sec','cik','0009991941',TRUE)"
+        "(23,'sec','cik','0009991941',TRUE),(24,'sec','cik','0009991942',TRUE),"
+        "(25,'sec','cik','0009991943',TRUE)"
     )
     conn.execute(
         "INSERT INTO coverage (instrument_id, coverage_tier, filings_status) VALUES "
-        "(21, 3, 'fpi'), (22, 3, 'analysable'), (23, 3, 'analysable')"
+        "(21, 3, 'fpi'), (22, 3, 'analysable'), (23, 3, 'analysable'), "
+        "(24, 3, 'fpi'), (25, 3, 'analysable')"
     )
-    for iid, last in ((21, 100), (22, 100), (23, 100)):
+    for iid, last in ((21, 100), (22, 100), (23, 100), (24, 100), (25, 100)):
         conn.execute(
             "INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last, spread_flag) "
             "VALUES (%s, now(), %s, %s, %s, FALSE)",
             (iid, last - 1, last + 1, last),
         )
-    for iid in (21, 22, 23):
+    for iid in (21, 22, 23, 24, 25):
         conn.execute(
             "INSERT INTO fundamentals_snapshot "
             "(instrument_id, as_of_date, revenue_ttm, gross_margin, operating_margin, "
@@ -53,11 +61,23 @@ def _seed(ebull_test_conn: psycopg.Connection[tuple]) -> psycopg.Connection[tupl
             "VALUES (%s, '2025-01-01', 1e11, 0.5, 0.3, 5e10, 1e10, 2e10, 1e10, 1e10, 30, 6)",
             (iid,),
         )
+    # #2117 curated ADS ratios: 24 → 10:1 (corrected), 25 → 5:1 (must be
+    # overridden by multiclass dominance).
+    conn.execute("INSERT INTO ads_ratio (instrument_id, ratio, source_form) VALUES (24, 10, 'F-6'), (25, 5, 'F-6')")
+    # 25 is a curated multiclass issuer (one FSDS row under its CIK is enough
+    # for resolve's EXISTS check and the view's dual_class CTE).
+    conn.execute(
+        "INSERT INTO instrument_class_shares_outstanding "
+        "(instrument_id, period_end, shares, class_member, source_cik, source_adsh, "
+        " source_form_type, source_fsds_qtr, source_filed_at, resolution_method, parser_version, ingested_at) "
+        "VALUES (25, '2025-01-01', 1e10, 'CommonClassA', '0009991943', '0000000000-00-000000', "
+        "'10-K', '2025Q1', now(), 'curated', 1, now())"
+    )
     conn.commit()
     return conn
 
 
-def _val(conn: psycopg.Connection[tuple], iid: int) -> dict[str, object]:
+def _val(conn: psycopg.Connection[tuple], iid: int) -> dict[str, Any]:
     cur = conn.cursor(row_factory=psycopg.rows.dict_row)
     cur.execute(
         "SELECT current_price, market_cap_live, pe_ratio, pb_ratio, p_fcf_ratio, "
@@ -109,3 +129,35 @@ def test_resolver_fails_closed_fpi_first(_seed: psycopg.Connection[tuple]) -> No
     assert resolve_market_cap_basis(_seed, instrument_id=21).basis == "fpi_adr_unavailable"
     assert resolve_market_cap_basis(_seed, instrument_id=22).basis == "not_multiclass"
     assert resolve_market_cap_basis(_seed, instrument_id=23).basis == "fpi_adr_unavailable"
+
+
+@pytest.mark.db
+def test_ratio_known_adr_corrected_not_suppressed(_seed: psycopg.Connection[tuple]) -> None:
+    # #2117: iid 24 has a curated 10:1 ratio. The view divides the per-ADS price
+    # (metric_price = 100/10 = 10) so every price-bearing column is CORRECT and
+    # PUBLISHED (not fail-closed): market_cap = 10 × 1e10 = 1e11 (not 1e12),
+    # pe = 10 / 6 (not 100 / 6). The raw per-ADS price still displays.
+    row = _val(_seed, 24)
+    assert row["current_price"] == 100
+    assert float(row["market_cap_live"]) == pytest.approx(1e11)  # corrected, not the 1e12 fake
+    assert float(row["pe_ratio"]) == pytest.approx(10 / 6)
+    res = resolve_market_cap_basis(_seed, instrument_id=24)
+    assert res.basis == "fpi_adr_ratio"
+    assert res.value is not None
+    assert float(res.value) == pytest.approx(1e11)
+
+
+@pytest.mark.db
+def test_multiclass_dominates_ads_ratio(_seed: psycopg.Connection[tuple]) -> None:
+    # #2117 (Codex ckpt-1 #1): iid 25 is a curated multiclass issuer that ALSO
+    # has a 5:1 ads_ratio row. Multiclass MUST dominate — the price is NOT
+    # divided. resolve returns a multiclass basis, never fpi_adr_ratio.
+    res = resolve_market_cap_basis(_seed, instrument_id=25)
+    assert res.basis in ("total_company", "multiclass_unavailable")
+    assert res.basis != "fpi_adr_ratio"
+    # In the view, ratio_known EXCLUDES dual_class, so metric_price = raw price:
+    # pe = 100 / 6 (undivided), NOT 100/5/6. market_cap is dual-class suppressed
+    # (#1664), proving the ratio path did not touch it.
+    row = _val(_seed, 25)
+    assert float(row["pe_ratio"]) == pytest.approx(100 / 6)
+    assert row["market_cap_live"] is None


### PR DESCRIPTION
## What

ADS-ratio ingestion → **exact ADR market caps**, instead of only suppressing them. Closes #2117 (child of #1939; step-1 was PR #2116 `bacef745`). Spec: `docs/specs/etl/2026-07-24-ads-ratio-adr-caps.md`.

The SEC DEI share count is the issuer's **ordinary** count; the tradable price is **per-ADS** (1 ADS = N ordinary), so any ordinary-shares × ADS-price product overstates by the ADS ratio. Step-1 could only fail-closed (suppress). This ingests a curated `ads_ratio` table and **corrects** the figures.

## Source rule

ADS ratio = ordinary shares per 1 ADS, fixed in the **Form F-6 registration / deposit agreement** (Securities Act Rule 466 / Form F-6); the 20-F cover restates it. **No XBRL tag.** Standard-filing reuse check (mandated, done empirically): edgartools 5.30.2 has **no F-6 parser** (registration coverage stops at S-1/F-1/S-3/424B/497K), and F-6 isn't linked to the scored ADR instruments in `filing_events`. → **curated reference table, not a parser.** Table membership also serves as detection — it catches the domestic-form ADR filers (AKTX) the Rule 3b-4 `fpi` fingerprint + name marker miss.

## Design

- **`ads_ratio` (sql/240)** — `instrument_id` PK, `ratio > 0`, `effective_date`/`source_*`. Keyed by instrument_id (a ratio applies to the specific ADS listing, not all of an issuer's listings). CURRENT-ratio contract (ratios change — AKTX 2023, ZLAB pre-2022). Seed the 5 scored ADRs via `is_primary_listing`-guarded symbol resolution (portable, idempotent).
- **`instrument_valuation` (sql/241)** — `metric_price = price / COALESCE(ratio, 1)` drives every price-bearing column; raw `current_price` stays per-ADS. `ratio_known = ads_ratio EXCEPT dual_class` (curated multiclass dominates). Suppress set = `fpi_adr EXCEPT ratio_known` (ratio-absent FPI still fail-closed). **No-op for every non-ADR name.**
- **`resolve_market_cap_basis`** — reordered: multiclass → `ads_ratio` (new `fpi_adr_ratio` basis, reads the corrected `market_cap_live` back from the view so endpoint == view) → `fpi` (fail-closed) → legacy. New `value` field on `MarketCapResolution`; endpoint branch consumes it.

## Ratios (each primary-source verified)

| sym | ratio | source | cap-math sanity |
|-----|-------|--------|-----------------|
| AKTX | 2000:1 | F-6 POS 2023-08-17 acc 0000919574-23-004884 ("one (1) ADS to two thousand ordinary shares") | 91.6B/2000 × $15.57 = **$0.71B** |
| ONC (BeiGene) | 13:1 | F-6 2025-05-01 ("thirteen (13) ordinary shares") | 1,444M/13 = 111M ADS |
| TEVA | 1:1 | F-6 2023-02-08 ("one (1) ordinary share") | 891M/1 = 891M ADS |
| CRTO | 1:1 | 20-F 2015-03-27 ("Each ADS represents one ordinary share") | 62.9M/1 = 62.9M ADS |
| ZLAB | 10:1 | 20-F + independent web; cap-math | 1,110M/10 = 111M ADS |

`eps`/`shares` proven **per-ordinary** on dev (ni/eps ≈ ordinary shares: ONC 1.045×, TEVA 1.0×, ZLAB 0.94×) → the `price/ratio` substitution is correct for **pe** as well as the shares-based columns.

## Codex

- **ckpt-1 (spec)** — 3 findings resolved: multiclass-dominance (`ratio_known EXCEPT dual_class`; resolve checks multiclass first), eps-per-ordinary proven empirically, `effective_date` + CURRENT-only contract.
- **ckpt-2 (fresh-agent, 4 lenses)** — 2 findings:
  - **FVB mis-denomination** → `fair_value_band.select_multiples` now fail-closes `fpi_adr_ratio` like `fpi_adr_unavailable` (FVB's own price bases aren't ADS-adjusted). Proper FVB ADS support **DEFERRED #2136**. Regression-tested.
  - **Seed symbol non-uniqueness** → seed now filters `is_primary_listing` (sql/043). FIXED.

## Verification (ETL clauses 8-12, at commit `ac96bfcc`)

- **8 — smoke panel (dev):** ADRs AKTX/ONC/ZLAB/CRTO + control AAPL/GME/MSFT/JPM/HD. Live `/instruments/{sym}/summary`: **AKTX $1.43T → $0.713B**, ONC $36.2B, ZLAB $1.9B, CRTO $1.14B (all real); AAPL $4.7T / GME $9.6B **unchanged**.
- **9 — cross-source:** 4/5 ratios from EDGAR primary filings (above) + ZLAB independent; every ratio cap-math-checked.
- **10 — backfill:** sql/240 + sql/241 applied on dev; `ads_ratio` = 5 rows. (View recomputes on read — no per-instrument sec_rebuild needed.)
- **11 — operator-visible:** live `/instruments/AKTX/summary` market cap = **$0.713B** (was $1,425.7B).
- TEVA cap stays NULL (pre-existing missing `shares_outstanding` in its TTM row — not a regression; its pe=23.26 is recovered).

## Tests

- `test_instrument_valuation_fpi_suppress.py` +2: ratio-known ADR corrected & un-suppressed; **multiclass dominates ads_ratio**. 6 db-tier pass.
- `test_fair_value_band_policy.py` +1: both FPI ADR bases fail-closed. 96 pass.
- Existing resolve/multiclass db tests (test_xbrl_derived_stats, test_scoring_market_cap_basis): 9 pass — reorder safe.

`ruff` ✓ · `ruff format --check` ✓ · `pyright` ✓ · `pytest -m "not db"` 5376 ✓ · `pytest tests/smoke` 132 ✓.

## Operator follow-up

Curated `ads_ratio` maintenance: add a name = one seed row (symbol + verified ratio + source). Ratios change — re-verify against the depositary/F-6 on `effective_date` cadence.
