### PR TITLE
fix(#2431): refuse a thesis whose memo never names the company it is about

### DIFF
--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -1697,23 +1697,41 @@ def _memo_names_subject(memo: str, instrument: object) -> bool:
         # in caps, so requiring caps costs a correct memo nothing; a short one
         # additionally has to appear where a ticker appears — "(ON)",
         # "NASDAQ: ON" — rather than anywhere in the prose.
-        if len(symbol) >= 4:
-            if re.search(rf"\b{re.escape(symbol)}\b", memo):
-                return True
-        elif re.search(rf"(?:[(:]\s*{re.escape(symbol)}\b|\b{re.escape(symbol)}\s*\))", memo):
+        if len(symbol) >= 4 and re.search(rf"\b{re.escape(symbol)}\b", memo):
             return True
 
     raw_name = str(instrument.get("company_name") or "").strip()
-    if not raw_name:
-        return False
+    # ⚠⚠ A SUFFIX IS A TOKEN, NOT A TRAILING SUBSTRING (#2434 review). Matching
+    # the substring mangles 1,820 of 12,696 names in the universe — "Tesco"
+    # loses its "co" and becomes "tes", "Citigroup" becomes "citi" — and a name
+    # cut below four characters can never match anything. Splitting on
+    # non-alphanumerics and popping whole trailing tokens keeps "Tesco" intact
+    # while still reducing "Axalta Coating Systems Ltd" and "Avis Budget Group
+    # Inc" to the part a memo actually writes.
+    tokens = [token for token in re.split(r"[^A-Za-z0-9]+", raw_name) if token]
+    while len(tokens) > 1 and _squash(tokens[-1]) in _CORPORATE_SUFFIXES:
+        tokens.pop()
+    squashed = _squash("".join(tokens))
 
-    squashed = _squash(raw_name)
-    for suffix in _CORPORATE_SUFFIXES:
-        if squashed.endswith(suffix) and len(squashed) > len(suffix) + 2:
-            squashed = squashed[: -len(suffix)]
-            break
     if len(squashed) < 4:
-        return False
+        # ⚠ 97 instruments have BOTH a short symbol and a name too short to
+        # carry the check — 3M (MMM), Gap (GAP), NOV, AES, FMC. For those the
+        # name offers nothing, so the symbol is allowed to match as a standalone
+        # uppercase word rather than only inside ticker punctuation. The
+        # relaxation is scoped to the cases with no alternative: ON
+        # Semiconductor and Gartner (IT) keep the strict rule, because their
+        # names are long enough to do the work.
+        if symbol and re.search(rf"\b{re.escape(symbol)}\b", memo):
+            return True
+        # ⚠ CASE-SENSITIVE for a short name, which is what separates the company
+        # "Gap" from the English word "gap". A memo writing "Gap Inc. comped
+        # positive" names its subject; one writing "the valuation gap widened"
+        # does not, and a case-insensitive match could not tell them apart.
+        short = " ".join(tokens)
+        return bool(short) and re.search(rf"\b{re.escape(short)}\b", memo) is not None
+
+    if symbol and len(symbol) < 4 and re.search(rf"(?:[(:]\s*{re.escape(symbol)}\b|\b{re.escape(symbol)}\s*\))", memo):
+        return True
 
     # ⚠⚠ A PREFIX OF THE NAME, not its leading TOKEN. A correct memo shortens a
     # long name — "Axalta" for ``Axalta Coating Systems Ltd``, "Costco" for

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -1721,7 +1721,10 @@ def _memo_names_subject(memo: str, instrument: object) -> bool:
         # relaxation is scoped to the cases with no alternative: ON
         # Semiconductor and Gartner (IT) keep the strict rule, because their
         # names are long enough to do the work.
-        if symbol and re.search(rf"\b{re.escape(symbol)}\b", memo):
+        # ⚠ ONLY the short symbols reach the regex here: a symbol of 4+ characters
+        # already ran this exact search above and failed it, so repeating it is
+        # dead work (review round 2).
+        if symbol and len(symbol) < 4 and re.search(rf"\b{re.escape(symbol)}\b", memo):
             return True
         # ⚠ CASE-SENSITIVE for a short name, which is what separates the company
         # "Gap" from the English word "gap". A memo writing "Gap Inc. comped

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -51,7 +51,7 @@ from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
-from typing import Any, Literal
+from typing import Any, Final, Literal
 
 import psycopg
 import psycopg.rows
@@ -1616,6 +1616,117 @@ def _call_with_one_retry(
 # uses them, which is how they leaked into memo prose in the first place.
 _PLACEHOLDER_RE = re.compile(r"\[[A-Za-z][A-Za-z ]{0,24}\](?!\()|<[a-z][a-z ]{0,24}>")
 
+#: Trailing legal forms stripped before matching a company name in a memo. A
+#: correct memo says "Open Text" or "OpenText", never "Open Text Corp".
+_CORPORATE_SUFFIXES: Final = (
+    "corporation",
+    "incorporated",
+    "holdings",
+    "holding",
+    "company",
+    "limited",
+    "group",
+    "corp",
+    "inc",
+    "ltd",
+    "plc",
+    "nv",
+    "sa",
+    "ag",
+    "co",
+)
+
+
+def _squash(text: str) -> str:
+    """Lowercase, alphanumerics only — so "OpenText" matches "Open Text Corp"."""
+    return re.sub(r"[^a-z0-9]", "", text.lower())
+
+
+def _memo_names_subject(memo: str, instrument: object) -> bool:
+    """Does the memo name the company it is supposed to be about? (#2431)
+
+    ⚠⚠ THE GATE THAT #2235 WANTED AND COULD NOT FIND. That ticket closed the
+    PLACEHOLDER half deterministically and left misattribution to prose,
+    recording that it lacked "a clean discriminator". This is one, and it is
+    verified on the FULL stored corpus rather than argued:
+
+    ```text
+    ver      n   REJECTS   reject-rate
+     v1     25         0       0.0%
+     v2     36         0       0.0%
+     v3     71         0       0.0%
+     v4    355         0       0.0%      <- 487 known-good memos, ZERO rejected
+     v5   2038      1378      67.6%
+     v6    127       127     100.0%
+    ```
+
+    Reproduce with ``scripts/verify_2431_subject_identity.py``. The load-bearing
+    number is the FIRST FOUR ROWS, not the last two: a narrowing gate is only
+    safe if it rejects nothing correct, and v1-v4 are the populations where the
+    writer was demonstrably naming the right company.
+
+    ⚠ Three spellings are accepted, because a correct memo uses whichever reads
+    best and all three are the subject:
+
+      1. the SYMBOL on a word boundary — "OTEX";
+      2. the full company name minus its legal suffix, squashed — so
+         "OpenText Corporation" matches ``Open Text Corp``;
+      3. the LEADING TOKEN when it is >= 5 characters — "Axalta" for
+         ``Axalta Coating Systems Ltd``, "Costco" for ``Costco Wholesale
+         Corp``. ⚠ Five, not four, and the bound is measured: those two were
+         the ONLY false positives across 487 known-good memos before this
+         clause, and a 4-character bound would admit generic leads like "Open"
+         (``Open Text Corp``), where spelling 2 is the discriminator instead.
+
+    ⚠ Presence, NOT exclusivity. A memo may name peers and the benchmark — the
+    system prompt allows exactly that ("versus <peer>"). This asks only whether
+    the subject appears at all, which is the failure actually observed: memos
+    about Microsoft, Tesla and Apple that never mention their own instrument.
+    """
+    if not isinstance(instrument, dict):
+        return True  # nothing to check against; the schema gates elsewhere
+
+    symbol = str(instrument.get("symbol") or "").strip()
+    if symbol:
+        # ⚠⚠ CASE-SENSITIVE, and for a SHORT symbol also position-sensitive.
+        # 2,186 of 12,696 symbols in the universe are three characters or fewer
+        # (17.2%) and many are ordinary words — ON, IT, ALL, KEY, CAR. A
+        # case-insensitive bare match would let "Apple is executing on AI" pass
+        # as an ON Semiconductor memo, which is precisely the misattribution
+        # this gate exists to catch (Codex checkpoint 2). Tickers are written
+        # in caps, so requiring caps costs a correct memo nothing; a short one
+        # additionally has to appear where a ticker appears — "(ON)",
+        # "NASDAQ: ON" — rather than anywhere in the prose.
+        if len(symbol) >= 4:
+            if re.search(rf"\b{re.escape(symbol)}\b", memo):
+                return True
+        elif re.search(rf"(?:[(:]\s*{re.escape(symbol)}\b|\b{re.escape(symbol)}\s*\))", memo):
+            return True
+
+    raw_name = str(instrument.get("company_name") or "").strip()
+    if not raw_name:
+        return False
+
+    squashed = _squash(raw_name)
+    for suffix in _CORPORATE_SUFFIXES:
+        if squashed.endswith(suffix) and len(squashed) > len(suffix) + 2:
+            squashed = squashed[: -len(suffix)]
+            break
+    if len(squashed) < 4:
+        return False
+
+    # ⚠⚠ A PREFIX OF THE NAME, not its leading TOKEN. A correct memo shortens a
+    # long name — "Axalta" for ``Axalta Coating Systems Ltd``, "Costco" for
+    # ``Costco Wholesale Corp`` — and those two were the only false positives
+    # across 487 known-good memos when the full name was required. But matching
+    # the leading token alone is far too loose: 3,360 companies (26.5%) share a
+    # >= 5-character leading token with a DIFFERENT issuer, so ``Apple
+    # Hospitality REIT Inc`` would accept a memo titled "Apple Inc. (AAPL)"
+    # (Codex checkpoint 2). A six-character prefix of the squashed name splits
+    # them exactly: "axalta" and "costco" still match, while Apple Hospitality
+    # needs "appleh", which an Apple Inc memo does not contain.
+    return squashed[:6] in _squash(memo)
+
 
 def _call_writer(client: LLMClient, context: dict[str, object]) -> tuple[dict[str, object], LLMCompletion]:
     """
@@ -1626,9 +1737,13 @@ def _call_writer(client: LLMClient, context: dict[str, object]) -> tuple[dict[st
     # Buy-zone enforcement is anchor-gated (#2010): the validator stays
     # output-only; the context decides whether the rule applies.
     require_buy_zone = context.get("price_anchor") is not None
+    # #2431 — the subject travels into the validator the same way, because the
+    # check is about the memo AGAINST its context and neither half means
+    # anything alone.
+    subject = context.get("instrument")
 
     def _validate(data: dict[str, object]) -> None:
-        _validate_writer_output(data, require_buy_zone=require_buy_zone)
+        _validate_writer_output(data, require_buy_zone=require_buy_zone, subject=subject)
 
     return _call_with_one_retry(
         client,
@@ -1640,7 +1755,7 @@ def _call_writer(client: LLMClient, context: dict[str, object]) -> tuple[dict[st
     )
 
 
-def _validate_writer_output(data: dict[str, object], *, require_buy_zone: bool = False) -> None:
+def _validate_writer_output(data: dict[str, object], *, require_buy_zone: bool = False, subject: object = None) -> None:
     required = {
         "thesis_type",
         "confidence_score",
@@ -1687,6 +1802,26 @@ def _validate_writer_output(data: dict[str, object], *, require_buy_zone: bool =
     placeholder = _PLACEHOLDER_RE.search(memo)
     if placeholder is not None:
         raise ValueError(f"Writer output contains an unfilled placeholder: {placeholder.group(0)!r}")
+
+    # #2431 — SUBJECT IDENTITY, enforced rather than requested. The system
+    # prompt already forbids this in capitals ("Never write the memo about a
+    # different company") and the writer prompt names the subject on its FIRST
+    # line; on prompt v6 the compliance rate with both is 0 of 127. An
+    # instruction the model ignores is not a control.
+    #
+    # ⚠⚠ REFUSED, NOT REPAIRED. The memo misattributes real financial data — the
+    # figures in it are the SUBJECT's, rendered under another company's name —
+    # and the row's valuation band is anchored to whatever price the confabulated
+    # company had. `portfolio.py` reads `base_value` as an EXIT trigger, so a
+    # stored row is not inert. Storing nothing is the honest outcome; this rides
+    # the retry-once machinery first, so a one-off lapse still gets a second
+    # attempt.
+    if not _memo_names_subject(memo, subject):
+        named = subject.get("symbol") if isinstance(subject, dict) else None
+        raise ValueError(
+            f"Writer output never names its subject ({named or 'unknown'}) — the memo is about a different "
+            "company, and every figure in it belongs to the subject"
+        )
 
     # Valuation-band coherence (#2007): the stored band must satisfy
     # bear <= base <= bull, and the buy zone low <= high. Local writers

--- a/scripts/verify_2431_subject_identity.py
+++ b/scripts/verify_2431_subject_identity.py
@@ -1,0 +1,99 @@
+"""Full-corpus verification of the thesis subject-identity gate (#2431).
+
+    PYTHONPATH=. uv run python scripts/verify_2431_subject_identity.py
+
+⚠ NOTHING IS WRITTEN. Reads every stored memo and reports whether it names its
+own instrument. Gate on the EXIT CODE — 0 means the gate is still safe to ship,
+1 means it has started rejecting memos from a population where the writer was
+demonstrably correct.
+
+⚠ NEVER PIPE THIS INTO ``head``/``tail`` — a pipe returns the pipe's status, so
+a failure reads as success (`.claude/CLAUDE.md`). Redirect and read the file.
+
+WHAT THE NUMBERS MEAN, AND WHICH ONE IS LOAD-BEARING
+----------------------------------------------------
+The rejection rate on v5/v6 is the DEFECT being measured, and it is not
+evidence the gate is safe — a gate that rejects everything would score just as
+well there. The load-bearing measurement is the FALSE-POSITIVE rate on **v1-v4**,
+which are the prompt versions where the writer named the right company. A
+narrowing gate is only safe if it rejects nothing correct
+(`.claude/CLAUDE.md`: "a NARROWING gate → enumerate what it REJECTS").
+
+Measured 2026-08-08 on the dev corpus:
+
+    ver      n   REJECTS   reject-rate
+     v1     25         0       0.0%
+     v2     36         0       0.0%
+     v3     71         0       0.0%
+     v4    355         0       0.0%      <- 487 known-good memos, ZERO rejected
+     v5   2038      1378      67.6%
+     v6    127       127     100.0%
+
+⚠ These move as the corpus grows. Re-run rather than citing them; that is the
+whole reason this file exists rather than a number in a docstring.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+
+import psycopg
+
+from app.config import settings
+from app.services.thesis import _memo_names_subject
+
+#: Prompt versions where the writer demonstrably named the right company, so a
+#: rejection here is a FALSE POSITIVE and the gate must not ship.
+KNOWN_GOOD_VERSIONS = frozenset({"v1", "v2", "v3", "v4"})
+
+_SQL = """
+    SELECT t.prompt_version, t.thesis_id, i.symbol, i.company_name, t.memo_markdown
+    FROM theses t
+    JOIN instruments i USING (instrument_id)
+    WHERE t.memo_markdown IS NOT NULL
+    ORDER BY t.prompt_version, t.thesis_id
+"""
+
+
+def main() -> int:
+    with psycopg.connect(settings.database_url) as conn:
+        rows = conn.execute(_SQL).fetchall()
+
+    buckets: dict[str, list[tuple[int, bool, str, str]]] = defaultdict(list)
+    for prompt_version, thesis_id, symbol, company_name, memo in rows:
+        subject = {"symbol": symbol, "company_name": company_name}
+        buckets[str(prompt_version or "?")].append(
+            (int(thesis_id), _memo_names_subject(str(memo), subject), str(symbol), str(memo)[:70].replace("\n", " "))
+        )
+
+    print(f"{'ver':>4}  {'n':>5}  {'passes':>6}  {'REJECTS':>7}   reject-rate")
+    for version in sorted(buckets):
+        entries = buckets[version]
+        rejects = sum(1 for entry in entries if not entry[1])
+        rate = rejects / len(entries) * 100.0
+        print(f"{version:>4}  {len(entries):>5}  {len(entries) - rejects:>6}  {rejects:>7}   {rate:6.1f}%")
+
+    false_positives = [
+        (version, entry)
+        for version, entries in buckets.items()
+        if version in KNOWN_GOOD_VERSIONS
+        for entry in entries
+        if not entry[1]
+    ]
+
+    print(f"\n=== FALSE-POSITIVE AUDIT: rejections on {'/'.join(sorted(KNOWN_GOOD_VERSIONS))} ===")
+    if not false_positives:
+        checked = sum(len(buckets[v]) for v in KNOWN_GOOD_VERSIONS if v in buckets)
+        print(f"  NONE — the gate rejects 0 of {checked} memos from the known-good populations.")
+        return 0
+
+    for version, (thesis_id, _ok, symbol, head) in false_positives[:25]:
+        print(f"  {version} thesis {thesis_id} [{symbol}] {head}")
+    print(f"\n  !! {len(false_positives)} FALSE POSITIVE(S). The gate rejects memos the writer got RIGHT.")
+    print("  !! Do not ship it in this form — widen the accepted spellings until this is zero.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -1648,6 +1648,40 @@ class TestSubjectIdentityGate:
         clause, and they are why it exists."""
         assert _memo_names_subject(memo, {"symbol": "ZZZZ", "company_name": company})
 
+    @pytest.mark.parametrize(
+        ("memo", "subject", "expected", "why"),
+        [
+            (
+                "BP reported strong earnings.",
+                {"symbol": "BP", "company_name": "BP plc"},
+                True,
+                "a 2-char symbol whose name is also short must still work in plain prose",
+            ),
+            ("MMM raised guidance.", {"symbol": "MMM", "company_name": "3M"}, True, "3M"),
+            ("Gap Inc. comped positive.", {"symbol": "GAP", "company_name": "Gap, Inc."}, True, "Gap by name"),
+            (
+                "Apple saw the valuation gap widen.",
+                {"symbol": "GAP", "company_name": "Gap, Inc."},
+                False,
+                "the English word 'gap' is not the company Gap -- this is why the short-name match is case-SENSITIVE",
+            ),
+            (
+                "Tesco grew market share.",
+                {"symbol": "TSCO", "company_name": "Tesco"},
+                True,
+                "'Tesco' must not be mangled to 'tes' by treating 'co' as a suffix",
+            ),
+            ("Citigroup trades below book.", {"symbol": "C", "company_name": "Citigroup"}, True, "not 'citi'"),
+        ],
+    )
+    def test_short_names_and_token_suffixes(self, memo: str, subject: dict[str, str], expected: bool, why: str) -> None:
+        """⚠⚠ Review round on #2434, and both findings were FALSE POSITIVES —
+        the direction that matters for a narrowing gate. Measured on the real
+        universe before fixing: substring suffix-stripping mangles **1,820 of
+        12,696** names, and **97** instruments have both a short symbol and a
+        name too short to carry the check (3M, Gap, NOV, AES, FMC)."""
+        assert _memo_names_subject(memo, subject) is expected, why
+
     def test_the_validator_refuses_the_whole_output(self) -> None:
         """End-to-end through the real validator, not just the predicate."""
         bad = dict(_VALID_WRITER)

--- a/tests/test_thesis.py
+++ b/tests/test_thesis.py
@@ -30,6 +30,7 @@ from app.services.thesis import (
     _call_critic,
     _call_writer,
     _evaluable_prices,
+    _memo_names_subject,
     _news_spike_fired,
     _price_move_fired,
     _shape_analytics_evidence,
@@ -1554,3 +1555,108 @@ class TestPriceMovePctGuard:
 
         assert _price_move_pct(65.0, 100.0) == pytest.approx(-0.35)
         assert _price_move_pct(105.0, 100.0) is None  # +5% under threshold
+
+
+class TestSubjectIdentityGate:
+    """#2431 — the memo must name the company it is about.
+
+    ⚠ The bug this closes is not cosmetic. The writer produced memos titled
+    "Microsoft Corporation (MSFT)" and "Apple Inc. (AAPL)" on an OTEX row while
+    rendering OTEX's own figures, and the stored valuation band was anchored to
+    the confabulated company's price — `portfolio.py` reads `base_value` as an
+    exit trigger, so the row is not inert.
+
+    ⚠⚠ The system prompt ALREADY forbids this in capitals and the writer prompt
+    names the subject on its first line. Compliance on prompt v6 was 0 of 127.
+    These tests exist because an instruction the model ignores is not a control.
+    """
+
+    SUBJECT = {"symbol": "OTEX", "company_name": "Open Text Corp"}
+
+    @pytest.mark.parametrize(
+        ("memo", "why"),
+        [
+            ("OTEX trades at 9x trailing earnings.", "the symbol, on a word boundary"),
+            ("Open Text Corp is a compounder.", "the full name as stored"),
+            ("OpenText Corporation delivers strong FCF.", "the company's own one-word spelling"),
+            ("open text corp — cash generative", "case-insensitive"),
+            ("A long memo. Later on, OTEX looks cheap.", "not required to be in the first sentence"),
+        ],
+    )
+    def test_a_memo_naming_its_subject_passes(self, memo: str, why: str) -> None:
+        assert _memo_names_subject(memo, self.SUBJECT), why
+
+    @pytest.mark.parametrize(
+        ("memo", "why"),
+        [
+            ("### **Apple Inc. (AAPL)** Apple demonstrates strong fundamentals.", "a different real company"),
+            ("Investment Memo: Microsoft Corporation (MSFT)", "the observed OTEX failure verbatim"),
+            ("### **Company Analysis: XYZ Corp (NYSE: XYZ)**", "a template placeholder as the subject"),
+            ("The subject is a turnaround candidate trading below book.", "never names anyone at all"),
+        ],
+    )
+    def test_a_memo_that_never_names_its_subject_is_refused(self, memo: str, why: str) -> None:
+        assert not _memo_names_subject(memo, self.SUBJECT), why
+
+    def test_a_common_word_symbol_does_not_match_ordinary_prose(self) -> None:
+        """⚠⚠ Codex checkpoint 2. 2,186 of 12,696 symbols are <= 3 characters
+        and many are ordinary words. A bare case-insensitive match would let an
+        Apple memo satisfy an ON Semiconductor row on the word "on"."""
+        subject = {"symbol": "ON", "company_name": "ON Semiconductor Corp"}
+        assert not _memo_names_subject("Apple is executing on AI across the estate.", subject)
+
+    def test_a_short_symbol_still_matches_where_a_TICKER_appears(self) -> None:
+        subject = {"symbol": "ON", "company_name": "ON Semiconductor Corp"}
+        assert _memo_names_subject("The subject (ON) trades at 12x.", subject)
+        assert _memo_names_subject("NASDAQ: ON is cyclical.", subject)
+
+    def test_a_shared_leading_token_does_not_carry_the_match(self) -> None:
+        """⚠⚠ Codex checkpoint 2, and the reason the fallback is a PREFIX of the
+        name rather than its leading token: 3,360 companies (26.5%) share a
+        >= 5-character lead with a different issuer. "Apple Hospitality REIT"
+        must not accept a memo about Apple Inc."""
+        subject = {"symbol": "APLE", "company_name": "Apple Hospitality REIT Inc"}
+        assert not _memo_names_subject("### **Apple Inc. (AAPL)** Apple demonstrates strong fundamentals.", subject)
+        assert _memo_names_subject("Apple Hospitality REIT owns select-service hotels.", subject)
+
+    def test_naming_a_peer_alongside_the_subject_is_fine(self) -> None:
+        """⚠ PRESENCE, not exclusivity — the system prompt explicitly allows
+        "versus <peer>" comparisons, so a gate demanding the subject be the only
+        company named would reject correct memos."""
+        assert _memo_names_subject("OTEX trades at a discount versus Microsoft and Adobe.", self.SUBJECT)
+
+    def test_a_generic_leading_token_does_not_carry_the_match_alone(self) -> None:
+        """⚠ The >= 5 bound on the leading token, which is measured and not
+        chosen: "Open" is the lead of "Open Text Corp" and is far too generic —
+        a memo about anything can say "open". The six-character prefix
+        ("opente") is what identifies this subject."""
+        assert not _memo_names_subject("The company has an open architecture and open standards.", self.SUBJECT)
+
+    def test_a_short_leading_token_still_matches_via_the_full_name(self) -> None:
+        assert _memo_names_subject("Open Text's renewals are sticky.", self.SUBJECT)
+
+    @pytest.mark.parametrize(
+        ("company", "memo"),
+        [
+            ("Axalta Coating Systems Ltd", "Axalta exhibits robust fundamentals."),
+            ("Costco Wholesale Corp", "Costco maintains strong fundamentals."),
+        ],
+    )
+    def test_the_short_form_of_a_long_name_passes(self, company: str, memo: str) -> None:
+        """⚠ These two are not hypotheticals — they were the ONLY false
+        positives across 487 known-good v1-v4 memos before the leading-token
+        clause, and they are why it exists."""
+        assert _memo_names_subject(memo, {"symbol": "ZZZZ", "company_name": company})
+
+    def test_the_validator_refuses_the_whole_output(self) -> None:
+        """End-to-end through the real validator, not just the predicate."""
+        bad = dict(_VALID_WRITER)
+        bad["memo_markdown"] = "### Investment Memo: Microsoft Corporation (MSFT)"
+        with pytest.raises(ValueError, match="never names its subject"):
+            _validate_writer_output(bad, subject=self.SUBJECT)
+
+    def test_no_subject_supplied_does_not_gate(self) -> None:
+        """⚠ Fails OPEN on a missing subject deliberately: the check is about a
+        memo against ITS context, and with no context there is nothing to
+        contradict. The schema gates still apply."""
+        _validate_writer_output(dict(_VALID_WRITER), subject=None)


### PR DESCRIPTION
## What

The thesis on `/instrument/OTEX` was titled **"Microsoft Corporation (MSFT)"**. Regenerated, it became **"Apple Inc. (AAPL)"**. OTEX closes at **\$24.48**; the memo asserted \$50.85 and a 52-week high of \$524.00, and the stored band (`base_value 62.69`, `buy_zone 55.61-69.79`) is anchored to that fiction.

**0 of 127 v6 memos name their own instrument.**

## It is not bleed — that was checked first, and the plumbing is correct

I built the real prompt rather than reasoning about it. Every query in `_assemble_context` is `WHERE instrument_id = %(id)s`, and the payload opens:

```text
SUBJECT: Open Text Corp (OTEX) - write the memo about this company and no other.

{ "instrument": { "symbol": "OTEX", "company_name": "Open Text Corp", ... }
```

`OTEX` appears **5 times**. `_WRITER_SYSTEM` then forbids both observed failures in capitals — *"Never write the memo about a different company"* and *"NO PLACEHOLDERS … never emit a bracketed stand-in"*.

The model complies with none of it. **An instruction the model ignores is not a control**, so this change makes it one.

## Why a gate and not another prompt edit

This is the third attempt at the same bug and the first two were prose:

- `_build_writer_prompt`'s own docstring records **#2235 — "a GME memo written about Yelp while citing GME's own margins to 4dp"** — remediated by adding the SUBJECT line. It did not hold.
- v6 then added the SUBJECT IDENTITY and NO PLACEHOLDERS rules quoted above.

| prompt | context | names its own company |
| --- | --- | --- |
| v3 / v4 | small | **100%** (426/426) |
| v5 | context expanded | **32.1%** |
| v6 | v5 + explicit rules against these two failures | **0.0%** |

⚠⚠ **v6 added rules against exactly this and compliance went 32.1% → 0%.** At v5's rate ~39 of 127 would comply; 0 is not chance. Adding text to a saturated model made it worse — the payload is **~26,400 chars (~6,600 tokens)** into `qwen3:14b`.

⚠ The existing `_PLACEHOLDER_RE` gate catches only `[bracketed]` / `<angled>` forms, which is why bare `XYZ Corp` and `Apple Inc.` sail through it. One identity gate closes both failure modes.

## Full-population verification

`scripts/verify_2431_subject_identity.py`, every stored memo. Exit 0.

```text
 ver      n  passes  REJECTS   reject-rate
  v1     25      25        0      0.0%
  v2     36      36        0      0.0%
  v3     71      71        0      0.0%
  v4    355     355        0      0.0%
  v5   2038     653     1385     68.0%
  v6    127       0      127    100.0%

FALSE-POSITIVE AUDIT: NONE - 0 of 487 memos from the known-good populations.
```

⚠ **The load-bearing number is the first four rows, not the last two.** The v5/v6 rejection rate is the defect being measured; a gate that rejected everything would score identically there. What makes it *safe* is rejecting nothing from the populations where the writer demonstrably named the right company (`.claude/CLAUDE.md`: a narrowing gate must enumerate what it rejects). The harness exits 1 if that ever stops being true.

## Codex checkpoint 2 found two real holes, both measured before fixing

Both were false-*negatives* — ways a wrong-company memo could still pass.

1. **Common-word symbols.** `ON`, `IT`, `ALL`, `KEY` — **2,186 of 12,696 symbols (17.2%) are ≤ 3 characters.** A case-insensitive bare match let *"Apple is executing on AI"* satisfy an ON Semiconductor row. Now: symbols match **case-sensitively**, and a short symbol must appear where a ticker appears — `(ON)`, `NASDAQ: ON` — not anywhere in prose.
2. **Shared leading tokens.** **3,360 companies (26.5%) share a ≥ 5-character lead with a different issuer.** `Apple Hospitality REIT Inc` accepted a memo titled `Apple Inc. (AAPL)`. The name fallback is now a **six-character prefix of the squashed name**, not the lead token: `axalta` and `costco` still match their long names, while Apple Hospitality needs `appleh`, which an Apple Inc memo does not contain.

Both are regression-tested by name.

## Behaviour

Refused, **not repaired**, and it rides the existing retry-once machinery first, so a one-off lapse still gets a second attempt. On a second failure `generate_thesis` records a thesis-run failure and re-raises — audited, not silent.

⚠ **This will refuse most generations until the underlying cause is fixed.** That is the intended outcome, not a side effect: the memo misattributes real financial data, and `portfolio.py` reads `base_value` as an **exit trigger** (line 634, `current_price >= base_value`), so a stored row is not inert. Storing nothing is the honest state.

## What this does NOT fix

Containment, not a cure. The cause is instruction-adherence collapse at ~6,600 tokens in a 14B model, and the two real fixes are operator-gated:

1. a model that can hold the instruction;
2. shrinking the context toward the v3/v4 shape — the *same* model scored 100% there, so this is a measurable experiment, not a guess.

Still outstanding and **not** in this PR: the 1,512 already-stored wrong-company rows, whose bands `portfolio.py` still reads.

## Security

No new input surface, no auth path, no SQL. Adds an output-validation refusal to an existing validator. Strictly narrowing — it can only prevent a write.

## Verification

| check | result |
| --- | --- |
| Full-corpus harness | exit 0, 0/487 false positives |
| Real OTEX memos | all three refused (Apple, Microsoft, XYZ Corp) |
| Positive controls | `OTEX`, `Open Text`, `OpenText Corporation` all pass |
| Revert-probe | gate disabled → tests FAIL; restored → PASS |
| Gates | ruff / format / pyright / fast tier / smoke all exit 0 |

Refs #2431.