### PR TITLE
Bound strategy observation storage

### DIFF
--- a/.claude/skills/quant/data-capability.md
+++ b/.claude/skills/quant/data-capability.md
@@ -192,3 +192,29 @@ minimum** — that is the specific thing a data purchase must buy.
    removes the era confound above.
 3. **Amihud on the daily corpus.** No new data at all — a conditioner, a
    per-name cost model, and a priced factor in one.
+
+---
+
+## 7. ⚠ Intraday storage is a measured budget, not `price_intraday` permission
+
+Before adding any recurring intraday writer, read
+`docs/proposals/ta/2026-08-09-strategy-observation-storage.md` and reproduce:
+
+```bash
+PYTHONPATH=. uv run python scripts/verify_2437_observation_storage.py --benchmark
+```
+
+The fixed caps are 30m/1,000 instruments/24 months,
+5m/250/12 months and 1m/50/30 days. Together they are 12.051M retained bars.
+Two plausible schemas were measured and rejected at 2.99 GB and 2.28 GB. The
+accepted completed-OHLCV shape is 117.5 bytes/row including its BRIN index,
+1.422 GB at all caps after upward rounding, with a per-tier/instrument monotonic
+watermark replacing a per-row btree. `store_intraday_bars` transactionally
+enforces retained width, stored-plus-incoming daily row count, alignment,
+completion, retention horizon and watermark backpressure.
+
+⚠ Do not add a second btree, derived-indicator columns, forming bars or raw
+ticks to this relation. Any schema change must rerun the temporary-table
+benchmark and stay below the 1.5 GB retained-tier budget. WebSocket quote
+history still needs a separate honest bid/ask/spread shape plus subscription
+coverage; it must not masquerade as traded OHLCV.

--- a/.claude/skills/quant/strategy-evidence.md
+++ b/.claude/skills/quant/strategy-evidence.md
@@ -17,6 +17,12 @@ prior is how a session spends a week on a family the evidence killed in 2016.
 ⚠ Companion to `data-sources/market-structure.md`, which owns *indicator
 formulations*. This file owns *whether a strategy family is worth building*.
 
+⚠ Storage companion: `quant/data-capability.md` §7. Every logical signal must
+reach the durable daily census, but only fired signals are durable detail;
+routine verdict detail is retained 90 days in drop-only partitions. Bypassing
+`store_strategy_observations` both breaks census parity and recreates the
+measured 8.42 GB/year failure.
+
 ---
 
 ## 0. ⚠⚠ WHAT SURVIVED — read this first, the rest of the file is mostly what did not

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -239,21 +239,26 @@ _SCAN_SQL = """
         w.strategy_version,
         w.frontier_date,
         w.updated_at,
-        COUNT(*) FILTER (WHERE s.verdict = 'fired' AND s.signal_kind = 'entry') AS fired_entries,
-        COUNT(*) FILTER (WHERE s.verdict = 'fired' AND s.signal_kind = 'exit') AS fired_exits,
-        COUNT(*) FILTER (WHERE s.verdict = 'not_fired') AS not_fired,
-        COUNT(*) FILTER (WHERE s.verdict = 'not_evaluable') AS not_evaluable
+        COALESCE(SUM(s.row_count) FILTER (
+            WHERE s.verdict = 'fired' AND s.signal_kind = 'entry'
+        ), 0) AS fired_entries,
+        COALESCE(SUM(s.row_count) FILTER (
+            WHERE s.verdict = 'fired' AND s.signal_kind = 'exit'
+        ), 0) AS fired_exits,
+        COALESCE(SUM(s.row_count) FILTER (WHERE s.verdict = 'not_fired'), 0) AS not_fired,
+        COALESCE(SUM(s.row_count) FILTER (WHERE s.verdict = 'not_evaluable'), 0) AS not_evaluable
     FROM strategy_scan_watermark w
-    LEFT JOIN strategy_signals s USING (strategy_id, strategy_version)
+    LEFT JOIN strategy_signal_daily_counts s USING (strategy_id, strategy_version)
     WHERE w.strategy_version = ANY(%(versions)s)
     GROUP BY w.strategy_id, w.strategy_version, w.frontier_date, w.updated_at
 """
 
 _EXCLUSIONS_SQL = """
-    SELECT strategy_id, strategy_version, not_evaluable_reason, COUNT(*) AS count
-    FROM strategy_signals
-    WHERE strategy_version = ANY(%(versions)s) AND not_evaluable_reason IS NOT NULL
-    GROUP BY strategy_id, strategy_version, not_evaluable_reason
+    SELECT strategy_id, strategy_version, reason_code AS not_evaluable_reason,
+           SUM(row_count) AS count
+    FROM strategy_signal_daily_counts
+    WHERE strategy_version = ANY(%(versions)s) AND verdict = 'not_evaluable'
+    GROUP BY strategy_id, strategy_version, reason_code
 """
 
 _LATEST_CORPUS_SQL = "SELECT MAX(bar_date) FROM research_price_daily"

