### PR TITLE
feat(#2437): validate the strategy automation control plane

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -11,17 +11,46 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
 ## Verification protocol
 
 1. **Index:** fetch `https://api-portal.etoro.com/llms.txt` — lists every doc page slug, grouped (trading-real, trading-demo, market-data, …).
-2. **Endpoint detail:** fetch the specific page as markdown: `https://api-portal.etoro.com/api-reference/<section>/<slug>.md` — full method/path/body/response/auth/rate-limit per page.
+2. **Endpoint detail:** fetch `https://api-portal.etoro.com/api-reference/<section>/<slug>`
+   through the browser tool — full method/path/body/response/auth/rate-limit per
+   page. The `.md` form and direct `curl` may be rejected even when the HTML page
+   is live; navigate from a neighbouring live page when the safe-open check
+   rejects a double-hyphen section slug.
 3. **Spec version:** the api-reference index page states the current OpenAPI version — record it in anything you write ("verified against vX.Y.Z on DATE").
 4. **Tooling:** use WebFetch (or the running app's HTTP client). **`curl` from CLI gets Cloudflare-blocked (403 "Attention Required")** — the portal allows browser-agent fetches only.
 5. When our code disagrees with the live doc but works (e.g. close body: doc says `InstrumentID` required, `close_position()` omits it), note the discrepancy where you found it and verify empirically on demo before relying on either.
 
-## Stable facts (re-verify anything load-bearing; last verified 2026-07-04, spec v1.279.0)
+## Stable facts (re-verify anything load-bearing; market/trading index re-verified 2026-08-09)
 
 - Base URL `https://public-api.etoro.com`; auth headers `x-api-key` + `x-user-key` + `x-request-id` (UUID); demo endpoints carry `/demo/` in the path.
-- Rate limits: 60 GET/min shared; writes ~20/min shared across related endpoints. 429 → `{"errorCode": "TooManyRequests"}`, no guaranteed Retry-After.
+- Rate limits have DRIFTED. The live portal index on 2026-08-09 documents the
+  market-data family at **120 GET/min shared**, ordinary trading reads at 60/min
+  shared, order writes at 20/min shared, and eligibility/what-if-cost endpoints
+  at 20/min dedicated. Do not retain the older blanket 60-GET/min assumption.
+  429 → `{"errorCode": "TooManyRequests"}`, no guaranteed Retry-After.
 - Trading (verified live): open by-amount/by-units; close per position with optional `UnitsToDeduct` (partial); **`PATCH /api/v2/trading[/demo]/positions/{positionId}`** for TP/SL edit (`stopLossRate`, `takeProfitRate`, `stopLossType` fixed|trailing, `clearStopLoss`, `clearTakeProfit`; ≥1 field; **202 async** `{operationId, positionId, referenceId}`).
 - Write ops are asynchronous (202) — re-sync portfolio before treating them as landed.
+- **Two trading preflight endpoints exist in BOTH demo and real**, each at a
+  dedicated 20 requests/minute: `POST /api/v2/trading/info/{demo|real}/eligibility`
+  and `POST /api/v2/trading/info/{demo|real}/costs`. Eligibility accepts at most
+  100 ids/symbols and returns open/close/partial-close permission, min exposure,
+  max units, order-quantity/fill types and per-settlement/per-direction leverage
+  configs with SL/TP limits. What-if accepts `buy` or `sellShort` opens and
+  returns an OPEN vocabulary of named cost rows (documented examples include
+  markup, market spread, transaction fee, overnight, weekend and tax) plus
+  `lastUpdated`. **Observed demo 2026-08-09: live rows used `value` and omitted
+  the documented `amount`; the unit/scale of `value` is not established, and
+  `lastUpdated` can be stale even on an HTTP-success response.** Preserve both
+  fields and the timestamp, and fail any future execution gate until the unit,
+  completeness and freshness contract is empirically proved. Never coerce a
+  missing field to zero. Thin, non-persisting adapters are wired in
+  `EtoroBrokerProvider`; a broader authenticated demo population probe is still
+  required before a storage schema or execution gate is promoted.
+- **Order-to-position reconciliation exists in v2:**
+  `GET /api/v2/trading/info/{demo|real}/orders:lookup` returns
+  `positionExecutions[].positionId`. This is the durable way to bind a submitted
+  strategy entry to the exact position it owns; do not infer the position from
+  instrument or FIFO order.
 
 ## ⚠⚠ WE HAVE INTRADAY HISTORY. Read this before saying otherwise — MEASURED 2026-08-09
 
@@ -69,15 +98,16 @@ Reproduce: `curl -s "http://localhost:8000/_debug/etoro-candles-probe?instrument
 
 | capability | what it gives | limit |
 | --- | --- | --- |
-| REST intraday candles | OHLCV history, any instrument, on demand | 1000 bars, no date anchor; **60 GET/min shared** |
+| REST intraday candles | OHLCV history, any instrument, on demand | 1000 bars, no date anchor; **120 market-data GET/min shared** |
 | WS rate stream | live bid/ask/last ticks, all instruments | no depth, no sizes; forward-only |
 | `research_price_daily` | 25.9M daily bars 1962-2026, survivorship-controlled | daily granularity only |
 
-⚠ **Corpus arithmetic, because the rate limit binds hard.** 60 GET/min shared means a
-full 6,700-instrument intraday pull is **~112 minutes per interval per pass**, and it
-competes with every other eToro call. A cross-sectional intraday study is therefore a
-*scheduled harvest*, not an ad-hoc query — budget for it in the design, and prefer
-`FourHours` (deepest history per request) when bootstrapping.
+⚠ **Corpus arithmetic, because the rate limit binds hard.** The currently
+documented 120 market-data GET/min shared gives a full 6,700-instrument pull a
+theoretical floor of **~56 minutes per interval per pass**, and it competes with
+every other market-data call. A cross-sectional intraday study is therefore a
+*scheduled harvest*, not an ad-hoc query — budget for it in the design, and
+prefer `FourHours` (deepest history per request) when bootstrapping.
 
 ## Scope boundary — what this file is NOT
 

--- a/.claude/skills/quant/measurement-discipline.md
+++ b/.claude/skills/quant/measurement-discipline.md
@@ -142,10 +142,13 @@ conditions, then bucket the outcome by **how many are simultaneously true** and 
 for a gradient. Searching all subsets on 6,700 stocks over six years manufactures a
 winner every time; a monotonic gradient across alignment counts does not.
 
-⚠ And know what a flat gradient means. Ours rose sharply from 0 to ~4 aligned and
-then went flat: **confluence identified what to avoid and not what to buy.** That is
-a real result — a filter is not a signal — and it is only visible because the
-marginals were printed alongside the buckets.
+⚠ And know what a flat gradient means. After correcting the #2437 next-session
+market-return leak, ours is noisy rather than monotonic: at 10 days the `vs base`
+column runs −35, −28, −39, −17, −10, approximately 0, +5, +2, −6, +14, −26,
++15 bps as alignment rises from 0 to 11. The sparse 9/11 cells do not rescue the
+lack of a gradient. **Equal-count confluence did not identify a buy signal or a
+stable filter.** Reproduce with
+`PYTHONPATH=. uv run python scripts/verify_2437_confluence.py`.
 
 ### 1.7 ⚠⚠ A level type is only real if it beats its own placebo
 
@@ -167,13 +170,14 @@ P1 fake fib 29/44/71    18.82 (t 2.79)   44.45 (t 4.76)
 
 ⚠⚠ **Both placebos BEAT the real thing, and both real levels sit below the
 unconditional baseline (44.28 bps).** Arbitrary fractions 29/44/71 outperform
-38.2/50/61.8; a displaced pseudo-level outperforms an actual pivot low. This matches
-the 2021 study finding Fibonacci zones do not beat non-Fibonacci zones, and goes
-further by killing support proximity too.
+38.2/50/61.8; a displaced pseudo-level outperforms an actual pivot low. This
+falsifies unique unconditional directional value for THESE constructions. It does
+not falsify every causal support/resistance definition or their possible value for
+path geometry, invalidation, or exits.
 
-⚠ Note what makes this conclusive rather than another null: the real condition and
-its twin are **indistinguishable, and the twin won**. That cannot be explained by
-"we measured it badly" — the same measurement was applied to both.
+⚠ The placebo comparison is evidence against the specified level rules, not a
+universal claim about chart structure. A new construction is a new registered
+trial and still needs a matched firing-rate placebo.
 
 ### 1.8 ⚠⚠ Era-split before you get excited, not as a robustness check
 
@@ -267,6 +271,29 @@ profitable simple rule remained** on the DJIA, S&P 500 or S&P futures.
 
 ⚠ The register is a documented **floor** — under-counting `M` raises the DSR, so
 every stored value is an upper bound on the honest one.
+
+### 3.1 "Test every combination" is not exhaustive subset search
+
+An operator asking to validate every strategy is asking for **complete coverage
+of the declared catalogue**, not permission to enumerate every subset of every
+indicator and retain the winner. With `N` binary conditions there are `2^N`
+subsets before thresholds, windows, directions, stops and universes multiply the
+search again. The winning backtest from that search is a selection artefact until
+the entire search count is charged and untouched evidence confirms it.
+
+> **Rule: CI must prove every implementation is registered and every registered
+> version receives the same test matrix. Statistical combinations must be
+> bounded, pre-registered interaction hypotheses with an economic rationale.**
+
+Exhaustive tests belong on finite software state spaces — outcome classes,
+ownership transitions, missing-field combinations and closed vocabularies — not
+on an unbounded strategy powerset. Failed strategies and rejected combinations
+remain visible in the result catalogue; hiding them undercounts the trial budget.
+
+⚠ Allocating more capital to whichever strategy just performed best is itself a
+new timing strategy. Register and backtest that allocation rule, or keep capital
+changes as explicit operator decisions. Do not smuggle performance chasing into
+a "picker" and then attribute its result to the underlying strategies.
 
 ---
 

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -19,6 +19,9 @@ from decimal import Decimal
 from typing import Any, Literal
 
 OrderStatus = Literal["filled", "pending", "rejected", "failed"]
+TradeDirection = Literal["buy", "sellShort"]
+SettlementType = Literal["cfd", "real", "realFutures", "marginTrade"]
+PreflightOrderType = Literal["mkt", "mit", "limitIOC"]
 
 
 @dataclass(frozen=True)
@@ -45,6 +48,105 @@ class OrderParams:
     take_profit_rate: Decimal | None = None
     is_tsl_enabled: bool = False
     leverage: int = 1
+
+
+@dataclass(frozen=True)
+class BrokerWhatIfOrder:
+    """A non-executing order shape for eToro's v2 cost preflight.
+
+    v1 deliberately supports the two transactions the current endpoint accepts
+    for an ``open`` action.  This type is evidence collection, not permission to
+    execute shorts: the execution path remains long-only until a separately
+    validated strategy and guard contract promote it.
+    """
+
+    instrument_id: int
+    transaction: TradeDirection
+    settlement_type: SettlementType
+    amount: Decimal | None = None
+    units: Decimal | None = None
+    order_type: PreflightOrderType = "mkt"
+    leverage: int = 1
+    order_currency: str = "usd"
+
+    def __post_init__(self) -> None:
+        if self.instrument_id <= 0:
+            raise ValueError("instrument_id must be positive")
+        if (self.amount is None) == (self.units is None):
+            raise ValueError("exactly one of amount or units must be provided")
+        value = self.amount if self.amount is not None else self.units
+        if value is None or value <= 0:
+            raise ValueError("amount or units must be positive")
+        if self.leverage < 1:
+            raise ValueError("leverage must be at least 1")
+        if self.order_currency.lower() != "usd":
+            raise ValueError("the current eToro preflight endpoint supports USD only")
+
+
+@dataclass(frozen=True)
+class BrokerLeverageConfig:
+    """One direction/settlement arm returned by trading eligibility."""
+
+    settlement_type: str
+    direction: str
+    leverage_values: tuple[int, ...]
+    min_position_amount: Decimal | None
+    allow_edit_stop_loss: bool | None
+    allow_edit_take_profit: bool | None
+    allow_stop_loss_take_profit: bool | None
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerInstrumentEligibility:
+    """Account-specific eligibility for one instrument at request time."""
+
+    instrument_id: int
+    symbol: str | None
+    min_position_exposure: Decimal | None
+    max_units_per_order: Decimal | None
+    allow_open_position: bool
+    allow_close_position: bool
+    allow_partial_close_position: bool
+    allow_trailing_stop_loss: bool
+    leverage_configs: tuple[BrokerLeverageConfig, ...]
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerEligibilityResponse:
+    """The complete resolved/not-found result of an eligibility preflight."""
+
+    currency: str
+    eligibilities: tuple[BrokerInstrumentEligibility, ...]
+    not_found_instrument_ids: tuple[int, ...]
+    not_found_symbols: tuple[str, ...]
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerCostComponent:
+    """One broker-named cost component; the vocabulary remains provider-owned."""
+
+    cost_type: str
+    # The docs show ``amount`` while the live demo response used ``value``.
+    # Preserve both until the provider documents or a controlled probe proves
+    # the unit semantics. Neither may be silently substituted for the other.
+    amount: Decimal | None
+    value: Decimal | None
+    currency: str
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerWhatIfCostResponse:
+    """Current broker cost estimate for a hypothetical order."""
+
+    instrument_id: int
+    symbol: str | None
+    costs: tuple[BrokerCostComponent, ...]
+    last_updated: datetime
+    raw_payload: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -235,4 +337,20 @@ class BrokerProvider(ABC):
         fakes that implement only the abstract surface keep working;
         the eToro implementation overrides it.
         """
+        raise NotImplementedError
+
+    def check_instrument_eligibility(
+        self,
+        instrument_ids: Sequence[int],
+    ) -> BrokerEligibilityResponse:
+        """Fetch current account-specific trading constraints without trading.
+
+        Non-abstract so existing provider fakes remain source compatible.  A
+        strategy execution gate must treat ``NotImplementedError`` as a refusal,
+        never as eligibility.
+        """
+        raise NotImplementedError
+
+    def get_what_if_costs(self, order: BrokerWhatIfOrder) -> BrokerWhatIfCostResponse:
+        """Fetch current broker-estimated costs without placing an order."""
         raise NotImplementedError

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -24,12 +24,18 @@ import httpx
 from app.config import settings
 from app.providers.broker import (
     BrokerClosedTrade,
+    BrokerCostComponent,
+    BrokerEligibilityResponse,
+    BrokerInstrumentEligibility,
+    BrokerLeverageConfig,
     BrokerMirror,
     BrokerMirrorPosition,
     BrokerOrderResult,
     BrokerPortfolio,
     BrokerPosition,
     BrokerProvider,
+    BrokerWhatIfCostResponse,
+    BrokerWhatIfOrder,
     OrderParams,
     OrderStatus,
 )
@@ -82,6 +88,15 @@ class TradeHistoryParseError(Exception):
     Same design as PortfolioParseError: directly subclasses Exception
     so it is never swallowed by the incidental-exception handlers
     inside the parse loop.
+    """
+
+
+class TradingPreflightParseError(Exception):
+    """Raised when a trading preflight response cannot be trusted.
+
+    Eligibility and cost data are safety inputs.  A partial best-effort parse
+    could turn an absent restriction or fee into permission, so malformed
+    responses fail the whole preflight instead of dropping fields or rows.
     """
 
 
@@ -148,6 +163,7 @@ class EtoroBrokerProvider(BrokerProvider):
         env_segment = f"/{env}" if env == "demo" else ""
         self._exec_prefix = f"/api/v1/trading/execution{env_segment}"
         self._info_prefix = f"/api/v1/trading/info{env_segment}"
+        self._v2_info_prefix = f"/api/v2/trading/info/{env}"
 
     def __enter__(self) -> EtoroBrokerProvider:
         return self
@@ -397,6 +413,64 @@ class EtoroBrokerProvider(BrokerProvider):
 
         return _normalise_order_info_response(raw, broker_order_ref)
 
+    def check_instrument_eligibility(
+        self,
+        instrument_ids: Sequence[int],
+    ) -> BrokerEligibilityResponse:
+        """Call the current v2 account-specific eligibility endpoint.
+
+        This is intentionally a non-persisting capability slice.  The caller
+        decides whether an observed response is worth storing after coverage,
+        change frequency, and byte cost have been measured.
+        """
+        ids = tuple(instrument_ids)
+        if not ids:
+            raise ValueError("instrument_ids must not be empty")
+        if len(ids) > 100:
+            raise ValueError("eToro eligibility accepts at most 100 instruments")
+        if any(instrument_id <= 0 for instrument_id in ids):
+            raise ValueError("instrument_ids must all be positive")
+        if len(set(ids)) != len(ids):
+            raise ValueError("instrument_ids must not contain duplicates")
+
+        response = self._http_write.post(
+            f"{self._v2_info_prefix}/eligibility",
+            json={"instrumentIds": list(ids), "currency": "USD"},
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        raw = response.json()
+        if not isinstance(raw, dict):
+            raise TradingPreflightParseError("eligibility response must be an object")
+        return _parse_eligibility_response(raw)
+
+    def get_what_if_costs(self, order: BrokerWhatIfOrder) -> BrokerWhatIfCostResponse:
+        """Call the current v2 what-if endpoint without placing an order."""
+        body: dict[str, Any] = {
+            "action": "open",
+            "transaction": order.transaction,
+            "instrumentId": order.instrument_id,
+            "settlementType": order.settlement_type,
+            "orderType": order.order_type,
+            "leverage": order.leverage,
+            "orderCurrency": order.order_currency.lower(),
+        }
+        if order.amount is not None:
+            body["amount"] = float(order.amount)
+        else:
+            body["units"] = float(order.units) if order.units is not None else None
+
+        response = self._http_write.post(
+            f"{self._v2_info_prefix}/costs",
+            json=body,
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        raw = response.json()
+        if not isinstance(raw, dict):
+            raise TradingPreflightParseError("what-if cost response must be an object")
+        return _parse_what_if_cost_response(raw)
+
     # ------------------------------------------------------------------
     # Portfolio reads
     # ------------------------------------------------------------------
@@ -524,6 +598,139 @@ def _normalise_order_info_response(
     ``amount``, ``units``, and ``positions[]`` with ``positionID``.
     """
     return _build_result(raw, raw, fallback_ref=broker_order_ref)
+
+
+def _required_bool(payload: dict[str, Any], key: str) -> bool:
+    value = payload.get(key)
+    if not isinstance(value, bool):
+        raise TradingPreflightParseError(f"{key} must be a boolean")
+    return value
+
+
+def _optional_decimal(payload: dict[str, Any], key: str) -> Decimal | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except decimal.DecimalException as exc:
+        raise TradingPreflightParseError(f"{key} must be numeric or null") from exc
+
+
+def _parse_eligibility_response(raw: dict[str, Any]) -> BrokerEligibilityResponse:
+    """Strictly parse the documented v2 eligibility response."""
+    currency = raw.get("currency")
+    rows = raw.get("eligibilities")
+    missing_ids = raw.get("notFoundInstrumentIds")
+    missing_symbols = raw.get("notFoundSymbols")
+    if not isinstance(currency, str) or not currency:
+        raise TradingPreflightParseError("eligibility currency must be a non-empty string")
+    if not isinstance(rows, list) or not isinstance(missing_ids, list) or not isinstance(missing_symbols, list):
+        raise TradingPreflightParseError("eligibility response arrays are missing or malformed")
+
+    parsed: list[BrokerInstrumentEligibility] = []
+    try:
+        for row in rows:
+            if not isinstance(row, dict):
+                raise TradingPreflightParseError("eligibilities entries must be objects")
+            leverage_rows = row.get("leverageConfigs")
+            if not isinstance(leverage_rows, list):
+                raise TradingPreflightParseError("leverageConfigs must be an array")
+            leverage_configs: list[BrokerLeverageConfig] = []
+            for config in leverage_rows:
+                if not isinstance(config, dict):
+                    raise TradingPreflightParseError("leverageConfigs entries must be objects")
+                values = config.get("leverageValues")
+                if not isinstance(values, list) or any(not isinstance(value, int) for value in values):
+                    raise TradingPreflightParseError("leverageValues must be an integer array")
+                leverage_configs.append(
+                    BrokerLeverageConfig(
+                        settlement_type=str(config["settlementType"]),
+                        direction=str(config["direction"]),
+                        leverage_values=tuple(values),
+                        min_position_amount=_optional_decimal(config, "minPositionAmount"),
+                        allow_edit_stop_loss=config.get("allowEditStopLoss")
+                        if isinstance(config.get("allowEditStopLoss"), bool)
+                        else None,
+                        allow_edit_take_profit=config.get("allowEditTakeProfit")
+                        if isinstance(config.get("allowEditTakeProfit"), bool)
+                        else None,
+                        allow_stop_loss_take_profit=config.get("allowStopLossTakeProfit")
+                        if isinstance(config.get("allowStopLossTakeProfit"), bool)
+                        else None,
+                        raw_payload=dict(config),
+                    )
+                )
+            symbol = row.get("symbol")
+            if symbol is not None and not isinstance(symbol, str):
+                raise TradingPreflightParseError("symbol must be a string or null")
+            parsed.append(
+                BrokerInstrumentEligibility(
+                    instrument_id=int(row["instrumentId"]),
+                    symbol=symbol,
+                    min_position_exposure=_optional_decimal(row, "minPositionExposure"),
+                    max_units_per_order=_optional_decimal(row, "maxUnitsPerOrder"),
+                    allow_open_position=_required_bool(row, "allowOpenPosition"),
+                    allow_close_position=_required_bool(row, "allowClosePosition"),
+                    allow_partial_close_position=_required_bool(row, "allowPartialClosePosition"),
+                    allow_trailing_stop_loss=_required_bool(row, "allowTrailingStopLoss"),
+                    leverage_configs=tuple(leverage_configs),
+                    raw_payload=dict(row),
+                )
+            )
+        return BrokerEligibilityResponse(
+            currency=currency,
+            eligibilities=tuple(parsed),
+            not_found_instrument_ids=tuple(int(value) for value in missing_ids),
+            not_found_symbols=tuple(str(value) for value in missing_symbols),
+            raw_payload=raw,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise TradingPreflightParseError(f"malformed eligibility response: {exc}") from exc
+
+
+def _parse_what_if_cost_response(raw: dict[str, Any]) -> BrokerWhatIfCostResponse:
+    """Strictly parse the documented v2 cost response without closing its vocabulary."""
+    rows = raw.get("costs")
+    if not isinstance(rows, list):
+        raise TradingPreflightParseError("costs must be an array")
+    symbol = raw.get("symbol")
+    if symbol is not None and not isinstance(symbol, str):
+        raise TradingPreflightParseError("symbol must be a string or null")
+    try:
+        costs: list[BrokerCostComponent] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                raise TradingPreflightParseError("cost entries must be objects")
+            cost_type = row["costType"]
+            currency = row["currency"]
+            if not isinstance(cost_type, str) or not cost_type or not isinstance(currency, str) or not currency:
+                raise TradingPreflightParseError("cost type and currency must be non-empty strings")
+            amount = _optional_decimal(row, "amount")
+            value = _optional_decimal(row, "value")
+            if amount is None and value is None:
+                raise TradingPreflightParseError("cost row must carry amount or value")
+            costs.append(
+                BrokerCostComponent(
+                    cost_type=cost_type,
+                    amount=amount,
+                    value=value,
+                    currency=currency,
+                    raw_payload=dict(row),
+                )
+            )
+        last_updated = datetime.fromisoformat(str(raw["lastUpdated"]).replace("Z", "+00:00"))
+        if last_updated.tzinfo is None:
+            raise TradingPreflightParseError("lastUpdated must include a timezone")
+        return BrokerWhatIfCostResponse(
+            instrument_id=int(raw["instrumentId"]),
+            symbol=symbol,
+            costs=tuple(costs),
+            last_updated=last_updated,
+            raw_payload=raw,
+        )
+    except (KeyError, TypeError, ValueError) as exc:
+        raise TradingPreflightParseError(f"malformed what-if cost response: {exc}") from exc
 
 
 def _parse_direct_position(payload: dict[str, Any]) -> BrokerPosition:

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -643,20 +643,21 @@ def _parse_eligibility_response(raw: dict[str, Any]) -> BrokerEligibilityRespons
                 values = config.get("leverageValues")
                 if not isinstance(values, list) or any(not isinstance(value, int) for value in values):
                     raise TradingPreflightParseError("leverageValues must be an integer array")
+                allow_edit_stop_loss = config.get("allowEditStopLoss")
+                allow_edit_take_profit = config.get("allowEditTakeProfit")
+                allow_stop_loss_take_profit = config.get("allowStopLossTakeProfit")
                 leverage_configs.append(
                     BrokerLeverageConfig(
                         settlement_type=str(config["settlementType"]),
                         direction=str(config["direction"]),
                         leverage_values=tuple(values),
                         min_position_amount=_optional_decimal(config, "minPositionAmount"),
-                        allow_edit_stop_loss=config.get("allowEditStopLoss")
-                        if isinstance(config.get("allowEditStopLoss"), bool)
+                        allow_edit_stop_loss=allow_edit_stop_loss if isinstance(allow_edit_stop_loss, bool) else None,
+                        allow_edit_take_profit=allow_edit_take_profit
+                        if isinstance(allow_edit_take_profit, bool)
                         else None,
-                        allow_edit_take_profit=config.get("allowEditTakeProfit")
-                        if isinstance(config.get("allowEditTakeProfit"), bool)
-                        else None,
-                        allow_stop_loss_take_profit=config.get("allowStopLossTakeProfit")
-                        if isinstance(config.get("allowStopLossTakeProfit"), bool)
+                        allow_stop_loss_take_profit=allow_stop_loss_take_profit
+                        if isinstance(allow_stop_loss_take_profit, bool)
                         else None,
                         raw_payload=dict(config),
                     )

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -75,7 +75,8 @@ Two-tier system, tracked per user key over a **1-minute rolling window**:
 
 | Tier | Limit | Applies to |
 |------|-------|------------|
-| **Standard** | **60 req/min** | All GET requests: market data, portfolio info, social reads, watchlist reads |
+| **Market data** | **120 req/min shared** | Instruments, rates, candles, closing prices, search and lookup catalogues; live portal index verified 2026-08-09 |
+| **Standard** | **60 req/min** | Ordinary portfolio/social/watchlist reads unless an endpoint declares another pool |
 | **Heavy** | **20 req/min** | All POST/PUT/DELETE: trade execution, watchlist writes, social writes |
 
 Exceeding returns **429 Too Many Requests**:
@@ -143,7 +144,10 @@ GET+POST requests cannot exceed the API limit.
 | DELETE | `/api/v1/trading/execution/market-open-orders/{orderId}` | Cancel pending open order | Not used (v1) |
 | POST | `/api/v1/trading/execution/market-close-orders/positions/{positionId}` | Close position — body `UnitsToDeduct` nullable → partial close (omit = full). Live doc also lists `InstrumentID` required; our impl omits it — verify on demo before relying | **Active** (full close; partial plumbed in provider, unexposed) |
 | DELETE | `/api/v1/trading/execution/market-close-orders/{orderId}` | Cancel pending close order | Not used (v1) |
-| PATCH | `/api/v2/trading/positions/{positionId}` | Edit TP/SL on open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). **202 async** `{operationId, positionId, referenceId}` — re-sync before treating as landed. Added between v1.158 and v1.279 (was orphaned `putTradeRequest` schema) | Planned — position detail page (spec 2026-07-04) |
+| PATCH | `/api/v2/trading/{real\|demo}/positions/{positionId}` | Edit TP/SL on one exact open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). Async acceptance `{operationId, positionId, referenceId}` — re-sync before treating as landed | Planned — required for strategy-owned ratchets |
+| POST | `/api/v2/trading/info/{real\|demo}/eligibility` | Up to 100 ids/symbols; account-specific open/close/partial-close permission, min exposure, max units, order/fill types, and leverage + SL/TP constraints by settlement/direction | **Adapter implemented; no persistence/execution gate yet** |
+| POST | `/api/v2/trading/info/{real\|demo}/costs` | What-if open cost rows for `buy` / `sellShort`: open vocabulary including spread, markup, transaction, overnight/weekend and tax; returns `lastUpdated`. Demo returned `value` while omitting documented `amount`; units and freshness are not yet proved | **Adapter implemented; no persistence/execution gate yet** |
+| GET | `/api/v2/trading/info/{real\|demo}/orders:lookup` | Detailed order and `positionExecutions[].positionId`; required to bind an entry order to the exact broker position | Not used — execution reconciliation gap |
 | POST | `/api/v1/trading/execution/limit-orders` | Limit/MIT order | Not used (v1 is market-only) |
 | DELETE | `/api/v1/trading/execution/limit-orders/{orderId}` | Cancel limit order | Not used (v1) |
 | GET | `/api/v1/trading/info/portfolio` | Full portfolio: positions, orders, mirrors, credit | **Active** — portfolio sync |
@@ -151,9 +155,30 @@ GET+POST requests cannot exceed the API limit.
 | GET | `/api/v1/trading/info/real/orders/{orderId}` | Single order status | **Active** — order polling |
 | GET | `/api/v1/trading/info/trade/history` | Trade history (`minDate` required) | Not used (v1) |
 
+⚠ **Live portal drift, detail pages verified 2026-08-09:** both preflights are
+v2 POSTs and each has a dedicated **20 requests/minute** limit. Their documented
+schemas are now represented by the non-persisting `BrokerEligibilityResponse`
+and `BrokerWhatIfCostResponse` adapters. Documentation examples are not population
+evidence: probe a bounded demo cohort before deciding which fields change often,
+which settlement/direction arms are actually returned, and whether observed
+`sellShort` eligibility and costs are adequate for a short strategy.
+
+The first authenticated demo census (2026-08-09, four exact members of the
+validated US-equity universe) found that HTTP success is not equivalent to
+orderability or current cost evidence. One instrument had
+`allowOpenPosition=false` despite eBull's stored `is_tradable=true`; the returned
+settlement/direction/leverage arms varied materially; minimum exposure ranged
+from USD 10 to USD 1,000; cost rows used `value` rather than documented
+`amount`; and one response's `lastUpdated` was more than five months old. This
+is sufficient to reject the current local tradability flag as an execution
+gate, but not sufficient to infer `value` units or full-universe coverage.
+
 ### Trading — Demo
 
-Same operations as Real, all prefixed with `/demo/` (e.g., `/api/v1/trading/execution/demo/market-open-orders/by-amount`; v2 TP/SL edit: `/api/v2/trading/demo/positions/{positionId}`).
+Same operations as Real with environment-specific paths (e.g., legacy v1 open:
+`/api/v1/trading/execution/demo/market-open-orders/by-amount`; current v2 TP/SL
+edit: `/api/v2/trading/demo/positions/{positionId}`; current v2 info:
+`/api/v2/trading/info/demo/...`).
 
 ### Agent portfolios (copy-trading management)
 

--- a/docs/proposals/ta/2026-08-09-evidence-backed-signal-engine.md
+++ b/docs/proposals/ta/2026-08-09-evidence-backed-signal-engine.md
@@ -1,0 +1,437 @@
+# Evidence-backed signal engine — validated inputs and free-source boundary
+
+Date: 2026-08-09
+Status: Research correction and implementation boundary
+Parent: #2437
+
+Companion implementation/control-plane contract:
+`2026-08-09-strategy-automation-control-plane.md`. It owns promotion, allocation,
+manual-position isolation, monitoring/P&L, bounded signal retention and the
+paper-to-live slice order; this document owns evidence, inputs and observation
+storage.
+
+## Decision
+
+Build a **cost-aware probability-of-path engine** for daily-to-multi-day setups,
+with intraday data used for causal confirmation and execution. Do not build an
+equal-vote indicator checklist and do not describe it as market making.
+
+A candidate becomes orderable only when all four independent gates pass:
+
+```text
+causal signal + positive net expectancy + executable quote + portfolio capacity
+```
+
+The output is not `BUY` or `SELL`. It is an auditable record containing the
+feature snapshot, target/stop/timeout geometry, calibrated probabilities,
+estimated costs, size, rejection reasons, and strategy/data versions.
+
+## Relevance window and market-regime contract
+
+The full 1962-2026 research corpus is an artefact/stress resource, not the
+headline benchmark for a strategy intended to trade after 2026. Decimalisation,
+electronic execution, Reg NMS, retail commission compression, broker product
+rules, participation and settlement have changed the mechanism that generates
+short-horizon returns and costs.
+
+Use fixed, disclosed views rather than selecting the cutoff that makes a rule win:
+
+```text
+primary relevance window   2022-01-01 onward
+recent sensitivity         rolling latest 24 and 36 months
+year/regime stability      each calendar year and declared structural regime
+older history              falsification and tail stress only
+forward evidence           immutable observation after rule freeze
+```
+
+The 2022 boundary is a versioned project construction, not a published natural
+law. It starts after the exceptional 2020-2021 zero-rate/meme stimulus interval
+and supplies more than a single year of observations. It must not be moved after
+results are opened. Report 2020+ beside it as a pandemic-era sensitivity arm,
+never pool pre-2000 observations into the primary statistic, and never claim that
+any historical window substitutes for post-freeze forward evidence.
+
+Promotion requires the sign and economic conclusion to survive the primary
+window and both recent sensitivities. Older data may kill a mechanism through a
+known artefact or tail, but may not rescue a strategy that fails recently.
+
+## Correction to the #2437 evidence
+
+`scripts/verify_2437_confluence.py` previously grouped returns by the next-open
+entry date and also used that date for market breadth and the 21-day market leg.
+That leaked the entry session's market return into a signal stated to be known at
+the prior close. The reported `breadth up day` marginal and every alignment-count
+result containing conditions 5 or 11 are invalid until recomputed.
+
+The script now separates `signal_date` from `entry_date`, fails closed when the
+signal-date market context is absent, and has a regression test. No prior
+confluence figure may be carried into a strategy specification.
+
+Full-population rerun, 2,353,114 stock-days:
+
+```text
+10-day unconditional baseline       44.28 bps
+10-day breadth-up condition          37.70 bps
+alignment-count vs-base sequence    -35, -28, -39, -17, -10, 0,
+                                     +5, +2, -6, +14, -26, +15 bps
+```
+
+The alignment sequence is not monotonic and its largest counts are sparse. Equal
+counting supplies no validated confluence signal. Reproduce with:
+`PYTHONPATH=. uv run python scripts/verify_2437_confluence.py`.
+
+The separate short-continuation result does not use this confluence code and is
+not invalidated by this defect. It remains exploratory because its five-bar
+cohorts overlap, its ~100 searches are undeclared, and it has no executable
+portfolio or forward sample.
+
+## Published evidence: what is justified to test
+
+These papers support **bounded hypotheses**, not implementation constants.
+
+| hypothesis family | evidence-supported statement | eBull test boundary |
+| --- | --- | --- |
+| intraday market momentum | Gao, Han, Li and Zhou find that the US market/ETF first half-hour return predicts the last half-hour return, with stronger predictability on high-volatility and high-volume days | Test on very liquid ETFs first. Do not generalise the published ETF result to individual stocks without a separate arm. |
+| short-term reversal / liquidity provision | Nagel finds reversal-strategy returns vary with VIX and rise in market turmoil, consistent with constrained liquidity provision | Test volatility regime as an interaction. It does not establish that buying every loser is profitable after eToro costs. |
+| market dependence | Replication evidence outside the US is mixed; an Australian study reproduces the US method but finds no local effect | Exchange/region is part of strategy identity. Pooling markets is prohibited. |
+| stops | Published stop-loss evidence is conditional on serial dependence and strategy family | Stops are risk-distribution parameters and require their own path backtest; they are never assumed to add edge. |
+
+Primary pages:
+
+- Gao et al., *Journal of Financial Economics*, 2018:
+  https://doi.org/10.1016/j.jfineco.2018.05.009
+- Nagel, *Review of Financial Studies*, 2012:
+  https://doi.org/10.1093/rfs/hhs066
+- Ho, Lv and Schultz, *Pacific-Basin Finance Journal*, 2021:
+  https://doi.org/10.1016/j.pacfin.2021.101499
+
+## The mathematical contract
+
+For instrument `i` at completed signal bar `t`, construct only point-in-time
+features:
+
+```text
+X(i,t) = price shock, trend, structure, volatility, volume,
+         market/sector context, liquidity, catalyst, session state
+```
+
+Minimum price-state definitions:
+
+```text
+log_return       = ln(adj_close[t] / adj_close[t-1])
+residual_return  = instrument_return - beta_market*market_return
+                   - beta_sector*sector_return
+shock_z          = residual_return / trailing_realised_volatility
+close_location   = (2*close - high - low) / (high - low)
+level_distance   = (price - causal_level) / ATR14
+```
+
+`beta_market` and `beta_sector` are trailing estimates ending at `t`; missing
+benchmarks make the residual feature unavailable rather than zero. The first
+implementation must also retain the raw return so the residual construction can
+be falsified against it.
+
+The label is a triple barrier using levels fixed from the signal snapshot:
+
+```text
+Y = target_first | stop_first | timeout
+```
+
+The decision model estimates calibrated `p_target`, `p_stop`, and `p_timeout`.
+The execution gate consumes:
+
+```text
+EV_net = p_target * target_payoff
+       - p_stop * stop_loss
+       + p_timeout * expected_timeout_payoff
+       - commission - spread - slippage - carry - borrow - FX
+```
+
+Promotion requires a positive **lower confidence bound** on `EV_net`, not a
+positive point estimate or win rate. The first model must be an auditable
+logistic/GAM-style model or a small fixed score. A tree model is a later trial;
+an unrestricted subset search or neural network is out of scope for this corpus.
+
+## Structure and ratcheting
+
+The #2437 placebo result establishes only that the tested support proximity and
+Fibonacci zones did not demonstrate unique unconditional directional value. It
+does not falsify causal structure as a path or risk variable.
+
+Allowed level sources in the first test:
+
+- confirmed pivot high/low, exposed only after its right-hand confirmation bars;
+- prior session/week/month high or low;
+- trailing Donchian high or low;
+- gap boundary known at the signal time.
+
+Every level is stored with `level_type`, `level_price`, `known_at`, and rule-set
+version. A break is defined in ATR units and must use a completed bar:
+
+```text
+long_break  = close > resistance + k*ATR14
+short_break = close < support    - k*ATR14
+```
+
+`k` is an unvalidated strategy parameter and must be registered before it is
+measured. A ratchet is tested as a separate strategy identity. It moves only in
+the protective direction and cannot be used to claim that the entry has edge.
+
+## Free and official source boundary
+
+### Available and worth integrating
+
+| source | verified capability | use | limitation |
+| --- | --- | --- | --- |
+| eToro REST + WebSocket | intraday OHLCV history plus live bid/ask/last already available in this repo | entry timing, realised volatility, observed live spread | REST has a 1,000-bar/no-anchor ceiling; stream has no depth or quote sizes |
+| eToro trading preflight | current v2 demo/real eligibility and what-if schemas are documented and thin adapters are implemented | current orderability, direction/settlement constraints, limits and broker-estimated ticket costs | documentation is not population evidence; actual demo coverage and point-in-time short availability still require a bounded probe |
+| SEC EDGAR | unauthenticated submissions and XBRL APIs; submissions typically update in under one second and XBRL in under one minute | causal filing/catalyst timestamp and structured fundamentals | filings are not a general news feed and many material events are unstructured |
+| Nasdaq Trader halt RSS | free, US exchange-wide halt/pause feed updated once per minute, with date queries | fail-closed eligibility, halt attribution and gap-risk analysis | current/dated halt events, not order-book history |
+| FINRA public API | consolidated short-interest datasets and the already-ingested short-interest source | slow-moving crowding/constraint context | short interest is not live borrow availability, fee, utilisation, or intraday short volume |
+| FRED/ALFRED | official macro time series through a free API key | macro regime and point-in-time vintage studies | not an execution feed; licensing/attribution is series-specific |
+
+Official documentation:
+
+- SEC EDGAR APIs: https://www.sec.gov/search-filings/edgar-application-programming-interfaces
+- Nasdaq halt RSS: https://www.nasdaqtrader.com/Trader.aspx?id=TradeHaltRSS
+- FINRA Developer Center: https://developer.finra.org/docs
+- FRED API: https://fred.stlouisfed.org/docs/api/fred/overview.html
+
+### Not freely obtainable at the required quality
+
+- consolidated historical bid/ask and trade tape for the full universe;
+- point-in-time historical stock-loan availability and borrow fee;
+- full L1 sizes, depth, queue position, aggressor side, and order-book events;
+- historical broker-specific order acceptance, slippage, margin and forced-close behaviour;
+- broad, reliably timestamped machine-readable news with redistribution rights;
+- historical options surfaces across the full equity universe.
+
+These fields must not be approximated with today's values or silently filled.
+Before calling shortability or costs unavailable, probe eToro's current
+eligibility and what-if endpoints. Any dimensions those endpoints omit remain
+forward-observation gaps. Consequently eBull can
+build a directional setup engine, but cannot honestly claim to implement
+institutional market making or order-flow strategies.
+
+## eToro capability audit — what actually needs changing
+
+### Already present; reuse it
+
+- Daily and intraday OHLCV, including 1/5/10/15/30-minute, 1-hour and 4-hour.
+- Live bid/ask/last WebSocket state and current spread computation.
+- Tradable-universe sync, exchange/type/industry catalogues and currency mapping.
+- Portfolio sync, order placement/polling, private-channel reconciliation,
+  fixed/trailing SL/TP API capability, execution guard and kill switch.
+- Outcome ledger/resolver, strategy ledger/registry, walk-forward/embargo,
+  block bootstrap, Deflated Sharpe and matched random-entry controls.
+
+### eToro supplies it; eBull currently loses or does not expose it
+
+1. The instrument/search payload documents `isOpen`, `isCurrentlyTradable`,
+   `isBuyEnabled`, `isDelisted`, `currentRate` and `dailyPriceChange`. The
+   provider normaliser currently discards them and sets `is_tradable=True` for
+   every returned non-internal record. Persist observed eligibility fields with
+   provider/receive timestamps; do not overload slower universe membership with
+   intraday orderability.
+2. Demo/real **instrument trading eligibility** has a thin non-persisting adapter.
+   The documented response exposes direction/settlement leverage arms, minimum
+   exposure, maximum units, open/close/partial-close and SL/TP constraints. Run
+   the bounded authenticated demo population probe before choosing persistence
+   columns; absence of a `SHORT` arm is a refusal, not a long default.
+3. Demo/real **what-if trading cost breakdown** has a thin non-persisting adapter.
+   The cost-name vocabulary remains provider-owned and open; the execution gate
+   must sum every returned cost and refuse unknown currency rather than select a
+   favourable subset. The first demo probe returned `value` while omitting the
+   documented `amount`; its unit/scale is unproved, and one successful response
+   carried a `lastUpdated` more than five months old. Preserve both fields and
+   timestamp, and refuse execution until units, completeness and freshness are
+   proved. Probe `buy` and `sellShort` across a broader liquid/illiquid cohort
+   before treating it as borrow/carry coverage.
+4. REST intraday history is passed through an in-memory chart cache and not
+   harvested into a research store. A bounded, rate-budgeted harvester is needed,
+   not a new data vendor.
+5. WebSocket quote history is collapsed into the latest-only `quotes` row.
+   Persist merged observations/bars plus subscription coverage; raw sparse frames
+   are not the research series.
+6. Trade history and detailed order/position reads exist but are not the primary
+   post-trade calibration ledger. Reuse them to reconcile simulated and broker
+   fills/costs.
+
+### Still absent after the eToro audit
+
+- depth/size/order-flow fields: eToro documents rate and private topics only;
+- historical point-in-time eligibility/borrow/cost responses before recording;
+- a consolidated trade print: measured `LastExecution` behaves as bid-side state;
+- arbitrary-depth intraday history beyond the 1,000-bar endpoint ceiling.
+
+## Storage budget and retention contract
+
+The measured eToro stream must **not** be stored row-for-message. In the
+universe capture it produced about 1,140 price-bearing updates/second during the
+US session, with peaks above 6,000/second. At the mean, 6.5 hours x 252 sessions
+would create about **6.7 billion rows/year**. This is rejected before schema
+design regardless of compression.
+
+Measured on the dev database 2026-08-09:
+
+```text
+database                         67,166,131,891 bytes
+price_daily       6,723,014 rows    827,564,032 bytes  (~123 bytes/row incl indexes)
+research_daily   25,920,971 rows  3,715,080,192 bytes  (~143 bytes/row incl indexes)
+candidate quote tuple                                  66 bytes before heap/index overhead
+candidate OHLCV tuple                                  80 bytes before heap/index overhead
+```
+
+Reproduce the relation figures with `pg_total_relation_size()` and `count(*)`
+over `price_daily` / `research_price_daily`; tuple figures use
+`pg_column_size(ROW(...))`. These are sizing anchors, not promises: the migration
+must remeasure its actual table and indexes after a representative load.
+
+### Required tiers
+
+| tier | cohort and resolution | retention | upper-bound purpose |
+| --- | --- | --- | --- |
+| current quote | all instruments, one row each | latest only | existing operational read path |
+| 30-minute context | at most 1,000 prequalified instruments | 24 months | broad intraday regime/context |
+| 5-minute setup | at most 250 actively ranked instruments | 12 months | formation/confirmation research |
+| 1-minute execution | at most 50 order-near instruments | rolling 30 days | spread, trigger and fill diagnosis |
+| feature snapshot | candidate evaluations only | durable | auditable decision input, not a price replica |
+| eligibility/cost | candidate preflights plus state changes | 24 months | broker constraint/cost calibration |
+| raw WS payload | sampled diagnostics only | <=24 hours | parser/transport diagnosis, never research |
+
+At the measured ~143-byte daily-table reference, the price-bar caps imply
+approximately:
+
+```text
+30m: 1,000 * 13 * 252 = 3.28m rows/year  ~= 0.47 GB/year
+ 5m:   250 * 78 * 252 = 4.91m rows/year  ~= 0.70 GB/year
+ 1m:    50 * 390 * 30 = 0.59m retained   ~= 0.08 GB retained
+```
+
+Target steady-state growth for the complete observation subsystem is therefore
+**<=1.5 GB/year**, including indexes and eligibility/feature rows. This is a
+hard acceptance budget, not an estimate to hand-wave past. The existing daily
+`pg_database_size` sampler and 7-day growth signal monitor the deployed effect.
+
+This budget does not excuse the existing signal-detail ledger. Measured
+2026-08-09, one successful scan wrote 34,698 rows and the 34,698-row relation
+occupied 32 MB, of which 24 MB was indexes. Retaining the same detail/index
+shape every session projects to 8.74 million rows and about 8.42 GB/year. Its
+aggregate-and-partition retention fix is therefore required independently of
+the bounded intraday tiers.
+
+### Physical and query rules
+
+- Aggregate merged WebSocket state in memory; write bars on close, not ticks.
+- Store no derived indicator history. Compute indicators from bars and persist
+  only the feature snapshot used for a candidate decision.
+- Monthly range partitions for retained intraday observations; retention drops
+  whole partitions rather than running large row deletes.
+- Primary access is `(instrument_id, observed_at)`; add no index without an
+  `EXPLAIN (ANALYZE, BUFFERS)` for an actual consumer query.
+- Eligibility/cost rows are event/state-change driven. An unchanged heartbeat
+  does not create a row.
+- Coverage intervals are coalesced (`subscribed_from`, `subscribed_to`), not one
+  coverage row per tick or minute.
+- The writer has explicit per-tier active-instrument caps and backpressure. It
+  degrades by refusing new low-priority subscriptions, never by growing an
+  unbounded queue.
+- Every job reports rows/bytes written and retention deletions. Post-deploy
+  acceptance compares actual 7-day DB growth with the declared budget.
+
+The existing empty `price_intraday` table is not automatically the target
+schema: it assumes one-minute trade-style OHLCV and has neither quote semantics,
+resolution identity, coverage nor partitioning. Because it contains zero rows,
+the implementation may replace it cleanly after the endpoint/cost spike fixes
+the required contract.
+
+## Ticket/slice order
+
+The work must land as independent, reviewable slices. Later slices are blocked
+until the previous measurement is recorded:
+
+1. **Capability spike:** typed demo eligibility + what-if-cost adapters are now
+   implemented and unit-tested. A four-instrument authenticated census proved
+   response drift, stale costs and a local-tradability mismatch; broader
+   population coverage and cost-unit proof remain. No migration and no recurring
+   writer until those measurements are recorded.
+2. **Storage benchmark:** representative temporary-table load, actual bytes/row,
+   insert throughput, index/query plan and retention-partition drop timing.
+3. **Eligibility observations:** state-change-only writer and latest view.
+4. **Bounded bar recorder:** 30m first; prove growth/queries before enabling 5m,
+   then 1m. Each tier has a separate enable flag and cap.
+5. **Feature snapshots/triple barriers:** consume the proven stores; no duplicate
+   price history.
+6. **Historical validation:** recent-regime contract, portfolio accounting and
+   controls.
+7. **Forward observation:** still no broker orders.
+8. **Paper execution:** separate operator promotion after untouched evidence.
+
+The parent #2437 documents the research thread. Dedicated implementation ticket
+numbers have not been verified in this workspace, so this spec must not pretend
+they already exist; create them from this slice order before implementation.
+
+## Features to add before paper trading
+
+1. **Eligibility/cost endpoint spike** — endpoint schemas and thin calls are
+   implemented with full raw payload retention in memory. Next measure a bounded
+   demo cohort: field presence, direction/settlement arms, unknown cost types,
+   response size and state-change frequency before designing tables.
+2. **Instrument eligibility observations** — preserve eToro's current open,
+   tradable, buy-enabled and delisted fields with `observed_at`; add SELL-specific
+   state only if the eligibility probe proves it exists.
+3. **Quote observation ledger** — append-only bid/ask/last, provider timestamp,
+   receive timestamp, instrument, session state and subscription coverage.
+4. **Execution-observation ledger** — candidate, what-if cost estimate, short
+   availability, requested order, broker response, fill, rejection and close.
+5. **Trading-halt ingest** — Nasdaq RSS with provider-native event identity,
+   source timestamps, halt code and resumption fields.
+6. **Causal catalyst join** — SEC accession/acceptance timestamps and existing
+   news events joined as optional context; absence remains absence.
+7. **Feature snapshot ledger** — immutable `X(i,t)` with input observation ids,
+   feature/rule version, `known_at`, and missing-reason codes.
+8. **Triple-barrier labels** — target, stop and timeout fixed at signal time;
+   ambiguous daily bars are not resolved optimistically.
+9. **Calibrated model evaluation** — Brier score, log loss, calibration curve,
+   expected calibration error, and decision-curve/net-EV results.
+10. **Portfolio simulator** — immutable cohorts, concurrency/gross exposure caps,
+   gap-CVaR sizing and calendar-block bootstrap.
+
+## Validation gates
+
+Historical promotion to forward observation requires all of:
+
+1. Causal invariance test: recomputing at `t` from a truncated series equals the
+   full-series feature at `t`.
+2. Trial declared before measurement; constants and code/data contract hashed.
+3. Purged folds and embargo around every label window.
+4. Calendar-block bootstrap at least as long as the maximum holding period.
+5. Matched random-entry control on the same dates, universe, exposure and costs.
+6. Stratification by era, price, liquidity, exchange and catalyst availability.
+7. Net result under base and stressed spread/slippage/borrow assumptions.
+8. No single day, issuer, catalyst class, month or best 1% of trades dominates.
+9. Portfolio drawdown and gap-CVaR within pre-registered limits.
+10. No paper order is enabled yet: historical validation promotes only to a
+    forward **observation** ledger. A later operator decision promotes observation
+    to paper execution after enough untouched events accumulate.
+
+## First bounded experiments
+
+Run these in order; do not tune later experiments using an opened hold-out:
+
+1. **Completed:** corrected long confluence retracts the invalid breadth result
+   and finds no monotonic alignment gradient.
+2. Put the frozen >=12% short-continuation rule through the existing portfolio,
+   block-bootstrap, trial-register and random-entry machinery.
+3. Test raw versus market/sector-residual shock with one fixed volatility
+   normalisation and the same execution rule.
+4. Test `shock_z x close_location x abnormal_volume` as one pre-registered
+   interaction model; no subset search.
+5. Test structure only as incremental information for `target_first` versus
+   `stop_first`, against matched arbitrary-level placebos.
+6. Test Gao et al.'s exact first/last-half-hour formulation on liquid US ETFs,
+   separately by instrument and after observed eToro costs. Do not start with
+   the broad single-stock universe.
+
+Until those experiments pass, the correct operator-visible state is
+`research_candidate`, never `validated` or `paper_ready`.

--- a/docs/proposals/ta/2026-08-09-plan-of-attack.md
+++ b/docs/proposals/ta/2026-08-09-plan-of-attack.md
@@ -88,9 +88,12 @@ carving a fake hold-out.
 - **Intraday residual reversal** (Brogaard/Han/Kim, sample to Dec 2022) on **30-minute
   midpoints** — the granularity we can already pull ~1 month back. ⚠ Their construction
   is long-short; the long leg alone is the weaker one.
-- **`breadth up day`** was the largest single marginal in the confluence table (+91.56
-  bps at 10 days, t 7.93, double any other). ⚠ Probably beta, not alpha — check before
-  getting interested.
+- ~~**`breadth up day` was the largest single marginal.**~~ **INVALIDATED
+  2026-08-09.** The original confluence code used the next-open entry date's market
+  return in a prior-close signal. After the causal-date fix, breadth-up is **37.70
+  bps at 10 days versus a 44.28 bps unconditional baseline**. Reproduce with
+  `PYTHONPATH=. uv run python scripts/verify_2437_confluence.py`. Do not reuse the
+  old +91.56 bps / t 7.93 figure.
 - **A tick recorder.** `price_intraday` is empty with no writer. ⚠ Schema mismatch
   noted in `data-capability.md`. Lower priority now that REST history exists, but it is
   the only way past the 1000-bar ceiling.
@@ -121,7 +124,6 @@ carving a fake hold-out.
 ## 6. Merge state
 
 - PR **#2442** merged (`61fb17da`).
-- PR **#2444** — this work. APPROVE, CI green, two NITPICKs `FIXED 245481a8`.
-  ⚠ The follow-up push resets the review requirement; re-poll before merging.
-- ⚠ `~/Dev/eBull` is on `feature/2437-short-side-edge`, **not detached at origin/main**.
-  Re-detach after merge.
+- PR **#2444** merged (`dbe5107b`).
+- The evidence correction, broker preflight and automation control-plane
+  follow-up is on `feature/2437-automation-control-plane`; PR number pending.

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -1,0 +1,351 @@
+# Strategy automation control plane — ownership, allocation and monitoring
+
+Date: 2026-08-09
+Status: Proposed contract; preflight adapter slice implemented, no strategy orders enabled
+Parent: #2437
+Companion: `2026-08-09-evidence-backed-signal-engine.md`
+
+## North star and non-promise
+
+The product goal is a hands-off **strategy sleeve** that can observe a validated
+signal, reserve explicitly allocated capital, place an exact broker order with a
+fixed SL/TP, manage only the position it opened, reconcile the full lifecycle and
+report strategy P&L separately from manual holdings.
+
+No system can promise winning trades. The enforceable target is narrower and
+testable: act only on pre-registered signals whose lower-bound net expectancy is
+positive under current broker constraints, and stop new entries when the live
+evidence or data quality breaches a declared limit.
+
+## Current repo reality
+
+Already present and reusable:
+
+- a complete versioned strategy manifest for S-1 through S-4;
+- daily `strategy_signal_scan`, scheduled after stored market data, recording
+  fired, not-fired and not-evaluable verdicts independently of funding;
+- signal, outcome and result ledgers;
+- next-bar fills, causal masks, ambiguity arms, portfolio backtesting, purged
+  folds/embargo, block bootstrap, Deflated Sharpe and synthetic controls;
+- per-position broker snapshots, exact position close API, fixed/trailing SL/TP
+  on entry, portfolio risk, execution guard and global kill switches;
+- current v2 eligibility and what-if-cost adapters, implemented without a writer.
+
+The first bounded authenticated demo census (2026-08-09) also proved that the
+preflight cannot be replaced by local catalogue state: one of four exact
+validated-universe instruments was refused for opening although the database
+marked it tradable. Eligibility arms and minimum exposure varied by instrument.
+Cost rows used an undocumented `value` field instead of documented `amount`, and
+one successful response was over five months stale. Those observations are
+useful blockers, not yet an execution-ready cost contract.
+
+The developer-database census on the same date found 34,698 signal-detail rows
+from the latest successful scan, zero resolved outcomes, 36 result rows and 48
+fold rows. The signal relation was already 32 MB (8 MB heap, 24 MB indexes).
+Every stored result covered 1962-01-02 through 2026-07-08, and S-4 had no result.
+Those result rows are legacy/stress evidence only: none satisfies the primary
+2022+ plus rolling 24/36-month relevance contract and none is allocation-ready.
+
+Not present and therefore blocking paper/live strategy execution:
+
+- no strategy catalogue/results/signals API or monitoring page;
+- no capital allocation/deployment record for a strategy version;
+- no durable link from a fired signal through a local order to the exact broker
+  `positionId`;
+- no pending/submitted-order reconciler despite the durable `submitted` state;
+- no strategy-owned position manager or SL/TP modification client;
+- no strategy-only realised/unrealised P&L view;
+- the existing recommendation EXIT path chooses the oldest broker position for
+  an instrument. It is unsafe for a strategy because that position can be manual;
+- `positions.source='ebull'` means only "opened through this app". A manual UI
+  order and a future automated strategy order are indistinguishable;
+- the historical outcome resolver is long-only. Short research may use the new
+  preflight to measure feasibility, but short execution remains blocked until
+  labels, returns, costs, guards and position accounting are side-aware.
+
+## The three ledgers must remain independent
+
+```text
+all evaluated bars -> signal ledger -> outcome ledger -> shadow performance
+                           |
+                           +-> funded candidate -> owned trade -> actual P&L
+```
+
+The monitoring surface reads both arms. A signal does not disappear because cash
+was unavailable, the strategy was paused, eligibility failed, or another trade
+already consumed the risk budget. This preserves the allocation-unbiased shadow
+track record and makes capture rate measurable.
+
+"All signals" on the operator page means every **fired** entry/exit signal,
+whether funded or not. Rendering millions of `not_fired` rows is neither useful
+nor the requirement. Those rows support coverage/exclusion statistics, shown as
+aggregates by date, strategy and reason.
+
+## Promotion and allocation are different decisions
+
+One immutable strategy version moves through:
+
+```text
+research_candidate -> historical_validated -> forward_observation
+                   -> paper_enabled -> live_enabled
+any enabled state  -> paused -> retired
+```
+
+- A computed metric never changes the stage automatically.
+- Each promotion pins the evidence/result ids, gate version, operator, time and
+  reason. A new code/parameter/universe/cost version starts again at research.
+- `paper_enabled` and `live_enabled` are separate promotions. The existing
+  `enable_auto_trading` and `enable_live_trading` switches remain higher-level
+  gates; neither promotes a strategy.
+- Allocation is an operator-entered maximum pot, not a command to spend it. The
+  gate sizes each order within available sleeve cash and portfolio-wide risk.
+- Capital is never automatically moved toward last month's winner. That creates
+  a second, unregistered timing strategy and performance-chasing bias. The picker
+  supplies comparable evidence; the operator changes allocations deliberately.
+
+## Strategy picker contract
+
+Each picker row must pin one strategy version and show, without favourable
+default sorting:
+
+- stage and whether observation/paper/live is enabled;
+- rules, universe, side, fill convention, SL/TP/timeout and cost model;
+- primary 2022+ and rolling 24/36-month net expectancy with confidence interval;
+- forward-observation and paper figures in separate columns, never pooled with
+  backtest results;
+- trade count and effective sample size, win rate, average win/loss, profit
+  factor, total/CAGR return, Sharpe/Sortino, maximum drawdown, turnover and
+  exposure time;
+- return versus buy-and-hold and matched random-entry control;
+- base and stressed costs, realised slippage, fill/rejection rate and unknown
+  cost coverage;
+- signal frequency, funded capture rate, concurrent-position demand and an
+  estimated capacity warning;
+- stability by year/regime/price/liquidity, dominance checks, DSR/trial count,
+  promotion refusals and live kill state;
+- allocated capital, currently reserved/invested capital, realised/unrealised
+  strategy P&L and remaining sleeve cash.
+
+Win rate is contextual metadata, never the ranking objective. A 35% hit-rate
+strategy can dominate a 70% one if its payoff distribution and costs are better.
+The primary comparison is lower-confidence-bound net expectancy alongside
+drawdown and capacity.
+
+A result missing the primary 2022+ and both rolling windows is visible as
+`legacy/stress only` and cannot be allocated. A missing strategy result, as for
+S-4 in the current database, is a displayed refusal rather than an omitted
+picker row. The UI must not reinterpret the current 1962-2026 aggregate as a
+recent result.
+
+## Manual-position isolation — hard invariant
+
+Ownership is a chain, not a label on an instrument:
+
+```text
+deployment -> fired signal -> strategy trade -> entry order
+           -> order lookup positionExecution -> broker positionId
+           -> stop changes / exact-position close -> exit order(s)
+```
+
+Rules:
+
+1. Never infer ownership from instrument id, symbol, `positions.source`, open
+   time, units or FIFO order.
+2. A strategy can close or patch SL/TP only when the exact `positionId` has one
+   active ownership record belonging to that strategy trade.
+3. Manual positions, including manual orders placed through eBull, never acquire
+   an ownership record and are therefore unmodifiable by strategy code.
+4. Manual positions still count toward portfolio cash, instrument/sector
+   concentration and total risk. Automation observes that exposure but does not
+   own or mutate it.
+5. eToro documents exact-position closes and detailed order lookup returning
+   `positionExecutions[].positionId`. The demo probe must still open two small
+   same-instrument positions through distinct flows and prove distinct ids survive
+   sync. If the broker ever nets or returns an ambiguous one-to-many execution,
+   the system enters `reconcile_required` and places no exit/ratchet. Until that
+   probe passes, a strategy entry on an instrument with a manual position must
+   fail closed.
+6. A disappeared owned position is not silently marked successful. Reconcile it
+   against order detail and trade history to distinguish broker SL/TP, manual
+   close, rejected/pending state and missing data.
+
+The existing `_load_position_id_for_exit()` FIFO lookup must never be called by a
+strategy executor. It can remain for the legacy recommendation path until that
+path receives its own ownership semantics.
+
+## Execution state machine
+
+One candidate progresses monotonically:
+
+```text
+observed -> rejected
+observed -> approved -> intent_persisted -> submitted
+submitted -> open | failed | reconcile_required
+open -> closing -> closed | reconcile_required
+```
+
+Before an entry:
+
+1. pin completed signal bar, feature snapshot and strategy/data versions;
+2. recheck stage, global switches, quote freshness, session and halt state;
+3. request current eligibility for the exact settlement/direction;
+4. request current what-if costs for the exact proposed ticket;
+5. recompute net EV and size from available **sleeve** capital;
+6. apply portfolio-wide cash, exposure, concentration, drawdown and gap-risk
+   limits, including manual holdings;
+7. persist a durable intent before broker I/O;
+8. place the order, reconcile order to exact position id, and verify broker SL/TP;
+9. refuse further action while identity or asynchronous state is ambiguous.
+
+For a stop ratchet, a completed causal bar proposes a new stop. The manager
+checks `new_stop > current_stop` for a long (opposite for a future short), broker
+eligibility, owned position id and current quote; persists an intent; sends the
+v2 PATCH; then re-syncs before recording it as applied. Every actual change is an
+event. Per-bar non-changes are metrics, not rows.
+
+## Real-time process boundaries
+
+- **Daily shadow scan (exists):** all registered daily strategies, no money.
+- **Intraday bar closer (new):** closes bounded 30m/5m/1m bars; never trades a
+  forming candle.
+- **Signal evaluator (extend):** writes every fired candidate before allocation.
+- **Allocation/execution gate (new):** consumes only enabled deployments and
+  current preflight data. One invocation, one audit verdict.
+- **Order reconciler (new, required before paper):** polls submitted/pending
+  orders, resolves exact position ids and detects orphan broker effects after a
+  crash.
+- **Owned-position manager (new):** SL/TP verification, causal ratchets, timeout
+  and strategy exit. It receives a trade id, never just an instrument id.
+- **Portfolio sync (exists, extend):** observes all positions but preserves the
+  separate durable ownership record.
+- **Health/kill monitor (new):** data freshness, scan heartbeat, queue lag,
+  reconciliation backlog, slippage/cost drift, drawdown and control-relative
+  alpha. A breach stops new entries; emergency owned-position exits remain
+  possible.
+
+"Real time" is strategy-relative and measured: completed bar time, evaluation
+time, preflight time, intent time, broker acceptance, fill and reconciliation
+time are all retained. A daily strategy does not need tick-level decisions; a
+five-minute strategy that finishes after the next bar is unhealthy.
+
+## Bounded database shape
+
+Do not add derived-indicator time series. After the capability/storage probes,
+the smallest control-plane schema is:
+
+| relation | grain | retention |
+| --- | --- | --- |
+| strategy promotions | one immutable stage change | durable; tens of rows |
+| strategy deployments | one current allocation per strategy version/mode | durable config + audit history |
+| candidate decisions | fired signal x allocation verdict | 24 months detailed; durable daily aggregates |
+| strategy trades | one funded lifecycle | durable |
+| strategy trade orders | one order linked to one owned trade and purpose | durable; joins existing orders/fills |
+| position ownership | one broker position id claimed by one trade | durable, including released ownership |
+| stop changes | one requested/applied/failed material change | durable; no heartbeat rows |
+| preflight observations | candidate request or changed eligibility state | 24 months; no unchanged polling rows |
+| strategy daily metrics | strategy/version/day/stage arm | durable compact aggregate |
+
+P&L is derived from owned trade order/fill links and broker close history; it is
+not copied into the general `positions` aggregate and not duplicated on every
+signal. The strategy page uses strategy-owned rows only. The main portfolio page
+continues to show the complete account, including manual and automated positions.
+
+The current signal scanner writes `instrument x declared signal leg x session`
+verdicts, not merely `universe x strategy`. The 2026-08-09 scan wrote 34,698
+rows; at 252 sessions that is **8.74 million rows/year**. The measured relation
+cost was about 963 bytes/row including indexes, implying roughly **8.42 GB/year**
+if its present detail and index shape is retained. Re-run
+`scripts/verify_2437_observation_storage.py` for current figures. Partitioning
+and retention must precede intraday verdicts. A proposed bounded policy is:
+
+- fired entry/exit signals and their outcomes: durable;
+- individual not-fired/not-evaluable daily rows: 90 days after a checked daily
+  aggregate exists;
+- aggregate counts by strategy/version/date/verdict/reason: durable;
+- intraday evaluations: write fired candidates plus aggregates, not one
+  `not_fired` row per instrument per minute.
+
+No deletion policy ships until a verifier proves aggregate counts equal the
+detail rows and no outcome/holdout/result foreign key depends on the deletion
+set. Retention drops partitions; it does not issue recurring mass deletes.
+
+## What "test every strategy or combination" means
+
+Exhaustively searching every subset, threshold and signal combination is
+impossible and would manufacture winners through multiple testing. The enforceable
+contract is:
+
+- every strategy implementation in the tree is in the manifest or CI fails;
+- every **permitted, pre-registered** strategy/version/combination runs through
+  the same test matrix and appears in the picker, including failures;
+- combinations are explicit interaction hypotheses with an economic rationale,
+  not the powerset of indicators;
+- every attempted variant increments the trial register, including abandoned
+  branches and manual inspection;
+- selection happens on train/validation only; one frozen holdout is opened once;
+- promotion uses recent-window stability, lower-bound net expectancy, costs,
+  portfolio simulation, random controls and untouched forward evidence;
+- paper/live performance is compared with the simultaneous unfunded shadow arm.
+
+Property tests should exhaust finite state/vocabulary combinations (ownership
+states, outcome classes, missing fields, side/settlement arms). Statistical
+hypotheses use bounded registered trials, not combinatorial enumeration.
+
+## Ordered implementation slices
+
+These are the ticket bodies; issue numbers are deliberately absent until issues
+are actually created.
+
+1. **Current v2 preflight adapters — implemented:** strict eligibility and
+   what-if types, bounded request validation, raw response retention in memory,
+   no writes and no execution use.
+2. **Authenticated demo capability census — four-instrument spike complete,
+   broader coverage open:** expand liquid/illiquid equity/ETF long/short
+   requests; establish cost units/freshness, response bytes, position-id
+   cardinality and v1-versus-v2 execution compatibility.
+3. **Recent-window result arms + read-only strategy observability:** compute the
+   fixed 2022+, rolling 24/36-month and per-year arms without overwriting legacy
+   evidence; then expose every manifest strategy, fired funded/unfunded signal,
+   outcome, exclusion, scan health, pinned metrics and explicit refusal state.
+   This can ship before trading; legacy-only rows are never allocatable.
+4. **Storage benchmark and retention:** actual bytes/query plans for signal
+   partitions, compact aggregates, preflight state changes and bounded intraday
+   bars. Migration follows evidence, not vice versa.
+5. **Promotion/deployment + ownership schema:** no broker writer yet. Enforce one
+   signal funding decision, exact order/trade/position links and immutable stage
+   changes.
+6. **Order/position reconciler:** consume detailed v2 order lookup and history;
+   close the existing submitted/pending crash gap; prove same-instrument manual
+   isolation in demo.
+7. **Paper allocator/executor:** exact strategy version, sleeve cash, current
+   preflight, SL/TP and portfolio guard; no live key path.
+8. **Owned-position manager:** exact-position exits, timeout and separately
+   registered ratchet variants; asynchronous PATCH re-sync.
+9. **Paper P&L and picker allocation controls:** strategy-only P&L, shadow versus
+   funded capture, manual allocation changes with audit.
+10. **Live promotion:** requires minimum forward/paper evidence, reconciliation
+    SLOs, kill drills and an explicit operator action in addition to both global
+    switches.
+
+## Acceptance tests before paper trading
+
+- strategy/manual positions on the same instrument retain distinct ids through
+  open, sync, partial close, SL/TP patch and strategy close;
+- attempting to close or patch an unowned/manual id fails before broker I/O;
+- a crash before call, during call and after broker acceptance reconciles without
+  a duplicate order or orphan position;
+- unknown/malformed/missing eligibility or cost fields refuse entry;
+- current total broker costs are included once and stressed, never selected by a
+  closed favourable vocabulary;
+- manual holdings affect risk capacity but never strategy P&L or lifecycle;
+- every fired signal appears with funded/rejected reason and later shadow outcome;
+- picker rows cannot mix strategy, data, cost, resolver, universe or ambiguity
+  versions;
+- no picker row is allocatable unless its fixed 2022+ and rolling 24/36-month
+  result arms exist and agree in sign after costs; pre-2000 data cannot rescue it;
+- strategy P&L reconciles to owned fills/history and the account-wide portfolio
+  reconciles separately to the broker;
+- retention preserves fired outcomes and daily census equality while staying
+  inside the declared database growth budget;
+- kill switch, stale data, scan lag, reconciliation backlog and drawdown tests
+  block new entries while leaving audited owned-position risk reduction usable.

--- a/scripts/verify_2437_confluence.py
+++ b/scripts/verify_2437_confluence.py
@@ -140,6 +140,24 @@ def _cluster(groups: dict[date, list[float]]) -> tuple[float, float, int]:
     return m, (m / se if se > 0 else 0.0), len(a)
 
 
+def _market_context(
+    signal_date: date,
+    lookback_date: date,
+    mkt: dict[date, float],
+    mkt_cum: dict[date, float],
+) -> tuple[float, bool] | None:
+    """Return causal market context observable at the signal close.
+
+    The trade is grouped by its next-open entry date, but market breadth and
+    relative strength belong to the completed signal bar.  Using the entry
+    date here leaks that session's return into a decision made the night before.
+    """
+    if signal_date not in mkt or signal_date not in mkt_cum or lookback_date not in mkt_cum:
+        return None
+    market_return_21d = mkt_cum[signal_date] / mkt_cum[lookback_date] - 1.0
+    return market_return_21d, mkt[signal_date] > 0
+
+
 def main() -> int:
     conn = psycopg.connect(settings.database_url)
     sids = [r[0] for r in conn.execute(_SERIES, {"s": START}).fetchall()]
@@ -217,9 +235,12 @@ def main() -> int:
             entry = adj_open[i + 1]
             if not np.isfinite(entry) or entry <= 0:
                 continue
-            day = dts[i + 1]
-            if day not in mkt:
+            signal_date = dts[i]
+            entry_date = dts[i + 1]
+            market_context = _market_context(signal_date, dts[i - 21], mkt, mkt_cum)
+            if market_context is None:
                 continue
+            m21, breadth_up = market_context
 
             w = adj[i - 251 : i + 1]
             hi252, lo60, hi60 = w.max(), adj_lo[i - 59 : i + 1].min(), adj_hi[i - 59 : i + 1].max()
@@ -229,8 +250,6 @@ def main() -> int:
             sup_d = min(((adj[i] - adj_lo[p]) / atr[i] for p in prior), default=99.0)
             fib = (adj[i] - lo60) / (hi60 - lo60) if hi60 > lo60 else -1.0
             r21 = adj[i] / adj[i - 21] - 1.0
-            m21 = mkt_cum[day] / mkt_cum[dts[i - 21]] - 1.0 if dts[i - 21] in mkt_cum else 0.0
-
             c = (
                 adj[i] > sma50[i] > sma200[i],
                 -0.12 <= pull <= -0.03,
@@ -242,7 +261,7 @@ def main() -> int:
                 sup_d <= 0.5,
                 any(abs(fib - lv) <= 0.03 for lv in (0.382, 0.5, 0.618)),
                 35.0 <= rsi[i] <= 55.0,
-                mkt[day] > 0,
+                breadth_up,
             )
             # ⚠ placebos are matched in SHAPE to conditions 9 and 8: the same
             # tolerance, the same swing, the same ATR unit -- only the level itself
@@ -258,14 +277,14 @@ def main() -> int:
             total += 1
             for h in HOLDS:
                 r = (adj[i + h] / entry - 1.0) * 1e4
-                base[h][day].append(r)
-                by_count[(k, h)][day].append(r)
+                base[h][entry_date].append(r)
+                by_count[(k, h)][entry_date].append(r)
                 for ci, on in enumerate(c):
                     if on:
-                        by_cond[(ci, h)][day].append(r)
+                        by_cond[(ci, h)][entry_date].append(r)
                 for pi, on in enumerate(p):
                     if on:
-                        by_placebo[(pi, h)][day].append(r)
+                        by_placebo[(pi, h)][entry_date].append(r)
         if n % 1000 == 0:
             print(f"  pass2 {n}/{len(sids)}", flush=True)
     conn.close()

--- a/scripts/verify_2437_observation_storage.py
+++ b/scripts/verify_2437_observation_storage.py
@@ -68,6 +68,13 @@ def projected_annual_signal_bytes(
     )
 
 
+def measured_bytes_per_row(rows: int, total_bytes: int) -> float | None:
+    """Return measured relation density, or ``None`` for an empty relation."""
+    if rows < 0 or total_bytes < 0:
+        raise ValueError("measured rows and bytes must be non-negative")
+    return total_bytes / rows if rows else None
+
+
 def main() -> None:
     query = """
         SELECT pg_database_size(current_database()),
@@ -108,13 +115,15 @@ def main() -> None:
         signal_total_bytes,
         latest_scan_rows,
     ) = map(int, row)
-    price_bpr = price_bytes / price_rows
-    research_bpr = research_bytes / research_rows
+    price_bpr = measured_bytes_per_row(price_rows, price_bytes)
+    research_bpr = measured_bytes_per_row(research_rows, research_bytes)
+    price_bpr_text = f"{price_bpr:.1f}" if price_bpr is not None else "n/a"
+    research_bpr_text = f"{research_bpr:.1f}" if research_bpr is not None else "n/a"
 
     print(f"database: {db_bytes:,} bytes")
     print(f"tradable instruments: {instruments:,}")
-    print(f"price_daily: {price_rows:,} rows, {price_bytes:,} bytes, {price_bpr:.1f} bytes/row")
-    print(f"research_price_daily: {research_rows:,} rows, {research_bytes:,} bytes, {research_bpr:.1f} bytes/row")
+    print(f"price_daily: {price_rows:,} rows, {price_bytes:,} bytes, {price_bpr_text} bytes/row")
+    print(f"research_price_daily: {research_rows:,} rows, {research_bytes:,} bytes, {research_bpr_text} bytes/row")
     print(
         f"strategy_signals: {signal_rows:,} rows, {signal_total_bytes:,} bytes "
         f"(heap {signal_heap_bytes:,}; indexes {signal_index_bytes:,})"

--- a/scripts/verify_2437_observation_storage.py
+++ b/scripts/verify_2437_observation_storage.py
@@ -1,0 +1,145 @@
+"""Size #2437 observation tiers and existing signal detail against the database.
+
+Run:
+    PYTHONPATH=. uv run python scripts/verify_2437_observation_storage.py
+
+Read-only. Nothing is written. The output is an acceptance input for the storage
+benchmark slice, not permission to create the proposed tables.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import psycopg
+
+from app.config import settings
+
+TRADING_DAYS = 252
+RTH_MINUTES = 390
+REFERENCE_BYTES_PER_ROW = 143
+
+
+@dataclass(frozen=True)
+class Tier:
+    name: str
+    instruments: int
+    minutes_per_bar: int
+    retained_days: int
+
+    @property
+    def rows(self) -> int:
+        bars_per_day = RTH_MINUTES // self.minutes_per_bar
+        return self.instruments * bars_per_day * self.retained_days
+
+
+TIERS = (
+    Tier("30-minute context", instruments=1_000, minutes_per_bar=30, retained_days=TRADING_DAYS),
+    Tier("5-minute setup", instruments=250, minutes_per_bar=5, retained_days=TRADING_DAYS),
+    Tier("1-minute execution", instruments=50, minutes_per_bar=1, retained_days=30),
+)
+
+
+def projected_bytes(tier: Tier, *, bytes_per_row: int = REFERENCE_BYTES_PER_ROW) -> int:
+    return tier.rows * bytes_per_row
+
+
+def projected_annual_signal_rows(rows_per_scan: int, *, trading_days: int = TRADING_DAYS) -> int:
+    """Annual detail rows if one completed daily scan has ``rows_per_scan`` rows."""
+    if rows_per_scan < 0 or trading_days < 0:
+        raise ValueError("signal rows and trading days must be non-negative")
+    return rows_per_scan * trading_days
+
+
+def projected_annual_signal_bytes(
+    rows_per_scan: int,
+    *,
+    measured_rows: int,
+    measured_total_bytes: int,
+    trading_days: int = TRADING_DAYS,
+) -> int:
+    """Project heap+index growth from this database's measured signal row cost."""
+    if measured_rows <= 0:
+        raise ValueError("measured_rows must be positive")
+    if measured_total_bytes < 0:
+        raise ValueError("measured_total_bytes must be non-negative")
+    return round(
+        projected_annual_signal_rows(rows_per_scan, trading_days=trading_days) * measured_total_bytes / measured_rows
+    )
+
+
+def main() -> None:
+    query = """
+        SELECT pg_database_size(current_database()),
+               (SELECT count(*) FROM instruments WHERE is_tradable),
+               (SELECT count(*) FROM price_daily),
+               pg_total_relation_size('price_daily'),
+               (SELECT count(*) FROM research_price_daily),
+               pg_total_relation_size('research_price_daily'),
+               (SELECT count(*) FROM strategy_signals),
+               pg_relation_size('strategy_signals'),
+               pg_indexes_size('strategy_signals'),
+               pg_total_relation_size('strategy_signals'),
+               coalesce((
+                   SELECT row_count
+                   FROM job_runs
+                   WHERE job_name = 'strategy_signal_scan'
+                     AND status = 'success'
+                     AND row_count IS NOT NULL
+                   ORDER BY started_at DESC
+                   LIMIT 1
+               ), 0)
+    """
+    with psycopg.connect(settings.database_url) as conn:
+        row = conn.execute(query).fetchone()
+    if row is None:
+        raise RuntimeError("database sizing query returned no row")
+
+    (
+        db_bytes,
+        instruments,
+        price_rows,
+        price_bytes,
+        research_rows,
+        research_bytes,
+        signal_rows,
+        signal_heap_bytes,
+        signal_index_bytes,
+        signal_total_bytes,
+        latest_scan_rows,
+    ) = map(int, row)
+    price_bpr = price_bytes / price_rows
+    research_bpr = research_bytes / research_rows
+
+    print(f"database: {db_bytes:,} bytes")
+    print(f"tradable instruments: {instruments:,}")
+    print(f"price_daily: {price_rows:,} rows, {price_bytes:,} bytes, {price_bpr:.1f} bytes/row")
+    print(f"research_price_daily: {research_rows:,} rows, {research_bytes:,} bytes, {research_bpr:.1f} bytes/row")
+    print(
+        f"strategy_signals: {signal_rows:,} rows, {signal_total_bytes:,} bytes "
+        f"(heap {signal_heap_bytes:,}; indexes {signal_index_bytes:,})"
+    )
+    if signal_rows and latest_scan_rows:
+        annual_rows = projected_annual_signal_rows(latest_scan_rows)
+        annual_bytes = projected_annual_signal_bytes(
+            latest_scan_rows,
+            measured_rows=signal_rows,
+            measured_total_bytes=signal_total_bytes,
+        )
+        print(
+            f"latest successful signal scan: {latest_scan_rows:,} rows; "
+            f"daily-detail projection {annual_rows:,} rows / {annual_bytes / 1_000_000_000:.2f} GB per year"
+        )
+    else:
+        print("latest successful signal scan: no measurable completed row count")
+    print(f"\nprojections at conservative {REFERENCE_BYTES_PER_ROW} bytes/row:")
+    total = 0
+    for tier in TIERS:
+        size = projected_bytes(tier)
+        total += size
+        print(f"  {tier.name:20} {tier.rows:>10,} rows  {size / 1_000_000:>8.1f} MB")
+    print(f"  {'price tiers total':20} {'':>10}       {total / 1_000_000:>8.1f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_2437_trading_preflight.py
+++ b/scripts/verify_2437_trading_preflight.py
@@ -1,0 +1,227 @@
+"""Bounded, non-trading census of eToro v2 eligibility and what-if costs.
+
+The script refuses every environment except ``demo``. It performs informational
+POST requests only; it creates no orders and writes no observation tables. The
+normal credential-access audit still runs, as it must for every decryption.
+
+Run from the repository root::
+
+    uv run python scripts/verify_2437_trading_preflight.py
+    uv run python scripts/verify_2437_trading_preflight.py --apply --limit 8
+
+The default is a DB-only dry run showing the deterministic liquidity-spread
+cohort. ``--apply`` makes one batched eligibility request and, for each returned
+LONG/SHORT configuration, one current cost request at leverage 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import asdict
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.providers.broker import BrokerInstrumentEligibility, BrokerWhatIfOrder
+from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+from app.security.master_key import ensure_broker_key_loaded
+from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
+from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
+from app.services.strategies.validated_universe import US_EQUITY_ASSET_CLASS, resolve_stocks_type_id
+
+logger = logging.getLogger(__name__)
+
+_SETTLEMENT_TYPES = {
+    "CFD": "cfd",
+    "REAL": "real",
+    "REALFUTURES": "realFutures",
+    "MARGINTRADE": "marginTrade",
+}
+
+
+def _load_cohort(conn: psycopg.Connection[Any], limit: int) -> list[tuple[int, str, Decimal]]:
+    """Select deterministic points across the latest dollar-volume distribution."""
+    instrument_type_id = resolve_stocks_type_id(conn)
+    rows = conn.execute(
+        """
+        WITH ranked AS (
+            SELECT i.instrument_id, i.symbol,
+                   (l.close * l.volume)::numeric AS dollar_volume,
+                   percent_rank() OVER (ORDER BY l.close * l.volume, i.instrument_id) AS pct
+            FROM instruments i
+            JOIN exchanges e ON e.exchange_id = i.exchange
+            CROSS JOIN LATERAL (
+                SELECT p.close, p.volume
+                FROM price_daily p
+                WHERE p.instrument_id = i.instrument_id
+                  AND p.close > 0 AND p.volume > 0
+                ORDER BY p.price_date DESC
+                LIMIT 1
+            ) l
+            WHERE i.is_tradable = TRUE
+              AND i.instrument_type_id = %(instrument_type_id)s
+              AND e.asset_class = %(asset_class)s
+        ), targets AS (
+            SELECT generate_series(0, %(limit_minus_one)s) AS slot
+        )
+        SELECT DISTINCT ON (r.instrument_id)
+               r.instrument_id, r.symbol, r.dollar_volume
+        FROM targets x
+        CROSS JOIN LATERAL (
+            SELECT instrument_id, symbol, dollar_volume, pct
+            FROM ranked
+            ORDER BY abs(pct - (x.slot::numeric / GREATEST(%(limit_minus_one)s, 1))), instrument_id
+            LIMIT 1
+        ) r
+        ORDER BY r.instrument_id
+        """,
+        {
+            "limit_minus_one": limit - 1,
+            "instrument_type_id": instrument_type_id,
+            "asset_class": US_EQUITY_ASSET_CLASS,
+        },
+    ).fetchall()
+    return [(int(row[0]), str(row[1]), Decimal(str(row[2]))) for row in rows]
+
+
+def _load_demo_credentials() -> tuple[str, str]:
+    with psycopg.connect(settings.database_url) as conn:
+        ensure_broker_key_loaded(conn)
+        operator_id = sole_operator_id(conn)
+        api_key = load_credential_for_provider_use(
+            conn,
+            operator_id=operator_id,
+            provider="etoro",
+            label="api_key",
+            environment="demo",
+            caller="verify_2437_trading_preflight",
+        )
+        conn.commit()
+        user_key = load_credential_for_provider_use(
+            conn,
+            operator_id=operator_id,
+            provider="etoro",
+            label="user_key",
+            environment="demo",
+            caller="verify_2437_trading_preflight",
+        )
+        conn.commit()
+    return api_key, user_key
+
+
+def _cost_orders(row: BrokerInstrumentEligibility) -> list[BrokerWhatIfOrder]:
+    orders: list[BrokerWhatIfOrder] = []
+    for config in row.leverage_configs:
+        settlement = _SETTLEMENT_TYPES.get(config.settlement_type.upper())
+        direction = config.direction.upper()
+        if settlement is None or direction not in {"LONG", "SHORT"} or 1 not in config.leverage_values:
+            continue
+        minimum = config.min_position_amount or row.min_position_exposure or Decimal("100")
+        amount = max(minimum, Decimal("100"))
+        orders.append(
+            BrokerWhatIfOrder(
+                instrument_id=row.instrument_id,
+                transaction="buy" if direction == "LONG" else "sellShort",
+                settlement_type=settlement,  # type: ignore[arg-type]
+                amount=amount,
+            )
+        )
+    return orders
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Call demo informational endpoints")
+    parser.add_argument("--limit", type=int, default=8, help="Cohort size, 1..100 (default 8)")
+    args = parser.parse_args()
+    if not 1 <= args.limit <= 100:
+        parser.error("--limit must be between 1 and 100")
+    if settings.etoro_env != "demo":
+        parser.error("refusing: ETORO_ENV must be demo for this probe")
+
+    with psycopg.connect(settings.database_url) as conn:
+        cohort = _load_cohort(conn, args.limit)
+    print(
+        json.dumps(
+            {
+                "mode": "apply" if args.apply else "dry_run",
+                "cohort": [
+                    {"instrument_id": instrument_id, "symbol": symbol, "dollar_volume": str(dollar_volume)}
+                    for instrument_id, symbol, dollar_volume in cohort
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    if not args.apply:
+        return 0
+
+    try:
+        api_key, user_key = _load_demo_credentials()
+    except (CredentialNotFound, NoOperatorError, AmbiguousOperatorError) as exc:
+        logger.error("cannot load demo credentials: %s", exc)
+        return 1
+
+    with EtoroBrokerProvider(api_key=api_key, user_key=user_key, env="demo") as broker:
+        eligibility = broker.check_instrument_eligibility([instrument_id for instrument_id, _, _ in cohort])
+        cost_rows: list[dict[str, object]] = []
+        for row in eligibility.eligibilities:
+            for order in _cost_orders(row):
+                result = broker.get_what_if_costs(order)
+                cost_rows.append(
+                    {
+                        "instrument_id": result.instrument_id,
+                        "transaction": order.transaction,
+                        "settlement_type": order.settlement_type,
+                        "amount": str(order.amount),
+                        "last_updated": result.last_updated.isoformat(),
+                        "costs": [
+                            asdict(cost)
+                            | {
+                                "amount": str(cost.amount) if cost.amount is not None else None,
+                                "value": str(cost.value) if cost.value is not None else None,
+                            }
+                            for cost in result.costs
+                        ],
+                    }
+                )
+
+    report = {
+        "requested": len(cohort),
+        "resolved": len(eligibility.eligibilities),
+        "not_found_instrument_ids": list(eligibility.not_found_instrument_ids),
+        "eligibility": [
+            {
+                "instrument_id": row.instrument_id,
+                "symbol": row.symbol,
+                "allow_open_position": row.allow_open_position,
+                "allow_close_position": row.allow_close_position,
+                "allow_partial_close_position": row.allow_partial_close_position,
+                "allow_trailing_stop_loss": row.allow_trailing_stop_loss,
+                "min_position_exposure": str(row.min_position_exposure),
+                "max_units_per_order": str(row.max_units_per_order),
+                "directions": [
+                    {
+                        "settlement_type": config.settlement_type,
+                        "direction": config.direction,
+                        "leverage_values": list(config.leverage_values),
+                        "min_position_amount": str(config.min_position_amount),
+                    }
+                    for config in row.leverage_configs
+                ],
+            }
+            for row in eligibility.eligibilities
+        ],
+        "cost_preflights": cost_rows,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -19,10 +19,12 @@ from app.providers.broker import (
     BrokerMirror,
     BrokerMirrorPosition,
     BrokerPortfolio,
+    BrokerWhatIfOrder,
     OrderParams,
 )
 from app.providers.implementations.etoro_broker import (
     EtoroBrokerProvider,
+    TradingPreflightParseError,
     _normalise_close_order_response,
     _normalise_open_order_response,
     _normalise_order_info_response,
@@ -73,6 +75,46 @@ FIXTURE_PORTFOLIO_RESPONSE = {
     },
 }
 
+FIXTURE_ELIGIBILITY_RESPONSE = {
+    "currency": "USD",
+    "eligibilities": [
+        {
+            "instrumentId": 1001,
+            "symbol": "AAPL",
+            "minPositionExposure": 50,
+            "maxUnitsPerOrder": 10000,
+            "allowOpenPosition": True,
+            "allowClosePosition": True,
+            "allowPartialClosePosition": True,
+            "allowTrailingStopLoss": True,
+            "leverageConfigs": [
+                {
+                    "settlementType": "CFD",
+                    "direction": "LONG",
+                    "leverageValues": [1, 2, 5],
+                    "minPositionAmount": 50,
+                    "allowEditStopLoss": True,
+                    "allowEditTakeProfit": True,
+                    "allowStopLossTakeProfit": True,
+                }
+            ],
+        }
+    ],
+    "notFoundInstrumentIds": [9999],
+    "notFoundSymbols": [],
+}
+
+FIXTURE_WHAT_IF_COST_RESPONSE = {
+    "instrumentId": 1001,
+    "symbol": "AAPL",
+    "costs": [
+        {"costType": "marketSpread", "amount": 0.03, "currency": "USD"},
+        {"costType": "transactionFee", "amount": 1, "currency": "USD"},
+        {"costType": "overnightFee", "value": 0.0, "currency": "USD"},
+    ],
+    "lastUpdated": "2026-05-25T08:30:00Z",
+}
+
 
 # ---------------------------------------------------------------------------
 # Environment-scoped path prefixes
@@ -89,6 +131,118 @@ class TestEnvironmentPrefixes:
         with EtoroBrokerProvider(api_key="k", user_key="u", env="real") as broker:
             assert broker._exec_prefix == "/api/v1/trading/execution"
             assert broker._info_prefix == "/api/v1/trading/info"
+
+
+# ---------------------------------------------------------------------------
+# v2 non-executing trading preflight (#2437)
+# ---------------------------------------------------------------------------
+
+
+class TestTradingPreflight:
+    def test_eligibility_posts_bounded_ids_to_current_demo_endpoint(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FIXTURE_ELIGIBILITY_RESPONSE
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = mock_resp
+
+            result = broker.check_instrument_eligibility([1001, 9999])
+
+            call = broker._http_write.post.call_args
+            assert call.args[0] == "/api/v2/trading/info/demo/eligibility"
+            assert call.kwargs["json"] == {"instrumentIds": [1001, 9999], "currency": "USD"}
+            assert result.currency == "USD"
+            assert result.eligibilities[0].allow_open_position is True
+            assert result.eligibilities[0].leverage_configs[0].leverage_values == (1, 2, 5)
+            assert result.not_found_instrument_ids == (9999,)
+
+    def test_eligibility_refuses_unbounded_or_ambiguous_requests(self) -> None:
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            for ids in ([], [1, 1], [0], list(range(1, 102))):
+                try:
+                    broker.check_instrument_eligibility(ids)
+                except ValueError:
+                    pass
+                else:  # pragma: no cover - assertion helper branch
+                    raise AssertionError(f"expected ValueError for {ids[:3]}")
+
+    def test_eligibility_fails_closed_when_permission_field_is_missing(self) -> None:
+        malformed = {
+            **FIXTURE_ELIGIBILITY_RESPONSE,
+            "eligibilities": [
+                {
+                    **FIXTURE_ELIGIBILITY_RESPONSE["eligibilities"][0],
+                    "allowOpenPosition": None,
+                }
+            ],
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = malformed
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = mock_resp
+            try:
+                broker.check_instrument_eligibility([1001])
+            except TradingPreflightParseError as exc:
+                assert "allowOpenPosition" in str(exc)
+            else:  # pragma: no cover - assertion helper branch
+                raise AssertionError("missing permission must fail closed")
+
+    def test_what_if_costs_posts_order_shape_and_preserves_open_cost_vocabulary(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FIXTURE_WHAT_IF_COST_RESPONSE
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = mock_resp
+            result = broker.get_what_if_costs(
+                BrokerWhatIfOrder(
+                    instrument_id=1001,
+                    transaction="buy",
+                    settlement_type="real",
+                    amount=Decimal("1000"),
+                )
+            )
+
+            call = broker._http_write.post.call_args
+            assert call.args[0] == "/api/v2/trading/info/demo/costs"
+            assert call.kwargs["json"] == {
+                "action": "open",
+                "transaction": "buy",
+                "instrumentId": 1001,
+                "settlementType": "real",
+                "orderType": "mkt",
+                "leverage": 1,
+                "orderCurrency": "usd",
+                "amount": 1000.0,
+            }
+            assert [(cost.cost_type, cost.amount, cost.value) for cost in result.costs] == [
+                ("marketSpread", Decimal("0.03"), None),
+                ("transactionFee", Decimal("1"), None),
+                ("overnightFee", None, Decimal("0.0")),
+            ]
+            assert result.last_updated.tzinfo is not None
+
+    def test_what_if_order_requires_exactly_one_positive_size(self) -> None:
+        for amount, units in (
+            (None, None),
+            (Decimal("1"), Decimal("1")),
+            (Decimal("0"), None),
+        ):
+            try:
+                BrokerWhatIfOrder(
+                    instrument_id=1001,
+                    transaction="buy",
+                    settlement_type="real",
+                    amount=amount,
+                    units=units,
+                )
+            except ValueError:
+                pass
+            else:  # pragma: no cover - assertion helper branch
+                raise AssertionError(f"invalid what-if size accepted: amount={amount}, units={units}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_verify_2437_confluence.py
+++ b/tests/test_verify_2437_confluence.py
@@ -1,0 +1,26 @@
+from datetime import date
+
+import pytest
+
+from scripts.verify_2437_confluence import _market_context
+
+
+def test_market_context_uses_signal_close_not_next_open_session() -> None:
+    lookback = date(2026, 7, 8)
+    signal = date(2026, 8, 6)
+    entry = date(2026, 8, 7)
+    market_returns = {signal: -0.01, entry: 0.08}
+    market_cumulative = {lookback: 1.0, signal: 0.95, entry: 1.026}
+
+    context = _market_context(signal, lookback, market_returns, market_cumulative)
+
+    assert context is not None
+    assert context[0] == pytest.approx(-0.05)
+    assert context[1] is False
+
+
+def test_market_context_fails_closed_when_signal_day_is_missing() -> None:
+    signal = date(2026, 8, 6)
+    lookback = date(2026, 7, 8)
+
+    assert _market_context(signal, lookback, {}, {lookback: 1.0}) is None

--- a/tests/test_verify_2437_observation_storage.py
+++ b/tests/test_verify_2437_observation_storage.py
@@ -1,0 +1,41 @@
+import pytest
+
+from scripts.verify_2437_observation_storage import (
+    TIERS,
+    Tier,
+    projected_annual_signal_bytes,
+    projected_annual_signal_rows,
+    projected_bytes,
+)
+
+
+def test_declared_tier_row_caps_are_stable() -> None:
+    assert {tier.name: tier.rows for tier in TIERS} == {
+        "30-minute context": 3_276_000,
+        "5-minute setup": 4_914_000,
+        "1-minute execution": 585_000,
+    }
+
+
+def test_projection_uses_measured_reference_size() -> None:
+    tier = Tier("test", instruments=2, minutes_per_bar=30, retained_days=3)
+
+    assert tier.rows == 78
+    assert projected_bytes(tier, bytes_per_row=100) == 7_800
+
+
+def test_signal_projection_includes_every_daily_verdict_leg() -> None:
+    assert projected_annual_signal_rows(34_698) == 8_743_896
+    assert (
+        projected_annual_signal_bytes(
+            34_698,
+            measured_rows=34_698,
+            measured_total_bytes=32_000_000,
+        )
+        == 8_064_000_000
+    )
+
+
+def test_signal_projection_refuses_an_unmeasured_row_size() -> None:
+    with pytest.raises(ValueError, match="measured_rows must be positive"):
+        projected_annual_signal_bytes(100, measured_rows=0, measured_total_bytes=0)

--- a/tests/test_verify_2437_observation_storage.py
+++ b/tests/test_verify_2437_observation_storage.py
@@ -3,6 +3,7 @@ import pytest
 from scripts.verify_2437_observation_storage import (
     TIERS,
     Tier,
+    measured_bytes_per_row,
     projected_annual_signal_bytes,
     projected_annual_signal_rows,
     projected_bytes,
@@ -39,3 +40,8 @@ def test_signal_projection_includes_every_daily_verdict_leg() -> None:
 def test_signal_projection_refuses_an_unmeasured_row_size() -> None:
     with pytest.raises(ValueError, match="measured_rows must be positive"):
         projected_annual_signal_bytes(100, measured_rows=0, measured_total_bytes=0)
+
+
+def test_measured_bytes_per_row_handles_an_empty_relation() -> None:
+    assert measured_bytes_per_row(0, 0) is None
+    assert measured_bytes_per_row(4, 100) == 25.0


### PR DESCRIPTION
## Summary

- fix the #2437 confluence probe's next-session market-context leak and pin it with regression tests
- add strict, non-persisting eToro v2 eligibility and what-if-cost adapters plus a demo-only probe
- define the evidence, monitoring, allocation, exact-position ownership and strategy-only P&L control plane
- measure current signal-ledger growth and specify bounded intraday tiers and retention order

## Findings recorded

- corrected 2020+ confluence population: 2.35m stock-days; no monotonic equal-count signal
- authenticated four-instrument demo census: local tradability mismatch, per-instrument eligibility arms, undocumented cost `value`, and stale successful cost response
- current signal ledger: 34,698 rows / 33.4 MB; present daily detail projects to 8.74m rows and 8.42 GB/year
- current result store: 36 results / 48 folds / zero outcomes; all results span 1962-2026 and are legacy/stress-only under the new 2022+ and rolling 24/36-month contract

## Safety boundary

No migration, recurring observation writer, strategy order, paper executor or live execution path is enabled. Demo calls were informational eligibility/cost preflights only and placed or modified no orders.

## Verification

- repository pre-push gate green: Ruff, format, Pyright, shell/structural lints, full fast pytest tier, application smoke suite and frontend integrity checks
- focused provider/confluence/storage tests: 55 passed with the local Postgres test service available
- `scripts/verify_2437_observation_storage.py` run against the developer database
- `scripts/verify_2437_trading_preflight.py --apply --limit 4` run against demo
- `git diff --check`

Refs #2437
