### PR TITLE
feat(#2282): research corpus stage 2b — HF archive ingest + CIK column

### DIFF
--- a/app/services/research_corpus_ingest.py
+++ b/app/services/research_corpus_ingest.py
@@ -1,0 +1,803 @@
+"""#2282 stage 2b — load the Hugging Face daily-price archive into the research corpus.
+
+``paperswithbacktest/Stocks-Daily-Price``: 4 Parquet shards, ~525 MB,
+25.8M rows, 7,693 symbols, 1962→2026, ~30 s to download.
+
+WHY THIS ARCHIVE AND NOT yfinance
+---------------------------------
+We never run a scraper. Yahoo's ToS §2.4(i) binds the *collector*; downloading
+a third party's already-published file does not put us in that role. The
+archive is nonetheless a Yahoo derivative (29/29 identical first-bar dates
+against Yahoo, including Yahoo's own artefacts — ``ATCX`` starting 2026-01-09
+is in this file too), so ``upstream_source`` records ``yahoo_derivative`` and
+never ``other``. Two vendors that both resolve to Yahoo are ONE observation;
+agreement between them is circular, not corroborating. See
+``.claude/skills/data-sources/research-price-corpus.md``.
+
+WHAT THIS IS NOT
+----------------
+Not ``price_daily``. That is the eToro-sourced EXECUTION view the order path
+reads. This is the RESEARCH corpus — third-party provenance, unspecified
+licence, deep history. sql/249's header states the separation at length.
+
+TWO PHASES, DELIBERATELY
+------------------------
+1. ``load_archive`` — series upsert, then bars via COPY, then the denormalised
+   census columns from a Python-side accumulator.
+2. ``run_quarantine`` — reads each series back from Postgres in date order and
+   runs the #2261 rule set over it.
+
+They are separate because the quarantine rules need a *complete* series in
+ascending date order (B4 and T1-T3 all read neighbours), and a symbol can
+straddle a Parquet row-group or shard boundary. Evaluating per-shard would
+produce a wrong verdict at every seam. Reading back from Postgres is a few
+minutes and is correct by construction. Both phases are independently
+idempotent.
+
+NOT IN scripts/check_bulk_ingest_copy_pattern.sh's whitelist
+------------------------------------------------------------
+That lint is scoped to the *ownership* dataset ingesters — its rule D.1
+requires ``INSERT INTO ownership_*`` as the drain, which this file will never
+have. The COPY-into-``_stg_``-then-``INSERT…SELECT…ON CONFLICT`` pattern it
+enforces is followed here regardless; only the registration is inapplicable.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import psycopg
+
+from app.services.price_quarantine import (
+    RULE_SET_VERSION,
+    Bar,
+    evaluate_series,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Provenance — recorded verbatim, per the #2282 handoff.
+# ---------------------------------------------------------------------------
+
+VENDOR = "paperswithbacktest/Stocks-Daily-Price"
+
+#: A Yahoo scrape, established by fingerprint rather than by the dataset card.
+UPSTREAM_SOURCE = "yahoo_derivative"
+
+#: The card's licence field literally reads "other". Not laundered into
+#: "public domain" or "MIT" — an unspecified licence is a real state.
+LICENCE = "other/unspecified"
+
+#: ⚠ VERIFIED, not assumed. The handoff said to record 'unknown' and to
+#: "verify it before claiming it"; sql/251's header carries the evidence:
+#: AAPL 2020-08-27 close = 125.01 against an unadjusted ~$500 and a 4:1 split
+#: settling 2020-08-31, so OHLC are split-adjusted. `adj_close` additionally
+#: carries the dividend adjustment (it differs from `close` for AAPL/CSCO and
+#: is identical for AMZN/AAL/BRK-A) and is stored in its own column, because
+#: for a dividend payer it sits OUTSIDE [low, high].
+ADJUSTMENT_BASIS = "split_adjusted"
+
+#: Asset class handed to the quarantine rule set. Every symbol in this archive
+#: is a US listing; ``params_for`` reads this to pick the 5-day-week
+#: continuity parameters.
+_ASSET_CLASS = "us_equity"
+
+#: eToro publishes venue variants of the same company as separate instrument
+#: rows — ``AAPL``, ``AAPL.RTH`` (regular trading hours) and ``AAPL.24-7``.
+#: They are the same issuer on a different session, and 536 of the 558 ``.RTH``
+#: rows say so themselves via ``canonical_instrument_id``. Resolving a research
+#: series onto a venue variant would attach deep history to the wrong row and
+#: consume the ``uq_research_price_series_vendor_instrument`` slot the real
+#: instrument needs.
+_VENUE_VARIANT_SUFFIXES = (".RTH", ".24-7")
+
+#: eToro suffixes some US primary listings ``.US`` where no bare symbol exists
+#: (``ABT.US`` is Abbott; there is no ``ABT`` row). Stripped for matching.
+_PRIMARY_LISTING_SUFFIX = ".US"
+
+
+# ---------------------------------------------------------------------------
+# Census of the load itself
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LoadCensus:
+    """What the load did, including everything it could not do.
+
+    Reported in full — a coverage figure that omits its own failures is the
+    thing #2282 exists to prevent.
+    """
+
+    symbols_seen: int = 0
+    series_upserted: int = 0
+    bars_copied: int = 0
+
+    #: Rows the archive supplies with no close at all (NaN). A bar without a
+    #: close is not a price observation, and ``research_price_daily.close`` is
+    #: NOT NULL. This is absence of data, NOT a price judgement — no floor, no
+    #: threshold. Counted so the drop is never silent.
+    rows_without_close: int = 0
+
+    #: (symbol, date) pairs the archive repeats. Drained via ON CONFLICT, so
+    #: the last one wins; counted so a vendor-side duplication is visible.
+    duplicate_bar_rows: int = 0
+
+    resolved_series: int = 0
+    unresolved_series: int = 0
+    #: Vendor symbols that matched more than one instrument after
+    #: normalisation. Left UNRESOLVED rather than guessed — an ambiguous join
+    #: recorded as ``symbol_exact`` would be a lie about its own evidence.
+    ambiguous_symbols: list[str] = field(default_factory=list)
+
+    #: Ticker-reuse guard (handoff obligation 3). See ``reuse_guard_note``.
+    reuse_guard_checked: int = 0
+    reuse_guard_uncheckable: int = 0
+
+    @property
+    def reuse_guard_note(self) -> str:
+        return (
+            f"ticker-reuse guard: {self.reuse_guard_checked} series checked at "
+            f"ingest, {self.reuse_guard_uncheckable} UNCHECKABLE HERE — the "
+            "schema holds no listing date. instruments.first_seen_at is the "
+            "eToro DETECTION date (#2290), not a listing date, and using it "
+            "would reject every series with real pre-2025 history; #2290's "
+            "forward record is what eventually supplies one. The delisting "
+            "half needs stage 2c's Form 25 suspension dates. ⚠ A DIFFERENT "
+            "discriminator does work and is run by `--verify`: return "
+            "correlation against price_daily over the shared window. It "
+            "reaches only the series with eToro overlap, and separating "
+            "reuse from split-epoch from eToro-side defects is #2293."
+        )
+
+
+@dataclass
+class QuarantineCensus:
+    series_evaluated: int = 0
+    bars_evaluated: int = 0
+    transitions_evaluated: int = 0
+    bar_verdicts_written: int = 0
+    transition_verdicts_written: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Symbol resolution
+# ---------------------------------------------------------------------------
+
+
+def normalise_vendor_symbol(symbol: str) -> str:
+    """Vendor symbol → our symbol spelling.
+
+    Yahoo (and therefore this archive) spells a share class with a hyphen —
+    ``BRK-A``, ``BF-B``. We spell it with a dot, matching the exchange's own
+    convention: ``BRK.B``. US tickers carry no native hyphen, so the
+    substitution is unambiguous.
+    """
+    return symbol.strip().upper().replace("-", ".")
+
+
+def index_instruments(
+    rows: Sequence[tuple[int, str]],
+) -> tuple[dict[str, int], set[str]]:
+    """``(instrument_id, symbol)`` rows → lookup key → instrument_id, plus ambiguous keys.
+
+    Pure, so the resolution policy is table-testable without a database — which
+    is where the interesting cases are (venue variants, ``.US`` collisions,
+    two instruments claiming one key).
+
+    Venue variants are excluded outright rather than deduplicated afterwards,
+    so a collision that survives into ``ambiguous`` is a genuine
+    two-instruments-one-symbol case and not eToro session bookkeeping.
+    """
+    index: dict[str, int] = {}
+    ambiguous: set[str] = set()
+    for instrument_id, symbol in rows:
+        sym = symbol.strip().upper()
+        if sym.endswith(_VENUE_VARIANT_SUFFIXES):
+            continue
+        if sym.endswith(_PRIMARY_LISTING_SUFFIX):
+            sym = sym[: -len(_PRIMARY_LISTING_SUFFIX)]
+        if sym in index and index[sym] != instrument_id:
+            ambiguous.add(sym)
+            continue
+        index[sym] = instrument_id
+
+    for sym in ambiguous:
+        index.pop(sym, None)
+    return index, ambiguous
+
+
+def build_symbol_index(conn: psycopg.Connection[Any]) -> tuple[dict[str, int], set[str]]:
+    """``index_instruments`` over #2289's validated universe.
+
+    Scoped to ``asset_class = 'us_equity'`` AND ``instrument_type_id = 5`` (US
+    stocks ex-ETF). ``us_equity`` alone is an EXCHANGE class and mixes in
+    several hundred ETFs — #2289 §4.0.
+    """
+    rows = conn.execute(
+        """
+        SELECT i.instrument_id, i.symbol
+        FROM instruments i
+        JOIN exchanges e ON e.exchange_id = i.exchange
+        WHERE e.asset_class = 'us_equity'
+          AND i.instrument_type_id = 5
+        """
+    ).fetchall()
+    return index_instruments([(int(r[0]), str(r[1])) for r in rows])
+
+
+# ---------------------------------------------------------------------------
+# Parquet reading
+# ---------------------------------------------------------------------------
+
+
+def _decimal(value: object) -> Decimal | None:
+    """Parquet double → Decimal, with NaN and infinity read as absent.
+
+    The archive uses NaN for a missing field rather than null. ``Decimal(str(nan))``
+    raises ``InvalidOperation``, so this is not optional defensiveness.
+    """
+    if value is None:
+        return None
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        return Decimal(str(value))
+    if isinstance(value, (int, Decimal)):
+        return Decimal(value)
+    return None
+
+
+@dataclass(frozen=True)
+class _Row:
+    symbol: str
+    bar_date: date
+    open: Decimal | None
+    high: Decimal | None
+    low: Decimal | None
+    close: Decimal | None
+    volume: int | None
+    adj_close: Decimal | None
+
+
+def iter_archive_symbols(paths: Sequence[Path]) -> Iterator[str]:
+    """Distinct symbols, reading ONLY the symbol column.
+
+    Parquet is columnar, so this touches a few MB rather than decoding 25.8M
+    rows of OHLCV to learn 7,693 strings.
+    """
+    import pyarrow.parquet as pq  # local import — pyarrow is heavy and only needed here
+
+    for path in paths:
+        reader = pq.ParquetFile(path)
+        for group in range(reader.metadata.num_row_groups):
+            table = reader.read_row_group(group, columns=["symbol"])
+            yield from table.column("symbol").unique().to_pylist()
+
+
+def iter_archive_rows(paths: Sequence[Path]) -> Iterator[_Row]:
+    """Stream the archive one Parquet row group at a time.
+
+    Row-group at a time rather than whole-file: a shard is ~6.5M rows and
+    materialising one as Python objects is several GB.
+    """
+    import pyarrow.parquet as pq  # local import — pyarrow is heavy and only needed here
+
+    for path in paths:
+        reader = pq.ParquetFile(path)
+        for group in range(reader.metadata.num_row_groups):
+            cols = reader.read_row_group(group).to_pydict()
+            for sym, bar_date, o, h, low, c, v, ac in zip(
+                cols["symbol"],
+                cols["date"],
+                cols["open"],
+                cols["high"],
+                cols["low"],
+                cols["close"],
+                cols["volume"],
+                cols["adj_close"],
+                strict=True,
+            ):
+                yield _Row(
+                    symbol=sym,
+                    bar_date=date.fromisoformat(bar_date),
+                    open=_decimal(o),
+                    high=_decimal(h),
+                    low=_decimal(low),
+                    close=_decimal(c),
+                    volume=int(v) if v is not None else None,
+                    adj_close=_decimal(ac),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — load
+# ---------------------------------------------------------------------------
+
+_STAGE_DDL = """
+CREATE TEMP TABLE _stg_research_bars (
+    -- Surrogate ordinal so the de-duplication below has a deterministic
+    -- "last one" to keep. COPY preserves insertion order into the heap, but
+    -- SELECT order is not guaranteed, so relying on it would be a bug that
+    -- only shows up under a parallel plan.
+    row_ordinal   BIGSERIAL,
+    vendor_symbol TEXT NOT NULL,
+    bar_date      DATE NOT NULL,
+    open          NUMERIC,
+    high          NUMERIC,
+    low           NUMERIC,
+    close         NUMERIC NOT NULL,
+    volume        BIGINT,
+    adj_close     NUMERIC
+) ON COMMIT DROP
+"""
+
+# ⚠ DISTINCT ON is load-bearing, not tidiness. Postgres raises
+# `cardinality_violation: ON CONFLICT DO UPDATE command cannot affect row a
+# second time` when the SELECT feeding an upsert contains the conflict key
+# twice — so a repeated (symbol, date) in one 500k-row batch would abort the
+# whole flush rather than resolving to "last one wins". The same trap is
+# documented in app/services/sec_13f_dataset_ingest.py.
+#
+# The 2026-08-05 load found zero duplicates in this archive, which is exactly
+# why this has to be right by construction: the failure mode is invisible until
+# the vendor republishes with one, and then it takes out a 25.8M-row load.
+_DRAIN_SQL = """
+INSERT INTO research_price_daily
+    (series_id, bar_date, open, high, low, close, volume, adj_close)
+SELECT DISTINCT ON (s.series_id, g.bar_date)
+       s.series_id, g.bar_date, g.open, g.high, g.low, g.close, g.volume, g.adj_close
+FROM _stg_research_bars g
+JOIN research_price_series s
+  ON s.vendor = %(vendor)s AND s.vendor_symbol = g.vendor_symbol
+ORDER BY s.series_id, g.bar_date, g.row_ordinal DESC
+ON CONFLICT (series_id, bar_date) DO UPDATE SET
+    open      = EXCLUDED.open,
+    high      = EXCLUDED.high,
+    low       = EXCLUDED.low,
+    close     = EXCLUDED.close,
+    volume    = EXCLUDED.volume,
+    adj_close = EXCLUDED.adj_close
+"""
+
+
+def upsert_series(
+    conn: psycopg.Connection[Any],
+    symbols: Sequence[str],
+    index: dict[str, int],
+    ambiguous: set[str],
+    census: LoadCensus,
+) -> None:
+    """Create one series row per vendor symbol, resolved where we can resolve it.
+
+    ⚠ An unresolved series is NOT an error and is NOT skipped. It is a company
+    that was listed and is not on eToro's book, i.e. the only measurement we
+    have of eToro-listing bias — see sql/249's header. Dropping it here would
+    delete the evidence the corpus exists to produce.
+    """
+    taken: set[int] = set()
+    payload: list[tuple[str, str, str, str, str, int | None, str | None]] = []
+    for symbol in symbols:
+        key = normalise_vendor_symbol(symbol)
+        instrument_id = index.get(key)
+        if key in ambiguous:
+            census.ambiguous_symbols.append(symbol)
+        if instrument_id is not None and instrument_id in taken:
+            # Two vendor symbols normalising onto one instrument within a
+            # vendor is the ticker-reuse pair the partial unique index rejects.
+            # Leave the second unresolved and counted rather than letting the
+            # insert fail the whole batch.
+            census.ambiguous_symbols.append(symbol)
+            instrument_id = None
+        if instrument_id is not None:
+            taken.add(instrument_id)
+        payload.append(
+            (
+                VENDOR,
+                symbol,
+                UPSTREAM_SOURCE,
+                LICENCE,
+                ADJUSTMENT_BASIS,
+                instrument_id,
+                "symbol_exact" if instrument_id is not None else None,
+            )
+        )
+
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO research_price_series
+                (vendor, vendor_symbol, upstream_source, licence,
+                 adjustment_basis, instrument_id, resolution_method)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (vendor, vendor_symbol) DO UPDATE SET
+                upstream_source   = EXCLUDED.upstream_source,
+                licence           = EXCLUDED.licence,
+                adjustment_basis  = EXCLUDED.adjustment_basis,
+                instrument_id     = EXCLUDED.instrument_id,
+                resolution_method = EXCLUDED.resolution_method,
+                updated_at        = now()
+            """,
+            payload,
+        )
+
+    census.series_upserted = len(payload)
+    census.resolved_series = sum(1 for row in payload if row[5] is not None)
+    census.unresolved_series = census.series_upserted - census.resolved_series
+    # Obligation 3: say what the guard could NOT check.
+    census.reuse_guard_uncheckable = census.resolved_series
+
+
+def load_archive(
+    conn: psycopg.Connection[Any],
+    paths: Sequence[Path],
+    *,
+    batch_rows: int = 500_000,
+) -> LoadCensus:
+    """Two passes over the archive: symbols, then bars.
+
+    The first pass is needed because a bar cannot be staged without a
+    ``series_id``, and the archive is not guaranteed sorted by symbol. It reads
+    one column, so it is cheap.
+    """
+    census = LoadCensus()
+
+    logger.info("pass 1/2: collecting symbols from %d shard(s)", len(paths))
+    symbols = sorted(set(iter_archive_symbols(paths)))
+    census.symbols_seen = len(symbols)
+
+    index, ambiguous = build_symbol_index(conn)
+    logger.info(
+        "resolving %d vendor symbols against %d us_equity type-5 instruments (%d ambiguous keys excluded)",
+        len(symbols),
+        len(index),
+        len(ambiguous),
+    )
+    upsert_series(conn, symbols, index, ambiguous, census)
+    conn.commit()
+
+    logger.info("pass 2/2: loading bars")
+    # (first_bar, last_bar, rows_staged) accumulated per symbol — ~7,693 narrow
+    # entries, so O(symbols) memory rather than O(bars).
+    #
+    # ⚠ This is deliberately the count of rows STAGED, not of distinct bars. A
+    # per-(symbol, date) dedup set over 25.8M rows would be ~2.5 GB, so vendor
+    # duplication is detected AFTER the load instead: the drain collapses
+    # duplicates via ON CONFLICT, so a symbol the archive repeats ends up with
+    # a stored bar_count higher than its actual bar rows, and
+    # `research_series_census_drift` reports it by name. That makes the drift
+    # assert a real check rather than a tautology — writing the census from the
+    # same aggregate the drift view reads would reconcile by construction and
+    # prove nothing.
+    stats: dict[str, tuple[date, date, int]] = {}
+
+    batch: list[tuple[Any, ...]] = []
+
+    def flush() -> None:
+        if not batch:
+            return
+        with conn.cursor() as cur:
+            cur.execute(_STAGE_DDL)
+            copy_sql = (
+                "COPY _stg_research_bars "
+                "(vendor_symbol, bar_date, open, high, low, close, volume, adj_close) "
+                "FROM STDIN"
+            )
+            with cur.copy(copy_sql) as copy:
+                for record in batch:
+                    copy.write_row(record)
+            cur.execute(_DRAIN_SQL, {"vendor": VENDOR})
+        conn.commit()  # ON COMMIT DROP releases the TEMP table
+        batch.clear()
+
+    for row in iter_archive_rows(paths):
+        if row.close is None:
+            census.rows_without_close += 1
+            continue
+        prior = stats.get(row.symbol)
+        if prior is None:
+            stats[row.symbol] = (row.bar_date, row.bar_date, 1)
+        else:
+            stats[row.symbol] = (
+                min(prior[0], row.bar_date),
+                max(prior[1], row.bar_date),
+                prior[2] + 1,
+            )
+
+        batch.append(
+            (
+                row.symbol,
+                row.bar_date,
+                row.open,
+                row.high,
+                row.low,
+                row.close,
+                row.volume,
+                row.adj_close,
+            )
+        )
+        census.bars_copied += 1
+        if len(batch) >= batch_rows:
+            flush()
+            logger.info("  %s bars loaded", f"{census.bars_copied:,}")
+    flush()
+
+    _write_census(conn, stats)
+    census.duplicate_bar_rows = reconcile_census(conn, VENDOR)
+    return census
+
+
+def _write_census(
+    conn: psycopg.Connection[Any],
+    stats: dict[str, tuple[date, date, int]],
+) -> None:
+    """Set the denormalised census columns from the load accumulator.
+
+    ⚠ ``bar_count = 0`` is unrepresentable by CHECK constraint (sql/249): "no
+    bars" has exactly one spelling, all three NULL. A symbol whose every row
+    lacked a close therefore never appears in ``stats`` and keeps its NULLs,
+    which is the correct state and not a gap.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            CREATE TEMP TABLE _stg_research_census (
+                vendor_symbol TEXT NOT NULL,
+                first_bar     DATE NOT NULL,
+                last_bar      DATE NOT NULL,
+                bar_count     INTEGER NOT NULL
+            ) ON COMMIT DROP
+            """
+        )
+        with cur.copy("COPY _stg_research_census (vendor_symbol, first_bar, last_bar, bar_count) FROM STDIN") as copy:
+            for symbol, (first, last, count) in stats.items():
+                copy.write_row((symbol, first, last, count))
+        cur.execute(
+            """
+            UPDATE research_price_series s
+               SET first_bar = g.first_bar,
+                   last_bar  = g.last_bar,
+                   bar_count = g.bar_count,
+                   updated_at = now()
+              FROM _stg_research_census g
+             WHERE s.vendor = %(vendor)s
+               AND s.vendor_symbol = g.vendor_symbol
+            """,
+            {"vendor": VENDOR},
+        )
+    conn.commit()
+    logger.info("census written for %d series", len(stats))
+
+
+def reconcile_census(conn: psycopg.Connection[Any], vendor: str) -> int:
+    """Correct any series the drift view disagrees with, and report the delta.
+
+    Runs ONCE, immediately after a bulk load, and only over series the drift
+    view actually names — so it is a targeted repair, not a re-derivation that
+    would make the subsequent drift assert meaningless.
+
+    The realistic cause is vendor duplication: the drain collapses repeated
+    (symbol, date) rows via ON CONFLICT while the accumulator counted each one.
+    Returns the total number of staged rows that turned out to be duplicates,
+    which is the figure ``LoadCensus.duplicate_bar_rows`` reports.
+    """
+    rows = conn.execute(
+        """
+        SELECT d.series_id, d.vendor_symbol,
+               d.stored_first_bar, d.actual_first_bar,
+               d.stored_last_bar,  d.actual_last_bar,
+               d.stored_bar_count, d.actual_bar_count
+        FROM research_series_census_drift d
+        WHERE d.vendor = %s
+        """,
+        (vendor,),
+    ).fetchall()
+
+    duplicates = 0
+    for (
+        series_id,
+        symbol,
+        stored_first,
+        actual_first,
+        stored_last,
+        actual_last,
+        stored_count,
+        actual_count,
+    ) in rows:
+        logger.warning(
+            "census drift on %s: first %s->%s last %s->%s count %s->%s",
+            symbol,
+            stored_first,
+            actual_first,
+            stored_last,
+            actual_last,
+            stored_count,
+            actual_count,
+        )
+        if stored_count is not None and actual_count is not None:
+            duplicates += max(0, int(stored_count) - int(actual_count))
+        conn.execute(
+            """
+            UPDATE research_price_series
+               SET first_bar = %s, last_bar = %s, bar_count = %s, updated_at = now()
+             WHERE series_id = %s
+            """,
+            (actual_first, actual_last, actual_count, series_id),
+        )
+    conn.commit()
+    if rows:
+        logger.warning("reconciled %d drifting series (%d duplicate rows)", len(rows), duplicates)
+    return duplicates
+
+
+def census_drift(conn: psycopg.Connection[Any]) -> int:
+    """Rows in ``research_series_census_drift``. MUST be 0 after a load.
+
+    The denormalised census columns are derived state with no trigger behind
+    them (a per-row trigger on a 25.8M-row COPY is the wrong trade), so this is
+    the only thing standing between "the ingest maintained them" and "the
+    ingest was believed to have maintained them".
+    """
+    row = conn.execute("SELECT count(*) FROM research_series_census_drift").fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — quarantine
+# ---------------------------------------------------------------------------
+
+
+def run_quarantine(
+    conn: psycopg.Connection[Any],
+    *,
+    vendor: str = VENDOR,
+    as_of: date,
+) -> QuarantineCensus:
+    """Run the #2261 rule set over every loaded series.
+
+    Rules are imported from ``app.services.price_quarantine`` and NOT
+    re-expressed here. One rule set, one implementation — a second copy in SQL
+    is how a closed vocabulary ends up with three spellings and a live 500.
+
+    Nothing is deleted and nothing is filtered. A failed company's last bar at
+    $0.0004 is the signal; a price floor here would be a survivorship filter
+    wearing a data-quality hat.
+    """
+    census = QuarantineCensus()
+    series = conn.execute(
+        """
+        SELECT series_id FROM research_price_series
+        WHERE vendor = %s AND bar_count IS NOT NULL
+        ORDER BY series_id
+        """,
+        (vendor,),
+    ).fetchall()
+
+    for (series_id,) in series:
+        rows = conn.execute(
+            """
+            SELECT bar_date, open, high, low, close, volume
+            FROM research_price_daily
+            WHERE series_id = %s
+            ORDER BY bar_date
+            """,
+            (series_id,),
+        ).fetchall()
+        if not rows:
+            continue
+        bars = [
+            Bar(
+                price_date=r[0],
+                open=r[1],
+                high=r[2],
+                low=r[3],
+                close=r[4],
+                volume=Decimal(r[5]) if r[5] is not None else None,
+            )
+            for r in rows
+        ]
+        verdicts = evaluate_series(bars, _ASSET_CLASS, as_of=as_of)
+
+        bar_rows = [
+            (
+                series_id,
+                v.price_date,
+                v.return_usable,
+                v.range_usable,
+                v.provisional,
+                list(v.rules),
+                RULE_SET_VERSION,
+            )
+            for v in verdicts.bars
+            if v.notable
+        ]
+        trans_rows = [
+            (
+                series_id,
+                v.price_date,
+                v.prior_date,
+                v.observed_ratio,
+                v.provisional,
+                list(v.rules),
+                v.turnover_ratio,
+                v.corroboration,
+                RULE_SET_VERSION,
+            )
+            for v in verdicts.transitions
+            if v.notable
+        ]
+
+        with conn.cursor() as cur:
+            # Replace this series' verdicts wholesale: a rule-set change must
+            # not leave a stale verdict from an older version behind, and the
+            # coverage row is what says which version a series was judged at.
+            cur.execute("DELETE FROM research_bar_quarantine WHERE series_id = %s", (series_id,))
+            cur.execute("DELETE FROM research_transition_quarantine WHERE series_id = %s", (series_id,))
+            if bar_rows:
+                cur.executemany(
+                    """
+                    INSERT INTO research_bar_quarantine
+                        (series_id, bar_date, return_usable, range_usable,
+                         provisional, rules, rule_set_version)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    bar_rows,
+                )
+            if trans_rows:
+                cur.executemany(
+                    """
+                    INSERT INTO research_transition_quarantine
+                        (series_id, bar_date, prior_date, observed_ratio,
+                         provisional, rules, turnover_ratio, corroboration,
+                         rule_set_version)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    trans_rows,
+                )
+            cur.execute(
+                """
+                INSERT INTO research_price_quarantine_coverage
+                    (series_id, rule_set_version, first_bar, last_bar,
+                     bars_evaluated, transitions_evaluated)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (series_id) DO UPDATE SET
+                    rule_set_version      = EXCLUDED.rule_set_version,
+                    first_bar             = EXCLUDED.first_bar,
+                    last_bar              = EXCLUDED.last_bar,
+                    bars_evaluated        = EXCLUDED.bars_evaluated,
+                    transitions_evaluated = EXCLUDED.transitions_evaluated,
+                    evaluated_at          = now()
+                """,
+                (
+                    series_id,
+                    RULE_SET_VERSION,
+                    bars[0].price_date,
+                    bars[-1].price_date,
+                    len(bars),
+                    len(verdicts.transitions),
+                ),
+            )
+        conn.commit()
+
+        census.series_evaluated += 1
+        census.bars_evaluated += len(bars)
+        census.transitions_evaluated += len(verdicts.transitions)
+        census.bar_verdicts_written += len(bar_rows)
+        census.transition_verdicts_written += len(trans_rows)
+        if census.series_evaluated % 500 == 0:
+            logger.info(
+                "  quarantine: %d series / %s bars",
+                census.series_evaluated,
+                f"{census.bars_evaluated:,}",
+            )
+
+    return census

