### PR TITLE
spike(#2446): prove eToro preflight remains fail-closed

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -38,14 +38,19 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
   configs with SL/TP limits. What-if accepts `buy` or `sellShort` opens and
   returns an OPEN vocabulary of named cost rows (documented examples include
   markup, market spread, transaction fee, overnight, weekend and tax) plus
-  `lastUpdated`. **Observed demo 2026-08-09: live rows used `value` and omitted
-  the documented `amount`; the unit/scale of `value` is not established, and
-  `lastUpdated` can be stale even on an HTTP-success response.** Preserve both
-  fields and the timestamp, and fail any future execution gate until the unit,
-  completeness and freshness contract is empirically proved. Never coerce a
-  missing field to zero. Thin, non-persisting adapters are wired in
-  `EtoroBrokerProvider`; a broader authenticated demo population probe is still
-  required before a storage schema or execution gate is promoted.
+  `lastUpdated`. **Measured demo 2026-08-09:** `etoro-preflight-v2` resolved a
+  deterministic four-Stock/four-ETF cohort but refused one locally tradable
+  name. Twenty complete 1x/10x long-real and x1 short-CFD requests across seven
+  permitted instruments all used `value` and omitted documented `amount`;
+  18/20 timestamps were about 41 hours old, 2/20 current. Scaling relationships
+  varied by component (proportional, invariant, rounded/other, zero-only), so
+  scale does not prove a unit. **Zero of 20 responses were execution-usable.**
+  Preserve both fields and the timestamp; fail execution until the provider
+  documents `value` or starts returning current documented monetary `amount`.
+  Never coerce a missing field to zero. Thin, non-persisting adapters and the
+  bounded census are wired in `EtoroBrokerProvider` and
+  `scripts/verify_2437_trading_preflight.py`; no recurring cost writer is
+  justified by this evidence.
 - **Order-to-position reconciliation exists in v2:**
   `GET /api/v2/trading/info/{demo|real}/orders:lookup` returns
   `positionExecutions[].positionId`. This is the durable way to bind a submitted

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -146,7 +146,7 @@ GET+POST requests cannot exceed the API limit.
 | DELETE | `/api/v1/trading/execution/market-close-orders/{orderId}` | Cancel pending close order | Not used (v1) |
 | PATCH | `/api/v2/trading/{real\|demo}/positions/{positionId}` | Edit TP/SL on one exact open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). Async acceptance `{operationId, positionId, referenceId}` — re-sync before treating as landed | Planned — required for strategy-owned ratchets |
 | POST | `/api/v2/trading/info/{real\|demo}/eligibility` | Up to 100 ids/symbols; account-specific open/close/partial-close permission, min exposure, max units, order/fill types, and leverage + SL/TP constraints by settlement/direction | **Adapter implemented; no persistence/execution gate yet** |
-| POST | `/api/v2/trading/info/{real\|demo}/costs` | What-if open cost rows for `buy` / `sellShort`: open vocabulary including spread, markup, transaction, overnight/weekend and tax; returns `lastUpdated`. Demo returned `value` while omitting documented `amount`; units and freshness are not yet proved | **Adapter implemented; no persistence/execution gate yet** |
+| POST | `/api/v2/trading/info/{real\|demo}/costs` | What-if open cost rows for `buy` / `sellShort`: open vocabulary including spread, markup, transaction, overnight/weekend and tax; returns `lastUpdated`. Demo returned `value` while omitting documented `amount`; controlled scaling did not establish one unit equation | **Adapter + bounded census implemented; fail closed for execution** |
 | GET | `/api/v2/trading/info/{real\|demo}/orders:lookup` | Detailed order and `positionExecutions[].positionId`; required to bind an entry order to the exact broker position | Not used — execution reconciliation gap |
 | POST | `/api/v1/trading/execution/limit-orders` | Limit/MIT order | Not used (v1 is market-only) |
 | DELETE | `/api/v1/trading/execution/limit-orders/{orderId}` | Cancel limit order | Not used (v1) |
@@ -162,6 +162,27 @@ and `BrokerWhatIfCostResponse` adapters. Documentation examples are not populati
 evidence: probe a bounded demo cohort before deciding which fields change often,
 which settlement/direction arms are actually returned, and whether observed
 `sellShort` eligibility and costs are adequate for a short strategy.
+
+### Authenticated demo census (2026-08-09)
+
+`etoro-preflight-v2` selected four Stocks and four ETFs at deterministic latest
+dollar-volume quantiles. Eligibility resolved 8/8, but refused opening for 1/8
+despite local `is_tradable=true`; the canonical parsed response was 12,579
+bytes. Within the dedicated 20-request budget, complete 1x/10x long-real and x1
+short-CFD pairs covered seven permitted instruments. All 20 calls succeeded
+(5,717 canonical parsed bytes total), all cost rows were USD-labelled `value`,
+and none supplied documented `amount`. Eighteen response timestamps were about
+41 hours old; only two were within the local conservative 24-hour ceiling.
+Scaling varied by component between ticket-proportional, invariant,
+rounded/other and zero-only. This evidence does not identify `value` as a
+monetary amount, rate or price-unit and **0/20 responses pass the execution-use
+contract**. Unknown fields are never coerced to zero.
+
+Reproduce against demo only:
+
+```bash
+PYTHONPATH=. uv run python scripts/verify_2437_trading_preflight.py --apply --limit 8 --max-cost-requests 20
+```
 
 The first authenticated demo census (2026-08-09, four exact members of the
 validated US-equity universe) found that HTTP success is not equivalent to

--- a/docs/proposals/ta/2026-08-09-evidence-backed-signal-engine.md
+++ b/docs/proposals/ta/2026-08-09-evidence-backed-signal-engine.md
@@ -350,11 +350,18 @@ the required contract.
 The work must land as independent, reviewable slices. Later slices are blocked
 until the previous measurement is recorded:
 
