### PR TITLE
fix(#2175): implement the HTML table model — a rowspan cell occupies the rows it covers

### DIFF
--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -65,7 +65,7 @@ import re
 from dataclasses import dataclass, replace
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Final
+from typing import Final, NamedTuple
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +142,11 @@ class Def14ABeneficialOwnershipTable:
 _TABLE_OPEN_RE: Final[re.Pattern[str]] = re.compile(r"<table\b[^>]*>", re.IGNORECASE)
 _TABLE_CLOSE_RE: Final[re.Pattern[str]] = re.compile(r"</table\s*>", re.IGNORECASE)
 _TR_RE: Final[re.Pattern[str]] = re.compile(r"<tr\b[^>]*>(.*?)</tr\s*>", re.IGNORECASE | re.DOTALL)
-_CELL_RE: Final[re.Pattern[str]] = re.compile(r"<(?:t[hd])\b[^>]*>(.*?)</t[hd]\s*>", re.IGNORECASE | re.DOTALL)
+# Group 1 is the tag's ATTRIBUTES, group 2 the cell contents. The attributes
+# are needed for ``rowspan`` — see :func:`_expand_row_spans`.
+_CELL_RE: Final[re.Pattern[str]] = re.compile(r"<(?:t[hd])\b([^>]*)>(.*?)</t[hd]\s*>", re.IGNORECASE | re.DOTALL)
+_ROWSPAN_RE: Final[re.Pattern[str]] = re.compile(r"\browspan\s*=\s*[\"']?\s*(\d+)", re.IGNORECASE)
+_COLSPAN_RE: Final[re.Pattern[str]] = re.compile(r"\bcolspan\s*=\s*[\"']?\s*(\d+)", re.IGNORECASE)
 _HTML_TAG_RE: Final[re.Pattern[str]] = re.compile(r"<[^>]+>")
 _NBSP_RE: Final[re.Pattern[str]] = re.compile(r"&nbsp;| ")
 _INLINE_WHITESPACE_RE: Final[re.Pattern[str]] = re.compile(r"[ \t\r\f\v]+")
@@ -811,7 +815,161 @@ def _looks_like_label_row(cells: tuple[str, ...]) -> bool:
     return "name" in matched and len(matched) >= 2
 
 
-def _parse_table_html(table_html: str) -> _RawTable | None:
+class _ExpandedRow(NamedTuple):
+    """One row after :func:`_expand_row_spans`.
+
+    ``own_cells`` is the row's own ``<td>``s, unshifted; ``inherited_cells`` is
+    what a live ``rowspan`` places into the row; ``cells`` is both, in layout
+    order. ``inherited_cells`` is empty exactly when the row inherited nothing.
+    """
+
+    cells: tuple[str, ...]
+    own_cells: tuple[str, ...]
+    inherited_cells: tuple[str, ...]
+
+
+def _expand_row_spans(rows: list[tuple[tuple[str, int, int], ...]]) -> list[_ExpandedRow]:
+    """Restore a ``rowspan`` cell into the rows it covers, at the right position.
+
+    ROWS is one ``(text, rowspan, colspan)`` triple per ``<td>``/``<th>`` in
+    document order. Returns one text tuple per row.
+
+    Source rule — the HTML Living Standard's table model (§4.9.12 "Forming a
+    table", *downward-growing cells*): a cell whose ``rowspan`` is N occupies the
+    same COLUMN SLOT in the next N-1 rows, so those rows carry fewer ``<td>``s in
+    the markup and every later cell in them sits further LEFT than its own markup
+    position suggests. Reading ``<td>`` position as column index — which this
+    parser did — mis-columns every continuation row of a spanned table.
+
+    Concretely (#2175, ``0001104659-25-029081``, Liberty Media): the holder cell
+    carries ``rowspan="6"`` over the issuer's six share series, so rows 2-6 lose
+    three leading cells. ``Title of Series`` then landed on ``name_idx`` and the
+    parser stored ``LLYVB`` / ``FWONK`` / ``LLYVK`` as beneficial owners, with the
+    share count read from whichever cell the value-recovery scan reached.
+
+    Two properties are deliberate, and BOTH were forced by the full-population
+    A/B — the naive form (markup-index carry, every row expanded) regressed three
+    accession classes:
+
+    1. **``colspan`` is read but NOT expanded.** A carried cell is placed by
+       LAYOUT column, which needs the colspan arithmetic; but it is emitted ONCE,
+       not ``colspan`` times. Expanding it would multiply captions inside
+       ``score_headers``, and :func:`_score_table_headers` SUMS keyword weights —
+       so a ``colspan=6`` caption would score six times and reshuffle table
+       selection corpus-wide. Ignoring colspan entirely is equally wrong: the
+       carry index is then a markup index, and on ``0001628280-26-025998``
+       (``colspan=3|6`` before a ``rowspan=4`` caption) it inserted the caption
+       three columns early, wrecked the promoted header and took a 16-holder
+       Item 403 table to ZERO.
+    2. **A ``<tr>`` carrying no cells of its own emits nothing, but still consumes
+       one row of every live span.** Consuming is the table model and is what
+       keeps the span decaying at the right rate. Emitting is not: EDGAR's
+       generated markup is full of cell-less spacer ``<tr>``s (the same accession
+       has two before its header row and one after), every cell such a row could
+       show is a repeat of one already emitted above, and materialising it
+       inserted a phantom one-cell row between the two header rows — which the
+       two-row-header promotion then adopted as ``column_headers``.
+
+    Reuse check (standard-filing rule). ``pandas.read_html`` implements the full
+    model and was tested on that exact Liberty table: pandas 3.0.2 returns a
+    uniform 24-column frame with ``Chase Carey Director`` repeated across all six
+    series rows, where this parser returned 24 cells then 21. Not adoptable
+    wholesale — it also expands colspan (see 1) and re-does cell-text extraction,
+    which every header-scoring constant here is tuned against. So the ALGORITHM
+    is mirrored from ``pandas.io.html._HtmlFrameParser._expand_colspan_rowspan``
+    (a remainder list drained ahead of each source cell) and the extraction is
+    left alone.
+
+    ``rowspan="0"`` (HTML: "span to the end of the row group") is treated as 1,
+    matching the pandas reference. EDGAR proxies do not use it and inventing a
+    to-end-of-table span for a malformed attribute is the riskier reading.
+    """
+    out: list[_ExpandedRow] = []
+    # (layout_column, columns_spanned, text, rows_left), ascending by column.
+    remainder: list[tuple[int, int, str, int]] = []
+    for cells in rows:
+        if not cells:
+            # Cell-less spacer row: consume a row of every live span, emit nothing.
+            remainder = [(col, width, text, left - 1) for col, width, text, left in remainder if left > 1]
+            out.append(_ExpandedRow((), (), ()))
+            continue
+        texts: list[str] = []
+        inherited: list[str] = []
+        next_remainder: list[tuple[int, int, str, int]] = []
+        column = 0
+        pending = iter(remainder)
+        carried = next(pending, None)
+        for text, rowspan, colspan in cells:
+            # Layout slots claimed by an earlier row's spanning cell come first.
+            while carried is not None and carried[0] <= column:
+                col, width, prev_text, left = carried
+                texts.append(prev_text)
+                inherited.append(prev_text)
+                column = max(column, col) + width
+                if left > 1:
+                    next_remainder.append((col, width, prev_text, left - 1))
+                carried = next(pending, None)
+            texts.append(text)
+            if rowspan > 1:
+                next_remainder.append((column, colspan, text, rowspan - 1))
+            column += colspan
+        while carried is not None:
+            col, width, prev_text, left = carried
+            texts.append(prev_text)
+            inherited.append(prev_text)
+            if left > 1:
+                next_remainder.append((col, width, prev_text, left - 1))
+            carried = next(pending, None)
+        out.append(_ExpandedRow(tuple(texts), tuple(text for text, _, _ in cells), tuple(inherited)))
+        # A span opened by THIS row can start left of one carried into it, so the
+        # append order is not sorted; the drain above requires that it is.
+        next_remainder.sort(key=lambda entry: entry[0])
+        remainder = next_remainder
+    return out
+
+
+def _row_contributes_only_inherited_values(row: _ExpandedRow) -> bool:
+    """True when ROW inherited a cell and contributes no value of its OWN.
+
+    #2175, third regression class. Issuers put ``rowspan="2"`` on a holder's
+    VALUE cells and stack the holder's name and address as two ``<tr>``s under
+    it. Restoring the span hands the address row the holder's own figures, and
+    it stores as a second holder at an identical share count —
+    ``0000107140-24-000176`` gained 'New York, NY 10055' at BlackRock's
+    6,782,743 / 14.97% and 'Baker Botts L.L.P. 2001 Ross Avenue…' at E.P.
+    Hamilton's 462,338 / 1.02%. A name test cannot separate these: the Baker
+    Botts line is a law firm's name and address, indistinguishable in isolation
+    from a genuine nominee holder.
+
+    The markup separates them. A row whose every number is INHERITED is a
+    continuation of the row that opened those spans — it is one holder rendered
+    over two lines, not two holders. A row with a value of its own is a holder
+    (Liberty's per-series continuation rows carry their own share counts).
+
+    ⚠ This test makes the value-carry class strictly non-regressive against
+    ``main``: for any row with an inherited cell, ``main`` saw the same ``<tr>``
+    with its own cells only, so ``main`` kept it exactly when it had an own value
+    — the same decision this makes. What changes for a kept row is its column
+    ALIGNMENT, which is the point of the expansion.
+
+    ⚠ The inherited cells must themselves be VALUES. Testing only "no own value"
+    also matched the second row of a two-row HEADER, whose own cells are captions
+    and which inherits a spanning caption — dropping it left the table with no
+    label row and took the same two accessions to zero a second time.
+    """
+    if not row.inherited_cells:
+        return False
+    if not any(_is_value_cell(cell) for cell in row.inherited_cells):
+        return False
+    return not any(_is_value_cell(cell) for cell in row.own_cells)
+
+
+def _is_value_cell(cell: str) -> bool:
+    """True when CELL parses as an Item 403 share count or percent."""
+    return _parse_share_count(cell) is not None or _parse_percent(cell) is not None
+
+
+def _parse_table_html(table_html: str, *, expand_spans: bool = True) -> _RawTable | None:
     """Extract one ``<table>`` block. Mirrors the helper in
     business_summary but kept inlined so this module is provider-
     side / self-contained (parsers should not import from
@@ -843,11 +1001,31 @@ def _parse_table_html(table_html: str) -> _RawTable | None:
         scrubbed = "".join(pieces)
     else:
         scrubbed = inner
-    cells_per_row: list[tuple[str, ...]] = []
+    # Two passes, and the ORDER is load-bearing: the row-span expansion below
+    # counts rows, so every ``<tr>`` must reach it — including the all-empty
+    # spacer rows the old single pass dropped here. Dropping a row first would
+    # make an earlier ``rowspan`` decay one row too fast and shift the rows
+    # after it back the way this expansion exists to fix.
+    spanned_rows: list[tuple[tuple[str, int, int], ...]] = []
     for tr_match in _TR_RE.finditer(scrubbed):
-        cells = tuple(_strip_inline_html(cell) for cell in _CELL_RE.findall(tr_match.group(1)))
-        if any(c for c in cells):
-            cells_per_row.append(cells)
+        spanned_rows.append(
+            tuple(
+                (
+                    _strip_inline_html(cell_inner),
+                    int(rs.group(1)) if (rs := _ROWSPAN_RE.search(attrs)) else 1,
+                    max(1, int(cs.group(1))) if (cs := _COLSPAN_RE.search(attrs)) else 1,
+                )
+                for attrs, cell_inner in _CELL_RE.findall(tr_match.group(1))
+            )
+        )
+    if expand_spans:
+        cells_per_row: list[tuple[str, ...]] = [
+            row.cells
+            for row in _expand_row_spans(spanned_rows)
+            if any(row.cells) and not _row_contributes_only_inherited_values(row)
+        ]
+    else:
+        cells_per_row = [cells for row in spanned_rows if any(cells := tuple(text for text, _, _ in row))]
     if not cells_per_row:
         return None
 
@@ -1547,6 +1725,19 @@ def _resolve_columns(headers: tuple[str, ...]) -> tuple[int, int, int]:
         if i == percent_idx:
             continue
         lower = h.lower()
+        # …and excluding every OTHER percent caption too, unless it carries a
+        # strong AMOUNT keyword. This is the exact mirror of the rule the percent
+        # pass above applies, and the same source rule drives it: 17 CFR 229.403
+        # column 3 is a COUNT, column 4 a PERCENT. The percent pass takes only the
+        # FIRST match, so on a multi-class table a SECOND percent caption stayed
+        # eligible for the shares tiering — and ``total`` is a tier-4 keyword, so
+        # '% of Total Voting Power' outranked the genuine 'Shares' column
+        # (#2175, 0001628280-26-025998: Dustin Moskovitz's Class B count filed
+        # against his Class A percent). The docstring above already states this
+        # for the percent side — "'Total as a Percentage of Shares Outstanding'
+        # is a real percent column" — it simply was not applied here.
+        if ("percent" in lower or "%" in lower) and not any(k in lower for k in _STRONG_SHARES_KEYWORDS):
+            continue
         for keyword, weight in SHARES_TIERS:
             if keyword in lower:
                 shares_tier_priority.append((str(i), weight))
@@ -2684,10 +2875,32 @@ _ADDRESS_ONLY_RE: Final[re.Pattern[str]] = re.compile(
     re.IGNORECASE,
 )
 
+# The SECOND line of a split US address — locality, state, ZIP and nothing else
+# ('New York, NY 10055', 'Bloomfield Hills, MI 48304'). It carries no street
+# number, so ``_ADDRESS_ONLY_RE`` above does not see it.
+#
+# #2175: this was a latent gap that the row-span expansion turned into a live
+# defect. Issuers put ``rowspan="2"`` on the VALUE cells of a holder whose name
+# and address are stacked; before the expansion the address row parsed no values
+# and died on the "neither shares nor percent" guard, and afterwards it inherited
+# the holder's own figures — so ``0000107140-24-000176`` gained 'New York, NY
+# 10055' at BlackRock's 6,782,743 / 14.97%, a verbatim duplicate of the row above
+# it. The prevention log already recorded 'malvern, pa 19355' as this shape
+# (#2164); that one lowercases, which is why the state anchor is a case-sensitive
+# two-letter group inside an otherwise case-insensitive pattern.
+#
+# Anchored at BOTH ends and capped at four locality words: a holder whose name
+# merely ENDS in this shape ('BlackRock, Inc. 55 East 52nd Street New York, NY
+# 10055') must keep passing, and does, because it does not match from the start.
+_CITY_STATE_ZIP_ONLY_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Za-z][A-Za-z.'\-]*(?:\s+[A-Za-z][A-Za-z.'\-]*){0,3}\s*,\s*(?i:[A-Z]{2})\.?\s+\d{5}(?:-\d{4})?\.?$"
+)
+
 
 def _is_address_fragment(name: str) -> bool:
-    """True when a holder-name cell holds only address material (#2140)."""
-    return bool(_ADDRESS_ONLY_RE.match(name.strip()))
+    """True when a holder-name cell holds only address material (#2140, #2175)."""
+    stripped = name.strip()
+    return bool(_ADDRESS_ONLY_RE.match(stripped) or _CITY_STATE_ZIP_ONLY_RE.match(stripped))
 
 
 # D1 clause 4-5 (#2160) — the tail after the name must carry ADDRESS evidence,
@@ -3256,7 +3469,21 @@ def parse_summary_compensation_table(html_text: str) -> Def14ASummaryCompTable:
     best_table: _RawTable | None = None
     for window_start, window_end in _find_sct_windows(html_text):
         for start, end in _scan_outer_tables(html_text, start=window_start, end=window_end):
-            parsed = _parse_table_html(html_text[start:end])
+            # ``expand_spans=False``: the Item 402(c) path carries its OWN
+            # compensation for rowspan-shifted rows (see the module comment above
+            # `Def14AExecCompRow` — "name-cell rowspan → continuation-year rows
+            # are index-shifted (AAPL/MSFT)"), built and tuned across #1945,
+            # #1967, #2088, #2094 and #2097. Feeding it the span-restored rows
+            # re-bases that machinery, and the full-population A/B measured the
+            # result: **580 accessions** drifted, every one of them the same way
+            # — ``executive_name``, ``fiscal_year``, ``salary`` and ``total_comp``
+            # identical, and ``principal_position`` repeated once per
+            # continuation year ('Executive Vice President and Chief Financial
+            # Officer' ×3 on 0000004904-25-000043). Re-basing this arm on the
+            # table model is the right end state and is NOT this ticket — #2175
+            # is Item 403. Keeping the SCT input byte-identical is what makes
+            # that separable. See the follow-up issue in the PR description.
+            parsed = _parse_table_html(html_text[start:end], expand_spans=False)
             if parsed is None:
                 continue
             score = _score_sct_headers(parsed.score_headers)

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -888,8 +888,16 @@ def _expand_row_spans(rows: list[tuple[tuple[str, int, int], ...]]) -> list[_Exp
     # (layout_column, columns_spanned, text, rows_left), ascending by column.
     remainder: list[tuple[int, int, str, int]] = []
     for cells in rows:
-        if not cells:
-            # Cell-less spacer row: consume a row of every live span, emit nothing.
+        if not any(text for text, _, _ in cells):
+            # Spacer row: consume a row of every live span, emit nothing. Covers
+            # BOTH shapes EDGAR generates — a `<tr>` with no cells at all, and one
+            # whose cells are all blank (`<tr><td>&#8203;</td></tr>`). Codex
+            # checkpoint 2 (P2) caught the second: the first draft tested `not
+            # cells`, so a blank-cell spacer crossed by a span was materialised
+            # into a phantom row instead. Both shapes contribute nothing of their
+            # own, and ``main`` dropped both on its `any(c for c in cells)` filter,
+            # so treating them alike is what keeps this a pure re-COLUMNING of the
+            # rows main already saw.
             remainder = [(col, width, text, left - 1) for col, width, text, left in remainder if left > 1]
             out.append(_ExpandedRow((), (), ()))
             continue

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -3065,3 +3065,106 @@ Two things S-4 adds to the prevention above:
 - Prevention: when an arm re-implements a ranked rule, resolve the ranking key to the SAME identifier the rule names, before the `row_number()`, and say so in the SQL. If the two identifiers are 1:1 today, that is a property of today's corpus, not of the rule.
 - Caught by: the arm's own per-date set comparison on its first full-population run. A count-only comparison (`762 dates, 101,318 picks` on both sides) would have reported PASS — the two selections have the same SIZE on every date.
 - Enforced in: this prevention log; `scripts/verify_2240_s2_cross_sectional.py` (`_RANKING_SQL`'s `eligible` CTE carries the incident and the two dates).
+### An HTML-table parser that reads `<td>` position as column index has not implemented the table model — and the symptom looks like bad DATA, not bad indexing (#2175, 2026-08-07)
+
+- Symptom: DEF 14A Item 403 multi-series tables stored the *Title of Series* ticker
+  as the beneficial owner — `LLYVB`, `FWONK`, `LBRDK`, `QRTEP`, `BATRK` — with a
+  share count taken from whichever cell the value-recovery scan happened to reach.
+  103 rows / 40 distinct ticker-shaped names / 50 accessions
+  (`SELECT … WHERE holder_name ~ '^[A-Z]{3,5}$'`). Four prior tickets patched this
+  family per-case (#2088 / #2094 / #2097 and #2169's lineage) and a fifth was
+  scoped as a name-rejection test.
+- Root cause: `_parse_table_html` extracted cells with
+  `<(?:t[hd])\b[^>]*>(.*?)</t[hd]\s*>` and used each cell's ordinal as its column.
+  That identity holds only for a table with no spans. Liberty Media's holder cell
+  carries `rowspan="6"` over the issuer's six share series, so rows 2-6 are three
+  `<td>`s short and every cell in them sits three columns left of where the parser
+  looked. Nothing about the output says "indexing"; it says "the parser thinks a
+  ticker is a person", which is why four rounds went after the names.
+- ⚠ **The reuse check answers this in one command and was worth running.**
+  `pandas.read_html` (already a dependency) implements the model: on that exact
+  table pandas 3.0.2 returns a uniform 24-column frame with `Chase Carey Director`
+  repeated across all six series rows where our parser returned 24 cells then 21.
+  Not adoptable wholesale — it also expands `colspan` and re-does cell-text
+  extraction — but it settled the diagnosis in minutes and supplied the reference
+  algorithm (`_HtmlFrameParser._expand_colspan_rowspan`).
+- ⚠ **Half the table model is worse than none, and only the full-population A/B
+  said so.** The naive form (carry by markup index, expand every row) passed 118
+  unit tests, the AAPL/GME/MSFT/JPM/HD panel with ZERO drift, and Codex — and
+  regressed three classes:
+  1. **Carry placed by markup index.** With `colspan=3|6` before a `rowspan=4`
+     caption the carry landed three columns early, wrecked the promoted header and
+     took `0001628280-26-025998` from 16 holders to **0**. Fix: read `colspan` for
+     the layout arithmetic, but emit the carried cell ONCE — expanding it would
+     multiply captions inside `score_headers`, which SUMS keyword weights.
+  2. **Cell-less spacer `<tr>`s materialised.** EDGAR's generated markup wraps
+     header rows in `<tr>`s with no `<td>` at all; filling them with carried text
+     inserted a phantom one-cell row that the two-row-header promotion then adopted
+     as `column_headers`. Fix: such a row emits nothing but still CONSUMES a row of
+     every live span — consuming is the table model, emitting is not.
+  3. **Stacked name/address rows inherited the holder's figures.** Issuers put
+     `rowspan="2"` on the VALUE cells; the address row previously died on the
+     "neither shares nor percent" guard and now inherited real numbers, so
+     `0000107140-24-000176` gained `New York, NY 10055` at BlackRock's exact
+     6,782,743 / 14.97%. Fix: a row that inherits a cell and contributes no value
+     of its OWN is a continuation, not a holder. ⚠ The first cut of that rule also
+     matched the second row of a two-row HEADER (own cells are captions, inherits a
+     spanning caption) and took the same accession to zero a SECOND time — the
+     inherited cells must themselves be values.
+- ⚠ **A shared cell extractor is shared with a caller that already compensated for
+  the same defect.** `parse_summary_compensation_table` uses the same
+  `_parse_table_html`, and the Item 402(c) path has carried its own rowspan-shift
+  compensation since #1945. Restoring the spans re-based it: **580 accessions**
+  drifted, all the same way — `executive_name`, `fiscal_year`, `salary` and
+  `total_comp` identical, `principal_position` repeated once per continuation year.
+  Fixed by keeping that caller's input byte-identical (`expand_spans=False`) rather
+  than re-tuning an arm this ticket has no mandate over. Same shape as the #2356
+  `_strip_inline_html` incident: **a fix placed at a shared chokepoint reaches
+  callers that never asked for it, and the second caller's compensating machinery
+  is exactly what makes the damage invisible to its unit tests.**
+- Prevention: (1) before adding an Nth per-case patch to a markup parser, ask
+  whether the parser implements the format's own model — for HTML tables that is
+  `rowspan`/`colspan`, and `pandas.read_html` is the one-command oracle for
+  whether it matters on YOUR failing document; (2) a span-restoration change is a
+  corpus change at the top review rung — its regressions are re-SELECTION of which
+  table wins, which no panel and no unit test can see; (3) when the fix lands in a
+  shared extractor, enumerate the other callers FIRST and decide per caller whether
+  its input may move.
+- Enforced in: this prevention log;
+  `app/providers/implementations/sec_def14a.py::_expand_row_spans` (both deliberate
+  departures from the pandas reference carry the measured accession that forced
+  them), `::_row_contributes_only_inherited_values`, `::_CITY_STATE_ZIP_ONLY_RE`,
+  `::_resolve_columns` (the mirrored percent-caption guard) and the
+  `expand_spans=False` comment at the SCT call site;
+  `tests/test_sec_def14a_parser.py::TestRowSpanExpansion` (8 revert-probed
+  invariants); `scripts/audit_def14a_rowspan.py` (arm-3 mechanism audit).
+
+### A monkeypatched parser entry point must forward the FULL signature — the harness reported a total collapse the code never had (#2175, 2026-08-07)
+
+- Symptom: the DEF 14A full-population A/B reported `sct_rows 67,828 -> 0` — every
+  Item 402(c) exec-comp row in the corpus gone. The parser had not regressed: the
+  same filing (`0000004904-25-000043`) returned 17 SCT rows when called directly.
+- Root cause: `scripts/ab_2140_def14a_parser.py` monkeypatches
+  `parser_mod._parse_table_html` with `def traced_parse_table(table_html: str)` to
+  instrument header promotions. The branch under test had added a keyword to that
+  entry point (`expand_spans=False` at the SCT call site), so every SCT call raised
+  `TypeError`, the harness's per-accession `except` swallowed it, and the counter
+  stayed at zero. The Item 403 arm passes no keyword, so its numbers were fine —
+  which is what made the output look like a targeted collapse of one arm rather
+  than a harness fault.
+- ⚠ The direction is the dangerous one. **A harness bug of this shape produces a
+  DRAMATIC number, and a dramatic number reads as a finding.** Ten minutes went on
+  "which of my changes emptied the SCT" before running the parser by hand. The
+  existing skill rule ("treat a clean result with more suspicion than a dirty one")
+  covers the false-negative direction; this is the false-POSITIVE one, and it costs
+  the same.
+- Prevention: (1) any monkeypatch of a function under test takes `**kwargs` and
+  forwards them — a wrapper that narrows the signature is a silent behaviour change
+  in every caller that uses the part it dropped; (2) when a harness reports a
+  total-collapse figure for ONE arm, reproduce it with a direct call to the parser
+  before reading it as a result; (3) changing a parser entry point's signature means
+  grepping `scripts/` for monkeypatches of that name in the same commit
+  (`grep -rn "parser_mod\._parse_table_html" scripts/`).
+- Enforced in: this prevention log; `scripts/ab_2140_def14a_parser.py`
+  (`traced_parse_table` and `patched` both take `**kwargs`, with the measured
+  `67,828 -> 0` in the why-comment).

--- a/scripts/ab_2140_def14a_parser.py
+++ b/scripts/ab_2140_def14a_parser.py
@@ -51,8 +51,14 @@ def _scan(limit: int | None) -> dict[str, Any]:
     original_parse_table = parser_mod._parse_table_html
     pending: dict[str, Any] = {}
 
-    def traced_parse_table(table_html: str) -> Any:
-        table = original_parse_table(table_html)
+    # ``**kwargs`` is load-bearing, not defensive (#2175). The SCT call site passes
+    # ``expand_spans=False``; a tracer that accepted only the positional argument
+    # raised TypeError inside the SCT arm, the harness swallowed it, and the run
+    # reported ``sct_rows: 67,828 -> 0`` — a total-collapse figure produced entirely
+    # by the harness while the parser itself returned 17 rows for the same filing.
+    # Any monkeypatch of a parser entry point must forward the full signature.
+    def traced_parse_table(table_html: str, **kwargs: Any) -> Any:
+        table = original_parse_table(table_html, **kwargs)
         if table is not None and table.column_headers != table.score_headers:
             pending.setdefault("promotions", []).append(
                 {"headers": list(table.column_headers), "width": len(table.column_headers)}
@@ -269,8 +275,9 @@ def _audit(limit: int | None) -> int:
         legacy_arm = len(parent) < max_data_width and parser_mod._looks_like_legacy_subheader(cols)
         return score if legacy_arm else parent
 
-    def patched(table_html: str) -> Any:
-        table = original_parse_table(table_html)
+    def patched(table_html: str, **kwargs: Any) -> Any:
+        # Forward the full signature — see the ``traced_parse_table`` comment above.
+        table = original_parse_table(table_html, **kwargs)
         if table is None:
             return None
         unfolded = unfolded_headers(table)

--- a/scripts/audit_def14a_rowspan.py
+++ b/scripts/audit_def14a_rowspan.py
@@ -1,0 +1,147 @@
+"""Arm 3 (mechanism audit) for the DEF 14A row-span expansion (#2175).
+
+The parse-to-parse A/B says WHAT changed. This says HOW MUCH of the corpus the
+mechanism touches and — the direction that matters per
+``.claude/skills/engineering/full-population-ab.md`` — what the change newly
+ADMITS that the old code could not see:
+
+  * ``tables_with_rowspan``     — candidate tables carrying any ``rowspan>1``.
+  * ``tables_shifted``          — of those, the ones where expansion actually
+    changes a row's cell tuple. A ``rowspan`` on the LAST column of the last
+    row shifts nothing; only these are the defect.
+  * ``rows_newly_non_empty``    — rows that were entirely empty in the markup
+    and now carry spanned text. These are rows the parser has NEVER seen, so no
+    guard in the row loop has any coverage of them. This is the admit side.
+  * ``header_width_changed``    — tables whose row-0 width moves. Row 0 feeds
+    the two-row-header promotion arms (which compare header width against data
+    width), so a move here can change WHICH TABLE WINS — the #2356 failure mode
+    where a correct-looking cell-level fix silently reselected the table.
+
+Offline — reads ``filing_raw_documents``, never fetches from EDGAR. Run on the
+BRANCH: it measures both sides in one process by calling the expansion or not,
+which is legitimate here because the expansion is a pure function of the parsed
+cells and there is no control BEHAVIOUR to reconstruct (contrast the simulated
+control the A/B skill forbids — that one had to re-derive a two-limb condition).
+
+    PYTHONPATH=. uv run python scripts/audit_def14a_rowspan.py --out /tmp/rowspan-audit.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from typing import Any
+
+import psycopg
+
+import app.providers.implementations.sec_def14a as P
+from app.config import settings
+
+
+def _rows_of(table_html: str) -> list[tuple[tuple[str, int, int], ...]] | None:
+    """The ``(text, rowspan, colspan)`` rows ``_parse_table_html`` builds, or None."""
+    open_match = P._TABLE_OPEN_RE.search(table_html)
+    close_idx = table_html.rfind("</table")
+    if open_match is None or close_idx == -1:
+        return None
+    inner = table_html[open_match.end() : close_idx]
+    nested = P._scan_outer_tables(inner)
+    if nested:
+        pieces: list[str] = []
+        cursor = 0
+        for start, end in nested:
+            pieces.append(inner[cursor:start])
+            pieces.append(" ")
+            cursor = end
+        pieces.append(inner[cursor:])
+        scrubbed = "".join(pieces)
+    else:
+        scrubbed = inner
+    out: list[tuple[tuple[str, int, int], ...]] = []
+    for tr_match in P._TR_RE.finditer(scrubbed):
+        out.append(
+            tuple(
+                (
+                    P._strip_inline_html(cell_inner),
+                    int(rs.group(1)) if (rs := P._ROWSPAN_RE.search(attrs)) else 1,
+                    max(1, int(cs.group(1))) if (cs := P._COLSPAN_RE.search(attrs)) else 1,
+                )
+                for attrs, cell_inner in P._CELL_RE.findall(tr_match.group(1))
+            )
+        )
+    return out
+
+
+def _audit(limit: int | None) -> dict[str, Any]:
+    totals: Counter[str] = Counter()
+    per_accession: dict[str, dict[str, int]] = {}
+    max_rowspan: list[tuple[int, str]] = []
+
+    sql = """
+        SELECT accession_number, payload
+        FROM filing_raw_documents
+        WHERE document_kind = 'def14a_body'
+        ORDER BY accession_number
+        LIMIT %(limit)s
+    """
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET statement_timeout = 0")
+        with conn.cursor(name="def14a_rowspan_audit") as cur:
+            cur.itersize = 20
+            cur.execute(sql, {"limit": limit})
+            for accession, body in cur:
+                totals["accessions"] += 1
+                acc_counts: Counter[str] = Counter()
+                for window_start, window_end in P._find_section_windows(body):
+                    for start, end in P._scan_outer_tables(body, start=window_start, end=window_end):
+                        spanned = _rows_of(body[start:end])
+                        if spanned is None:
+                            continue
+                        acc_counts["tables"] += 1
+                        biggest = max((rs for row in spanned for _, rs, _ in row), default=1)
+                        if biggest <= 1:
+                            continue
+                        acc_counts["tables_with_rowspan"] += 1
+                        max_rowspan.append((biggest, accession))
+                        expanded = [row.cells for row in P._expand_row_spans(spanned)]
+                        control = [tuple(text for text, _, _ in row) for row in spanned]
+                        if expanded != control:
+                            acc_counts["tables_shifted"] += 1
+                        for before_row, after_row in zip(control, expanded, strict=True):
+                            if not any(before_row) and any(after_row):
+                                acc_counts["rows_newly_non_empty"] += 1
+                        if control and expanded and len(control[0]) != len(expanded[0]):
+                            acc_counts["header_width_changed"] += 1
+                    # Only the FIRST window that yields tables is scanned, mirroring
+                    # the parser's window loop closely enough for a scale figure.
+                    if acc_counts["tables"]:
+                        break
+                totals.update(acc_counts)
+                if acc_counts.get("tables_shifted"):
+                    per_accession[accession] = dict(acc_counts)
+
+    max_rowspan.sort(reverse=True)
+    return {
+        "totals": dict(totals),
+        "accessions_with_a_shifted_table": len(per_accession),
+        "largest_rowspans": max_rowspan[:20],
+        "per_accession": per_accession,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    summary = _audit(args.limit)
+    with open(args.out, "w") as fh:
+        json.dump(summary, fh, indent=2)
+    print(json.dumps({k: v for k, v in summary.items() if k != "per_accession"}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -2140,6 +2140,23 @@ class TestRowSpanExpansion:
             ("Name of Beneficial Owner", "Shares", "%", "% of Total Voting Power"),
         ]
 
+    def test_a_BLANK_cell_spacer_row_is_a_spacer_too(self) -> None:
+        """Codex ckpt-2 P2. EDGAR renders spacers both ways — no cells at all, and
+        a row of blank cells (`<tr><td>&nbsp;</td></tr>`, which
+        ``_strip_inline_html`` returns as ``''``). Testing only `not cells`
+        materialised the second into a phantom row carrying the spanning caption,
+        which is the shape that reaches the header promotion.
+
+        ⚠ A U+200B cell is NOT blank (`'\\u200b'` is a non-empty, non-whitespace
+        string) and is deliberately not covered — ``main`` kept those rows too, so
+        treating them as spacers would be a change this A/B has not measured."""
+        rows: list[tuple[tuple[str, int, int], ...]] = [
+            (("Name", 3, 1), ("Shares", 1, 1)),
+            (("", 1, 1), ("", 1, 1)),
+            (("100", 1, 1),),
+        ]
+        assert [row.cells for row in _expand_row_spans(rows)] == [("Name", "Shares"), (), ("Name", "100")]
+
     def test_a_cell_less_spacer_row_emits_nothing_but_still_consumes_the_span(self) -> None:
         """EDGAR's generated markup puts cell-less ``<tr>``s around header rows.
         They are rows per the table model, so a span must decay across them —

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -32,6 +32,7 @@ from app.providers.implementations.sec_def14a import (
     _clean_holder_name,
     _contains_specific_name,
     _detect_role_heading,
+    _expand_row_spans,
     _has_item403_value_rows,
     _is_address_fragment,
     _is_beneficial_owner_identity,
@@ -2076,3 +2077,184 @@ class TestAmpersandFirmNames:
     def test_ampersand_does_not_rescue_a_heading(self) -> None:
         for text in ("Directors and Executive Officers:", "5% Stockholders"):
             assert not _is_beneficial_owner_identity(text), text
+
+
+class TestRowSpanExpansion:
+    """#2175 — the HTML table model, which this parser did not implement.
+
+    A ``rowspan=N`` cell occupies the same COLUMN SLOT in the next N-1 rows
+    (HTML Living Standard §4.9.12, downward-growing cells), so those rows carry
+    fewer ``<td>``s and everything in them sits further LEFT than its markup
+    position. Reading markup position as column index mis-columns every
+    continuation row — which is why an Item 403 multi-series table stored the
+    'Title of Series' ticker as the beneficial owner.
+    """
+
+    def test_a_leading_span_is_carried_down_into_the_following_rows(self) -> None:
+        rows: list[tuple[tuple[str, int, int], ...]] = [
+            (("John C. Malone", 3, 1), ("LLYVA", 1, 1), ("251", 1, 1)),
+            (("LLYVB", 1, 1), ("18", 1, 1)),
+            (("LLYVK", 1, 1), ("5", 1, 1)),
+        ]
+        assert [row.cells for row in _expand_row_spans(rows)] == [
+            ("John C. Malone", "LLYVA", "251"),
+            ("John C. Malone", "LLYVB", "18"),
+            ("John C. Malone", "LLYVK", "5"),
+        ]
+
+    def test_a_span_beyond_a_short_rows_own_cells_still_occupies_its_slot(self) -> None:
+        """The trailing-remainder branch: the spanning cell's column index is
+        past the end of the next row's own cells, so the per-cell drain never
+        reaches it and only the after-the-loop pass places it."""
+        rows: list[tuple[tuple[str, int, int], ...]] = [
+            (("Common Stock", 1, 1), ("Vanguard", 1, 1), ("footnote (1)", 2, 1)),
+            (("Common Stock", 1, 1), ("BlackRock", 1, 1)),
+        ]
+        assert [row.cells for row in _expand_row_spans(rows)] == [
+            ("Common Stock", "Vanguard", "footnote (1)"),
+            ("Common Stock", "BlackRock", "footnote (1)"),
+        ]
+
+    def test_rowspan_zero_is_treated_as_one(self) -> None:
+        """HTML reads ``rowspan=0`` as 'to the end of the row group'. EDGAR
+        proxies do not use it, and the pandas reference treats it as 1 — so a
+        malformed attribute must not invent a span over the whole table."""
+        rows: list[tuple[tuple[str, int, int], ...]] = [
+            (("Name", 0, 1), ("100", 1, 1)),
+            (("Other", 1, 1), ("200", 1, 1)),
+        ]
+        assert [row.cells for row in _expand_row_spans(rows)] == [("Name", "100"), ("Other", "200")]
+
+    def test_a_carried_cell_is_placed_by_LAYOUT_column_not_markup_index(self) -> None:
+        """0001628280-26-025998: ``colspan=3 | colspan=6 | rowspan=4 colspan=3``.
+        The spanning caption's markup index is 2 and its layout column is 9. A
+        markup-index carry inserted it third in the label row, which wrecked the
+        promoted header and took a 16-holder Item 403 table to ZERO rows."""
+        rows: list[tuple[tuple[str, int, int], ...]] = [
+            (("Class A Common Stock", 1, 3), ("Class B Common Stock", 1, 6), ("% of Total Voting Power", 2, 3)),
+            (("Name of Beneficial Owner", 1, 3), ("Shares", 1, 3), ("%", 1, 3)),
+        ]
+        assert [row.cells for row in _expand_row_spans(rows)] == [
+            ("Class A Common Stock", "Class B Common Stock", "% of Total Voting Power"),
+            # Appended LAST — layout column 9 is right of every own cell.
+            ("Name of Beneficial Owner", "Shares", "%", "% of Total Voting Power"),
+        ]
+
+    def test_a_cell_less_spacer_row_emits_nothing_but_still_consumes_the_span(self) -> None:
+        """EDGAR's generated markup puts cell-less ``<tr>``s around header rows.
+        They are rows per the table model, so a span must decay across them —
+        but everything they could show repeats the row above, and emitting one
+        inserted a phantom header row that the promotion then adopted."""
+        rows: list[tuple[tuple[str, int, int], ...]] = [
+            (("Name", 3, 1), ("Shares", 1, 1)),
+            (),
+            (("100", 1, 1),),
+            (("200", 1, 1),),
+        ]
+        assert [row.cells for row in _expand_row_spans(rows)] == [
+            ("Name", "Shares"),
+            (),
+            ("Name", "100"),
+            # The span was 3 rows and the spacer consumed the second, so it has
+            # expired by here — a spacer that emitted would have shifted this.
+            ("200",),
+        ]
+
+    def test_a_second_percent_caption_does_not_win_the_shares_column(self) -> None:
+        """17 CFR 229.403 column 3 is a COUNT, column 4 a PERCENT. The percent
+        pass takes only the FIRST match, so on a multi-class table the second
+        percent caption stayed eligible for the shares tiering — and 'total' is
+        the top tier, so '% of Total Voting Power' outranked the real 'Shares'
+        column and filed a Class B count against a Class A percent."""
+        headers = ("Name of Beneficial Owner", "Shares", "%", "Shares", "%", "% of Total Voting Power †")
+        assert _resolve_columns(headers) == (0, 1, 2)
+
+    def test_a_stacked_address_row_does_not_inherit_the_holders_figures(self) -> None:
+        """0000107140-24-000176: the VALUE cells carry ``rowspan=2`` over a
+        stacked name/address pair. Before the expansion the address row parsed
+        no values and died on the 'neither shares nor percent' guard; after it,
+        the row inherited BlackRock's own 6,782,743 / 14.97% and stored a
+        verbatim duplicate under the name 'New York, NY 10055'."""
+        body = """
+        <table>
+          <tr><th>Name and Address of Beneficial Owner</th>
+              <th>Amount and Nature of Beneficial Ownership</th><th>Percent of Class</th></tr>
+          <tr><td>BlackRock, Inc.</td><td rowspan="2">6,782,743</td><td rowspan="2">14.97%</td></tr>
+          <tr><td>New York, NY 10055</td></tr>
+          <tr><td>The Vanguard Group, Inc.</td><td rowspan="2">5,466,211</td><td rowspan="2">12.07%</td></tr>
+          <tr><td>Malverne, PA 19355</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares, r.percent_of_class) for r in parsed.rows] == [
+            ("BlackRock, Inc.", Decimal("6782743"), Decimal("14.97")),
+            ("The Vanguard Group, Inc.", Decimal("5466211"), Decimal("12.07")),
+        ]
+
+    def test_an_inherited_value_row_is_dropped_even_when_its_cell_reads_as_a_name(self) -> None:
+        """The same accession's other case, and the one no NAME test can reach:
+        E.P. Hamilton's address continuation is the law firm 'Baker Botts
+        L.L.P. 2001 Ross Avenue, Suite 900 Dallas, TX 75201' — a corporate name
+        with a street address, indistinguishable in isolation from a genuine
+        nominee holder. Only the markup separates them: every figure in the row
+        is inherited. Deliberately NOT an address-only cell, so this test fails
+        if the continuation rule is removed even though the address rule stays."""
+        body = """
+        <table>
+          <tr><th>Name and Address of Beneficial Owner</th>
+              <th>Amount and Nature of Beneficial Ownership</th><th>Percent of Class</th></tr>
+          <tr><td>E.P. Hamilton Trusts, LLC (2)(7)</td>
+              <td rowspan="2">462,338</td><td rowspan="2">1.02%</td></tr>
+          <tr><td>Baker Botts L.L.P. 2001 Ross Avenue, Suite 900 Dallas, TX 75201</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares, r.percent_of_class) for r in parsed.rows] == [
+            ("E.P. Hamilton Trusts, LLC", Decimal("462338"), Decimal("1.02")),
+        ]
+
+    def test_a_two_row_header_inheriting_a_spanning_caption_is_not_a_continuation(self) -> None:
+        """The rule above must test that the INHERITED cells are values. A
+        two-row header's second row also inherits (the spanning caption) and
+        also has no own value — dropping it left the table with no label row and
+        took 0001628280-26-025998's 16 holders to zero a second time."""
+        body = """
+        <table>
+          <tr><td colspan="3">Class A Common Stock</td><td colspan="3">Class B Common Stock</td>
+              <td colspan="3" rowspan="2">% of Total Voting Power</td></tr>
+          <tr><td colspan="3">Name of Beneficial Owner</td><td colspan="3">Shares</td></tr>
+          <tr><td>The Vanguard Group (1)</td><td>13,114,167</td><td>7.90%</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [r.holder_name for r in parsed.rows] == ["The Vanguard Group"]
+
+    def test_multi_series_table_names_the_holder_not_the_series_ticker(self) -> None:
+        """0001104659-25-029081 (Liberty Media) shape. On main this stored
+        'LLYVB' / 'LLYVK' as beneficial owners with share counts read from
+        whichever cell the recovery scan reached."""
+        body = """
+        <table>
+          <tr><th>Name</th><th>Title of Series</th>
+              <th>Amount and Nature of Beneficial Ownership</th><th>Percent of Series</th></tr>
+          <tr><td rowspan="3">Chase Carey, Director</td><td>LLYVA</td><td>1,200</td><td>1.1%</td></tr>
+          <tr><td>LLYVB</td><td>—</td><td>—</td></tr>
+          <tr><td>LLYVK</td><td>1,425</td><td>2.2%</td></tr>
+          <tr><td rowspan="2">Berkshire Hathaway, Inc.</td><td>LLYVA</td><td>4,986,588</td><td>8.4%</td></tr>
+          <tr><td>LLYVK</td><td>2,000,000</td><td>3.1%</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        names = [r.holder_name for r in parsed.rows]
+        assert names == ["Chase Carey, Director", "Berkshire Hathaway, Inc."]
+        # No series ticker survives as a holder identity.
+        assert not [n for n in names if n in ("LLYVA", "LLYVB", "LLYVK")]
+        # The kept row is the FIRST series the issuer lists. Collapsing a
+        # holder's N series rows to one is the dedup in ``_extract_holder_rows``
+        # (identity-keyed, Item 403 counts a beneficial owner once) and there is
+        # no class column to key on — tracked separately, see the class
+        # docstring reference in the module.
+        assert [(r.shares, r.percent_of_class) for r in parsed.rows] == [
+            (Decimal("1200"), Decimal("1.1")),
+            (Decimal("4986588"), Decimal("8.4")),
+        ]


### PR DESCRIPTION
## What

`_parse_table_html` read each `<td>`'s ordinal as its column index. That identity holds only for a table with no spans, so **every continuation row of a `rowspan` table was mis-columned**. Liberty Media's holder cell carries `rowspan="6"` over the issuer's six share series, so rows 2-6 are three `<td>`s short, `Title of Series` landed on `name_idx`, and the parser stored `LLYVB` / `FWONK` / `LBRDK` as beneficial owners with a share count taken from whichever cell the value-recovery scan reached.

Measured this session, not copied from the issue:

```sql
SELECT count(*), count(DISTINCT holder_name), count(DISTINCT accession_number)
FROM def14a_beneficial_holdings WHERE holder_name ~ '^[A-Z]{3,5}$';
-- 103 rows | 40 distinct names | 50 accessions
```

Closes #2175. Folds in #2176 class 2 (TDS), whose eleven "people in the class column" are that same misalignment.

## Source rule

The HTML Living Standard's table model, §4.9.12 *Forming a table*, **downward-growing cells**: a cell with `rowspan=N` occupies the same column slot in the next N-1 rows. Reg S-K Item 403 (17 CFR 229.403) prescribes the columns; it does not prescribe a layout, so the markup model is what maps a cell to a column. `_resolve_columns`' new percent guard is 229.403's own column 3 (a COUNT) vs column 4 (a PERCENT) — the mirror of a rule the percent pass already applied.

## Standard-filing reuse check

Mandatory here: this family had four prior per-case patches (#2088 / #2094 / #2097 and #2169's lineage), which is the trigger.

| candidate | result on OUR failing case (`0001104659-25-029081`) |
| --- | --- |
| `edgartools.extract_beneficial_ownership` | **returns `None`** — cannot even diagnose (consistent with skill G17) |
| `pandas.read_html` 3.0.2 (already a dependency) | **implements the model** — uniform 24-column frame, `Chase Carey Director` repeated across all six series rows, where ours returned 24 cells then 21 |

Not adoptable wholesale: `read_html` also expands `colspan`, and `_score_table_headers` SUMS keyword weights, so a `colspan=6` caption would score six times and reshuffle table selection corpus-wide. So the **algorithm** is mirrored from `pandas.io.html._HtmlFrameParser._expand_colspan_rowspan` and the cell extraction is untouched.

## Four things the full-population A/B forced

The naive version (carry by markup index, expand every row) passed 118 unit tests, the golden panel with **zero** drift, and Codex. It regressed three classes anyway. Each fix below names the accession that forced it, in the code.

1. **Carried cells are placed by LAYOUT column.** `colspan` is read for the arithmetic but never expanded. With `colspan=3|6` before a `rowspan=4` caption the markup-index carry landed three columns early, wrecked the promoted header and took `0001628280-26-025998` from 16 holders to **0**.
2. **A spacer `<tr>` emits nothing but still consumes a row of every span.** Consuming is the table model; emitting is not. Covers both shapes EDGAR generates — no cells at all, and all-blank cells (the second was Codex ckpt-2 P2).
3. **A row that inherits a cell and contributes no value of its own is a continuation, not a holder.** `rowspan="2"` on a holder's VALUE cells over a stacked name/address pair gave `0000107140-24-000176` a second "holder" `New York, NY 10055` at BlackRock's exact 6,782,743 / 14.97%. ⚠ The first cut also matched the second row of a two-row HEADER and took the same accession to zero a second time — the *inherited* cells must themselves be values.
4. **The generic `total` shares tier no longer claims a percent caption.** The percent pass takes only the FIRST match, so a second percent caption stayed eligible for the shares tiering, and `total` is tier 4 — `% of Total Voting Power` outranked the real `Shares` column and filed Dustin Moskovitz's Class B count against his Class A percent.

## Full-population A/B — 42,699 stored `def14a_body` payloads

Two real checkouts: control ran in a `git worktree` detached at `origin/main`, treatment on the branch. 0 `def14a_body` rows were inserted in the 6h spanning both arms, so the corpus is identical for both.

| | control (`origin/main`) | branch |
| --- | --- | --- |
| accessions with rows | 7,172 | **7,176** |
| rows | 109,187 | **109,267** |
| `sct_rows` (Item 402c) | 67,828 | **67,828** |
| SCT accessions drifted | — | **0** |

**Distinct holders, keyed `lower(trim(holder_name))` — every one classified, none averaged:**

- **Lost 182 across 73 accessions.** 98 address lines (`malvern, pa 19355`, `new york, ny 10055`, …), 31 share-series tickers, 28 labels/headings failing the owner-identity test, 24 from the single re-selection below. **Zero unclassified.**
- **Gained 262 across 60 accessions.** 241 genuine (BlackRock, Vanguard, FMR, Dimensional, T. Rowe Price, PRIMECAP, Capital International, Victory, Kayne Anderson Rudnick, plus named directors and officers); 21 enumerated junk — `building one` ×2, `palisades west, building one` ×2/×1, `one congress street, suite` ×2, `state street financial center` ×2, `one beacon street`, `shares subject to voting proxy` ×2, `indirect`, four `executive vice president & …` titles, and **`total` ×4**. The bare-aggregate-label class is #2176's per-row negative test and is left to it.
- **Four accessions go 0 → 16-21 real holders**: `0001577526-25-000012`, `0001628280-24-038092`, `0001174947-24-001089`, `0002077096-25-000112`.

**Arm 2 (parse vs STORED)** — the pairwise regression, *stored holders `main` reproduces and the branch does not*: 72 accessions / 181 holders, the same classification as above.

**Arm 3 (mechanism audit, `scripts/audit_def14a_rowspan.py`)** — 735,285 candidate tables; 32,846 carry a `rowspan>1`; **29,906 actually shift a row**, across **4,824 of 42,699 accessions**; 9,881 rows newly non-empty; `header_width_changed` **0** corpus-wide. Largest span seen is 50. So the mechanism touches 11.3% of accessions and only ~60 change output — most shifted tables are not the winning Item 403 table.

**The one re-selection, inspected.** `0001104659-24-081952` goes 25 → 12 rows. Not a value change: window `3361154-3873154` had five qualifying tables and **zero eligible** under control because the mis-columning left their identity fraction at 0.10-0.44, below the 0.5 floor — so the parser fell through to the whole-document window and returned SiriusXM's section. All five now score `idfrac = 1.00`, the higher-priority window wins as `_find_section_windows` intends, and the holders become Liberty Media's own board (Malone, Maffei, Bennett) plus Berkshire / Vanguard / Corvex / Point72. I believe this is correct for a Liberty Media filing; it is the one movement here that rests on judgement rather than arithmetic, so it is called out rather than buried.

## Item 402(c) is deliberately untouched

`parse_summary_compensation_table` shares this extractor and has carried its own rowspan-shift compensation since #1945 ("name-cell rowspan → continuation-year rows are index-shifted (AAPL/MSFT)"). Feeding it span-restored rows re-based that machinery: the A/B measured **580 accessions** drifting, every one the same way — `executive_name`, `fiscal_year`, `salary`, `total_comp` identical, `principal_position` repeated once per continuation year. So that call site passes `expand_spans=False` and its output is now byte-identical (drift 0, `sct_rows` unchanged). Re-basing that arm on the table model is worth doing and is not this ticket.

## Definition of Done

| clause | evidence | commit |
| --- | --- | --- |
| 8 — panel of 5 | AAPL / GME / MSFT / JPM / HD, all 10 stored accessions re-parsed under both checkouts: **0 holders lost, 0 gained, 0 values changed**. (The panel is inert here and says so — which is exactly why it is not the gate.) | `42322d4c` |
| 9 — cross-source | **SEC EDGAR direct**, re-fetched `…/1560385/000110465925029081/tm252442-2_def14a.htm` (3,059,223 bytes, byte-identical to the stored payload), read independently with `pandas.read_html` 3.0.2: `Evan D. Malone Director` holds `LLYVA 3`, `LLYVB 18(4)`, `LLYVK 15(4)(7)`, `FWONA 3`, `FWONB 17(4)`, `FWONK 24(7)`. `main` stored the 18 under a holder named **`LLYVB`** and the 17 under **`FWONB`**; the branch names Evan D. Malone and takes the first-listed series, `LLYVA = 3`. Figures match. | `42322d4c` |
| 10 — backfill | **operator** — see `## OPERATOR VERIFY` on #2175 | — |
| 11 — live figure | **operator** — same block; this worktree cannot reach the dev stack | — |
| 12 — recorded | this table | — |

## Tests

`TestRowSpanExpansion` — 10 tests, **9 revert-probed, all CAUGHT**: rowspan ignored; layout cursor advancing by 1 instead of `colspan`; spacer row emitting; blank-cell spacer not treated as a spacer; trailing-carry pass deleted; `rowspan=0` spanning the table; continuation rule removed; continuation rule ignoring whether inherited cells are values; percent captions eligible for the shares tiering.

⚠ Two probes initially reported CAUGHT/NOT-CAUGHT for the wrong reason and were rewritten — one broke syntax (pytest exit 4, which fails every test), one targeted a fixture that a second guard already covered. A probe that passes for the wrong reason proves nothing; both are noted in the harness.

Gates, each run separately: `ruff check` · `ruff format --check` · `pyright` (0/0/0) · `pytest -m "not db"` · `pytest tests/smoke` · file-scoped `-m db` over `test_def14a_ingest`, `test_manifest_parser_def14a`, `test_def14a_drift`, `test_rewash_filings`, `test_rewash_def14a_correct_zero`, `test_def14a_drill`. All exit 0.

⚠ The `ebull_test_template` on this box is at `260_strategy_signals_thin_cross_section.sql`, ahead of this branch's `256` — the concurrent TA loop rebuilt it from its own worktree. Harmless for a parser-only diff, but anyone chasing a db-tier failure here should check that first.

## Security

No security surface. Parser-only change over already-stored filing bodies; no new input path, no auth, no SQL. The one network call in this work was a read-only SEC EDGAR fetch for the cross-source check, using the configured `sec_user_agent`.

## Follow-ups

- **Item 402(c) on the table model** — the 580-accession `principal_position` duplication above; needs its own A/B against the exec-comp arm.
- **One holder × N share classes has nowhere to be stored.** 229.403 prescribes column 1 as `Title of class`; `_resolve_columns` returns three of the four prescribed columns and `def14a_beneficial_holdings` has no class column. So a multi-series holder's N rows collapse to one on the `lower(trim(holder_name))` dedup and keep the FIRST series' figures — for Liberty that is arbitrary with respect to which sibling instrument is being served. Strictly better than storing a ticker as a holder, still not right.
- ⚠ **`.claude/skills/data-sources/edgartools.md` G17 could not be updated** — this loop lacks write permission on `.claude/skills/**` (a prior session hit the same wall). The lesson (`pandas.read_html` is the one-command oracle for a markup-model defect; edgartools returns `None` here) is in `docs/review-prevention-log.md` and should be copied into G17 by the next session that has the permission.

## Prevention log

Two entries added: the table-model class itself, and a harness-integrity one — the A/B monkeypatches `_parse_table_html`, the wrapper did not forward `**kwargs`, and it reported `sct_rows 67,828 -> 0` while the parser returned 17 rows for the same filing. A harness bug of that shape produces a *dramatic* number, and a dramatic number reads as a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)