### PR TITLE
feat(#2282): research corpus schema + coverage census (stage 2a)

### DIFF
--- a/sql/249_research_price_corpus.sql
+++ b/sql/249_research_price_corpus.sql
@@ -1,0 +1,278 @@
+-- 249_research_price_corpus.sql
+--
+-- #2282 stage 2a (phase 1 of #2240) — the RESEARCH corpus, and the
+-- per-instrument coverage census that makes its survivorship auditable.
+--
+-- ⚠⚠ THIS IS NOT `price_daily`, AND MUST NEVER BE MERGED INTO IT.
+-- `price_daily` is the eToro-sourced EXECUTION view: bid-derived CFD candles,
+-- ~4 years deep (1,000-bar API cap, #603), survivors only. This is the
+-- RESEARCH view: deep history, third-party provenance, delisted names retained
+-- once the paid half lands. The two roles are separated deliberately — see
+-- `docs/proposals/ta/strategy-catalogue-and-backtest-validity.md` §0 and
+-- `.claude/skills/data-sources/research-price-corpus.md`. Merging them would
+-- put an unspecified-licence Yahoo derivative into the table the order path
+-- reads, which is both a provenance failure and a correctness one (the two
+-- series differ by a consistent half-spread, −0.14% to −0.22%).
+--
+--
+-- WHY THE SERIES IS NOT KEYED ON instrument_id
+-- ---------------------------------------------------------------------------
+-- The obvious schema is `(instrument_id, bar_date)`, mirroring `price_daily`.
+-- It is wrong here, and wrong in the direction that destroys the evidence.
+--
+-- The corpus is keyed on the VENDOR'S symbol, and a large share of vendor
+-- symbols have no `instruments` row at all — the HF archive carries 7,693
+-- symbols against our 6,733 tradable US stocks, and the overlap is partial in
+-- both directions. Those unmatched symbols are not junk to be dropped: they
+-- are companies that were listed and are not on eToro's book today, i.e. they
+-- are the direct measure of **eToro-listing bias** (§4.0), a survivorship-
+-- shaped bias that #2284 did NOT measure and that buying a delisted corpus
+-- does NOT fix. An `instrument_id`-keyed table discards exactly that
+-- population at ingest and then cannot answer the question it was built for.
+--
+-- So: series identity is `(vendor, vendor_symbol)`. `instrument_id` is a
+-- NULLABLE resolution recorded with its method. **Unresolved is data, not an
+-- error.**
+--
+--
+-- WHY first_bar / last_bar / bar_count LIVE ON THE SERIES ROW
+-- ---------------------------------------------------------------------------
+-- This is the gap #2282 was filed to close. `instrument_price_supply`
+-- (sql/248) is a FRESHNESS tracker — `last_known_bar`,
+-- `consecutive_no_advance`, `last_attempt_at` — and carries neither a first
+-- bar nor a bar count. So "is this corpus survivor-biased?" was a 40-minute
+-- investigation during the #2284 spike, where `lse-data`'s catalog answered
+-- the same question in ONE call because it returns first/last/ticks per
+-- symbol.
+--
+-- Maintaining them at ingest rather than as a view over `research_price_daily`
+-- is deliberate: the archive is ~25.8M rows, and a census that requires a full
+-- scan is a census nobody runs. Denormalised, the census is an aggregate over
+-- ~7,693 narrow rows.
+--
+-- ⚠ The consequence is that they are DERIVED STATE and can drift from the
+-- bars. `research_series_census_drift` below is the reconciliation query; run
+-- it after any bulk load. Do not add a trigger — a per-row trigger on a 25.8M
+-- row COPY is the wrong trade, and the ingest owns the maintenance.
+
+-- ---------------------------------------------------------------------------
+-- Series identity + provenance
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS research_price_series (
+    series_id       BIGSERIAL PRIMARY KEY,
+
+    -- Identity. The vendor's own symbol, verbatim — NOT normalised to ours.
+    vendor          TEXT NOT NULL,
+    vendor_symbol   TEXT NOT NULL,
+
+    -- Provenance, recorded honestly. The HF archive is a Yahoo derivative
+    -- whose dataset card licence field reads "other"; #2284's close-out is
+    -- explicit that laundering that into "public data" is the failure the
+    -- prevention log names. `upstream_source` exists so a derivative can never
+    -- be mistaken for an independent source: two vendors that both resolve to
+    -- 'yahoo' are ONE observation, not two, and any cross-source agreement
+    -- between them is circular.
+    upstream_source TEXT NOT NULL
+        CHECK (upstream_source IN
+            ('yahoo', 'yahoo_derivative', 'firstratedata',
+             'historicaldata_net', 'etoro', 'other', 'unknown')),
+    licence         TEXT NOT NULL,
+
+    -- Adjustment basis. 'unknown' is a legitimate and common value and must
+    -- NOT default to an assumption: an unadjusted series with unknown splits
+    -- is not a usable TA input (§0.1(c2)), and silently treating one as
+    -- adjusted is how a corpus poisons every downstream indicator.
+    adjustment_basis TEXT NOT NULL
+        CHECK (adjustment_basis IN
+            ('unadjusted', 'split_adjusted',
+             'split_and_dividend_adjusted', 'unknown')),
+
+    -- Resolution to our universe. NULL instrument_id = "this series is a
+    -- company we do not carry", which is a MEASUREMENT, not a defect.
+    instrument_id   BIGINT REFERENCES instruments(instrument_id),
+    resolution_method TEXT
+        CHECK (resolution_method IN ('symbol_exact', 'cik', 'manual')),
+
+    -- Census columns — maintained by the ingest, reconciled by the drift
+    -- query below. NULL across all three = series row exists, no bars loaded.
+    -- ⚠ `bar_count = 0` is FORBIDDEN, not merely discouraged (see the
+    -- all-or-nothing constraint below). It would be a SECOND spelling of "no
+    -- bars", and two spellings of one state is how an audit metric goes quietly
+    -- wrong: `research_corpus_census.series_without_bars` counts
+    -- `bar_count IS NULL`, so a zero-valued row would vanish from it while the
+    -- drift view also considered it reconciled. Forbidding the ambiguity is
+    -- cheaper than teaching both views about it.
+    first_bar       DATE,
+    last_bar        DATE,
+    bar_count       INTEGER,
+
+    -- Delisting, where known. Populated from the Form 25 register (#2282 2c)
+    -- for US names and from #2290's forward record for non-US.
+    -- ⚠ This is the SUSPENSION date — the last tradable day — not the filing
+    -- date and not the removal-effective date. A Form 25 carries three
+    -- distinct dates plus master.idx's `filed`; picking the wrong one
+    -- mistruncates every series it touches. See sec-edgar.md §2.6 trap 5.
+    delisting_date  DATE,
+    delisting_source TEXT
+        CHECK (delisting_source IN ('sec_form25', 'universe_membership', 'vendor')),
+
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT research_price_series_vendor_symbol_uq
+        UNIQUE (vendor, vendor_symbol),
+    -- Ordered range, same invariant shape as instrument_symbol_history (103).
+    CONSTRAINT research_price_series_bars_ordered
+        CHECK (first_bar IS NULL OR last_bar IS NULL OR last_bar >= first_bar),
+    -- The census is all-or-nothing, and a populated census means >= 1 bar.
+    -- This is what makes "no bars" have exactly ONE representation.
+    CONSTRAINT research_price_series_census_all_or_nothing
+        CHECK (
+            (first_bar IS NULL AND last_bar IS NULL AND bar_count IS NULL)
+            OR (first_bar IS NOT NULL AND last_bar IS NOT NULL
+                AND bar_count IS NOT NULL AND bar_count > 0)
+        ),
+    -- A resolution without its method is an unauditable join — the exact
+    -- failure class the CUSIP/CIK identity work already guards against.
+    CONSTRAINT research_price_series_resolution_evidenced
+        CHECK ((instrument_id IS NULL) = (resolution_method IS NULL)),
+    CONSTRAINT research_price_series_delisting_evidenced
+        CHECK ((delisting_date IS NULL) = (delisting_source IS NULL))
+);
+
+-- Resolution is many-to-one at most: two vendor symbols may resolve to the
+-- same instrument only if they come from different vendors. Within one
+-- vendor, two symbols resolving to one instrument means the resolver has
+-- attached a ticker-reuse pair to a single company — the `SI` / Silvergate
+-- failure mode, where a 2025 series is welded onto a company that died in
+-- 2023.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_research_price_series_vendor_instrument
+    ON research_price_series (vendor, instrument_id)
+    WHERE instrument_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_research_price_series_instrument
+    ON research_price_series (instrument_id)
+    WHERE instrument_id IS NOT NULL;
+
+COMMENT ON TABLE research_price_series IS
+    'Research-corpus series identity, keyed on (vendor, vendor_symbol) NOT on '
+    'instrument_id — unmatched vendor symbols are the measure of eToro-listing '
+    'bias and must not be dropped at ingest. Carries the coverage census '
+    '(first_bar/last_bar/bar_count) that instrument_price_supply (sql/248) '
+    'lacks, plus provenance and the Form 25 SUSPENSION date.';
+
+COMMENT ON COLUMN research_price_series.upstream_source IS
+    'The ORIGINAL source, not the immediate vendor. Two vendors resolving to '
+    'yahoo are one observation — cross-source agreement between them is '
+    'circular. The HF archive is yahoo_derivative (29/29 identical first-bar '
+    'dates vs Yahoo, including Yahoo artefacts).';
+
+COMMENT ON COLUMN research_price_series.delisting_date IS
+    'SUSPENSION date — the last tradable day. NOT the Form 25 filing date and '
+    'NOT the removal-effective date; a Form 25 carries three distinct dates '
+    '(sec-edgar.md 2.6 trap 5). Using the wrong one mistruncates the series.';
+
+-- ---------------------------------------------------------------------------
+-- Bars
+-- ---------------------------------------------------------------------------
+--
+-- Deliberately NOT carrying the indicator columns price_daily has (sma_50,
+-- rsi_14, macd_*, ...). vectorbt/TA-Lib compute indicators over a series
+-- directly, so persisting an indicator history for the research corpus is
+-- storage and drift for no read — see the spec's §8 phase-2 note. Bars only.
+
+CREATE TABLE IF NOT EXISTS research_price_daily (
+    series_id   BIGINT NOT NULL
+        REFERENCES research_price_series(series_id) ON DELETE CASCADE,
+    bar_date    DATE NOT NULL,
+    open        NUMERIC,
+    high        NUMERIC,
+    low         NUMERIC,
+    close       NUMERIC NOT NULL,
+    volume      BIGINT,
+    PRIMARY KEY (series_id, bar_date)
+);
+
+COMMENT ON TABLE research_price_daily IS
+    'Research-corpus bars, keyed on series_id. No indicator columns by design '
+    '(vectorbt computes them over the series); no instrument_id by design '
+    '(see research_price_series).';
+
+-- ---------------------------------------------------------------------------
+-- The census — acceptance item 1 of #2282
+-- ---------------------------------------------------------------------------
+--
+-- Reports per asset class: instruments, first bar, last bar, bar count, and
+-- the count carrying a delisting record. Unresolved series are reported under
+-- a '(unresolved)' class rather than dropped — that row IS the eToro-listing
+-- bias measurement, and a census that hid it would defeat its own purpose.
+--
+-- ⚠ Per #2289/§4.0 the VALIDATED universe is `us_equity` AND
+-- instrument_type_id = 5 (US stocks ex-ETF, 6,733). The census reports by
+-- asset class alone, so a us_equity row here still mixes 555 ETFs in. Consumers
+-- gating on validation must apply the type filter themselves; this view is
+-- deliberately the wider picture.
+
+CREATE OR REPLACE VIEW research_corpus_census AS
+SELECT
+    COALESCE(e.asset_class, CASE WHEN s.instrument_id IS NULL
+                                 THEN '(unresolved)' ELSE '(unmapped)' END)
+                                                       AS asset_class,
+    s.vendor,
+    count(*)                                           AS series,
+    count(s.instrument_id)                             AS resolved_series,
+    min(s.first_bar)                                   AS earliest_first_bar,
+    max(s.last_bar)                                    AS latest_last_bar,
+    sum(s.bar_count)                                   AS bars,
+    count(*) FILTER (WHERE s.bar_count IS NULL)        AS series_without_bars,
+    count(s.delisting_date)                            AS series_with_delisting
+FROM research_price_series s
+LEFT JOIN instruments i ON i.instrument_id = s.instrument_id
+LEFT JOIN exchanges   e ON e.exchange_id::text = i.exchange
+GROUP BY 1, 2;
+
+COMMENT ON VIEW research_corpus_census IS
+    'Per asset-class corpus coverage: series, resolved series, first/last bar, '
+    'bar count, series carrying a delisting record. The (unresolved) row is '
+    'the eToro-listing-bias measurement and is reported, never filtered out.';
+
+-- Reconciliation for the denormalised census columns. The ingest maintains
+-- them; this is how you prove it did. Expected to return zero rows — any row
+-- is a series whose stored census disagrees with its bars.
+CREATE OR REPLACE VIEW research_series_census_drift AS
+SELECT
+    s.series_id,
+    s.vendor,
+    s.vendor_symbol,
+    s.first_bar   AS stored_first_bar,
+    b.first_bar   AS actual_first_bar,
+    s.last_bar    AS stored_last_bar,
+    b.last_bar    AS actual_last_bar,
+    s.bar_count   AS stored_bar_count,
+    b.bar_count   AS actual_bar_count
+FROM research_price_series s
+LEFT JOIN (
+    SELECT series_id,
+           min(bar_date)  AS first_bar,
+           max(bar_date)  AS last_bar,
+           count(*)::int  AS bar_count
+    FROM research_price_daily
+    GROUP BY series_id
+) b ON b.series_id = s.series_id
+-- ⚠ No COALESCE on bar_count. An earlier draft wrote
+-- `COALESCE(s.bar_count, 0) IS DISTINCT FROM COALESCE(b.bar_count, 0)`, which
+-- silently reconciled a series storing `bar_count = 0` against a series with no
+-- bar rows at all — a row that `series_without_bars` (keyed on IS NULL) also
+-- missed, so it was absent from both audits at once. The all-or-nothing
+-- constraint above now makes `bar_count = 0` unrepresentable, so a plain
+-- IS DISTINCT FROM is both correct and sufficient: NULL vs NULL reconciles,
+-- NULL vs a real count drifts.
+WHERE s.first_bar IS DISTINCT FROM b.first_bar
+   OR s.last_bar  IS DISTINCT FROM b.last_bar
+   OR s.bar_count IS DISTINCT FROM b.bar_count;
+
+COMMENT ON VIEW research_series_census_drift IS
+    'Reconciles the denormalised census columns against the actual bars. '
+    'Expected empty; run after any bulk load. Deliberately a view and not a '
+    'trigger — a per-row trigger on a 25.8M-row COPY is the wrong trade.';

--- a/sql/249_research_price_corpus.sql
+++ b/sql/249_research_price_corpus.sql
@@ -229,7 +229,10 @@ SELECT
     count(s.delisting_date)                            AS series_with_delisting
 FROM research_price_series s
 LEFT JOIN instruments i ON i.instrument_id = s.instrument_id
-LEFT JOIN exchanges   e ON e.exchange_id::text = i.exchange
+-- Both sides are TEXT; no cast. Matches the five existing call sites in app/
+-- (instruments.py, calendar.py). An earlier draft carried `e.exchange_id::text`,
+-- which is a no-op that reads as a papered-over type mismatch.
+LEFT JOIN exchanges   e ON e.exchange_id = i.exchange
 GROUP BY 1, 2;
 
 COMMENT ON VIEW research_corpus_census IS

--- a/tests/test_research_corpus_schema.py
+++ b/tests/test_research_corpus_schema.py
@@ -1,0 +1,206 @@
+"""Research-corpus schema invariants (#2282 stage 2a, sql/249).
+
+These are SQL-level invariants, not policy, so they get ONE DB-backed test for
+the genuinely-new mechanism rather than a file per code path (per the repo's
+lean-tests rule). What they pin down is the pair of decisions that a later
+change is most likely to "simplify" back out:
+
+1. **The series is keyed on (vendor, vendor_symbol), and `instrument_id` is
+   nullable.** An unresolved series is a MEASUREMENT — it is a company that was
+   listed and is not on eToro's book, i.e. the direct measure of eToro-listing
+   bias (#2289 §4.0). Making `instrument_id` NOT NULL would look like tidying
+   and would delete the evidence the census exists to produce.
+
+2. **The census columns are denormalised and therefore drift.** They live on
+   the series row so the census is an aggregate over ~7,693 rows instead of a
+   scan of ~25.8M bars. `research_series_census_drift` is how that trade is
+   kept honest, so it has to actually catch an unmaintained write.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+_VENDOR = "paperswithbacktest/Stocks-Daily-Price"
+
+
+def _new_series(
+    conn: psycopg.Connection[tuple],
+    symbol: str,
+    *,
+    instrument_id: int | None = None,
+    resolution_method: str | None = None,
+) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO research_price_series
+            (vendor, vendor_symbol, upstream_source, licence,
+             adjustment_basis, instrument_id, resolution_method)
+        VALUES (%s, %s, 'yahoo_derivative', 'other/unspecified',
+                'unknown', %s, %s)
+        RETURNING series_id
+        """,
+        (_VENDOR, symbol, instrument_id, resolution_method),
+    ).fetchone()
+    assert row is not None
+    conn.commit()
+    return row[0]
+
+
+@pytest.mark.db
+class TestSeriesIdentity:
+    def test_series_resolves_to_no_instrument(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """An unresolved series is legal and is reported, not dropped.
+
+        This is the whole reason the corpus is not keyed on instrument_id.
+        """
+        _new_series(ebull_test_conn, "UMPQ")
+
+        row = ebull_test_conn.execute(
+            "SELECT asset_class, series, resolved_series FROM research_corpus_census"
+        ).fetchone()
+        assert row == ("(unresolved)", 1, 0)
+
+    def test_resolution_without_method_is_rejected(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        seeded_instrument_id: int,
+    ) -> None:
+        """A join with no recorded evidence is unauditable.
+
+        Same failure class the CUSIP/CIK identity work already guards against:
+        an inferred mapping that cannot be re-checked later.
+        """
+        with pytest.raises(psycopg.errors.CheckViolation):
+            _new_series(ebull_test_conn, "AAPL", instrument_id=seeded_instrument_id)
+
+    def test_one_vendor_cannot_map_two_symbols_to_one_instrument(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        seeded_instrument_id: int,
+    ) -> None:
+        """The ticker-reuse guard, at the schema level.
+
+        Two symbols from ONE vendor resolving to one instrument means the
+        resolver has welded a later occupant of a ticker onto the company that
+        vacated it — the `SI` / Silvergate case, where a series beginning
+        2025-07-31 attaches to a company that failed in 2023.
+        """
+        _new_series(
+            ebull_test_conn,
+            "SI",
+            instrument_id=seeded_instrument_id,
+            resolution_method="symbol_exact",
+        )
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            _new_series(
+                ebull_test_conn,
+                "SI-DELISTED",
+                instrument_id=seeded_instrument_id,
+                resolution_method="symbol_exact",
+            )
+
+    def test_delisting_date_requires_its_source(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A delisting date whose provenance is unknown cannot be trusted to
+        truncate a series — a Form 25 carries three distinct dates and only the
+        suspension date is the last tradable day (sec-edgar.md §2.6 trap 5)."""
+        series_id = _new_series(ebull_test_conn, "FRCB")
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ebull_test_conn.execute(
+                "UPDATE research_price_series SET delisting_date = %s WHERE series_id = %s",
+                ("2023-05-01", series_id),
+            )
+
+    def test_upstream_source_vocabulary_is_closed(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Two vendors that both resolve to Yahoo are ONE observation.
+
+        An open text column lets a Yahoo derivative be recorded as something
+        independent, which makes a circular cross-source check look like
+        corroboration — the #2284 finding in one column.
+        """
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ebull_test_conn.execute(
+                """
+                INSERT INTO research_price_series
+                    (vendor, vendor_symbol, upstream_source, licence,
+                     adjustment_basis)
+                VALUES (%s, 'X', 'definitely_independent', 'mit', 'unknown')
+                """,
+                (_VENDOR,),
+            )
+
+
+@pytest.mark.db
+class TestCensusDrift:
+    def test_drift_view_catches_unmaintained_census_columns(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """Bars written without maintaining the denormalised census must show.
+
+        If this ever returns empty for an unmaintained write, the census is
+        silently wrong and every survivorship answer read off it is too.
+        """
+        series_id = _new_series(ebull_test_conn, "GME")
+        ebull_test_conn.execute(
+            "INSERT INTO research_price_daily (series_id, bar_date, close) "
+            "VALUES (%s, '2023-01-03', 10.5), (%s, '2023-02-28', 9.25)",
+            (series_id, series_id),
+        )
+        ebull_test_conn.commit()
+
+        row = ebull_test_conn.execute(
+            "SELECT stored_bar_count, actual_bar_count, actual_first_bar, "
+            "       actual_last_bar FROM research_series_census_drift"
+        ).fetchone()
+        assert row is not None
+        stored_count, actual_count, first_bar, last_bar = row
+        assert stored_count is None
+        assert actual_count == 2
+        assert str(first_bar) == "2023-01-03"
+        assert str(last_bar) == "2023-02-28"
+
+        ebull_test_conn.execute(
+            "UPDATE research_price_series SET first_bar = %s, last_bar = %s, bar_count = 2 WHERE series_id = %s",
+            ("2023-01-03", "2023-02-28", series_id),
+        )
+        ebull_test_conn.commit()
+
+        remaining = ebull_test_conn.execute("SELECT count(*) FROM research_series_census_drift").fetchone()
+        assert remaining == (0,)
+
+    def test_zero_bar_count_is_unrepresentable(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """ "No bars" must have exactly ONE spelling.
+
+        Regression for a real gap: the drift view used to compare
+        ``COALESCE(bar_count, 0)``, so a series storing ``bar_count = 0`` with
+        no bar rows reconciled cleanly — while ``series_without_bars`` (keyed on
+        ``IS NULL``) also missed it. The row was absent from BOTH audits at
+        once, which is the worst place for a row to be. The constraint now makes
+        the second spelling impossible rather than teaching each view about it.
+        """
+        series_id = _new_series(ebull_test_conn, "ZERO")
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ebull_test_conn.execute(
+                "UPDATE research_price_series "
+                "SET first_bar = '2023-01-03', last_bar = '2023-01-03', bar_count = 0 "
+                "WHERE series_id = %s",
+                (series_id,),
+            )
+
+    def test_census_columns_are_all_or_nothing(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        """A half-written census is worse than none — it reads as authoritative."""
+        series_id = _new_series(ebull_test_conn, "PARTIAL")
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ebull_test_conn.execute(
+                "UPDATE research_price_series SET first_bar = '2023-01-03' WHERE series_id = %s",
+                (series_id,),
+            )
+
+    def test_bars_ordered_constraint(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        series_id = _new_series(ebull_test_conn, "MSFT")
+        with pytest.raises(psycopg.errors.CheckViolation):
+            ebull_test_conn.execute(
+                "UPDATE research_price_series "
+                "SET first_bar = '2023-06-01', last_bar = '2020-01-01' "
+                "WHERE series_id = %s",
+                (series_id,),
+            )


### PR DESCRIPTION
Stage **2a** of #2282 — the schema and the per-instrument coverage census. Stages 2b (HF archive ingest) and 2c (Form 25 register) follow on separate branches; this one deliberately lands alone because it is the piece that fixes what the two after it write into.

`sql/249_research_price_corpus.sql` + one integration test. No ingest, no job, no endpoint.

## The decision that matters: the series is NOT keyed on `instrument_id`

The obvious schema mirrors `price_daily`: `(instrument_id, bar_date)`. It is wrong here, and wrong in the direction that destroys the evidence.

The corpus is keyed on the **vendor's** symbol, and a large share of vendor symbols have no `instruments` row — the HF archive carries **7,693 symbols** against our **6,733 tradable US stocks**, and the overlap is partial in both directions. Those unmatched symbols are not junk to drop. They are companies that *were* listed and are not on eToro's book today — the direct measure of **eToro-listing bias** (#2289 §4.0), a survivorship-shaped bias that #2284 did **not** measure and that buying a delisted corpus does **not** fix.

An `instrument_id`-keyed table discards exactly that population at ingest and then cannot answer the question it was built for. So series identity is `(vendor, vendor_symbol)`, and `instrument_id` is a **nullable resolution recorded with its method**. Unresolved is data, not an error — the census reports it as an `(unresolved)` row rather than filtering it out.

## The census columns, and why they are denormalised

`first_bar` / `last_bar` / `bar_count` live **on the series row**. This is the gap #2282 was filed to close: `instrument_price_supply` (`sql/248`) is a *freshness* tracker — `last_known_bar`, `consecutive_no_advance`, `last_attempt_at` — and carries neither a first bar nor a bar count. That is why *"is this corpus survivor-biased?"* was a 40-minute investigation during the #2284 spike, when `lse-data`'s catalog answered the same question in one call by returning first/last/ticks per symbol.

Maintaining them at ingest rather than as a view over the bars is the deliberate trade: the archive is ~25.8M rows, and a census requiring a full scan is a census nobody runs. Denormalised, it is an aggregate over ~7,693 narrow rows. `research_series_census_drift` is the reconciliation that keeps the trade honest — expected empty, run after any bulk load. **No trigger**: a per-row trigger on a 25.8M-row `COPY` is the wrong trade, and the ingest owns the maintenance.

## Three traps encoded as constraints rather than comments

- **`delisting_date` is the SUSPENSION date** — the last tradable day, not the filing date and not the removal-effective date. A Form 25 carries three distinct dates plus `master.idx`'s `filed` (`sec-edgar.md` §2.6 trap 5), and picking the wrong one mistruncates every series it touches. `CHECK` pairs it with its source.
- **`upstream_source` is a closed vocabulary.** Two vendors that both resolve to Yahoo are **one** observation, so agreement between them is circular, not corroboration — the #2284 finding in one column. An open text column would let a Yahoo derivative be recorded as independent.
- **A partial unique index on `(vendor, instrument_id)`** blocks the ticker-reuse weld at the schema level: two symbols from one vendor resolving to one instrument means the resolver has attached a later occupant of a ticker to the company that vacated it — the `SI` / Silvergate case, where a series beginning 2025-07-31 lands on a company that failed in 2023.

## Review

**Codex checkpoint 2 found one real P2**, and it is a good one. The drift view compared `COALESCE(s.bar_count, 0) IS DISTINCT FROM COALESCE(b.bar_count, 0)`, so a series storing `bar_count = 0` with no bar rows reconciled cleanly — while `series_without_bars` (keyed on `IS NULL`) *also* missed it. The row was absent from **both** audits at once, which is the worst place for a row to be.

Fixed by removing the ambiguity rather than teaching two views to agree about it: a census-all-or-nothing constraint with `bar_count > 0` when set makes the second spelling of "no bars" unrepresentable, and the drift view drops the `COALESCE`. Regression test added (`test_zero_bar_count_is_unrepresentable`), and the rationale is written into the SQL at both sites so a future simplification does not reintroduce it.

Ran with the new file **staged** — an unstaged new file is invisible to `codex exec review` and on #2262 that cost a full round.

## Verification

Definition-of-Done clauses 8-12 (smoke panel / cross-source / backfill / live figure) **do not apply**: this creates new, empty tables and changes no existing row, no parser and no read path. There is likewise no full-population A/B to run — an A/B needs a control, and there is no prior state of these tables. Stage 2b, which actually ingests, is where both gates bite.

What was verified, on the real dev DB at `3578e884`:

| check | result |
| --- | --- |
| Migration applies | `run_migrations()` → `['249_research_price_corpus.sql']` |
| Migration re-applies cleanly after edit | dropped objects + `schema_migrations` row, re-ran — clean (avoids the #1333 content-drift trap) |
| `research_corpus_census` | returns the `(unresolved)` row for an unmatched series |
| `research_series_census_drift` | catches an unmaintained write (`stored NULL` vs `actual 2`), clears to 0 after maintenance |
| resolution without method | `CheckViolation` |
| `last_bar` before `first_bar` | `CheckViolation` |
| delisting date without source | `CheckViolation` |
| `upstream_source = 'definitely_independent'` | `CheckViolation` |
| `bar_count = 0` | `CheckViolation` (the Codex P2) |
| partial census write | `CheckViolation` |
| `ON DELETE CASCADE` | bars removed with the series |
| `_PLANNER_TABLES` | **no edit needed** — derived the inbound-FK closure the fixture builds and confirmed it reaches both new tables via `instruments`, per the tuple's own documented rule. Verified rather than assumed |

Gates: `ruff check` / `ruff format --check` clean, `pyright` 0 errors, fast tier exit 0, smoke exit 0, `-m db` on the new file exit 0 (gated on exit code — this repo's pytest config suppresses the `N passed` line).

## Security model

Not applicable. No authentication or authorisation surface, no user-controlled input, no order path. All SQL in the test is parameterised. The one provenance-adjacent point is deliberate and stated in the schema: the HF archive is a Yahoo derivative under an unspecified licence, and `upstream_source` / `licence` exist so that is recorded rather than laundered — the failure #2284's close-out names.

Refs #2282. Refs #2240. Refs #2289.