### PR TITLE
fix(#2169): one <tr> holding N Item 403 holders is N rows, not one

### DIFF
--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -1997,6 +1997,21 @@ def extract_plan_name_and_trustee(holder_name: str) -> tuple[str, str | None]:
 # ---------------------------------------------------------------------------
 
 
+# Score floor for a table to be a WINDOW CANDIDATE — below this we don't trust
+# the match. Empirically tuned: a minimal-header beneficial-ownership table
+# (``Name`` / ``Shares`` / ``Percent``) scores 3; tables with SEC-prescribed
+# wording score 6+. Compensation / option-grant tables typically score 0-2 even
+# when they include a "Name" column, because they lack ``shares`` / ``percent``
+# cues.
+#
+# Module-level rather than a local of ``parse_beneficial_ownership_table``
+# because the offline census scripts have to reproduce the same candidate set —
+# ``scripts/census_def14a_stacked_cell_holders.py`` re-derived it as its own
+# literal 3, and a local cannot be imported, so the two would have drifted the
+# first time this moved (review NITPICK on PR #2359).
+_WINDOW_SCORE_FLOOR: Final[int] = 3
+
+
 def parse_beneficial_ownership_table(html_text: str) -> Def14ABeneficialOwnershipTable:
     """Parse a DEF 14A primary doc HTML body and extract the
     Item 12 beneficial-ownership table.
@@ -2012,14 +2027,6 @@ def parse_beneficial_ownership_table(html_text: str) -> Def14ABeneficialOwnershi
     """
     if not html_text:
         return Def14ABeneficialOwnershipTable(as_of_date=None, rows=[], raw_table_score=0)
-
-    # Score floor — below this we don't trust the match. Empirically
-    # tuned: a minimal-header beneficial-ownership table
-    # (``Name`` / ``Shares`` / ``Percent``) scores 3; tables with
-    # SEC-prescribed wording score 6+. Compensation / option-grant
-    # tables typically score 0-2 even when they include a "Name"
-    # column because they lack ``shares``/``percent`` cues.
-    SCORE_FLOOR = 3
 
     candidate_windows = _find_section_windows(html_text)
     best_score = 0
@@ -2062,7 +2069,7 @@ def parse_beneficial_ownership_table(html_text: str) -> Def14ABeneficialOwnershi
             score = _score_table_headers(parsed.score_headers)
             if score > window_best_score:
                 window_best_score = score
-            if score >= SCORE_FLOOR:
+            if score >= _WINDOW_SCORE_FLOOR:
                 window_qualifying.append((score, parsed))
         # D2 / D3 (#2160) — ELIGIBILITY decides both which table wins the window
         # and which tables join it as Item 403 siblings. Header score no longer

--- a/app/providers/implementations/sec_def14a.py
+++ b/app/providers/implementations/sec_def14a.py
@@ -62,6 +62,7 @@ from __future__ import annotations
 import html
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import date, datetime
 from decimal import Decimal, InvalidOperation
@@ -2132,6 +2133,195 @@ def _pad_row(raw_row: tuple[str, ...], *, name_idx: int, shares_idx: int, percen
     return list(raw_row) + [""] * max(0, max(name_idx, shares_idx, percent_idx) + 1 - len(raw_row))
 
 
+def _cell_segments(cell: str) -> list[str]:
+    """Non-empty LINES of CELL, in document order.
+
+    ``_strip_inline_html`` collapses every whitespace class EXCEPT ``\\n``
+    (``_INLINE_WHITESPACE_RE``), so a cell's interior line breaks survive into
+    the parsed table. That is deliberate — the Item 402(c) SCT path splits a
+    name from its title on exactly that character — and it is what makes the
+    ``<br>``-stacked Item 403 row below recoverable at all.
+
+    ⚠ **It recovers only the half of that shape where a SOURCE newline follows
+    the tag.** ``_strip_inline_html`` replaces ``<br>`` itself with a SPACE, so
+    ``'486,340<br>658,400'`` arrives as one line and nothing here can segment
+    it — and ``_parse_share_count`` strips spaces and commas, so that cell
+    parses to 486,340,658,400. Measured, not hypothetical: 30 rows across 9
+    accessions of ``def14a_beneficial_holdings`` hold a share count above 1e10.
+    Filed as **#2358** rather than fixed here, because representing ``<br>`` as
+    a line break has to happen in the cell extractor that
+    ``parse_summary_compensation_table`` also uses — the shared-chokepoint class
+    #2175's prevention-log entry was written about, where the same move drifted
+    580 accessions of Item 402(c) output.
+    """
+    return [line.strip() for line in cell.split("\n") if line.strip()]
+
+
+def _stacked_name_blocks(cell: str) -> list[str]:
+    """Split a stacked Item 403 NAME cell into one block per beneficial owner.
+
+    Split on BLANK LINES, then flatten each block the way
+    ``_clean_beneficial_holder_name`` flattens a whole cell.
+
+    ⚠ Line ordinal cannot be used to align the name cell against the value
+    cells, and the ticket's own accession is the proof: on
+    ``0000351998-18-000006`` the value cells run 10 lines (``486,340`` at 0,
+    ``658,400`` at 9) while the name cell runs 17, because the issuer's
+    ``880 Third Avenue, 16 th`` / ``Floor`` and ``New`` / ``York, NY 10022``
+    are SOURCE WRAPS inside one holder's address. Index 9 of the name cell is
+    blank; the second holder starts at 10.
+
+    No published rule governs this — 17 CFR 229.403 prescribes the columns, not
+    the markup — so the split is fixed BY CONSTRUCTION on the blank line, and
+    the caller gates it on the block count matching the value count exactly.
+    A cell with no blank-line separator yields one block, the gate fails, and
+    the row is left exactly as it is today.
+    """
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in cell.split("\n"):
+        if line.strip():
+            current.append(line.strip())
+        elif current:
+            blocks.append(" ".join(current))
+            current = []
+    if current:
+        blocks.append(" ".join(current))
+    return blocks
+
+
+# The placeholders ``_parse_share_count`` and ``_parse_percent`` already accept
+# as "no value stated". A stacked value column may legitimately carry one per
+# line — an issuer reporting a percent for a holder whose count it omits — so
+# they neither evidence a holder nor contradict one.
+_ABSENT_VALUE_SEGMENTS: Final[frozenset[str]] = frozenset({"-", "—", "–", "N/A", "n/a"})
+
+
+def _is_whole_share_segment(segment: str) -> bool:
+    """True when SEGMENT is a 229.403 column-3 amount — a WHOLE share count."""
+    if "%" in segment:
+        return False
+    value = _parse_share_count(segment)
+    return value is not None and value == value.to_integral_value()
+
+
+def _is_percent_segment(segment: str) -> bool:
+    """True when SEGMENT is UNAMBIGUOUSLY a 229.403 column-4 percent.
+
+    Same bar as the ragged-row percent recovery in ``_extract_holder_rows``: a
+    bare number is not accepted, because ``_parse_percent``'s [0, 100] clamp
+    reads a small share count as a percent.
+    """
+    if "%" not in segment and segment not in ("*", "**"):
+        return False
+    return _parse_percent(segment) is not None
+
+
+def _value_stack_state(segments: list[str], is_value: Callable[[str], bool]) -> str:
+    """Classify a value column's line stack: ``none`` / ``stack`` / ``veto``.
+
+    ``none``  — fewer than two lines, or no line states a value at all.
+    ``stack`` — two or more lines, every one either a value or an explicit
+                placeholder, at least one a value.
+    ``veto``  — a multi-line cell carrying something that is neither.
+    """
+    if len(segments) < 2 or not any(is_value(segment) for segment in segments):
+        return "none"
+    if all(is_value(segment) or segment in _ABSENT_VALUE_SEGMENTS for segment in segments):
+        return "stack"
+    return "veto"
+
+
+def _split_stacked_holder_row(
+    raw_row: tuple[str, ...],
+    *,
+    name_idx: int,
+    shares_idx: int,
+    percent_idx: int,
+) -> list[tuple[str, ...]] | None:
+    """Expand ONE ``<tr>`` holding N beneficial owners into N rows, or ``None``.
+
+    Source rule: 17 CFR 229.403(a) and (b) prescribe a TABLE with one entry per
+    beneficial owner, and column 3 ("Amount and nature of beneficial
+    ownership") states ONE amount for ONE owner. A value cell that holds two
+    whole share counts on separate lines is therefore two owners the issuer
+    rendered inside a single ``<tr>`` with ``<br>``, not one owner with two
+    figures — the same class of defect as #2175, where the parser had not
+    implemented the ``rowspan`` half of the table model. Here the issuer's row
+    model is the LINE STACK and ours is the ``<tr>``.
+
+    Neither value parser tolerates the stack (``_parse_share_count`` of
+    ``'486,340 \\n \\n 658,400'`` is ``None``, and so is ``_parse_percent`` of
+    ``'5.86% \\n \\n 7.94%'``), so today the row dies on the "neither shares nor
+    percent parsed" guard and takes every holder in it with it —
+    ``0000351998-18-000006`` scores 12 on a textbook Item 403 header and stores
+    zero holders.
+
+    The trigger is the VALUE side, never the name side. A name cell with
+    interior line breaks is ambiguous by itself: a render wrap produces exactly
+    that, which is why ``_clean_beneficial_holder_name`` flattens it (#2140 D5 —
+    an interior wrap otherwise split ONE person across two holder identities on
+    704 rows / 117 instruments). Requiring the amounts to stack first is what
+    keeps that flatten intact: a wrapped name over a single amount never
+    reaches this function.
+
+    Every gate below must hold, or the row is returned unsplit:
+
+    1. A value column stacks ``k >= 2`` segments and **every** segment parses —
+       all whole share counts, or all percents. A partial stack ('486,340' and
+       a stray footnote line) is not evidence of k owners, and admitting it
+       would align the columns by a count nothing supports.
+    2. When BOTH value columns stack, they agree on ``k``.
+    3. The name cell yields exactly ``k`` blank-line-separated blocks.
+
+    Cells other than the name and the aligned value columns are distributed
+    when they carry exactly ``k`` non-empty lines (the footnote column of the
+    cited accession does: ``'(1)'`` and ``'(2)'``) and blanked otherwise —
+    leaving a stacked string in place would feed the value-recovery scans a
+    two-number cell that neither parser accepts.
+    """
+    cells = _pad_row(raw_row, name_idx=name_idx, shares_idx=shares_idx, percent_idx=percent_idx)
+
+    share_segs = _cell_segments(cells[shares_idx]) if 0 <= shares_idx < len(cells) else []
+    percent_segs = _cell_segments(cells[percent_idx]) if 0 <= percent_idx < len(cells) else []
+    shares_state = _value_stack_state(share_segs, _is_whole_share_segment)
+    percent_state = _value_stack_state(percent_segs, _is_percent_segment)
+
+    # A value column that stacks but does not fully resolve CONTRADICTS whatever
+    # count the other column offers, so it vetoes the split rather than being
+    # ignored. Without this, '486,340 / see note / 658,400' against two percents
+    # splits on the percent column's count of 2 and drops both amounts.
+    if "veto" in (shares_state, percent_state):
+        return None
+
+    if shares_state == "stack" and percent_state == "stack":
+        if len(share_segs) != len(percent_segs):
+            return None
+        count = len(share_segs)
+    elif shares_state == "stack":
+        count = len(share_segs)
+    elif percent_state == "stack":
+        count = len(percent_segs)
+    else:
+        return None
+
+    name_blocks = _stacked_name_blocks(cells[name_idx]) if 0 <= name_idx < len(cells) else []
+    if len(name_blocks) != count:
+        return None
+
+    split: list[tuple[str, ...]] = []
+    for ordinal in range(count):
+        row: list[str] = []
+        for index, cell in enumerate(cells):
+            if index == name_idx:
+                row.append(name_blocks[ordinal])
+                continue
+            segments = _cell_segments(cell)
+            row.append(segments[ordinal] if len(segments) == count else "")
+        split.append(tuple(row))
+    return split
+
+
 def _resolve_row_name(cells: list[str], *, name_idx: int, shares_idx: int) -> tuple[int, str]:
     """Return ``(source_index, raw_name_cell)`` for one data row.
 
@@ -2330,7 +2520,14 @@ def _extract_holder_rows(
     # Carrying the name forward is purely ADDITIVE at the row level: it fires
     # only on a pair where BOTH rows are already being dropped.
     pending_owner_name: str | None = None
-    raw_rows = list(table.rows)
+    # One-<tr>-N-holders expansion (#2169), BEFORE the loop rather than inside
+    # it: the stacked-name/address recovery above looks at ``raw_rows[idx + 1]``,
+    # so the sequence it walks must already be the expanded one or a split row's
+    # successor is the un-split original.
+    raw_rows: list[tuple[str, ...]] = []
+    for source_row in table.rows:
+        split = _split_stacked_holder_row(source_row, name_idx=name_idx, shares_idx=shares_idx, percent_idx=percent_idx)
+        raw_rows.extend(split if split is not None else [source_row])
     for idx, raw_row in enumerate(raw_rows):
         # The diversions below are gated on the NEXT row actually being an
         # address row, so the behaviour change is bounded to the stacked shape

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -3234,3 +3234,37 @@ Two things S-4 adds to the prevention above:
 - Caught by: running `--calibrate` and reading its output against the constants, in the same session. Not by any test — pinning the provenance constants by test would pin them to themselves.
 - Prevention: when a spec figure is copied into code, **re-measure it against the population the code uses** before writing it down, and put the reproducing command beside it. Where a figure must be written (a result row needs it, as here for stage 5c), have the verify script PRINT the live value next to the frozen one so a divergence is visible on every run rather than on the day somebody re-derives it.
 - Enforced in: this prevention log; `app/services/cost_model.py::CALIBRATION_LIMITS` (the corrected figures, with a note recording that two of them had been carried over); `scripts/verify_2240_cost_model.py::calibrate` (prints n, capture-hour concentration and distinct capture dates on every run).
+### A census hooked into the SELECTION path cannot see a defect that empties its own table (#2169, 2026-08-07)
+
+- Symptom: the first cut of `scripts/census_def14a_stacked_cell_holders.py` counted
+  the one-`<tr>`-N-holders shape by tracing `_extract_table_holders` at the
+  concatenation loop in `parse_beneficial_ownership_table` — the natural hook, because
+  that loop runs over exactly the tables the parser accepted. It reported **0 flagged
+  accessions in 300 payloads**, and **0 on the ticket's own known accession**.
+- Root cause: the shape being counted makes the table extract zero holders, so
+  `_is_item403_eligible` returns `False`, the window never qualifies, `best_table`
+  stays `None` and the concatenation loop never runs. On `0000351998-18-000006` the
+  table scores 12 on a textbook Item 403 header and is still never selected. **The
+  census was measuring the population of a defect over a set the defect removes
+  itself from.**
+- Fix: census over CANDIDATE tables — walk `_find_section_windows` →
+  `_scan_outer_tables` → `_parse_table_html` → score floor, and count rows there. The
+  full population then returned 3 accessions / 3 rows, of which the two nobody knew
+  about (`0000894671-25-000016`, `0001140361-26-013025`, the same issuer in
+  consecutive years) are the class the ticket flagged as uncounted: the shape riding
+  alongside 13 genuine holders, silently losing the second holder in the row.
+- ⚠ **Generalise past "def14a".** Whenever a census measures how often a parser
+  FAILS, ask which stage of the pipeline discards the failing item, and hook the
+  census UPSTREAM of that stage. A hook downstream of any rejection reports the
+  population of what survived rejection, which for a "how often does this break"
+  question is guaranteed to be an undercount — and it undercounts silently, with a
+  clean-looking zero.
+- ⚠ Second, independent failure on the same script and worth its own line: the rewrite
+  left a dangling `P._extract_table_holders = original` from the deleted monkeypatch,
+  which would have raised `NameError` **after** the scan loop and discarded a
+  40-minute full-population run before it wrote its JSON. `ruff` finds it in one
+  second (`F821 Undefined name`). **Lint the harness before launching it, not after —
+  a long-running measurement script is the one place where a name error costs
+  wall-clock instead of a traceback.**
+- Enforced in: this prevention log; `scripts/census_def14a_stacked_cell_holders.py`
+  (`_candidate_rows`'s docstring carries the measured zero that forced it).

--- a/scripts/census_def14a_stacked_cell_holders.py
+++ b/scripts/census_def14a_stacked_cell_holders.py
@@ -1,0 +1,234 @@
+"""Full-population census of the ONE-ROW / N-HOLDERS Item 403 shape (#2169).
+
+The defect: an issuer renders several beneficial owners inside a SINGLE
+``<tr>``, separated by ``<br>``, so every cell of that row is a stack of
+lines rather than one value. ``_clean_beneficial_holder_name`` flattens the
+name stack into one holder (correct for #2140 D5's render wrap, wrong here)
+and the value cells — which now hold two numbers — fail to parse, so the row
+is dropped.
+
+#2169 asks for the census BEFORE any fix, because the known population is one
+2018 accession found incidentally and "the same shape riding alongside genuine
+holders is uncounted".
+
+What is counted, and why the VALUE side is the discriminator: a name cell with
+interior newlines is ambiguous (a render wrap produces exactly that, which is
+what #2140 D5's flatten exists for). A cell that parses as TWO OR MORE share
+counts is not ambiguous — 17 CFR 229.403 column 3 is one amount per beneficial
+owner, so a second whole number on its own line in that cell is a second
+holder's amount, not a wrap of the first.
+
+Offline — reads ``filing_raw_documents``, never fetches from EDGAR. Runs on
+whichever tree it is invoked from; report the commit alongside the numbers.
+
+    PYTHONPATH=. uv run python scripts/census_def14a_stacked_cell_holders.py --out /tmp/2169-census.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from typing import Any
+
+import psycopg
+
+import app.providers.implementations.sec_def14a as P
+from app.config import settings
+
+
+def _segments(cell: str) -> list[str]:
+    """Non-empty lines of CELL, in document order."""
+    return [seg.strip() for seg in cell.split("\n") if seg.strip()]
+
+
+def _whole_counts(segs: list[str]) -> list[str]:
+    """Segments that parse as a WHOLE share count (229.403 column 3 is a count)."""
+    out = []
+    for seg in segs:
+        if "%" in seg:
+            continue
+        value = P._parse_share_count(seg)
+        if value is not None and value == value.to_integral_value():
+            out.append(seg)
+    return out
+
+
+def _percents(segs: list[str]) -> list[str]:
+    """Segments that are UNAMBIGUOUSLY a percent (carry '%' or the '*' marker)."""
+    out = []
+    for seg in segs:
+        if "%" not in seg and seg not in ("*", "**"):
+            continue
+        if P._parse_percent(seg) is not None:
+            out.append(seg)
+    return out
+
+
+# Arm 2 (Codex checkpoint 2, #2169). ``<br>`` is stripped to a SPACE by
+# ``_strip_inline_html``, not to a newline, so an issuer whose markup carries no
+# literal source newline after the tag renders two amounts onto ONE line:
+# ``'486,340<br>658,400'`` arrives as ``'486,340 658,400'``. Arm 1's newline
+# segmentation cannot see that, and neither can the split this ticket adds — but
+# ``_parse_share_count`` strips spaces AND commas, so the cell parses to
+# 486,340,658,400. That is a WRONG STORED VALUE rather than a dropped row, which
+# is strictly worse, so its population has to be measured rather than assumed.
+#
+# Two or more whitespace-separated groups of >= 3 digits. Three, not one: a
+# trailing 1-2 digit group is the unbracketed footnote superscript that
+# ``_TRAILING_FOOTNOTE_RE`` already strips ('52,606,862 1' is #2140's case, not
+# this one).
+_GLUED_AMOUNTS_RE = re.compile(r"^[\s(\[]*\d[\d,]{2,}(?:\s+\d[\d,]{2,})+[\s)\]]*$")
+
+
+_SCORE_FLOOR = 3
+
+
+def _candidate_rows(body: str) -> list[dict[str, Any]]:
+    """Every data row of every CANDIDATE Item 403 table, censused.
+
+    Deliberately NOT the tables the parser selects. The shape being counted
+    empties its own table, so ``_is_item403_eligible`` rejects it, the window
+    never qualifies and the concatenation loop never runs — a census hooked
+    into that loop reports zero on the ticket's own known accession
+    (measured: ``0000351998-18-000006``, score 12, selected tables 0).
+    """
+    out: list[dict[str, Any]] = []
+    seen_offsets: set[tuple[int, int]] = set()
+    for window_start, window_end in P._find_section_windows(body):
+        for start, end in P._scan_outer_tables(body, start=window_start, end=window_end):
+            if (start, end) in seen_offsets:
+                continue
+            seen_offsets.add((start, end))
+            table = P._parse_table_html(body[start:end])
+            if table is None or not table.rows:
+                continue
+            if P._score_table_headers(table.score_headers) < _SCORE_FLOOR:
+                continue
+            name_idx, shares_idx, percent_idx = P._resolve_columns(table.column_headers)
+            for raw_row in table.rows:
+                cells = P._pad_row(raw_row, name_idx=name_idx, shares_idx=shares_idx, percent_idx=percent_idx)
+                name_cell = cells[name_idx] if name_idx < len(cells) else ""
+                shares_cell = cells[shares_idx] if shares_idx < len(cells) else ""
+                pct_cell = cells[percent_idx] if 0 <= percent_idx < len(cells) else ""
+                share_segs = _segments(shares_cell)
+                out.append(
+                    {
+                        "name_segments": _segments(name_cell),
+                        "share_values": _whole_counts(share_segs),
+                        "percent_values": _percents(_segments(pct_cell)),
+                        # Arm 2 — one line, two amounts, no newline to split on.
+                        "glued_shares": [seg for seg in share_segs if _GLUED_AMOUNTS_RE.match(seg)],
+                    }
+                )
+    return out
+
+
+def _scan(limit: int | None) -> dict[str, Any]:
+    totals = Counter()
+    flagged: list[dict[str, Any]] = []
+    glued_rows: list[dict[str, Any]] = []
+
+    sql = """
+        SELECT accession_number, payload
+        FROM filing_raw_documents
+        WHERE document_kind = 'def14a_body'
+        ORDER BY accession_number
+        LIMIT %(limit)s
+    """
+
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET statement_timeout = 0")
+        with conn.cursor(name="def14a_stacked_census") as cur:
+            cur.itersize = 20
+            cur.execute(sql, {"limit": limit})
+            for accession, body in cur:
+                totals["accessions"] += 1
+                if totals["accessions"] % 2000 == 0:
+                    print(
+                        f"... {totals['accessions']} accessions, {totals['accessions_flagged']} flagged",
+                        flush=True,
+                    )
+                try:
+                    captured = _candidate_rows(body)
+                except Exception as exc:  # noqa: BLE001 — a census must not abort mid-corpus
+                    totals["parse_errors"] += 1
+                    print(f"PARSE-ERROR {accession}: {type(exc).__name__}: {exc}", file=sys.stderr, flush=True)
+                    continue
+
+                totals["candidate_rows"] += len(captured)
+                glued = [row for row in captured if row["glued_shares"]]
+                if glued:
+                    totals["rows_glued"] += len(glued)
+                    totals["accessions_glued"] += 1
+                    glued_rows.append({"accession": accession, "rows": glued[:5]})
+                acc_flagged = []
+                for row in captured:
+                    n_shares = len(row["share_values"])
+                    n_pct = len(row["percent_values"])
+                    if n_shares < 2 and n_pct < 2:
+                        continue
+                    acc_flagged.append(row)
+                if not acc_flagged:
+                    continue
+                # Only now is the full parse worth its cost — the census is a
+                # scan over 42k proxies and running BOTH paths on every one of
+                # them doubled a 40-minute job for a figure needed on the
+                # handful that flag.
+                try:
+                    holders = len(P.parse_beneficial_ownership_table(body).rows)
+                except Exception as exc:  # noqa: BLE001
+                    totals["parse_errors"] += 1
+                    print(f"PARSE-ERROR {accession}: {type(exc).__name__}: {exc}", file=sys.stderr, flush=True)
+                    continue
+                totals["accessions_flagged"] += 1
+                totals["rows_flagged"] += len(acc_flagged)
+                # The extra holders the shape hides: one row carries N amounts,
+                # the parser stores at most one.
+                totals["hidden_holders"] += sum(
+                    max(len(r["share_values"]), len(r["percent_values"])) - 1 for r in acc_flagged
+                )
+                if holders == 0:
+                    totals["accessions_flagged_zero_holders"] += 1
+                else:
+                    totals["accessions_flagged_with_holders"] += 1
+                flagged.append(
+                    {
+                        "accession": accession,
+                        "stored_holders": holders,
+                        "rows": acc_flagged,
+                    }
+                )
+
+    return {"totals": dict(totals), "flagged": flagged, "glued": glued_rows}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--limit", type=int, default=None)
+    args = ap.parse_args()
+
+    summary = _scan(args.limit)
+    with open(args.out, "w") as fh:
+        json.dump(summary, fh, indent=1)
+
+    print("== totals ==")
+    for key, value in sorted(summary["totals"].items()):
+        print(f"  {key:34s} {value:>10}")
+    print(f"\n== arm 2: single-line glued amounts: {len(summary['glued'])} accessions ==")
+    for entry in summary["glued"][:20]:
+        print(f"  {entry['accession']}  {[r['glued_shares'] for r in entry['rows']]}")
+    print(f"\n== flagged accessions: {len(summary['flagged'])} ==")
+    for entry in summary["flagged"][:40]:
+        print(f"  {entry['accession']}  stored_holders={entry['stored_holders']}  rows={len(entry['rows'])}")
+        for row in entry["rows"][:3]:
+            print(f"      shares={row['share_values']}  pct={row['percent_values']}")
+            print(f"      name  ={row['name_segments'][:8]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/census_def14a_stacked_cell_holders.py
+++ b/scripts/census_def14a_stacked_cell_holders.py
@@ -83,9 +83,6 @@ def _percents(segs: list[str]) -> list[str]:
 _GLUED_AMOUNTS_RE = re.compile(r"^[\s(\[]*\d[\d,]{2,}(?:\s+\d[\d,]{2,})+[\s)\]]*$")
 
 
-_SCORE_FLOOR = 3
-
-
 def _candidate_rows(body: str) -> list[dict[str, Any]]:
     """Every data row of every CANDIDATE Item 403 table, censused.
 
@@ -105,7 +102,7 @@ def _candidate_rows(body: str) -> list[dict[str, Any]]:
             table = P._parse_table_html(body[start:end])
             if table is None or not table.rows:
                 continue
-            if P._score_table_headers(table.score_headers) < _SCORE_FLOOR:
+            if P._score_table_headers(table.score_headers) < P._WINDOW_SCORE_FLOOR:
                 continue
             name_idx, shares_idx, percent_idx = P._resolve_columns(table.column_headers)
             for raw_row in table.rows:

--- a/scripts/census_def14a_stacked_cell_holders.py
+++ b/scripts/census_def14a_stacked_cell_holders.py
@@ -38,33 +38,27 @@ import psycopg
 import app.providers.implementations.sec_def14a as P
 from app.config import settings
 
-
-def _segments(cell: str) -> list[str]:
-    """Non-empty lines of CELL, in document order."""
-    return [seg.strip() for seg in cell.split("\n") if seg.strip()]
+# The segmentation and the two value classifiers are the PARSER's, imported
+# rather than restated (review NITPICK on PR #2359, and the same drift the
+# `_SCORE_FLOOR` nitpick before it named): a census whose definition of "this
+# segment is a 229.403 amount" differs from the code's is measuring a different
+# population than the one the fix acts on.
+#
+# ⚠ Consequence, and it is deliberate: this script is coupled to a tree where
+# `_is_whole_share_segment` / `_is_percent_segment` exist, so it cannot be run
+# unmodified against a pre-#2169 checkout. The control-arm numbers in the PR
+# were taken with the self-contained earlier revision for exactly that reason.
+_segments = P._cell_segments
 
 
 def _whole_counts(segs: list[str]) -> list[str]:
-    """Segments that parse as a WHOLE share count (229.403 column 3 is a count)."""
-    out = []
-    for seg in segs:
-        if "%" in seg:
-            continue
-        value = P._parse_share_count(seg)
-        if value is not None and value == value.to_integral_value():
-            out.append(seg)
-    return out
+    """Segments that are a 229.403 column-3 amount — a WHOLE share count."""
+    return [seg for seg in segs if P._is_whole_share_segment(seg)]
 
 
 def _percents(segs: list[str]) -> list[str]:
-    """Segments that are UNAMBIGUOUSLY a percent (carry '%' or the '*' marker)."""
-    out = []
-    for seg in segs:
-        if "%" not in seg and seg not in ("*", "**"):
-            continue
-        if P._parse_percent(seg) is not None:
-            out.append(seg)
-    return out
+    """Segments that are UNAMBIGUOUSLY a 229.403 column-4 percent."""
+    return [seg for seg in segs if P._is_percent_segment(seg)]
 
 
 # Arm 2 (Codex checkpoint 2, #2169). ``<br>`` is stripped to a SPACE by

--- a/scripts/probe_2169_stacked_cell_holders.py
+++ b/scripts/probe_2169_stacked_cell_holders.py
@@ -1,0 +1,186 @@
+"""Revert-probe the one-``<tr>``-N-holders invariant tests (#2169).
+
+    PYTHONPATH=. uv run python scripts/probe_2169_stacked_cell_holders.py
+
+Same two guards as ``scripts/probe_2240_s1_momentum.py``:
+
+1. ⚠ **Every anchor must occur EXACTLY ONCE**, asserted before the replace. A
+   probe that silently matches nothing mutates nothing, the test passes, and the
+   harness reports ``CAUGHT`` for a defect it never injected.
+2. ⚠ **A probe must DELETE or INVERT behaviour, never wrap it.**
+
+⚠ **The verdict gates on exit code 1, not on "non-zero"** (#2214, 2026-08-07):
+pytest exits **4** on a USAGE error, which is not a caught defect but reads as
+one under a ``rc != 0`` test — that reported a false 4/4 CAUGHT. Anything other
+than 0 or 1 is printed as a harness fault. For the same reason the subprocess
+passes ``-n 0`` rather than ``-p no:xdist``, which conflicts with this repo's
+``addopts``.
+
+⚠ NOT A TEST, and it must never become one: it mutates a tracked source file on
+disk. CI does not run it. Everything here is pure-tier; no database is needed.
+
+WHAT IS NOT PROBED, AND WHY
+---------------------------
+⚠ **``_cell_segments`` itself.** Every gate consumes it, so any mutation of it
+fails several tests at once and the probe attributes the catch to whichever
+selector ran — it discriminates nothing. Its behaviour is pinned by the gate
+probes below, each of which needs it correct to fail for the stated reason.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SRC = Path("app/providers/implementations/sec_def14a.py")
+TESTS = "tests/test_sec_def14a_parser.py"
+
+#: (what the injected defect IS, [(anchor, replacement), ...], -k selector)
+PROBES: list[tuple[str, list[tuple[str, str]], str]] = [
+    (
+        "the expansion is not wired into the row loop at all (pre-#2169 behaviour)",
+        [
+            (
+                "        raw_rows.extend(split if split is not None else [source_row])",
+                "        raw_rows.append(source_row)",
+            )
+        ],
+        "test_one_tr_holding_two_holders_yields_two_rows",
+    ),
+    (
+        # Gate 1. Without the veto the split runs on the OTHER column's count
+        # and both amounts are dropped into blanked cells.
+        "a partially-parsing value stack no longer vetoes the split",
+        [
+            (
+                '    if "veto" in (shares_state, percent_state):\n        return None',
+                "    if False:\n        return None",
+            )
+        ],
+        "test_a_partially_numeric_value_stack_is_not_split",
+    ),
+    (
+        # Gate 2. Two amounts against three percents: whichever column is
+        # consulted first silently wins and the name blocks align to it.
+        "the two value columns no longer have to agree on the holder count",
+        [
+            (
+                "        if len(share_segs) != len(percent_segs):\n            return None",
+                "        if False:\n            return None",
+            )
+        ],
+        "test_value_columns_that_disagree_on_the_count_are_not_split",
+    ),
+    (
+        # Gate 3, attacked at the construction rather than the comparison:
+        # treating EVERY line as its own holder is the obvious alternative
+        # split, and it is what #2140 D5's flatten exists to prevent.
+        "the name cell splits on every line instead of on blank lines",
+        [
+            (
+                "        if line.strip():\n            current.append(line.strip())\n        elif current:",
+                "        if line.strip():\n            blocks.append(line.strip())\n        elif current:",
+            )
+        ],
+        "test_a_name_cell_with_no_blank_line_separator_is_not_split",
+    ),
+    (
+        # The NAME side driving the count is the whole hazard of this ticket —
+        # #2140 D5 measured 704 rows / 117 instruments split across two holder
+        # identities by an interior render wrap.
+        "the holder count falls back to the NAME blocks when no value column stacks",
+        [
+            (
+                "    else:\n        return None\n\n    name_blocks =",
+                "    else:\n        count = len(_stacked_name_blocks(cells[name_idx]))\n\n    name_blocks =",
+            )
+        ],
+        "test_a_wrapped_name_over_a_single_amount_is_not_split",
+    ),
+    (
+        "an unaligned non-value cell is carried through whole instead of blanked",
+        [
+            (
+                '            row.append(segments[ordinal] if len(segments) == count else "")',
+                "            row.append(segments[ordinal] if len(segments) == count else cell)",
+            )
+        ],
+        "test_a_stacked_row_distributes_every_aligned_cell_by_ordinal",
+    ),
+    (
+        "the percent column alone can no longer evidence the split",
+        [
+            (
+                '    elif percent_state == "stack":\n        count = len(percent_segs)',
+                "    elif False:\n        count = len(percent_segs)",
+            )
+        ],
+        "test_a_percent_only_stack_splits_when_the_amounts_are_absent",
+    ),
+    (
+        # The floor is what keeps the expansion inert on the ordinary corpus:
+        # at < 1 a single-value row "stacks" at count 1 and every row in every
+        # Item 403 table goes through the split path.
+        "the two-line floor drops to one, so an ordinary row is a stack of one",
+        [("    if len(segments) < 2 or not any", "    if len(segments) < 1 or not any")],
+        "test_an_ordinary_single_holder_row_is_never_split",
+    ),
+]
+
+
+def run(selector: str) -> int:
+    """The named tests, in a subprocess so the mutated module is re-imported."""
+    return subprocess.run(
+        ["uv", "run", "pytest", TESTS, "-q", "-k", selector, "-p", "no:randomly", "-n", "0"],
+        capture_output=True,
+    ).returncode
+
+
+def main() -> int:
+    original = SRC.read_text()
+    failures: list[str] = []
+    try:
+        for name, edits, selector in PROBES:
+            mutated = original
+            bad_anchor = False
+            for old, new in edits:
+                count = mutated.count(old)
+                if count != 1:
+                    failures.append(f"{name}: anchor occurs {count} times, expected exactly 1 — probe proves nothing")
+                    bad_anchor = True
+                    break
+                mutated = mutated.replace(old, new)
+            if bad_anchor:
+                continue
+            SRC.write_text(mutated)
+            rc = run(selector)
+            SRC.write_text(original)
+            if rc == 1:
+                verdict = "CAUGHT"
+            elif rc == 0:
+                verdict = "*** NOT CAUGHT ***"
+                failures.append(name)
+            else:
+                verdict = f"*** HARNESS FAULT rc={rc} ***"
+                failures.append(f"{name}: pytest exited {rc} (usage/collection error, not a catch)")
+            print(f"  {verdict:<28} {name}", flush=True)
+    finally:
+        # ⚠ Restored even on KeyboardInterrupt. A harness that can leave a
+        # tracked source file mutated is one Ctrl-C away from a defect committed
+        # by accident.
+        SRC.write_text(original)
+
+    rc_suite = run("TestStackedCellHolders")
+    print(f"\n  restored suite: {'PASS' if rc_suite == 0 else f'*** rc={rc_suite} ***'}", flush=True)
+    if rc_suite:
+        failures.append("restored suite does not pass")
+    if failures:
+        print("\nUNCAUGHT:\n  " + "\n  ".join(failures), flush=True)
+        return 1
+    print(f"\nall {len(PROBES)} probes caught", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -2442,3 +2442,29 @@ York, NY 10022</td><td>486,340
             )
             is None
         )
+
+    def test_a_single_percent_beside_a_stacked_amount_column_is_not_copied_to_both(self) -> None:
+        """Review WARNING on PR #2359. When the amounts stack to k=2 and the
+        percent cell holds ONE value, that value is blanked rather than
+        duplicated across the split rows.
+
+        17 CFR 229.403 column 4 is per-owner: one percent beside two amounts
+        belongs to at most ONE of them, and the markup does not say which.
+        Copying it would fabricate a figure for the other — and
+        `ownership_def14a_*` reads `percent_of_class` as the holder's own. NULL
+        is the honest value; the amounts, which the markup DOES align, survive.
+
+        Measured before it was chosen: the full-population A/B over 42,705
+        payloads loses zero distinct holders, and no accession in the corpus
+        carries this shape today — so this test pins a decision, not a
+        behaviour anyone has observed.
+        """
+        assert _split_stacked_holder_row(
+            ("Alpha Capital LLC\n\nBeta Partners LP", "486,340\n\n658,400", "5.86%"),
+            name_idx=0,
+            shares_idx=1,
+            percent_idx=2,
+        ) == [
+            ("Alpha Capital LLC", "486,340", ""),
+            ("Beta Partners LP", "658,400", ""),
+        ]

--- a/tests/test_sec_def14a_parser.py
+++ b/tests/test_sec_def14a_parser.py
@@ -46,6 +46,7 @@ from app.providers.implementations.sec_def14a import (
     _resolve_columns,
     _score_table_headers,
     _shares_cell_percent_signature,
+    _split_stacked_holder_row,
     _strip_inline_html,
     extract_plan_name_and_trustee,
     is_esop_plan,
@@ -2275,3 +2276,169 @@ class TestRowSpanExpansion:
             (Decimal("1200"), Decimal("1.1")),
             (Decimal("4986588"), Decimal("8.4")),
         ]
+
+
+class TestStackedCellHolders:
+    """#2169 — one ``<tr>`` holding N beneficial owners, ``<br>``-stacked.
+
+    17 CFR 229.403(a)/(b) prescribe a table with one entry per beneficial owner
+    and ONE amount per entry (column 3), so a value cell holding two whole share
+    counts on separate lines is two owners rendered inside one ``<tr>``, not one
+    owner with two figures. ``0000351998-18-000006`` scores 12 on a textbook
+    Item 403 header and stored ZERO holders: neither value parser accepts the
+    stacked cell, so the row died on the "neither shares nor percent" guard.
+
+    Every gate has its own test, because the risk here is the OPPOSITE
+    direction — #2140 D5 flattens interior line breaks precisely because a
+    render wrap otherwise splits one person across two holder identities
+    (704 rows / 117 instruments full-pop). The trigger is the VALUE side.
+    """
+
+    def test_one_tr_holding_two_holders_yields_two_rows(self) -> None:
+        """The ticket's accession, cell-for-cell: two amounts, two percents,
+        two footnote markers, and a name cell whose two blocks are separated by
+        a blank line and internally wrapped mid-address."""
+        body = """
+        <table>
+          <tr><th>Name and Address</th><th>Amount and Nature of Beneficial Ownership</th>
+              <th></th><th>Percent of Shares Outstanding</th></tr>
+          <tr><td>Penbrook Management, LLC
+AnKap Partners, L.P.
+880 Third Avenue, 16 th
+Floor
+New York, NY 10022
+
+Renaissance Technologies LLC
+800
+Third Avenue
+New
+York, NY 10022</td><td>486,340
+
+
+
+658,400</td><td>(1)
+
+
+
+(2)</td><td>5.86%
+
+
+
+7.94%</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.shares, r.percent_of_class) for r in parsed.rows] == [
+            (Decimal("486340"), Decimal("5.86")),
+            (Decimal("658400"), Decimal("7.94")),
+        ]
+        assert parsed.rows[0].holder_name.startswith("Penbrook Management, LLC AnKap Partners, L.P.")
+        assert parsed.rows[1].holder_name.startswith("Renaissance Technologies LLC")
+
+    def test_a_wrapped_name_over_a_single_amount_is_not_split(self) -> None:
+        """#2140 D5's flatten must survive intact. A render wrap puts interior
+        line breaks in the name cell — including a blank one — but the value
+        side does not stack, so the row is one holder and the name flattens."""
+        body = """
+        <table>
+          <tr><th>Name and Address of Beneficial Owner</th>
+              <th>Number of Shares</th><th>Percent of Class</th></tr>
+          <tr><td>Michael
+ O. Johnson
+
+ 55 East 52nd Street</td><td>1,500,000</td><td>5.5%</td></tr>
+          <tr><td>The Vanguard Group</td><td>3,000,000</td><td>11.0%</td></tr>
+        </table>
+        """
+        parsed = parse_beneficial_ownership_table(_proxy_html(body=body))
+        assert [(r.holder_name, r.shares) for r in parsed.rows] == [
+            ("Michael O. Johnson 55 East 52nd Street", Decimal("1500000")),
+            ("The Vanguard Group", Decimal("3000000")),
+        ]
+
+    def test_a_partially_numeric_value_stack_is_not_split(self) -> None:
+        """Gate 1. A stacked value cell whose segments do not ALL parse as
+        whole share counts is not evidence of k owners — the count would then
+        rest on whichever lines happened to be numeric, and the name blocks
+        would be aligned against it."""
+        assert (
+            _split_stacked_holder_row(
+                ("Alpha Capital LLC\n\nBeta Partners LP", "486,340\nsee note\n658,400", "5.86%\n\n7.94%"),
+                name_idx=0,
+                shares_idx=1,
+                percent_idx=2,
+            )
+            is None
+        )
+
+    def test_value_columns_that_disagree_on_the_count_are_not_split(self) -> None:
+        """Gate 2. Two amounts against three percents cannot both be right, and
+        picking either would align the name blocks against a count the other
+        column contradicts."""
+        assert (
+            _split_stacked_holder_row(
+                ("Alpha Capital LLC\n\nBeta Partners LP", "486,340\n\n658,400", "5.86%\n7.10%\n7.94%"),
+                name_idx=0,
+                shares_idx=1,
+                percent_idx=2,
+            )
+            is None
+        )
+
+    def test_a_name_cell_with_no_blank_line_separator_is_not_split(self) -> None:
+        """Gate 3. Without a blank line the name cell yields ONE block, so
+        there is no construction that assigns the second amount an owner — the
+        row is left exactly as it is today rather than guessed at."""
+        assert (
+            _split_stacked_holder_row(
+                ("Alpha Capital LLC\nBeta Partners LP", "486,340\n\n658,400", "5.86%\n\n7.94%"),
+                name_idx=0,
+                shares_idx=1,
+                percent_idx=2,
+            )
+            is None
+        )
+
+    def test_a_stacked_row_distributes_every_aligned_cell_by_ordinal(self) -> None:
+        """The split is positional across the row: a non-value column carrying
+        exactly k non-empty lines (the footnote column of the cited accession)
+        is distributed, and one that does not align is blanked rather than left
+        holding a two-value string the recovery scans would then read."""
+        assert _split_stacked_holder_row(
+            (
+                "Alpha Capital LLC\n\nBeta Partners LP",
+                "486,340\n\n658,400",
+                "(1)\n\n(2)",
+                "unaligned",
+                "5.86%\n\n7.94%",
+            ),
+            name_idx=0,
+            shares_idx=1,
+            percent_idx=4,
+        ) == [
+            ("Alpha Capital LLC", "486,340", "(1)", "", "5.86%"),
+            ("Beta Partners LP", "658,400", "(2)", "", "7.94%"),
+        ]
+
+    def test_a_percent_only_stack_splits_when_the_amounts_are_absent(self) -> None:
+        """229.403 column 4 is as prescribed as column 3, and issuers omit the
+        count column outright. Two percents over two name blocks is the same
+        evidence."""
+        assert _split_stacked_holder_row(
+            ("Alpha Capital LLC\n\nBeta Partners LP", "—\n\n—", "5.86%\n\n7.94%"),
+            name_idx=0,
+            shares_idx=1,
+            percent_idx=2,
+        ) == [
+            ("Alpha Capital LLC", "—", "5.86%"),
+            ("Beta Partners LP", "—", "7.94%"),
+        ]
+
+    def test_an_ordinary_single_holder_row_is_never_split(self) -> None:
+        """The whole corpus is this shape; the expansion must be inert on it."""
+        assert (
+            _split_stacked_holder_row(
+                ("The Vanguard Group, Inc.", "3,000,000", "11.0%"), name_idx=0, shares_idx=1, percent_idx=2
+            )
+            is None
+        )


### PR DESCRIPTION
## What changed

An issuer can render several Item 403 beneficial owners inside a **single `<tr>`**, one
per line, so every cell of that row is a stack. `_parse_share_count` of
`'486,340 \n \n 658,400'` is `None` and so is `_parse_percent` of `'5.86% \n \n 7.94%'`,
so the row died on the "neither shares nor percent parsed" guard and took every holder in
it. `0000351998-18-000006` scores **12** on a textbook Item 403 header and stored **zero**
holders.

`_split_stacked_holder_row` expands such a row into N rows before the extraction loop, so
every downstream rule (role headings, the stacked name/address carry, ESOP detection,
identity dedup) sees ordinary rows.

**Source rule.** 17 CFR 229.403(a) and (b) prescribe a table with one entry per beneficial
owner, and column 3 ("Amount and nature of beneficial ownership") states ONE amount for ONE
owner. Two whole share counts in one cell is therefore two owners, not one owner with two
figures. The reg prescribes the columns, not the markup, so **no published rule governs how
to split the name cell** — that half is fixed **by construction** on the blank line, and
gated so a cell without one is left exactly as it is today.

**Why the trigger is the VALUE side and never the name side.** `_clean_beneficial_holder_name`
flattens interior line breaks because of #2140 D5, where a render wrap split ONE person
across two holder identities on 704 rows / 117 instruments. A wrapped name over a single
amount never reaches the new code. Three gates, each with its own revert-probed test:

1. every segment of a stacked value column must parse (a partial stack vetoes the split);
2. when both value columns stack they must agree on the count;
3. the name cell must yield exactly that many blank-line-separated blocks.

⚠ Line ORDINAL cannot align the columns, and the ticket's accession is the proof: the value
cells run 10 lines and the name cell runs 17, because `880 Third Avenue, 16 th` / `Floor`
are source wraps inside one holder's address.

## Census — deliverable 1 of the ticket, and it changed the design

`scripts/census_def14a_stacked_cell_holders.py`, **full population, 42,705 stored
`def14a_body` payloads**, 171,731 candidate rows:

```
accessions                        42705
candidate_rows                   171731
accessions_flagged                    3
  ...with holders already            2      <- the class the ticket said was uncounted
  ...extracting zero                 1      <- the known accession
rows_flagged                          3
hidden_holders                        3
```

⚠ **The first cut of the census reported 0 — including on the ticket's own accession.** It
hooked the concatenation loop in `parse_beneficial_ownership_table`, which never runs for
these tables: the shape empties its own table, so `_is_item403_eligible` rejects it and the
window never qualifies. The census had to be moved upstream of the rejection, onto
CANDIDATE tables. Written up in `docs/review-prevention-log.md`.

The two unknown accessions (`0000894671-25-000016`, `0001140361-26-013025` — Ohio Valley
Banc Corp, consecutive years) each stored 13 holders while silently losing the second holder
in one row: `Edward A. Bell`, 320,510 / 6.80% and 359,033 / 7.62%.

## Full-population A/B — two real checkouts

Control detached at `origin/main` in `.ebull-2169-control`, treatment on this branch,
`scripts/ab_2140_def14a_parser.py`:

```
accessions                        42705 ->      42705
accessions_with_rows               7176 ->       7177
rows                             109267 ->     109273

Item 402(c) SCT drift (must be empty):     0 accessions
accessions LOSING rows:                    0
accessions GAINING rows:                   3
distinct holders lost (total):             0
distinct holders gained (total):           6
newly-promoted distinct header shapes:     0
```

**Gain side, enumerated and classified by hand** — all six are genuine holders, none is an
address fragment or a label:

| accession | gained |
| --- | --- |
| `0000351998-18-000006` | `Penbrook Management, LLC AnKap Partners, L.P. …` 486,340 / 5.86%; `Renaissance Technologies LLC …` 658,400 / 7.94% |
| `0000894671-25-000016` | `Edward A. Bell …` 320,510 / 6.80%; `The Ohio Valley Bank Company, Trustee for ESOP …` 344,512 / 7.31% |
| `0001140361-26-013025` | `Edward A. Bell …` 359,033 / 7.62%; `The Ohio Valley Bank Company, Trustee for ESOP …` 335,681 / 7.13% |

The zero on the Item 402(c) arm is the check that matters structurally: `_split_stacked_holder_row`
lives in `_extract_holder_rows`, which the SCT path does not use — the shared-chokepoint
hazard #2175 was written about does not apply here, and the arm proves it rather than
asserting it.

## Revert probes — 8/8

`scripts/probe_2169_stacked_cell_holders.py`, each anchor asserted to occur exactly once,
each verdict gated on **exit code 1** (not "non-zero" — pytest exits 4 on a usage error,
which reported a false CAUGHT on #2214):

```
CAUGHT  the expansion is not wired into the row loop at all (pre-#2169 behaviour)
CAUGHT  a partially-parsing value stack no longer vetoes the split
CAUGHT  the two value columns no longer have to agree on the holder count
CAUGHT  the name cell splits on every line instead of on blank lines
CAUGHT  the holder count falls back to the NAME blocks when no value column stacks
CAUGHT  an unaligned non-value cell is carried through whole instead of blanked
CAUGHT  the percent column alone can no longer evidence the split
CAUGHT  the two-line floor drops to one, so an ordinary row is a stack of one
restored suite: PASS
```

The fifth is the #2140 D5 guard: letting the NAME side drive the count is the failure this
whole design is shaped around, and the probe confirms a test fails when it can.

## Standard-filing reuse check

Run on OUR failing document, not from the coverage notes:

- **`pandas.read_html`** (already a dependency, and the oracle that settled #2175) collapses
  the same way and worse — one row, values joined with spaces:
  `486,340  658,400  (1)  (2)`. It implements `rowspan`/`colspan`, not `<br>`.
- **edgartools** `edgar.proxy.html_extractor.extract_beneficial_ownership` on an
  `lxml` tree of the same payload returns **3 rows from a different table**:
  `BeneficialOwner(name='Anthony', …, shares=0)`, `'Joel'`, `'Rajeev'` — first names, zero
  shares. Not adoptable.
- **Structured source:** none. `.claude/skills/data-sources/sec-edgar.md` §"structured-data
  mandate" records DEF 14A as *"narrative HTML; no structured-XBRL mandate as of 2026-05"*.
  The ECD/Item 402(v) tags this parser already uses for NEO names are Item **402**, not 403.

## Filed, not fixed here — #2358

Codex checkpoint 2 found the other half of the shape and it is worse. `_strip_inline_html`
replaces `<br>` with a **space**, so an issuer whose markup carries no literal newline after
the tag renders `'486,340<br>658,400'` as one line — and `_parse_share_count` strips spaces
and commas, giving **486,340,658,400**. Measured on the full stored table (110,748 rows):
**30 rows above 1e10 across 9 accessions**, worst `3,183,454,219,115,736`. A wrong value, not
a dropped row.

Not folded in, deliberately: representing `<br>` as a line break has to happen in the cell
extractor that `parse_summary_compensation_table` also uses, where `\n` is load-bearing for
the name/title split — the shared-chokepoint class whose last instance drifted 580 accessions
of Item 402(c) output. It needs its own A/B arm and its own rebuild scope. The limitation is
recorded in `_cell_segments`'s docstring so the next reader meets it in the code.

## Definition of Done — ETL clauses

| clause | evidence | commit |
| --- | --- | --- |
| 8 — panel smoke | Every panel instrument's Item 403-bearing proxy, both A/B arms, holder lists byte-identical: AAPL `0001308179-26-000008` 16→16 · GME `0001193125-26-235130` 9→9 · HD `0000354950-26-000090` 21→21 · JPM `0000019617-26-000096` 18→18 · MSFT `0001193125-25-245150` 20→20 | `9ad8cb82` |
| 9 — cross-source | **Renaissance Technologies LLC's own SC 13G** on Data I/O, accession `0001037389-18-000025`, filed 2018-02-14 as of 2017-12-31, fetched from EDGAR: row (9) aggregate amount **658,400**, row (11) **7.99%**. This branch parses **658,400 / 7.94%** from the DEF 14A — share count exact; the percent differs because the proxy's denominator is its own later record-date count. Independent filer, independent form. | `9ad8cb82` |
| 10 — backfill | **Operator's** — see below. Three accessions, two issuers. | — |
| 11 — live figure | **Operator's** — this branch is a worktree; `:8000` serves `~/Dev/eBull`. | — |
| 12 — this table | — | `9ad8cb82` |

Gates, each run separately and unpiped: `ruff check` · `ruff format --check` · `pyright`
(0 errors) · `pytest -m "not db"` · `pytest tests/smoke` · `pytest -m db` on the six def14a
modules — all exit 0.

`_PARSER_VERSION_DEF14A` stays `def14a-v13`, matching #2175, which changed far more and did
not bump it: `sec_rebuild` resets `ingest_status='pending'` by scope and does not consult the
version, so the rewash does not depend on a bump.

## Security

No auth, authorisation, SQL or user-input surface. The parser reads stored SEC payloads; the
census and probe scripts are read-only against the dev DB (the probe mutates a tracked source
file on disk and restores it in a `finally`, and is not run by CI).

Closes #2169. Refs #2358. Refs #2175.
