### PR TITLE
fix(#2197): burn down newsAnalyticsCharts.tsx — linear curve on the rolling sentiment trend

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -76,7 +76,7 @@
  * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
  * `FundamentalsPane.tsx` (1 curve, 4 palette) and `riskCharts.tsx` (2 curve)
  * done in #2197, largest entries first, then the singles one file at a time.
- * 6 violations remain across 4 files.
+ * 5 violations remain across 3 files, all of them raw-palette reads.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -122,7 +122,6 @@ const RULE_PALETTE = "palette";
 const RATCHET = {
   "components/insider/InsiderByOfficer.tsx": { curve: 0, palette: 2 },
   "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },
-  "components/news/newsAnalyticsCharts.tsx": { curve: 1, palette: 0 },
   "pages/components/ChartWorkspaceCanvas.tsx": { curve: 0, palette: 2 },
 };
 

--- a/frontend/src/components/news/newsAnalyticsCharts.tsx
+++ b/frontend/src/components/news/newsAnalyticsCharts.tsx
@@ -115,7 +115,7 @@ export function SentimentTrendChart({ series }: { series: SentimentSeries }): JS
           <ReferenceLine y={0} stroke={theme.borderColor} />
           <Tooltip content={<SentimentTooltip />} cursor={{ stroke: theme.gridLine }} />
           <Area
-            type="monotone"
+            type="linear"
             dataKey="rolling"
             baseValue={0}
             stroke="url(#newsSentStroke)"


### PR DESCRIPTION
## What

Sixth burn-down PR, and the **last curve entry** — every remaining violation is now a raw-palette read.

- 1 × cubic curve type → linear on the bicolor sentiment `<Area>`.
- No palette work — this file already takes every colour from the resolved theme.
- Ratchet entry **deleted**.
- Docstring burn-down count lowered `6 across 4` → `5 across 3`.

## Why linear

The plotted series is a **rolling sentiment value per day**. Discrete observations; the connecting line is a reading aid and the honest one is straight. Settled rule from #2185. (`connectNulls` and `baseValue={0}` are unchanged — the zero baseline the bicolor fill keys off is untouched.)

## Worth noting

This file's module docstring already describes the banned palettes **in prose** — *"never from either raw palette imported by name out of `@/lib/chartTheme`"* — rather than quoting the literal. That is the correct pattern: the gate is line-based, so a quoted example would register as a violation with nothing to burn down and would sit in the ratchet forever (`Sparkline.tsx` precedent, #2190). No prose fix needed here.

## Verification

All exit codes captured **without a pipe** (`cmd > file 2>&1; echo $?`) — `cmd | tail` then `$?` reports *tail's* status, the trap that falsely passed four gate tests in #2190.

| check | exit |
|---|---|
| `charts:check` | 0 — 280 files, 5 capped across 3 files |
| `pnpm typecheck` | 0 |
| `pnpm test:unit` | 0 — 135 files / 1476 tests pass |
| `pnpm dark:check` | 0 |
| `pnpm pills:check` | 0 |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no functional regressions |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 1, palette: 0 }`: exit 1, `curve violations fell 1 -> 0 but the ratchet still says 1`. Restored, exit 0.

## Remaining

5 violations across 3 files, all raw-palette:

| file | palette |
|---|---|
| `components/insider/InsiderByOfficer.tsx` | 2 |
| `pages/components/ChartWorkspaceCanvas.tsx` | 2 |
| `components/insider/InsiderNetByMonth.tsx` | 1 |

⚠ Two things the next PRs need to know:

- The gate counts **per line, per palette name**, not per occurrence — `for (const palette of RAW_PALETTES) if (line.includes(palette))` pushes at most once per name per line. `InsiderNetByMonth.tsx:194` holds `lightTheme.up` *and* `lightTheme.down` on one line but is capped at `palette: 1`. Fixing "one violation" there means editing two references.
- `ChartWorkspaceCanvas.tsx` is structural, not a rename. Both reads are module-scope (`SMA_COLORS` line 48, `COMPARE_COLORS` line 59) where no hook can run. `COMPARE_COLORS` is exported with exactly one consumer — line 595 of its own file, which already falls back to `theme.compare[0]`. `SMA_COLORS`' two consumers straddle two components, only one of which binds the theme. That PR goes last and will carry the options.

Then the teardown PR: delete `RATCHET`, `checkRatchet()`'s ratchet branch, and the empty-ratchet guard.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
