### PR TITLE
docs(#2241): correct WS-limit attribution, add replication evidence

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -32,11 +32,23 @@ of a documented limit is not absence of a limit.** Measured on demo
 
 | limit | value | behaviour at the boundary |
 | --- | --- | --- |
-| topics per **session** | **4,999** | rejected: `errorCode: SubscribeFailed`, `"Too many subscriptions for session"`. Connection survives. Per-frame **atomic** — a straddling frame bounces whole, nothing partially applied. |
-| bytes per **frame** | **25 KiB** (25,600) | **silent: close 1006, empty reason, no ack, no error envelope.** Not applied. Bracket 25,529 B ok / 25,719 B dead. |
+| topics per **session** | **4,999** | rejected: `errorCode: SubscribeFailed`, `"Too many subscriptions for session"`. Connection survives **and keeps serving**. Per-frame **atomic** — a straddling frame bounces whole, nothing partially applied. |
+| bytes per **frame** | **25 KiB** (25,600) | **silent: socket dropped, no ack, no error envelope.** Not applied. Bracket 25,529 B ok / 25,719 B dead. |
 
+- 4,999 replicated exactly on a second independent session — not a
+  single-run artefact.
+- **An over-cap rejection does not poison the session.** Measured after a
+  rejection: 3,141 rate messages in the next 20s on already-subscribed
+  topics, and both `Subscribe` and `Unsubscribe` still acked. No reconnect
+  needed — handle the rejection, do not tear down.
+- **The over-size drop is not a client-side limit.** `ws.send()` returns
+  normally and the close is `1006 ABNORMAL_CLOSURE` with an empty reason,
+  i.e. **no close frame was received at all** — the socket is dropped, not
+  closed. Attribution is server-or-intermediary; do not assume either.
 - The session cap is **per connection, not per key** — 3 concurrent sessions
-  hold the full 12,684 universe (measured 12,684/12,684, 0 failures, 2.21s).
+  hold the full 12,684 universe (measured 12,684/12,684 topics **accepted**,
+  2.21s; "0 failures" there means zero rejected Subscribe frames, and says
+  nothing about data completeness, which S2/#2242 owns).
 - `Unsubscribe` frees capacity — live occupancy, not a lifetime budget.
 - **Chunk by BYTES, never by topic count** — instrument-id width varies, so a
   count-based cap does not bound frame size. 500 topics ≈ 9.4 KB, proven.

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -447,8 +447,16 @@ against the wire, not against parsed ticks.**
 
 | limit | value | behaviour at the boundary |
 | --- | --- | --- |
-| topics per **session** | **4,999** | Subscribe rejected with `errorCode: SubscribeFailed`, `errorMessage: "Too many subscriptions for session"`. Connection survives. Rejection is **per-frame and atomic** — a frame straddling the cap bounces whole. |
-| bytes per **frame** | **25 KiB** (25,600) | **No ack, no error — the server closes with 1006 and an empty reason.** Subscription not applied. Bracket: 25,529 B acked / 25,719 B closed. |
+| topics per **session** | **4,999** | Subscribe rejected with `errorCode: SubscribeFailed`, `errorMessage: "Too many subscriptions for session"`. Connection survives and keeps serving. Rejection is **per-frame and atomic** — a frame straddling the cap bounces whole. |
+| bytes per **frame** | **25 KiB** (25,600) | **No ack, no error — the socket is dropped** (`1006 ABNORMAL_CLOSURE`, empty reason, i.e. no close frame). Subscription not applied. Bracket: 25,529 B acked / 25,719 B dropped. |
+
+4,999 was replicated exactly on a second independent session. An over-cap
+rejection does **not** poison the session — 3,141 rate messages arrived in
+the following 20s on already-subscribed topics, and both `Subscribe` and
+`Unsubscribe` still acked, so a rejection needs handling rather than a
+reconnect. The over-size drop is **not** a client-side send limit:
+`ws.send()` returns normally and no close frame is received, so
+attribution is server-or-intermediary.
 
 The session cap is **per connection, not per API key**: concurrent sessions
 each get their own 4,999, so the full 12,684-instrument universe fits in 3


### PR DESCRIPTION
Follow-up to #2250. A Codex pass over the S1 verdict raised objections against the **measurement**, not the design. Three were material and cheap to answer, so I re-measured rather than reasoning about them.

| objection | re-measured result | doc change |
| --- | --- | --- |
| Cap is a single observation, no variance | **4,999 exactly**, replicated on a second independent session | recorded as replicated |
| "Connection survives a rejection" ≠ it still *serves* | **3,141 rate messages in the next 20s** on already-subscribed topics; `Subscribe` **and** `Unsubscribe` both still acked | now says a rejection needs *handling*, not a reconnect |
| "The server closes with 1006" — could be our client, or an intermediary | `ws.send()` returns normally (so **not** a client-side send limit) and the close is `1006 ABNORMAL_CLOSURE` with an empty reason, meaning **no close frame arrived at all** | reworded to "the socket is dropped"; attribution stated as server-or-intermediary |

Also scopes the "0 failures" claim: it counted **rejected Subscribe frames**, and says nothing about data completeness. That is S2's (#2242) job and the doc now says so.

The third one is the reason this PR exists — "the server closes" was a stronger claim than the evidence supports, and it would have been inherited as fact by whoever builds the collector.

## Security

No security surface. Doc-only.

Refs #2241. Refs #2240.
