### PR TITLE
fix(#2197): burn down OwnershipHistoryChart.tsx — linear curves on the per-filing ownership lines

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -76,7 +76,7 @@
  * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
  * `FundamentalsPane.tsx` (1 curve, 4 palette) and `riskCharts.tsx` (2 curve)
  * done in #2197, largest entries first, then the singles one file at a time.
- * 7 violations remain across 5 files.
+ * 6 violations remain across 4 files.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -122,7 +122,6 @@ const RULE_PALETTE = "palette";
 const RATCHET = {
   "components/insider/InsiderByOfficer.tsx": { curve: 0, palette: 2 },
   "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },
-  "components/instrument/OwnershipHistoryChart.tsx": { curve: 1, palette: 0 },
   "components/news/newsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
   "pages/components/ChartWorkspaceCanvas.tsx": { curve: 0, palette: 2 },
 };

--- a/frontend/src/components/instrument/OwnershipHistoryChart.tsx
+++ b/frontend/src/components/instrument/OwnershipHistoryChart.tsx
@@ -279,7 +279,7 @@ function HistoryBody({
                 key={l.key}
                 dataKey={l.key}
                 name={l.label}
-                type="monotone"
+                type="linear"
                 stroke={accents[i % accents.length]}
                 dot={{ r: 2 }}
                 isAnimationActive={false}


### PR DESCRIPTION
## What

Fifth burn-down PR for the chart-integrity ratchet.

- 1 × cubic curve type → linear on the mapped ownership `<Line>` series.
- No palette work — series colours already come from an `accents` array derived from the resolved theme.
- Ratchet entry **deleted**.
- Docstring burn-down count lowered `7 across 5` → `6 across 4`.

## Why linear

The chart plots N ownership lines against **filing dates**. Each point is a position *as disclosed on a specific filing*, not a sample of a continuously-varying quantity. Between two filings the true holding is unknown — nothing was reported — so a curved connector asserts a shape the data cannot support. Straight is the honest reading aid. Settled rule from #2185.

`dot={{ r: 2 }}` was already present, so the actual filing points stay visible against the connector.

Note the single `type=` edit covers all N series: it sits inside `lines.map(...)`, so one prop feeds every rendered line.

## Verification

| check | result |
|---|---|
| `pnpm charts:check` | OK — 280 files, 6 capped across 4 files |
| `pnpm typecheck` | exit 0 |
| `pnpm test:unit` | exit 0 — 135 files / 1476 tests pass |
| `pnpm dark:check` | OK — 384 files |
| `pnpm pills:check` | OK — 386 files |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no correctness issues |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 1, palette: 0 }`: exit 1, `curve violations fell 1 -> 0 but the ratchet still says 1`. Restored, exit 0.

Exit codes above were captured **without a pipe** (`cmd > file 2>&1; echo $?`). `cmd | tail` then `$?` reports *tail's* status, not the command's — the trap that falsely passed four gate tests in #2190, and which I re-triggered once while preparing this PR before re-running properly.

## Remaining

6 violations across 4 files:

| file | curve | palette |
|---|---|---|
| `components/insider/InsiderByOfficer.tsx` | 0 | 2 |
| `pages/components/ChartWorkspaceCanvas.tsx` | 0 | 2 |
| `components/insider/InsiderNetByMonth.tsx` | 0 | 1 |
| `components/news/newsAnalyticsCharts.tsx` | 1 | 0 |

Two notes for whoever takes the rest:

- ⚠ The gate counts **per line, per palette name**, not per occurrence. `InsiderNetByMonth.tsx:194` holds `lightTheme.up` *and* `lightTheme.down` on one line but is capped at `palette: 1` — fixing "one violation" there means editing two references.
- ⚠ `ChartWorkspaceCanvas.tsx` is structural. Both reads are module-scope (`SMA_COLORS`, `COMPARE_COLORS`), where no hook can run; `COMPARE_COLORS` is exported with exactly one consumer, in its own file, on a line that already falls back to `theme.compare[0]`. It gets its own PR, last.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
