### PR TITLE
feat(#2121): DEF 14A holder_role as a non-additive overlay label

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4714,6 +4714,9 @@ class _HolderModel(BaseModel):
     # Per-lot breakdown when an owner's additive direct/indirect lots were
     # collapsed to one line (#1942). Empty for single-lot holders.
     lots: list[_HolderLotModel] = []
+    # DEF 14A proxy role tag (#2121) — display label only, present solely on the
+    # non-additive ``def14a_unmatched`` memo overlay; ``None`` everywhere else.
+    holder_role: str | None = None
 
 
 class _SliceModel(BaseModel):
@@ -5029,6 +5032,7 @@ def _rollup_to_response(
                             )
                             for lot in h.lots
                         ],
+                        holder_role=h.holder_role,
                     )
                     for h in s.holders
                 ],

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -229,6 +229,15 @@ class Holder:
     # indirect) were collapsed to one display line (#1942). Display-only; the
     # lots SUM to ``shares`` (already counted once). Empty for single-lot owners.
     lots: tuple[HolderLot, ...] = ()
+    # DEF 14A proxy role tag (``officer`` / ``director`` / ``principal`` /
+    # ``group``), parser-derived from the SEC Item 403 sub-table the holder
+    # appeared in (#2121). DISPLAY-LABEL ONLY — populated solely on the
+    # non-additive ``def14a_unmatched`` memo overlay (never on matched holders
+    # that land in insiders/blockholders), and never used in additive math: the
+    # ``group`` row is the Item 403(b) "all directors & officers as a group"
+    # aggregate of the individual rows, so summing it double-counts (I21/#1659).
+    # ``None`` for every non-DEF-14A holder and for unlabelled proxy rows.
+    holder_role: str | None = None
 
 
 @dataclass(frozen=True)
@@ -723,6 +732,10 @@ class _Candidate:
     accession_number: str
     source_row_id: int
     ownership_nature: str | None = None
+    # DEF 14A proxy role tag carried from ``ownership_def14a_current`` so the
+    # unmatched slice-build can surface it as a display label (#2121). Only the
+    # DEF 14A read path sets it; every other source leaves it ``None``.
+    holder_role: str | None = None
 
 
 def edgar_archive_url(accession_number: str | None) -> str | None:
