### PR TITLE
feat(#1908): chart residuals — theme literals, drawdown 0-anchor, volume badge in the price axis (visual v2 PR-3)

### DIFF
--- a/frontend/src/components/instrument/OwnershipSunburst.tsx
+++ b/frontend/src/components/instrument/OwnershipSunburst.tsx
@@ -241,6 +241,12 @@ const SUNBURST_STYLES = [
   // slate-400 outline reads on both light (white) and dark
   // (slate-950) backgrounds. Default ``currentColor`` defaults to
   // black — invisible on dark mode.
+  //
+  // This ONE literal cannot read `chartTheme`: `SUNBURST_STYLES` is a
+  // module-level string injected as a <style> block, outside React, and
+  // importing `lightTheme` directly is forbidden (operator-ui-conventions).
+  // It is deliberately the same value as `chartTheme.textMuted` in the light
+  // palette — if that slot moves, move this with it (#1908 PR-3).
   ".ownership-sunburst .recharts-pie-sector:has(path[data-known='true']) path:focus-visible {",
   "  outline: 2px solid #94a3b8;",
   "  outline-offset: -1px;",
@@ -336,7 +342,15 @@ export function OwnershipSunburst({
             patternUnits="userSpaceOnUse"
             patternTransform="rotate(45)"
           >
-            <line x1={0} y1={0} x2={0} y2={6} stroke="#94a3b8" strokeOpacity={0.45} strokeWidth={1.2} />
+            <line
+              x1={0}
+              y1={0}
+              x2={0}
+              y2={6}
+              stroke={theme.textMuted}
+              strokeOpacity={0.45}
+              strokeWidth={1.2}
+            />
           </pattern>
         </defs>
       </svg>

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -577,6 +577,14 @@ export function ChartCanvas({
     const volume = chart.addSeries(HistogramSeries, {
       priceScaleId: "volume",
       priceFormat: { type: "volume" },
+      // The volume overlay must NOT draw a last-value badge or price line
+      // (#1908 PR-3). It lives on its own `volume` scale, but lightweight-charts
+      // still paints those onto the VISIBLE right price gutter, where they land
+      // on top of the price ticks — a volume figure rendered in the price axis.
+      // Every sibling series in this file already disables both; the volume
+      // series was the one left on the library defaults.
+      lastValueVisible: false,
+      priceLineVisible: false,
     });
     chart
       .priceScale("volume")

--- a/frontend/src/components/risk/riskCharts.test.tsx
+++ b/frontend/src/components/risk/riskCharts.test.tsx
@@ -17,7 +17,10 @@ describe("drawdownDomainMin", () => {
     expect(drawdownDomainMin(0)).toBe(0);
   });
 
-  it("never lifts the axis above the peak line, even on a bad positive row", () => {
+  it("still returns 0 as the LOWER bound when a malformed row makes even the minimum positive", () => {
+    // Note this is only the lower bound. The `0` upper bound is deliberately
+    // left expandable (no `allowDataOverflow`), so such a row shows up as a
+    // visible anomaly above the peak line rather than being clipped away.
     expect(drawdownDomainMin(0.05)).toBe(0);
   });
 });

--- a/frontend/src/components/risk/riskCharts.test.tsx
+++ b/frontend/src/components/risk/riskCharts.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { drawdownDomainMin } from "@/components/risk/riskCharts";
+
+describe("drawdownDomainMin", () => {
+  it("keeps 0 as the top of the axis for a shallow series (the #1908 clipping bug)", () => {
+    // Before: recharts' auto-domain fitted [-0.02, -0.002] and the peak line
+    // at 0 fell off the top of the chart.
+    expect(drawdownDomainMin(-0.02)).toBe(-0.02);
+  });
+
+  it("does not clip a deep drawdown", () => {
+    expect(drawdownDomainMin(-0.743)).toBe(-0.743);
+  });
+
+  it("holds the anchor at 0 for a series that never drew down", () => {
+    expect(drawdownDomainMin(0)).toBe(0);
+  });
+
+  it("never lifts the axis above the peak line, even on a bad positive row", () => {
+    expect(drawdownDomainMin(0.05)).toBe(0);
+  });
+});

--- a/frontend/src/components/risk/riskCharts.tsx
+++ b/frontend/src/components/risk/riskCharts.tsx
@@ -104,14 +104,18 @@ export interface UnderwaterProps {
  * Lower bound of the drawdown y-axis (#1908 PR-3).
  *
  * Drawdown is ≤ 0 by construction and is read AGAINST the peak, so 0 is the
- * anchor the whole series is measured from and must always be the TOP of the
- * axis. Recharts' auto-domain fits `[dataMin, dataMax]` instead: a series whose
+ * anchor the whole series is measured from and belongs at the TOP of the axis.
+ * Recharts' auto-domain fits `[dataMin, dataMax]` instead: a series whose
  * shallowest point is −2% renders with the axis topping out at −2%, which both
  * pushes the `ReferenceLine y={0}` off-chart AND rescales the shape so a mild
  * drawdown looks as deep as a severe one.
  *
- * Clamps at 0 defensively — a positive value (a bad row) must never lift the
- * axis above the peak line.
+ * The `0` upper bound is NOT paired with `allowDataOverflow` on purpose. A
+ * numeric domain entry in recharts is expanded to cover the data unless that
+ * flag is set, so a malformed POSITIVE row would still push the axis above 0 —
+ * and that is the behaviour we want: an impossible drawdown should be visible
+ * as an anomaly, not silently clipped out of the viewport. For every
+ * well-formed series (all values ≤ 0) `dataMax` is 0 and the anchor holds.
  */
 export function drawdownDomainMin(dataMin: number): number {
   return Math.min(dataMin, 0);

--- a/frontend/src/components/risk/riskCharts.tsx
+++ b/frontend/src/components/risk/riskCharts.tsx
@@ -100,6 +100,23 @@ export interface UnderwaterProps {
   readonly points: ReadonlyArray<DrawdownPoint>;
 }
 
+/**
+ * Lower bound of the drawdown y-axis (#1908 PR-3).
+ *
+ * Drawdown is ≤ 0 by construction and is read AGAINST the peak, so 0 is the
+ * anchor the whole series is measured from and must always be the TOP of the
+ * axis. Recharts' auto-domain fits `[dataMin, dataMax]` instead: a series whose
+ * shallowest point is −2% renders with the axis topping out at −2%, which both
+ * pushes the `ReferenceLine y={0}` off-chart AND rescales the shape so a mild
+ * drawdown looks as deep as a severe one.
+ *
+ * Clamps at 0 defensively — a positive value (a bad row) must never lift the
+ * axis above the peak line.
+ */
+export function drawdownDomainMin(dataMin: number): number {
+  return Math.min(dataMin, 0);
+}
+
 export function UnderwaterChart({ points }: UnderwaterProps): JSX.Element {
   const theme = useChartTheme();
   const data = points
@@ -120,7 +137,9 @@ export function UnderwaterChart({ points }: UnderwaterProps): JSX.Element {
             minTickGap={28}
             {...sharedAxis(theme)}
           />
+          {/* Pin the top of the axis to 0 (#1908 PR-3) — see drawdownDomainMin. */}
           <YAxis
+            domain={[drawdownDomainMin, 0]}
             tickFormatter={(v: number) => pct(v, 0)}
             width={48}
             {...sharedAxis(theme)}

--- a/frontend/src/pages/ChartPage.tsx
+++ b/frontend/src/pages/ChartPage.tsx
@@ -38,6 +38,7 @@ import {
   type NormalisedChartCandles,
 } from "@/lib/chartData";
 import { useAsync } from "@/lib/useAsync";
+import { useChartTheme } from "@/lib/useChartTheme";
 
 const RANGES: { id: ChartRange; label: string }[] = [
   { id: "1d", label: "1D" },
@@ -72,12 +73,10 @@ const INDICATOR_LABELS: Record<IndicatorId, string> = {
   ema50: "EMA 50",
 };
 
-const INDICATOR_COLORS: Record<IndicatorId, string> = {
-  sma20: "#3b82f6",
-  sma50: "#a855f7",
-  ema20: "#0ea5e9",
-  ema50: "#ec4899",
-};
+// Indicator swatches are NOT declared here — they are `chartTheme.indicator.*`
+// (#1908 PR-3). This file used to re-declare the same four hex values, so the
+// toggle button and the line it draws could drift apart on a palette change,
+// with nothing to catch it. Read them from `useChartTheme()` at the call site.
 
 const MAX_COMPARES = 3;
 
@@ -92,6 +91,10 @@ function parseNum(v: string | null | undefined): number | null {
 
 export function ChartPage(): JSX.Element {
   const { symbol = "" } = useParams<{ symbol: string }>();
+  // Indicator swatches come from the resolved theme, never a local literal —
+  // the toggle button and the plotted line must be the same colour by
+  // construction (#1908 PR-3).
+  const chartTheme = useChartTheme();
   const [searchParams, setSearchParams] = useSearchParams();
 
   // Range param
@@ -457,8 +460,11 @@ export function ChartPage(): JSX.Element {
                   }`}
                   style={
                     active
-                      ? { borderColor: INDICATOR_COLORS[id], color: INDICATOR_COLORS[id] }
-                      : { borderColor: "#e2e8f0" }
+                      ? {
+                          borderColor: chartTheme.indicator[id],
+                          color: chartTheme.indicator[id],
+                        }
+                      : { borderColor: chartTheme.borderColor }
                   }
                   data-testid={`indicator-${id}`}
                 >

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -314,6 +314,14 @@ export function ChartWorkspaceCanvas({
     const volume = chart.addSeries(HistogramSeries, {
       priceScaleId: "volume",
       priceFormat: { type: "volume" },
+      // The volume overlay must NOT draw a last-value badge or price line
+      // (#1908 PR-3). It lives on its own `volume` scale, but lightweight-charts
+      // still paints those onto the VISIBLE right price gutter, where they land
+      // on top of the price ticks — a volume figure rendered in the price axis.
+      // Every sibling series in this file already disables both; the volume
+      // series was the one left on the library defaults.
+      lastValueVisible: false,
+      priceLineVisible: false,
     });
     chart.priceScale("volume").applyOptions({ scaleMargins: { top: 0.75, bottom: 0 } });
 


### PR DESCRIPTION
Refs #1908.

Visual v2 sub-PR 3. Issue item 3 ("charts read budget") was specced as "one chartTheme pass — charts have no shared tokens". **Grepping falsified that premise:** `frontend/src/lib/chartTheme.ts` already exists, carries both palettes, exposes `useChartTheme()`, and is honoured almost everywhere. So this PR is re-scoped to the four specific defects that were actually left.

## 1. `ChartPage` re-declared colours the theme already owns

`pages/ChartPage.tsx` held a private `INDICATOR_COLORS` map whose four hex values were byte-identical to `chartTheme.indicator.*`, plus a stray `#e2e8f0` for the inactive border (= `theme.borderColor`). The toggle button's swatch and the line it actually draws were therefore two independent sources — a palette change moves one and not the other, and nothing catches it. Both now read `useChartTheme()`.

## 2. `OwnershipSunburst` — one literal themed, one documented

The hatch-pattern stroke now reads `theme.textMuted`. Its sibling inside `SUNBURST_STYLES` genuinely **cannot** be themed: that is a module-level string injected as a `<style>` block, outside React, and importing `lightTheme` directly is forbidden by `operator-ui-conventions.md`. Rather than fake it, the literal is documented as deliberately tracking the `textMuted` slot so a palette change knows to move it.

## 3. The drawdown chart clipped its own zero anchor

Drawdown is <= 0 by construction and is read AGAINST the peak, so 0 is the anchor the entire series is measured from. Recharts' auto-domain fits `[dataMin, dataMax]`, so a series whose shallowest point is -2% rendered with the axis topping out at -2%. Two consequences: the `ReferenceLine y={0}` fell off the top of the chart, and the shape was silently rescaled so a mild drawdown looked as deep as a severe one.

The lower bound is now `drawdownDomainMin` — pure and table-tested.

**Codex checkpoint-2 caught an overclaim here and it is worth recording.** My first version documented the `0` upper bound as "clamps a bad positive row". That is false: recharts expands a numeric domain entry to cover the data unless `allowDataOverflow` is set. The fix was to the *claim*, not the code — keeping the bound expandable is the behaviour we want, because an impossible positive drawdown should be **visible as an anomaly, not clipped out of the viewport**. For every well-formed series `dataMax` is 0 and the anchor holds.

## 4. A volume figure was being painted into the price axis

The volume histogram was the only series in either chart file left on the library's default `lastValueVisible` / `priceLineVisible` — every sibling series in both files already disables them. lightweight-charts draws those onto the **visible right price gutter** even though the volume series lives on its own scale.

Verified live on `/instrument/AAPL/chart?range=1y`, by screenshotting the price gutter with and without the change:

- **before** — a `7.1K` badge sits at the bottom of the price axis, on top of the `200.00` price tick
- **after** — only the price badge (`332.95`) remains

Fixed in both `ChartWorkspaceCanvas` and `PriceChart`.

## Deliberately not in this PR

Both are filed rather than half-done:

- **TradingView attribution restyle.** The licence requires attribution; "restyle placement/size within licence" is a licence-terms question, not a code decision, and I am not going to guess at what the licence permits.
- **Sparkline last-value labels / min-height.** A feature addition (new props + render path), not a residual.

## Verification

- `pnpm typecheck` — clean.
- `pnpm test:unit` — **133 files / 1412 tests pass**, including 4 new table tests on `drawdownDomainMin` (shallow series keeps the 0 top, deep series is not clipped, flat series, malformed positive row).
- `pnpm dark:check` — 382 files, no violations.
- Pre-push gate green.
- Codex checkpoint-2 — one P2 finding (the domain overclaim above), fixed before push.
- Live FE-QA on AAPL 1Y as described, 0 console errors.

No backend, API, or schema changes.