--- a/app/services/research_corpus_ingest.py
+++ b/app/services/research_corpus_ingest.py
@@ -395,6 +395,16 @@ def upsert_series(
             # vendor is the ticker-reuse pair the partial unique index rejects.
             # Leave the second unresolved and counted rather than letting the
             # insert fail the whole batch.
+            #
+            # ⚠ WHICH of the pair keeps the resolution is decided by
+            # ``symbols`` order, which ``load_archive`` sorts — so it is
+            # lexicographic, deterministic and ARBITRARY, not a policy. That is
+            # deliberate: there is no evidence at ingest for preferring one
+            # spelling of a reused ticker over the other, and inventing a
+            # tie-break (shorter symbol, more bars, earlier first bar) would
+            # dress a coin flip up as a rule. Both symbols land in
+            # ``ambiguous_symbols`` and are reported, so the pair is visible
+            # rather than silently halved.
             census.ambiguous_symbols.append(symbol)
             instrument_id = None
         if instrument_id is not None:

--- a/scripts/ingest_2282_research_archive.py
+++ b/scripts/ingest_2282_research_archive.py
@@ -1,0 +1,278 @@
+"""#2282 stage 2b — download and load the HF daily-price archive into the research corpus.
+
+Run from repo root:
+
+    uv run python -m scripts.ingest_2282_research_archive --download
+    uv run python -m scripts.ingest_2282_research_archive --load
+    uv run python -m scripts.ingest_2282_research_archive --quarantine
+    uv run python -m scripts.ingest_2282_research_archive --verify
+
+⚠ Long-running (~20-40 min end to end on 25.8M rows). Launch it with the
+tool's own background mode — a ``nohup … &`` started inside an ordinary tool
+call is killed when that call's process group is cleaned up, and a load that
+dies part-way shows up only as a wrong bar count.
+
+Idempotent at every stage: the series upsert is ON CONFLICT, the bar drain is
+ON CONFLICT, and the quarantine replaces a series' verdicts wholesale.
+
+``--verify`` is acceptance item 4 — the regression guard on the adjustment
+basis. It compares this corpus against ``price_daily`` (eToro, split-adjusted)
+over every overlapping instrument, not a hand-picked panel: if the archive's
+OHLC were unadjusted, the two return series would diverge on every name that
+split inside the overlap window.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+import httpx
+import psycopg
+
+from app.config import settings
+from app.services import research_corpus_ingest as ingest
+
+logger = logging.getLogger("ingest_2282")
+
+_HF_BASE = "https://huggingface.co/datasets/paperswithbacktest/Stocks-Daily-Price/resolve/main/data"
+_SHARDS = [f"train-{i:05d}-of-00004.parquet" for i in range(4)]
+_DEFAULT_CACHE = Path("var/research_corpus")
+
+
+def download(cache: Path) -> list[Path]:
+    """Fetch the four Parquet shards. ~525 MB total, ~30 s on a decent link.
+
+    Plain HTTP against the public resolve URL rather than ``huggingface_hub``:
+    the repo does not carry that dependency and a signed-URL redirect plus four
+    GETs does not justify adding one.
+    """
+    cache.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for name in _SHARDS:
+        target = cache / name
+        paths.append(target)
+        if target.exists() and target.stat().st_size > 0:
+            logger.info("have %s (%.0f MB)", name, target.stat().st_size / 1e6)
+            continue
+        started = time.time()
+        with httpx.stream("GET", f"{_HF_BASE}/{name}", follow_redirects=True, timeout=300.0) as response:
+            response.raise_for_status()
+            with target.open("wb") as handle:
+                for chunk in response.iter_bytes(1 << 20):
+                    handle.write(chunk)
+        logger.info(
+            "downloaded %s (%.0f MB in %.0fs)",
+            name,
+            target.stat().st_size / 1e6,
+            time.time() - started,
+        )
+    return paths
+
+
+def load(conn: psycopg.Connection[tuple], cache: Path) -> int:
+    paths = [cache / name for name in _SHARDS]
+    missing = [p.name for p in paths if not p.exists()]
+    if missing:
+        logger.error("missing shard(s): %s — run --download first", ", ".join(missing))
+        return 1
+
+    started = time.time()
+    census = ingest.load_archive(conn, paths)
+    drift = ingest.census_drift(conn)
+
+    print("\n=== stage 2b load census ===")
+    print(f"  vendor                : {ingest.VENDOR}")
+    print(f"  upstream_source       : {ingest.UPSTREAM_SOURCE}")
+    print(f"  licence               : {ingest.LICENCE}")
+    print(f"  adjustment_basis      : {ingest.ADJUSTMENT_BASIS}  (OHLC; adj_close is split+div)")
+    print(f"  symbols seen          : {census.symbols_seen:,}")
+    print(f"  series upserted       : {census.series_upserted:,}")
+    print(f"    resolved            : {census.resolved_series:,}")
+    print(f"    unresolved          : {census.unresolved_series:,}   <- eToro-listing-bias measure")
+    print(f"    ambiguous symbols   : {len(census.ambiguous_symbols):,}")
+    print(f"  bars loaded           : {census.bars_copied:,}")
+    print(f"  rows without a close  : {census.rows_without_close:,}  (dropped, counted, no floor)")
+    print(f"  duplicate vendor rows : {census.duplicate_bar_rows:,}")
+    print(f"  {census.reuse_guard_note}")
+    print(f"  census drift rows     : {drift}   <- MUST be 0")
+    print(f"  elapsed               : {time.time() - started:.0f}s")
+
+    if drift:
+        logger.error("census drift is %d, expected 0 — the load is NOT done", drift)
+        return 1
+    return 0
+
+
+def quarantine(conn: psycopg.Connection[tuple], as_of: date) -> int:
+    started = time.time()
+    census = ingest.run_quarantine(conn, as_of=as_of)
+    print("\n=== stage 2b quarantine census ===")
+    print(f"  series evaluated      : {census.series_evaluated:,}")
+    print(f"  bars evaluated        : {census.bars_evaluated:,}")
+    print(f"  transitions evaluated : {census.transitions_evaluated:,}")
+    print(f"  bar verdicts stored   : {census.bar_verdicts_written:,}")
+    print(f"  trans verdicts stored : {census.transition_verdicts_written:,}")
+    print(f"  elapsed               : {time.time() - started:.0f}s")
+    for row in conn.execute("SELECT * FROM research_quarantine_census").fetchall():
+        print(f"  census view: {row}")
+    return 0
+
+
+_VERIFY_SQL = """
+WITH overlap AS (
+    SELECT s.series_id,
+           s.instrument_id,
+           r.bar_date,
+           r.close                                            AS research_close,
+           p.close                                            AS etoro_close,
+           lag(r.close) OVER w                                AS research_prev,
+           lag(p.close) OVER w                                AS etoro_prev
+    FROM research_price_series s
+    JOIN research_price_daily r ON r.series_id = s.series_id
+    JOIN price_daily p
+      ON p.instrument_id = s.instrument_id AND p.price_date = r.bar_date
+    WHERE s.vendor = %(vendor)s
+      AND s.instrument_id IS NOT NULL
+    WINDOW w AS (PARTITION BY s.series_id ORDER BY r.bar_date)
+),
+rets AS (
+    SELECT instrument_id,
+           research_close / research_prev - 1 AS research_ret,
+           etoro_close / etoro_prev - 1       AS etoro_ret,
+           research_close / etoro_close       AS level_ratio
+    FROM overlap
+    WHERE research_prev > 0 AND etoro_prev > 0 AND etoro_close > 0
+),
+per_instrument AS (
+    SELECT instrument_id,
+           count(*)                                     AS n,
+           corr(research_ret::float8, etoro_ret::float8) AS ret_corr,
+           -- ⚠ MEDIAN, not mean. A level ratio is a ratio: one mis-levelled
+           -- name at 30x drags a mean across 5,174 instruments into
+           -- meaninglessness. The first draft of this query reported a mean
+           -- level gap of +0.367 against an expected -0.0015 and looked like a
+           -- failed adjustment-basis check; the median was +0.0020, which is
+           -- the half-spread the reference predicts. The statistic was wrong,
+           -- not the data.
+           -- (No literal percent signs in this string: psycopg scans SQL
+           -- comments for placeholders too, and a stray one raises
+           -- "incomplete placeholder".)
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY level_ratio) AS med_level_ratio
+    FROM rets
+    GROUP BY instrument_id
+    HAVING count(*) >= 60
+)
+SELECT count(*)                                        AS instruments,
+       sum(n)                                          AS paired_bars,
+       round(percentile_cont(0.5) WITHIN GROUP (ORDER BY ret_corr)::numeric, 4)
+                                                       AS median_return_corr,
+       round(percentile_cont(0.5) WITHIN GROUP (ORDER BY med_level_ratio)::numeric, 6)
+                                                       AS median_level_ratio,
+       count(*) FILTER (WHERE abs(ln(med_level_ratio)) <= 0.01)
+                                                       AS instruments_level_within_1pct,
+       count(*) FILTER (WHERE ret_corr >= 0.90)        AS instruments_corr_at_least_0_90,
+       count(*) FILTER (WHERE ret_corr >= 0.90 AND abs(ln(med_level_ratio)) > 0.10)
+                                                       AS tail_agreeing_returns_offset_level,
+       count(*) FILTER (WHERE ret_corr < 0.90)         AS tail_disagreeing_returns
+FROM per_instrument
+"""
+
+
+def verify(conn: psycopg.Connection[tuple]) -> int:
+    """Acceptance item 4 — full-population regression guard on the adjustment basis.
+
+    Every overlapping instrument, not a panel. An unadjusted research series
+    against a split-adjusted ``price_daily`` would show up as a low return
+    correlation on every name that split inside the overlap window; a
+    dividend-adjusted close sitting in the ``close`` column would show up as a
+    level ratio drifting away from 1 over time.
+
+    The tail is REPORTED, not absorbed. Two signatures were characterised on
+    the 2026-08-05 load and they are different problems:
+
+    * **returns agree, level is offset by a constant factor** — the archive
+      snapshot is frozen (last bar 2026-07-06) while ``price_daily`` keeps
+      retro-adjusting, so any split after the snapshot rescales one side and
+      not the other. ``FFAI`` is exactly 1/147.7 on all 162 overlapping bars
+      including the last, at correlation 0.995.
+    * **returns disagree** — the two sources are not describing the same
+      series. Some of that is ticker reuse on the research side; some is on
+      the eToro side (mean return sigma in this group is 37.8, which is not a
+      plausible equity return series).
+
+    Telling those apart per-instrument is a separate investigation into
+    ``price_daily`` quality and is NOT this ticket.
+    """
+    row = conn.execute(_VERIFY_SQL, {"vendor": ingest.VENDOR}).fetchone()
+    assert row is not None
+    (
+        instruments,
+        paired,
+        median_corr,
+        median_level,
+        within_1pct,
+        corr_ok,
+        tail_level,
+        tail_returns,
+    ) = row
+    print("\n=== stage 2b verification vs price_daily (eToro) ===")
+    print(f"  instruments compared          : {instruments:,}")
+    print(f"  paired bars                   : {paired:,}")
+    print(f"  median return correlation     : {median_corr}")
+    print(f"  median level ratio (res/eToro): {median_level}")
+    print(f"  level within +/-1%            : {within_1pct:,} ({100 * within_1pct / max(1, instruments):.1f}%)")
+    print(f"  return corr >= 0.90           : {corr_ok:,} ({100 * corr_ok / max(1, instruments):.1f}%)")
+    print(f"  tail, returns agree/level off : {tail_level:,}  (frozen-snapshot split epoch)")
+    print(f"  tail, returns disagree        : {tail_returns:,}  (not the same series)")
+    print(
+        "\n  Reference (#2240 §0, TA spike): return correlation 0.963-0.996 and a\n"
+        "  level gap of about -0.15% attributable to eToro's Bid half-spread.\n"
+        "  A materially lower MEDIAN correlation would mean the archive's OHLC\n"
+        "  are NOT split-adjusted as sql/251 claims."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--download", action="store_true")
+    parser.add_argument("--load", action="store_true")
+    parser.add_argument("--quarantine", action="store_true")
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--cache", type=Path, default=_DEFAULT_CACHE)
+    parser.add_argument(
+        "--as-of",
+        type=date.fromisoformat,
+        default=date.today(),
+        help="Quarantine 'today' — sets which trailing bars count as provisional.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+
+    if not any((args.download, args.load, args.quarantine, args.verify)):
+        parser.error("pick at least one of --download / --load / --quarantine / --verify")
+
+    if args.download:
+        download(args.cache)
+
+    if not any((args.load, args.quarantine, args.verify)):
+        return 0
+
+    with psycopg.connect(settings.database_url) as conn:
+        if args.load and (rc := load(conn, args.cache)):
+            return rc
+        if args.quarantine and (rc := quarantine(conn, args.as_of)):
+            return rc
+        if args.verify and (rc := verify(conn)):
+            return rc
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ingest_2282_research_archive.py
+++ b/scripts/ingest_2282_research_archive.py
@@ -166,6 +166,25 @@ per_instrument AS (
     FROM rets
     GROUP BY instrument_id
     HAVING count(*) >= 60
+),
+scored AS (
+    -- ⚠ ln() raises a domain error on zero and on negatives, and this corpus
+    -- deliberately has no price floor: two loaded bars are already at
+    -- close <= 0, and price_daily holds 154. They happen not to overlap TODAY,
+    -- which is exactly what makes it a latent crash in the acceptance guard
+    -- rather than a theoretical one.
+    --
+    -- Guarded here rather than by adding `research_close > 0` to the WHERE
+    -- above, because that would be a narrowing gate on precisely the
+    -- failed-company population the corpus exists to retain: FRCB's last bar
+    -- is 0.0004 and a delisted name's final bars are the signal. NULL means
+    -- "level not comparable for this instrument", and a NULL comparison
+    -- excludes it from the FILTERs without removing any bar.
+    SELECT n,
+           ret_corr,
+           med_level_ratio,
+           ln(nullif(greatest(med_level_ratio, 0), 0)) AS log_level_ratio
+    FROM per_instrument
 )
 SELECT count(*)                                        AS instruments,
        sum(n)                                          AS paired_bars,
@@ -173,13 +192,13 @@ SELECT count(*)                                        AS instruments,
                                                        AS median_return_corr,
        round(percentile_cont(0.5) WITHIN GROUP (ORDER BY med_level_ratio)::numeric, 6)
                                                        AS median_level_ratio,
-       count(*) FILTER (WHERE abs(ln(med_level_ratio)) <= 0.01)
+       count(*) FILTER (WHERE abs(log_level_ratio) <= 0.01)
                                                        AS instruments_level_within_1pct,
        count(*) FILTER (WHERE ret_corr >= 0.90)        AS instruments_corr_at_least_0_90,
-       count(*) FILTER (WHERE ret_corr >= 0.90 AND abs(ln(med_level_ratio)) > 0.10)
+       count(*) FILTER (WHERE ret_corr >= 0.90 AND abs(log_level_ratio) > 0.10)
                                                        AS tail_agreeing_returns_offset_level,
        count(*) FILTER (WHERE ret_corr < 0.90)         AS tail_disagreeing_returns
-FROM per_instrument
+FROM scored
 """
 
 

