### PR TITLE
chore: headless TA loop — one claude -p per iteration, no state machine

### DIFF
--- a/scripts/autonomy/README.md
+++ b/scripts/autonomy/README.md
@@ -58,3 +58,38 @@ the auto-reload-on-merge from #2144 was silently dead for weeks.
 Safe to run this daemon WITHOUT the AI loop and with the kill switch ON — the
 kill switch gates only the trade jobs (`morning_candidate_review`,
 `retry_deferred`), not data ingestion.
+
+## `ta_loop.sh` — the headless TA loop
+
+```bash
+scripts/autonomy/ta_loop.sh          # run until stopped
+touch  <worktree>/var/autonomy/PAUSE # graceful stop after the current iteration
+cat    <worktree>/var/autonomy/status.md   # what it last did
+tail -f <worktree>/var/autonomy/loop.log
+```
+
+⚠ **Deliberately dumb, and that is the design.** The previous eBull loop ran
+through the autonomy-engine supervisor and died on 2026-07-23 spinning on
+`WARN cannot determine kind for in-flight 'coder' (state unreadable)` — it
+wedged on its own state machine and nobody noticed for two weeks. This one has
+no state machine: one iteration is one `claude -p` call, and a dead iteration
+costs exactly one iteration.
+
+Three things it inherits from real incidents:
+
+- **Runs in its own git worktree** (`/Users/lukebradford/Dev/.ebull-autonomy`).
+  Two Claude instances on `~/Dev/eBull` clobber each other's uncommitted work —
+  prevention-log entry, 2026-07-16.
+- **PAUSE is announced in `status.md`, not just the log.** The engine's loop sat
+  paused for a MONTH printing its pause line into a log nobody opened.
+- **Never pipes a command it needs the exit code or progress from.** A pipe
+  returns the pipe's status and buffers output; that cost 7 minutes of
+  misdiagnosis on 2026-08-05.
+
+It stops itself after 3 consecutive failed iterations rather than hammering —
+three in a row means something structural that another immediate attempt will
+not fix.
+
+⚠ It has the dev **database** but NOT the dev **stack**: `:8000` and `:5173`
+serve `~/Dev/eBull`, not the worktree. Full-population verification works;
+live-endpoint dev-verify does not.

--- a/scripts/autonomy/com.ebull.ta-loop.plist
+++ b/scripts/autonomy/com.ebull.ta-loop.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  eBull TA headless loop.
+
+  Install (once):
+    cp scripts/autonomy/com.ebull.ta-loop.plist ~/Library/LaunchAgents/
+    launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ebull.ta-loop.plist
+
+  Stop it gracefully (finishes the current iteration, then idles):
+    touch /Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/PAUSE
+
+  Stop it entirely:
+    launchctl bootout gui/$(id -u)/com.ebull.ta-loop
+
+  Check on it:
+    cat /Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/status.md
+
+  ⚠ KeepAlive is TRUE so a crashed iteration restarts, but the driver itself
+  stops after 3 consecutive failures. That pairing is deliberate: launchd
+  handles "the process died", the driver handles "the work keeps failing", and
+  neither pretends to do the other's job. The previous loop conflated them and
+  spun on a wedged state file for two weeks.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ebull.ta-loop</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/lukebradford/Dev/.ebull-autonomy/scripts/autonomy/ta_loop.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/lukebradford/Dev/.ebull-autonomy</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <!-- Homebrew first: `claude` and `uv` both live there. -->
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <!-- A pause between iterations so a fast-failing loop cannot hammer
+             the API or the review bot. -->
+        <key>TA_LOOP_COOLDOWN</key>
+        <string>120</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- ⚠ Not piped anywhere. The driver's own log is the record; these catch
+         anything that escapes it (a bad PATH, a missing binary) which is
+         precisely the class of failure that leaves no application-level trace. -->
+    <key>StandardOutPath</key>
+    <string>/Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/launchd.err.log</string>
+</dict>
+</plist>

--- a/scripts/autonomy/com.ebull.ta-loop.plist
+++ b/scripts/autonomy/com.ebull.ta-loop.plist
@@ -2,9 +2,27 @@
 <!--
   eBull TA headless loop.
 
-  Install (once):
+  Install (once) — driver copy FIRST, then the agent:
+    mkdir -p /Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/bin
+    cp scripts/autonomy/ta_loop.sh scripts/autonomy/ta_loop_prompt.md \
+       /Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/bin/
     cp scripts/autonomy/com.ebull.ta-loop.plist ~/Library/LaunchAgents/
     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ebull.ta-loop.plist
