### PR TITLE
feat(#2240): phase 3a — strategy registry contract

### DIFF
--- a/app/services/strategy_registry.py
+++ b/app/services/strategy_registry.py
@@ -37,7 +37,7 @@ import json
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args
 
 from app.services.indicator_series import IndicatorSeries, MultiIndicatorSeries, Universe
 
@@ -74,33 +74,21 @@ NotEvaluableReason = Literal[
     "no_fill_bar",
 ]
 
-VERDICTS: frozenset[str] = frozenset({"fired", "not_fired", "not_evaluable"})
-SIGNAL_KINDS: frozenset[str] = frozenset({"entry", "exit"})
+# ⚠ DERIVED from the Literals above, never restated. Review flagged the
+# vocabulary being written out three times here — and sql/255's CHECK makes a
+# fourth — which is precisely the closed-vocabulary-in-N-places defect the
+# prevention log carries from #2218 (a member added in one place and missed in
+# the others writes rows nothing reads). `get_args` makes drift impossible in
+# Python; tests/test_strategy_registry.py pins the SQL CHECK against these.
+VERDICTS: frozenset[str] = frozenset(get_args(Verdict))
+SIGNAL_KINDS: frozenset[str] = frozenset(get_args(SignalKind))
+NOT_EVALUABLE_REASONS: frozenset[str] = frozenset(get_args(NotEvaluableReason))
 
-NOT_EVALUABLE_REASONS: frozenset[str] = frozenset(
-    {
-        "missing_volume",
-        "missing_spread",
-        "insufficient_warmup",
-        "quarantined_bar",
-        "series_break",
-        "not_listed",
-        "ambiguous_intrabar",
-        "no_fill_bar",
-    }
-)
-
-PARENT_REASON_CODES: frozenset[str] = frozenset(
-    {
-        "missing_volume",
-        "missing_spread",
-        "insufficient_warmup",
-        "quarantined_bar",
-        "series_break",
-        "not_listed",
-        "ambiguous_intrabar",
-    }
-)
+#: The seven from parent criterion 8. `no_fill_bar` is OURS and is excluded
+#: deliberately — see NotEvaluableReason. Kept as an explicit subtraction so
+#: adding a parent code later cannot silently land on our side of the line.
+OUR_ADDITIONAL_REASON_CODES: frozenset[str] = frozenset({"no_fill_bar"})
+PARENT_REASON_CODES: frozenset[str] = NOT_EVALUABLE_REASONS - OUR_ADDITIONAL_REASON_CODES
 
 
 @dataclass(frozen=True)

--- a/app/services/strategy_registry.py
+++ b/app/services/strategy_registry.py
@@ -1,0 +1,283 @@
+"""Phase 3a — the strategy registry contract.
+
+Spec: ``docs/proposals/ta/2026-08-05-strategy-registry-and-signal-ledger.md``.
+Refs #2240, #2245, #2288.
+
+WHAT A STRATEGY IS HERE
+----------------------
+A pure function over a ``BarSeries`` plus its indicator series, returning a
+verdict per bar. Code, not rows: a rules table needs an interpreter, and an
+interpreter is a second place for the fill-timing rule to be got wrong.
+
+⚠⚠ THE FILL RULE IS ENFORCED BY THE SHAPE OF THIS API, NOT BY A CONSTRAINT.
+
+Parent §3.5: *"Signal on the close of bar t → fill at the OPEN of bar t+1. No
+exceptions… The backtester must make same-bar fills structurally impossible
+rather than merely discouraged."*
+
+A ``StrategySignal`` carries a bar INDEX and nothing else. There is no field
+through which a strategy could request a fill price, a fill date, or a fill
+bar. The writer resolves the fill from the series. **A same-bar fill is not
+expressible**, which is what "structurally impossible" has to mean — removing
+the capability rather than detecting its misuse.
+
+⚠ An earlier draft of the spec claimed a ``CHECK (fill_bar_date >
+signal_bar_date)`` was "the whole mechanism". It is not: a writer can record
+``signal_bar_date = t-1``, fill on ``t``, and use bar ``t``'s data with every
+constraint passing. That CHECK is a backstop against a buggy writer and is
+described as one.
+
+⚠⚠ EVALUABILITY IS DECIDED BEFORE THE CONDITION RUNS. See ``evaluate``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from app.services.indicator_series import IndicatorSeries, MultiIndicatorSeries, Universe
+
+STRATEGY_SET_ID = "strategy-registry-v1"
+
+
+def _module_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+Verdict = Literal["fired", "not_fired", "not_evaluable"]
+
+SignalKind = Literal["entry", "exit"]
+
+#: ⚠ CLOSED vocabulary. Seven codes are parent criterion 8 verbatim:
+#: *"`not_evaluable` carries a reason code … These have different bias
+#: implications and collapsing them loses the ability to tell a data gap from a
+#: real absence."* Free text cannot be counted, so it cannot support criterion
+#: 9's "measure what you reject".
+#:
+#: ⚠ ``no_fill_bar`` is an EIGHTH, added here and flagged as an addition rather
+#: than smuggled in: the last bar of any series has no ``t+1``, so a signal
+#: there can never be filled, and none of the seven describes that. It is not a
+#: data gap — it is the edge of the series. If the parent's vocabulary is the
+#: authority, this needs adopting there too.
+NotEvaluableReason = Literal[
+    "missing_volume",
+    "missing_spread",
+    "insufficient_warmup",
+    "quarantined_bar",
+    "series_break",
+    "not_listed",
+    "ambiguous_intrabar",
+    "no_fill_bar",
+]
+
+VERDICTS: frozenset[str] = frozenset({"fired", "not_fired", "not_evaluable"})
+SIGNAL_KINDS: frozenset[str] = frozenset({"entry", "exit"})
+
+NOT_EVALUABLE_REASONS: frozenset[str] = frozenset(
+    {
+        "missing_volume",
+        "missing_spread",
+        "insufficient_warmup",
+        "quarantined_bar",
+        "series_break",
+        "not_listed",
+        "ambiguous_intrabar",
+        "no_fill_bar",
+    }
+)
+
+PARENT_REASON_CODES: frozenset[str] = frozenset(
+    {
+        "missing_volume",
+        "missing_spread",
+        "insufficient_warmup",
+        "quarantined_bar",
+        "series_break",
+        "not_listed",
+        "ambiguous_intrabar",
+    }
+)
+
+
+@dataclass(frozen=True)
+class StrategySignal:
+    """One bar's verdict.
+
+    ⚠ ``signal_index`` is an index into the series the strategy was given, and
+    it is the ONLY positional information a strategy emits. No fill date, no
+    fill price, no fill bar — see the module docstring.
+    """
+
+    verdict: Verdict
+    signal_index: int
+    kind: SignalKind = "entry"
+    #: Required when ``verdict == "not_evaluable"``, forbidden otherwise.
+    reason: NotEvaluableReason | None = None
+
+    def __post_init__(self) -> None:
+        # ⚠ `Literal` is a TYPE-CHECK annotation and enforces nothing at
+        # runtime — an untyped caller can pass `reason="free text"` or an
+        # unknown verdict straight through. This class exists to keep verdicts
+        # and reason codes COUNTABLE (criterion 9 has to count them), so the
+        # closed sets are checked here rather than assumed.
+        if self.verdict not in VERDICTS:
+            raise ValueError(f"unknown verdict {self.verdict!r}; must be one of {sorted(VERDICTS)}")
+        if self.kind not in SIGNAL_KINDS:
+            raise ValueError(f"unknown signal kind {self.kind!r}; must be one of {sorted(SIGNAL_KINDS)}")
+        if self.reason is not None and self.reason not in NOT_EVALUABLE_REASONS:
+            raise ValueError(f"unknown reason code {self.reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+        if self.verdict == "not_evaluable" and self.reason is None:
+            raise ValueError("not_evaluable requires a reason code (parent criterion 8)")
+        if self.verdict != "not_evaluable" and self.reason is not None:
+            raise ValueError(f"reason {self.reason!r} is meaningless on verdict {self.verdict!r}")
+        if self.signal_index < 0:
+            raise ValueError(f"signal_index must be non-negative, got {self.signal_index}")
+
+
+@dataclass(frozen=True)
+class StrategyIdentity:
+    """Everything that makes this a distinct strategy.
+
+    ⚠ Parent criterion 11: *"Strategy identity must cover code, not just
+    parameters — same params with a changed filter, universe or cost model is a
+    different strategy."* So the version hashes ALL of it. An earlier draft
+    hashed only the defining module's source (copying ``indicator_series``),
+    which misses the universe and the cost model entirely — two genuinely
+    different strategies would then share a version and their signals would
+    collide on the ledger's uniqueness key.
+
+    ⚠ This is also why ``universe`` is NOT a separate column in that key:
+    criterion 11 puts it *inside* the identity, so one identity spanning two
+    universes is not one strategy.
+    """
+
+    strategy_id: str
+    params: Mapping[str, object]
+    universe: Universe
+    cost_model_id: str
+    #: Source of the module DEFINING the strategy, not of this registry.
+    source_hash: str
+
+    @property
+    def version(self) -> str:
+        payload = json.dumps(
+            {
+                "strategy_id": self.strategy_id,
+                "params": self.params,
+                "universe": self.universe,
+                "cost_model_id": self.cost_model_id,
+                "source_hash": self.source_hash,
+                "registry": _module_hash(),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return f"{STRATEGY_SET_ID}+{hashlib.sha256(payload.encode()).hexdigest()[:12]}"
+
+
+#: A strategy body. Invoked ONLY on bars where every declared input is
+#: evaluable — see ``evaluate``.
+StrategyBody = Callable[[int], bool]
+
+
+@dataclass(frozen=True)
+class StrategyInput:
+    """One indicator series a strategy depends on, WITH the reason code to
+    record when it cannot support a value.
+
+    ⚠ The reason has to come from the caller, and this pairing is the fix for a
+    real defect Codex found at checkpoint 2. ``evaluate`` originally recorded a
+    single ``warmup_reason`` for every unevaluable bar, which collapsed
+    quarantined bars, series breaks and genuine data gaps all into
+    ``insufficient_warmup`` — destroying precisely what parent criterion 8
+    exists for: *"These have different bias implications and collapsing them
+    loses the ability to tell a data gap from a real absence."*
+
+    ``indicator_series`` knows THAT a value is unevaluable but not WHY — it has
+    no database access and cannot know whether a NULL came from a quarantined
+    bar or a missing volume field. The caller assembling the inputs does. So
+    the knowledge is supplied where it exists rather than guessed where it does
+    not.
+
+    ⚠ Warm-up is distinguished structurally, not by the caller: a leading
+    ``None`` that is NOT in ``not_evaluable_indices`` is the indicator warming
+    up, and is always ``insufficient_warmup``.
+    """
+
+    series: IndicatorSeries | MultiIndicatorSeries
+    #: Recorded when this input is unevaluable for a data reason.
+    reason: NotEvaluableReason
+
+
+def _unevaluable_reason_at(inputs: Sequence[StrategyInput], index: int) -> NotEvaluableReason | None:
+    """The reason this bar cannot be judged, or None if every input is fine.
+
+    Data reasons win over warm-up: a bar that is BOTH inside an indicator's
+    warm-up and quarantined is reported as quarantined, because that is the one
+    with a bias implication worth counting.
+    """
+    warming = False
+    for declared in inputs:
+        series = declared.series
+        if index in series.not_evaluable_indices:
+            return declared.reason
+        if isinstance(series, IndicatorSeries):
+            if series.values[index] is None:
+                warming = True
+        else:
+            if any(component[index] is None for component in series.components.values()):
+                warming = True
+    return "insufficient_warmup" if warming else None
+
+
+def evaluate(
+    body: StrategyBody,
+    *,
+    inputs: Sequence[StrategyInput],
+    n_bars: int,
+    kind: SignalKind = "entry",
+) -> list[StrategySignal]:
+    """Run ``body`` over every bar, returning one verdict each.
+
+    ⚠⚠ EVALUABILITY IS CHECKED BEFORE ``body`` IS CALLED, AND THAT IS THE WHOLE
+    POINT OF THIS FUNCTION.
+
+    Python's ``and`` / ``or`` short-circuit. A strategy written as::
+
+        close[i] > sma[i] and volume[i] > vol_sma[i] * 1.5
+
+    returns False the moment ``close <= sma``, WITHOUT ever touching
+    ``volume``. If ``volume`` was unevaluable at that bar, the strategy has
+    reported ``not_fired`` for a bar it could not actually judge — which is
+    design-doc decision 5's corruption ("could not evaluate" indistinguishable
+    from "did not fire", silently corrupting the win-rate denominator)
+    re-entering through the back door after being closed at the indicator
+    layer.
+
+    Checking every declared input first makes short-circuit ordering
+    irrelevant, rather than something each strategy author has to remember not
+    to get wrong. ``body`` is only ever invoked on bars where all of its inputs
+    are evaluable, so inside it a ``None`` is impossible by construction.
+
+    ⚠ The LAST bar is ``no_fill_bar``, not a fire. A signal on the final bar of
+    a series has no ``t+1`` to fill at, and reporting it as ``fired`` would
+    hand the backtester a trade that cannot be entered. Parent criterion 8's
+    seven codes do not cover this case; see ``NotEvaluableReason``.
+    """
+    signals: list[StrategySignal] = []
+    for index in range(n_bars):
+        if index == n_bars - 1:
+            signals.append(StrategySignal(verdict="not_evaluable", signal_index=index, kind=kind, reason="no_fill_bar"))
+            continue
+        reason = _unevaluable_reason_at(inputs, index)
+        if reason is not None:
+            signals.append(StrategySignal(verdict="not_evaluable", signal_index=index, kind=kind, reason=reason))
+            continue
+        fired = body(index)
+        signals.append(StrategySignal(verdict="fired" if fired else "not_fired", signal_index=index, kind=kind))
+    return signals

--- a/sql/255_strategy_signals.sql
+++ b/sql/255_strategy_signals.sql
@@ -1,0 +1,149 @@
+-- 255_strategy_signals.sql
+--
+-- Phase 3b — the signal ledger.
+-- Spec: docs/proposals/ta/2026-08-05-strategy-registry-and-signal-ledger.md
+-- Registry contract: app/services/strategy_registry.py (phase 3a).
+--
+--
+-- ⚠⚠ WHAT THE CONSTRAINTS BELOW DO AND DO NOT PROVE
+-- ---------------------------------------------------------------------------
+-- Parent §3.5 requires same-bar fills to be "structurally impossible rather
+-- than merely discouraged". An earlier draft of the spec claimed the CHECK at
+-- the bottom of this file WAS that mechanism. It is not, and saying so here
+-- matters more than the constraint itself:
+--
+--   A writer can record signal_bar_date = t-1, fill on t, and use bar t's
+--   data. Every constraint in this file passes.
+--
+-- The actual mechanism is the SHAPE of the registry API — a StrategySignal
+-- carries a bar INDEX and no fill field at all, so a same-bar fill cannot be
+-- expressed. These constraints are a BACKSTOP against a buggy writer, and are
+-- described as one so nobody mistakes them for the guarantee.
+--
+--
+-- GRAIN: ONE ROW PER (STRATEGY VERSION, INSTRUMENT, SIGNAL BAR, KIND)
+-- ---------------------------------------------------------------------------
+-- `strategy_version` is IN the key, not beside it. Without it, re-running a
+-- changed strategy either collides with or silently overwrites the old signal,
+-- and the ledger stops being a record of what was actually decided.
+--
+-- `signal_kind` is in the key because parent §3.5 applies the fill rule to
+-- "entries and exits alike" — a strategy exiting one position and entering
+-- another on the same bar for the same instrument is legitimate.
+--
+-- ⚠ `universe` is deliberately NOT in the key. Parent criterion 11: "universe
+-- is part of the identity hash … 'S-1 on US stocks' and 'S-1 on eu_equity' are
+-- two strategies and always were." It is INSIDE strategy_version, so a key
+-- carrying it too would permit one strategy identity to span two universes,
+-- which criterion 11 says is not one strategy. It is stored as a column for
+-- querying and labelling (#2288), never for identity.
+--
+-- ⚠ NO TIMEFRAME COLUMN, and intraday is NOT a "just add one" migration.
+-- v1 is daily and `signal_bar_date` is a DATE, so every intraday bar on one
+-- date would collide on this key. Intraday needs bar-INSTANT identity — a
+-- different key, not an extra column. Stated so the next person prices it
+-- correctly rather than discovering it.
+
+CREATE TABLE IF NOT EXISTS strategy_signals (
+    signal_id        BIGSERIAL PRIMARY KEY,
+
+    -- Identity of the producer. `strategy_version` hashes code + params +
+    -- universe + cost model (criterion 11), so it changes whenever any of
+    -- those do and old signals become visibly stale rather than silently
+    -- reinterpreted under new logic.
+    strategy_id      TEXT NOT NULL,
+    strategy_version TEXT NOT NULL,
+
+    instrument_id    BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+
+    -- Bar t: the close that triggered. NOT the fill date, NOT wall clock.
+    signal_bar_date  DATE NOT NULL,
+    signal_kind      TEXT NOT NULL
+        CHECK (signal_kind IN ('entry', 'exit')),
+
+    verdict          TEXT NOT NULL
+        CHECK (verdict IN ('fired', 'not_fired', 'not_evaluable')),
+
+    -- ⚠ CLOSED vocabulary — parent criterion 8's seven codes plus `no_fill_bar`.
+    -- Free text was the first draft and is rejected: criterion 9 requires
+    -- counting what was excluded ("measure what you reject"), and free text
+    -- cannot be counted. `no_fill_bar` is OUR addition, flagged as such in
+    -- strategy_registry.py rather than passed off as the parent's.
+    not_evaluable_reason TEXT
+        CHECK (not_evaluable_reason IS NULL OR not_evaluable_reason IN (
+            'missing_volume', 'missing_spread', 'insufficient_warmup',
+            'quarantined_bar', 'series_break', 'not_listed',
+            'ambiguous_intrabar', 'no_fill_bar'
+        )),
+
+    -- Bar t+1. Populated ONLY when the signal fired — a not_fired or
+    -- not_evaluable bar has no fill.
+    fill_bar_date    DATE,
+    fill_price       NUMERIC,
+
+    -- #2288's labelling contract. NOT NULL and no default: a metric computed
+    -- on a survivor-only universe must be marked as such, and a column with a
+    -- default is a column a writer can forget.
+    universe         TEXT NOT NULL
+        CHECK (universe IN ('survivor_only', 'survivorship_free')),
+
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT strategy_signals_unique
+        UNIQUE (strategy_id, strategy_version, instrument_id, signal_bar_date, signal_kind),
+
+    -- A reason is required exactly when the verdict is not_evaluable, and
+    -- meaningless otherwise. Without this, a `fired` row could carry a reason
+    -- code and corrupt the criterion-9 counts.
+    CONSTRAINT strategy_signals_reason_matches_verdict
+        CHECK (
+            (verdict = 'not_evaluable' AND not_evaluable_reason IS NOT NULL)
+            OR (verdict <> 'not_evaluable' AND not_evaluable_reason IS NULL)
+        ),
+
+    -- A fill exists exactly when the signal fired.
+    CONSTRAINT strategy_signals_fill_matches_verdict
+        CHECK (
+            (verdict = 'fired' AND fill_bar_date IS NOT NULL AND fill_price IS NOT NULL)
+            OR (verdict <> 'fired' AND fill_bar_date IS NULL AND fill_price IS NULL)
+        ),
+
+    -- ⚠ THE BACKSTOP, not the mechanism. See the header. It proves the two
+    -- stored dates are ordered and nothing about which bar was read.
+    CONSTRAINT strategy_signals_fill_after_signal
+        CHECK (fill_bar_date IS NULL OR fill_bar_date > signal_bar_date)
+);
+
+-- The read pattern phase 4/5 have: every signal a strategy version produced,
+-- in bar order, to walk outcomes forward.
+CREATE INDEX IF NOT EXISTS idx_strategy_signals_version_bar
+    ON strategy_signals (strategy_id, strategy_version, signal_bar_date);
+
+-- Per-instrument replay, and the join phase 4's resolver needs.
+CREATE INDEX IF NOT EXISTS idx_strategy_signals_instrument_bar
+    ON strategy_signals (instrument_id, signal_bar_date);
+
+-- Criterion 9 — "measure what you reject". Counting exclusions by reason is a
+-- reporting requirement, not an ad-hoc query, so it gets an index.
+CREATE INDEX IF NOT EXISTS idx_strategy_signals_reason
+    ON strategy_signals (strategy_id, strategy_version, not_evaluable_reason)
+    WHERE not_evaluable_reason IS NOT NULL;
+
+COMMENT ON TABLE strategy_signals IS
+    'Signal ledger: one row per (strategy version, instrument, signal bar, '
+    'kind). strategy_version hashes code + params + universe + cost model '
+    '(criterion 11), so a changed strategy never overwrites or reinterprets '
+    'an old signal. ⚠ The fill-order CHECK is a BACKSTOP — same-bar fills are '
+    'made impossible by the registry API carrying no fill field, not by this '
+    'table.';
+
+COMMENT ON COLUMN strategy_signals.fill_bar_date IS
+    'Bar t+1: the NEXT BAR IN THAT INSTRUMENT''S SERIES, never '
+    'signal_bar_date + 1 day. Calendar gaps are normal — S4 measured 1,204 '
+    'tradable instruments whose latest bar is over a month old — and date '
+    'arithmetic would invent a fill on a day the instrument did not trade.';
+
+COMMENT ON COLUMN strategy_signals.universe IS
+    'survivor_only | survivorship_free (#2288). Every v1 signal is '
+    'survivor_only: #2284 measured the research corpus serving 0 of 259 known '
+    'delisted names. Any win rate computed from these rows inherits that.';

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -1,0 +1,266 @@
+"""Phase 3a — the registry contract.
+
+Pure, no DB. Spec:
+`docs/proposals/ta/2026-08-05-strategy-registry-and-signal-ledger.md`.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    sma_series,
+)
+from app.services.strategy_registry import (
+    PARENT_REASON_CODES,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+from app.services.technical_analysis import OHLCVRow
+
+U = "survivor_only"
+
+
+def _bars(closes: list[float]) -> BarSeries:
+    rows: list[OHLCVRow] = [
+        {
+            "open": Decimal(str(c)),
+            "high": Decimal(str(c + 1)),
+            "low": Decimal(str(c - 1)),
+            "close": Decimal(str(c)),
+            "volume": 100,
+        }
+        for c in closes
+    ]
+    start = date(2024, 1, 1)
+    return BarSeries(dates=tuple(start + timedelta(days=i) for i in range(len(closes))), rows=tuple(rows))
+
+
+_CLOSES = [100 + (i % 7) - 3 + i * 0.1 for i in range(60)]
+
+
+class TestSignalShapeForbidsSameBarFill:
+    """⚠ The fill rule is enforced by the SHAPE of this API, not a constraint.
+
+    The spec's first draft claimed a `CHECK (fill_bar_date > signal_bar_date)`
+    was "the whole mechanism". It is not — a writer can record
+    `signal_bar_date = t-1`, fill on `t`, and use bar `t`'s data with every
+    constraint passing. What actually makes a same-bar fill impossible is that
+    a strategy has no way to express one.
+    """
+
+    def test_a_signal_carries_no_fill_field_at_all(self) -> None:
+        signal = StrategySignal(verdict="fired", signal_index=5)
+        fields = set(signal.__dataclass_fields__)
+        assert fields == {"verdict", "signal_index", "kind", "reason"}
+        # No fill_price, fill_date, fill_bar, fill_index — the capability is
+        # absent, not guarded.
+        assert not any("fill" in f for f in fields)
+
+
+class TestReasonCodeContract:
+    """Parent criterion 8: `not_evaluable` carries a reason CODE, not text."""
+
+    def test_not_evaluable_requires_a_reason(self) -> None:
+        with pytest.raises(ValueError, match="requires a reason code"):
+            StrategySignal(verdict="not_evaluable", signal_index=3)
+
+    def test_a_reason_on_a_decided_verdict_is_rejected(self) -> None:
+        """A reason beside `fired` would make the code uncountable — criterion
+        9 needs to count them to 'measure what you reject'."""
+        with pytest.raises(ValueError, match="meaningless"):
+            StrategySignal(verdict="fired", signal_index=3, reason="missing_volume")
+
+    def test_the_seven_parent_codes_are_carried_verbatim(self) -> None:
+        assert PARENT_REASON_CODES == {
+            "missing_volume",
+            "missing_spread",
+            "insufficient_warmup",
+            "quarantined_bar",
+            "series_break",
+            "not_listed",
+            "ambiguous_intrabar",
+        }
+
+    def test_no_fill_bar_is_ours_and_is_not_claimed_as_the_parents(self) -> None:
+        """⚠ An addition, flagged rather than smuggled. If it silently joined
+        PARENT_REASON_CODES a reader would attribute it to criterion 8."""
+        assert "no_fill_bar" not in PARENT_REASON_CODES
+
+
+class TestEvaluabilityBeatsShortCircuit:
+    """⚠⚠ The hole Codex found at checkpoint 1.
+
+    Python's `and` short-circuits, so a strategy returns False on the first
+    failing condition WITHOUT touching a later unevaluable input — reporting
+    `not_fired` for a bar it could not judge. That is decision 5's corruption
+    re-entering after being closed at the indicator layer.
+    """
+
+    @staticmethod
+    def _inputs_with_hole(hole: int) -> tuple[IndicatorSeries, IndicatorSeries]:
+        series = _bars(_CLOSES)
+        good = sma_series(series, universe=U, period=5)
+        holed = IndicatorSeries(
+            values=tuple(None if i == hole else 1.0 for i in range(len(series))),
+            universe=U,
+            not_evaluable_indices=(hole,),
+        )
+        return good, holed
+
+    def test_short_circuiting_body_still_yields_not_evaluable(self) -> None:
+        hole = 30
+        good, holed = self._inputs_with_hole(hole)
+
+        # A body that short-circuits: it never reads `holed` when the first
+        # condition fails. Under the old contract this returned not_fired.
+        calls: list[int] = []
+
+        def body(i: int) -> bool:
+            calls.append(i)
+            return False  # first condition always fails; second never reached
+
+        signals = evaluate(
+            body,
+            inputs=[StrategyInput(good, "missing_volume"), StrategyInput(holed, "quarantined_bar")],
+            n_bars=len(good),
+        )
+
+        assert signals[hole].verdict == "not_evaluable"
+        # ⚠ the reason is the INPUT's, not a blanket warm-up code
+        assert signals[hole].reason == "quarantined_bar"
+        # ⚠ The body was never invoked on the holed bar — that is the mechanism.
+        assert hole not in calls
+
+    def test_body_never_sees_a_none(self) -> None:
+        """Inside a body a `None` is impossible by construction, so a strategy
+        author cannot write the bug even carelessly."""
+        good, holed = self._inputs_with_hole(30)
+
+        def body(i: int) -> bool:
+            assert good.values[i] is not None
+            assert holed.values[i] is not None
+            return True
+
+        evaluate(
+            body,
+            inputs=[StrategyInput(good, "missing_volume"), StrategyInput(holed, "quarantined_bar")],
+            n_bars=len(good),
+        )
+
+
+class TestLastBarHasNoFill:
+    def test_final_bar_is_no_fill_bar(self) -> None:
+        """A signal on the last bar has no t+1 to fill at. Reporting it as
+        `fired` would hand the backtester an unenterable trade."""
+        series = _bars(_CLOSES)
+        sma = sma_series(series, universe=U, period=5)
+        signals = evaluate(lambda i: True, inputs=[StrategyInput(sma, "missing_volume")], n_bars=len(series))
+
+        assert signals[-1].verdict == "not_evaluable"
+        assert signals[-1].reason == "no_fill_bar"
+        # ...and the bar before it is a normal decision.
+        assert signals[-2].verdict == "fired"
+
+
+class TestIdentityCoversMoreThanSource:
+    """Parent criterion 11: identity covers code, params, universe and cost
+    model. Hashing module source alone (the first draft, copied from
+    `indicator_series`) misses universe and cost model entirely — two different
+    strategies would share a version and collide on the ledger key."""
+
+    @staticmethod
+    def _identity(**overrides: object) -> StrategyIdentity:
+        base: dict[str, object] = {
+            "strategy_id": "S-1",
+            "params": {"period": 200},
+            "universe": "survivor_only",
+            "cost_model_id": "etoro-v1",
+            "source_hash": "abc123",
+        }
+        base.update(overrides)
+        return StrategyIdentity(**base)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"params": {"period": 50}},
+            {"universe": "survivorship_free"},
+            {"cost_model_id": "etoro-v2"},
+            {"source_hash": "def456"},
+            {"strategy_id": "S-2"},
+        ],
+    )
+    def test_every_component_changes_the_version(self, override: dict[str, object]) -> None:
+        assert self._identity().version != self._identity(**override).version
+
+    def test_identical_identities_agree(self) -> None:
+        assert self._identity().version == self._identity().version
+
+    def test_param_ordering_does_not_change_the_version(self) -> None:
+        """Canonical JSON — otherwise a dict literal reordering would look like
+        a new strategy and orphan every stored signal."""
+        a = self._identity(params={"a": 1, "b": 2})
+        b = self._identity(params={"b": 2, "a": 1})
+        assert a.version == b.version
+
+
+class TestReasonCodesAreNotCollapsed:
+    """[C2] The defect Codex found: `evaluate` recorded ONE `warmup_reason` for
+    every unevaluable bar, collapsing quarantined bars, series breaks and data
+    gaps into `insufficient_warmup` — destroying exactly what criterion 8
+    exists for. Each input now carries its own code."""
+
+    def test_each_input_contributes_its_own_reason(self) -> None:
+        series = _bars(_CLOSES)
+        n = len(series)
+        vol_gap = IndicatorSeries(
+            values=tuple(None if i == 20 else 1.0 for i in range(n)),
+            universe=U,
+            not_evaluable_indices=(20,),
+        )
+        quarantined = IndicatorSeries(
+            values=tuple(None if i == 30 else 1.0 for i in range(n)),
+            universe=U,
+            not_evaluable_indices=(30,),
+        )
+        signals = evaluate(
+            lambda i: True,
+            inputs=[StrategyInput(vol_gap, "missing_volume"), StrategyInput(quarantined, "quarantined_bar")],
+            n_bars=n,
+        )
+        assert signals[20].reason == "missing_volume"
+        assert signals[30].reason == "quarantined_bar"
+
+    def test_warm_up_is_distinguished_from_a_data_reason(self) -> None:
+        """⚠ Warm-up is structural, not caller-supplied: a leading None that is
+        NOT in not_evaluable_indices is the indicator warming up."""
+        series = _bars(_CLOSES)
+        sma = sma_series(series, universe=U, period=10)
+        signals = evaluate(lambda i: True, inputs=[StrategyInput(sma, "quarantined_bar")], n_bars=len(series))
+        assert signals[0].reason == "insufficient_warmup"
+        assert signals[5].reason == "insufficient_warmup"
+
+
+class TestClosedVocabulariesEnforcedAtRuntime:
+    """[C2] `Literal` enforces nothing at runtime. This class is the contract
+    that keeps verdicts and reason codes countable, so it checks."""
+
+    def test_free_text_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown reason code"):
+            StrategySignal(verdict="not_evaluable", signal_index=0, reason="free text")  # type: ignore[arg-type]
+
+    def test_unknown_verdict_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown verdict"):
+            StrategySignal(verdict="maybe", signal_index=0)  # type: ignore[arg-type]
+
+    def test_unknown_kind_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown signal kind"):
+            StrategySignal(verdict="fired", signal_index=0, kind="hedge")  # type: ignore[arg-type]

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -17,7 +17,11 @@ from app.services.indicator_series import (
     sma_series,
 )
 from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    OUR_ADDITIONAL_REASON_CODES,
     PARENT_REASON_CODES,
