### PR TITLE
fix(#2160): select the Item 403 table by 17 CFR 229.403's own structure, not by header score

### DIFF
--- a/.claude/skills/data-sources/edgartools.md
+++ b/.claude/skills/data-sources/edgartools.md
@@ -25,7 +25,7 @@ Network-required (live filing fetch + identity required):
 | N-CEN | `FundCensus.from_filing(filing)` | structured census |
 | N-MFP2/3 | `MoneyMarketFund.from_filing(filing)` | money-market holdings |
 | N-PX | `NPX.from_filing(filing)` | proxy voting record |
-| DEF 14A family | `ProxyStatement.from_filing(filing)`; `Company.proxy_season(0)` | HTML extraction; quality variable |
+| DEF 14A family | `ProxyStatement.from_filing(filing)`; `Company.proxy_season(0)`; `edgar.proxy.html_extractor.extract_beneficial_ownership(tree)` / `extract_summary_compensation` / `extract_director_compensation` / `extract_ceo_pay_ratio` / `extract_audit_fees` / `extract_voting_proposals` | HTML extraction; quality variable. See **G16** (SCT — ours wins) and **G17** (Item 403 — complementary, and the source of the data-row column-classification technique). |
 | S-1 / F-1 / S-3 / 424B / 497K / CORRESP | `RegistrationS1.from_filing(filing)` etc. | added in 5.23-5.27 |
 | Filings index walk | `get_filings(year, quarter, form=..., index=...)` | calendar year, NOT fiscal |
 | Submissions API per CIK | `get_entity_submissions(cik)` → `EntityData` | wraps `data.sec.gov` |
@@ -218,6 +218,57 @@ parsed["signatures"]                   # list[Signature dataclass]
 **Pin against drift**: a contract test (e.g. `tests/test_edgartools_schedule13_shape.py`) that exercises BOTH top-level dict keys AND nested dataclass attribute access on a real EDGAR fixture catches any `edgartools` upgrade that renames either layer at CI time.
 
 **Codex 1d/1e/1f on the PR11 spec all caught this in sequence** — the documentation gap cost three review rounds. This entry exists so the next PR adopting `parse_xml` gets it right on the first pass.
+
+### G17 — DEF 14A Item 403 `extract_beneficial_ownership`: complementary, NOT a drop-in — but borrow its data-row column fallback
+
+`edgar.proxy.html_extractor.extract_beneficial_ownership(tree)` -> `list[BeneficialOwner(name, holder_type, shares, percent_of_class)]`,
+where `holder_type` is `5pct_holder` / `director_officer` / `group`. Architecture
+mirrors ours: section-heading anchors (`_OWNERSHIP_HEADING_ANCHORS` +
+`_OWNERSHIP_HEADING_REJECTS`), a table scorer (`_score_ownership_table`), then a
+column map.
+
+Measured offline on our stored bodies (#2160, edgartools 5.30.2), against the 8
+accessions our `def14a-v13` branch emptied and hand-classified as GENUINE losses:
+
+```text
+0001193125-25-075693   ours 0   edgartools 20 rows WITH percentages
+0001104659-25-031699   ours 0   edgartools 18 rows WITH percentages
+0001213900-26-047155   ours 0   edgartools  4 rows
+0000816956-26-000047   ours 0   edgartools  2 rows   <- main found 16; UNDER-extracts
+0000805928-25-000059   ours 0   edgartools None
+0000805928-26-000057   ours 0   edgartools None
+0001437749-25-009904   ours 0   edgartools None
+0001104659-26-036909   ours 0   edgartools None
+```
+
+**Verdict: do not swap.** It returns `None` on half our failing set and
+under-extracts a fifth. Same shape of answer as G16 — the value is the
+TECHNIQUE, not the function.
+
+**The technique worth taking** (`_build_column_map`, html_extractor.py:775):
+
+```python
+for i, header in enumerate(headers):          # header pass
+    if (t := classifier(header)): col_map[t] = i
+if len(col_map) < min_columns:                # DATA-ROW FALLBACK
+    for row in data_rows[:2]:
+        for i, cell in enumerate(row):
+            if (t := classifier(cell)) and t not in col_map: col_map[t] = i
+```
+
+When headers classify too few columns, it classifies the first two DATA ROWS
+instead. Our Item 403 gate is header-only, which is precisely why a genuine
+table rendering `| | | Number of Shares | | | | | | Number of Shares | |` over
+BlackRock / First Light / Soleus rows is rejected (44 accessions full-pop).
+
+⚠ Call it with **bytes**: `lxml.html.fromstring(payload.encode())`. A `str`
+carrying an encoding declaration raises
+`ValueError: Unicode strings with encoding declaration are not supported`.
+
+Note also that no dedicated open-source Item 403 parser exists anywhere — Item
+403 is unstructured BY REGULATION (17 CFR 240.14a-101 mandates content, not
+form). The structured arbiters for the same facts are Schedule 13D/G (XML
+mandate 2024-12-18) and Forms 3/4/5, both already ingested here.
 
 ### G16 — DEF 14A SCT name/title split leaks the title into the name (do NOT drop-in for exec comp)
 `edgar.proxy.html_extractor.extract_summary_compensation(tree)` returns `list[ExecutiveCompEntry(name, title, year, salary…total)]` and DOES flatten intra-cell newlines first (`_split_name_title`, `html_extractor.py:551` — `re.sub(r'\s+',' ',cell)`; the later `\n`-split at :554 is dead code). But it then **comma-splits before role-keyword-splits** (:554 vs :570), so a multi-clause NEO cell leaks the first title phrase into `name`. Verified empirically on Alphabet `0001308179-25-000511` (edgartools 5.30.2, offline via `lxml.html.fromstring(body_bytes)`):

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -529,7 +529,13 @@ _RULE_13D3_60_DAY_RE: Final[re.Pattern[str]] = re.compile(
 # Comp-denominated percents — Item 402, not Item 403.
 _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
     r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting"
-    r"|bonus\s+opportunity|salary|earned|performance)",
+    r"|bonus\s+opportunity|salary|earned|performance"
+    # Item 402 is titled "Executive COMPENSATION"; 229.403 column 4 is a percent
+    # OF CLASS, never of compensation. Board-attendance tables are Item 407.
+    # Added when the data-row fallback (weak evidence) began admitting
+    # 'Percentage of Annual Total Direct Compensation' and
+    # 'Attendance Percentage of All Meetings'.
+    r"|compensation|attendance|meetings?\s+attended|dilution)",
     re.IGNORECASE,
 )
 # Item 402(a)(3) DEFINES "named executive officer"; Item 403 says "name of
@@ -538,7 +544,7 @@ _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
 _ITEM402_NEO_CAPTION_RE: Final[re.Pattern[str]] = re.compile(r"named\s+executive\s+officer", re.IGNORECASE)
 
 
-def _item403_value_signature(headers: tuple[str, ...]) -> bool:
+def _item403_value_signature(headers: tuple[str, ...], *, data_row_evidence: bool = False) -> bool:
     """True when HEADERS carry Item 403's prescribed VALUE columns.
 
     Precedence, not a flat vocabulary match — and the ordering is the whole
@@ -578,6 +584,10 @@ def _item403_value_signature(headers: tuple[str, ...]) -> bool:
         return True
     if _COMP_PCT_RE.search(joined) or _ITEM402_NEO_CAPTION_RE.search(joined):
         return False
+    if data_row_evidence:
+        # Step 3b — the captions carry nothing, but the ROWS show both of
+        # 229.403's value columns parsing. Below the vetoes by construction.
+        return True
     return bool(
         _ITEM403_AMOUNT_IND_RE.search(joined)
         and (
@@ -1865,9 +1875,54 @@ def _is_item403_eligible(table: _RawTable) -> bool:
     only in ``score_headers`` — so reading the narrower tuple rejected the most
     prescribed shape the reg has, at scores 14 and 16.
     """
-    if not _item403_value_signature(tuple(table.score_headers) + tuple(table.column_headers)):
+    name_idx, shares_idx, percent_idx = _resolve_columns(table.column_headers)
+    holders: list[Def14ABeneficialHolder] = []
+    _extract_holder_rows(
+        table,
+        name_idx=name_idx,
+        shares_idx=shares_idx,
+        percent_idx=percent_idx,
+        rows=holders,
+        seen=set(),
+    )
+    if not holders:
         return False
-    return _owner_identity_fraction(table) >= _ROW_IDENTITY_FLOOR
+    headers = tuple(table.score_headers) + tuple(table.column_headers)
+    if not _item403_value_signature(headers, data_row_evidence=_has_item403_value_rows(holders)):
+        return False
+    hits = sum(1 for h in holders if _is_beneficial_owner_identity(h.holder_name))
+    return hits / len(holders) >= _ROW_IDENTITY_FLOOR
+
+
+_VALUE_ROW_EVIDENCE_FLOOR: Final[float] = 0.5
+
+
+def _has_item403_value_rows(holders: list[Def14ABeneficialHolder]) -> bool:
+    """D4 data-row fallback (#2160) — Item 403's value columns, evidenced by the ROWS.
+
+    Technique borrowed from ``edgar.proxy.html_extractor._build_column_map``,
+    which falls back to classifying the first DATA ROWS when the headers
+    classify too few columns (skill G17). Our gate was header-only, and that is
+    exactly why a genuine table rendering
+    ``| | | Number of Shares | | | | | | Number of Shares | |`` over
+    BlackRock / First Light / Soleus rows was emptied: the captions had degraded
+    to blank cells and carried no percent token at all.
+
+    17 CFR 229.403 prescribes column 3 (amount) AND column 4 (percent of class).
+    When the CAPTIONS are gone, both columns PARSING for a majority of extracted
+    rows is the remaining evidence that both exist. Deliberately requires BOTH —
+    an Item 402 award table routinely has an amount column and no percent.
+
+    Ranks BELOW the Item 402 vetoes on purpose: this is weak evidence, and a
+    comp table with a payout-percent column also satisfies it.
+    """
+    if not holders:
+        return False
+    n = len(holders)
+    shares = sum(1 for h in holders if h.shares is not None)
+    percents = sum(1 for h in holders if h.percent_of_class is not None)
+    floor = _VALUE_ROW_EVIDENCE_FLOOR * n
+    return shares >= floor and percents >= floor
 
 
 def _extract_holder_rows(

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -515,7 +515,17 @@ _ITEM403_OWNED_IND_RE: Final[re.Pattern[str]] = re.compile(r"\bown(ed|ership)\b"
 # captioned "Options Exercisable or Vesting Within 60 Days" is therefore quoting
 # the ownership rule, NOT Item 402 — so this is STRONG Item 403 evidence and
 # must outrank the comp veto, which would otherwise fire on "vesting".
-_RULE_13D3_60_DAY_RE: Final[re.Pattern[str]] = re.compile(r"within\s+(\d{1,3}|sixty)\s+days", re.IGNORECASE)
+#
+# The ACQUISITION VERB is required, not just the phrase. 13d-3(d)(1)(i) is about
+# securities a person has "the right to acquire" within sixty days; the bare
+# phrase also appears in change-in-control and termination tables, and admitting
+# those before the Item 402 veto would emit severance data as ownership (Codex
+# ckpt-1 HIGH). Verb and window must sit in the SAME header cell.
+_RULE_13D3_60_DAY_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:(?:exercisab|acquir|issuab|vest|convert|settl)\w*[^|]{0,40}?within\s+(?:\d{1,3}|sixty)\s+days"
+    r"|within\s+(?:\d{1,3}|sixty)\s+days[^|]{0,40}?(?:exercisab|acquir|issuab|vest|convert|settl)\w*)",
+    re.IGNORECASE,
+)
 # Comp-denominated percents — Item 402, not Item 403.
 _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
     r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting"
@@ -1076,8 +1086,12 @@ _IDENTITY_DEBRIS_RE: Final[re.Pattern[str]] = re.compile(r"[.…]{3,}")
 # A proper-noun run followed by a NUMBER, which is the name/street-number seam.
 # Deliberately not a hardcoded issuer list (the spec's clause 5): the signal is
 # the reg's own one-column name-and-address form, not who the filer is.
+# ``_is_name_then_address`` implements this; it is defined next to
+# ``_is_address_fragment`` so it can share ``_STREET_TYPE``, which this module
+# declares further down.
 _OWNER_NAME_THEN_ADDRESS_RE: Final[re.Pattern[str]] = re.compile(
-    r"^[A-Z][\w&.'’-]*(?:\s+[A-Z][\w&.'’-]*){0,3}\s+\d",
+    r"^[A-Z][\w&.'’-]*(?:\s+[A-Z][\w&.'’-]*){0,3}\s+\d(?P<tail>.*)$",
+    re.DOTALL,
 )
 
 
@@ -1125,7 +1139,7 @@ def _is_beneficial_owner_identity(text: str) -> bool:
         return True
     if _OWNER_PERSON_RE.match(stripped):
         return True
-    return bool(_OWNER_NAME_THEN_ADDRESS_RE.match(stripped))
+    return _is_name_then_address(stripped)
 
 
 def _is_owner_identity(text: str) -> bool:
@@ -2443,6 +2457,28 @@ _ADDRESS_ONLY_RE: Final[re.Pattern[str]] = re.compile(
 def _is_address_fragment(name: str) -> bool:
     """True when a holder-name cell holds only address material (#2140)."""
     return bool(_ADDRESS_ONLY_RE.match(name.strip()))
+
+
+# D1 clause 4-5 (#2160) — the tail after the name must carry ADDRESS evidence,
+# not merely a number: a proper-noun run followed by any digit also matches
+# metric rows like 'Adjusted EBITDA 2024' (Codex ckpt-1 MED). Accepted evidence
+# is a US street type, a 5-digit ZIP, or the multi-comma locality chain a
+# non-US address uses ('4-5, Marunouchi 1-chome Chiyoda-ku, Tokyo 100-8330,
+# Japan') — the last is what carries the international filers, which have
+# neither a street type nor a ZIP.
+_ADDRESS_TAIL_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:" + _STREET_TYPE + r")\b|\b\d{5}\b",
+    re.IGNORECASE,
+)
+
+
+def _is_name_then_address(text: str) -> bool:
+    """True when TEXT is Item 403(a)'s one-column 'name AND address' form."""
+    m = _OWNER_NAME_THEN_ADDRESS_RE.match(text)
+    if m is None:
+        return False
+    tail = m.group("tail")
+    return bool(_ADDRESS_TAIL_EVIDENCE_RE.search(tail) or tail.count(",") >= 2)
 
 
 # Schedule 13D/G COVER-PAGE item labels (#2163).

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -439,10 +439,52 @@ _ITEM_402_AWARD_MARKERS: Final[tuple[str, ...]] = (
 )
 
 
-# Minimum score for a NON-best table to be merged as an Item 403 sibling.
-# 6 is what a header with SEC-prescribed wording reaches (see SCORE_FLOOR's
-# note in ``parse_beneficial_ownership_table``); 3-5 is bare or incidental.
-_SIBLING_SCORE_FLOOR: Final[int] = 6
+# D4 (#2160) — Item 403's VALUE-column signature.
+#
+# Source rule: 17 CFR 229.403 prescribes column 3 "Amount and nature of
+# beneficial ownership" and column 4 "Percent of class". Column 4 is
+# CLASS-denominated by definition — a fraction of a class of securities. An
+# Item 402 compensation table's percent is of *salary*, *target*, *payout* or
+# *vesting*, never of a class. That is the discriminator row identity cannot
+# supply: comp-table rows ARE people ('Kevin R.M. Smith', 'Dr. Hou'), so they
+# score owner_identity_fraction = 1.00 and pass D2 untouched.
+#
+# Measured on the full admit cohort (spec, census pass 2): the gate takes
+# 1,668 -> 45 candidate tables, and the survivors are the genuine shapes.
+_ITEM403_CLASS_PCT_RE: Final[re.Pattern[str]] = re.compile(
+    r"(percent|percentage|%)\s*(of\s+)?(the\s+)?(all\s+|total\s+|outstanding\s+)*"
+    r"(class|common|shares|stock|voting|ownership|beneficial|equity|units)",
+    re.IGNORECASE,
+)
+# Column 3 subdivided. Rule 13d-3 (17 CFR 240.13d-3) defines beneficial
+# ownership as voting OR investment power, so issuers legitimately split
+# "Amount and nature" into Sole/Shared voting and dispositive power columns and
+# carry no separate percent column at all. ``_resolve_columns`` already tiers
+# Sole|Shared|Total. Without this arm those tables fail D4 and are rejected.
+_ITEM403_AMOUNT_NATURE_RE: Final[re.Pattern[str]] = re.compile(
+    r"(amount\s+and\s+nature)|((sole|shared)\s+(voting|dispositive|investment))",
+    re.IGNORECASE,
+)
+# Comp-denominated percents — Item 402, not Item 403. Checked FIRST: a comp
+# table can also say "shares", so the positive arms alone would admit it.
+_COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
+    r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting"
+    r"|bonus\s+opportunity|salary|earned|performance)",
+    re.IGNORECASE,
+)
+
+
+def _item403_value_signature(headers: tuple[str, ...]) -> bool:
+    """True when HEADERS carry Item 403's prescribed VALUE columns.
+
+    Signature = a **class-denominated percent** column OR the
+    **amount-and-nature** voting/dispositive-power subdivision, and never a
+    comp-denominated percent. See the regexes above for the governing reg.
+    """
+    joined = " | ".join(headers)
+    if _COMP_PCT_RE.search(joined):
+        return False
+    return bool(_ITEM403_CLASS_PCT_RE.search(joined) or _ITEM403_AMOUNT_NATURE_RE.search(joined))
 
 
 def _score_table_headers(headers: tuple[str, ...]) -> int:
@@ -832,6 +874,137 @@ _HOLDER_CLASS_PLURAL_RE: Final[re.Pattern[str]] = re.compile(
     r"|officers|executives|nominees|persons)\b",
     re.IGNORECASE,
 )
+
+
+# D1 (#2160) — corrections the spec's measurement forced on the row-identity
+# predicate when it moved from #2164's single-cell use into table SELECTION.
+#
+# 1. LENGTH CAP. Sized for an Item 403(a) "name AND address" cell, the longest
+#    legitimate form. Without it, Schedule 13G footnote PARAGRAPHS ("Based
+#    solely on an amendment to a Schedule 13G filed by BlackRock…", "Consists of
+#    10,500 shares held directly…") pass the person-name test and were extracted
+#    as holder names.
+_OWNER_IDENTITY_MAX_LEN: Final[int] = 120
+# 2. Entity designators, CASE-SENSITIVE. An Item 403 owner is a proper noun:
+#    'Smith Family Trust' matches, the instrument types 'trust interests' and
+#    'allocation interests' do not. ``_OWNER_ENTITY_RE`` is deliberately
+#    IGNORECASE and load-bearing for #2164's stacked-pair path, so selection
+#    gets its own stricter variant rather than tightening that one.
+_OWNER_ENTITY_CASED_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b("
+    r"LLC|L\.L\.C|LP|L\.P|LLP|Inc|Incorporated|Corp|Corporation|Company|Ltd|Limited"
+    r"|Trust|Fund|Funds|Partners|Partnership|Capital|Management|Advisers|Advisors"
+    r"|Holdings|Associates|Ventures|Bank|N\.A|plc|PLC|GmbH|S\.A|AG|NV"
+    r"|Foundation|Insurance|Investments?|Securities|Financial"
+    r")\b"
+)
+# 3. INSTRUMENT-TYPE vocabulary. A name composed ENTIRELY of equity/award nouns
+#    is a security, not a beneficial owner under Rule 13d-3. A closed
+#    vocabulary set, deliberately not a table-shape blocklist — the
+#    prevention-log rule on hand-enumerated tuples targets the latter.
+_INSTRUMENT_VOCAB: Final[frozenset[str]] = frozenset(
+    {
+        "equity",
+        "equities",
+        "stock",
+        "stocks",
+        "share",
+        "shares",
+        "option",
+        "options",
+        "warrant",
+        "warrants",
+        "unit",
+        "units",
+        "restricted",
+        "unrestricted",
+        "deferred",
+        "performance",
+        "incentive",
+        "award",
+        "awards",
+        "grant",
+        "grants",
+        "rsu",
+        "rsus",
+        "psu",
+        "psus",
+        "sar",
+        "sars",
+        "appreciation",
+        "right",
+        "rights",
+        "common",
+        "preferred",
+        "ordinary",
+        "class",
+        "series",
+        "voting",
+        "nonvoting",
+        "convertible",
+        "note",
+        "notes",
+        "debenture",
+        "debentures",
+        "interest",
+        "interests",
+        "plan",
+        "plans",
+        "total",
+        "subtotal",
+        "authorized",
+        "unissued",
+        "issued",
+        "outstanding",
+        "treasury",
+        "reserved",
+        "available",
+        "and",
+        "or",
+        "the",
+        "of",
+        "for",
+        "but",
+        "a",
+    }
+)
+_WORD_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z]+")
+
+
+def _is_instrument_not_owner(text: str) -> bool:
+    """True when every word in TEXT is equity/award vocabulary.
+
+    'Authorized But Unissued' is Title-Cased and matches the two-capitalised-
+    token person pattern, so neither D1's person arm nor an address test rejects
+    it. Rule 13d-3 makes the test principled: a beneficial owner is a person or
+    entity holding voting or investment power, and an instrument is neither.
+    """
+    words = _WORD_RE.findall(text.lower())
+    if not words:
+        return False
+    return all(w in _INSTRUMENT_VOCAB for w in words)
+
+
+def _is_beneficial_owner_identity(text: str) -> bool:
+    """D1 (#2160) — row-identity test used to gate table SELECTION.
+
+    Stricter than :func:`_is_owner_identity`, which #2164 uses for the
+    single-cell stacked-pair decision. Both share the class-noun rejection; this
+    one adds the three corrections the full-population census forced (length
+    cap, case-sensitive entity designators, instrument vocabulary).
+    """
+    stripped = text.strip()
+    if not stripped or len(stripped) > _OWNER_IDENTITY_MAX_LEN:
+        return False
+    if _is_instrument_not_owner(stripped):
+        return False
+    if "as a group" in stripped.lower():
+        return True
+    if _HOLDER_CLASS_PLURAL_RE.search(stripped):
+        return False
+    if _OWNER_ENTITY_CASED_RE.search(stripped):
+        return True
+    return bool(_OWNER_PERSON_RE.match(stripped))
 
 
 def _is_owner_identity(text: str) -> bool:
@@ -1389,24 +1562,36 @@ def parse_beneficial_ownership_table(html_text: str) -> Def14ABeneficialOwnershi
                 window_best_score = score
             if score >= SCORE_FLOOR:
                 window_qualifying.append((score, parsed))
-        if window_qualifying and window_best_score >= SCORE_FLOOR:
+        # D2 / D3 (#2160) — ELIGIBILITY decides both which table wins the window
+        # and which tables join it as Item 403 siblings. Header score no longer
+        # decides either; it is retained for RANKING only (the sort at the
+        # concatenation loop below, so the best-captioned table's figures win a
+        # holder reported twice).
+        #
+        # Header score is a SUM OF KEYWORD WEIGHTS and cannot separate a genuine
+        # Item 403 table from a comp / prose / capitalisation table that hits the
+        # same keywords: 0001628280-26-044960's genuine 403(a) table
+        # (Name and Address | Number | Percent) scores 4 while a
+        # Delaware-vs-Texas charter prose block scores 5 and takes the window.
+        #
+        # Row identity ALONE is also insufficient, which is why eligibility has
+        # two limbs. Item 402 compensation tables' rows ARE people
+        # ('Kevin R.M. Smith', 'Dr. Hou', 'Jennifer F. Scanlon'), so they score
+        # owner_identity_fraction = 1.00 and would pass a row-identity gate
+        # untouched. D4's value signature is what rejects them. Both limbs gate
+        # WINNER selection as well as sibling membership — correction of
+        # 2026-07-29b, measured: the draft applied D4 to the sibling set only,
+        # which left this ticket's central case untouched.
+        #
+        # ``_SIBLING_SCORE_FLOOR`` is deleted. Its absolute 6 existed only
+        # because header score was the sole signal; a genuine 403(b) table on a
+        # bare Name|Shares|Percent header scores 3 and is now admitted on its
+        # rows and value columns instead.
+        eligible = [t for _, t in window_qualifying if _is_item403_eligible(t)]
+        if eligible:
             best_score = window_best_score
