### PR TITLE
Strategy promotion, allocation, and exact ownership controls (#2454)

### DIFF
--- a/.claude/skills/quant/trade-lifecycle.md
+++ b/.claude/skills/quant/trade-lifecycle.md
@@ -82,6 +82,12 @@ momentum, not universally (Moreira-Muir vs Cederburg et al.).
 - ⚠⚠ **Never measure close-to-open alpha as fillable.** A measured +43.9 bps
   effect lived entirely in that unreachable window and the tradable half had the
   **opposite sign**.
+- **Ownership is exact, never inferred.** Persist strategy trade → strategy
+  entry order → detailed broker order lookup → `positionExecutions[].positionId`.
+  A strategy may patch or close only that actively owned `positionId`; never use
+  symbol/instrument matching, units, timestamps, source labels, or FIFO. A manual
+  same-instrument position has no ownership row and must remain unmodifiable by
+  strategy code, while still counting toward portfolio-wide risk.
 
 ### `INITIAL_STOP`
 

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -454,10 +454,13 @@ def claim_exact_position(
           ON sto.strategy_trade_id = t.strategy_trade_id
          AND sto.order_id = %s AND sto.purpose = 'entry'
         JOIN orders o ON o.order_id = sto.order_id AND o.execution_origin = 'strategy'
+        JOIN strategy_order_position_executions execution
+          ON execution.order_id = o.order_id
+         AND execution.broker_position_id = %s
         JOIN broker_positions p ON p.position_id = %s
         WHERE t.strategy_trade_id = %s
         """,
-        (entry_order_id, broker_position_id, strategy_trade_id),
+        (entry_order_id, broker_position_id, broker_position_id, strategy_trade_id),
     ).fetchone()
     if row is None:
         raise StrategyOwnershipError("position claim requires the exact strategy entry order and broker position id")
@@ -473,6 +476,29 @@ def claim_exact_position(
     ).fetchone()
     assert claimed is not None
     return int(claimed[0])
+
+
+def record_order_position_execution(conn: psycopg.Connection[Any], *, order_id: int, broker_position_id: int) -> None:
+    """Persist one exact position id returned by detailed strategy-order lookup.
+
+    The future reconciler owns the broker call. This broker-free control-plane
+    method records its result and refuses manual-origin orders.
+    """
+    if broker_position_id <= 0:
+        raise StrategyOwnershipError("broker_position_id must be positive")
+    row = conn.execute(
+        "SELECT execution_origin FROM orders WHERE order_id = %s",
+        (order_id,),
+    ).fetchone()
+    if row is None or row[0] != "strategy":
+        raise StrategyOwnershipError("position executions may be recorded only for a strategy-origin order")
+    conn.execute(
+        """
+        INSERT INTO strategy_order_position_executions (order_id, broker_position_id)
+        VALUES (%s, %s)
+        """,
+        (order_id, broker_position_id),
+    )
 
 
 def assert_exact_position_owned(
@@ -532,5 +558,6 @@ __all__ = [
     "decide_funding",
     "link_strategy_order",
     "promote_strategy",
+    "record_order_position_execution",
     "release_exact_position",
 ]

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -448,7 +448,7 @@ def claim_exact_position(
     """Claim the exact position returned for this trade's strategy entry order."""
     row = conn.execute(
         """
-        SELECT t.instrument_id, p.instrument_id
+        SELECT 1
         FROM strategy_trades t
         JOIN strategy_trade_orders sto
           ON sto.strategy_trade_id = t.strategy_trade_id
@@ -457,15 +457,12 @@ def claim_exact_position(
         JOIN strategy_order_position_executions execution
           ON execution.order_id = o.order_id
          AND execution.broker_position_id = %s
-        JOIN broker_positions p ON p.position_id = %s
         WHERE t.strategy_trade_id = %s
         """,
-        (entry_order_id, broker_position_id, broker_position_id, strategy_trade_id),
+        (entry_order_id, broker_position_id, strategy_trade_id),
     ).fetchone()
     if row is None:
         raise StrategyOwnershipError("position claim requires the exact strategy entry order and broker position id")
-    if row[0] != row[1]:
-        raise StrategyOwnershipError("broker position instrument does not match the strategy trade")
     claimed = conn.execute(
         """
         INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id)

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -323,10 +323,12 @@ def decide_funding(
             raise StrategyControlError("capital may only be allocated to an entry signal")
         if deployment_id is None or amount is None or amount <= 0:
             raise StrategyControlError("allocated verdict requires deployment_id and positive amount")
+        _lock_strategy(conn, str(signal[0]), str(signal[1]))
         deployment = conn.execute(
             """
             SELECT strategy_id, strategy_version, mode, capital_limit, enabled
             FROM strategy_deployments WHERE deployment_id = %s
+            FOR UPDATE
             """,
             (deployment_id,),
         ).fetchone()
@@ -334,7 +336,32 @@ def decide_funding(
             raise StrategyControlError("allocation requires an enabled deployment")
         if (deployment[0], deployment[1]) != (signal[0], signal[1]):
             raise StrategyControlError("signal and deployment strategy versions do not match")
-        if amount > Decimal(str(deployment[3])):
+        stage = current_stage(conn, str(signal[0]), str(signal[1]))
+        mode = cast(Mode, deployment[2])
+        eligible: dict[Mode, frozenset[Stage]] = {
+            "paper": frozenset({"paper_enabled", "live_enabled"}),
+            "live": frozenset({"live_enabled"}),
+        }
+        if stage not in eligible[mode]:
+            raise StrategyControlError(f"{mode} funding cannot be allocated at strategy stage {stage!r}")
+
+        # The deployment lock serialises the reservation read with concurrent
+        # decisions. Decisions with no trade are pending; reconciliations stay
+        # reserved. Closed/failed trades release their allocation capacity.
+        reserved_row = conn.execute(
+            """
+            SELECT COALESCE(SUM(d.amount), 0)
+            FROM strategy_funding_decisions d
+            LEFT JOIN strategy_trades t
+              ON t.funding_decision_id = d.funding_decision_id
+            WHERE d.deployment_id = %s AND d.verdict = 'allocated'
+              AND (t.strategy_trade_id IS NULL OR t.status NOT IN ('closed', 'failed'))
+            """,
+            (deployment_id,),
+        ).fetchone()
+        assert reserved_row is not None
+        reserved = Decimal(str(reserved_row[0]))
+        if reserved + amount > Decimal(str(deployment[3])):
             raise StrategyControlError("allocation exceeds the deployment capital_limit")
     elif deployment_id is not None or amount is not None:
         raise StrategyControlError("rejected verdict cannot reserve deployment capital")

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -1,0 +1,509 @@
+"""Operator-governed strategy promotion, allocation, and exact ownership.
+
+This module is intentionally broker-free.  It creates the durable authority a
+later executor must prove, but cannot place, patch, or close an order itself.
+Manual order paths remain in :mod:`app.services.order_client` and never acquire
+strategy ownership by instrument coincidence.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal, cast
+
+import psycopg
+import psycopg.rows
+
+Stage = Literal[
+    "research_candidate",
+    "historical_validated",
+    "forward_observation",
+    "paper_enabled",
+    "live_enabled",
+    "paused",
+    "retired",
+]
+Mode = Literal["paper", "live"]
+
+GOVERNANCE_GATE_VERSION = "strategy-governance-v1"
+
+# Two-key Postgres advisory-lock namespace.  2454 is this issue's stable,
+# documented namespace; hashtext(strategy identity) supplies the per-version
+# key.  Do not reuse 2454 for an unrelated advisory lock.
+_ADVISORY_LOCK_NAMESPACE = 2454
+
+_NEXT_STAGE: dict[Stage | None, frozenset[Stage]] = {
+    None: frozenset({"research_candidate"}),
+    "research_candidate": frozenset({"historical_validated", "paused"}),
+    "historical_validated": frozenset({"forward_observation", "paused"}),
+    "forward_observation": frozenset({"paper_enabled", "paused"}),
+    "paper_enabled": frozenset({"live_enabled", "paused"}),
+    "live_enabled": frozenset({"paused"}),
+    "paused": frozenset({"retired"}),
+    "retired": frozenset(),
+}
+
+_RESULT_EVIDENCE_STAGES = frozenset({"historical_validated", "forward_observation"})
+_EXTERNAL_EVIDENCE_STAGES = frozenset({"historical_validated", "forward_observation", "paper_enabled", "live_enabled"})
+
+
+class StrategyControlError(ValueError):
+    """A fail-closed control-plane refusal."""
+
+
+class StrategyOwnershipError(StrategyControlError):
+    """The exact broker position is not actively owned by this trade."""
+
+
+@dataclass(frozen=True)
+class Promotion:
+    promotion_id: int
+    strategy_id: str
+    strategy_version: str
+    from_stage: Stage | None
+    to_stage: Stage
+
+
+@dataclass(frozen=True)
+class Deployment:
+    deployment_id: int
+    strategy_id: str
+    strategy_version: str
+    mode: Mode
+    capital_limit: Decimal
+    enabled: bool
+    revision: int
+
+
+def _require_text(value: str, field: str) -> None:
+    if not value.strip():
+        raise StrategyControlError(f"{field} must be non-empty")
+
+
+def _lock_strategy(conn: psycopg.Connection[Any], strategy_id: str, strategy_version: str) -> None:
+    conn.execute(
+        "SELECT pg_advisory_xact_lock(%s, hashtext(%s))",
+        (_ADVISORY_LOCK_NAMESPACE, f"{strategy_id}\x1f{strategy_version}"),
+    )
+
+
+def current_stage(conn: psycopg.Connection[Any], strategy_id: str, strategy_version: str) -> Stage | None:
+    row = conn.execute(
+        """
+        SELECT to_stage
+        FROM strategy_promotions
+        WHERE strategy_id = %s AND strategy_version = %s
+        ORDER BY promotion_id DESC
+        LIMIT 1
+        """,
+        (strategy_id, strategy_version),
+    ).fetchone()
+    return cast(Stage, row[0]) if row is not None else None
+
+
+def promote_strategy(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    to_stage: Stage,
+    promoted_by: str,
+    reason: str,
+    evidence_ref: str | None = None,
+    result_ids: Sequence[int] = (),
+    gate_version: str = GOVERNANCE_GATE_VERSION,
+) -> Promotion:
+    """Append one explicit, ordered promotion event.
+
+    Evidence is pinned, never inferred from a current metric.  Result ids must
+    belong to this exact strategy version.  Global auto/live switches are not
+    read here and therefore cannot create or advance a promotion.
+    """
+    for value, field in (
+        (strategy_id, "strategy_id"),
+        (strategy_version, "strategy_version"),
+        (promoted_by, "promoted_by"),
+        (reason, "reason"),
+        (gate_version, "gate_version"),
+    ):
+        _require_text(value, field)
+    if evidence_ref is not None:
+        _require_text(evidence_ref, "evidence_ref")
+    if len(set(result_ids)) != len(result_ids):
+        raise StrategyControlError("result_ids must be unique")
+
+    _lock_strategy(conn, strategy_id, strategy_version)
+    from_stage = current_stage(conn, strategy_id, strategy_version)
+    if to_stage not in _NEXT_STAGE[from_stage]:
+        raise StrategyControlError(f"invalid promotion transition: {from_stage!r} -> {to_stage!r}")
+
+    if to_stage in _EXTERNAL_EVIDENCE_STAGES and evidence_ref is None:
+        raise StrategyControlError(f"{to_stage} requires an immutable evidence_ref")
+    if to_stage in _RESULT_EVIDENCE_STAGES and not result_ids:
+        raise StrategyControlError(f"{to_stage} requires at least one pinned result_id")
+
+    if result_ids:
+        rows = conn.execute(
+            """
+            SELECT result_id
+            FROM strategy_results_store
+            WHERE strategy_id = %s AND strategy_version = %s
+              AND result_id = ANY(%s)
+            """,
+            (strategy_id, strategy_version, list(result_ids)),
+        ).fetchall()
+        found = {int(row[0]) for row in rows}
+        missing = set(result_ids) - found
+        if missing:
+            raise StrategyControlError(
+                f"result_ids do not belong to {strategy_id}@{strategy_version}: {sorted(missing)}"
+            )
+
+    row = conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id, strategy_version, from_stage, to_stage, gate_version,
+            evidence_ref, promoted_by, reason
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING promotion_id
+        """,
+        (
+            strategy_id,
+            strategy_version,
+            from_stage,
+            to_stage,
+            gate_version,
+            evidence_ref,
+            promoted_by,
+            reason,
+        ),
+    ).fetchone()
+    assert row is not None
+    promotion_id = int(row[0])
+    if result_ids:
+        with conn.cursor() as cur:
+            cur.executemany(
+                """
+                INSERT INTO strategy_promotion_results (promotion_id, result_id)
+                VALUES (%s, %s)
+                """,
+                [(promotion_id, result_id) for result_id in result_ids],
+            )
+    return Promotion(promotion_id, strategy_id, strategy_version, from_stage, to_stage)
+
+
+def configure_deployment(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    mode: Mode,
+    capital_limit: Decimal,
+    enabled: bool,
+    changed_by: str,
+    reason: str,
+    currency: str = "USD",
+) -> Deployment:
+    """Create/update one operator capital ceiling and append its audit event."""
+    for value, field in (
+        (strategy_id, "strategy_id"),
+        (strategy_version, "strategy_version"),
+        (changed_by, "changed_by"),
+        (reason, "reason"),
+        (currency, "currency"),
+    ):
+        _require_text(value, field)
+    if capital_limit < 0:
+        raise StrategyControlError("capital_limit must be non-negative")
+
+    _lock_strategy(conn, strategy_id, strategy_version)
+    stage = current_stage(conn, strategy_id, strategy_version)
+    eligible: dict[Mode, frozenset[Stage]] = {
+        "paper": frozenset({"paper_enabled", "live_enabled"}),
+        "live": frozenset({"live_enabled"}),
+    }
+    if enabled and stage not in eligible[mode]:
+        raise StrategyControlError(f"{mode} deployment cannot be enabled at stage {stage!r}")
+
+    existing = conn.execute(
+        """
+        SELECT deployment_id, revision
+        FROM strategy_deployments
+        WHERE strategy_id = %s AND strategy_version = %s AND mode = %s
+        FOR UPDATE
+        """,
+        (strategy_id, strategy_version, mode),
+    ).fetchone()
+    if existing is None:
+        revision = 1
+        row = conn.execute(
+            """
+            INSERT INTO strategy_deployments (
+                strategy_id, strategy_version, mode, capital_limit, currency,
+                enabled, revision, updated_by, reason
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING deployment_id
+            """,
+            (
+                strategy_id,
+                strategy_version,
+                mode,
+                capital_limit,
+                currency,
+                enabled,
+                revision,
+                changed_by,
+                reason,
+            ),
+        ).fetchone()
+        assert row is not None
+        deployment_id = int(row[0])
+    else:
+        deployment_id = int(existing[0])
+        revision = int(existing[1]) + 1
+        conn.execute(
+            """
+            UPDATE strategy_deployments
+            SET capital_limit = %s, currency = %s, enabled = %s,
+                revision = %s, updated_by = %s, reason = %s, updated_at = now()
+            WHERE deployment_id = %s
+            """,
+            (capital_limit, currency, enabled, revision, changed_by, reason, deployment_id),
+        )
+
+    conn.execute(
+        """
+        INSERT INTO strategy_deployment_events (
+            deployment_id, revision, capital_limit, currency, enabled,
+            changed_by, reason
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+        """,
+        (deployment_id, revision, capital_limit, currency, enabled, changed_by, reason),
+    )
+    return Deployment(
+        deployment_id,
+        strategy_id,
+        strategy_version,
+        mode,
+        capital_limit,
+        enabled,
+        revision,
+    )
+
+
+def decide_funding(
+    conn: psycopg.Connection[Any],
+    *,
+    signal_id: int,
+    verdict: Literal["allocated", "rejected"],
+    reason_code: str,
+    deployment_id: int | None = None,
+    amount: Decimal | None = None,
+    detail: str | None = None,
+) -> int:
+    """Persist the sole funding verdict for a durable fired signal."""
+    _require_text(reason_code, "reason_code")
+    if detail is not None:
+        _require_text(detail, "detail")
+    signal = conn.execute(
+        """
+        SELECT strategy_id, strategy_version, signal_kind, verdict
+        FROM strategy_signals WHERE signal_id = %s
+        FOR UPDATE
+        """,
+        (signal_id,),
+    ).fetchone()
+    if signal is None or signal[3] != "fired":
+        raise StrategyControlError("funding decisions require a fired durable signal")
+
+    if verdict == "allocated":
+        if signal[2] != "entry":
+            raise StrategyControlError("capital may only be allocated to an entry signal")
+        if deployment_id is None or amount is None or amount <= 0:
+            raise StrategyControlError("allocated verdict requires deployment_id and positive amount")
+        deployment = conn.execute(
+            """
+            SELECT strategy_id, strategy_version, mode, capital_limit, enabled
+            FROM strategy_deployments WHERE deployment_id = %s
+            """,
+            (deployment_id,),
+        ).fetchone()
+        if deployment is None or not bool(deployment[4]):
+            raise StrategyControlError("allocation requires an enabled deployment")
+        if (deployment[0], deployment[1]) != (signal[0], signal[1]):
+            raise StrategyControlError("signal and deployment strategy versions do not match")
+        if amount > Decimal(str(deployment[3])):
+            raise StrategyControlError("allocation exceeds the deployment capital_limit")
+    elif deployment_id is not None or amount is not None:
+        raise StrategyControlError("rejected verdict cannot reserve deployment capital")
+
+    row = conn.execute(
+        """
+        INSERT INTO strategy_funding_decisions (
+            signal_id, deployment_id, verdict, amount, reason_code, detail
+        ) VALUES (%s, %s, %s, %s, %s, %s)
+        RETURNING funding_decision_id
+        """,
+        (signal_id, deployment_id, verdict, amount, reason_code, detail),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def create_strategy_trade(conn: psycopg.Connection[Any], funding_decision_id: int) -> int:
+    """Create a planned trade from one allocated decision; derive its instrument."""
+    row = conn.execute(
+        """
+        SELECT d.verdict, s.instrument_id
+        FROM strategy_funding_decisions d
+        JOIN strategy_signals s ON s.signal_id = d.signal_id
+        WHERE d.funding_decision_id = %s
+        """,
+        (funding_decision_id,),
+    ).fetchone()
+    if row is None or row[0] != "allocated":
+        raise StrategyControlError("a strategy trade requires an allocated funding decision")
+    created = conn.execute(
+        """
+        INSERT INTO strategy_trades (funding_decision_id, instrument_id)
+        VALUES (%s, %s)
+        RETURNING strategy_trade_id
+        """,
+        (funding_decision_id, row[1]),
+    ).fetchone()
+    assert created is not None
+    return int(created[0])
+
+
+def link_strategy_order(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_trade_id: int,
+    order_id: int,
+    purpose: Literal["entry", "exit", "stop_loss", "take_profit", "stop_ratchet", "reconcile"],
+) -> int:
+    """Link an explicitly strategy-origin order to a same-instrument trade."""
+    row = conn.execute(
+        """
+        SELECT t.instrument_id, o.instrument_id, o.execution_origin
+        FROM strategy_trades t CROSS JOIN orders o
+        WHERE t.strategy_trade_id = %s AND o.order_id = %s
+        """,
+        (strategy_trade_id, order_id),
+    ).fetchone()
+    if row is None:
+        raise StrategyControlError("strategy trade or order does not exist")
+    if row[2] != "strategy":
+        raise StrategyControlError("manual orders cannot be linked to strategy trades")
+    if row[0] != row[1]:
+        raise StrategyControlError("strategy trade and order instruments do not match")
+    linked = conn.execute(
+        """
+        INSERT INTO strategy_trade_orders (strategy_trade_id, order_id, purpose)
+        VALUES (%s, %s, %s)
+        RETURNING strategy_trade_order_id
+        """,
+        (strategy_trade_id, order_id, purpose),
+    ).fetchone()
+    assert linked is not None
+    return int(linked[0])
+
+
+def claim_exact_position(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_trade_id: int,
+    entry_order_id: int,
+    broker_position_id: int,
+) -> int:
+    """Claim the exact position returned for this trade's strategy entry order."""
+    row = conn.execute(
+        """
+        SELECT t.instrument_id, p.instrument_id
+        FROM strategy_trades t
+        JOIN strategy_trade_orders sto
+          ON sto.strategy_trade_id = t.strategy_trade_id
+         AND sto.order_id = %s AND sto.purpose = 'entry'
+        JOIN orders o ON o.order_id = sto.order_id AND o.execution_origin = 'strategy'
+        JOIN broker_positions p ON p.position_id = %s
+        WHERE t.strategy_trade_id = %s
+        """,
+        (entry_order_id, broker_position_id, strategy_trade_id),
+    ).fetchone()
+    if row is None:
+        raise StrategyOwnershipError("position claim requires the exact strategy entry order and broker position id")
+    if row[0] != row[1]:
+        raise StrategyOwnershipError("broker position instrument does not match the strategy trade")
+    claimed = conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id)
+        VALUES (%s, %s)
+        RETURNING ownership_id
+        """,
+        (strategy_trade_id, broker_position_id),
+    ).fetchone()
+    assert claimed is not None
+    return int(claimed[0])
+
+
+def assert_exact_position_owned(
+    conn: psycopg.Connection[Any], *, strategy_trade_id: int, broker_position_id: int
+) -> None:
+    """Fail unless this exact trade/id pair has active strategy ownership."""
+    row = conn.execute(
+        """
+        SELECT 1 FROM strategy_position_ownership
+        WHERE strategy_trade_id = %s AND broker_position_id = %s
+          AND status = 'active'
+        """,
+        (strategy_trade_id, broker_position_id),
+    ).fetchone()
+    if row is None:
+        raise StrategyOwnershipError(
+            f"broker position {broker_position_id} is not actively owned by strategy trade {strategy_trade_id}"
+        )
+
+
+def release_exact_position(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_trade_id: int,
+    broker_position_id: int,
+    reason: str,
+) -> None:
+    """Release only the exact active ownership pair, preserving its history."""
+    _require_text(reason, "reason")
+    row = conn.execute(
+        """
+        UPDATE strategy_position_ownership
+        SET status = 'released', released_at = now(), release_reason = %s
+        WHERE strategy_trade_id = %s AND broker_position_id = %s
+          AND status = 'active'
+        RETURNING ownership_id
+        """,
+        (reason, strategy_trade_id, broker_position_id),
+    ).fetchone()
+    if row is None:
+        raise StrategyOwnershipError(
+            f"broker position {broker_position_id} is not actively owned by strategy trade {strategy_trade_id}"
+        )
+
+
+__all__ = [
+    "Deployment",
+    "GOVERNANCE_GATE_VERSION",
+    "Promotion",
+    "StrategyControlError",
+    "StrategyOwnershipError",
+    "assert_exact_position_owned",
+    "claim_exact_position",
+    "configure_deployment",
+    "create_strategy_trade",
+    "current_stage",
+    "decide_funding",
+    "link_strategy_order",
+    "promote_strategy",
+    "release_exact_position",
+]

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -265,6 +265,7 @@ the smallest control-plane schema is:
 | candidate decisions | fired signal x allocation verdict | 24 months detailed; durable daily aggregates |
 | strategy trades | one funded lifecycle | durable |
 | strategy trade orders | one order linked to one owned trade and purpose | durable; joins existing orders/fills |
+| order position executions | exact `positionExecutions[].positionId` returned for one strategy order | durable; typically one/few rows per entry |
 | position ownership | one broker position id claimed by one trade | durable, including released ownership |
 | stop changes | one requested/applied/failed material change | durable; no heartbeat rows |
 | preflight observations | candidate request or changed eligibility state | 24 months; no unchanged polling rows |
@@ -355,8 +356,8 @@ are actually created.
 5. **Promotion/deployment + ownership schema — implemented:** no broker writer.
    `sql/281` stores append-only ordered promotion events and pinned result ids,
    one current paper/live capital ceiling with a complete revision history, one
-   funding decision per fired signal, strategy trade/order links, and durable
-   exact broker-position ownership. Existing orders default to `manual`; a
+   funding decision per fired signal, strategy trade/order links, exact detailed
+   order `positionExecutions[]`, and durable broker-position ownership. Existing orders default to `manual`; a
    manual order cannot be linked as strategy authority. The service accepts a
    `(strategy_trade_id, broker_position_id)` pair and never an instrument-only
    mutation target. A real-Postgres same-instrument test proves an unowned manual

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -352,9 +352,18 @@ are actually created.
    90-day routine-detail partitions, daily aggregates, capped intraday bar
    partitions, monotonic watermarks, BRIN reads and whole-partition retention
    now enforce the measured 1.5 GB retained-tier budget.
-5. **Promotion/deployment + ownership schema:** no broker writer yet. Enforce one
-   signal funding decision, exact order/trade/position links and immutable stage
-   changes.
+5. **Promotion/deployment + ownership schema — implemented:** no broker writer.
+   `sql/281` stores append-only ordered promotion events and pinned result ids,
+   one current paper/live capital ceiling with a complete revision history, one
+   funding decision per fired signal, strategy trade/order links, and durable
+   exact broker-position ownership. Existing orders default to `manual`; a
+   manual order cannot be linked as strategy authority. The service accepts a
+   `(strategy_trade_id, broker_position_id)` pair and never an instrument-only
+   mutation target. A real-Postgres same-instrument test proves an unowned manual
+   position remains inaccessible while the separately claimed strategy position
+   can be released. Global auto/live switches are not read by promotion and
+   cannot change stage. Broker I/O remains absent and live execution remains
+   disabled.
 6. **Order/position reconciler:** consume detailed v2 order lookup and history;
    close the existing submitted/pending crash gap; prove same-instrument manual
    isolation in demo.

--- a/sql/281_strategy_promotion_ownership.sql
+++ b/sql/281_strategy_promotion_ownership.sql
@@ -1,0 +1,212 @@
+-- 281_strategy_promotion_ownership.sql
+--
+-- #2454 / #2437 control-plane slice 5.  This migration deliberately adds no
+-- broker writer.  It records the operator decisions that may eventually
+-- authorise one, and the exact broker position identity that every later
+-- strategy mutation must present.
+
+-- A promotion is an append-only event.  Current state is derived from the
+-- newest event; there is no mutable `promotable` boolean for a metric refresh
+-- to flip behind an operator's back.
+CREATE TABLE IF NOT EXISTS strategy_promotions (
+    promotion_id       BIGSERIAL PRIMARY KEY,
+    strategy_id        TEXT NOT NULL,
+    strategy_version   TEXT NOT NULL,
+    from_stage         TEXT,
+    to_stage           TEXT NOT NULL,
+    gate_version       TEXT NOT NULL,
+    evidence_ref       TEXT,
+    promoted_by        TEXT NOT NULL,
+    reason             TEXT NOT NULL,
+    promoted_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT strategy_promotions_from_stage_check CHECK (
+        from_stage IS NULL OR from_stage IN (
+            'research_candidate', 'historical_validated',
+            'forward_observation', 'paper_enabled', 'live_enabled',
+            'paused', 'retired'
+        )
+    ),
+    CONSTRAINT strategy_promotions_to_stage_check CHECK (to_stage IN (
+        'research_candidate', 'historical_validated',
+        'forward_observation', 'paper_enabled', 'live_enabled',
+        'paused', 'retired'
+    )),
+    CONSTRAINT strategy_promotions_non_empty CHECK (
+        strategy_id <> '' AND strategy_version <> '' AND gate_version <> ''
+        AND promoted_by <> '' AND reason <> ''
+        AND (evidence_ref IS NULL OR evidence_ref <> '')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_promotions_one_initial
+    ON strategy_promotions (strategy_id, strategy_version)
+    WHERE from_stage IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_promotions_one_successor
+    ON strategy_promotions (strategy_id, strategy_version, from_stage)
+    WHERE from_stage IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_promotions_current
+    ON strategy_promotions (strategy_id, strategy_version, promotion_id DESC);
+
+-- A promotion may pin several result arms/folds.  Real FKs are used rather
+-- than a JSON/array of ids so deleting or mistyping evidence cannot leave a
+-- promotion that merely looks evidenced.
+CREATE TABLE IF NOT EXISTS strategy_promotion_results (
+    promotion_id BIGINT NOT NULL
+        REFERENCES strategy_promotions(promotion_id) ON DELETE RESTRICT,
+    result_id BIGINT NOT NULL
+        REFERENCES strategy_results_store(result_id) ON DELETE RESTRICT,
+    PRIMARY KEY (promotion_id, result_id)
+);
+
+-- Current operator capital ceilings.  These are maxima, never instructions to
+-- spend the full amount.  Mutations are mirrored to the event table below.
+CREATE TABLE IF NOT EXISTS strategy_deployments (
+    deployment_id      BIGSERIAL PRIMARY KEY,
+    strategy_id        TEXT NOT NULL,
+    strategy_version   TEXT NOT NULL,
+    mode                TEXT NOT NULL CHECK (mode IN ('paper', 'live')),
+    capital_limit       NUMERIC(18,6) NOT NULL CHECK (capital_limit >= 0),
+    currency            TEXT NOT NULL DEFAULT 'USD',
+    enabled             BOOLEAN NOT NULL DEFAULT false,
+    revision            BIGINT NOT NULL DEFAULT 1 CHECK (revision >= 1),
+    updated_by          TEXT NOT NULL,
+    reason              TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_deployments_unique UNIQUE
+        (strategy_id, strategy_version, mode),
+    CONSTRAINT strategy_deployments_non_empty CHECK (
+        strategy_id <> '' AND strategy_version <> '' AND currency <> ''
+        AND updated_by <> '' AND reason <> ''
+    )
+);
+
+CREATE TABLE IF NOT EXISTS strategy_deployment_events (
+    deployment_event_id BIGSERIAL PRIMARY KEY,
+    deployment_id       BIGINT NOT NULL
+        REFERENCES strategy_deployments(deployment_id) ON DELETE RESTRICT,
+    revision             BIGINT NOT NULL CHECK (revision >= 1),
+    capital_limit        NUMERIC(18,6) NOT NULL CHECK (capital_limit >= 0),
+    currency             TEXT NOT NULL,
+    enabled              BOOLEAN NOT NULL,
+    changed_by           TEXT NOT NULL,
+    reason               TEXT NOT NULL,
+    changed_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_deployment_events_unique
+        UNIQUE (deployment_id, revision),
+    CONSTRAINT strategy_deployment_events_non_empty CHECK (
+        currency <> '' AND changed_by <> '' AND reason <> ''
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_deployment_events_recent
+    ON strategy_deployment_events (deployment_id, revision DESC);
+
+-- Exactly one durable verdict for each fired signal.  A rejection consumes no
+-- capital and names no deployment.  This is intentionally narrow: rationale
+-- is a bounded code plus a short operator/debug detail, not a market snapshot.
+CREATE TABLE IF NOT EXISTS strategy_funding_decisions (
+    funding_decision_id BIGSERIAL PRIMARY KEY,
+    signal_id           BIGINT NOT NULL UNIQUE
+        REFERENCES strategy_signals(signal_id) ON DELETE RESTRICT,
+    deployment_id       BIGINT
+        REFERENCES strategy_deployments(deployment_id) ON DELETE RESTRICT,
+    verdict              TEXT NOT NULL CHECK (verdict IN ('allocated', 'rejected')),
+    amount               NUMERIC(18,6),
+    reason_code          TEXT NOT NULL,
+    detail               TEXT,
+    decided_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_funding_decisions_shape CHECK (
+        (verdict = 'allocated' AND deployment_id IS NOT NULL AND amount > 0)
+        OR (verdict = 'rejected' AND deployment_id IS NULL AND amount IS NULL)
+    ),
+    CONSTRAINT strategy_funding_decisions_non_empty CHECK (
+        reason_code <> '' AND (detail IS NULL OR detail <> '')
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_funding_decisions_recent
+    ON strategy_funding_decisions (decided_at DESC);
+
+-- A strategy trade is born from one allocated funding decision.  Later slices
+-- extend the lifecycle, but ownership is already explicit and durable here.
+CREATE TABLE IF NOT EXISTS strategy_trades (
+    strategy_trade_id   BIGSERIAL PRIMARY KEY,
+    funding_decision_id BIGINT NOT NULL UNIQUE
+        REFERENCES strategy_funding_decisions(funding_decision_id) ON DELETE RESTRICT,
+    instrument_id       BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE RESTRICT,
+    status              TEXT NOT NULL DEFAULT 'planned'
+        CHECK (status IN ('planned', 'submitted', 'open', 'closing', 'closed',
+                          'failed', 'reconcile_required')),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Existing/manual order creation keeps its behaviour through this default.
+-- Automated code must opt in explicitly, and the link below supplies the
+-- strategy trade and purpose.
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS execution_origin TEXT NOT NULL DEFAULT 'manual';
+
+ALTER TABLE orders
+    DROP CONSTRAINT IF EXISTS orders_execution_origin_check;
+
+ALTER TABLE orders
+    ADD CONSTRAINT orders_execution_origin_check
+    CHECK (execution_origin IN ('manual', 'strategy'));
+
+CREATE INDEX IF NOT EXISTS idx_orders_strategy_origin
+    ON orders (created_at DESC) WHERE execution_origin = 'strategy';
+
+CREATE TABLE IF NOT EXISTS strategy_trade_orders (
+    strategy_trade_order_id BIGSERIAL PRIMARY KEY,
+    strategy_trade_id       BIGINT NOT NULL
+        REFERENCES strategy_trades(strategy_trade_id) ON DELETE RESTRICT,
+    order_id                BIGINT NOT NULL UNIQUE
+        REFERENCES orders(order_id) ON DELETE RESTRICT,
+    purpose                 TEXT NOT NULL CHECK (purpose IN (
+        'entry', 'exit', 'stop_loss', 'take_profit', 'stop_ratchet', 'reconcile'
+    )),
+    linked_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_trade_orders_one_purpose
+        UNIQUE (strategy_trade_id, purpose, order_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_trade_orders_trade
+    ON strategy_trade_orders (strategy_trade_id, linked_at);
+
+-- Deliberately no FK to broker_positions: the broker snapshot is current-state
+-- storage and legitimately removes a closed position.  Ownership must survive
+-- that removal for audit and reconciliation.  A broker id is never recycled
+-- between strategy trades; release records history rather than deleting it.
+CREATE TABLE IF NOT EXISTS strategy_position_ownership (
+    ownership_id       BIGSERIAL PRIMARY KEY,
+    strategy_trade_id  BIGINT NOT NULL
+        REFERENCES strategy_trades(strategy_trade_id) ON DELETE RESTRICT,
+    broker_position_id BIGINT NOT NULL UNIQUE CHECK (broker_position_id > 0),
+    status             TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'released')),
+    claimed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    released_at        TIMESTAMPTZ,
+    release_reason     TEXT,
+    CONSTRAINT strategy_position_ownership_release_shape CHECK (
+        (status = 'active' AND released_at IS NULL AND release_reason IS NULL)
+        OR (status = 'released' AND released_at IS NOT NULL AND release_reason <> '')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_position_one_active_trade
+    ON strategy_position_ownership (strategy_trade_id)
+    WHERE status = 'active';
+
+COMMENT ON TABLE strategy_position_ownership IS
+    'Durable exact broker position ownership for automated strategy trades. '
+    'Strategy mutation services require (strategy_trade_id, broker_position_id); '
+    'instrument/FIFO inference is forbidden. Manual positions have no row.';
+
+COMMENT ON COLUMN orders.execution_origin IS
+    'manual by default to preserve existing UI/order behaviour; strategy is '
+    'set only by the strategy executor and requires a strategy_trade_orders link.';

--- a/sql/282_strategy_multi_position_ownership.sql
+++ b/sql/282_strategy_multi_position_ownership.sql
@@ -1,0 +1,14 @@
+-- 282_strategy_multi_position_ownership.sql
+--
+-- #2454 review correction: one broker order may return several
+-- positionExecutions[].positionId values. Exact ownership retains all of them.
+
+DROP INDEX IF EXISTS idx_strategy_position_one_active_trade;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_position_active_trade
+    ON strategy_position_ownership (strategy_trade_id, broker_position_id)
+    WHERE status = 'active';
+
+COMMENT ON INDEX idx_strategy_position_active_trade IS
+    'All active exact broker positions for one strategy trade. An entry order '
+    'may produce multiple positionExecutions; every id is owned independently.';

--- a/sql/283_strategy_order_position_executions.sql
+++ b/sql/283_strategy_order_position_executions.sql
@@ -1,0 +1,22 @@
+-- 283_strategy_order_position_executions.sql
+--
+-- #2454 review correction: same-instrument identity is not provenance. The
+-- reconciler records every exact positionExecutions[].positionId returned by
+-- detailed lookup for a strategy-origin order. Ownership may be claimed only
+-- through this mapping.
+
+CREATE TABLE IF NOT EXISTS strategy_order_position_executions (
+    order_id           BIGINT NOT NULL
+        REFERENCES orders(order_id) ON DELETE RESTRICT,
+    broker_position_id BIGINT NOT NULL UNIQUE CHECK (broker_position_id > 0),
+    recorded_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (order_id, broker_position_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_order_position_executions_order
+    ON strategy_order_position_executions (order_id, broker_position_id);
+
+COMMENT ON TABLE strategy_order_position_executions IS
+    'Exact positionExecutions[].positionId values from detailed lookup of a '
+    'strategy-origin order. Same-instrument broker positions absent here are '
+    'not claimable and remain manual/unowned.';

--- a/sql/284_strategy_ownership_constraint_corrections.sql
+++ b/sql/284_strategy_ownership_constraint_corrections.sql
@@ -1,0 +1,31 @@
+-- 284_strategy_ownership_constraint_corrections.sql
+--
+-- #2454 PR review corrections. PostgreSQL CHECK accepts NULL, so released
+-- ownership must test release_reason IS NOT NULL explicitly. A trade may have
+-- several exit/ratchet/reconcile orders over its life, but exactly one entry
+-- order establishes its position-execution provenance.
+
+ALTER TABLE strategy_position_ownership
+    DROP CONSTRAINT IF EXISTS strategy_position_ownership_release_shape;
+
+ALTER TABLE strategy_position_ownership
+    ADD CONSTRAINT strategy_position_ownership_release_shape CHECK (
+        (status = 'active' AND released_at IS NULL AND release_reason IS NULL)
+        OR (
+            status = 'released'
+            AND released_at IS NOT NULL
+            AND release_reason IS NOT NULL
+            AND release_reason <> ''
+        )
+    );
+
+ALTER TABLE strategy_trade_orders
+    DROP CONSTRAINT IF EXISTS strategy_trade_orders_one_purpose;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_trade_orders_one_entry
+    ON strategy_trade_orders (strategy_trade_id)
+    WHERE purpose = 'entry';
+
+COMMENT ON INDEX idx_strategy_trade_orders_one_entry IS
+    'One entry order establishes one strategy trade; later purposes may have '
+    'multiple attempts/events and remain distinguished by order_id.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -193,6 +193,12 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # carries yet (the record is written BEFORE the row it authorises), so an FK
     # would refuse the exact ordering the trigger requires.
     "strategy_holdout_accesses",
+    # #2454 — governance roots.  Their children are discovered through inbound
+    # FKs, but neither root has an FK path from instruments.  Keeping them here
+    # prevents a promotion/deployment in one DB test becoming another test's
+    # current operator decision.
+    "strategy_promotions",
+    "strategy_deployments",
     "positions",
     "quotes",
     # #1919 — thesis generation attempts (FK → instruments + theses).

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -215,8 +215,6 @@ def test_same_instrument_manual_position_is_never_inferred_as_owned(
     strategy_position_id = 900002
     second_strategy_position_id = 900003
     _position(conn, manual_position_id, instrument_id)
-    _position(conn, strategy_position_id, instrument_id)
-    _position(conn, second_strategy_position_id, instrument_id)
     entry_order = _order(conn, instrument_id=instrument_id)
     link_strategy_order(conn, strategy_trade_id=trade_id, order_id=entry_order, purpose="entry")
 
@@ -232,6 +230,8 @@ def test_same_instrument_manual_position_is_never_inferred_as_owned(
 
     record_order_position_execution(conn, order_id=entry_order, broker_position_id=strategy_position_id)
     record_order_position_execution(conn, order_id=entry_order, broker_position_id=second_strategy_position_id)
+    # Detailed lookup commonly leads portfolio sync. Exact ownership is
+    # claimable before either strategy position enters broker_positions.
     claim_exact_position(
         conn,
         strategy_trade_id=trade_id,

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -19,6 +19,7 @@ from app.services.strategy_control_plane import (
     decide_funding,
     link_strategy_order,
     promote_strategy,
+    record_order_position_execution,
     release_exact_position,
 )
 
@@ -218,6 +219,19 @@ def test_same_instrument_manual_position_is_never_inferred_as_owned(
     _position(conn, second_strategy_position_id, instrument_id)
     entry_order = _order(conn, instrument_id=instrument_id)
     link_strategy_order(conn, strategy_trade_id=trade_id, order_id=entry_order, purpose="entry")
+
+    # Instrument equality is not provenance: the pre-existing manual position
+    # cannot be claimed because detailed lookup did not return it for this order.
+    with pytest.raises(StrategyOwnershipError, match="exact strategy entry order"):
+        claim_exact_position(
+            conn,
+            strategy_trade_id=trade_id,
+            entry_order_id=entry_order,
+            broker_position_id=manual_position_id,
+        )
+
+    record_order_position_execution(conn, order_id=entry_order, broker_position_id=strategy_position_id)
+    record_order_position_execution(conn, order_id=entry_order, broker_position_id=second_strategy_position_id)
     claim_exact_position(
         conn,
         strategy_trade_id=trade_id,

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -1,0 +1,294 @@
+"""#2454 strategy governance and exact-position ownership integration tests."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.strategy_control_plane import (
+    StrategyControlError,
+    StrategyOwnershipError,
+    assert_exact_position_owned,
+    claim_exact_position,
+    configure_deployment,
+    create_strategy_trade,
+    current_stage,
+    decide_funding,
+    link_strategy_order,
+    promote_strategy,
+    release_exact_position,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _instrument(conn: psycopg.Connection[Any], instrument_id: int = 2454001) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable)
+        VALUES (%s, %s, %s, true)
+        """,
+        (instrument_id, f"T{instrument_id}", f"Test {instrument_id}"),
+    )
+
+
+def _signal(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int = 2454001,
+    strategy_id: str = "S-OWN",
+    strategy_version: str = "v1",
+) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id, strategy_version, instrument_id, signal_bar_date,
+            signal_kind, verdict, fill_bar_date, fill_price, universe,
+            input_rule_set_versions
+        ) VALUES (%s, %s, %s, '2026-08-06', 'entry', 'fired',
+                  '2026-08-07', 100, 'survivor_only',
+                  '{"indicator_series":"rules-v1"}'::jsonb)
+        RETURNING signal_id
+        """,
+        (strategy_id, strategy_version, instrument_id),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _paper_stage(conn: psycopg.Connection[Any]) -> None:
+    """Seed an already-audited chain; transition mechanics are tested separately."""
+    conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id, strategy_version, from_stage, to_stage, gate_version,
+            evidence_ref, promoted_by, reason
+        ) VALUES
+          ('S-OWN', 'v1', NULL, 'research_candidate', 'test-v1', NULL, 'test', 'registered'),
+          ('S-OWN', 'v1', 'research_candidate', 'historical_validated', 'test-v1', 'e:hist', 'test', 'validated'),
+          ('S-OWN', 'v1', 'historical_validated', 'forward_observation', 'test-v1', 'e:fwd', 'test', 'observe'),
+          ('S-OWN', 'v1', 'forward_observation', 'paper_enabled', 'test-v1', 'e:paper', 'test', 'paper')
+        """
+    )
+
+
+def _deployment_and_trade(conn: psycopg.Connection[Any], signal_id: int) -> int:
+    deployment = configure_deployment(
+        conn,
+        strategy_id="S-OWN",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("1000"),
+        enabled=True,
+        changed_by="operator",
+        reason="test allocation",
+    )
+    decision_id = decide_funding(
+        conn,
+        signal_id=signal_id,
+        verdict="allocated",
+        deployment_id=deployment.deployment_id,
+        amount=Decimal("100"),
+        reason_code="within_risk_budget",
+    )
+    return create_strategy_trade(conn, decision_id)
+
+
+def _order(conn: psycopg.Connection[Any], *, instrument_id: int, origin: str = "strategy") -> int:
+    row = conn.execute(
+        """
+        INSERT INTO orders (
+            instrument_id, action, order_type, requested_amount, status,
+            execution_origin
+        ) VALUES (%s, 'BUY', 'MARKET', 100, 'filled', %s)
+        RETURNING order_id
+        """,
+        (instrument_id, origin),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _position(conn: psycopg.Connection[Any], position_id: int, instrument_id: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO broker_positions (
+            position_id, instrument_id, is_buy, units, amount,
+            initial_amount_in_dollars, open_rate, open_conversion_rate,
+            open_date_time, raw_payload
+        ) VALUES (%s, %s, true, 1, 100, 100, 100, 1, now(), '{}'::jsonb)
+        """,
+        (position_id, instrument_id),
+    )
+
+
+def test_promotion_is_ordered_explicit_and_evidenced(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    first = promote_strategy(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        to_stage="research_candidate",
+        promoted_by="operator",
+        reason="register preregistered candidate",
+    )
+    assert first.from_stage is None
+    assert current_stage(conn, "S-GOV", "v1") == "research_candidate"
+
+    with pytest.raises(StrategyControlError, match="invalid promotion transition"):
+        promote_strategy(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            to_stage="paper_enabled",
+            promoted_by="operator",
+            reason="skip evidence",
+            evidence_ref="invalid:skip",
+        )
+    with pytest.raises(StrategyControlError, match="requires an immutable evidence_ref"):
+        promote_strategy(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            to_stage="historical_validated",
+            promoted_by="operator",
+            reason="missing evidence",
+        )
+
+    # Runtime switches are deliberately irrelevant to governance state.
+    conn.execute("UPDATE runtime_config SET enable_auto_trading = true, enable_live_trading = true WHERE id = true")
+    assert current_stage(conn, "S-GOV", "v1") == "research_candidate"
+
+
+def test_deployment_has_one_current_row_and_complete_history(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    _paper_stage(conn)
+    first = configure_deployment(
+        conn,
+        strategy_id="S-OWN",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("1000"),
+        enabled=True,
+        changed_by="operator",
+        reason="initial paper pot",
+    )
+    second = configure_deployment(
+        conn,
+        strategy_id="S-OWN",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("750"),
+        enabled=False,
+        changed_by="operator",
+        reason="pause allocation",
+    )
+    assert second.deployment_id == first.deployment_id
+    assert second.revision == 2
+    assert conn.execute(
+        "SELECT count(*) FROM strategy_deployments WHERE strategy_id='S-OWN' AND mode='paper'"
+    ).fetchone() == (1,)
+    assert conn.execute(
+        "SELECT revision, capital_limit, enabled FROM strategy_deployment_events ORDER BY revision"
+    ).fetchall() == [(1, Decimal("1000.000000"), True), (2, Decimal("750.000000"), False)]
+
+
+def test_same_instrument_manual_position_is_never_inferred_as_owned(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    instrument_id = 2454001
+    _instrument(conn, instrument_id)
+    signal_id = _signal(conn, instrument_id=instrument_id)
+    _paper_stage(conn)
+    trade_id = _deployment_and_trade(conn, signal_id)
+
+    manual_position_id = 900001
+    strategy_position_id = 900002
+    _position(conn, manual_position_id, instrument_id)
+    _position(conn, strategy_position_id, instrument_id)
+    entry_order = _order(conn, instrument_id=instrument_id)
+    link_strategy_order(conn, strategy_trade_id=trade_id, order_id=entry_order, purpose="entry")
+    claim_exact_position(
+        conn,
+        strategy_trade_id=trade_id,
+        entry_order_id=entry_order,
+        broker_position_id=strategy_position_id,
+    )
+
+    assert_exact_position_owned(conn, strategy_trade_id=trade_id, broker_position_id=strategy_position_id)
+    with pytest.raises(StrategyOwnershipError, match="not actively owned"):
+        assert_exact_position_owned(conn, strategy_trade_id=trade_id, broker_position_id=manual_position_id)
+
+    release_exact_position(
+        conn,
+        strategy_trade_id=trade_id,
+        broker_position_id=strategy_position_id,
+        reason="paper position closed",
+    )
+    with pytest.raises(StrategyOwnershipError, match="not actively owned"):
+        assert_exact_position_owned(conn, strategy_trade_id=trade_id, broker_position_id=strategy_position_id)
+
+
+def test_manual_order_cannot_become_strategy_authority(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    instrument_id = 2454002
+    _instrument(conn, instrument_id)
+    signal_id = _signal(conn, instrument_id=instrument_id)
+    _paper_stage(conn)
+    trade_id = _deployment_and_trade(conn, signal_id)
+    manual_order = _order(conn, instrument_id=instrument_id, origin="manual")
+
+    with pytest.raises(StrategyControlError, match="manual orders cannot be linked"):
+        link_strategy_order(conn, strategy_trade_id=trade_id, order_id=manual_order, purpose="entry")
+
+
+def test_funding_is_once_only_and_cannot_exceed_operator_cap(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    _instrument(conn)
+    signal_id = _signal(conn)
+    _paper_stage(conn)
+    deployment = configure_deployment(
+        conn,
+        strategy_id="S-OWN",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("100"),
+        enabled=True,
+        changed_by="operator",
+        reason="bounded test pot",
+    )
+    with pytest.raises(StrategyControlError, match="exceeds"):
+        decide_funding(
+            conn,
+            signal_id=signal_id,
+            verdict="allocated",
+            deployment_id=deployment.deployment_id,
+            amount=Decimal("101"),
+            reason_code="invalid",
+        )
+    first = decide_funding(
+        conn,
+        signal_id=signal_id,
+        verdict="rejected",
+        reason_code="risk_budget_exhausted",
+    )
+    assert first > 0
+    with pytest.raises(psycopg.errors.UniqueViolation):
+        decide_funding(
+            conn,
+            signal_id=signal_id,
+            verdict="rejected",
+            reason_code="duplicate",
+        )

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -212,8 +212,10 @@ def test_same_instrument_manual_position_is_never_inferred_as_owned(
 
     manual_position_id = 900001
     strategy_position_id = 900002
+    second_strategy_position_id = 900003
     _position(conn, manual_position_id, instrument_id)
     _position(conn, strategy_position_id, instrument_id)
+    _position(conn, second_strategy_position_id, instrument_id)
     entry_order = _order(conn, instrument_id=instrument_id)
     link_strategy_order(conn, strategy_trade_id=trade_id, order_id=entry_order, purpose="entry")
     claim_exact_position(
@@ -222,8 +224,21 @@ def test_same_instrument_manual_position_is_never_inferred_as_owned(
         entry_order_id=entry_order,
         broker_position_id=strategy_position_id,
     )
+    # One entry order may produce several positionExecutions. Each exact id is
+    # owned independently while the same-instrument manual id remains outside.
+    claim_exact_position(
+        conn,
+        strategy_trade_id=trade_id,
+        entry_order_id=entry_order,
+        broker_position_id=second_strategy_position_id,
+    )
 
     assert_exact_position_owned(conn, strategy_trade_id=trade_id, broker_position_id=strategy_position_id)
+    assert_exact_position_owned(
+        conn,
+        strategy_trade_id=trade_id,
+        broker_position_id=second_strategy_position_id,
+    )
     with pytest.raises(StrategyOwnershipError, match="not actively owned"):
         assert_exact_position_owned(conn, strategy_trade_id=trade_id, broker_position_id=manual_position_id)
 
@@ -291,4 +306,79 @@ def test_funding_is_once_only_and_cannot_exceed_operator_cap(
             signal_id=signal_id,
             verdict="rejected",
             reason_code="duplicate",
+        )
+
+
+def test_funding_rechecks_stage_and_aggregate_active_reservations(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    for instrument_id in (2454011, 2454012, 2454013):
+        _instrument(conn, instrument_id)
+    _paper_stage(conn)
+    deployment = configure_deployment(
+        conn,
+        strategy_id="S-OWN",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("100"),
+        enabled=True,
+        changed_by="operator",
+        reason="aggregate reservation test",
+    )
+    first_signal = _signal(conn, instrument_id=2454011)
+    first_decision = decide_funding(
+        conn,
+        signal_id=first_signal,
+        verdict="allocated",
+        deployment_id=deployment.deployment_id,
+        amount=Decimal("60"),
+        reason_code="within_risk_budget",
+    )
+    first_trade = create_strategy_trade(conn, first_decision)
+
+    second_signal = _signal(conn, instrument_id=2454012)
+    with pytest.raises(StrategyControlError, match="exceeds"):
+        decide_funding(
+            conn,
+            signal_id=second_signal,
+            verdict="allocated",
+            deployment_id=deployment.deployment_id,
+            amount=Decimal("41"),
+            reason_code="would_exceed_active_reservations",
+        )
+
+    # Closed/failed trades release capacity; lifetime allocations do not make
+    # an operator's fixed pot unusable forever.
+    conn.execute(
+        "UPDATE strategy_trades SET status = 'closed' WHERE strategy_trade_id = %s",
+        (first_trade,),
+    )
+    second_decision = decide_funding(
+        conn,
+        signal_id=second_signal,
+        verdict="allocated",
+        deployment_id=deployment.deployment_id,
+        amount=Decimal("100"),
+        reason_code="capacity_released",
+    )
+    assert second_decision > first_decision
+
+    promote_strategy(
+        conn,
+        strategy_id="S-OWN",
+        strategy_version="v1",
+        to_stage="paused",
+        promoted_by="operator",
+        reason="pause new entries",
+    )
+    third_signal = _signal(conn, instrument_id=2454013)
+    with pytest.raises(StrategyControlError, match="cannot be allocated"):
+        decide_funding(
+            conn,
+            signal_id=third_signal,
+            verdict="allocated",
+            deployment_id=deployment.deployment_id,
+            amount=Decimal("1"),
+            reason_code="must_fail_while_paused",
         )

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -217,6 +217,15 @@ def test_same_instrument_manual_position_is_never_inferred_as_owned(
     _position(conn, manual_position_id, instrument_id)
     entry_order = _order(conn, instrument_id=instrument_id)
     link_strategy_order(conn, strategy_trade_id=trade_id, order_id=entry_order, purpose="entry")
+    duplicate_entry_order = _order(conn, instrument_id=instrument_id)
+    with pytest.raises(psycopg.errors.UniqueViolation):
+        with conn.transaction():
+            link_strategy_order(
+                conn,
+                strategy_trade_id=trade_id,
+                order_id=duplicate_entry_order,
+                purpose="entry",
+            )
 
     # Instrument equality is not provenance: the pre-existing manual position
     # cannot be claimed because detailed lookup did not return it for this order.
@@ -253,6 +262,16 @@ def test_same_instrument_manual_position_is_never_inferred_as_owned(
         strategy_trade_id=trade_id,
         broker_position_id=second_strategy_position_id,
     )
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with conn.transaction():
+            conn.execute(
+                """
+                UPDATE strategy_position_ownership
+                SET status = 'released', released_at = now(), release_reason = NULL
+                WHERE strategy_trade_id = %s AND broker_position_id = %s
+                """,
+                (trade_id, second_strategy_position_id),
+            )
     with pytest.raises(StrategyOwnershipError, match="not actively owned"):
         assert_exact_position_owned(conn, strategy_trade_id=trade_id, broker_position_id=manual_position_id)
 

--- a/tests/test_strategy_registry.py
+++ b/tests/test_strategy_registry.py
@@ -404,7 +404,15 @@ class TestVocabularyIsDefinedOnce:
         from pathlib import Path
 
         sql_dir = Path(__file__).resolve().parents[1] / "sql"
-        pattern = re.compile(rf"{column}[^;]*?IN \(([^)]*)\)", re.DOTALL)
+        # Bind the column match to the DDL statement for THIS table.  Looking
+        # only for the table name somewhere in the file let sql/281's FK to
+        # strategy_signals make the unrelated funding-decision ``verdict``
+        # vocabulary look like strategy_signals.verdict.
+        pattern = re.compile(
+            rf"(?:CREATE TABLE(?: IF NOT EXISTS)?|ALTER TABLE)\s+{re.escape(table)}"
+            rf"[^;]*?{re.escape(column)}[^;]*?IN \(([^)]*)\)",
+            re.DOTALL,
+        )
         for path in sorted(sql_dir.glob("*.sql"), reverse=True):
             body = re.sub(r"--[^\n]*", "", path.read_text())
             if table not in body:


### PR DESCRIPTION
Closes #2454
Parent #2437

## Outcome

Adds the broker-free governance and ownership authority for the strategy sleeve:

- append-only ordered promotion events with pinned evidence/result ids;
- one current paper/live capital ceiling per strategy version with complete revision history;
- one funding verdict per fired signal, rechecking current stage and aggregate active reservations under lock;
- explicit manual/strategy order origin without changing existing manual order behavior;
- durable trade/order/purpose links;
- detailed order-to-position execution provenance and exact position ownership, including multiple position executions from one entry;
- no instrument, symbol, timestamp, units, source, or FIFO ownership inference;
- no broker writer and no automatic promotion from runtime switches or metrics.

## Validation

- Four Codex review rounds: three rounds found and fixed paused-stage allocation, aggregate-cap, multi-position, provenance, and lookup-before-sync defects; final review clean.
- `uv run pytest -q tests/test_strategy_control_plane.py`: 6 passed.
- Focused schema/cleanup/registry/retention tests: green.
- Full `.githooks/pre-push`: green (ruff, format, pyright, chokepoint lints, full non-DB tier, smoke, frontend integrity).
- Deliberate broad `pytest -m db`: eight unrelated/order-dependent failures; six pass isolated. The two repeatable failures are existing thesis TestClient pool setup and `quotes_refresh` bootstrap declaration; neither changed by this branch. All changed-surface DB tests pass.

## Safety posture

Live broker execution remains disabled. Current measured strategy evidence still fails promotion prerequisites, so this PR creates governance authority but promotes no strategy and allocates no capital.