### PR TITLE
feat(#2394): the strategy manifest — enumeration that cannot be forgotten, and the placement two guards decided

### DIFF
--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -1,0 +1,406 @@
+"""The strategy manifest — enumeration that cannot be forgotten (#2394 §2).
+
+Spec: ``docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md`` §2.
+Registry contract: ``app/services/strategy_registry.py`` (phase 3a). Refs #2240.
+
+THE DEFECT THIS CLOSES
+----------------------
+There was no enumeration of strategies anywhere — no ``__all__``, no registry
+list. Every caller imported modules by name, so the strategy set was whatever a
+given script happened to import. Measured on this tree by
+``scripts/verify_2394_strategy_manifest.py --census`` (nothing here is
+hardcoded): the per-module import counts are lopsided, which is why every
+phase-5 run report carries S-1 and S-3 figures and not S-2 and S-4. **Not a
+decision — an import list.** Adding S-5 means finding every one of those sites,
+and forgetting one produces a silently smaller population rather than an error,
+which is criterion 9's *"exclusion is visible rather than assumed harmless"*
+failing one layer up from where it was fixed.
+
+⚠⚠ THIS IS A SEPARATE MODULE AND **NOT** ``strategy_registry.py``, WHICH IS
+WHERE SPEC §2 PUT IT. Three reasons, the first of which is measurable:
+
+1. ``StrategyIdentity.version`` hashes ``_module_hash()`` — the bytes of
+   ``strategy_registry.py``. A manifest living there would move **every stored
+   strategy version every time a strategy is added**, so registering S-5 would
+   invalidate S-1's entire track record for no reason of S-1's. This module
+   leaves those bytes untouched, and that is checkable rather than asserted:
+   ``verify_2394_strategy_manifest.py --identity`` diffs the file against
+   ``origin/main`` and re-derives all four versions.
+2. The registry is imported **by** every strategy module, so it cannot import
+   them back. A bottom-of-file import would work only by accident of ordering.
+3. ``ExitRegime`` lives in ``position_builder``. Putting the manifest in the
+   registry would couple the pure signal contract to the position layer, and
+   every strategy module would then import the backtester transitively.
+
+⚠⚠ AND IT IS NOT INSIDE ``app/services/strategies/`` EITHER, WHICH IS WHERE IT
+WAS FIRST WRITTEN. ``tests/test_strategy_registry.py::TestInputRuleSetsAre
+Complete`` walks every module in that package and requires any imported
+``app.services`` module carrying a ``RULE_SET_VERSION`` to be inside
+``INPUT_RULE_SETS``. This module imports ``position_builder``, which has one — so
+the guard failed, correctly, on the first run of the fast tier.
+
+The two obvious answers are both wrong. Adding ``position_builder`` to
+``INPUT_RULE_SETS`` would move every strategy identity, which is reason 1 above
+happening by another route. Excluding this file from the walk would weaken a
+guard that is working. The manifest is not a strategy — it computes no verdict —
+so it belongs outside the package the guard scopes to, and the guard's reach is
+left exactly as it was.
+
+⚠ A CORRECTION TO SPEC §1, which says *"``STRATEGY_SET_ID`` … Adding or removing
+a strategy changes the set, so the manifest is versioned by it."* It does not,
+and must not: ``STRATEGY_SET_ID`` is a literal in the registry, and no field of
+``StrategyIdentity`` is a function of manifest membership. S-1's signals are not
+changed by S-5 existing, so S-1's version must not move when S-5 lands. The set
+id names the **contract** version, not the membership.
+
+⚠ WHAT THE MANIFEST DOES NOT CARRY: per-strategy *tuning*. No thresholds, no
+windows, no cost overrides. That is #2333's stance inherited verbatim — *"a
+field they must remember to fill is the same omission with a nicer name"*.
+
+⚠ WHAT IT DOES CARRY, AND WHY THAT IS NOT TUNING: the OPERATIONAL CONTRACT. A
+runner cannot invoke a strategy at all without knowing whether it is
+``per_series`` or ``cross_sectional``, which ``signal_kind`` legs it emits, and
+which exit regime resolves its outcomes. Omitting those forces the runner back
+into per-strategy ``if`` branches — the same defect in a new location.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Set
+from dataclasses import dataclass
+from datetime import date
+from types import MappingProxyType
+from typing import Literal, Protocol, get_args
+
+from app.services.indicator_series import BarSeries, Universe
+from app.services.position_builder import ExitRegime
+from app.services.strategies.s1_time_series_momentum import S1_STRATEGY_ID, s1_identity, s1_signals
+from app.services.strategies.s2_cross_sectional_momentum import (
+    MIN_CROSS_SECTION,
+    S2_STRATEGY_ID,
+    rebalance_dates,
+    s2_identity,
+    s2_member,
+    s2_select,
+)
+from app.services.strategies.s3_mean_reversion_in_trend import MAX_HOLD_BARS as S3_MAX_HOLD_BARS
+from app.services.strategies.s3_mean_reversion_in_trend import S3_STRATEGY_ID, s3_identity, s3_signals
+from app.services.strategies.s4_volatility_compression_breakout import MAX_HOLD_BARS as S4_MAX_HOLD_BARS
+from app.services.strategies.s4_volatility_compression_breakout import S4_STRATEGY_ID, s4_identity, s4_signals
+from app.services.strategy_registry import (
+    SIGNAL_KINDS,
+    CrossSectionalMember,
+    CrossSectionalSelect,
+    NotEvaluableReason,
+    SignalKind,
+    StrategyIdentity,
+    StrategySignal,
+)
+
+#: How the runner has to invoke this strategy. ``per_series`` takes one
+#: instrument's bars; ``cross_sectional`` needs a whole panel on a date, because
+#: "hold the top decile" is a statement about the cross-section and not about
+#: any one member (see ``strategy_registry.evaluate_cross_sectional``).
+StrategyClass = Literal["per_series", "cross_sectional"]
+
+#: ⚠ DERIVED, never restated — the closed-vocabulary-in-N-places defect the
+#: registry already fixed with ``get_args`` (#2218).
+STRATEGY_CLASSES: frozenset[str] = frozenset(get_args(StrategyClass))
+
+
+class IdentityFactory(Protocol):
+    """``s*_identity``. Both arguments are required — criterion 11 puts the
+    universe and the cost model *inside* the identity."""
+
+    def __call__(self, *, universe: Universe, cost_model_id: str) -> StrategyIdentity: ...
+
+
+class PerSeriesSignals(Protocol):
+    """The uniform per-series call. Every leg the strategy emits, in one list.
+
+    ⚠ ``masked_reason`` is one name for what the catalogue spells two ways:
+    ``s1_signals``/``s3_signals`` take ``close_reason`` (they read only closes),
+    ``s4_signals`` takes ``masked_reason`` (it reads all four OHLC fields). The
+    adapters below are exactly where that difference is absorbed — a runner
+    passing ``close_reason=`` to S-4 is a ``TypeError`` at call time, which is
+    the 19-call-site problem wearing a keyword.
+    """
+
+    def __call__(
+        self, series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason
+    ) -> list[StrategySignal]: ...
+
+
+class MemberStager(Protocol):
+    """The uniform cross-sectional call: one member's contribution to the panel.
+
+    ⚠ This is the MEMBER entry point, not ``s2_signals``. ``s2_signals`` holds
+    the whole panel in memory and says so; a full-corpus runner must stream one
+    series at a time through this and ``select``, which is what
+    ``StagedMember`` is public for.
+    """
+
+    def __call__(
+        self,
+        series: BarSeries,
+        *,
+        panel_decision_dates: Set[date],
+        universe: Universe,
+        masked_reason: NotEvaluableReason,
+    ) -> CrossSectionalMember: ...
+
+
+class DecisionCalendar(Protocol):
+    """The panel dates this strategy may act on, from the panel's union calendar.
+
+    ⚠ Returns ``None`` for a strategy with no calendar, rather than being absent
+    for one. That is what makes the runner branch-free::
+
+        regime = entry.exit_regime(entry.decision_calendar(calendar))
+
+    "No calendar" and "a calendar with no dates" stay distinguishable, which is
+    the same distinction ``ExitRegime.__post_init__`` already refuses to lose.
+    """
+
+    def __call__(self, calendar: Iterable[date]) -> frozenset[date] | None: ...
+
+
+class ExitRegimeFactory(Protocol):
+    """Which close sources this strategy declares — spec §3's table, executable.
+
+    ⚠ The table exists today only as prose in ``ExitRegime``'s docstring, and
+    every caller hand-builds the dataclass from it (``verify_2240_position_
+    builder.py`` builds S-1's and S-3's; nothing builds S-2's or S-4's). A
+    docstring cannot be iterated and cannot be wrong-in-CI, which is the same
+    reason this manifest exists at all.
+    """
+
+    def __call__(self, decision_dates: frozenset[date] | None) -> ExitRegime: ...
+
+
+@dataclass(frozen=True)
+class StrategyEntry:
+    """One registered strategy: how to identify it, how to invoke it, how it exits.
+
+    ⚠ A TAGGED UNION, checked rather than documented. ``strategy_class`` selects
+    which invocation fields must be present, and ``__post_init__`` refuses an
+    entry that populates the other arm — an entry declaring ``per_series`` while
+    carrying a ``select`` is a registration whose two halves disagree, and the
+    runner would honour whichever half it happened to read.
+    """
+
+    strategy_id: str
+    identity: IdentityFactory
+    strategy_class: StrategyClass
+    #: The legs this strategy emits. S-1/S-3 emit entry AND exit; S-2/S-4 entry
+    #: only. A runner reading this knows whether an absent exit row is a missing
+    #: write or the strategy's design.
+    signal_kinds: frozenset[SignalKind]
+    exit_regime: ExitRegimeFactory
+    decision_calendar: DecisionCalendar
+    #: ``per_series`` only.
+    signals: PerSeriesSignals | None = None
+    #: ``cross_sectional`` only, all three together.
+    member: MemberStager | None = None
+    select: CrossSectionalSelect | None = None
+    min_participants: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.strategy_id.strip():
+            raise ValueError("strategy_id must be a non-empty declaration")
+        if self.strategy_class not in STRATEGY_CLASSES:
+            raise ValueError(
+                f"unknown strategy class {self.strategy_class!r}; must be one of {sorted(STRATEGY_CLASSES)}"
+            )
+        # ⚠ A comprehension rather than set difference: ``signal_kinds`` is
+        # typed ``frozenset[SignalKind]`` and ``SIGNAL_KINDS`` is the runtime
+        # ``frozenset[str]``, and set operators are invariant in the element
+        # type. The membership test is what is actually wanted — an untyped
+        # caller can pass any string, which is the case being refused.
+        unknown = {kind for kind in self.signal_kinds if kind not in SIGNAL_KINDS}
+        if unknown:
+            raise ValueError(f"unknown signal kinds {sorted(unknown)}; must be within {sorted(SIGNAL_KINDS)}")
+        if "entry" not in self.signal_kinds:
+            raise ValueError(
+                f"{self.strategy_id} declares {sorted(self.signal_kinds)} and no entry leg — an exit-only "
+                "strategy has no position to close, and outcome resolution consumes fired ENTRIES"
+            )
+        cross_sectional_fields = (self.member, self.select, self.min_participants)
+        if self.strategy_class == "per_series":
+            if self.signals is None:
+                raise ValueError(f"{self.strategy_id} is per_series and declares no signals function")
+            if any(field is not None for field in cross_sectional_fields):
+                raise ValueError(
+                    f"{self.strategy_id} is per_series but carries cross-sectional fields — the runner would "
+                    "invoke whichever half it read first"
+                )
+        else:
+            if self.signals is not None:
+                raise ValueError(f"{self.strategy_id} is cross_sectional but carries a per-series signals function")
+            if any(field is None for field in cross_sectional_fields):
+                raise ValueError(
+                    f"{self.strategy_id} is cross_sectional and must declare member, select and "
+                    "min_participants together — a panel runner needs all three to rank anything"
+                )
+        if self.min_participants is not None and self.min_participants < 1:
+            raise ValueError(f"min_participants must be at least 1, got {self.min_participants}")
+
+
+def _no_decision_calendar(calendar: Iterable[date]) -> frozenset[date] | None:
+    """A per-series strategy acts on every bar it is evaluable at, not on a calendar."""
+    return None
+
+
+def _s1_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+    return s1_signals(series, universe=universe, close_reason=masked_reason)
+
+
+def _s3_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+    return s3_signals(series, universe=universe, close_reason=masked_reason)
+
+
+def _s4_signals(series: BarSeries, *, universe: Universe, masked_reason: NotEvaluableReason) -> list[StrategySignal]:
+    return s4_signals(series, universe=universe, masked_reason=masked_reason)
+
+
+def _s2_member(
+    series: BarSeries,
+    *,
+    panel_decision_dates: Set[date],
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+) -> CrossSectionalMember:
+    return s2_member(
+        series,
+        panel_rebalance_dates=panel_decision_dates,
+        universe=universe,
+        close_reason=masked_reason,
+    )
+
+
+def _reject_decision_dates(strategy_id: str, decision_dates: frozenset[date] | None) -> None:
+    """A per-series strategy handed a calendar is a runner bug, not a no-op.
+
+    Silently ignoring it would let a caller believe S-1 rebalances monthly.
+    """
+    if decision_dates is not None:
+        raise ValueError(
+            f"{strategy_id} declares no decision calendar, so it cannot be given {len(decision_dates)} "
+            "decision dates — pass the result of its own decision_calendar()"
+        )
+
+
+def _s1_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """§4 gives S-1 no holding bound, so ``signal_pair`` is its only close source.
+
+    ⚠ Spec §5.3 flags that as a genuine open problem for the walk-forward
+    embargo and recommends giving S-1 a declared bound. That would be a NEW
+    strategy version and is not this ticket's to make — the manifest records
+    what S-1 is today, not what it should become.
+    """
+    _reject_decision_dates(S1_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=True, level_based=False, max_hold_bars=None, rebalance_dates=None)
+
+
+def _s2_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-2 closes on the calendar: its hold is *"until the next rebalance"*.
+
+    ⚠ It declares NO ``max_hold_bars`` on purpose — approximating a month as 21
+    bars would invent a parameter §4 does not give.
+    """
+    if decision_dates is None:
+        raise ValueError(
+            f"{S2_STRATEGY_ID} closes on its rebalance calendar and cannot be built without one — "
+            "pass rebalance_dates(panel calendar)"
+        )
+    return ExitRegime(signal_pair=False, level_based=False, max_hold_bars=None, rebalance_dates=decision_dates)
+
+
+def _s3_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-3 exits on its own exit leg OR on the hold cap.
+
+    ⚠ ``level_based=False``: S-3 has no stop and no target — its exit is
+    ``rsi_14 > 50`` — so ``ExitLevels`` cannot be constructed for it. That is
+    ``ExitRegime``'s own correction to the catalogue's prose, carried here.
+    """
+    _reject_decision_dates(S3_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=True, level_based=False, max_hold_bars=S3_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+def _s4_exit_regime(decision_dates: frozenset[date] | None) -> ExitRegime:
+    """S-4 exits on an ATR stop/target fixed at signal time, or on the hold cap.
+
+    ⚠ ``level_based=True`` says the levels EXIST; nothing in ``app/`` computes
+    them yet (only ``scripts/verify_2240_outcome_resolver.py`` builds an
+    ``ExitLevels`` at all, generically). Stated rather than left to be
+    discovered: a runner reaching this entry needs a level provider, and the
+    manifest is not it.
+    """
+    _reject_decision_dates(S4_STRATEGY_ID, decision_dates)
+    return ExitRegime(signal_pair=False, level_based=True, max_hold_bars=S4_MAX_HOLD_BARS, rebalance_dates=None)
+
+
+#: Every strategy in the catalogue, keyed by ``strategy_id``.
+#:
+#: ⚠⚠ COMPLETENESS IS A TEST, NOT A CONVENTION.
+#: ``tests/test_strategy_manifest.py::TestManifestIsComplete`` walks every module
+#: under ``app.services.strategies`` and fails if one exposing a
+#: ``*_STRATEGY_ID`` is missing from here — the same pattern
+#: ``TestInputRuleSetsAreComplete`` already proves for ``INPUT_RULE_SETS``. So a
+#: strategy present in the tree but absent here **fails CI** rather than quietly
+#: not running.
+STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
+    {
+        S1_STRATEGY_ID: StrategyEntry(
+            strategy_id=S1_STRATEGY_ID,
+            identity=s1_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry", "exit"}),
+            exit_regime=_s1_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s1_signals,
+        ),
+        S2_STRATEGY_ID: StrategyEntry(
+            strategy_id=S2_STRATEGY_ID,
+            identity=s2_identity,
+            strategy_class="cross_sectional",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s2_exit_regime,
+            decision_calendar=rebalance_dates,
+            member=_s2_member,
+            select=s2_select,
+            min_participants=MIN_CROSS_SECTION,
+        ),
+        S3_STRATEGY_ID: StrategyEntry(
+            strategy_id=S3_STRATEGY_ID,
+            identity=s3_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry", "exit"}),
+            exit_regime=_s3_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s3_signals,
+        ),
+        S4_STRATEGY_ID: StrategyEntry(
+            strategy_id=S4_STRATEGY_ID,
+            identity=s4_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s4_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s4_signals,
+        ),
+    }
+)
+
+
+__all__ = [
+    "STRATEGY_CLASSES",
+    "STRATEGY_MANIFEST",
+    "DecisionCalendar",
+    "ExitRegimeFactory",
+    "IdentityFactory",
+    "MemberStager",
+    "PerSeriesSignals",
+    "StrategyClass",
+    "StrategyEntry",
+]

--- a/docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md
+++ b/docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md
@@ -60,6 +60,42 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry]   # strategy_id -> identity fn, s
                                                  # class, emitted legs, resolver shape
 ```
 
+⚠⚠ **CORRECTION, made while implementing it: the manifest landed in
+`app/services/strategy_manifest.py`, NOT in `strategy_registry.py`.** The shape above is
+unchanged; the placement was wrong for a reason this section could not see, and the first
+of the four is measurable:
+
+1. `StrategyIdentity.version` hashes `_module_hash()` — **the bytes of
+   `strategy_registry.py`**. A manifest living there would move *every stored strategy
+   version every time a strategy is added*, so registering S-5 would invalidate S-1's
+   entire track record for no reason of S-1's. `verify_2394_strategy_manifest.py
+   --identity` asserts all five identity-bearing files are byte-identical to `origin/main`
+   and prints the four versions, so the claim is checked rather than asserted.
+2. The registry is imported **by** every strategy module, so it cannot import them back.
+3. `ExitRegime` lives in `position_builder`; putting the manifest in the registry would
+   couple the pure signal contract to the position layer.
+4. ⚠ **It is not inside `app/services/strategies/` either**, which is where it was first
+   written. `TestInputRuleSetsAreComplete` walks every module in that package and requires
+   any imported `app.services` module carrying a `RULE_SET_VERSION` to be in
+   `INPUT_RULE_SETS` — and the manifest imports `position_builder`, which has one. The
+   guard failed on the first fast-tier run, correctly. Adding `position_builder` to
+   `INPUT_RULE_SETS` would be reason 1 by another route; excluding the file would weaken a
+   working guard. The manifest computes no verdict, so it belongs outside the package the
+   guard scopes to.
+
+⚠ **A second correction, to §1's last bullet** — *"Adding or removing a strategy changes
+the set, so the manifest is versioned by it."* It does not, and must not.
+`STRATEGY_SET_ID` is a literal in the registry and no field of `StrategyIdentity` is a
+function of manifest membership. S-1's signals are unchanged by S-5 existing, so S-1's
+version must not move when S-5 lands. The set id names the **contract** version, not the
+membership.
+
+⚠ **A third, to the field list** — the entry carries an `ExitRegimeFactory` rather than a
+free-text "resolver shape". `position_builder.ExitRegime` already *is* the per-strategy
+close-source contract, and §3's table already lives in its docstring as prose that every
+caller hand-builds from. The manifest makes that table executable instead of adding a
+second vocabulary for it.
+
 **The completeness check is a test, not a convention**, mirroring the pattern already proven
 by `tests/test_strategy_registry.py::TestInputRuleSetsAreComplete`: walk every module under
 `app.services.strategies` (excluding known non-strategy modules), and fail if a module

--- a/scripts/probe_2394_strategy_manifest.py
+++ b/scripts/probe_2394_strategy_manifest.py
@@ -1,0 +1,165 @@
+"""Revert-probes for the strategy manifest's invariant tests (#2394 §2).
+
+    PYTHONPATH=. uv run python scripts/probe_2394_strategy_manifest.py
+
+⚠ NOTHING IS WRITTEN TO THE DATABASE. This edits source files in place, runs one
+targeted test, and restores them — including on failure. Gate on the EXIT CODE:
+0 means every probe was CAUGHT by the test it targets, 1 means at least one
+defect passed the suite unnoticed.
+
+WHY THIS EXISTS
+---------------
+A test asserting a value can pass because the value is right OR because the
+assertion never runs. Each probe below injects the exact defect one test claims
+to guard, and requires that test to FAIL. A probe that changes nothing proves
+nothing, so every substitution asserts it matched exactly once before applying
+it — the prevention-log lesson from a probe that silently matched no text.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MANIFEST = REPO / "app" / "services" / "strategy_manifest.py"
+
+
+@dataclass(frozen=True)
+class Probe:
+    """One injected defect and the test that must catch it."""
+
+    name: str
+    path: Path
+    old: str
+    new: str
+    test: str
+
+
+PROBES: tuple[Probe, ...] = (
+    Probe(
+        name="a strategy exists in the tree but is not registered",
+        path=MANIFEST,
+        old="""        S4_STRATEGY_ID: StrategyEntry(
+            strategy_id=S4_STRATEGY_ID,
+            identity=s4_identity,
+            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s4_exit_regime,
+            decision_calendar=_no_decision_calendar,
+            signals=_s4_signals,
+        ),
+""",
+        new="",
+        test="tests/test_strategy_manifest.py::TestManifestIsComplete::test_every_strategy_module_is_registered",
+    ),
+    Probe(
+        name="an adapter drops the caller's reason code and defaults it",
+        path=MANIFEST,
+        old="    return s4_signals(series, universe=universe, masked_reason=masked_reason)",
+        new='    return s4_signals(series, universe=universe, masked_reason="quarantined_bar")',
+        test=(
+            "tests/test_strategy_manifest.py::TestUniformInvocationEqualsTheDirectCall"
+            "::test_the_reason_code_reaches_the_verdict"
+        ),
+    ),
+    Probe(
+        name="an adapter forwards to the wrong strategy's function",
+        path=MANIFEST,
+        old="    return s3_signals(series, universe=universe, close_reason=masked_reason)",
+        new="    return s1_signals(series, universe=universe, close_reason=masked_reason)",
+        test=(
+            "tests/test_strategy_manifest.py::TestUniformInvocationEqualsTheDirectCall"
+            "::test_close_reason_strategies_match"
+        ),
+    ),
+    Probe(
+        name="S-3's hold cap is dropped from its exit regime",
+        path=MANIFEST,
+        old=(
+            "    return ExitRegime(signal_pair=True, level_based=False, "
+            "max_hold_bars=S3_MAX_HOLD_BARS, rebalance_dates=None)"
+        ),
+        new="    return ExitRegime(signal_pair=True, level_based=False, max_hold_bars=None, rebalance_dates=None)",
+        test="tests/test_strategy_manifest.py::TestExitRegimeTableIsExecutable::test_regime_matches_the_spec_table",
+    ),
+    Probe(
+        name="a per-series strategy silently accepts a rebalance calendar",
+        path=MANIFEST,
+        old="""    if decision_dates is not None:
+        raise ValueError(""",
+        new="""    if False:
+        raise ValueError(""",
+        test=(
+            "tests/test_strategy_manifest.py::TestExitRegimeTableIsExecutable"
+            "::test_a_per_series_strategy_refuses_a_calendar"
+        ),
+    ),
+    Probe(
+        name="a strategy declares a leg it does not emit",
+        path=MANIFEST,
+        old="""            strategy_class="per_series",
+            signal_kinds=frozenset({"entry"}),
+            exit_regime=_s4_exit_regime,""",
+        new="""            strategy_class="per_series",
+            signal_kinds=frozenset({"entry", "exit"}),
+            exit_regime=_s4_exit_regime,""",
+        test=(
+            "tests/test_strategy_manifest.py::TestUniformInvocationEqualsTheDirectCall"
+            "::test_emitted_kinds_are_the_declared_kinds"
+        ),
+    ),
+    Probe(
+        name="the completeness walk stops reading the strategy modules",
+        path=REPO / "tests" / "test_strategy_manifest.py",
+        old="            if path.name in cls._NOT_STRATEGIES:\n                continue",
+        new="            if True:\n                continue",
+        test="tests/test_strategy_manifest.py::TestManifestIsComplete::test_the_walk_finds_the_strategies",
+    ),
+)
+
+
+def _run(test: str) -> int:
+    """The targeted test's exit code. ⚠ Not piped — a pipe returns the pipe's
+    status, which is the defect this repo has re-committed twice."""
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", test, "-q", "--no-header", "-p", "no:cacheprovider"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    ).returncode
+
+
+def main() -> int:
+    failures: list[str] = []
+    for probe in PROBES:
+        original = probe.path.read_text()
+        count = original.count(probe.old)
+        if count != 1:
+            failures.append(f"NO-OP PROBE: {probe.name!r} matched its target {count} times, expected exactly 1")
+            print(f"  ✗ {probe.name}: target matched {count} times — the probe would prove nothing", flush=True)
+            continue
+        probe.path.write_text(original.replace(probe.old, probe.new))
+        try:
+            code = _run(probe.test)
+        finally:
+            probe.path.write_text(original)
+        if code == 0:
+            failures.append(f"NOT CAUGHT: {probe.name!r} passed {probe.test}")
+            print(f"  ✗ {probe.name}: the test PASSED with the defect present", flush=True)
+        else:
+            print(f"  ✓ {probe.name}: caught (exit {code})", flush=True)
+
+    print(f"\nprobes {len(PROBES)}   caught {len(PROBES) - len(failures)}   missed {len(failures)}")
+    for failure in failures:
+        print(f"  {failure}")
+
+    baseline = _run("tests/test_strategy_manifest.py")
+    print(f"restored suite exit {baseline}")
+    return 0 if not failures and baseline == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_2394_strategy_manifest.py
+++ b/scripts/verify_2394_strategy_manifest.py
@@ -1,0 +1,266 @@
+"""Full-population verification of the strategy manifest (#2394 §2).
+
+    PYTHONPATH=. uv run python scripts/verify_2394_strategy_manifest.py --all
+
+⚠ NOTHING IS WRITTEN. Every arm reads and prints. Gate on the EXIT CODE — 0
+means every arm passed, 1 means at least one did not.
+
+⚠ NEVER PIPE THIS INTO ``head``/``tail``. A pipe returns the pipe's status, so a
+failure reads as success, and it buffers the progress lines a long run is judged
+by (`.claude/CLAUDE.md`).
+
+THREE ARMS, MEASURING DIFFERENT THINGS
+--------------------------------------
+``--census`` — the defect, counted on this tree rather than quoted from the
+issue. How many call sites name a strategy module directly, per module, and how
+many strategies the manifest covers. This is the asymmetry that made every
+phase-5 run report carry S-1 and S-3 figures and not S-2 and S-4.
+
+``--identity`` — ⚠⚠ THE CLAIM MOST WORTH FALSIFYING. ``StrategyIdentity.version``
+hashes the bytes of ``strategy_registry.py`` and of the defining strategy
+module, so a manifest placed in either would move every stored strategy version
+the moment a strategy is added. This arm diffs all five identity-bearing files
+against ``origin/main`` and requires them BYTE-IDENTICAL, then prints the four
+versions this tree produces. It is a proof about the change, not about the data.
+
+``--equivalence`` — the full research corpus, every series, through the fail-
+closed masked loader. For each per-series strategy the manifest's uniform call
+is compared verdict-for-verdict against the module's own function, and for S-2
+the staged member is compared field-for-field. The adapters absorb a keyword
+difference (``close_reason`` vs ``masked_reason``); a wrapper that forwards the
+wrong keyword or the wrong module's function type-checks and fails only when
+called. It also reports the per-strategy verdict distribution, which is what a
+manifest-driven runner would cover — the same population for all four, where an
+import list covered two.
+
+⚠ S-2's PANEL VERDICTS ARE NOT RESOLVED HERE. Ranking needs the panel's union
+calendar and a cross-section per date, which ``verify_2240_s2_cross_sectional.py``
+already streams. The claim made here is about the manifest's INVOCATION
+contract, not about S-2's verdicts, and the two must not be pooled.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import psycopg
+
+from app.config import settings
+from app.services.cost_model import COST_MODEL_ID
+from app.services.indicator_series import BarSeries
+from app.services.research_price_structure_store import load_masked_series
+from app.services.strategies.s1_time_series_momentum import s1_signals
+from app.services.strategies.s2_cross_sectional_momentum import s2_member
+from app.services.strategies.s3_mean_reversion_in_trend import s3_signals
+from app.services.strategies.s4_volatility_compression_breakout import s4_signals
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.technical_analysis import OHLCVRow
+
+REPO = Path(__file__).resolve().parent.parent
+
+#: The research corpus is survivor-only (#2284) and every figure below inherits
+#: that label (#2288).
+UNIVERSE = "survivor_only"
+
+#: What ``load_masked_series`` means by an absent field.
+MASKED_REASON = "quarantined_bar"
+
+#: ⚠ Every file whose BYTES are inside a ``StrategyIdentity.version``: the
+#: registry (via ``_module_hash``) and each strategy module (via its own
+#: ``_source_hash``). Editing any of them moves stored versions.
+IDENTITY_BEARING = (
+    "app/services/strategy_registry.py",
+    "app/services/strategies/s1_time_series_momentum.py",
+    "app/services/strategies/s2_cross_sectional_momentum.py",
+    "app/services/strategies/s3_mean_reversion_in_trend.py",
+    "app/services/strategies/s4_volatility_compression_breakout.py",
+)
+
+#: The direct function each manifest adapter is required to agree with. ⚠ Named
+#: here rather than reached through the manifest, which would compare it to
+#: itself.
+DIRECT_PER_SERIES = {
+    "s1-time-series-momentum": s1_signals,
+    "s3-mean-reversion-in-trend": s3_signals,
+}
+
+
+def _series_bars(bars: object) -> BarSeries:
+    rows: list[OHLCVRow] = [
+        {"open": b.open, "high": b.high, "low": b.low, "close": b.close, "volume": b.volume}  # type: ignore[typeddict-item, union-attr]
+        for b in bars  # type: ignore[attr-defined]
+    ]
+    return BarSeries(dates=tuple(b.bar_date for b in bars), rows=tuple(rows))  # type: ignore[attr-defined]
+
+
+def census() -> bool:
+    """The import asymmetry, counted on this tree."""
+    print("CENSUS — how the strategy set was decided before the manifest")
+    roots = [REPO / "app", REPO / "scripts", REPO / "tests"]
+    sites: Counter[str] = Counter()
+    files: Counter[str] = Counter()
+    pattern = re.compile(r"strategies\.(s\d+)_")
+    for root in roots:
+        for path in sorted(root.rglob("*.py")):
+            if path.name == "strategy_manifest.py":
+                continue
+            text = path.read_text()
+            seen: set[str] = set()
+            for match in pattern.finditer(text):
+                sites[match.group(1)] += 1
+                seen.add(match.group(1))
+            for module in seen:
+                files[module] += 1
+
+    total_sites = sum(sites.values())
+    print(f"  call sites naming a strategy module directly: {total_sites}")
+    for module in sorted(set(sites) | set(files)):
+        print(f"    {module}: {sites[module]} sites across {files[module]} files")
+    print(f"  manifest entries: {len(STRATEGY_MANIFEST)} — {', '.join(sorted(STRATEGY_MANIFEST))}")
+
+    classes = Counter(entry.strategy_class for entry in STRATEGY_MANIFEST.values())
+    print(f"  by class: {dict(sorted(classes.items()))}")
+    legs = {key: sorted(entry.signal_kinds) for key, entry in sorted(STRATEGY_MANIFEST.items())}
+    for key, kinds in legs.items():
+        print(f"    {key}: emits {kinds}")
+
+    spread = max(sites.values()) - min(sites.values()) if sites else 0
+    print(f"  ⚠ the spread between the most- and least-imported module is {spread} call sites")
+    return True
+
+
+def identity() -> bool:
+    """⚠⚠ No identity-bearing file may have moved. See the module docstring."""
+    print("IDENTITY — does this change move any stored strategy version?")
+    ok = True
+    for relative in IDENTITY_BEARING:
+        head = subprocess.run(
+            ["git", "show", f"origin/main:{relative}"],
+            cwd=REPO,
+            capture_output=True,
+        )
+        if head.returncode != 0:
+            print(f"  ✗ {relative}: not readable at origin/main")
+            ok = False
+            continue
+        current = (REPO / relative).read_bytes()
+        same = current == head.stdout
+        print(f"  {'✓' if same else '✗'} {relative}: {'byte-identical to origin/main' if same else 'CHANGED'}")
+        ok = ok and same
+
+    print("  versions this tree produces:")
+    for key, entry in sorted(STRATEGY_MANIFEST.items()):
+        version = entry.identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        print(f"    {key}: {version}")
+    if not ok:
+        print("  ⚠⚠ an identity-bearing file moved — every stored signal for that strategy is now a different version")
+    return ok
+
+
+def equivalence() -> bool:
+    """Full corpus: the manifest's call must equal the module's own."""
+    print("EQUIVALENCE — the manifest's uniform call vs the module's own function")
+    started = time.monotonic()
+    with psycopg.connect(settings.database_url) as conn:
+        series_ids = [
+            int(row[0])
+            for row in conn.execute("SELECT series_id FROM research_price_series ORDER BY series_id").fetchall()
+        ]
+        print(f"  research series {len(series_ids)}", flush=True)
+
+        empty = 0
+        bars = 0
+        mismatches: list[str] = []
+        verdicts: Counter[tuple[str, str, str]] = Counter()
+        s2_participating = 0
+        for n, series_id in enumerate(series_ids, start=1):
+            masked = load_masked_series(conn, series_id)
+            if not masked.bars:
+                empty += 1
+                continue
+            series = _series_bars(masked.bars)
+            bars += len(series)
+
+            for key, direct in DIRECT_PER_SERIES.items():
+                entry = STRATEGY_MANIFEST[key]
+                assert entry.signals is not None
+                got = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                want = direct(series, universe=UNIVERSE, close_reason=MASKED_REASON)
+                if got != want:
+                    mismatches.append(f"{key} series {series_id}")
+                for signal in got:
+                    verdicts[(key, signal.kind, signal.verdict)] += 1
+
+            s4 = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
+            assert s4.signals is not None
+            got_s4 = s4.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            if got_s4 != s4_signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON):
+                mismatches.append(f"s4-volatility-compression-breakout series {series_id}")
+            for signal in got_s4:
+                verdicts[("s4-volatility-compression-breakout", signal.kind, signal.verdict)] += 1
+
+            s2 = STRATEGY_MANIFEST["s2-cross-sectional-momentum"]
+            assert s2.member is not None
+            dates = s2.decision_calendar(series.dates)
+            assert dates is not None
+            got_member = s2.member(series, panel_decision_dates=dates, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            want_member = s2_member(series, panel_rebalance_dates=dates, universe=UNIVERSE, close_reason=MASKED_REASON)
+            if (
+                got_member.dates != want_member.dates
+                or got_member.decision_indices != want_member.decision_indices
+                or got_member.score.values != want_member.score.values
+                or got_member.score.not_evaluable_indices != want_member.score.not_evaluable_indices
+            ):
+                mismatches.append(f"s2-cross-sectional-momentum series {series_id}")
+            s2_participating += len(got_member.decision_indices)
+
+            if n % 250 == 0:
+                print(f"  {n}/{len(series_ids)} series, {bars} bars ({time.monotonic() - started:.0f}s)", flush=True)
+
+    print(f"  series with bars {len(series_ids) - empty}   (fail-closed empties: {empty})")
+    print(f"  bars {bars}")
+    print(f"  s2 member decision bars {s2_participating}")
+    print("  verdict distribution, per strategy — the population a manifest-driven runner covers:")
+    for (key, kind, verdict), count in sorted(verdicts.items()):
+        print(f"    {key} {kind} {verdict}: {count}")
+    print(f"  mismatches {len(mismatches)}")
+    for line in mismatches[:20]:
+        print(f"    {line}")
+    print(f"  elapsed {time.monotonic() - started:.1f}s")
+    return not mismatches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--census", action="store_true")
+    parser.add_argument("--identity", action="store_true")
+    parser.add_argument("--equivalence", action="store_true")
+    parser.add_argument("--all", action="store_true")
+    args = parser.parse_args()
+    if not (args.census or args.identity or args.equivalence or args.all):
+        parser.error("pick at least one arm: --census / --identity / --equivalence / --all")
+
+    results: list[tuple[str, bool]] = []
+    if args.census or args.all:
+        results.append(("census", census()))
+        print()
+    if args.identity or args.all:
+        results.append(("identity", identity()))
+        print()
+    if args.equivalence or args.all:
+        results.append(("equivalence", equivalence()))
+        print()
+
+    for name, passed in results:
+        print(f"{name}: {'PASS' if passed else 'FAIL'}")
+    return 0 if all(passed for _, passed in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_strategy_manifest.py
+++ b/tests/test_strategy_manifest.py
@@ -1,0 +1,394 @@
+"""The strategy manifest — enumeration that cannot be forgotten (#2394 §2).
+
+Spec: ``docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md`` §2.
+Module under test: ``app/services/strategy_manifest.py``.
+
+⚠ THE EXPECTED VALUES ARE LITERALS, NOT IMPORTS. Spec §3's exit-regime table
+and the four strategy ids are written out below rather than imported from the
+modules they describe. A reference that imports the constant it validates is a
+tautology — it agrees with any value the source happens to hold, including a
+wrong one. The bridge between the literals and the source is
+``test_the_spec_ids_are_the_modules_ids``, which is the ONE place the two are
+compared, and which fails loudly if a module renames itself.
+
+Pure tier: no database, no fixtures, no IO.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Sequence
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.services import strategies
+from app.services.cost_model import COST_MODEL_ID
+from app.services.indicator_series import BarSeries
+from app.services.position_builder import ExitRegime
+from app.services.strategies.s1_time_series_momentum import s1_identity, s1_signals
+from app.services.strategies.s2_cross_sectional_momentum import rebalance_dates, s2_member
+from app.services.strategies.s3_mean_reversion_in_trend import s3_signals
+from app.services.strategies.s4_volatility_compression_breakout import s4_signals
+from app.services.strategy_manifest import (
+    STRATEGY_MANIFEST,
+    StrategyEntry,
+)
+from app.services.technical_analysis import OHLCVRow
+
+UNIVERSE = "survivor_only"
+REASON = "series_break"
+
+#: §4's four catalogue strategies, written out. See the module docstring.
+SPEC_S1 = "s1-time-series-momentum"
+SPEC_S2 = "s2-cross-sectional-momentum"
+SPEC_S3 = "s3-mean-reversion-in-trend"
+SPEC_S4 = "s4-volatility-compression-breakout"
+
+#: Spec §3's table, verbatim, as ``(signal_pair, level_based, max_hold_bars,
+#: has_rebalance_dates)``. ⚠ Written out for the reason in the module docstring:
+#: importing ``S3_MAX_HOLD_BARS`` here would make the assertion agree with
+#: whatever the module says, which is not a check.
+SPEC_EXIT_REGIMES: dict[str, tuple[bool, bool, int | None, bool]] = {
+    SPEC_S1: (True, False, None, False),
+    SPEC_S2: (False, False, None, True),
+    SPEC_S3: (True, False, 10, False),
+    SPEC_S4: (False, True, 40, False),
+}
+
+#: The legs each strategy emits — §4: S-1 and S-3 have an exit rule, S-2 closes
+#: on the calendar and S-4 on its levels, so neither emits an exit SIGNAL.
+SPEC_SIGNAL_KINDS: dict[str, frozenset[str]] = {
+    SPEC_S1: frozenset({"entry", "exit"}),
+    SPEC_S2: frozenset({"entry"}),
+    SPEC_S3: frozenset({"entry", "exit"}),
+    SPEC_S4: frozenset({"entry"}),
+}
+
+SPEC_CLASSES: dict[str, str] = {
+    SPEC_S1: "per_series",
+    SPEC_S2: "cross_sectional",
+    SPEC_S3: "per_series",
+    SPEC_S4: "per_series",
+}
+
+
+def _bars(closes: Sequence[float | None], *, start: date = date(2020, 1, 1)) -> BarSeries:
+    """One bar per close. ``None`` is a MASKED field, as ``load_masked_series``
+    produces — present and empty, not absent."""
+    rows: list[OHLCVRow] = [
+        {
+            "open": None if c is None else Decimal(str(c)),
+            "high": None if c is None else Decimal(str(c + 1)),
+            "low": None if c is None else Decimal(str(c - 1)),
+            "close": None if c is None else Decimal(str(c)),
+            "volume": 1_000,
+        }  # type: ignore[typeddict-item]
+        for c in closes
+    ]
+    return BarSeries(dates=tuple(start + timedelta(days=i) for i in range(len(closes))), rows=tuple(rows))
+
+
+#: Long enough that S-1's and S-3's 200-bar inputs warm up, so the per-series
+#: entries are exercised past their warm-up and not only inside it.
+_CLOSES: list[float | None] = [100.0 + (i % 17) for i in range(260)]
+_HOLED_CLOSES: list[float | None] = [None, *_CLOSES[1:]]
+
+
+class TestManifestIsComplete:
+    """⚠⚠ COVERAGE IS CHECKED, NOT PROMISED — the pattern
+    ``TestInputRuleSetsAreComplete`` already proves for ``INPUT_RULE_SETS``.
+
+    The defect being prevented is an omission with no symptom: a strategy exists
+    in the tree, nobody adds it to the manifest, and every runner and every
+    verify script silently covers a smaller population than it reports. That is
+    criterion 9's *"exclusion is visible rather than assumed harmless"* failing
+    one layer up from where it was fixed.
+    """
+
+    _STRATEGIES_DIR = Path(strategies.__file__).parent
+
+    #: Modules in the package that are deliberately not strategies. Listed
+    #: rather than pattern-matched: a new helper module must be named here on
+    #: purpose, so "not a strategy" stays a decision instead of an accident.
+    _NOT_STRATEGIES = frozenset({"__init__.py", "validated_universe.py"})
+
+    @classmethod
+    def _declared_strategy_ids(cls) -> dict[str, str]:
+        """``{module file: the string its *_STRATEGY_ID is assigned}``.
+
+        Read with ``ast`` rather than by importing, so a module that fails to
+        import is a missing entry here and therefore a test failure, not an
+        error that could be mistaken for unrelated breakage.
+        """
+        found: dict[str, str] = {}
+        for path in sorted(cls._STRATEGIES_DIR.glob("*.py")):
+            if path.name in cls._NOT_STRATEGIES:
+                continue
+            tree = ast.parse(path.read_text())
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Assign):
+                    continue
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Name)
+                        and target.id.endswith("_STRATEGY_ID")
+                        and isinstance(node.value, ast.Constant)
+                        and isinstance(node.value.value, str)
+                    ):
+                        found[path.name] = node.value.value
+        return found
+
+    def test_the_walk_finds_the_strategies(self) -> None:
+        """⚠ A completeness test that silently matched nothing would pass
+        forever. Pin that it is actually reading the modules it claims to — the
+        prevention-log lesson from a probe that matched nothing."""
+        declared = self._declared_strategy_ids()
+        assert len(declared) == 4, f"expected the four catalogue modules, walked {sorted(declared)}"
+        assert declared["s1_time_series_momentum.py"] == SPEC_S1
+
+    def test_every_strategy_module_is_registered(self) -> None:
+        missing = {
+            module: strategy_id
+            for module, strategy_id in sorted(self._declared_strategy_ids().items())
+            if strategy_id not in STRATEGY_MANIFEST
+        }
+        assert not missing, (
+            "these strategies exist in the tree but are absent from STRATEGY_MANIFEST, so a runner "
+            f"iterating it covers a smaller population than it reports (#2394 §2): {missing}"
+        )
+
+    def test_no_entry_is_registered_for_a_module_that_does_not_exist(self) -> None:
+        """The other direction. A key with no module is a runner that raises at
+        import — or worse, a strategy id that outlives its code and keeps
+        appearing in a stored ledger."""
+        declared = set(self._declared_strategy_ids().values())
+        orphans = sorted(set(STRATEGY_MANIFEST) - declared)
+        assert not orphans, f"manifest keys with no strategy module: {orphans}"
+
+    def test_the_spec_ids_are_the_modules_ids(self) -> None:
+        """⚠ THE ONE BRIDGE between this file's literals and the source. Every
+        other assertion here is written against the literals, so without this
+        the whole file could agree with a renamed strategy."""
+        assert set(self._declared_strategy_ids().values()) == {SPEC_S1, SPEC_S2, SPEC_S3, SPEC_S4}
+
+
+class TestEntriesDescribeTheirStrategy:
+    def test_key_equals_entry_id(self) -> None:
+        mismatched = {key: entry.strategy_id for key, entry in STRATEGY_MANIFEST.items() if key != entry.strategy_id}
+        assert not mismatched, f"manifest keyed differently from the entry it holds: {mismatched}"
+
+    def test_identity_factory_returns_that_strategy(self) -> None:
+        """⚠ Invoked, not inspected. A copy-paste of the wrong ``s*_identity``
+        into an entry is invisible to any structural check and would file every
+        S-3 signal under S-1's identity."""
+        for key, entry in STRATEGY_MANIFEST.items():
+            identity = entry.identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+            assert identity.strategy_id == key
+
+    def test_classes_are_the_spec_classes(self) -> None:
+        assert {key: entry.strategy_class for key, entry in STRATEGY_MANIFEST.items()} == SPEC_CLASSES
+
+    def test_declared_signal_kinds_are_the_spec_legs(self) -> None:
+        assert {key: set(entry.signal_kinds) for key, entry in STRATEGY_MANIFEST.items()} == {
+            key: set(kinds) for key, kinds in SPEC_SIGNAL_KINDS.items()
+        }
+
+
+class TestExitRegimeTableIsExecutable:
+    """Spec §3's table is prose in ``ExitRegime``'s docstring and every caller
+    hand-builds it. These assert the manifest reproduces it."""
+
+    @staticmethod
+    def _regime(strategy_id: str) -> ExitRegime:
+        entry = STRATEGY_MANIFEST[strategy_id]
+        calendar = [date(2020, 1, 1) + timedelta(days=i) for i in range(90)]
+        return entry.exit_regime(entry.decision_calendar(calendar))
+
+    @pytest.mark.parametrize("strategy_id", sorted(SPEC_EXIT_REGIMES))
+    def test_regime_matches_the_spec_table(self, strategy_id: str) -> None:
+        signal_pair, level_based, max_hold, has_calendar = SPEC_EXIT_REGIMES[strategy_id]
+        regime = self._regime(strategy_id)
+        assert regime.signal_pair is signal_pair
+        assert regime.level_based is level_based
+        assert regime.max_hold_bars == max_hold
+        assert (regime.rebalance_dates is not None) is has_calendar
+
+    def test_a_per_series_strategy_refuses_a_calendar(self) -> None:
+        """Ignoring it would let a caller believe S-1 rebalances monthly."""
+        with pytest.raises(ValueError, match="declares no decision calendar"):
+            STRATEGY_MANIFEST[SPEC_S1].exit_regime(frozenset({date(2020, 2, 3)}))
+
+    def test_the_calendar_strategy_refuses_no_calendar(self) -> None:
+        with pytest.raises(ValueError, match="cannot be built without one"):
+            STRATEGY_MANIFEST[SPEC_S2].exit_regime(None)
+
+    def test_per_series_decision_calendar_is_none_not_empty(self) -> None:
+        """ "No calendar" and "a calendar with no dates" must stay distinct —
+        ``ExitRegime`` refuses the empty set for exactly that reason."""
+        for strategy_id in (SPEC_S1, SPEC_S3, SPEC_S4):
+            entry = STRATEGY_MANIFEST[strategy_id]
+            assert entry.decision_calendar([date(2020, 1, 1), date(2020, 2, 1)]) is None
+
+    def test_the_calendar_strategy_computes_rebalances(self) -> None:
+        entry = STRATEGY_MANIFEST[SPEC_S2]
+        calendar = [date(2020, 1, 1) + timedelta(days=i) for i in range(90)]
+        assert entry.decision_calendar(calendar) == rebalance_dates(calendar)
+
+
+class TestUniformInvocationEqualsTheDirectCall:
+    """⚠⚠ THE ADAPTERS ARE THE RISK, AND ONLY A CALL FINDS IT.
+
+    ``s1_signals``/``s3_signals`` take ``close_reason``; ``s4_signals`` takes
+    ``masked_reason``. The manifest presents one signature, so each entry wraps
+    its module's. A wrapper passing the wrong keyword, or the wrong module's
+    function, type-checks fine and fails at call time — which for a nightly scan
+    means the first failure is in production.
+    """
+
+    @pytest.mark.parametrize(
+        ("strategy_id", "direct"),
+        [(SPEC_S1, s1_signals), (SPEC_S3, s3_signals)],
+    )
+    def test_close_reason_strategies_match(self, strategy_id: str, direct: object) -> None:
+        entry = STRATEGY_MANIFEST[strategy_id]
+        assert entry.signals is not None
+        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        expected = direct(_bars(_CLOSES), universe=UNIVERSE, close_reason=REASON)  # type: ignore[operator]
+        assert via_manifest == expected
+        assert any(signal.verdict == "fired" for signal in via_manifest), (
+            "the fixture never fires, so an adapter returning refusals for every bar would pass"
+        )
+
+    def test_masked_reason_strategy_matches(self) -> None:
+        entry = STRATEGY_MANIFEST[SPEC_S4]
+        assert entry.signals is not None
+        via_manifest = entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        assert via_manifest == s4_signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4])
+    def test_the_reason_code_reaches_the_verdict(self, strategy_id: str) -> None:
+        """⚠ An adapter could accept ``masked_reason`` and drop it, defaulting
+        the module's own argument. Equality against the direct call would still
+        pass if BOTH sides were wrong, so this asserts the caller's code is what
+        comes back."""
+        entry = STRATEGY_MANIFEST[strategy_id]
+        assert entry.signals is not None
+        signals = entry.signals(_bars(_HOLED_CLOSES), universe=UNIVERSE, masked_reason=REASON)
+        assert signals[0].verdict == "not_evaluable"
+        assert signals[0].reason == REASON
+
+    @pytest.mark.parametrize("strategy_id", [SPEC_S1, SPEC_S3, SPEC_S4])
+    def test_emitted_kinds_are_the_declared_kinds(self, strategy_id: str) -> None:
+        """⚠ ``signal_kinds`` is a claim about the strategy, so it is measured
+        from what it emits rather than trusted."""
+        entry = STRATEGY_MANIFEST[strategy_id]
+        assert entry.signals is not None
+        emitted = {signal.kind for signal in entry.signals(_bars(_CLOSES), universe=UNIVERSE, masked_reason=REASON)}
+        assert emitted == set(entry.signal_kinds)
+
+    def test_cross_sectional_member_matches_the_direct_call(self) -> None:
+        entry = STRATEGY_MANIFEST[SPEC_S2]
+        assert entry.member is not None and entry.select is not None
+        series = _bars(_CLOSES)
+        dates = entry.decision_calendar(series.dates)
+        assert dates is not None
+        via_manifest = entry.member(series, panel_decision_dates=dates, universe=UNIVERSE, masked_reason=REASON)
+        expected = s2_member(series, panel_rebalance_dates=dates, universe=UNIVERSE, close_reason=REASON)
+        assert via_manifest.dates == expected.dates
+        assert via_manifest.decision_indices == expected.decision_indices
+        assert via_manifest.score.values == expected.score.values
+
+    def test_cross_sectional_select_ranks(self) -> None:
+        entry = STRATEGY_MANIFEST[SPEC_S2]
+        assert entry.select is not None and entry.min_participants is not None
+        scores = {key: float(key) for key in range(entry.min_participants)}
+        winners = entry.select(date(2020, 3, 2), scores)
+        assert winners and set(winners) <= set(scores)
+
+
+class TestEntryRefusesAContradictoryRegistration:
+    """The tagged union is checked, not documented — an entry whose two halves
+    disagree would be honoured by whichever half the runner read."""
+
+    @staticmethod
+    def _kwargs(**overrides: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "strategy_id": "s9-test",
+            "identity": s1_identity,
+            "strategy_class": "per_series",
+            "signal_kinds": frozenset({"entry"}),
+            "exit_regime": lambda decision_dates: ExitRegime(
+                signal_pair=True, level_based=False, max_hold_bars=None, rebalance_dates=None
+            ),
+            "decision_calendar": lambda calendar: None,
+            "signals": STRATEGY_MANIFEST[SPEC_S1].signals,
+        }
+        base.update(overrides)
+        return base
+
+    def test_the_baseline_registration_is_valid(self) -> None:
+        """⚠ Without this, every refusal below could be passing for the wrong
+        reason — a baseline that raises makes them all vacuous."""
+        assert StrategyEntry(**self._kwargs()).strategy_id == "s9-test"  # type: ignore[arg-type]
+
+    def test_per_series_without_a_signals_function(self) -> None:
+        with pytest.raises(ValueError, match="declares no signals function"):
+            StrategyEntry(**self._kwargs(signals=None))  # type: ignore[arg-type]
+
+    def test_per_series_carrying_cross_sectional_fields(self) -> None:
+        with pytest.raises(ValueError, match="carries cross-sectional fields"):
+            StrategyEntry(**self._kwargs(min_participants=10))  # type: ignore[arg-type]
+
+    def test_cross_sectional_missing_half_its_contract(self) -> None:
+        with pytest.raises(ValueError, match="must declare member, select and min_participants together"):
+            StrategyEntry(
+                **self._kwargs(
+                    strategy_class="cross_sectional",
+                    signals=None,
+                    member=STRATEGY_MANIFEST[SPEC_S2].member,
+                )  # type: ignore[arg-type]
+            )
+
+    def test_cross_sectional_carrying_a_per_series_function(self) -> None:
+        with pytest.raises(ValueError, match="carries a per-series signals function"):
+            StrategyEntry(
+                **self._kwargs(
+                    strategy_class="cross_sectional",
+                    member=STRATEGY_MANIFEST[SPEC_S2].member,
+                    select=STRATEGY_MANIFEST[SPEC_S2].select,
+                    min_participants=10,
+                )  # type: ignore[arg-type]
+            )
+
+    def test_an_unknown_class(self) -> None:
+        with pytest.raises(ValueError, match="unknown strategy class"):
+            StrategyEntry(**self._kwargs(strategy_class="per_bar"))  # type: ignore[arg-type]
+
+    def test_an_unknown_signal_kind(self) -> None:
+        with pytest.raises(ValueError, match="unknown signal kinds"):
+            StrategyEntry(**self._kwargs(signal_kinds=frozenset({"entry", "hedge"})))  # type: ignore[arg-type]
+
+    def test_an_exit_only_strategy(self) -> None:
+        """Outcome resolution consumes fired ENTRIES, so an exit-only
+        registration writes rows nothing can resolve."""
+        with pytest.raises(ValueError, match="no entry leg"):
+            StrategyEntry(**self._kwargs(signal_kinds=frozenset({"exit"})))  # type: ignore[arg-type]
+
+    def test_a_blank_strategy_id(self) -> None:
+        with pytest.raises(ValueError, match="non-empty declaration"):
+            StrategyEntry(**self._kwargs(strategy_id="  "))  # type: ignore[arg-type]
+
+    def test_a_cross_section_of_zero(self) -> None:
+        with pytest.raises(ValueError, match="min_participants must be at least 1"):
+            StrategyEntry(
+                **self._kwargs(
+                    strategy_class="cross_sectional",
+                    signals=None,
+                    member=STRATEGY_MANIFEST[SPEC_S2].member,
+                    select=STRATEGY_MANIFEST[SPEC_S2].select,
+                    min_participants=0,
+                )  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
Implements §2 of the runner spec (`docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md`), merged in #2397 an hour before this branch. **The runner itself is deliberately not here** — §3.1 is blocked on #2290's append-only universe membership, which §3.1.1 promotes from open question to prerequisite, and this worktree cannot reach the dev API in any case.

## The defect

The strategy set was an import list. No `__all__`, no registry list — whichever modules a given script happened to import. Measured on this tree by `verify_2394_strategy_manifest.py --census` (nothing hardcoded):

```
call sites naming a strategy module directly: 42
  s1: 14 sites across 12 files    s2: 5 sites across 4 files
  s3: 16 sites across 12 files    s4: 7 sites across 5 files
⚠ spread between most- and least-imported module: 11 call sites
```

That asymmetry is why every phase-5 run report carries S-1 and S-3 figures and not S-2 and S-4. Adding S-5 today means finding all 42 sites, and missing one produces a **silently smaller population rather than an error** — criterion 9's *"exclusion is visible rather than assumed harmless"* failing one layer above where it was fixed.

## What landed

`app/services/strategy_manifest.py` — `STRATEGY_MANIFEST`, one `StrategyEntry` per catalogue strategy:

- **identity factory** (`s*_identity`), **class** (`per_series` / `cross_sectional`), **emitted legs**, **`ExitRegimeFactory`**;
- **a uniform invocation contract**, so the runner needs no per-strategy branch. This is load-bearing: `s1_signals`/`s3_signals` take `close_reason`, `s4_signals` takes `masked_reason`. The adapters absorb that, and a wrapper forwarding the wrong keyword or the wrong module's function type-checks fine and fails only when called.
- **a tagged union checked in `__post_init__`** — an entry declaring `per_series` while carrying a `select` is refused, because a runner would honour whichever half it read first.

Completeness is a **test**, not a convention, mirroring `TestInputRuleSetsAreComplete`: `tests/test_strategy_manifest.py::TestManifestIsComplete` walks every module in `app/services/strategies/` and fails if one declaring a `*_STRATEGY_ID` is absent from the manifest — plus the reverse direction, so a key outliving its module fails too.

## ⚠⚠ The placement is not the spec's, and two independent facts decided it

**Not `strategy_registry.py`** (where §2 put it). `StrategyIdentity.version` hashes `_module_hash()` — the **bytes of that file**. A manifest there would move *every stored strategy version every time a strategy is added*: registering S-5 would invalidate S-1's entire track record for no reason of S-1's. Secondarily, the registry is imported **by** every strategy module so it cannot import them back, and `ExitRegime` lives in `position_builder`.

**Not `app/services/strategies/` either**, which is where it was first written. `TestInputRuleSetsAreComplete` walks that package and requires any imported `app.services` module carrying a `RULE_SET_VERSION` to be inside `INPUT_RULE_SETS`. The manifest imports `position_builder`, which has one — **so the guard failed on the first fast-tier run, correctly.** Both obvious answers are wrong: adding `position_builder` to `INPUT_RULE_SETS` is reason 1 by another route, and excluding the file weakens a working guard. The manifest computes no verdict, so it belongs outside the package the guard scopes to, and the guard's reach is left exactly as it was.

## Two spec claims corrected in the doc

- **§1's *"the manifest is versioned by `STRATEGY_SET_ID`"* is wrong, and must stay wrong.** `STRATEGY_SET_ID` is a literal and no field of `StrategyIdentity` is a function of manifest membership. S-1's signals are unchanged by S-5 existing, so S-1's version must not move when S-5 lands. The set id names the *contract* version, not the membership.
- **The entry carries an `ExitRegimeFactory`, not a new "resolver shape" vocabulary.** §3's per-strategy table already lives in `ExitRegime`'s docstring as prose that every caller hand-builds from (`verify_2240_position_builder.py` builds S-1's and S-3's; nothing built S-2's or S-4's). The manifest makes that table executable rather than adding a second spelling of it.

## Verification

`PYTHONPATH=. uv run python scripts/verify_2394_strategy_manifest.py --all` — **exit 0**, at commit `a7924bb0`:

| arm | result |
| --- | --- |
| census | 42 call sites; 4 manifest entries; 3 `per_series` + 1 `cross_sectional` |
| identity | all **5** identity-bearing files byte-identical to `origin/main` — this change moves **no** stored strategy version |
| equivalence | **7,709** research series (7,693 with bars, 16 fail-closed empties), **25,818,944** bars, **0 mismatches**, 843.1s |

The equivalence arm is the full corpus through the fail-closed masked loader: every per-series entry's uniform call compared verdict-for-verdict against the module's own function, and S-2's staged member compared field-for-field (1,192,774 decision bars). ⚠ **S-2's panel verdicts are not resolved here** — ranking needs the union calendar and a cross-section per date, which `verify_2240_s2_cross_sectional.py` already streams. The claim is about the invocation contract, not S-2's verdicts, and the two must not be pooled.

**Revert-probes** — `scripts/probe_2394_strategy_manifest.py`, **7 injected defects, 7 caught, 0 missed**, suite restored green (exit 0). Each asserts its target matched exactly once before applying, and one probe *did* report `matched 0 times` after `ruff format` collapsed a line — the no-op guard working, not a pass.

Gates, each run separately, never piped: `ruff check` 0, `ruff format --check` 0, `pyright` 0, `pytest -m "not db"` 0, `pytest tests/smoke` 0. Pre-push hook green.

Codex checkpoint 2 (behavioural rung — service logic): one P3, the spec correction still naming the pre-move path. Fixed in this commit before push.

No migration, no backfill, no operator-visible surface — DoD clauses 8-12 do not apply; nothing reads or writes a table.

## Security

No security surface. Pure in-process registration data and function references; no database write, no network, no broker path, no user input.

## What this unblocks

The runner (§3.1/§3.2) can iterate one mapping instead of branching per strategy, and cannot silently under-cover. Still blocked on #2290 before a daily scan may start, per §3.1.1.

Refs #2394. Refs #2240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
