### PR TITLE
docs(#2394): spec §3.2's strategy_backtest_run — the invocation unit the measurement moved, and the free hold-out arm criterion 5 cannot survive

### DIFF
--- a/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
+++ b/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
@@ -15,8 +15,8 @@ PYTHONPATH=. uv run python scripts/verify_2394_backtest_run.py --all
 ```
 
 exit 0, on the dev corpus, 2026-08-08 — with **three labelled exceptions**, all
-in §§8-9 and all estimates rather than measurements: the three-run cost
-comparison (three invocations, not one), the six-pass extrapolation, and the
+in §§8-9 and all estimates rather than measurements: the four-run cost
+comparison (four invocations, not one), the six-pass extrapolation, and the
 synthetic-control cost.
 Acceptance criterion 10 names them so the distinction cannot erode. Every other
 figure, including every share and percentage, is computed by the script; none is
@@ -65,11 +65,10 @@ hold-out result over 5,266. `evaluated_instrument_count` and the gate's
 job that computes the count once and stamps it on both rows is wrong on one of
 them. ⚠ 4,022 is a **ceiling, not the count**: warm-up, `not_evaluable` bars and
 S-2's minimum cross-section all remove instruments that have in-sample bars but
-produce no in-sample position. The count on the row is the measured set. On S-1
-masked that set is **3,541**, 12% below the 4,022 ceiling — so a job stamping the ceiling
-would overstate its own population on every in-sample row. `--arm` prints
-"instruments with >=1 in-sample position" for exactly this reason, and its gate
-candidate is built from that set rather than from the corpus's.
+produce no in-sample position. The count on the row is the measured set: on S-1
+masked it is **3,541**, 12% below the 4,022 ceiling, so a job stamping the
+ceiling would overstate its own population on every in-sample row. `--arm`
+prints "instruments with >=1 in-sample position" for exactly this reason.
 
 ⚠ **Zero series end before the boundary**, which is the survivor-only label
 (#2288 clause 1) showing up as a shape rather than as a caveat: a corpus that
@@ -365,26 +364,26 @@ merge two results — the #2286 shape the constraint was written against.
 ## 8. Cost
 
 `--arm`, one arm (S-1, masked, full corpus, whole window), full population, run
-**three times** on the same box and the same code:
+**four times** on the same box and the same code:
 
-| phase | run 1 | run 2 | run 3 |
-| --- | ---: | ---: | ---: |
-| corpus pass | 256.8s | 415.9s | 356.6s |
-| — masked bar loading | 84.7s (33.0%) | 142.9s (34.4%) | 136.8s (38.4%) |
-| — signals → positions | 148.1s (57.7%) | 229.9s (55.3%) | 184.2s (51.7%) |
-| — curve accumulation | 3.8s (1.5%) | 4.5s (1.1%) | 4.1s (1.1%) |
-| curve + metrics | 33.4s | 97.9s | 87.8s |
-| **TOTAL** | **290.3s** | **513.7s** | **444.4s** |
+| phase | run 1 | run 2 | run 3 | run 4 |
+| --- | ---: | ---: | ---: | ---: |
+| corpus pass | 256.8s | 415.9s | 356.6s | 290.8s |
+| — masked bar loading | 84.7s (33.0%) | 142.9s (34.4%) | 136.8s (38.4%) | 84.8s (29.2%) |
+| — signals → positions | 148.1s (57.7%) | 229.9s (55.3%) | 184.2s (51.7%) | 178.1s (61.2%) |
+| — curve accumulation | 3.8s (1.5%) | 4.5s (1.1%) | 4.1s (1.1%) | 4.7s (1.6%) |
+| curve + metrics | 33.4s | 97.9s | 87.8s | 39.7s |
+| **TOTAL** | **290.3s** | **513.7s** | **444.4s** | **330.5s** |
 
-3,135,355 positions over 5,266 series, 0 empties — **identical in all three**.
+3,135,355 positions over 5,266 series, 0 empties — **identical in all four**.
 
 ⚠ **The wall clock is not reproducible to better than ~1.8× on this box, and the
-spread is reported rather than averaged away.** All three runs did the same work
+spread is reported rather than averaged away.** All four runs did the same work
 on the same data and produced the same positions; the box was carrying other
 sessions' load. Plan on the slowest figure. What IS stable is the phase *shape* —
-roughly a third of the time is loading bars, about half is signals→positions, and
-the curve accumulation is ~1% — which is the part an optimisation decision would
-rest on, and it is the reason the spread does not undermine the section.
+29-38% of the time is loading bars, 52-61% is signals→positions, and the curve
+accumulation is ~1% in every run — which is the part an optimisation decision
+would rest on, and it is the reason the spread does not undermine the section.
 
 **Six passes is 29–51 minutes.** ⚠ That multiplication is an estimate and is
 labelled one: only S-1 was measured. S-3 is per-series and comparable; S-2 is
@@ -407,8 +406,8 @@ criterion 3's number and criterion 6 consumes it.
 
 ## 9. What the job can and cannot close on the gate
 
-`--arm` builds the row this job would store and runs `check_promotable` on it.
-Measured, not predicted — **8 refusals**:
+`--arm` runs `check_promotable` on a probe row. Measured, not predicted —
+**8 refusals**:
 
 | refusal | can this job close it? |
 | --- | --- |
@@ -421,12 +420,27 @@ Measured, not predicted — **8 refusals**:
 | `quarantine_arms_not_compared` | yes — both arms stored via the pair writer |
 | `synthetic_control_not_run` | **not in this cut** — see below |
 
-⚠ **The refusal list above is measured on ONE row** — S-1, in-sample, masked,
-with no DSR, no trial count and no arm comparison supplied, which is the *bare*
-row. It is the worst case and every entry in the table's right-hand column is a
-claim about what a fuller run closes, not something `--arm` demonstrated. The
-acceptance criteria (§14) require the implementation to re-measure the list on
-**every** written row.
+⚠ **The row is a WHOLE-WINDOW probe, not a namespace arm, and the substitution is
+demonstrated rather than waved through.** `--arm` deliberately builds no
+namespace-scoped curve — §5 is the reason: choosing that axis is the
+implementation's first decision and nothing in the tree has ever made it. So the
+probe's metric set spans both namespaces while its identity has to name one, and
+that inconsistency would matter if the gate read a metric *value*. It does not:
+blanking criterion 3's block-bootstrap field group and re-gating adds
+**exactly `effective_sample_size_not_computed` and removes nothing** — printed
+by the arm, and a failure if it ever moves. The gate reads one metric, for
+presence.
+
+⚠ Even so, the list is measured on **one** row and is the *bare* worst case: no
+DSR, no trial count, no arm comparison supplied. Every entry in the table's
+right-hand column is a claim about what a fuller run closes, not something
+`--arm` demonstrated. Acceptance criterion 8 requires the implementation to
+re-measure the list on **every** written row.
+
+⚠ A side result worth keeping: the same 8 refusals came back from a 300-series
+`--limit` run and from the full 5,266-series one. The list is a function of what
+the row *carries*, not of how much data went into it — which is why a probe can
+answer this question at all.
 
 ⚠⚠ **`effective_sample_size` is not free, and it nearly read as if it were.**
 `compute_metrics` computes criterion 3's block bootstrap **only when
@@ -643,7 +657,7 @@ maintenance problem.
 10. Every figure in §§0, 3, 4, 5, 6, 9 and the per-arm timings in §8 is printed
     by `scripts/verify_2394_backtest_run.py --all`, exit 0. ⚠ **Three things in
     this document are NOT script output and are labelled where they appear:**
-    §8's three-run comparison (three invocations), §8's six-pass estimate
+    §8's four-run comparison (four invocations), §8's six-pass estimate
     (arithmetic over an S-1 measurement, with S-2 explicitly excluded from the
     extrapolation), and §9's synthetic-control cost. Each is an estimate and
     none is quoted as a measurement.

--- a/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
+++ b/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
@@ -1,0 +1,649 @@
+# `strategy_backtest_run` — §3.2, settled against the corpus
+
+Spec for #2394 §3.2, the second of the two jobs
+`docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md` declares. §3.1
+shipped in `cc89c63e`. Parent: `docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md`
+§5; criteria from `docs/proposals/ta/strategy-catalogue-and-backtest-validity.md`
+§5; the frozen split, the arms and the gate from
+`docs/proposals/ta/2026-08-07-bounded-backtester.md` §§3.4, 5.2, 5.4, 6, 9.
+Refs #2240, #2288, #2284, #2277.
+
+⚠ **Every figure below is printed by**
+
+```bash
+PYTHONPATH=. uv run python scripts/verify_2394_backtest_run.py --all
+```
+
+exit 0, on the dev corpus, 2026-08-08 — with **three labelled exceptions**, all
+in §§8-9 and all estimates rather than measurements: the three-run cost
+comparison (three invocations, not one), the six-pass extrapolation, and the
+synthetic-control cost.
+Acceptance criterion 10 names them so the distinction cannot erode. Every other
+figure, including every share and percentage, is computed by the script; none is
+hand-written arithmetic, per the standing rule that a derived statistic written
+into prose goes stale silently in the place a reader trusts most.
+
+⚠ **`--arm` measures ONE strategy per invocation, and every figure it produces is
+a statement about that strategy.** The default is S-1. Where this document
+generalises from it — the ambiguity-arm claim in §6 — the generalisation rests on
+a structural check `--runnable` performs over the whole manifest, not on the
+single arm.
+
+**What §3.2 says today, in full:** *"Runs the harness for a strategy × namespace
+× arm and persists via `result_ledger`. Manual-trigger only: it is expensive, and
+its `StrategyIdentity.version` must be stable for a stored row to mean
+anything."* Three sentences. The measurement below contradicts the first one at
+the unit, and replaces "it is expensive" — which is a guess — with the reason
+that actually forces a manual trigger.
+
+## 0. The population, measured
+
+`--population`, over the corpus ∩ §4.0 validated universe:
+
+```
+validated universe        6,735 instruments
+of which the corpus holds 5,266
+bars in window       23,339,583   1962-01-02 … 2026-07-08
+  in-sample          17,501,058   74.98%
+  hold-out            5,838,525   25.02%
+series with in-sample bars only        0
+series with hold-out bars only     1,244
+series spanning the boundary       4,022
+hold-out-only share                23.6%   in-sample population ceiling 4,022 of 5,266
+```
+
+The bar split reproduces §5.2's frozen literals to the bar (M14/M18), so the
+boundary in `strategy_result.HOLDOUT_BOUNDARY` still describes this corpus. The
+arm **compares and fails**; it does not re-fit. §5.2: *"a recomputed boundary
+walks forward silently and re-admits hold-out data into training"*.
+
+⚠ **The two namespaces are over different populations, and by 23.6%.** 1,244 of
+the 5,266 series hold no bar before the boundary — they list after 2021-06-29 —
+so an in-sample result is computed over **at most** 4,022 instruments and a
+hold-out result over 5,266. `evaluated_instrument_count` and the gate's
+`evaluated_instrument_ids` subset test therefore differ **per namespace**, and a
+job that computes the count once and stamps it on both rows is wrong on one of
+them. ⚠ 4,022 is a **ceiling, not the count**: warm-up, `not_evaluable` bars and
+S-2's minimum cross-section all remove instruments that have in-sample bars but
+produce no in-sample position. The count on the row is the measured set. On S-1
+masked that set is **3,541**, 12% below the 4,022 ceiling — so a job stamping the ceiling
+would overstate its own population on every in-sample row. `--arm` prints
+"instruments with >=1 in-sample position" for exactly this reason, and its gate
+candidate is built from that set rather than from the corpus's.
+
+⚠ **Zero series end before the boundary**, which is the survivor-only label
+(#2288 clause 1) showing up as a shape rather than as a caveat: a corpus that
+contained delistings would have series that stop in 1998. It does not.
+
+## 1. Source rules
+
+| decision | rule, and where it comes from |
+| --- | --- |
+| Fill at the open of `t+1` | Parent §3.5 rule 1. Enforced by `signal_ledger.resolve_fills`; this job does not re-implement it. |
+| The 75/25 boundary and its inclusivity | §5.2, bar-weighted, **frozen** in `strategy_result.HOLDOUT_BOUNDARY`. Not recomputed here. |
+| A position spanning the boundary is hold-out | §5.2, verbatim. Implemented in `strategy_result.namespace_for_position`. |
+| Result identity's members | `sql/262`'s grain comment + `ResultIdentity`. Fourteen fields; §7 below lists who supplies each. |
+| Hold-out access is logged | Criterion 5, enforced by `sql/264`'s trigger — a hold-out row with no `evaluate` record is refused by the database. |
+| `M`, the declared trial count | Criterion 6. `app/services/trial_register.TRIAL_REGISTER`, version `trial-register-2026-08-07`, **M = 11**. ⚠ Includes abandoned branches; not derivable from the manifest. |
+| The two ambiguity arms | §3.4. Both computed, both reported; a material gap blocks promotion. |
+| The two quarantine arms | Criterion 9. Both stored, through `result_ledger.store_*_arm_pair`, which makes the lone-arm state unreachable. |
+| A duplicate identity raises | §2 of the runner spec: *"raising, loudly. `DO NOTHING` would hide corpus drift"*. |
+
+⚠ **No threshold, window or ratio is chosen in this document.** Every constant it
+uses is imported from a module that already froze it, which is why the tables
+below cite module attributes rather than numbers.
+
+## 2. ⚠⚠ The invocation unit is the strategy SET, not one strategy
+
+§3.2 says *"runs the harness for a strategy × namespace × arm"*. It cannot, if
+the row is to be judgeable, and the reason is arithmetic rather than
+architectural.
+
+Criterion 6's Deflated Sharpe deflates the observed Sharpe by `V[SR_n]`, the
+variance of the Sharpes **across the measured trials**. `deflated_sharpe.py`:
+
+```
+MIN_MEASURED_TRIALS: Final = 2
+```
+
+A single strategy is one measured trial, `V[SR_n]` does not exist, and
+`deflate_sharpe` refuses. Equation (8)'s inter-trial correlation needs the same
+thing from the other side: it is measured off the trials' realised return series
+on the dates **both** traded, so one trial has nothing to correlate with.
+
+So a per-strategy invocation writes rows that carry `deflated_sharpe = NULL`, and
+the gate refuses every one of them with `deflated_sharpe_not_computed` — a
+refusal the operator cannot act on, because no amount of re-running one strategy
+will clear it.
+
+**Rule.** One invocation evaluates **every runnable strategy** in
+`STRATEGY_MANIFEST`, and the DSR is computed once across them at the end. A
+`strategy_id` param may narrow the set for a debugging run; the job then declares
+the DSR absent and says why, rather than writing a row that looks incomplete for
+an unexplained reason.
+
+⚠ **What the DSR consumes is per-trade moments and a per-entry-date return
+series, per strategy** — the Sharpe variance across trials, and equation (8)'s
+correlation off the dates two trials both traded. Both come off the trade list
+the evaluation already produced, so the job holds each strategy's trade returns
+keyed by entry fill date (criterion 3's cluster key, so the two correlation
+constructions in this phase agree about "the same day") until step 2 of §10's
+sequence. ⚠ **S-2 has no per-instrument holding period** — its closes are
+rebalance drop-outs — but it still produces positions with entry fills and
+returns, so its trade axis is the same shape as S-1's. The one thing the job must
+not do is build the correlation on a date axis one strategy padded with zeros: a
+trial that did not trade on a date carries no pairwise information and the dates
+are intersected, not unioned.
+
+⚠ **The register and the manifest agree, and that is checked rather than
+assumed.** `verify_2240_statistics.py` carries a hand-written
+`_SLEEVE_TRIAL_IDS` map from sleeve label to register trial id, guarded by three
+P8 checks against staleness and collision. This job needs none of that: measured
+by `--runnable`, **every one of the 4 manifest ids is a declared trial id**, so
+`strategy_id` *is* the trial id. The equality is asserted by the arm, so a fifth
+strategy landing without a register entry fails there rather than silently
+under-counting `M` — which raises the DSR, in the favourable direction.
+
+## 3. S-4 cannot be backtested, and the CODE refuses it — not the docstring
+
+`--runnable`, over `STRATEGY_MANIFEST` rather than a hand-written list:
+
+```
+s1-time-series-momentum              per_series       RUNNABLE
+s2-cross-sectional-momentum          cross_sectional  RUNNABLE
+s3-mean-reversion-in-trend           per_series       RUNNABLE
+s4-volatility-compression-breakout   per_series       BLOCKED
+  build_positions refuses: signal 1 is a level-based entry with no outcome at
+  the pinned version pair — resolve it before building positions rather than
+  falling through to the max-hold close
+runnable 3 of 4
+```
+
+The refusal is **demonstrated by calling `build_positions`**, not quoted from its
+docstring, because the entire exclusion of S-4 rests on it and a docstring cannot
+be wrong in CI. The chain is: S-4 is the only entry with `level_based=True` →
+`build_positions` raises on a level-based entry with no outcome at the pin →
+outcomes come only from `outcome_resolver.resolve_outcome` → that needs an
+`ExitLevels` → **`grep -rn 'ExitLevels(' app scripts tests` returns one verify
+script and two test modules and nothing in `app/`**.
+
+Same blocker the §3.1 spec §7 records for the outcome-resolution job. Neither job
+is waiting on the other; both are waiting on an S-4 exit-level provider.
+
+⚠ **S-4 is excluded, not skipped silently.** The job emits it as a refusal with
+this reason, per criterion 9's *"exclusion is visible rather than assumed
+harmless"*. A three-of-four run that reports "3 strategies evaluated" is the
+manifest defect (#2394 §2) reappearing one layer up, which is exactly what the
+manifest exists to stop.
+
+## 4. ⚠⚠ Both namespaces come out of ONE pass — so criterion 5 has to be enforced by the JOB
+
+`namespace_for_position` is a **filter over positions the corpus sweep has
+already produced** — a property of the function, not of any strategy. Measured by
+`--arm` on S-1 masked, one pass (the *split* is S-1's; the *freeness* is
+structural):
+
+```
+in_sample   2,456,097   78.34%
+hold_out      679,258   21.66%
+```
+
+Both numbers came out of the same corpus sweep (§8's timings are for that one
+pass). The hold-out arm is therefore **free**, and that is the problem.
+
+Criterion 5's whole mechanism is that looking at the withheld side is rare,
+deliberate and logged; `store_holdout_result` makes `accessed_by` and `purpose`
+keyword-only with no defaults for exactly that reason, and `sql/264`'s trigger
+refuses a hold-out row with no `evaluate` record. But a job that computes both
+partitions anyway and writes both turns the access log into **a count of cron
+fires**, and `check_promotable`'s criterion-5 clause — every evaluation must have
+a recorded access — then passes on rows nobody deliberately looked at.
+
+**Rule.** The job computes and writes the **in-sample** arm by default. The
+hold-out arm is written only when the invocation carries both of:
+
+- `holdout_purpose` — a free-text, non-empty, no-default param. It is stored as
+  `strategy_holdout_accesses.purpose` and is the audit's only content.
+- `holdout_accessed_by` — likewise required and non-defaulted.
+
+⚠ **`accessed_by` cannot be derived from the request, and I checked.**
+`pending_job_requests` has a `requested_by` column and `app/api/jobs.py` fills
+it (`_identify_requestor`), but the listener dispatches
+`invoker(params=validated_params)` and nothing else — the `JobInvoker` contract
+is `Callable[[Mapping[str, Any]], None]`, so the requester never reaches the job
+body. Plumbing it is a separate change to the job runtime; until then the param
+is the mechanism, and the `requested_by` column on the request row is the
+corroborating record beside it.
+
+⚠ **The hold-out partition must not be COMPUTED on an in-sample invocation
+either**, not merely left unwritten. It costs nothing to compute, so the only
+thing separating "we have the number" from "we looked" is the job's own
+restraint; a run that computes the hold-out metrics and logs them at INFO has
+performed an unrecorded evaluation whatever the table says. The positions are
+partitioned, the hold-out side is **counted and discarded**, and the count is the
+only hold-out figure an in-sample run emits.
+
+## 5. The per-namespace equity axis — a construction nothing has had to choose yet
+
+`grep -rn namespace_for_position app scripts tests` returns
+`verify_2240_holdout_namespace.py`, which **counts** the partition and builds no
+curve from it, and `tests/test_strategy_result.py`. **No namespace-scoped equity
+curve has ever been built in this repo.** `verify_2240_statistics.py --curve`
+runs one curve over the whole 16,236-date axis, both namespaces mixed.
+
+That is a real gap, because `compute_metrics` takes the axis and
+`periods_per_year` is measured from it: run a hold-out arm on the full axis and
+its CAGR is diluted by 59 years in which it holds nothing.
+
+The obvious answer — each namespace's axis is its own date range — does not
+survive §5.2. A position that spans the boundary **belongs to the hold-out and
+keeps its true entry fill**, so its leg starts before 2021-06-29 and cannot be
+placed on an axis beginning there. Measured on S-1 masked:
+
+```
+of the hold-out rows, 2,661 entered BEFORE the boundary (spanning) — 0.39%
+earliest hold-out entry   2018-10-03
+hold-out axis lead        1,000 calendar days before the boundary
+latest in-sample close    2021-06-28   (boundary is 2021-06-29)
+```
+
+2,661 spanning positions out of 679,258 hold-out rows, and the earliest reaches
+back **1,000 calendar days** — under three years, not decades. That number is
+what makes the construction below usable rather than degenerate: had it come back
+1974, a hold-out arm containing a 50-year leg would have been a different
+problem. The in-sample side lands on 2021-06-28, the last trading day before the
+boundary, which is `namespace_for_position` behaving.
+
+**Rule, fixed by construction and stated because no published formulation covers
+it.** A namespace's equity axis is the evaluation axis truncated to the closed
+span of that namespace's own positions: from the earliest `entry_fill_bar_date`
+among them to the latest close-or-mark. ⚠ **Both ends are measured, neither is
+named** — the in-sample start is that namespace's earliest entry fill and NOT the
+corpus start, because a strategy's warm-up means its first position lands well
+after the first bar and an axis padded back to 1962 would dilute exactly the
+CAGR this rule exists to protect. For hold-out the span reaches back to the
+earliest spanning entry. Both bounds are **measured per run and reported**, never
+declared, and the job asserts the in-sample bound is strictly before
+`HOLDOUT_BOUNDARY` — a violation means `namespace_for_position` mis-classified,
+not that the axis needs widening.
+
+⚠ **`window_start` / `window_end` on the row stay the full evaluation window**,
+and the two are not the same thing. `sql/262` is explicit that no CHECK ties the
+namespace to the window because *"the window is the EVALUATION window and the
+namespace selects within it"*. The axis is how the arm's metrics are computed;
+the window is what the arm was cut from. Storing the truncated span in
+`window_start` would make two rows over one corpus look like two corpora.
+
+## 6. The arms, and the row count
+
+`--arms`, every factor a `len()` of the thing that defines it:
+
+```
+runnable strategies      3   s1-…, s2-…, s3-…
+namespaces               2   hold_out, in_sample
+ambiguity arms           2   best_case, worst_case
+quarantine arms          2   admitted, masked
+result scopes            2   portfolio, sleeve
+product                 48   result rows per full invocation
+sleeve scope only       24
+```
+
+**`portfolio` scope is out.** It is a statement about a cross-strategy allocator
+and nothing in `app/` allocates across strategies. 24 sleeve rows.
+
+⚠ **24 rows is NOT 24 corpus passes**, and the difference is the whole cost
+argument:
+
+- the **two namespaces** are one pass (§4);
+- the **two ambiguity arms** are one pass for all three runnable strategies, and
+  the argument is STRUCTURAL rather than a generalisation from the one strategy
+  `--arm` runs. `position_builder` assigns `close_source == "ambiguous"` only
+  inside its `if regime.level_based:` branch; `--runnable` checks over the whole
+  manifest that **no runnable strategy is level_based**, and fails if one ever
+  is. So an `ambiguous` close is unreachable for every strategy in the runnable
+  set, including the two `--arm` did not execute. `--arm`'s close-source census
+  on S-1 masked corroborates it on real data — **`signal_pair` 3,133,100,
+  `open_at_window_end` 2,255, `ambiguous` 0** — and fails if that zero moves;
+- the **two quarantine arms** are genuinely two passes: `masked` and `admitted`
+  are different bar sets.
+
+So: **3 strategies × 2 quarantine arms = 6 corpus passes → 24 stored rows.**
+
+⚠ The second ambiguity row is written as the same numbers under the other label,
+and the job **asserts** the two are equal rather than recomputing them. §3.4
+requires both reported; recomputing an identical pass to produce an identical row
+is cost with no evidence in it.
+
+## 7. The identity — fourteen members, and who supplies each
+
+`ResultIdentity` hashes fourteen fields into `result_version`, and `sql/262`
+stores every one as its own column *"because a hash tells you two rows differ and
+never which field moved"*. §4 question 6 of the runner spec asked which the job
+must pin. All of them; here is where each comes from.
+
+| field | source | job's choice? |
+| --- | --- | --- |
+| `strategy_id` | `STRATEGY_MANIFEST` key | no — iterated |
+| `strategy_version` | `entry.identity(universe=…, cost_model_id=…).version` | no |
+| `result_scope` | `'sleeve'` | fixed, §6 |
+| `namespace` | the partition | **param-gated** for hold-out, §4 |
+| `ambiguity_arm` | both, §6 | no |
+| `quarantine_arm` | both, §6 | no |
+| `sizing_rule` | `equity_curve.SIZING_RULE_ID` | no |
+| `cost_model_id` | `cost_model.COST_MODEL_ID` | no |
+| `corpus_version` | `strategy_result.CORPUS_VERSION` | no |
+| `window_start` / `window_end` | `EVALUATION_WINDOW_START` / `_END` | no |
+| `position_rule_set_version` | `position_builder.RULE_SET_VERSION` | no |
+| `outcome_rule_set_version` | `outcome_resolver`'s rule-set version | no |
+| `input_rule_set_version` | `price_quarantine.RULE_SET_VERSION` — see below | no |
+
+⚠ **Thirteen of the fourteen are read from a module that froze them, and that is
+the design working.** The only operator-facing degree of freedom is whether the
+hold-out arm runs. A job that let an operator pass a sizing rule or a window
+would be minting result identities that no code path can reproduce.
+
+⚠⚠ **`input_rule_set_version` is the QUARANTINE rule set, and it is NOT the same
+thing as `StrategyIdentity.input_rule_set_versions`.** Two similarly-named
+concepts that a spec saying "the indicator + quarantine rule sets" would have
+merged. `strategy_registry.INPUT_RULE_SETS` is
+`{"indicator_series": INDICATOR_SERIES_RULE_SET_VERSION}` — indicator only — and
+it is already inside `strategy_version` (#2333), so folding it in here would
+hash it twice. The result column is a single string and `sql/262` says what it
+is for: *"`input_rule_set_version` is `sql/256`'s third key member and is here
+for its reason: re-run the quarantine under a changed rule set and the same
+signal resolves differently with the resolver byte-identical."* `sql/256`'s own
+comment names `load_masked_series` and `price_quarantine`'s rule set explicitly.
+So it is `price_quarantine.RULE_SET_VERSION`, and indicator drift reaches the row
+through `strategy_version`.
+
+⚠ **`outcome_rule_set_version` has to be stamped even though no runnable strategy
+produces an outcome.** It is a member of the hash and `sql/262` declares it
+`NOT NULL` with a non-empty CHECK, so the job reads the resolver's live version
+rather than writing a placeholder. A blank would pass `NOT NULL` and silently
+merge two results — the #2286 shape the constraint was written against.
+
+## 8. Cost
+
+`--arm`, one arm (S-1, masked, full corpus, whole window), full population, run
+**three times** on the same box and the same code:
+
+| phase | run 1 | run 2 | run 3 |
+| --- | ---: | ---: | ---: |
+| corpus pass | 256.8s | 415.9s | 356.6s |
+| — masked bar loading | 84.7s (33.0%) | 142.9s (34.4%) | 136.8s (38.4%) |
+| — signals → positions | 148.1s (57.7%) | 229.9s (55.3%) | 184.2s (51.7%) |
+| — curve accumulation | 3.8s (1.5%) | 4.5s (1.1%) | 4.1s (1.1%) |
+| curve + metrics | 33.4s | 97.9s | 87.8s |
+| **TOTAL** | **290.3s** | **513.7s** | **444.4s** |
+
+3,135,355 positions over 5,266 series, 0 empties — **identical in all three**.
+
+⚠ **The wall clock is not reproducible to better than ~1.8× on this box, and the
+spread is reported rather than averaged away.** All three runs did the same work
+on the same data and produced the same positions; the box was carrying other
+sessions' load. Plan on the slowest figure. What IS stable is the phase *shape* —
+roughly a third of the time is loading bars, about half is signals→positions, and
+the curve accumulation is ~1% — which is the part an optimisation decision would
+rest on, and it is the reason the spread does not undermine the section.
+
+**Six passes is 29–51 minutes.** ⚠ That multiplication is an estimate and is
+labelled one: only S-1 was measured. S-3 is per-series and comparable; S-2 is
+`cross_sectional` and its cost is **not** S-1's, because `s2_select` needs the
+panel's scored cross-section resident on each rebalance date rather than one
+series at a time. The implementation measures S-2 separately and this section
+gets its number.
+
+⚠ **"It is expensive" was never the reason for a manual trigger, and pretending
+it was would have got the design wrong.** Half an hour is a scheduled job's
+workload, not a human's. The reasons the trigger is manual are §4 (criterion 5
+requires a purpose a cron fire cannot supply) and §2 of the runner spec (a stored
+row is meaningless if its identity moved between runs). Both are governance, and
+neither is affected by making it faster.
+
+⚠ **The block bootstrap is a third of the non-corpus time and scales with
+trades**, not with series: 2,000 resamples over 15,731 date clusters. It is
+inside `compute_metrics` and is not optional — `effective_sample_size` is
+criterion 3's number and criterion 6 consumes it.
+
+## 9. What the job can and cannot close on the gate
+
+`--arm` builds the row this job would store and runs `check_promotable` on it.
+Measured, not predicted — **8 refusals**:
+
+| refusal | can this job close it? |
+| --- | --- |
+| `universe_basis_not_survivorship_free` | **no** — the corpus is survivor-only (#2284) |
+| `carry_unmodelled` | **no** — `cost_model.CARRY_BPS` is `None` (#2277) |
+| `holdout_never_evaluated` | yes, on a deliberate hold-out invocation (§4) |
+| `deflated_sharpe_not_computed` | yes, once the run covers ≥ 2 strategies (§2) |
+| `trial_count_undeclared` | yes — `TRIAL_REGISTER.declared_count`, M = 11 |
+| `ambiguity_arms_not_compared` | yes — the stored pair supplies `ambiguity_material` |
+| `quarantine_arms_not_compared` | yes — both arms stored via the pair writer |
+| `synthetic_control_not_run` | **not in this cut** — see below |
+
+⚠ **The refusal list above is measured on ONE row** — S-1, in-sample, masked,
+with no DSR, no trial count and no arm comparison supplied, which is the *bare*
+row. It is the worst case and every entry in the table's right-hand column is a
+claim about what a fuller run closes, not something `--arm` demonstrated. The
+acceptance criteria (§14) require the implementation to re-measure the list on
+**every** written row.
+
+⚠⚠ **`effective_sample_size` is not free, and it nearly read as if it were.**
+`compute_metrics` computes criterion 3's block bootstrap **only when
+`bootstrap_seed` is passed** — it defaults to `None`, and the module says so:
+*"⚠⚠ `bootstrap_seed` IS REQUIRED FOR CRITERION 3 AND DEFAULTS TO OFF."* The
+reason `effective_sample_size_not_computed` is absent from the measured list is
+that `--arm` goes through `_Sleeve.report`, which passes
+`verify_2240_statistics.BOOTSTRAP_SEED = 20260807` — **a verify-script literal.
+Nothing in `app/` owns a block-bootstrap seed.** The job must declare and freeze
+one of its own, in `app/`, beside the constant it is an input to; inheriting a
+script's literal would make every stored effective sample size a function of a
+file no production path imports.
+
+⚠⚠ **The job cannot make anything promotable, and that is correct rather than a
+shortfall.** **Three** refusals survive every run this cut can produce:
+`universe_basis_not_survivorship_free` and `carry_unmodelled`, both blocked on
+work outside this epic (#2284's corpus purchase, #2277's carry measurement), and
+`synthetic_control_not_run`, blocked on the stage below. §6 of the
+bounded-backtester spec states the intended initial state in those words — *"the
+gate's initial state is 'nothing is promotable'. That is correct, not a bug to
+work around."* What this job changes is that the refusals become **specific and
+few** instead of eight-of-eight.
+
+**`synthetic_control` is out of this cut**, with a reason rather than an
+omission. §9's control is *"for ONE strategy"* — the cohort's entries are placed
+against that strategy's own holding distribution — so it is 1,000 full-corpus
+member evaluations **per strategy**, not a corpus-level constant that could be
+computed once and reused. At §8's measured pass cost that is days, and the only
+existing cohort lives in a developer cache (`~/.cache/ebull/2240_cohort`, S-1
+only) that no job may depend on. It needs its own stage and a persisted cohort;
+until then the column is NULL and the refusal is visible.
+
+## 10. Trigger, params, idempotency, transaction boundary
+
+**Trigger.** `POST /jobs/strategy_backtest_run/run`, the existing durable-queue
+path. Not in `SCHEDULED_JOBS`. Params-aware — a native `JobInvoker`, not
+`_adapt_zero_arg` — with `ParamMetadata` declared so
+`validate_job_params(allow_internal_keys=False)` rejects an unknown or malformed
+key before the request is queued. Precedent: `sec_13f_quarterly_sweep` and
+`sec_n_port_ingest`.
+
+Four registry edits, none of them optional and all of them easy to leave out:
+the name constant and invoker in `app/jobs/runtime.py` (`_INVOKERS`, hence
+`VALID_JOB_NAMES`, which is what the API's 404 check reads); a new member of
+`app/jobs/sources.py::Lane`; an entry in `MANUAL_TRIGGER_JOB_SOURCES` mapping the
+job to that lane; and the params in `MANUAL_TRIGGER_JOB_METADATA`.
+
+Params: `strategy_id` (optional, narrows the set — see §2's DSR consequence),
+`holdout_purpose` and `holdout_accessed_by`, `trial_register_version` (optional
+assertion — refuse if it is not the live register's, so a run cannot silently
+deflate against a register that has moved).
+
+⚠ **"Required together" is not expressible in `ParamMetadata`** — it declares
+per-key type and requiredness and has no conditional model. So the pairing is
+checked in the **job body**, first thing, before any corpus work: exactly one of
+"neither supplied" (in-sample run) and "both supplied, both non-empty" (hold-out
+run) is legal, and one-of-two is a refusal. Leaving it to the metadata layer
+would let a hold-out run start with a blank `purpose`, which is the #2286 shape —
+a present-but-empty field passing a presence check.
+
+**Idempotency, and it must be checked FIRST.** `strategy_results_unique
+(strategy_id, strategy_version, result_version)` — a re-run of an unchanged
+configuration **raises**, per §2 of the runner spec. No `ON CONFLICT`, and none
+is to be added: `DO NOTHING` would hide corpus drift, and a compare-every-field
+no-op is not worth building before a collision is observed.
+
+⚠ **The identity is fully determined before the corpus is touched** (§7: thirteen
+of fourteen fields are module constants, and the fourteenth is the namespace).
+So the job computes every `result_version` it intends to write and **refuses up
+front** if any already exists. Discovering the collision at INSERT time would
+throw away the full half-hour pass, and the operator's remedy — delete the row
+deliberately — is the same either way.
+
+**Transaction boundary, and it is NOT per strategy.** §2 puts the DSR across the
+whole strategy set, and `StrategyResult.__post_init__` binds `deflated` to
+`trial_count` and `deflated_sharpe` while `sql/266` has an all-or-nothing CHECK —
+so a row cannot be written first and deflated later. `result_ledger` has no
+updater at all; every writer is an INSERT. Therefore:
+
+1. evaluate every strategy × quarantine arm, holding metrics in memory;
+2. compute the DSR once, across the measured trials;
+3. write, one `conn.transaction()` per arm pair, via the pair writers.
+
+⚠ **This inverts "one strategy's failure does not stop the others", which the
+first draft copied from §3.1 without checking whether it still held.** It does
+not: the DSR's `V[SR_n]` is a function of *which* trials were measured, so a run
+that loses S-2 in step 1 and proceeds would deflate S-1 and S-3 against a
+two-trial variance while the run reports itself complete — a **more confident**
+number obtained by losing evidence. A strategy failing in step 1 aborts the
+invocation. Nothing has been written at that point, which is the reason the
+phases are ordered this way rather than the phases being ordered to suit the
+failure rule.
+
+**Concurrency.** Reuse `app/jobs/locks.py`'s `JobLock` with a backtest-specific
+lane. ⚠ **It is session-scoped `pg_try_advisory_lock(hashtext('job_source:{lane}')::int)`
+taken on the lock manager's own connection, and the point of naming that here is
+that it must stay so.** The prevention-log entry warns about
+`pg_advisory_xact_lock` acquired inside a savepoint being held until the
+top-level transaction commits; with the multi-arm write phase above, substituting
+one would hold the lane until the last arm pair committed. Do not invent a second
+locking vocabulary and do not switch to an xact lock.
+
+⚠ **It must not share `strategy_signal_scan`'s lane.** The two jobs write
+different tables from different corpora — the scan reads live `price_daily`, this
+reads the frozen research corpus — and blocking the daily scan behind a
+half-hour backtest is the exact coupling §3 of the runner spec split them to
+avoid.
+
+## 11. Observability
+
+Per run, per `(strategy_id, namespace, ambiguity_arm, quarantine_arm)`:
+
+- the row count written and the `result_version` of each;
+- `evaluated_instrument_count` **per namespace** (§0: they differ by 23.6%);
+- the position partition and the close-source census (§4, §6) — the latter is
+  what keeps the ambiguity claim honest run to run;
+- the per-namespace axis bounds (§5), measured, so a widening is visible;
+- the refusal list from `check_promotable` for each row, so the operator reads
+  *why* nothing is promotable without querying;
+- **every excluded strategy with its reason** — S-4's level-based refusal today.
+
+⚠⚠ **Computing the refusal list must not itself touch the hold-out access log.**
+`PromotionCandidate.quarantine_arms_compared` has a database-reading helper —
+`result_ledger.quarantine_arms_compared()` — and on a `hold_out` identity it
+**records a `read` access**, deliberately, because *"looking is the event
+criterion 5 governs"*. A job that gated every hold-out row it had just written
+would add one read record per row and turn the audit trail into a count of its
+own automation. The job supplies the boolean **directly**: it wrote both arms in
+the same transaction, so it knows, and it must not ask the database a question it
+is the answer to. Same for `ambiguity_material`, which it computes from the pair
+it holds.
+
+⚠ A strategy that produced **no row** must be visible, and no index can say so;
+the count is emitted against the runnable set the job computed, and a shortfall
+**fails the run**. ⚠ **"Shortfall" means against the RUNNABLE set, not against
+the manifest** — S-4 is expected to be absent and its exclusion is a reported
+reason, not a failure. The two are distinguished by the runnable computation
+itself: a strategy that was runnable at plan time and produced no row is the
+failure; one that was never runnable is a line in the exclusion list. Same
+construction §3.1 landed after the review bot found its population gate anchored
+on the wrong side.
+
+## 12. What this job does not do
+
+- **It touches no broker path**, and no live-data path either. It reads the
+  frozen research corpus at `CORPUS_VERSION` through
+  `research_price_structure_store.load_masked_series`;
+  `strategy_signal_scan` reads live `price_daily` through
+  `price_masked_bars`. The two are deliberately different sources and their rows
+  are not comparable. ⚠ **The research loader is the only bar source this job may
+  use, and S-2 is where that could slip** — assembling a panel is the one place a
+  `price_daily` read would look like a convenience rather than a corpus change.
+- **It does not resolve outcomes.** Blocked on the same S-4 exit-level provider,
+  and it must carry the §3.1 spec §7 immature-window rule when it lands.
+- **It does not run the walk-forward split.** `store_walk_forward_folds` exists
+  and `WalkForwardFolds` refuses a partial set; wiring it is a follow-on once a
+  result row exists to attach folds to.
+- **It does not compute the synthetic control** (§9).
+- **It writes nothing to `strategy_signals`.** The result layer reads the corpus
+  directly and does not go through the live ledger.
+
+## 13. Residual risk
+
+⚠ **A re-freeze invalidates every stored row and nothing enforces the reread.**
+`CORPUS_VERSION` is a literal; bumping it is §5.2's deliberate re-freeze. Rows
+written under the old version stay, correctly, but nothing refuses to *compare*
+them with new ones — that is a phase-6 read-side concern (question 7 of the
+runner spec, "version mixing on read") and this job cannot close it. It can only
+make the version visible on every row, which `sql/262` already does.
+
+⚠ **`trial_count` is M for the whole register, not for the strategies this run
+measured**, and that is criterion 6's intent — *"including abandoned branches,
+manual eyeballing and discarded parameter values"*. A reader seeing `M = 11` on a
+row from a 3-strategy run may misread it as an error. It is not, and the run
+report says so explicitly beside the number.
+
+⚠ **`--runnable` checks manifest ⊆ register, not the converse, and the asymmetry
+is deliberate.** The register declares 11 trials of which 4 are manifest
+strategies; the other 7 are RSI variants and spike arms that were searched and
+abandoned. Those are exactly what `M` is supposed to count and exactly what
+cannot be measured — they have no shipped strategy to run. So a register entry
+with no manifest entry is the normal case; a manifest entry with no register
+entry is the defect, and that is the direction checked. What this does NOT catch
+is a register that has gone stale in the other sense — an entry whose evidence
+link is dead. Nothing in this job can check that, and it is the register's own
+maintenance problem.
+
+## 14. Acceptance
+
+1. A full invocation writes 24 sleeve rows — 3 runnable strategies × 2
+   namespaces × 2 ambiguity arms × 2 quarantine arms. A **runnable** strategy
+   that produced no row fails the run; a never-runnable one is a named line in
+   the exclusion list (§11).
+2. S-4 is refused with the `build_positions` message in §3, not skipped.
+3. A hold-out row is written **only** when `holdout_purpose` and
+   `holdout_accessed_by` are both supplied and non-empty, and
+   `strategy_holdout_accesses` gains **exactly one** `evaluate` record per
+   hold-out row written and **no `read` records at all** (§11).
+4. An in-sample invocation emits the hold-out **count** and no hold-out metric.
+5. A colliding `result_version` is refused **before** the corpus pass, not at
+   INSERT; and an INSERT collision still raises on `strategy_results_unique`
+   rather than being absorbed by an `ON CONFLICT` that does not exist.
+6. A strategy failing during evaluation aborts the invocation with **zero rows
+   written**, and the DSR is never computed over a set smaller than the one the
+   run planned.
+7. Every row carries a non-null `effective_sample_size`, from a
+   block-bootstrap seed frozen **in `app/`** — not inherited from
+   `verify_2240_statistics.BOOTSTRAP_SEED`.
+8. `check_promotable` is re-measured on **every** written row and returns exactly
+   the refusals §9's table says the job cannot close, and no others. §9's
+   measured 8-refusal list is the bare-row worst case, not this criterion.
+9. The two ambiguity arms of a runnable strategy are asserted equal, and the
+   close-source census shows `ambiguous = 0` for each strategy actually run.
+10. Every figure in §§0, 3, 4, 5, 6, 9 and the per-arm timings in §8 is printed
+    by `scripts/verify_2394_backtest_run.py --all`, exit 0. ⚠ **Three things in
+    this document are NOT script output and are labelled where they appear:**
+    §8's three-run comparison (three invocations), §8's six-pass estimate
+    (arithmetic over an S-1 measurement, with S-2 explicitly excluded from the
+    extrapolation), and §9's synthetic-control cost. Each is an estimate and
+    none is quoted as a measurement.

--- a/scripts/verify_2394_backtest_run.py
+++ b/scripts/verify_2394_backtest_run.py
@@ -47,8 +47,12 @@ thing that defines it.
       run or a filter;
   A3  the close-source census, which is what makes the ambiguity-arm claim
       measurable rather than structural prose;
-  A4  ``check_promotable`` on the row this job would store, so the refusal list
-      the operator would see is measured and not predicted.
+  A4  ``check_promotable`` on a WHOLE-WINDOW probe row, so the refusal list the
+      operator would see is measured and not predicted. ⚠ The probe is not a
+      namespace arm — this script builds no namespace-scoped curve (spec §5) —
+      and A4 DEMONSTRATES that the substitution is sound by blanking
+      ``effective_sample_size`` and showing the gate reads exactly one metric,
+      for presence only.
 """
 
 from __future__ import annotations
@@ -57,6 +61,7 @@ import argparse
 import sys
 import time
 from collections import Counter
+from dataclasses import replace
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
@@ -177,8 +182,8 @@ def population() -> int:
     print(f"  validated universe        {len(universe):>12,} instruments", flush=True)
     print(f"  of which the corpus holds {int(instruments):>12,}", flush=True)
     print(f"  bars in window            {total:>12,}   {first_bar} … {last_bar}", flush=True)
-    print(f"    in-sample               {int(in_sample):>12,}   {100.0 * in_sample / total:.2f}%", flush=True)
-    print(f"    hold-out                {int(hold_out):>12,}   {100.0 * hold_out / total:.2f}%", flush=True)
+    print(f"    in-sample               {int(in_sample):>12,}   {100.0 * in_sample / max(total, 1):.2f}%", flush=True)
+    print(f"    hold-out                {int(hold_out):>12,}   {100.0 * hold_out / max(total, 1):.2f}%", flush=True)
     series_total = int(in_only) + int(out_only) + int(both)
     print(f"  series with in-sample bars only  {int(in_only):>7,}", flush=True)
     print(f"  series with hold-out bars only   {int(out_only):>7,}", flush=True)
@@ -196,7 +201,7 @@ def population() -> int:
     # re-fitted. §5.2: "a recomputed boundary walks forward silently and
     # re-admits hold-out data into training". A drift here is a corpus-version
     # event, so this arm FAILS rather than updating anything.
-    share = 100.0 * in_sample / total
+    share = 100.0 * in_sample / max(total, 1)
     if not 74.0 <= share <= 76.0:
         problems.append(
             f"the frozen boundary now splits the slice {share:.2f}/{100.0 - share:.2f} rather than 75/25 — "
@@ -671,18 +676,19 @@ def arm(*, limit: int | None, strategy_id: str) -> int:
             metrics=metrics,
             universe_basis=UNIVERSE,
             carry_unmodelled=CARRY_UNMODELLED,
-            # ⚠ THE IN-SAMPLE COUNT, not the corpus's. `len(pairs) - empty`
-            # counts every series the pass loaded, including the ones whose
-            # positions are all hold-out — and this row says `in_sample`.
-            evaluated_instrument_count=len(in_sample_instruments),
+            # ⚠⚠ THE WHOLE-CORPUS COUNT, matching the WHOLE-WINDOW curve the
+            # metrics above came off — not the in-sample subset, which would
+            # describe a population these metrics were not computed over. This
+            # probe row is NOT a namespace arm; see the note below the census.
+            evaluated_instrument_count=len(pairs) - empty,
         )
         candidate = PromotionCandidate(
             result=result,
-            evaluated_instrument_ids=frozenset(in_sample_instruments),
+            evaluated_instrument_ids=frozenset(int(row[0]) for row in pairs),
             validated_universe_ids=frozenset(universe),
         )
         refusals = check_promotable(candidate)
-        print("\n  [A4] check_promotable on the row this job would store", flush=True)
+        print("\n  [A4] check_promotable on a WHOLE-WINDOW probe row", flush=True)
         for refusal in refusals:
             print(f"      {refusal}", flush=True)
         print(f"      {len(refusals)} refusals", flush=True)
@@ -690,6 +696,48 @@ def arm(*, limit: int | None, strategy_id: str) -> int:
             problems.append(
                 "the bare row is PROMOTABLE — §3.2's whole argument is that it cannot be, so either the gate or "
                 "this script is wrong"
+            )
+
+        # ⚠⚠ WHY A WHOLE-WINDOW ROW IS A VALID PROBE OF A LIST THE JOB WILL
+        # PRODUCE PER NAMESPACE, and it is DEMONSTRATED rather than asserted.
+        # This arm deliberately builds no namespace-scoped curve (spec §5: none
+        # has ever been built, and choosing its axis is the implementation's
+        # first decision), so the metric set above spans both namespaces while
+        # the identity has to name one. That inconsistency would matter if the
+        # gate read any metric VALUE. It reads exactly one metric, and only for
+        # PRESENCE — so the refusal list cannot move with the metrics, only with
+        # their absence. Blanking `effective_sample_size` must add that one code
+        # and change nothing else; anything more means the gate consumes a
+        # number this probe got from the wrong population.
+        # ⚠ ALL NINE, not just `effective_sample_size`. `StrategyMetrics`
+        # enforces criterion 3's block-bootstrap fields as one set — *"present
+        # or absent as a whole"* — so blanking the single field the gate reads
+        # raises at construction. Found by running this; the group is the unit.
+        no_bootstrap = replace(
+            metrics,
+            effective_sample_size=None,
+            expectancy_ci_low_pct=None,
+            expectancy_ci_high_pct=None,
+            bootstrap_block_length=None,
+            bootstrap_cluster_count=None,
+            bootstrap_resamples=None,
+            bootstrap_seed=None,
+            bootstrap_design_effect=None,
+            bootstrap_model_id=None,
+        )
+        blanked = check_promotable(replace(candidate, result=replace(result, metrics=no_bootstrap)))
+        added = set(blanked) - set(refusals)
+        removed = set(refusals) - set(blanked)
+        print(
+            f"      metric-blanked probe adds {sorted(added)} and removes {sorted(removed)} — "
+            "the gate reads one metric, for presence",
+            flush=True,
+        )
+        if added != {"effective_sample_size_not_computed"} or removed:
+            problems.append(
+                f"blanking effective_sample_size moved the refusal list by {sorted(added)}/{sorted(removed)} rather "
+                "than by exactly that one code — the gate reads a metric VALUE, so a whole-window probe cannot "
+                "stand in for a namespace-scoped row and A4 has to build a real one"
             )
 
     for problem in sleeve.problems:

--- a/scripts/verify_2394_backtest_run.py
+++ b/scripts/verify_2394_backtest_run.py
@@ -1,0 +1,739 @@
+"""Full-population measurement behind #2394 §3.2 — ``strategy_backtest_run`` (#2240).
+
+    PYTHONPATH=. uv run python scripts/verify_2394_backtest_run.py --all
+
+⚠ NOTHING IS WRITTEN. Every arm reads and prints. Gate on the EXIT CODE — 0
+means every arm passed, 1 means at least one did not.
+
+⚠ NEVER PIPE THIS INTO ``head``/``tail``. A pipe returns the pipe's status, so a
+failure reads as success, and it buffers the progress lines a long run is judged
+by (`.claude/CLAUDE.md`). Redirect to a file and read the file.
+
+WHY THIS EXISTS
+---------------
+§3.2 of ``docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md`` is three
+sentences: *"Runs the harness for a strategy × namespace × arm and persists via
+result_ledger. Manual-trigger only: it is expensive, and its
+StrategyIdentity.version must be stable."* Its own §4 question 6 then says the
+identity is wider than that. Every number the §3.2 spec quotes is produced here,
+so none of them is arithmetic done in prose.
+
+THE ARMS
+--------
+``--population`` — the corpus ∩ validated-universe slice this job would evaluate,
+and the frozen §5.2 split re-derived at BAR level against the literals in
+``strategy_result``. ⚠ Re-derived and COMPARED, never re-fitted:
+``verify_2240_result_model.py --frozen`` owns the same assertion and this arm
+must agree with it.
+
+``--runnable`` — which manifest strategies can produce a stored result TODAY.
+Derived from ``STRATEGY_MANIFEST`` rather than from a hand-written list, and the
+level-based refusal is demonstrated by CALLING ``build_positions``, not asserted
+from the docstring.
+
+``--arms`` — the arm-count arithmetic: how many ``strategy_results`` rows one
+"backtest everything" invocation would write, from the manifest and the closed
+vocabularies. ⚠ Nothing here is a literal count; each factor is ``len()`` of the
+thing that defines it.
+
+``--arm`` — the expensive one. Runs ONE arm end-to-end over the whole corpus
+(S-1, masked, whole window) through the real path — ``STRATEGY_MANIFEST`` →
+``signal_ledger.resolve_fills`` → ``build_positions`` → ``cost_positions`` →
+``build_equity_curve`` → ``compute_metrics`` — and reports:
+
+  A1  the wall-clock cost, split by phase, so "expensive" is a number;
+  A2  the §5.2 namespace partition of the positions the SINGLE pass produced —
+      which is the finding that decides whether the hold-out arm is a second
+      run or a filter;
+  A3  the close-source census, which is what makes the ambiguity-arm claim
+      measurable rather than structural prose;
+  A4  ``check_promotable`` on the row this job would store, so the refusal list
+      the operator would see is measured and not predicted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from collections import Counter
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Final
+
+import psycopg
+
+from app.config import settings
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID
+from app.services.deflated_sharpe import MIN_MEASURED_TRIALS
+from app.services.equity_curve import SIZING_RULE_ID, LegBook
+from app.services.indicator_series import BarSeries
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.position_builder import (
+    RULE_SET_VERSION as BUILDER_RULE_SET_VERSION,
+)
+from app.services.position_builder import (
+    EntryFill,
+    ExitRegime,
+    OutcomePin,
+    Window,
+    build_positions,
+)
+from app.services.position_costing import CostedPosition, cost_positions
+from app.services.research_price_structure_store import (
+    QUARANTINE_ARMS,
+    QUARANTINE_RULE_SET_VERSION,
+    load_masked_series,
+)
+from app.services.signal_ledger import resolve_fills
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry
+from app.services.strategy_result import (
+    AMBIGUITY_ARMS,
+    CORPUS_VERSION,
+    EVALUATION_WINDOW_END,
+    EVALUATION_WINDOW_START,
+    HOLDOUT_BOUNDARY,
+    RESULT_NAMESPACES,
+    RESULT_SCOPES,
+    PromotionCandidate,
+    ResultIdentity,
+    StrategyResult,
+    check_promotable,
+    namespace_for_position,
+)
+from app.services.strategy_statistics import METRIC_SET_ID
+from app.services.trial_register import TRIAL_REGISTER
+from scripts.verify_2240_position_builder import UNIVERSE, _fills, _to_series
+from scripts.verify_2240_statistics import (
+    _AXIS_SQL,
+    _benchmark_leg,
+    _Sleeve,
+)
+
+#: ``--arm``'s default. ⚠ A DEFAULT, not a hardwiring — ``--strategy`` selects
+#: any per-series manifest entry. S-1 is the default because it is the trial the
+#: rest of phase 5 was measured on, so its figures are comparable with the
+#: existing run reports.
+DEFAULT_ARM_STRATEGY: Final = "s1-time-series-momentum"
+
+_BAR_SPLIT_SQL = """
+    SELECT
+        count(*) FILTER (WHERE d.bar_date <  %(boundary)s) AS in_sample,
+        count(*) FILTER (WHERE d.bar_date >= %(boundary)s) AS hold_out,
+        count(DISTINCT s.instrument_id)                    AS instruments,
+        min(d.bar_date)                                    AS first_bar,
+        max(d.bar_date)                                    AS last_bar
+    FROM research_price_series s
+    JOIN research_price_daily d ON d.series_id = s.series_id
+    WHERE s.instrument_id = ANY(%(ids)s)
+      AND d.bar_date BETWEEN %(start)s AND %(end)s
+"""
+
+_SERIES_SIDE_SQL = """
+    SELECT
+        count(*) FILTER (WHERE has_in_sample AND NOT has_hold_out) AS in_sample_only,
+        count(*) FILTER (WHERE has_hold_out AND NOT has_in_sample) AS hold_out_only,
+        count(*) FILTER (WHERE has_in_sample AND has_hold_out)     AS both
+    FROM (
+        SELECT
+            s.series_id,
+            bool_or(d.bar_date <  %(boundary)s) AS has_in_sample,
+            bool_or(d.bar_date >= %(boundary)s) AS has_hold_out
+        FROM research_price_series s
+        JOIN research_price_daily d ON d.series_id = s.series_id
+        WHERE s.instrument_id = ANY(%(ids)s)
+          AND d.bar_date BETWEEN %(start)s AND %(end)s
+        GROUP BY s.series_id
+    ) sides
+"""
+
+
+def population() -> int:
+    """Arm 1 — the slice, and the frozen split re-derived at bar level."""
+    print("\n[population] the corpus ∩ validated-universe slice §3.2 would evaluate", flush=True)
+    print(f"  corpus version   {CORPUS_VERSION}", flush=True)
+    print(f"  window           {EVALUATION_WINDOW_START} … {EVALUATION_WINDOW_END}", flush=True)
+    print(f"  boundary         {HOLDOUT_BOUNDARY}   (FIRST hold-out bar)", flush=True)
+
+    problems: list[str] = []
+    with psycopg.connect(settings.database_url) as conn:
+        universe = load_validated_universe(conn)
+        params = {
+            "ids": list(universe),
+            "start": EVALUATION_WINDOW_START,
+            "end": EVALUATION_WINDOW_END,
+            "boundary": HOLDOUT_BOUNDARY,
+        }
+        row = conn.execute(_BAR_SPLIT_SQL, params).fetchone()
+        assert row is not None
+        in_sample, hold_out, instruments, first_bar, last_bar = row
+        sides = conn.execute(_SERIES_SIDE_SQL, params).fetchone()
+        assert sides is not None
+        in_only, out_only, both = sides
+
+    total = int(in_sample) + int(hold_out)
+    print(f"  validated universe        {len(universe):>12,} instruments", flush=True)
+    print(f"  of which the corpus holds {int(instruments):>12,}", flush=True)
+    print(f"  bars in window            {total:>12,}   {first_bar} … {last_bar}", flush=True)
+    print(f"    in-sample               {int(in_sample):>12,}   {100.0 * in_sample / total:.2f}%", flush=True)
+    print(f"    hold-out                {int(hold_out):>12,}   {100.0 * hold_out / total:.2f}%", flush=True)
+    series_total = int(in_only) + int(out_only) + int(both)
+    print(f"  series with in-sample bars only  {int(in_only):>7,}", flush=True)
+    print(f"  series with hold-out bars only   {int(out_only):>7,}", flush=True)
+    print(f"  series spanning the boundary     {int(both):>7,}", flush=True)
+    # ⚠ COMPUTED, never written into prose by hand. The two namespaces are over
+    # different populations and this is the size of the difference — the number
+    # `evaluated_instrument_count` and the gate's subset test differ by.
+    print(
+        f"  hold-out-only share              {100.0 * out_only / max(series_total, 1):>6.1f}%   "
+        f"in-sample population ceiling {int(in_only) + int(both):,} of {series_total:,}",
+        flush=True,
+    )
+
+    # ⚠ The split is re-derived and COMPARED against the frozen literal, never
+    # re-fitted. §5.2: "a recomputed boundary walks forward silently and
+    # re-admits hold-out data into training". A drift here is a corpus-version
+    # event, so this arm FAILS rather than updating anything.
+    share = 100.0 * in_sample / total
+    if not 74.0 <= share <= 76.0:
+        problems.append(
+            f"the frozen boundary now splits the slice {share:.2f}/{100.0 - share:.2f} rather than 75/25 — "
+            "the corpus moved under a frozen literal, which is a re-freeze event (§5.2), not a rounding"
+        )
+    # A series with no in-sample bars contributes to no in-sample result and is
+    # not an error; it is reported because the evaluated_instrument_count the
+    # gate reads differs per namespace and nothing else says so.
+    if int(out_only) == 0 and int(in_only) == 0:
+        print("  ⚠ every series spans the boundary — the two namespaces share one population", flush=True)
+
+    for problem in problems:
+        print(f"  *** {problem}", flush=True)
+    return 1 if problems else 0
+
+
+#: A calendar to hand ``decision_calendar`` so every entry's ``exit_regime``
+#: constructs. ⚠ NOT cosmetic: ``ExitRegime`` refuses an EMPTY
+#: ``rebalance_dates`` — "no calendar" and "a calendar with no dates" are kept
+#: distinguishable — so S-2's factory raises on ``()``. One year of consecutive
+#: days is enough for ``rebalance_dates`` to find its month boundaries, and the
+#: regime SHAPE (which this script reads) does not depend on the dates in it.
+_PROBE_CALENDAR: Final = tuple(
+    date.fromordinal(n) for n in range(date(2020, 1, 1).toordinal(), date(2021, 1, 1).toordinal())
+)
+
+
+def _regime_for(entry: StrategyEntry) -> ExitRegime:
+    return entry.exit_regime(entry.decision_calendar(_PROBE_CALENDAR))
+
+
+def _demonstrate_level_refusal(entry: StrategyEntry) -> str | None:
+    """Call ``build_positions`` on a level-based entry with no outcome.
+
+    Returns the refusal message, or ``None`` if it did NOT refuse — which would
+    mean §3.2's blocker has gone away and the spec is stale.
+
+    ⚠ THE REFUSAL IS DEMONSTRATED, NOT QUOTED. ``position_builder``'s docstring
+    says a level-based entry needs an outcome; a docstring cannot be wrong in
+    CI, and the whole reason S-4 is excluded from §3.2 rests on this raise.
+    """
+    regime: ExitRegime = _regime_for(entry)
+    if not regime.level_based:
+        return None
+    when = date(2020, 1, 2)
+    later = date(2020, 1, 3)
+    series = BarSeries(
+        dates=(when, later),
+        rows=(
+            {"open": 10.0, "high": 11.0, "low": 9.0, "close": 10.5, "volume": 1000},  # type: ignore[typeddict-item]
+            {"open": 10.5, "high": 11.5, "low": 9.5, "close": 11.0, "volume": 1000},  # type: ignore[typeddict-item]
+        ),
+    )
+    try:
+        build_positions(
+            strategy_id=entry.strategy_id,
+            strategy_version="probe",
+            entries=[
+                EntryFill(
+                    signal_id=1,
+                    instrument_id=1,
+                    signal_bar_date=when,
+                    fill_bar_date=later,
+                    fill_price=Decimal("10.5"),
+                )
+            ],
+            exits=[],
+            outcomes=[],
+            # ⚠ A pin IS supplied: without one the raise would be the
+            # missing-pin check one line earlier, which is a different defect.
+            outcome_pin=_OUTCOME_PIN,
+            series={1: series},
+            regime=regime,
+            window=Window(start=when, end=later),
+        )
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+#: The pin the level-based demonstration supplies. ⚠ REAL ``OutcomePin`` values,
+#: not stand-ins: ``build_positions`` refuses a level-based regime with a null
+#: pin one check EARLIER, so a stand-in that failed construction would produce
+#: the wrong raise and the demonstration would prove something else.
+_OUTCOME_PIN: Final = OutcomePin(
+    rule_set_version=OUTCOME_RULE_SET_VERSION,
+    input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+)
+
+
+def runnable() -> int:
+    """Arm 2 — which manifest strategies can produce a stored result today."""
+    print("\n[runnable] which STRATEGY_MANIFEST entries can produce a result row", flush=True)
+    problems: list[str] = []
+    blocked: list[str] = []
+    for strategy_id, entry in sorted(STRATEGY_MANIFEST.items()):
+        regime = _regime_for(entry)
+        refusal = _demonstrate_level_refusal(entry)
+        state = "RUNNABLE"
+        if regime.level_based:
+            if refusal is None:
+                problems.append(
+                    f"{strategy_id} is level_based and build_positions did NOT refuse an entry with no outcome — "
+                    "§3.2's exclusion of it rests on that refusal, so the spec is now stale"
+                )
+                state = "RUNNABLE (refusal gone — see above)"
+            else:
+                state = "BLOCKED"
+                blocked.append(strategy_id)
+        print(f"  {strategy_id:<38} {entry.strategy_class:<16} {state}", flush=True)
+        print(
+            f"      signal_pair={regime.signal_pair} level_based={regime.level_based} "
+            f"max_hold_bars={regime.max_hold_bars} rebalance_dates="
+            f"{'None' if regime.rebalance_dates is None else len(regime.rebalance_dates)}",
+            flush=True,
+        )
+        if refusal is not None:
+            print(f"      build_positions refuses: {refusal}", flush=True)
+
+    print(f"\n  runnable {len(STRATEGY_MANIFEST) - len(blocked)} of {len(STRATEGY_MANIFEST)}", flush=True)
+    if blocked:
+        print(f"  blocked: {', '.join(blocked)} — every one of them level_based", flush=True)
+
+    # ⚠ Criterion 6's `M` counts DECLARED trials, and a measured trial the
+    # register does not declare under-counts the search and RAISES the DSR.
+    # ``verify_2240_statistics`` guards that with a hand-written label→trial-id
+    # map; this checks the property that makes such a map unnecessary — the
+    # manifest key IS the register's trial id.
+    print(f"\n  trial register {TRIAL_REGISTER.version}   M = {TRIAL_REGISTER.declared_count}", flush=True)
+    undeclared = sorted(set(STRATEGY_MANIFEST) - TRIAL_REGISTER.trial_ids)
+    if undeclared:
+        problems.append(
+            f"manifest strategies {undeclared} are not declared trials in {TRIAL_REGISTER.version} — their Sharpes "
+            "would be measured but uncounted in M, which under-counts the search and raises the DSR"
+        )
+    else:
+        print(f"  every one of the {len(STRATEGY_MANIFEST)} manifest ids is a declared trial id", flush=True)
+
+    # ⚠ The blocker behind the level-based refusal, COUNTED rather than grepped
+    # in prose. `outcome_resolver.resolve_outcome` needs an `ExitLevels`, and a
+    # spec sentence saying "nothing in app/ constructs one" goes stale silently
+    # the day something does.
+    constructions = _exit_levels_constructions()
+    for root in sorted(constructions):
+        print(f"  ExitLevels( constructed in {root + '/':<9} {constructions[root]:>3} site(s)", flush=True)
+    if constructions.get("app", 0):
+        problems.append(
+            f"{constructions['app']} ExitLevels( construction(s) now exist in app/ — S-4's blocker may have gone, "
+            "and §3 of the spec has to be re-derived rather than trusted"
+        )
+
+    # ⚠⚠ THE AMBIGUITY-ARM CLAIM IS STRUCTURAL AND CHECKED HERE, not inferred
+    # from one strategy's census. `position_builder` assigns
+    # `close_source == "ambiguous"` only inside its `if regime.level_based:`
+    # branch, so a runnable (non-level) strategy cannot produce one — which is
+    # why the two ambiguity arms of a runnable strategy are one measurement
+    # (§6). `--arm`'s close-source census corroborates it on real data; this is
+    # what makes it true for the strategies `--arm` does not run.
+    level_based_runnable = sorted(
+        strategy_id
+        for strategy_id, entry in STRATEGY_MANIFEST.items()
+        if strategy_id not in blocked and _regime_for(entry).level_based
+    )
+    if level_based_runnable:
+        problems.append(
+            f"runnable strategies {level_based_runnable} are level_based — an `ambiguous` close is then reachable "
+            "and the two ambiguity arms are NOT one measurement"
+        )
+    else:
+        print(
+            "  no runnable strategy is level_based → `ambiguous` is unreachable → the two ambiguity arms of "
+            "every runnable strategy are one measurement",
+            flush=True,
+        )
+
+    for problem in problems:
+        print(f"  *** {problem}", flush=True)
+    return 1 if problems else 0
+
+
+def _exit_levels_constructions() -> dict[str, int]:
+    """Count ``ExitLevels(`` construction sites per top-level directory.
+
+    ⚠ Counted in Python rather than shelled out to ``grep``: a spec citing a
+    grep command is evidence nothing runs, and this arm's exit code is what
+    makes the claim hold run to run.
+    """
+    counts: dict[str, int] = {}
+    for root in ("app", "scripts", "tests"):
+        found = 0
+        for path in Path(root).rglob("*.py"):
+            found += path.read_text(encoding="utf-8").count("ExitLevels(")
+        counts[root] = found
+    return counts
+
+
+def arms() -> int:
+    """Arm 3 — how many result rows one "backtest everything" invocation writes."""
+    print("\n[arms] the row count of one full invocation, from the manifest and the vocabularies", flush=True)
+    runnable_ids = sorted(
+        strategy_id for strategy_id, entry in STRATEGY_MANIFEST.items() if not _regime_for(entry).level_based
+    )
+    factors = (
+        ("runnable strategies", len(runnable_ids), ", ".join(runnable_ids)),
+        ("namespaces", len(RESULT_NAMESPACES), ", ".join(sorted(RESULT_NAMESPACES))),
+        ("ambiguity arms", len(AMBIGUITY_ARMS), ", ".join(sorted(AMBIGUITY_ARMS))),
+        ("quarantine arms", len(QUARANTINE_ARMS), ", ".join(sorted(QUARANTINE_ARMS))),
+        ("result scopes", len(RESULT_SCOPES), ", ".join(sorted(RESULT_SCOPES))),
+    )
+    total = 1
+    for label, count, members in factors:
+        total *= count
+        print(f"  {label:<22} {count:>3}   {members}", flush=True)
+    print(f"  {'product':<22} {total:>3}   result rows per full invocation", flush=True)
+    sleeve_only = total // len(RESULT_SCOPES)
+    print(
+        f"  {'sleeve scope only':<22} {sleeve_only:>3}   "
+        "(portfolio scope needs a cross-strategy allocator that does not exist)",
+        flush=True,
+    )
+
+    # ⚠⚠ THE INVOCATION UNIT IS THE STRATEGY SET, NOT ONE STRATEGY, and this is
+    # what says so. Criterion 6's DSR deflates by `V[SR_n]` over the MEASURED
+    # trials, so it does not exist below `MIN_MEASURED_TRIALS`. A per-strategy
+    # invocation therefore cannot fill `deflated_sharpe`, and the gate refuses
+    # every row it writes with `deflated_sharpe_not_computed`.
+    print(
+        f"\n  MIN_MEASURED_TRIALS      {MIN_MEASURED_TRIALS:>3}   "
+        "V[SR_n] does not exist below it, so one strategy alone cannot produce a Deflated Sharpe",
+        flush=True,
+    )
+    if len(runnable_ids) < MIN_MEASURED_TRIALS:
+        print(
+            f"  *** only {len(runnable_ids)} runnable strategies — below MIN_MEASURED_TRIALS, so NO invocation "
+            "can produce a promotable row",
+            flush=True,
+        )
+        return 1
+    return 0
+
+
+def arm(*, limit: int | None, strategy_id: str) -> int:
+    """Arm 4 — one arm end-to-end over the whole corpus. A1-A4 in the header.
+
+    ⚠ ONE STRATEGY PER INVOCATION, and which one is printed. Every figure this
+    arm produces is a statement about the strategy named, not about the set:
+    ``--arms`` supplies the multiplier and §6 of the spec supplies the
+    structural argument for what generalises. A `cross_sectional` entry is
+    refused here rather than silently mis-measured — its panel is resident, not
+    streamed, so this loop is the wrong shape for it.
+    """
+    started = time.monotonic()
+    entry = STRATEGY_MANIFEST[strategy_id]
+    if entry.signals is None:
+        raise RuntimeError(
+            f"{strategy_id} is {entry.strategy_class}; this arm streams one series at a time and cannot "
+            "measure a strategy whose decision needs the panel resident"
+        )
+    identity = entry.identity(universe=UNIVERSE, cost_model_id=COST_MODEL_ID)
+    regime = _regime_for(entry)
+    window = Window(start=EVALUATION_WINDOW_START, end=EVALUATION_WINDOW_END)
+
+    print(f"\n[arm] {strategy_id} {identity.version}", flush=True)
+    print(f"      builder {BUILDER_RULE_SET_VERSION}", flush=True)
+    print(f"      cost model {COST_MODEL_ID}   carry_unmodelled {CARRY_UNMODELLED}", flush=True)
+    print(f"      sizing rule {SIZING_RULE_ID}   metric set {METRIC_SET_ID}", flush=True)
+    print("      quarantine arm masked   ambiguity arm worst_case   scope sleeve", flush=True)
+
+    load_s = 0.0
+    evaluate_s = 0.0
+    absorb_s = 0.0
+    namespaces: Counter[str] = Counter()
+    close_sources: Counter[str] = Counter()
+    spanning = 0
+    earliest_holdout_entry: date | None = None
+    latest_in_sample_close: date | None = None
+    in_sample_instruments: set[int] = set()
+    problems: list[str] = []
+
+    with psycopg.connect(settings.database_url) as conn:
+        universe = load_validated_universe(conn)
+        bounds = {"ids": list(universe), "start": EVALUATION_WINDOW_START, "end": EVALUATION_WINDOW_END}
+        axis = tuple(row[0] for row in conn.execute(_AXIS_SQL, bounds).fetchall())
+        axis_pos = {when: index for index, when in enumerate(axis)}
+        print(f"  evaluation axis  {len(axis):,} trading dates", flush=True)
+
+        pairs = conn.execute(
+            "SELECT instrument_id, series_id FROM research_price_series "
+            "WHERE instrument_id = ANY(%(ids)s) ORDER BY instrument_id, series_id",
+            {"ids": list(universe)},
+        ).fetchall()
+        if limit is not None:
+            pairs = pairs[:limit]
+            print(f"  ⚠ LIMITED to the first {len(pairs)} series — NOT a full-population figure", flush=True)
+
+        sleeve = _Sleeve(strategy_id)
+        benchmark = LegBook()
+        empty = 0
+
+        for n, (instrument_id, series_id) in enumerate(pairs, start=1):
+            mark = time.monotonic()
+            masked = load_masked_series(conn, series_id)
+            load_s += time.monotonic() - mark
+            if not masked.bars:
+                empty += 1
+                continue
+            series, _masked_opens = _to_series(masked.bars)
+            indices = [axis_pos[when] for when in series.dates if when in axis_pos]
+            if len(indices) < 2:
+                empty += 1
+                continue
+            first_axis_index, last_axis_index = indices[0], indices[-1]
+            closes = [float("nan")] * (last_axis_index - first_axis_index + 1)
+            for when, row in zip(series.dates, series.rows, strict=True):
+                slot = axis_pos.get(when)
+                close = row.get("close")
+                if slot is not None and close is not None:
+                    closes[slot - first_axis_index] = float(close)
+            _benchmark_leg(
+                benchmark,
+                series=series,
+                axis_pos=axis_pos,
+                closes=closes,
+                first_axis_index=first_axis_index,
+            )
+
+            mark = time.monotonic()
+            signals = entry.signals(series, universe=UNIVERSE, masked_reason="quarantined_bar")
+            rows = resolve_fills(signals, series=series, identity=identity, instrument_id=int(instrument_id))
+            entries, exits = _fills(rows, int(instrument_id))
+            built = build_positions(
+                strategy_id=entry.strategy_id,
+                strategy_version=identity.version,
+                entries=entries,
+                exits=exits,
+                outcomes=[],
+                outcome_pin=None,
+                series={int(instrument_id): series},
+                regime=regime,
+                window=window,
+            )
+            costed: list[CostedPosition] = list(cost_positions(built.positions))
+            evaluate_s += time.monotonic() - mark
+
+            # A2 / A3 — the §5.2 partition and the close-source census, taken on
+            # the positions the SINGLE pass produced.
+            for row_costed in costed:
+                position = row_costed.position
+                side = namespace_for_position(position.entry_fill_bar_date, position.close_bar_date)
+                namespaces[side] += 1
+                close_sources[position.close_source or "open_at_window_end"] += 1
+                # ⚠ The two extremes below are what decide the per-namespace
+                # equity AXIS, which nothing in the tree has ever had to choose:
+                # `verify_2240_holdout_namespace.py` counts this partition and
+                # builds no curve from it. A spanning position belongs to the
+                # hold-out (§5.2) and carries its true entry fill, so the
+                # hold-out axis cannot start at the boundary — it has to reach
+                # back to the earliest such entry, and how far back that is is
+                # the number that says whether the construction is usable.
+                if side == "hold_out":
+                    if position.entry_fill_bar_date < HOLDOUT_BOUNDARY:
+                        spanning += 1
+                    if earliest_holdout_entry is None or position.entry_fill_bar_date < earliest_holdout_entry:
+                        earliest_holdout_entry = position.entry_fill_bar_date
+                else:
+                    # ⚠ The IN-SAMPLE instrument set, kept separately because
+                    # the gate's subset test is per namespace (§0: the two
+                    # populations differ) and an all-instruments set would
+                    # verify a claim this row does not make.
+                    in_sample_instruments.add(int(instrument_id))
+                    if position.close_bar_date is not None and (
+                        latest_in_sample_close is None or position.close_bar_date > latest_in_sample_close
+                    ):
+                        latest_in_sample_close = position.close_bar_date
+
+            mark = time.monotonic()
+            sleeve.absorb(
+                costed,
+                series=series,
+                window=window,
+                axis_pos=axis_pos,
+                closes=closes,
+                first_axis_index=first_axis_index,
+            )
+            absorb_s += time.monotonic() - mark
+
+            if n % 500 == 0:
+                print(
+                    f"  {n}/{len(pairs)} series, {sleeve.positions:,} positions ({time.monotonic() - started:.0f}s)",
+                    flush=True,
+                )
+
+    corpus_s = time.monotonic() - started
+    print(f"\n  series with usable bars  {len(pairs) - empty:,}   (fail-closed empties: {empty})", flush=True)
+
+    from app.services.equity_curve import build_equity_curve  # noqa: PLC0415 — after the corpus pass
+
+    benchmark_curve = build_equity_curve(benchmark, date_count=len(axis))
+    metrics = sleeve.report(axis=axis, benchmark_curve=benchmark_curve)
+    total_s = time.monotonic() - started
+
+    # A1 — the cost, split by phase.
+    print("\n  [A1] cost of ONE arm over the full corpus", flush=True)
+    print(f"      corpus pass            {corpus_s:>10.1f}s", flush=True)
+    print(f"        masked bar loading   {load_s:>10.1f}s   {100.0 * load_s / corpus_s:.1f}%", flush=True)
+    print(f"        signals→positions    {evaluate_s:>10.1f}s   {100.0 * evaluate_s / corpus_s:.1f}%", flush=True)
+    print(f"        curve accumulation   {absorb_s:>10.1f}s   {100.0 * absorb_s / corpus_s:.1f}%", flush=True)
+    print(f"      curve + metrics        {total_s - corpus_s:>10.1f}s", flush=True)
+    print(f"      TOTAL                  {total_s:>10.1f}s", flush=True)
+
+    # A2 — the partition. This is the finding that decides whether the hold-out
+    # arm is a second run or a filter over the same pass.
+    positions_total = sum(namespaces.values())
+    print("\n  [A2] the §5.2 namespace partition of ONE pass's positions", flush=True)
+    for side, count in sorted(namespaces.items()):
+        print(f"      {side:<12} {count:>10,}   {100.0 * count / max(positions_total, 1):.2f}%", flush=True)
+    holdout_rows = namespaces.get("hold_out", 0)
+    print(
+        f"      of the hold-out rows, {spanning:,} entered BEFORE the boundary (spanning) — "
+        f"{100.0 * spanning / max(holdout_rows, 1):.2f}%",
+        flush=True,
+    )
+    print(f"      earliest hold-out entry   {earliest_holdout_entry}   (the hold-out curve's axis must reach it)")
+    if earliest_holdout_entry is not None:
+        lead = (HOLDOUT_BOUNDARY - earliest_holdout_entry).days
+        print(
+            f"      hold-out axis lead        {lead:,} calendar days before the boundary   "
+            "(how far back the spanning legs force the axis)",
+            flush=True,
+        )
+    print(f"      latest in-sample close    {latest_in_sample_close}   (boundary is {HOLDOUT_BOUNDARY})", flush=True)
+    print(f"      instruments with >=1 in-sample position  {len(in_sample_instruments):,}", flush=True)
+    if latest_in_sample_close is not None and latest_in_sample_close >= HOLDOUT_BOUNDARY:
+        problems.append(
+            f"an in-sample position closes {latest_in_sample_close}, on or after the boundary — "
+            "namespace_for_position would have to have mis-classified it"
+        )
+
+    # A3 — the close sources. `ambiguous` is reachable only through an outcome,
+    # and outcomes only for a level-based regime, so a non-level arm's two
+    # ambiguity arms are the same measurement. This is what says so.
+    print("\n  [A3] close-source census", flush=True)
+    for source, count in close_sources.most_common():
+        print(f"      {source:<22} {count:>10,}", flush=True)
+    if close_sources.get("ambiguous"):
+        problems.append(
+            f"{close_sources['ambiguous']} positions closed 'ambiguous' on a non-level arm — the two ambiguity "
+            "arms would then differ, and §3.2's claim that they cannot is falsified"
+        )
+
+    # A4 — the refusal list the operator would see on the row this job stores.
+    if metrics is None:
+        problems.append("the metric set did not construct, so no candidate could be gated")
+    else:
+        result = StrategyResult(
+            identity=ResultIdentity(
+                strategy_id=entry.strategy_id,
+                strategy_version=identity.version,
+                result_scope="sleeve",
+                namespace="in_sample",
+                ambiguity_arm="worst_case",
+                quarantine_arm="masked",
+                sizing_rule=SIZING_RULE_ID,
+                cost_model_id=COST_MODEL_ID,
+                corpus_version=CORPUS_VERSION,
+                window_start=EVALUATION_WINDOW_START,
+                window_end=EVALUATION_WINDOW_END,
+                position_rule_set_version=BUILDER_RULE_SET_VERSION,
+                outcome_rule_set_version=_OUTCOME_PIN.rule_set_version,
+                input_rule_set_version=_OUTCOME_PIN.input_rule_set_version,
+            ),
+            metrics=metrics,
+            universe_basis=UNIVERSE,
+            carry_unmodelled=CARRY_UNMODELLED,
+            # ⚠ THE IN-SAMPLE COUNT, not the corpus's. `len(pairs) - empty`
+            # counts every series the pass loaded, including the ones whose
+            # positions are all hold-out — and this row says `in_sample`.
+            evaluated_instrument_count=len(in_sample_instruments),
+        )
+        candidate = PromotionCandidate(
+            result=result,
+            evaluated_instrument_ids=frozenset(in_sample_instruments),
+            validated_universe_ids=frozenset(universe),
+        )
+        refusals = check_promotable(candidate)
+        print("\n  [A4] check_promotable on the row this job would store", flush=True)
+        for refusal in refusals:
+            print(f"      {refusal}", flush=True)
+        print(f"      {len(refusals)} refusals", flush=True)
+        if not refusals:
+            problems.append(
+                "the bare row is PROMOTABLE — §3.2's whole argument is that it cannot be, so either the gate or "
+                "this script is wrong"
+            )
+
+    for problem in sleeve.problems:
+        print(f"  *** {problem}", flush=True)
+    for problem in problems:
+        print(f"  *** {problem}", flush=True)
+    return 1 if (problems or sleeve.problems) else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--population", action="store_true")
+    parser.add_argument("--runnable", action="store_true")
+    parser.add_argument("--arms", action="store_true")
+    parser.add_argument("--arm", action="store_true")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument(
+        "--strategy",
+        default=DEFAULT_ARM_STRATEGY,
+        choices=sorted(STRATEGY_MANIFEST),
+        help="--arm only: which manifest strategy to measure. Cross-sectional entries are refused.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="⚠ --arm only, and the output says so: a limited run is NOT a full-population figure",
+    )
+    args = parser.parse_args()
+    if not any((args.population, args.runnable, args.arms, args.arm, args.all)):
+        parser.print_help()
+        return 2
+
+    status = 0
+    if args.all or args.population:
+        status |= population()
+    if args.all or args.runnable:
+        status |= runnable()
+    if args.all or args.arms:
+        status |= arms()
+    if args.all or args.arm:
+        status |= arm(limit=args.limit, strategy_id=args.strategy)
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Specs #2394 §3.2, `strategy_backtest_run` — the remaining half of the ticket. §3.1 (the daily signal scan) merged in `cc89c63e`. Two files: the spec, and `scripts/verify_2394_backtest_run.py`, which prints every figure the spec quotes (4 arms, exit 0, **nothing is written to the DB**).

§3.2 exists today as three sentences: *"Runs the harness for a strategy × namespace × arm and persists via `result_ledger`. Manual-trigger only: it is expensive, and its `StrategyIdentity.version` must be stable."* Its own §4 question 6 then says the identity is under-specified. Measured against the corpus, the first sentence is wrong at the unit and the second is right for the wrong reason.

## The three findings that changed the design

**1. The invocation unit is the strategy SET, not one strategy.** Criterion 6's Deflated Sharpe deflates by `V[SR_n]` across the *measured* trials, and `deflated_sharpe.MIN_MEASURED_TRIALS = 2`. A per-strategy run cannot produce a DSR at all, so every row it writes carries `deflated_sharpe_not_computed` — a refusal no amount of re-running one strategy clears. One invocation now covers every runnable strategy.

**2. Both namespaces come out of ONE pass, so the hold-out arm is free — and that is the problem.** `namespace_for_position` is a filter over positions the sweep already produced: 2,456,097 in-sample / 679,258 hold-out from a single S-1 masked pass. Criterion 5's whole mechanism is that looking at the withheld side is rare and deliberate; a job that computes both anyway turns the access log into a count of cron fires. So the hold-out arm requires `holdout_purpose` + `holdout_accessed_by`, and an in-sample run **counts and discards** the hold-out side rather than computing its metrics.

⚠ `accessed_by` cannot be derived from the request: `pending_job_requests.requested_by` is filled by the API, but the listener dispatches `invoker(params=…)` and nothing else, so the requester never reaches the job body.

**3. S-4 cannot be backtested, and the code says so.** `build_positions` refuses a level-based entry with no outcome — **demonstrated by calling it**, not quoted from a docstring, because the whole exclusion rests on that raise. `ExitLevels(` construction sites: **app/ 0**, scripts/ 5, tests/ 6. Same blocker as the outcome-resolution job.

## Measured (this branch, dev corpus, `verify_2394_backtest_run.py --all` exit 0)

```
population   5,266 series / 23,339,583 bars; 17,501,058 in-sample (74.98%) / 5,838,525 hold-out
             1,244 series have NO in-sample bar → the two namespaces differ by 23.6%
runnable     3 of 4; S-4 BLOCKED; all 4 manifest ids are declared trial ids (M = 11)
arms         3 × 2 × 2 × 2 × 1 sleeve = 24 rows, from 6 corpus passes
arm (S-1)    3,135,355 positions; ambiguous closes 0; 8 promotion refusals
             spanning hold-out entries 2,661 (0.39%), reaching 1,000 days back
             instruments with >=1 in-sample position 3,541 — 12% below the 4,022 ceiling
```

A fifth finding fell out of §0: **zero series end before the boundary.** That is the survivor-only label showing up as a shape rather than a caveat — a corpus with delistings would have series that stop in 1998.

## What Codex killed at checkpoint 1

Six things, and two were load-bearing:

- **"Two refusals survive every run" was wrong — it is three.** `synthetic_control_not_run` survives this cut too.
- **The transaction boundary was copied from §3.1 without checking it still held.** "One strategy's failure does not stop the others" is *unsafe* here: the DSR's `V[SR_n]` is a function of which trials were measured, so losing S-2 and proceeding deflates S-1 and S-3 against a two-trial variance and reports itself complete — a more confident number obtained by losing evidence. The run now evaluates all, computes the DSR, then writes; a failure aborts with zero rows.
- `effective_sample_size` is **not** free: `compute_metrics(bootstrap_seed=…)` defaults to `None`, and the only seed in the tree is `verify_2240_statistics.BOOTSTRAP_SEED` — a script literal. The job must freeze one in `app/`.
- The locking rationale was stale: `JobLock` is session-scoped `pg_try_advisory_lock`, not `pg_advisory_xact_lock`.
- Computing the refusal list would itself have written criterion-5 `read` records, via `result_ledger.quarantine_arms_compared()`.
- `input_rule_set_version` is the **quarantine** rule set, not "indicator + quarantine" — the indicator set is already inside `strategy_version` (#2333) and folding it in would hash it twice.

It also flagged every derived number that the script did not print. Those are now computed by the script (the 23.6% share, the 0.39% spanning share, the 1,000-day axis lead, the in-sample instrument count) or explicitly labelled as estimates in acceptance criterion 10 — the three-run cost table, the six-pass extrapolation and the synthetic-control cost, none of which is one invocation's output.

## Verification

`--all` exit 0. The `--arm` leg ran three times over the full corpus; all three produced identical position counts and wall clocks spanning 290.3s / 513.7s / 444.4s, which is reported rather than averaged — the box was carrying other sessions. The phase *shape* is stable across all three and that is the part the cost argument uses.

Gates: `ruff check` · `ruff format --check` · `pyright` · `pytest -m "not db"` · `pytest tests/smoke` — each run separately, all exit 0.

## Security

No security model. Read-only measurement script, no endpoint, no auth surface, no order path. The one governance-adjacent decision — that hold-out access requires an operator-supplied purpose — makes the audit trail stricter, not looser.

## Not in this PR

The implementation. Also out of the specced cut, with reasons rather than omissions: the synthetic control (§9's cohort is per-strategy, 1,000 full-corpus evaluations each, and the only one that exists lives in a developer cache), the walk-forward split, and outcome resolution.

Refs #2394. Refs #2240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)