### PR TITLE
docs(#2394): spec §3.1's daily signal scan, after the measurement killed four of its own claims

### DIFF
--- a/docs/proposals/ta/2026-08-08-strategy-signal-scan.md
+++ b/docs/proposals/ta/2026-08-08-strategy-signal-scan.md
@@ -1,0 +1,506 @@
+# The daily signal scan — §3.1, settled against the live corpus
+
+Spec for **#2394 §3.1**. Parent: `2026-08-08-strategy-runner-and-manifest.md`
+(§2's manifest, §3.1's job, §3.1.1's blocking prerequisite, §3.1.2's five
+underspecified items, §4's seven open questions). Above that:
+`strategy-catalogue-and-backtest-validity.md` §3.5 and criteria 8/9/11. Refs #2240.
+
+§4 of the parent says its open questions are *"to settle before implementation,
+not during"*. This document settles them. Every figure below was computed by
+`scripts/verify_2394_signal_scan_cost.py` on the dev database on 2026-08-08;
+nothing is quoted from a prior session.
+
+    PYTHONPATH=. uv run python scripts/verify_2394_signal_scan_cost.py --all
+
+## 0. The population, measured
+
+`--population`:
+
+```text
+price_daily          bars 6723014  instruments 12185  last bar 2026-08-08
+research_price_daily bars 25920971  series 7709  last bar 2026-07-08
+research series carrying an instrument_id: 5269/7709
+validated universe 6735; loadable through the masked loader 6547
+strategy_signals 0 rows; strategy_outcomes 0 rows
+instrument_universe_membership 0 rows
+last-bar-date histogram over the loadable universe (top 6):
+  2026-08-07: 5783
+  2023-02-28: 21
+  2026-08-06: 9
+  2026-08-08: 7
+  2025-06-26: 7
+  2026-02-27: 6
+bars per instrument: min 1  median 613  max 1046  total 3627106
+research bars per series for contrast: 25920971/7709 = 3,362
+instruments with fewer than 200 bars (sma_200 cannot evaluate): 2624 (40.1%)
+```
+
+⚠ The histogram and the depth both go through the **coverage join**, not raw
+`price_daily`. An earlier version joined the raw table and called the result "the
+loadable universe" — which counts bars the fail-closed loader never returns, so
+it would have described a population the scan does not see.
+
+## 1. Source rules
+
+Nothing below is reasoned from first principles where a rule already exists in
+the tree. The five that bind:
+
+- **`signal_ledger.store_signals`' INSERT carries no `ON CONFLICT`,
+  deliberately**: *"A colliding key raises `UniqueViolation` and aborts the batch
+  … `DO UPDATE` would let a re-run overwrite a recorded decision."* ⚠ The
+  behaviour is the **writer's**, not `sql/255`'s — the migration supplies the
+  `UNIQUE (strategy_id, strategy_version, instrument_id, signal_bar_date,
+  signal_kind)` key that the absent clause would have needed. Either way every
+  row this job writes is **terminal**, which is the constraint §2 is derived
+  from, not a preference.
+- **`strategy_registry.NotEvaluableReason` includes `no_fill_bar`**, flagged as
+  an addition to criterion 8's seven: *"the last bar of any series has no `t+1`,
+  so a signal there can never be filled … it is the edge of the series."*
+- **`outcome_ledger.select_pending_fills`** is a `LEFT JOIN … WHERE o.outcome_id
+  IS NULL` at one `(rule_set_version, input_rule_set_version)` pin. A signal
+  that has *any* outcome row at that pin — including an `unresolved` one — is
+  never returned again.
+- **`position_builder.build_positions`** raises on `outcomes` supplied for a
+  regime that is not `level_based`: *"they would be read by nothing, and a close
+  source nobody applies is a close source nobody notices is missing."*
+- **Prevention log, "Source-absence gates over a date-keyed window must tolerate
+  holidays"**: *"the per-day watermark only advances on success, so the date was
+  re-requested every run and wedged phase 1 indefinitely."* §3's watermark is
+  shaped to make that failure impossible rather than unlikely.
+
+## 2. The scan runs in ARREARS — one bar behind the frontier
+
+**This is the decision the job's whole shape follows from, and it is measured.**
+
+A signal on the final bar of a series can never be filled, so
+`strategy_registry.evaluate` stamps it `not_evaluable` / `no_fill_bar`. `sql/255`
+has no `ON CONFLICT`. Therefore a scan that writes *today's* bar writes a refusal
+that can never be corrected when tomorrow's bar arrives — the corrected row
+collides on `(strategy_id, strategy_version, instrument_id, signal_bar_date,
+signal_kind)` and raises.
+
+`--arrears` computes each series' verdict at its **second-to-last** bar twice —
+once with the next bar present (what a one-day-arrears scan sees) and once with
+that bar truncated away (what a same-day scan sees):
+
+```text
+per strategy, at each series' SECOND-TO-LAST bar:
+  s1-time-series-momentum:            compared 13070, differ 13070, of which fired-with-next 3658
+  s3-mean-reversion-in-trend:         compared 13070, differ 13070, of which fired-with-next 2323
+  s4-volatility-compression-breakout: compared  6535, differ  6535, of which fired-with-next  204
+TOTAL compared 32675, differ 32675, fired-and-lost 6185
+```
+
+⚠ **`differ = 100%` is not the finding and must not be quoted as one.** It is
+true by construction: without bar `D+1`, bar `D` *is* the last bar, so its
+verdict is `no_fill_bar` unconditionally. The load-bearing number is the
+**6,185 rows whose verdict with `D+1` present is `fired`** — real decisions a
+same-day scan records permanently as unevaluable. The transition census makes
+the shape explicit:
+
+```text
+s1: fired/- -> not_evaluable/no_fill_bar: 3658
+s3: fired/- -> not_evaluable/no_fill_bar: 2323
+s4: fired/- -> not_evaluable/no_fill_bar:  204
+```
+
+**Rule.** The scan's write date is `frontier - 1 bar` on each instrument's own
+calendar, where the frontier is §3's completeness condition. A scan may never
+write a `signal_bar_date` equal to the last bar it can see.
+
+## 3. The frontier, and the watermark
+
+§4 question 3: *"'after the candle refresh' must name a concrete condition."*
+
+⚠ **It cannot be `max(price_date)`.** The histogram in §0 is why: on the day
+this was measured, 7 instruments carried a bar at `2026-08-08` and 5,783 did
+not. A scan keyed on the maximum evaluates a date most of the universe is
+missing and manufactures thousands of refusals out of a refresh still in flight —
+and by §1 those refusals are terminal.
+
+**Frontier = the modal last bar date across the loadable universe, ties broken on
+the later date.** Measured today: `2026-08-07`, held by 5,783 of 6,547 (88.3%),
+printed by the script rather than assumed.
+
+**Completeness floor, fixed by construction: the modal share must be ≥ 2/3 of the
+loadable universe, or the scan refuses the day and reports.** There is no
+published rule for this and the honest form is to say so and freeze the constant
+(the `.claude/CLAUDE.md` rule for exactly this case). ⚠ It is a **job** parameter,
+not a strategy parameter — it selects *when* to evaluate, never *what* the
+verdict is — so it is deliberately outside `StrategyIdentity` and criterion 11
+does not reach it. Refusing is safe in a way that scanning is not: a skipped day
+can be picked up tomorrow, a written row cannot be withdrawn.
+
+### 3.1 The write date is per instrument, and the watermark is not
+
+⚠ **This was wrong in the first draft and the measurement caught it.** The write
+date is the bar before the frontier *on each instrument's own calendar*, and that
+is a distribution, not a constant — `BarSeries` allows calendar gaps and never
+interpolates them:
+
+```text
+write-date distribution across eligible series:
+  2026-08-06=5779, 2026-07-31=1, 2026-08-05=1, 2026-08-04=1, 2026-07-28=1
+```
+
+So a watermark holding one `signal_bar_date` cannot describe what was written. It
+holds a **calendar frontier** instead:
+
+> **Watermark** = per `(strategy_id, strategy_version)`, the last frontier date
+> the scan completed. On each run the scan writes, for every eligible instrument,
+> each of its own bars strictly **after** the watermark and strictly **before**
+> that instrument's last bar. Then it sets the watermark to the current frontier.
+
+That shape settles three things at once:
+
+- **Re-runs.** A second run in the same day has `watermark == frontier` and does
+  nothing, without `ON CONFLICT` — which parent §2.1 forbids in both arms
+  (`DO NOTHING` hides corpus drift, `DO UPDATE` overwrites a recorded decision).
+- **The three stragglers above.** An instrument that missed sessions gets all its
+  unwritten bars in the window, not just one — so a gap does not silently drop a
+  day of its record.
+- **Holidays.** ⚠ The first draft said *"a market holiday advances the
+  watermark"*, which contradicted itself: a holiday has no bar, so there is no
+  `signal_bar_date` to advance to. Against a calendar frontier there is no
+  contradiction — on a holiday the frontier has not moved, `watermark ==
+  frontier`, the scan writes nothing and is not stuck. The prevention-log entry
+  in §1 (*"the per-day watermark only advances on success, so the date was
+  re-requested every run and wedged phase 1 indefinitely"*) is avoided by
+  construction rather than by tolerance: the watermark tracks a frontier the
+  corpus supplies, never a date the scan hoped to find.
+
+⚠ **"Wrote nothing" and "failed" must remain distinguishable**, and the watermark
+alone cannot carry both. A run that completes with zero rows advances it; a run
+that raises does not.
+
+## 4. It reads the LIVE corpus, through a masked loader that does not exist yet
+
+§4 question 4 says *"settle the source first, then measure"*. Settled:
+
+Every phase-5 figure on this epic was measured on `research_price_daily` — a
+frozen archive keyed on `series_id`. §0 shows it last moved on `2026-07-08`, a
+month stale, and only 5,269 of its 7,709 series carry an `instrument_id` at all.
+`strategy_signals.instrument_id` is a foreign key to `instruments`. **A daily
+scan cannot run on the research corpus.** It reads `price_daily`, which reached
+`2026-08-08` on the day of measurement.
+
+⚠ **There is no masked loader for `price_daily` in `app/`, and the scan cannot
+use raw bars.** `indicator_series`' own header: *"Quarantine and adjustment basis
+are the CALLER's gate. These functions have no database access and compute over
+whatever bars they are handed."* The pieces exist and the gap is small:
+
+| piece | research corpus | live corpus |
+| --- | --- | --- |
+| verdict table | `research_bar_quarantine` | `price_bar_quarantine` — populated, 11,132 instruments |
+| coverage table | `research_price_quarantine_coverage` | `price_quarantine_coverage` — covers all 6,547 loadable |
+| masking rule | `_apply_arm` | corpus-agnostic already; names `series_id` only in its return type |
+| loader | `load_masked_series` | **missing** |
+
+⚠ `price_quarantine_store.usable_bar_filter_sql` is **not** the missing piece and
+must not be pressed into service. It is a row **filter**; the strategies need a
+per-field **mask**. `load_masked_series` says why: *"Masking the whole bar on
+either verdict would discard good data and shift every N-bar window."* A filter
+silently shortens every warm-up window.
+
+**Rule.** Implementation adds an instrument-keyed masked loader mirroring
+`research_price_structure_store._LOAD_SQL` field for field — fail-closed at the
+instrument level (an instrument with no coverage row at the current
+`rule_set_version` loads as zero bars), per-field masking on `range_usable` /
+`return_usable`, and the #2354 value-keyed open mask. `scripts/verify_2394_
+signal_scan_cost.py::_load_live_masked` is the measured prototype, not the
+shipping code.
+
+## 5. It recomputes from the series start — no trailing window
+
+§3.1.2 item 1: *"The runner either gains single-date entry points or recomputes
+history and filters — decide, and state which."*
+
+`rsi_series` and `atr_series` are Wilder-smoothed from the series start —
+recursive with unbounded memory, which `indicator_series.atr_window_series`
+documents and measures. So a trailing-K-bar recompute is a **different function**,
+not a cheaper one, and `StrategyIdentity` records no window: two runs at
+different K are indistinguishable once stored.
+
+`--truncation` compares the frontier verdict under full history against 250- and
+750-bar trailing windows:
+
+```text
+window 250 bars — series deeper than it: 3290
+  s1 0/3290   s3 0/3290   s4 0/3290   frontier verdicts differ (0.00%)
+window 750 bars — series deeper than it: 2033
+  s1 0/2033   s3 0/2033   s4 0/2033   frontier verdicts differ (0.00%)
+```
+
+⚠ **That is a negative result and it does not license truncation.** Zero
+disagreement here is a property of this corpus's depth (median 613 bars) against
+a boolean threshold comparison, not a property of the functions. It is reported
+because the honest form of "we did not adopt the optimisation" is the
+measurement that would have justified it.
+
+**The reason not to truncate is §6's cost, not this arm.** A full-history
+recompute of the entire universe takes 40.2 s. There is no budget pressure to
+trade an unrecorded parameter for.
+
+**Rule.** The scan recomputes each instrument's full stored history and takes the
+verdicts at the write-date index. No single-date entry point is added, and no
+window is introduced.
+
+## 6. Cost, and the daily write volume
+
+§4 question 4: *"§3.1's 'cheap' is an assertion until it is measured."* `--cost`,
+over 6,547 series and 3,627,106 bars:
+
+| stage | seconds |
+| --- | --- |
+| load, masked, all 6,547 instruments | 23.3 |
+| `s1-time-series-momentum` | 13.8 |
+| `s3-mean-reversion-in-trend` | 16.4 |
+| `s4-volatility-compression-breakout` | 26.1 |
+| `s2-cross-sectional-momentum` (staged) | 0.5 |
+| **strategy evaluation total** | **56.8** |
+
+Under a minute and a half end to end, at 255,420 bar-evaluations/s. §3.1's
+"cheap" holds, measured. ⚠ The per-strategy seconds include `resolve_fills` and
+move run to run with machine load — S-1 and S-3 swapped order between two runs of
+this arm — so the figure that carries is the order of magnitude, which is
+minutes-not-hours.
+
+⚠ **The census runs through `signal_ledger.resolve_fills`, not off the raw
+strategy verdicts.** Codex caught the first version taking strategy output
+directly, which is not what the ledger stores: a `fired` verdict whose `t+1` open
+is absent or non-positive is stored as `not_evaluable` / `unusable_fill_price`
+(#2354). On this population the two agree — no `unusable_fill_price` row appears
+below — but that is now a measurement rather than an assumption.
+
+⚠ It is taken at the **write date**, not the frontier. An earlier version
+censused the frontier and reported 5,783 `no_fill_bar` rows per leg —
+structurally guaranteed by §2, and a measurement of the refusal rather than of
+the scan.
+
+```text
+write date = frontier - 1 bar; series eligible to be written 5783
+
+s1 entry  fired 1722   not_fired 1623   insufficient_warmup 2435   quarantined_bar 3
+s1 exit   fired 1384   not_fired 1961   insufficient_warmup 2435   quarantined_bar 3
+s3 entry  fired   11   not_fired 3322   insufficient_warmup 2410   quarantined_bar 40
+s3 exit   fired 1946   not_fired 1387   insufficient_warmup 2410   quarantined_bar 40
+s4 entry  fired  108   not_fired 5382   insufficient_warmup  100   quarantined_bar 193
+```
+
+Each leg sums to 5,783 — every eligible instrument gets a verdict, which is
+criterion 9's *"exclusion is visible rather than assumed harmless"* satisfied by
+construction. ⚠ The script **asserts** that sum per leg and fails the arm on a
+short one, so a silently smaller population is a non-zero exit code rather than a
+number a reader has to add up.
+
+**Daily write volume**, computed by the script rather than by hand:
+
+```text
+TOTAL rows per scan day 34698 (per-series legs 28915 + s2 5783)
+at 252 trading days that is 8,743,896 rows/year at one strategy_version
+insufficient_warmup rows 9790 of 28915 per-series rows (33.9%)
+```
+
+Sizing, not a problem — but it is the number a retention or partitioning decision
+would be made from, and it did not exist before this run.
+
+⚠ **A third of every scan day is `insufficient_warmup`**, and for S-1 alone it is
+2,435 of 5,783 — matching §0's 2,624 instruments (40.1%) holding fewer than 200
+bars. The live corpus is shallow: median 613 bars per instrument against
+25,920,971 / 7,709 = 3,362 per research series, both printed. So a large minority
+of the tradable universe is structurally unevaluable for any `sma_200`-gated
+strategy. That is a fact about `price_daily`'s depth, not a defect in the scan,
+and it must appear in the operator surface rather than be absorbed into
+`not_fired`.
+
+### 6.1 S-2 needs the panel's union calendar, and a slice of it
+
+⚠ **`rebalance_dates` must be given the panel's union calendar, never a single
+member's dates.** It fires on *"the first bar whose calendar month differs from
+the previous bar's — i.e. act at the start of the new month"*, which is causal
+for the reason its own docstring gives: the last session of a month is not
+knowable at that session. ⚠ The first draft of this spec said "the last trading
+day of each month" — **wrong, and Codex caught it**; the rule is the first bar of
+the new month, and reading it the other way would have specced a look-ahead into
+the runner.
+
+Because it reads only the dates it is handed, a per-member calendar makes each
+name rebalance on *its own* first-bar-of-month, so names that resumed on
+different days rank against nobody. An earlier version of `--cost` did exactly
+that and reported `thin_cross_section (1 < 10)` — a measurement of the bug, not
+of S-2. On the union calendar the panel has **73 rebalance dates over 6.6 years
+(11.0/year)**, and the write date measured is not one of them: **0
+decision-bar participants**.
+
+That is correct behaviour and has two consequences the runner must encode:
+
+1. **On a non-rebalance day S-2 still writes a verdict for every member.**
+   `CrossSectionalMember`: *"Everything else is an ordinary `not_fired` … It is a
+   verdict, not an absence."* The script counts that directly — `rows at the
+   write date 5783` — so S-2's contribution is the whole eligible population on
+   every scan day, with 11.0 days a year carrying any `fired`.
+2. **The panel is a slice, not the corpus.** `evaluate_cross_sectional` holds
+   every member's whole score series in memory at once. A daily scan needs one
+   date's cross-section, so it stages each member, keeps that date's score, and
+   calls `s2_select` once — 0.6 s, measured. Full panel materialisation is
+   explicitly unsafe at corpus scale (parent §2) and is not needed here.
+
+⚠ `s2_select` is handed the **write date**, not the frontier. Today's
+implementation ignores `when` — but the manifest's `CrossSectionalSelect`
+contract exists so a date-aware selector needs no signature change, and passing
+the wrong date would be silent until one arrives.
+
+## 7. It writes SIGNALS ONLY — outcome resolution is NOT this job
+
+§3.1 as drafted says the scan also *"resolves prior open signals into
+`strategy_outcomes`"*. **It cannot, for any strategy in the catalogue today**,
+and the reason is structural rather than a matter of sequencing.
+
+- `strategy_outcomes` is fed only by `outcome_resolver.resolve_outcome`, which
+  requires `ExitLevels` — a take-profit, a stop and a max hold.
+- Only **S-4** declares `level_based=True`, so S-1, S-2 and S-3 have nothing to
+  resolve: their closes are position-layer constructs (`signal_pair`,
+  `max_hold_bars`, `rebalance_dates`). ⚠ That is enforced at the **reader**, not
+  in the schema: `build_positions` raises on outcomes supplied for a non-level
+  regime, while `outcome_ledger.store_outcomes` only checks that the parent is a
+  fired entry. So the invariant is "nothing constructs them and the consumer
+  refuses them", not "the table forbids them" — which is why this section is a
+  rule for the runner rather than an observation about the DDL.
+- **Nothing in `app/` constructs an `ExitLevels`.** `grep -rn 'ExitLevels('
+  app scripts tests` returns one verify script and two test modules. The
+  manifest already states this: *"`level_based=True` says the levels EXIST;
+  nothing in `app/` computes them yet."*
+
+So the scan's outcome half has no work to do for three strategies and no inputs
+for the fourth.
+
+⚠ **And there is a second, sharper reason not to bolt it on later without
+thought.** `select_pending_fills` returns fills with **no outcome row at the
+pin**. An immature window — a signal whose max-hold has not elapsed — resolves to
+`unresolved` / `window_truncated`. Store that today and the signal leaves the
+pending set **permanently**: tomorrow's mature resolution collides on
+`(signal_id, rule_set_version, input_rule_set_version)`, and there is no
+`ON CONFLICT` there either. §3.1.2's *"immature windows need a policy"* has
+exactly one safe answer: **do not write an outcome for a window that has not
+closed.** `unresolved` is for a window that closed and could not be judged, not
+for one still open.
+
+**Rule.** §3.1 ships as `strategy_signal_scan`, signals only. Outcome resolution
+is a separate job on a separate ticket, blocked on an S-4 exit-level provider,
+and it must carry the immature-window rule above as an acceptance criterion.
+
+This also settles §4 question 1 (*"does the scan resolve outcomes, or a second
+job?"*): a second job, because the first one cannot.
+
+## 8. Transaction boundary, failure isolation, concurrency
+
+**One transaction per `(strategy_id, frontier)`** — the unit the watermark names,
+which per §3.1 is a frontier and not a write date, because the write date varies
+by instrument. A strategy's run is all-or-nothing, and one strategy's failure does
+not stop the others: the manifest is iterated, each entry's batch commits
+independently, and the watermark advances per `(strategy_id, strategy_version)`.
+A half-written batch under a no-`ON CONFLICT` key is unrecoverable without a
+delete, so the batch boundary and the watermark unit have to be the same thing.
+
+**Concurrency (§4 question 2).** ⚠ Uniqueness catches a duplicate only *after*
+the work is done, and under a raising key that means an aborted batch rather than
+a no-op. `app/jobs/locks.py` already has the lane mechanism —
+`pg_try_advisory_lock(hashtext('job_source:{source}')::int)`, session-scoped,
+released in a `finally`. Reuse it with a scan-specific lane; do not invent a
+second locking vocabulary.
+
+⚠ **Take the lock in a connection that is not inside the writing transaction.**
+Prevention log: *"`pg_advisory_xact_lock` acquired in a savepoint is absorbed by
+the parent and held until the TOP-LEVEL transaction commits"* — with a
+per-strategy commit boundary that would hold every strategy's lock until the last
+one finished.
+
+## 9. Observability (§4 question 5)
+
+Writing rows is not enough. The job reports, per run:
+
+- the frontier date, the write date, and the watermark it resumed from;
+- per `(strategy_id, signal_kind, verdict, not_evaluable_reason)`, the row count
+  — the §6 census shape, emitted by the job rather than by a script;
+- instruments in the validated universe that produced **no row at all**, with
+  which of the two reasons: no bars through the masked loader (188 today), or a
+  series whose last bar is not the frontier (764 today).
+
+⚠ **A strategy-date with zero rows must be visible, and no index can do that.**
+The first draft pointed at `idx_strategy_signals_reason`; Codex is right that it
+cannot help — it is keyed `(strategy_id, strategy_version, not_evaluable_reason)`
+with no `signal_bar_date`, and more fundamentally **an absent row indexes to
+nothing**. Zero-coverage is only detectable against an *expected* count, so the
+job must emit the count it wrote against the eligible population it computed, per
+strategy, per run — and a mismatch is a failure, not a log line. A scan that
+silently covered 4,000 instruments instead of 5,783 is the manifest defect
+(#2394 §2) reappearing at the population layer. `verify_2394_signal_scan_cost.py
+--cost` already asserts exactly this equality and exits non-zero on a short leg;
+the job inherits the check rather than the index.
+
+## 10. The population is survivor-only, and says so
+
+§3.1.1 named #2290 as blocking. It merged (`f234a1e3`) and
+`instrument_universe_membership` is live — but §0 measures it at **0 rows**, by
+design: `sync_universe` calls `reconcile_universe_membership`
+(`app/services/universe.py:226`), so the table accrues from the next
+`nightly_universe_sync` and not before, and #2290 carries a no-backfill clause
+because the historical transitions were destroyed as they happened.
+
+So the membership record cannot answer "was X tradable on date D" for any past
+date, and will not for some time. §3.1.1 offers two arms and the second is the
+one available: **the scan pins `universe = 'survivor_only'` on every row**, which
+is the label #2288 already defined and which `load_validated_universe`'s own
+docstring insists on: *"Do not quietly drop the filter to make a number look
+better — that would widen the population without changing the label, which is
+worse than the bias."*
+
+⚠ This is not a workaround that expires quietly. The switch to a point-in-time
+population is a **new `universe` value**, hence a new `strategy_version`, hence a
+new track record beside the old one — not an in-place correction. Stated here so
+that the day membership history is deep enough to use, nobody treats it as a bug
+fix.
+
+## 11. What this job does not do
+
+- **It touches no broker path.** It records what would happen. Funding is a later
+  phase, and §3.1's own note stands: the unfunded set is the
+  **allocation-unbiased arm**, not "the unbiased control" — it still inherits
+  survivor-only membership, `not_evaluable` exclusions and quarantine masking.
+- **It does not backfill.** Signals are a function of what was known on the day.
+  §3.1: *"Every day this job is not running is a day of validation permanently
+  lost."* Deriving yesterday's signals from today's stored bars would reintroduce
+  the look-ahead phase 5 spent itself removing.
+- **It does not run `strategy_backtest_run`** (§3.2), and must never be gated
+  behind it.
+
+## 12. Residual risk this spec does not close
+
+⚠ **A corrected historical bar cannot be reflected in an already-written
+signal.** `LedgerRow` records `input_rule_set_versions` (the indicator and
+quarantine rule sets) but **no corpus version**, and the writer has no
+`ON CONFLICT`. So if `daily_candle_refresh`'s trailing-correction window revises
+a bar the scan has already evaluated, the stored verdict is wrong and is
+unrewritable — the corrected row collides on the uniqueness key.
+
+This is inherent to the no-`ON CONFLICT` design and is not created by this job;
+the job is simply the first thing that will encounter it, daily and at scale. It
+needs its own ticket, and the shape of the fix (a corpus version in the key, or
+an explicit supersede-and-record path) is a decision about the ledger, not about
+the scan. Flagged here rather than absorbed.
+
+## 13. Acceptance
+
+1. `strategy_signals` accrues rows daily at `universe = 'survivor_only'`, with
+   `signal_bar_date` never equal to any instrument's last bar.
+2. A re-run on the same frontier is a **no-op via the watermark** — not via
+   `ON CONFLICT`, which does not exist and must not be added.
+3. A market holiday leaves the frontier unmoved, writes zero rows, and does not
+   wedge: the next run with a moved frontier writes the whole gap.
+4. The per-run census sums to the eligible-instrument count for every
+   `(strategy_id, signal_kind)` — a shortfall fails the run rather than
+   under-reporting it.
+5. The scan refuses a day whose modal frontier share is below the §3 floor.
+6. Every figure in §§0, 2, 3.1, 5, 6 is **printed** by
+   `scripts/verify_2394_signal_scan_cost.py --all`, exit 0 — none is arithmetic
+   done in this document.

--- a/scripts/verify_2394_signal_scan_cost.py
+++ b/scripts/verify_2394_signal_scan_cost.py
@@ -1,0 +1,639 @@
+"""Full-population measurement for the daily signal scan (#2394 §3.1).
+
+    PYTHONPATH=. uv run python scripts/verify_2394_signal_scan_cost.py --all
+
+⚠ NOTHING IS WRITTEN. Every arm reads and prints. Gate on the EXIT CODE — 0
+means every arm passed, 1 means at least one did not.
+
+⚠ NEVER PIPE THIS INTO ``head``/``tail``. A pipe returns the pipe's status, so a
+failure reads as success, and it buffers the progress lines a multi-minute run
+is judged by (`.claude/CLAUDE.md`).
+
+⚠⚠ THIS READS THE **LIVE** CORPUS (``price_daily``), NOT THE RESEARCH CORPUS.
+Every phase-5 figure on this epic was measured on ``research_price_daily``,
+which is a frozen archive keyed on ``series_id``. A daily scan cannot run on it:
+``--population`` prints both corpora's last bar and the share of research series
+that even carry an ``instrument_id``. The strategy code is corpus-agnostic; the
+LOADER is not, and there is no masked loader for ``price_daily`` in ``app/`` —
+``_load_live_masked`` below is this script's own, mirroring
+``research_price_structure_store._LOAD_SQL`` field for field so the measurement
+is of the corpus and not of a second masking rule.
+
+FOUR ARMS, MEASURING DIFFERENT THINGS
+-------------------------------------
+``--population`` — who a daily scan would cover, on the live corpus, today:
+validated-universe size, how many carry bars, quarantine coverage at the current
+rule-set version (the loader is fail-closed, so an uncovered instrument is an
+excluded one), per-instrument depth, and the last-bar-date histogram. That last
+one is §4 question 3 — *"after the candle refresh" must name a concrete
+condition* — and the histogram is the reason it cannot be ``max(price_date)``.
+
+``--arrears`` — ⚠⚠ THE CLAIM MOST WORTH FALSIFYING, and the one that decides the
+job's shape. The final bar of any series has no ``t+1``, so no decision on it can
+be filled, and ``strategy_registry.evaluate`` stamps it ``not_evaluable`` /
+``no_fill_bar``. ``sql/255`` carries no ``ON CONFLICT``, so that row is
+**terminal**: when tomorrow's bar arrives, the corrected row collides on
+``(strategy_id, strategy_version, instrument_id, signal_bar_date, signal_kind)``
+and raises. This arm computes each series' verdict at its SECOND-TO-LAST bar
+twice — with the next bar present (a one-day-arrears scan) and without it (a
+same-day scan) — and counts the disagreement. ⚠ Its first version asked
+``resolve_fills`` instead and measured 0 of 0, because the refusal happens one
+layer up; see the function's own docstring.
+
+``--cost`` — §4 question 4: *"Cost of a full daily scan is unmeasured, and
+§3.1's 'cheap' is an assertion until it is."* Streams every validated-universe
+instrument through the masked loader and runs all four manifest entries over the
+full history, timed. Reports the per-strategy verdict census at the frontier
+date — the daily WRITE volume, which is also §4 question 5's observability
+denominator.
+
+⚠ S-2 IS STAGED, NOT PANEL-MATERIALISED. ``evaluate_cross_sectional`` holds every
+member's whole score series in memory at once, which §2 of the spec calls
+explicitly unsafe at corpus scale. A daily scan needs ONE date's cross-section,
+so this arm keeps only the frontier date's score per member and calls
+``s2_select`` once. That is a finding, not an optimisation: the panel a daily
+scan needs is a slice, not the corpus.
+
+``--truncation`` — §3.1.2 item 1: *"Strategy functions emit full-series verdicts,
+not a single bar. The runner either gains single-date entry points or recomputes
+history and filters — decide, and state which."* ``rsi_series`` and
+``atr_series`` are **Wilder-smoothed from the series start** (recursive, infinite
+memory — ``indicator_series`` says so in ``atr_window_series``' docstring and
+measures the gap on a 36-bar fixture). So a trailing-K-bar recompute is a
+DIFFERENT function, not a cheaper one. This arm runs both and counts how many
+instruments disagree at the frontier bar, per K, per strategy. A non-zero count
+settles the question by measurement rather than by argument.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections import Counter
+from datetime import date
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.services.cost_model import COST_MODEL_ID
+from app.services.indicator_series import BarSeries
+from app.services.price_quarantine import RULE_SET_VERSION as QUARANTINE_RULE_SET_VERSION
+from app.services.signal_ledger import resolve_fills
+from app.services.strategies.s2_cross_sectional_momentum import S2_STRATEGY_ID
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry
+from app.services.technical_analysis import OHLCVRow
+
+#: The live corpus is today's tradable list, so every figure here inherits the
+#: survivorship label #2288 put on the research one. ``instrument_universe_
+#: membership`` (#2290) is the fix and is empty by design until the next
+#: ``nightly_universe_sync`` — ``--population`` prints its row count so the
+#: claim is checked rather than repeated.
+UNIVERSE = "survivor_only"
+
+#: What the masked loader means by an absent field, in the strategies' own
+#: closed vocabulary.
+MASKED_REASON = "quarantined_bar"
+
+#: Trailing windows the truncation arm compares against full history. 250 ≈ one
+#: trading year (S-1 needs ``sma_200``, so anything shorter cannot evaluate it at
+#: all and the comparison would be against a refusal); 750 ≈ three.
+TRUNCATION_WINDOWS = (250, 750)
+
+# ⚠ A FIELD-FOR-FIELD MIRROR of `research_price_structure_store._LOAD_SQL`
+# against the live corpus. The JOIN to the coverage table — not a LEFT JOIN — is
+# the fail-closed rule: bars outside an evaluated range are not returned, because
+# an unevaluated bar is unchecked rather than clean. The LEFT JOIN to the verdict
+# table is right for the opposite reason: that table is SPARSE, a row exists only
+# when it says something, so a missing row IS a clean bar inside a covered range.
+_LIVE_LOAD_SQL = """
+    SELECT d.price_date,
+           d.open,
+           d.high,
+           d.low,
+           d.close,
+           d.volume,
+           COALESCE(q.range_usable, TRUE)  AS range_usable,
+           COALESCE(q.return_usable, TRUE) AS return_usable
+    FROM price_daily d
+    JOIN price_quarantine_coverage cov
+      ON cov.instrument_id = d.instrument_id
+     AND cov.rule_set_version = %(quarantine_version)s
+     AND d.price_date BETWEEN cov.first_bar AND cov.last_bar
+    LEFT JOIN price_bar_quarantine q
+      ON q.instrument_id = d.instrument_id
+     AND q.price_date = d.price_date
+     AND q.rule_set_version = %(quarantine_version)s
+    WHERE d.instrument_id = %(instrument_id)s
+    ORDER BY d.price_date
+"""
+
+
+def _load_live_masked(conn: psycopg.Connection[Any], instrument_id: int) -> BarSeries:
+    """One instrument's live bars, quarantined fields masked to ``None``.
+
+    The masking rule is ``_apply_arm``'s, and only the ``masked`` arm: this is a
+    production-shaped read, and criterion 9's ``admitted`` arm is a sensitivity
+    measurement that has no place in a scan. ⚠ The OPEN is masked on its VALUE
+    (#2354) — ``price_quarantine`` has no axis for it, and a stored ``open = 0``
+    reaching ``resolve_fills`` books a fill at price 0.
+    """
+    rows = conn.execute(
+        _LIVE_LOAD_SQL,
+        {"instrument_id": instrument_id, "quarantine_version": QUARANTINE_RULE_SET_VERSION},
+    ).fetchall()
+    dates: list[date] = []
+    bars: list[OHLCVRow] = []
+    for bar_date, open_, high, low, close, volume, range_usable, return_usable in rows:
+        dates.append(bar_date)
+        bars.append(
+            {
+                "open": open_ if (open_ is not None and open_ > 0) else None,  # type: ignore[typeddict-item]
+                "high": high if range_usable else None,  # type: ignore[typeddict-item]
+                "low": low if range_usable else None,  # type: ignore[typeddict-item]
+                "close": close if return_usable else None,  # type: ignore[typeddict-item]
+                "volume": volume,
+            }
+        )
+    return BarSeries(dates=tuple(dates), rows=tuple(bars))
+
+
+def _tail(series: BarSeries, window: int) -> BarSeries:
+    """The last ``window`` bars, as its own series."""
+    return BarSeries(dates=series.dates[-window:], rows=series.rows[-window:])
+
+
+def _per_series_entries() -> list[StrategyEntry]:
+    """Every ``per_series`` manifest entry, in id order.
+
+    ⚠ Read from the manifest rather than imported by name — that asymmetry is
+    the defect #2394 §2 closed, and re-opening it in the script that measures
+    the runner would be the same mistake one layer out.
+    """
+    return [entry for _, entry in sorted(STRATEGY_MANIFEST.items()) if entry.strategy_class == "per_series"]
+
+
+def _cross_sectional_entry() -> StrategyEntry:
+    entry = STRATEGY_MANIFEST[S2_STRATEGY_ID]
+    assert entry.member is not None and entry.select is not None and entry.min_participants is not None
+    return entry
+
+
+def _universe_with_bars(conn: psycopg.Connection[Any]) -> list[int]:
+    """Validated-universe ids that carry at least one bar inside a covered range.
+
+    ⚠ The predicate is the LOADER's, not ``EXISTS (price_daily)``. An instrument
+    whose bars all sit outside its quarantine coverage loads as zero bars, and
+    counting it as covered would report a population the scan does not reach.
+    """
+    ids = load_validated_universe(conn)
+    conn.execute("CREATE TEMP TABLE IF NOT EXISTS _scan_uni (instrument_id BIGINT PRIMARY KEY)")
+    conn.execute("TRUNCATE _scan_uni")
+    with conn.cursor().copy("COPY _scan_uni (instrument_id) FROM STDIN") as copy:
+        for instrument_id in ids:
+            copy.write_row((instrument_id,))
+    rows = conn.execute(
+        """
+        SELECT u.instrument_id
+        FROM _scan_uni u
+        WHERE EXISTS (
+            SELECT 1 FROM price_daily d
+            JOIN price_quarantine_coverage cov
+              ON cov.instrument_id = d.instrument_id
+             AND cov.rule_set_version = %(v)s
+             AND d.price_date BETWEEN cov.first_bar AND cov.last_bar
+            WHERE d.instrument_id = u.instrument_id
+        )
+        ORDER BY u.instrument_id
+        """,
+        {"v": QUARANTINE_RULE_SET_VERSION},
+    ).fetchall()
+    return [int(row[0]) for row in rows]
+
+
+def population() -> bool:
+    """Who the scan covers, and on which corpus."""
+    print("POPULATION — the live corpus, today")
+    with psycopg.connect(settings.database_url) as conn:
+        live = conn.execute(
+            "SELECT count(*), count(DISTINCT instrument_id), max(price_date) FROM price_daily"
+        ).fetchone()
+        research = conn.execute(
+            "SELECT count(*), count(DISTINCT series_id), max(bar_date) FROM research_price_daily"
+        ).fetchone()
+        mapped = conn.execute("SELECT count(*), count(instrument_id) FROM research_price_series").fetchone()
+        assert live is not None and research is not None and mapped is not None
+        print(f"  price_daily          bars {live[0]}  instruments {live[1]}  last bar {live[2]}")
+        print(f"  research_price_daily bars {research[0]}  series {research[1]}  last bar {research[2]}")
+        print(f"  research series carrying an instrument_id: {mapped[1]}/{mapped[0]}")
+
+        universe = load_validated_universe(conn)
+        with_bars = _universe_with_bars(conn)
+        print(f"  validated universe {len(universe)}; loadable through the masked loader {len(with_bars)}")
+
+        # ⚠ Three separate literal statements rather than a loop over a tuple of
+        # strings: psycopg 3.3's `execute` is typed on `LiteralString`, and a
+        # string bound to a loop variable is no longer one.
+        ledger = conn.execute(
+            """
+            SELECT (SELECT count(*) FROM strategy_signals),
+                   (SELECT count(*) FROM strategy_outcomes),
+                   (SELECT count(*) FROM instrument_universe_membership)
+            """
+        ).fetchone()
+        assert ledger is not None
+        print(f"  strategy_signals {ledger[0]} rows; strategy_outcomes {ledger[1]} rows")
+        print(f"  instrument_universe_membership {ledger[2]} rows (#2290 — empty until the next universe sync)")
+
+        # ⚠⚠ BOTH QUERIES BELOW GO THROUGH THE COVERAGE JOIN, not through raw
+        # `price_daily`. An earlier version joined `_scan_uni` to the raw table
+        # and called the result "the loadable universe" — which counts bars the
+        # fail-closed loader does not return, so the depth and the histogram
+        # would describe a population the scan never sees. Caught by Codex at
+        # checkpoint 1.
+        print("  last-bar-date histogram over the LOADABLE universe (top 6):")
+        hist = conn.execute(
+            """
+            SELECT last_bar::text, count(*) FROM (
+                SELECT d.instrument_id, max(d.price_date) AS last_bar
+                FROM price_daily d
+                JOIN _scan_uni u ON u.instrument_id = d.instrument_id
+                JOIN price_quarantine_coverage cov
+                  ON cov.instrument_id = d.instrument_id
+                 AND cov.rule_set_version = %(v)s
+                 AND d.price_date BETWEEN cov.first_bar AND cov.last_bar
+                GROUP BY 1
+            ) t GROUP BY 1 ORDER BY 2 DESC LIMIT 6
+            """,
+            {"v": QUARANTINE_RULE_SET_VERSION},
+        ).fetchall()
+        for last_bar, count in hist:
+            print(f"    {last_bar}: {count}")
+        depth = conn.execute(
+            """
+            SELECT min(n), percentile_disc(0.5) WITHIN GROUP (ORDER BY n), max(n), sum(n),
+                   count(*) FILTER (WHERE n < 200),
+                   round(100.0 * count(*) FILTER (WHERE n < 200) / count(*), 1)
+            FROM (
+                SELECT count(*) AS n
+                FROM price_daily d
+                JOIN _scan_uni u ON u.instrument_id = d.instrument_id
+                JOIN price_quarantine_coverage cov
+                  ON cov.instrument_id = d.instrument_id
+                 AND cov.rule_set_version = %(v)s
+                 AND d.price_date BETWEEN cov.first_bar AND cov.last_bar
+                GROUP BY d.instrument_id
+            ) t
+            """,
+            {"v": QUARANTINE_RULE_SET_VERSION},
+        ).fetchone()
+        assert depth is not None
+        print(f"  bars per instrument: min {depth[0]}  median {depth[1]}  max {depth[2]}  total {depth[3]}")
+        research_depth = float(research[0]) / float(research[1]) if research[1] else 0.0
+        print(f"  research bars per series for contrast: {research[0]}/{research[1]} = {research_depth:,.0f}")
+        print(f"  instruments with fewer than 200 bars (sma_200 cannot evaluate): {depth[4]} ({depth[5]}%)")
+    return True
+
+
+def _frontier_date(series_by_id: dict[int, BarSeries]) -> date:
+    """The modal last bar across the loaded population.
+
+    ⚠ NOT ``max``. The histogram in ``--population`` is why: a handful of
+    instruments carry a bar the rest of the corpus does not have yet, so a scan
+    keyed on the maximum would evaluate a date most of the universe is missing
+    and manufacture thousands of refusals out of a refresh still in flight.
+
+    ⚠ Ties break on the LATER date, and the modal SHARE is printed rather than
+    assumed — the spec's completeness condition is a floor on that share, so a
+    reader has to be able to see what it is on the day.
+    """
+    counts = Counter(series.dates[-1] for series in series_by_id.values() if len(series))
+    best = max(counts.items(), key=lambda item: (item[1], item[0]))
+    total = sum(counts.values())
+    print(f"  frontier {best[0]} held by {best[1]}/{total} loadable series ({100.0 * best[1] / max(total, 1):.1f}%)")
+    return best[0]
+
+
+def _run_population(conn: psycopg.Connection[Any], instrument_ids: list[int]) -> dict[int, BarSeries]:
+    loaded: dict[int, BarSeries] = {}
+    started = time.monotonic()
+    for n, instrument_id in enumerate(instrument_ids, start=1):
+        series = _load_live_masked(conn, instrument_id)
+        if len(series):
+            loaded[instrument_id] = series
+        if n % 1000 == 0:
+            print(f"  loaded {n}/{len(instrument_ids)} ({time.monotonic() - started:.0f}s)", flush=True)
+    print(
+        f"  loaded {len(loaded)} series, {sum(len(s) for s in loaded.values())} bars "
+        f"in {time.monotonic() - started:.1f}s",
+        flush=True,
+    )
+    return loaded
+
+
+def arrears() -> bool:
+    """What a scan-of-today writes down that a scan-of-yesterday would not.
+
+    ⚠⚠ AN EARLIER VERSION OF THIS ARM MEASURED THE WRONG LAYER AND ITS PASS WAS
+    VACUOUS. It asked ``resolve_fills`` how many FIRED last-bar signals it
+    downgraded, and got 0 of 0 — because the strategy never emits ``fired``
+    there in the first place. ``strategy_registry.evaluate`` stamps the final bar
+    ``not_evaluable`` / ``no_fill_bar`` before the writer ever sees it, and
+    ``resolve_fills``' own docstring says so (*"a no-op on the normal path"*).
+    A 0-of-0 comparison proves nothing, which is the repo's probe rule applied to
+    a measurement.
+
+    The question a scan actually faces is a DIFFERENT one: what does bar ``D``'s
+    verdict become once ``D+1`` exists? So this arm computes each series' verdict
+    at its SECOND-TO-LAST bar twice — once over the full series (bar ``D+1`` is
+    present, which is what a scan running one day in arrears sees) and once over
+    the series truncated so that bar is last (what a same-day scan sees). Every
+    row where the two differ is a decision a same-day scan writes down wrongly,
+    and ``sql/255`` has no ``ON CONFLICT``, so it can never be corrected.
+    """
+    print("ARREARS — what a same-day scan records that a one-day-arrears scan would not")
+    with psycopg.connect(settings.database_url) as conn:
+        instrument_ids = _universe_with_bars(conn)
+        loaded = _run_population(conn, instrument_ids)
+
+    frontier = _frontier_date(loaded)
+    print(f"  frontier (modal last) bar date: {frontier}")
+
+    compared: Counter[str] = Counter()
+    differ: Counter[str] = Counter()
+    lost_fired: Counter[str] = Counter()
+    transitions: Counter[tuple[str, str, str]] = Counter()
+    started = time.monotonic()
+    for entry in _per_series_entries():
+        assert entry.signals is not None
+        for series in loaded.values():
+            if len(series) < 2:
+                continue
+            index = len(series) - 2
+            same_day = _tail(series, len(series) - 1)
+            same_day_index = len(same_day) - 1
+            with_next = {
+                (s.kind, s.verdict, s.reason)
+                for s in entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                if s.signal_index == index
+            }
+            without = {
+                (s.kind, s.verdict, s.reason)
+                for s in entry.signals(same_day, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                if s.signal_index == same_day_index
+            }
+            compared[entry.strategy_id] += len(with_next)
+            for kind, verdict, reason in sorted(with_next):
+                match = [row for row in without if row[0] == kind]
+                got = match[0] if match else ("", "absent", None)
+                if (verdict, reason) == (got[1], got[2]):
+                    continue
+                differ[entry.strategy_id] += 1
+                transitions[(entry.strategy_id, f"{verdict}/{reason or '-'}", f"{got[1]}/{got[2] or '-'}")] += 1
+                if verdict == "fired":
+                    lost_fired[entry.strategy_id] += 1
+
+    print("  per strategy, at each series' SECOND-TO-LAST bar:")
+    total_compared = total_differ = total_lost = 0
+    for entry in _per_series_entries():
+        key = entry.strategy_id
+        print(f"    {key}: compared {compared[key]}, differ {differ[key]}, of which fired-with-next {lost_fired[key]}")
+        total_compared += compared[key]
+        total_differ += differ[key]
+        total_lost += lost_fired[key]
+    print("  transitions (verdict with D+1 present -> verdict without it):")
+    for (key, was, now), count in sorted(transitions.items(), key=lambda item: -item[1]):
+        print(f"    {key}: {was} -> {now}: {count}")
+    print(
+        f"  TOTAL compared {total_compared}, differ {total_differ}, fired-and-lost {total_lost} "
+        f"({time.monotonic() - started:.1f}s)"
+    )
+    if not total_compared:
+        print("  ⚠⚠ nothing compared — this arm measured no population and its verdict is worthless")
+        return False
+    if not total_differ:
+        print("  ⚠ no difference measured; the arrears argument does NOT hold on this corpus")
+        return False
+    print("  ⚠⚠ a same-day scan records a different verdict for the same bar, and store_signals has no")
+    print("     ON CONFLICT, so the corrected row can never be written. The scan must run in ARREARS.")
+    return True
+
+
+def cost() -> bool:
+    """§4 q4 — what a full daily scan actually costs, and what it writes.
+
+    ⚠ THE CENSUS IS TAKEN AT THE WRITE DATE, WHICH IS THE FRONTIER MINUS ONE BAR,
+    not at the frontier. An earlier version censused the frontier itself and
+    reported 5,783 ``no_fill_bar`` rows per leg — structurally guaranteed, since
+    the frontier IS the last bar and no decision there can be filled. It measured
+    the refusal, not the scan. ``--arrears`` is the arm that establishes the
+    offset; this one reports what the job actually stores.
+    """
+    print("COST — full-history recompute over the live validated universe")
+    with psycopg.connect(settings.database_url) as conn:
+        instrument_ids = _universe_with_bars(conn)
+        loaded = _run_population(conn, instrument_ids)
+
+    frontier = _frontier_date(loaded)
+    at_frontier = {i: s for i, s in loaded.items() if s.dates[-1] == frontier and len(s) >= 2}
+    bars = sum(len(series) for series in loaded.values())
+    write_dates = Counter(series.dates[-2] for series in at_frontier.values())
+    write_date = write_dates.most_common(1)[0][0]
+    print(f"  frontier bar date {frontier}; {len(loaded)} series, {bars} bars")
+    print(f"  write date = frontier - 1 bar; series eligible to be written {len(at_frontier)}")
+    # ⚠ The write date is PER INSTRUMENT — the bar before the frontier on that
+    # instrument's own calendar — so it is a distribution, not a constant, and a
+    # watermark keyed on one date has to answer to this spread.
+    spread = ", ".join(f"{when.isoformat()}={n}" for when, n in write_dates.most_common(5))
+    print(f"  write-date distribution across eligible series: {spread}")
+
+    # ⚠⚠ THE CENSUS RUNS THROUGH `resolve_fills`, NOT OFF THE RAW VERDICTS.
+    # A `fired` verdict whose t+1 open is absent or non-positive is STORED as
+    # `not_evaluable` / `unusable_fill_price` (#2354), so a census of strategy
+    # output is not a census of the ledger. Caught by Codex at checkpoint 1.
+    verdicts: Counter[tuple[str, str, str, str]] = Counter()
+    per_strategy_seconds: dict[str, float] = {}
+    for entry in _per_series_entries():
+        assert entry.signals is not None
+        identity = entry.identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+        started = time.monotonic()
+        for instrument_id, series in loaded.items():
+            signals = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            if instrument_id not in at_frontier:
+                continue
+            rows = resolve_fills(signals, series=series, identity=identity, instrument_id=instrument_id)
+            target = series.dates[-2]
+            for row in rows:
+                if row.signal_bar_date != target:
+                    continue
+                verdicts[(entry.strategy_id, row.signal_kind, row.verdict, row.not_evaluable_reason or "")] += 1
+        per_strategy_seconds[entry.strategy_id] = time.monotonic() - started
+        print(f"  {entry.strategy_id}: {per_strategy_seconds[entry.strategy_id]:.1f}s", flush=True)
+
+    s2 = _cross_sectional_entry()
+    assert s2.member is not None and s2.select is not None and s2.min_participants is not None
+    started = time.monotonic()
+    # ⚠⚠ THE REBALANCE CALENDAR IS THE PANEL'S UNION, NOT EACH MEMBER'S OWN.
+    # `rebalance_dates` fires on the FIRST bar whose calendar month differs from
+    # the previous bar's — the start of the new month, and causal for the reason
+    # its docstring gives: the last session of a month is not knowable at that
+    # session. Given a per-member calendar it fires on that member's own first
+    # bar of each month, so members that resumed on different days rebalance on
+    # different dates and the cross-section collapses. An earlier version of this
+    # arm did exactly that and reported `thin_cross_section (1 < 10)`, which is a
+    # measurement of the bug rather than of S-2.
+    union = sorted({when for series in loaded.values() for when in series.dates})
+    panel_dates = s2.decision_calendar(union)
+    assert panel_dates is not None
+    scores: dict[int, float] = {}
+    s2_participants = 0
+    s2_rows = 0
+    for instrument_id, series in loaded.items():
+        member = s2.member(series, panel_decision_dates=panel_dates, universe=UNIVERSE, masked_reason=MASKED_REASON)
+        if instrument_id not in at_frontier:
+            continue
+        index = len(series) - 2
+        # ⚠ EVERY member gets a row at the write date, decision bar or not.
+        # `CrossSectionalMember`: "Everything else is an ordinary not_fired …
+        # It is a verdict, not an absence." So S-2's write volume is the whole
+        # eligible population on every scan day, not just on a rebalance.
+        s2_rows += 1
+        if index not in member.decision_indices:
+            continue
+        s2_participants += 1
+        value = member.score.values[index]
+        if value is not None:
+            scores[instrument_id] = value
+    s2_seconds = time.monotonic() - started
+    span_years = (union[-1] - union[0]).days / 365.25 if len(union) > 1 else 0.0
+    print(
+        f"  s2 panel rebalance dates on the union calendar: {len(panel_dates)} over "
+        f"{span_years:.1f} years ({len(panel_dates) / max(span_years, 1e-9):.1f}/year)"
+    )
+    if len(scores) < s2.min_participants:
+        s2_selected = 0
+        s2_note = f"thin_cross_section ({len(scores)} < {s2.min_participants})"
+    else:
+        s2_selected = len(s2.select(write_date, scores))
+        s2_note = "selected"
+    print(
+        f"  {s2.strategy_id}: {s2_seconds:.1f}s, rows at the write date {s2_rows}, "
+        f"decision-bar participants {s2_participants}, scored {len(scores)}, {s2_note} {s2_selected}"
+    )
+
+    print("  write-date verdict census — the daily write volume, as the ledger would store it:")
+    for (key, kind, verdict, reason), count in sorted(verdicts.items()):
+        suffix = f" ({reason})" if reason else ""
+        print(f"    {key} {kind} {verdict}{suffix}: {count}")
+    per_leg: Counter[tuple[str, str]] = Counter()
+    for (key, kind, _verdict, _reason), count in verdicts.items():
+        per_leg[(key, kind)] += count
+    ok = True
+    for (key, kind), n in sorted(per_leg.items()):
+        if n != len(at_frontier):
+            print(f"  ⚠⚠ {key} {kind} censused {n} rows against {len(at_frontier)} eligible series — a leg is short")
+            ok = False
+    daily_rows = sum(verdicts.values()) + s2_rows
+    print(f"  TOTAL rows per scan day {daily_rows} (per-series legs {sum(verdicts.values())} + s2 {s2_rows})")
+    print(f"  at 252 trading days that is {daily_rows * 252:,} rows/year at one strategy_version")
+    warmup = sum(n for (key, kind, verdict, reason), n in verdicts.items() if reason == "insufficient_warmup")
+    print(
+        f"  insufficient_warmup rows {warmup} of {sum(verdicts.values())} per-series rows "
+        f"({100.0 * warmup / max(sum(verdicts.values()), 1):.1f}%)"
+    )
+    evaluation = sum(per_strategy_seconds.values()) + s2_seconds
+    print(
+        f"  strategy evaluation total {evaluation:.1f}s over {bars} bars "
+        f"({bars * len(STRATEGY_MANIFEST) / max(evaluation, 1e-9):,.0f} bar-evaluations/s)"
+    )
+    return ok
+
+
+def truncation() -> bool:
+    """§3.1.2 q1 — is a trailing-window recompute the same function? Measure it."""
+    print("TRUNCATION — trailing-window recompute vs full history, at the frontier bar")
+    with psycopg.connect(settings.database_url) as conn:
+        instrument_ids = _universe_with_bars(conn)
+        loaded = _run_population(conn, instrument_ids)
+
+    frontier = _frontier_date(loaded)
+    eligible = {i: s for i, s in loaded.items() if s.dates[-1] == frontier}
+    print(f"  frontier {frontier}; series ending there {len(eligible)}")
+
+    disagreements: Counter[tuple[int, str]] = Counter()
+    compared: Counter[tuple[int, str]] = Counter()
+    deeper_than: Counter[int] = Counter()
+    started = time.monotonic()
+    for entry in _per_series_entries():
+        assert entry.signals is not None
+        for series in eligible.values():
+            index = len(series) - 1
+            emitted = entry.signals(series, universe=UNIVERSE, masked_reason=MASKED_REASON)
+            full = {(s.kind, s.verdict, s.reason) for s in emitted if s.signal_index == index}
+            for window in TRUNCATION_WINDOWS:
+                if len(series) <= window:
+                    continue
+                deeper_than[window] += 1
+                tail = _tail(series, window)
+                tail_index = len(tail) - 1
+                got = {
+                    (s.kind, s.verdict, s.reason)
+                    for s in entry.signals(tail, universe=UNIVERSE, masked_reason=MASKED_REASON)
+                    if s.signal_index == tail_index
+                }
+                compared[(window, entry.strategy_id)] += 1
+                if got != full:
+                    disagreements[(window, entry.strategy_id)] += 1
+
+    for window in TRUNCATION_WINDOWS:
+        deeper = deeper_than[window] // max(len(_per_series_entries()), 1)
+        print(f"  window {window} bars — series deeper than it: {deeper}")
+        for entry in _per_series_entries():
+            key = (window, entry.strategy_id)
+            n = compared[key]
+            bad = disagreements[key]
+            share = f"{100.0 * bad / n:.2f}%" if n else "n/a"
+            print(f"    {entry.strategy_id}: {bad}/{n} frontier verdicts differ ({share})")
+    print(f"  elapsed {time.monotonic() - started:.1f}s")
+    if not sum(disagreements.values()):
+        print("  ⚠ NO disagreement measured. That does NOT license truncation — rsi/atr are Wilder-recursive,")
+        print("    so equality here is a property of this corpus's depth, not of the functions.")
+    else:
+        print("  ⚠⚠ a trailing-window recompute is a DIFFERENT function. The scan must recompute from the")
+        print("     series start, and identity records no window, so the two cannot be told apart once stored.")
+    return True
+
+
+ARMS = {
+    "population": population,
+    "arrears": arrears,
+    "cost": cost,
+    "truncation": truncation,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ARMS:
+        parser.add_argument(f"--{name}", action="store_true")
+    parser.add_argument("--all", action="store_true")
+    args = parser.parse_args()
+
+    selected = [name for name in ARMS if getattr(args, name)] or (list(ARMS) if args.all else [])
+    if not selected:
+        parser.print_help()
+        return 2
+
+    ok = True
+    for name in selected:
+        print()
+        ok = ARMS[name]() and ok
+    print()
+    print("PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Settles §4's seven open questions and §3.1.2's five underspecified items for the daily signal scan, before any of it is implemented — which is what §4 of the runner spec asks for: *"to settle before implementation, not during"*.

Adds two files. No behaviour changes, no schema, no job.

- `docs/proposals/ta/2026-08-08-strategy-signal-scan.md` — the spec.
- `scripts/verify_2394_signal_scan_cost.py` — four read-only arms supplying every figure in it. `PYTHONPATH=. uv run python scripts/verify_2394_signal_scan_cost.py --all`, exit 0.

## The four decisions, and what decided them

**The scan runs one bar in arrears.** The final bar of any series has no `t+1`, so `strategy_registry.evaluate` stamps it `not_evaluable`/`no_fill_bar`, and `signal_ledger.store_signals` has no `ON CONFLICT` to correct it with when tomorrow's bar arrives. `--arrears` computes each series' second-to-last verdict with and without its successor: **6,185 signals per day** that are `fired` with `D+1` present would be recorded permanently as unevaluable.

**It reads the live corpus, and needs a loader that does not exist.** Every phase-5 figure on this epic came from `research_price_daily` — frozen at `2026-07-08`, keyed on `series_id`, with only 5,269 of 7,709 series carrying an `instrument_id`. `strategy_signals.instrument_id` is an FK to `instruments`. So the scan reads `price_daily` (live to `2026-08-08`), and implementation must add an instrument-keyed masked loader mirroring `research_price_structure_store._LOAD_SQL`. ⚠ `price_quarantine_store.usable_bar_filter_sql` is a row **filter** and cannot substitute for a per-field **mask** — filtering shortens every warm-up window.

**No trailing window.** `--truncation` finds 0/3290 and 0/2033 frontier verdicts differing at 250- and 750-bar windows. That is reported as a **negative result that does not license truncation** — `rsi_series`/`atr_series` are Wilder-recursive, so equality is a property of this corpus's depth, not of the functions, and `StrategyIdentity` records no window. The actual reason not to truncate is that a full recompute is 56.8 s.

**Signals only — outcome resolution is a separate, blocked job.** `strategy_outcomes` is fed only by `outcome_resolver.resolve_outcome`, which needs `ExitLevels`. S-4 is the only `level_based` strategy and nothing in `app/` constructs an `ExitLevels`. Separately, `select_pending_fills` excludes any signal that already has an outcome row at the pin — so writing `unresolved`/`window_truncated` for an immature window drops that signal from the pending set **forever**. §3.1.2's "immature windows need a policy" has one safe answer: do not write an outcome for a window that has not closed.

## Measured, full population, 2026-08-08

```
validated universe 6735; loadable through the masked loader 6547
frontier 2026-08-07 held by 5783/6547 loadable series (88.3%)
bars per instrument: min 1  median 613  max 1046  total 3627106
research bars per series for contrast: 25920971/7709 = 3,362
fewer than 200 bars (sma_200 cannot evaluate): 2624 (40.1%)

strategy evaluation total 56.8s over 3627106 bars (255,420 bar-evaluations/s)
TOTAL rows per scan day 34698 (per-series legs 28915 + s2 5783)
at 252 trading days that is 8,743,896 rows/year at one strategy_version
insufficient_warmup rows 9790 of 28915 per-series rows (33.9%)
```

§3.1's "cheap" now holds by measurement rather than by assertion.

## What Codex killed at checkpoint 1

Four claims in the first draft were wrong and are now fixed, with the error recorded where it was made:

1. **`rebalance_dates` fires on the FIRST bar of a new month**, not the last trading day. The draft said the latter, which read as a rule would have specced a look-ahead into the runner — the function's own docstring explains why it must be causal.
2. **The write date is per instrument** (`2026-08-06=5779, 2026-07-31=1, 2026-08-05=1, 2026-08-04=1, 2026-07-28=1`), so a watermark holding one `signal_bar_date` cannot describe what was written. It holds a **frontier** instead — which also resolves the draft's self-contradiction about holidays advancing a bar-date watermark.
3. **`usable_bar_filter_sql`**, not `usable_bar_predicate`.
4. **`idx_strategy_signals_reason` cannot make a zero-row strategy-date visible** — no `signal_bar_date` in the key, and an absent row indexes to nothing. Zero-coverage is only detectable against an expected count, so the job emits one and the script asserts it.

## What the measurement killed in itself

The arrears arm's first version asked `resolve_fills` how many *fired* last-bar signals it downgraded and got **0 of 0** — because the refusal happens one layer up, in `strategy_registry.evaluate`. A 0-of-0 comparison proves nothing; rewritten to compare the second-to-last bar with and without its successor. The cost arm censused the frontier (5,783 `no_fill_bar` rows per leg, guaranteed by construction) instead of the write date, took strategy output rather than `resolve_fills` output, gave S-2 a per-member calendar (`thin_cross_section (1 < 10)` — a measurement of the bug), and computed the population histogram off raw `price_daily` rather than through the coverage join. All four fixed.

## Flagged, not absorbed

§12 records a residual the spec does not close: **a corrected historical bar cannot be reflected in an already-written signal.** `LedgerRow` carries `input_rule_set_versions` but no corpus version, and there is no `ON CONFLICT`. If `daily_candle_refresh`'s trailing-correction window revises a bar the scan already evaluated, the stored verdict is wrong and unrewritable. Inherent to the ledger's design, not created here — but this job is the first thing that will hit it daily and at scale. Needs its own ticket; the fix is a decision about the ledger, not about the scan.

## Security model

Not applicable. Two new files: a proposal document and a read-only measurement script. The script opens one connection, runs `SELECT`s and one `CREATE TEMP TABLE`, and writes nothing to any persistent table. No endpoint, no job registration, no broker path, no schema change.

## Gates

`ruff check` · `ruff format --check` · `pyright` · `pytest -m "not db"` · `pytest tests/smoke` — all exit 0, run separately and unpiped.

Refs #2394. Refs #2240.