### PR TITLE
fix(#2197): burn down filingsAnalyticsCharts.tsx — linear curve on the quarterly red-flag mean

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -75,8 +75,8 @@
  * done in #2190 — it was first because it renders on an operator-facing
  * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
  * `FundamentalsPane.tsx` (1 curve, 4 palette) and `riskCharts.tsx` (2 curve)
- * done in #2197, largest entries first. 8 violations remain across 6 files —
- * all of them singles.
+ * done in #2197, largest entries first, then the singles one file at a time.
+ * 7 violations remain across 5 files.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -120,7 +120,6 @@ const RULE_PALETTE = "palette";
  * Measured on `origin/main` at d5853233.
  */
 const RATCHET = {
-  "components/filings/filingsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
   "components/insider/InsiderByOfficer.tsx": { curve: 0, palette: 2 },
   "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },
   "components/instrument/OwnershipHistoryChart.tsx": { curve: 1, palette: 0 },

--- a/frontend/src/components/filings/filingsAnalyticsCharts.tsx
+++ b/frontend/src/components/filings/filingsAnalyticsCharts.tsx
@@ -246,7 +246,7 @@ export function RedFlagTrendChart({
           />
           <Tooltip content={<RedFlagTooltip />} cursor={{ stroke: theme.crosshair }} />
           <Line
-            type="monotone"
+            type="linear"
             dataKey="avg_score"
             name="avg red-flag"
             stroke={theme.down}


### PR DESCRIPTION
## What

Fourth burn-down PR for the chart-integrity ratchet; first of the six singles.

- 1 × cubic curve type → linear on the red-flag trend `<Line>`.
- No palette work — this file already reads `theme.*` throughout, so its entry was curve-only.
- Ratchet entry **deleted**.
- Docstring burn-down count lowered `8 across 6` → `7 across 5`.

## Why linear

The series is a **mean red-flag score per quarter** (`avg_score`, `dataKey` plotted against quarter buckets, fixed `domain={[0, 1]}`, `ticks={[0, 0.5, 1]}`). Discrete per-quarter observations — the connecting line is a reading aid, and the honest one is straight. Settled rule from #2185.

`dot={{ r: 3 }}` was already present, so the reported quarters stay individually visible.

## Verification

| check | result |
|---|---|
| `pnpm charts:check` | OK — 280 files, 7 capped across 5 files |
| `pnpm typecheck` | pass |
| `pnpm test:unit` | 135 files / 1476 tests pass |
| `pnpm dark:check` | OK — 384 files |
| `pnpm pills:check` | OK — 386 files |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no regressions |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 1, palette: 0 }`: exit 1, `curve violations fell 1 -> 0 but the ratchet still says 1`. Restored, exit 0. (Run without a pipe — `cmd | head` then `$?` reports *head's* status, which falsely passed four gate tests in #2190.)

## Remaining

7 violations across 5 files:

| file | curve | palette |
|---|---|---|
| `components/insider/InsiderByOfficer.tsx` | 0 | 2 |
| `pages/components/ChartWorkspaceCanvas.tsx` | 0 | 2 |
| `components/insider/InsiderNetByMonth.tsx` | 0 | 1 |
| `components/instrument/OwnershipHistoryChart.tsx` | 1 | 0 |
| `components/news/newsAnalyticsCharts.tsx` | 1 | 0 |

⚠ **`ChartWorkspaceCanvas.tsx` is structural, not a swap, and is deliberately last.** Its two reads are at **module scope** (`SMA_COLORS`, `COMPARE_COLORS` at lines 48 / 59), where no hook can run — and `COMPARE_COLORS` is *exported* and consumed elsewhere. That one needs a shape decision rather than a rename; it will get its own PR with the options written out.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
