### PR TITLE
fix(#2187): release the local LLM model after each thesis batch, allow-list what may load, one launcher for the jobs daemon

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -112,7 +112,7 @@
         }
       },
       "osx": {
-        "command": "pgrep -f '[p]ython3 -m app\\.jobs(\\.dev_reload)?($|[[:space:]])' | xargs kill -9 2>/dev/null; uv run python -m app.jobs.dev_reload"
+        "command": "mkdir -p var/autonomy-logs; if launchctl kickstart -k \"gui/$(id -u)/com.ebull.jobs-daemon\" 2>/dev/null; then echo '==> restarted launchd com.ebull.jobs-daemon; tailing its log (closing this panel does NOT stop the daemon)'; exec tail -n 50 -F var/autonomy-logs/launchd.jobs-daemon.err.log; else echo '==> launchd agent com.ebull.jobs-daemon not installed (see scripts/autonomy/README.md) — running a local supervisor instead'; exec uv run python -m app.jobs.dev_reload; fi"
       },
       "linux": {
         "command": "pgrep -f '[p]ython3 -m app\\.jobs(\\.dev_reload)?($|[[:space:]])' | xargs kill -9 2>/dev/null; uv run python -m app.jobs.dev_reload"

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -47,7 +47,11 @@ import psycopg
 
 from app.config import settings
 from app.services.anthropic_client import make_anthropic_client
-from app.services.runtime_config import get_runtime_config
+from app.services.runtime_config import (
+    get_runtime_config,
+    is_local_llm_endpoint,
+    local_llm_model_violation,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +63,30 @@ LLM_REQUEST_TIMEOUT: httpx.Timeout = httpx.Timeout(
     read=600.0,
     write=30.0,
     pool=10.0,
+)
+
+# Native Ollama model-lifecycle route (#2187). NOT part of the
+# OpenAI-compatible surface — it lives at the server ROOT, not under
+# ``/v1``, so the release path strips the ``/v1`` suffix off
+# ``llm_base_url``. Verified empirically 2026-08-02 against ollama on
+# this box: ``POST {"model": M, "keep_alive": 0}`` answers
+# ``{"done_reason": "unload"}`` and the model leaves ``/api/ps`` within
+# seconds (ollama RSS 9.28 GB → 0.05 GB). Unload is ASYNCHRONOUS — the
+# model can still appear in ``/api/ps`` on the very next call, with
+# ``expires_at`` set to now.
+#
+# Passing ``keep_alive`` in the ``/v1/chat/completions`` BODY does not
+# work: it is not an OpenAI field and Ollama ignores it there. That is
+# why release is a separate call rather than a request parameter.
+_OLLAMA_UNLOAD_PATH = "/api/generate"
+
+# Release is best-effort housekeeping, not a generation — it must never
+# hold a job open the way a 600s decode window legitimately can.
+LLM_RELEASE_TIMEOUT: httpx.Timeout = httpx.Timeout(
+    connect=5.0,
+    read=30.0,
+    write=10.0,
+    pool=5.0,
 )
 
 # Empirical (spec "Empirical verification", 2026-07-09): qwen3's default
@@ -93,11 +121,20 @@ _LLM_CALL_SEMAPHORE = threading.Semaphore(1)
 
 
 class LLMProviderNotConfigured(RuntimeError):
-    """Raised when the configured provider cannot be constructed.
+    """Raised when the configured provider must not be used as configured.
 
-    Only reachable on the ``anthropic`` path with no ``ANTHROPIC_API_KEY``
-    set — the ``openai_compatible`` path needs no key (Ollama ignores it)
-    and its base URL / model columns are NOT NULL with defaults.
+    Two reachable causes:
+
+    * the ``anthropic`` path with no ``ANTHROPIC_API_KEY`` set (the
+      ``openai_compatible`` path needs no key — Ollama ignores it — and
+      its base URL / model columns are NOT NULL with defaults);
+    * a locally-hosted model outside ``LOCAL_LLM_MODEL_ALLOWLIST``
+      (#2187), which /config rejects but a direct SQL write could still
+      leave in the row.
+
+    ``thesis_refresh`` catches this and records a PREREQ_SKIP with the
+    reason, so a bad config row is a visible skip rather than an hourly
+    crash loop.
     """
 
 
@@ -121,6 +158,15 @@ class LLMClient(Protocol):
     model: str
 
     def complete(self, *, system: str, user: str, max_tokens: int) -> LLMCompletion: ...
+
+    def release_model(self) -> None:
+        """Best-effort: drop this model from the serving process's memory.
+
+        Part of the interface (not an ``OpenAICompatProvider`` detail) so
+        every implementation — including test fakes — has to answer the
+        question. Implementations that hold nothing locally no-op.
+        """
+        ...
 
 
 def strip_think_block(text: str) -> str:
@@ -199,6 +245,39 @@ class OpenAICompatProvider:
             completion_tokens=usage.get("completion_tokens"),
         )
 
+    def release_model(self) -> None:
+        """Unload this model from a LOCAL inference server (#2187).
+
+        Skipped for remote endpoints: the weights are not in our RAM and
+        the unload route is not ours to call. Holds the same
+        per-process semaphore as ``complete`` so a release can never
+        land mid-generation in this process.
+
+        Best-effort by contract — a failure here costs memory, never
+        correctness, so it is logged and swallowed. Non-Ollama local
+        servers (llama.cpp, vLLM) simply 404 this route and take that
+        path.
+        """
+        if not is_local_llm_endpoint(self._base_url):
+            return
+        root = self._base_url.removesuffix("/v1")
+        try:
+            with _LLM_CALL_SEMAPHORE:
+                response = httpx.post(
+                    f"{root}{_OLLAMA_UNLOAD_PATH}",
+                    json={"model": self.model, "keep_alive": 0},
+                    timeout=LLM_RELEASE_TIMEOUT,
+                )
+            response.raise_for_status()
+        except Exception:
+            logger.warning(
+                "llm: release of local model %s failed (best-effort, continuing)",
+                self.model,
+                exc_info=True,
+            )
+        else:
+            logger.info("llm: released local model %s", self.model)
+
 
 class AnthropicProvider:
     """Wraps the existing bounded-timeout Anthropic SDK client (#1479).
@@ -238,6 +317,10 @@ class AnthropicProvider:
             prompt_tokens=message.usage.input_tokens,
             completion_tokens=message.usage.output_tokens,
         )
+
+    def release_model(self) -> None:
+        """No-op: a cloud model holds no memory on this machine (#2187)."""
+        return
 
 
 @dataclass(frozen=True)
@@ -282,6 +365,21 @@ def make_llm_clients(conn: psycopg.Connection[Any]) -> LLMClientPair:
             writer=AnthropicProvider(sdk, model=cfg.llm_model_writer),
             critic=AnthropicProvider(sdk, model=cfg.llm_model_critic),
         )
+    # #2187 allow-list at the LOAD site, not just at /config: the PATCH
+    # guard cannot see a model written straight into the row by SQL, and
+    # this is the only place a model is actually pulled into memory.
+    for field_name, model in (
+        ("llm_model_writer", cfg.llm_model_writer),
+        ("llm_model_critic", cfg.llm_model_critic),
+    ):
+        violation = local_llm_model_violation(
+            provider=cfg.llm_provider,
+            base_url=cfg.llm_base_url,
+            model=model,
+            field=field_name,
+        )
+        if violation is not None:
+            raise LLMProviderNotConfigured(violation)
     return LLMClientPair(
         writer=OpenAICompatProvider(
             base_url=cfg.llm_base_url, model=cfg.llm_model_writer, api_key=settings.llm_api_key
@@ -290,3 +388,23 @@ def make_llm_clients(conn: psycopg.Connection[Any]) -> LLMClientPair:
             base_url=cfg.llm_base_url, model=cfg.llm_model_critic, api_key=settings.llm_api_key
         ),
     )
+
+
+def release_local_models(clients: LLMClientPair) -> None:
+    """Release every distinct model a completed batch left resident (#2187).
+
+    Called once per ``thesis_refresh`` batch rather than per generation:
+    the model must stay warm across the ≤5 back-to-back generations
+    (a reload costs seconds each), but must NOT stay warm for the ~33
+    idle minutes that follow — that residency is the OOM.
+
+    Deduplicated by model name because writer and critic share one model
+    by default (``DEFAULT_LLM_MODEL_WRITER`` == ``DEFAULT_LLM_MODEL_CRITIC``).
+    Each ``release_model`` is already best-effort; this never raises.
+    """
+    seen: set[str] = set()
+    for client in (clients.writer, clients.critic):
+        if client.model in seen:
+            continue
+        seen.add(client.model)
+        client.release_model()

--- a/app/services/runtime_config.py
+++ b/app/services/runtime_config.py
@@ -29,6 +29,7 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, cast
+from urllib.parse import urlsplit
 
 import psycopg
 import psycopg.rows
@@ -66,6 +67,45 @@ DEFAULT_LLM_PROVIDER = "openai_compatible"
 DEFAULT_LLM_BASE_URL = "http://localhost:11434/v1"
 DEFAULT_LLM_MODEL_WRITER = "qwen3:14b"
 DEFAULT_LLM_MODEL_CRITIC = "qwen3:14b"
+
+# Hosts that mean "the inference server runs on THIS machine" — the only
+# case where a resident model's weights consume OUR RAM. Remote
+# OpenAI-compatible endpoints (a vLLM box, OpenAI itself) are exempt from
+# both the size allow-list and the post-batch release: neither the memory
+# hazard nor the unload route applies there.
+_LOCAL_LLM_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})
+
+# Models the thesis job may load into LOCAL memory (#2187).
+#
+# Why a cap exists: `thesis_refresh` is hourly and runs ≤5 generations at
+# ≈260s each (app/workers/scheduler.py JOB_THESIS_REFRESH), so the chosen
+# model is resident ~27 of every 60 minutes — as WIRED unified memory on
+# Apple silicon, which cannot be paged out. On the 24 GB dev box that is
+# already the OOM budget; a bigger model turns thrash into a hard OOM.
+# `mistral-small:latest` (14.33 GB pulled locally) is the concrete blob
+# this excludes. The ceiling here is qwen3:14b at 9.28 GB.
+#
+# This is a code constant, not config, deliberately: it is the guard
+# AGAINST config drift, so it must not itself be settable through the
+# surface it protects. Widening it is a reviewed one-line edit — measure
+# the model's resident size (`ollama list`) against the box first.
+#
+# Match is EXACT, tag included, and must stay that way: an Ollama tag
+# carries the quantization, and quantization dominates resident size.
+# `qwen3:14b` is Q4_K_M at 9.28 GB; a `qwen3:14b-q8_0` sibling is ~15 GB.
+# A family-or-prefix match would therefore admit the exact class of blob
+# this list exists to exclude.
+LOCAL_LLM_MODEL_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "qwen3:14b",
+        "qwen3:8b",
+        "deepseek-r1:14b",
+        "deepseek-r1:8b",
+        "phi4:14b",
+        "gemma3:12b",
+        "llama3.1:8b",
+    }
+)
 
 # Boot-recovery audit attribution. Operators investigating the audit log can
 # search for this exact reason to find re-seed events caused by a vanished
