### PR TITLE
docs: add a review-intensity ladder and close the 8 gaps a Codex verification pass found

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -268,6 +268,34 @@ closed decision. Caught by a Codex pass on the assessment, not by any test.
 **A symptom you find surprising is as likely to be a decision you have not read as
 a bug.** Check which, before you write it down.
 
+## Review-intensity ladder — pick the rung, then stop
+
+**This is the single source for "how much review does this change need". Every other
+file defers to it.** The old set applied near-maximum scrutiny to everything, which
+looks safe and is not: it buries the signal from the checks that matter, and Opus 5
+already self-verifies, so a blanket pass costs tokens without improving the result.
+
+Match the rung to what could actually go wrong. Climbing higher than the change warrants
+is a defect, not diligence.
+
+| the change is… | what it gets |
+| --- | --- |
+| **A narrow diff** — one or two files, mechanical, no data semantics | self-review + the deterministic pre-push hook + the review bot. **Nothing else.** No second-opinion pass, no lens library, no extra agent. |
+| **A behavioural change with data semantics** — service logic, endpoints, scoring inputs | the above + the relevant domain skill read for the surface touched |
+| **A corpus change** — parser, ETL, schema migration, metric derivation | the above + full-population A/B (`full-population-ab.md`) + Definition-of-Done clauses 8-12 evidence table. **This rung is non-negotiable; it is evidence, not reassurance.** |
+| **A judgement artefact** — spec, plan, causal claim, priority order, acceptance criteria | a second opinion on the FRAMING (this is where Codex has actually paid — see below) |
+| **A high-stakes cross-domain plan** | committee review, capped at 2-3 lenses unless the operator explicitly asks for the full panel |
+| **A rebuttal-only merge round** | a second opinion on the REBUTTED CLAIMS ONLY — never a whole-diff re-review |
+
+Two rules that cut across every rung:
+
+- **Never ask a reviewer to be conservative.** No "only real bugs", no "high-severity
+  only", no "skip nits". Opus 5 takes it literally and reports less. Ask for everything;
+  classify severity yourself afterwards.
+- **Never run a second agent to check your own work.** If you can review it yourself in a
+  handful of tool calls, do that. Deterministic gates (hook, CI, A/B harness) are not
+  "another pass" — they produce evidence you do not already have.
+
 ## Codex second-opinion — mandatory checkpoints
 
 Codex runs at exactly three points in the workflow. Non-negotiable.
@@ -285,7 +313,7 @@ sits.** When you have an assessment or a plan, hand Codex the numbers and the
 reasoning and ask it to attack the framing — not just "review this diff".
 
 1. **Before writing code** — two Codex passes:
-   - **After spec is written, before user final-approves:** `codex exec "Review this spec for <feature>. Path: docs/specs/<area>/<topic>.md (live spec) OR docs/proposals/<area>/<topic>.md (unshipped). Focus on correctness gaps, invariant violations, missing edge cases. For any ownership/filings/metric data-treatment decision: FLAG it if the spec infers the treatment from first principles where a documented source rule exists (SEC reg/Item, EDGAR, form spec) and is not cited; FLAG any signal whose safety rests on a sample rather than a full-population check. Reply terse."` Fix issues before presenting spec to user for sign-off.
+   - **After spec is written, before user final-approves:** `codex exec "Review this spec for <feature>. Path: docs/specs/<area>/<topic>.md (live spec) OR docs/proposals/<area>/<topic>.md (unshipped). Report EVERY plausible correctness gap, invariant violation and missing edge case — do not pre-filter by severity or confidence, I will classify afterwards. For any ownership/filings/metric data-treatment decision: FLAG it if the spec infers the treatment from first principles where a documented source rule exists (SEC reg/Item, EDGAR, form spec) and is not cited; FLAG any signal whose safety rests on a sample rather than a full-population check. Reply terse."` Fix issues before presenting spec to user for sign-off.
    - **After implementation plan is written, before first task dispatch:** same invocation against the plan doc. Catches plan-shape bugs (bad task decomposition, missing dependency, wrong contract) before any subagent starts coding.
 2. **Before first push** — after self-review + local gates pass, run `codex exec review` on the branch. Fix anything real before pushing.
 3. **Before merging on a rebuttal-only round** — if the latest review's findings are all rebuttals (no code changes pending), run Codex to confirm the rebuttals are sound. Without this step, rebuttals are unverified and may hide real bugs the review bot *did* catch in disguise.
@@ -432,7 +460,9 @@ Both must pass.
 
 ## Required engineering skills
 
-Read and apply these before pushing:
+Read and apply these before pushing — **scoped by the review-intensity ladder above**,
+not all of them on every diff. A narrow change needs the pre-push checklist and
+nothing more:
 
 - `.claude/skills/engineering/pre-flight-review.md`
 - `.claude/skills/engineering/pre-pr-fresh-agent-review.md` — a LENS LIBRARY (financial-plumbing / data-engineer / data-scientist / adversarial) for filings ETL, schema, identity-resolution and observations diffs. **No longer a mandatory pre-push gate** (revised 2026-08-03): a blanket second-agent pass before every push is the "use a subagent to verify" pattern Anthropic's Opus 5 guidance says causes over-verification, and it contradicted this file's own "delegate gathering, never concluding" rule. Reach for the lenses when a diff on those surfaces is genuinely large or unfamiliar.
