### PR TITLE
tech-debt(#2151): resolve the TradingView attribution by licence + label the sparkline

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,36 @@
+eBull
+Copyright 2026 Luke Bradford
+
+This product includes software developed by third parties, listed below.
+
+-------------------------------------------------------------------------------
+Lightweight Charts™
+Copyright 2023 TradingView, Inc.
+https://www.tradingview.com/
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this software except in compliance with the License. You may obtain a copy of
+the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+TradingView's terms for this library additionally require that the attribution
+notice above and a link to https://www.tradingview.com/ appear on the pages of
+the application available to users. eBull satisfies the link requirement with a
+persistent "Charts by TradingView" link in the application sidebar
+(frontend/src/layout/Sidebar.tsx), which is rendered on every authenticated
+route. Because that link fulfils the requirement, the library's own per-chart
+`layout.attributionLogo` option is set to false on the chart surfaces — a
+disposition the library documents explicitly:
+
+    "Using this attribution logo is sufficient for meeting this linking
+     requirement. However, if you already fulfill this requirement then you
+     can disable this attribution logo."
+        -- LayoutOptions.attributionLogo, lightweight-charts typings
+
+If the sidebar link is ever removed, either restore `attributionLogo: true` on
+every chart surface or place an equivalent link elsewhere on the page.
+-------------------------------------------------------------------------------

--- a/frontend/src/components/dashboard/PortfolioValueChart.tsx
+++ b/frontend/src/components/dashboard/PortfolioValueChart.tsx
@@ -247,6 +247,10 @@ function ValueCanvas({
         background: { color: theme.bg },
         textColor: theme.textSecondary,
         fontSize: 11,
+        // Attribution is satisfied by the shell-level "Charts by TradingView"
+        // link (layout/Sidebar.tsx) + the repo-root NOTICE, which the library
+        // documents as an explicit alternative to this per-chart logo (#2151).
+        attributionLogo: false,
       },
       grid: {
         vertLines: { color: theme.gridLine },

--- a/frontend/src/components/instrument/PriceChart.tsx
+++ b/frontend/src/components/instrument/PriceChart.tsx
@@ -506,6 +506,10 @@ export function ChartCanvas({
         background: { color: theme.bg },
         textColor: theme.textSecondary,
         fontSize: 11,
+        // Attribution is satisfied by the shell-level "Charts by TradingView"
+        // link (layout/Sidebar.tsx) + the repo-root NOTICE, which the library
+        // documents as an explicit alternative to this per-chart logo (#2151).
+        attributionLogo: false,
       },
       grid: {
         vertLines: { color: theme.gridLine },

--- a/frontend/src/components/instrument/Sparkline.test.tsx
+++ b/frontend/src/components/instrument/Sparkline.test.tsx
@@ -96,3 +96,58 @@ describe("Sparkline — hover tooltip", () => {
     expect(screen.queryByTestId("sparkline-tooltip")).toBeNull();
   });
 });
+
+describe("Sparkline — last-value label + height floor (#2151)", () => {
+  it("renders no last-value label by default", () => {
+    render(<Sparkline values={[10, 20, 30]} />);
+    expect(screen.queryByTestId("sparkline-last-value")).toBeNull();
+  });
+
+  it("renders the FINAL value when showLastValue is set", () => {
+    render(<Sparkline values={[10, 20, 30]} showLastValue />);
+    const label = screen.getByTestId("sparkline-last-value");
+    // The last point, not the max and not the first.
+    expect(label.textContent).toBe("30");
+  });
+
+  it("formats the last value through formatValue", () => {
+    render(
+      <Sparkline
+        values={[1, 2, 3.14159]}
+        showLastValue
+        formatValue={(v) => `${v.toFixed(1)}x`}
+      />,
+    );
+    expect(screen.getByTestId("sparkline-last-value").textContent).toBe("3.1x");
+  });
+
+  it("clamps a below-floor height up to the 24px minimum", () => {
+    const { container } = render(<Sparkline values={[1, 2, 3]} height={4} />);
+    expect(container.querySelector("svg")?.getAttribute("height")).toBe("24");
+  });
+
+  it("honours a height above the floor", () => {
+    const { container } = render(<Sparkline values={[1, 2, 3]} height={48} />);
+    expect(container.querySelector("svg")?.getAttribute("height")).toBe("48");
+  });
+
+  it("reserves the same floored box when the series is too short to plot", () => {
+    // The empty branch must not collapse the row differently from the plotted
+    // one, or a series dropping to <2 points shifts the layout around it.
+    const { container } = render(<Sparkline values={[42]} height={4} />);
+    expect(container.querySelector("polyline")).toBeNull();
+    expect(container.querySelector("svg")?.getAttribute("height")).toBe("24");
+  });
+
+  it("puts className on the wrapper so the label inherits the line colour", () => {
+    const { container } = render(
+      <Sparkline values={[1, 2, 3]} showLastValue className="text-blue-600" />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("text-blue-600");
+    // currentColor still resolves for the stroke, inherited from the wrapper.
+    expect(container.querySelector("polyline")?.getAttribute("stroke")).toBe(
+      "currentColor",
+    );
+  });
+});

--- a/frontend/src/components/instrument/Sparkline.tsx
+++ b/frontend/src/components/instrument/Sparkline.tsx
@@ -1,27 +1,50 @@
 /**
  * Sparkline — hand-coded SVG <polyline> sparkline. No external chart
- * dependency. Used in `FundamentalsPane` for compact 8-point time
- * series (revenue, op income, net income, total debt over 8 quarters).
+ * dependency.
+ *
+ * Its one caller is the score-history strip in `VerdictTab` (#2151 corrected
+ * the previous claim here that `FundamentalsPane` uses it — that pane replaced
+ * its four sparklines with Recharts AreaCharts in the design-system v1
+ * redesign, and has not rendered a Sparkline since).
  *
  * Phase 2 (#576): hover tooltip shows the value at the cursor index.
+ * #2151: optional last-value label, and a height floor so the plot can never
+ * collapse to a sliver.
  *
- * Coloring: default `stroke="currentColor"` lets callers drive the
- * polyline color via a Tailwind `text-*` class on `className` (e.g.
- * `text-emerald-500`). Existing FundamentalsPane callers rely on this.
- * For chart-theme alignment, new callers should pass
+ * Coloring: default `stroke="currentColor"` lets callers drive the polyline
+ * color via a Tailwind `text-*` class on `className` (e.g. `text-emerald-500`).
+ * Since #2151 `className` lands on the WRAPPER rather than the <svg>, so the
+ * last-value label inherits the same `currentColor` as the stroke and cannot
+ * drift from it — including in dark mode, where a bare text colour has no
+ * lint gate (prevention-log → "A bare text-<color> class has no dark-mode
+ * gate"). For chart-theme alignment, new callers should pass
  * `stroke={lightTheme.accent[N]}` from `@/lib/chartTheme` — see #586.
  */
 
 import { useState, useCallback, type JSX } from "react";
 
+/**
+ * Floor for the rendered plot height. A sparkline shorter than this reads as a
+ * sliver rather than a trend, and the empty (<2 points) branch would otherwise
+ * reserve a differently-sized box and shift the row (#2151).
+ */
+const MIN_HEIGHT = 24;
+
 export interface SparklineProps {
   readonly values: ReadonlyArray<number>;
   readonly width?: number;
+  /** Requested plot height. Clamped up to `MIN_HEIGHT` (24px). */
   readonly height?: number;
   readonly stroke?: string;
+  /** Applied to the wrapper, so the svg AND the last-value label inherit it. */
   readonly className?: string;
   /** Custom value formatter. Default: 2 decimal places with locale separators. */
   readonly formatValue?: (v: number) => string;
+  /**
+   * Render the final value as a label after the line. Off by default — a
+   * sparkline in a dense table cell usually has no room for it.
+   */
+  readonly showLastValue?: boolean;
 }
 
 interface HoverState {
@@ -35,12 +58,14 @@ function defaultFormat(v: number): string {
 export function Sparkline({
   values,
   width = 80,
-  height = 24,
+  height = MIN_HEIGHT,
   stroke = "currentColor",
   className,
   formatValue = defaultFormat,
+  showLastValue = false,
 }: SparklineProps): JSX.Element {
   const [hover, setHover] = useState<HoverState | null>(null);
+  const plotHeight = Math.max(height, MIN_HEIGHT);
 
   const handleMove = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
@@ -62,7 +87,11 @@ export function Sparkline({
   }, []);
 
   if (values.length < 2) {
-    return <svg width={width} height={height} className={className} />;
+    return (
+      <div className={`relative inline-flex items-center ${className ?? ""}`}>
+        <svg width={width} height={plotHeight} />
+      </div>
+    );
   }
 
   const min = Math.min(...values);
@@ -73,23 +102,26 @@ export function Sparkline({
     .map((v, i) => {
       const x = i * xStep;
       // When all values are equal (range === 0) center the flat line
-      // at height/2 rather than clipping it to the bottom boundary.
+      // at plotHeight/2 rather than clipping it to the bottom boundary.
       const y =
         range === 0
-          ? height / 2
-          : height - ((v - min) / range) * height;
+          ? plotHeight / 2
+          : plotHeight - ((v - min) / range) * plotHeight;
       return `${x.toFixed(1)},${y.toFixed(1)}`;
     })
     .join(" ");
 
   const hoveredValue = hover !== null ? values[hover.idx] : undefined;
+  const lastValue = values[values.length - 1];
 
   return (
-    <div className="relative inline-block" onMouseLeave={handleLeave}>
+    <div
+      className={`relative inline-flex items-center gap-1 ${className ?? ""}`}
+      onMouseLeave={handleLeave}
+    >
       <svg
         width={width}
-        height={height}
-        className={className}
+        height={plotHeight}
         aria-hidden="true"
         onMouseMove={handleMove}
       >
@@ -102,6 +134,15 @@ export function Sparkline({
           strokeLinejoin="round"
         />
       </svg>
+      {/* Laid out AFTER the svg rather than absolutely positioned at the final
+          point's y: an out-of-flow label in a scrollable list is the #1858
+          escape trap, and an in-flow label cannot be clipped by a tight cell.
+          Colour is inherited from the wrapper, so it always matches the line. */}
+      {showLastValue && lastValue !== undefined ? (
+        <span className="text-[10px] tabular-nums" data-testid="sparkline-last-value">
+          {formatValue(lastValue)}
+        </span>
+      ) : null}
       {hover !== null && hoveredValue !== undefined ? (
         <div
           className="absolute left-0 top-full z-10 mt-0.5 whitespace-nowrap rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-white shadow"

--- a/frontend/src/components/instrument/VerdictTab.tsx
+++ b/frontend/src/components/instrument/VerdictTab.tsx
@@ -341,6 +341,7 @@ export function VerdictTab({
               values={historyValues}
               width={240}
               height={48}
+              showLastValue
               className="text-blue-600 dark:text-blue-400"
             />
             <span className="text-[10px] text-slate-400">

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -39,6 +39,29 @@ export function Sidebar() {
           </NavLink>
         ))}
       </nav>
+      {/* Lightweight Charts attribution (#2151). The library is Apache-2.0,
+          and TradingView's terms (node_modules/lightweight-charts/README.md
+          §License) require the attribution notice plus "a link to
+          https://www.tradingview.com/ to the page of your website ... that is
+          available to your users". The per-chart `attributionLogo` option is
+          documented as ONE sufficient way to meet that link requirement —
+          "if you already fulfill this requirement then you can disable this
+          attribution logo" (LayoutOptions.attributionLogo). This shell-level
+          link is how we fulfil it, so the charts set the option false. The
+          notice itself lives in the repo-root NOTICE file.
+          Keep this link on every authenticated page; removing it while the
+          charts have the logo disabled would put us out of compliance. */}
+      <div className="mt-auto px-5 py-4 text-xs text-slate-500 dark:text-slate-400">
+        Charts by{" "}
+        <a
+          href="https://www.tradingview.com/"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-blue-600 hover:underline dark:text-blue-400"
+        >
+          TradingView
+        </a>
+      </div>
     </aside>
   );
 }

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -279,6 +279,10 @@ export function ChartWorkspaceCanvas({
         background: { color: theme.bg },
         textColor: theme.textSecondary,
         fontSize: 11,
+        // Attribution is satisfied by the shell-level "Charts by TradingView"
+        // link (layout/Sidebar.tsx) + the repo-root NOTICE, which the library
+        // documents as an explicit alternative to this per-chart logo (#2151).
+        attributionLogo: false,
       },
       grid: {
         vertLines: { color: theme.gridLine },


### PR DESCRIPTION
Closes #2151. Two sub-items, both of which the issue explicitly wanted researched before coding.

---

## 1. TradingView attribution — the licence answers it, and it isn't "restyle"

The issue proposed *"restyle placement/size **within licence**"* and said that qualifier was the whole ticket. Reading the licence makes it the wrong shape of answer, twice.

**Governing terms.** `lightweight-charts@5.1.0` is **Apache-2.0** (`node_modules/lightweight-charts/LICENSE`, "Copyright 2023 TradingView, Inc."). The attribution obligation is stated in `README.md` §License:

> *"This license requires specifying TradingView as the product creator. You shall add the "attribution notice" from the NOTICE file **and a link to https://www.tradingview.com/ to the page of your website or mobile application that is available to your users**."*

That is a **page-level** obligation, not a per-canvas one. The library documents its own per-chart logo as merely *one sufficient way* to discharge it — `LayoutOptions.attributionLogo`, `dist/typings.d.ts`:

> *"Using this attribution logo is sufficient for meeting this linking requirement. **However, if you already fulfill this requirement then you can disable this attribution logo.**"*

**Restyling is not achievable regardless.** The API exposes `attributionLogo` as a `boolean` only — there is no position, size, or opacity option — and the mark is painted **into the canvas**, so there is no DOM node and no CSS to target. "Move it / shrink it / fade it" cannot be done at any licence posture.

**Note on Apache §4(d):** it is conditional — *"If the Work includes a NOTICE text file as part of its distribution"*. The npm package ships **no** NOTICE file (contents: `LICENSE`, `README.md`, `dist`, `package.json`), so §4(d) does not bite; the README's attribution ask is what governs.

**What shipped**
- One persistent **"Charts by TradingView"** link in the app sidebar (`frontend/src/layout/Sidebar.tsx`) — rendered on every authenticated route, so every page carrying a chart carries the link.
- A repo-root **`NOTICE`** carrying the attribution notice, and recording the dependency explicitly: if the sidebar link is ever removed, `attributionLogo` must go back to `true` or an equivalent link must be placed elsewhere.
- `attributionLogo: false` on all three surfaces: `PriceChart`, `ChartWorkspaceCanvas`, `PortfolioValueChart`.

Net effect: the mark stops repeating bottom-left on every chart (the #1908 item-3 complaint) and the attribution becomes *more* discoverable, not less — it is now a real text link in the chrome plus an in-repo notice, where before it was only a canvas glyph and nothing in the repo.

## 2. Sparkline last-value label + height floor

- **`showLastValue`** renders the final value after the line. Off by default — a sparkline in a dense table cell usually has no room.
- **Height floor** (`MIN_HEIGHT = 24`) clamps the plot, and the `<2`-point empty branch now reserves the same floored box, so a series dropping below two points cannot shift the row around it.
- **`className` moves to the wrapper**, so the label inherits the same `currentColor` as the stroke and cannot drift from it — including in dark mode, where a bare text colour has **no** lint gate (prevention-log → *"A bare `text-<color>` class has no dark-mode gate"*). The existing caller passes `text-blue-600 dark:text-blue-400`, so both line and label get the pair for free.
- The label is laid out **in flow** after the svg, not absolutely positioned at the final point's y. Trade-off taken deliberately: an out-of-flow label inside a scrollable list is the #1858 dead-scroll escape trap, and an in-flow one cannot be clipped by a tight cell. Cost is that the label sits vertically centred rather than at the last point's exact y.

### Premise correction

The issue asked to apply this to "the score-history sparkline in `VerdictTab` **and the `FundamentalsPane` series**". `FundamentalsPane` has **no** Sparkline — it replaced its four sparklines with Recharts AreaCharts in the design-system v1 redesign (its own module docstring records this). `VerdictTab` is the sole caller. `Sparkline`'s docstring still claimed FundamentalsPane used it; corrected in this PR.

## Security model

None. Presentation-only frontend change plus a repo-root `NOTICE` text file. No endpoint, no auth surface, no data written, no API shape touched. The new outbound link carries `rel="noreferrer noopener"` with `target="_blank"`.

## Verification

**Gates** (at `8f1a89cf`): `pnpm typecheck` clean · `pnpm dark:check` OK 383 files · `pnpm test:unit` **134 files / 1436 tests** pass · pre-push hook green · `codex exec review --base origin/main` — no actionable regressions.

7 tests added to `Sparkline.test.tsx`: label absent by default, label shows the FINAL value (not the max, not the first), label honours `formatValue`, below-floor height clamps to 24, above-floor height is honoured, the empty branch reserves the same floored box, and `className` lands on the wrapper while `stroke` still resolves `currentColor`.

**Change-coupled FE-QA on the running dev stack** (`localhost:5173`):

| Surface | Result |
|---|---|
| `/portfolio` (PortfolioValueChart) | canvas logo **gone**; exactly **1** tradingview.com link on the page, in the sidebar, visible, `rel="noreferrer noopener"` |
| `/instrument/CTSH` (PriceChart) | 7 canvases, **0** tradingview.com links outside the sidebar |
| `/instrument/CTSH/chart` (ChartWorkspaceCanvas) | 7 canvases, **0** outside the sidebar |
| `/instrument/CTSH?tab=verdict` | last-value label renders `0.79` — matches the instrument's score; wrapper class `... text-blue-600 dark:text-blue-400`; svg height `48` (above the floor, honoured) |

0 console errors on every page. Before/after screenshots of the portfolio chart confirm the bottom-left mark is gone and the sidebar link is present.

No backfill / rebuild clauses apply — no parser, schema, or ownership data path is touched.