### PR TITLE
chore: union-merge the prevention log so concurrent appends stop conflicting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,21 @@
 # also parse cleanly, but committing CRLF keeps the fixtures faithful
 # to what FINRA actually serves.
 tests/fixtures/finra/regsho/*.txt text eol=crlf
+
+# ⚠ Append-only logs: resolve concurrent appends by KEEPING BOTH SIDES.
+#
+# Two loops branch from main at the same time, both append their lesson at the
+# end of the file, and every merge then conflicts on the same last hunk. On
+# 2026-08-06 that was NINE hand-resolutions in one night, each of which was the
+# identical decision — keep both entries, in order. `merge=union` is that
+# decision, made once.
+#
+# Safe here specifically because these files are APPEND-ONLY by convention: a
+# union merge is wrong when both sides EDIT the same region, and right when both
+# sides add to the end. If an entry ever needs rewriting rather than adding, do
+# it in its own commit with nothing else in flight on the file.
+#
+# ⚠ Local only. Git's merge drivers do not run on GitHub's server-side merge
+# button, so this helps the loops' `git rebase origin/main` (which is where the
+# conflicts actually happen) and does nothing for a web merge.
+docs/review-prevention-log.md merge=union


### PR DESCRIPTION
Two loops branch from `main` at the same time, both append a lesson to the end of `docs/review-prevention-log.md`, and every subsequent rebase conflicts on the same last hunk. On 2026-08-06 that was **nine hand-resolutions in one night**, each the identical decision: keep both entries, in order.

`merge=union` is that decision, made once and made by git.

## ⚠ My first diagnosis was wrong, and the correction is the interesting part

I assumed the loops were inserting mid-file and was going to teach both prompts to append at the end instead. **They already append at the end** — the newest entries are today's, at the bottom. That is precisely *why* they collide: EOF is a single shared anchor, so "append at the end" makes conflicts certain rather than avoiding them.

The fix is not a convention anyone has to follow. It is a merge driver.

## Verified, not asserted

Throwaway repo reproducing the real shape — two branches each appending, then `git rebase`:

```
REBASE CLEAN — no conflict

### entry one
### entry from loop A (#111)
### entry from loop B (#222)
```

Both entries survive, in order. In this repo, `git check-attr merge -- docs/review-prevention-log.md` reports `union`.

## Two limits, both written into the file

- **Right for append-only, wrong for edits.** If both sides rewrite the same region, union keeps both versions rather than choosing. Rewriting an existing entry belongs in its own commit with nothing else in flight on that file.
- **Local only.** Merge drivers do not run on GitHub's server-side merge button. This helps the `git rebase origin/main` the loops actually perform — which is where every one of the nine conflicts occurred — and does nothing for a web merge.

Cosmetic: a blank line between two concurrently-appended entries can be collapsed, leaving them adjacent. The `###` headings still separate them.

## Scope

One file, `.gitattributes`, 18 lines of which most are the comment explaining when union is unsafe. No code, no schema, no behaviour.

## Security

None — a merge strategy for one documentation file.

Refs #2240.