-1. **Capability spike:** typed demo eligibility + what-if-cost adapters are now
-   implemented and unit-tested. A four-instrument authenticated census proved
-   response drift, stale costs and a local-tradability mismatch; broader
-   population coverage and cost-unit proof remain. No migration and no recurring
-   writer until those measurements are recorded.
+1. **Capability spike — complete, cost use blocked:** typed demo eligibility +
+   what-if-cost adapters are implemented and unit-tested. The versioned
+   `etoro-preflight-v2` census selected four stocks and four ETFs at deterministic
+   liquidity quantiles. All eight resolved; one locally tradable name was
+   refused. Twenty bounded 1x/10x long-real and x1 short-CFD requests sampled
+   seven permitted names: all returned USD-labelled `value`, none documented
+   `amount`; 18/20 timestamps were about 41 hours old and 2/20 current. Scaling
+   was not one equation across components. Consequently 0/20 responses are
+   execution-usable. No migration or recurring writer is justified by this
+   endpoint. Reproduce with `PYTHONPATH=. uv run python
+   scripts/verify_2437_trading_preflight.py --apply --limit 8
+   --max-cost-requests 20` in demo.
 2. **Storage benchmark:** representative temporary-table load, actual bytes/row,
    insert throughput, index/query plan and retention-partition drop timing.
 3. **Eligibility observations:** state-change-only writer and latest view.
@@ -373,10 +380,13 @@ they already exist; create them from this slice order before implementation.
 
 ## Features to add before paper trading
 
-1. **Eligibility/cost endpoint spike** — endpoint schemas and thin calls are
-   implemented with full raw payload retention in memory. Next measure a bounded
-   demo cohort: field presence, direction/settlement arms, unknown cost types,
-   response size and state-change frequency before designing tables.
+1. **Eligibility/cost endpoint spike — measured:** endpoint schemas and thin
+   calls retain raw payloads in memory. The deterministic bounded demo census
+   records field presence, direction/settlement arms, cost vocabulary, canonical
+   parsed-response bytes, exact scaling relationships and timestamp age. It
+   proves current cost results are not safe to persist as normalised monetary
+   costs or consume in execution; eligibility may later be stored as compact
+   state changes, but recurring cost polling remains unjustified.
 2. **Instrument eligibility observations** — preserve eToro's current open,
    tradable, buy-enabled and delisted fields with `observed_at`; add SELL-specific
    state only if the eligibility probe proves it exists.

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -31,13 +31,18 @@ Already present and reusable:
   on entry, portfolio risk, execution guard and global kill switches;
 - current v2 eligibility and what-if-cost adapters, implemented without a writer.
 
-The first bounded authenticated demo census (2026-08-09) also proved that the
-preflight cannot be replaced by local catalogue state: one of four exact
-validated-universe instruments was refused for opening although the database
-marked it tradable. Eligibility arms and minimum exposure varied by instrument.
-Cost rows used an undocumented `value` field instead of documented `amount`, and
-one successful response was over five months stale. Those observations are
-useful blockers, not yet an execution-ready cost contract.
+Two bounded authenticated demo censuses (2026-08-09) proved that preflight
+cannot be replaced by local catalogue state. The versioned follow-up used four
+stocks and four ETFs selected at deterministic liquidity quantiles: all eight
+resolved, but one locally tradable instrument was refused for opening. It then
+round-robin sampled 20 complete 1x/10x long-real and x1 short-CFD cost arms
+across seven permitted instruments, within the endpoint's 20/minute cap. Every
+response used undocumented `value` and omitted documented `amount`, so **zero
+of 20 were execution-usable**. Eighteen were about 41 hours stale and only two
+were within 24 hours. Exact scaling relationships were mixed: proportional,
+invariant, rounded/other and zero-only. The earlier five-month-stale refused
+instrument is no longer sent to the cost endpoint. These are measured blockers,
+not an execution-ready cost contract.
 
 The developer-database census on the same date found 34,698 signal-detail rows
 from the latest successful scan, zero resolved outcomes, 36 result rows and 48
@@ -299,10 +304,12 @@ are actually created.
 1. **Current v2 preflight adapters — implemented:** strict eligibility and
    what-if types, bounded request validation, raw response retention in memory,
    no writes and no execution use.
-2. **Authenticated demo capability census — four-instrument spike complete,
-   broader coverage open:** expand liquid/illiquid equity/ETF long/short
-   requests; establish cost units/freshness, response bytes, position-id
-   cardinality and v1-versus-v2 execution compatibility.
+2. **Authenticated demo capability census — complete, execution cost blocked:**
+   the deterministic equity/ETF population, long/short scaling arms, payload
+   bytes, mismatch denominator and freshness are measured. Undocumented
+   `value` semantics and mostly stale rows refuse cost consumption. Exact
+   position-id cardinality and v1-versus-v2 execution compatibility move to the
+   ownership/reconciliation slice, where an actual demo order exists.
 3. **Recent-window result arms + read-only strategy observability:** compute the
    fixed 2022+, rolling 24/36-month and per-year arms without overwriting legacy
    evidence; then expose every manifest strategy, fired funded/unfunded signal,

