### PR TITLE
fix(#2212): green the db tier — 29 stale failures, 2 real conditions, 1 exposed

### DIFF
--- a/tests/api/test_capability_overrides_admin_endpoint.py
+++ b/tests/api/test_capability_overrides_admin_endpoint.py
@@ -30,6 +30,11 @@ def _build_app(conn: MagicMock) -> FastAPI:
     return app
 
 
+# Row keys must mirror the endpoint's SELECT list
+# (``exchange_id, description, asset_class, capabilities`` —
+# app/api/capability_overrides_admin.py:176). The human label column is
+# ``exchanges.description``, not ``name`` (#1904); a row missing it raises
+# KeyError inside the endpoint rather than failing an assertion (#2212).
 def _make_cur(rows: list[dict[str, object]]) -> MagicMock:
     cur = MagicMock()
     cur.__enter__ = MagicMock(return_value=cur)
@@ -60,7 +65,7 @@ def test_seed_match_returns_empty_overrides() -> None:
         [
             {
                 "exchange_id": "4",
-                "name": "Nasdaq",
+                "description": "Nasdaq",
                 "asset_class": "us_equity",
                 "capabilities": dict(_US_EQUITY_SEED),
             },
@@ -87,7 +92,7 @@ def test_diverged_row_lists_only_changed_capabilities() -> None:
         [
             {
                 "exchange_id": "4",
-                "name": "Nasdaq",
+                "description": "Nasdaq",
                 "asset_class": "us_equity",
                 "capabilities": overridden,
             },
@@ -122,7 +127,7 @@ def test_reordered_providers_are_not_drift() -> None:
         [
             {
                 "exchange_id": "4",
-                "name": "Nasdaq",
+                "description": "Nasdaq",
                 "asset_class": "us_equity",
                 "capabilities": reordered,
             },
@@ -148,7 +153,7 @@ def test_non_us_equity_seed_is_empty() -> None:
         [
             {
                 "exchange_id": "100",
-                "name": "Crypto Exchange",
+                "description": "Crypto Exchange",
                 "asset_class": "crypto",
                 "capabilities": crypto_with_data,
             },

--- a/tests/api/test_orders_safety_layers.py
+++ b/tests/api/test_orders_safety_layers.py
@@ -6,15 +6,55 @@ these tests do not need to seed an instrument row.  The layer state is
 toggled via the existing /sync/layers/{name}/enabled endpoint (which
 also hits the dev DB via the shared connection pool), so no direct
 psycopg.connect call against settings.database_url is required.
+
+Kill-switch isolation (#2212)
+-----------------------------
+``clean_client`` drives the real app against the dev DB, and the order path
+checks the kill switch FIRST by design (``app/api/orders.py:503`` — "Safety
+checks first — kill switch blocks everything"), before the layer gate at :511.
+The dev DB carries a deliberately-active kill switch ("autonomy loop unattended
+— block any order path", activated_by=monitor, 2026-06-28), so end-to-end both
+tests got a 403 for the *kill-switch* reason and never reached the layer gate —
+the assertion they exist to make was unreachable, and had been since that switch
+was thrown.
+
+The fix patches ``get_kill_switch_status`` as the orders module resolves it, for
+the duration of these two tests only. It never writes to ``kill_switch`` —
+clearing the operator's standing block to make a test pass would disable every
+order path in dev. Kill-switch enforcement itself keeps its own coverage:
+tests/test_execution_guard.py::TestCheckKillSwitch (active switch fails, missing
+row fails closed) and tests/test_ops_monitor.py::(activate/deactivate/status).
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
 
 
+@pytest.fixture
+def _kill_switch_inactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the order path's kill-switch probe report inactive.
+
+    Read-only: patches the symbol, not the row.
+    """
+    import app.api.orders as orders
+
+    def _inactive(_conn: Any) -> dict[str, Any]:
+        return {
+            "is_active": False,
+            "activated_at": None,
+            "activated_by": None,
+            "reason": None,
+        }
+
+    monkeypatch.setattr(orders, "get_kill_switch_status", _inactive)
+
+
 @pytest.mark.integration
+@pytest.mark.usefixtures("_kill_switch_inactive")
 def test_manual_buy_blocked_when_fx_rates_disabled(clean_client: TestClient) -> None:
     clean_client.post(
         "/sync/layers/fx_rates/enabled",
@@ -34,6 +74,7 @@ def test_manual_buy_blocked_when_fx_rates_disabled(clean_client: TestClient) -> 
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("_kill_switch_inactive")
 def test_manual_buy_blocked_when_portfolio_sync_disabled(clean_client: TestClient) -> None:
     clean_client.post(
         "/sync/layers/portfolio_sync/enabled",

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -179,6 +179,15 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "thesis_outcomes",
     "instruments",
     "job_runs",
+    # #1508 C6 / migration 185 — per-job first-seen anchor. Standalone: its only
+    # constraint is the PK on job_name, so no inbound-FK path reaches it and the
+    # derived closure cannot pick it up. Omitted when it shipped, so anchors
+    # leaked between tests: tests/test_job_first_seen.py's "no anchor row" case
+    # read whichever anchor the previously-run test in that file had committed
+    # and flipped never_started with it. Presented as an xdist flake (#2212) —
+    # it is order-dependence, and reproduces every time when the 7-day-anchor
+    # test runs immediately before it.
+    "job_first_seen",
     "financial_periods_raw",
     "financial_periods",
     "dividend_events",

--- a/tests/jobs/test_sec_rate_membership.py
+++ b/tests/jobs/test_sec_rate_membership.py
@@ -17,15 +17,44 @@ pytestmark = pytest.mark.db
 # Generated 2026-06-08 via: source_for over the full registry (spec §3d).
 # Adding/removing a sec_rate job MUST update this set AND re-run the
 # write-safety audit for the new member (spec §3a).
+#
+# Write-safety audit, 2026-08-03 (#2212) — the four members added since the
+# 2026-06-08 freeze. `sec_rate` is an N=4 in-process semaphore, so a member runs
+# CONCURRENTLY with its lanemates; §3a requires every shared write to be
+# ordering-safe by something OTHER than the lane. Traced write-set per job:
+#
+#   daily_financial_facts            → financial_facts_raw. NOT a sole writer
+#     (fundamentals_sync + sec_companyfacts_ingest also write it), but
+#     upsert_facts_for_instrument is a last-write-wins idempotent UPSERT on
+#     identical source-derived data — rationale already recorded inline at
+#     app/jobs/sources.py (docs/etl/sources/sec_xbrl_facts.md). Safe.
+#   sec_13f_notice_sync              → institutional_filer_13f_notices, via
+#     ON CONFLICT (accession_number) DO UPDATE from an immutable filing. Safe.
+#   institutional_13f_notice_backfill → same table, same upsert (shares
+#     _process_day with the sync job). The pair can now overlap: _already_captured
+#     is a read-then-upsert TOCTOU, so a boundary accession may be fetched twice
+#     → one wasted rate-floor-bounded SEC fetch + a convergent write, no
+#     corruption. Same acceptance as §3a's "boundary overlap" case. Safe.
+#   drs_disclosure_refresh           → ownership_drs_observations only, via
+#     ON CONFLICT (instrument_id, source_accession) DO UPDATE from an immutable
+#     filing; sole writer of that table. Safe.
+#
+# None of the four writes a watermark, a *_current table, data_freshness_index or
+# sec_filing_manifest, so no ordering-sensitive write is involved. Self-overlap
+# stays covered by the per-job-name in-process lock (§4).
 EXPECTED_SEC_RATE_MEMBERS = frozenset(
     {
         "cusip_universe_backfill",
         "daily_cik_refresh",
+        "daily_financial_facts",
         "daily_research_refresh",
+        "drs_disclosure_refresh",
         "filings_history_seed",
+        "institutional_13f_notice_backfill",
         "mf_directory_sync",
         "ncen_classifier_yearly",
         "sec_13f_filer_directory_sync",
+        "sec_13f_notice_sync",
         "sec_13f_quarterly_sweep",
         "sec_8k_events_ingest",
         "sec_atom_fast_lane",

--- a/tests/test_api_filings.py
+++ b/tests/test_api_filings.py
@@ -280,7 +280,10 @@ class TestListFilings:
         client.get("/filings/1")
 
         items_sql: str = cursors[2].execute.call_args[0][0]
-        assert "order by filing_date desc" in items_sql.lower()
+        # Table-qualified since the query gained the ``fe`` alias; the trailing
+        # ``, fe.filing_event_id DESC`` tiebreak makes pagination deterministic
+        # and does not change the primary sort this test pins.
+        assert "order by fe.filing_date desc" in items_sql.lower()
 
     def test_limit_capped_at_max(self) -> None:
         resp = client.get("/filings/1", params={"limit": 999})

--- a/tests/test_api_instruments.py
+++ b/tests/test_api_instruments.py
@@ -67,8 +67,16 @@ def _make_instrument_row(
     last: float | None = 185.55,
     spread_pct: float | None = 0.054,
     quoted_at: datetime | None = _NOW,
+    session_profile: str = "us_equity",
 ) -> dict[str, Any]:
-    """Build a dict matching the joined instruments+quotes+coverage query shape."""
+    """Build a dict matching the joined instruments+quotes+coverage query shape.
+
+    Superset of both endpoints' SELECT lists: the list query
+    (``app/api/instruments.py:771``) ignores the extra keys, while the detail
+    query adds ``session_profile`` (``_SESSION_PROFILE_SQL``, :566) which
+    ``get_instrument`` reads unconditionally at :4180 — a row missing it raises
+    KeyError inside the endpoint rather than failing an assertion (#2212).
+    """
     return {
         "instrument_id": instrument_id,
         "symbol": symbol,
@@ -88,6 +96,7 @@ def _make_instrument_row(
         "last": last,
         "spread_pct": spread_pct,
         "quoted_at": quoted_at,
+        "session_profile": session_profile,
     }
 
 
@@ -109,12 +118,22 @@ def _mock_conn(cursor_results: list[list[dict[str, Any]]]) -> MagicMock:
     ``cursor_results`` is a list of result sets, one per ``cur.execute()`` call.
     Each ``fetchone()`` returns the first row (or None), and ``fetchall()``
     returns the full list.
+
+    Queries beyond the end of the script yield an EMPTY result set rather than
+    raising ``StopIteration`` — the fake models "a DB holding only the scripted
+    rows", not "a DB that explodes on the Nth+1 query". Without this, adding any
+    query to an endpoint turns every test in this file red at once for a reason
+    unrelated to what it asserts: #1924's per-page ``load_day_changes`` call
+    (``app/api/instruments.py:796``) was a third query on a two-result script and
+    took all 13 TestListInstruments cases that return a row down at once (#2212).
+    Matches the tolerant ``next(result_iter, [])`` already used by
+    ``tests/test_api_filings.py::_mock_conn``.
     """
     cur = MagicMock()
     result_iter = iter(cursor_results)
 
     def _on_execute(*_args: Any, **_kwargs: Any) -> None:
-        rows = next(result_iter)
+        rows = next(result_iter, [])
         cur.fetchone.return_value = rows[0] if rows else None
         cur.fetchall.return_value = rows
 

--- a/tests/test_bootstrap_state_prerequisite.py
+++ b/tests/test_bootstrap_state_prerequisite.py
@@ -22,6 +22,7 @@ import psycopg
 from app.workers.scheduler import (
     JOB_CUSIP_EXTID_SWEEP,
     JOB_CUSIP_UNIVERSE_BACKFILL,
+    JOB_DAILY_NEWS_REFRESH,
     JOB_DAILY_PORTFOLIO_SYNC,
     JOB_ETORO_LOOKUPS_REFRESH,
     JOB_EXCHANGES_METADATA_REFRESH,
@@ -34,6 +35,7 @@ from app.workers.scheduler import (
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
     JOB_ORPHAN_TEST_DB_REAP,
     JOB_OWNERSHIP_OBSERVATIONS_BACKFILL,
+    JOB_PG_SIZE_SAMPLE,
     JOB_RAW_DATA_RETENTION_SWEEP,
     JOB_RETRY_DEFERRED,
     JOB_RETRY_SWEEPER,
@@ -42,6 +44,7 @@ from app.workers.scheduler import (
     JOB_SEC_MANIFEST_WORKER,
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
+    JOB_THESIS_REFRESH,
     JOB_WEEKLY_REPORT,
     SCHEDULED_JOBS,
     _bootstrap_complete,
@@ -156,6 +159,22 @@ NON_GATED_SCHEDULED: frozenset[str] = frozenset(
         # bootstrap gate like any non-exempt job (pauses cleanly during
         # bootstrap). No bootstrap dependency of its own.
         JOB_RETRY_SWEEPER,
+        # #2212 (audited 2026-08-03) — three scheduled jobs that drifted in
+        # without a per-job prereq. All three are
+        # ``exempt_from_universal_bootstrap_gate=False``, so the UNIVERSAL gate
+        # (#1181, app/jobs/runtime.py::_wrap_invoker) already rejects their
+        # scheduled fires with ``bootstrap_not_complete`` until bootstrap
+        # completes. Adding a per-job ``_bootstrap_complete`` would double-gate —
+        # the same JOB_NCEN_CLASSIFIER call above.
+        #   * daily_news_refresh — Yahoo-RSS ingest; no bootstrap-produced input.
+        #   * pg_size_sample — DB-size telemetry sampler; meaningful (and
+        #     arguably most useful) during bootstrap itself.
+        #   * thesis_refresh — carries a prereq, but it gates LLM-provider
+        #     reachability (``_llm_provider_resolvable``), not bootstrap state,
+        #     so ``_references_bootstrap_complete`` correctly reports False.
+        JOB_DAILY_NEWS_REFRESH,
+        JOB_PG_SIZE_SAMPLE,
+        JOB_THESIS_REFRESH,
     }
 )
 

--- a/tests/test_ownership_observations.py
+++ b/tests/test_ownership_observations.py
@@ -68,6 +68,19 @@ class TestProvenanceBlockUniformity:
     they auto-enroll into this test via the
     ``information_schema.tables`` LIKE pattern."""
 
+    # Tables that match the LIKE pattern but are NOT part of the two-layer
+    # ownership model, so the provenance block does not apply to them.
+    #
+    # ownership_drs_observations (#844 PR-2, sql/239) is issuer-disclosed
+    # registered-vs-street overlay data: one row per (instrument, accession),
+    # no ``_current`` twin, no ownership_observations_repair category, and its
+    # own header states it "never joins the ownership pie". Its identity key is
+    # (instrument_id, source_accession) rather than the provenance block's
+    # (source, source_document_id, known_from/known_to) bitemporal shape, so
+    # requiring that block would mean retrofitting columns nothing reads
+    # (#2212). Excluded by name, not by loosening the invariant.
+    _NON_TWO_LAYER_OVERLAYS: frozenset[str] = frozenset({"ownership_drs_observations"})
+
     _PROVENANCE_COLS: tuple[str, ...] = (
         "source",
         "source_document_id",
@@ -96,11 +109,29 @@ class TestProvenanceBlockUniformity:
                   AND table_name NOT LIKE 'ownership_%%_observations_%%'
                 """
             )
-            tables = [str(row["table_name"]) for row in cur.fetchall()]
+            discovered = {str(row["table_name"]) for row in cur.fetchall()}
 
-        assert tables, "no ownership_*_observations tables found"
+        assert discovered, "no ownership_*_observations tables found"
 
-        for table in tables:
+        # Classification gate. Every table matching the pattern must be either a
+        # two-layer category (the repair sweep's own registry is the definition
+        # of that model) or a declared overlay — so a NEW table matching the
+        # pattern fails here until someone classifies it, which is the drift
+        # signal this test exists for.
+        from app.jobs.ownership_observations_repair import _CATEGORIES
+
+        two_layer = {obs_table for _current, obs_table, *_rest in _CATEGORIES}
+        unclassified = discovered - two_layer - self._NON_TWO_LAYER_OVERLAYS
+        assert not unclassified, (
+            f"Unclassified ownership_*_observations table(s): {sorted(unclassified)}. "
+            "Add to app.jobs.ownership_observations_repair._CATEGORIES (two-layer "
+            "model → must carry the full provenance block) or to "
+            "_NON_TWO_LAYER_OVERLAYS with a rationale."
+        )
+        missing_tables = two_layer - discovered
+        assert not missing_tables, f"Registered two-layer categories with no table: {sorted(missing_tables)}"
+
+        for table in sorted(two_layer):
             with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
                 cur.execute(
                     """

--- a/tests/test_scheduled_adapter.py
+++ b/tests/test_scheduled_adapter.py
@@ -343,13 +343,19 @@ def test_pending_retry_status_when_freshness_recheck_covers_failed_scope(
         ON CONFLICT (instrument_id) DO NOTHING
         """
     )
+    # ``next_recheck_at = now()`` — already due, so it is <= next_fire_at
+    # whatever the wall clock says. ``now() + 5 minutes`` was NOT: this job
+    # fires hourly at :35 (scheduler.py:1010), so between :30 and :35 UTC the
+    # recheck landed AFTER the next fire and the row correctly read ``failed``,
+    # failing this test for ~5 minutes in every hour (#2212). The negative
+    # sibling below covers the not-covered case by omitting the row entirely,
+    # so nothing here depends on the offset's size.
     ebull_test_conn.execute(
         """
         INSERT INTO data_freshness_index
             (subject_type, subject_id, source, state, next_recheck_at,
              instrument_id)
-        VALUES ('issuer', '9100002', 'sec_form4', 'error',
-                now() + interval '5 minutes', 9100002)
+        VALUES ('issuer', '9100002', 'sec_form4', 'error', now(), 9100002)
         """
     )
     ebull_test_conn.commit()

--- a/tests/test_sync_orchestrator_api.py
+++ b/tests/test_sync_orchestrator_api.py
@@ -66,13 +66,23 @@ class TestPostSyncDisabled:
 
 
 class TestGetSyncLayersShape:
-    def test_returns_10_layers_with_schema(self, client, auth_headers) -> None:
-        """Read-only against dev DB — pre-existing runs/freshness OK."""
+    def test_returns_every_registered_layer_with_schema(self, client, auth_headers) -> None:
+        """Read-only against dev DB — pre-existing runs/freshness OK.
+
+        Asserted against ``registry.LAYERS`` rather than a frozen count: the
+        contract is "the endpoint exposes every registered layer", and a literal
+        went stale the moment a layer shipped — 10 → 12 via ``risk_metrics``
+        (#591/PR #1637) and ``fair_value_band`` (#2009/PR #2019), neither of
+        which touched this file (#2212).
+        """
+        from app.services.sync_orchestrator.registry import LAYERS
+
         r = client.get("/sync/layers", headers=auth_headers)
         assert r.status_code == 200
         data = r.json()
-        assert len(data["layers"]) == 10
         names = {layer["name"] for layer in data["layers"]}
+        assert names == set(LAYERS.keys())
+        assert len(data["layers"]) == len(LAYERS)
         assert "universe" in names
         assert "monthly_reports" in names
         for layer in data["layers"]:


### PR DESCRIPTION
Closes #2212.

The `-m db` tier had 29 failures on `origin/main`, invisible while the tier cost 66 min. All 29 are gone; one further failure that the isolation fix exposed is also fixed. Test-only diff — no `app/` or `sql/` change.

Each failure was root-caused before it was touched. Three of them were not stale assertions at all.

## Stale assertions / drifted fakes (23)

| Test(s) | Cause | Fix |
|---|---|---|
| `test_api_instruments.py` — 13 × `TestListInstruments` | #1924 added a third query (`load_day_changes`, `app/api/instruments.py:796`); the positional fake scripted two result sets and raised `StopIteration` | fake yields an empty result set past the end of the script, matching the tolerant `next(result_iter, [])` already in `test_api_filings.py::_mock_conn` |
| `test_api_instruments.py` — 6 × `TestGetInstrumentDetail` | detail SELECT gained `session_profile` (`_SESSION_PROFILE_SQL`); `get_instrument` reads it unconditionally at `:4180` → `KeyError` | added to the row helper |
| `test_api_filings.py::test_items_ordered_by_filing_date_desc` | query gained the `fe` alias + a `filing_event_id DESC` tiebreak | assertion table-qualified; primary sort unchanged |
| `test_capability_overrides_admin_endpoint.py` × 2 | endpoint selects `exchanges.description` (#1904); fake rows still keyed `name` → `KeyError` at `:191` | row key renamed, SELECT list cited above the helper |
| `test_sync_orchestrator_api.py::TestGetSyncLayersShape` | literal `10`; registry is 12 since `risk_metrics` (#591/PR #1637) and `fair_value_band` (#2009/PR #2019) | asserts `set(LAYERS.keys())` — the contract is "exposes every registered layer", so the next layer needs no edit here |

## Audits the assertion messages asked for (3)

Not constant bumps — each of these tests exists to force a decision.

**`test_sec_rate_membership_is_frozen`.** `sec_rate` is an N=4 semaphore, so a new member runs *concurrently* with its lanemates; spec §3a requires every shared write to be ordering-safe by something other than the lane. Write-set traced for all four new members:

- `daily_financial_facts` → `financial_facts_raw`; not a sole writer, but `upsert_facts_for_instrument` is a last-write-wins idempotent UPSERT (rationale already recorded inline in `app/jobs/sources.py`).
- `sec_13f_notice_sync` and `institutional_13f_notice_backfill` → `institutional_filer_13f_notices`, `ON CONFLICT (accession_number) DO UPDATE` from an immutable filing. The pair can now overlap: `_already_captured` is a read-then-upsert TOCTOU, so a boundary accession may be fetched twice → one rate-floor-bounded wasted fetch and a convergent write. Same acceptance as §3a's "boundary overlap" case.
- `drs_disclosure_refresh` → `ownership_drs_observations` only, `ON CONFLICT (instrument_id, source_accession) DO UPDATE`, sole writer.

None writes a watermark, a `*_current` table, `data_freshness_index` or `sec_filing_manifest`. Self-overlap stays covered by the per-job-name in-process lock (§4). Audit recorded in the test file, next to the set it justifies.

**`test_every_scheduled_job_either_gated_or_explicitly_excluded`.** `daily_news_refresh`, `pg_size_sample`, `thesis_refresh` all carry `exempt_from_universal_bootstrap_gate=False`, so the universal gate (#1181) already rejects their scheduled fires with `bootstrap_not_complete`; a per-job `_bootstrap_complete` would double-gate. Same call as `JOB_NCEN_CLASSIFIER` (#1504). `thesis_refresh` has a prerequisite, but it gates LLM-provider reachability, not bootstrap state.

**`test_every_observations_table_carries_full_provenance_block`.** `ownership_drs_observations` (#844 PR-2, `sql/239`) matches the `ownership_%_observations` name glob but is not part of the two-layer model — no `_current` twin, no repair-sweep category, and its own header says it "never joins the ownership pie". Requiring the bitemporal provenance block would mean retrofitting columns nothing reads. Rather than widening the glob's exemptions ad hoc, the test now derives the two-layer set from `ownership_observations_repair._CATEGORIES` and asserts every discovered table is either in that registry or in a named overlay set — so a new table matching the pattern still fails until someone classifies it, which is what the test is for.

## Not stale — real conditions (3)

**`test_orders_safety_layers.py` × 2.** These drive the real app against the dev DB, and the order path checks the kill switch first by design (`app/api/orders.py:503`) before the layer gate at `:511`. The dev DB carries a deliberately-active kill switch (`autonomy loop unattended — block any order path`, `activated_by=monitor`, 2026-06-28), so both tests got a 403 for the *kill-switch* reason and never reached the assertion they exist to make — and had not since that switch was thrown. Fixed by patching `get_kill_switch_status` as the orders module resolves it, for these two tests only. It never writes to `kill_switch`: clearing the operator's standing block to make a test pass would disable every order path in dev. Kill-switch enforcement keeps its own coverage in `test_execution_guard.py::TestCheckKillSwitch` and `test_ops_monitor.py`.

**`test_job_first_seen::test_no_anchor_row_is_not_never_started`** — filed as an xdist flake; it is order-dependence. `job_first_seen` (migration 185) has only a PK, so no inbound-FK path reaches it and the derived cleanup closure cannot pick it up — exactly the standalone-table case `_PLANNER_TABLES` documents. Anchors leaked between tests, and the "no anchor row" case read whichever anchor the previous test in the file had committed. Added to `_PLANNER_TABLES`. Reproduces 100% of the time when the 7-day-anchor test runs immediately before it:

```
$ uv run pytest -m db -q -n 0 tests/test_job_first_seen.py::test_old_first_seen_never_run_reads_never_started \
                              tests/test_job_first_seen.py::test_no_anchor_row_is_not_never_started
FAILED ...::test_no_anchor_row_is_not_never_started   # before
EXIT=0                                                # after
```

**`test_scheduled_adapter::test_pending_retry_status_when_freshness_recheck_covers_failed_scope`** — surfaced by the fix above, which stopped the leak that was propping it up. Pre-existing and independent: it fails in isolation both with and without the `_PLANNER_TABLES` change. It inserted `next_recheck_at = now() + 5 minutes` and asserted the recheck lands before the next fire, but `sec_filing_documents_ingest` fires hourly at `:35` (`scheduler.py:1010`) — so between `:30` and `:35` UTC the recheck landed *after* the next fire and the row correctly read `failed`. Broken ~5 minutes in every hour. Now inserts `now()` (already due, so `<= next_fire_at` whatever the clock says); verified at 15:34 UTC, inside the previously-failing window.

## Verification

Full tier, batched per the issue's own reproduce block, gated on **pytest's** exit code (this repo's pytest config suppresses the `N passed` line):

```bash
find tests -name 'test_*.py' | sort | split -l 40 - /tmp/chunk_
for f in /tmp/chunk_*; do
  out=$(uv run pytest -m db -q $(tr '\n' ' ' < "$f") 2>&1); echo "$f exit=$?"
done
```

- baseline on this branch before any edit: **29 failures**, matching the issue exactly.
- after: all 29 gone. Tier wall-clock 396–413 s across two full runs.
- `uv run ruff check .` / `ruff format --check .` / `pyright` / `pytest -m "not db"` all clean.

## Known-remaining: an intermittent class this does NOT fix

Two full-tier runs after the fixes each surfaced **two** failures, and all four were different tests: `test_api_audit::test_invalid_stage_returns_422`, `test_api_theses::test_zero_limit_rejected` (run 1), `test_api_auth_session::TestMe::test_me_without_cookie_returns_401`, `test_jobs_boot_guard::TestColdStartToleranceWrapper::test_cold_start_returns_without_breadcrumb_or_exit` (run 2). All four pass in isolation and on chunk re-run.

This is a distinct root cause from the 29 stale assertions and is **not** claimed to be fixed here. `test_api_audit` and `test_api_auth_session` are in a chunk containing none of this PR's changed files. Tracked separately in #2224 with the evidence; the deterministic tier is green, and that was #2212's stated blocker.

## Security

Test-only diff. One security-relevant judgement: the kill-switch fix patches a symbol for the duration of two tests and never mutates `kill_switch`, so the operator's standing block on every order path in dev is untouched.
