### PR TITLE
docs(#2241): record measured eToro WebSocket limits

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -23,6 +23,36 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
 - Trading (verified live): open by-amount/by-units; close per position with optional `UnitsToDeduct` (partial); **`PATCH /api/v2/trading[/demo]/positions/{positionId}`** for TP/SL edit (`stopLossRate`, `takeProfitRate`, `stopLossType` fixed|trailing, `clearStopLoss`, `clearTakeProfit`; ≥1 field; **202 async** `{operationId, positionId, referenceId}`).
 - Write ops are asynchronous (202) — re-sync portfolio before treating them as landed.
 
+## WebSocket limits — MEASURED, because the portal documents none
+
+`websocket/overview.md` and `websocket/topics.md` state no cap of any kind:
+no topics/frame, no topics/connection, no concurrent-session limit. **Absence
+of a documented limit is not absence of a limit.** Measured on demo
+(#2241, 2026-08-04):
+
+| limit | value | behaviour at the boundary |
+| --- | --- | --- |
+| topics per **session** | **4,999** | rejected: `errorCode: SubscribeFailed`, `"Too many subscriptions for session"`. Connection survives. Per-frame **atomic** — a straddling frame bounces whole, nothing partially applied. |
+| bytes per **frame** | **25 KiB** (25,600) | **silent: close 1006, empty reason, no ack, no error envelope.** Not applied. Bracket 25,529 B ok / 25,719 B dead. |
+
+- The session cap is **per connection, not per key** — 3 concurrent sessions
+  hold the full 12,684 universe (measured 12,684/12,684, 0 failures, 2.21s).
+- `Unsubscribe` frees capacity — live occupancy, not a lifetime budget.
+- **Chunk by BYTES, never by topic count** — instrument-id width varies, so a
+  count-based cap does not bound frame size. 500 topics ≈ 9.4 KB, proven.
+- **Correlate every frame uuid to its ack.** Over-size is silent, so a missing
+  ack is the only signal that a Subscribe did not take. eToro acks both ops:
+  `{"id": …, "success": true, "operation": "Subscribe"}`.
+
+Two rate-push shapes: a fat snapshot, and a thin delta carrying only
+`{"Date","PriceRateID"}` (no price, no `InstrumentID`) that
+`_parse_rate_content` drops. 23% of inner rate messages parsed to a
+`QuoteUpdate` — **size ingest against the wire, not parsed ticks.** The
+snapshot also carries undocumented `OfficialClosingPrice`, `IsMarketOpen`,
+`IsExchangeOpen`, `ConversionRateBid`/`Ask` (see
+`docs/etoro-api-reference.md` §WebSocket API); undocumented means
+unversioned, so re-verify before depending on them.
+
 ## Maintenance
 
 When you verify a NEW capability or find drift: update `docs/etoro-api-reference.md` + the memory reference files in the same session (skill-ownership rule — no "later").

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -428,6 +428,43 @@ Rate message fields: `Ask`, `Bid`, `LastExecution`, `Date` (ISO 8601),
 `UnitMarginBid`, `BidDiscounted`, `AskDiscounted`,
 `UnitMarginBidDiscounted`, `UnitMarginAskDiscounted`).
 
+**Undocumented fields present on the snapshot push** (measured #2241,
+2026-08-04 — absent from `api-reference/websocket/topics.md`, therefore
+unversioned; re-verify anything load-bearing): `InstrumentID`,
+`IsInstrumentActive`, `OfficialClosingPrice`, `IsMarketOpen`,
+`IsExchangeOpen`, `ConversionRateBid`, `ConversionRateAsk`, `AllowBuy`,
+`AllowSell`, `MaxPositionUnits`. `IsMarketOpen` and `IsExchangeOpen` are
+independent and do disagree (EURUSD: `true` / `false` at 23:37 UTC).
+
+**Two push shapes.** The fat snapshot above, and a steady-state thin delta
+carrying only `{"Date", "PriceRateID"}` — no price, no `InstrumentID`
+(the instrument is only on the envelope's `topic`). `_parse_rate_content`
+returns `None` for the thin shape. Measured ratio: 2,422 parsed
+`QuoteUpdate`s out of 10,564 inner rate messages (23%). **Size ingest
+against the wire, not against parsed ticks.**
+
+### WebSocket limits (measured, #2241 — the portal documents NONE)
+
+| limit | value | behaviour at the boundary |
+| --- | --- | --- |
+| topics per **session** | **4,999** | Subscribe rejected with `errorCode: SubscribeFailed`, `errorMessage: "Too many subscriptions for session"`. Connection survives. Rejection is **per-frame and atomic** — a frame straddling the cap bounces whole. |
+| bytes per **frame** | **25 KiB** (25,600) | **No ack, no error — the server closes with 1006 and an empty reason.** Subscription not applied. Bracket: 25,529 B acked / 25,719 B closed. |
+
+The session cap is **per connection, not per API key**: concurrent sessions
+each get their own 4,999, so the full 12,684-instrument universe fits in 3
+(measured: 12,684/12,684 accepted, 0 failures, 2.21s, no disconnect over a
+120s hold). `Unsubscribe` frees capacity, so it is live occupancy rather
+than a session lifetime budget.
+
+Consequences for any caller: **chunk Subscribe/Unsubscribe by BYTES**, not
+topic count (instrument-id width varies) — 500 topics is ~9.4 KB and is
+proven at scale; and **correlate each frame uuid to its ack**, because an
+over-size frame is silent and a missing ack is the only signal. eToro acks
+both ops as `{"id": …, "success": true, "operation": "Subscribe"}`.
+
+Time-to-first-tick after subscribe held at 0.03–0.18s from 10 through 4,999
+topics — no degradation with topic count.
+
 **No volume / size / quantity field exists on any WS topic** (#608, verified
 2026-06-27 against both api-portal `/websocket/topics` and
 `websocket-doc.html`). eToro's WS has exactly two topics — `instrument:<id>`


### PR DESCRIPTION
## What

Records the two eToro WebSocket limits measured by spike S1, in the etoro-api skill and `docs/etoro-api-reference.md`. Doc-only — no code changes.

The portal documents **no** WS limit of any kind: `websocket/overview.md` and `websocket/topics.md` state nothing about topics per frame, topics per connection, or concurrent sessions. Two limits exist.

| limit | value | behaviour at the boundary |
| --- | --- | --- |
| topics per **session** | 4,999 | Subscribe rejected, `errorCode: SubscribeFailed`, `"Too many subscriptions for session"`. Connection survives. Per-frame **atomic** — a straddling frame bounces whole. |
| bytes per **frame** | 25 KiB (25,600) | **Silent**: close 1006, empty reason, no ack, no error envelope, subscription not applied. Bracket 25,529 B ok / 25,719 B dead. |

The session cap is **per connection, not per key**, so 3 concurrent sessions hold the full 12,684-instrument universe (measured 12,684/12,684 accepted, 0 failures, 2.21s, 120s hold with no disconnect). `Unsubscribe` frees capacity.

## Why it matters beyond the spike

Two rules for any caller, both recorded:

- **Chunk by bytes, not topic count.** Instrument-id width varies, so a count-based cap does not bound frame size.
- **Correlate each frame uuid to its ack.** An over-size frame produces no error — a missing ack is the only signal that a Subscribe did not take.

Also recorded: the undocumented snapshot fields (`OfficialClosingPrice`, `IsMarketOpen`, `IsExchangeOpen`, `ConversionRateBid`/`Ask`), flagged as unversioned; and the thin-delta push shape carrying only `{"Date","PriceRateID"}` that `_parse_rate_content` drops — 23% of inner rate messages parse to a `QuoteUpdate`, so ingest sizing must use wire volume, not parsed ticks.

## Scope of the measurement

Demo environment, 2026-08-03 23:35–00:20 UTC with most equity markets closed, so only 495 instruments (3.9%) ever pushed. The **subscription** limits are unaffected by that; **throughput** under a live session is explicitly not established here and remains S2's (#2242) job.

## Security

No security surface. Doc-only; no credential handling, endpoint, or auth behaviour changes. The throwaway probe read credentials through the existing `load_existing_broker_key` path (read-only, no stale-cipher revoke pass) and was not merged.

## Follow-up filed

#2249 — `etoro_websocket.py:881` replays every topic in one Subscribe frame on reconnect, which above 25 KiB yields connect → replay → 1006 → backoff → forever. Latent today (#498 keeps the ref set to a few dozen); fatal for the #2240 collector.

Refs #2241. Refs #2240.
