### PR TITLE
fix(#2173): release the DEF 14A zero-holder rewash guard when every stored row is a Schedule 13D/G cover-page label

### DIFF
--- a/app/services/rewash_filings.py
+++ b/app/services/rewash_filings.py
@@ -40,7 +40,7 @@ current spec.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
 from typing import Any
@@ -490,6 +490,53 @@ register_parser(
 # ---------------------------------------------------------------------------
 
 
+def _stored_rows_are_all_13d_cover_labels(conn: psycopg.Connection[Any], accession_number: str) -> bool:
+    """True when EVERY stored holder for ACCESSION_NUMBER is a 13D/G form field.
+
+    Source rule: 17 CFR 240.13d-101 (Schedule 13D) and 240.13d-102 (Schedule
+    13G) prescribe a numbered cover page whose rows 7-11 are the voting and
+    dispositive-power lines. Proxies embed those cover pages as exhibits, and
+    before #2163 the numbered layout parsed as a table whose "holder names"
+    were the item labels and whose "share counts" were the ROW NUMBERS.
+
+    17 CFR 229.403 column 2 is a *beneficial owner*, which Rule 13d-3 (17 CFR
+    240.13d-3) defines as a person or entity holding voting or investment
+    power. A cover-page item label is neither, so an accession whose every
+    stored row is one of them holds no Item 403 data at all and zero rows is
+    the reg-correct outcome.
+
+    ALL, not ANY: a mixed accession has at least one row that may be a genuine
+    holder, and superseding those is the data loss the guard exists to prevent.
+    Measured full-population — 2 of 7,141 accessions with stored holdings are
+    all-cover-label, and NONE is mixed.
+
+    Returns ``False`` for an accession with no stored rows, so it can never be
+    the reason an empty parse is accepted.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT holder_name FROM def14a_beneficial_holdings WHERE accession_number = %s",
+            (accession_number,),
+        )
+        names = [row[0] for row in cur.fetchall()]
+    return all_names_are_13d_cover_labels(names)
+
+
+def all_names_are_13d_cover_labels(names: Sequence[str | None]) -> bool:
+    """The DECISION behind :func:`_stored_rows_are_all_13d_cover_labels`, pure.
+
+    Split out so the release rule is table-testable without a database — the
+    SQL above is a plain read and carries none of the judgement.
+    """
+    from app.providers.implementations.sec_def14a import _SCHEDULE_13D_COVER_LABEL_RE
+
+    cleaned = [(name or "").strip() for name in names]
+    if not cleaned or any(not name for name in cleaned):
+        # An empty or blank-bearing set is never proof of a correct zero.
+        return False
+    return all(_SCHEDULE_13D_COVER_LABEL_RE.match(name) for name in cleaned)
+
+
 def _apply_def14a(
     conn: psycopg.Connection[Any],
     raw_doc: RawFilingDocument,
@@ -585,7 +632,37 @@ def _apply_def14a(
             f"parse_beneficial_ownership_table failed for accession={raw_doc.accession_number}: {exc}"
         ) from exc
 
-    if not parsed.rows:
+    # #2173 — the zero-holder guard cannot, on its own, tell "the parser broke"
+    # from "zero is the RIGHT answer", so it pins the latter forever with the
+    # junk still live. Release it on exactly one provable case: every stored row
+    # is a Schedule 13D/G COVER-PAGE item label (17 CFR 240.13d-101 / -102).
+    # 229.403 column 2 is a beneficial owner, which Rule 13d-3 defines as a
+    # person or entity holding voting or investment power; a cover-page item
+    # label is a FORM FIELD and is neither. Superseding those rows is the
+    # correction, not data loss.
+    #
+    # Keyed on what is STORED, deliberately, rather than on a reason threaded
+    # out of the parser: the test can then only ever release rows that are
+    # provably not Item 403 data, so a genuine table that the parser stops
+    # finding still raises. Full population: 2 of 7,141 accessions with stored
+    # holdings qualify — exactly the two #2163 created — and none is mixed.
+    supersede_correct_zero = (
+        not parsed.rows and had_existing_rows and _stored_rows_are_all_13d_cover_labels(conn, raw_doc.accession_number)
+    )
+    if supersede_correct_zero:
+        # Falls through to the replace-then-insert path below, which with zero
+        # rows deletes the typed rows, tombstones the accession's observations
+        # (``_record_def14a_observations_for_filing`` with an empty holder list
+        # runs its supersede UPDATE and then writes nothing) and lets
+        # ``refresh_def14a_current`` prune ``_current`` via WHEN NOT MATCHED BY
+        # SOURCE. No special-case SQL, and in particular no empty-array
+        # ``<> ALL('{}')`` path — ``_supersede_dropped_holdings`` is not on it.
+        logger.info(
+            "DEF 14A accession=%s re-parses to zero holders and every stored row is a "
+            "Schedule 13D/G cover-page label — superseding rather than failing the rewash",
+            raw_doc.accession_number,
+        )
+    if not parsed.rows and not supersede_correct_zero:
         if had_existing_rows:
             # Parser regression on a populated accession — raise
             # so the operator sees the gap in rows_failed rather

--- a/tests/test_rewash_def14a_correct_zero.py
+++ b/tests/test_rewash_def14a_correct_zero.py
@@ -1,0 +1,53 @@
+"""#2173 — when is a zero-holder DEF 14A re-parse the RIGHT answer?
+
+``_apply_def14a``'s guard raises ``RewashParseError`` whenever a re-parse
+produces no holders for an accession that previously had rows. That is correct
+as a regression brake, but it cannot tell "the parser broke" from "zero is the
+right answer" — so #2163's two Schedule 13D/G cover-page accessions were pinned
+at their old parser version with the junk still live.
+
+The release rule is keyed on what is STORED, not on a reason threaded out of the
+parser: it can then only ever release rows that are provably not Item 403 data.
+"""
+
+from __future__ import annotations
+
+from app.services.rewash_filings import all_names_are_13d_cover_labels
+
+# The rows actually stored for the two accessions named on #2173, verbatim.
+_ACC_0001104659_17_023458 = [
+    "SHARED DISPOSITIVE POWER -0",
+    "SHARED VOTING POWER -0",
+    "SOLE DISPOSITIVE POWER 32,005,260 shares of Common Stock (See Items 5 and 5)",
+]
+_ACC_0001308179_25_000114 = [
+    "Sole voting power",
+    "Shared voting power",
+    "Sole investment power",
+    "Shared investment power",
+]
+
+
+class TestCorrectZeroRelease:
+    def test_the_two_cover_page_accessions_release(self) -> None:
+        """17 CFR 240.13d-101/-102 cover-page item labels are form fields, not
+        beneficial owners under Rule 13d-3, so zero rows is reg-correct."""
+        assert all_names_are_13d_cover_labels(_ACC_0001104659_17_023458)
+        assert all_names_are_13d_cover_labels(_ACC_0001308179_25_000114)
+
+    def test_a_genuine_holder_anywhere_keeps_the_guard(self) -> None:
+        """ALL, not ANY. A mixed accession has at least one row that may be a
+        real holder, and superseding those is the loss the guard prevents."""
+        assert not all_names_are_13d_cover_labels([*_ACC_0001308179_25_000114, "BlackRock, Inc."])
+        assert not all_names_are_13d_cover_labels(["The Vanguard Group", "SHARED VOTING POWER -0"])
+        assert not all_names_are_13d_cover_labels(["BlackRock, Inc.", "The Vanguard Group"])
+
+    def test_an_empty_or_blank_set_is_never_proof(self) -> None:
+        """``all()`` over an empty sequence is vacuously TRUE — the same shape
+        as the ``<> ALL('{}')`` trap that made #2140's supersede delete a whole
+        accession. An accession with no stored rows must not read as a correct
+        zero."""
+        assert not all_names_are_13d_cover_labels([])
+        assert not all_names_are_13d_cover_labels(["", "   "])
+        assert not all_names_are_13d_cover_labels([None])
+        assert not all_names_are_13d_cover_labels(["SHARED VOTING POWER -0", ""])


### PR DESCRIPTION
## What changed

`_apply_def14a` (`app/services/rewash_filings.py`) raises `RewashParseError` whenever a
re-parse produces zero holders for an accession that previously had rows. That is right
as a regression brake, but it cannot distinguish **"the parser broke"** from **"zero is
the right answer"**.

This releases the guard on exactly one provable case: **every stored holder name for the
accession is a Schedule 13D/G cover-page item label.**

## Why

#2163 correctly stopped parsing embedded Schedule 13D/G cover pages as Item 403 tables.
Two accessions contain no Item 403 table at all, so their correct parse is zero rows —
and both are therefore pinned at `def14a-v11` with the junk still live and
operator-visible:

```text
0001104659-17-023458  'SHARED VOTING POWER -0'                                8.0000
0001104659-17-023458  'SOLE DISPOSITIVE POWER 32,005,260 shares of Common…'   9.0000
0001308179-25-000114  'Sole investment power'                          82447476.0000
0001308179-25-000114  'Sole voting power'                              73524638.0000
```

Those "share counts" are the cover-page ROW NUMBERS (rows 8, 9, 10) and, for the
transposed table, BlackRock's figures read off the wrong axis.

## Source rule

17 CFR **240.13d-101** (Schedule 13D) and **240.13d-102** (Schedule 13G) prescribe the
numbered cover page whose rows 7-11 are the voting and dispositive-power lines.

17 CFR **229.403** column 2 is a *beneficial owner*, which **Rule 13d-3** (17 CFR
240.13d-3) defines as a person or entity holding voting or investment power. A
cover-page item label is a FORM FIELD and is neither — so zero rows is the reg-correct
outcome for these filings and the store must be able to reflect it.

## Design — keyed on what is STORED, not on a parser reason

The issue offered two options; this is neither, and deliberately so.

Threading a `no_item_403_section` reason out of the parser (option 1) would make the
brake fire on *parser intent*, which a parser bug also produces. Keying on the STORED
rows means the test can only ever release rows that are **provably not Item 403 data**.
A genuine table the parser stops finding still raises.

That also decouples this from **#2160**: its 199 newly-emptied accessions hold real
holder names, so none of them qualifies and all stay guarded.

**`_is_owner_identity` is NOT a usable discriminator here** — it returns `True` for 5 of
the 7 stored labels (`SHARED VOTING POWER -0` reads as a two-capitalised-token person
name). The cover-label regex `_SCHEDULE_13D_COVER_LABEL_RE`, already on `main` from
#2163, catches all 7.

## Full-population verification

Per `.claude/skills/engineering/full-population-ab.md`, this touches a SAFETY mechanism,
so the arm that matters is *"accessions the guard currently protects that would now be
emptied"* — enumerated and hand-classified, not counted.

Over **all 7,141 accessions with stored holdings**:

```text
ALL rows are 13D cover labels : 2    <- exactly the two on the issue
SOME row is a cover label     : 2    <- i.e. ZERO mixed accessions
```

Both are listed in full in the commit message. There is no mixed cohort, so the
ALL-vs-ANY choice costs nothing today and is still the safe one tomorrow.

## Safety notes

- **ALL, not ANY.** A mixed accession has at least one row that may be a real holder, and
  superseding those is the loss the guard exists to prevent.
- **An empty set is never proof.** `all()` over an empty sequence is vacuously TRUE — the
  same shape as the `<> ALL('{}')` trap that `_supersede_dropped_holdings` guards
  against. `all_names_are_13d_cover_labels([])` returns `False`, as does any set with a
  blank name. Pinned by test.
- **No new SQL on the release path.** It falls through to the existing
  replace-then-insert flow, which with zero rows deletes the typed rows, tombstones the
  accession's observations (`_record_def14a_observations_for_filing` runs its supersede
  UPDATE then writes nothing) and lets `refresh_def14a_current` prune `_current` via
  `WHEN NOT MATCHED BY SOURCE`. `_supersede_dropped_holdings` — the function carrying the
  empty-array guard — is not on this path at all.

## Tests

Decision extracted to a pure `all_names_are_13d_cover_labels()` and table-tested, per the
repo's prefer-pure-policy-over-real-DBs rule; the SQL is a plain read carrying no
judgement. `tests/test_rewash_def14a_correct_zero.py` — release, ALL-not-ANY, and the
vacuous-empty-set case.

## Conscious tradeoffs

- **Narrow by construction.** A future correct-zero class that is not a 13D/G cover page
  stays pinned. That is deliberate: this releases only what is provable today, and the
  brake keeps its full strength everywhere else. If another class appears, it gets its
  own measured predicate.
- **No parser-version bump.** This changes the rewash chokepoint, not the parse, so
  bumping would force a needless 42,577-body re-walk. The two accessions are below the
  current version already and will be re-visited by the next `def14a_body` rewash.

## Checks

`ruff check` · `ruff format --check` · `pyright` · `pytest -m "not db"` · `pytest
tests/smoke` — all pass. Codex `exec review --base origin/main`: no regression found.

Closes #2173. Refs #2163. Refs #2160.