### PR TITLE
chore: bump transitive nanoid past GHSA-2v37-7h3g-55p8 to unblock CI

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1157,8 +1157,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2574,7 +2574,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   node-releases@2.0.37: {}
 
@@ -2639,7 +2639,7 @@ snapshots:
 
   postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
The `supply-chain` job's npm bulk advisory audit began failing **repo-wide** on 2026-08-07, on a newly-published advisory rather than on any diff:

```
audited 327 packages against the npm bulk advisory endpoint
1 advisories at or above 'high':
  [high] nanoid (installed: 3.3.16; vulnerable: <3.3.17)
    nanoid: custom generators can loop indefinitely when size is zero
    https://github.com/advisories/GHSA-2v37-7h3g-55p8
```

## Change

Lockfile only: `nanoid` **3.3.16 → 3.3.18** via `pnpm --dir frontend update nanoid`. `nanoid` is transitive (`postcss@8.5.22 → nanoid`), not in `frontend/package.json`, so there is no direct-dependency range change and no `package.json` diff.

## Environmental, not branch-specific

`supply-chain` passed on each of the last four `main` runs — most recently `9fc0062b` at 20:06Z — and failed at 21:35Z on #2387, a branch touching **no** frontend files. #2387 is `BLOCKED` solely on this, and so is every other PR in the repo including the concurrent TA loop's.

## Security

This *is* the security change: it clears a `high` advisory. `GHSA-2v37-7h3g-55p8` is DoS-shaped — a custom-alphabet generator can loop indefinitely when `size` is zero. Reached here only through `postcss` at build time rather than at runtime in the served bundle, so real exposure was low; the audit floor is `high` and the gate is right to stop on it.

## Verification

Pre-push hook green end to end, including all 24 chokepoint lints, `dark:check`, `pills:check`, chart integrity, fast tier and smoke.

⚠ The first push attempt failed on `tests/test_concurrent_fetch.py::TestRateLimitSafetyUnderConcurrency::test_throttle_lock_serialises_request_stamping[16]` — `throttle violation: 0.0108s < 0.02s floor`. That is **#2339**, the tracked load-sensitive flake in the fast tier, reproduced here at load average 12 and passing on a re-run at load 3.7. Same test, same `[16]` parametrisation, same assertion as the ticket records. Nothing was skipped or weakened, and `--no-verify` was not used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)