### PR TITLE
fix(#2217): residual stops subtracting treasury from a base that already excludes it

### DIFF
--- a/.claude/skills/metrics-analyst/SKILL.md
+++ b/.claude/skills/metrics-analyst/SKILL.md
@@ -202,18 +202,19 @@ The ownership card is the cleanest example of "one fetch, one snapshot, one deno
 - **Endpoint**: `/ownership-rollup.treasury_shares` + `treasury_as_of` (top-level fields, NOT inside `slices`); also balance sheet endpoint.
 - **Chart**: `OwnershipPanel.tsx` renders treasury wedge above the ring; legend has treasury swatch.
 - **Cadence**: companyfacts daily sync.
-- **Caveats**: excluded from numerator of `concentration.pct_outstanding_known` — issuer doesn't "invest" in itself (`_compute_concentration:2626`). Treasury IS allowed to push chart "oversubscribed" if `Σ pie_wedges + treasury > shares_outstanding` (stale-13F + fresh Form 4 mix); residual clamps to zero, banner flags it.
-- **Validation**: check `shares_authorized ≥ shares_issued ≥ treasury_shares` invariant.
+- **Caveats**: excluded from numerator of `concentration.pct_outstanding_known` — issuer doesn't "invest" in itself. ⚠ **Treasury is NOT in the residual either, since #2217.** It is neither added to nor subtracted from `shares_outstanding` anywhere: `shares issued = shares outstanding + treasury`, so the DEI/us-gaap outstanding figure already excludes it. Treasury is a purely additive TOP wedge drawn outside the ring (design: `docs/proposals/etl/ownership-tier0-cik-history.md` §OwnershipPanel).
+- ⚠ **This bullet previously read "treasury IS allowed to push the chart oversubscribed" — that was the caveat the bug hid behind.** It was written as a rare stale-13F artefact; measured, it was firing on 9 of 20 large caps because `_compute_residual` subtracted treasury from a base excluding it. **A documented caveat is a hypothesis about frequency — measure the rate before accepting it as the explanation.**
+- **Validation**: check `shares_authorized ≥ shares_issued ≥ treasury_shares` invariant. Note treasury can legitimately exceed *outstanding* (Goldman: 199.9%) — a serial repurchaser retires nothing; that is not a data error.
 
 ### Public float / residual
 - **Definition**: shares not attributable to any known SEC filing or treasury — by construction includes retail, undeclared institutional below 13F threshold, and any filer outside coverage cohort.
-- **Formula**: `residual = shares_outstanding − Σ (slices where denominator_basis="pie_wedge") − treasury_shares`. Clamped ≥ 0; `oversubscribed` flag fires when negative (`_compute_residual:2591`).
-- **Storage**: not stored — computed at read time.
-- **Service**: [app/services/ownership_rollup.py:2591](../../../app/services/ownership_rollup.py#L2591) (`_compute_residual`).
+- **Formula**: `residual = shares_outstanding − Σ (slices where denominator_basis="pie_wedge")`. **No treasury term** (#2217). Clamped ≥ 0; `oversubscribed` fires when the raw value is negative.
+- **Storage**: not stored — computed at read time. (So a fix here needs no backfill; it lands the moment the API process reloads.)
+- **Service**: [app/services/ownership_rollup.py:2814](../../../app/services/ownership_rollup.py#L2814) (`_compute_residual`); [`:2866`](../../../app/services/ownership_rollup.py#L2866) (`_compute_concentration`).
 - **Endpoint**: `/ownership-rollup.residual.{shares, pct_outstanding, oversubscribed}`.
 - **Chart**: `OwnershipPanel.tsx` `ResidualLine` (`:355`); always rendered as grey "Public / unattributed" wedge.
-- **Caveats**: residual is NOT a free signal — 90% residual on a small-cap usually means coverage is incomplete, not that retail owns 90%. Coverage banner is the right cue.
-- **Validation**: `Σ all wedges + residual + treasury ≈ shares_outstanding` exactly when `oversubscribed=false`.
+- **Caveats**: residual is NOT a free signal — 90% residual on a small-cap usually means coverage is incomplete, not that retail owns 90%. Coverage banner is the right cue. ⚠ **`oversubscribed` is currently unusable as an exception signal: it fires on 47% of the 4,421 instruments with a denominator (#2226), because Σ pie wedges alone exceeds outstanding (OPCH 513%, PRVA 187%). #2217 removed the treasury term and took it from 52% → 47%; the rest is a separate defect.**
+- **Validation**: `Σ pie wedges + residual = shares_outstanding` exactly when `oversubscribed=false`. ⚠ **Treasury is NOT a term in that identity** — it was until #2217, which is precisely the arithmetic that made public float render zero for KO/GS/JPM/PG/XOM. If treasury belonged in it, no issuer could hold treasury above 100% of outstanding, and many do.
 
 ### denominator_basis explained per kind
 

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -5621,9 +5621,10 @@ def get_instrument_exec_compensation(
 
 # Slice categories present on ``OwnershipSlice.category``. The
 # frontend's ``CATEGORY_LABELS`` set also includes ``treasury`` —
-# treasury is a memo row in the CSV (additive wedge on the chart),
-# not a holders slice. Treated as a valid filter value below: it
-# scopes the CSV to the treasury memo + residual rows only.
+# treasury is a memo row in the CSV (a wedge drawn on top of the chart,
+# never inside the denominator, and since #2217 not deducted from the
+# residual either), not a holders slice. Treated as a valid filter value
+# below: it scopes the CSV to the treasury memo + residual rows only.
 _ROLLUP_CSV_SLICE_CATEGORIES: frozenset[str] = frozenset(
     {"insiders", "blockholders", "institutions", "etfs", "def14a_unmatched", "funds", "esop"},
 )
@@ -5665,9 +5666,11 @@ def get_instrument_ownership_rollup_csv(
             "drops all slice holders and emits only the treasury + residual "
             "memo rows. ``funds`` and ``esop`` are memo-overlay slices — their "
             "rows render with the ``__memo:<category>__`` prefix in the output "
-            "CSV so they are outside the additive (treasury + residual + "
-            "Σ pie-wedge) reconciliation. Without ``category``, every slice "
-            "is exported."
+            "CSV so they are outside the additive (residual + Σ pie-wedge) "
+            "reconciliation — as does treasury, which since #2217 is "
+            "``__memo:treasury__`` and is NOT a term in that sum "
+            "(shares_outstanding already excludes it). Without ``category``, "
+            "every slice is exported."
         ),
     ),
     conn: psycopg.Connection[object] = Depends(get_conn),

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -5664,13 +5664,9 @@ def get_instrument_ownership_rollup_csv(
             "| etfs | def14a_unmatched | funds | esop | treasury. Slice "
             "categories scope the export to that slice's holders; ``treasury`` "
             "drops all slice holders and emits only the treasury + residual "
-            "memo rows. ``funds`` and ``esop`` are memo-overlay slices — their "
-            "rows render with the ``__memo:<category>__`` prefix in the output "
-            "CSV so they are outside the additive (residual + Σ pie-wedge) "
-            "reconciliation — as does treasury, which since #2217 is "
-            "``__memo:treasury__`` and is NOT a term in that sum "
-            "(shares_outstanding already excludes it). Without ``category``, "
-            "every slice is exported."
+            "memo rows. Without ``category``, every slice is exported. See the "
+            "endpoint description for which rows are additive and for the "
+            "2026-08-03 ``__memo:treasury__`` rename (#2217)."
         ),
     ),
     conn: psycopg.Connection[object] = Depends(get_conn),

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -5691,7 +5691,29 @@ def get_instrument_ownership_rollup_csv(
     Reads run inside ``snapshot_read`` so the per-slice totals,
     treasury, and residual all reconcile against one REPEATABLE
     READ snapshot. Same isolation contract as the JSON rollup
-    endpoint."""
+    endpoint.
+
+    ⚠ **BREAKING for CSV consumers, 2026-08-03 (#2217).** The treasury
+    row's ``category`` cell changed from ``__treasury__`` to
+    ``__memo:treasury__``, and treasury is no longer a term in the
+    additive reconciliation. A consumer keying on the literal
+    ``__treasury__`` will stop matching that row; one summing
+    ``pie + treasury + residual`` will now overshoot
+    ``shares_outstanding`` by the treasury amount.
+
+    Migration: filter on the ``__memo:`` / ``__dropped:`` category
+    prefixes — the rule the export has always documented — rather than
+    on individual tokens. The reconciliation is::
+
+        Σ (rows whose category starts with neither __memo: nor __dropped:)
+            == shares_outstanding
+
+    Why it changed: ``shares_outstanding`` is the DEI/us-gaap OUTSTANDING
+    count, which already excludes treasury (shares issued = outstanding +
+    treasury). Treasury can and does exceed outstanding outright (Goldman:
+    199.9%), so it was never additive against this base — including it
+    drove the residual negative and rendered public float as zero for
+    every large repurchaser."""
     symbol_clean = symbol.strip().upper()
     if not symbol_clean:
         raise HTTPException(status_code=400, detail="symbol is required")

--- a/app/services/bootstrap_validation.py
+++ b/app/services/bootstrap_validation.py
@@ -329,7 +329,8 @@ def _check_cross_source(rollups: list[tuple[str, OwnershipRollup]], warnings: li
         if rollup.residual.oversubscribed:
             warnings.append(
                 f"reconciliation: {symbol} mildly oversubscribed "
-                f"(known holders + treasury exceed shares_outstanding — stale 13F vs fresh XBRL)"
+                f"(known holders exceed shares_outstanding — stale 13F vs fresh XBRL). "
+                f"Treasury is not part of this comparison (#2217)"
             )
     logger.info("bootstrap_validation: cross-source reconciliation OK (%d rendered)", len(rollups))
 

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -15,7 +15,11 @@ closes:
   * **Wrong denominator** — the prior frontend math used
     ``shares_outstanding + treasury_shares``; the canonical
     denominator is ``shares_outstanding`` only, with treasury
-    rendered as an additive top wedge.
+    rendered as a separate wedge stacked on top of the ring.
+    "On top" is a DRAWING instruction, not an arithmetic one:
+    treasury is outside the denominator, outside the residual
+    (#2217) and outside the CSV's additive reconciliation, where
+    it is a ``__memo:treasury__`` row.
   * **No cross-channel dedup** — the prior pipeline summed Form 4 +
     13D/A + 13F + DEF 14A as a partition (e.g. Cohen on GME read as
     ~75M shares because his Form 4 cumulative AND his 13D/A row
@@ -2822,10 +2826,13 @@ def _compute_residual(
     (see :func:`_read_shares_outstanding`), and shares issued = shares outstanding
     + treasury — so treasury shares were never in this base and subtracting them
     removed a quantity that is not there. That is the design contract too: the
-    denominator is outstanding only, with treasury rendered as an ADDITIVE top
-    wedge (``docs/proposals/etl/ownership-tier0-cik-history.md`` §OwnershipPanel;
-    the module docstring's "wrong denominator" ship-blocker). The frontend was
-    corrected then; this residual kept the mirror-image of the same error.
+    denominator is outstanding only, with treasury drawn as a separate wedge on
+    top of the ring (``docs/proposals/etl/ownership-tier0-cik-history.md``
+    §OwnershipPanel; the module docstring's "wrong denominator" ship-blocker).
+    That doc calls the wedge "additive" in the RENDERING sense — stacked above
+    the ring — which is not a licence to add or subtract it anywhere in the
+    arithmetic. The frontend was corrected then; this residual kept the
+    mirror-image of the same error.
 
     Left uncorrected it read as a *negative* residual for any serial repurchaser
     — 9 of 20 sampled large caps, with Coca-Cola, Goldman, JPM, P&G and Exxon

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -4138,7 +4138,7 @@ def build_rollup_csv(rollup: OwnershipRollup) -> str:
     # Form 4) become ``dropped_sources`` and would otherwise vanish from the
     # CSV audit. Emit them as ``__dropped:<source>__`` memo rows — excluded
     # from any SUM(shares) reconciliation (the sum invariant holds over the
-    # pie-wedge rows + treasury + residual), but visible so an operator can see
+    # pie-wedge rows + residual; treasury is a memo row, #2217), but visible so an operator can see
     # the full filing trail behind a deduped owner.
     for slc in pie_slices:
         for holder in slc.holders:

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -4026,17 +4026,31 @@ _CSV_HEADER: tuple[str, ...] = (
 def build_rollup_csv(rollup: OwnershipRollup) -> str:
     """Flatten a deduped :class:`OwnershipRollup` into a CSV string.
 
-    One row per surviving holder across all slices, plus two memo
-    rows at the end:
+    One row per surviving holder across all slices, plus:
 
-      * ``__treasury__`` — issuer treasury share count (additive
-        wedge on the chart, not a deduped holder).
       * ``__residual__`` — ``Public / unattributed`` block (clamped
-        to 0 when oversubscribed).
+        to 0 when oversubscribed). ADDITIVE.
+      * ``__memo:treasury__`` — issuer treasury share count. NOT
+        additive (#2217).
 
-    The two memo rows let an operator sum the ``shares`` column and
-    verify it equals ``shares_outstanding`` without round-tripping
-    to a separate endpoint.
+    The additive reconciliation an operator can run on the ``shares``
+    column is::
+
+        Σ (rows whose category is neither __memo:* nor __dropped:*)
+            == shares_outstanding
+
+    i.e. pie-wedge holders + residual. **Treasury is not a term.**
+    ``shares_outstanding`` is the DEI/us-gaap OUTSTANDING count, which
+    already excludes treasury (shares issued = outstanding + treasury),
+    so adding treasury back would overshoot by exactly that amount —
+    and treasury can exceed outstanding outright (Goldman: 199.9%).
+    It moved from ``__treasury__`` to the established
+    ``__memo:<category>__`` prefix so the one documented filter rule
+    excludes it, the same way funds and unmatched DEF 14A rows are
+    excluded. It keeps its historical emission position (immediately
+    before ``__residual__``) rather than moving to the trailing memo
+    block — only the category token changed, so a consumer keying on
+    the prefix needs no positional rework.
 
     Header always emitted so an automation pipe can be branchless on
     empty rollups (no_data state, pre-ingest instruments).
@@ -4054,8 +4068,8 @@ def build_rollup_csv(rollup: OwnershipRollup) -> str:
     writer.writerow(_CSV_HEADER)
 
     # Emit pie-wedge slices first so the additive-sum invariant holds
-    # against (treasury_shares + residual.shares + Σ pie-wedge holders)
-    # = shares_outstanding. Memo-overlay slices (funds, esop, future
+    # against (residual.shares + Σ pie-wedge holders) = shares_outstanding.
+    # Treasury is NOT a term (#2217). Memo-overlay slices (funds, esop, future
     # DRS / short-interest) are emitted in a trailing block with the
     # ``__memo:<category>__`` prefix so spreadsheet consumers can
     # filter them OUT of any SUM(shares) reconciliation. Codex
@@ -4093,7 +4107,7 @@ def build_rollup_csv(rollup: OwnershipRollup) -> str:
             [
                 "",
                 "Treasury (memo)",
-                "__treasury__",
+                "__memo:treasury__",
                 str(rollup.treasury_shares),
                 treasury_pct,
                 "",

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -280,10 +280,11 @@ class OwnershipSlice:
 
 @dataclass(frozen=True)
 class ResidualBlock:
-    """``Public / unattributed`` wedge. ``oversubscribed=True`` when
-    deduped slices + treasury exceed shares_outstanding (stale
-    13F + fresh Form 4 / 13D mix); residual clamps to 0 in that
-    case and the frontend renders the warning bar."""
+    """``Public / unattributed`` wedge. ``oversubscribed=True`` when the
+    deduped pie-wedge slices exceed shares_outstanding (stale 13F + fresh
+    Form 4 / 13D mix); residual clamps to 0 in that case and the frontend
+    renders the warning bar. Treasury is NOT part of this comparison —
+    shares outstanding already excludes it (#2217)."""
 
     shares: Decimal
     pct_outstanding: Decimal
@@ -2813,17 +2814,34 @@ def _build_slice(
 def _compute_residual(
     outstanding: Decimal,
     slices: Sequence[OwnershipSlice],
-    treasury: Decimal | None,
 ) -> ResidualBlock:
     """Compute the ``Public / unattributed`` residual.
 
-    Stale-mixed-date inputs (fresh Form 4 + old 13F) can leave the
-    raw residual negative — we clamp to 0 and surface
-    ``oversubscribed=True`` so the frontend renders a warning bar.
-    The category-counted slices use deduped totals, so the only path
-    to oversubscription is the snapshot-lag class of bug, not a
-    dedup mistake."""
-    treasury_d = treasury if treasury is not None else Decimal(0)
+    Treasury is NOT deducted (#2217). ``outstanding`` is
+    ``dei:EntityCommonStockSharesOutstanding`` / ``us-gaap:CommonStockSharesOutstanding``
+    (see :func:`_read_shares_outstanding`), and shares issued = shares outstanding
+    + treasury — so treasury shares were never in this base and subtracting them
+    removed a quantity that is not there. That is the design contract too: the
+    denominator is outstanding only, with treasury rendered as an ADDITIVE top
+    wedge (``docs/proposals/etl/ownership-tier0-cik-history.md`` §OwnershipPanel;
+    the module docstring's "wrong denominator" ship-blocker). The frontend was
+    corrected then; this residual kept the mirror-image of the same error.
+
+    Left uncorrected it read as a *negative* residual for any serial repurchaser
+    — 9 of 20 sampled large caps, with Coca-Cola, Goldman, JPM, P&G and Exxon
+    rendering a public float of exactly ZERO, and the warning bar below blaming
+    snapshot lag for it. Goldman carries treasury equal to 199.9% of outstanding,
+    which is only possible *because* the base excludes it.
+
+    Stale-mixed-date inputs (fresh Form 4 + old 13F) can still leave the raw
+    residual negative — we clamp to 0 and surface ``oversubscribed=True`` so the
+    frontend renders a warning bar. The category-counted slices use deduped
+    totals, so with the treasury term gone the remaining paths to
+    oversubscription are the snapshot-lag class and a genuine over-attribution,
+    not arithmetic.
+
+    :func:`_compute_concentration` below has always excluded treasury correctly;
+    the two now agree."""
     # Memo-overlay slices (funds N-PORT; DEF 14A proxy_disclosure #1659; future
     # ESOP/DRS/short-interest) do NOT contribute to ``sum_known`` — they describe
     # positions already counted via a pie-wedge slice (N-PORT funds are fund-level
@@ -2833,7 +2851,7 @@ def _compute_residual(
         (s.total_shares for s in slices if s.denominator_basis == "pie_wedge"),
         Decimal(0),
     )
-    raw = outstanding - sum_known - treasury_d
+    raw = outstanding - sum_known
     clamped = raw if raw > 0 else Decimal(0)
     pct = clamped / outstanding if outstanding > 0 else Decimal(0)
     return ResidualBlock(
@@ -3929,7 +3947,7 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
         funds_holders=funds_holders,
         esop_holders=esop_holders,
     )
-    residual = _compute_residual(effective_outstanding, slices, treasury)
+    residual = _compute_residual(effective_outstanding, slices)
     concentration = _compute_concentration(effective_outstanding, slices)
     sanity = _compute_sanity(slices, effective_outstanding)
     # Independent denominator tie-out (#1647 part 5) — reads the comparison figure from

--- a/tests/test_ownership_machine_trust_envelope.py
+++ b/tests/test_ownership_machine_trust_envelope.py
@@ -278,7 +278,7 @@ def test_proxy_disclosure_excluded_from_concentration() -> None:
 def test_proxy_disclosure_excluded_from_residual() -> None:
     inst = _slice("institutions", [_h("400", as_of=date(2025, 3, 31))], outstanding="1000")
     proxy = _proxy(_h("300", as_of=date(2025, 3, 31), source="def14a", name="Sponsor group"))
-    r = _compute_residual(Decimal("1000"), [inst, proxy], None)
+    r = _compute_residual(Decimal("1000"), [inst, proxy])
     # Residual = 1000 - 400 (only the additive institutions); proxy not subtracted.
     assert r.shares == Decimal("600")
     assert r.oversubscribed is False

--- a/tests/test_ownership_rollup.py
+++ b/tests/test_ownership_rollup.py
@@ -1075,8 +1075,12 @@ class TestResidualAndCoverage:
         return conn
 
     def test_residual_label_and_value(self, _setup: psycopg.Connection[tuple]) -> None:
-        """30M known + 10M treasury → residual = 60M, label =
-        Public / unattributed, oversubscribed=False."""
+        """30M known of 100M outstanding → residual = 70M.
+
+        The 10M treasury is NOT deducted (#2217): ``shares_outstanding`` already
+        excludes treasury (shares issued = outstanding + treasury), so the old
+        60M expectation double-counted it. This assertion is what pinned the bug
+        in place — it was asserting the defect, not the contract."""
         conn = _setup
         _seed_form4(
             conn,
@@ -1092,10 +1096,44 @@ class TestResidualAndCoverage:
         rollup = ownership_rollup.get_ownership_rollup(conn, symbol="RESID", instrument_id=789_020)
 
         assert rollup.residual.label == "Public / unattributed"
-        assert rollup.residual.shares == Decimal("60000000")
+        assert rollup.residual.shares == Decimal("70000000")
         assert rollup.residual.oversubscribed is False
         # Concentration: 30M / 100M = 30% (treasury excluded from numerator).
         assert rollup.concentration.pct_outstanding_known == Decimal("0.30")
+
+    def test_treasury_exceeding_outstanding_does_not_zero_residual(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    ) -> None:
+        """Regression for #2217, in the shape that made it operator-visible.
+
+        A serial repurchaser can carry treasury far in excess of shares
+        outstanding — Goldman Sachs held 199.9% at the time of the fix, which is
+        only possible *because* outstanding excludes treasury. Deducting it drove
+        the residual negative before a single holder was counted, so public float
+        rendered as ZERO and the warning bar blamed 13F snapshot lag for it.
+
+        200% treasury with only 30% attributed must leave the remaining 70%
+        public and the flag clear."""
+        conn = ebull_test_conn
+        _seed_instrument(conn, iid=789_021, symbol="BUYBACK")
+        _seed_outstanding(conn, instrument_id=789_021, shares="100000000", treasury="200000000")
+        _seed_form4(
+            conn,
+            accession="0001234500-25-000125",
+            instrument_id=789_021,
+            filer_cik="0009999002",
+            filer_name="Big Holder Inc",
+            txn_date=date(2026, 3, 1),
+            post_transaction_shares="30000000",
+        )
+        conn.commit()
+
+        rollup = ownership_rollup.get_ownership_rollup(conn, symbol="BUYBACK", instrument_id=789_021)
+
+        assert rollup.treasury_shares == Decimal("200000000")
+        assert rollup.residual.shares == Decimal("70000000")
+        assert rollup.residual.oversubscribed is False
 
     def test_oversubscribed_clamps_residual_to_zero(self, _setup: psycopg.Connection[tuple]) -> None:
         """Stale 13F + fresh 13D: holders sum to 110% of outstanding.

--- a/tests/test_ownership_rollup_csv.py
+++ b/tests/test_ownership_rollup_csv.py
@@ -220,8 +220,8 @@ def test_build_csv_emits_dropped_source_memo_rows() -> None:
     """#1640: a deduped owner's losing filings (e.g. Cohen's 13D behind his
     Form 4) are ``dropped_sources``. They surface as ``__dropped:<source>__``
     memo rows — excluded from the SUM(shares) reconciliation but visible for
-    audit. The sum invariant (pie-wedge holders + treasury + residual ==
-    outstanding) holds over the non-memo rows."""
+    audit. The sum invariant (pie-wedge holders + residual == outstanding;
+    treasury is NOT a term, #2217) holds over the non-memo rows."""
     cohen = _holder(
         cik="0001767470",
         name="Cohen Ryan",
@@ -421,8 +421,9 @@ def test_build_csv_handles_null_cik_and_no_as_of() -> None:
 def test_build_csv_memo_overlay_slices_emit_after_residual_with_prefix() -> None:
     """Funds slice (#919) is a memo overlay (``denominator_basis=
     'institution_subset'``). Per the documented CSV invariant
-    (treasury_shares + residual.shares + Σ pie-wedge holders =
-    shares_outstanding), memo-overlay rows must be emitted in a
+    (residual.shares + Σ pie-wedge holders = shares_outstanding;
+    treasury is a ``__memo:`` row, not a term, #2217), memo-overlay
+    rows must be emitted in a
     trailing block AFTER residual with the ``__memo:<category>__``
     category prefix so spreadsheet consumers can filter them out of
     any SUM(shares) reconciliation. Codex pre-push review for #919
@@ -456,14 +457,14 @@ def test_build_csv_memo_overlay_slices_emit_after_residual_with_prefix() -> None
         ),
         denominator_basis="institution_subset",
     )
-    # outstanding = 10M; pie-wedge insider 500k + treasury 100k +
-    # residual must = 10M for the documented additive-sum invariant
-    # to hold. residual = 10M - 500k - 100k = 9.4M.
+    # outstanding = 10M; pie-wedge insider 500k + residual must = 10M for the
+    # documented additive-sum invariant to hold, so residual = 9.5M. Treasury
+    # (100k) is NOT a term since #2217 — it is a ``__memo:`` row like funds.
     csv = build_rollup_csv(
         _rollup(
             slices=(insiders, funds),
             treasury="100000",
-            residual_shares="9400000",
+            residual_shares="9500000",
         ),
     )
     lines = csv.splitlines()
@@ -479,22 +480,27 @@ def test_build_csv_memo_overlay_slices_emit_after_residual_with_prefix() -> None
     assert "0000036405,Vanguard 500 Index Fund,__memo:funds__,200000," in lines[4]
 
     # The actual reconciliation invariant: SUM(pie-wedge holder shares)
-    # + treasury + residual = shares_outstanding. The memo row's 200k
+    # + residual = shares_outstanding (treasury excluded, #2217). The 200k
     # is OUTSIDE this sum — that is the contract being pinned. If the
     # CSV builder ever folds memo rows into the additive total the
     # operator's spreadsheet reconciliation breaks; if it ever drops
     # pie-wedge holders into the memo block it under-counts. Pinning
     # the exact rows + the equality below catches both regressions.
-    pie_share_total = Decimal("500000")  # insiders only — funds excluded
-    treasury_total = Decimal("100000")
-    residual_total = Decimal("9400000")
-    outstanding = Decimal("10000000")
-    assert pie_share_total + treasury_total + residual_total == outstanding
-    # Memo total is non-zero AND outside the additive sum. Removing
-    # ``__memo:funds__`` filtering would push the additive total above
-    # outstanding by exactly this delta and break the assertion above.
-    memo_share_total = Decimal("200000")
-    assert memo_share_total > 0
+    # Summed from the EMITTED CSV, applying the one documented filter rule.
+    # The previous version of this block asserted
+    # ``500000 + 100000 + 9400000 == 10000000`` over hand-written literals — an
+    # arithmetic identity that never read the CSV, so it could not fail when the
+    # builder changed. That is why the treasury row's additive/memo status could
+    # drift unnoticed (#2217).
+    rows = [ln.split(",") for ln in lines[1:]]
+    additive = sum(Decimal(r[3]) for r in rows if not r[2].startswith("__memo:") and not r[2].startswith("__dropped:"))
+    assert additive == Decimal("10000000")  # 500k insider + 9.5M residual
+
+    # Both memo rows carry real, non-zero share counts and are excluded: if
+    # either the funds overlay (200k) or treasury (100k) leaked into the
+    # additive block the assertion above would overshoot by exactly that much.
+    excluded = sum(Decimal(r[3]) for r in rows if r[2].startswith("__memo:"))
+    assert excluded == Decimal("300000")
 
 
 def test_build_csv_def14a_proxy_disclosure_emits_as_memo_excluded_from_sum() -> None:

--- a/tests/test_ownership_rollup_csv.py
+++ b/tests/test_ownership_rollup_csv.py
@@ -540,7 +540,7 @@ def test_build_csv_def14a_proxy_disclosure_emits_as_memo_excluded_from_sum() -> 
         _rollup(
             slices=(insiders, proxy),
             treasury="100000",
-            residual_shares="9400000",  # 10M - 500k insiders - 100k treasury; proxy excluded
+            residual_shares="9500000",  # 10M - 500k insiders; treasury + proxy both excluded
         ),
     )
     lines = csv.splitlines()
@@ -550,8 +550,12 @@ def test_build_csv_def14a_proxy_disclosure_emits_as_memo_excluded_from_sum() -> 
     assert "__memo:treasury__" in lines[2]
     assert "__residual__" in lines[3]
     assert "Sponsor Control Group,__memo:def14a_unmatched__,300000," in lines[4]
-    # Additive reconciliation excludes the proxy block.
-    assert Decimal("500000") + Decimal("100000") + Decimal("9400000") == Decimal("10000000")
+    # Additive reconciliation, summed from the EMITTED CSV — excludes the proxy
+    # block AND treasury. Previously asserted over literals, which never read
+    # the CSV and so could not fail when the builder changed (#2217).
+    rows = [ln.split(",") for ln in lines[1:]]
+    additive = sum(Decimal(r[3]) for r in rows if not r[2].startswith("__memo:") and not r[2].startswith("__dropped:"))
+    assert additive == Decimal("10000000")  # 500k insider + 9.5M residual
 
 
 def test_build_csv_memo_overlay_only_no_pie_slices() -> None:

--- a/tests/test_ownership_rollup_csv.py
+++ b/tests/test_ownership_rollup_csv.py
@@ -212,7 +212,7 @@ def test_build_csv_row_per_holder_across_slices() -> None:
     assert lines[2].startswith("0000222222,BigFund,institutions,2000000,")
     assert "13f" in lines[2] and ",OTHER," in lines[2]
     assert ",ETF," in lines[3]  # filer_type column
-    assert lines[4].startswith(",Treasury (memo),__treasury__,500000,")
+    assert lines[4].startswith(",Treasury (memo),__memo:treasury__,500000,")
     assert lines[5].startswith(",Public / unattributed,__residual__,6500000,")
 
 
@@ -257,6 +257,45 @@ def test_build_csv_emits_dropped_source_memo_rows() -> None:
     )
     # 38,347,842 (Cohen once) + 410,027,315 residual == 448,375,157 outstanding.
     assert summed == Decimal("448375157")
+
+
+def test_build_csv_sum_invariant_holds_with_treasury_present() -> None:
+    """The additive reconciliation must hold for a treasury-carrying issuer.
+
+    Regression for the gap that let #2217 reach the CSV: the invariant test
+    above runs with ``treasury=None``, and treasury's old ``__treasury__``
+    category was outside the ``__memo:``/``__dropped:`` filter — so no test
+    ever summed a CSV that contained a treasury row. Once the residual stopped
+    deducting treasury, the exported column would have summed to
+    ``outstanding + treasury`` and nothing would have failed.
+
+    Treasury is deliberately LARGER than outstanding here (12M vs 10M), the
+    Goldman shape: if it were an additive term the sum could not reconcile at
+    all.
+    """
+    holder = _holder(
+        cik="0000111111",
+        name="Alice CEO",
+        shares="3000000",
+        pct="0.30",
+        source="form4",
+        accession="0000111-26-000001",
+    )
+    insiders = _slice("insiders", (holder,))
+    csv = build_rollup_csv(
+        _rollup(slices=(insiders,), treasury="12000000", residual_shares="7000000"),
+    )
+    lines = csv.splitlines()
+
+    assert any(",Treasury (memo),__memo:treasury__,12000000," in ln for ln in lines)
+
+    data_rows = [ln.split(",") for ln in lines[1:]]
+    summed = sum(
+        Decimal(r[3]) for r in data_rows if not r[2].startswith("__dropped:") and not r[2].startswith("__memo:")
+    )
+    # 3,000,000 attributed + 7,000,000 residual == 10,000,000 outstanding.
+    # The 12,000,000 treasury row is excluded by the documented filter.
+    assert summed == Decimal("10000000")
 
 
 def test_build_csv_omits_treasury_row_when_treasury_zero_or_none() -> None:
@@ -434,7 +473,7 @@ def test_build_csv_memo_overlay_slices_emit_after_residual_with_prefix() -> None
     assert "insiders," in lines[1]
     assert "Vanguard" not in lines[1]
     # Treasury + residual sit between pie-wedge and memo blocks.
-    assert "__treasury__" in lines[2]
+    assert "__memo:treasury__" in lines[2]
     assert "__residual__" in lines[3]
     # Memo row carries the `__memo:funds__` prefix on the category column.
     assert "0000036405,Vanguard 500 Index Fund,__memo:funds__,200000," in lines[4]
@@ -502,7 +541,7 @@ def test_build_csv_def14a_proxy_disclosure_emits_as_memo_excluded_from_sum() -> 
     # header / insider / treasury / residual / memo:def14a_unmatched = 5 lines.
     assert len(lines) == 5
     assert "insiders," in lines[1]
-    assert "__treasury__" in lines[2]
+    assert "__memo:treasury__" in lines[2]
     assert "__residual__" in lines[3]
     assert "Sponsor Control Group,__memo:def14a_unmatched__,300000," in lines[4]
     # Additive reconciliation excludes the proxy block.


### PR DESCRIPTION
Closes #2217. Refs #2226.

`_compute_residual` computed `outstanding - sum_known - treasury`. Treasury was never in that base, so the subtraction removed a quantity that is not there — and for any serial repurchaser it drove the residual negative before a single holder was counted. The residual clamps at zero, so **public float rendered as exactly ZERO** for KO, GS, JPM, HD, PG, XOM, PFE, WFC and MS, with the `oversubscribed` warning bar below blaming 13F snapshot lag for it. The operator got a wrong number *and* a wrong explanation.

## Source rule

The denominator is `dei:EntityCommonStockSharesOutstanding` / `us-gaap:CommonStockSharesOutstanding` (`_read_shares_outstanding`), both of which are **outstanding**, not issued. Shares issued = shares outstanding + treasury, so the DEI cover-page count already excludes treasury.

This is also the module's own settled contract, not an inference. The 2026-05-03 codex audit's ship-blocker was *"wrong denominator — the prior frontend math used `shares_outstanding + treasury_shares`; the canonical denominator is `shares_outstanding` only, with treasury rendered as an additive top wedge"*, and the design doc spells it out (`docs/proposals/etl/ownership-tier0-cik-history.md`, §OwnershipPanel: *"Treasury renders as a category wedge on top, additive"*). The frontend was corrected then. This residual kept the mirror image of the same error and nobody noticed.

Three independent confirmations that the base excludes treasury:

- **95 instruments carry treasury ≥ 100% of outstanding** (Goldman: 199.9%). Arithmetically impossible if outstanding included it.
- `_compute_concentration`, 12 lines below, has always excluded treasury correctly. The right treatment already existed in the same file.
- Cross-source (stockanalysis.com, KO): shares outstanding **4.30B** — matches ours exactly — and float **3.87B**. If the 2.737B treasury sat inside that 4.30B, float could not exceed 1.57B.

## Fix

`raw = outstanding - sum_known`. `_compute_concentration` untouched. Treasury remains a rendered top wedge — no change to the chart.

## Full-population A/B

⚠ **The first A/B was invalid and was thrown away.** Run as two sequential processes against the live dev DB, it reported four invariant failures including zero-treasury controls moving and `concentration` changing on 465 instruments — which this diff cannot touch. Cause: the jobs daemon rewrote **2,175 `ownership_institutions_current` rows** between the arms. The arms saw different data.

Rebuilt as a **paired** design: for each instrument both arms are evaluated inside one `snapshot_read` (REPEATABLE READ) from one set of slices, so concurrent ingest cannot land between them. Neither arm is simulated — the control is origin/main's `_compute_residual` body extracted verbatim via `git show` and exec'd, invoked on the same `(outstanding, slices, treasury)` the live path built; the treatment is the real function reached through the real `get_ownership_rollup`.

**4,421 instruments** (every instrument with a denominator; 192 return before the residual is computed). 0 harness errors.

| invariant | result |
|---|---|
| residual never decreases | **PASS** (0) |
| no instrument GAINS `oversubscribed` | **PASS** (0) |
| zero-treasury instruments byte-identical | **PASS** (0) |
| delta == treasury exactly, where unclamped | **PASS** (0) |

| | control | treatment |
|---|---|---|
| `oversubscribed` | 2,297 (52.0%) | 2,076 (47.0%) |
| public float renders **zero** | 2,297 (52.0%) | 2,076 (47.0%) |
| unchanged / changed | — | 3,761 / 660 |

**Gain side inspected** (largest increases), not just the count of fixed rows:

| symbol | treasury % of outstanding | residual before | after | flag |
|---|---|---|---|---|
| XOM | 93.5% | 0.00% | 31.06% | True→False |
| PFE | 69.0% | 0.00% | 30.30% | True→False |
| KO | 63.6% | 0.00% | 23.68% | True→False |
| PG | 71.6% | 0.00% | 28.38% | True→False |
| BKNG | 108.1% | 0.00% | 71.78% | True→False |
| MUFG | 6.3% | 93.70% | 99.98% | False→False |
| DIS | 7.5% | 12.96% | 20.44% | False→False |

No instrument ends with `residual_pct > 100%`. DIS and MUFG are the cases the ticket did not anticipate: a small treasury balance moves the number without ever having tripped the flag, so this fix corrects names that were never flagged as wrong.

## ⚠ One ticket acceptance criterion is FALSIFIED

The ticket predicted `oversubscribed` prevalence would fall "to ~0, and any survivor is explicable by date skew". **It does not** — 52.0% → 47.0%. **1,245 of the 2,076 survivors hold no treasury at all**, so treasury arithmetic was never their cause; their pie wedges alone exceed outstanding (OPCH 513%, PRVA 187%, HPQ 105%).

That is a second, larger defect with the same operator-visible symptom. Filed as **#2226** with the population numbers and four candidate causes, rather than folded in here. `oversubscribed` remains unusable as an exception signal until it is fixed, and that is stated in the skill rather than left for the next reader to rediscover.

## Codex checkpoint 2 caught a real one

`build_rollup_csv` documented and emitted an additive reconciliation of `Σ pie holders + treasury + residual = shares_outstanding`. Once the residual stopped deducting treasury, that column summed to `outstanding + treasury` — the export contradicting the JSON it exports.

Treasury moves from `__treasury__` to `__memo:treasury__`, the prefix convention funds and unmatched-DEF-14A rows already use, so the single documented filter rule excludes it. Emission position is unchanged (immediately before `__residual__`); only the category token moved. The invariant is now `Σ (non-memo, non-dropped) + residual = shares_outstanding`.

**Operator-visible contract change:** a spreadsheet keying on the literal `__treasury__` needs updating to `__memo:treasury__` — or, better, to the `__memo:` prefix rule, which is what the docs have always told consumers to filter on.

## Why no test caught any of this

Two test defects, both fixed here:

1. `test_residual_label_and_value` asserted `residual == 60M` for 100M outstanding / 30M known / 10M treasury. It was **asserting the defect**, not the contract. Now 70M, plus a new regression test using the Goldman shape — treasury (200%) larger than outstanding — which must leave 70% public and the flag clear.
2. The CSV reconciliation test runs with `treasury=None`, and `__treasury__` sat outside the `__memo:`/`__dropped:` filter it applies, so **no test had ever summed a CSV containing a treasury row**. Added one that does. Separately, the memo-overlay test's "invariant" block asserted `500000 + 100000 + 9400000 == 10000000` over hand-written literals — an identity that never read the CSV and could not fail when the builder changed. It now parses the emitted CSV.

## Definition-of-Done evidence

| clause | evidence |
|---|---|
| 8 — smoke panel | live `/instruments/{sym}/ownership-rollup` on dev, at `349d06ba`: KO 23.68%, GS 23.78%, JPM 24.23%, PG 28.38%, XOM 31.06% — all `oversubscribed=false`. Controls AAPL 33.59%, MSFT 25.77%, GME 51.02% unchanged (no treasury row). |
| 9 — cross-source | stockanalysis.com KO: outstanding 4.30B (matches), float 3.87B — see Source rule above. |
| 10 — backfill | **N/A, and that is a property of the metric, not a skip.** The rollup is computed at read time and stored nowhere (`metrics-analyst`: "Storage: not stored"). No `sec_rebuild` scope applies; the fix lands when the API process reloads, which it has. |
| 11 — operator-visible figure | verified on the running dev stack, table in clause 8. |
| 12 — commit SHA | `349d06ba`. |

## Skill correction (same PR)

`metrics-analyst` carried the same error in two places and is corrected:

- Its **validation identity** was `Σ all wedges + residual + treasury ≈ shares_outstanding`, which only holds if treasury were in the base.
- Its **caveat** read *"treasury IS allowed to push chart oversubscribed"* — written as a rare stale-13F artefact. That is the caveat this bug hid behind for months: at 2% it is a caveat, at 45% of large caps it is a defect wearing one. The rule added is to measure the rate before accepting a documented caveat as the explanation.

The lesson was already extracted to `docs/review-prevention-log.md` and `full-population-ab.md` during the audit that found this, so it is not re-added.

## Checks

`ruff check` / `ruff format --check` / `pyright` (0 errors) / `pytest -m "not db"` all clean. `-m db` green over `test_ownership_rollup`, `test_ownership_rollup_csv`, `test_ownership_machine_trust_envelope`, `test_bootstrap_validation`, `test_api_instruments`.

⚠ The fast tier caught a caller I had missed (`test_ownership_machine_trust_envelope` calls `_compute_residual` directly) — my earlier `-m db` run over that file skipped it, because it is a pure-logic test.

## Security

No security surface. Read-path arithmetic on already-authorised data; no new input, query or permission.
