### PR TITLE
fix(#2163): read DEF 14A Item 403 column 4 as a percent, not as a share count

### DIFF
--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1626,9 +1626,18 @@ def _extract_holder_rows(
                 # ``Shares = —`` and ``Percent = 8.4`` would otherwise store
                 # shares=8.4 (Codex pre-push review). Leaving shares NULL is the
                 # safe fallback; _parse_percent already handles bare percents.
-                if candidate is not None and candidate == candidate.to_integral_value():
-                    shares, shares_src_idx = candidate, i
-                    break
+                if candidate is None or candidate != candidate.to_integral_value():
+                    continue
+                # #2163 A/B round 2: when the PRIMARY cell was held back as a
+                # percent, the recovery must not simply grab the next percent
+                # along. 0001177394-25-000016 ('Minimum Payment … as Percentage
+                # of Base Salary') held back 30.0 and then recovered '100.0'
+                # from the next column — still a percent, now stored as a share
+                # count. Apply the same signature test to the candidate.
+                if percent_signature is not None and _shares_cell_percent_signature(cells, i, table.column_headers):
+                    continue
+                shares, shares_src_idx = candidate, i
+                break
         if shares is None and percent_signature == "fractional":
             # Nothing whole anywhere in the row, and the only evidence against
             # the cell was that it is not an integer. A fractional beneficial
@@ -1638,14 +1647,6 @@ def _extract_holder_rows(
             # restored — a lone '%' sibling or a percent caption is decisive.
             shares = _parse_share_count(shares_raw)
             shares_src_idx = shares_idx if shares is not None else -1
-        if percent is None and percent_signature == "marker":
-            # The cell IS the percent (229.403 column 4). Read it as one
-            # directly: the recovery scan below only accepts cells carrying a
-            # '%' or the '*' marker, so a percent identified by its CAPTION
-            # would otherwise be dropped and the row would lose both values.
-            percent = _parse_percent(shares_raw)
-            if percent is not None:
-                percent_src_idx = shares_idx
         if percent is None:
             # Ragged row (#2140 D3): issuers interleave footnote-only cells
             # ('(2)') mid-row, so a data row can be WIDER than its header row
@@ -1678,6 +1679,20 @@ def _extract_holder_rows(
                     percent = _parse_percent(text)
                     if percent is not None:
                         break
+
+        # LAST resort, and deliberately after the scan above (#2163 A/B round
+        # 3): a hold-back that SUCCEEDED — the real whole count was found at a
+        # DIFFERENT index — proves the held-back cell was 229.403 column 4.
+        # But it is weaker evidence than an unambiguous '%'-bearing cell, so it
+        # must not pre-empt the scan. Running it FIRST cost the row its real
+        # percent on tables carrying two percent-ish columns:
+        # 0000950170-24-100030 'Edward J. Richardson' has 98.1 at shares_idx and
+        # 14.8 under 'Percent of Class'; pre-empting stored 98.1.
+        held_back_succeeded = percent_signature is not None and shares is not None and shares_src_idx != shares_idx
+        if percent is None and (percent_signature == "marker" or held_back_succeeded):
+            percent = _parse_percent(shares_raw)
+            if percent is not None:
+                percent_src_idx = shares_idx
 
         # Drop rows where neither shares nor percent parsed — that's
         # almost always a free-text annotation row ("Notes:",

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -939,6 +939,63 @@ def _parse_percent(raw: str) -> Decimal | None:
 # the parser locates each canonical column by header substring and
 # falls back to positional defaults (col 0 = name, col 1 = shares,
 # col -1 = percent) when the headers are missing or ambiguous.
+def _shares_cell_percent_signature(cells: list[str], shares_idx: int, headers: tuple[str, ...]) -> str | None:
+    """Return the signature by which the cell resolved at ``shares_idx`` is a
+    PERCENT rather than a share count, or ``None`` when it reads as a count.
+
+    Source rule — 17 CFR 229.403 (Reg S-K Item 403) prescribes column 3 as
+    "Amount and nature of beneficial ownership" (a COUNT of shares) and column 4
+    as "Percent of class" (a percentage). They are two distinct columns, and the
+    reg's own captions are the discriminator.
+
+    The failure this guards (#2163): a header row carrying empty SPACER cells
+    that its data rows do not carry is WIDER than the data, so ``shares_idx``
+    lands one or more columns to the right — on the percent. The value still
+    parses (``_parse_share_count('17.4')`` is a valid ``Decimal``), so the
+    ``if shares is None`` recovery below never fires and the real count one cell
+    to the left is discarded. 0001308179-24-000672 stored BlackRock at 17.4
+    shares and threw away 6,236,345.
+
+    ``'17.4%'`` in ONE cell is NOT this bug — ``_parse_share_count`` already
+    rejects it. The defect needs the value and its sign in SEPARATE cells, which
+    is what HTML table rendering produces.
+
+    Two signature strengths, deliberately:
+
+    * ``"marker"`` — the cell's next non-empty sibling is a lone percent sign,
+      or the resolved caption itself names a percent. UNAMBIGUOUS: the value is
+      a percent and must be read as one.
+    * ``"fractional"`` — the value merely is not a whole number. Suggestive
+      (shares are whole) but a fractional holding is not impossible, so the
+      caller restores the original reading when the row offers nothing better.
+    """
+    raw = cells[shares_idx] if 0 <= shares_idx < len(cells) else ""
+    value = _parse_share_count(raw)
+    if value is None:
+        return None
+    # A percent of class is bounded by definition — ownership is a fraction of a
+    # class — and ``_parse_percent`` has clamped to [0, 100] since #1228. A value
+    # above that ceiling therefore CANNOT be the 229.403 column-4 percent no
+    # matter what the surrounding cells look like, so it is never held back.
+    #
+    # Load-bearing, not defensive: without it a row rendered
+    # ``[name, '1,234,567', '%', '5.6']`` — the sign cell BEFORE the percent
+    # value — would read the sibling '%' as decisive, hold back a genuine
+    # 1.2M-share holding, find no whole alternative (5.6 is fractional), and
+    # drop the count entirely.
+    if value.is_nan() or value.is_infinite() or value > Decimal(100) or value < Decimal(0):
+        return None
+    nxt = next((c.strip() for c in cells[shares_idx + 1 :] if c.strip()), "")
+    if nxt in ("%", "(%)"):
+        return "marker"
+    caption = headers[shares_idx].lower() if 0 <= shares_idx < len(headers) else ""
+    if ("percent" in caption or "%" in caption) and not any(k in caption for k in _STRONG_SHARES_KEYWORDS):
+        return "marker"
+    if value != value.to_integral_value():
+        return "fractional"
+    return None
+
+
 def _resolve_columns(headers: tuple[str, ...]) -> tuple[int, int, int]:
     """Return ``(name_idx, shares_idx, percent_idx)``.
 
@@ -1514,6 +1571,14 @@ def _extract_holder_rows(
         name_src_idx, holder_name_raw = _resolve_row_name(cells, name_idx=name_idx, shares_idx=shares_idx)
 
         holder_name = _clean_beneficial_holder_name(holder_name_raw)
+        if _SCHEDULE_13D_COVER_LABEL_RE.match(holder_name):
+            # Proxies embed Schedule 13D/G COVER PAGES as exhibits. Their
+            # numbered rows read as a table whose "names" are the cover-page
+            # item labels and whose "share counts" are the ROW NUMBERS
+            # (0001104659-17-023458 stored 'SHARED VOTING POWER -0' with
+            # shares=8). Not an Item 403 table — see the regex for the rule.
+            pending_owner_name = None
+            continue
         if _is_address_fragment(holder_name):
             # ADDRESS half of a stacked pair — take the name carried from the
             # preceding row. ``name_src_idx`` deliberately keeps pointing at
@@ -1525,6 +1590,15 @@ def _extract_holder_rows(
             pending_owner_name = None
             continue
         shares = _parse_share_count(shares_raw)
+        # #2163 — 17 CFR 229.403 column 3 is a COUNT, column 4 is a PERCENT.
+        # A percent-signatured value at shares_idx is not a holding; hold it
+        # back so the recovery scan below runs and finds the real count. See
+        # ``_shares_cell_percent_signature`` for the two signature strengths.
+        percent_signature = (
+            _shares_cell_percent_signature(cells, shares_idx, table.column_headers) if shares is not None else None
+        )
+        if percent_signature is not None:
+            shares = None
         shares_src_idx = shares_idx if shares is not None else -1
         # Parse the positional percent BEFORE recovering shares, so the
         # recovery knows whether percent_idx actually yielded a percent. When
@@ -1555,6 +1629,23 @@ def _extract_holder_rows(
                 if candidate is not None and candidate == candidate.to_integral_value():
                     shares, shares_src_idx = candidate, i
                     break
+        if shares is None and percent_signature == "fractional":
+            # Nothing whole anywhere in the row, and the only evidence against
+            # the cell was that it is not an integer. A fractional beneficial
+            # holding is unusual but not impossible (DRIP/plan fractions), so
+            # restore the original reading rather than drop the row's only
+            # number on a suggestive signal. ``"marker"`` is deliberately NOT
+            # restored — a lone '%' sibling or a percent caption is decisive.
+            shares = _parse_share_count(shares_raw)
+            shares_src_idx = shares_idx if shares is not None else -1
+        if percent is None and percent_signature == "marker":
+            # The cell IS the percent (229.403 column 4). Read it as one
+            # directly: the recovery scan below only accepts cells carrying a
+            # '%' or the '*' marker, so a percent identified by its CAPTION
+            # would otherwise be dropped and the row would lose both values.
+            percent = _parse_percent(shares_raw)
+            if percent is not None:
+                percent_src_idx = shares_idx
         if percent is None:
             # Ragged row (#2140 D3): issuers interleave footnote-only cells
             # ('(2)') mid-row, so a data row can be WIDER than its header row
@@ -1969,6 +2060,36 @@ _ADDRESS_ONLY_RE: Final[re.Pattern[str]] = re.compile(
 def _is_address_fragment(name: str) -> bool:
     """True when a holder-name cell holds only address material (#2140)."""
     return bool(_ADDRESS_ONLY_RE.match(name.strip()))
+
+
+# Schedule 13D/G COVER-PAGE item labels (#2163).
+#
+# Source rule — 17 CFR 240.13d-101 (Schedule 13D) and 240.13d-102 (Schedule 13G)
+# prescribe a numbered cover page. Rows 7-11 are the voting/dispositive power
+# and aggregate-amount lines; rows 1-6 and 12-14 are the reporting-person,
+# funding, citizenship and type-of-person lines. Proxies embed these cover pages
+# as exhibits, and the numbered layout parses as a table whose "holder names"
+# are these labels and whose "share counts" are the ROW NUMBERS.
+#
+# They are not Item 403 rows: 229.403 column 2 is a *beneficial owner*, which
+# Rule 13d-3 (17 CFR 240.13d-3) defines as a person or entity holding voting or
+# investment power. A cover-page item label is neither. The all-caps two-token
+# shape ('SHARED VOTING POWER') otherwise reads as a person name, so neither the
+# owner-identity test nor an address test rejects it.
+_SCHEDULE_13D_COVER_LABEL_RE: Final[re.Pattern[str]] = re.compile(
+    r"^(?:"
+    r"(?:sole|shared)\s+(?:voting|dispositive)\s+power\b"  # rows 7-10
+    r"|aggregate\s+amount\s+beneficially\s+owned\b"  # row 11
+    r"|percent\s+of\s+class\s+represented\s+by\s+amount\s+in\s+row\b"  # row 13
+    r"|type\s+of\s+reporting\s+person\b"  # row 14
+    r"|name[s]?\s+of\s+reporting\s+person\b"  # row 1
+    r"|check\s+(?:the\s+appropriate\s+)?box\b"  # rows 2, 5, 12
+    r"|sec\s+use\s+only\b"  # row 3
+    r"|source\s+of\s+funds\b"  # row 4
+    r"|citizenship\s+or\s+place\s+of\s+organization\b"  # row 6
+    r")",
+    re.IGNORECASE,
+)
 
 
 def _looks_like_name_cell(cell: str) -> bool:

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -960,14 +960,19 @@ def _shares_cell_percent_signature(cells: list[str], shares_idx: int, headers: t
     rejects it. The defect needs the value and its sign in SEPARATE cells, which
     is what HTML table rendering produces.
 
-    Two signature strengths, deliberately:
+    Two signature strengths, split on SEMANTIC vs POSITIONAL evidence:
 
-    * ``"marker"`` — the cell's next non-empty sibling is a lone percent sign,
-      or the resolved caption itself names a percent. UNAMBIGUOUS: the value is
-      a percent and must be read as one.
-    * ``"fractional"`` — the value merely is not a whole number. Suggestive
-      (shares are whole) but a fractional holding is not impossible, so the
-      caller restores the original reading when the row offers nothing better.
+    * ``"decisive"`` — the resolved CAPTION names a percent and carries none of
+      ``_STRONG_SHARES_KEYWORDS``. The column says what it holds; that is not
+      an artefact of anything else in the row, so the value is a percent and is
+      never restored as a share count.
+    * ``"weak"`` — a lone ``%`` sibling cell, or a non-integral value. Both are
+      suggestive but circumstantial: a fractional holding is unusual and not
+      impossible, and a ``%`` sign rendered in its OWN cell can sit to the right
+      of a genuine small holding (``[name, '50', '%', '0.1']`` — Codex ckpt-2).
+      The caller restores the original reading when the row offers no
+      whole-number alternative, so a real count is never dropped on positional
+      evidence alone.
     """
     raw = cells[shares_idx] if 0 <= shares_idx < len(cells) else ""
     value = _parse_share_count(raw)
@@ -985,14 +990,12 @@ def _shares_cell_percent_signature(cells: list[str], shares_idx: int, headers: t
     # drop the count entirely.
     if value.is_nan() or value.is_infinite() or value > Decimal(100) or value < Decimal(0):
         return None
-    nxt = next((c.strip() for c in cells[shares_idx + 1 :] if c.strip()), "")
-    if nxt in ("%", "(%)"):
-        return "marker"
     caption = headers[shares_idx].lower() if 0 <= shares_idx < len(headers) else ""
     if ("percent" in caption or "%" in caption) and not any(k in caption for k in _STRONG_SHARES_KEYWORDS):
-        return "marker"
-    if value != value.to_integral_value():
-        return "fractional"
+        return "decisive"
+    nxt = next((c.strip() for c in cells[shares_idx + 1 :] if c.strip()), "")
+    if nxt in ("%", "(%)") or value != value.to_integral_value():
+        return "weak"
     return None
 
 
@@ -1638,13 +1641,15 @@ def _extract_holder_rows(
                     continue
                 shares, shares_src_idx = candidate, i
                 break
-        if shares is None and percent_signature == "fractional":
-            # Nothing whole anywhere in the row, and the only evidence against
-            # the cell was that it is not an integer. A fractional beneficial
-            # holding is unusual but not impossible (DRIP/plan fractions), so
-            # restore the original reading rather than drop the row's only
-            # number on a suggestive signal. ``"marker"`` is deliberately NOT
-            # restored — a lone '%' sibling or a percent caption is decisive.
+        if shares is None and percent_signature == "weak":
+            # Nothing whole anywhere in the row, and the evidence against the
+            # cell was only circumstantial — a non-integral value (a fractional
+            # DRIP/plan holding is unusual but real) or a lone '%' sibling cell,
+            # which can sit to the RIGHT of a genuine small holding when the
+            # issuer renders the sign in its own column (Codex ckpt-2:
+            # ``[name, '50', '%', '0.1']`` would otherwise lose the 50 shares).
+            # Restore rather than drop the row's only number. ``"decisive"`` is
+            # NOT restored — a percent CAPTION states what the column holds.
             shares = _parse_share_count(shares_raw)
             shares_src_idx = shares_idx if shares is not None else -1
         if percent is None:
@@ -1689,7 +1694,7 @@ def _extract_holder_rows(
         # 0000950170-24-100030 'Edward J. Richardson' has 98.1 at shares_idx and
         # 14.8 under 'Percent of Class'; pre-empting stored 98.1.
         held_back_succeeded = percent_signature is not None and shares is not None and shares_src_idx != shares_idx
-        if percent is None and (percent_signature == "marker" or held_back_succeeded):
+        if percent is None and (percent_signature == "decisive" or held_back_succeeded):
             percent = _parse_percent(shares_raw)
             if percent is not None:
                 percent_src_idx = shares_idx

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -2078,7 +2078,15 @@ def _is_address_fragment(name: str) -> bool:
 # owner-identity test nor an address test rejects it.
 _SCHEDULE_13D_COVER_LABEL_RE: Final[re.Pattern[str]] = re.compile(
     r"^(?:"
-    r"(?:sole|shared)\s+(?:voting|dispositive)\s+power\b"  # rows 7-10
+    # Rows 7-10. ``investment`` is included alongside the cover page's own
+    # ``dispositive`` because Rule 13d-3 defines beneficial ownership as voting
+    # OR INVESTMENT power and issuers paraphrase the cover page with it
+    # (0001308179-25-000114 renders a TRANSPOSED table — holders are COLUMNS,
+    # rows are the four power types — and stored 'Sole investment power' as a
+    # holder holding 82,447,476 shares). Note this matches resolved HOLDER
+    # NAMES; #2160's D4 matches the same vocabulary in HEADERS, where it is a
+    # POSITIVE Item 403 signal. Different surfaces, no contradiction.
+    r"(?:sole|shared)\s+(?:voting|dispositive|investment)\s+power\b"
     r"|aggregate\s+amount\s+beneficially\s+owned\b"  # row 11
     r"|percent\s+of\s+class\s+represented\s+by\s+amount\s+in\s+row\b"  # row 13
     r"|type\s+of\s+reporting\s+person\b"  # row 14

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -130,7 +130,18 @@ from app.services.sec_identity import siblings_for_issuer_cik
 # section heading whose noun precedes the threshold ('Other Shareowners that
 # Beneficially Own More than 5%') now sets the 'principal' role instead of
 # letting the management block's role leak onto the holders below it.
-_PARSER_VERSION_DEF14A = "def14a-v11"
+# v12 (#2163): 17 CFR 229.403 column 3 ("Amount and nature of beneficial
+# ownership") is a COUNT, column 4 ("Percent of class") is a PERCENT. A header
+# row carrying empty SPACER cells its data rows do not carry is wider than the
+# data, so shares_idx lands on the percent column; the value still parses, the
+# ragged-row recovery never fires, and the real count one cell to the left is
+# discarded (0001308179-24-000672 stored BlackRock at 17.4 shares and threw away
+# 6,236,345). A percent-signatured value at shares_idx is now held back so the
+# recovery runs, and is read as the percent when the signature is decisive.
+# Also: embedded Schedule 13D/G cover pages (17 CFR 240.13d-101/-102) are no
+# longer parsed as Item 403 tables — their numbered rows stored the cover-page
+# item labels as holder names and the ROW NUMBERS as share counts.
+_PARSER_VERSION_DEF14A = "def14a-v12"
 
 logger = logging.getLogger(__name__)
 

--- a/docs/specs/filings/2026-07-29-def14a-item403-percent-as-shares.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-percent-as-shares.md
@@ -1,0 +1,170 @@
+# DEF 14A Item 403 — percent stored as a share count
+
+Issue: #2163 (re-scoped; the original 23-accession wrong-table cohort moved
+to #2160, which closes 19 of them by model change).
+
+This ticket is the opposite failure to #2160. The table is selected
+**correctly** — a genuine Item 403 table, genuine 5% holders — and the values
+are read off the wrong columns.
+
+## Source rule
+
+**Schedule 14A Item 6(d)** (17 CFR 240.14a-101) requires the registrant to
+furnish the information called for by Item 403 of Regulation S-K.
+
+**17 CFR 229.403** (Reg S-K Item 403) prescribes the table for both subsections:
+
+| # | 403(a) — >5% owners | 403(b) — management + group |
+|---|---|---|
+| 1 | Title of class | Title of class |
+| 2 | Name **and address** of beneficial owner | Name of beneficial owner |
+| 3 | **Amount and nature of beneficial ownership** | Amount and nature of beneficial ownership |
+| 4 | **Percent of class** | Percent of class |
+
+The load-bearing point: **columns 3 and 4 are DISTINCT columns with distinct
+units.** Column 3 is an amount of securities — a count. Column 4 is a
+percentage of the class. A value read out of column 4 and persisted as column 3
+is not a rounding problem, it is a unit error: BlackRock's 17.4% became a
+holding of 17.4 shares while its actual 6,236,345 shares were discarded.
+
+**Rule 13d-3** (17 CFR 240.13d-3) defines "beneficial owner" as a person or
+entity holding voting or investment power. This is what makes column 2 a name
+and not a label — load-bearing for the Schedule 13D class below.
+
+**17 CFR 240.13d-101 / 240.13d-102** prescribe the NUMBERED cover page for
+Schedules 13D and 13G. Rows 7–11 are the sole/shared voting and dispositive
+power lines and the aggregate-amount line; rows 1–6 and 12–14 are the
+reporting-person, funding, citizenship and type-of-person lines.
+
+**#1228 (settled in this parser):** a percent of class is bounded — ownership is
+a fraction of a class — and `_parse_percent` has clamped to `[0, 100]` since
+that ticket. That existing invariant is reused here as a ceiling, not
+re-derived.
+
+## The defect
+
+`_resolve_columns` maps canonical columns by header index. A header row carrying
+empty SPACER cells that its data rows do not carry is WIDER than the data, so
+every resolved index after the first spacer is shifted right.
+
+```text
+0001308179-24-000672
+column_headers = ['Name and address of beneficial owner', '', 'Number\n of shares', '', 'Percent\n of class*']
+resolved       = (name=0, shares=2, percent=4)
+row 0          = ['BlackRock, Inc. 1 50 Hudson Yards\n New York, NY 10001', '6,236,345', '17.4', '%']
+stored         = BlackRock, Inc. … | shares=17.4000 | percent=NULL
+```
+
+`shares_idx=2` lands on the percent. `percent_idx=4` is off the end of a 4-cell
+row. Critically `_parse_share_count('17.4')` **succeeds**, so the `if shares is
+None` ragged-row recovery added in #2140 never fires and the real count at index
+1 is never read.
+
+`'17.4%'` in ONE cell was never this bug — `_parse_share_count` already rejects
+it. The defect needs the value and its sign in SEPARATE cells, which is exactly
+what HTML table rendering produces.
+
+## Full-population verification
+
+Sized **by re-parse, not by SQL proxy.** The stored-table proxy
+
+```sql
+SELECT count(*), count(DISTINCT accession_number)
+FROM def14a_beneficial_holdings
+WHERE shares IS NOT NULL AND shares <> trunc(shares) AND percent_of_class IS NULL;
+--  166 rows | 68 accessions
+```
+
+is a **floor**: a percent of exactly `5` is stored as `5` shares and is
+invisible to it. `scripts/census_def14a_percent_as_shares.py` traces the real
+parse path over all 42,566 stored `def14a_body` payloads and inspects the
+WINNING table's resolved `shares_idx` cell per row.
+
+| population | accessions | rows |
+|---|---|---|
+| SQL proxy (fractional + percent NULL) | 68 | 166 |
+| percent signature at `shares_idx` (census) | 176 | 741 |
+| **the fix actually fires on** | **110** | **353** |
+
+The gap between 741 and 353 is the `[0, 100]` ceiling doing its job: captions
+such as `'2023-2025 PSU Shares Earned at 42% of Target (#)'` and `'Number and
+Percentage of Shares Beneficially Owned'` contain a `%` but carry share counts
+in the millions, and are left alone.
+
+## Design
+
+A share count is a whole number of securities; a value bearing a percent
+signature under a column that is not column 3 is column 4's value.
+`_shares_cell_percent_signature` classifies the cell resolved at `shares_idx`:
+
+| signature | test | treatment |
+|---|---|---|
+| — | value `> 100` or `< 0` | never held back — cannot be a 229.403 column-4 percent (#1228) |
+| `marker` | next non-empty sibling cell is a lone `%` / `(%)` | decisive: held back, and read AS the percent |
+| `marker` | caption at `shares_idx` names a percent and carries none of `_STRONG_SHARES_KEYWORDS` | same |
+| `fractional` | value is not an integer | suggestive: held back, but **restored** if the row offers no whole-number alternative |
+
+Held back means `shares = None`, which lets #2140's existing recovery scan run
+and find the real count elsewhere in the row. That scan already required
+integrality; this change makes the PRIMARY parse consistent with it rather than
+adding a new heuristic.
+
+The `> 100` ceiling is load-bearing, not defensive. Without it a row rendered
+`[name, '1,234,567', '%', '5.6']` — the sign cell BEFORE the percent value —
+would read the sibling `%` as decisive, hold back a genuine 1.2M-share holding,
+find no whole alternative (5.6 is fractional), and drop the count entirely.
+
+`fractional` is deliberately weaker than `marker`: a fractional beneficial
+holding is unusual but real (`FMR LLC` holds 15,072,586.57 on
+`0000086312-26-000103`), so it must never be decisive on its own.
+
+### Second class — embedded Schedule 13D/G cover pages
+
+Proxies embed Schedule 13D/G cover pages as exhibits. The numbered layout parses
+as a table whose "holder names" are the cover-page item labels and whose "share
+counts" are the ROW NUMBERS:
+
+```text
+0001104659-17-023458
+'SHARED VOTING POWER -0'                              shares=8
+'SOLE DISPOSITIVE POWER 32,005,260 shares of Common'  shares=9
+'SHARED DISPOSITIVE POWER -0'                         shares=10
+```
+
+The same label vocabulary also appears in **transposed** tables, where the
+holders are COLUMNS and the rows are the power types — `0001308179-25-000114`
+stored `Sole investment power` as a holder of 82,447,476 shares (that figure is
+BlackRock's, read off the wrong axis). `investment` is therefore matched
+alongside the cover page's own `dispositive`: Rule 13d-3 defines beneficial
+ownership as voting **or investment** power and issuers paraphrase with it.
+
+Note this predicate matches resolved **holder names**. #2160's D4 matches the
+same vocabulary in **headers**, where it is a POSITIVE Item 403 signal
+(229.403 column 3 legitimately subdivides into sole/shared voting power).
+Different surfaces; the two do not contradict.
+
+Neither the owner-identity test nor the address test rejects these — the
+all-caps two-token shape (`SHARED VOTING POWER`) reads as a person name.
+`_SCHEDULE_13D_COVER_LABEL_RE` matches the 240.13d-101/-102 cover-page item
+labels, anchored at the start of the resolved holder name. 229.403 column 2 is a
+beneficial owner (Rule 13d-3); a cover-page item label is not one.
+
+## Not in scope
+
+- **Wrong-table selection** (an Item 402 comp table or a capitalisation table
+  winning over the real Item 403 table) is #2160. Where this fix fires on such a
+  table it moves a junk share count to a junk percent — less wrong, still the
+  wrong table, and #2160 removes the row entirely.
+- **The window loop takes the FIRST qualifying window, not the best.** Untouched
+  here; #2160 owns it.
+
+## Verification
+
+- Full-population A/B, three arms, per `.claude/skills/engineering/full-population-ab.md`.
+  Control is the #2164 head (`2da7caa1`), which is what `main` becomes when
+  PR #2170 merges. Metric is DISTINCT HOLDERS keyed as `holder_name_key`
+  (`lower(trim(holder_name))`), never row count.
+- Arm 3 audits `holder_role` drift, which arms 1 and 2 cannot see because both
+  key on holder NAME.
+- Parser version bumps to `def14a-v12` so the corpus re-drives through
+  `_apply_def14a` with #2157's share-class sibling fan-out.

--- a/docs/specs/filings/2026-07-29-def14a-item403-percent-as-shares.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-percent-as-shares.md
@@ -97,12 +97,28 @@ A share count is a whole number of securities; a value bearing a percent
 signature under a column that is not column 3 is column 4's value.
 `_shares_cell_percent_signature` classifies the cell resolved at `shares_idx`:
 
+The split is **semantic vs positional evidence**, not "how many signals fired":
+
 | signature | test | treatment |
 |---|---|---|
 | — | value `> 100` or `< 0` | never held back — cannot be a 229.403 column-4 percent (#1228) |
-| `marker` | next non-empty sibling cell is a lone `%` / `(%)` | decisive: held back, and read AS the percent |
-| `marker` | caption at `shares_idx` names a percent and carries none of `_STRONG_SHARES_KEYWORDS` | same |
-| `fractional` | value is not an integer | suggestive: held back, but **restored** if the row offers no whole-number alternative |
+| `decisive` | caption at `shares_idx` names a percent and carries none of `_STRONG_SHARES_KEYWORDS` | the column states what it holds; held back and never restored |
+| `weak` | next non-empty sibling cell is a lone `%` / `(%)`, **or** value is not an integer | circumstantial; held back, but **restored** if the row offers no whole-number alternative |
+
+A lone `%` sibling was `marker` (decisive) in the first draft. Codex ckpt-2
+falsified that: when an issuer renders the sign in its own column, a genuine
+small holding sits immediately to its left — `[name, '50', '%', '0.1']` — and a
+decisive reading drops the 50 shares. Column ORDER is not evidence about a
+cell's meaning; the column CAPTION is.
+
+Order matters as well as strength. The held-back cell is a **last-resort**
+percent source, applied only after #2140's ragged-row scan, which accepts solely
+cells carrying a `%` or the `*` marker and is therefore stronger evidence.
+Multi-class tables carry several percent columns and `_resolve_columns`' `total`
+tier matches `'Percent of Total Voting Rights'`; pre-empting the scan on
+`0000950170-24-100030` (Richardson Electronics, 16 headers over 19-cell rows)
+overwrote the real `Percent of Common Stock Class` value 14.8 with 98.1.
+Found by arm 3 in A/B round 2.
 
 Held back means `shares = None`, which lets #2140's existing recovery scan run
 and find the real count elsewhere in the row. That scan already required

--- a/scripts/audit_def14a_value_assignment.py
+++ b/scripts/audit_def14a_value_assignment.py
@@ -1,0 +1,119 @@
+"""Arm 3 — mechanism audit for the DEF 14A Item 403 value assignment (#2163).
+
+The A/B harness (``scripts/ab_2140_def14a_parser.py``) keys on holder NAME, so
+it is blind to a holder that survives with the WRONG numbers — which is exactly
+what this ticket is about. It is equally blind to ``holder_role`` drift (#2164's
+40-holder ``principal`` -> ``None`` regression was visible only to a role audit).
+
+This captures ``{accession: {holder_name_key: [shares, percent, role]}}`` so the
+diff can state, per holder, whether the change moved a value, moved a role,
+added a value that was NULL, or dropped one.
+
+Run on BOTH checkouts — a real control, never a simulated one — and diff:
+
+    PYTHONPATH=. uv run python scripts/audit_def14a_value_assignment.py /tmp/a.json
+    PYTHONPATH=. uv run python scripts/audit_def14a_value_assignment.py --diff /tmp/a.json /tmp/b.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import psycopg
+
+import app.providers.implementations.sec_def14a as parser_mod
+from app.config import settings
+
+
+def _scan(out: str) -> int:
+    audit: dict[str, dict[str, list[str | None]]] = {}
+    n = 0
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET statement_timeout = 0")
+        with conn.cursor(name="value_audit") as cur:
+            cur.itersize = 20
+            cur.execute(
+                "SELECT accession_number, payload FROM filing_raw_documents "
+                "WHERE document_kind = 'def14a_body' ORDER BY accession_number"
+            )
+            for acc, payload in cur:
+                n += 1
+                if n % 2000 == 0:
+                    print(f"... {n}", file=sys.stderr, flush=True)
+                try:
+                    res = parser_mod.parse_beneficial_ownership_table(payload)
+                except Exception:  # noqa: BLE001 — the audit must not abort mid-corpus
+                    continue
+                if not res.rows:
+                    continue
+                # Keyed exactly as the database keys holders (holder_name_key is
+                # lower(trim(holder_name)), sql/116:110) so "the same holder"
+                # means the same thing it means in the read path.
+                audit[acc] = {
+                    h.holder_name.strip().lower(): [
+                        str(h.shares) if h.shares is not None else None,
+                        str(h.percent_of_class) if h.percent_of_class is not None else None,
+                        h.holder_role,
+                    ]
+                    for h in res.rows
+                }
+    with open(out, "w") as fh:
+        json.dump(audit, fh)
+    print(f"DONE {n} accessions, {len(audit)} with rows", file=sys.stderr)
+    return 0
+
+
+def _diff(before_path: str, after_path: str) -> int:
+    with open(before_path) as fh:
+        before: dict[str, Any] = json.load(fh)
+    with open(after_path) as fh:
+        after: dict[str, Any] = json.load(fh)
+
+    buckets: dict[str, list[str]] = {
+        "shares_changed": [],
+        "shares_added": [],
+        "shares_dropped": [],
+        "percent_changed": [],
+        "percent_added": [],
+        "percent_dropped": [],
+        "role_changed": [],
+    }
+    for acc, holders in before.items():
+        post = after.get(acc, {})
+        for name, (b_sh, b_pc, b_role) in holders.items():
+            if name not in post:
+                continue  # holder-level loss/gain is arm 1's job, not this one
+            a_sh, a_pc, a_role = post[name]
+            tag = f"{acc} {name[:44]!r}"
+            if b_sh != a_sh:
+                key = "shares_added" if b_sh is None else ("shares_dropped" if a_sh is None else "shares_changed")
+                buckets[key].append(f"{tag} {b_sh} -> {a_sh}")
+            if b_pc != a_pc:
+                key = "percent_added" if b_pc is None else ("percent_dropped" if a_pc is None else "percent_changed")
+                buckets[key].append(f"{tag} {b_pc} -> {a_pc}")
+            if b_role != a_role:
+                buckets["role_changed"].append(f"{tag} {b_role} -> {a_role}")
+
+    worst = 0
+    for key, items in buckets.items():
+        print(f"\n== {key}: {len(items)} ==")
+        for line in items[:40]:
+            print(f"  {line}")
+        if len(items) > 40:
+            print(f"  ... and {len(items) - 40} more")
+        # Role drift and dropped values are the regression-shaped buckets.
+        if key in ("role_changed", "shares_dropped", "percent_dropped") and items:
+            worst = 1
+    return worst
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--diff":
+        return _diff(argv[1], argv[2])
+    return _scan(argv[0])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/census_def14a_percent_as_shares.py
+++ b/scripts/census_def14a_percent_as_shares.py
@@ -105,6 +105,8 @@ def scan(limit: int | None) -> dict[str, Any]:
             print(f"INSPECT-ERROR {type(exc).__name__}: {exc}", file=sys.stderr)
         return original(table, name_idx=name_idx, shares_idx=shares_idx, percent_idx=percent_idx, rows=rows, seen=seen)
 
+    # Restored in the ``finally`` below (Codex ckpt-3): an exception escaping the
+    # loop would otherwise leave the module patched for the rest of the process.
     P._extract_holder_rows = traced
 
     sql = """
@@ -116,31 +118,35 @@ def scan(limit: int | None) -> dict[str, Any]:
     """
     hits: dict[str, list[dict[str, Any]]] = {}
     n_acc = 0
-    with psycopg.connect(settings.database_url) as conn:
-        conn.execute("SET statement_timeout = 0")
-        with conn.cursor(name="c2163") as cur:
-            cur.itersize = 20
-            cur.execute(sql, {"limit": limit})
-            for accession, body in cur:
-                n_acc += 1
-                if n_acc % 2000 == 0:
-                    print(f"  ... {n_acc} accessions, {len(hits)} hit", file=sys.stderr)
-                bucket.clear()
-                try:
-                    parsed = P.parse_beneficial_ownership_table(body)
-                except Exception as exc:  # noqa: BLE001
-                    print(f"PARSE-ERROR {accession}: {type(exc).__name__}: {exc}", file=sys.stderr)
-                    continue
-                if not bucket:
-                    continue
-                # Only count suspects that actually SURVIVED into stored rows
-                # with that value as their share count.
-                stored = {(r.holder_name.strip().lower(), str(r.shares)) for r in parsed.rows if r.shares is not None}
-                live = [b for b in bucket if (b["holder"], b["value"]) in stored]
-                if live:
-                    hits[accession] = live
+    try:
+        with psycopg.connect(settings.database_url) as conn:
+            conn.execute("SET statement_timeout = 0")
+            with conn.cursor(name="c2163") as cur:
+                cur.itersize = 20
+                cur.execute(sql, {"limit": limit})
+                for accession, body in cur:
+                    n_acc += 1
+                    if n_acc % 2000 == 0:
+                        print(f"  ... {n_acc} accessions, {len(hits)} hit", file=sys.stderr)
+                    bucket.clear()
+                    try:
+                        parsed = P.parse_beneficial_ownership_table(body)
+                    except Exception as exc:  # noqa: BLE001
+                        print(f"PARSE-ERROR {accession}: {type(exc).__name__}: {exc}", file=sys.stderr)
+                        continue
+                    if not bucket:
+                        continue
+                    # Only count suspects that actually SURVIVED into stored rows
+                    # with that value as their share count.
+                    stored = {
+                        (r.holder_name.strip().lower(), str(r.shares)) for r in parsed.rows if r.shares is not None
+                    }
+                    live = [b for b in bucket if (b["holder"], b["value"]) in stored]
+                    if live:
+                        hits[accession] = live
 
-    P._extract_holder_rows = original
+    finally:
+        P._extract_holder_rows = original
     return {"accessions_scanned": n_acc, "hits": hits}
 
 

--- a/scripts/census_def14a_percent_as_shares.py
+++ b/scripts/census_def14a_percent_as_shares.py
@@ -1,0 +1,165 @@
+"""#2163 census — size the percent-stored-as-share-count cohort BY RE-PARSE.
+
+The SQL proxy (``shares <> trunc(shares) AND percent_of_class IS NULL``) is a
+FLOOR: a percent of exactly ``5`` is stored as ``5`` shares and is invisible.
+This traces the real parse path, inspects the WINNING Item 403 table's resolved
+``shares_idx`` cell per row, and flags rows where that cell is a PERCENT.
+
+17 CFR 229.403 column 3 = "Amount and nature of beneficial ownership" (a count
+of shares); column 4 = "Percent of class". They are distinct columns.
+
+Read-only, offline from ``filing_raw_documents``.
+
+    PYTHONPATH=. uv run python scripts/census_def14a_percent_as_shares.py --out /tmp/census2163.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+import psycopg
+
+import app.providers.implementations.sec_def14a as P
+from app.config import settings
+
+_PCT_SIGNS = ("%", "(%)")
+
+
+def _next_nonempty(cells: list[str], start: int) -> str:
+    return next((c.strip() for c in cells[start:] if c.strip()), "")
+
+
+def _inspect_table(table: Any, name_idx: int, shares_idx: int, percent_idx: int) -> list[dict[str, Any]]:
+    """Return one record per data row whose shares_idx cell looks like a PERCENT."""
+    out: list[dict[str, Any]] = []
+    headers = table.column_headers
+    hdr_w = len(headers)
+    data_w = max((len(r) for r in table.rows), default=0)
+    header_blanks = sum(1 for h in headers if not h.strip())
+    ragged_header = hdr_w > data_w and header_blanks > 0
+    shares_caption = headers[shares_idx].lower() if 0 <= shares_idx < hdr_w else ""
+    pct_caption = "percent" in shares_caption or "%" in shares_caption
+
+    for raw_row in table.rows:
+        cells = P._pad_row(raw_row, name_idx=name_idx, shares_idx=shares_idx, percent_idx=percent_idx)
+        if not any(c.strip() for c in cells):
+            continue
+        raw_shares = cells[shares_idx] if 0 <= shares_idx < len(cells) else ""
+        v = P._parse_share_count(raw_shares)
+        if v is None:
+            continue
+        name_src_idx, raw_name = P._resolve_row_name(cells, name_idx=name_idx, shares_idx=shares_idx)
+        holder = P._clean_beneficial_holder_name(raw_name)
+        if not holder:
+            continue
+
+        fractional = v != v.to_integral_value()
+        pct_sibling = _next_nonempty(cells, shares_idx + 1) in _PCT_SIGNS
+        pct_in_cell = "%" in raw_shares
+
+        # Is a genuine WHOLE share count available elsewhere in the row?
+        alt: str | None = None
+        for i, cell in enumerate(cells):
+            if i in (name_src_idx, shares_idx):
+                continue
+            if "%" in cell:
+                continue
+            cand = P._parse_share_count(cell)
+            if cand is not None and cand == cand.to_integral_value() and cand > 0:
+                alt = cell.strip()
+                break
+
+        if not (fractional or pct_sibling or pct_caption or pct_in_cell):
+            continue
+        out.append(
+            {
+                "holder": holder.strip().lower(),
+                "shares_cell": raw_shares.strip(),
+                "value": str(v),
+                "fractional": fractional,
+                "pct_sibling": pct_sibling,
+                "pct_caption": pct_caption,
+                "pct_in_cell": pct_in_cell,
+                "ragged_header": ragged_header,
+                "hdr_w": hdr_w,
+                "data_w": data_w,
+                "alt_whole": alt,
+                "idx": [name_idx, shares_idx, percent_idx],
+                "headers": list(headers),
+            }
+        )
+    return out
+
+
+def scan(limit: int | None) -> dict[str, Any]:
+    original = P._extract_holder_rows
+    bucket: list[dict[str, Any]] = []
+
+    def traced(table: Any, *, name_idx: int, shares_idx: int, percent_idx: int, rows: Any, seen: Any) -> None:
+        try:
+            bucket.extend(_inspect_table(table, name_idx, shares_idx, percent_idx))
+        except Exception as exc:  # noqa: BLE001 — census must not abort mid-corpus
+            print(f"INSPECT-ERROR {type(exc).__name__}: {exc}", file=sys.stderr)
+        return original(table, name_idx=name_idx, shares_idx=shares_idx, percent_idx=percent_idx, rows=rows, seen=seen)
+
+    P._extract_holder_rows = traced
+
+    sql = """
+        SELECT accession_number, payload
+        FROM filing_raw_documents
+        WHERE document_kind = 'def14a_body'
+        ORDER BY accession_number
+        LIMIT %(limit)s
+    """
+    hits: dict[str, list[dict[str, Any]]] = {}
+    n_acc = 0
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET statement_timeout = 0")
+        with conn.cursor(name="c2163") as cur:
+            cur.itersize = 20
+            cur.execute(sql, {"limit": limit})
+            for accession, body in cur:
+                n_acc += 1
+                if n_acc % 2000 == 0:
+                    print(f"  ... {n_acc} accessions, {len(hits)} hit", file=sys.stderr)
+                bucket.clear()
+                try:
+                    parsed = P.parse_beneficial_ownership_table(body)
+                except Exception as exc:  # noqa: BLE001
+                    print(f"PARSE-ERROR {accession}: {type(exc).__name__}: {exc}", file=sys.stderr)
+                    continue
+                if not bucket:
+                    continue
+                # Only count suspects that actually SURVIVED into stored rows
+                # with that value as their share count.
+                stored = {(r.holder_name.strip().lower(), str(r.shares)) for r in parsed.rows if r.shares is not None}
+                live = [b for b in bucket if (b["holder"], b["value"]) in stored]
+                if live:
+                    hits[accession] = live
+
+    P._extract_holder_rows = original
+    return {"accessions_scanned": n_acc, "hits": hits}
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--limit", type=int, default=None)
+    a = ap.parse_args(argv)
+    res = scan(a.limit)
+    with open(a.out, "w") as fh:
+        json.dump(res, fh)
+    rows = sum(len(v) for v in res["hits"].values())
+    print(f"scanned={res['accessions_scanned']} hit_accessions={len(res['hits'])} hit_rows={rows}")
+    frac = sum(1 for v in res["hits"].values() for r in v if r["fractional"])
+    ragged = len({k for k, v in res["hits"].items() if any(r["ragged_header"] for r in v)})
+    withalt = sum(1 for v in res["hits"].values() for r in v if r["alt_whole"])
+    print(f"  fractional={frac}  ragged_header_accessions={ragged}  rows_with_whole_alt={withalt}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -1742,3 +1742,25 @@ class TestTwoPercentColumnsOrdering:
         cells = ["Dennis Polk", "30.0", "100.0", "%"]
         headers = ("Name", "Target as a Percentage of Base Salary", "Maximum", "")
         assert _shares_cell_percent_signature(cells, 2, headers) is not None
+
+    def test_a_small_holding_before_a_lone_percent_sign_is_not_dropped(self) -> None:
+        # Codex ckpt-2. When the issuer renders the '%' sign in its OWN column,
+        # a genuine small holding sits immediately to its left and trips the
+        # sibling test. That evidence is POSITIONAL, so it is "weak": with no
+        # whole-number alternative in the row the original reading is restored
+        # rather than the row losing its share count.
+        body = """
+        <table>
+          <tr><th>Name of Beneficial Owner</th><th>Shares Beneficially Owned</th>
+              <th></th><th>Percent of Class</th></tr>
+          <tr><td>Jane Q. Director</td><td>50</td><td>%</td><td>0.1</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares) for r in parsed.rows] == [("Jane Q. Director", Decimal("50"))]
+
+    def test_a_percent_CAPTION_is_still_decisive(self) -> None:
+        # The complement: caption evidence is SEMANTIC, so it is never restored.
+        cells = ["Simon Leung", "29.6"]
+        headers = ("Name", "Minimum Payment (if Threshold is Met) as Percentage of Base Salary")
+        assert _shares_cell_percent_signature(cells, 1, headers) == "decisive"

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -1710,3 +1710,35 @@ class TestEmbeddedSchedule13DCoverPage:
         assert not _SCHEDULE_13D_COVER_LABEL_RE.match("BlackRock, Inc.")
         assert not _SCHEDULE_13D_COVER_LABEL_RE.match("Power Corporation of Canada")
         assert not _SCHEDULE_13D_COVER_LABEL_RE.match("Sole Proprietor Holdings LLC")
+
+
+class TestTwoPercentColumnsOrdering:
+    """#2163 A/B round 3. Multi-class Item 403 tables carry SEVERAL percent
+    columns, and `_resolve_columns`' `total` shares-tier happily matches
+    'Percent of Total Voting Rights'. The held-back cell is therefore only a
+    LAST-resort percent source: it must never pre-empt the ragged-row scan,
+    which accepts only cells carrying a '%' or the '*' marker."""
+
+    def test_an_unambiguous_percent_cell_beats_the_held_back_cell(self) -> None:
+        # 0000950170-24-100030 (Richardson Electronics) shape. On main this
+        # stored shares=98.1 / percent=14.8; pre-empting the scan stored
+        # percent=98.1 and lost the real 14.8.
+        body = """
+        <table>
+          <tr><th>Name of Beneficial Owner</th><th>Shares of Common Stock</th>
+              <th>Percent of Common Stock Class</th><th>Percent of Total Voting Rights</th></tr>
+          <tr><td>Edward J. Richardson</td><td>2,129,271</td><td>14.8%</td><td>98.1</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares, r.percent_of_class) for r in parsed.rows] == [
+            ("Edward J. Richardson", Decimal("2129271"), Decimal("14.8"))
+        ]
+
+    def test_the_recovery_scan_will_not_take_another_percent_as_the_count(self) -> None:
+        # Regression B: when the primary cell was held back as a percent, the
+        # recovery must not simply grab the next percent along
+        # (0001177394-25-000016 held back 30.0 then recovered 100.0).
+        cells = ["Dennis Polk", "30.0", "100.0", "%"]
+        headers = ("Name", "Target as a Percentage of Base Salary", "Maximum", "")
+        assert _shares_cell_percent_signature(cells, 2, headers) is not None

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -1701,6 +1701,10 @@ class TestEmbeddedSchedule13DCoverPage:
 
     def test_the_label_test_is_anchored_and_spares_real_holders(self) -> None:
         assert _SCHEDULE_13D_COVER_LABEL_RE.match("SHARED VOTING POWER -0")
+        # Rule 13d-3 says voting OR INVESTMENT power; 0001308179-25-000114
+        # renders a TRANSPOSED table whose rows are the four power types.
+        assert _SCHEDULE_13D_COVER_LABEL_RE.match("Sole investment power")
+        assert _SCHEDULE_13D_COVER_LABEL_RE.match("Shared investment power")
         assert _SCHEDULE_13D_COVER_LABEL_RE.match("Aggregate Amount Beneficially Owned by Each Reporting Person")
         assert _SCHEDULE_13D_COVER_LABEL_RE.match("TYPE OF REPORTING PERSON")
         assert not _SCHEDULE_13D_COVER_LABEL_RE.match("BlackRock, Inc.")

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -25,6 +25,7 @@ from datetime import date
 from decimal import Decimal
 
 from app.providers.implementations.sec_def14a import (
+    _SCHEDULE_13D_COVER_LABEL_RE,
     Def14ABeneficialOwnershipTable,
     _clean_beneficial_holder_name,
     _clean_holder_name,
@@ -37,6 +38,7 @@ from app.providers.implementations.sec_def14a import (
     _parse_share_count,
     _resolve_columns,
     _score_table_headers,
+    _shares_cell_percent_signature,
     _strip_inline_html,
     extract_plan_name_and_trustee,
     is_esop_plan,
@@ -1606,3 +1608,101 @@ class TestFivePercentHeadingIsOrderInsensitive:
             ("Ashbel C. Williams", "officer"),
             ("BlackRock, Inc.", "principal"),
         ]
+
+
+class TestPercentStoredAsShareCount:
+    """#2163 — 17 CFR 229.403 column 3 ("Amount and nature of beneficial
+    ownership") is a COUNT of shares; column 4 ("Percent of class") is a
+    percentage. A header row carrying empty SPACER cells its data rows do not
+    carry is WIDER than the data, so ``shares_idx`` lands on the percent column.
+    ``_parse_share_count('17.4')`` succeeds, so the ragged-row recovery never
+    fires and the real count one cell to the left is discarded."""
+
+    def test_spacer_widened_header_does_not_store_the_percent_as_shares(self) -> None:
+        # 0001308179-24-000672 shape: headers ('Name and address of beneficial
+        # owner', '', 'Number of shares', '', 'Percent of class*') — 5 cells
+        # over 4-cell data rows — resolved (name=0, shares=2, percent=4), so
+        # BlackRock stored shares=17.4 / percent=NULL and 6,236,345 was lost.
+        body = """
+        <table>
+          <tr><th>Name and address of beneficial owner</th><th></th><th>Number of shares</th>
+              <th></th><th>Percent of class*</th></tr>
+          <tr><td>BlackRock, Inc.</td><td>6,236,345</td><td>17.4</td><td>%</td></tr>
+          <tr><td>Vanguard Group, Inc.</td><td>3,761,632</td><td>10.5</td><td>%</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares, r.percent_of_class) for r in parsed.rows] == [
+            ("BlackRock, Inc.", Decimal("6236345"), Decimal("17.4")),
+            ("Vanguard Group, Inc.", Decimal("3761632"), Decimal("10.5")),
+        ]
+
+    def test_a_whole_percent_is_caught_too(self) -> None:
+        # The SQL proxy for this class (`shares <> trunc(shares)`) is a FLOOR: a
+        # percent of exactly 5 is stored as 5 shares and is invisible to it. The
+        # lone '%' sibling cell is what makes it detectable.
+        body = """
+        <table>
+          <tr><th>Name and address of beneficial owner</th><th></th><th>Number of shares</th>
+              <th></th><th>Percent of class</th></tr>
+          <tr><td>State Street Corporation</td><td>1,904,790</td><td>5</td><td>%</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares, r.percent_of_class) for r in parsed.rows] == [
+            ("State Street Corporation", Decimal("1904790"), Decimal("5"))
+        ]
+
+    def test_a_share_count_above_the_percent_ceiling_is_never_held_back(self) -> None:
+        # A percent of class is bounded by definition; _parse_percent has
+        # clamped to [0, 100] since #1228. Without that ceiling a row rendering
+        # the sign cell BEFORE the percent value would read the '%' sibling as
+        # decisive and drop a genuine 1.2M-share holding.
+        cells = ["Ninepoint Partners LP", "1,234,567", "%", "5.6"]
+        headers = ("Name of Beneficial Owner", "Shares", "", "Percent")
+        assert _shares_cell_percent_signature(cells, 1, headers) is None
+
+    def test_a_fractional_value_with_nothing_better_in_the_row_is_kept(self) -> None:
+        # 'fractional' alone is suggestive, not decisive — a fractional holding
+        # is unusual but not impossible. With no whole candidate anywhere in the
+        # row the original reading is restored rather than the row losing its
+        # only number.
+        body = """
+        <table>
+          <tr><th>Name of Beneficial Owner</th><th>Amount and Nature of Beneficial Ownership</th></tr>
+          <tr><td>Jane Q. Holder</td><td>1,234.5</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares) for r in parsed.rows] == [("Jane Q. Holder", Decimal("1234.5"))]
+
+
+class TestEmbeddedSchedule13DCoverPage:
+    """#2163 — 17 CFR 240.13d-101 / -102 prescribe a NUMBERED cover page for
+    Schedules 13D / 13G. Proxies embed those cover pages as exhibits, and the
+    numbered layout parses as a table whose holder names are the item labels and
+    whose share counts are the ROW NUMBERS. 229.403 column 2 is a beneficial
+    owner (a person or entity, per Rule 13d-3); an item label is not."""
+
+    def test_cover_page_power_rows_are_not_holders(self) -> None:
+        # 0001104659-17-023458 stored 'SHARED VOTING POWER -0' with shares=8,
+        # 'SOLE DISPOSITIVE POWER 32,005,260 shares…' with shares=9, etc.
+        body = """
+        <table>
+          <tr><th>NUMBER OF SHARES BENEFICIALLY OWNED BY EACH REPORTING PERSON WITH</th><th></th>
+              <th>7.</th><th></th><th>SOLE VOTING POWER 32,005,260 shares of Common Stock</th></tr>
+          <tr><td></td><td></td><td>8.</td><td></td><td>SHARED VOTING POWER -0-</td></tr>
+          <tr><td></td><td></td><td>9.</td><td></td><td>SOLE DISPOSITIVE POWER 32,005,260 shares</td></tr>
+          <tr><td></td><td></td><td>10.</td><td></td><td>SHARED DISPOSITIVE POWER -0-</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert parsed.rows == []
+
+    def test_the_label_test_is_anchored_and_spares_real_holders(self) -> None:
+        assert _SCHEDULE_13D_COVER_LABEL_RE.match("SHARED VOTING POWER -0")
+        assert _SCHEDULE_13D_COVER_LABEL_RE.match("Aggregate Amount Beneficially Owned by Each Reporting Person")
+        assert _SCHEDULE_13D_COVER_LABEL_RE.match("TYPE OF REPORTING PERSON")
+        assert not _SCHEDULE_13D_COVER_LABEL_RE.match("BlackRock, Inc.")
+        assert not _SCHEDULE_13D_COVER_LABEL_RE.match("Power Corporation of Canada")
+        assert not _SCHEDULE_13D_COVER_LABEL_RE.match("Sole Proprietor Holdings LLC")


### PR DESCRIPTION
## What and why

17 CFR 229.403 prescribes column 3 as **"Amount and nature of beneficial ownership"** (a
COUNT of shares) and column 4 as **"Percent of class"**. They are distinct columns with
distinct units. This PR stops the parser reading column 4 and persisting it as column 3.

A header row carrying empty SPACER cells that its data rows do not carry is WIDER than the
data, so every resolved index after the first spacer shifts right and `shares_idx` lands on
a percent:

```text
0001308179-24-000672
column_headers = ['Name and address of beneficial owner', '', 'Number of shares', '', 'Percent of class*']
resolved       = (name=0, shares=2, percent=4)
row 0          = ['BlackRock, Inc. 1 50 Hudson Yards New York, NY 10001', '6,236,345', '17.4', '%']
stored         = BlackRock, Inc. … | shares=17.4000 | percent=NULL
```

`_parse_share_count('17.4')` **succeeds**, so #2140's `if shares is None` ragged-row
recovery never fires and the real 6,236,345 at index 1 is discarded. (`'17.4%'` in ONE cell
was never this bug — `_parse_share_count` already rejects it. The defect needs the value
and its sign in SEPARATE cells, which is what HTML table rendering produces.)

Spec: `docs/specs/filings/2026-07-29-def14a-item403-percent-as-shares.md`.

## Source rule

- **17 CFR 229.403** (Reg S-K Item 403), reached via **Schedule 14A Item 6(d)**
  (17 CFR 240.14a-101) — columns 3 and 4, their units, and the fact that column 4 is
  denominated on **the class whose count column 3 holds**.
- **Rule 13d-3** (17 CFR 240.13d-3) — "beneficial owner" is a person or entity holding
  voting **or investment** power. Load-bearing twice: it makes column 2 a name rather than
  a label, and it is why `investment` joins `voting`/`dispositive` in the cover-page test.
- **17 CFR 240.13d-101 / -102** — the NUMBERED Schedule 13D/13G cover page.
- **#1228**, already settled in this parser — a percent of class is bounded, and
  `_parse_percent` has clamped to `[0, 100]` since. Reused here as a ceiling, not re-derived.

## Design

`_shares_cell_percent_signature` classifies the cell resolved at `shares_idx`. The split is
**semantic vs positional evidence**, not "how many signals fired":

| signature | test | treatment |
|---|---|---|
| — | value `> 100` or `< 0` | never held back — cannot be a column-4 percent (#1228) |
| `decisive` | the CAPTION names a percent and carries none of `_STRONG_SHARES_KEYWORDS` | the column states what it holds; held back, never restored |
| `weak` | a lone `%` sibling cell, **or** a non-integral value | circumstantial; held back, but **restored** if the row offers no whole-number alternative |

"Held back" means `shares = None`, which lets #2140's existing recovery scan run and find
the real count. That scan already required integrality; this makes the PRIMARY parse
consistent with it rather than adding a new heuristic.

Two ordering/strength constraints, both found by measurement and recorded in the spec:

- The held-back cell is a **last-resort** percent source, applied only AFTER the ragged-row
  scan. The scan accepts solely cells carrying a `%` or the `*` marker and is therefore
  stronger evidence.
- The `> 100` ceiling is load-bearing, not defensive: without it a row rendered
  `[name, '1,234,567', '%', '5.6']` would read the sibling `%` as decisive and drop a
  genuine 1.2M-share holding.

Also rejects embedded **Schedule 13D/G cover pages**, whose numbered rows stored the
cover-page item labels as holder names and the ROW NUMBERS as share counts
(`0001104659-17-023458`: `'SHARED VOTING POWER -0'` with `shares=8`). The same vocabulary
appears in TRANSPOSED tables where holders are columns — `0001308179-25-000114` stored
`'Sole investment power'` as a holder of 82,447,476 shares, BlackRock's figure read off the
wrong axis.

## Full-population verification

Cohort sized **by re-parse, not by SQL proxy** (`scripts/census_def14a_percent_as_shares.py`).
The stored-table proxy is a FLOOR — a percent of exactly `5` is stored as `5` shares and is
invisible to it:

| population | accessions | rows |
|---|---|---|
| SQL proxy (`shares <> trunc(shares) AND percent IS NULL`) | 68 | 166 |
| percent signature at `shares_idx` (census) | 176 | 741 |
| the fix fires on | 110 | 353 |

The gap between 741 and 353 is the `[0,100]` ceiling working: captions such as
`'2023-2025 PSU Shares Earned at 42% of Target (#)'` and `'Number and Percentage of Shares
Beneficially Owned'` contain a `%` but carry share counts in the millions, and are left alone.

### Four A/B rounds, two real checkouts, never a simulated control

Control `~/Dev/ebull-2163-ctl` @ `2da7caa1` (the #2164 head, i.e. what `main` became).

**Arm 1 — parse vs parse.** Round 4, all 42,566 stored bodies:

```text
accessions_with_rows      7,170 ->  7,168
rows                    105,341 -> 105,334
shares_without_percent    9,071 ->  8,900
sct_rows                 67,573 -> 67,573   (Item 402(c) blast radius: unchanged)
Item 402(c) SCT drift:   0 accessions
promoted header shapes:  13,273 -> 13,273, 0 newly promoted

accessions LOSING rows:  2      accessions GAINING rows: 0
distinct holders lost:   7      distinct holders gained:  0
  0001308179-25-000114  -4  sole/shared voting power, sole/shared investment power
  0001104659-17-023458  -3  sole/shared dispositive power, shared voting power
```

**Every lost identity is a Schedule 13D cover-page label. Zero genuine holders lost.**

**Arm 3 — value + role audit** (`scripts/audit_def14a_value_assignment.py`, new).
Load-bearing for this ticket: arms 1 and 2 key on holder NAME, so a holder that survives
with the WRONG NUMBERS is invisible to both — which is exactly what #2163 is. Arm 1 reports
**zero gains** for a change that corrects 353 values.

```text
shares_changed   329      of which 325 recovered to a REAL count (> 100)
shares_added       0
shares_dropped     4      all Item 402 comp-table percents under decisive captions
percent_added    164      rows that had NO percent now have one
percent_changed   14      all improvements — see below
percent_dropped    0
role_changed       0      <-- #2164's regression class, clean
```

Sample recoveries: Danaher `0000313616-25-000081` Mitchell P. Rales **4.9 → 34,932,704**,
Steven M. Rales 6.1 → 43,489,945; `0000740260-26-000010` Vanguard 13.5 → 63,988,891,
BlackRock 8.8 → 41,935,325.

**The 14 percent changes are all class re-pairings**, and they are the same defect seen from
the other side. Multi-class tables put `% of Total Voting Power` at `shares_idx`:

```text
0001193125-25-065614
headers: Name | Shares of Class A Common Stock(2) | Class A Share% | FOA Units(2) | % of Total Voting Power(3)
resolved: name=0, shares=8, percent=4
Blackstone: 3,192,284 | 29.8% | 4,837,533 | 33.7%
  before: percent = 33.7   (total voting power, paired with a Class A count)
  after : shares  = 3,192,284, percent = 29.8   (both Class A)
```

229.403 column 4 is the percent **of the class** column 3 counts. Same shape on Pagaya
`0001883085-26-000039` (Class B 9,922,774 now paired with Class B 57.1%, not the 40.1%
voting-power figure).

**Residual, hand-classified, all on tables #2160 removes outright:** 4 rows on
`0000868857-26-000006` (AECOM ownership-guidelines table, 87.0 → 100.0) and 4 dropped on
`0001177394-25-000016` / `0001628280-26-007901` (`'Minimum Payment (if Threshold is Met) as
Percentage of Base Salary'`). Never share counts to begin with.

### Defects this process caught in my own change

Budgeted for, per `.claude/skills/engineering/full-population-ab.md`. Each round found one:

1. **Round 1 (arm 1)** — the cover-page predicate half-covered a TRANSPOSED table,
   cleaning 2 of 4 junk rows. Fixed by matching `investment` power (`63428f4c`).
2. **Round 2 (arm 3)** — reading the held-back cell as the percent BEFORE the ragged-row
   scan overwrote the real percent on multi-class tables: Richardson Electronics 14.8 →
   98.1, Jack Dorsey 0.5 → 79.7, both genuine. Fixed by ordering (`9b998bb9`). Invisible to
   arm 1.
3. **Round 2 (arm 3)** — the recovery scan could take the next percent along as the share
   count. Candidate now gets the same signature test (`9b998bb9`).
4. **Codex ckpt-2 [P2]** — a lone `%` sibling was decisive, but when an issuer renders the
   sign in its own column a genuine small holding sits to its left
   (`[name, '50', '%', '0.1']`) and the count was dropped. Split the strengths on semantic
   vs positional evidence (`722e4855`). **Conscious cost:** 3 junk rows this PR previously
   removed now survive, all on #2160-owned tables; matching `main` on them is not a
   regression, and never losing a genuine holder outranks removing junk that has an owner.

## Definition of done — ETL clauses 8-12

All at commit `b47110cc`, dev DB, after the v12 rewash.

| clause | evidence |
|---|---|
| 8. Panel smoke | `AAPL` `GME` `MSFT` `JPM` `HD` via `/instruments/{symbol}/ownership-rollup`. All 200; 4 of 5 carry a `def14a_unmatched` slice with `dominant_source=def14a` (AAPL 15, GME 10, MSFT 10, HD 22 filers; JPM has no matched DEF 14A blockholder, which is correct for it). |
| 9. Cross-source | `0000950170-25-048978` vs SEC EDGAR direct — Vanguard `94,052,723 / 12.76%`, BlackRock `64,137,817 / 8.70%`, exact. |
| 10. Backfill executed | `PYTHONPATH=. uv run python scripts/rewash.py --kind def14a_body` (the CLI, in-process through `_apply_def14a` with #2157's sibling fan-out — NOT `sec_rebuild`). Result `scanned=42566 reparsed=7274 skipped=35267 failed=25`. 7,112 of 7,137 accessions that have holdings are now on `def14a-v12`. |
| 11. Operator-visible figure | `0001308179-24-000672` now stores `BlackRock, Inc. … 6,236,345 / 17.4%` (was `17.4` shares / `NULL`), plus Vanguard `3,761,632 / 10.5`, Dimensional `2,817,228 / 7.9`, State Street `1,904,790 / 5.3`. |
| 12. Recorded at commit | this table, at `b47110cc`. |

On the version histogram: 35,091 rows stay on `def14a-v1` permanently — they are proxies
with **no Item 403 table**, so `_apply_def14a` returns falsy and `run_rewash` skips without
bumping. Judge completeness by *accessions WITH holdings not on the current version*, never
by the raw histogram.

### ⚠ Known gap this PR does NOT close — filed as #2173

The 7 junk cover-page rows are removed **at parse time but not in storage.** Both affected
accessions now yield zero holders, which trips `_apply_def14a`'s regression brake
(`RewashParseError: re-parse produced zero holders; previous parser found rows`), so they
stay pinned at `def14a-v11` and the rows remain live:

```text
0001104659-17-023458  'SHARED VOTING POWER -0'          8.0000
0001308179-25-000114  'Sole investment power'    82,447,476.0000
```

The guard is right to exist and I am deliberately not weakening a safety mechanism inside
this PR. #2160 does **not** cover it either — that ticket unblocks its residual by making a
genuine table selectable, and these two filings have no Item 403 table to select. #2173
carries the fix with its own full-population A/B. `failed=25` on the v12 pass = 23
pre-existing (#2160's cohort) + these 2.

Everything else in this PR — the 353 corrected values across 110 accessions — landed.

## Review

Bot **APPROVE** on `b47110cc` with one NITPICK: the census script monkey-patches
`P._extract_holder_rows` to trace, which breaks silently if that private signature changes.
ACCEPTED as-is — it is offline operator tooling, not shipped code, and the alternative
(re-implementing table selection in the script) is the "never simulate the control" failure
the A/B skill warns about. The tracer wrapper takes the same keyword-only arguments as the
real function, so a signature change fails loudly at call time rather than silently.

## Tradeoffs / notes

- Parser version bumps to `def14a-v12` so the corpus re-drives through `_apply_def14a` with
  #2157's share-class sibling fan-out. The conflict key derives from `holder_name`, so a
  corrected row lands under the SAME key here (names are untouched) — this PR changes values
  and drops junk rows, so `_supersede_dropped_holdings` carries the removals. Its empty-set
  guard is untouched (`x <> ALL('{}')` is vacuously TRUE — prevention-log #2140 BLOCKING).
- Wrong-TABLE selection stays out of scope; that is #2160. Where this fix fires on such a
  table it moves a junk share count to a junk percent — less wrong, still the wrong table,
  and #2160 removes the row entirely.
- `0000937556-23-000099` (`Eli Kammerman`, 301 shares) was verified as a **detector false
  positive** — a genuine small holding — and is deliberately untouched.

Closes #2163.
