### PR TITLE
fix(#2229): a later complete 13F-HR omitting a security proves the filer exited it

### DIFF
--- a/.claude/skills/engineering/full-population-ab.md
+++ b/.claude/skills/engineering/full-population-ab.md
@@ -88,6 +88,32 @@ classify each one by hand. "Net +11,000" hides "and 101 real holders vanished".
 parsed as holders — appeared only among the gains. A change that only adds
 looks safe and isn't.
 
+### For a READ-TIME metric, latency is a second metric — measure it
+
+Issue #2229. A metric computed at read time and stored nowhere (the ownership
+rollup: `metrics-analyst` says "Storage: not stored") runs its every predicate
+on **every operator request**. The correctness arms above ask whether the FIGURE
+changed; they are silent on what it now costs, and so is every other gate —
+lint, typecheck, the test suite, the review bot.
+
+That change's supersession predicate was correct and made the endpoint **11-20x
+slower**: AAPL 214ms → 2,390ms, HD 180ms → 3,675ms.
+
+So time control vs treatment on the real path before pushing. It is the same
+`git show origin/main:<path>` control extraction the paired design already uses
+— just `perf_counter` around each arm instead of diffing the figure. Doing it
+surfaced three things no correctness arm could:
+
+1. A subquery scoped to the **instrument** was being re-evaluated per **row**;
+   hoisting it to a CTE was behaviour-preserving (identical counts) and cut
+   3,675ms → 1,449ms.
+2. The better data source measured **3x worse** until it had a covering index.
+3. Therefore: **a missing index can make you reject the correct source.**
+   `idx_inst_current_filer (filer_cik)` alone made `MAX(period_end)` heap-fetch
+   every row of a filer like Vanguard — 7,651ms, against 25ms with
+   `(filer_cik, period_end DESC)`. Measure the source and its index together,
+   or the index decision silently becomes a data-model decision.
+
 ## Three arms, because one cannot see what the others see
 
 **Arm 1 — parse vs parse.** `main` in a git worktree vs the branch. Catches

