### PR TITLE
docs: correct three now-false claims in the instruction set + close two premise-checking holes

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -91,6 +91,8 @@ Follow this order unless the user explicitly says otherwise:
 3. Read `docs/review-prevention-log.md`. State which entries are relevant. If none apply, say so explicitly.
 4. If implementation pressure suggests changing a settled decision or risks repeating a prevention entry, stop and surface it before coding.
 4b. **Research the source rule + falsify the premise FIRST — before writing the spec.** For ownership/filings/metric work: look up the governing SEC reg/Item or EDGAR/form rule (per "Source-rule before design"), and verify the issue's premise + any inferred signal against the SOURCE and the FULL population (query the dev DB / read the filing structure), not a sample. The handoff premise is falsified more often than not (member_of_group #1645, dimensional dei #1646/#1623, market-cap-as-float #1662, def14a-additive #1659) — and a wrong premise sinks the spec. Do this BEFORE step 6, not after Codex ckpt-1 (#1659 burned a spec + impl on a heuristic the full-population scan then killed).
+
+4c. **An INHERITED root-cause is a premise too — re-falsify it before building on it.** Step 4b was being read as "falsify the ISSUE's premise", which leaves a hole: a fix that a PRIOR SESSION root-caused, wrote up on-issue, and handed off as "ready to implement" arrives already carrying an author's confidence, so it gets implemented instead of tested. **A prior session's conclusion is evidence, not a finding.** Re-run its discriminator against the full population before writing any code — it is one query and it is the cheapest step in the ticket. Precedent (2026-08-03, #2182 B1): a handoff labelled "ROOT CAUSE CONFIRMED" proposed gating period-row creation on "≥1 duration fact"; the full-population check showed that gate suppressing **9,236 legitimate prior-year comparative balance sheets** (Reg S-X 3-01(a) requires two years of balance sheet, all instant facts) to catch **1,584** real shells. It was the SECOND falsified discriminator on that ticket after `months_covered IS NULL` (38.9% precision). Two failed keys in a row is the signal to question the MODEL, not to try a third key.
 5. Read the relevant engineering skills before writing code.
 6. Make schema/interface changes first.
 7. Implement service logic.
@@ -137,6 +139,21 @@ audit" pass: anything to contest? process inadequate anywhere? spec
 intent orphaned in prose? Findings become tickets IMMEDIATELY (template:
 the 2026-07-17 batch #2066-#2075). Do not fold findings into unrelated
 PRs or leave them in session notes — a finding without a ticket is lost.
+
+**The same rule binds INCIDENTAL findings, not just scheduled audits.** A
+defect noticed while doing something else — a query run in passing, a
+number that looked wrong on a panel, a job whose `success` did not match
+its output — becomes a ticket in that session, before the current task
+resumes. It does not go in the PR description of an unrelated change and
+it does not go in a memory file. Precedent (2026-08-03): five minutes of
+ad-hoc dev-DB queries during an unrelated assessment surfaced three
+unticketed defects — #2213 (OpenFIGI resolution dark for 7 weeks behind
+`success`-reporting sweeps), #2214 (ETF filer typing starved, 1 of
+11,465) and #2215 — none of which any scheduled pass would have found,
+because nothing was failing. **The health signals this app reports are
+self-consistent — a job that no-ops and reports success is invisible to
+every automated check we have.** Manual spot-measurement is currently the
+only detector for that class, so its output must be captured.
 
 ## Parallel-session coordination (#2075; 07-16 race lesson)
 
@@ -274,15 +291,30 @@ test. The `db` marker is auto-applied at collection
 pulls a real-DB fixture or whose module touches `psycopg.connect` /
 the test-DB URL / `run_migrations` / `TestClient`.
 
-The **DB-backed integration tier** (`-m db`, ~half the suite) is OFF the
-per-push path — it was the multi-minute, xdist-flaky, routinely
+The **DB-backed integration tier** (`-m db`, ~44% of the suite) is OFF
+the per-push path — it was the hour-plus, xdist-flaky, routinely
 `--no-verify`'d cost that paid no rent on every push. Run it
 deliberately when you change DB/SQL/ingest/schema code:
 
 ```bash
 docker compose --profile test up -d postgres-test   # once per session
-uv run pytest -m db                                  # full integration tier
+uv run pytest -m db tests/test_<touched>.py ...      # touched modules + neighbours
 ```
