### PR TITLE
perf(#2171): index def14a_beneficial_holdings on accession_number — four seq scans, not one

### DIFF
--- a/scripts/bench_2171_def14a_accession_lookup.py
+++ b/scripts/bench_2171_def14a_accession_lookup.py
@@ -1,0 +1,217 @@
+"""Time the accession-keyed lookups on ``def14a_beneficial_holdings``.
+
+Issue: #2171.
+
+Every rewashed DEF 14A row and every live DEF 14A ingest runs several lookups
+keyed on ``accession_number`` alone. None of the four indexes present leads with
+that column, so each one is a sequential scan whose cost grows with the table.
+
+The three shapes timed here are the read-side ones, at their call sites:
+
+    A. ``app/services/rewash_filings.py:518``   cover-label guard
+       ``SELECT holder_name ... WHERE accession_number = %s``
+    B. ``app/services/rewash_filings.py:587``   existing-rows probe
+       ``SELECT issuer_cik, instrument_id ... WHERE accession_number = %s LIMIT 1``
+    C. ``app/services/rewash_filings.py:851``   sibling-instrument union
+       ``SELECT DISTINCT instrument_id ... WHERE accession_number = %s
+         AND instrument_id IS NOT NULL``
+
+Two write shapes are NOT timed, because timing them means executing them:
+
+    D. ``app/services/rewash_filings.py:720``  accession-wide DELETE — same
+       predicate as A, so A's plan is its plan. Confirm with ``--explain``.
+    E. ``app/services/def14a_ingest.py:743``   DELETE carrying
+       ``instrument_id = ANY(...)``, which already leads with
+       ``uq_def14a_holdings_instrument_accession_holder``. Not a seq scan today;
+       included in ``--explain`` so a regression there is visible.
+
+FULL POPULATION, not a sample: each shape runs once per accession over every
+distinct ``accession_number`` in the table. A single hot accession measures the
+buffer cache, not the scan.
+
+Read-only. Runs against whatever ``settings.database_url`` points at, and never
+writes. Index variants are created and dropped OUTSIDE this script so the same
+binary times every arm.
+
+Usage:
+    uv run python scripts/bench_2171_def14a_accession_lookup.py --label pre
+    uv run python scripts/bench_2171_def14a_accession_lookup.py --explain
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from typing import Any, LiteralString
+
+import psycopg
+
+from app.config import settings
+
+# Verbatim from the call sites named in the module docstring. Kept as literals
+# rather than imported: the point is to time the SQL, and importing the callers
+# would drag in the rewash runner's transaction and locking.
+SHAPES: dict[str, LiteralString] = {
+    "A_cover_label_guard": ("SELECT holder_name FROM def14a_beneficial_holdings WHERE accession_number = %s"),
+    "B_existing_rows_probe": (
+        "SELECT issuer_cik, instrument_id FROM def14a_beneficial_holdings WHERE accession_number = %s LIMIT 1"
+    ),
+    "C_sibling_instrument_union": (
+        "SELECT DISTINCT instrument_id FROM def14a_beneficial_holdings "
+        "WHERE accession_number = %s AND instrument_id IS NOT NULL"
+    ),
+}
+
+EXPLAIN_ONLY: dict[str, tuple[LiteralString, tuple[object, ...]]] = {
+    "D_accession_wide_delete": (
+        "DELETE FROM def14a_beneficial_holdings WHERE accession_number = %s",
+        (),
+    ),
+    "E_ingest_supersede_delete": (
+        "DELETE FROM def14a_beneficial_holdings WHERE accession_number = %s "
+        "AND instrument_id = ANY(%s::bigint[]) AND holder_name <> ALL(%s::text[])",
+        ([1], ["placeholder"]),
+    ),
+}
+
+
+def _accessions(conn: psycopg.Connection[Any]) -> list[str]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT DISTINCT accession_number FROM def14a_beneficial_holdings ORDER BY accession_number")
+        return [row[0] for row in cur.fetchall()]
+
+
+def _census(conn: psycopg.Connection[Any], when: str) -> None:
+    """Table size at arm start and end.
+
+    The dev jobs daemon writes this table while the bench runs, and the arms are
+    sequential — the prevention-log rule that an A/B is invalid across sequential
+    arms under a concurrent writer applies directly. A seq scan's cost is a
+    function of table size, so drift between arms is the contamination that
+    matters. Printed rather than guarded: the arms cannot be serialised against
+    the daemon from here, so the honest move is to publish the drift alongside
+    the timings and let the reader judge it against the effect size.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT count(*), count(DISTINCT accession_number), "
+            "pg_size_pretty(pg_relation_size('def14a_beneficial_holdings')) "
+            "FROM def14a_beneficial_holdings"
+        )
+        row = cur.fetchone()
+    assert row is not None
+    print(f"  census[{when}] rows={row[0]} accessions={row[1]} heap={row[2]}")
+
+
+def _time_shapes(conn: psycopg.Connection[Any], accessions: list[str], label: str) -> int:
+    print(f"label={label}  accessions={len(accessions)}")
+    _census(conn, "start")
+    for name, sql in SHAPES.items():
+        started = time.perf_counter()
+        rows = 0
+        with conn.cursor() as cur:
+            for acc in accessions:
+                cur.execute(sql, (acc,))
+                rows += len(cur.fetchall())
+        elapsed = time.perf_counter() - started
+        per_call_ms = elapsed * 1000.0 / len(accessions)
+        print(f"  {name:<28} total={elapsed:8.2f}s  per_call={per_call_ms:7.3f}ms  rows={rows}", flush=True)
+    _census(conn, "end")
+    return 0
+
+
+def _explain(conn: psycopg.Connection[Any], accession: str) -> int:
+    for name, sql in SHAPES.items():
+        print(f"--- {name}")
+        with conn.cursor() as cur:
+            # EXPLAIN ANALYZE is safe on the read shapes.
+            cur.execute(f"EXPLAIN (ANALYZE, BUFFERS) {sql}", (accession,))
+            for row in cur.fetchall():
+                print(f"    {row[0]}")
+    for name, (sql, extra) in EXPLAIN_ONLY.items():
+        print(f"--- {name}  (plan only — EXPLAIN without ANALYZE, it is a DELETE)")
+        with conn.cursor() as cur:
+            cur.execute(f"EXPLAIN {sql}", (accession, *extra))
+            for row in cur.fetchall():
+                print(f"    {row[0]}")
+    return 0
+
+
+def _verify(conn: psycopg.Connection[Any], accessions: list[str]) -> int:
+    """Full-population equivalence: indexed plan vs forced seq-scan plan.
+
+    An index is only safe if it changes no answer. The A/B that establishes that
+    is not a timing — it is running every shape over every accession twice, once
+    with the index available and once with the planner forced back onto the
+    pre-migration plan, and requiring the result sets to be identical.
+
+    Forcing is per-transaction (``SET LOCAL``) and read-only.
+
+    ``enable_indexonlyscan`` is turned off in the control arm alongside
+    ``enable_indexscan``. Empirically it is redundant — Postgres will not choose
+    an index-only scan with ``enable_indexscan = off``, verified by EXPLAINing
+    shape C's control plan on the dev corpus and getting a Seq Scan — but the
+    dependency is undocumented at the call site and shape C is precisely the one
+    the migration covers index-only, so the control is stated explicitly rather
+    than relying on it (Codex checkpoint 2, P3). The assertion below turns the
+    whole question into a check instead of a claim.
+    """
+    _census(conn, "verify")
+    mismatches = 0
+    for name, sql in SHAPES.items():
+        differing = 0
+        with conn.cursor() as cur:
+            # The control arm is only a control if it really is the pre-migration
+            # plan. Assert that once per shape rather than assuming it.
+            cur.execute("SET LOCAL enable_indexscan = off")
+            cur.execute("SET LOCAL enable_bitmapscan = off")
+            cur.execute("SET LOCAL enable_indexonlyscan = off")
+            cur.execute(f"EXPLAIN {sql}", (accessions[0],))
+            control_plan = "\n".join(str(r[0]) for r in cur.fetchall())
+            if "Seq Scan" not in control_plan:
+                print(f"  CONTROL NOT A SEQ SCAN for {name}:\n{control_plan}")
+                return 1
+            for acc in accessions:
+                cur.execute("SET LOCAL enable_indexscan = on")
+                cur.execute("SET LOCAL enable_bitmapscan = on")
+                cur.execute("SET LOCAL enable_indexonlyscan = on")
+                cur.execute("SET LOCAL enable_seqscan = on")
+                indexed = sorted(map(repr, cur.execute(sql, (acc,)).fetchall()))
+                # Force the pre-migration plan.
+                cur.execute("SET LOCAL enable_indexscan = off")
+                cur.execute("SET LOCAL enable_bitmapscan = off")
+                cur.execute("SET LOCAL enable_indexonlyscan = off")
+                control = sorted(map(repr, cur.execute(sql, (acc,)).fetchall()))
+                if indexed != control:
+                    differing += 1
+                    if differing <= 3:
+                        print(f"    MISMATCH {name} {acc}: indexed={indexed!r} control={control!r}")
+        print(f"  {name:<28} accessions={len(accessions)} mismatches={differing}", flush=True)
+        mismatches += differing
+    print(f"  TOTAL mismatches={mismatches}")
+    return 0 if mismatches == 0 else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--label", default="unlabelled", help="arm name recorded in the output")
+    ap.add_argument("--explain", action="store_true", help="print plans for one accession instead of timing")
+    ap.add_argument("--verify", action="store_true", help="full-population equivalence: indexed vs forced seq scan")
+    args = ap.parse_args(argv)
+
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET statement_timeout = 0")
+        accessions = _accessions(conn)
+        if not accessions:
+            print("no accessions in def14a_beneficial_holdings — nothing to measure", file=sys.stderr)
+            return 1
+        if args.explain:
+            return _explain(conn, accessions[0])
+        if args.verify:
+            return _verify(conn, accessions)
+        return _time_shapes(conn, accessions, args.label)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sql/258_def14a_holdings_accession_idx.sql
+++ b/sql/258_def14a_holdings_accession_idx.sql
@@ -1,0 +1,40 @@
+-- #2171 — index def14a_beneficial_holdings on accession_number.
+--
+-- Sibling of #2157 / migration 242, which fixed the same class of defect on
+-- ownership_def14a_observations. The DEF 14A rewash and the live DEF 14A
+-- ingest key FOUR statements on accession_number alone, and none of the four
+-- indexes present leads with that column
+-- (def14a_beneficial_holdings_pkey, idx_def14a_holdings_instrument_as_of,
+-- idx_def14a_holdings_issuer_holder,
+-- uq_def14a_holdings_instrument_accession_holder — the last CONTAINS
+-- accession_number but leads with instrument_id, so a lookup keyed on the
+-- accession alone cannot use it). All four were sequential scans of the whole
+-- table, per accession, on every rewashed row:
+--
+--   app/services/rewash_filings.py:518   cover-label guard      SELECT holder_name
+--   app/services/rewash_filings.py:587   existing-rows probe    SELECT issuer_cik, instrument_id … LIMIT 1
+--   app/services/rewash_filings.py:720   replace-then-insert    DELETE
+--   app/services/rewash_filings.py:851   sibling-instrument set SELECT DISTINCT instrument_id … AND instrument_id IS NOT NULL
+--
+-- A fifth (app/services/def14a_ingest.py:743) also filters on the accession
+-- but carries instrument_id = ANY(...) alongside, so it already leads with the
+-- unique index and was never a seq scan.
+--
+-- NOT the partial ``WHERE instrument_id IS NOT NULL`` index proposed on the
+-- issue. instrument_id is NULLABLE on this table, so Postgres cannot prove the
+-- predicate holds for the three statements that filter on accession_number
+-- alone, and could not use a partial index for any of them — it would have
+-- closed one of the four seq scans. (Measured on the dev corpus: 110,748 rows,
+-- 0 with a NULL instrument_id, so the partial form would not even have been
+-- smaller. Reproduce with: SELECT count(*), count(instrument_id) FROM
+-- def14a_beneficial_holdings;)
+--
+-- Second column is instrument_id so shape :851's SELECT DISTINCT instrument_id
+-- can be served index-only.
+--
+-- NOT CONCURRENTLY, following migration 242 on the sibling table: the heap is
+-- 18 MB / 110,748 rows on the dev corpus, so the build holds its SHARE lock
+-- for well under a second and does not need the autocommit directive plus the
+-- DROP-INVALID dance that migration 204 carries for the 1.46M-row manifest.
+CREATE INDEX IF NOT EXISTS idx_def14a_holdings_accession
+    ON def14a_beneficial_holdings (accession_number, instrument_id);

