### PR TITLE
fix(#2197): burn down InsiderByOfficer.tsx — resolved theme on the net-direction bar cells

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -76,7 +76,7 @@
  * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
  * `FundamentalsPane.tsx` (1 curve, 4 palette) and `riskCharts.tsx` (2 curve)
  * done in #2197, largest entries first, then the singles one file at a time.
- * 5 violations remain across 3 files, all of them raw-palette reads.
+ * 3 violations remain across 2 files, all of them raw-palette reads.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -120,7 +120,6 @@ const RULE_PALETTE = "palette";
  * Measured on `origin/main` at d5853233.
  */
 const RATCHET = {
-  "components/insider/InsiderByOfficer.tsx": { curve: 0, palette: 2 },
   "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },
   "pages/components/ChartWorkspaceCanvas.tsx": { curve: 0, palette: 2 },
 };

--- a/frontend/src/components/insider/InsiderByOfficer.tsx
+++ b/frontend/src/components/insider/InsiderByOfficer.tsx
@@ -22,7 +22,6 @@ import {
 
 import type { InsiderTransactionDetail } from "@/api/instruments";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
-import { lightTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import {
   directionOf,
@@ -215,9 +214,9 @@ export function InsiderByOfficer({
                   key={b.key}
                   fill={
                     b.net > 0
-                      ? lightTheme.up
+                      ? theme.up
                       : b.net < 0
-                        ? lightTheme.down
+                        ? theme.down
                         : theme.borderColor
                   }
                 />


### PR DESCRIPTION
## What

Seventh burn-down PR for the chart-integrity ratchet.

- 2 × raw-palette read → the resolved `theme`; the `lightTheme` import dropped entirely.
- Ratchet entry **deleted**.
- Docstring burn-down count lowered `5 across 3` → `3 across 2`.

## The defect shape

The `<Cell>` fill was split-brained **within a single expression** — raw palette on the two value branches, resolved theme on the else:

```
fill={ b.net > 0 ? lightTheme.up
     : b.net < 0 ? lightTheme.down
     : theme.borderColor }
```

`theme` is bound at line 170 and used correctly for ticks, tooltip and cursor throughout the same component. That is exactly what makes this class survive review — the file reads as theme-aware, and the one ternary that isn't sits inside otherwise-correct code (prevention log → *"a chart that binds the theme AND imports the raw palette is light-only, and no gate sees it"*).

No visual change today: `darkTheme` aliases `up` / `down` straight to the light references (`frontend/src/lib/chartTheme.ts:165-166`), so the swapped values are byte-identical at runtime. Latent-fragility fix, not a repaint.

## Verification

All exit codes captured **without a pipe** (`cmd > file 2>&1; echo $?`) — `cmd | tail` then `$?` reports *tail's* status, the trap that falsely passed four gate tests in #2190.

| check | exit |
|---|---|
| `charts:check` | 0 — 280 files, 3 capped across 2 files |
| `pnpm typecheck` | 0 |
| `pnpm test:unit` | 0 — 135 files / 1476 tests pass |
| `pnpm dark:check` | 0 |
| `pnpm pills:check` | 0 |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no correctness issues |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 0, palette: 2 }`: exit 1, `palette violations fell 2 -> 0 but the ratchet still says 2`. Restored, exit 0.

## Remaining

3 violations across 2 files:

| file | palette |
|---|---|
| `pages/components/ChartWorkspaceCanvas.tsx` | 2 |
| `components/insider/InsiderNetByMonth.tsx` | 1 |

⚠ `InsiderNetByMonth.tsx:194` is capped at **1** but holds **two** references (`lightTheme.up` and `lightTheme.down` on the same line) — the gate pushes at most one violation per palette *name* per *line*, not per occurrence. Fixing "one violation" there means editing two refs.

⚠ `ChartWorkspaceCanvas.tsx` is structural: module-scope `SMA_COLORS` / `COMPARE_COLORS` where no hook can run, `COMPARE_COLORS` a dead export whose only consumer already falls back to `theme.compare[0]`. Goes last, with the options written out.

Then the teardown PR: delete `RATCHET`, `checkRatchet()`'s ratchet branch, and the empty-ratchet guard.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