--- a/sql/250_research_price_series_cik.sql
+++ b/sql/250_research_price_series_cik.sql
@@ -1,0 +1,98 @@
+-- 250_research_price_series_cik.sql
+--
+-- #2282 stage 2b/2c prerequisite — give a research series somewhere to carry
+-- a CIK.
+--
+--
+-- WHY THIS IS NEEDED BEFORE THE FORM 25 REGISTER (2c)
+-- ---------------------------------------------------------------------------
+-- The Form 25 register is keyed on CIK: 17 CFR 240.12d2-2 filings identify the
+-- issuer by CIK and carry no ticker at all (sec-edgar.md §2.6 trap 4 — SEC
+-- drops `tickers` to `[]` on delisting and `companyconcept/…/dei/
+-- TradingSymbol.json` 404s). So the register's natural join key to the corpus
+-- is CIK.
+--
+-- `research_price_series` (sql/249) had nowhere to put one. Every CIK-bearing
+-- table in this schema hangs off `instrument_id` (`instrument_sec_profile`
+-- sql/051, `instrument_cik_history` sql/102) or off a filer
+-- (`institutional_filers` sql/090, `blockholder_filers` sql/095). But the
+-- entire 2c population is UNRESOLVED series — delisted companies have no
+-- `instruments` row by construction, since eToro's book is survivors only.
+-- Without this column the register can only join on the symbol string, which
+-- is precisely the ticker-reuse hazard sql/249 documents at length: `SI`
+-- (Silvergate, failed 2023) is a live ticker for a different company, and 10
+-- of Yahoo's 48 hits on the 2023 cohort begin AFTER the delisting they are
+-- supposed to record.
+--
+-- CIK is stable across delisting, ticker change and reuse. Symbol is not.
+--
+--
+-- WHY TEXT AND NOT BIGINT
+-- ---------------------------------------------------------------------------
+-- Every CIK in this schema is TEXT, 10-digit zero-padded (verified on dev:
+-- 5,339/5,339 `instrument_sec_profile` rows and 5,109/5,109
+-- `instrument_cik_history` rows match `^[0-9]{10}$`). Storing it as BIGINT
+-- here would make every join to those tables a cast, and casts on identity
+-- columns are how identity bugs hide. The CHECK below pins the padding so a
+-- caller cannot insert `1067983` alongside `0001067983` and create two
+-- spellings of Berkshire.
+--
+--
+-- WHY THERE IS NO UNIQUE (vendor, cik)
+-- ---------------------------------------------------------------------------
+-- Deliberately asymmetric with the `uq_research_price_series_vendor_instrument`
+-- partial unique index sql/249 added. Two vendor symbols mapping to one
+-- INSTRUMENT within a vendor is a resolver bug (the ticker-reuse pair). Two
+-- vendor symbols mapping to one CIK is normal and correct: multi-class issuers
+-- file under a single CIK (GOOG/GOOGL under 0001652044, BRK.A/BRK.B under
+-- 0001067983). A unique index here would reject real data.
+
+ALTER TABLE research_price_series
+    ADD COLUMN IF NOT EXISTS cik        TEXT,
+    ADD COLUMN IF NOT EXISTS cik_source TEXT;
+
+-- Closed vocabulary, same shape as `resolution_method` / `delisting_source`.
+--   sec_form25             — read off the Form 25 / 25-NSE filing itself (2c)
+--   instrument_sec_profile — carried across from an already-resolved instrument
+--   manual                 — operator-asserted, and therefore auditable as such
+ALTER TABLE research_price_series
+    DROP CONSTRAINT IF EXISTS research_price_series_cik_source_vocab;
+ALTER TABLE research_price_series
+    ADD CONSTRAINT research_price_series_cik_source_vocab
+        CHECK (cik_source IS NULL
+               OR cik_source IN ('sec_form25', 'instrument_sec_profile', 'manual'));
+
+-- A CIK without its provenance is an unauditable join — the same invariant
+-- sql/249 applies to `instrument_id`/`resolution_method` and to
+-- `delisting_date`/`delisting_source`.
+ALTER TABLE research_price_series
+    DROP CONSTRAINT IF EXISTS research_price_series_cik_evidenced;
+ALTER TABLE research_price_series
+    ADD CONSTRAINT research_price_series_cik_evidenced
+        CHECK ((cik IS NULL) = (cik_source IS NULL));
+
+-- 10-digit zero-padded, matching every other CIK column in the schema.
+ALTER TABLE research_price_series
+    DROP CONSTRAINT IF EXISTS research_price_series_cik_padded;
+ALTER TABLE research_price_series
+    ADD CONSTRAINT research_price_series_cik_padded
+        CHECK (cik IS NULL OR cik ~ '^[0-9]{10}$');
+
+-- The register's read path: "which series belong to the issuer this Form 25
+-- names". Partial — most series will never carry a CIK (non-US names have no
+-- SEC identity at all).
+CREATE INDEX IF NOT EXISTS idx_research_price_series_cik
+    ON research_price_series (cik)
+    WHERE cik IS NOT NULL;
+
+COMMENT ON COLUMN research_price_series.cik IS
+    'SEC CIK, 10-digit zero-padded TEXT to match instrument_sec_profile / '
+    'instrument_cik_history. The join key for the Form 25 delisting register: '
+    'CIK survives delisting, ticker change and ticker reuse, and a delisted '
+    'name has no instruments row to borrow one from. Not unique per vendor — '
+    'multi-class issuers file one CIK for several symbols.';
+
+COMMENT ON COLUMN research_price_series.cik_source IS
+    'How the CIK was established. A CIK without provenance is an unauditable '
+    'join; CHECK-paired with cik, same invariant as instrument_id/'
+    'resolution_method.';

