### PR TITLE
docs(#1917,#1908): UI design-first proposals (Research hub + Visual v2) for sign-off

### DIFF
--- a/docs/proposals/ui/2026-07-24-1908-visual-v2.md
+++ b/docs/proposals/ui/2026-07-24-1908-visual-v2.md
@@ -1,0 +1,48 @@
+# Proposal: Visual system v2 (#1908, folds #559)
+
+Status: **DRAFT — PR-1 is operator-taste-gated; needs sign-off before execution.**
+
+## The "settled reversal" framing — corrected
+
+The ticket reads as if re-introducing cards reverses a settled decision. **It does not.** There is no card/surface decision in `docs/settled-decisions.md`. The relevant history is **operator taste in #691**, which killed *shadowed, elevated "Trello card"* surfaces — it did **not** ban flat surfaces. So v2 is not a reversal; it is completing #691's surface system.
+
+## Recommendation: HYBRID surface model
+
+Keep the current **flat-hairline base** for list/narrative sections (unchanged). Add **exactly one** new **flat card variant** for **stat/chart tiles only**:
+
+- fill `slate-900/40` (dark) / subtle light equivalent, `1px` border, **no shadow, no elevation**.
+- Fixes the current "stats float in empty space" problem without re-introducing the #691 Trello look.
+
+This is the one operator-taste call in the whole ticket → **surface the hybrid rec first, get sign-off, then build PR-1.**
+
+## Sub-PR breakdown (small, independently shippable)
+
+| PR | scope | gate |
+|---|---|---|
+| **PR-1** | `tailwind.config` design tokens + type scale + the **one** flat card-variant | ⚠ **operator-taste-gated** — sign off the hybrid card first |
+| **PR-2** | **Badge** component — consolidate ~21 inline pills + 6 existing into one; color **+ text** (never color-alone, a11y) | engineering |
+| **PR-3** | `chartTheme` — unify chart colors/axes/tooltips on tokens | engineering |
+| **PR-4** | verdict-humanize — `VerdictTab.tsx:201-203` raw enum → human copy | engineering |
+| **PR-5** | density pass — spacing/line-height tightening on the grid surfaces | engineering |
+
+Only **PR-1** needs the taste sign-off. PR-2..PR-5 are mechanical consolidations (derivable), shippable after PR-1's tokens land.
+
+## Fold #559
+
+`#559` (badge/pill consolidation) is a strict subset of **PR-2**. Fold it in and close #559 on PR-2 merge.
+
+## Guardrails (carry from existing skills)
+
+- **Dark mode**: every new class pair honors the `dark:check` gate (`frontend/scripts/check-dark-classes.mjs`) — 2 themes, no bare surfaces.
+- **Color + text, never color-alone** (Badge): the pill's meaning is in its text; color is decorative (a11y + the operator-ui convention).
+- **No shadow / no elevation** on the card variant — that is the #691 line; hold it.
+
+## Open questions for the operator (sign-off gate)
+
+1. **Hybrid card** — approve one flat card variant (fill + 1px border, no shadow) for stat/chart tiles only? (Recommended.) Or stay fully flat-hairline everywhere?
+2. **Ordering** — PR-1 (tokens+card) first, then PR-2..PR-5 in the order above? (Recommended.)
+3. Anything in the type scale / density you want to steer before PR-1?
+
+## Non-goals
+
+- No layout/IA change (that is #1917). No new pages. No color palette overhaul beyond token extraction — v2 is consolidation + one surface variant, not a redesign.

--- a/docs/proposals/ui/2026-07-24-1917-research-hub.md
+++ b/docs/proposals/ui/2026-07-24-1917-research-hub.md
@@ -1,0 +1,58 @@
+# Proposal: Research hub — merge 4 pages into one instrument surface (#1917)
+
+Status: **DRAFT — needs operator sign-off before execution.** Design-first per the roadmap.
+
+## Problem
+
+Four top-level sidebar pages are four views of the *same instrument universe*, differing only in which column set + filter the operator wants:
+
+| page | route | today shows | backing endpoint |
+|---|---|---|---|
+| Instruments | `/instruments` | the whole tradable universe | `/instruments` list |
+| Rankings | `/rankings` | universe ranked by score | `/rankings` |
+| Theses | `/theses` | instruments with a generated thesis | `/theses` |
+| Recommendations | `/recommendations` | portfolio-manager actions | `/recommendations` |
+
+Nav is 4 items (`Sidebar.tsx:7-10`) for what is one mental object ("the research surface"). The operator context-switches pages to change lens; each is a separate route + page shell + table.
+
+## Recommendation
+
+One **`/research`** hub with **view presets** as a **segmented control** (tabs), not chips. Rationale: a preset swaps the *endpoint + column set + default sort* — it is a mode, not an additive filter. Segmented tabs read as "pick one lens"; chips read as "toggle several", which mismodels it. (Grounding: Finviz screener tabs, TradingView screener presets, Investing.com — all use mode tabs for this exact "same universe, different lens" pattern.)
+
+Presets:
+
+| tab | lens | endpoint | landing |
+|---|---|---|---|
+| **Ranked** | universe by score | `/rankings` | ← **default landing** |
+| **Universe** | all tradable | `/instruments` | |
+| **Theses** | thesis generation queue + status | `/theses` | ⚠ NOT a 2nd score table |
+| **Actioned** | portfolio-manager recommendations | `/recommendations` | |
+
+⚠ **Theses tab is a generation queue, not a second ranking table.** Its value is "what has/needs a thesis + staleness", not re-ranking. Keep its distinct columns (verdict, staleness, generated-at) — do not collapse it into the Ranked grid.
+
+### Routing + migration
+
+- Route `/research?view=ranked|universe|theses|actioned` (query param drives the preset; deep-linkable, back-button-friendly).
+- **Redirect shims** for the 4 old routes → reuse the existing `InstrumentDetailRedirect` pattern (`App.tsx:81,87`). Each shim forwards to `/research?view=…` **and preserves query strings** (e.g. Theses `?held&stale` → `/research?view=theses&held&stale`) so existing deep links + bookmarks survive.
+- **Sidebar 4 → 1**: `Sidebar.tsx:7-10` collapses to a single "Research" item.
+- **Repoint 4 in-app links** currently pointing at the old routes: `PositionsTable.tsx:40` (→ rankings), `AlertsStrip.tsx:387,743`, `PortfolioPage.tsx:285` (→ rankings). Point them at the appropriate `/research?view=…`.
+
+### Decouple #1912 (heat-map) — do NOT block on it
+
+#1912 (ownership/universe heat-map) is **blocked on #1939** (its endpoint is unmerged). Do not let it gate the hub. Land the hub with a **Table | Map render-mode toggle** where **Map is present but disabled/"coming soon"** — ship **table-only** now; the map drops in when #1939/#1912 land, no re-architecture.
+
+## Shared primitives (depends on #1901)
+
+The hub composes the same table primitives #1901 factored out (`portfolioRows`, `avatar`, cell renderers). #1917 should land **after** #1901 so it reuses them rather than re-implementing. (#1901 PR-1 + PR-2 merged this session.)
+
+## Open questions for the operator (sign-off gate)
+
+1. **Preset set + names** — Ranked / Universe / Theses / Actioned as above? Different labels?
+2. **Default landing** — Ranked (recommended) vs Universe?
+3. **Scope of PR-1** — hub shell + presets + redirects + sidebar collapse, table-only, map-toggle-disabled? (Recommended: yes, one PR; map is a later PR.)
+4. **Theses tab** — confirm it stays a generation-queue view (verdict/staleness), not folded into Ranked.
+
+## Non-goals (this ticket)
+
+- No new columns/metrics. No scoring change. No map (deferred to #1912/#1939).
+- Behavior-preserving per lens: each preset renders what its page renders today.


### PR DESCRIPTION
Two design-first UI proposals under `docs/proposals/ui/` for operator sign-off before any execution. **No code changes.**

## #1917 — Research hub
Merge Instruments / Rankings / Theses / Recommendations (`Sidebar.tsx:7-10`) into one `/research` hub with **view presets as segmented tabs** (a preset swaps endpoint + columns = a mode, not an additive filter). Land on **Ranked**. Route `/research?view=…`; redirect shims (reuse `InstrumentDetailRedirect`) preserve query strings; Sidebar 4→1; repoint 4 in-app links (`PositionsTable:40`, `AlertsStrip:387/743`, `PortfolioPage:285`). **Decouple #1912 heat-map** (blocked on #1939) → Table|Map toggle, ship table-only. ⚠ Theses tab = generation queue, not a 2nd score table. Reuses the #1901 shared table primitives (merged this session).

## #1908 — Visual v2
The "settled reversal" framing is **corrected**: no card decision exists in `settled-decisions.md`; #691 killed shadowed Trello cards, not flat surfaces. **HYBRID rec**: keep the flat-hairline base, add **one** flat card variant (fill + 1px border, **no shadow**) for stat/chart tiles only — framed as completing #691. Sub-PRs: **PR-1** tokens + card (⚠ taste-gated) → **PR-2** Badge (folds & closes #559) → **PR-3** chartTheme → **PR-4** verdict-humanize (`VerdictTab:201-203`) → **PR-5** density.

Each doc ends with the specific **sign-off decisions** needed. Execution waits on those answers.

Refs #1917. Refs #1908. Refs #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