--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -127,6 +127,7 @@ from app.workers.scheduler import (
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
     JOB_STRATEGY_BACKTEST_RUN,
+    JOB_STRATEGY_OBSERVATION_RETENTION,
     JOB_STRATEGY_SIGNAL_SCAN,
     JOB_THESIS_BREAK_SCAN,
     JOB_THESIS_DQ_AUDIT,
@@ -193,6 +194,7 @@ from app.workers.scheduler import (
     sec_nport_filer_directory_sync,
     seed_cost_models,
     strategy_backtest_run,
+    strategy_observation_retention,
     strategy_signal_scan,
     thesis_break_scan,
     thesis_dq_audit,
@@ -344,6 +346,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # the frontier watermark rather than by a DAG edge. Own "strategy_scan" lane,
     # resolved from SCHEDULED_JOBS, so no MANUAL_TRIGGER_JOB_SOURCES entry.
     JOB_STRATEGY_SIGNAL_SCAN: _adapt_zero_arg(strategy_signal_scan),
+    JOB_STRATEGY_OBSERVATION_RETENTION: _adapt_zero_arg(strategy_observation_retention),
     # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY and NOT in
     # SCHEDULED_JOBS: criterion 5 requires a hold-out purpose no cron fire can
     # supply. ⚠ Registered NATIVELY, not through ``_adapt_zero_arg`` — the body

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -338,8 +338,10 @@ when one overruns). Scheduled-only, so NOT added to the
   orchestrator adapter inner-JobLock AND the operator manual-trigger path. NOT
   in SCHEDULED_JOBS (the DAG layer's cadence/freshness gate the run), so NOT
   added to the ``bootstrap_stages.lane`` CHECK.
-* ``strategy_scan`` — ``strategy_signal_scan`` (#2394 §3.1) only. DB-only
-  producer, sole writer of ``strategy_signals`` + ``strategy_scan_watermark``;
+* ``strategy_scan`` — ``strategy_signal_scan`` (#2394 §3.1) plus
+  ``strategy_observation_retention`` (#2448). The DB-only producer is sole
+  writer of the signal/count/observation relations and scan watermark; the
+  retention sibling drops only expired leaf partitions after the scan;
   reads ``price_daily`` / ``price_bar_quarantine`` MVCC-safe. ⚠ The lane is
   load-bearing for CORRECTNESS here, unlike the two above where it is a
   starvation fix: ``store_signals`` has no ``ON CONFLICT``, so two overlapping

--- a/app/services/signal_ledger.py
+++ b/app/services/signal_ledger.py
@@ -306,7 +306,13 @@ _INSERT = """
 
 
 def store_signals(conn: psycopg.Connection[tuple], rows: Sequence[LedgerRow]) -> int:
-    """Insert ``rows``, returning the number written.
+    """Insert durable FIRED ``rows``, returning the number written.
+
+    Routine negative decisions go through
+    ``strategy_observation_storage.store_strategy_observations`` so they reach
+    the 90-day partition and durable daily census rather than this heavily
+    indexed, outcome-referenced ledger. Keeping this low-level function public
+    for outcome fixtures does not permit bypassing that #2448 boundary.
 
     ⚠⚠ **NO** ``ON CONFLICT``**, deliberately.** A colliding key raises
     ``UniqueViolation`` and aborts the batch. Both alternatives are worse:
@@ -325,6 +331,12 @@ def store_signals(conn: psycopg.Connection[tuple], rows: Sequence[LedgerRow]) ->
     """
     if not rows:
         return 0
+    non_fired = [row.verdict for row in rows if row.verdict != "fired"]
+    if non_fired:
+        raise ValueError(
+            f"strategy_signals is fired-only; got {len(non_fired)} routine verdict row(s) — "
+            "use store_strategy_observations so daily counts and retention stay complete"
+        )
     with conn.cursor() as cur:
         cur.executemany(
             _INSERT,

--- a/app/services/strategy_observation_storage.py
+++ b/app/services/strategy_observation_storage.py
@@ -1,0 +1,714 @@
+"""Bounded persistence for strategy observations and completed intraday bars.
+
+Fired signals remain in ``strategy_signals`` because outcomes and future trade
+ownership refer to their durable ``signal_id``. Routine negative decisions are
+kept in monthly partitions for 90 days and represented durably by daily counts.
+Intraday storage accepts only the three declared tiers and refuses a batch that
+exceeds its instrument or completed-bars-per-day cap.
+
+Refs #2437, #2448. Schema: ``sql/276_strategy_observation_storage.sql``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from types import MappingProxyType
+from typing import Any, Final, Literal, cast
+
+import psycopg
+import psycopg.sql
+
+from app.services.signal_ledger import LedgerRow, store_signals
+
+Timeframe = Literal["30m", "5m", "1m"]
+
+SIGNAL_DETAIL_RETENTION_DAYS: Final = 90
+
+
+@dataclass(frozen=True)
+class IntradayTier:
+    timeframe: Timeframe
+    minutes_per_bar: int
+    max_instruments: int
+    retention_days: int | None
+    retention_months: int | None
+    partition_granularity: Literal["month", "day"]
+
+    def __post_init__(self) -> None:
+        if (self.retention_days is None) == (self.retention_months is None):
+            raise ValueError("an intraday tier needs exactly one retention unit")
+
+    @property
+    def max_bars_per_instrument_day(self) -> int:
+        return 390 // self.minutes_per_bar
+
+
+_TIERS = (
+    IntradayTier(
+        "30m",
+        minutes_per_bar=30,
+        max_instruments=1_000,
+        retention_days=None,
+        retention_months=24,
+        partition_granularity="month",
+    ),
+    IntradayTier(
+        "5m",
+        minutes_per_bar=5,
+        max_instruments=250,
+        retention_days=None,
+        retention_months=12,
+        partition_granularity="month",
+    ),
+    IntradayTier(
+        "1m",
+        minutes_per_bar=1,
+        max_instruments=50,
+        retention_days=30,
+        retention_months=None,
+        partition_granularity="day",
+    ),
+)
+INTRADAY_TIERS: Final[Mapping[Timeframe, IntradayTier]] = MappingProxyType({tier.timeframe: tier for tier in _TIERS})
+
+
+@dataclass(frozen=True)
+class SignalStorageReport:
+    logical_rows: int
+    fired_rows: int
+    retained_observation_rows: int
+    aggregate_rows: int
+    input_payload_bytes: int
+
+
+@dataclass(frozen=True)
+class IntradayBar:
+    timeframe: Timeframe
+    bar_time: datetime
+    instrument_id: int
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: Decimal | None
+    source: str
+
+    def __post_init__(self) -> None:
+        if self.timeframe not in INTRADAY_TIERS:
+            raise ValueError(f"unknown timeframe {self.timeframe!r}; must be one of {list(INTRADAY_TIERS)}")
+        if self.bar_time.tzinfo is None:
+            raise ValueError("bar_time must be timezone-aware")
+        if self.instrument_id <= 0:
+            raise ValueError("instrument_id must be positive")
+        if min(self.open, self.high, self.low, self.close) <= 0:
+            raise ValueError("OHLC prices must be positive")
+        if self.high < max(self.open, self.close, self.low) or self.low > min(self.open, self.close, self.high):
+            raise ValueError("OHLC prices are inconsistent")
+        if self.volume is not None and self.volume < 0:
+            raise ValueError("volume must be non-negative when present")
+        if not self.source.strip():
+            raise ValueError("source must be non-empty")
+
+
+@dataclass(frozen=True)
+class IntradayStorageReport:
+    rows_written: int
+    instruments: int
+    partitions_touched: int
+    input_payload_bytes: int
+
+
+@dataclass(frozen=True)
+class RetentionPlan:
+    signal_partitions: tuple[str, ...]
+    intraday_partitions: tuple[str, ...]
+
+    @property
+    def partitions(self) -> tuple[str, ...]:
+        return self.signal_partitions + self.intraday_partitions
+
+
+_INSERT_OBSERVATION = """
+    INSERT INTO strategy_signal_observations (
+        strategy_id, strategy_version, instrument_id, signal_bar_date,
+        signal_kind, verdict, reason_code
+    ) VALUES (
+        %(strategy_id)s, %(strategy_version)s, %(instrument_id)s, %(signal_bar_date)s,
+        %(signal_kind)s, %(verdict)s, %(reason_code)s
+    )
+"""
+
+_INSERT_DAILY_COUNT = """
+    INSERT INTO strategy_signal_daily_counts (
+        strategy_id, strategy_version, signal_bar_date,
+        signal_kind, verdict, reason_code, row_count
+    ) VALUES (
+        %(strategy_id)s, %(strategy_version)s, %(signal_bar_date)s,
+        %(signal_kind)s, %(verdict)s, %(reason_code)s, %(row_count)s
+    )
+"""
+
+_INSERT_INTRADAY_BAR = """
+    INSERT INTO strategy_intraday_bars (
+        timeframe, bar_time, instrument_id, open, high, low, close, volume, source
+    ) VALUES (
+        %(timeframe)s, %(bar_time)s, %(instrument_id)s,
+        %(open)s, %(high)s, %(low)s, %(close)s, %(volume)s, %(source)s
+    )
+"""
+
+_READ_INTRADAY_WATERMARKS = """
+    SELECT timeframe, instrument_id, last_bar_time
+    FROM strategy_intraday_watermarks
+    WHERE timeframe = ANY(%(timeframes)s)
+      AND instrument_id = ANY(%(instrument_ids)s)
+"""
+
+_ADVANCE_INTRADAY_WATERMARK = """
+    INSERT INTO strategy_intraday_watermarks (timeframe, instrument_id, last_bar_time, updated_at)
+    VALUES (%(timeframe)s, %(instrument_id)s, %(last_bar_time)s, now())
+    ON CONFLICT (timeframe, instrument_id) DO UPDATE
+       SET last_bar_time = EXCLUDED.last_bar_time,
+           updated_at = now()
+     WHERE EXCLUDED.last_bar_time > strategy_intraday_watermarks.last_bar_time
+"""
+
+_TIER_LOCK_IDS: Final[Mapping[Timeframe, int]] = MappingProxyType({"30m": 30, "5m": 5, "1m": 1})
+
+_FIND_CROSS_TABLE_SIGNAL_CONFLICT = """
+    WITH incoming AS (
+        SELECT *
+        FROM unnest(
+            %(strategy_ids)s::text[],
+            %(strategy_versions)s::text[],
+            %(instrument_ids)s::bigint[],
+            %(signal_dates)s::date[],
+            %(signal_kinds)s::text[],
+            %(verdicts)s::text[]
+        ) AS item(strategy_id, strategy_version, instrument_id, signal_bar_date, signal_kind, verdict)
+    )
+    SELECT item.strategy_id, item.strategy_version, item.instrument_id,
+           item.signal_bar_date, item.signal_kind
+    FROM incoming AS item
+    JOIN strategy_signals AS durable
+      USING (strategy_id, strategy_version, instrument_id, signal_bar_date, signal_kind)
+    WHERE item.verdict <> 'fired'
+    UNION ALL
+    SELECT item.strategy_id, item.strategy_version, item.instrument_id,
+           item.signal_bar_date, item.signal_kind
+    FROM incoming AS item
+    JOIN strategy_signal_observations AS retained
+      USING (strategy_id, strategy_version, instrument_id, signal_bar_date, signal_kind)
+    WHERE item.verdict = 'fired'
+    LIMIT 1
+"""
+
+
+def _next_month(value: date) -> date:
+    return date(value.year + (value.month == 12), 1 if value.month == 12 else value.month + 1, 1)
+
+
+def _months_before(value: date, months: int) -> date:
+    ordinal = value.year * 12 + value.month - 1 - months
+    year, month_zero_based = divmod(ordinal, 12)
+    month = month_zero_based + 1
+    # Retention checks only complete month partitions, so the first of the
+    # target month is the exact and leap-safe cutoff.
+    return date(year, month, 1)
+
+
+def _signal_partition_name(value: date) -> str:
+    return f"strategy_signal_observations_y{value.year:04d}m{value.month:02d}"
+
+
+def ensure_signal_partition(conn: psycopg.Connection[Any], value: date) -> str:
+    """Create the one bounded monthly leaf required by ``value``."""
+    start = value.replace(day=1)
+    end = _next_month(start)
+    name = _signal_partition_name(value)
+    statement = psycopg.sql.SQL(
+        "CREATE TABLE IF NOT EXISTS {} PARTITION OF strategy_signal_observations FOR VALUES FROM ({}) TO ({})"
+    ).format(psycopg.sql.Identifier(name), psycopg.sql.Literal(start), psycopg.sql.Literal(end))
+    conn.execute(statement)
+    return name
+
+
+def _intraday_partition_bounds(tier: IntradayTier, value: datetime) -> tuple[datetime, datetime, str]:
+    utc_value = value.astimezone(UTC)
+    if tier.partition_granularity == "day":
+        start = utc_value.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+        suffix = f"y{start.year:04d}m{start.month:02d}d{start.day:02d}"
+    else:
+        start = utc_value.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        next_date = _next_month(start.date())
+        end = datetime(next_date.year, next_date.month, 1, tzinfo=UTC)
+        suffix = f"y{start.year:04d}m{start.month:02d}"
+    return start, end, f"strategy_intraday_bars_{tier.timeframe}_{suffix}"
+
+
+def _intraday_retention_floor(tier: IntradayTier, observed_date: date) -> date:
+    if tier.retention_days is not None:
+        return observed_date - timedelta(days=tier.retention_days)
+    return _months_before(observed_date, cast(int, tier.retention_months))
+
+
+def ensure_intraday_partition(conn: psycopg.Connection[Any], timeframe: Timeframe, value: datetime) -> str:
+    tier = INTRADAY_TIERS[timeframe]
+    start, end, name = _intraday_partition_bounds(tier, value)
+    parent = f"strategy_intraday_bars_{timeframe}"
+    statement = psycopg.sql.SQL("CREATE TABLE IF NOT EXISTS {} PARTITION OF {} FOR VALUES FROM ({}) TO ({})").format(
+        psycopg.sql.Identifier(name),
+        psycopg.sql.Identifier(parent),
+        psycopg.sql.Literal(start),
+        psycopg.sql.Literal(end),
+    )
+    conn.execute(statement)
+    return name
+
+
+def _ledger_payload_bytes(row: LedgerRow) -> int:
+    fields = (
+        row.strategy_id,
+        row.strategy_version,
+        str(row.instrument_id),
+        row.signal_bar_date.isoformat(),
+        row.signal_kind,
+        row.verdict,
+        row.not_evaluable_reason or "",
+    )
+    return sum(len(field.encode("utf-8")) for field in fields)
+
+
+def _logical_signal_key(row: LedgerRow) -> tuple[str, str, int, date, str]:
+    return (
+        row.strategy_id,
+        row.strategy_version,
+        row.instrument_id,
+        row.signal_bar_date,
+        row.signal_kind,
+    )
+
+
+def store_strategy_observations(conn: psycopg.Connection[Any], rows: Sequence[LedgerRow]) -> SignalStorageReport:
+    """Persist one complete census without durable negative-decision bloat.
+
+    No conflict is ignored. The scan watermark makes a normal repeat a no-op;
+    any collision here means recorded evidence drifted and must abort the same
+    transaction as the watermark advance.
+    """
+    if not rows:
+        return SignalStorageReport(0, 0, 0, 0, 0)
+
+    logical_keys = [_logical_signal_key(row) for row in rows]
+    duplicate_keys = [key for key, count in Counter(logical_keys).items() if count > 1]
+    if duplicate_keys:
+        raise ValueError(f"strategy observation batch contains duplicate logical signal key(s): {duplicate_keys[:3]}")
+
+    fired = [row for row in rows if row.verdict == "fired"]
+    observations = [row for row in rows if row.verdict != "fired"]
+    counts: Counter[tuple[str, str, date, str, str, str]] = Counter(
+        (
+            row.strategy_id,
+            row.strategy_version,
+            row.signal_bar_date,
+            row.signal_kind,
+            row.verdict,
+            row.not_evaluable_reason or "",
+        )
+        for row in rows
+    )
+
+    identities = sorted({(row.strategy_id, row.strategy_version) for row in rows})
+    with conn.transaction():
+        for strategy_id, strategy_version in identities:
+            # One lock per immutable identity makes the cross-table check safe
+            # for concurrent first writes without retaining one key row per
+            # routine observation.
+            conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended(%s, 2448) # hashtextextended(%s, 2449))",
+                (strategy_id, strategy_version),
+            )
+            watermark = conn.execute(
+                """
+                SELECT frontier_date
+                FROM strategy_scan_watermark
+                WHERE strategy_id = %s AND strategy_version = %s
+                """,
+                (strategy_id, strategy_version),
+            ).fetchone()
+            if watermark is not None:
+                stale = [
+                    row
+                    for row in rows
+                    if row.strategy_id == strategy_id
+                    and row.strategy_version == strategy_version
+                    and row.signal_bar_date < watermark[0]
+                ]
+                if stale:
+                    raise ValueError(
+                        f"strategy observation precedes terminal watermark {watermark[0]} for "
+                        f"{strategy_id}/{strategy_version}: {_logical_signal_key(stale[0])}"
+                    )
+
+        conflict = conn.execute(
+            _FIND_CROSS_TABLE_SIGNAL_CONFLICT,
+            {
+                "strategy_ids": [row.strategy_id for row in rows],
+                "strategy_versions": [row.strategy_version for row in rows],
+                "instrument_ids": [row.instrument_id for row in rows],
+                "signal_dates": [row.signal_bar_date for row in rows],
+                "signal_kinds": [row.signal_kind for row in rows],
+                "verdicts": [row.verdict for row in rows],
+            },
+        ).fetchone()
+        if conflict is not None:
+            raise ValueError(f"strategy observation conflicts with a verdict in the other storage tier: {conflict}")
+
+        for month in sorted({row.signal_bar_date.replace(day=1) for row in observations}):
+            ensure_signal_partition(conn, month)
+        fired_written = store_signals(cast(psycopg.Connection[tuple], conn), fired)
+        with conn.cursor() as cur:
+            if observations:
+                cur.executemany(
+                    _INSERT_OBSERVATION,
+                    [
+                        {
+                            "strategy_id": row.strategy_id,
+                            "strategy_version": row.strategy_version,
+                            "instrument_id": row.instrument_id,
+                            "signal_bar_date": row.signal_bar_date,
+                            "signal_kind": row.signal_kind,
+                            "verdict": row.verdict,
+                            "reason_code": row.not_evaluable_reason or "",
+                        }
+                        for row in observations
+                    ],
+                )
+                observation_written = cur.rowcount
+                if observation_written < 0:
+                    raise RuntimeError("strategy_signal_observations INSERT did not report a row count")
+            else:
+                observation_written = 0
+            cur.executemany(
+                _INSERT_DAILY_COUNT,
+                [
+                    {
+                        "strategy_id": key[0],
+                        "strategy_version": key[1],
+                        "signal_bar_date": key[2],
+                        "signal_kind": key[3],
+                        "verdict": key[4],
+                        "reason_code": key[5],
+                        "row_count": count,
+                    }
+                    for key, count in counts.items()
+                ],
+            )
+            aggregate_written = cur.rowcount
+        if aggregate_written < 0:
+            raise RuntimeError("strategy_signal_daily_counts INSERT did not report a row count")
+        if fired_written + observation_written != len(rows):
+            raise RuntimeError(
+                f"strategy observation write stored {fired_written} fired + {observation_written} retained "
+                f"against {len(rows)} logical rows"
+            )
+        return SignalStorageReport(
+            logical_rows=len(rows),
+            fired_rows=fired_written,
+            retained_observation_rows=observation_written,
+            aggregate_rows=aggregate_written,
+            input_payload_bytes=sum(_ledger_payload_bytes(row) for row in rows),
+        )
+
+
+def _intraday_payload_bytes(row: IntradayBar) -> int:
+    fields = (
+        row.timeframe,
+        row.bar_time.isoformat(),
+        str(row.instrument_id),
+        str(row.open),
+        str(row.high),
+        str(row.low),
+        str(row.close),
+        "" if row.volume is None else str(row.volume),
+        row.source,
+    )
+    return sum(len(field.encode("utf-8")) for field in fields)
+
+
+def store_intraday_bars(
+    conn: psycopg.Connection[Any],
+    rows: Sequence[IntradayBar],
+    *,
+    observed_at: datetime,
+) -> IntradayStorageReport:
+    """Store completed bars after applying tier caps and bounded backpressure."""
+    if observed_at.tzinfo is None:
+        raise ValueError("observed_at must be timezone-aware")
+    if not rows:
+        return IntradayStorageReport(0, 0, 0, 0)
+
+    instruments_by_tier: dict[Timeframe, set[int]] = defaultdict(set)
+    bars_by_instrument_day: Counter[tuple[Timeframe, int, date]] = Counter()
+    keys: set[tuple[Timeframe, datetime, int]] = set()
+    for row in rows:
+        tier = INTRADAY_TIERS[row.timeframe]
+        utc_time = row.bar_time.astimezone(UTC)
+        if utc_time > observed_at.astimezone(UTC):
+            raise ValueError(f"{row.timeframe} bar {utc_time} is still in the future at {observed_at}")
+        retention_floor = _intraday_retention_floor(tier, observed_at.astimezone(UTC).date())
+        if utc_time.date() < retention_floor:
+            raise ValueError(
+                f"{row.timeframe} bar {utc_time} is before retained horizon {retention_floor} at {observed_at}"
+            )
+        if utc_time.second or utc_time.microsecond or utc_time.minute % tier.minutes_per_bar:
+            raise ValueError(f"{row.timeframe} bar_time {utc_time} is not aligned to a completed tier boundary")
+        key = (row.timeframe, utc_time, row.instrument_id)
+        if key in keys:
+            raise ValueError(f"duplicate intraday bar in batch: {key}")
+        keys.add(key)
+        instruments_by_tier[row.timeframe].add(row.instrument_id)
+        bars_by_instrument_day[(row.timeframe, row.instrument_id, utc_time.date())] += 1
+
+    for timeframe, instruments in instruments_by_tier.items():
+        tier = INTRADAY_TIERS[timeframe]
+        if len(instruments) > tier.max_instruments:
+            raise ValueError(
+                f"{timeframe} batch contains {len(instruments)} instruments; cap is {tier.max_instruments}"
+            )
+    for (timeframe, instrument_id, bar_date), count in bars_by_instrument_day.items():
+        maximum = INTRADAY_TIERS[timeframe].max_bars_per_instrument_day
+        if count > maximum:
+            raise ValueError(
+                f"{timeframe}/{instrument_id}/{bar_date} contains {count} bars; regular-session cap is {maximum}"
+            )
+
+    ordered = sorted(rows, key=lambda item: (item.timeframe, item.instrument_id, item.bar_time))
+    requested_days = sorted(bars_by_instrument_day)
+
+    # This savepoint/transaction makes every application-level refusal below
+    # atomic even if a caller catches it. A transaction advisory lock per tier
+    # also closes the absent-watermark race without adding a per-bar btree.
+    with conn.transaction():
+        for timeframe in sorted(instruments_by_tier):
+            conn.execute("SELECT pg_advisory_xact_lock(2448, %s)", (_TIER_LOCK_IDS[timeframe],))
+
+        active_rows = conn.execute(
+            """
+            SELECT timeframe, instrument_id
+            FROM strategy_intraday_watermarks
+            WHERE timeframe = ANY(%(timeframes)s)
+            """,
+            {"timeframes": sorted(instruments_by_tier)},
+        ).fetchall()
+        active_by_tier: dict[Timeframe, set[int]] = defaultdict(set)
+        for timeframe, instrument_id in active_rows:
+            active_by_tier[cast(Timeframe, str(timeframe))].add(int(instrument_id))
+        for timeframe, incoming in instruments_by_tier.items():
+            resulting_width = len(active_by_tier[timeframe] | incoming)
+            maximum = INTRADAY_TIERS[timeframe].max_instruments
+            if resulting_width > maximum:
+                raise ValueError(
+                    f"{timeframe} retained universe would contain {resulting_width} instruments; cap is {maximum}"
+                )
+
+        stored_day_counts: dict[tuple[Timeframe, int, date], int] = {}
+        for timeframe, instrument_id, bar_date in requested_days:
+            row = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM strategy_intraday_bars
+                WHERE timeframe = %(timeframe)s
+                  AND instrument_id = %(instrument_id)s
+                  AND bar_time >= %(day_start)s
+                  AND bar_time < %(day_end)s
+                """,
+                {
+                    "timeframe": timeframe,
+                    "instrument_id": instrument_id,
+                    "day_start": datetime.combine(bar_date, datetime.min.time(), tzinfo=UTC),
+                    "day_end": datetime.combine(bar_date + timedelta(days=1), datetime.min.time(), tzinfo=UTC),
+                },
+            ).fetchone()
+            stored_day_counts[(timeframe, instrument_id, bar_date)] = int(row[0]) if row else 0
+        for key, incoming_count in bars_by_instrument_day.items():
+            maximum = INTRADAY_TIERS[key[0]].max_bars_per_instrument_day
+            total = stored_day_counts[key] + incoming_count
+            if total > maximum:
+                raise ValueError(
+                    f"{key[0]}/{key[1]}/{key[2]} would contain {total} bars; regular-session cap is {maximum}"
+                )
+
+        existing = {
+            (cast(Timeframe, str(row[0])), int(row[1])): row[2]
+            for row in conn.execute(
+                _READ_INTRADAY_WATERMARKS,
+                {
+                    "timeframes": sorted(instruments_by_tier),
+                    "instrument_ids": sorted({row.instrument_id for row in rows}),
+                },
+            ).fetchall()
+        }
+        last_by_key: dict[tuple[Timeframe, int], datetime] = {}
+        for row in ordered:
+            key = (row.timeframe, row.instrument_id)
+            utc_time = row.bar_time.astimezone(UTC)
+            prior = existing.get(key)
+            if prior is not None and utc_time <= prior:
+                raise ValueError(
+                    f"{row.timeframe}/{row.instrument_id} bar {utc_time} is at or behind stored watermark {prior}"
+                )
+            last_by_key[key] = utc_time
+
+        partitions = {ensure_intraday_partition(conn, row.timeframe, row.bar_time) for row in ordered}
+        with conn.cursor() as cur:
+            cur.executemany(
+                _INSERT_INTRADAY_BAR,
+                [
+                    {
+                        "timeframe": row.timeframe,
+                        "bar_time": row.bar_time.astimezone(UTC),
+                        "instrument_id": row.instrument_id,
+                        "open": row.open,
+                        "high": row.high,
+                        "low": row.low,
+                        "close": row.close,
+                        "volume": row.volume,
+                        "source": row.source,
+                    }
+                    for row in ordered
+                ],
+            )
+            written = cur.rowcount
+            cur.executemany(
+                _ADVANCE_INTRADAY_WATERMARK,
+                [
+                    {"timeframe": key[0], "instrument_id": key[1], "last_bar_time": last_bar_time}
+                    for key, last_bar_time in last_by_key.items()
+                ],
+            )
+            watermarks_advanced = cur.rowcount
+        if written < 0:
+            raise RuntimeError("strategy_intraday_bars INSERT did not report a row count")
+        if watermarks_advanced != len(last_by_key):
+            raise RuntimeError(
+                f"advanced {watermarks_advanced} intraday watermarks against {len(last_by_key)} instrument tiers"
+            )
+        return IntradayStorageReport(
+            rows_written=written,
+            instruments=len({row.instrument_id for row in rows}),
+            partitions_touched=len(partitions),
+            input_payload_bytes=sum(_intraday_payload_bytes(row) for row in rows),
+        )
+
+
+_SIGNAL_PARTITION_RE = re.compile(r"^strategy_signal_observations_y(\d{4})m(\d{2})$")
+_INTRADAY_MONTH_RE = re.compile(r"^strategy_intraday_bars_(30m|5m)_y(\d{4})m(\d{2})$")
+_INTRADAY_DAY_RE = re.compile(r"^strategy_intraday_bars_1m_y(\d{4})m(\d{2})d(\d{2})$")
+
+
+def _partition_names(conn: psycopg.Connection[Any]) -> tuple[str, ...]:
+    rows = conn.execute(
+        """
+        SELECT child.relname
+        FROM pg_inherits i
+        JOIN pg_class child ON child.oid = i.inhrelid
+        JOIN pg_class parent ON parent.oid = i.inhparent
+        WHERE parent.relname IN (
+            'strategy_signal_observations',
+            'strategy_intraday_bars_30m',
+            'strategy_intraday_bars_5m',
+            'strategy_intraday_bars_1m'
+        )
+        ORDER BY child.relname
+        """
+    ).fetchall()
+    return tuple(str(row[0]) for row in rows)
+
+
+def retention_plan(conn: psycopg.Connection[Any], *, as_of: datetime) -> RetentionPlan:
+    """Return only leaf relations whose entire bound is outside retention."""
+    if as_of.tzinfo is None:
+        raise ValueError("as_of must be timezone-aware")
+    today = as_of.astimezone(UTC).date()
+    signal_cutoff = today - timedelta(days=SIGNAL_DETAIL_RETENTION_DAYS)
+    intraday_cutoffs = {
+        timeframe: (
+            today - timedelta(days=tier.retention_days)
+            if tier.retention_days is not None
+            else _months_before(today, cast(int, tier.retention_months))
+        )
+        for timeframe, tier in INTRADAY_TIERS.items()
+    }
+    signal: list[str] = []
+    intraday: list[str] = []
+    for name in _partition_names(conn):
+        if match := _SIGNAL_PARTITION_RE.fullmatch(name):
+            end = _next_month(date(int(match[1]), int(match[2]), 1))
+            if end <= signal_cutoff:
+                signal.append(name)
+            continue
+        if match := _INTRADAY_MONTH_RE.fullmatch(name):
+            timeframe = cast(Timeframe, match[1])
+            end = _next_month(date(int(match[2]), int(match[3]), 1))
+            if end <= intraday_cutoffs[timeframe]:
+                intraday.append(name)
+            continue
+        if match := _INTRADAY_DAY_RE.fullmatch(name):
+            end = date(int(match[1]), int(match[2]), int(match[3])) + timedelta(days=1)
+            if end <= intraday_cutoffs["1m"]:
+                intraday.append(name)
+    return RetentionPlan(tuple(signal), tuple(intraday))
+
+
+def drop_expired_partitions(conn: psycopg.Connection[Any], *, as_of: datetime, dry_run: bool = True) -> RetentionPlan:
+    """Drop expired detail leaves and release empty universe watermarks."""
+    plan = retention_plan(conn, as_of=as_of)
+    if dry_run:
+        return plan
+    with conn.transaction():
+        for timeframe in sorted(INTRADAY_TIERS):
+            conn.execute("SELECT pg_advisory_xact_lock(2448, %s)", (_TIER_LOCK_IDS[timeframe],))
+        for name in plan.partitions:
+            # ``name`` came from pg_class and must still match one of the closed
+            # patterns in ``retention_plan``; Identifier handles quoting as a
+            # second boundary. A caller can never supply a relation name.
+            conn.execute(psycopg.sql.SQL("DROP TABLE {}").format(psycopg.sql.Identifier(name)))
+        # Watermarks are bounded control metadata, not observations. Releasing
+        # one only after every retained bar for the tier/instrument has expired
+        # permits deliberate universe rotation without weakening the cap.
+        conn.execute(
+            """
+            DELETE FROM strategy_intraday_watermarks AS watermark
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM strategy_intraday_bars AS bar
+                WHERE bar.timeframe = watermark.timeframe
+                  AND bar.instrument_id = watermark.instrument_id
+            )
+            """
+        )
+    return plan
+
+
+__all__ = [
+    "INTRADAY_TIERS",
+    "SIGNAL_DETAIL_RETENTION_DAYS",
+    "IntradayBar",
+    "IntradayStorageReport",
+    "IntradayTier",
+    "RetentionPlan",
+    "SignalStorageReport",
+    "drop_expired_partitions",
+    "ensure_intraday_partition",
+    "ensure_signal_partition",
+    "retention_plan",
+    "store_intraday_bars",
+    "store_strategy_observations",
+]

--- a/app/services/strategy_observation_storage.py
+++ b/app/services/strategy_observation_storage.py
@@ -178,6 +178,9 @@ _ADVANCE_INTRADAY_WATERMARK = """
      WHERE EXCLUDED.last_bar_time > strategy_intraday_watermarks.last_bar_time
 """
 
+# These use PostgreSQL's two-int advisory-lock space as (2448, tier id).
+# Strategy identities below use the separate one-bigint overload, so their
+# hash can only over-serialise another identity; it cannot collide with a tier.
 _TIER_LOCK_IDS: Final[Mapping[Timeframe, int]] = MappingProxyType({"30m": 30, "5m": 5, "1m": 1})
 
 _FIND_CROSS_TABLE_SIGNAL_CONFLICT = """

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -6,10 +6,10 @@ of ``2026-08-08-strategy-runner-and-manifest.md``). Manifest:
 Table: ``sql/255_strategy_signals.sql``. Watermark:
 ``sql/272_strategy_scan_watermark.sql``. Refs #2240, #2394.
 
-⚠⚠ EVERY ROW THIS JOB WRITES IS TERMINAL, AND THAT IS THE CONSTRAINT THE WHOLE
-SHAPE FOLLOWS FROM. ``store_signals`` has no ``ON CONFLICT`` — *"DO UPDATE would
-let a re-run overwrite a recorded decision"* — so a row written wrongly cannot be
-corrected, only superseded by a version bump. Four consequences, each measured
+⚠⚠ EVERY LOGICAL ROW THIS JOB WRITES IS TERMINAL, AND THAT IS THE CONSTRAINT THE
+WHOLE SHAPE FOLLOWS FROM. Fired detail, retained negative detail and the daily
+census all omit ``ON CONFLICT`` — a re-run cannot overwrite a recorded decision,
+only a version bump can supersede it. Four consequences, each measured
 rather than argued (``scripts/verify_2394_signal_scan_cost.py``, full population,
 2026-08-08):
 
@@ -58,9 +58,10 @@ from app.services.price_masked_bars import (
     load_masked_bars,
     load_union_calendar,
 )
-from app.services.signal_ledger import LedgerRow, resolve_fills, store_signals
+from app.services.signal_ledger import LedgerRow, resolve_fills
 from app.services.strategies.validated_universe import load_validated_universe
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry
+from app.services.strategy_observation_storage import store_strategy_observations
 from app.services.strategy_registry import (
     SignalKind,
     StrategyIdentity,
@@ -149,6 +150,10 @@ class StrategyScanResult:
     status: StrategyScanStatus
     resumed_from: date | None
     rows_written: int = 0
+    durable_signal_rows: int = 0
+    retained_observation_rows: int = 0
+    aggregate_rows: int = 0
+    storage_input_bytes: int = 0
     #: Expected rows per leg — the sum of the per-instrument windows the census
     #: is checked against. Spec §9: *"a mismatch is a failure, not a log line"*.
     expected_per_leg: int = 0
@@ -206,8 +211,8 @@ def choose_frontier(last_bars: Mapping[int, date]) -> Frontier | None:
     ⚠ NOT ``max``. Spec §3: on the day this was measured 7 instruments carried a
     bar at ``2026-08-08`` and 5,783 did not. A scan keyed on the maximum
     evaluates a date most of the universe is missing and manufactures thousands
-    of refusals out of a refresh still in flight — and by ``store_signals``'
-    missing ``ON CONFLICT``, those refusals are terminal.
+    of refusals out of a refresh still in flight — every storage tier's missing
+    ``ON CONFLICT`` makes those refusals terminal.
 
     Ties break on the later date so that a corpus split evenly between two
     consecutive sessions advances rather than stalls.
@@ -852,7 +857,7 @@ def _commit_strategy(
             eligible_instruments=eligible_instruments,
         )
         with conn.transaction():
-            written = store_signals(conn, rows)
+            storage = store_strategy_observations(conn, rows)
             advance_watermark(
                 conn,
                 strategy_id=plan.entry.strategy_id,
@@ -877,7 +882,11 @@ def _commit_strategy(
         strategy_version=plan.version,
         status="written",
         resumed_from=plan.watermark,
-        rows_written=written,
+        rows_written=storage.logical_rows,
+        durable_signal_rows=storage.fired_rows,
+        retained_observation_rows=storage.retained_observation_rows,
+        aggregate_rows=storage.aggregate_rows,
+        storage_input_bytes=storage.input_payload_bytes,
         expected_per_leg=expected_per_leg,
         instruments_evaluated=instruments_evaluated,
         census={key: count for bucket in census.values() for key, count in bucket.items()},
@@ -904,12 +913,17 @@ def log_report(report: ScanReport) -> None:
     )
     for result in report.per_strategy:
         logger.info(
-            "  %s %s (%s) resumed_from=%s rows=%d expected_per_leg=%d instruments=%d%s",
+            "  %s %s (%s) resumed_from=%s logical_rows=%d durable_fired=%d retained_detail=%d "
+            "aggregate_rows=%d input_bytes=%d expected_per_leg=%d instruments=%d%s",
             result.strategy_id,
             result.status,
             result.strategy_version,
             result.resumed_from,
             result.rows_written,
+            result.durable_signal_rows,
+            result.retained_observation_rows,
+            result.aggregate_rows,
+            result.storage_input_bytes,
             result.expected_per_leg,
             result.instruments_evaluated,
             f" error={result.error}" if result.error else "",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -370,6 +370,9 @@ JOB_PRICE_QUARANTINE_REFRESH = "price_quarantine_refresh"
 # if candles have not moved, the frontier has not moved, and the watermark makes
 # the run a no-op. See app/services/strategy_signal_scan.py.
 JOB_STRATEGY_SIGNAL_SCAN = "strategy_signal_scan"
+# #2448 — range-partition retention. Shares ``strategy_scan`` so a partition
+# cannot be dropped while the scanner is inserting into it.
+JOB_STRATEGY_OBSERVATION_RETENTION = "strategy_observation_retention"
 # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY, and NOT because it is
 # expensive: half an hour is a scheduled job's workload. The reasons are
 # governance — criterion 5 requires a hold-out purpose a cron fire cannot
@@ -1963,10 +1966,11 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         source="strategy_scan",
         description=(
             "Daily 06:45 UTC — evaluates every strategy in "
-            "STRATEGY_MANIFEST over the validated universe and writes "
-            "strategy_signals. Runs one bar in ARREARS: a signal on "
+            "STRATEGY_MANIFEST over the validated universe. Fired signals are "
+            "durable; routine detail is retained 90 days with durable counts. "
+            "Runs one bar in ARREARS: a signal on "
             "the last bar of a series has no t+1, so it is "
-            "not_evaluable/no_fill_bar, and store_signals has no ON "
+            "not_evaluable/no_fill_bar, and the stores have no ON "
             "CONFLICT to correct it with — a same-day scan would "
             "record 6,185 real fired decisions a day as permanently "
             "unevaluable (measured, full population). The date it "
@@ -1993,6 +1997,20 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         # new frontier, so it writes the whole gap. Catching up on boot would
         # fire a ~2-minute full-corpus pass on every dev-stack restart for a day
         # the next scheduled fire covers anyway.
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_STRATEGY_OBSERVATION_RETENTION,
+        display_name="Strategy observation retention (#2448)",
+        source="strategy_scan",
+        description=(
+            "Daily 07:05 UTC — after the 06:45 signal scan, drops whole expired "
+            "range partitions: negative signal detail after 90 days, 30m bars "
+            "after 24 months, 5m bars after 12 months and 1m bars after 30 days. "
+            "Fired signals and daily counts are durable. Never issues a mass DELETE."
+        ),
+        cadence=Cadence.daily(hour=7, minute=5),
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
     ),
@@ -4911,6 +4929,23 @@ def strategy_signal_scan() -> None:
         # run would be recorded green with a strategy silently dark.
         if failed:
             raise RuntimeError(f"strategy_signal_scan: {len(failed)} strategy(ies) failed: {failed}")
+
+
+def strategy_observation_retention() -> None:
+    """Drop only complete expired #2448 observation partitions."""
+    from datetime import UTC, datetime
+
+    from app.services.strategy_observation_storage import drop_expired_partitions
+
+    with _tracked_job(JOB_STRATEGY_OBSERVATION_RETENTION) as tracker:
+        with connect_job() as conn:
+            plan = drop_expired_partitions(conn, as_of=datetime.now(tz=UTC), dry_run=False)
+            tracker.row_count = len(plan.partitions)
+        logger.info(
+            "strategy_observation_retention: dropped %d signal + %d intraday partitions",
+            len(plan.signal_partitions),
+            len(plan.intraday_partitions),
+        )
 
 
 def strategy_backtest_run(params: Mapping[str, Any]) -> None:

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -1,7 +1,7 @@
 # Strategy automation control plane — ownership, allocation and monitoring
 
 Date: 2026-08-09
-Status: Slices 1–3 implemented through read-only monitoring; no strategy orders enabled
+Status: Slices 1–4 implemented through bounded read-only monitoring; no strategy orders enabled
 Parent: #2437
 Companion: `2026-08-09-evidence-backed-signal-engine.md`
 
@@ -275,13 +275,19 @@ not copied into the general `positions` aggregate and not duplicated on every
 signal. The strategy page uses strategy-owned rows only. The main portfolio page
 continues to show the complete account, including manual and automated positions.
 
-The current signal scanner writes `instrument x declared signal leg x session`
-verdicts, not merely `universe x strategy`. The 2026-08-09 scan wrote 34,698
-rows; at 252 sessions that is **8.74 million rows/year**. The measured relation
-cost was about 963 bytes/row including indexes, implying roughly **8.42 GB/year**
-if its present detail and index shape is retained. Re-run
-`scripts/verify_2437_observation_storage.py` for current figures. Partitioning
-and retention must precede intraday verdicts. A proposed bounded policy is:
+The 2026-08-09 scan evaluated 34,698 logical rows; the old all-detail shape
+projected **8.42 GB/year**. Slice 4 now stores only fired detail durably, retains
+routine detail in 90-day monthly partitions, and keeps a durable daily census.
+The one-time move proved zero aggregate/detail mismatches and zero outcome
+dependencies on routine verdicts before moving 29,527 rows. Monitoring's scan
+aggregate fell from 15.6 ms to 0.05 ms.
+
+The accepted intraday candidate stores only completed OHLCV bars under the
+fixed 30m/1,000/24m, 5m/250/12m and 1m/50/30d caps. Two earlier physical shapes
+were rejected at 2.99 GB and 2.28 GB. The watermark + BRIN shape measured 117.5
+bytes/row and **1.410 GB** at all caps, with an 8.7 ms representative read.
+Re-run `scripts/verify_2437_observation_storage.py --benchmark`; details are in
+`2026-08-09-strategy-observation-storage.md`. The shipped policy is:
 
 - fired entry/exit signals and their outcomes: durable;
 - individual not-fired/not-evaluable daily rows: 90 days after a checked daily
@@ -290,9 +296,10 @@ and retention must precede intraday verdicts. A proposed bounded policy is:
 - intraday evaluations: write fired candidates plus aggregates, not one
   `not_fired` row per instrument per minute.
 
-No deletion policy ships until a verifier proves aggregate counts equal the
-detail rows and no outcome/holdout/result foreign key depends on the deletion
-set. Retention drops partitions; it does not issue recurring mass deletes.
+The deletion policy shipped only after the verifier proved aggregate/detail
+equality and enumerated the one inbound dependency (`strategy_outcomes`), which
+cannot reference a routine verdict through its writer. Recurring retention drops
+partitions; it never issues mass row deletes.
 
 ## What "test every strategy or combination" means
 
@@ -340,9 +347,11 @@ are actually created.
    `complete` for S-1 through S-3, while the remaining registered windows render
    their measured `missing`/`partial` state and S-4 retains its explicit builder
    exclusion.
-4. **Storage benchmark and retention:** actual bytes/query plans for signal
-   partitions, compact aggregates, preflight state changes and bounded intraday
-   bars. Migration follows evidence, not vice versa.
+4. **Storage benchmark and retention — implemented:** actual temporary-table
+   bytes/query plans rejected two oversized candidates; durable fired signals,
+   90-day routine-detail partitions, daily aggregates, capped intraday bar
+   partitions, monotonic watermarks, BRIN reads and whole-partition retention
+   now enforce the measured 1.5 GB retained-tier budget.
 5. **Promotion/deployment + ownership schema:** no broker writer yet. Enforce one
    signal funding decision, exact order/trade/position links and immutable stage
    changes.

--- a/docs/proposals/ta/2026-08-09-strategy-observation-storage.md
+++ b/docs/proposals/ta/2026-08-09-strategy-observation-storage.md
@@ -1,0 +1,110 @@
+# Bounded strategy observation storage
+
+Date: 2026-08-09
+Status: Implemented
+Parent: #2437
+Ticket: #2448
+
+## Decision
+
+The signal/outcome evidence chain remains complete without retaining every
+routine verdict forever:
+
+- fired signals stay durable in `strategy_signals` because outcomes and future
+  trade ownership refer to `signal_id`;
+- not-fired/not-evaluable detail moves to monthly
+  `strategy_signal_observations` partitions and is retained for 90 days;
+- `strategy_signal_daily_counts` durably retains every
+  strategy/version/date/kind/verdict/reason count;
+- the scanner writes all three destinations and its watermark in one
+  per-strategy transaction, without conflict suppression;
+- a daily 07:05 job drops complete expired leaf partitions, never row-level
+  deletes;
+- intraday storage holds completed OHLCV bars only—no ticks, forming bars or
+  derived indicator series.
+
+The one-time migration from the old mixed signal ledger first proves daily
+aggregate equality and that no outcome refers to a non-fired row, moves the
+still-retained detail, proves equality again, and only then removes those rows
+from the durable fired ledger. The recurring path cannot issue that delete.
+
+Splitting detail does not weaken the old one-verdict-per-logical-key rule. The
+writer rejects duplicate keys inside a batch, serialises each strategy/version,
+checks the opposite detail table before writing, and rejects dates behind the
+scan watermark. The watermark preserves terminality after negative detail has
+expired without retaining another per-instrument key relation.
+
+## Fixed caps and backpressure
+
+| tier | instruments | regular-session bars/day | retention | partition |
+| --- | ---: | ---: | ---: | --- |
+| context | 1,000 | 13 × 30m | 24 months | monthly |
+| setup | 250 | 78 × 5m | 12 months | monthly |
+| execution | 50 | 390 × 1m | 30 days | daily |
+
+`store_intraday_bars` rejects an unknown tier, an over-wide retained universe,
+too many stored-plus-incoming bars for one instrument/day, duplicate keys
+inside a batch, unaligned or future/forming bar times, invalid OHLCV, and any
+bar outside the tier's retained horizon or at/behind the durable per-tier/
+instrument watermark. A transaction lock
+serialises each tier's cap/watermark decision, closing the concurrent first-
+write race without adding a per-bar btree. It inserts in instrument/time order
+so the BRIN ranges remain useful. This is a storage API, not an ingest source;
+no recurring intraday fetch is enabled by this ticket.
+
+## Measured design iterations
+
+Reproduce with:
+
+```bash
+PYTHONPATH=. uv run python scripts/verify_2437_observation_storage.py --benchmark
+```
+
+The script uses rollback-only temporary tables populated from the developer
+corpus. On 2026-08-09 it measured:
+
+| shape | bytes/row incl. indexes | capped projection | decision |
+| --- | ---: | ---: | --- |
+| numeric OHLCV + two btrees | 247.9 | 2.99 GB | rejected |
+| double OHLCV + one btree | 189.2 | 2.28 GB | rejected |
+| double OHLCV + monotonic watermark + BRIN | 117.5 | 1.422 GB | accepted |
+
+The accepted 200,000-row sample used 23,412,736 heap bytes and 49,152 index
+bytes, inserted in 0.25 seconds, and served a representative bounded
+instrument/time reads in 8-11 ms across repeated runs. Projection rounds measured bytes-per-row upward;
+the code-enforced check fails if a future
+shape exceeds the 1.5 GB retained-tier budget.
+
+The current fired population measured 405.6 bytes/row under its fired-only
+indexes, projecting 0.528 GB/year at the measured peak 5,171 fired rows per
+trading day. Negative detail measured 309.1 bytes/row and is bounded by a
+90-day cutoff applied to complete monthly partitions (at most one partial-month
+overhang), rather than annual accumulation. The durable daily census has only
+46 groups for the current 34,698 logical rows.
+
+The existing all-detail design was 33.4 MB for 34,698 rows and projected 8.42
+GB/year. After routing monitoring to the count table, the current-version scan
+aggregate fell from 15.6 ms over detail to 0.05 ms over two cached count pages.
+
+## Retention safety
+
+The verifier compares the daily census in both directions against all durable
+fired detail and the most recent 90 days of negative detail using `EXCEPT ALL`.
+Older routine counts deliberately remain durable after their detail partition
+expires and are outside that detail-parity window. The measured mismatch count
+is zero. It also enumerates inbound foreign keys; only
+`strategy_outcomes.signal_id` protects `strategy_signals`, and the migration
+proves none of those rows refers to a routine verdict before moving data.
+
+`retention_plan` discovers only leaf relations whose names match the closed
+partition vocabulary and whose entire date bound is expired. `DROP TABLE` uses
+an SQL identifier sourced from `pg_class`, never request text. Tests prove a dry
+run, actual whole-partition drop, and preservation of current partitions. Once
+all retained bars for a tier/instrument have expired, the small watermark row is
+deleted too; that permits bounded universe rotation without deleting bar rows.
+
+## What remains disabled
+
+No intraday source, signal evaluator, deployment, allocation or broker writer is
+enabled here. The schema makes their future storage bounded; it does not make
+their data available or their strategies promotable.

--- a/scripts/verify_2437_observation_storage.py
+++ b/scripts/verify_2437_observation_storage.py
@@ -1,15 +1,21 @@
-"""Size #2437 observation tiers and existing signal detail against the database.
+"""Size #2437 observation tiers and verify #2448's bounded schema.
 
 Run:
     PYTHONPATH=. uv run python scripts/verify_2437_observation_storage.py
+    PYTHONPATH=. uv run python scripts/verify_2437_observation_storage.py --benchmark
 
-Read-only. Nothing is written. The output is an acceptance input for the storage
-benchmark slice, not permission to create the proposed tables.
+The default census is read-only. ``--benchmark`` creates transaction-local
+temporary tables, measures inserts/indexes/query plans, and rolls them back;
+nothing persists after the connection closes.
 """
 
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass
+from math import ceil
+from time import perf_counter
+from typing import Any, LiteralString, cast
 
 import psycopg
 
@@ -18,6 +24,7 @@ from app.config import settings
 TRADING_DAYS = 252
 RTH_MINUTES = 390
 REFERENCE_BYTES_PER_ROW = 143
+ANNUAL_OBSERVATION_GROWTH_BUDGET_BYTES = 1_500_000_000
 
 
 @dataclass(frozen=True)
@@ -34,7 +41,7 @@ class Tier:
 
 
 TIERS = (
-    Tier("30-minute context", instruments=1_000, minutes_per_bar=30, retained_days=TRADING_DAYS),
+    Tier("30-minute context", instruments=1_000, minutes_per_bar=30, retained_days=TRADING_DAYS * 2),
     Tier("5-minute setup", instruments=250, minutes_per_bar=5, retained_days=TRADING_DAYS),
     Tier("1-minute execution", instruments=50, minutes_per_bar=1, retained_days=30),
 )
@@ -75,7 +82,209 @@ def measured_bytes_per_row(rows: int, total_bytes: int) -> float | None:
     return total_bytes / rows if rows else None
 
 
+def _scalar(conn: psycopg.Connection[Any], query: str) -> int:
+    row = conn.execute(cast(LiteralString, query)).fetchone()
+    if row is None:
+        raise RuntimeError("measurement query returned no row")
+    return int(row[0])
+
+
+def _benchmark_candidate_tables(conn: psycopg.Connection[Any], *, sample_rows: int = 200_000) -> None:
+    """Measure the deployed row shapes without leaving a persistent relation."""
+    conn.execute("CREATE TEMP TABLE bench_fired_signals (LIKE strategy_signals INCLUDING ALL)")
+    started = perf_counter()
+    conn.execute("INSERT INTO bench_fired_signals SELECT * FROM strategy_signals WHERE verdict = 'fired'")
+    fired_insert_s = perf_counter() - started
+    fired_rows = _scalar(conn, "SELECT count(*) FROM bench_fired_signals")
+    fired_bytes = _scalar(conn, "SELECT pg_total_relation_size('bench_fired_signals')")
+
+    conn.execute("CREATE TEMP TABLE bench_signal_detail (LIKE strategy_signal_observations INCLUDING ALL)")
+    started = perf_counter()
+    conn.execute(
+        """
+        INSERT INTO bench_signal_detail (
+            strategy_id, strategy_version, instrument_id, signal_bar_date,
+            signal_kind, verdict, reason_code, created_at
+        )
+        SELECT strategy_id, strategy_version, instrument_id, signal_bar_date,
+               signal_kind, verdict, reason_code, created_at
+        FROM strategy_signal_observations
+        """
+    )
+    detail_insert_s = perf_counter() - started
+    detail_rows = _scalar(conn, "SELECT count(*) FROM bench_signal_detail")
+    detail_bytes = _scalar(conn, "SELECT pg_total_relation_size('bench_signal_detail')")
+
+    conn.execute("CREATE TEMP TABLE bench_daily_counts (LIKE strategy_signal_daily_counts INCLUDING ALL)")
+    started = perf_counter()
+    conn.execute("INSERT INTO bench_daily_counts SELECT * FROM strategy_signal_daily_counts")
+    count_insert_s = perf_counter() - started
+    count_rows = _scalar(conn, "SELECT count(*) FROM bench_daily_counts")
+    count_bytes = _scalar(conn, "SELECT pg_total_relation_size('bench_daily_counts')")
+
+    conn.execute("CREATE TEMP TABLE bench_intraday (LIKE strategy_intraday_bars INCLUDING ALL)")
+    started = perf_counter()
+    conn.execute(
+        """
+        INSERT INTO bench_intraday (
+            timeframe, bar_time, instrument_id, open, high, low, close, volume, source, captured_at
+        )
+        SELECT '5m',
+               timestamptz '2024-01-01 00:00:00+00' + row_number() OVER () * interval '5 minutes',
+               s.instrument_id, d.open, d.high, d.low, d.close, d.volume, 'research-sample', now()
+        FROM research_price_daily d
+        JOIN research_price_series s ON s.series_id = d.series_id
+        WHERE s.instrument_id IS NOT NULL
+          AND d.open > 0 AND d.high > 0 AND d.low > 0 AND d.close > 0
+          AND d.high >= GREATEST(d.open, d.close, d.low)
+          AND d.low <= LEAST(d.open, d.close, d.high)
+        LIMIT %(sample_rows)s
+        """,
+        {"sample_rows": sample_rows},
+    )
+    intraday_insert_s = perf_counter() - started
+    intraday_rows = _scalar(conn, "SELECT count(*) FROM bench_intraday")
+    intraday_heap_bytes = _scalar(conn, "SELECT pg_relation_size('bench_intraday')")
+    intraday_index_bytes = _scalar(conn, "SELECT pg_indexes_size('bench_intraday')")
+    intraday_bytes = _scalar(conn, "SELECT pg_total_relation_size('bench_intraday')")
+
+    intraday_bpr = measured_bytes_per_row(intraday_rows, intraday_bytes)
+    print("\ntemporary-table benchmark (heap + indexes, rolled back):")
+    print(
+        f"  durable fired signals:  {fired_rows:,} rows / {fired_bytes:,} bytes "
+        f"({measured_bytes_per_row(fired_rows, fired_bytes):.1f} bytes/row; {fired_insert_s:.3f}s)"
+        if fired_rows
+        else "  durable fired signals: no source rows"
+    )
+    print(
+        f"  retained signal detail: {detail_rows:,} rows / {detail_bytes:,} bytes "
+        f"({measured_bytes_per_row(detail_rows, detail_bytes):.1f} bytes/row; {detail_insert_s:.3f}s)"
+        if detail_rows
+        else "  retained signal detail: no source rows"
+    )
+    print(
+        f"  durable daily counts:   {count_rows:,} rows / {count_bytes:,} bytes "
+        f"({measured_bytes_per_row(count_rows, count_bytes):.1f} bytes/row; {count_insert_s:.3f}s)"
+        if count_rows
+        else "  durable daily counts: no source rows"
+    )
+    print(
+        f"  intraday candidate:     {intraday_rows:,} rows / {intraday_bytes:,} bytes "
+        f"(heap {intraday_heap_bytes:,}; indexes {intraday_index_bytes:,}; "
+        f"{intraday_bpr:.1f} bytes/row; {intraday_insert_s:.3f}s)"
+        if intraday_bpr is not None
+        else "  intraday candidate: no sample rows"
+    )
+    if intraday_bpr is not None:
+        # Round upward: a storage acceptance check must never gain headroom
+        # from truncating the measured relation density.
+        projected = sum(projected_bytes(tier, bytes_per_row=ceil(intraday_bpr)) for tier in TIERS)
+        print(f"  capped intraday steady state: {sum(tier.rows for tier in TIERS):,} rows / {projected / 1e9:.3f} GB")
+        if projected > ANNUAL_OBSERVATION_GROWTH_BUDGET_BYTES:
+            raise RuntimeError(
+                f"intraday caps project {projected:,} bytes, above "
+                f"{ANNUAL_OBSERVATION_GROWTH_BUDGET_BYTES:,}-byte budget"
+            )
+    if fired_rows:
+        fired_bpr = fired_bytes / fired_rows
+        daily_fired = _scalar(
+            conn,
+            """
+            SELECT COALESCE(MAX(row_count), 0)
+            FROM (
+                SELECT (created_at AT TIME ZONE 'UTC')::date, COUNT(*) AS row_count
+                FROM strategy_signals
+                WHERE verdict = 'fired'
+                GROUP BY 1
+            ) AS daily
+            """,
+        )
+        annual_fired = ceil(daily_fired * TRADING_DAYS * fired_bpr)
+        print(
+            f"  durable fired-signal growth: {annual_fired / 1e9:.3f} GB/year "
+            f"at measured peak {daily_fired:,} fired rows/day"
+        )
+        if annual_fired > ANNUAL_OBSERVATION_GROWTH_BUDGET_BYTES:
+            raise RuntimeError(
+                f"fired-signal growth projects {annual_fired:,} bytes/year, above "
+                f"{ANNUAL_OBSERVATION_GROWTH_BUDGET_BYTES:,}-byte budget"
+            )
+
+    plan = conn.execute(
+        """
+        EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+        SELECT timeframe, bar_time, open, high, low, close, volume
+        FROM bench_intraday
+        WHERE instrument_id = 1
+          AND timeframe = '5m'
+          AND bar_time >= timestamptz '2024-01-01 00:00:00+00'
+        ORDER BY bar_time DESC
+        LIMIT 500
+        """
+    ).fetchone()
+    if plan is not None:
+        payload = plan[0][0]
+        print(f"  representative intraday read: {payload['Execution Time']:.3f} ms")
+
+
+def _verify_signal_parity_and_dependencies(conn: psycopg.Connection[Any]) -> None:
+    mismatches = _scalar(
+        conn,
+        """
+        WITH detail AS (
+            SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                   verdict, COALESCE(not_evaluable_reason, '') AS reason_code, COUNT(*) AS row_count
+            FROM strategy_signals
+            GROUP BY 1, 2, 3, 4, 5, 6
+            UNION ALL
+            SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                   verdict, reason_code, COUNT(*) AS row_count
+            FROM strategy_signal_observations
+            WHERE signal_bar_date >= CURRENT_DATE - 90
+            GROUP BY 1, 2, 3, 4, 5, 6
+        ), combined AS (
+            SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                   verdict, reason_code, SUM(row_count) AS row_count
+            FROM detail
+            GROUP BY 1, 2, 3, 4, 5, 6
+        ), delta AS (
+            (SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                    verdict, reason_code, row_count
+             FROM strategy_signal_daily_counts
+             WHERE verdict = 'fired'
+                OR signal_bar_date >= CURRENT_DATE - 90
+             EXCEPT ALL
+             SELECT * FROM combined)
+            UNION ALL
+            (SELECT * FROM combined
+             EXCEPT ALL
+             SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                    verdict, reason_code, row_count
+             FROM strategy_signal_daily_counts
+             WHERE verdict = 'fired'
+                OR signal_bar_date >= CURRENT_DATE - 90)
+        )
+        SELECT COUNT(*) FROM delta
+        """,
+    )
+    dependencies = conn.execute(
+        """
+        SELECT conrelid::regclass::text, conname
+        FROM pg_constraint
+        WHERE confrelid = 'strategy_signals'::regclass
+        ORDER BY 1, 2
+        """
+    ).fetchall()
+    print(f"signal aggregate/detail parity mismatches (all fired + 90d routine): {mismatches}")
+    print(f"relations protecting fired signal ids: {[(str(row[0]), str(row[1])) for row in dependencies]}")
+    if mismatches:
+        raise RuntimeError("strategy signal aggregate/detail census is not equal; retention must not run")
+
+
 def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--benchmark", action="store_true", help="run rollback-only temporary-table benchmark")
+    args = parser.parse_args()
     query = """
         SELECT pg_database_size(current_database()),
                (SELECT count(*) FROM instruments WHERE is_tradable),
@@ -99,6 +308,10 @@ def main() -> None:
     """
     with psycopg.connect(settings.database_url) as conn:
         row = conn.execute(query).fetchone()
+        _verify_signal_parity_and_dependencies(conn)
+        if args.benchmark:
+            _benchmark_candidate_tables(conn)
+            conn.rollback()
     if row is None:
         raise RuntimeError("database sizing query returned no row")
 
@@ -128,7 +341,7 @@ def main() -> None:
         f"strategy_signals: {signal_rows:,} rows, {signal_total_bytes:,} bytes "
         f"(heap {signal_heap_bytes:,}; indexes {signal_index_bytes:,})"
     )
-    if signal_rows and latest_scan_rows:
+    if signal_rows and latest_scan_rows and signal_rows == latest_scan_rows:
         annual_rows = projected_annual_signal_rows(latest_scan_rows)
         annual_bytes = projected_annual_signal_bytes(
             latest_scan_rows,
@@ -140,7 +353,10 @@ def main() -> None:
             f"daily-detail projection {annual_rows:,} rows / {annual_bytes / 1_000_000_000:.2f} GB per year"
         )
     else:
-        print("latest successful signal scan: no measurable completed row count")
+        print(
+            f"latest successful signal scan: {latest_scan_rows:,} logical rows; "
+            "durable relation is now fired-only, so its post-move physical size is not a daily-detail projection"
+        )
     print(f"\nprojections at conservative {REFERENCE_BYTES_PER_ROW} bytes/row:")
     total = 0
     for tier in TIERS:

--- a/scripts/verify_2437_observation_storage.py
+++ b/scripts/verify_2437_observation_storage.py
@@ -20,6 +20,7 @@ from typing import Any, LiteralString, cast
 import psycopg
 
 from app.config import settings
+from app.services.strategy_observation_storage import SIGNAL_DETAIL_RETENTION_DAYS
 
 TRADING_DAYS = 252
 RTH_MINUTES = 390
@@ -228,9 +229,7 @@ def _benchmark_candidate_tables(conn: psycopg.Connection[Any], *, sample_rows: i
 
 
 def _verify_signal_parity_and_dependencies(conn: psycopg.Connection[Any]) -> None:
-    mismatches = _scalar(
-        conn,
-        """
+    parity_query = f"""
         WITH detail AS (
             SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
                    verdict, COALESCE(not_evaluable_reason, '') AS reason_code, COUNT(*) AS row_count
@@ -240,7 +239,7 @@ def _verify_signal_parity_and_dependencies(conn: psycopg.Connection[Any]) -> Non
             SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
                    verdict, reason_code, COUNT(*) AS row_count
             FROM strategy_signal_observations
-            WHERE signal_bar_date >= CURRENT_DATE - 90
+            WHERE signal_bar_date >= CURRENT_DATE - {SIGNAL_DETAIL_RETENTION_DAYS}
             GROUP BY 1, 2, 3, 4, 5, 6
         ), combined AS (
             SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
@@ -252,7 +251,7 @@ def _verify_signal_parity_and_dependencies(conn: psycopg.Connection[Any]) -> Non
                     verdict, reason_code, row_count
              FROM strategy_signal_daily_counts
              WHERE verdict = 'fired'
-                OR signal_bar_date >= CURRENT_DATE - 90
+                OR signal_bar_date >= CURRENT_DATE - {SIGNAL_DETAIL_RETENTION_DAYS}
              EXCEPT ALL
              SELECT * FROM combined)
             UNION ALL
@@ -262,10 +261,13 @@ def _verify_signal_parity_and_dependencies(conn: psycopg.Connection[Any]) -> Non
                     verdict, reason_code, row_count
              FROM strategy_signal_daily_counts
              WHERE verdict = 'fired'
-                OR signal_bar_date >= CURRENT_DATE - 90)
+                OR signal_bar_date >= CURRENT_DATE - {SIGNAL_DETAIL_RETENTION_DAYS})
         )
         SELECT COUNT(*) FROM delta
-        """,
+    """
+    mismatches = _scalar(
+        conn,
+        parity_query,
     )
     dependencies = conn.execute(
         """

--- a/sql/276_strategy_observation_storage.sql
+++ b/sql/276_strategy_observation_storage.sql
@@ -1,0 +1,121 @@
+-- 276_strategy_observation_storage.sql
+--
+-- #2448 — bounded signal and intraday observation storage.
+--
+-- The durable signal ledger keeps FIRED decisions because outcomes and future
+-- strategy trades refer to signal_id. Routine not-fired/not-evaluable detail
+-- moves to a 90-day range-partitioned observation relation, while this compact
+-- daily census remains durable. This prevents a daily scan from growing the
+-- heavily indexed strategy_signals relation by the measured 8.42 GB/year.
+
+CREATE TABLE IF NOT EXISTS strategy_signal_daily_counts (
+    strategy_id      TEXT NOT NULL,
+    strategy_version TEXT NOT NULL,
+    signal_bar_date  DATE NOT NULL,
+    signal_kind      TEXT NOT NULL CHECK (signal_kind IN ('entry', 'exit')),
+    verdict          TEXT NOT NULL CHECK (verdict IN ('fired', 'not_fired', 'not_evaluable')),
+    -- Empty string is the closed, non-null representation of "no reason" so
+    -- it can participate in the primary key. It is legal exactly when the
+    -- verdict is not `not_evaluable`.
+    reason_code      TEXT NOT NULL CHECK (reason_code IN (
+        '', 'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price'
+    )),
+    row_count        BIGINT NOT NULL CHECK (row_count > 0),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (
+        strategy_id, strategy_version, signal_bar_date,
+        signal_kind, verdict, reason_code
+    ),
+    CONSTRAINT strategy_signal_daily_counts_reason_matches_verdict CHECK (
+        (verdict = 'not_evaluable') = (reason_code <> '')
+    )
+);
+
+-- Seed the durable census before the writer changes. Idempotence is required
+-- because migrations are replayed against test databases; a conflict with a
+-- different count is deliberately not overwritten.
+INSERT INTO strategy_signal_daily_counts (
+    strategy_id, strategy_version, signal_bar_date,
+    signal_kind, verdict, reason_code, row_count
+)
+SELECT strategy_id, strategy_version, signal_bar_date,
+       signal_kind, verdict, COALESCE(not_evaluable_reason, ''), COUNT(*)
+FROM strategy_signals
+GROUP BY strategy_id, strategy_version, signal_bar_date,
+         signal_kind, verdict, COALESCE(not_evaluable_reason, '')
+ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS strategy_signal_observations (
+    strategy_id      TEXT NOT NULL,
+    strategy_version TEXT NOT NULL,
+    instrument_id    BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    signal_bar_date  DATE NOT NULL,
+    signal_kind      TEXT NOT NULL CHECK (signal_kind IN ('entry', 'exit')),
+    verdict          TEXT NOT NULL CHECK (verdict IN ('not_fired', 'not_evaluable')),
+    reason_code      TEXT NOT NULL CHECK (reason_code IN (
+        '', 'missing_volume', 'missing_spread', 'insufficient_warmup',
+        'quarantined_bar', 'series_break', 'not_listed',
+        'ambiguous_intrabar', 'no_fill_bar', 'thin_cross_section',
+        'unusable_fill_price'
+    )),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (
+        strategy_id, strategy_version, instrument_id,
+        signal_bar_date, signal_kind
+    ),
+    CONSTRAINT strategy_signal_observations_reason_matches_verdict CHECK (
+        (verdict = 'not_evaluable') = (reason_code <> '')
+    )
+) PARTITION BY RANGE (signal_bar_date);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_signal_observations_instrument_date
+    ON strategy_signal_observations (instrument_id, signal_bar_date DESC);
+
+-- Intraday bars are observations, not derived indicator series and not ticks.
+-- The first partition level keeps the three independently capped/retained tiers
+-- physically separable; leaf range partitions are created by the bounded writer.
+CREATE TABLE IF NOT EXISTS strategy_intraday_bars (
+    timeframe       TEXT NOT NULL CHECK (timeframe IN ('30m', '5m', '1m')),
+    bar_time        TIMESTAMPTZ NOT NULL,
+    instrument_id   BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    open             NUMERIC NOT NULL CHECK (open > 0),
+    high             NUMERIC NOT NULL CHECK (high > 0),
+    low              NUMERIC NOT NULL CHECK (low > 0),
+    close            NUMERIC NOT NULL CHECK (close > 0),
+    volume           NUMERIC CHECK (volume IS NULL OR volume >= 0),
+    source           TEXT NOT NULL,
+    captured_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (timeframe, bar_time, instrument_id),
+    CONSTRAINT strategy_intraday_bars_ohlc_shape CHECK (
+        high >= GREATEST(open, close, low)
+        AND low <= LEAST(open, close, high)
+    )
+) PARTITION BY LIST (timeframe);
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_bars_30m
+    PARTITION OF strategy_intraday_bars FOR VALUES IN ('30m')
+    PARTITION BY RANGE (bar_time);
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_bars_5m
+    PARTITION OF strategy_intraday_bars FOR VALUES IN ('5m')
+    PARTITION BY RANGE (bar_time);
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_bars_1m
+    PARTITION OF strategy_intraday_bars FOR VALUES IN ('1m')
+    PARTITION BY RANGE (bar_time);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_intraday_bars_instrument_time
+    ON strategy_intraday_bars (instrument_id, timeframe, bar_time DESC);
+
+COMMENT ON TABLE strategy_signal_daily_counts IS
+    'Durable daily census for every evaluated strategy signal. #2448.';
+COMMENT ON TABLE strategy_signal_observations IS
+    'Non-fired/not-evaluable signal detail retained for 90 days in monthly partitions. Fired rows remain durable in strategy_signals. #2448.';
+COMMENT ON TABLE strategy_intraday_bars IS
+    'Bounded completed OHLCV bars for strategy context/setup/execution tiers; never forming bars, indicators, or ticks. #2448.';

--- a/sql/277_strategy_intraday_storage_compaction.sql
+++ b/sql/277_strategy_intraday_storage_compaction.sql
@@ -1,0 +1,28 @@
+-- 277_strategy_intraday_storage_compaction.sql
+--
+-- #2448 benchmark correction. The first candidate measured 247.9 bytes/row
+-- including indexes, projecting 2.99 GB at the declared 24m/12m/30d caps.
+-- Two indexes carried the same three keys in different orders. Keep one primary
+-- key ordered for the real consumer (timeframe + instrument + time range), and
+-- use fixed-width doubles for observational OHLCV values. Strategy maths still
+-- converts to Decimal at its decision boundary; this table is not an order or
+-- accounting ledger.
+
+DROP INDEX IF EXISTS idx_strategy_intraday_bars_instrument_time;
+
+ALTER TABLE strategy_intraday_bars
+    DROP CONSTRAINT IF EXISTS strategy_intraday_bars_pkey;
+
+ALTER TABLE strategy_intraday_bars
+    ALTER COLUMN open TYPE DOUBLE PRECISION USING open::double precision,
+    ALTER COLUMN high TYPE DOUBLE PRECISION USING high::double precision,
+    ALTER COLUMN low TYPE DOUBLE PRECISION USING low::double precision,
+    ALTER COLUMN close TYPE DOUBLE PRECISION USING close::double precision,
+    ALTER COLUMN volume TYPE DOUBLE PRECISION USING volume::double precision;
+
+ALTER TABLE strategy_intraday_bars
+    ADD CONSTRAINT strategy_intraday_bars_pkey
+    PRIMARY KEY (timeframe, instrument_id, bar_time);
+
+COMMENT ON CONSTRAINT strategy_intraday_bars_pkey ON strategy_intraday_bars IS
+    'Single uniqueness/read index: timeframe + instrument range scans ordered by bar_time. #2448 measured replacement for two-key-order indexes.';

--- a/sql/278_strategy_intraday_watermark_and_brin.sql
+++ b/sql/278_strategy_intraday_watermark_and_brin.sql
@@ -1,0 +1,26 @@
+-- 278_strategy_intraday_watermark_and_brin.sql
+--
+-- #2448 second measured correction. One btree primary key still projected the
+-- declared retained tiers at ~2.28 GB (117 bytes heap + 72 bytes index/row).
+-- A per-instrument monotonic watermark gives the single writer replay/duplicate
+-- protection in O(number of instruments), while a BRIN index stays proportional
+-- to page ranges rather than to the 12.05M retained bars. The writer inserts in
+-- instrument/time order so the BRIN ranges remain selective.
+
+ALTER TABLE strategy_intraday_bars
+    DROP CONSTRAINT IF EXISTS strategy_intraday_bars_pkey;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_intraday_bars_instrument_time_brin
+    ON strategy_intraday_bars USING BRIN (instrument_id, bar_time)
+    WITH (pages_per_range = 16);
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_watermarks (
+    timeframe      TEXT NOT NULL CHECK (timeframe IN ('30m', '5m', '1m')),
+    instrument_id  BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    last_bar_time  TIMESTAMPTZ NOT NULL,
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (timeframe, instrument_id)
+);
+
+COMMENT ON TABLE strategy_intraday_watermarks IS
+    'Monotonic per-tier/instrument frontier. The bounded intraday writer refuses bars at or behind it before append. #2448.';

--- a/sql/279_strategy_signal_fired_only_indexes.sql
+++ b/sql/279_strategy_signal_fired_only_indexes.sql
@@ -1,0 +1,18 @@
+-- 279_strategy_signal_fired_only_indexes.sql
+--
+-- #2448: after sql/276 the durable strategy_signals writer stores FIRED rows
+-- only. The per-instrument replay index has no production predicate consumer,
+-- and exclusion counts now read strategy_signal_daily_counts. Replace the
+-- strategy/version/date index with its fired-only form and remove the two write
+-- amplification paths. The PK and immutable-decision UNIQUE constraint remain.
+
+DROP INDEX IF EXISTS idx_strategy_signals_version_bar;
+DROP INDEX IF EXISTS idx_strategy_signals_instrument_bar;
+DROP INDEX IF EXISTS idx_strategy_signals_reason;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_signals_fired_version_bar
+    ON strategy_signals (strategy_id, strategy_version, signal_bar_date)
+    WHERE verdict = 'fired';
+
+COMMENT ON INDEX idx_strategy_signals_fired_version_bar IS
+    'Fired-only outcome/pending-result scan. Routine verdict counts moved to strategy_signal_daily_counts in #2448.';

--- a/sql/280_strategy_signal_negative_detail_move.sql
+++ b/sql/280_strategy_signal_negative_detail_move.sql
@@ -1,0 +1,127 @@
+-- 280_strategy_signal_negative_detail_move.sql
+--
+-- #2448 one-time transition of still-retained routine verdicts out of the
+-- durable fired ledger. This is deliberately the only row DELETE in the
+-- design: recurring retention drops whole strategy_signal_observations leaf
+-- partitions. The two guards run before and after the move so no aggregate or
+-- outcome dependency can be lost.
+
+DO $$
+DECLARE
+    month_start DATE;
+    month_end DATE;
+    partition_name TEXT;
+    mismatch_count BIGINT;
+    dependent_count BIGINT;
+BEGIN
+    SELECT COUNT(*) INTO dependent_count
+    FROM strategy_outcomes o
+    JOIN strategy_signals s ON s.signal_id = o.signal_id
+    WHERE s.verdict <> 'fired';
+
+    IF dependent_count <> 0 THEN
+        RAISE EXCEPTION
+            'refusing #2448 move: % outcome row(s) refer to non-fired signal detail',
+            dependent_count;
+    END IF;
+
+    WITH detail AS (
+        SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+               verdict, COALESCE(not_evaluable_reason, '') AS reason_code,
+               COUNT(*) AS row_count
+        FROM strategy_signals
+        GROUP BY 1, 2, 3, 4, 5, 6
+    ), delta AS (
+        (SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                verdict, reason_code, row_count
+         FROM strategy_signal_daily_counts
+         EXCEPT ALL
+         SELECT * FROM detail)
+        UNION ALL
+        (SELECT * FROM detail
+         EXCEPT ALL
+         SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                verdict, reason_code, row_count
+         FROM strategy_signal_daily_counts)
+    )
+    SELECT COUNT(*) INTO mismatch_count FROM delta;
+
+    IF mismatch_count <> 0 THEN
+        RAISE EXCEPTION
+            'refusing #2448 move: daily aggregate differs from pre-move detail in % group(s)',
+            mismatch_count;
+    END IF;
+
+    FOR month_start IN
+        SELECT DISTINCT date_trunc('month', signal_bar_date)::date
+        FROM strategy_signals
+        WHERE verdict <> 'fired'
+    LOOP
+        month_end := (month_start + INTERVAL '1 month')::date;
+        partition_name := format(
+            'strategy_signal_observations_y%sm%s',
+            to_char(month_start, 'YYYY'),
+            to_char(month_start, 'MM')
+        );
+        EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF strategy_signal_observations '
+            'FOR VALUES FROM (%L) TO (%L)',
+            partition_name,
+            month_start,
+            month_end
+        );
+    END LOOP;
+
+    WITH moved AS (
+        DELETE FROM strategy_signals
+        WHERE verdict <> 'fired'
+        RETURNING strategy_id, strategy_version, instrument_id,
+                  signal_bar_date, signal_kind, verdict,
+                  COALESCE(not_evaluable_reason, '') AS reason_code,
+                  created_at
+    )
+    INSERT INTO strategy_signal_observations (
+        strategy_id, strategy_version, instrument_id, signal_bar_date,
+        signal_kind, verdict, reason_code, created_at
+    )
+    SELECT strategy_id, strategy_version, instrument_id, signal_bar_date,
+           signal_kind, verdict, reason_code, created_at
+    FROM moved;
+
+    WITH detail AS (
+        SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+               verdict, COALESCE(not_evaluable_reason, '') AS reason_code,
+               COUNT(*) AS row_count
+        FROM strategy_signals
+        GROUP BY 1, 2, 3, 4, 5, 6
+        UNION ALL
+        SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+               verdict, reason_code, COUNT(*) AS row_count
+        FROM strategy_signal_observations
+        GROUP BY 1, 2, 3, 4, 5, 6
+    ), combined AS (
+        SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+               verdict, reason_code, SUM(row_count) AS row_count
+        FROM detail
+        GROUP BY 1, 2, 3, 4, 5, 6
+    ), delta AS (
+        (SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                verdict, reason_code, row_count
+         FROM strategy_signal_daily_counts
+         EXCEPT ALL
+         SELECT * FROM combined)
+        UNION ALL
+        (SELECT * FROM combined
+         EXCEPT ALL
+         SELECT strategy_id, strategy_version, signal_bar_date, signal_kind,
+                verdict, reason_code, row_count
+         FROM strategy_signal_daily_counts)
+    )
+    SELECT COUNT(*) INTO mismatch_count FROM delta;
+
+    IF mismatch_count <> 0 THEN
+        RAISE EXCEPTION
+            'rolling back #2448 move: aggregate differs from split detail in % group(s)',
+            mismatch_count;
+    END IF;
+END $$;

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -177,6 +177,34 @@ def test_completed_zero_signal_scan_uses_its_watermark(
     assert strategy.scan.not_evaluable == 0
 
 
+def test_scan_health_reads_durable_daily_counts_after_detail_retention(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    version = _current_versions()[strategy_id]
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_scan_watermark (strategy_id, strategy_version, frontier_date)
+        VALUES (%s, %s, %s)
+        """,
+        (strategy_id, version, date(2026, 7, 8)),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_signal_daily_counts (
+            strategy_id, strategy_version, signal_bar_date,
+            signal_kind, verdict, reason_code, row_count
+        ) VALUES (%s, %s, %s, 'entry', 'fired', '', 17)
+        """,
+        (strategy_id, version, date(2026, 7, 7)),
+    )
+
+    overview = get_strategy_overview(ebull_test_conn)
+    strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+
+    assert strategy.scan.fired_entries == 17
+
+
 def test_overview_maps_only_exact_current_holdout_provenance(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:

--- a/tests/test_signal_ledger_writer_db.py
+++ b/tests/test_signal_ledger_writer_db.py
@@ -26,6 +26,7 @@ import pytest
 
 from app.services.indicator_series import BarSeries
 from app.services.signal_ledger import resolve_fills, store_signals
+from app.services.strategy_observation_storage import store_strategy_observations
 from app.services.strategy_registry import StrategyIdentity, StrategySignal
 from app.services.technical_analysis import OHLCVRow
 
@@ -89,7 +90,10 @@ def test_stored_fill_price_is_open_of_the_next_bar_in_price_daily(
         identity=_IDENTITY,
         instrument_id=instrument_id,
     )
-    assert store_signals(ebull_test_conn, rows) == len(rows)
+    report = store_strategy_observations(ebull_test_conn, rows)
+    assert report.logical_rows == len(rows)
+    assert report.fired_rows == 3
+    assert report.retained_observation_rows == 1
     ebull_test_conn.commit()
 
     # The join is the assertion: every stored fill must equal price_daily's
@@ -123,9 +127,13 @@ def test_stored_fill_price_is_open_of_the_next_bar_in_price_daily(
         # Friday → Monday. `signal_bar_date + 1 day` would be 2024-01-06.
         (date(2024, 1, 5), "fired", None, date(2024, 1, 8), Decimal("102.30")),
         (date(2024, 1, 8), "fired", None, date(2024, 1, 9), Decimal("103.40")),
-        # Acceptance 8 — the last bar has no t+1.
-        (date(2024, 1, 9), "not_evaluable", "no_fill_bar", None, None),
     ]
+    retained = ebull_test_conn.execute(
+        "SELECT signal_bar_date, verdict, reason_code FROM strategy_signal_observations WHERE instrument_id = %s",
+        (instrument_id,),
+    ).fetchall()
+    # Acceptance 8 — the last bar has no t+1, but routine detail is bounded.
+    assert retained == [(date(2024, 1, 9), "not_evaluable", "no_fill_bar")]
 
     # #2333 — the indicator rule set the signals were computed under, stored on
     # every row and equal to the one hashed into `strategy_version`. The

--- a/tests/test_strategy_observation_storage.py
+++ b/tests/test_strategy_observation_storage.py
@@ -1,0 +1,359 @@
+"""#2448 bounded strategy observation storage contracts."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.signal_ledger import LedgerRow
+from app.services.strategy_observation_storage import (
+    INTRADAY_TIERS,
+    IntradayBar,
+    drop_expired_partitions,
+    ensure_intraday_partition,
+    ensure_signal_partition,
+    store_intraday_bars,
+    store_strategy_observations,
+)
+from scripts.verify_2437_observation_storage import _verify_signal_parity_and_dependencies
+
+
+@pytest.fixture
+def observation_instruments(ebull_test_conn: psycopg.Connection[tuple]) -> tuple[int, int]:
+    with ebull_test_conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+            VALUES (%s, %s, %s, TRUE)
+            """,
+            [(998801, "OBS1", "Observation One"), (998802, "OBS2", "Observation Two")],
+        )
+    return 998801, 998802
+
+
+def _ledger_row(
+    *,
+    instrument_id: int,
+    verdict: str,
+    signal_bar_date: date = date(2026, 8, 7),
+) -> LedgerRow:
+    fired = verdict == "fired"
+    not_evaluable = verdict == "not_evaluable"
+    return LedgerRow(
+        strategy_id="s-storage-test",
+        strategy_version="strategy-registry-v1+storage",
+        instrument_id=instrument_id,
+        signal_bar_date=signal_bar_date,
+        signal_kind="entry",
+        verdict=verdict,  # type: ignore[arg-type]
+        universe="survivor_only",
+        input_rule_set_versions={"indicator_series": "indicator-v1"},
+        not_evaluable_reason="no_fill_bar" if not_evaluable else None,
+        fill_bar_date=date(2026, 8, 8) if fired else None,
+        fill_price=Decimal("101.25") if fired else None,
+    )
+
+
+def test_schema_separates_durable_counts_retained_detail_and_intraday_tiers(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    kinds = dict(
+        ebull_test_conn.execute(
+            """
+            SELECT relname, relkind
+            FROM pg_class
+            WHERE relname IN (
+                'strategy_signal_daily_counts',
+                'strategy_signal_observations',
+                'strategy_intraday_bars',
+                'strategy_intraday_bars_30m',
+                'strategy_intraday_bars_5m',
+                'strategy_intraday_bars_1m'
+            )
+            """
+        ).fetchall()
+    )
+    assert kinds == {
+        "strategy_signal_daily_counts": "r",
+        "strategy_signal_observations": "p",
+        "strategy_intraday_bars": "p",
+        "strategy_intraday_bars_30m": "p",
+        "strategy_intraday_bars_5m": "p",
+        "strategy_intraday_bars_1m": "p",
+    }
+
+
+def test_signal_batch_keeps_only_fired_detail_durable_and_census_matches(
+    ebull_test_conn: psycopg.Connection[tuple], observation_instruments: tuple[int, int]
+) -> None:
+    first, second = observation_instruments
+    rows = [
+        _ledger_row(instrument_id=first, verdict="fired"),
+        _ledger_row(instrument_id=second, verdict="not_fired"),
+        _ledger_row(instrument_id=first, verdict="not_evaluable", signal_bar_date=date(2026, 8, 6)),
+    ]
+
+    report = store_strategy_observations(ebull_test_conn, rows)
+
+    assert report.logical_rows == 3
+    assert report.fired_rows == 1
+    assert report.retained_observation_rows == 2
+    assert report.aggregate_rows == 3
+    assert report.input_payload_bytes > 0
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_signals WHERE strategy_id = 's-storage-test'"
+    ).fetchone() == (1,)
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_signal_observations WHERE strategy_id = 's-storage-test'"
+    ).fetchone() == (2,)
+    assert ebull_test_conn.execute(
+        "SELECT sum(row_count) FROM strategy_signal_daily_counts WHERE strategy_id = 's-storage-test'"
+    ).fetchone() == (Decimal("3"),)
+
+
+def test_signal_split_preserves_one_terminal_verdict_per_logical_key(
+    ebull_test_conn: psycopg.Connection[tuple], observation_instruments: tuple[int, int]
+) -> None:
+    first, _ = observation_instruments
+    routine = _ledger_row(instrument_id=first, verdict="not_fired")
+    fired = _ledger_row(instrument_id=first, verdict="fired")
+
+    with pytest.raises(ValueError, match="duplicate logical signal"):
+        store_strategy_observations(ebull_test_conn, [routine, fired])
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_signal_daily_counts WHERE strategy_id = 's-storage-test'"
+    ).fetchone() == (0,)
+
+    store_strategy_observations(ebull_test_conn, [routine])
+    with pytest.raises(ValueError, match="conflicts with a verdict in the other storage tier"):
+        store_strategy_observations(ebull_test_conn, [fired])
+    assert ebull_test_conn.execute(
+        "SELECT sum(row_count) FROM strategy_signal_daily_counts WHERE strategy_id = 's-storage-test'"
+    ).fetchone() == (Decimal("1"),)
+
+
+def test_intraday_writer_enforces_caps_alignment_and_completed_bars(
+    ebull_test_conn: psycopg.Connection[tuple], observation_instruments: tuple[int, int]
+) -> None:
+    first, second = observation_instruments
+    rows = [
+        IntradayBar(
+            timeframe="5m",
+            bar_time=datetime(2026, 8, 7, 10, 30, tzinfo=UTC),
+            instrument_id=instrument_id,
+            open=Decimal("100"),
+            high=Decimal("102"),
+            low=Decimal("99"),
+            close=Decimal("101"),
+            volume=Decimal("1000"),
+            source="fixture",
+        )
+        for instrument_id in (first, second)
+    ]
+
+    report = store_intraday_bars(
+        ebull_test_conn,
+        rows,
+        observed_at=datetime(2026, 8, 7, 10, 31, tzinfo=UTC),
+    )
+    assert report.rows_written == 2
+    assert report.instruments == 2
+    assert report.partitions_touched == 1
+    assert report.input_payload_bytes > 0
+    with pytest.raises(ValueError, match="at or behind stored watermark"):
+        store_intraday_bars(
+            ebull_test_conn,
+            [rows[0]],
+            observed_at=datetime(2026, 8, 7, 10, 32, tzinfo=UTC),
+        )
+
+    misaligned = replace(rows[0], bar_time=datetime(2026, 8, 7, 10, 32, tzinfo=UTC))
+    with pytest.raises(ValueError, match="not aligned"):
+        store_intraday_bars(
+            ebull_test_conn,
+            [misaligned],
+            observed_at=datetime(2026, 8, 7, 10, 33, tzinfo=UTC),
+        )
+
+    expired = replace(rows[0], bar_time=datetime(2024, 1, 1, 10, 30, tzinfo=UTC))
+    with pytest.raises(ValueError, match="before retained horizon"):
+        store_intraday_bars(
+            ebull_test_conn,
+            [expired],
+            observed_at=datetime(2026, 8, 7, 10, 33, tzinfo=UTC),
+        )
+
+    cap = INTRADAY_TIERS["1m"].max_instruments
+    too_wide = [
+        IntradayBar(
+            timeframe="1m",
+            bar_time=datetime(2026, 8, 7, 10, 30, tzinfo=UTC),
+            instrument_id=10_000 + index,
+            open=Decimal("100"),
+            high=Decimal("101"),
+            low=Decimal("99"),
+            close=Decimal("100"),
+            volume=None,
+            source="fixture",
+        )
+        for index in range(cap + 1)
+    ]
+    with pytest.raises(ValueError, match="cap is 50"):
+        store_intraday_bars(
+            ebull_test_conn,
+            too_wide,
+            observed_at=datetime(2026, 8, 7, 10, 31, tzinfo=UTC),
+        )
+
+
+def test_intraday_caps_apply_across_repeated_batches(
+    ebull_test_conn: psycopg.Connection[tuple], observation_instruments: tuple[int, int]
+) -> None:
+    first, _ = observation_instruments
+    base = IntradayBar(
+        timeframe="30m",
+        bar_time=datetime(2026, 8, 7, 9, 0, tzinfo=UTC),
+        instrument_id=first,
+        open=Decimal("100"),
+        high=Decimal("101"),
+        low=Decimal("99"),
+        close=Decimal("100"),
+        volume=None,
+        source="fixture",
+    )
+    first_batch = [
+        replace(base, bar_time=base.bar_time.replace(hour=9 + offset // 2, minute=30 * (offset % 2)))
+        for offset in range(7)
+    ]
+    second_batch = [
+        replace(base, bar_time=base.bar_time.replace(hour=12 + (offset + 1) // 2, minute=30 * ((offset + 1) % 2)))
+        for offset in range(7)
+    ]
+    store_intraday_bars(
+        ebull_test_conn,
+        first_batch,
+        observed_at=datetime(2026, 8, 7, 12, 1, tzinfo=UTC),
+    )
+    with pytest.raises(ValueError, match="would contain 14 bars"):
+        store_intraday_bars(
+            ebull_test_conn,
+            second_batch,
+            observed_at=datetime(2026, 8, 7, 16, 1, tzinfo=UTC),
+        )
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_intraday_bars WHERE timeframe = '30m' AND instrument_id = %s",
+        (first,),
+    ).fetchone() == (7,)
+
+    instrument_ids = list(range(999_000, 999_051))
+    with ebull_test_conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+            VALUES (%s, %s, %s, TRUE)
+            """,
+            [
+                (instrument_id, f"WIDTH{offset}", f"Width {offset}")
+                for offset, instrument_id in enumerate(instrument_ids)
+            ],
+        )
+    minute_base = replace(base, timeframe="1m", bar_time=datetime(2026, 8, 7, 10, 0, tzinfo=UTC))
+    store_intraday_bars(
+        ebull_test_conn,
+        [replace(minute_base, instrument_id=instrument_id) for instrument_id in instrument_ids[:25]],
+        observed_at=datetime(2026, 8, 7, 10, 1, tzinfo=UTC),
+    )
+    with pytest.raises(ValueError, match="retained universe would contain 51 instruments"):
+        store_intraday_bars(
+            ebull_test_conn,
+            [
+                replace(
+                    minute_base,
+                    instrument_id=instrument_id,
+                    bar_time=datetime(2026, 8, 7, 10, 1, tzinfo=UTC),
+                )
+                for instrument_id in instrument_ids[25:]
+            ],
+            observed_at=datetime(2026, 8, 7, 10, 2, tzinfo=UTC),
+        )
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_intraday_bars WHERE timeframe = '1m'").fetchone() == (
+        25,
+    )
+
+
+def test_retention_drops_whole_expired_partitions_and_keeps_current(
+    ebull_test_conn: psycopg.Connection[tuple],
+    observation_instruments: tuple[int, int],
+) -> None:
+    first, _ = observation_instruments
+    expired_signal = ensure_signal_partition(ebull_test_conn, date(2020, 1, 15))
+    current_signal = ensure_signal_partition(ebull_test_conn, date(2026, 8, 1))
+    expired_intraday = ensure_intraday_partition(
+        ebull_test_conn,
+        "1m",
+        datetime(2020, 1, 1, tzinfo=UTC),
+    )
+    current_intraday = ensure_intraday_partition(
+        ebull_test_conn,
+        "30m",
+        datetime(2026, 8, 1, tzinfo=UTC),
+    )
+    as_of = datetime(2026, 8, 9, tzinfo=UTC)
+    store_strategy_observations(
+        ebull_test_conn,
+        [_ledger_row(instrument_id=first, verdict="not_fired", signal_bar_date=date(2020, 1, 1))],
+    )
+    # Deliberate raw fixture: production writes reject already-expired bars, but
+    # retention still needs to prove it can clean legacy data and its watermark.
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_intraday_bars (
+            timeframe, bar_time, instrument_id, open, high, low, close, source
+        ) VALUES ('1m', TIMESTAMPTZ '2020-01-01 10:00:00+00', %s, 100, 101, 99, 100, 'expired-fixture')
+        """,
+        (first,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_intraday_watermarks (timeframe, instrument_id, last_bar_time)
+        VALUES ('1m', %s, TIMESTAMPTZ '2020-01-01 10:00:00+00')
+        """,
+        (first,),
+    )
+
+    plan = drop_expired_partitions(ebull_test_conn, as_of=as_of)
+    assert expired_signal in plan.signal_partitions
+    assert expired_intraday in plan.intraday_partitions
+    assert current_signal not in plan.partitions
+    assert current_intraday not in plan.partitions
+
+    dropped = drop_expired_partitions(ebull_test_conn, as_of=as_of, dry_run=False)
+    assert dropped == plan
+    assert ebull_test_conn.execute("SELECT to_regclass(%s)", (expired_signal,)).fetchone() == (None,)
+    assert ebull_test_conn.execute("SELECT to_regclass(%s)", (expired_intraday,)).fetchone() == (None,)
+    assert ebull_test_conn.execute("SELECT to_regclass(%s)", (current_signal,)).fetchone() == (current_signal,)
+    assert ebull_test_conn.execute("SELECT to_regclass(%s)", (current_intraday,)).fetchone() == (current_intraday,)
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_signal_daily_counts WHERE strategy_id = 's-storage-test'"
+    ).fetchone() == (1,)
+    _verify_signal_parity_and_dependencies(ebull_test_conn)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_scan_watermark (
+            strategy_id, strategy_version, frontier_date
+        ) VALUES ('s-storage-test', 'strategy-registry-v1+storage', DATE '2020-01-02')
+        """
+    )
+    with pytest.raises(ValueError, match="precedes terminal watermark"):
+        store_strategy_observations(
+            ebull_test_conn,
+            [_ledger_row(instrument_id=first, verdict="fired", signal_bar_date=date(2020, 1, 1))],
+        )
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_intraday_watermarks WHERE timeframe = '1m' AND instrument_id = %s",
+        (first,),
+    ).fetchone() == (0,)

--- a/tests/test_verify_2437_observation_storage.py
+++ b/tests/test_verify_2437_observation_storage.py
@@ -12,7 +12,7 @@ from scripts.verify_2437_observation_storage import (
 
 def test_declared_tier_row_caps_are_stable() -> None:
     assert {tier.name: tier.rows for tier in TIERS} == {
-        "30-minute context": 3_276_000,
+        "30-minute context": 6_552_000,
         "5-minute setup": 4_914_000,
         "1-minute execution": 585_000,
     }


### PR DESCRIPTION
Closes #2448
Refs #2437

## Outcome

Makes signal and intraday observation storage measurably bounded without weakening the terminal signal ledger. Fired signals and compact daily census counts remain durable; routine detail and completed intraday bars use whole-partition retention. No intraday ingest or broker execution is enabled.

## Measured decisions

- Rejected numeric OHLCV plus two btrees: 2.99 GB projected.
- Rejected double OHLCV plus one btree: 2.28 GB projected.
- Accepted double OHLCV plus monotonic watermark and BRIN: 117.5 bytes/row, 1.422 GB at all declared caps.
- Fired-only detail projects 0.528 GB/year at the measured peak 5,171 fired rows/day.
- Current-version monitoring aggregate improved from 15.6 ms to 0.05 ms.
- One-time move preserved 34,698 logical rows: 5,171 fired durable rows plus 29,527 retained routine rows; parity mismatch is zero.

## Safety

- Width, stored-plus-incoming daily counts, retention horizons, completion, alignment, watermark and OHLCV constraints are enforced transactionally.
- Cross-table and watermark guards preserve one terminal verdict per logical signal after the ledger split and after routine detail expires.
- Daily retention drops complete leaves only and releases empty watermark metadata; fired outcomes and historical census counts remain durable.
- The three independent Codex review findings were FIXED: steady-state parity after expiry, cross-table logical-key uniqueness, and rejection of already-expired intraday backfills. Final review found no actionable correctness issues.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not db"` — 7,196 passed, 3 skipped
- `uv run pytest tests/smoke` — 153 passed, 3 skipped
- focused storage/API/scheduler/database suite — 149 passed
- `PYTHONPATH=. uv run python scripts/verify_2437_observation_storage.py --benchmark` — zero parity mismatches, 1.422 GB accepted projection
- `PYTHONPATH=. uv run python scripts/verify_2447_strategy_monitoring.py` — API query plans remain sub-millisecond
- repository pre-push gate — green