### PR TITLE
fix(#2197): burn down InsiderNetByMonth.tsx — resolved theme on the net-direction bar cells

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -76,7 +76,9 @@
  * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
  * `FundamentalsPane.tsx` (1 curve, 4 palette) and `riskCharts.tsx` (2 curve)
  * done in #2197, largest entries first, then the singles one file at a time.
- * 3 violations remain across 2 files, all of them raw-palette reads.
+ * 2 violations remain, both in `ChartWorkspaceCanvas.tsx` — the last entry,
+ * and the only structural one: its reads are at MODULE SCOPE, where no hook
+ * can run.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -120,7 +122,6 @@ const RULE_PALETTE = "palette";
  * Measured on `origin/main` at d5853233.
  */
 const RATCHET = {
-  "components/insider/InsiderNetByMonth.tsx": { curve: 0, palette: 1 },
   "pages/components/ChartWorkspaceCanvas.tsx": { curve: 0, palette: 2 },
 };
 

--- a/frontend/src/components/insider/InsiderNetByMonth.tsx
+++ b/frontend/src/components/insider/InsiderNetByMonth.tsx
@@ -22,7 +22,6 @@ import {
 
 import type { InsiderTransactionDetail } from "@/api/instruments";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
-import { lightTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import { directionOf, signedShares } from "@/lib/insiderClassify";
 
@@ -191,7 +190,7 @@ export function InsiderNetByMonth({
               <Cell
                 key={b.month}
                 fill={
-                  b.net > 0 ? lightTheme.up : b.net < 0 ? lightTheme.down : theme.borderColor
+                  b.net > 0 ? theme.up : b.net < 0 ? theme.down : theme.borderColor
                 }
               />
             ))}


### PR DESCRIPTION
## What

Eighth burn-down PR. One file left after this.

- 2 raw-palette references → the resolved `theme`; `lightTheme` import dropped.
- Ratchet entry **deleted**.
- Docstring burn-down count lowered `3 across 2` → `2 across 1`.

## Same defect as #2204, and a demonstration of how the gate counts

Byte-for-byte the same bug as `InsiderByOfficer.tsx`: the `<Cell>` fill ternary reads the raw palette on the two value branches and the resolved theme on the else, inside a component that binds `theme` (line 159) and uses it correctly for the reference line, tooltip and cursor.

The interesting part is the **count**. This entry was capped at `palette: 1` while #2204's was `palette: 2` — for the identical defect. The difference is purely formatting:

```
// InsiderByOfficer — prettier broke it across lines → 2 violations
? lightTheme.up
: b.net < 0
  ? lightTheme.down

// InsiderNetByMonth — fits on one line → 1 violation
b.net > 0 ? lightTheme.up : b.net < 0 ? lightTheme.down : theme.borderColor
```

`scanSource` iterates `for (const palette of RAW_PALETTES) if (line.includes(palette))` and pushes **at most one violation per palette name per line**, not per occurrence. So the ratchet's numbers measure *offending lines*, not offending reads.

That is fine for the ratchet's job — it only ever needs to compare a file against itself — but it means the headline "25 violations" understated the actual number of references, and anyone treating a cap as a reference count will come up short. Worth knowing while the mechanism is still alive; it disappears with the teardown PR.

No visual change today: `darkTheme` aliases `up` / `down` to the light references (`frontend/src/lib/chartTheme.ts:165-166`).

## Verification

All exit codes captured **without a pipe** (`cmd > file 2>&1; echo $?`).

| check | exit |
|---|---|
| `charts:check` | 0 — 280 files, 2 capped across 1 file |
| `pnpm typecheck` | 0 |
| `pnpm test:unit` | 0 — 135 files / 1476 tests pass |
| `pnpm dark:check` | 0 |
| `pnpm pills:check` | 0 |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | no regressions |

**Ratchet both-directions proof.** Re-added the now-stale entry `{ curve: 0, palette: 1 }`: exit 1, `palette violations fell 1 -> 0 but the ratchet still says 1`. Restored, exit 0.

## Remaining

`pages/components/ChartWorkspaceCanvas.tsx` — 2 palette, the last entry and the only structural one. Both reads are at **module scope** (`SMA_COLORS` line 48, `COMPARE_COLORS` line 59) where no hook can run. Tracing consumers:

- `COMPARE_COLORS` is **exported with exactly one consumer**, line 595 of its own file, which already reads `COMPARE_COLORS[i % len] ?? theme.compare[0]` — raw palette for the value, resolved theme for the fallback. The export is dead.
- `SMA_COLORS` has two consumers: line 682 (inside `ChartWorkspaceCanvas`, `theme` bound at 230) and line 972 (inside `RichTooltip`, which binds nothing).

Planned shape: bind the theme in `RichTooltip`, delete both module consts, drop the dead export, and rewrite the doc comment whose stated rationale — *"avoids threading the theme hook through every indicator setter"* — stops being true. Then the teardown PR deletes `RATCHET`, `checkRatchet()`'s ratchet branch, and the empty-ratchet guard.

Refs #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