+    SIGNAL_KINDS,
+    VERDICTS,
     StrategyIdentity,
     StrategyInput,
     StrategySignal,
@@ -264,3 +268,37 @@ class TestClosedVocabulariesEnforcedAtRuntime:
     def test_unknown_kind_rejected(self) -> None:
         with pytest.raises(ValueError, match="unknown signal kind"):
             StrategySignal(verdict="fired", signal_index=0, kind="hedge")  # type: ignore[arg-type]
+
+
+class TestVocabularyIsDefinedOnce:
+    """[review NITPICK] The reason vocabulary was written out three times in
+    Python, and sql/255's CHECK is a fourth place. That is the
+    closed-vocabulary-in-N-places defect the prevention log carries from #2218:
+    a member added in one place and missed in the others writes rows nothing
+    reads. The Python sets are now derived via `get_args`; this pins the SQL.
+    """
+
+    @staticmethod
+    def _check_values(constraint: str, column: str) -> set[str]:
+        import re
+        from pathlib import Path
+
+        sql = (Path(__file__).resolve().parents[1] / "sql" / "255_strategy_signals.sql").read_text()
+        # The CHECK bodies are multi-line; grab from the column name to the
+        # closing paren of its IN (...) list.
+        match = re.search(rf"{column}[^;]*?IN \(([^)]*)\)", sql, re.DOTALL)
+        assert match is not None, f"no IN-list found for {column}"
+        return {value.strip().strip("'") for value in match.group(1).split(",") if value.strip()}
+
+    def test_sql_reason_codes_match_the_python_vocabulary(self) -> None:
+        assert self._check_values("strategy_signals", "not_evaluable_reason") == NOT_EVALUABLE_REASONS
+
+    def test_sql_verdicts_match(self) -> None:
+        assert self._check_values("strategy_signals", "verdict") == VERDICTS
+
+    def test_sql_signal_kinds_match(self) -> None:
+        assert self._check_values("strategy_signals", "signal_kind") == SIGNAL_KINDS
+
+    def test_parent_codes_are_the_derived_set_minus_ours(self) -> None:
+        assert PARENT_REASON_CODES == NOT_EVALUABLE_REASONS - OUR_ADDITIONAL_REASON_CODES
+        assert len(PARENT_REASON_CODES) == 7

