### PR TITLE
feat(#2447): add recent strategy evidence and monitoring

### DIFF
--- a/.claude/skills/quant/data-capability.md
+++ b/.claude/skills/quant/data-capability.md
@@ -136,9 +136,12 @@ minimum** — that is the specific thing a data purchase must buy.
 ## 4. Known gaps, ranked by what they would unlock
 
 1. **Survivorship-free universe** — ⚠⚠ **the highest-value gap.** Only **2 of
-   7,709** series carry a delisting date. #2346 measured free archives serving
-   **258/259** of a delisted cohort, so the data is obtainable. It closes a
-   standing promotion refusal *and* removes the bias inflating every number.
+   7,709** series carry a delisting date. Do not repeat the stale claim that a
+   free archive serves 258/259 delisted names: #2284's issuer-resolved 2023 Form
+   25 cohort found Yahoo/free snapshots served **0 of 382** usable delisting
+   histories, with ticker reuse and OTC continuation making apparent hits
+   unsafe. A genuinely survivorship-free adjusted corpus is a paid validation
+   gate; development remains survivor-labelled and unpromotable.
 2. **Options / implied volatility** — the largest missing conditioner. Our
    best-understood effect (Nagel) is vol-conditioned, and we can only build the
    trailing-realised proxy.

--- a/.claude/skills/quant/strategy-evidence.md
+++ b/.claude/skills/quant/strategy-evidence.md
@@ -1189,6 +1189,28 @@ Filed as **#2441**.
    prior. The repo's rule stands: *grep before cite, run it or delete the
    quantifier.*
 
+### Recent-regime and storage contract (#2437)
+
+Do not let a 1962–2026 aggregate answer whether a strategy is viable now. Keep
+that row as stress/context evidence and require the code-pinned windows in
+`strategy_recent_evidence.RECENT_EVIDENCE_WINDOWS`: primary 2022+, rolling
+24/36 months, and each calendar year/YTD. Each window is part of
+`ResultIdentity.version`; never accept raw dates from an operator. A strategy
+must fail closed when any required recent window is absent or loses its net
+expectancy sign. Pre-2000 performance cannot rescue it.
+
+Store only the aggregate result arms. At the current three runnable strategies,
+the complete recent matrix is 96 rows (8 windows x 3 strategies x 2 ambiguity x
+2 quarantine). Reuse the daily corpus during compute; do not persist indicator,
+position or equity-curve time series merely to render the picker. Fired signals
+remain durable; non-fired/not-evaluable detail is a bounded-retention concern and
+must have checked daily aggregates before deletion.
+
+Keep historical backtest, forward observation, paper and live as separate arms.
+All fired signals remain visible when unfunded. Missing broker cost semantics,
+survivorship, carry, outcomes, controls or ownership produce named refusals; they
+never become zero/default inputs.
+
 ---
 
 ## 5. Open-source landscape
@@ -1272,4 +1294,3 @@ trip.** The entire long-only short-horizon game is played inside the spread. No
 quantity of extra conditions repairs a cost problem — which is why the operator's
 shorting decision mattered more than any signal found in the same session: the short
 side has 200-440 bps of gross to work with, not 44.
-

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -391,8 +391,7 @@ def get_strategy_overview(
                 exclusion_reason=excluded_by_id.get(strategy_id),
                 scan=scan,
                 evidence_windows=windows,
-                legacy_result_count=result_counts.get(strategy_id, 0)
-                - sum(len(rows) for key, rows in exact.items() if key in declared_pairs),
+                legacy_result_count=result_counts.get(strategy_id, 0) - sum(len(rows) for rows in exact.values()),
                 all_recent_evidence_complete=all_complete,
                 allocation_refusals=allocation_refusals,
             )

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -22,10 +22,13 @@ from app.api.auth import require_session_or_service_token
 from app.db import get_conn
 from app.services.backtest_run import BACKTEST_UNIVERSE, runnable_strategies
 from app.services.cost_model import COST_MODEL_ID
+from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_result import CORPUS_VERSION
 
 router = APIRouter(
     prefix="/strategies",
@@ -212,7 +215,22 @@ _RESULTS_SQL = """
         GROUP BY strategy_id, strategy_version
     ) a USING (strategy_id, strategy_version)
     WHERE r.strategy_version = ANY(%(versions)s)
+      AND r.namespace = 'hold_out'
+      AND r.corpus_version = %(corpus_version)s
+      AND r.cost_model_id = %(cost_model_id)s
+      AND r.sizing_rule = %(sizing_rule)s
+      AND r.benchmark_rule = %(benchmark_rule)s
+      AND r.position_rule_set_version = %(position_version)s
+      AND r.outcome_rule_set_version = %(outcome_version)s
+      AND r.input_rule_set_version = %(input_version)s
     ORDER BY r.strategy_id, r.window_start, r.window_end, r.ambiguity_arm, r.quarantine_arm
+"""
+
+_RESULT_COUNTS_SQL = """
+    SELECT strategy_id, COUNT(*) AS count
+    FROM strategy_results_store
+    WHERE strategy_version = ANY(%(versions)s)
+    GROUP BY strategy_id
 """
 
 _SCAN_SQL = """
@@ -246,10 +264,21 @@ def get_strategy_overview(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> StrategyOverviewResponse:
     versions = _current_versions()
-    params = {"versions": list(versions.values())}
+    params = {
+        "versions": list(versions.values()),
+        "corpus_version": CORPUS_VERSION,
+        "cost_model_id": COST_MODEL_ID,
+        "sizing_rule": SIZING_RULE_ID,
+        "benchmark_rule": BENCHMARK_RULE_ID,
+        "position_version": POSITION_RULE_SET_VERSION,
+        "outcome_version": OUTCOME_RULE_SET_VERSION,
+        "input_version": QUARANTINE_RULE_SET_VERSION,
+    }
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(_RESULTS_SQL, params)
         result_rows = list(cur.fetchall())
+        cur.execute(_RESULT_COUNTS_SQL, params)
+        result_count_rows = list(cur.fetchall())
         cur.execute(_SCAN_SQL, params)
         scan_rows = list(cur.fetchall())
         cur.execute(_EXCLUSIONS_SQL, params)
@@ -261,6 +290,7 @@ def get_strategy_overview(
     results_by_strategy: dict[str, list[dict[str, object]]] = defaultdict(list)
     for row in result_rows:
         results_by_strategy[str(row["strategy_id"])].append(row)
+    result_counts = {str(row["strategy_id"]): int(row["count"]) for row in result_count_rows}
     scan_by_strategy = {str(row["strategy_id"]): row for row in scan_rows}
     exclusions: dict[str, Counter[str]] = defaultdict(Counter)
     for row in exclusion_rows:
@@ -361,9 +391,8 @@ def get_strategy_overview(
                 exclusion_reason=excluded_by_id.get(strategy_id),
                 scan=scan,
                 evidence_windows=windows,
-                legacy_result_count=sum(
-                    (row["window_start"], row["window_end"]) not in declared_pairs for row in strategy_rows
-                ),
+                legacy_result_count=result_counts.get(strategy_id, 0)
+                - sum(len(rows) for key, rows in exact.items() if key in declared_pairs),
                 all_recent_evidence_complete=all_complete,
                 allocation_refusals=allocation_refusals,
             )

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1,0 +1,415 @@
+"""Read-only strategy evidence and fired-signal monitoring (#2447).
+
+This surface intentionally has no mutation route.  It reports the current
+manifest denominator, exact-version recent evidence, scan health, and every
+fired signal whether or not capital was available.  Allocation and execution
+remain disabled until later tickets add ownership-safe broker reconciliation.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Literal, cast
+
+import psycopg
+import psycopg.rows
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+
+from app.api.auth import require_session_or_service_token
+from app.db import get_conn
+from app.services.backtest_run import BACKTEST_UNIVERSE, runnable_strategies
+from app.services.cost_model import COST_MODEL_ID
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+
+router = APIRouter(
+    prefix="/strategies",
+    tags=["strategies"],
+    dependencies=[Depends(require_session_or_service_token)],
+)
+
+_TITLES = {
+    "s1-time-series-momentum": "Time-series momentum",
+    "s2-cross-sectional-momentum": "Cross-sectional momentum",
+    "s3-mean-reversion-in-trend": "Mean reversion in trend",
+    "s4-volatility-compression-breakout": "Volatility compression breakout",
+}
+
+
+class ScanHealth(BaseModel):
+    frontier_date: date | None
+    updated_at: datetime | None
+    status: Literal["never_run", "current", "stale"]
+    fired_entries: int = 0
+    fired_exits: int = 0
+    not_fired: int = 0
+    not_evaluable: int = 0
+    exclusions_by_reason: dict[str, int] = Field(default_factory=dict)
+
+
+class ResultArm(BaseModel):
+    result_version: str
+    ambiguity_arm: str
+    quarantine_arm: str
+    universe_basis: str
+    corpus_version: str
+    cost_model_id: str
+    sizing_rule: str
+    benchmark_rule: str
+    position_rule_set_version: str
+    outcome_rule_set_version: str
+    input_rule_set_version: str
+    evaluated_instrument_count: int
+    trade_count: int
+    expectancy_per_trade_pct: Decimal
+    expectancy_ci_low_pct: Decimal | None
+    expectancy_ci_high_pct: Decimal | None
+    total_return_pct: Decimal
+    cagr_pct: Decimal
+    sharpe: Decimal
+    sortino: Decimal | None
+    max_drawdown_pct: Decimal
+    profit_factor: Decimal | None
+    exposure_time_pct: Decimal
+    turnover_annualised: Decimal
+    return_vs_buy_and_hold_pct: Decimal
+    deflated_sharpe: Decimal | None
+    promotion_refusals: list[str]
+
+
+class EvidenceWindow(BaseModel):
+    window_id: str
+    label: str
+    window_start: date
+    window_end: date
+    status: Literal["missing", "partial", "complete"]
+    arms: list[ResultArm]
+
+
+class StrategyOverview(BaseModel):
+    strategy_id: str
+    strategy_version: str
+    title: str
+    runnable: bool
+    exclusion_reason: str | None
+    scan: ScanHealth
+    evidence_windows: list[EvidenceWindow]
+    legacy_result_count: int
+    all_recent_evidence_complete: bool
+    allocation_ready: bool = False
+    allocation_refusals: list[str]
+
+
+class StrategyOverviewResponse(BaseModel):
+    as_of: datetime
+    observation_stage: Literal["forward_observation"] = "forward_observation"
+    execution_enabled: bool = False
+    storage_policy: str = "aggregate_results_only"
+    strategies: list[StrategyOverview]
+
+
+class FiredSignal(BaseModel):
+    signal_id: int
+    strategy_id: str
+    strategy_version: str
+    instrument_id: int
+    symbol: str
+    company_name: str | None
+    signal_bar_date: date
+    signal_kind: str
+    fill_bar_date: date
+    fill_price: Decimal
+    universe: str
+    outcome: str | None
+    exit_bar_date: date | None
+    exit_price: Decimal | None
+    gross_return_pct: Decimal | None
+    outcome_reason: str | None
+    observation_stage: Literal["forward_observation"] = "forward_observation"
+    funding_status: Literal["unfunded"] = "unfunded"
+    funding_reason: Literal["execution_not_enabled"] = "execution_not_enabled"
+
+
+class FiredSignalsResponse(BaseModel):
+    items: list[FiredSignal]
+    next_cursor: int | None
+
+
+def _current_versions() -> dict[str, str]:
+    return {
+        strategy_id: entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        for strategy_id, entry in STRATEGY_MANIFEST.items()
+    }
+
+
+def _promotion_refusals(
+    row: dict[str, object],
+    *,
+    ambiguity_complete: bool,
+    quarantine_complete: bool,
+    accesses_complete: bool,
+) -> list[str]:
+    """Reproduce every gate input recoverable from a compact stored result.
+
+    The writer already proved evaluated membership against the validated
+    universe before insert; the table intentionally stores only its count.  We
+    do not fabricate a second population snapshot here.  All current rows are
+    refused independently by survivorship, carry and synthetic-control gaps.
+    """
+    refusals: list[str] = []
+    if not row["universe_basis"]:
+        refusals.append("universe_basis_absent")
+    elif row["universe_basis"] != "survivorship_free":
+        refusals.append("universe_basis_not_survivorship_free")
+    if row["carry_unmodelled"]:
+        refusals.append("carry_unmodelled")
+    if cast(int, row["evaluated_instrument_count"]) == 0:
+        refusals.append("no_instruments_evaluated")
+    if not accesses_complete:
+        refusals.append("holdout_accesses_unrecorded")
+    if row["deflated_sharpe"] is None:
+        refusals.append("deflated_sharpe_not_computed")
+    if row["trial_count"] is None:
+        refusals.append("trial_count_undeclared")
+    if row["effective_sample_size"] is None:
+        refusals.append("effective_sample_size_not_computed")
+    # Runnable v1 strategies are non-level regimes: ambiguity is unreachable,
+    # so the two labelled rows are intentionally the same measurement.
+    if not ambiguity_complete:
+        refusals.append("ambiguity_arms_not_compared")
+    if not quarantine_complete:
+        refusals.append("quarantine_arms_not_compared")
+    if row["synthetic_control_model_id"] is None:
+        refusals.append("synthetic_control_not_run")
+    else:
+        ci_low = cast(Decimal, row["synthetic_control_mean_return_ci_low_pct"])
+        ci_high = cast(Decimal, row["synthetic_control_mean_return_ci_high_pct"])
+        strategy_sharpe = cast(Decimal, row["sharpe"])
+        cohort_threshold = cast(Decimal, row["synthetic_control_sharpe_threshold"])
+        if ci_low > 0 or ci_high < 0:
+            refusals.append("synthetic_control_cohort_shows_edge")
+        if strategy_sharpe <= cohort_threshold:
+            refusals.append("synthetic_control_sharpe_below_cohort")
+    return refusals
+
+
+_RESULTS_SQL = """
+    SELECT
+        r.*,
+        COALESCE(a.accesses, 0) AS accesses,
+        COALESCE(a.evaluations, 0) AS evaluations
+    FROM strategy_results_store r
+    LEFT JOIN (
+        SELECT strategy_id, strategy_version,
+               COUNT(*) FILTER (WHERE access_kind = 'evaluate') AS evaluations,
+               COUNT(*) AS accesses
+        FROM strategy_holdout_accesses
+        GROUP BY strategy_id, strategy_version
+    ) a USING (strategy_id, strategy_version)
+    WHERE r.strategy_version = ANY(%(versions)s)
+    ORDER BY r.strategy_id, r.window_start, r.window_end, r.ambiguity_arm, r.quarantine_arm
+"""
+
+_SCAN_SQL = """
+    SELECT
+        w.strategy_id,
+        w.strategy_version,
+        w.frontier_date,
+        w.updated_at,
+        COUNT(*) FILTER (WHERE s.verdict = 'fired' AND s.signal_kind = 'entry') AS fired_entries,
+        COUNT(*) FILTER (WHERE s.verdict = 'fired' AND s.signal_kind = 'exit') AS fired_exits,
+        COUNT(*) FILTER (WHERE s.verdict = 'not_fired') AS not_fired,
+        COUNT(*) FILTER (WHERE s.verdict = 'not_evaluable') AS not_evaluable
+    FROM strategy_scan_watermark w
+    LEFT JOIN strategy_signals s USING (strategy_id, strategy_version)
+    WHERE w.strategy_version = ANY(%(versions)s)
+    GROUP BY w.strategy_id, w.strategy_version, w.frontier_date, w.updated_at
+"""
+
+_EXCLUSIONS_SQL = """
+    SELECT strategy_id, strategy_version, not_evaluable_reason, COUNT(*) AS count
+    FROM strategy_signals
+    WHERE strategy_version = ANY(%(versions)s) AND not_evaluable_reason IS NOT NULL
+    GROUP BY strategy_id, strategy_version, not_evaluable_reason
+"""
+
+_LATEST_CORPUS_SQL = "SELECT MAX(bar_date) FROM research_price_daily"
+
+
+@router.get("/overview", response_model=StrategyOverviewResponse)
+def get_strategy_overview(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyOverviewResponse:
+    versions = _current_versions()
+    params = {"versions": list(versions.values())}
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_RESULTS_SQL, params)
+        result_rows = list(cur.fetchall())
+        cur.execute(_SCAN_SQL, params)
+        scan_rows = list(cur.fetchall())
+        cur.execute(_EXCLUSIONS_SQL, params)
+        exclusion_rows = list(cur.fetchall())
+        cur.execute(_LATEST_CORPUS_SQL)
+        latest_row = cur.fetchone()
+        latest_corpus_date = None if latest_row is None else latest_row["max"]
+
+    results_by_strategy: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in result_rows:
+        results_by_strategy[str(row["strategy_id"])].append(row)
+    scan_by_strategy = {str(row["strategy_id"]): row for row in scan_rows}
+    exclusions: dict[str, Counter[str]] = defaultdict(Counter)
+    for row in exclusion_rows:
+        exclusions[str(row["strategy_id"])][str(row["not_evaluable_reason"])] += int(row["count"])
+
+    runnable, excluded = runnable_strategies()
+    excluded_by_id = {item.strategy_id: item.reason for item in excluded}
+    strategies: list[StrategyOverview] = []
+    for strategy_id in sorted(STRATEGY_MANIFEST):
+        strategy_rows = results_by_strategy[strategy_id]
+        exact = defaultdict(list)
+        declared_pairs = {(item.window.start, item.window.end): item for item in RECENT_EVIDENCE_WINDOWS.values()}
+        for row in strategy_rows:
+            key = (row["window_start"], row["window_end"])
+            if key in declared_pairs:
+                exact[key].append(row)
+
+        windows: list[EvidenceWindow] = []
+        for item in RECENT_EVIDENCE_WINDOWS.values():
+            rows = exact[(item.window.start, item.window.end)]
+            arm_keys = {(row["ambiguity_arm"], row["quarantine_arm"]) for row in rows}
+            expected_arm_keys = {
+                ("best_case", "masked"),
+                ("best_case", "admitted"),
+                ("worst_case", "masked"),
+                ("worst_case", "admitted"),
+            }
+            arms_complete = arm_keys == expected_arm_keys
+            ambiguity_complete = all(
+                {(ambiguity, quarantine) for ambiguity in ("best_case", "worst_case")}.issubset(arm_keys)
+                for quarantine in ("masked", "admitted")
+                if any(key[1] == quarantine for key in arm_keys)
+            ) and bool(arm_keys)
+            quarantine_complete = all(
+                {(ambiguity, quarantine) for quarantine in ("masked", "admitted")}.issubset(arm_keys)
+                for ambiguity in ("best_case", "worst_case")
+                if any(key[0] == ambiguity for key in arm_keys)
+            ) and bool(arm_keys)
+            status: Literal["missing", "partial", "complete"] = (
+                "complete" if arms_complete else "partial" if rows else "missing"
+            )
+            arms = []
+            for row in rows:
+                accesses_complete = int(row["accesses"]) >= int(row["evaluations"]) > 0
+                arms.append(
+                    ResultArm(
+                        **{field: row[field] for field in ResultArm.model_fields if field != "promotion_refusals"},
+                        promotion_refusals=_promotion_refusals(
+                            row,
+                            ambiguity_complete=ambiguity_complete,
+                            quarantine_complete=quarantine_complete,
+                            accesses_complete=accesses_complete,
+                        ),
+                    )
+                )
+            windows.append(
+                EvidenceWindow(
+                    window_id=item.window_id,
+                    label=item.label,
+                    window_start=item.window.start,
+                    window_end=item.window.end,
+                    status=status,
+                    arms=arms,
+                )
+            )
+
+        scan_row = scan_by_strategy.get(strategy_id)
+        frontier = None if scan_row is None else scan_row["frontier_date"]
+        scan_status: Literal["never_run", "current", "stale"] = (
+            "never_run"
+            if frontier is None
+            else "current"
+            if latest_corpus_date is not None and frontier >= latest_corpus_date
+            else "stale"
+        )
+        scan = ScanHealth(
+            frontier_date=frontier,
+            updated_at=None if scan_row is None else scan_row["updated_at"],
+            status=scan_status,
+            fired_entries=0 if scan_row is None else int(scan_row["fired_entries"]),
+            fired_exits=0 if scan_row is None else int(scan_row["fired_exits"]),
+            not_fired=0 if scan_row is None else int(scan_row["not_fired"]),
+            not_evaluable=0 if scan_row is None else int(scan_row["not_evaluable"]),
+            exclusions_by_reason=dict(exclusions[strategy_id]),
+        )
+        all_complete = all(window.status == "complete" for window in windows)
+        allocation_refusals = ["execution_not_enabled", "broker_cost_unknown"]
+        if strategy_id not in runnable:
+            allocation_refusals.append("strategy_not_runnable")
+        if not all_complete:
+            allocation_refusals.append("recent_evidence_incomplete")
+        strategies.append(
+            StrategyOverview(
+                strategy_id=strategy_id,
+                strategy_version=versions[strategy_id],
+                title=_TITLES.get(strategy_id, strategy_id),
+                runnable=strategy_id in runnable,
+                exclusion_reason=excluded_by_id.get(strategy_id),
+                scan=scan,
+                evidence_windows=windows,
+                legacy_result_count=sum(
+                    (row["window_start"], row["window_end"]) not in declared_pairs for row in strategy_rows
+                ),
+                all_recent_evidence_complete=all_complete,
+                allocation_refusals=allocation_refusals,
+            )
+        )
+    return StrategyOverviewResponse(as_of=datetime.now(tz=UTC), strategies=strategies)
+
+
+_FIRED_SIGNALS_SQL = """
+    SELECT
+        s.signal_id, s.strategy_id, s.strategy_version, s.instrument_id,
+        i.symbol, i.company_name, s.signal_bar_date, s.signal_kind,
+        s.fill_bar_date, s.fill_price, s.universe,
+        o.outcome, o.exit_bar_date, o.exit_price, o.gross_return_pct,
+        o.reason AS outcome_reason
+    FROM strategy_signals s
+    JOIN instruments i ON i.instrument_id = s.instrument_id
+    LEFT JOIN strategy_outcomes o
+      ON o.signal_id = s.signal_id
+     AND o.rule_set_version = %(outcome_version)s
+     AND o.input_rule_set_version = %(input_version)s
+    WHERE s.verdict = 'fired'
+      AND s.strategy_version = ANY(%(versions)s)
+      AND (%(cursor)s::bigint IS NULL OR s.signal_id < %(cursor)s)
+    ORDER BY s.signal_id DESC
+    LIMIT %(limit)s
+"""
+
+
+@router.get("/signals", response_model=FiredSignalsResponse)
+def get_fired_signals(
+    cursor: int | None = Query(default=None, ge=1),
+    limit: int = Query(default=50, ge=1, le=100),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> FiredSignalsResponse:
+    params = {
+        "versions": list(_current_versions().values()),
+        "cursor": cursor,
+        "limit": limit,
+        "outcome_version": OUTCOME_RULE_SET_VERSION,
+        "input_version": QUARANTINE_RULE_SET_VERSION,
+    }
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_FIRED_SIGNALS_SQL, params)
+        rows = list(cur.fetchall())
+    items = [FiredSignal(**row) for row in rows]
+    return FiredSignalsResponse(items=items, next_cursor=items[-1].signal_id if len(items) == limit else None)
+
+
+__all__ = ["router"]

--- a/app/main.py
+++ b/app/main.py
@@ -55,6 +55,7 @@ from app.api.recommendations import router as recommendations_router
 from app.api.reports import router as reports_router
 from app.api.scores import router as scores_router
 from app.api.sse_quotes import router as sse_quotes_router
+from app.api.strategies import router as strategies_router
 from app.api.sync import router as sync_router
 from app.api.system import router as system_router
 from app.api.tax import router as tax_router
@@ -558,6 +559,7 @@ app.include_router(recommendations_router)
 app.include_router(reports_router)
 app.include_router(scores_router)
 app.include_router(sse_quotes_router)
+app.include_router(strategies_router)
 app.include_router(sync_router)
 app.include_router(system_router)
 app.include_router(tax_router)

--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -260,6 +260,7 @@ _INSAMPLE_AXIS_SQL = """
     JOIN research_price_daily d ON d.series_id = s.series_id
     WHERE s.instrument_id = ANY(%(ids)s)
       AND d.bar_date >= %(start)s
+      AND d.bar_date <= %(end)s
       AND d.bar_date < %(boundary)s
     GROUP BY d.bar_date
     ORDER BY 1
@@ -867,6 +868,8 @@ class _Corpus:
     axis: tuple[date, ...]
     axis_pos: Mapping[date, int]
     pairs: tuple[tuple[int, int], ...]
+    evaluation_start: date = EVALUATION_WINDOW_START
+    evaluation_end: date = EVALUATION_WINDOW_END
     #: The pre-boundary prefix of ``axis``, and how many bars the panel carries
     #: on each of its dates. Criterion 5's fold cut is weighted by the latter.
     in_sample_axis: tuple[date, ...] = ()
@@ -874,18 +877,29 @@ class _Corpus:
 
     @property
     def window(self) -> Window:
-        return Window(start=EVALUATION_WINDOW_START, end=EVALUATION_WINDOW_END)
+        return Window(start=self.evaluation_start, end=self.evaluation_end)
 
 
-def load_corpus(conn: psycopg.Connection[Any], *, limit: int | None = None) -> _Corpus:
+def load_corpus(
+    conn: psycopg.Connection[Any],
+    *,
+    limit: int | None = None,
+    evaluation_window: Window | None = None,
+) -> _Corpus:
     """The corpus ∩ §4.0 validated-universe slice, and its union calendar.
 
     ⚠ ``limit`` exists for a smoke run and the caller must say so in its report.
     A limited pass is not a full-population figure and no row written from one
     describes the population its ``evaluated_instrument_count`` claims.
     """
+    window = evaluation_window or Window(start=EVALUATION_WINDOW_START, end=EVALUATION_WINDOW_END)
+    if window.start < EVALUATION_WINDOW_START or window.end > EVALUATION_WINDOW_END:
+        raise ValueError(
+            f"evaluation window {window.start} -> {window.end} lies outside the frozen corpus window "
+            f"{EVALUATION_WINDOW_START} -> {EVALUATION_WINDOW_END}"
+        )
     universe = load_validated_universe(conn)
-    bounds = {"ids": list(universe), "start": EVALUATION_WINDOW_START, "end": EVALUATION_WINDOW_END}
+    bounds = {"ids": list(universe), "start": window.start, "end": window.end}
     axis = tuple(row[0] for row in conn.execute(_AXIS_SQL, bounds).fetchall())
     pairs = [(int(row[0]), int(row[1])) for row in conn.execute(_SERIES_SQL, {"ids": list(universe)}).fetchall()]
     if limit is not None:
@@ -893,7 +907,7 @@ def load_corpus(conn: psycopg.Connection[Any], *, limit: int | None = None) -> _
 
     in_sample = conn.execute(
         _INSAMPLE_AXIS_SQL,
-        {"ids": list(universe), "start": EVALUATION_WINDOW_START, "boundary": HOLDOUT_BOUNDARY},
+        {"ids": list(universe), "start": window.start, "end": window.end, "boundary": HOLDOUT_BOUNDARY},
     ).fetchall()
     in_sample_axis = tuple(row[0] for row in in_sample)
     # ⚠⚠ THE PREFIX INVARIANT, ASSERTED AND NOT ASSUMED. Both queries run over
@@ -916,6 +930,8 @@ def load_corpus(conn: psycopg.Connection[Any], *, limit: int | None = None) -> _
         axis=axis,
         axis_pos={when: index for index, when in enumerate(axis)},
         pairs=tuple(pairs),
+        evaluation_start=window.start,
+        evaluation_end=window.end,
         in_sample_axis=in_sample_axis,
         in_sample_bar_counts=tuple(int(row[1]) for row in in_sample),
     )
@@ -1393,13 +1409,15 @@ def build_result(
     ambiguity_arm: AmbiguityArm,
     quarantine_arm: QuarantineArm,
     deflated: DeflatedSharpeResult | None,
+    evaluation_window: Window | None = None,
 ) -> StrategyResult:
     """One ``strategy_results`` row. §7's fourteen identity members, all pinned.
 
     ⚠ THIRTEEN OF THE FOURTEEN ARE READ FROM A MODULE THAT FROZE THEM, and that
-    is the design working. The only operator-facing degree of freedom is whether
-    the hold-out arm runs at all; a job that let an operator pass a sizing rule
-    or a window would be minting result identities no code path can reproduce.
+    is the design working. Recent-evidence windows are the sole exception: they
+    are selected from ``strategy_recent_evidence.RECENT_EVIDENCE_WINDOWS`` by
+    the caller and remain part of the result hash. Raw dates are not exposed as
+    job parameters, so an operator still cannot mint an unregistered window.
 
     ⚠⚠ ``input_rule_set_version`` IS THE QUARANTINE RULE SET, and it is NOT
     ``StrategyIdentity.input_rule_set_versions`` (which is indicator-only and is
@@ -1414,6 +1432,7 @@ def build_result(
     rather than a placeholder written — a blank would pass ``NOT NULL`` and
     silently merge two results (the #2286 shape).
     """
+    window = evaluation_window or Window(start=EVALUATION_WINDOW_START, end=EVALUATION_WINDOW_END)
     return StrategyResult(
         identity=ResultIdentity(
             strategy_id=strategy_id,
@@ -1426,8 +1445,8 @@ def build_result(
             benchmark_rule=BENCHMARK_RULE_ID,
             cost_model_id=COST_MODEL_ID,
             corpus_version=CORPUS_VERSION,
-            window_start=EVALUATION_WINDOW_START,
-            window_end=EVALUATION_WINDOW_END,
+            window_start=window.start,
+            window_end=window.end,
             position_rule_set_version=POSITION_RULE_SET_VERSION,
             outcome_rule_set_version=OUTCOME_RULE_SET_VERSION,
             input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
@@ -1551,6 +1570,7 @@ def run_backtest(
     holdout_accessed_by: str | None = None,
     trial_register_version: str | None = None,
     limit: int | None = None,
+    evaluation_window: Window | None = None,
     manifest: Mapping[str, StrategyEntry] = STRATEGY_MANIFEST,
 ) -> BacktestRunReport:
     """Evaluate every runnable strategy and persist criterion 9's arm pairs.
@@ -1578,7 +1598,10 @@ def run_backtest(
             "that does not describe the search"
         )
     holdout_requested = _check_holdout_pairing(purpose=holdout_purpose, accessed_by=holdout_accessed_by)
-    namespaces: tuple[ResultNamespace, ...] = ("in_sample", "hold_out") if holdout_requested else ("in_sample",)
+    namespaces = _namespaces_for_window(
+        holdout_requested=holdout_requested,
+        evaluation_window=evaluation_window,
+    )
 
     runnable, excluded = runnable_strategies(manifest)
     if strategy_id is not None:
@@ -1588,7 +1611,7 @@ def run_backtest(
     if not runnable:
         raise RuntimeError("no manifest strategy is runnable — every entry is blocked, so there is nothing to store")
 
-    corpus = load_corpus(conn, limit=limit)
+    corpus = load_corpus(conn, limit=limit, evaluation_window=evaluation_window)
     identities = {
         entry_id: manifest[entry_id].identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
         for entry_id in runnable
@@ -1605,8 +1628,8 @@ def run_backtest(
             benchmark_rule=BENCHMARK_RULE_ID,
             cost_model_id=COST_MODEL_ID,
             corpus_version=CORPUS_VERSION,
-            window_start=EVALUATION_WINDOW_START,
-            window_end=EVALUATION_WINDOW_END,
+            window_start=corpus.window.start,
+            window_end=corpus.window.end,
             position_rule_set_version=POSITION_RULE_SET_VERSION,
             outcome_rule_set_version=OUTCOME_RULE_SET_VERSION,
             input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
@@ -1725,6 +1748,30 @@ def _check_holdout_pairing(*, purpose: str | None, accessed_by: str | None) -> b
     return True
 
 
+def _namespaces_for_window(
+    *,
+    holdout_requested: bool,
+    evaluation_window: Window | None,
+) -> tuple[ResultNamespace, ...]:
+    """Bind custom windows to audited hold-out evidence and nothing else.
+
+    The frozen 1962–2026 run keeps its original namespace behaviour. A custom
+    window is deliberately narrower: it may only inspect dates from the hold-out
+    side of the frozen boundary and cannot produce an ``in_sample`` row under a
+    different date range. The public runner only supplies registered windows.
+    """
+    if evaluation_window is None:
+        return ("in_sample", "hold_out") if holdout_requested else ("in_sample",)
+    if evaluation_window.start < HOLDOUT_BOUNDARY:
+        raise ValueError(
+            f"a custom recent-evidence window must start on or after the frozen hold-out boundary "
+            f"{HOLDOUT_BOUNDARY}; got {evaluation_window.start}"
+        )
+    if not holdout_requested:
+        raise ValueError("a custom recent-evidence window is hold-out evidence and requires an audited access")
+    return ("hold_out",)
+
+
 def _assert_ambiguity_unreachable(measurement: ArmMeasurement) -> None:
     """§6 — a runnable strategy cannot close ``ambiguous``, and this measures it.
 
@@ -1800,6 +1847,7 @@ def _write_rows(
                     ambiguity_arm=ambiguity,
                     quarantine_arm="masked",
                     deflated=_deflated_for(masked_arm.namespaces[namespace], deflations.get((namespace, "masked"))),
+                    evaluation_window=corpus.window,
                 )
                 admitted = build_result(
                     admitted_arm.namespaces[namespace],
@@ -1808,6 +1856,7 @@ def _write_rows(
                     ambiguity_arm=ambiguity,
                     quarantine_arm="admitted",
                     deflated=_deflated_for(admitted_arm.namespaces[namespace], deflations.get((namespace, "admitted"))),
+                    evaluation_window=corpus.window,
                 )
                 pending.append((strategy_id, namespace, ambiguity, masked, admitted))
 

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -238,11 +238,11 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
     # price_quarantine_refresh — #2261 full-corpus quarantine recompute. No
     # operator params: scope is the whole priced universe.
     "price_quarantine_refresh": (),
-    # strategy_backtest_run — #2394 §3.2. Four params, and the two hold-out ones
-    # are the only operator-facing degree of freedom the job HAS: §7 pins
-    # thirteen of the fourteen result-identity members to module constants, so
-    # exposing a sizing rule or a window would let an operator mint result
-    # identities no code path can reproduce.
+    # strategy_backtest_run — #2394 §3.2. Five params. ``evidence_window`` is
+    # an enum over code-pinned dates, not an operator-tunable date range. The
+    # hold-out pair controls audited access; the enum selects a reproducible
+    # identity already declared in code. A sizing rule or raw window remains
+    # forbidden because it would mint an identity no code path owns.
     #
     # ⚠⚠ ``holdout_purpose`` AND ``holdout_accessed_by`` ARE REQUIRED TOGETHER,
     # AND THAT IS NOT EXPRESSIBLE HERE. ParamMetadata declares per-key type and
@@ -297,6 +297,25 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
                 "version, so it cannot silently deflate against a register that has moved."
             ),
             field_type="string",
+        ),
+        ParamMetadata(
+            name="evidence_window",
+            label="Recent evidence window",
+            help_text=(
+                "Optional code-pinned recent-regime window. Selecting one evaluates only audited hold-out "
+                "evidence and therefore requires both hold-out fields. Raw dates are never accepted."
+            ),
+            field_type="enum",
+            enum_values=(
+                "primary-2022-plus",
+                "rolling-36m",
+                "rolling-24m",
+                "year-2022",
+                "year-2023",
+                "year-2024",
+                "year-2025",
+                "year-2026-ytd",
+            ),
         ),
     ),
     "risk_metrics_refresh": (),

--- a/app/services/strategy_recent_evidence.py
+++ b/app/services/strategy_recent_evidence.py
@@ -1,0 +1,85 @@
+"""Pinned recent-regime windows for strategy evidence (#2447).
+
+These windows are deliberately code, not request parameters.  A result window
+is part of ``ResultIdentity.version``; accepting arbitrary dates would let an
+operator search until a favourable interval appeared and then present that row
+as if it were the declared test.  The registry also gives the monitoring API a
+complete denominator: a missing row is visible as missing evidence.
+
+Only compact aggregate result rows are stored.  Daily bars remain in the
+existing research corpus and indicators/positions are recomputed while a run is
+active, so adding all eight windows costs 96 rows at the current three runnable
+strategies (8 windows x 3 strategies x 2 ambiguity x 2 quarantine), not another
+time-series store.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from types import MappingProxyType
+from typing import Final, Literal
+
+from app.services.position_builder import Window
+from app.services.strategy_result import EVALUATION_WINDOW_END, HOLDOUT_BOUNDARY
+
+RecentEvidenceWindowId = Literal[
+    "primary-2022-plus",
+    "rolling-36m",
+    "rolling-24m",
+    "year-2022",
+    "year-2023",
+    "year-2024",
+    "year-2025",
+    "year-2026-ytd",
+]
+
+
+@dataclass(frozen=True)
+class RecentEvidenceWindow:
+    window_id: RecentEvidenceWindowId
+    label: str
+    window: Window
+    required_for_allocation: bool = True
+
+    def __post_init__(self) -> None:
+        if self.window.start < HOLDOUT_BOUNDARY:
+            raise ValueError(
+                f"recent evidence {self.window_id} starts {self.window.start}, before hold-out {HOLDOUT_BOUNDARY}"
+            )
+        if self.window.end > EVALUATION_WINDOW_END:
+            raise ValueError(
+                f"recent evidence {self.window_id} ends {self.window.end}, after corpus {EVALUATION_WINDOW_END}"
+            )
+
+
+_WINDOWS = (
+    RecentEvidenceWindow("primary-2022-plus", "Primary: 2022 onward", Window(date(2022, 1, 1), EVALUATION_WINDOW_END)),
+    RecentEvidenceWindow("rolling-36m", "Rolling 36 months", Window(date(2023, 7, 9), EVALUATION_WINDOW_END)),
+    RecentEvidenceWindow("rolling-24m", "Rolling 24 months", Window(date(2024, 7, 9), EVALUATION_WINDOW_END)),
+    RecentEvidenceWindow("year-2022", "Calendar 2022", Window(date(2022, 1, 1), date(2022, 12, 31))),
+    RecentEvidenceWindow("year-2023", "Calendar 2023", Window(date(2023, 1, 1), date(2023, 12, 31))),
+    RecentEvidenceWindow("year-2024", "Calendar 2024", Window(date(2024, 1, 1), date(2024, 12, 31))),
+    RecentEvidenceWindow("year-2025", "Calendar 2025", Window(date(2025, 1, 1), date(2025, 12, 31))),
+    RecentEvidenceWindow("year-2026-ytd", "2026 year to corpus date", Window(date(2026, 1, 1), EVALUATION_WINDOW_END)),
+)
+
+RECENT_EVIDENCE_WINDOWS: Final = MappingProxyType({item.window_id: item for item in _WINDOWS})
+
+
+def recent_evidence_window(window_id: str) -> RecentEvidenceWindow:
+    """Resolve only a declared window; raw dates never cross this boundary."""
+    try:
+        return RECENT_EVIDENCE_WINDOWS[window_id]  # type: ignore[index]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown recent evidence window {window_id!r}; must be one of {list(RECENT_EVIDENCE_WINDOWS)}"
+        ) from exc
+
+
+__all__ = [
+    "RECENT_EVIDENCE_WINDOWS",
+    "RecentEvidenceWindow",
+    "RecentEvidenceWindowId",
+    "recent_evidence_window",
+]

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4954,10 +4954,9 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
     from app.services.backtest_run import run_backtest
     from app.services.strategy_recent_evidence import recent_evidence_window
 
-    evidence_window_id = _optional_str(params.get("evidence_window"))
-    evaluation_window = None if evidence_window_id is None else recent_evidence_window(evidence_window_id).window
-
     with _tracked_job(JOB_STRATEGY_BACKTEST_RUN) as tracker:
+        evidence_window_id = _optional_str(params.get("evidence_window"))
+        evaluation_window = None if evidence_window_id is None else recent_evidence_window(evidence_window_id).window
         with connect_job() as conn:
             report = run_backtest(
                 conn,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -4939,6 +4939,8 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
       the service body before any corpus work.
     * ``trial_register_version`` (string) — optional assertion. A run cannot
       silently deflate against a register that has moved.
+    * ``evidence_window`` (enum) — one pinned recent-evidence window. Raw dates
+      are never accepted; selecting one also requires the audited hold-out pair.
 
     ⚠ ``row_count`` is RESULT ROWS written. Zero is never a success here: the
     service raises if a runnable strategy produced no row, because an absent row
@@ -4950,6 +4952,10 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
     insert of a pair would commit before the second failed.
     """
     from app.services.backtest_run import run_backtest
+    from app.services.strategy_recent_evidence import recent_evidence_window
+
+    evidence_window_id = _optional_str(params.get("evidence_window"))
+    evaluation_window = None if evidence_window_id is None else recent_evidence_window(evidence_window_id).window
 
     with _tracked_job(JOB_STRATEGY_BACKTEST_RUN) as tracker:
         with connect_job() as conn:
@@ -4959,6 +4965,7 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
                 holdout_purpose=_optional_str(params.get("holdout_purpose")),
                 holdout_accessed_by=_optional_str(params.get("holdout_accessed_by")),
                 trial_register_version=_optional_str(params.get("trial_register_version")),
+                evaluation_window=evaluation_window,
             )
             tracker.row_count = report.rows_written
 

--- a/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
+++ b/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
@@ -331,15 +331,16 @@ must pin. All of them; here is where each comes from.
 | `sizing_rule` | `equity_curve.SIZING_RULE_ID` | no |
 | `cost_model_id` | `cost_model.COST_MODEL_ID` | no |
 | `corpus_version` | `strategy_result.CORPUS_VERSION` | no |
-| `window_start` / `window_end` | `EVALUATION_WINDOW_START` / `_END` | no |
+| `window_start` / `window_end` | frozen default, or `RECENT_EVIDENCE_WINDOWS` | pinned enum only |
 | `position_rule_set_version` | `position_builder.RULE_SET_VERSION` | no |
 | `outcome_rule_set_version` | `outcome_resolver`'s rule-set version | no |
 | `input_rule_set_version` | `price_quarantine.RULE_SET_VERSION` — see below | no |
 
 ⚠ **Thirteen of the fourteen are read from a module that froze them, and that is
-the design working.** The only operator-facing degree of freedom is whether the
-hold-out arm runs. A job that let an operator pass a sizing rule or a window
-would be minting result identities that no code path can reproduce.
+the design working.** #2447 adds only code-pinned recent windows: the operator
+selects an id from `RECENT_EVIDENCE_WINDOWS`, never raw dates, and the exact
+dates remain in the result hash. A job that accepted a sizing rule or arbitrary
+window would still mint identities that no code path can reproduce.
 
 ⚠⚠ **`input_rule_set_version` is the QUARANTINE rule set, and it is NOT the same
 thing as `StrategyIdentity.input_rule_set_versions`.** Two similarly-named

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -1,7 +1,7 @@
 # Strategy automation control plane — ownership, allocation and monitoring
 
 Date: 2026-08-09
-Status: Proposed contract; preflight adapter slice implemented, no strategy orders enabled
+Status: Slices 1–3 implemented through read-only monitoring; no strategy orders enabled
 Parent: #2437
 Companion: `2026-08-09-evidence-backed-signal-engine.md`
 
@@ -51,9 +51,28 @@ Every stored result covered 1962-01-02 through 2026-07-08, and S-4 had no result
 Those result rows are legacy/stress evidence only: none satisfies the primary
 2022+ plus rolling 24/36-month relevance contract and none is allocation-ready.
 
+The #2447 read paths were measured on that population after implementation and
+after the primary recent-window run added 12 compact result rows
+(`PYTHONPATH=. uv run python scripts/verify_2447_strategy_monitoring.py`).
+Latest and cursor fired-signal pages used the `strategy_signals` primary key
+backwards and returned 50 fully joined rows in **under 1 ms**. Current-version
+scan aggregates deliberately used a 34,698-row sequential scan and completed in
+**15.2 ms**. The 48-row result ledger completed in **under 0.2 ms**. Those figures do
+not justify another index today; #2448 re-measures after retention/partition
+design rather than paying write amplification speculatively.
+
+The audited primary 2022-01-01 through 2026-07-08 run is complete for all four
+ambiguity/quarantine arms of S-1 through S-3. Its admitted/best-case results
+were S-1: -84.75% total return, -2.23 Sharpe and -84.98% maximum drawdown;
+S-2: +41.33%, 0.44 Sharpe and -30.55% drawdown; S-3: -48.45%, -0.46 Sharpe and
+-52.41% drawdown. None is allocation-ready: every arm records the measured
+survivor-only universe, unmodelled carry and absent synthetic control as
+refusals. S-4 remains explicitly excluded because its level-based entry has no
+outcome at the pinned version pair. These results validate the storage and
+monitoring path; they do not validate a winning strategy.
+
 Not present and therefore blocking paper/live strategy execution:
 
-- no strategy catalogue/results/signals API or monitoring page;
 - no capital allocation/deployment record for a strategy version;
 - no durable link from a fired signal through a local order to the exact broker
   `positionId`;
@@ -310,11 +329,16 @@ are actually created.
    `value` semantics and mostly stale rows refuse cost consumption. Exact
    position-id cardinality and v1-versus-v2 execution compatibility move to the
    ownership/reconciliation slice, where an actual demo order exists.
-3. **Recent-window result arms + read-only strategy observability:** compute the
+3. **Recent-window result arms + read-only strategy observability — implemented:** compute the
    fixed 2022+, rolling 24/36-month and per-year arms without overwriting legacy
    evidence; then expose every manifest strategy, fired funded/unfunded signal,
    outcome, exclusion, scan health, pinned metrics and explicit refusal state.
-   This can ship before trading; legacy-only rows are never allocatable.
+   The runner accepts only a code-pinned window id and hashes its exact dates;
+   the API/page are read-only, exact-current-version and keyset-paginated.
+   Legacy-only rows are never allocatable. The primary 2022+ window now renders
+   `complete` for S-1 through S-3, while the remaining registered windows render
+   their measured `missing`/`partial` state and S-4 retains its explicit builder
+   exclusion.
 4. **Storage benchmark and retention:** actual bytes/query plans for signal
    partitions, compact aggregates, preflight state changes and bounded intraday
    bars. Migration follows evidence, not vice versa.

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -57,7 +57,8 @@ after the primary recent-window run added 12 compact result rows
 Latest and cursor fired-signal pages used the `strategy_signals` primary key
 backwards and returned 50 fully joined rows in **under 1 ms**. Current-version
 scan aggregates deliberately used a 34,698-row sequential scan and completed in
-**15.2 ms**. The 48-row result ledger completed in **under 0.2 ms**. Those figures do
+**15.6 ms**. The exact-provenance query returned the 12 recent arms in **0.1 ms**
+and the separate all-result count completed in **0.03 ms** across 48 stored rows. Those figures do
 not justify another index today; #2448 re-measures after retention/partition
 design rather than paying write amplification speculatively.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import { OperatorsPage } from "@/pages/OperatorsPage";
 import { CopyTradingPage } from "@/pages/CopyTradingPage";
 import { PortfolioPage } from "@/pages/PortfolioPage";
 import { CalendarPage } from "@/pages/CalendarPage";
+import { StrategiesPage } from "@/pages/StrategiesPage";
 
 export function App() {
   return (
@@ -69,6 +70,7 @@ export function App() {
           <Route index element={<DashboardPage />} />
           <Route path="portfolio" element={<PortfolioPage />} />
           <Route path="calendar" element={<CalendarPage />} />
+          <Route path="strategies" element={<StrategiesPage />} />
           {/* Legacy per-instrument routes redirect to the canonical
               `/instrument/:symbol` research page. Introduced in Slice 3
               of the per-stock research spec; Slice 5 deleted

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,0 +1,13 @@
+import { apiFetch } from "@/api/client";
+import type { FiredSignalsResponse, StrategyOverviewResponse } from "@/api/types";
+
+export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
+  return apiFetch("/strategies/overview");
+}
+
+export function fetchFiredSignals(cursor: number | null): Promise<FiredSignalsResponse> {
+  const params = new URLSearchParams();
+  if (cursor !== null) params.set("cursor", String(cursor));
+  const query = params.size === 0 ? "" : `?${params.toString()}`;
+  return apiFetch(`/strategies/signals${query}`);
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -11,6 +11,7 @@
  *   - /recommendations     -> app/api/recommendations.py
  *   - /audit              -> app/api/audit.py
  *   - /rankings            -> app/api/scores.py
+ *   - /strategies/*        -> app/api/strategies.py
  *
  * Rule: when a backend response_model changes, update this file in the same
  * PR. Drift here breaks every page silently. There is no codegen yet (#59
@@ -2392,4 +2393,105 @@ export interface BootstrapTimelineRunResponse {
 export interface BootstrapTimelineResponse {
   run: BootstrapTimelineRunResponse | null;
   stages: BootstrapTimelineStageResponse[];
+}
+
+// ---------------------------------------------------------------------------
+// /strategies (app/api/strategies.py, #2447)
+// ---------------------------------------------------------------------------
+
+export interface StrategyResultArm {
+  result_version: string;
+  ambiguity_arm: string;
+  quarantine_arm: string;
+  universe_basis: string;
+  corpus_version: string;
+  cost_model_id: string;
+  sizing_rule: string;
+  benchmark_rule: string;
+  position_rule_set_version: string;
+  outcome_rule_set_version: string;
+  input_rule_set_version: string;
+  evaluated_instrument_count: number;
+  trade_count: number;
+  expectancy_per_trade_pct: string;
+  expectancy_ci_low_pct: string | null;
+  expectancy_ci_high_pct: string | null;
+  total_return_pct: string;
+  cagr_pct: string;
+  sharpe: string;
+  sortino: string | null;
+  max_drawdown_pct: string;
+  profit_factor: string | null;
+  exposure_time_pct: string;
+  turnover_annualised: string;
+  return_vs_buy_and_hold_pct: string;
+  deflated_sharpe: string | null;
+  promotion_refusals: string[];
+}
+
+export interface StrategyEvidenceWindow {
+  window_id: string;
+  label: string;
+  window_start: string;
+  window_end: string;
+  status: "missing" | "partial" | "complete";
+  arms: StrategyResultArm[];
+}
+
+export interface StrategyOverview {
+  strategy_id: string;
+  strategy_version: string;
+  title: string;
+  runnable: boolean;
+  exclusion_reason: string | null;
+  scan: {
+    frontier_date: string | null;
+    updated_at: string | null;
+    status: "never_run" | "current" | "stale";
+    fired_entries: number;
+    fired_exits: number;
+    not_fired: number;
+    not_evaluable: number;
+    exclusions_by_reason: Record<string, number>;
+  };
+  evidence_windows: StrategyEvidenceWindow[];
+  legacy_result_count: number;
+  all_recent_evidence_complete: boolean;
+  allocation_ready: false;
+  allocation_refusals: string[];
+}
+
+export interface StrategyOverviewResponse {
+  as_of: string;
+  observation_stage: "forward_observation";
+  execution_enabled: false;
+  storage_policy: "aggregate_results_only";
+  strategies: StrategyOverview[];
+}
+
+export interface FiredSignal {
+  signal_id: number;
+  strategy_id: string;
+  strategy_version: string;
+  instrument_id: number;
+  symbol: string;
+  company_name: string | null;
+  signal_bar_date: string;
+  signal_kind: string;
+  fill_bar_date: string;
+  fill_price: string;
+  universe: string;
+  outcome: string | null;
+  exit_bar_date: string | null;
+  exit_price: string | null;
+  gross_return_pct: string | null;
+  outcome_reason: string | null;
+  observation_stage: "forward_observation";
+  funding_status: "unfunded";
+  funding_reason: "execution_not_enabled";
+}
+
+export interface FiredSignalsResponse {
+  items: FiredSignal[];
+  next_cursor: number | null;
 }

--- a/frontend/src/layout/Sidebar.tsx
+++ b/frontend/src/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ const NAV_ITEMS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "Dashboard", end: true },
   { to: "/portfolio", label: "Portfolio" },
   { to: "/calendar", label: "Calendar" },
+  { to: "/strategies", label: "Strategies" },
   // #1917 — one Research item; Instruments/Rankings/Theses/Recommendations are
   // now view presets under /research.
   { to: "/research", label: "Research" },

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -1,0 +1,124 @@
+import { StrictMode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as strategiesApi from "@/api/strategies";
+import type { FiredSignalsResponse, StrategyOverviewResponse } from "@/api/types";
+import { StrategiesPage } from "@/pages/StrategiesPage";
+
+const OVERVIEW: StrategyOverviewResponse = {
+  as_of: "2026-08-09T12:00:00Z",
+  observation_stage: "forward_observation",
+  execution_enabled: false,
+  storage_policy: "aggregate_results_only",
+  strategies: [
+    {
+      strategy_id: "s4-volatility-compression-breakout",
+      strategy_version: "strategy-registry-v1+abc",
+      title: "Volatility compression breakout",
+      runnable: false,
+      exclusion_reason: "level-based entry has no outcome",
+      scan: {
+        frontier_date: "2026-08-07",
+        updated_at: "2026-08-08T06:45:00Z",
+        status: "current",
+        fired_entries: 108,
+        fired_exits: 0,
+        not_fired: 5382,
+        not_evaluable: 293,
+        exclusions_by_reason: { quarantined_bar: 293 },
+      },
+      evidence_windows: [
+        {
+          window_id: "primary-2022-plus",
+          label: "Primary: 2022 onward",
+          window_start: "2022-01-01",
+          window_end: "2026-07-08",
+          status: "missing",
+          arms: [],
+        },
+      ],
+      legacy_result_count: 0,
+      all_recent_evidence_complete: false,
+      allocation_ready: false,
+      allocation_refusals: ["execution_not_enabled", "recent_evidence_incomplete"],
+    },
+  ],
+};
+
+const SIGNALS: FiredSignalsResponse = {
+  items: [
+    {
+      signal_id: 42,
+      strategy_id: "s4-volatility-compression-breakout",
+      strategy_version: "strategy-registry-v1+abc",
+      instrument_id: 1,
+      symbol: "AAA",
+      company_name: "Alpha",
+      signal_bar_date: "2026-08-06",
+      signal_kind: "entry",
+      fill_bar_date: "2026-08-07",
+      fill_price: "12.34",
+      universe: "survivor_only",
+      outcome: null,
+      exit_bar_date: null,
+      exit_price: null,
+      gross_return_pct: null,
+      outcome_reason: null,
+      observation_stage: "forward_observation",
+      funding_status: "unfunded",
+      funding_reason: "execution_not_enabled",
+    },
+  ],
+  next_cursor: 42,
+};
+
+describe("StrategiesPage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps an excluded strategy and its unfunded signal visible under StrictMode", async () => {
+    vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(OVERVIEW);
+    vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue(SIGNALS);
+    render(
+      <StrictMode>
+        <MemoryRouter>
+          <StrategiesPage />
+        </MemoryRouter>
+      </StrictMode>,
+    );
+    expect(await screen.findByText("Volatility compression breakout")).toBeInTheDocument();
+    expect(screen.getByText(/Backtest exclusion:/)).toBeInTheDocument();
+    expect(screen.getByText("AAA")).toBeInTheDocument();
+    expect(screen.getByText("unfunded · execution disabled")).toBeInTheDocument();
+  });
+
+  it("uses the server cursor when the operator requests older signals", async () => {
+    vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(OVERVIEW);
+    const signals = vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue(SIGNALS);
+    render(
+      <MemoryRouter>
+        <StrategiesPage />
+      </MemoryRouter>,
+    );
+    await screen.findByText("AAA");
+    await userEvent.click(screen.getByRole("button", { name: "Older" }));
+    await waitFor(() => expect(signals).toHaveBeenLastCalledWith(42));
+  });
+
+  it("renders actionable empty states for successful empty responses", async () => {
+    vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue({ ...OVERVIEW, strategies: [] });
+    vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue({ items: [], next_cursor: null });
+    render(
+      <MemoryRouter>
+        <StrategiesPage />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText("No registered strategies")).toBeInTheDocument();
+    expect(screen.getByText("No fired signals")).toBeInTheDocument();
+    expect(screen.getByText(/current strategy versions have not fired/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react";
+
+import {
+  fetchFiredSignals,
+  fetchStrategyOverview,
+} from "@/api/strategies";
+import type { StrategyEvidenceWindow, StrategyOverview } from "@/api/types";
+import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { EmptyState } from "@/components/states/EmptyState";
+import { formatDate, formatNumber } from "@/lib/format";
+import { useAsync } from "@/lib/useAsync";
+
+function number(value: string | null, suffix = ""): string {
+  if (value === null) return "—";
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? `${formatNumber(parsed, 2)}${suffix}` : "—";
+}
+
+function EvidenceTable({ windows }: { readonly windows: StrategyEvidenceWindow[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-left text-xs">
+        <thead className="text-slate-500 dark:text-slate-400">
+          <tr>
+            <th className="pb-2 pr-4 font-medium">Window</th>
+            <th className="pb-2 pr-4 font-medium">Status</th>
+            <th className="pb-2 pr-4 font-medium">Trades</th>
+            <th className="pb-2 pr-4 font-medium">Expectancy</th>
+            <th className="pb-2 pr-4 font-medium">Sharpe</th>
+            <th className="pb-2 pr-4 font-medium">Max drawdown</th>
+            <th className="pb-2 font-medium">Refusals</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+          {windows.map((window) => {
+            const representative = window.arms.find(
+              (arm) => arm.ambiguity_arm === "worst_case" && arm.quarantine_arm === "masked",
+            );
+            return (
+              <tr key={window.window_id}>
+                <td className="py-2 pr-4">
+                  <div className="font-medium text-slate-800 dark:text-slate-200">{window.label}</div>
+                  <div className="text-slate-500">
+                    {formatDate(window.window_start)}–{formatDate(window.window_end)}
+                  </div>
+                </td>
+                <td className="py-2 pr-4">{window.status}</td>
+                <td className="py-2 pr-4 tabular-nums">{representative?.trade_count ?? "—"}</td>
+                <td className="py-2 pr-4 tabular-nums">
+                  {number(representative?.expectancy_per_trade_pct ?? null, "%")}
+                </td>
+                <td className="py-2 pr-4 tabular-nums">{number(representative?.sharpe ?? null)}</td>
+                <td className="py-2 pr-4 tabular-nums">
+                  {number(representative?.max_drawdown_pct ?? null, "%")}
+                </td>
+                <td className="max-w-xs py-2 text-slate-500">
+                  {representative?.promotion_refusals.join(", ") ?? "Recent evidence not computed"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StrategyPanel({ strategy }: { readonly strategy: StrategyOverview }) {
+  return (
+    <article className="border-t border-slate-200 pt-3 dark:border-slate-800">
+      <header className="mb-3 flex items-baseline justify-between gap-2">
+        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{strategy.title}</h2>
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          {strategy.runnable ? "runnable" : "excluded"} · scan {strategy.scan.status} · frontier{" "}
+          {formatDate(strategy.scan.frontier_date)}
+        </span>
+      </header>
+      <div className="mb-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+        <div>
+          <div className="text-xs text-slate-500">Fired entries</div>
+          <div className="tabular-nums">{formatNumber(strategy.scan.fired_entries, 0)}</div>
+        </div>
+        <div>
+          <div className="text-xs text-slate-500">Fired exits</div>
+          <div className="tabular-nums">{formatNumber(strategy.scan.fired_exits, 0)}</div>
+        </div>
+        <div>
+          <div className="text-xs text-slate-500">Not evaluable</div>
+          <div className="tabular-nums">{formatNumber(strategy.scan.not_evaluable, 0)}</div>
+        </div>
+        <div>
+          <div className="text-xs text-slate-500">Legacy result rows</div>
+          <div className="tabular-nums">{formatNumber(strategy.legacy_result_count, 0)}</div>
+        </div>
+      </div>
+      {strategy.exclusion_reason ? (
+        <p className="mb-3 text-xs text-amber-700 dark:text-amber-400">
+          Backtest exclusion: {strategy.exclusion_reason}
+        </p>
+      ) : null}
+      <EvidenceTable windows={strategy.evidence_windows} />
+      <details className="mt-3 text-xs text-slate-500">
+        <summary className="cursor-pointer">Allocation refusals and provenance</summary>
+        <p className="mt-2">{strategy.allocation_refusals.join(", ")}</p>
+        <p className="mt-1 break-all">Strategy version: {strategy.strategy_version}</p>
+      </details>
+    </article>
+  );
+}
+
+export function StrategiesPage() {
+  const [cursor, setCursor] = useState<number | null>(null);
+  const [cursorHistory, setCursorHistory] = useState<Array<number | null>>([]);
+  const overview = useAsync(fetchStrategyOverview, []);
+  const signals = useAsync(() => fetchFiredSignals(cursor), [cursor]);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Strategies</h1>
+        <p className="mt-1 max-w-4xl text-sm text-slate-600 dark:text-slate-400">
+          Read-only forward observation. Every current-version fired signal is shown whether funded or
+          unfunded; historical backtests remain separate. Allocation and broker execution are disabled.
+        </p>
+      </header>
+
+      <Section title="Strategy evidence" action="Exact current versions">
+        {overview.loading ? <SectionSkeleton rows={8} /> : null}
+        {overview.error ? <SectionError onRetry={overview.refetch} /> : null}
+        {overview.data?.strategies.length === 0 ? (
+          <EmptyState
+            title="No registered strategies"
+            description="Add a strategy to the manifest before evidence can be monitored."
+          />
+        ) : null}
+        {overview.data && overview.data.strategies.length > 0 ? (
+          <div className="space-y-6">
+            {overview.data.strategies.map((strategy) => (
+              <StrategyPanel key={strategy.strategy_id} strategy={strategy} />
+            ))}
+          </div>
+        ) : null}
+      </Section>
+
+      <Section title="Fired signals" action="Forward observation · all unfunded">
+        {signals.loading ? <SectionSkeleton rows={6} /> : null}
+        {signals.error ? <SectionError onRetry={signals.refetch} /> : null}
+        {signals.data?.items.length === 0 ? (
+          <EmptyState title="No fired signals" description="The current strategy versions have not fired yet." />
+        ) : null}
+        {signals.data && signals.data.items.length > 0 ? (
+          <>
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-left text-xs">
+                <thead className="text-slate-500 dark:text-slate-400">
+                  <tr>
+                    <th className="pb-2 pr-4 font-medium">Signal</th>
+                    <th className="pb-2 pr-4 font-medium">Instrument</th>
+                    <th className="pb-2 pr-4 font-medium">Fill</th>
+                    <th className="pb-2 pr-4 font-medium">Outcome</th>
+                    <th className="pb-2 font-medium">Funding</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {signals.data.items.map((signal) => (
+                    <tr key={signal.signal_id}>
+                      <td className="py-2 pr-4">
+                        <div>{signal.strategy_id}</div>
+                        <div className="text-slate-500">
+                          {signal.signal_kind} · {formatDate(signal.signal_bar_date)}
+                        </div>
+                      </td>
+                      <td className="py-2 pr-4">
+                        <div className="font-medium">{signal.symbol}</div>
+                        <div className="text-slate-500">{signal.company_name ?? `#${signal.instrument_id}`}</div>
+                      </td>
+                      <td className="py-2 pr-4 tabular-nums">
+                        {formatDate(signal.fill_bar_date)} · {number(signal.fill_price)}
+                      </td>
+                      <td className="py-2 pr-4">
+                        {signal.outcome ?? "pending"}
+                        {signal.gross_return_pct ? ` · ${number(signal.gross_return_pct, "%")}` : ""}
+                      </td>
+                      <td className="py-2 text-slate-500">unfunded · execution disabled</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                disabled={cursorHistory.length === 0}
+                onClick={() => {
+                  const previous = cursorHistory.at(-1) ?? null;
+                  setCursorHistory((history) => history.slice(0, -1));
+                  setCursor(previous);
+                }}
+                className="border border-slate-300 px-3 py-1 text-xs disabled:opacity-40 dark:border-slate-700"
+              >
+                Newer
+              </button>
+              <button
+                type="button"
+                disabled={signals.data.next_cursor === null}
+                onClick={() => {
+                  setCursorHistory((history) => [...history, cursor]);
+                  setCursor(signals.data?.next_cursor ?? null);
+                }}
+                className="border border-slate-300 px-3 py-1 text-xs disabled:opacity-40 dark:border-slate-700"
+              >
+                Older
+              </button>
+            </div>
+          </>
+        ) : null}
+      </Section>
+    </div>
+  );
+}

--- a/scripts/verify_2447_strategy_monitoring.py
+++ b/scripts/verify_2447_strategy_monitoring.py
@@ -16,6 +16,7 @@ import psycopg.sql
 
 from app.api.strategies import (
     _FIRED_SIGNALS_SQL,
+    _RESULT_COUNTS_SQL,
     _RESULTS_SQL,
     _SCAN_SQL,
     _current_versions,
@@ -23,8 +24,12 @@ from app.api.strategies import (
     get_strategy_overview,
 )
 from app.config import settings
+from app.services.cost_model import COST_MODEL_ID
+from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_result import CORPUS_VERSION
 from scripts._dev_guard import assert_dev_environment
 
 _PLAN_QUERIES = {
@@ -32,6 +37,7 @@ _PLAN_QUERIES = {
     "cursor_fired_page": _FIRED_SIGNALS_SQL,
     "scan_aggregate": _SCAN_SQL,
     "result_ledger": _RESULTS_SQL,
+    "result_counts": _RESULT_COUNTS_SQL,
 }
 
 
@@ -68,6 +74,11 @@ def main() -> None:
             "limit": 50,
             "outcome_version": OUTCOME_RULE_SET_VERSION,
             "input_version": QUARANTINE_RULE_SET_VERSION,
+            "corpus_version": CORPUS_VERSION,
+            "cost_model_id": COST_MODEL_ID,
+            "sizing_rule": SIZING_RULE_ID,
+            "benchmark_rule": BENCHMARK_RULE_ID,
+            "position_version": POSITION_RULE_SET_VERSION,
         }
         print(
             {

--- a/scripts/verify_2447_strategy_monitoring.py
+++ b/scripts/verify_2447_strategy_monitoring.py
@@ -1,0 +1,96 @@
+"""Reproduce #2447's read-only monitoring census and query plans.
+
+Run with::
+
+    PYTHONPATH=. uv run python scripts/verify_2447_strategy_monitoring.py
+
+No writes.  The dev guard prevents an accidental plan run against a remote DB.
+"""
+
+from __future__ import annotations
+
+from typing import Any, LiteralString, cast
+
+import psycopg
+import psycopg.sql
+
+from app.api.strategies import (
+    _FIRED_SIGNALS_SQL,
+    _RESULTS_SQL,
+    _SCAN_SQL,
+    _current_versions,
+    get_fired_signals,
+    get_strategy_overview,
+)
+from app.config import settings
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from scripts._dev_guard import assert_dev_environment
+
+_PLAN_QUERIES = {
+    "latest_fired_page": _FIRED_SIGNALS_SQL,
+    "cursor_fired_page": _FIRED_SIGNALS_SQL,
+    "scan_aggregate": _SCAN_SQL,
+    "result_ledger": _RESULTS_SQL,
+}
+
+
+def _plan(conn: psycopg.Connection[Any], query: str, params: dict[str, object]) -> dict[str, object]:
+    # Every caller supplies a module-owned SQL constant from ``_PLAN_QUERIES``;
+    # no request or operator value is ever promoted into the statement text.
+    statement = psycopg.sql.SQL("EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) {}").format(
+        psycopg.sql.SQL(cast(LiteralString, query))
+    )
+    row = conn.execute(statement, params).fetchone()
+    if row is None:
+        raise RuntimeError("EXPLAIN returned no row")
+    payload = row[0][0]
+    plan = payload["Plan"]
+    return {
+        "execution_ms": payload["Execution Time"],
+        "planning_ms": payload["Planning Time"],
+        "root_node": plan["Node Type"],
+        "rows": plan["Actual Rows"],
+        "shared_hit_blocks": plan.get("Shared Hit Blocks", 0),
+        "shared_read_blocks": plan.get("Shared Read Blocks", 0),
+    }
+
+
+def main() -> None:
+    assert_dev_environment()
+    versions = list(_current_versions().values())
+    with psycopg.connect(settings.database_url) as conn:
+        overview = get_strategy_overview(conn)
+        signals = get_fired_signals(cursor=None, limit=50, conn=conn)
+        params: dict[str, object] = {
+            "versions": versions,
+            "cursor": None,
+            "limit": 50,
+            "outcome_version": OUTCOME_RULE_SET_VERSION,
+            "input_version": QUARANTINE_RULE_SET_VERSION,
+        }
+        print(
+            {
+                "strategies": [
+                    {
+                        "strategy_id": item.strategy_id,
+                        "runnable": item.runnable,
+                        "legacy_rows": item.legacy_result_count,
+                        "recent_complete": item.all_recent_evidence_complete,
+                        "fired_entries": item.scan.fired_entries,
+                    }
+                    for item in overview.strategies
+                ],
+                "first_page_rows": len(signals.items),
+                "next_cursor": signals.next_cursor,
+            }
+        )
+        for name, query in _PLAN_QUERIES.items():
+            plan_params = dict(params)
+            if name == "cursor_fired_page":
+                plan_params["cursor"] = signals.next_cursor or 1
+            print(name, _plan(conn, query, plan_params))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -8,7 +8,16 @@ from decimal import Decimal
 import psycopg
 
 from app.api.strategies import ResultArm, _current_versions, _promotion_refusals, get_strategy_overview
+from app.services.cost_model import COST_MODEL_ID
+from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
+from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.result_ledger import store_holdout_result, store_in_sample_result
 from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+from app.services.strategy_result import CORPUS_VERSION
+from tests.test_result_ledger import build_metrics, build_result
 
 
 def test_current_versions_cover_the_manifest_including_excluded_s4() -> None:
@@ -166,3 +175,67 @@ def test_completed_zero_signal_scan_uses_its_watermark(
     assert strategy.scan.fired_exits == 0
     assert strategy.scan.not_fired == 0
     assert strategy.scan.not_evaluable == 0
+
+
+def test_overview_maps_only_exact_current_holdout_provenance(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    window = RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window
+    identity = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "window_start": window.start,
+        "window_end": window.end,
+        "corpus_version": CORPUS_VERSION,
+        "cost_model_id": COST_MODEL_ID,
+        "sizing_rule": SIZING_RULE_ID,
+        "benchmark_rule": BENCHMARK_RULE_ID,
+        "position_rule_set_version": POSITION_RULE_SET_VERSION,
+        "outcome_rule_set_version": OUTCOME_RULE_SET_VERSION,
+        "input_rule_set_version": QUARANTINE_RULE_SET_VERSION,
+    }
+    metrics = build_metrics(
+        profit_factor=None,
+        sortino=None,
+        losing_trade_count=0,
+        losing_period_count=0,
+    )
+    exact = build_result(**identity, ambiguity_arm="best_case", quarantine_arm="admitted", metrics=metrics)
+    store_holdout_result(
+        ebull_test_conn,
+        exact,
+        accessed_by="tests/test_api_strategies.py",
+        purpose="verify API result mapping",
+    )
+    store_holdout_result(
+        ebull_test_conn,
+        build_result(
+            **{**identity, "cost_model_id": "stale-cost-v0"},
+            ambiguity_arm="worst_case",
+            quarantine_arm="admitted",
+        ),
+        accessed_by="tests/test_api_strategies.py",
+        purpose="prove stale provenance is excluded",
+    )
+    store_in_sample_result(
+        ebull_test_conn,
+        build_result(
+            **identity,
+            namespace="in_sample",
+            ambiguity_arm="worst_case",
+            quarantine_arm="masked",
+        ),
+    )
+
+    overview = get_strategy_overview(ebull_test_conn)
+    strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+    primary = next(item for item in strategy.evidence_windows if item.window_id == "primary-2022-plus")
+
+    assert primary.status == "partial"
+    assert len(primary.arms) == 1
+    assert primary.arms[0].result_version == exact.identity.version
+    assert primary.arms[0].sortino is None
+    assert primary.arms[0].profit_factor is None
+    assert strategy.legacy_result_count == 2

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -1,0 +1,168 @@
+"""Read-only strategy monitoring contracts (#2447)."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+
+from app.api.strategies import ResultArm, _current_versions, _promotion_refusals, get_strategy_overview
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+
+
+def test_current_versions_cover_the_manifest_including_excluded_s4() -> None:
+    versions = _current_versions()
+    assert set(versions) == set(STRATEGY_MANIFEST)
+    assert "s4-volatility-compression-breakout" in versions
+    assert all(version.startswith("strategy-registry-v1+") for version in versions.values())
+
+
+def test_result_refusals_fail_closed_without_expanding_the_database() -> None:
+    row: dict[str, object] = {
+        "universe_basis": "survivor_only",
+        "carry_unmodelled": True,
+        "evaluated_instrument_count": 5266,
+        "deflated_sharpe": None,
+        "trial_count": None,
+        "effective_sample_size": None,
+        "synthetic_control_model_id": None,
+        "synthetic_control_passed": None,
+    }
+    assert _promotion_refusals(
+        row,
+        ambiguity_complete=False,
+        quarantine_complete=False,
+        accesses_complete=False,
+    ) == [
+        "universe_basis_not_survivorship_free",
+        "carry_unmodelled",
+        "holdout_accesses_unrecorded",
+        "deflated_sharpe_not_computed",
+        "trial_count_undeclared",
+        "effective_sample_size_not_computed",
+        "ambiguity_arms_not_compared",
+        "quarantine_arms_not_compared",
+        "synthetic_control_not_run",
+    ]
+
+
+def test_a_complete_measured_result_still_exposes_standing_refusals() -> None:
+    row: dict[str, object] = {
+        "universe_basis": "survivor_only",
+        "carry_unmodelled": True,
+        "evaluated_instrument_count": 5266,
+        "deflated_sharpe": 0.8,
+        "trial_count": 12,
+        "effective_sample_size": 200,
+        "synthetic_control_model_id": "random-entry-v1",
+        "synthetic_control_passed": True,
+        "synthetic_control_mean_return_ci_low_pct": -1,
+        "synthetic_control_mean_return_ci_high_pct": 1,
+        "sharpe": 0.8,
+        "synthetic_control_sharpe_threshold": 0.5,
+    }
+    assert _promotion_refusals(
+        row,
+        ambiguity_complete=True,
+        quarantine_complete=True,
+        accesses_complete=True,
+    ) == [
+        "universe_basis_not_survivorship_free",
+        "carry_unmodelled",
+    ]
+
+
+def test_partial_arm_refusals_do_not_claim_the_completed_comparison_is_missing() -> None:
+    row: dict[str, object] = {
+        "universe_basis": "survivorship_free",
+        "carry_unmodelled": False,
+        "evaluated_instrument_count": 1,
+        "deflated_sharpe": 0.8,
+        "trial_count": 12,
+        "effective_sample_size": 200,
+        "synthetic_control_model_id": "random-entry-v1",
+        "synthetic_control_mean_return_ci_low_pct": -1,
+        "synthetic_control_mean_return_ci_high_pct": 1,
+        "sharpe": 0.8,
+        "synthetic_control_sharpe_threshold": 0.5,
+    }
+    assert _promotion_refusals(
+        row,
+        ambiguity_complete=True,
+        quarantine_complete=False,
+        accesses_complete=True,
+    ) == ["quarantine_arms_not_compared"]
+
+
+def test_result_arm_accepts_valid_undefined_downside_metrics() -> None:
+    arm = ResultArm(
+        result_version="v1",
+        ambiguity_arm="best_case",
+        quarantine_arm="admitted",
+        universe_basis="survivor_only",
+        corpus_version="corpus-v1",
+        cost_model_id="cost-v1",
+        sizing_rule="equal-weight",
+        benchmark_rule="buy-and-hold",
+        position_rule_set_version="position-v1",
+        outcome_rule_set_version="outcome-v1",
+        input_rule_set_version="input-v1",
+        evaluated_instrument_count=1,
+        trade_count=1,
+        expectancy_per_trade_pct=Decimal("1"),
+        expectancy_ci_low_pct=None,
+        expectancy_ci_high_pct=None,
+        total_return_pct=Decimal("1"),
+        cagr_pct=Decimal("1"),
+        sharpe=Decimal("1"),
+        sortino=None,
+        max_drawdown_pct=Decimal("0"),
+        profit_factor=None,
+        exposure_time_pct=Decimal("1"),
+        turnover_annualised=Decimal("1"),
+        return_vs_buy_and_hold_pct=Decimal("1"),
+        deflated_sharpe=None,
+        promotion_refusals=[],
+    )
+
+    assert arm.sortino is None
+    assert arm.profit_factor is None
+
+
+def test_empty_ledgers_still_return_all_manifest_strategies(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    overview = get_strategy_overview(ebull_test_conn)
+    assert [item.strategy_id for item in overview.strategies] == sorted(STRATEGY_MANIFEST)
+    assert all(item.scan.status == "never_run" for item in overview.strategies)
+    assert all(not item.all_recent_evidence_complete for item in overview.strategies)
+    assert all(len(item.evidence_windows) == 8 for item in overview.strategies)
+    s4 = next(item for item in overview.strategies if item.strategy_id == "s4-volatility-compression-breakout")
+    assert not s4.runnable
+    assert s4.exclusion_reason is not None
+
+
+def test_completed_zero_signal_scan_uses_its_watermark(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s2-cross-sectional-momentum"
+    version = _current_versions()[strategy_id]
+    frontier = date(2026, 7, 8)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_scan_watermark (strategy_id, strategy_version, frontier_date)
+        VALUES (%s, %s, %s)
+        """,
+        (strategy_id, version, frontier),
+    )
+
+    overview = get_strategy_overview(ebull_test_conn)
+    strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+
+    assert strategy.scan.frontier_date == frontier
+    assert strategy.scan.status == "stale"
+    assert strategy.scan.fired_entries == 0
+    assert strategy.scan.fired_exits == 0
+    assert strategy.scan.not_fired == 0
+    assert strategy.scan.not_evaluable == 0

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -38,6 +38,7 @@ from app.services.backtest_run import (
     _fills,
     _measure_namespace,
     _NamespaceBook,
+    _namespaces_for_window,
     _shifted,
     assert_no_existing_results,
     build_in_sample_split,
@@ -49,6 +50,7 @@ from app.services.cost_model import COST_MODEL_ID
 from app.services.deflated_sharpe import DSR_MODEL_ID, TradeMoments
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID, LegBook
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
+from app.services.position_builder import Window
 from app.services.research_price_structure_store import QUARANTINE_ARMS, QUARANTINE_RULE_SET_VERSION
 from app.services.signal_ledger import LedgerRow
 from app.services.strategy_result import (
@@ -467,6 +469,43 @@ class TestBuildResult:
         from dataclasses import replace
 
         assert replace(masked.identity, quarantine_arm="admitted") == admitted.identity
+
+    def test_a_recent_window_is_part_of_the_result_identity(self) -> None:
+        recent = Window(date(2024, 7, 9), EVALUATION_WINDOW_END)
+        legacy = build_result(
+            _measurement(),
+            strategy_id="s1-time-series-momentum",
+            strategy_version="strategy-v1+abc",
+            ambiguity_arm="worst_case",
+            quarantine_arm="masked",
+            deflated=None,
+        )
+        result = build_result(
+            _measurement(),
+            strategy_id="s1-time-series-momentum",
+            strategy_version="strategy-v1+abc",
+            ambiguity_arm="worst_case",
+            quarantine_arm="masked",
+            deflated=None,
+            evaluation_window=recent,
+        )
+        assert (result.identity.window_start, result.identity.window_end) == (recent.start, recent.end)
+        assert result.identity.version != legacy.identity.version
+
+
+class TestRecentWindowNamespace:
+    def test_registered_recent_window_is_holdout_only_and_audited(self) -> None:
+        recent = Window(date(2022, 1, 1), EVALUATION_WINDOW_END)
+        assert _namespaces_for_window(holdout_requested=True, evaluation_window=recent) == ("hold_out",)
+        with pytest.raises(ValueError, match="requires an audited access"):
+            _namespaces_for_window(holdout_requested=False, evaluation_window=recent)
+
+    def test_custom_window_cannot_reclassify_pre_boundary_data(self) -> None:
+        with pytest.raises(ValueError, match="on or after the frozen hold-out boundary"):
+            _namespaces_for_window(
+                holdout_requested=True,
+                evaluation_window=Window(date(2020, 1, 1), date(2022, 1, 1)),
+            )
 
 
 class TestPlannedIdentities:

--- a/tests/test_jobs_runtime.py
+++ b/tests/test_jobs_runtime.py
@@ -568,7 +568,7 @@ class TestProductionInvokerRegistry:
             # test exists to force: criterion 5 requires a hold-out purpose and
             # an accessor that a cron fire cannot supply, so a scheduled fire
             # could only ever produce in-sample rows. Source-lock
-            # "strategy_backtest" + four params in MANUAL_TRIGGER_JOB_METADATA
+            # "strategy_backtest" + five params in MANUAL_TRIGGER_JOB_METADATA
             # complete the triangle. ⚠ It does NOT share strategy_signal_scan's
             # lane — that one IS scheduled, and blocking the daily shadow track
             # record behind a ~30-50 minute backtest is the coupling §3 of the

--- a/tests/test_strategy_recent_evidence.py
+++ b/tests/test_strategy_recent_evidence.py
@@ -1,0 +1,40 @@
+"""The recent evidence denominator and its anti-window-shopping boundary."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.processes.param_metadata import MANUAL_TRIGGER_JOB_METADATA
+from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS, recent_evidence_window
+from app.services.strategy_result import EVALUATION_WINDOW_END, HOLDOUT_BOUNDARY
+
+
+def test_all_required_windows_are_named_and_inside_the_holdout_corpus() -> None:
+    assert tuple(RECENT_EVIDENCE_WINDOWS) == (
+        "primary-2022-plus",
+        "rolling-36m",
+        "rolling-24m",
+        "year-2022",
+        "year-2023",
+        "year-2024",
+        "year-2025",
+        "year-2026-ytd",
+    )
+    assert all(item.required_for_allocation for item in RECENT_EVIDENCE_WINDOWS.values())
+    assert all(item.window.start >= HOLDOUT_BOUNDARY for item in RECENT_EVIDENCE_WINDOWS.values())
+    assert all(item.window.end <= EVALUATION_WINDOW_END for item in RECENT_EVIDENCE_WINDOWS.values())
+    assert RECENT_EVIDENCE_WINDOWS["primary-2022-plus"].window.start == date(2022, 1, 1)
+
+
+def test_raw_or_unknown_window_ids_are_refused() -> None:
+    with pytest.raises(ValueError, match="unknown recent evidence window"):
+        recent_evidence_window("2025-03-01:2025-04-01")
+
+
+def test_manual_job_exposes_ids_but_never_raw_dates() -> None:
+    metadata = {item.name: item for item in MANUAL_TRIGGER_JOB_METADATA["strategy_backtest_run"]}
+    window = metadata["evidence_window"]
+    assert window.field_type == "enum"
+    assert window.enum_values == tuple(RECENT_EVIDENCE_WINDOWS)

--- a/tests/test_strategy_recent_evidence.py
+++ b/tests/test_strategy_recent_evidence.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import date
+from types import SimpleNamespace
 
 import pytest
 
 from app.services.processes.param_metadata import MANUAL_TRIGGER_JOB_METADATA
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS, recent_evidence_window
 from app.services.strategy_result import EVALUATION_WINDOW_END, HOLDOUT_BOUNDARY
+from app.workers import scheduler
 
 
 def test_all_required_windows_are_named_and_inside_the_holdout_corpus() -> None:
@@ -38,3 +42,24 @@ def test_manual_job_exposes_ids_but_never_raw_dates() -> None:
     window = metadata["evidence_window"]
     assert window.field_type == "enum"
     assert window.enum_values == tuple(RECENT_EVIDENCE_WINDOWS)
+
+
+def test_invalid_window_is_recorded_inside_the_job_tracking_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    @contextmanager
+    def tracked(job_name: str) -> Iterator[SimpleNamespace]:
+        events.append(f"entered:{job_name}")
+        try:
+            yield SimpleNamespace(row_count=0)
+        finally:
+            events.append(f"exited:{job_name}")
+
+    monkeypatch.setattr(scheduler, "_tracked_job", tracked)
+
+    with pytest.raises(ValueError, match="unknown recent evidence window"):
+        scheduler.strategy_backtest_run({"evidence_window": "searched-favourable-dates"})
+
+    assert events == ["entered:strategy_backtest_run", "exited:strategy_backtest_run"]


### PR DESCRIPTION
## Outcome

Ships the read-only strategy observability slice for #2437 without enabling allocation or broker execution.

- registers eight immutable recent-regime windows (2022+, rolling 36/24 months, and 2022-2026 yearly views)
- extends the audited backtest runner to compute exact-date recent hold-out arms without replacing the legacy 1962-2026 stress rows
- adds the manual-job evidence-window picker; arbitrary date search is not accepted
- exposes every current manifest strategy, including excluded S-4, exact-version evidence/provenance/refusals, scan health, and every fired signal through authenticated read-only APIs
- adds a Strategies page with keyset pagination and explicit unfunded/execution-disabled state
- updates the quant skills/specs with the measured eToro/data and bounded-storage conclusions

## Database and performance

No migration and no derived indicator/time-series table. All eight windows cost at most 96 compact aggregate rows at the current 3 runnable strategies x 4 sensitivity arms.

Measured on the 63 GB developer database:

- 34,698 current scan-detail rows aggregate in 15.2 ms
- latest/cursor pages return 50 joined signals in under 1 ms
- 48 result rows read in under 0.2 ms
- no additional index is justified; #2448 owns the measured retention/partition work

The audited primary 2022-01-01..2026-07-08 run stored 12 rows. S1 and S3 were materially negative; S2 returned +41.33% with 0.44 Sharpe and -30.55% drawdown. Every arm remains unallocatable because the universe is survivor-only, carry is unmodelled, and synthetic control is absent. S-4 remains explicitly excluded.

## Review findings resolved

Independent Codex review found and this branch fixes:

- valid NULL Sortino/profit-factor metrics could fail response validation
- a successful zero-signal scan could appear as never run because health was signal-led rather than watermark-led

Both have regression tests.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not db"` — 7,195 passed, 3 skipped
- `uv run pytest tests/smoke` — 153 passed, 3 skipped
- `pnpm --dir frontend test:unit` — 1,488 passed
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend dark:check`
- `pnpm --dir frontend pills:check`
- `pnpm --dir frontend build`
- full repository pre-push hook — green
- `PYTHONPATH=. uv run python scripts/verify_2447_strategy_monitoring.py`

Closes #2447
Refs #2437
