### PR TITLE
fix(#2297): wire the Form 25 delisting guard — and the wiring falsifies it

### DIFF
--- a/.claude/skills/data-sources/research-price-corpus.md
+++ b/.claude/skills/data-sources/research-price-corpus.md
@@ -126,32 +126,67 @@ Two guards are mandatory whenever free data is used, because it fails silently:
 - **Label it.** A metric computed on a survivor-only universe is marked as such in the
   signal ledger, not in a comment.
 - **Guard ticker reuse.** Require the series' first bar to precede the instrument's known
-  listing date, and truncate at any Form 25 suspension date.
+  listing date. ⚠ The second half as originally written — "truncate at any Form 25
+  suspension date" — was tried in #2297 and does not work; see the block immediately
+  below before implementing anything against it.
 
-⚠⚠ **The second guard is NOT implemented — do not assume it ran.** Measured
-2026-08-05 while scoping #2279:
+⚠⚠ **The second guard is now WIRED (#2297) and the wiring FALSIFIED it. Truncating at the
+Form 25 suspension date cannot be done correctly, and the reason is structural, not a
+coverage gap that more data fixes.** Run
+`uv run python -m scripts.ingest_2282_research_archive --link-delistings` for live figures.
 
+The asymmetry, measured on the full 2023 register — this is the whole finding:
+
+```sql
+select coalesce(rule_provision,'(c)/absent') as provision,
+       count(*), count(suspension_date)
+  from sec_form25_common_equity_delistings group by 1;
+--   (a)(3)  212  62
+--   (b)     105   0
 ```
-research_price_series                 7,693 series
-  ... with delisting_date populated       0
-sec_form25_common_equity_delistings     317 rows, 260 with a resolved_symbol
-cohort symbols also present in the corpus 16
-```
 
-The schema (sql/249 `delisting_date` + `delisting_source`, CHECK-paired, with a column
-comment insisting on the SUSPENSION date) and the register (#2282 2c) both exist. **Nothing
-joins them** — `grep -rn "delisting_date" app/ scripts/` returns one hit, a docstring. So 16
-corpus series are 2023-delisted names whose bars run straight through the delisting: the
-`SI`/Silvergate shape sql/249 names as its target failure mode.
+- **`(b)` is the provision where truncation is unambiguously right** — exchange-initiated
+  delisting for non-compliance, the ticker died. It states a suspension date on **0 of 105**
+  cohort rows, because that sentence lives in the EX-99 rule-provision exhibit and exchanges
+  attach a stub (sec-edgar.md §2.6 trap 5).
+- **Every date the cohort supplies is `(a)(3)`** — merger, holdco reorganisation,
+  redomiciliation, where the same economic entity commonly keeps trading under the same
+  ticker and a continuous series is CORRECT.
 
-Filed as **#2297**. Until it lands, every figure computed on this corpus is computed over
-series that may be welded, and that has to be stated rather than assumed away. This is the
-class the instruction set warns about — the guard *reads* as present because the column,
-the comment and the register all exist, and it is enforced nowhere.
+So the truncation set is empty by construction, and a provision-blind truncation fires only
+where it is wrong. Concretely, the two corpus series that carry a date are `LIN` (Linde plc,
+8,572 bars, 1992→2026) and `AMRX` (Amneal, 2,051 bars) — **both `is_tradable = true` in our
+universe today**. Truncating either deletes ~3 years of correct history from a live name.
+Linde's own EX-99 (accession `0000876661-23-000160`, fetched direct from EDGAR) states all
+three dates: removal-effective March 13, operation-of-law March 01, *"suspended from trading
+on March 02, 2023"* — and LIN trades now.
+
+**What #2297 therefore shipped:** the date and its `delisting_provision` are STORED
+(sql/253, CHECK-tied so a reader of the date cannot lose the provision), and nothing
+truncates — at ingest or at read time. `link_form25_delistings` in
+`app/services/research_corpus_ingest.py`.
+
+**What is actually detectable, and it is the OTHER half of the guard.** "First bar precedes
+the known listing date" was thought unimplementable because the schema holds no listing date.
+A proxy needs neither a listing date nor a threshold: a series whose first bar postdates a
+Form 25 on the same symbol cannot be the series of the security that filing removed. Four
+today — `ALPS` (filed 2023-07-27, first bar 2025-10-31), `ATCX` (2023-04-19 → 2026-01-09),
+`USX` (2023-07-03 → 2026-06-03), `DBD` (2023-06-20 → 2023-08-14). ⚠ It is reported, never
+acted on: `DBD` is Diebold Nixdorf relisting after Chapter 11, the SAME company. The honest
+output is "identity unverified" — which is the FIRST guard (label it), not the second.
+
+⚠ **No corpus series is currently known to be welded.** `REED` and `SRAX` span their `(b)`
+filings with no gap at all (last bar the day before, first bar the day of) — both moved to
+OTC, which is continuation of the same company, not contamination. `terminating` is **0**:
+nothing in the archive ends at a delisting, which is the same structural fact as the 0/259
+acceptance result below.
+
+⚠ **The overlap is 15 series, not 16.** The earlier figure counted JOIN ROWS: `AESI` has two
+cohort filings (a 25-NSE and its 25-NSE/A, same day), so a naive join double-counts it —
+§2.6 trap 1's shape one level up. Aggregate the cohort per symbol before joining.
 
 ⚠ Note also that only **62 of 317** cohort rows carry a `suspension_date` at all (395 of
-1,282 across the whole register), because the date lives in the EX-99 rule-provision exhibit
-and most filings attach a stub. The other 255 must stay NULL; back-filling with `filed_date`
+1,282 across the whole register). The other 255 must stay NULL; back-filling with `filed_date`
 is a different event and mistruncates. Reproduce with
 `select count(*), count(suspension_date) from sec_form25_register`.
 

--- a/.claude/skills/data-sources/sec-edgar.md
+++ b/.claude/skills/data-sources/sec-edgar.md
@@ -448,6 +448,27 @@ suspension date?") is only checkable on those 38. For the rest, `filed_date` is 
 date available and it is a **different event** — store NULL rather than substituting, which
 is why `research_price_series.delisting_date` is CHECK-paired to `delisting_source`.
 
+⚠⚠ **The scarcity is not uniform across provisions, and the direction is the worst
+possible one.** Measured 2026-08-05 (#2297) on the common-equity cohort:
+
+```sql
+select coalesce(rule_provision,'(c)/absent'), count(*), count(suspension_date)
+  from sec_form25_common_equity_delistings group by 1;
+--   (a)(3)  212  62
+--   (b)     105   0
+```
+
+**`(b)` — the exchange-initiated failure, the one provision where truncating a price series
+is unambiguously right — states a suspension date on ZERO of 105.** Every date the cohort
+supplies is on `(a)(3)`, where the same ticker very often keeps trading (holdco reorg,
+redomiciliation) and truncation is likely WRONG. Linde is the worked case: its `(a)(3)`
+EX-99 states all three dates cleanly, and `LIN` is `is_tradable = true` today.
+
+So "truncate at the suspension date" is not a guard that needs better coverage — it is a
+rule that can only ever fire where it does the damage. Store the date WITH its provision
+(sql/253 `delisting_provision`) and let the reader stratify; do not truncate on the date
+alone. Full write-up in `research-price-corpus.md`.
+
 **Coverage limit, stated once:** Form 25 is **US-only**. There is no free authoritative
 equivalent for EU / UK / Asia / MENA listings.
 

--- a/app/services/research_corpus_ingest.py
+++ b/app/services/research_corpus_ingest.py
@@ -150,8 +150,11 @@ class LoadCensus:
             "schema holds no listing date. instruments.first_seen_at is the "
             "eToro DETECTION date (#2290), not a listing date, and using it "
             "would reject every series with real pre-2025 history; #2290's "
-            "forward record is what eventually supplies one. The delisting "
-            "half needs stage 2c's Form 25 suspension dates. ⚠ A DIFFERENT "
+            "forward record is what eventually supplies one. ⚠ The delisting "
+            "half is now WIRED (#2297, `--link-delistings`) and it reaches "
+            "almost nothing: `(b)` delistings state no suspension date at all, "
+            "so the truncation set is empty by construction — see "
+            "`link_form25_delistings`. ⚠ A DIFFERENT "
             "discriminator does work and is run by `--verify`: return "
             "correlation against price_daily over the shared window. It "
             "reaches only the series with eToro overlap, and separating "
@@ -810,4 +813,256 @@ def run_quarantine(
                 f"{census.bars_evaluated:,}",
             )
 
+    return census
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Form 25 delisting linkage (#2297)
+# ---------------------------------------------------------------------------
+#
+# THE GUARD AS SPECIFIED DOES NOT WORK, AND THE MEASUREMENT SAYS SO
+# ---------------------------------------------------------------------------
+# `research-price-corpus.md` names two mandatory guards, the second being
+# "require the series' first bar to precede the known listing date, and
+# truncate at any Form 25 suspension date". sql/249 shipped the columns and
+# #2282 stage 2c shipped the register; nothing joined them, which is what #2297
+# was filed for.
+#
+# Joining them produced a falsified premise rather than a fix. Measured on the
+# full 2023 register, not a sample:
+#
+#     provision   cohort rows   with a suspension_date
+#     (a)(3)          212              62
+#     (b)             105               0
+#
+# `(b)` — exchange-initiated delisting for non-compliance — is the provision
+# where truncation is unambiguously right, and it never states a suspension
+# date, because that sentence lives in the EX-99 rule-provision exhibit and
+# exchanges attach a stub (sec-edgar.md §2.6 trap 5). Every date the cohort
+# does supply is `(a)(3)`: merger, holdco reorganisation, redomiciliation,
+# where the same economic entity commonly keeps trading under the same ticker.
+#
+# So the truncation set is EMPTY by construction, and the two series that carry
+# a date are `LIN` (Linde plc, 8,572 bars) and `AMRX` (Amneal, 2,051) — both
+# `instruments.is_tradable = true` today. Truncating either would delete ~3
+# years of correct history from a live name to satisfy a rule aimed at dead
+# ones.
+#
+# ⚠ THEREFORE THIS FUNCTION DOES NOT TRUNCATE, AT INGEST OR AT READ TIME.
+# It records the evidence (date + provision, CHECK-tied by sql/253) and
+# publishes what is NOT covered. Reader-side truncation was the right call
+# between the two options on the table; it is simply not the question, because
+# a provision-blind truncation has nothing correct to act on and a
+# provision-aware one has nothing to act on at all.
+#
+# WHAT IS ACTUALLY DETECTABLE
+# ---------------------------------------------------------------------------
+# The other half of the guard — "first bar precedes the known listing date" —
+# was thought unimplementable because the schema holds no listing date. It has
+# a usable proxy that needs no suspension date and no threshold: a series whose
+# FIRST bar postdates a Form 25 filing on the same symbol cannot be the series
+# of the security that filing removed. That is reported, not acted on, because
+# `DBD` proves post-dating is not sufficient evidence of reuse — Diebold
+# Nixdorf's 2023-08-14 restart is the same company relisting after Chapter 11.
+# The honest output is "identity unverified", which is the FIRST mandatory
+# guard (label it), not the second.
+
+
+@dataclass
+class DelistingLinkCensus:
+    """What the linkage covered, and — the load-bearing half — what it did not."""
+
+    #: Corpus series whose vendor symbol appears in the common-equity cohort.
+    overlap_series: int = 0
+    #: Series given a ``delisting_date``. Requires a stated suspension date.
+    suspension_dates_written: int = 0
+    #: Overlapping series left NULL because the filing states no suspension
+    #: date. NOT back-filled from ``filed_date``: that is a different event and
+    #: mistruncates every series it touches (sec-edgar.md §2.6 trap 5).
+    no_suspension_date: int = 0
+    #: Symbols whose cohort filings disagree on provision or suspension date.
+    #: Left NULL rather than tie-broken — two different delisting events on one
+    #: ticker is precisely the ambiguity the guard exists to surface.
+    conflicting: list[str] = field(default_factory=list)
+    #: Overlap by rule provision. `(b)` here with a zero write count is the
+    #: measurement that kills provision-blind truncation.
+    by_provision: dict[str, int] = field(default_factory=dict)
+    #: (symbol, earliest filing, first bar) where the series starts AFTER a
+    #: Form 25 on that symbol. Identity unverified — may be a later occupant
+    #: or the same issuer relisting.
+    identity_unverified: list[tuple[str, date, date]] = field(default_factory=list)
+    #: (symbol, earliest filing, last bar) where the series ends BEFORE the
+    #: filing — a genuine termination, the shape the acceptance test expects
+    #: and has never yet observed on this archive.
+    terminating: list[tuple[str, date, date]] = field(default_factory=list)
+
+    @property
+    def coverage_note(self) -> str:
+        return (
+            "Form 25 coverage is 2023 ONLY (1,282 filings, 2023-01-03 to "
+            "2023-12-29) against a corpus spanning 1962-2026, and Form 25 is "
+            "US-only — there is no free authoritative equivalent for EU/UK/"
+            "Asia/MENA, where #2290's forward record is the only future "
+            "source. The cohort also excludes the 128 issuer-filed paragraph "
+            "(c) filings, which are delistings but carry no "
+            "descriptionClassSecurity and so cannot be verified as COMMON "
+            "EQUITY (sql/252's view comment). A series absent from this "
+            "linkage is therefore UNCHECKED, never 'checked and clean'."
+        )
+
+
+@dataclass(frozen=True)
+class Form25Match:
+    """One corpus series' aggregated Form 25 evidence, as the cohort CTE returns it."""
+
+    symbol: str
+    first_bar: date | None
+    last_bar: date | None
+    earliest_filed: date
+    provision_variants: int
+    provision: str | None
+    suspension_variants: int
+    suspension_date: date | None
+
+
+def classify_form25_match(match: Form25Match) -> str:
+    """What to do with one match: ``write`` / ``conflict`` / ``no_suspension``.
+
+    Pure so the policy is table-testable without a corpus. Three rules, and the
+    two refusals matter more than the write:
+
+    ``conflict`` — the cohort's filings for this symbol disagree on the
+    provision or on the suspension date. Two different delisting events on one
+    ticker is exactly the ambiguity the guard exists to surface, so it is
+    counted and left NULL rather than tie-broken. There is no source rule
+    saying which of two filings wins, and inventing a precedence order
+    (latest-filed? the /A amendment?) would be a fabricated citation.
+
+    ``no_suspension`` — the filing states no suspension date. NULL is the
+    correct value: ``filed_date`` is a DIFFERENT event (a Form 25 carries up to
+    three dates, sec-edgar.md §2.6 trap 5), and substituting it mistruncates
+    every series it touches. This is the common case, not the exception —
+    ``(b)`` supplies a suspension date on 0 of 105 cohort rows.
+    """
+    if match.provision_variants > 1 or match.suspension_variants > 1:
+        return "conflict"
+    if match.suspension_date is None:
+        return "no_suspension"
+    return "write"
+
+
+def link_form25_delistings(
+    conn: psycopg.Connection[Any],
+    *,
+    vendor: str = VENDOR,
+) -> DelistingLinkCensus:
+    """Write Form 25 suspension dates onto the corpus. Truncates nothing.
+
+    Idempotent: clears every previously ``sec_form25``-sourced delisting for
+    this vendor before writing, so a rebuilt register cannot leave a stale date
+    behind. Other ``delisting_source`` values (``universe_membership``,
+    ``vendor``) are untouched — they come from #2290's forward record and this
+    function has no evidence about them.
+    """
+    census = DelistingLinkCensus()
+
+    # Scoped to the common-equity VIEW, never the raw register: a Form 25 is
+    # per-SECURITY, so `sec_form25_register` contains bond and warrant
+    # delistings whose issuer is very much alive (§2.6 traps 2, 3 and 6 —
+    # Berkshire filed two in 2023 and both were notes).
+    rows = conn.execute(
+        """
+        WITH cohort AS (
+            SELECT d.resolved_symbol                     AS symbol,
+                   min(d.filed_date)                     AS earliest_filed,
+                   count(DISTINCT d.rule_provision)      AS provision_variants,
+                   min(d.rule_provision)                 AS provision,
+                   count(DISTINCT d.suspension_date)     AS suspension_variants,
+                   min(d.suspension_date)                AS suspension_date
+              FROM sec_form25_common_equity_delistings d
+             WHERE d.resolved_symbol IS NOT NULL
+             GROUP BY d.resolved_symbol
+        )
+        SELECT s.series_id, s.vendor_symbol, s.first_bar, s.last_bar,
+               c.earliest_filed, c.provision_variants, c.provision,
+               c.suspension_variants, c.suspension_date
+          FROM research_price_series s
+          JOIN cohort c ON c.symbol = s.vendor_symbol
+         WHERE s.vendor = %s
+         ORDER BY s.vendor_symbol
+        """,
+        (vendor,),
+    ).fetchall()
+
+    conn.execute(
+        """
+        UPDATE research_price_series
+           SET delisting_date = NULL, delisting_source = NULL,
+               delisting_provision = NULL, updated_at = now()
+         WHERE vendor = %s AND delisting_source = 'sec_form25'
+        """,
+        (vendor,),
+    )
+
+    for (
+        series_id,
+        symbol,
+        first_bar,
+        last_bar,
+        earliest_filed,
+        provision_variants,
+        provision,
+        suspension_variants,
+        suspension_date,
+    ) in rows:
+        match = Form25Match(
+            symbol=symbol,
+            first_bar=first_bar,
+            last_bar=last_bar,
+            earliest_filed=earliest_filed,
+            provision_variants=provision_variants,
+            provision=provision,
+            suspension_variants=suspension_variants,
+            suspension_date=suspension_date,
+        )
+        census.overlap_series += 1
+        key = provision if provision_variants == 1 else "conflicting"
+        census.by_provision[key] = census.by_provision.get(key, 0) + 1
+
+        if first_bar is not None and first_bar > earliest_filed:
+            census.identity_unverified.append((symbol, earliest_filed, first_bar))
+        if last_bar is not None and last_bar < earliest_filed:
+            census.terminating.append((symbol, earliest_filed, last_bar))
+
+        action = classify_form25_match(match)
+        if action == "conflict":
+            census.conflicting.append(symbol)
+            continue
+        if action == "no_suspension":
+            census.no_suspension_date += 1
+            continue
+
+        conn.execute(
+            """
+            UPDATE research_price_series
+               SET delisting_date = %s,
+                   delisting_source = 'sec_form25',
+                   delisting_provision = %s,
+                   updated_at = now()
+             WHERE series_id = %s
+            """,
+            (suspension_date, provision, series_id),
+        )
+        census.suspension_dates_written += 1
+
+    conn.commit()
+    logger.info(
+        "form25 linkage: %d overlapping series, %d dated, %d with no stated "
+        "suspension date, %d conflicting, %d identity-unverified",
+        census.overlap_series,
+        census.suspension_dates_written,
+        census.no_suspension_date,
+        len(census.conflicting),
+        len(census.identity_unverified),
+    )
     return census

--- a/app/services/research_corpus_ingest.py
+++ b/app/services/research_corpus_ingest.py
@@ -1025,16 +1025,29 @@ def link_form25_delistings(
             suspension_variants=suspension_variants,
             suspension_date=suspension_date,
         )
+        action = classify_form25_match(match)
         census.overlap_series += 1
-        key = provision if provision_variants == 1 else "conflicting"
+
+        # Bucket by the CLASSIFIER's verdict, never by re-deriving the
+        # condition here. Keying on `provision_variants` alone undercounts:
+        # a symbol whose filings agree on the provision but disagree on the
+        # suspension date is a conflict the classifier refuses to write, and
+        # it would still have been filed under its provision — a census that
+        # disagrees with the writer about what happened.
+        key = "conflicting" if action == "conflict" else provision
         census.by_provision[key] = census.by_provision.get(key, 0) + 1
 
+        # ``earliest_filed`` is min() over the symbol's cohort filings, and the
+        # min is deliberate rather than incidental. Both tests below are
+        # one-sided, so the earliest filing is the CONSERVATIVE bound: "the
+        # series begins after a Form 25 on this symbol" and "the series ends
+        # before any Form 25 on this symbol" are each true against min() for
+        # every filing, including when a conflicted symbol carries two events.
         if first_bar is not None and first_bar > earliest_filed:
             census.identity_unverified.append((symbol, earliest_filed, first_bar))
         if last_bar is not None and last_bar < earliest_filed:
             census.terminating.append((symbol, earliest_filed, last_bar))
 
-        action = classify_form25_match(match)
         if action == "conflict":
             census.conflicting.append(symbol)
             continue

--- a/scripts/ingest_2282_research_archive.py
+++ b/scripts/ingest_2282_research_archive.py
@@ -6,6 +6,7 @@ Run from repo root:
     uv run python -m scripts.ingest_2282_research_archive --load
     uv run python -m scripts.ingest_2282_research_archive --quarantine
     uv run python -m scripts.ingest_2282_research_archive --verify
+    uv run python -m scripts.ingest_2282_research_archive --link-delistings
 
 ⚠ Long-running (~20-40 min end to end on 25.8M rows). Launch it with the
 tool's own background mode — a ``nohup … &`` started inside an ordinary tool
@@ -120,6 +121,34 @@ def quarantine(conn: psycopg.Connection[tuple], as_of: date) -> int:
     print(f"  elapsed               : {time.time() - started:.0f}s")
     for row in conn.execute("SELECT * FROM research_quarantine_census").fetchall():
         print(f"  census view: {row}")
+    return 0
+
+
+def link_delistings(conn: psycopg.Connection[tuple]) -> int:
+    """#2297 — wire the Form 25 register to the corpus. Writes dates, truncates nothing.
+
+    Prints the NOT-covered side first, deliberately. A linkage that reports
+    only what it matched reads as a completed guard; this one's headline
+    finding is that the truncation set is empty by construction.
+    """
+    census = ingest.link_form25_delistings(conn)
+    print("\n=== #2297 Form 25 delisting linkage ===")
+    print(f"  overlapping series      : {census.overlap_series:,}")
+    print(f"  suspension dates written: {census.suspension_dates_written:,}")
+    print(f"  no suspension date (NULL, not back-filled): {census.no_suspension_date:,}")
+    print(f"  conflicting symbols     : {census.conflicting or 'none'}")
+    print("  overlap by rule provision:")
+    for provision, n in sorted(census.by_provision.items()):
+        print(f"    {provision:>14} : {n:,}")
+    print(
+        f"  identity unverified (series starts after a Form 25 on the same symbol): {len(census.identity_unverified):,}"
+    )
+    for symbol, filed, first_bar in census.identity_unverified:
+        print(f"    {symbol:<8} filed {filed}  first bar {first_bar}")
+    print(f"  terminating at/near the filing: {len(census.terminating):,}")
+    for symbol, filed, last_bar in census.terminating:
+        print(f"    {symbol:<8} filed {filed}  last bar {last_bar}")
+    print(f"\n  coverage: {census.coverage_note}")
     return 0
 
 
@@ -263,6 +292,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--load", action="store_true")
     parser.add_argument("--quarantine", action="store_true")
     parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--link-delistings", action="store_true")
     parser.add_argument("--cache", type=Path, default=_DEFAULT_CACHE)
     parser.add_argument(
         "--as-of",
@@ -274,13 +304,13 @@ def main(argv: list[str] | None = None) -> int:
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
 
-    if not any((args.download, args.load, args.quarantine, args.verify)):
-        parser.error("pick at least one of --download / --load / --quarantine / --verify")
+    if not any((args.download, args.load, args.quarantine, args.verify, args.link_delistings)):
+        parser.error("pick at least one of --download / --load / --quarantine / --verify / --link-delistings")
 
     if args.download:
         download(args.cache)
 
-    if not any((args.load, args.quarantine, args.verify)):
+    if not any((args.load, args.quarantine, args.verify, args.link_delistings)):
         return 0
 
     with psycopg.connect(settings.database_url) as conn:
@@ -289,6 +319,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.quarantine and (rc := quarantine(conn, args.as_of)):
             return rc
         if args.verify and (rc := verify(conn)):
+            return rc
+        if args.link_delistings and (rc := link_delistings(conn)):
             return rc
     return 0
 

--- a/sql/253_research_series_delisting_provision.sql
+++ b/sql/253_research_series_delisting_provision.sql
@@ -1,0 +1,82 @@
+-- 253_research_series_delisting_provision.sql
+--
+-- #2297 — wire the Form 25 register (sql/252) to the research corpus (sql/249)
+-- and make the stored delisting date SAFE TO READ.
+--
+--
+-- WHY A PROVISION COLUMN AND NOT JUST THE DATE
+-- ---------------------------------------------------------------------------
+-- sql/249 shipped `delisting_date` + `delisting_source` and nothing populated
+-- them. The obvious fix — join the register's `resolved_symbol` to
+-- `vendor_symbol` and write the suspension date — creates a WORSE bug than the
+-- one it closes, because of an asymmetry measured on the full 2023 register:
+--
+--     provision   cohort rows   with a suspension_date
+--     (a)(3)          212              62
+--     (b)             105               0
+--
+-- `(b)` is exchange-initiated delisting for non-compliance: the ticker died,
+-- and truncating there is unambiguously right. It NEVER states a suspension
+-- date, because the date lives in the EX-99 rule-provision exhibit and
+-- exchanges attach a stub (sec-edgar.md §2.6 trap 5).
+--
+-- `(a)(3)` is "instruments now evidence OTHER securities by operation of law"
+-- — merger, holdco reorganisation, redomiciliation. The same economic entity
+-- very often keeps trading under the same ticker, so a continuous series is
+-- the CORRECT answer, not contamination. Every suspension date the cohort
+-- supplies is on this provision.
+--
+-- So a bare `delisting_date` is a loaded gun: it can only ever be populated
+-- where truncating on it is likely to be wrong. Measured on the corpus, the
+-- two series it reaches are `LIN` (Linde plc, 8,572 bars, 1992-2026) and
+-- `AMRX` (Amneal, 2,051 bars) — BOTH `instruments.is_tradable = true` today.
+-- Truncating either deletes ~3 years of correct history from a live name.
+--
+-- The provision travels with the date so no reader can lose that distinction.
+-- It is deliberately NOT a boolean: `(b)` and `(a)(3)` are the whole point,
+-- and sql/252's header makes the same argument for the register itself.
+--
+--
+-- WHAT IS **NOT** DENORMALISED HERE, AND WHY
+-- ---------------------------------------------------------------------------
+-- The filing date, the accession and the issuer stay in `sec_form25_register`
+-- and are read by joining `resolved_symbol = vendor_symbol`. Both tables live
+-- in this database, the join is 16 rows today, and copying those fields across
+-- would be three more things to drift. Only the provision is copied, because
+-- it is the one field a reader of `delisting_date` cannot safely be without.
+
+ALTER TABLE research_price_series
+    ADD COLUMN IF NOT EXISTS delisting_provision TEXT;
+
+-- BICONDITIONAL, both directions load-bearing:
+--
+--   → A Form 25-sourced delisting MUST carry its provision. A one-way check
+--     ("provision only from sec_form25") would still permit the bare date this
+--     migration exists to abolish, reachable by a manual UPDATE or a future
+--     writer — i.e. the schema would still be able to represent the unsafe
+--     state.
+--   ← #2290's forward record for non-US names and any vendor flag have no
+--     Rule 12d2-2 paragraph, so a provision on those is a fabricated citation.
+--
+-- ``IS NOT DISTINCT FROM`` rather than ``=`` because delisting_source is
+-- nullable and a NULL comparison would make the whole CHECK evaluate to NULL,
+-- which Postgres accepts as satisfied — the constraint would silently pass on
+-- exactly the rows that carry no source.
+ALTER TABLE research_price_series
+    DROP CONSTRAINT IF EXISTS research_price_series_provision_from_form25;
+ALTER TABLE research_price_series
+    ADD CONSTRAINT research_price_series_provision_from_form25
+        CHECK (
+            (delisting_source IS NOT DISTINCT FROM 'sec_form25')
+            = (delisting_provision IS NOT NULL)
+        );
+
+COMMENT ON COLUMN research_price_series.delisting_provision IS
+    'Rule 12d2-2 paragraph from the Form 25 that supplied delisting_date, e.g. '
+    '''(a)(3)'' or ''(b)''. ⚠ READ THIS BEFORE TRUNCATING ON delisting_date. '
+    '(b) is an exchange-initiated failure and the series should end; (a)(3) is '
+    'a merger/holdco reorganisation where the same ticker very often keeps '
+    'trading and a continuous series is correct. Measured on the 2023 register: '
+    'all 62 cohort suspension dates are (a)(3), and (b) supplies none at all '
+    '(sec-edgar.md 2.6 trap 5), so a provision-blind truncation fires only '
+    'where it is most likely to be wrong.';

--- a/tests/test_research_corpus_ingest.py
+++ b/tests/test_research_corpus_ingest.py
@@ -21,9 +21,13 @@ The schema invariants themselves live in ``test_research_corpus_schema.py``.
 
 from __future__ import annotations
 
+from datetime import date
+
 import pytest
 
 from app.services.research_corpus_ingest import (
+    Form25Match,
+    classify_form25_match,
     index_instruments,
     normalise_vendor_symbol,
 )
@@ -93,3 +97,76 @@ def test_same_instrument_listed_twice_is_not_a_collision() -> None:
     index, ambiguous = index_instruments([(10, "ABT"), (10, "ABT")])
     assert index == {"ABT": 10}
     assert ambiguous == set()
+
+
+# ---------------------------------------------------------------------------
+# #2297 — Form 25 delisting-link policy
+# ---------------------------------------------------------------------------
+#
+# The three cases below are the whole policy, and TWO OF THEM ARE REFUSALS.
+# That ratio is the finding: measured on the full 2023 register, `(b)` — the
+# provision where truncating a series is unambiguously right — states a
+# suspension date on 0 of 105 cohort rows, so `no_suspension` is the normal
+# outcome and `write` is the exception. A test suite that only exercised the
+# happy path would describe a guard that does not exist.
+
+
+def _match(**overrides: object) -> Form25Match:
+    """A match that WRITES unless an override makes it refuse.
+
+    ⚠ Deliberately not a "neutral" baseline: this fixture is the write case,
+    stated as such. A baseline that the classifier already refuses would make
+    every override look like it worked (test-quality.md, "a neutral fixture is
+    not neutral if the thing under test classifies it").
+    """
+    base: dict[str, object] = {
+        "symbol": "LIN",
+        "first_bar": date(1992, 6, 17),
+        "last_bar": date(2026, 7, 7),
+        "earliest_filed": date(2023, 3, 2),
+        "provision_variants": 1,
+        "provision": "(a)(3)",
+        "suspension_variants": 1,
+        "suspension_date": date(2023, 3, 2),
+    }
+    base.update(overrides)
+    return Form25Match(**base)  # type: ignore[arg-type]
+
+
+def test_stated_suspension_date_is_written() -> None:
+    # LIN, verified against SEC EDGAR direct: the EX-99 for accession
+    # 0000876661-23-000160 names THREE dates — removal-effective March 13,
+    # operation-of-law March 01, "suspended from trading on March 02, 2023".
+    # 2023-03-02 is the one that truncates correctly, per §2.6 trap 5.
+    assert classify_form25_match(_match()) == "write"
+
+
+def test_absent_suspension_date_is_never_backfilled_from_filed_date() -> None:
+    # The filing date is RIGHT THERE on the match and is a different event.
+    # Substituting it is the failure mode sql/249's CHECK pair exists to stop.
+    match = _match(suspension_date=None)
+    assert match.earliest_filed is not None
+    assert classify_form25_match(match) == "no_suspension"
+
+
+def test_disagreeing_filings_are_left_null_rather_than_tie_broken() -> None:
+    assert classify_form25_match(_match(suspension_variants=2)) == "conflict"
+    assert classify_form25_match(_match(provision_variants=2, provision=None)) == "conflict"
+
+
+def test_conflict_outranks_the_missing_date_branch() -> None:
+    # ⚠ The discriminating case, and the reason it is written with
+    # suspension_date=None: with the two branches in the other order this
+    # returns "no_suspension", which would UNDERCOUNT conflicts by silently
+    # filing them as ordinary missing dates. Probed by swapping the branches —
+    # this assertion fails, the other four still pass.
+    assert classify_form25_match(_match(provision_variants=2, suspension_date=None)) == "conflict"
+
+
+def test_provision_does_not_change_the_write_decision() -> None:
+    # ⚠ The classifier is provision-BLIND on purpose. Storing the date is
+    # always right (it is a true fact about the security); it is TRUNCATING on
+    # it that must be provision-aware, which is why sql/253 carries the
+    # provision alongside and nothing in this module truncates.
+    assert classify_form25_match(_match(provision="(b)")) == "write"
+    assert classify_form25_match(_match(provision="(a)(3)")) == "write"


### PR DESCRIPTION
## What was broken

`research_price_series.delisting_date` was populated on **0 of 7,693** series. The column
(sql/249, CHECK-paired, with a thorough comment), the register (#2282 stage 2c) and the
"mandatory" guard wording in `research-price-corpus.md` all existed. Nothing joined them —
`grep -rn "delisting_date" app/ scripts/` returned one hit, a docstring.

This is the self-consistent-health-signal class: the guard *reads* as present and is
enforced nowhere, so nothing fails and every audit passes.

## The premise check falsified the guard rather than completing it

Full 2023 register, common-equity cohort (`sec_form25_common_equity_delistings`), not a
sample:

```sql
select coalesce(rule_provision,'(c)/absent'), count(*), count(suspension_date)
  from sec_form25_common_equity_delistings group by 1;
--   (a)(3)  212   62
--   (b)     105    0
```

- **`(b)`** — exchange-initiated delisting for non-compliance, the one provision where
  truncating a price series is unambiguously right — states a suspension date on **0 of
  105**. The sentence lives in the EX-99 rule-provision exhibit and exchanges attach a stub
  (sec-edgar.md §2.6 trap 5).
- **Every date the cohort supplies is `(a)(3)`** — merger / holdco reorg / redomiciliation,
  where the same economic entity commonly keeps trading under the same ticker and a
  continuous series is *correct*.

The truncation set is therefore empty by construction, and a provision-blind truncation
fires only where it is wrong. The two corpus series carrying a date are `LIN` (Linde plc,
8,572 bars, 1992→2026) and `AMRX` (Amneal, 2,051 bars) — **both `is_tradable = true` in our
universe today**. Truncating either deletes ~3 years from a live name.

⚠ The overlap is **15 series, not the 16** on the issue. `AESI` has two cohort filings (a
25-NSE and its 25-NSE/A, same day), so a naive join double-counts it — §2.6 trap 1's shape
one level up. The cohort is now aggregated per symbol before joining.

⚠ **No series is currently known to be welded.** `REED` and `SRAX` span their `(b)` filings
with no gap (last bar the day before, first bar the day of) — both moved to OTC, which is
the same company continuing. `terminating` is **0**: nothing in this archive ends at a
delisting, the same structural fact as the 0/259 acceptance result.

## What ships

| | |
|---|---|
| `sql/253` | `delisting_provision`, **biconditionally** CHECK-tied to `delisting_source = 'sec_form25'` so a bare Form 25 date cannot be represented at all |
| `link_form25_delistings` | writes date + provision, clears stale `sec_form25` rows first (idempotent), **truncates nothing** at ingest or read time |
| `classify_form25_match` | the pure policy: `write` / `conflict` / `no_suspension`. Two of three outcomes are refusals |
| `--link-delistings` | new phase on `scripts/ingest_2282_research_archive.py`, printing the NOT-covered side first |

**Scope item 2 (reader-side vs ingest-side truncation) is answered "neither", not deferred.**
Reader-side was the right call between the two options; it is simply not the question,
because a provision-blind truncation has nothing correct to act on and a provision-aware one
has nothing to act on at all.

**Scope item 3** — "first bar precedes the known listing date" was thought unimplementable
(no listing date in the schema). It has a proxy needing neither a listing date nor a
threshold: a series whose first bar postdates a Form 25 on the same symbol cannot be the
series of the security that filing removed. Four today — `ALPS`, `ATCX`, `USX`, `DBD`. ⚠
Reported, never acted on: `DBD` is Diebold Nixdorf relisting after Chapter 11, the same
company. The honest output is "identity unverified", which is the FIRST guard (label it).

**Scope item 4** — residual coverage is printed by the phase itself rather than written
down: 2023-only register against a 1962→2026 corpus, US-only, and the 128 issuer-filed
paragraph-(c) filings excluded because their security class is unverifiable.

## Source rule

17 CFR 240.12d2-2, via `.claude/skills/data-sources/sec-edgar.md` §2.6 (traps 1, 2, 3, 5, 6)
— read before any column was chosen. §2.6 trap 5 is the governing rule for *which* date:
a Form 25 carries filing, removal-effective and suspension dates plus `master.idx`'s `filed`,
and only the suspension date is the last tradable day.

## Full-population verification

Every figure above is the full 2023 register (1,282 filings) and the full corpus (7,693
series). No sampling.

## Definition-of-Done clauses 8-12 — commit `72603779`

| clause | evidence |
|---|---|
| **8** smoke panel | The default panel is not informative here — none of `AAPL/GME/MSFT/JPM/HD` appears in the delisting cohort. Exercised the linkage's own population instead: `LIN`, `AMRX` (dated), `DBD`, `ALPS`, `ATCX`, `USX` (identity-unverified), `REED`, `SRAX` (`(b)` spanners). Stored result: `AMRX 2023-11-07 sec_form25 (a)(3)` / `LIN 2023-03-02 sec_form25 (a)(3)`, 2 of 7,693. |
| **9** cross-source | **SEC EDGAR direct.** Fetched `Archives/edgar/data/1707925/000087666123000160/ruleprovisionnotice.htm`. It states all three dates: removal-effective *"March 13, 2023"*, operation-of-law *"March 01, 2023"*, and *"this security was suspended from trading on **March 02, 2023**"*. Stored `delisting_date = 2023-03-02` ✓ — the parser took the suspension date, per trap 5. |
| **10** backfill executed | `uv run python -m scripts.ingest_2282_research_archive --link-delistings`, exit 0. Not a `sec_rebuild` scope — this corpus is outside the manifest worker. Re-run after the migration edit: identical output, idempotent. |
| **11** operator-visible figure | The corpus has no HTTP surface; the phase census is the operator-visible artefact and is reproduced in full in the issue close-out. Constraint probed live on the dev DB in both directions: bare Form 25 date → `CheckViolation`; provision without `sec_form25` source → `CheckViolation`; the two real rows survive. |
| **12** | this table, at `72603779`. |

## Tests

Five pure-logic tests, no DB. **Revert-probed**: swapping the two branches of
`classify_form25_match` fails `test_conflict_outranks_the_missing_date_branch` and only that
one; restoring passes. Without the probe that test was vacuous — the version I first wrote
passed under both orderings.

Fixture is deliberately the *write* case rather than a "neutral" baseline, per
test-quality.md's new section — a baseline the classifier already refuses would make every
override look like it worked.

## Skills updated (same PR, per skill-ownership rule 3)

- `research-price-corpus.md` — the ⚠⚠ "NOT implemented" block replaced with the falsification
  and what shipped; the mandatory-guard bullet no longer states the truncation half flatly.
- `sec-edgar.md` §2.6 trap 5 — the `(b)`-states-no-suspension-date asymmetry is new and is
  the load-bearing half; trap 5 previously said only that dates are scarce overall.

## Security

No security model touched — research corpus, no auth surface, no order path.

Closes #2297.
Refs #2282.
Refs #2290.
Refs #2279.