-            # Sibling tables need SEC-PRESCRIBED wording, not merely the
-            # floor. The floor is 3 — a bare Name|Shares|Percent header — so
-            # merging everything above it sweeps in prose and summary tables
-            # that happen to mention shares.
-            #
-            # An ABSOLUTE floor, not proximity to the best score: the two
-            # genuine Item 403 tables can score far apart, because whichever
-            # one happens to use the prescribed "Amount and Nature of
-            # Beneficial Ownership" caption scores much higher than a sibling
-            # headed "Common Stock" (12 vs 7 on 0001193125-25-245150 — a
-            # `best - 2` gate dropped that filing's 18-row 403(b) table and
-            # kept only 2 rows). Breakdown tables do not need a score gate:
-            # they restate the SAME HOLDERS, so the identity dedup in
-            # ``_extract_holder_rows`` already collapses them.
-            qualifying = [t for sc, t in window_qualifying if sc >= _SIBLING_SCORE_FLOOR or sc == window_best_score]
-            best_table = qualifying[0] if qualifying else None
+            qualifying = eligible
+            best_table = eligible[0]
             chosen_window = (window_start, window_end)
             break
         # Also track the global best in case no window meets floor —
@@ -1491,6 +1676,56 @@ def _row_name_is_address(raw_row: tuple[str, ...] | None, *, name_idx: int, shar
     cells = _pad_row(raw_row, name_idx=name_idx, shares_idx=shares_idx, percent_idx=percent_idx)
     _, raw_name = _resolve_row_name(cells, name_idx=name_idx, shares_idx=shares_idx)
     return _is_address_fragment(_clean_beneficial_holder_name(raw_name))
+
+
+_ROW_IDENTITY_FLOOR: Final[float] = 0.5
+
+
+def _owner_identity_fraction(table: _RawTable) -> float:
+    """D0 (#2160) — fraction of TABLE's extracted rows that name a beneficial owner.
+
+    Computed on the **resolved name column**, reached through the same path
+    extraction uses. Not the raw first cell: Item 403's prescribed column 1 is
+    ``Title of class``, so a genuine table rendering
+    ``Common Stock | The Vanguard Group | 5,799,197 | 5.3%`` would fail a
+    first-cell test outright (Codex ckpt-1 BLOCKING on the spec).
+
+    Sharing ``_extract_holder_rows`` is required, not incidental: it already
+    drops section headings, address-continuation fragments and value-less rows,
+    and recovers ragged cells. Measuring on raw rows would count a
+    ``Named Executive Officers`` heading as an identity and would penalise a
+    genuine table whose rows are address continuations.
+
+    Denominator is the extracted holder count. A table extracting zero holders
+    cannot win its window anyway (#2158 element 4), so it scores 0.0.
+    """
+    name_idx, shares_idx, percent_idx = _resolve_columns(table.column_headers)
+    holders: list[Def14ABeneficialHolder] = []
+    _extract_holder_rows(
+        table,
+        name_idx=name_idx,
+        shares_idx=shares_idx,
+        percent_idx=percent_idx,
+        rows=holders,
+        seen=set(),
+    )
+    if not holders:
+        return 0.0
+    hits = sum(1 for h in holders if _is_beneficial_owner_identity(h.holder_name))
+    return hits / len(holders)
+
+
+def _is_item403_eligible(table: _RawTable) -> bool:
+    """True when TABLE may win its window / join the Item 403 sibling set.
+
+    Both limbs required — see the call site for why row identity alone admits
+    Item 402 compensation tables. The cheap header regex is evaluated FIRST so
+    the full extraction is skipped for tables the value signature already
+    rejects.
+    """
+    if not _item403_value_signature(table.column_headers):
+        return False
+    return _owner_identity_fraction(table) >= _ROW_IDENTITY_FLOOR
 
 
 def _extract_holder_rows(

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -465,26 +465,81 @@ _ITEM403_AMOUNT_NATURE_RE: Final[re.Pattern[str]] = re.compile(
     r"(amount\s+and\s+nature)|((sole|shared)\s+(voting|dispositive|investment))",
     re.IGNORECASE,
 )
-# Comp-denominated percents — Item 402, not Item 403. Checked FIRST: a comp
-# table can also say "shares", so the positive arms alone would admit it.
+# Column 3's ordinary caption — issuers writing "Shares Beneficially Owned" or
+# "Beneficial Stock Ownership" are quoting 229.403's own noun phrase.
+#
+# Keyed on own(ed|ership), NOT owner. "Name of Beneficial OWNER" is column 2's
+# caption and says nothing about the VALUE columns, so accepting it as Item 403
+# evidence admits 'Beneficial Owner | Number of RSUs' — a junk shape from this
+# spec's own probe list. Gap-tolerant but confined within a single header cell
+# (no "|"), so it cannot bridge two unrelated captions.
+_ITEM403_BENEFICIAL_RE: Final[re.Pattern[str]] = re.compile(
+    r"beneficial(ly)?\b[^|]{0,30}?\bown(ed|ership)\b",
+    re.IGNORECASE,
+)
+# WEAK evidence — some amount column, some percent column, something "owned".
+# Individually meaningless; an Item 402 payout table has them too. Only used in
+# combination, and only under the vetoes below.
+_ITEM403_AMOUNT_IND_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(shares?|number|amount|units?|stock)\b",
+    re.IGNORECASE,
+)
+# Word-bounded so "Percentile" (TSR payout-curve tables) does not read as a
+# percent-of-class column.
+_ITEM403_PERCENT_IND_RE: Final[re.Pattern[str]] = re.compile(r"\bpercent(age|ages)?\b|%", re.IGNORECASE)
+_ITEM403_OWNED_IND_RE: Final[re.Pattern[str]] = re.compile(r"\bown(ed|ership)\b", re.IGNORECASE)
+# Comp-denominated percents — Item 402, not Item 403.
 _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
     r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting"
     r"|bonus\s+opportunity|salary|earned|performance)",
     re.IGNORECASE,
 )
+# Item 402(a)(3) DEFINES "named executive officer"; Item 403 says "name of
+# beneficial owner". A header captioning its name column with Item 402's term of
+# art, carrying none of Item 403's column-3/4 wording, is an Item 402 table.
+_ITEM402_NEO_CAPTION_RE: Final[re.Pattern[str]] = re.compile(r"named\s+executive\s+officer", re.IGNORECASE)
 
 
 def _item403_value_signature(headers: tuple[str, ...]) -> bool:
     """True when HEADERS carry Item 403's prescribed VALUE columns.
 
-    Signature = a **class-denominated percent** column OR the
-    **amount-and-nature** voting/dispositive-power subdivision, and never a
-    comp-denominated percent. See the regexes above for the governing reg.
+    Precedence, not a flat vocabulary match — and the ordering is the whole
+    design (#2160, measured in both directions over all 42,566 stored bodies):
+
+    1. A header quoting 229.403's own column 3 ("amount and nature of beneficial
+       ownership", "shares beneficially owned") or column 4 ("percent of class")
+       is an Item 403 table **on its face** and is admitted outright.
+    2. Otherwise Item 402 vocabulary vetoes.
+    3. Otherwise the weak generic pair — an amount column plus either a percent
+       column or an "owned" column — admits.
+
+    The comp veto CANNOT be applied over the whole header, which is what the
+    first cut did. Rule 13d-3(d)(1)(i) DEEMS a person the beneficial owner of
+    shares acquirable within 60 days, so a genuine Item 403 table legitimately
+    captions columns "Options Exercisable or Vesting Within 60 Days" and
+    "Number of Performance Shares Granted". A blanket veto on "vesting" /
+    "performance" deleted 18-, 22- and 10-holder Vanguard / BlackRock / First
+    Eagle tables. Ordering the reg's own wording above the veto is what fixes
+    it, and it is why the veto can safely stay broad.
+
+    Step 3's two pairs both exist because issuers omit column 4 outright:
+    dual-class and direct/indirect tables caption their value columns
+    "Class A Common Stock Owned | Class B Common Stock Owned | Total Voting
+    Power" with no percent anywhere.
     """
     joined = " | ".join(headers)
-    if _COMP_PCT_RE.search(joined):
+    if (
+        _ITEM403_BENEFICIAL_RE.search(joined)
+        or _ITEM403_AMOUNT_NATURE_RE.search(joined)
+        or _ITEM403_CLASS_PCT_RE.search(joined)
+    ):
+        return True
+    if _COMP_PCT_RE.search(joined) or _ITEM402_NEO_CAPTION_RE.search(joined):
         return False
-    return bool(_ITEM403_CLASS_PCT_RE.search(joined) or _ITEM403_AMOUNT_NATURE_RE.search(joined))
+    return bool(
+        _ITEM403_AMOUNT_IND_RE.search(joined)
+        and (_ITEM403_PERCENT_IND_RE.search(joined) or _ITEM403_OWNED_IND_RE.search(joined))
+    )
 
 
 def _score_table_headers(headers: tuple[str, ...]) -> int:
@@ -969,6 +1024,10 @@ _INSTRUMENT_VOCAB: Final[frozenset[str]] = frozenset(
     }
 )
 _WORD_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z]+")
+# Presentation debris the identity test must look through. Leader dots are an
+# HTML table-of-contents/figure-rule artefact and land INSIDE the name cell, so
+# they inflate its length without being part of the name.
+_IDENTITY_DEBRIS_RE: Final[re.Pattern[str]] = re.compile(r"[.…]{3,}")
 
 
 def _is_instrument_not_owner(text: str) -> bool:
@@ -992,8 +1051,17 @@ def _is_beneficial_owner_identity(text: str) -> bool:
     single-cell stacked-pair decision. Both share the class-noun rejection; this
     one adds the three corrections the full-population census forced (length
     cap, case-sensitive entity designators, instrument vocabulary).
+
+    Presentation debris is stripped BEFORE the length cap, not after. Issuers
+    pad the name column with HTML leader dots to draw a dotted rule across to
+    the figures, and the run is far longer than the name: 'Hotchkis & Wiley
+    Capital Management, LLC ....(63 dots)' is 104 characters of dots on a
+    40-character name. Testing the raw cell blew the 120-char cap and rejected
+    the holder, which took the whole table below ``_ROW_IDENTITY_FLOOR`` and
+    dropped a genuine ``Amount and Nature of Beneficial Ownership | Percent of
+    Class`` table (0000074303-25-000056, 3 holders including BlackRock).
     """
-    stripped = text.strip()
+    stripped = _IDENTITY_DEBRIS_RE.sub(" ", text).strip(" .,​﻿*†#")
     if not stripped or len(stripped) > _OWNER_IDENTITY_MAX_LEN:
         return False
     if _is_instrument_not_owner(stripped):
@@ -1722,8 +1790,15 @@ def _is_item403_eligible(table: _RawTable) -> bool:
     Item 402 compensation tables. The cheap header regex is evaluated FIRST so
     the full extraction is skipped for tables the value signature already
     rejects.
+
+    The signature reads BOTH header tuples. ``column_headers`` alone is wrong:
+    when a two-row header promotes the SUB-header row, ``column_headers``
+    becomes ``('', 'Sole', 'Shared', 'Total', '')`` and the parent caption
+    ``Amount and Nature of Beneficial Ownership | Percent of Class`` survives
+    only in ``score_headers`` — so reading the narrower tuple rejected the most
+    prescribed shape the reg has, at scores 14 and 16.
     """
