### PR TITLE
fix(#2184): resolve instrument refs by symbol OR numeric id, and stop reporting an outage as an empty state

### DIFF
--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -24,11 +24,12 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Literal, get_args
+from typing import Literal, LiteralString, get_args
 
 import httpx
 import psycopg
@@ -113,6 +114,89 @@ def _short_lived_conn(request: Request) -> Iterator[psycopg.Connection[object]]:
         yield conn
     finally:
         gen.close()
+
+
+# ---------------------------------------------------------------------------
+# Instrument reference resolution (#2184)
+# ---------------------------------------------------------------------------
+
+# Every `/instruments/{symbol}/...` route resolved by symbol only, so a
+# numeric-id URL — the shape the FE itself mints at
+# `components/dashboard/AlertsStrip.tsx:204` and the shape
+# `pages/InstrumentDetailRedirect.tsx` bookmarks use — 404'd the whole
+# drill page. These two helpers are the one place that decision lives.
+# 29 sites in this module carried the by-symbol SQL verbatim; #2184
+# converts the two fundamentals-drill endpoints, leaving 27 to adopt it.
+
+# `LiteralString`, not `str` — psycopg's `execute` takes `QueryNoTemplate`,
+# which is how the type checker enforces that no caller can route a
+# runtime-built string through here (house precedent:
+# `app/services/peer_comparison.py:200`).
+_RESOLVE_BY_ID_SQL: LiteralString = """
+    SELECT instrument_id, symbol FROM instruments
+    WHERE instrument_id = %(iid)s
+    LIMIT 1
+"""
+
+# `symbol` is not UNIQUE across exchanges (see migration 043), so order by
+# `is_primary_listing DESC, instrument_id ASC` to make the winner
+# deterministic on collisions. Preserved verbatim from the call sites.
+_RESOLVE_BY_SYMBOL_SQL: LiteralString = """
+    SELECT instrument_id, symbol FROM instruments
+    WHERE UPPER(symbol) = %(s)s
+    ORDER BY is_primary_listing DESC, instrument_id ASC
+    LIMIT 1
+"""
+
+# ASCII digits only — `str.isdigit()` is True for '²' and Arabic-Indic
+# digits, and `int('²')` raises. A ref is an id only if it is entirely
+# ASCII digits.
+#
+# Bounded at 19 digits = BIGINT's own width, so no digit string this
+# branch accepts can be a valid `instrument_id` and be rejected. The
+# bound is load-bearing, not cosmetic: `int()` raises `ValueError` past
+# `sys.get_int_max_str_digits()` (4300 by default), so an unbounded
+# pattern turns `/instruments/<5000 digits>/financials` into a 500
+# instead of a 404. Anything longer falls to the symbol branch, misses,
+# and 404s cleanly.
+_NUMERIC_REF = re.compile(r"^[0-9]{1,19}$")
+
+
+def instrument_ref_query(ref: str) -> tuple[LiteralString, dict[str, object]]:
+    """Pick the lookup SQL + bound params for a symbol-or-id path param.
+
+    Ref of 1-19 ASCII digits → resolve by ``instrument_id``; anything
+    else → resolve by symbol with the existing deterministic tie-break.
+
+    Safe on the full population: 0 of the instruments in the universe
+    have a purely-numeric ``symbol`` (verified 2026-07-31 against the dev
+    DB; numeric-leading tickers like ``1810.HK`` / ``2501.T`` all carry a
+    non-digit exchange suffix, so they take the symbol branch). A 19-digit
+    value past BIGINT's range does not raise either — Postgres compares it
+    as numeric and returns no rows, i.e. a clean 404.
+
+    Pure — no DB access — so the branch is table-testable without a
+    fixture. Callers must pass a non-empty, stripped ref.
+    """
+    cleaned = ref.strip()
+    if _NUMERIC_REF.match(cleaned):
+        return _RESOLVE_BY_ID_SQL, {"iid": int(cleaned)}
+    return _RESOLVE_BY_SYMBOL_SQL, {"s": cleaned.upper()}
+
+
+def resolve_instrument_ref(conn: psycopg.Connection[object], ref: str) -> tuple[int, str] | None:
+    """Resolve a symbol-or-id path param to ``(instrument_id, symbol)``.
+
+    Returns ``None`` when nothing matches — the caller owns the 404 so it
+    can keep its own message.
+    """
+    sql, params = instrument_ref_query(ref)
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(sql, params)
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return int(row["instrument_id"]), str(row["symbol"])
 
 
 # ---------------------------------------------------------------------------
@@ -865,41 +949,31 @@ def get_instrument_financials(
 
     Returns an empty row list (not 500, not 404) when no SEC data
     exists — the UI shows "no statement data available".
+
+    ``symbol`` accepts a ticker OR a numeric ``instrument_id`` (#2184) —
+    the FE links instruments by id in places, and the drill page inherits
+    whichever form the URL carries.
     """
-    symbol_clean = symbol.strip().upper()
+    symbol_clean = symbol.strip()
     if not symbol_clean:
         raise HTTPException(status_code=400, detail="symbol is required")
 
     columns = _STATEMENT_COLUMNS[statement]
 
-    # Resolve symbol -> instrument_id for the local read. `symbol` is
-    # not UNIQUE across exchanges (see migration 043), so order by
-    # `is_primary_listing DESC, instrument_id ASC` to make the winner
-    # deterministic on collisions.
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT instrument_id, symbol FROM instruments
-            WHERE UPPER(symbol) = %(s)s
-            ORDER BY is_primary_listing DESC, instrument_id ASC
-            LIMIT 1
-            """,
-            {"s": symbol_clean},
-        )
-        inst_row = cur.fetchone()
-
-    if inst_row is None:
+    resolved = resolve_instrument_ref(conn, symbol_clean)
+    if resolved is None:
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id, resolved_symbol = resolved
 
     local_rows, local_currency = _fetch_local_financials(
         conn,
-        int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+        instrument_id,
         columns,
         period,
     )
     if local_rows:
         return InstrumentFinancials(
-            symbol=str(inst_row["symbol"]),  # type: ignore[index]
+            symbol=resolved_symbol,
             statement=statement,
             period=period,
             currency=local_currency,
@@ -910,7 +984,7 @@ def get_instrument_financials(
     # No SEC coverage → empty payload. Frontend renders the empty-
     # state hint; no fallback to a non-canonical source.
     return InstrumentFinancials(
-        symbol=str(inst_row["symbol"]),  # type: ignore[index]
+        symbol=resolved_symbol,
         statement=statement,
         period=period,
         currency=None,
@@ -932,33 +1006,25 @@ def get_instrument_fcf_yield(
     cross-currency issuers (no FX normaliser) are fail-closed SUPPRESSED
     (``suppressed_reason`` set, ``points`` empty); the FE keeps the absolute
     FCF line + a caveat. Policy lives in app/services/fcf_yield.py.
+
+    ``symbol`` accepts a ticker OR a numeric ``instrument_id`` (#2184).
     """
-    symbol_clean = symbol.strip().upper()
+    symbol_clean = symbol.strip()
     if not symbol_clean:
         raise HTTPException(status_code=400, detail="symbol is required")
 
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
-            SELECT instrument_id, symbol FROM instruments
-            WHERE UPPER(symbol) = %(s)s
-            ORDER BY is_primary_listing DESC, instrument_id ASC
-            LIMIT 1
-            """,
-            {"s": symbol_clean},
-        )
-        inst_row = cur.fetchone()
-
-    if inst_row is None:
+    resolved = resolve_instrument_ref(conn, symbol_clean)
+    if resolved is None:
         raise HTTPException(status_code=404, detail=f"Instrument {symbol} not found")
+    instrument_id, resolved_symbol = resolved
 
     result = fcf_yield_series(
         conn,
-        instrument_id=int(inst_row["instrument_id"]),  # type: ignore[arg-type]
+        instrument_id=instrument_id,
         period=period,
     )
     return FcfYieldSeries(
-        symbol=str(inst_row["symbol"]),  # type: ignore[index]
+        symbol=resolved_symbol,
         suppressed_reason=result.suppressed_reason,
         points=[
             FcfYieldPoint(

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -121,12 +121,24 @@ def _short_lived_conn(request: Request) -> Iterator[psycopg.Connection[object]]:
 # ---------------------------------------------------------------------------
 
 # Every `/instruments/{symbol}/...` route resolved by symbol only, so a
-# numeric-id URL — the shape the FE itself mints at
-# `components/dashboard/AlertsStrip.tsx:204` and the shape
-# `pages/InstrumentDetailRedirect.tsx` bookmarks use — 404'd the whole
-# drill page. These two helpers are the one place that decision lives.
-# 29 sites in this module carried the by-symbol SQL verbatim; #2184
-# converts the two fundamentals-drill endpoints, leaving 27 to adopt it.
+# numeric-id drill URL — `/instrument/1001/fundamentals` — 404'd the
+# whole page (spec §1.1).
+#
+# Reachability, stated accurately because the first draft of this comment
+# got it wrong: NO frontend code path mints `/instrument/<id>/...`. Every
+# `/instrument/${…}` mint site in `frontend/src` passes a symbol — none
+# passes an `instrument_id` — and
+# `components/dashboard/AlertsStrip.tsx:204` mints the PLURAL legacy route
+# `/instruments/${row.instrument_id}` (`App.tsx:89`), which
+# `pages/InstrumentDetailRedirect.tsx` resolves by id and redirects to
+# `/instrument/:symbol`. The id form therefore reaches this module only via
+# a hand-typed or hand-edited URL, which is exactly what spec §1.1 claims —
+# a real defect, but not a machine-generated one. Do not size the remaining
+# 27-endpoint conversion off a "the FE mints this" premise.
+#
+# These two helpers are the one place that decision lives. 29 sites in this
+# module carried the by-symbol SQL verbatim; #2184 converts the two
+# fundamentals-drill endpoints, leaving 27 to adopt it.
 
 # `LiteralString`, not `str` — psycopg's `execute` takes `QueryNoTemplate`,
 # which is how the type checker enforces that no caller can route a
@@ -149,54 +161,72 @@ _RESOLVE_BY_SYMBOL_SQL: LiteralString = """
 """
 
 # ASCII digits only — `str.isdigit()` is True for '²' and Arabic-Indic
-# digits, and `int('²')` raises. A ref is an id only if it is entirely
+# digits, and `int('²')` raises. A ref can be an id only if it is entirely
 # ASCII digits.
 #
 # Bounded at 19 digits = BIGINT's own width, so no digit string this
-# branch accepts can be a valid `instrument_id` and be rejected. The
-# bound is load-bearing, not cosmetic: `int()` raises `ValueError` past
+# pattern rejects could have been a valid `instrument_id`. The bound is
+# load-bearing, not cosmetic: `int()` raises `ValueError` past
 # `sys.get_int_max_str_digits()` (4300 by default), so an unbounded
 # pattern turns `/instruments/<5000 digits>/financials` into a 500
-# instead of a 404. Anything longer falls to the symbol branch, misses,
+# instead of a 404. Anything longer gets the symbol attempt only, misses,
 # and 404s cleanly.
 _NUMERIC_REF = re.compile(r"^[0-9]{1,19}$")
 
 
-def instrument_ref_query(ref: str) -> tuple[LiteralString, dict[str, object]]:
-    """Pick the lookup SQL + bound params for a symbol-or-id path param.
+def instrument_ref_queries(ref: str) -> list[tuple[LiteralString, dict[str, object]]]:
+    """Ordered lookup attempts for a symbol-or-id path param.
 
-    Ref of 1-19 ASCII digits → resolve by ``instrument_id``; anything
-    else → resolve by symbol with the existing deterministic tie-break.
+    Attempt 1 is ALWAYS the by-symbol query. A ref of 1-19 ASCII digits
+    appends attempt 2, the by-id query. The caller runs them in order and
+    takes the first hit.
 
-    Safe on the full population: 0 of the instruments in the universe
-    have a purely-numeric ``symbol`` (verified 2026-07-31 against the dev
-    DB; numeric-leading tickers like ``1810.HK`` / ``2501.T`` all carry a
-    non-digit exchange suffix, so they take the symbol branch). A 19-digit
-    value past BIGINT's range does not raise either — Postgres compares it
-    as numeric and returns no rows, i.e. a clean 404.
+    **Symbol first, id as fallback** — the ordering is the safety
+    property, not a preference. ``/instrument/:symbol`` is the route's
+    declared contract and every FE link site passes a ticker; the id form
+    is a compat shim for a hand-typed URL. Branching *exclusively* on
+    "looks numeric" would let an unrelated ``instrument_id`` shadow a real
+    ticker the day eToro admits a letterless one (a bare ``1810`` rather
+    than ``1810.HK``), rendering a DIFFERENT issuer's financials under that
+    ticker instead of 404ing. ``instrument_id`` spans 1..1,065,714, which
+    squarely covers 4-digit exchange codes, and nothing in the schema or in
+    ``sync_universe`` forbids it. Today the collision does not exist (0 of
+    12,691 ``instruments`` rows have a purely-numeric ``symbol``; dev DB,
+    2026-07-31) — but that is a property of the current universe, not an
+    enforced invariant, so this order is what makes the resolution safe
+    rather than merely lucky.
 
-    Pure — no DB access — so the branch is table-testable without a
-    fixture. Callers must pass a non-empty, stripped ref.
+    Cost: one extra index seek, on the id path only. ``UPPER(symbol)`` is
+    covered by ``idx_instruments_symbol_primary`` (``sql/043``).
+
+    A 19-digit value past BIGINT's range does not raise — Postgres compares
+    it as numeric and returns no rows, i.e. a clean 404.
+
+    Pure — no DB access — so the ordering is table-testable without a
+    fixture. Callers must pass a non-empty ref.
     """
     cleaned = ref.strip()
+    attempts: list[tuple[LiteralString, dict[str, object]]] = [
+        (_RESOLVE_BY_SYMBOL_SQL, {"s": cleaned.upper()}),
+    ]
     if _NUMERIC_REF.match(cleaned):
-        return _RESOLVE_BY_ID_SQL, {"iid": int(cleaned)}
-    return _RESOLVE_BY_SYMBOL_SQL, {"s": cleaned.upper()}
+        attempts.append((_RESOLVE_BY_ID_SQL, {"iid": int(cleaned)}))
+    return attempts
 
 
 def resolve_instrument_ref(conn: psycopg.Connection[object], ref: str) -> tuple[int, str] | None:
     """Resolve a symbol-or-id path param to ``(instrument_id, symbol)``.
 
-    Returns ``None`` when nothing matches — the caller owns the 404 so it
-    can keep its own message.
+    Returns ``None`` when no attempt matches — the caller owns the 404 so
+    it can keep its own message.
     """
-    sql, params = instrument_ref_query(ref)
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(sql, params)
-        row = cur.fetchone()
-    if row is None:
-        return None
-    return int(row["instrument_id"]), str(row["symbol"])
+    for sql, params in instrument_ref_queries(ref):
+        with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+            cur.execute(sql, params)
+            row = cur.fetchone()
+        if row is not None:
+            return int(row["instrument_id"]), str(row["symbol"])
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/pages/FundamentalsPage.test.tsx
+++ b/frontend/src/pages/FundamentalsPage.test.tsx
@@ -143,8 +143,8 @@ describe("FundamentalsPage", () => {
 
   it("shows a 'no SEC XBRL coverage' empty state when every statement reports source='unavailable'", async () => {
     // The real /financials contract: 200 OK with source='unavailable'
-    // and rows=[] for non-SEC instruments. A 404 only fires for an
-    // unknown symbol, which falls through to the generic error.
+    // and rows=[] for non-SEC instruments. A 404 only fires when the
+    // route param names no instrument at all — a separate empty state.
     vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
       ((_symbol: string, query: { statement: "income" | "balance" | "cashflow" }) =>
         Promise.resolve({
@@ -192,5 +192,38 @@ describe("FundamentalsPage", () => {
     renderAt("/instrument/GME/fundamentals");
     const link = await screen.findByRole("link", { name: /Raw statements/i });
     expect(link).toHaveAttribute("href", "/instrument/GME?tab=financials");
+  });
+
+  // ---- #2184 -------------------------------------------------------------
+
+  it("renders an EmptyState (not the red error banner) on a 404", async () => {
+    const { ApiError } = await import("@/api/client");
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      (() => Promise.reject(new ApiError(404, "Instrument ZZZZ not found"))) as never,
+    );
+    renderAt("/instrument/ZZZZ/fundamentals");
+
+    expect(await screen.findByText(/Instrument not found/i)).toBeInTheDocument();
+    expect(screen.getByText(/No instrument matches "ZZZZ"/i)).toBeInTheDocument();
+    // The red "Failed to load. Check the browser console" banner and its
+    // Retry affordance must NOT appear — nothing failed.
+    expect(screen.queryByRole("button", { name: /Retry/i })).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows the RESOLVED symbol in the heading when the route param is a numeric id", async () => {
+    mockHappyPath();
+    renderAt("/instrument/1699/fundamentals");
+
+    // Payload echoes symbol='GME'; the heading must not read "1699".
+    expect(
+      await screen.findByRole("heading", { name: /Fundamentals — GME/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Fundamentals — 1699/)).toBeNull();
+    // Sibling links follow the resolved symbol too, so the operator does
+    // not carry the id form into the next page.
+    expect(
+      screen.getByRole("link", { name: /Raw statements/i }),
+    ).toHaveAttribute("href", "/instrument/GME?tab=financials");
   });
 });

--- a/frontend/src/pages/FundamentalsPage.test.tsx
+++ b/frontend/src/pages/FundamentalsPage.test.tsx
@@ -196,10 +196,15 @@ describe("FundamentalsPage", () => {
 
   // ---- #2184 -------------------------------------------------------------
 
-  it("renders an EmptyState (not the red error banner) on a 404", async () => {
+  it("renders an EmptyState (not the red error banner) on the endpoint's own 404", async () => {
     const { ApiError } = await import("@/api/client");
+    // Shaped like a real response: `client.ts` sets BOTH `message` and
+    // `detail` from a string `{"detail": ...}` body.
     vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
-      (() => Promise.reject(new ApiError(404, "Instrument ZZZZ not found"))) as never,
+      (() =>
+        Promise.reject(
+          new ApiError(404, "Instrument ZZZZ not found", "Instrument ZZZZ not found"),
+        )) as never,
     );
     renderAt("/instrument/ZZZZ/fundamentals");
 
@@ -209,6 +214,43 @@ describe("FundamentalsPage", () => {
     // Retry affordance must NOT appear — nothing failed.
     expect(screen.queryByRole("button", { name: /Retry/i })).toBeNull();
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps SectionError for a bare FastAPI 404 (missing route / mis-proxied base)", async () => {
+    // An outage must NOT be reported as a data absence. FastAPI answers a
+    // missing or renamed route with `{"detail":"Not Found"}` — same status,
+    // different meaning — and the operator needs the Retry affordance.
+    const { ApiError } = await import("@/api/client");
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      (() => Promise.reject(new ApiError(404, "Not Found", "Not Found"))) as never,
+    );
+    renderAt("/instrument/GME/fundamentals");
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/No instrument matches/i)).toBeNull();
+  });
+
+  it("offers no dead-end sibling links on the not-found path", async () => {
+    // Both header links would point at `/instrument/<unresolvable ref>`,
+    // which dead-ends exactly like this page did. Only the EmptyState's
+    // `/instruments` link is a real recovery route.
+    const { ApiError } = await import("@/api/client");
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(
+      (() =>
+        Promise.reject(
+          new ApiError(404, "Instrument ZZZZ not found", "Instrument ZZZZ not found"),
+        )) as never,
+    );
+    renderAt("/instrument/ZZZZ/fundamentals");
+
+    await screen.findByText(/Instrument not found/i);
+    expect(screen.queryByRole("link", { name: /Raw statements/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /Back to/i })).toBeNull();
+    expect(
+      screen.getByRole("link", { name: /Browse instruments/i }),
+    ).toHaveAttribute("href", "/instruments");
   });
 
   it("shows the RESOLVED symbol in the heading when the route param is a numeric id", async () => {
@@ -225,5 +267,56 @@ describe("FundamentalsPage", () => {
     expect(
       screen.getByRole("link", { name: /Raw statements/i }),
     ).toHaveAttribute("href", "/instrument/GME?tab=financials");
+  });
+
+  it("keeps the resolved symbol across a period toggle on a numeric-id URL", async () => {
+    // `useAsync` clears `data` at the start of every deps-driven fetch
+    // (lib/useAsync.ts:98), so without the latch the header reverts to
+    // "1699" mid-toggle and `backHref`/`rawHref` point at
+    // `/instrument/1699`, which dead-ends. Deferring the resolve lets the
+    // assertion land while the refetch is genuinely in flight.
+    const pending: Array<() => void> = [];
+    vi.spyOn(api, "fetchInstrumentFinancials").mockImplementation(((
+      _symbol: string,
+      query: { statement: "income" | "balance" | "cashflow"; period: string },
+    ) => {
+      const payload =
+        query.statement === "income"
+          ? SAMPLE_INCOME
+          : query.statement === "balance"
+            ? SAMPLE_BALANCE
+            : SAMPLE_CASHFLOW;
+      if (query.period === "annual") {
+        return new Promise((resolve) => {
+          pending.push(() => resolve(payload));
+        });
+      }
+      return Promise.resolve(payload);
+    }) as never);
+
+    renderAt("/instrument/1699/fundamentals");
+    await screen.findByRole("heading", { name: /Fundamentals — GME/i });
+
+    fireEvent.click(screen.getByTestId("fundamentals-period-annual"));
+
+    // In flight: data is null, but the heading must still read GME.
+    await waitFor(() => {
+      expect(screen.getByTestId("fundamentals-period-annual")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+    expect(
+      screen.getByRole("heading", { name: /Fundamentals — GME/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Fundamentals — 1699/)).toBeNull();
+    expect(screen.getByRole("link", { name: /Back to GME/i })).toHaveAttribute(
+      "href",
+      "/instrument/GME",
+    );
+
+    // Let the in-flight annual fetches settle so the test does not leave
+    // pending promises behind.
+    for (const resolve of pending) resolve();
   });
 });

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -183,8 +183,16 @@ export function FundamentalsPage(): JSX.Element {
 
   const loading = income.loading || balance.loading || cashflow.loading;
   const errors = [income.error, balance.error, cashflow.error];
-  const notFound = errors.some(isNotFound);
-  const errored = errors.some((e) => e !== null && !isNotFound(e));
+  // Classify each error ONCE, then read both conditions off the same
+  // pass. The two used to call isNotFound independently, which is not
+  // just duplicated work — it left "is a 404" and "is not a 404" free to
+  // drift apart if the predicate were ever changed at one site only.
+  // `errored` deliberately wins over `notFound` downstream: a genuine
+  // failure must surface as SectionError + Retry, never as a
+  // "no such instrument" empty state.
+  const notFoundFlags = errors.map((e) => e !== null && isNotFound(e));
+  const notFound = notFoundFlags.some(Boolean);
+  const errored = errors.some((e, i) => e !== null && !notFoundFlags[i]);
   // The `/financials` endpoint returns 200 with `source="unavailable"`
   // and `rows=[]` when an instrument has no SEC coverage (non-US
   // issuer, no CIK, etc.) — see app/api/instruments.py around the

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -1,6 +1,10 @@
 /**
  * /instrument/:symbol/fundamentals — quant-grade financials drill (#589).
  *
+ * `:symbol` is a ticker OR a numeric instrument_id — the backend resolves
+ * either (#2184). The heading and the sibling links always show the
+ * RESOLVED symbol, so `/instrument/1001/fundamentals` reads "AAPL".
+ *
  * Replaces the thin "Financials" tab as the L2 analytical view. Nine
  * panes laid out top → bottom in a single scroll column, mirroring
  * the per-domain catalog in the parent spec. Each pane is a recharts
@@ -32,6 +36,7 @@
 import { useCallback, useMemo } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
+import { ApiError } from "@/api/client";
 import { fetchFcfYield, fetchInstrumentFinancials } from "@/api/instruments";
 import type { FcfYieldSeries, InstrumentFinancials } from "@/api/types";
 import {
@@ -57,6 +62,17 @@ import { joinStatements } from "@/lib/fundamentalsMetrics";
 
 type Period = "quarterly" | "annual";
 const VALID_PERIODS: ReadonlyArray<Period> = ["quarterly", "annual"];
+
+/**
+ * A 404 means the route param names no instrument we hold — an operator
+ * typo, or a stale bookmark. That is an EMPTY state, not a failure:
+ * `SectionError`'s red "check the browser console" banner tells the
+ * operator to debug a working app (#2184). Any other status is a genuine
+ * failure and still gets the banner.
+ */
+function isNotFound(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 404;
+}
 
 export function FundamentalsPage(): JSX.Element {
   const { symbol = "" } = useParams<{ symbol: string }>();
@@ -120,21 +136,30 @@ export function FundamentalsPage(): JSX.Element {
     );
   }, [income.data, balance.data, cashflow.data]);
 
-  const backHref = `/instrument/${encodeURIComponent(symbol)}`;
-  const rawHref = `/instrument/${encodeURIComponent(symbol)}?tab=financials`;
+  // The route param may be a ticker OR a numeric instrument_id (#2184 —
+  // the backend resolves either). The payload echoes the RESOLVED symbol,
+  // so the heading and the sibling links show `AAPL`, never `1001`. Falls
+  // back to the raw param only before the first response lands.
+  const resolvedSymbol =
+    income.data?.symbol ?? balance.data?.symbol ?? cashflow.data?.symbol ?? symbol;
+
+  const backHref = `/instrument/${encodeURIComponent(resolvedSymbol)}`;
+  const rawHref = `/instrument/${encodeURIComponent(resolvedSymbol)}?tab=financials`;
 
   const loading = income.loading || balance.loading || cashflow.loading;
-  const errored =
-    income.error !== null || balance.error !== null || cashflow.error !== null;
+  const errors = [income.error, balance.error, cashflow.error];
+  const notFound = errors.some(isNotFound);
+  const errored = errors.some((e) => e !== null && !isNotFound(e));
   // The `/financials` endpoint returns 200 with `source="unavailable"`
   // and `rows=[]` when an instrument has no SEC coverage (non-US
   // issuer, no CIK, etc.) — see app/api/instruments.py around the
   // `_fetch_local_financials` empty-result branch. A 404 means the
-  // symbol itself isn't recognised, which falls through to the
-  // generic SectionError. The "no SEC XBRL coverage" empty state
-  // fires when every statement explicitly reports `unavailable`.
+  // route param itself isn't recognised — an empty state, handled
+  // separately above. The "no SEC XBRL coverage" empty state fires
+  // when every statement explicitly reports `unavailable`.
   const noSecCoverage =
     !errored &&
+    !notFound &&
     income.data?.source === "unavailable" &&
     balance.data?.source === "unavailable" &&
     cashflow.data?.source === "unavailable";
@@ -150,11 +175,11 @@ export function FundamentalsPage(): JSX.Element {
     <div className="mx-auto max-w-screen-xl space-y-4 p-4">
       <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
         <Link to={backHref} className="text-xs text-sky-700 hover:underline">
-          ← Back to {symbol}
+          ← Back to {resolvedSymbol}
         </Link>
         <div className="mt-1 flex flex-wrap items-baseline justify-between gap-2">
           <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
-            Fundamentals — {symbol}
+            Fundamentals — {resolvedSymbol}
           </h1>
           <div className="flex items-center gap-2 text-xs">
             <div className="flex gap-1">
@@ -197,13 +222,22 @@ export function FundamentalsPage(): JSX.Element {
         <SectionSkeleton rows={6} />
       ) : errored ? (
         <SectionError onRetry={refetchAll} />
+      ) : notFound ? (
+        <EmptyState
+          title="Instrument not found"
+          description={`No instrument matches "${symbol}". The URL takes either a ticker (AAPL) or a numeric instrument id (1001).`}
+        >
+          <Link to="/instruments" className="text-sm text-sky-700 hover:underline">
+            ← Browse instruments
+          </Link>
+        </EmptyState>
       ) : noSecCoverage ? (
         <EmptyState
           title="No fundamentals data"
           description="No SEC XBRL coverage for this instrument — likely a non-US issuer or one without an SEC CIK."
         >
           <Link to={backHref} className="text-sm text-sky-700 hover:underline">
-            ← Back to {symbol}
+            ← Back to {resolvedSymbol}
           </Link>
         </EmptyState>
       ) : periods.length === 0 ? (
@@ -212,7 +246,7 @@ export function FundamentalsPage(): JSX.Element {
           description="No XBRL statement rows on file for this instrument yet."
         >
           <Link to={backHref} className="text-sm text-sky-700 hover:underline">
-            ← Back to {symbol}
+            ← Back to {resolvedSymbol}
           </Link>
         </EmptyState>
       ) : (

--- a/frontend/src/pages/FundamentalsPage.tsx
+++ b/frontend/src/pages/FundamentalsPage.tsx
@@ -33,7 +33,7 @@
  * numbers without losing the symbol context.
  */
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import { ApiError } from "@/api/client";
@@ -64,14 +64,28 @@ type Period = "quarterly" | "annual";
 const VALID_PERIODS: ReadonlyArray<Period> = ["quarterly", "annual"];
 
 /**
- * A 404 means the route param names no instrument we hold — an operator
- * typo, or a stale bookmark. That is an EMPTY state, not a failure:
+ * "This endpoint says the ref names no instrument we hold" — an operator
+ * typo or a stale bookmark. That is an EMPTY state, not a failure:
  * `SectionError`'s red "check the browser console" banner tells the
- * operator to debug a working app (#2184). Any other status is a genuine
- * failure and still gets the banner.
+ * operator to debug a working app (#2184).
+ *
+ * Status alone is NOT enough. FastAPI answers a missing/renamed route or
+ * a mis-proxied `/api` base with a bare `{"detail":"Not Found"}`, and
+ * `client.ts` turns any non-2xx into `ApiError` (it special-cases only
+ * 401). Matching on status alone would render "No instrument matches
+ * AAPL" for every instrument during an outage, with no Retry — reporting
+ * a broken deploy as a data absence. So also require the endpoint's own
+ * message, which both drill raise sites spell `Instrument {symbol} not
+ * found` (app/api/instruments.py:994 financials, :1047 fcf-yield; the
+ * same string at all 30 sites in that module). The match is
+ * case-sensitive, which is what separates it from FastAPI's "Not Found".
+ *
+ * If that backend message ever changes, this guard fails CLOSED — back to
+ * `SectionError` + Retry, never to a false empty state.
  */
 function isNotFound(err: unknown): boolean {
-  return err instanceof ApiError && err.status === 404;
+  if (!(err instanceof ApiError) || err.status !== 404) return false;
+  return typeof err.detail === "string" && err.detail.includes("not found");
 }
 
 export function FundamentalsPage(): JSX.Element {
@@ -138,10 +152,31 @@ export function FundamentalsPage(): JSX.Element {
 
   // The route param may be a ticker OR a numeric instrument_id (#2184 —
   // the backend resolves either). The payload echoes the RESOLVED symbol,
-  // so the heading and the sibling links show `AAPL`, never `1001`. Falls
-  // back to the raw param only before the first response lands.
+  // so the heading and the sibling links show `AAPL`, never `1001`.
+  //
+  // Latched, because reading the payload alone is not enough: `useAsync`
+  // calls `setData(null)` at the start of every non-preserved fetch
+  // (lib/useAsync.ts:98), and the period toggle changes the deps
+  // `[symbol, period]`. Without the latch, every Quarterly→Annual toggle
+  // on `/instrument/1001/fundamentals` reverts the header to "1001" for
+  // the duration of the request and points `backHref` / `rawHref` at
+  // `/instrument/1001`, which dead-ends — `InstrumentPage` still resolves
+  // by symbol only. (`preserveOnRefetch` does NOT fix this: it applies
+  // only when `tick > 0`, i.e. an explicit `refetch()`, not a deps change.)
+  //
+  // The latch is keyed on the RAW ref so it is discarded when the operator
+  // navigates to a different instrument — React Router reuses this
+  // component across param changes, so an unkeyed latch would briefly show
+  // the previous instrument's symbol.
+  const payloadSymbol =
+    income.data?.symbol ?? balance.data?.symbol ?? cashflow.data?.symbol ?? null;
+  const resolvedRef = useRef<{ ref: string; symbol: string } | null>(null);
+  if (payloadSymbol !== null) {
+    resolvedRef.current = { ref: symbol, symbol: payloadSymbol };
+  }
   const resolvedSymbol =
-    income.data?.symbol ?? balance.data?.symbol ?? cashflow.data?.symbol ?? symbol;
+    payloadSymbol ??
+    (resolvedRef.current?.ref === symbol ? resolvedRef.current.symbol : symbol);
 
   const backHref = `/instrument/${encodeURIComponent(resolvedSymbol)}`;
   const rawHref = `/instrument/${encodeURIComponent(resolvedSymbol)}?tab=financials`;
@@ -174,9 +209,19 @@ export function FundamentalsPage(): JSX.Element {
   return (
     <div className="mx-auto max-w-screen-xl space-y-4 p-4">
       <header className="border-b border-slate-200 dark:border-slate-800 pb-3">
-        <Link to={backHref} className="text-xs text-sky-700 hover:underline">
-          ← Back to {resolvedSymbol}
-        </Link>
+        {/* On the not-found path both sibling links point at
+            `/instrument/<unresolvable ref>`, which dead-ends the same way
+            this page just did — `InstrumentPage` resolves by symbol only.
+            Offering them would hand the operator a second failure instead
+            of a recovery route, so the header drops to plain text and the
+            EmptyState's `/instruments` link is the only way out. */}
+        {notFound ? (
+          <span className="text-xs text-slate-500">Instrument drill</span>
+        ) : (
+          <Link to={backHref} className="text-xs text-sky-700 hover:underline">
+            ← Back to {resolvedSymbol}
+          </Link>
+        )}
         <div className="mt-1 flex flex-wrap items-baseline justify-between gap-2">
           <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
             Fundamentals — {resolvedSymbol}
@@ -202,9 +247,11 @@ export function FundamentalsPage(): JSX.Element {
                 Annual
               </button>
             </div>
-            <Link to={rawHref} className="text-sky-700 hover:underline">
-              Raw statements →
-            </Link>
+            {!notFound && (
+              <Link to={rawHref} className="text-sky-700 hover:underline">
+                Raw statements →
+              </Link>
+            )}
           </div>
         </div>
         <p className="mt-1 text-xs text-slate-500">

--- a/tests/test_api_instrument_financials.py
+++ b/tests/test_api_instrument_financials.py
@@ -49,6 +49,34 @@ def _clear_db_override() -> None:
     app.dependency_overrides.pop(get_conn, None)
 
 
+def _install_sequenced_db_conn(
+    fetchone_results: list[dict | None],
+    periods_rows: list[dict] | None = None,
+) -> MagicMock:
+    """Stub DB where each ``fetchone`` returns the next item in
+    ``fetchone_results``.
+
+    Needed for the symbol-or-id resolver (#2184), which makes up to TWO
+    resolution queries: the by-symbol attempt first, then the by-id
+    attempt only if that missed. Returns the shared cursor mock so a
+    caller can inspect ``execute`` calls.
+    """
+    cur_mock = MagicMock()
+    cur_mock.__enter__.return_value = cur_mock
+    cur_mock.fetchone.side_effect = list(fetchone_results)
+    cur_mock.fetchall.return_value = periods_rows if periods_rows is not None else []
+
+    def _conn() -> Iterator[MagicMock]:
+        conn_mock = MagicMock()
+        conn_mock.cursor.return_value = cur_mock
+        yield conn_mock
+
+    from app.db import get_conn
+
+    app.dependency_overrides[get_conn] = _conn
+    return cur_mock
+
+
 def test_unknown_symbol_returns_404(client: TestClient) -> None:
     _install_db_conn(None)
     try:
@@ -208,3 +236,77 @@ def test_cashflow_statement_dispatch(client: TestClient) -> None:
     body = resp.json()
     assert body["statement"] == "cashflow"
     assert body["period"] == "quarterly"
+
+
+# ---------------------------------------------------------------------------
+# #2184 — symbol-or-id path param. Spec §1.1's named acceptance test:
+# "request each drill endpoint by id and by symbol; both must 200."
+#
+# These drive the real handler through `resolve_instrument_ref`, which the
+# pure-logic table test in `tests/test_instrument_ref_resolution.py` does
+# not execute. Limits, stated honestly: the cursor is a MagicMock, so these
+# pin the routing, the attempt ORDER, and the SQL↔params binding — not that
+# a column name exists in Postgres. Column correctness rests on the dev
+# stack verification recorded in the PR.
+# ---------------------------------------------------------------------------
+
+
+def test_numeric_id_returns_200_with_the_resolved_symbol(client: TestClient) -> None:
+    """`/instruments/1699/financials` — the shape that 404'd before #2184.
+
+    The by-symbol attempt misses (no ticker "1699"), the by-id attempt
+    hits, and the payload echoes the RESOLVED symbol so the FE heading can
+    read "GME" rather than "1699".
+    """
+    cur_mock = _install_sequenced_db_conn([None, {"instrument_id": 1699, "symbol": "GME"}])
+    try:
+        resp = client.get("/instruments/1699/financials?statement=income&period=annual")
+    finally:
+        _clear_db_override()
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["symbol"] == "GME"
+
+    # Both resolution attempts ran, symbol first — and each bound its own
+    # param key. A placeholder/param-key mismatch (`%(iid)s` bound with
+    # `{"s": ...}`) is precisely what psycopg raises on at runtime and what
+    # a fetchone-only assertion would miss.
+    executed = [(str(c.args[0]), c.args[1]) for c in cur_mock.execute.call_args_list if c.args]
+    resolution = [e for e in executed if "FROM instruments" in e[0]]
+    assert len(resolution) == 2, executed
+    assert "UPPER(symbol) = %(s)s" in resolution[0][0]
+    assert resolution[0][1] == {"s": "1699"}
+    assert "instrument_id = %(iid)s" in resolution[1][0]
+    assert resolution[1][1] == {"iid": 1699}
+
+
+def test_symbol_never_triggers_the_id_attempt(client: TestClient) -> None:
+    """The shadowing guard, end to end.
+
+    A ref that resolves as a symbol must stop there. If the id attempt
+    ever ran first — or ran at all on a hit — an unrelated
+    `instrument_id` could serve a DIFFERENT issuer's financials under a
+    numeric-looking ticker.
+    """
+    cur_mock = _install_sequenced_db_conn([{"instrument_id": 1001, "symbol": "AAPL"}])
+    try:
+        resp = client.get("/instruments/AAPL/financials?statement=income&period=annual")
+    finally:
+        _clear_db_override()
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["symbol"] == "AAPL"
+    executed = [str(c.args[0]) for c in cur_mock.execute.call_args_list if c.args]
+    resolution = [sql for sql in executed if "FROM instruments" in sql]
+    assert len(resolution) == 1, resolution
+    assert "instrument_id = %(iid)s" not in resolution[0]
+
+
+def test_numeric_ref_matching_nothing_still_404s(client: TestClient) -> None:
+    """Both attempts miss → 404, not a 500 and not a wrong instrument."""
+    _install_sequenced_db_conn([None, None])
+    try:
+        resp = client.get("/instruments/999999999/financials?statement=income")
+    finally:
+        _clear_db_override()
+    assert resp.status_code == 404

--- a/tests/test_instrument_ref_resolution.py
+++ b/tests/test_instrument_ref_resolution.py
@@ -1,0 +1,101 @@
+"""Pure-logic table test for the symbol-or-id path-param branch (#2184).
+
+`/instrument/1001/fundamentals` 404'd because every drill endpoint
+resolved `WHERE UPPER(symbol) = %(s)s`. `instrument_ref_query` is the one
+place that decision now lives; these tests pin the branch and the bound
+params without touching Postgres.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from app.api.instruments import (
+    _RESOLVE_BY_ID_SQL,
+    _RESOLVE_BY_SYMBOL_SQL,
+    instrument_ref_query,
+)
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected_sql", "expected_params"),
+    [
+        # --- id branch: entirely ASCII digits ---
+        ("1001", _RESOLVE_BY_ID_SQL, {"iid": 1001}),
+        ("1", _RESOLVE_BY_ID_SQL, {"iid": 1}),
+        # Leading zeros are still an id; int() normalises them.
+        ("0001001", _RESOLVE_BY_ID_SQL, {"iid": 1001}),
+        # Whitespace is stripped before the branch is chosen.
+        ("  1001  ", _RESOLVE_BY_ID_SQL, {"iid": 1001}),
+        # 19 digits = BIGINT's own width, so the bound never rejects a
+        # value that could be a real id. This one is past BIGINT's RANGE
+        # and still takes the id branch — Postgres compares it as numeric
+        # and returns no rows, i.e. a clean 404 (verified against the dev
+        # DB rather than assumed).
+        ("9" * 19, _RESOLVE_BY_ID_SQL, {"iid": int("9" * 19)}),
+        # --- symbol branch: anything else ---
+        # 20+ digits cannot be an instrument_id, so it falls here and
+        # misses. Load-bearing: `int()` raises ValueError past
+        # `sys.get_int_max_str_digits()` (4300), which an unbounded
+        # numeric branch would turn into a 500 instead of a 404.
+        ("9" * 20, _RESOLVE_BY_SYMBOL_SQL, {"s": "9" * 20}),
+        ("1" * 5000, _RESOLVE_BY_SYMBOL_SQL, {"s": "1" * 5000}),
+        ("AAPL", _RESOLVE_BY_SYMBOL_SQL, {"s": "AAPL"}),
+        # Case is normalised for the UPPER(symbol) comparison.
+        ("aapl", _RESOLVE_BY_SYMBOL_SQL, {"s": "AAPL"}),
+        ("  aapl  ", _RESOLVE_BY_SYMBOL_SQL, {"s": "AAPL"}),
+        # Numeric-LEADING tickers are symbols, not ids — every one in the
+        # universe carries a non-digit exchange suffix (0 purely-numeric
+        # symbols across the full instruments table, checked 2026-07-31).
+        ("1810.HK", _RESOLVE_BY_SYMBOL_SQL, {"s": "1810.HK"}),
+        ("2501.T", _RESOLVE_BY_SYMBOL_SQL, {"s": "2501.T"}),
+        ("3DA.ASX", _RESOLVE_BY_SYMBOL_SQL, {"s": "3DA.ASX"}),
+        ("BRK.B", _RESOLVE_BY_SYMBOL_SQL, {"s": "BRK.B"}),
+        # `str.isdigit()` is True for these but `int()` either raises
+        # ('²') or silently accepts a non-ASCII id ('١٠٠١'). The ASCII
+        # regex keeps both on the symbol branch, where they harmlessly
+        # miss.
+        ("²", _RESOLVE_BY_SYMBOL_SQL, {"s": "²"}),
+        ("١٠٠١", _RESOLVE_BY_SYMBOL_SQL, {"s": "١٠٠١"}),
+        # Mixed digits + letters stay on the symbol branch.
+        ("1001A", _RESOLVE_BY_SYMBOL_SQL, {"s": "1001A"}),
+        ("-1001", _RESOLVE_BY_SYMBOL_SQL, {"s": "-1001"}),
+    ],
+)
+def test_instrument_ref_query_branch(ref: str, expected_sql: str, expected_params: dict[str, object]) -> None:
+    sql, params = instrument_ref_query(ref)
+    assert sql == expected_sql
+    assert params == expected_params
+
+
+def test_symbol_branch_keeps_the_deterministic_tie_break() -> None:
+    """`symbol` is not UNIQUE across exchanges (migration 043) — the
+    collision winner must stay `is_primary_listing DESC, instrument_id
+    ASC`, exactly as the 27 unconverted call sites still spell it."""
+    sql, _ = instrument_ref_query("AAPL")
+    assert "ORDER BY is_primary_listing DESC, instrument_id ASC" in sql
+    assert "LIMIT 1" in sql
+
+
+def test_a_pathological_digit_string_never_reaches_int() -> None:
+    """Regression: `int()` raises `ValueError` past
+    `sys.get_int_max_str_digits()`, so an unbounded numeric branch turned
+    `/instruments/<5000 digits>/financials` into a 500. The 19-digit
+    bound must keep that input on the symbol branch — no raise."""
+    assert int("1" * 4000)  # inside the limit
+    with pytest.raises(ValueError):
+        int("1" * (sys.get_int_max_str_digits() + 1))
+
+    sql, params = instrument_ref_query("1" * (sys.get_int_max_str_digits() + 1))
+    assert sql == _RESOLVE_BY_SYMBOL_SQL
+    assert "iid" not in params
+
+
+def test_id_branch_does_not_filter_on_symbol() -> None:
+    """An id lookup is unique by primary key — no UPPER(symbol) predicate,
+    and no ORDER BY needed to make it deterministic."""
+    sql, _ = instrument_ref_query("1001")
+    assert "UPPER(symbol)" not in sql
+    assert "instrument_id = %(iid)s" in sql

--- a/tests/test_instrument_ref_resolution.py
+++ b/tests/test_instrument_ref_resolution.py
@@ -1,9 +1,18 @@
-"""Pure-logic table test for the symbol-or-id path-param branch (#2184).
+"""Pure-logic table test for the symbol-or-id path-param resolution (#2184).
 
 `/instrument/1001/fundamentals` 404'd because every drill endpoint
-resolved `WHERE UPPER(symbol) = %(s)s`. `instrument_ref_query` is the one
-place that decision now lives; these tests pin the branch and the bound
-params without touching Postgres.
+resolved `WHERE UPPER(symbol) = %(s)s`. `instrument_ref_queries` is the
+one place that decision now lives; these tests pin the attempt ORDER and
+the bound params without touching Postgres.
+
+The order is the safety property: symbol always first, id only as a
+fallback, so an unrelated `instrument_id` can never shadow a real ticker.
+See the function's own docstring for why that is not hypothetical.
+
+The end-to-end "by id AND by symbol both 200" acceptance test named in
+spec §1.1 lives in `tests/test_api_instrument_financials.py` — it drives
+the real handler through `resolve_instrument_ref`, which this file does
+not exercise.
 """
 
 from __future__ import annotations
@@ -15,66 +24,87 @@ import pytest
 from app.api.instruments import (
     _RESOLVE_BY_ID_SQL,
     _RESOLVE_BY_SYMBOL_SQL,
-    instrument_ref_query,
+    instrument_ref_queries,
 )
+
+
+def _by_symbol(s: str) -> tuple[str, dict[str, object]]:
+    return (_RESOLVE_BY_SYMBOL_SQL, {"s": s})
+
+
+def _by_id(iid: int) -> tuple[str, dict[str, object]]:
+    return (_RESOLVE_BY_ID_SQL, {"iid": iid})
 
 
 @pytest.mark.parametrize(
-    ("ref", "expected_sql", "expected_params"),
+    ("ref", "expected"),
     [
-        # --- id branch: entirely ASCII digits ---
-        ("1001", _RESOLVE_BY_ID_SQL, {"iid": 1001}),
-        ("1", _RESOLVE_BY_ID_SQL, {"iid": 1}),
-        # Leading zeros are still an id; int() normalises them.
-        ("0001001", _RESOLVE_BY_ID_SQL, {"iid": 1001}),
-        # Whitespace is stripped before the branch is chosen.
-        ("  1001  ", _RESOLVE_BY_ID_SQL, {"iid": 1001}),
+        # --- numeric refs: symbol attempt FIRST, id attempt second ---
+        ("1001", [_by_symbol("1001"), _by_id(1001)]),
+        ("1", [_by_symbol("1"), _by_id(1)]),
+        # Leading zeros: the symbol attempt keeps them verbatim (a ticker
+        # "0001001" would be a literal match), the id attempt normalises
+        # them via int().
+        ("0001001", [_by_symbol("0001001"), _by_id(1001)]),
+        # Whitespace is stripped before either attempt is built.
+        ("  1001  ", [_by_symbol("1001"), _by_id(1001)]),
         # 19 digits = BIGINT's own width, so the bound never rejects a
         # value that could be a real id. This one is past BIGINT's RANGE
-        # and still takes the id branch — Postgres compares it as numeric
+        # and still gets the id attempt — Postgres compares it as numeric
         # and returns no rows, i.e. a clean 404 (verified against the dev
         # DB rather than assumed).
-        ("9" * 19, _RESOLVE_BY_ID_SQL, {"iid": int("9" * 19)}),
-        # --- symbol branch: anything else ---
-        # 20+ digits cannot be an instrument_id, so it falls here and
-        # misses. Load-bearing: `int()` raises ValueError past
-        # `sys.get_int_max_str_digits()` (4300), which an unbounded
-        # numeric branch would turn into a 500 instead of a 404.
-        ("9" * 20, _RESOLVE_BY_SYMBOL_SQL, {"s": "9" * 20}),
-        ("1" * 5000, _RESOLVE_BY_SYMBOL_SQL, {"s": "1" * 5000}),
-        ("AAPL", _RESOLVE_BY_SYMBOL_SQL, {"s": "AAPL"}),
+        ("9" * 19, [_by_symbol("9" * 19), _by_id(int("9" * 19))]),
+        # --- non-numeric refs: symbol attempt ONLY ---
+        # 20+ digits cannot be an instrument_id, so no id attempt is made
+        # and the symbol attempt misses. Load-bearing: `int()` raises
+        # ValueError past `sys.get_int_max_str_digits()` (4300), which an
+        # unbounded numeric branch would turn into a 500 instead of a 404.
+        ("9" * 20, [_by_symbol("9" * 20)]),
+        ("1" * 5000, [_by_symbol("1" * 5000)]),
+        ("AAPL", [_by_symbol("AAPL")]),
         # Case is normalised for the UPPER(symbol) comparison.
-        ("aapl", _RESOLVE_BY_SYMBOL_SQL, {"s": "AAPL"}),
-        ("  aapl  ", _RESOLVE_BY_SYMBOL_SQL, {"s": "AAPL"}),
+        ("aapl", [_by_symbol("AAPL")]),
+        ("  aapl  ", [_by_symbol("AAPL")]),
         # Numeric-LEADING tickers are symbols, not ids — every one in the
         # universe carries a non-digit exchange suffix (0 purely-numeric
         # symbols across the full instruments table, checked 2026-07-31).
-        ("1810.HK", _RESOLVE_BY_SYMBOL_SQL, {"s": "1810.HK"}),
-        ("2501.T", _RESOLVE_BY_SYMBOL_SQL, {"s": "2501.T"}),
-        ("3DA.ASX", _RESOLVE_BY_SYMBOL_SQL, {"s": "3DA.ASX"}),
-        ("BRK.B", _RESOLVE_BY_SYMBOL_SQL, {"s": "BRK.B"}),
+        ("1810.HK", [_by_symbol("1810.HK")]),
+        ("2501.T", [_by_symbol("2501.T")]),
+        ("3DA.ASX", [_by_symbol("3DA.ASX")]),
+        ("BRK.B", [_by_symbol("BRK.B")]),
         # `str.isdigit()` is True for these but `int()` either raises
         # ('²') or silently accepts a non-ASCII id ('١٠٠١'). The ASCII
-        # regex keeps both on the symbol branch, where they harmlessly
-        # miss.
-        ("²", _RESOLVE_BY_SYMBOL_SQL, {"s": "²"}),
-        ("١٠٠١", _RESOLVE_BY_SYMBOL_SQL, {"s": "١٠٠١"}),
-        # Mixed digits + letters stay on the symbol branch.
-        ("1001A", _RESOLVE_BY_SYMBOL_SQL, {"s": "1001A"}),
-        ("-1001", _RESOLVE_BY_SYMBOL_SQL, {"s": "-1001"}),
+        # regex means no id attempt is built; the symbol attempt
+        # harmlessly misses.
+        ("²", [_by_symbol("²")]),
+        ("١٠٠١", [_by_symbol("١٠٠١")]),
+        # Mixed digits + letters get the symbol attempt only.
+        ("1001A", [_by_symbol("1001A")]),
+        ("-1001", [_by_symbol("-1001")]),
     ],
 )
-def test_instrument_ref_query_branch(ref: str, expected_sql: str, expected_params: dict[str, object]) -> None:
-    sql, params = instrument_ref_query(ref)
-    assert sql == expected_sql
-    assert params == expected_params
+def test_instrument_ref_queries(ref: str, expected: list[tuple[str, dict[str, object]]]) -> None:
+    assert instrument_ref_queries(ref) == expected
 
 
-def test_symbol_branch_keeps_the_deterministic_tie_break() -> None:
+def test_symbol_is_always_the_first_attempt() -> None:
+    """The ordering is the safety property, so pin it explicitly rather
+    than leaving it implied by the table above.
+
+    An id-first branch would let `instrument_id = 1810` shadow a ticker
+    `1810` and serve a DIFFERENT issuer's financials under it. 0 of 12,691
+    instruments have a purely-numeric symbol today, but nothing enforces
+    that, so the order — not the population — is what makes this safe."""
+    for ref in ("1001", "1", "9" * 19, "AAPL", "1810.HK"):
+        first_sql, _ = instrument_ref_queries(ref)[0]
+        assert first_sql == _RESOLVE_BY_SYMBOL_SQL, ref
+
+
+def test_symbol_attempt_keeps_the_deterministic_tie_break() -> None:
     """`symbol` is not UNIQUE across exchanges (migration 043) — the
     collision winner must stay `is_primary_listing DESC, instrument_id
     ASC`, exactly as the 27 unconverted call sites still spell it."""
-    sql, _ = instrument_ref_query("AAPL")
+    sql, _ = instrument_ref_queries("AAPL")[0]
     assert "ORDER BY is_primary_listing DESC, instrument_id ASC" in sql
     assert "LIMIT 1" in sql
 
@@ -83,19 +113,20 @@ def test_a_pathological_digit_string_never_reaches_int() -> None:
     """Regression: `int()` raises `ValueError` past
     `sys.get_int_max_str_digits()`, so an unbounded numeric branch turned
     `/instruments/<5000 digits>/financials` into a 500. The 19-digit
-    bound must keep that input on the symbol branch — no raise."""
+    bound must mean no id attempt is built — no raise."""
     assert int("1" * 4000)  # inside the limit
     with pytest.raises(ValueError):
         int("1" * (sys.get_int_max_str_digits() + 1))
 
-    sql, params = instrument_ref_query("1" * (sys.get_int_max_str_digits() + 1))
-    assert sql == _RESOLVE_BY_SYMBOL_SQL
-    assert "iid" not in params
+    attempts = instrument_ref_queries("1" * (sys.get_int_max_str_digits() + 1))
+    assert len(attempts) == 1
+    assert attempts[0][0] == _RESOLVE_BY_SYMBOL_SQL
 
 
-def test_id_branch_does_not_filter_on_symbol() -> None:
+def test_id_attempt_does_not_filter_on_symbol() -> None:
     """An id lookup is unique by primary key — no UPPER(symbol) predicate,
     and no ORDER BY needed to make it deterministic."""
-    sql, _ = instrument_ref_query("1001")
+    sql, params = instrument_ref_queries("1001")[1]
     assert "UPPER(symbol)" not in sql
     assert "instrument_id = %(iid)s" in sql
+    assert params == {"iid": 1001}


### PR DESCRIPTION
Implements spec §1.1 from `docs/proposals/ui/2026-07-31-fundamentals-drill-refinement.md` (PR #2186).

## Defect

`/instrument/1001/fundamentals` (1001 = AAPL) rendered **"Failed to load. Check the browser console for details."** with the heading "Fundamentals — 1001". All four data calls returned `{"detail":"Instrument 1001 not found"}`.

`app/api/instruments.py` resolved `WHERE UPPER(symbol) = %(s)s` — symbol only — while the app links to instruments by numeric id elsewhere. Whether the drill page worked depended entirely on which link you arrived through.

## Fix

A shared `instrument_ref_queries` / `resolve_instrument_ref` pair returning **ordered attempts**: by-symbol always first, by-id appended only for a 1–19 ASCII-digit ref. Adopted by `get_instrument_financials` and `get_instrument_fcf_yield`.

**Symbol-first ordering is the safety property, and it was a review finding, not the first cut.** The original implementation used an exclusive "looks numeric → id, no fallback" branch. That was fail-silent: nothing in the schema or `sync_universe` stops eToro admitting a letterless ticker, and `instrument_id` spans 1..1,065,714 — which covers 4-digit exchange codes. A bare `1810` would have served a *different issuer's* financials under that ticker rather than 404ing. The route's declared contract (`/instrument/:symbol`) now wins; the id form is an explicit compat fallback costing one extra index seek on the rare path.

**The 19-digit bound is load-bearing, not cosmetic.** Codex checkpoint 2 found that an unbounded numeric branch hands a 5,000-digit path param to `int()`, which raises `ValueError` past `sys.get_int_max_str_digits()` — a 500 where a 404 belongs. Pinned by `test_a_pathological_digit_string_never_reaches_int`.

## Frontend

**A 404 no longer renders as a red "check the browser console" banner.** Two review findings sharpened this:

- Status-only matching meant a bare FastAPI `{"detail":"Not Found"}` — from a missing route or a mis-proxied `/api` base — would render *"No instrument matches AAPL"* for **every** instrument, with no Retry. An outage reported as a data absence. Now also requires the endpoint's own message (`Instrument {symbol} not found`, case-sensitive so it cannot match FastAPI's generic "Not Found"). Degrades **fail-closed**: if the backend message ever changes, the page falls back to SectionError + Retry, never to a false empty state.
- `resolvedSymbol` reverted to the raw route param on every period toggle, because `useAsync` calls `setData(null)` at the start of each non-preserved fetch. Fixed with a ref latch **keyed on the raw ref** — the key matters because React Router reuses the component across param changes, so an unkeyed latch would briefly show the previous instrument's symbol.
- Both header links on the not-found path pointed at `/instrument/<unresolvable ref>`, which fails the same way the page just did — the operator's only recovery affordances were second dead ends. Now suppressed, leaving the EmptyState's `/instruments` link as the exit.

## Dev-verified on the live stack

```
1001   200  symbol=AAPL rows=20 ccy=USD      AAPL   200  symbol=AAPL rows=20
1699   200  symbol=GME  rows=17 ccy=USD      GME    200  symbol=GME  rows=17
```

Page at `/instrument/1001/fundamentals` renders **"Fundamentals — AAPL"**, all 9 sections, no error banner.

## Scope deliberately not taken

**27 of 29 endpoints in `instruments.py` still carry the by-symbol SQL verbatim.** Verified by count, not estimate: `grep -c 'UPPER(symbol) = %(s)s'` returns 28 = 27 call sites + the shared constant. They are byte-identical in shape so adoption is mechanical, but it belongs in its own PR.

The parent route `/instrument/:symbol` and the other 8 drill routes still 404 on a numeric id — same defect class, out of scope here. The fundamentals page's own links use the *resolved* symbol so they do not hit it; a hand-typed `/instrument/1001` still fails.

## Risk recorded

The id branch's safety no longer rests on "no instrument has a purely-numeric symbol" — symbol-first ordering removed that dependency. Verified anyway across the full dev-DB `instruments` table: 12,691 rows, **0** matching `^[0-9]+$` (numeric-*leading* tickers like `1810.HK`, `2501.T`, `3DA.ASX` all carry a non-digit suffix, so they take the symbol branch).

## Gates

All 7 pass: `ruff check` · `ruff format --check` · `pyright` 0 errors · `pytest -m "not db"` 5,504 passed / 14 skipped · `frontend typecheck` · `test:unit` 1,457 passed · `dark:check` · `pills:check`. Codex checkpoint 2 run: round 1 found the P3 above, round 2 clean.

DoD clauses 8–12 do not apply — this changes no parser, schema, or stored data, only endpoint resolution.

Refs #2184. Refs #2183.
