### PR TITLE
docs: TA operator-surface skill — show the outcome, not the mechanism

### DIFF
--- a/.claude/skills/frontend/ta-operator-surface.md
+++ b/.claude/skills/frontend/ta-operator-surface.md
@@ -1,0 +1,141 @@
+# frontend/ta-operator-surface
+
+## When to use
+
+Read before adding, renaming or removing **any figure, chart, control or label on the TA
+managed-trading surface** (phase 6/7). Pair it with `design-system.md` (surfaces, badges,
+chart theme), `operator-ui-conventions.md` (formatters, colour semantics) and the `dataviz`
+skill (chart form + palette validation).
+
+This file exists because the TA surface has a failure mode the other frontend skills do not
+cover: **it is built by someone fluent in the backtest vocabulary, for someone who is not.**
+Every metric here has a precise engineering meaning and a different, blunter question the
+operator is actually asking. Rendering the first and calling it the second is the defect.
+
+---
+
+## The governing rule — show the OUTCOME, not the MECHANISM
+
+The operator's question is almost always *"did it work, and what did it make me?"* The
+system's answer is usually a mechanism — which exit path fired, which gate refused, which
+arm the row came from. **Mechanism is a drill-through, never the headline.**
+
+Precedent (2026-08-08, concept v6). A panel titled *"How trades closed"* rendered
+`strategy_outcomes.resolution_method` verbatim as four bars:
+
+```text
+Hit its target · Stopped out · Signal said exit · Ran out of time
+```
+
+Operator response: *"Not sure what 3 of these mean."* Correct response. Three of the four
+are the same outcome — **the trade did not reach its goal** — separated by a mechanism only
+the parser cares about. The panel answered "by what route did the position close", a
+question nobody asked, and buried the one that was asked.
+
+The fix is not better labels. It is **collapsing to the outcome the user is asking about**,
+and putting the mechanism one level down:
+
+```text
+Reached its goal      34
+Didn't                66      → drill through for how: stopped / exited / timed out
+```
+
+**Test: if two rows would make the operator take the same action, they are one row.**
+
+---
+
+## Every figure passes three gates before it ships
+
+Apply to each number, bar, line and axis label — individually, not to the panel as a whole.
+
+1. **The sentence test.** Can a non-quant say what it means in one plain sentence, without
+   the word it is named after? "Expectancy" fails; *"what an average trade makes you after
+   costs"* passes. If the only available sentence restates the label, the label is jargon.
+2. **The decision test.** Does it change what the operator would do? If the answer is
+   "it's interesting", it belongs in the drill-through or nowhere. A page of true,
+   inert numbers is noise with good provenance.
+3. **The provenance test.** Name the column or the arithmetic. Every figure is either
+   a stored column (`strategy_results_store.max_drawdown_pct`), a documented derivation
+   (`trade_count − losing_trade_count` for win rate), or it does not ship. A figure with no
+   source is invented, and this repo's whole posture is that inventing one is the
+   cardinal defect.
+
+A figure failing 1 or 2 is not deleted by default — it is **demoted** to the drill-through.
+Failing 3 is deleted.
+
+---
+
+## Helper hover vs drill-through — pick by what's missing
+
+Both exist so the surface can stay quiet. They are not interchangeable.
+
+| The operator lacks… | Give them | Shape |
+| --- | --- | --- |
+| the **meaning** of a word | **helper hover** on the label | one or two sentences, ≤ ~220px, dotted underline on the label |
+| the **composition** of a number | **drill-through** | a panel or tab, opened deliberately |
+| the **mechanism** behind an outcome | **drill-through** | never a hover — it is a second question, not a definition |
+| nothing — it is self-evident | neither | most figures; resist decorating them |
+
+**A helper hover never carries a number.** The moment it does, it is data hiding from the
+layout, and it will go stale independently of the figure it explains.
+
+**Never spell out what the design already says.** A paragraph under a chart explaining how
+to read the chart means the chart is wrong. Fix the chart.
+
+---
+
+## The metric inventory — what we hold, and what it is called on screen
+
+Source of truth for names. If a new figure appears on the surface, add a row here with its
+column; if it has no column, it does not ship. Verify column names against
+`strategy_results_store` / `strategy_signals` / `strategy_outcomes` at write time
+(grep-before-cite), not from this table's memory.
+
+| Operator-facing name | Backed by | Gate 2 — why it earns its place |
+| --- | --- | --- |
+| **Made you** | position P&L, `gross_return_pct` net of `cost_model` | the only figure most sessions need |
+| **Worst dip** | `max_drawdown_pct` | what the operator *feels*; a strategy can end up and have halved on the way |
+| **Success rate** | `trade_count − losing_trade_count` over `trade_count` | "how often did it work" — the question actually asked |
+| **Per trade** | `expectancy_per_trade_pct` | decides whether it makes money at all; pair with success rate, never alone |
+| **vs buy &amp; hold** | `return_vs_buy_and_hold_pct` | the catalogue's own bar: fail it and it is not a strategy |
+| **Money working** | `exposure_time_pct` | answers "is my cash idle" |
+| **Turnaround** | `bars_held`, or `periods_per_year ÷ turnover_annualised` | half the return calculation — a fast small edge beats a slow big one |
+| **Captured** | `strategy_signals.verdict` funded ÷ fired | the missed-opportunity number |
+| **Why skipped** | `verdict` + `not_evaluable_reason` | tells the operator which lever to pull (pot size vs strategy choice) |
+| **Confidence** | `deflated_sharpe` vs its threshold | one bar against one line; never the four DSR inputs on the surface |
+| Profit factor | `profit_factor` | drill-through — duplicates success rate + per trade for most readers |
+| Sharpe / Sortino / ESS / deff / block length / trial count | the DSR + bootstrap columns | **drill-through only.** These are how we know, not what we know |
+
+⚠ **Win rate alone is banned as a headline** — the catalogue is explicit that a 76%-win
+strategy at 1:4 loses money. It ships only beside expectancy, never on its own.
+
+---
+
+## Naming — say the outcome in the operator's words
+
+- Prefer the verb the operator would use: *made you*, *worst dip*, *money working*.
+- Never surface an internal enum verbatim (`not_evaluable`, `carry_unmodelled`,
+  `survivor_only`). Translate, and keep the enum in the drill-through for support.
+- A refusal says **what is missing and who fixes it**, not the rule that fired.
+- ⚠ **Numbers that are unknown are not zero.** `carry` and FX are `None` in `cost_model.py`
+  by deliberate design. Render unknown as unknown; a zero here is a lie that flatters.
+
+---
+
+## Review loop — run this before any TA-surface PR
+
+Walk the rendered page top to bottom. For **each section**, then **each figure inside it**:
+
+1. Read the label aloud. Does it name an outcome or a mechanism?
+2. Apply the three gates. Record demote / keep / delete.
+3. If it needs explanation — is that a definition (hover) or a composition (drill)?
+4. Check the figure against its column. Does the arithmetic still hold?
+5. Check the **chart form** against `dataviz`: right form for the job, palette validated,
+   hover layer present, no dual axis.
+6. Check every **static string** for drift — version labels, counts and dates written by
+   hand go stale silently. (Precedent: a footer read "Concept v5" on the v6 page, in the
+   same pass that shipped v6. Compute it or omit it.)
+
+Record the pass as a table in the PR description: figure · gate result · action. A pass
+with no demotions is a pass that was not run — this surface accretes engineering detail by
+default, because the people building it can read it.


