### PR TITLE
docs(#1908): design-system skill correction — editorial-chrome-first (card conflicts with v1)

### DIFF
--- a/.claude/skills/frontend/design-system.md
+++ b/.claude/skills/frontend/design-system.md
@@ -8,12 +8,14 @@ Read before any change to eBull's visual system — surfaces/cards, badges/pills
 
 ## Surface model (the #691 line) — SETTLED
 
-There is **no card/surface decision in `docs/settled-decisions.md`**. The governing history is operator taste in **#691**, which killed *shadowed, elevated "Trello card"* surfaces — it did **not** ban flat surfaces. So the standing surface system is a **hybrid**:
+The base surface is **settled and deliberate**: design-system **v1 is borderless "editorial chrome"** (`components/instrument/Pane.tsx:32-47`). It already replaced the prior rounded card (border + shadow + `bg-white`) with a **single hairline top-rule + small-caps title**, on an explicit rationale — financial operators **scan across panes for cross-pane signal** (revenue trend → dividend yield → insider buying), so the grid must read as **one document, not a Trello-board of separate cards**. That IS the #691 completion. `StatTile.tsx` follows the same rule ("the hairline IS the tile chrome", #1592).
 
-- **Flat-hairline base** — lists, tables, narrative sections. Border/hairline separators, no fill, no elevation. This is the default; most surfaces are this.
-- **One flat card variant** — for **stat tiles and chart tiles only** (the things that otherwise "float in empty space"). Spec: subtle fill (`bg-slate-900/40` dark / `bg-slate-50` light equivalent), `1px` border, `rounded`, **NO shadow, NO elevation**. That last clause IS the #691 line — hold it. Never add `shadow-*` or a raised/Trello look to a card.
+**Do NOT reflexively "add cards".** A bounded/filled card fragments the cross-pane scan the v1 system was built to protect — reversing it inside the instrument grid (or any scanning grid of Panes) is a **settled-decision reversal**: surface it to the operator with a recommendation, don't just ship it.
 
-Decision rule: **narrative/list → flat-hairline; stat/chart tile → the flat card variant.** Nothing else gets a third surface. (Frame any v2 work as "completing #691's surface system," not "reversing a decision.")
+- **Default = editorial chrome** — hairline rule + title, no fill, no border box, no shadow. Panes, stat rows, narrative sections. `Pane` / `StatTile` already encode this; reuse them.
+- **A bounding surface is a narrow, JUSTIFIED exception** — only for a genuinely **standalone** tile that is NOT part of a scanning grid and reads as unanchored on bare page background (e.g. a lone chart with no neighbouring panes). Even then: flat only — subtle fill + `1px` border, `rounded`, **NO shadow, NO elevation** (the #691 line). If in doubt, prefer fixing "floating" with **spacing/grouping/density** (see Density) inside editorial chrome, not a card.
+
+Decision rule: **editorial chrome first.** Reach for a bounding surface only for a standalone unanchored tile, and never retrofit cards onto a Pane scanning grid without operator sign-off — that's reversing v1's documented rationale.
 
 ## Badge / pill — ONE component
 


### PR DESCRIPTION
Investigating #1908 PR-1 surfaced that "add a flat card variant for stat/chart tiles" partly **conflicts** with settled design-system **v1**: `components/instrument/Pane.tsx` is deliberately borderless "editorial chrome" — it already replaced the rounded card (border+shadow+bg) with a hairline rule + title, on an explicit rationale: operators **scan across panes for cross-pane signal**, so the grid must read as **one document, not separate cards**. `StatTile` follows the same hairline rule (#1592). That IS #691's completion.

So the card idea isn't the clean assembly of a known-good idea — inside the Pane scanning grids it would **reverse** a well-reasoned v1 decision.

## Change
Corrects the `frontend/design-system` skill: **editorial-chrome is the settled base**; a bounding surface is a **narrow, justified exception** for a genuinely standalone unanchored tile only, never retrofitted onto a Pane grid without operator sign-off. Prefer fixing "floating stats" with **spacing/grouping/density** inside editorial chrome, not cards.

No app code. This is the researched design finding + the corrected standing decision. The card-vs-editorial call is surfaced on the issue with a recommendation (hold editorial-chrome, fix via density); the non-card #1908 work (Badge/#559, chartTheme, verdict-humanize, density) is unaffected.

Refs #1908. Refs #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)