### PR TITLE
refactor(#1901 PR-2): dedup avatar tone + portfolio row model across the 3 tables

### DIFF
--- a/frontend/src/components/dashboard/PositionsTable.tsx
+++ b/frontend/src/components/dashboard/PositionsTable.tsx
@@ -4,6 +4,8 @@ import { formatMoney, formatNumber, formatPct, pnlPct } from "@/lib/format";
 import { EmptyState } from "@/components/states/EmptyState";
 import { UnconvertedBadge } from "@/components/portfolio/UnconvertedBadge";
 import { LivePriceCell } from "@/components/quotes/LivePriceCell";
+import { Avatar } from "@/lib/avatar";
+import { buildSortedRows } from "@/lib/portfolioRows";
 
 /**
  * Positions table — unified view of direct positions and copy-trading mirrors.
@@ -44,21 +46,8 @@ export function PositionsTable({
     );
   }
 
-  // Build a unified sorted list: positions use market_value, mirrors use mirror_equity.
-  type RowItem =
-    | { kind: "position"; data: PositionItem }
-    | { kind: "mirror"; data: PortfolioMirrorItem };
-
-  const rows: RowItem[] = [
-    ...positions.map((p) => ({ kind: "position" as const, data: p })),
-    ...mirrors.map((m) => ({ kind: "mirror" as const, data: m })),
-  ];
-
-  rows.sort((a, b) => {
-    const mvA = a.kind === "position" ? a.data.market_value : a.data.mirror_equity;
-    const mvB = b.kind === "position" ? b.data.market_value : b.data.mirror_equity;
-    return mvB - mvA;
-  });
+  // Positions + mirrors merged, sorted by dollar value (#1901 shared builder).
+  const rows = buildSortedRows(positions, mirrors);
 
   // The live-quote stream is owned by the parent page (Dashboard or
   // Portfolio) so the instrument-id union — held positions + every
@@ -146,22 +135,6 @@ function PositionRow({ p, displayCurrency }: { p: PositionItem; displayCurrency:
   );
 }
 
-/** eToro-style colour derived from the username string. */
-const AVATAR_TONES = [
-  "bg-blue-600",
-  "bg-emerald-600",
-  "bg-amber-600",
-  "bg-rose-600",
-  "bg-violet-600",
-  "bg-cyan-600",
-] as const;
-
-function avatarTone(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  return AVATAR_TONES[Math.abs(hash) % AVATAR_TONES.length] ?? "bg-blue-600";
-}
-
 function MirrorRow({
   m,
   currency,
@@ -181,11 +154,7 @@ function MirrorRow({
           to={`/copy-trading/${m.mirror_id}`}
           className="group flex items-center gap-2 hover:no-underline"
         >
-          <span
-            className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white ${avatarTone(m.parent_username)}`}
-          >
-            {m.parent_username.charAt(0).toUpperCase()}
-          </span>
+          <Avatar username={m.parent_username} size="md" />
           <span className="font-medium text-blue-600 group-hover:underline">
             {m.parent_username}
           </span>

--- a/frontend/src/lib/avatar.test.ts
+++ b/frontend/src/lib/avatar.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { avatarTone } from "@/lib/avatar";
+
+const TONES = [
+  "bg-blue-600",
+  "bg-emerald-600",
+  "bg-amber-600",
+  "bg-rose-600",
+  "bg-violet-600",
+  "bg-cyan-600",
+];
+
+describe("avatarTone", () => {
+  it("is deterministic — same name yields the same tone", () => {
+    expect(avatarTone("@gurutrader")).toBe(avatarTone("@gurutrader"));
+  });
+
+  it("always returns a known tone class", () => {
+    for (const name of ["", "a", "@gurutrader", "Zoë", "12345", "  spaced  "]) {
+      expect(TONES).toContain(avatarTone(name));
+    }
+  });
+
+  it("distributes distinct names across more than one tone", () => {
+    const names = Array.from({ length: 40 }, (_, i) => `trader-${i}`);
+    const distinct = new Set(names.map(avatarTone));
+    expect(distinct.size).toBeGreaterThan(1);
+  });
+
+  it("empty string is handled without throwing", () => {
+    expect(() => avatarTone("")).not.toThrow();
+    expect(TONES).toContain(avatarTone(""));
+  });
+});

--- a/frontend/src/lib/avatar.tsx
+++ b/frontend/src/lib/avatar.tsx
@@ -1,0 +1,49 @@
+/**
+ * eToro-style initials avatar — one source for the tone hash + circle markup
+ * that PositionsTable (dashboard), PortfolioPage (workstation) and
+ * CopyTradingPage each previously re-declared (#1901 PR-2).
+ *
+ * The tone is a deterministic function of the username so the same trader
+ * always gets the same colour across every surface.
+ */
+
+/** Deterministic avatar background, keyed on the username string. */
+const AVATAR_TONES = [
+  "bg-blue-600",
+  "bg-emerald-600",
+  "bg-amber-600",
+  "bg-rose-600",
+  "bg-violet-600",
+  "bg-cyan-600",
+] as const;
+
+/** Stable colour for a username — same input always yields the same tone. */
+export function avatarTone(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  return AVATAR_TONES[Math.abs(hash) % AVATAR_TONES.length] ?? "bg-blue-600";
+}
+
+/** Circle diameter + text size per call site (behaviour-preserving mapping):
+ *  sm = PortfolioPage row, md = Dashboard row, lg = CopyTradingPage header. */
+const AVATAR_SIZES = {
+  sm: "h-6 w-6 text-[10px]",
+  md: "h-7 w-7 text-xs",
+  lg: "h-8 w-8 text-sm",
+} as const;
+
+export function Avatar({
+  username,
+  size = "md",
+}: {
+  username: string;
+  size?: keyof typeof AVATAR_SIZES;
+}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center justify-center rounded-full font-semibold text-white ${AVATAR_SIZES[size]} ${avatarTone(username)}`}
+    >
+      {username.charAt(0).toUpperCase()}
+    </span>
+  );
+}

--- a/frontend/src/lib/portfolioRows.test.ts
+++ b/frontend/src/lib/portfolioRows.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { PositionItem, PortfolioMirrorItem } from "@/api/types";
+import {
+  buildSortedRows,
+  matchesRowSearch,
+  rowMarketValue,
+  type RowItem,
+} from "@/lib/portfolioRows";
+
+function position(
+  instrumentId: number,
+  symbol: string,
+  overrides: Partial<PositionItem> = {},
+): PositionItem {
+  return {
+    instrument_id: instrumentId,
+    symbol,
+    company_name: `${symbol} Inc.`,
+    open_date: "2026-01-01",
+    avg_cost: 100,
+    current_price: 110,
+    current_units: 1,
+    cost_basis: 100,
+    market_value: 110,
+    unrealized_pnl: 10,
+    valuation_source: "quote",
+    source: "broker",
+    updated_at: "2026-04-18T00:00:00Z",
+    currency: "GBP",
+    trades: [],
+    ...overrides,
+  };
+}
+
+function mirror(
+  mirrorId: number,
+  parentUsername: string,
+  overrides: Partial<PortfolioMirrorItem> = {},
+): PortfolioMirrorItem {
+  return {
+    mirror_id: mirrorId,
+    parent_username: parentUsername,
+    active: true,
+    funded: 1000,
+    mirror_equity: 1200,
+    unrealized_pnl: 200,
+    position_count: 5,
+    started_copy_date: "2026-01-01",
+    ...overrides,
+  };
+}
+
+describe("rowMarketValue", () => {
+  it("uses market_value for positions, mirror_equity for mirrors", () => {
+    expect(
+      rowMarketValue({ kind: "position", data: position(1, "AAA", { market_value: 42 }) }),
+    ).toBe(42);
+    expect(
+      rowMarketValue({ kind: "mirror", data: mirror(9, "@x", { mirror_equity: 77 }) }),
+    ).toBe(77);
+  });
+});
+
+describe("buildSortedRows", () => {
+  it("merges positions + mirrors and sorts by worth descending", () => {
+    const rows = buildSortedRows(
+      [
+        position(1, "AAA", { market_value: 100 }),
+        position(2, "BBB", { market_value: 300 }),
+      ],
+      [mirror(9, "@x", { mirror_equity: 200 })],
+    );
+    expect(rows.map((r) => rowMarketValue(r))).toEqual([300, 200, 100]);
+    // The 200 slot is the mirror interleaved between the two positions.
+    expect(rows[1]?.kind).toBe("mirror");
+  });
+
+  it("defaults mirrors to empty", () => {
+    const rows = buildSortedRows([position(1, "AAA")]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kind).toBe("position");
+  });
+
+  it("returns an empty list for no positions or mirrors", () => {
+    expect(buildSortedRows([], [])).toEqual([]);
+  });
+});
+
+describe("matchesRowSearch", () => {
+  const pos: RowItem = { kind: "position", data: position(1, "AAPL") };
+  const mir: RowItem = { kind: "mirror", data: mirror(9, "@gurutrader") };
+
+  it("matches everything on an empty query", () => {
+    expect(matchesRowSearch(pos, "")).toBe(true);
+    expect(matchesRowSearch(mir, "")).toBe(true);
+  });
+
+  it("matches a position by symbol or company, case-insensitively", () => {
+    expect(matchesRowSearch(pos, "aapl")).toBe(true);
+    expect(matchesRowSearch(pos, "inc")).toBe(true);
+    expect(matchesRowSearch(pos, "msft")).toBe(false);
+  });
+
+  it("matches a mirror by trader username", () => {
+    expect(matchesRowSearch(mir, "GURU")).toBe(true);
+    expect(matchesRowSearch(mir, "aapl")).toBe(false);
+  });
+});

--- a/frontend/src/lib/portfolioRows.ts
+++ b/frontend/src/lib/portfolioRows.ts
@@ -1,0 +1,46 @@
+import type { PositionItem, PortfolioMirrorItem } from "@/api/types";
+
+/**
+ * Unified position + mirror row model — one source for the RowItem union,
+ * the market-value sort key, and the search predicate that PositionsTable
+ * (dashboard) and PortfolioPage (workstation) each previously inlined
+ * (#1901 PR-2).
+ *
+ * Positions and mirrors both contribute to "account worth", so they merge
+ * into one list sorted by dollar value descending. Pure — table-tested
+ * without React.
+ */
+export type RowItem =
+  | { kind: "position"; data: PositionItem }
+  | { kind: "mirror"; data: PortfolioMirrorItem };
+
+/** Sort/worth key: a position is worth its market value, a mirror its equity. */
+export function rowMarketValue(row: RowItem): number {
+  return row.kind === "position" ? row.data.market_value : row.data.mirror_equity;
+}
+
+/** Merge positions + mirrors into one list sorted by market value descending. */
+export function buildSortedRows(
+  positions: PositionItem[],
+  mirrors: PortfolioMirrorItem[] = [],
+): RowItem[] {
+  const rows: RowItem[] = [
+    ...positions.map((data) => ({ kind: "position" as const, data })),
+    ...mirrors.map((data) => ({ kind: "mirror" as const, data })),
+  ];
+  rows.sort((a, b) => rowMarketValue(b) - rowMarketValue(a));
+  return rows;
+}
+
+/** Case-insensitive match: position by symbol/company, mirror by trader name. */
+export function matchesRowSearch(row: RowItem, query: string): boolean {
+  if (!query) return true;
+  const lower = query.toLowerCase();
+  if (row.kind === "position") {
+    return (
+      row.data.symbol.toLowerCase().includes(lower) ||
+      row.data.company_name.toLowerCase().includes(lower)
+    );
+  }
+  return row.data.parent_username.toLowerCase().includes(lower);
+}

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -8,6 +8,7 @@ import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/S
 import { EmptyState } from "@/components/states/EmptyState";
 import { LiveQuoteProvider } from "@/components/quotes/LiveQuoteProvider";
 import { LivePriceCell } from "@/components/quotes/LivePriceCell";
+import { Avatar } from "@/lib/avatar";
 import type { MirrorSummary, MirrorPositionItem, MirrorClosedPositionItem } from "@/api/types";
 
 /**
@@ -46,7 +47,7 @@ export function CopyTradingPage() {
         </Link>
         {username ? (
           <h1 className="flex items-center gap-2 text-xl font-semibold text-slate-800 dark:text-slate-100">
-            <TraderAvatar username={username} />
+            <Avatar username={username} size="lg" />
             {username}
           </h1>
         ) : (
@@ -81,35 +82,6 @@ export function CopyTradingPage() {
         </>
       )}
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Trader avatar — eToro-style initials circle
-// ---------------------------------------------------------------------------
-
-const AVATAR_TONES = [
-  "bg-blue-600",
-  "bg-emerald-600",
-  "bg-amber-600",
-  "bg-rose-600",
-  "bg-violet-600",
-  "bg-cyan-600",
-] as const;
-
-function avatarTone(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  return AVATAR_TONES[Math.abs(hash) % AVATAR_TONES.length] ?? "bg-blue-600";
-}
-
-function TraderAvatar({ username }: { username: string }) {
-  return (
-    <span
-      className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-semibold text-white ${avatarTone(username)}`}
-    >
-      {username.charAt(0).toUpperCase()}
-    </span>
   );
 }
 

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -26,10 +26,12 @@ import type {
   PortfolioResponse,
 } from "@/api/types";
 import { portfolioTotals } from "@/lib/portfolioTotals";
-
-type RowItem =
-  | { kind: "position"; data: PositionItem }
-  | { kind: "mirror"; data: PortfolioMirrorItem };
+import { Avatar } from "@/lib/avatar";
+import {
+  buildSortedRows,
+  matchesRowSearch,
+  type RowItem,
+} from "@/lib/portfolioRows";
 
 interface CloseTarget {
   instrumentId: number;
@@ -95,27 +97,11 @@ export function PortfolioPage() {
   // so they share the same sorted list.
   const allRows: RowItem[] = useMemo(() => {
     if (portfolio.data === null) return [];
-    const positions = portfolio.data.positions.map<RowItem>((p) => ({
-      kind: "position",
-      data: p,
-    }));
-    const mirrors = portfolio.data.mirrors.map<RowItem>((m) => ({
-      kind: "mirror",
-      data: m,
-    }));
-    const combined = [...positions, ...mirrors];
-    combined.sort((a, b) => {
-      const mvA =
-        a.kind === "position" ? a.data.market_value : a.data.mirror_equity;
-      const mvB =
-        b.kind === "position" ? b.data.market_value : b.data.mirror_equity;
-      return mvB - mvA;
-    });
-    return combined;
+    return buildSortedRows(portfolio.data.positions, portfolio.data.mirrors);
   }, [portfolio.data]);
 
   const visible = useMemo(
-    () => allRows.filter((r) => matchesSearch(r, search)),
+    () => allRows.filter((r) => matchesRowSearch(r, search)),
     [allRows, search],
   );
   const totalPages = Math.max(1, Math.ceil(visible.length / PAGE_SIZE));
@@ -426,34 +412,6 @@ function Stat({
 // Table
 // ---------------------------------------------------------------------------
 
-function matchesSearch(row: RowItem, q: string): boolean {
-  if (!q) return true;
-  const lower = q.toLowerCase();
-  if (row.kind === "position") {
-    return (
-      row.data.symbol.toLowerCase().includes(lower) ||
-      row.data.company_name.toLowerCase().includes(lower)
-    );
-  }
-  return row.data.parent_username.toLowerCase().includes(lower);
-}
-
-const AVATAR_TONES = [
-  "bg-blue-600",
-  "bg-emerald-600",
-  "bg-amber-600",
-  "bg-rose-600",
-  "bg-violet-600",
-  "bg-cyan-600",
-] as const;
-
-function avatarTone(name: string): string {
-  let hash = 0;
-  for (let i = 0; i < name.length; i++)
-    hash = (hash * 31 + name.charCodeAt(i)) | 0;
-  return AVATAR_TONES[Math.abs(hash) % AVATAR_TONES.length] ?? "bg-blue-600";
-}
-
 function PortfolioTable({
   pageRows,
   displayCurrency,
@@ -719,11 +677,7 @@ function MirrorRow({
     >
       <td className="px-4 py-2 text-left">
         <span className="inline-flex items-center gap-2">
-          <span
-            className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold text-white ${avatarTone(m.parent_username)}`}
-          >
-            {m.parent_username.charAt(0).toUpperCase()}
-          </span>
+          <Avatar username={m.parent_username} size="sm" />
           <span className="font-medium text-slate-800 dark:text-slate-100">
             {m.parent_username}
           </span>


### PR DESCRIPTION
## What

#1901 PR-2 — kill the remaining Dashboard/Portfolio/CopyTrading duplication that PR-1 (`320e66c2`, shared `portfolioTotals`) left behind. Behaviour-preserving; no UX change.

Two new pure modules, three consumers rewired:

- **`frontend/src/lib/avatar.tsx`** — `avatarTone()` + `AVATAR_TONES` (the eToro-style hash→colour) and an `<Avatar username size>` component. Previously re-declared verbatim in **three** files (PositionsTable:150, PortfolioPage:441, CopyTradingPage:91). Size map preserves each call site exactly: `sm`=h-6 (portfolio row), `md`=h-7 (dashboard row), `lg`=h-8 (copy-trading header).
- **`frontend/src/lib/portfolioRows.ts`** — the `RowItem` union, `rowMarketValue()`, `buildSortedRows()` (positions+mirrors merged, sorted by dollar value desc), and `matchesRowSearch()`. The union + sort were duplicated in PositionsTable and PortfolioPage; the search predicate lived inline in PortfolioPage.

Consumers now import the shared primitives:
- `PositionsTable.tsx` (dashboard, compact read-only) — `buildSortedRows` + `<Avatar size="md">`.
- `PortfolioPage.tsx` (workstation, full: search/`/`focus/Esc/j-k/Enter/pagination/tabs/Add+Close modals) — `buildSortedRows` + `matchesRowSearch` + `<Avatar size="sm">`.
- `CopyTradingPage.tsx` — `<Avatar size="lg">` (dropped the local `TraderAvatar`).

## Why not one table component

The two tables share *primitives*, not *layout*: dashboard renders 7 read-only columns; portfolio renders 10 columns with per-row Add/Close, avg-entry, trade-count, and the keyboard/search/pagination shell. Merging them would need a `variant` prop threading ~8 feature flags — the mega-component the ticket explicitly says to avoid. So the split shells stay; only the pure logic (tone, RowItem, sort, search) is shared. This matches the issue's own evidence comment ("duplicated avatarTone/AVATAR_TONES, unified sort, and live-price cell wiring"). LivePriceCell was already a shared component — no work there.

## Tests

- New pure table-tests: `avatar.test.ts` (determinism, tone range, distribution, empty string), `portfolioRows.test.ts` (sort order + interleave, empty defaults, search semantics).
- `PortfolioPage.test.tsx` (sort order, testids, keyboard, FX badge, pagination, search) unchanged and green — markup + testids identical after the swap.

## Verification

- `pnpm --dir frontend typecheck` — clean.
- `pnpm --dir frontend test:unit` — 129 files, 1378 tests pass (+11 new).
- `pnpm --dir frontend dark:check` — 257 files, no violations.
- Backend untouched (FE-only diff).

Closes #1901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
