### PR TITLE
fix(#2286): .env.example documented six EBULL_ variables the app never read

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,59 @@ EBULL_BOOTSTRAP_TOKEN=
 # ADR 0001. Generate a fresh value with:
 #   python -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode())"
 EBULL_SECRETS_KEY=
+
+# ======================================================================
+# The settings below were undocumented until #2286. Every one of them is
+# a real `Settings` field with a working default -- leaving them unset is
+# fine and is what the dev stack does. They are listed so a fresh clone
+# can SEE them rather than discovering them from a runtime failure.
+#
+# Every name here accepts both the EBULL_ spelling and the bare one
+# (app/config.py::_ebull_alias). The EBULL_ form is the documented one.
+# ======================================================================
+
+# --- Infrastructure ---------------------------------------------------
+# Redis, used as the IPC layer for live pricing. Unset = the default
+# below; the app does not require Redis for anything on the scoring or
+# order path.
+EBULL_REDIS_URL=redis://localhost:6379/0
+
+# Directory for the local secret bootstrap material (ADR 0003). Unset =
+# platformdirs user_data_dir("eBull"). Note master_key.py reads the
+# EBULL_DATA_DIR environment variable directly and takes precedence over
+# this field, so setting it in the process env overrides .env.
+EBULL_DATA_DIR=
+
+# eToro API base. Change only to point at a mock or a replay proxy --
+# eToro is the EXECUTION venue, and repointing it repoints the order path.
+EBULL_ETORO_BASE_URL=https://public-api.etoro.com
+
+# --- Session cookie ---------------------------------------------------
+# Name of the operator session cookie. Change only if it collides with
+# something else on the same origin; changing it logs everyone out.
+EBULL_SESSION_COOKIE_NAME=ebull_session
+
+# --- Jobs / orchestration ---------------------------------------------
+# Master switch for the job orchestrator. `false` stops scheduled work
+# from running at all -- the API still serves, but nothing refreshes.
+EBULL_ORCHESTRATOR_ENABLED=true
+
+# Deadlines for the two long SEC sweeps, in seconds (default 6h each).
+# A sweep that exceeds its deadline stops and resumes on the next fire
+# rather than running unbounded.
+EBULL_SEC_13F_SWEEP_DEADLINE_SECONDS=21600
+EBULL_SEC_N_PORT_SWEEP_DEADLINE_SECONDS=21600
+
+# How many SEC filers are ingested concurrently. The 10 req/s SEC rate
+# budget is shared and enforced separately, so raising this does not
+# raise throughput past that ceiling -- it only deepens the queue.
+EBULL_SEC_FILER_INGEST_CONCURRENCY=8
+
+# --- Feature flags (default off) --------------------------------------
+# Dry-run mode for raw-payload retention: log what WOULD be deleted and
+# delete nothing. Useful before a first retention run on a new corpus.
+EBULL_RAW_RETENTION_DRY_RUN=false
+
+# Skip re-fetching filing bodies already stored. Off by default because
+# the dedupe key is still being validated.
+EBULL_ENABLE_FILINGS_FETCH_DEDUPE=false

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,6 @@
 import os
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, AliasGenerator, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Minimum service-token length. 32 chars of base64/hex is ~192 bits of
@@ -39,8 +39,81 @@ os.environ.setdefault("PGCONNECT_TIMEOUT", str(DB_CONNECT_TIMEOUT_S))
 DEV_LIKE_ENVS: frozenset[str] = frozenset({"dev", "test", "local"})
 
 
+def _ebull_alias(field_name: str) -> AliasChoices:
+    """Accept both ``EBULL_<NAME>`` and the bare ``<NAME>`` for every field.
+
+    ⚠ THIS IS A SECURITY-RELEVANT DEFAULT, not a convenience. ``EBULL_`` is this
+    repo's environment-variable convention — ``EBULL_SECRETS_KEY``,
+    ``EBULL_ENV``, ``EBULL_DATA_DIR``, ``EBULL_SKIP_CATCH_UP`` and the rest are
+    all read that way, and ``.env.example`` + the README document the settings
+    below under the same prefix. But ``Settings`` has no ``env_prefix``, so
+    before this generator existed a field read ONLY the bare name and silently
+    dropped the documented one.
+
+    #1406 hit exactly this on ``secrets_key`` and fixed it with a per-field
+    ``AliasChoices``. It fixed one field and left six — measured 2026-08-05
+    (#2286): ``EBULL_SERVICE_TOKEN``, ``EBULL_BOOTSTRAP_TOKEN``, ``EBULL_HOST``,
+    ``EBULL_SESSION_COOKIE_SECURE``, ``EBULL_SESSION_IDLE_TIMEOUT_MINUTES`` and
+    ``EBULL_SESSION_ABSOLUTE_TIMEOUT_HOURS`` were all documented, all set in the
+    working ``.env``, and all read by nothing. The sharpest was the cookie flag:
+    an operator setting ``EBULL_SESSION_COOKIE_SECURE=true`` for a TLS
+    deployment got an insecure cookie and no indication (it feeds ``secure=`` at
+    ``app/api/auth_session.py``). The bootstrap-token case degraded to Mode A on
+    loopback and failed CLOSED off it, so it was a denial of the configured mode
+    rather than a bypass.
+
+    A seventh per-field patch would have been the wrong fix. Generating the
+    alias for every field makes the trap unrepresentable instead of remembered,
+    which is the difference between a rule and a habit. The documented
+    ``EBULL_`` spelling wins; the bare name stays working for back-compat.
+
+    Guarded by ``tests/test_config_env_contract.py``, which derives the field
+    set by AST and asserts each has a ``.env.example`` entry under one of its
+    accepted names — the check has to read the ALIAS set, because a check on
+    bare field names would have passed happily throughout the whole defect.
+    """
+    upper = field_name.upper()
+    return AliasChoices(f"EBULL_{upper}", upper)
+
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        extra="ignore",
+        alias_generator=AliasGenerator(validation_alias=_ebull_alias),
+        # ⚠ LOAD-BEARING, and it is what makes the alias above safe to add.
+        # A blank ``FOO=`` line means "not configured" to every operator who
+        # ever copied .env.example; pydantic-settings disagrees by default and
+        # treats it as the empty string. That interacts badly with an alias:
+        # the documented ``EBULL_FOO=`` (blank, copied from the example and
+        # never filled) is PRESENT, so it wins the AliasChoices race, and the
+        # bare ``FOO=<real value>`` sitting two lines below is never consulted.
+        #
+        # Measured on the working .env before this landed (#2286): adding the
+        # alias alone moved ``service_token`` from a 64-character credential to
+        # "" — a live break of the bearer-token auth path, caused by a fix.
+        # Caught by running Settings() against the REAL .env rather than a
+        # synthetic one, which is the only place the duplicate existed.
+        #
+        # It also corrects a pre-existing inconsistency: ``secrets_key`` is
+        # typed ``str | None`` and was already reading "" rather than None from
+        # a blank line, so every ``is None`` check on it was quietly false.
+        env_ignore_empty=True,
+        # ⚠ REQUIRED once alias_generator is set, and its absence fails
+        # SILENTLY. A ``validation_alias`` REPLACES the field name as an input
+        # key, so without this ``Settings(database_url=...)`` stops being
+        # accepted — and because ``extra="ignore"`` is set, the kwarg is
+        # discarded without error and the value falls back to .env or the
+        # default. Verified: both kwargs of
+        # ``Settings(database_url=..., app_env=...)`` were dropped.
+        #
+        # No caller uses field-name kwargs today (only ``_env_file=None``), so
+        # nothing was broken — but leaving it out would have reintroduced the
+        # exact defect this change exists to fix, one layer up: a value you set
+        # that does nothing and says nothing. Caught by Codex, not by the
+        # suite, because no test constructs Settings that way.
+        populate_by_name=True,
+    )
 
     app_env: str = "dev"
     database_url: str = "postgresql://postgres:postgres@localhost:5432/ebull"

