### PR TITLE
docs: the autonomy loop's rebuttal rule had no terminal state, and contradicted CLAUDE.md

### DIFF
--- a/.autonomy/loop_prompt.md
+++ b/.autonomy/loop_prompt.md
@@ -22,10 +22,37 @@ branches, no unpushed WIP).
    **merge ONLY via `"$AUTONOMY_ENGINE_HOME/bin/safe_merge.sh" <pr>`** (mechanically
    verifies bot-APPROVE-on-latest-SHA + CI-green; never `gh pr merge` directly).
    If the latest round is **rebuttal-only** (no code change, you think the bot is
-   wrong), do NOT merge unattended — that needs Codex ckpt-3 + human judgment;
-   leave the PR open with your reasoning and move on. If `safe_merge.sh` reports
-   manual-mode (the repo's merge gate is `manual`), leave the PR open and move to
-   the next ticket — do not attempt to merge it yourself.
+   wrong), run **Codex ckpt-3** over the rebuttals — and then finish the ticket:
+
+   - **Codex agrees your rebuttals are sound, and nothing else is outstanding →
+     MERGE.** `.claude/CLAUDE.md`'s decision tree is explicit that this needs
+     **no user rubber-stamp**: *"if Codex and the author both agree the remaining
+     bot findings are unfounded rebuttals and there is nothing else to action,
+     that's sufficient to merge."*
+   - **Codex finds something, or sides with the bot against you → fix it, push,
+     and restart the loop.** The new commit is a NEW round: once the bot APPROVEs
+     that SHA with nothing outstanding, merge it. ⚠ A rebuttal is a property of
+     **the round it appeared in**, not a permanent mark on the PR — reading it as
+     permanent makes a PR that ever drew one nitpick rebuttal unmergeable forever,
+     however much verification follows.
+   - **Escalate ONLY** where Codex cannot settle it: an architecture or scope
+     trade-off, or a settled-decision reversal. Then leave the PR open **and say
+     in the comment exactly what would unblock it** — an open PR with no stated
+     unblock condition is work nobody comes back to.
+
+   ⚠⚠ **Precedent, 2026-08-08 (#2240, PR #2427).** This paragraph used to read
+   *"do NOT merge unattended — that needs Codex ckpt-3 + human judgment; leave the
+   PR open and move on."* The loop did everything right — ran ckpt-3, which found
+   a real silent last-write-wins in `_cut_splits`, fixed it, pushed, and got a
+   clean bot APPROVE on the new SHA — and then **still refused to merge**, because
+   the PR had once contained a rebuttal. It sat merge-ready and abandoned until the
+   operator asked why. It also went `CONFLICTING` in the meantime, which costs a
+   rebase and re-review. The old wording both contradicted `.claude/CLAUDE.md` and
+   had no terminal state; "leave it open and move on" is not an outcome.
+
+   If `safe_merge.sh` reports manual-mode (the repo's merge gate is `manual`),
+   leave the PR open and move to the next ticket — do not attempt to merge it
+   yourself. That one IS a real stop: the gate is the operator's switch.
 
    **Push discipline — run the terminal push/PR step in the FOREGROUND, never
    background it (#1771).** The pre-push gate is slow (full fast tier + smoke +


### PR DESCRIPTION
## What

`.autonomy/loop_prompt.md` told the loop that a **rebuttal-only** review round *"needs Codex ckpt-3 + human judgment; leave the PR open with your reasoning and move on."*

`.claude/CLAUDE.md`'s review decision tree says the opposite:

> if Codex and the author both agree the remaining bot findings are unfounded rebuttals and there is nothing else to action, that's sufficient to merge — **no user rubber-stamp required**.

So the loop was running a stricter rule than the repo's, in the one direction that costs the most: it could reach a merge-ready state and then decline to merge.

## Why it is worse than a conflict — it has no exit

On **#2427** the loop did everything right. It ran ckpt-3, which found a real silent last-write-wins in `_cut_splits` (a duplicate arm key overwriting a split cut over a different population). It fixed it, pushed `e57c78b3`, and the bot APPROVEd that SHA with no findings.

At that point the latest round was not rebuttal-only. It was a clean approve. **The loop still refused**, reading "the round contains a rebuttal of mine" as a permanent property of the PR rather than of the round:

> I am **not merging this round regardless** — this loop's operating rule is to leave a PR open when the round contains a rebuttal of mine.

The PR then sat merge-ready and unattended until the operator noticed, and went `CONFLICTING` in the meantime (my own #2426 touched the same files), costing a rebase and a full re-review round. Merged as `df5fa597` after that.

⚠ This is the same defect class `.claude/CLAUDE.md` already documents for the doc-only skip notice: **a gate with no terminal state makes a PR permanently unmergeable**, and it fails silently, because "still open" is indistinguishable from "still working".

## The change

Replaces "do not merge, move on" with the three outcomes spelled out:

- Codex agrees and nothing is outstanding → **merge** (quoting CLAUDE.md's own sentence, so the two files cannot drift again).
- Codex finds something or sides with the bot → fix, push, **and the new commit is a NEW round**; merge when the bot approves that SHA.
- Escalate **only** where Codex genuinely cannot settle it — an architecture/scope trade-off or a settled-decision reversal — **and say what would unblock it**. An open PR with no stated unblock condition is work nobody comes back to.

Keeps the one stop that is real: `safe_merge.sh` reporting manual-mode, because that gate is the operator's switch.

The #2427 precedent is recorded inline rather than in the prevention log, because the loop reads this file and will not read that one.

## Security

None — a prompt/instruction file for the unattended loop. No code, no schema, no runtime path. The hard safety rules (never trade, never touch the kill switch, merge only via `safe_merge.sh`, never `--no-verify`) are untouched and still enforced by `.autonomy/hard_rules.md`.

## Verification

Doc-only. `git diff` touches lines 25-56 of one file. The MD022/MD032 warnings the linter reports at other lines are pre-existing (headings followed directly by lists) and merely renumbered by the insertion — not introduced here, and not fixed here to keep the diff narrow.

Refs #2240.