@@ -107,6 +147,43 @@ class RuntimeConfig:
 
 def _utcnow() -> datetime:
     return datetime.now(tz=UTC)
+
+
+def is_local_llm_endpoint(base_url: str) -> bool:
+    """True when ``base_url`` points at an inference server on this machine.
+
+    Gates both #2187 controls (the model allow-list and the post-batch
+    model release) — a remote endpoint holds its weights in someone
+    else's RAM and exposes no unload route we own.
+    """
+    try:
+        host = urlsplit(base_url).hostname
+    except ValueError:
+        # Malformed URL: not provably local, so no local-only rule applies.
+        return False
+    return host is not None and host.lower() in _LOCAL_LLM_HOSTS
+
+
+def local_llm_model_violation(*, provider: str, base_url: str, model: str, field: str) -> str | None:
+    """Return an error message if ``model`` may not be loaded locally, else None.
+
+    Single source of truth for the #2187 allow-list rule. Callers pick
+    their own failure mode from it: the /config PATCH path raises
+    ``ValueError`` (→ HTTP 400), while ``make_llm_clients`` raises
+    ``LLMProviderNotConfigured`` so ``thesis_refresh`` records a
+    PREREQ_SKIP instead of crash-looping on a bad config row.
+    """
+    if provider != "openai_compatible" or not is_local_llm_endpoint(base_url):
+        return None
+    if model in LOCAL_LLM_MODEL_ALLOWLIST:
+        return None
+    return (
+        f"{field}={model!r} is not in the local-model allow-list "
+        f"{sorted(LOCAL_LLM_MODEL_ALLOWLIST)} (#2187: a locally-hosted model is "
+        f"resident ~27 min/hour as wired memory; oversized models OOM the box). "
+        f"Widen LOCAL_LLM_MODEL_ALLOWLIST in app/services/runtime_config.py after "
+        f"checking the model's size against available RAM."
+    )
 
 
 def ensure_runtime_config_singleton(conn: psycopg.Connection[Any]) -> None:
@@ -358,6 +435,23 @@ def update_runtime_config(
         new_llm_base_url = llm_base_url if llm_base_url is not None else str(current["llm_base_url"])
         new_llm_model_writer = llm_model_writer if llm_model_writer is not None else str(current["llm_model_writer"])
         new_llm_model_critic = llm_model_critic if llm_model_critic is not None else str(current["llm_model_critic"])
+
+        # #2187 allow-list, evaluated on the RESULTING triple, not on the
+        # provided fields: a PATCH that only moves llm_base_url from a
+        # remote endpoint to localhost newly subjects the (unchanged)
+        # model columns to the local-memory rule.
+        for field_name, new_model in (
+            ("llm_model_writer", new_llm_model_writer),
+            ("llm_model_critic", new_llm_model_critic),
+        ):
+            violation = local_llm_model_violation(
+                provider=new_llm_provider,
+                base_url=new_llm_base_url,
+                model=new_model,
+                field=field_name,
+            )
+            if violation is not None:
+                raise ValueError(violation)
 
         # No-op patch detection: if every provided field already matches the
         # current row, refuse the patch.  Otherwise the UPDATE would silently

--- a/app/services/runtime_config.py
+++ b/app/services/runtime_config.py
@@ -25,7 +25,9 @@ covers all config-style changes.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
+import socket
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, cast
@@ -68,12 +70,12 @@ DEFAULT_LLM_BASE_URL = "http://localhost:11434/v1"
 DEFAULT_LLM_MODEL_WRITER = "qwen3:14b"
 DEFAULT_LLM_MODEL_CRITIC = "qwen3:14b"
 
-# Hosts that mean "the inference server runs on THIS machine" — the only
-# case where a resident model's weights consume OUR RAM. Remote
-# OpenAI-compatible endpoints (a vLLM box, OpenAI itself) are exempt from
-# both the size allow-list and the post-batch release: neither the memory
-# hazard nor the unload route applies there.
-_LOCAL_LLM_HOSTS: frozenset[str] = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})
+# Hostnames that mean "the inference server runs on THIS machine". IP
+# LITERALS are not listed here — they are classified numerically below,
+# because a string set silently misses valid loopback spellings
+# (`127.1`, `2130706433`, anything else in 127.0.0.0/8) and each miss is
+# a silent bypass of the allow-list (Codex ckpt-2).
+_LOCAL_LLM_HOSTNAMES: frozenset[str] = frozenset({"localhost"})
 
 # Models the thesis job may load into LOCAL memory (#2187).
 #
