### PR TITLE
fix(#2218): a job that makes zero progress stops reporting 'success'

### DIFF
--- a/.claude/skills/ops-monitor/SKILL.md
+++ b/.claude/skills/ops-monitor/SKILL.md
@@ -30,6 +30,38 @@ name)` reads the latest `job_runs` row per scheduled job. `record_job_start` /
 `row_count`, `error_msg`). The kill switch also lives here
 (`activate_kill_switch` / `get_kill_switch_status`).
 
+⚠⚠ **`success` means "it finished", NOT "it did anything" — until a job opts into
+progress reporting (#2218).** Completion and progress are different facts, and
+deriving health from the first is how OpenFIGI resolution ran dark for seven weeks
+behind an unbroken run of `success / row_count 0` (#2213). A job that binds a
+whole-batch failure to a counter instead of raising is invisible to every check
+this app has.
+
+The opt-in is `tracker.progress = JobProgress(candidates_seen=…, outcomes={…},
+errors={…})` in the invoker; `_finish_tracked` runs
+`app/services/job_progress.py::degradation_reason` over it and writes
+`status='degraded'` + `progress_json` instead of `success`. Two rules, and
+⚠ **"zero rows written" is deliberately NOT one of them** — most jobs legitimately
+have nothing to do, and a blanket zero-rows alarm is noise that trains the operator
+to ignore the signal. The discriminator is `candidates_seen`: saw nothing / did
+nothing is healthy, saw work / produced no terminal outcome is stalled.
+
+⚠ **`progress is None` is judged exactly as before**, so the ~50 unwired jobs are
+inert. When investigating a suspect job, `progress_json IS NULL` means "this job
+does not report progress" — NOT "it reported zero". They are different claims and
+only one of them is evidence.
+
+⚠ **The terminal-status vocabulary is `ops_monitor.TERMINAL_STATUS_SQL`, and it is
+the single source.** It was hand-spelled in five SQL `IN (...)` literals across four
+modules plus two Python `Literal`s, and pyright cannot see inside a SQL string —
+adding a status to the CHECK constraint without touching all of them writes rows
+nothing reads. `tests/test_job_terminal_status_contract.py` derives the set from
+sql/254's constraint text and greps `app/` for hand-spelled lists.
+⚠ `sync_orchestrator/dispatcher.py::reset_stale_in_flight` uses a deliberately
+NARROWER set (`success`/`failure`/`degraded`) — `skipped` and `cancelled` mean the
+work was not done, and whether boot recovery should re-fire those is an open
+question. Do not "fix" it to the shared constant.
+
 **Admin verdict (`health_verdict.py`).** `verdict_for_row(row, now=...)` /
 `compute_verdict(...)` collapse a row's `ProcessStatus` pill + `stale_reasons`
 chips into ONE precedence-ordered `HealthVerdict` (`current` / `working` /

--- a/app/api/jobs.py
+++ b/app/api/jobs.py
@@ -80,7 +80,7 @@ class JobRunResponse(BaseModel):
     job_name: str
     started_at: datetime
     finished_at: datetime | None
-    status: Literal["running", "success", "failure", "skipped"]
+    status: Literal["running", "success", "failure", "skipped", "cancelled", "degraded"]
     row_count: int | None
     error_msg: str | None
     linked_request_id: int | None = None

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -55,6 +55,7 @@ from app.services.bootstrap_state import (
 )
 from app.services.ops_monitor import (
     JobHealth,
+    JobStatus,
     LayerHealth,
     LayerStatus,
     check_all_layers,
@@ -111,7 +112,7 @@ class KillSwitchStateResponse(BaseModel):
 
 class JobHealthResponse(BaseModel):
     name: str
-    last_status: Literal["running", "success", "failure", "skipped"] | None
+    last_status: JobStatus | None
     last_started_at: datetime | None
     last_finished_at: datetime | None
     detail: str
@@ -194,7 +195,7 @@ class JobOverviewResponse(BaseModel):
     # there is no live-fire-time source to compete with the cadence
     # computation. The frontend can drop the discriminator at its leisure.
     next_run_time_source: Literal["live", "declared"]
-    last_status: Literal["running", "success", "failure", "skipped"] | None
+    last_status: JobStatus | None
     last_started_at: datetime | None
     last_finished_at: datetime | None
     detail: str

--- a/app/services/job_progress.py
+++ b/app/services/job_progress.py
@@ -1,0 +1,93 @@
+"""#2218 — the progress verdict: did this job actually do anything?
+
+WHY THIS EXISTS
+---------------
+Job health was derived from COMPLETION. `cusip_resolver_post_bulk_sweep` binds
+a whole-batch OpenFIGI failure to an `api_errors` counter rather than raising,
+so a pass where every CUSIP errored recorded `status='success', row_count=0`;
+OpenFIGI resolution was dark for seven weeks behind that signal (#2213). The
+same shape starved ETF filer typing for two months (#2214). Neither was caught
+by any automated check, because every check reads the same "did it finish"
+signal.
+
+ONE RULE, DELIBERATELY, AND WHAT IT IS NOT
+------------------------------------------
+⚠ **"Zero rows written" is NOT a degradation.** Plenty of jobs legitimately
+have nothing to do on a given run, and a blanket zero-rows alarm is noise that
+trains the operator to ignore the signal — which is strictly worse than no
+signal. The distinction is `candidates_seen`: a job that saw no work and did
+none is healthy; a job that saw work and produced no terminal outcome is
+stalled. That is why the counters are persisted rather than inferred.
+
+The verdict is pure and lives here rather than in each invoker so that all
+jobs answer the same question the same way — the recurring lesson from the
+closed-vocabulary defects is that a rule expressed once in code cannot drift
+from a rule expressed twice.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class JobProgress:
+    """What a job saw, what it produced, and what went wrong.
+
+    ``candidates_seen`` — units of work the job identified. ``None`` means the
+    job does not count them, which is NOT zero: a job that cannot say how much
+    work it saw cannot be judged stalled, and claiming otherwise would invent
+    an alarm out of an absence.
+
+    ``outcomes`` — terminal buckets that each represent work genuinely
+    completed. Every one of them counts as progress, so a job must NOT put a
+    bucket here that it also reports as an error.
+
+    ``errors`` — buckets that represent work the job could not do. Any non-zero
+    value degrades the run.
+    """
+
+    candidates_seen: int | None = None
+    outcomes: Mapping[str, int] = field(default_factory=dict)
+    errors: Mapping[str, int] = field(default_factory=dict)
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "candidates_seen": self.candidates_seen,
+            "outcomes": dict(self.outcomes),
+            "errors": dict(self.errors),
+        }
+
+
+def degradation_reason(progress: JobProgress | None) -> str | None:
+    """Operator-visible reason this run made no progress, or ``None``.
+
+    Two conditions, both from the #2218 acceptance criteria and neither
+    inferred from row counts:
+
+    1. **Any error bucket is non-zero.** A run that errored on some of its work
+       and completed the rest is still degraded — partial progress hides the
+       same stall at a smaller scale, and #2213's job was at 100% errors for
+       seven weeks without one of them reaching the health verdict.
+    2. **Saw candidates, produced no terminal outcome.** The silent-stall
+       shape: work identified, nothing resolved, nothing errored either.
+
+    ``None`` progress returns ``None`` — a job that does not report progress is
+    judged exactly as it was before, which keeps this change inert for every
+    job that has not opted in.
+    """
+    if progress is None:
+        return None
+
+    failed = {name: n for name, n in progress.errors.items() if n}
+    if failed:
+        detail = ", ".join(f"{name}={n}" for name, n in sorted(failed.items()))
+        return f"errors reported: {detail}"
+
+    seen = progress.candidates_seen
+    if seen is not None and seen > 0 and not any(progress.outcomes.values()):
+        buckets = ", ".join(sorted(progress.outcomes)) or "none reported"
+        return f"saw {seen} candidates and produced no terminal outcome (buckets: {buckets})"
+
+    return None

--- a/app/services/job_progress.py
+++ b/app/services/job_progress.py
@@ -44,6 +44,12 @@ class JobProgress:
     completed. Every one of them counts as progress, so a job must NOT put a
     bucket here that it also reports as an error.
 
+    ⚠ Buckets may legitimately OVERLAP within ``outcomes`` (the CUSIP sweep
+    reports both ``resolved`` and ``promoted``, and a promoted CUSIP was also
+    resolved). That is fine for the "any outcome" test and would be WRONG for
+    anyone who later sums them as units of work — do not add that reading
+    without changing the contract first.
+
     ``errors`` — buckets that represent work the job could not do. Any non-zero
     value degrades the run.
     """
@@ -80,13 +86,17 @@ def degradation_reason(progress: JobProgress | None) -> str | None:
     if progress is None:
         return None
 
-    failed = {name: n for name, n in progress.errors.items() if n}
+    # ``n > 0`` rather than truthiness (Codex ckpt-3): a negative count is
+    # nonsense either way, but truthiness makes ``{"api_errors": -1}`` degrade
+    # while ``{"done": -1}`` reads as progress — the two nonsense values would
+    # be treated as opposites.
+    failed = {name: n for name, n in progress.errors.items() if n > 0}
     if failed:
         detail = ", ".join(f"{name}={n}" for name, n in sorted(failed.items()))
         return f"errors reported: {detail}"
 
     seen = progress.candidates_seen
-    if seen is not None and seen > 0 and not any(progress.outcomes.values()):
+    if seen is not None and seen > 0 and not any(n > 0 for n in progress.outcomes.values()):
         buckets = ", ".join(sorted(progress.outcomes)) or "none reported"
         return f"saw {seen} candidates and produced no terminal outcome (buckets: {buckets})"
 

--- a/app/services/job_retry.py
+++ b/app/services/job_retry.py
@@ -44,6 +44,8 @@ from typing import Any
 import psycopg
 from psycopg.types.json import Jsonb
 
+from app.services.ops_monitor import TERMINAL_STATUS_SQL
+
 logger = logging.getLogger(__name__)
 
 _REQUESTED_BY = "system:retry_backoff"
@@ -169,10 +171,10 @@ def _refire_one(
 
 def _is_latest_terminal(conn: psycopg.Connection[Any], *, job_name: str, run_id: int) -> bool:
     row = conn.execute(
-        """
+        f"""
         SELECT run_id FROM job_runs
          WHERE job_name = %(job)s
-           AND status IN ('success', 'failure', 'skipped', 'cancelled')
+           AND status IN {TERMINAL_STATUS_SQL}
          ORDER BY started_at DESC, run_id DESC
          LIMIT 1
         """,

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -28,10 +28,10 @@ than that threshold, the layer is flagged as stale.
 from __future__ import annotations
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, LiteralString
 
 import psycopg
 import psycopg.rows
@@ -125,7 +125,38 @@ _LAYER_QUERIES: dict[LayerName, str] = {
     "scores": "SELECT MAX(scored_at) AS latest FROM scores",
 }
 
-JobStatus = Literal["running", "success", "failure", "skipped"]
+# ⚠ "cancelled" was missing here before #2218 even though sql/137 added it to
+# the CHECK constraint in 2026 — the same drift this ticket is about, one
+# vocabulary over. Kept in sync with JOB_TERMINAL_STATUSES below by
+# tests/test_job_terminal_status_contract.py.
+JobStatus = Literal["running", "success", "failure", "skipped", "cancelled", "degraded"]
+
+# #2218 — THE terminal-status vocabulary for ``job_runs``, in one place.
+#
+# It was in five SQL string literals across four modules, all spelling
+# ``IN ('success', 'failure', 'skipped', 'cancelled')`` by hand. Adding
+# 'degraded' to the CHECK constraint without touching all five leaves the new
+# status invisible to the admin verdict, the retry sweeper and the bootstrap
+# gate — the row exists and nothing reads it, which is the same defect shape
+# this ticket is about. pyright cannot see inside a SQL string, so the only
+# defences are this constant and the derive-from-the-migration contract test
+# in tests/test_job_terminal_status_contract.py.
+#
+# 'running' is deliberately absent: it is a status but not a TERMINAL one.
+#: The ``IN (...)`` list, spelled ONCE and interpolated into every query that
+#: needs it. Declared as the literal rather than joined from the tuple below
+#: because psycopg3 types ``execute(query=...)`` as ``LiteralString`` — a
+#: runtime-joined string is ``str`` and pyright rejects it, which is a real
+#: guard against interpolating caller input and worth keeping rather than
+#: casting around.
+TERMINAL_STATUS_SQL: Final[LiteralString] = "('success', 'failure', 'skipped', 'cancelled', 'degraded')"
+
+#: Derived FROM the SQL literal, not maintained beside it — two hand-written
+#: copies of a vocabulary is the defect this whole constant exists to stop.
+JOB_TERMINAL_STATUSES: Final[tuple[str, ...]] = tuple(
+    part.strip().strip("'") for part in TERMINAL_STATUS_SQL.strip("()").split(",")
+)
+
 
 LayerStatus = Literal["ok", "stale", "empty", "error"]
 
@@ -240,11 +271,11 @@ def _retry_plan(
     # cap we stop retrying regardless, so deeper history is irrelevant.
     with conn.cursor() as cur:
         cur.execute(
-            """
+            f"""
             SELECT status FROM job_runs
              WHERE job_name = %(job)s
                AND run_id   <> %(id)s
-               AND status IN ('success', 'failure', 'skipped', 'cancelled')
+               AND status IN {TERMINAL_STATUS_SQL}
                AND (started_at < %(ts)s
                     OR (started_at = %(ts)s AND run_id < %(id)s))
              ORDER BY started_at DESC, run_id DESC
@@ -432,10 +463,11 @@ def record_job_finish(
     conn: psycopg.Connection[Any],
     run_id: int,
     *,
-    status: Literal["success", "failure"],
+    status: Literal["success", "failure", "degraded"],
     row_count: int | None = None,
     error_msg: str | None = None,
     error_category: FailureCategory | None = None,
+    progress: Mapping[str, Any] | None = None,
     now: datetime | None = None,
 ) -> None:
     """Record the completion of a scheduled job.
@@ -445,6 +477,13 @@ def record_job_finish(
     ``attempt`` so the ``jobs_retry_sweeper`` re-fires it before its next
     natural cadence slot. A non-failure terminal clears ``next_retry_at``
     and leaves ``attempt`` at its default.
+
+    ``degraded`` (#2218) — the run COMPLETED and made no progress. It takes
+    the non-failure retry path deliberately: nothing raised, so there is no
+    transient-vs-permanent classification to make and re-firing it immediately
+    would just re-hit whatever is not progressing. It is a signal to the
+    operator, not a retry trigger. ``progress`` is the evidence, persisted so
+    the successor to #2213 is a query rather than log archaeology.
     """
     now = now or _utcnow()
     if status == "failure":
@@ -467,7 +506,8 @@ def record_job_finish(
             error_msg      = %(error_msg)s,
             error_category = %(error_category)s,
             next_retry_at  = %(next_retry_at)s,
-            attempt        = %(attempt)s
+            attempt        = %(attempt)s,
+            progress_json  = %(progress)s
         WHERE run_id = %(run_id)s
           AND status = 'running'
         """,
@@ -479,6 +519,7 @@ def record_job_finish(
             "error_category": error_category.value if error_category else None,
             "next_retry_at": next_retry_at,
             "attempt": attempt,
+            "progress": Jsonb(dict(progress)) if progress is not None else None,
             "run_id": run_id,
         },
     )

--- a/app/services/processes/__init__.py
+++ b/app/services/processes/__init__.py
@@ -52,6 +52,12 @@ ProcessStatus = Literal[
     "pending_first_run",
     "running",
     "ok",
+    # #2218 — the run COMPLETED and made no progress. Distinct from "failed"
+    # (nothing raised, so there is no error to show and no retry to schedule)
+    # and from "ok" (which is what OpenFIGI resolution reported for seven weeks
+    # while it was dark). Collapsing it into either loses what the operator
+    # needs to know.
+    "degraded",
     "failed",
     "pending_retry",
     "cancelled",
@@ -65,7 +71,12 @@ ProcessStatus = Literal[
 # ``health_verdict.compute_verdict``). The FE renders ONE verdict pill.
 HealthVerdict = Literal["current", "working", "self_healing", "attention", "stale_manual", "paused"]
 
-RunStatus = Literal["success", "failure", "partial", "cancelled", "skipped"]
+# ⚠ #2218 — "degraded" is NOT folded into "partial". The kill-switch branch
+# of health_verdict deliberately reads a benign ingest-sweep "partial" as
+# green while halted; a degraded run is the opposite (it is the state
+# OpenFIGI resolution sat in, unseen, for seven weeks) and must stay red
+# behind the switch, so it needs its own member rather than a mapping.
+RunStatus = Literal["success", "failure", "partial", "cancelled", "skipped", "degraded"]
 
 WatermarkCursorKind = Literal[
     "filed_at",

--- a/app/services/processes/health_verdict.py
+++ b/app/services/processes/health_verdict.py
@@ -232,6 +232,20 @@ def compute_verdict(
         return ("stale_manual", False, "aged one-shot failure")
     if status == "failed":
         return ("attention", False, "last run failed")
+    if status == "degraded":
+        # #2218. Attention, not a softer verdict: the whole defect was that a
+        # job making zero progress read as healthy for seven weeks, so a state
+        # that does not reach the operator is the bug rather than the fix.
+        # Placed after ``failed`` and before ``cancelled`` — a raised failure
+        # is the louder fact when both are somehow in play, and neither is
+        # allowed to mask an actionable stale reason (the block above already
+        # returned for those, preserving the ckpt-1 invariant).
+        #
+        # No retry branch above it on purpose: nothing raised, so there is no
+        # ``next_retry_at`` and re-firing would just re-hit whatever is not
+        # progressing. A degraded row stays red until a run actually
+        # progresses.
+        return ("attention", False, "completed with no progress")
     if status == "cancelled":
         # Task 5 (#1508): a cancel traceable to a deliberate operator stop
         # request (process_stop_requests join, resolved by the adapter) is
@@ -331,7 +345,10 @@ def verdict_for_row(row: ProcessRow, *, now: datetime) -> tuple[HealthVerdict, b
         # benign green (``has_failures`` counts ``ingest_status='failed'`` only).
         # So keeping ``partial`` red here would paint a row red that reads green
         # when the switch is off — false-red flooding, the #1831 bug (bot review).
-        last_run_failed=row.last_run is not None and row.last_run.status == "failure",
+        # #2218 — degraded counts here for the same reason failure does: it
+        # reddens on the non-disabled path, so hiding it behind the halt would
+        # re-introduce exactly the masking this branch exists to prevent.
+        last_run_failed=row.last_run is not None and row.last_run.status in ("failure", "degraded"),
     )
 
 

--- a/app/services/processes/post_bootstrap_activation.py
+++ b/app/services/processes/post_bootstrap_activation.py
@@ -42,6 +42,7 @@ from typing import Any, Literal
 import psycopg
 from psycopg.types.json import Jsonb
 
+from app.services.ops_monitor import TERMINAL_STATUS_SQL
 from app.services.processes.bootstrap_coverage import BOOTSTRAP_COVERED_FRESHNESS_SOURCES
 
 logger = logging.getLogger(__name__)
@@ -153,10 +154,10 @@ def _latest_terminal_by_job(
 ) -> dict[str, tuple[str, str | None]]:
     """Latest terminal ``(status, error_msg)`` per job_name (never-run jobs absent)."""
     rows = conn.execute(
-        """
+        f"""
         SELECT DISTINCT ON (job_name) job_name, status, error_msg
           FROM job_runs
-         WHERE status IN ('success', 'failure', 'skipped', 'cancelled')
+         WHERE status IN {TERMINAL_STATUS_SQL}
          ORDER BY job_name, started_at DESC
         """
     ).fetchall()

--- a/app/services/processes/scheduled_adapter.py
+++ b/app/services/processes/scheduled_adapter.py
@@ -34,7 +34,7 @@ import psycopg.rows
 
 from app.services.data_freshness import cadence_for
 from app.services.job_liveness import cadence_period
-from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX
+from app.services.ops_monitor import LANE_BUSY_SKIP_PREFIX, TERMINAL_STATUS_SQL
 from app.services.processes import (
     ActiveRunSummary,
     ErrorClassSummary,
@@ -179,6 +179,9 @@ _RUN_STATUS_TO_SUMMARY: dict[str, RunStatus] = {
     "failure": "failure",
     "skipped": "skipped",
     "cancelled": "cancelled",
+    # #2218 — carried through as its own member, NOT folded into "partial";
+    # see the RunStatus comment in app/services/processes/__init__.py.
+    "degraded": "degraded",
 }
 
 
@@ -223,6 +226,12 @@ def _status_for(
         return "failed"
     if last_terminal_status == "success":
         return "ok"
+    # #2218. ⚠ Placed BEFORE the fall-through, which is the whole point: an
+    # unhandled terminal status lands on `pending_first_run` — "never ran" —
+    # so a new status added without touching this function would report the
+    # single most misleading state available.
+    if last_terminal_status == "degraded":
+        return "degraded"
     if last_terminal_status == "cancelled":
         return "cancelled"
     if last_terminal_status == "skipped":
@@ -279,13 +288,13 @@ def _read_latest_terminal_run(conn: psycopg.Connection[Any], *, job_name: str) -
     """Latest terminal job_runs row (success / failure / skipped / cancelled)."""
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            """
+            f"""
             SELECT run_id, started_at, finished_at, status, row_count,
                    error_msg, error_classes, rows_skipped_by_reason,
                    rows_errored, cancelled_at, next_retry_at, attempt
               FROM job_runs
              WHERE job_name = %(name)s
-               AND status   IN ('success', 'failure', 'skipped', 'cancelled')
+               AND status   IN {TERMINAL_STATUS_SQL}
              ORDER BY started_at DESC
              LIMIT 1
             """,
@@ -329,11 +338,11 @@ def _read_latest_anchor_terminal_run(conn: psycopg.Connection[Any], *, job_name:
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            """
+            f"""
             SELECT run_id, started_at, finished_at, status
               FROM job_runs
              WHERE job_name = %(name)s
-               AND status   IN ('success', 'failure', 'skipped', 'cancelled')
+               AND status   IN {TERMINAL_STATUS_SQL}
                AND NOT (status = 'skipped' AND error_msg LIKE %(lane_busy_pat)s)
              ORDER BY started_at DESC
              LIMIT 1
@@ -1111,12 +1120,12 @@ def list_runs(conn: psycopg.Connection[Any], *, process_id: str, days: int) -> l
         raise ValueError("days must be positive")
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
-            """
+            f"""
             SELECT run_id, started_at, finished_at, status, row_count,
                    rows_skipped_by_reason, rows_errored, cancelled_at
               FROM job_runs
              WHERE job_name   = %(name)s
-               AND status     IN ('success', 'failure', 'skipped', 'cancelled')
+               AND status     IN {TERMINAL_STATUS_SQL}
                AND started_at >= now() - (%(days)s::int * INTERVAL '1 day')
              ORDER BY started_at DESC
             """,

--- a/app/services/sync_orchestrator/dispatcher.py
+++ b/app/services/sync_orchestrator/dispatcher.py
@@ -322,7 +322,17 @@ def reset_stale_in_flight(
               AND NOT EXISTS (
                 SELECT 1 FROM job_runs jr
                 WHERE jr.linked_request_id = pjr.request_id
-                  AND jr.status IN ('success', 'failure')
+                  -- #2218 — 'degraded' belongs here: the job RAN, it simply
+                  -- made no progress. Without it, a crash between the terminal
+                  -- row and mark_request_completed replays a request that
+                  -- already executed.
+                  --
+                  -- ⚠ Deliberately NOT app.services.ops_monitor's full
+                  -- TERMINAL_STATUS_SQL. This set is narrower on purpose:
+                  -- 'skipped' and 'cancelled' mean the work was NOT done, and
+                  -- whether a boot recovery should re-fire those is a separate
+                  -- question this ticket does not answer.
+                  AND jr.status IN ('success', 'failure', 'degraded')
               )
               AND NOT EXISTS (
                 SELECT 1 FROM sync_runs sr

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -54,6 +54,7 @@ from app.services.exchange_directory import refresh_exchange_directory
 from app.services.exchanges import refresh_exchanges_metadata
 from app.services.execution_guard import evaluate_recommendation
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
+from app.services.job_progress import JobProgress, degradation_reason
 from app.services.llm_client import LLMProviderNotConfigured, make_llm_clients, release_local_models
 from app.services.market_data import most_recent_trading_day, refresh_market_data, refresh_quotes
 from app.services.mf_directory import refresh_mf_directory
@@ -2160,13 +2161,7 @@ def _tracked_job(job_name: str) -> Generator[_JobTracker]:
             else:
                 try:
                     with psycopg.connect(settings.database_url) as conn:
-                        record_job_finish(
-                            conn,
-                            tracker.run_id,
-                            status="success",
-                            row_count=tracker.row_count,
-                            error_msg=tracker.note,
-                        )
+                        _finish_tracked(conn, tracker)
                         if tracker.row_count is not None:
                             spike = check_row_count_spike(
                                 conn,
@@ -2214,13 +2209,7 @@ def _tracked_job(job_name: str) -> Generator[_JobTracker]:
         else:
             try:
                 with psycopg.connect(settings.database_url) as conn:
-                    record_job_finish(
-                        conn,
-                        tracker.run_id,
-                        status="success",
-                        row_count=tracker.row_count,
-                        error_msg=tracker.note,
-                    )
+                    _finish_tracked(conn, tracker)
                     # Check for row-count spikes after recording the successful run.
                     # Exclude the current run_id so we compare against the *previous*
                     # successful run, not the one we just wrote.
@@ -2243,6 +2232,13 @@ class _JobTracker:
     the body ran cleanly but the operator should know nothing happened.
     Leaving it ``None`` records the success row with NULL error_msg
     (the historical contract).
+
+    ``progress`` (#2218) — optional :class:`JobProgress` the body fills in
+    with what it SAW versus what it PRODUCED. When set and
+    ``degradation_reason`` fires, the terminal row is written
+    ``status='degraded'`` instead of ``'success'``. Leaving it ``None``
+    keeps the historical contract exactly, so this is opt-in per job and
+    inert for every job that has not been wired.
     """
 
     def __init__(self, job_name: str) -> None:
@@ -2250,6 +2246,34 @@ class _JobTracker:
         self.run_id: int = 0
         self.row_count: int | None = None
         self.note: str | None = None
+        self.progress: JobProgress | None = None
+
+
+def _finish_tracked(conn: psycopg.Connection[Any], tracker: _JobTracker) -> None:
+    """Write the non-failure terminal row for a tracked job (#2218).
+
+    Both of ``_tracked_job``'s success paths route through here so the
+    degraded verdict cannot apply on one and not the other — the early-return
+    branch and the main branch were byte-identical duplicates, which is
+    exactly how a rule ends up enforced in one place and not the other.
+
+    ⚠ The reason goes into ``error_msg`` on purpose: that is the field the
+    admin row and ``/system/jobs`` already surface, so a degraded run explains
+    itself without a second read. ``tracker.note`` still wins when the body
+    set one — a soft-skip digest is a deliberate operator message and must not
+    be overwritten by a derived string.
+    """
+    reason = degradation_reason(tracker.progress)
+    record_job_finish(
+        conn,
+        tracker.run_id,
+        status="degraded" if reason else "success",
+        row_count=tracker.row_count,
+        error_msg=tracker.note or reason,
+        progress=tracker.progress.as_json() if tracker.progress is not None else None,
+    )
+    if reason:
+        logger.warning("%s: DEGRADED — %s", tracker.job_name, reason)
 
 
 def _load_etoro_credentials(job_name: str) -> tuple[str, str] | None:
@@ -6698,6 +6722,23 @@ def cusip_resolver_post_bulk_sweep(params: Mapping[str, Any]) -> None:
                 conn.commit()
 
         tracker.row_count = report.promoted
+        # #2218 — the counters below were logged and nothing else. A pass where
+        # every CUSIP errored recorded `success / row_count 0`, which is how
+        # OpenFIGI resolution stayed dark from 2026-06-18 to 2026-08-02 (#2213).
+        # `resolved` and `no_instrument_match` are BOTH outcomes: a CUSIP the
+        # resolver answered for and we could not match to an instrument is work
+        # completed, not work missed — treating it as an error would degrade
+        # every healthy run, since most bulk CUSIPs are not in our universe.
+        tracker.progress = JobProgress(
+            candidates_seen=report.candidates_seen,
+            outcomes={
+                "resolved": report.resolved,
+                "promoted": report.promoted,
+                "no_instrument_match": report.no_instrument_match,
+                "unresolved_by_openfigi": report.unresolved_by_openfigi,
+            },
+            errors={"api_errors": report.api_errors},
+        )
         logger.info(
             "cusip_resolver_post_bulk_sweep: passes=%d candidates=%d resolved=%d promoted=%d "
             "no_instrument_match=%d unresolved_by_openfigi=%d api_errors=%d "
@@ -7283,6 +7324,25 @@ def ncen_classifier_yearly() -> None:
             report = classify_filers_via_ncen(conn, sec)
 
         tracker.row_count = report.classifications_written
+        # #2218 — this job ran ONCE (2026-06-04), reported success, wrote 0
+        # rows, and on a yearly cadence would not have fired again until 2027
+        # while `classify_filer_type` fell through to INV for all 11,464 filers
+        # (#2214). `no_ncen_found` is an OUTCOME, not an error: a filer with no
+        # N-CEN census filing is a resolved question, and the docstring's
+        # "empty filer-seed list = natural no-op" case is preserved because
+        # `filers_seen` is then 0 and the stall rule does not fire.
+        tracker.progress = JobProgress(
+            candidates_seen=report.filers_seen,
+            outcomes={
+                "classifications_written": report.classifications_written,
+                "no_ncen_found": report.no_ncen_found,
+            },
+            errors={
+                "parse_failures": report.parse_failures,
+                "fetch_failures": report.fetch_failures,
+                "crash_failures": report.crash_failures,
+            },
+        )
         logger.info(
             "ncen_classifier_yearly: filers_seen=%d classifications_written=%d "
             "no_ncen_found=%d parse_failures=%d fetch_failures=%d crash_failures=%d",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -6736,11 +6736,13 @@ def cusip_resolver_post_bulk_sweep(params: Mapping[str, Any]) -> None:
         # terminal.
         #
         # ⚠ `unresolved_by_openfigi` is the one worth defending, because it looks
-        # like a miss. It is reachable ONLY on a 200 response with per-item "no
-        # match" — `OpenFigiResolver` raises `OpenFigiTransportError` /
-        # `OpenFigiRateLimited` on every transport, HTTP and parse failure, so an
-        # empty mapping dict for a non-empty input cannot mean "the API silently
-        # failed". And it is the DOMINANT legitimate outcome: `select
+        # like a miss. It cannot mean a transport/HTTP failure —
+        # `OpenFigiResolver` raises `OpenFigiTransportError` / `OpenFigiRateLimited`
+        # on those, so they land in `api_errors`. It is NOT, however, exclusively
+        # "OpenFIGI said no": `_parse_entry` returns None for a per-item
+        # `{"error": ...}` too, and that is indistinguishable here from a real
+        # no-match (#2304). The justification for keeping it an outcome is the
+        # DISTRIBUTION, not purity: `select
         # resolution_status, count(*) from unresolved_13f_cusips group by 1`
         # returns 60,011 `openfigi_unknown` against 3,027 `resolved_via_openfigi`.
         # Excluding it from `outcomes` would degrade nearly every real run — the

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -2262,6 +2262,11 @@ def _finish_tracked(conn: psycopg.Connection[Any], tracker: _JobTracker) -> None
     itself without a second read. ``tracker.note`` still wins when the body
     set one — a soft-skip digest is a deliberate operator message and must not
     be overwritten by a derived string.