+
+⚠ **The cost premise changed on 2026-08-03 (#1568): the full tier is now
+~3.5 min, down from 66 min.** Whether that puts it back on the push gate
+is an OPERATOR call (it changes every push), not an agent one — until
+they decide, the gate is unchanged. But for a broad-surface diff there
+is no longer any excuse to skip the whole tier. Run it in file-scoped
+batches, never bare `-m db` (which has wedged this box twice):
+
+```bash
+find tests -name 'test_*.py' | sort | split -l 40 - /tmp/chunk_
+for f in /tmp/chunk_*; do uv run pytest -m db -q $(tr '\n' ' ' < "$f"); done
+```
+
+Gate on the EXIT CODE — this repo's pytest config suppresses the final
+`N passed` line, so the durations block is the last thing printed.
 
 CI does NOT run pytest (removed 2026-05-05). `--no-verify` is for
 genuine emergencies only (precedent: #1387).

--- a/.claude/skills/metrics-analyst/SKILL.md
+++ b/.claude/skills/metrics-analyst/SKILL.md
@@ -163,7 +163,8 @@ The ownership card is the cleanest example of "one fetch, one snapshot, one deno
 - **Endpoint**: `GET /instruments/{symbol}/ownership-rollup` slices `category="institutions"` and `category="etfs"`; flat list at `GET /instruments/{symbol}/institutional-holdings` ([app/api/instruments.py:4098](../../../app/api/instruments.py#L4098)).
 - **Chart**: `OwnershipPanel.tsx` ring 2 (institutions+etfs).
 - **Cadence**: `sec_13f_quarterly_sweep` Sat 02:00 UTC, 6h deadline. Filer directory walks last 4 closed quarters.
-- **Caveats**: AAPL was historically under-counted ~10× until #840-A through #840-F landed full decomposition. Universe expansion via #841 still pending — institutional totals can lag reality. CUSIP coverage gates the join: 7.4% on dev as of #914 vs 80% target.
+- **Caveats**: AAPL was historically under-counted ~10× until #840-A through #840-F landed full decomposition. Universe expansion via #841 still pending — institutional totals can lag reality.
+  - ⚠ **CUSIP resolution gates the join, and `institutional_holdings.instrument_id` is `NOT NULL` — so an unresolved CUSIP is a DROPPED holding, not a degraded one. Every institutional % is a lower bound.** Measured 2026-08-03: 7,419,463 resolved holding rows vs **33,319,332 unresolved observations** across 109,630 CUSIPs (18.2% by observation). Most unresolved are legitimately out of universe (bonds, options, foreign, non-eToro) so a low absolute rate is EXPECTED and is not itself the defect. **The defect is #2213: the OpenFIGI leg has been dark since 2026-06-18** while the surrounding sweeps kept reporting `success`, and 44,195 CUSIPs (11.2M observations) carry `resolution_status IS NULL` — never attempted, still growing. This is the direct cause of `coverage.state = 'unknown_universe'` on the ownership card for all five golden-panel instruments. (Supersedes the old "7.4% on dev as of #914 vs 80% target" figure.)
 - **Validation**: cross-check vs WhaleWisdom / SEC EDGAR direct; track `unresolved_13f_cusips` count.
 - **denominator_basis**: `pie_wedge`. ETF filer-type holdings come from same 13F data but render as separate slice for legibility.
 
@@ -223,12 +224,21 @@ The ownership card is the cleanest example of "one fetch, one snapshot, one deno
 | insiders | pie_wedge | Beneficial ownership; sums into pie |
 | blockholders | pie_wedge | 13D/G; sums into pie |
 | institutions | pie_wedge | 13F-HR equity; sums into pie |
-| etfs | pie_wedge | 13F-HR by filer-type ETF; sums into pie |
+| etfs | pie_wedge | 13F-HR by filer-type ETF; sums into pie. ⚠ **EMPTY UNIVERSE-WIDE today (#2214)** — see below |
 | def14a_unmatched | proxy_disclosure (memo overlay, #1659) | DEF 14A holders unresolved to Form 4 / 13F. NON-ADDITIVE — a Rule 13d-3 deemed/overlapping disclosure (SEC Item 403), already counted via 13D/G + 13F + Form 4; excluded from pie/residual/concentration, rendered as a cross-check overlay (reverses #1627's additive wedge) |
 | funds | institution_subset | N-PORT positions are strict subset of parent advisor's 13F-HR aggregate; memo overlay only |
 | treasury | (special) | Top-level field; rendered above pie; excluded from concentration numerator |
 
 Future overlays (ESOP #843 / DRS / short-interest #961) will land as additional `institution_subset` rows.
+
+### ⚠ Two slices do not render what their name promises (measured 2026-08-03)
+
+Before quoting either of these to an operator, read the ticket — the API declares the category, the UI carries a wedge, and neither renders.
+
+- **`etfs` is empty for the entire universe (#2214).** `institutional_filers` has **1** filer typed `ETF` and 11,464 typed `INV`, because both inputs to `classify_filer_type` are starved: `etf_filer_cik_seeds` holds 1 row and `ncen_filer_classifications` holds **0** (`ncen_classifier_yearly` ran once on 2026-06-04, reported `success`, wrote nothing, and is on a YEARLY cadence). **Ownership totals are NOT wrong** — ETF-managed 13F holdings still land in `institutions`, so the pie sums correctly. What is lost is the index-vs-active decomposition.
+- **`blockholders` is structurally invisible on any name that also has a 13F/Form 4 filer (#2215).** The data exists (22,770 rows / 4,898 instruments; every golden-panel name has 2-3 rows) but `_PRIORITY_RANK` correctly gives Form 4 / 13F precedence, and Vanguard / BlackRock / State Street file both a 13G and a 13F. So an empty blockholder wedge means "deduped away", NOT "no >5% holder" — opposite conclusions, identical rendering.
+
+**General rule this pair teaches:** a declared-but-empty slice is worse than an absent one, because absence reads as a finding. When adding a category to the rollup, verify it renders non-empty on the golden panel before shipping the wedge.
 
 ### Share-class collapse (GOOGL+GOOG)
 - GOOGL and GOOG share CIK 1652044 (Alphabet) but separate CUSIPs and separate `instrument_id`. Each class has its own card.


### PR DESCRIPTION
Doc-only. Audit prompted by the 2026-08-03 landscape assessment; every change is a claim measurement contradicted, or a rule that demonstrably failed to fire.

## What was wrong

| file | claim | reality |
|---|---|---|
| `.claude/CLAUDE.md` | db tier is "the multi-minute, xdist-flaky" cost; run bare `uv run pytest -m db` | 3.5 min since #1568, and bare `-m db` contradicted `test-quality.md`'s "NEVER bare" (it has wedged this box twice) |
| `metrics-analyst/SKILL.md` | "CUSIP coverage 7.4% on dev as of #914 vs 80% target" | 18.2% by observation, measured 2026-08-03 — and the number was never the point: `institutional_holdings.instrument_id` is `NOT NULL`, so an unresolved CUSIP is a **dropped** holding and every institutional % is a lower bound |
| `metrics-analyst/SKILL.md` | `etfs` slice "13F-HR by filer-type ETF; sums into pie" | empty for the entire universe (#2214) — 1 of 11,465 filers typed ETF |

## Two rules that did not fire

**Step 4b only bound the ISSUE's premise.** #2182 B1 arrived from a prior session labelled "ROOT CAUSE CONFIRMED" with a specific fix. Implementing it would have suppressed **9,236 legitimate prior-year comparative balance sheets** (Reg S-X 3-01(a) requires two years of balance sheet; every column on one is an instant fact) to catch **1,584** real shells. It was the second falsified discriminator on that ticket after `months_covered IS NULL` at 38.9% precision. New **step 4c**: a prior session's conclusion is evidence, not a finding — re-run its discriminator on the full population first. It is one query.

**The retrospective checkpoint only bound scheduled audits.** #2213, #2214 and #2215 all came out of ad-hoc dev-DB queries run during an unrelated assessment. No scheduled pass would have found them, because nothing was failing — `ncen_classifier_yearly` reported `success` having written zero rows, and the CUSIP sweeps reported `success` with their OpenFIGI leg dark for seven weeks. A job that no-ops and reports success is invisible to every automated check in this repo, so manual spot-measurement is currently the only detector for that class and its output has to be captured as tickets.

## Also added

`metrics-analyst` now documents the two slices that don't render what their names promise — `etfs` (starved, #2214) and `blockholders` (deduped away on any name with a 13F filer, #2215) — with the generalised rule: **a declared-but-empty slice is worse than an absent one, because absence reads as a finding.** Verify a new slice renders non-empty on the golden panel before shipping its wedge.

## Verification

Doc-only; no code paths touched. Checked that every `.claude/skills/**` and `docs/**` path referenced from `CLAUDE.md` still resolves (all do). Markdown lint caught a wrapped line beginning `#2214` parsing as an ATX heading — rewrapped.

Refs #1568. Refs #2182. Refs #2213. Refs #2214. Refs #2215.
