### PR TITLE
fix(#2197): burn down dividendsCharts.tsx — linear curves, resolved theme, ratchet entry deleted

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -71,9 +71,10 @@
  * the code that reads it. An empty ratchet is a bug, not a milestone: the gate
  * refuses to run with one, so the mechanism cannot outlive the debt.
  *
- * Burn-down progress: `PerformanceChart.tsx` (2 curve) done in #2190 — it was
- * first because it renders on an operator-facing statement. 25 violations
- * remain across 9 files.
+ * Burn-down progress (#2197 tracks the drain): `PerformanceChart.tsx` (2 curve)
+ * done in #2190 — it was first because it renders on an operator-facing
+ * statement. `dividendsCharts.tsx` (3 curve, 7 palette) done in #2197, largest
+ * entry first. 15 violations remain across 8 files.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -117,7 +118,6 @@ const RULE_PALETTE = "palette";
  * Measured on `origin/main` at d5853233.
  */
 const RATCHET = {
-  "components/dividends/dividendsCharts.tsx": { curve: 3, palette: 7 },
   "components/filings/filingsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
   "components/insider/InsiderByOfficer.tsx": { curve: 0, palette: 2 },
   "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },

--- a/frontend/src/components/dividends/dividendsCharts.tsx
+++ b/frontend/src/components/dividends/dividendsCharts.tsx
@@ -27,7 +27,7 @@ import {
 
 import type { DividendPeriod } from "@/api/instruments";
 import type { InstrumentFinancialRow } from "@/api/types";
-import { type ChartTheme, defaultTooltipStyle, lightTheme } from "@/lib/chartTheme";
+import { type ChartTheme, defaultTooltipStyle } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import {
   buildCumulativeDps,
@@ -138,10 +138,10 @@ export function DpsLineChart({ history }: HistoryProps): JSX.Element {
             contentStyle={defaultTooltipStyle(theme)}
           />
           <Line
-            type="monotone"
+            type="linear"
             dataKey="dps"
             name="DPS declared"
-            stroke={lightTheme.accent[0]}
+            stroke={theme.accent[0]}
             strokeWidth={2.5}
             dot={false}
             isAnimationActive={false}
@@ -197,11 +197,11 @@ export function CumulativeDpsChart({ history }: HistoryProps): JSX.Element {
             contentStyle={defaultTooltipStyle(theme)}
           />
           <Area
-            type="monotone"
+            type="linear"
             dataKey="cumulative_dps"
             name="Cumulative DPS"
-            stroke={lightTheme.accent[1]}
-            fill={lightTheme.accent[1]}
+            stroke={theme.accent[1]}
+            fill={theme.accent[1]}
             fillOpacity={0.15}
             strokeWidth={2.5}
             dot={false}
@@ -249,7 +249,7 @@ export function PayoutRatioChart({ cashflowRows }: PayoutRatioProps): JSX.Elemen
           />
           <ReferenceLine
             y={100}
-            stroke={lightTheme.accent[3]}
+            stroke={theme.accent[3]}
             strokeDasharray="4 4"
             label={{
               value: "100%",
@@ -264,12 +264,12 @@ export function PayoutRatioChart({ cashflowRows }: PayoutRatioProps): JSX.Elemen
             contentStyle={defaultTooltipStyle(theme)}
           />
           <Line
-            type="monotone"
+            type="linear"
             dataKey="payout_pct"
             name="Payout / FCF"
-            stroke={lightTheme.accent[2]}
+            stroke={theme.accent[2]}
             strokeWidth={2.5}
-            dot={{ r: 3, fill: lightTheme.accent[2] }}
+            dot={{ r: 3, fill: theme.accent[2] }}
             isAnimationActive={false}
           />
         </LineChart>
@@ -324,7 +324,7 @@ export function YieldOnCostChart({
           />
           <Bar dataKey="yoc_pct" name="Yield-on-cost" isAnimationActive={false}>
             {series.map((s) => (
-              <Cell key={s.fiscal_year} fill={lightTheme.up} />
+              <Cell key={s.fiscal_year} fill={theme.up} />
             ))}
           </Bar>
         </BarChart>


### PR DESCRIPTION
## What

First of nine burn-down PRs for the chart-integrity ratchet. `components/dividends/dividendsCharts.tsx` was the largest entry — 10 of the 25 remaining violations (3 curve + 7 palette).

- 3 × cubic curve type → linear (`DpsLineChart`, `CumulativeDpsChart`, `PayoutRatioChart`).
- 7 × raw-palette read → the resolved `theme` from `useChartTheme()`.
- Ratchet entry **deleted** (not set to all-zero — an all-zero entry is an orphan the stale-cap check flags forever).
- Docstring burn-down count lowered `25 across 9` → `15 across 8`.

## Why it was a defect, and why nothing rendered wrong

All four components already called `useChartTheme()` and bound it to `theme`, using it correctly for axes / grid / tooltip — then reached past it for `lightTheme.accent[…]` on the *series* colours. That is the exact shape the prevention log flags: the correct binding in the same file is what makes it survive review, because the file reads as theme-aware.

It is invisible on screen today because `darkTheme` aliases the saturated slots straight to the light references (`frontend/src/lib/chartTheme.ts:165-181` — `up`, `down`, `accent`, `indicator`, `regression`, `channel*`). So the swapped values are **byte-identical at runtime**; this is a latent-fragility fix, not a repaint. It becomes a light-only page the day an accent diverges in dark.

Curve rule: dividends per share, cumulative DPS and payout ratio are discrete per-period observations. A smoothed connector draws the line through magnitudes no period reported and can overshoot a local extreme.

## Verification

| check | result |
|---|---|
| `pnpm charts:check` | OK — 280 files, 15 capped across 8 files |
| `pnpm typecheck` | pass |
| `pnpm test:unit` | 135 files / 1476 tests pass |
| `pnpm dark:check` | OK — 384 files |
| `pnpm pills:check` | OK — 386 files |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no actionable regressions |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 3, palette: 7 }` and re-ran the gate: exit 1, with `curve violations fell 3 -> 0 but the ratchet still says 3` and the matching palette line. Restored, exit 0. The cap this PR removes was live, so the fix is real rather than bookkeeping. (Run without a pipe — `cmd | head` then `$?` reports *head's* status and falsely passes gate tests, per #2190.)

The file's test (`dividendsCharts.test.tsx`, 55 lines) asserts no colours and no curve props, so it neither caught this nor breaks on the fix.

## Tradeoffs

- **One file per PR**, per the ticket's own rule and the gate's docstring. The ratchet fails in both directions, so each PR must lower its own cap in the same commit; batching files would make a single revert unable to restore a consistent cap.
- Global `lightTheme.` → `theme.` swap rather than site-by-site edits: verified all 7 sites sit inside functions that already bind `theme`, and the import no longer names `lightTheme` at all — which is the actual smell the design-system skill names.
- No new tests. The gate itself is the regression test for both rules, and it now fails this file on its first reintroduced violation rather than capping it.

## Remaining

15 violations across 8 files. Next largest: `FundamentalsPane.tsx` (5), `riskCharts.tsx` (2), then six singles. Done = `RATCHET`, `checkRatchet()`'s ratchet branch, and the empty-ratchet guard all deleted.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