+
+    ``or`` rather than ``is not None`` is deliberate: an EMPTY note is not a
+    message, so falling through to the reason is the better outcome. Writing
+    ``""`` into ``error_msg`` would leave a degraded row with no explanation at
+    all, which is the one thing this function exists to prevent.
     """
     reason = degradation_reason(tracker.progress)
     record_job_finish(
@@ -6725,10 +6730,21 @@ def cusip_resolver_post_bulk_sweep(params: Mapping[str, Any]) -> None:
         # #2218 — the counters below were logged and nothing else. A pass where
         # every CUSIP errored recorded `success / row_count 0`, which is how
         # OpenFIGI resolution stayed dark from 2026-06-18 to 2026-08-02 (#2213).
-        # `resolved` and `no_instrument_match` are BOTH outcomes: a CUSIP the
-        # resolver answered for and we could not match to an instrument is work
-        # completed, not work missed — treating it as an error would degrade
-        # every healthy run, since most bulk CUSIPs are not in our universe.
+        # `resolved`, `no_instrument_match` and `unresolved_by_openfigi` are ALL
+        # outcomes: a CUSIP the resolver answered for is work completed, whatever
+        # the answer was. Each one tombstones the row, which is what makes it
+        # terminal.
+        #
+        # ⚠ `unresolved_by_openfigi` is the one worth defending, because it looks
+        # like a miss. It is reachable ONLY on a 200 response with per-item "no
+        # match" — `OpenFigiResolver` raises `OpenFigiTransportError` /
+        # `OpenFigiRateLimited` on every transport, HTTP and parse failure, so an
+        # empty mapping dict for a non-empty input cannot mean "the API silently
+        # failed". And it is the DOMINANT legitimate outcome: `select
+        # resolution_status, count(*) from unresolved_13f_cusips group by 1`
+        # returns 60,011 `openfigi_unknown` against 3,027 `resolved_via_openfigi`.
+        # Excluding it from `outcomes` would degrade nearly every real run — the
+        # false-alarm direction #2218 explicitly warns against.
         tracker.progress = JobProgress(
             candidates_seen=report.candidates_seen,
             outcomes={

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -80,7 +80,7 @@ export interface ConfigResponse {
 export type LayerStatus = "ok" | "stale" | "empty" | "error";
 export type OverallStatus = "ok" | "degraded" | "down";
 export type JobLastStatus =
-  "running" | "success" | "failure" | "skipped" | null;
+  JobRunStatus | null;
 export type CadenceKind =
   "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "every_n_minutes";
 
@@ -211,7 +211,15 @@ export interface ParamMetadata {
 // /jobs/runs (app/api/jobs.py — issue #13 PR B)
 // ---------------------------------------------------------------------------
 
-export type JobRunStatus = "running" | "success" | "failure" | "skipped";
+// #2218 — "degraded": the run completed and made no progress. "cancelled"
+// was already reachable server-side (sql/137) and missing here.
+export type JobRunStatus =
+  | "running"
+  | "success"
+  | "failure"
+  | "skipped"
+  | "cancelled"
+  | "degraded";
 
 export interface JobRunResponse {
   run_id: number;
@@ -2057,6 +2065,10 @@ export type ProcessStatus =
   | "pending_first_run"
   | "running"
   | "ok"
+  // #2218 — the run COMPLETED and made no progress. Not `ok` (that is what
+  // OpenFIGI resolution reported for seven weeks while it was dark) and not
+  // `failed` (nothing raised, so there is no error to show).
+  | "degraded"
   | "failed"
   | "pending_retry"
   | "cancelled"
@@ -2083,7 +2095,7 @@ export type HealthVerdict =
   | "paused";
 
 export type ProcessRunStatus =
-  "success" | "failure" | "partial" | "cancelled" | "skipped";
+  "success" | "failure" | "partial" | "cancelled" | "skipped" | "degraded";
 
 export type CursorKind =
   | "filed_at"

--- a/frontend/src/components/admin/__fixtures__/processes.ts
+++ b/frontend/src/components/admin/__fixtures__/processes.ts
@@ -71,6 +71,12 @@ export function deriveVerdict(
       return { health_verdict: "self_healing", self_healing: true, verdict_reason: "retry scheduled" };
     case "failed":
       return { health_verdict: "attention", self_healing: false, verdict_reason: "last run failed" };
+    case "degraded":
+      return {
+        health_verdict: "attention",
+        self_healing: false,
+        verdict_reason: "completed with no progress",
+      };
     case "cancelled":
       return { health_verdict: "attention", self_healing: false, verdict_reason: "last run cancelled" };
     case "pending_first_run":

--- a/frontend/src/components/admin/processStatus.ts
+++ b/frontend/src/components/admin/processStatus.ts
@@ -41,6 +41,11 @@ export const STATUS_VISUAL: Record<ProcessStatus, StatusVisual> = {
   // slot. A deliberate small colour change, not a no-op.
   running: { label: "running", tone: "info" },
   ok: { label: "ok", tone: "ok" },
+  // #2218 — `warn`, not `risk`: the job completed, so this is not an
+  // incident, but it made no progress and needs the operator. Sits between
+  // `ok` and `failed` visually because that is exactly where it sits
+  // semantically.
+  degraded: { label: "no progress", tone: "warn" },
   failed: { label: "failed", tone: "risk" },
   pending_retry: { label: "pending retry", tone: "warn" },
   cancelled: { label: "cancelled", tone: "neutral", extraClass: "line-through" },

--- a/frontend/src/pages/AdminJobDetailPage.tsx
+++ b/frontend/src/pages/AdminJobDetailPage.tsx
@@ -26,11 +26,17 @@ import {
 import { useAsync } from "@/lib/useAsync";
 import { formatDateTime } from "@/lib/format";
 
+// Exhaustive by type, which is why adding a status to JobRunStatus fails the
+// build here rather than rendering an unstyled cell — #2218 relies on that.
 const STATUS_TONE: Record<JobRunResponse["status"], string> = {
   success: "text-emerald-700",
   failure: "text-red-700",
   running: "text-sky-700",
   skipped: "text-slate-500",
+  cancelled: "text-slate-500",
+  // #2218 — amber: the run completed, so it is not a failure, but it made no
+  // progress and needs the operator.
+  degraded: "text-amber-700",
 };
 
 export function AdminJobDetailPage() {
@@ -97,7 +103,8 @@ function RunsTable({ rows }: { rows: JobRunResponse[] }) {
             <th className="py-2 pr-4">Duration</th>
             <th className="py-2 pr-4 text-right">Rows</th>
             {/* Sixth column carries the per-row expand button on
-                failure rows. Declared here so the header and body row
+                failure and degraded rows (#2218 — both persist an
+                error_msg). Declared here so the header and body row
                 column counts match (5 vs 6 would skew alignment and
                 flag the table as malformed by semantic-HTML linters). */}
             <th className="py-2 pr-2 text-right">
@@ -117,7 +124,11 @@ function RunsTable({ rows }: { rows: JobRunResponse[] }) {
 
 function RunRow({ row }: { row: JobRunResponse }) {
   const [expanded, setExpanded] = useState(false);
-  const expandable = row.status === "failure" && row.error_msg !== null;
+  // #2218 — degraded rows carry their reason in `error_msg` too (the
+  // "api_errors=..." / no-progress detail). Gating expansion on `failure`
+  // alone renders an amber row with no way to read why it is amber.
+  const expandable =
+    (row.status === "failure" || row.status === "degraded") && row.error_msg !== null;
   const duration = formatDuration(row.started_at, row.finished_at);
   return (
     <>

--- a/sql/254_job_runs_degraded_progress.sql
+++ b/sql/254_job_runs_degraded_progress.sql
@@ -1,0 +1,78 @@
+-- 254_job_runs_degraded_progress.sql
+--
+-- #2218 — a job that makes ZERO progress must stop reporting 'success'.
+--
+--
+-- THE DEFECT THIS CLOSES
+-- ---------------------------------------------------------------------------
+-- Job health is derived from COMPLETION, not from PROGRESS. Two instances
+-- found within an hour of each other on 2026-08-03, neither flagged by any
+-- automated check:
+--
+--   * `cusip_resolver_post_bulk_sweep` — the resolver binds a whole-batch
+--     OpenFIGI failure to an `api_errors` counter instead of raising, and the
+--     invoker records `row_count = report.promoted`. A pass where EVERY CUSIP
+--     errored logs `row_count = 0, status = 'success'`. OpenFIGI resolution
+--     stopped 2026-06-18 and the job reported healthy through 2026-08-02.
+--     Measured on this DB 2026-08-05: the last four runs are
+--     `success / row_count 0`, unbroken.
+--   * `ncen_classifier_yearly` — one run, 2026-06-04, `success`, 0 rows, and
+--     `ncen_filer_classifications` is still empty. On a YEARLY cadence it
+--     would not fire again until 2027.
+--
+-- The health surface is self-consistent — `/system/status`, `job_runs` success
+-- rates and the admin verdict all agree these jobs are fine, because all three
+-- derive from the same "did it finish" signal. There was no detector for the
+-- no-op-success class at all; both instances were found by ad-hoc query.
+--
+--
+-- WHY A COUNTER COLUMN AND NOT "ZERO ROWS = FAILURE"
+-- ---------------------------------------------------------------------------
+-- ⚠ Plenty of jobs legitimately have nothing to do on a given run, so a blanket
+-- "row_count = 0 is a failure" would be noise that trains the operator to
+-- ignore the signal. The distinction is `candidates_seen`: a job that saw no
+-- work and did none is healthy; a job that saw work and produced no terminal
+-- outcome at all is stalled. That distinction cannot be inferred after the
+-- fact from `row_count`, which is why the counters have to be PERSISTED rather
+-- than left in log lines — #2213 was diagnosed by log archaeology, and the
+-- point of this migration is that the next one is a query.
+--
+-- `progress_json` is deliberately free-shaped: every job counts different
+-- things (`api_errors` / `unresolved_by_openfigi` / `parse_failures` /
+-- `fetch_failures`), and freezing that into columns would mean a migration per
+-- job. The VERDICT is what is standardised, in
+-- `app/services/job_progress.py`; this column is its evidence.
+
+ALTER TABLE job_runs
+    ADD COLUMN IF NOT EXISTS progress_json JSONB;
+
+-- 'degraded' — the run completed and made no progress. Distinct from
+-- 'failure' (raised) and from 'success' (completed AND progressed), because
+-- collapsing it into either loses the thing the operator needs: a degraded run
+-- is not an incident to page on, and it is not fine.
+ALTER TABLE job_runs
+    DROP CONSTRAINT IF EXISTS job_runs_status_check;
+-- ⚠ 'cancelled' is in this list because sql/137 added it. The obvious way to
+-- write this migration is to copy the most recent list you happen to find —
+-- sql/020's, which predates sql/137 — and that DROPS 'cancelled'. It fails
+-- silently in the worst direction: a database with no cancelled rows accepts
+-- the constraint and then rejects the next cancelled run, and this dev DB has
+-- exactly zero (`select status, count(*) from job_runs group by 1` →
+-- success/skipped/failure/running only), so it applied clean. Caught by Codex
+-- at checkpoint 2, not by any gate.
+--
+-- The full vocabulary, derived from the constraint by
+-- tests/test_job_terminal_status_contract.py so a sixth member cannot be
+-- added here and missed in the five SQL terminal-status filters that read it.
+ALTER TABLE job_runs
+    ADD CONSTRAINT job_runs_status_check
+        CHECK (status IN ('running', 'success', 'failure', 'skipped', 'cancelled', 'degraded'));
+
+COMMENT ON COLUMN job_runs.progress_json IS
+    'Per-job progress counters, as the job itself counts them: '
+    '{"candidates_seen": N, "outcomes": {...}, "errors": {...}}. The verdict '
+    'derived from it is app/services/job_progress.py::degradation_reason, and '
+    'status = ''degraded'' is that verdict. Persisted rather than logged '
+    'because #2213 took log archaeology to diagnose — the successor should be '
+    'a query. NULL means the job does not report progress, which is NOT the '
+    'same as reporting zero.';

--- a/tests/services/processes/test_health_verdict.py
+++ b/tests/services/processes/test_health_verdict.py
@@ -143,6 +143,10 @@ def test_no_stale_status_mapping() -> None:
         "running": ("working", False),
         "pending_retry": ("self_healing", True),
         "failed": ("attention", False),
+        # #2218 — this row is why the `set(expected) == set(_ALL_STATUSES)`
+        # assertion below earns its keep: adding the status without it would
+        # have shipped a member with no pinned verdict.
+        "degraded": ("attention", False),
         "cancelled": ("attention", False),
         "pending_first_run": ("working", False),
         "ok": ("current", False),
@@ -625,3 +629,41 @@ def test_verdict_for_row_wedged_running_reads_red() -> None:
     attention — a hung non-heartbeating job is never falsely calm."""
     row = _row(role="steady_state", status="running", stale_reasons=("mid_flight_stuck",))
     assert verdict_for_row(row, now=_NOW)[0] == "attention"
