### PR TITLE
feat(#2451): reconcile strategy orders to exact broker positions

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -53,9 +53,16 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
   justified by this evidence.
 - **Order-to-position reconciliation exists in v2:**
   `GET /api/v2/trading/info/{demo|real}/orders:lookup` returns
-  `positionExecutions[].positionId`. This is the durable way to bind a submitted
-  strategy entry to the exact position it owns; do not infer the position from
-  instrument or FIFO order.
+  `positionExecutions[].positionId`. The live detail page verified 2026-08-09
+  requires exactly one of numeric `orderId` or `referenceId`; `referenceId` is
+  the `X-Request-Id` sent on submission. The current v2 create-order page states
+  that this unique GUID is required for idempotency. Commit it before broker
+  I/O, never rotate it after an uncertain response, and use the same value for
+  lookup/retry. This is the durable way to bind a submitted strategy entry to
+  the exact position(s) it owns; do not infer a position from instrument, time,
+  units or FIFO order. The response also supplies opening units, average price,
+  execution time and fees; retain these compact facts to prove partial-fill and
+  one-to-many cardinality without storing every poll payload.
 
 ## ⚠⚠ WE HAVE INTRADAY HISTORY. Read this before saying otherwise — MEASURED 2026-08-09
 

--- a/.claude/skills/quant/trade-lifecycle.md
+++ b/.claude/skills/quant/trade-lifecycle.md
@@ -88,6 +88,12 @@ momentum, not universally (Moreira-Muir vs Cederburg et al.).
   symbol/instrument matching, units, timestamps, source labels, or FIFO. A manual
   same-instrument position has no ownership row and must remain unmodifiable by
   strategy code, while still counting toward portfolio-wide risk.
+- **Broker submission identity is durable before I/O.** Commit one immutable
+  UUID, send it as eToro v2 `X-Request-Id`, and reuse it for both an idempotent
+  retry and `orders:lookup.referenceId`. After an uncertain response, never
+  rotate the UUID or submit a newly keyed order. Pending/partial executions are
+  owned by exact returned position id but keep the entry backlog unresolved;
+  an overdue backlog blocks new entries.
 
 ### `INITIAL_STOP`
 

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import Any, Literal
+from uuid import UUID
 
 OrderStatus = Literal["filled", "pending", "rejected", "failed"]
 TradeDirection = Literal["buy", "sellShort"]
@@ -34,6 +35,42 @@ class BrokerOrderResult:
     filled_units: Decimal | None
     fees: Decimal
     raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerPositionExecution:
+    """One exact position created or affected by a detailed broker order."""
+
+    position_id: int
+    state: str
+    remaining_units: Decimal | None
+    opening_units: Decimal | None
+    average_price: Decimal | None
+    execution_time: datetime | None
+    fees: Decimal | None
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class BrokerOrderDetail:
+    """Current v2 order detail resolved by order id or submission UUID."""
+
+    broker_order_ref: str
+    reference_id: str | None
+    status: OrderStatus
+    broker_status: str
+    instrument_id: int
+    position_executions: tuple[BrokerPositionExecution, ...]
+    last_update: datetime | None
+    raw_payload: dict[str, Any]
+
+
+class BrokerOrderLookupError(RuntimeError):
+    """A detailed order lookup failed or returned an unsafe shape."""
+
+
+class BrokerOrderNotFound(BrokerOrderLookupError):
+    """No order currently resolves for the supplied durable identity."""
 
 
 @dataclass(frozen=True)
@@ -291,12 +328,16 @@ class BrokerProvider(ABC):
         amount: Decimal | None,
         units: Decimal | None,
         params: OrderParams | None = None,
+        *,
+        request_id: UUID | None = None,
     ) -> BrokerOrderResult:
         """
         Place an order with the broker.
 
         Exactly one of amount or units should be provided.
         params: optional SL/TP and leverage settings. None = broker defaults.
+        request_id: optional durable broker idempotency identity. Strategy
+        callers must commit this UUID before I/O and reuse it after uncertainty.
         Returns the broker's response, including fill details if immediately filled.
         """
 
@@ -336,6 +377,20 @@ class BrokerProvider(ABC):
         Non-abstract with a NotImplementedError default so existing test
         fakes that implement only the abstract surface keep working;
         the eToro implementation overrides it.
+        """
+        raise NotImplementedError
+
+    def lookup_order(
+        self,
+        *,
+        order_id: str | None = None,
+        reference_id: str | None = None,
+    ) -> BrokerOrderDetail:
+        """Resolve exact order/position detail using one durable identity.
+
+        ``reference_id`` is the idempotency UUID supplied when the order was
+        submitted.  It is therefore usable even when a process crashed before
+        persisting the broker-assigned order id.
         """
         raise NotImplementedError
 

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from types import TracebackType
 from typing import Any
+from uuid import UUID, uuid4
 
 import httpx
 
@@ -30,9 +31,13 @@ from app.providers.broker import (
     BrokerLeverageConfig,
     BrokerMirror,
     BrokerMirrorPosition,
+    BrokerOrderDetail,
+    BrokerOrderLookupError,
+    BrokerOrderNotFound,
     BrokerOrderResult,
     BrokerPortfolio,
     BrokerPosition,
+    BrokerPositionExecution,
     BrokerProvider,
     BrokerWhatIfCostResponse,
     BrokerWhatIfOrder,
@@ -98,6 +103,10 @@ class TradingPreflightParseError(Exception):
     could turn an absent restriction or fee into permission, so malformed
     responses fail the whole preflight instead of dropping fields or rows.
     """
+
+
+class OrderDetailParseError(BrokerOrderLookupError):
+    """The exact-order response cannot safely establish position identity."""
 
 
 def _order_body_common(
@@ -180,11 +189,9 @@ class EtoroBrokerProvider(BrokerProvider):
         """Close the underlying HTTP client. Prefer using as a context manager."""
         self._client.close()
 
-    def _request_headers(self) -> dict[str, str]:
-        """Per-request headers — fresh UUID for x-request-id."""
-        from uuid import uuid4
-
-        return {"x-request-id": str(uuid4())}
+    def _request_headers(self, request_id: UUID | None = None) -> dict[str, str]:
+        """Return a caller-owned idempotency UUID or a fresh request identity."""
+        return {"x-request-id": str(request_id or uuid4())}
 
     # ------------------------------------------------------------------
     # BrokerProvider implementation
@@ -197,6 +204,8 @@ class EtoroBrokerProvider(BrokerProvider):
         amount: Decimal | None,
         units: Decimal | None,
         params: OrderParams | None = None,
+        *,
+        request_id: UUID | None = None,
     ) -> BrokerOrderResult:
         # Reject unrecognised actions before any HTTP call.
         if action not in _ALLOWED_PLACE_ORDER_ACTIONS:
@@ -267,7 +276,7 @@ class EtoroBrokerProvider(BrokerProvider):
             response = self._http_write.post(
                 endpoint,
                 json=body,
-                headers=self._request_headers(),
+                headers=self._request_headers(request_id),
             )
             response.raise_for_status()
             raw = response.json()
@@ -412,6 +421,58 @@ class EtoroBrokerProvider(BrokerProvider):
             )
 
         return _normalise_order_info_response(raw, broker_order_ref)