+
+  ⚠ launchd runs the copy under var/autonomy/bin/, NOT the tracked script.
+  The driver drives a worktree whose branch changes every iteration, so a
+  driver read from a tracked path is deleted by its own `git checkout` the
+  first time the loop branches off a commit older than this one. `/var/*` is
+  gitignored, so the installed copy is invisible to every checkout.
+  Re-copy it after any change to ta_loop.sh — the tracked file is the source,
+  the installed file is what runs.
+
+  ⚠ This plist is a LOCAL-MACHINE artefact and its absolute paths and username
+  are deliberate, not an oversight: launchd requires absolute paths, offers no
+  variable expansion in ProgramArguments, and this loop drives one specific
+  worktree on one specific Mac. It is committed for provenance and recovery,
+  not for reuse. Anyone else: change the four paths, or drive it by hand with
+  TA_LOOP_WORKTREE.
 
   Stop it gracefully (finishes the current iteration, then idles):
     touch /Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/PAUSE
@@ -29,7 +47,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/lukebradford/Dev/.ebull-autonomy/scripts/autonomy/ta_loop.sh</string>
+        <string>/Users/lukebradford/Dev/.ebull-autonomy/var/autonomy/bin/ta_loop.sh</string>
     </array>
 
     <key>WorkingDirectory</key>
@@ -41,7 +59,11 @@
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <!-- A pause between iterations so a fast-failing loop cannot hammer
-             the API or the review bot. -->
+             the API or the review bot. Longer than ta_loop.sh's own 60s
+             default (TA_LOOP_COOLDOWN in the script) on purpose: unattended
+             runs get twice the backoff a supervised one does. If the script's
+             default changes, this stays as-is unless the reason above changes
+             with it. -->
         <key>TA_LOOP_COOLDOWN</key>
         <string>120</string>
     </dict>

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -75,12 +75,36 @@ fi
 # mkdir is the atomic test-and-set available everywhere; macOS ships no flock(1).
 LOCK="$STATE_DIR/loop.lock"
 if ! mkdir "$LOCK" 2>/dev/null; then
-  holder="$(cat "$LOCK/pid" 2>/dev/null || true)"
-  if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
-    log "ABORT another ta_loop.sh holds $LOCK (pid $holder)"
-    exit 1
+  # ⚠ `mkdir` and the pid write are two operations, so a holder that has taken
+  # the lock microseconds ago has not written its pid yet. Reading that gap as
+  # "stale" would have the newcomer steal the lock from a live loop — the exact
+  # race the lock exists to prevent, reintroduced by the lock. So: retry the
+  # read for a second, and only fall back to the directory's age.
+  holder=""
+  for _ in 1 2 3 4 5; do
+    holder="$(cat "$LOCK/pid" 2>/dev/null || true)"
+    [[ -n "$holder" ]] && break
+    sleep 0.2
+  done
+
+  if [[ -n "$holder" ]]; then
+    if kill -0 "$holder" 2>/dev/null; then
+      log "ABORT another ta_loop.sh holds $LOCK (pid $holder)"
+      exit 1
+    fi
+    log "clearing stale lock $LOCK (holder $holder is gone)"
+  else
+    # No pid after a second. Either a holder was killed between mkdir and the
+    # write, or the lock predates a reboot. Age decides: under a minute is
+    # assumed live, because refusing to start is recoverable and stealing is
+    # not.
+    if [[ -z "$(find "$LOCK" -maxdepth 0 -mmin +1 2>/dev/null)" ]]; then
+      log "ABORT $LOCK exists with no pid and is under a minute old -- assuming a live holder"
+      exit 1
+    fi
+    log "clearing stale lock $LOCK (no pid file, older than a minute)"
   fi