+
+
+# ---------------------------------------------------------------------------
+# #2218 — degraded
+# ---------------------------------------------------------------------------
+
+
+def test_degraded_reads_attention() -> None:
+    """A run that completed and made no progress is red.
+
+    The entire defect was that this state read as healthy for seven weeks
+    (#2213), so anything softer than attention re-introduces it.
+    """
+    v, sh, reason = compute_verdict(status="degraded", stale_reasons=())
+    assert (v, sh, reason) == ("attention", False, "completed with no progress")
+
+
+def test_degraded_does_not_mask_an_actionable_stale_reason() -> None:
+    """ckpt-1 invariant: the stale block still runs first."""
+    _, _, reason = compute_verdict(status="degraded", stale_reasons=("queue_stuck",))
+    assert reason == "queue stuck"
+
+
+def test_degraded_is_not_self_healed_by_a_retry_in_flight() -> None:
+    """⚠ Deliberate: nothing raised, so there is no ``next_retry_at`` and
+    re-firing would just re-hit whatever is not progressing. The retry branch
+    is scoped to ``failed`` / ``pending_retry`` and must not widen to cover
+    this — a degraded row stays red until a run actually progresses."""
+    v, sh, reason = compute_verdict(status="degraded", stale_reasons=(), retry_in_flight=True, retry_at_display="14:30")
+    assert (v, sh, reason) == ("attention", False, "completed with no progress")
+
+
+def test_degraded_last_run_is_not_hidden_behind_the_kill_switch() -> None:
+    """#1831's carve-out covers what the non-disabled path reddens, and the
+    degraded state now reddens. Without this a halt would hide it — the exact
+    masking the disabled branch exists to prevent."""
+    v, _, reason = compute_verdict(status="disabled", stale_reasons=(), last_run_failed=True)
+    assert (v, reason) == ("attention", "last run failed")