@@ -155,13 +157,37 @@ def is_local_llm_endpoint(base_url: str) -> bool:
     Gates both #2187 controls (the model allow-list and the post-batch
     model release) — a remote endpoint holds its weights in someone
     else's RAM and exposes no unload route we own.
+
+    IP hosts are classified numerically (``is_loopback`` / unspecified),
+    not by string match, so every spelling of loopback resolves the same
+    way. ``socket.inet_aton`` is used for the IPv4 pass because it
+    accepts the shorthand and integer forms ``ipaddress`` rejects
+    (``127.1``, ``2130706433``); it parses numerically and never performs
+    a DNS lookup.
+
+    Known limit: a NAMED host other than ``localhost`` that happens to
+    resolve to this machine (``mymac.local``) reads as remote. Resolving
+    it would put DNS in a config-validation path. The rule targets drift
+    on the local-first default, not a determined operator — a deliberate
+    remote-looking pointer at your own box opts out of both controls.
     """
     try:
-        host = urlsplit(base_url).hostname
+        host = urlsplit(base_url).hostname  # lowercased; IPv6 brackets stripped
     except ValueError:
         # Malformed URL: not provably local, so no local-only rule applies.
         return False
-    return host is not None and host.lower() in _LOCAL_LLM_HOSTS
+    if host is None:
+        return False
+    if host in _LOCAL_LLM_HOSTNAMES:
+        return True
+    try:
+        address: ipaddress.IPv4Address | ipaddress.IPv6Address = ipaddress.IPv4Address(socket.inet_aton(host))
+    except OSError:
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            return False  # a hostname we cannot classify without DNS
+    return address.is_loopback or address.is_unspecified
 
 
 def local_llm_model_violation(*, provider: str, base_url: str, model: str, field: str) -> str | None:

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -3295,9 +3295,16 @@ def thesis_refresh() -> None:
         # per generation would cost seconds each), then is released in
         # ``finally`` — including when the batch dies mid-way, which is
         # exactly when the weights would otherwise sit resident until the
-        # next hourly fire. Reached only past the early no-batch return,
-        # so a run that loaded nothing never unloads another consumer's
-        # model on this shared box.
+        # next hourly fire.
+        #
+        # Gated on ``load_attempted``, set immediately before the ONLY
+        # call that can pull a model into memory. A non-empty batch is
+        # not sufficient: a batch that is entirely LOCKED_BY_SIBLING
+        # never generates here, and on this shared box the sibling
+        # holding those locks is plausibly mid-generation with the same
+        # local model — an unconditional release would de-warm it
+        # (Codex ckpt-2).
+        load_attempted = False
         try:
             for idx, item in enumerate(batch, start=1):
                 try:
@@ -3311,6 +3318,7 @@ def thesis_refresh() -> None:
                                 )
                                 locked_skipped += 1
                             else:
+                                load_attempted = True
                                 generate_thesis(
                                     instrument_id=item.instrument_id,
                                     conn=conn,
@@ -3334,7 +3342,8 @@ def thesis_refresh() -> None:
                     skipped += 1
                 report_progress(idx, total)
         finally:
-            release_local_models(clients)
+            if load_attempted:
+                release_local_models(clients)
 
         report_progress(total, total, force=True)
         tracker.row_count = generated

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -54,7 +54,7 @@ from app.services.exchange_directory import refresh_exchange_directory
 from app.services.exchanges import refresh_exchanges_metadata
 from app.services.execution_guard import evaluate_recommendation
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
-from app.services.llm_client import LLMProviderNotConfigured, make_llm_clients
+from app.services.llm_client import LLMProviderNotConfigured, make_llm_clients, release_local_models
 from app.services.market_data import refresh_market_data
 from app.services.mf_directory import refresh_mf_directory
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
@@ -3291,40 +3291,50 @@ def thesis_refresh() -> None:
         skipped = 0
         locked_skipped = 0
         total = len(batch)
-        for idx, item in enumerate(batch, start=1):
-            try:
-                with connect_job() as conn:
-                    with instrument_lock(conn, item.instrument_id) as acquired:
-                        if not acquired:
-                            logger.info(
-                                "thesis_refresh: LOCKED_BY_SIBLING symbol=%s instrument_id=%d",
-                                item.symbol,
-                                item.instrument_id,
-                            )
-                            locked_skipped += 1
-                        else:
-                            generate_thesis(
-                                instrument_id=item.instrument_id,
-                                conn=conn,
-                                clients=clients,
-                                trigger="scheduled",
-                            )
-                            # Thesis row is committed by generate_thesis
-                            # (#293). Rankings pick the fresh thesis up at
-                            # the next morning_candidate_review scoring
-                            # run (#2065 — the cascade rerank path is
-                            # gone; that daily recompute was already the
-                            # only rerank landing in practice).
-                            generated += 1
-            except Exception:
-                logger.warning(
-                    "thesis_refresh: failed for symbol=%s instrument_id=%d, skipping",
-                    item.symbol,
-                    item.instrument_id,
-                    exc_info=True,
-                )
-                skipped += 1
-            report_progress(idx, total)
+        # #2187: the local model stays warm for the whole batch (a reload
+        # per generation would cost seconds each), then is released in
+        # ``finally`` — including when the batch dies mid-way, which is
+        # exactly when the weights would otherwise sit resident until the
+        # next hourly fire. Reached only past the early no-batch return,
+        # so a run that loaded nothing never unloads another consumer's
+        # model on this shared box.
+        try:
+            for idx, item in enumerate(batch, start=1):
+                try:
+                    with connect_job() as conn:
+                        with instrument_lock(conn, item.instrument_id) as acquired:
+                            if not acquired:
+                                logger.info(
+                                    "thesis_refresh: LOCKED_BY_SIBLING symbol=%s instrument_id=%d",
+                                    item.symbol,
+                                    item.instrument_id,
+                                )
+                                locked_skipped += 1
+                            else:
+                                generate_thesis(
+                                    instrument_id=item.instrument_id,
+                                    conn=conn,
+                                    clients=clients,
+                                    trigger="scheduled",
+                                )
+                                # Thesis row is committed by generate_thesis
+                                # (#293). Rankings pick the fresh thesis up at
+                                # the next morning_candidate_review scoring
+                                # run (#2065 — the cascade rerank path is
+                                # gone; that daily recompute was already the
+                                # only rerank landing in practice).
+                                generated += 1
+                except Exception:
+                    logger.warning(
+                        "thesis_refresh: failed for symbol=%s instrument_id=%d, skipping",
+                        item.symbol,
+                        item.instrument_id,
+                        exc_info=True,
+                    )
+                    skipped += 1
+                report_progress(idx, total)
+        finally:
+            release_local_models(clients)
 
         report_progress(total, total, force=True)
         tracker.row_count = generated

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -2424,3 +2424,73 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
   account for every change; a value diff is either a real regression or a
   staleness that has been lying to tests since it appeared.
 - Enforced in: this log.
+
+---
+
+### Two supervisors for one singleton: the loser parks forever and its feature dies silently
+- First seen in: #2187 (2026-08-02). A launchd agent (`com.ebull.jobs-daemon`,
+  `KeepAlive` + `ThrottleInterval=60`) and the VS Code `stack: jobs` task both
+  launched the jobs daemon. The task `kill -9`-ed **both** process patterns
+  (`app\.jobs(\.dev_reload)?`) and started `app.jobs.dev_reload`; launchd
+  respawned its own copy inside the throttle window and won the PG
+  advisory-lock race. `dev_reload`'s child FATAL-exited, and its supervisor
+  only respawns on a `*.py` change — never on a tick — so it parked at ~19 MB
+  indefinitely. Net effect: **#2144's auto-reload-on-merge was dead for weeks
+  while both processes looked healthy**, and every jobs/parser merge silently
+  went back to needing the manual restart #2144 existed to remove.
+- Symptom: a process singleton guarded by an advisory lock / PID file has more
+  than one launcher (init system + IDE task + `nohup` runbook line). Because
+  the lock does its job, there is no error and no duplicate work — the visible
+  state is one healthy daemon. What is lost is whatever the *losing*
+  supervisor provided (a file watcher, a log tail, a restart policy), and that
+  loss is invisible precisely because the lock made the failure graceful.
+  `pgrep`-ing for the daemon confirms "it's running" and tells you nothing.
+- Prevention: a supervised singleton gets **exactly one launcher**, named in
+  the launcher's own comment, and every other entry point delegates to it
+  rather than starting its own copy (here: `.vscode/tasks.json` runs
+  `launchctl kickstart -k gui/$UID/com.ebull.jobs-daemon` and tails the
+  agent's log). When adding a supervisor wrapper around an existing daemon,
+  check for other launchers **before** shipping: `launchctl list | grep <name>`,
+  `grep -rn "<module>" .vscode/ scripts/ docs/`. Judge a supervisor by the
+  behaviour it provides, not by the child being alive — the #2144 tell was
+  the supervisor's RSS parked at ~19 MB, never that the daemon was down.
+- Enforced in: this log; `scripts/autonomy/com.ebull.jobs-daemon.plist`
+  (the "THERE MUST BE EXACTLY ONE LAUNCHER" block);
+  `scripts/autonomy/README.md` ("Exactly one launcher"); `.vscode/tasks.json`
+  (`stack: jobs` delegates to `launchctl kickstart`).
+
+---
+
+### A resident local-LLM model is a standing memory cost, not a per-call one
+- First seen in: #2187 (2026-08-02). The OOM was diagnosed twice from the
+  wrong premise — first "something set a 12h `keep_alive`", then "a duplicate
+  daemon double-polls". Both were falsified by measurement: `api/ps` showed
+  `expires_at = now + 5m` **sliding** (the default timer, refreshed by every
+  request), and the launchd log showed 4-5 theses/hour with zero variance
+  across 24 hours. The real mechanism needed no bug at all — `thesis_refresh`
+  is hourly with ≤5 generations at ≈260s each, so the model is resident ~27 of
+  every 60 minutes, 24/7, **by design**. On Apple silicon that is WIRED
+  unified memory, which cannot be paged out.
+- Symptom: an inference-server model appears to be "stuck" in memory. Every
+  keep-alive/TTL lever looks like the fix and none of them help, because a
+  polling caller refreshes the rolling timer faster than it can expire. The
+  TTL only ever governs the tail after the LAST call, so tuning it is close to
+  a no-op whenever the batch is longer than the TTL.
+- Prevention: before tuning any TTL, measure the caller's duty cycle
+  (`grep`-count the job's completions per hour in its log) and compare it to
+  the TTL. If duty-cycle ≫ TTL, the lever is an **explicit release after the
+  batch**, not a shorter timer. Release once per batch, never per call — the
+  model must stay warm across back-to-back generations. Put the release in
+  `finally` (a batch that dies mid-way is exactly when the weights would
+  otherwise sit until the next fire) and behind the "did we load anything?"
+  early return, so a no-op run cannot evict another consumer's model on a
+  shared box. Note that `keep_alive` is **not** an OpenAI field: sending it in
+  a `/v1/chat/completions` body looks like a fix and does nothing — Ollama's
+  unload route is native (`POST /api/generate {"keep_alive": 0}`) and lives at
+  the server ROOT, not under `/v1`.
+- Enforced in: this log;
+  `app/services/llm_client.py::OpenAICompatProvider.release_model` +
+  `release_local_models`; `app/workers/scheduler.py::thesis_refresh` (the
+  `finally` release); `tests/test_thesis_refresh_lock.py`
+  (`test_batch_releases_local_model_when_a_generation_raises`,
+  `test_empty_batch_does_not_release`).

--- a/frontend/src/components/settings/LlmProviderSection.test.tsx
+++ b/frontend/src/components/settings/LlmProviderSection.test.tsx
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { ApiError } from "@/api/client";
 import { patchConfig } from "@/api/config";
 import type { ConfigResponse } from "@/api/types";
 import { LlmProviderSection } from "@/components/settings/LlmProviderSection";
@@ -186,6 +187,28 @@ describe("LlmProviderSection", () => {
     await user.click(screen.getByRole("button", { name: /save llm config/i }));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(/failed to save llm config/i);
+  });
+
+  it("surfaces the server's own rejection detail (#2187 allow-list)", async () => {
+    // The 400 body names the field, the allowed set, and where to widen
+    // it. A generic phrase would strand the operator on a form that just
+    // says "failed" after typing a plausible model name.
+    mockedPatchConfig.mockRejectedValue(
+      new ApiError(
+        400,
+        "llm_model_writer='mistral-small:latest' is not in the local-model allow-list ['qwen3:14b']",
+      ),
+    );
+    const user = userEvent.setup();
+    renderSection();
+
+    const writerInput = screen.getByDisplayValue("qwen3:14b");
+    await user.clear(writerInput);
+    await user.type(writerInput, "mistral-small:latest");
+    await user.type(screen.getByPlaceholderText("Why are you changing this?"), "try a bigger model");
+    await user.click(screen.getByRole("button", { name: /save llm config/i }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/not in the local-model allow-list/i);
   });
 
   it("blocks save when no operator is authenticated (#1992)", () => {

--- a/frontend/src/components/settings/LlmProviderSection.tsx
+++ b/frontend/src/components/settings/LlmProviderSection.tsx
@@ -14,6 +14,7 @@
 import { useState } from "react";
 import type { FormEvent } from "react";
 
+import { ApiError } from "@/api/client";
 import { patchConfig } from "@/api/config";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { useConfig } from "@/lib/ConfigContext";
@@ -39,7 +40,13 @@ export function LlmProviderSection(): JSX.Element {
   const [reason, setReason] = useState("");
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
-  const [error, setError] = useState(false);
+  // The server's own `detail`, not a generic phrase (OrderEntryModal
+  // pattern). #2187 made rejection an ordinary operator path — a model
+  // outside LOCAL_LLM_MODEL_ALLOWLIST is a plausible thing to type, and
+  // the 400 body names the offending field, the allowed set, and where
+  // to widen it. Dropping that into the console only would leave the
+  // operator staring at a form that just says "failed".
+  const [error, setError] = useState<string | null>(null);
 
   const runtime = config.data?.runtime ?? null;
   const displayedProvider = provider ?? runtime?.llm_provider ?? "openai_compatible";
@@ -55,7 +62,7 @@ export function LlmProviderSection(): JSX.Element {
     e.preventDefault();
     if (operatorName === null) return;
     setSaving(true);
-    setError(false);
+    setError(null);
     setSuccess(false);
     try {
       // Only send fields that actually changed — the backend rejects
@@ -77,7 +84,11 @@ export function LlmProviderSection(): JSX.Element {
       config.refetch();
     } catch (err: unknown) {
       console.error("Failed to update LLM provider config", err);
-      setError(true);
+      setError(
+        err instanceof ApiError
+          ? err.message
+          : "Failed to save LLM config. Check the browser console for details.",
+      );
     } finally {
       setSaving(false);
     }
@@ -202,12 +213,12 @@ export function LlmProviderSection(): JSX.Element {
                 LLM provider config updated.
               </p>
             )}
-            {error && (
+            {error !== null && (
               <p
                 role="alert"
                 className="rounded bg-red-50 dark:bg-red-950/40 px-2 py-1.5 text-xs text-red-700 dark:text-red-300"
               >
-                Failed to save LLM config. Check the browser console for details.
+                {error}
               </p>
             )}
           </form>

--- a/scripts/autonomy/README.md
+++ b/scripts/autonomy/README.md
@@ -29,11 +29,31 @@ launchctl list | grep jobs-daemon                       # confirm loaded
 tail -f var/autonomy-logs/launchd.jobs-daemon.err.log   # scheduler ticks (stderr)
 ```
 
+Restart (after a jobs/parser merge, or any time you want a clean boot):
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.ebull.jobs-daemon"
+```
+
 Stop:
 
 ```bash
 launchctl unload ~/Library/LaunchAgents/com.ebull.jobs-daemon.plist
 ```
+
+## Exactly one launcher (#2187)
+
+This agent is the only thing that may start the jobs daemon. The VS Code
+`stack: jobs` task no longer launches its own supervisor — it runs the
+`kickstart` above and tails the agent's log, so closing that panel does not
+stop the daemon.
+
+Why it matters: when both launched a daemon, the task `kill -9`-ed both process
+patterns and started `app.jobs.dev_reload`, `KeepAlive` respawned this agent
+inside `ThrottleInterval`, and whichever lost the PG advisory-lock race stayed
+lost — `dev_reload`'s supervisor only respawns its child on a `*.py` change, not
+on a tick, so it parked at ~19 MB forever. Both processes looked healthy while
+the auto-reload-on-merge from #2144 was silently dead for weeks.
 
 Safe to run this daemon WITHOUT the AI loop and with the kill switch ON — the
 kill switch gates only the trade jobs (`morning_candidate_review`,

--- a/scripts/autonomy/com.ebull.jobs-daemon.plist
+++ b/scripts/autonomy/com.ebull.jobs-daemon.plist
@@ -15,8 +15,18 @@
   (for `uv`) + HOME (uv cache) are injected. The daemon's own PG advisory lock
   prevents a duplicate if a manual daemon is still running — stop that first.
 
+  THERE MUST BE EXACTLY ONE LAUNCHER, AND IT IS THIS AGENT (#2187). The VS Code
+  `stack: jobs` task used to start its own supervisor after `kill -9`-ing both
+  process patterns; KeepAlive then respawned this agent inside ThrottleInterval
+  and won the advisory-lock race, so the task's `dev_reload` child FATAL-exited
+  and its supervisor parked forever (it only respawns on a `*.py` change, never
+  on a tick). Net effect: #2144's auto-reload-on-merge was dead in practice
+  while both processes looked healthy. That task now runs
+  `launchctl kickstart -k gui/$UID/com.ebull.jobs-daemon` instead — use the same
+  command by hand to restart the daemon.
+
   Install: substitute __REPO__ with the repo root, copy to
-  ~/Library/LaunchAgents/, `launchctl load` it. See scripts/autonomy/setup.md.
+  ~/Library/LaunchAgents/, `launchctl load` it. See scripts/autonomy/README.md.
 -->
 <plist version="1.0">
 <dict>

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -22,6 +22,7 @@ from app.services.llm_client import (
     OpenAICompatProvider,
     make_llm_clients,
     normalize_completion_text,
+    release_local_models,
     strip_code_fence,
     strip_think_block,
 )
@@ -188,6 +189,76 @@ class TestOpenAICompatProvider:
 
 
 # ---------------------------------------------------------------------------
+# Model release (#2187)
+# ---------------------------------------------------------------------------
+
+_OLLAMA_ROOT = "http://localhost:11434"
+
+
+class TestReleaseModel:
+    @respx.mock
+    def test_local_model_unloaded_at_server_root(self) -> None:
+        # The unload route is Ollama-native and lives at the ROOT, not
+        # under /v1 — a request to {base_url}/api/generate would 404.
+        route = respx.post(f"{_OLLAMA_ROOT}/api/generate").mock(
+            return_value=httpx.Response(200, json={"done_reason": "unload"})
+        )
+        OpenAICompatProvider(base_url=_BASE_URL, model="qwen3:14b").release_model()
+
+        assert route.called
+        assert json.loads(route.calls.last.request.content) == {"model": "qwen3:14b", "keep_alive": 0}
+
+    @respx.mock
+    def test_remote_endpoint_is_never_unloaded(self) -> None:
+        # Someone else's RAM, someone else's lifecycle: no call at all.
+        route = respx.post("https://llm.example.com/api/generate")
+        OpenAICompatProvider(base_url="https://llm.example.com/v1", model="qwen3:14b").release_model()
+        assert not route.called
+
+    @respx.mock
+    def test_failure_is_swallowed(self) -> None:
+        # Best-effort by contract: a failed release costs memory, never
+        # the batch that just succeeded.
+        respx.post(f"{_OLLAMA_ROOT}/api/generate").mock(return_value=httpx.Response(500, text="boom"))
+        OpenAICompatProvider(base_url=_BASE_URL, model="qwen3:14b").release_model()
+
+    @respx.mock
+    def test_transport_error_is_swallowed(self) -> None:
+        respx.post(f"{_OLLAMA_ROOT}/api/generate").mock(side_effect=httpx.ConnectError("down"))
+        OpenAICompatProvider(base_url=_BASE_URL, model="qwen3:14b").release_model()
+
+    def test_anthropic_release_is_a_noop(self) -> None:
+        sdk = MagicMock()
+        AnthropicProvider(sdk, model="claude-sonnet-4-6").release_model()
+        assert sdk.mock_calls == []
+
+    @respx.mock
+    def test_pair_with_shared_model_releases_once(self) -> None:
+        route = respx.post(f"{_OLLAMA_ROOT}/api/generate").mock(
+            return_value=httpx.Response(200, json={"done_reason": "unload"})
+        )
+        release_local_models(make_llm_clients(_config_conn(provider="openai_compatible")))
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_pair_with_split_models_releases_each(self) -> None:
+        route = respx.post(f"{_OLLAMA_ROOT}/api/generate").mock(
+            return_value=httpx.Response(200, json={"done_reason": "unload"})
+        )
+        clients = make_llm_clients(
+            _config_conn(
+                provider="openai_compatible",
+                writer_model="deepseek-r1:14b",
+                critic_model="qwen3:14b",
+            )
+        )
+        release_local_models(clients)
+        assert route.call_count == 2
+        released = {json.loads(c.request.content)["model"] for c in route.calls}
+        assert released == {"deepseek-r1:14b", "qwen3:14b"}
+
+
+# ---------------------------------------------------------------------------
 # AnthropicProvider
 # ---------------------------------------------------------------------------
 
@@ -288,6 +359,32 @@ class TestMakeLLMClients:
         )
         assert clients.writer.model == "deepseek-r1:14b"
         assert clients.critic.model == "qwen3:14b"
+
+    def test_local_model_outside_allowlist_rejected(self) -> None:
+        # #2187: /config rejects this, but a direct SQL write could still
+        # leave it in the row — the load site must fail closed too, as
+        # LLMProviderNotConfigured so thesis_refresh records a PREREQ_SKIP.
+        conn = _config_conn(provider="openai_compatible", writer_model="mistral-small:latest")
+        with pytest.raises(LLMProviderNotConfigured, match="allow-list"):
+            make_llm_clients(conn)
+
+    def test_critic_model_outside_allowlist_rejected(self) -> None:
+        conn = _config_conn(provider="openai_compatible", critic_model="mistral-small:latest")
+        with pytest.raises(LLMProviderNotConfigured, match="llm_model_critic"):
+            make_llm_clients(conn)
+
+    def test_remote_endpoint_exempt_from_allowlist(self) -> None:
+        # Not our RAM — an arbitrary model name on a remote vLLM/OpenAI
+        # endpoint must not be blocked by a local-memory rule.
+        clients = make_llm_clients(
+            _config_conn(
+                provider="openai_compatible",
+                base_url="https://llm.example.com/v1",
+                writer_model="some-huge-remote-model",
+                critic_model="some-huge-remote-model",
+            )
+        )
+        assert clients.writer.model == "some-huge-remote-model"
 
     def test_anthropic_path_requires_key(self) -> None:
         conn = _config_conn(provider="anthropic", writer_model="claude-sonnet-4-6")

--- a/tests/test_llm_eval_thesis.py
+++ b/tests/test_llm_eval_thesis.py
@@ -68,6 +68,10 @@ class FakeClient:
     def __init__(self, script: list[LLMCompletion | Exception]) -> None:
         self._script = list(script)
         self.calls = 0
+        self.releases = 0
+
+    def release_model(self) -> None:
+        self.releases += 1
 
     def complete(self, *, system: str, user: str, max_tokens: int) -> LLMCompletion:
         self.calls += 1

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -377,6 +377,11 @@ class TestIsLocalLlmEndpoint:
             "http://LOCALHOST:11434/v1",
             "http://[::1]:11434/v1",
             "http://0.0.0.0:11434/v1",
+            # Loopback spellings a string set would silently miss, each
+            # one a bypass of the allow-list (Codex ckpt-2).
+            "http://127.1:11434/v1",
+            "http://2130706433:11434/v1",
+            "http://127.0.0.53:11434/v1",
         ],
     )
     def test_local_hosts(self, base_url: str) -> None:

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -23,6 +23,8 @@ from app.services.runtime_config import (
     RuntimeConfigCorrupt,
     RuntimeConfigNoOp,
     get_runtime_config,
+    is_local_llm_endpoint,
+    local_llm_model_violation,
     update_runtime_config,
     write_kill_switch_audit,
 )
@@ -249,6 +251,9 @@ class TestUpdateRuntimeConfig:
 
     def test_llm_split_knobs_audit_independently(self) -> None:
         # #1995: writer and critic changed together → one audit row EACH.
+        # Both models must be in LOCAL_LLM_MODEL_ALLOWLIST (#2187) — _row()
+        # points at localhost, so a fictional tag would now be rejected
+        # before the audit path this test is about.
         conn = _make_conn(
             [
                 _make_cursor([_row()]),
@@ -260,11 +265,11 @@ class TestUpdateRuntimeConfig:
             updated_by="op",
             reason="deepseek writer, qwen critic",
             llm_model_writer="deepseek-r1:14b",
-            llm_model_critic="qwen3:14b-q8",
+            llm_model_critic="qwen3:8b",
             now=_NOW,
         )
         assert updated.llm_model_writer == "deepseek-r1:14b"
-        assert updated.llm_model_critic == "qwen3:14b-q8"
+        assert updated.llm_model_critic == "qwen3:8b"
 
         fields = {c[0][1]["field"] for c in conn.execute.call_args_list}
         assert fields == {"llm_model_writer", "llm_model_critic"}
@@ -356,3 +361,108 @@ class TestWriteKillSwitchAudit:
         params = conn.execute.call_args[0][1]
         assert params["old"] is None
         assert params["new"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# Local-model allow-list (#2187)
+# ---------------------------------------------------------------------------
+
+
+class TestIsLocalLlmEndpoint:
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "http://localhost:11434/v1",
+            "http://127.0.0.1:11434/v1",
+            "http://LOCALHOST:11434/v1",
+            "http://[::1]:11434/v1",
+            "http://0.0.0.0:11434/v1",
+        ],
+    )
+    def test_local_hosts(self, base_url: str) -> None:
+        assert is_local_llm_endpoint(base_url) is True
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            "https://api.openai.com/v1",
+            "http://192.168.1.20:8000/v1",
+            "http://llm.internal:11434/v1",
+            # A host that merely CONTAINS "localhost" is remote.
+            "https://localhost.example.com/v1",
+            "",
+        ],
+    )
+    def test_remote_or_unparseable_hosts(self, base_url: str) -> None:
+        assert is_local_llm_endpoint(base_url) is False
+
+
+class TestLocalLlmModelViolation:
+    _LOCAL = "http://localhost:11434/v1"
+
+    def test_allow_listed_local_model_passes(self) -> None:
+        assert (
+            local_llm_model_violation(
+                provider="openai_compatible", base_url=self._LOCAL, model="qwen3:14b", field="llm_model_writer"
+            )
+            is None
+        )
+
+    def test_oversized_local_model_rejected(self) -> None:
+        violation = local_llm_model_violation(
+            provider="openai_compatible",
+            base_url=self._LOCAL,
+            model="mistral-small:latest",
+            field="llm_model_writer",
+        )
+        assert violation is not None
+        assert "llm_model_writer" in violation
+        assert "mistral-small:latest" in violation
+
+    def test_quantization_variant_is_not_admitted_by_family(self) -> None:
+        # The whole point of exact matching: qwen3:14b is Q4_K_M at
+        # ~9.3 GB, a q8_0 sibling is ~15 GB. A prefix/family match would
+        # wave through the blob this list exists to exclude.
+        assert (
+            local_llm_model_violation(
+                provider="openai_compatible", base_url=self._LOCAL, model="qwen3:14b-q8_0", field="llm_model_writer"
+            )
+            is not None
+        )
+
+    def test_remote_endpoint_exempt(self) -> None:
+        assert (
+            local_llm_model_violation(
+                provider="openai_compatible",
+                base_url="https://llm.example.com/v1",
+                model="anything-at-all",
+                field="llm_model_writer",
+            )
+            is None
+        )
+
+    def test_anthropic_provider_exempt(self) -> None:
+        # Cloud model; base_url is irrelevant on that path and nothing is
+        # resident locally.
+        assert (
+            local_llm_model_violation(
+                provider="anthropic", base_url=self._LOCAL, model="claude-sonnet-4-6", field="llm_model_critic"
+            )
+            is None
+        )
+
+
+class TestUpdateRuntimeConfigAllowlist:
+    def test_patching_to_oversized_local_model_rejected(self) -> None:
+        conn = _make_conn([_make_cursor([_row()])])
+        with pytest.raises(ValueError, match="allow-list"):
+            update_runtime_config(conn, updated_by="op", reason="r", llm_model_writer="mistral-small:latest", now=_NOW)
+
+    def test_moving_base_url_to_localhost_rechecks_unchanged_models(self) -> None:
+        # The resulting-triple rule: only llm_base_url is patched, but it
+        # newly subjects the untouched model columns to the local rule.
+        conn = _make_conn(
+            [_make_cursor([_row(llm_base_url="https://llm.example.com/v1", llm_model_writer="some-huge-remote-model")])]
+        )
+        with pytest.raises(ValueError, match="allow-list"):
+            update_runtime_config(conn, updated_by="op", reason="r", llm_base_url="http://localhost:11434/v1", now=_NOW)

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -223,6 +223,10 @@ class _FakeLLMClient:
     def __init__(self, completions: list[LLMCompletion | Exception]) -> None:
         self._completions = list(completions)
         self.calls: list[dict[str, object]] = []
+        self.releases = 0
+
+    def release_model(self) -> None:
+        self.releases += 1
 
     def complete(self, *, system: str, user: str, max_tokens: int) -> LLMCompletion:
         self.calls.append({"system": system, "user": user, "max_tokens": max_tokens})

--- a/tests/test_thesis_refresh_lock.py
+++ b/tests/test_thesis_refresh_lock.py
@@ -178,6 +178,23 @@ def test_empty_batch_does_not_release(mocked_env) -> None:  # type: ignore[no-un
     mocked_env["release"].assert_not_called()
 
 
+def test_all_locked_batch_does_not_release(mocked_env) -> None:  # type: ignore[no-untyped-def]
+    """Codex ckpt-2: a NON-empty batch that is entirely
+    LOCKED_BY_SIBLING never loads a model here — and the sibling holding
+    those locks is plausibly mid-generation with the same local model, so
+    releasing would de-warm someone else's work."""
+
+    @contextmanager
+    def fake_lock(conn, iid):  # type: ignore[no-untyped-def]
+        yield False  # sibling holds every one
+
+    with patch.object(scheduler, "instrument_lock", fake_lock):
+        scheduler.thesis_refresh()
+
+    mocked_env["generate_thesis"].assert_not_called()
+    mocked_env["release"].assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _select_thesis_batch — pure scope/batch selection (spec §6)
 # ---------------------------------------------------------------------------