+
+    def lookup_order(
+        self,
+        *,
+        order_id: str | None = None,
+        reference_id: str | None = None,
+    ) -> BrokerOrderDetail:
+        """Resolve v2 order detail and every exact position execution.
+
+        eToro requires exactly one of ``orderId`` or ``referenceId``. The
+        latter is the X-Request-Id used for the idempotent submission, so it
+        closes the response-before-persist crash gap.
+        """
+        if (order_id is None) == (reference_id is None):
+            raise ValueError("exactly one of order_id or reference_id is required")
+        if order_id is not None:
+            try:
+                numeric_order_id = int(order_id)
+            except ValueError as exc:
+                raise ValueError("order_id must be a positive integer") from exc
+            if numeric_order_id <= 0:
+                raise ValueError("order_id must be a positive integer")
+            params: dict[str, str | int] = {"orderId": numeric_order_id}
+        else:
+            from uuid import UUID
+
+            assert reference_id is not None
+            try:
+                canonical_reference = str(UUID(reference_id))
+            except ValueError as exc:
+                raise ValueError("reference_id must be a UUID") from exc
+            params = {"referenceId": canonical_reference}
+
+        try:
+            response = self._http_read.get(
+                f"{self._v2_info_prefix}/orders:lookup",
+                params=params,
+                headers=self._request_headers(),
+            )
+            response.raise_for_status()
+            raw = response.json()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise BrokerOrderNotFound("broker order was not found") from exc
+            raise BrokerOrderLookupError(f"broker order lookup returned HTTP {exc.response.status_code}") from exc
+        except httpx.HTTPError as exc:
+            raise BrokerOrderLookupError(f"broker order lookup transport error: {exc}") from exc
+        except ValueError as exc:
+            raise BrokerOrderLookupError("broker order lookup returned non-JSON data") from exc
+        if not isinstance(raw, dict):
+            raise OrderDetailParseError("order detail response must be an object")
+        return _parse_order_detail(raw, reference_id=reference_id)
 
     def check_instrument_eligibility(
         self,
@@ -732,6 +793,110 @@ def _parse_what_if_cost_response(raw: dict[str, Any]) -> BrokerWhatIfCostRespons
         )
     except (KeyError, TypeError, ValueError) as exc:
         raise TradingPreflightParseError(f"malformed what-if cost response: {exc}") from exc
+
+
+def _order_detail_decimal(payload: dict[str, Any], key: str) -> Decimal | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except decimal.DecimalException as exc:
+        raise OrderDetailParseError(f"{key} must be numeric or null") from exc
+
+
+def _order_detail_time(payload: dict[str, Any], key: str) -> datetime | None:
+    value = payload.get(key)
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise OrderDetailParseError(f"{key} must be an ISO timestamp or null") from exc
+    if parsed.tzinfo is None:
+        raise OrderDetailParseError(f"{key} must include a timezone")
+    return parsed
+
+
+def _parse_order_detail(raw: dict[str, Any], *, reference_id: str | None) -> BrokerOrderDetail:
+    """Strictly parse the documented v2 ``orders:lookup`` response."""
+    try:
+        order_id = int(raw["orderId"])
+        status_object = raw["status"]
+        asset = raw["asset"]
+        execution_rows = raw["positionExecutions"]
+        if order_id <= 0:
+            raise OrderDetailParseError("orderId must be positive")
+        if not isinstance(status_object, dict) or not isinstance(asset, dict):
+            raise OrderDetailParseError("status and asset must be objects")
+        broker_status = status_object.get("name")
+        if not isinstance(broker_status, str) or not broker_status:
+            raise OrderDetailParseError("status.name must be a non-empty string")
+        instrument_id = int(asset["instrumentId"])
+        if instrument_id <= 0:
+            raise OrderDetailParseError("asset.instrumentId must be positive")
+        if not isinstance(execution_rows, list):
+            raise OrderDetailParseError("positionExecutions must be an array")
+
+        executions: list[BrokerPositionExecution] = []
+        position_ids: set[int] = set()
+        for row in execution_rows:
+            if not isinstance(row, dict):
+                raise OrderDetailParseError("positionExecutions entries must be objects")
+            position_id = int(row["positionId"])
+            state = row["state"]
+            if position_id <= 0 or position_id in position_ids:
+                raise OrderDetailParseError("positionExecutions positionId values must be positive and unique")
+            if not isinstance(state, str) or not state:
+                raise OrderDetailParseError("positionExecutions state must be non-empty")
+            position_ids.add(position_id)
+            opening = row.get("openingData")
+            if opening is not None and not isinstance(opening, dict):
+                raise OrderDetailParseError("positionExecutions openingData must be an object or null")
+            opening_data = opening or {}
+            remaining_units = _order_detail_decimal(row, "remainingUnits")
+            opening_units = _order_detail_decimal(opening_data, "units")
+            average_price = _order_detail_decimal(opening_data, "avgPrice")
+            execution_time = _order_detail_time(opening_data, "executionTime")
+            fees = _order_detail_decimal(opening_data, "fees")
+            if opening_units is None or opening_units <= 0:
+                raise OrderDetailParseError("openingData.units must be positive for a position execution")
+            if average_price is None or average_price <= 0:
+                raise OrderDetailParseError("openingData.avgPrice must be positive for a position execution")
+            if execution_time is None:
+                raise OrderDetailParseError("openingData.executionTime is required for a position execution")
+            if remaining_units is None or remaining_units < 0:
+                raise OrderDetailParseError("remainingUnits must be non-negative for a position execution")
+            if fees is None or fees < 0:
+                raise OrderDetailParseError("openingData.fees must be non-negative for a position execution")
+            executions.append(
+                BrokerPositionExecution(
+                    position_id=position_id,
+                    state=state,
+                    remaining_units=remaining_units,
+                    opening_units=opening_units,
+                    average_price=average_price,
+                    execution_time=execution_time,
+                    fees=fees,
+                    raw_payload=dict(row),
+                )
+            )
+
+        normalised_status: OrderStatus = _STATUS_MAP.get(broker_status, "pending")
+        return BrokerOrderDetail(
+            broker_order_ref=str(order_id),
+            reference_id=reference_id,
+            status=normalised_status,
+            broker_status=broker_status,
+            instrument_id=instrument_id,
+            position_executions=tuple(executions),
+            last_update=_order_detail_time(raw, "lastUpdate"),
+            raw_payload=raw,
+        )
+    except OrderDetailParseError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise OrderDetailParseError(f"malformed order detail response: {exc}") from exc
 
 
 def _parse_direct_position(payload: dict[str, Any]) -> BrokerPosition:

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -445,8 +445,6 @@ class EtoroBrokerProvider(BrokerProvider):
                 raise ValueError("order_id must be a positive integer")
             params: dict[str, str | int] = {"orderId": numeric_order_id}
         else:
-            from uuid import UUID
-
             assert reference_id is not None
             try:
                 canonical_reference = str(UUID(reference_id))

--- a/app/services/strategy_order_reconciliation.py
+++ b/app/services/strategy_order_reconciliation.py
@@ -104,6 +104,9 @@ def ensure_strategy_request_id(conn: psycopg.Connection[Any], *, order_id: int) 
 
 
 def _payload_hash(detail: BrokerOrderDetail) -> str:
+    # Settled review-prevention decision #471 removed duplicate raw persistence
+    # for etoro_broker once its decision-bearing fields land in SQL. Keep the
+    # response process-local and retain a reproducibility fingerprint instead.
     canonical = json.dumps(detail.raw_payload, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(canonical.encode()).hexdigest()
 

--- a/app/services/strategy_order_reconciliation.py
+++ b/app/services/strategy_order_reconciliation.py
@@ -1,0 +1,556 @@
+"""Crash-safe reconciliation of strategy orders to exact broker positions.
+
+The submission UUID is committed before broker I/O and is never rotated.  A
+restart can therefore resolve an accepted order through eToro's documented v2
+``orders:lookup?referenceId=...`` contract.  This module never places or closes
+an order and never infers position ownership from an instrument match.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal, cast
+from uuid import UUID, uuid4
+
+import psycopg
+import psycopg.rows
+from psycopg.pq import TransactionStatus
+
+from app.providers.broker import (
+    BrokerOrderDetail,
+    BrokerOrderLookupError,
+    BrokerOrderNotFound,
+    BrokerPositionExecution,
+    BrokerProvider,
+)
+from app.services.strategy_control_plane import StrategyControlError, StrategyOwnershipError
+
+ReconciliationState = Literal[
+    "unresolved",
+    "pending",
+    "resolved",
+    "rejected",
+    "not_found",
+    "ambiguous",
+    "error",
+]
+
+_KNOWN_PENDING_BROKER_STATES = frozenset({"Pending"})
+_KNOWN_FILLED_BROKER_STATES = frozenset({"Filled", "Executed"})
+_KNOWN_REJECTED_BROKER_STATES = frozenset({"Rejected", "Failed", "Cancelled", "Canceled"})
+_TERMINAL_RECONCILIATION_STATES = frozenset({"resolved", "rejected"})
+
+
+class StrategyReconciliationError(StrategyControlError):
+    """The broker response cannot safely advance a strategy order."""
+
+
+@dataclass(frozen=True)
+class ReconciliationResult:
+    order_id: int
+    state: ReconciliationState
+    broker_order_ref: str | None
+    broker_status: str | None
+    position_ids: tuple[int, ...]
+    error_code: str | None = None
+
+
+@dataclass(frozen=True)
+class ReconciliationHealth:
+    active_block: bool
+    overdue_count: int
+    oldest_unresolved_at: datetime | None
+
+
+def ensure_strategy_request_id(conn: psycopg.Connection[Any], *, order_id: int) -> UUID:
+    """Assign a strategy order's immutable broker idempotency UUID once.
+
+    The caller must commit after this function and before broker I/O. Repeated
+    calls return the same UUID, including a retry after a pre-call crash.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT o.execution_origin, o.strategy_request_id
+            FROM orders o
+            JOIN strategy_trade_orders sto ON sto.order_id = o.order_id
+            WHERE o.order_id = %s
+            FOR UPDATE OF o
+            """,
+            (order_id,),
+        )
+        row = cur.fetchone()
+    if row is None or row["execution_origin"] != "strategy":
+        raise StrategyReconciliationError("only a linked strategy-origin order may receive a request id")
+    stored_request_id = row["strategy_request_id"]
+    request_id = UUID(str(stored_request_id)) if stored_request_id is not None else uuid4()
+    if stored_request_id is None:
+        conn.execute(
+            "UPDATE orders SET strategy_request_id = %s WHERE order_id = %s",
+            (request_id, order_id),
+        )
+    conn.execute(
+        """
+        INSERT INTO strategy_order_reconciliation_state (order_id)
+        VALUES (%s)
+        ON CONFLICT (order_id) DO NOTHING
+        """,
+        (order_id,),
+    )
+    return request_id
+
+
+def _payload_hash(detail: BrokerOrderDetail) -> str:
+    canonical = json.dumps(detail.raw_payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _record_failure(
+    conn: psycopg.Connection[Any],
+    *,
+    order_id: int,
+    state: Literal["not_found", "ambiguous", "error"],
+    error_code: str,
+    broker_status: str | None = None,
+) -> ReconciliationResult:
+    conn.execute(
+        """
+        INSERT INTO strategy_order_reconciliation_state (
+            order_id, state, last_attempt_at, attempt_count, broker_status,
+            last_error_code, updated_at
+        ) VALUES (%s, %s, now(), 1, %s, %s, now())
+        ON CONFLICT (order_id) DO UPDATE SET
+            state = EXCLUDED.state,
+            last_attempt_at = now(),
+            reconciled_at = NULL,
+            attempt_count = strategy_order_reconciliation_state.attempt_count + 1,
+            broker_status = EXCLUDED.broker_status,
+            last_error_code = EXCLUDED.last_error_code,
+            updated_at = now()
+        """,
+        (order_id, state, broker_status, error_code),
+    )
+    conn.execute(
+        """
+        UPDATE strategy_trades t
+        SET status = 'reconcile_required', updated_at = now()
+        FROM strategy_trade_orders sto
+        WHERE sto.order_id = %s AND sto.strategy_trade_id = t.strategy_trade_id
+          AND t.status NOT IN ('closed', 'failed')
+        """,
+        (order_id,),
+    )
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT o.broker_order_ref,
+                   ARRAY(
+                       SELECT execution.broker_position_id
+                       FROM strategy_order_position_executions execution
+                       WHERE execution.order_id = o.order_id
+                       ORDER BY execution.broker_position_id
+                   ) AS position_ids
+            FROM orders o
+            WHERE o.order_id = %s
+            """,
+            (order_id,),
+        )
+        persisted = cur.fetchone()
+    assert persisted is not None
+    persisted_ref = persisted["broker_order_ref"]
+    return ReconciliationResult(
+        order_id,
+        state,
+        str(persisted_ref) if persisted_ref is not None else None,
+        broker_status,
+        tuple(int(value) for value in persisted["position_ids"]),
+        error_code,
+    )
+
+
+def _record_execution(
+    conn: psycopg.Connection[Any],
+    *,
+    order_id: int,
+    execution: BrokerPositionExecution,
+) -> None:
+    row = conn.execute(
+        """
+        INSERT INTO strategy_order_position_executions (
+            order_id, broker_position_id, position_state, remaining_units,
+            opening_units, average_price, execution_time, fees,
+            last_observed_at
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, now())
+        ON CONFLICT (order_id, broker_position_id) DO UPDATE SET
+            position_state = EXCLUDED.position_state,
+            remaining_units = EXCLUDED.remaining_units,
+            opening_units = COALESCE(
+                strategy_order_position_executions.opening_units,
+                EXCLUDED.opening_units
+            ),
+            average_price = COALESCE(
+                strategy_order_position_executions.average_price,
+                EXCLUDED.average_price
+            ),
+            execution_time = COALESCE(
+                strategy_order_position_executions.execution_time,
+                EXCLUDED.execution_time
+            ),
+            fees = COALESCE(strategy_order_position_executions.fees, EXCLUDED.fees),
+            last_observed_at = now()
+        WHERE (
+            strategy_order_position_executions.opening_units IS NULL
+            OR EXCLUDED.opening_units IS NULL
+            OR strategy_order_position_executions.opening_units = EXCLUDED.opening_units
+        ) AND (
+            strategy_order_position_executions.average_price IS NULL
+            OR EXCLUDED.average_price IS NULL
+            OR strategy_order_position_executions.average_price = EXCLUDED.average_price
+        ) AND (
+            strategy_order_position_executions.execution_time IS NULL
+            OR EXCLUDED.execution_time IS NULL
+            OR strategy_order_position_executions.execution_time = EXCLUDED.execution_time
+        ) AND (
+            strategy_order_position_executions.fees IS NULL
+            OR EXCLUDED.fees IS NULL
+            OR strategy_order_position_executions.fees = EXCLUDED.fees
+        )
+        RETURNING broker_position_id
+        """,
+        (
+            order_id,
+            execution.position_id,
+            execution.state,
+            execution.remaining_units,
+            execution.opening_units,
+            execution.average_price,
+            execution.execution_time,
+            execution.fees,
+        ),
+    ).fetchone()
+    if row is None:
+        raise StrategyReconciliationError("broker changed immutable opening execution facts")
+
+
+def _claim_entry_execution(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_trade_id: int,
+    broker_position_id: int,
+) -> None:
+    inserted = conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id)
+        VALUES (%s, %s)
+        ON CONFLICT (broker_position_id) DO NOTHING
+        RETURNING ownership_id
+        """,
+        (strategy_trade_id, broker_position_id),
+    ).fetchone()
+    if inserted is not None:
+        return
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            "SELECT strategy_trade_id FROM strategy_position_ownership WHERE broker_position_id = %s",
+            (broker_position_id,),
+        )
+        existing = cur.fetchone()
+    if existing is None or int(existing["strategy_trade_id"]) != strategy_trade_id:
+        raise StrategyOwnershipError("broker position is already owned by a different strategy trade")
+
+
+def _apply_detail(
+    conn: psycopg.Connection[Any],
+    *,
+    order_id: int,
+    detail: BrokerOrderDetail,
+) -> ReconciliationResult:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT o.instrument_id, o.broker_order_ref, sto.strategy_trade_id, sto.purpose,
+                   state.state AS reconciliation_state
+            FROM orders o
+            JOIN strategy_trade_orders sto ON sto.order_id = o.order_id
+            LEFT JOIN strategy_order_reconciliation_state state ON state.order_id = o.order_id
+            WHERE o.order_id = %s AND o.execution_origin = 'strategy'
+            FOR UPDATE OF o
+            """,
+            (order_id,),
+        )
+        local = cur.fetchone()
+    if local is None:
+        raise StrategyReconciliationError("order is not linked strategy authority")
+    instrument_id = local["instrument_id"]
+    existing_ref = local["broker_order_ref"]
+    strategy_trade_id = local["strategy_trade_id"]
+    purpose = local["purpose"]
+    prior_state = local["reconciliation_state"]
+    if int(instrument_id) != detail.instrument_id:
+        raise StrategyReconciliationError("broker order instrument differs from durable intent")
+    if existing_ref is not None and str(existing_ref) != detail.broker_order_ref:
+        raise StrategyReconciliationError("broker order id differs from the previously reconciled id")
+
+    broker_status = detail.broker_status
+    if broker_status in _KNOWN_FILLED_BROKER_STATES:
+        state: ReconciliationState = "resolved"
+        order_status = "filled"
+    elif broker_status in _KNOWN_REJECTED_BROKER_STATES:
+        state = "rejected"
+        order_status = "rejected"
+    elif broker_status in _KNOWN_PENDING_BROKER_STATES:
+        state = "pending"
+        order_status = "pending"
+    else:
+        raise StrategyReconciliationError(f"unknown broker order status: {broker_status}")
+
+    if prior_state in _TERMINAL_RECONCILIATION_STATES and prior_state != state:
+        raise StrategyReconciliationError("broker order attempted to regress or change terminal state")
+
+    if state == "rejected" and detail.position_executions:
+        raise StrategyReconciliationError("rejected broker order unexpectedly has position executions")
+    if state == "resolved" and purpose == "entry" and not detail.position_executions:
+        raise StrategyReconciliationError("filled strategy entry has no exact position executions")
+
+    for execution in detail.position_executions:
+        _record_execution(conn, order_id=order_id, execution=execution)
+        if purpose == "entry":
+            _claim_entry_execution(
+                conn,
+                strategy_trade_id=int(strategy_trade_id),
+                broker_position_id=execution.position_id,
+            )
+
+    conn.execute(
+        """
+        INSERT INTO strategy_order_reconciliation_state (
+            order_id, state, last_attempt_at, reconciled_at, attempt_count,
+            broker_status, position_count, last_error_code,
+            last_payload_sha256, updated_at
+        ) VALUES (
+            %s, %s, now(),
+            CASE WHEN %s IN ('resolved', 'rejected') THEN now() ELSE NULL END,
+            1, %s, %s, NULL, %s, now()
+        )
+        ON CONFLICT (order_id) DO UPDATE SET
+            state = EXCLUDED.state,
+            last_attempt_at = now(),
+            reconciled_at = EXCLUDED.reconciled_at,
+            attempt_count = strategy_order_reconciliation_state.attempt_count + 1,
+            broker_status = EXCLUDED.broker_status,
+            position_count = EXCLUDED.position_count,
+            last_error_code = NULL,
+            last_payload_sha256 = EXCLUDED.last_payload_sha256,
+            updated_at = now()
+        """,
+        (order_id, state, state, broker_status, len(detail.position_executions), _payload_hash(detail)),
+    )
+    conn.execute(
+        """
+        UPDATE orders
+        SET broker_order_ref = %s, status = %s
+        WHERE order_id = %s
+        """,
+        (detail.broker_order_ref, order_status, order_id),
+    )
+    if purpose == "entry":
+        trade_status = "open" if state == "resolved" else ("failed" if state == "rejected" else "submitted")
+        conn.execute(
+            "UPDATE strategy_trades SET status = %s, updated_at = now() WHERE strategy_trade_id = %s",
+            (trade_status, strategy_trade_id),
+        )
+    return ReconciliationResult(
+        order_id,
+        state,
+        detail.broker_order_ref,
+        broker_status,
+        tuple(execution.position_id for execution in detail.position_executions),
+    )
+
+
+def reconcile_strategy_order(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    order_id: int,
+) -> ReconciliationResult:
+    """Poll and reconcile one linked strategy order without any broker write."""
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise StrategyReconciliationError(
+            "reconciliation requires an idle connection so broker I/O cannot run inside a DB transaction"
+        )
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT o.broker_order_ref, o.strategy_request_id,
+                   state.state AS reconciliation_state,
+                   state.broker_status,
+                   ARRAY(
+                       SELECT execution.broker_position_id
+                       FROM strategy_order_position_executions execution
+                       WHERE execution.order_id = o.order_id
+                       ORDER BY execution.broker_position_id
+                   ) AS position_ids
+            FROM orders o
+            JOIN strategy_trade_orders sto ON sto.order_id = o.order_id
+            LEFT JOIN strategy_order_reconciliation_state state ON state.order_id = o.order_id
+            WHERE o.order_id = %s AND o.execution_origin = 'strategy'
+            """,
+            (order_id,),
+        )
+        identity = cur.fetchone()
+    conn.commit()
+    if identity is None:
+        raise StrategyReconciliationError("order is not linked strategy authority")
+    broker_ref = identity["broker_order_ref"]
+    request_id = identity["strategy_request_id"]
+    prior_state = identity["reconciliation_state"]
+    if prior_state in _TERMINAL_RECONCILIATION_STATES:
+        return ReconciliationResult(
+            order_id=order_id,
+            state=cast(ReconciliationState, prior_state),
+            broker_order_ref=str(broker_ref) if broker_ref is not None else None,
+            broker_status=identity["broker_status"],
+            position_ids=tuple(int(value) for value in identity["position_ids"]),
+        )
+    if request_id is None:
+        with conn.transaction():
+            return _record_failure(
+                conn,
+                order_id=order_id,
+                state="ambiguous",
+                error_code="missing_submission_request_id",
+            )
+    try:
+        if broker_ref is not None and str(broker_ref).isdigit() and int(str(broker_ref)) > 0:
+            detail = broker.lookup_order(order_id=str(broker_ref))
+        else:
+            detail = broker.lookup_order(reference_id=str(request_id))
+    except BrokerOrderNotFound:
+        with conn.transaction():
+            return _record_failure(
+                conn,
+                order_id=order_id,
+                state="not_found",
+                error_code="broker_order_not_found",
+            )
+    except BrokerOrderLookupError:
+        with conn.transaction():
+            return _record_failure(
+                conn,
+                order_id=order_id,
+                state="error",
+                error_code="broker_lookup_error",
+            )
+    try:
+        with conn.transaction():
+            return _apply_detail(conn, order_id=order_id, detail=detail)
+    except StrategyReconciliationError, StrategyOwnershipError:
+        with conn.transaction():
+            return _record_failure(
+                conn,
+                order_id=order_id,
+                state="ambiguous",
+                error_code="unsafe_broker_detail",
+            )
+
+
+def reconcile_backlog(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    limit: int = 50,
+) -> tuple[ReconciliationResult, ...]:
+    """Reconcile a bounded oldest-first restart backlog."""
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100")
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise StrategyReconciliationError("backlog reconciliation requires an idle connection")
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT state.order_id
+            FROM strategy_order_reconciliation_state state
+            JOIN orders o ON o.order_id = state.order_id
+            WHERE state.state NOT IN ('resolved', 'rejected')
+              AND o.execution_origin = 'strategy'
+            ORDER BY state.first_unresolved_at, state.order_id
+            LIMIT %s
+            """,
+            (limit,),
+        )
+        rows = cur.fetchall()
+    conn.commit()
+    return tuple(reconcile_strategy_order(conn, broker=broker, order_id=int(row["order_id"])) for row in rows)
+
+
+def enforce_reconciliation_slo(
+    conn: psycopg.Connection[Any],
+    *,
+    max_unresolved_seconds: int,
+) -> ReconciliationHealth:
+    """Block new strategy entries when unresolved order identity exceeds policy.
+
+    The threshold is an explicit deployment input, not a made-up constant. The
+    current row is updated in place, so healthy polling does not grow the DB.
+    """
+    if max_unresolved_seconds <= 0:
+        raise ValueError("max_unresolved_seconds must be positive")
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT count(*) AS overdue_count, min(first_unresolved_at) AS oldest_unresolved_at
+            FROM strategy_order_reconciliation_state
+            WHERE state NOT IN ('resolved', 'rejected')
+              AND first_unresolved_at <= now() - make_interval(secs => %s)
+            """,
+            (max_unresolved_seconds,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    overdue_count = int(row["overdue_count"])
+    oldest = row["oldest_unresolved_at"]
+    active = overdue_count > 0
+    reason = (
+        f"{overdue_count} strategy order(s) exceed the configured reconciliation SLO"
+        if active
+        else "reconciliation backlog is within the configured SLO"
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_execution_blocks (
+            source, active, reason, blocked_at, cleared_at, updated_at
+        ) VALUES (
+            'order_reconciliation', %s, %s,
+            CASE WHEN %s THEN now() ELSE NULL END,
+            CASE WHEN %s THEN NULL ELSE now() END,
+            now()
+        )
+        ON CONFLICT (source) DO UPDATE SET
+            active = EXCLUDED.active,
+            reason = EXCLUDED.reason,
+            blocked_at = CASE
+                WHEN EXCLUDED.active AND NOT strategy_execution_blocks.active THEN now()
+                WHEN EXCLUDED.active THEN strategy_execution_blocks.blocked_at
+                ELSE NULL
+            END,
+            cleared_at = CASE WHEN EXCLUDED.active THEN NULL ELSE now() END,
+            updated_at = now()
+        """,
+        (active, reason, active, active),
+    )
+    return ReconciliationHealth(active, overdue_count, oldest)
+
+
+__all__ = [
+    "ReconciliationHealth",
+    "ReconciliationResult",
+    "StrategyReconciliationError",
+    "enforce_reconciliation_slo",
+    "ensure_strategy_request_id",
+    "reconcile_backlog",
+    "reconcile_strategy_order",
+]

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -147,7 +147,7 @@ GET+POST requests cannot exceed the API limit.
 | PATCH | `/api/v2/trading/{real\|demo}/positions/{positionId}` | Edit TP/SL on one exact open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). Async acceptance `{operationId, positionId, referenceId}` — re-sync before treating as landed | Planned — required for strategy-owned ratchets |
 | POST | `/api/v2/trading/info/{real\|demo}/eligibility` | Up to 100 ids/symbols; account-specific open/close/partial-close permission, min exposure, max units, order/fill types, and leverage + SL/TP constraints by settlement/direction | **Adapter implemented; no persistence/execution gate yet** |
 | POST | `/api/v2/trading/info/{real\|demo}/costs` | What-if open cost rows for `buy` / `sellShort`: open vocabulary including spread, markup, transaction, overnight/weekend and tax; returns `lastUpdated`. Demo returned `value` while omitting documented `amount`; controlled scaling did not establish one unit equation | **Adapter + bounded census implemented; fail closed for execution** |