-  log "clearing stale lock $LOCK (holder '${holder:-unknown}' is gone)"
+
   rm -rf "$LOCK"
   mkdir "$LOCK" || { log "FATAL cannot take lock $LOCK"; exit 1; }
 fi

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# eBull TA loop — deliberately dumb.
+#
+# WHY THIS IS DUMB ON PURPOSE
+# ---------------------------
+# The previous eBull loop ran through the autonomy-engine's supervisor and
+# died on 2026-07-23 spinning on:
+#
+#   WARN cannot determine kind for in-flight 'coder' (state unreadable)
+#        -- skipping this tick
+#
+# It wedged on its own state machine and nobody noticed for two weeks. So this
+# has no state machine. One iteration = one `claude -p` invocation. If an
+# iteration dies, the next one starts clean. There is nothing to become
+# unreadable.
+#
+# USAGE
+#   scripts/autonomy/ta_loop.sh            # run until stopped
+#   touch var/autonomy/PAUSE               # graceful stop after current iteration
+#   tail -f var/autonomy/loop.log          # watch
+#   cat var/autonomy/status.md             # what it last did
+#
+# ⚠ Runs in its OWN git worktree. Two Claude instances on ~/Dev/eBull will
+# clobber each other's uncommitted work — there is a prevention-log entry for
+# exactly that race (2026-07-16).
+
+set -uo pipefail
+
+WORKTREE="${TA_LOOP_WORKTREE:-/Users/lukebradford/Dev/.ebull-autonomy}"
+STATE_DIR="${TA_LOOP_STATE:-$WORKTREE/var/autonomy}"
+PROMPT="$WORKTREE/scripts/autonomy/ta_loop_prompt.md"
+PAUSE="$STATE_DIR/PAUSE"
+LOG="$STATE_DIR/loop.log"
+STATUS="$STATE_DIR/status.md"
+MAX_ITERATIONS="${TA_LOOP_MAX:-0}"        # 0 = unbounded
+COOLDOWN_SECONDS="${TA_LOOP_COOLDOWN:-60}"
+
+mkdir -p "$STATE_DIR"
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" | tee -a "$LOG"; }
+
+if [[ ! -d "$WORKTREE/.git" && ! -f "$WORKTREE/.git" ]]; then
+  log "FATAL worktree $WORKTREE is not a git checkout"
+  exit 1
+fi
+if [[ ! -f "$PROMPT" ]]; then
+  log "FATAL prompt not found at $PROMPT"
+  exit 1
+fi
+
+log "=== ta_loop start (worktree=$WORKTREE, max=$MAX_ITERATIONS, cooldown=${COOLDOWN_SECONDS}s) ==="
+
+iteration=0
+consecutive_failures=0
+
+while true; do
+  # ⚠ PAUSE is checked FIRST and always announced. The engine's loop sat
+  # paused for a month printing the same line into a log nobody read; this one
+  # also writes it into status.md, which is the file a human actually opens.
+  if [[ -f "$PAUSE" ]]; then
+    log "PAUSED by sentinel $PAUSE -- remove it to resume"
+    { echo "# TA loop: PAUSED"; echo; echo "Sentinel present: \`$PAUSE\`"; echo; echo "Remove it to resume. Last update $(date -u +%Y-%m-%dT%H:%M:%SZ)."; } > "$STATUS"
+    sleep "$COOLDOWN_SECONDS"
+    continue
+  fi
+
+  if [[ "$MAX_ITERATIONS" -gt 0 && "$iteration" -ge "$MAX_ITERATIONS" ]]; then
+    log "reached max iterations ($MAX_ITERATIONS) -- stopping"
+    break
+  fi
+
+  iteration=$((iteration + 1))
+  started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  transcript="$STATE_DIR/iteration-$(date -u +%Y%m%dT%H%M%SZ).log"
+  log "--- iteration $iteration start"
+
+  # ⚠ NOT piped into head/tail. A pipe returns the pipe's status and buffers
+  # the output, which cost 7 minutes of misdiagnosis on 2026-08-05. Redirect
+  # to a file; read the file.
+  ( cd "$WORKTREE" && claude -p "$(cat "$PROMPT")" --permission-mode acceptEdits ) \
+      > "$transcript" 2>&1
+  rc=$?
+
+  if [[ $rc -eq 0 ]]; then
+    consecutive_failures=0
+    log "--- iteration $iteration OK (transcript: $(basename "$transcript"))"
+  else
+    consecutive_failures=$((consecutive_failures + 1))
+    log "--- iteration $iteration FAILED rc=$rc (failures in a row: $consecutive_failures)"
+  fi
+
+  {
+    echo "# TA loop status"
+    echo
+    echo "- iteration: **$iteration**"
+    echo "- started: $started"
+    echo "- finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "- exit code: $rc"
+    echo "- consecutive failures: $consecutive_failures"
+    echo "- transcript: \`$transcript\`"
+    echo
+    echo "## Last 40 lines"
+    echo '```'
+    tail -40 "$transcript" 2>/dev/null
+    echo '```'
+  } > "$STATUS"
+
+  # ⚠ Back off on repeated failure rather than hammering. Three in a row means
+  # something structural (auth, quota, a wedged repo) that another immediate
+  # attempt will not fix.
+  if [[ $consecutive_failures -ge 3 ]]; then
+    log "STOPPING: 3 consecutive failures -- see $transcript"
+    break
+  fi
+
+  sleep "$COOLDOWN_SECONDS"
+done
+
+log "=== ta_loop exit after $iteration iteration(s) ==="

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -77,7 +77,14 @@ while true; do
   # ⚠ NOT piped into head/tail. A pipe returns the pipe's status and buffers
   # the output, which cost 7 minutes of misdiagnosis on 2026-08-05. Redirect
   # to a file; read the file.
