### PR TITLE
docs: extract five process lessons from the 2026-08-03 accuracy audit

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -155,6 +155,46 @@ self-consistent — a job that no-ops and reports success is invisible to
 every automated check we have.** Manual spot-measurement is currently the
 only detector for that class, so its output must be captured.
 
+## Subagents: delegate GATHERING, never CONCLUDING
+
+Correctness in this repo depends on context that does not travel: 74 settled
+decisions, 283 prevention-log entries, and per-metric caveats spread across the
+data-foundation skills. A subagent starts without them and cannot know what it has
+not read.
+
+So the split is not by difficulty, it is by **what the output is**:
+
+- **Safe to delegate — measurement and location.** "Run this query and return the
+  distribution." "Find every caller of X." "List the files matching this shape."
+  "Fetch these 20 endpoints and tabulate one field." The result is checkable
+  against the source, and wrong output is obvious.
+- **Do NOT delegate — causal claims, severity, priority, or a fix.** "Why is Y
+  happening", "is this a bug", "which of these matters most", "propose the fix".
+  A subagent will produce a fluent, plausible answer built on the fraction of the
+  decision-history it happened to read, and you will not be able to tell.
+
+The evidence is not hypothetical, and it is not about subagents being weak — the
+MAIN agent made exactly this error on 2026-08-03. I had correct measurements
+(`coverage.state = unknown_universe` on all five golden-panel instruments) and drew
+a confident causal conclusion (#2213 causes it) that was false, because I had read
+`metrics-analyst` but not `settled-decisions.md` or the producing function's
+docstring. Same failure mode a subagent has by construction, in an agent that at
+least *could* have read the context.
+
+Practical consequences:
+
+1. Fan out read-only measurement freely — it is the cheapest parallelism available
+   and this session had four independent ones (fundamentals gaps, ownership state,
+   frontend inventory, instruction-file audit).
+2. Bring the numbers back and do the reasoning **in the main thread**, where the
+   settled decisions are.
+3. If you must delegate an investigation that ends in a judgement, pass the
+   relevant settled decisions and skill sections INTO the prompt. An agent cannot
+   check a rule it was never given.
+4. Prefer a Codex pass over the assembled reasoning to a subagent producing the
+   reasoning — Codex attacks a framing you supply, which is the failure mode you
+   actually have.
+
 ## Parallel-session coordination (#2075; 07-16 race lesson)
 
 Multiple sessions may hold overlapping handoffs. Non-negotiable:
@@ -193,9 +233,46 @@ Multiple sessions may hold overlapping handoffs. Non-negotiable:
 6. Re-run local checks before every follow-up push.
 7. Merge only after review is satisfied on the most recent commit and CI is green.
 
+## Never assert a CAUSE without checking whether the effect is a settled decision
+
+Working-order step 2 ("read `docs/settled-decisions.md`") was being applied only
+to tickets being worked, not to causal claims made while investigating. Those
+are where it matters most, because a cause-claim written into a ticket becomes
+the next session's acceptance criterion.
+
+Before writing "X causes Y" about any operator-visible symptom:
+
+1. `grep` `docs/settled-decisions.md` for Y;
+2. read the **docstring of the function that produces Y** — in this repo the
+   disposal rationale is usually written there, at length, by whoever settled it.
+
+Precedent (2026-08-03, #2213): I filed "the OpenFIGI stall is the direct cause of
+`coverage.state = unknown_universe` on the ownership card". It is not.
+`_read_universe_estimates` returns hard-coded `None` for every category, and its
+docstring records committee verdict #790 (disposed 2026-06-17): *"`unknown_universe`
+IS the truthful state — faking a denominator is the lie."* The state is
+unconditional and correct. Left standing, that claim would have handed the next
+session an acceptance signal that can never move — and pointed them at reopening a
+closed decision. Caught by a Codex pass on the assessment, not by any test.
+
+**A symptom you find surprising is as likely to be a decision you have not read as
+a bug.** Check which, before you write it down.
+
 ## Codex second-opinion — mandatory checkpoints
 
 Codex runs at exactly three points in the workflow. Non-negotiable.
+
+**Where it actually pays (2026-08-03 evidence).** The three checkpoints below are
+all DIFF-shaped, and on that diff Codex found nothing while the review bot found a
+real WARNING. The same day, a Codex pass over an *assessment* — findings, causal
+claims, ticket framing, execution order — caught a false causal claim (#2213), a
+missed ordering dependency, an under-prioritised bug that turned out to be the
+session's largest defect (#2217), and two tickets scoped around a symptom rather
+than their shared root cause (#2218). One session is not a trend, but the shape is
+worth acting on: **Codex earns most on JUDGEMENT artefacts (specs, plans, priority
+orders, causal claims) and least on line-level diffs, where the review bot already
+sits.** When you have an assessment or a plan, hand Codex the numbers and the
+reasoning and ask it to attack the framing — not just "review this diff".
 
 1. **Before writing code** — two Codex passes:
    - **After spec is written, before user final-approves:** `codex exec "Review this spec for <feature>. Path: docs/specs/<area>/<topic>.md (live spec) OR docs/proposals/<area>/<topic>.md (unshipped). Focus on correctness gaps, invariant violations, missing edge cases. For any ownership/filings/metric data-treatment decision: FLAG it if the spec infers the treatment from first principles where a documented source rule exists (SEC reg/Item, EDGAR, form spec) and is not cited; FLAG any signal whose safety rests on a sample rather than a full-population check. Reply terse."` Fix issues before presenting spec to user for sign-off.

--- a/.claude/skills/engineering/full-population-ab.md
+++ b/.claude/skills/engineering/full-population-ab.md
@@ -16,6 +16,41 @@ the panel was green on all seven that still contained real defects. 8 of its 14
 defects were visible only full-population. If you find yourself writing "spot-
 checked on AAPL/GME/MSFT and it looks right", you have not verified anything.
 
+## A documented caveat is a hypothesis about FREQUENCY — measure the rate
+
+The most expensive failure of 2026-08-03 was caused by a skill being right.
+
+`metrics-analyst` documents: *"Treasury IS allowed to push chart 'oversubscribed'
+if Σ pie_wedges + treasury > shares_outstanding (stale-13F + fresh Form 4 mix);
+residual clamps to zero, banner flags it."* True as written. So when the golden
+panel returned `oversubscribed=true` for JPM and HD, I read it as the documented
+condition and moved on. **The caveat functioned as a blindfold.**
+
+Sampling 20 large caps instead of 5 returned **9 oversubscribed** — 45%. A
+condition that fires on nearly half the population is not an edge case, and that
+rate was the tell. The actual cause was arithmetic: `residual` subtracted treasury
+from `shares_outstanding`, a base that already excludes it (shares issued = shares
+outstanding + treasury). GS carries treasury equal to 199.9% of outstanding, so
+`raw` was negative before any holder was counted. Public float rendered as ZERO
+for Coca-Cola, Goldman, JPM, P&G and Exxon (#2217).
+
+The rule:
+
+- A caveat tells you a condition CAN occur. It does not tell you how often, and
+  the author usually did not measure. **"Expected" at 2% is a caveat; the same
+  condition at 45% is a defect wearing the caveat as cover.**
+- When you meet a documented-expected condition in live data, spend the one query
+  it costs to get its RATE across the population before accepting it.
+- The dangerous shape is specifically: a caveat that explains an observation you
+  would otherwise have investigated. That is where it earns its cost.
+- Corollary to "a 3-5 item panel is not evidence": the panel is not evidence for
+  operator-visible METRIC correctness either, not just for parsers. Two of five is
+  a shrug; nine of twenty is an investigation. **A panel too small to carry a rate
+  cannot falsify a caveat.**
+
+Cheapest form of this check: loop the live endpoint over ~20 names and count. It
+took under a minute and it found the largest defect of the session.
+
 ## Choosing the metric
 
 **Row count is the wrong metric, and it is wrong in both directions.**
@@ -64,7 +99,7 @@ When a change **widens** what a selector or scorer can see, its failure mode is
 **admitting things it previously could not see**. A guard tuned against the old
 input has no coverage of them.
 
-#2158's audit reported "0 shapes where the fold lowers the score, 0 newly
+Issue #2158's audit reported "0 shapes where the fold lowers the score, 0 newly
 disqualified" and looked clean. Both counters were the wrong direction. The real
 hazard was Item 402(g) tables **newly clearing the floor** — 47 shapes in a
 300-item smoke, and it emitted vesting data as beneficial ownership.
@@ -101,7 +136,7 @@ Arms 1 and 2 key on the ENTITY identity — for DEF 14A, `holder_name`. Any
 other column the change can move is invisible to both, and the diff will look
 clean while the column is wrong.
 
-#2164 changed a role-heading regex. Arms 1 and 2 were green; a separate
+Issue #2164 changed a role-heading regex. Arms 1 and 2 were green; a separate
 role audit — re-parsing BOTH trees and diffing `{accession: {name: role}}` —
 found **40 holders whose `holder_role` regressed** from `principal` to `None`.
 Nothing in the name-keyed arms could have shown it.
@@ -118,7 +153,7 @@ control's roles from the branch's output.
 When the change deliberately alters the identity key, the raw diff reports the
 whole re-keyed population as loss, and it looks catastrophic.
 
-#2164's arm 1 reported **606 distinct holders lost**. Every one was a re-key:
+Issue #2164's arm 1 reported **606 distinct holders lost**. Every one was a re-key:
 the fix strips zero-width characters and footnote markers from `holder_name`,
 and `holder_name_key` is `lower(trim(...))` — `trim()` removes neither. After
 normalising BOTH sides by the same two transforms, genuine loss was **0**.
@@ -141,7 +176,7 @@ a bad merge reaching stored data.
 Plan for 3+ rounds on any real parser change. One round means you have not
 looked hard enough.
 
-#2164 ran three rounds and found a real defect in each of the first two — 35
+Issue #2164 ran three rounds and found a real defect in each of the first two — 35
 genuine holders lost in round 1, 40 role regressions in round 2. **Codex, 114
 unit tests and the 5-filing panel all passed the round-1 design.** Treat a clean
 Codex review as weak evidence about corpus behaviour; it reads the diff, not the

--- a/.claude/skills/engineering/sql-correctness.md
+++ b/.claude/skills/engineering/sql-correctness.md
@@ -242,7 +242,7 @@ performance decision, not just a correctness one. Check that an index actually
 leads with the column you filter on — "the table has four indexes" means nothing
 if all four lead with something else.
 
-#2157 added an instrument-set lookup filtering `source_document_id` **alone** —
+Issue #2157 added an instrument-set lookup filtering `source_document_id` **alone** —
 by construction there was no `instrument_id` to lead with, since finding the
 instruments was the point. Every index on the table led with `instrument_id` or
 `holder_name_key`, so the lookup sequentially scanned 111,867 rows per accession

--- a/.claude/skills/filings-analyst/SKILL.md
+++ b/.claude/skills/filings-analyst/SKILL.md
@@ -61,7 +61,7 @@ Filing/coverage alerts: `app/api/alerts.py`, `app/api/coverage.py`.
 **Planned (not shipped):** tender / going-private parser (SC TO-T/TO-I/14D9/13E3 →
 `tender_offer_events`) — spec `docs/specs/filings/2026-07-05-tender-going-private-parser.md`;
 no table/parser in the tree yet. Deep filing-text thesis analysis is build-priority
-#3→#4 (CLAUDE.md); LLM memo work lives in the `thesis-writer` / `thesis-critic` skills.
+Issue #3→#4 (CLAUDE.md); LLM memo work lives in the `thesis-writer` / `thesis-critic` skills.
 
 ## Invariants
 

--- a/.claude/skills/frontend/async-data-loading.md
+++ b/.claude/skills/frontend/async-data-loading.md
@@ -208,7 +208,7 @@ When a bug reproduces in the browser but not under test, wrap the render in
 `<StrictMode>` before doubting the repro.
 
 Assert on the DATA handed to the child, not on chrome rendered from URL params —
-#2207's compare chips rendered correctly over a permanently empty series, so a
+Issue #2207's compare chips rendered correctly over a permanently empty series, so a
 chips-only assertion was green throughout. The stub exposes
 `data-compare-rows="MSFT:2,GOOG:2"` precisely so the count is assertable.
 

--- a/.claude/skills/valuation-analyst/SKILL.md
+++ b/.claude/skills/valuation-analyst/SKILL.md
@@ -28,7 +28,7 @@ P/S, P/B + EV/EBITDA percentiles, **fvb_v5** #2043) that feeds the thesis writer
 as passive evidence + a **base-to-base** divergence audit — NOT the thesis
 bear/base/bull. Synthesis rules: peer + own percentiles, blend base,
 **outer-envelope wings clamped by a fixed per-leg cap** (`_R_UP`/`_R_DN`, v2
-#2022), own history uses **interior quantiles p25/p75** (not p20/p80 — a
+Issue #2022), own history uses **interior quantiles p25/p75** (not p20/p80 — a
 near-max of ~6 quarters is unreproducible). **EV/EBITDA is peer-only** (no
 own-history EBITDA exists; snapshot lacks it) with strict D&A + cash-present +
 debt/interest coherence gates and a fail-closed leg drop when the net-debt
@@ -75,7 +75,7 @@ otherwise. Rows are append-only (`UNIQUE(instrument_id, thesis_version)`).
 (`CREATE VIEW`, `sql/201_instrument_valuation_dual_class_suppress.sql:45`,
 latest revision) joining latest quote + TTM fundamentals. It NULLs
 shares-distorted columns for curated dual-class instruments (#1664 /
-#1623). Scoring reads it (`scoring.py:1285`) only when no thesis
+Issue #1623). Scoring reads it (`scoring.py:1285`) only when no thesis
 `base_value` exists.
 
 **Consumed by the scoring value family** — weight `0.25`

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -2549,3 +2549,31 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Symptom: the #1955 sibling-gap class in the **rendering** layer. Two families of overlay draw onto one shared axis; a later change teaches one family about a display-unit mode and misses the other. Nothing fails — both series render, the axis just silently auto-scales to the union of two incompatible units, so an axis label like `250.00` means percent in the lower region and dollars in the upper one with nothing marking the boundary. Worse than the overlays being meaningless: turning them on destroys the readability of the comparison the operator opened compare mode to see. Typecheck and unit tests are blind to it (the numbers are all valid `number`s) and lightweight-charts cannot render in jsdom, so only a browser look catches it.
 - Prevention: when a chart introduces a display-unit mode (% change, log scale, rebased-to-100, currency conversion), grep every `addSeries` / `setData` call site that targets the SAME price scale and confirm each one takes the branch — a shared axis means the transform is a property of the AXIS, not of the series that happened to prompt the change. Pin it with a test asserting the union range of (primary ∪ every overlay) equals the primary's range, i.e. enabling an overlay cannot widen the axis. Prefer deriving the branch from ONE named flag (`compareMode`) over re-deriving `compares.length > 0` per effect, so a reader can grep the flag and enumerate every consumer.
 - Enforced in: this log; `.claude/skills/frontend/design-system.md`; `frontend/src/pages/components/ChartWorkspaceCanvas.tsx` (both the indicator and trend effects branch on `compareMode`); `frontend/src/pages/components/ChartWorkspaceCanvas.test.tsx` ("normalized indicators — compare mode invariants (#2209)").
+
+### A documented caveat became a blindfold — "expected" is a claim about frequency
+
+- First seen in: #2217 (found 2026-08-03 during an unrelated accuracy audit).
+- Symptom: `metrics-analyst` documents that treasury may legitimately push the ownership chart `oversubscribed` on a stale-13F + fresh-Form-4 mix. When the golden panel returned `oversubscribed=true` for JPM and HD, the documented caveat was accepted as the explanation and the observation was dropped. Sampling 20 large caps instead of 5 returned **9** — 45%. The real cause was arithmetic: `_compute_residual` subtracted `treasury_shares` from `shares_outstanding`, a base that already excludes treasury (shares issued = shares outstanding + treasury). GS holds treasury equal to 199.9% of outstanding, so the residual went negative before any holder was counted, clamped to zero, and public float rendered as **ZERO** for Coca-Cola, Goldman, JPM, P&G and Exxon. 12 lines below, `_compute_concentration` already excluded treasury correctly — the right treatment existed in the same file.
+- Prevention: a caveat states that a condition CAN occur; it says nothing about how often, and the author usually never measured. **"Expected" at 2% is a caveat; the same condition at 45% is a defect wearing the caveat as cover.** On meeting a documented-expected condition in live data, spend the one query it costs to get its RATE across the population before accepting it. The dangerous shape is precisely a caveat that explains away an observation you would otherwise have investigated. Also: the 3-5 instrument golden panel is not evidence for operator-visible METRIC correctness, not just for parsers — a panel too small to carry a rate cannot falsify a caveat.
+- Enforced in: this prevention log; `.claude/skills/engineering/full-population-ab.md` ("A documented caveat is a hypothesis about FREQUENCY"). `metrics-analyst` treasury/residual entry to be corrected when #2217 lands.
+
+---
+
+### Asserting a cause without checking whether the effect is a settled decision
+
+- First seen in: #2213 (2026-08-03), caught by a Codex pass over the assessment, not by any test.
+- Symptom: a ticket was filed claiming an OpenFIGI resolution stall was "the direct cause of `coverage.state = unknown_universe` on the ownership card for all five golden-panel instruments". It is not. `ownership_rollup._read_universe_estimates` returns hard-coded `None` for every category, and its docstring records committee verdict #790 (disposed 2026-06-17): *"`unknown_universe` IS the truthful state — faking a denominator is the lie."* The state is unconditional and correct. Left standing, the claim would have given the next session an acceptance signal that can never move, and pointed them at reopening a closed decision.
+- Root cause of the miss: working-order step 2 ("read `docs/settled-decisions.md`") was being applied to tickets being *worked*, not to causal claims made while *investigating* — which is where it matters most, because a cause-claim written into a ticket becomes the next session's acceptance criterion.
+- Prevention: before writing "X causes Y" about any operator-visible symptom, (1) grep `docs/settled-decisions.md` for Y, and (2) read the docstring of the function that produces Y — in this repo the disposal rationale is usually written there at length by whoever settled it. **A symptom you find surprising is as likely to be a decision you have not read as it is to be a bug.**
+- Enforced in: this prevention log; `.claude/CLAUDE.md` ("Never assert a CAUSE without checking whether the effect is a settled decision").
+
+---
+
+### A line beginning `#<digits>` renders as an H1
+
+- First seen in: 2026-08-03, in `.claude/skills/engineering/full-population-ab.md` (4 occurrences) and caught again in a CLAUDE.md edit the same day.
+- Symptom: prose wrapped so that an issue reference lands at the start of a line (`#2164 changed a role-heading regex...`) is parsed by markdown as an ATX heading and renders as giant text, silently corrupting the document structure of a skill file. Invisible in the editor's plain-text view; only the markdown linter (MD018) flags it.
+- Prevention: never let a line start with `#` followed by a digit. Prefix the word `Issue` or rewrap. Markdown lint warnings on `.claude/**` and `docs/**` are worth reading rather than dismissing as cosmetic — this class silently breaks the rendering of the very files agents read for instruction.
+- Enforced in: this prevention log; the four occurrences in `full-population-ab.md` are fixed.
+
+---

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -475,7 +475,7 @@ Entity-level data (10-K text, business summary, financial facts) is
 denormalised across siblings — acceptable for the small share-class
 population (~10 known instruments). If the population grows to 50+, file
 a follow-up to introduce a proper `entities` layer (Option B from the
-#1094 design discussion).
+Issue #1094 design discussion).
 
 `canonical_instrument_id` (#819) is a **different** mechanism for `.RTH`
 operational duplicates — same security, two ticker variants. Don't


### PR DESCRIPTION
Doc-only. Every rule here is a mistake made this session, with the evidence attached — no hypotheticals.

## 1. Never assert a CAUSE without checking settled-decisions (`CLAUDE.md`)

Working-order step 2 says read `docs/settled-decisions.md`. It was being applied to tickets being *worked*, not to causal claims made while *investigating* — which is where it matters most, because a cause-claim written into a ticket becomes the next session's acceptance criterion.

I filed #2213 claiming an OpenFIGI stall was "the direct cause of `coverage.state = unknown_universe`". It is not: `_read_universe_estimates` returns hard-coded `None` for every category, and its docstring records committee verdict #790 — *"`unknown_universe` IS the truthful state — faking a denominator is the lie."* Left standing, that would have handed the next session an acceptance signal that can never move, and pointed them at reopening a closed decision.

**Rule:** before writing "X causes Y", grep settled-decisions for **Y**, and read the docstring of the function that produces Y. In this repo the disposal rationale is usually written there, at length, by whoever settled it. *A symptom you find surprising is as likely to be a decision you have not read as it is to be a bug.*

## 2. Where Codex actually pays (`CLAUDE.md`)

All three mandated checkpoints are **diff-shaped**. Evidence from this session:

| Codex ran on | outcome |
|---|---|
| the #1568 diff (ckpt 2) | "no actionable correctness issues" — the review bot then found a real WARNING |
| an **assessment** (findings, causal claims, ticket framing, order) | caught a false causal claim (#2213), a missed ordering dependency, an under-prioritised bug that became the session's largest defect (#2217), and two tickets scoped around a symptom rather than their shared root cause (#2218) |

One session is not a trend and I have **not** changed the mandate. But the shape is recorded: Codex earns most on judgement artefacts, least on line diffs where the review bot already sits. Hand it the numbers and the reasoning and ask it to attack the framing.

## 3. Subagents: delegate GATHERING, never CONCLUDING (`CLAUDE.md`)

Correctness here depends on context that does not travel — 74 settled decisions, 286 prevention entries, per-metric caveats across the data skills. The split is not by difficulty but by **what the output is**: measurement and location are safe to fan out and checkable against the source; causal claims, severity, priority and proposed fixes are not.

The evidence is not hypothetical and is not about subagents being weak: **the main agent made exactly this error.** Correct measurements, false conclusion, because it had read `metrics-analyst` but not `settled-decisions.md`. Same failure mode a subagent has by construction, in an agent that at least *could* have read the context. Practical form: fan out read-only measurement freely, do the reasoning in the main thread, and if you must delegate a judgement, pass the governing decisions into the prompt — an agent cannot check a rule it was never given.

## 4. A documented caveat is a FREQUENCY hypothesis (`full-population-ab.md`)

The most expensive failure of the session was caused by a skill being **right**.

`metrics-analyst` correctly documents that treasury can push the ownership chart `oversubscribed`. So when the golden panel returned `oversubscribed=true` for JPM and HD, I read the documented condition and moved on. **The caveat functioned as a blindfold.**

Sampling 20 large caps instead of 5 returned **9** — 45%. The cause was arithmetic (#2217): `_compute_residual` subtracts treasury from `shares_outstanding`, a base that already excludes it. Public float renders **ZERO** for Coca-Cola, Goldman, JPM, P&G and Exxon.

**"Expected" at 2% is a caveat; the same condition at 45% is a defect wearing the caveat as cover.** Corollary to the existing "a 3-5 item panel is not evidence": that applies to operator-visible metric correctness too, not just parsers — *a panel too small to carry a rate cannot falsify a caveat*. The check that found it was a one-minute loop over 20 endpoints.

## 5. `#<digits>` at line-start renders as an H1 (prevention log + 6 fixes)

Prose wrapped so an issue ref lands at line-start is parsed as an ATX heading, silently corrupting a skill file's structure. Invisible in plain text; only MD018 flags it. Found 4 in `full-population-ab.md` and 1 in a CLAUDE.md edit the same day.

Fixed all 6 in **rule-bearing files** (`.claude/**` + `settled-decisions.md`). The **28 in `docs/specs/**` are historical records and deliberately left** — that is a scope decision, not an oversight; say so if you want them swept too.

## Verification

Doc-only, no code paths touched. Confirmed zero remaining `^#[0-9]` in `.claude/**`, `settled-decisions.md` and `review-prevention-log.md`. Prevention-log entries: 283 → 286.

Refs #2213. Refs #2217. Refs #2218.
