### PR TITLE
docs(#2243): correct the WS rate-push model and LastExecution semantics

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -78,30 +78,50 @@ Census over 180,666 messages: 59.8% pure heartbeat, 16.8% `Bid`+`Ask`,
 - "23% of messages parse" is right but does **not** mean "77% are inert" —
   only ~60% are. Size ingest against the wire.
 
-**`LastExecution` is NOT a trade print. It is the pre-markup bid**
-(`BidDiscounted`) at full precision — the portal's *"price of the most recent
-trade execution"* is wrong, the second time this field's documented meaning has
-diverged from the wire (cf. #1429's `last = 0.00`). Over 26,741 observations it
-never left `[bid, ask]` (0.00%) and equalled `BidDiscounted` on 100.0% of
-Tokyo-equity, 97.8% of FX, 58.7% of crypto observations.
+**`LastExecution` is NOT a trade print** — the portal's *"price of the most
+recent trade execution"* is wrong, the second time this field's documented
+meaning has diverged from the wire (cf. #1429's `last = 0.00`). Over 26,741
+observations it **never left `[bid, ask]`** (0.00%), which a real print would.
+It is bid-side, and how tightly is asset-class-dependent — state the class, not
+a single global label:
+
+| arm | `== BidDiscounted` | reading |
+| --- | --- | --- |
+| Tokyo equity | 100.0% | is the pre-markup bid |
+| FX | 97.8% | is the pre-markup bid |
+| crypto | 58.7% | bid-*near*, not identical (median spread position 0.000, mean 0.041) |
+
+⚠ Crypto does not fit the clean story — do not carry "it IS BidDiscounted" across
+asset classes without re-measuring. `== AskDiscounted` is 0.0% everywhere.
 
 ⚠ **Run the bid/ask-excursion test against `BidDiscounted`/`AskDiscounted`, not
 `Bid`/`Ask`.** eToro's markup makes the FX series look like a derived mid
 (mean spread position 0.399) when against the underlying quote it sits exactly
 on the bid. The wrong column pair yields the opposite verdict.
 
-**eToro's own `OneMinute` REST candle is built from the BID series.** Bars
-rebuilt from `Bid` reproduce it on 77.1% of closes / 60.3% of full OHLC; from
-`LastExecution` 55.0% / 48.1%; from mid or ask, **0%**. **Build bars from
-`Bid`.** Corollary: WS bars and REST candles are the *same* price series, so
-choosing between them is about volume and cost, not price truthfulness.
+**Build 1-minute bars from `Bid`.** This is an *empirical compatibility rule* —
+`Bid` is the series that reproduces eToro's own `OneMinute` REST candle — not a
+claim about what the candle semantically is. Reconstruction scores, 131 complete
+minutes: `Bid` 77.1% of closes / 60.3% of full OHLC; `LastExecution` 55.0% /
+48.1%; mid or ask **0%**.
+
+The residual is granularity, not a second series: on a re-run attributing all 42
+mismatches, **zero were Tokyo equities** (100% exact there), and every mismatch
+was **within 0.20%** of the REST close — median 0.0019%, max 0.0716%, none above
+1%. Reconstruction is the discriminator that settled this spike; containment
+alone did not (see the prevention-log entry).
 
 **`OneMinute` volume is equity-only** — populated for US and Tokyo equities,
 always `None` for crypto and FX. Volume-confirmed rules are structurally
-impossible on crypto/FX from either path.
+impossible on crypto/FX from either path. Bid bars cannot carry trade volume at
+all, so volume must come from the REST candle.
 
-⚠ Verdict measured on crypto / FX / Tokyo equities. **The US-session equity arm
-is still outstanding** (#2243) — do not treat US behaviour as settled.
+⚠ **Scope of this verdict: demo env, one 10-minute window, crypto / FX / Tokyo
+equities.** Not measured: **live env** (may price, mark up or smooth
+differently), **US equities** (#2243's arm is still outstanding), **HK** (shut
+during the capture, 0 messages), and any stressed regime — open/close auction,
+halt, wide spread, FX rollover. Re-measure before treating any of those as
+settled.
 
 ## Maintenance
 

--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -56,14 +56,52 @@ of a documented limit is not absence of a limit.** Measured on demo
   ack is the only signal that a Subscribe did not take. eToro acks both ops:
   `{"id": …, "success": true, "operation": "Subscribe"}`.
 
-Two rate-push shapes: a fat snapshot, and a thin delta carrying only
-`{"Date","PriceRateID"}` (no price, no `InstrumentID`) that
-`_parse_rate_content` drops. 23% of inner rate messages parsed to a
-`QuoteUpdate` — **size ingest against the wire, not parsed ticks.** The
-snapshot also carries undocumented `OfficialClosingPrice`, `IsMarketOpen`,
+The snapshot also carries undocumented `OfficialClosingPrice`, `IsMarketOpen`,
 `IsExchangeOpen`, `ConversionRateBid`/`Ask` (see
 `docs/etoro-api-reference.md` §WebSocket API); undocumented means
 unversioned, so re-verify before depending on them.
+
+## WS rate semantics — MEASURED (#2243, 2026-08-04)
+
+**Rate pushes are FIELD-LEVEL SPARSE DELTAS, not "fat vs thin".** ⚠ This
+corrects the two-shape model recorded under #2241. Any subset of `Bid`,
+`Ask`, `LastExecution`, `BidDiscounted`, `AskDiscounted` can arrive alone;
+the instrument is always on the envelope `topic`, never in the payload.
+Census over 180,666 messages: 59.8% pure heartbeat, 16.8% `Bid`+`Ask`,
+10.5% `Bid`+`BidDiscounted`+`LastExecution`, 10.1% `Ask`+`AskDiscounted`,
+1.6% `LastExecution` alone, ~1.2% across 12 further combinations.
+
+- **`_parse_rate_content` requires BOTH `Bid` and `Ask`, so it drops 58.1% of
+  price-CHANGING messages** — stored quotes run 1.5–2.6× staler than the feed
+  allows. Tracked as #2252. **Any consumer must carry per-instrument state and
+  merge deltas**; requiring a complete payload sees under half the market.
+- "23% of messages parse" is right but does **not** mean "77% are inert" —
+  only ~60% are. Size ingest against the wire.
+
+**`LastExecution` is NOT a trade print. It is the pre-markup bid**
+(`BidDiscounted`) at full precision — the portal's *"price of the most recent
+trade execution"* is wrong, the second time this field's documented meaning has
+diverged from the wire (cf. #1429's `last = 0.00`). Over 26,741 observations it
+never left `[bid, ask]` (0.00%) and equalled `BidDiscounted` on 100.0% of
+Tokyo-equity, 97.8% of FX, 58.7% of crypto observations.
+
+⚠ **Run the bid/ask-excursion test against `BidDiscounted`/`AskDiscounted`, not
+`Bid`/`Ask`.** eToro's markup makes the FX series look like a derived mid
+(mean spread position 0.399) when against the underlying quote it sits exactly
+on the bid. The wrong column pair yields the opposite verdict.
+
+**eToro's own `OneMinute` REST candle is built from the BID series.** Bars
+rebuilt from `Bid` reproduce it on 77.1% of closes / 60.3% of full OHLC; from
+`LastExecution` 55.0% / 48.1%; from mid or ask, **0%**. **Build bars from
+`Bid`.** Corollary: WS bars and REST candles are the *same* price series, so
+choosing between them is about volume and cost, not price truthfulness.
+
+**`OneMinute` volume is equity-only** — populated for US and Tokyo equities,
+always `None` for crypto and FX. Volume-confirmed rules are structurally
+impossible on crypto/FX from either path.
+
+⚠ Verdict measured on crypto / FX / Tokyo equities. **The US-session equity arm
+is still outstanding** (#2243) — do not treat US behaviour as settled.
 
 ## Maintenance
 

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -436,12 +436,48 @@ unversioned; re-verify anything load-bearing): `InstrumentID`,
 `AllowSell`, `MaxPositionUnits`. `IsMarketOpen` and `IsExchangeOpen` are
 independent and do disagree (EURUSD: `true` / `false` at 23:37 UTC).
 
-**Two push shapes.** The fat snapshot above, and a steady-state thin delta
-carrying only `{"Date", "PriceRateID"}` — no price, no `InstrumentID`
-(the instrument is only on the envelope's `topic`). `_parse_rate_content`
-returns `None` for the thin shape. Measured ratio: 2,422 parsed
-`QuoteUpdate`s out of 10,564 inner rate messages (23%). **Size ingest
-against the wire, not against parsed ticks.**
+**Rate pushes are FIELD-LEVEL SPARSE DELTAS** (measured #2243, 2026-08-04;
+this corrects the "two push shapes" model recorded under #2241). A push
+carries only the fields that changed — any subset of `Bid`, `Ask`,
+`LastExecution`, `BidDiscounted`, `AskDiscounted` may arrive alone. The
+instrument is on the envelope's `topic`, not in the payload, on every shape.
+
+Census over 180,666 messages (240 instruments, 608 s, crypto + FX + Tokyo
+equities):
+
+| share | shape |
+| --- | --- |
+| 59.8% | heartbeat — `{"Date","PriceRateID"}` only, no price field |
+| 16.8% | `Bid`+`Ask` — **the only shape `_parse_rate_content` accepts** |
+| 10.5% | `Bid`+`BidDiscounted`+`LastExecution` |
+| 10.1% | `Ask`+`AskDiscounted` |
+| 1.6% | `LastExecution` alone |
+| ~1.2% | 12 further partial combinations |
+
+`_parse_rate_content` requires **both** `Bid` and `Ask`, so it discards every
+partial: **58.1% of price-CHANGING messages are dropped** (21,245 of 36,564),
+making the stored quote 1.5–2.6× staler than the feed allows (median gap
+between usable updates vs actual price changes: crypto 3.01s vs 1.15s, JP
+3.99s vs 1.85s, FX 1.53s vs 1.02s). Tracked as #2252. **A consumer must carry
+per-instrument state and merge deltas** — requiring a complete payload sees
+under half the market.
+
+**Size ingest against the wire, not against parsed ticks.** The earlier "23%
+parse" figure is right but was read as "77% are inert"; only ~60% are.
+
+**`LastExecution` is NOT a trade print — it is the pre-markup bid**
+(`BidDiscounted`), at full precision. Measured #2243 over 26,741 observations:
+it never left `[bid, ask]` (0.00%), and equals `BidDiscounted` on 100.0% of
+Tokyo-equity, 97.8% of FX and 58.7% of crypto observations. ⚠ Against eToro's
+*marked-up* `Bid`/`Ask` the FX series sits mid-spread (mean position 0.399) and
+looks like a derived mid — **the excursion test must be run against
+`BidDiscounted`/`AskDiscounted` or it returns the wrong answer.**
+
+**eToro's own `OneMinute` REST candle is built from the BID series**, not from
+trades or the mid. Bars rebuilt from `Bid` reproduce it on 77.1% of closes and
+60.3% of full OHLC; from `LastExecution` 55.0% / 48.1%; from mid or ask, 0%.
+**Build bars from `Bid`.** `OneMinute` volume is **equity-only** — populated for
+US and Tokyo equities, always `None` for crypto and FX.
 
 ### WebSocket limits (measured, #2241 — the portal documents NONE)
 

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -465,19 +465,31 @@ under half the market.
 **Size ingest against the wire, not against parsed ticks.** The earlier "23%
 parse" figure is right but was read as "77% are inert"; only ~60% are.
 
-**`LastExecution` is NOT a trade print — it is the pre-markup bid**
-(`BidDiscounted`), at full precision. Measured #2243 over 26,741 observations:
-it never left `[bid, ask]` (0.00%), and equals `BidDiscounted` on 100.0% of
-Tokyo-equity, 97.8% of FX and 58.7% of crypto observations. ⚠ Against eToro's
-*marked-up* `Bid`/`Ask` the FX series sits mid-spread (mean position 0.399) and
-looks like a derived mid — **the excursion test must be run against
-`BidDiscounted`/`AskDiscounted` or it returns the wrong answer.**
+**`LastExecution` is NOT a trade print** (measured #2243). Over 26,741
+observations it **never left `[bid, ask]`** (0.00%), which a real print would.
+It is bid-side, and how tightly is asset-class-dependent: `== BidDiscounted` on
+**100.0%** of Tokyo-equity and **97.8%** of FX observations, but only **58.7%**
+of crypto (bid-*near*: median spread position 0.000, mean 0.041). `==
+AskDiscounted` is 0.0% everywhere. ⚠ Do not carry a single global label across
+asset classes — crypto does not fit the clean story.
 
-**eToro's own `OneMinute` REST candle is built from the BID series**, not from
-trades or the mid. Bars rebuilt from `Bid` reproduce it on 77.1% of closes and
-60.3% of full OHLC; from `LastExecution` 55.0% / 48.1%; from mid or ask, 0%.
-**Build bars from `Bid`.** `OneMinute` volume is **equity-only** — populated for
-US and Tokyo equities, always `None` for crypto and FX.
+⚠ Against eToro's *marked-up* `Bid`/`Ask` the FX series sits mid-spread (mean
+position 0.399) and looks like a derived mid — **the excursion test must be run
+against `BidDiscounted`/`AskDiscounted` or it returns the wrong answer.**
+
+**Build 1-minute bars from `Bid`** — an empirical compatibility rule: `Bid` is
+the series that reproduces eToro's own `OneMinute` REST candle. Over 131
+complete minutes, `Bid` matched 77.1% of closes / 60.3% of full OHLC;
+`LastExecution` 55.0% / 48.1%; mid or ask 0%. The residual is granularity, not a
+second series — attributing all 42 mismatches, **zero were Tokyo equities**, and
+all were **within 0.20%** of the REST close (median 0.0019%, max 0.0716%).
+
+`OneMinute` volume is **equity-only** — populated for US and Tokyo equities,
+always `None` for crypto and FX.
+
+⚠ **Scope: demo env, one 10-minute window, crypto / FX / Tokyo equities.** Live
+env, US equities (#2243 arm outstanding), HK (shut during capture) and stressed
+regimes (auction, halt, wide spread, FX rollover) are all unmeasured.
 
 ### WebSocket limits (measured, #2241 — the portal documents NONE)
 

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -2633,3 +2633,23 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - Enforced in: this prevention log. No automated gate — the failure is in the shell, not
   in the repo, so the guard is the habit of reaching for the heredoc whenever the body
   contains a code identifier.
+
+---
+
+### A discriminator run against the WRONG pair of columns returns the opposite verdict
+
+- First seen in: #2243 (2026-08-04).
+- Symptom: S3 asked whether `QuoteUpdate.last` is a real trade print. The spike's own stated method was the textbook one — a print can trade outside the quote, a derived value cannot — so: does `last` ever leave `[bid, ask]`? Run against eToro's `Bid`/`Ask`, the FX arm came back with `last` sitting mid-spread (mean normalised position 0.399, median 0.425, never equal to bid or ask), which reads as **a derived mid**. Run against the `BidDiscounted`/`AskDiscounted` columns in the same payload, `last` sits **exactly on the bid** in 97.8% of the same observations. The two runs support opposite conclusions about the same field on the same data.
+- Root cause of the miss: `Bid`/`Ask` are eToro's **marked-up** quote; the `*Discounted` fields are the underlying one. A test of the form "is X inside the interval [A, B]" silently assumes A and B are the interval the source actually derives X from. Nothing about the column names says which pair that is, and the obvious pair was the wrong one. The same shape recurs anywhere a vendor publishes both a raw and an adjusted/marked-up/net figure — the discriminator is only as good as the reference series it is measured against.
+- Prevention: before running a containment or excursion discriminator, **enumerate every candidate reference series in the payload and run the test against all of them**, then report the full matrix rather than the one pair that looked canonical. A discriminator that yields different verdicts per reference pair has not answered the question — it has found that the reference is the actual unknown. Corollary, from the same spike: the eventual verdict was settled not by the containment test at all but by **reconstruction** — rebuilding the vendor's own published artefact (its `OneMinute` candle) from each candidate series and scoring which one reproduces it. Reconstruction beats containment because it has a ground truth; containment only has a bound.
+- Enforced in: this prevention log; `.claude/skills/data-sources/etoro-api.md` (§WS rate semantics carries the "run it against `BidDiscounted`/`AskDiscounted`" warning inline).
+
+---
+
+### A "disagreement" count with no catch-up control measures LATENCY and reports it as data loss
+
+- First seen in: #2243 (2026-08-04).
+- Symptom: to test whether eToro's sparse WS deltas drop price updates, a second connection took a forced full snapshot every 20s and the accumulated delta-state was compared against it. **3,435 of 4,566 field comparisons disagreed — 75%.** Read at face value that is a stream losing three quarters of its updates, and it would have justified abandoning WS-built bars outright. Adding a look-ahead control — for each disagreement, does the streaming session *ever* reach the snapshot's value? — showed **100% caught up within 30s and 0 never did.** The feed is lossless; the holder was sub-second behind a fresh read.
+- Root cause of the miss: comparing a continuously-updated accumulator against a point-in-time authoritative read conflates two different failure modes — "never received it" and "had not received it *yet*". At any sampling instant a healthy stream is legitimately a few hundred ms stale, so the disagreement rate is a function of tick rate and sampling latency, not of correctness. The measurement looked decisive and pointed the wrong way.
+- Prevention: whenever a freshness or completeness check compares live-accumulated state against an authoritative snapshot, **the disagreement count is not the finding — the unresolved-after-lookahead count is.** Always pair it with "did the accumulator subsequently converge to the snapshot value, and within what window", and report both. Same family as the narrowing-gate rule: the raw count is silent about the thing you actually care about.
+- Enforced in: this prevention log. The S3 probe scripts attached to #2243 carry the control as `s3_position.py` §D6.

--- a/docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md
+++ b/docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md
@@ -120,10 +120,18 @@ Consequences:
 >    equities. The choice between the paths is about **volume and cost, not price
 >    truthfulness**.
 >
-> Also settled there: `QuoteUpdate.last` is **not** a trade print but the
-> pre-markup bid, so **bars must be built from `Bid`, not `last`**. And the WS
-> rate push is a field-level sparse delta whose partial shapes production
-> currently discards (#2252) — the collector must carry per-instrument state.
+> Also settled there: `QuoteUpdate.last` is **not** a trade print — it never
+> leaves `[bid, ask]` in 26,741 observations — and is bid-side (exactly
+> `BidDiscounted` on 100% of Tokyo-equity and 97.8% of FX observations, but only
+> 58.7% of crypto). So **bars must be built from `Bid`, not `last`**, as an
+> empirical compatibility rule: `Bid` is what reproduces eToro's own candle.
+> And the WS rate push is a field-level sparse delta whose partial shapes
+> production currently discards (#2252) — the collector must carry
+> per-instrument state.
+>
+> ⚠ Measured on demo, one 10-minute window, crypto / FX / Tokyo equities. Live
+> env, US equities, HK and stressed regimes (auction, halt, wide spread) are
+> unmeasured; phase 0b should not treat them as settled.
 
 ## 3. Decisions taken
 

--- a/docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md
+++ b/docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md
@@ -108,6 +108,23 @@ Consequences:
   are structurally impossible on them and they are not comparable to the daily
   bars already stored.
 
+> ⚠ **Amended by S3 (#2243), 2026-08-04 — two claims above are wrong.**
+>
+> 1. `IntradayBar.volume` is **equity-only**. It is populated for US and Tokyo
+>    equities and is always `None` for crypto and FX, so volume-confirmed rules
+>    are impossible on those classes from *either* path, not just the WS one.
+> 2. The two paths are **the same price series**. eToro's own `OneMinute` candle
+>    is built from the **bid** (bars rebuilt from `Bid` reproduce it on 77.1% of
+>    closes / 60.3% of full OHLC; from mid or ask, 0%). So "fall back to REST
+>    candles for real prices" does not buy print-based bars — it buys volume, on
+>    equities. The choice between the paths is about **volume and cost, not price
+>    truthfulness**.
+>
+> Also settled there: `QuoteUpdate.last` is **not** a trade print but the
+> pre-markup bid, so **bars must be built from `Bid`, not `last`**. And the WS
+> rate push is a field-level sparse delta whose partial shapes production
+> currently discards (#2252) — the collector must carry per-instrument state.
+
 ## 3. Decisions taken
 
 1. **Win = take-profit hit before stop-loss, with a max-hold expiry.** Operator


### PR DESCRIPTION
Corrects two claims about the eToro WS rate feed that are already shipped in `docs/etoro-api-reference.md` and the `etoro-api` skill, and were about to be built on by phase 0b of #2240.

## What was wrong

**1. The rate push is not "fat snapshot vs thin heartbeat".** #2241 recorded two shapes. It is a **field-level sparse delta** — any subset of `Bid` / `Ask` / `LastExecution` / `BidDiscounted` / `AskDiscounted` arrives alone. Census over 180,666 messages: 59.8% pure heartbeat, 16.8% `Bid`+`Ask`, 10.5% `Bid`+`BidDiscounted`+`LastExecution`, 10.1% `Ask`+`AskDiscounted`, 1.6% `LastExecution` alone, ~1.2% across 12 further shapes.

Consequence, and the reason this is not a cosmetic doc fix: `_parse_rate_content` requires **both** `Bid` and `Ask`, so it discards **58.1% of price-changing messages** (21,245 of 36,564). Stored quotes run 1.5–2.6× staler than the feed allows. Filed as **#2252**. The S1 "23% parse" figure was right but was being read as "77% are inert"; only ~60% are.

**2. `LastExecution` is not a trade print.** The portal documents it as *"price of the most recent trade execution"*. Over 26,741 observations it **never left `[bid, ask]`** (0.00%) — a real print can trade through the quote. It is bid-side, and how tightly is asset-class-dependent:

| arm | `== BidDiscounted` |
| --- | --- |
| Tokyo equity | 100.0% |
| FX | 97.8% |
| crypto | 58.7% (bid-*near*, median spread position 0.000) |

`== AskDiscounted` is 0.0% everywhere. This is the second time this field's documented meaning has diverged from the wire — #1429 was the first (`last = 0.00` persisted for un-traded instruments).

## The load-bearing methodology finding

⚠ **Run the excursion test against `BidDiscounted`/`AskDiscounted`, not `Bid`/`Ask`.** Against eToro's *marked-up* quote the FX series sits mid-spread (mean normalised position 0.399) and reads as a **derived mid**. Against the underlying quote it sits exactly on the bid, 97.8%. The same data, the same test, opposite verdicts — the reference series was the actual unknown. Both prevention-log entries in this diff come from that.

What settled the spike was not containment but **reconstruction**: rebuilding eToro's own `OneMinute` REST candle from each candidate series. `Bid` 77.1% of closes / 60.3% full OHLC; `LastExecution` 55.0% / 48.1%; mid and ask **0%**. So bars must be built from `Bid`.

## Consequences recorded for #2240

- WS and REST are the **same price series** — eToro's candle is bid-derived. "Fall back to REST candles for real prices" does not buy print-based bars; it buys **volume**, and volume is **equity-only** (`None` for all crypto and FX). The choice between the paths is about volume and cost, not price truthfulness. The design doc asserted the opposite and now carries a correction note.
- The collector must carry per-instrument state and merge deltas.

## Review-intensity rung

Doc-only diff, no code. Per the ladder that is self-review + pre-push hook + review bot. But the underlying artefact is a **judgement artefact** (a causal claim that becomes phase 0b's acceptance criterion), so it went through the checkpoint-1 Codex pass, and that pass changed the diff — see below.

## Codex pass — two objections held, both actioned in `25332f95`

1. **"IS the pre-markup bid" over-claimed.** Crypto at 58.7% does not fit a single global label. Restated per asset class; the unconditional claim is now only the negative (not a print), which the containment evidence does support outright.
2. **"Build bars from `Bid`" was smuggling in semantics.** Restated as an *empirical compatibility rule* — `Bid` is what reproduces eToro's own candle. Same build decision, honest basis.

Codex also asked whether the 77.1% residual undermines the conclusion. Measured rather than caveated: attributing all 42 mismatches, **zero were Tokyo equities** (100% exact there) and every mismatch was **within 0.20%** of the REST close — median 0.0019%, max 0.0716%, none above 1%. Tick granularity, not a second series.

Remaining Codex points were phase-0b implementation scope (out-of-order handling, replay determinism, candle-revision checks, tick-size normalisation) and are not actioned here.

## Scope limits — stated in all three docs

Demo env, a single 10-minute window (2026-08-04 00:46–00:56 UTC), crypto / FX / Tokyo equities. **Unmeasured:** live env, US equities (#2243's arm is outstanding and that issue stays open on it), HK (shut during capture, 0 messages), and stressed regimes — auction, halt, wide spread, FX rollover.

## Security

No security surface. Documentation and skill files only; no code, schema, endpoint or credential path touched. The probe scripts that produced these numbers were read-only (no `private` topic, no `quotes` writes) and are attached to #2243 rather than merged.

## Verification

- `.githooks/pre-push` green on `25332f95` (lint, format, typecheck, fast tier, smoke, chokepoint-lint, chart-integrity).
- Every figure quoted here comes from the capture attached to #2243; the scripts that reproduce them are in that issue's comments.
- No DoD clauses 8–12: no ETL, parser, schema or ingest change in this diff.

Refs #2240. Refs #2243. Refs #2252. Refs #2241.
