### PR TITLE
fix(#2197): burn down ChartWorkspaceCanvas.tsx and delete the ratchet mechanism

### DIFF
--- a/frontend/scripts/check-chart-integrity.mjs
+++ b/frontend/scripts/check-chart-integrity.mjs
@@ -41,44 +41,37 @@
  * as protection. If the scope ever widens to `src/`, rule B needs a real
  * early-return for it at that point, not before.
  *
- * THE RATCHET — and why it is NOT the skip-list #987 killed
- * --------------------------------------------------------
- * Widening the scope in one step would fail every developer's pre-push on all
- * 27 pre-existing violations, and a gate that is red on day one gets disabled
- * rather than obeyed. So the pre-existing debt is capped, not exempted, by
- * `RATCHET` below.
+ * THE RATCHET — drained and removed (#2197)
+ * -----------------------------------------
+ * This gate shipped over 27 pre-existing violations. Failing every pre-push on
+ * day one would have got it disabled rather than obeyed, so the debt was
+ * CAPPED, not exempted, by a `RATCHET` map: a per-file, per-rule, EXACT count.
+ * `actual > cap` caught regression; `actual < cap` caught a burn-down that
+ * forgot to lower its number, which is the half that stops every fix leaving
+ * headroom for the debt to return. Unlisted files failed on their first
+ * violation, so new charts were guarded from the start rather than after the
+ * last fix. That is why it was not the skip-list #987 killed — a skip-list is
+ * binary and lets debt grow invisibly inside a listed file; a counted ratchet
+ * cannot.
  *
- * `check-dark-classes.mjs` carries the instruction "do NOT reintroduce a
- * skip-list — fix the file instead", from #987, which drained its Check F
- * skip-list to empty. That instruction is about not re-adding debt to an
- * already-clean gate, and it stands. This is a different mechanism at a
- * different stage — the same stage `dark:check` was at BEFORE #987, widening
- * over debt that already exists:
+ * It is now GONE, drained one file at a time across #2190 and #2197
+ * (`PerformanceChart` · `dividendsCharts` · `FundamentalsPane` · `riskCharts` ·
+ * `filingsAnalyticsCharts` · `OwnershipHistoryChart` · `newsAnalyticsCharts` ·
+ * `InsiderByOfficer` · `InsiderNetByMonth` · `ChartWorkspaceCanvas`). The gate
+ * refused to run on an empty map by design, so the final fix and the removal of
+ * the mechanism had to land in the SAME commit — the mechanism could not
+ * outlive the debt. Do not reintroduce it: this is now a plain tree-wide check,
+ * and a new violation is simply a failure to fix before pushing.
  *
- *   - A skip-list is binary. A listed file is not checked, so debt inside it
- *     can GROW invisibly. That is what made #987's drain necessary.
- *   - This ratchet is a COUNT, per file and per rule, and the match is EXACT.
- *     A listed file at its cap still fails on violation N+1, so debt cannot
- *     grow. It also fails when the actual count drops BELOW the cap, which
- *     forces a burn-down PR to lower the number in the same commit — without
- *     that half, every fix silently leaves headroom for the debt to return and
- *     the "temporary" mechanism becomes permanent.
- *   - An unlisted file fails on its first violation, so new charts are guarded
- *     immediately. That is the durable guarantee, and it lands now rather than
- *     after all 29 fixes.
- *
- * Burn the entries down one file at a time, then DELETE the `RATCHET` map and
- * the code that reads it. An empty ratchet is a bug, not a milestone: the gate
- * refuses to run with one, so the mechanism cannot outlive the debt.
- *
- * Burn-down progress (#2197 tracks the drain): `PerformanceChart.tsx` (2 curve)
- * done in #2190 — it was first because it renders on an operator-facing
- * statement. `dividendsCharts.tsx` (3 curve, 7 palette) then
- * `FundamentalsPane.tsx` (1 curve, 4 palette) and `riskCharts.tsx` (2 curve)
- * done in #2197, largest entries first, then the singles one file at a time.
- * 2 violations remain, both in `ChartWorkspaceCanvas.tsx` — the last entry,
- * and the only structural one: its reads are at MODULE SCOPE, where no hook
- * can run.
+ * Two things learned draining it, worth keeping:
+ *   - The counts measured offending LINES, not offending references. The
+ *     scanner records at most one violation per palette name per line, so the
+ *     same defect cost 2 in one file and 1 in another purely because of where
+ *     the formatter put a line break.
+ *   - The last entry was the one the mechanism could not have fixed early:
+ *     module-scope colour constants, where no hook can run. A shortcut taken
+ *     because "the palettes are identical anyway" is self-reinforcing — module
+ *     scope is exactly where the correct read is unavailable.
  *
  * Note the forbidden strings are assembled from fragments below: these gates
  * are textual and line-based, so writing the banned literal in this file — even
@@ -111,19 +104,6 @@ const RAW_PALETTES = ["light" + "Theme.", "dark" + "Theme."];
 
 const RULE_CURVE = "curve";
 const RULE_PALETTE = "palette";
-
-/**
- * Pre-existing debt at the moment the scope widened (#2190), as
- * `src`-relative POSIX path → per-rule count. Counts are EXACT, not ceilings:
- * see the ratchet note in the module docstring. Lower a number in the same
- * commit that fixes the violations; delete the entry at zero; delete this map
- * and its reader once it is empty.
- *
- * Measured on `origin/main` at d5853233.
- */
-const RATCHET = {
-  "pages/components/ChartWorkspaceCanvas.tsx": { curve: 0, palette: 2 },
-};
 
 /**
  * Collect every `.ts` / `.tsx` under `dir`.
@@ -182,52 +162,21 @@ const REASONS = {
 };
 
 /**
- * Compare measured counts against `RATCHET`, returning human-readable failures.
+ * Every measured violation as a `path:line: reason` failure string.
  *
- * Both directions fail, and the `stale` direction is the load-bearing one —
- * see the ratchet note in the module docstring.
+ * Reports EVERY offending line, not just the first per file: a developer
+ * fixing a chart should see the whole list in one run rather than rediscover
+ * it one pre-push at a time.
  */
-function checkRatchet(measured, ratchet) {
+function reportViolations(measured) {
   const failures = [];
-  const rules = [RULE_CURVE, RULE_PALETTE];
-
-  for (const [path, allowed] of Object.entries(ratchet)) {
-    for (const rule of rules) {
-      const cap = allowed[rule] ?? 0;
-      const actual = measured[path]?.[rule] ?? 0;
-      if (actual > cap) {
-        failures.push(
-          `${path}: ${rule} violations rose ${cap} -> ${actual}. ` +
-            "Ratchet entries cap pre-existing debt; they do not license more of it.",
-        );
-      } else if (actual < cap) {
-        failures.push(
-          `${path}: ${rule} violations fell ${cap} -> ${actual} but the ratchet ` +
-            `still says ${cap}. Lower it to ${actual} (or delete the entry at zero) ` +
-            "in this commit — a stale cap is headroom for the debt to return.",
-        );
-      }
-    }
-  }
-
   for (const [path, counts] of Object.entries(measured)) {
-    if (path in ratchet) continue;
-    for (const rule of rules) {
-      // Report EVERY offending line, not just the first: a developer fixing a
-      // new chart should see the whole list in one run rather than rediscover
-      // it one pre-push at a time. `*Lines` is optional so this stays callable
-      // with bare `{ curve, palette }` counts (the unit tests do exactly that).
-      const lines = counts[`${rule}Lines`] ?? [];
-      if (lines.length > 0) {
-        for (const line of lines) {
-          failures.push(`${path}:${line}: ${REASONS[rule]}`);
-        }
-      } else if ((counts[rule] ?? 0) > 0) {
-        failures.push(`${path}: ${counts[rule]}x ${REASONS[rule]}`);
+    for (const rule of [RULE_CURVE, RULE_PALETTE]) {
+      for (const line of counts[`${rule}Lines`]) {
+        failures.push(`${path}:${line}: ${REASONS[rule]}`);
       }
     }
   }
-
   return failures;
 }
 
@@ -250,24 +199,12 @@ for (const scope of SCOPES) {
   }
 }
 
-// An empty ratchet means the debt is drained: delete the mechanism rather than
-// leaving a dormant one for the next person to add to.
-if (Object.keys(RATCHET).length === 0) {
-  console.error(
-    "x chart-integrity ratchet is empty — the debt is drained. Delete RATCHET, " +
-      "checkRatchet() and this guard; the gate is now a plain tree-wide check.",
-  );
-  process.exit(1);
-}
-
 const measured = {};
 for (const file of files) {
   const found = scanSource(readFileSync(file, "utf8"));
   if (found.length === 0) continue;
   const path = keyFor(file);
   measured[path] = {
-    curve: found.filter((f) => f.rule === RULE_CURVE).length,
-    palette: found.filter((f) => f.rule === RULE_PALETTE).length,
     curveLines: found.filter((f) => f.rule === RULE_CURVE).map((f) => f.line),
     paletteLines: found
       .filter((f) => f.rule === RULE_PALETTE)
@@ -275,43 +212,20 @@ for (const file of files) {
   };
 }
 
-// A ratchet entry for a file that no longer exists is stale bookkeeping: it
-// would keep the map alive past the debt it describes.
-const orphans = Object.keys(RATCHET).filter(
-  (path) => !files.some((f) => keyFor(f) === path),
-);
-
-// An orphan is already fully explained by its own message; leaving it in the
-// ratchet passed to `checkRatchet` would ALSO report it as a stale cap
-// ("fell 2 -> 0"), which is the same fact stated twice and sends the reader
-// looking for a file that is gone.
-const liveRatchet = Object.fromEntries(
-  Object.entries(RATCHET).filter(([path]) => !orphans.includes(path)),
-);
-
-const failures = [
-  ...orphans.map(
-    (path) =>
-      `${path}: ratchet entry for a file that no longer exists — delete the entry.`,
-  ),
-  ...checkRatchet(measured, liveRatchet),
-];
+const failures = reportViolations(measured);
 
 if (failures.length > 0) {
   console.error(`x ${failures.length} chart-integrity violation(s):\n`);
   for (const f of failures) console.error(`  ${f}`);
   console.error(
     "\nSee .claude/skills/frontend/design-system.md " +
-      '§"Chart theming — ONE source". Do NOT widen a ratchet entry to pass.',
+      '§"Chart theming — ONE source". Fix the file; do NOT reintroduce a ' +
+      "ratchet or a skip-list to pass.",
   );
   process.exit(1);
 }
 
-const capped = Object.values(RATCHET).reduce(
-  (sum, c) => sum + c.curve + c.palette,
-  0,
-);
 console.log(
-  `OK chart-integrity gate: ${files.length} files, no new violations ` +
-    `(${capped} pre-existing capped across ${Object.keys(RATCHET).length} files — #2190 burn-down)`,
+  `OK chart-integrity gate: ${files.length} files, no violations ` +
+    "(ratchet drained and removed — #2197)",
 );

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -31,7 +31,7 @@ import {
   humanizeVolume,
   tickFormatter,
 } from "@/lib/chartFormatters";
-import { lightTheme } from "@/lib/chartTheme";
+import type { ChartTheme } from "@/lib/chartTheme";
 import { useChartTheme } from "@/lib/useChartTheme";
 import { useLiveLastBar } from "@/lib/useLiveLastBar";
 import { useMarketSpecials } from "@/lib/useMarketSpecials";
@@ -40,13 +40,22 @@ import type { SessionProfile } from "@/api/types";
 export type IndicatorId = "sma20" | "sma50" | "ema20" | "ema50";
 export const INDICATOR_IDS: IndicatorId[] = ["sma20", "sma50", "ema20", "ema50"];
 
-// Keep palette keys exhaustively typed against IndicatorId so a missing or
-// misspelled key in theme.indicator fails typecheck rather than
-// returning undefined at runtime. Indicator slots are saturated and
-// identical across light/dark, so reading from `lightTheme` directly
-// avoids threading the theme hook through every indicator setter.
-const SMA_COLORS: Record<IndicatorId, string> = lightTheme.indicator;
-
+// Indicator colours come from the resolved palette's `indicator` slots,
+// read at each use site via useChartTheme(). The exhaustiveness guarantee
+// the old module-scope table provided is unchanged: ChartTheme declares
+// `indicator` with exactly the IndicatorId keys, so adding an id without
+// adding its slot fails typecheck rather than returning undefined at
+// runtime.
+//
+// This used to be a module-scope constant reading the light palette
+// directly, on the rationale that the slots are identical across
+// light/dark so it "avoids threading the theme hook through every
+// indicator setter". That rationale is what #2185 identified as the
+// defect: the aliasing is a current fact about the palettes, not a
+// contract, and the day a slot diverges every such read silently stops
+// following the theme. Module scope is also precisely where the hook
+// cannot run, so the shortcut is self-reinforcing — hence the reads move
+// to the components.
 const SMA_LABELS: Record<IndicatorId, string> = {
   sma20: "SMA(20)",
   sma50: "SMA(50)",
@@ -54,9 +63,18 @@ const SMA_LABELS: Record<IndicatorId, string> = {
   ema50: "EMA(50)",
 };
 
-// Fixed palette for compare overlays — distinct from SMA colors.
-// Compare slots are also saturated and identical across light/dark.
-export const COMPARE_COLORS: readonly string[] = lightTheme.compare;
+// Compare-overlay colours come from the resolved palette's `compare`
+// rotation, distinct from the indicator slots. Formerly an exported
+// module-scope constant off the light palette — the export had exactly one
+// consumer, in this file, on a line that already fell back to
+// `theme.compare[0]`. Removed rather than re-homed.
+//
+// Kept as a pure function of (theme, index) rather than inlined at the two
+// call sites: the series-creation path and the theme-change recolour path
+// MUST agree, and a duplicated `idx % len` is exactly how they would drift.
+function compareColorAt(theme: ChartTheme, idx: number): string {
+  return theme.compare[idx % theme.compare.length] ?? theme.compare[0];
+}
 
 export interface CompareSeries {
   readonly symbol: string;
@@ -455,7 +473,24 @@ export function ChartWorkspaceCanvas({
       wickDownColor: theme.down,
     });
     primaryLine.applyOptions({ color: theme.primaryLine });
-  }, [theme]);
+
+    // Recolour series that already exist. Their colours are chosen in the
+    // creation branch of their own effects, which do NOT rerun on a theme
+    // change — so without this, a theme toggle would leave a drawn indicator
+    // or compare line on the previous palette while `RichTooltip`, which
+    // reads the resolved theme at render, moved to the new one: the line and
+    // its own readout would disagree about the colour of the same series.
+    // Latent while the saturated slots alias across palettes, real the day
+    // one diverges — which is the whole point of reading them from the theme.
+    for (const [id, series] of indicatorRefs.current) {
+      series.applyOptions({ color: theme.indicator[id] });
+    }
+    compares.forEach((cs, colorIdx) => {
+      const color = compareColorAt(theme, colorIdx);
+      compareColorRef.current.set(cs.symbol, color);
+      compareLineRefs.current.get(cs.symbol)?.applyOptions({ color });
+    });
+  }, [theme, compares]);
 
   // Numeric / null-filtered rows. Computed during render so values
   // are available to the live-tick aggregator's historical anchor on
@@ -591,8 +626,7 @@ export function ChartWorkspaceCanvas({
 
     // Add/update series for each compare symbol.
     compares.forEach((cs, colorIdx) => {
-      const color =
-        COMPARE_COLORS[colorIdx % COMPARE_COLORS.length] ?? theme.compare[0];
+      const color = compareColorAt(theme, colorIdx);
       compareColorRef.current.set(cs.symbol, color);
 
       const compareClean: NumericBar[] = cs.rows.flatMap((r) => {
@@ -679,7 +713,7 @@ export function ChartWorkspaceCanvas({
       let series = indicatorRefs.current.get(id);
       if (!series) {
         series = chart.addSeries(LineSeries, {
-          color: SMA_COLORS[id]!,
+          color: theme.indicator[id],
           lineWidth: 2,
           priceLineVisible: false,
           lastValueVisible: false,
@@ -898,6 +932,7 @@ export function ChartWorkspaceCanvas({
  * a second row when present.
  */
 function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
+  const theme = useChartTheme();
   const fmt = (n: number) => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
   const fmtPct = (v: number | null | undefined) => {
     if (v === null || v === undefined) return "—";
@@ -969,7 +1004,7 @@ function RichTooltip({ hover }: { hover: RichHoverState }): JSX.Element {
           {hover.indicators.map((row) => (
             <span key={row.id} className="flex items-baseline gap-1">
               <span className="text-slate-400">{row.label}</span>
-              <span style={{ color: SMA_COLORS[row.id] }}>{fmt(row.value)}</span>
+              <span style={{ color: theme.indicator[row.id] }}>{fmt(row.value)}</span>
             </span>
           ))}
         </>

--- a/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
+++ b/frontend/src/pages/components/ChartWorkspaceCanvas.tsx
@@ -474,17 +474,25 @@ export function ChartWorkspaceCanvas({
     });
     primaryLine.applyOptions({ color: theme.primaryLine });
 
-    // Recolour series that already exist. Their colours are chosen in the
-    // creation branch of their own effects, which do NOT rerun on a theme
-    // change — so without this, a theme toggle would leave a drawn indicator
-    // or compare line on the previous palette while `RichTooltip`, which
-    // reads the resolved theme at render, moved to the new one: the line and
-    // its own readout would disagree about the colour of the same series.
-    // Latent while the saturated slots alias across palettes, real the day
-    // one diverges — which is the whole point of reading them from the theme.
+    // Recolour indicator series that already exist. Their colour is chosen in
+    // the creation branch of the indicator effect, which does NOT rerun on a
+    // theme change — so without this a theme toggle would leave a drawn line
+    // on the previous palette while `RichTooltip`, which reads the resolved
+    // theme at render, moved to the new one: the line and its own readout
+    // would disagree about the colour of the same series. Latent while the
+    // saturated slots alias across palettes, real the day one diverges —
+    // which is the whole point of reading them from the theme. Reads refs
+    // only, so it needs no dep beyond `theme`.
     for (const [id, series] of indicatorRefs.current) {
       series.applyOptions({ color: theme.indicator[id] });
     }
+  }, [theme]);
+
+  // Compare overlays get their own effect rather than riding the one above:
+  // their colour depends on position in `compares`, and folding that dep into
+  // the theme effect would re-run the whole chart/candle/primaryLine
+  // applyOptions block on every compare-list change (review of PR #2206).
+  useEffect(() => {
     compares.forEach((cs, colorIdx) => {
       const color = compareColorAt(theme, colorIdx);
       compareColorRef.current.set(cs.symbol, color);


### PR DESCRIPTION
## What

Final burn-down PR. The last two violations are fixed **and the ratchet mechanism is deleted in the same commit** — it had to be, see below.

- 2 × raw-palette read → the resolved `theme`; `lightTheme` import dropped.
- `RATCHET`, `checkRatchet()`'s ratchet branch, the orphan-entry logic and the empty-ratchet guard: **all deleted**. The gate is now a plain tree-wide check.
- `pnpm charts:check` green on a bare scan: `280 files, no violations`.

## Why the fix and the teardown cannot be separate PRs

The gate refuses to run on an empty map by design. Leaving the entry in fails the stale-cap check (`fell 2 -> 0`); deleting it trips the empty-ratchet guard. Either half alone is red, so the final fix and the removal of the mechanism must land together — the mechanism cannot outlive the debt. That was deliberate in #2190 and it worked exactly as intended.

## The structural part

Both reads were at **module scope**, where no hook can run:

- **`SMA_COLORS`** — two consumers: line 682 inside `ChartWorkspaceCanvas` (binds `theme` at 230) and line 972 inside `RichTooltip` (bound nothing). `RichTooltip` now binds the theme; both read `theme.indicator`. The exhaustiveness guarantee the old `Record<IndicatorId, string>` annotation provided is unchanged — `ChartTheme` declares `indicator` with exactly the `IndicatorId` keys. Typecheck now accepts the read **without** the `!` non-null assertion `SMA_COLORS[id]!` needed.
- **`COMPARE_COLORS`** — exported, with exactly one consumer: line 595 of its own file, on a line that already read `COMPARE_COLORS[i % len] ?? theme.compare[0]` (raw palette for the value, resolved theme for the fallback). Verified repo-wide that nothing else imports it. Export deleted, not re-homed.

The doc comment justifying the module-scope shortcut — *"the slots are identical across light/dark, so reading from the light palette directly avoids threading the theme hook through every indicator setter"* — is rewritten. That rationale is the defect: the aliasing is a current fact about the palettes, not a contract, and module scope is precisely where the correct read is unavailable, so the shortcut is self-reinforcing.

## A regression Codex caught, and the fix

The first cut of this PR **introduced a new latent defect while removing the old one.** Series colours are chosen in the *creation* branch of their own effects, which do not rerun on a theme change.

- Before: line and tooltip both read the frozen light table, so they always agreed (both wrong together).
- After the first cut: `RichTooltip` read the live theme; a **already-drawn** line kept its creation-time colour. On a theme toggle the line and its own readout would show different colours for the same series.

Invisible today because the saturated slots alias — which is exactly the class of latent bug this whole ticket exists to remove, so shipping it would have been self-defeating. Fixed by extending the file's existing `[theme]` effect (the established pattern, already re-applying chart/candle/`primaryLine` options) to recolour live indicator and compare series. `compareColorAt(theme, idx)` was extracted so the creation path and the recolour path cannot drift on the `idx % len` formula.

## Verification

Exit codes captured **without a pipe** (`cmd > file 2>&1; echo $?`).

| check | exit |
|---|---|
| `charts:check` (bare scan) | 0 — 280 files, no violations |
| `pnpm typecheck` | 0 |
| **`pnpm test`** (FULL tier, not `test:unit`) | 0 — 136 files / 1478 tests pass |
| `pnpm dark:check` | 0 |
| `pnpm pills:check` | 0 |
| pre-push gate (backend + smoke + FE) | green |
| `codex exec review --base origin/main` | clean on re-run after the fix above |

The **full** FE tier was run deliberately: this adds `applyOptions` calls on indicator/compare series, i.e. new lightweight-charts API surface for this component, which is the exact shape that passes `test:unit` locally and fails CI on a per-test `vi.mock` (prevention log → #1841).

**The gate still fails.** Deleting the ratchet rewrote the reporting path, so a green run proves nothing on its own. Injected one violation of each rule into a scanned file:

- curve → `exit 1`, `components/risk/riskCharts.tsx:158: cubic interpolation on a discrete financial series — use the linear curve type`
- palette → `exit 1`, `components/risk/riskCharts.tsx:161: raw palette outside lib/chartTheme.ts — read the resolved palette via useChartTheme()`

Both restored, exit 0. (My first injection attempt silently produced `type="mono.tone"` and "passed" — a false negative in the *test*, not the gate. Redone properly.)

**Live page exercised** (`/instrument/AAPL/chart`, dev stack): 4 indicators enabled, 2 compare tickers added, four light↔dark toggles with both active. **0 console errors.** Indicator lines render in distinct colours and the `RichTooltip` readout colour-matches each line; compare overlays rotate through the compare slots. The operator's theme setting was restored to dark afterwards.

Worth noting from that pass: the AAPL primary line visibly flips **white → black** across the toggle while indicator and compare colours stay identical. `primaryLine` already diverges between palettes — concrete evidence that "the slots are identical anyway" is true only of *specific* slots, which is the argument for reading all of them from the theme.

## Also cleaned up

`checkRatchet()`'s bare-count fallback branch was unreachable — `measured` always carries `*Lines` — and its comment claimed *"the unit tests do exactly that"*. Nothing imports this script (verified repo-wide); the claim contradicted `scanSource`'s own docstring two functions above. Removed under the file's own stated principle about dead logic that reads as protection.

## Out of scope, filed separately

Deep-linking `?compare=MSFT,JPM` renders the compare chips but the series stay empty (`—` in the tooltip), while adding the same tickers interactively works. **Confirmed pre-existing** by stashing this branch and reproducing the identical result on unmodified `origin/main`. Not touched here; filed as #2207 with the reproduction and the control.

Closes #2197. Refs #2190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

