### PR TITLE
docs(#2178): extract the render-cost and contract-chain lessons to the prevention log + frontend skill

### DIFF
--- a/.claude/skills/frontend/api-shape-and-types.md
+++ b/.claude/skills/frontend/api-shape-and-types.md
@@ -86,3 +86,42 @@ If your diff touches `app/api/*.py` response models or `frontend/src/api/types.t
 - [ ] New endpoint has its own fetcher file under `frontend/src/api/`
 - [ ] Page consumes via `useAsync`, not via raw `apiFetch`
 - [ ] No page component touches auth outside `useSession` (no manual token handling; no `setUnauthorizedHandler` calls)
+
+## An array field's length is not bounded by the type (#2178)
+
+`Foo[]` says nothing about size. A field the backend "obviously" keeps small
+can be unbounded in production, and the stored history keeps whatever it had
+when it was written — a builder fix does not retro-shrink data already
+persisted.
+
+`score_changes` was typed `ScoreChangeV2[]` and carried **29,281 rows** for one
+month (4.38 MB of a 4.39 MB snapshot). The page mapped every row to a
+react-router `<Link>` — ~150k DOM nodes in one synchronous commit, which froze
+the tab.
+
+Rules:
+
+- **Cap what you render, in the component, independent of the payload.**
+  `rows.slice(0, CAP)` with the cap as a named const and a comment saying why.
+  Server-side capping is necessary but not sufficient: snapshots, caches, and
+  any immutable stored payload predate your fix.
+- **Set the FE cap above the backend's own limit** so a later server-side bump
+  is not silently truncated by the client.
+- **When you cap, say so in the UI** — "N of M shown" — and carry the pre-cap
+  total as its own field. Make that field optional and fall back to
+  `array.length` when absent, so records written before the field existed
+  report their real count instead of an invented one.
+- Self-review prompt: for every `.map()` over an API array, "what is the
+  largest this can be in production, and what does one row cost to render?"
+  A `<Link>`, a chart, or a nested component makes the answer much worse than
+  a `<span>`.
+
+## Disclosure elements do not defer render cost (#2178)
+
+`<details>`, `hidden`, and `display:none` are presentation-only. React still
+evaluates the JSX and commits the DOM. The reports appendix built ~9 MB of
+`JSON.stringify(snap, null, 2)` on every render while looking collapsed.
+
+Gate expensive children on **state** and render `null` until opened. Applies to
+`JSON.stringify`, large `.map()`s, and charts inside any collapsed region.
+See `ReportsPage.tsx::RawJsonAppendix`.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -2340,3 +2340,51 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
   writing another HTML heuristic.
 - Enforced in: this log; `.claude/skills/data-sources/edgartools.md` (DEF 14A
   row now names `extract_beneficial_ownership` and the data-row fallback).
+
+---
+
+### `<details>` does not defer render cost — React commits its children regardless
+- First seen in: #2178
+- Symptom: The reports appendix wrapped `JSON.stringify(snap, null, 2)` in a
+  `<details>` element, reading as "only built when opened". `<details>`
+  collapses **visually**; React still evaluates the expression and commits the
+  `<pre>` on every render. A monthly snapshot was ~4.4 MB, so every render
+  materialised ~9 MB of text plus a giant text node the operator never asked
+  for. Confirmed live: `<pre>` count was 0 after the state fix and only became
+  1 on click.
+- Prevention: Gate expensive children on **state**, not on a disclosure
+  element. `<details>`/`hidden`/`display:none`/CSS collapse are all
+  presentation-only — they change paint, never the React commit. Before
+  wrapping anything in a disclosure widget, ask "does the JSX inside cost
+  anything to *build*?" If yes (JSON.stringify, a large `.map`, a chart),
+  render `null` until opened. Grep prompt for review: any `<details>` whose
+  body contains `JSON.stringify`, `.map(`, or a component that takes a large
+  array prop.
+- Enforced in: this log; `frontend/src/pages/ReportsPage.tsx::RawJsonAppendix`
+  and its test "does not build the raw-JSON appendix until the operator opens it".
+
+---
+
+### A snapshot-shape change breaks a contract chain the fast tier cannot see
+- First seen in: #2178
+- Symptom: Adding one top-level key (`score_changes_total`) to the report
+  builders silently broke the deliberate chain
+  **builder == fixture == FE key list == interface**. The parity test
+  (`tests/test_reporting_v2_db.py::test_v2_fixture_is_backend_emitted`) is
+  `db`-marked, so `pytest -m "not db"` — the push gate — never ran it. Codex
+  ckpt-2 caught it; the local gates were all green and would have shipped it.
+- Prevention: Any change to a top-level key emitted by `generate_weekly_report`
+  / `generate_monthly_report` must, in the SAME diff: (1) regenerate the
+  fixtures with `REPORT_FIXTURE_WRITE=1 uv run pytest
+  tests/test_reporting_v2_db.py -k fixture_is_backend_emitted`, (2) update
+  `WEEKLY_KEYS`/`MONTHLY_KEYS` in `frontend/src/api/reportSnapshot.test.ts`,
+  (3) update the interface in `reportSnapshot.ts`. Because the guard is
+  `db`-marked, run that file explicitly — do not rely on the push gate.
+- Secondary finding: the regeneration surfaced an UNRELATED stale value the
+  parity test could never catch — the fixture's `sector` read `"Technology"`
+  where the builder emits `"Information Technology"` (#1634/#1851/#1951). The
+  parity test compares **keys only**, so fixture *values* drift silently and
+  indefinitely. When regenerating any golden fixture, diff the values too and
+  account for every change; a value diff is either a real regression or a
+  staleness that has been lying to tests since it appeared.
+- Enforced in: this log.


### PR DESCRIPTION
Doc-only. CLAUDE.md requires a lesson surfaced mid-task be extracted into the prevention log and the relevant skill rather than left in a merged PR description. #2178 (merged `7aeeeb37`) produced two.

## Prevention log

**`<details>` does not defer render cost.** The reports appendix wrapped `JSON.stringify(snap, null, 2)` in `<details>`, reading as "only built when opened". It collapses visually; React still evaluates the expression and commits the `<pre>` every render — ~9 MB of text for a 4.4 MB snapshot the operator never expanded. Entry gives the review grep: any `<details>` whose body holds `JSON.stringify`, `.map(`, or a large-array prop.

**A snapshot-shape change breaks a contract chain the fast tier cannot see.** Adding one key broke **builder == fixture == FE key list == interface**. The guard (`test_v2_fixture_is_backend_emitted`) is `db`-marked, so `pytest -m "not db"` never ran it — every local gate was green. Codex ckpt-2 caught it. Entry lists the three files that must move together and says to run that test file explicitly.

Second-order finding recorded in the same entry: the parity test compares **keys only**, so fixture *values* drift silently. Regenerating surfaced a stale `sector: "Technology"` where the builder emits `"Information Technology"` — wrong since #1634/#1851/#1951 and invisible to the guard. Rule added: when regenerating a golden fixture, diff the values too and account for every change.

## Skill — `.claude/skills/frontend/api-shape-and-types.md`

**An array field's length is not bounded by its type.** `ScoreChangeV2[]` carried 29,281 rows; the page rendered a react-router `<Link>` per row. Rules: cap in the component independent of payload (stored data predates your fix), set the FE cap above the backend's so a later bump is not silently truncated, disclose "N of M shown", and make the pre-cap total optional with an `array.length` fallback so records written before the field report their real count.

**Disclosure elements do not defer render cost** — cross-reference to the above.

Refs #2178.