--- a/scripts/verify_2437_trading_preflight.py
+++ b/scripts/verify_2437_trading_preflight.py
@@ -266,7 +266,7 @@ def _fetch_cost(
     """Keep one malformed arm from destroying the bounded population census."""
     try:
         return broker.get_what_if_costs(order), None
-    except (httpx.HTTPError, TradingPreflightParseError, ValueError) as exc:
+    except (httpx.HTTPError, TradingPreflightParseError, json.JSONDecodeError) as exc:
         return None, type(exc).__name__
 
 

--- a/scripts/verify_2437_trading_preflight.py
+++ b/scripts/verify_2437_trading_preflight.py
@@ -32,7 +32,7 @@ import psycopg
 
 from app.config import settings
 from app.providers.broker import BrokerInstrumentEligibility, BrokerWhatIfCostResponse, BrokerWhatIfOrder
-from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+from app.providers.implementations.etoro_broker import EtoroBrokerProvider, TradingPreflightParseError
 from app.security.master_key import ensure_broker_key_loaded
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
@@ -259,6 +259,17 @@ def _bounded_cost_arms(
     return arms[:max_requests]
 
 
+def _fetch_cost(
+    broker: EtoroBrokerProvider,
+    order: BrokerWhatIfOrder,
+) -> tuple[BrokerWhatIfCostResponse | None, str | None]:
+    """Keep one malformed arm from destroying the bounded population census."""
+    try:
+        return broker.get_what_if_costs(order), None
+    except (httpx.HTTPError, TradingPreflightParseError, ValueError) as exc:
+        return None, type(exc).__name__
+
+
 def _freshness(last_updated: datetime, observed_at: datetime) -> tuple[Decimal, str]:
     age = Decimal(str((observed_at - last_updated).total_seconds()))
     if age < 0:
@@ -428,9 +439,8 @@ def main() -> int:
         cost_rows: list[dict[str, object]] = []
         cost_errors: list[dict[str, object]] = []
         for arm_id, multiplier, order in selected_arms:
-            try:
-                result = broker.get_what_if_costs(order)
-            except (httpx.HTTPError, ValueError) as exc:
+            result, error_type = _fetch_cost(broker, order)
+            if result is None:
                 cost_errors.append(
                     {
                         "arm_id": arm_id,
@@ -438,7 +448,7 @@ def main() -> int:
                         "transaction": order.transaction,
                         "settlement_type": order.settlement_type,
                         "multiplier": str(multiplier),
-                        "error_type": type(exc).__name__,
+                        "error_type": error_type,
                     }
                 )
                 continue

--- a/scripts/verify_2437_trading_preflight.py
+++ b/scripts/verify_2437_trading_preflight.py
@@ -6,12 +6,14 @@ normal credential-access audit still runs, as it must for every decryption.
 
 Run from the repository root::
 
-    uv run python scripts/verify_2437_trading_preflight.py
-    uv run python scripts/verify_2437_trading_preflight.py --apply --limit 8
+    PYTHONPATH=. uv run python scripts/verify_2437_trading_preflight.py
+    PYTHONPATH=. uv run python scripts/verify_2437_trading_preflight.py --apply --limit 8
 
-The default is a DB-only dry run showing the deterministic liquidity-spread
-cohort. ``--apply`` makes one batched eligibility request and, for each returned
-LONG/SHORT configuration, one current cost request at leverage 1.
+The default is a DB-only dry run showing a deterministic, type-balanced cohort
+across US-equity Stocks and ETFs. ``--apply`` makes one batched eligibility
+request, then bounded cost requests for eligible long-real and x1 short-CFD
+arms at 1x and 10x their base ticket. No cost row is execution-usable unless it
+uses the documented monetary ``amount`` field, USD, and a current timestamp.
 """
 
 from __future__ import annotations
@@ -19,21 +21,30 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-from dataclasses import asdict
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
+import httpx
 import psycopg
 
 from app.config import settings
-from app.providers.broker import BrokerInstrumentEligibility, BrokerWhatIfOrder
+from app.providers.broker import BrokerInstrumentEligibility, BrokerWhatIfCostResponse, BrokerWhatIfOrder
 from app.providers.implementations.etoro_broker import EtoroBrokerProvider
 from app.security.master_key import ensure_broker_key_loaded
 from app.services.broker_credentials import CredentialNotFound, load_credential_for_provider_use
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
-from app.services.strategies.validated_universe import US_EQUITY_ASSET_CLASS, resolve_stocks_type_id
+from app.services.strategies.validated_universe import US_EQUITY_ASSET_CLASS
 
 logger = logging.getLogger(__name__)
+
+CENSUS_VERSION = "etoro-preflight-v2"
+COHORT_TYPE_DESCRIPTIONS = ("Stocks", "ETF")
+COST_SCALE_MULTIPLIERS = (Decimal("1"), Decimal("10"))
+COST_FRESHNESS_MAX_AGE = timedelta(hours=24)
+MAX_COST_REQUESTS_PER_RUN = 20  # Dedicated endpoint budget: 20 requests / 60 seconds.
 
 _SETTLEMENT_TYPES = {
     "CFD": "cfd",
@@ -43,49 +54,108 @@ _SETTLEMENT_TYPES = {
 }
 
 
-def _load_cohort(conn: psycopg.Connection[Any], limit: int) -> list[tuple[int, str, Decimal]]:
-    """Select deterministic points across the latest dollar-volume distribution."""
-    instrument_type_id = resolve_stocks_type_id(conn)
+@dataclass(frozen=True)
+class CohortMember:
+    instrument_id: int
+    symbol: str
+    instrument_type: str
+    dollar_volume: Decimal
+    local_is_tradable: bool
+
+
+def _canonical_payload_bytes(payload: object) -> int:
+    """Parsed payload size under a reproducible canonical JSON encoding."""
+    return len(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+
+
+def _resolve_type_ids(conn: psycopg.Connection[Any]) -> dict[str, int]:
     rows = conn.execute(
         """
-        WITH ranked AS (
-            SELECT i.instrument_id, i.symbol,
-                   (l.close * l.volume)::numeric AS dollar_volume,
-                   percent_rank() OVER (ORDER BY l.close * l.volume, i.instrument_id) AS pct
-            FROM instruments i
-            JOIN exchanges e ON e.exchange_id = i.exchange
-            CROSS JOIN LATERAL (
-                SELECT p.close, p.volume
-                FROM price_daily p
-                WHERE p.instrument_id = i.instrument_id
-                  AND p.close > 0 AND p.volume > 0
-                ORDER BY p.price_date DESC
-                LIMIT 1
-            ) l
-            WHERE i.is_tradable = TRUE
-              AND i.instrument_type_id = %(instrument_type_id)s
-              AND e.asset_class = %(asset_class)s
-        ), targets AS (
-            SELECT generate_series(0, %(limit_minus_one)s) AS slot
-        )
-        SELECT DISTINCT ON (r.instrument_id)
-               r.instrument_id, r.symbol, r.dollar_volume
-        FROM targets x
-        CROSS JOIN LATERAL (
-            SELECT instrument_id, symbol, dollar_volume, pct
-            FROM ranked
-            ORDER BY abs(pct - (x.slot::numeric / GREATEST(%(limit_minus_one)s, 1))), instrument_id
-            LIMIT 1
-        ) r
-        ORDER BY r.instrument_id
+        SELECT description, instrument_type_id
+        FROM etoro_instrument_types
+        WHERE description = ANY(%(descriptions)s)
+        ORDER BY description, instrument_type_id
         """,
-        {
-            "limit_minus_one": limit - 1,
-            "instrument_type_id": instrument_type_id,
-            "asset_class": US_EQUITY_ASSET_CLASS,
-        },
+        {"descriptions": list(COHORT_TYPE_DESCRIPTIONS)},
     ).fetchall()
-    return [(int(row[0]), str(row[1]), Decimal(str(row[2]))) for row in rows]
+    grouped: dict[str, list[int]] = defaultdict(list)
+    for description, instrument_type_id in rows:
+        grouped[str(description)].append(int(instrument_type_id))
+    for description in COHORT_TYPE_DESCRIPTIONS:
+        if len(grouped[description]) != 1:
+            raise RuntimeError(
+                f"etoro_instrument_types.description = {description!r} resolved to "
+                f"{len(grouped[description])} rows; the cohort has no stable anchor"
+            )
+    return {description: grouped[description][0] for description in COHORT_TYPE_DESCRIPTIONS}
+
+
+def _type_quotas(limit: int) -> dict[str, int]:
+    """Split the total bound deterministically, favouring Stocks for odd limits."""
+    base, remainder = divmod(limit, len(COHORT_TYPE_DESCRIPTIONS))
+    return {
+        description: base + (1 if index < remainder else 0)
+        for index, description in enumerate(COHORT_TYPE_DESCRIPTIONS)
+    }
+
+
+def _load_cohort(conn: psycopg.Connection[Any], limit: int) -> list[CohortMember]:
+    """Select deterministic points across each type's latest liquidity distribution."""
+    type_ids = _resolve_type_ids(conn)
+    cohort: list[CohortMember] = []
+    for description, quota in _type_quotas(limit).items():
+        if quota == 0:
+            continue
+        rows = conn.execute(
+            """
+            WITH ranked AS (
+                SELECT i.instrument_id, i.symbol, i.is_tradable,
+                       (l.close * l.volume)::numeric AS dollar_volume,
+                       percent_rank() OVER (ORDER BY l.close * l.volume, i.instrument_id) AS pct
+                FROM instruments i
+                JOIN exchanges e ON e.exchange_id = i.exchange
+                CROSS JOIN LATERAL (
+                    SELECT p.close, p.volume
+                    FROM price_daily p
+                    WHERE p.instrument_id = i.instrument_id
+                      AND p.close > 0 AND p.volume > 0
+                    ORDER BY p.price_date DESC
+                    LIMIT 1
+                ) l
+                WHERE i.is_tradable = TRUE
+                  AND i.instrument_type_id = %(instrument_type_id)s
+                  AND e.asset_class = %(asset_class)s
+            ), targets AS (
+                SELECT generate_series(0, %(quota_minus_one)s) AS slot
+            )
+            SELECT DISTINCT ON (r.instrument_id)
+                   r.instrument_id, r.symbol, r.dollar_volume, r.is_tradable
+            FROM targets x
+            CROSS JOIN LATERAL (
+                SELECT instrument_id, symbol, dollar_volume, is_tradable, pct
+                FROM ranked
+                ORDER BY abs(pct - (x.slot::numeric / GREATEST(%(quota_minus_one)s, 1))), instrument_id
+                LIMIT 1
+            ) r
+            ORDER BY r.instrument_id
+            """,
+            {
+                "quota_minus_one": quota - 1,
+                "instrument_type_id": type_ids[description],
+                "asset_class": US_EQUITY_ASSET_CLASS,
+            },
+        ).fetchall()
+        cohort.extend(
+            CohortMember(
+                instrument_id=int(row[0]),
+                symbol=str(row[1]),
+                instrument_type=description,
+                dollar_volume=Decimal(str(row[2])),
+                local_is_tradable=bool(row[3]),
+            )
+            for row in rows
+        )
+    return sorted(cohort, key=lambda row: (COHORT_TYPE_DESCRIPTIONS.index(row.instrument_type), row.instrument_id))
 
 
 def _load_demo_credentials() -> tuple[str, str]:
@@ -113,12 +183,15 @@ def _load_demo_credentials() -> tuple[str, str]:
     return api_key, user_key
 
 
-def _cost_orders(row: BrokerInstrumentEligibility) -> list[BrokerWhatIfOrder]:
+def _base_cost_orders(row: BrokerInstrumentEligibility) -> list[BrokerWhatIfOrder]:
+    """Return only the two arms this spike is authorised to characterise."""
     orders: list[BrokerWhatIfOrder] = []
     for config in row.leverage_configs:
         settlement = _SETTLEMENT_TYPES.get(config.settlement_type.upper())
         direction = config.direction.upper()
-        if settlement is None or direction not in {"LONG", "SHORT"} or 1 not in config.leverage_values:
+        is_long_real = direction == "LONG" and settlement == "real"
+        is_short_cfd = direction == "SHORT" and settlement == "cfd"
+        if (not is_long_real and not is_short_cfd) or 1 not in config.leverage_values:
             continue
         minimum = config.min_position_amount or row.min_position_exposure or Decimal("100")
         amount = max(minimum, Decimal("100"))
@@ -130,35 +203,212 @@ def _cost_orders(row: BrokerInstrumentEligibility) -> list[BrokerWhatIfOrder]:
                 amount=amount,
             )
         )
