### PR TITLE
feat(#2240): S-4 volatility compression breakout — the catalogue's third strategy

### DIFF
--- a/.claude/skills/engineering/test-quality.md
+++ b/.claude/skills/engineering/test-quality.md
@@ -403,6 +403,47 @@ Two things that made the fixtures reliable rather than approximate:
   a later fixture edit drifts off the boundary and the test keeps passing while
   testing nothing — which is the vacuous-test class this whole section is about.
 
+### ⚠ A reference implementation imports NONE of the constants it validates
+
+Precedent twice in one day (#2240 S-3 and S-4, 2026-08-06) — two of the three
+strategies written so far, which makes it the default mistake rather than a slip.
+Both had a reference re-derivation written by a deliberately different algorithm
+(S-4's `sorted(window).index(v)` against the module's count-of-comparisons), and
+both fed it the module's own constants. Probes that shifted the constants
+(S-3: period 14 → 13; S-4: window 100 → 50 and lookback 20 → 10) reported
+`NOT CAUGHT`: the reference moved with the code and both sides agreed on a rule
+neither was checking.
+
+**Independence of the ALGORITHM is not independence of the PARAMETERS**, and a
+parameter is exactly what a spec fixes. So: **a reference transcribes the spec's
+numbers by hand and imports none of them.** The divergence between the
+hand-written literal and the module's constant IS the test; sharing the constant
+deletes it while leaving everything looking right.
+
+**The shape that works, and it needs both halves:**
+
+1. Declare the spec's numbers as `SPEC_*` literals at the top of the test file,
+   with the rule quoted verbatim beside them. Every expected value reads those.
+2. Add exactly ONE bridge test (`TestSpecConstants`) asserting the module's
+   constants equal the `SPEC_*` ones, and let it be the only place the module's
+   constants are read as values. Without it the reference is independent but
+   nothing notices the code quietly using a different number — a constant change
+   then makes other tests silently wrong instead of failing one loudly.
+
+Scope, because over-applying this is its own defect: the rule binds the numbers
+an ASSERTION depends on. Using the module's constant as scaffolding — sizing a
+fixture window, indexing a warm-up boundary — is fine and often clearer; the
+bridge test is what keeps the two in step.
+
+Corollary for probe harnesses: **write a revert probe for a spec constant even
+when it looks inert.** Neither instance was visible until a probe mutated one —
+in S-4's case 37 tests, `ruff`, `pyright` and a clean 32.5M-bar full-population
+arm all passed, the arm clean *because* it was fed the same constants indirectly.
+A constant is the single thing a reference is most tempted to share.
+
+Live examples: `tests/test_strategy_s3.py` and `tests/test_strategy_s4.py`
+(`SPEC_*` block + `TestSpecConstants`).
+
 ## A "neutral" fixture is not neutral if the thing under test classifies it
 
 Bit twice in one PR (#2279, 2026-08-05), and both times the test failed against

--- a/app/services/strategies/s4_volatility_compression_breakout.py
+++ b/app/services/strategies/s4_volatility_compression_breakout.py
@@ -1,0 +1,386 @@
+"""S-4 — volatility compression breakout. The catalogue's third implemented strategy.
+
+Parent spec: ``docs/proposals/ta/strategy-catalogue-and-backtest-validity.md``
+§4 (S-4), §3.5 (execution semantics), §4.0 (validated universe), §5 criteria 4,
+8 and 11. Registry contract: ``app/services/strategy_registry.py`` (3a).
+Refs #2240, #2288.
+
+THE RULE, VERBATIM FROM §4
+-------------------------
+    Setup: ``atr_14(t)`` sits in the bottom quartile of its own trailing
+    100-bar distribution, **computed on bars <= t**. Signal: ``close(t) >`` the
+    highest close of bars ``t-20 .. t-1`` (**prior** 20 bars, excluding *t*
+    itself — including it makes the condition partly self-referential). Fill at
+    ``open(t+1)``. Exit: stop at ``entry - 2 x atr_14(t)``, profit target at
+    ``entry + 3 x atr_14(t)``, hard max-hold 40 bars — whichever comes first.
+    ⚠ ATR is indexed at **``t``, the signal bar**, never at ``t+1``: sizing a
+    stop off the fill bar's own range leaks that bar into the decision that
+    produced it. Levels are fixed at signal time and do not move. If one bar
+    spans both stop and target, the outcome is ``ambiguous`` per §3.5 rule 4.
+    Params: 3 (compression window, breakout lookback, ATR stop multiple).
+    Data: OHLC only, but requires **complete** OHLC.
+
+⚠⚠ THE TWO LEGS' WINDOW BOUNDARIES ARE DELIBERATELY ASYMMETRIC, AND MAKING THEM
+CONSISTENT WOULD BE A SPEC VIOLATION. Compression is *"computed on bars <= t"* —
+the window INCLUDES ``t``, because the question is where today's ATR sits in its
+own recent distribution, and excluding today would ask about a distribution
+today is not in. The breakout window EXCLUDES ``t``, and §4 says why in its own
+parenthesis: ``close(t) > max(closes including close(t))`` is satisfiable only by
+a tie and is *"partly self-referential"*. Two windows, two boundaries, one
+sentence of spec each. ``TestWindowBoundaries`` pins both.
+
+⚠⚠ THIS STRATEGY HAS NO EXIT SIGNAL LEG, AND CANNOT HAVE ONE.
+S-1 and S-3 each exit on a per-bar price condition, so their exits are signals.
+All three of S-4's exit conditions — stop, target, max-hold — are measured FROM
+THE ENTRY, so all three are position state, and a pure per-bar verdict function
+has none. This is S-3's ``MAX_HOLD_BARS`` reasoning applied to the whole exit
+rather than to one half of it. The parameters are NOT dropped: ``ATR_STOP_MULTIPLE``,
+``ATR_TARGET_MULTIPLE`` and ``MAX_HOLD_BARS`` are carried in ``S4_PARAMS``, so
+criterion 11 hashes them into the identity, and their consumer is
+``outcome_resolver.ExitLevels`` (phase 4a), whose caller is phase 5.
+
+⚠ THE ATR THAT SIZES THE BRACKET IS INDEXED AT THE SIGNAL BAR, AND THIS MODULE
+CANNOT GET THAT WRONG BECAUSE IT DOES NOT EMIT IT. A ``StrategySignal`` carries a
+bar index and nothing else (3a's module docstring), so whoever builds the
+``ExitLevels`` recomputes ``atr_series`` and reads ``signal_index`` — never
+``signal_index + 1``. §4 flags this as the exact trap ("sizing a stop off the fill
+bar's own range leaks that bar into the decision that produced it") and it was one
+of the five findings Codex's second spec round caught. The API shape is what
+prevents it here, in the same way the absent fill field prevents a same-bar fill.
+
+⚠ "BOTTOM QUARTILE" HAS NO PUBLISHED FORMULATION AND IS THEREFORE FIXED BY
+CONSTRUCTION HERE, NOT INVENTED SILENTLY.
+`.claude/CLAUDE.md`: *"Where a published formulation genuinely does NOT exist …
+say so explicitly and fix the rule by construction, freezing the constants in a
+version hash — do not invent a citation and do not leave the choice implicit."*
+Bollinger's Squeeze has a published rule (BandWidth at its lowest in six months);
+"ATR in the bottom quartile of its own trailing 100 bars" does not — it is this
+spec's own construction, and §4 states the window and the quartile but not the
+membership test. Sample quantiles are not one thing: NumPy ships nine
+interpolation methods, and picking one would be an unstated constant doing real
+work at the boundary. So membership is defined by RANK, which has no
+interpolation and no free parameter:
+
+    compression(t) := #{w in W : w < atr_14(t)} / |W|,  W = atr_14[t-99 .. t]
+    the setup holds iff  compression(t) < 0.25
+
+i.e. **the empirical CDF's left limit at today's ATR** — the fraction of the
+window strictly below it. With ``|W| = 100`` and no ties, today's ATR is the
+k-th smallest and ``compression = (k-1)/100``, so the setup holds for exactly
+k <= 25: the bottom 25 of 100, which is what "bottom quartile" has to mean for
+the count to come out right. ``TestCompressionRankRule`` pins that boundary at
+k=25 and k=26.
+
+⚠ Ties are resolved FAVOURABLY, and that is forced rather than chosen. Counting
+``w <= atr(t)`` instead would make the verdict depend on how many equal values
+happen to sit in the window, so two bars with IDENTICAL ATRs in the SAME window
+could get different verdicts according to their index — a rule that reads
+arbitrary order as signal. Counting strictly-below gives every tied value the
+same fraction and therefore the same verdict. ``TestCompressionRankRule`` pins it.
+
+⚠ The degenerate consequence, stated rather than left to be discovered: on a
+window whose 100 ATRs are ALL equal, ``compression = 0.0`` and the setup holds on
+every bar. A point-mass distribution has no quartiles, so no membership rule is
+"right" there; this one answers "maximally compressed", which is the reading that
+matches the strategy's intent. It is defused by the conjunction rather than by a
+special case — the breakout leg needs ``close(t)`` STRICTLY above 20 prior
+closes, which a series flat enough to hold ATR exactly constant cannot produce.
+``test_a_flat_series_never_fires`` is that claim, asserted rather than argued.
+
+⚠ A MASKED BAR REFUSES THE WHOLE TAIL OF THE SERIES, exactly as S-3's RSI does
+and for the same reason: ``atr_series`` is Wilder-smoothed from the series start,
+so it carries state across every bar and has no window for a hole to clear. S-4
+inherits S-3's blast radius, not S-1's. Counted rather than asserted away —
+``scripts/verify_2240_s4_volatility_breakout.py --census`` reports it over the
+validated universe.
+
+⚠ §4 REQUIRES COMPLETE OHLC, WHICH IS WIDER THAN S-1/S-3's CLOSE-ONLY NEED.
+*"instruments with NULL high/low and any bar inside a ``price_series_break``
+segment are ``not_evaluable``, not absent."* The high/low half is enforced here
+transitively and correctly: ``atr_series`` refuses on a NULL high, a NULL low or
+a NULL previous close, so a bar with a good close and a missing high is refused
+rather than judged. The ``price_series_break`` half is the CALLER's, and
+deliberately so — ``series_break`` is one of criterion 8's seven reason codes and
+this module has no database access, so it takes the code from the caller through
+``masked_reason`` in the same way S-1 and S-3 do.
+
+⚠ WHAT THIS MODULE DOES NOT GUARD, INHERITED FROM ``indicator_series``.
+Quarantine and adjustment basis are the CALLER's gate. There is no database
+access here, so bars arrive however the caller loaded them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from pathlib import Path
+
+from app.services.indicator_series import (
+    BarSeries,
+    IndicatorSeries,
+    Universe,
+    atr_series,
+)
+from app.services.strategy_registry import (
+    NOT_EVALUABLE_REASONS,
+    NotEvaluableReason,
+    StrategyIdentity,
+    StrategyInput,
+    StrategySignal,
+    evaluate,
+)
+
+S4_STRATEGY_ID = "s4-volatility-compression-breakout"
+
+#: ⚠ FIXED, NEVER TUNED (§6: *"Forbidden — continuous re-optimisation"*). Module
+#: constants rather than function arguments, for the reason S-1 and S-3 both
+#: give: a threshold that can be passed in is a threshold that can be swept, and
+#: criterion 11 would then need every sweep value registered as its own strategy.
+#: Changing any of them moves ``_source_hash`` AND ``S4_PARAMS``, so the identity
+#: moves and the prior track record is not inherited.
+ATR_PERIOD = 14
+COMPRESSION_WINDOW = 100
+#: The "quartile" of §4's *"bottom quartile"*, as a rank fraction — see the
+#: module docstring for why membership is a rank rather than an interpolated
+#: sample quantile.
+COMPRESSION_QUANTILE = 0.25
+BREAKOUT_LOOKBACK = 20
+
+#: The bracket, in ATR multiples at the SIGNAL bar. ⚠ Declared here and hashed
+#: into the identity, but NOT evaluated by ``s4_signals`` — see the module
+#: docstring. Their consumer is ``outcome_resolver.ExitLevels``.
+ATR_STOP_MULTIPLE = 2.0
+ATR_TARGET_MULTIPLE = 3.0
+MAX_HOLD_BARS = 40
+
+#: ⚠ §4 says *"Params: 3 (compression window, breakout lookback, ATR stop
+#: multiple)"* and this dict carries SEVEN entries. Recorded rather than resolved
+#: by dropping four, exactly as S-3 records the same discrepancy: §4 counts
+#: *free* parameters — the numbers a sweep would move — while criterion 11 hashes
+#: *everything that makes this a distinct strategy*. ``atr_period`` is Wilder's
+#: own default and ``compression_quantile`` is fixed by the word "quartile", but
+#: an S-4 computed on ``atr_20``, or on a tercile, is a different strategy and
+#: must not silently inherit this one's track record. The two exit multiples are
+#: here for the stronger reason that NOTHING IN THIS MODULE READS THEM: the
+#: identity hash is the only thing keeping them attached to the rule.
+S4_PARAMS: Mapping[str, object] = {
+    "atr_period": ATR_PERIOD,
+    "compression_window": COMPRESSION_WINDOW,
+    "compression_quantile": COMPRESSION_QUANTILE,
+    "breakout_lookback": BREAKOUT_LOOKBACK,
+    "atr_stop_multiple": ATR_STOP_MULTIPLE,
+    "atr_target_multiple": ATR_TARGET_MULTIPLE,
+    "max_hold_bars": MAX_HOLD_BARS,
+}
+
+#: The first index at which BOTH legs can be evaluated, DERIVED from the rule
+#: rather than restated as an independent number.
+#:
+#: ``atr_series`` emits its first value at index ``ATR_PERIOD`` (Wilder seeds on
+#: the mean of true ranges 1..period). A compression window of 100 ending at
+#: ``i`` reaches back to ``i - 99``, so it is full only from
+#: ``ATR_PERIOD + COMPRESSION_WINDOW - 1 = 113``. The breakout leg needs 20 prior
+#: closes and is ready at index 20. 113 binds.
+#:
+#: NOT enforced by a length check — the series above emit ``None`` until their
+#: windows are full and 3a's runner turns that into ``insufficient_warmup``. An
+#: explicit ``len(series) < 113 -> refuse`` would be a second, weaker copy of the
+#: same rule: it would pass a 200-bar series whose bar 150 still sits inside the
+#: tail an early masked bar refused.
+WARMUP_BARS = ATR_PERIOD + COMPRESSION_WINDOW - 1
+
+
+def _source_hash() -> str:
+    """Hash of THIS module — the ``source_hash`` half of criterion 11.
+
+    ``StrategyIdentity.version`` mixes this with the params, the universe, the
+    cost-model id and the registry's own source. Same construction as
+    ``indicator_series.RULE_SET_VERSION``, and the same deliberate
+    over-invalidation: editing a comment here moves the version, which makes
+    previously stored signals visibly stale rather than silently mixed.
+    """
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+def s4_identity(*, universe: Universe, cost_model_id: str) -> StrategyIdentity:
+    """The registered identity of S-4 on one universe under one cost model.
+
+    ⚠ Both arguments are REQUIRED and neither has a default, for the reason S-1
+    states: criterion 11 makes universe and cost model part of the identity, so a
+    default would silently register a strategy the caller never declared.
+    ``cost_model_id`` is rejected when blank — ``str`` does not distinguish "not
+    supplied" from ``""``, and a present-but-empty declaration is the #2286 shape.
+    """
+    if not cost_model_id.strip():
+        raise ValueError(
+            "cost_model_id must be a non-empty declaration (criterion 11 hashes it); "
+            "no cost model exists yet, so pass an explicit placeholder rather than an empty string"
+        )
+    return StrategyIdentity(
+        strategy_id=S4_STRATEGY_ID,
+        params=S4_PARAMS,
+        universe=universe,
+        cost_model_id=cost_model_id,
+        source_hash=_source_hash(),
+    )
+
+
+def _close_input(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """The bar closes, in the shape 3a's runner checks for evaluability.
+
+    ⚠ The close is DECLARED, not relied upon transitively — S-1's and S-3's
+    reasoning applies unchanged. A NULL close at bar ``i`` already makes
+    ``atr_14(i)`` unevaluable, so declaring it changes no verdict today. It is
+    declared anyway because the breakout rule READS ``close(t)``, and an
+    undeclared input is a guard that exists only as a property of a different
+    module.
+    """
+    closes = series.float_closes
+    return IndicatorSeries(
+        values=tuple(closes),
+        universe=universe,
+        not_evaluable_indices=tuple(i for i, value in enumerate(closes) if value is None),
+    )
+
+
+def compression_rank_series(atr: IndicatorSeries, *, universe: Universe) -> IndicatorSeries:
+    """Fraction of the trailing ``COMPRESSION_WINDOW`` ATRs strictly below ATR(t).
+
+    The empirical CDF's left limit, per the module docstring. The COMPARISON
+    against ``COMPRESSION_QUANTILE`` deliberately stays in ``s4_signals``'s body
+    rather than being folded in here: this series carries a measured quantity, so
+    a probe that relaxes the threshold has something to relax, and ``--census``
+    has a distribution to report rather than a boolean.
+
+    ⚠ The window INCLUDES ``t`` (§4: *"computed on bars <= t"*), so ``atr(t)`` is
+    always one of the values it is ranked against and the fraction can never
+    reach 1.0.
+
+    Refusal is split the way 3a requires. An index whose window overlaps ATR's
+    own unevaluable set is a DATA refusal and is listed in
+    ``not_evaluable_indices``; an index whose window merely reaches back into
+    ATR's warm-up is left as a bare ``None``, which 3a reads as
+    ``insufficient_warmup``. Collapsing the two would destroy exactly what
+    criterion 8 exists for.
+    """
+    n = len(atr)
+    values: list[float | None] = [None] * n
+    unevaluable: list[int] = []
+    atr_bad = set(atr.not_evaluable_indices)
+
+    for index in range(n):
+        low = index - COMPRESSION_WINDOW + 1
+        if low < 0:
+            continue  # fewer than COMPRESSION_WINDOW bars exist yet — warm-up.
+        if any(j in atr_bad for j in range(low, index + 1)):
+            unevaluable.append(index)
+            continue
+        window = atr.values[low : index + 1]
+        if any(value is None for value in window):
+            continue  # the window reaches into ATR's warm-up — still warm-up.
+        current = atr.values[index]
+        assert current is not None  # implied by the window check above.
+        below = sum(1 for value in window if value is not None and value < current)
+        values[index] = below / len(window)
+
+    return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+
+def prior_high_close_series(series: BarSeries, *, universe: Universe) -> IndicatorSeries:
+    """Highest close of the ``BREAKOUT_LOOKBACK`` bars STRICTLY BEFORE ``t``.
+
+    ⚠ ``t`` IS EXCLUDED. §4: *"the highest close of bars ``t-20 .. t-1``
+    (**prior** 20 bars, excluding *t* itself — including it makes the condition
+    partly self-referential)"*. Including it would leave ``close(t) > max(...)``
+    satisfiable only by a tie, i.e. never, under a strict comparison — the rule
+    would silently never fire rather than fail.
+
+    A masked close anywhere in the window is a DATA refusal, not warm-up: the
+    field is present and empty, so the window genuinely cannot support a maximum.
+    Indices with fewer than ``BREAKOUT_LOOKBACK`` bars behind them are warm-up.
+    """
+    closes = series.float_closes
+    n = len(closes)
+    values: list[float | None] = [None] * n
+    unevaluable: list[int] = []
+
+    for index in range(n):
+        low = index - BREAKOUT_LOOKBACK
+        if low < 0:
+            continue  # fewer than BREAKOUT_LOOKBACK prior bars — warm-up.
+        window = closes[low:index]  # ⚠ excludes `index` itself.
+        if any(value is None for value in window):
+            unevaluable.append(index)
+            continue
+        values[index] = max(value for value in window if value is not None)
+
+    return IndicatorSeries(tuple(values), universe, tuple(unevaluable))
+
+
+def s4_signals(
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+) -> list[StrategySignal]:
+    """S-4's entry verdict for every bar. ⚠ ENTRIES ONLY — see the module docstring.
+
+    ⚠ ALL FOUR INPUTS ARE DECLARED TO THE ONE LEG, including the raw ``atr``
+    that the condition does not read directly. ``atr`` is declared because
+    ``compression_rank_series`` is derived from it and a caller reading this
+    function should see the strategy's real data requirement, not a requirement
+    laundered through a helper — and because §3.1 makes evaluability a property
+    of the STRATEGY, decided before any condition runs, so the set of declared
+    inputs is the honest statement of what the bar needs. It changes no verdict
+    (every ATR refusal already propagates into the rank series), which is why it
+    is unprobeable and is called out here rather than left to look load-bearing.
+
+    ``masked_reason`` is the code recorded when an OHLC field is missing, and it
+    comes from the caller because only the caller knows why: bars from
+    ``load_masked_series`` are missing because the quarantine masked them
+    (``quarantined_bar``), whereas §4's *"any bar inside a ``price_series_break``
+    segment"* is ``series_break``. A different loader owes a different code.
+    """
+    if masked_reason not in NOT_EVALUABLE_REASONS:
+        raise ValueError(f"unknown reason code {masked_reason!r}; must be one of {sorted(NOT_EVALUABLE_REASONS)}")
+
+    closes = series.float_closes
+    atr = atr_series(series, universe=universe, period=ATR_PERIOD)
+    compression = compression_rank_series(atr, universe=universe)
+    prior_high = prior_high_close_series(series, universe=universe)
+
+    inputs = (
+        StrategyInput(series=_close_input(series, universe=universe), reason=masked_reason),
+        StrategyInput(series=atr, reason=masked_reason),
+        StrategyInput(series=compression, reason=masked_reason),
+        StrategyInput(series=prior_high, reason=masked_reason),
+    )
+
+    def entry(index: int) -> bool:
+        close = closes[index]
+        rank = compression.values[index]
+        highest_prior_close = prior_high.values[index]
+        # Not reachable through `evaluate`, which refuses the bar first. Present
+        # to narrow the types and to fail loudly for a direct caller.
+        assert close is not None and rank is not None and highest_prior_close is not None
+        return rank < COMPRESSION_QUANTILE and close > highest_prior_close
+
+    return evaluate(entry, inputs=inputs, n_bars=len(series), kind="entry")
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "ATR_STOP_MULTIPLE",
+    "ATR_TARGET_MULTIPLE",
+    "BREAKOUT_LOOKBACK",
+    "COMPRESSION_QUANTILE",
+    "COMPRESSION_WINDOW",
+    "MAX_HOLD_BARS",
+    "S4_PARAMS",
+    "S4_STRATEGY_ID",
+    "WARMUP_BARS",
+    "compression_rank_series",
+    "prior_high_close_series",
+    "s4_identity",
+    "s4_signals",
+]

--- a/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
+++ b/docs/proposals/ta/strategy-catalogue-and-backtest-validity.md
@@ -752,6 +752,70 @@ Data: OHLC only, but requires **complete** OHLC — instruments with NULL high/l
 and any bar inside a `price_series_break` segment are `not_evaluable`, not
 absent.
 
+✅ **IMPLEMENTED 2026-08-06** — `app/services/strategies/s4_volatility_compression_breakout.py`,
+a pure function against the phase-3a registry contract. Four notes it settles
+that this entry left open:
+
+- ⚠⚠ **"Bottom quartile" had no membership rule, and there is no published one to
+  cite** — so it is fixed **by construction** and said out loud, per the
+  instruction set's rule for exactly this case. Bollinger's Squeeze has a
+  published formulation (BandWidth at its lowest in six months); "ATR in the
+  bottom quartile of its own trailing 100 bars" is this document's own
+  construction, and it states the window and the quartile but not the test.
+  Sample quantiles are not one thing — NumPy ships nine interpolation methods —
+  so membership is defined by **rank**, which has no interpolation and no free
+  parameter: `compression(t) = #{w ∈ W : w < atr_14(t)} / |W|` over
+  `W = atr_14[t-99 .. t]`, and the setup holds iff that is `< 0.25`. With 100
+  distinct values the k-th smallest scores `(k-1)/100`, so exactly the bottom 25
+  qualify. ⚠ Ties are **forced** favourable, not chosen: counting `w ≤ atr(t)`
+  would let two bars with identical ATRs in one window rank differently by
+  position, i.e. read arbitrary order as signal.
+- ⚠⚠ **S-4 has NO exit signal leg, and cannot have one.** S-1 and S-3 exit on a
+  per-bar price condition; all three of S-4's — stop, target, max-hold — are
+  measured *from the entry*, so all three are position state and a pure per-bar
+  verdict function has none. This is S-3's `MAX_HOLD_BARS` reasoning applied to a
+  whole exit bracket. The parameters are not dropped: `ATR_STOP_MULTIPLE`,
+  `ATR_TARGET_MULTIPLE` and `MAX_HOLD_BARS` are hashed into the identity
+  (criterion 11) and consumed by `outcome_resolver.ExitLevels` (phase 4a).
+  **Nothing in the module reads them**, so the identity hash is the only thing
+  holding them to this rule — which is why the revert probe that drops one from
+  `S4_PARAMS` is the one that matters most on this module.
+- **The two windows keep DIFFERENT boundaries, deliberately.** Compression is
+  *"computed on bars ≤ t"* (inclusive — today's ATR is ranked against a
+  distribution it is in); the breakout excludes `t` for the reason this entry
+  already gives. Making them consistent would be a spec violation, so each is
+  pinned by its own test.
+- ⚠ **A masked bar refuses the whole TAIL of the series**, inherited from Wilder
+  smoothing exactly as S-3's RSI is, and **much larger here** — `atr_14` needs
+  high, low *and* the previous close, so more fields can kill it. Counted, not
+  asserted away: over the validated universe **361 of 5,266 series carry a masked
+  bar, and they cost 611,092 bars** on which the 20-bar breakout frame had
+  recovered and the ATR never will (`--census`, 2026-08-06). Both legs also share
+  ONE warm-up at 113 bars (`atr_14`'s seed plus the 100-bar window), a narrowing
+  of **484,594 bars** whose breakout leg was evaluable.
+
+**Full-population verification** (`scripts/verify_2240_s4_volatility_breakout.py`),
+2026-08-06. ⚠ The ATR and the prior-20 high are compared as VALUES, bar by bar,
+not merely through the verdicts they feed — both sides compute in float64 in the
+same order, so agreement is expected to be bit-for-bit and any difference is
+logic rather than rounding:
+
+| corpus | series | bars | values compared | value mismatches | verdict mismatches | ties |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `research_price_daily` | 7,693 | 25,818,944 | 51,637,888 | **0** | **0** | 0 |
+| `price_daily` | 12,185 | 6,702,891 | 13,405,782 | **0** | **0** | 0 |
+| | | **32,521,835** | **65,043,670** | **0** | **0** | **0** |
+
+Census over the §4.0 validated universe on masked bars: 23,339,583 bars —
+fired 699,632 (2.998%), not_fired 21,432,155 (91.827%), not_evaluable 1,207,796
+(5.175%; `quarantined_bar` 613,835 · `insufficient_warmup` 588,695 ·
+`no_fill_bar` 5,266). Revert probes 16/16 caught.
+
+⚠ **No performance claim is attached, deliberately** — the same reason S-3 ships
+without one. §4's survivorship table grades every strategy's *omission* bias on a
+survivor-only corpus, the fired share above is a count of signals rather than of
+outcomes, and §5's acceptance criteria are phase 5's work, not this module's.
+
 **S-5 · Support/resistance retest** *(blocked on #2279)*
 Level formation: cluster swing pivots into levels using **only bars strictly
 before the break**, with each pivot subject to its confirmation lag (§3.5

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -3009,3 +3009,27 @@ add an entry here as part of resolving the comment (`EXTRACTED docs/review-preve
 - ⚠ Third: `.claude/skills/data-sources/finra.md` §2.7 asserted the bimonthly CDN returns **404** and that its provider "only maps 404". Both false — it returns 403 with a 111-byte body, and the provider had mapped both since #916. The skill had drifted away from the code in the direction that makes the bug harder to see.
 - Prevention: before deriving any reporting calendar, grep the governing rule for *designated*/*prescribed*/*published by*; if present, the calendar is a list to be read or probed, not computed. Where probing is the only route, validate the fetched artefact against its own self-description before storing it.
 - Enforced in: this prevention log; `app/jobs/finra_short_interest_refresh.py` (`_fetch_designated_file` + the `_MAX_ANCHOR_WALKBACK_DAYS` rationale comment); `app/services/finra_short_interest_ingest.py` (body-date contract in the module docstring); `scripts/audit_finra_settlement_calendar.py` (re-runnable full-population scan).
+
+⚠ **RECURRED THE SAME DAY, INDEPENDENTLY (#2240 S-4, 2026-08-06).** Recorded here
+rather than as a second section, because a recurrence is worth more than a
+restatement — and because the two happened in parallel branches, so S-4's tests
+were written before this entry existed on `main`. `tests/test_strategy_s4.py`
+imported `COMPRESSION_WINDOW` and `BREAKOUT_LOOKBACK` into its reference and the
+probes for "window shortened 100 → 50" and "lookback shortened 20 → 10" both
+reported `*** NOT CAUGHT ***` — the identical failure, in a reference that was
+independent in algorithm (`sorted(window).index(v)` against the module's
+count-of-comparisons) and shared in parameters. Two strategies out of three hit
+it, which is the number that says this is the default mistake and not a slip.
+
+Two things S-4 adds to the prevention above:
+
+- **Scope.** The rule binds the numbers the ASSERTION depends on, not the ones a
+  fixture is built from. Using the module's constant as scaffolding — sizing a
+  window, indexing a warm-up boundary — is fine and often clearer; it is the
+  expected-value path that must carry hand-transcribed literals.
+- **Write the probe even when the constant looks inert.** Neither instance was
+  visible until a probe mutated the constant: 35 tests, `ruff`, `pyright` and a
+  clean 32.5M-bar full-population arm all passed in the S-4 case, and the arm was
+  clean *because* it was fed the module's constants indirectly too. A spec
+  constant is the single thing a reference is most tempted to share, so it is the
+  one most worth probing.

--- a/scripts/probe_2240_s4_volatility_breakout.py
+++ b/scripts/probe_2240_s4_volatility_breakout.py
@@ -1,0 +1,230 @@
+"""Revert-probe the S-4 invariant tests (#2240).
+
+    uv run python scripts/probe_2240_s4_volatility_breakout.py
+
+Sister to ``scripts/probe_2240_s1_momentum.py``, whose two guards apply unchanged:
+
+1. ⚠ **Every anchor must occur EXACTLY ONCE**, asserted before the replace. A
+   probe that silently matches nothing mutates nothing, the test passes, and the
+   harness reports ``CAUGHT`` for a defect it never injected.
+2. ⚠ **A probe must DELETE or INVERT behaviour, never wrap it.** Guard 1 says
+   nothing about whether the replacement changes anything.
+
+⚠ NOT A TEST, and it must never become one: it mutates a tracked source file on
+disk. CI does not run it. Everything here is pure-tier, so no database is needed.
+
+WHAT IS NOT PROBED, AND WHY
+---------------------------
+⚠ **Three of the four declared inputs are individually redundant**, and no probe
+is written for them rather than one being contrived that reports ``CAUGHT`` for
+something else. ``s4_signals`` declares close, ATR, compression and prior-high;
+deleting any of the first, second or fourth changes NO verdict, because
+``atr_series`` already refuses on a NULL close, and ``compression_rank_series``
+already refuses on every ATR refusal — while the prior-high window's refusals are
+a strict subset of the tail ATR refuses anyway. They are declared because §3.1
+makes evaluability a property of the STRATEGY and an undeclared input is a guard
+that exists only as a property of a different module, which is exactly the
+reasoning S-1 records for its own close declaration. The COMPRESSION input is not
+redundant (it carries the 113-bar warm-up that ATR alone does not) and IS probed.
+
+⚠ **The final bar's** ``no_fill_bar`` **refusal** lives in
+``strategy_registry.evaluate`` (3a), not here, and is probed with that module.
+
+⚠ **The exit bracket.** ``ATR_STOP_MULTIPLE`` / ``ATR_TARGET_MULTIPLE`` /
+``MAX_HOLD_BARS`` are not read by any code path in this module — S-4 has no exit
+leg (see its docstring), and their consumer is ``outcome_resolver.ExitLevels``.
+So the only thing that can hold them to the rule is the identity hash, and the
+probe that matters is the one that drops one from ``S4_PARAMS``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SRC = Path("app/services/strategies/s4_volatility_compression_breakout.py")
+TESTS = "tests/test_strategy_s4.py"
+
+CONDITION = "        return rank < COMPRESSION_QUANTILE and close > highest_prior_close"
+
+#: (what the injected defect IS, [(anchor, replacement), ...], -k selector)
+PROBES: list[tuple[str, list[tuple[str, str]], str]] = [
+    (
+        # ⚠ NOT the flat fixture, and not the rising one. Both are degenerate on
+        # BOTH conjuncts at once, so relaxing either leaves the other false and
+        # the probe reports NOT CAUGHT — the S-3 lesson, already in the
+        # prevention log. Each operator gets its own exact-equality fixture.
+        "setup leg relaxed to <= (fires with the ATR exactly ON the quartile)",
+        [(CONDITION, "        return rank <= COMPRESSION_QUANTILE and close > highest_prior_close")],
+        "test_a_compression_rank_exactly_on_the_quartile_does_not_fire",
+    ),
+    (
+        "breakout leg relaxed to >= (fires with the close exactly ON the prior high)",
+        [(CONDITION, "        return rank < COMPRESSION_QUANTILE and close >= highest_prior_close")],
+        "test_a_close_exactly_on_the_prior_high_does_not_fire",
+    ),
+    (
+        # Without the setup leg S-4 is "buy any 20-bar breakout", not a
+        # compression strategy. Only detectable on bars where the breakout leg
+        # is true and the setup leg is false — the quadrant the cycle fixture
+        # asserts it covers.
+        "the compression setup leg dropped entirely",
+        [(CONDITION, "        return close > highest_prior_close")],
+        "test_every_bar_matches_the_naive_reference",
+    ),
+    (
+        "the breakout leg dropped entirely",
+        [(CONDITION, "        return rank < COMPRESSION_QUANTILE")],
+        "test_every_bar_matches_the_naive_reference",
+    ),
+    (
+        # §4: *"computed on bars <= t"*. Dropping `t` from its own window also
+        # drops the divisor to 99, so a new ATR high scores 1.0 instead of 0.99.
+        "the compression window excludes the ranked bar",
+        [("        window = atr.values[low : index + 1]", "        window = atr.values[low:index]")],
+        "test_the_compression_rank_can_never_reach_one or test_the_window_includes_the_ranked_bar",
+    ),
+    (
+        # §4's own parenthesis: *"including it makes the condition partly
+        # self-referential"*. Under a strict `>` the rule then never fires at
+        # all — it fails silently rather than loudly, which is why it is probed.
+        "the breakout window includes the signal bar",
+        [
+            (
+                "        window = closes[low:index]  # ⚠ excludes `index` itself.",
+                "        window = closes[low : index + 1]",
+            )
+        ],
+        "test_the_breakout_window_excludes_the_signal_bar",
+    ),
+    (
+        # ⚠ Tie handling is FORCED, not chosen: counting `<=` makes two bars with
+        # identical ATRs in one window rank differently by position.
+        "the rank counts ties as below (<= instead of <)",
+        [
+            (
+                "        below = sum(1 for value in window if value is not None and value < current)",
+                "        below = sum(1 for value in window if value is not None and value <= current)",
+            )
+        ],
+        "test_a_constant_atr_ramp_fires_every_warm_bar",
+    ),
+    (
+        # The one input declaration that is NOT redundant — it carries the
+        # 113-bar warm-up that the raw ATR (warm at 14) does not.
+        "the compression input dropped from the declared set",
+        [
+            (
+                "        StrategyInput(series=compression, reason=masked_reason),\n",
+                "",
+            )
+        ],
+        "test_the_first_evaluable_bar_is_the_warm_up_boundary",
+    ),
+    (
+        "the ATR period changed away from Wilder's 14",
+        [("ATR_PERIOD = 14", "ATR_PERIOD = 20")],
+        "test_every_bar_matches_the_naive_reference",
+    ),
+    (
+        "the compression window shortened from §4's 100 bars",
+        [("COMPRESSION_WINDOW = 100", "COMPRESSION_WINDOW = 50")],
+        "test_every_bar_matches_the_naive_reference",
+    ),
+    (
+        "the breakout lookback shortened from §4's 20 bars",
+        [("BREAKOUT_LOOKBACK = 20", "BREAKOUT_LOOKBACK = 10")],
+        "test_every_bar_matches_the_naive_reference",
+    ),
+    (
+        # S-4 has no exit leg and cannot have one; emitting under the exit kind
+        # would put entry decisions on the ledger's exit key.
+        "the single leg emitted under the exit kind",
+        [('n_bars=len(series), kind="entry")', 'n_bars=len(series), kind="exit")')],
+        "test_every_signal_is_an_entry",
+    ),
+    (
+        "a blank cost-model declaration accepted into the identity hash",
+        [("    if not cost_model_id.strip():", "    if False:")],
+        "test_a_blank_cost_model_id_is_rejected",
+    ),
+    (
+        # Criterion 11 requires identity to cover CODE. A constant hash means an
+        # edited rule inherits the prior track record.
+        "the source hash frozen to a constant",
+        [
+            (
+                "    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]",
+                '    return "0" * 12',
+            )
+        ],
+        "test_the_source_hash_is_this_strategys_own_source",
+    ),
+    (
+        "the compression window dropped from the hashed parameters",
+        [('    "compression_window": COMPRESSION_WINDOW,\n', "")],
+        "test_the_identity_carries_every_parameter_of_the_rule",
+    ),
+    (
+        # ⚠ THE PROBE THAT MATTERS MOST ON THIS MODULE. Nothing in the code reads
+        # the stop multiple, so nothing except the identity hash would notice it
+        # drifting away from §4's rule — S-3's MAX_HOLD_BARS lesson, applied to a
+        # whole exit bracket rather than half of one.
+        "the ATR stop multiple dropped from the hashed parameters",
+        [('    "atr_stop_multiple": ATR_STOP_MULTIPLE,\n', "")],
+        "test_the_identity_carries_every_parameter_of_the_rule",
+    ),
+]
+
+
+def run(selector: str) -> int:
+    """The named tests, in a subprocess so the mutated module is re-imported."""
+    return subprocess.run(
+        ["uv", "run", "pytest", TESTS, "-q", "-k", selector, "-p", "no:randomly", "-n", "0"],
+        capture_output=True,
+    ).returncode
+
+
+def main() -> int:
+    original = SRC.read_text()
+    failures: list[str] = []
+    try:
+        for name, edits, selector in PROBES:
+            mutated = original
+            bad_anchor = False
+            for old, new in edits:
+                count = mutated.count(old)
+                if count != 1:
+                    failures.append(f"{name}: anchor occurs {count} times, expected exactly 1 — probe proves nothing")
+                    bad_anchor = True
+                    break
+                mutated = mutated.replace(old, new)
+            if bad_anchor:
+                continue
+            SRC.write_text(mutated)
+            rc = run(selector)
+            SRC.write_text(original)
+            verdict = "CAUGHT" if rc != 0 else "*** NOT CAUGHT ***"
+            print(f"  {verdict:<20} {name}", flush=True)
+            if rc == 0:
+                failures.append(name)
+    finally:
+        # ⚠ Restored even on KeyboardInterrupt. A harness that can leave a
+        # tracked source file mutated is one Ctrl-C away from a defect committed
+        # by accident.
+        SRC.write_text(original)
+
+    rc_suite = run("test_")
+    print(f"\n  restored suite: {'PASS' if rc_suite == 0 else '*** FAIL ***'}", flush=True)
+    if rc_suite:
+        failures.append("restored suite does not pass")
+    if failures:
+        print("\nUNCAUGHT:\n  " + "\n  ".join(failures), flush=True)
+        return 1
+    print(f"\nall {len(PROBES)} probes caught", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2240_s4_volatility_breakout.py
+++ b/scripts/verify_2240_s4_volatility_breakout.py
@@ -1,0 +1,532 @@
+"""Full-population verification of S-4 volatility compression breakout (#2240).
+
+    PYTHONPATH=. uv run python scripts/verify_2240_s4_volatility_breakout.py --all
+
+⚠ NOTHING IS WRITTEN. Both arms read and print. Gate on the EXIT CODE — 0 means
+every arm passed, 1 means at least one did not.
+
+⚠ NEVER PIPE THIS INTO ``head``/``tail``. A pipe returns the pipe's status, so a
+failure reads as success, and it buffers the progress lines a long run is judged
+by (`.claude/CLAUDE.md`). Redirect to a file and read the file.
+
+TWO ARMS, MEASURING DIFFERENT THINGS
+------------------------------------
+``--equivalence`` — every bar of BOTH corpora, ``research_price_daily`` and
+``price_daily``, on RAW bars, against a re-derivation of the same rule.
+
+⚠⚠ WHAT IS INDEPENDENTLY DERIVED HERE, AND WHAT IS NOT. Stating this precisely
+matters more on S-4 than on S-1, because S-4's inputs are not all the same shape
+and a blanket "compared against SQL" would be false:
+
+- **The true range is SQL's**, from ``lag(close)`` and the bar's own high/low.
+  This is where an OHLC alignment bug would live — a TR that reaches the wrong
+  previous close, or reads high/low off the fill bar — and the SQL side has no
+  index and no state, so a shared off-by-one would have to occur in both.
+- **The prior-20 high is SQL's**, from ``max(close) OVER (ROWS BETWEEN 20
+  PRECEDING AND 1 PRECEDING)``. §4's *"excluding t itself"* is a frame boundary
+  on that side and a slice bound on ours, which is the cleanest possible
+  independent statement of the same rule.
+- **The compression rank is re-derived by a DIFFERENT ALGORITHM** —
+  ``sorted(window).index(value)``, the position of the first occurrence in a
+  sorted window, against the module's count-of-comparisons. Not SQL's: counting
+  window values below a per-row value has no window-function form, and the
+  array-unnest form is 100 comparisons on each of 32.5M bars.
+- ⚠ **The Wilder recursion is RE-IMPLEMENTED in this script, not SQL-derived**,
+  and that is the weakest link — a recursive CTE over 32.5M rows needs indexed
+  temp tables per corpus. What it still catches is transcription and HORIZON
+  errors (where the seed lands, where the tail refusal starts), because the
+  re-implementation is fed SQL's true ranges. What it cannot catch is an error
+  in the Wilder arithmetic itself, which is pinned instead by
+  ``tests/test_indicator_series.py`` and by phase 2a's
+  ``verify_2240_indicator_series.py``. ⚠ Phase 2a checks ATR at the LAST BAR of
+  each series only; this arm checks EVERY bar, which is the gap it closes.
+
+⚠ BOTH SIDES COMPUTE IN float64 IN THE SAME ORDER, so the ATR is expected to
+agree BIT-FOR-BIT and the run asserts that on the full population rather than
+assuming it. SQL casts to ``double precision`` before any arithmetic for exactly
+this reason: left in ``numeric`` it would divide exactly where we divide
+approximately, and every near-tie would need a tolerance. Any ATR disagreement is
+therefore a logic difference, not a rounding one, and is counted as a hard
+mismatch with no tie allowance. The only comparison left with two arithmetics is
+``close > prior_high``, both ``numeric`` on the SQL side and ``float`` on ours —
+those get the tie treatment S-1 established.
+
+``--census`` — the §4.0 validated universe (US stocks ex-ETF) on MASKED bars, via
+the fail-closed loader. Reports the verdict distribution and the refusal
+breakdown by reason (criterion 9's "measure what you reject"), plus TWO
+S-4-specific counts:
+
+- the bars the 113-bar warm-up narrows away from a breakout leg that was already
+  computable at bar 20; and
+- ⚠ **the bars refused because a hole EARLIER in the series killed the ATR
+  recursion**. This is S-3's blast radius in a second guise: Wilder smoothing
+  carries state, so ``atr_series`` refuses every bar after a masked one rather
+  than recovering, and S-4 inherits it. Counted, not asserted away.
+
+⚠ The two arms are NOT comparable and the numbers must not be pooled: different
+populations, different bars (raw vs masked), different purpose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections import Counter
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+from psycopg import sql as pgsql
+
+from app.config import settings
+from app.services.indicator_series import BarSeries, atr_series
+from app.services.research_price_structure_store import load_masked_series
+from app.services.strategies.s4_volatility_compression_breakout import (
+    ATR_PERIOD,
+    BREAKOUT_LOOKBACK,
+    COMPRESSION_QUANTILE,
+    COMPRESSION_WINDOW,
+    S4_STRATEGY_ID,
+    WARMUP_BARS,
+    _source_hash,
+    compression_rank_series,
+    prior_high_close_series,
+    s4_identity,
+    s4_signals,
+)
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.technical_analysis import OHLCVRow
+
+#: The research corpus is survivor-only (#2284: no free source serves the
+#: delisted cohort), and ``price_daily`` is eToro's listing as it stands today.
+#: Both are ``survivor_only`` and every figure below inherits that label (#2288).
+UNIVERSE = "survivor_only"
+
+#: No cost model exists yet — §5 criterion 2 specifies one and §8 sequences it.
+COST_MODEL_ID = "undeclared-v0"
+
+#: Relative margin below which a disagreement is arithmetic, not logic.
+TIE_TOLERANCE = 1e-9
+
+#: ⚠ Read at IMPORT, microseconds after the strategy module is loaded, so it is
+#: the hash of the code this process actually runs. See ``_stamped_version``.
+_SOURCE_AT_IMPORT = _source_hash()
+
+
+#: ⚠ Every arithmetic operand is cast to ``double precision`` BEFORE the
+#: operation, not after — ``(high - low)::float8`` would subtract in ``numeric``
+#: and round once, which is a different number from subtracting two float64s.
+#: The whole bit-for-bit claim above rests on this line being written this way.
+#:
+#: ⚠ ``count(*)`` and ``count(close)`` are BOTH required on the 20-bar frame. The
+#: first rejects a frame that has not filled yet, the second one holding a NULL
+#: close. Either alone admits the other case, and they are different verdicts —
+#: a short frame is warm-up, a holed one is a data gap (criterion 8).
+_BAR_TEMPLATE = """
+WITH b AS (
+  SELECT {key} AS k,
+         {date_column} AS d,
+         open, high, low, close, volume,
+         lag(close) OVER w AS prev_close,
+         CASE WHEN count(*) OVER w20 = {lookback} AND count(close) OVER w20 = {lookback}
+              THEN max(close) OVER w20 END AS prior_high
+  FROM {table}
+  WINDOW w AS (PARTITION BY {key} ORDER BY {date_column}),
+         w20 AS (PARTITION BY {key} ORDER BY {date_column}
+                 ROWS BETWEEN {lookback} PRECEDING AND 1 PRECEDING)
+)
+SELECT k, d, open, high, low, close, volume, prior_high,
+       CASE WHEN high IS NULL OR low IS NULL OR close IS NULL OR prev_close IS NULL THEN NULL
+            ELSE greatest(high::float8 - low::float8,
+                          abs(high::float8 - prev_close::float8),
+                          abs(low::float8 - prev_close::float8)) END AS tr
+FROM b
+ORDER BY k, d
+"""
+
+
+def _bar_sql(table: str, key: str, date_column: str) -> pgsql.Composed:
+    """Per-bar OHLCV plus Postgres' own true range and prior-20 high.
+
+    Composed through ``psycopg.sql`` rather than an f-string: the table and key
+    vary per corpus, and a frame offset cannot be a query parameter, so the two
+    kinds of interpolation are separated — ``Identifier`` for names, ``Literal``
+    for the lookback — instead of pasted into one string.
+    """
+    return pgsql.SQL(_BAR_TEMPLATE).format(
+        table=pgsql.Identifier(table),
+        key=pgsql.Identifier(key),
+        date_column=pgsql.Identifier(date_column),
+        lookback=pgsql.Literal(BREAKOUT_LOOKBACK),
+    )
+
+
+CORPORA = (
+    ("research_price_daily", _bar_sql("research_price_daily", "series_id", "bar_date")),
+    ("price_daily", _bar_sql("price_daily", "instrument_id", "price_date")),
+)
+
+
+def _wilder_from_true_ranges(trs: list[float | None]) -> tuple[list[float | None], int]:
+    """Wilder ATR from SQL's true ranges, plus the index the tail refusal starts.
+
+    ⚠ Re-implemented rather than SQL-derived — see the module docstring for what
+    that does and does not buy. The HORIZON logic is the part worth having twice:
+    the first NULL true range at or after index 1 ends the series for ATR
+    purposes, because Wilder smoothing carries state and has no window for a hole
+    to clear. Written here from §4's data requirement rather than copied.
+    """
+    n = len(trs)
+    values: list[float | None] = [None] * n
+    first_null = next((i for i in range(1, n) if trs[i] is None), None)
+    horizon = n if first_null is None else first_null
+    if horizon <= ATR_PERIOD:
+        return values, horizon
+    window = [t for t in trs[1 : ATR_PERIOD + 1] if t is not None]
+    current = sum(window) / ATR_PERIOD
+    values[ATR_PERIOD] = current
+    for i in range(ATR_PERIOD + 1, horizon):
+        tr = trs[i]
+        assert tr is not None
+        current = (current * (ATR_PERIOD - 1) + tr) / ATR_PERIOD
+        values[i] = current
+    return values, horizon
+
+
+def _reference_verdicts(
+    closes: list[Decimal | None],
+    atr: list[float | None],
+    horizon: int,
+    prior_high: list[Decimal | None],
+) -> list[str]:
+    """The verdict per bar, from the re-derived inputs only.
+
+    Mirrors 3a's runner precedence without sharing a line of its code: the last
+    bar has no ``t+1``; then a data refusal; then warm-up; then the two strict
+    comparisons.
+    """
+    n = len(closes)
+    out: list[str] = []
+    for i in range(n):
+        if i == n - 1:
+            out.append("not_evaluable")
+            continue
+        window_start = i - COMPRESSION_WINDOW + 1
+        # A data refusal: the close itself, the ATR tail after a hole, or a
+        # 20-bar frame that Postgres refused because it held a NULL close.
+        holed = closes[i] is None or i >= horizon or (i >= BREAKOUT_LOOKBACK and prior_high[i] is None)
+        if holed:
+            out.append("not_evaluable")
+            continue
+        if window_start < 0 or atr[window_start] is None or atr[i] is None or i < BREAKOUT_LOOKBACK:
+            out.append("not_evaluable")
+            continue
+        window = [v for v in atr[window_start : i + 1] if v is not None]
+        current = atr[i]
+        assert current is not None
+        # ⚠ A DIFFERENT DERIVATION: in a sorted window the index of the first
+        # occurrence of `current` IS the count of values strictly below it.
+        rank = sorted(window).index(current) / len(window)
+        close, high = closes[i], prior_high[i]
+        assert close is not None and high is not None
+        out.append("fired" if (rank < COMPRESSION_QUANTILE and close > high) else "not_fired")
+    return out
+
+
+def _relative(a: Decimal, b: Decimal) -> float:
+    scale = max(abs(float(b)), 1e-12)
+    return abs(float(a) - float(b)) / scale
+
+
+class _Tally:
+    """⚠ A COUNTER PLUS A BOUNDED SAMPLE, never a list padded to keep a count.
+
+    The idiom this replaces appended an empty string past the printed cap purely
+    so ``len()`` stayed right, which grows an unbounded list of nothing. Both
+    kinds route through ``record`` so the count and the sample cannot drift apart.
+    """
+
+    SAMPLE_CAP = 20
+
+    def __init__(self) -> None:
+        self.series = 0
+        self.bars = 0
+        self.atr_mismatches = 0
+        self.atr_sample: list[str] = []
+        self.verdict_mismatches = 0
+        self.verdict_sample: list[str] = []
+        self.ties = 0
+        self.max_tie_margin = 0.0
+        self.min_real_margin = float("inf")
+
+    def record_atr(self, problem: str) -> None:
+        self.atr_mismatches += 1
+        if len(self.atr_sample) < self.SAMPLE_CAP:
+            self.atr_sample.append(problem)
+
+    def record_verdict(self, problem: str) -> None:
+        self.verdict_mismatches += 1
+        if len(self.verdict_sample) < self.SAMPLE_CAP:
+            self.verdict_sample.append(problem)
+
+
+def _compare(
+    key: int,
+    dates: list[date],
+    rows: list[OHLCVRow],
+    trs: list[float | None],
+    prior_high_sql: list[Decimal | None],
+    tally: _Tally,
+) -> None:
+    """One series: strategy verdicts against the re-derivation, bar by bar."""
+    lengths = {
+        "dates": len(dates),
+        "rows": len(rows),
+        "trs": len(trs),
+        "prior_high_sql": len(prior_high_sql),
+    }
+    # ⚠ ENFORCED, NOT ASSUMED. The comparison loop indexes all four by the same
+    # `i`, and the alignment they rest on is a promise each producer keeps rather
+    # than something any of them validates. A trimmed list would surface as an
+    # IndexError naming the wrong thing instead of as the alignment defect this
+    # arm exists to catch (#2240 round 3 on S-3).
+    if len(set(lengths.values())) != 1:
+        raise RuntimeError(f"series {key} is misaligned across the two derivations: {lengths}")
+
+    series = BarSeries(dates=tuple(dates), rows=tuple(rows))
+    signals = s4_signals(series, universe=UNIVERSE, masked_reason="quarantined_bar")
+    closes = series.closes
+
+    atr_ref, horizon = _wilder_from_true_ranges(trs)
+    atr_python = atr_series(series, universe=UNIVERSE, period=ATR_PERIOD).values
+    prior_high_python = prior_high_close_series(series, universe=UNIVERSE).values
+
+    tally.series += 1
+    tally.bars += len(series)
+
+    # ⚠ The ATR is compared BIT-FOR-BIT, values not verdicts. Both sides are
+    # float64 in the same order, so any difference is logic, never rounding.
+    for i in range(len(series)):
+        if atr_ref[i] != atr_python[i] and tally.atr_mismatches < 10_000:
+            tally.record_atr(f"{key} {dates[i]}: python={atr_python[i]!r} sql-derived={atr_ref[i]!r}")
+
+    # The prior-20 high is Postgres' frame against our slice — exact on both.
+    for i in range(len(series)):
+        high_sql = prior_high_sql[i]
+        want = None if high_sql is None else float(high_sql)
+        if want != prior_high_python[i] and tally.atr_mismatches < 10_000:
+            tally.record_atr(f"{key} {dates[i]} prior_high: python={prior_high_python[i]!r} sql={want!r}")
+
+    expected = _reference_verdicts(closes, atr_ref, horizon, prior_high_sql)
+    for i, want in enumerate(expected):
+        got = signals[i].verdict
+        if got == want:
+            continue
+        close, high = closes[i], prior_high_sql[i]
+        margin = float("inf") if close is None or high is None else _relative(close, high)
+        if margin < TIE_TOLERANCE:
+            tally.ties += 1
+            tally.max_tie_margin = max(tally.max_tie_margin, margin)
+            continue
+        tally.min_real_margin = min(tally.min_real_margin, margin)
+        tally.record_verdict(f"{key} {dates[i]}: python={got} reference={want} margin={margin:.3e}")
+
+
+def equivalence() -> int:
+    """Every bar of both corpora: strategy verdict vs the re-derivation."""
+    failures = 0
+    for table, sql in CORPORA:
+        started = time.monotonic()
+        tally = _Tally()
+        print(f"\n[{table}] streaming…", flush=True)
+        with psycopg.connect(settings.database_url) as conn, conn.cursor(name=f"s4_{table}") as cur:
+            cur.itersize = 50_000
+            cur.execute(sql)
+            current: int | None = None
+            dates: list[date] = []
+            rows: list[OHLCVRow] = []
+            trs: list[float | None] = []
+            prior_high_sql: list[Decimal | None] = []
+            for row in cur:
+                key = row[0]
+                if key != current:
+                    if current is not None:
+                        _compare(current, dates, rows, trs, prior_high_sql, tally)
+                        if tally.series % 500 == 0:
+                            print(
+                                f"  {tally.series} series, {tally.bars} bars, "
+                                f"{tally.atr_mismatches} value / {tally.verdict_mismatches} verdict mismatches, "
+                                f"{tally.ties} ties ({time.monotonic() - started:.0f}s)",
+                                flush=True,
+                            )
+                    current, dates, rows, trs, prior_high_sql = key, [], [], [], []
+                dates.append(row[1])
+                rows.append({"open": row[2], "high": row[3], "low": row[4], "close": row[5], "volume": row[6]})
+                prior_high_sql.append(row[7])
+                trs.append(row[8])
+            if current is not None:
+                _compare(current, dates, rows, trs, prior_high_sql, tally)
+
+        print(f"  series                {tally.series}")
+        print(f"  bars                  {tally.bars}")
+        print(f"  ATR + prior-high values compared {2 * tally.bars}")
+        print(f"  VALUE MISMATCHES      {tally.atr_mismatches}")
+        print(f"  verdicts compared     {tally.bars}")
+        print(f"  VERDICT MISMATCHES    {tally.verdict_mismatches}")
+        print(f"  ties (< {TIE_TOLERANCE:g})       {tally.ties}   max margin {tally.max_tie_margin:.3e}")
+        if tally.atr_mismatches or tally.verdict_mismatches:
+            if tally.verdict_mismatches:
+                print(f"  smallest real margin {tally.min_real_margin:.3e}")
+            for problem in tally.atr_sample + tally.verdict_sample:
+                print("   ", problem)
+            failures += 1
+        print(f"  elapsed               {time.monotonic() - started:.1f}s", flush=True)
+    return failures
+
+
+def _stamped_version() -> str:
+    """The strategy version, with the source pinned either side of reading it.
+
+    ⚠ MEASURED, NOT HYPOTHETICAL (2026-08-06, S-1 on this ticket).
+    ``_source_hash`` re-reads the strategy file at CALL time, while Python
+    imported the module once at process start. The probe harness mutates that
+    file, runs a test and restores it; running the two concurrently printed a
+    strategy version belonging to an INJECTED DEFECT next to figures produced by
+    the clean code. A start-of-run vs end-of-run comparison DOES NOT catch it —
+    the mutation is transient and restores itself, so the two ends agree. The
+    check has to BRACKET THE READ, against an anchor taken at import.
+    """
+    if _source_hash() != _SOURCE_AT_IMPORT:
+        raise RuntimeError(f"strategy source moved before stamping (expected {_SOURCE_AT_IMPORT}) — refusing to report")
+    version = s4_identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID).version
+    if _source_hash() != _SOURCE_AT_IMPORT:
+        raise RuntimeError(f"strategy source moved while stamping (expected {_SOURCE_AT_IMPORT}) — refusing to report")
+    return version
+
+
+def census() -> int:
+    """Verdict + refusal distribution over the §4.0 validated universe, masked."""
+    started = time.monotonic()
+    print(f"\n[census] strategy {S4_STRATEGY_ID} version {_stamped_version()}", flush=True)
+
+    with psycopg.connect(settings.database_url) as conn:
+        universe = load_validated_universe(conn)
+        print(f"  validated universe {len(universe)} instruments (US stocks ex-ETF, §4.0)", flush=True)
+        series_ids = [
+            row[0]
+            for row in conn.execute(
+                "SELECT series_id FROM research_price_series WHERE instrument_id = ANY(%(ids)s) ORDER BY series_id",
+                {"ids": list(universe)},
+            ).fetchall()
+        ]
+        print(f"  research series in it {len(series_ids)}", flush=True)
+
+        verdicts: Counter[str] = Counter()
+        reasons: Counter[str] = Counter()
+        bars = 0
+        narrowed = 0
+        tail_refused = 0
+        series_with_a_hole = 0
+        empty = 0
+        range_masked = 0
+        return_masked = 0
+        for n, series_id in enumerate(series_ids, start=1):
+            masked = load_masked_series(conn, series_id)
+            if not masked.bars:
+                empty += 1
+                continue
+            range_masked += masked.range_masked
+            return_masked += masked.return_masked
+            rows: list[OHLCVRow] = [
+                {"open": b.open, "high": b.high, "low": b.low, "close": b.close, "volume": b.volume}  # type: ignore[typeddict-item]
+                for b in masked.bars
+            ]
+            series = BarSeries(dates=tuple(b.bar_date for b in masked.bars), rows=tuple(rows))
+            bars += len(series)
+            for signal in s4_signals(series, universe=UNIVERSE, masked_reason="quarantined_bar"):
+                verdicts[signal.verdict] += 1
+                if signal.reason is not None:
+                    reasons[signal.reason] += 1
+
+            atr = atr_series(series, universe=UNIVERSE, period=ATR_PERIOD)
+            prior_high = prior_high_close_series(series, universe=UNIVERSE)
+            compression = compression_rank_series(atr, universe=UNIVERSE)
+
+            # The narrowing, counted rather than asserted harmless: bars whose
+            # breakout leg is warm AND evaluable while the compression window is
+            # still filling. §3.1 makes evaluability a property of the STRATEGY,
+            # so those bars are refused although one leg could have been judged.
+            #
+            # ⚠ COUNTED PER BAR, not as `WARMUP_BARS - BREAKOUT_LOOKBACK` per
+            # series. The closed form is right only on a series with no holes,
+            # and this arm runs on MASKED bars by definition — a hole inside the
+            # 20-bar frame makes the breakout leg a data refusal rather than a
+            # narrowed one, and the closed form counts it anyway. Same per-bar
+            # shape as `verify_2240_s1_momentum.py`.
+            narrowed += sum(
+                1
+                for i in range(len(series) - 1)
+                if prior_high.values[i] is not None
+                and compression.values[i] is None
+                and i not in compression.not_evaluable_indices
+            )
+
+            # ⚠ S-4's OWN BIAS, with no S-1 equivalent: bars refused ONLY because
+            # a masked bar EARLIER in the series killed the Wilder recursion,
+            # while the 20-bar breakout frame had already recovered and the bar's
+            # own OHLC is complete. All three of high/low/close are required —
+            # without them the refusal is the bar's own, not inherited.
+            if atr.not_evaluable_indices:
+                series_with_a_hole += 1
+                bad = set(atr.not_evaluable_indices)
+                tail_refused += sum(
+                    1
+                    for i in range(WARMUP_BARS, len(series) - 1)
+                    if i in bad
+                    and prior_high.values[i] is not None
+                    and rows[i]["close"] is not None
+                    and rows[i]["high"] is not None
+                    and rows[i]["low"] is not None
+                )
+            if n % 500 == 0:
+                print(f"  {n}/{len(series_ids)} series, {bars} bars ({time.monotonic() - started:.0f}s)", flush=True)
+
+    total = sum(verdicts.values())
+    print(f"  series with bars  {len(series_ids) - empty}   (fail-closed empties: {empty})")
+    print(f"  bars              {bars}")
+    print(f"  masked fields     range {range_masked} · return {return_masked}")
+    for verdict in ("fired", "not_fired", "not_evaluable"):
+        count = verdicts[verdict]
+        share = 100.0 * count / total if total else 0.0
+        print(f"      {verdict:<16} {count:>12,}  {share:6.3f}%")
+    for reason, count in sorted(reasons.items()):
+        print(f"        reason {reason:<20} {count:>12,}")
+    print(f"  bars narrowed by the shared warm-up:            {narrowed:,}")
+    print(f"  series carrying a masked bar:                   {series_with_a_hole:,}")
+    print(f"  bars refused by the ATR tail alone:             {tail_refused:,}")
+    print(f"  elapsed           {time.monotonic() - started:.1f}s", flush=True)
+    # A census reports; it has no pass/fail of its own beyond running clean.
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--equivalence", action="store_true", help="both corpora, raw bars, vs a re-derivation")
+    parser.add_argument("--census", action="store_true", help="validated universe, masked bars, verdict distribution")
+    parser.add_argument("--all", action="store_true")
+    args = parser.parse_args()
+    if not (args.equivalence or args.census or args.all):
+        parser.error("pick at least one arm: --equivalence, --census or --all")
+
+    failures = 0
+    if args.equivalence or args.all:
+        failures += equivalence()
+    if args.census or args.all:
+        failures += census()
+    print(f"\nverdict: {'*** FAIL ***' if failures else 'PASS'}", flush=True)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_strategy_s4.py
+++ b/tests/test_strategy_s4.py
@@ -1,0 +1,690 @@
+"""S-4 volatility compression breakout — the catalogue's third strategy (#2240).
+
+Spec: ``docs/proposals/ta/strategy-catalogue-and-backtest-validity.md`` §4
+(S-4), §3.5, §4.0, §5 criteria 4/8/11. Registry: phase 3a.
+
+⚠ WHAT THE REFERENCE DERIVES INDEPENDENTLY, AND WHAT IT DOES NOT.
+``_reference_verdicts`` re-derives the two legs by DIFFERENT ALGORITHMS from the
+module's: the compression rank comes from ``sorted(window).index(value)`` (the
+position of the first occurrence in a sorted window IS the count strictly below)
+against the module's count-of-comparisons, and the prior high from ``max()`` over
+an explicit slice. The refusal bookkeeping — which index is a data refusal, which
+is warm-up, and their precedence — is written out here independently too.
+
+⚠ The ATR itself is NOT independently derived, and saying so is the point. The
+Wilder recursion has no naive alternative that is bit-exact, and an approximate
+one would make every boundary fixture below unreliable. ``atr_series`` is pinned
+by ``tests/test_indicator_series.py``; what is checked HERE is the composition on
+top of it. The reference calls it with a LITERAL period rather than
+``ATR_PERIOD``, so a changed constant still fails.
+
+Pure tier: no database, no fixtures, no IO.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+import app.services.strategies.s4_volatility_compression_breakout as s4_module
+from app.services.indicator_series import BarSeries, IndicatorSeries, atr_series
+from app.services.signal_ledger import resolve_fills
+from app.services.strategies.s4_volatility_compression_breakout import (
+    ATR_PERIOD,
+    BREAKOUT_LOOKBACK,
+    COMPRESSION_QUANTILE,
+    COMPRESSION_WINDOW,
+    S4_PARAMS,
+    S4_STRATEGY_ID,
+    WARMUP_BARS,
+    compression_rank_series,
+    prior_high_close_series,
+    s4_identity,
+    s4_signals,
+)
+from app.services.strategy_registry import StrategySignal
+from app.services.technical_analysis import OHLCVRow
+
+UNIVERSE = "survivor_only"
+REASON = "quarantined_bar"
+
+#: ⚠⚠ §4's NUMBERS, TRANSCRIBED BY HAND. Nothing below imports the module's
+#: constants for an expected value — the reference must not move when the code
+#: does, or the comparison is a tautology. Measured on this branch:
+#: `scripts/probe_2240_s4_volatility_breakout.py` reported `*** NOT CAUGHT ***`
+#: for BOTH "window 100 -> 50" and "lookback 20 -> 10" while the reference
+#: imported them. Same defect S-3 hit the same day (prevention log) — two of the
+#: three strategies, which makes it the default mistake rather than a slip.
+#:
+#: The rule, verbatim: *"Setup: atr_14(t) sits in the bottom quartile of its own
+#: trailing 100-bar distribution … Signal: close(t) > the highest close of bars
+#: t-20 .. t-1 … Exit: stop at entry - 2 x atr_14(t), profit target at
+#: entry + 3 x atr_14(t), hard max-hold 40 bars."*
+#:
+#: ⚠ Scope: this binds numbers an ASSERTION depends on. Using the module's
+#: constant as scaffolding — sizing a window, indexing a warm-up boundary — is
+#: fine, and `TestSpecConstants` is what keeps the two in step.
+SPEC_ATR_PERIOD = 14
+SPEC_COMPRESSION_WINDOW = 100
+SPEC_COMPRESSION_QUANTILE = 0.25
+SPEC_BREAKOUT_LOOKBACK = 20
+SPEC_ATR_STOP_MULTIPLE = 2.0
+SPEC_ATR_TARGET_MULTIPLE = 3.0
+SPEC_MAX_HOLD_BARS = 40
+
+
+def _bars(closes: Sequence[float | None], half_ranges: Sequence[float] | None = None) -> BarSeries:
+    """One bar per close, ``high = close + h`` and ``low = close - h``.
+
+    ``half_ranges`` is what lets a fixture drive the ATR directly — S-1 and S-3
+    read closes only, so their helper could pin the range at 1.0. S-4's setup leg
+    is a statement about bar RANGES, so a fixture that cannot vary them cannot
+    exercise it. ``None`` is a MASKED bar, as ``load_masked_series`` produces:
+    every field present and empty, not absent.
+    """
+    spans = [1.0] * len(closes) if half_ranges is None else list(half_ranges)
+    assert len(spans) == len(closes), "half_ranges must align with closes"
+    rows: list[OHLCVRow] = [
+        {
+            "open": None if c is None else Decimal(str(c)),
+            "high": None if c is None else Decimal(str(c + h)),
+            "low": None if c is None else Decimal(str(c - h)),
+            "close": None if c is None else Decimal(str(c)),
+            "volume": 1_000,
+        }  # type: ignore[typeddict-item]
+        for c, h in zip(closes, spans, strict=True)
+    ]
+    start = date(2020, 1, 1)
+    return BarSeries(dates=tuple(start + timedelta(days=i) for i in range(len(closes))), rows=tuple(rows))
+
+
+def _reference_verdicts(
+    closes: Sequence[float | None],
+    half_ranges: Sequence[float] | None = None,
+) -> list[tuple[str, str | None]]:
+    """(verdict, reason) per bar, re-derived independently of the module.
+
+    Mirrors 3a's runner precedence exactly: the last bar has no ``t+1``; then a
+    data refusal on ANY declared input; then warm-up; and only then is the
+    condition asked.
+    """
+    # ⚠ The SPEC_* literals, never the module's constants — see their comment.
+    period = SPEC_ATR_PERIOD
+    compression_window = SPEC_COMPRESSION_WINDOW
+    breakout_lookback = SPEC_BREAKOUT_LOOKBACK
+    quantile = SPEC_COMPRESSION_QUANTILE
+
+    series = _bars(closes, half_ranges)
+    atr = atr_series(series, universe=UNIVERSE, period=period)
+    atr_bad = set(atr.not_evaluable_indices)
+    n = len(closes)
+
+    out: list[tuple[str, str | None]] = []
+    for i in range(n):
+        if i == n - 1:
+            out.append(("not_evaluable", "no_fill_bar"))
+            continue
+
+        # --- data refusals, over every declared input -----------------------
+        compression_window_holed = i + 1 >= compression_window and any(
+            j in atr_bad for j in range(i - compression_window + 1, i + 1)
+        )
+        breakout_window_holed = i >= breakout_lookback and any(
+            closes[j] is None for j in range(i - breakout_lookback, i)
+        )
+        if closes[i] is None or i in atr_bad or compression_window_holed or breakout_window_holed:
+            out.append(("not_evaluable", REASON))
+            continue
+
+        # --- warm-up ---------------------------------------------------------
+        window_ready = i + 1 >= compression_window and all(
+            atr.values[j] is not None for j in range(i - compression_window + 1, i + 1)
+        )
+        if not window_ready or i < breakout_lookback:
+            out.append(("not_evaluable", "insufficient_warmup"))
+            continue
+
+        # --- the rule --------------------------------------------------------
+        window = [atr.values[j] for j in range(i - compression_window + 1, i + 1)]
+        current = atr.values[i]
+        assert current is not None
+        # ⚠ A DIFFERENT DERIVATION of the same number: in a sorted window the
+        # index of the first occurrence of `current` IS the count strictly below.
+        rank = sorted(w for w in window if w is not None).index(current) / len(window)
+        prior_high = max(w for w in closes[i - breakout_lookback : i] if w is not None)
+        close = closes[i]
+        assert close is not None
+        fired = rank < quantile and close > prior_high
+        out.append(("fired" if fired else "not_fired", None))
+    return out
+
+
+def _run(closes: Sequence[float | None], half_ranges: Sequence[float] | None = None) -> list[StrategySignal]:
+    return s4_signals(_bars(closes, half_ranges), universe=UNIVERSE, masked_reason=REASON)
+
+
+N = 300
+
+#: Rising by a constant step with a constant bar range, so EVERY true range is
+#: identical and the ATR is exactly constant. That makes it the degenerate
+#: all-ties window the module docstring describes: rank is 0.0 on every bar, so
+#: the setup leg holds everywhere and only the breakout leg decides.
+RISING: list[float | None] = [100.0 + i for i in range(N)]
+
+#: Constant price. Also a constant ATR (the range is fixed), so the setup leg
+#: holds everywhere here too — and NOTHING fires, because a flat series cannot
+#: put a close strictly above its own prior 20. This pair is the module
+#: docstring's claim that the conjunction defuses the degenerate case.
+FLAT: list[float | None] = [100.0] * N
+
+
+def _ramps(*legs: tuple[int, float, float]) -> list[float]:
+    """Piecewise-linear closes: ``(bars, start, step)`` per leg."""
+    out: list[float] = []
+    for bars, start, step in legs:
+        out.extend(start + step * k for k in range(bars))
+    return out
+
+
+def _spans(*legs: tuple[int, float]) -> list[float]:
+    """Piecewise-constant half-ranges: ``(bars, half_range)`` per leg."""
+    out: list[float] = []
+    for bars, half_range in legs:
+        out.extend([half_range] * bars)
+    return out
+
+
+#: ⚠ THE FIXTURE THAT HAS TO COVER ALL FOUR CONJUNCT COMBINATIONS, asserted
+#: below rather than hoped for. Volatile and quiet stretches drive the ATR up and
+#: down so the compression rank crosses 0.25 in both directions, while the closes
+#: rise and fall so the breakout leg does too. A fixture missing the
+#: (compression false, breakout true) quadrant passes a rule with the setup leg
+#: deleted, which is S-1's lesson applied to S-4's pair.
+CYCLE_CLOSES: list[float | None] = [
+    *_ramps((60, 100.0, 3.0), (60, 280.0, -3.0), (60, 100.0, 0.2), (60, 112.0, -0.2), (60, 100.0, 1.0))
+]
+CYCLE_SPANS: list[float] = _spans((60, 8.0), (60, 8.0), (60, 0.4), (60, 0.4), (60, 2.0))
+
+
+#: Monotonically widening bar ranges against a FLAT close, so ``TR = 2h`` exactly
+#: and the ATR is strictly increasing — every warm bar is then the maximum of its
+#: own trailing window.
+RISING_ATR_SPANS: list[float] = [1.0 + 0.1 * i for i in range(N)]
+
+#: The bar the constructed quartile boundary lands on.
+BOUNDARY_INDEX = 150
+
+
+def _quartile_boundary() -> tuple[list[float | None], list[float]]:
+    """A series whose bar 150 sits EXACTLY on the quartile — by construction.
+
+    ⚠ CONSTRUCTED, NOT SEARCHED FOR, and the difference is robustness. Searching
+    a wandering fixture for ``rank == 0.25`` finds knife-edge bars that a
+    one-ULP change relocates (measured: the widest search over piecewise-constant
+    volatility fixtures yielded ONE such bar with the breakout leg also true).
+    This construction yields a whole INTERVAL of valid spike sizes instead.
+
+    It works because a flat close makes the true range exactly ``2h``: with the
+    close unchanged bar to bar, ``TR = max(2h, |Δ|+h) = 2h``. So a long stretch
+    at constant ``h`` seeds Wilder on ``2h`` and holds it there EXACTLY —
+
+        bars 0..124   h=5.0   -> TR 10 -> ATR exactly 10.0 from bar 14
+        bars 125..149 h=0.5   -> TR 1  -> ATR decays monotonically to ~2.41
+        bar  150      h=52.0  -> TR 104, and the close jumps 100 -> 105
+
+    Bar 150's window is bars 51..150: seventy-four at exactly 10.0, twenty-five
+    decaying, and bar 150 itself. Any spike putting ``atr(150)`` strictly between
+    the highest quiet value (``131/14 = 9.3571…``) and the loud plateau (10.0)
+    gives a below-count of exactly 25, hence ``rank = 25/100 = 0.25`` — exact in
+    binary float. ``h = 52.0`` lands it at ~9.6677, roughly mid-interval, so the
+    fixture has margin on both sides rather than sitting on an edge.
+
+    ⚠ ``|Δ| = 5`` at the spike is well inside ``h = 52``, so the jump does not
+    disturb ``TR = 2h`` — which is what keeps the arithmetic above exact.
+    """
+    closes: list[float | None] = []
+    spans: list[float] = []
+    for i in range(N):
+        if i <= 124:
+            closes.append(100.0)
+            spans.append(5.0)
+        elif i <= 149:
+            closes.append(100.0)
+            spans.append(0.5)
+        elif i == BOUNDARY_INDEX:
+            closes.append(105.0)
+            spans.append(52.0)
+        else:
+            closes.append(105.0)
+            spans.append(0.5)
+    return closes, spans
+
+
+class TestTheRule:
+    """§4: ``atr_14(t)`` in the bottom quartile of its trailing 100, AND
+    ``close(t)`` above the highest close of the prior 20."""
+
+    @pytest.mark.parametrize(
+        ("closes", "spans"),
+        [(RISING, None), (FLAT, None), (CYCLE_CLOSES, CYCLE_SPANS)],
+        ids=["rising", "flat", "cycle"],
+    )
+    def test_every_bar_matches_the_naive_reference(
+        self, closes: Sequence[float | None], spans: Sequence[float] | None
+    ) -> None:
+        signals = _run(closes, spans)
+        expected = _reference_verdicts(closes, spans)
+        assert len(signals) == len(closes)
+        for i, (verdict, reason) in enumerate(expected):
+            assert (signals[i].verdict, signals[i].reason) == (verdict, reason), f"bar {i}"
+
+    def test_the_cycle_fixture_exercises_both_outcomes(self) -> None:
+        """Guards the table test from passing vacuously."""
+        signals = _run(CYCLE_CLOSES, CYCLE_SPANS)
+        assert {"fired", "not_fired"} <= {s.verdict for s in signals}
+
+    def test_the_cycle_fixture_covers_all_four_conjunct_combinations(self) -> None:
+        """⚠ WITHOUT THIS THE TABLE TEST CANNOT SEE A DROPPED CONJUNCT.
+
+        Either leg alone agrees with the pair on every bar except those in its
+        own off-quadrant, so a fixture missing a quadrant passes a rule with that
+        leg deleted."""
+        series = _bars(CYCLE_CLOSES, CYCLE_SPANS)
+        atr = atr_series(series, universe=UNIVERSE, period=ATR_PERIOD)
+        compression = compression_rank_series(atr, universe=UNIVERSE)
+        prior_high = prior_high_close_series(series, universe=UNIVERSE)
+        closes = series.float_closes
+
+        combinations = set()
+        for i in range(WARMUP_BARS, len(CYCLE_CLOSES) - 1):
+            rank, high, close = compression.values[i], prior_high.values[i], closes[i]
+            assert rank is not None and high is not None and close is not None
+            combinations.add((rank < COMPRESSION_QUANTILE, close > high))
+        assert combinations == {(True, True), (True, False), (False, True), (False, False)}
+
+    def test_a_constant_atr_ramp_fires_every_warm_bar(self) -> None:
+        """⚠ THE DEGENERATE ALL-TIES WINDOW, asserted rather than argued.
+
+        Every true range on ``RISING`` is identical, so all 100 window ATRs are
+        equal and the count STRICTLY below today's is 0 — rank 0.0, setup holds.
+        A ``<=`` count would make the rank 1.0 here and fire nothing."""
+        series = _bars(RISING)
+        atr = atr_series(series, universe=UNIVERSE, period=ATR_PERIOD)
+        warm = [v for v in atr.values[ATR_PERIOD:] if v is not None]
+        assert len(set(warm)) == 1, "fixture drifted: the ATR is meant to be exactly constant"
+
+        signals = _run(RISING)
+        assert [s.verdict for s in signals[WARMUP_BARS:-1]] == ["fired"] * (N - WARMUP_BARS - 1)
+
+    def test_a_flat_series_never_fires(self) -> None:
+        """The other half of the same claim: the setup leg holds on every bar of
+        a flat series too (constant ATR), and the CONJUNCTION is what stops it —
+        a flat close cannot sit strictly above its own prior 20."""
+        series = _bars(FLAT)
+        atr = atr_series(series, universe=UNIVERSE, period=ATR_PERIOD)
+        compression = compression_rank_series(atr, universe=UNIVERSE)
+        assert compression.values[WARMUP_BARS] == 0.0, "the setup leg is meant to HOLD here"
+
+        signals = _run(FLAT)
+        assert not any(s.verdict == "fired" for s in signals)
+
+
+class TestCompressionRankRule:
+    """The rank rule itself, on synthetic ATRs — exact, and free of Wilder drift.
+
+    ⚠ "Bottom quartile" has no published formulation, so the module fixes it by
+    construction (see its docstring). These are the tests that pin the
+    construction: the k=25/k=26 boundary, and favourable tie handling.
+    """
+
+    @staticmethod
+    def _atr(values: Sequence[float]) -> IndicatorSeries:
+        return IndicatorSeries(tuple(values), UNIVERSE)
+
+    def test_the_kth_smallest_of_a_hundred_is_in_the_quartile_up_to_k_25(self) -> None:
+        """With 100 distinct values the k-th smallest has ``k-1`` strictly below,
+        so ``rank = (k-1)/100`` and ``rank < 0.25`` holds for exactly k <= 25 —
+        the bottom 25 of 100, which is what "bottom quartile" must mean."""
+        ordered = [float(v) for v in range(1, COMPRESSION_WINDOW + 1)]
+        for k, target in ((25, 25.0), (26, 26.0)):
+            # Put the k-th smallest LAST so it is the ranked bar, keeping the
+            # window's contents identical between the two cases.
+            window = [v for v in ordered if v != target] + [target]
+            rank = compression_rank_series(self._atr(window), universe=UNIVERSE).values[-1]
+            assert rank == (k - 1) / COMPRESSION_WINDOW
+        rank_25 = compression_rank_series(
+            self._atr([v for v in ordered if v != 25.0] + [25.0]), universe=UNIVERSE
+        ).values[-1]
+        rank_26 = compression_rank_series(
+            self._atr([v for v in ordered if v != 26.0] + [26.0]), universe=UNIVERSE
+        ).values[-1]
+        assert rank_25 is not None and rank_26 is not None
+        assert rank_25 < COMPRESSION_QUANTILE, "the 25th smallest of 100 is in the bottom quartile"
+        assert not rank_26 < COMPRESSION_QUANTILE, "the 26th smallest of 100 is not"
+
+    def test_the_boundary_rank_is_exactly_representable(self) -> None:
+        """``rank == 0.25`` iff exactly 25 of 100 sit below — an INTEGER
+        condition, and ``25/100`` is exact in binary float. So the boundary
+        fixtures below compare exactly rather than approximately."""
+        window = [float(v) for v in range(1, COMPRESSION_WINDOW + 1)]
+        window = [v for v in window if v != 26.0] + [26.0]
+        assert compression_rank_series(self._atr(window), universe=UNIVERSE).values[-1] == COMPRESSION_QUANTILE
+
+    def test_tied_values_all_receive_the_same_rank(self) -> None:
+        """⚠ FORCED, NOT CHOSEN. Counting ``<=`` would make two bars with
+        IDENTICAL ATRs in the same window rank differently according to their
+        position, i.e. read arbitrary order as signal."""
+        window = [1.0] * 40 + [float(v) for v in range(2, 62)]
+        ranks = []
+        for tied_position in range(3):
+            rotated = [v for v in window if v != 1.0]
+            rotated = [1.0] * 39 + rotated[: 21 + tied_position] + [1.0] + rotated[21 + tied_position :]
+            assert len(rotated) == COMPRESSION_WINDOW
+            ranks.append(compression_rank_series(self._atr(rotated), universe=UNIVERSE).values[-1])
+        assert len(set(ranks)) == 1
+
+    def test_the_window_includes_the_ranked_bar(self) -> None:
+        """§4: *"computed on bars <= t"*. With ``t`` excluded the divisor and the
+        contents both change; here the ranked value is the window MAXIMUM, so
+        including it gives ``99/100`` and excluding it would give ``99/99``."""
+        window = [float(v) for v in range(1, COMPRESSION_WINDOW)] + [1_000.0]
+        assert compression_rank_series(self._atr(window), universe=UNIVERSE).values[-1] == 0.99
+
+
+class TestStrictComparisons:
+    """§4 writes both comparisons strictly. ⚠ ONE EXACT-EQUALITY FIXTURE PER
+    OPERATOR — a fixture that is degenerate on both pins NEITHER, because
+    relaxing one leaves the other conjunct false and the probe reports NOT
+    CAUGHT. That is the S-3 lesson, already in the prevention log."""
+
+    @staticmethod
+    def _quiet_after_volatile() -> tuple[list[float | None], list[float]]:
+        """A volatile first half then a long quiet tail, so the recent ATRs are
+        the smallest of their trailing 100 and the setup leg holds in the tail."""
+        closes: list[float | None] = [*_ramps((80, 100.0, 4.0), (80, 420.0, -4.0), (140, 100.0, 0.05))]
+        spans = _spans((160, 12.0), (140, 0.2))
+        return closes, spans
+
+    def test_a_close_exactly_on_the_prior_high_does_not_fire(self) -> None:
+        """Pins the breakout leg's ``>``. The setup leg is strictly true here, so
+        a ``>=`` on the breakout is the only thing that could fire this bar."""
+        closes, spans = self._quiet_after_volatile()
+        i = 260
+        prior = [c for c in closes[i - BREAKOUT_LOOKBACK : i] if c is not None]
+        closes[i] = max(prior)
+
+        series = _bars(closes, spans)
+        atr = atr_series(series, universe=UNIVERSE, period=ATR_PERIOD)
+        compression = compression_rank_series(atr, universe=UNIVERSE)
+        prior_high = prior_high_close_series(series, universe=UNIVERSE)
+        rank = compression.values[i]
+        # ⚠ Asserted, not assumed: if the fixture drifts off the boundary or out
+        # of the compressed regime the test would pass while testing nothing.
+        assert rank is not None and rank < COMPRESSION_QUANTILE, "setup leg must be strictly true"
+        assert closes[i] == prior_high.values[i], "the breakout comparison must be an exact equality"
+
+        assert _run(closes, spans)[i].verdict == "not_fired"
+
+    def test_a_compression_rank_exactly_on_the_quartile_does_not_fire(self) -> None:
+        """Pins the setup leg's ``<``, on a CONSTRUCTED boundary rather than a
+        found one — see ``_quartile_boundary``. The breakout leg is strictly true
+        here, so a ``<=`` on the setup is the only thing that could fire it."""
+        closes, spans = _quartile_boundary()
+        series = _bars(closes, spans)
+        atr = atr_series(series, universe=UNIVERSE, period=ATR_PERIOD)
+        compression = compression_rank_series(atr, universe=UNIVERSE)
+        prior_high = prior_high_close_series(series, universe=UNIVERSE)
+        i = BOUNDARY_INDEX
+
+        # ⚠ Asserted, not assumed. Every one of these can drift silently, and
+        # each would leave the test passing while testing nothing.
+        window = [atr.values[j] for j in range(i - COMPRESSION_WINDOW + 1, i + 1)]
+        assert {v for v in window[:74]} == {10.0}, "the loud plateau must be exactly flat"
+        assert compression.values[i] == COMPRESSION_QUANTILE, "the setup comparison must be an exact equality"
+        close, high = closes[i], prior_high.values[i]
+        assert close is not None and high is not None and close > high, "breakout leg must be strictly true"
+
+        assert _run(closes, spans)[i].verdict == "not_fired"
+
+
+class TestWindowBoundaries:
+    """§4 gives the two legs DIFFERENT boundaries on purpose."""
+
+    def test_the_breakout_window_excludes_the_signal_bar(self) -> None:
+        """Including ``t`` makes ``close(t) > max(...including close(t))``
+        satisfiable only by a tie, i.e. never under a strict ``>`` — the rule
+        would silently never fire rather than fail. Any fire at all falsifies
+        the inclusive reading."""
+        series = _bars(CYCLE_CLOSES, CYCLE_SPANS)
+        prior_high = prior_high_close_series(series, universe=UNIVERSE)
+        closes = series.float_closes
+        i = WARMUP_BARS + 5
+        assert prior_high.values[i] == max(c for c in closes[i - BREAKOUT_LOOKBACK : i] if c is not None)
+        assert any(s.verdict == "fired" for s in _run(CYCLE_CLOSES, CYCLE_SPANS))
+
+    def test_the_compression_rank_can_never_reach_one(self) -> None:
+        """§4: *"computed on bars <= t"* — the window CONTAINS the ranked bar, so
+        at most 99 of its 100 values can be strictly below and the rank tops out
+        at 0.99. An exclusive window (``t-100 .. t-1``) has no such ceiling: its
+        100 values are all other bars, so a new ATR high scores a full 1.0.
+
+        Pinned on a strictly-rising ATR, where EVERY warm bar is its own window's
+        maximum — so the ceiling is exercised on every bar rather than sampled.
+        ``RISING_ATR_SPANS`` widens the bar range monotonically, and a flat close
+        makes ``TR = 2h`` exactly, so the ATR is strictly increasing by
+        construction (asserted below)."""
+        atr = atr_series(_bars(FLAT, RISING_ATR_SPANS), universe=UNIVERSE, period=ATR_PERIOD)
+        warm = [v for v in atr.values[ATR_PERIOD:] if v is not None]
+        assert all(b > a for a, b in zip(warm, warm[1:], strict=False)), "fixture drifted: ATR must be rising"
+
+        ranks = [v for v in compression_rank_series(atr, universe=UNIVERSE).values if v is not None]
+        assert ranks
+        assert set(ranks) == {0.99}, "every bar is its own window's maximum, so every rank is 99/100"
+
+
+class TestWarmUp:
+    """One warm-up for the whole strategy, derived from the rule."""
+
+    def test_the_warm_up_is_the_atr_seed_plus_the_compression_window(self) -> None:
+        assert WARMUP_BARS == ATR_PERIOD + COMPRESSION_WINDOW - 1 == 113
+
+    def test_the_first_evaluable_bar_is_the_warm_up_boundary(self) -> None:
+        signals = _run(RISING)
+        assert (signals[WARMUP_BARS - 1].verdict, signals[WARMUP_BARS - 1].reason) == (
+            "not_evaluable",
+            "insufficient_warmup",
+        )
+        assert signals[WARMUP_BARS].verdict != "not_evaluable"
+
+    def test_a_bar_with_a_warm_breakout_leg_but_a_cold_atr_is_still_refused(self) -> None:
+        """⚠ THE NARROWING. Bar 40 has 20 prior closes, so the breakout leg IS
+        computable there; it is refused anyway, because per-leg evaluability
+        would make the same bar live for one leg and warming for the other."""
+        cold = BREAKOUT_LOOKBACK + 20
+        assert cold < WARMUP_BARS
+        signals = _run(RISING)
+        assert (signals[cold].verdict, signals[cold].reason) == ("not_evaluable", "insufficient_warmup")
+
+    def test_a_series_shorter_than_the_warm_up_is_never_evaluable(self) -> None:
+        signals = _run(RISING[:100])
+        assert {s.verdict for s in signals} == {"not_evaluable"}
+        assert {s.reason for s in signals} == {"insufficient_warmup", "no_fill_bar"}
+
+
+class TestMissingBars:
+    """Criterion 8: a data gap and a real absence must stay distinguishable."""
+
+    def test_a_masked_bar_records_the_callers_reason_not_warm_up(self) -> None:
+        closes = list(RISING)
+        closes[200] = None
+        signals = _run(closes)
+        assert (signals[200].verdict, signals[200].reason) == ("not_evaluable", REASON)
+
+    def test_a_masked_bar_refuses_the_whole_tail_not_a_window(self) -> None:
+        """⚠ S-4's blast radius, inherited from Wilder smoothing exactly as S-3's
+        is. ``atr_series`` carries state across every bar, so there is no window
+        for the hole to clear — S-1 would have recovered 200 bars later."""
+        closes = list(RISING)
+        closes[150] = None
+        signals = _run(closes)
+        assert all(s.reason == REASON for s in signals[150:-1])
+        assert signals[149].reason != REASON
+
+    def test_a_missing_high_is_refused_rather_than_judged(self) -> None:
+        """§4 requires COMPLETE OHLC. A bar with a good close and no high has a
+        computable breakout leg and an uncomputable ATR."""
+        series = _bars(RISING)
+        rows = list(series.rows)
+        rows[200] = {**rows[200], "high": None}  # type: ignore[typeddict-item]
+        holed = BarSeries(dates=series.dates, rows=tuple(rows))
+        signals = s4_signals(holed, universe=UNIVERSE, masked_reason="series_break")
+        assert (signals[200].verdict, signals[200].reason) == ("not_evaluable", "series_break")
+
+    def test_a_reason_outside_the_closed_vocabulary_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown reason code"):
+            s4_signals(_bars(RISING), universe=UNIVERSE, masked_reason="looked_quiet")  # type: ignore[arg-type]
+
+
+class TestNoExitLeg:
+    """⚠ S-4's structural difference from S-1 and S-3, pinned so a later edit
+    cannot add an exit leg without this failing. All three of §4's exit
+    conditions are measured from the ENTRY, so none is a per-bar verdict."""
+
+    def test_every_signal_is_an_entry(self) -> None:
+        signals = _run(CYCLE_CLOSES, CYCLE_SPANS)
+        assert {s.kind for s in signals} == {"entry"}
+        assert len(signals) == len(CYCLE_CLOSES)
+
+    def test_the_exit_parameters_are_carried_in_the_identity_even_though_unread(self) -> None:
+        """Nothing in the module reads them, so the identity hash is the ONLY
+        thing keeping them attached to the rule."""
+        assert dict(S4_PARAMS)["atr_stop_multiple"] == SPEC_ATR_STOP_MULTIPLE
+        assert dict(S4_PARAMS)["atr_target_multiple"] == SPEC_ATR_TARGET_MULTIPLE
+        assert dict(S4_PARAMS)["max_hold_bars"] == SPEC_MAX_HOLD_BARS
+
+
+class TestLastBar:
+    def test_the_final_bar_is_no_fill_bar(self) -> None:
+        signals = _run(RISING)
+        assert (signals[-1].verdict, signals[-1].reason) == ("not_evaluable", "no_fill_bar")
+
+
+class TestCausality:
+    """Criterion 4: every value at bar ``t`` uses only bars <= ``t``."""
+
+    def test_a_bars_verdict_is_unchanged_when_later_bars_are_removed(self) -> None:
+        full = _run(CYCLE_CLOSES, CYCLE_SPANS)
+        for index in range(WARMUP_BARS, len(CYCLE_CLOSES) - 1, 7):
+            truncated = _run(CYCLE_CLOSES[: index + 2], CYCLE_SPANS[: index + 2])
+            assert truncated[index].verdict == full[index].verdict, f"bar {index}"
+
+    def test_the_truncation_sweep_covers_bars_of_both_verdicts(self) -> None:
+        """A sweep over a stretch where nothing changes cannot detect a
+        look-ahead, so the fixture is asserted to vary across it."""
+        full = _run(CYCLE_CLOSES, CYCLE_SPANS)
+        swept = [full[i].verdict for i in range(WARMUP_BARS, len(CYCLE_CLOSES) - 1, 7)]
+        assert {"fired", "not_fired"} <= set(swept)
+
+
+class TestIdentity:
+    """Criterion 11: identity = code + config + data contract."""
+
+    def test_a_blank_cost_model_id_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            s4_identity(universe=UNIVERSE, cost_model_id="   ")
+
+    def test_the_version_moves_with_the_universe(self) -> None:
+        a = s4_identity(universe="survivor_only", cost_model_id="undeclared-v0")
+        b = s4_identity(universe="survivorship_free", cost_model_id="undeclared-v0")
+        assert a.version != b.version
+
+    def test_the_version_moves_with_the_cost_model(self) -> None:
+        a = s4_identity(universe=UNIVERSE, cost_model_id="undeclared-v0")
+        b = s4_identity(universe=UNIVERSE, cost_model_id="static-p75-v1")
+        assert a.version != b.version
+
+    def test_the_identity_carries_every_parameter_of_the_rule(self) -> None:
+        identity = s4_identity(universe=UNIVERSE, cost_model_id="undeclared-v0")
+        assert identity.strategy_id == S4_STRATEGY_ID
+        assert dict(identity.params) == {
+            "atr_period": SPEC_ATR_PERIOD,
+            "compression_window": SPEC_COMPRESSION_WINDOW,
+            "compression_quantile": SPEC_COMPRESSION_QUANTILE,
+            "breakout_lookback": SPEC_BREAKOUT_LOOKBACK,
+            "atr_stop_multiple": SPEC_ATR_STOP_MULTIPLE,
+            "atr_target_multiple": SPEC_ATR_TARGET_MULTIPLE,
+            "max_hold_bars": SPEC_MAX_HOLD_BARS,
+        }
+        assert dict(S4_PARAMS) == dict(identity.params)
+
+    def test_the_source_hash_is_this_strategys_own_source(self) -> None:
+        """⚠ Recomputed here from the FILE, not compared against the module's own
+        helper: ``source_hash == _source_hash()`` holds just as well when both
+        are a constant, which is the one defect this guards."""
+        import app.services.strategies.s4_volatility_compression_breakout as s4
+
+        expected = hashlib.sha256(Path(s4.__file__).read_bytes()).hexdigest()[:12]
+        assert s4_identity(universe=UNIVERSE, cost_model_id="x").source_hash == expected
+
+
+class TestLedgerRoundTrip:
+    """The signals have to survive 3c's writer, which is where the fill is
+    resolved and where a same-bar fill would surface."""
+
+    def test_every_fired_row_fills_at_the_next_bars_open(self) -> None:
+        series = _bars(CYCLE_CLOSES, CYCLE_SPANS)
+        rows = resolve_fills(
+            s4_signals(series, universe=UNIVERSE, masked_reason=REASON),
+            series=series,
+            identity=s4_identity(universe=UNIVERSE, cost_model_id="undeclared-v0"),
+            instrument_id=1,
+        )
+        fired = [row for row in rows if row.verdict == "fired"]
+        assert fired
+        by_date = {d: i for i, d in enumerate(series.dates)}
+        for row in fired:
+            index = by_date[row.signal_bar_date]
+            assert row.fill_bar_date == series.dates[index + 1]
+            assert row.fill_price == series.rows[index + 1]["open"]
+
+    def test_one_row_per_bar_with_no_key_collision(self) -> None:
+        series = _bars(CYCLE_CLOSES, CYCLE_SPANS)
+        rows = resolve_fills(
+            s4_signals(series, universe=UNIVERSE, masked_reason=REASON),
+            series=series,
+            identity=s4_identity(universe=UNIVERSE, cost_model_id="undeclared-v0"),
+            instrument_id=1,
+        )
+        assert len(rows) == len(CYCLE_CLOSES)
+        keys = {(row.signal_bar_date, row.signal_kind) for row in rows}
+        assert len(keys) == len(rows)
+
+
+class TestSpecConstants:
+    """⚠ The bridge between §4's prose and the module's constants.
+
+    Everything else in this file reasons in ``SPEC_*`` literals, so the reference
+    cannot move when the code does. That independence has a price: nothing would
+    then notice the module quietly using a different number. This class is that
+    notice, and it is the ONLY place the module's constants are read as values.
+
+    Same shape as ``tests/test_strategy_s3.py::TestSpecConstants``, which exists
+    for the same incident.
+    """
+
+    def test_the_modules_constants_are_the_specs_numbers(self) -> None:
+        assert s4_module.ATR_PERIOD == SPEC_ATR_PERIOD
+        assert s4_module.COMPRESSION_WINDOW == SPEC_COMPRESSION_WINDOW
+        assert s4_module.COMPRESSION_QUANTILE == SPEC_COMPRESSION_QUANTILE
+        assert s4_module.BREAKOUT_LOOKBACK == SPEC_BREAKOUT_LOOKBACK
+        assert s4_module.ATR_STOP_MULTIPLE == SPEC_ATR_STOP_MULTIPLE
+        assert s4_module.ATR_TARGET_MULTIPLE == SPEC_ATR_TARGET_MULTIPLE
+        assert s4_module.MAX_HOLD_BARS == SPEC_MAX_HOLD_BARS
+
+    def test_the_warm_up_is_derived_from_the_specs_two_windows(self) -> None:
+        assert s4_module.WARMUP_BARS == SPEC_ATR_PERIOD + SPEC_COMPRESSION_WINDOW - 1


### PR DESCRIPTION
Refs #2240.

Third strategy in the parent catalogue (`docs/proposals/ta/strategy-catalogue-and-backtest-validity.md` §4), a pure function against the phase-3a registry contract. S-1 and S-3 are already in; S-2 is cross-sectional and does not fit the per-bar contract, so S-4 is the next one that does.

**The rule, verbatim from §4.** Setup: `atr_14(t)` sits in the bottom quartile of its own trailing 100-bar distribution, computed on bars ≤ t. Signal: `close(t) >` the highest close of bars `t-20 .. t-1`. Fill at `open(t+1)` — resolved by `signal_ledger`, never by this module, because a `StrategySignal` carries a bar index and has no field through which a fill could be requested.

## Four things §4 left open

**1. "Bottom quartile" has no published formulation, so it is fixed BY CONSTRUCTION and said out loud.**

This is the instruction set's own rule for the case where no source rule exists — Bollinger's Squeeze has a published definition (BandWidth at its lowest in six months), and "ATR in the bottom quartile of its trailing 100" does not; it is this spec's construction, and it states the window and the quartile but not the membership test. Sample quantiles are not one thing (NumPy ships nine interpolation methods), so picking one would put an unstated constant at exactly the boundary where it decides. Membership is therefore a **rank**, which has no interpolation and no free parameter:

```
compression(t) = #{w ∈ W : w < atr_14(t)} / |W|,   W = atr_14[t-99 .. t]
setup holds iff compression(t) < 0.25
```

With 100 distinct values the k-th smallest scores `(k-1)/100`, so exactly the bottom 25 qualify — which is what "bottom quartile" has to mean for the count to come out right.

⚠ **Ties are forced favourable, not chosen.** Counting `w ≤ atr(t)` would make two bars with *identical* ATRs in the *same* window rank differently according to their position — a rule that reads arbitrary order as signal. Counting strictly-below gives every tied value the same verdict.

⚠ The degenerate case is stated rather than left to be discovered: on a window of 100 equal ATRs the rank is 0.0 and the setup holds everywhere. A point-mass distribution has no quartiles, so no rule is "right" there. It is defused by the **conjunction**, not by a special case — the breakout leg needs a close strictly above 20 prior closes, which a series flat enough to hold ATR exactly constant cannot produce. That is asserted (`test_a_flat_series_never_fires`), not argued.

**2. S-4 has no exit signal leg, and cannot have one.**

S-1 and S-3 exit on a per-bar price condition. All three of S-4's exit conditions — stop, target, max-hold — are measured *from the entry*, so all three are position state, and a pure per-bar verdict function has none. This is S-3's `MAX_HOLD_BARS` reasoning applied to a whole bracket instead of half of one.

The parameters are not dropped: `ATR_STOP_MULTIPLE`, `ATR_TARGET_MULTIPLE` and `MAX_HOLD_BARS` sit in `S4_PARAMS`, so criterion 11 hashes them into the identity, and their consumer is `outcome_resolver.ExitLevels` (phase 4a). ⚠ **Nothing in the module reads them**, which means the identity hash is the only thing holding them to §4's rule — so the revert probe that drops one from `S4_PARAMS` is the one that matters most here.

⚠ §4 warns that the bracket's ATR must be indexed at the **signal** bar, never the fill bar. This module cannot get that wrong because it does not emit it: the consumer recomputes `atr_series` and reads `signal_index`. The API shape prevents it, the same way the absent fill field prevents a same-bar fill.

**3. The two windows keep different boundaries, deliberately.** Compression is *"computed on bars ≤ t"* — inclusive, because the question is where today's ATR sits in a distribution it is part of. The breakout excludes `t`, for the reason §4 gives in its own parenthesis (including it makes the condition partly self-referential, and under a strict `>` the rule would then never fire rather than fail). Making them consistent would be a spec violation, so each is pinned by its own test.

**4. A masked bar refuses the whole TAIL of the series.** Inherited from Wilder smoothing exactly as S-3's RSI is — `atr_series` carries state across every bar and has no window for a hole to clear — and **larger here**, because `atr_14` needs high, low *and* the previous close, so more fields can kill it. Counted, not asserted away (below).

## Full-population verification

`scripts/verify_2240_s4_volatility_breakout.py`, two arms, both run at `85e55a26`'s tree. ⚠ Gate on the exit code; the script is never piped.

**`--equivalence`** — every bar of both corpora, raw bars. ⚠ **The ATR and the prior-20 high are compared as VALUES, bar by bar, not merely through the verdicts they feed.** Both sides compute in float64 in the same order (SQL casts to `double precision` *before* any arithmetic, not after), so agreement is expected bit-for-bit and any difference is logic rather than rounding.

| corpus | series | bars | values compared | value mismatches | verdict mismatches | ties |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `research_price_daily` | 7,693 | 25,818,944 | 51,637,888 | **0** | **0** | 0 |
| `price_daily` | 12,185 | 6,702,891 | 13,405,782 | **0** | **0** | 0 |
| | | **32,521,835** | **65,043,670** | **0** | **0** | **0** |

⚠ **What is independently derived, stated precisely, because a blanket "compared against SQL" would be false here.** The true range is SQL's (from `lag(close)` and the bar's own high/low — where an OHLC alignment bug would live). The prior-20 high is SQL's, as a frame boundary `ROWS BETWEEN 20 PRECEDING AND 1 PRECEDING` against our slice bound. The compression rank is re-derived by a **different algorithm** (`sorted(window).index(v)` against the module's count-of-comparisons). The **Wilder recursion is re-implemented in the script, not SQL-derived** — a recursive CTE over 32.5M rows needs indexed temp tables per corpus — so it catches transcription and horizon errors but not an error in the Wilder arithmetic itself, which is pinned instead by `tests/test_indicator_series.py` and phase 2a. ⚠ Phase 2a checks ATR at the **last bar of each series only**; this arm checks every bar, which is the gap it closes.

**`--census`** — §4.0 validated universe (6,735 instruments → 5,266 research series), masked bars, fail-closed loader. 23,339,583 bars.

| verdict | count | share |
| --- | ---: | ---: |
| fired | 699,632 | 2.998% |
| not_fired | 21,432,155 | 91.827% |
| not_evaluable | 1,207,796 | 5.175% |

Refusals by reason (criterion 9's "measure what you reject"): `quarantined_bar` 613,835 · `insufficient_warmup` 588,695 · `no_fill_bar` 5,266.

Two S-4-specific counts, because both are narrowings and narrowings get counted rather than asserted safe:

- **361 of 5,266 series carry a masked bar, and they cost 611,092 bars** on which the 20-bar breakout frame had recovered and the ATR never will. That is the blast radius in point 4 — compare S-3's 29 series / 80,476 bars on the same universe.
- **484,594 bars** are narrowed by the shared 113-bar warm-up (`atr_14`'s seed plus the 100-bar window) despite a breakout leg that was already evaluable at bar 20. Both legs share one warm-up because §3.1 makes evaluability a property of the strategy — per-leg warm-ups would make the same bar live for one leg and warming for the other.

## Revert probes: 16/16 caught

`scripts/probe_2240_s4_volatility_breakout.py`. Each injects a defect, asserts the anchor occurs **exactly once** first, confirms the guarding test fails, restores, and re-runs the suite clean.

⚠ **Two of them reported `*** NOT CAUGHT ***` on the first run, and the cause was a real defect in the tests, not in the strategy.** `_reference_verdicts` imported `COMPRESSION_WINDOW` and `BREAKOUT_LOOKBACK` from the module it exists to validate, so when the probe shortened the windows the reference shortened with them and the comparison became a tautology. The re-derivation was independent in *algorithm* and not in *parameters* — and a parameter is exactly what a spec fixes. Fixed to hand-transcribed literals; 35 tests and the full-population arm were green throughout, so nothing else in the repo could have found it.

Extracted to `docs/review-prevention-log.md` and `.claude/skills/engineering/test-quality.md` in this commit, with the corollary that a spec constant is worth a revert probe *even when it looks inert*, because a constant is the thing a reference is most tempted to share.

## Boundary fixtures are constructed, not searched for

Per the prevention log's existing entry, a fixture that is degenerate on both conjuncts pins neither operator — so each strict comparison gets its own exact-equality fixture with the other conjunct strictly true, and every precondition is asserted inside the test so a drifting fixture fails loudly instead of passing vacuously.

The compression boundary is **constructed**: a flat close makes `TR = 2h` exactly, so a long constant-volatility stretch holds the ATR at exactly `2h`, a 25-bar quiet dip puts exactly 25 window values below, and any spike landing `atr(150)` strictly between `131/14` and `10.0` gives `rank = 25/100 = 0.25` — exact in binary float, with a whole interval of valid spike sizes. A search over piecewise-constant volatility fixtures had found exactly **one** qualifying bar, which a one-ULP change relocates; the construction has margin on both sides.

## Checks

- `ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` · `pytest tests/smoke` — all exit 0, run separately, none piped.
- Pre-push hook green.
- Codex checkpoint 2 (`codex exec review --base origin/main`, files staged first so the new modules were visible): no findings.

## Security

No security surface. No database writes, no endpoints, no auth, no user input, no order path — a pure function over bars plus two read-only verification scripts. The verification script's SQL is composed through `psycopg.sql.Identifier`/`Literal`, with no string interpolation of any value.

## Not in scope

No performance claim is attached, deliberately — the same reason S-3 shipped without one. §4's survivorship table grades every strategy's omission bias on a survivor-only corpus, the fired share above counts signals rather than outcomes, and §5's acceptance criteria are phase 5's work. Nothing here allocates capital or reaches an order path.
