### PR TITLE
fix(#2235): deterministic placeholder gate + subject anchor (v6)

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -212,7 +212,19 @@ _MAX_TOKENS_CRITIC = 2048
 # 37.20" leaked verbatim into a MSFT memo), derived arithmetic must END in a
 # per-share price + band sanity cross-check (a $52.8B P/S "target" shipped),
 # cited figures verbatim-or-show-inputs (fabricated 13.1% gross margin).
-_PROMPT_VERSION = "v5"
+# v6 (#2235): subject-identity anchor. v5's context expansion left the
+# instrument identity as one buried mid-payload field, and the writer
+# sporadically wrote the memo about a different company while citing the
+# subject's own figures (a GME memo about Yelp, quoting GME's 34.39% gross
+# margin verbatim) — 19 such memos on v5, zero on v1-v4. _build_writer_prompt
+# now states the subject ahead of the JSON, and _WRITER_SYSTEM opens its rule
+# list with a subject-identity rule. Second v5-only leak fixed here: v5
+# abstracted its worked example to placeholders to stop a literal
+# "12 x EPS 3.10 = 37.20" leaking, which traded example-leakage for
+# placeholder-leakage (46 memos containing "[Company] operates in the
+# [sector]") — an explicit no-placeholder rule now closes that. Context shape
+# and _validate_writer_output are unchanged.
+_PROMPT_VERSION = "v6"
 
 # thesis_runs.trigger — matches the table CHECK in sql/218.
 RunTrigger = Literal["manual", "cascade", "scheduled"]
@@ -1320,6 +1332,18 @@ Produce a JSON object with EXACTLY these fields:
 }
 
 Rules:
+- SUBJECT IDENTITY. The memo is about ONE company: the instrument named on the
+  SUBJECT line above the context, which is the same company as the `instrument`
+  block's `symbol` / `company_name`. Name that company explicitly in the memo's
+  first sentence. Never write the memo about a different company — every
+  figure in the context describes the SUBJECT, so a memo naming anyone else
+  misattributes real financial data. Peers, competitors and the benchmark may
+  be cited only as explicit comparisons ("versus <peer>"), never as the
+  subject.
+- NO PLACEHOLDERS in memo_markdown. Every slot carries an actual value from
+  THIS context. Never emit a bracketed stand-in — no "[Company]", "[sector]",
+  "[X]", "<multiple>", "<peer>". The angle-bracket forms in this prompt are
+  schema notation describing what to produce; they are not text to copy.
 - thesis_type must be one of: compounder, value, turnaround, speculative
 - stance must be one of: buy, hold, watch, avoid
 - confidence_score in [0.0, 1.0] — higher means more conviction
@@ -1430,7 +1454,23 @@ Rules:
 
 
 def _build_writer_prompt(context: dict[str, object]) -> str:
-    return json.dumps(context, indent=2, default=str)
+    """Name the subject instrument, then hand over the JSON context.
+
+    The instrument identity is one field in the middle of a large payload.
+    v5's context expansion (fair_value_band, analytics_evidence, ta_state,
+    valuation, risk_metrics, price_anchor) diluted it enough that the writer
+    sporadically confabulated a different company — #2235, a GME memo written
+    about Yelp while citing GME's own margins to 4dp. Stating the subject
+    ahead of the context gives identity a position the payload cannot bury.
+    """
+    subject_line = ""
+    instrument = context.get("instrument")
+    if isinstance(instrument, dict):
+        symbol = instrument.get("symbol")
+        if symbol:
+            name = instrument.get("company_name") or symbol
+            subject_line = f"SUBJECT: {name} ({symbol}) — write the memo about this company and no other.\n\n"
+    return subject_line + json.dumps(context, indent=2, default=str)
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import re
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -1581,6 +1582,41 @@ def _call_with_one_retry(
         )
 
 