-  ( cd "$WORKTREE" && claude -p "$(cat "$PROMPT")" --permission-mode acceptEdits ) \
+  # ⚠ --output-format=stream-json so the transcript fills LIVE, not at exit.
+  # The first version buffered everything until the process ended, which made
+  # "is it progressing?" unanswerable from the loop's own instrumentation —
+  # you had to go and read git. That is the same invisibility failure as the
+  # month-long silent PAUSE, one layer down.
+  ( cd "$WORKTREE" && claude -p "$(cat "$PROMPT")" \
+        --permission-mode acceptEdits \
+        --output-format=stream-json --verbose --include-partial-messages ) \
       > "$transcript" 2>&1
   rc=$?
 

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -188,10 +188,20 @@ while true; do
   # occurrence inside a larger payload cannot match.
   # (grep is the DOWNSTREAM command here and its status is the one being read
   # — this is not the `gate | tail` pattern that hides an exit code.)
+  # jq when it is there (/usr/bin/jq ships with macOS, so it normally is):
+  # `.type` is then the TOP-LEVEL field and a nested "type":"result" inside
+  # quoted tool output cannot match at all. `fromjson?` skips any line that is
+  # not valid JSON rather than aborting the scan. The regex below is the
+  # fallback, not the primary.
   result_ok=0
-  result_line="$(grep -E '^\{.*"type":"result".*\}$' "$transcript" | tail -1)"
-  if [[ -n "$result_line" ]] && printf '%s\n' "$result_line" | grep -q '"is_error":false'; then
-    result_ok=1
+  if command -v jq >/dev/null 2>&1; then
+    verdict="$(jq -R -r 'fromjson? | select(.type=="result") | .is_error' "$transcript" 2>/dev/null | tail -1)"
+    [[ "$verdict" == "false" ]] && result_ok=1
+  else
+    result_line="$(grep -E '^\{.*"type":"result".*\}$' "$transcript" | tail -1)"
+    if [[ -n "$result_line" ]] && printf '%s\n' "$result_line" | grep -q '"is_error":false'; then
+      result_ok=1
+    fi
   fi
 
   if [[ $rc -eq 0 && $result_ok -eq 1 ]]; then

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -18,7 +18,19 @@
 #   scripts/autonomy/ta_loop.sh            # run until stopped
 #   touch var/autonomy/PAUSE               # graceful stop after current iteration
 #   tail -f var/autonomy/loop.log          # watch
-#   cat var/autonomy/status.md             # what it last did
+#   cat var/autonomy/status.md             # what it is doing / last did
+#
+# INSTALLED COPY — what launchd actually runs
+#   mkdir -p <worktree>/var/autonomy/bin
+#   cp scripts/autonomy/ta_loop.sh scripts/autonomy/ta_loop_prompt.md \
+#      <worktree>/var/autonomy/bin/
+#
+# ⚠ Run the INSTALLED copy, never the tracked one, for anything unattended.
+# The driver drives a worktree that changes branch every iteration; a driver
+# read from a tracked path is deleted by its own `git checkout` the moment it
+# branches off a commit older than itself. `/var/*` is gitignored, so a copy
+# under var/autonomy/bin/ is invisible to every checkout and cannot be moved
+# out from under a running loop.
 #
 # ⚠ Runs in its OWN git worktree. Two Claude instances on ~/Dev/eBull will
 # clobber each other's uncommitted work — there is a prevention-log entry for
@@ -28,7 +40,15 @@ set -uo pipefail
 
 WORKTREE="${TA_LOOP_WORKTREE:-/Users/lukebradford/Dev/.ebull-autonomy}"
 STATE_DIR="${TA_LOOP_STATE:-$WORKTREE/var/autonomy}"
-PROMPT="$WORKTREE/scripts/autonomy/ta_loop_prompt.md"
+
+# ⚠ The prompt is resolved next to THIS script, not at a fixed path inside the
+# checkout. The driver drives a worktree whose branch changes every iteration,
+# so anything it reads from a tracked path can vanish under it — check out a
+# branch based on a commit predating this PR and the loop deletes its own
+# prompt mid-run. Installed copies live in var/autonomy/bin/, which `/var/*`
+# in .gitignore keeps out of git's reach entirely.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PROMPT="${TA_LOOP_PROMPT:-$SELF_DIR/ta_loop_prompt.md}"
 PAUSE="$STATE_DIR/PAUSE"
 LOG="$STATE_DIR/loop.log"
 STATUS="$STATE_DIR/status.md"
@@ -48,7 +68,26 @@ if [[ ! -f "$PROMPT" ]]; then
   exit 1
 fi
 
