### PR TITLE
fix(#2178): cap report rank movers at the builder and the render

### DIFF
--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -227,21 +227,70 @@ def _positions_opened_closed(
     return opened, closed
 
 
+def _select_rank_movers(
+    rows: list[dict[str, Any]],
+    *,
+    top_n: int = 10,
+) -> list[dict[str, Any]]:
+    """Pick the rows that belong on the statement, from one row per instrument.
+
+    `rows` is already collapsed to one row per instrument (its single
+    largest move in the period) and sorted by `rank_delta` DESC, so
+    risers lead and fallers trail.
+
+    Takes `top_n` from EACH direction rather than the top `2 * top_n` by
+    magnitude — the same shape `_compute_contributors` uses for
+    contributors/drags. Pure magnitude skews hard in practice: for June
+    2026 the top 20 by `ABS(rank_delta)` are 4 risers and 16 fallers, so
+    a section titled "Rank movers" would read as a market-wide collapse.
+    The pre-cap total travels alongside as `score_changes_total`, so the
+    exhibit never claims to be the whole set.
+    """
+    risers = [r for r in rows if r["rank_delta"] > 0][:top_n]
+    fallers = [r for r in rows if r["rank_delta"] < 0]
+    # `rows` is DESC, so fallers trail with the most-negative last. Take
+    # them from the tail via an index, NOT `[-top_n:]` — a negative slice
+    # turns `top_n=0` into `[-0:]`, which is the whole list.
+    return risers + fallers[max(len(fallers) - top_n, 0) :]
+
+
 def _score_changes(
     conn: psycopg.Connection[Any],
     period_start: date,
     period_end: date,
     min_rank_delta: int = 5,
-) -> list[dict[str, Any]]:
-    """Significant rank movements in the report period.
+    *,
+    top_n: int = 10,
+) -> tuple[list[dict[str, Any]], int]:
+    """Biggest rank movers in the report period — capped for the statement.
 
-    Filters to rows where ABS(rank_delta) >= min_rank_delta.
+    Returns `(movers, total)`. One row per instrument — its single
+    largest-magnitude `rank_delta` in the window — then
+    `_select_rank_movers` caps each direction at `top_n`. `total` is the
+    pre-cap instrument count, stored as `score_changes_total` so the
+    exhibit never reads as the full movement set.
+
+    **Why per-row `rank_delta` and never a start-vs-end rank diff:** a
+    report period routinely spans a `model_version` bump (June 2026 spans
+    v1.1/v1.2/v1.3-balanced), and settled-decisions "Rank delta
+    comparison" holds that ranks are only comparable within one
+    model_version. `scoring._fetch_prior_ranks` filters
+    `model_version = %(mv)s`, so every STORED `rank_delta` is
+    version-safe by construction; subtracting two ranks across the
+    window is not, and would report the model change as instrument
+    movement.
+
+    `ABS(rank_delta) >= min_rank_delta` is retained but near-inert on the
+    live universe (June median |rank_delta| = 301 across ~3,900 names) —
+    `top_n` is what actually bounds the payload.
+
     rank and rank_delta were added to scores in migration 007.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT s.instrument_id,
+            SELECT DISTINCT ON (s.instrument_id)
+                   s.instrument_id,
                    i.symbol,
                    s.total_score,
                    s.rank,
@@ -253,22 +302,26 @@ def _score_changes(
               AND s.scored_at < %(end)s::date + 1
               AND s.rank_delta IS NOT NULL
               AND ABS(s.rank_delta) >= %(min_delta)s
-            ORDER BY ABS(s.rank_delta) DESC
+            ORDER BY s.instrument_id, ABS(s.rank_delta) DESC, s.scored_at DESC
             """,
             {"start": period_start, "end": period_end, "min_delta": min_rank_delta},
         )
         rows = cur.fetchall()
-    return [
+    movers: list[dict[str, Any]] = [
         {
             "instrument_id": r["instrument_id"],
             "symbol": r["symbol"],
             "total_score": _dec(r["total_score"]),
             "rank": r["rank"],
-            "rank_delta": r["rank_delta"],
+            "rank_delta": int(r["rank_delta"]),
             "scored_at": r["scored_at"].isoformat() if r["scored_at"] is not None else None,
         }
         for r in rows
     ]
+    # SQL orders by instrument_id (DISTINCT ON requires it), so re-sort
+    # by signed delta: risers first, fallers last.
+    collapsed = sorted(movers, key=lambda r: int(r["rank_delta"]), reverse=True)
+    return _select_rank_movers(collapsed, top_n=top_n), len(collapsed)
 
 
 def _budget_snapshot(conn: psycopg.Connection[Any]) -> dict[str, Any]:
@@ -1646,7 +1699,7 @@ def generate_weekly_report(
     # remains in the snapshot shape as an empty list so existing
     # readers (frontend, downstream report consumers) don't NPE.
     upcoming_earnings: list[dict[str, Any]] = []
-    score_changes = _score_changes(conn, period_start, period_end)
+    score_changes, score_changes_total = _score_changes(conn, period_start, period_end)
     budget = _budget_snapshot(conn)
     positions_now = _positions_snapshot(conn)
     prior = _load_prior_snapshot(conn, report_type="weekly", period_start=period_start)
@@ -1696,6 +1749,9 @@ def generate_weekly_report(
         "positions_closed": positions_closed,
         "upcoming_earnings": upcoming_earnings,
         "score_changes": score_changes,
+        # Pre-cap mover count — `score_changes` is a top-N exhibit, and
+        # the statement must not imply it is the full set (#2178).
+        "score_changes_total": score_changes_total,
         "budget": budget,
         # Per-instrument position snapshot so the *next* weekly
         # snapshot can compute period contribution against it.
@@ -1737,7 +1793,7 @@ def generate_monthly_report(
     # Rank movers were weekly-only pre-#1596 (committee finding: the
     # monthly model-review section cited a key the monthly builder
     # never wrote).
-    score_changes = _score_changes(conn, period_start, period_end)
+    score_changes, score_changes_total = _score_changes(conn, period_start, period_end)
     prior = _load_prior_snapshot(conn, report_type="monthly", period_start=period_start)
     # When `prior` is absent OR lacks the `positions` key (pre-feature
     # snapshots from before Slice 4), pass `None` so
@@ -1803,6 +1859,9 @@ def generate_monthly_report(
         "risk": risk,
         "thesis_summary": thesis_summary,
         "score_changes": score_changes,
+        # Pre-cap mover count — `score_changes` is a top-N exhibit, and
+        # the statement must not imply it is the full set (#2178).
+        "score_changes_total": score_changes_total,
         "pnl": pnl,
         "position_pnl": position_pnl,
         "win_rate": win_rate_data["win_rate_pct"],

--- a/frontend/src/api/reportSnapshot.test.ts
+++ b/frontend/src/api/reportSnapshot.test.ts
@@ -61,6 +61,7 @@ const WEEKLY_KEYS = [
   "report_type",
   "schema_version",
   "score_changes",
+  "score_changes_total",
   "top_performers",
   "upcoming_earnings",
 ].sort();
@@ -88,6 +89,7 @@ const MONTHLY_KEYS = [
   "rolling_returns",
   "schema_version",
   "score_changes",
+  "score_changes_total",
   "tax_provision",
   "thesis_accuracy",
   "thesis_summary",

--- a/frontend/src/api/reportSnapshot.ts
+++ b/frontend/src/api/reportSnapshot.ts
@@ -256,6 +256,11 @@ interface SnapshotV2Base {
   positions: PositionRowV2[];
   pnl: PnlV2;
   score_changes: ScoreChangeV2[];
+  /** Pre-cap mover count. `score_changes` is a top-N exhibit, not the
+   *  full set (#2178). Optional: snapshots generated before #2178 carry
+   *  the uncapped array and no total, so the FE falls back to the array
+   *  length rather than claiming a count it does not have. */
+  score_changes_total?: number;
 }
 
 export interface WeeklySnapshotV2 extends SnapshotV2Base {

--- a/frontend/src/components/reports/MonthlySections.tsx
+++ b/frontend/src/components/reports/MonthlySections.tsx
@@ -309,10 +309,13 @@ export function ModelThesisSection({
 
       <div>
         <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
-          Rank movers{" "}
-          <span className="normal-case text-slate-400">
-            (largest single move per name; {shown.length} of {moverTotal} shown)
-          </span>
+          Rank movers
+          {shown.length > 0 ? (
+            <span className="normal-case text-slate-400">
+              {" "}
+              (largest single move per name; {shown.length} of {moverTotal} shown)
+            </span>
+          ) : null}
         </h3>
         {scoreChanges.length === 0 ? (
           <NilLine>No significant rank movements this period.</NilLine>

--- a/frontend/src/components/reports/MonthlySections.tsx
+++ b/frontend/src/components/reports/MonthlySections.tsx
@@ -226,15 +226,32 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
   );
 }
 
+/** Hard render cap on "Rank movers", independent of payload size.
+ *
+ *  Snapshots generated before #2178 carry the UNCAPPED array — the June
+ *  2026 monthly holds 29,281 rows (4.38 MB of a 4.39 MB snapshot), and
+ *  rendering a react-router `<Link>` per row froze the page. Those rows
+ *  are already stored, so the builder fix alone does not rescue them;
+ *  this cap is what makes a pre-#2178 snapshot renderable without a
+ *  regen. Sits above the builder's own top-N so a future `top_n` bump
+ *  is not silently truncated here. */
+const MOVER_RENDER_CAP = 50;
+
 export function ModelThesisSection({
   attribution,
   thesis,
   scoreChanges,
+  scoreChangesTotal,
 }: {
   attribution: AttributionSummaryV2;
   thesis: ThesisSummaryV2;
   scoreChanges: MonthlySnapshotV2["score_changes"];
+  scoreChangesTotal: MonthlySnapshotV2["score_changes_total"];
 }) {
+  const shown = scoreChanges.slice(0, MOVER_RENDER_CAP);
+  // Pre-#2178 snapshots have no total; the array IS the full set there,
+  // so its length is the honest count rather than an invented one.
+  const moverTotal = scoreChangesTotal ?? scoreChanges.length;
   const components: ReadonlyArray<readonly [string, string | null]> = [
     ["Gross return", attribution.avg_gross_return_pct],
     ["Market", attribution.avg_market_return_pct],
@@ -292,13 +309,16 @@ export function ModelThesisSection({
 
       <div>
         <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
-          Rank movers
+          Rank movers{" "}
+          <span className="normal-case text-slate-400">
+            (largest single move per name; {shown.length} of {moverTotal} shown)
+          </span>
         </h3>
         {scoreChanges.length === 0 ? (
           <NilLine>No significant rank movements this period.</NilLine>
         ) : (
           <ul className="max-w-md space-y-0.5">
-            {scoreChanges.map((s) => (
+            {shown.map((s) => (
               <li key={`${s.instrument_id}-${s.scored_at}`} className="flex items-baseline justify-between gap-4">
                 <Link
                   to={`/instrument/${encodeURIComponent(s.symbol)}`}

--- a/frontend/src/pages/ReportsPage.test.tsx
+++ b/frontend/src/pages/ReportsPage.test.tsx
@@ -149,8 +149,13 @@ describe("ReportsPage — v2 monthly statement", () => {
       expect(screen.getByText("Sector exposure")).toBeInTheDocument();
     });
     // Named sector appears in both the holdings table and the exposure
-    // bars — both render the resolved name, never a numeric id.
-    expect(screen.getAllByText("Technology").length).toBeGreaterThanOrEqual(2);
+    // bars — both render the resolved name, never a numeric id. The
+    // name is the canonical SIC-derived GICS label (#1634/#1851/#1951),
+    // not eToro's coarse "Technology"; the fixture carried the stale
+    // coarse value until it was regenerated (#2178).
+    expect(
+      screen.getAllByText("Information Technology").length,
+    ).toBeGreaterThanOrEqual(2);
   });
 
   it("footer carries generated_at and the benchmark basis", async () => {
@@ -240,6 +245,9 @@ describe("ReportsPage — unbounded-payload defences (#2178)", () => {
   function monthlyWithMovers(count: number): Record<string, unknown> {
     return {
       ...(monthlyFixture as Record<string, unknown>),
+      // Override the fixture's own total (0) so the header stays
+      // coherent with the array this helper builds.
+      score_changes_total: count,
       score_changes: Array.from({ length: count }, (_, i) => ({
         instrument_id: i + 1,
         symbol: `S${i + 1}`,
@@ -274,9 +282,12 @@ describe("ReportsPage — unbounded-payload defences (#2178)", () => {
   });
 
   it("falls back to the array length when a pre-#2178 snapshot has no total", async () => {
-    // No score_changes_total key: the array IS the full set there, so
-    // claiming a different number would invent data.
-    mockedMonthly.mockResolvedValue([row(monthlyWithMovers(12))]);
+    // A genuinely pre-#2178 snapshot has no score_changes_total at all —
+    // strip the key the current builder now always writes. The array IS
+    // the full set there, so claiming a different number invents data.
+    const legacy = { ...monthlyWithMovers(12) };
+    delete legacy["score_changes_total"];
+    mockedMonthly.mockResolvedValue([row(legacy)]);
     renderPage();
     await waitFor(() => {
       expect(screen.getByText(/12 of 12 shown/)).toBeInTheDocument();

--- a/frontend/src/pages/ReportsPage.test.tsx
+++ b/frontend/src/pages/ReportsPage.test.tsx
@@ -9,7 +9,7 @@
  * InsiderByOfficer convention — jsdom can't lay out
  * ResponsiveContainer.
  */
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -229,5 +229,71 @@ describe("ReportsPage — states and legacy routing", () => {
     await waitFor(() => {
       expect(mockedMonthly).toHaveBeenCalledWith(100);
     });
+  });
+});
+
+describe("ReportsPage — unbounded-payload defences (#2178)", () => {
+  /** A pre-#2178 snapshot: the builder shipped every scored row in the
+   *  period, so the stored monthly for June 2026 carries 29,281. Those
+   *  rows are already persisted, so the builder fix does not rescue
+   *  them — the page must survive them on its own. */
+  function monthlyWithMovers(count: number): Record<string, unknown> {
+    return {
+      ...(monthlyFixture as Record<string, unknown>),
+      score_changes: Array.from({ length: count }, (_, i) => ({
+        instrument_id: i + 1,
+        symbol: `S${i + 1}`,
+        total_score: "50",
+        rank: i + 1,
+        rank_delta: count - i,
+        scored_at: "2026-06-15T00:00:00Z",
+      })),
+    };
+  }
+
+  it("caps the rendered mover list regardless of payload size", async () => {
+    mockedMonthly.mockResolvedValue([row(monthlyWithMovers(500))]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Model & thesis review")).toBeInTheDocument();
+    });
+    // Symbols are S1..S500 in rank_delta-DESC order; only the first 50
+    // may reach the DOM. S1 is in, S51 is not.
+    expect(screen.getByText("S1")).toBeInTheDocument();
+    expect(screen.queryByText("S51")).not.toBeInTheDocument();
+  });
+
+  it("discloses the pre-cap total so the exhibit never reads as the full set", async () => {
+    mockedMonthly.mockResolvedValue([
+      row({ ...monthlyWithMovers(20), score_changes_total: 3898 }),
+    ]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/20 of 3898 shown/)).toBeInTheDocument();
+    });
+  });
+
+  it("falls back to the array length when a pre-#2178 snapshot has no total", async () => {
+    // No score_changes_total key: the array IS the full set there, so
+    // claiming a different number would invent data.
+    mockedMonthly.mockResolvedValue([row(monthlyWithMovers(12))]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/12 of 12 shown/)).toBeInTheDocument();
+    });
+  });
+
+  it("does not build the raw-JSON appendix until the operator opens it", async () => {
+    mockedMonthly.mockResolvedValue([row(monthlyFixture as Record<string, unknown>)]);
+    const { container } = renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Appendix: snapshot data")).toBeInTheDocument();
+    });
+    // `<details>` would have committed the <pre> while merely collapsed;
+    // state-gating means there is no <pre> at all.
+    expect(container.querySelector("pre")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw JSON" }));
+    expect(container.querySelector("pre")).not.toBeNull();
   });
 });

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -14,7 +14,7 @@
  * Period navigation is URL-backed (?type=&period=) with PUSH so the
  * back button walks periods (§6.6).
  */
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { fetchMonthlyReports, fetchWeeklyReports } from "@/api/reports";
@@ -67,6 +67,36 @@ function PageSkeleton() {
           <SectionSkeleton rows={4} />
         </div>
       ))}
+    </div>
+  );
+}
+
+/** Raw-snapshot appendix, gated on STATE rather than `<details>`.
+ *
+ *  `<details>` collapses visually only — React still builds the
+ *  pretty-printed string and commits the `<pre>` on every render. A
+ *  monthly snapshot is ~4.4 MB, so `JSON.stringify(snap, null, 2)` was
+ *  materialising ~9 MB of text and a giant text node on a page the
+ *  operator had not asked to expand (#2178). Rendering nothing until
+ *  the operator opts in keeps the cost where the intent is.
+ */
+function RawJsonAppendix({ snap }: { snap: SnapshotV2 }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="text-xs">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        className="cursor-pointer text-slate-500 hover:underline"
+      >
+        Raw JSON
+      </button>
+      {open ? (
+        <pre className="mt-2 overflow-x-auto rounded bg-slate-50 p-2 dark:bg-slate-900/40">
+          {JSON.stringify(snap, null, 2)}
+        </pre>
+      ) : null}
     </div>
   );
 }
@@ -183,6 +213,7 @@ function StatementV2({
                 attribution={monthly.attribution_summary}
                 thesis={monthly.thesis_summary}
                 scoreChanges={monthly.score_changes}
+                scoreChangesTotal={monthly.score_changes_total}
               />
             </Section>
           </div>
@@ -194,12 +225,7 @@ function StatementV2({
       </Section>
 
       <Section title="Appendix: snapshot data">
-        <details className="text-xs">
-          <summary className="cursor-pointer text-slate-500">Raw JSON</summary>
-          <pre className="mt-2 overflow-x-auto rounded bg-slate-50 p-2 dark:bg-slate-900/40">
-            {JSON.stringify(snap, null, 2)}
-          </pre>
-        </details>
+        <RawJsonAppendix snap={snap} />
       </Section>
 
       <StatementFooter generatedAt={snap.generated_at} benchmarkLabel={benchmarkLabel} />

--- a/tests/fixtures/report_snapshot_v2/monthly.json
+++ b/tests/fixtures/report_snapshot_v2/monthly.json
@@ -41,7 +41,7 @@
     "unrealized_delta": null,
     "ytd_return": null
   },
-  "generated_at": "2026-06-12T15:15:46.731524+00:00",
+  "generated_at": "2026-07-30T23:50:31.444596+00:00",
   "holdings": [
     {
       "company_name": "Report Co",
@@ -51,7 +51,7 @@
       "period_contribution": null,
       "period_contribution_bps": null,
       "price": "110.000000",
-      "sector": "Technology",
+      "sector": "Information Technology",
       "since_entry_return_pct": "0.100000",
       "symbol": "RPTV2A",
       "units": "10.000000",
@@ -114,7 +114,7 @@
     "observation_label": "since inception, monthly observations",
     "observations": 0,
     "sector_exposure": {
-      "Technology": "0.523810"
+      "Information Technology": "0.523810"
     },
     "volatility": null
   },
@@ -147,6 +147,7 @@
   },
   "schema_version": 2,
   "score_changes": [],
+  "score_changes_total": 0,
   "tax_provision": {
     "estimated_tax_gbp": "0",
     "estimated_tax_usd": "0",

--- a/tests/fixtures/report_snapshot_v2/weekly.json
+++ b/tests/fixtures/report_snapshot_v2/weekly.json
@@ -31,7 +31,7 @@
     "unrealized_delta": null,
     "ytd_return": null
   },
-  "generated_at": "2026-06-12T15:15:46.710742+00:00",
+  "generated_at": "2026-07-30T23:50:31.428315+00:00",
   "holdings": [
     {
       "company_name": "Report Co",
@@ -41,7 +41,7 @@
       "period_contribution": null,
       "period_contribution_bps": null,
       "price": "110.000000",
-      "sector": "Technology",
+      "sector": "Information Technology",
       "since_entry_return_pct": "0.100000",
       "symbol": "RPTV2A",
       "units": "10.000000",
@@ -92,6 +92,7 @@
   "report_type": "weekly",
   "schema_version": 2,
   "score_changes": [],
+  "score_changes_total": 0,
   "top_performers": [
     {
       "company_name": "Report Co",

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1073,3 +1073,84 @@ class TestRollingWindowContiguity:
         from app.services.reporting import _is_contiguous_monthly
 
         assert _is_contiguous_monthly([], date(2026, 5, 1)) is True
+
+
+class TestSelectRankMovers:
+    """Rank movers is a capped statement exhibit (#2178).
+
+    Pre-#2178 the builder shipped every scored row in the period —
+    29,281 for June 2026, 4.38 MB of a 4.39 MB snapshot — and the
+    frontend rendered one router `<Link>` per row, freezing the page.
+    """
+
+    @staticmethod
+    def _rows(deltas: list[int]) -> list[dict[str, Any]]:
+        """Rows as `_score_changes` hands them over: one per instrument,
+        already sorted by `rank_delta` DESC."""
+        return [
+            {"instrument_id": i, "symbol": f"S{i}", "rank_delta": d}
+            for i, d in enumerate(sorted(deltas, reverse=True), start=1)
+        ]
+
+    def test_caps_each_direction_independently(self) -> None:
+        """Both directions survive even when one dominates by magnitude.
+
+        The June 2026 shape: the top 20 by ABS(rank_delta) are 4 risers
+        and 16 fallers. Selecting by pure magnitude would render "Rank
+        movers" as an almost-uniform collapse. Here the fallers are
+        strictly larger in magnitude than every riser, so a magnitude
+        cut would return zero risers.
+        """
+        from app.services.reporting import _select_rank_movers
+
+        rows = self._rows([10, 20, 30, 40] + [-100, -200, -300, -400, -500])
+        result = _select_rank_movers(rows, top_n=2)
+
+        assert [r["rank_delta"] for r in result] == [40, 30, -400, -500]
+
+    def test_keeps_biggest_movers_not_the_first_encountered(self) -> None:
+        """Fallers trail a DESC list, so the biggest sit at the END."""
+        from app.services.reporting import _select_rank_movers
+
+        rows = self._rows([-1, -2, -3, -50, -60])
+        result = _select_rank_movers(rows, top_n=2)
+
+        assert [r["rank_delta"] for r in result] == [-50, -60]
+
+    def test_output_stays_descending(self) -> None:
+        """The statement list reads risers-first; the FE does no sorting."""
+        from app.services.reporting import _select_rank_movers
+
+        rows = self._rows([5, -5, 900, -900, 1, -1])
+        result = _select_rank_movers(rows, top_n=3)
+        deltas = [r["rank_delta"] for r in result]
+
+        assert deltas == sorted(deltas, reverse=True)
+
+    def test_fewer_movers_than_cap_returns_all(self) -> None:
+        from app.services.reporting import _select_rank_movers
+
+        rows = self._rows([7, -7])
+        assert len(_select_rank_movers(rows, top_n=10)) == 2
+
+    def test_one_sided_period_returns_only_that_side(self) -> None:
+        """A period where every mover fell must not fabricate risers."""
+        from app.services.reporting import _select_rank_movers
+
+        rows = self._rows([-3, -4, -5])
+        result = _select_rank_movers(rows, top_n=2)
+
+        assert [r["rank_delta"] for r in result] == [-4, -5]
+
+    def test_zero_cap_selects_nothing(self) -> None:
+        """Guards the negative-slice trap: `[-0:]` is the WHOLE list, so
+        a naive tail slice would turn the tightest cap into no cap."""
+        from app.services.reporting import _select_rank_movers
+
+        rows = self._rows([10, 20, -10, -20])
+        assert _select_rank_movers(rows, top_n=0) == []
+
+    def test_empty_input(self) -> None:
+        from app.services.reporting import _select_rank_movers
+
+        assert _select_rank_movers([], top_n=10) == []


### PR DESCRIPTION
## Problem

`/reports` renders weekly fine. Selecting **Monthly** made the page unresponsive.

The backend was not the cause — `/reports/monthly?limit=100` returns in **0.13s**. Three client-side defects:

1. **`_score_changes` was unbounded and un-deduped.** `scores` holds one row per instrument *per scoring run*, and the query had no `LIMIT` and no per-instrument collapse, so a monthly window returned the cross product. June 2026: **29,281 rows across 3,898 instruments and 18 runs** (`TPR` appeared 18 times) — **4.38 MB of a 4.39 MB snapshot**.
2. **The frontend rendered every row**, one react-router `<Link>` each (~29k Links, ~150k DOM nodes, one synchronous commit).
3. **The appendix built ~9 MB of pretty-printed JSON on every render.** `<details>` collapses visually only; React still committed the `<pre>`.

Weekly survived only because "Rank movers" is monthly-gated (`monthly !== null` in `ReportsPage.tsx`). Its snapshot carries the same defect — 10,656 rows — unrendered.

## Source rule — why not a start-vs-end rank diff

The obvious reading of "rank movers" is net rank at `period_end` minus `period_start`. **That is unsafe here**, and the premise was falsified against the DB before speccing:

```
model_version   rows   instruments   days   window
v1.1-balanced  41,963      3,895      11    Jun 4–18
v1.2-balanced  11,670      3,890       1    Jun 18
v1.3-balanced  38,938      3,896       8    Jun 19–29
```

A single report period routinely spans a `model_version` bump. `docs/settled-decisions.md` → "Rank delta comparison" holds that ranks are comparable only within one model_version, and `scoring._fetch_prior_ranks` enforces it (`AND model_version = %(mv)s`, `app/services/scoring.py:2113`). So every **stored** `rank_delta` is version-safe by construction; subtracting two ranks across the window is not, and would report the model change as instrument movement.

The fix therefore uses only per-row `rank_delta` and never compares `rank` across rows.

## Change

**Builder** (`app/services/reporting.py`)
- `DISTINCT ON (instrument_id)` keeps each name's single largest-magnitude move in the window.
- `_select_rank_movers` takes `top_n` from **each direction** — the shape `_compute_contributors` already uses for contributors/drags. Pure magnitude skews badly: June's top 20 by `ABS(rank_delta)` are **4 risers and 16 fallers**, which would render "Rank movers" as a market-wide collapse.
- `score_changes_total` carries the pre-cap count so a top-N exhibit never reads as the full set.
- `ABS(rank_delta) >= min_rank_delta` is retained but near-inert — June's median `|rank_delta|` is **301** across ~3,900 names, so the threshold admits essentially everyone. `top_n` is what bounds the payload.

**Frontend**
- Hard 50-row render cap independent of payload size. The 29k-row snapshots are **already stored**, so the builder fix alone does not rescue them; this cap is what makes a pre-#2178 snapshot renderable without a regen. Sits above the builder's own top-N so a future `top_n` bump is not silently truncated.
- Appendix moves from `<details>` to state — nothing is built until the operator opts in.
- `score_changes_total` is optional in the interface; pre-#2178 snapshots have none, and the FE falls back to the array length rather than inventing a count.

## Result

| | before | after |
|---|---|---|
| June `score_changes` bytes | 4,379,583 | **3,039** |
| rows | 29,281 | 20 (10 risers / 10 fallers) |
| rows per instrument | up to 18 | 1 |

Verified against the real dev DB, not a fixture:

```
rows returned: 20   pre-cap total: 3898
risers 10 / fallers 10
descending? True    unique instruments? True
top: KLAC+3601, ATEX+2648, AIOT+2245, SWBI+2092
bot: GHM-2277, CCL-2368, DDS-2537, KAVL-2737
```

## Conscious tradeoffs

- **The exhibit is a narrowing.** 20 of 3,898 movers render. Mitigated by `score_changes_total` in the payload and "N of M shown" in the header — but the operator no longer has the full set in the snapshot. `score_changes` is display-only (no backend consumer; grep confirms the only readers are `MonthlySections.tsx` and the builder itself), so nothing downstream loses input.
- **`top_n` is balanced, not magnitude-faithful.** A period where one direction genuinely dominates will look more symmetric than it was. The alternative renders one-sided sections that read as broken.
- **Already-stored snapshots keep their 29k arrays** until regenerated. The FE cap makes them safe to view; see the operator follow-up below.

## Unrelated change swept in

Regenerating the v2 fixtures (`REPORT_FIXTURE_WRITE=1`) surfaced a **pre-existing staleness**: the checked-in fixture's `sector` read `"Technology"` (eToro's coarse label) where the builder emits `"Information Technology"` (canonical SIC-derived GICS, #1634/#1851/#1951). The parity test compares *keys only*, so the stale value survived. `ReportsPage.test.tsx` asserted the stale string and is updated to the canonical label. Flagging it because it is not part of the fix.

## Codex

`codex exec review --base origin/main` caught a **[P1]** before first push: adding `score_changes_total` broke the deliberate contract chain **builder == fixture == FE key list == interface**. `test_v2_fixture_is_backend_emitted` is `db`-marked, so the fast tier never ran it. Fixed in `e1727608` (fixtures regenerated + `WEEKLY_KEYS`/`MONTHLY_KEYS` updated). Re-review returned clean.

## Tests

- Pure table tests for the selection policy (`tests/test_reporting.py::TestSelectRankMovers`): direction caps, tail-slice correctness, DESC ordering, one-sided periods, empty input, and the `[-0:]` whole-list trap that a naive negative slice would hit at `top_n=0`.
- FE coverage for the render cap, the total disclosure, its pre-#2178 fallback, and appendix gating.

## Gates

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` (exit 0) · `pytest tests/smoke` (exit 0) · `pytest tests/test_reporting_v2_db.py tests/test_reporting.py` (exit 0) · `frontend typecheck` · `test:unit` (134 files, 1455 tests) · `dark:check` · `pills:check` — all green.

## Operator follow-up (not yet done)

Stored snapshots still carry the uncapped arrays. `_upsert_report_snapshot` is `ON CONFLICT (report_type, period_start) DO UPDATE`, so regeneration is safe and idempotent. Regenerating via Admin → Jobs → `weekly_report` / `monthly_report` shrinks them; the FE cap means this is not a blocker for viewing.

Closes #2178.