--- a/tests/test_job_degraded_terminal.py
+++ b/tests/test_job_degraded_terminal.py
@@ -1,0 +1,146 @@
+"""#2218 — the degraded terminal, end to end against a real database.
+
+ONE integration test, per the repo's test-tiering guidance: the genuinely-new
+SQL mechanism is ``job_runs.status = 'degraded'`` + ``progress_json``, and the
+policy that decides it is table-tested purely in ``test_job_progress.py``.
+What only a real DB can prove is that the new status survives the
+``job_runs_status_check`` constraint sql/254 rewrites and that the JSONB
+round-trips — a mocked cursor asserts the parameters and would pass against a
+constraint that rejects the value.
+
+⚠ Exercised through the REAL ``_tracked_job`` rather than by calling
+``record_job_finish`` directly. The bug class this ticket exists to close is a
+rule enforced in one code path and not its duplicate: ``_tracked_job`` had two
+byte-identical success branches, and a test that bypasses them proves nothing
+about which one runs.
+
+⚠⚠ ``_tracked_job`` calls ``psycopg.connect`` on ``settings.database_url``
+itself — the operator's DEV DB — so ``ebull_test_conn`` alone does NOT
+redirect it. The
+first draft of this file wrote four rows into the dev ``job_runs`` before that
+was noticed. Same shape as conftest's ``_filer_ingest_worker_conns_use_test_db``
+fixture (#1274), and the fix is the same: patch the global for the duration.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+from app.config import settings
+from app.services.job_progress import JobProgress
+from app.workers.scheduler import _tracked_job
+from tests.fixtures.ebull_test_db import test_database_url
+
+_JOB = "test_degraded_terminal_job"
+
+
+@pytest.fixture(autouse=True)
+def _tracked_job_writes_to_the_test_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect ``settings.database_url`` for the duration.
+
+    ``_tracked_job``'s three connect calls (start, failure, success) read the
+    global directly and are not injectable, so patching it is the only seam.
+    ⚠ The wording here avoids the literal call spelling on purpose: the
+    ``test_no_settings_url_in_destructive_paths`` smoke guard is a line-literal
+    grep and does not know a docstring from code — it caught this file once.
+
+    Autouse so a test added later cannot forget it and silently write to the
+    operator's dev DB.
+    """
+    monkeypatch.setattr(settings, "database_url", test_database_url())
+
+
+def _latest(conn: psycopg.Connection[tuple], job_name: str) -> tuple[str, int | None, str | None, dict]:
+    row = conn.execute(
+        """
+        SELECT status, row_count, error_msg, progress_json
+          FROM job_runs WHERE job_name = %s ORDER BY run_id DESC LIMIT 1
+        """,
+        (job_name,),
+    ).fetchone()
+    assert row is not None, "no job_runs row written"
+    return (str(row[0]), row[1], row[2], row[3])
+
+
+def test_a_run_that_errored_everything_is_degraded_not_success(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """#2213's exact shape: the resolver bound a whole-batch failure to a
+    counter, nothing raised, and the run recorded ``success / row_count 0``
+    for seven weeks."""
+    with _tracked_job(_JOB) as tracker:
+        tracker.row_count = 0
+        tracker.progress = JobProgress(
+            candidates_seen=44_195,
+            outcomes={"promoted": 0},
+            errors={"api_errors": 44_195},
+        )
+
+    status, row_count, error_msg, progress = _latest(ebull_test_conn, _JOB)
+    assert status == "degraded"
+    # ⚠ row_count is still 0 and still recorded. The old signal is not
+    # replaced — it was never wrong, it was just never sufficient.
+    assert row_count == 0
+    assert error_msg is not None and "api_errors=44195" in error_msg
+    assert progress["errors"] == {"api_errors": 44195}
+    assert progress["candidates_seen"] == 44195
+
+
+def test_a_run_that_progressed_is_still_success(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The inert half, and the one that would fail loudly if the verdict were
+    wired the wrong way round — every healthy job in the scheduler depends on
+    it."""
+    job = f"{_JOB}_healthy"
+    with _tracked_job(job) as tracker:
+        tracker.row_count = 3
+        tracker.progress = JobProgress(
+            candidates_seen=10,
+            outcomes={"promoted": 3, "no_instrument_match": 7},
+            errors={"api_errors": 0},
+        )
+
+    status, row_count, error_msg, progress = _latest(ebull_test_conn, job)
+    assert status == "success"
+    assert row_count == 3
+    assert error_msg is None
+    assert progress["outcomes"]["no_instrument_match"] == 7
+
+
+def test_a_job_reporting_no_progress_keeps_the_historical_contract(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """Opt-in property, asserted against the DB because it is what makes this
+    change safe to land on ~50 unwired jobs: no progress reported → ``success``
+    and a NULL ``progress_json``, exactly as before.
+
+    ⚠ NULL is asserted rather than ``{}``: an empty object would read as "this
+    job reported zero of everything", which is a different and false claim.
+    """
+    job = f"{_JOB}_unwired"
+    with _tracked_job(job) as tracker:
+        tracker.row_count = 12
+
+    status, row_count, error_msg, progress = _latest(ebull_test_conn, job)
+    assert (status, row_count, error_msg, progress) == ("success", 12, None, None)
+
+
+def test_an_operator_note_is_not_overwritten_by_the_degraded_reason(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """``tracker.note`` is a deliberate operator message (a soft-skip digest).
+    The derived reason must not clobber it — but the status must still be
+    degraded, so the signal is not lost either."""
+    job = f"{_JOB}_noted"
+    with _tracked_job(job) as tracker:
+        tracker.note = "all archives fresh"
+        tracker.progress = JobProgress(candidates_seen=5, outcomes={"done": 0})
+
+    status, _, error_msg, progress = _latest(ebull_test_conn, job)
+    assert status == "degraded"
+    assert error_msg == "all archives fresh"
+    # The reason is not lost when the note wins — progress_json carries the
+    # evidence, which is the whole point of persisting it.
+    assert progress["candidates_seen"] == 5

--- a/tests/test_job_progress.py
+++ b/tests/test_job_progress.py
@@ -107,3 +107,12 @@ def test_progress_serialises_with_its_three_axes_intact() -> None:
         "outcomes": {"done": 1},
         "errors": {"boom": 2},
     }
+
+
+def test_negative_counts_are_not_treated_as_opposites() -> None:
+    """Codex ckpt-3. A negative count is nonsense in either bucket, but under
+    truthiness it degraded on the error side and read as PROGRESS on the
+    outcome side — the same bad value pointing two different ways.
+    """
+    assert degradation_reason(JobProgress(errors={"api_errors": -1})) is None
+    assert degradation_reason(JobProgress(candidates_seen=5, outcomes={"done": -1})) is not None

--- a/tests/test_job_progress.py
+++ b/tests/test_job_progress.py
@@ -1,0 +1,109 @@
+"""#2218 — the progress verdict. Pure, no database.
+
+Every case below is drawn from a real run shape rather than an imagined one:
+the two defects that motivated the ticket (#2213 `cusip_resolver_post_bulk_sweep`
+at 100% `api_errors`, #2214 `ncen_classifier_yearly` writing zero rows) and the
+healthy shapes that must NOT be degraded, which is where a naive "zero rows =
+alarm" rule would have produced noise.
+"""
+
+from __future__ import annotations
+
+from app.services.job_progress import JobProgress, degradation_reason
+
+
+def test_no_progress_reported_is_judged_exactly_as_before() -> None:
+    # The opt-in property. Every job that has not been wired must be inert,
+    # otherwise this change silently reclassifies the whole scheduler.
+    assert degradation_reason(None) is None
+
+
+def test_saw_nothing_did_nothing_is_healthy() -> None:
+    # ⚠ The case a "zero rows written = failure" rule gets wrong, and the
+    # reason the ticket says not to build one. A sweep with an empty queue is
+    # the normal state of most jobs most of the time.
+    progress = JobProgress(candidates_seen=0, outcomes={"promoted": 0}, errors={"api_errors": 0})
+    assert degradation_reason(progress) is None
+
+
+def test_saw_work_and_did_some_is_healthy() -> None:
+    progress = JobProgress(
+        candidates_seen=120,
+        outcomes={"promoted": 3, "no_instrument_match": 117},
+        errors={"api_errors": 0},
+    )
+    assert degradation_reason(progress) is None
+
+
+def test_a_non_universe_outcome_still_counts_as_progress() -> None:
+    # Most bulk CUSIPs resolve to something outside our universe. If
+    # `no_instrument_match` were treated as a miss, every healthy run of
+    # `cusip_resolver_post_bulk_sweep` would read degraded — the false-alarm
+    # direction, which trains the operator to ignore the signal.
+    progress = JobProgress(candidates_seen=500, outcomes={"promoted": 0, "no_instrument_match": 500})
+    assert degradation_reason(progress) is None
+
+
+def test_all_errored_is_degraded() -> None:
+    # #2213's actual shape: the resolver raised, every CUSIP was bound to the
+    # error counter, and the job recorded success / row_count 0 for seven
+    # weeks.
+    progress = JobProgress(
+        candidates_seen=44_195,
+        outcomes={"promoted": 0, "no_instrument_match": 0},
+        errors={"api_errors": 44_195},
+    )
+    reason = degradation_reason(progress)
+    assert reason is not None
+    assert "api_errors=44195" in reason
+
+
+def test_partial_errors_still_degrade() -> None:
+    # ⚠ Deliberate, and the interesting half: a run that did SOME work and
+    # errored the rest is degraded. The seven-week stall was a 100%-error run,
+    # but the same failure at 20% hides the same defect at a smaller scale and
+    # is the shape that precedes it.
+    progress = JobProgress(candidates_seen=100, outcomes={"promoted": 80}, errors={"api_errors": 20})
+    assert degradation_reason(progress) is not None
+
+
+def test_saw_candidates_but_no_terminal_outcome_is_the_silent_stall() -> None:
+    # #2214's shape: filers seen, nothing classified, nothing errored either.
+    progress = JobProgress(
+        candidates_seen=11_464,
+        outcomes={"classifications_written": 0, "no_ncen_found": 0},
+        errors={"parse_failures": 0, "fetch_failures": 0},
+    )
+    reason = degradation_reason(progress)
+    assert reason is not None
+    assert "11464" in reason
+
+
+def test_errors_outrank_the_stall_reason() -> None:
+    # Both conditions hold here. The error detail is the more actionable of
+    # the two — "it errored on 5 things" points somewhere, "it produced
+    # nothing" does not — so it must be the reported reason.
+    progress = JobProgress(candidates_seen=5, outcomes={"promoted": 0}, errors={"api_errors": 5})
+    reason = degradation_reason(progress)
+    assert reason is not None
+    assert reason.startswith("errors reported")
+
+
+def test_unknown_candidate_count_cannot_trigger_the_stall_rule() -> None:
+    # `None` is not zero and is not "many". A job that does not count its
+    # candidates cannot be judged stalled without inventing an alarm out of an
+    # absence, which is the same error class as back-filling a missing date.
+    progress = JobProgress(candidates_seen=None, outcomes={"promoted": 0})
+    assert degradation_reason(progress) is None
+
+
+def test_progress_serialises_with_its_three_axes_intact() -> None:
+    # `progress_json` is the evidence #2213 needed and did not have. The
+    # shape is asserted because a reader querying for the next stall will
+    # query these keys.
+    progress = JobProgress(candidates_seen=7, outcomes={"done": 1}, errors={"boom": 2})
+    assert progress.as_json() == {
+        "candidates_seen": 7,
+        "outcomes": {"done": 1},
+        "errors": {"boom": 2},
+    }

--- a/tests/test_job_terminal_status_contract.py
+++ b/tests/test_job_terminal_status_contract.py
@@ -1,0 +1,112 @@
+"""#2218 — the ``job_runs`` status vocabulary, derived rather than trusted.
+
+WHY THIS FILE EXISTS
+--------------------
+The vocabulary was spelled by hand in **eight** places: the CHECK constraint
+(rewritten across sql/014, sql/020, sql/137, sql/254), five SQL ``IN (...)``
+filters in four modules, and two Python ``Literal``s. pyright cannot see inside
+a SQL string, so nothing connected them, and the drift was already real before
+this ticket:
+
+* ``ops_monitor.JobStatus`` was missing ``cancelled``, which sql/137 added.
+* The first draft of sql/254 was copied from sql/020 — which predates sql/137 —
+  and silently DROPPED ``cancelled`` from the constraint. It applied clean on
+  this dev DB because there happen to be no cancelled rows, and would have
+  rejected the next one. Codex caught it at checkpoint 2; no gate did.
+
+So the guard reads the migration as text and asserts the Python constants
+agree. It is deliberately a SOURCE-derived test, not a DB test: it fails in the
+fast tier, on a machine with no Postgres, at the moment the sixth member is
+added.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.services.ops_monitor import JOB_TERMINAL_STATUSES, TERMINAL_STATUS_SQL
+
+_MIGRATION = Path(__file__).resolve().parents[1] / "sql" / "254_job_runs_degraded_progress.sql"
+
+#: ``running`` is a status but NOT a terminal one — a row still in flight has
+#: not finished, and every "latest terminal run" query must exclude it or the
+#: admin verdict would read an in-progress run as the last outcome.
+_NON_TERMINAL = frozenset({"running"})
+
+
+def _constraint_statuses() -> set[str]:
+    """Statuses the shipped CHECK constraint admits, parsed from the migration."""
+    sql = _MIGRATION.read_text()
+    match = re.search(
+        r"ADD CONSTRAINT job_runs_status_check\s*\n?\s*CHECK \(status IN \(([^)]*)\)\)",
+        sql,
+    )
+    assert match is not None, "could not find the job_runs_status_check definition in sql/254"
+    return {value.strip().strip("'") for value in match.group(1).split(",")}
+
+
+def test_terminal_statuses_are_the_constraint_minus_running() -> None:
+    """The load-bearing assertion.
+
+    Adding a status to the migration without adding it here fails; adding it
+    here without the migration fails. Either direction is the drift that let a
+    degraded row be written and never read.
+    """
+    assert set(JOB_TERMINAL_STATUSES) == _constraint_statuses() - _NON_TERMINAL
+
+
+def test_the_sql_fragment_and_the_tuple_cannot_disagree() -> None:
+    """``JOB_TERMINAL_STATUSES`` is parsed from ``TERMINAL_STATUS_SQL``, so this
+    pins the derivation rather than a second hand-written copy."""
+    assert TERMINAL_STATUS_SQL.startswith("(") and TERMINAL_STATUS_SQL.endswith(")")
+    assert set(JOB_TERMINAL_STATUSES) == {
+        part.strip().strip("'") for part in TERMINAL_STATUS_SQL.strip("()").split(",")
+    }
+
+
+def test_cancelled_survived_the_migration_rewrite() -> None:
+    """Named explicitly because losing it is the specific mistake that was made.
+
+    sql/137 added ``cancelled``; a migration copied from sql/020 drops it, and
+    the loss is invisible on any database that has no cancelled rows to
+    validate against.
+    """
+    assert "cancelled" in _constraint_statuses()
+
+
+def test_degraded_is_terminal() -> None:
+    # If it were excluded from the terminal set, the row would be written and
+    # every "latest terminal run" query would skip past it to an older,
+    # greener run — the exact way to ship this ticket and change nothing.
+    assert "degraded" in JOB_TERMINAL_STATUSES
+
+
+def test_no_module_spells_the_terminal_list_by_hand() -> None:
+    """Grep guard for the pattern that caused the drift.
+
+    ⚠ Matches the SHAPE, not an exact string, because the five sites differed
+    only in whitespace and an equality check would have read each as "not the
+    same literal".
+
+    Two precision fixes, both found by running it:
+
+    * ``'failure'`` is required. ``bootstrap_adapter`` filters
+      ``IN ('success', 'error', 'skipped', 'blocked', 'cancelled')`` — a
+      DIFFERENT vocabulary on a different table, and flagging it would make
+      this guard a nuisance that gets deleted.
+    * Python comment lines are stripped first. Otherwise the guard flags the
+      comment in ``ops_monitor`` that quotes the anti-pattern in order to warn
+      about it.
+    """
+    root = Path(__file__).resolve().parents[1] / "app"
+    pattern = re.compile(r"IN\s*\(\s*'success'[^)]*'failure'[^)]*'skipped'[^)]*\)", re.IGNORECASE)
+
+    def _code(path: Path) -> str:
+        return "\n".join(line for line in path.read_text().splitlines() if not line.lstrip().startswith("#"))
+
+    offenders = [str(path.relative_to(root)) for path in root.rglob("*.py") if pattern.search(_code(path))]
+    assert offenders == [], (
+        f"hand-spelled terminal-status list in {offenders} — "
+        "import TERMINAL_STATUS_SQL from app.services.ops_monitor instead"
+    )


### PR DESCRIPTION
## The defect

Job health was derived from **completion**, not progress. `cusip_resolver_post_bulk_sweep`
binds a whole-batch OpenFIGI failure to an `api_errors` counter rather than raising, and the
invoker records `row_count = report.promoted`. A pass where *every* CUSIP errored logged
`status='success', row_count=0`. OpenFIGI resolution stopped 2026-06-18 and the job reported
healthy through 2026-08-02 (#2213); the same shape hid #2214.

The health surface is self-consistent — `/system/status`, `job_runs` success rates and the
admin verdict all agree, because all three read the same "did it finish" signal. There was
no detector for the no-op-success class at all.

## What ships

| | |
|---|---|
| `sql/254` | `job_runs.status = 'degraded'` + `progress_json` |
| `app/services/job_progress.py` | the pure verdict — `JobProgress` + `degradation_reason` |
| `_JobTracker.progress` / `_finish_tracked` | both of `_tracked_job`'s previously **duplicated** success branches now route through one finisher, so the verdict cannot apply on one and not the other |
| wiring | the two known jobs. Opt-in: `progress is None` → judged exactly as before, so ~50 unwired jobs are inert |
| surfacing | `ProcessStatus` / `RunStatus` / `JobStatus`, scheduled adapter, health verdict (`attention`), admin pill + expandable row |

**Two rules, and "zero rows written" is deliberately not one of them.** Plenty of jobs
legitimately have nothing to do; a blanket zero-rows alarm is noise that trains the operator
to ignore the signal, which is strictly worse than no signal. The distinction is
`candidates_seen` — saw no work and did none is healthy, saw work and produced no terminal
outcome is stalled — and it cannot be inferred from `row_count` after the fact, which is why
the counters are **persisted**. #2213 was diagnosed by log archaeology; its successor should
be a query.

`degraded` takes the non-failure retry path on purpose: nothing raised, so there is no
transient/permanent classification to make and re-firing would just re-hit whatever is not
progressing. It is a signal, not a retry trigger.

## ⚠ Two findings that reframe the follow-on tickets

Both from running the wired jobs on dev, and both mean the next tickets are cheaper but
differently shaped than filed.

**#2214 is not a no-op-success defect.** `ncen_classifier_yearly` now reports
`candidates_seen=6, no_ncen_found=6, classifications_written=0` — an honest `success`. It has
**6** active rows in `institutional_filer_seeds` and none of them files N-CEN. The empty
`ncen_filer_classifications` table is a **seed-population** problem upstream, not a
classifier problem. This PR correctly does *not* flag it.

**#2213's 44,195 backlog is not in this job's queue.** The sweep now reports
`candidates_seen=0`, and that is correct: `_select_unresolved_bulk_cusips` filters
`AND u.source IS NOT NULL`, and the 44,429 pending rows are the **legacy `source IS NULL`
partition**, owned by the fuzzy resolver path. The bulk partition is fully drained.

```
select resolution_status, (source is not null) as bulk, count(*) from unresolved_13f_cusips group by 1,2;
--   openfigi_unknown      true   60011
--   (null)                false  44429   <- #2213's backlog, a different job's queue
--   resolved_via_openfigi true    3027
--   openfigi_no_instrument true   2199
```

So this PR gives #2213 the detector it needed, and simultaneously shows the pile-up is in a
queue this job never reads. Recorded here rather than acted on — #2213 is the next ticket
and this is its evidence, not a licence to widen this one.

## Drift the work exposed, fixed here

- `ops_monitor.JobStatus` was missing `cancelled`, which `sql/137` added to the CHECK
  constraint. Two vocabularies, already out of step before this ticket.
- The terminal-status list was hand-spelled in **five** SQL literals across four modules.
  Adding a status to the constraint without touching all five writes a row nothing reads.
- ⚠ **The first draft of sql/254 was copied from sql/020 — which predates sql/137 — and
  silently dropped `cancelled` from the constraint.** It applied clean on this dev DB
  because there are zero cancelled rows, and would have rejected the next one. Caught by
  Codex at checkpoint 2; no gate saw it.

All three now derive from one constant (`TERMINAL_STATUS_SQL`), pinned to the migration text
by `tests/test_job_terminal_status_contract.py` — a source-derived test that fails in the
fast tier, with no Postgres, the moment a sixth member is added.

## Codex checkpoint 2

Two rounds, four findings, all real, all fixed before this push:

1. **P1** — the migration dropped `cancelled` (above).
2. **P1** — `_read_latest_terminal_run` / `_read_latest_anchor_terminal_run` / `list_runs`
   still filtered to the old four, so a degraded row would have been skipped in favour of an
   older, greener run. Ship-it-and-change-nothing.
3. **P2** — `dispatcher.reset_stale_in_flight` treated only `('success','failure')` as
   terminal, so a crash between the terminal row and `mark_request_completed` would replay a
   request that already ran. ⚠ Fixed by adding `degraded` only, **not** by reusing the shared
   vocabulary: that set is narrower on purpose, and whether boot recovery should re-fire
   `skipped` / `cancelled` is a separate question this ticket does not answer.
4. **P2** — the admin job-history row was expandable only on `failure`, so a degraded run
   rendered amber with its `api_errors=…` reason unreadable.

## Definition-of-Done clauses 8-12 — commit `4780e8a6`

| clause | evidence |
|---|---|
| **8** smoke panel | The default `AAPL/GME/MSFT/JPM/HD` panel is not informative — this change is job-shaped, not instrument-shaped. Exercised the two wired jobs on dev instead, via `POST /jobs/{name}/run`: `cusip_resolver_post_bulk_sweep` (run 80462) → `success`, `progress_json = {"candidates_seen": 0, "outcomes": {…all 0}, "errors": {"api_errors": 0}}`. `ncen_classifier_yearly` (run 80468) → `success`, `{"candidates_seen": 6, "outcomes": {"no_ncen_found": 6, "classifications_written": 0}, "errors": {…all 0}}`. Both correctly NOT degraded. |
| **9** cross-source | N/A in the usual sense — no external figure is derived. The equivalent check is the constraint against its own migration text, asserted by `test_job_terminal_status_contract.py`, and the live `pg_get_constraintdef` after re-apply: `CHECK (status = ANY (ARRAY['running','success','failure','skipped','cancelled','degraded']))`. |
| **10** backfill | None required — `progress_json` is NULL for historical rows, which is the honest value ("this job did not report progress"), not zero. Not a `sec_rebuild` scope. |
| **11** operator-visible | `/system/status` and the two job rows re-read after both runs; `progress_json` is populated on real runs and the rows render green, correctly. ⚠ **No job on dev is currently degraded** — both are honestly healthy (see the findings above), so the red path is proven by `test_job_degraded_terminal.py` driving the real `_tracked_job` against a real database, plus the exhaustive `set(expected) == set(_ALL_STATUSES)` verdict contract. Stating that rather than manufacturing a degraded row to photograph. |
| **12** | this table, at `4780e8a6`. |

## Tests

- `test_job_progress.py` — 10 pure table tests. Every case is a real run shape, including the
  three that must **not** degrade (a naive rule gets those wrong).
- `test_job_degraded_terminal.py` — one DB test through the real `_tracked_job`, because only
  a real database proves the new status survives the rewritten CHECK. ⚠ The first draft wrote
  four rows into the **dev** `job_runs` before I noticed `_tracked_job` opens its own
  connection on the global URL; deleted, and the file now has an autouse redirect fixture.
  The `test_no_settings_url_in_destructive_paths` smoke guard then caught the *docstring*
  describing it — line-literal by design — so the wording works around it and says so.
- `test_job_terminal_status_contract.py` — derives the vocabulary from the migration.
  ⚠ **Revert-probed**: re-introducing one hand-spelled list fails
  `test_no_module_spells_the_terminal_list_by_hand` and only that test; restoring passes. Two
  precision fixes were needed to make it usable — it must require `'failure'` (so
  `bootstrap_adapter`'s different vocabulary is not flagged) and must strip comments (or it
  flags the comment warning about the anti-pattern).
- `test_health_verdict.py` — four new cases. The existing exhaustiveness assertion caught the
  new status with no verdict pinned, which is the guard working.

## Security

No security model touched — ops reporting only. No auth surface, no order path. The kill
switch interaction is deliberate and covered: a degraded last run is **not** hidden behind
the halt, mirroring what #1831 already does for a failed one.

Closes #2218.
Refs #2213.
Refs #2214.
