### PR TITLE
docs(#2289): validation universe is 6,733 US stocks ex-ETF, plus forward-record non-US from today

### DIFF
--- a/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
+++ b/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
@@ -391,7 +391,7 @@ vocabulary. What survives is a short list, and it is mostly boring.
 | family | who runs it | evidence | our data fit |
 | --- | --- | --- | --- |
 | **Time-series momentum / trend following** | the entire managed-futures / CTA industry (AQR, Winton, Man AHL) | strongest and longest — replicated across a century and every asset class | **excellent** — needs only close prices |
-| **Cross-sectional momentum (12-1)** | ubiquitous in quant equity | the most replicated equity anomaly there is | **excellent** — 12,179 instruments is real breadth |
+| **Cross-sectional momentum (12-1)** | ubiquitous in quant equity | the most replicated equity anomaly there is | ⚠ **revised by §4.0** — 12,179 is the *tradable* count, not the *validatable* one. S-2 ranks within **6,733 US stocks**; still real breadth, but half what this cell claimed |
 | **Short-horizon mean reversion (1–5d)** | stat-arb desks | real, but capacity-limited and cost-sensitive | **conditional** — dies on our p90 spread. ⚠ v1 has **no ex-ante liquidity gate at all**: no as-of spread is stored (§5 criterion 2), so costs are charged at settlement from the static model and the strategy is simply allowed to lose on them. A real gate arrives once spread history accrues (§8) |
 | **Volatility regime / compression breakout** | CTAs, vol funds | decent; overlaps trend | **good** — ATR/range only |
 | **Support / resistance as liquidity** | discretionary desks; systematised rarely | weak-to-moderate; mechanism (resting orders at prior extremes) is real | **buildable** once #2279 primitives exist |
@@ -443,7 +443,7 @@ strategy at a time. So it is specified once, here, and applies to all of them.
 
 ### 4.0 Validation universe — DECIDED 2026-08-05 (#2289)
 
-**Strategies are validated on `us_equity` only. Non-US instruments stay tradable
+**Strategies are validated on US common stocks only. Non-US instruments stay tradable
 but are not backtest-validated, and no strategy allocates to them on backtest
 evidence.** §0.1(c3) left this as "a scope decision for §4"; this is the call.
 
@@ -459,6 +459,16 @@ Measured on the dev corpus 2026-08-05 (`instruments` ⋈ `exchanges.asset_class`
 | `mena_equity` | 61 | no |
 | **non-US equity** | **4,749 (37.4%)** | **no source at any price we would pay** |
 
+⚠ **`us_equity` is an *exchange* classification, not a security-type filter, and
+the validated universe is narrower than the row above.** Of the 7,288, **6,733
+are `Stocks` and 555 are `ETF`** (`etoro_instrument_types` 5 and 6; `asset_class`
+lives on `exchanges`). Ranking an ETF against a common stock is precisely the
+homogeneity violation S-2's own ⚠ warns about, and a fund's price path is a
+basket's, not an issuer's. **The validated universe is `asset_class='us_equity'
+AND instrument_type_id = 5` — 6,733 instruments.** ADRs and US-listed foreign
+private issuers sit *inside* that 6,733 and are not separable today; they are the
+same population the Form 25 cohort under-resolves (below).
+
 Why this had to be decided *before* the catalogue rather than caveated after it:
 eToro serves all 12,684 shallowly, so a global backtest neither fails nor warns —
 it simply never sees the non-US losers. Validated on 57% of the universe, traded
@@ -466,7 +476,8 @@ across 100% of it, with nothing in the output to say so.
 
 **Adopted: #2289 option (1) + option (3).**
 
-**(1) US-only validation universe.** Every §5 gate is run over `us_equity`. A
+**(1) US-only validation universe.** Every §5 gate is run over the 6,733 US
+stocks defined above. A
 strategy's live universe may be wider than its validated one, but the difference
 is carried in the signal ledger (#2288), and §7's allocation reads the validated
 universe, not the live one.
@@ -488,15 +499,58 @@ Option (2) — global universe, survivor-biased, labelled — was rejected. It p
 the entire weight on a label holding under pressure, at the one moment (an
 allocation decision) when pressure is highest.
 
-**Per-strategy consequence:**
+**Allocation invariant — the part a label cannot carry.** "Not validated" has to
+bind execution, not just display:
 
-| strategy | validated universe | note |
-| --- | --- | --- |
-| S-1 time-series momentum | `us_equity` | per-instrument; may run live wider, marked unvalidated |
-| S-2 cross-sectional momentum | `us_equity` | resolves §9 Q1 — see below |
-| S-3 mean reversion in trend | `us_equity` | the #2260 shape; survivorship bias is **largest** here, so this one is gated on the corpus purchase as well as the universe |
-| S-4 volatility breakout | `us_equity` | |
-| S-5 / S-6 | `us_equity` | blocked on #2279 regardless |
+1. No backtest-derived allocation reaches an instrument outside the validated
+   universe. Zero, not scaled-down.
+2. **Live paper results on unvalidated instruments do not become allocation
+   evidence either.** §6 moves capital toward what is working; without this
+   clause a non-US sleeve accumulates live performance and re-enters allocation
+   through the back door, having passed none of §5. If a non-US variant is ever
+   to be allocated against, it registers as a **separate strategy identity** —
+   universe is part of the identity hash (criterion 11), so "S-1 on `us_equity`"
+   and "S-1 on `eu_equity`" are two strategies and always were.
+3. Performance metrics are reported split by validated universe, never pooled.
+   A pooled number launders (2) back in as arithmetic.
+
+**Two biases this decision does NOT fix.** Both are survivorship-shaped and
+neither was measured by #2284, so neither is covered by buying the corpus:
+
+- **eToro-listing bias.** The research universe is *"US names eToro lists
+  today, plus delisted names the corpus supplies"* — not *"US names that were
+  listed as of the entry date"*. A company that traded 2005–2015 and was never
+  on eToro's book is absent, and its absence looks exactly like survivorship.
+  The bought corpus reduces this (it is keyed on the market, not on eToro) but
+  only for names we think to ask for. Quantify it before trusting any
+  cross-sectional result: count corpus symbols with no `instruments` row.
+- **Form 25 resolution residue.** The register resolves **382 of 443 issuers
+  (86.2%)**; the missing 13.8% is closed-end funds (N-CSR, no cover-page XBRL)
+  and foreign private issuers (`sec-edgar.md` §2.6). US is "correctable" at
+  86.2%, not 100%, and the residue is **not** random with respect to fund-shaped
+  instruments.
+
+**Per-strategy consequence.** Survivorship acts through two distinct channels
+and collapsing them into one column hides which fix applies:
+
+- **selection** — the missing names change *which* instruments are picked;
+  fixed by a point-in-time universe (criterion 1).
+- **price-path** — the missing names change the *distribution of outcomes* for
+  instruments already picked; fixed only by a corpus that retains the losers'
+  bars to the end.
+
+| strategy | validated universe | selection | price-path | note |
+| --- | --- | --- | --- | --- |
+| S-1 time-series momentum | US stocks | low | **high** | per-instrument, so nothing is ranked away — but averaging outcomes over survivors only is still biased |
+| S-2 cross-sectional momentum | US stocks | **highest** | **high** | ranks are *directly* altered by missing bankrupt losers; the skill calls this shape fatal |
+| S-3 mean reversion in trend | US stocks | low | **highest** | the #2260 shape — oversold names that kept going are exactly what is missing. Gated on the corpus purchase, not just the universe |
+| S-4 volatility breakout | US stocks | low | **high** | not harmless: distress *is* volatility expansion, so the missing names are over-represented in the setup |
+| S-5 / S-6 | US stocks | low | **high** | failed names generate many breaks and retests near distress. Blocked on #2279, but that is not the only gate |
+
+⚠ Nothing in this table is "safe". The column that matters for sequencing is
+**selection**, because only S-2 is blocked on it; every strategy is blocked on
+price-path, i.e. on the corpus purchase, before its numbers may be allocated
+against.
 
 ⚠ **S-2 is not descoped, and #2289's body was one step too pessimistic on it.**
 It argued S-2 needs index-membership history that even the paid US options do not
@@ -504,7 +558,7 @@ sell. S-2 as written in this section does not rank within an index — it ranks
 within the *eligible listed* universe (≥273 bars, one asset class, one currency).
 What it needs is point-in-time **listing** membership, which the Form 25 register
 plus a delisted-inclusive US corpus does supply. Restricting its ranking universe
-to `us_equity` — which §9 Q1 already recommended on homogeneity grounds — is
+to US stocks — which §9 Q1 already recommended on homogeneity grounds — is
 sufficient. If S-2 is ever re-specified against an index, that reopens.
 
 ---
@@ -630,8 +684,15 @@ must not display a win rate anywhere the operator can allocate against it.
 Issue #2260 exists because a plausible number met none of these and was believed.
 
 1. **Point-in-time universe.** Selection only from instruments listed as of the
-   entry date. Pre-2026-06 this is impossible (§2.1) → those results carry a
-   `survivorship_unadjusted` flag in the data model, not just in prose.
+   entry date. Results that cannot satisfy it carry a `survivorship_unadjusted`
+   flag in the data model, not just in prose.
+   ⚠ **Scoped by §4.0 — "pre-2026-06 this is impossible (§2.1)" is now only half
+   true.** For **US stocks** it is satisfiable back to the 1990s: the Form 25
+   register supplies dated delistings (at 86.2% issuer resolution) and a bought
+   delisted-inclusive corpus supplies the bars. For the **4,749 non-US**
+   instruments it remains impossible for all history predating #2290's forward
+   record, and no purchase changes that. So the flag is not a legacy marker to
+   be retired — it is the permanent state of every non-US result.
 2. **Costs applied per trade — with an honest model, not a fictional one.**
    ⚠ The first draft said "use the spread as of the entry date". **That is
    unimplementable**: `quotes` holds one row per instrument (1,456 rows / 1,456
@@ -817,7 +878,7 @@ answer to a supplementary forward record.
 
 | when | what | why |
 | --- | --- | --- |
-| **NEW — first** | **research corpus ingest**: deep public OHLCV + delisted names, into their own tables, separate from the eToro-sourced `price_daily` | §0 — 45 years vs 4, survivorship-inclusive. Unblocks §5 criteria 1, 3, 5 and 6, none of which were satisfiable before |
+| **NEW — first** (#2282) | **research corpus ingest**, into its own tables, separate from the eToro-sourced `price_daily`. ⚠ **Two purchases, not one:** deep history on *survivors* is free today (the HF Parquet archive, 1962→2026); **delisted names are the paid part and land at the validation gate** | §0 — decades vs 4 years. Unblocks §5 criteria 3, 5 and 6 immediately; criterion 1 only once the delisted half lands |
 | **NEW — with it** | **delisting register from SEC Form 25 / 25-NSE** via EDGAR full-index | §0 — authoritative dated delisting record, free, and we already have the SEC fetch discipline. Gives point-in-time membership back to the 1990s rather than from today |
 | **NEW — cheap** | **measured eToro cost model**: the ~0.15% half-spread from §0, per class and price band | §5 criterion 2 — replaces the static guess with a measurement, and re-links research prices to execution reality |
 | **now — reinstated (#2290)** | **append-only universe-membership recording** | §4.0 option (3). For the 4,749 non-US instruments this is the *only* path there will ever be, and today's `sync_universe` overwrites the transition instead of recording it. Not optional, and not "downgraded" any more |
@@ -843,6 +904,14 @@ gate (#2260).** The measured landscape, the Yahoo-fingerprint technique and the
 `.claude/skills/data-sources/research-price-corpus.md` — read that, not a
 vendor-tier list in a spec that will go stale again.
 
+So that a future reader knows whether they need to open it: the skill is what
+carries the **vendor acceptance criteria** — delisted coverage measured against
+the 382-name cohort, split/dividend adjustment basis, security-level (not
+ticker-level) identity, symbol-history and ticker-reuse handling, listing and
+suspension dates, exchange/currency fields, and redistribution/ToS constraints.
+Any candidate is run against that cohort **before** purchase; a vendor's own
+survivorship claim is not evidence.
+
 ---
 
 ## 9. Open questions for the operator
@@ -850,10 +919,14 @@ vendor-tier list in a spec that will go stale again.
 1. ✅ **RESOLVED 2026-08-05 by §4.0 / #2289 — US-only, and it now binds every
    strategy, not just S-2.** The recommendation here was US-only on *homogeneity*
    grounds (currency and session effects). #2284 supplied a harder reason:
-   `us_equity` is the only slice of the universe whose survivorship can be
+   US stocks are the only slice of the universe whose survivorship can be
    corrected at all. "Add regions once #2244 is settled" is therefore no longer
    the unblocking condition — the condition is a non-US delisting record, which
    only #2290's forward recording will ever produce.
+   ⚠ And it produces one **only for periods after recording starts**. Forward
+   recording never corrects the past; it makes the constraint expire gradually
+   from the day it ships, which is the whole reason it ships now rather than
+   when non-US validation is wanted.
 2. **Rebalance cadence for S-2.** Monthly is standard and cheap. Weekly triples
    turnover and cost for marginal responsiveness. Recommendation: **monthly**.
 3. **Minimum history and price floor for eligibility.** ≥273 bars for S-2

--- a/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
+++ b/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
@@ -443,7 +443,7 @@ strategy at a time. So it is specified once, here, and applies to all of them.
 
 ### 4.0 Validation universe — DECIDED 2026-08-05 (#2289)
 
-**Strategies are validated on US common stocks only. Non-US instruments stay tradable
+**Strategies are validated on US stocks (ex-ETF) only. Non-US instruments stay tradable
 but are not backtest-validated, and no strategy allocates to them on backtest
 evidence.** §0.1(c3) left this as "a scope decision for §4"; this is the call.
 
@@ -452,7 +452,7 @@ Measured on the dev corpus 2026-08-05 (`instruments` ⋈ `exchanges.asset_class`
 
 | asset class | tradable | survivorship-correctable? |
 | --- | ---: | --- |
-| `us_equity` | 7,288 | **yes** — Form 25 register (#2282 2c) + a bought US corpus |
+| `us_equity` | 7,288 | **partially** — Form 25 register (#2282 2c) + a bought US corpus, at 86.2% issuer resolution and subject to the two biases below. Not "yes" |
 | `eu_equity` | 2,805 | no |
 | `uk_equity` | 989 | no |
 | `asia_equity` | 894 | no |
@@ -465,14 +465,33 @@ are `Stocks` and 555 are `ETF`** (`etoro_instrument_types` 5 and 6; `asset_class
 lives on `exchanges`). Ranking an ETF against a common stock is precisely the
 homogeneity violation S-2's own ⚠ warns about, and a fund's price path is a
 basket's, not an issuer's. **The validated universe is `asset_class='us_equity'
-AND instrument_type_id = 5` — 6,733 instruments.** ADRs and US-listed foreign
-private issuers sit *inside* that 6,733 and are not separable today; they are the
-same population the Form 25 cohort under-resolves (below).
+AND instrument_type_id = 5` — 6,733 instruments.**
+
+⚠ **That cut is *necessary, not sufficient*, and this section deliberately says
+"US stocks ex-ETF" rather than "US common stocks".** eToro's `Stocks` type is a
+provider classification, not a security-master one: ADRs/ADSs, US-listed foreign
+private issuers, REITs, BDCs, preferreds, units, rights and SPAC remnants can all
+carry it. Calling the result "common stock" would be the wrong-population error
+this document's own §10 lesson is about. Two consequences:
+
+- The residue is **partly separable, contrary to a first draft of this
+  paragraph** — `ads_ratio` (`sql/240`) and the FPI/ADR valuation suppression
+  (`sql/237`) already identify part of the ADR population. Narrowing the cut
+  further is open work, not an impossibility; it is deferred because S-1..S-4 do
+  not rank across issuer domicile and S-2 is the only one that would notice.
+- **`instruments.instrument_type_id` carries no foreign key** — verified: the
+  only constraints on `instruments` are the PK, the `canonical_instrument_id`
+  FK and a self-reference check. The universe definition therefore rests on an
+  unconstrained integer maintained by the provider sync. It is clean today
+  (0 NULL across all 12,684 tradable), so this is a latent risk rather than a
+  live defect: **the universe query must assert the type-id lookup resolves,
+  not assume it.**
 
 Why this had to be decided *before* the catalogue rather than caveated after it:
 eToro serves all 12,684 shallowly, so a global backtest neither fails nor warns —
-it simply never sees the non-US losers. Validated on 57% of the universe, traded
-across 100% of it, with nothing in the output to say so.
+it simply never sees the non-US losers. Left undecided, that ends as validated on
+57% of the universe and allocated across 100% of it, with nothing in the output
+to say so — which is what the allocation invariant below exists to prevent.
 
 **Adopted: #2289 option (1) + option (3).**
 
@@ -504,15 +523,25 @@ bind execution, not just display:
 
 1. No backtest-derived allocation reaches an instrument outside the validated
    universe. Zero, not scaled-down.
-2. **Live paper results on unvalidated instruments do not become allocation
+2. **Order eligibility, not just allocation eligibility.** (1) constrains which
+   *pots* are funded; it does not constrain what a funded pot then buys. A
+   US-validated S-1 sleeve receiving capital and spending it on a non-US live
+   signal satisfies (1) and defeats it. So: **an order funded from a strategy's
+   allocation may only be placed on an instrument in that strategy's validated
+   universe.** This is a hard pre-trade rule and belongs in
+   [`execution_guard.py`](../../../app/services/execution_guard.py) — which is
+   deterministic, fail-closed and already writes one `decision_audit` row per
+   invocation — not in the signal ledger. **A ledger label is observability;
+   this needs enforcement.**
+3. **Live paper results on unvalidated instruments do not become allocation
    evidence either.** §6 moves capital toward what is working; without this
    clause a non-US sleeve accumulates live performance and re-enters allocation
    through the back door, having passed none of §5. If a non-US variant is ever
    to be allocated against, it registers as a **separate strategy identity** —
-   universe is part of the identity hash (criterion 11), so "S-1 on `us_equity`"
+   universe is part of the identity hash (criterion 11), so "S-1 on US stocks"
    and "S-1 on `eu_equity`" are two strategies and always were.
-3. Performance metrics are reported split by validated universe, never pooled.
-   A pooled number launders (2) back in as arithmetic.
+4. Performance metrics are reported split by validated universe, never pooled.
+   A pooled number launders (3) back in as arithmetic.
 
 **Two biases this decision does NOT fix.** Both are survivorship-shaped and
 neither was measured by #2284, so neither is covered by buying the corpus:
@@ -530,34 +559,45 @@ neither was measured by #2284, so neither is covered by buying the corpus:
   86.2%, not 100%, and the residue is **not** random with respect to fund-shaped
   instruments.
 
-**Per-strategy consequence.** Survivorship acts through two distinct channels
-and collapsing them into one column hides which fix applies:
+**Per-strategy consequence.** An earlier draft of this table graded
+"selection" against "price-path" and got it wrong, in a way worth recording
+because it is the intuitive error: it labelled every non-ranking strategy
+`selection = low`. That is false. A delisted name absent from the corpus never
+fires its signals at all, so **the trade set is truncated for every strategy**,
+not only for the one that ranks. The distinction that actually earns its place
+is **what fixes it**:
 
-- **selection** — the missing names change *which* instruments are picked;
-  fixed by a point-in-time universe (criterion 1).
-- **price-path** — the missing names change the *distribution of outcomes* for
-  instruments already picked; fixed only by a corpus that retains the losers'
-  bars to the end.
+- **omission** — the missing names' own trades never appear. Affects **every**
+  strategy. Fixed only by a corpus that retains the losers' bars to the end,
+  i.e. by the purchase.
+- **rank contamination** — the missing names change which *surviving* names get
+  picked, because the rule is relative. Affects **S-2 alone**. Needs
+  point-in-time membership at each rebalance (criterion 1) *on top of* the
+  corpus.
 
-| strategy | validated universe | selection | price-path | note |
+| strategy | validated universe | omission | rank contamination | note |
 | --- | --- | --- | --- | --- |
-| S-1 time-series momentum | US stocks | low | **high** | per-instrument, so nothing is ranked away — but averaging outcomes over survivors only is still biased |
-| S-2 cross-sectional momentum | US stocks | **highest** | **high** | ranks are *directly* altered by missing bankrupt losers; the skill calls this shape fatal |
-| S-3 mean reversion in trend | US stocks | low | **highest** | the #2260 shape — oversold names that kept going are exactly what is missing. Gated on the corpus purchase, not just the universe |
-| S-4 volatility breakout | US stocks | low | **high** | not harmless: distress *is* volatility expansion, so the missing names are over-represented in the setup |
-| S-5 / S-6 | US stocks | low | **high** | failed names generate many breaks and retests near distress. Blocked on #2279, but that is not the only gate |
+| S-1 time-series momentum | US stocks ex-ETF | **high** | none | trades on names that later died are simply absent, so the outcome distribution is survivor-truncated |
+| S-2 cross-sectional momentum | US stocks ex-ETF | **high** | **yes — only strategy affected** | a missing bankrupt loser promotes a survivor into the top decile that never belonged there. The skill calls this shape fatal |
+| S-3 mean reversion in trend | US stocks ex-ETF | **highest** | none | the #2260 shape. "Oversold and kept going" is the *definition* of the missing population, so the absent signals are disproportionately the losing ones |
+| S-4 volatility breakout | US stocks ex-ETF | **high** | none | distress *is* volatility expansion, so delisted names are over-represented in the setup, not incidental to it |
+| S-5 / S-6 | US stocks ex-ETF | **high** | none | failed names generate many breaks and retests near distress. Blocked on #2279, but that is not the only gate |
 
-⚠ Nothing in this table is "safe". The column that matters for sequencing is
-**selection**, because only S-2 is blocked on it; every strategy is blocked on
-price-path, i.e. on the corpus purchase, before its numbers may be allocated
-against.
+⚠ **Nothing in this table is "safe", and omission is not a lesser problem than
+contamination.** The only sequencing consequence is that S-2 additionally needs
+criterion 1; every strategy is blocked on the corpus purchase before its numbers
+may be allocated against.
 
 ⚠ **S-2 is not descoped, and #2289's body was one step too pessimistic on it.**
 It argued S-2 needs index-membership history that even the paid US options do not
 sell. S-2 as written in this section does not rank within an index — it ranks
 within the *eligible listed* universe (≥273 bars, one asset class, one currency).
-What it needs is point-in-time **listing** membership, which the Form 25 register
-plus a delisted-inclusive US corpus does supply. Restricting its ranking universe
+What it needs is point-in-time **listing** membership.
+⚠ Form 25 supplies only the *end* of a listing. Criterion 1 needs both ends, and
+the start has no equivalent register — it comes from the corpus's first bar, which
+is a proxy and is exactly what the ticker-reuse guard (#2282 scope item 7) exists
+to police. Listing membership is therefore *reconstructable* for US stocks, not
+simply *available*. Restricting its ranking universe
 to US stocks — which §9 Q1 already recommended on homogeneity grounds — is
 sufficient. If S-2 is ever re-specified against an index, that reopens.
 
@@ -592,11 +632,12 @@ Params: 3 (lookback, skip, decile).
 Rationale: the most replicated equity anomaly; the skip window prevents
 short-term reversal contaminating the momentum signal.
 Eligibility, evaluated **as-of each rebalance date** (§3.5 rule 5): ≥273 bars
-of history at that date. Roughly 7,700 instruments qualify today, but the
-as-of count in 2022 was far smaller — the backtest must use the historical
-count, not today's.
+of history at that date. ⚠ "Roughly 7,700 instruments qualify today" was the *global* count and is
+superseded by §4.0: S-2 ranks within the 6,733 US stocks ex-ETF, and the as-of
+count in 2022 was smaller again — the backtest must use the historical count,
+not today's and not the global one.
 ⚠ Rank within one asset class and one currency, or a currency move ranks
-against an equity move. See §9 Q1.
+against an equity move. Settled by §4.0 (§9 Q1 is resolved): US stocks, USD.
 ⚠ Returns are **price returns, not total returns** — eToro candles carry no
 dividend adjustment (`price_adjustments` is empty; see §5 criterion 10). This
 systematically understates high-yield names over a 12-month lookback.
@@ -687,9 +728,11 @@ Issue #2260 exists because a plausible number met none of these and was believed
    entry date. Results that cannot satisfy it carry a `survivorship_unadjusted`
    flag in the data model, not just in prose.
    ⚠ **Scoped by §4.0 — "pre-2026-06 this is impossible (§2.1)" is now only half
-   true.** For **US stocks** it is satisfiable back to the 1990s: the Form 25
-   register supplies dated delistings (at 86.2% issuer resolution) and a bought
-   delisted-inclusive corpus supplies the bars. For the **4,749 non-US**
+   true.** For the **resolved subset of US stocks** it is reconstructable back to
+   the 1990s: the Form 25 register supplies dated delistings and a bought
+   delisted-inclusive corpus supplies the bars. "Resolved subset" is load-bearing
+   — 86.2% issuer resolution, CEF/FPI-shaped residue, plus eToro-listing bias
+   (§4.0). It is not 100% and must not be reported as though it were. For the **4,749 non-US**
    instruments it remains impossible for all history predating #2290's forward
    record, and no purchase changes that. So the flag is not a legacy marker to
    be retired — it is the permanent state of every non-US result.
@@ -919,8 +962,8 @@ survivorship claim is not evidence.
 1. ✅ **RESOLVED 2026-08-05 by §4.0 / #2289 — US-only, and it now binds every
    strategy, not just S-2.** The recommendation here was US-only on *homogeneity*
    grounds (currency and session effects). #2284 supplied a harder reason:
-   US stocks are the only slice of the universe whose survivorship can be
-   corrected at all. "Add regions once #2244 is settled" is therefore no longer
+   US stocks are the only slice of the universe whose survivorship is
+   economically correctable at all — and then only partially (§4.0). "Add regions once #2244 is settled" is therefore no longer
    the unblocking condition — the condition is a non-US delisting record, which
    only #2290's forward recording will ever produce.
    ⚠ And it produces one **only for periods after recording starts**. Forward

--- a/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
+++ b/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
@@ -441,6 +441,74 @@ strategy at a time. So it is specified once, here, and applies to all of them.
 
 ## 4. Strategy catalogue v1
 
+### 4.0 Validation universe — DECIDED 2026-08-05 (#2289)
+
+**Strategies are validated on `us_equity` only. Non-US instruments stay tradable
+but are not backtest-validated, and no strategy allocates to them on backtest
+evidence.** §0.1(c3) left this as "a scope decision for §4"; this is the call.
+
+Measured on the dev corpus 2026-08-05 (`instruments` ⋈ `exchanges.asset_class`;
+`asset_class` is on `exchanges`, not on `instruments`):
+
+| asset class | tradable | survivorship-correctable? |
+| --- | ---: | --- |
+| `us_equity` | 7,288 | **yes** — Form 25 register (#2282 2c) + a bought US corpus |
+| `eu_equity` | 2,805 | no |
+| `uk_equity` | 989 | no |
+| `asia_equity` | 894 | no |
+| `mena_equity` | 61 | no |
+| **non-US equity** | **4,749 (37.4%)** | **no source at any price we would pay** |
+
+Why this had to be decided *before* the catalogue rather than caveated after it:
+eToro serves all 12,684 shallowly, so a global backtest neither fails nor warns —
+it simply never sees the non-US losers. Validated on 57% of the universe, traded
+across 100% of it, with nothing in the output to say so.
+
+**Adopted: #2289 option (1) + option (3).**
+
+**(1) US-only validation universe.** Every §5 gate is run over `us_equity`. A
+strategy's live universe may be wider than its validated one, but the difference
+is carried in the signal ledger (#2288), and §7's allocation reads the validated
+universe, not the live one.
+
+**(3) Forward-record non-US membership from today**, so the constraint expires
+instead of being permanent. This is not free-standing: `sync_universe` currently
+*destroys* the transition it would need to record —
+`UPDATE instruments SET is_tradable = FALSE, last_seen_at = NOW()`
+([`app/services/universe.py`](../../../app/services/universe.py)) overwrites in
+place, so there is no dated membership row, and `last_seen_at` ends up holding
+the date we **noticed** the instrument was gone rather than the last date it was
+listed. That is Form 25 trap 5 in a different costume (`sec-edgar.md` §2.6): the
+detection date is never the date the consumer needs. Specified and ticketed as
+**#2290**; the shape to copy is `instrument_symbol_history` (`sql/103`), which
+already carries the exact temporal invariants — ordered ranges, single-current
+partial unique index, GIST no-overlap.
+
+Option (2) — global universe, survivor-biased, labelled — was rejected. It puts
+the entire weight on a label holding under pressure, at the one moment (an
+allocation decision) when pressure is highest.
+
+**Per-strategy consequence:**
+
+| strategy | validated universe | note |
+| --- | --- | --- |
+| S-1 time-series momentum | `us_equity` | per-instrument; may run live wider, marked unvalidated |
+| S-2 cross-sectional momentum | `us_equity` | resolves §9 Q1 — see below |
+| S-3 mean reversion in trend | `us_equity` | the #2260 shape; survivorship bias is **largest** here, so this one is gated on the corpus purchase as well as the universe |
+| S-4 volatility breakout | `us_equity` | |
+| S-5 / S-6 | `us_equity` | blocked on #2279 regardless |
+
+⚠ **S-2 is not descoped, and #2289's body was one step too pessimistic on it.**
+It argued S-2 needs index-membership history that even the paid US options do not
+sell. S-2 as written in this section does not rank within an index — it ranks
+within the *eligible listed* universe (≥273 bars, one asset class, one currency).
+What it needs is point-in-time **listing** membership, which the Form 25 register
+plus a delisted-inclusive US corpus does supply. Restricting its ranking universe
+to `us_equity` — which §9 Q1 already recommended on homogeneity grounds — is
+sufficient. If S-2 is ever re-specified against an index, that reopens.
+
+---
+
 Six strategies. Deliberately few, each with ≤3 free parameters, each with a
 stated economic rationale. **A strategy with no rationale is a data-mining
 result waiting to fail out-of-sample**, and phase 8 (discovery) is safe only
@@ -752,7 +820,7 @@ answer to a supplementary forward record.
 | **NEW — first** | **research corpus ingest**: deep public OHLCV + delisted names, into their own tables, separate from the eToro-sourced `price_daily` | §0 — 45 years vs 4, survivorship-inclusive. Unblocks §5 criteria 1, 3, 5 and 6, none of which were satisfiable before |
 | **NEW — with it** | **delisting register from SEC Form 25 / 25-NSE** via EDGAR full-index | §0 — authoritative dated delisting record, free, and we already have the SEC fetch discipline. Gives point-in-time membership back to the 1990s rather than from today |
 | **NEW — cheap** | **measured eToro cost model**: the ~0.15% half-spread from §0, per class and price band | §5 criterion 2 — replaces the static guess with a measurement, and re-links research prices to execution reality |
-| now (downgraded) | point-in-time universe membership recording | still worth having as our own forward record, but no longer the only path to survivorship-free backtests |
+| **now — reinstated (#2290)** | **append-only universe-membership recording** | §4.0 option (3). For the 4,749 non-US instruments this is the *only* path there will ever be, and today's `sync_universe` overwrites the transition instead of recording it. Not optional, and not "downgraded" any more |
 | now (downgraded) | spread / liquidity history | still the route to *as-of* costs; the §0 measurement covers v1 |
 | phase 2 | historical indicator recomputation | with criterion 4 enforced by test. ⚠ Reconsider scope: `vectorbt`/TA-Lib compute indicators over a series directly, so persisting a full indicator history may be unnecessary for backtesting and needed only for the live signals lens |
 | **phase 2b** (#2279) | price-structure primitives | S-5/S-6 need them; the registry's vocabulary must be settled before phase 3 fixes it |
@@ -763,24 +831,29 @@ answer to a supplementary forward record.
 | phase 7 | allocation page | §7 |
 | phase 8 | discovery | only with criterion 6 enforced |
 
-**Vendor question, if free sources prove insufficient.** Free tier tested and
-working today (public feed for prices, EDGAR for delistings). If coverage or
-terms become a problem, the measured options are EODHD at **£19.99/mo** for 30+
-years EOD across 60+ exchanges — but **delisted coverage sits on the £59.99
-Fundamentals tier or the £99.99 all-in-one** — or Sharadar's US bundle via
-Nasdaq Data Link, which is explicitly point-in-time and survivorship-free back
-to the 1990s. Worth revisiting only once the free path is shown to be the
-binding constraint; do not buy data to solve a problem we have not hit.
+⚠ **RETIRED 2026-08-05 (#2284).** This paragraph used to read *"free tier tested
+and working today … do not buy data to solve a problem we have not hit"*, and
+listed EODHD / Sharadar subscription tiers as the fallback. Both halves are
+falsified. The free path was searched exhaustively — ten sources, **every free
+one returns 0 of 382** on the delisted cohort — and the problem *has* been hit,
+structurally, not contingently. The two sources that pass are **one-off
+purchases** (~$299), not subscriptions. **Build free now, buy at the validation
+gate (#2260).** The measured landscape, the Yahoo-fingerprint technique and the
+382-name acceptance test live in
+`.claude/skills/data-sources/research-price-corpus.md` — read that, not a
+vendor-tier list in a spec that will go stale again.
 
 ---
 
 ## 9. Open questions for the operator
 
-1. **Universe breadth for S-2.** Cross-sectional momentum ranks instruments
-   against each other. Rank US equities only (7,098, homogeneous), or all
-   equities across regions (11,684, adds currency and session effects)?
-   Recommendation: **US-only for v1**, add regions once S-4's session semantics
-   (#2244) are settled.
+1. ✅ **RESOLVED 2026-08-05 by §4.0 / #2289 — US-only, and it now binds every
+   strategy, not just S-2.** The recommendation here was US-only on *homogeneity*
+   grounds (currency and session effects). #2284 supplied a harder reason:
+   `us_equity` is the only slice of the universe whose survivorship can be
+   corrected at all. "Add regions once #2244 is settled" is therefore no longer
+   the unblocking condition — the condition is a non-US delisting record, which
+   only #2290's forward recording will ever produce.
 2. **Rebalance cadence for S-2.** Monthly is standard and cheap. Weekly triples
    turnover and cost for marginal responsiveness. Recommendation: **monthly**.
 3. **Minimum history and price floor for eligibility.** ≥273 bars for S-2


### PR DESCRIPTION
Takes the #2289 scope decision that §0.1(c3) of the TA spec left open, and closes the loop #2284 opened. Doc-only.

## The decision

**Adopted: #2289 option (1) + option (3).** Strategies are validated on **US stocks ex-ETF (6,733)**; non-US instruments stay tradable but are not backtest-validated; and universe membership starts being recorded forward from today so the constraint expires rather than being permanent.

New **§4.0** in `docs/proposals/ta/strategy-catalogue-and-backtest-validity.md` carries it.

Why it had to be decided before §4 rather than caveated after: eToro serves all 12,684 instruments shallowly, so a global backtest neither fails nor warns — it simply never sees the non-US losers.

## Measured, not assumed

Dev corpus, 2026-08-05 (`instruments` ⋈ `exchanges.asset_class` — `asset_class` is on `exchanges`, not on `instruments`):

| asset class | tradable |
| --- | ---: |
| `us_equity` | 7,288 |
| `eu_equity` | 2,805 |
| `uk_equity` | 989 |
| `asia_equity` | 894 |
| `mena_equity` | 61 |
| **non-US equity** | **4,749 (37.4%)** |

And the cut that matters: of the 7,288 `us_equity`, **6,733 are `Stocks` and 555 are `ETF`** (`etoro_instrument_types` 5 / 6). Ranking an ETF against a common stock is the exact homogeneity violation S-2's own ⚠ warns about, so the validated universe is `asset_class='us_equity' AND instrument_type_id = 5`.

## What else changed, and why

**A new ticket, #2290 — `sync_universe` destroys the transition option (3) needs.** `UPDATE instruments SET is_tradable = FALSE, last_seen_at = NOW()` overwrites in place: no dated membership row, and `last_seen_at` ends up holding the date we *noticed* the instrument was gone rather than the last date it was listed. That is **Form 25 trap 5 in a different costume** (`sec-edgar.md` §2.6) — the detection date is never the date the consumer needs. Grepped `is_tradable` / `deactivat` in `settled-decisions.md` and the prevention log: nothing governs this, so it is a gap and not a disposal being reopened. Shape to copy is `instrument_symbol_history` (`sql/103`), which already has the temporal invariants.

**Contradictions this decision created elsewhere, fixed in the same PR:** §3's "12,179 is real breadth" (that is the tradable count, not the validatable one), §5 criterion 1's "pre-2026-06 this is impossible", §8's research-corpus row, S-2's stale global 7,700 count, and the now-resolved §9 Q1 pointer.

**§8's vendor paragraph retired.** It read *"free tier tested and working today … do not buy data to solve a problem we have not hit"* and listed EODHD/Sharadar subscription tiers. Both halves falsified by #2284. Replaced with a pointer to `research-price-corpus.md` **plus a one-line list of what that skill carries**, so a future reader knows whether they need to open it.

**S-2 is not descoped, contra #2289's body.** The issue argued S-2 needs index-membership history that even the paid US options do not sell. S-2 as specified ranks within the eligible *listed* universe, not an index — so point-in-time listing membership suffices, and restricting its ranking universe to US stocks (which §9 Q1 already recommended on homogeneity grounds) is the fix.

## Review

Judgement-artefact rung → Codex checkpoint 1, two rounds. Both changed the substance, so both are worth stating:

**Round 1** — `us_equity` is an *exchange* classification and silently included 555 ETFs; the allocation rule left live paper evidence as a back door into §6 allocation; the per-strategy table called S-3 the largest survivorship risk, contradicting `research-price-corpus.md`, which calls cross-sectional momentum fatal; and two biases were unnamed (eToro-listing bias, the Form 25 86.2% resolution residue).

**Round 2** — three that mattered:

1. **The sensitivity table was still wrong.** Grading "selection" vs "price-path" labelled every non-ranking strategy `selection = low`. False: a delisted name absent from the corpus never fires its signals at all, so the trade set is truncated for *every* strategy. Recut as **omission** (all strategies) vs **rank contamination** (S-2 alone). The wrong version is described in place — it is the intuitive error and will be made again.
2. **The allocation invariant had a live route left open.** It constrained which *pots* are funded, not what a funded pot then buys — a US-validated S-1 sleeve could take capital and spend it on a non-US live signal. Added order eligibility as a hard pre-trade rule in `execution_guard.py` (deterministic, fail-closed, already `decision_audit`-ing every invocation), with the point stated plainly: a ledger label is observability, enforcement is a different thing.
3. **`instrument_type_id = 5` is necessary, not sufficient.** eToro's `Stocks` still admits ADR/ADS, FPI, REIT, BDC, preferred, unit, right and SPAC remnant, so the section says "US stocks ex-ETF" and never "common stock" — calling it that would be this document's own §10 wrong-population error. Two facts verified against dev while folding this: `instruments.instrument_type_id` has **no foreign key** (only the PK, the `canonical_instrument_id` FK and a self-ref check) though 0 NULLs across 12,684 today, so the universe query must assert the lookup resolves; and "not separable today" was too strong — `ads_ratio` (`sql/240`) and the FPI/ADR suppression (`sql/237`) already identify part of that population.

Also corrected on round 2: Form 25 supplies only the **end** of a listing, so criterion 1's point-in-time membership is *reconstructable* (start = corpus first bar, policed by the ticker-reuse guard), not simply *available*; and `us_equity` correctability downgraded from "yes" to "partially", since 86.2% issuer resolution with a CEF/FPI-shaped residue is not 100%.

## Security model

Not applicable — documentation only, no code, no schema, no endpoint. The one security-adjacent point is directional: §4.0 moves a constraint *into* `execution_guard.py`'s fail-closed pre-trade path rather than leaving it as a display label. That is a specification, not an implementation; #2290 and the phase-3 work carry it.

## Verification

Doc-only diff, so Definition-of-Done clauses 8-12 (smoke panel, cross-source, backfill, live figure) do not apply — no parser, ETL or schema changed. Pre-push gate green at `06467f2a`. Every figure quoted above was read off the dev DB during this session rather than carried from the issue body; where a number differs from #2289's (6,733 vs 7,288) the difference is the finding.

Closes #2289. Refs #2240. Refs #2282. Refs #2284. Refs #2290.