### PR TITLE
docs: correct quote-freshness ownership and record the dev process topology

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -23,6 +23,25 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
 - Trading (verified live): open by-amount/by-units; close per position with optional `UnitsToDeduct` (partial); **`PATCH /api/v2/trading[/demo]/positions/{positionId}`** for TP/SL edit (`stopLossRate`, `takeProfitRate`, `stopLossType` fixed|trailing, `clearStopLoss`, `clearTakeProfit`; ≥1 field; **202 async** `{operationId, positionId, referenceId}`).
 - Write ops are asynchronous (202) — re-sync portfolio before treating them as landed.
 
+## Scope boundary — what this file is NOT
+
+This file documents **eToro's** behaviour: endpoints, limits, payload shapes,
+rate semantics. It deliberately does not document **our** policy for using
+them, and you will be misled if you look for that here:
+
+- **What we subscribe to** is visibility-driven (#498) — the WS boots quiet and
+  sends no Subscribe frame until an SSE stream lands. That is our decision, not
+  an eToro constraint. → `.claude/skills/market-data/SKILL.md`,
+  `docs/proposals/etl/visibility-driven-live-prices.md`.
+- **Which job keeps which table current** → `.claude/skills/market-data/SKILL.md`.
+- **Where our WS client process actually runs** (and why `lsof` against the
+  uvicorn pids cannot see its socket under `--reload`) →
+  `.claude/skills/ops-monitor/SKILL.md` §Process topology.
+
+Recorded 2026-08-04 (#2271) because a session went looking for the last two
+here, found only eToro protocol facts, and concluded the subscriber was
+disconnected when it was not.
+
 ## WebSocket limits — MEASURED, because the portal documents none
 
 `websocket/overview.md` and `websocket/topics.md` state no cap of any kind:

--- a/.claude/skills/market-data/SKILL.md
+++ b/.claude/skills/market-data/SKILL.md
@@ -47,10 +47,14 @@ last > 0`, sql/181). Price-derived risk stats live in
 `instrument_risk_metrics_observations`/`_current` (sql/198, `risk_v1`).
 
 **Jobs** — `daily_candle_refresh` (`app/workers/scheduler.py`, `etoro` lane)
-calls `refresh_market_data(..., skip_quotes=True)`; hourly `fx_rates_refresh`
-(`db` lane) owns quote freshness so the daily EOD job never shadows fresher
-quotes. Both registered in `app/jobs/runtime.py`; bootstrap stage
-`candle_refresh` (`bootstrap_orchestrator.py`).
+calls `refresh_market_data(..., skip_quotes=True)`; **`quotes_refresh` (hourly
+@ :23, `etoro` lane) owns quote freshness**, so the daily EOD sweep never
+shadows fresher quotes and never stamps instruments with marks taken 70
+minutes apart. `fx_rates_refresh` (`db` lane, daily 17:00 CET) owns ECB FX
+rates ONLY — it gave up its batch-quote phase in #502 and owned nothing about
+quotes for the ~3 months until #2271. All registered in
+`app/jobs/runtime.py`; bootstrap stage `candle_refresh`
+(`bootstrap_orchestrator.py`).
 
 **Read paths** — `/instruments/{symbol}/candles` reads `price_daily` only, no
 provider fallback (empty state, not 404). `/intraday-candles` fetches live from

--- a/.claude/skills/ops-monitor/SKILL.md
+++ b/.claude/skills/ops-monitor/SKILL.md
@@ -55,6 +55,35 @@ lock (`JOBS_PROCESS_LOCK_KEY`, `app/jobs/locks.py`) enforces one jobs process.
 `launchctl kickstart` is a no-op and merged scheduler/parser changes are NOT
 picked up until the operator restarts that task — check `ps -o ppid` first.
 
+⚠⚠ **The API's application object does NOT live in either process that
+`pgrep -f uvicorn` matches.** Under `uvicorn --reload` (the dev stack's shape)
+the app runs in a **multiprocessing-spawned worker**; `pgrep -f uvicorn` returns
+the `uv run uvicorn` parent and the uvicorn supervisor, and *neither holds
+application sockets*. So `lsof` against those pids reports zero outbound
+connections on a completely healthy app — and it fails in the direction that
+manufactures a bug, because "zero sockets" reads as a dead subsystem.
+
+Measured 2026-08-04 (#2271), with the eToro WS fully connected the whole time:
+
+```
+pid=60224 etoro_sockets=1   <- multiprocessing-spawned app worker
+pid=61071 etoro_sockets=0   <- uv run uvicorn (parent)
+pid=61124 etoro_sockets=0   <- uvicorn supervisor
+```
+
+Both the #2271 report and the first diagnosis pass concluded "the WS subscriber
+is not connected" from exactly that measurement. It was wrong, and it pointed
+the investigation away from the real defect (`quotes` had no scheduled writer).
+
+**To check whether the app holds a connection, ask the app, not the OS.**
+`GET /_debug/etoro-ws` returns `ws_state` (CONNECTING/OPEN/CLOSING/CLOSED) from
+inside the process that owns the socket, which no external process inspection
+can get wrong. If you must inspect externally, resolve the target host and grep
+every pid for its address (`lsof -nP -i TCP | grep <ip>`) — matching on the
+command line will miss the worker. General rule: **prefer an in-process liveness
+report over external process inspection, and when an external measurement says a
+subsystem is dead, confirm it in-process before writing it into a ticket.**
+
 ## Invariants (do not break)
 
 - **Process topology (#719, settled 2026-04-30):** no scheduler / executor /

--- a/app/main.py
+++ b/app/main.py
@@ -407,8 +407,9 @@ def _bootstrap_fx_rates(pool: ConnectionPool[Any]) -> None:
     """Populate ``live_fx_rates`` synchronously when the table is empty.
 
     Per the visibility-driven live-prices spec
-    (docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md
-    PR C), the daily Frankfurter cron does not guarantee rates are
+    (docs/proposals/etl/visibility-driven-live-prices.md, PR C — moved from
+    docs/superpowers/specs/, see docs/_archive/path-migration-map.md), the
+    daily Frankfurter cron does not guarantee rates are
     in the table at boot — a fresh DB, a wiped table, or a process
     restart between ECB publishes would all leave readers seeing
     no rows. Non-SSE handlers (``/portfolio``, ``/portfolio/copy-trading``,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4585,7 +4585,8 @@ def fx_rates_refresh() -> None:
     """Refresh live FX rates from Frankfurter (ECB reference rates).
 
     Per the visibility-driven live-prices spec
-    (docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md):
+    (docs/proposals/etl/visibility-driven-live-prices.md — moved from
+    docs/superpowers/specs/, see docs/_archive/path-migration-map.md):
 
     - Cadence cut from hourly to once daily at 17:00 CET. ECB
       publishes reference rates once per working day ~16:00 CET, so

--- a/docs/proposals/etl/visibility-driven-live-prices.md
+++ b/docs/proposals/etl/visibility-driven-live-prices.md
@@ -2,7 +2,31 @@
 
 Date: 2026-04-25
 Author: Luke / Claude
-Status: Draft v3 (post-Codex round 3; pending operator sign-off)
+Status: **SHIPPED and LIVE** — this describes current behaviour, not a proposal.
+The "Draft v3 (post-Codex round 3; pending operator sign-off)" header stood for
+months after the design shipped, which reads as "never built" to anyone checking
+how live prices actually work. It lives under `docs/proposals/` only because the
+whole tree moved (`docs/_archive/path-migration-map.md`); treat the directory as
+an accident of that move, not as its status.
+
+**Amendments since sign-off — read these before trusting the body below:**
+
+- **#502** cut FX cadence hourly → daily 17:00 CET and **dropped Phase 2 (eToro
+  batch quotes)** from `fx_rates_refresh`, on the rationale that the WS covers
+  quotes. True for the browser only.
+- **#2271** (2026-08-04) found the consequence: because the WS is
+  visibility-driven, dropping Phase 2 left the `quotes` table with **no
+  scheduled writer at all** for ~3 months, while eight headless services kept
+  reading it (scoring, portfolio, execution_guard, position_monitor, valuation,
+  transaction_cost, coverage, the quotes-gated valuation view). Held-position
+  marks were 14-22h stale. Fixed by the `quotes_refresh` job (hourly @ :23).
+  So **"what the operator can't see, doesn't stream" remains right for the WS,
+  but it was never a statement about who keeps `quotes` current.**
+
+Implementation: `app/services/etoro_websocket.py`, `app/api/sse_quotes.py`,
+`app/main.py::_maybe_start_etoro_ws`. Operating invariants are in
+`.claude/skills/market-data/SKILL.md` — that is the maintained summary; this
+document is the design record.
 
 ## Goal
 


### PR DESCRIPTION
## Issue reference

Refs #2271.

## Summary

The operator asked whether the eToro portal docs needed revising after #2271.
They do not — none of that ticket's confusion was an eToro fact, and the eToro
skill is accurate and well-measured. The gaps were all in our documentation of
our own decisions. Five of them, one shipped by me earlier today.

## What was actually wrong

**1. The market-data skill contradicted itself — my miss in #2275.**
The Jobs section read *"hourly `fx_rates_refresh` (`db` lane) owns quote
freshness"*. False since #502 (~3 months). I fixed that exact sentence in
`scheduler.py` in #2275 and left the identical one standing in the skill, then
added an Invariants bullet saying `quotes_refresh` owns it — so the file
asserted both. Corrected, with what `fx_rates_refresh` actually owns now
(ECB FX rates only).

**2. Two live docstrings cite a spec path that does not exist.**
`app/main.py` and `app/workers/scheduler.py` both point at
`docs/superpowers/specs/2026-04-25-visibility-driven-live-prices-spec.md`. The
document moved to `docs/proposals/etl/visibility-driven-live-prices.md`; only
`docs/_archive/path-migration-map.md` records that, so following the citation
from the code lands nowhere. Repointed, with the move noted.

**3. The design record read as "never shipped".**
That spec still carried `Status: Draft v3 (post-Codex round 3; pending operator
sign-off)` for behaviour that has been live for months, and sits under
`docs/proposals/` — a directory that means "not built". Anyone checking how live
prices work would reasonably conclude the design was never adopted. Marked
SHIPPED, with the directory explained as an artefact of the tree move, plus the
two amendments that matter: #502 dropped Phase 2, and #2271 found that this left
`quotes` with no scheduled writer. The body is otherwise untouched — it is the
design record; the maintained summary is the market-data skill, and it now says so.

**4. Process topology under `--reload` was undocumented.**
`ops-monitor` documents the jobs-daemon/API split (#719) but only logically.
Nothing recorded that the API's application object runs in a
**multiprocessing-spawned worker**, so `pgrep -f uvicorn` matches the parent and
supervisor — neither of which holds application sockets:

```
pid=60224 etoro_sockets=1   <- spawned app worker
pid=61071 etoro_sockets=0   <- uv run uvicorn (parent)
pid=61124 etoro_sockets=0   <- uvicorn supervisor
```

This fails in the direction that manufactures a bug: zero sockets reads as a
dead subsystem. Both the #2271 report and my first diagnosis pass concluded "the
WS subscriber is not connected" from exactly this measurement, while the socket
was open the whole time — and it pointed the investigation away from the real
defect. Recorded with the rule: **ask the app (`/_debug/etoro-ws` → `ws_state`),
not the OS**; if you must inspect externally, resolve the host and grep every
pid for the address.

**5. The eToro skill now states its scope boundary.**
It documents eToro's behaviour, not our policy for using it. A session went
looking there for our subscription policy and our process topology, found only
protocol facts, and drew a false conclusion from the absence. Three pointers
added — subscription policy, job/table ownership, process topology — each to the
file that actually owns it. Deliberately pointers, not content: putting our
decisions into a source-of-truth-about-eToro file is how that file stops being
trustworthy.

## The pattern worth naming

All five are the same failure, not five unrelated typos: **the durable statement
of a decision lived somewhere that does not get read, or does not get updated
when the decision changes.** #502 changed behaviour and updated neither the skill
nor the two comments pointing at it. The doc move updated a migration map but not
the citations. The design record kept a draft header past shipping.

That is why #2271 took three months to surface and why the first diagnosis pass
went to the wrong subsystem — every artefact a reader would consult was
individually plausible and collectively wrong.

## Security and audit model

No execution path touched. Comments, docstrings, skills and one design document;
zero behaviour change.

## Testing

Doc/comment-only, but the two edited docstrings are in live modules, so the full
gate ran:

- [x] `uv run ruff check .` / `ruff format --check .` pass
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest -m "not db"` passes
- [x] `uv run pytest tests/smoke` passes (both edited modules are import-critical)
- [x] Verified `docs/proposals/etl/visibility-driven-live-prices.md` exists and the old path does not

## Checklist

- [x] Branch named `docs/{short-description}`
- [x] No order placement path bypasses execution guard (none touched)
- [x] Lint / format / typecheck pass
