### PR TITLE
fix(#2197): burn down FundamentalsPane.tsx — linear curve, resolved theme in the grid, ratchet entry deleted

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -73,8 +73,9 @@
  *
  * Burn-down progress (#2197 tracks the drain): `PerformanceChart.tsx` (2 curve)
  * done in #2190 — it was first because it renders on an operator-facing
- * statement. `dividendsCharts.tsx` (3 curve, 7 palette) done in #2197, largest
- * entry first. 15 violations remain across 8 files.
+ * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
+ * `FundamentalsPane.tsx` (1 curve, 4 palette) done in #2197, largest entries
+ * first. 10 violations remain across 7 files.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -121,7 +122,6 @@ const RATCHET = {
   "components/filings/filingsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
   "components/insider/InsiderByOfficer.tsx": { curve: 0, palette: 2 },
   "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },
-  "components/instrument/FundamentalsPane.tsx": { curve: 1, palette: 4 },
   "components/instrument/OwnershipHistoryChart.tsx": { curve: 1, palette: 0 },
   "components/news/newsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
   "components/risk/riskCharts.tsx": { curve: 2, palette: 0 },

--- a/frontend/src/components/instrument/FundamentalsPane.tsx
+++ b/frontend/src/components/instrument/FundamentalsPane.tsx
@@ -56,7 +56,7 @@ import type { InstrumentFinancialRow, InstrumentSummary } from "@/api/types";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { Pane } from "@/components/instrument/Pane";
 import { formatBigNumber } from "@/lib/format";
-import { defaultTooltipStyle, lightTheme } from "@/lib/chartTheme";
+import { defaultTooltipStyle } from "@/lib/chartTheme";
 import { useAsync } from "@/lib/useAsync";
 import { useChartTheme } from "@/lib/useChartTheme";
 import { useCallback, useId, useMemo } from "react";
@@ -318,6 +318,7 @@ function FundamentalsGrid({
 }: {
   readonly series: ReadonlyArray<SeriesRow>;
 }): JSX.Element {
+  const theme = useChartTheme();
   const revenue = buildCellPoints(series, (r) => r.revenue);
   const opIncome = buildCellPoints(series, (r) => r.operatingIncome);
   const netIncome = buildCellPoints(series, (r) => r.netIncome);
@@ -340,7 +341,7 @@ function FundamentalsGrid({
         points={revenue}
         nonNull={nonNullCount(revenue)}
         totalLen={totalLen}
-        fillColor={lightTheme.accent[1]}
+        fillColor={theme.accent[1]}
       />
       <FundamentalCell
         label="Op income"
@@ -348,7 +349,7 @@ function FundamentalsGrid({
         points={opIncome}
         nonNull={nonNullCount(opIncome)}
         totalLen={totalLen}
-        fillColor={lightTheme.up}
+        fillColor={theme.up}
       />
       <FundamentalCell
         label="Net income"
@@ -356,7 +357,7 @@ function FundamentalsGrid({
         points={netIncome}
         nonNull={nonNullCount(netIncome)}
         totalLen={totalLen}
-        fillColor={lightTheme.up}
+        fillColor={theme.up}
       />
       <FundamentalCell
         label="Total debt"
@@ -364,7 +365,7 @@ function FundamentalsGrid({
         points={totalDebt}
         nonNull={nonNullCount(totalDebt)}
         totalLen={totalLen}
-        fillColor={lightTheme.accent[3]}
+        fillColor={theme.accent[3]}
       />
     </div>
   );
@@ -475,7 +476,7 @@ function FundamentalCell({
                 contentStyle={defaultTooltipStyle(theme)}
               />
               <Area
-                type="monotone"
+                type="linear"
                 dataKey="value"
                 stroke={fillColor}
                 strokeWidth={1.75}


### PR DESCRIPTION
## What

Second burn-down PR for the chart-integrity ratchet, second-largest entry (5 of the 15 remaining).

- 1 × cubic curve type → linear on the per-metric sparkline cell (`FundamentalCell`'s `<Area>`).
- 4 × raw-palette read → the resolved `theme`.
- Ratchet entry **deleted** (not set to all-zero — an all-zero entry is an orphan the stale-cap check flags forever).
- Docstring burn-down count lowered `15 across 8` → `10 across 7`.

## The one design decision

This file is **not** shaped like `dividendsCharts.tsx` (PR #2198). There, all four components already bound `useChartTheme()` and the fix was a pure `lightTheme.` → `theme.` swap. Here the four palette reads live in `FundamentalsGrid`, which binds no theme at all and passes a resolved **hex** down to `FundamentalCell` — and the *child* is the one that calls `useChartTheme()`.

Two valid fixes:

- **(A) taken** — bind `useChartTheme()` in `FundamentalsGrid`, keep the `fillColor: string` prop. One added line, mirrors the merged precedent.
- **(B) rejected** — replace `FundamentalCell`'s `fillColor: string` with a theme-slot key and resolve inside the child, so the parent names no colours at all.

B is strictly tighter: the gate bans the raw-palette **names**, not an arbitrary hex, so under A a future edit could pass a literal `"#3b82f6"` through the prop and no gate would see it. Rejected anyway because it invents a colour vocabulary to guard a hypothetical, against CLAUDE.md's KISS rule (*smallest code that solves the problem; no "what if" abstractions*). Flagging it here so a reviewer can overrule rather than discover it.

`FundamentalsGrid` is a real component (it already calls `useId()`), and it is rendered as `<FundamentalsGrid />` inside a ternary rather than called conditionally, so the added hook is legal.

## Why it was a defect, and why nothing rendered wrong

Same latent shape as #2198: `darkTheme` aliases the saturated slots straight to the light references (`frontend/src/lib/chartTheme.ts:165-181` — `up`, `accent`, …), so the swapped values are **byte-identical at runtime today**. This is a fragility fix, not a repaint; it becomes a light-only page the day an accent diverges in dark.

Curve rule: the sparkline plots revenue / operating income / net income / total debt per reporting period — discrete observations. A smoothed connector draws through magnitudes no period reported. (`connectNulls={false}` was already correct.)

## Verification

| check | result |
|---|---|
| `pnpm charts:check` | OK — 280 files, 10 capped across 7 files |
| `pnpm typecheck` | pass |
| `pnpm test:unit` | 135 files / 1476 tests pass |
| `pnpm dark:check` | OK — 384 files |
| `pnpm pills:check` | OK — 386 files |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no regressions found |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 1, palette: 4 }` and re-ran the gate: exit 1, `curve violations fell 1 -> 0 but the ratchet still says 1` plus the matching palette line. Restored, exit 0. The cap this PR removes was live. (Run without a pipe — `cmd | head` then `$?` reports *head's* status, which falsely passed four gate tests in #2190.)

## Remaining

10 violations across 7 files. Next: `riskCharts.tsx` (2 curve, 0 palette — both inside functions that already bind the theme), then six singles. Done = `RATCHET`, `checkRatchet()`'s ratchet branch, and the empty-ratchet guard all deleted.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
