### PR TITLE
fix(#2324): the worktree guard skipped the one path a human runs by hand

### DIFF
--- a/scripts/autonomy/loop_status.sh
+++ b/scripts/autonomy/loop_status.sh
@@ -20,7 +20,17 @@
 
 set -uo pipefail
 
-# name|worktree|branch-glob-for-PR-listing
+# name|worktree|branch-globs
+#
+# ⚠ THREE fields, but `|` appears more than twice: the third field is the
+# REMAINDER of the line, so any `|` after the second is part of the glob's own
+# alternation rather than a fourth field. That is a real property of
+# `IFS='|' read -r name worktree pr_glob` — the last variable takes what is
+# left, delimiters included — not an accident, and it is written down here
+# because the row does not look like it parses (#2324). Verified: the
+# `ownership` row yields the full `fix/*|chore/ownership-*|docs/ownership-*`,
+# not just `fix/*`. If it kept only the first, that loop's `chore/` and `docs/`
+# PRs would vanish from its own status view.
 #
 # ⚠ The glob must match ONLY the branches that loop opens, or the section is
 # worse than useless — it shows another loop's PR under this loop's heading and

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -62,10 +62,22 @@ COOLDOWN_SECONDS="${TA_LOOP_COOLDOWN:-60}"
 # loop: the plist set WorkingDirectory and the prompt but not the worktree, so
 # the ownership agent drove the TA worktree and hit its lock three times in 21
 # seconds under KeepAlive. The lock held, but nothing SAID what was wrong.
-inferred_worktree="${SELF_DIR%/var/autonomy/bin}"
-if [[ "$inferred_worktree" != "$SELF_DIR" && "$inferred_worktree" != "$WORKTREE" ]]; then
-  echo "FATAL installed under $inferred_worktree but TA_LOOP_WORKTREE=$WORKTREE" >&2
-  echo "      refusing to drive another loop's checkout -- set TA_LOOP_WORKTREE in the plist" >&2
+#
+# ⚠ BOTH homes count. The first version stripped only `/var/autonomy/bin`, and
+# `${x%suffix}` returns `x` UNCHANGED when the suffix is absent — so for a
+# directly-run tracked script the two sides were equal, the first conjunct was
+# false, and the guard was skipped entirely (#2324). The bypass was the tracked
+# path, which is the one a human runs by hand: exactly the case where a wrong
+# TA_LOOP_WORKTREE is most likely and least expected.
+inferred_worktree=""
+case "$SELF_DIR" in
+  */var/autonomy/bin) inferred_worktree="${SELF_DIR%/var/autonomy/bin}" ;;
+  */scripts/autonomy) inferred_worktree="${SELF_DIR%/scripts/autonomy}" ;;
+esac
+if [[ -n "$inferred_worktree" && "$inferred_worktree" != "$WORKTREE" ]]; then
+  echo "FATAL running from $inferred_worktree but TA_LOOP_WORKTREE=$WORKTREE" >&2
+  echo "      refusing to drive another loop's checkout -- set TA_LOOP_WORKTREE to match," >&2
+  echo "      or run the driver installed under that worktree's var/autonomy/bin" >&2
   exit 1
 fi
 

--- a/scripts/autonomy/ta_loop.sh
+++ b/scripts/autonomy/ta_loop.sh
@@ -74,6 +74,13 @@ case "$SELF_DIR" in
   */var/autonomy/bin) inferred_worktree="${SELF_DIR%/var/autonomy/bin}" ;;
   */scripts/autonomy) inferred_worktree="${SELF_DIR%/scripts/autonomy}" ;;
 esac
+# A checkout at the filesystem root strips to the empty string rather than to
+# "/", and the emptiness test below would then read as "no path to infer" and
+# let the guard pass — silently, which is the one behaviour this guard exists
+# to rule out. Absurd layout, one line to close.
+[[ -z "$inferred_worktree" && -n "${SELF_DIR:-}" ]] && case "$SELF_DIR" in
+  /var/autonomy/bin|/scripts/autonomy) inferred_worktree="/" ;;
+esac
 if [[ -n "$inferred_worktree" && "$inferred_worktree" != "$WORKTREE" ]]; then
   echo "FATAL running from $inferred_worktree but TA_LOOP_WORKTREE=$WORKTREE" >&2
   echo "      refusing to drive another loop's checkout -- set TA_LOOP_WORKTREE to match," >&2


### PR DESCRIPTION
Two findings the review bot raised on **#2322**, which touches neither file. They belong to #2323 (`88c43616`) and were filed as **#2324** rather than lost. Both verified against `origin/main` before fixing.

## 1. The guard was bypassable — and the bypass was the hand-run path

`${x%suffix}` returns `x` **unchanged** when the suffix is absent. So:

```bash
inferred_worktree="${SELF_DIR%/var/autonomy/bin}"
if [[ "$inferred_worktree" != "$SELF_DIR" && "$inferred_worktree" != "$WORKTREE" ]]; then
```

For the tracked script the two sides are equal, the first conjunct is false, and the check never runs. The clause was meant to scope the guard to installed drivers — but the tracked path is not arbitrary either: it is always `<checkout>/scripts/autonomy`, so it infers the checkout just as well.

That left the bypass on the copy **a person runs by hand**, which is where a wrong `TA_LOOP_WORKTREE` is most likely and least expected — and it is the exact incident the guard was written for two commits earlier (the ownership agent driving the TA worktree, three lock aborts in 21 seconds).

Both homes are now matched by `case`, and the guard fires whenever a recognised path disagrees with `TA_LOOP_WORKTREE`.

| invocation | `TA_LOOP_WORKTREE` | before | after |
| --- | --- | --- | --- |
| `scripts/autonomy/ta_loop.sh` | another checkout | **accepted** | `FATAL running from …`, exit 1 |
| installed `var/autonomy/bin/ta_loop.sh` | another checkout | refused | refused |
| either | matching | proceeds | proceeds |

**The bypass was real, not theoretical.** Control run against `origin/main`'s own copy with `TA_LOOP_WORKTREE` pointed at the other loop: the old script sails past the guard and only stops later on the prompt check. The new one refuses at the guard, naming both paths and both remedies.

## 2. `LOOPS` rows carry more `|` than the comment declared

The format comment said three fields; the `ownership` row has five separators. It **parses correctly** — `IFS='|' read -r name worktree pr_glob` gives the last variable the remainder of the line, delimiters included, so the third field is the entire `fix/*|chore/ownership-*|docs/ownership-*` alternation. Verified directly.

But nothing said so, and a reader who assumed truncation would "fix" it into a real defect — if the glob were ever only `fix/*`, that loop's `chore/` and `docs/` PRs would vanish from its own status view, which the same comment calls "worse than useless". Now written down, with the consequence stated.

## Acceptance (from the issue, run at `8b441e80`)

```
--- open PRs (headRef feature/2240-*)
  #2331  feature/2240-s4-volatility-breakout

--- open PRs (headRef fix/*|chore/ownership-*|docs/ownership-*)
  #2326  fix/2213-openfigi-cusip-consumers
  #2325  fix/2304-openfigi-item-error
```

Correct attribution both ways, no cross-listing.

## Security

Operator tooling only; no data path, no endpoint, no credential. The change makes a refusal *more* likely, never less — the guard now fires in a case where it previously stayed silent, and its polarity (refuse, exit 1) is unchanged.

## Follow-up

Both loops' installed drivers get re-copied from the merged source once this lands — `var/autonomy/bin/` is what actually runs, and the tracked file is only the source.

Closes #2324.