-log "=== ta_loop start (worktree=$WORKTREE, max=$MAX_ITERATIONS, cooldown=${COOLDOWN_SECONDS}s) ==="
+# ⚠ ONE driver per worktree. The dedicated worktree stops this loop clobbering
+# ~/Dev/eBull; it does nothing about a second copy of the loop itself, and
+# launchd's KeepAlive makes that reachable in one step — agent running, human
+# starts a manual run, two Claudes in one checkout (prevention log 2026-07-16).
+# mkdir is the atomic test-and-set available everywhere; macOS ships no flock(1).
+LOCK="$STATE_DIR/loop.lock"
+if ! mkdir "$LOCK" 2>/dev/null; then
+  holder="$(cat "$LOCK/pid" 2>/dev/null || true)"
+  if [[ -n "$holder" ]] && kill -0 "$holder" 2>/dev/null; then
+    log "ABORT another ta_loop.sh holds $LOCK (pid $holder)"
+    exit 1
+  fi
+  log "clearing stale lock $LOCK (holder '${holder:-unknown}' is gone)"
+  rm -rf "$LOCK"
+  mkdir "$LOCK" || { log "FATAL cannot take lock $LOCK"; exit 1; }
+fi
+echo "$$" > "$LOCK/pid"
+trap 'rm -rf "$LOCK"' EXIT
+
+log "=== ta_loop start (worktree=$WORKTREE, max=$MAX_ITERATIONS, cooldown=${COOLDOWN_SECONDS}s, pid=$$) ==="
 
 iteration=0
 consecutive_failures=0
@@ -71,8 +110,24 @@ while true; do
 
   iteration=$((iteration + 1))
   started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  transcript="$STATE_DIR/iteration-$(date -u +%Y%m%dT%H%M%SZ).log"
+  # pid+iteration suffix: the timestamp alone is 1-second resolution, so a
+  # fast-failing iteration could otherwise overwrite the transcript that
+  # explains why it failed.
+  transcript="$STATE_DIR/iteration-$(date -u +%Y%m%dT%H%M%SZ)-$$.$iteration.log"
   log "--- iteration $iteration start"
+
+  # ⚠ status.md is written BEFORE the iteration as well as after. Written only
+  # at the end, the file a human is told to open does not exist at all during
+  # the first run — which is the same "instrumentation is silent exactly when
+  # you need it" failure as the month-long unnoticed PAUSE.
+  {
+    echo "# TA loop status"
+    echo
+    echo "- iteration: **$iteration** — IN FLIGHT"
+    echo "- started: $started"
+    echo "- pid: $$"
+    echo "- transcript: \`$transcript\`"
+  } > "$STATUS"
 
   # ⚠ NOT piped into head/tail. A pipe returns the pipe's status and buffers
   # the output, which cost 7 minutes of misdiagnosis on 2026-08-05. Redirect
@@ -88,12 +143,26 @@ while true; do
       > "$transcript" 2>&1
   rc=$?
 
-  if [[ $rc -eq 0 ]]; then
+  # ⚠ rc is not the whole answer under --output-format=stream-json. The stream
+  # is a sequence of JSON events and its LAST line is the result event, which
+  # carries the task-level verdict independently of how the process exited.
+  # Verified 2026-08-06 against the installed CLI: a successful run ends with
+  # one object containing "type":"result" and "is_error":false, and exits 0.
+  # Require both, so a stream that terminates tidily on a failed task still
+  # counts toward the 3-strike stop rather than looking like progress.
+  # (grep is the DOWNSTREAM command here and its status is the one being read
+  # — this is not the `gate | tail` pattern that hides an exit code.)
+  result_ok=0
+  if tail -1 "$transcript" | grep -q '"is_error":false'; then
+    result_ok=1
+  fi
+
+  if [[ $rc -eq 0 && $result_ok -eq 1 ]]; then
     consecutive_failures=0
     log "--- iteration $iteration OK (transcript: $(basename "$transcript"))"
   else
     consecutive_failures=$((consecutive_failures + 1))