--- a/tests/test_thesis_refresh_lock.py
+++ b/tests/test_thesis_refresh_lock.py
@@ -41,6 +41,7 @@ def mocked_env():  # type: ignore[no-untyped-def]
         patch.object(scheduler, "psycopg") as psycopg_mod,
         patch.object(scheduler, "connect_job") as connect_job_mock,
         patch.object(scheduler, "generate_thesis") as gen,
+        patch.object(scheduler, "release_local_models") as release,
         patch.object(scheduler, "report_progress"),
     ):
         tracker = MagicMock()
@@ -73,6 +74,8 @@ def mocked_env():  # type: ignore[no-untyped-def]
             "tracked_cm": tracked_cm,
             "make_client": make_client,
             "prereq_skip": prereq_skip,
+            "release": release,
+            "candidates": candidates_mock,
         }
 
 
@@ -127,6 +130,52 @@ def test_provider_unresolvable_prereq_skips_before_tracked_job(mocked_env) -> No
     assert mocked_env["prereq_skip"].call_args.args[0] == scheduler.JOB_THESIS_REFRESH
     mocked_env["tracked_cm"].assert_not_called()
     mocked_env["generate_thesis"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Local-model release after the batch (#2187)
+# ---------------------------------------------------------------------------
+
+
+def test_batch_releases_local_model_when_done(mocked_env) -> None:  # type: ignore[no-untyped-def]
+    """#2187: the model stays warm across the batch, then is released —
+    otherwise qwen3:14b sits 9.77 GB wired for the ~33 idle min/hour."""
+
+    @contextmanager
+    def fake_lock(conn, iid):  # type: ignore[no-untyped-def]
+        yield True
+
+    with patch.object(scheduler, "instrument_lock", fake_lock):
+        scheduler.thesis_refresh()
+
+    mocked_env["release"].assert_called_once_with(mocked_env["make_client"].return_value)
+
+
+def test_batch_releases_local_model_when_a_generation_raises(mocked_env) -> None:  # type: ignore[no-untyped-def]
+    """A failed batch is exactly when the weights would otherwise stay
+    resident until the next hourly fire — release runs in ``finally``."""
+    mocked_env["generate_thesis"].side_effect = RuntimeError("decode blew up")
+
+    @contextmanager
+    def fake_lock(conn, iid):  # type: ignore[no-untyped-def]
+        yield True
+
+    with patch.object(scheduler, "instrument_lock", fake_lock):
+        scheduler.thesis_refresh()
+
+    assert mocked_env["tracker"].row_count == 0
+    mocked_env["release"].assert_called_once()
+
+
+def test_empty_batch_does_not_release(mocked_env) -> None:  # type: ignore[no-untyped-def]
+    """Nothing was loaded, so nothing is unloaded — on a shared box an
+    unconditional release would evict another consumer's model."""
+    mocked_env["candidates"].return_value = []
+
+    scheduler.thesis_refresh()
+
+    mocked_env["generate_thesis"].assert_not_called()
+    mocked_env["release"].assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two independent fixes for #2187, both scoped by the measurement recorded on-issue.

**(a) Exactly one launcher for the jobs daemon.** `.vscode/tasks.json` `stack: jobs` no longer `kill -9`s both process patterns and starts its own supervisor. It now runs `launchctl kickstart -k gui/$(id -u)/com.ebull.jobs-daemon` and tails the agent's log, falling back to a local supervisor only when the agent is not installed (so non-launchd boxes still work). Linux/Windows unchanged.

**(b) Release the model after each batch, and cap what may load.**
- `OpenAICompatProvider.release_model()` unloads via Ollama's native `POST {root}/api/generate {"keep_alive": 0}`.
- `release_local_models()` runs once per `thesis_refresh` batch in a `finally`, gated on `load_attempted`.
- `LOCAL_LLM_MODEL_ALLOWLIST` gates models loaded into local memory, enforced at the `/config` PATCH **and** at the load site.
- `LlmProviderSection` renders the server's own 400 detail instead of a generic phrase.

## Why the obvious fixes don't work

The issue was diagnosed twice from a premise that measurement then falsified (12h `keep_alive`; then a duplicate daemon double-polling). Neither survived. The real mechanism needs no bug:

`thesis_refresh` is hourly with ≤5 generations at ≈260s each (`app/workers/scheduler.py` `JOB_THESIS_REFRESH`), so **qwen3:14b is resident ~27 of every 60 minutes, 24/7, by design** — as WIRED unified memory on Apple silicon, which cannot be paged out. Two consequences:

- **`OLLAMA_KEEP_ALIVE` is near a no-op.** Every request refreshes the rolling timer, so the TTL only ever governs the tail after the *last* call. It cannot touch the 22-minute run.
- **`keep_alive` in the request body does nothing.** It is not an OpenAI field; we post to `/v1/chat/completions`, where Ollama ignores it. The unload route is native and lives at the server **root**, not under `/v1` — hence a separate call, not a request parameter.

## Design decisions a reviewer will want justified

**Release once per batch, not per call.** The model must stay warm across the ≤5 back-to-back generations (a reload costs seconds each); it must not stay warm for the ~33 idle minutes that follow. The `finally` covers a batch that dies mid-way — precisely when the weights would otherwise sit until the next hourly fire.

**Release is gated on `load_attempted`, set immediately before `generate_thesis` — the only call that can pull a model into memory.** A non-empty batch is not sufficient: a batch that is entirely `LOCKED_BY_SIBLING` never generates here, and the sibling holding those locks is plausibly mid-generation with the same model on this shared box. (Codex ckpt-2 finding.)

**The manual thesis path (`app/api/theses.py`) deliberately does NOT release.** It is self-limiting — one generation, then Ollama's default 5m timer expires because nothing refreshes it. The job path is not self-limiting, which is the entire bug.

**Allow-list match is exact, tag included.** An Ollama tag carries the quantization and quantization dominates resident size: `qwen3:14b` is Q4_K_M at 9.28 GB, a `qwen3:14b-q8_0` sibling is ~15 GB. A family/prefix match would admit the exact class of blob the list exists to exclude (`mistral-small:latest`, 14.33 GB, is the one pulled on this box).

**Enforced at two sites with two exception types.** `/config` PATCH raises `ValueError` → 400; `make_llm_clients` raises `LLMProviderNotConfigured` → the existing PREREQ_SKIP row, so a bad config row is a visible skip rather than an hourly crash loop. One shared predicate (`local_llm_model_violation`) holds the rule so the two sites cannot diverge. The load-site check is not redundant: a direct SQL write bypasses the API entirely.

**Validated on the RESULTING triple, not the provided fields.** A PATCH that only moves `llm_base_url` from a remote box to localhost newly subjects the *unchanged* model columns to the local-memory rule. Checking only what the caller passed would let that through. Test: `test_moving_base_url_to_localhost_rechecks_unchanged_models`.

**Loopback is classified numerically, not by string match.** A literal set silently missed `127.1`, `2130706433`, and the rest of 127.0.0.0/8 — each miss a bypass of the allow-list *and* a skipped release for a model still in local RAM. `socket.inet_aton` does the IPv4 pass because it accepts shorthand and integer forms `ipaddress` rejects, and it parses numerically without any DNS lookup (verified empirically). (Codex ckpt-2 finding.)

**Documented fail-open:** a named host other than `localhost` that resolves to this machine (`mymac.local`) reads as remote. Resolving it would put DNS in a config-validation path. The rule targets drift on the local-first default, not a determined operator.

**Remote endpoints and the Anthropic path are exempt from both controls** — not our RAM, and no unload route we own.

## Security model

No new external surface. The allow-list is a **code constant, not config**, deliberately: it guards against config drift, so it must not be settable through the surface it protects. `/config` PATCH remains behind the existing `require_session_or_service_token` gate; nothing about auth changes. The release call is outbound to a loopback address only, never to a remote host, and is best-effort — a failure costs memory, never correctness or a completed batch. No secrets move: keys stay env-only (`runtime_config_audit` stores old/new values in plaintext, which is why they never enter this table).

Files outside the diff that matter: `scripts/check_llm_chokepoint.sh` bans `chat/completions` outside `llm_client.py`; the new release call uses `/api/generate` and lives in that same module, so the chokepoint invariant is intact.

## Verification

Against live ollama + dev DB at `48caa6a9`:

```
1. before:                     []
2. real completion:            finish=stop model=llama3.1:8b text='{"ok": 1}'
3. resident after completion:  ['llama3.1:8b']
4. resident after release:     []
```

Ollama RSS 9.28 GB → 0.05 GB after release. Unload is asynchronous (`/api/ps` still lists the model on the next call with `expires_at == now`), which is why the check sleeps.

Live `/config` PATCH, service-token auth:

| PATCH | Result |
|---|---|
| `llm_model_writer=mistral-small:latest` | **400** with the field, the allowed set, and where to widen it |
| `llm_model_writer=qwen3:14b-q8_0` | **400**, same |
| row after both | unchanged (`qwen3:14b` / `qwen3:14b`) — rejected before the UPDATE |

Allow-list predicate against the real constant: `llama3.1:8b` ALLOWED, `qwen3:14b` ALLOWED, `mistral-small:latest` REJECTED, `qwen3:14b-q8_0` REJECTED.

Gates: `ruff check` / `ruff format --check` / `pyright` (0 errors) / `pytest -m "not db"` (753 files, exit 0) / `pytest tests/smoke` (exit 0) / `pnpm typecheck` / `pnpm test:unit` (1476 passed) / dark, pills, charts gates all clean. Codex ckpt-2 run three times; the first two findings are fixed above, the third pass is clean.

## Conscious tradeoffs

- Widening the allow-list needs a code edit + review, not a config change. That is the point, but it is friction — the 400 body names the constant and the file so the path is obvious.
- The `stack: jobs` fallback branch can still start a second supervisor on a box with no launchd agent installed. There, no duplicate is possible, so the fallback is safe.
- `launchd.jobs-daemon.err.log` is ~50 MB and unrotated (noted on-issue). Out of scope here; log rotation is a separate concern from the memory fix.

## Prevention log

Two entries: *"Two supervisors for one singleton: the loser parks forever and its feature dies silently"* and *"A resident local-LLM model is a standing memory cost, not a per-call one"*.

## Settled decisions / prevention log applicability

No entry in `docs/settled-decisions.md` governs LLM model selection or process supervision — the Thesis-semantics section covers versioning, freshness, prompt budget and the mandatory critic call, none of which this touches (thesis output is byte-identical; only when the weights are evicted changes). Relevant existing prevention-log entries applied: the best-effort-contract rule (a best-effort hook must isolate its own failures and never be load-bearing) and the allow-list discipline entry (an allow-list a rejection keys on must cover every naming convention the path accepts — addressed by exact-tag matching plus the numeric loopback classification).

Closes #2187
