### PR TITLE
docs: close the global-project seam and the last coherence defects

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -100,7 +100,7 @@ Follow this order unless the user explicitly says otherwise:
 8. Self-review the diff using the pre-flight review skill.
 9. Run local checks.
 10. Write a complete PR description.
-11. Follow the branch and PR workflow below — push, poll, wait, resolve, repeat until APPROVE on the most recent commit with CI green.
+11. Follow the branch and PR workflow below — push, poll, wait, resolve, repeat until the review is SATISFIED on the most recent commit with CI green. "Satisfied" means an APPROVE, **or** the bot's doc-only skip notice ("Doc-only diff — engineering review skipped to save tokens"), which is a terminal state, not a pending one — a doc-only PR can never receive an APPROVE, so reading this gate literally makes such PRs permanently unmergeable.
 
 ## Terminal step of a ticket — never leave state to reconstruct
 
@@ -220,54 +220,6 @@ Multiple sessions may hold overlapping handoffs. Non-negotiable:
    re-detach), re-check live state via gh/git — a sibling may have done
    it already.
 
-## Branch and PR workflow
-
-1. Create a branch before touching code.
-   - `feature/{issue-number}-short-description`
-   - `fix/{issue-number}-short-description`
-2. Commit only on that branch.
-3. Push and open a PR.
-   After every push, poll:
-   - `gh pr view {pr_number} --comments`
-   - `gh pr checks {pr_number}`
-
-   Do not push again until:
-   - the Claude review has posted
-   - CI results are visible
-   - all review comments have been read
-
-   Do not push a follow-up commit for CI alone without first reading the review comments on the latest commit.
-   If the review has not posted yet, wait and poll again rather than continuing blindly.
-4. Wait for Claude review and CI on the latest commit.
-5. Resolve every review comment explicitly.
-6. Re-run local checks before every follow-up push.
-7. Merge only after review is satisfied on the most recent commit and CI is green.
-
-## Never assert a CAUSE without checking whether the effect is a settled decision
-
-Working-order step 2 ("read `docs/settled-decisions.md`") was being applied only
-to tickets being worked, not to causal claims made while investigating. Those
-are where it matters most, because a cause-claim written into a ticket becomes
-the next session's acceptance criterion.
-
-Before writing "X causes Y" about any operator-visible symptom:
-
-1. `grep` `docs/settled-decisions.md` for Y;
-2. read the **docstring of the function that produces Y** — in this repo the
-   disposal rationale is usually written there, at length, by whoever settled it.
-
-Precedent (2026-08-03, #2213): I filed "the OpenFIGI stall is the direct cause of
-`coverage.state = unknown_universe` on the ownership card". It is not.
-`_read_universe_estimates` returns hard-coded `None` for every category, and its
-docstring records committee verdict #790 (disposed 2026-06-17): *"`unknown_universe`
-IS the truthful state — faking a denominator is the lie."* The state is
-unconditional and correct. Left standing, that claim would have handed the next
-session an acceptance signal that can never move — and pointed them at reopening a
-closed decision. Caught by a Codex pass on the assessment, not by any test.
-
-**A symptom you find surprising is as likely to be a decision you have not read as
-a bug.** Check which, before you write it down.
-
 ## Review-intensity ladder — pick the rung, then stop
 
 **This is the single source for "how much review does this change need". Every other
@@ -296,13 +248,101 @@ Two rules that cut across every rung:
   handful of tool calls, do that. Deterministic gates (hook, CI, A/B harness) are not
   "another pass" — they produce evidence you do not already have.
 
+## Branch and PR workflow
+
+**How much review this PR needs is decided by the review-intensity ladder above, not
+by this section.** What follows is the mechanical sequence, which is the same at every
+rung; the ladder decides what feeds into it.
+
+1. Create a branch before touching code.
+   - `feature/{issue-number}-short-description`
+   - `fix/{issue-number}-short-description`
+   - `docs/{issue-number}-short-description` or `docs/{short-description}` — instruction
+     set, skills, prevention log, specs. Maintenance of the operating documents often has
+     no ticket, and inventing one to satisfy a naming rule is worse than the rule.
+   - `chore/{short-description}` — tooling, CI, dependency bumps.
+2. Commit only on that branch.
+3. Push and open a PR.
+   After every push, poll:
+   - `gh pr view {pr_number} --comments`
+   - `gh pr checks {pr_number}`
+
+   Do not push again until:
+   - the Claude review has posted
+   - CI results are visible
+   - all review comments have been read
+
+   Do not push a follow-up commit for CI alone without first reading the review comments on the latest commit.
+   If the review has not posted yet, wait and poll again rather than continuing blindly.
+4. Wait for Claude review and CI on the latest commit.
+5. Resolve every review comment explicitly.
+6. Re-run local checks before every follow-up push.
+7. Merge only after review is satisfied on the most recent commit and CI is green
+   ("satisfied" = APPROVE, or the doc-only skip notice — see Working order step 11).
+
+### Composition with the global `~/.claude/CLAUDE.md`
+
+That file states the same workflow for every project the operator works on. Where the two
+disagree, **this file wins for eBull work** — it knows the repo's CI gates and the review
+bot's actual behaviour. Two specific reconciliations (raised 2026-08-03):
+
+- **"Close all linked issues" on merge** — do NOT apply literally. This repo's PR template
+  and the `pr-issue-link` CI gate deliberately distinguish `Closes/Fixes/Resolves` (issue
+  closes) from `Refs/Part of/Umbrella` (issue stays open). Closing a referenced umbrella
+  or parent issue because a child PR merged is a regression, not compliance. Close what
+  the PR resolves; leave the rest.
+- **Branch naming** — the global file lists only `feature/` and `fix/`. This file adds
+  `docs/` and `chore/`, because instruction-set and tooling maintenance frequently has no
+  ticket and minting one to satisfy a naming rule is worse than the rule.
+
+Both are worth fixing in the global file too, but that is the operator's to edit — it
+affects all their projects, not just this one.
+
+## Never assert a CAUSE without checking whether the effect is a settled decision
+
+Working-order step 2 ("read `docs/settled-decisions.md`") was being applied only
+to tickets being worked, not to causal claims made while investigating. Those
+are where it matters most, because a cause-claim written into a ticket becomes
+the next session's acceptance criterion.
+
+Before writing "X causes Y" about any operator-visible symptom:
+
+1. `grep` `docs/settled-decisions.md` for Y;
+2. read the **docstring of the function that produces Y** — in this repo the
+   disposal rationale is usually written there, at length, by whoever settled it.
+
+Precedent (2026-08-03, #2213): I filed "the OpenFIGI stall is the direct cause of
+`coverage.state = unknown_universe` on the ownership card". It is not.
+`_read_universe_estimates` returns hard-coded `None` for every category, and its
+docstring records committee verdict #790 (disposed 2026-06-17): *"`unknown_universe`
+IS the truthful state — faking a denominator is the lie."* The state is
+unconditional and correct. Left standing, that claim would have handed the next
+session an acceptance signal that can never move — and pointed them at reopening a
+closed decision. Caught by a Codex pass on the assessment, not by any test.
+
+**A symptom you find surprising is as likely to be a decision you have not read as
+a bug.** Check which, before you write it down.
+
 ## Codex second-opinion — mandatory checkpoints
 
 Codex runs at exactly three points in the workflow. Non-negotiable.
 
-**Where it actually pays (2026-08-03 evidence).** The three checkpoints below are
-all DIFF-shaped, and on that diff Codex found nothing while the review bot found a
-real WARNING. The same day, a Codex pass over an *assessment* — findings, causal
+> ⚠ **KNOWN CONTRADICTION with the review-intensity ladder above — operator decision
+> pending (raised 2026-08-03).** The ladder says a narrow diff gets "self-review +
+> pre-push hook + review bot, nothing else" and that you should never run a second agent
+> to check your own work. Checkpoint 2 below mandates `codex exec review` on every branch
+> before first push, which contradicts both.
+>
+> **Until the operator rules, checkpoint 2 wins** — it is their declared process and this
+> note exists so the conflict is deterministic rather than silent, not so it can be
+> quietly ignored.
+>
+> The recommendation on the table is to RE-TARGET rather than delete: keep checkpoints 1
+> and 3 (both judgement-artefact shaped, where Codex has demonstrably paid), drop
+> checkpoint 2, and let the ladder decide when a diff warrants a second opinion.
+
+**Where it actually pays (2026-08-03 evidence).** Checkpoint 2 is DIFF-shaped, and on
+that diff Codex found nothing while the review bot found a real WARNING. The same day, a Codex pass over an *assessment* — findings, causal
 claims, ticket framing, execution order — caught a false causal claim (#2213), a
 missed ordering dependency, an under-prioritised bug that turned out to be the
 session's largest defect (#2217), and two tickets scoped around a symptom rather
@@ -338,7 +378,8 @@ Push + wait for Claude review bot + CI
 Bot findings? → Triage each: FIXED / DEFERRED / REBUTTED
   ↓
 Any rebuttals on latest review?
-  ├─ No  → all fixed → merge when green + APPROVE on latest commit
+  ├─ No  → all fixed → merge when green + review SATISFIED on latest commit
+  │                      (APPROVE, or the doc-only skip notice — see step 11)
   └─ Yes → Codex review (checkpoint 3: before rebuttal-only merge)
             ↓
             Codex + author both agree rebuttals sound + nothing else to do → merge

--- a/.claude/skills/engineering/pr-authoring.md
+++ b/.claude/skills/engineering/pr-authoring.md
@@ -65,7 +65,7 @@ Examples:
 - missing quote fallback
 
 ### Security model
-State the security story explicitly: input surfaces touched, and whether any execution path is affected (if so, confirm the execution guard is called and `decision_audit` is written before any order is staged). If none, say "No execution path touched." (Template heading: "Security and audit model".)
+State the security story: input surfaces touched, and whether any execution path is affected (if so, confirm the execution guard is called and `decision_audit` is written before any order is staged). **This is the ONE section that is never omitted** — the PR template always carries the heading, and silence about security reads as "not considered" rather than "not applicable". When nothing applies, one line is the whole section: "No execution path touched." Do not expand it into a paragraph to look thorough. (Template heading: "Security and audit model".)
 
 ### Tests added
 Summarise the behaviour covered by tests.

--- a/.claude/skills/engineering/pre-push-checklist.md
+++ b/.claude/skills/engineering/pre-push-checklist.md
@@ -57,9 +57,18 @@ marker stays absent ~15s) is stolen; a live owner is waited on
 indefinitely. Fast tier ~60-90s under load (the ~25s figure above is
 quiet-machine).
 
-## Then read `git diff origin/main...HEAD` top to bottom
+## Then check the branch diff — scope always, contents proportionally
 
-Adopt the reviewer's posture: read what is there, not what you intended.
+The branch-SCOPE check below is **not optional at any rung** — it is the only thing
+standing between you and a silent revert of somebody else's merged work, and it is one
+command.
+
+Reading the whole diff top to bottom is a different matter: on a narrow change you have
+just written and already reviewed, a second full pass is the re-check Opus 5 already
+performs, and the review-intensity ladder in `CLAUDE.md` says to skip it. Read the diff
+in full when it is large, unfamiliar, spans surfaces you did not hold in mind at once,
+or touches data semantics. When you do, adopt the reviewer's posture: read what is
+there, not what you intended.
 
 **First, check the branch SCOPE — one command, catches silent reverts:**
 


### PR DESCRIPTION
Doc-only. Third and **final** Codex pass, deliberately scoped away from another rule-by-rule sweep — running review passes until they stop finding things is itself the over-verification pattern this work has been removing. Codex's closing verdict, which I asked for explicitly:

> *"Stop after those. The remaining problems are not rule-level correctness bugs; they are consolidation and one global-file policy decision. A fourth broad pass over the same instruction set today would be the over-verification pattern you are trying to remove."*

## The new angle: the global `~/.claude/CLAUDE.md`

Neither prior pass had looked at it. It governs every project, composes with the project file, and lives outside the repo. Auditing my own behaviour against it, **I violated it four times today without noticing.**

| conflict | verdict |
|---|---|
| Branch naming — `docs/…` matches neither `feature/{issue}` nor `fix/{issue}` | confirmed; `docs/` + `chore/` added project-side |
| "Merge only after APPROVE" — the bot **skips** doc-only diffs, so those PRs could never be mergeable | confirmed; skip is now an explicit satisfying terminal state |
| Security prose conflict | **partly refuted** — see below |
| "Re-read the diff myself" is a redundant re-check | partly confirmed; scoped rather than deleted |

Plus four Codex found that I hadn't, including that global "close all linked issues" would **wrongly close umbrella/parent issues**, since this repo's template and `pr-issue-link` gate deliberately distinguish `Closes` from `Refs`/`Part of`.

## Where Codex refuted me, and it mattered

I claimed the project file said "omit the security section if nothing to say", conflicting with global. It doesn't — the general rule says omit filler, the security subsection says write `"No execution path touched"`, and the PR template *always* renders the heading. So it was **internal project ambiguity**, not a global conflict. Resolved toward the template: security is the one section never omitted, because silence reads as "not considered" rather than "not applicable" — but one line is the whole section when nothing applies.

## The coherence fixes

- **Ladder moved above "Branch and PR workflow".** A top-down reader hit the PR workflow and its merge gate before the ladder that decides how much review any of it needs. All three "ladder above" references still resolve.
- **The ladder/Codex contradiction is now explicit rather than silent.** The ladder says a narrow diff gets "nothing else" and never a second agent to check your own work; checkpoint 2 mandates `codex exec review` before every first push. Precedence is stated — checkpoint 2 wins until the operator rules — with the re-targeting recommendation attached. **An operating document must not carry two mandatory rules that contradict without saying which wins.**
- **Fixed a factual error I introduced**: "the three checkpoints below are all DIFF-shaped". Checkpoint 1 is spec/plan review; only checkpoint 2 is diff-shaped.
- **Diff re-read scoped, not deleted.** The branch-SCOPE check stays mandatory at every rung — it is the one thing standing between us and a silent revert of merged work (there is precedent) — while reading the whole diff top to bottom is now proportional to size and unfamiliarity.

## Left for the operator

Four items in the **global** file, which I have not touched because it affects all their projects: branch-naming patterns, "close all linked issues", the "re-read the diff myself" clause, and the requirement that commit messages enumerate each review concern — a burden the project layer neither imposes nor advertises.

## Verification

Doc-only. Confirmed the moved section is intact and unsplit (25 `##` headings before and after), all three directional references to the ladder still point backwards correctly, and no stale `until APPROVE` phrasing remains.
