### PR TITLE
feat(strategies): add fail-closed demo allocator (#2449)

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -367,3 +367,29 @@ arm's own session.
 ## Maintenance
 
 When you verify a NEW capability or find drift: update `docs/etoro-api-reference.md` + the memory reference files in the same session (skill-ownership rule — no "later").
+
+## Automated paper-entry boundary — VERIFIED 2026-08-09 (#2449)
+
+- Use only `POST /api/v2/trading/execution/demo/orders` for strategy entry.
+  The adapter must refuse `env != demo`; never derive a strategy endpoint from a
+  generic real/demo prefix and never fall back to the legacy manual writer.
+- Commit one UUID before I/O and send that exact value as `X-Request-Id`.
+  Acceptance returns `orderId`, `referenceId` and `token`; require a positive
+  order id and `referenceId == request UUID`. Any malformed/transport/5xx result
+  is uncertain and resolves through `orders:lookup`, not a newly keyed POST.
+- The MVP shape is long `buy`, `real`, market, x1, USD amount, fixed stop loss
+  and take profit. Shorts are CFDs and are outside this contract.
+- Current cost docs show `costs[].amount` in USD plus `lastUpdated`, but the
+  measured demo spike returned undocumented `value`. `amount` and `value` are
+  not aliases: automated use rejects `value`, stale/missing/negative/non-USD
+  components and positive recurring fees without an explicit hold horizon.
+- Do not treat portfolio `credit` as spendable cash. The official P&L formulas
+  are: available cash = credits minus manual pending-open orders and other
+  pending orders; total invested includes direct/mirror positions, mirror
+  adjusted cash, pending orders and external costs; equity = available cash +
+  total invested + unrealised P&L. All manual holdings count toward risk even
+  though strategy ownership remains exact-order provenance only.
+
+Primary pages: `trading--demo/create-an-order`,
+`trading--demo/get-what-if-trading-cost-breakdown`, and guides
+`calculate-available-cash`, `calculate-total-invested`, `calculate-equity`.

--- a/.claude/skills/quant/trade-lifecycle.md
+++ b/.claude/skills/quant/trade-lifecycle.md
@@ -94,6 +94,23 @@ momentum, not universally (Moreira-Muir vs Cederburg et al.).
   rotate the UUID or submit a newly keyed order. Pending/partial executions are
   owned by exact returned position id but keep the entry backlog unresolved;
   an overdue backlog blocks new entries.
+- **Paper allocation is a conjunction, not a score.** Current quote/session,
+  fresh signal scan, fresh halt feed/no unresolved halt, current exact-arm
+  eligibility, documented current costs, reconciliation health, global/strategy
+  switches, operator cap, account cash/exposure/concentration/drawdown and a
+  positive stressed lower-bound net expectancy must all pass. One strong metric
+  never compensates for a missing safety input.
+- **Size against the whole demo account.** Manual positions and pending orders
+  reduce cash, portfolio exposure and instrument concentration capacity, but
+  they never enter strategy P&L or become close/ratchet targets. Ticket size is
+  the minimum of operator ticket rule/cap, remaining strategy sleeve, broker
+  available cash, portfolio capacity and instrument capacity.
+- **Use lower-bound net expectancy:** `min(pinned bootstrap expectancy CI) -
+  stressed documented current costs / exact ticket amount * 100`. Unknown cost
+  units or unmodelled recurring-horizon fees are refusals, not zero.
+- **Persist the negative arm.** Each durable fired entry gets one compact funded
+  or rejected preflight. A rejection is monitoring evidence and must name its
+  closed reason; do not retain repeated raw broker/feed snapshots to achieve it.
 
 ### `INITIAL_STOP`
 

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -73,6 +73,42 @@ class BrokerOrderNotFound(BrokerOrderLookupError):
     """No order currently resolves for the supplied durable identity."""
 
 
+class BrokerOrderSubmissionError(RuntimeError):
+    """A demo strategy submission failed before acceptance was established."""
+
+
+class BrokerOrderSubmissionUncertain(BrokerOrderSubmissionError):
+    """Transport/response failure requires lookup by the same request UUID."""
+
+
+@dataclass(frozen=True)
+class BrokerStrategyOrder:
+    """The deliberately narrow order shape allowed by the paper MVP."""
+
+    instrument_id: int
+    amount: Decimal
+    settlement_type: Literal["real"]
+    stop_loss_rate: Decimal
+    take_profit_rate: Decimal
+
+    def __post_init__(self) -> None:
+        if self.instrument_id <= 0 or self.amount <= 0:
+            raise ValueError("strategy order instrument and amount must be positive")
+        if self.settlement_type != "real":
+            raise ValueError("the paper MVP supports real settlement only")
+        if self.stop_loss_rate <= 0 or self.take_profit_rate <= 0:
+            raise ValueError("fixed stop-loss and take-profit rates are required")
+
+
+@dataclass(frozen=True)
+class BrokerOrderSubmission:
+    """Broker acceptance identity; execution detail is reconciled separately."""
+
+    broker_order_ref: str
+    reference_id: UUID
+    token: UUID
+
+
 @dataclass(frozen=True)
 class OrderParams:
     """Optional parameters for order placement.
@@ -282,6 +318,27 @@ class BrokerPortfolio:
 
 
 @dataclass(frozen=True)
+class BrokerInstrumentInvestment:
+    """USD capital currently committed to one instrument, any ownership."""
+
+    instrument_id: int
+    amount: Decimal
+
+
+@dataclass(frozen=True)
+class BrokerAccountRiskSnapshot:
+    """Decision-bearing account totals derived from eToro's P&L endpoint."""
+
+    available_cash: Decimal
+    total_invested: Decimal
+    unrealized_pnl: Decimal
+    equity: Decimal
+    instrument_investments: tuple[BrokerInstrumentInvestment, ...]
+    observed_at: datetime
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
 class BrokerClosedTrade:
     """One closed-position slice from the broker's trade history.
 
@@ -408,4 +465,27 @@ class BrokerProvider(ABC):
 
     def get_what_if_costs(self, order: BrokerWhatIfOrder) -> BrokerWhatIfCostResponse:
         """Fetch current broker-estimated costs without placing an order."""
+        raise NotImplementedError
+
+    def place_demo_strategy_order(
+        self,
+        order: BrokerStrategyOrder,
+        *,
+        request_id: UUID,
+    ) -> BrokerOrderSubmission:
+        """Submit the strict v2 demo-only strategy shape.
+
+        Non-abstract for compatibility with existing test providers. A caller
+        must treat ``NotImplementedError`` as refusal, never fall back to the
+        generic/live-capable writer.
+        """
+        raise NotImplementedError
+
+    def get_account_risk_snapshot(self) -> BrokerAccountRiskSnapshot:
+        """Get demo-account cash, invested capital, P&L and equity.
+
+        A strategy gate must refuse when this capability is absent; the older
+        portfolio reader's ``credit`` field is not available cash because it
+        omits pending orders.
+        """
         raise NotImplementedError

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -24,10 +24,12 @@ import httpx
 
 from app.config import settings
 from app.providers.broker import (
+    BrokerAccountRiskSnapshot,
     BrokerClosedTrade,
     BrokerCostComponent,
     BrokerEligibilityResponse,
     BrokerInstrumentEligibility,
+    BrokerInstrumentInvestment,
     BrokerLeverageConfig,
     BrokerMirror,
     BrokerMirrorPosition,
@@ -35,10 +37,14 @@ from app.providers.broker import (
     BrokerOrderLookupError,
     BrokerOrderNotFound,
     BrokerOrderResult,
+    BrokerOrderSubmission,
+    BrokerOrderSubmissionError,
+    BrokerOrderSubmissionUncertain,
     BrokerPortfolio,
     BrokerPosition,
     BrokerPositionExecution,
     BrokerProvider,
+    BrokerStrategyOrder,
     BrokerWhatIfCostResponse,
     BrokerWhatIfOrder,
     OrderParams,
@@ -321,6 +327,66 @@ class EtoroBrokerProvider(BrokerProvider):
         raw["_ebull_action"] = action
         return _normalise_open_order_response(raw)
 
+    def place_demo_strategy_order(
+        self,
+        order: BrokerStrategyOrder,
+        *,
+        request_id: UUID,
+    ) -> BrokerOrderSubmission:
+        """Submit the v2 paper-MVP order; no real endpoint can be selected.
+
+        The generic v1 writer remains for manual behavior. Automated strategy
+        code must call this method and cannot inherit ``self._env`` into a real
+        path by mistake.
+        """
+        if self._env != "demo":
+            raise BrokerOrderSubmissionError("strategy paper orders require demo credentials")
+        body: dict[str, Any] = {
+            "action": "open",
+            "transaction": "buy",
+            "instrumentId": order.instrument_id,
+            "settlementType": "real",
+            "orderType": "mkt",
+            "leverage": 1,
+            "amount": float(order.amount),
+            "orderCurrency": "usd",
+            "stopLossRate": float(order.stop_loss_rate),
+            "takeProfitRate": float(order.take_profit_rate),
+            "stopLossType": "fixed",
+        }
+        try:
+            response = self._http_write.post(
+                "/api/v2/trading/execution/demo/orders",
+                json=body,
+                headers=self._request_headers(request_id),
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            # The broker explicitly rejected a 4xx request. A 5xx may have
+            # accepted it before failing, so only the latter is uncertain.
+            if 400 <= exc.response.status_code < 500:
+                raise BrokerOrderSubmissionError(
+                    f"demo strategy order rejected with HTTP {exc.response.status_code}"
+                ) from exc
+            raise BrokerOrderSubmissionUncertain("demo strategy order returned a server error") from exc
+        except httpx.HTTPError as exc:
+            raise BrokerOrderSubmissionUncertain("demo strategy order transport failed") from exc
+        try:
+            raw = response.json()
+        except ValueError as exc:
+            raise BrokerOrderSubmissionUncertain("demo strategy order returned non-JSON data") from exc
+        if not isinstance(raw, dict):
+            raise BrokerOrderSubmissionUncertain("demo strategy order response must be an object")
+        try:
+            broker_order_id = int(raw["orderId"])
+            reference_id = UUID(str(raw["referenceId"]))
+            token = UUID(str(raw["token"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrokerOrderSubmissionUncertain("demo strategy order response identity is malformed") from exc
+        if broker_order_id <= 0 or reference_id != request_id:
+            raise BrokerOrderSubmissionUncertain("demo strategy order response identity does not match intent")
+        return BrokerOrderSubmission(str(broker_order_id), reference_id, token)
+
     def close_position(
         self,
         position_id: int,
@@ -569,6 +635,20 @@ class EtoroBrokerProvider(BrokerProvider):
             raw_payload=raw,
             mirrors=tuple(_parse_mirrors_payload(raw_mirrors)),
         )
+
+    def get_account_risk_snapshot(self) -> BrokerAccountRiskSnapshot:
+        """Fetch and strictly derive the official demo P&L risk totals."""
+        if self._env != "demo":
+            raise TradingPreflightParseError("strategy account risk requires demo credentials")
+        response = self._http_read.get(
+            "/api/v1/trading/info/demo/pnl",
+            headers=self._request_headers(),
+        )
+        response.raise_for_status()
+        raw = response.json()
+        if not isinstance(raw, dict):
+            raise TradingPreflightParseError("account P&L response must be an object")
+        return _parse_account_risk_snapshot(raw, observed_at=datetime.now(UTC))
 
     def get_trade_history(self, min_date: datetime, page_size: int = 200) -> Sequence[BrokerClosedTrade]:
         """Fetch all closed-trade rows with closeTimestamp >= min_date.
@@ -895,6 +975,123 @@ def _parse_order_detail(raw: dict[str, Any], *, reference_id: str | None) -> Bro
         raise
     except (KeyError, TypeError, ValueError) as exc:
         raise OrderDetailParseError(f"malformed order detail response: {exc}") from exc
+
+
+def _parse_account_risk_snapshot(
+    raw: dict[str, Any],
+    *,
+    observed_at: datetime,
+) -> BrokerAccountRiskSnapshot:
+    """Apply eToro's published cash/invested/equity formulas exactly."""
+
+    def _array(parent: dict[str, Any], key: str) -> list[Any]:
+        value = parent.get(key)
+        if not isinstance(value, list):
+            raise TradingPreflightParseError(f"account P&L {key} must be an array")
+        return value
+
+    def _row(value: Any, label: str) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise TradingPreflightParseError(f"account P&L {label} row must be an object")
+        return value
+
+    def _money(parent: dict[str, Any], key: str) -> Decimal:
+        if key not in parent or isinstance(parent[key], bool):
+            raise TradingPreflightParseError(f"account P&L {key} is required")
+        try:
+            value = Decimal(str(parent[key]))
+        except decimal.DecimalException as exc:
+            raise TradingPreflightParseError(f"account P&L {key} must be numeric") from exc
+        if not value.is_finite():
+            raise TradingPreflightParseError(f"account P&L {key} must be finite")
+        return value
+
+    def _instrument_id(parent: dict[str, Any]) -> int:
+        raw_id = parent.get("instrumentId", parent.get("instrumentID"))
+        if raw_id is None:
+            raise TradingPreflightParseError("account P&L instrument id is required")
+        try:
+            value = int(raw_id)
+        except (TypeError, ValueError) as exc:
+            raise TradingPreflightParseError("account P&L instrument id is required") from exc
+        if value <= 0:
+            raise TradingPreflightParseError("account P&L instrument id must be positive")
+        return value
+
+    try:
+        credit = _money(raw, "credits")
+        positions = _array(raw, "positions")
+        mirrors = _array(raw, "mirrors")
+        open_orders = _array(raw, "ordersForOpen")
+        orders = _array(raw, "orders")
+        investments: dict[int, Decimal] = {}
+        total_invested = Decimal("0")
+        unrealized = Decimal("0")
+
+        for item in positions:
+            row = _row(item, "positions")
+            amount = _money(row, "amount")
+            pnl = _money(_row(row.get("unrealizedPnL"), "positions.unrealizedPnL"), "pnL")
+            instrument_id = _instrument_id(row)
+            total_invested += amount
+            unrealized += pnl
+            investments[instrument_id] = investments.get(instrument_id, Decimal("0")) + amount
+
+        for item in mirrors:
+            mirror = _row(item, "mirrors")
+            closed_profit = _money(mirror, "closedPositionsNetProfit")
+            total_invested += _money(mirror, "availableAmount") - closed_profit
+            unrealized += closed_profit
+            for item_position in _array(mirror, "positions"):
+                row = _row(item_position, "mirrors.positions")
+                amount = _money(row, "amount")
+                pnl = _money(_row(row.get("unrealizedPnL"), "mirrors.positions.unrealizedPnL"), "pnL")
+                instrument_id = _instrument_id(row)
+                total_invested += amount
+                unrealized += pnl
+                investments[instrument_id] = investments.get(instrument_id, Decimal("0")) + amount
+
+        pending_amount = Decimal("0")
+        for item in open_orders:
+            row = _row(item, "ordersForOpen")
+            mirror_id = int(row.get("mirrorID", row.get("mirrorId", 0)))
+            if mirror_id != 0:
+                continue
+            amount = _money(row, "amount")
+            external = _money(row, "totalExternalCosts")
+            instrument_id = _instrument_id(row)
+            pending_amount += amount
+            total_invested += amount + external
+            investments[instrument_id] = investments.get(instrument_id, Decimal("0")) + amount + external
+
+        for item in orders:
+            row = _row(item, "orders")
+            amount = _money(row, "amount")
+            instrument_id = _instrument_id(row)
+            pending_amount += amount
+            total_invested += amount
+            investments[instrument_id] = investments.get(instrument_id, Decimal("0")) + amount
+
+        available_cash = credit - pending_amount
+        equity = available_cash + total_invested + unrealized
+        if available_cash < 0 or total_invested < 0 or equity <= 0 or any(value < 0 for value in investments.values()):
+            raise TradingPreflightParseError("account P&L derived risk totals are outside safe bounds")
+        return BrokerAccountRiskSnapshot(
+            available_cash=available_cash,
+            total_invested=total_invested,
+            unrealized_pnl=unrealized,
+            equity=equity,
+            instrument_investments=tuple(
+                BrokerInstrumentInvestment(instrument_id, amount)
+                for instrument_id, amount in sorted(investments.items())
+            ),
+            observed_at=observed_at,
+            raw_payload=raw,
+        )
+    except TradingPreflightParseError:
+        raise
+    except (KeyError, TypeError, ValueError, decimal.DecimalException) as exc:
+        raise TradingPreflightParseError(f"malformed account P&L response: {exc}") from exc
 
 
 def _parse_direct_position(payload: dict[str, Any]) -> BrokerPosition:

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -77,6 +77,26 @@ class Deployment:
     revision: int
 
 
+@dataclass(frozen=True)
+class ExecutionPolicy:
+    deployment_id: int
+    revision: int
+    ticket_fraction: Decimal
+    max_ticket_amount: Decimal
+    stop_loss_pct: Decimal
+    take_profit_pct: Decimal
+    max_quote_age_seconds: int
+    max_scan_age_seconds: int
+    max_halt_feed_age_seconds: int
+    max_cost_age_seconds: int
+    max_reconciliation_age_seconds: int
+    max_instrument_exposure_pct: Decimal
+    max_portfolio_exposure_pct: Decimal
+    max_drawdown_pct: Decimal
+    min_net_expectancy_pct: Decimal
+    cost_stress_multiplier: Decimal
+
+
 def _require_text(value: str, field: str) -> None:
     if not value.strip():
         raise StrategyControlError(f"{field} must be non-empty")
@@ -291,6 +311,141 @@ def configure_deployment(
         enabled,
         revision,
     )
+
+
+def configure_execution_policy(
+    conn: psycopg.Connection[Any],
+    *,
+    deployment_id: int,
+    ticket_fraction: Decimal,
+    max_ticket_amount: Decimal,
+    stop_loss_pct: Decimal,
+    take_profit_pct: Decimal,
+    max_quote_age_seconds: int,
+    max_scan_age_seconds: int,
+    max_halt_feed_age_seconds: int,
+    max_cost_age_seconds: int,
+    max_reconciliation_age_seconds: int,
+    max_instrument_exposure_pct: Decimal,
+    max_portfolio_exposure_pct: Decimal,
+    max_drawdown_pct: Decimal,
+    min_net_expectancy_pct: Decimal,
+    cost_stress_multiplier: Decimal,
+    changed_by: str,
+    reason: str,
+) -> ExecutionPolicy:
+    """Set explicit paper-execution limits and append the complete revision.
+
+    There are intentionally no policy defaults: every number can authorise or
+    refuse capital and must therefore be an operator decision visible in the
+    audit stream.
+    """
+    for value, field in ((changed_by, "changed_by"), (reason, "reason")):
+        _require_text(value, field)
+    if not (Decimal("0") < ticket_fraction <= Decimal("1")):
+        raise StrategyControlError("ticket_fraction must be in (0, 1]")
+    if max_ticket_amount <= 0:
+        raise StrategyControlError("max_ticket_amount must be positive")
+    if not (Decimal("0") < stop_loss_pct < Decimal("100")) or take_profit_pct <= 0:
+        raise StrategyControlError("stop/take-profit percentages must be positive and stop_loss_pct < 100")
+    ages = (
+        max_quote_age_seconds,
+        max_scan_age_seconds,
+        max_halt_feed_age_seconds,
+        max_cost_age_seconds,
+        max_reconciliation_age_seconds,
+    )
+    if any(value <= 0 for value in ages):
+        raise StrategyControlError("freshness and reconciliation ages must be positive")
+    if not (Decimal("0") < max_instrument_exposure_pct <= Decimal("100")):
+        raise StrategyControlError("max_instrument_exposure_pct must be in (0, 100]")
+    if not (Decimal("0") < max_portfolio_exposure_pct <= Decimal("100")):
+        raise StrategyControlError("max_portfolio_exposure_pct must be in (0, 100]")
+    if not (Decimal("0") < max_drawdown_pct < Decimal("100")):
+        raise StrategyControlError("max_drawdown_pct must be in (0, 100)")
+    if cost_stress_multiplier < 1:
+        raise StrategyControlError("cost_stress_multiplier must be at least 1")
+
+    deployment = conn.execute(
+        "SELECT mode FROM strategy_deployments WHERE deployment_id = %s FOR UPDATE",
+        (deployment_id,),
+    ).fetchone()
+    if deployment is None:
+        raise StrategyControlError("deployment does not exist")
+    if deployment[0] != "paper":
+        raise StrategyControlError("the MVP execution policy is paper-only")
+    current = conn.execute(
+        "SELECT revision FROM strategy_execution_policies WHERE deployment_id = %s",
+        (deployment_id,),
+    ).fetchone()
+    revision = 1 if current is None else int(current[0]) + 1
+    values = (
+        deployment_id,
+        revision,
+        ticket_fraction,
+        max_ticket_amount,
+        stop_loss_pct,
+        take_profit_pct,
+        max_quote_age_seconds,
+        max_scan_age_seconds,
+        max_halt_feed_age_seconds,
+        max_cost_age_seconds,
+        max_reconciliation_age_seconds,
+        max_instrument_exposure_pct,
+        max_portfolio_exposure_pct,
+        max_drawdown_pct,
+        min_net_expectancy_pct,
+        cost_stress_multiplier,
+        changed_by,
+        reason,
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_execution_policies (
+            deployment_id, revision, ticket_fraction, max_ticket_amount,
+            stop_loss_pct, take_profit_pct, max_quote_age_seconds,
+            max_scan_age_seconds, max_halt_feed_age_seconds,
+            max_cost_age_seconds, max_reconciliation_age_seconds,
+            max_instrument_exposure_pct, max_portfolio_exposure_pct,
+            max_drawdown_pct, min_net_expectancy_pct,
+            cost_stress_multiplier, updated_by, reason
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (deployment_id) DO UPDATE SET
+            revision = EXCLUDED.revision,
+            ticket_fraction = EXCLUDED.ticket_fraction,
+            max_ticket_amount = EXCLUDED.max_ticket_amount,
+            stop_loss_pct = EXCLUDED.stop_loss_pct,
+            take_profit_pct = EXCLUDED.take_profit_pct,
+            max_quote_age_seconds = EXCLUDED.max_quote_age_seconds,
+            max_scan_age_seconds = EXCLUDED.max_scan_age_seconds,
+            max_halt_feed_age_seconds = EXCLUDED.max_halt_feed_age_seconds,
+            max_cost_age_seconds = EXCLUDED.max_cost_age_seconds,
+            max_reconciliation_age_seconds = EXCLUDED.max_reconciliation_age_seconds,
+            max_instrument_exposure_pct = EXCLUDED.max_instrument_exposure_pct,
+            max_portfolio_exposure_pct = EXCLUDED.max_portfolio_exposure_pct,
+            max_drawdown_pct = EXCLUDED.max_drawdown_pct,
+            min_net_expectancy_pct = EXCLUDED.min_net_expectancy_pct,
+            cost_stress_multiplier = EXCLUDED.cost_stress_multiplier,
+            updated_by = EXCLUDED.updated_by, reason = EXCLUDED.reason,
+            updated_at = now()
+        """,
+        values,
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_execution_policy_events (
+            deployment_id, revision, ticket_fraction, max_ticket_amount,
+            stop_loss_pct, take_profit_pct, max_quote_age_seconds,
+            max_scan_age_seconds, max_halt_feed_age_seconds,
+            max_cost_age_seconds, max_reconciliation_age_seconds,
+            max_instrument_exposure_pct, max_portfolio_exposure_pct,
+            max_drawdown_pct, min_net_expectancy_pct,
+            cost_stress_multiplier, changed_by, reason
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        values,
+    )
+    return ExecutionPolicy(*values[:16])
 
 
 def decide_funding(
@@ -543,6 +698,7 @@ def release_exact_position(
 
 __all__ = [
     "Deployment",
+    "ExecutionPolicy",
     "GOVERNANCE_GATE_VERSION",
     "Promotion",
     "StrategyControlError",
@@ -550,6 +706,7 @@ __all__ = [
     "assert_exact_position_owned",
     "claim_exact_position",
     "configure_deployment",
+    "configure_execution_policy",
     "create_strategy_trade",
     "current_stage",
     "decide_funding",

--- a/app/services/strategy_halts.py
+++ b/app/services/strategy_halts.py
@@ -1,0 +1,208 @@
+"""Bounded ingestion of Nasdaq Trader's free, primary-source halt RSS feed.
+
+The feed is a safety observation, never trading authority. A missing, stale or
+malformed snapshot makes the paper executor refuse the signal. Successful
+polls update one feed-state row and upsert provider-native halt identities;
+rows older than 90 days are removed by the same transaction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from email.utils import parsedate_to_datetime
+from types import MappingProxyType
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import httpx
+import psycopg
+from psycopg.pq import TransactionStatus
+
+SOURCE = "nasdaq_trader_rss"
+NASDAQ_HALT_RSS_URL = "https://www.nasdaqtrader.com/rss.aspx?feed=tradehalts"
+_NDAQ = "{http://www.nasdaqtrader.com/}"
+_NY = ZoneInfo("America/New_York")
+_MAX_BYTES = 2_000_000
+_MAX_ITEMS = 5_000
+_RETENTION_DAYS = 90
+
+
+class HaltFeedError(ValueError):
+    """The source payload cannot safely establish current halt state."""
+
+
+@dataclass(frozen=True)
+class MarketHalt:
+    symbol: str
+    halt_at: datetime
+    market: str
+    reason_code: str
+    resumed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class HaltSnapshot:
+    source_pub_at: datetime
+    payload_sha256: str
+    halts: tuple[MarketHalt, ...]
+
+
+def _text(item: ET.Element, name: str, *, required: bool = False) -> str | None:
+    node = item.find(f"{_NDAQ}{name}")
+    value = node.text.strip() if node is not None and node.text else ""
+    if required and not value:
+        raise HaltFeedError(f"halt item is missing {name}")
+    return value or None
+
+
+def _market_time(date_value: str, time_value: str) -> datetime:
+    try:
+        local = datetime.strptime(f"{date_value} {time_value}", "%m/%d/%Y %H:%M:%S.%f").replace(tzinfo=_NY)
+    except ValueError as exc:
+        raise HaltFeedError("halt feed contains an invalid market timestamp") from exc
+    return local.astimezone(UTC)
+
+
+def parse_halt_rss(payload: bytes) -> HaltSnapshot:
+    """Parse the documented RSS fields without evaluating embedded HTML."""
+    if not payload or len(payload) > _MAX_BYTES:
+        raise HaltFeedError("halt feed payload is empty or exceeds the byte limit")
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise HaltFeedError("halt feed is not valid XML") from exc
+    channel = root.find("channel")
+    if root.tag != "rss" or channel is None:
+        raise HaltFeedError("halt feed is not an RSS channel")
+    pub_text = channel.findtext("pubDate")
+    if not pub_text:
+        raise HaltFeedError("halt feed is missing pubDate")
+    try:
+        source_pub_at = parsedate_to_datetime(pub_text).astimezone(UTC)
+    except (TypeError, ValueError) as exc:
+        raise HaltFeedError("halt feed pubDate is invalid") from exc
+    items = channel.findall("item")
+    if len(items) > _MAX_ITEMS:
+        raise HaltFeedError("halt feed exceeds the item limit")
+    declared = channel.findtext(f"{_NDAQ}numItems")
+    if declared is None or not declared.isdigit() or int(declared) != len(items):
+        raise HaltFeedError("halt feed item count does not match numItems")
+
+    rows: list[MarketHalt] = []
+    identities: set[tuple[str, datetime]] = set()
+    for item in items:
+        symbol = _text(item, "IssueSymbol", required=True)
+        halt_date = _text(item, "HaltDate", required=True)
+        halt_time = _text(item, "HaltTime", required=True)
+        market = _text(item, "Market", required=True)
+        reason = _text(item, "ReasonCode", required=True)
+        assert symbol and halt_date and halt_time and market and reason
+        halt_at = _market_time(halt_date, halt_time)
+        resume_date = _text(item, "ResumptionDate")
+        resume_time = _text(item, "ResumptionTradeTime")
+        if (resume_date is None) != (resume_time is None):
+            raise HaltFeedError("halt feed has an incomplete resumption timestamp")
+        resumed_at = _market_time(resume_date, resume_time) if resume_date and resume_time else None
+        if resumed_at is not None and resumed_at < halt_at:
+            raise HaltFeedError("halt resumption precedes its halt")
+        identity = (symbol.upper(), halt_at)
+        if identity in identities:
+            raise HaltFeedError("halt feed contains duplicate provider identity")
+        identities.add(identity)
+        rows.append(MarketHalt(symbol.upper(), halt_at, market, reason, resumed_at))
+    return HaltSnapshot(
+        source_pub_at=source_pub_at,
+        payload_sha256=hashlib.sha256(payload).hexdigest(),
+        halts=tuple(rows),
+    )
+
+
+def store_halt_snapshot(
+    conn: psycopg.Connection[Any],
+    *,
+    snapshot: HaltSnapshot,
+    fetched_at: datetime,
+) -> int:
+    """Upsert one snapshot and enforce the 90-day storage boundary."""
+    if fetched_at.tzinfo is None:
+        raise HaltFeedError("fetched_at must be timezone-aware")
+    if snapshot.source_pub_at > fetched_at + timedelta(minutes=5):
+        raise HaltFeedError("halt feed pubDate is implausibly in the future")
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO strategy_market_halts (
+                source, symbol, halt_at, market, reason_code, resumed_at, observed_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (source, symbol, halt_at) DO UPDATE SET
+                market = EXCLUDED.market,
+                reason_code = EXCLUDED.reason_code,
+                resumed_at = EXCLUDED.resumed_at,
+                observed_at = EXCLUDED.observed_at
+            """,
+            [
+                (SOURCE, row.symbol, row.halt_at, row.market, row.reason_code, row.resumed_at, fetched_at)
+                for row in snapshot.halts
+            ],
+        )
+    conn.execute(
+        """
+        INSERT INTO strategy_halt_feed_state (
+            source, fetched_at, source_pub_at, item_count, payload_sha256
+        ) VALUES (%s, %s, %s, %s, %s)
+        ON CONFLICT (source) DO UPDATE SET
+            fetched_at = EXCLUDED.fetched_at,
+            source_pub_at = EXCLUDED.source_pub_at,
+            item_count = EXCLUDED.item_count,
+            payload_sha256 = EXCLUDED.payload_sha256
+        """,
+        (SOURCE, fetched_at, snapshot.source_pub_at, len(snapshot.halts), snapshot.payload_sha256),
+    )
+    deleted = conn.execute(
+        "DELETE FROM strategy_market_halts WHERE resumed_at IS NOT NULL AND halt_at < %s RETURNING 1",
+        (fetched_at - timedelta(days=_RETENTION_DAYS),),
+    ).fetchall()
+    return len(deleted)
+
+
+def active_halt_symbols(snapshot: HaltSnapshot) -> MappingProxyType[str, MarketHalt]:
+    """Expose the current active rows for pure tests/callers."""
+    return MappingProxyType({row.symbol: row for row in snapshot.halts if row.resumed_at is None})
+
+
+def refresh_halt_feed(
+    conn: psycopg.Connection[Any],
+    *,
+    client: httpx.Client,
+    fetched_at: datetime | None = None,
+) -> HaltSnapshot:
+    """Fetch then atomically store one feed without holding a DB transaction."""
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise HaltFeedError("halt refresh requires an idle database connection")
+    observed = (fetched_at or datetime.now(UTC)).astimezone(UTC)
+    try:
+        response = client.get(NASDAQ_HALT_RSS_URL, timeout=20.0)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise HaltFeedError("Nasdaq halt feed request failed") from exc
+    payload = response.content
+    snapshot = parse_halt_rss(payload)
+    with conn.transaction():
+        store_halt_snapshot(conn, snapshot=snapshot, fetched_at=observed)
+    return snapshot
+
+
+__all__ = [
+    "HaltFeedError",
+    "HaltSnapshot",
+    "MarketHalt",
+    "NASDAQ_HALT_RSS_URL",
+    "SOURCE",
+    "active_halt_symbols",
+    "parse_halt_rss",
+    "refresh_halt_feed",
+    "store_halt_snapshot",
+]

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -1,0 +1,835 @@
+"""Fail-closed allocator and demo-only executor for fired entry signals.
+
+All observations are current and account-specific. Every refusal is retained as
+the signal's compact shadow arm; every allocation commits its intent and broker
+idempotency UUID before the sole demo broker write. Manual positions contribute
+to account/instrument risk but can never acquire strategy ownership here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, time, timedelta
+from decimal import ROUND_DOWN, Decimal
+from typing import Any, Literal, cast
+from zoneinfo import ZoneInfo
+
+import psycopg
+import psycopg.rows
+from psycopg.pq import TransactionStatus
+
+from app.providers.broker import (
+    BrokerAccountRiskSnapshot,
+    BrokerEligibilityResponse,
+    BrokerOrderSubmissionError,
+    BrokerOrderSubmissionUncertain,
+    BrokerProvider,
+    BrokerStrategyOrder,
+    BrokerWhatIfCostResponse,
+    BrokerWhatIfOrder,
+)
+from app.services.market_calendar import us_market_status
+from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
+from app.services.strategy_control_plane import (
+    StrategyControlError,
+    create_strategy_trade,
+    decide_funding,
+    link_strategy_order,
+)
+from app.services.strategy_order_reconciliation import (
+    enforce_reconciliation_slo,
+    ensure_strategy_request_id,
+)
+
+_NY = ZoneInfo("America/New_York")
+_CENT = Decimal("0.01")
+_RECURRING_COSTS = frozenset({"overnightfee", "overweekendfee"})
+_ALLOCATOR_ADVISORY_LOCK = (2449, 1)
+
+
+class StrategyPaperExecutionError(StrategyControlError):
+    """The executor contract was called with unsafe process state."""
+
+
+@dataclass(frozen=True)
+class PaperExecutionResult:
+    signal_id: int
+    verdict: Literal["rejected", "submitted", "submission_uncertain", "broker_rejected"]
+    reason_code: str
+    amount: Decimal | None = None
+    strategy_trade_id: int | None = None
+    order_id: int | None = None
+
+
+@dataclass(frozen=True)
+class _Intent:
+    signal_id: int
+    strategy_id: str
+    strategy_version: str
+    instrument_id: int
+    symbol: str
+    deployment_id: int
+    deployment_limit: Decimal
+    policy_revision: int
+    ticket_fraction: Decimal
+    max_ticket_amount: Decimal
+    stop_loss_pct: Decimal
+    take_profit_pct: Decimal
+    max_quote_age_seconds: int
+    max_scan_age_seconds: int
+    max_halt_feed_age_seconds: int
+    max_cost_age_seconds: int
+    max_reconciliation_age_seconds: int
+    max_instrument_exposure_pct: Decimal
+    max_portfolio_exposure_pct: Decimal
+    max_drawdown_pct: Decimal
+    min_net_expectancy_pct: Decimal
+    cost_stress_multiplier: Decimal
+    quote_at: datetime
+    ask: Decimal
+    scan_at: datetime
+    halt_feed_at: datetime
+    gross_expectancy_ci_low_pct: Decimal
+    reserved: Decimal
+
+
+def _age_ok(observed_at: datetime, *, now: datetime, max_seconds: int) -> bool:
+    return observed_at <= now + timedelta(seconds=5) and observed_at >= now - timedelta(seconds=max_seconds)
+
+
+def _session_is_open(now: datetime) -> bool:
+    local = now.astimezone(_NY)
+    status = us_market_status(local.date())
+    if status == "closed":
+        return False
+    close_at = time(13, 0) if status == "half_day" else time(16, 0)
+    return time(9, 30) <= local.time().replace(tzinfo=None) < close_at
+
+
+@contextmanager
+def _allocator_lock(conn: psycopg.Connection[Any]) -> Iterator[None]:
+    """Serialize the paper account's read-risk-reserve-submit critical section."""
+    conn.execute("SELECT pg_advisory_lock(%s, %s)", _ALLOCATOR_ADVISORY_LOCK)
+    conn.commit()
+    try:
+        yield
+    finally:
+        if conn.info.transaction_status != TransactionStatus.IDLE:
+            conn.rollback()
+        row = conn.execute("SELECT pg_advisory_unlock(%s, %s)", _ALLOCATOR_ADVISORY_LOCK).fetchone()
+        conn.commit()
+        if row is None or row[0] is not True:
+            raise StrategyPaperExecutionError("paper allocator advisory lock ownership was lost")
+
+
+def _existing_result(conn: psycopg.Connection[Any], signal_id: int) -> PaperExecutionResult | None:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT d.verdict, d.reason_code, d.amount, t.strategy_trade_id,
+                   o.order_id, o.status, o.broker_order_ref
+            FROM strategy_funding_decisions d
+            LEFT JOIN strategy_trades t ON t.funding_decision_id = d.funding_decision_id
+            LEFT JOIN strategy_trade_orders sto
+              ON sto.strategy_trade_id = t.strategy_trade_id AND sto.purpose = 'entry'
+            LEFT JOIN orders o ON o.order_id = sto.order_id
+            WHERE d.signal_id = %s
+            """,
+            (signal_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    if row["verdict"] == "rejected":
+        verdict: Literal["rejected", "submitted", "submission_uncertain", "broker_rejected"] = "rejected"
+    elif row["status"] == "rejected":
+        verdict = "broker_rejected"
+    elif row["status"] == "submitted" and row["broker_order_ref"] is None:
+        verdict = "submission_uncertain"
+    else:
+        verdict = "submitted"
+    return PaperExecutionResult(
+        signal_id=signal_id,
+        verdict=verdict,
+        reason_code=str(row["reason_code"]),
+        amount=Decimal(str(row["amount"])) if row["amount"] is not None else None,
+        strategy_trade_id=int(row["strategy_trade_id"]) if row["strategy_trade_id"] is not None else None,
+        order_id=int(row["order_id"]) if row["order_id"] is not None else None,
+    )
+
+
+def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime) -> tuple[_Intent | None, str | None]:
+    """Load DB gates as one observation; return a closed reason on absence."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT s.signal_id, s.strategy_id, s.strategy_version, s.instrument_id,
+                   i.symbol, i.is_tradable, e.asset_class,
+                   d.deployment_id, d.capital_limit, d.enabled, d.currency,
+                   p.revision AS policy_revision, p.*,
+                   q.quoted_at, q.ask, q.spread_flag,
+                   w.updated_at AS scan_at,
+                   h.fetched_at AS halt_feed_at,
+                   EXISTS (
+                       SELECT 1 FROM strategy_market_halts mh
+                       WHERE mh.source = 'nasdaq_trader_rss'
+                         AND mh.symbol = upper(i.symbol) AND mh.resumed_at IS NULL
+                   ) AS is_halted,
+                   EXISTS (
+                       SELECT 1 FROM strategy_execution_blocks b WHERE b.active
+                   ) AS execution_blocked,
+                   (
+                       SELECT COALESCE(SUM(fd.amount), 0)
+                       FROM strategy_funding_decisions fd
+                       LEFT JOIN strategy_trades st ON st.funding_decision_id = fd.funding_decision_id
+                       WHERE fd.deployment_id = d.deployment_id AND fd.verdict = 'allocated'
+                         AND (st.strategy_trade_id IS NULL OR st.status NOT IN ('closed', 'failed'))
+                   ) AS reserved,
+                   evidence.result_count, evidence.qualified_result_count,
+                   evidence.expectancy_ci_low_pct
+            FROM strategy_signals s
+            JOIN instruments i ON i.instrument_id = s.instrument_id
+            LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+            LEFT JOIN strategy_deployments d
+              ON d.strategy_id = s.strategy_id AND d.strategy_version = s.strategy_version
+             AND d.mode = 'paper'
+            LEFT JOIN strategy_execution_policies p ON p.deployment_id = d.deployment_id
+            LEFT JOIN quotes q ON q.instrument_id = s.instrument_id
+            LEFT JOIN strategy_scan_watermark w
+              ON w.strategy_id = s.strategy_id AND w.strategy_version = s.strategy_version
+            LEFT JOIN strategy_halt_feed_state h ON h.source = 'nasdaq_trader_rss'
+            LEFT JOIN LATERAL (
+                SELECT count(*) AS result_count,
+                       count(*) FILTER (WHERE
+                           r.expectancy_ci_low_pct IS NOT NULL
+                           AND r.namespace = 'hold_out'
+                           AND r.window_start >= DATE '2022-01-01'
+                           AND r.universe_basis = 'survivorship_free'
+                           AND r.carry_unmodelled = false
+                           AND r.trial_count IS NOT NULL
+                           AND r.deflated_sharpe IS NOT NULL
+                           AND r.effective_sample_size IS NOT NULL
+                           AND r.synthetic_control_passed = true
+                       ) AS qualified_result_count,
+                       min(r.expectancy_ci_low_pct) FILTER (WHERE
+                           r.expectancy_ci_low_pct IS NOT NULL
+                           AND r.namespace = 'hold_out'
+                           AND r.window_start >= DATE '2022-01-01'
+                           AND r.universe_basis = 'survivorship_free'
+                           AND r.carry_unmodelled = false
+                           AND r.trial_count IS NOT NULL
+                           AND r.deflated_sharpe IS NOT NULL
+                           AND r.effective_sample_size IS NOT NULL
+                           AND r.synthetic_control_passed = true
+                       ) AS expectancy_ci_low_pct
+                FROM strategy_promotion_results pr
+                JOIN strategy_promotions promotion ON promotion.promotion_id = pr.promotion_id
+                JOIN strategy_results_store r ON r.result_id = pr.result_id
+                WHERE promotion.strategy_id = s.strategy_id
+                  AND promotion.strategy_version = s.strategy_version
+            ) evidence ON true
+            WHERE s.signal_id = %s AND s.signal_kind = 'entry' AND s.verdict = 'fired'
+            """,
+            (signal_id,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None, "signal_not_fired_entry"
+    checks = (
+        (bool(row["is_tradable"]), "instrument_not_tradable"),
+        (row["asset_class"] == "us_equity", "unsupported_market_session"),
+        (row["deployment_id"] is not None, "paper_deployment_missing"),
+        (bool(row["enabled"]), "paper_deployment_disabled"),
+        (row["currency"] == "USD", "deployment_currency_unsupported"),
+        (row["policy_revision"] is not None, "execution_policy_missing"),
+        (not bool(row["execution_blocked"]), "execution_block_active"),
+        (row["quoted_at"] is not None and row["ask"] is not None, "quote_missing"),
+        (
+            row["ask"] is not None and Decimal(str(row["ask"])).is_finite() and Decimal(str(row["ask"])) > 0,
+            "quote_ask_invalid",
+        ),
+        (not bool(row["spread_flag"]), "quote_spread_flagged"),
+        (row["scan_at"] is not None, "scan_watermark_missing"),
+        (row["halt_feed_at"] is not None, "halt_feed_missing"),
+        (not bool(row["is_halted"]), "instrument_halted"),
+        (
+            int(row["result_count"] or 0) > 0
+            and int(row["qualified_result_count"] or 0) == int(row["result_count"])
+            and row["expectancy_ci_low_pct"] is not None,
+            "expectancy_evidence_missing",
+        ),
+    )
+    for passed, reason in checks:
+        if not passed:
+            return None, reason
+    quote_at = cast(datetime, row["quoted_at"])
+    scan_at = cast(datetime, row["scan_at"])
+    halt_feed_at = cast(datetime, row["halt_feed_at"])
+    if not _age_ok(quote_at, now=now, max_seconds=int(row["max_quote_age_seconds"])):
+        return None, "quote_stale"
+    if not _age_ok(scan_at, now=now, max_seconds=int(row["max_scan_age_seconds"])):
+        return None, "scan_stale"
+    if not _age_ok(halt_feed_at, now=now, max_seconds=int(row["max_halt_feed_age_seconds"])):
+        return None, "halt_feed_stale"
+    if not _session_is_open(now):
+        return None, "market_session_closed"
+    return _Intent(
+        signal_id=signal_id,
+        strategy_id=str(row["strategy_id"]),
+        strategy_version=str(row["strategy_version"]),
+        instrument_id=int(row["instrument_id"]),
+        symbol=str(row["symbol"]),
+        deployment_id=int(row["deployment_id"]),
+        deployment_limit=Decimal(str(row["capital_limit"])),
+        policy_revision=int(row["policy_revision"]),
+        ticket_fraction=Decimal(str(row["ticket_fraction"])),
+        max_ticket_amount=Decimal(str(row["max_ticket_amount"])),
+        stop_loss_pct=Decimal(str(row["stop_loss_pct"])),
+        take_profit_pct=Decimal(str(row["take_profit_pct"])),
+        max_quote_age_seconds=int(row["max_quote_age_seconds"]),
+        max_scan_age_seconds=int(row["max_scan_age_seconds"]),
+        max_halt_feed_age_seconds=int(row["max_halt_feed_age_seconds"]),
+        max_cost_age_seconds=int(row["max_cost_age_seconds"]),
+        max_reconciliation_age_seconds=int(row["max_reconciliation_age_seconds"]),
+        max_instrument_exposure_pct=Decimal(str(row["max_instrument_exposure_pct"])),
+        max_portfolio_exposure_pct=Decimal(str(row["max_portfolio_exposure_pct"])),
+        max_drawdown_pct=Decimal(str(row["max_drawdown_pct"])),
+        min_net_expectancy_pct=Decimal(str(row["min_net_expectancy_pct"])),
+        cost_stress_multiplier=Decimal(str(row["cost_stress_multiplier"])),
+        quote_at=quote_at,
+        ask=Decimal(str(row["ask"])),
+        scan_at=scan_at,
+        halt_feed_at=halt_feed_at,
+        gross_expectancy_ci_low_pct=Decimal(str(row["expectancy_ci_low_pct"])),
+        reserved=Decimal(str(row["reserved"])),
+    ), None
+
+
+def _persist_rejection(
+    conn: psycopg.Connection[Any],
+    *,
+    signal_id: int,
+    reason_code: str,
+    now: datetime,
+    intent: _Intent | None = None,
+    risk: BrokerAccountRiskSnapshot | None = None,
+) -> PaperExecutionResult:
+    existing = _existing_result(conn, signal_id)
+    conn.commit()
+    if existing is not None:
+        return existing
+    with conn.transaction():
+        decide_funding(conn, signal_id=signal_id, verdict="rejected", reason_code=reason_code)
+        conn.execute(
+            """
+            INSERT INTO strategy_entry_preflights (
+                signal_id, deployment_id, policy_revision, verdict, reason_code,
+                evaluated_at, quote_at, scan_at, halt_feed_at,
+                broker_available_cash, account_equity, account_invested,
+                instrument_invested, gross_expectancy_ci_low_pct
+            ) VALUES (%s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                signal_id,
+                intent.deployment_id if intent else None,
+                intent.policy_revision if intent else None,
+                reason_code,
+                now,
+                intent.quote_at if intent else None,
+                intent.scan_at if intent else None,
+                intent.halt_feed_at if intent else None,
+                risk.available_cash if risk else None,
+                risk.equity if risk else None,
+                risk.total_invested if risk else None,
+                next(
+                    (x.amount for x in risk.instrument_investments if x.instrument_id == intent.instrument_id),
+                    Decimal("0"),
+                )
+                if risk and intent
+                else None,
+                intent.gross_expectancy_ci_low_pct if intent else None,
+            ),
+        )
+    return PaperExecutionResult(signal_id, "rejected", reason_code)
+
+
+def _eligibility_reason(response: BrokerEligibilityResponse, intent: _Intent, amount: Decimal) -> str | None:
+    if response.currency.upper() != "USD" or intent.instrument_id in response.not_found_instrument_ids:
+        return "eligibility_unresolved"
+    matches = [row for row in response.eligibilities if row.instrument_id == intent.instrument_id]
+    if len(matches) != 1 or not matches[0].allow_open_position:
+        return "instrument_ineligible"
+    arms = [
+        arm
+        for arm in matches[0].leverage_configs
+        if arm.settlement_type.lower() == "real" and arm.direction.upper() == "LONG" and 1 in arm.leverage_values
+    ]
+    if len(arms) != 1:
+        return "eligibility_arm_ambiguous"
+    arm = arms[0]
+    if arm.allow_stop_loss_take_profit is not True:
+        return "fixed_exit_not_allowed"
+    minimum = arm.min_position_amount or matches[0].min_position_exposure
+    if minimum is None or amount < minimum:
+        return "below_broker_minimum"
+    return None
+
+
+def _costs(
+    response: BrokerWhatIfCostResponse,
+    *,
+    intent: _Intent,
+    amount: Decimal,
+    now: datetime,
+) -> tuple[Decimal, Decimal] | str:
+    if response.instrument_id != intent.instrument_id or not _age_ok(
+        response.last_updated, now=now, max_seconds=intent.max_cost_age_seconds
+    ):
+        return "costs_stale_or_mismatched"
+    total = Decimal("0")
+    if not response.costs:
+        return "costs_missing"
+    for component in response.costs:
+        if component.amount is None or component.value is not None:
+            return "cost_unit_undocumented"
+        if component.currency.upper() != "USD" or component.amount < 0:
+            return "cost_currency_or_value_invalid"
+        if component.cost_type.replace("_", "").lower() in _RECURRING_COSTS and component.amount > 0:
+            return "recurring_cost_horizon_unmodelled"
+        total += component.amount
+    stressed = total * intent.cost_stress_multiplier
+    net = intent.gross_expectancy_ci_low_pct - (stressed / amount * Decimal("100"))
+    return stressed, net
+
+
+def _risk_and_amount(
+    conn: psycopg.Connection[Any],
+    *,
+    intent: _Intent,
+    risk: BrokerAccountRiskSnapshot,
+    now: datetime,
+) -> tuple[Decimal, Decimal, Decimal] | str:
+    if not _age_ok(risk.observed_at, now=now, max_seconds=intent.max_quote_age_seconds):
+        return "account_risk_stale"
+    current_instrument = next(
+        (row.amount for row in risk.instrument_investments if row.instrument_id == intent.instrument_id),
+        Decimal("0"),
+    )
+    # A just-accepted strategy order may not yet be visible in the provider's
+    # account snapshot. Count every unresolved local submission as additional
+    # risk. Once reconciliation is terminal, the provider snapshot is authority.
+    pending_row = conn.execute(
+        """
+        SELECT COALESCE(SUM(d.amount), 0),
+               COALESCE(SUM(d.amount) FILTER (WHERE t.instrument_id=%s), 0)
+        FROM strategy_funding_decisions d
+        JOIN strategy_trades t ON t.funding_decision_id=d.funding_decision_id
+        JOIN strategy_trade_orders sto ON sto.strategy_trade_id=t.strategy_trade_id
+          AND sto.purpose='entry'
+        JOIN orders o ON o.order_id=sto.order_id AND o.execution_origin='strategy'
+        LEFT JOIN strategy_order_reconciliation_state r ON r.order_id=o.order_id
+        WHERE d.verdict='allocated' AND t.status NOT IN ('closed', 'failed')
+          AND (r.state IS NULL OR r.state NOT IN ('resolved', 'rejected'))
+        """,
+        (intent.instrument_id,),
+    ).fetchone()
+    assert pending_row is not None
+    pending_total = Decimal(str(pending_row[0]))
+    pending_instrument = Decimal(str(pending_row[1]))
+    conn.commit()
+    with conn.transaction():
+        row = conn.execute(
+            "SELECT equity_high_water FROM strategy_paper_account_risk_state WHERE id = true FOR UPDATE"
+        ).fetchone()
+        high_water = max(Decimal(str(row[0])) if row else risk.equity, risk.equity)
+        drawdown = (high_water - risk.equity) / high_water * Decimal("100")
+        conn.execute(
+            """
+            INSERT INTO strategy_paper_account_risk_state (
+                id, equity_high_water, last_equity, last_drawdown_pct, observed_at
+            ) VALUES (true, %s, %s, %s, %s)
+            ON CONFLICT (id) DO UPDATE SET
+                equity_high_water = EXCLUDED.equity_high_water,
+                last_equity = EXCLUDED.last_equity,
+                last_drawdown_pct = EXCLUDED.last_drawdown_pct,
+                observed_at = EXCLUDED.observed_at
+            """,
+            (high_water, risk.equity, drawdown, risk.observed_at),
+        )
+    if drawdown > intent.max_drawdown_pct:
+        return "account_drawdown_limit"
+    deployment_remaining = max(Decimal("0"), intent.deployment_limit - intent.reserved)
+    portfolio_capacity = max(
+        Decimal("0"),
+        risk.equity * intent.max_portfolio_exposure_pct / Decimal("100") - risk.total_invested - pending_total,
+    )
+    instrument_capacity = max(
+        Decimal("0"),
+        risk.equity * intent.max_instrument_exposure_pct / Decimal("100") - current_instrument - pending_instrument,
+    )
+    amount = min(
+        intent.deployment_limit * intent.ticket_fraction,
+        intent.max_ticket_amount,
+        deployment_remaining,
+        max(Decimal("0"), risk.available_cash - pending_total),
+        portfolio_capacity,
+        instrument_capacity,
+    ).quantize(_CENT, rounding=ROUND_DOWN)
+    if amount <= 0:
+        return "risk_capacity_exhausted"
+    return amount, current_instrument, drawdown
+
+
+def _resume_uncertain_submission(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    existing: PaperExecutionResult,
+) -> PaperExecutionResult:
+    """Retry a committed intent with its original idempotency identity."""
+    if existing.order_id is None or existing.strategy_trade_id is None or existing.amount is None:
+        raise StrategyPaperExecutionError("uncertain strategy submission is missing durable authority")
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT o.instrument_id, o.strategy_request_id,
+                   p.stop_loss_rate, p.take_profit_rate
+            FROM orders o
+            JOIN strategy_trade_orders sto
+              ON sto.order_id=o.order_id AND sto.purpose='entry'
+            JOIN strategy_trades t ON t.strategy_trade_id=sto.strategy_trade_id
+            JOIN strategy_funding_decisions d ON d.funding_decision_id=t.funding_decision_id
+            JOIN strategy_entry_preflights p ON p.signal_id=d.signal_id AND p.verdict='allocated'
+            WHERE o.order_id=%s AND o.execution_origin='strategy'
+              AND o.status='submitted' AND o.broker_order_ref IS NULL
+            """,
+            (existing.order_id,),
+        )
+        row = cur.fetchone()
+    conn.commit()
+    if row is None or row["strategy_request_id"] is None:
+        raise StrategyPaperExecutionError("uncertain strategy submission identity is incomplete")
+    request_id = row["strategy_request_id"]
+    try:
+        submission = broker.place_demo_strategy_order(
+            BrokerStrategyOrder(
+                instrument_id=int(row["instrument_id"]),
+                amount=existing.amount,
+                settlement_type="real",
+                stop_loss_rate=Decimal(str(row["stop_loss_rate"])),
+                take_profit_rate=Decimal(str(row["take_profit_rate"])),
+            ),
+            request_id=request_id,
+        )
+    except BrokerOrderSubmissionError as exc:
+        if isinstance(exc, BrokerOrderSubmissionUncertain):
+            return existing
+        with conn.transaction():
+            conn.execute("UPDATE orders SET status='rejected' WHERE order_id=%s", (existing.order_id,))
+            conn.execute(
+                "UPDATE strategy_trades SET status='failed', updated_at=now() WHERE strategy_trade_id=%s",
+                (existing.strategy_trade_id,),
+            )
+            conn.execute(
+                """
+                UPDATE strategy_order_reconciliation_state
+                SET state='rejected', reconciled_at=now(), last_attempt_at=now(),
+                    attempt_count=attempt_count+1,
+                    last_error_code='broker_submission_rejected', updated_at=now()
+                WHERE order_id=%s
+                """,
+                (existing.order_id,),
+            )
+        return PaperExecutionResult(
+            existing.signal_id,
+            "broker_rejected",
+            "broker_submission_rejected",
+            existing.amount,
+            existing.strategy_trade_id,
+            existing.order_id,
+        )
+    except Exception:
+        return existing
+    with conn.transaction():
+        conn.execute(
+            "UPDATE orders SET broker_order_ref=%s WHERE order_id=%s",
+            (submission.broker_order_ref, existing.order_id),
+        )
+        conn.execute(
+            "UPDATE strategy_trades SET status='submitted', updated_at=now() WHERE strategy_trade_id=%s",
+            (existing.strategy_trade_id,),
+        )
+    return PaperExecutionResult(
+        existing.signal_id,
+        "submitted",
+        "broker_accepted",
+        existing.amount,
+        existing.strategy_trade_id,
+        existing.order_id,
+    )
+
+
+def _execute_fired_paper_signal_locked(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    signal_id: int,
+    now: datetime | None = None,
+) -> PaperExecutionResult:
+    """Evaluate and, only if every gate aligns, submit one demo order."""
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise StrategyPaperExecutionError("paper execution requires an idle connection")
+    evaluated_at = (now or datetime.now(UTC)).astimezone(UTC)
+    existing = _existing_result(conn, signal_id)
+    conn.commit()
+    if existing is not None and existing.verdict != "submission_uncertain":
+        return existing
+    try:
+        runtime = get_runtime_config(conn)
+        kill_row = conn.execute("SELECT is_active FROM kill_switch WHERE id = true").fetchone()
+        conn.commit()
+    except RuntimeConfigCorrupt:
+        return _persist_rejection(conn, signal_id=signal_id, reason_code="runtime_config_corrupt", now=evaluated_at)
+    if not runtime.enable_auto_trading:
+        return _persist_rejection(conn, signal_id=signal_id, reason_code="auto_trading_disabled", now=evaluated_at)
+    if kill_row is None or bool(kill_row[0]):
+        return _persist_rejection(
+            conn, signal_id=signal_id, reason_code="kill_switch_active_or_missing", now=evaluated_at
+        )
+    if existing is not None:
+        return _resume_uncertain_submission(conn, broker=broker, existing=existing)
+
+    # This updates one bounded current-state block. It never calls the broker.
+    provisional = conn.execute(
+        """
+        SELECT p.max_reconciliation_age_seconds
+        FROM strategy_signals s
+        JOIN strategy_deployments d ON d.strategy_id=s.strategy_id AND d.strategy_version=s.strategy_version
+          AND d.mode='paper'
+        JOIN strategy_execution_policies p ON p.deployment_id=d.deployment_id
+        WHERE s.signal_id=%s
+        """,
+        (signal_id,),
+    ).fetchone()
+    conn.commit()
+    if provisional is not None:
+        health = enforce_reconciliation_slo(conn, max_unresolved_seconds=int(provisional[0]))
+        conn.commit()
+        if health.active_block:
+            return _persist_rejection(conn, signal_id=signal_id, reason_code="reconciliation_overdue", now=evaluated_at)
+
+    intent, reason = _load_intent(conn, signal_id=signal_id, now=evaluated_at)
+    conn.commit()
+    if intent is None:
+        return _persist_rejection(
+            conn,
+            signal_id=signal_id,
+            reason_code=reason or "preflight_unavailable",
+            now=evaluated_at,
+        )
+
+    try:
+        risk = broker.get_account_risk_snapshot()
+    except Exception:
+        return _persist_rejection(
+            conn, signal_id=signal_id, reason_code="account_risk_unavailable", now=evaluated_at, intent=intent
+        )
+    sized = _risk_and_amount(conn, intent=intent, risk=risk, now=evaluated_at)
+    if isinstance(sized, str):
+        return _persist_rejection(
+            conn, signal_id=signal_id, reason_code=sized, now=evaluated_at, intent=intent, risk=risk
+        )
+    amount, instrument_invested, drawdown = sized
+    try:
+        eligibility = broker.check_instrument_eligibility([intent.instrument_id])
+    except Exception:
+        return _persist_rejection(
+            conn, signal_id=signal_id, reason_code="eligibility_unavailable", now=evaluated_at, intent=intent, risk=risk
+        )
+    eligibility_reason = _eligibility_reason(eligibility, intent, amount)
+    if eligibility_reason:
+        return _persist_rejection(
+            conn, signal_id=signal_id, reason_code=eligibility_reason, now=evaluated_at, intent=intent, risk=risk
+        )
+    try:
+        costs = broker.get_what_if_costs(
+            BrokerWhatIfOrder(
+                instrument_id=intent.instrument_id,
+                transaction="buy",
+                settlement_type="real",
+                amount=amount,
+                leverage=1,
+            )
+        )
+    except Exception:
+        return _persist_rejection(
+            conn, signal_id=signal_id, reason_code="costs_unavailable", now=evaluated_at, intent=intent, risk=risk
+        )
+    assessed = _costs(costs, intent=intent, amount=amount, now=evaluated_at)
+    if isinstance(assessed, str):
+        return _persist_rejection(
+            conn, signal_id=signal_id, reason_code=assessed, now=evaluated_at, intent=intent, risk=risk
+        )
+    stressed_cost, net_expectancy = assessed
+    if net_expectancy < intent.min_net_expectancy_pct:
+        return _persist_rejection(
+            conn,
+            signal_id=signal_id,
+            reason_code="net_expectancy_below_policy",
+            now=evaluated_at,
+            intent=intent,
+            risk=risk,
+        )
+    stop_rate = (intent.ask * (Decimal("1") - intent.stop_loss_pct / Decimal("100"))).quantize(
+        Decimal("0.000001"), rounding=ROUND_DOWN
+    )
+    take_rate = (intent.ask * (Decimal("1") + intent.take_profit_pct / Decimal("100"))).quantize(
+        Decimal("0.000001"), rounding=ROUND_DOWN
+    )
+
+    # Re-load under locks through the control-plane allocator. Any concurrent
+    # reservation that consumes the cap makes this transaction fail closed.
+    with conn.transaction():
+        decision_id = decide_funding(
+            conn,
+            signal_id=signal_id,
+            verdict="allocated",
+            deployment_id=intent.deployment_id,
+            amount=amount,
+            reason_code="all_paper_entry_gates_passed",
+        )
+        trade_id = create_strategy_trade(conn, decision_id)
+        order_row = conn.execute(
+            """
+            INSERT INTO orders (
+                instrument_id, action, order_type, requested_amount, status,
+                raw_payload_json, execution_origin
+            ) VALUES (%s, 'BUY', 'MARKET', %s, 'submitted', NULL, 'strategy')
+            RETURNING order_id
+            """,
+            (intent.instrument_id, amount),
+        ).fetchone()
+        assert order_row is not None
+        order_id = int(order_row[0])
+        link_strategy_order(conn, strategy_trade_id=trade_id, order_id=order_id, purpose="entry")
+        request_id = ensure_strategy_request_id(conn, order_id=order_id)
+        conn.execute(
+            """
+            INSERT INTO strategy_entry_preflights (
+                signal_id, deployment_id, policy_revision, verdict, reason_code,
+                evaluated_at, quote_at, scan_at, halt_feed_at,
+                eligibility_checked_at, costs_at, broker_available_cash,
+                account_equity, account_invested, instrument_invested,
+                account_drawdown_pct, allocated_amount,
+                gross_expectancy_ci_low_pct, stressed_cost_amount,
+                net_expectancy_pct, stop_loss_rate, take_profit_rate
+            ) VALUES (
+                %s, %s, %s, 'allocated', 'all_paper_entry_gates_passed',
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            )
+            """,
+            (
+                signal_id,
+                intent.deployment_id,
+                intent.policy_revision,
+                evaluated_at,
+                intent.quote_at,
+                intent.scan_at,
+                intent.halt_feed_at,
+                evaluated_at,
+                costs.last_updated,
+                risk.available_cash,
+                risk.equity,
+                risk.total_invested,
+                instrument_invested,
+                drawdown,
+                amount,
+                intent.gross_expectancy_ci_low_pct,
+                stressed_cost,
+                net_expectancy,
+                stop_rate,
+                take_rate,
+            ),
+        )
+    # The transaction context commits before this broker call.
+    try:
+        submission = broker.place_demo_strategy_order(
+            BrokerStrategyOrder(
+                instrument_id=intent.instrument_id,
+                amount=amount,
+                settlement_type="real",
+                stop_loss_rate=stop_rate,
+                take_profit_rate=take_rate,
+            ),
+            request_id=request_id,
+        )
+    except BrokerOrderSubmissionError as exc:
+        uncertain = isinstance(exc, BrokerOrderSubmissionUncertain)
+        with conn.transaction():
+            if uncertain:
+                conn.execute(
+                    "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() "
+                    "WHERE strategy_trade_id=%s",
+                    (trade_id,),
+                )
+            else:
+                conn.execute("UPDATE orders SET status='rejected' WHERE order_id=%s", (order_id,))
+                conn.execute(
+                    "UPDATE strategy_trades SET status='failed', updated_at=now() WHERE strategy_trade_id=%s",
+                    (trade_id,),
+                )
+                conn.execute(
+                    """
+                    UPDATE strategy_order_reconciliation_state
+                    SET state='rejected', reconciled_at=now(), last_attempt_at=now(),
+                        attempt_count=attempt_count+1, last_error_code='broker_submission_rejected', updated_at=now()
+                    WHERE order_id=%s
+                    """,
+                    (order_id,),
+                )
+        return PaperExecutionResult(
+            signal_id,
+            "submission_uncertain" if uncertain else "broker_rejected",
+            "submission_uncertain" if uncertain else "broker_submission_rejected",
+            amount,
+            trade_id,
+            order_id,
+        )
+    except Exception:
+        with conn.transaction():
+            conn.execute(
+                "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() WHERE strategy_trade_id=%s",
+                (trade_id,),
+            )
+        return PaperExecutionResult(
+            signal_id, "submission_uncertain", "submission_uncertain", amount, trade_id, order_id
+        )
+    with conn.transaction():
+        conn.execute(
+            "UPDATE orders SET broker_order_ref=%s WHERE order_id=%s",
+            (submission.broker_order_ref, order_id),
+        )
+        conn.execute(
+            "UPDATE strategy_trades SET status='submitted', updated_at=now() WHERE strategy_trade_id=%s",
+            (trade_id,),
+        )
+    return PaperExecutionResult(signal_id, "submitted", "broker_accepted", amount, trade_id, order_id)
+
+
+def execute_fired_paper_signal(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    signal_id: int,
+    now: datetime | None = None,
+) -> PaperExecutionResult:
+    """Serialize and evaluate one fired signal against whole-account demo risk."""
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise StrategyPaperExecutionError("paper execution requires an idle connection")
+    with _allocator_lock(conn):
+        return _execute_fired_paper_signal_locked(conn, broker=broker, signal_id=signal_id, now=now)
+
+
+__all__ = ["PaperExecutionResult", "StrategyPaperExecutionError", "execute_fired_paper_signal"]

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -550,8 +550,6 @@ def _resume_uncertain_submission(
             existing.strategy_trade_id,
             existing.order_id,
         )
-    except Exception:
-        return existing
     with conn.transaction():
         conn.execute(
             "UPDATE orders SET broker_order_ref=%s WHERE order_id=%s",
@@ -798,14 +796,15 @@ def _execute_fired_paper_signal_locked(
             order_id,
         )
     except Exception:
+        # The broker contract translates transport/response uncertainty into
+        # BrokerOrderSubmissionUncertain. Preserve exact reconciliation
+        # authority here, but let programming/contract bugs fail loudly.
         with conn.transaction():
             conn.execute(
                 "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() WHERE strategy_trade_id=%s",
                 (trade_id,),
             )
-        return PaperExecutionResult(
-            signal_id, "submission_uncertain", "submission_uncertain", amount, trade_id, order_id
-        )
+        raise
     with conn.transaction():
         conn.execute(
             "UPDATE orders SET broker_order_ref=%s WHERE order_id=%s",

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -145,13 +145,13 @@ GET+POST requests cannot exceed the API limit.
 | POST | `/api/v1/trading/execution/market-close-orders/positions/{positionId}` | Close position — body `UnitsToDeduct` nullable → partial close (omit = full). Live doc also lists `InstrumentID` required; our impl omits it — verify on demo before relying | **Active** (full close; partial plumbed in provider, unexposed) |
 | DELETE | `/api/v1/trading/execution/market-close-orders/{orderId}` | Cancel pending close order | Not used (v1) |
 | PATCH | `/api/v2/trading/{real\|demo}/positions/{positionId}` | Edit TP/SL on one exact open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). Async acceptance `{operationId, positionId, referenceId}` — re-sync before treating as landed | Planned — required for strategy-owned ratchets |
-| POST | `/api/v2/trading/info/{real\|demo}/eligibility` | Up to 100 ids/symbols; account-specific open/close/partial-close permission, min exposure, max units, order/fill types, and leverage + SL/TP constraints by settlement/direction | **Adapter implemented; no persistence/execution gate yet** |
-| POST | `/api/v2/trading/info/{real\|demo}/costs` | What-if open cost rows for `buy` / `sellShort`: open vocabulary including spread, markup, transaction, overnight/weekend and tax; returns `lastUpdated`. Demo returned `value` while omitting documented `amount`; controlled scaling did not establish one unit equation | **Adapter + bounded census implemented; fail closed for execution** |
-| GET | `/api/v2/trading/info/{real\|demo}/orders:lookup` | Exactly one of numeric `orderId` or submission `referenceId`; returns status and every `positionExecutions[].positionId` with opening units/average price. Shared 60 GET/min quota | **Active for strategy reconciliation** — strict adapter, exact execution persistence and restart backlog; no broker writer in this slice |
+| POST | `/api/v2/trading/info/{real\|demo}/eligibility` | Up to 100 ids/symbols; account-specific open/close/partial-close permission, min exposure, max units, order/fill types, and leverage + SL/TP constraints by settlement/direction | **Active as a just-in-time paper gate**; response is process-local |
+| POST | `/api/v2/trading/info/{real\|demo}/costs` | What-if open cost rows for `buy` / `sellShort`: open vocabulary including spread, markup, transaction, overnight/weekend and tax; returns `lastUpdated`. Demo returned `value` while omitting documented `amount`; controlled scaling did not establish one unit equation | **Active fail-closed paper gate**: documented fresh USD `amount` only; `value`/unknown horizon refuses |
+| GET | `/api/v2/trading/info/{real\|demo}/orders:lookup` | Exactly one of numeric `orderId` or submission `referenceId`; returns status and every `positionExecutions[].positionId` with opening units/average price. Shared 60 GET/min quota | **Active for strategy reconciliation** — strict adapter, exact execution persistence and restart backlog |
 | POST | `/api/v1/trading/execution/limit-orders` | Limit/MIT order | Not used (v1 is market-only) |
 | DELETE | `/api/v1/trading/execution/limit-orders/{orderId}` | Cancel limit order | Not used (v1) |
 | GET | `/api/v1/trading/info/portfolio` | Full portfolio: positions, orders, mirrors, credit | **Active** — portfolio sync |
-| GET | `/api/v1/trading/info/real/pnl` | Portfolio with P&L details | Not used — computed locally |
+| GET | `/api/v1/trading/info/{real\|demo}/pnl` | Positions, mirrors, pending orders, credit and P&L inputs for the published cash/invested/equity formula | **Demo active as a just-in-time paper risk gate**; raw response is process-local |
 | GET | `/api/v1/trading/info/real/orders/{orderId}` | Single order status | **Active** — order polling |
 | GET | `/api/v1/trading/info/trade/history` | Trade history (`minDate` required) | Not used (v1) |
 
@@ -168,6 +168,12 @@ UUID as the idempotency key, and `orders:lookup.referenceId` as that same
 submission header. Strategy execution must commit this immutable UUID before
 network I/O and reuse it on every retry. A missing response therefore becomes a
 lookup/retry of one identity, never a newly keyed duplicate order.
+
+`POST /api/v2/trading/execution/demo/orders` is now the sole automated paper
+writer. Its adapter refuses non-demo credentials and its accepted shape is
+long `buy`, `real`, market, x1, USD amount with fixed SL/TP. It validates a
+positive `orderId` and exact `referenceId == X-Request-Id`; the generic legacy
+writer remains manual and is not an automated fallback.
 
 ### Authenticated demo census (2026-08-09)
 
@@ -206,6 +212,11 @@ Same operations as Real with environment-specific paths (e.g., legacy v1 open:
 `/api/v1/trading/execution/demo/market-open-orders/by-amount`; current v2 TP/SL
 edit: `/api/v2/trading/demo/positions/{positionId}`; current v2 info:
 `/api/v2/trading/info/demo/...`).
+
+Automated paper entry uses the fixed path
+`/api/v2/trading/execution/demo/orders`; it is intentionally not formed from a
+real/demo environment prefix. Demo account risk uses
+`/api/v1/trading/info/demo/pnl` and applies the published formulas below.
 
 ### Agent portfolios (copy-trading management)
 

--- a/docs/proposals/ta/2026-08-09-evidence-backed-signal-engine.md
+++ b/docs/proposals/ta/2026-08-09-evidence-backed-signal-engine.md
@@ -374,9 +374,47 @@ until the previous measurement is recorded:
 7. **Forward observation:** still no broker orders.
 8. **Paper execution:** separate operator promotion after untouched evidence.
 
-The parent #2437 documents the research thread. Dedicated implementation ticket
-numbers have not been verified in this workspace, so this spec must not pretend
-they already exist; create them from this slice order before implementation.
+The parent #2437 documents the research thread. The ordered implementation
+tickets now exist: #2447 evidence, #2448 bounded storage, #2454 governance and
+ownership, #2451 crash-safe reconciliation, #2449 paper allocation/execution,
+#2452 position management, #2453 monitoring/P&L and #2450 live gate.
+
+### Validated paper-execution contract (#2449)
+
+- Automated entry has one deliberately separate writer: eToro v2
+  `POST /api/v2/trading/execution/demo/orders`. It refuses non-demo credentials,
+  permits long `real` settlement at x1 only, requires fixed SL and TP, and sends
+  the immutable pre-I/O UUID as `X-Request-Id`. The live flag cannot select a
+  different endpoint.
+- Available cash, total invested and equity come from the demo P&L endpoint and
+  the formulas in eToro's current guides. `clientPortfolio.credit` alone is not
+  available cash because pending orders must be deducted. Every position and
+  pending order, manual or automated, consumes portfolio/instrument capacity;
+  only exact strategy order/position provenance grants mutation authority.
+- The current cost docs return USD `amount`, while the measured demo sample
+  returned undocumented `value`. The executor accepts only documented `amount`,
+  rejects `value`, stale/missing/negative/non-USD components and any positive
+  recurring fee whose holding horizon is unmodelled. Net expectancy is the
+  minimum pinned bootstrap expectancy CI less stressed current cost divided by
+  the exact ticket amount.
+- The free Nasdaq Trader RSS feed is the primary halt source. Its documented
+  once-per-minute refresh guidance, provider `(symbol, halt_at)` identity,
+  source publication time, halt code and trade-resumption time are retained.
+  Missing/stale/malformed feed state or an unresolved halt refuses entry.
+- Storage stays bounded: one policy current row plus revision events; one
+  preflight/shadow row per durable fired signal; one rolling account high-water
+  row; one halt-feed state row; and halt events retained for 90 days. Raw P&L,
+  eligibility, cost, order and RSS payloads stay process-local.
+- Every gate failure becomes the fired signal's sole unfunded shadow decision.
+  Passing all gates commits funding, trade, order link and request UUID before
+  broker I/O. A transport-uncertain submission is never retried under a new UUID;
+  it enters the existing reconciliation backlog and blocks later entries if it
+  breaches the configured SLO.
+
+Primary contracts verified 2026-08-09: [eToro create order](https://api-portal.etoro.com/api-reference/trading--demo/create-an-order),
+[eToro what-if costs](https://api-portal.etoro.com/api-reference/trading--demo/get-what-if-trading-cost-breakdown),
+[eToro equity formula](https://api-portal.etoro.com/guides/calculate-equity), and
+[Nasdaq Trader halt RSS](https://www.nasdaqtrader.com/Trader.aspx?id=TradeHaltRSS).
 
 ## Features to add before paper trading
 

--- a/sql/287_strategy_paper_execution.sql
+++ b/sql/287_strategy_paper_execution.sql
@@ -1,0 +1,126 @@
+-- 287_strategy_paper_execution.sql
+--
+-- #2449 / #2437 demo-only allocator.  Policy is current state plus a bounded
+-- audit history; each fired signal gets at most one compact preflight row.
+-- Broker payloads, quote histories and polling heartbeats are deliberately not
+-- copied here.
+
+CREATE TABLE IF NOT EXISTS strategy_execution_policies (
+    deployment_id                   BIGINT PRIMARY KEY
+        REFERENCES strategy_deployments(deployment_id) ON DELETE RESTRICT,
+    revision                        BIGINT NOT NULL CHECK (revision >= 1),
+    ticket_fraction                 NUMERIC(12,8) NOT NULL CHECK (ticket_fraction > 0 AND ticket_fraction <= 1),
+    max_ticket_amount               NUMERIC(18,6) NOT NULL CHECK (max_ticket_amount > 0),
+    stop_loss_pct                   NUMERIC(12,8) NOT NULL CHECK (stop_loss_pct > 0 AND stop_loss_pct < 100),
+    take_profit_pct                 NUMERIC(12,8) NOT NULL CHECK (take_profit_pct > 0),
+    max_quote_age_seconds           INTEGER NOT NULL CHECK (max_quote_age_seconds > 0),
+    max_scan_age_seconds            INTEGER NOT NULL CHECK (max_scan_age_seconds > 0),
+    max_halt_feed_age_seconds       INTEGER NOT NULL CHECK (max_halt_feed_age_seconds > 0),
+    max_cost_age_seconds            INTEGER NOT NULL CHECK (max_cost_age_seconds > 0),
+    max_reconciliation_age_seconds  INTEGER NOT NULL CHECK (max_reconciliation_age_seconds > 0),
+    max_instrument_exposure_pct     NUMERIC(12,8) NOT NULL CHECK (
+        max_instrument_exposure_pct > 0 AND max_instrument_exposure_pct <= 100
+    ),
+    max_portfolio_exposure_pct      NUMERIC(12,8) NOT NULL CHECK (
+        max_portfolio_exposure_pct > 0 AND max_portfolio_exposure_pct <= 100
+    ),
+    max_drawdown_pct                NUMERIC(12,8) NOT NULL CHECK (max_drawdown_pct > 0 AND max_drawdown_pct < 100),
+    min_net_expectancy_pct          NUMERIC(12,8) NOT NULL,
+    cost_stress_multiplier          NUMERIC(12,8) NOT NULL CHECK (cost_stress_multiplier >= 1),
+    updated_by                      TEXT NOT NULL CHECK (updated_by <> '' AND length(updated_by) <= 200),
+    reason                          TEXT NOT NULL CHECK (reason <> '' AND length(reason) <= 1000),
+    created_at                      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS strategy_execution_policy_events (
+    policy_event_id                 BIGSERIAL PRIMARY KEY,
+    deployment_id                  BIGINT NOT NULL
+        REFERENCES strategy_deployments(deployment_id) ON DELETE RESTRICT,
+    revision                       BIGINT NOT NULL CHECK (revision >= 1),
+    ticket_fraction                NUMERIC(12,8) NOT NULL,
+    max_ticket_amount              NUMERIC(18,6) NOT NULL,
+    stop_loss_pct                  NUMERIC(12,8) NOT NULL,
+    take_profit_pct                NUMERIC(12,8) NOT NULL,
+    max_quote_age_seconds          INTEGER NOT NULL,
+    max_scan_age_seconds           INTEGER NOT NULL,
+    max_halt_feed_age_seconds      INTEGER NOT NULL,
+    max_cost_age_seconds           INTEGER NOT NULL,
+    max_reconciliation_age_seconds INTEGER NOT NULL,
+    max_instrument_exposure_pct    NUMERIC(12,8) NOT NULL,
+    max_portfolio_exposure_pct     NUMERIC(12,8) NOT NULL,
+    max_drawdown_pct               NUMERIC(12,8) NOT NULL,
+    min_net_expectancy_pct         NUMERIC(12,8) NOT NULL,
+    cost_stress_multiplier         NUMERIC(12,8) NOT NULL,
+    changed_by                     TEXT NOT NULL CHECK (changed_by <> '' AND length(changed_by) <= 200),
+    reason                         TEXT NOT NULL CHECK (reason <> '' AND length(reason) <= 1000),
+    changed_at                     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (deployment_id, revision)
+);
+
+-- One current feed observation, updated in place every successful fetch.
+CREATE TABLE IF NOT EXISTS strategy_halt_feed_state (
+    source          TEXT PRIMARY KEY CHECK (source = 'nasdaq_trader_rss'),
+    fetched_at      TIMESTAMPTZ NOT NULL,
+    source_pub_at   TIMESTAMPTZ NOT NULL,
+    item_count      INTEGER NOT NULL CHECK (item_count >= 0),
+    payload_sha256  TEXT NOT NULL CHECK (payload_sha256 ~ '^[0-9a-f]{64}$')
+);
+
+-- Provider-native halt identity. Rows are upserted as Nasdaq adds resumption
+-- fields; a routine deletes rows older than 90 days.
+CREATE TABLE IF NOT EXISTS strategy_market_halts (
+    source              TEXT NOT NULL CHECK (source = 'nasdaq_trader_rss'),
+    symbol              TEXT NOT NULL CHECK (symbol <> '' AND length(symbol) <= 40),
+    halt_at             TIMESTAMPTZ NOT NULL,
+    market              TEXT NOT NULL CHECK (market <> '' AND length(market) <= 80),
+    reason_code         TEXT NOT NULL CHECK (reason_code <> '' AND length(reason_code) <= 20),
+    resumed_at          TIMESTAMPTZ,
+    observed_at         TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (source, symbol, halt_at),
+    CHECK (resumed_at IS NULL OR resumed_at >= halt_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_market_halts_active_symbol
+    ON strategy_market_halts (symbol, halt_at DESC) WHERE resumed_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_strategy_market_halts_retention
+    ON strategy_market_halts (halt_at);
+
+-- Decision-bearing facts only. This is a one-row shadow/allocated arm for a
+-- durable fired signal and does not retain raw eligibility/cost/portfolio data.
+CREATE TABLE IF NOT EXISTS strategy_entry_preflights (
+    signal_id                    BIGINT PRIMARY KEY
+        REFERENCES strategy_signals(signal_id) ON DELETE RESTRICT,
+    deployment_id                BIGINT
+        REFERENCES strategy_deployments(deployment_id) ON DELETE RESTRICT,
+    policy_revision              BIGINT,
+    verdict                      TEXT NOT NULL CHECK (verdict IN ('allocated', 'rejected')),
+    reason_code                  TEXT NOT NULL CHECK (reason_code <> '' AND length(reason_code) <= 100),
+    evaluated_at                 TIMESTAMPTZ NOT NULL,
+    quote_at                     TIMESTAMPTZ,
+    scan_at                      TIMESTAMPTZ,
+    halt_feed_at                 TIMESTAMPTZ,
+    eligibility_checked_at       TIMESTAMPTZ,
+    costs_at                     TIMESTAMPTZ,
+    broker_available_cash        NUMERIC(18,6),
+    account_equity               NUMERIC(18,6),
+    account_invested             NUMERIC(18,6),
+    instrument_invested          NUMERIC(18,6),
+    account_drawdown_pct         NUMERIC(12,8),
+    allocated_amount             NUMERIC(18,6),
+    gross_expectancy_ci_low_pct  NUMERIC(12,8),
+    stressed_cost_amount         NUMERIC(18,6),
+    net_expectancy_pct           NUMERIC(12,8),
+    stop_loss_rate               NUMERIC(18,6),
+    take_profit_rate             NUMERIC(18,6),
+    CHECK (
+        (verdict = 'allocated' AND deployment_id IS NOT NULL AND policy_revision IS NOT NULL
+         AND allocated_amount > 0 AND stop_loss_rate > 0 AND take_profit_rate > 0)
+        OR
+        (verdict = 'rejected' AND allocated_amount IS NULL)
+    )
+);
+
+COMMENT ON TABLE strategy_entry_preflights IS
+    'One compact decision-bearing preflight per fired entry signal. Rejections '
+    'are the unfunded shadow arm; raw broker/feed payloads are not persisted.';

--- a/sql/288_strategy_paper_account_risk_state.sql
+++ b/sql/288_strategy_paper_account_risk_state.sql
@@ -1,0 +1,11 @@
+-- 288_strategy_paper_account_risk_state.sql
+-- #2449: one rolling demo-account high-water mark. It starts when paper
+-- automation is configured and updates in place; no account-value series.
+
+CREATE TABLE IF NOT EXISTS strategy_paper_account_risk_state (
+    id                  BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    equity_high_water   NUMERIC(18,6) NOT NULL CHECK (equity_high_water > 0),
+    last_equity         NUMERIC(18,6) NOT NULL CHECK (last_equity > 0),
+    last_drawdown_pct   NUMERIC(12,8) NOT NULL CHECK (last_drawdown_pct >= 0),
+    observed_at         TIMESTAMPTZ NOT NULL
+);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -201,6 +201,12 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "strategy_deployments",
     # #2451 — bounded current kill state has no FK by design.
     "strategy_execution_blocks",
+    # #2448/#2449 — bounded strategy current-state roots have no FKs. Their
+    # signal/deployment children are derived by the planner from roots above.
+    "strategy_scan_watermark",
+    "strategy_halt_feed_state",
+    "strategy_market_halts",
+    "strategy_paper_account_risk_state",
     "positions",
     "quotes",
     # #1919 — thesis generation attempts (FK → instruments + theses).

--- a/tests/test_bootstrap_state_prerequisite.py
+++ b/tests/test_bootstrap_state_prerequisite.py
@@ -36,6 +36,7 @@ from app.workers.scheduler import (
     JOB_ORPHAN_TEST_DB_REAP,
     JOB_OWNERSHIP_OBSERVATIONS_BACKFILL,
     JOB_PG_SIZE_SAMPLE,
+    JOB_QUOTES_REFRESH,
     JOB_RAW_DATA_RETENTION_SWEEP,
     JOB_RETRY_DEFERRED,
     JOB_RETRY_SWEEPER,
@@ -175,6 +176,10 @@ NON_GATED_SCHEDULED: frozenset[str] = frozenset(
         JOB_DAILY_NEWS_REFRESH,
         JOB_PG_SIZE_SAMPLE,
         JOB_THESIS_REFRESH,
+        # #2449 audit — current quotes have no bootstrap-produced input and
+        # the non-exempt job is already stopped by the universal gate. A
+        # second per-job gate would duplicate that authority.
+        JOB_QUOTES_REFRESH,
     }
 )
 

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -20,7 +20,9 @@ from app.providers.broker import (
     BrokerMirror,
     BrokerMirrorPosition,
     BrokerOrderNotFound,
+    BrokerOrderSubmissionError,
     BrokerPortfolio,
+    BrokerStrategyOrder,
     BrokerWhatIfOrder,
     OrderParams,
 )
@@ -148,6 +150,28 @@ FIXTURE_WHAT_IF_COST_RESPONSE = {
         {"costType": "overnightFee", "value": 0.0, "currency": "USD"},
     ],
     "lastUpdated": "2026-05-25T08:30:00Z",
+}
+
+FIXTURE_ACCOUNT_PNL_RESPONSE = {
+    "credits": 1000,
+    "positions": [
+        {"instrumentId": 1001, "amount": 200, "unrealizedPnL": {"pnL": 20}},
+        {"instrumentId": 1002, "amount": 100, "unrealizedPnL": {"pnL": -5}},
+    ],
+    "mirrors": [
+        {
+            "availableAmount": 50,
+            "closedPositionsNetProfit": 10,
+            "positions": [
+                {"instrumentId": 1001, "amount": 25, "unrealizedPnL": {"pnL": 2}},
+            ],
+        }
+    ],
+    "ordersForOpen": [
+        {"instrumentId": 1001, "mirrorID": 0, "amount": 40, "totalExternalCosts": 1},
+        {"instrumentId": 1002, "mirrorID": 99, "amount": 999, "totalExternalCosts": 999},
+    ],
+    "orders": [{"instrumentId": 1002, "amount": 30}],
 }
 
 
@@ -278,6 +302,90 @@ class TestTradingPreflight:
                 pass
             else:  # pragma: no cover - assertion helper branch
                 raise AssertionError(f"invalid what-if size accepted: amount={amount}, units={units}")
+
+
+class TestStrategyAccountRisk:
+    def test_official_pnl_formula_counts_manual_positions_and_pending_orders(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FIXTURE_ACCOUNT_PNL_RESPONSE
+
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            result = broker.get_account_risk_snapshot()
+
+        assert result.available_cash == Decimal("930")  # 1000 - 40 - 30
+        assert result.total_invested == Decimal("436")  # 200+100+(50-10)+25+40+1+30
+        assert result.unrealized_pnl == Decimal("27")  # 20-5+2+10
+        assert result.equity == Decimal("1393")
+        assert [(row.instrument_id, row.amount) for row in result.instrument_investments] == [
+            (1001, Decimal("266")),
+            (1002, Decimal("130")),
+        ]
+
+    def test_account_risk_fails_closed_on_partial_pnl_shape(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {**FIXTURE_ACCOUNT_PNL_RESPONSE, "orders": None}
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            try:
+                broker.get_account_risk_snapshot()
+            except TradingPreflightParseError as exc:
+                assert "orders" in str(exc)
+            else:  # pragma: no cover
+                raise AssertionError("partial P&L response must fail closed")
+
+
+class TestDemoStrategyOrder:
+    def test_v2_writer_is_demo_only_x1_fixed_exit_and_idempotent(self) -> None:
+        request_id = UUID("1c94300c-90aa-4303-9d00-dec376d74efb")
+        token = UUID("066faaee-e1e9-49d2-a568-c6e1cc336ad8")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "token": str(token),
+            "orderId": 13902598,
+            "referenceId": str(request_id),
+        }
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.post.return_value = mock_resp
+            result = broker.place_demo_strategy_order(
+                BrokerStrategyOrder(
+                    instrument_id=1001,
+                    amount=Decimal("100"),
+                    settlement_type="real",
+                    stop_loss_rate=Decimal("90"),
+                    take_profit_rate=Decimal("120"),
+                ),
+                request_id=request_id,
+            )
+            call = broker._http_write.post.call_args
+        assert call.args[0] == "/api/v2/trading/execution/demo/orders"
+        assert call.kwargs["headers"] == {"x-request-id": str(request_id)}
+        assert call.kwargs["json"]["leverage"] == 1
+        assert call.kwargs["json"]["stopLossType"] == "fixed"
+        assert call.kwargs["json"]["settlementType"] == "real"
+        assert result.broker_order_ref == "13902598"
+        assert result.reference_id == request_id
+
+    def test_real_credentials_cannot_select_a_strategy_writer(self) -> None:
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="real") as broker:
+            try:
+                broker.place_demo_strategy_order(
+                    BrokerStrategyOrder(
+                        instrument_id=1001,
+                        amount=Decimal("100"),
+                        settlement_type="real",
+                        stop_loss_rate=Decimal("90"),
+                        take_profit_rate=Decimal("120"),
+                    ),
+                    request_id=uuid4(),
+                )
+            except BrokerOrderSubmissionError:
+                pass
+            else:  # pragma: no cover
+                raise AssertionError("real credentials must not reach the paper writer")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_strategy_halts.py
+++ b/tests/test_strategy_halts.py
@@ -1,0 +1,91 @@
+"""Nasdaq Trader halt feed parsing and bounded persistence tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.strategy_halts import HaltFeedError, parse_halt_rss, store_halt_snapshot
+
+_XML = b"""<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:ndaq="http://www.nasdaqtrader.com/">
+  <channel>
+    <title>NASDAQTrader.com</title>
+    <pubDate>Fri, 07 Aug 2026 15:00:00 GMT</pubDate>
+    <ndaq:numItems>2</ndaq:numItems>
+    <item>
+      <ndaq:HaltDate>08/07/2026</ndaq:HaltDate>
+      <ndaq:HaltTime>10:01:02.000</ndaq:HaltTime>
+      <ndaq:IssueSymbol>HALT</ndaq:IssueSymbol>
+      <ndaq:Market>NASDAQ</ndaq:Market>
+      <ndaq:ReasonCode>T1</ndaq:ReasonCode>
+      <ndaq:ResumptionDate />
+      <ndaq:ResumptionTradeTime />
+    </item>
+    <item>
+      <ndaq:HaltDate>08/07/2026</ndaq:HaltDate>
+      <ndaq:HaltTime>09:45:00.000</ndaq:HaltTime>
+      <ndaq:IssueSymbol>BACK</ndaq:IssueSymbol>
+      <ndaq:Market>NYSE</ndaq:Market>
+      <ndaq:ReasonCode>T5</ndaq:ReasonCode>
+      <ndaq:ResumptionDate>08/07/2026</ndaq:ResumptionDate>
+      <ndaq:ResumptionTradeTime>10:00:00.000</ndaq:ResumptionTradeTime>
+    </item>
+  </channel>
+</rss>"""
+
+
+def test_parse_uses_provider_identity_and_eastern_market_time() -> None:
+    snapshot = parse_halt_rss(_XML)
+    assert len(snapshot.halts) == 2
+    assert snapshot.halts[0].symbol == "HALT"
+    assert snapshot.halts[0].halt_at == datetime(2026, 8, 7, 14, 1, 2, tzinfo=UTC)
+    assert snapshot.halts[0].resumed_at is None
+    assert snapshot.halts[1].resumed_at == datetime(2026, 8, 7, 14, 0, tzinfo=UTC)
+
+
+def test_partial_resumption_and_count_drift_fail_closed() -> None:
+    for malformed in (
+        _XML.replace(
+            b"<ndaq:ResumptionTradeTime />",
+            b"<ndaq:ResumptionTradeTime>10:00:00.000</ndaq:ResumptionTradeTime>",
+        ),
+        _XML.replace(b"<ndaq:numItems>2</ndaq:numItems>", b"<ndaq:numItems>3</ndaq:numItems>"),
+    ):
+        with pytest.raises(HaltFeedError):
+            parse_halt_rss(malformed)
+
+
+@pytest.mark.integration
+def test_store_upserts_current_state_and_removes_old_rows(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    fetched = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)
+    conn.execute(
+        """
+        INSERT INTO strategy_market_halts (
+            source, symbol, halt_at, market, reason_code, resumed_at, observed_at
+        ) VALUES ('nasdaq_trader_rss', 'OLD', %s, 'NASDAQ', 'T1', %s, %s),
+                 ('nasdaq_trader_rss', 'STILL', %s, 'NASDAQ', 'T1', NULL, %s)
+        """,
+        (
+            fetched - timedelta(days=91),
+            fetched - timedelta(days=90),
+            fetched - timedelta(days=91),
+            fetched - timedelta(days=120),
+            fetched - timedelta(days=120),
+        ),
+    )
+    snapshot = parse_halt_rss(_XML)
+
+    assert store_halt_snapshot(conn, snapshot=snapshot, fetched_at=fetched) == 1
+    assert store_halt_snapshot(conn, snapshot=snapshot, fetched_at=fetched) == 0
+    assert conn.execute("SELECT count(*) FROM strategy_halt_feed_state").fetchone() == (1,)
+    assert conn.execute("SELECT count(*) FROM strategy_market_halts").fetchone() == (3,)
+    assert conn.execute(
+        "SELECT symbol FROM strategy_market_halts WHERE resumed_at IS NULL ORDER BY symbol"
+    ).fetchall() == [("HALT",), ("STILL",)]

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -1,0 +1,483 @@
+"""#2449 demo allocator/executor integration tests against real Postgres."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from threading import Barrier, Event
+from time import sleep
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import psycopg
+import pytest
+
+from app.providers.broker import (
+    BrokerAccountRiskSnapshot,
+    BrokerCostComponent,
+    BrokerEligibilityResponse,
+    BrokerInstrumentEligibility,
+    BrokerInstrumentInvestment,
+    BrokerLeverageConfig,
+    BrokerOrderSubmission,
+    BrokerOrderSubmissionUncertain,
+    BrokerProvider,
+    BrokerWhatIfCostResponse,
+)
+from app.services.result_ledger import store_holdout_result
+from app.services.strategy_control_plane import (
+    configure_deployment,
+    configure_execution_policy,
+    create_strategy_trade,
+    decide_funding,
+    link_strategy_order,
+)
+from app.services.strategy_paper_executor import PaperExecutionResult, execute_fired_paper_signal
+from tests.fixtures.ebull_test_db import test_database_url
+from tests.test_result_ledger import (
+    BOOTSTRAP_BLOCK,
+    build_control,
+    build_deflated,
+    build_metrics,
+    build_result,
+)
+
+pytestmark = pytest.mark.integration
+
+_NOW = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)  # Friday 11:00 New York
+_REQUEST_ID = UUID("1c94300c-90aa-4303-9d00-dec376d74efb")
+
+
+def _seed(conn: psycopg.Connection[Any], *, auto: bool = True) -> int:
+    conn.execute(
+        "INSERT INTO exchanges (exchange_id, country, asset_class) VALUES ('2', 'US', 'us_equity') "
+        "ON CONFLICT (exchange_id) DO UPDATE SET asset_class='us_equity'"
+    )
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency,
+            is_tradable
+        ) VALUES (2449001, 'TALLOC', 'Allocator test', '2', 'USD', true)
+        """
+    )
+    metrics = build_metrics(
+        **{
+            **BOOTSTRAP_BLOCK,
+            "expectancy_ci_low_pct": 5.0,
+            "expectancy_ci_high_pct": 6.0,
+        }
+    )
+    deflated = build_deflated()
+    result_id = store_holdout_result(
+        conn,
+        build_result(
+            strategy_id="S-ALLOC",
+            strategy_version="v1",
+            namespace="hold_out",
+            window_start=date(2022, 1, 1),
+            universe_basis="survivorship_free",
+            carry_unmodelled=False,
+            metrics=metrics,
+            deflated=deflated,
+            trial_count=deflated.declared_trials,
+            deflated_sharpe=Decimal(repr(deflated.deflated_sharpe)),
+            synthetic_control=build_control(
+                metrics,
+                mean_return_pct=0.0,
+                mean_return_ci_low_pct=-1.0,
+                mean_return_ci_high_pct=1.0,
+                cohort_sharpe_threshold=-4.0,
+                cohort_return_threshold_pct=-101.0,
+            ),
+        ),
+        accessed_by="tests/test_strategy_paper_executor.py",
+        purpose="paper allocation evidence fixture",
+    )
+    promotion_rows = conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id, strategy_version, from_stage, to_stage, gate_version,
+            evidence_ref, promoted_by, reason
+        ) VALUES
+          ('S-ALLOC', 'v1', NULL, 'research_candidate', 'test-v1', NULL, 'test', 'registered'),
+          ('S-ALLOC', 'v1', 'research_candidate', 'historical_validated', 'test-v1', 'e:h', 'test', 'historical'),
+          ('S-ALLOC', 'v1', 'historical_validated', 'forward_observation', 'test-v1', 'e:f', 'test', 'forward'),
+          ('S-ALLOC', 'v1', 'forward_observation', 'paper_enabled', 'test-v1', 'e:p', 'test', 'paper')
+        RETURNING promotion_id, to_stage
+        """
+    ).fetchall()
+    historical_id = next(int(row[0]) for row in promotion_rows if row[1] == "historical_validated")
+    conn.execute(
+        "INSERT INTO strategy_promotion_results (promotion_id, result_id) VALUES (%s, %s)",
+        (historical_id, result_id),
+    )
+    deployment = configure_deployment(
+        conn,
+        strategy_id="S-ALLOC",
+        strategy_version="v1",
+        mode="paper",
+        capital_limit=Decimal("1000"),
+        enabled=True,
+        changed_by="test",
+        reason="paper allocation test",
+    )
+    configure_execution_policy(
+        conn,
+        deployment_id=deployment.deployment_id,
+        ticket_fraction=Decimal("0.20"),
+        max_ticket_amount=Decimal("500"),
+        stop_loss_pct=Decimal("5"),
+        take_profit_pct=Decimal("10"),
+        max_quote_age_seconds=60,
+        max_scan_age_seconds=60,
+        max_halt_feed_age_seconds=60,
+        max_cost_age_seconds=60,
+        max_reconciliation_age_seconds=60,
+        max_instrument_exposure_pct=Decimal("30"),
+        max_portfolio_exposure_pct=Decimal("80"),
+        max_drawdown_pct=Decimal("10"),
+        min_net_expectancy_pct=Decimal("1"),
+        cost_stress_multiplier=Decimal("2"),
+        changed_by="test",
+        reason="explicit test limits",
+    )
+    signal = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id, strategy_version, instrument_id, signal_bar_date,
+            signal_kind, verdict, fill_bar_date, fill_price, universe,
+            input_rule_set_versions
+        ) VALUES ('S-ALLOC', 'v1', 2449001, '2026-08-05', 'entry', 'fired',
+                  '2026-08-06', 100, 'survivor_only',
+                  '{"indicator_series":"rules-v1"}'::jsonb)
+        RETURNING signal_id
+        """
+    ).fetchone()
+    assert signal is not None
+    conn.execute(
+        "INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last, spread_pct, spread_flag) "
+        "VALUES (2449001, %s, 99, 100, 99.5, 1, false)",
+        (_NOW,),
+    )
+    conn.execute(
+        "INSERT INTO strategy_scan_watermark (strategy_id, strategy_version, frontier_date, updated_at) "
+        "VALUES ('S-ALLOC', 'v1', '2026-08-07', %s) "
+        "ON CONFLICT (strategy_id, strategy_version) DO UPDATE SET "
+        "frontier_date=EXCLUDED.frontier_date, updated_at=EXCLUDED.updated_at",
+        (_NOW,),
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_halt_feed_state (
+            source, fetched_at, source_pub_at, item_count, payload_sha256
+        ) VALUES ('nasdaq_trader_rss', %s, %s, 0, %s)
+        ON CONFLICT (source) DO UPDATE SET
+            fetched_at=EXCLUDED.fetched_at, source_pub_at=EXCLUDED.source_pub_at,
+            item_count=EXCLUDED.item_count, payload_sha256=EXCLUDED.payload_sha256
+        """,
+        (_NOW, _NOW, "0" * 64),
+    )
+    conn.execute(
+        """
+        INSERT INTO runtime_config (
+            id, enable_auto_trading, enable_live_trading, updated_by, reason
+        ) VALUES (true, %s, true, 'test', 'paper allocator fixture')
+        ON CONFLICT (id) DO UPDATE SET
+            enable_auto_trading=EXCLUDED.enable_auto_trading,
+            enable_live_trading=EXCLUDED.enable_live_trading,
+            updated_by=EXCLUDED.updated_by, reason=EXCLUDED.reason,
+            updated_at=now()
+        """,
+        (auto,),
+    )
+    conn.execute(
+        """
+        INSERT INTO kill_switch (id, is_active)
+        VALUES (true, false)
+        ON CONFLICT (id) DO UPDATE SET
+            is_active=false, activated_at=NULL, activated_by=NULL, reason=NULL
+        """
+    )
+    conn.commit()
+    return int(signal[0])
+
+
+def _broker(*, undocumented_cost: bool = False) -> MagicMock:
+    broker = MagicMock(spec=BrokerProvider)
+    broker.get_account_risk_snapshot.return_value = BrokerAccountRiskSnapshot(
+        available_cash=Decimal("600"),
+        total_invested=Decimal("400"),
+        unrealized_pnl=Decimal("0"),
+        equity=Decimal("1000"),
+        instrument_investments=(BrokerInstrumentInvestment(2449001, Decimal("250")),),
+        observed_at=_NOW,
+        raw_payload={},
+    )
+    broker.check_instrument_eligibility.return_value = BrokerEligibilityResponse(
+        currency="USD",
+        eligibilities=(
+            BrokerInstrumentEligibility(
+                instrument_id=2449001,
+                symbol="TALLOC",
+                min_position_exposure=Decimal("10"),
+                max_units_per_order=None,
+                allow_open_position=True,
+                allow_close_position=True,
+                allow_partial_close_position=True,
+                allow_trailing_stop_loss=False,
+                leverage_configs=(
+                    BrokerLeverageConfig(
+                        settlement_type="real",
+                        direction="LONG",
+                        leverage_values=(1,),
+                        min_position_amount=Decimal("10"),
+                        allow_edit_stop_loss=True,
+                        allow_edit_take_profit=True,
+                        allow_stop_loss_take_profit=True,
+                        raw_payload={},
+                    ),
+                ),
+                raw_payload={},
+            ),
+        ),
+        not_found_instrument_ids=(),
+        not_found_symbols=(),
+        raw_payload={},
+    )
+    broker.get_what_if_costs.return_value = BrokerWhatIfCostResponse(
+        instrument_id=2449001,
+        symbol="TALLOC",
+        costs=(
+            BrokerCostComponent(
+                cost_type="marketSpread",
+                amount=None if undocumented_cost else Decimal("0.5"),
+                value=Decimal("0.5") if undocumented_cost else None,
+                currency="USD",
+                raw_payload={},
+            ),
+        ),
+        last_updated=_NOW,
+        raw_payload={},
+    )
+    broker.place_demo_strategy_order.return_value = BrokerOrderSubmission(
+        broker_order_ref="13902598",
+        reference_id=_REQUEST_ID,
+        token=UUID("066faaee-e1e9-49d2-a568-c6e1cc336ad8"),
+    )
+    return broker
+
+
+def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    broker = _broker()
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "submitted"
+    assert result.amount == Decimal("50.00")  # 30% equity cap - $250 manual/existing exposure
+    submitted = broker.place_demo_strategy_order.call_args
+    assert submitted.kwargs["request_id"] == _REQUEST_ID
+    assert submitted.args[0].amount == Decimal("50.00")
+    assert submitted.args[0].stop_loss_rate == Decimal("95.000000")
+    assert submitted.args[0].take_profit_rate == Decimal("110.000000")
+    assert conn.execute(
+        "SELECT strategy_request_id, execution_origin, broker_order_ref FROM orders WHERE order_id=%s",
+        (result.order_id,),
+    ).fetchone() == (_REQUEST_ID, "strategy", "13902598")
+    assert conn.execute(
+        "SELECT verdict, allocated_amount, net_expectancy_pct FROM strategy_entry_preflights WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == ("allocated", Decimal("50.000000"), Decimal("3.00000000"))
+    conn.commit()
+
+    # Retry is read-only and cannot submit a duplicate.
+    assert execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW).order_id == result.order_id
+    broker.place_demo_strategy_order.assert_called_once()
+
+
+def test_disabled_global_switch_keeps_an_unfunded_shadow_arm(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    signal_id = _seed(ebull_test_conn, auto=False)
+    broker = _broker()
+
+    result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "auto_trading_disabled"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+    assert ebull_test_conn.execute(
+        "SELECT verdict, reason_code FROM strategy_funding_decisions WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == ("rejected", "auto_trading_disabled")
+
+
+def test_undocumented_cost_units_refuse_before_any_order_exists(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    broker = _broker(undocumented_cost=True)
+
+    result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.reason_code == "cost_unit_undocumented"
+    broker.place_demo_strategy_order.assert_not_called()
+    assert ebull_test_conn.execute("SELECT count(*) FROM orders WHERE execution_origin='strategy'").fetchone() == (0,)
+
+
+def test_non_positive_ask_is_a_preflight_rejection_not_submission_uncertainty(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    ebull_test_conn.execute("UPDATE quotes SET ask=0 WHERE instrument_id=2449001")
+    ebull_test_conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "quote_ask_invalid"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_order_reconciliation_state").fetchone() == (0,)
+
+
+def test_unresolved_local_strategy_order_consumes_risk_before_broker_snapshot_catches_up(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    deployment = ebull_test_conn.execute(
+        "SELECT deployment_id FROM strategy_deployments WHERE strategy_id='S-ALLOC' AND mode='paper'"
+    ).fetchone()
+    assert deployment is not None
+    deployment_id = int(deployment[0])
+    prior_signal = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id, strategy_version, instrument_id, signal_bar_date,
+            signal_kind, verdict, fill_bar_date, fill_price, universe,
+            input_rule_set_versions
+        ) VALUES ('S-ALLOC', 'v1', 2449001, '2026-08-04', 'entry', 'fired',
+                  '2026-08-05', 100, 'survivor_only',
+                  '{"indicator_series":"rules-v1"}'::jsonb)
+        RETURNING signal_id
+        """
+    ).fetchone()
+    assert prior_signal is not None
+    decision_id = decide_funding(
+        ebull_test_conn,
+        signal_id=int(prior_signal[0]),
+        verdict="allocated",
+        deployment_id=deployment_id,
+        amount=Decimal("60"),
+        reason_code="test_unresolved_order",
+    )
+    trade_id = create_strategy_trade(ebull_test_conn, decision_id)
+    order = ebull_test_conn.execute(
+        """
+        INSERT INTO orders (
+            instrument_id, action, order_type, requested_amount, status,
+            raw_payload_json, execution_origin
+        ) VALUES (2449001, 'BUY', 'MARKET', 60, 'submitted', NULL, 'strategy')
+        RETURNING order_id
+        """
+    ).fetchone()
+    assert order is not None
+    link_strategy_order(
+        ebull_test_conn,
+        strategy_trade_id=trade_id,
+        order_id=int(order[0]),
+        purpose="entry",
+    )
+    ebull_test_conn.execute(
+        "UPDATE strategy_trades SET status='reconcile_required' WHERE strategy_trade_id=%s",
+        (trade_id,),
+    )
+    ebull_test_conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "risk_capacity_exhausted"
+    broker.check_instrument_eligibility.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
+def test_transport_uncertainty_retries_only_the_committed_uuid(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    broker = _broker()
+    accepted = broker.place_demo_strategy_order.return_value
+    broker.place_demo_strategy_order.side_effect = [
+        BrokerOrderSubmissionUncertain("timeout"),
+        accepted,
+    ]
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    first = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+    assert first.verdict == "submission_uncertain"
+    second = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert second.verdict == "submitted"
+    assert [call.kwargs["request_id"] for call in broker.place_demo_strategy_order.call_args_list] == [
+        _REQUEST_ID,
+        _REQUEST_ID,
+    ]
+    assert ebull_test_conn.execute(
+        "SELECT strategy_request_id FROM orders WHERE execution_origin='strategy'"
+    ).fetchall() == [(_REQUEST_ID,)]
+
+
+def test_concurrent_same_signal_callers_submit_exactly_once(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    broker = _broker()
+    accepted = broker.place_demo_strategy_order.return_value
+    both_started = Barrier(2)
+    first_submission_entered = Event()
+    release_submission = Event()
+
+    def place_once(*args: Any, **kwargs: Any) -> BrokerOrderSubmission:
+        del args, kwargs
+        first_submission_entered.set()
+        assert release_submission.wait(timeout=5)
+        return accepted
+
+    broker.place_demo_strategy_order.side_effect = place_once
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    def execute() -> PaperExecutionResult:
+        with psycopg.connect(test_database_url()) as worker_conn:
+            both_started.wait(timeout=5)
+            return execute_fired_paper_signal(worker_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(execute)
+        second = pool.submit(execute)
+        if not first_submission_entered.wait(timeout=5):
+            release_submission.set()
+            first.result(timeout=5)
+            second.result(timeout=5)
+            raise AssertionError("neither concurrent caller reached the broker submission boundary")
+        sleep(0.1)
+        assert broker.place_demo_strategy_order.call_count == 1
+        release_submission.set()
+        results = (first.result(timeout=5), second.result(timeout=5))
+
+    assert results[0].order_id == results[1].order_id
+    assert {result.verdict for result in results} == {"submitted"}
+    assert broker.place_demo_strategy_order.call_count == 1

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -440,6 +440,51 @@ def test_transport_uncertainty_retries_only_the_committed_uuid(
     ).fetchall() == [(_REQUEST_ID,)]
 
 
+def test_unexpected_initial_submission_bug_propagates_with_reconciliation_authority(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    broker = _broker()
+    broker.place_demo_strategy_order.side_effect = RuntimeError("provider programming bug")
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    with pytest.raises(RuntimeError, match="provider programming bug"):
+        execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert ebull_test_conn.execute(
+        """
+        SELECT t.status, o.strategy_request_id, r.state
+        FROM strategy_trades t
+        JOIN strategy_trade_orders sto ON sto.strategy_trade_id=t.strategy_trade_id
+        JOIN orders o ON o.order_id=sto.order_id
+        JOIN strategy_order_reconciliation_state r ON r.order_id=o.order_id
+        """
+    ).fetchone() == ("reconcile_required", _REQUEST_ID, "unresolved")
+
+
+def test_unexpected_uncertain_retry_bug_propagates_instead_of_looping_silently(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    broker = _broker()
+    broker.place_demo_strategy_order.side_effect = [
+        BrokerOrderSubmissionUncertain("timeout"),
+        RuntimeError("retry programming bug"),
+    ]
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+    assert (
+        execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW).verdict
+        == "submission_uncertain"
+    )
+
+    with pytest.raises(RuntimeError, match="retry programming bug"):
+        execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert broker.place_demo_strategy_order.call_count == 2
+
+
 def test_concurrent_same_signal_callers_submit_exactly_once(
     ebull_test_conn: psycopg.Connection[Any],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Closes #2449.
Refs #2437.

- adds the explicit paper execution policy, compact preflight shadow arm, rolling drawdown state, and bounded Nasdaq halt state
- adds strict eToro demo-only v2 strategy submission plus the documented account P&L risk formulas
- sizes against whole-account cash, portfolio exposure, instrument concentration, deployment capital and drawdown; manual positions consume capacity but never gain strategy ownership
- requires recent qualified hold-out evidence and lower-bound net expectancy after stressed current costs
- commits the exact request UUID, fixed SL/TP, trade and order before broker I/O; uncertain submissions retry only that identity
- serializes allocation and counts unresolved local submissions so stale broker snapshots cannot oversubscribe account risk
- keeps live execution unavailable and retains one compact rejection arm per fired signal

## Database boundary

- current policy: one row per deployment; revisions are explicit audit events
- preflight: one row per fired signal, no raw broker/feed payloads
- account risk: one rolling singleton row, no equity time series
- halt feed: one singleton fetch state plus provider-native halt rows; only resumed rows age out after 90 days
- measured empty relation footprint in the dev database: approximately 112 kB

## Review resolution

Codex review:

- FIXED: active halts were initially eligible for the 90-day purge; active rows are now retained indefinitely
- FIXED: deployment-only locking did not protect whole-account limits; the executor now serializes read-risk-reserve-submit and charges unresolved local orders conservatively
- FIXED: concurrent same-signal callers could lose a read-before-write race; the idempotency check is now inside the allocator lock and a two-connection regression proves one broker call
- FIXED: non-positive quote validation is classified as a preflight rejection, never broker uncertainty

## Validation

- pre-push gate green: formatting, Ruff, Pyright, shell/lint invariants, fast tests, smoke tests and frontend integrity checks
- 69 focused broker/halt/executor tests pass, including real PostgreSQL, crash retry, concurrent duplicate prevention, manual-risk isolation, active-halt retention and undocumented-cost refusal
- frontend typecheck and production build pass
- migration replay reports no pending migrations
- full suite completed with this slice green; three independently reproducible existing xdist isolation failures remain outside this diff (auth-session mock leakage, exchange seed mutation, manifest-parser registry mutation)

Broker execution remains fail-closed: the currently measured strategies do not satisfy the complete evidence gate, so this PR cannot place a demo order from current production evidence.