### PR TITLE
tech-debt(#2152): sweep the de-facto rose red family onto the documented red

### DIFF
--- a/.claude/skills/frontend/operator-ui-conventions.md
+++ b/.claude/skills/frontend/operator-ui-conventions.md
@@ -42,6 +42,15 @@ Restrained palette. Each color has one job. Mixing them dilutes the signal.
 
 Do not introduce new color families (purple, pink, cyan, etc.) without a documented reason. Do not use red for "in progress" or amber for "ok".
 
+**`rose-*` is NOT a second red (#2152, settled 2026-07-29).** It had drifted into ~28 sites as a de-facto parallel error/negative family — every negative money figure on the dashboard (`StatTile`), most error alert surfaces, and several severity tones — so a `risk` badge and the negative figure beside it rendered two different reds. All semantic sites are swept to `red-*`. The sweep went this way, not the other, because the table above is the settled decision, `Badge`'s `risk` tone was taken from it in #1908 PR-2, and `red-*` already had ~450 occurrences to rose's 31. Reach for `red-*` for error / risk / breached / EXIT / negative money; never `rose-*`.
+
+Two surviving `rose-` references are deliberate and must NOT be swept — neither is a status colour:
+
+- `lib/avatar.tsx` — the 6-tone deterministic **identity-hash** palette (blue/emerald/amber/rose/violet/cyan). Categorical, not semantic: it exists to make the same trader the same colour everywhere. Recolouring rose→red here would make one in six avatars read as an error. The same reasoning covers its violet and cyan.
+- `components/instrument/OwnershipSunburst.tsx` — a **comment** naming the hue of `ChartTheme.accent[4]`. Chart series read the resolved theme (see Chart colours below); there is no Tailwind class here to sweep.
+
+**Semantic colour carried by TEXT needs its `dark:` partner written by hand** — `check-dark-classes.mjs` keys off background / border / hover tokens only, so a bare `text-red-700` passes the gate while rendering low-contrast in dark (prevention-log → "A bare `text-<color>` class has no dark-mode gate"). Prefer reusing `Badge` / `StatTile`, which already carry both.
+
 **Chart colours:** in any component that calls `useChartTheme()`, read the returned `theme` for ALL colours — series fills/strokes included — never import `lightTheme` directly. The dark palette aliases the saturated slots (`up`/`down`/`accent`/`regression`) to the light values today, so `lightTheme.down` happens to render identically, but referencing `theme` is the fragility-free form (prevention-log → "Chart series colours should read the resolved `theme`").
 
 ## Status pill vocabulary

--- a/frontend/src/components/broker/ValidationResultDisplay.tsx
+++ b/frontend/src/components/broker/ValidationResultDisplay.tsx
@@ -9,7 +9,7 @@ export function ValidationResultDisplay({
 }): JSX.Element | null {
   if (error !== null) {
     return (
-      <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
+      <div role="alert" className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300">
         {error}
       </div>
     );
@@ -18,7 +18,7 @@ export function ValidationResultDisplay({
 
   if (!result.auth_valid) {
     return (
-      <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
+      <div role="alert" className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300">
         Authentication failed — check your eToro public key and private key.
       </div>
     );

--- a/frontend/src/components/dashboard/RollingPnlStrip.test.tsx
+++ b/frontend/src/components/dashboard/RollingPnlStrip.test.tsx
@@ -131,8 +131,8 @@ describe("RollingPnlStrip", () => {
     });
     renderStrip();
     const pct = await screen.findByText("-1.37%");
-    expect(pct.className).toContain("text-rose-600");
-    expect(pct.className).toContain("dark:text-rose-400");
+    expect(pct.className).toContain("text-red-600");
+    expect(pct.className).toContain("dark:text-red-400");
     expect(pct.className).not.toContain("text-slate-500");
   });
 

--- a/frontend/src/components/dashboard/StatTile.tsx
+++ b/frontend/src/components/dashboard/StatTile.tsx
@@ -51,7 +51,7 @@ export function StatTile({
           ? "text-slate-600 dark:text-slate-400"
           : "text-slate-900 dark:text-slate-100";
   const sizeClass = size === "md" ? "text-lg" : "text-2xl";
-  const hintToneClass = toneHint ? toneClass : "text-slate-500";
+  const hintToneClass = toneHint ? toneClass : "text-slate-500 dark:text-slate-400";
   return (
     <div className="border-t border-slate-200 dark:border-slate-800 px-1 pt-3 pb-1">
       <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">

--- a/frontend/src/components/dashboard/StatTile.tsx
+++ b/frontend/src/components/dashboard/StatTile.tsx
@@ -46,7 +46,7 @@ export function StatTile({
     tone === "positive"
       ? "text-emerald-600 dark:text-emerald-400"
       : tone === "negative"
-        ? "text-rose-600 dark:text-rose-400"
+        ? "text-red-600 dark:text-red-400"
         : tone === "muted"
           ? "text-slate-600 dark:text-slate-400"
           : "text-slate-900 dark:text-slate-100";

--- a/frontend/src/components/instrument/EightKEventsPanel.tsx
+++ b/frontend/src/components/instrument/EightKEventsPanel.tsx
@@ -45,7 +45,7 @@ export interface EightKEventsPanelProps {
 function severityTone(severity: string | null): string {
   switch (severity) {
     case "critical":
-      return "bg-rose-100 dark:bg-rose-900/40 text-rose-800 dark:text-rose-200";
+      return "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200";
     case "material":
       return "bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200";
     case "informational":

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -390,14 +390,17 @@ function FundamentalCell({
   const delta = yoyDelta(points);
   const lastIdx = lastNonNullIndex(points);
   const latestVal = lastIdx >= 0 ? points[lastIdx]!.value : null;
+  // Every branch carries its dark partner (#2152 review): a bare text colour
+  // has no lint gate, so a ternary themed on only one arm renders half its
+  // states washed out in dark and stays green on `dark:check`.
   const deltaClass =
     delta === null
-      ? "text-slate-400"
+      ? "text-slate-400 dark:text-slate-500"
       : delta.pct > 0
-        ? "text-emerald-600"
+        ? "text-emerald-600 dark:text-emerald-400"
         : delta.pct < 0
           ? "text-red-600 dark:text-red-400"
-          : "text-slate-500";
+          : "text-slate-500 dark:text-slate-400";
   // Per-instance + per-label gradient id (Codex review): two
   // FundamentalsPane instances in the same DOM previously collided.
   const gradId = `fund-grad-${idPrefix}-${label.replace(/[^a-z]/gi, "")}`;

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -396,7 +396,7 @@ function FundamentalCell({
       : delta.pct > 0
         ? "text-emerald-600"
         : delta.pct < 0
-          ? "text-rose-600"
+          ? "text-red-600 dark:text-red-400"
           : "text-slate-500";
   // Per-instance + per-label gradient id (Codex review): two
   // FundamentalsPane instances in the same DOM previously collided.

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -125,7 +125,7 @@ function formatDelta(raw: string): { label: string; colour: string } {
   }
   return {
     label: Math.round(num).toLocaleString("en-US"),
-    colour: "bg-rose-100 dark:bg-rose-900/40 text-rose-800 dark:text-rose-200",
+    colour: "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-200",
   };
 }
 
@@ -176,7 +176,7 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
             <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Disposed
             </span>
-            <span className="mt-1 font-mono text-base tabular-nums text-rose-700">
+            <span className="mt-1 font-mono text-base tabular-nums text-red-700 dark:text-red-300">
               {totalDisposed > 0 ? "-" : ""}
               {Math.round(totalDisposed).toLocaleString("en-US")}
             </span>
@@ -241,7 +241,7 @@ function Row({ txn }: { txn: InsiderTransactionDetail }) {
   const codeColour = isBuy
     ? "text-emerald-700"
     : isSell
-      ? "text-rose-700"
+      ? "text-red-700 dark:text-red-300"
       : "text-slate-600";
   const planned = txn.deemed_execution_date !== null;
   const late = txn.transaction_timeliness === "L";

--- a/frontend/src/components/instrument/InsiderActivityPanel.tsx
+++ b/frontend/src/components/instrument/InsiderActivityPanel.tsx
@@ -161,7 +161,7 @@ function SummaryStrip({ summary }: { summary: InsiderSummary }) {
             <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Acquired
             </span>
-            <span className="mt-1 font-mono text-base tabular-nums text-emerald-700">
+            <span className="mt-1 font-mono text-base tabular-nums text-emerald-700 dark:text-emerald-300">
               {totalAcquired > 0 ? "+" : ""}
               {Math.round(totalAcquired).toLocaleString("en-US")}
             </span>
@@ -238,11 +238,13 @@ function Row({ txn }: { txn: InsiderTransactionDetail }) {
   const code = txnCodeLabel(txn.txn_code, txn.acquired_disposed_code);
   const isBuy = txn.txn_code === "P";
   const isSell = txn.txn_code === "S";
+  // Every arm carries its dark partner (#2152 review) — a bare text colour has
+  // no lint gate, so a half-themed ternary washes out in dark and stays green.
   const codeColour = isBuy
-    ? "text-emerald-700"
+    ? "text-emerald-700 dark:text-emerald-300"
     : isSell
       ? "text-red-700 dark:text-red-300"
-      : "text-slate-600";
+      : "text-slate-600 dark:text-slate-400";
   const planned = txn.deemed_execution_date !== null;
   const late = txn.transaction_timeliness === "L";
   const footnoteEntries = Object.entries(txn.footnotes);

--- a/frontend/src/components/settings/BudgetConfigSection.tsx
+++ b/frontend/src/components/settings/BudgetConfigSection.tsx
@@ -220,7 +220,7 @@ export function BudgetConfigSection() {
               {configError && (
                 <p
                   role="alert"
-                  className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+                  className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
                 >
                   Failed to save budget config. Check the browser console for
                   details.
@@ -315,7 +315,7 @@ export function BudgetConfigSection() {
             {eventError && (
               <p
                 role="alert"
-                className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+                className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
               >
                 Failed to record capital event. Check the browser console for
                 details.

--- a/frontend/src/components/settings/DisplayCurrencySection.tsx
+++ b/frontend/src/components/settings/DisplayCurrencySection.tsx
@@ -81,7 +81,7 @@ export function DisplayCurrencySection({ currentCurrency, onChanged }: Props) {
         {error !== null && (
           <div
             role="alert"
-            className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+            className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
           >
             {error}
           </div>

--- a/frontend/src/components/settings/LlmProviderSection.tsx
+++ b/frontend/src/components/settings/LlmProviderSection.tsx
@@ -205,7 +205,7 @@ export function LlmProviderSection(): JSX.Element {
             {error && (
               <p
                 role="alert"
-                className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+                className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
               >
                 Failed to save LLM config. Check the browser console for details.
               </p>

--- a/frontend/src/pages/BrokerSetupPage.tsx
+++ b/frontend/src/pages/BrokerSetupPage.tsx
@@ -269,7 +269,7 @@ export function BrokerSetupPage(): JSX.Element {
         {error !== null && (
           <div
             role="alert"
-            className="mb-3 rounded bg-rose-50 dark:bg-rose-900/30 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+            className="mb-3 rounded bg-red-50 dark:bg-red-900/30 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
           >
             {error}
           </div>

--- a/frontend/src/pages/CopyTradingPage.tsx
+++ b/frontend/src/pages/CopyTradingPage.tsx
@@ -256,7 +256,7 @@ function ClosedExitsTable({
                 ) : null}
               </td>
               <td className="px-2 py-2 text-left">
-                <span className={e.is_buy ? "text-emerald-600" : "text-rose-600"}>
+                <span className={e.is_buy ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}>
                   {e.is_buy ? "Buy" : "Sell"}
                 </span>
               </td>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -93,7 +93,7 @@ export function LoginPage(): JSX.Element {
           />
         </label>
         {error !== null && (
-          <div role="alert" className="mb-3 rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
+          <div role="alert" className="mb-3 rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300">
             {error}
           </div>
         )}

--- a/frontend/src/pages/OperatorsPage.tsx
+++ b/frontend/src/pages/OperatorsPage.tsx
@@ -120,7 +120,7 @@ export function OperatorsPage(): JSX.Element {
       </div>
 
       {loadError !== null && (
-        <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-3 py-2 text-xs text-rose-700 dark:text-rose-300">
+        <div role="alert" className="rounded bg-red-50 dark:bg-red-950/40 px-3 py-2 text-xs text-red-700 dark:text-red-300">
           {loadError}
         </div>
       )}
@@ -150,7 +150,7 @@ export function OperatorsPage(): JSX.Element {
                   type="button"
                   onClick={() => void handleDelete(row)}
                   disabled={busyId === row.id}
-                  className="rounded border border-rose-300 px-2 py-1 text-xs text-rose-700 hover:bg-rose-50 disabled:opacity-50"
+                  className="rounded border border-red-300 dark:border-red-700 px-2 py-1 text-xs text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/40 disabled:opacity-50"
                 >
                   {busyId === row.id ? "Deleting…" : "Delete"}
                 </button>
@@ -159,7 +159,7 @@ export function OperatorsPage(): JSX.Element {
           </ul>
         )}
         {actionError !== null && (
-          <p role="alert" className="mt-2 text-xs text-rose-700">
+          <p role="alert" className="mt-2 text-xs text-red-700 dark:text-red-300">
             {actionError}
           </p>
         )}
@@ -199,7 +199,7 @@ export function OperatorsPage(): JSX.Element {
           {createError !== null && (
             <div
               role="alert"
-              className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+              className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
             >
               {createError}
             </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -403,7 +403,7 @@ function BrokerCredentialsSection(): JSX.Element {
       </div>
 
       {loadError !== null && (
-        <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-3 py-2 text-xs text-rose-700 dark:text-rose-300">
+        <div role="alert" className="rounded bg-red-50 dark:bg-red-950/40 px-3 py-2 text-xs text-red-700 dark:text-red-300">
           {loadError}
         </div>
       )}
@@ -462,7 +462,7 @@ function BrokerCredentialsSection(): JSX.Element {
                       type="button"
                       onClick={() => void handleRevoke(row)}
                       disabled={busyId === row.id}
-                      className="rounded border border-rose-300 px-2 py-1 text-xs text-rose-700 hover:bg-rose-50 disabled:opacity-50"
+                      className="rounded border border-red-300 dark:border-red-700 px-2 py-1 text-xs text-red-700 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-950/40 disabled:opacity-50"
                     >
                       {busyId === row.id ? "Revoking…" : "Revoke"}
                     </button>
@@ -474,7 +474,7 @@ function BrokerCredentialsSection(): JSX.Element {
         </ul>
       )}
       {actionError !== null && (
-        <p role="alert" className="text-xs text-rose-700">
+        <p role="alert" className="text-xs text-red-700 dark:text-red-300">
           {actionError}
         </p>
       )}
@@ -534,7 +534,7 @@ function BrokerCredentialsSection(): JSX.Element {
             />
           </label>
           {editError !== null && (
-            <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
+            <div role="alert" className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300">
               {editError}
             </div>
           )}
@@ -617,7 +617,7 @@ function BrokerCredentialsSection(): JSX.Element {
           />
 
           {editError !== null && (
-            <div role="alert" className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300">
+            <div role="alert" className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300">
               {editError}
             </div>
           )}
@@ -718,7 +718,7 @@ function BrokerCredentialsSection(): JSX.Element {
           {createError !== null && (
             <div
               role="alert"
-              className="rounded bg-rose-50 dark:bg-rose-950/40 px-2 py-1.5 text-xs text-rose-700 dark:text-rose-300"
+              className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
             >
               {createError}
             </div>

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -121,7 +121,7 @@ export function SetupPage(): JSX.Element {
         {error !== null && (
           <div
             role="alert"
-            className="mb-3 rounded bg-rose-50 px-2 py-1.5 text-xs text-rose-700 dark:bg-rose-950/40 dark:text-rose-300"
+            className="mb-3 rounded bg-red-50 px-2 py-1.5 text-xs text-red-700 dark:bg-red-950/40 dark:text-red-300"
           >
             {error}
           </div>


### PR DESCRIPTION
Closes #2152.

## The decision

The issue asked for one of two sweeps, picked once and applied wholesale. **Decision (a): rose is wrong; sweep to `red-*`.**

`.claude/skills/frontend/operator-ui-conventions.md` names exactly five families — red for error / risk / breached / EXIT — and says *"Do not introduce new color families."* `rose-*` had drifted in as a second red across ~28 sites, so a `risk` badge and the negative figure beside it rendered two different reds.

Three reasons it goes this way rather than making rose the house red:

1. The colour table **is** the settled decision; rose was never documented.
2. `Badge`'s `risk` tone was taken from that table in #1908 PR-2 — the newest and most authoritative consolidation already chose red.
3. Blast radius: **31** rose occurrences vs **454** red. The reverse sweep is ~15× the churn *and* would additionally rewrite the skill, the `Badge` primitive, and every existing red site to chase the undocumented family.

## Two rose references deliberately survive

Both are non-semantic, and the skill now records *why* so a later pass doesn't "finish the job":

- **`lib/avatar.tsx`** — the 6-tone deterministic **identity-hash** palette (`blue / emerald / amber / rose / violet / cyan`). Categorical, not status: it exists so the same trader is the same colour on every surface. Recolouring rose→red would make one in six trader avatars read as an error. The same argument already covers its `violet` and `cyan`, which the table also doesn't name.
- **`components/instrument/OwnershipSunburst.tsx`** — a **comment** naming the hue of `ChartTheme.accent[4]`. Chart series read the resolved theme; there is no Tailwind class here to sweep.

The issue listed the avatar as "arguably fine to keep" — this PR makes that call explicitly rather than leaving it ambiguous, since the acceptance criterion is a grep.

## Bonus fix on the same lines: eight missing dark partners

While rewriting these lines I added the `dark:` partners on the bare semantic colours among them — `FundamentalsPane`, `InsiderActivityPanel` (×2), `CopyTradingPage`, `OperatorsPage` (×2), `SettingsPage` (×2).

A bare `text-red-700` has **no** dark gate: `check-dark-classes.mjs` keys off background / border / hover tokens only (prevention-log → *"A bare `text-<color>` class has no dark-mode gate"*). These had been light-only since they were written and `dark:check` was green over them the whole time. Leaving a known light-only defect on a line I was already editing wasn't defensible.

## Security model

None. Presentation-only frontend change: colour class names and one skill doc. No endpoint, no auth surface, no data written, no logic touched. `git diff` is a pure class-string rename plus added `dark:` variants.

## Verification

**Gates** (at `4b8c32ee`): `pnpm typecheck` clean · `pnpm dark:check` OK 383 files · `pnpm test:unit` **134 files / 1429 tests** pass · pre-push hook green · `codex exec review --base origin/main` — no discrete regressions.

**Acceptance criterion from the issue:**
```
$ grep -rn "rose-" frontend/src --include='*.tsx' --include='*.ts'
frontend/src/components/instrument/OwnershipSunburst.tsx:109   # comment naming an accent hue
frontend/src/lib/avatar.tsx:15                                 # identity-hash palette
frontend/src/lib/avatar.test.ts:8                              # its test mirror
```
— exactly what the decision permits, and `operator-ui-conventions.md` now matches the tree.

`RollingPnlStrip.test.tsx` asserted the negative tone's classes directly and was updated with the sweep (`text-red-600` / `dark:text-red-400`), which is also a live check that `StatTile`'s negative tone kept both halves of its pair.

**Change-coupled FE-QA on the running dev stack** (`localhost:5173`), both themes eyeballed on a negative-money surface and an error surface as the issue requires:

| Check | Result |
|---|---|
| `/` dashboard, negative money | `-£1,077.70`, `-£3,477.58`, `-£65.56`, `-£1,250.53` all `text-red-600 dark:text-red-400` — same red as the `risk` badges beside them |
| `/` dashboard, dark theme | computed colour `rgb(248, 113, 113)` = `red-400`; legible, not the washed-out light-only value |
| `/` dashboard, light theme | screenshotted; negatives and the emerald positives still read as one system |
| `/settings` (error surfaces) | **0** rose elements in the DOM |
| `/` remaining rose | exactly **1** — the `bg-rose-600` avatar circle for trader "T", i.e. the documented exception, confirmed by reading its class list |

0 console errors on every page. No backfill / rebuild clauses apply — no parser, schema, or ownership data path is touched.