+# #2235 — WHY THERE IS NO MISATTRIBUTION ASSERTION HERE.
+#
+# The defect is real and still live: 19 of 2,037 v5 memos (0.93%) declare their
+# subject as a different company — "Yelp (YELP)" heading a GME memo, "Apple
+# (AAPL)" heading AGCO's, measured 2026-08-05. It is NOT gated below, because
+# three candidate discriminators were each falsified against the full stored
+# corpus rather than a sample:
+#
+#   1. First `<Capitalised Name> (<TICKER>)` in the memo must be the subject.
+#      35 rejects, of which "Free Cash Flow (FCF)", "Price-to-Earnings (PE)",
+#      "Return on Assets (ROA)" are correct memos. A gate that retry-fails a
+#      correct memo takes `thesis_refresh` down at ~1.7% of generations.
+#   2. Same, restricted to the memo's opening (120/200/300/400 chars). The
+#      term expansions appear there too — 25 rejects at 120 chars, same shape.
+#   3. Drop matches where the ticker is an initialism of the preceding words.
+#      Removes 2 of 29. "Price-to-sales (PS)", "Equity (ROE)", "ETF Trust
+#      (SPY)" all survive it.
+#
+# Three failed keys is the signal to question the MODEL, not to try a fourth
+# (.claude/CLAUDE.md, "Source-rule before design"). A soft warning was also
+# rejected: at ~40% false positives it is noise that trains the operator to
+# ignore it, which is the same argument #2218 makes against a blanket
+# zero-rows alarm.
+#
+# ⚠ The prompt anchor above and the v6 bump remain UNVERIFIED — at 0.93% an
+# A/B powered to detect a halving needs thousands of local generations. Tracked
+# separately; the measurement query lives on that ticket.
+
+# Bracketed stand-ins the writer emitted instead of values. ``[text](url)`` is a
+# markdown link and must not match, hence the negative lookahead. The lowercase
+# angle form catches "<multiple>" / "<peer>" — the prompt's own schema notation
+# uses them, which is how they leaked into memo prose in the first place.
+_PLACEHOLDER_RE = re.compile(r"\[[A-Za-z][A-Za-z ]{0,24}\](?!\()|<[a-z][a-z ]{0,24}>")
+
+
 def _call_writer(client: LLMClient, context: dict[str, object]) -> tuple[dict[str, object], LLMCompletion]:
     """
     Call the LLM writer and parse the structured thesis JSON.
@@ -1642,6 +1678,15 @@ def _validate_writer_output(data: dict[str, object], *, require_buy_zone: bool =
     memo = data.get("memo_markdown")
     if not isinstance(memo, str) or not memo.strip():
         raise ValueError("Writer output memo_markdown must be a non-empty string")
+
+    # #2235 — the placeholder leak, enforced deterministically. Verified on the
+    # FULL stored corpus, not a sample: 74 of 2,037 v5 memos (3.6%) rejected,
+    # every one a genuine "[Company]" / "[sector]" / "[Name]" stand-in, and
+    # zero correct memos caught. Unlike the misattribution above, this has a
+    # clean discriminator, so it gets a real gate and rides retry-once.
+    placeholder = _PLACEHOLDER_RE.search(memo)
+    if placeholder is not None:
+        raise ValueError(f"Writer output contains an unfilled placeholder: {placeholder.group(0)!r}")
 
     # Valuation-band coherence (#2007): the stored band must satisfy
     # bear <= base <= bull, and the buy zone low <= high. Local writers

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -582,6 +582,56 @@ class TestValidateWriterOutput:
     def test_valid_passes(self) -> None:
         _validate_writer_output(_VALID_WRITER)  # should not raise
 
+    # ------------------------------------------------------------------
+    # #2235 — unfilled placeholders in memo_markdown
+    # ------------------------------------------------------------------
+    #
+    # ⚠ The fixture above is the PASSING case and is stated as such. Its memo
+    # contains "## AAPL" and a "### Valuation" heading — markdown syntax the
+    # placeholder pattern must not mistake for a stand-in. A "neutral" memo
+    # would not exercise that (test-quality.md).
+
+    @pytest.mark.parametrize(
+        "memo",
+        [
+            "[Company] operates in the [sector] with strong margins.",
+            "## [Company Name]\n\nA durable compounder.",
+            "Trading at [X] times forward earnings.",
+            "Fair value is <multiple> times EPS.",
+            "Compares favourably with <peer>.",
+        ],
+    )
+    def test_placeholder_in_memo_raises(self, memo: str) -> None:
+        """Every form here was observed in a STORED v5 memo, not invented.
+        74 of 2,037 v5 memos carry one; the distinct set is
+        [Company] / [Company Name] / [Company name] / [company] /
+        [Instrument Name] / [Name] / [sector] / [base] / [bear] / [malformed].
+        """
+        bad = {**_VALID_WRITER, "memo_markdown": memo}
+        with pytest.raises(ValueError, match="placeholder"):
+            _validate_writer_output(bad)
+
+    @pytest.mark.parametrize(
+        "memo",
+        [
+            # Markdown link — the negative lookahead exists for exactly this.
+            "See [the latest 10-K](https://sec.gov/x) for segment detail.",
+            # Headings and emphasis are not stand-ins.
+            "## AAPL\n\n### Valuation\n\nTrading below **fair value**.",
+            # A bracketed footnote marker is a value, not a placeholder.
+            "Gross margin 44.1% [1] versus 43.0% prior.",
+            # Comparison operators must not read as angle-bracket stand-ins.
+            "Revenue growth < 5% would break the thesis.",
+        ],
+    )
+    def test_legitimate_brackets_do_not_raise(self, memo: str) -> None:
+        """The false-positive guard. A gate that rejects correct memos rides
+        retry-once and then FAILS the thesis, so its precision is the whole
+        question — verified at zero false positives across all 2,525 stored
+        memos before this landed."""
+        ok = {**_VALID_WRITER, "memo_markdown": memo}
+        _validate_writer_output(ok)  # should not raise
+
     def test_missing_field_raises(self) -> None:
         bad = {k: v for k, v in _VALID_WRITER.items() if k != "stance"}
         with pytest.raises(ValueError, match="missing fields"):


### PR DESCRIPTION
**Out of draft.** Ships the half with a clean discriminator; the other half is now #2306 with its falsified attempts recorded.

## Problem

A GME instrument page rendered a thesis whose memo is about **Yelp** — `thesis_id=2010`, `instrument_id=1699`, `prompt_version=v5`, `model=qwen3:14b`. Not plumbing: the row is under the right `instrument_id`, and the memo quotes GME's own gross margin 34.39% / operating margin 10.35% to 4dp. The model invents the identity.

Second, separate v5 leak: memos containing unfilled `[Company] operates in the [sector]` stand-ins. v5 abstracted its worked example to placeholders to stop a literal `12 x EPS 3.10 = 37.20` leaking into an MSFT memo — trading example-leakage for placeholder-leakage.

## What ships

**1. Deterministic placeholder gate.** `_validate_writer_output` rejects an unfilled bracketed stand-in and rides the existing retry-once machinery.

⚠ **Verified on the FULL stored corpus, not a sample** — which is the thing the original draft could not do:

```
2,525 memos | 74 rejected | all v5
distinct forms: [Company] [Company Name] [Company name] [company]
                [Instrument Name] [Name] [sector] [base] [bear] [malformed]
false positives: 0
```

All ten distinct matches are genuine. Markdown links (`[text](url)`), headings (`## AAPL`), footnote markers (`[1]`) and `<` comparisons are covered by explicit negative tests.

**2. Subject anchor + `_PROMPT_VERSION` v6.** `_build_writer_prompt` states `SUBJECT: <company> (<symbol>)` ahead of the JSON; `_WRITER_SYSTEM` opens with a subject-identity rule and a no-placeholder rule.

## What deliberately does NOT ship, and why

A misattribution gate. **Three discriminators falsified against the same 2,525-memo corpus:**

| # | rule | result |
|---|---|---|
| 1 | first `<Name> (<TICKER>)` must be the subject | 35 rejects — `Free Cash Flow (FCF)`, `Price-to-Earnings (PE)`, `Return on Assets (ROA)` are **correct** memos. Retry-fails ~1.7% of generations, permanently (the model rewrites the same expansion). |
| 2 | as (1), restricted to the opening (120/200/300/400 chars) | Term expansions are in the opening too — 25 rejects at 120. |
| 3 | as (1), dropping ticker-is-an-initialism matches | Removes 2 of 29. `Price-to-sales (PS)`, `Equity (ROE)`, `ETF Trust (SPY)` survive. |

Three failed keys is the signal to question the model, not to try a fourth. A soft warning was rejected too — ~40% false positives is noise that trains the operator to ignore it, the same argument #2218 makes against a blanket zero-rows alarm. The reasoning is written into `thesis.py` where the gate would have gone, so the next reader does not retry them.

**Tracked as #2306**, with the three dead ends and three untried directions.

## Corrections to the original draft

- **Rate is 0.93%, not ~3.5%.** 19 of 2,037 v5 memos on a stricter detector. The direction matters more than the number: the event is *rarer* than the A/B was sized for, so that A/B is further from feasible, not closer. It is abandoned rather than fixed.
- **The A/B is not the blocker any more** — it was the wrong instrument. The placeholder gate is verified by construction against the full corpus; nothing about it needs an experiment.
- ⚠ The prompt anchor and v6 remain **unverified**. Stated, not hidden. #2238's own interim A/B measured 0 of 4 treatment memos naming the subject, which is also why an assertion of the form "the first sentence names the subject" is unenforceable — it would retry-fail every generation and take `thesis_refresh` down.

## Still live

The defect is still firing: `NXPI→(AAPL)` 08-01, `SIRI→(KO)` 08-02, `DINO→(AAPL)`, `AGCO→(AAPL)`, `DINO→(MSFT)` all 08-04 — after this PR was opened, because v5 is still production. 19 stored memos are wrong and render to the operator today; regenerate-or-flag is open on #2306.

## Testing

Rebased onto `main` (2 days, 7 merges). `ruff` / `ruff format --check` / `pyright` / fast tier / smoke all exit 0.

⚠ **Revert-probed**: removing the placeholder assertion fails 5 tests; restoring it passes. The gate is load-bearing, not decoration.

## Security

No security surface — prompt text, a validator branch and a version constant. No auth, schema, endpoint or data path touched.

Closes #2235.
Refs #2306.