-    log "--- iteration $iteration FAILED rc=$rc (failures in a row: $consecutive_failures)"
+    log "--- iteration $iteration FAILED rc=$rc result_ok=$result_ok (failures in a row: $consecutive_failures)"
   fi
 
   {
@@ -103,6 +172,7 @@ while true; do
     echo "- started: $started"
     echo "- finished: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "- exit code: $rc"
+    echo "- result event ok: $result_ok"
     echo "- consecutive failures: $consecutive_failures"
     echo "- transcript: \`$transcript\`"
     echo

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -161,10 +161,15 @@ while true; do
   # "is it progressing?" unanswerable from the loop's own instrumentation —
   # you had to go and read git. That is the same invisibility failure as the
   # month-long silent PAUSE, one layer down.
+  # ⚠ stderr goes to its OWN file. Merged into the transcript it lands wherever
+  # it lands — the CLI's settings warnings arrive before the first event, and
+  # nothing stops a shutdown message arriving after the last one. The transcript
+  # is parsed below, so anything non-JSON in it is a correctness problem, not
+  # noise. Verified 2026-08-06: a plain run writes 157 bytes to stderr.
   ( cd "$WORKTREE" && claude -p "$(cat "$PROMPT")" \
         --permission-mode acceptEdits \
         --output-format=stream-json --verbose --include-partial-messages ) \
-      > "$transcript" 2>&1
+      > "$transcript" 2> "$transcript.err"
   rc=$?
 
   # ⚠ rc is not the whole answer under --output-format=stream-json. The stream
@@ -174,10 +179,18 @@ while true; do
   # one object containing "type":"result" and "is_error":false, and exits 0.
   # Require both, so a stream that terminates tidily on a failed task still
   # counts toward the 3-strike stop rather than looking like progress.
+  # ⚠ Find the result event by TYPE; do not trust the last line to be it, and
+  # do not match `is_error` anywhere in the stream. Under
+  # --include-partial-messages the transcript carries stream_event, message,
+  # text_delta and system events too, and any of them may grow an `is_error`
+  # field — matching the wrong event would report a verdict for something that
+  # is not the task. Anchored to a whole-line JSON object so a nested
+  # occurrence inside a larger payload cannot match.
   # (grep is the DOWNSTREAM command here and its status is the one being read
   # — this is not the `gate | tail` pattern that hides an exit code.)
   result_ok=0
-  if tail -1 "$transcript" | grep -q '"is_error":false'; then
+  result_line="$(grep -E '^\{.*"type":"result".*\}$' "$transcript" | tail -1)"
+  if [[ -n "$result_line" ]] && printf '%s\n' "$result_line" | grep -q '"is_error":false'; then
     result_ok=1
   fi
 
@@ -204,6 +217,15 @@ while true; do
     echo '```'
     tail -40 "$transcript" 2>/dev/null
     echo '```'
+    # stderr is its own file now, so it needs its own window or it becomes the
+    # thing nobody looks at.
+    if [[ -s "$transcript.err" ]]; then
+      echo
+      echo "## stderr (last 20)"
+      echo '```'
+      tail -20 "$transcript.err" 2>/dev/null
+      echo '```'
+    fi
   } > "$STATUS"
 
   # ⚠ Back off on repeated failure rather than hammering. Three in a row means

