### PR TITLE
refactor(#1901 PR-1): extract shared portfolioTotals helper — dedup the #2129 FX logic

### DIFF
--- a/frontend/src/components/dashboard/SummaryCards.tsx
+++ b/frontend/src/components/dashboard/SummaryCards.tsx
@@ -1,6 +1,7 @@
 import type { BudgetStateResponse, PortfolioResponse } from "@/api/types";
 import { useDisplayCurrency } from "@/lib/DisplayCurrencyContext";
-import { formatMoney, formatPct, pnlPct } from "@/lib/format";
+import { formatMoney, formatPct } from "@/lib/format";
+import { portfolioTotals } from "@/lib/portfolioTotals";
 import { SectionSkeleton } from "@/components/dashboard/Section";
 import { StatTile } from "@/components/dashboard/StatTile";
 
@@ -44,30 +45,11 @@ export function SummaryCards({
     );
   }
 
-  let totalPnl = 0;
-  let totalCost = 0;
-  for (const p of data.positions) {
-    totalPnl += p.unrealized_pnl;
-    totalCost += p.cost_basis;
-  }
-  // Include mirror P&L in the total: mirrors contribute both to the
-  // unrealized total and to the cost basis denominator (via funded amount).
-  for (const m of data.mirrors ?? []) {
-    totalPnl += m.unrealized_pnl;
-    totalCost += m.funded;
-  }
-  const pnlFraction = pnlPct(totalPnl, totalCost);
-
-  // Label the portfolio totals with the currency the backend actually converted to
-  // (response.display_currency), NOT the /config context — those can observe
-  // different config states (#2129). The budget card keeps the config currency: its
-  // `available_for_deployment` is separate budget math with no per-response currency.
-  const displayCurrency = data.display_currency;
-  // The totals sum every money source (positions, cash, mirror equity); if any stayed
-  // in a non-display currency on an FX-degrade, the sum mixes currencies under one
-  // symbol. The backend flags this (covering cash/mirror, which carry no per-row
-  // currency) rather than the FE deriving it from positions alone (#2129).
-  const hasUnconverted = data.fx_incomplete;
+  // #1901: shared totals + #2129 display-currency labeling (single source, also
+  // used by the Portfolio workstation's SummaryBar). The budget card keeps the
+  // /config currency: its `available_for_deployment` is separate budget math with
+  // no per-response currency.
+  const { totalPnl, pnlFraction, displayCurrency, hasUnconverted } = portfolioTotals(data);
 
   return (
     <>

--- a/frontend/src/lib/portfolioTotals.test.ts
+++ b/frontend/src/lib/portfolioTotals.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { PortfolioResponse } from "@/api/types";
+import { portfolioTotals } from "@/lib/portfolioTotals";
+
+/** Minimal PortfolioResponse carrying only the fields portfolioTotals reads. */
+function resp(over: Partial<PortfolioResponse>): PortfolioResponse {
+  return {
+    positions: [],
+    mirrors: [],
+    display_currency: "USD",
+    fx_incomplete: false,
+    ...over,
+  } as PortfolioResponse;
+}
+
+describe("portfolioTotals", () => {
+  it("sums P&L and cost over positions AND mirrors", () => {
+    const t = portfolioTotals(
+      resp({
+        positions: [
+          { unrealized_pnl: 100, cost_basis: 1000 },
+          { unrealized_pnl: -40, cost_basis: 600 },
+        ] as PortfolioResponse["positions"],
+        mirrors: [{ unrealized_pnl: 40, funded: 400 }] as PortfolioResponse["mirrors"],
+      }),
+    );
+    expect(t.totalPnl).toBe(100);
+    expect(t.totalCost).toBe(2000);
+    expect(t.pnlFraction).toBeCloseTo(0.05); // 100 / 2000
+  });
+
+  it("returns null pnlFraction when total cost is 0 (never divides by zero)", () => {
+    const t = portfolioTotals(
+      resp({ positions: [{ unrealized_pnl: 0, cost_basis: 0 }] as PortfolioResponse["positions"] }),
+    );
+    expect(t.pnlFraction).toBeNull();
+  });
+
+  it("passes through display_currency and fx_incomplete (#2129, single source)", () => {
+    const t = portfolioTotals(resp({ display_currency: "GBP", fx_incomplete: true }));
+    expect(t.displayCurrency).toBe("GBP");
+    expect(t.hasUnconverted).toBe(true);
+  });
+
+  it("handles empty positions and absent mirrors", () => {
+    const t = portfolioTotals(resp({ positions: [], mirrors: undefined as unknown as [] }));
+    expect(t.totalPnl).toBe(0);
+    expect(t.totalCost).toBe(0);
+    expect(t.pnlFraction).toBeNull();
+  });
+});

--- a/frontend/src/lib/portfolioTotals.ts
+++ b/frontend/src/lib/portfolioTotals.ts
@@ -1,0 +1,49 @@
+import type { PortfolioResponse } from "@/api/types";
+import { pnlPct } from "@/lib/format";
+
+export interface PortfolioTotals {
+  /** Σ unrealized P&L over positions AND mirrors. */
+  totalPnl: number;
+  /** Cost denominator: Σ position cost_basis + Σ mirror funded. */
+  totalCost: number;
+  /** Capital-weighted P&L fraction (totalPnl / totalCost), null when totalCost is 0. */
+  pnlFraction: number | null;
+  /** #2129: the currency the backend actually converted the totals to
+   *  (`response.display_currency`), NOT the /config context — those can observe
+   *  different config states. Label every totals cell with this. */
+  displayCurrency: string;
+  /** #2129: true when any money source (position/cash/mirror) stayed native on an
+   *  FX-degrade, so the summed totals mix currencies under one symbol. The backend
+   *  flags this (it covers cash/mirror, which carry no per-row currency); the FE
+   *  must not re-derive it from positions alone. */
+  hasUnconverted: boolean;
+}
+
+/**
+ * Single source for the portfolio total P&L / cost / display-currency labeling
+ * shared by the Dashboard cockpit (`SummaryCards`) and the Portfolio workstation
+ * (`SummaryBar`) — #1901 dedup. Both previously inlined this same computation,
+ * including the #2129 FX-degrade logic, risking divergence.
+ *
+ * Mirrors contribute to BOTH the P&L total (`unrealized_pnl`) and the cost
+ * denominator (`funded`). Pure — table-tested without React.
+ */
+export function portfolioTotals(data: PortfolioResponse): PortfolioTotals {
+  let totalPnl = 0;
+  let totalCost = 0;
+  for (const p of data.positions) {
+    totalPnl += p.unrealized_pnl;
+    totalCost += p.cost_basis;
+  }
+  for (const m of data.mirrors ?? []) {
+    totalPnl += m.unrealized_pnl;
+    totalCost += m.funded;
+  }
+  return {
+    totalPnl,
+    totalCost,
+    pnlFraction: pnlPct(totalPnl, totalCost),
+    displayCurrency: data.display_currency,
+    hasUnconverted: data.fx_incomplete,
+  };
+}

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -23,7 +23,9 @@ import type {
   BrokerPositionItem,
   PositionItem,
   PortfolioMirrorItem,
+  PortfolioResponse,
 } from "@/api/types";
+import { portfolioTotals } from "@/lib/portfolioTotals";
 
 type RowItem =
   | { kind: "position"; data: PositionItem }
@@ -273,7 +275,7 @@ export function PortfolioPage() {
       ) : (
         <LiveQuoteProvider instrumentIds={liveQuoteIds}>
         <div className="space-y-3">
-          <SummaryBar data={portfolio.data} displayCurrency={portfolio.data.display_currency} />
+          <SummaryBar data={portfolio.data} />
           {allRows.length === 0 ? (
             <EmptyState
               title="No positions yet"
@@ -360,36 +362,12 @@ export function PortfolioPage() {
 // Summary bar
 // ---------------------------------------------------------------------------
 
-function SummaryBar({
-  data,
-  displayCurrency,
-}: {
-  data: {
-    total_aum: number;
-    cash_balance: number | null;
-    cash_currency: string;
-    positions: PositionItem[];
-    mirrors?: PortfolioMirrorItem[];
-    fx_incomplete: boolean;
-  };
-  // The currency the backend converted the totals to (response.display_currency),
-  // NOT the /config context — those can diverge (#2129).
-  displayCurrency: string;
-}) {
-  const mirrors = data.mirrors ?? [];
-  const totalPnl =
-    data.positions.reduce((s, p) => s + p.unrealized_pnl, 0) +
-    mirrors.reduce((s, m) => s + m.unrealized_pnl, 0);
-  const totalInvested =
-    data.positions.reduce((s, p) => s + p.cost_basis, 0) +
-    mirrors.reduce((s, m) => s + m.funded, 0);
-  const pct = totalInvested !== 0 ? totalPnl / totalInvested : null;
-  const posCount = data.positions.length + mirrors.length;
-  const mirrorCount = mirrors.length;
-  // Totals sum every money source (positions, cash, mirror equity); any left native on
-  // an FX-degrade makes the sum mix currencies (#2129). The backend flags this
-  // (covering cash/mirror) rather than deriving from positions alone.
-  const hasUnconverted = data.fx_incomplete;
+function SummaryBar({ data }: { data: PortfolioResponse }) {
+  // #1901: shared totals + #2129 display-currency labeling (single source, also
+  // used by the Dashboard cockpit's SummaryCards).
+  const { totalPnl, pnlFraction, displayCurrency, hasUnconverted } = portfolioTotals(data);
+  const mirrorCount = (data.mirrors ?? []).length;
+  const posCount = data.positions.length + mirrorCount;
 
   return (
     <div className="flex flex-wrap gap-x-8 gap-y-2 border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-2 text-sm">
@@ -398,7 +376,7 @@ function SummaryBar({
       <Stat
         label="P&L"
         value={formatMoney(totalPnl, displayCurrency)}
-        hint={pct === null ? undefined : formatPct(pct)}
+        hint={pnlFraction === null ? undefined : formatPct(pnlFraction)}
         tone={totalPnl >= 0 ? "positive" : "negative"}
       />
       <Stat label="Positions" value={String(posCount)} />


### PR DESCRIPTION
## What

#1901 PR-1 of 2 — extract the duplicated portfolio-summary computation into one pure helper. Part of #1901 (Dashboard/Portfolio dedup). Refs #2129 (consolidates its FX-degrade display-currency labeling into a single source).

Dashboard's `SummaryCards` (cockpit) and Portfolio's `SummaryBar` (workstation) both **inlined the same computation**: Σ unrealized P&L / cost over positions **and** mirrors, the capital-weighted pnl fraction, and the #2129 `display_currency` labeling + `fx_incomplete` mixed-currencies warning — down to duplicated comments. Two copies of money-display logic = a latent divergence risk (the #2129 fix had to be applied to both).

## Change

- New pure `frontend/src/lib/portfolioTotals.ts` — single source for `{ totalPnl, totalCost, pnlFraction, displayCurrency, hasUnconverted }`.
- `SummaryCards` and `SummaryBar` both consume it; **layouts stay distinct** (cards vs bar — the intended cockpit/workstation split, which the operator confirmed, not a thing to merge).
- `SummaryBar` drops its now-redundant `displayCurrency` prop (derived from the helper); the single call-site updated.

## Behavior-preserving

- `pnlPct(totalPnl, totalCost)` (`costBasis === 0 → null`) is **exactly** SummaryBar's prior `totalInvested !== 0 ? totalPnl / totalInvested : null`.
- Mirror `funded` stays in the cost denominator; mirror `unrealized_pnl` in the P&L total.
- `display_currency` / `fx_incomplete` passthrough unchanged → identical labels + warning.
- No layout / JSX change to either summary.

## Verification

- `pnpm --dir frontend typecheck` ✓ · `pnpm --dir frontend test:unit` — **1367 pass** (incl. `SummaryCards.test` + `PortfolioPage.test`, which render the helper-wired components).
- New `portfolioTotals.test.ts` — 4 cases (positions+mirrors sum, zero-cost→null, #2129 passthrough, empty/absent-mirrors).
- Codex ckpt-2: no findings (arithmetic matches both prior computations, zero-cost handling, #2129 passthrough, call-site consistency).
- ⚠ Manual eyeball: chrome-devtools MCP profile was locked (a browser instance is already running), so I could not screenshot — the render is covered by the passing component tests, but a glance at Dashboard + Portfolio summaries on the running :5173 is worth a moment.

## Next

PR-2: unify the compact `PositionsTable` (Dashboard) and the inline full `PortfolioTable` (Portfolio, in the 784-line page) into one component with `compact | full` variants — the larger dedup.