--- a/tests/test_strategy_signals_ledger.py
+++ b/tests/test_strategy_signals_ledger.py
@@ -1,0 +1,139 @@
+"""Phase 3b — the ledger's constraints, exercised against a real database.
+
+⚠ ONE integration test, per the repo's test-tiering rule: the genuinely-new
+SQL mechanism is this table's constraint set, and a mocked cursor asserts the
+parameters while passing against a constraint that would reject them.
+"""
+
+from __future__ import annotations
+
+import psycopg
+import pytest
+
+_BASE = {
+    "strategy_id": "S-TEST",
+    "strategy_version": "strategy-registry-v1+abc123",
+    "signal_bar_date": "2024-01-02",
+    "signal_kind": "entry",
+    "verdict": "not_fired",
+    "universe": "survivor_only",
+}
+
+
+#: ⚠ A FIXED statement, not an f-string built from the override keys. psycopg
+#: types `query` as `LiteralString` precisely to stop dynamic SQL, and the
+#: pre-push hook caught the f-string version — correctly. A fixed column list
+#: is also more honest about what is under test.
+_INSERT = """
+    INSERT INTO strategy_signals (
+        strategy_id, strategy_version, instrument_id, signal_bar_date,
+        signal_kind, verdict, not_evaluable_reason, fill_bar_date,
+        fill_price, universe
+    ) VALUES (
+        %(strategy_id)s, %(strategy_version)s, %(instrument_id)s, %(signal_bar_date)s,
+        %(signal_kind)s, %(verdict)s, %(not_evaluable_reason)s, %(fill_bar_date)s,
+        %(fill_price)s, %(universe)s
+    )
+"""
+
+
+def _insert(conn: psycopg.Connection[tuple], instrument_id: int, **overrides: object) -> None:
+    row: dict[str, object] = {
+        **_BASE,
+        "instrument_id": instrument_id,
+        "not_evaluable_reason": None,
+        "fill_bar_date": None,
+        "fill_price": None,
+    }
+    row.update(overrides)
+    conn.execute(_INSERT, row)
+
+
+@pytest.fixture
+def instrument_id(ebull_test_conn: psycopg.Connection[tuple]) -> int:
+    # ⚠ `instruments.instrument_id` is eToro's identifier, assigned upstream —
+    # NOT a serial. An insert that omits it fails NOT NULL, which is how this
+    # fixture failed first time round.
+    row = ebull_test_conn.execute("SELECT instrument_id FROM instruments LIMIT 1").fetchone()
+    if row is not None:
+        return int(row[0])
+    ebull_test_conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (999001, 'TESTX', 'Test Instrument', true)"
+    )
+    return 999001
+
+
+@pytest.mark.parametrize(
+    ("label", "overrides"),
+    [
+        # ⚠ The backstop. NOT the mechanism — a writer can record
+        # signal_bar_date = t-1, fill on t, and pass every constraint here.
+        # Same-bar fills are made impossible by the registry API carrying no
+        # fill field at all (phase 3a).
+        ("same-bar fill", {"verdict": "fired", "fill_bar_date": "2024-01-02", "fill_price": 10}),
+        ("fill before signal", {"verdict": "fired", "fill_bar_date": "2024-01-01", "fill_price": 10}),
+        ("fired with no fill", {"verdict": "fired"}),
+        ("not_evaluable with no reason", {"verdict": "not_evaluable"}),
+        (
+            "reason on a fired row",
+            {
+                "verdict": "fired",
+                "fill_bar_date": "2024-01-03",
+                "fill_price": 10,
+                "not_evaluable_reason": "series_break",
+            },
+        ),
+        # Free text is what criterion 9 cannot count.
+        ("free-text reason", {"verdict": "not_evaluable", "not_evaluable_reason": "because reasons"}),
+        ("unknown verdict", {"verdict": "maybe"}),
+        ("unknown universe", {"universe": "everything"}),
+        ("unknown signal_kind", {"signal_kind": "hedge"}),
+    ],
+)
+def test_ledger_rejects(
+    ebull_test_conn: psycopg.Connection[tuple], instrument_id: int, label: str, overrides: dict
+) -> None:
+    with pytest.raises(psycopg.errors.Error), ebull_test_conn.transaction():
+        _insert(ebull_test_conn, instrument_id, **overrides)
+
+
+def test_ledger_accepts_the_valid_shapes(ebull_test_conn: psycopg.Connection[tuple], instrument_id: int) -> None:
+    with ebull_test_conn.transaction():
+        _insert(ebull_test_conn, instrument_id)
+        _insert(
+            ebull_test_conn,
+            instrument_id,
+            signal_bar_date="2024-02-05",
+            verdict="fired",
+            fill_bar_date="2024-02-06",
+            fill_price=101.25,
+        )
+        _insert(
+            ebull_test_conn,
+            instrument_id,
+            signal_kind="exit",
+            verdict="not_evaluable",
+            not_evaluable_reason="no_fill_bar",
+        )
+
+
+def test_same_bar_and_kind_collides_but_a_new_version_does_not(
+    ebull_test_conn: psycopg.Connection[tuple], instrument_id: int
+) -> None:
+    """The uniqueness key: a changed strategy must NOT overwrite an old signal,
+    which is the whole reason strategy_version is IN the key."""
+    with ebull_test_conn.transaction():
+        _insert(ebull_test_conn, instrument_id)
+
+    with pytest.raises(psycopg.errors.UniqueViolation), ebull_test_conn.transaction():
+        _insert(ebull_test_conn, instrument_id)
+
+    # Same bar, same instrument, DIFFERENT version — a distinct decision.
+    with ebull_test_conn.transaction():
+        _insert(ebull_test_conn, instrument_id, strategy_version="strategy-registry-v1+def456")
+
+    # ...and the same bar as an EXIT is also distinct (parent §3.5 covers
+    # "entries and exits alike").
+    with ebull_test_conn.transaction():
+        _insert(ebull_test_conn, instrument_id, signal_kind="exit")