--- a/scripts/autonomy/ta_loop_prompt.md
+++ b/scripts/autonomy/ta_loop_prompt.md
@@ -1,0 +1,93 @@
+You are working on the eBull TA strategy platform, headless and unattended. One
+task per run. You have the full repo, the local dev Postgres, and all project
+skills.
+
+## Read first — do not skip
+
+1. `.claude/CLAUDE.md` — engineering discipline. Non-negotiable and hard-won.
+2. `docs/proposals/ta/2026-08-05-strategy-registry-and-signal-ledger.md` — phase 3.
+3. `docs/proposals/ta/strategy-catalogue-and-backtest-validity.md` §3.5 and the
+   numbered criteria — execution semantics.
+4. `docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md` §5 — phases.
+5. `docs/review-prevention-log.md` — skim for anything touching what you change.
+
+## Pick ONE task
+
+Check `gh pr list --state open` and recent commits first — never duplicate work
+already in flight. Then take the first item below that is not done:
+
+1. **Phase 3c** — the signal-ledger writer. Resolves `fill_index = signal_index + 1`
+   from the series, fill price from that bar's OPEN, refuses when no next bar
+   exists (`no_fill_bar`), enforces the uniqueness key. `strategy_registry.py`
+   and `sql/255_strategy_signals.sql` already exist — read both.
+2. **Phase 4** — outcome resolver: `tp_hit` / `sl_hit` / `expired` / `ambiguous`.
+   Spike S5 (#2245) is ANSWERED — read its final comment for the rule and the
+   measured ambiguous rate.
+3. **Strategy catalogue** S-1 onward from the parent spec §4, each a pure
+   function against the phase 3a registry contract.
+4. **#2311** — vectorise `indicator_series` (currently 83.3 s against a < 60 s
+   acceptance). Ticket has the profile and the constraints.
+
+⚠ **ONE task. Do it completely — spec-conformant, tested, PR opened, review
+resolved, merged if green. Do not start a second.** A half-finished second task
+is worse than an idle iteration.
+
+## You HAVE a database — use it
+
+Unlike a cloud sandbox, you can reach the dev Postgres. So the full-population
+rule applies in full:
+
+- **Verify on the FULL population, never a sample.** This repo has repeatedly
+  been bitten by a favourable sample: a 3-series Bollinger check showed a 40×
+  safety margin and the full 7,354-series sweep then failed it with 193
+  mismatches.
+- ⚠ **Never state a number you did not compute in this run.**
+- Migrations: apply with `PYTHONPATH=. uv run python scripts/migrate.py`.
+- ⚠ You are in a WORKTREE. The dev API (:8000) and vite (:5173) serve
+  `~/Dev/eBull`, NOT here — so endpoint dev-verify is unavailable. Database
+  access works fine. If a task needs a live endpoint, say so on the issue and
+  pick the next task.
+
+## Workflow
+
+- `git checkout -b feature/2240-<short>` off `origin/main`. NEVER commit to main.
+- Schema → service → tests → glue.
+- **Revert-probe every invariant test**: inject the defect it guards, confirm
+  the test FAILS, restore, confirm it passes. ⚠ When injecting via string
+  replace, `assert s.count(old) == 1` first — a probe that silently matches
+  nothing proves nothing, and that has already happened here.
+- Gates, each run SEPARATELY, never piped into `head`/`tail` (a pipe returns
+  the pipe's status and buffers output):
+  - `uv run ruff check .`
+  - `uv run ruff format --check .`
+  - `uv run pyright`
+  - `uv run pytest -m "not db" -q`
+  - `uv run pytest tests/smoke -q`
+  All must exit 0.
+- Push, open a PR with a complete description.
+- Poll `gh pr checks <n>` and `gh pr view <n> --comments` until the review bot
+  has posted AND CI is green.
+- Resolve EVERY comment as `FIXED <sha>` / `DEFERRED #<issue>` / `REBUTTED <reason>`.
+- Merge only on bot APPROVE of the LATEST commit + CI green:
+  `gh pr merge <n> --squash --delete-branch`. ⚠ If the round contains a
+  rebuttal of yours, do NOT merge — leave it open with your reasoning.
+
+## Hard safety rules
+
+- **NEVER execute, approve or simulate a trade.** No order endpoints, no
+  approving recommendations, no touching the kill switch, no closing positions.
+- **NEVER `git push --no-verify`.**
+- **NEVER weaken, skip or delete a failing test to make a gate pass.** If a test
+  fails, fix the code — or explain on the PR why the test was wrong, with
+  evidence.
+- **NEVER drop, truncate or rewrite dev-DB data** beyond a reviewed migration.
+- Clean up anything you insert while testing.
+
+## Finish every run by reporting
+
+Post a short comment on issue **#2240** stating: what you did, what merged (with
+SHA), what you measured, and what the next run should pick up. If you stopped
+early, say exactly why and what is needed to unblock.
+
+Then leave the worktree clean: no half-done branches, no unpushed commits, no
+work intended to ship left without a PR.

--- a/scripts/autonomy/ta_loop_status.sh
+++ b/scripts/autonomy/ta_loop_status.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# What is the TA loop doing RIGHT NOW?
+#
+# ⚠ Exists because the first version of this loop could not answer that. The
+# transcript only filled at process exit and status.md only wrote at iteration
+# end, so mid-iteration the only way to tell progress from a hang was to go and
+# read git by hand. That is the same invisibility failure as the month-long
+# silent PAUSE, one layer down — so the fix is a command that reads every
+# signal at once.
+
+set -uo pipefail
+
+WORKTREE="${TA_LOOP_WORKTREE:-/Users/lukebradford/Dev/.ebull-autonomy}"
+STATE_DIR="${TA_LOOP_STATE:-$WORKTREE/var/autonomy}"
+
+echo "=== TA loop status @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo
+
+# 1. Is it alive, and is it paused?
+if [[ -f "$STATE_DIR/PAUSE" ]]; then
+  echo "STATE: ** PAUSED ** (sentinel: $STATE_DIR/PAUSE — remove to resume)"
+elif pgrep -f "ta_loop.sh" >/dev/null 2>&1; then
+  if pgrep -f "claude -p" >/dev/null 2>&1; then
+    pid=$(pgrep -f "claude -p" | head -1)
+    elapsed=$(ps -o etime= -p "$pid" 2>/dev/null | tr -d ' ')
+    echo "STATE: RUNNING — iteration in flight for ${elapsed:-?}"
+  else
+    echo "STATE: RUNNING — between iterations (cooldown)"
+  fi
+else
+  echo "STATE: NOT RUNNING"
+fi
+echo
+
+# 2. What has it actually produced? This is the signal that cannot lie — files
+#    on disk and a branch name beat any self-report.
+echo "--- worktree"
+if [[ -d "$WORKTREE" ]]; then
+  branch=$(git -C "$WORKTREE" branch --show-current 2>/dev/null)
+  echo "branch : ${branch:-<detached>}"
+  echo "head   : $(git -C "$WORKTREE" log --oneline -1 2>/dev/null)"
+  changed=$(git -C "$WORKTREE" status --short 2>/dev/null | wc -l | tr -d ' ')
+  echo "changed: $changed file(s)"
+  git -C "$WORKTREE" status --short 2>/dev/null | head -10 | sed 's/^/         /'
+else
+  echo "(worktree missing: $WORKTREE)"
+fi
+echo
+
+# 3. Open PRs it may be waiting on.
+echo "--- open PRs"
+gh pr list --state open --limit 5 --json number,title,headRefName \
+  --jq '.[] | "  #\(.number)  \(.headRefName)  \(.title[0:60])"' 2>/dev/null \
+  || echo "  (gh unavailable)"
+echo
+
+# 4. Recent driver activity.
+echo "--- loop.log (last 8)"
+tail -8 "$STATE_DIR/loop.log" 2>/dev/null | sed 's/^/  /' || echo "  (no log yet)"
+echo
+
+# 5. Live transcript. stream-json is one JSON object per line, so the tail is
+#    only useful decoded — show the assistant's most recent text.
+newest=$(ls -t "$STATE_DIR"/iteration-*.log 2>/dev/null | head -1)
+if [[ -n "${newest:-}" ]]; then
+  echo "--- latest transcript: $(basename "$newest") ($(wc -c < "$newest" | tr -d ' ') bytes)"
+  tail -200 "$newest" 2>/dev/null | python3 -c '
+import json, sys
+texts = []
+for line in sys.stdin:
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        event = json.loads(line)
+    except ValueError:
+        continue
+    message = event.get("message") or {}
+    for block in message.get("content") or []:
+        if isinstance(block, dict):
+            if block.get("type") == "text" and block.get("text", "").strip():
+                texts.append(block["text"].strip())
+            elif block.get("type") == "tool_use":
+                texts.append(f"[tool: {block.get(\"name\")}]")
+for entry in texts[-6:]:
+    print("  " + entry[:220].replace("\n", " "))
+' 2>/dev/null || tail -4 "$newest" | cut -c1-200 | sed 's/^/  /'
+fi