-| GET | `/api/v2/trading/info/{real\|demo}/orders:lookup` | Detailed order and `positionExecutions[].positionId`; required to bind an entry order to the exact broker position | Not used — execution reconciliation gap |
+| GET | `/api/v2/trading/info/{real\|demo}/orders:lookup` | Exactly one of numeric `orderId` or submission `referenceId`; returns status and every `positionExecutions[].positionId` with opening units/average price. Shared 60 GET/min quota | **Active for strategy reconciliation** — strict adapter, exact execution persistence and restart backlog; no broker writer in this slice |
 | POST | `/api/v1/trading/execution/limit-orders` | Limit/MIT order | Not used (v1 is market-only) |
 | DELETE | `/api/v1/trading/execution/limit-orders/{orderId}` | Cancel limit order | Not used (v1) |
 | GET | `/api/v1/trading/info/portfolio` | Full portfolio: positions, orders, mirrors, credit | **Active** — portfolio sync |
@@ -162,6 +162,12 @@ and `BrokerWhatIfCostResponse` adapters. Documentation examples are not populati
 evidence: probe a bounded demo cohort before deciding which fields change often,
 which settlement/direction arms are actually returned, and whether observed
 `sellShort` eligibility and costs are adequate for a short strategy.
+
+The current v2 create-order contract also documents a unique `X-Request-Id`
+UUID as the idempotency key, and `orders:lookup.referenceId` as that same
+submission header. Strategy execution must commit this immutable UUID before
+network I/O and reuse it on every retry. A missing response therefore becomes a
+lookup/retry of one identity, never a newly keyed duplicate order.
 
 ### Authenticated demo census (2026-08-09)
 

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -365,9 +365,16 @@ are actually created.
    can be released. Global auto/live switches are not read by promotion and
    cannot change stage. Broker I/O remains absent and live execution remains
    disabled.