### PR DESCRIPTION
Adds `.claude/skills/frontend/ta-operator-surface.md`, plus the first pass of its own review loop run against the phase 6/7 concept. Doc-only.

## Why

The operator reviewed a "How trades closed" panel and said *"not sure what 3 of these mean"*:

```
Hit its target · Stopped out · Signal said exit · Ran out of time
```

They were right. Three of the four are the **same outcome** — the trade did not reach its goal — separated by a mechanism only the parser cares about. The panel answered "by what route did the position close", which nobody asked, and buried "did it work", which is the whole question.

That is not a labelling bug, it is a category error, and it will recur on every figure this surface adds because the people building it can read the raw vocabulary fluently.

## What the skill adds

- **The governing rule** — outcome is the headline, mechanism is a drill-through. Test: *if two rows would make the operator take the same action, they are one row.*
- **Three gates per figure**, applied individually: sentence (can a non-quant define it without using its own name), decision (does it change what they'd do), provenance (name the column or the arithmetic). Fail 1 or 2 → demote to drill-through; fail 3 → delete.
- **Helper hover vs drill-through** chosen by what's missing — meaning gets a hover, composition or mechanism gets a drill. A hover never carries a number.
- **The metric inventory** — operator-facing name → backing column → why it earns its place. Sharpe / Sortino / ESS / deff / block length / trial count are marked drill-through only: they are *how we know*, not *what we know*.
- **A review loop** for every TA-surface PR, including a static-string drift check.

## The loop, run — 31 figures

| Figure | Gate | Action |
| --- | --- | --- |
| How trades closed (4 bars) | 1 fail | **Collapse to 2** — "Reached its goal" / "Didn't", mechanism behind a drill |
| Confidence `0.082 / needs 0.083` | 1 fail | Keep the bar, **demote the raw number** — the ratio is meaningless unaided |
| Profit factor | 2 fail | **Demote** — duplicates success rate + per trade for most readers |
| Where trades end up (8 bins) | 2 marginal | **Demote to drill** — interesting, rarely decision-changing |
| Win rate (label) | naming | **Rename "Success rate"** — the operator's own word |
| Implied / year | pass | Keep — the only cross-strategy comparator |
| Worst dip · vs buy &amp; hold · Money working | pass | Keep — all three change a decision |
| Captured % · Missed edge · Why skipped | pass | Keep — the missed-opportunity lever |
| Taken vs missed chart | pass | Keep — unbiased control for a biased funded sample |
| Footer "Concept v5" on the v6 page | 6 fail | **Fix** — hand-written version drifted in the same pass that shipped v6 |

Net: 4 demotions, 1 collapse, 1 rename, 1 drift fix. Per the skill's own closing line — *a pass with no demotions is a pass that was not run*.

## Security

No security surface. Documentation only — no code, schema, endpoint or auth path touched.

## Verification

Doc-only, one new file. Pre-push gate green. Does not touch either running loop's files.

Refs #2240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)