### PR DESCRIPTION
## Why

**The eBull loop has not run since 2026-07-23.** It did not pause — it wedged:

```
2026-07-23T12:09:54Z WARN cannot determine kind for in-flight 'coder'
                          (state unreadable) -- skipping this tick
```

It spun on that, stopped at 13:09, and was never restarted. Two weeks dead. ⚠ I guessed wrong about the cause twice tonight before reading its log — first assuming it was idle by design, then that a cloud agent was the answer.

Separately: the only autonomy supervisor still running on the Mac drives the **autonomy-engine's own repo**, not eBull, and has been **paused by a zero-byte sentinel since 8 July**.

## What this is

The simplest thing that works: **one iteration = one `claude -p` invocation** against a prompt file. No supervisor, no state machine, nothing to become unreadable. A dead iteration costs exactly one iteration.

```bash
scripts/autonomy/ta_loop.sh
touch <worktree>/var/autonomy/PAUSE     # graceful stop
cat   <worktree>/var/autonomy/status.md # what it last did
```

## Three lessons from real incidents, baked in

- ⚠ **Own git worktree** (`.ebull-autonomy`). Two Claude instances on `~/Dev/eBull` clobber each other's uncommitted work — prevention log, 2026-07-16.
- ⚠ **PAUSE is written to `status.md`, not just the log.** The engine's loop sat paused for a *month* printing its pause line into a file nobody opened. The failure wasn't the pause, it was the invisibility.
- ⚠ **Never pipes a command whose exit code or progress it needs.** A pipe returns the pipe's status *and* buffers — that cost 7 minutes of misdiagnosis on 2026-08-05, and it's already a CLAUDE.md rule.

Stops after 3 consecutive failures rather than hammering: three in a row means something structural (auth, quota, wedged repo) that another immediate attempt won't fix.

## What it can and cannot do

✅ **Has the dev database** — so the full-population rule applies in full, which is the whole reason a local loop beats a cloud one. The prompt cites the Bollinger incident (3-series sample showed a 40× margin; the full 7,354-series sweep failed with 193 mismatches) as the reason.

⚠ **Does not have the dev stack.** `:8000` and `:5173` serve `~/Dev/eBull`, not the worktree. Live-endpoint dev-verify is unavailable, and the prompt tells it to say so on the issue and move on rather than fake it.

## Safety

Hard rules in the prompt: never execute/approve/simulate a trade, never touch the kill switch or order endpoints, never `push --no-verify`, never weaken a failing test to pass a gate, never state a number it didn't compute. Merge only on bot APPROVE of the **latest** commit + CI green; rebuttal rounds are left open for a human.

`shellcheck -S warning` clean, `bash -n` clean.

Refs #2240. Refs #2307.