--- a/app/api/instruments.py
+++ b/app/api/instruments.py
@@ -4741,6 +4741,20 @@ class _CorrectionAppliedModel(BaseModel):
         blockholders wedge.
       * ``insider_control_group_collapse`` (#1652) — a sponsor's GP/LP chain deemed block
         counted once across Form 4 / Form 3 / 13D / 13G (insiders slice).
+      * ``superseded_by_later_13f_hr`` (#2229) — a filer's stale 13F-HR removed because
+        the filer filed a LATER holdings report that omits this security (Form 13F
+        Special Instruction 5b: a holdings report is a COMPLETE statement of the
+        Manager's Section 13(f) holdings, so the omission proves the exit).
+        ``superseded_period`` + ``winning_accession`` set, NT fields null.
+
+    ⚠ This Literal is a CLOSED vocabulary and the service layer's ``kind`` strings are
+    NOT validated against it until serialization — so a new kind added to
+    ``ownership_rollup.CorrectionApplied`` without being added HERE makes the endpoint
+    500 on exactly the instruments the new correction fires for, while every
+    service-layer test still passes. That is what happened when #2229 landed; the
+    sibling to keep in step is ``frontend/src/api/ownership.ts``
+    (``OwnershipCorrectionKind``). See prevention-log "contract-field wired into one
+    model not its sibling".
 
     The NT-specific fields are null for the #1644/#1649 kinds; ``family_id`` /
     ``source_channel`` / ``winning_source`` / ``winning_accession`` / ``detail``
@@ -4753,6 +4767,7 @@ class _CorrectionAppliedModel(BaseModel):
         "institutional_family_collapse",
         "blockholder_group_collapse",
         "insider_control_group_collapse",
+        "superseded_by_later_13f_hr",
     ]
     filer_cik: str | None
     filer_name: str

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -151,6 +151,14 @@ class CorrectionApplied:
     Closed ``kind`` vocab:
       * ``suppressed_by_13f_nt`` (#1639) — a filer's stale 13F-HR removed because
         the filer filed a 13F-NT for a later quarter. NT-specific fields set.
+      * ``superseded_by_later_13f_hr`` (#2229) — a filer's stale 13F-HR removed
+        because the filer filed a LATER holdings report that omits this security.
+        Form 13F SI 5b makes a holdings report a complete statement of the Manager's
+        §13(f) holdings, so the omission is affirmative evidence of an exit. Distinct
+        from ``suppressed_by_13f_nt``: the Notice says the filer holds nothing
+        reportable at all, this says it no longer holds THIS security. A row matching
+        both is reported only under the NT kind. ``superseded_period`` set, NT fields
+        None; the winning period is in ``detail``.
       * ``def14a_restates_institution`` (#1644) — a proxy 5%-holder figure folded
         under a larger 13F family sum (the channel restated, did not add).
       * ``institutional_family_collapse`` (#1649) — a family's 13F shell figure
@@ -921,13 +929,59 @@ def _collect_canonical_holders_from_current(conn: psycopg.Connection[Any], instr
     # ``_current``, so the strict ``>`` is always well-defined. The companion
     # :func:`_read_notice_suppressions` lists exactly the rows this excludes for
     # the ``corrections_applied`` telemetry.
+    #
+    # 13F-HR supersession (#2229) generalises that from the Notice case to the
+    # ordinary one. ``_current`` keeps the latest row per (instrument, filer,
+    # nature, exposure) and its MERGE deletes only ``NOT MATCHED BY SOURCE`` — but
+    # 13F reports an exit by OMISSION, never by a zero row, so a filer who sold out
+    # kept contributing its last reported position forever. 96.7% of filers whose
+    # row was stuck at 2025-12-31 had in fact filed later: they had stopped holding
+    # THIS instrument, not stopped filing.
+    #
+    # Form 13F Special Instruction 5b: a "13F HOLDINGS REPORT" reports ALL securities
+    # over which the Manager has investment discretion. A later report from the same
+    # filer that omits this security is therefore affirmative evidence the position
+    # is gone — no date threshold and no tuning constant, unlike the as-of bound this
+    # ticket originally proposed. ``institutional_holdings`` is the raw landing
+    # table, so a later ``period_of_report`` there is the filer's newer 13F for some
+    # OTHER instrument; had that filing contained this one, ``_current`` would carry
+    # the later period.
+    #
+    # ⚠ The guard matters as much as the predicate. Absence from a later filing can
+    # also mean OUR CUSIP resolution failed on it. ``unresolved_13f_cusips`` holds
+    # 109,683 rows, 1,650 of whose CUSIPs are resolvable via ``external_identifiers``
+    # — the instrument is known to us but some filing's row never bound. Without the
+    # guard this silently deletes real holders on exactly the instruments whose
+    # ingest is weakest, so an instrument with any unresolved sighting at or after
+    # the row's period is exempt from supersession entirely.
+    #
+    # The guard deliberately does NOT narrow by ``resolution_status``. Of the 3,227
+    # sighting rows whose CUSIP binds to a known instrument, 1,724 are marked
+    # ``resolved_via_openfigi`` / ``resolved_via_extid`` — but a resolution MARKING is
+    # not proof the holdings were re-ingested (#2213: OpenFIGI resolution ran dark for
+    # seven weeks behind success-reporting sweeps). Narrowing would fix more
+    # instruments at the cost of silently deleting real holders where that assumption
+    # is wrong, and the two errors are not symmetric: a false keep leaves an
+    # instrument visibly oversubscribed, a false delete is invisible. Broad it is;
+    # 1,648 instruments are exempted, which the A/B measures rather than assumes.
+    #
+    # Two Special Instructions checked and deliberately NOT guarded against:
+    #   * COMBINATION reports (SI 5c) are not complete, and we cannot tell them apart
+    #     (``sec_filing_manifest.form`` is only ``13F-HR``/``13F-HR/A``; the Report
+    #     Type checkbox lives in ``primary_doc.xml``, which we do not retain
+    #     queryably). Not a correctness risk: if manager B's holdings are reported by
+    #     manager A, A's filing INCLUDES those shares, so dropping B's stale row
+    #     removes a double count rather than a holder.
+    #   * De minimis omission (SI 9) lets a Manager omit a holding under 10,000 shares
+    #     AND under $200,000. Anything omitted on that basis is ≤10,000 shares, which
+    #     is negligible against any pie wedge.
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
             SELECT c.filer_cik, c.filer_name, c.filer_type, c.ownership_nature,
                    c.source, c.source_accession, c.shares, c.period_end
             FROM ownership_institutions_current c
-            WHERE c.instrument_id = %s
+            WHERE c.instrument_id = %(iid)s
               AND c.shares IS NOT NULL
               AND c.exposure_kind = 'EQUITY'
               AND NOT EXISTS (
@@ -935,8 +989,26 @@ def _collect_canonical_holders_from_current(conn: psycopg.Connection[Any], instr
                     WHERE n.filer_cik  = c.filer_cik
                       AND n.period_end > c.period_end
               )
+              AND NOT (
+                    EXISTS (
+                        SELECT 1
+                        FROM institutional_holdings h
+                        JOIN institutional_filers f ON f.filer_id = h.filer_id
+                        WHERE f.cik = c.filer_cik
+                          AND h.period_of_report > c.period_end
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM unresolved_13f_cusips u
+                        JOIN external_identifiers e
+                          ON e.identifier_type = 'cusip'
+                         AND e.identifier_value = u.cusip
+                        WHERE e.instrument_id = %(iid)s
+                          AND u.last_period_end >= c.period_end
+                    )
+              )
             """,
-            (instrument_id,),
+            {"iid": instrument_id},
         )
         for row in cur.fetchall():
             rows.append(
@@ -1002,6 +1074,82 @@ def _read_notice_suppressions(conn: psycopg.Connection[Any], instrument_id: int)
                     winning_nt_period=row["winning_nt_period"],
                     winning_nt_accession=str(row["winning_nt_accession"]),
                     source_channel="13f",  # the folded channel (#1647 generic provenance)
+                )
+            )
+    return tuple(rows)
+
+
+def _read_hr_supersessions(conn: psycopg.Connection[Any], instrument_id: int) -> tuple[CorrectionApplied, ...]:
+    """List the institution rows EXCLUDED by 13F-HR supersession (#2229), with the
+    later filing that proves the exit, for the ``corrections_applied`` telemetry.
+
+    The selection is the exact complement of the rollup institutions query's second
+    ``NOT (... AND NOT EXISTS ...)`` clause — these are the rows that filter removed.
+    Mirrors :func:`_read_notice_suppressions`: the lateral join picks the filer's
+    LATEST subsequent ``period_of_report`` (``ORDER BY ... DESC``, never a bare
+    ``LIMIT 1``, per the deterministic-pick rule). Without this the operator would
+    see the institutions wedge shrink with no visible cause — the same reason #1639
+    shipped its own producer.
+
+    The 13F-NT exclusion is repeated here so a row suppressed by BOTH mechanisms is
+    reported once, by :func:`_read_notice_suppressions` (the Notice is the stronger
+    evidence: the filer declared it holds nothing reportable at all)."""
+    rows: list[CorrectionApplied] = []
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT c.filer_cik, c.filer_name, c.shares,
+                   c.period_end AS superseded_period,
+                   c.source_accession,
+                   n.period_of_report AS winning_period
+            FROM ownership_institutions_current c
+            JOIN LATERAL (
+                SELECT h.period_of_report
+                FROM institutional_holdings h
+                JOIN institutional_filers f ON f.filer_id = h.filer_id
+                WHERE f.cik = c.filer_cik
+                  AND h.period_of_report > c.period_end
+                ORDER BY h.period_of_report DESC
+                LIMIT 1
+            ) n ON TRUE
+            WHERE c.instrument_id = %(iid)s
+              AND c.shares IS NOT NULL
+              AND c.exposure_kind = 'EQUITY'
+              AND NOT EXISTS (
+                    SELECT 1 FROM institutional_filer_13f_notices nt
+                    WHERE nt.filer_cik  = c.filer_cik
+                      AND nt.period_end > c.period_end
+              )
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM unresolved_13f_cusips u
+                    JOIN external_identifiers e
+                      ON e.identifier_type = 'cusip'
+                     AND e.identifier_value = u.cusip
+                    WHERE e.instrument_id = %(iid)s
+                      AND u.last_period_end >= c.period_end
+              )
+            ORDER BY c.shares DESC, c.filer_cik
+            """,
+            {"iid": instrument_id},
+        )
+        for row in cur.fetchall():
+            rows.append(
+                CorrectionApplied(
+                    kind="superseded_by_later_13f_hr",
+                    filer_cik=str(row["filer_cik"]),
+                    filer_name=str(row["filer_name"]),
+                    shares_removed=Decimal(row["shares"]),
+                    superseded_period=row["superseded_period"],
+                    source_channel="13f",  # the folded channel (#1647 generic provenance)
+                    winning_source="13f",
+                    winning_accession=(str(row["source_accession"]) if row["source_accession"] else None),
+                    detail=(
+                        f"Filer reported holdings for {row['winning_period']} that omit this security; "
+                        f"Form 13F Special Instruction 5b makes a holdings report a complete statement "
+                        f"of the Manager's Section 13(f) holdings, so the {row['superseded_period']} "
+                        f"position is closed."
+                    ),
                 )
             )
     return tuple(rows)
@@ -3971,11 +4119,14 @@ def get_ownership_rollup(conn: psycopg.Connection[Any], symbol: str, instrument_
     estimates = _read_universe_estimates(conn, instrument_id)
     coverage = _compute_coverage(slices, estimates)
     banner = _banner_for_state(coverage.state, coverage, concentration.pct_outstanding_known)
-    # 13F-NT supersession telemetry (#1639): the rows the institutions query
-    # excluded, so the shrunk wedge + grown residual are explainable. Read from
-    # the same snapshot as everything else (caller is inside snapshot_read).
+    # 13F-NT supersession telemetry (#1639) + 13F-HR supersession telemetry (#2229):
+    # the rows the institutions query excluded, so the shrunk wedge + grown residual
+    # are explainable. Read from the same snapshot as everything else (caller is
+    # inside snapshot_read). NT first — a row suppressed by both is reported once,
+    # under the stronger evidence.
     corrections_applied = (
         *_read_notice_suppressions(conn, instrument_id),
+        *_read_hr_supersessions(conn, instrument_id),
         *family_corrections,
         *same_accession_corrections,
         *insider_group_corrections,

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -942,10 +942,18 @@ def _collect_canonical_holders_from_current(conn: psycopg.Connection[Any], instr
     # over which the Manager has investment discretion. A later report from the same
     # filer that omits this security is therefore affirmative evidence the position
     # is gone — no date threshold and no tuning constant, unlike the as-of bound this
-    # ticket originally proposed. ``institutional_holdings`` is the raw landing
-    # table, so a later ``period_of_report`` there is the filer's newer 13F for some
-    # OTHER instrument; had that filing contained this one, ``_current`` would carry
-    # the later period.
+    # ticket originally proposed.
+    #
+    # The evidence is read from ``ownership_institutions_current`` ITSELF, not from
+    # the ``institutional_holdings`` landing table. Both were measured: they agree on
+    # 9,067 filers, ``_current`` is NEWER on 148 and behind on 0, because ``_current``
+    # is fed by the continuous manifest parser as well as the quarterly bulk dataset.
+    # Using one table also makes the predicate self-consistent — a later ``period_end``
+    # for this filer against some OTHER instrument means the filing existed and did
+    # not contain this one, or ``_current`` would carry the later period for it.
+    # (Needs ``idx_inst_current_filer_period``, sql/245: without it the MAX heap-fetches
+    # every row of a filer like Vanguard and the lookup costs 7,651ms instead of 25ms
+    # on AAPL. This runs at READ time on every rollup request.)
     #
     # ⚠ The guard matters as much as the predicate. Absence from a later filing can
     # also mean OUR CUSIP resolution failed on it. ``unresolved_13f_cusips`` holds
@@ -978,34 +986,34 @@ def _collect_canonical_holders_from_current(conn: psycopg.Connection[Any], instr
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
+            WITH guard AS (
+                SELECT MAX(u.last_period_end) AS max_unresolved
+                FROM unresolved_13f_cusips u
+                JOIN external_identifiers e
+                  ON e.identifier_type = 'cusip'
+                 AND e.identifier_value = u.cusip
+                WHERE e.instrument_id = %(iid)s
+            )
             SELECT c.filer_cik, c.filer_name, c.filer_type, c.ownership_nature,
                    c.source, c.source_accession, c.shares, c.period_end
             FROM ownership_institutions_current c
+            CROSS JOIN guard g
+            LEFT JOIN LATERAL (
+                SELECT MAX(x.period_end) AS latest_filed_period
+                FROM ownership_institutions_current x
+                WHERE x.filer_cik = c.filer_cik
+            ) n ON TRUE
             WHERE c.instrument_id = %(iid)s
               AND c.shares IS NOT NULL
               AND c.exposure_kind = 'EQUITY'
               AND NOT EXISTS (
-                    SELECT 1 FROM institutional_filer_13f_notices n
-                    WHERE n.filer_cik  = c.filer_cik
-                      AND n.period_end > c.period_end
+                    SELECT 1 FROM institutional_filer_13f_notices nt
+                    WHERE nt.filer_cik  = c.filer_cik
+                      AND nt.period_end > c.period_end
               )
               AND NOT (
-                    EXISTS (
-                        SELECT 1
-                        FROM institutional_holdings h
-                        JOIN institutional_filers f ON f.filer_id = h.filer_id
-                        WHERE f.cik = c.filer_cik
-                          AND h.period_of_report > c.period_end
-                    )
-                    AND NOT EXISTS (
-                        SELECT 1
-                        FROM unresolved_13f_cusips u
-                        JOIN external_identifiers e
-                          ON e.identifier_type = 'cusip'
-                         AND e.identifier_value = u.cusip
-                        WHERE e.instrument_id = %(iid)s
-                          AND u.last_period_end >= c.period_end
-                    )
+                    COALESCE(n.latest_filed_period > c.period_end, FALSE)
+                    AND NOT COALESCE(g.max_unresolved >= c.period_end, FALSE)
               )
             """,
             {"iid": instrument_id},
@@ -1083,13 +1091,18 @@ def _read_hr_supersessions(conn: psycopg.Connection[Any], instrument_id: int) ->
     """List the institution rows EXCLUDED by 13F-HR supersession (#2229), with the
     later filing that proves the exit, for the ``corrections_applied`` telemetry.
 
-    The selection is the exact complement of the rollup institutions query's second
-    ``NOT (... AND NOT EXISTS ...)`` clause — these are the rows that filter removed.
-    Mirrors :func:`_read_notice_suppressions`: the lateral join picks the filer's
-    LATEST subsequent ``period_of_report`` (``ORDER BY ... DESC``, never a bare
-    ``LIMIT 1``, per the deterministic-pick rule). Without this the operator would
-    see the institutions wedge shrink with no visible cause — the same reason #1639
-    shipped its own producer.
+    The selection is the exact complement of the rollup institutions query's final
+    ``NOT (...)`` clause — these are the rows that filter removed, so the two must be
+    kept in step. Mirrors :func:`_read_notice_suppressions`: the lateral join picks
+    the filer's LATEST subsequent period (``ORDER BY ... DESC`` on both keys, never a
+    bare ``LIMIT 1``, per the deterministic-pick rule). Without this the operator
+    would see the institutions wedge shrink with no visible cause — the same reason
+    #1639 shipped its own producer.
+
+    ``winning_accession`` is the LATER filing's accession, not the removed row's:
+    Codex ckpt-2 caught it pointing at the superseded row while labelling it the
+    winning source, which would send an operator auditing the correction to the
+    losing filing.
 
     The 13F-NT exclusion is repeated here so a row suppressed by BOTH mechanisms is
     reported once, by :func:`_read_notice_suppressions` (the Notice is the stronger
@@ -1098,19 +1111,26 @@ def _read_hr_supersessions(conn: psycopg.Connection[Any], instrument_id: int) ->
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
+            WITH guard AS (
+                SELECT MAX(u.last_period_end) AS max_unresolved
+                FROM unresolved_13f_cusips u
+                JOIN external_identifiers e
+                  ON e.identifier_type = 'cusip'
+                 AND e.identifier_value = u.cusip
+                WHERE e.instrument_id = %(iid)s
+            )
             SELECT c.filer_cik, c.filer_name, c.shares,
                    c.period_end AS superseded_period,
-                   c.source_accession AS superseded_accession,
                    n.period_of_report AS winning_period,
                    n.accession_number AS winning_accession
             FROM ownership_institutions_current c
+            CROSS JOIN guard g
             JOIN LATERAL (
-                SELECT h.period_of_report, h.accession_number
-                FROM institutional_holdings h
-                JOIN institutional_filers f ON f.filer_id = h.filer_id
-                WHERE f.cik = c.filer_cik
-                  AND h.period_of_report > c.period_end
-                ORDER BY h.period_of_report DESC, h.accession_number DESC
+                SELECT x.period_end AS period_of_report, x.source_accession AS accession_number
+                FROM ownership_institutions_current x
+                WHERE x.filer_cik = c.filer_cik
+                  AND x.period_end > c.period_end
+                ORDER BY x.period_end DESC, x.source_accession DESC
                 LIMIT 1
             ) n ON TRUE
             WHERE c.instrument_id = %(iid)s
@@ -1121,15 +1141,7 @@ def _read_hr_supersessions(conn: psycopg.Connection[Any], instrument_id: int) ->
                     WHERE nt.filer_cik  = c.filer_cik
                       AND nt.period_end > c.period_end
               )
-              AND NOT EXISTS (
-                    SELECT 1
-                    FROM unresolved_13f_cusips u
-                    JOIN external_identifiers e
-                      ON e.identifier_type = 'cusip'
-                     AND e.identifier_value = u.cusip
-                    WHERE e.instrument_id = %(iid)s
-                      AND u.last_period_end >= c.period_end
-              )
+              AND NOT COALESCE(g.max_unresolved >= c.period_end, FALSE)
             ORDER BY c.shares DESC, c.filer_cik
             """,
             {"iid": instrument_id},

--- a/app/services/ownership_rollup.py
+++ b/app/services/ownership_rollup.py
@@ -1100,16 +1100,17 @@ def _read_hr_supersessions(conn: psycopg.Connection[Any], instrument_id: int) ->
             """
             SELECT c.filer_cik, c.filer_name, c.shares,
                    c.period_end AS superseded_period,
-                   c.source_accession,
-                   n.period_of_report AS winning_period
+                   c.source_accession AS superseded_accession,
+                   n.period_of_report AS winning_period,
+                   n.accession_number AS winning_accession
             FROM ownership_institutions_current c
             JOIN LATERAL (
-                SELECT h.period_of_report
+                SELECT h.period_of_report, h.accession_number
                 FROM institutional_holdings h
                 JOIN institutional_filers f ON f.filer_id = h.filer_id
                 WHERE f.cik = c.filer_cik
                   AND h.period_of_report > c.period_end
-                ORDER BY h.period_of_report DESC
+                ORDER BY h.period_of_report DESC, h.accession_number DESC
                 LIMIT 1
             ) n ON TRUE
             WHERE c.instrument_id = %(iid)s
@@ -1143,9 +1144,16 @@ def _read_hr_supersessions(conn: psycopg.Connection[Any], instrument_id: int) ->
                     superseded_period=row["superseded_period"],
                     source_channel="13f",  # the folded channel (#1647 generic provenance)
                     winning_source="13f",
-                    winning_accession=(str(row["source_accession"]) if row["source_accession"] else None),
+                    # The WINNER is the later filing that proves the exit, NOT the stale
+                    # row being removed (Codex ckpt-2). Pointing this at
+                    # ``c.source_accession`` would send an operator auditing the
+                    # correction to the losing accession while labelling it the winner —
+                    # mirrors ``winning_nt_accession`` on the NT kind, which names the
+                    # Notice.
+                    winning_accession=(str(row["winning_accession"]) if row["winning_accession"] else None),
                     detail=(
-                        f"Filer reported holdings for {row['winning_period']} that omit this security; "
+                        f"Filer reported holdings for {row['winning_period']} "
+                        f"(accession {row['winning_accession']}) that omit this security; "
                         f"Form 13F Special Instruction 5b makes a holdings report a complete statement "
                         f"of the Manager's Section 13(f) holdings, so the {row['superseded_period']} "
                         f"position is closed."

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -2587,3 +2587,23 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Enforced in: this prevention log; `.claude/skills/engineering/full-population-ab.md` §Mechanics.
 
 ---
+
+### A closed vocabulary declared in three places is validated in none of them
+
+- First seen in: #2229 (2026-08-03). Found by curling the live dev endpoint for Definition-of-Done clause 8, not by any test.
+- Symptom: a new `CorrectionApplied` kind (`superseded_by_later_13f_hr`) was added to the service layer. `_CorrectionAppliedModel.kind` in `app/api/instruments.py` is a closed Pydantic `Literal` and `frontend/src/api/ownership.ts::OwnershipCorrectionKind` is a closed TS union; neither was updated. **Every `/instruments/{sym}/ownership-rollup` request that fired the new correction returned 500** — 364 corrections on AAPL, 691 on HD — while `ruff`, `pyright`, the fast tier, the smoke test, both DB-backed supersession suites and `test_api_instruments.py` were all green.
+- Root cause of the miss: the service constructs the dataclass with a plain `str` field; the Literal is only evaluated at *serialization*. Service-layer tests assert on the dataclass and never serialize, and no API test exercised an instrument that had a correction. The two declarations were coupled by convention only. This is the #1955 class ("contract-field wired into one model not its sibling") in its most expensive form, because the failure is a hard 500 rather than a wrong number.
+- Prevention: when a vocabulary is declared in more than one place, **derive one from the other in a test** rather than adding a case per value. `tests/test_correction_kind_vocab_contract.py` reads every `CorrectionApplied(kind=...)` out of the service by AST and asserts the API Literal and the FE union cover all of them, plus the reverse so a rename cannot leave stale vocabulary behind. Two guards on the extractor itself were load-bearing and both fired while it was being written: a `>= 6` lower bound caught it missing a conditional-expression call site (matching bare `ast.Constant` made BOTH branches of `"a" if src == "x" else "b"` invisible), and a subsequent blind `ast.walk` over-collected `"x"` — the comparison operand in that conditional's test. **A coverage assertion built on an extractor needs a test that the extractor found anything, or it passes vacuously** — the `x <> ALL('{}')` failure mode in test form.
+- Enforced in: this prevention log; `tests/test_correction_kind_vocab_contract.py`; the docstring on `_CorrectionAppliedModel` names its sibling explicitly.
+
+---
+
+### A read-time metric needs a LATENCY arm, not just a correctness A/B
+
+- First seen in: #2229 (2026-08-03).
+- Symptom: the supersession predicate was correct — the paired full-population A/B would have confirmed it — and made the operator-facing ownership-rollup endpoint **11-20x slower**: AAPL 214ms → 2,390ms, HD 180ms → 3,675ms. The rollup is computed at read time and stored nowhere (`metrics-analyst`: "Storage: not stored"), so a predicate added to it runs on every request. Nothing in the correctness harness, the test suite or the review checklist measures wall time.
+- Root cause of the miss: `full-population-ab.md` measures whether the FIGURE changed. For a metric with no stored artefact, "cost per request" is a second axis the same change can regress, and it is invisible to every existing gate.
+- Prevention: for any change to a read-time-computed metric, **time control vs treatment on the real endpoint before pushing** — same `git show origin/main` control extraction the paired A/B already uses, just measuring `perf_counter` instead of the figure. Three findings came out of doing it here, none of which correctness testing would surface: (1) a subquery scoped to the *instrument* was being re-evaluated per *row* and belonged in a CTE; (2) the better data source measured 3x WORSE until it had a covering index — `idx_inst_current_filer (filer_cik)` alone made `MAX(period_end)` heap-fetch every row of a filer like Vanguard, 7,651ms, against 25ms with `(filer_cik, period_end DESC)`; (3) **a missing index can make you reject the correct source.** Measure the source and the index together, or the index decision silently becomes a data-model decision.
+- Enforced in: this prevention log; `.claude/skills/engineering/full-population-ab.md`; `sql/245_inst_current_filer_period_idx.sql` records the measurement in its header.
+
+---

--- a/frontend/src/api/ownership.ts
+++ b/frontend/src/api/ownership.ts
@@ -299,14 +299,18 @@ export interface OwnershipSharesOutstandingSource {
 /** A figure-changing correction applied at read time (#1639 / #1647).
  *  First-class structured record so the UI / a machine consumer sees WHY the
  *  institutions total changed, not just the corrected number. ``kind`` is a
- *  closed vocabulary; today only ``suppressed_by_13f_nt`` (a filer's stale
- *  13F-HR removed because the filer filed a 13F-NT for a later quarter). */
+ *  closed vocabulary — keep it in step with the backend Literal in
+ *  ``app/api/instruments.py::_CorrectionAppliedModel``, which is the one that
+ *  500s the endpoint when a new kind is missing. */
 export type OwnershipCorrectionKind =
   | "suppressed_by_13f_nt"
   | "def14a_restates_institution"
   | "institutional_family_collapse"
   | "blockholder_group_collapse"
-  | "insider_control_group_collapse";
+  | "insider_control_group_collapse"
+  /** #2229 — a filer's stale 13F-HR removed because the filer filed a LATER
+   *  holdings report omitting this security (Form 13F Special Instruction 5b). */
+  | "superseded_by_later_13f_hr";
 
 export interface OwnershipCorrectionApplied {
   readonly kind: OwnershipCorrectionKind;

--- a/sql/245_inst_current_filer_period_idx.sql
+++ b/sql/245_inst_current_filer_period_idx.sql
@@ -1,0 +1,24 @@
+-- #2229 — index ownership_institutions_current on (filer_cik, period_end DESC).
+--
+-- 13F-HR supersession asks, for each of an instrument's 13F rows, "what is the
+-- LATEST period this filer reported for ANY security?" — a later period proves the
+-- filer filed again and omitted this one (Form 13F Special Instruction 5b: a
+-- holdings report is a COMPLETE statement of the Manager's Section 13(f)
+-- holdings).
+--
+-- The only existing index on this table besides the PK is
+-- idx_inst_current_filer (filer_cik), which is not covering: MAX(period_end) then
+-- heap-fetches every row for that filer, and a manager like Vanguard holds
+-- thousands. Measured on the dev corpus (2.3M rows), the supersession lookup ran
+-- 7,651ms for AAPL and 4,025ms for HD. With this index it is 25ms and 17ms — the
+-- ownership-rollup endpoint is computed at READ time on every request, so that
+-- difference is operator-visible latency, not a batch cost.
+--
+-- Leading column is filer_cik because the lookup has no instrument_id to lead
+-- with, by construction: it is deliberately asking about the filer's holdings in
+-- OTHER instruments. period_end DESC makes it an index-only scan for the MAX.
+--
+-- Not CONCURRENTLY — the migration runner wraps each file in a transaction and
+-- CREATE INDEX CONCURRENTLY cannot run inside one.
+CREATE INDEX IF NOT EXISTS idx_inst_current_filer_period
+    ON ownership_institutions_current (filer_cik, period_end DESC);

--- a/tests/test_correction_kind_vocab_contract.py
+++ b/tests/test_correction_kind_vocab_contract.py
@@ -1,0 +1,125 @@
+"""The ``CorrectionApplied.kind`` vocabulary must agree across all three declarations.
+
+Pure-logic (no DB, no app boot). #2229 shipped a new kind in the service layer and the
+full service-level test suite stayed green while **every rollup that fired the new
+correction 500'd**, because ``_CorrectionAppliedModel.kind`` is a closed Pydantic
+``Literal`` that is only evaluated at serialization time. Nothing tied the two together.
+
+This is the recurring class the prevention log calls "contract-field wired into one model
+not its sibling": the fix is not another test for the specific kind, it is a test that
+enumerates what the service actually emits and requires the consumers to keep up.
+
+Three declarations, one vocabulary:
+  * producer — ``app/services/ownership_rollup.py``, every ``CorrectionApplied(kind=...)``
+  * API      — ``app/api/instruments.py``, ``_CorrectionAppliedModel.kind`` Literal
+  * frontend — ``frontend/src/api/ownership.ts``, ``OwnershipCorrectionKind``
+
+The producer side is read by AST rather than by importing and introspecting, so a kind
+that is only reachable on a rare data path still counts: what matters is that the string
+exists in the code, not that some fixture happened to trigger it.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import get_args
+
+from app.api.instruments import _CorrectionAppliedModel
+
+_REPO = Path(__file__).resolve().parents[1]
+_SERVICE = _REPO / "app" / "services" / "ownership_rollup.py"
+_FRONTEND = _REPO / "frontend" / "src" / "api" / "ownership.ts"
+
+
+def _kind_expressions() -> list[ast.expr]:
+    """The ``kind=`` argument expression of every ``CorrectionApplied(...)`` call."""
+    tree = ast.parse(_SERVICE.read_text())
+    out: list[ast.expr] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+        if name != "CorrectionApplied":
+            continue
+        out.extend(kw.value for kw in node.keywords if kw.arg == "kind")
+    return out
+
+
+def _resolve(expr: ast.expr) -> set[str]:
+    """String literals this expression can EVALUATE to.
+
+    Deliberately not ``ast.walk`` — one call site is
+    ``"def14a_restates_institution" if src == "def14a" else "institutional_family_collapse"``,
+    and a blind walk also picks up ``"def14a"``, which is a comparison operand in the
+    test, never a kind. Only value positions count: a constant, or both branches of a
+    conditional. Anything else resolves empty and is caught by
+    :func:`test_every_kind_argument_is_statically_readable`.
+    """
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        return {expr.value}
+    if isinstance(expr, ast.IfExp):
+        return _resolve(expr.body) | _resolve(expr.orelse)
+    return set()
+
+
+def _emitted_kinds() -> set[str]:
+    """Every kind the service can construct a ``CorrectionApplied`` with."""
+    return {kind for expr in _kind_expressions() for kind in _resolve(expr)}
+
+
+def _api_kinds() -> set[str]:
+    annotation = _CorrectionAppliedModel.model_fields["kind"].annotation
+    return set(get_args(annotation))
+
+
+def _frontend_kinds() -> set[str]:
+    src = _FRONTEND.read_text()
+    match = re.search(r"export type OwnershipCorrectionKind\s*=(.*?);", src, re.DOTALL)
+    assert match is not None, "OwnershipCorrectionKind union not found in ownership.ts"
+    return set(re.findall(r'"([a-z0-9_]+)"', match.group(1)))
+
+
+def test_service_emits_at_least_one_kind() -> None:
+    """Guard the guard: if the AST walk silently under-collected, every assertion below
+    would pass vacuously — the ``x <> ALL('{}')`` failure mode in test form. This caught
+    the first version of ``_emitted_kinds`` missing a conditional-expression call site."""
+    assert len(_emitted_kinds()) >= 6
+
+
+def test_every_kind_argument_is_statically_readable() -> None:
+    """No ``CorrectionApplied(kind=...)`` may hide its value behind a name the AST walk
+    cannot resolve — otherwise the coverage assertions below go quietly blind to it."""
+    opaque = [ast.dump(expr) for expr in _kind_expressions() if not _resolve(expr)]
+    assert not opaque, f"kind= argument(s) with no statically resolvable string: {opaque}"
+
+
+def test_api_literal_covers_every_kind_the_service_emits() -> None:
+    """A kind missing here 500s the ownership-rollup endpoint on exactly the
+    instruments the correction fires for, while service-layer tests stay green."""
+    missing = _emitted_kinds() - _api_kinds()
+    assert not missing, (
+        f"{sorted(missing)} emitted by ownership_rollup.CorrectionApplied but absent from "
+        f"_CorrectionAppliedModel.kind in app/api/instruments.py — the endpoint will 500."
+    )
+
+
+def test_frontend_union_covers_every_kind_the_service_emits() -> None:
+    missing = _emitted_kinds() - _frontend_kinds()
+    assert not missing, (
+        f"{sorted(missing)} emitted by the service but absent from OwnershipCorrectionKind "
+        f"in frontend/src/api/ownership.ts."
+    )
+
+
+def test_no_declared_kind_is_unreachable() -> None:
+    """The reverse direction: a kind declared in the API or the frontend that the service
+    never emits is dead vocabulary — either a rename that left a stale entry behind, or a
+    producer that was deleted without its contract."""
+    emitted = _emitted_kinds()
+    stale_api = _api_kinds() - emitted
+    stale_fe = _frontend_kinds() - emitted
+    assert not stale_api, f"declared in the API Literal but never emitted: {sorted(stale_api)}"
+    assert not stale_fe, f"declared in the frontend union but never emitted: {sorted(stale_fe)}"

--- a/tests/test_ownership_13f_hr_supersession.py
+++ b/tests/test_ownership_13f_hr_supersession.py
@@ -1,0 +1,314 @@
+"""DB-backed tests for 13F-HR supersession in the ownership rollup (#2229).
+
+Sibling of ``test_ownership_13f_nt_supersession.py`` (#1639), which covers the Notice
+case. This covers the ORDINARY case: a filer that simply stopped holding the security.
+
+``ownership_institutions_current`` keeps the latest row per (instrument, filer, nature,
+exposure) and its MERGE deletes only ``NOT MATCHED BY SOURCE``, but 13F reports an exit
+by OMISSION rather than a zero row — so a filer that sold out kept contributing its last
+reported position forever. Form 13F Special Instruction 5b makes a "13F HOLDINGS REPORT"
+a COMPLETE statement of the Manager's Section 13(f) holdings, so a later report from the
+same filer that omits this security is affirmative evidence the position is closed.
+
+The predicate lives in SQL (the second ``NOT (...)`` clause in
+``_collect_canonical_holders_from_current`` + the lateral join in
+``_read_hr_supersessions``), so it is exercised where it lives — against a real Postgres.
+
+Instrument-id range 2_229_xxx is reserved for these scenarios.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services import ownership_rollup
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401 — fixture re-export
+
+pytestmark = pytest.mark.integration
+
+_FILER = "0000102909"
+_OTHER_FILER = "0000789019"
+_HR_PERIOD = date(2025, 12, 31)
+_HR_ACC = "0000102909-26-000101"
+_CUSIP = "037833100"
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple], *, iid: int, symbol: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, %s, %s, '4', 'USD', TRUE)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (iid, symbol, f"{symbol} Inc"),
+    )
+
+
+def _seed_outstanding(conn: psycopg.Connection[tuple], *, iid: int, shares: str) -> None:
+    period_end = date(2026, 3, 31)
+    conn.execute(
+        """
+        INSERT INTO financial_facts_raw (
+            instrument_id, taxonomy, concept, unit, period_end, val,
+            form_type, filed_date, accession_number, fiscal_year, fiscal_period
+        ) VALUES (%s, 'dei', 'EntityCommonStockSharesOutstanding', 'shares', %s, %s,
+                  '10-Q', %s, %s, %s, 'Q4')
+        ON CONFLICT DO NOTHING
+        """,
+        (iid, period_end, Decimal(shares), period_end, f"OUT-{iid}", period_end.year),
+    )
+
+
+def _seed_institution_current(
+    conn: psycopg.Connection[tuple],
+    *,
+    iid: int,
+    filer_cik: str,
+    shares: str,
+    period_end: date,
+    accession: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO ownership_institutions_current (
+            instrument_id, filer_cik, filer_name, ownership_nature, source,
+            source_document_id, source_accession, filed_at, period_end, shares,
+            exposure_kind
+        ) VALUES (%s, %s, 'ACME CAPITAL', 'economic', '13f', %s, %s, %s, %s, %s, 'EQUITY')
+        ON CONFLICT (instrument_id, filer_cik, ownership_nature, exposure_kind)
+        DO UPDATE SET shares = EXCLUDED.shares, period_end = EXCLUDED.period_end
+        """,
+        (
+            iid,
+            filer_cik,
+            f"{accession}#1",
+            accession,
+            datetime(period_end.year, period_end.month, 1, tzinfo=UTC),
+            period_end,
+            Decimal(shares),
+        ),
+    )
+
+
+def _seed_later_filing(
+    conn: psycopg.Connection[tuple],
+    *,
+    filer_cik: str,
+    period_of_report: date,
+    other_iid: int,
+) -> None:
+    """Seed evidence that ``filer_cik`` filed a 13F covering ``period_of_report`` —
+    for a DIFFERENT instrument, which is exactly the real shape: the filing exists and
+    does not mention the instrument under test."""
+    row = conn.execute(
+        """
+        INSERT INTO institutional_filers (cik, name)
+        VALUES (%s, 'ACME CAPITAL')
+        ON CONFLICT (cik) DO UPDATE SET name = EXCLUDED.name
+        RETURNING filer_id
+        """,
+        (filer_cik,),
+    ).fetchone()
+    assert row is not None
+    conn.execute(
+        """
+        INSERT INTO institutional_holdings (
+            filer_id, instrument_id, accession_number, period_of_report, shares, filed_at
+        ) VALUES (%s, %s, %s, %s, 1000, %s)
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            row[0],
+            other_iid,
+            f"{filer_cik}-26-{period_of_report.month:02d}{period_of_report.day:02d}",
+            period_of_report,
+            datetime(period_of_report.year, period_of_report.month, 1, tzinfo=UTC),
+        ),
+    )
+
+
+def _seed_unresolved_cusip(conn: psycopg.Connection[tuple], *, iid: int, last_period_end: date) -> None:
+    """Bind a CUSIP to ``iid`` AND record it as unresolved at ``last_period_end`` —
+    the case where absence from a later filing is OUR resolution failure, not an exit."""
+    # ``is_primary`` listed explicitly (#1173): a SEC-sourced CUSIP is primary, and the
+    # OpenFIGI fallback deliberately writes FALSE so the SEC row wins in
+    # ``_load_cusip_map``. Never rely on the column DEFAULT here.
+    conn.execute(
+        """
+        INSERT INTO external_identifiers (instrument_id, provider, identifier_type, identifier_value, is_primary)
+        VALUES (%s, 'sec', 'cusip', %s, TRUE) ON CONFLICT DO NOTHING
+        """,
+        (iid, _CUSIP),
+    )
+    # ``unresolved_13f_cusips`` has no PK — only PARTIAL unique indexes
+    # (``(cusip) WHERE source IS NULL`` and ``(cusip, source) WHERE source IS NOT NULL``),
+    # so a bare ``ON CONFLICT (cusip)`` raises InvalidColumnReference. The test DB is
+    # fresh per test, so a plain INSERT is correct here.
+    conn.execute(
+        """
+        INSERT INTO unresolved_13f_cusips (cusip, name_of_issuer, observation_count, last_period_end)
+        VALUES (%s, 'ACME', 1, %s)
+        """,
+        (_CUSIP, last_period_end),
+    )
+
+
+def _seed_notice(conn: psycopg.Connection[tuple], *, filer_cik: str, period_end: date) -> None:
+    conn.execute(
+        """
+        INSERT INTO institutional_filer_13f_notices (
+            filer_cik, accession_number, period_end, form, filed_at
+        ) VALUES (%s, %s, %s, '13F-NT', %s)
+        ON CONFLICT (accession_number) DO UPDATE SET period_end = EXCLUDED.period_end
+        """,
+        (filer_cik, f"{filer_cik}-26-00NT", period_end, datetime(2026, 5, 8, tzinfo=UTC)),
+    )
+
+
+def _institution_filer_ciks(rollup: ownership_rollup.OwnershipRollup) -> set[str | None]:
+    out: set[str | None] = set()
+    for slc in rollup.slices:
+        if slc.category in ("institutions", "etfs"):
+            out.update(h.filer_cik for h in slc.holders)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Headline scenario
+# ---------------------------------------------------------------------------
+
+
+def test_later_hr_supersedes_exited_position_and_emits_correction(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A filer holding 400 of 1,000 shares at 2025-12-31 that filed again for
+    2026-03-31 without this security has exited. Its stale row must leave the
+    institutions wedge, and the removal must be explained in ``corrections_applied``
+    — an operator seeing the wedge shrink needs the reason (#1639's contract)."""
+    conn = ebull_test_conn
+    iid, other = 2_229_001, 2_229_901
+    _seed_instrument(conn, iid=iid, symbol="HREXIT")
+    _seed_instrument(conn, iid=other, symbol="HROTHER")
+    _seed_outstanding(conn, iid=iid, shares="1000")
+    _seed_institution_current(conn, iid=iid, filer_cik=_FILER, shares="400", period_end=_HR_PERIOD, accession=_HR_ACC)
+    _seed_later_filing(conn, filer_cik=_FILER, period_of_report=date(2026, 3, 31), other_iid=other)
+
+    rollup = ownership_rollup.get_ownership_rollup(conn, symbol="HREXIT", instrument_id=iid)
+
+    assert _FILER not in _institution_filer_ciks(rollup)
+    corrections = [c for c in rollup.corrections_applied if c.kind == "superseded_by_later_13f_hr"]
+    assert len(corrections) == 1
+    correction = corrections[0]
+    assert correction.filer_cik == _FILER
+    assert correction.shares_removed == Decimal(400)
+    assert correction.superseded_period == _HR_PERIOD
+    assert correction.source_channel == "13f"
+    assert "2026-03-31" in correction.detail
+    # The shares return to the public residual rather than vanishing.
+    assert rollup.residual.pct_outstanding == Decimal(1)
+    assert rollup.residual.oversubscribed is False
+
+
+def test_nt_and_hr_both_applicable_reports_once_under_nt(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A row superseded by BOTH mechanisms is reported once, under the Notice — the
+    stronger evidence (the filer declared it holds nothing reportable at all). Without
+    this the operator sees one removal counted twice."""
+    conn = ebull_test_conn
+    iid, other = 2_229_002, 2_229_902
+    _seed_instrument(conn, iid=iid, symbol="HRBOTH")
+    _seed_instrument(conn, iid=other, symbol="HRBOTHO")
+    _seed_outstanding(conn, iid=iid, shares="1000")
+    _seed_institution_current(conn, iid=iid, filer_cik=_FILER, shares="400", period_end=_HR_PERIOD, accession=_HR_ACC)
+    _seed_later_filing(conn, filer_cik=_FILER, period_of_report=date(2026, 3, 31), other_iid=other)
+    _seed_notice(conn, filer_cik=_FILER, period_end=date(2026, 3, 31))
+
+    rollup = ownership_rollup.get_ownership_rollup(conn, symbol="HRBOTH", instrument_id=iid)
+
+    assert _FILER not in _institution_filer_ciks(rollup)
+    kinds = [c.kind for c in rollup.corrections_applied]
+    assert kinds == ["suppressed_by_13f_nt"], kinds
+
+
+# ---------------------------------------------------------------------------
+# Predicate table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("iid", "case", "later_period", "unresolved_at", "notice_at", "expect_kept"),
+    [
+        # No later filing at all — the filer may still hold. Kept.
+        (2_229_101, "no_later_filing", None, None, None, True),
+        # Later filing omitting this security → exited. Dropped.
+        (2_229_102, "later_filing", date(2026, 3, 31), None, None, False),
+        # Filing for the SAME period as the row — that IS the row's own filing, so it
+        # is not evidence of anything. Strict ``>`` keeps it.
+        (2_229_103, "same_period", _HR_PERIOD, None, None, True),
+        # Only EARLIER filings → says nothing about later holdings. Kept.
+        (2_229_104, "earlier_only", date(2025, 9, 30), None, None, True),
+        # ⚠ The guard: this instrument's CUSIP failed to resolve on a filing at or after
+        # the row's period, so absence is OUR ingest gap, not an exit. Kept.
+        (2_229_105, "unresolved_cusip_guard", date(2026, 3, 31), date(2026, 3, 31), None, True),
+        # Guard must not over-apply: an unresolved sighting STRICTLY BEFORE the row's
+        # period cannot explain absence from a filing after it. Dropped.
+        (2_229_106, "unresolved_too_old", date(2026, 3, 31), date(2025, 6, 30), None, False),
+    ],
+)
+def test_hr_supersession_predicate(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+    iid: int,
+    case: str,
+    later_period: date | None,
+    unresolved_at: date | None,
+    notice_at: date | None,
+    expect_kept: bool,
+) -> None:
+    conn = ebull_test_conn
+    other = iid + 800
+    _seed_instrument(conn, iid=iid, symbol=f"HR{iid % 1000}")
+    _seed_instrument(conn, iid=other, symbol=f"HO{iid % 1000}")
+    _seed_outstanding(conn, iid=iid, shares="1000")
+    _seed_institution_current(conn, iid=iid, filer_cik=_FILER, shares="400", period_end=_HR_PERIOD, accession=_HR_ACC)
+    if later_period is not None:
+        _seed_later_filing(conn, filer_cik=_FILER, period_of_report=later_period, other_iid=other)
+    if unresolved_at is not None:
+        _seed_unresolved_cusip(conn, iid=iid, last_period_end=unresolved_at)
+    if notice_at is not None:
+        _seed_notice(conn, filer_cik=_FILER, period_end=notice_at)
+
+    rollup = ownership_rollup.get_ownership_rollup(conn, symbol="HR", instrument_id=iid)
+
+    kept = _FILER in _institution_filer_ciks(rollup)
+    assert kept is expect_kept, f"case={case}: filer kept={kept}, expected {expect_kept}"
+    assert (len(rollup.corrections_applied) == 0) is expect_kept
+
+
+def test_another_filers_later_filing_does_not_cross(
+    ebull_test_conn: psycopg.Connection[tuple],  # noqa: F811
+) -> None:
+    """A DIFFERENT filer's later report says nothing about this filer's holdings.
+    The join must be on ``filer_cik``, not on the instrument alone."""
+    conn = ebull_test_conn
+    iid, other = 2_229_003, 2_229_903
+    _seed_instrument(conn, iid=iid, symbol="HRCROSS")
+    _seed_instrument(conn, iid=other, symbol="HRCROSSO")
+    _seed_outstanding(conn, iid=iid, shares="1000")
+    _seed_institution_current(conn, iid=iid, filer_cik=_FILER, shares="400", period_end=_HR_PERIOD, accession=_HR_ACC)
+    _seed_later_filing(conn, filer_cik=_OTHER_FILER, period_of_report=date(2026, 3, 31), other_iid=other)
+
+    rollup = ownership_rollup.get_ownership_rollup(conn, symbol="HRCROSS", instrument_id=iid)
+
+    assert _FILER in _institution_filer_ciks(rollup)
+    assert rollup.corrections_applied == ()

--- a/tests/test_ownership_13f_hr_supersession.py
+++ b/tests/test_ownership_13f_hr_supersession.py
@@ -214,6 +214,12 @@ def test_later_hr_supersedes_exited_position_and_emits_correction(
     assert correction.superseded_period == _HR_PERIOD
     assert correction.source_channel == "13f"
     assert "2026-03-31" in correction.detail
+    # ⚠ The WINNER is the later filing that proves the exit, not the stale row being
+    # removed. Codex ckpt-2 caught this pointing at ``c.source_accession`` — an operator
+    # auditing the correction would have been sent to the losing accession while it was
+    # labelled the winning source.
+    assert correction.winning_accession == f"{_FILER}-26-0331"
+    assert correction.winning_accession != _HR_ACC
     # The shares return to the public residual rather than vanishing.
     assert rollup.residual.pct_outstanding == Decimal(1)
     assert rollup.residual.oversubscribed is False

--- a/tests/test_ownership_13f_hr_supersession.py
+++ b/tests/test_ownership_13f_hr_supersession.py
@@ -108,32 +108,21 @@ def _seed_later_filing(
     other_iid: int,
 ) -> None:
     """Seed evidence that ``filer_cik`` filed a 13F covering ``period_of_report`` —
-    for a DIFFERENT instrument, which is exactly the real shape: the filing exists and
-    does not mention the instrument under test."""
-    row = conn.execute(
-        """
-        INSERT INTO institutional_filers (cik, name)
-        VALUES (%s, 'ACME CAPITAL')
-        ON CONFLICT (cik) DO UPDATE SET name = EXCLUDED.name
-        RETURNING filer_id
-        """,
-        (filer_cik,),
-    ).fetchone()
-    assert row is not None
-    conn.execute(
-        """
-        INSERT INTO institutional_holdings (
-            filer_id, instrument_id, accession_number, period_of_report, shares, filed_at
-        ) VALUES (%s, %s, %s, %s, 1000, %s)
-        ON CONFLICT DO NOTHING
-        """,
-        (
-            row[0],
-            other_iid,
-            f"{filer_cik}-26-{period_of_report.month:02d}{period_of_report.day:02d}",
-            period_of_report,
-            datetime(period_of_report.year, period_of_report.month, 1, tzinfo=UTC),
-        ),
+    against a DIFFERENT instrument, which is exactly the real shape: the filing exists
+    and does not mention the instrument under test.
+
+    The evidence lives in ``ownership_institutions_current`` itself, not in the
+    ``institutional_holdings`` landing table: the two agree on 9,067 filers and
+    ``_current`` is newer on 148 (it is fed by the continuous manifest parser as well
+    as the quarterly bulk dataset), so the predicate reads the fresher source and
+    stays self-consistent on one table."""
+    _seed_institution_current(
+        conn,
+        iid=other_iid,
+        filer_cik=filer_cik,
+        shares="1000",
+        period_end=period_of_report,
+        accession=f"{filer_cik}-26-{period_of_report.month:02d}{period_of_report.day:02d}99",
     )
 
 
@@ -218,7 +207,7 @@ def test_later_hr_supersedes_exited_position_and_emits_correction(
     # removed. Codex ckpt-2 caught this pointing at ``c.source_accession`` — an operator
     # auditing the correction would have been sent to the losing accession while it was
     # labelled the winning source.
-    assert correction.winning_accession == f"{_FILER}-26-0331"
+    assert correction.winning_accession == f"{_FILER}-26-033199"
     assert correction.winning_accession != _HR_ACC
     # The shares return to the public residual rather than vanishing.
     assert rollup.residual.pct_outstanding == Decimal(1)

--- a/tests/test_ownership_13f_hr_supersession.py
+++ b/tests/test_ownership_13f_hr_supersession.py
@@ -272,7 +272,8 @@ def test_hr_supersession_predicate(
 ) -> None:
     conn = ebull_test_conn
     other = iid + 800
-    _seed_instrument(conn, iid=iid, symbol=f"HR{iid % 1000}")
+    symbol = f"HR{iid % 1000}"
+    _seed_instrument(conn, iid=iid, symbol=symbol)
     _seed_instrument(conn, iid=other, symbol=f"HO{iid % 1000}")
     _seed_outstanding(conn, iid=iid, shares="1000")
     _seed_institution_current(conn, iid=iid, filer_cik=_FILER, shares="400", period_end=_HR_PERIOD, accession=_HR_ACC)
@@ -283,7 +284,7 @@ def test_hr_supersession_predicate(
     if notice_at is not None:
         _seed_notice(conn, filer_cik=_FILER, period_end=notice_at)
 
-    rollup = ownership_rollup.get_ownership_rollup(conn, symbol="HR", instrument_id=iid)
+    rollup = ownership_rollup.get_ownership_rollup(conn, symbol=symbol, instrument_id=iid)
 
     kept = _FILER in _institution_filer_ciks(rollup)
     assert kept is expect_kept, f"case={case}: filer kept={kept}, expected {expect_kept}"


### PR DESCRIPTION
Closes #2229. Refs #2226.

`ownership_institutions_current` keeps the latest row per (instrument, filer, nature, exposure) and its MERGE deletes only `WHEN NOT MATCHED BY SOURCE`. But **13F reports an exit by OMISSION, never a zero row**, so a filer that sold out kept contributing its last reported position forever. 704,163 of 2,297,713 rows (30.6%) carried `period_end <= 2025-12-31`.

## Source rule

Form 13F Special Instruction 5b (`https://www.sec.gov/files/form13f.pdf`): *"If all of the securities with respect to which a Manager has investment discretion are reported in this report, check the box for Report Type '13F HOLDINGS REPORT'"*. A holdings report is a **complete** statement of the Manager's §13(f) holdings for the period, so **a later report from the same filer that omits this security is affirmative evidence the position is closed**.

This generalises I15 (#1639) from the Notice case to the ordinary one. I15 already encodes exactly this reasoning for `13F-NT`; nothing about the argument is specific to Notices.

Two Special Instructions checked and deliberately **not** guarded against:

- **COMBINATION reports (SI 5c)** are not complete, and we cannot distinguish them — `sec_filing_manifest.form` is only `13F-HR`/`13F-HR/A`; the Report Type checkbox lives in `primary_doc.xml`, which we do not retain queryably. Not a correctness risk: if manager B's holdings are reported by manager A, A's filing *includes* those shares, so dropping B's stale row removes a double count rather than a holder.
- **De minimis omission (SI 9)** lets a Manager omit a holding under 10,000 shares AND under $200,000. Anything omitted on that basis is ≤10,000 shares — negligible against any pie wedge.

## ⚠ The ticket's own premise was falsified before implementation

I filed #2229 proposing an as-of/expiry bound. The full population killed that framing: **6,965 of 7,204 filers (96.7%)** whose row was stuck at 2025-12-31 **had filed later** — they stopped holding *this instrument*, not filing. Supersession needs no date threshold and no tuning constant. The ticket is retitled and the correction is on-issue.

A time bound was also measurably worse *and* less principled: it removes rows that may still be held (median clean instrument loses 9.8%, 1,383 over 10%) purely because a filer was late.

## The guard is load-bearing

Absence from a later filing can also mean **our CUSIP resolution failed on it**. `unresolved_13f_cusips` holds 109,683 rows, **1,650 of whose CUSIPs bind to a known instrument**. An instrument with any unresolved sighting at or after a row's period is exempt from supersession entirely.

Deliberately **not** narrowed by `resolution_status`, though 1,724 of 3,227 sighting rows are marked `resolved_via_openfigi`/`resolved_via_extid`: a resolution marking is not proof the holdings were re-ingested (#2213 — OpenFIGI ran dark for seven weeks behind success-reporting sweeps). The two errors are not symmetric — a false keep leaves an instrument visibly oversubscribed, a false delete is invisible.

## Paired full-population A/B

**4,421 instruments, 0 harness errors.** Both arms evaluated inside ONE `snapshot_read` (REPEATABLE READ) per instrument, so concurrent ingest cannot land between them — the #2217 lesson. Control is `origin/main`'s collector extracted verbatim via `git show` and exec'd; neither arm is simulated.

| invariant | result |
|---|---|
| residual never decreases | **PASS** |
| no instrument gains `oversubscribed` | **PASS** |
| zero-correction instruments byte-identical | **PASS** |
| total pie never grows | **PASS** |
| pie never falls by MORE than was superseded | **PASS** |
| no instrument ends with residual > 100% | **PASS** |
| every changed instrument has ≥1 correction | **PASS** |

| | control | treatment |
|---|---|---|
| `oversubscribed` / public float renders zero | 2,076 (47.0%) | **1,781 (40.3%)** |
| unchanged / changed | — | 821 / 3,600 |
| corrections emitted | — | 531,674 |

### ⚠ One invariant failed first, and the finding is in the failure

"institutions-slice delta == shares removed" failed on 332 instruments, **179 of them in the alarming direction** — the wedge fell by *more* than was removed (VEON: −73,865,612 on 1,032,534 superseded).

It is not a defect, and the invariant was mis-specified. Those shares **moved slice**: once the stale 13F row goes, that CIK's 13D/G disclosure becomes the winning source under the existing dedup priority and re-routes the holder to blockholders.

```
VEON   blockholders   840,625,000 ->   913,802,600   (+73,177,600)
       institutions   236,120,536 ->   162,254,924   (-73,865,612)
       TOTAL PIE    1,080,410,628 -> 1,079,722,616   (   -688,012)
```

Restated at the pie level: **0 instruments fall by more than was superseded**; 3,157 fall by exactly the removed shares (no other channel), 443 by less (another channel took over). Arguably an improvement — the holder is now attributed to the channel that actually has current data.

### Gain side inspected

| symbol | ratio before | after | residual | flag |
|---|---|---|---|---|
| IDR.US | 52.05 | 0.52 | 0.000 → 0.476 | True→False |
| XIFR | 1.07 | 0.64 | 0.000 → 0.363 | True→False |
| BOLD | 1.06 | 0.75 | 0.000 → 0.252 | True→False |
| KOSS | 0.40 | 0.08 | 0.602 → 0.925 | False→False |

### What it REJECTS (narrowing-gate discipline)

Median instrument that was **already clean** loses 6.2% of its institutions wedge; 94 lose >50%. Those are micro-caps whose entire institutional stake was 0.4–2.5% of outstanding and where every filer exited — e.g. `UOKAF` 2.2%→0, `PRPH` 1.1%→0. Every removed row has a later filing from the same filer omitting the security, so this is correction, not collateral.

## ⚠ Read-path latency — an 11-20x regression, caught by measuring, not by testing

The rollup is computed at read time and stored nowhere, so this predicate runs on **every operator request**. First working version: **AAPL 214ms → 2,390ms, HD 180ms → 3,675ms**. No correctness arm, test or lint sees this.

Three fixes, each measured:

1. Hoist both subqueries out of the row loop — the CUSIP guard is *instrument*-scoped but was re-evaluated per filer row. 3,675ms → 1,449ms on HD, **identical supersession counts**, so behaviour-preserving.
2. Read the per-filer latest period from `ownership_institutions_current` rather than the `institutional_holdings` landing table. Measured: the two agree on 9,067 filers, `_current` is **newer on 148 and behind on 0** (it is fed by the continuous manifest parser as well as the quarterly bulk dataset). Fresher, and self-consistent on one table.
3. **`sql/245`** adds `idx_inst_current_filer_period (filer_cik, period_end DESC)`. Without it, (2) is far *worse*: the only existing index is `(filer_cik)` alone, so `MAX(period_end)` heap-fetches every row of a filer like Vanguard — **7,651ms** on AAPL, against **25ms** with the index.

Net: AAPL 197→321ms, HD 191→341ms (~1.6-1.8x), against 11-20x.

A missing index nearly made me reject the *correct* data source. That lesson is in the A/B skill now.

NULL handling is explicit (`COALESCE` on both comparisons) rather than relying on three-valued logic — a NULL latest-period or NULL guard would otherwise make the whole `NOT (...)` NULL and silently drop the row.

## ⚠ The endpoint 500'd and every test was green

`_CorrectionAppliedModel.kind` is a closed Pydantic `Literal`, evaluated only at serialization. Adding the kind to the service alone made **every rollup that fired the correction return 500** — while `ruff`, `pyright`, the fast tier, smoke, both DB-backed supersession suites and `test_api_instruments.py` all passed. Found by curling the live dev endpoint for the clause 8 evidence.

This is the #1955 class in its most expensive form, so the fix is not a test for this kind: `tests/test_correction_kind_vocab_contract.py` reads every `CorrectionApplied(kind=...)` out of the service by AST and requires the API Literal and the FE union to cover all of them, plus the reverse so a rename cannot leave stale vocabulary behind. Two guards on the extractor fired while it was being written (a `>= 6` lower bound caught it missing a conditional-expression call site; a blind `ast.walk` then over-collected a comparison operand).

## Definition-of-Done evidence

| clause | evidence |
|---|---|
| 8 — smoke panel | live `/instruments/{sym}/ownership-rollup` on dev at `10073b84`: AAPL 200 (residual 33.9%, 364 corrections), MSFT 200 (26.3%, 482), GME 200 (53.3%, 218), JPM 200 (24.6%, 443), HD 200 (25.2%, 691), HPQ 200 (0.4%, 414 — was 105.5% oversubscribed) |
| 9 — cross-source | institutional ownership after the change: AAPL 66.1%, MSFT 73.7%, JPM 74.8% — all in line with published institutional-ownership figures; large caps move only 0.2-0.5pp because those positions are actively maintained |
| 10 — backfill | **N/A, a property of the metric.** The rollup is computed at read time and stored nowhere (`metrics-analyst`: "Storage: not stored"). No `sec_rebuild` scope applies. `sql/245` is an additive index; it was created on dev with `CREATE INDEX CONCURRENTLY` so the jobs daemon was never blocked, and the migration is `IF NOT EXISTS` |
| 11 — operator-visible figure | verified on the running dev stack, table in clause 8 |
| 12 — commit SHA | `10073b84` for clauses 8/11; A/B run against `0303917d` |

## Checks

`ruff check` / `ruff format --check` / `pyright` (0 errors) / `pytest -m "not db"` / `pytest tests/smoke` all clean. `-m db` green over `test_ownership_13f_hr_supersession`, `test_ownership_13f_nt_supersession`, `test_ownership_rollup`, `test_ownership_rollup_csv`, `test_ownership_machine_trust_envelope`, `test_ownership_observations`, `test_api_instruments`. `pnpm --dir frontend typecheck` + `test:unit` clean.

Two repo gates caught real defects in my test seeds: the `external_identifiers` chokepoint lint (#1173, missing explicit `is_primary`) and the `source_accession` CHECK constraint.

## What this does NOT fix

#2226 stays open. Its cohort is 47.0% → 40.3%; the remaining 1,781 are the other axes measured in the partition there — **#2230** (Section 16 / 13D-G deemed attribution), **#2231** (no split adjustment exists), **#2232** (implausible denominators). No single fix clears it, which is why the acceptance criterion here is stated on the institutions channel rather than on `oversubscribed` prevalence — #2217 set the latter and had it falsified.

## Security

No security surface. Read-path filtering on already-authorised data; no new input, permission or user-controlled value. The new SQL is fully parameterised.
