### PR TITLE
fix(#2317): bound signal_index on both sides in the ledger writer

### DIFF
--- a/app/services/signal_ledger.py
+++ b/app/services/signal_ledger.py
@@ -202,7 +202,23 @@ def resolve_fills(
     seen: set[tuple[date, SignalKind]] = set()
 
     for signal in signals:
-        if signal.signal_index >= n_bars:
+        # ⚠ TWO-SIDED, and the lower half is load-bearing (#2317). A negative
+        # index passes `>= n_bars` and then WRAPS under Python list indexing —
+        # at `series.dates[...]` below and again at `signal_index + 1` — so
+        # rather than raising, the writer would resolve the signal against a bar
+        # near the END of the series and store the result as an ordinary fill. A
+        # ledger row that is wrong-but-plausible is worse than one that fails,
+        # because nothing downstream can tell.
+        #
+        # ⚠ `StrategySignal.__post_init__` already refuses a negative index, so
+        # this cannot fire on any path that goes through the contract, and it is
+        # not claimed to fix a live wrong-row bug. It is here for the reason
+        # refusal 1 above is repeated: the writer must not depend on which
+        # producer fed it, and `Sequence[StrategySignal]` is an annotation, not a
+        # runtime gate. `outcome_resolver.resolve_outcome` bounds its own
+        # `fill_index` two-sided already — this brings the two layers in line
+        # instead of leaving one of them trusting its caller.
+        if not 0 <= signal.signal_index < n_bars:
             raise ValueError(
                 f"signal_index {signal.signal_index} is outside the {n_bars}-bar series it was resolved against "
                 "— the signals and the series must come from the same run"

--- a/tests/test_signal_ledger.py
+++ b/tests/test_signal_ledger.py
@@ -147,6 +147,39 @@ class TestBatchIntegrity:
         with pytest.raises(ValueError, match="outside the 4-bar series"):
             resolve_fills([_fired_at(9)], series=_series(_CONSECUTIVE), identity=_IDENTITY, instrument_id=1)
 
+    # ⚠ -1 and -2 are BOTH here because they fail differently, and a -1-only
+    # test would have passed before the bound was two-sided (#2317). Measured on
+    # this fixture against `5078c173`:
+    #
+    #   idx=-1: RAISED "fill_bar_date 2024-01-02 is not after signal_bar_date
+    #           2024-01-05" — caught, but by the fill-after-signal mirror and
+    #           with a misleading diagnosis. `fill_index = -1 + 1 = 0`, so the
+    #           fill resolves EARLIER than the signal and trips that CHECK.
+    #   idx=-2: STORED verdict=fired signal_bar=2024-01-04 fill_bar=2024-01-05
+    #           price=103 — a well-formed row, dates correctly ordered, wrong
+    #           bars. At -2 or below `fill_index` is still negative, so both
+    #           dates wrap TOGETHER and every mirrored constraint passes.
+    #
+    # So the backstop is blind below -1 by construction, and only the writer's
+    # own bound closes it.
+    @pytest.mark.parametrize("signal_index", [-1, -2])
+    def test_a_negative_signal_index_raises_rather_than_wrapping(self, signal_index: int) -> None:
+        """#2317. Python list indexing makes `series.dates[-2]` legal, so a
+        one-sided bound does not fail — it silently resolves a bar near the END
+        of the series.
+
+        ⚠ The state is built by mutating a frozen instance because
+        `StrategySignal.__post_init__` refuses a negative index at construction,
+        and the subject here is the WRITER's bound rather than the contract's.
+        `resolve_fills` takes `Sequence[StrategySignal]`, which is an annotation
+        and not a runtime gate — so this is a state the parameter type admits,
+        the same shape as the half-fill defect on this module.
+        """
+        signal = _fired_at(0)
+        object.__setattr__(signal, "signal_index", signal_index)
+        with pytest.raises(ValueError, match="outside the 4-bar series"):
+            resolve_fills([signal], series=_series(_CONSECUTIVE), identity=_IDENTITY, instrument_id=1)
+
     def test_duplicate_bar_and_kind_in_one_batch_raises(self) -> None:
         with pytest.raises(ValueError, match="duplicate signal"):
             resolve_fills(


### PR DESCRIPTION
## What

`signal_ledger.resolve_fills` bounded `signal_index` on one side only:

```python
if signal.signal_index >= n_bars:
```

A negative index passes that, then wraps under Python list indexing — at `series.dates[signal.signal_index]` and again at `signal.signal_index + 1`. Now two-sided, matching `outcome_resolver.resolve_outcome`, which has always written `if not 0 <= fill_index < n_bars`.

## Why the test covers -1 AND -2

Measured against merged `5078c173` on the 4-bar fixture in `tests/test_signal_ledger.py` (throwaway script, deleted):

| idx | pre-fix behaviour |
| --- | --- |
| -1 | **RAISED** `fill_bar_date 2024-01-02 is not after signal_bar_date 2024-01-05` — caught, but by the fill-after-signal mirror, with a misleading diagnosis |
| -2 | **STORED** `verdict=fired signal_bar=2024-01-04 fill_bar=2024-01-05 price=103` |
| -3 | **STORED** `verdict=fired signal_bar=2024-01-03 fill_bar=2024-01-04 price=102` |

`fill_index = -1 + 1 = 0`, so at -1 the fill resolves *earlier* than the signal and trips the `fill_bar_date > signal_bar_date` mirror. At -2 and below `fill_index` is still negative, so both dates wrap **together**, stay correctly ordered, and every mirrored constraint passes. The backstop is blind below -1 by construction.

Consequence for the test, which is the reason this table is in the PR and not just the commit: **a -1-only test passes before the fix**, via a guard unrelated to the one being added. The issue's fix note asked for "the negative case"; one case would have been probe-positive for the wrong reason.

## Scope — this is defence-in-depth, not a live wrong-row fix

`StrategySignal.__post_init__` has refused a negative index since `cfabe45c` (phase 3a), one PR *before* the writer existed, so the branch is unreachable through the contract. `resolve_fills` takes `Sequence[StrategySignal]`, which is an annotation and not a runtime gate — the state is reachable only by bypassing the constructor, which is what the test does (`object.__setattr__` on the frozen instance, documented in the test docstring).

It is still worth closing, for the reason the module already repeats the final-bar `no_fill_bar` stamp that `evaluate` also applies: *"the writer must not depend on which producer fed it."* One of the two index-owning layers trusted its caller and the other did not.

**Blast radius, computed on the dev DB this run:** `strategy_signals` 0 rows / 0 strategies / 0 filled; `strategy_outcomes` 0 rows. Nothing stored could have been affected — phase 5 has not run.

## Defect class

Third instance on this surface of *a validator that rejects the states its current caller happens to produce, rather than the states its parameter type admits* — after the half-fill `a is not None and b is not None` mirror (Codex, checkpoint 2, same PR) and the `CrossSectionalMember.decision_indices` bound, which got it right. Already carried in `docs/review-prevention-log.md`; no new entry, and the in-code comment names the sibling layer so the next author copies the right shape.

## Verification

- Revert probe: injected the one-sided bound back (`assert s.count(old) == 1` first), both params **FAILED**, restored, both pass.
- `ruff check` 0 · `ruff format --check` 0 · `pyright` 0 · `pytest -m "not db"` 0 · `pytest tests/smoke` 0.
- DB tier, file-scoped on the touched surface: `pytest -m db tests/test_signal_ledger_writer_db.py tests/test_strategy_signals_ledger.py -n 0` → 0.

## Security

No security surface: a pure bounds check on an in-process index, no I/O, no user input, no auth or SQL path touched.

Closes #2317. Refs #2240.