@@ -1148,6 +1161,7 @@ def _read_def14a_unmatched_from_current(conn: psycopg.Connection[Any], instrumen
             SELECT
                 row_number() OVER (ORDER BY holder_name_key, ownership_nature) AS holding_id,
                 holder_name,
+                holder_role,
                 ownership_nature,
                 shares,
                 period_end AS as_of_date,
@@ -1314,8 +1328,8 @@ def _enrich_and_union_def14a(
     against. These are mostly named officers in the proxy who never
     filed a Form 4 / Form 3.
 
-    ``def14a_rows`` shape: ``{holding_id, holder_name, ownership_nature,
-    shares, as_of_date, accession_number}`` — supplied by
+    ``def14a_rows`` shape: ``{holding_id, holder_name, holder_role,
+    ownership_nature, shares, as_of_date, accession_number}`` — supplied by
     :func:`_read_def14a_unmatched_from_current`. Codex pre-push review
     for #905 caught the prior shape that omitted ``ownership_nature``:
     ``ownership_def14a_current`` PK is
@@ -1343,6 +1357,7 @@ def _enrich_and_union_def14a(
             accession_number=str(row["accession_number"]),  # type: ignore[arg-type]
             source_row_id=int(row["holding_id"]),  # type: ignore[arg-type]
             ownership_nature=str(row["ownership_nature"]) if row.get("ownership_nature") else None,
+            holder_role=str(row["holder_role"]) if row.get("holder_role") else None,
         )
         # Use the resolver's ``matched`` flag, not just ``cik is not
         # None``. The resolver returns ``matched=True, cik=None`` for a
@@ -2535,6 +2550,11 @@ def _bucket_into_slices(
                 as_of_date=c.as_of_date,
                 filer_type=None,
                 dropped_sources=(),
+                # #2121: display-label only. Populated here on the non-additive
+                # memo overlay ALONE — matched DEF 14A rows go through
+                # ``_dedup_by_priority`` into insiders/blockholders and leave
+                # ``holder_role`` at its ``None`` default (I21/#1659 guarantee).
+                holder_role=c.holder_role,
             )
             for c in unmatched_def14a
         ]
@@ -2763,6 +2783,7 @@ def _build_slice(
             dropped_sources=h.dropped_sources,
             family_members=h.family_members,  # display breakdown of a collapsed family (#1644/#1649)
             lots=h.lots,  # per-lot breakdown of a collapsed direct/indirect owner (#1942)
+            holder_role=h.holder_role,  # DEF 14A proxy display label (#2121); None off the overlay
         )
         for h in holders
     )

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -123,6 +123,14 @@ export interface OwnershipHolder {
    * Empty/absent for single-lot holders.
    */
   readonly lots?: readonly OwnershipLot[];
+  /**
+   * DEF 14A proxy role tag (#2121) — ``officer`` / ``director`` / ``principal``
+   * / ``group``, or null. Parser-derived from the SEC Item 403 sub-table the
+   * holder appeared in. DISPLAY LABEL ONLY: present solely on the non-additive
+   * ``def14a_unmatched`` memo overlay; the ``group`` row is the Item 403(b)
+   * "directors & officers as a group" aggregate, so it is never summed.
+   */
+  readonly holder_role?: string | null;
 }
 
 /** One additive Section-16 lot (direct / indirect) of a collapsed owner

--- a/frontend/src/components/instrument/OwnershipPanel.test.ts
+++ b/frontend/src/components/instrument/OwnershipPanel.test.ts
@@ -23,7 +23,11 @@ import { describe, expect, it } from "vitest";
 
 import type { OwnershipRollupResponse } from "@/api/ownership";
 
-import { rollupToSunburstInputs } from "./OwnershipPanel";
+import {
+  hasParsedHolderName,
+  proxyRoleLabel,
+  rollupToSunburstInputs,
+} from "./OwnershipPanel";
 
 function _baseRollup(
   overrides: Partial<OwnershipRollupResponse> = {},
@@ -446,5 +450,33 @@ describe("rollupToSunburstInputs — source_url threading (#921)", () => {
       source_url:
         "https://www.sec.gov/Archives/edgar/data/1000010/000100001026000010-index.html",
     });
+  });
+});
+
+describe("proxyRoleLabel — DEF 14A role display label (#2121)", () => {
+  it("maps the known SEC Item 403 role tags", () => {
+    expect(proxyRoleLabel("officer")).toBe("Officer");
+    expect(proxyRoleLabel("director")).toBe("Director");
+    expect(proxyRoleLabel("principal")).toBe("5% holder");
+    // The 403(b) aggregate row is labelled distinctly so its large,
+    // non-additive share count reads as a group total, not a person.
+    expect(proxyRoleLabel("group")).toBe("Group total");
+  });
+
+  it("title-cases an unknown tag rather than dropping it", () => {
+    expect(proxyRoleLabel("trustee")).toBe("Trustee");
+  });
+});
+
+describe("hasParsedHolderName — role badge suppressed on unparsed names (#2121)", () => {
+  it("true for real holder names", () => {
+    expect(hasParsedHolderName("The Baupost Group, L.L.C.")).toBe(true);
+    expect(hasParsedHolderName("Jane Officer")).toBe(true);
+  });
+
+  it("false for numeric-only names (share count leaked into the name column)", () => {
+    expect(hasParsedHolderName("11,005,001")).toBe(false);
+    expect(hasParsedHolderName("1,234.56")).toBe(false);
+    expect(hasParsedHolderName("  190,827,921  ")).toBe(false);
   });
 });

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -570,13 +570,6 @@ const _OVERLAY_TOP_N = 8;
  * funds-specific double-count copy is keyed on the category.
  */
 /**
- * Human label for a DEF 14A proxy role tag (#2121). Purely descriptive — the
- * SEC Item 403 sub-table each holder appeared in. ``group`` is the 403(b) "all
- * directors & officers as a group" AGGREGATE row (its shares already contain the
- * individual officer/director rows), so it is labelled distinctly and never
- * added to the pie. Unknown values fall through to a title-cased raw string.
- */
-/**
  * A minority of stored DEF 14A rows have a numeric ``holder_name`` (a share
  * count leaked into the name column — a parser bug tracked separately, ~13% of
  * proxy rows full-pop). Don't stamp a confident role badge onto a row whose
@@ -587,6 +580,13 @@ export function hasParsedHolderName(name: string): boolean {
   return /[A-Za-z]/.test(name);
 }
 
+/**
+ * Human label for a DEF 14A proxy role tag (#2121). Purely descriptive — the
+ * SEC Item 403 sub-table each holder appeared in. ``group`` is the 403(b) "all
+ * directors & officers as a group" AGGREGATE row (its shares already contain the
+ * individual officer/director rows), so it is labelled distinctly and never
+ * added to the pie. Unknown values fall through to a title-cased raw string.
+ */
 export function proxyRoleLabel(role: string): string {
   switch (role) {
     case "officer":

--- a/frontend/src/components/instrument/OwnershipPanel.tsx
+++ b/frontend/src/components/instrument/OwnershipPanel.tsx
@@ -569,6 +569,39 @@ const _OVERLAY_TOP_N = 8;
  * ``institution_subset`` slice surfaces here automatically; only the
  * funds-specific double-count copy is keyed on the category.
  */
+/**
+ * Human label for a DEF 14A proxy role tag (#2121). Purely descriptive — the
+ * SEC Item 403 sub-table each holder appeared in. ``group`` is the 403(b) "all
+ * directors & officers as a group" AGGREGATE row (its shares already contain the
+ * individual officer/director rows), so it is labelled distinctly and never
+ * added to the pie. Unknown values fall through to a title-cased raw string.
+ */
+/**
+ * A minority of stored DEF 14A rows have a numeric ``holder_name`` (a share
+ * count leaked into the name column — a parser bug tracked separately, ~13% of
+ * proxy rows full-pop). Don't stamp a confident role badge onto a row whose
+ * identity failed to parse: require at least one letter in the name. This
+ * declines to decorate a known-broken row; it does not re-derive the role.
+ */
+export function hasParsedHolderName(name: string): boolean {
+  return /[A-Za-z]/.test(name);
+}
+
+export function proxyRoleLabel(role: string): string {
+  switch (role) {
+    case "officer":
+      return "Officer";
+    case "director":
+      return "Director";
+    case "principal":
+      return "5% holder";
+    case "group":
+      return "Group total";
+    default:
+      return role.charAt(0).toUpperCase() + role.slice(1);
+  }
+}
+
 function OverlaySection({ slice }: OverlaySectionProps): JSX.Element {
   const total = parseShareCount(slice.total_shares) ?? 0;
   const totalPct = parseShareCount(slice.pct_outstanding) ?? 0;
@@ -628,6 +661,14 @@ function OverlaySection({ slice }: OverlaySectionProps): JSX.Element {
                   ) : (
                     h.filer_name
                   )}
+                  {isProxy && h.holder_role && hasParsedHolderName(h.filer_name) ? (
+                    <span
+                      className="ml-1.5 rounded bg-slate-200 px-1 py-0.5 text-[0.5rem] font-medium uppercase tracking-wide text-slate-600 dark:bg-slate-700 dark:text-slate-300"
+                      title="SEC Item 403 proxy role — descriptive only, not added to the pie"
+                    >
+                      {proxyRoleLabel(h.holder_role)}
+                    </span>
+                  ) : null}
                 </td>
                 <td className="py-1 text-right font-mono text-slate-600 dark:text-slate-300">
                   {formatShares(hShares)}

--- a/tests/test_def14a_holder_role_label.py
+++ b/tests/test_def14a_holder_role_label.py
@@ -1,0 +1,83 @@
+"""#2121 — DEF 14A ``holder_role`` is a DISPLAY LABEL on the non-additive
+``def14a_unmatched`` memo overlay ONLY, and must never leak into the additive
+insiders / blockholders slices (I21 / #1659).
+
+Pure tests over ``_bucket_into_slices`` (unmatched carry) and
+``_dedup_by_priority`` (matched-path drop) — no DB, so they run in the fast
+tier. The invariant is enforced by construction: only the unmatched slice-build
+sets ``Holder.holder_role``; the dedup path that feeds insiders/blockholders
+never passes it, so it stays ``None``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.services.ownership_rollup import (
+    Holder,
+    _bucket_into_slices,
+    _Candidate,
+    _dedup_by_priority,
+)
+
+
+def _def14a_candidate(name: str, role: str | None, *, source_row_id: int = 1) -> _Candidate:
+    return _Candidate(
+        source="def14a",
+        priority_rank=99,
+        filer_cik=None,
+        filer_name=name,
+        filer_type=None,
+        shares=Decimal("5000"),
+        as_of_date=None,
+        accession_number="0000000000-24-000001",
+        source_row_id=source_row_id,
+        ownership_nature="beneficial",
+        holder_role=role,
+    )
+
+
+def test_unmatched_slice_carries_holder_role() -> None:
+    """Each unmatched DEF 14A candidate's role reaches the overlay holder."""
+    cands = [
+        _def14a_candidate("Jane Officer", "officer", source_row_id=1),
+        _def14a_candidate("All directors and officers as a group", "group", source_row_id=2),
+        _def14a_candidate("Unlabelled Holder", None, source_row_id=3),
+    ]
+    slices = _bucket_into_slices({}, cands, Decimal("1000000"))
+    proxy = next(s for s in slices if s.category == "def14a_unmatched")
+
+    roles = {h.filer_name: h.holder_role for h in proxy.holders}
+    assert roles["Jane Officer"] == "officer"
+    assert roles["All directors and officers as a group"] == "group"
+    assert roles["Unlabelled Holder"] is None
+    # The overlay stays non-additive regardless of the label.
+    assert proxy.denominator_basis == "proxy_disclosure"
+
+
+def test_matched_def14a_holder_never_carries_role() -> None:
+    """A DEF 14A candidate that resolves to a filer flows through
+    ``_dedup_by_priority`` into insiders/blockholders — the resulting Holder
+    must leave ``holder_role`` at ``None`` even though the candidate carried one
+    (the I21/#1659 no-leak guarantee)."""
+    matched = _def14a_candidate("Matched Insider", "officer")
+    survivors = _dedup_by_priority([matched])
+    assert len(survivors) == 1
+    assert survivors[0].holder_role is None
+
+
+def test_holder_role_defaults_none() -> None:
+    """Non-DEF-14A holders never set the field."""
+    h = Holder(
+        filer_cik="0000000000",
+        filer_name="Vanguard",
+        shares=Decimal("100"),
+        pct_outstanding=Decimal("0.1"),
+        winning_source="13f",
+        winning_accession="0000000000-24-000009",
+        winning_edgar_url=None,
+        as_of_date=None,
+        filer_type="institution",
+        dropped_sources=(),
+    )
+    assert h.holder_role is None


### PR DESCRIPTION
## What

#2121 — surface the DEF 14A proxy `holder_role` (`officer` / `director` / `principal` / `group`) as a **non-additive display label** on the `def14a_unmatched` memo overlay. The field was already stored on `ownership_def14a_current`; the rollup read simply dropped it. Now it rides the unmatched-slice holders out to the overlay.

## Source rule

SEC Reg S-K **Item 403** (17 CFR 229.403): 403(a) = >5% beneficial owners (`principal`); 403(b) = management (directors/officers) **plus** the "all directors & officers as a group" aggregate (`group`). The `group` row's shares already contain the individual officer/director rows, so it is non-additive with them — which is exactly why the whole `def14a_unmatched` slice is `denominator_basis='proxy_disclosure'` and never enters the pie/residual/concentration math (#1659 / I21).

## The invariant (display-label only, never additive)

`holder_role` is populated on **one** code path — the unmatched slice-build (`_bucket_into_slices`). Matched DEF 14A holders (those that resolve to a Form 4 / 13D/G / 13F filer) flow through `_dedup_by_priority` / `_dedup_within_source`, which construct `Holder` **without** `holder_role`, so they reach the additive insiders/blockholders slices with `holder_role=None`. `_build_slice` copies the field when rebuilding to fill `pct_outstanding`, but by construction the additive sources reaching it carry `None`. No additive math reads the field (residual/concentration/pie filter on `denominator_basis` and only read shares/totals). A pure test pins both directions.

## Threading

- `ownership_rollup.py`: `_Candidate` + `Holder` gain `holder_role: str | None = None`; the drop-site SELECT (`_read_def14a_unmatched_from_current`) projects it; `_enrich_and_union_def14a` carries it onto the candidate; the unmatched slice-build and `_build_slice` copy it.
- `instruments.py`: `_HolderModel` gains optional `holder_role`, wired in the Holder→model map.
- `ownership.ts`: `OwnershipHolder.holder_role?`.
- `OwnershipPanel.tsx`: `OverlaySection` renders a subtle role badge next to the holder name — proxy overlay only, text-carries-meaning (not colour-alone), with a "descriptive only, not added to the pie" title.

## Full-population verification + a display guard

Verifying on the full dev DB surfaced two **pre-existing DEF 14A parser** quality gaps (in ingest/classification, NOT this read-path change), filed as **#2140**:
- 13.4% of shares-bearing proxy rows have a numeric `holder_name` (share count leaked into the name column).
- 60% of "as a group" aggregate rows are mis-tagged (not `group`); 1,160 institution-named rows tagged as an individual role.

To avoid stamping a confident role badge onto a row whose identity failed to parse, the overlay suppresses the badge when the name has no letters (`hasParsedHolderName`). This declines to decorate a known-broken row; it does not re-derive the role. The label is faithful, best-effort surfacing of the stored classification; the parser fix is tracked in #2140.

## Verification (dev DB, live endpoint)

`/instruments/{symbol}/ownership-rollup` on the def14a-heavy panel — role renders on the overlay, `denominator_basis` stays `proxy_disclosure`:
- **LOGI** — `principal:4, director:37, officer:7`
- **UBER** — `principal:4, officer:31`
- **MKTX** — `principal:9, director:36`
- **CYH** — `officer:10, principal:9, director:21`

## Tests / gates

- New pure test `tests/test_def14a_holder_role_label.py` (fast tier): unmatched carries role; matched-path Holder stays `None`; default `None`.
- `OwnershipPanel.test.ts`: `proxyRoleLabel` mapping + `hasParsedHolderName` guard.
- `ruff` · `ruff format --check` · `pyright` · `pytest -m "not db"` · `pytest tests/smoke` — all green.
- DB tier: `pytest tests/test_ownership_rollup.py -m db -k "def14a or unmatched or slice"` — 12 passed.
- `pnpm typecheck` · `test:unit` (1382) · `dark:check` — green.
- Codex ckpt-2: no findings (independently verified the non-additive invariant across all Holder constructors).

Closes #2121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
