### PR TITLE
fix(#1914 part-1): recover comparative FY history — global period_end merge

### DIFF
--- a/app/services/fundamentals/__init__.py
+++ b/app/services/fundamentals/__init__.py
@@ -995,6 +995,93 @@ def _resolve_flow_value(
     return None
 
 
+def _resolve_period_fiscal_year(
+    anchor_fy: dict[tuple[str, date], int],
+    period_type: str,
+    period_end: date,
+    stamped_fy: int,
+) -> int:
+    """Re-derive a fiscal period's fiscal_year from its own ``period_end`` (#1914).
+
+    SEC XBRL re-stamps every prior-year comparative in a 10-K with the FILING's
+    ``fy``, so the stamp is only reliable for the filing's OWN primary period.
+    ``anchor_fy`` maps ``(period_type, primary_period_end) -> fy`` for every
+    period_end that was some retained filing's primary (max) period — where the
+    stamp is authoritative.
+
+    - Exact hit: the ``period_end`` was itself a filing's primary → use that fy.
+    - Comparative-only ``period_end`` (its own filing aged out of the raw store):
+      carry the issuer's fiscal-year convention by calendar-year delta from the
+      nearest same-``period_type`` anchor. This is correct for off-December
+      (e.g. Feb) fiscal-year-enders because consecutive fiscal years' primary
+      period_ends are ~one calendar year apart.
+    - No anchor at all (degenerate — no primary of this period_type in store):
+      fall back to the SEC stamp.
+
+    Source rule: SEC companyfacts ``fy`` is the filing's context, not the fact's
+    period (#682); DocumentFiscalYearFocus for a filing's own primary period is
+    authoritative; Reg S-X 210.3-02 makes the comparatives real, consecutive
+    annual periods.
+    """
+    direct = anchor_fy.get((period_type, period_end))
+    if direct is not None:
+        return direct
+    same_type = [(pe, fy) for (pt, pe), fy in anchor_fy.items() if pt == period_type]
+    if same_type:
+        pe, fy = min(same_type, key=lambda c: (abs(c[0].year - period_end.year), c[0]))
+        return fy - (pe.year - period_end.year)
+    return stamped_fy
+
+
+def _build_period_row(
+    *,
+    period_type: str,
+    fiscal_quarter: int | None,
+    fiscal_year: int,
+    period_end: date,
+    canonical_facts: list[FactRow],
+    reported_currency: str,
+) -> PeriodRow:
+    """Build one ``PeriodRow`` from the facts at a single (period_type, period_end).
+
+    ``canonical_facts`` must be pre-sorted ``filed_date`` DESC so the tag-priority
+    "first write wins" pulls each concept's value from the latest filing that
+    reports it (#682 restatement priority). Provenance (source_ref / filed_date /
+    form_type) reflects the contributing accessions.
+    """
+    starts = [f.period_start for f in canonical_facts if f.period_start is not None]
+    period_start = min(starts) if starts else None
+    months = _months_between(period_start, period_end)
+    accession_numbers = sorted({f.accession_number for f in canonical_facts})
+    source_ref = accession_numbers[0] if len(accession_numbers) == 1 else ",".join(accession_numbers)
+    latest_filing = max(canonical_facts, key=lambda f: f.filed_date)
+    row = PeriodRow(
+        period_end_date=period_end,
+        period_type=period_type,
+        fiscal_year=fiscal_year,
+        fiscal_quarter=fiscal_quarter,
+        period_start_date=period_start,
+        months_covered=months,
+        source="sec_edgar",
+        source_ref=source_ref,
+        reported_currency=reported_currency,
+        form_type=latest_filing.form_type,
+        filed_date=latest_filing.filed_date,
+    )
+    col_priority: dict[str, int] = {}
+    for fact in canonical_facts:
+        mapping = _TAG_TO_COLUMN.get(fact.concept)
+        if mapping is None:
+            continue
+        col_name, priority = mapping
+        current_priority = col_priority.get(col_name)
+        if current_priority is not None and priority >= current_priority:
+            continue  # existing value has higher or equal priority
+        setattr(row, col_name, fact.val)
+        col_priority[col_name] = priority
+    return row
+
+
 def _derive_periods_from_facts(
     facts: Sequence[FactRow],
     reported_currency: str = "USD",
@@ -1034,121 +1121,152 @@ def _derive_periods_from_facts(
 
         grouped[(fact.fiscal_year, fp)].append(fact)
 
-    # Build period rows
+    # #1914 — primary-period fiscal_year anchor. SEC re-stamps every prior-year
+    # comparative in a 10-K with the FILING's fy, so bucketing by the stamp (above)
+    # drops the comparatives. Build a map of each period_end that was some retained
+    # filing's PRIMARY (max) period to that filing's stamp (authoritative there), so
+    # the per-period loop can re-derive fiscal_year from period_end. Built from the
+    # SAME _TAG_TO_COLUMN-mapped facts the boundary derivation uses (#558: DEI as-of
+    # contexts must not lift the anchor to the filing date).
+    _acc_fp_facts: dict[tuple[str, str], list[FactRow]] = defaultdict(list)
+    for (_stamped_fy, fp), period_facts in grouped.items():
+        for f in period_facts:
+            if f.concept in _TAG_TO_COLUMN:
+                _acc_fp_facts[(f.accession_number, fp)].append(f)
+    # When two accessions each treat the same period_end as their primary but stamp
+    # it with different ``fy`` (a fiscal-year re-label / source error), the
+    # latest-filed accession's stamp wins — deterministic + restatement-priority
+    # aligned, not DB read-order dependent (Codex ckpt-2). Track (filed_date,
+    # accession) as the tie-break key.
+    _anchor_best: dict[tuple[str, date], tuple[date, str, int]] = {}
+    for (_acc, fp), fs in _acc_fp_facts.items():
+        primary = max(fs, key=lambda f: f.period_end)
+        key = (_FP_MAP[fp][0], primary.period_end)
+        cand = (primary.filed_date, primary.accession_number, primary.fiscal_year)
+        current = _anchor_best.get(key)
+        if current is None or (cand[0], cand[1]) > (current[0], current[1]):
+            _anchor_best[key] = cand
+    anchor_fy: dict[tuple[str, date], int] = {k: v[2] for k, v in _anchor_best.items()}
+
+    # Build period rows.
+    #
+    # Quarterly periods keep the original per-(stamped_fy, fp) single-row
+    # (max period_end) behavior — the blank-prior-year bug is an FY phenomenon, and
+    # TTM (sql/220) + the Q4 = FY − ΣQ derivation depend on the quarter SET staying
+    # byte-identical. FY periods are #1914-recovered: gathered GLOBALLY by
+    # period_end (loop below) so a prior year that one filing reports only as a
+    # comparative merges — per-concept, latest-filed wins — with facts other
+    # filings carry for the same period. That cross-filing union is essential: an
+    # aged/partial primary 10-K may lack revenue that a later 10-K's comparative
+    # column carries, and vice-versa; picking a single whole row would blank one.
     periods: list[PeriodRow] = []
-    for (fy, fp), period_facts in grouped.items():
+    fy_facts_by_end: dict[date, list[FactRow]] = defaultdict(list)
+    fy_float_facts: list[FactRow] = []
+    _, _fy_fiscal_quarter = _FP_MAP["FY"]
+
+    for (stamped_fy, fp), period_facts in grouped.items():
         period_type, fiscal_quarter = _FP_MAP[fp]
 
-        # Determine period dates from financial-line-item facts only.
-        # DEI facts (e.g. dei:EntityCommonStockSharesOutstanding) carry
-        # an "as-of" context endDate equal to the filing date, ~6 weeks
-        # after the real fiscal period end. Including them in the
-        # max(period_end) lifted period_end to the filing date and
-        # produced duplicate rows in financial_periods on subsequent
-        # runs (issue #558). Restrict boundary derivation to facts
-        # whose concept maps to a canonical column — those are the
-        # fiscal-period-bearing line items.
+        # Boundary derivation uses financial-line-item facts only. DEI facts carry
+        # an "as-of" context endDate = the filing date (~6 weeks after the real
+        # fiscal period end); including them would lift max(period_end) to the
+        # filing date and duplicate rows (#558). Restrict to _TAG_TO_COLUMN facts.
         mapped_facts = [f for f in period_facts if f.concept in _TAG_TO_COLUMN]
-        if not mapped_facts:
-            # Group has only DEI / unmapped concepts. Without a mapped
-            # fact we cannot anchor a real fiscal period; skip rather
-            # than fabricate one from filing-date metadata.
-            continue
-        period_end = max(f.period_end for f in mapped_facts)
 
-        # #682: SEC re-stamps every prior-year comparative row in a
-        # 10-K/10-Q with the FILING's ``fy`` / ``fp`` context, not the
-        # comparative's own fiscal period. So a 2026-filed 10-K
-        # reporting comparatives for 2023 / 2024 / 2025 emits THREE
-        # facts under ``fy=2025, fp=FY`` for the same concept — one
-        # per ``period_end`` (2023-12-31 / 2024-12-31 / 2025-12-31).
-        # Pre-fix the iteration order picked the EARLIEST period_end's
-        # value (the comparative-year row, e.g. IEP's $6.00 from 2023)
-        # as the canonical FY 2025 value; ``_canonical_merge`` then
-        # derived Q4 as FY − YTD = $4.50, both wrong values flowed to
-        # the operator-visible dividend chart. Filter the value-bearing
-        # set to facts whose ``period_end`` matches the canonical
-        # max(period_end) for this fiscal period — only the actual
-        # fiscal-period-end row contributes values.
-        canonical_facts = [f for f in mapped_facts if f.period_end == period_end]
-        # Within the canonical-end set, prefer the most recently filed
-        # fact when the same concept appears under multiple accessions
-        # (10-K/A amendments, restatements). Sorting by filed_date DESC
-        # makes "first write wins" pull from the latest filing — same
-        # priority discriminator the issue calls out.
-        canonical_facts = sorted(
-            canonical_facts,
-            key=lambda f: (f.filed_date, f.accession_number),
-            reverse=True,
-        )
-
-        starts = [f.period_start for f in canonical_facts if f.period_start is not None]
-        period_start = min(starts) if starts else None
-        months = _months_between(period_start, period_end)
-
-        # Collect accession numbers for source_ref (only canonical
-        # facts — comparative-year accessions don't contribute values
-        # to this row, so they shouldn't appear in provenance).
-        accession_numbers = sorted({f.accession_number for f in canonical_facts})
-        source_ref = accession_numbers[0] if len(accession_numbers) == 1 else ",".join(accession_numbers)
-
-        # Find the most recent filed_date and form_type from the
-        # canonical-end set (matches the value provenance).
-        latest_filing = max(canonical_facts, key=lambda f: f.filed_date)
-
-        row = PeriodRow(
-            period_end_date=period_end,
-            period_type=period_type,
-            fiscal_year=fy,
-            fiscal_quarter=fiscal_quarter,
-            period_start_date=period_start,
-            months_covered=months,
-            source="sec_edgar",
-            source_ref=source_ref,
-            reported_currency=reported_currency,
-            form_type=latest_filing.form_type,
-            filed_date=latest_filing.filed_date,
-        )
-
-        # Apply values with tag priority. Iterating ``canonical_facts``
-        # in ``filed_date DESC`` order means "first-write-wins" pulls
-        # from the latest filing for any given (concept, period_end).
-        col_priority: dict[str, int] = {}
-        for fact in canonical_facts:
-            mapping = _TAG_TO_COLUMN.get(fact.concept)
-            if mapping is None:
-                continue
-            col_name, priority = mapping
-            current_priority = col_priority.get(col_name)
-            if current_priority is not None and priority >= current_priority:
-                continue  # existing value has higher or equal priority
-            setattr(row, col_name, fact.val)
-            col_priority[col_name] = priority
-
-        # #735 — DEI public-float overlay (FY only). EntityPublicFloat is a
-        # 10-K cover-page fact stamped (fiscal_year, 'FY') but with
-        # period_end = issuer Q2-end, so it is NOT in ``mapped_facts``
-        # (kept out of _TAG_TO_COLUMN to avoid lifting the FY anchor, #558)
-        # and would be dropped by the ``canonical_facts`` period_end filter.
-        # Pull it from the full ``period_facts`` set instead: current float =
-        # max(period_end) then latest filed_date (guards comparative
-        # re-stamps, #682). Value-only overlay — provenance columns
-        # (source_ref / filed_date / form_type) intentionally stay tied to
-        # the canonical fiscal-period facts; the float fact's accession is
-        # NOT appended to source_ref (that is the raw-upsert key). USD-only
-        # guard so a malformed/future non-USD float never lands in a USD
-        # column.
         if period_type == "FY":
-            float_facts = [
+            # Defer FY rows to the global-by-period_end merge below; also stash the
+            # cover-page float facts (kept out of _TAG_TO_COLUMN per #558/#735).
+            for f in mapped_facts:
+                fy_facts_by_end[f.period_end].append(f)
+            fy_float_facts.extend(
                 f
                 for f in period_facts
                 if f.concept == _DEI_PUBLIC_FLOAT_CONCEPT and f.unit == "USD" and f.val is not None
-            ]
-            if float_facts:
-                chosen = max(float_facts, key=lambda f: (f.period_end, f.filed_date, f.accession_number))
-                row.public_float_usd = chosen.val
+            )
+            continue
 
-        periods.append(row)
+        if not mapped_facts:
+            # Group has only DEI / unmapped concepts — no real fiscal period to
+            # anchor; skip rather than fabricate one from filing-date metadata.
+            continue
+        # #682: the filing re-stamps its comparatives with its own fp, so keep only
+        # the max period_end (the filing's own quarter); latest-filed wins per
+        # concept on restatement (10-K/A amendments).
+        period_end = max(f.period_end for f in mapped_facts)
+        canonical_facts = sorted(
+            [f for f in mapped_facts if f.period_end == period_end],
+            key=lambda f: (f.filed_date, f.accession_number),
+            reverse=True,
+        )
+        periods.append(
+            _build_period_row(
+                period_type=period_type,
+                fiscal_quarter=fiscal_quarter,
+                fiscal_year=stamped_fy,
+                period_end=period_end,
+                canonical_facts=canonical_facts,
+                reported_currency=reported_currency,
+            )
+        )
+
+    # #1914 — one FY row per distinct period_end, merged across EVERY filing that
+    # reports it (as its own primary or a later filing's comparative column), with
+    # per-concept latest-filed priority. fiscal_year is re-derived from the
+    # period_end itself (the SEC stamp is only reliable for a filing's own primary
+    # period; comparatives inherit the filing's stamp — #682).
+    for period_end, mapped_facts in fy_facts_by_end.items():
+        canonical_facts = sorted(mapped_facts, key=lambda f: (f.filed_date, f.accession_number), reverse=True)
+        fiscal_year = _resolve_period_fiscal_year(anchor_fy, "FY", period_end, canonical_facts[0].fiscal_year)
+        periods.append(
+            _build_period_row(
+                period_type="FY",
+                fiscal_quarter=_fy_fiscal_quarter,
+                fiscal_year=fiscal_year,
+                period_end=period_end,
+                canonical_facts=canonical_facts,
+                reported_currency=reported_currency,
+            )
+        )
+
+    # #735 — DEI public-float overlay. EntityPublicFloat is a 10-K cover-page fact
+    # (period_end = issuer Q2-end, kept out of _TAG_TO_COLUMN per #558). It is a
+    # current-snapshot metric with no per-historical-year meaning, so attach the
+    # current float (max period_end, latest filed) to the most recent FY row only.
+    # Value-only overlay — the float fact's accession is NOT added to source_ref;
+    # USD-only guard so a non-USD float never lands in a USD column.
+    if fy_float_facts:
+        fy_rows = [p for p in periods if p.period_type == "FY"]
+        if fy_rows:
+            latest_fy = max(fy_rows, key=lambda p: p.period_end_date)
+            chosen = max(fy_float_facts, key=lambda f: (f.period_end, f.filed_date, f.accession_number))
+            latest_fy.public_float_usd = chosen.val
+
+    # #1914 collision log — two DISTINCT period_ends re-deriving to the same
+    # (fiscal_year, fiscal_quarter, period_type) are collapsed by the SQL
+    # best-source merge (DISTINCT ON, winner = source priority → filed_date DESC →
+    # period_end DESC). These are the ~137 genuine fiscal-year-change / stub-year
+    # collisions deferred to #541 (integer fiscal_year cannot key two real periods).
+    # Surface the dropped period so nothing collapses silently; winner selection
+    # itself stays in the SQL layer, this only mirrors its order to name the loser.
+    _collision_groups: dict[tuple[int, int | None, str], list[PeriodRow]] = defaultdict(list)
+    for p in periods:
+        _collision_groups[(p.fiscal_year, p.fiscal_quarter, p.period_type)].append(p)
+    for (c_fy, _c_fq, c_type), group in _collision_groups.items():
+        ends = {p.period_end_date for p in group}
+        if len(ends) > 1:
+            winner = max(group, key=lambda p: (p.filed_date or date.min, p.period_end_date))
+            dropped = sorted(e for e in ends if e != winner.period_end_date)
+            logger.warning(
+                "financial_periods fiscal_year collision (#1914/#541): fy=%s %s maps "
+                "%d distinct period_ends %s; SQL merge keeps %s, drops %s "
+                "(distinct real periods sharing one integer fiscal_year label).",
+                c_fy,
+                c_type,
+                len(ends),
+                sorted(ends),
+                winner.period_end_date,
+                dropped,
+            )
 
     # #2036 — YTD de-cumulation fill. Interim cash-flow statements are
     # YTD-only (17 CFR 210.10-01(c)(3)); their Q2/Q3 duration facts were
@@ -1190,8 +1308,21 @@ def _derive_periods_from_facts(
                 if dep is not None:
                     row.depreciation_amort = dep + (row.intangible_amortization or Decimal(0))
 
-    # Q4 derivation: if FY exists but Q4 does not, derive Q4 = FY - Q1 - Q2 - Q3
-    fy_periods = {p.fiscal_year: p for p in periods if p.period_type == "FY"}
+    # Q4 derivation: if FY exists but Q4 does not, derive Q4 = FY - Q1 - Q2 - Q3.
+    # On a #1914/#541 fiscal_year collision (two FY period_ends → one label), pick
+    # the SAME row the SQL best-source merge will keep (filed_date DESC, then
+    # period_end DESC) so the derived Q4 is computed from the surviving FY row, not
+    # a to-be-dropped loser (Codex ckpt-2).
+    fy_periods: dict[int, PeriodRow] = {}
+    for p in periods:
+        if p.period_type != "FY":
+            continue
+        cur = fy_periods.get(p.fiscal_year)
+        if cur is None or (p.filed_date or date.min, p.period_end_date) > (
+            cur.filed_date or date.min,
+            cur.period_end_date,
+        ):
+            fy_periods[p.fiscal_year] = p
     existing_quarters: dict[int, dict[str, PeriodRow]] = defaultdict(dict)
     for p in periods:
         if p.period_type in ("Q1", "Q2", "Q3", "Q4"):

--- a/app/services/fundamentals/__init__.py
+++ b/app/services/fundamentals/__init__.py
@@ -1136,8 +1136,11 @@ def _derive_periods_from_facts(
     # When two accessions each treat the same period_end as their primary but stamp
     # it with different ``fy`` (a fiscal-year re-label / source error), the
     # latest-filed accession's stamp wins — deterministic + restatement-priority
-    # aligned, not DB read-order dependent (Codex ckpt-2). Track (filed_date,
-    # accession) as the tie-break key.
+    # aligned, not DB read-order dependent (Codex ckpt-2). Tie-break key is
+    # (filed_date, accession_number): on an identical filed_date the
+    # lexicographically-larger accession wins — the same "lex-larger accession =
+    # later in the filer-year sequence" rule the #682 canonical merge uses, so a
+    # same-day 10-K/A amendment beats the original it corrects.
     _anchor_best: dict[tuple[str, date], tuple[date, str, int]] = {}
     for (_acc, fp), fs in _acc_fp_facts.items():
         primary = max(fs, key=lambda f: f.period_end)
@@ -1243,18 +1246,28 @@ def _derive_periods_from_facts(
 
     # #1914 collision log — two DISTINCT period_ends re-deriving to the same
     # (fiscal_year, fiscal_quarter, period_type) are collapsed by the SQL
-    # best-source merge (DISTINCT ON, winner = source priority → filed_date DESC →
-    # period_end DESC). These are the ~137 genuine fiscal-year-change / stub-year
-    # collisions deferred to #541 (integer fiscal_year cannot key two real periods).
-    # Surface the dropped period so nothing collapses silently; winner selection
-    # itself stays in the SQL layer, this only mirrors its order to name the loser.
+    # best-source merge (DISTINCT ON). These are the ~137 genuine fiscal-year-change
+    # / stub-year collisions deferred to #541 (integer fiscal_year cannot key two
+    # real periods). Surface the dropped period so nothing collapses silently;
+    # winner selection itself stays in the SQL layer, this only mirrors its order
+    # to name the loser. The SQL winner order is: source priority → filed_date DESC
+    # → period_end DESC → source_ref ASC. Source priority is CONSTANT here (this
+    # derivation emits only source='sec_edgar'), so it drops out; mirror the
+    # remaining three keys exactly via negated ordinals (DESC) + source_ref (ASC).
     _collision_groups: dict[tuple[int, int | None, str], list[PeriodRow]] = defaultdict(list)
     for p in periods:
         _collision_groups[(p.fiscal_year, p.fiscal_quarter, p.period_type)].append(p)
     for (c_fy, _c_fq, c_type), group in _collision_groups.items():
         ends = {p.period_end_date for p in group}
         if len(ends) > 1:
-            winner = max(group, key=lambda p: (p.filed_date or date.min, p.period_end_date))
+            winner = min(
+                group,
+                key=lambda p: (
+                    -(p.filed_date or date.min).toordinal(),
+                    -p.period_end_date.toordinal(),
+                    p.source_ref,
+                ),
+            )
             dropped = sorted(e for e in ends if e != winner.period_end_date)
             logger.warning(
                 "financial_periods fiscal_year collision (#1914/#541): fy=%s %s maps "

--- a/docs/specs/fundamentals/2026-07-24-1914-fy-history-gapfill.md
+++ b/docs/specs/fundamentals/2026-07-24-1914-fy-history-gapfill.md
@@ -1,0 +1,126 @@
+# #1914 part-1 — FY history gap-fill (period-anchored fiscal_year)
+
+## Problem (full-population, dev DB 2026-07-04)
+`financial_periods` materialises ~1 annual row per *filing*, keyed on the filing's
+SEC-stamped `fiscal_year`, so the comparative prior-years every 10-K reports are
+discarded even though their facts sit in `financial_facts_raw` now.
+
+- AAPL FY rows: 2025 / 2024 / 2023 / **2012** — FY2013–2022 missing; the Financials
+  tab jumps 2023 → 2012.
+- Full-pop (4,700 SEC-covered): 325 instruments have exactly 1 FY row; 609 ≤2;
+  **386 have a year gap** (max−min+1 > row count). Mega-caps included.
+
+## Root cause (code)
+`_derive_periods_from_facts` (`app/services/fundamentals/__init__.py:1035`) groups
+facts by `(fact.fiscal_year, fp)` where `fact.fiscal_year` is the **filing-stamped**
+`fy`. SEC re-stamps every prior-year comparative in a 10-K with the *filing's* `fy`
+(the #682 comment documents this). The #682 fix then takes `period_end =
+max(period_end)` per bucket and keeps only that period_end's facts
+(`canonical_facts`, line 1073) — correctly fixing the *value* of the filing-year row
+but **discarding the comparative period_ends entirely** (they never become their own
+`PeriodRow`). `financial_periods` is built `DISTINCT ON (fiscal_year, fiscal_quarter,
+period_type)` from `_raw` (best-source match on `fp.fiscal_year = bs.fiscal_year`,
+line 1546), so the sparsity propagates to the canonical table.
+
+## Source rule
+- **SEC XBRL companyfacts `fy`/`fp`** are the *filing's* fiscal context, NOT the
+  fact's own period — a comparative annual duration ending 2021-09-25 emitted inside
+  a FY2023 10-K is stamped `fy=2023`. The fact's authoritative fiscal-period identity
+  is its **`period_end`** (+ `period_start`), not the stamp. (Documented in #682.)
+- **Reg S-X 17 CFR 210.3-02** governs the *duration* statements (income,
+  comprehensive income, cash flows): a 10-K presents the **three most recent,
+  consecutive** fiscal years — so those comparatives are real, consecutive annual
+  periods, recoverable and continuous by construction.
+- **Reg S-X 17 CFR 210.3-01** governs the balance-sheet *instant* columns: **two**
+  most recent fiscal year-ends. So gap-filled balance-sheet history may be **one year
+  shorter** than income/cashflow history — expected, not a defect. Both are recovered
+  by the same `period_end` regroup (instants also carry `period_end`).
+- **`DocumentFiscalYearFocus`** for a filing's *own* primary period IS reliable; only
+  the comparative re-stamps drift. So the fiscal_year of a `period_end` = the `fy`
+  stamped when that `period_end` was the **primary (max) period** of some filing.
+
+## Full-population verification (already run, per the #1914 root-cause comment)
+Candidate fiscal_year mechanisms, distinct-period_end→one-fiscal_year collisions:
+
+| mechanism | collisions | note |
+|---|---|---|
+| offset from SEC `fy` (originally greenlit) | 352 (7.6%) | inherits `fy`-stamp drift |
+| naive `period_end.year` | 157 groups | + 2.6% mislabelled ±1 vs issuer (Feb-enders) |
+| **primary-period-anchored (this spec)** | **137 (~1.5%)** | fewest; matches issuer labels |
+
+The residual ~137 are *genuine* (fiscal-year-end changes / stub years / source
+errors) where two real annual periods fall near one integer label. No integer-
+`fiscal_year` key can represent them without dropping a real period — the bijective
+identity is `period_end`. That is the #541 model fix, out of part-1 scope.
+
+## Mechanism (part-1)
+Re-derive the annual `fiscal_year` from the period's own identity, anchored on the
+primary filing:
+
+1. **Primary-anchor map** (pass 1): built from the SAME #558/#1835-admitted facts —
+   only `_TAG_TO_COLUMN`-mapped facts that pass the duration guard (NOT raw filing
+   facts; DEI/unmapped "as-of" contexts would lift the anchor to the filing date, per
+   #558). For each `fp` and each accession, the *primary* period_end is
+   `max(period_end)` over that accession's admitted `fp` facts; map that
+   `period_end → fy` from the accession's stamp. (A period_end that is the max of any
+   retained filing is "seen as primary".)
+2. **Group by the period, not the stamp** (pass 2): group facts by `(fp,
+   period_end)` instead of `(fact.fiscal_year, fp)`. Each distinct `(fp, period_end)`
+   becomes a `PeriodRow` — the comparative years now survive.
+3. **fiscal_year per row**:
+   - if `period_end` is in the primary-anchor map → use that `fy`;
+   - else (comparative-only, e.g. an aged-out 10-K's year) → **year-delta from the
+     nearest anchor**: `fy = anchor_fy − (anchor_period_end.year − period_end.year)`.
+     This carries the issuer's fiscal-year convention (Feb-enders included).
+4. **Value assignment** unchanged in spirit: within a `(fp, period_end)` group, take
+   the latest-filed fact per concept (restatement priority — same `filed_date DESC,
+   accession DESC` order the #682 fix uses). This is *simpler and stricter* than the
+   old max-and-discard: each period_end takes its own value, so a comparative can
+   never overwrite a primary.
+5. **Collision tail (~137)**: when two distinct `period_end`s re-derive to the same
+   `(fiscal_year, fiscal_quarter, period_type)`, the collapse is done by the
+   **existing** SQL best-source merge `DISTINCT ON (fiscal_year, fiscal_quarter,
+   period_type)` in `_canonical_merge_instrument` (`__init__.py:~1588`), whose winner
+   order — source priority → `filed_date DESC` → `period_end_date DESC` → `source_ref
+   ASC` — is authoritative and unchanged. **Detection + logging lives in
+   `_derive_periods_from_facts`** (Python), which alone sees every `(fp, period_end)
+   → fiscal_year` mapping for the instrument before the SQL collapse: group the
+   emitted rows by `(fiscal_year, fiscal_quarter, period_type)`, and for any group of
+   ≥2, `logger.warning` the `period_end`(s) that the SQL order will drop (computed
+   with the same winner order) — so nothing collapses silently. Winner selection
+   itself stays in one layer (SQL); Python only mirrors its order to name the loser.
+   The #541 `period_end`-key migration removes the collapse entirely.
+
+Preserve the existing guards: #558 (DEI-context period_end exclusion — boundary
+derivation stays on `_TAG_TO_COLUMN` facts), #1835 FY duration guard
+(`_FLOW_DURATION_DAYS`, and the `months_covered < 11` FY delete), #682 restatement
+priority.
+
+## Scope (DECIDED — part-1)
+Ship the clean gap-fills now on the existing integer `fiscal_year` key; defer the
+~137 genuine collisions to #541 (logged). Delivers continuous mega-cap FY history
+(AAPL FY2013–2025) immediately.
+
+## Implementation loci
+- `_derive_periods_from_facts` (`fundamentals/__init__.py:~1010–1145`): the regroup +
+  primary-anchor map + year-delta fallback + collision log. Core change.
+- Verify the periods_raw → `financial_periods` best-source materialisation
+  (`__init__.py:~1500–1550`, match on `fiscal_year`) now sees distinct fiscal_years
+  and no longer collapses comparatives.
+- No schema migration (columns exist). No FE change (the read at
+  `instruments.py:818` already orders by `period_end DESC` and renders whatever rows
+  exist).
+
+## Tests
+- Pure test of `_derive_periods_from_facts` with a synthetic AAPL-shaped fact set:
+  a FY2023 10-K carrying FY2021/2022/2023 comparatives → 3 distinct PeriodRows with
+  fiscal_year 2021/2022/2023 (not all 2023). Feb-ender case (period_end 2025-02-01 →
+  fiscal_year 2024 via anchor). Collision case → one row + a logged drop.
+
+## Backfill + verification (ETL clauses 8–12)
+1. `POST /jobs/sec_rebuild/run` `{"source": "sec_edgar"}` (or per-instrument for the
+   panel first) on dev DB — re-derives `financial_periods` from raw.
+2. Panel smoke AAPL/GME/MSFT/JPM/HD: `/instruments/{sym}/financials?period=annual`
+   shows continuous prior years.
+3. Cross-source: AAPL FY2021 revenue = **$365.817B** (10-K) vs rendered.
+4. Record job invocation + figures + commit SHA in the PR.

--- a/tests/test_financial_normalization.py
+++ b/tests/test_financial_normalization.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from app.services.fundamentals import (
     FactRow,
     _derive_periods_from_facts,
+    _resolve_period_fiscal_year,
 )
 
 
@@ -663,22 +664,33 @@ class TestPriorYearComparativeMisattribution:
         ]
 
     def test_canonical_fy_value_comes_from_max_period_end(self) -> None:
-        """Acceptance criterion from issue #682: only the
-        ``period_end=2025-12-31`` row drives the canonical FY 2025 row.
+        """#682 invariant: the FY2025 row's value comes ONLY from its own
+        ``period_end=2025-12-31`` ($2.00), never the earliest comparative.
+
+        #1914: the comparative FY2023/FY2024 rows are now ALSO recovered as
+        their own rows (their own period_end + own value), instead of being
+        discarded — so multi-year views no longer show blank prior years.
         """
         periods = _derive_periods_from_facts(
             self._ten_k_with_three_comparative_years(),
             reported_currency="USD",
         )
 
-        fy_rows = [p for p in periods if p.period_type == "FY"]
-        assert len(fy_rows) == 1
-        fy = fy_rows[0]
-        assert fy.fiscal_year == 2025
-        assert fy.period_end_date == date(2025, 12, 31)
-        assert fy.period_start_date == date(2025, 1, 1)
-        assert fy.dps_declared == Decimal("2.00")
-        assert fy.months_covered == 12
+        fy_rows = {p.fiscal_year: p for p in periods if p.period_type == "FY"}
+        # #1914 — all three comparative years recovered from the one 10-K.
+        assert set(fy_rows) == {2023, 2024, 2025}
+        # #682 — the primary FY2025 row keeps its OWN value, not the earliest
+        # comparative ($6.00 from 2023).
+        fy25 = fy_rows[2025]
+        assert fy25.period_end_date == date(2025, 12, 31)
+        assert fy25.period_start_date == date(2025, 1, 1)
+        assert fy25.dps_declared == Decimal("2.00")
+        assert fy25.months_covered == 12
+        # #1914 — each comparative carries its own year's value + period_end.
+        assert fy_rows[2024].period_end_date == date(2024, 12, 31)
+        assert fy_rows[2024].dps_declared == Decimal("3.50")
+        assert fy_rows[2023].period_end_date == date(2023, 12, 31)
+        assert fy_rows[2023].dps_declared == Decimal("6.00")
 
     def test_comparative_year_facts_do_not_pollute_source_ref(self) -> None:
         """Provenance for the FY row comes only from the accession that
@@ -707,7 +719,11 @@ class TestPriorYearComparativeMisattribution:
         )
 
         periods = _derive_periods_from_facts(facts, reported_currency="USD")
-        fy = next(p for p in periods if p.period_type == "FY")
+        # The PRIMARY FY row (period_end 2025-12-31) draws provenance only from the
+        # accession that contributed its value — the comparative's accession never
+        # leaks in. (#1914: the comparative is now its own row, so target the
+        # primary end explicitly.)
+        fy = next(p for p in periods if p.period_type == "FY" and p.period_end_date == date(2025, 12, 31))
         assert "prior-10k-accn" not in fy.source_ref
         assert fy.source_ref == "0001104659-26-019821"
 
@@ -802,10 +818,14 @@ class TestPriorYearComparativeWithFrame:
         ]
 
         periods = _derive_periods_from_facts(facts, reported_currency="USD")
-        fy = next(p for p in periods if p.period_type == "FY")
-        assert fy.fiscal_year == 2025
-        assert fy.period_end_date == date(2025, 12, 31)
-        assert fy.revenue == Decimal("3000")  # NOT 1000 (would be the bug)
+        fy_rows = {p.fiscal_year: p for p in periods if p.period_type == "FY"}
+        # #682 — the primary FY2025 row takes its OWN period_end's value (3000),
+        # never the earliest framed comparative (1000).
+        assert fy_rows[2025].period_end_date == date(2025, 12, 31)
+        assert fy_rows[2025].revenue == Decimal("3000")  # NOT 1000 (would be the bug)
+        # #1914 — the framed comparatives are recovered as their own FY rows.
+        assert fy_rows[2024].revenue == Decimal("2000")
+        assert fy_rows[2023].revenue == Decimal("1000")
 
 
 class TestRestatementSameFiledDateTieBreaker:
@@ -1956,3 +1976,117 @@ class TestDaComponentSum2036:
         assert "Depreciation" in RAW_ONLY_CONCEPTS
         assert "Depreciation" in _ALL_TRACKED_TAGS
         assert "Depreciation" not in _TAG_TO_COLUMN
+
+
+class TestFiscalYearGapFill1914:
+    """#1914 — comparative prior-year annual periods are recovered as their own
+    rows, with fiscal_year re-derived from each period's own primary filing."""
+
+    def test_resolve_exact_anchor(self) -> None:
+        anchor = {("FY", date(2023, 9, 30)): 2023, ("FY", date(2024, 9, 28)): 2024}
+        assert _resolve_period_fiscal_year(anchor, "FY", date(2023, 9, 30), 9999) == 2023
+
+    def test_resolve_year_delta_fallback_sept_ender(self) -> None:
+        # 2021-09-25 is a comparative-only end (no anchor); nearest anchor is
+        # 2023-09-30 (fy 2023) → 2023 - (2023 - 2021) = 2021.
+        anchor = {("FY", date(2023, 9, 30)): 2023}
+        assert _resolve_period_fiscal_year(anchor, "FY", date(2021, 9, 25), 2023) == 2021
+
+    def test_resolve_year_delta_fallback_feb_ender(self) -> None:
+        # Off-December fiscal-year-end: anchor 2025-02-01 → fy 2024.
+        anchor = {("FY", date(2025, 2, 1)): 2024}
+        assert _resolve_period_fiscal_year(anchor, "FY", date(2024, 2, 3), 2025) == 2023
+        assert _resolve_period_fiscal_year(anchor, "FY", date(2023, 1, 28), 2025) == 2022
+
+    def test_resolve_no_anchor_falls_back_to_stamp(self) -> None:
+        assert _resolve_period_fiscal_year({}, "FY", date(2024, 12, 31), 2024) == 2024
+
+    def _fy_fact(self, *, val: str, end: str, start: str, fy: int, acc: str, filed: str) -> FactRow:
+        return _fact(
+            concept="Revenues",
+            val=Decimal(val),
+            period_end=end,
+            period_start=start,
+            frame=f"CY{end[:4]}",
+            fiscal_year=fy,
+            fiscal_period="FY",
+            form_type="10-K",
+            accession_number=acc,
+            filed_date=filed,
+        )
+
+    def test_comparatives_recovered_across_two_filings(self) -> None:
+        """Two 10-Ks (FY2024 + FY2025), each carrying two comparatives. The
+        FY2023 end is a comparative in BOTH filings (its own 10-K aged out), so it
+        is recovered; FY2024 is a primary of its own filing, not duplicated."""
+        facts = [
+            # FY2025 10-K: comparatives 2023, 2024 + primary 2025.
+            self._fy_fact(val="300", end="2023-09-30", start="2022-10-01", fy=2025, acc="A", filed="2025-11-01"),
+            self._fy_fact(val="391", end="2024-09-28", start="2023-10-01", fy=2025, acc="A", filed="2025-11-01"),
+            self._fy_fact(val="416", end="2025-09-27", start="2024-09-29", fy=2025, acc="A", filed="2025-11-01"),
+            # FY2024 10-K: comparatives 2022, 2023 + primary 2024.
+            self._fy_fact(val="274", end="2022-09-24", start="2021-09-26", fy=2024, acc="B", filed="2024-11-01"),
+            self._fy_fact(val="300", end="2023-09-30", start="2022-10-01", fy=2024, acc="B", filed="2024-11-01"),
+            self._fy_fact(val="391", end="2024-09-28", start="2023-10-01", fy=2024, acc="B", filed="2024-11-01"),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        # Every distinct FY end is emitted (from each filing carrying it); the SQL
+        # best-source merge keeps the latest-filed row per fiscal_year. Replicate
+        # that winner order (filed_date DESC, period_end DESC) to check the
+        # canonical outcome.
+        canon: dict[int, object] = {}
+        for p in periods:
+            if p.period_type != "FY":
+                continue
+            key = (p.filed_date, p.period_end_date)
+            if p.fiscal_year not in canon or key > canon[p.fiscal_year][0]:  # type: ignore[index]
+                canon[p.fiscal_year] = (key, p)
+        fy_rows = {y: v[1] for y, v in canon.items()}  # type: ignore[index]
+        # Continuous FY2022–FY2025 recovered from two filings.
+        assert set(fy_rows) == {2022, 2023, 2024, 2025}
+        assert fy_rows[2022].revenue == Decimal("274")
+        assert fy_rows[2023].revenue == Decimal("300")
+        assert fy_rows[2024].revenue == Decimal("391")
+        assert fy_rows[2025].revenue == Decimal("416")
+        # FY2024 (2024-09-28) is reported by BOTH filings (primary in B, comparative
+        # in A) — the row merges them, with A's later filing driving provenance
+        # (#682 restatement priority) and both accessions cited.
+        assert fy_rows[2024].period_end_date == date(2024, 9, 28)
+        assert fy_rows[2024].filed_date == date(2025, 11, 1)
+        assert "A" in fy_rows[2024].source_ref and "B" in fy_rows[2024].source_ref
+
+    def test_anchor_conflict_resolves_to_latest_filed(self) -> None:
+        """When two filings each treat the same period_end as their primary but
+        stamp it with different fy (a re-label / source error), the latest-filed
+        accession's stamp wins — deterministic, not DB read-order dependent."""
+        facts = [
+            # Original stamps 2024-06-30 as fy=2024.
+            self._fy_fact(val="100", end="2024-06-30", start="2023-07-01", fy=2024, acc="OLD", filed="2024-08-01"),
+            # Later re-label stamps the SAME period_end as fy=2025.
+            self._fy_fact(val="105", end="2024-06-30", start="2023-07-01", fy=2025, acc="NEW", filed="2025-08-01"),
+        ]
+        periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        fy_rows = [p for p in periods if p.period_type == "FY"]
+        # One merged FY row for the shared period_end, labelled by the latest filing.
+        assert len(fy_rows) == 1
+        assert fy_rows[0].fiscal_year == 2025
+        assert fy_rows[0].period_end_date == date(2024, 6, 30)
+
+    def test_collision_is_logged_not_silent(self, caplog) -> None:
+        """A fiscal-year-end change makes two distinct annual ends both anchor to
+        fy=2024 (both are their own filing's primary). Part-1 keeps one via the SQL
+        merge; the drop must be logged (#1914/#541), never silent."""
+        import logging
+
+        facts = [
+            # Old June fiscal-year-end 10-K stamped fy=2024 (full year).
+            self._fy_fact(val="100", end="2024-06-30", start="2023-07-01", fy=2024, acc="OLD", filed="2024-08-01"),
+            # New Dec fiscal-year-end 10-K also stamped fy=2024 (full year) — a
+            # genuine collision: two full annual periods on one integer fy label.
+            self._fy_fact(val="120", end="2024-12-31", start="2024-01-01", fy=2024, acc="NEW", filed="2025-02-01"),
+        ]
+        with caplog.at_level(logging.WARNING, logger="app.services.fundamentals"):
+            periods = _derive_periods_from_facts(facts, reported_currency="USD")
+        collided = [p for p in periods if p.period_type == "FY" and p.fiscal_year == 2024]
+        assert {p.period_end_date for p in collided} == {date(2024, 6, 30), date(2024, 12, 31)}
+        assert any("fiscal_year collision" in r.message for r in caplog.records)


### PR DESCRIPTION
## What

#1914 part-1 — recover the comparative prior-year **FY** rows that multi-year fundamentals views were rendering blank. Spec: `docs/specs/fundamentals/2026-07-24-1914-fy-history-gapfill.md` (Codex ckpt-1 reviewed).

## Root cause

`_derive_periods_from_facts` grouped XBRL facts by the SEC filing-stamped `fiscal_year` and kept only `max(period_end)` per bucket (the #682 canonical-value fix). SEC re-stamps every prior-year comparative in a 10-K with the *filing's* `fy`, so a FY2023 10-K's FY2021/FY2022 comparatives all land in the `fy=2023` bucket and were **discarded**. `financial_periods` ended up with ~1 FY row per filing → AAPL showed FY2025/2024/2023 then jumped to 2012.

## Fix

- **FY periods are gathered globally by `period_end`** (across all filings) and merged with per-concept latest-filed priority (`_build_period_row`). This is the key correctness point: an aged/partial primary 10-K may lack a value (e.g. revenue) that a later 10-K's comparative column carries, and vice-versa — a whole-row pick would blank one; the per-concept union recovers both.
- **`fiscal_year` is re-derived from the `period_end`** (`_resolve_period_fiscal_year`): exact match to the filing where that end was the *primary* (max) period (its stamp is authoritative), else calendar-year-delta from the nearest same-type anchor (carries off-December fiscal-year-enders — GME/HD Feb).
- **Quarters are unchanged** — same per-`(stamped_fy, fp)` max-end single-row behavior, so TTM (sql/220) and the Q4 = FY − ΣQ derivation stay byte-identical. The multi-year gap is an FY phenomenon; recovering comparative quarters only adds collision noise from re-stamped/short quarter facts.
- **Collision tail (~137, deferred to #541)**: two distinct annual `period_end`s that re-derive to one integer `fiscal_year` (fiscal-year-end changes / stub years / source errors) are collapsed by the existing SQL `DISTINCT ON (fiscal_year, fiscal_quarter, period_type)` best-source merge (winner = source priority → filed_date DESC → period_end DESC). `_derive_periods_from_facts` now `logger.warning`s the dropped period so nothing collapses silently.
- **`public_float_usd`** (DEI cover-page, #735) now attaches to the latest FY row only — it is a current-snapshot metric (no per-historical-year meaning) and has no read consumer (grep-verified: written to `financial_periods`, never selected by any endpoint/scoring).

## Source rule

- SEC companyfacts `fy`/`fp` are the *filing's* context, not the fact's period (#682); DocumentFiscalYearFocus for a filing's own primary period is authoritative.
- Reg S-X **210.3-02** (income/comprehensive-income/cash-flow: 3 most recent fiscal years) makes the duration comparatives real, consecutive annual periods. Reg S-X **210.3-01** (balance sheet: 2 most recent year-ends) — so the *oldest* recovered comparative may carry balance-sheet instants but no income (its income year aged out of the retained filings); expected, not a defect.

## Full-population verification (dev DB, real facts, in-memory — no mutation)

Ran the new derivation over each panel instrument's real `financial_facts_raw`, applied the SQL winner order, checked canonical FY rows:

| symbol | canonical FY years | income-populated | note |
|---|---|---|---|
| AAPL | 2009–2012, 2020–2025 | 8/10 | **FY2021 rev = $365.8B** (10-K: $365.817B ✓), FY2022 $394.3B; was 2025/2024/2023/2012 |
| GME | 2021–2025 (no gap) | 4/5 | FY2022 rev = $5.9B recovered |
| MSFT | 2010–2013, 2020–2025 | 8/10 | |
| JPM | 2007–2010, 2020–2025 | 8/10 | |
| HD | 2020–2025 (no gap) | 5/6 | |

Cross-source: AAPL FY2021 revenue **$365.817B** matches the FY2021 10-K. Mid-history gaps (AAPL 2013–2019) are retention-swept raw (`financial_facts_retention.py` keeps the latest few 10-Ks) — recoverable only if their facts return to raw; the derivation recovers everything present.

## Tests / gates

- `tests/test_financial_normalization.py::TestFiscalYearGapFill1914` (new, fast tier): `_resolve_period_fiscal_year` (exact / year-delta Sept + Feb enders / no-anchor); cross-filing FY merge recovers continuous years with correct per-year values + latest-filed provenance; collision is logged.
- Updated the two #682 comparative tests to assert the preserved invariant (primary row keeps its own value) **plus** the new recovery (comparatives now their own rows).
- `ruff` · `ruff format --check` · `pyright` · `pytest -m "not db"` (5387) · `pytest tests/smoke` — green.
- DB tier: `test_api_instrument_financials` (8), `test_fundamentals_snapshot_writethrough` + `test_fundamentals_upsert_integration` (9), `test_canonical_merge_*` + `test_financial_facts_service` + valuation (22) — pass.
- Codex ckpt-2 (fresh-agent, financial-plumbing/data-engineer/data-scientist lenses): core design confirmed (no double-counting, quarters byte-identical, #558/#682/#735/#1835 preserved). Two Medium determinism findings **fixed + tested**: (a) Q4-derivation on a fiscal_year collision now selects the same FY row the SQL merge keeps (filed_date DESC, period_end DESC); (b) primary-anchor conflicts (same period_end stamped with different fy by two filings) now resolve to the latest-filed accession, not DB read-order.

## Operator follow-up (ETL clause 10/11 — backfill)

The derivation change requires re-materialising `financial_periods` from raw:
1. **Restart the VS Code `stack:jobs` task** (the jobs daemon serves `~/Dev/eBull`; this is a parser change, so the running daemon must pick it up).
2. `POST /jobs/sec_rebuild/run` `{"source": "sec_edgar"}` (dev DB) — re-derives `financial_periods` full-population; monitor drain.
3. Smoke `/instruments/{AAPL,GME,MSFT,JPM,HD}/financials?period=annual` — confirm continuous prior years render.

Verified pre-merge via in-memory derivation on real dev facts (above); the live backfill + endpoint render is the post-merge operator step.

Closes #1914 (part-1). Residual ~137 fiscal-year collisions + deep-history (pre-retention) gaps tracked for #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
