### PR TITLE
feat(#2144): auto-reload the dev jobs daemon on source change

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -103,7 +103,7 @@
       "label": "stack: jobs",
       "type": "shell",
       "windows": {
-        "command": "Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'python.exe' -and $_.CommandLine -match 'app\\.jobs' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }; uv run python -m app.jobs",
+        "command": "Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'python.exe' -and $_.CommandLine -match 'app\\.jobs' } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }; uv run python -m app.jobs.dev_reload",
         "options": {
           "shell": {
             "executable": "pwsh",
@@ -112,10 +112,10 @@
         }
       },
       "osx": {
-        "command": "pgrep -f '[p]ython3 -m app.jobs($|[[:space:]])' | xargs kill -9 2>/dev/null; uv run python -m app.jobs"
+        "command": "pgrep -f '[p]ython3 -m app\\.jobs(\\.dev_reload)?($|[[:space:]])' | xargs kill -9 2>/dev/null; uv run python -m app.jobs.dev_reload"
       },
       "linux": {
-        "command": "pgrep -f '[p]ython3 -m app.jobs($|[[:space:]])' | xargs kill -9 2>/dev/null; uv run python -m app.jobs"
+        "command": "pgrep -f '[p]ython3 -m app\\.jobs(\\.dev_reload)?($|[[:space:]])' | xargs kill -9 2>/dev/null; uv run python -m app.jobs.dev_reload"
       },
       "isBackground": true,
       "presentation": {

--- a/app/config.py
+++ b/app/config.py
@@ -30,6 +30,14 @@ _MIN_SERVICE_TOKEN_LEN = 32
 DB_CONNECT_TIMEOUT_S = 10
 os.environ.setdefault("PGCONNECT_TIMEOUT", str(DB_CONNECT_TIMEOUT_S))
 
+# --- dev-like environments (single source) --------------------------------
+# The set of ``app_env`` values that count as "a developer's machine".
+# Allowlist, NOT a denylist on "prod": a future ``staging`` / ``qa`` / ``uat``
+# must be treated as production-like by default and never silently get a
+# dev-only affordance (debug routers, test-DB reaping, jobs auto-reload).
+# Add a new env here explicitly when it genuinely needs one.
+DEV_LIKE_ENVS: frozenset[str] = frozenset({"dev", "test", "local"})
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")

--- a/app/db/dev_test_db_reaper.py
+++ b/app/db/dev_test_db_reaper.py
@@ -68,7 +68,7 @@ import psycopg.errors
 import psycopg.rows
 from psycopg import sql
 
-from app.config import settings
+from app.config import DEV_LIKE_ENVS, settings
 
 logger = logging.getLogger(__name__)
 
@@ -217,8 +217,8 @@ def _do_sweep(*, min_age: timedelta, now: datetime | None, admin_url: str | None
 # Dev-like environments where reaping leaked test DBs is appropriate. A
 # production jobs process (app_env="prod") must NEVER connect to the admin
 # DB to reap test databases — there are none there, and the intent must be
-# unambiguous to a reviewer.
-_DEV_LIKE_ENVS: frozenset[str] = frozenset({"dev", "test", "local"})
+# unambiguous to a reviewer. The set itself lives in app.config as the
+# single source shared with the debug-router gate and the jobs auto-reloader.
 
 
 @dataclass(frozen=True)
@@ -248,7 +248,7 @@ def run_orphan_test_db_reap(
     the next crash-recovery fsync pass (#1444). Best-effort — the
     underlying reapers swallow operational failures.
     """
-    if settings.app_env not in _DEV_LIKE_ENVS:
+    if settings.app_env not in DEV_LIKE_ENVS:
         logger.info("orphan test-DB reap skipped: app_env=%s", settings.app_env)
         return ReapResult(skipped=True)
     invalid = force_drop_invalid_test_dbs(admin_url=admin_url)

--- a/app/jobs/dev_reload.py
+++ b/app/jobs/dev_reload.py
@@ -1,0 +1,251 @@
+"""Dev-only auto-reload supervisor for the jobs daemon (#2144).
+
+Runs as ``python -m app.jobs.dev_reload``. Watches ``app/**/*.py`` and
+restarts the real jobs daemon (``python -m app.jobs``, spawned as a child
+process) whenever a source file changes — so a merge to a scheduler /
+ingest / parser / derivation module goes live without the operator
+manually restarting the VS Code ``stack: jobs`` task. Mirrors what
+uvicorn ``--reload`` already gives the API process.
+
+Outside a dev-like ``app_env`` this module is a pass-through: it logs
+once and runs ``app.jobs.__main__.main()`` IN-PROCESS, so pointing a
+production launcher at it changes nothing — no watcher, no extra
+process, no behavioural delta.
+
+Why a hand-rolled supervisor and not ``watchfiles.run_process``
+--------------------------------------------------------------
+``run_process`` caps shutdown at ``sigint_timeout=5`` + ``sigkill_timeout=1``
+— six seconds, then SIGKILL. The jobs daemon's graceful drain routinely
+runs past two minutes (it waits for in-flight syncs/ingests to finish),
+so ``run_process`` would hard-kill mid-job on every reload. #2144
+explicitly requires the SIGTERM drain semantics stay intact, so we drive
+the child's lifecycle ourselves and only escalate to SIGKILL after
+``_DRAIN_TIMEOUT_S``. We still use watchfiles for the file watching —
+it is already resolved in ``uv.lock`` as a ``uvicorn[standard]`` extra.
+
+Singleton-fence ordering (load-bearing)
+---------------------------------------
+The daemon acquires a Postgres advisory lock as a singleton fence and
+FATAL-exits at boot if it is already held (``app/jobs/__main__.py``
+step 3). A restart must therefore be strictly sequential: the old child
+is fully reaped — releasing the lock — BEFORE the replacement is
+spawned. Never spawn-then-kill. After a SIGKILL escalation we also
+settle for ``_POST_KILL_SETTLE_S`` so Postgres notices the dead session
+and drops the lock, mirroring ``stack-restart.sh``'s ``kill_jobs_process``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Final
+
+from app.config import DEV_LIKE_ENVS, settings
+
+logger = logging.getLogger(__name__)
+
+# Repo root: app/jobs/dev_reload.py -> app/jobs -> app -> <repo root>.
+_APP_DIR: Final[Path] = Path(__file__).resolve().parents[1]
+_REPO_ROOT: Final[Path] = _APP_DIR.parent
+
+# How long to let the child drain after SIGTERM before escalating to
+# SIGKILL. The daemon's own shutdown waits on in-flight jobs; observed
+# drains have exceeded two minutes, so three is the escalation floor
+# rather than a target (a healthy idle daemon exits in well under a
+# second).
+_DRAIN_TIMEOUT_S: Final[float] = 180.0
+
+# Bound on reaping the corpse after SIGKILL — a killed process is
+# already gone; this only covers the wait() round-trip.
+_KILL_REAP_TIMEOUT_S: Final[float] = 10.0
+
+# After a SIGKILL the fence connection is closed by the OS, not by the
+# daemon, so Postgres only drops the advisory lock once it notices the
+# dead session. Same one-second settle stack-restart.sh uses.
+_POST_KILL_SETTLE_S: Final[float] = 1.0
+
+# Watcher tick. watchfiles yields an empty set on timeout (with
+# yield_on_timeout=True), which is how we poll for child death and for
+# our own stop_event without a second thread.
+_WATCH_TICK_MS: Final[int] = 1000
+
+_CHILD_ARGV: Final[list[str]] = [sys.executable, "-m", "app.jobs"]
+
+
+def changes_are_stale(paths: Iterable[str], spawn_time: float) -> bool:
+    """True when every changed path was last modified before ``spawn_time``.
+
+    The rust watcher keeps collecting while we block on a drain, so the
+    batch delivered right after a restart usually replays the very edits
+    that *caused* it. The child we just spawned already read those files,
+    so restarting again would be pure cost (another full drain).
+
+    A path that no longer exists is NOT treated as stale (Codex pre-push
+    review). A deletion has no mtime to compare, so suppressing on it
+    would silently skip the reload for a deleted or renamed module — the
+    daemon would keep running the old code until some unrelated edit
+    happened to land. Deletions are rare next to edits, so forcing a
+    reload costs at most one redundant restart while the suppression
+    still does its job on the common edit path. Running stale code
+    silently is the worse failure.
+
+    An empty batch is NOT stale either: callers use empty batches as the
+    watcher's idle tick, and they must not be mistaken for a suppressed
+    reload.
+    """
+    paths = list(paths)
+    if not paths:
+        return False
+    for raw in paths:
+        try:
+            if os.stat(raw).st_mtime > spawn_time:
+                return False
+        except OSError:
+            return False
+    return True
+
+
+def _spawn_child() -> subprocess.Popen[bytes]:
+    logger.info("jobs dev-reload: starting %s", " ".join(_CHILD_ARGV))
+    return subprocess.Popen(_CHILD_ARGV, cwd=_REPO_ROOT)
+
+
+def _stop_child(proc: subprocess.Popen[bytes]) -> None:
+    """SIGTERM the child and WAIT for it to die, escalating if it hangs.
+
+    Returns only once the process has been reaped, so the caller is safe
+    to spawn a replacement (see the singleton-fence note above).
+    """
+    if proc.poll() is not None:
+        return
+    logger.info("jobs dev-reload: SIGTERM -> pid %d, draining (max %.0fs)", proc.pid, _DRAIN_TIMEOUT_S)
+    started = time.monotonic()
+    try:
+        proc.send_signal(signal.SIGTERM)
+    except ProcessLookupError:
+        proc.wait()
+        return
+    try:
+        proc.wait(timeout=_DRAIN_TIMEOUT_S)
+        logger.info("jobs dev-reload: drained cleanly in %.1fs", time.monotonic() - started)
+        return
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "jobs dev-reload: pid %d still draining after %.0fs — escalating to SIGKILL",
+            proc.pid,
+            _DRAIN_TIMEOUT_S,
+        )
+    proc.kill()
+    try:
+        proc.wait(timeout=_KILL_REAP_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        logger.error("jobs dev-reload: pid %d unreaped after SIGKILL", proc.pid)
+    time.sleep(_POST_KILL_SETTLE_S)
+
+
+def _supervise() -> int:
+    # Imported lazily, INSIDE the dev-only path: watchfiles reaches us as a
+    # `uvicorn[standard]` extra (and is declared in the dev dependency-group
+    # for the direct import), so the non-dev pass-through in main() must not
+    # depend on it being installed.
+    from watchfiles import PythonFilter, watch
+
+    stop_event = threading.Event()
+
+    def _handler(signum: int, _frame: object) -> None:
+        logger.info("jobs dev-reload: received signal %d, shutting down", signum)
+        stop_event.set()
+
+    for name in ("SIGTERM", "SIGINT", "SIGBREAK"):
+        sig = getattr(signal, name, None)
+        if sig is not None:
+            try:
+                signal.signal(sig, _handler)
+            except ValueError, OSError:
+                logger.debug("jobs dev-reload: signal %s not registrable on this platform", name)
+
+    logger.info("jobs dev-reload: watching %s for *.py changes", _APP_DIR)
+    child = _spawn_child()
+    spawn_time = time.time()
+    crash_reported = False
+
+    try:
+        for changes in watch(
+            _APP_DIR,
+            watch_filter=PythonFilter(),
+            stop_event=stop_event,
+            rust_timeout=_WATCH_TICK_MS,
+            yield_on_timeout=True,
+            raise_interrupt=False,
+        ):
+            if stop_event.is_set():
+                break
+
+            if not changes:
+                # Idle tick — the only place we notice the child dying on
+                # its own. A clean exit means somebody stopped the daemon
+                # deliberately, so we stop too. A crash (bad import after a
+                # merge, unhandled boot error) leaves the supervisor alive
+                # so the next edit can bring it back without the operator
+                # re-running the task.
+                code = child.poll()
+                if code is None:
+                    continue
+                if code == 0:
+                    logger.info("jobs dev-reload: child exited 0; supervisor exiting")
+                    return 0
+                if not crash_reported:
+                    # Once per crash, not once per tick.
+                    crash_reported = True
+                    logger.error(
+                        "jobs dev-reload: child exited %d — staying up; next *.py change will respawn",
+                        code,
+                    )
+                continue
+
+            paths = [path for _change, path in changes]
+            if changes_are_stale(paths, spawn_time):
+                logger.debug("jobs dev-reload: ignoring %d change(s) older than the running child", len(paths))
+                continue
+
+            logger.info("jobs dev-reload: %d change(s), e.g. %s — reloading", len(paths), paths[0])
+            _stop_child(child)
+            if stop_event.is_set():
+                return 0
+            child = _spawn_child()
+            spawn_time = time.time()
+            crash_reported = False
+    finally:
+        _stop_child(child)
+
+    return 0
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    if settings.app_env not in DEV_LIKE_ENVS:
+        # Pass-through: identical to `python -m app.jobs`, no watcher and
+        # no supervising process. Keeps this module safe to wire into any
+        # launcher without branching per environment.
+        from app.jobs.__main__ import serve
+
+        logger.info(
+            "jobs dev-reload: app_env=%s is not dev-like — auto-reload OFF, running daemon in-process",
+            settings.app_env,
+        )
+        sys.exit(serve())
+    sys.exit(_supervise())
+
+
+if __name__ == "__main__":
+    main()

--- a/app/jobs/dev_reload.py
+++ b/app/jobs/dev_reload.py
@@ -112,9 +112,20 @@ def changes_are_stale(paths: Iterable[str], spawn_time: float) -> bool:
     return True
 
 
-def _spawn_child() -> subprocess.Popen[bytes]:
+def _spawn_child() -> tuple[subprocess.Popen[bytes], float]:
+    """Spawn the daemon, returning it with the wall-time it was started.
+
+    The timestamp is taken BEFORE ``Popen`` (review nitpick on PR #2156).
+    Reading it afterwards would place it slightly late, so an edit landing
+    in the fork/exec window would compare as older than the child and be
+    suppressed — the daemon would then run code it never read. Sampling
+    early biases the other way: such an edit reads as newer and forces one
+    extra reload. Same principle as the deleted-path case — a redundant
+    restart is always preferable to silently-stale code.
+    """
     logger.info("jobs dev-reload: starting %s", " ".join(_CHILD_ARGV))
-    return subprocess.Popen(_CHILD_ARGV, cwd=_REPO_ROOT)
+    spawn_time = time.time()
+    return subprocess.Popen(_CHILD_ARGV, cwd=_REPO_ROOT), spawn_time
 
 
 def _stop_child(proc: subprocess.Popen[bytes]) -> None:
@@ -172,8 +183,7 @@ def _supervise() -> int:
                 logger.debug("jobs dev-reload: signal %s not registrable on this platform", name)
 
     logger.info("jobs dev-reload: watching %s for *.py changes", _APP_DIR)
-    child = _spawn_child()
-    spawn_time = time.time()
+    child, spawn_time = _spawn_child()
     crash_reported = False
 
     try:
@@ -219,8 +229,7 @@ def _supervise() -> int:
             _stop_child(child)
             if stop_event.is_set():
                 return 0
-            child = _spawn_child()
-            spawn_time = time.time()
+            child, spawn_time = _spawn_child()
             crash_reported = False
     finally:
         _stop_child(child)

--- a/app/main.py
+++ b/app/main.py
@@ -60,7 +60,7 @@ from app.api.tax import router as tax_router
 from app.api.theses import instrument_thesis_router
 from app.api.theses import router as theses_router
 from app.api.watchlist import router as watchlist_router
-from app.config import settings
+from app.config import DEV_LIKE_ENVS, settings
 from app.db import get_conn
 from app.db.migrations import migration_status, run_migrations
 from app.db.pg_settings import API_CREDENTIAL_HEALTH_LISTENER_APPLICATION_NAME
@@ -539,7 +539,7 @@ app.include_router(fundamentals_admin_router)  # #677 fundamentals force-refresh
 # environments like `staging`/`qa`/`uat` are denied by default and
 # never silently expose operator credentials. Add new envs here
 # explicitly when they need diagnostic access. PR #610 review.
-if settings.app_env in {"dev", "test", "local"}:
+if settings.app_env in DEV_LIKE_ENVS:
     app.include_router(debug_ws_router)
 app.include_router(capability_overrides_admin_router)
 app.include_router(filings_router)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ dev = [
   # calls when the sidecar is populated. respx mocks httpx at the
   # transport layer — smallest primitive that satisfies the contract.
   "respx>=0.21",
+  # #2144: app/jobs/dev_reload.py imports watchfiles DIRECTLY for the
+  # dev-only jobs-daemon auto-reload. It already resolves transitively as a
+  # `uvicorn[standard]` extra (uv.lock pins 1.1.1) — declared here so a
+  # direct import is not leaning on somebody else's transitive dep, and in
+  # the dev group because the import is lazy inside the dev-only path.
+  "watchfiles>=1.0",
 ]
 
 [tool.ruff]

--- a/scripts/autonomy/com.ebull.jobs-daemon.plist
+++ b/scripts/autonomy/com.ebull.jobs-daemon.plist
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  launchd LaunchAgent for the JOBS DAEMON (the ETL / ingest + scheduler runner,
-  `python -m app.jobs`). Independent of the autonomy loop supervisor — this keeps
+  launchd LaunchAgent for the JOBS DAEMON (the ETL / ingest + scheduler runner).
+  Launches via the `app.jobs.dev_reload` wrapper (#2144), which watches `app/**`
+  and restarts the daemon on source change in a dev-like `app_env`, and is an
+  exact in-process pass-through to `python -m app.jobs` anywhere else — so this
+  plist is unchanged in behaviour outside dev.
+  Independent of the autonomy loop supervisor — this keeps
   DATA fresh unattended (SEC manifest worker, per-CIK poll, orchestrator sync,
   fundamentals, portfolio sync) with the AI loop OFF.
 
@@ -25,7 +29,7 @@
     <string>run</string>
     <string>python</string>
     <string>-m</string>
-    <string>app.jobs</string>
+    <string>app.jobs.dev_reload</string>
   </array>
 
   <key>WorkingDirectory</key>

--- a/stack-restart.sh
+++ b/stack-restart.sh
@@ -145,7 +145,7 @@ if [[ "$jobs" -eq 1 ]]; then
   echo "Restarting jobs process..."
   kill_jobs_process
   start_detached "jobs" \
-    uv run python -m app.jobs
+    uv run python -m app.jobs.dev_reload
 fi
 
 if [[ "$frontend" -eq 1 ]]; then

--- a/tests/jobs/test_dev_reload.py
+++ b/tests/jobs/test_dev_reload.py
@@ -1,0 +1,61 @@
+"""#2144 — dev jobs-daemon auto-reload: stale-batch suppression.
+
+Pure-logic only (no DB, no subprocess). The one non-obvious decision in
+the supervisor is whether a change batch delivered *after* a restart
+should trigger another restart: the rust watcher keeps buffering while
+we block on a drain, so the batch that lands right after a reload
+usually replays the very edits that caused it, and acting on it costs a
+second full drain for nothing.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from app.jobs.dev_reload import changes_are_stale
+
+
+def _touch(path: Path, mtime: float) -> str:
+    path.write_text("x")
+    os.utime(path, (mtime, mtime))
+    return str(path)
+
+
+def test_empty_batch_is_not_stale() -> None:
+    # The supervisor uses an empty batch as the watcher's idle tick. If it
+    # read as "stale" the caller could confuse a suppressed reload with a
+    # liveness poll.
+    assert changes_are_stale([], spawn_time=1000.0) is False
+
+
+def test_batch_older_than_the_running_child_is_stale(tmp_path: Path) -> None:
+    paths = [
+        _touch(tmp_path / "a.py", 900.0),
+        _touch(tmp_path / "b.py", 950.0),
+    ]
+    assert changes_are_stale(paths, spawn_time=1000.0) is True
+
+
+def test_any_path_newer_than_the_child_forces_a_reload(tmp_path: Path) -> None:
+    paths = [
+        _touch(tmp_path / "a.py", 900.0),
+        _touch(tmp_path / "b.py", 1001.0),
+    ]
+    assert changes_are_stale(paths, spawn_time=1000.0) is False
+
+
+def test_deleted_path_alone_forces_a_reload(tmp_path: Path) -> None:
+    # Codex pre-push review: a deleted/renamed module has no mtime to
+    # compare against, so it must NOT be suppressed — otherwise deleting a
+    # module leaves the daemon running the old code until an unrelated edit
+    # lands. One redundant restart beats silently-stale code.
+    assert changes_are_stale([str(tmp_path / "gone.py")], spawn_time=1000.0) is False
+
+
+def test_deleted_path_does_not_mask_a_newer_sibling(tmp_path: Path) -> None:
+    paths = [
+        str(tmp_path / "gone.py"),
+        _touch(tmp_path / "fresh.py", 1001.0),
+    ]
+    assert changes_are_stale(paths, spawn_time=1000.0) is False

--- a/uv.lock
+++ b/uv.lock
@@ -336,6 +336,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "watchfiles" },
 ]
 
 [package.metadata]
@@ -368,6 +369,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.5" },
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.4.0" },
+    { name = "watchfiles", specifier = ">=1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The jobs daemon (`uv run python -m app.jobs`) is pinned to the working-tree checkout and holds old code until restarted. Every merge touching code the daemon executes — scoring, ingest, parsers, schedulers, fundamentals derivation — needed a **manual restart of the VS Code `stack: jobs` task** before going live. That was the tail step on #2127-P2, #2131, #2117 and #1914.

It is also the one step the agent cannot automate: the daemon is a VS Code task (PPID ≠ 1), not launchd, so `launchctl kickstart` is a no-op. The API process already avoids this via uvicorn `--reload`; the daemon did not.

## What changed

New `app/jobs/dev_reload.py` — a supervisor that watches `app/**/*.py` and restarts the daemon (spawned as a child process) on change. Every launcher now points at it: `.vscode/tasks.json` (`stack: jobs`, all three platforms), `stack-restart.sh`, and `scripts/autonomy/com.ebull.jobs-daemon.plist`.

Also promotes the dev-env allowlist to `app.config.DEV_LIKE_ENVS` as a single source, replacing the duplicate `{"dev", "test", "local"}` literal in `app/db/dev_test_db_reaper.py` and `app/main.py` rather than adding a third copy.

## Why not `watchfiles.run_process`

It is the obvious reuse candidate and it was rejected on evidence. Its shutdown ceiling is `sigint_timeout=5` + `sigkill_timeout=1` — **6 seconds, then SIGKILL**. The daemon's graceful drain waits on in-flight syncs/ingests and routinely exceeds two minutes, so `run_process` would hard-kill mid-job on every reload — exactly what #2144 forbids ("keep single-flight + graceful SIGTERM drain semantics intact"). We drive the child lifecycle ourselves and escalate only after `_DRAIN_TIMEOUT_S = 180`. watchfiles is still used for the watching itself.

## Correctness model

**Singleton-fence ordering (load-bearing).** The daemon acquires a Postgres advisory lock as a singleton fence and FATAL-exits at boot if it is already held (`app/jobs/__main__.py` step 3). A restart is therefore strictly sequential: the old child is fully reaped — releasing the lock — *before* the replacement is spawned. Never spawn-then-kill. After a SIGKILL escalation there is a 1s settle so Postgres notices the dead session, mirroring `stack-restart.sh`'s `kill_jobs_process`.

**Prod is untouched.** Outside a dev-like `app_env`, `main()` is an exact in-process pass-through to `app.jobs.__main__.serve()` — no watcher, no supervising process, no behavioural delta. This is why the launchd plist could be repointed safely. The `watchfiles` import is lazy *inside* the dev-only path, so the pass-through does not depend on watchfiles being installed.

**Crash handling.** A child that exits non-zero (bad import after a merge) leaves the supervisor alive so the next edit brings it back; a clean exit 0 means someone stopped the daemon deliberately, so the supervisor exits too.

## Dependency

`watchfiles` was **already resolved in `uv.lock`** as a `uvicorn[standard]` extra (pinned 1.1.1) — no new package enters the dependency graph. It is now declared explicitly in the dev group because we import it directly rather than leaning on somebody else's transitive dep. `pyproject.toml` and `uv.lock` are both committed.

## Verification

Supervisor mechanics exercised end-to-end against a stub child, isolated from the live daemon's singleton fence:

| Path | Result |
|---|---|
| Boot | child spawned |
| `.py` change → reload | `SIGTERM -> pid 98907` → `drained cleanly in 2.0s` → new child `99092` spawned 54 ms later (sequential, no overlap) |
| Graceful drain honoured | stub's SIGTERM handler ran its full simulated drain; **not** killed |
| 5-file burst | coalesced into **one** reload (`5 change(s) … reloading`) — a merge writing N files causes 1 restart, not N |
| SIGKILL escalation | stubborn child ignoring SIGTERM: `still draining after 3s — escalating to SIGKILL`, respawn exactly 1.0s later (the `_POST_KILL_SETTLE_S` fence settle) |
| Supervisor SIGTERM | child drained, exit 0, **no stray processes** |

Pure-logic tests for the stale-batch suppression rule: `tests/jobs/test_dev_reload.py` (5 tests, passing).

Gates: `ruff check` / `ruff format --check` / `pyright` clean; `pytest -m "not db"` exit 0; `pytest tests/smoke` exit 0; full pre-push hook green (incl. shellcheck + chokepoint lints + dark-mode gate).

## Codex pre-push review

Found one real defect, fixed in the same commit: `changes_are_stale` treated a **vanished** path as stale, which silently suppressed deletion-only batches (a rename, or a `git checkout` dropping a module) — the daemon would keep running the old code until an unrelated edit landed. A missing path now forces the reload. Trade accepted deliberately: at most one redundant restart, versus silently-stale code.

## ⚠ Honest caveat

**One final manual `stack: jobs` restart is still needed** — to pick up the wrapper itself. The currently-running daemon was launched as `python -m app.jobs` before this change existed; it cannot adopt its own supervisor. After that single restart, no further manual restarts are required.

The full end-to-end acceptance test (merge to `origin/main` → running daemon picks it up) therefore cannot be demonstrated pre-merge for the same reason; the supervisor mechanics are proven above against a stub child instead.

## Tradeoffs

- **180s drain ceiling** before SIGKILL — an escalation floor, not a target. A healthy idle daemon exits in well under a second; the ceiling only bites on a genuinely wedged drain, where killing is the right answer anyway.
- **Stale-batch suppression is best-effort**, keyed on mtime vs. spawn wall-time. Worst case is one redundant restart, never a missed one.
- Daemon is **down for the duration of a drain** during reload. Acceptable in dev; this is the same window the manual restart already had.

Refs #2144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)