### PR DESCRIPTION
Phase 3 ticket 3a. Spec merged at `d0e16391`.

## What it is

A strategy is a **pure function** over a `BarSeries` plus its indicator series, returning a verdict per bar. Code, not rows — a rules table needs an interpreter, and an interpreter is a second place for the fill-timing rule to be got wrong.

## ⚠⚠ The fill rule is enforced by the API's shape, not a constraint

Parent §3.5 demands same-bar fills be *"structurally impossible rather than merely discouraged"*. The spec's first draft claimed a `CHECK (fill_bar_date > signal_bar_date)` did that; **Codex refuted it at checkpoint 1** — a writer can record `signal_bar_date = t-1`, fill on `t`, and use bar `t`'s data with every constraint passing.

The real mechanism: **`StrategySignal` carries a bar index and nothing else.** No fill price, no fill date, no fill bar. A same-bar fill is not *expressible*, because there is no parameter through which to request one. A test asserts no field of `StrategySignal` contains `"fill"` — the capability is absent, not guarded.

## ⚠⚠ Evaluability is decided before the condition runs

Python short-circuits. `close > sma and volume > x` returns False on the first clause **without ever touching `volume`** — so a bar where `volume` was unevaluable gets reported `not_fired`, a verdict the strategy could not actually reach. That is design-doc decision 5's corruption re-entering through the back door after being closed at the indicator layer.