+    return sorted(orders, key=lambda order: (order.transaction, order.settlement_type))
+
+
+def _cost_orders(row: BrokerInstrumentEligibility) -> list[tuple[str, Decimal, BrokerWhatIfOrder]]:
+    if not row.allow_open_position:
+        return []
+    orders: list[tuple[str, Decimal, BrokerWhatIfOrder]] = []
+    for base in _base_cost_orders(row):
+        assert base.amount is not None
+        for multiplier in COST_SCALE_MULTIPLIERS:
+            arm_id = f"{CENSUS_VERSION}:{base.instrument_id}:{base.transaction}:{base.settlement_type}:{multiplier}x"
+            orders.append(
+                (
+                    arm_id,
+                    multiplier,
+                    BrokerWhatIfOrder(
+                        instrument_id=base.instrument_id,
+                        transaction=base.transaction,
+                        settlement_type=base.settlement_type,
+                        amount=base.amount * multiplier,
+                    ),
+                )
+            )
     return orders
+
+
+def _interleave_cost_arms(
+    eligibilities: tuple[BrokerInstrumentEligibility, ...],
+    instrument_types: dict[int, str],
+) -> list[tuple[str, Decimal, BrokerWhatIfOrder]]:
+    """Round-robin complete scaling pairs across types before applying the cap."""
+    groups: dict[str, list[list[tuple[str, Decimal, BrokerWhatIfOrder]]]] = defaultdict(list)
+    for row in eligibilities:
+        arms = _cost_orders(row)
+        for index in range(0, len(arms), len(COST_SCALE_MULTIPLIERS)):
+            groups[instrument_types[row.instrument_id]].append(arms[index : index + len(COST_SCALE_MULTIPLIERS)])
+    interleaved: list[tuple[str, Decimal, BrokerWhatIfOrder]] = []
+    max_groups = max((len(rows) for rows in groups.values()), default=0)
+    for index in range(max_groups):
+        for description in COHORT_TYPE_DESCRIPTIONS:
+            if index < len(groups[description]):
+                interleaved.extend(groups[description][index])
+    return interleaved
+
+
+def _bounded_cost_arms(
+    arms: list[tuple[str, Decimal, BrokerWhatIfOrder]],
+    max_requests: int,
+) -> list[tuple[str, Decimal, BrokerWhatIfOrder]]:
+    if not 2 <= max_requests <= MAX_COST_REQUESTS_PER_RUN:
+        raise ValueError(f"max_requests must be between 2 and {MAX_COST_REQUESTS_PER_RUN}")
+    if max_requests % len(COST_SCALE_MULTIPLIERS):
+        raise ValueError("max_requests must preserve complete scaling pairs")
+    return arms[:max_requests]
+
+
+def _freshness(last_updated: datetime, observed_at: datetime) -> tuple[Decimal, str]:
+    age = Decimal(str((observed_at - last_updated).total_seconds()))
+    if age < 0:
+        return age, "future_timestamp_blocking"
+    if age > Decimal(str(COST_FRESHNESS_MAX_AGE.total_seconds())):
+        return age, "stale_blocking"
+    return age, "within_24h"
+
+
+def _cost_response_usable(result: BrokerWhatIfCostResponse, freshness_status: str) -> tuple[bool, list[str]]:
+    blockers: list[str] = []
+    if freshness_status != "within_24h":
+        blockers.append(freshness_status)
+    if not result.costs:
+        blockers.append("empty_cost_breakdown")
+    for cost in result.costs:
+        if cost.currency.upper() != "USD":
+            blockers.append(f"unknown_currency:{cost.currency}")
+        if cost.amount is None:
+            blockers.append(f"undocumented_value_semantics:{cost.cost_type}")
+    return not blockers, sorted(set(blockers))
+
+
+def _classify_scaling(cost_rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Classify exact 1x/10x relationships without claiming undocumented units."""
+    grouped: dict[tuple[object, ...], list[tuple[Decimal, Decimal]]] = defaultdict(list)
+    for row in cost_rows:
+        multiplier = Decimal(str(row["multiplier"]))
+        for cost in row["costs"]:  # type: ignore[union-attr]
+            assert isinstance(cost, dict)
+            for field in ("amount", "value"):
+                raw_value = cost[field]
+                if raw_value is not None:
+                    grouped[
+                        (
+                            row["instrument_id"],
+                            row["transaction"],
+                            row["settlement_type"],
+                            cost["cost_type"],
+                            cost["currency"],
+                            field,
+                        )
+                    ].append((multiplier, Decimal(str(raw_value))))
+
+    classifications: list[dict[str, object]] = []
+    for key, observations in sorted(grouped.items(), key=lambda item: tuple(str(part) for part in item[0])):
+        values = dict(observations)
+        base = values.get(Decimal("1"))
+        scaled = values.get(Decimal("10"))
+        if base is None or scaled is None:
+            relationship = "incomplete_blocking"
+        elif base == 0 and scaled == 0:
+            relationship = "zero_only_uninformative"
+        elif scaled == base * Decimal("10"):
+            relationship = "ticket_proportional"
+        elif scaled == base:
+            relationship = "ticket_invariant"
+        else:
+            relationship = "other_blocking"
+        classifications.append(
+            {
+                "instrument_id": key[0],
+                "transaction": key[1],
+                "settlement_type": key[2],
+                "cost_type": key[3],
+                "currency": key[4],
+                "field": key[5],
+                "equation": "cost(k * base_ticket) = k * cost(base_ticket)" if base is not None else None,
+                "relationship": relationship,
+                "observations": [
+                    {"multiplier": str(multiplier), "cost": str(value)} for multiplier, value in sorted(observations)
+                ],
+                "execution_semantics": (
+                    "documented_order_currency_amount" if key[5] == "amount" else "undocumented_blocking"
+                ),
+            }
+        )
+    return classifications
+
+
+def _coverage(eligibilities: tuple[BrokerInstrumentEligibility, ...]) -> dict[str, object]:
+    direction_counts: Counter[str] = Counter()
+    settlement_counts: Counter[str] = Counter()
+    leverage_counts: Counter[str] = Counter()
+    for row in eligibilities:
+        for config in row.leverage_configs:
+            direction_counts[config.direction] += 1
+            settlement_counts[config.settlement_type] += 1
+            for leverage in config.leverage_values:
+                leverage_counts[str(leverage)] += 1
+    return {
+        "direction_config_counts": dict(sorted(direction_counts.items())),
+        "settlement_config_counts": dict(sorted(settlement_counts.items())),
+        "leverage_config_counts": dict(sorted(leverage_counts.items(), key=lambda item: int(item[0]))),
+    }
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--apply", action="store_true", help="Call demo informational endpoints")
-    parser.add_argument("--limit", type=int, default=8, help="Cohort size, 1..100 (default 8)")
+    parser.add_argument("--limit", type=int, default=8, help="Total cohort size, 2..100 (default 8)")
+    parser.add_argument(
+        "--max-cost-requests",
+        type=int,
+        default=MAX_COST_REQUESTS_PER_RUN,
+        help=f"Hard request cap, 2..{MAX_COST_REQUESTS_PER_RUN} (default {MAX_COST_REQUESTS_PER_RUN})",
+    )
     args = parser.parse_args()
-    if not 1 <= args.limit <= 100:
-        parser.error("--limit must be between 1 and 100")
+    if not 2 <= args.limit <= 100:
+        parser.error("--limit must be between 2 and 100 so both Stocks and ETFs are represented")
+    if not 2 <= args.max_cost_requests <= MAX_COST_REQUESTS_PER_RUN:
+        parser.error(f"--max-cost-requests must be between 2 and {MAX_COST_REQUESTS_PER_RUN}")
+    if args.max_cost_requests % len(COST_SCALE_MULTIPLIERS):
+        parser.error("--max-cost-requests must be divisible by the number of scaling arms (2)")
     if settings.etoro_env != "demo":
         parser.error("refusing: ETORO_ENV must be demo for this probe")
 
     with psycopg.connect(settings.database_url) as conn:
         cohort = _load_cohort(conn, args.limit)
-    print(
-        json.dumps(
+    cohort_counts = Counter(row.instrument_type for row in cohort)
+    dry_report = {
+        "census_version": CENSUS_VERSION,
+        "mode": "apply" if args.apply else "dry_run",
+        "cohort_definition": {
+            "asset_class": US_EQUITY_ASSET_CLASS,
+            "instrument_types": list(COHORT_TYPE_DESCRIPTIONS),
+            "selection": "equal type quota; nearest deterministic latest-dollar-volume quantiles",
+            "requested_total": args.limit,
+            "selected_total": len(cohort),
+            "selected_by_type": dict(sorted(cohort_counts.items())),
+        },
+        "request_budget": {
+            "eligibility_requests": 1,
+            "cost_requests_max": args.max_cost_requests,
+            "cost_endpoint_documented_limit_per_60s": MAX_COST_REQUESTS_PER_RUN,
+            "scaling_multipliers": [str(value) for value in COST_SCALE_MULTIPLIERS],
+        },
+        "cohort": [
             {
-                "mode": "apply" if args.apply else "dry_run",
-                "cohort": [
-                    {"instrument_id": instrument_id, "symbol": symbol, "dollar_volume": str(dollar_volume)}
-                    for instrument_id, symbol, dollar_volume in cohort
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        )
-    )
+                "instrument_id": row.instrument_id,
+                "symbol": row.symbol,
+                "instrument_type": row.instrument_type,
+                "dollar_volume": str(row.dollar_volume),
+                "local_is_tradable": row.local_is_tradable,
+            }
+            for row in cohort
+        ],
+    }
     if not args.apply:
+        print(json.dumps(dry_report, indent=2, sort_keys=True))
         return 0
 
     try:
@@ -167,34 +417,93 @@ def main() -> int:
         logger.error("cannot load demo credentials: %s", exc)
         return 1
 
+    observed_at = datetime.now(UTC)
     with EtoroBrokerProvider(api_key=api_key, user_key=user_key, env="demo") as broker:
-        eligibility = broker.check_instrument_eligibility([instrument_id for instrument_id, _, _ in cohort])
+        eligibility = broker.check_instrument_eligibility([row.instrument_id for row in cohort])
+        all_arms = _interleave_cost_arms(
+            eligibility.eligibilities,
+            {row.instrument_id: row.instrument_type for row in cohort},
+        )
+        selected_arms = _bounded_cost_arms(all_arms, args.max_cost_requests)
         cost_rows: list[dict[str, object]] = []
-        for row in eligibility.eligibilities:
-            for order in _cost_orders(row):
+        cost_errors: list[dict[str, object]] = []
+        for arm_id, multiplier, order in selected_arms:
+            try:
                 result = broker.get_what_if_costs(order)
-                cost_rows.append(
+            except (httpx.HTTPError, ValueError) as exc:
+                cost_errors.append(
                     {
-                        "instrument_id": result.instrument_id,
+                        "arm_id": arm_id,
+                        "instrument_id": order.instrument_id,
                         "transaction": order.transaction,
                         "settlement_type": order.settlement_type,
-                        "amount": str(order.amount),
-                        "last_updated": result.last_updated.isoformat(),
-                        "costs": [
-                            asdict(cost)
-                            | {
-                                "amount": str(cost.amount) if cost.amount is not None else None,
-                                "value": str(cost.value) if cost.value is not None else None,
-                            }
-                            for cost in result.costs
-                        ],
+                        "multiplier": str(multiplier),
+                        "error_type": type(exc).__name__,
                     }
                 )
+                continue
+            received_at = datetime.now(UTC)
+            age_seconds, freshness_status = _freshness(result.last_updated, received_at)
+            usable, blockers = _cost_response_usable(result, freshness_status)
+            cost_rows.append(
+                {
+                    "arm_id": arm_id,
+                    "instrument_id": result.instrument_id,
+                    "transaction": order.transaction,
+                    "settlement_type": order.settlement_type,
+                    "multiplier": str(multiplier),
+                    "ticket_amount_usd": str(order.amount),
+                    "last_updated": result.last_updated.isoformat(),
+                    "received_at": received_at.isoformat(),
+                    "age_seconds_at_receipt": str(age_seconds),
+                    "freshness_status": freshness_status,
+                    "canonical_response_bytes": _canonical_payload_bytes(result.raw_payload),
+                    "execution_usable": usable,
+                    "execution_blockers": blockers,
+                    "costs": [
+                        asdict(cost)
+                        | {
+                            "amount": str(cost.amount) if cost.amount is not None else None,
+                            "value": str(cost.value) if cost.value is not None else None,
+                        }
+                        for cost in result.costs
+                    ],
+                }
+            )
 
-    report = {
-        "requested": len(cohort),
-        "resolved": len(eligibility.eligibilities),
-        "not_found_instrument_ids": list(eligibility.not_found_instrument_ids),
+    cohort_by_id = {row.instrument_id: row for row in cohort}
+    returned_by_id = {row.instrument_id: row for row in eligibility.eligibilities}
+    mismatch_ids = sorted(
+        instrument_id
+        for instrument_id, member in cohort_by_id.items()
+        if member.local_is_tradable
+        and (instrument_id not in returned_by_id or not returned_by_id[instrument_id].allow_open_position)
+    )
+    cost_types = Counter(
+        str(cost["cost_type"])
+        for row in cost_rows
+        for cost in row["costs"]  # type: ignore[union-attr]
+        if isinstance(cost, dict)
+    )
+    currencies = Counter(
+        str(cost["currency"])
+        for row in cost_rows
+        for cost in row["costs"]  # type: ignore[union-attr]
+        if isinstance(cost, dict)
+    )
+    report = dry_report | {
+        "observed_at": observed_at.isoformat(),
+        "population": {
+            "requested": len(cohort),
+            "resolved": len(eligibility.eligibilities),
+            "refused_open": sum(not row.allow_open_position for row in eligibility.eligibilities),
+            "not_found_instrument_ids": list(eligibility.not_found_instrument_ids),
+            "not_found_symbols": list(eligibility.not_found_symbols),
+            "local_tradable_broker_open_mismatch_count": len(mismatch_ids),
+            "local_tradable_broker_open_mismatch_ids": mismatch_ids,
+        },
+        "eligibility_canonical_response_bytes": _canonical_payload_bytes(eligibility.raw_payload),
+        "eligibility_coverage": _coverage(eligibility.eligibilities),
         "eligibility": [
             {
                 "instrument_id": row.instrument_id,
@@ -217,6 +526,21 @@ def main() -> int:
             }
             for row in eligibility.eligibilities
         ],
+        "cost_population": {
+            "eligible_arms": len(all_arms),
+            "requested_arms": len(selected_arms),
+            "skipped_by_rate_budget": len(all_arms) - len(selected_arms),
+            "resolved_arms": len(cost_rows),
+            "errored_arms": len(cost_errors),
+            "execution_usable_arms": sum(bool(row["execution_usable"]) for row in cost_rows),
+            "canonical_response_bytes": sum(
+                value for row in cost_rows if isinstance((value := row["canonical_response_bytes"]), int)
+            ),
+            "cost_type_row_counts": dict(sorted(cost_types.items())),
+            "currency_row_counts": dict(sorted(currencies.items())),
+        },
+        "cost_errors": cost_errors,
+        "cost_scaling": _classify_scaling(cost_rows),
         "cost_preflights": cost_rows,
     }
     print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/test_verify_2437_trading_preflight.py
+++ b/tests/test_verify_2437_trading_preflight.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from json import JSONDecodeError
 from unittest.mock import MagicMock
 
 from app.providers.broker import (
@@ -115,14 +116,28 @@ def test_cost_request_budget_cannot_exceed_endpoint_limit_or_split_scaling_pair(
 
 
 def test_malformed_cost_arm_is_reported_without_aborting_census() -> None:
+    order = _cost_orders(_eligibility())[0][2]
+    for error in (TradingPreflightParseError("drift"), JSONDecodeError("not JSON", "", 0)):
+        broker = MagicMock()
+        broker.get_what_if_costs.side_effect = error
+
+        result, error_type = _fetch_cost(broker, order)
+
+        assert result is None
+        assert error_type == type(error).__name__
+
+
+def test_programming_value_error_is_not_hidden_as_an_arm_error() -> None:
     broker = MagicMock()
-    broker.get_what_if_costs.side_effect = TradingPreflightParseError("drift")
+    broker.get_what_if_costs.side_effect = ValueError("local bug")
     order = _cost_orders(_eligibility())[0][2]
 
-    result, error_type = _fetch_cost(broker, order)
-
-    assert result is None
-    assert error_type == "TradingPreflightParseError"
+    try:
+        _fetch_cost(broker, order)
+    except ValueError as exc:
+        assert str(exc) == "local bug"
+    else:  # pragma: no cover - assertion helper branch
+        raise AssertionError("unrelated ValueError was hidden as a provider arm error")
 
 
 def test_scaling_equation_classifies_proportional_invariant_and_incomplete_fields() -> None:

--- a/tests/test_verify_2437_trading_preflight.py
+++ b/tests/test_verify_2437_trading_preflight.py
@@ -1,0 +1,174 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+from app.providers.broker import (
+    BrokerCostComponent,
+    BrokerInstrumentEligibility,
+    BrokerLeverageConfig,
+    BrokerWhatIfCostResponse,
+)
+from scripts.verify_2437_trading_preflight import (
+    CENSUS_VERSION,
+    MAX_COST_REQUESTS_PER_RUN,
+    _bounded_cost_arms,
+    _canonical_payload_bytes,
+    _classify_scaling,
+    _cost_orders,
+    _cost_response_usable,
+    _freshness,
+    _interleave_cost_arms,
+    _type_quotas,
+)
+
+
+def _config(settlement: str, direction: str, minimum: str = "10") -> BrokerLeverageConfig:
+    return BrokerLeverageConfig(
+        settlement_type=settlement,
+        direction=direction,
+        leverage_values=(1, 2),
+        min_position_amount=Decimal(minimum),
+        allow_edit_stop_loss=True,
+        allow_edit_take_profit=True,
+        allow_stop_loss_take_profit=True,
+        raw_payload={},
+    )
+
+
+def _eligibility() -> BrokerInstrumentEligibility:
+    return BrokerInstrumentEligibility(
+        instrument_id=101,
+        symbol="TEST",
+        min_position_exposure=Decimal("50"),
+        max_units_per_order=Decimal("1000"),
+        allow_open_position=True,
+        allow_close_position=True,
+        allow_partial_close_position=True,
+        allow_trailing_stop_loss=True,
+        leverage_configs=(
+            _config("REAL", "LONG"),
+            _config("CFD", "SHORT", "250"),
+            _config("CFD", "LONG"),
+        ),
+        raw_payload={},
+    )
+
+
+def _cost_response(*, amount: Decimal | None, value: Decimal | None, currency: str = "USD") -> BrokerWhatIfCostResponse:
+    return BrokerWhatIfCostResponse(
+        instrument_id=101,
+        symbol="TEST",
+        costs=(
+            BrokerCostComponent(
+                cost_type="marketSpread",
+                amount=amount,
+                value=value,
+                currency=currency,
+                raw_payload={},
+            ),
+        ),
+        last_updated=datetime(2026, 8, 9, tzinfo=UTC),
+        raw_payload={},
+    )
+
+
+def test_type_quotas_are_bounded_balanced_and_deterministic() -> None:
+    assert _type_quotas(8) == {"Stocks": 4, "ETF": 4}
+    assert _type_quotas(7) == {"Stocks": 4, "ETF": 3}
+
+
+def test_cost_arms_are_versioned_scaled_and_restricted_to_authorised_shapes() -> None:
+    arms = _cost_orders(_eligibility())
+
+    assert len(arms) == 4
+    assert [arm[2].transaction for arm in arms] == ["buy", "buy", "sellShort", "sellShort"]
+    assert [arm[2].settlement_type for arm in arms] == ["real", "real", "cfd", "cfd"]
+    assert [arm[2].amount for arm in arms] == [Decimal("100"), Decimal("1000"), Decimal("250"), Decimal("2500")]
+    assert all(arm[0].startswith(f"{CENSUS_VERSION}:101:") for arm in arms)
+
+
+def test_cost_arms_skip_refused_instruments_and_interleave_types_in_complete_pairs() -> None:
+    refused = BrokerInstrumentEligibility(
+        **{**_eligibility().__dict__, "instrument_id": 303, "allow_open_position": False}
+    )
+    etf = BrokerInstrumentEligibility(**{**_eligibility().__dict__, "instrument_id": 202})
+
+    arms = _interleave_cost_arms((_eligibility(), refused, etf), {101: "Stocks", 202: "ETF", 303: "Stocks"})
+
+    assert [arm[2].instrument_id for arm in arms] == [101, 101, 202, 202, 101, 101, 202, 202]
+    assert all(arm[2].instrument_id != 303 for arm in arms)
+
+
+def test_cost_request_budget_cannot_exceed_endpoint_limit_or_split_scaling_pair() -> None:
+    arms = _cost_orders(_eligibility()) * 10
+
+    assert len(_bounded_cost_arms(arms, MAX_COST_REQUESTS_PER_RUN)) == 20
+    for invalid in (1, 3, MAX_COST_REQUESTS_PER_RUN + 2):
+        try:
+            _bounded_cost_arms(arms, invalid)
+        except ValueError:
+            pass
+        else:  # pragma: no cover - assertion helper branch
+            raise AssertionError(f"invalid request cap accepted: {invalid}")
+
+
+def test_scaling_equation_classifies_proportional_invariant_and_incomplete_fields() -> None:
+    rows: list[dict[str, object]] = []
+    for multiplier, proportional, invariant in (("1", "2", "7"), ("10", "20", "7")):
+        rows.append(
+            {
+                "instrument_id": 101,
+                "transaction": "buy",
+                "settlement_type": "real",
+                "multiplier": multiplier,
+                "costs": [
+                    {"cost_type": "spread", "currency": "USD", "amount": proportional, "value": None},
+                    {"cost_type": "fee", "currency": "USD", "amount": None, "value": invariant},
+                ],
+            }
+        )
+    rows.append(
+        {
+            "instrument_id": 202,
+            "transaction": "buy",
+            "settlement_type": "real",
+            "multiplier": "1",
+            "costs": [{"cost_type": "fee", "currency": "USD", "amount": "1", "value": None}],
+        }
+    )
+
+    classifications = _classify_scaling(rows)
+    by_key = {(row["instrument_id"], row["cost_type"], row["field"]): row for row in classifications}
+
+    assert by_key[(101, "spread", "amount")]["relationship"] == "ticket_proportional"
+    assert by_key[(101, "spread", "amount")]["execution_semantics"] == "documented_order_currency_amount"
+    assert by_key[(101, "fee", "value")]["relationship"] == "ticket_invariant"
+    assert by_key[(101, "fee", "value")]["execution_semantics"] == "undocumented_blocking"
+    assert by_key[(202, "fee", "amount")]["relationship"] == "incomplete_blocking"
+
+
+def test_freshness_and_cost_semantics_fail_closed() -> None:
+    observed_at = datetime(2026, 8, 9, 12, tzinfo=UTC)
+    _, current_status = _freshness(observed_at - timedelta(minutes=5), observed_at)
+    _, stale_status = _freshness(observed_at - timedelta(days=2), observed_at)
+    _, future_status = _freshness(observed_at + timedelta(seconds=1), observed_at)
+
+    assert current_status == "within_24h"
+    assert stale_status == "stale_blocking"
+    assert future_status == "future_timestamp_blocking"
+    assert _cost_response_usable(_cost_response(amount=Decimal("1"), value=None), current_status) == (True, [])
+    assert _cost_response_usable(_cost_response(amount=None, value=Decimal("1")), current_status) == (
+        False,
+        ["undocumented_value_semantics:marketSpread"],
+    )
+    assert _cost_response_usable(_cost_response(amount=Decimal("1"), value=None), stale_status) == (
+        False,
+        ["stale_blocking"],
+    )
+    assert _cost_response_usable(_cost_response(amount=Decimal("1"), value=None, currency="GBP"), current_status) == (
+        False,
+        ["unknown_currency:GBP"],
+    )
+
+
+def test_canonical_payload_size_is_key_order_independent() -> None:
+    assert _canonical_payload_bytes({"b": 1, "a": 2}) == _canonical_payload_bytes({"a": 2, "b": 1})

--- a/tests/test_verify_2437_trading_preflight.py
+++ b/tests/test_verify_2437_trading_preflight.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 from app.providers.broker import (
     BrokerCostComponent,
@@ -7,6 +8,7 @@ from app.providers.broker import (
     BrokerLeverageConfig,
     BrokerWhatIfCostResponse,
 )
+from app.providers.implementations.etoro_broker import TradingPreflightParseError
 from scripts.verify_2437_trading_preflight import (
     CENSUS_VERSION,
     MAX_COST_REQUESTS_PER_RUN,
@@ -15,6 +17,7 @@ from scripts.verify_2437_trading_preflight import (
     _classify_scaling,
     _cost_orders,
     _cost_response_usable,
+    _fetch_cost,
     _freshness,
     _interleave_cost_arms,
     _type_quotas,
@@ -109,6 +112,17 @@ def test_cost_request_budget_cannot_exceed_endpoint_limit_or_split_scaling_pair(
             pass
         else:  # pragma: no cover - assertion helper branch
             raise AssertionError(f"invalid request cap accepted: {invalid}")
+
+
+def test_malformed_cost_arm_is_reported_without_aborting_census() -> None:
+    broker = MagicMock()
+    broker.get_what_if_costs.side_effect = TradingPreflightParseError("drift")
+    order = _cost_orders(_eligibility())[0][2]
+
+    result, error_type = _fetch_cost(broker, order)
+
+    assert result is None
+    assert error_type == "TradingPreflightParseError"
 
 
 def test_scaling_equation_classifies_proportional_invariant_and_incomplete_fields() -> None:


### PR DESCRIPTION
Closes #2446
Refs #2437

## Outcome

Proves the current demo preflight is not safe as an execution-cost input, without adding a writer or migration.

- deterministic `etoro-preflight-v2` cohort: four Stocks + four ETFs across latest dollar-volume quantiles
- complete 1x/10x long-real and x1 short-CFD arms, round-robin across types and hard-capped at the documented 20 cost requests/minute
- counts local/broker tradability mismatches, refusals, missing rows and complete coverage denominators
- records canonical parsed-response bytes, cost vocabulary, currencies, timestamp age and exact scaling relationship
- refuses undocumented `value`, non-USD, empty, stale or future-dated responses for execution use
- updates the eToro reference, source skill and #2437 control-plane/evidence specs

## Measured demo result (2026-08-09)

- eligibility: 8/8 resolved; 1/8 locally tradable instrument refused; 12,579 canonical bytes
- costs: 20/20 calls succeeded across seven permitted instruments; 5,717 canonical bytes
- schema: every cost row used undocumented `value`; none used documented monetary `amount`
- freshness: 18/20 about 41 hours stale; 2/20 current under the local 24-hour ceiling
- scale: relationships were mixed across proportional, invariant, rounded/other and zero-only
- execution verdict: 0/20 usable; fail closed

## Validation

- `uv run ruff check scripts/verify_2437_trading_preflight.py tests/test_verify_2437_trading_preflight.py`
- `uv run ruff format --check scripts/verify_2437_trading_preflight.py tests/test_verify_2437_trading_preflight.py`
- `uv run pyright scripts/verify_2437_trading_preflight.py tests/test_verify_2437_trading_preflight.py`
- `uv run pytest tests/test_verify_2437_trading_preflight.py tests/test_broker_provider.py -q` (56 passed)
- full repository pre-push gate: green (non-blocking existing dev DB warning: 63 GB > 60 GB)
