### PR TITLE
fix(#2433): holdout_never_evaluated follows the ledger, not the invocation

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -1482,10 +1482,27 @@ def _candidate(
     )
 
 
-def _expected_refusals(*, holdout_requested: bool, deflated: bool) -> frozenset[PromotionRefusal]:
-    """What §9's table says a row from THIS invocation must still refuse on."""
+def _expected_refusals(
+    *, holdout_requested: bool, deflated: bool, prior_holdout_evaluations: int = 0
+) -> frozenset[PromotionRefusal]:
+    """What §9's table says a row from this run must still refuse on.
+
+    ⚠⚠ ``holdout_never_evaluated`` IS A PROPERTY OF THE STRATEGY VERSION, NOT OF
+    THIS INVOCATION (#2433). ``check_promotable`` derives it from the LEDGER —
+    stored hold-out rows and recorded ``evaluate`` accesses for the
+    ``(strategy_id, strategy_version)`` pair — so predicting it from
+    ``holdout_requested`` alone is only right on a FIRST run. Once a version has
+    been hold-out evaluated, an in-sample-only re-run legitimately does not carry
+    the refusal, and this function used to insist it did.
+
+    It was unreachable until #2426: ``assert_no_existing_results`` refused any
+    re-run whose ``result_version`` already existed, so a second invocation never
+    reached the check. Adding ``benchmark_rule`` to the identity hash moved every
+    version, made a re-run possible for the first time, and the corrected
+    buy-and-hold run rejected here after a full corpus pass.
+    """
     expected = set(STANDING_REFUSALS)
-    if not holdout_requested:
+    if not holdout_requested and prior_holdout_evaluations <= 0:
         expected.add("holdout_never_evaluated")
     if not deflated:
         expected.update({"deflated_sharpe_not_computed", "trial_count_undeclared"})
@@ -1794,7 +1811,14 @@ def _write_rows(
                 )
                 pending.append((strategy_id, namespace, ambiguity, masked, admitted))
 
-    _preflight_gate(pending, validated=validated, holdout_requested=holdout_requested)
+    # ⚠ Read ONCE, before anything is written, so the preflight prediction and
+    # the post-write re-measure share a source (#2433).
+    prior_holdout: dict[tuple[str, str], int] = {}
+    for _strategy_id, _namespace, _ambiguity, masked, _admitted in pending:
+        key = (masked.identity.strategy_id, masked.identity.strategy_version)
+        if key not in prior_holdout:
+            prior_holdout[key] = holdout_access_counts(conn, *key).holdout_evaluations
+    _preflight_gate(pending, validated=validated, holdout_requested=holdout_requested, prior_holdout=prior_holdout)
     splits = _cut_splits(arms, corpus=corpus)
     _assert_every_in_sample_row_has_a_split(pending, splits)
 
@@ -1846,7 +1870,14 @@ def _write_rows(
                 recorded_accesses=accesses,
             )
         )
-        expected = _expected_refusals(holdout_requested=holdout_requested, deflated=result.deflated is not None)
+        # ⚠ The SAME ``evaluations`` the outcome was derived from. Predicting the
+        # expectation from a different source than the actual is exactly the
+        # mismatch #2433 was.
+        expected = _expected_refusals(
+            holdout_requested=holdout_requested,
+            deflated=result.deflated is not None,
+            prior_holdout_evaluations=evaluations,
+        )
         if set(outcome) != expected:
             raise RuntimeError(
                 f"{identity.strategy_id} {identity.namespace}/{identity.quarantine_arm} stored with refusals "
@@ -1980,6 +2011,7 @@ def _preflight_gate(
     *,
     validated: frozenset[int],
     holdout_requested: bool,
+    prior_holdout: Mapping[tuple[str, str], int],
 ) -> None:
     """The refusal list every row WILL carry, checked before anything is stored.
 
@@ -1988,8 +2020,15 @@ def _preflight_gate(
     refuses a row without one), so the two counts are equal by construction and
     the gate's ``recorded_accesses < holdout_evaluations`` clause cannot fire on
     a row this job wrote.
+
+    ⚠⚠ THE PROJECTION STARTS FROM WHAT THE LEDGER ALREADY HOLDS (#2433), not
+    from zero. A strategy version hold-out evaluated by an EARLIER run carries
+    those rows into ``check_promotable`` at write time, so a projection counting
+    only this run's pending rows predicts a refusal set the stored rows will not
+    have — and a gate whose prediction is wrong cannot catch the mismatch it
+    exists for.
     """
-    projected: Counter[tuple[str, str]] = Counter()
+    projected: Counter[tuple[str, str]] = Counter(prior_holdout)
     for _strategy_id, namespace, _ambiguity, masked, admitted in pending:
         if namespace == "hold_out":
             for result in (masked, admitted):
@@ -2011,7 +2050,13 @@ def _preflight_gate(
                     recorded_accesses=count,
                 )
             )
-            expected = _expected_refusals(holdout_requested=holdout_requested, deflated=result.deflated is not None)
+            expected = _expected_refusals(
+                holdout_requested=holdout_requested,
+                deflated=result.deflated is not None,
+                prior_holdout_evaluations=prior_holdout.get(
+                    (result.identity.strategy_id, result.identity.strategy_version), 0
+                ),
+            )
             if set(outcome) != expected:
                 raise RuntimeError(
                     f"{result.identity.strategy_id} {result.identity.namespace}/"

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -228,6 +228,36 @@ class TestExpectedRefusals:
             "holdout_never_evaluated"
         }
 
