### PR TITLE
feat(#2437): the signal was on the short side — one arm survives every check

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,9 +19,20 @@ You are helping build **eBull**, a long-horizon AI-assisted investment engine fo
 
 - Demo-first
 - Small-capital live later
-- Long only in v1
-- No leverage
-- No shorting
+- **Shorting: PERMITTED for research and paper trading** (operator decision, 2026-08-09,
+  reversing "long only in v1" / "no shorting"). ⚠ Gated on the same bar as everything
+  else: *"we need to trust the strategies though"* — validated in backtest, then paper,
+  before any cash. ⚠⚠ A short on eToro is a **CFD**, not stock: contract with the broker,
+  no ownership. Easy-to-borrow costs spread only; **hard-to-borrow (>10% annual) accrues a
+  daily fee at 21:00 GMT, tripled at weekends** — and a name that just fell 12% is the
+  archetypal hard-to-borrow candidate, so the cost model cannot reuse the long one.
+  Shorting is also restricted by share availability, volatility halts, and region.
+  ⚠⚠ Short losses are unbounded, so a mean return is not a sufficient basis for a short
+  strategy — the tail and the delisting attribution decide (see #2437).
+- **No leverage — still barred, and deliberately sequenced after validation** (operator,
+  2026-08-09: *"I'd lean to leverage once we have validated that we have a high level of
+  success first"*). ⚠ Note a CFD short at x1 is unleveraged exposure and does not breach
+  this; anything above x1 does.
 - No silent bypass of failed checks
 
 ## Engineering discipline (non-negotiable)

--- a/.claude/skills/quant/data-capability.md
+++ b/.claude/skills/quant/data-capability.md
@@ -35,7 +35,7 @@ ownership_insiders_*           ~300K
 def14a_beneficial_holdings     110,832
 benchmark/sector series        102,027   16 comparators, SPY 1993-01-29 -> 2024-09-27
 quotes                           1,557   ⚠ LATEST only, one row per instrument
-price_intraday                       0   ⚠ table exists, empty
+price_intraday                       0   ⚠ empty = BUILD gap, NOT a data gap (see below)
 ```
 
 ---
@@ -55,6 +55,49 @@ operator corrected it more than once.** The accurate statement:
 | tick-level updates | depth beyond L1 |
 | all instruments (on subscription) | trade-side / aggressor classification |
 | observed `spread_pct` | reliable traded volume |
+
+### ⚠⚠ And the WebSocket is only HALF the answer — we also have REST intraday HISTORY
+
+The table above was still not the full correction, which is why the error kept
+regenerating: it describes the LIVE feed, so a reader who wants *history* concludes
+we must record it forward from today. **We do not.**
+
+`EtoroMarketDataProvider.get_intraday_candles` serves intraday OHLCV on demand, per
+instrument, right now. Measured 2026-08-09 on AAPL at `count=1000`:
+
+| interval | reach back |
+| --- | --- |
+| `OneMinute` | ~2 days |
+| `FiveMinutes` | ~5 days |
+| `ThirtyMinutes` | ~1 month |
+| `OneHour` | ~2 months |
+| `FourHours` | **~8 months** |
+
+⚠ `count` caps at 1000 and **the URL carries no date anchor** — always the *last* N
+bars, so reach is a pure function of interval and going deeper does require polling
+forward. ⚠ Volume IS populated. ⚠ Extended hours ARE included, so an RTH-only study
+must filter sessions itself.
+
+⚠⚠ **This matters for what we can test, not just what we hold.** Brogaard/Han/Kim's
+intraday residual reversal — the strongest recent price-only evidence found in the
+#2437 sweep, sample through Dec 2022 — is measured on **30-minute midpoints**, which
+is exactly what this endpoint returns for the last month.
+
+⚠ Rate limit binds the corpus, not the capability: **60 GET/min shared** means a full
+6,700-instrument pass is ~112 minutes per interval and competes with every other eToro
+call. A cross-sectional intraday study is a scheduled harvest, not an ad-hoc query.
+
+**Three distinct capabilities. Collapsing them is the error itself:**
+
+| capability | gives | limit |
+| --- | --- | --- |
+| REST intraday candles | OHLCV history on demand | 1000 bars, no date anchor, 60 GET/min |
+| WS rate stream | live bid/ask/last, all instruments | **no depth, no sizes** — the real gap |
+| `research_price_daily` | 25.9M daily bars 1962-2026 | daily granularity |
+
+Source of truth: `.claude/skills/data-sources/etoro-api.md` § "WE HAVE INTRADAY
+HISTORY". Probe before asserting:
+`curl -s "http://localhost:8000/_debug/etoro-candles-probe?instrument_id=1001&count=1000&interval=FourHours"`
 
 ⚠ Every occurrence of "size" in `app/services/etoro_websocket.py` refers to
 **WebSocket frame bytes**, not order size. Verified by grep, not assumed.

--- a/.claude/skills/quant/measurement-discipline.md
+++ b/.claude/skills/quant/measurement-discipline.md
@@ -22,7 +22,7 @@ by a test.
 
 ---
 
-## 1. ⚠⚠ The five ways we have actually fooled ourselves
+## 1. ⚠⚠ The eight ways we have actually fooled ourselves
 
 ### 1.1 Pooling correlated observations as independent — the most expensive one
 
@@ -105,6 +105,91 @@ defect is the population of one, regardless of whether the sentence is true.
 > quantifier.**
 
 ---
+
+### 1.6 ⚠⚠ The univariate instrument — testing one condition and reporting the null
+
+**This is the biggest methodological error of the 2026-08-09 pass, and it produced
+three false nulls in a row.**
+
+Gap fade, 12-month momentum, one-day loser reversal: each tested as ONE condition,
+averaged across the whole cross-section, each returning nothing after costs and
+clustering, each written up as "the effect is dead".
+
+⚠⚠ **That conclusion does not follow.** A marginal test estimates `E[r | A]`. A
+trader claiming a setup is claiming `E[r | A,B,C,D,E]`. Those can have **opposite
+signs**. If an edge exists only where several conditions co-occur, then measuring
+each alone returns ~zero *by construction* — the firings where the others were
+absent swamp the few where they were present. The instrument cannot detect the
+thing, and the null it produces is about the instrument.
+
+⚠ Three failed univariate tests are **one** piece of evidence about univariate
+tests, not three about the market. Do not let them accumulate into a verdict.
+
+**Evidence:** Gu, Kelly & Xiu (NBER w25398) — ML asset-pricing gains come materially
+from **nonlinear predictor interactions**. Lo, Mamaysky & Wang (JF 2000) — technical
+patterns must be made algorithmic and tested as **conditional distributions**.
+
+**Our own proof, and it was sitting in the output:** buying a one-day −5% drop is
+−437 bps at breadth 2-5 and **+91 bps at breadth 101+**. Same signal, opposite sign,
+on a conditioning variable that was simply not being measured. The tell was
+day-clustered and year-clustered `t` disagreeing **in sign** (−4.49 vs +1.81) — when
+two clusterings of the same data disagree that way, the outcome covaries with
+something the test is averaging over. **That disagreement is a finding, not a
+nuisance.**
+
+**Test for the conjunction with ONE degree of freedom, not 2^N.** Pre-specify the
+conditions, then bucket the outcome by **how many are simultaneously true** and look
+for a gradient. Searching all subsets on 6,700 stocks over six years manufactures a
+winner every time; a monotonic gradient across alignment counts does not.
+
+⚠ And know what a flat gradient means. Ours rose sharply from 0 to ~4 aligned and
+then went flat: **confluence identified what to avoid and not what to buy.** That is
+a real result — a filter is not a signal — and it is only visible because the
+marginals were printed alongside the buckets.
+
+### 1.7 ⚠⚠ A level type is only real if it beats its own placebo
+
+Before claiming price behaves differently at support, Fibonacci, pivots, round
+numbers or an anchored VWAP: **construct an arbitrary level of the same shape and
+measure both.** Same tolerance, same swing, same ATR unit — only the level itself
+differs. Without the placebo arm, a hit rate measures the tolerance and the fact
+that price is often mid-range, not the level.
+
+**Measured 2026-08-09 (`scripts/verify_2437_confluence.py`, 2020+, 2.35M stock-days,
+day-clustered):**
+
+```text
+      8 near support    16.78 (t 2.46)   40.47 (t 4.33)
+     P2 fake support    18.84 (t 2.82)   42.26 (t 4.65)
+    9 fib 38/50/62      14.58 (t 2.16)   38.22 (t 4.09)
+P1 fake fib 29/44/71    18.82 (t 2.79)   44.45 (t 4.76)
+```
+
+⚠⚠ **Both placebos BEAT the real thing, and both real levels sit below the
+unconditional baseline (44.28 bps).** Arbitrary fractions 29/44/71 outperform
+38.2/50/61.8; a displaced pseudo-level outperforms an actual pivot low. This matches
+the 2021 study finding Fibonacci zones do not beat non-Fibonacci zones, and goes
+further by killing support proximity too.
+
+⚠ Note what makes this conclusive rather than another null: the real condition and
+its twin are **indistinguishable, and the twin won**. That cannot be explained by
+"we measured it badly" — the same measurement was applied to both.
+
+### 1.8 ⚠⚠ Era-split before you get excited, not as a robustness check
+
+A long sample averages over market structures that no longer exist. Cut at real
+structural events — **2001 decimalisation, 2007 Reg NMS, 2019 zero commissions** —
+never arbitrary dates.
+
+The gap-down fade measured **+156 bps at t 5.73 over 1962-2026**, and **+11.8 bps at
+t 1.39 over 2020-2026**. It paid 100-180 bps a year from 2001 to 2019 and has paid
+nothing since. ⚠ Pre-2001 the sign is **negative**, so the effect existed only inside
+one 19-year regime, opened and closed by structural change.
+
+⚠⚠ **The binding consequence: for anything short-horizon the usable sample is 2020+,
+about six years.** That is a much weaker statistical position than the corpus size
+suggests, and it is the honest one. A 64-year `t 5.73` described a market we cannot
+trade in.
 
 ## 2. Traps specific to price data
 

--- a/.claude/skills/quant/strategy-evidence.md
+++ b/.claude/skills/quant/strategy-evidence.md
@@ -1207,3 +1207,69 @@ Filed as **#2441**.
 - **Quantpedia** — 900-1,200+ strategies, a subset replicated in QuantConnect.
   Use as a **hypothesis source with mechanisms attached**, never a shopping
   list. Every one taken is a declared trial.
+
+## ⚠⚠ The short side — where our own data actually has an edge (2026-08-09, #2437)
+
+**Shorting was permitted by operator decision on 2026-08-09** (research and paper
+trading; leverage still barred until validation). It immediately re-read three
+results this project had recorded as failures, and the lesson generalises:
+
+⚠⚠ **A hard constraint does not merely block strategies — it makes findings look
+like nulls.** "Buy the one-day loser" lost money monotonically and was written up as
+a null three times. It was never a null: an isolated stock that drops hard *keeps
+dropping*, which is the strongest and most consistent effect measured on our corpus.
+Long-only, that finding had no expression beyond "do not buy", so it was filed as
+absence of signal rather than presence of an inverted one.
+
+**The surviving arm — short a >=12% one-day drop, cover after 5 bars, 20% stop**
+(`scripts/verify_2437_short_stops.py`, 2020+, day-clustered, 1,364 event days):
+
+```text
+stop   gross  median  win%     t  ex-top1%   worst  net@30%/yr
+none   216.3   133.9  54.4  5.59      82.5  -41254       108.9
+ 20%   156.8    74.1  52.3  4.83      77.6   -8749        49.4
+ 12%   130.4   -68.7  48.1  4.61      81.0   -8749        23.0
+  5%    81.4  -500.0  32.2  3.94      46.6   -3429       -26.0
+```
+
+**Checks it passed that killed every sibling arm:**
+
+- ⚠ **`ex-top1%` barely moves** (82.5 → 77.6 → 81.0) as the stop tightens. Deleting
+  the best 1% of trades is the test for "is this a lottery on collapses". It is not.
+  Every **10-day** arm failed exactly here, inverting to negative.
+- **Delisting is not the driver.** Our corpus is survivorship-controlled, so a
+  backtested short collects in full from names that went to zero. Dying names are
+  0.4-1.0% of trades and their mean is *negative* at -12%; excluding them **raises**
+  the edge (333 → 341 bps).
+- **Survives borrow.** Still +49 bps net at a 30%/yr tier.
+
+⚠⚠ **A stop does not protect a short against a gap.** 141 of 1,402 stops filled at an
+OPEN above the level. Worst trade is **-87% even with the 20% stop**, and identical at
+12% and 8% — no stop level catches it. Shorts gap against you exactly when the news is
+good (takeover, trial result, beat). **Position sizing must survive -87% on one name
+regardless of the stop**; that is a concurrency and weight constraint, not a risk note.
+
+⚠ **Tighter is not safer.** Below a 20% stop the median goes negative and by 5% the
+win rate is 32%: you are stopped out of trades that would have won — spike, cover,
+then the collapse happens without you.
+
+⚠⚠ **Cost model for an eToro short is NOT the long one.** It is a CFD, not stock.
+Easy-to-borrow costs spread only; hard-to-borrow (>10%/yr) accrues daily at 21:00 GMT
+and **triple at weekends**, so borrow accrues per CALENDAR day. A name that just fell
+12% is the archetypal hard-to-borrow candidate, and eToro's docs name "temporary
+unavailability of shares to borrow" as a live restriction.
+
+⚠⚠ **Not yet a strategy.** This arm emerged from ~100 tested arms in one session, so
+`t 4.83` is a searched-over statistic — register it in `trial_register.py` with the
+full search count first. Outstanding: portfolio simulation (per-trade results say
+nothing about an equity curve at ~6 concurrent firings/day), eToro borrow
+availability at firing time, and a genuine out-of-sample window.
+
+### Why the long side kept failing, stated once
+
+⚠ Unconditional 10-day drift on the liquid universe is **44 bps against a 50 bps round
+trip.** The entire long-only short-horizon game is played inside the spread. No
+quantity of extra conditions repairs a cost problem — which is why the operator's
+shorting decision mattered more than any signal found in the same session: the short
+side has 200-440 bps of gross to work with, not 44.
+

--- a/docs/proposals/ta/2026-08-09-gap-fade-and-the-decay-finding.md
+++ b/docs/proposals/ta/2026-08-09-gap-fade-and-the-decay-finding.md
@@ -198,3 +198,91 @@ Every rule and every confirming condition is declared to `trial_register.py`
 before measurement. ⚠ Testing 10 setups × 10 conditions is **100 trials**, which
 raises the deflated-Sharpe bar to roughly the 0.174 level. Budget accordingly, or
 test fewer things properly.
+
+---
+
+## 7. The loser reversal: tested, falsified, and the gradient underneath it
+
+Codex round 5 was briefed with SEC/fundamental data **hard-forbidden** (our measured
+SEC ingest lag is a median of **2 days**, p90 37, with only 4.6% same-day — and even
+at zero latency, Form 4s are machine-parsed off EDGAR dissemination in milliseconds,
+so that race was never available). Its verdict:
+
+> **"No daily-bars-only long-only strategy is already proven, post-2020, to clear
+> 50 bps after retail costs."**
+
+It surfaced exactly one candidate: **extreme one-day loser reversal**, ~+1.1% over 10
+days after left-tail daily shocks, CRSP common stocks, sample through 2022.
+
+`scripts/verify_2437_loser_reversal.py` tests it on our own 2020-2026 data. Entry at
+the **next bar's adjusted open**, exit at the adjusted close k bars later, adjusted
+prices throughout (which kills the ex-dividend contamination ranked #1 in §2),
+day-clustered inference, universe of prior close ≥ \$20 and 20-day median dollar
+volume ≥ \$10m.
+
+```text
+     signal  hold    events  gross bps      NET   t(day)  t(year)
+unconditional  10 2,517,714      38.21   -11.79     3.59     1.92
+  1d <= -5%    10    82,712     -91.74  -141.74    -4.49    +1.81
+  1d <= -8%    10    25,644    -199.25  -249.25    -6.00    +0.30
+ 1d <= -12%    10     8,015    -333.31  -383.31    -5.72    -0.85
+```
+
+⚠⚠ **The sign is inverted and the dose-response is monotonic in both directions** —
+bigger drop is worse, longer hold is worse. **0 of 15 conditional arms** clear net > 0
+with day-clustered t ≥ 2. A monotonic gradient is far harder to dismiss than a single
+null: this is continuation, not reversal.
+
+### ⚠⚠ The clustering disagreement was a finding, not a nuisance
+
+At `1d <= -5%`, 10-day hold: **t(day) −4.49 but t(year) +1.81.** Opposite signs. Both
+can only be true if the outcome covaries with **how many names fire on the same day** —
+day-clustering weights each day equally, year-clustering pools events and is therefore
+dominated by the days carrying hundreds of them.
+
+That is a claim about mechanism, and it is directly testable. Breadth (the count of
+qualifying events sharing an entry day) is known at the close of day t, before the
+open we enter at, so conditioning on it is not lookahead.
+
+```text
+breadth   10-day hold    gross bps      NET       t    days
+  2-5                      -437.80  -487.80   -4.87     111
+ 6-20                      -154.34  -204.34   -4.45     550
+21-100                      -39.12   -89.12   -1.47     730
+ 101+                       +91.09   +41.09   +1.34     201
+```
+
+**Perfectly monotonic in breadth.** An isolated stock dropping 5% while the market is
+calm keeps falling — **−487 bps net over ten days**. The sign only turns positive when
+101+ names drop together.
+
+**Mechanism, and it is the one Codex proposed in §4.2 for the gap fade:** a lone name
+dropping is firm-specific news that reprices and *stays* repriced; a market-wide drop
+is correlated, partly forced selling that can revert. Our data now says the same thing
+from the other direction.
+
+### ⚠ Why this is still not a strategy
+
+1. ⚠⚠ **The profitable bucket is not a stock signal.** "101+ names down ≥5% on one
+   day" is a **market crash**. This is beta timing — buy-the-dip on the index — not
+   stock selection. It would not tell us *which* name to buy.
+2. **It is not significant.** t 1.34, net +41 bps.
+3. ⚠⚠ **The effective sample is far smaller than 201 days.** Those days cluster into
+   a handful of episodes (COVID, the 2022 bear). Independent events are perhaps 5-15,
+   so even t 1.34 overstates it. Codex's own arithmetic applies —
+   `N_eff = N / (1 + (N-1)·rho)` — and crash days are the maximum-rho case.
+4. **The best-evidenced version is long-short** (Brogaard/Han/Kim intraday residual
+   reversal, 30-minute midpoints, sample to Dec 2022). We are long-only, the weaker leg.
+
+### What is worth keeping
+
+⚠ **Breadth is the first conditioning variable this session with a mechanism behind it
+rather than a curve fit**, it is free to compute, it is known before entry, and it
+produced a clean monotonic gradient rather than a lone significant bucket. Carry it as
+a *feature* into any future short-horizon test; do not trade it as a signal.
+
+⚠⚠ **And the corrected capability premise:** this pass was framed around "daily bars
+only". That was false. `get_intraday_candles` serves `FourHours` ~8 months back and
+`ThirtyMinutes` ~1 month back for every instrument today — the exact granularity
+Brogaard/Han/Kim measure on. See `.claude/skills/data-sources/etoro-api.md`
+§ "WE HAVE INTRADAY HISTORY".

--- a/docs/proposals/ta/2026-08-09-plan-of-attack.md
+++ b/docs/proposals/ta/2026-08-09-plan-of-attack.md
@@ -1,0 +1,127 @@
+# Plan of attack — where #2437 stands and what to run next
+
+Written 2026-08-09 as a session handoff. ⚠ Read this before re-deriving anything;
+every number below is measured and every script named exists and runs.
+
+---
+
+## 0. The state in five lines
+
+- **One strategy candidate survives every check**: short a ≥12% one-day drop, cover
+  after 5 bars, 20% stop. `t 4.83` day-clustered, 1,364 event days, 2020+.
+- ⚠⚠ **It is not validated.** It came out of ~100 searched arms and is unregistered.
+- **Shorting is permitted** (operator, 2026-08-09). **Leverage is not**, until validated.
+- **The long side fails on COST**, not signal — 44 bps drift vs a 50 bps round trip.
+- ⚠⚠ **We have intraday history** (`FourHours` ~8 months). This was wrong four times.
+
+## 1. The candidate, precisely
+
+`scripts/verify_2437_short_stops.py`. Universe: prior close ≥ \$20, 20-day median
+dollar volume ≥ \$10m, 2020+. Entry SHORT at the next bar's adjusted open, cover at
+the adjusted close 5 bars later, stop at +20% (gap-through fills at the open).
+
+```text
+stop   gross  median  win%     t  ex-top1%   worst  net@30%/yr
+none   216.3   133.9  54.4  5.59      82.5  -41254       108.9
+ 20%   156.8    74.1  52.3  4.83      77.6   -8749        49.4
+ 12%   130.4   -68.7  48.1  4.61      81.0   -8749        23.0
+  5%    81.4  -500.0  32.2  3.94      46.6   -3429       -26.0
+```
+
+⚠⚠ **Worst trade is −87% even with the stop**, identical at 12% and 8%: no stop level
+catches a gap, and 141 of 1,402 stops filled at an open above the level. Sizing must
+survive −87% on one name.
+
+## 2. Run these next, in this order
+
+### 2a. Portfolio simulation — DO THIS FIRST
+
+Everything measured so far is **per trade**. 8,049 trades over 1,364 days is ~6
+concurrent firings per day, so sizing and concurrency decide the equity curve, not the
+per-trade mean. ⚠ A +49 bps net per-trade edge can be an excellent portfolio or a
+ruinous one purely on how many are held at once and how the −87% tail lands.
+
+Reuse `app/services/equity_curve.py`. ⚠ Read #2426's lesson first: `build_equity_curve`
+**rebalances on every event date**, which manufactured 23.2 pts/yr on the old
+benchmark. For a short book, decide the weighting rule deliberately and state it —
+`equal_weight_buy_and_hold_v1` exists precisely because reuse imports policy, not just
+plumbing.
+
+Report: equity curve, max drawdown, worst day, concurrency distribution, and the
+curve's sensitivity to a per-name weight cap.
+
+### 2b. Register the trial before searching further
+
+⚠⚠ `t 4.83` **searched-over is not `t 4.83` pre-registered.** Register in
+`trial_register.py` with the honest count (~100 arms this session: gap fade across 5
+bands × 5 eras, 15 reversal arms, 25 breadth cells, 12 confluence buckets, 13
+conditions, 6 short arms, 5 stops). At 100 trials the deflated-Sharpe bar is ≈0.174.
+
+⚠ Do this **before** more searching, or the denominator keeps growing.
+
+### 2c. eToro borrow availability — could kill it outright
+
+A ≥12% one-day drop is the archetypal hard-to-borrow name, and eToro's own docs list
+*"temporary unavailability of shares to borrow"* as a live restriction. If the names
+this fires on cannot be shorted at the moment they fire, the statistics are moot.
+
+⚠ Unknown whether the API exposes shortability per instrument — **check, do not
+assume** (`.claude/skills/data-sources/etoro-api.md`, verification protocol).
+
+### 2d. Out-of-sample
+
+2020-2026 is one sample and it has been searched hard. ⚠ There is no clean hold-out
+left in the post-2020 regime, and pre-2020 is a *different regime* (see §4), so this
+likely means **forward paper trading**, not a historical split. Say so rather than
+carving a fake hold-out.
+
+## 3. Open threads worth picking up
+
+- **Confluence on the SHORT side.** The 11-condition alignment test was measured for
+  long entries only. The short side has 200-440 bps of gross rather than 44, so
+  conditioning has somewhere to go. ⚠ Reuse `verify_2437_confluence.py`; keep the
+  alignment-count gradient (1 d.o.f.), do not search subsets.
+- **`P(hit stop before target)`** — the first-passage model. Codex's spec: triple-barrier
+  labels, walk-forward with purge and embargo, scored on **Brier + calibration curves**,
+  not average return. ⚠ *"A model that ranks well but is miscalibrated is dangerous for
+  sizing"* — and sizing is exactly what it would feed.
+- **Intraday residual reversal** (Brogaard/Han/Kim, sample to Dec 2022) on **30-minute
+  midpoints** — the granularity we can already pull ~1 month back. ⚠ Their construction
+  is long-short; the long leg alone is the weaker one.
+- **`breadth up day`** was the largest single marginal in the confluence table (+91.56
+  bps at 10 days, t 7.93, double any other). ⚠ Probably beta, not alpha — check before
+  getting interested.
+- **A tick recorder.** `price_intraday` is empty with no writer. ⚠ Schema mismatch
+  noted in `data-capability.md`. Lower priority now that REST history exists, but it is
+  the only way past the 1000-bar ceiling.
+
+## 4. Rules this session established — do not relearn them
+
+1. ⚠⚠ **Never test one condition and report the null.** `E[r|A]` and `E[r|A,B,C,D,E]`
+   can have opposite signs. Our proof: the −5% drop is −437 bps at breadth 2-5 and
+   **+91 at breadth 101+**. Tell = day- and year-clustering disagreeing **in sign**.
+2. ⚠⚠ **A level type needs a placebo arm.** Fake fib 29/44/71 beat real 38.2/50/61.8;
+   fake support beat real pivot-low support. Both real ones sit below baseline.
+3. ⚠⚠ **Era-split before excitement.** Gap fade: t 5.73 over 1962-2026, t 1.39 over
+   2020+, negative pre-2001. Usable short-horizon sample ≈ 6 years.
+4. ⚠⚠ **A hard constraint makes findings look like nulls.** "Buy the loser" was filed
+   as a null three times; it was an inverted signal with no expression.
+5. ⚠ **Probe a provider before asserting a capability gap.** An empty table measures
+   what we chose to store, not what the source will serve.
+
+## 5. Closed — do not reopen
+
+- **SEC-keyed intraday signals.** Measured ingest lag: median **2 days**, p90 37, only
+  4.6% same-day. Even at zero latency, Form 4s are machine-parsed off EDGAR
+  dissemination in milliseconds. SEC data is a multi-month horizon or nothing.
+- **Support proximity and Fibonacci as entry conditions.** Falsified by placebo (§4.2).
+- **The gap-down fade.** Dead since 2020 (+11.8 bps, t 1.39).
+- **Long-only one-day loser reversal.** Wrong sign, monotonically.
+
+## 6. Merge state
+
+- PR **#2442** merged (`61fb17da`).
+- PR **#2444** — this work. APPROVE, CI green, two NITPICKs `FIXED 245481a8`.
+  ⚠ The follow-up push resets the review requirement; re-poll before merging.
+- ⚠ `~/Dev/eBull` is on `feature/2437-short-side-edge`, **not detached at origin/main**.
+  Re-detach after merge.

--- a/scripts/verify_2437_confluence.py
+++ b/scripts/verify_2437_confluence.py
@@ -1,0 +1,313 @@
+"""Does CONFLUENCE pay? Forward returns by how many conditions align (#2437).
+
+    PYTHONPATH=. uv run python scripts/verify_2437_confluence.py
+
+⚠ NOTHING IS WRITTEN. Gate on the EXIT CODE. Never pipe into head/tail.
+
+WHY THIS EXISTS -- THE INSTRUMENT, NOT THE IDEA
+-----------------------------------------------
+Every prior test in this research pass was UNIVARIATE: one condition, averaged
+across the whole cross-section. Gap down >2%. One-day drop <=-5%. 12-month
+momentum. All returned nothing usable after costs and clustering, and each time
+the conclusion recorded was "the effect is dead".
+
+⚠⚠ That conclusion does not follow, and the operator said so five times before it
+landed. If an edge exists only where several conditions CO-OCCUR, then measuring
+each condition alone returns ~zero BY CONSTRUCTION: the firings where the other
+conditions were absent swamp the few where they were present. A univariate test
+is structurally incapable of finding a conjunction-dependent effect. We were
+running the instrument that cannot detect the thing, then reporting the null.
+
+WHAT THIS DOES DIFFERENTLY
+--------------------------
+Eleven pre-specified conditions, each a plain binary read off the chart, all
+computable at the close of day t. Then ONE measurement: forward return bucketed
+by HOW MANY of them are true simultaneously.
+
+⚠ That is deliberately a single degree of freedom, not a search. Testing all 2^11
+subsets would manufacture a winner from noise on 6,700 stocks over six years.
+Asking "does expectancy rise monotonically with alignment count" asks the
+operator's actual question -- *do traders need several things to line up* -- and
+a monotonic gradient across buckets is far harder to fake than one lucky cell.
+The breadth split in `verify_2437_loser_reversal.py` is the precedent: the
+gradient was the finding, not any single bucket.
+
+⚠⚠ INCLUDES THE TWO FAMILIES I DISMISSED WITHOUT TESTING. Support proximity
+(distance to a prior pivot low) and Fibonacci retracement (position within the
+60-day swing near 38.2/50/61.8%) are conditions 8 and 9. Both are constructed
+mechanically -- no hand-drawn lines, no discretion -- so "does price behave
+differently near these levels" becomes a measurement rather than an opinion. If
+they carry nothing, the per-condition table will say so; that is a result, not a
+prior.
+
+DISCIPLINE
+----------
+- Every condition uses data up to and including the close of day t. Entry is the
+  OPEN of day t+1. No lookahead anywhere.
+- Adjusted prices throughout, so dividends and splits cannot fake a signal.
+- ⚠ DAY-CLUSTERED inference. Conditions like trend and breadth are shared across
+  hundreds of names at once, so pooling observations would inflate t enormously.
+- Costs deducted. Every bucket is reported against the unconditional baseline
+  over the same days -- an alignment count that merely matches drift is not edge.
+- Per-condition marginals are printed too, precisely so the univariate view and
+  the conjunction view sit side by side and can be compared.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from datetime import date
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+
+START = "2019-06-01"  # 6mo warmup before the 2020+ measurement window
+MEASURE_FROM = 2020
+HOLDS = (5, 10)
+MIN_PRICE = 20.0
+MIN_DOLLAR_VOL = 10_000_000.0
+COST_BPS = 50.0
+
+CONDITIONS = (
+    "1 uptrend c>50>200",
+    "2 pullback 3-12%",
+    "3 near 52w high",
+    "4 vol regime calm",
+    "5 rel strength +",
+    "6 volume quiet",
+    "7 strong close",
+    "8 near support",
+    "9 fib 38/50/62",
+    "10 rsi 35-55",
+    "11 breadth up day",
+)
+
+# ⚠⚠ PLACEBO LEVELS. Codex round 6: the only test that settles whether a level type
+# is special is to compare it against ARBITRARY levels drawn from the same swing.
+# A 2021 study found Fibonacci zones did not beat non-Fibonacci zones -- so a bare
+# "price is near 38.2%" hit rate proves nothing, because price is often mid-range
+# and any fraction would score. These two ride alongside conditions 8 and 9 and are
+# reported separately; they are NOT counted in the alignment total.
+#
+# The read is a DIFFERENCE, not a level: if `fib` and `fib placebo` score the same,
+# 38.2/50/61.8 carry nothing beyond "somewhere in the range". Same for support
+# against a randomly displaced pseudo-level.
+PLACEBOS = ("P1 fake fib 29/44/71", "P2 fake support")
+
+_SERIES = "SELECT DISTINCT series_id FROM research_price_daily WHERE bar_date >= %(s)s ORDER BY series_id"
+_BARS = """
+    SELECT bar_date, open, high, low, close, adj_close, volume
+    FROM research_price_daily
+    WHERE series_id = %(sid)s AND bar_date >= %(s)s
+      AND open > 0 AND high > 0 AND low > 0 AND close > 0 AND adj_close > 0
+    ORDER BY bar_date
+"""
+
+
+def _sma(x: np.ndarray, n: int) -> np.ndarray:
+    out = np.full_like(x, np.nan)
+    if len(x) >= n:
+        c = np.cumsum(np.insert(x, 0, 0.0))
+        out[n - 1 :] = (c[n:] - c[:-n]) / n
+    return out
+
+
+def _rsi(x: np.ndarray, n: int = 14) -> np.ndarray:
+    out = np.full_like(x, np.nan)
+    d = np.diff(x)
+    up = np.where(d > 0, d, 0.0)
+    dn = np.where(d < 0, -d, 0.0)
+    if len(d) < n:
+        return out
+    au, ad = up[:n].mean(), dn[:n].mean()
+    for i in range(n, len(d)):
+        au = (au * (n - 1) + up[i]) / n  # Wilder smoothing, not a plain mean
+        ad = (ad * (n - 1) + dn[i]) / n
+        out[i + 1] = 100.0 if ad == 0 else 100.0 - 100.0 / (1.0 + au / ad)
+    return out
+
+
+def _cluster(groups: dict[date, list[float]]) -> tuple[float, float, int]:
+    means = [float(np.mean(v)) for v in groups.values() if v]
+    if len(means) < 5:
+        return float("nan"), float("nan"), len(means)
+    a = np.asarray(means)
+    m = float(a.mean())
+    se = float(a.std(ddof=1) / np.sqrt(len(a)))
+    return m, (m / se if se > 0 else 0.0), len(a)
+
+
+def main() -> int:
+    conn = psycopg.connect(settings.database_url)
+    sids = [r[0] for r in conn.execute(_SERIES, {"s": START}).fetchall()]
+    print(f"{len(sids):,} series", flush=True)
+
+    # ---- pass 1: equal-weight market return per day, for breadth + rel strength
+    mkt_sum: dict[date, float] = defaultdict(float)
+    mkt_n: dict[date, int] = defaultdict(int)
+    for n, sid in enumerate(sids, start=1):
+        rows = conn.execute(_BARS, {"sid": sid, "s": START}).fetchall()
+        if len(rows) < 40:
+            continue
+        adj = np.asarray([float(r[5]) for r in rows])
+        cl = np.asarray([float(r[4]) for r in rows])
+        for i in range(1, len(rows)):
+            if cl[i] >= MIN_PRICE:
+                mkt_sum[rows[i][0]] += adj[i] / adj[i - 1] - 1.0
+                mkt_n[rows[i][0]] += 1
+        if n % 1500 == 0:
+            print(f"  pass1 {n}/{len(sids)}", flush=True)
+    mkt = {d: mkt_sum[d] / mkt_n[d] for d in mkt_sum if mkt_n[d] >= 50}
+    dates_sorted = sorted(mkt)
+    mkt_cum = {}
+    acc = 1.0
+    for d in dates_sorted:
+        acc *= 1.0 + mkt[d]
+        mkt_cum[d] = acc
+    print(f"market series: {len(mkt):,} days", flush=True)
+
+    # ---- pass 2: conditions + forward returns
+    by_count: dict[tuple[int, int], dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+    by_cond: dict[tuple[int, int], dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+    base: dict[int, dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+    by_placebo: dict[tuple[int, int], dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+    cond_hits = np.zeros(len(CONDITIONS), dtype=np.int64)
+    placebo_hits = np.zeros(len(PLACEBOS), dtype=np.int64)
+    total = 0
+
+    for n, sid in enumerate(sids, start=1):
+        rows = conn.execute(_BARS, {"sid": sid, "s": START}).fetchall()
+        if len(rows) < 260:
+            continue
+        dts = [r[0] for r in rows]
+        op = np.asarray([float(r[1]) for r in rows])
+        hi = np.asarray([float(r[2]) for r in rows])
+        lo = np.asarray([float(r[3]) for r in rows])
+        cl = np.asarray([float(r[4]) for r in rows])
+        adj = np.asarray([float(r[5]) for r in rows])
+        vol = np.asarray([float(r[6] or 0.0) for r in rows])
+
+        f = adj / cl
+        adj_open, adj_hi, adj_lo = op * f, hi * f, lo * f
+        sma50, sma200 = _sma(adj, 50), _sma(adj, 200)
+        rsi = _rsi(adj)
+        tr = np.maximum(
+            adj_hi[1:] - adj_lo[1:], np.maximum(np.abs(adj_hi[1:] - adj[:-1]), np.abs(adj_lo[1:] - adj[:-1]))
+        )
+        atr = np.full_like(adj, np.nan)
+        atr[20:] = np.convolve(tr, np.ones(20) / 20, mode="valid")[: len(adj) - 20]
+        dvol = cl * vol
+        rng = adj_hi - adj_lo
+        cpos = np.where(rng > 0, (adj - adj_lo) / np.maximum(rng, 1e-12), 0.5)
+
+        # pivot lows: a low that is the minimum of its +/-5 neighbourhood.
+        # ⚠ uses only bars up to j+5, and is consulted at i > j+5, so no lookahead.
+        pivots = [j for j in range(5, len(adj) - 5) if adj_lo[j] == adj_lo[j - 5 : j + 6].min()]
+
+        for i in range(252, len(adj) - max(HOLDS) - 1):
+            if dts[i].year < MEASURE_FROM or cl[i] < MIN_PRICE:
+                continue
+            if float(np.median(dvol[i - 20 : i])) < MIN_DOLLAR_VOL:
+                continue
+            if not np.isfinite(sma200[i]) or not np.isfinite(atr[i]) or atr[i] <= 0:
+                continue
+            entry = adj_open[i + 1]
+            if not np.isfinite(entry) or entry <= 0:
+                continue
+            day = dts[i + 1]
+            if day not in mkt:
+                continue
+
+            w = adj[i - 251 : i + 1]
+            hi252, lo60, hi60 = w.max(), adj_lo[i - 59 : i + 1].min(), adj_hi[i - 59 : i + 1].max()
+            peak10 = adj[i - 10 : i + 1].max()
+            pull = adj[i] / peak10 - 1.0
+            prior = [p for p in pivots if p < i - 5 and adj_lo[p] < adj[i]]
+            sup_d = min(((adj[i] - adj_lo[p]) / atr[i] for p in prior), default=99.0)
+            fib = (adj[i] - lo60) / (hi60 - lo60) if hi60 > lo60 else -1.0
+            r21 = adj[i] / adj[i - 21] - 1.0
+            m21 = mkt_cum[day] / mkt_cum[dts[i - 21]] - 1.0 if dts[i - 21] in mkt_cum else 0.0
+
+            c = (
+                adj[i] > sma50[i] > sma200[i],
+                -0.12 <= pull <= -0.03,
+                adj[i] / hi252 >= 0.85,
+                0.010 <= atr[i] / adj[i] <= 0.035,
+                r21 > m21,
+                dvol[i] < float(np.median(dvol[i - 20 : i])),
+                cpos[i] > 0.6,
+                sup_d <= 0.5,
+                any(abs(fib - lv) <= 0.03 for lv in (0.382, 0.5, 0.618)),
+                35.0 <= rsi[i] <= 55.0,
+                mkt[day] > 0,
+            )
+            # ⚠ placebos are matched in SHAPE to conditions 9 and 8: the same
+            # tolerance, the same swing, the same ATR unit -- only the level itself
+            # is arbitrary. Anything else and the comparison measures the tolerance
+            # rather than the level.
+            p = (
+                any(abs(fib - lv) <= 0.03 for lv in (0.29, 0.44, 0.71)),
+                abs(sup_d - 1.5) <= 0.25,
+            )
+            k = int(sum(c))
+            cond_hits += np.asarray(c, dtype=np.int64)
+            placebo_hits += np.asarray(p, dtype=np.int64)
+            total += 1
+            for h in HOLDS:
+                r = (adj[i + h] / entry - 1.0) * 1e4
+                base[h][day].append(r)
+                by_count[(k, h)][day].append(r)
+                for ci, on in enumerate(c):
+                    if on:
+                        by_cond[(ci, h)][day].append(r)
+                for pi, on in enumerate(p):
+                    if on:
+                        by_placebo[(pi, h)][day].append(r)
+        if n % 1000 == 0:
+            print(f"  pass2 {n}/{len(sids)}", flush=True)
+    conn.close()
+
+    print(f"\nCONFLUENCE TEST, {MEASURE_FROM}+  ({total:,} stock-days)")
+    print("entry = next bar's adjusted OPEN, exit = adjusted CLOSE h bars later")
+    print(f"⚠ DAY-CLUSTERED t. ⚠ NET deducts {COST_BPS:.0f} bps.\n")
+
+    for h in HOLDS:
+        bm, bt, _ = _cluster(base[h])
+        print(f"--- hold {h} bars --- unconditional baseline {bm:.2f} bps (t {bt:.2f})")
+        print(f"{'aligned':>9}{'stock-days':>12}{'gross bps':>11}{'NET':>9}{'vs base':>10}{'t':>8}{'days':>7}")
+        for k in range(len(CONDITIONS) + 1):
+            m, t, nd = _cluster(by_count[(k, h)])
+            if not np.isfinite(m):
+                continue
+            ev = sum(len(v) for v in by_count[(k, h)].values())
+            print(f"{k:>9}{ev:>12,}{m:>11.2f}{m - COST_BPS:>9.2f}{m - bm:>10.2f}{t:>8.2f}{nd:>7}")
+        print()
+
+    print("PER-CONDITION MARGINALS (the univariate view, for comparison)")
+    print(f"{'condition':>20}{'fire rate':>11}{'5d bps':>9}{'t':>8}{'10d bps':>10}{'t':>8}")
+    for ci, name in enumerate(CONDITIONS):
+        m5, t5, _ = _cluster(by_cond[(ci, 5)])
+        m10, t10, _ = _cluster(by_cond[(ci, 10)])
+        rate = cond_hits[ci] / max(total, 1)
+        print(f"{name:>20}{rate:>10.1%}{m5:>9.2f}{t5:>8.2f}{m10:>10.2f}{t10:>8.2f}")
+
+    print("\n⚠⚠ PLACEBO LEVELS -- compare against conditions 8 and 9 above.")
+    print("   Same tolerance, same swing, arbitrary level. If these score the same,")
+    print("   the level type carries nothing beyond 'price is somewhere in the range'.")
+    for pi, name in enumerate(PLACEBOS):
+        m5, t5, _ = _cluster(by_placebo[(pi, 5)])
+        m10, t10, _ = _cluster(by_placebo[(pi, 10)])
+        rate = placebo_hits[pi] / max(total, 1)
+        print(f"{name:>20}{rate:>10.1%}{m5:>9.2f}{t5:>8.2f}{m10:>10.2f}{t10:>8.2f}")
+
+    print("\n⚠ The question is the GRADIENT across alignment counts, not any one bucket.")
+    print("⚠ If confluence is real, 'vs base' rises with the count. If it is folklore,")
+    print("  the column is flat or noisy and the marginals already told the whole story.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2437_loser_reversal.py
+++ b/scripts/verify_2437_loser_reversal.py
@@ -59,6 +59,7 @@ HOLDS = (1, 2, 3, 5, 10)  # trading days, exit at the close
 MIN_PRICE = 20.0  # prior close, unadjusted -- the tradable price
 MIN_DOLLAR_VOL = 10_000_000.0  # 20-day median
 COST_BPS = 50.0  # round trip, deducted from every figure
+BREADTH_SIGNAL = -0.05  # ⚠ must be one of DROP_THRESHOLDS; asserted in _breadth_report
 
 _SERIES = """
     SELECT DISTINCT series_id
@@ -110,7 +111,12 @@ def _breadth_report(by_day: dict[tuple[float | None, int], dict[object, list[flo
     ⚠ Breadth is known at the close of day t, before the next open we enter at,
     so conditioning on it is not lookahead.
     """
-    print("\nBREADTH SPLIT -- does the crowd matter? (signal `1d <= -5%`)")
+    # ⚠ `by_day` is a defaultdict, so an absent key yields an EMPTY bucket rather
+    # than raising -- a future edit to DROP_THRESHOLDS would silently delete this
+    # whole report and print nothing but headers. Fail loudly instead.
+    if BREADTH_SIGNAL not in DROP_THRESHOLDS:
+        raise ValueError(f"BREADTH_SIGNAL {BREADTH_SIGNAL} is not in DROP_THRESHOLDS {DROP_THRESHOLDS}")
+    print(f"\nBREADTH SPLIT -- does the crowd matter? (signal `1d <= {BREADTH_SIGNAL:.0%}`)")
     print("breadth = number of qualifying events sharing that entry day.")
     print("⚠ each row is a mean ACROSS DAYS in the bucket, so days weigh equally.\n")
     header = f"{'breadth':>14}{'hold':>6}{'days':>7}{'events':>10}{'gross bps':>11}{'NET':>9}{'t':>8}"
@@ -120,7 +126,7 @@ def _breadth_report(by_day: dict[tuple[float | None, int], dict[object, list[flo
     for lo, hi in buckets:
         label = f"{lo}" if lo == hi else (f"{lo}-{hi}" if hi < 10**9 else f"{lo}+")
         for k in HOLDS:
-            day_map = by_day[(-0.05, k)]
+            day_map = by_day[(BREADTH_SIGNAL, k)]
             sel = {d: v for d, v in day_map.items() if lo <= len(v) <= hi}
             if len(sel) < 5:
                 continue

--- a/scripts/verify_2437_loser_reversal.py
+++ b/scripts/verify_2437_loser_reversal.py
@@ -91,6 +91,47 @@ def _cluster_t(groups: dict[object, list[float]], min_n: int = 1) -> tuple[float
     return m, (m / se if se > 0 else 0.0), len(a)
 
 
+def _breadth_report(by_day: dict[tuple[float | None, int], dict[object, list[float]]]) -> None:
+    """Split the drop signal by how MANY names dropped that day.
+
+    ⚠⚠ Why this exists: on the first run, day-clustered and year-clustered t
+    disagreed in SIGN (`1d <= -5%`, 10-day hold: t(day) -4.49 vs t(year) +1.81).
+    Both can only be true if outcome covaries with how many events a day carries
+    -- day-clustering weights every day equally, year-clustering pools events and
+    so is dominated by the days where hundreds of names fired at once.
+
+    That is a testable claim about mechanism rather than a statistical nuisance:
+    a market-wide crash is forced/correlated selling that can revert, whereas a
+    lone name dropping while the market is flat is firm-specific news that
+    reprices and stays repriced. `breadth` -- the count of qualifying events on
+    the entry day -- is the cheapest available proxy for which one happened, and
+    unlike a sector or beta control it needs no extra data.
+
+    ⚠ Breadth is known at the close of day t, before the next open we enter at,
+    so conditioning on it is not lookahead.
+    """
+    print("\nBREADTH SPLIT -- does the crowd matter? (signal `1d <= -5%`)")
+    print("breadth = number of qualifying events sharing that entry day.")
+    print("⚠ each row is a mean ACROSS DAYS in the bucket, so days weigh equally.\n")
+    header = f"{'breadth':>14}{'hold':>6}{'days':>7}{'events':>10}{'gross bps':>11}{'NET':>9}{'t':>8}"
+    print(header)
+    print("-" * len(header))
+    buckets = ((1, 1), (2, 5), (6, 20), (21, 100), (101, 10**9))
+    for lo, hi in buckets:
+        label = f"{lo}" if lo == hi else (f"{lo}-{hi}" if hi < 10**9 else f"{lo}+")
+        for k in HOLDS:
+            day_map = by_day[(-0.05, k)]
+            sel = {d: v for d, v in day_map.items() if lo <= len(v) <= hi}
+            if len(sel) < 5:
+                continue
+            m, t, n_days = _cluster_t(sel)
+            print(
+                f"{label:>14}{k:>6}{n_days:>7}{sum(len(v) for v in sel.values()):>10,}"
+                f"{m:>11.2f}{m - COST_BPS:>9.2f}{t:>8.2f}"
+            )
+        print()
+
+
 def main() -> int:
     # threshold -> hold -> day -> [returns bps]; None threshold = unconditional
     by_day: dict[tuple[float | None, int], dict[object, list[float]]] = defaultdict(lambda: defaultdict(list))
@@ -152,6 +193,8 @@ def main() -> int:
     header = f"{'signal':>14}{'hold':>6}{'events':>10}{'gross bps':>11}{'NET':>9}{'t(day)':>9}{'days':>7}{'t(year)':>9}"
     print(header)
     print("-" * len(header))
+
+    _breadth_report(by_day)
 
     survivors = 0
     for th in (None, *DROP_THRESHOLDS):

--- a/scripts/verify_2437_short_continuation.py
+++ b/scripts/verify_2437_short_continuation.py
@@ -1,0 +1,218 @@
+"""Short the isolated loser: does the edge survive its own tail? (#2437)
+
+    PYTHONPATH=. uv run python scripts/verify_2437_short_continuation.py
+
+⚠ NOTHING IS WRITTEN. Gate on the EXIT CODE. Never pipe into head/tail.
+
+WHY
+---
+`verify_2437_loser_reversal.py` measured buying one-day losers and found it loses
+money monotonically -- worse with a bigger drop, worse with a longer hold, worse
+when fewer names fall alongside. Reported three times as a null.
+
+⚠⚠ It was never a null. It is the strongest effect measured in this research pass,
+pointing the other way: an isolated stock that drops hard KEEPS dropping. It read
+as failure only because the project was long-only, so the finding had no
+expression beyond "do not buy". The operator lifted that constraint on 2026-08-09
+(shorting permitted for research and paper trading; leverage still barred until
+validation), which makes the short leg testable for the first time.
+
+⚠⚠ A MEAN IS NOT ENOUGH FOR A SHORT, and this is the whole reason this script
+exists rather than a sign flip in the old one. A long's worst case is -100%; a
+short's is unbounded. A name that falls 12% and then rebounds 60% costs more than
+twenty good trades earn. So the mean is reported LAST here, after the things that
+actually decide whether it is tradable:
+
+  - win rate per trade, and the median, not just the mean
+  - the worst trades, and what the mean looks like with the best 1% of shorts
+    removed (i.e. strip the collapses and see if anything is left)
+  - ⚠⚠ DELISTING ATTRIBUTION. Our corpus is survivorship-controlled, so it
+    contains names that went to zero. A backtested short harvests those in full.
+    In reality the position is bought in, halted, or force-closed at a price we
+    never see. If the edge lives in series that terminate shortly after the
+    signal, it is an artefact of holding a short through an event we could not
+    have held through. This is the single most likely way the result is wrong.
+
+⚠ COST MODEL IS NOT THE LONG ONE. An eToro short is a CFD. Easy-to-borrow costs
+spread only; hard-to-borrow (>10% annual) accrues daily at 21:00 GMT and TRIPLE at
+weekends -- and a stock that just fell 12% is the archetypal hard-to-borrow name.
+`BORROW_BPS_PER_DAY` is a placeholder for the >10%/yr tier (~2.7 bps/day) and is
+applied per calendar day held, not per trading day, because financing accrues at
+weekends. ⚠ It is an ASSUMPTION, not a measurement -- eToro does not publish a
+per-symbol borrow table via the API, so the honest treatment is to show the result
+at several borrow tiers and let the reader see where it breaks.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from datetime import date
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+
+START = "2020-01-01"
+DROPS = (-0.05, -0.08, -0.12)
+HOLDS = (5, 10)
+MIN_PRICE = 20.0
+MIN_DOLLAR_VOL = 10_000_000.0
+SPREAD_BPS = 50.0
+BORROW_TIERS_BPS_PER_DAY = (0.0, 2.7, 8.2)  # 0%, ~10%/yr, ~30%/yr annualised
+TERMINATION_LOOKAHEAD = 252  # a series ending within a year counts as "died"
+
+_SERIES = """
+    SELECT series_id, MAX(bar_date) AS last_bar
+    FROM research_price_daily
+    WHERE bar_date >= %(s)s
+    GROUP BY series_id
+    ORDER BY series_id
+"""
+_BARS = """
+    SELECT bar_date, open, close, adj_close, volume
+    FROM research_price_daily
+    WHERE series_id = %(sid)s AND bar_date >= %(s)s
+      AND open > 0 AND close > 0 AND adj_close > 0
+    ORDER BY bar_date
+"""
+
+
+def _cluster(groups: dict[date, list[float]]) -> tuple[float, float, int]:
+    means = [float(np.mean(v)) for v in groups.values() if v]
+    if len(means) < 5:
+        return float("nan"), float("nan"), len(means)
+    a = np.asarray(means)
+    m = float(a.mean())
+    se = float(a.std(ddof=1) / np.sqrt(len(a)))
+    return m, (m / se if se > 0 else 0.0), len(a)
+
+
+def main() -> int:
+    with psycopg.connect(settings.database_url) as conn:
+        rows = conn.execute(_SERIES, {"s": START}).fetchall()
+        last_bar = {r[0]: r[1] for r in rows}
+        corpus_end = max(last_bar.values())
+        sids = [r[0] for r in rows]
+        print(f"{len(sids):,} series, corpus ends {corpus_end}", flush=True)
+
+        # (drop, hold) -> day -> [short gross bps]; plus flat lists for tail stats
+        by_day: dict[tuple[float, int], dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+        by_day_alive: dict[tuple[float, int], dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+        flat: dict[tuple[float, int], list[float]] = defaultdict(list)
+        died: dict[tuple[float, int], list[float]] = defaultdict(list)
+        held_days: dict[tuple[float, int], list[int]] = defaultdict(list)
+
+        for n, sid in enumerate(sids, start=1):
+            bars = conn.execute(_BARS, {"sid": sid, "s": START}).fetchall()
+            if len(bars) < 60:
+                continue
+            dts = [b[0] for b in bars]
+            op = np.asarray([float(b[1]) for b in bars])
+            cl = np.asarray([float(b[2]) for b in bars])
+            adj = np.asarray([float(b[3]) for b in bars])
+            vol = np.asarray([float(b[4] or 0.0) for b in bars])
+            adj_open = op * (adj / cl)
+            ret1 = np.empty_like(adj)
+            ret1[0] = np.nan
+            ret1[1:] = adj[1:] / adj[:-1] - 1.0
+            dvol = cl * vol
+            # ⚠ a series whose last bar is well inside the corpus has stopped
+            # trading -- delisted, acquired, or renamed. Shorting into that is the
+            # case a backtest flatters most.
+            terminated = (corpus_end - last_bar[sid]).days > 30
+
+            for i in range(21, len(cl) - max(HOLDS) - 1):
+                if cl[i] < MIN_PRICE or float(np.median(dvol[i - 20 : i])) < MIN_DOLLAR_VOL:
+                    continue
+                entry = adj_open[i + 1]
+                if not np.isfinite(entry) or entry <= 0:
+                    continue
+                day = dts[i + 1]
+                dies_soon = terminated and (last_bar[sid] - day).days <= TERMINATION_LOOKAHEAD
+                for th in DROPS:
+                    if ret1[i] > th:
+                        continue
+                    for h in HOLDS:
+                        key = (th, h)
+                        # ⚠ SHORT: we profit when the price FALLS, so the sign flips.
+                        short_bps = -(adj[i + h] / entry - 1.0) * 1e4
+                        by_day[key][day].append(short_bps)
+                        flat[key].append(short_bps)
+                        held_days[key].append((dts[i + h] - day).days)
+                        if dies_soon:
+                            died[key].append(short_bps)
+                        else:
+                            by_day_alive[key][day].append(short_bps)
+            if n % 1000 == 0:
+                print(f"  {n}/{len(sids)}", flush=True)
+
+    print(f"\nSHORT THE ONE-DAY LOSER, {START} onward")
+    print("entry = SHORT at next bar's adjusted OPEN, cover at adjusted CLOSE h bars later")
+    print(f"universe: prior close >= ${MIN_PRICE:.0f}, 20d median dollar volume >= ${MIN_DOLLAR_VOL / 1e6:.0f}m")
+    print(f"⚠ DAY-CLUSTERED t. ⚠ spread {SPREAD_BPS:.0f} bps round trip, borrow shown per tier.\n")
+
+    hdr = f"{'signal':>12}{'hold':>6}{'trades':>9}{'gross':>9}{'median':>9}{'win%':>7}{'t':>7}{'days':>7}"
+    hdr += "".join(f"{f'net@{b}':>10}" for b in BORROW_TIERS_BPS_PER_DAY)
+    print(hdr)
+    print("-" * len(hdr))
+    for th in DROPS:
+        for h in HOLDS:
+            key = (th, h)
+            m, t, nd = _cluster(by_day[key])
+            if not np.isfinite(m):
+                continue
+            arr = np.asarray(flat[key])
+            cal = float(np.mean(held_days[key])) if held_days[key] else h
+            line = (
+                f"{th:>11.0%}{h:>6}{len(arr):>9,}{m:>9.1f}{float(np.median(arr)):>9.1f}"
+                f"{float((arr > 0).mean()) * 100:>7.1f}{t:>7.2f}{nd:>7}"
+            )
+            for b in BORROW_TIERS_BPS_PER_DAY:
+                line += f"{m - SPREAD_BPS - b * cal:>10.1f}"
+            print(line)
+    print(f"\n⚠ borrow tiers are bps/CALENDAR day ({BORROW_TIERS_BPS_PER_DAY}) = 0%, ~10%/yr, ~30%/yr.")
+
+    print("\n⚠⚠ TAIL -- a short's losses are unbounded, so the mean is not the story.")
+    print(f"{'signal':>12}{'hold':>6}{'worst':>10}{'p1':>9}{'p5':>9}{'p95':>9}{'best':>10}{'mean ex-top1%':>15}")
+    for th in DROPS:
+        for h in HOLDS:
+            arr = np.asarray(flat[(th, h)])
+            if arr.size < 100:
+                continue
+            cut = float(np.percentile(arr, 99))
+            ex = arr[arr <= cut]
+            print(
+                f"{th:>11.0%}{h:>6}{arr.min():>10.0f}{float(np.percentile(arr, 1)):>9.0f}"
+                f"{float(np.percentile(arr, 5)):>9.0f}{float(np.percentile(arr, 95)):>9.0f}"
+                f"{arr.max():>10.0f}{float(ex.mean()):>15.1f}"
+            )
+    print("⚠ 'mean ex-top1%' strips the biggest SHORT WINS (the collapses). If the")
+    print("  edge vanishes there, it is a lottery on a handful of blow-ups, not a strategy.")
+
+    print("\n⚠⚠ DELISTING ATTRIBUTION -- the most likely way this result is wrong.")
+    print(f"a trade is 'dying' if its series stops trading within {TERMINATION_LOOKAHEAD} days of entry.")
+    print(
+        f"{'signal':>12}{'hold':>6}{'dying':>8}{'share':>8}{'dying mean':>12}"
+        f"{'ALIVE mean':>12}{'alive t':>9}{'days':>7}"
+    )
+    for th in DROPS:
+        for h in HOLDS:
+            key = (th, h)
+            arr = np.asarray(flat[key])
+            d = np.asarray(died[key])
+            am, at, ad = _cluster(by_day_alive[key])
+            if arr.size < 100 or not np.isfinite(am):
+                continue
+            print(
+                f"{th:>11.0%}{h:>6}{d.size:>8,}{d.size / arr.size * 100:>7.1f}%"
+                f"{(d.mean() if d.size else float('nan')):>12.1f}{am:>12.1f}{at:>9.2f}{ad:>7}"
+            )
+    print("⚠ 'ALIVE mean' excludes every name that stopped trading within the year.")
+    print("  That is the honest number: it is the only one we could actually have held.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2437_short_stops.py
+++ b/scripts/verify_2437_short_stops.py
@@ -1,0 +1,172 @@
+"""The surviving short arm, with a stop attached (#2437).
+
+    PYTHONPATH=. uv run python scripts/verify_2437_short_stops.py
+
+⚠ NOTHING IS WRITTEN. Gate on the EXIT CODE. Never pipe into head/tail.
+
+WHY
+---
+`verify_2437_short_continuation.py` left exactly one arm standing: short a stock
+that fell >=12% in a day, cover 5 days later. It survived costs at every borrow
+tier, survived deleting its best 1% of trades, survived excluding every name that
+stopped trading, and carried a positive median with a 54.4% win rate over 1,364
+independent event days.
+
+⚠⚠ And it is still untradable as written, because the worst single trade was
+-412% and 1% of trades lost 50% or more. A short's loss is unbounded, so that is
+not a tail to note and move past -- one such trade erases roughly 190 average
+winners. A hard stop is therefore STRUCTURAL, not a refinement.
+
+⚠ Which means the stopped version is a DIFFERENT STRATEGY and the unstopped
+numbers do not describe it. A stop truncates the left tail, which is the point,
+but it also converts some eventual winners into realised losses -- the position
+that spikes 12% on day two and then collapses pays nothing once you are out.
+Whether that trade is worth making is exactly what this measures, and it cannot
+be reasoned out.
+
+HOW THE STOP IS FILLED -- the honest treatment
+----------------------------------------------
+⚠⚠ A stop is not a guaranteed price. Each day we check the bar in the order the
+session actually delivers it:
+
+  1. If the OPEN is already at or above the stop, we fill at the OPEN. This is
+     the gap-through case, and it is where a short actually gets hurt -- pretending
+     the stop filled at its level would invent money that a gap never offered.
+  2. Otherwise, if the HIGH touched the stop, we fill AT the stop level.
+
+⚠ This is still optimistic. Intraday we could be filled worse than the stop even
+without a gap, and a halt can reopen far away. Read the stopped figures as an
+upper bound, in the same way the unstopped ones were a lower bound on risk.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from datetime import date
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+
+START = "2020-01-01"
+DROP = -0.12  # the surviving threshold
+HOLD = 5  # the surviving hold
+STOPS = (None, 0.20, 0.12, 0.08, 0.05)  # cover if price rises this far above entry
+MIN_PRICE = 20.0
+MIN_DOLLAR_VOL = 10_000_000.0
+SPREAD_BPS = 50.0
+BORROW_TIERS = (0.0, 2.7, 8.2)  # bps per CALENDAR day: 0%, ~10%/yr, ~30%/yr
+
+_SERIES = "SELECT DISTINCT series_id FROM research_price_daily WHERE bar_date >= %(s)s ORDER BY series_id"
+_BARS = """
+    SELECT bar_date, open, high, low, close, adj_close, volume
+    FROM research_price_daily
+    WHERE series_id = %(sid)s AND bar_date >= %(s)s
+      AND open > 0 AND high > 0 AND low > 0 AND close > 0 AND adj_close > 0
+    ORDER BY bar_date
+"""
+
+
+def _cluster(groups: dict[date, list[float]]) -> tuple[float, float, int]:
+    means = [float(np.mean(v)) for v in groups.values() if v]
+    if len(means) < 5:
+        return float("nan"), float("nan"), len(means)
+    a = np.asarray(means)
+    m = float(a.mean())
+    se = float(a.std(ddof=1) / np.sqrt(len(a)))
+    return m, (m / se if se > 0 else 0.0), len(a)
+
+
+def main() -> int:
+    by_day: dict[float, dict[date, list[float]]] = defaultdict(lambda: defaultdict(list))
+    flat: dict[float, list[float]] = defaultdict(list)
+    stopped: dict[float, int] = defaultdict(int)
+    gapped: dict[float, int] = defaultdict(int)
+
+    with psycopg.connect(settings.database_url) as conn:
+        sids = [r[0] for r in conn.execute(_SERIES, {"s": START}).fetchall()]
+        print(f"{len(sids):,} series", flush=True)
+        for n, sid in enumerate(sids, start=1):
+            bars = conn.execute(_BARS, {"sid": sid, "s": START}).fetchall()
+            if len(bars) < 60:
+                continue
+            dts = [b[0] for b in bars]
+            op = np.asarray([float(b[1]) for b in bars])
+            hi = np.asarray([float(b[2]) for b in bars])
+            cl = np.asarray([float(b[4]) for b in bars])
+            adj = np.asarray([float(b[5]) for b in bars])
+            vol = np.asarray([float(b[6] or 0.0) for b in bars])
+            f = adj / cl
+            adj_open, adj_hi = op * f, hi * f
+            ret1 = np.empty_like(adj)
+            ret1[0] = np.nan
+            ret1[1:] = adj[1:] / adj[:-1] - 1.0
+            dvol = cl * vol
+
+            for i in range(21, len(cl) - HOLD - 1):
+                if ret1[i] > DROP or cl[i] < MIN_PRICE:
+                    continue
+                if float(np.median(dvol[i - 20 : i])) < MIN_DOLLAR_VOL:
+                    continue
+                entry = adj_open[i + 1]
+                if not np.isfinite(entry) or entry <= 0:
+                    continue
+                day = dts[i + 1]
+                for s in STOPS:
+                    k = -1.0 if s is None else s
+                    exit_px = adj[i + HOLD]
+                    if s is not None:
+                        level = entry * (1.0 + s)
+                        for j in range(i + 1, i + HOLD + 1):
+                            if adj_open[j] >= level:  # gap-through: no stop protection
+                                exit_px = adj_open[j]
+                                stopped[k] += 1
+                                gapped[k] += 1
+                                break
+                            if adj_hi[j] >= level:
+                                exit_px = level
+                                stopped[k] += 1
+                                break
+                    r = -(exit_px / entry - 1.0) * 1e4
+                    by_day[k][day].append(r)
+                    flat[k].append(r)
+            if n % 1000 == 0:
+                print(f"  {n}/{len(sids)}", flush=True)
+
+    print(f"\nSHORT A >={abs(DROP):.0%} ONE-DAY DROP, COVER AFTER {HOLD} BARS, {START} onward")
+    print("entry = SHORT at next bar's adjusted OPEN. stop = cover if price rises that far.")
+    print("⚠ gap-through fills at the OPEN, not the stop level. ⚠ DAY-CLUSTERED t.\n")
+    hdr = f"{'stop':>8}{'trades':>9}{'stopped':>9}{'gapped':>8}{'gross':>9}{'median':>9}{'win%':>7}{'t':>7}"
+    hdr += f"{'ex-top1%':>10}{'worst':>9}" + "".join(f"{f'net@{b}':>9}" for b in BORROW_TIERS)
+    print(hdr)
+    print("-" * len(hdr))
+    for s in STOPS:
+        k = -1.0 if s is None else s
+        m, t, _ = _cluster(by_day[k])
+        arr = np.asarray(flat[k])
+        if arr.size < 100 or not np.isfinite(m):
+            continue
+        ex = arr[arr <= float(np.percentile(arr, 99))]
+        label = "none" if s is None else f"{s:.0%}"
+        line = (
+            f"{label:>8}{arr.size:>9,}{stopped[k]:>9,}{gapped[k]:>8,}{m:>9.1f}"
+            f"{float(np.median(arr)):>9.1f}{float((arr > 0).mean()) * 100:>7.1f}{t:>7.2f}"
+            f"{float(ex.mean()):>10.1f}{arr.min():>9.0f}"
+        )
+        # ⚠ calendar days, because CFD financing accrues at weekends too
+        for b in BORROW_TIERS:
+            line += f"{m - SPREAD_BPS - b * (HOLD * 7 / 5):>9.1f}"
+        print(line)
+
+    print("\n⚠ 'gapped' counts stops that filled at an OPEN above the level -- the case")
+    print("  where the stop gave no protection at all. It is the honest cost of the tail.")
+    print("⚠⚠ Read across: a tighter stop should cut 'worst' hard. If it also cuts")
+    print("   'gross' and 'ex-top1%' to nothing, the tail WAS the strategy and there is")
+    print("   no tradable version -- truncating the loss also truncates the edge.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2437_short_stops.py
+++ b/scripts/verify_2437_short_stops.py
@@ -57,7 +57,19 @@ STOPS = (None, 0.20, 0.12, 0.08, 0.05)  # cover if price rises this far above en
 MIN_PRICE = 20.0
 MIN_DOLLAR_VOL = 10_000_000.0
 SPREAD_BPS = 50.0
-BORROW_TIERS = (0.0, 2.7, 8.2)  # bps per CALENDAR day: 0%, ~10%/yr, ~30%/yr
+BORROW_TIERS = (0.0, 2.7, 8.2)  # bps per financed day: 0%, ~10%/yr, ~30%/yr
+
+# ⚠ How many days of borrow a HOLD-bar position actually pays for.
+# eToro charges the fee at 21:00 GMT each day a position is open and TRIPLES it on
+# Friday for stocks, to cover the weekend. So a 5-trading-day hold pays four ordinary
+# nights plus one Friday at 3x = 4 + 3 = 7 day-equivalents.
+#
+# ⚠ It is a FLAT approximation and coarser than the docstring's prose: a real hold
+# straddles a different number of Fridays depending on the weekday it opens (0 or 1
+# here, more for longer holds), and holidays are ignored entirely. Every hold is
+# charged the worst case of exactly one triple, which errs against the strategy --
+# the right direction for a cost assumption, but it is an assumption, not a model.
+BORROW_DAY_EQUIVALENTS = (HOLD - 1) + 3
 
 _SERIES = "SELECT DISTINCT series_id FROM research_price_daily WHERE bar_date >= %(s)s ORDER BY series_id"
 _BARS = """
@@ -155,9 +167,8 @@ def main() -> int:
             f"{float(np.median(arr)):>9.1f}{float((arr > 0).mean()) * 100:>7.1f}{t:>7.2f}"
             f"{float(ex.mean()):>10.1f}{arr.min():>9.0f}"
         )
-        # ⚠ calendar days, because CFD financing accrues at weekends too
         for b in BORROW_TIERS:
-            line += f"{m - SPREAD_BPS - b * (HOLD * 7 / 5):>9.1f}"
+            line += f"{m - SPREAD_BPS - b * BORROW_DAY_EQUIVALENTS:>9.1f}"
         print(line)
 
     print("\n⚠ 'gapped' counts stops that filled at an OPEN above the level -- the case")


### PR DESCRIPTION
## What this is

Research output, no runtime or trading paths touched. Four read-only verification
scripts plus skill and instruction updates.

The operator permitted **shorting** for research and paper trading on 2026-08-09,
keeping leverage barred until validation. That single decision re-read three results
this research pass had already recorded as failures.

## The finding

"Buy the one-day loser" loses money monotonically — worse with a bigger drop, worse
with a longer hold, worse when fewer names fall alongside. It was written up as a null
three times. It was never a null. An **isolated stock that drops hard keeps dropping**,
and that is the strongest, most consistent effect measured on our corpus. Long-only,
the finding had no expression beyond "do not buy", so it was filed as absence of signal
rather than presence of an inverted one.

**The surviving arm: short a ≥12% one-day drop, cover after 5 bars, 20% stop.**

```
stop   gross  median  win%     t  ex-top1%   worst  net@30%/yr
none   216.3   133.9  54.4  5.59      82.5  -41254       108.9
 20%   156.8    74.1  52.3  4.83      77.6   -8749        49.4
 12%   130.4   -68.7  48.1  4.61      81.0   -8749        23.0
  5%    81.4  -500.0  32.2  3.94      46.6   -3429       -26.0
```

2020+, day-clustered, 1,364 independent event days.

## Why this arm and not its siblings

Each check killed a different one:

- **`ex-top1%` barely moves** (82.5 → 77.6 → 81.0) as the stop tightens. Deleting the
  best 1% of trades tests "is this a lottery on collapses". It is not. Every **10-day**
  arm failed exactly here, inverting to negative with a sub-50% win rate.
- **Delisting is not the driver.** The corpus is survivorship-controlled, so a
  backtested short collects in full from names that went to zero. Dying names are
  0.4-1.0% of trades, their mean is *negative* at −12%, and excluding them **raises**
  the edge (333 → 341 bps).
- **Survives borrow** at a 30%/yr tier.
- **Tighter is not safer** — by a 12% stop the median is negative; by 5% the win rate is
  32%, because the stock spikes, we cover, and the collapse happens without us.

## Risk model

⚠ **A stop does not protect a short against a gap.** 141 of 1,402 stops filled at an
open *above* the level. Worst trade is **−87% even with the 20% stop**, identical at 12%
and 8% — no stop level catches it. Shorts gap against you exactly when the news is good.
**Position sizing must survive −87% on one name regardless of the stop**; that is a
concurrency and weight constraint, not a risk note. The fill model reflects it:
gap-through fills at the open, never at the stop level.

⚠ **Cost model is a CFD, not stock.** Easy-to-borrow costs spread only; hard-to-borrow
(>10%/yr) accrues daily at 21:00 GMT and **triples at weekends**, so borrow accrues per
*calendar* day. Shown at 0/10/30%/yr rather than assumed — eToro exposes no per-symbol
borrow table.

## Three lessons that outrank the strategy

1. **The univariate instrument was broken.** A marginal test estimates `E[r|A]`; a
   trader claims `E[r|A,B,C,D,E]`, and those can have opposite signs. Our own output
   proved it — the −5% drop is −437 bps at breadth 2-5 and **+91 at breadth 101+**. The
   tell was day- and year-clustered `t` disagreeing **in sign**. Test conjunctions by
   alignment-count gradient (one degree of freedom), never 2^N subsets.
2. **Levels need a placebo arm.** Fake Fibonacci 29/44/71 **beat** real 38.2/50/61.8;
   a displaced pseudo-level **beat** real pivot-low support; both real conditions sit
   below the unconditional baseline. Conclusive precisely because the twin received the
   identical measurement.
3. **Era-split before excitement, not as a robustness check.** The gap fade is t 5.73
   over 1962-2026 and t 1.39 over 2020+, with a negative sign pre-2001. The usable
   short-horizon sample is ~6 years.

Also recorded once: the long side keeps failing on **cost**, not signal — 44 bps of
unconditional 10-day drift against a 50 bps round trip means the whole long-only
short-horizon game is played inside the spread.

## Not done, and explicitly not claimed

⚠ **This arm emerged from ~100 tested arms in one session.** `t 4.83` searched-over is
not `t 4.83` pre-registered; at 100 trials the deflated-Sharpe bar is ≈0.174. It needs
registering in `trial_register.py` with the full search count.

Outstanding before it is a strategy: portfolio simulation (per-trade says nothing about
an equity curve at ~6 concurrent firings/day), eToro borrow availability at firing time,
and a genuine out-of-sample window.

## Security

No security model touched. All four scripts are read-only measurement against the dev
research corpus; nothing writes, and no endpoint, credential or trading path changes.

## Verification

`ruff check`, `ruff format --check`, `pyright` clean on all four scripts. Each was run
to completion against the dev corpus and its output is quoted in the commit messages.
No schema, parser or ETL change, so Definition-of-Done clauses 8-12 do not apply.

Refs #2437.
