### PR TITLE
fix(#2190): burn down PerformanceChart.tsx — linear curves, ratchet entry deleted

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -67,10 +67,13 @@
  *     immediately. That is the durable guarantee, and it lands now rather than
  *     after all 29 fixes.
  *
- * Burn the entries down one file at a time (`PerformanceChart.tsx` first — it
- * is on an operator-facing statement), then DELETE the `RATCHET` map and the
- * code that reads it. An empty ratchet is a bug, not a milestone: the gate
+ * Burn the entries down one file at a time, then DELETE the `RATCHET` map and
+ * the code that reads it. An empty ratchet is a bug, not a milestone: the gate
  * refuses to run with one, so the mechanism cannot outlive the debt.
+ *
+ * Burn-down progress: `PerformanceChart.tsx` (2 curve) done in #2190 — it was
+ * first because it renders on an operator-facing statement. 25 violations
+ * remain across 9 files.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -121,7 +124,6 @@ const RATCHET = {
   "components/instrument/FundamentalsPane.tsx": { curve: 1, palette: 4 },
   "components/instrument/OwnershipHistoryChart.tsx": { curve: 1, palette: 0 },
   "components/news/newsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
-  "components/reports/PerformanceChart.tsx": { curve: 2, palette: 0 },
   "components/risk/riskCharts.tsx": { curve: 2, palette: 0 },
   "pages/components/ChartWorkspaceCanvas.tsx": { curve: 0, palette: 2 },
 };

--- a/frontend/src/components/reports/PerformanceChart.tsx
+++ b/frontend/src/components/reports/PerformanceChart.tsx
@@ -85,7 +85,7 @@ export function PerformanceChart({
             <ReferenceLine y={100} stroke={theme.gridLine} />
             <Tooltip content={<PerformanceTooltip />} cursor={{ stroke: theme.crosshair }} />
             <Line
-              type="monotone"
+              type="linear"
               dataKey="portfolio"
               stroke={theme.primaryLine}
               strokeWidth={1.5}
@@ -95,7 +95,7 @@ export function PerformanceChart({
             />
             {hasBenchmark ? (
               <Line
-                type="monotone"
+                type="linear"
                 dataKey="benchmark"
                 stroke={theme.accent[1]}
                 strokeWidth={1.5}


### PR DESCRIPTION
## What

First file of the #2190 burn-down. `components/reports/PerformanceChart.tsx` — both series switched from the cubic curve type to linear, and its `RATCHET` entry deleted.

Chosen first because it renders on an operator-facing statement (§4.2 performance vs benchmark), which is why #2190's own docstring named it as the starting point.

## Why it matters here specifically

The chart plots a trailing snapshot window of **2-5 indexed points**, both series normalised to 100 at window start. Cubic interpolation on that draws a path through values no period ever reported, and can overshoot a local extreme between two points — so the rendered line can show the portfolio crossing the benchmark, or breaching 100, in a period where it did neither.

That is sharpened by the component's own sparse-series treatment, whose docstring says: *"2-5 points must read as stated fact, not rendering failure."* A smoothed connector directly contradicts that intent. Linear is the only honest connector between discrete observations — the same reasoning #2185 shipped rule A on.

## Ratchet handling

The entry is **deleted**, not set to zero, per the gate's own instruction: *"Lower it to {actual} (or delete the entry at zero) in this commit — a stale cap is headroom for the debt to return."* An all-zero entry would be an orphan that the stale-cap check flags on every run forever.

**I verified the stale-cap direction is load-bearing rather than assuming it** — that half is what makes the mechanism a ratchet rather than a skip-list, so it is worth proving once:

```
# probe: re-add the now-stale entry
"components/reports/PerformanceChart.tsx": { curve: 2, palette: 0 },
$ pnpm --dir frontend charts:check
... Do NOT widen a ratchet entry to pass.
ELIFECYCLE Command failed with exit code 1        <- fails, as designed
```

Reverted immediately after. Gate now:

```
OK chart-integrity gate: 280 files, no new violations
   (25 pre-existing capped across 9 files — #2190 burn-down)
```

27 across 10 files → **25 across 9**.

## Security model

None engaged. This is a two-token change to a chart's interpolation prop plus a lint-gate constant; no data path, no auth surface, no network, no user input. The rendered figures are unchanged — only the connector drawn between them.

## Verification

- `pnpm charts:check` — 280 files, 25 pre-existing across 9 files (down from 27/10)
- `pnpm dark:check` — 384 files, no violations
- `pnpm pills:check` — 386 files, no violations
- `pnpm typecheck` — clean
- `pnpm test:unit` — **135 files, 1476 tests passed**
- `ruff check` — clean (no Python touched)
- Codex ckpt-2 — clean; independently ran the gate itself

## Conscious tradeoffs

- The historical "27 real violations total ... measured on `origin/main` at `d5853233`" line in the docstring is **left as-is**. It records what the scope widening cost at that commit; rewriting it each burn-down PR would destroy the baseline. The live count is reported by the gate at runtime, and a separate burn-down-progress note now carries the remaining figure.
- Nine files remain. One per PR, as #2190 specifies — the ratchet forces each to lower its own cap in the same commit, so there is no way to fix a file and leave headroom behind.

Refs #2190.
