### PR TITLE
feat(#1917): Research hub — merge 4 instrument pages into /research view presets

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -295,6 +295,8 @@ Read and apply these before pushing:
 - `.claude/skills/frontend/safety-state-ui.md`
 - `.claude/skills/frontend/api-shape-and-types.md`
 - `.claude/skills/frontend/operator-ui-conventions.md`
+- `.claude/skills/frontend/design-system.md` — standing surface/card/badge/chart/density decisions (visual v2). Assembling the system is engineering, NOT a taste-gate.
+- `.claude/skills/frontend/information-architecture.md` — standing nav/page-consolidation decisions (lens hub + view presets). Consolidating existing pages is engineering, NOT a taste-gate.
 
 ### Data foundation skills (read before SEC ingest / schema / parser / metric work)
 

--- a/.claude/skills/frontend/design-system.md
+++ b/.claude/skills/frontend/design-system.md
@@ -1,0 +1,40 @@
+# frontend/design-system
+
+## When to use
+
+Read before any change to eBull's visual system — surfaces/cards, badges/pills, chart theming, spacing/density, typography, or Tailwind tokens. These are **standing operator decisions**, not per-ticket taste calls. Assembling the system below is **engineering, not a taste-gate** — decide and build; do NOT open a "which look do you prefer?" loop. Only a genuinely NEW visual identity (new brand palette, a new elevated-surface language) escalates to the operator.
+
+> Companion: `operator-ui-conventions.md` owns *presentation* (formatters, color semantics, copy). This file owns the *surface + component system*. Don't duplicate.
+
+## Surface model (the #691 line) — SETTLED
+
+There is **no card/surface decision in `docs/settled-decisions.md`**. The governing history is operator taste in **#691**, which killed *shadowed, elevated "Trello card"* surfaces — it did **not** ban flat surfaces. So the standing surface system is a **hybrid**:
+
+- **Flat-hairline base** — lists, tables, narrative sections. Border/hairline separators, no fill, no elevation. This is the default; most surfaces are this.
+- **One flat card variant** — for **stat tiles and chart tiles only** (the things that otherwise "float in empty space"). Spec: subtle fill (`bg-slate-900/40` dark / `bg-slate-50` light equivalent), `1px` border, `rounded`, **NO shadow, NO elevation**. That last clause IS the #691 line — hold it. Never add `shadow-*` or a raised/Trello look to a card.
+
+Decision rule: **narrative/list → flat-hairline; stat/chart tile → the flat card variant.** Nothing else gets a third surface. (Frame any v2 work as "completing #691's surface system," not "reversing a decision.")
+
+## Badge / pill — ONE component
+
+One `Badge` component; never hand-roll an inline pill. Meaning is carried by **text, never color alone** (a11y + operator-ui color semantics). Color is the decorative reinforcement of the text, drawn from the `operator-ui-conventions.md` color table (red=risk, amber=warn, emerald=ok, blue=neutral). Consolidate any inline `rounded bg-… px-… text-…` pill into `Badge`. New status chips go through `Badge`, full stop.
+
+## Chart theming — ONE source
+
+Charts read colors, axes, gridlines, and tooltip styling from a single `chartTheme` module (tokens), not per-chart literals. A new chart imports the theme; it does not re-pick colors. Keep chart series colors on the same restrained palette as the rest of the UI (color = signal, not decoration).
+
+## Density
+
+eBull is an operator dashboard, not a consumer app — **dense by default**. Grid/table surfaces get tight spacing + line-height. When in doubt, tighter. (See `operator-ui-conventions.md` density grid prefs.)
+
+## Tokens + type scale
+
+Design tokens (surface fills, border colors, the type scale) live in `tailwind.config` — extract once, reference everywhere. No magic hex/px in components. A new spacing/type value that isn't a token is a smell: add the token.
+
+## Dark mode — non-negotiable
+
+Every surface/token pair ships both themes and passes the `frontend/scripts/check-dark-classes.mjs` gate. No bare (light-only) surface classes.
+
+## Standing execution rule
+
+The above is decided. When a ticket says "visual v2 / cards / badges / chart polish / density," implement it against this skill — sub-PR it small (tokens+card → badge → chartTheme → humanized copy → density), reuse existing components, run the dark gate + typecheck + `test:unit`. Surface to the operator only a genuinely new visual identity, never the assembly of this system.

--- a/.claude/skills/frontend/information-architecture.md
+++ b/.claude/skills/frontend/information-architecture.md
@@ -1,0 +1,41 @@
+# frontend/information-architecture
+
+## When to use
+
+Read before any change to eBull's top-level navigation / page structure — merging or splitting pages, adding a nav item, or building a multi-view surface. These are **standing operator decisions**. Consolidating existing pages into a coherent hub is **engineering, not a taste-gate** — decide the shape from the tickets + the surfaces themselves and build it; do NOT open a "should I merge these?" sign-off loop. Escalate only a genuinely new nav paradigm or an irreversible route removal with live external links you can't shim.
+
+## The lens-consolidation pattern — SETTLED
+
+When **N routes render N lenses on ONE dataset** (same underlying universe, differing only in which columns + filter + default sort are shown), that is **one surface, not N pages**. Consolidate into a single hub with **view presets**.
+
+Canonical case (#1917): Instruments / Rankings / Theses / Recommendations are four lenses on the instrument universe → one **`/research`** hub.
+
+### Presets = a segmented control, NOT chips
+
+A preset swaps the **endpoint + column set + default sort** — it is a **mode**, not an additive filter. Model it as a **segmented control (tabs)**: "pick one lens." Chips model "toggle several at once" and mismodel a mode swap. (Grounding: Finviz/TradingView/Investing.com screeners all use mode tabs for exactly this "same universe, different lens" problem.)
+
+- Route the preset in the URL: `/research?view=ranked|universe|…` — deep-linkable, back-button-correct.
+- **Land on the highest-value lens** (Ranked for eBull — scored universe is the daily driver).
+- A preset that is a **generation/action queue** (e.g. Theses = "what has/needs a thesis + staleness") stays a queue with its own columns — it is NOT a second copy of the main ranked table. Don't collapse a queue into the grid.
+
+### Migration is mechanical — do all of it
+
+1. **Redirect shims** for every old route → the hub preset. Reuse the existing `InstrumentDetailRedirect` shim pattern (`App.tsx`). **Forward query strings** (e.g. `/theses?held&stale` → `/research?view=theses&held&stale`) so existing deep links + bookmarks survive.
+2. **Collapse the sidebar** (`Sidebar.tsx`) — N items → 1.
+3. **Repoint every in-app link** that targeted an old route (grep `to="/rankings"` etc.) at the appropriate `?view=…`.
+
+### Decouple blocked sub-features
+
+A blocked companion (e.g. a heat-map endpoint that isn't merged) must NOT gate the hub. Ship a **render-mode toggle** (Table | Map) with the blocked mode **present but disabled/"coming soon"**, table-only now; the blocked mode drops in later with no re-architecture.
+
+## Lens components must PRESERVE the hub's `view` param
+
+A lens page that owns URL query state (filters, pager, sort) commonly writes it by rebuilding a fresh `URLSearchParams` — which **drops the hub's `view` param**, so the next filter/pager click bounces the operator off the lens back to the default preset. When a page can be mounted under the hub, its `setSearchParams` must **preserve params it does not own**: start from the current params (`setSearchParams((prev) => …)` or `new URLSearchParams(base)`), delete-then-set only its own keys, and leave `view` (and any future foreign param) untouched. (Caught in #1917 Codex ckpt-2 on `ThesesPage.writeFilters`.)
+
+## Reuse the shared table primitives
+
+The hub composes the same extracted table primitives, not re-implemented ones (`frontend/src/lib/portfolioRows.ts`, `frontend/src/lib/avatar.tsx`, shared cell renderers from the #1901 dedup). If a primitive doesn't exist yet, extract it once and share — never fork a fifth copy.
+
+## Standing execution rule
+
+The consolidation shape above is decided. Implement it against this skill: behavior-preserving per lens (each preset renders what its page renders today), one PR for the hub shell + presets + redirects + sidebar collapse, run typecheck + `test:unit` + the dark gate. Surface to the operator only a genuinely new nav paradigm — never the assembly of a hub from pages that already exist.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,8 @@ import { RequireAuth } from "@/components/RequireAuth";
 import { ConfigProvider } from "@/lib/ConfigContext";
 import { DisplayCurrencyProvider } from "@/lib/DisplayCurrencyContext";
 import { DashboardPage } from "@/pages/DashboardPage";
-import { RankingsPage } from "@/pages/RankingsPage";
+import { ResearchHubPage } from "@/pages/ResearchHubPage";
+import { PresetRedirect } from "@/pages/PresetRedirect";
 import { InstrumentDetailRedirect } from "@/pages/InstrumentDetailRedirect";
 import { InstrumentPage } from "@/pages/InstrumentPage";
 import { Tenk10KDrilldownPage } from "@/pages/Tenk10KDrilldownPage";
@@ -21,8 +22,6 @@ import { NewsAnalysisPage } from "@/pages/NewsAnalysisPage";
 import { PeersPage } from "@/pages/PeersPage";
 import { ReportsPage } from "@/pages/ReportsPage";
 import { TaxPage } from "@/pages/TaxPage";
-import { RecommendationsPage } from "@/pages/RecommendationsPage";
-import { ThesesPage } from "@/pages/ThesesPage";
 import { AdminPage } from "@/pages/AdminPage";
 import { AdminJobDetailPage } from "@/pages/AdminJobDetailPage";
 import { ProcessDetailPage } from "@/pages/ProcessDetailPage";
@@ -36,7 +35,6 @@ import { LoginPage } from "@/pages/LoginPage";
 import { SetupPage } from "@/pages/SetupPage";
 import { OperatorsPage } from "@/pages/OperatorsPage";
 import { CopyTradingPage } from "@/pages/CopyTradingPage";
-import { InstrumentsPage } from "@/pages/InstrumentsPage";
 import { PortfolioPage } from "@/pages/PortfolioPage";
 import { CalendarPage } from "@/pages/CalendarPage";
 
@@ -81,8 +79,12 @@ export function App() {
             path="portfolio/:instrumentId"
             element={<InstrumentDetailRedirect search="?tab=positions" />}
           />
-          <Route path="rankings" element={<RankingsPage />} />
-          <Route path="instruments" element={<InstrumentsPage />} />
+          {/* #1917 — Research hub subsumes Instruments/Rankings/Theses/
+              Recommendations as view presets. Old routes redirect here,
+              preserving their query strings. */}
+          <Route path="research" element={<ResearchHubPage />} />
+          <Route path="rankings" element={<PresetRedirect view="ranked" />} />
+          <Route path="instruments" element={<PresetRedirect view="universe" />} />
           <Route
             path="instruments/:instrumentId"
             element={<InstrumentDetailRedirect />}
@@ -133,8 +135,8 @@ export function App() {
             element={<PeersPage />}
           />
           <Route path="copy-trading/:mirrorId" element={<CopyTradingPage />} />
-          <Route path="theses" element={<ThesesPage />} />
-          <Route path="recommendations" element={<RecommendationsPage />} />
+          <Route path="theses" element={<PresetRedirect view="theses" />} />
+          <Route path="recommendations" element={<PresetRedirect view="actioned" />} />
           <Route path="reports" element={<ReportsPage />} />
           <Route path="tax" element={<TaxPage />} />
           <Route path="admin" element={<AdminPage />} />

--- a/frontend/src/components/dashboard/AlertsStrip.test.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.test.tsx
@@ -794,7 +794,9 @@ describe("AlertsStrip — thesis staleness", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/AAPL, GME/)).toBeInTheDocument();
     const link = screen.getByRole("link", { name: /Review in Theses/i });
-    expect(link).toHaveAttribute("href", "/theses?held=true&stale=true");
+    // #1917 — Theses is now a Research-hub preset; the deep link forwards the
+    // held/stale query so the Theses lens still lands pre-filtered.
+    expect(link).toHaveAttribute("href", "/research?view=theses&held=true&stale=true");
     // Standing condition: never counted as unseen — no "new" pill.
     expect(screen.queryByText(/new$/)).not.toBeInTheDocument();
   });

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -384,7 +384,7 @@ function ThesisStaleCard({ item }: { item: ThesisStaleItem }) {
       </div>
       <div className="flex shrink-0 flex-col items-end gap-1">
         <Link
-          to="/theses?held=true&stale=true"
+          to="/research?view=theses&held=true&stale=true"
           className="text-xs font-medium text-sky-600 dark:text-sky-400 underline hover:text-sky-800 dark:hover:text-sky-300"
         >
           Review in Theses
@@ -676,7 +676,7 @@ export function AlertsStrip(): JSX.Element | null {
       Math.max(0, unseenRank - renderedRank) +
       Math.max(0, unseenThesisChange - renderedThesisChange) +
       Math.max(0, unseenThesisBreak - renderedThesisBreak);
-    const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /recommendations (or /theses for thesis alerts) before dismissing if they might matter.`;
+    const msg = `Dismiss all ${totalUnseen} unseen alerts? ${hiddenCount} are not shown above. Review them at /research?view=actioned (or ?view=theses for thesis alerts) before dismissing if they might matter.`;
     if (!window.confirm(msg)) return;
 
     const promises: Promise<void>[] = [];
@@ -740,7 +740,7 @@ export function AlertsStrip(): JSX.Element | null {
               Dismiss all ({totalUnseen}) as acknowledged
             </button>
             <Link
-              to="/recommendations"
+              to="/research?view=actioned"
               className="text-xs text-slate-500 dark:text-slate-400 underline hover:text-slate-700"
             >
               Triage at /recommendations

--- a/frontend/src/components/dashboard/AlertsStrip.tsx
+++ b/frontend/src/components/dashboard/AlertsStrip.tsx
@@ -743,7 +743,7 @@ export function AlertsStrip(): JSX.Element | null {
               to="/research?view=actioned"
               className="text-xs text-slate-500 dark:text-slate-400 underline hover:text-slate-700"
             >
-              Triage at /recommendations
+              Triage recommendations
             </Link>
           </div>
         ) : null}

--- a/frontend/src/components/dashboard/PositionsTable.tsx
+++ b/frontend/src/components/dashboard/PositionsTable.tsx
@@ -39,7 +39,7 @@ export function PositionsTable({
         title="No positions yet"
         description="Open a position from the rankings page to see it here."
       >
-        <Link to="/rankings" className="text-sm font-medium text-blue-600 hover:underline">
+        <Link to="/research?view=ranked" className="text-sm font-medium text-blue-600 hover:underline">
           Go to rankings →
         </Link>
       </EmptyState>

--- a/frontend/src/components/dashboard/alertModel.test.ts
+++ b/frontend/src/components/dashboard/alertModel.test.ts
@@ -103,7 +103,7 @@ describe("guardReasonMeta", () => {
   it("falls back to a humanized label + triage action for an unknown code", () => {
     const m = guardReasonMeta("some_new_rule");
     expect(m.label).toBe("Some new rule");
-    expect(m.action.to).toBe("/recommendations");
+    expect(m.action.to).toBe("/research?view=actioned");
   });
 });
 

--- a/frontend/src/components/dashboard/alertModel.ts
+++ b/frontend/src/components/dashboard/alertModel.ts
@@ -50,13 +50,13 @@ export interface GuardReasonMeta {
 }
 
 const ADMIN = { label: "Manage in Admin", to: "/admin" };
-const TRIAGE = { label: "Triage", to: "/recommendations" };
+const TRIAGE = { label: "Triage", to: "/research?view=actioned" };
 
 /**
  * One entry per execution-guard RuleName (app/services/execution_guard.py:89-107).
  * Config / safety-layer rejections point at /admin (where the operator acts — e.g. the
  * kill switch is deactivated there, NOT from this strip). Data / per-instrument rejections
- * point at /recommendations for triage. Unknown codes fall back to a humanized label.
+ * point at /research?view=actioned for triage. Unknown codes fall back to a humanized label.
  */
 export const GUARD_REASON_META: Record<string, GuardReasonMeta> = {
   kill_switch: {

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -4,10 +4,9 @@ const NAV_ITEMS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/portfolio", label: "Portfolio" },
   { to: "/calendar", label: "Calendar" },
-  { to: "/instruments", label: "Instruments" },
-  { to: "/rankings", label: "Rankings" },
-  { to: "/theses", label: "Theses" },
-  { to: "/recommendations", label: "Recommendations" },
+  // #1917 — one Research item; Instruments/Rankings/Theses/Recommendations are
+  // now view presets under /research.
+  { to: "/research", label: "Research" },
   { to: "/reports", label: "Reports" },
   { to: "/tax", label: "Tax" },
   { to: "/admin", label: "Admin" },

--- a/frontend/src/pages/PortfolioPage.tsx
+++ b/frontend/src/pages/PortfolioPage.tsx
@@ -268,7 +268,7 @@ export function PortfolioPage() {
               description="Open a position from the rankings page to see it here."
             >
               <Link
-                to="/rankings"
+                to="/research?view=ranked"
                 className="text-sm font-medium text-blue-600 hover:underline"
               >
                 Go to rankings →

--- a/frontend/src/pages/PresetRedirect.tsx
+++ b/frontend/src/pages/PresetRedirect.tsx
@@ -1,0 +1,16 @@
+import { Navigate, useLocation } from "react-router-dom";
+
+/**
+ * Route shim for the four pages the Research hub (#1917) subsumed
+ * (`/instruments`, `/rankings`, `/theses`, `/recommendations`). Redirects to
+ * `/research?view=…` while FORWARDING the incoming query string, so existing
+ * deep links + bookmarks survive — e.g. the AlertsStrip's
+ * `/theses?held=true&stale=true` lands on `/research?held=true&stale=true&view=theses`
+ * and the Theses lens reads those params unchanged.
+ */
+export function PresetRedirect({ view }: { view: string }): JSX.Element {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  params.set("view", view);
+  return <Navigate to={`/research?${params.toString()}`} replace />;
+}

--- a/frontend/src/pages/ResearchHubPage.test.tsx
+++ b/frontend/src/pages/ResearchHubPage.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * #1917 — Research hub: view presets + old-route redirect shims.
+ * The four lens pages are mocked to identifiable stubs; the tests pin the hub's
+ * routing/preset behaviour, not each page's internals.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+
+import { ResearchHubPage } from "@/pages/ResearchHubPage";
+import { PresetRedirect } from "@/pages/PresetRedirect";
+
+vi.mock("@/pages/RankingsPage", () => ({ RankingsPage: () => <div data-testid="lens-ranked" /> }));
+vi.mock("@/pages/InstrumentsPage", () => ({ InstrumentsPage: () => <div data-testid="lens-universe" /> }));
+vi.mock("@/pages/ThesesPage", () => ({ ThesesPage: () => <div data-testid="lens-theses" /> }));
+vi.mock("@/pages/RecommendationsPage", () => ({
+  RecommendationsPage: () => <div data-testid="lens-actioned" />,
+}));
+
+function LocationProbe() {
+  const loc = useLocation();
+  return (
+    <>
+      <div data-testid="path">{loc.pathname}</div>
+      <div data-testid="search">{loc.search}</div>
+    </>
+  );
+}
+
+function renderAt(initial: string) {
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      <Routes>
+        <Route path="/research" element={<ResearchHubPage />} />
+        <Route path="/rankings" element={<PresetRedirect view="ranked" />} />
+        <Route path="/instruments" element={<PresetRedirect view="universe" />} />
+        <Route path="/theses" element={<PresetRedirect view="theses" />} />
+        <Route path="/recommendations" element={<PresetRedirect view="actioned" />} />
+      </Routes>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
+}
+
+describe("ResearchHubPage — presets", () => {
+  it("lands on Ranked when no view param", () => {
+    renderAt("/research");
+    expect(screen.getByTestId("lens-ranked")).toBeInTheDocument();
+    expect(screen.queryByTestId("lens-universe")).toBeNull();
+  });
+
+  it("renders the lens named by ?view=", () => {
+    renderAt("/research?view=theses");
+    expect(screen.getByTestId("lens-theses")).toBeInTheDocument();
+  });
+
+  it("falls back to Ranked on an unknown view", () => {
+    renderAt("/research?view=bogus");
+    expect(screen.getByTestId("lens-ranked")).toBeInTheDocument();
+  });
+
+  it("switches lens + URL when a preset tab is clicked", async () => {
+    const user = userEvent.setup();
+    renderAt("/research");
+    await user.click(screen.getByRole("tab", { name: "Actioned" }));
+    expect(screen.getByTestId("lens-actioned")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("search").textContent).toBe("?view=actioned"));
+  });
+
+  it("shows the disabled Map affordance on a table lens", () => {
+    renderAt("/research?view=ranked");
+    expect(screen.getByText("Map")).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("hides the Map affordance on a non-mappable lens (Theses)", () => {
+    renderAt("/research?view=theses");
+    expect(screen.queryByText("Map")).toBeNull();
+  });
+});
+
+describe("PresetRedirect — old routes forward to the hub, preserving query", () => {
+  it("/rankings → /research?view=ranked", async () => {
+    renderAt("/rankings");
+    await waitFor(() => {
+      expect(screen.getByTestId("path").textContent).toBe("/research");
+      expect(screen.getByTestId("search").textContent).toBe("?view=ranked");
+    });
+    expect(screen.getByTestId("lens-ranked")).toBeInTheDocument();
+  });
+
+  it("/theses?held=true&stale=true → /research?...&view=theses (query preserved)", async () => {
+    renderAt("/theses?held=true&stale=true");
+    await waitFor(() => {
+      expect(screen.getByTestId("path").textContent).toBe("/research");
+      const search = screen.getByTestId("search").textContent ?? "";
+      expect(search).toContain("held=true");
+      expect(search).toContain("stale=true");
+      expect(search).toContain("view=theses");
+    });
+    expect(screen.getByTestId("lens-theses")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ResearchHubPage.test.tsx
+++ b/frontend/src/pages/ResearchHubPage.test.tsx
@@ -70,7 +70,7 @@ describe("ResearchHubPage — presets", () => {
 
   it("shows the disabled Map affordance on a table lens", () => {
     renderAt("/research?view=ranked");
-    expect(screen.getByText("Map")).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("button", { name: "Map" })).toBeDisabled();
   });
 
   it("hides the Map affordance on a non-mappable lens (Theses)", () => {

--- a/frontend/src/pages/ResearchHubPage.tsx
+++ b/frontend/src/pages/ResearchHubPage.tsx
@@ -102,17 +102,26 @@ export function ResearchHubPage(): JSX.Element {
  */
 function RenderModeToggle(): JSX.Element {
   return (
-    <div className="inline-flex gap-0.5 rounded-lg border border-slate-200 bg-slate-50 p-0.5 text-sm dark:border-slate-800 dark:bg-slate-900/40">
-      <span className="rounded-md bg-white px-3 py-1.5 font-medium text-slate-900 dark:bg-slate-800 dark:text-slate-100">
+    <div
+      role="group"
+      aria-label="Render mode"
+      className="inline-flex gap-0.5 rounded-lg border border-slate-200 bg-slate-50 p-0.5 text-sm dark:border-slate-800 dark:bg-slate-900/40"
+    >
+      <button
+        type="button"
+        aria-pressed="true"
+        className="rounded-md bg-white px-3 py-1.5 font-medium text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+      >
         Table
-      </span>
-      <span
+      </button>
+      <button
+        type="button"
+        disabled
         title="Ownership / geography map — coming soon (#1912)"
-        aria-disabled="true"
-        className="cursor-not-allowed rounded-md px-3 py-1.5 font-medium text-slate-400 dark:text-slate-600"
+        className="cursor-not-allowed rounded-md px-3 py-1.5 font-medium text-slate-400 disabled:opacity-100 dark:text-slate-600"
       >
         Map
-      </span>
+      </button>
     </div>
   );
 }

--- a/frontend/src/pages/ResearchHubPage.tsx
+++ b/frontend/src/pages/ResearchHubPage.tsx
@@ -1,0 +1,118 @@
+import { useSearchParams } from "react-router-dom";
+
+import { RankingsPage } from "@/pages/RankingsPage";
+import { InstrumentsPage } from "@/pages/InstrumentsPage";
+import { ThesesPage } from "@/pages/ThesesPage";
+import { RecommendationsPage } from "@/pages/RecommendationsPage";
+
+/**
+ * Research hub (#1917) — one surface for the four lenses on the instrument
+ * universe (Instruments / Rankings / Theses / Recommendations were four
+ * top-level pages differing only in which columns + filter they show).
+ *
+ * A view preset is a MODE, not an additive filter, so it renders as a segmented
+ * control, not chips (see `frontend/information-architecture` skill). The preset
+ * lives in the URL (`/research?view=…`) so it is deep-linkable and back-button
+ * correct; the old routes redirect here preserving their query strings, so a
+ * `/theses?held&stale` bookmark lands on `?view=theses&held&stale` and the
+ * Theses lens reads those params unchanged.
+ *
+ * Each preset renders the existing page component verbatim — behaviour-preserving
+ * per lens. The Theses lens is a generation queue (status/staleness), NOT a second
+ * ranked table. The Map render mode is decoupled from #1912 (its endpoint is
+ * unmerged): the toggle is present-but-disabled on the table lenses, table-only.
+ */
+type ViewKey = "ranked" | "universe" | "theses" | "actioned";
+
+interface Preset {
+  label: string;
+  hint: string;
+  Component: () => JSX.Element;
+  mappable: boolean;
+}
+
+const PRESETS: Record<ViewKey, Preset> = {
+  ranked: { label: "Ranked", hint: "Universe by score", Component: RankingsPage, mappable: true },
+  universe: { label: "Universe", hint: "All tradable instruments", Component: InstrumentsPage, mappable: true },
+  theses: { label: "Theses", hint: "Thesis generation queue + staleness", Component: ThesesPage, mappable: false },
+  actioned: { label: "Actioned", hint: "Portfolio-manager recommendations", Component: RecommendationsPage, mappable: false },
+};
+
+// Landing lens = Ranked (the scored universe is the daily driver).
+const VIEW_ORDER: ViewKey[] = ["ranked", "universe", "theses", "actioned"];
+const DEFAULT_VIEW: ViewKey = "ranked";
+
+function isViewKey(v: string | null): v is ViewKey {
+  return v === "ranked" || v === "universe" || v === "theses" || v === "actioned";
+}
+
+export function ResearchHubPage(): JSX.Element {
+  const [params, setParams] = useSearchParams();
+  const raw = params.get("view");
+  const view: ViewKey = isViewKey(raw) ? raw : DEFAULT_VIEW;
+  const active = PRESETS[view];
+  const ActiveLens = active.Component;
+
+  return (
+    <div className="space-y-4 pt-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        {/* Segmented control — one lens at a time. Switching a preset drops the
+            previous lens's own params (they are lens-specific); a deep link that
+            arrives with them still works because the target lens reads the URL. */}
+        <div
+          role="tablist"
+          aria-label="Research view"
+          className="inline-flex gap-0.5 rounded-lg border border-slate-200 bg-slate-50 p-0.5 dark:border-slate-800 dark:bg-slate-900/40"
+        >
+          {VIEW_ORDER.map((key) => {
+            const p = PRESETS[key];
+            const selected = key === view;
+            return (
+              <button
+                key={key}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                title={p.hint}
+                onClick={() => setParams({ view: key })}
+                className={[
+                  "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                  selected
+                    ? "bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+                    : "text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200",
+                ].join(" ")}
+              >
+                {p.label}
+              </button>
+            );
+          })}
+        </div>
+        {active.mappable ? <RenderModeToggle /> : null}
+      </div>
+
+      <ActiveLens />
+    </div>
+  );
+}
+
+/**
+ * Table | Map render-mode affordance. Map is decoupled from #1912 (endpoint
+ * unmerged) — present but disabled so the hub ships table-only now and the map
+ * drops in later with no re-architecture (#1917 / information-architecture skill).
+ */
+function RenderModeToggle(): JSX.Element {
+  return (
+    <div className="inline-flex gap-0.5 rounded-lg border border-slate-200 bg-slate-50 p-0.5 text-sm dark:border-slate-800 dark:bg-slate-900/40">
+      <span className="rounded-md bg-white px-3 py-1.5 font-medium text-slate-900 dark:bg-slate-800 dark:text-slate-100">
+        Table
+      </span>
+      <span
+        title="Ownership / geography map — coming soon (#1912)"
+        aria-disabled="true"
+        className="cursor-not-allowed rounded-md px-3 py-1.5 font-medium text-slate-400 dark:text-slate-600"
+      >
+        Map
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/ThesesPage.test.tsx
+++ b/frontend/src/pages/ThesesPage.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { ThesesPage } from "@/pages/ThesesPage";
@@ -49,10 +49,15 @@ function respond(items: ThesisLibraryItem[], total = items.length): ThesisLibrar
   return { items, total, offset: 0, limit: 50 };
 }
 
+function LocationProbe() {
+  return <div data-testid="search">{useLocation().search}</div>;
+}
+
 function renderPage(initialEntry = "/theses") {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
       <ThesesPage />
+      <LocationProbe />
     </MemoryRouter>,
   );
 }
@@ -101,6 +106,21 @@ describe("ThesesPage", () => {
       "href",
       "/instrument/AAPL?tab=verdict",
     );
+  });
+
+  it("preserves the Research hub's view param when a filter is toggled (#1917)", async () => {
+    // Under the hub the URL is /research?view=theses; a filter click must NOT drop
+    // `view` (else the hub falls back to Ranked mid-filtering — Codex ckpt-2).
+    mockedFetch.mockResolvedValue(respond([makeItem()]));
+    const user = userEvent.setup();
+    renderPage("/theses?view=theses");
+    await screen.findByText("AAPL");
+    await user.click(screen.getByRole("checkbox", { name: "Held only" }));
+    await waitFor(() => {
+      const search = screen.getByTestId("search").textContent ?? "";
+      expect(search).toContain("view=theses");
+      expect(search).toContain("held=true");
+    });
   });
 
   it("shows the guiding empty state when no theses exist", async () => {

--- a/frontend/src/pages/ThesesPage.tsx
+++ b/frontend/src/pages/ThesesPage.tsx
@@ -57,8 +57,15 @@ function readFilters(p: URLSearchParams): LibraryFilters {
   };
 }
 
-function writeFilters(f: LibraryFilters): URLSearchParams {
-  const out = new URLSearchParams();
+const _OWNED_FILTER_KEYS = ["held", "stale", "stance", "offset"] as const;
+
+function writeFilters(f: LibraryFilters, base: URLSearchParams): URLSearchParams {
+  // Preserve any param this page does NOT own — e.g. the Research hub's `view`
+  // (#1917): rebuilding from scratch dropped it, bouncing the operator off the
+  // Theses lens back to Ranked on any filter/pager click. Manage only the
+  // library-filter keys (clear then set, so toggling a filter off removes it).
+  const out = new URLSearchParams(base);
+  for (const k of _OWNED_FILTER_KEYS) out.delete(k);
   if (f.held) out.set("held", "true");
   if (f.stale) out.set("stale", "true");
   if (f.stance !== "") out.set("stance", f.stance);
@@ -200,7 +207,7 @@ export function ThesesPage(): JSX.Element {
       offset: 0,
       ...next,
     };
-    setSearchParams(writeFilters(merged), { replace: true });
+    setSearchParams((prev) => writeFilters(merged, prev), { replace: true });
   }
 
   async function onRequestFresh(row: ThesisLibraryItem): Promise<void> {


### PR DESCRIPTION
## What

#1917 — merge the four instrument-universe pages (Instruments / Rankings / Theses / Recommendations) into one **`/research`** hub with **view presets**. Behaviour-preserving per lens: each preset renders the existing page component verbatim.

Executed per the new standing skill `frontend/information-architecture` (this consolidation is engineering, not a taste-gate — assembling existing pages).

## How

- **`ResearchHubPage`** — a segmented control (a preset swaps endpoint+columns = a *mode*, so tabs not chips) over `Ranked` / `Universe` / `Theses` / `Actioned`. Preset lives in the URL (`/research?view=…`) → deep-linkable, back-button correct. Lands on **Ranked** (the scored universe is the daily driver). Unknown `?view=` falls back to Ranked.
- **`PresetRedirect`** — the four old routes (`/rankings`, `/instruments`, `/theses`, `/recommendations`) redirect to the hub **forwarding their query string**, so `/theses?held=true&stale=true` → `/research?view=theses&held=true&stale=true` and the Theses lens reads `held`/`stale` unchanged. Bookmarks + the AlertsStrip deep links survive.
- **Sidebar** 4 → 1 ("Research").
- **In-app links repointed**: `PositionsTable`, `PortfolioPage` (→ ranked), `AlertsStrip` (thesis-staleness → theses w/ filters; dismiss-all copy; recommendations link → actioned), `alertModel` TRIAGE (→ actioned).
- **Theses lens stays a generation queue** (verdict/staleness), NOT a second ranked table — its own page renders unchanged.
- **Map render mode decoupled from #1912** (endpoint unmerged): a Table | Map toggle is present on the table lenses with **Map disabled** ("coming soon (#1912)") — ships table-only, no re-architecture when the map lands.

## Skills (bundled — the standing decision record)

Two new frontend skills encode where the operator stands so future UI work decides + builds without a sign-off loop (operator directive this session):
- `frontend/information-architecture.md` — the lens-consolidation pattern (N pages that are N lenses on one dataset → one hub with segmented presets; redirect shims preserve deep links; decouple blocked sub-features).
- `frontend/design-system.md` — the visual surface/badge/chart/density system (for the follow-on #1908). Both registered in `.claude/CLAUDE.md`.

## Tests

- `ResearchHubPage.test.tsx` (new): default lands on Ranked; `?view=` renders the named lens; unknown view → Ranked; tab click switches lens + URL; Map affordance present-and-disabled on table lenses, absent on Theses; PresetRedirect forwards `/rankings`→`?view=ranked` and preserves `/theses?held=true&stale=true`.
- Updated `AlertsStrip.test.tsx` + `alertModel.test.ts` for the repointed links.
- `pnpm typecheck` · `test:unit` (1390) · `dark:check` (260 files) — all green. Codex ckpt-2: (verdict appended on push).

Closes #1917.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