--- a/tests/test_def14a_holdings_accession_index.py
+++ b/tests/test_def14a_holdings_accession_index.py
@@ -1,0 +1,112 @@
+"""Migration 258 — ``idx_def14a_holdings_accession`` must be USABLE, not merely present.
+
+#2171. Four statements in the DEF 14A rewash and ingest paths key on
+``accession_number`` alone (``rewash_filings.py`` :518, :587, :720, :851). An
+existence assertion cannot tell a usable index from an unusable one, and the
+unusable variant is the one the issue proposed: a partial index
+``WHERE instrument_id IS NOT NULL`` is invisible to the three statements that do
+not carry that predicate, because ``instrument_id`` is nullable and Postgres
+cannot prove the implication. Such an index passes "does it exist?" and leaves
+three of four seq scans in place.
+
+So the test drives the planner instead. ``SET enable_seqscan = off`` makes a seq
+scan expensive but still legal, so the planner falls back to one whenever no
+index is *usable* for the shape — which is exactly the discriminator wanted. At
+test-fixture row counts a seq scan would otherwise always win on cost, so this
+is also the only way to assert the plan at all.
+
+The query strings are the call-site shapes, parameterless so ``EXPLAIN`` can run
+them without executing the DELETE.
+
+Division of labour between the two tests here, established by revert-probe and
+worth stating because it is not obvious:
+
+* The PLAN test catches the partial-index defect. Probed: rebuilding migration
+  258 as ``(accession_number) WHERE instrument_id IS NOT NULL`` fails it for
+  :518, :587 and :720, and correctly still passes for :851 — the one shape a
+  partial index does serve.
+* The STRUCTURAL test catches wrong column ORDER. The plan test cannot: given
+  ``(instrument_id, accession_number)`` Postgres will happily scan the whole
+  index and report ``Index Cond: (accession_number = …)`` on it, so the plan
+  names our index and looks healthy. Probed: that variant passes all four plan
+  assertions and fails the structural one. At fixture row counts cost is the
+  only thing separating "leads with the column" from "contains the column", and
+  cost at that scale is a fixture artefact, not an invariant.
+"""
+
+from __future__ import annotations
+
+from typing import LiteralString
+
+import psycopg
+import pytest
+
+from tests.fixtures.ebull_test_db import ebull_test_conn as ebull_test_conn  # noqa: F401
+
+_INDEX = "idx_def14a_holdings_accession"
+
+# Verbatim predicate shapes from the call sites. A literal accession stands in
+# for the bound parameter — the plan shape is what is under test, not the value.
+_ACC: LiteralString = "'0001193125-26-000001'"
+
+_SHAPES: list[tuple[str, LiteralString]] = [
+    (
+        "rewash_filings.py:518 cover-label guard",
+        f"SELECT holder_name FROM def14a_beneficial_holdings WHERE accession_number = {_ACC}",
+    ),
+    (
+        "rewash_filings.py:587 existing-rows probe",
+        f"SELECT issuer_cik, instrument_id FROM def14a_beneficial_holdings WHERE accession_number = {_ACC} LIMIT 1",
+    ),
+    (
+        "rewash_filings.py:720 replace-then-insert DELETE",
+        f"DELETE FROM def14a_beneficial_holdings WHERE accession_number = {_ACC}",
+    ),
+    (
+        "rewash_filings.py:851 sibling-instrument set",
+        "SELECT DISTINCT instrument_id FROM def14a_beneficial_holdings "
+        f"WHERE accession_number = {_ACC} AND instrument_id IS NOT NULL",
+    ),
+]
+
+
+def _plan(conn: psycopg.Connection[tuple], sql: LiteralString) -> str:
+    with conn.cursor() as cur:
+        # EXPLAIN without ANALYZE — one of the shapes is a DELETE.
+        cur.execute(f"EXPLAIN {sql}")
+        return "\n".join(row[0] for row in cur.fetchall())
+
+
+def test_index_exists_and_leads_with_accession_number(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SELECT indexdef FROM pg_indexes WHERE indexname = %s", (_INDEX,))
+        row = cur.fetchone()
+    ebull_test_conn.commit()
+    assert row is not None, "migration 258 index missing"
+    indexdef = row[0]
+    # Leading column is the whole point: uq_def14a_holdings_instrument_accession_holder
+    # already CONTAINS accession_number and is useless here because it leads with
+    # instrument_id.
+    assert "(accession_number" in indexdef, f"{_INDEX} does not lead with accession_number: {indexdef}"
+    # A partial index would silently serve only the one shape that carries the
+    # predicate; migration 258 must be unconditional.
+    assert " WHERE " not in indexdef, f"{_INDEX} must not be partial: {indexdef}"
+
+
+@pytest.mark.parametrize(("label", "sql"), _SHAPES, ids=[s[0] for s in _SHAPES])
+def test_accession_keyed_shape_can_use_the_index(
+    ebull_test_conn: psycopg.Connection[tuple], label: str, sql: LiteralString
+) -> None:
+    with ebull_test_conn.cursor() as cur:
+        cur.execute("SET LOCAL enable_seqscan = off")
+        plan = _plan(ebull_test_conn, sql)
+    ebull_test_conn.rollback()
+    assert _INDEX in plan, f"{label} cannot use {_INDEX}; planner chose:\n{plan}"
+    # Named AND driving the scan. Without this, a plan that merely mentions the
+    # index somewhere would satisfy the assertion. Matched per line rather than
+    # as a prefix: shape :851 conjoins the IS NOT NULL check into the same
+    # condition, so the text is ``Index Cond: ((accession_number = …) AND …)``.
+    conds = [line.strip() for line in plan.splitlines() if line.strip().startswith("Index Cond:")]
+    assert any("accession_number" in cond for cond in conds), (
+        f"{label} reaches {_INDEX} without an accession_number index condition:\n{plan}"
+    )


### PR DESCRIPTION
## What

Adds `idx_def14a_holdings_accession` on `def14a_beneficial_holdings (accession_number, instrument_id)` (migration `sql/258`), plus a full-population bench/equivalence harness and plan-driven tests.

## Why the issue's prescribed fix was not the fix

#2171 named ONE seq scan (`rewash_filings.py:851`) and prescribed a **partial** index `WHERE instrument_id IS NOT NULL`. Re-measured before building — both halves of that were wrong.

**There are four, not one.** Every accession-keyed statement on this table, verified by `EXPLAIN` on the dev corpus at `211dc277`:

| call site | shape | plan before |
| --- | --- | --- |
| `app/services/rewash_filings.py:518` | cover-label guard, `SELECT holder_name` | Seq Scan |
| `app/services/rewash_filings.py:587` | existing-rows probe, `SELECT issuer_cik, instrument_id … LIMIT 1` | Seq Scan |
| `app/services/rewash_filings.py:720` | replace-then-insert `DELETE` | Seq Scan |
| `app/services/rewash_filings.py:851` | sibling-instrument union | Seq Scan |
| `app/services/def14a_ingest.py:743` | supersede `DELETE`, carries `instrument_id = ANY(...)` | Index Scan (already fine) |

**A partial index closes only one of the four.** `instrument_id` is nullable in DDL, so Postgres cannot prove the query predicate implies the index predicate for the three statements filtering on the accession alone. It is not smaller either:

```sql
SELECT count(*), count(instrument_id) FROM def14a_beneficial_holdings;
--  110748 | 110748     -- 0 NULL
```

Built all three variants on dev and timed each over the **full population of 7,222 distinct accessions** (`scripts/bench_2171_def14a_accession_lookup.py`):

| arm | A (:518) | B (:587) | C (:851) | total |
| --- | --- | --- | --- | --- |
| pre-index | 34.15s | 17.97s | 37.26s | **89.38s** |
| partial, as the issue proposed | 49.44s | 31.11s | 1.75s | **82.30s** |
| migration 258 `(accession_number, instrument_id)` | 1.49s | 1.47s | 1.44s | **4.40s** |

The partial variant recovers ~8% of the cost and would have shown a green `EXPLAIN` on the one call site the issue quoted. Migration 258 recovers ~95%; index size 1120 kB.

Second column is `instrument_id` so shape C is served **index-only** — post-migration plan shows `Index Only Scan … Heap Fetches: 0`. Shape E moved to the new index at slightly lower cost (8.31 vs 8.44), no regression.

Not `CONCURRENTLY`, following `sql/242` on the sibling table (same #2157 defect): 18 MB heap, sub-second build, so it does not need the autocommit directive + DROP-INVALID dance `sql/204` carries for the 1.46M-row manifest.

**Arm contamination:** the dev jobs daemon writes this table and the arms are sequential. The harness prints a census at each arm boundary; it read `rows=110748 accessions=7222 heap=18 MB` identically at the start and end of every arm, so no drift occurred across the comparison.

## Safety — full-population equivalence

An index is safe iff it changes no answer. `--verify` runs every shape over all 7,222 accessions twice — once with the index available, once with the planner forced back onto the pre-migration plan — and compares result sets:

```
A_cover_label_guard          accessions=7222 mismatches=0
B_existing_rows_probe        accessions=7222 mismatches=0
C_sibling_instrument_union   accessions=7222 mismatches=0
TOTAL mismatches=0
```

The control arm asserts it really is a `Seq Scan` per shape rather than assuming it.

**One latent hazard measured, deliberately not changed.** `rewash_filings.py:587` is `LIMIT 1` with no `ORDER BY`, so a plan change may return a different row. 97 of 7,222 accessions have >1 distinct `(issuer_cik, instrument_id)`. Blast radius is nil today and the equivalence run found 0 mismatches on that shape, for two independent reasons: 0 of 7,222 accessions have >1 distinct `issuer_cik`, and all 97 have a non-empty sibling set, so `_resolve_siblings` ignores the picked instrument. It also only ever enters `_def14a_holdings_instrument_ids` as a union member of a set that already contains it. Not widening this diff to add an `ORDER BY` (#2329's lesson); filed separately.

## Tests

`tests/test_def14a_holdings_accession_index.py` — plan-driven, not existence-driven, because an existence assertion cannot tell a usable index from an unusable one. `SET enable_seqscan = off` makes a seq scan expensive but legal, so the planner falls back to one exactly when no index is usable.

Revert-probed both defects (`assert s.count(old) == 1` before each injection):

| injected defect | result |
| --- | --- |
| `(accession_number) WHERE instrument_id IS NOT NULL` | 4 tests FAIL; `:851` correctly still passes |
| `(instrument_id, accession_number)` | structural test FAILS |
| restored | all 5 pass |

Probe 2 found a hole in my own first draft: the four plan tests passed with a deliberately useless index, because Postgres will scan a whole index and still print `Index Cond: (accession_number = …)` for a non-leading column. Column order is only separable by cost, and cost at fixture scale is an artefact — so the structural test owns order, the plan test owns the partial-index defect, and the docstring records which catches which.

## Definition of Done — ETL clauses

**Clause 8 — panel smoke (dev DB).** Recomputed with the planner forced back to the pre-index plan; identical both ways.

| symbol | rows | distinct holders | accessions | latest as_of | max % of class |
| --- | --- | --- | --- | --- | --- |
| AAPL | 31 | 17 | 2 | 2026-01-02 | 9.6300 |
| GME | 20 | 12 | 2 | 2026-05-20 | 9.5000 |
| HD | 43 | 26 | 2 | 2026-03-06 | 10.0000 |
| JPM | 37 | 21 | 2 | 2026-01-02 | 9.8600 |
| MSFT | 39 | 21 | 2 | 2025-08-01 | 8.9500 |

**Clause 9 — cross-source.** SEC EDGAR direct, accession `0001308179-26-000008`, primary doc `aapl014016-def14a.htm` (fetched with the configured `sec_user_agent` per `.claude/skills/data-sources/sec-edgar.md` §4). Item 403 table states `The Vanguard Group 1,415,826,462 … 9.63%` and `BlackRock, Inc. 1,043,713,019 … 7.10%`. Stored rows match exactly on both shares and percent.

**Clauses 10 + 11 — operator.** `## OPERATOR VERIFY` block posted on #2171. This is an index-only change with a measured zero-mismatch equivalence, so no rebuild is required for correctness; the block covers applying the migration and re-confirming the plan.

**Clause 12 — SHA.** All of the above at `2c08dacb`.

## Security model

Not applicable. No new query, no new predicate, no user-controlled input, no change to any authorisation path — the diff adds one index, one read-only measurement script and one test.

## Gates

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` · `pytest tests/smoke` — all exit 0. DB tier run file-scoped over the 12 `def14a`/`rewash` modules in two batches, both exit 0. Codex checkpoint 2 run with the migration staged; its one P3 (make the control arm's index-only suppression explicit) is applied — empirically it was already a Seq Scan, but the dependency was undocumented and is now asserted rather than assumed.

Closes #2171. Refs #2157. Refs #2164.
