### PR TITLE
feat(#1908): humanize the verdict scorer output — structured penalty/reward chips (visual v2 PR-4)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1059,6 +1059,27 @@ export interface AuditListResponse {
   limit: number;
 }
 
+/**
+ * One entry of `scores.penalties_json`. Written by
+ * `app/services/scoring.py::_insert_score` — the column carries BOTH penalties
+ * and rewards, disambiguated by `kind` (#1635).
+ *
+ * `kind` is OPTIONAL because rows written before #1635 carry only
+ * `{name, deduction, reason}`. Read the discriminator through
+ * `lib/scoreExplanation.ts::isReward`, never by testing `kind` directly.
+ *
+ * Both magnitudes are POSITIVE: `deduction` is subtracted from the score,
+ * `addition` is added. Keeping rewards out of `deduction` is deliberate — a
+ * negative penalty would corrupt `total_penalty` and the explanation string.
+ */
+export interface ScorePenaltyItem {
+  name: string;
+  reason: string;
+  kind?: string;
+  deduction?: number;
+  addition?: number;
+}
+
 // ---------------------------------------------------------------------------
 // /rankings (app/api/scores.py)
 // ---------------------------------------------------------------------------
@@ -1086,7 +1107,7 @@ export interface RankingItem {
   // visibly flagged (on `scores` since #1820).
   data_completeness: number | null;
   completeness_tier: string | null;
-  penalties_json: Record<string, unknown>[] | null;
+  penalties_json: ScorePenaltyItem[] | null;
   explanation: string | null;
   model_version: string;
   scored_at: string;
@@ -1136,7 +1157,7 @@ export interface ScoreHistoryItem {
   momentum_score: number | null;
   sentiment_score: number | null;
   confidence_score: number | null;
-  penalties_json: Record<string, unknown>[] | null;
+  penalties_json: ScorePenaltyItem[] | null;
   explanation: string | null;
   rank: number | null;
   rank_delta: number | null;
@@ -1234,7 +1255,7 @@ export interface VerdictScore {
   confidence_score: number | null;
   data_completeness: number | null;
   completeness_tier: string | null;
-  penalties_json: Record<string, unknown>[] | null;
+  penalties_json: ScorePenaltyItem[] | null;
   explanation: string | null;
   analytics_json: IarAnalytics | null;
 }

--- a/frontend/src/components/instrument/VerdictTab.test.tsx
+++ b/frontend/src/components/instrument/VerdictTab.test.tsx
@@ -164,6 +164,69 @@ describe("VerdictTab", () => {
     expect(screen.getByText(/postdates this score/)).toBeInTheDocument();
   });
 
+  it("renders penalties/rewards as humanized chips and hides the raw scorer string behind an expander (#1908 PR-4)", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict(
+        {
+          penalties_json: [
+            {
+              name: "high_realized_volatility",
+              reason: "3y annualized vol=0.71 > 0.60",
+              kind: "penalty",
+              deduction: 0.04,
+            },
+            {
+              name: "strong_calmar",
+              reason: "3y total-return Calmar=1.85 > high threshold 0.75",
+              kind: "reward",
+              addition: 0.03,
+            },
+          ],
+          explanation:
+            "value: base_value missing; penalties fired: high_realized_volatility (total deduction: 0.04)",
+        },
+        FULL_IAR,
+      ),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={null} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("0.82")).toBeInTheDocument();
+
+    // Humanized, signed, with the scorer's own reason on hover.
+    expect(screen.getByText("High realized volatility")).toBeInTheDocument();
+    expect(screen.getByText("−0.04")).toBeInTheDocument();
+    expect(screen.getByText("Strong Calmar")).toBeInTheDocument();
+    expect(screen.getByText("+0.03")).toBeInTheDocument();
+    expect(
+      screen.getByTitle("3y annualized vol=0.71 > 0.60"),
+    ).toBeInTheDocument();
+
+    // The raw audit string is still present verbatim — inside a collapsed
+    // <details>, not deleted. Never drop the audit trail to tidy the UI.
+    const detail = screen.getByText(/base_value missing/);
+    expect(detail).toBeInTheDocument();
+    expect(detail.closest("details")).not.toBeNull();
+    expect(detail.closest("details")?.hasAttribute("open")).toBe(false);
+  });
+
+  it("renders no chips when the score row has no penalties (rewards/penalties are optional)", async () => {
+    vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
+      makeVerdict({ penalties_json: null }, FULL_IAR),
+    );
+    render(
+      <MemoryRouter>
+        <VerdictTab instrumentId={1} thesis={null} />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("0.82")).toBeInTheDocument();
+    expect(screen.queryByText(/^[−+]\d/)).not.toBeInTheDocument();
+    // The explanation expander still renders — it is independent of chips.
+    expect(screen.getByText("Scorer detail")).toBeInTheDocument();
+  });
+
   it("renders scored-but-no-IAR honestly (pre-#1823 row)", async () => {
     vi.spyOn(verdictApi, "fetchScoreVerdict").mockResolvedValue(
       makeVerdict({}, null),

--- a/frontend/src/components/instrument/VerdictTab.tsx
+++ b/frontend/src/components/instrument/VerdictTab.tsx
@@ -35,6 +35,7 @@ import { EmptyState } from "@/components/states/EmptyState";
 import { useAsync } from "@/lib/useAsync";
 import { Badge, type BadgeTone } from "@/components/ui/Badge";
 import { completenessTone } from "@/lib/badgeTone";
+import { toScoreChips } from "@/lib/scoreExplanation";
 
 export interface VerdictTabProps {
   readonly instrumentId: number;
@@ -140,6 +141,7 @@ export function VerdictTab({
 
   const iar = score.analytics_json;
   const peer = iar?.peer_grade;
+  const chips = toScoreChips(score.penalties_json);
 
   // Score-history sparkline values, oldest→newest (the API returns newest first).
   const historyValues = (history.data?.items ?? [])
@@ -200,10 +202,31 @@ export function VerdictTab({
             as of {score.scored_at.slice(0, 10)} · {score.model_version}
           </span>
         </div>
+        {/* Penalties + rewards as chips, from the STRUCTURED `penalties_json`
+            (#1908 PR-4) — not parsed out of the explanation text. The raw
+            explanation is the audit trail, so it stays available verbatim
+            behind the expander below rather than being reworded or dropped. */}
+        {chips.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {chips.map((chip) => (
+              <Badge key={chip.key} tone={chip.tone} title={chip.title}>
+                {chip.label}
+                {chip.delta !== "" && (
+                  <span className="tabular-nums font-semibold">{chip.delta}</span>
+                )}
+              </Badge>
+            ))}
+          </div>
+        )}
         {score.explanation !== null && (
-          <p className="mt-2 max-w-prose text-xs text-slate-600 dark:text-slate-400">
-            {score.explanation}
-          </p>
+          <details className="group mt-2">
+            <summary className="cursor-pointer text-[11px] text-slate-500 hover:text-slate-700 dark:hover:text-slate-300">
+              Scorer detail
+            </summary>
+            <p className="mt-1 max-w-prose text-xs text-slate-600 dark:text-slate-400">
+              {score.explanation}
+            </p>
+          </details>
         )}
         {thesis !== null && new Date(thesis.created_at) > new Date(score.scored_at) && (
           <p className="mt-2 text-[11px] text-amber-700 dark:text-amber-300">

--- a/frontend/src/lib/scoreExplanation.test.ts
+++ b/frontend/src/lib/scoreExplanation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScorePenaltyItem } from "@/api/types";
+import { humanizePenaltyName, isReward, toScoreChips } from "@/lib/scoreExplanation";
+
+describe("isReward", () => {
+  it("trusts an explicit kind", () => {
+    expect(isReward({ name: "strong_calmar", reason: "", kind: "reward", addition: 0.03 })).toBe(true);
+    expect(isReward({ name: "deep_drawdown", reason: "", kind: "penalty", deduction: 0.04 })).toBe(false);
+  });
+
+  it("treats a kind-less legacy row as a penalty (pre-#1635 payload shape)", () => {
+    // Rows written before rewards existed carry only {name, deduction, reason}.
+    expect(isReward({ name: "high_realized_volatility", reason: "", deduction: 0.04 })).toBe(false);
+  });
+
+  it("falls back to the magnitude field when kind is absent but an addition is present", () => {
+    expect(isReward({ name: "strong_calmar", reason: "", addition: 0.03 })).toBe(true);
+  });
+});
+
+describe("humanizePenaltyName", () => {
+  it("uses curated copy for every name the scorer can emit", () => {
+    // The nine identifiers in app/services/scoring.py.
+    const names = [
+      "stale_thesis",
+      "missing_critical_data",
+      "wide_spread",
+      "high_red_flag",
+      "extreme_dilution",
+      "low_confidence",
+      "high_realized_volatility",
+      "deep_drawdown",
+      "strong_calmar",
+    ];
+    for (const n of names) {
+      expect(humanizePenaltyName(n), n).not.toContain("_");
+      expect(humanizePenaltyName(n)[0], n).toBe(humanizePenaltyName(n)[0]?.toUpperCase());
+    }
+    expect(humanizePenaltyName("high_realized_volatility")).toBe("High realized volatility");
+  });
+
+  it("degrades an unknown scorer name instead of dropping it — the backend may add penalties first", () => {
+    expect(humanizePenaltyName("brand_new_penalty")).toBe("Brand new penalty");
+  });
+});
+
+describe("toScoreChips", () => {
+  it("returns nothing for a score with no penalties row", () => {
+    expect(toScoreChips(null)).toEqual([]);
+    expect(toScoreChips([])).toEqual([]);
+  });
+
+  it("signs a penalty negative and a reward positive, with the scorer reason on hover", () => {
+    const items: ScorePenaltyItem[] = [
+      {
+        name: "high_realized_volatility",
+        reason: "3y annualized vol=0.71 > 0.60",
+        kind: "penalty",
+        deduction: 0.04,
+      },
+      {
+        name: "strong_calmar",
+        reason: "3y total-return Calmar=1.85 > high threshold 0.75 (mode scale 0.75)",
+        kind: "reward",
+        addition: 0.03,
+      },
+    ];
+    const [penalty, reward] = toScoreChips(items);
+
+    expect(penalty).toMatchObject({
+      label: "High realized volatility",
+      delta: "−0.04", // U+2212 MINUS, not a hyphen
+      tone: "risk",
+      title: "3y annualized vol=0.71 > 0.60",
+    });
+    expect(reward).toMatchObject({
+      label: "Strong Calmar",
+      delta: "+0.03",
+      tone: "ok",
+    });
+  });
+
+  it("renders a magnitude-less entry as a label rather than 'NaN' or nothing", () => {
+    const [chip] = toScoreChips([{ name: "wide_spread", reason: "spread flag set" }]);
+    expect(chip?.label).toBe("Wide spread");
+    expect(chip?.delta).toBe("");
+    expect(chip?.tone).toBe("risk");
+  });
+
+  it("keys chips uniquely so a repeated scorer name cannot collide", () => {
+    const chips = toScoreChips([
+      { name: "deep_drawdown", reason: "a", kind: "penalty", deduction: 0.02 },
+      { name: "deep_drawdown", reason: "b", kind: "penalty", deduction: 0.03 },
+    ]);
+    expect(new Set(chips.map((c) => c.key)).size).toBe(2);
+  });
+});

--- a/frontend/src/lib/scoreExplanation.ts
+++ b/frontend/src/lib/scoreExplanation.ts
@@ -1,0 +1,100 @@
+/**
+ * Humanize the deterministic scorer's audit output (#1908 PR-4).
+ *
+ * The Verdict tab used to render `scores.explanation` raw — scorer internals
+ * verbatim, e.g.
+ *
+ *   "value: base_value missing; bear_value missing; fundamentals fallback
+ *    (no thesis); penalties fired: high_realized_volatility (total deduction:
+ *    0.04)"
+ *
+ * The penalty/reward half of that string is ALREADY structured on the same
+ * row: `scores.penalties_json` (`app/services/scoring.py::_insert_score`)
+ * carries `{name, deduction|addition, reason, kind}` per entry. So the chips
+ * below are built from the STRUCTURED field — this module never parses the
+ * explanation text. The raw string stays available verbatim, behind an
+ * expander, because it is the audit trail.
+ *
+ * Names are stable identifiers emitted by `_compute_penalties` /
+ * `_realized_risk_penalties` / the Calmar reward. `PENALTY_LABEL` covers the
+ * nine the scorer can emit today; anything new degrades to a de-snake-cased
+ * label rather than disappearing — the scorer is free to add a penalty
+ * without a frontend release.
+ */
+import type { ScorePenaltyItem } from "@/api/types";
+import type { BadgeTone } from "@/components/ui/Badge";
+
+/**
+ * Operator-facing copy per scorer identifier. Sources:
+ * `app/services/scoring.py` — `stale_thesis`, `missing_critical_data`,
+ * `wide_spread`, `high_red_flag`, `extreme_dilution`, `low_confidence`
+ * (`_compute_penalties`); `high_realized_volatility`, `deep_drawdown`
+ * (`_realized_risk_penalties`, v1.2+); `strong_calmar` (v1.3+ reward).
+ */
+const PENALTY_LABEL: Record<string, string> = {
+  stale_thesis: "Stale thesis",
+  missing_critical_data: "Missing critical data",
+  wide_spread: "Wide spread",
+  high_red_flag: "High red-flag score",
+  extreme_dilution: "Extreme dilution",
+  low_confidence: "Low thesis confidence",
+  high_realized_volatility: "High realized volatility",
+  deep_drawdown: "Deep drawdown",
+  strong_calmar: "Strong Calmar",
+};
+
+/**
+ * Reward vs penalty. `kind` is authoritative when present; rows written before
+ * #1635 have no `kind` at all and are penalties, so fall back to "carries an
+ * `addition`" rather than assuming either way.
+ */
+export function isReward(item: ScorePenaltyItem): boolean {
+  if (item.kind === "reward") return true;
+  if (item.kind === "penalty") return false;
+  return typeof item.addition === "number";
+}
+
+/** `high_realized_volatility` → "High realized volatility". */
+export function humanizePenaltyName(name: string): string {
+  const known = PENALTY_LABEL[name];
+  if (known !== undefined) return known;
+  const words = name.replace(/_/g, " ").trim();
+  if (words === "") return name;
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+export interface ScoreChip {
+  /** React key — the scorer name, unique per row in practice. */
+  readonly key: string;
+  readonly label: string;
+  /** Signed magnitude, e.g. "−0.04" / "+0.03". Empty when neither
+   *  magnitude is present (a malformed row still renders its label). */
+  readonly delta: string;
+  readonly tone: BadgeTone;
+  /** The scorer's own `reason` — surfaced on hover, not truncated. */
+  readonly title: string;
+}
+
+/**
+ * Structured penalties/rewards → chips. Rewards read `ok`, penalties `risk`.
+ *
+ * Uses U+2212 MINUS for the deduction (not a hyphen) so the sign aligns in a
+ * tabular-nums row and cannot be misread as a dash.
+ */
+export function toScoreChips(items: ScorePenaltyItem[] | null): ScoreChip[] {
+  if (items === null) return [];
+  return items.map((item, i) => {
+    const reward = isReward(item);
+    const magnitude = reward ? item.addition : item.deduction;
+    return {
+      key: `${item.name}-${i}`,
+      label: humanizePenaltyName(item.name),
+      delta:
+        typeof magnitude === "number"
+          ? `${reward ? "+" : "−"}${Math.abs(magnitude).toFixed(2)}`
+          : "",
+      tone: reward ? ("ok" as BadgeTone) : ("risk" as BadgeTone),
+      title: item.reason,
+    };
+  });
+}


### PR DESCRIPTION
Refs #1908.

Visual v2 sub-PR 4. Fixes issue item 5: **"Raw debug strings in UI"** — the Verdict tab rendered `scores.explanation` verbatim, e.g.

> value: base_value missing; bear_value missing; fundamentals fallback (no thesis); penalties fired: high_realized_volatility (total deduction: 0.04)

## Premise corrected: no string parsing needed

The ticket (and my own proposal doc) framed this as *parse the explanation into chips*. Grepping the write path falsified that framing — **the penalty/reward half of that string is already structured on the same row.**

`app/services/scoring.py:2302-2307` writes one entry per penalty/reward into `scores.penalties_json`:

```
{"name": ..., "deduction": 0.04, "reason": ..., "kind": "penalty"}
{"name": ..., "addition":  0.03, "reason": ..., "kind": "reward"}
```

…and `/verdict` already puts the column on the wire (`app/api/scores.py:718, 751`). So the chips are built from the **structured field**; nothing in this PR parses explanation text. That matters beyond tidiness — a string-parser would silently break the moment the scorer reworded a note.

## What changed

**`api/types.ts`** — `penalties_json` was typed `Record<string, unknown>[] | null` in three interfaces (`RankingItem`, `VerdictScore`, and the score list item), i.e. structurally opaque. Now a documented `ScorePenaltyItem`. `kind` is **optional** on purpose: rows written before #1635 (when rewards were added) carry only `{name, deduction, reason}`.

**`lib/scoreExplanation.ts`** — pure, table-tested:
- `isReward` — `kind` first; falls back to "carries an `addition`" so a kind-less legacy row reads as a penalty rather than being guessed either way.
- `humanizePenaltyName` — curated operator copy for the **9 identifiers the scorer can emit** (`stale_thesis`, `missing_critical_data`, `wide_spread`, `high_red_flag`, `extreme_dilution`, `low_confidence`, `high_realized_volatility`, `deep_drawdown`, `strong_calmar`), with a de-snake-cased fallback so the backend can add a penalty without a frontend release and it still renders.
- `toScoreChips` — signed magnitude using U+2212 MINUS (aligns under `tabular-nums`, cannot be misread as a dash), `risk`/`ok` tone, the scorer's own `reason` carried to `title` for hover.

**`VerdictTab`** — chips row + the raw explanation moved into a collapsed `<details>` labelled "Scorer detail". **The audit string is preserved verbatim, not reworded or dropped** — it is the audit trail; the point is to stop it being the default read.

## Full-population grounding

Queried the dev DB rather than assuming which names exist. Over the last 2 days of scored rows, `penalties_json` contains exactly six distinct entries, all carrying `kind`:

| kind | name | rows |
|---|---|---|
| reward | strong_calmar | 3912 |
| penalty | deep_drawdown | 3656 |
| penalty | high_realized_volatility | 3464 |
| penalty | extreme_dilution | 2038 |
| penalty | high_red_flag | 1516 |
| penalty | low_confidence | 761 |

The label map covers those six plus the three the scorer can emit but that did not fire in the window (`stale_thesis`, `missing_critical_data`, `wide_spread`).

## Verification

- `pnpm typecheck` — clean.
- `pnpm test:unit` — **132 files / 1408 tests pass**. New: 9 pure tests on `scoreExplanation` (kind-first reward detection, legacy kind-less row → penalty, curated + fallback labels, U+2212 sign, magnitude-less entry renders its label instead of `NaN`, unique chip keys) + 2 `VerdictTab` render tests (chips render humanized/signed/with hover reason; raw string still present inside a **closed** `<details>`; no-penalties row renders no chips but keeps the expander).
- `pnpm dark:check` — 381 files, no violations.
- Pre-push gate green; Codex checkpoint-2 (`codex exec review --base origin/main`) — no findings.
- **Live FE-QA — AKTX (`instrument_id` 1050391, the 6-entry row), `/instrument/AKTX?tab=verdict`**: renders `High red-flag score −0.10`, `Extreme dilution −0.10`, `Low thesis confidence −0.10`, `High realized volatility −0.08`, `Deep drawdown −0.04`, `Strong Calmar +0.06`, with the raw explanation collapsed under "Scorer detail". The two console 404s on that page are a pre-existing `/segments?axis=business` gap for AKTX, not from this change.

No backend, API, or schema changes — read-side only, on a column that has been populated since #1635.