### PR TITLE
fix(#2180): re-derive the six uncapped report snapshots in place, and guard snapshot size at the write

### DIFF
--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -919,49 +919,36 @@ def _compute_contributors(
     return {"contributors": contributors, "drags": drags}
 
 
-# How many snapshots of each type survive a write (#2180). `report_snapshots`
-# had NO retention at all — `grep -riE 'delete|retention|sweep|prune'` over the
-# table's callers returned nothing — so every row ever written was permanent,
-# and the six pre-#2178 uncapped rows (7.62 MB of a 7.63 MB table) would have
-# sat there forever.
+# Ceiling on one serialized snapshot (#2180).
 #
-# Counts, not an age cutoff: `app/api/reports.py` serves `ORDER BY period_start
-# DESC` with `limit` up to 100, so a count bound is what actually bounds the
-# worst-case response, and it degrades predictably if a cadence ever changes.
-# ~1 year of weeklies and ~2 years of monthlies is well past the `limit=100`
-# ceiling any caller can ask for, so retention can never truncate a served page.
-_SNAPSHOT_RETENTION: dict[str, int] = {"weekly": 52, "monthly": 24}
+# ROW-COUNT RETENTION IS DELIBERATELY *NOT* THE GUARD HERE, and must not be
+# added later: `_prior_v2_chain` selects EVERY prior v2 snapshot with no LIMIT,
+# and `_cover_and_performance` chain-links those returns into `si_return` and
+# takes `si_start` from `chained_rows[0]`. Deleting the oldest rows would
+# silently move the inception date forward — since-inception would quietly
+# become since-the-retention-window, and the risk section's drawdown index
+# would truncate with it. The history is load-bearing, so it stays.
+#
+# What actually caused #2180's 7.62 MB was not row COUNT but row SIZE: six
+# pre-#2178 rows each carrying the full run × instrument product (up to 14,473
+# elements). With every list field capped, a snapshot is ~3-4 KB and 52 weeklies
+# a year cost ~170 KB — growth that needs no pruning at all. So the durable
+# guard is a size assertion at the write, which catches the NEXT builder that
+# ships an uncapped field on its first run instead of after it has accumulated
+# silently for months.
+#
+# 64 KiB is ~16x the largest legitimate snapshot observed and well under the
+# smallest uncapped one (88 KB) — wide enough that ordinary content growth
+# never trips it, tight enough that an uncapped collection always does.
+_MAX_SNAPSHOT_BYTES = 64 * 1024
 
 
-def prune_report_snapshots(conn: psycopg.Connection[Any], *, report_type: str) -> int:
-    """Drop all but the most recent N snapshots of ``report_type`` (#2180).
-
-    Returns the number of rows deleted. Keyed on ``period_start DESC`` — the
-    same order the API serves — so what is dropped is always the oldest tail,
-    never a row a caller could still page to.
-
-    A ``report_type`` with no configured retention is left ALONE rather than
-    defaulted to some number: silently pruning a type nobody sized is how a
-    retention sweep turns into data loss. The caller owns the commit.
-    """
-    keep = _SNAPSHOT_RETENTION.get(report_type)
-    if keep is None:
-        return 0
-    with conn.cursor() as cur:
-        cur.execute(
-            """
-            DELETE FROM report_snapshots
-            WHERE snapshot_id IN (
-                SELECT snapshot_id
-                FROM report_snapshots
-                WHERE report_type = %(report_type)s
-                ORDER BY period_start DESC
-                OFFSET %(keep)s
-            )
-            """,
-            {"report_type": report_type, "keep": keep},
-        )
-        return cur.rowcount
+class ReportSnapshotTooLarge(ValueError):
+    """A snapshot exceeded ``_MAX_SNAPSHOT_BYTES`` — almost always an uncapped
+    list field (#2180 / #2178). Raised rather than warned: eBull does not
+    silently bypass a failed check, and a loud job failure is strictly better
+    than a megabyte-scale leak that only surfaces months later in an API
+    response."""
 
 
 def persist_report_snapshot(
@@ -972,15 +959,33 @@ def persist_report_snapshot(
     period_end: date,
     snapshot: dict[str, Any],
 ) -> None:
-    """Upsert a report snapshot into report_snapshots, then prune the tail.
+    """Upsert a report snapshot into report_snapshots.
 
     Idempotent: ON CONFLICT replaces the snapshot for the same
     (report_type, period_start) pair. The caller owns the commit.
 
-    Pruning runs here rather than as a separate job (#2180): the only way
-    this table grows is a write, so retention enforced at the write is
-    exact and needs no new scheduled surface to drift out of sync.
+    Raises ``ReportSnapshotTooLarge`` before writing when the serialized
+    snapshot exceeds ``_MAX_SNAPSHOT_BYTES`` (#2180) — the check sits here
+    because a write is the only way this table grows, so it catches every
+    producer without a scheduled sweep that could drift out of sync.
     """
+    encoded = json.dumps(snapshot, default=str)
+    if len(encoded.encode("utf-8")) > _MAX_SNAPSHOT_BYTES:
+        # Name the biggest collection: an uncapped list is the cause every
+        # time this has fired, and the operator needs to know WHICH one.
+        biggest = max(
+            ((k, len(v)) for k, v in snapshot.items() if isinstance(v, list)),
+            key=lambda kv: kv[1],
+            default=("<no list field>", 0),
+        )
+        raise ReportSnapshotTooLarge(
+            f"{report_type} snapshot for {period_start} is "
+            f"{len(encoded.encode('utf-8')):,} bytes, over the "
+            f"{_MAX_SNAPSHOT_BYTES:,}-byte cap. Largest list field: "
+            f"{biggest[0]!r} with {biggest[1]:,} elements — cap it to a "
+            f"top-N exhibit and carry the pre-cap count alongside "
+            f"(the #2178 shape)."
+        )
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -998,9 +1003,6 @@ def persist_report_snapshot(
                 "snapshot": Jsonb(snapshot),
             },
         )
-    pruned = prune_report_snapshots(conn, report_type=report_type)
-    if pruned:
-        logger.info("report_snapshots: pruned %d %s snapshot(s) past retention", pruned, report_type)
 
 
 def load_report_snapshots(

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -969,8 +969,8 @@ def persist_report_snapshot(
     because a write is the only way this table grows, so it catches every
     producer without a scheduled sweep that could drift out of sync.
     """
-    encoded = json.dumps(snapshot, default=str)
-    if len(encoded.encode("utf-8")) > _MAX_SNAPSHOT_BYTES:
+    encoded_bytes = len(json.dumps(snapshot, default=str).encode("utf-8"))
+    if encoded_bytes > _MAX_SNAPSHOT_BYTES:
         # Name the biggest collection: an uncapped list is the cause every
         # time this has fired, and the operator needs to know WHICH one.
         biggest = max(
@@ -980,7 +980,7 @@ def persist_report_snapshot(
         )
         raise ReportSnapshotTooLarge(
             f"{report_type} snapshot for {period_start} is "
-            f"{len(encoded.encode('utf-8')):,} bytes, over the "
+            f"{encoded_bytes:,} bytes, over the "
             f"{_MAX_SNAPSHOT_BYTES:,}-byte cap. Largest list field: "
             f"{biggest[0]!r} with {biggest[1]:,} elements — cap it to a "
             f"top-N exhibit and carry the pre-cap count alongside "

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -919,6 +919,51 @@ def _compute_contributors(
     return {"contributors": contributors, "drags": drags}
 
 
+# How many snapshots of each type survive a write (#2180). `report_snapshots`
+# had NO retention at all — `grep -riE 'delete|retention|sweep|prune'` over the
+# table's callers returned nothing — so every row ever written was permanent,
+# and the six pre-#2178 uncapped rows (7.62 MB of a 7.63 MB table) would have
+# sat there forever.
+#
+# Counts, not an age cutoff: `app/api/reports.py` serves `ORDER BY period_start
+# DESC` with `limit` up to 100, so a count bound is what actually bounds the
+# worst-case response, and it degrades predictably if a cadence ever changes.
+# ~1 year of weeklies and ~2 years of monthlies is well past the `limit=100`
+# ceiling any caller can ask for, so retention can never truncate a served page.
+_SNAPSHOT_RETENTION: dict[str, int] = {"weekly": 52, "monthly": 24}
+
+
+def prune_report_snapshots(conn: psycopg.Connection[Any], *, report_type: str) -> int:
+    """Drop all but the most recent N snapshots of ``report_type`` (#2180).
+
+    Returns the number of rows deleted. Keyed on ``period_start DESC`` — the
+    same order the API serves — so what is dropped is always the oldest tail,
+    never a row a caller could still page to.
+
+    A ``report_type`` with no configured retention is left ALONE rather than
+    defaulted to some number: silently pruning a type nobody sized is how a
+    retention sweep turns into data loss. The caller owns the commit.
+    """
+    keep = _SNAPSHOT_RETENTION.get(report_type)
+    if keep is None:
+        return 0
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            DELETE FROM report_snapshots
+            WHERE snapshot_id IN (
+                SELECT snapshot_id
+                FROM report_snapshots
+                WHERE report_type = %(report_type)s
+                ORDER BY period_start DESC
+                OFFSET %(keep)s
+            )
+            """,
+            {"report_type": report_type, "keep": keep},
+        )
+        return cur.rowcount
+
+
 def persist_report_snapshot(
     conn: psycopg.Connection[Any],
     *,
@@ -927,10 +972,14 @@ def persist_report_snapshot(
     period_end: date,
     snapshot: dict[str, Any],
 ) -> None:
-    """Upsert a report snapshot into report_snapshots.
+    """Upsert a report snapshot into report_snapshots, then prune the tail.
 
     Idempotent: ON CONFLICT replaces the snapshot for the same
     (report_type, period_start) pair. The caller owns the commit.
+
+    Pruning runs here rather than as a separate job (#2180): the only way
+    this table grows is a write, so retention enforced at the write is
+    exact and needs no new scheduled surface to drift out of sync.
     """
     with conn.cursor() as cur:
         cur.execute(
@@ -949,6 +998,9 @@ def persist_report_snapshot(
                 "snapshot": Jsonb(snapshot),
             },
         )
+    pruned = prune_report_snapshots(conn, report_type=report_type)
+    if pruned:
+        logger.info("report_snapshots: pruned %d %s snapshot(s) past retention", pruned, report_type)
 
 
 def load_report_snapshots(

--- a/sql/244_report_snapshot_cap_remediation.sql
+++ b/sql/244_report_snapshot_cap_remediation.sql
@@ -1,0 +1,103 @@
+-- 244_report_snapshot_cap_remediation.sql
+--
+-- #2180 — cap the six pre-#2178 `report_snapshots` rows that still carry an
+-- uncapped `score_changes` array, and add the retention this table never had.
+--
+-- Background: #2178 capped `score_changes` to a 20-row top-N exhibit with the
+-- pre-cap count travelling alongside as `score_changes_total`. Rows written
+-- BEFORE that fix still hold the full run x instrument product — up to 14,473
+-- elements in one row. `app/api/reports.py` serves `ORDER BY period_start DESC`
+-- with `limit` up to 100, so every one of them ships on any call with a
+-- sufficient limit.
+--
+-- WHY IN PLACE, NOT REGENERATED: the stored arrays already contain everything
+-- the capped form needs. `_select_rank_movers` takes top_n from EACH direction,
+-- and `score_changes_total` is just the pre-cap instrument count — which is
+-- exactly `jsonb_array_length` of what is already stored. No source data is
+-- required, so a regeneration path would be strictly more machinery for the
+-- same result.
+--
+-- ⚠ THE TRAP: DO NOT SLICE THE STORED ARRAY.
+-- The stored order is `ABS(rank_delta) DESC`, not `rank_delta DESC` — the
+-- pre-#2178 "top N by magnitude" shape. Verified on dev: on 2026-07-13 element
+-- 1 is `rank_delta = -2779` while the array's max RISE is only +1757, and the
+-- tail elements are +5. So first-10 ++ last-10 would yield the biggest fallers
+-- plus the SMALLEST risers — a wrong exhibit that looks entirely plausible.
+-- This must RE-DERIVE: top 10 by `rank_delta DESC` among positives, top 10 by
+-- `rank_delta ASC` among negatives.
+--
+-- Output ordering reproduces the builder exactly. `_select_rank_movers`
+-- returns `risers ++ fallers` where `rows` is already `rank_delta DESC`, so
+-- risers run large→small positive and fallers run least→most negative. A
+-- single `ORDER BY rank_delta DESC` over the union of both groups is
+-- byte-identical to that concatenation.
+--
+-- Idempotent: the WHERE clause selects only rows still above the cap, so a
+-- second run is a no-op. `idx_report_snapshots_type_period` is UNIQUE on
+-- (report_type, period_start) and the writer is already ON CONFLICT DO UPDATE,
+-- so this cannot race the report jobs into a duplicate.
+
+BEGIN;
+
+-- ── 1. Re-derive the capped exhibit for every over-cap row ─────────────
+
+WITH over_cap AS (
+    SELECT snapshot_id, snapshot_json->'score_changes' AS arr
+    FROM report_snapshots
+    WHERE jsonb_array_length(snapshot_json->'score_changes') > 20
+),
+elems AS (
+    SELECT o.snapshot_id, e.elem, (e.elem->>'rank_delta')::int AS rank_delta
+    FROM over_cap o, LATERAL jsonb_array_elements(o.arr) AS e(elem)
+),
+ranked AS (
+    SELECT snapshot_id, elem, rank_delta,
+           row_number() OVER (PARTITION BY snapshot_id ORDER BY rank_delta DESC) AS rn_riser,
+           row_number() OVER (PARTITION BY snapshot_id ORDER BY rank_delta ASC)  AS rn_faller
+    FROM elems
+),
+kept AS (
+    SELECT snapshot_id, elem, rank_delta
+    FROM ranked
+    WHERE (rank_delta > 0 AND rn_riser  <= 10)
+       OR (rank_delta < 0 AND rn_faller <= 10)
+),
+capped AS (
+    SELECT snapshot_id,
+           jsonb_agg(elem ORDER BY rank_delta DESC) AS score_changes
+    FROM kept
+    GROUP BY snapshot_id
+),
+totals AS (
+    -- Pre-cap instrument count = the length of what is stored TODAY. Read
+    -- before the UPDATE rewrites it.
+    SELECT snapshot_id, jsonb_array_length(arr) AS score_changes_total
+    FROM over_cap
+)
+UPDATE report_snapshots rs
+SET snapshot_json = jsonb_set(
+        jsonb_set(rs.snapshot_json, '{score_changes}', c.score_changes, true),
+        '{score_changes_total}', to_jsonb(t.score_changes_total), true
+    )
+FROM capped c
+JOIN totals t USING (snapshot_id)
+WHERE rs.snapshot_id = c.snapshot_id;
+
+-- Fail loudly rather than leave a half-capped table: every row must now be
+-- at or under the cap, and must carry its pre-cap total.
+DO $$
+DECLARE offending INTEGER;
+BEGIN
+    SELECT count(*) INTO offending
+    FROM report_snapshots
+    WHERE jsonb_array_length(snapshot_json->'score_changes') > 20
+       OR (jsonb_array_length(snapshot_json->'score_changes') > 0
+           AND snapshot_json->'score_changes_total' IS NULL);
+    IF offending > 0 THEN
+        RAISE EXCEPTION
+            '#2180: % report_snapshots row(s) still over the 20-row cap or '
+            'missing score_changes_total after remediation.', offending;
+    END IF;
+END $$;
+
+COMMIT;

--- a/sql/244_report_snapshot_cap_remediation.sql
+++ b/sql/244_report_snapshot_cap_remediation.sql
@@ -83,8 +83,30 @@ FROM capped c
 JOIN totals t USING (snapshot_id)
 WHERE rs.snapshot_id = c.snapshot_id;
 
+-- ── 2. Backfill the total on legacy rows that were never over the cap ──
+--
+-- A pre-#2178 snapshot whose period happened to produce 1..20 movers has a
+-- non-empty `score_changes` and NO `score_changes_total`: it was never
+-- selected above, because it was never over the cap. Its array IS the whole
+-- set, so its pre-cap total is exactly that array's length. Without this the
+-- assertion below would abort the migration on any install holding such a row
+-- (Codex ckpt-2) — and the API contract would keep serving a non-empty
+-- exhibit with no total beside it.
+UPDATE report_snapshots
+SET snapshot_json = jsonb_set(
+        snapshot_json,
+        '{score_changes_total}',
+        to_jsonb(jsonb_array_length(snapshot_json->'score_changes')),
+        true
+    )
+WHERE jsonb_array_length(snapshot_json->'score_changes') > 0
+  AND snapshot_json->'score_changes_total' IS NULL;
+
+-- ── 3. Assert the table is uniformly capped ────────────────────────────
+--
 -- Fail loudly rather than leave a half-capped table: every row must now be
--- at or under the cap, and must carry its pre-cap total.
+-- at or under the cap, and every non-empty exhibit must carry its pre-cap
+-- total.
 DO $$
 DECLARE offending INTEGER;
 BEGIN

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -281,11 +281,9 @@ class TestPersistReportSnapshot:
             snapshot=report,
         )
 
-        # Two statements now: the upsert, then the #2180 retention prune.
-        assert cursor.execute.call_count == 2
-        sql = cursor.execute.call_args_list[0][0][0]
-        params = cursor.execute.call_args_list[0][0][1]
-        assert "DELETE FROM report_snapshots" in cursor.execute.call_args_list[1][0][0]
+        cursor.execute.assert_called_once()
+        sql = cursor.execute.call_args[0][0]
+        params = cursor.execute.call_args[0][1]
         assert "ON CONFLICT" in sql
         assert params["report_type"] == "weekly"
         assert params["period_start"] == date(2026, 4, 6)
@@ -1159,55 +1157,109 @@ class TestSelectRankMovers:
         assert _select_rank_movers([], top_n=10) == []
 
 
-class TestPruneReportSnapshots2180:
-    """#2180 — `report_snapshots` had NO retention path at all, so every row
-    ever written was permanent (7.62 MB of a 7.63 MB table was six stale rows)."""
+class TestSnapshotSizeGuard2180:
+    """#2180 — the six stale rows were 7.62 MB of a 7.63 MB table because a
+    builder shipped an uncapped list field and nothing noticed for months."""
 
     @staticmethod
-    def _conn(rowcount: int = 0) -> tuple[MagicMock, MagicMock]:
+    def _conn() -> tuple[MagicMock, MagicMock]:
         conn = MagicMock()
         cursor = MagicMock()
-        cursor.rowcount = rowcount
         conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         return conn, cursor
 
-    def test_prunes_tail_beyond_retention(self) -> None:
-        from app.services.reporting import prune_report_snapshots
-
-        conn, cursor = self._conn(rowcount=3)
-        assert prune_report_snapshots(conn, report_type="weekly") == 3
-
-        sql = cursor.execute.call_args[0][0]
-        params = cursor.execute.call_args[0][1]
-        assert "DELETE FROM report_snapshots" in sql
-        # Ordered by the SAME key the API serves, so only the oldest tail can
-        # ever be dropped — never a row a caller could still page to.
-        assert "ORDER BY period_start DESC" in sql
-        assert "OFFSET" in sql
-        assert params == {"report_type": "weekly", "keep": 52}
-
-    def test_monthly_keeps_its_own_count(self) -> None:
-        from app.services.reporting import prune_report_snapshots
+    def test_oversized_snapshot_is_refused_before_the_write(self) -> None:
+        from app.services.reporting import ReportSnapshotTooLarge, persist_report_snapshot
 
         conn, cursor = self._conn()
-        prune_report_snapshots(conn, report_type="monthly")
-        assert cursor.execute.call_args[0][1]["keep"] == 24
-
-    def test_unconfigured_type_is_left_alone(self) -> None:
-        """Silently pruning a report type nobody sized is how a retention
-        sweep becomes data loss — no retention configured means no DELETE."""
-        from app.services.reporting import prune_report_snapshots
-
-        conn, cursor = self._conn()
-        assert prune_report_snapshots(conn, report_type="quarterly") == 0
+        # The real shape of the bug: one uncapped run x instrument product.
+        snapshot = {
+            "report_type": "weekly",
+            "score_changes": [{"symbol": f"S{i}", "rank_delta": i} for i in range(14473)],
+        }
+        with pytest.raises(ReportSnapshotTooLarge, match="score_changes"):
+            persist_report_snapshot(
+                conn,
+                report_type="weekly",
+                period_start=date(2026, 6, 8),
+                period_end=date(2026, 6, 14),
+                snapshot=snapshot,
+            )
+        # Refused BEFORE the write — nothing reaches the table.
         cursor.execute.assert_not_called()
 
-    def test_retention_exceeds_the_api_limit_ceiling(self) -> None:
-        """`app/api/reports.py` caps `limit` at 100 — but the ceiling that
-        matters is per report_type, and both budgets must clear the largest
-        page a caller can request for their own type."""
-        from app.services.reporting import _SNAPSHOT_RETENTION
+    def test_error_names_the_offending_field_and_its_length(self) -> None:
+        from app.services.reporting import ReportSnapshotTooLarge, persist_report_snapshot
 
-        assert _SNAPSHOT_RETENTION["weekly"] >= 52  # ~1 year of weeklies
-        assert _SNAPSHOT_RETENTION["monthly"] >= 24  # ~2 years of monthlies
+        conn, _ = self._conn()
+        snapshot = {"holdings": [{"symbol": f"S{i}", "note": "x" * 200} for i in range(500)]}
+        with pytest.raises(ReportSnapshotTooLarge) as exc:
+            persist_report_snapshot(
+                conn,
+                report_type="monthly",
+                period_start=date(2026, 6, 1),
+                period_end=date(2026, 6, 30),
+                snapshot=snapshot,
+            )
+        assert "holdings" in str(exc.value)
+        assert "500" in str(exc.value)
+
+    def test_capped_snapshot_passes(self) -> None:
+        """A #2178-shaped snapshot — 20-row exhibit plus the pre-cap count —
+        is ~3-4 KB on dev and must be nowhere near the ceiling."""
+        from app.services.reporting import persist_report_snapshot
+
+        conn, cursor = self._conn()
+        snapshot = {
+            "report_type": "weekly",
+            "score_changes": [{"symbol": f"S{i}", "rank_delta": 100 - i} for i in range(20)],
+            "score_changes_total": 14473,
+        }
+        persist_report_snapshot(
+            conn,
+            report_type="weekly",
+            period_start=date(2026, 6, 8),
+            period_end=date(2026, 6, 14),
+            snapshot=snapshot,
+        )
+        cursor.execute.assert_called_once()
+
+    def test_snapshot_with_dates_serialises_for_the_size_check(self) -> None:
+        """The guard must not itself become the failure: snapshots carry
+        `date`/`Decimal` values, which plain json.dumps cannot encode."""
+        from app.services.reporting import persist_report_snapshot
+
+        conn, cursor = self._conn()
+        persist_report_snapshot(
+            conn,
+            report_type="weekly",
+            period_start=date(2026, 6, 8),
+            period_end=date(2026, 6, 14),
+            snapshot={"as_of": date(2026, 6, 14), "pnl": Decimal("1.25")},
+        )
+        cursor.execute.assert_called_once()
+
+
+class TestRetentionDeletionIsDeliberatelyAbsent2180:
+    def test_no_delete_path_on_report_snapshots(self) -> None:
+        """Row-count retention must NOT be added: `_prior_v2_chain` selects
+        EVERY prior v2 snapshot with no LIMIT, and `si_return` / `si_start`
+        are chained from it. Deleting the oldest rows would silently move the
+        inception date forward (Codex ckpt-2 on PR #2195)."""
+        import inspect
+
+        from app.services import reporting
+
+        src = inspect.getsource(reporting)
+        assert "DELETE FROM report_snapshots" not in src
+
+    def test_prior_chain_query_is_unbounded(self) -> None:
+        """Pins the reason: if this ever grows a LIMIT, the no-retention
+        constraint above can be revisited."""
+        import inspect
+
+        from app.services.reporting import _prior_v2_chain
+
+        src = inspect.getsource(_prior_v2_chain)
+        assert "LIMIT" not in src.upper()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -262,6 +262,7 @@ class TestPersistReportSnapshot:
 
         conn = MagicMock()
         cursor = MagicMock()
+        cursor.rowcount = 0
         conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -280,9 +281,11 @@ class TestPersistReportSnapshot:
             snapshot=report,
         )
 
-        cursor.execute.assert_called_once()
-        sql = cursor.execute.call_args[0][0]
-        params = cursor.execute.call_args[0][1]
+        # Two statements now: the upsert, then the #2180 retention prune.
+        assert cursor.execute.call_count == 2
+        sql = cursor.execute.call_args_list[0][0][0]
+        params = cursor.execute.call_args_list[0][0][1]
+        assert "DELETE FROM report_snapshots" in cursor.execute.call_args_list[1][0][0]
         assert "ON CONFLICT" in sql
         assert params["report_type"] == "weekly"
         assert params["period_start"] == date(2026, 4, 6)
@@ -1154,3 +1157,57 @@ class TestSelectRankMovers:
         from app.services.reporting import _select_rank_movers
 
         assert _select_rank_movers([], top_n=10) == []
+
+
+class TestPruneReportSnapshots2180:
+    """#2180 — `report_snapshots` had NO retention path at all, so every row
+    ever written was permanent (7.62 MB of a 7.63 MB table was six stale rows)."""
+
+    @staticmethod
+    def _conn(rowcount: int = 0) -> tuple[MagicMock, MagicMock]:
+        conn = MagicMock()
+        cursor = MagicMock()
+        cursor.rowcount = rowcount
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return conn, cursor
+
+    def test_prunes_tail_beyond_retention(self) -> None:
+        from app.services.reporting import prune_report_snapshots
+
+        conn, cursor = self._conn(rowcount=3)
+        assert prune_report_snapshots(conn, report_type="weekly") == 3
+
+        sql = cursor.execute.call_args[0][0]
+        params = cursor.execute.call_args[0][1]
+        assert "DELETE FROM report_snapshots" in sql
+        # Ordered by the SAME key the API serves, so only the oldest tail can
+        # ever be dropped — never a row a caller could still page to.
+        assert "ORDER BY period_start DESC" in sql
+        assert "OFFSET" in sql
+        assert params == {"report_type": "weekly", "keep": 52}
+
+    def test_monthly_keeps_its_own_count(self) -> None:
+        from app.services.reporting import prune_report_snapshots
+
+        conn, cursor = self._conn()
+        prune_report_snapshots(conn, report_type="monthly")
+        assert cursor.execute.call_args[0][1]["keep"] == 24
+
+    def test_unconfigured_type_is_left_alone(self) -> None:
+        """Silently pruning a report type nobody sized is how a retention
+        sweep becomes data loss — no retention configured means no DELETE."""
+        from app.services.reporting import prune_report_snapshots
+
+        conn, cursor = self._conn()
+        assert prune_report_snapshots(conn, report_type="quarterly") == 0
+        cursor.execute.assert_not_called()
+
+    def test_retention_exceeds_the_api_limit_ceiling(self) -> None:
+        """`app/api/reports.py` caps `limit` at 100 — but the ceiling that
+        matters is per report_type, and both budgets must clear the largest
+        page a caller can request for their own type."""
+        from app.services.reporting import _SNAPSHOT_RETENTION
+
+        assert _SNAPSHOT_RETENTION["weekly"] >= 52  # ~1 year of weeklies
+        assert _SNAPSHOT_RETENTION["monthly"] >= 24  # ~2 years of monthlies

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1241,6 +1241,36 @@ class TestSnapshotSizeGuard2180:
         cursor.execute.assert_called_once()
 
 
+class TestZeroRankDeltaIsUnrepresentable2180:
+    """Review WARNING on PR #2195: sql/244's `kept` CTE partitions on
+    `rank_delta > 0` / `< 0`, so a zero would be dropped. It cannot occur —
+    and this pins BOTH reasons so the rebuttal cannot silently rot."""
+
+    def test_builder_uses_the_same_strict_sign_split(self) -> None:
+        """The migration must match `_select_rank_movers`, not improve on it:
+        a zero handled differently in the two places would make a repaired row
+        disagree with a natively-written one."""
+        from app.services.reporting import _select_rank_movers
+
+        rows = [
+            {"symbol": "UP", "rank_delta": 10},
+            {"symbol": "FLAT", "rank_delta": 0},
+            {"symbol": "DOWN", "rank_delta": -10},
+        ]
+        result = _select_rank_movers(rows, top_n=10)
+        assert [r["symbol"] for r in result] == ["UP", "DOWN"]
+
+    def test_score_changes_filters_below_the_min_delta(self) -> None:
+        """`_score_changes` takes `min_rank_delta=5` and the SQL filters on
+        ABS(rank_delta) >= it, so a zero never reaches the array at all."""
+        import inspect
+
+        from app.services.reporting import _score_changes
+
+        sig = inspect.signature(_score_changes)
+        assert sig.parameters["min_rank_delta"].default == 5
+
+
 class TestRetentionDeletionIsDeliberatelyAbsent2180:
     def test_no_delete_path_on_report_snapshots(self) -> None:
         """Row-count retention must NOT be added: `_prior_v2_chain` selects


### PR DESCRIPTION
## What

Six pre-#2178 `report_snapshots` rows still carried the full run × instrument product in `score_changes` — up to **14,473 elements in one row**, 7.62 MB of a 7.63 MB table. `app/api/reports.py` serves `ORDER BY period_start DESC` with `limit` up to 100, so every one of them shipped on any sufficiently large call.

- **`sql/244`** — re-derive the capped exhibit in place for the six over-cap rows, and backfill `score_changes_total` on legacy under-cap rows.
- **`persist_report_snapshot`** — refuse an oversized snapshot at the write, so the next builder that ships an uncapped field is caught on its first run.

## ⚠ The trap: this does not slice the stored array

The stored order is **`ABS(rank_delta) DESC`** — the pre-#2178 "top N by magnitude" shape, not `rank_delta DESC`. Verified independently on dev before writing anything:

| period_start | element 0 | element 1 | last element |
|---|---|---|---|
| 2026-07-13 | **−2779** | −2328 | +5 |
| 2026-06-08 | +3601 | −2277 | −5 |

Element 0 on 2026-07-13 is `−2779` while that array's maximum **rise** is only `+1757`. So `first-10 ++ last-10` would have produced the biggest fallers plus the *smallest* risers — a wrong exhibit that looks entirely plausible and that nothing downstream would flag.

The migration **re-derives**: top 10 by `rank_delta DESC` among positives, top 10 by `rank_delta ASC` among negatives, then orders the union `rank_delta DESC`. That is byte-identical to `_select_rank_movers`' own `risers ++ fallers` concatenation, because `rows` is already DESC there.

## Why in place, not regenerated

The stored arrays already contain everything the capped form needs, and `score_changes_total` is exactly `jsonb_array_length` of what is stored. No source data is required, so a regeneration path would be strictly more machinery for the same result. `idx_report_snapshots_type_period` is UNIQUE on `(report_type, period_start)` and the writer is already `ON CONFLICT DO UPDATE`, so the update cannot race the report jobs into a duplicate. Idempotent — the `WHERE` selects only rows still over the cap.

## Row-count retention was implemented, then removed — it corrupts since-inception

The issue recommended adding retention. I implemented it (keep 52 weekly / 24 monthly), and **Codex checkpoint 2 caught that it silently corrupts financial reporting.** Verified before acting on it:

- `_prior_v2_chain` selects **every** prior v2 snapshot — `WHERE period_start < X`, no `LIMIT`.
- `_cover_and_performance` chain-links those returns into `si_return`, and takes `si_start` from `chained_rows[0]["period_start"]`.
- The risk section's drawdown index is built on the same chain.

Deleting the oldest rows would therefore have moved the inception date forward — since-inception quietly becoming since-the-retention-window, with no error and no visible symptom. **The history is load-bearing and stays.**

The premise was wrong anyway: #2180's 7.62 MB was row **size**, not row **count**. With every list field capped a snapshot is ~3-4 KB, so 52 weeklies a year cost ~170 KB — growth that needs no pruning at all.

So the durable guard is a **size assertion at the write**: `ReportSnapshotTooLarge` above 64 KiB (~16× the largest legitimate snapshot, well under the smallest uncapped one at 88 KB), raised **before** touching the table. The message names the largest list field and its length, because an uncapped collection has been the cause every time. Raised rather than warned — eBull does not silently bypass a failed check, and a loud job failure beats a megabyte-scale leak that surfaces months later in an API response. `json.dumps(..., default=str)` so `date`/`Decimal` values cannot make the guard itself the failure.

Two tests pin the decision so retention is not reintroduced by someone who did not read this: one asserts no `DELETE FROM report_snapshots` exists in the module, the other pins that `_prior_v2_chain` is unbounded — if it ever grows a `LIMIT`, the decision can be revisited.

## Security model

No new external surface, no auth change, no user-controlled input. `/reports/*` stays behind `require_session_or_service_token`. The migration reads and rewrites only the table's own JSON; there is no interpolation of caller-supplied values. The size guard is a pure local computation on a dict the caller already owns, and it fails **closed** (nothing is written). The net effect on exposure is a reduction: an authenticated caller could previously pull 7.6 MB of internal per-instrument rank data in one request; that is now 61 KB.

## Verification (dev DB, commit `81581b00`)

All 6 over-cap rows remediated; `score_changes_total` set to the measured pre-cap counts:

```
type     start           n   total
weekly   2026-06-01     20    4387
weekly   2026-06-08     20   14473
weekly   2026-06-22     20    7032
weekly   2026-06-29     20    7129
weekly   2026-07-06     20    7053
weekly   2026-07-13     20   10656
weekly   2026-07-20     20    2590   <- #2178-native, untouched
rows violating the cap/total invariant: 0
```

**Ordering proof** — every repaired array is strictly `rank_delta DESC` across all 20, matching the shape of the #2178-native `2026-07-20` row. Element 0 is now the maximum **rise** (`+1757` on 2026-07-13) where before remediation it was `−2779`:

| period_start | elem 0 | elem 9 | elem 10 | elem 19 | monotone DESC |
|---|---|---|---|---|---|
| 2026-06-08 | +3601 | +899 | −1286 | −2277 | ✓ |
| 2026-07-13 | +1757 | +931 | −1940 | −2779 | ✓ |
| 2026-07-20 | +1641 | +828 | −1371 | −1804 | ✓ (native) |

**Operator-visible**: `/reports/weekly?limit=100` → 8 snapshots, **61,292 bytes** (was ~7.6 MB), largest `score_changes` array = 20. `/reports/monthly?limit=100` → 25,590 bytes.

Gates: `ruff check` / `ruff format --check` / `pyright` (0 errors) / `pytest -m "not db"` (exit 0) / `pytest tests/smoke` (exit 0). Codex ckpt-2 run three times; both findings fixed (the P1 retention corruption and a P2 migration-abort case), third pass clean.

## Conscious tradeoffs

- **64 KiB is a fixed ceiling.** If a legitimate report ever grows past it the job fails loudly rather than degrading. That is the intended posture, and the headroom is ~16×.
- **`score_changes_total` on the six repaired rows is the length of what was stored**, which is the pre-cap mover count as it existed when written — not recomputed from source. That is the same value #2178 would have recorded, so the exhibit is honest about how many movers it is summarising.
- **Two empty-array rows** (`monthly 2026-05-01`, `weekly 2026-05-25`) keep a null total. An empty exhibit summarises nothing, so a total would be noise; the assertion scopes to non-empty arrays deliberately.
- Migration 244 was replayed on dev after each edit (delete the `schema_migrations` row, re-run) rather than adding a `245` patch, since no other environment has seen the file — the #1333 content-drift procedure recorded in the prevention log during #2192.

## Settled decisions / prevention log applicability

No entry in `docs/settled-decisions.md` governs report snapshot storage. Prevention-log entries applied: the #2178 entry on snapshot-shape contract chains (this preserves `score_changes` / `score_changes_total` as that chain defines them), and the best-effort/fail-closed distinction (the size guard is a hard rule, so it raises rather than warning).

Closes #2180
