### PR TITLE
fix(#2197): burn down riskCharts.tsx — linear curves on the daily drawdown + rolling-vol series

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -74,8 +74,9 @@
  * Burn-down progress (#2197 tracks the drain): `PerformanceChart.tsx` (2 curve)
  * done in #2190 — it was first because it renders on an operator-facing
  * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
- * `FundamentalsPane.tsx` (1 curve, 4 palette) done in #2197, largest entries
- * first. 10 violations remain across 7 files.
+ * `FundamentalsPane.tsx` (1 curve, 4 palette) and `riskCharts.tsx` (2 curve)
+ * done in #2197, largest entries first. 8 violations remain across 6 files —
+ * all of them singles.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -124,7 +125,6 @@ const RATCHET = {
   "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },
   "components/instrument/OwnershipHistoryChart.tsx": { curve: 1, palette: 0 },
   "components/news/newsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
-  "components/risk/riskCharts.tsx": { curve: 2, palette: 0 },
   "pages/components/ChartWorkspaceCanvas.tsx": { curve: 0, palette: 2 },
 };
 

--- a/frontend/src/components/risk/riskCharts.tsx
+++ b/frontend/src/components/risk/riskCharts.tsx
@@ -155,7 +155,7 @@ export function UnderwaterChart({ points }: UnderwaterProps): JSX.Element {
             contentStyle={defaultTooltipStyle(theme)}
           />
           <Area
-            type="monotone"
+            type="linear"
             dataKey="drawdown"
             name="Drawdown"
             stroke={theme.down}
@@ -213,7 +213,7 @@ export function RollingVolChart({ points }: RollingVolProps): JSX.Element {
             contentStyle={defaultTooltipStyle(theme)}
           />
           <Line
-            type="monotone"
+            type="linear"
             dataKey="vol"
             name="Annualized vol"
             stroke={theme.accent[3]}


### PR DESCRIPTION
## What

Third burn-down PR for the chart-integrity ratchet.

- 2 × cubic curve type → linear: `UnderwaterChart`'s drawdown `<Area>` and `RollingVolChart`'s annualized-vol `<Line>`.
- No palette work — this file already reads `theme.*` throughout (it is the file the prevention log cites as the correct example), which is why its entry was curve-only.
- Ratchet entry **deleted**.
- Docstring burn-down count lowered `10 across 7` → `8 across 6`. Every remaining entry is now a single.

## Why linear

Both series are **per-trading-day** observations (`dataKey="date"`, `formatDay`), not a continuous function sampled for display. The connecting line is a reading aid, and the only honest one is straight — the settled rule from #2185.

`UnderwaterChart` is the sharper case. The file already goes to some length to keep its 0 anchor truthful: `drawdownDomainMin` pins the axis top at 0, and `allowDataOverflow` is *deliberately* omitted so a malformed positive row shows up as a visible anomaly rather than being clipped. A curved connector between daily points is the same class of visual claim the axis work is guarding against.

**One precision note for the record.** The gate's docstring justifies the rule partly with *"can overshoot a local extreme"*. That specific claim is shaky for recharts' `monotone`, which is Fritsch–Carlson monotone cubic interpolation — the property that algorithm is named for is that it does **not** overshoot between points. I have not corrected the docstring in this PR (it is the gate's own rationale, written in #2185, and rewriting it is not this PR's job), but the load-bearing half of the rule stands on its own without that clause: the rendered path still implies intermediate magnitudes that were never observed. Flagging rather than silently propagating it. Happy to fix the wording in the final teardown PR if a reviewer agrees.

## Verification

| check | result |
|---|---|
| `pnpm charts:check` | OK — 280 files, 8 capped across 6 files |
| `pnpm typecheck` | pass |
| `pnpm test:unit` | 135 files / 1476 tests pass |
| `pnpm dark:check` | OK — 384 files |
| `pnpm pills:check` | OK — 386 files |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no correctness issues |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 2, palette: 0 }` and re-ran: exit 1, `curve violations fell 2 -> 0 but the ratchet still says 2`. Restored, exit 0. The cap this PR removes was live. (Run without a pipe — `cmd | head` then `$?` reports *head's* status, which falsely passed four gate tests in #2190.)

## Remaining

8 violations across 6 files, all singles:

| file | curve | palette |
|---|---|---|
| `components/insider/InsiderByOfficer.tsx` | 0 | 2 |
| `pages/components/ChartWorkspaceCanvas.tsx` | 0 | 2 |
| `components/insider/InsiderNetByMonth.tsx` | 0 | 1 |
| `components/filings/filingsAnalyticsCharts.tsx` | 1 | 0 |
| `components/instrument/OwnershipHistoryChart.tsx` | 1 | 0 |
| `components/news/newsAnalyticsCharts.tsx` | 1 | 0 |

Done = `RATCHET`, `checkRatchet()`'s ratchet branch, and the empty-ratchet guard all deleted, with `pnpm charts:check` green on a bare scan.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