@@ -465,7 +495,7 @@ Read and apply these before pushing:
 
 ## Settled decisions
 
-→ Covered in the Working order above (steps 2 and 4).
+→ Covered in the Working order above (steps 2 and 3), and by the rule "Never assert a CAUSE without checking whether the effect is a settled decision".
 
 ## Repo discipline
 

--- a/.claude/skills/committee-review/SKILL.md
+++ b/.claude/skills/committee-review/SKILL.md
@@ -7,6 +7,18 @@ description: Multi-agent committee review of a plan, spec, or design document. D
 
 ## When to use
 
+> ⚠ **Default to 2-3 lenses, not 8 (revised 2026-08-03).** This skill dispatches 7 agents
+> plus a Codex pass and blocks on all 8. That collides with `CLAUDE.md`'s subagent rule
+> ("if one agent can do it, use one, not several") and with Anthropic's Opus 5 guidance
+> on capping delegation — Opus 5 delegates readily, and 8 agents on a doc that needed two
+> is the single most expensive mistake available in this repo.
+>
+> Escalate to the full panel ONLY when the operator asks for it explicitly, or when a
+> 2-3 lens pass has already returned findings that genuinely span more boundaries than
+> those lenses covered. Pick the 2-3 by where the doc is most likely to be WRONG, not by
+> what would be nice to have. The full panel is the top rung of the review-intensity
+> ladder in `CLAUDE.md`; do not climb to it by default.
+
 Trigger this skill when:
 - A plan, spec, or design doc is about to gate code-writing work (high cost of being wrong).
 - The doc has already been through 1+ review rounds AND prior reviews produced unverified-claim findings (signal: prior plan cited APIs that don't exist).

--- a/.claude/skills/engineering/full-population-ab.md
+++ b/.claude/skills/engineering/full-population-ab.md
@@ -16,6 +16,20 @@ the panel was green on all seven that still contained real defects. 8 of its 14
 defects were visible only full-population. If you find yourself writing "spot-
 checked on AAPL/GME/MSFT and it looks right", you have not verified anything.
 
+**This does not contradict Definition-of-Done clause 8** (`CLAUDE.md`), which requires
+smoking the AAPL/GME/MSFT/JPM/HD panel. The two answer different questions and both are
+required on a corpus change:
+
+| | question it answers | what a green result proves |
+| --- | --- | --- |
+| **Golden panel (DoD 8-11)** | does the operator-visible figure still RENDER, end to end, after the backfill? | the read path works on known-good instruments |
+| **Full-population A/B** | is the change SAFE across the corpus? | nothing was silently lost or admitted at scale |
+
+A green panel with no A/B means "it renders" and says nothing about safety. An A/B with
+no panel means "the numbers moved as intended" and says nothing about whether the chart
+still draws. Neither substitutes for the other — and a panel too small to carry a rate
+also cannot falsify a documented caveat (see below).
+
 ## A documented caveat is a hypothesis about FREQUENCY — measure the rate
 
 The most expensive failure of 2026-08-03 was caused by a skill being right.
@@ -173,8 +187,11 @@ earlier fix **in the same PR**. Expect this. Fix them in the same PR rather than
 shipping the widening and filing the fallout; each round is cheap compared with
 a bad merge reaching stored data.
 
-Plan for 3+ rounds on any real parser change. One round means you have not
-looked hard enough.
+Budget for multiple rounds on any real parser change: every round that FINDS something,
+or that changes the harness, invalidates the previous one and needs a re-run. A single
+clean round is sufficient only when the harness demonstrably covers all three arms and
+the blind spots listed above — it is the harness coverage that justifies stopping, not
+the round count.
 
 Issue #2164 ran three rounds and found a real defect in each of the first two — 35
 genuine holders lost in round 1, 40 role regressions in round 2. **Codex, 114

--- a/.claude/skills/engineering/pre-flight-review.md
+++ b/.claude/skills/engineering/pre-flight-review.md
@@ -96,7 +96,16 @@ Ask:
 - did I create hidden tech debt without recording it?
 
 ### I. Settled decision check
-Before coding, read `docs/settled-decisions.md` and list every decision that applies to this issue.
+
+> ⚠ These two sections (I and J) are **planning-time input, not a pre-push ritual**. This
+> is a pre-PUSH self-review skill, so by the time you read it the decisions should already
+> have shaped the code — re-listing them here produces prose, not safety. Use them as a
+> last-look filter: *did anything I actually wrote contradict a decision or repeat a
+> prevention entry?* If not, write nothing. Per `CLAUDE.md` working order step 2, cite an
+> entry only where it shapes or blocks the plan; a standalone "no settled decision
+> applies" sentence is worth nothing.
+
+Read `docs/settled-decisions.md` for decisions touching the surface you changed.
 
 For each relevant decision:
 - state what the rule is
@@ -117,7 +126,10 @@ Typical examples:
 - action-specific execution guard rules
 
 ### J. Prevention log check
-Before coding, read `docs/review-prevention-log.md` and identify any entries relevant to this issue.
+
+Same posture as I — a last-look filter, not a survey to narrate.
+
+Read `docs/review-prevention-log.md` for entries matching the bug classes your diff could plausibly reintroduce.
 
 For each relevant entry:
 - state the bug class

--- a/.claude/skills/engineering/pre-pr-fresh-agent-review.md
+++ b/.claude/skills/engineering/pre-pr-fresh-agent-review.md
@@ -102,4 +102,4 @@ If our observations table doesn't carry a field EdgarTools exposes for the same 
 
 ## Perf-claim diffs
 
-If the diff also asserts a performance improvement (latency, throughput, wall-clock) against any ETL hot path, the [`etl-perf-claims`](etl-perf-claims.md) skill is mandatory in this fresh-agent review pass — load it alongside the financial-plumbing / data-engineer / data-scientist / adversarial lenses so the §4 artifact contract + §5 process rules are part of the lens stack before push.
+If the diff asserts a performance improvement (latency, throughput, wall-clock) against any ETL hot path, [`etl-perf-claims`](etl-perf-claims.md) applies **whether or not you run this lens pass** — its §4 artifact contract is enforced by the `perf-claim-lint` CI gate, so it is a deterministic requirement on the change, not a step in a review. Load it as a lens too if you are running this pass anyway.


### PR DESCRIPTION
Doc-only. Second Codex pass over the merged Opus 5 tuning (#2220). It confirmed the big changes landed, then found the set still carried verification-as-ritual in several places — and made the sharper structural point that the whole thing is **too heavy for narrow work**.

## The core problem it named

> *"The current instructions still make a small fix walk through settled-decision reading, prevention-log reading, self-review, pre-push checklist, mandatory Codex diff review, review bot, CI, and possibly rebuttal Codex. The new final reminder says 'do the narrow task,' but the mandatory sections do not provide enough explicit escape hatches."*

That's correct, and adding "be concise" to the end of the file was never going to fix it. The fix is a **review-intensity ladder** in `CLAUDE.md` — the single source every other file now defers to:

| the change is… | what it gets |
| --- | --- |
| narrow diff | self-review + pre-push hook + review bot. **Nothing else.** |
| behavioural, data semantics | + the domain skill for the surface touched |
| **corpus change** (parser/ETL/schema/metric) | + full-population A/B + DoD 8-12 evidence. **Non-negotiable — evidence, not reassurance.** |
| judgement artefact (spec, plan, causal claim, priority order) | second opinion on the FRAMING |
| high-stakes cross-domain plan | committee, capped at 2-3 lenses unless the operator asks for the full panel |
| rebuttal-only round | second opinion on the REBUTTED CLAIMS only, never a whole-diff re-review |

**Climbing higher than the change warrants is now explicitly a defect, not diligence.**

## The 8 specific gaps, each verified in the file before changing

1. **The demotion was half-done.** `pre-pr-fresh-agent-review` says "not a verification gate" but still sat inside `CLAUDE.md`'s "Read and apply these before pushing" list — so the optional file remained part of the mandatory reading set. Its `etl-perf-claims` clause also still read "mandatory in this fresh-agent review pass"; reworded, since that artifact contract is enforced by the `perf-claim-lint` CI gate and binds the **change** regardless of whether any review runs.
2. **Stale cross-reference** — "Covered in the Working order above (steps 2 and 4)" predated merging old steps 2+3. My renumbering script checked for `step 4b`/`4c` but not this phrasing.
3. **`pre-flight-review` contradicted yesterday's de-ritualisation** — sections I and J still demanded listing every applicable settled decision and explicitly saying none apply. Reframed as a last-look filter.
4. **The mandated Codex spec prompt still said "Focus on correctness gaps…"** with no report-everything framing — the same Opus 5 trap I'd fixed in the lens library but not here.
5. **`full-population-ab` said "Plan for 3+ rounds. One round means you have not looked hard enough"** — an unconditional re-check instruction. Now: rounds are justified by what they *find* and by harness changes; one clean round suffices when the harness covers all three arms.
6. **DoD clause 8 read as contradicting "a 3-5 panel is not evidence".** Added a table making the split explicit — the panel proves the read path **renders**, the A/B proves the change is **safe**. Both required; neither substitutes.
7. **`committee-review` dispatches 7 agents + Codex and blocks on all 8**, colliding with "if one agent can do it, use one, not several". Now defaults to 2-3 lenses.

## Still not changed

**The mandatory Codex checkpoints.** Codex has now recommended removing the diff-shaped ones twice, and the guidance supports it — it notes the file itself admits diff passes paid poorly, then mandates them anyway, and that this conflicts with the new final reminder's "no extra pass 'to be safe'". It stays because it is the operator's declared process. The ladder now makes the recommended replacement concrete, so adopting it is a one-line change if they want it.

## Verification

Doc-only. Confirmed zero remaining instances of the three fixed anti-patterns (`steps 2 and 4`, `Real correctness bugs only`, `If none, say "None"`) anywhere under `.claude/`. Two markdown table separators normalised after MD060 flagged them.