`evaluate` checks every declared input **before** invoking the body. Inside a body a `None` is impossible by construction, so short-circuit ordering is irrelevant rather than something each author must remember.

The last bar is `no_fill_bar`, never a fire — it has no *t+1*, and firing would hand the backtester an unenterable trade.

## Codex checkpoint 2 — two defects, both attacking this module's purpose

**1. Reason codes were collapsed.** `evaluate` recorded one `warmup_reason` for every unevaluable bar, so quarantined bars, series breaks and genuine data gaps all became `insufficient_warmup`. That destroys precisely what criterion 8 exists for — *"collapsing them loses the ability to tell a data gap from a real absence"*.

⚠ Self-inflicted, and the worst kind: I wrote three paragraphs defending the closed vocabulary and then collapsed it at the only place that populates it. Fixed by pairing each input with its reason code (`StrategyInput`), because `indicator_series` knows *that* a value is unevaluable but not *why* — it has no DB access and cannot tell a quarantined bar from a missing volume field. Warm-up stays structural: a `None` outside `not_evaluable_indices`.

**2. `Literal` enforces nothing at runtime**, so `reason="free text"` passed straight through the class whose whole job is keeping reason codes countable. Closed sets now checked in `__post_init__`.

## Also from checkpoint 1

Identity hashes **code + params + universe + cost model** (criterion 11), not module source alone — source-only misses universe and cost model, so two genuinely different strategies would share a version and collide on the ledger key.

## ⚠ A probe that proved nothing, and how it was caught

The first revert-probe run reported the evaluability guard as **not** load-bearing. It was wrong: `ruff format` had reflowed the target, `str.replace` matched nothing, and the probe silently injected **no defect at all** while reporting success.

Re-run with `assert s.count(old) == 1` on every anchor. All five invariants then fail exactly the tests that guard them:

| injected defect | tests failed |
|---|---|
| evaluability guard removed | 2 |
| last bar allowed to fire | 1 |
| reasons collapsed to warm-up | 2 |
| runtime vocabulary check removed | 1 |
| `universe` dropped from the identity hash | 1 |

A probe without an asserted anchor proves as little as a vacuous test.

## Security

No security surface — a pure contract module, no DB, no auth, no order path. Phase 7 is where anything reaches execution, via `execution_guard` (decision 4).

## Next

3b (schema) then 3c (writer). ⚠ No strategy is implemented in any of them — a registry shaped around its first sample strategy fits that one and nothing else.

Refs #2240. Refs #2288.
