### PR TITLE
docs: point the final reminder at the global file instead of restating it

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -575,21 +575,20 @@ When replying to review:
 
 ## Final reminder — read this last
 
-This file is long. These four are the ones that decay first, so they are repeated here
-deliberately (Anthropic's Opus 5 guidance recommends pairing a conciseness instruction
-in a long prompt with a short reminder near the end).
+**These rules are STATED in the global `~/.claude/CLAUDE.md` ("Working with Claude
+Opus 5"), which is their single source.** They are echoed here — as a list of names, not
+a restatement — because this file is long and Anthropic's Opus 5 guidance recommends
+pairing a conciseness instruction with a short reminder near the end of a long prompt.
+If a rule below ever disagrees with the global file, the global file is right and this
+list is stale.
 
-- **Be concise.** Keep replies and written documents as short as the substance allows.
-  Cover what matters; do not pad with filler sections, redundant summaries or
-  boilerplate. This applies to PR descriptions, specs and issue comments as much as to
-  chat — Opus 5's written deliverables run long by default.
-- **Do the narrow task.** Deliver what was asked at the scope intended. Make routine
-  judgement calls yourself; check in only where different readings lead to materially
-  different work. If a better approach exists, say so in a sentence and continue.
-- **Don't add verification the model already does.** No re-checking your own answer, no
-  second agent to confirm your work, no extra pass "to be safe". The deterministic gates
-  (pre-push hook, full-population A/B on corpus changes, the review-comment resolution
-  contract) stay — those are evidence, not reassurance.
-- **Ask a reviewer for everything, filter afterwards.** Never prompt a review with "only
-  real bugs" or "be conservative" — Opus 5 takes it literally and reports less. Get the
-  full list, then classify severity yourself.
+- **Be concise** — replies and written documents both.
+- **Do the narrow task** — at the scope asked, without quietly widening it.
+- **Don't add verification the model already does** — no re-checking your own answer, no
+  second agent to confirm your own work.
+- **Ask a reviewer for everything, filter afterwards** — never "only real bugs".
+
+The eBull-specific half is the **review-intensity ladder** above: it decides which of
+this repo's gates a given change actually needs. The deterministic ones it selects —
+pre-push hook, full-population A/B on corpus changes, the review-comment resolution
+contract — are evidence, not reassurance, and none of the above weakens them.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -149,7 +149,7 @@ left only in a PR description of an unrelated change, or in a memory file.
 File it immediately when it is high-risk, cheap to write up, or would be
 lost once the context is gone. Otherwise record the evidence in a short
 handoff note and file it at the end of the task. **Do not turn a narrow
-ticket into an audit** — Opus 5 expands scope readily, and "I found
+ticket into an audit** — scope expands readily under agentic work, and "I found
 something while I was in there" is the most common way a one-file fix
 becomes a session. Precedent (2026-08-03): five minutes of
 ad-hoc dev-DB queries during an unrelated assessment surfaced three
@@ -193,8 +193,8 @@ Practical consequences:
    and this session had four independent ones (fundamentals gaps, ownership state,
    frontend inventory, instruction-file audit). **But do not delegate work you can
    finish yourself in a handful of tool calls, and never spawn an agent to verify or
-   double-check your own work** — Opus 5 delegates more readily than earlier models
-   and already self-verifies, so both patterns cost tokens and time without improving
+   double-check your own work** — delegation is cheap to reach for and self-verification
+   already happens, so both patterns cost tokens and time without improving
    the result. If one agent can do it, use one, not several.
 2. Bring the numbers back and do the reasoning **in the main thread**, where the
    settled decisions are.
@@ -224,8 +224,8 @@ Multiple sessions may hold overlapping handoffs. Non-negotiable:
 
 **This is the single source for "how much review does this change need". Every other
 file defers to it.** The old set applied near-maximum scrutiny to everything, which
-looks safe and is not: it buries the signal from the checks that matter, and Opus 5
-already self-verifies, so a blanket pass costs tokens without improving the result.
+looks safe and is not: it buries the signal from the checks that matter, and
+self-verification already happens, so a blanket pass costs tokens without improving the result.
 
 Match the rung to what could actually go wrong. Climbing higher than the change warrants
 is a defect, not diligence.
@@ -242,7 +242,7 @@ is a defect, not diligence.
 Two rules that cut across every rung:
 
 - **Never ask a reviewer to be conservative.** No "only real bugs", no "high-severity
-  only", no "skip nits". Opus 5 takes it literally and reports less. Ask for everything;
+  only", no "skip nits". A good reviewer takes it literally and reports less. Ask for everything;
   classify severity yourself afterwards.
 - **Never run a second agent to check your own work.** If you can review it yourself in a
   handful of tool calls, do that. Deterministic gates (hook, CI, A/B harness) are not
@@ -506,7 +506,7 @@ not all of them on every diff. A narrow change needs the pre-push checklist and
 nothing more:
 
 - `.claude/skills/engineering/pre-flight-review.md`
-- `.claude/skills/engineering/pre-pr-fresh-agent-review.md` — a LENS LIBRARY (financial-plumbing / data-engineer / data-scientist / adversarial) for filings ETL, schema, identity-resolution and observations diffs. **No longer a mandatory pre-push gate** (revised 2026-08-03): a blanket second-agent pass before every push is the "use a subagent to verify" pattern Anthropic's Opus 5 guidance says causes over-verification, and it contradicted this file's own "delegate gathering, never concluding" rule. Reach for the lenses when a diff on those surfaces is genuinely large or unfamiliar.
+- `.claude/skills/engineering/pre-pr-fresh-agent-review.md` — a LENS LIBRARY (financial-plumbing / data-engineer / data-scientist / adversarial) for filings ETL, schema, identity-resolution and observations diffs. **No longer a mandatory pre-push gate** (revised 2026-08-03): a blanket second-agent pass before every push is the "use a subagent to verify" pattern that causes over-verification, and it contradicted this file's own "delegate gathering, never concluding" rule. Reach for the lenses when a diff on those surfaces is genuinely large or unfamiliar.
 - `.claude/skills/engineering/pr-authoring.md`
 - `.claude/skills/engineering/review-resolution.md`
 - `.claude/skills/engineering/python-hygiene.md`
@@ -576,9 +576,9 @@ When replying to review:
 ## Final reminder — read this last
 
 **These rules are STATED in the global `~/.claude/CLAUDE.md` ("Working with Claude
-Opus 5"), which is their single source.** They are echoed here — as a list of names, not
-a restatement — because this file is long and Anthropic's Opus 5 guidance recommends
-pairing a conciseness instruction with a short reminder near the end of a long prompt.
+"Working style"), which is their single source.** They are echoed here — as a list of
+names, not a restatement — because this file is long and a short reminder near the end of
+a long prompt is worth more than one buried at the top.
 If a rule below ever disagrees with the global file, the global file is right and this
 list is stale.
 

--- a/.claude/skills/committee-review/SKILL.md
+++ b/.claude/skills/committee-review/SKILL.md
@@ -9,9 +9,9 @@ description: Multi-agent committee review of a plan, spec, or design document. D
 
 > ⚠ **Default to 2-3 lenses, not 8 (revised 2026-08-03).** This skill dispatches 7 agents
 > plus a Codex pass and blocks on all 8. That collides with `CLAUDE.md`'s subagent rule
-> ("if one agent can do it, use one, not several") and with Anthropic's Opus 5 guidance
-> on capping delegation — Opus 5 delegates readily, and 8 agents on a doc that needed two
-> is the single most expensive mistake available in this repo.
+> ("if one agent can do it, use one, not several") and with the standing rule to cap
+> delegation — 8 agents on a doc that needed two is the single most expensive mistake
+> available in this repo.
 >
 > Escalate to the full panel ONLY when the operator asks for it explicitly, or when a
 > 2-3 lens pass has already returned findings that genuinely span more boundaries than

--- a/.claude/skills/engineering/pr-authoring.md
+++ b/.claude/skills/engineering/pr-authoring.md
@@ -15,9 +15,8 @@ pad with filler sections, redundant summaries or boilerplate. A one-file fix doe
 need the full section set, and a section with nothing to say should be omitted rather
 than filled with a placeholder.
 
-This matters more on Opus 5 than it did on earlier models: its written deliverables run
-longer by default, so a template that reads as "produce all of these" reliably yields a
-padded document. The sections below are the areas a reviewer needs covered **when they
+Written deliverables run long by default, so a template that reads as "produce all of
+these" reliably yields a padded document. The sections below are the areas a reviewer needs covered **when they
 apply** — not a form to complete.
 
 The exception is the ETL/parser/schema evidence table (CLAUDE.md Definition of Done

--- a/.claude/skills/engineering/pre-pr-fresh-agent-review.md
+++ b/.claude/skills/engineering/pre-pr-fresh-agent-review.md
@@ -5,8 +5,7 @@ review prompt reliably misses the edges — SEC filing semantics, dedup/denomina
 correctness, partition and idempotency behaviour.
 
 > ⚠ **This is a lens library, not a verification gate (revised 2026-08-03).** It used to
-> be mandatory before every push on the surfaces below. Anthropic's Opus 5 prompting
-> guidance is explicit that separate verification steps — *"include a final verification
+> be mandatory before every push on the surfaces below. Separate verification steps — *"include a final verification
 > step", "use a subagent to verify"* — cause **over-verification** on this model and that
 > removing them "reduces wasted tokens with no loss in quality". A blanket pre-push
 > second-agent pass is exactly that pattern, and it contradicted this repo's own

--- a/.claude/skills/engineering/pre-push-checklist.md
+++ b/.claude/skills/engineering/pre-push-checklist.md
@@ -64,8 +64,8 @@ standing between you and a silent revert of somebody else's merged work, and it 
 command.
 
 Reading the whole diff top to bottom is a different matter: on a narrow change you have
-just written and already reviewed, a second full pass is the re-check Opus 5 already
-performs, and the review-intensity ladder in `CLAUDE.md` says to skip it. Read the diff
+just written and already reviewed, a second full pass is a re-check that already
+happens, and the review-intensity ladder in `CLAUDE.md` says to skip it. Read the diff
 in full when it is large, unfamiliar, spans surfaces you did not hold in mind at once,
 or touches data semantics. When you do, adopt the reviewer's posture: read what is
 there, not what you intended.


### PR DESCRIPTION
Doc-only, one file, net **-1 line**. Consequence of moving the Opus 5 working rules to the global `~/.claude/CLAUDE.md` today.

## Why

Those rules are properties of the **model**, not of this repo. Every project here runs on Opus 5, so re-deriving "don't add verification the model already does" per repo was the wrong shape — I originally put them in this file, which was a misplacement.

Moving them out left this file's final-reminder block restating rules that now live elsewhere. That breaks the operator's own standard, stated two sections above it in the same global file: *"Single source of truth for constants — export once, import everywhere."* Two copies of a rule is two copies to drift.

## What changed

The block **stays** — Anthropic's guidance explicitly recommends pairing a conciseness instruction with a short reminder near the *end* of a long prompt, and this file is 570 lines. But it is now a list of **names** pointing at the global statement rather than a second copy of it, with explicit precedence: *if the two ever disagree, the global file is right and this list is stale.*

It also now says what the eBull-specific half actually is — the **review-intensity ladder**, which selects which of this repo's gates a given change needs. The deterministic gates it selects (pre-push hook, full-population A/B on corpus changes, the review-comment resolution contract) are evidence, not reassurance, and nothing in the global rules weakens them.

## Global file changes for reference

Not in this diff (it lives outside the repo, at `~/.claude/CLAUDE.md`, and is not under version control — backed up before editing). It went 48 → 102 lines:

- **New "Working with Claude Opus 5" section** — the five model-level rules, stated once.
- **Branch naming** — `docs/` and `chore/` added, no issue number required.
- **Merge gate** — "APPROVE" → "review SATISFIED", written generically: an APPROVE *or* the review system's documented terminal state for that diff class. Deliberately does not assume every project has eBull's doc-only-skipping bot, and warns against the opposite error of treating any *absence* of review as a skip.
- **"Re-read the diff myself"** → the branch-SCOPE check stays mandatory (it catches silent reverts); the full re-read is proportional.
- **"Close all linked issues"** → close what the PR resolves, leave `Refs`/`Part of`/umbrella open.
- **Commit messages** no longer required to re-enumerate each review concern — the per-comment replies are already the audit trail.
- **New corollary under "Verify before asserting"** — check whether a surprising behaviour is a deliberate decision before claiming a cause. Generalised from today's #2213 retraction.

All eight load-bearing rules verified preserved verbatim, including every security non-negotiable — those were not touched.