+    @pytest.mark.parametrize(
+        ("holdout_requested", "prior", "expects_never_evaluated"),
+        [
+            (False, 0, True),  # first run, in-sample only -- the refusal applies
+            (False, 12, False),  # RE-RUN of a version already hold-out evaluated (#2433)
+            (True, 0, False),  # this run evaluates the hold-out
+            (True, 12, False),  # both -- still evaluated
+        ],
+    )
+    def test_holdout_never_evaluated_follows_the_LEDGER_not_the_invocation(
+        self, holdout_requested: bool, prior: int, expects_never_evaluated: bool
+    ) -> None:
+        """#2433 — ``check_promotable`` derives this refusal from stored hold-out
+        rows, so predicting it from ``holdout_requested`` alone is right only on
+        a FIRST run.
+
+        ⚠ Row two is the one that mattered: it was unreachable until #2426 moved
+        every ``result_version``, and the first re-run it allowed rejected after
+        a full corpus pass with the corrected buy-and-hold numbers unwritten.
+        """
+        refusals = _expected_refusals(
+            holdout_requested=holdout_requested, deflated=True, prior_holdout_evaluations=prior
+        )
+        assert ("holdout_never_evaluated" in refusals) is expects_never_evaluated
+
+    def test_a_prior_evaluation_does_not_disturb_the_other_refusals(self) -> None:
+        assert _expected_refusals(
+            holdout_requested=False, deflated=False, prior_holdout_evaluations=12
+        ) == STANDING_REFUSALS | {"deflated_sharpe_not_computed", "trial_count_undeclared"}
+
     def test_no_dsr_adds_both_criterion_6_refusals(self) -> None:
         """⚠ TWO codes, not one. A DSR with no trial count is as refused as no
         DSR at all, and collapsing them would make "which of the two is missing"


### PR DESCRIPTION
## What

The corrected #2426 backtest run (request 250) completed the **whole corpus pass** and then rejected at the write assertion. Nothing written.

```text
s1-time-series-momentum in_sample/masked stored with refusals
  [carry_unmodelled, synthetic_control_not_run, universe_basis_not_survivorship_free]
against the expected
  [carry_unmodelled, holdout_never_evaluated, synthetic_control_not_run, universe_basis_not_survivorship_free]
```

## Root cause

`check_promotable` derives `holdout_never_evaluated` from the **ledger** — stored hold-out rows and recorded `evaluate` accesses for the `(strategy_id, strategy_version)` pair, read via `holdout_access_counts`.

`_expected_refusals` derived it from **this invocation's** arguments:

```python
if not holdout_requested:
    expected.add("holdout_never_evaluated")
```

Those agree only on a **first** run. `holdout_never_evaluated` is a property of the strategy version's history, not of whichever invocation happens to be writing — so once a version has been hold-out evaluated, an in-sample-only re-run legitimately does not carry the refusal, and the assertion fires.

The mismatch is visible in one function: `_write_rows` reads the real counts at line 1837 and then predicts the expectation from a different source at line 1849.

## Why it surfaced now

Unreachable until #2426. `assert_no_existing_results` refused any re-run whose `result_version` already existed, so a second invocation never reached the check. Adding `benchmark_rule` to the identity hash moved every version and made a re-run possible for the first time — and the first one it allowed hit this.

⚠ #2426's tail, not a fault in it: the fix unblocked a path whose assumptions nobody had been able to exercise.

## The fix — one source of truth on both sides

1. **Post-write re-measure** reuses the same `evaluations` its outcome was derived from.
2. **Preflight projection starts from the ledger** rather than from zero.

The second is the part worth arguing. Preflight's docstring calls itself *"the refusal list every row WILL carry, checked before anything is stored"*. Projecting only this run's pending rows meant that on a re-run it predicted a refusal set the stored rows would not have — so it would pass, and then the post-write check would be the thing that noticed. Both sides now read the ledger once, before anything is written. **A gate whose prediction is wrong cannot catch the mismatch it exists for.**

## What this deliberately does NOT do

It does not re-run the hold-out. The alternative unblock — supplying `holdout_purpose` + `holdout_accessed_by` so `holdout_requested=True` and the expectation matches — would record a **second hold-out evaluation** of the same `strategy_version`, and criterion 5 exists to make exactly that expensive. Nothing about the strategies changed between the runs; only the benchmark's composition, which is a measurement instrument and not a strategy parameter. Spending a hold-out look to work around an assertion bug is the wrong trade.

✅ The failed run cost nothing: `strategy_holdout_accesses` is still 12 rows, all stamped `2026-08-08T11:23:41Z` from the original run. It rejected before recording any access.

## Verification

| check | result |
| --- | --- |
| Table test, four cases (`holdout_requested` × prior) | pass — row two is the re-run case that was broken |
| Revert-probe | ledger ignored → tests FAIL; restored → PASS |
| Codex checkpoint 2 | *"I did not find a discrete regression introduced by this patch."* |
| Gates | ruff / format / pyright / fast tier / smoke all exit 0 |

⚠ `-m db` on the touched files collects nothing — this is pure logic and the fast tier covers it.

## What is still needed after merge

The corrected numbers still do not exist. `strategy_results_store` holds only the 24 pre-#2426 rows at `benchmark_rule = equal_weight_concurrent_v1` and the 33,706,844% comparator. Once this merges, re-trigger:

```bash
curl -X POST localhost:8000/jobs/strategy_backtest_run/run \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{}'
```

Expect 12 in-sample rows at `equal_weight_buy_and_hold_v1`. ⚠ The 12 stale hold-out rows stay on the old comparator; whether to re-measure them is a real criterion-5 spend and is the operator's call, not this PR's.

## Security

No new input surface, no auth path, no SQL construction. Adds a read of an existing counting helper (`holdout_access_counts` — pure `count(*)`, records nothing) and widens one predicate. Strictly a gate-expectation correction.

Closes #2433. Refs #2426. Refs #2394.