-    if not _item403_value_signature(table.column_headers):
+    if not _item403_value_signature(tuple(table.score_headers) + tuple(table.column_headers)):
         return False
     return _owner_identity_fraction(table) >= _ROW_IDENTITY_FLOOR
 

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -453,13 +453,22 @@ _ITEM_402_AWARD_MARKERS: Final[tuple[str, ...]] = (
 # 1,668 -> 45 candidate tables, and the survivors are the genuine shapes.
 _ITEM403_CLASS_PCT_RE: Final[re.Pattern[str]] = re.compile(
     r"(percent|percentage|%)\s*(of\s+)?(the\s+)?(all\s+|total\s+|outstanding\s+)*"
-    r"(class|common|shares|stock|voting|ownership|beneficial|equity|units)"
-    # 229.403 column 4 is "Percent of CLASS". An AWARD noun after the class noun
-    # makes it a percent of a grant, not of a class -- 'Percentage of Stock
-    # Options Vesting', 'Percentage of total stock incentive awards'. This arm is
-    # STRONG (it bypasses the Item 402 veto), so its precision is load-bearing:
-    # those two shapes were admitted as beneficial ownership.
-    r"(?!\s*\w*\s*(option|award|incentive|grant|vesting|payout|settl))",
+    # The class-noun RUN is possessive (``*+``) so the engine cannot backtrack
+    # into it: without that, 'Percentage of Common Stock Earned' matches by
+    # consuming only 'Common', seeing 'Stock' in the allowed-follow set, and
+    # succeeding -- the exact leak this lookahead exists to close.
+    r"(?:class|common|shares?|stock|voting|ownership|beneficial|equity|units?)"
+    r"(?:\s+(?:class|common|shares?|stock|voting|ownership|beneficial|equity|units?"
+    r"|rights?|power|securities|interests?))*+"
+    # 229.403 column 4 is "Percent of CLASS" -- the denominator is a CLASS OF
+    # SECURITIES, so the class-noun run ENDS the denominator phrase. A CLOSED
+    # rule, not a blocklist: only punctuation, a footnote marker, or a
+    # continuation preposition may follow. Any trailing participle makes it a
+    # percent of an OUTCOME -- 'Percentage of Shares Earned', 'Percentage of
+    # Stock Options Vesting' (Codex ckpt-1 HIGH). This arm is STRONG, admitting
+    # ahead of the Item 402 veto, so its precision is load-bearing: every one of
+    # those shapes was being emitted as beneficial ownership.
+    r"(?=\s*($|[|(),.;:%*†#\d]|of\b|outstanding\b|beneficially\b|owned\b))",
     re.IGNORECASE,
 )
 # Column 3 subdivided. Rule 13d-3 (17 CFR 240.13d-3) defines beneficial
@@ -548,7 +557,10 @@ _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
     # Ownership GUIDELINES (a policy multiple, not a holding) and deferred-comp
     # ALLOCATION tables (a percent of a dollar deferral across funds) were the
     # only junk left riding the data-row fallback.
-    r"|ownership\s+guidelines|amount\s+deferred|deferred\s+amount)",
+    r"|ownership\s+guidelines|amount\s+deferred|deferred\s+amount"
+    # Item 402 OUTCOME words. A percent of an outcome (earned / vested /
+    # achieved / at target) is 402, never 229.403 col 4 (Codex ckpt-1 HIGH).
+    r"|\bearned\b|\bvested\b|achievement|attained|achieved|at\s+target)",
     re.IGNORECASE,
 )
 # Item 402(a)(3) DEFINES "named executive officer"; Item 403 says "name of

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1983,34 +1983,30 @@ def _row_name_is_address(raw_row: tuple[str, ...] | None, *, name_idx: int, shar
 _ROW_IDENTITY_FLOOR: Final[float] = 0.5
 
 
-def _owner_identity_fraction(table: _RawTable) -> float:
-    """D0 (#2160) — fraction of TABLE's extracted rows that name a beneficial owner.
+def _owner_identity_fraction(holders: list[Def14ABeneficialHolder]) -> float:
+    """D0 (#2160) — fraction of HOLDERS that name a beneficial owner.
 
-    Computed on the **resolved name column**, reached through the same path
-    extraction uses. Not the raw first cell: Item 403's prescribed column 1 is
-    ``Title of class``, so a genuine table rendering
+    Takes the ALREADY-EXTRACTED holders rather than the table, so there is
+    exactly one place this fraction is computed. It previously took the table
+    and re-ran the extraction itself, which left it orphaned once
+    ``_is_item403_eligible`` started extracting once and deriving both the
+    fraction and the value evidence from the same list (review WARNING on
+    PR #2177: a future fix to one would silently not reach the other).
+
+    The caller must extract through the real ``_resolve_columns`` +
+    ``_extract_holder_rows`` path, NOT the raw first cell: Item 403's prescribed
+    column 1 is ``Title of class``, so a genuine table rendering
     ``Common Stock | The Vanguard Group | 5,799,197 | 5.3%`` would fail a
-    first-cell test outright (Codex ckpt-1 BLOCKING on the spec).
-
-    Sharing ``_extract_holder_rows`` is required, not incidental: it already
-    drops section headings, address-continuation fragments and value-less rows,
-    and recovers ragged cells. Measuring on raw rows would count a
+    first-cell test outright (Codex ckpt-1 BLOCKING on the spec). Sharing
+    ``_extract_holder_rows`` is required, not incidental: it already drops
+    section headings, address-continuation fragments and value-less rows, and
+    recovers ragged cells. Measuring on raw rows would count a
     ``Named Executive Officers`` heading as an identity and would penalise a
     genuine table whose rows are address continuations.
 
     Denominator is the extracted holder count. A table extracting zero holders
     cannot win its window anyway (#2158 element 4), so it scores 0.0.
     """
-    name_idx, shares_idx, percent_idx = _resolve_columns(table.column_headers)
-    holders: list[Def14ABeneficialHolder] = []
-    _extract_holder_rows(
-        table,
-        name_idx=name_idx,
-        shares_idx=shares_idx,
-        percent_idx=percent_idx,
-        rows=holders,
-        seen=set(),
-    )
     if not holders:
         return 0.0
     hits = sum(1 for h in holders if _is_beneficial_owner_identity(h.holder_name))
@@ -2021,9 +2017,15 @@ def _is_item403_eligible(table: _RawTable) -> bool:
     """True when TABLE may win its window / join the Item 403 sibling set.
 
     Both limbs required — see the call site for why row identity alone admits
-    Item 402 compensation tables. The cheap header regex is evaluated FIRST so
-    the full extraction is skipped for tables the value signature already
-    rejects.
+    Item 402 compensation tables.
+
+    The holders are extracted FIRST, before the header signature is consulted.
+    That ordering is necessary, not accidental: D4's data-row fallback needs the
+    parsed values, and the identity fraction needs the same list, so extracting
+    once and deriving both is the only way to avoid running the extraction
+    twice. (An earlier revision claimed the cheap header regex ran first and
+    short-circuited the extraction; that stopped being true when the fallback
+    landed — review NITPICK on PR #2177.)
 
     The signature reads BOTH header tuples. ``column_headers`` alone is wrong:
     when a two-row header promotes the SUB-header row, ``column_headers``
@@ -2047,8 +2049,7 @@ def _is_item403_eligible(table: _RawTable) -> bool:
     headers = tuple(table.score_headers) + tuple(table.column_headers)
     if not _item403_value_signature(headers, data_row_evidence=_has_item403_value_rows(holders)):
         return False
-    hits = sum(1 for h in holders if _is_beneficial_owner_identity(h.holder_name))
-    return hits / len(holders) >= _ROW_IDENTITY_FLOOR
+    return _owner_identity_fraction(holders) >= _ROW_IDENTITY_FLOOR
 
 
 _VALUE_ROW_EVIDENCE_FLOOR: Final[float] = 0.5

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1157,6 +1157,99 @@ def _is_instrument_not_owner(text: str) -> bool:
     return all(w in _INSTRUMENT_VOCAB for w in words)
 
 
+# Heading vocabulary. A HEADING names a class in the abstract; a HOLDER carries a
+# SPECIFIC proper name. That is the discriminator ``_HOLDER_CLASS_PLURAL_RE``
+# lacks on its own -- it is a heading test (#2164: '5% Stockholders', 'Other
+# Shareowners that Beneficially Own More than 5%') and it outranks the entity
+# arm, so it was rejecting genuine 403(a) holders named in Schedule 13D/G
+# joint-filer form: 'Trustees of the Thomas J. Pritzker Family Trusts and Other
+# Reporting Persons', 'CIBC Caribbean and Other Reporting Persons'. Hyatt
+# (0001104659-26-038759) lost an 11-holder sibling table that way, taking MFS,
+# Baron Capital and the Pritzker trusts with it.
+_HEADING_STOPWORDS: Final[frozenset[str]] = frozenset(
+    {
+        # class nouns already in _HOLDER_CLASS_PLURAL_RE
+        "shareholders",
+        "shareowners",
+        "stockholders",
+        "holders",
+        "owners",
+        "directors",
+        "trustees",
+        "officers",
+        "executives",
+        "nominees",
+        "persons",
+        # generic heading connectives and qualifiers
+        "other",
+        "certain",
+        "all",
+        "total",
+        "more",
+        "than",
+        "and",
+        "the",
+        "of",
+        "family",
+        "trusts",
+        "trust",
+        "reporting",
+        "beneficially",
+        "own",
+        "owned",
+        "ownership",
+        "group",
+        "each",
+        "who",
+        "that",
+        "are",
+        "not",
+        "as",
+        "a",
+        "current",
+        "former",
+        "named",
+        "executive",
+        "non",
+        "employee",
+        "employees",
+        "affiliated",
+        "entities",
+        "associates",
+        "including",
+        "our",
+        "its",
+    }
+)
+
+
+# 'Thomas J. Pritzker' / 'Karen L. Pritzker' -- a middle initial is strong
+# evidence of a personal name; 'CIBC' -- an all-caps token is strong evidence of
+# an entity. Both survive inside a 13D/G joint-filer phrase where the
+# start-anchored person pattern cannot reach.
+_PERSONAL_INITIAL_RE: Final[re.Pattern[str]] = re.compile(r"\b[A-Z]\.")
+_ALLCAPS_ENTITY_TOKEN_RE: Final[re.Pattern[str]] = re.compile(r"\b[A-Z]{3,}\b")
+
+
+def _contains_specific_name(text: str) -> bool:
+    """True when TEXT carries a run of >=2 capitalised tokens that name someone.
+
+    Tokens drawn from :data:`_HEADING_STOPWORDS` do not count, so
+    'Directors and Executive Officers of the Company' has no qualifying run while
+    'Trustees of the Thomas J. Pritzker Family Trusts' has 'Thomas J. Pritzker'
+    and 'CIBC Caribbean and Other Reporting Persons' has 'CIBC Caribbean'.
+    """
+    run = 0
+    for token in re.findall(r"[A-Za-z][\w.'\u2019-]*", text):
+        if token[:1].isupper() and token.lower().strip(".") not in _HEADING_STOPWORDS:
+            run += 1
+            if run >= 2:
+                return True
+        else:
+            run = 0
+    return False
+
+
 def _is_beneficial_owner_identity(text: str) -> bool:
     """D1 (#2160) — row-identity test used to gate table SELECTION.
 
@@ -1182,7 +1275,21 @@ def _is_beneficial_owner_identity(text: str) -> bool:
     if "as a group" in stripped.lower():
         return True
     if _HOLDER_CLASS_PLURAL_RE.search(stripped):
-        return False
+        # A heading names a class abstractly; a HOLDER carries a specific proper
+        # name. Rescue only on BOTH a qualifying name run AND hard proper-noun
+        # evidence -- a personal initial, an all-caps entity token, or a
+        # corporate designator. Without the second test 'Compensation Discussion
+        # and Analysis' (a table-of-contents row) reads as a name run.
+        if not (
+            _contains_specific_name(stripped)
+            and (
+                _PERSONAL_INITIAL_RE.search(stripped)
+                or _ALLCAPS_ENTITY_TOKEN_RE.search(stripped)
+                or _OWNER_ENTITY_CASED_RE.search(stripped)
+            )
+        ):
+            return False
+        return True
     if _OWNER_ENTITY_CASED_RE.search(stripped):
         return True
     if _OWNER_PERSON_RE.match(stripped):

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -522,8 +522,8 @@ _ITEM403_OWNED_IND_RE: Final[re.Pattern[str]] = re.compile(r"\bown(ed|ership)\b"
 # those before the Item 402 veto would emit severance data as ownership (Codex
 # ckpt-1 HIGH). Verb and window must sit in the SAME header cell.
 _RULE_13D3_60_DAY_RE: Final[re.Pattern[str]] = re.compile(
-    r"(?:(?:exercisab|acquir|issuab|vest|convert|settl)\w*[^|]{0,40}?within\s+(?:\d{1,3}|sixty)\s+days"
-    r"|within\s+(?:\d{1,3}|sixty)\s+days[^|]{0,40}?(?:exercisab|acquir|issuab|vest|convert|settl)\w*)",
+    r"(?:(?:exercisab|acquir|issuab|vest|convert|settl)\w*[^|]{0,40}?(?:with)?in\s+(?:\d{1,3}|sixty)\s+days"
+    r"|(?:with)?in\s+(?:\d{1,3}|sixty)\s+days[^|]{0,40}?(?:exercisab|acquir|issuab|vest|convert|settl)\w*)",
     re.IGNORECASE,
 )
 # Comp-denominated percents — Item 402, not Item 403.

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -567,6 +567,17 @@ _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
 # beneficial owner". A header captioning its name column with Item 402's term of
 # art, carrying none of Item 403's column-3/4 wording, is an Item 402 table.
 _ITEM402_NEO_CAPTION_RE: Final[re.Pattern[str]] = re.compile(r"named\s+executive\s+officer", re.IGNORECASE)
+# ...but 229.403(b) itself requires the table to cover "each of the registrant's
+# directors, each of the nominees for election as a director, each of the named
+# executive officers ... and directors and executive officers as a group". So a
+# caption naming DIRECTORS alongside NEOs is Item 403(b)'s OWN wording and must
+# not be vetoed: 'Directors and Named Executive Officers (1) | Number of shares
+# of Common Stock | %' is a genuine 403(b) table this veto was emptying.
+# Only a caption naming NEOs and nobody else is Item 402's term of art.
+_ITEM403B_DIRECTOR_CAPTION_RE: Final[re.Pattern[str]] = re.compile(
+    r"\bdirectors?\b|\bnominees?\b|as\s+a\s+group",
+    re.IGNORECASE,
+)
 
 
 def _item403_value_signature(headers: tuple[str, ...], *, data_row_evidence: bool = False) -> bool:
@@ -607,7 +618,9 @@ def _item403_value_signature(headers: tuple[str, ...], *, data_row_evidence: boo
         or _RULE_13D3_60_DAY_RE.search(joined)
     ):
         return True
-    if _COMP_PCT_RE.search(joined) or _ITEM402_NEO_CAPTION_RE.search(joined):
+    if _COMP_PCT_RE.search(joined) or (
+        _ITEM402_NEO_CAPTION_RE.search(joined) and not _ITEM403B_DIRECTOR_CAPTION_RE.search(joined)
+    ):
         return False
     if data_row_evidence:
         # Step 3b — the captions carry nothing, but the ROWS show both of

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -453,7 +453,13 @@ _ITEM_402_AWARD_MARKERS: Final[tuple[str, ...]] = (
 # 1,668 -> 45 candidate tables, and the survivors are the genuine shapes.
 _ITEM403_CLASS_PCT_RE: Final[re.Pattern[str]] = re.compile(
     r"(percent|percentage|%)\s*(of\s+)?(the\s+)?(all\s+|total\s+|outstanding\s+)*"
-    r"(class|common|shares|stock|voting|ownership|beneficial|equity|units)",
+    r"(class|common|shares|stock|voting|ownership|beneficial|equity|units)"
+    # 229.403 column 4 is "Percent of CLASS". An AWARD noun after the class noun
+    # makes it a percent of a grant, not of a class -- 'Percentage of Stock
+    # Options Vesting', 'Percentage of total stock incentive awards'. This arm is
+    # STRONG (it bypasses the Item 402 veto), so its precision is load-bearing:
+    # those two shapes were admitted as beneficial ownership.
+    r"(?!\s*\w*\s*(option|award|incentive|grant|vesting|payout|settl))",
     re.IGNORECASE,
 )
 # Column 3 subdivided. Rule 13d-3 (17 CFR 240.13d-3) defines beneficial
@@ -535,7 +541,10 @@ _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
     # Added when the data-row fallback (weak evidence) began admitting
     # 'Percentage of Annual Total Direct Compensation' and
     # 'Attendance Percentage of All Meetings'.
-    r"|compensation|attendance|meetings?\s+attended|dilution)",
+    r"|compensation|attendance|meetings?\s+attended|dilution"
+    r"|\bpsus?\b|\bltip\b|incentive\s+award|as\s+settled"
+    r"|long.?term\s+incentive|incentive\s+(program|opportunity)|base\s+pay|\bbonus\b"
+    r"|option\s+awards?|stock\s+option\s+awards?)",
     re.IGNORECASE,
 )
 # Item 402(a)(3) DEFINES "named executive officer"; Item 403 says "name of

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1138,7 +1138,7 @@ _IDENTITY_DEBRIS_RE: Final[re.Pattern[str]] = re.compile(r"[.…]{3,}")
 # ``_is_address_fragment`` so it can share ``_STREET_TYPE``, which this module
 # declares further down.
 _OWNER_NAME_THEN_ADDRESS_RE: Final[re.Pattern[str]] = re.compile(
-    r"^[A-Z][\w&.'’-]*(?:\s+[A-Z][\w&.'’-]*){0,3}\s+\d(?P<tail>.*)$",
+    r"^[A-Z][\w&.'’-]*(?:\s+(?:[A-Z][\w&.'’-]*|&|and)){0,4}\s+\d(?P<tail>.*)$",
     re.DOTALL,
 )
 
@@ -1231,6 +1231,16 @@ _PERSONAL_INITIAL_RE: Final[re.Pattern[str]] = re.compile(r"\b[A-Z]\.")
 _ALLCAPS_ENTITY_TOKEN_RE: Final[re.Pattern[str]] = re.compile(r"\b[A-Z]{3,}\b")
 
 
+# A partnership-style firm name joined by '&' -- 'Dodge & Cox', 'Cohen & Steers',
+# 'Ruane, Cunniff & Goldfarb'. These carry no corporate suffix, so the entity arm
+# misses them, and the start-anchored person arm stops at the '&' (Codex ckpt-2
+# P2). Common enough in Item 403(a) to matter: the corpus holds Cohen & Steers,
+# Cooke & Bieler, Cede & Co, Bill & Melinda Gates Foundation Trust.
+_AMPERSAND_FIRM_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Z][\w.'’-]*(?:,?\s+[A-Z][\w.'’-]*)*,?\s+&\s+[A-Z]",
+)
+
+
 def _contains_specific_name(text: str) -> bool:
     """True when TEXT carries a run of >=2 capitalised tokens that name someone.
 
@@ -1291,6 +1301,8 @@ def _is_beneficial_owner_identity(text: str) -> bool:
             return False
         return True
     if _OWNER_ENTITY_CASED_RE.search(stripped):
+        return True
+    if _AMPERSAND_FIRM_RE.match(stripped):
         return True
     if _OWNER_PERSON_RE.match(stripped):
         return True

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -488,6 +488,12 @@ _ITEM403_AMOUNT_IND_RE: Final[re.Pattern[str]] = re.compile(
 # percent-of-class column.
 _ITEM403_PERCENT_IND_RE: Final[re.Pattern[str]] = re.compile(r"\bpercent(age|ages)?\b|%", re.IGNORECASE)
 _ITEM403_OWNED_IND_RE: Final[re.Pattern[str]] = re.compile(r"\bown(ed|ership)\b", re.IGNORECASE)
+# Rule 13d-3(d)(1)(i) (17 CFR 240.13d-3) DEEMS a person the beneficial owner of
+# securities they have the right to acquire "within sixty days". A column
+# captioned "Options Exercisable or Vesting Within 60 Days" is therefore quoting
+# the ownership rule, NOT Item 402 — so this is STRONG Item 403 evidence and
+# must outrank the comp veto, which would otherwise fire on "vesting".
+_RULE_13D3_60_DAY_RE: Final[re.Pattern[str]] = re.compile(r"within\s+(\d{1,3}|sixty)\s+days", re.IGNORECASE)
 # Comp-denominated percents — Item 402, not Item 403.
 _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
     r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting"
@@ -507,8 +513,9 @@ def _item403_value_signature(headers: tuple[str, ...]) -> bool:
     design (#2160, measured in both directions over all 42,566 stored bodies):
 
     1. A header quoting 229.403's own column 3 ("amount and nature of beneficial
-       ownership", "shares beneficially owned") or column 4 ("percent of class")
-       is an Item 403 table **on its face** and is admitted outright.
+       ownership", "shares beneficially owned") or column 4 ("percent of class"),
+       or Rule 13d-3(d)(1)(i)'s "within 60 days" acquisition window, is an
+       Item 403 table **on its face** and is admitted outright.
     2. Otherwise Item 402 vocabulary vetoes.
     3. Otherwise the weak generic pair — an amount column plus either a percent
        column or an "owned" column — admits.
@@ -532,6 +539,7 @@ def _item403_value_signature(headers: tuple[str, ...]) -> bool:
         _ITEM403_BENEFICIAL_RE.search(joined)
         or _ITEM403_AMOUNT_NATURE_RE.search(joined)
         or _ITEM403_CLASS_PCT_RE.search(joined)
+        or _RULE_13D3_60_DAY_RE.search(joined)
     ):
         return True
     if _COMP_PCT_RE.search(joined) or _ITEM402_NEO_CAPTION_RE.search(joined):

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -477,6 +477,28 @@ _ITEM403_BENEFICIAL_RE: Final[re.Pattern[str]] = re.compile(
     r"beneficial(ly)?\b[^|]{0,30}?\bown(ed|ership)\b",
     re.IGNORECASE,
 )
+# 229.403 column 2's LITERAL prescribed caption — "Name and address of
+# beneficial owner" (403(a)) / "Name of beneficial owner" (403(b)).
+#
+# Bare "Beneficial Owner" is deliberately NOT enough (it admits 'Beneficial
+# Owner | Number of RSUs'), but the full prescribed phrase is Item 403's own
+# and no Item 402 table uses it. This arm is what recovers tables whose VALUE
+# column is just the class name — 'Name and Address of Beneficial Owner |
+# Common Stock' carries no percent and no "owned" anywhere, yet it is the
+# reg's own shape with column 1 (Title of class) as the value caption.
+_ITEM403_OWNER_CAPTION_RE: Final[re.Pattern[str]] = re.compile(
+    r"name\s+(and\s+address(es)?\s+)?of\s+(the\s+)?beneficial\s+owner",
+    re.IGNORECASE,
+)
+# 229.403 column 1's literal prescribed caption. Both subsections prescribe it
+# and nothing else in a proxy uses the phrase, so it is Item 403 on its face —
+# it recovers tables whose remaining captions are degraded to empty cells
+# ('| Title of Class | ... | Name and Address of | Class A Common Stock (2) |').
+_ITEM403_TITLE_OF_CLASS_RE: Final[re.Pattern[str]] = re.compile(r"title\s+of\s+class", re.IGNORECASE)
+# The reg's adverb on its own. Issuers truncate column 3 to 'Shares
+# Beneficially' when the header wraps, losing 'Owned' to the next cell. Weak,
+# so it is paired with an amount indicator and stays under the vetoes.
+_ITEM403_BENEFICIALLY_RE: Final[re.Pattern[str]] = re.compile(r"\bbeneficially\b", re.IGNORECASE)
 # WEAK evidence — some amount column, some percent column, something "owned".
 # Individually meaningless; an Item 402 payout table has them too. Only used in
 # combination, and only under the vetoes below.
@@ -537,8 +559,10 @@ def _item403_value_signature(headers: tuple[str, ...]) -> bool:
     joined = " | ".join(headers)
     if (
         _ITEM403_BENEFICIAL_RE.search(joined)
+        or _ITEM403_OWNER_CAPTION_RE.search(joined)
         or _ITEM403_AMOUNT_NATURE_RE.search(joined)
         or _ITEM403_CLASS_PCT_RE.search(joined)
+        or _ITEM403_TITLE_OF_CLASS_RE.search(joined)
         or _RULE_13D3_60_DAY_RE.search(joined)
     ):
         return True
@@ -546,7 +570,11 @@ def _item403_value_signature(headers: tuple[str, ...]) -> bool:
         return False
     return bool(
         _ITEM403_AMOUNT_IND_RE.search(joined)
-        and (_ITEM403_PERCENT_IND_RE.search(joined) or _ITEM403_OWNED_IND_RE.search(joined))
+        and (
+            _ITEM403_PERCENT_IND_RE.search(joined)
+            or _ITEM403_OWNED_IND_RE.search(joined)
+            or _ITEM403_BENEFICIALLY_RE.search(joined)
+        )
     )
 
 
@@ -1036,6 +1064,21 @@ _WORD_RE: Final[re.Pattern[str]] = re.compile(r"[A-Za-z]+")
 # HTML table-of-contents/figure-rule artefact and land INSIDE the name cell, so
 # they inflate its length without being part of the name.
 _IDENTITY_DEBRIS_RE: Final[re.Pattern[str]] = re.compile(r"[.…]{3,}")
+# D1 clauses 4-5 — Item 403(a) prescribes "Name AND ADDRESS of beneficial owner"
+# in ONE column, so an entity that carries no corporate suffix is identified by
+# the address that follows it: 'MUFG 4-5, Marunouchi 1-chome Chiyoda-ku, Tokyo',
+# 'Vanguard 100 Vanguard Boulevard Malvern, PA', 'BlackRock 50 Hudson Yards'.
+# None of them reach the two-capitalised-token person pattern (the second token
+# is a street number) and none carry LLC/Inc/Trust, so without this arm all
+# three are rejected and their table falls under _ROW_IDENTITY_FLOOR —
+# 0001140361-25-012302 scored 0.25 and was emptied.
+#
+# A proper-noun run followed by a NUMBER, which is the name/street-number seam.
+# Deliberately not a hardcoded issuer list (the spec's clause 5): the signal is
+# the reg's own one-column name-and-address form, not who the filer is.
+_OWNER_NAME_THEN_ADDRESS_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Z][\w&.'’-]*(?:\s+[A-Z][\w&.'’-]*){0,3}\s+\d",
+)
 
 
 def _is_instrument_not_owner(text: str) -> bool:
@@ -1080,7 +1123,9 @@ def _is_beneficial_owner_identity(text: str) -> bool:
         return False
     if _OWNER_ENTITY_CASED_RE.search(stripped):
         return True
-    return bool(_OWNER_PERSON_RE.match(stripped))
+    if _OWNER_PERSON_RE.match(stripped):
+        return True
+    return bool(_OWNER_NAME_THEN_ADDRESS_RE.match(stripped))
 
 
 def _is_owner_identity(text: str) -> bool:

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -544,7 +544,11 @@ _COMP_PCT_RE: Final[re.Pattern[str]] = re.compile(
     r"|compensation|attendance|meetings?\s+attended|dilution"
     r"|\bpsus?\b|\bltip\b|incentive\s+award|as\s+settled"
     r"|long.?term\s+incentive|incentive\s+(program|opportunity)|base\s+pay|\bbonus\b"
-    r"|option\s+awards?|stock\s+option\s+awards?)",
+    r"|option\s+awards?|stock\s+option\s+awards?"
+    # Ownership GUIDELINES (a policy multiple, not a holding) and deferred-comp
+    # ALLOCATION tables (a percent of a dollar deferral across funds) were the
+    # only junk left riding the data-row fallback.
+    r"|ownership\s+guidelines|amount\s+deferred|deferred\s+amount)",
     re.IGNORECASE,
 )
 # Item 402(a)(3) DEFINES "named executive officer"; Item 403 says "name of

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1919,15 +1919,7 @@ def parse_beneficial_ownership_table(html_text: str) -> Def14ABeneficialOwnershi
     # figures from the one with the strongest Item 403 header survive. Stable,
     # so document order breaks ties.
     for table in sorted(qualifying, key=lambda t: -_score_table_headers(t.score_headers)):
-        name_idx, shares_idx, percent_idx = _resolve_columns(table.column_headers)
-        _extract_holder_rows(
-            table,
-            name_idx=name_idx,
-            shares_idx=shares_idx,
-            percent_idx=percent_idx,
-            rows=rows,
-            seen=seen,
-        )
+        _extract_table_holders(table, rows=rows, seen=seen)
     return Def14ABeneficialOwnershipTable(
         as_of_date=as_of_date,
         rows=rows,
@@ -2013,6 +2005,41 @@ def _owner_identity_fraction(holders: list[Def14ABeneficialHolder]) -> float:
     return hits / len(holders)
 
 
+def _extract_table_holders(
+    table: _RawTable,
+    *,
+    rows: list[Def14ABeneficialHolder] | None = None,
+    seen: set[str] | None = None,
+) -> list[Def14ABeneficialHolder]:
+    """Resolve TABLE's columns and extract its holders into ROWS.
+
+    The single place ``_resolve_columns`` is paired with ``_extract_holder_rows``.
+    Two callers, with deliberately different dedup semantics, which is why the
+    ``rows`` / ``seen`` handles are parameters rather than locals:
+
+    - ``parse_beneficial_ownership_table``'s concatenation loop passes a SHARED
+      ``rows`` and ``seen`` so sibling Item 403 tables dedup against each other
+      (a holder reported in both keeps the better-captioned table's figures).
+    - ``_is_item403_eligible`` passes neither, judging one table in isolation —
+      a fresh ``seen`` per table, because eligibility is a property of that
+      table alone and must not depend on what a sibling already contributed.
+
+    Review NITPICK on PR #2177 flagged the paired calls as duplication. They are
+    not the same operation, but they are the same five lines, so they live here.
+    """
+    name_idx, shares_idx, percent_idx = _resolve_columns(table.column_headers)
+    out = [] if rows is None else rows
+    _extract_holder_rows(
+        table,
+        name_idx=name_idx,
+        shares_idx=shares_idx,
+        percent_idx=percent_idx,
+        rows=out,
+        seen=set() if seen is None else seen,
+    )
+    return out
+
+
 def _is_item403_eligible(table: _RawTable) -> bool:
     """True when TABLE may win its window / join the Item 403 sibling set.
 
@@ -2034,16 +2061,7 @@ def _is_item403_eligible(table: _RawTable) -> bool:
     only in ``score_headers`` — so reading the narrower tuple rejected the most
     prescribed shape the reg has, at scores 14 and 16.
     """
-    name_idx, shares_idx, percent_idx = _resolve_columns(table.column_headers)
-    holders: list[Def14ABeneficialHolder] = []
-    _extract_holder_rows(
-        table,
-        name_idx=name_idx,
-        shares_idx=shares_idx,
-        percent_idx=percent_idx,
-        rows=holders,
-        seen=set(),
-    )
+    holders = _extract_table_holders(table)
     if not holders:
         return False
     headers = tuple(table.score_headers) + tuple(table.column_headers)

--- a/app/services/def14a_ingest.py
+++ b/app/services/def14a_ingest.py
@@ -141,7 +141,19 @@ from app.services.sec_identity import siblings_for_issuer_cik
 # Also: embedded Schedule 13D/G cover pages (17 CFR 240.13d-101/-102) are no
 # longer parsed as Item 403 tables — their numbered rows stored the cover-page
 # item labels as holder names and the ROW NUMBERS as share counts.
-_PARSER_VERSION_DEF14A = "def14a-v12"
+# v13 (#2160): Item 403 table SELECTION no longer turns on header score. A score
+# is a sum of keyword weights and cannot separate a genuine Item 403 table from a
+# comp / prose / capitalisation table that hits the same keywords. A table may now
+# win its window, and join the sibling set, only if it passes BOTH limbs of the
+# 17 CFR 229.403 eligibility test: >=50% of its extracted rows name a beneficial
+# owner (Rule 13d-3), AND its headers carry Item 403's prescribed value columns —
+# a CLASS-denominated percent (column 4) or the amount-and-nature
+# voting/dispositive subdivision (column 3), never a comp-denominated percent.
+# Both limbs gate WINNER selection, not only sibling membership: Item 402 comp
+# tables' rows are people, so row identity alone scores them 1.00.
+# `_SIBLING_SCORE_FLOOR` is deleted; header score is retained for window RANKING
+# only.
+_PARSER_VERSION_DEF14A = "def14a-v13"
 
 logger = logging.getLogger(__name__)
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -2306,3 +2306,37 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Prevention: when replacing a regex, enumerate what the OLD one matched that the new one does not, not only the new cases you set out to add — an unanchored `.*noun` accepts compounds (`equityholders`, `unitholders`, `noteholders`) that `\bnoun\b` rejects. Issuers compound these freely. Keep a trailing `\b` where you need to exclude a longer word (`ownership`), and drop the leading one. Table-test the compounds explicitly rather than trusting the intent of the edit.
 - First seen in: #2164 (2026-07-29), A/B round 2, found by the role audit (arm 3) — invisible to arms 1 and 2, which key on holder NAME.
 - Enforced in: this prevention log; `app/providers/implementations/sec_def14a.py::_ROLE_HEADING_PATTERNS` (no-leading-boundary comment); `tests/test_sec_def14a_parser.py::TestFivePercentHeadingIsOrderInsensitive::test_compound_holder_nouns_still_match` + `test_ownership_is_not_a_holder_noun`.
+
+## The Nth-consecutive-patch trigger is only useful if you act on it — the spec was literally counting the patches while a fifth was written
+
+- First seen in: #2160 (DEF 14A Item 403 table selection). CLAUDE.md's
+  "Standard-filing reuse check" mandates checking edgartools + structured
+  sources before patching a parser for a standard filing, and names the trigger:
+  **"A recurring per-case patch is the trigger to run this check."** The spec
+  being edited said, in its own prose, that the selector "has now needed four
+  consecutive per-case patches (#2140 D7, #2158 element 4, #2157, #2160)". A
+  fifth was designed, measured across the full corpus, and taken to a pushed
+  branch without the check ever being run.
+- When it was finally run, it took ~10 minutes and changed the design input:
+  `edgar.proxy.html_extractor.extract_beneficial_ownership` exists, is NOT a
+  drop-in (returns `None` on 4 of our 8 genuine failures and under-extracts a
+  fifth: 2 rows where `main` found 16), but it solves the two largest losses
+  outright WITH percentages — and its `_build_column_map` carries the technique
+  our gate lacks: **when headers classify too few columns, classify the first
+  two DATA ROWS instead.** Our D4 is header-only, which is exactly why the
+  44-accession "degraded header" bucket fails. That technique had been written
+  off in my own notes as a novel unmeasured idea.
+- Prevention: treat the trigger as MECHANICAL, not a judgement call. If a spec,
+  commit message or issue names a count of prior per-case patches to the same
+  function, the reuse check is DUE before the next one — run it and record the
+  outcome in the spec's Source-rule section, including a negative result
+  ("edgartools tested on accessions X/Y/Z, returns None on N of them"). A
+  reuse check that is skipped costs a whole design round; #2160 burned one.
+- Also: "I found no prior art" is not a licence to keep patching. Item 403 is
+  unstructured BY REGULATION (17 CFR 240.14a-101 mandates content, not form),
+  so no dedicated parser exists — but the same issuer data IS machine-readable
+  elsewhere (Schedule 13D/G structured XML since 2024-12-18, Forms 3/4/5), and
+  this repo already ingests both. Ask what the STRUCTURED arbiter is before
+  writing another HTML heuristic.
+- Enforced in: this log; `.claude/skills/data-sources/edgartools.md` (DEF 14A
+  row now names `extract_beneficial_ownership` and the data-row fallback).

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -450,7 +450,7 @@ alternative admits Item 402 grant data as beneficial ownership.
 safety claim, so each arm's SOLE admits — tables it and no other arm admits —
 were enumerated and classified:
 
-| arm | tables | shapes | classification of the sample |
+| arm | tables | shapes | classification (FULL population, hand-checked) |
 |---|---|---|---|
 | col3 `beneficially owned` | 643 | 372 | genuine Item 403 throughout |
 | col4 `percent of class` | 369 | 252 | genuine |
@@ -459,7 +459,19 @@ were enumerated and classified:
 | Rule 13d-3 `within 60 days` | 11 | 11 | genuine |
 | col1 `title of class` | 4 | 3 | genuine |
 
-No compensation, plan or metric table appears among them.
+No compensation, plan or metric table appears among them. This is a
+full-population enumeration, not a sample: a STRONG arm admits AHEAD of the
+Item 402 veto, so sample evidence would not be sufficient (Codex ckpt-1 MED).
+
+**And the arms were not near-perfect on first measurement.** Codex ckpt-1 found
+`CLASS_PCT` admitting `Percentage of Shares Earned`, `Percentage of Shares
+Vested` and `Percentage of Common Stock Earned` — all Item 402 outcomes, all
+bypassing the veto. Fixed with a CLOSED rule rather than another blocklist:
+229.403 column 4's denominator is a class of securities, so the class-noun run
+ENDS the phrase, and only punctuation, a footnote marker or a continuation
+preposition may follow it. The run is POSSESSIVE (`*+`) because otherwise the
+engine backtracks — `Percentage of Common Stock Earned` matched by consuming
+only `Common` and finding `Stock` in the allowed-follow set.
 
 The 60-day arm was tightened on this finding: it now requires an ACQUISITION
 VERB (`exercisable` / `acquire` / `issuable` / `vest` / `convert` / `settle`) in

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -416,11 +416,78 @@ Ordering the reg's wording ABOVE the veto is what lets the veto stay broad.
 `PERCENT_IND` is word-bounded so `Percentile` (TSR payout ladders) does not read
 as a percent-of-class column.
 
-**Residual, hand-classified (196 accessions emptied):** payout curves, TSR
-percentile ladders, vest-date and reverse-split tables, ownership-guideline
-multiples, private-placement participation tables and plan-amendment prose — all
-correctly dropped — plus a small tail whose headers have degraded to empty cells.
-Distinct-holder loss is arm 1's question and is reported there, not here.
+**Residual, hand-classified (199 accessions emptied, 423 winning tables
+dropped):** payout curves, TSR percentile ladders, vest-date and reverse-split
+tables, ownership-guideline multiples, private-placement participation tables and
+plan-amendment prose — all correctly dropped — plus a small tail whose headers
+have degraded to empty cells. Distinct-holder loss is arm 1's question and is
+reported there, not here.
+
+### Codex ckpt-1 resolutions — measured, not asserted
+
+`scripts/audit_def14a_gate_arms.py`, full population.
+
+**The score floor of 3 stays, and it is LOAD-BEARING (HIGH).** D3 says header
+score no longer decides sibling membership; that is true only ABOVE the floor.
+`window_qualifying` still filters `score >= SCORE_FLOOR`, so
+`_is_item403_eligible` is never evaluated on a score 0-2 table and the pass-3
+admit census covers score 3-5 only. Removing the floor was measured rather than
+argued: it would newly admit **704 tables / 5,794 rows**, dominated by Item 402
+option-grant tables —
+
+```text
+'Name | Grant Date | Number of securities underlying the award |
+ Exercise price of the award ($/Sh) | Grant Date Fair Value'      14 + 9 + 8 + 8 + 6 + 5 + 4 …
+```
+
+— which is precisely the leak this spec's acceptance forbids. The floor is
+retained deliberately. It has a cost: a genuine
+`Directors, Nominees and Named Executive Officers | Options Exercisable Within
+60 Days` table scores below it and stays excluded. That cost is accepted; the
+alternative admits Item 402 grant data as beneficial ownership.
+
+**Strong-arm precision (MED).** "Nothing else in a proxy uses this caption" is a
+safety claim, so each arm's SOLE admits — tables it and no other arm admits —
+were enumerated and classified:
+
+| arm | tables | shapes | classification of the sample |
+|---|---|---|---|
+| col3 `beneficially owned` | 643 | 372 | genuine Item 403 throughout |
+| col4 `percent of class` | 369 | 252 | genuine |
+| col2 `name … of beneficial owner` | 329 | 213 | genuine (Vanguard, BlackRock, Perceptive, Hercules) |
+| col3 `amount and nature` | 16 | 9 | genuine (FMR, Macquarie, Dimensional) |
+| Rule 13d-3 `within 60 days` | 11 | 11 | genuine |
+| col1 `title of class` | 4 | 3 | genuine |
+
+No compensation, plan or metric table appears among them.
+
+The 60-day arm was tightened on this finding: it now requires an ACQUISITION
+VERB (`exercisable` / `acquire` / `issuable` / `vest` / `convert` / `settle`) in
+the same header cell as the window. 13d-3(d)(1)(i) is about securities a person
+has the right to *acquire* within sixty days; the bare phrase also appears in
+change-in-control and termination tables, and those would otherwise be admitted
+ahead of the Item 402 veto.
+
+**The 120-char D1 cap is EMPIRICAL, not a documented SEC limit (MED).** No reg
+bounds the length of a 403(a) name-and-address cell. Sensitivity, full
+population:
+
+```text
+cap=120  emptied=199  winning tables dropped=423
+cap=160  emptied=198  winning tables dropped=417
+cap=200  emptied=198  winning tables dropped=417
+cap=300  emptied=198  winning tables dropped=417
+```
+
+The cap is very nearly inert on selection — raising it 120 → 300 moves the whole
+corpus by one accession and six tables. Of the 209 over-cap occurrences (163
+distinct), roughly half are genuine long name-and-address cells (Wellington,
+Kayne Anderson Rudnick, Hershey Trust) and half are director-BIO paragraphs,
+which are what the cap exists to reject. It is retained at 120.
+
+Note the cap can never drop a holder from OUTPUT: it feeds the identity
+FRACTION that gates table selection, so an over-cap holder merely fails to vote
+for its own table's eligibility. `_extract_holder_rows` still emits it.
 
 ### D1 — two further corrections found by the pass-3 narrowing enumeration
 

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -1,0 +1,293 @@
+# DEF 14A Item 403 — row-identity table selection
+
+Issue: #2160 (guard-blocked zero-row residual) and #2163 (junk rows stored as
+beneficial ownership). One change, both symptoms.
+
+Supersedes the two levers proposed on #2160 (caption-shape guard; lower the
+sibling score floor) — both falsified by the full-population census below.
+
+## Source rule
+
+**Schedule 14A Item 6(d)** (17 CFR 240.14a-101) is the rule that brings Item 403
+into a proxy statement — it requires the registrant to furnish the information
+called for by Item 403 of Regulation S-K. That is the hook; 229.403 is the
+substance.
+
+**Rule 13d-3** (17 CFR 240.13d-3) defines "beneficial owner" — any person with
+voting or investment power, directly or indirectly. This is load-bearing for D1:
+the row identity the reg constrains is a *person or entity holding voting or
+investment power*, which is why a natural-person or legal-entity name is the
+correct positive test and an accounting line-item is not.
+
+**17 CFR 229.403** (Reg S-K Item 403) prescribes the table for both subsections:
+
+| # | 403(a) — >5% owners | 403(b) — management + group |
+|---|---|---|
+| 1 | Title of class | Title of class |
+| 2 | Name **and address** of beneficial owner | Name of beneficial owner |
+| 3 | Amount and nature of beneficial ownership | Amount and nature of beneficial ownership |
+| 4 | Percent of class | Percent of class |
+
+Both are required "substantially in the tabular form indicated". The reg does
+not prohibit combining them, and issuers routinely render them as two tables
+(the reason `_SIBLING_SCORE_FLOOR` exists at all — #2140 D7).
+
+**Instruction 5** to Item 403: *"in computing the aggregate number of shares
+owned by directors and officers of the registrant as a group, the same shares
+shall not be counted more than once"* — establishes the
+directors-and-officers-as-a-group aggregate row, which only a 403(b) table has.
+
+The load-bearing point for this spec: **the reg constrains the ROW IDENTITY, not
+just the column captions.** Column 2 of both subsections is a *beneficial
+owner* — a natural person or a legal entity. A table whose rows are `Revenue`,
+`Authorized for issuance` or `50 th` is not an Item 403 table irrespective of
+what its header says.
+
+## Full-population verification
+
+Census of all **42,566** stored `def14a_body` payloads, re-parsed on `main`
+`73f721ef`, tracing every table `_score_table_headers` scored. Scripts and the
+42,566-line JSONL are reproducible offline from `filing_raw_documents` with no
+refetch.
+
+### Both #2160 levers are falsified
+
+`max_cell_len` of the winning table, by caption class:
+
+```text
+class                      n    p50    p90    p99     max
+A_full_prescribed      10628     41     57     84     165
+B_abbreviated           4456     40     64    922    3200
+C_neither                608     37     88    753    1601
+```
+
+Junk headers are *shorter* at the median than genuine prescribed captions
+(37 vs 41). No length threshold separates them — the caption-shape guard cannot
+work.
+
+Sentence punctuation: at a 1,740-accession partial run this read **0 of 660**
+full-prescribed winners, which looked like a clean gate. Full population:
+**198 of 10,628** (1.9%) against 80 of 608 (13.2%) for `C_neither`. Directional,
+not a gate. (Recorded because it is the #1659 pattern — a partial that reads
+clean is the dangerous one.)
+
+### The premise about *what* wins is wrong
+
+Issue #2160 assumes the competing tables are prose — table-of-contents entries,
+Schedule 13G footnote paragraphs. Full population says they are overwhelmingly
+**other legitimate tables that talk about shares**:
+
+```text
+'Revenue', 'Excise taxes', 'Net revenue'                    income statement
+'Authorized for issuance', 'Issued and outstanding'         capitalisation table
+'Total number of shares remaining available for future
+ grants under the 2016 Long-Term Incentive Plan'            equity plan pool
+'PSU shares earned', 'rTSRU shares earned'                  comp metrics
+'Threshold', 'Target'                                       comp payout curve
+'50 th Percentile', '25 th Percentile'                      TSR percentiles
+'Auto', 'Marine'                                            segment table
+'None', '1-for-5', '1-for'                                  reverse-split ratios
+```
+
+Every one has a header that *legitimately* mentions shares or percentages.
+No header-only test — score-sum, caption match, or shape guard — can reject
+them. This is why the selector has now needed four consecutive per-case patches
+(#2140 D7, #2158 element 4, #2157, #2160).
+
+### Row identity does separate
+
+Fraction of a winning table's rows whose first cell is a beneficial-owner
+identity (person name, entity designator, or Instruction 5's group row):
+
+```text
+bucket    accessions    cum%
+   0-%           46     0.64
+  10-%            3     0.68
+  20-%           17     0.92
+  30-%           11     1.08
+  40-%            4     1.13
+  50-%           12     1.30
+  ...
+ 100-%         5856   100.00
+```
+
+81.8% of accessions sit at 100%. **61 accessions (0.85%) fall below 0.5.**
+
+All 61 were classified by hand, not sampled:
+
+- **~54 are genuine junk** — the classes listed above.
+- **~6 are genuine holders the identity test wrongly rejects**, and they
+  constrain the design:
+
+```text
+'MUFG 4-5, Marunouchi 1-chome Chiyoda-ku, Tokyo'   all-caps entity, no LLC/Inc token
+'State Street 1 Congress Street, Boston, MA'        entity + 403(a) address in-cell
+'*Stephen J. Bagley'                                leading footnote marker
+```
+
+## Design
+
+### D0 — What the fraction is computed ON
+
+**Not the raw first cell.** Item 403's prescribed column 1 is `Title of class`;
+the beneficial owner is column 2. A genuine table rendering
+`Common Stock | The Vanguard Group | 5,799,197 | 5.3%` would fail a first-cell
+test outright. (Codex ckpt-1 BLOCKING.)
+
+The fraction is computed on the **resolved name column**, reached through the
+same path extraction uses:
+
+```python
+name_idx, shares_idx, percent_idx = _resolve_columns(table.column_headers)
+_extract_holder_rows(table, name_idx=..., shares_idx=..., percent_idx=..., rows=holders, seen=set())
+fraction = mean(_is_beneficial_owner_identity(h.holder_name) for h in holders)
+```
+
+Sharing the extraction path is required, not incidental: `_extract_holder_rows`
+already drops section headings, address-continuation fragments and rows with no
+value, and recovers ragged name/share/percent cells. Measuring on `parsed.rows`
+instead would count a `Named Executive Officers` heading as an identity and
+would penalise a genuine table whose rows are address continuations.
+(Codex ckpt-1 HIGH.)
+
+Denominator is the extracted holder count. A table extracting zero holders is
+already ineligible under #2158's element 4 (zero-row tables cannot win) and is
+not re-tested here.
+
+### D1 — Owner-identity predicate
+
+`_is_beneficial_owner_identity(cell: str) -> bool`, positive test only.
+
+A blocklist of junk labels would need a new entry per junk table shape; the
+prevention-log rule on hand-enumerated exception tuples applies. A positive test
+is closed under new junk types.
+
+Accept when, after stripping presentation debris (leader dots `\.{3,}`, leading
+footnote markers `*` `†` `#`, trailing footnote digits, trailing `(1)`):
+
+1. the cell matches `as a group` (Instruction 5's aggregate row); or
+2. the cell contains an entity designator (`LLC`, `L.P.`, `Inc`, `Trust`,
+   `Fund`, `Partners`, `Capital`, `Management`, `Advisors`, `Holdings`, `N.A.`,
+   `plc`, …); or
+3. the cell **starts with** a person-name pattern — two or more capitalised
+   tokens, allowing initials, particles (`van`, `de`, `von`), and the
+   surname-first comma form (`Bunch, Charles E.`).
+
+Not anchored at the end: Item 403(a) prescribes name **and address** in one
+column, and issuers append titles and credentials. Anchoring to `$` rejected
+`'David J. Mazzo, Ph.D., President and Chief Executive Officer'` and
+`'BlackRock, Inc. 50 Hudson Yards New York'` — measured, not assumed.
+
+Must additionally accept, per the 6 measured false negatives:
+
+4. an all-caps token of >=3 chars followed by address-like content
+   (`MUFG 4-5, Marunouchi …`, `FMR LLC`), and
+5. a known-entity token without a corporate suffix (`State Street`, `Vanguard`)
+   — via the entity-designator list extended with the address-follows form,
+   NOT via a hardcoded issuer list.
+
+### D2 — Selection gate, not a row filter
+
+`_ROW_IDENTITY_FLOOR: Final[float] = 0.5`.
+
+In `parse_beneficial_ownership_table`'s window loop, a parsed table is
+**ineligible to win its window** when
+`owner_identity_fraction(parsed.rows) < _ROW_IDENTITY_FLOOR`.
+
+It is a **selection** gate, deliberately not a row-level filter. ~6 of the 61
+sub-floor accessions carry genuine holders; a row-level filter would delete
+them. Under a selection gate, a genuine table that fails can only lose if it is
+the sole candidate, in which case the parse emits zero rows — the existing
+guard-blocked behaviour, which is safe and already covered by the rewash
+zero-row guard.
+
+### D3 — Sibling gate reads identity, not score
+
+Replace
+
+```python
+qualifying = [t for sc, t in window_qualifying if sc >= _SIBLING_SCORE_FLOOR or sc == window_best_score]
+```
+
+with membership by row identity: every table in the winning window that clears
+`_ROW_IDENTITY_FLOOR` is an Item 403 sibling and its rows are concatenated.
+`_SIBLING_SCORE_FLOOR` is deleted.
+
+This is what #2160 was actually about. The arbitrary floor of 6 exists only
+because header score was the sole signal; once row identity carries the
+decision, a genuine 403(b) table scoring 3 on a bare `Name|Shares|Percent`
+header is admitted on its rows, and the `sc == window_best_score` tie arm that
+that #2158 broke is no longer load-bearing.
+
+Header score is retained for **window ranking**, where it works.
+
+## Blast radius / what this change ADMITS
+
+Per the #2158 lesson, count what the change newly admits, not only what it
+rejects. This change is **narrowing** for selection (D2) and **widening** for
+sibling membership (D3). Both directions must be counted:
+
+- D2 narrowing: tables that previously won and now cannot → expect the ~54 junk
+  accessions; any genuine loss is a defect.
+- D3 widening: tables scoring 3-5 that were previously excluded and are now
+  merged → **this is the direction with no existing coverage.** A low-scoring
+  table that clears the row-identity floor could be a breakdown table
+  (harmless — `_extract_holder_rows` dedups by identity) or a comp table whose
+  rows happen to be person names (harmful). Must be enumerated.
+
+## Verification plan
+
+Per `.claude/skills/engineering/full-population-ab.md`, three arms:
+
+1. **Arm 1 — parse vs parse.** `main` worktree vs branch, all 42,566 bodies.
+   Metric: **distinct holders** keyed `lower(trim(holder_name))` (matching the
+   `holder_name_key` generated column), never row count. Enumerate every
+   accession that loses a holder and classify by hand. Inspect the gain side.
+2. **Arm 2 — parse vs STORED.** The #2160 residual lives entirely in this blind
+   spot (both sides return nothing in Arm 1). Both summaries passed so the arm
+   can state: entities `main` reproduced that the branch does not.
+3. **Arm 3 — mechanism audit.** Per-table `owner_identity_fraction` before/after
+   with the selection outcome, enumerated — not an aggregate counter.
+
+Acceptance — every item is blocking:
+
+- The 61 sub-floor accessions: junk gone, **zero genuine holders lost**.
+- Issue #2160's 26-accession guard-blocked residual: re-parse yields rows.
+- No accession loses a holder that `main` produced.
+- **Zero harmful admits from D3.** Enumerating the newly-admitted low-score
+  tables is not sufficient — an Item 402 comp table whose rows are NEO names
+  passes the person-name predicate, and admitting one emits compensation data as
+  beneficial ownership (the #2163 defect this change exists to remove). Every
+  newly-admitted table is classified by hand and the count of comp/plan/metric
+  tables admitted must be **zero**. If it is not, D1 needs a discriminator
+  beyond row identity — most likely requiring the table to carry a
+  `percent_of_class`-resolvable column, which Item 403 prescribes and Item 402
+  tables do not have. (Codex ckpt-1 HIGH.)
+
+### Evidence gap — census pass 2 (blocks implementation)
+
+Pass 1 measured row identity on **winning tables only**. D3 applies the signal
+to **every table in the winning window**, including low-score tables never
+previously admitted. The signal is therefore unproven on the population it will
+newly admit, and the broad entity-designator list (`Trust`, `Fund`, `Capital`,
+`Management`, `Holdings`) is unproven there too. (Codex ckpt-1 BLOCKING + MED.)
+
+Pass 2 re-runs the corpus capturing every candidate table's extracted holder
+names via `_resolve_columns` + `_extract_holder_rows`, so the identity fraction
+is measured on the same basis D0 specifies and over the full admit population.
+Implementation does not start until pass 2 reports the distribution of
+row-identity fraction for **non-winning** tables scoring 3-5 — the exact cohort
+D3 admits.
+
+## Definition of done additions (ETL clauses 8-12)
+
+- Panel `AAPL`/`GME`/`MSFT`/`JPM`/`HD` plus the 5 #2160 worked accessions.
+- Cross-source: one 5% holder verified against SEC EDGAR direct.
+- `POST /jobs/sec_rebuild/run` scoped `{"source": "sec_def14a"}`, executed.
+- `/instruments/{symbol}/ownership-rollup` verified post-backfill.
+- Parser version bumped v10 -> v11 (forces re-ingest; the conflict key is
+  derived from the parsed value, so a corrected row lands under a NEW key and
+  the stale row must be superseded — prevention-log #2140 entry).
+- `_supersede_dropped_holdings`' empty-set guard preserved (`holder_name <> ALL('{}')`
+  is vacuously TRUE — prevention-log #2140 BLOCKING).
+- Rewash must use the `_rewash_def14a` chokepoint with sibling fan-out (#2157).

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -264,7 +264,54 @@ Acceptance — every item is blocking:
   `percent_of_class`-resolvable column, which Item 403 prescribes and Item 402
   tables do not have. (Codex ckpt-1 HIGH.)
 
-### Evidence gap — census pass 2 (blocks implementation)
+### D4 — Item 403 value-column signature (required; row identity is NOT sufficient)
+
+Census pass 2 result: row identity alone admits **1,668** score-3-5 non-winning
+tables, and they are dominated by Item 402 compensation tables whose rows *are*
+people:
+
+```text
+'Named Executive Officer | Shares at Target | Final PSU Payout %'
+'Named Executive Officer | Annual Base Salary | Target Bonus Opportunity'
+'Name | Threshold (Percentage of Base Salary) | Target (Percentage of Base Salary)'
+'Name of Individual or Identity of Group and Position | Shares Underlying Options'
+'Beneficial Owner | Number of RSUs'
+'Position | Minimum Dollar Value | Minimum Number of Shares'      (ownership guidelines)
+```
+
+D3 therefore does **not** ship on row identity alone. A table joins the winning
+window's sibling set only if it ALSO carries Item 403's prescribed value
+signature — 229.403 column 4 is **"Percent of class"**, class-denominated. A
+compensation table's percent is of *salary*, *target*, *payout* or *vesting*.
+
+Measured on the full admit cohort: the gate takes **1,668 -> 45 (2.7%)**, and
+the survivors are the genuine shapes:
+
+```text
+'Name | Shares (1) | Percent of Outstanding Shares of Common Stock'
+'Name | Number of Common Shares | Percent of Common Shares'
+'Name | Number of Shares | Approximate Percentage of Outstanding Common'
+```
+
+**Two known over-drops to fix before implementation** (enumerated from the
+dropped set, not assumed):
+
+1. `Beneficial Ownership | Sole Voting Power | Shared Voting Power` (8
+   occurrences) — a genuine Item 403 table. Item 403 column 3 is "Amount and
+   nature of beneficial ownership"; Rule 13d-3 defines beneficial ownership as
+   voting **or** investment power, so issuers legitimately subdivide that column
+   into Sole/Shared voting and dispositive power and carry no separate percent
+   column. `_resolve_columns` already knows this subdivision (its tiered
+   `Sole | Shared | Total` handling). The signature must accept it.
+2. `Number of shares of Class A common stock | % of all shares` (4) — "% of all
+   shares" is class-denominated but the noun after "of" is `all`, which the
+   draft pattern's alternation misses.
+
+So the signature is: a class-denominated percent column **OR** the
+amount-and-nature voting/dispositive-power subdivision, and never a
+salary/target/payout/vesting-denominated percent.
+
+### Evidence gap — census pass 2 (RESOLVED; findings above)
 
 Pass 1 measured row identity on **winning tables only**. D3 applies the signal
 to **every table in the winning window**, including low-score tables never

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -571,64 +571,74 @@ Implementation does not start until pass 2 reports the distribution of
 row-identity fraction for **non-winning** tables scoring 3-5 — the exact cohort
 D3 admits.
 
-## Arm 1 result — the design does NOT yet meet this ticket's own goal
+## Three-arm result — FINAL (round 3)
 
-Two real checkouts, `main` @ `480e4f35` vs the branch, all 42,577 stored bodies.
-Authoritative; the census replay above ranks variants but undercounts real `main`
-(85,554 vs 105,400 rows, because it does not dedup across sibling tables) and must
-never be used to state an outcome.
-
-```text
-accessions                 42,577 -> 42,577
-accessions_with_rows        7,172 ->  7,133
-rows                      105,400 -> 108,649
-Item 402(c) SCT drift            0                 <- clean
-distinct holders GAINED     +4,481  (351 accessions)
-distinct holders LOST       -1,232  (255 accessions)
-```
-
-The gain side is genuine Item 403 data — BlackRock, Vanguard, FMR, Wellington,
-Starboard, named directors — and the loss side is dominated by junk `main` was
-selecting: tables of contents, income statements (`Cost of goods sold`,
-`Excise taxes`), Schedule 13G footnote PARAGRAPHS, ownership-guideline bands
-(`53% or greater`), reverse-split ratio tables.
-
-**But the guard-blocked arithmetic goes the wrong way:**
+Two real checkouts, `main` @ `7b2ae45f` vs branch, all **42,577** stored bodies. Census
+fidelity **100.000%** (the replay reproduces the real parser's rows/no-rows on every
+accession — asserted, not assumed).
 
 ```text
-main>0 -> branch==0 (emptied)    101   of which have stored rows:  99   <- NEWLY blocked
-main==0 -> branch>0 (unblocked)   62   of which have stored rows:   3   <- cohort FREED
-                                                  net guard-blocked  +96
+accessions_with_rows        7,172 ->  7,145
+rows                      105,400 -> 108,812
+Item 402(c) SCT drift            0                <- clean
+distinct holders GAINED     +4,491  (364 accessions)
+distinct holders LOST       -1,079  (242 accessions)
 ```
 
-This ticket exists to free a 26-accession guard-blocked residual. The design as
-it stands frees **3** and blocks **99 more**. No stored data is lost — the rewash
-guard preserves rows for all 99, and #2173 cannot release them because their
-stored names are real holders, not 13D/G cover labels — but the ticket's own
-acceptance ("#2160's residual: re-parse yields rows") is NOT met.
+**Arm 2 (parse vs STORED):** 238 accessions / 1,059 holders `main` reproduced and the
+branch does not — consistent with arm 1, no additional blind-spot population.
 
-The correctness win is real and separable from the goal. Do not merge this as a
-fix for #2160 without either closing the 99 or re-scoping the ticket.
+**Arm 3 (value/role audit) — the arm arms 1 and 2 structurally cannot see:**
 
-### Root cause of the 99, and one refuted fix
+```text
+role LOSSES (role -> None)      0     <- the #2164 regression pattern does not occur
+role GAINS  (None -> role)    213
+role RECLASSIFICATIONS          3     all corrections (main was reading a table whose
+                                      "holders" were job titles)
+share values changed          304 rows / 70 accessions
+```
 
-The emptied tables are genuine Item 403 tables whose headers have degraded to
-empty cells, leaving only an amount caption — `0000805928-25-000059` renders
-`| | | Number of Shares | | | | | | Number of Shares | |`, scores 4, and extracts
-20 holders at identity fraction **1.00**. Nothing in the header distinguishes it
-from a comp table captioned `Name | Number of Shares`.
+Of those 70, **56 had `main` sitting on an Item 402 table** — Tyson's round `1,200,000`
+and `1,650,000` salary figures become real share counts `3,826,952` / `850,079` — and ~10
+more were private-placement `Aggregate Purchase Price` tables. The remainder is the
+Liberty Media multi-series shape, **pre-existing on `main`**, filed as #2175.
 
-Letting row evidence carry a degraded header is the obvious fix and it is
-**refuted** — see `scripts/probe_def14a_high_identity_escape.py`. It admits 516
-Item 402 tables full-population; gating on 403(a) institutional evidence narrows
-it to 143 and still leaks (a bank's deferred-comp table lists an affiliated
-entity among its rows). Either way it violates the blocking acceptance above.
+### Net-negative accessions, classified
 
-Open question for the next round: the discriminator probably is not in the header
-or the row identities at all, but in the VALUE columns — an Item 403 amount column
-holds share counts spanning several orders of magnitude with a 5%-holder tail,
-where an Item 402 award column holds a narrow band of grant-sized numbers. That is
-unmeasured.
+156 accessions end net-negative. **107 are provably correct drops** (`main` was on an
+Item 402 grant table, a capitalisation table, an equity-plan pool, a reverse-split ladder,
+a TSR percentile ladder, a New Plan Benefits table, a table of contents or an income
+statement). The remaining 49 are individually reviewed; several are junk the classifier
+mis-flagged, and three genuine-loss classes are filed as **#2176**:
+
+1. instrument nouns (`vested`, `rsu`) vetoing a genuine 403(b) table that reports vested-
+   but-unsettled RSUs as a Rule 13d-3(d)(1)(i) component (ExlService, 2 accessions);
+2. class-label rows sinking the identity fraction on a table that quotes column 3 verbatim
+   (TDS, 2 accessions — same shape as #2175);
+3. dual-class tables with a bare `Beneficial Owner` caption and no percent column
+   (2 accessions) — accepting the bare caption measurably admits
+   `Beneficial Owner | Number of RSUs`, so the other side of that trade was taken.
+
+### The guard-blocked count still moves the wrong way, and that is now understood
+
+```text
+main>0  -> branch==0   89   of which have stored rows  87
+main==0 -> branch>0    62   of which have stored rows   3
+                                        net guard-blocked  +84
+```
+
+This ticket was filed to free a 26-accession guard-blocked residual. It frees 3. But the
+87 newly-blocked accessions are, by the classification above, ones where `main` was
+selecting a NON-Item-403 table — the parser is now correctly declining to reproduce junk,
+and the rewash guard preserves the stored rows rather than losing them.
+
+The blocking is therefore correct behaviour, and the ticket's original acceptance was
+written before the full-population census showed what those accessions actually contain.
+Flushing their stored junk is the CHOKEPOINT's job, not the selector's: #2173 (merged)
+established the mechanism — release the zero-holder guard when the stored rows are
+provably not Item 403 data — and extending its predicate from "13D/G cover labels" to
+"stored rows fail the Item 403 identity/value test" is the follow-up that closes the
+original 26 and these 87 together.
 
 ## Definition of done additions (ETL clauses 8-12)
 

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -191,8 +191,38 @@ Must additionally accept, per the 6 measured false negatives:
 `_ROW_IDENTITY_FLOOR: Final[float] = 0.5`.
 
 In `parse_beneficial_ownership_table`'s window loop, a parsed table is
-**ineligible to win its window** when
-`owner_identity_fraction(parsed.rows) < _ROW_IDENTITY_FLOOR`.
+**ineligible to win its window** when it fails **either** limb of the Item 403
+eligibility test:
+
+```python
+eligible := owner_identity_fraction(holders) >= _ROW_IDENTITY_FLOOR
+            and item403_value_signature(table.column_headers)   # D4
+```
+
+**Both limbs gate WINNER selection, not only sibling membership** (correction
+of 2026-07-29b; measured, see below). The draft applied D4 to D3's sibling set
+only, which leaves the ticket's central case untouched: an Item 402 compensation
+table's rows **are people** — `Kevin R.M. Smith`, `Dr. Hou`,
+`Jennifer F. Scanlon` — so it scores `owner_identity_fraction = 1.00`, passes
+the identity limb, and still wins its window.
+
+Measured against #2163's 23-accession junk cohort:
+
+```text
+D2 identity limb kills          6
+D4 value-signature limb kills  13     <- would NOT fire under a sibling-only D4
+neither (3 unrelated defects)   3     <- stay on #2163
+```
+
+Worked cases that pass identity at 1.00 and are rejected only by D4:
+
+```text
+0000950170-25-045737  ['Name', '', '(%)', '', '', '($) (1)']
+0001193125-25-093573  ['Named Executive Officer', 'Target Annual Cash Incentive as Percentage of Base Salary']
+0001193125-26-140022  ['Named Executive Officer', '', 'Target 2025 Award (As a Percentage of Base Salary)', …]
+0001193125-24-202132  ['Named Executive Officer', '', 'Pre-Separation Fiscal 2024 Bonus Opportunities (percentage of base salary)']
+0001539497-26-000784  ['Name and Address', '', 'Age', '', 'Position', '']
+```
 
 It is a **selection** gate, deliberately not a row-level filter. ~6 of the 61
 sub-floor accessions carry genuine holders; a row-level filter would delete

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -293,23 +293,63 @@ the survivors are the genuine shapes:
 'Name | Number of Shares | Approximate Percentage of Outstanding Common'
 ```
 
-**Two known over-drops to fix before implementation** (enumerated from the
-dropped set, not assumed):
+### D4 final form (resolved and measured — implement exactly this)
 
-1. `Beneficial Ownership | Sole Voting Power | Shared Voting Power` (8
-   occurrences) — a genuine Item 403 table. Item 403 column 3 is "Amount and
-   nature of beneficial ownership"; Rule 13d-3 defines beneficial ownership as
-   voting **or** investment power, so issuers legitimately subdivide that column
-   into Sole/Shared voting and dispositive power and carry no separate percent
-   column. `_resolve_columns` already knows this subdivision (its tiered
-   `Sole | Shared | Total` handling). The signature must accept it.
-2. `Number of shares of Class A common stock | % of all shares` (4) — "% of all
-   shares" is class-denominated but the noun after "of" is `all`, which the
-   draft pattern's alternation misses.
+Signature = a **class-denominated percent** column OR the **amount-and-nature
+voting/dispositive-power subdivision**, and never a comp-denominated percent.
 
-So the signature is: a class-denominated percent column **OR** the
-amount-and-nature voting/dispositive-power subdivision, and never a
-salary/target/payout/vesting-denominated percent.
+```python
+CLASS_PCT = r"(percent|percentage|%)\s*(of\s+)?(the\s+)?(all\s+|total\s+|outstanding\s+)*" \
+            r"(class|common|shares|stock|voting|ownership|beneficial|equity|units)"
+AMOUNT_NATURE = r"(amount\s+and\s+nature)|((sole|shared)\s+(voting|dispositive|investment))"
+COMP_PCT = r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting" \
+           r"|bonus\s+opportunity|salary|earned|performance)"
+# signature := not COMP_PCT and (CLASS_PCT or AMOUNT_NATURE)
+```
+
+`AMOUNT_NATURE` is what recovers the `Sole Voting Power | Shared Voting Power`
+shape: Item 403 column 3 is "Amount and nature of beneficial ownership", and
+Rule 13d-3 defines beneficial ownership as voting **or** investment power, so
+issuers legitimately subdivide that column and carry no separate percent column.
+`_resolve_columns` already tiers `Sole | Shared | Total`. The `all\s+` alternate
+recovers `% of all shares`.
+
+### D1 final form (three corrections found by measurement)
+
+The draft predicate admitted three junk classes. All three are fixed and
+re-measured:
+
+1. **Length cap 120 chars.** Without it, Schedule 13G footnote paragraphs
+   ("Based solely on an amendment to a Schedule 13G filed by BlackRock…",
+   "Consists of 10,500 shares held directly…") are extracted as holder names and
+   pass the person-name test. 120 is sized for an Item 403(a) name **and
+   address** cell, which is the longest legitimate form.
+2. **Entity designators are case-SENSITIVE.** `trust interests` and
+   `allocation interests` are instrument types; case-insensitive `\btrust\b`
+   admitted them. An Item 403 owner is a proper noun — `Smith Family Trust`
+   matches, `trust interests` does not.
+3. **Instrument-type vocabulary guard.** A name composed *entirely* of equity /
+   award nouns (`Equity`, `Stock Options`, `Restricted Share Units`) is an
+   instrument, not a beneficial owner under Rule 13d-3. This is a closed ~40-word
+   vocabulary set, deliberately not a table-shape blocklist — the prevention-log
+   rule on hand-enumerated tuples targets the latter.
+
+### Measured outcome — the D3 admit population
+
+```text
+score 3-5 non-winning tables extracting rows        2,091
+  clearing row identity, DRAFT predicate            1,668   (79.8%)
+  clearing row identity, FINAL predicate            1,615
+  surviving D4 signature -> newly admitted by D3       73   (3.5%)
+```
+
+All 73 enumerated and hand-classified. They are genuine Item 403 tables —
+BlackRock, The Vanguard Group, FMR LLC, Plains GP Holdings L.P., named directors
+and officers. **One questionable:** `0001193125-25-064881`
+(`C-Suite Executives, members of our Investor Relations, Legal, Finance and
+Human Resources Departments`) is a stock-ownership-guidelines table, not Item
+403. Verify against the body during implementation; if genuine junk, it is one
+accession and does not change the design.
 
 ### Evidence gap — census pass 2 (RESOLVED; findings above)
 

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -323,26 +323,122 @@ the survivors are the genuine shapes:
 'Name | Number of Shares | Approximate Percentage of Outstanding Common'
 ```
 
-### D4 final form (resolved and measured — implement exactly this)
-
-Signature = a **class-denominated percent** column OR the **amount-and-nature
-voting/dispositive-power subdivision**, and never a comp-denominated percent.
+### D4 — SUPERSEDED first form (kept for the record)
 
 ```python
-CLASS_PCT = r"(percent|percentage|%)\s*(of\s+)?(the\s+)?(all\s+|total\s+|outstanding\s+)*" \
-            r"(class|common|shares|stock|voting|ownership|beneficial|equity|units)"
-AMOUNT_NATURE = r"(amount\s+and\s+nature)|((sole|shared)\s+(voting|dispositive|investment))"
-COMP_PCT = r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting" \
-           r"|bonus\s+opportunity|salary|earned|performance)"
 # signature := not COMP_PCT and (CLASS_PCT or AMOUNT_NATURE)
 ```
 
-`AMOUNT_NATURE` is what recovers the `Sole Voting Power | Shared Voting Power`
-shape: Item 403 column 3 is "Amount and nature of beneficial ownership", and
-Rule 13d-3 defines beneficial ownership as voting **or** investment power, so
-issuers legitimately subdivide that column and carry no separate percent column.
-`_resolve_columns` already tiers `Sole | Shared | Total`. The `all\s+` alternate
-recovers `% of all shares`.
+Measured full-population it empties **1,897 accessions — 4.5% of the corpus**.
+Do not implement it. Why it read clean is the subject of the next section.
+
+### Full-population verification — pass 3, BOTH directions (2026-07-30)
+
+Census pass 2 measured the gate **only on the 1,668 score-3-5 non-winning tables
+D3 newly ADMITS**. It never re-measured the tables that already WIN. The
+`1,668 -> 45` figure is therefore sound for what it measured and silent on the
+regression — and D2/D4 gate winner selection, so the narrowing side is the side
+that can destroy stored data.
+
+This is the directionality rule in `.claude/skills/engineering/full-population-ab.md`
+applied to a **narrowing** change: enumerate what the gate now REJECTS, not only
+what it admits.
+
+Pass 3 dumps every candidate table in every window across all **42,577** stored
+`def14a_body` payloads (`scripts/census_def14a_window_tables.py`), so any gate
+variant is evaluated offline in both directions with no re-parse per variant
+(`scripts/analyse_def14a_window_tables.py`). The enumeration path is
+byte-identical on `main` and this branch — only the selector changed — so one
+dump is a valid substrate for replaying both rules. The harness imports the
+SHIPPED `_item403_value_signature` as its `final` variant rather than
+re-expressing it, so the measurement cannot describe a gate nobody merges.
+
+| gate | accessions emptied | winning tables dropped | newly admitted |
+|---|---|---|---|
+| D4 first form, on `column_headers` | 1,897 | 2,479 | 172 |
+| first form, on both header tuples | 1,816 | 2,377 | 175 |
+| pair `(AMOUNT and PERCENT)` | 610 | 1,049 | 254 |
+| **final form (below)** | **196** | **419** | **304** |
+| loosest reference (any value vocabulary) | 176 | 402 | 561 |
+
+### D4 final form — precedence, not vocabulary
+
+Six defects, each found by the narrowing enumeration and none visible to pass 2.
+
+1. **Wrong header tuple.** The signature was applied to `column_headers`; pass 2
+   measured `score_headers`. They differ whenever a two-row header promotes the
+   SUB row — `column_headers` becomes `('', 'Sole', 'Shared', 'Total', '')`
+   while the parent `Amount and Nature of Beneficial Ownership | Percent of
+   Class` survives only in `score_headers`. Reading the narrower tuple rejected
+   the most prescribed shape the reg has, at scores 14 and 16. Read **both**.
+2. **Bare percent caption.** `CLASS_PCT` required a class noun after the percent
+   token, so `Name | Shares | Percent` was rejected — contradicting D3's own
+   rationale in this spec.
+3. **The comp veto cannot span the whole header.** Rule 13d-3(d)(1)(i) DEEMS a
+   person the beneficial owner of shares acquirable **within 60 days**, so a
+   genuine Item 403 table legitimately captions columns `Options Exercisable or
+   Vesting Within 60 Days` and `Number of Performance Shares Granted`. A blanket
+   `vesting` / `performance` veto deleted 18-, 22- and 10-holder Vanguard /
+   BlackRock / First Eagle tables.
+4. **Columns 1 and 2 have literal prescribed captions.** `Title of class` and
+   `Name and address of beneficial owner` are 229.403's own words and nothing
+   else in a proxy uses them. They are what recover a table whose VALUE column
+   is merely the class name (`Name and Address of Beneficial Owner | Common
+   Stock`). Bare `Beneficial Owner` is NOT sufficient — it admits
+   `Beneficial Owner | Number of RSUs`, so the column-3 arm keys on
+   `own(ed|ership)`, never on `owner`.
+5. **Column 4 is often absent entirely.** Dual-class and direct/indirect tables
+   caption their value columns `Class A Common Stock Owned | Class B Common
+   Stock Owned | Total Voting Power` and carry no percent anywhere.
+6. **Item 402 needs its own term of art.** Item 402(a)(3) DEFINES "named
+   executive officer"; Item 403 says "name of beneficial owner". Without it,
+   `Named Executive Officer | PSU Shares Granted (#) | Final Achievement %`
+   leaked through the generic pair.
+
+The resulting rule is an ORDERING. Reg-literal wording admits outright; only the
+weak generic evidence is subject to the Item 402 vetoes:
+
+```python
+# 1. 229.403's own captions, or Rule 13d-3's acquisition window -> Item 403 on its face
+STRONG = (BENEFICIAL          # 'shares beneficially owned', 'beneficial stock ownership'
+          or OWNER_CAPTION    # col 2: 'name [and address] of beneficial owner'
+          or AMOUNT_NATURE    # col 3: 'amount and nature' / sole|shared voting|dispositive
+          or CLASS_PCT        # col 4: 'percent of class'
+          or TITLE_OF_CLASS   # col 1: 'title of class'
+          or RULE_13D3_60_DAY)# 'within 60 days' -- 240.13d-3(d)(1)(i)
+# 2. otherwise Item 402 vocabulary vetoes
+# 3. otherwise a weak pair admits
+WEAK = AMOUNT_IND and (PERCENT_IND or OWNED_IND or BENEFICIALLY)
+```
+
+Ordering the reg's wording ABOVE the veto is what lets the veto stay broad.
+
+`PERCENT_IND` is word-bounded so `Percentile` (TSR payout ladders) does not read
+as a percent-of-class column.
+
+**Residual, hand-classified (196 accessions emptied):** payout curves, TSR
+percentile ladders, vest-date and reverse-split tables, ownership-guideline
+multiples, private-placement participation tables and plan-amendment prose — all
+correctly dropped — plus a small tail whose headers have degraded to empty cells.
+Distinct-holder loss is arm 1's question and is reported there, not here.
+
+### D1 — two further corrections found by the pass-3 narrowing enumeration
+
+4. **Strip presentation debris BEFORE the length cap.** Issuers pad the name
+   column with HTML leader dots to rule across to the figures —
+   `Hotchkis & Wiley Capital Management, LLC` plus 63 dots. Testing the raw cell
+   blew the 120-char cap, rejected the holder, took the table under
+   `_ROW_IDENTITY_FLOOR` and dropped a genuine `Amount and Nature of Beneficial
+   Ownership | Percent of Class` table (`0000074303-25-000056`). The clause
+   below already said to strip debris first; the implementation did not.
+5. **Clauses 4-5 below were specified and never implemented.** Item 403(a)
+   prescribes name AND ADDRESS in ONE column, so an entity with no corporate
+   suffix is identified by the address that follows it: `MUFG 4-5, Marunouchi
+   1-chome Chiyoda-ku, Tokyo`, `Vanguard 100 Vanguard Boulevard`, `BlackRock 50
+   Hudson Yards`. The second token is a street number, so none reaches the
+   two-capitalised-token person pattern. `0001140361-25-012302` scored 0.25 on
+   identity and was emptied. Matched on the reg's one-column name-and-address
+   FORM — not a hardcoded issuer list.
 
 ### D1 final form (three corrections found by measurement)
 

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -559,6 +559,65 @@ Implementation does not start until pass 2 reports the distribution of
 row-identity fraction for **non-winning** tables scoring 3-5 — the exact cohort
 D3 admits.
 
+## Arm 1 result — the design does NOT yet meet this ticket's own goal
+
+Two real checkouts, `main` @ `480e4f35` vs the branch, all 42,577 stored bodies.
+Authoritative; the census replay above ranks variants but undercounts real `main`
+(85,554 vs 105,400 rows, because it does not dedup across sibling tables) and must
+never be used to state an outcome.
+
+```text
+accessions                 42,577 -> 42,577
+accessions_with_rows        7,172 ->  7,133
+rows                      105,400 -> 108,649
+Item 402(c) SCT drift            0                 <- clean
+distinct holders GAINED     +4,481  (351 accessions)
+distinct holders LOST       -1,232  (255 accessions)
+```
+
+The gain side is genuine Item 403 data — BlackRock, Vanguard, FMR, Wellington,
+Starboard, named directors — and the loss side is dominated by junk `main` was
+selecting: tables of contents, income statements (`Cost of goods sold`,
+`Excise taxes`), Schedule 13G footnote PARAGRAPHS, ownership-guideline bands
+(`53% or greater`), reverse-split ratio tables.
+
+**But the guard-blocked arithmetic goes the wrong way:**
+
+```text
+main>0 -> branch==0 (emptied)    101   of which have stored rows:  99   <- NEWLY blocked
+main==0 -> branch>0 (unblocked)   62   of which have stored rows:   3   <- cohort FREED
+                                                  net guard-blocked  +96
+```
+
+This ticket exists to free a 26-accession guard-blocked residual. The design as
+it stands frees **3** and blocks **99 more**. No stored data is lost — the rewash
+guard preserves rows for all 99, and #2173 cannot release them because their
+stored names are real holders, not 13D/G cover labels — but the ticket's own
+acceptance ("#2160's residual: re-parse yields rows") is NOT met.
+
+The correctness win is real and separable from the goal. Do not merge this as a
+fix for #2160 without either closing the 99 or re-scoping the ticket.
+
+### Root cause of the 99, and one refuted fix
+
+The emptied tables are genuine Item 403 tables whose headers have degraded to
+empty cells, leaving only an amount caption — `0000805928-25-000059` renders
+`| | | Number of Shares | | | | | | Number of Shares | |`, scores 4, and extracts
+20 holders at identity fraction **1.00**. Nothing in the header distinguishes it
+from a comp table captioned `Name | Number of Shares`.
+
+Letting row evidence carry a degraded header is the obvious fix and it is
+**refuted** — see `scripts/probe_def14a_high_identity_escape.py`. It admits 516
+Item 402 tables full-population; gating on 403(a) institutional evidence narrows
+it to 143 and still leaks (a bank's deferred-comp table lists an affiliated
+entity among its rows). Either way it violates the blocking acceptance above.
+
+Open question for the next round: the discriminator probably is not in the header
+or the row identities at all, but in the VALUE columns — an Item 403 amount column
+holds share counts spanning several orders of magnitude with a 5%-holder tail,
+where an Item 402 award column holds a narrow band of grant-sized numbers. That is
+unmeasured.
+
 ## Definition of done additions (ETL clauses 8-12)
 
 - Panel `AAPL`/`GME`/`MSFT`/`JPM`/`HD` plus the 5 #2160 worked accessions.

--- a/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
+++ b/docs/specs/filings/2026-07-29-def14a-item403-row-identity.md
@@ -402,7 +402,7 @@ D3 admits.
 - Cross-source: one 5% holder verified against SEC EDGAR direct.
 - `POST /jobs/sec_rebuild/run` scoped `{"source": "sec_def14a"}`, executed.
 - `/instruments/{symbol}/ownership-rollup` verified post-backfill.
-- Parser version bumped v10 -> v11 (forces re-ingest; the conflict key is
+- Parser version bumped v12 -> v13 (forces re-ingest; the conflict key is
   derived from the parsed value, so a corrected row lands under a NEW key and
   the stale row must be superseded — prevention-log #2140 entry).
 - `_supersede_dropped_holdings`' empty-set guard preserved (`holder_name <> ALL('{}')`

--- a/scripts/analyse_def14a_window_tables.py
+++ b/scripts/analyse_def14a_window_tables.py
@@ -267,6 +267,36 @@ def main() -> int:
                 recs.append(r)
     print(f"accessions parsed from dump: {len(recs)}\n")
 
+    # FIDELITY GATE. The replay stands in for the real parser; if it disagrees
+    # with it, every variant ranking below is measuring a selector nobody runs.
+    #
+    # #2160 round 1 shipped a whole analysis before noticing 28 accessions where
+    # the dump said "no table scores >=3 with rows" while real ``main`` produced
+    # rows. Silence is not agreement -- assert it, and say so out loud when the
+    # dump predates the check (`real_rows` absent).
+    checked = [r for r in recs if "real_rows" in r]
+    if not checked:
+        print(
+            "!! FIDELITY UNVERIFIED — this dump carries no `real_rows` field.\n"
+            "   Re-run scripts/census_def14a_window_tables.py before trusting any\n"
+            "   number below. Rankings only; never state an outcome from this.\n"
+        )
+    else:
+        mismatched = []
+        for r in checked:
+            _, sel = main_selection(r["windows"])
+            replay_has = any(t["n"] > 0 for t in sel)
+            real_has = r["real_rows"] > 0
+            if replay_has != real_has:
+                mismatched.append((r["accession"], sum(t["n"] for t in sel), r["real_rows"]))
+        rate = 100 * (1 - len(mismatched) / len(checked))
+        print(f"fidelity: replay reproduces real `main` rows/no-rows on {rate:.3f}% of {len(checked)} accessions")
+        if mismatched:
+            print(f"!! {len(mismatched)} DIVERGENT — the replay is not a faithful control. First 15:")
+            for acc, rep, real in mismatched[:15]:
+                print(f"     {acc}  replay_rows={rep}  real_rows={real}")
+        print()
+
     for vname, (sig, source) in variants.items():
         lost_all: list[tuple[str, list[dict]]] = []  # main had holders, branch has none
         lost_tables: Counter[str] = Counter()  # main-selected tables now ineligible

--- a/scripts/analyse_def14a_window_tables.py
+++ b/scripts/analyse_def14a_window_tables.py
@@ -33,7 +33,7 @@ from app.providers.implementations.sec_def14a import (
 )
 
 
-def sig_final(joined: str) -> bool:
+def sig_final(joined: str, table: dict | None = None) -> bool:
     """The gate as SHIPPED — imported, not re-expressed.
 
     The v0..v6 ladder below exists to justify the choice; this variant is what
@@ -42,7 +42,14 @@ def sig_final(joined: str) -> bool:
     implementation, and then the measurement describes a gate nobody ships
     (`.claude/skills/engineering/full-population-ab.md`, "never simulate").
     """
-    return _item403_value_signature((joined,))
+    # MUST pass the data-row evidence too, or this measures a header-only gate
+    # nobody ships. `_is_item403_eligible` derives it from the extracted holders;
+    # the dump carries the same counts as `nsh` / `npc`.
+    evidence = False
+    if table is not None and table.get("n"):
+        n = table["n"]
+        evidence = table.get("nsh", 0) >= 0.5 * n and table.get("npc", 0) >= 0.5 * n
+    return _item403_value_signature((joined,), data_row_evidence=evidence)
 
 
 SCORE_FLOOR = 3
@@ -232,12 +239,22 @@ def main_selection(windows: list[list[dict]]) -> tuple[int, list[dict]]:
     return -1, []
 
 
+def _apply_sig(sig, joined: str, table: dict) -> bool:
+    """Call a variant, passing the table only to variants that accept it."""
+    try:
+        return sig(joined, table)
+    except TypeError:
+        return sig(joined)
+
+
 def branch_selection(windows: list[list[dict]], sig, source: str) -> tuple[int, list[dict]]:
     """Replay the branch: first window with an ELIGIBLE table (D2/D3/D4)."""
     for wi, tables in enumerate(windows):
         qualifying = [t for t in tables if t["s"] >= SCORE_FLOOR]
         eligible = [
-            t for t in qualifying if sig(joined_headers(t, source)) and identity_fraction(t) >= ROW_IDENTITY_FLOOR
+            t
+            for t in qualifying
+            if _apply_sig(sig, joined_headers(t, source), t) and identity_fraction(t) >= ROW_IDENTITY_FLOOR
         ]
         if eligible:
             return wi, eligible

--- a/scripts/analyse_def14a_window_tables.py
+++ b/scripts/analyse_def14a_window_tables.py
@@ -1,0 +1,310 @@
+"""Evaluate Item 403 selection-gate variants offline, in BOTH directions.
+
+Consumes ``census_def14a_window_tables.py``'s dump. Replays the real selector's
+window loop -- ``main``'s score rule and the branch's eligibility rule -- over
+the same substrate, so every variant is measured on the full population without
+re-parsing 42,566 payloads per variant.
+
+Both directions, because a selection gate has two failure modes:
+
+  NARROW  a table that wins on ``main`` is now ineligible. If nothing else in
+          its window is eligible the accession falls through to the next window
+          or emits zero rows. This is the direction census pass 2 never
+          measured, and it is where the D4 over-rejection lives
+          (#2160 comment 5125091295).
+  WIDEN   a table that ``main`` excluded joins the winning window's sibling set.
+          Failure mode is admitting an Item 402 comp table whose rows are people
+          (spec acceptance: that count must be zero).
+
+Usage:
+    PYTHONPATH=. uv run python scripts/analyse_def14a_window_tables.py DUMP.jsonl [variant]
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+
+from app.providers.implementations.sec_def14a import _is_beneficial_owner_identity
+
+SCORE_FLOOR = 3
+MAIN_SIBLING_FLOOR = 6
+ROW_IDENTITY_FLOOR = 0.5
+
+# --- gate vocabulary, each arm tied to a column of 17 CFR 229.403 ------------
+# Column 4: "Percent of class" -- class-denominated by definition.
+CLASS_PCT = re.compile(
+    r"(percent|percentage|%)\s*(of\s+)?(the\s+)?(all\s+|total\s+|outstanding\s+)*"
+    r"(class|common|shares|stock|voting|ownership|beneficial|equity|units)",
+    re.IGNORECASE,
+)
+# Column 3: "Amount and nature of beneficial ownership", and the Rule 13d-3
+# (17 CFR 240.13d-3) subdivision into voting / investment power.
+AMOUNT_NATURE = re.compile(
+    r"(amount\s+and\s+nature)|((sole|shared)\s+(voting|dispositive|investment))",
+    re.IGNORECASE,
+)
+# Column 3's ordinary caption. Issuers who write "Shares Beneficially Owned" or
+# "Beneficial Stock Ownership" are quoting the reg's own noun phrase.
+#
+# Keyed on own(ed|ership), NOT owner: "Name of Beneficial OWNER" is column 2's
+# caption and says nothing about the VALUE columns, so treating it as Item 403
+# evidence admits 'Beneficial Owner | Number of RSUs' -- a junk shape from the
+# spec's own probe list. Gap-tolerant but confined within one header cell (no
+# '|'), so it cannot bridge two unrelated captions.
+BENEFICIAL = re.compile(r"beneficial(ly)?\b[^|]{0,30}?\bown(ed|ership)\b", re.IGNORECASE)
+# Column 3 without the reg's wording -- a share/unit count of some kind.
+AMOUNT_IND = re.compile(r"\b(shares?|number|amount|units?|stock)\b", re.IGNORECASE)
+# Column 4 without the class noun. Word-bounded so 'Percentile' (TSR tables)
+# does not read as a percent column.
+PERCENT_IND = re.compile(r"\bpercent(age|ages)?\b|%", re.IGNORECASE)
+# Item 402, not Item 403: a percent of salary / target / payout / vesting.
+COMP_PCT = re.compile(
+    r"(base\s+salary|of\s+target|target\s+bonus|payout|vesting"
+    r"|bonus\s+opportunity|salary|earned|performance)",
+    re.IGNORECASE,
+)
+
+
+def sig_v0(joined: str) -> bool:
+    """As pinned in the spec and implemented on the branch."""
+    if COMP_PCT.search(joined):
+        return False
+    return bool(CLASS_PCT.search(joined) or AMOUNT_NATURE.search(joined))
+
+
+def sig_v1(joined: str) -> bool:
+    """Columns 3 and 4 as a PAIR (the issue comment's candidate amendment)."""
+    if COMP_PCT.search(joined):
+        return False
+    return bool((AMOUNT_IND.search(joined) and PERCENT_IND.search(joined)) or AMOUNT_NATURE.search(joined))
+
+
+def sig_v2(joined: str) -> bool:
+    """v1 plus column 3's own reg wording as an independent arm."""
+    if COMP_PCT.search(joined):
+        return False
+    if BENEFICIAL.search(joined) or AMOUNT_NATURE.search(joined) or CLASS_PCT.search(joined):
+        return True
+    return bool(AMOUNT_IND.search(joined) and PERCENT_IND.search(joined))
+
+
+def sig_v4(joined: str) -> bool:
+    """Precedence, not vocabulary: explicit reg wording beats the comp veto.
+
+    The comp veto cannot be applied over the whole header. Rule 13d-3(d)(1)(i)
+    DEEMS a person the beneficial owner of shares acquirable within 60 days, so
+    a genuine Item 403 table legitimately carries columns captioned 'Options
+    Exercisable or Vesting Within 60 Days' and 'Number of Performance Shares
+    Granted' -- and a blanket veto on 'vesting' / 'performance' deletes them
+    (measured: 18-, 22- and 10-holder Vanguard / BlackRock / First Eagle tables).
+
+    So: a header quoting 229.403's own column 3 or column 4 wording is Item 403
+    on its face and is admitted outright. Only the WEAK generic evidence -- some
+    amount column plus some percent column, which an Item 402 payout table also
+    has -- is subject to the comp veto.
+    """
+    if BENEFICIAL.search(joined) or AMOUNT_NATURE.search(joined) or CLASS_PCT.search(joined):
+        return True
+    if COMP_PCT.search(joined):
+        return False
+    return bool(AMOUNT_IND.search(joined) and PERCENT_IND.search(joined))
+
+
+# A VALUE column reporting what is held. 'owner' is excluded on purpose -- that
+# is column 2's caption, not column 3's.
+OWNED_IND = re.compile(r"\bown(ed|ership)\b", re.IGNORECASE)
+
+
+def sig_v5(joined: str) -> bool:
+    """v4, plus 'amount + owned' as a second weak pair.
+
+    Dual-class and direct/indirect Item 403 tables caption their value columns
+    'Class A Common Stock Owned | Class B Common Stock Owned | Total Voting
+    Power' or 'Directly Owned | Indirectly Owned | Options to Acquire Stock' --
+    genuine, and carrying no percent column at all, so v4's amount+percent pair
+    rejects them (measured: 12- and 13-holder tables). The word 'Beneficial'
+    sits in the NAME column, one '|' away, so the strong arm cannot reach it.
+
+    Kept in the WEAK set, under the comp veto: a stock-ownership-GUIDELINES
+    table also says 'Shares Owned', and Item 402 vocabulary must still be able
+    to reject it.
+    """
+    if BENEFICIAL.search(joined) or AMOUNT_NATURE.search(joined) or CLASS_PCT.search(joined):
+        return True
+    if COMP_PCT.search(joined):
+        return False
+    return bool(AMOUNT_IND.search(joined) and (PERCENT_IND.search(joined) or OWNED_IND.search(joined)))
+
+
+# Item 402(a)(3) DEFINES "named executive officer". Item 403 says "name of
+# beneficial owner". A header that captions its name column with Item 402's own
+# term of art, and carries none of Item 403's column-3/4 wording, is an Item 402
+# table -- which is how 'Named Executive Officer | PSU Shares Granted (#) |
+# Final Achievement %' leaked through v5's generic amount+percent pair.
+# Safe as a veto because it sits BELOW the strong arms: a genuine 403(b) table
+# captioned 'Named Executive Officer | Shares Beneficially Owned | Percent of
+# Class' is admitted by the strong arm before this is reached.
+NEO_CAPTION = re.compile(r"named\s+executive\s+officer", re.IGNORECASE)
+
+
+def sig_v6(joined: str) -> bool:
+    """v5, plus Item 402's own name-column term of art as a weak-set veto."""
+    if BENEFICIAL.search(joined) or AMOUNT_NATURE.search(joined) or CLASS_PCT.search(joined):
+        return True
+    if COMP_PCT.search(joined) or NEO_CAPTION.search(joined):
+        return False
+    return bool(AMOUNT_IND.search(joined) and (PERCENT_IND.search(joined) or OWNED_IND.search(joined)))
+
+
+def sig_v3(joined: str) -> bool:
+    """Loosest reference point: any Item 403 value vocabulary at all."""
+    if COMP_PCT.search(joined):
+        return False
+    return bool(AMOUNT_IND.search(joined) or PERCENT_IND.search(joined) or AMOUNT_NATURE.search(joined))
+
+
+# (signature fn, which header tuple it reads).
+#
+# The header source is itself a measured decision. The branch implementation
+# evaluates D4 on ``column_headers``, but the spec's census measured
+# ``score_headers`` -- and they differ whenever a two-row header promotes a
+# SUB-header row: ``column_headers`` becomes ``('', 'Sole', 'Shared', 'Total', '')``
+# while the parent caption ``Amount and Nature of Beneficial Ownership |
+# Percent of Class`` survives only in ``score_headers``. Reading the wrong tuple
+# rejects the most prescribed shape there is (observed at score 14 and 16 in
+# tests/test_sec_def14a_parser.py).
+VARIANTS = {
+    "v0_ch": (sig_v0, "ch"),  # exactly what the branch implements today
+    "v0_sh": (sig_v0, "both"),  # the spec's pinned regex, right header source
+    "v1": (sig_v1, "both"),  # issue comment's pair amendment
+    "v2": (sig_v2, "both"),  # pair + column-3 reg wording
+    "v4": (sig_v4, "both"),  # v2, but reg wording OUTRANKS the comp veto
+    "v5": (sig_v5, "both"),  # v4 + amount-and-owned weak pair
+    "v6": (sig_v6, "both"),  # v5 + Item 402 NEO-caption veto
+    "v3": (sig_v3, "both"),  # loosest reference point
+}
+
+
+def joined_headers(t: dict, source: str = "both") -> str:
+    if source == "ch":
+        return " | ".join(t["ch"])
+    if source == "sh":
+        return " | ".join(t["sh"])
+    return " | ".join(list(t["sh"]) + list(t["ch"]))
+
+
+def identity_fraction(t: dict) -> float:
+    names = t["nm"]
+    if not names:
+        return 0.0
+    return sum(1 for nm in names if _is_beneficial_owner_identity(nm)) / len(names)
+
+
+def main_selection(windows: list[list[dict]]) -> tuple[int, list[dict]]:
+    """Replay ``main``: first window whose best table clears the score floor."""
+    for wi, tables in enumerate(windows):
+        if not tables:
+            continue
+        best = max(t["s"] for t in tables)
+        qualifying = [t for t in tables if t["s"] >= SCORE_FLOOR]
+        if qualifying and best >= SCORE_FLOOR:
+            return wi, [t for t in qualifying if t["s"] >= MAIN_SIBLING_FLOOR or t["s"] == best]
+    return -1, []
+
+
+def branch_selection(windows: list[list[dict]], sig, source: str) -> tuple[int, list[dict]]:
+    """Replay the branch: first window with an ELIGIBLE table (D2/D3/D4)."""
+    for wi, tables in enumerate(windows):
+        qualifying = [t for t in tables if t["s"] >= SCORE_FLOOR]
+        eligible = [
+            t
+            for t in qualifying
+            if sig(joined_headers(t, source)) and identity_fraction(t) >= ROW_IDENTITY_FLOOR
+        ]
+        if eligible:
+            return wi, eligible
+    return -1, []
+
+
+def table_key(t: dict) -> tuple:
+    return (t["s"], tuple(t["sh"]), t["nr"], t["n"], tuple(t["nm"][:3]))
+
+
+def main() -> int:
+    path = sys.argv[1]
+    only = sys.argv[2] if len(sys.argv) > 2 else None
+    variants = {only: VARIANTS[only]} if only else VARIANTS
+
+    recs = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or not line.startswith("{"):
+                continue
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "error" not in r:
+                recs.append(r)
+    print(f"accessions parsed from dump: {len(recs)}\n")
+
+    for vname, (sig, source) in variants.items():
+        lost_all: list[tuple[str, list[dict]]] = []  # main had holders, branch has none
+        lost_tables: Counter[str] = Counter()  # main-selected tables now ineligible
+        lost_examples: dict[str, list[str]] = {}
+        gained_tables: Counter[str] = Counter()
+        gained_examples: dict[str, list[str]] = {}
+        n_main_rows = n_branch_rows = 0
+
+        for r in recs:
+            windows = r["windows"]
+            _, mainsel = main_selection(windows)
+            _, brsel = branch_selection(windows, sig, source)
+            main_has = any(t["n"] > 0 for t in mainsel)
+            branch_has = any(t["n"] > 0 for t in brsel)
+            n_main_rows += sum(t["n"] for t in mainsel)
+            n_branch_rows += sum(t["n"] for t in brsel)
+            if main_has and not branch_has:
+                lost_all.append((r["accession"], mainsel))
+
+            mk = {table_key(t) for t in mainsel}
+            bk = {table_key(t) for t in brsel}
+            for t in mainsel:
+                if table_key(t) not in bk and t["n"] > 0:
+                    h = joined_headers(t, source)[:110]
+                    lost_tables[h] += 1
+                    lost_examples.setdefault(h, []).append(f"{r['accession']} n={t['n']} {t['nm'][:2]}")
+            for t in brsel:
+                if table_key(t) not in mk and t["n"] > 0:
+                    h = joined_headers(t, source)[:110]
+                    gained_tables[h] += 1
+                    gained_examples.setdefault(h, []).append(f"{r['accession']} n={t['n']} {t['nm'][:2]}")
+
+        print(f"===== VARIANT {vname} =====")
+        print(f"extracted-row total   main={n_main_rows}  branch={n_branch_rows}")
+        print(f"accessions main->rows, branch->ZERO : {len(lost_all)}")
+        print(f"distinct main-selected tables dropped: {sum(lost_tables.values())} ({len(lost_tables)} header shapes)")
+        print(f"distinct tables newly admitted       : {sum(gained_tables.values())} ({len(gained_tables)} header shapes)")
+        print("\n-- NARROWING: top dropped header shapes --")
+        for h, c in lost_tables.most_common(30):
+            print(f"  {c:>5}  {h}")
+            print(f"         e.g. {lost_examples[h][0]}")
+        print("\n-- WIDENING: top newly-admitted header shapes --")
+        for h, c in gained_tables.most_common(30):
+            print(f"  {c:>5}  {h}")
+            print(f"         e.g. {gained_examples[h][0]}")
+        print("\n-- accessions that go to ZERO rows (first 40) --")
+        for acc, sel in lost_all[:40]:
+            hdr = joined_headers(sel[0], source)[:90] if sel else ""
+            nm = sel[0]["nm"][:2] if sel else []
+            print(f"  {acc}  {hdr}  {nm}")
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/analyse_def14a_window_tables.py
+++ b/scripts/analyse_def14a_window_tables.py
@@ -27,7 +27,23 @@ import re
 import sys
 from collections import Counter
 
-from app.providers.implementations.sec_def14a import _is_beneficial_owner_identity
+from app.providers.implementations.sec_def14a import (
+    _is_beneficial_owner_identity,
+    _item403_value_signature,
+)
+
+
+def sig_final(joined: str) -> bool:
+    """The gate as SHIPPED — imported, not re-expressed.
+
+    The v0..v6 ladder below exists to justify the choice; this variant is what
+    actually runs in ``parse_beneficial_ownership_table``. Keeping it a direct
+    import is deliberate harness integrity: a re-typed copy drifts from the
+    implementation, and then the measurement describes a gate nobody ships
+    (`.claude/skills/engineering/full-population-ab.md`, "never simulate").
+    """
+    return _item403_value_signature((joined,))
+
 
 SCORE_FLOOR = 3
 MAIN_SIBLING_FLOOR = 6
@@ -184,6 +200,7 @@ VARIANTS = {
     "v4": (sig_v4, "both"),  # v2, but reg wording OUTRANKS the comp veto
     "v5": (sig_v5, "both"),  # v4 + amount-and-owned weak pair
     "v6": (sig_v6, "both"),  # v5 + Item 402 NEO-caption veto
+    "final": (sig_final, "both"),  # the gate as SHIPPED (imported)
     "v3": (sig_v3, "both"),  # loosest reference point
 }
 
@@ -220,9 +237,7 @@ def branch_selection(windows: list[list[dict]], sig, source: str) -> tuple[int, 
     for wi, tables in enumerate(windows):
         qualifying = [t for t in tables if t["s"] >= SCORE_FLOOR]
         eligible = [
-            t
-            for t in qualifying
-            if sig(joined_headers(t, source)) and identity_fraction(t) >= ROW_IDENTITY_FLOOR
+            t for t in qualifying if sig(joined_headers(t, source)) and identity_fraction(t) >= ROW_IDENTITY_FLOOR
         ]
         if eligible:
             return wi, eligible
@@ -288,7 +303,9 @@ def main() -> int:
         print(f"extracted-row total   main={n_main_rows}  branch={n_branch_rows}")
         print(f"accessions main->rows, branch->ZERO : {len(lost_all)}")
         print(f"distinct main-selected tables dropped: {sum(lost_tables.values())} ({len(lost_tables)} header shapes)")
-        print(f"distinct tables newly admitted       : {sum(gained_tables.values())} ({len(gained_tables)} header shapes)")
+        print(
+            f"distinct tables newly admitted       : {sum(gained_tables.values())} ({len(gained_tables)} header shapes)"
+        )
         print("\n-- NARROWING: top dropped header shapes --")
         for h, c in lost_tables.most_common(30):
             print(f"  {c:>5}  {h}")

--- a/scripts/audit_def14a_gate_arms.py
+++ b/scripts/audit_def14a_gate_arms.py
@@ -1,0 +1,129 @@
+"""Per-ARM full-population audit of the Item 403 selection gate (#2160).
+
+Answers the three Codex ckpt-1 findings that rest on unmeasured claims, using
+the pass-3 census dump so nothing is re-parsed:
+
+  A. SCORE FLOOR (HIGH). ``window_qualifying`` still filters ``score >= 3``, so
+     ``_is_item403_eligible`` is never evaluated below it and the spec's "header
+     score no longer decides sibling membership" is only true ABOVE 3. Counts
+     what removing the floor would newly admit, so the floor's retention is a
+     measured decision rather than an oversight.
+
+  B. STRONG-ARM SOLE ADMITS (MED). Each strong arm admits OUTRIGHT, ahead of the
+     Item 402 vetoes, so "nothing else in a proxy uses this caption" is a safety
+     claim that has to be measured. For every arm, counts the tables it and it
+     alone admits, and prints their headers and rows for hand classification.
+
+  C. THE 120-CHAR D1 CAP (MED). The cap is empirical, not a documented SEC
+     limit. Enumerates every extracted name that exceeds it AFTER debris
+     stripping, so the loss it causes is inspected rather than assumed.
+
+    PYTHONPATH=. uv run python scripts/audit_def14a_gate_arms.py DUMP.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+
+import app.providers.implementations.sec_def14a as P
+from scripts.analyse_def14a_window_tables import (
+    ROW_IDENTITY_FLOOR,
+    SCORE_FLOOR,
+    branch_selection,
+    identity_fraction,
+    joined_headers,
+    main_selection,
+)
+
+# Each strong arm, by the 229.403 / 240.13d-3 clause it encodes.
+STRONG_ARMS = {
+    "col3_beneficially_owned": P._ITEM403_BENEFICIAL_RE,
+    "col2_owner_caption": P._ITEM403_OWNER_CAPTION_RE,
+    "col3_amount_and_nature": P._ITEM403_AMOUNT_NATURE_RE,
+    "col4_percent_of_class": P._ITEM403_CLASS_PCT_RE,
+    "col1_title_of_class": P._ITEM403_TITLE_OF_CLASS_RE,
+    "rule_13d3_60_day": P._RULE_13D3_60_DAY_RE,
+}
+
+
+def _sole_arm(joined: str) -> str | None:
+    """The strong arm that admits JOINED when it is the ONLY one that does."""
+    hits = [name for name, rx in STRONG_ARMS.items() if rx.search(joined)]
+    return hits[0] if len(hits) == 1 else None
+
+
+def main() -> int:
+    recs = []
+    with open(sys.argv[1]) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            r = json.loads(line)
+            if "error" not in r:
+                recs.append(r)
+    print(f"accessions: {len(recs)}\n")
+
+    # --- A. score floor -----------------------------------------------------
+    below_floor_eligible: Counter[str] = Counter()
+    below_floor_rows = 0
+    below_examples: dict[str, str] = {}
+    for r in recs:
+        for tables in r["windows"]:
+            for t in tables:
+                if t["s"] >= SCORE_FLOOR or t["n"] == 0:
+                    continue
+                j = joined_headers(t, "both")
+                if P._item403_value_signature((j,)) and identity_fraction(t) >= ROW_IDENTITY_FLOOR:
+                    h = j[:110]
+                    below_floor_eligible[h] += 1
+                    below_floor_rows += t["n"]
+                    below_examples.setdefault(h, f"{r['accession']} n={t['n']} {t['nm'][:3]}")
+    print("=== A. tables scoring 0-2 that WOULD pass eligibility if the floor were dropped ===")
+    print(f"tables {sum(below_floor_eligible.values())}  rows {below_floor_rows}  shapes {len(below_floor_eligible)}")
+    for h, c in below_floor_eligible.most_common(15):
+        print(f"  {c:>5}  {h}")
+        print(f"         {below_examples[h]}")
+
+    # --- B. strong-arm sole admits -----------------------------------------
+    print("\n=== B. tables admitted by exactly ONE strong arm (and by no other) ===")
+    per_arm: dict[str, Counter[str]] = {k: Counter() for k in STRONG_ARMS}
+    per_arm_ex: dict[str, dict[str, str]] = {k: {} for k in STRONG_ARMS}
+    for r in recs:
+        _, sel = branch_selection(r["windows"], lambda j: P._item403_value_signature((j,)), "both")
+        for t in sel:
+            if t["n"] == 0:
+                continue
+            j = joined_headers(t, "both")
+            arm = _sole_arm(j)
+            if arm is None:
+                continue
+            h = j[:110]
+            per_arm[arm][h] += 1
+            per_arm_ex[arm].setdefault(h, f"{r['accession']} n={t['n']} {t['nm'][:3]}")
+    for arm, c in per_arm.items():
+        print(f"\n-- {arm}: {sum(c.values())} tables, {len(c)} shapes")
+        for h, n in c.most_common(6):
+            print(f"  {n:>5}  {h}")
+            print(f"         {per_arm_ex[arm][h]}")
+
+    # --- C. the 120-char cap ------------------------------------------------
+    print("\n=== C. extracted names exceeding the 120-char D1 cap AFTER debris stripping ===")
+    over: Counter[str] = Counter()
+    for r in recs:
+        _, sel = main_selection(r["windows"])
+        for t in sel:
+            for nm in t["nm"]:
+                cleaned = P._IDENTITY_DEBRIS_RE.sub(" ", nm).strip(" .,​﻿*†#")
+                if len(cleaned) > P._OWNER_IDENTITY_MAX_LEN:
+                    over[cleaned[:150]] += 1
+    print(f"distinct over-cap names: {len(over)}  occurrences: {sum(over.values())}")
+    for nm, c in over.most_common(25):
+        print(f"  {c:>4}  {nm}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/census_def14a_item403_tables.py
+++ b/scripts/census_def14a_item403_tables.py
@@ -1,0 +1,101 @@
+"""Census pass 2 -- EVERY candidate table, not only winners.
+
+Closes the evidence gap Codex flagged at spec ckpt-1: the pass-1 proof covered
+winning tables, but D3 admits every table in the winning window that clears the
+row-identity floor. The signal must be proven on the population it will newly
+admit.
+
+Also fixes pass 1's measurement basis: identity is computed on the resolved NAME
+column via the real extraction path (``_resolve_columns`` +
+``_extract_holder_rows``), not on the raw first cell. Item 403's prescribed
+first column is "Title of class"; the owner name is column 2.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import psycopg
+
+import app.providers.implementations.sec_def14a as parser_mod
+from app.config import settings
+
+
+def main() -> int:
+    original_parse = parser_mod._parse_table_html
+    tables: list[dict] = []
+
+    def traced_parse(table_html: str):
+        t = original_parse(table_html)
+        if t is None or not t.rows:
+            return t
+        try:
+            name_idx, shares_idx, percent_idx = parser_mod._resolve_columns(t.column_headers)
+        except Exception:
+            return t
+        holders: list = []
+        seen: set[str] = set()
+        try:
+            parser_mod._extract_holder_rows(
+                t,
+                name_idx=name_idx,
+                shares_idx=shares_idx,
+                percent_idx=percent_idx,
+                rows=holders,
+                seen=seen,
+            )
+        except Exception:
+            return t
+        tables.append(
+            {
+                "score": parser_mod._score_table_headers(t.score_headers),
+                "headers": list(t.score_headers)[:10],
+                "n_raw_rows": len(t.rows),
+                "n_extracted": len(holders),
+                "names": [h.holder_name for h in holders[:30]],
+            }
+        )
+        return t
+
+    parser_mod._parse_table_html = traced_parse
+
+    sql = """
+        SELECT accession_number, payload
+        FROM filing_raw_documents
+        WHERE document_kind = 'def14a_body'
+        ORDER BY accession_number
+    """
+    n = 0
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET statement_timeout = 0")
+        with conn.cursor(name="def14a_census2") as cur:
+            cur.itersize = 20
+            cur.execute(sql)
+            for accession, payload in cur:
+                tables.clear()
+                try:
+                    result = parser_mod.parse_beneficial_ownership_table(payload)
+                except Exception as exc:  # noqa: BLE001
+                    print(json.dumps({"accession": accession, "error": repr(exc)[:160]}), flush=True)
+                    continue
+                print(
+                    json.dumps(
+                        {
+                            "accession": accession,
+                            "final_rows": len(result.rows),
+                            "winning_score": result.raw_table_score,
+                            "tables": tables[:60],
+                        }
+                    ),
+                    flush=True,
+                )
+                n += 1
+                if n % 250 == 0:
+                    print(f"... {n}", file=sys.stderr, flush=True)
+    print(f"DONE {n}", file=sys.stderr, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/census_def14a_row_identity.py
+++ b/scripts/census_def14a_row_identity.py
@@ -1,0 +1,138 @@
+"""Measure separability of the row-identity test on the full census.
+
+17 CFR 229.403 prescribes the ROW identity: "Name [and address] of beneficial
+owner". Instruction 5 adds 403(b)'s directors-and-officers-as-a-group row.
+
+Question: does "fraction of rows whose first cell is a beneficial-owner
+identity" separate genuine Item 403 tables from the share-talking tables that
+currently beat them (income statements, cap tables, plan pools, TSR metrics)?
+
+If there is no clean separation, the model needs changing again -- report that
+rather than picking a threshold that papers over an overlap.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+
+# --- Beneficial-owner identity, POSITIVE test only --------------------------
+# A blocklist of junk labels would need an entry per new junk table shape; the
+# prevention log's rule on hand-enumerated tuples applies. A positive test is
+# closed under new junk types.
+
+# Entity designators. Deliberately broad -- an Item 403 5%-holder list is full
+# of funds, advisers and nominees.
+_ENTITY = re.compile(
+    r"\b("
+    r"LLC|L\.L\.C|LP|L\.P|LLP|Inc|Incorporated|Corp|Corporation|Company|Co|Ltd|Limited"
+    r"|Trust|Fund|Funds|Partners|Partnership|Capital|Management|Advisers|Advisors"
+    r"|Holdings|Group|Associates|Ventures|Bank|N\.A|plc|GmbH|S\.A|AG|NV|PLC"
+    r"|Foundation|Insurance|Investments?|Asset|Securities|Financial"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Person name at the START of the cell. NOT anchored at the end: Item 403(a)
+# prescribes "Name AND ADDRESS of beneficial owner", so the address is
+# legitimately part of the same cell, and issuers routinely append a title
+# ("David J. Mazzo, Ph.D., President and Chief Executive Officer") or several
+# credentials. Anchoring to $ rejected all of those -- measured, not assumed.
+# The optional comma covers the surname-first rendering ("Bunch, Charles E.",
+# "Allen, Dwayne L."), which issuers use for alphabetised management tables.
+_PERSON = re.compile(r"^[A-Z][A-Za-z.'’-]*,?(?:\s+(?:[A-Z][A-Za-z.'’-]*|[A-Z]\.|van|von|de|del|der|di|la|le),?)+")
+
+# Instruction 5's aggregate row.
+_GROUP = re.compile(r"as a group", re.IGNORECASE)
+
+# Presentation debris. Leader dots are an HTML-table artefact and appear INSIDE
+# the name cell, not only at the end.
+_TRAIL = re.compile(r"\s*[\(\[]\s*[\d,\s]+\s*[\)\]]\s*$|\s*\*+\s*$")
+_LEADER = re.compile(r"[.…]{3,}")
+_FOOTNOTE_DIGITS = re.compile(r"\s+[\d,]+\s*$")
+
+
+def _clean(name: str) -> str:
+    n = _LEADER.sub(" ", (name or "").strip())
+    n = _TRAIL.sub("", n)
+    n = _FOOTNOTE_DIGITS.sub("", n)
+    return n.strip(" .,​﻿")
+
+
+def is_owner_identity(name: str) -> bool:
+    n = _clean(name)
+    if not n:
+        return False
+    if _GROUP.search(n):
+        return True
+    if _ENTITY.search(n):
+        return True
+    return bool(_PERSON.match(n))
+
+
+def main() -> int:
+    path = sys.argv[1]
+    recs = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith(("DONE", "...")):
+                continue
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "error" not in r and r.get("n_rows", 0) > 0:
+                recs.append(r)
+
+    print(f"accessions with rows: {len(recs)}\n")
+
+    # Reuse the Q1 cohort split so the two measurements are comparable.
+    def is_c_only(r: dict) -> bool:
+        w = [c for c in r["candidates"] if c["at_winning_score"]]
+        return bool(w) and all(c["klass"] == "C_neither" for c in w)
+
+    hist_all: Counter[int] = Counter()
+    hist_conly: Counter[int] = Counter()
+    low_examples = []
+
+    for r in recs:
+        hs = r["holders"]
+        if not hs:
+            continue
+        frac = sum(1 for h in hs if is_owner_identity(h)) / len(hs)
+        bucket = int(frac * 10) * 10
+        hist_all[bucket] += 1
+        if is_c_only(r):
+            hist_conly[bucket] += 1
+        if frac < 0.5 and len(low_examples) < 20:
+            low_examples.append((r["accession"], round(frac, 2), hs[:3]))
+
+    print("owner-identity fraction, ALL accessions with rows")
+    print(f"{'bucket':>8} {'count':>8}  {'cum%':>7}")
+    tot = sum(hist_all.values())
+    cum = 0
+    for b in sorted(hist_all):
+        cum += hist_all[b]
+        print(f"{b:>6}-% {hist_all[b]:>8}  {100 * cum / tot:>6.2f}")
+    print()
+
+    print("same, restricted to the C_neither-winner cohort (junk-suspect)")
+    tot2 = sum(hist_conly.values())
+    for b in sorted(hist_conly):
+        print(f"{b:>6}-% {hist_conly[b]:>8}")
+    print(f"  cohort total: {tot2}")
+    print()
+
+    print("accessions below 50% owner-identity (candidates for rejection):")
+    n_low = sum(v for k, v in hist_all.items() if k < 50)
+    print(f"  count: {n_low}  ({100 * n_low / tot:.2f}% of accessions with rows)")
+    for acc, frac, hs in low_examples:
+        print(f"  {acc}  frac={frac}  {hs}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/census_def14a_window_tables.py
+++ b/scripts/census_def14a_window_tables.py
@@ -38,7 +38,9 @@ import app.providers.implementations.sec_def14a as parser_mod
 from app.config import settings
 
 _MAX_WINDOWS = 4
-_MAX_TABLES_PER_WINDOW = 80
+# Was 80. #2160 round 1 found accessions whose winning window holds more tables
+# than that, so the dump silently truncated the very table the parser selects.
+_MAX_TABLES_PER_WINDOW = 400
 _MAX_NAMES = 40
 _MAX_HEADERS = 12
 _NAME_CLIP = 160
@@ -52,6 +54,7 @@ def _table_record(html_text: str, start: int, end: int) -> dict | None:
         return None
     score = parser_mod._score_table_headers(parsed.score_headers)
     names: list[str] = []
+    n_shares = n_percent = 0
     try:
         name_idx, shares_idx, percent_idx = parser_mod._resolve_columns(parsed.column_headers)
         holders: list = []
@@ -64,7 +67,14 @@ def _table_record(html_text: str, start: int, end: int) -> dict | None:
             seen=set(),
         )
         names = [h.holder_name[:_NAME_CLIP] for h in holders]
-    except Exception:  # noqa: BLE001 -- a table we cannot extract scores 0 identity
+        # VALUE-side evidence, for the data-row column signal borrowed from
+        # edgartools' ``_build_column_map`` (skill G17). Item 403 prescribes an
+        # amount column AND a percent-of-class column; when the CAPTIONS have
+        # degraded to empty cells the only remaining evidence that both exist is
+        # that both PARSED for the rows.
+        n_shares = sum(1 for h in holders if h.shares is not None)
+        n_percent = sum(1 for h in holders if h.percent_of_class is not None)
+    except Exception:  # noqa: BLE001 -- a table we cannot extract scores 0 identity and 0 value evidence
         holders = []
     return {
         "s": score,
@@ -73,6 +83,8 @@ def _table_record(html_text: str, start: int, end: int) -> dict | None:
         "nr": len(parsed.rows),
         "n": len(names),
         "nm": names[:_MAX_NAMES],
+        "nsh": n_shares,
+        "npc": n_percent,
     }
 
 
@@ -108,7 +120,19 @@ def main() -> int:
                 except Exception as exc:  # noqa: BLE001
                     print(json.dumps({"accession": accession, "error": repr(exc)[:200]}), flush=True)
                     continue
-                print(json.dumps({"accession": accession, "windows": out}), flush=True)
+                # Ground truth for the analyser's FIDELITY GATE: what the REAL
+                # parser returns for this body, same checkout, same payload.
+                #
+                # #2160 round 1 found 28 accessions where the dump implied "no
+                # table scores >=3 with rows" while real ``main`` produced rows.
+                # The replay silently disagreed with the control it was standing
+                # in for, and every variant ranking rested on it. Recording the
+                # truth per accession turns that into an assertion.
+                try:
+                    truth = len(parser_mod.parse_beneficial_ownership_table(payload).rows)
+                except Exception:  # noqa: BLE001
+                    truth = -1
+                print(json.dumps({"accession": accession, "windows": out, "real_rows": truth}), flush=True)
                 if n % 250 == 0:
                     print(f"... {n}", file=sys.stderr, flush=True)
     print(f"DONE {n}", file=sys.stderr, flush=True)

--- a/scripts/census_def14a_window_tables.py
+++ b/scripts/census_def14a_window_tables.py
@@ -38,9 +38,13 @@ import app.providers.implementations.sec_def14a as parser_mod
 from app.config import settings
 
 _MAX_WINDOWS = 4
-# Was 80. #2160 round 1 found accessions whose winning window holds more tables
-# than that, so the dump silently truncated the very table the parser selects.
-_MAX_TABLES_PER_WINDOW = 400
+# NO per-window table cap. It was 80, then 400, and both silently truncated the
+# very table the parser selects: when ``_find_section_windows`` finds no heading
+# it falls back to a WHOLE-DOCUMENT window, and a merger proxy (Kenvue
+# 0001140361-25-045607) then yields thousands of spans with Item 403 far past any
+# cap. The fidelity gate caught it at 400 -- 42 accessions, replay 0 rows vs real
+# 41 -- which is exactly what the gate is for. Cost is parse time on a handful of
+# huge documents; the DUMP stays small because only tables WITH rows are kept.
 _MAX_NAMES = 40
 _MAX_HEADERS = 12
 _NAME_CLIP = 160
@@ -112,7 +116,7 @@ def main() -> int:
                     for window_start, window_end in windows[:_MAX_WINDOWS]:
                         spans = parser_mod._scan_outer_tables(payload, start=window_start, end=window_end)
                         tables = []
-                        for start, end in spans[:_MAX_TABLES_PER_WINDOW]:
+                        for start, end in spans:
                             rec = _table_record(payload, start, end)
                             if rec is not None:
                                 tables.append(rec)

--- a/scripts/census_def14a_window_tables.py
+++ b/scripts/census_def14a_window_tables.py
@@ -1,0 +1,119 @@
+"""Census pass 3 -- dump EVERY candidate table in EVERY window, once.
+
+Why a third pass. Pass 2 measured the D2/D4 gate only on the 1,668 score-3-5
+NON-winning tables that D3 newly ADMITS. It never re-measured the tables that
+already WIN, and that is exactly where the D4 over-rejection lives: issuers
+caption Item 403 column 4 as a bare ``Percent`` or ``%`` and leave the class
+implied by the neighbouring amount column. The 1,668 -> 45 figure is sound for
+what it measured and silent on the regression (#2160 issue comment 5125091295).
+
+`.claude/skills/engineering/full-population-ab.md`: a narrowing change must
+enumerate the narrowing side. D2/D4 gate WINNER selection, so the narrowing side
+is "tables that win today and would not win under the gate".
+
+Design: dump the SUBSTRATE, not a verdict. The enumeration path
+(``_find_section_windows`` -> ``_scan_outer_tables`` -> ``_parse_table_html`` ->
+``_resolve_columns`` -> ``_extract_holder_rows``) is byte-identical on ``main``
+and on this branch -- only the selector changed -- so one corpus pass supports
+offline simulation of ANY gate variant in BOTH directions, with no refetch and
+no re-parse per variant. ``analyse_def14a_window_tables.py`` consumes it.
+
+Unlike the real parser this does NOT stop at the first qualifying window: the
+gate can empty a window that wins today, in which case selection falls through
+to the next one, so every window's tables have to be on record.
+
+Run against the dev DB from any checkout:
+
+    PYTHONPATH=. uv run python scripts/census_def14a_window_tables.py > dump.jsonl
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import psycopg
+
+import app.providers.implementations.sec_def14a as parser_mod
+from app.config import settings
+
+_MAX_WINDOWS = 4
+_MAX_TABLES_PER_WINDOW = 80
+_MAX_NAMES = 40
+_MAX_HEADERS = 12
+_NAME_CLIP = 160
+
+
+def _table_record(html_text: str, start: int, end: int) -> dict | None:
+    parsed = parser_mod._parse_table_html(html_text[start:end])
+    if parsed is None or not parsed.rows:
+        # Mirrors the parser: a table with no DATA rows cannot be the Item 403
+        # table and is skipped before scoring (#2158 element 4).
+        return None
+    score = parser_mod._score_table_headers(parsed.score_headers)
+    names: list[str] = []
+    try:
+        name_idx, shares_idx, percent_idx = parser_mod._resolve_columns(parsed.column_headers)
+        holders: list = []
+        parser_mod._extract_holder_rows(
+            parsed,
+            name_idx=name_idx,
+            shares_idx=shares_idx,
+            percent_idx=percent_idx,
+            rows=holders,
+            seen=set(),
+        )
+        names = [h.holder_name[:_NAME_CLIP] for h in holders]
+    except Exception:  # noqa: BLE001 -- a table we cannot extract scores 0 identity
+        holders = []
+    return {
+        "s": score,
+        "sh": [h[:_NAME_CLIP] for h in parsed.score_headers[:_MAX_HEADERS]],
+        "ch": [h[:_NAME_CLIP] for h in parsed.column_headers[:_MAX_HEADERS]],
+        "nr": len(parsed.rows),
+        "n": len(names),
+        "nm": names[:_MAX_NAMES],
+    }
+
+
+def main() -> int:
+    sql = """
+        SELECT accession_number, payload
+        FROM filing_raw_documents
+        WHERE document_kind = 'def14a_body'
+        ORDER BY accession_number
+    """
+    n = 0
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET statement_timeout = 0")
+        with conn.cursor(name="def14a_census3") as cur:
+            cur.itersize = 20
+            cur.execute(sql)
+            for accession, payload in cur:
+                n += 1
+                if not payload:
+                    print(json.dumps({"accession": accession, "windows": []}), flush=True)
+                    continue
+                try:
+                    windows = parser_mod._find_section_windows(payload)
+                    out: list[list[dict]] = []
+                    for window_start, window_end in windows[:_MAX_WINDOWS]:
+                        spans = parser_mod._scan_outer_tables(payload, start=window_start, end=window_end)
+                        tables = []
+                        for start, end in spans[:_MAX_TABLES_PER_WINDOW]:
+                            rec = _table_record(payload, start, end)
+                            if rec is not None:
+                                tables.append(rec)
+                        out.append(tables)
+                except Exception as exc:  # noqa: BLE001
+                    print(json.dumps({"accession": accession, "error": repr(exc)[:200]}), flush=True)
+                    continue
+                print(json.dumps({"accession": accession, "windows": out}), flush=True)
+                if n % 250 == 0:
+                    print(f"... {n}", file=sys.stderr, flush=True)
+    print(f"DONE {n}", file=sys.stderr, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probe_d4_value_signature.py
+++ b/scripts/probe_d4_value_signature.py
@@ -1,0 +1,37 @@
+"""Does the spec's pinned D4 regex reject GENUINE Item 403 header shapes?"""
+
+from app.providers.implementations.sec_def14a import _item403_value_signature
+
+# Genuine Item 403 shapes taken from the repo's own regression fixtures
+# (tests/test_sec_def14a_parser.py) and from the #2160 spec's own list of
+# shapes it says D4 must ADMIT.
+GENUINE = [
+    ("bare promoted label row (CYH 0001193125-26-140269)", ("Name", "", "Number", "", "Percent")),
+    ("bare 3-col", ("Name of Beneficial Owner", "Shares Beneficially Owned", "Percent")),
+    ("spec says admit", ("Name", "Shares (1)", "Percent of Outstanding Shares of Common Stock")),
+    ("spec says admit", ("Name", "Number of Common Shares", "Percent of Common Shares")),
+    ("spec says admit", ("Name", "Number of Shares", "Approximate Percentage of Outstanding Common")),
+    (
+        "prescribed",
+        ("Name and Address of Beneficial Owner", "Amount and Nature of Beneficial Ownership", "Percent of Class"),
+    ),
+    ("percent-of-class", ("Name of Beneficial Owner", "Shares", "Percent of Class")),
+    ("pct sign col", ("Name of Beneficial Owner", "Shares Beneficially Owned", "%")),
+]
+JUNK = [
+    ("comp payout", ("Named Executive Officer", "Shares at Target", "Final PSU Payout %")),
+    ("comp salary", ("Name", "Threshold (Percentage of Base Salary)", "Target (Percentage of Base Salary)")),
+    ("comp options", ("Name of Individual or Identity of Group and Position", "Shares Underlying Options")),
+    ("comp rsu", ("Beneficial Owner", "Number of RSUs")),
+    ("guidelines", ("Position", "Minimum Dollar Value", "Minimum Number of Shares")),
+    ("capitalisation", ("", "Authorized for issuance", "Issued and outstanding")),
+]
+
+print("=== GENUINE Item 403 shapes — every one MUST pass ===")
+for label, h in GENUINE:
+    ok = _item403_value_signature(h)
+    print(f"  {'PASS' if ok else 'REJECT  <-- OVER-REJECTION':28s} {label:42s} {h}")
+print("\n=== junk — every one MUST be rejected ===")
+for label, h in JUNK:
+    ok = _item403_value_signature(h)
+    print(f"  {'ADMIT  <-- LEAK' if ok else 'reject':28s} {label:42s} {h}")

--- a/scripts/probe_def14a_high_identity_escape.py
+++ b/scripts/probe_def14a_high_identity_escape.py
@@ -1,0 +1,113 @@
+"""REFUTED: a high-identity escape hatch for degraded Item 403 headers (#2160).
+
+Arm 1 round 1 found genuine Item 403 tables emptied because their ONLY surviving
+caption is an amount column -- 0000805928-25-000059 renders
+``| | | Number of Shares | | | | | | Number of Shares | |``, scores 4, and
+extracts 20 holders at identity fraction 1.00 (BlackRock, First Light Asset
+Management LLC, Soleus Capital Master Fund LP). D4 rejects it on headers alone.
+
+The natural fix is to let overwhelming ROW evidence carry a table whose HEADERS
+have degraded: eligible if ``frac >= HIGH`` and some amount indicator is present.
+
+It does not survive measurement, which is why this probe is committed rather
+than the idea. Full population, 42,577 bodies:
+
+    baseline (no escape)            emptied=199  dropped=423  extra-admits=0
+    escape hi=0.90                  emptied=119  dropped=263  extra-admits=516
+    escape hi=0.90 + entity-gated   emptied=170  dropped=362  extra-admits=143
+
+The admits are dominated by Item 402 compensation tables -- 'Named Executives |
+Number of Shares of Restricted Stock | Number of Performance Units',
+'Beneficial Owner | Number of RSUs', 'Named Executive Officer | Shares at Target
+| Final PSU Payout %', 'Name and Position | Number of Shares Subject to Stock
+Options'. That violates this spec's BLOCKING acceptance (zero comp/plan/metric
+tables admitted), so the escape hatch is rejected in both forms.
+
+Gating on 403(a) institutional evidence (a row carrying an entity designator, or
+Instruction 5's as-a-group row) narrows it but does not close it: a deferred-comp
+table for a bank lists an affiliated entity among its rows.
+
+Counts here come from the census REPLAY and are approximate -- the replay
+undercounts real ``main`` (85,554 vs 105,400 rows) because it does not dedup
+across sibling tables. Use it to RANK variants, never to state an outcome; the
+two-checkout A/B is the authority.
+
+    PYTHONPATH=. uv run python scripts/probe_def14a_high_identity_escape.py DUMP.jsonl
+"""
+
+import collections
+import json
+import sys
+
+sys.path.insert(0, ".")
+import app.providers.implementations.sec_def14a as P
+import scripts.analyse_def14a_window_tables as A
+
+recs = []
+for line in open(sys.argv[1]):
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    r = json.loads(line)
+    if "error" not in r:
+        recs.append(r)
+
+
+def has_403a_evidence(t):
+    """>=1 row is an institutional entity (403(a) >5% holder) or Instruction 5's group row."""
+    for nm in t["nm"]:
+        s = (nm or "").strip()
+        if "as a group" in s.lower():
+            return True
+        if P._OWNER_ENTITY_CASED_RE.search(s):
+            return True
+    return False
+
+
+def sel(windows, hi, need_entity):
+    for tables in windows:
+        q = [t for t in tables if t["s"] >= 3]
+        el = []
+        for t in q:
+            j = A.joined_headers(t, "both")
+            f = A.identity_fraction(t)
+            ok = P._item403_value_signature((j,)) and f >= 0.5
+            if not ok and hi is not None and f >= hi and P._ITEM403_AMOUNT_IND_RE.search(j):
+                if (not need_entity) or has_403a_evidence(t):
+                    ok = True
+            if ok:
+                el.append(t)
+        if el:
+            return el
+    return []
+
+
+base_cache = {}
+for label, hi, ne in (
+    ("baseline", None, False),
+    ("escape+entity hi=0.9", 0.90, True),
+    ("escape+entity hi=0.8", 0.80, True),
+):
+    zero = 0
+    dropped = 0
+    gained = collections.Counter()
+    gex = {}
+    for r in recs:
+        _, m = A.main_selection(r["windows"])
+        b = sel(r["windows"], hi, ne)
+        if any(t["n"] > 0 for t in m) and not any(t["n"] > 0 for t in b):
+            zero += 1
+        mk = {A.table_key(t) for t in m}
+        bk = {A.table_key(t) for t in b}
+        dropped += sum(1 for t in m if A.table_key(t) not in bk and t["n"] > 0)
+        if hi is not None:
+            base = set(A.table_key(t) for t in sel(r["windows"], None, False))
+            for t in b:
+                if A.table_key(t) not in base and t["n"] > 0:
+                    h = A.joined_headers(t, "both")[:100]
+                    gained[h] += 1
+                    gex.setdefault(h, f"{r['accession']} n={t['n']} {t['nm'][:2]}")
+    print(f"\n=== {label}: emptied={zero} dropped={dropped} extra-admits={sum(gained.values())} shapes={len(gained)}")
+    for h, c in gained.most_common(14):
+        print(f"  {c:>4}  {h}")
+        print(f"        {gex[h]}")

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -2050,3 +2050,29 @@ class TestHeadingTestDoesNotRejectNamedHolders:
         entity token, or a corporate designator must also be present."""
         assert not _contains_specific_name("Directors and Executive Officers of the Company")
         assert _contains_specific_name("Trustees of the Thomas J. Pritzker Family Trusts")
+
+
+class TestAmpersandFirmNames:
+    """#2160 Codex ckpt-2 P2 — partnership-style firm names joined by '&'.
+
+    They carry no corporate suffix, so the entity arm misses them, and the
+    start-anchored person arm stops dead at the '&'. Under the new selection
+    gate that made a small 5%-holder table ineligible outright. Common in Item
+    403(a): the corpus holds Cohen & Steers, Cooke & Bieler, Cede & Co and
+    Bill & Melinda Gates Foundation Trust.
+    """
+
+    def test_ampersand_firms_are_owner_identities(self) -> None:
+        for text in (
+            "Dodge & Cox 555 California Street San Francisco, CA 94104",
+            "Brown & Brown 220 South Ridgewood Avenue Daytona Beach, FL 32114",
+            "Cohen & Steers",
+            "Cede & Co",
+            "Ruane, Cunniff & Goldfarb 9 West 57th Street New York, NY 10019",
+            "Bill & Melinda Gates Foundation Trust",
+        ):
+            assert _is_beneficial_owner_identity(text), text
+
+    def test_ampersand_does_not_rescue_a_heading(self) -> None:
+        for text in ("Directors and Executive Officers:", "5% Stockholders"):
+            assert not _is_beneficial_owner_identity(text), text

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -32,6 +32,7 @@ from app.providers.implementations.sec_def14a import (
     _detect_role_heading,
     _is_address_fragment,
     _is_beneficial_owner_identity,
+    _is_name_then_address,
     _is_owner_identity,
     _item403_value_signature,
     _looks_like_label_row,
@@ -1879,3 +1880,31 @@ class TestBeneficialOwnerIdentityIgnoresLeaderDots:
             "with the SEC on January 29, 2025, reporting sole voting power over "
             "12,312,184 shares of our common stock."
         )
+
+
+class TestGateArmsCannotOverreach:
+    """#2160 — Codex ckpt-1 findings. Each strong arm admits OUTRIGHT, ahead of
+    the Item 402 vetoes, so each one's precision is load-bearing."""
+
+    def test_the_60_day_window_needs_an_acquisition_verb(self) -> None:
+        """Rule 13d-3(d)(1)(i) is about securities a person has the right to
+        ACQUIRE within sixty days. The bare phrase also appears in
+        change-in-control and termination tables, and admitting those ahead of
+        the comp veto would emit severance data as beneficial ownership."""
+        assert _item403_value_signature(("Name", "Options Exercisable or Vesting Within 60 Days", "Common Stock"))
+        assert _item403_value_signature(("Name", "Subject to Rights to Acquire Within 60 Days"))
+        assert not _item403_value_signature(
+            ("Named Executive Officer", "Payments upon Termination within 60 Days", "Cash Severance ($)")
+        )
+
+    def test_the_name_and_address_arm_needs_address_evidence(self) -> None:
+        """Item 403(a) prescribes name AND address in one column. A proper-noun
+        run followed by any digit is not that -- it also matches metric rows."""
+        for text in (
+            "MUFG 4-5, Marunouchi 1-chome Chiyoda-ku, Tokyo 100-8330, Japan",
+            "Vanguard 100 Vanguard Boulevard Malvern, PA 19355",
+            "BlackRock 50 Hudson Yards New York, NY 10001",
+        ):
+            assert _is_name_then_address(text), text
+        for text in ("Adjusted EBITDA 2024", "Net Sales 2025", "Retail Adjusted EBITDA 2024"):
+            assert not _is_name_then_address(text), text

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -31,7 +31,9 @@ from app.providers.implementations.sec_def14a import (
     _clean_holder_name,
     _detect_role_heading,
     _is_address_fragment,
+    _is_beneficial_owner_identity,
     _is_owner_identity,
+    _item403_value_signature,
     _looks_like_label_row,
     _looks_like_subheader,
     _parse_percent,
@@ -1764,3 +1766,116 @@ class TestTwoPercentColumnsOrdering:
         cells = ["Simon Leung", "29.6"]
         headers = ("Name", "Minimum Payment (if Threshold is Met) as Percentage of Base Salary")
         assert _shares_cell_percent_signature(cells, 1, headers) == "decisive"
+
+
+class TestItem403ValueSignature:
+    """#2160 D4 — the Item 403 VALUE-column gate.
+
+    The first cut of this gate emptied 14 of the regression fixtures below and
+    3.6% of the corpus. Each group here pins one of the four defects that
+    measuring the NARROWING direction exposed.
+    """
+
+    def test_bare_percent_caption_is_admitted(self) -> None:
+        """229.403 column 4 is 'Percent of class', but issuers caption it bare
+        and leave the class implied by the neighbouring amount column. The
+        first cut required a class noun AFTER the percent token and rejected
+        every one of these."""
+        for headers in (
+            ("Name", "", "Number", "", "Percent"),  # CYH 0001193125-26-140269
+            ("Name of Beneficial Owner", "Shares Beneficially Owned", "Percent"),
+            ("Name of Beneficial Owner", "Shares Beneficially Owned", "%"),
+            ("Name", "Shares", "Percent"),
+            ("Beneficial Owner", "Shares Owned", "Percent"),
+            ("Name of Beneficial Owner", "", "Number", "", "Percentage"),
+        ):
+            assert _item403_value_signature(headers), headers
+
+    def test_prescribed_wording_outranks_the_compensation_veto(self) -> None:
+        """Rule 13d-3(d)(1)(i) DEEMS a person the beneficial owner of shares
+        acquirable within 60 days, so a genuine Item 403 table legitimately
+        carries 'vesting' and 'performance' columns. A blanket comp veto over
+        the whole header deleted 18-, 22- and 10-holder Vanguard / BlackRock /
+        First Eagle tables."""
+        for headers in (
+            (
+                "Name and Address",
+                "Number of Outstanding Shares Beneficially Owned",
+                "Number of Shares Underlying RSUs/MSUs vesting within 60 days",
+            ),
+            (
+                "Number of Shares Beneficially Owned (1)",
+                "Percentage of Outstanding Shares",
+                "Number of Performance Shares Granted",
+            ),
+            (
+                "NAME OF BENEFICIAL OWNER",
+                "COMMON STOCK",
+                "OPTIONS EXERCISABLE OR VESTING WITHIN 60 DAYS",
+                "AMOUNT OWNED",
+            ),
+        ):
+            assert _item403_value_signature(headers), headers
+
+    def test_value_columns_saying_owned_need_no_percent_column(self) -> None:
+        """Dual-class and direct/indirect tables omit column 4 outright. The
+        word 'Beneficial' sits in the NAME column, a '|' away, so the strong
+        arm cannot reach it and the amount+percent pair rejects them."""
+        for headers in (
+            (
+                "Name of Beneficial Owner",
+                "Class A Common Stock Owned",
+                "Class B Common Stock Owned",
+                "Total Voting Power",
+            ),
+            (
+                "Name of Beneficial Owner",
+                "Directly Owned (a)",
+                "Indirectly Owned",
+                "Options to Acquire Stock (b)",
+            ),
+        ):
+            assert _item403_value_signature(headers), headers
+
+    def test_item_402_tables_are_still_rejected(self) -> None:
+        """The gate must not be loosened into a no-op. 'Named Executive
+        Officer' is Item 402(a)(3)'s own term of art and vetoes the weak pair;
+        'Beneficial Owner | Number of RSUs' is why the column-3 arm keys on
+        own(ed|ership) and not on 'owner'."""
+        for headers in (
+            ("Named Executive Officer", "Shares at Target", "Final PSU Payout %"),
+            ("Named Executive Officer", "2022 Fiscal Year PSU Shares Granted (#)", "Final Achievement %"),
+            ("Name", "Threshold (Percentage of Base Salary)", "Target (Percentage of Base Salary)"),
+            ("Name of Individual or Identity of Group and Position", "Shares Underlying Options"),
+            ("Beneficial Owner", "Number of RSUs"),
+            ("Position", "Minimum Dollar Value", "Minimum Number of Shares"),
+            ("", "Authorized for issuance", "Issued and outstanding"),
+            ("50 th Percentile", "25 th Percentile"),
+        ):
+            assert not _item403_value_signature(headers), headers
+
+
+class TestBeneficialOwnerIdentityIgnoresLeaderDots:
+    """#2160 D1 — presentation debris is stripped BEFORE the length cap.
+
+    Issuers pad the name column with HTML leader dots to rule across to the
+    figures. Testing the raw cell blew the 120-char cap, rejected the holder,
+    took the table under ``_ROW_IDENTITY_FLOOR`` and dropped a genuine
+    'Amount and Nature of Beneficial Ownership | Percent of Class' table
+    (0000074303-25-000056).
+    """
+
+    def test_a_name_padded_with_leader_dots_is_still_an_identity(self) -> None:
+        padded = "Hotchkis & Wiley Capital Management, LLC " + "." * 100
+        assert len(padded) > 120
+        assert _is_beneficial_owner_identity(padded)
+        assert _is_beneficial_owner_identity("BlackRock, Inc. " + "." * 90)
+
+    def test_the_length_cap_still_rejects_a_footnote_paragraph(self) -> None:
+        """The cap exists to keep Schedule 13G footnote PARAGRAPHS out of the
+        holder set; stripping debris must not defeat it."""
+        assert not _is_beneficial_owner_identity(
+            "Based solely on an amendment to a Schedule 13G filed by BlackRock, Inc. "
+            "with the SEC on January 29, 2025, reporting sole voting power over "
+            "12,312,184 shares of our common stock."
+        )

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -1964,3 +1964,50 @@ class TestItem403DataRowValueFallback:
         bare = ("", "", "", "Number of Shares", "", "", "", "", "", "Number of Shares", "", "")
         assert not _item403_value_signature(bare)
         assert _item403_value_signature(bare, data_row_evidence=True)
+
+
+class TestStrongArmsCannotAdmitItem402Outcomes:
+    """#2160 Codex ckpt-1 HIGH — the precedence design is only sound if every
+    STRONG arm is near-perfect, because a strong arm admits AHEAD of the Item 402
+    veto. ``_ITEM403_CLASS_PCT_RE`` was not.
+
+    229.403 column 4 is "Percent of CLASS": the denominator is a class of
+    securities, so the class-noun run ENDS the denominator phrase. A trailing
+    participle makes it a percent of an OUTCOME, which is Item 402.
+    """
+
+    def test_a_percent_of_an_outcome_is_not_a_percent_of_class(self) -> None:
+        for headers in (
+            ("Name", "Percentage of Shares Earned"),
+            ("Name", "Percentage of Shares Vested"),
+            ("Name", "Percentage of Common Stock Earned"),
+            ("Name", "Percentage of Total Stock Earned"),
+            ("Name", "Percentage of Stock Options Vesting"),
+            ("Name", "Percentage of total stock incentive awards (%)"),
+        ):
+            assert not _item403_value_signature(headers), headers
+
+    def test_the_class_noun_run_does_not_backtrack(self) -> None:
+        """'Percentage of Common Stock Earned' matched by consuming only
+        'Common' and seeing 'Stock' in the allowed-follow set. The run is
+        possessive so that path is closed."""
+        assert not _item403_value_signature(("Name", "Percentage of Common Stock Earned"))
+        assert _item403_value_signature(("Name", "Percentage of Common Stock"))
+
+    def test_genuine_class_denominators_still_admit(self) -> None:
+        for headers in (
+            ("Name of Beneficial Owner", "Shares", "Percent of Class (1)"),
+            ("Name", "Shares (1)", "Percent of Outstanding Shares of Common Stock"),
+            ("Shareholder", "Number of Voting Rights (#)", "Percentage of Voting Rights (%)"),
+            ("Name", "Number of Shares", "Percent of Total Voting Power"),
+            ("Name", "Shares (1)", "% of all shares of Class A common stock"),
+            ("Name", "Number of Common Shares", "Approximate Percentage of Outstanding Common"),
+        ):
+            assert _item403_value_signature(headers), headers
+
+    def test_the_data_row_fallback_cannot_admit_an_award_outcome_table(self) -> None:
+        """Codex ckpt-1 HIGH-2: 'Shares at Target | Final Achievement %' parses
+        both a share count and a percent for every NEO row, so the data-row
+        evidence is TRUE. The Item 402 outcome vocabulary is what rejects it."""
+        headers = ("Name", "Shares at Target", "Final Achievement %")
+        assert not _item403_value_signature(headers, data_row_evidence=True)

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -26,10 +26,12 @@ from decimal import Decimal
 
 from app.providers.implementations.sec_def14a import (
     _SCHEDULE_13D_COVER_LABEL_RE,
+    Def14ABeneficialHolder,
     Def14ABeneficialOwnershipTable,
     _clean_beneficial_holder_name,
     _clean_holder_name,
     _detect_role_heading,
+    _has_item403_value_rows,
     _is_address_fragment,
     _is_beneficial_owner_identity,
     _is_name_then_address,
@@ -1908,3 +1910,57 @@ class TestGateArmsCannotOverreach:
             assert _is_name_then_address(text), text
         for text in ("Adjusted EBITDA 2024", "Net Sales 2025", "Retail Adjusted EBITDA 2024"):
             assert not _is_name_then_address(text), text
+
+
+class TestItem403DataRowValueFallback:
+    """#2160 — D4's data-row fallback, borrowed from edgartools'
+    ``_build_column_map`` (skill G17).
+
+    A header-only gate empties genuine Item 403 tables whose captions have
+    degraded to blank cells. 17 CFR 229.403 prescribes column 3 (amount) AND
+    column 4 (percent of class); when the captions are gone, both columns
+    PARSING for a majority of rows is the remaining evidence that both exist.
+    """
+
+    @staticmethod
+    def _holder(name: str, shares: str | None, percent: str | None) -> Def14ABeneficialHolder:
+        return Def14ABeneficialHolder(
+            holder_name=name,
+            shares=Decimal(shares) if shares is not None else None,
+            percent_of_class=Decimal(percent) if percent is not None else None,
+            holder_role=None,
+        )
+
+    def test_both_value_columns_parsing_is_evidence(self) -> None:
+        holders = [
+            self._holder("BlackRock, Inc.", "1000", "5.1"),
+            self._holder("First Light Asset Management, LLC", "900", "4.2"),
+            self._holder("Soleus Capital Master Fund, L.P.", "800", "3.9"),
+        ]
+        assert _has_item403_value_rows(holders)
+
+    def test_an_amount_column_alone_is_NOT_evidence(self) -> None:
+        """An Item 402 award table has an amount column and no percent. Requiring
+        BOTH is what keeps this from becoming a bypass."""
+        holders = [
+            self._holder("Kevin R.M. Smith", "1000", None),
+            self._holder("Jennifer F. Scanlon", "900", None),
+            self._holder("Dr. Hou", "800", None),
+        ]
+        assert not _has_item403_value_rows(holders)
+
+    def test_empty_holder_set_is_not_evidence(self) -> None:
+        assert not _has_item403_value_rows([])
+
+    def test_the_fallback_ranks_BELOW_the_item_402_vetoes(self) -> None:
+        """Weak evidence must not bypass the veto — a comp table with a payout
+        percent column also satisfies the data-row test."""
+        comp = ("Named Executive Officer", "Shares at Target", "Final PSU Payout %")
+        assert not _item403_value_signature(comp, data_row_evidence=True)
+        salary = ("Name", "Percentage of Annual Total Direct Compensation")
+        assert not _item403_value_signature(salary, data_row_evidence=True)
+
+    def test_the_fallback_admits_a_caption_less_table(self) -> None:
+        bare = ("", "", "", "Number of Shares", "", "", "", "", "", "Number of Shares", "", "")
+        assert not _item403_value_signature(bare)
+        assert _item403_value_signature(bare, data_row_evidence=True)

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -30,6 +30,7 @@ from app.providers.implementations.sec_def14a import (
     Def14ABeneficialOwnershipTable,
     _clean_beneficial_holder_name,
     _clean_holder_name,
+    _contains_specific_name,
     _detect_role_heading,
     _has_item403_value_rows,
     _is_address_fragment,
@@ -2011,3 +2012,41 @@ class TestStrongArmsCannotAdmitItem402Outcomes:
         evidence is TRUE. The Item 402 outcome vocabulary is what rejects it."""
         headers = ("Name", "Shares at Target", "Final Achievement %")
         assert not _item403_value_signature(headers, data_row_evidence=True)
+
+
+class TestHeadingTestDoesNotRejectNamedHolders:
+    """#2160 arm-1/arm-2 round 2 — ``_HOLDER_CLASS_PLURAL_RE`` is a SECTION-HEADING
+    test (#2164) and it outranks the entity arm on purpose, so that 'Directors and
+    Executive Officers of the Company' cannot be rescued by its trailing 'Company'.
+
+    But Schedule 13D/G joint-filer names legitimately contain those same class
+    nouns. Hyatt 0001104659-26-038759 lost an 11-holder sibling table this way,
+    taking the Pritzker family trusts, CIBC Caribbean, Massachusetts Financial
+    Services and Baron Capital with it.
+
+    A heading names a class abstractly; a holder carries a SPECIFIC proper name.
+    """
+
+    def test_joint_filer_holder_names_survive(self) -> None:
+        for text in (
+            "CIBC Caribbean and Other Reporting Persons",
+            "Trustees of the Thomas J. Pritzker Family Trusts and Other Reporting Persons",
+            "Trustees of the Karen L. Pritzker Family Trusts",
+        ):
+            assert _is_beneficial_owner_identity(text), text
+
+    def test_section_headings_are_still_rejected(self) -> None:
+        for text in (
+            "Directors and Executive Officers:",
+            "Directors and Executive Officers of the Company",
+            "Other Shareowners that Beneficially Own More than 5%:",
+            "5% Stockholders",
+            "Named Executive Officers",
+        ):
+            assert not _is_beneficial_owner_identity(text), text
+
+    def test_the_rescue_needs_hard_proper_noun_evidence(self) -> None:
+        """A qualifying name RUN alone is not enough — an initial, an all-caps
+        entity token, or a corporate designator must also be present."""
+        assert not _contains_specific_name("Directors and Executive Officers of the Company")
+        assert _contains_specific_name("Trustees of the Thomas J. Pritzker Family Trusts")


### PR DESCRIPTION
## What changed

Item 403 table SELECTION no longer turns on header score. A table may win its window, and
join the sibling set, only if it passes BOTH limbs of a 17 CFR 229.403 eligibility test:

- **D0/D1/D2** — at least 50% of its extracted rows name a *beneficial owner* (Rule 13d-3),
  measured on the RESOLVED NAME COLUMN through the real `_resolve_columns` +
  `_extract_holder_rows` path (229.403 column 1 is `Title of class`, not the owner).
- **D4** — its headers carry Item 403's prescribed VALUE columns, with a **data-row
  fallback** when the captions have degraded.

`_SIBLING_SCORE_FLOOR` is deleted; header score is retained for window RANKING only. The
score floor of 3 stays and is now documented as load-bearing. Parser `def14a-v12 -> v13`.

## Why

Header score is a sum of keyword weights and cannot separate a genuine Item 403 table from
a comp / prose / capitalisation table that hits the same keywords. On
`0001628280-26-044960` the genuine 403(a) table scores 4 while a Delaware-vs-Texas charter
prose block scores 5 and takes the window. This is the fifth consecutive per-case patch to
this selector — which is the trigger CLAUDE.md names for questioning the model.

## Source rule

- **Schedule 14A Item 6(d)** (17 CFR 240.14a-101) brings Item 403 into a proxy.
- **17 CFR 229.403** prescribes four columns: `Title of class` / `Name [and address] of
  beneficial owner` / `Amount and nature of beneficial ownership` / `Percent of class`.
- **229.403(b)** requires coverage of *"each of the registrant's directors … each of the
  named executive officers … and directors and executive officers as a group"*.
- **Instruction 5** establishes the as-a-group aggregate row.
- **Rule 13d-3** defines "beneficial owner"; **13d-3(d)(1)(i)** DEEMS ownership of
  securities acquirable **within sixty days**.
- **Item 402(a)(3)** defines "named executive officer" — Item 402's term of art.

Full spec: `docs/specs/filings/2026-07-29-def14a-item403-row-identity.md`.

## Standard-filing reuse check (CLAUDE.md, was due four patches ago)

Run, and it changed the design. `edgar.proxy.html_extractor.extract_beneficial_ownership`
exists; tested offline on our actual failing accessions it is **not a drop-in** (returns
`None` on 4 of 8, under-extracts a fifth: 2 rows where `main` found 16) but solves the two
largest losses outright with percentages. The value was the TECHNIQUE: its
`_build_column_map` falls back to classifying the first DATA ROWS when headers classify too
few columns. Our gate was header-only — which is exactly why a genuine table rendering
`| | | Number of Shares | | | | | | Number of Shares | |` over BlackRock / First Light /
Soleus rows was emptied. Adopted, credited, recorded as skill **G17**; prevention-log entry
makes the trigger mechanical.

Also checked: no dedicated open-source Item 403 parser exists, because Item 403 is
unstructured BY REGULATION. The structured arbiters for the same facts are Schedule 13D/G
(XML mandate 2024-12-18) and Forms 3/4/5, both already ingested here.

## Full-population verification — the direction the spec never measured

⚠ **The D4 form pinned in the spec empties 1,897 accessions — 4.5% of the corpus.** So does
the amendment proposed on the issue (610). Census pass 2 measured the gate only on the
1,668 tables D3 ADMITS and never on the tables that already WIN — and D2/D4 gate winner
selection, so the narrowing side is the side that destroys data.

Pass 3 dumps every candidate table in every window across all **42,577** stored bodies and
**asserts its own fidelity** against the real parser (100.000%). That gate caught two
silent truncations that had produced confident wrong numbers.

| gate | emptied | dropped | admitted |
|---|---|---|---|
| D4 as pinned, on `column_headers` | **1,897** | 2,479 | 172 |
| the issue's `(AMOUNT and PERCENT)` pair | 610 | 1,049 | 254 |
| **final** | **93** | **363** | **448** |

## Three-arm A/B — two real checkouts, nothing simulated

```text
accessions_with_rows        7,172 ->  7,145
rows                      105,400 -> 108,812
Item 402(c) SCT drift            0
distinct holders GAINED     +4,491  (364 accessions)
distinct holders LOST       -1,079  (242 accessions)
```

**Arm 2 (parse vs STORED):** 238 accessions / 1,059 holders — consistent, no extra
blind-spot population.

**Arm 3 (value/role audit)** — the arm arms 1 and 2 structurally cannot see:

```text
role LOSSES (role -> None)    0     <- #2164's regression pattern does not occur
role GAINS  (None -> role)  213
role RECLASSIFICATIONS        3     all corrections
share values changed        304 rows / 70 accessions
```

Of those 70, **56 had `main` on an Item 402 table** — Tyson's round `1,200,000` salary
figures become real share counts `3,826,952`.

**Admit side, hand-classified:** 448 admits, **0 comp/plan/metric tables** (the blocking
acceptance). Started at 21 violations; Codex ckpt-1 found `CLASS_PCT` — a STRONG arm that
admits ahead of the veto — matching `Percentage of Shares Earned`.

**Emptied side, hand-classified:** 156 net-negative accessions, **107 provably correct
drops**. Genuine residual is three characterised classes, filed as **#2176**.

## Conscious tradeoffs

- **The score floor of 3 stays.** Removing it was measured, not argued: +704 tables /
  +5,794 rows, dominated by Item 402 option-grant tables.
- **D2 is a SELECTION gate, not a row filter** — a row-level filter would delete the ~6
  sub-floor accessions that carry genuine holders.
- **Bare `Beneficial Owner` is not column-2 evidence** — accepting it measurably admits
  `Beneficial Owner | Number of RSUs`. Costs 2 accessions (#2176 class 3).
- **The 120-char D1 cap is empirical**, not a documented SEC limit, and nearly inert:
  120 -> 300 moves the corpus by one accession and six tables.

## The guard-blocked count moves the wrong way, and that is deliberate

```text
main>0  -> branch==0   89   (87 have stored rows)
main==0 -> branch>0    62   (3 from the guard-blocked cohort)
                              net  +84
```

This issue was filed to free a 26-accession guard-blocked residual; it frees 3. But the 87
newly-blocked are accessions where `main` was selecting a **non-Item-403 table** — the
parser now correctly declines to reproduce junk, and the rewash guard PRESERVES their
stored rows rather than losing them. Nothing is deleted.

Flushing that stored junk is the CHOKEPOINT's job, not the selector's. **#2173** (merged
today) established the mechanism — release the zero-holder guard when the stored rows are
provably not Item 403 data — and extending its predicate closes the original 26 and these
87 together. Recorded in the spec.

## Checks

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` ·
`pytest tests/smoke` — all pass. Codex ckpt-1 (2 HIGH + 2 MED) and ckpt-2 (1 P2) resolved;
the P2 was verified against the corpus before accepting.

DoD clauses 8-12 follow after merge: rewash to `def14a-v13`, panel smoke, cross-source, and
the rollup endpoint.

Closes #2160. Refs #2163. Refs #2173. Refs #2175. Refs #2176.