### PR TITLE
docs: pair A/B arms when they read the live dev DB

### DIFF
--- a/.claude/skills/engineering/full-population-ab.md
+++ b/.claude/skills/engineering/full-population-ab.md
@@ -214,6 +214,29 @@ item. With the index: ~300/min. `EXPLAIN` the new query once; it costs seconds.
   see byte-identical input.
 - Run both sides concurrently; a git worktree at `origin/main` gives the control
   side without disturbing the dev checkout.
+- ⚠ **If either side reads the LIVE dev DB, two sequential runs are not an A/B.**
+  The jobs daemon keeps ingesting underneath you, so the arms see different
+  inputs and the diff is measuring ingest, not your change. #2217 ran control
+  and treatment as two ~4-minute processes 15 minutes apart; **2,175
+  `ownership_institutions_current` rows were rewritten between them**, and the
+  diff reported four invariant failures — including zero-treasury control
+  instruments moving, and `concentration` changing on 465 instruments, which
+  that diff could not touch.
+
+  **The tell is an invariant failing on a quantity your change cannot affect.**
+  When you see one, suspect the harness before the fix.
+
+  Fix by **pairing**: one process, and for each item evaluate BOTH arms inside a
+  single `snapshot_read` (REPEATABLE READ) from one set of inputs, so nothing
+  can land between them. That is not "simulating the control" — extract the
+  control function's body verbatim from `git show origin/main:<path>` and `exec`
+  it, then invoke it on the same arguments the live path built. Both arms are
+  real code; only the contamination is gone. Re-run paired, #2217's four
+  invariants all passed and the controls were byte-identical.
+
+  Offline re-parse from stored payloads (above) is immune to this — prefer it
+  when the data allows. Pairing is for metrics computed at read time, which have
+  no stored artefact to re-parse.
 - Long runs need `run_in_background: true` — a `nohup … &` started inside an
   ordinary tool call is killed when that call's process group is cleaned up.
 - Reference implementation: `scripts/ab_2140_def14a_parser.py`

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -2577,3 +2577,13 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Enforced in: this prevention log; the four occurrences in `full-population-ab.md` are fixed.
 
 ---
+
+### A/B whose two arms read the live dev DB is measuring ingest, not the change
+
+- First seen in: #2217 (2026-08-03), caught by the harness's own invariants, not by review.
+- Symptom: control and treatment were run as two sequential ~4-minute processes against the live dev DB, 15 minutes apart. The diff reported four invariant failures — residual decreasing on 42 instruments, zero-treasury control instruments moving, and `concentration` changing on 465 — none of which the one-line arithmetic change could produce. The jobs daemon had rewritten **2,175 `ownership_institutions_current` rows** in the window between the arms, so the two sides simply saw different data.
+- Root cause of the miss: the existing guidance ("run both sides concurrently, use a worktree for the control") addresses code isolation, and is silent on DATA isolation. It assumes the offline re-parse path, where both sides read frozen payloads. A metric computed at read time has no stored artefact to re-parse, so both arms necessarily hit the live database — which never stops moving.
+- Prevention: **an invariant failing on a quantity the change cannot affect means suspect the harness before the fix.** For read-time metrics, pair the arms: one process, and for each item evaluate BOTH inside a single `snapshot_read` (REPEATABLE READ) from one set of inputs. Extract the control body verbatim via `git show origin/main:<path>` and `exec` it rather than retyping or deriving it analytically — that keeps "never simulate the control" intact while removing the contamination. Re-run paired, all four invariants passed and the controls were byte-identical.
+- Enforced in: this prevention log; `.claude/skills/engineering/full-population-ab.md` §Mechanics.
+
+---


### PR DESCRIPTION
Extracted from #2217. Doc-only.

#2217's first full-population A/B was invalid and had to be discarded. Control and treatment ran as two sequential ~4-minute processes against the live dev DB, 15 minutes apart. The diff reported four invariant failures — residual decreasing on 42 instruments, zero-treasury control instruments moving, and `concentration` changing on 465 — none of which a one-line arithmetic change could produce. The jobs daemon had rewritten **2,175 `ownership_institutions_current` rows** between the arms.

The skill's existing guidance ("run both sides concurrently; a worktree at `origin/main` gives the control") addresses **code** isolation and is silent on **data** isolation, because it assumes the offline re-parse path where both sides read frozen payloads. A metric computed at read time has no stored artefact to re-parse, so both arms necessarily hit a database that never stops moving.

Adds two things:

- **The tell** — an invariant failing on a quantity your change cannot affect means suspect the harness before the fix. That is what pointed at the contamination rather than at the diff.
- **The technique** — pairing: one process, both arms evaluated inside a single `snapshot_read` (REPEATABLE READ) from one set of inputs. The control body is extracted verbatim via `git show origin/main:<path>` and `exec`'d rather than retyped or derived analytically, so the skill's "never simulate the control" rule still holds — both arms are real code, only the contamination is gone. Re-run paired, all four of #2217's invariants passed and the controls were byte-identical.

Also notes that offline re-parse is immune to this and should stay the default; pairing is for read-time metrics only.

Lands in `.claude/skills/engineering/full-population-ab.md` §Mechanics and `docs/review-prevention-log.md`, per the rule that a lesson must not live only in a PR description.

## Security

Doc-only; no code, no security surface.

Refs #2217.