-6. **Order/position reconciler:** consume detailed v2 order lookup and history;
-   close the existing submitted/pending crash gap; prove same-instrument manual
-   isolation in demo.
+6. **Order/position reconciler — implemented:** persist an immutable submission
+   UUID before broker I/O, use it as both the documented v2 idempotency key and
+   `orders:lookup.referenceId`, and retain exact position cardinality, partial
+   units, average price, fees and execution time. Restart polling updates one
+   compact state row per order; malformed/unknown/rejected-with-position shapes
+   fail closed. An explicit reconciliation-age policy activates one bounded
+   new-entry kill row rather than appending polling heartbeats. Real-Postgres
+   crash-point tests cover before-call identity, during-call uncertainty,
+   after-acceptance replay, partial fills and a same-instrument manual position
+   that remains unclaimed. No broker writer or paper allocator is enabled.
 7. **Paper allocator/executor:** exact strategy version, sleeve cash, current
    preflight, SL/TP and portfolio guard; no live key path.
 8. **Owned-position manager:** exact-position exits, timeout and separately

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -374,7 +374,12 @@ are actually created.
    new-entry kill row rather than appending polling heartbeats. Real-Postgres
    crash-point tests cover before-call identity, during-call uncertainty,
    after-acceptance replay, partial fills and a same-instrument manual position