--- a/sql/251_research_corpus_adj_close_and_quarantine.sql
+++ b/sql/251_research_corpus_adj_close_and_quarantine.sql
@@ -1,0 +1,184 @@
+-- 251_research_corpus_adj_close_and_quarantine.sql
+--
+-- #2282 stage 2b — two things the archive's actual shape forced, both
+-- discovered by reading the file rather than the dataset card.
+--
+--
+-- 1. WHY `adj_close` IS A SEPARATE COLUMN AND NOT A CHOICE OF `close`
+-- ---------------------------------------------------------------------------
+-- The HF archive carries BOTH `close` and `adj_close`, with Yahoo's standard
+-- semantics — verified empirically, not assumed:
+--
+--   AAPL 2020-08-27  close 125.01   adj_close 121.2564
+--   AAPL 2020-08-31  close 129.04   adj_close 125.1654
+--
+-- AAPL's unadjusted close on 2020-08-27 was ~$500; the 4:1 split settled
+-- 2020-08-31. 125.01 = 500.04/4, so **OHLC are SPLIT-ADJUSTED**. And
+-- `adj_close` differs from `close` only for dividend payers (AAPL, CSCO) while
+-- being bit-identical for non-payers (AMZN, AAL, BRK-A), so **`adj_close` is
+-- split AND dividend adjusted**.
+--
+-- That is a schema constraint, not a preference. `open`/`high`/`low` carry only
+-- the split adjustment, so writing `adj_close` into the `close` column would
+-- produce bars whose close sits OUTSIDE [low, high] for every dividend payer —
+-- silently, and in a way that breaks every candle-shaped indicator and every
+-- containment check (including rule B2 of the #2261 quarantine, which would
+-- then fire on the whole dividend-paying universe).
+--
+-- So `close` stays the split-adjusted price that is consistent with OHLC, and
+-- the total-return series gets its own nullable column rather than being
+-- discarded. Discarding it would be irreversible without re-loading 25.8M rows.
+--
+-- ⚠ `research_price_series.adjustment_basis` describes the OHLC columns. A
+-- series loaded from this archive is 'split_adjusted'. The #2282 handoff said
+-- to record 'unknown' and to "verify it before claiming it" — this is that
+-- verification, and it is reproducible from the two AAPL bars above.
+
+ALTER TABLE research_price_daily
+    ADD COLUMN IF NOT EXISTS adj_close NUMERIC;
+
+COMMENT ON COLUMN research_price_daily.adj_close IS
+    'Split AND dividend adjusted close, where the vendor supplies one. The '
+    'OHLC columns carry only the split adjustment (see '
+    'research_price_series.adjustment_basis), so adj_close is NOT '
+    'interchangeable with close: for a dividend payer it sits outside '
+    '[low, high]. Total-return work reads this column; candle-shaped '
+    'indicators read close.';
+
+-- ---------------------------------------------------------------------------
+-- 2. QUARANTINE VERDICTS FOR THE RESEARCH CORPUS
+-- ---------------------------------------------------------------------------
+--
+-- Same model as sql/247 (#2261) and the SAME RULES — `evaluate_series` in
+-- app/services/price_quarantine.py is reused verbatim, not re-implemented.
+-- Re-expressing B1-B4/T1-T3 in SQL would be the closed-vocabulary-in-three-
+-- places failure the 2026-08-03 session hit: one rule set, one implementation.
+--
+-- Separate TABLES are unavoidable, though. sql/247's are keyed on
+-- `instrument_id` with an FK to `instruments`, and the research corpus is keyed
+-- on `series_id` precisely because most of its series have no instruments row
+-- (that population IS the eToro-listing-bias measurement — see sql/249). A
+-- research verdict therefore has nowhere to live in the 247 tables.
+--
+-- ⚠ WHY QUARANTINE AND NOT A PRICE FILTER. A hard price floor at ingest would
+-- be a survivorship filter wearing a data-quality hat: FRCB's last bar is
+-- $0.0004 and `price_daily` already holds 154 rows at `close <= 0`. Failed
+-- companies trade at fractions of a cent — that is the signal, not noise. The
+-- ingest rejects nothing on price; it records a verdict and counts it.
+--
+-- Sparse, like 247: a row exists only when it says something.
+
+CREATE TABLE IF NOT EXISTS research_price_quarantine_coverage (
+    series_id             BIGINT NOT NULL PRIMARY KEY
+        REFERENCES research_price_series(series_id) ON DELETE CASCADE,
+    rule_set_version      TEXT    NOT NULL,
+    first_bar             DATE    NOT NULL,
+    last_bar              DATE    NOT NULL,
+    bars_evaluated        INTEGER NOT NULL CHECK (bars_evaluated > 0),
+    transitions_evaluated INTEGER NOT NULL CHECK (transitions_evaluated >= 0),
+    evaluated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (last_bar >= first_bar)
+);
+
+CREATE INDEX IF NOT EXISTS idx_research_quarantine_coverage_version
+    ON research_price_quarantine_coverage (rule_set_version);
+
+COMMENT ON TABLE research_price_quarantine_coverage IS
+    'Which research series have been evaluated, at which rule-set version. '
+    'The verdict tables are SPARSE, so absence of a verdict row means either '
+    '"clean" or "never evaluated" — reads must be fail-closed against this '
+    'table, exactly as for price_quarantine_coverage (sql/247).';
+
+CREATE TABLE IF NOT EXISTS research_bar_quarantine (
+    series_id        BIGINT  NOT NULL
+        REFERENCES research_price_series(series_id) ON DELETE CASCADE,
+    bar_date         DATE    NOT NULL,
+    return_usable    BOOLEAN NOT NULL,
+    range_usable     BOOLEAN NOT NULL,
+    provisional      BOOLEAN NOT NULL,
+    rules            TEXT[]  NOT NULL,
+    rule_set_version TEXT    NOT NULL,
+    PRIMARY KEY (series_id, bar_date),
+    -- Sparse-table invariant, same as price_bar_quarantine: a writer bug that
+    -- emits an all-clean row per bar would turn this into a 25.8M-row copy of
+    -- research_price_daily and silently change every census denominator.
+    CHECK (NOT return_usable OR NOT range_usable OR provisional)
+);
+
+CREATE INDEX IF NOT EXISTS idx_research_bar_quarantine_version
+    ON research_bar_quarantine (rule_set_version);
+
+CREATE TABLE IF NOT EXISTS research_transition_quarantine (
+    series_id        BIGINT  NOT NULL
+        REFERENCES research_price_series(series_id) ON DELETE CASCADE,
+    bar_date         DATE    NOT NULL,   -- the LATER bar
+    prior_date       DATE    NOT NULL,   -- the earlier bar
+    observed_ratio   NUMERIC(24,12),
+    provisional      BOOLEAN NOT NULL,
+    rules            TEXT[]  NOT NULL,
+    turnover_ratio   NUMERIC(24,12),
+    corroboration    TEXT NOT NULL CHECK (corroboration IN (
+                         'spike', 'flat', 'collapse', 'unclassifiable', 'not_applicable')),
+    rule_set_version TEXT    NOT NULL,
+    PRIMARY KEY (series_id, bar_date),
+    CHECK (prior_date < bar_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_research_transition_quarantine_version
+    ON research_transition_quarantine (rule_set_version);
+
+COMMENT ON TABLE research_transition_quarantine IS
+    'Transition verdicts (T1-T3) for research series, keyed on the LATER bar. '
+    'Stores ADMITTED-BACK transitions too (corroboration = spike): a narrowing '
+    'gate is measured by what it rejects against what it saw, so the admitted '
+    'side is the denominator and cannot be dropped.';
+
+-- The operator-visible rejection census. Fractions of what was actually
+-- EVALUATED (the coverage table's denominators), never of whatever happens to
+-- be in research_price_daily when somebody looks.
+-- ⚠ The verdict counts are LEFT JOINed per series, not computed by correlated
+-- subqueries over the whole verdict table. A subquery filtered only on
+-- rule_set_version counts every vendor's verdicts and then repeats that global
+-- total on each vendor's row — invisible while one vendor is loaded, wrong the
+-- day a second one is. Same class as the sql/249 drift-view COALESCE: a census
+-- that is right by accident is a census that will be read after the accident
+-- stops holding.
+CREATE OR REPLACE VIEW research_quarantine_census AS
+SELECT
+    c.rule_set_version,
+    s.vendor,
+    count(*)                                        AS series_evaluated,
+    sum(c.bars_evaluated)                           AS bars_evaluated,
+    sum(c.transitions_evaluated)                    AS transitions_evaluated,
+    -- ::bigint because sum() over a bigint yields numeric, and a later
+    -- CREATE OR REPLACE cannot change a view column's type.
+    coalesce(sum(b.return_unusable), 0)::bigint     AS bars_return_unusable,
+    coalesce(sum(b.range_unusable), 0)::bigint      AS bars_range_unusable,
+    coalesce(sum(t.quarantined), 0)::bigint         AS transitions_quarantined,
+    coalesce(sum(t.admitted_back), 0)::bigint       AS transitions_admitted_back
+FROM research_price_quarantine_coverage c
+JOIN research_price_series s ON s.series_id = c.series_id
+LEFT JOIN (
+    SELECT series_id,
+           rule_set_version,
+           count(*) FILTER (WHERE NOT return_usable) AS return_unusable,
+           count(*) FILTER (WHERE NOT range_usable)  AS range_unusable
+    FROM research_bar_quarantine
+    GROUP BY series_id, rule_set_version
+) b ON b.series_id = c.series_id AND b.rule_set_version = c.rule_set_version
+LEFT JOIN (
+    SELECT series_id,
+           rule_set_version,
+           count(*) FILTER (WHERE cardinality(rules) > 0) AS quarantined,
+           count(*) FILTER (WHERE cardinality(rules) = 0
+                              AND corroboration = 'spike') AS admitted_back
+    FROM research_transition_quarantine
+    GROUP BY series_id, rule_set_version
+) t ON t.series_id = c.series_id AND t.rule_set_version = c.rule_set_version
+GROUP BY c.rule_set_version, s.vendor;
+
+COMMENT ON VIEW research_quarantine_census IS
+    'Research-corpus quarantine outcome per rule-set version and vendor. '
+    'Reports the ADMITTED side as well as the rejected side — a narrowing '
+    'gate whose census only counts rejections cannot be checked for '
+    'over-rejection.';

--- a/tests/test_research_corpus_ingest.py
+++ b/tests/test_research_corpus_ingest.py
@@ -1,0 +1,95 @@
+"""#2282 stage 2b — symbol-resolution policy for the research-corpus ingest.
+
+Pure tests, no database. The resolution policy is where this ingest can go
+quietly wrong, and every failure mode below was found by measuring the actual
+dev universe rather than imagined:
+
+* 558 ``.RTH`` and 9 ``.24-7`` rows are eToro VENUE VARIANTS of a company that
+  already has an instrument row. Resolving deep history onto one of those
+  attaches the corpus to the wrong row AND consumes the
+  ``uq_research_price_series_vendor_instrument`` slot the real instrument needs.
+* 224 ``.US`` rows are the only row for their company (``ABT.US`` is Abbott;
+  there is no ``ABT``), so that suffix must be stripped, not skipped.
+* The archive spells share classes Yahoo's way — ``BRK-A`` where we write
+  ``BRK.B``.
+* 27 keys still collide after all of that. They stay UNRESOLVED: an ambiguous
+  join recorded as ``symbol_exact`` would be a lie about its own evidence, and
+  sql/249's whole point is that an unresolved series is a measurement.
+
+The schema invariants themselves live in ``test_research_corpus_schema.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.research_corpus_ingest import (
+    index_instruments,
+    normalise_vendor_symbol,
+)
+
+
+@pytest.mark.parametrize(
+    ("vendor_symbol", "expected"),
+    [
+        ("AAPL", "AAPL"),
+        ("aapl", "AAPL"),
+        (" AAPL ", "AAPL"),
+        # Yahoo spells a share class with a hyphen; we spell it with a dot.
+        ("BRK-A", "BRK.A"),
+        ("BRK-B", "BRK.B"),
+        ("BF-B", "BF.B"),
+    ],
+)
+def test_normalise_vendor_symbol(vendor_symbol: str, expected: str) -> None:
+    assert normalise_vendor_symbol(vendor_symbol) == expected
+
+
+def test_venue_variants_never_win_the_key() -> None:
+    """``AAPL.RTH`` and ``AAPL.24-7`` are the same company on a different session.
+
+    Order matters here: the variants are listed FIRST so a naive
+    last-write-wins index would resolve ``AAPL`` onto instrument 8754 (the RTH
+    row) instead of 1001.
+    """
+    index, ambiguous = index_instruments(
+        [
+            (8754, "AAPL.RTH"),
+            (15569, "AAPL.24-7"),
+            (1001, "AAPL"),
+        ]
+    )
+    assert index == {"AAPL": 1001}
+    assert ambiguous == set()
+
+
+def test_us_suffix_is_stripped_not_skipped() -> None:
+    """``ABT.US`` is Abbott's only instrument row — skipping it loses the name."""
+    index, ambiguous = index_instruments([(1552, "ABT.US"), (9001, "ABT.RTH")])
+    assert index == {"ABT": 1552}
+    assert ambiguous == set()
+
+
+def test_share_class_dots_are_preserved() -> None:
+    """``.B`` is part of the ticker; only the venue suffixes are meaningful."""
+    index, _ = index_instruments([(1118, "BRK.B")])
+    assert index[normalise_vendor_symbol("BRK-B")] == 1118
+
+
+def test_colliding_key_resolves_to_nothing() -> None:
+    """Two instruments claiming one key leaves BOTH unresolved.
+
+    Picking one would record ``resolution_method = 'symbol_exact'`` against a
+    join that was in fact a coin flip. Unresolved is a measurement; a wrong
+    resolution is a corrupted one, and it is silent.
+    """
+    index, ambiguous = index_instruments([(10, "ABT"), (11, "ABT.US")])
+    assert "ABT" not in index
+    assert ambiguous == {"ABT"}
+
+
+def test_same_instrument_listed_twice_is_not_a_collision() -> None:
+    """Idempotence: the same (id, symbol) pair repeated is not ambiguity."""
+    index, ambiguous = index_instruments([(10, "ABT"), (10, "ABT")])
+    assert index == {"ABT": 10}
+    assert ambiguous == set()


### PR DESCRIPTION
Stage 2b of #2282. Loads the Hugging Face daily-price archive into the research corpus that stage 2a (`2cd70369`, sql/249) created, and adds the nullable CIK stage 2c needs first.

## What changed

**`sql/250`** — nullable `cik` + `cik_source` on `research_price_series`.

The gap: every CIK-bearing table in this schema hangs off `instrument_id` (`instrument_sec_profile` sql/051, `instrument_cik_history` sql/102) or a filer. But the entire 2c population is UNRESOLVED series — a delisted company has no `instruments` row, because eToro's book is survivors only. So without a CIK on the series, the Form 25 register can only join on the symbol string, which is precisely the ticker-reuse hazard sql/249 spends 30 lines documenting (`SI` is a live ticker for a company that is not Silvergate).

TEXT, 10-digit zero-padded, matching every other CIK column (verified: 5,339/5,339 `instrument_sec_profile` and 5,109/5,109 `instrument_cik_history` rows match `^[0-9]{10}$`). Deliberately **not** unique per vendor, unlike `instrument_id` — multi-class issuers file one CIK for several symbols (GOOG/GOOGL, BRK.A/BRK.B), so a unique index would reject real data.

**`sql/251`** — `research_price_daily.adj_close`, plus quarantine verdict tables.

**`app/services/research_corpus_ingest.py`** + **`scripts/ingest_2282_research_archive.py`** — the load, census maintenance, quarantine pass and verification.

## The adjustment basis is `split_adjusted`, not `unknown`

The handoff specified `adjustment_basis = 'unknown'` verbatim and added "NOT `split_adjusted`. Verify it before claiming it." This is that verification:

| | `close` | `adj_close` |
|---|---|---|
| AAPL 2020-08-27 | 125.01 | 121.2564 |
| AAPL 2020-08-31 | 129.04 | 125.1654 |

AAPL's unadjusted close on 2020-08-27 was ~$500 and the 4:1 split settled 2020-08-31; 125.01 = 500.04/4. So **OHLC are split-adjusted**. `adj_close` differs from `close` for dividend payers (AAPL, CSCO) and is bit-identical for non-payers (AMZN, AAL, BRK-A), so **`adj_close` is split *and* dividend adjusted**.

That forced a schema decision rather than a preference: `open`/`high`/`low` carry only the split adjustment, so writing `adj_close` into the `close` column puts the close **outside `[low, high]`** for every dividend payer. Silent, and it breaks every candle-shaped indicator plus quarantine rule B2. Hence a separate nullable column rather than a choice between the two.

Provenance is otherwise recorded exactly as specified and not softened: `upstream_source = 'yahoo_derivative'`, `licence = 'other/unspecified'`.

## Quarantine, not rejection

Handoff obligation 4. Nothing is filtered on price — FRCB's last bar is $0.0004 and `price_daily` already holds 154 rows at `close <= 0`. A floor here would be a survivorship filter wearing a data-quality hat.

Verdict tables are new because sql/247's are keyed on `instrument_id` with an FK to `instruments`, and most research series have no instrument row. The **rules** are imported verbatim from `app/services/price_quarantine.py` — `evaluate_series` — and not re-expressed in SQL. One rule set, one implementation; the 2026-08-03 closed-vocabulary-in-three-places incident is the reason.

## Definition-of-Done evidence (clauses 8-12), commit `606d9ae9`

Migrations 250 + 251 applied to dev; `schema_migrations` head is `251_research_corpus_adj_close_and_quarantine.sql`.

| step | result |
|---|---|
| load (`--load`) | **25,818,944 bars / 7,693 series in 241s** |
| census drift | **0** (the gate; asserted before the load reports success) |
| resolved / unresolved | 5,269 / **2,424** |
| ambiguous symbols | 24, left unresolved |
| rows with no close (NaN) | 117, dropped and counted |
| duplicate vendor rows | 0 |
| quarantine (`--quarantine`) | 7,693 series, 25.8M bars, 25.8M transitions, 169s |
| verdicts stored | 1,315 bar / 1,931 transition (242 return-unusable, 1,315 range-unusable, 1,564 transitions quarantined, 367 admitted back) |

The **2,424 unresolved** is not a shortfall — it is the artefact sql/249 was keyed on `(vendor, vendor_symbol)` to preserve. Those are companies that were listed and are not on eToro's book, i.e. the only measurement we have of eToro-listing bias (#2289 §4.0), which #2284 did not measure and which buying a delisted corpus does not fix.

### Cross-source verification (clause 9), full population

`--verify` compares the corpus against `price_daily` (eToro) across **every** overlapping instrument, not a panel:

```
instruments compared          : 5,174
paired bars                   : 3,021,827
median return correlation     : 0.9920      <- #2240 §0 reference: 0.963-0.996
median level ratio (res/eToro): 1.002030    <- reference: ~0.15% half-spread
level within +/-1%            : 4,527 (87.5%)
return corr >= 0.90           : 4,488 (86.7%)
tail, returns agree/level off : 53
tail, returns disagree        : 686
```

⚠ **The first draft of this query reported a mean level gap of +36.7% and looked like a failed adjustment-basis check.** It used `avg()` over a *ratio*: one mis-levelled name at 30x drags a mean across 5,174 instruments into meaninglessness. The median is +0.20%, which is the half-spread the reference predicts. The statistic was wrong, not the data — the query now uses `percentile_cont` and the comment records why.

The 686-instrument disagreeing tail is **reported, not absorbed**, and is filed separately as **#2293**: mean daily-return sigma inside it is **eToro 37.8 vs research 0.111**, which is not a plausible equity return series and is therefore a `price_daily` question rather than a corpus one. Folding it into this PR would have turned a load into an audit.

## Ticker-reuse guard — what it could NOT check

Handoff obligation 3 said to say what the guard could not check rather than implying it passed. The load reports:

> ticker-reuse guard: 0 series checked at ingest, 5,269 UNCHECKABLE HERE — the schema holds no listing date.

`instruments.first_seen_at` is the eToro **detection** date (#2290), not a listing date; using it would reject every series with real pre-2025 history. #2290's forward record is what eventually supplies one, and the delisting half needs 2c's Form 25 suspension dates.

A **different** discriminator does work and is run by `--verify`: return correlation against `price_daily` over the shared window. It reaches only series with eToro overlap, and separating reuse from split-epoch from eToro-side defects is #2293.

## Symbol resolution

The dev universe made this less trivial than it looks, and each case is table-tested in `tests/test_research_corpus_ingest.py`:

- 558 `.RTH` and 9 `.24-7` rows are eToro **venue variants** of a company that already has an instrument row (536 say so via `canonical_instrument_id`). Resolving deep history onto one attaches the corpus to the wrong row and consumes the `uq_research_price_series_vendor_instrument` slot the real instrument needs. Excluded.
- 224 `.US` rows are the **only** row for their company (`ABT.US` is Abbott; there is no `ABT`). Suffix stripped, not skipped.
- Yahoo spells share classes with a hyphen (`BRK-A`) where we use a dot (`BRK.B`).
- 27 keys still collide. They stay **unresolved** — an ambiguous join recorded as `symbol_exact` would be a lie about its own evidence.

Scoped to `asset_class = 'us_equity' AND instrument_type_id = 5` per #2289: `us_equity` alone is an exchange class and mixes in several hundred ETFs.

## Review

Rung: **corpus change** (parser/ETL/schema migration) — full-population verification above plus clauses 8-12, and Codex checkpoint 2 ran before first push. It found two real defects, both fixed and both re-verified:

- **P1** — `INSERT … SELECT … ON CONFLICT DO UPDATE` raises `cardinality_violation: ON CONFLICT DO UPDATE command cannot affect row a second time` when the SELECT contains the conflict key twice. The loader documented duplicates as "last one wins" and would in fact have aborted a 500k-row flush. Now `DISTINCT ON (series_id, bar_date) … ORDER BY … row_ordinal DESC` over a surrogate ordinal (COPY heap order is not a guaranteed SELECT order). Verified: a staged duplicate now stores the later row rather than raising.
- **P2** — `research_quarantine_census`'s correlated subqueries counted verdicts across **all** vendors and repeated the global total on each vendor row. Invisible with one vendor loaded, wrong the day a second one is. Now LEFT JOINed per `(series_id, rule_set_version)`. Same figures as before on the current single-vendor corpus, so no regression.

## Security

No new external input reaches a trust boundary. The archive is a static file fetched over HTTPS and parsed with pyarrow; no user-controlled values reach SQL (parameterised throughout); no new endpoint, no new auth surface. The corpus is deliberately **not** `price_daily` and is not read by the order path — sql/249's header states that separation and sql/251 restates it.

## Local checks

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` · `pytest tests/smoke` · `pytest -m db tests/test_research_corpus_schema.py` — all pass.

Refs #2282. Refs #2284. Refs #2290. Refs #2293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)