--- a/app/security/master_key.py
+++ b/app/security/master_key.py
@@ -449,7 +449,18 @@ def bootstrap(conn: psycopg.Connection[object]) -> BootResult:
     # install the key when state == "normal" (i.e. matching ciphertext
     # exists) — clean_install with no env override returns None so the
     # first credential save runs the lazy-gen path.
-    install_key = settings.secrets_key is not None or state == "normal"
+    # ``bool(...)`` and NOT ``is not None`` — deliberately, and it must match
+    # the ``if settings.secrets_key:`` test above that decides ``derived``.
+    # ``is not None`` reads "the operator set the env override", which is only
+    # true when the variable is ABSENT vs SET. A blank ``EBULL_SECRETS_KEY=``
+    # line — the state you get by copying .env.example and not filling it in,
+    # and the state the working .env was actually in — made the field ``""``,
+    # so this took the env-override branch with no override set while
+    # ``derived`` came from the file path. #2286 fixed the root cause with
+    # ``env_ignore_empty=True``; this keeps the two tests consistent even if
+    # the field is ever ``""`` again, rather than relying on a config flag two
+    # modules away.
+    install_key = bool(settings.secrets_key) or state == "normal"
     return BootResult(
         state=state,
         broker_encryption_key=derived if install_key else None,

--- a/tests/test_config_env_contract.py
+++ b/tests/test_config_env_contract.py
@@ -1,0 +1,152 @@
+"""Derived contract between ``Settings``, ``.env.example`` and the alias rule.
+
+⚠ THE CHECK READS THE ALIAS SET, NOT THE BARE FIELD NAME. That is the whole
+point and it is not a detail: a check keyed on bare field names would have
+passed happily throughout the #2286 defect, because `.env.example` documented
+``EBULL_SERVICE_TOKEN`` while the field read only ``SERVICE_TOKEN``. Both
+"documented" and "a field exists" were true; the one thing that mattered — that
+the documented spelling is one the field actually accepts — was checked nowhere.
+
+Same shape as the closed-vocabulary contract test from #2229, and the same
+recurring lesson: a three-place invariant with no derived check always drifts.
+Here the three places are `.env.example`, ``Settings``, and the alias rule.
+
+Field names are read by AST rather than by importing ``Settings``, so the test
+does not depend on a working environment and cannot be fooled by whatever
+happens to be set when it runs.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+from pydantic import AliasChoices
+
+from app.config import Settings, _ebull_alias
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PY = REPO_ROOT / "app" / "config.py"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+
+# Fields deliberately absent from `.env.example`, each with the reason. An
+# entry here is a DECISION, not a snooze: adding one is how you say "an operator
+# should never set this", and the reason is what a reviewer checks.
+#
+# ⚠ Empty on purpose right now. #2286 found that every previously-undocumented
+# field turned out to be one an operator legitimately might set — including two
+# credentials and a cookie-security flag. If you are about to add a name here,
+# the bar is "setting this cannot help anyone", not "documenting it is tedious".
+DELIBERATELY_UNDOCUMENTED: dict[str, str] = {}
+
+
+def _settings_field_names() -> list[str]:
+    """Annotated field names on ``Settings``, by AST."""
+    tree = ast.parse(CONFIG_PY.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "Settings":
+            return [
+                stmt.target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name)
+            ]
+    raise AssertionError("class Settings not found in app/config.py")
+
+
+def _env_example_keys() -> set[str]:
+    """Assignment keys in `.env.example`, commented-out ones included.
+
+    A commented `# FOO=` line still documents the variable — it tells the
+    operator it exists and is optional — so it counts. What does NOT count is
+    prose merely mentioning the name, which is why this matches an assignment.
+    """
+    pattern = re.compile(r"^\s*#?\s*([A-Za-z_][A-Za-z0-9_]*)\s*=", re.MULTILINE)
+    return set(pattern.findall(ENV_EXAMPLE.read_text()))
+
+
+def _accepted_names(field: str) -> set[str]:
+    """Every env-var spelling that actually reaches ``field``."""
+    info = Settings.model_fields[field]
+    alias = info.validation_alias
+    if alias is None:
+        return {field.upper()}
+    if isinstance(alias, AliasChoices):
+        return {str(c) for c in alias.choices}
+    return {str(alias)}
+
+
+def test_every_settings_field_is_documented_under_a_name_it_accepts() -> None:
+    documented = _env_example_keys()
+    missing = [
+        field
+        for field in _settings_field_names()
+        if field not in DELIBERATELY_UNDOCUMENTED and not (_accepted_names(field) & documented)
+    ]
+    assert not missing, (
+        "Settings fields with no .env.example entry under any name they accept: "
+        f"{sorted(missing)}. .env.example is the only onboarding contract a fresh "
+        "clone has (README: `cp .env.example .env`), so an absent field is one the "
+        "operator can only discover from a runtime failure. Add an entry, or add "
+        "the field to DELIBERATELY_UNDOCUMENTED with a reason."
+    )
+
+
+def test_env_example_documents_no_variable_the_app_cannot_read() -> None:
+    """The #2286 defect, stated as a test.
+
+    Six `EBULL_*` variables were documented, set in the working `.env`, and read
+    by nothing — including two credentials and the session-cookie security flag.
+    Nothing failed, because a variable the app ignores produces silence.
+    """
+    accepted: set[str] = set()
+    for field in _settings_field_names():
+        accepted |= _accepted_names(field)
+
+    # Names `.env.example` documents that no Settings field accepts. Some are
+    # legitimately not Settings fields at all (docker-compose reads POSTGRES_*,
+    # the runtime reads EBULL_ENV via os.environ), so only EBULL_-prefixed names
+    # whose bare form IS a Settings field can be judged here — those are exactly
+    # the ones that look like they configure a setting and do not.
+    fields_upper = {f.upper() for f in _settings_field_names()}
+    unreadable = sorted(
+        key
+        for key in _env_example_keys()
+        if key.startswith("EBULL_") and key.removeprefix("EBULL_") in fields_upper and key not in accepted
+    )
+    assert not unreadable, (
+        f".env.example documents EBULL_-prefixed variables the app does not read: {unreadable}. "
+        "Each names a real Settings field, so an operator setting it gets silence rather than "
+        "an error. This is what #2286 found live in the working .env."
+    )
+
+
+@pytest.mark.parametrize("field", ["service_token", "bootstrap_token", "session_cookie_secure", "secrets_key"])
+def test_security_relevant_fields_accept_the_documented_ebull_spelling(field: str) -> None:
+    """Named individually because these are the ones whose silence costs something.
+
+    ``secrets_key`` is included even though #1406 already fixed it: it is the
+    regression that proves the generator subsumes the per-field alias, so the
+    explicit one could be removed without re-breaking it.
+    """
+    assert f"EBULL_{field.upper()}" in _accepted_names(field)
+    assert field.upper() in _accepted_names(field), "bare name must stay working for back-compat"
+
+
+def test_alias_helper_produces_both_spellings() -> None:
+    assert {str(c) for c in _ebull_alias("some_field").choices} == {"EBULL_SOME_FIELD", "SOME_FIELD"}
+
+
+def test_field_name_kwargs_still_construct_settings() -> None:
+    """`alias_generator` without `populate_by_name` drops kwargs SILENTLY.
+
+    A `validation_alias` replaces the field name as an input key, and with
+    `extra="ignore"` the discarded kwarg raises nothing — the value just falls
+    back to `.env` or the default. That is the very defect this module's alias
+    work exists to fix, reintroduced one layer up, so it gets a test rather
+    than a comment.
+    """
+    s = Settings(database_url="postgresql://sentinel/x", app_env="sentinel_env")
+    assert s.database_url == "postgresql://sentinel/x"
+    assert s.app_env == "sentinel_env"

--- a/tests/test_config_env_contract.py
+++ b/tests/test_config_env_contract.py
@@ -61,8 +61,15 @@ def _env_example_keys() -> set[str]:
     A commented `# FOO=` line still documents the variable — it tells the
     operator it exists and is optional — so it counts. What does NOT count is
     prose merely mentioning the name, which is why this matches an assignment.
+
+    ⚠ UPPERCASE-only, deliberately. Every env var here is UPPER_SNAKE, and the
+    looser `[A-Za-z_]` form would match ordinary prose inside a comment (`# set
+    foo=bar to ...`). That failure is PERMISSIVE — a false match makes a field
+    look documented when it is not — so the check would fail in the direction
+    that reports success. Measured on the current file the two forms return an
+    identical 38 keys, so this narrows the future, not the present.
     """
-    pattern = re.compile(r"^\s*#?\s*([A-Za-z_][A-Za-z0-9_]*)\s*=", re.MULTILINE)
+    pattern = re.compile(r"^\s*(?:#\s*)?([A-Z][A-Z0-9_]*)\s*=", re.MULTILINE)
     return set(pattern.findall(ENV_EXAMPLE.read_text()))
 
 


### PR DESCRIPTION
The issue framed this as *"17 settings undocumented"*. Re-measuring before acting (working-order 3b) found a different and sharper problem, and it was **live on the dev box**.

## What was actually wrong

`.env.example` documents six `EBULL_`-prefixed variables. `Settings` has **no `env_prefix`** ([app/config.py:43](app/config.py#L43)) and only `secrets_key` carried an alias — so five of the six were read by nothing.

Verified empirically against an isolated empty `.env`, not inferred from the code:

| documented in `.env.example` | app read it? | result with the var set |
| --- | --- | --- |
| `EBULL_SECRETS_KEY` | ✅ | picked up — per-field alias from #1406 |
| `EBULL_SERVICE_TOKEN` | ❌ | `service_token` stayed `None` |
| `EBULL_BOOTSTRAP_TOKEN` | ❌ | `bootstrap_token` stayed `None` |
| `EBULL_SESSION_COOKIE_SECURE=true` | ❌ | stayed **`False`** |
| `EBULL_SESSION_IDLE_TIMEOUT_MINUTES=999` | ❌ | stayed `60` |
| `EBULL_SESSION_ABSOLUTE_TIMEOUT_HOURS=999` | ❌ | stayed `12` |
| `EBULL_HOST=<x>` | ❌ | stayed `127.0.0.1` |

**Four of these are set in the working `.env` right now.** Nothing errored, nothing warned, every health check passed — the self-consistent-signal class.

### Security impact, checked rather than assumed

- **`EBULL_SESSION_COOKIE_SECURE` is the sharp one.** It feeds `secure=` on the real cookie ([auth_session.py:164](app/api/auth_session.py#L164), `:175`). An operator setting it `true` for a TLS deployment got an insecure cookie and no indication. **No fail-closed rescue.**
- **`EBULL_BOOTSTRAP_TOKEN` degrades but fails CLOSED.** [README.md:189](README.md#L189) instructs setting it; `resolve_bootstrap_token()` reads `settings.bootstrap_token`, which stayed `None`. Traced both branches of `is_setup_authorised`: loopback silently runs Mode A instead of the configured Mode B; off-loopback `active is None → return False`. **A denial of the configured mode, not a bypass** — stating that plainly because the opposite claim is the more alarming one and is not what the code does.

## Why a generator and not a seventh alias

[config.py:186-190](app/config.py#L186-L190) already describes this exact trap, for `secrets_key`, from #1406:

> `Settings` has no `env_prefix` so without an alias the field would only read the bare `SECRETS_KEY` and silently drop a documented `EBULL_SECRETS_KEY`.

**#1406 fixed one field and left six** — including two credentials and the cookie flag. `EBULL_` is unambiguously the house convention (58 refs to `EBULL_SECRETS_KEY`, 50 to `EBULL_ENV`, plus `EBULL_SKIP_CATCH_UP`, `EBULL_DEV_DB_NAMES`…, all read via `os.environ` and all working). `Settings` is the outlier. One `alias_generator` yielding `AliasChoices("EBULL_<NAME>", "<NAME>")` makes the trap unrepresentable instead of remembered.

## Two things the alias alone would have broken

Both caught before push, and neither by the existing suite.

**1. `env_ignore_empty=True` — a live auth break, caused by the fix.**

The working `.env` has `EBULL_SERVICE_TOKEN=` (blank, copied from the example and never filled) *and* `SERVICE_TOKEN=<64 chars>` two lines below. A blank var is **present**, so it wins the AliasChoices race:

```
Settings() against the REAL .env, alias only:        service_token len=0   ← broken
Settings() against the REAL .env, alias + ignore:    service_token len=64  ← correct
```

Only visible by running `Settings()` against the **real** `.env` — a synthetic fixture has no duplicate. It also fixes a pre-existing inconsistency: `secrets_key` is typed `str | None` and was reading `""`, so every `is None` check on it was quietly false.

**2. `populate_by_name=True` — the same defect, one layer up.**

A `validation_alias` replaces the field name as an input key, so `Settings(database_url=...)` silently stopped being accepted and `extra="ignore"` discarded it with no error. Measured: both kwargs of `Settings(database_url=..., app_env=...)` dropped. No caller uses field-name kwargs today (only `_env_file=None`), so nothing was broken — but omitting this would have reintroduced *a value you set that does nothing and says nothing*, which is the entire subject of this PR. **Found by Codex at checkpoint 2**; no test constructed `Settings` that way.

## Related one-token fix in the master-key path

[master_key.py:452](app/security/master_key.py#L452) had:

```python
install_key = settings.secrets_key is not None or state == "normal"
```

The comment above it says the intent is *"when `EBULL_SECRETS_KEY` is set"*. But `is not None` is true for a **blank** line too, so on this box it took the env-override branch with no override set, while `derived` came from the file path (the `if settings.secrets_key:` test 35 lines above is truthiness, not identity). Now `bool(...)`, consistent with that test and robust even if the field is ever `""` again.

## The guard

`tests/test_config_env_contract.py` derives the `Settings` field set **by AST** and asserts each is documented under a name it **actually accepts**.

That last clause is the whole point: a check keyed on bare field names would have passed happily throughout this defect, because `.env.example` documented `EBULL_SERVICE_TOKEN` while the field read `SERVICE_TOKEN`. Both "it is documented" and "the field exists" were true; the only thing that mattered was checked nowhere. Same shape as the closed-vocabulary contract test from #2229.

A second test asserts `.env.example` documents no `EBULL_*` variable whose bare form is a real field but which nothing accepts — i.e. this exact defect, as a test.

`.env.example` also gains the **10 genuinely-missing** fields in house style (`REDIS_URL`, `DATA_DIR`, `ETORO_BASE_URL`, `SESSION_COOKIE_NAME`, `ORCHESTRATOR_ENABLED`, the two SEC sweep deadlines, `SEC_FILER_INGEST_CONCURRENCY`, `RAW_RETENTION_DRY_RUN`, `ENABLE_FILINGS_FETCH_DEDUPE`). `DELIBERATELY_UNDOCUMENTED` is empty on purpose — every previously-undocumented field turned out to be one an operator legitimately might set.

## ⚠ Operator action after merge

`.env` on this box has **`SERVICE_TOKEN`** (64 chars, working) and **`EBULL_SERVICE_TOKEN=`** (blank). With `env_ignore_empty` the blank one is ignored and the real token keeps working, so **no action is required for correctness** — but the duplicate is worth deleting so the file says what it means. Same for any other blank `EBULL_*` line whose bare twin carries the value. No values were read, printed or committed while doing this.

## Not in this PR

Scope item 2 of the issue — deciding which settings belong in the admin UI vs deploy-time vs secrets — is untouched. It is a product decision, not a drift fix, and folding it in would have hidden a security-relevant correction inside a refactor. Item 3 (prune dead entries) found nothing dead: `LSE_API_KEY` had already been removed.

## Security

The change is a tightening. Credentials and the session-cookie flag now honour the spelling the docs have always told operators to use; nothing new is read from the environment that was not already documented; both spellings are accepted so no existing deployment loses a setting. `env_ignore_empty` cannot promote an unset value to a set one — it only stops a blank from masking a real one.

## Checks

`ruff check` · `ruff format --check` · `pyright` · `pytest -m "not db"` (0 failures) · `pytest tests/smoke` (0 failures) · `pytest -m db tests/test_security_master_key.py` (green — the touched security module) · Codex checkpoint 2.

Refs #2286. Refs #1406.