-   that remains unclaimed. No broker writer or paper allocator is enabled.
+   that remains unclaimed. Detailed lookup follows the settled eToro carve-out
+   in `docs/review-prevention-log.md` (#471): all decision-bearing identity,
+   status, execution, units, price, time and fee fields land in compact SQL;
+   the full body remains process-local and one SHA-256 fingerprint is retained
+   per order. Repeated polls append no JSON. No broker writer or paper allocator
+   is enabled.
 7. **Paper allocator/executor:** exact strategy version, sleeve cash, current
    preflight, SL/TP and portfolio guard; no live key path.
 8. **Owned-position manager:** exact-position exits, timeout and separately

--- a/sql/285_strategy_order_reconciliation.sql
+++ b/sql/285_strategy_order_reconciliation.sql
@@ -1,0 +1,106 @@
+-- 285_strategy_order_reconciliation.sql
+--
+-- #2451 / #2437 slice 6. Persist the broker submission UUID before I/O, keep
+-- only one compact reconciliation state per strategy order, and retain exact
+-- position execution facts without a polling-event heap.
+
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS strategy_request_id UUID;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_orders_strategy_request_id
+    ON orders (strategy_request_id)
+    WHERE strategy_request_id IS NOT NULL;
+
+ALTER TABLE orders
+    DROP CONSTRAINT IF EXISTS orders_strategy_request_origin_check;
+
+ALTER TABLE orders
+    ADD CONSTRAINT orders_strategy_request_origin_check CHECK (
+        strategy_request_id IS NULL OR execution_origin = 'strategy'
+    );
+
+CREATE OR REPLACE FUNCTION prevent_strategy_request_id_change()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF OLD.strategy_request_id IS NOT NULL
+       AND NEW.strategy_request_id IS DISTINCT FROM OLD.strategy_request_id THEN
+        RAISE EXCEPTION 'strategy_request_id is immutable once assigned';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_orders_strategy_request_id_immutable ON orders;
+CREATE TRIGGER trg_orders_strategy_request_id_immutable
+BEFORE UPDATE OF strategy_request_id ON orders
+FOR EACH ROW EXECUTE FUNCTION prevent_strategy_request_id_change();
+
+-- A position may occur in its opening order and later exact-position close or
+-- patch orders. Provenance is the (order, position) pair; ownership remains
+-- globally unique in strategy_position_ownership.
+ALTER TABLE strategy_order_position_executions
+    DROP CONSTRAINT IF EXISTS strategy_order_position_executions_broker_position_id_key;
+
+ALTER TABLE strategy_order_position_executions
+    ADD COLUMN IF NOT EXISTS position_state TEXT,
+    ADD COLUMN IF NOT EXISTS remaining_units NUMERIC(28,10),
+    ADD COLUMN IF NOT EXISTS opening_units NUMERIC(28,10),
+    ADD COLUMN IF NOT EXISTS average_price NUMERIC(28,10),
+    ADD COLUMN IF NOT EXISTS execution_time TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS fees NUMERIC(28,10),
+    ADD COLUMN IF NOT EXISTS last_observed_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS idx_strategy_order_position_execution_position
+    ON strategy_order_position_executions (broker_position_id, order_id);
+
+CREATE TABLE IF NOT EXISTS strategy_order_reconciliation_state (
+    order_id              BIGINT PRIMARY KEY
+        REFERENCES orders(order_id) ON DELETE RESTRICT,
+    state                 TEXT NOT NULL DEFAULT 'unresolved' CHECK (state IN (
+        'unresolved', 'pending', 'resolved', 'rejected', 'not_found',
+        'ambiguous', 'error'
+    )),
+    first_unresolved_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_attempt_at       TIMESTAMPTZ,
+    reconciled_at         TIMESTAMPTZ,
+    attempt_count         INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+    broker_status         TEXT,
+    position_count        INTEGER NOT NULL DEFAULT 0 CHECK (position_count >= 0),
+    last_error_code       TEXT,
+    last_payload_sha256   TEXT,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_order_reconciliation_hash_check CHECK (
+        last_payload_sha256 IS NULL OR last_payload_sha256 ~ '^[0-9a-f]{64}$'
+    ),
+    CONSTRAINT strategy_order_reconciliation_resolved_shape CHECK (
+        (state IN ('resolved', 'rejected') AND reconciled_at IS NOT NULL)
+        OR (state NOT IN ('resolved', 'rejected') AND reconciled_at IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_order_reconciliation_backlog
+    ON strategy_order_reconciliation_state (first_unresolved_at, order_id)
+    WHERE state NOT IN ('resolved', 'rejected');
+
+-- One current kill condition per source. Poll success updates this row; it does
+-- not append heartbeats. Later health controls share this bounded table.
+CREATE TABLE IF NOT EXISTS strategy_execution_blocks (
+    source       TEXT PRIMARY KEY,
+    active       BOOLEAN NOT NULL,
+    reason       TEXT NOT NULL CHECK (reason <> ''),
+    blocked_at   TIMESTAMPTZ,
+    cleared_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_execution_blocks_time_shape CHECK (
+        (active AND blocked_at IS NOT NULL AND cleared_at IS NULL)
+        OR (NOT active AND cleared_at IS NOT NULL)
+    )
+);
+
+COMMENT ON COLUMN orders.strategy_request_id IS
+    'Immutable UUID committed before strategy broker I/O and reused as the '
+    'eToro v2 X-Request-Id idempotency key and orders:lookup referenceId.';
+
+COMMENT ON TABLE strategy_order_reconciliation_state IS
+    'One bounded current-state row per strategy order; repeated polling updates '
+    'this row rather than retaining unbounded response/event payloads.';

--- a/sql/286_strategy_reconciliation_text_bounds.sql
+++ b/sql/286_strategy_reconciliation_text_bounds.sql
@@ -1,0 +1,45 @@
+-- 286_strategy_reconciliation_text_bounds.sql
+--
+-- #2451 hardening kept separate because sql/285 was exercised against the dev
+-- database before review completed. Bound broker-owned text before persistence
+-- and give the trigger function a strategy-specific name.
+
+CREATE OR REPLACE FUNCTION strategy_prevent_request_id_change()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF OLD.strategy_request_id IS NOT NULL
+       AND NEW.strategy_request_id IS DISTINCT FROM OLD.strategy_request_id THEN
+        RAISE EXCEPTION 'strategy_request_id is immutable once assigned';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_orders_strategy_request_id_immutable ON orders;
+CREATE TRIGGER trg_orders_strategy_request_id_immutable
+BEFORE UPDATE OF strategy_request_id ON orders
+FOR EACH ROW EXECUTE FUNCTION strategy_prevent_request_id_change();
+
+DROP FUNCTION IF EXISTS prevent_strategy_request_id_change();
+
+ALTER TABLE strategy_order_position_executions
+    ADD CONSTRAINT strategy_order_position_execution_text_bounds CHECK (
+        position_state IS NULL OR char_length(position_state) BETWEEN 1 AND 64
+    );
+
+ALTER TABLE strategy_order_reconciliation_state
+    ADD CONSTRAINT strategy_order_reconciliation_text_bounds CHECK (
+        (broker_status IS NULL OR char_length(broker_status) BETWEEN 1 AND 64)
+        AND (last_error_code IS NULL OR char_length(last_error_code) BETWEEN 1 AND 64)
+    );
+
+ALTER TABLE strategy_execution_blocks
+    DROP CONSTRAINT strategy_execution_blocks_reason_check;
+
+ALTER TABLE strategy_execution_blocks
+    ADD CONSTRAINT strategy_execution_blocks_reason_check CHECK (
+        char_length(reason) BETWEEN 1 AND 500
+    ),
+    ADD CONSTRAINT strategy_execution_blocks_source_bound CHECK (
+        char_length(source) BETWEEN 1 AND 64
+    );

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -199,6 +199,8 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # current operator decision.
     "strategy_promotions",
     "strategy_deployments",
+    # #2451 — bounded current kill state has no FK by design.
+    "strategy_execution_blocks",
     "positions",
     "quotes",
     # #1919 — thesis generation attempts (FK → instruments + theses).

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -12,22 +12,26 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import MagicMock
+from uuid import UUID, uuid4
 
 import httpx
 
 from app.providers.broker import (
     BrokerMirror,
     BrokerMirrorPosition,
+    BrokerOrderNotFound,
     BrokerPortfolio,
     BrokerWhatIfOrder,
     OrderParams,
 )
 from app.providers.implementations.etoro_broker import (
     EtoroBrokerProvider,
+    OrderDetailParseError,
     TradingPreflightParseError,
     _normalise_close_order_response,
     _normalise_open_order_response,
     _normalise_order_info_response,
+    _parse_order_detail,
 )
 
 # ---------------------------------------------------------------------------
@@ -64,6 +68,37 @@ FIXTURE_ORDER_INFO_RESPONSE = {
     "amount": 100.0,
     "units": 0.54,
     "positions": [{"positionID": 98765}],
+}
+
+FIXTURE_ORDER_DETAIL_RESPONSE = {
+    "orderId": 13902598,
+    "status": {"id": 3, "name": "Filled", "errorCode": 0, "errorMessage": None},
+    "asset": {"instrumentId": 1001, "symbol": "AAPL"},
+    "positionExecutions": [
+        {
+            "positionId": 9001,
+            "state": "open",
+            "remainingUnits": 6.5,
+            "openingData": {
+                "executionTime": "2026-08-09T09:00:01Z",
+                "units": 6.5,
+                "avgPrice": 95.25,
+                "fees": 2.5,
+            },
+        },
+        {
+            "positionId": 9002,
+            "state": "open",
+            "remainingUnits": 4,
+            "openingData": {
+                "executionTime": "2026-08-09T09:00:02Z",
+                "units": 4,
+                "avgPrice": 95.5,
+                "fees": 1.5,
+            },
+        },
+    ],
+    "lastUpdate": "2026-08-09T09:00:02Z",
 }
 
 FIXTURE_PORTFOLIO_RESPONSE = {
@@ -272,6 +307,26 @@ class TestPlaceOrderByAmount:
             assert body["Leverage"] == 1
             assert body["Amount"] == 100.0
             assert "AmountInUnits" not in body
+
+    def test_uses_caller_owned_request_id_for_idempotency(self) -> None:
+        request_id = UUID("6f0b1702-99f8-41fe-97d7-0841c448e603")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FIXTURE_OPEN_ORDER_RESPONSE
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = mock_resp
+
+            broker.place_order(
+                1001,
+                "BUY",
+                amount=Decimal("100"),
+                units=None,
+                request_id=request_id,
+            )
+
+            headers = broker._http_write.post.call_args.kwargs["headers"]
+            assert headers["x-request-id"] == str(request_id)
 
     def test_returns_filled_result(self) -> None:
         mock_resp = MagicMock()
@@ -553,6 +608,77 @@ class TestGetOrderStatus:
 
             assert result.status == "failed"
             assert result.broker_order_ref == "12345"
+
+
+class TestDetailedOrderLookup:
+    def test_reference_id_routes_to_v2_and_preserves_exact_executions(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FIXTURE_ORDER_DETAIL_RESPONSE
+        reference_id = "1c94300c-90aa-4303-9d00-dec376d74efb"
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            result = broker.lookup_order(reference_id=reference_id)
+
+        call = broker._http_read.get.call_args
+        assert call.args[0] == "/api/v2/trading/info/demo/orders:lookup"
+        assert call.kwargs["params"] == {"referenceId": reference_id}
+        assert result.broker_order_ref == "13902598"
+        assert result.instrument_id == 1001
+        assert [execution.position_id for execution in result.position_executions] == [9001, 9002]
+        assert result.position_executions[0].opening_units == Decimal("6.5")
+        assert result.position_executions[0].average_price == Decimal("95.25")
+
+    def test_order_id_is_mutually_exclusive_and_positive(self) -> None:
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            for kwargs in ({}, {"order_id": "1", "reference_id": str(uuid4())}, {"order_id": "0"}):
+                try:
+                    broker.lookup_order(**kwargs)  # type: ignore[arg-type]
+                except ValueError:
+                    pass
+                else:  # pragma: no cover - assertion helper branch
+                    raise AssertionError("unsafe lookup identity must be refused")
+
+    def test_404_is_distinct_from_transport_failure(self) -> None:
+        response = httpx.Response(404, request=httpx.Request("GET", "https://example.test"))
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.side_effect = httpx.HTTPStatusError(
+                "not found", request=response.request, response=response
+            )
+            try:
+                broker.lookup_order(order_id="123")
+            except BrokerOrderNotFound:
+                pass
+            else:  # pragma: no cover - assertion helper branch
+                raise AssertionError("404 must remain distinguishable for crash reconciliation")
+
+    def test_parser_refuses_duplicate_position_identity(self) -> None:
+        malformed = {
+            **FIXTURE_ORDER_DETAIL_RESPONSE,
+            "positionExecutions": [
+                FIXTURE_ORDER_DETAIL_RESPONSE["positionExecutions"][0],
+                FIXTURE_ORDER_DETAIL_RESPONSE["positionExecutions"][0],
+            ],
+        }
+        try:
+            _parse_order_detail(malformed, reference_id=None)
+        except OrderDetailParseError:
+            pass
+        else:  # pragma: no cover - assertion helper branch
+            raise AssertionError("duplicate exact position ids must fail closed")
+
+    def test_parser_refuses_execution_without_fill_facts(self) -> None:
+        execution = dict(FIXTURE_ORDER_DETAIL_RESPONSE["positionExecutions"][0])
+        execution["openingData"] = {"executionTime": "2026-08-09T09:00:01Z", "fees": 0}
+        malformed = {**FIXTURE_ORDER_DETAIL_RESPONSE, "positionExecutions": [execution]}
+        try:
+            _parse_order_detail(malformed, reference_id=None)
+        except OrderDetailParseError as exc:
+            assert "units" in str(exc)
+        else:  # pragma: no cover - assertion helper branch
+            raise AssertionError("position identity without positive fill facts must fail closed")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_strategy_order_reconciliation.py
+++ b/tests/test_strategy_order_reconciliation.py
@@ -1,0 +1,283 @@
+"""#2451 crash-safe strategy order reconciliation integration tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.providers.broker import (
+    BrokerOrderDetail,
+    BrokerOrderLookupError,
+    BrokerOrderNotFound,
+    BrokerPositionExecution,
+    BrokerProvider,
+)
+from app.services.strategy_control_plane import (
+    StrategyControlError,
+    configure_deployment,
+    create_strategy_trade,
+    decide_funding,
+    link_strategy_order,
+)
+from app.services.strategy_order_reconciliation import (
+    enforce_reconciliation_slo,
+    ensure_strategy_request_id,
+    reconcile_strategy_order,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_trade(conn: psycopg.Connection[Any], *, instrument_id: int = 2451001) -> tuple[int, int]:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) VALUES (%s, %s, %s, true)",
+        (instrument_id, f"R{instrument_id}", "Reconciliation test"),
+    )
+    signal_row = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id, strategy_version, instrument_id, signal_bar_date,
+            signal_kind, verdict, fill_bar_date, fill_price, universe,
+            input_rule_set_versions
+        ) VALUES ('S-REC', 'v1', %s, '2026-08-06', 'entry', 'fired',
+                  '2026-08-07', 100, 'survivor_only',
+                  '{"indicator_series":"rules-v1"}'::jsonb)
+        RETURNING signal_id
+        """,
+        (instrument_id,),
+    ).fetchone()
+    assert signal_row is not None
+    signal_id = signal_row[0]
+    conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id, strategy_version, from_stage, to_stage, gate_version,
+            evidence_ref, promoted_by, reason
+        ) VALUES
+          ('S-REC', 'v1', NULL, 'research_candidate', 'test-v1', NULL, 'test', 'registered'),
+          ('S-REC', 'v1', 'research_candidate', 'historical_validated', 'test-v1', 'e:h', 'test', 'historical'),
+          ('S-REC', 'v1', 'historical_validated', 'forward_observation', 'test-v1', 'e:f', 'test', 'forward'),
+          ('S-REC', 'v1', 'forward_observation', 'paper_enabled', 'test-v1', 'e:p', 'test', 'paper')
+        """
+    )
+    deployment = configure_deployment(
+        conn,
+        strategy_id="S-REC",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("1000"),
+        enabled=True,
+        changed_by="test",
+        reason="reconciliation fixture",
+    )
+    decision_id = decide_funding(
+        conn,
+        signal_id=int(signal_id),
+        verdict="allocated",
+        deployment_id=deployment.deployment_id,
+        amount=Decimal("100"),
+        reason_code="test",
+    )
+    trade_id = create_strategy_trade(conn, decision_id)
+    order_row = conn.execute(
+        """
+        INSERT INTO orders (
+            instrument_id, action, order_type, requested_amount, status,
+            execution_origin
+        ) VALUES (%s, 'BUY', 'MARKET', 100, 'submitted', 'strategy')
+        RETURNING order_id
+        """,
+        (instrument_id,),
+    ).fetchone()
+    assert order_row is not None
+    order_id = order_row[0]
+    link_strategy_order(conn, strategy_trade_id=trade_id, order_id=int(order_id), purpose="entry")
+    return trade_id, int(order_id)
+
+
+def _detail(
+    *,
+    broker_status: str = "Filled",
+    position_ids: tuple[int, ...] = (910001, 910002),
+) -> BrokerOrderDetail:
+    executions = tuple(
+        BrokerPositionExecution(
+            position_id=position_id,
+            state="open",
+            remaining_units=Decimal("0.5"),
+            opening_units=Decimal("0.5"),
+            average_price=Decimal("100"),
+            execution_time=datetime(2026, 8, 9, 9, 0, tzinfo=UTC),
+            fees=Decimal("0.1"),
+            raw_payload={"positionId": position_id},
+        )
+        for position_id in position_ids
+    )
+    return BrokerOrderDetail(
+        broker_order_ref="13902598",
+        reference_id=None,
+        status="filled" if broker_status == "Filled" else "pending",
+        broker_status=broker_status,
+        instrument_id=2451001,
+        position_executions=executions,
+        last_update=datetime(2026, 8, 9, 9, 1, tzinfo=UTC),
+        raw_payload={
+            "orderId": 13902598,
+            "status": {"name": broker_status},
+            "asset": {"instrumentId": 2451001},
+            "positionExecutions": [{"positionId": value} for value in position_ids],
+        },
+    )
+
+
+def test_crash_identity_is_stable_and_recovery_is_idempotent(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    trade_id, order_id = _seed_trade(conn)
+
+    # Before-call crash: the committed identity would survive, and a restart
+    # never mints a second UUID.
+    first_request_id = ensure_strategy_request_id(conn, order_id=order_id)
+    assert ensure_strategy_request_id(conn, order_id=order_id) == first_request_id
+    conn.commit()
+
+    # During-call transport uncertainty: retain the same UUID and fail closed.
+    uncertain_broker = MagicMock(spec=BrokerProvider)
+    uncertain_broker.lookup_order.side_effect = BrokerOrderLookupError("timeout")
+    uncertain = reconcile_strategy_order(conn, broker=uncertain_broker, order_id=order_id)
+    assert uncertain.state == "error"
+    assert uncertain_broker.lookup_order.call_args.kwargs == {"reference_id": str(first_request_id)}
+    assert ensure_strategy_request_id(conn, order_id=order_id) == first_request_id
+    conn.commit()
+
+    # After broker acceptance: exact position cardinality and partial units are
+    # durable. Replaying the same response creates no duplicate mappings/claims.
+    accepted_broker = MagicMock(spec=BrokerProvider)
+    accepted_broker.lookup_order.return_value = _detail()
+    first = reconcile_strategy_order(conn, broker=accepted_broker, order_id=order_id)
+    second = reconcile_strategy_order(conn, broker=accepted_broker, order_id=order_id)
+    assert first.state == second.state == "resolved"
+    assert first.position_ids == (910001, 910002)
+    accepted_broker.lookup_order.assert_called_once()
+    assert conn.execute(
+        "SELECT count(*) FROM strategy_order_position_executions WHERE order_id = %s", (order_id,)
+    ).fetchone() == (2,)
+    assert conn.execute(
+        "SELECT count(*) FROM strategy_position_ownership WHERE strategy_trade_id = %s", (trade_id,)
+    ).fetchone() == (2,)
+    assert conn.execute(
+        "SELECT opening_units, average_price FROM strategy_order_position_executions "
+        "WHERE order_id = %s ORDER BY broker_position_id LIMIT 1",
+        (order_id,),
+    ).fetchone() == (Decimal("0.5000000000"), Decimal("100.0000000000"))
+    assert conn.execute("SELECT raw_payload_json FROM orders WHERE order_id = %s", (order_id,)).fetchone() == (None,)
+
+
+def test_pending_partial_fill_is_owned_but_remains_in_backlog(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    trade_id, order_id = _seed_trade(conn)
+    ensure_strategy_request_id(conn, order_id=order_id)
+    conn.commit()
+    broker = MagicMock(spec=BrokerProvider)
+    broker.lookup_order.return_value = _detail(broker_status="Pending", position_ids=(910010,))
+
+    result = reconcile_strategy_order(conn, broker=broker, order_id=order_id)
+
+    assert result.state == "pending"
+    assert conn.execute(
+        "SELECT broker_position_id FROM strategy_position_ownership WHERE strategy_trade_id = %s", (trade_id,)
+    ).fetchone() == (910010,)
+    assert conn.execute("SELECT status FROM strategy_trades WHERE strategy_trade_id = %s", (trade_id,)).fetchone() == (
+        "submitted",
+    )
+
+
+def test_same_instrument_manual_position_is_observed_but_never_claimed(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    trade_id, order_id = _seed_trade(conn)
+    conn.execute(
+        """
+        INSERT INTO broker_positions (
+            position_id, instrument_id, is_buy, units, amount,
+            initial_amount_in_dollars, open_rate, open_conversion_rate,
+            open_date_time, raw_payload
+        ) VALUES (919999, 2451001, true, 1, 100, 100, 100, 1, now(), '{}'::jsonb)
+        """
+    )
+    ensure_strategy_request_id(conn, order_id=order_id)
+    conn.commit()
+    broker = MagicMock(spec=BrokerProvider)
+    broker.lookup_order.return_value = _detail(position_ids=(910020,))
+
+    reconcile_strategy_order(conn, broker=broker, order_id=order_id)
+
+    owned = conn.execute(
+        "SELECT broker_position_id FROM strategy_position_ownership WHERE strategy_trade_id = %s", (trade_id,)
+    ).fetchall()
+    assert owned == [(910020,)]
+    assert 919999 not in {row[0] for row in owned}
+
+
+def test_not_found_and_overdue_backlog_activate_entry_kill(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    _, order_id = _seed_trade(conn)
+    ensure_strategy_request_id(conn, order_id=order_id)
+    conn.commit()
+    broker = MagicMock(spec=BrokerProvider)
+    broker.lookup_order.side_effect = BrokerOrderNotFound("not yet visible")
+
+    result = reconcile_strategy_order(conn, broker=broker, order_id=order_id)
+    assert result.state == "not_found"
+    conn.execute(
+        "UPDATE strategy_order_reconciliation_state SET first_unresolved_at = now() - interval '11 seconds' "
+        "WHERE order_id = %s",
+        (order_id,),
+    )
+    unhealthy = enforce_reconciliation_slo(conn, max_unresolved_seconds=10)
+    assert unhealthy.active_block is True
+    assert unhealthy.overdue_count == 1
+    assert conn.execute(
+        "SELECT active FROM strategy_execution_blocks WHERE source = 'order_reconciliation'"
+    ).fetchone() == (True,)
+    conn.commit()
+
+    # A later exact resolution clears the same bounded state row; no heartbeat
+    # or alert-event heap is accumulated.
+    broker.lookup_order.side_effect = None
+    broker.lookup_order.return_value = _detail(position_ids=(910030,))
+    reconcile_strategy_order(conn, broker=broker, order_id=order_id)
+    healthy = enforce_reconciliation_slo(conn, max_unresolved_seconds=10)
+    assert healthy.active_block is False
+    assert conn.execute("SELECT count(*) FROM strategy_execution_blocks").fetchone() == (1,)
+
+
+def test_manual_order_cannot_receive_strategy_submission_identity(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    conn.execute(
+        "INSERT INTO instruments (instrument_id, symbol, company_name, is_tradable) "
+        "VALUES (2451099, 'MANREC', 'Manual', true)"
+    )
+    manual_order_row = conn.execute(
+        """
+        INSERT INTO orders (instrument_id, action, order_type, requested_amount, status)
+        VALUES (2451099, 'BUY', 'MARKET', 100, 'submitted') RETURNING order_id
+        """
+    ).fetchone()
+    assert manual_order_row is not None
+    manual_order_id = manual_order_row[0]
+    with pytest.raises(StrategyControlError, match="strategy-origin"):
+        ensure_strategy_request_id(conn, order_id=int(manual_order_id))


### PR DESCRIPTION
## Summary
- persist one immutable strategy submission UUID before broker I/O and pass it unchanged as eToro `X-Request-Id`
- recover orders through documented v2 reference/order lookup and bind every exact `positionExecution.positionId`
- keep one bounded reconciliation row per order plus one current execution-block row, with no polling payload heap
- fail closed on ambiguous identity, unsafe payloads, ownership conflicts, or overdue reconciliation
- preserve manual position isolation while retaining portfolio-wide observation

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not db" -q`
- `uv run pytest tests/smoke -q`
- focused provider and real-Postgres reconciliation tests
- complete repository pre-push gate

## Independent review dispositions
- FIXED P1: strategy submission identity can now be supplied to `place_order` and is sent unchanged as `x-request-id`; provider test pins the header.
- REBUTTED P1: multi-position ownership is already enabled by `sql/282_strategy_multi_position_ownership.sql` on main, which drops the obsolete unique trade index. The real-Postgres reconciliation test persists two active broker positions for one trade.

No broker order was placed by this change. Live strategy execution remains disabled.

Closes #2451