### PR TITLE
feat: manage exact strategy-owned positions

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -393,3 +393,29 @@ When you verify a NEW capability or find drift: update `docs/etoro-api-reference
 Primary pages: `trading--demo/create-an-order`,
 `trading--demo/get-what-if-trading-cost-breakdown`, and guides
 `calculate-available-cash`, `calculate-total-invested`, `calculate-equity`.
+
+## Automated paper-position boundary — VERIFIED 2026-08-09 (#2452)
+
+- Strategy edits use only `PATCH /api/v2/trading/demo/positions/{positionId}`;
+  strategy closes use only
+  `POST /api/v1/trading/execution/demo/market-close-orders/positions/{positionId}`.
+  Both adapters refuse real credentials and require the exact actively owned
+  broker position id before domain code reaches broker I/O.
+- PATCH returns asynchronous acceptance only. Persist the UUID first, require
+  response `positionId` and `referenceId` to match, then re-fetch the portfolio;
+  never mark the edit applied from HTTP 202.
+- A close is complete only when
+  `GET /api/v1/trading/info/demo/close-orders/{orderId}` returns the exact owned
+  id in `positions[]`. Portfolio disappearance alone cannot distinguish broker
+  SL/TP, manual intervention, missing data and the requested close.
+- Neither endpoint documents lookup by request UUID. If the process loses the
+  accepted operation/order identity, re-sync once: exact requested SL/TP already
+  landed may be accepted; every other outcome is `reconcile_required`, never a
+  newly keyed replay.
+- Keep only policy revisions and material mutation facts. Unchanged completed
+  bars and polling heartbeats write no rows; repeat rejection of the same
+  material edit reuses its terminal audit result.
+
+Primary pages: `trading--demo/modify-stop-loss-and-take-profit-settings-on-an-open-position`,
+`trading--demo/close-demo-position-by-units`, and
+`trading--demo/get-close-order-information-and-closed-position-details`.

--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -415,6 +415,10 @@ Primary pages: `trading--demo/create-an-order`,
 - Keep only policy revisions and material mutation facts. Unchanged completed
   bars and polling heartbeats write no rows; repeat rejection of the same
   material edit reuses its terminal audit result.
+- Return the untouched response object with every typed mutation result/error.
+  Persist it before advancing the material operation: PATCH/latest close detail
+  on the operation row and close submission on its linked order. Overwrite the
+  latest close-detail response rather than appending a row for every poll.
 
 Primary pages: `trading--demo/modify-stop-loss-and-take-profit-settings-on-an-open-position`,
 `trading--demo/close-demo-position-by-units`, and

--- a/.claude/skills/execution-guard/SKILL.md
+++ b/.claude/skills/execution-guard/SKILL.md
@@ -78,6 +78,13 @@ blocks new entries. They are still audited: one durable
 I/O, an unowned position id fails before I/O, and broker acceptance is not
 treated as application until exact-position re-sync/close-order reconciliation.
 This is demo-only and must not be routed through the legacy manual close helper.
+The broker adapter must return the untouched JSON object alongside every typed
+position-mutation result (including error responses where a body exists). The
+manager persists that object before applying the typed transition: PATCH/latest
+close-detail responses live on the single material operation row, and close
+submission responses live on the linked `orders` row. Keep this bounded to the
+latest response for that material operation; never append portfolio polls,
+heartbeats, or unchanged-bar payloads.
 
 ## Invariants (do not break)
 
@@ -101,6 +108,11 @@ This is demo-only and must not be routed through the legacy manual close helper.
   all three are independent gates (settled: "Kill switch" / "Config controls").
 - Deterministic: identical DB state ⇒ identical verdict. No ML, no randomness, no
   external I/O inside any DB transaction.
+- **Raw mutation response before state transition:** grep any new automated
+  broker method for `response.json()`. Its typed result/error must retain the
+  untouched dict, and the service must write it to the material operation/order
+  before using the typed fields to advance broker state. Do not satisfy this by
+  creating an append-only poll or market-data payload heap.
 
 ## Failure conditions
 

--- a/.claude/skills/execution-guard/SKILL.md
+++ b/.claude/skills/execution-guard/SKILL.md
@@ -70,6 +70,15 @@ currently returns 501 and demo fills are synthetic.
 Operator surfaces: `GET /audit` + `GET /audit/{decision_id}` (evidence_json
 detail), `GET /alerts/guard-rejections` (stage `execution_guard` FAILs).
 
+Strategy-owned paper exits (#2452) are a separate risk-reduction path in
+`strategy_position_manager.manage_owned_position`. They do not call
+`evaluate_recommendation` and intentionally remain usable while the kill switch
+blocks new entries. They are still audited: one durable
+`strategy_position_operations` intent exists before exact-position PATCH/close
+I/O, an unowned position id fails before I/O, and broker acceptance is not
+treated as application until exact-position re-sync/close-order reconciliation.
+This is demo-only and must not be routed through the legacy manual close helper.
+
 ## Invariants (do not break)
 
 - **Fail closed, no silent bypass** (CLAUDE.md non-negotiables; settled-decisions

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -81,6 +81,42 @@ class BrokerOrderSubmissionUncertain(BrokerOrderSubmissionError):
     """Transport/response failure requires lookup by the same request UUID."""
 
 
+class BrokerPositionMutationError(RuntimeError):
+    """A demo strategy position mutation was explicitly rejected."""
+
+
+class BrokerPositionMutationUncertain(BrokerPositionMutationError):
+    """A position mutation may have reached the broker and must be re-synced."""
+
+
+@dataclass(frozen=True)
+class BrokerPositionEditSubmission:
+    """Asynchronous acceptance identity for an exact-position SL/TP edit."""
+
+    operation_id: UUID
+    position_id: int
+    reference_id: UUID
+
+
+@dataclass(frozen=True)
+class BrokerPositionCloseSubmission:
+    """Acceptance identity for an exact-position close order."""
+
+    broker_order_ref: str
+    position_id: int
+
+
+@dataclass(frozen=True)
+class BrokerCloseOrderDetail:
+    """Current exact close-order result and the positions it affected."""
+
+    broker_order_ref: str
+    status: OrderStatus
+    broker_status: str
+    position_ids: tuple[int, ...]
+    reference_id: UUID | None
+
+
 @dataclass(frozen=True)
 class BrokerStrategyOrder:
     """The deliberately narrow order shape allowed by the paper MVP."""
@@ -449,6 +485,31 @@ class BrokerProvider(ABC):
         submitted.  It is therefore usable even when a process crashed before
         persisting the broker-assigned order id.
         """
+        raise NotImplementedError
+
+    def edit_demo_strategy_position(
+        self,
+        *,
+        position_id: int,
+        stop_loss_rate: Decimal,
+        take_profit_rate: Decimal | None,
+        request_id: UUID,
+    ) -> BrokerPositionEditSubmission:
+        """Edit one demo position; automated strategy code has no real path."""
+        raise NotImplementedError
+
+    def close_demo_strategy_position(
+        self,
+        *,
+        position_id: int,
+        instrument_id: int,
+        request_id: UUID,
+    ) -> BrokerPositionCloseSubmission:
+        """Close one whole demo position by its exact broker id."""
+        raise NotImplementedError
+
+    def get_demo_close_order(self, *, order_id: str) -> BrokerCloseOrderDetail:
+        """Resolve one exact demo close order and its affected position ids."""
         raise NotImplementedError
 
     def check_instrument_eligibility(

--- a/app/providers/broker.py
+++ b/app/providers/broker.py
@@ -12,7 +12,7 @@ balance).  It does not own DB access or domain logic.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
@@ -84,6 +84,10 @@ class BrokerOrderSubmissionUncertain(BrokerOrderSubmissionError):
 class BrokerPositionMutationError(RuntimeError):
     """A demo strategy position mutation was explicitly rejected."""
 
+    def __init__(self, message: str, *, raw_payload: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.raw_payload = raw_payload
+
 
 class BrokerPositionMutationUncertain(BrokerPositionMutationError):
     """A position mutation may have reached the broker and must be re-synced."""
@@ -96,6 +100,7 @@ class BrokerPositionEditSubmission:
     operation_id: UUID
     position_id: int
     reference_id: UUID
+    raw_payload: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -104,6 +109,7 @@ class BrokerPositionCloseSubmission:
 
     broker_order_ref: str
     position_id: int
+    raw_payload: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -115,6 +121,7 @@ class BrokerCloseOrderDetail:
     broker_status: str
     position_ids: tuple[int, ...]
     reference_id: UUID | None
+    raw_payload: dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -494,6 +501,7 @@ class BrokerProvider(ABC):
         stop_loss_rate: Decimal,
         take_profit_rate: Decimal | None,
         request_id: UUID,
+        persist_response: Callable[[dict[str, Any]], None] | None = None,
     ) -> BrokerPositionEditSubmission:
         """Edit one demo position; automated strategy code has no real path."""
         raise NotImplementedError
@@ -504,11 +512,17 @@ class BrokerProvider(ABC):
         position_id: int,
         instrument_id: int,
         request_id: UUID,
+        persist_response: Callable[[dict[str, Any]], None] | None = None,
     ) -> BrokerPositionCloseSubmission:
         """Close one whole demo position by its exact broker id."""
         raise NotImplementedError
 
-    def get_demo_close_order(self, *, order_id: str) -> BrokerCloseOrderDetail:
+    def get_demo_close_order(
+        self,
+        *,
+        order_id: str,
+        persist_response: Callable[[dict[str, Any]], None] | None = None,
+    ) -> BrokerCloseOrderDetail:
         """Resolve one exact demo close order and its affected position ids."""
         raise NotImplementedError
 

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -26,6 +26,7 @@ from app.config import settings
 from app.providers.broker import (
     BrokerAccountRiskSnapshot,
     BrokerClosedTrade,
+    BrokerCloseOrderDetail,
     BrokerCostComponent,
     BrokerEligibilityResponse,
     BrokerInstrumentEligibility,
@@ -42,7 +43,11 @@ from app.providers.broker import (
     BrokerOrderSubmissionUncertain,
     BrokerPortfolio,
     BrokerPosition,
+    BrokerPositionCloseSubmission,
+    BrokerPositionEditSubmission,
     BrokerPositionExecution,
+    BrokerPositionMutationError,
+    BrokerPositionMutationUncertain,
     BrokerProvider,
     BrokerStrategyOrder,
     BrokerWhatIfCostResponse,
@@ -441,6 +446,132 @@ class EtoroBrokerProvider(BrokerProvider):
             )
 
         return _normalise_close_order_response(raw)
+
+    def edit_demo_strategy_position(
+        self,
+        *,
+        position_id: int,
+        stop_loss_rate: Decimal,
+        take_profit_rate: Decimal | None,
+        request_id: UUID,
+    ) -> BrokerPositionEditSubmission:
+        """Strict v2 adapter for automated demo-only position edits."""
+        if self._env != "demo":
+            raise BrokerPositionMutationError("strategy position edits require demo credentials")
+        if position_id <= 0 or stop_loss_rate <= 0:
+            raise BrokerPositionMutationError("position id and stop rate must be positive")
+        body: dict[str, Any] = {
+            "stopLossRate": float(stop_loss_rate),
+            "stopLossType": "fixed",
+        }
+        if take_profit_rate is not None:
+            if take_profit_rate <= 0:
+                raise BrokerPositionMutationError("take-profit rate must be positive")
+            body["takeProfitRate"] = float(take_profit_rate)
+        try:
+            response = self._http_write.patch(
+                f"/api/v2/trading/demo/positions/{position_id}",
+                json=body,
+                headers=self._request_headers(request_id),
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if 400 <= exc.response.status_code < 500:
+                raise BrokerPositionMutationError(
+                    f"demo position edit rejected with HTTP {exc.response.status_code}"
+                ) from exc
+            raise BrokerPositionMutationUncertain("demo position edit returned a server error") from exc
+        except httpx.HTTPError as exc:
+            raise BrokerPositionMutationUncertain("demo position edit transport failed") from exc
+        try:
+            raw = response.json()
+            operation_id = UUID(str(raw["operationId"]))
+            returned_position_id = int(raw["positionId"])
+            reference_id = UUID(str(raw["referenceId"]))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrokerPositionMutationUncertain("demo position edit response identity is malformed") from exc
+        if returned_position_id != position_id or reference_id != request_id:
+            raise BrokerPositionMutationUncertain("demo position edit response identity does not match intent")
+        return BrokerPositionEditSubmission(operation_id, returned_position_id, reference_id)
+
+    def close_demo_strategy_position(
+        self,
+        *,
+        position_id: int,
+        instrument_id: int,
+        request_id: UUID,
+    ) -> BrokerPositionCloseSubmission:
+        """Strict v1 adapter for an exact, whole demo-position close."""
+        if self._env != "demo":
+            raise BrokerPositionMutationError("strategy position closes require demo credentials")
+        if position_id <= 0 or instrument_id <= 0:
+            raise BrokerPositionMutationError("position and instrument ids must be positive")
+        try:
+            response = self._http_write.post(
+                f"/api/v1/trading/execution/demo/market-close-orders/positions/{position_id}",
+                json={"InstrumentID": instrument_id, "UnitsToDeduct": None},
+                headers=self._request_headers(request_id),
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if 400 <= exc.response.status_code < 500:
+                raise BrokerPositionMutationError(
+                    f"demo position close rejected with HTTP {exc.response.status_code}"
+                ) from exc
+            raise BrokerPositionMutationUncertain("demo position close returned a server error") from exc
+        except httpx.HTTPError as exc:
+            raise BrokerPositionMutationUncertain("demo position close transport failed") from exc
+        try:
+            raw = response.json()
+            order = raw["orderForClose"]
+            broker_order_ref = int(order["orderID"])
+            returned_position_id = int(order["positionID"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrokerPositionMutationUncertain("demo position close response identity is malformed") from exc
+        if broker_order_ref <= 0 or returned_position_id != position_id:
+            raise BrokerPositionMutationUncertain("demo position close response identity does not match intent")
+        return BrokerPositionCloseSubmission(str(broker_order_ref), returned_position_id)
+
+    def get_demo_close_order(self, *, order_id: str) -> BrokerCloseOrderDetail:
+        """Resolve a close order without inferring success from disappearance."""
+        if self._env != "demo" or not order_id.isdigit() or int(order_id) <= 0:
+            raise BrokerPositionMutationError("valid demo close-order identity is required")
+        try:
+            response = self._http_read.get(
+                f"/api/v1/trading/info/demo/close-orders/{order_id}",
+                headers=self._request_headers(),
+            )
+            response.raise_for_status()
+            raw = response.json()
+            returned_order_id = int(raw["orderID"])
+            raw_positions = raw.get("positions") or []
+            if not isinstance(raw_positions, list):
+                raise TypeError("positions must be a list")
+            if any(not isinstance(row, dict) for row in raw_positions):
+                raise TypeError("every affected position must be an object")
+            position_ids = tuple(int(row["positionID"]) for row in raw_positions)
+            error_code = raw.get("errorCode")
+            raw_status = str(raw.get("statusID", "unknown"))
+            reference = raw.get("referenceID")
+            reference_id = UUID(str(reference)) if reference else None
+        except httpx.HTTPStatusError as exc:
+            raise BrokerPositionMutationError(
+                f"demo close-order lookup failed with HTTP {exc.response.status_code}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise BrokerPositionMutationUncertain("demo close-order lookup transport failed") from exc
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BrokerPositionMutationUncertain("demo close-order lookup response is malformed") from exc
+        if returned_order_id != int(order_id):
+            raise BrokerPositionMutationUncertain("demo close-order lookup identity does not match")
+        status: OrderStatus
+        if error_code not in (None, 0, "0"):
+            status = "rejected"
+        elif position_ids:
+            status = "filled"
+        else:
+            status = "pending"
+        return BrokerCloseOrderDetail(order_id, status, raw_status, position_ids, reference_id)
 
     def get_order_status(self, broker_order_ref: str) -> BrokerOrderResult:
         try:

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import decimal
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
 from types import TracebackType
@@ -454,6 +454,7 @@ class EtoroBrokerProvider(BrokerProvider):
         stop_loss_rate: Decimal,
         take_profit_rate: Decimal | None,
         request_id: UUID,
+        persist_response: Callable[[dict[str, Any]], None] | None = None,
     ) -> BrokerPositionEditSubmission:
         """Strict v2 adapter for automated demo-only position edits."""
         if self._env != "demo":
@@ -468,31 +469,43 @@ class EtoroBrokerProvider(BrokerProvider):
             if take_profit_rate <= 0:
                 raise BrokerPositionMutationError("take-profit rate must be positive")
             body["takeProfitRate"] = float(take_profit_rate)
+        raw: dict[str, Any] | None = None
         try:
             response = self._http_write.patch(
                 f"/api/v2/trading/demo/positions/{position_id}",
                 json=body,
                 headers=self._request_headers(request_id),
             )
+            raw = _safe_json(response)
+            if persist_response is not None:
+                persist_response(raw)
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            error_raw = raw or _safe_json(exc.response)
             if 400 <= exc.response.status_code < 500:
                 raise BrokerPositionMutationError(
-                    f"demo position edit rejected with HTTP {exc.response.status_code}"
+                    f"demo position edit rejected with HTTP {exc.response.status_code}",
+                    raw_payload=error_raw,
                 ) from exc
-            raise BrokerPositionMutationUncertain("demo position edit returned a server error") from exc
+            raise BrokerPositionMutationUncertain(
+                "demo position edit returned a server error", raw_payload=error_raw
+            ) from exc
         except httpx.HTTPError as exc:
             raise BrokerPositionMutationUncertain("demo position edit transport failed") from exc
+        assert raw is not None
         try:
-            raw = response.json()
             operation_id = UUID(str(raw["operationId"]))
             returned_position_id = int(raw["positionId"])
             reference_id = UUID(str(raw["referenceId"]))
         except (KeyError, TypeError, ValueError) as exc:
-            raise BrokerPositionMutationUncertain("demo position edit response identity is malformed") from exc
+            raise BrokerPositionMutationUncertain(
+                "demo position edit response identity is malformed", raw_payload=raw
+            ) from exc
         if returned_position_id != position_id or reference_id != request_id:
-            raise BrokerPositionMutationUncertain("demo position edit response identity does not match intent")
-        return BrokerPositionEditSubmission(operation_id, returned_position_id, reference_id)
+            raise BrokerPositionMutationUncertain(
+                "demo position edit response identity does not match intent", raw_payload=raw
+            )
+        return BrokerPositionEditSubmission(operation_id, returned_position_id, reference_id, raw)
 
     def close_demo_strategy_position(
         self,
@@ -500,49 +513,70 @@ class EtoroBrokerProvider(BrokerProvider):
         position_id: int,
         instrument_id: int,
         request_id: UUID,
+        persist_response: Callable[[dict[str, Any]], None] | None = None,
     ) -> BrokerPositionCloseSubmission:
         """Strict v1 adapter for an exact, whole demo-position close."""
         if self._env != "demo":
             raise BrokerPositionMutationError("strategy position closes require demo credentials")
         if position_id <= 0 or instrument_id <= 0:
             raise BrokerPositionMutationError("position and instrument ids must be positive")
+        raw: dict[str, Any] | None = None
         try:
             response = self._http_write.post(
                 f"/api/v1/trading/execution/demo/market-close-orders/positions/{position_id}",
                 json={"InstrumentID": instrument_id, "UnitsToDeduct": None},
                 headers=self._request_headers(request_id),
             )
+            raw = _safe_json(response)
+            if persist_response is not None:
+                persist_response(raw)
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
+            error_raw = raw or _safe_json(exc.response)
             if 400 <= exc.response.status_code < 500:
                 raise BrokerPositionMutationError(
-                    f"demo position close rejected with HTTP {exc.response.status_code}"
+                    f"demo position close rejected with HTTP {exc.response.status_code}",
+                    raw_payload=error_raw,
                 ) from exc
-            raise BrokerPositionMutationUncertain("demo position close returned a server error") from exc
+            raise BrokerPositionMutationUncertain(
+                "demo position close returned a server error", raw_payload=error_raw
+            ) from exc
         except httpx.HTTPError as exc:
             raise BrokerPositionMutationUncertain("demo position close transport failed") from exc
+        assert raw is not None
         try:
-            raw = response.json()
             order = raw["orderForClose"]
             broker_order_ref = int(order["orderID"])
             returned_position_id = int(order["positionID"])
         except (KeyError, TypeError, ValueError) as exc:
-            raise BrokerPositionMutationUncertain("demo position close response identity is malformed") from exc
+            raise BrokerPositionMutationUncertain(
+                "demo position close response identity is malformed", raw_payload=raw
+            ) from exc
         if broker_order_ref <= 0 or returned_position_id != position_id:
-            raise BrokerPositionMutationUncertain("demo position close response identity does not match intent")
-        return BrokerPositionCloseSubmission(str(broker_order_ref), returned_position_id)
+            raise BrokerPositionMutationUncertain(
+                "demo position close response identity does not match intent", raw_payload=raw
+            )
+        return BrokerPositionCloseSubmission(str(broker_order_ref), returned_position_id, raw)
 
-    def get_demo_close_order(self, *, order_id: str) -> BrokerCloseOrderDetail:
+    def get_demo_close_order(
+        self,
+        *,
+        order_id: str,
+        persist_response: Callable[[dict[str, Any]], None] | None = None,
+    ) -> BrokerCloseOrderDetail:
         """Resolve a close order without inferring success from disappearance."""
         if self._env != "demo" or not order_id.isdigit() or int(order_id) <= 0:
             raise BrokerPositionMutationError("valid demo close-order identity is required")
+        raw: dict[str, Any] | None = None
         try:
             response = self._http_read.get(
                 f"/api/v1/trading/info/demo/close-orders/{order_id}",
                 headers=self._request_headers(),
             )
+            raw = _safe_json(response)
+            if persist_response is not None:
+                persist_response(raw)
             response.raise_for_status()
-            raw = response.json()
             returned_order_id = int(raw["orderID"])
             raw_positions = raw.get("positions") or []
             if not isinstance(raw_positions, list):
@@ -556,14 +590,18 @@ class EtoroBrokerProvider(BrokerProvider):
             reference_id = UUID(str(reference)) if reference else None
         except httpx.HTTPStatusError as exc:
             raise BrokerPositionMutationError(
-                f"demo close-order lookup failed with HTTP {exc.response.status_code}"
+                f"demo close-order lookup failed with HTTP {exc.response.status_code}",
+                raw_payload=raw or _safe_json(exc.response),
             ) from exc
         except httpx.HTTPError as exc:
             raise BrokerPositionMutationUncertain("demo close-order lookup transport failed") from exc
         except (KeyError, TypeError, ValueError) as exc:
-            raise BrokerPositionMutationUncertain("demo close-order lookup response is malformed") from exc
+            raise BrokerPositionMutationUncertain(
+                "demo close-order lookup response is malformed", raw_payload=raw
+            ) from exc
+        assert raw is not None
         if returned_order_id != int(order_id):
-            raise BrokerPositionMutationUncertain("demo close-order lookup identity does not match")
+            raise BrokerPositionMutationUncertain("demo close-order lookup identity does not match", raw_payload=raw)
         status: OrderStatus
         if error_code not in (None, 0, "0"):
             status = "rejected"
@@ -571,7 +609,7 @@ class EtoroBrokerProvider(BrokerProvider):
             status = "filled"
         else:
             status = "pending"
-        return BrokerCloseOrderDetail(order_id, status, raw_status, position_ids, reference_id)
+        return BrokerCloseOrderDetail(order_id, status, raw_status, position_ids, reference_id, raw)
 
     def get_order_status(self, broker_order_ref: str) -> BrokerOrderResult:
         try:
@@ -1511,6 +1549,7 @@ def _build_result(
 def _safe_json(response: httpx.Response) -> dict[str, Any]:
     """Extract JSON from an error response, falling back to text."""
     try:
-        return response.json()  # type: ignore[no-any-return]
+        value = response.json()
+        return dict(value) if isinstance(value, dict) else {"raw_json": value}
     except Exception:
         return {"raw_text": response.text}

--- a/app/providers/resilient_client.py
+++ b/app/providers/resilient_client.py
@@ -126,6 +126,16 @@ class ResilientClient:
         """Throttled, retried POST request."""
         return self._request("POST", url, json=json, headers=headers)
 
+    def patch(
+        self,
+        url: str,
+        *,
+        json: object | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Throttled, retried PATCH request."""
+        return self._request("PATCH", url, json=json, headers=headers)
+
     # ------------------------------------------------------------------
     # Internal
     # ------------------------------------------------------------------

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -456,14 +456,7 @@ def _resume_operation(
                     conn, operation_id=operation_id, raw_payload=raw
                 ),
             )
-        except BrokerPositionMutationError as exc:
-            if exc.raw_payload is not None:
-                with conn.transaction():
-                    conn.execute(
-                        "UPDATE strategy_position_operations SET broker_response_json=%s, updated_at=now() "
-                        "WHERE position_operation_id=%s",
-                        (Jsonb(exc.raw_payload), operation_id),
-                    )
+        except BrokerPositionMutationError:
             return PositionManagerResult(
                 owned.strategy_trade_id, owned.broker_position_id, "pending", "close_lookup_unavailable", operation_id
             )
@@ -476,11 +469,6 @@ def _resume_operation(
         with conn.transaction():
             order_status = "filled" if exact else "rejected"
             conn.execute("UPDATE orders SET status=%s WHERE order_id=%s", (order_status, operation["order_id"]))
-            conn.execute(
-                "UPDATE strategy_position_operations SET broker_response_json=%s, updated_at=now() "
-                "WHERE position_operation_id=%s",
-                (Jsonb(detail.raw_payload), operation_id),
-            )
             if exact:
                 _finish_close(
                     conn,
@@ -633,12 +621,6 @@ def _submit_edit(
     except BrokerPositionMutationError as exc:
         uncertain = isinstance(exc, BrokerPositionMutationUncertain)
         with conn.transaction():
-            if exc.raw_payload is not None:
-                conn.execute(
-                    "UPDATE strategy_position_operations SET broker_response_json=%s, updated_at=now() "
-                    "WHERE position_operation_id=%s",
-                    (Jsonb(exc.raw_payload), operation_id),
-                )
             _terminal(
                 conn,
                 operation_id=operation_id,
@@ -662,11 +644,10 @@ def _submit_edit(
         conn.execute(
             """
             UPDATE strategy_position_operations
-            SET status='submitted', broker_operation_id=%s, broker_response_json=%s,
-                submitted_at=now(), updated_at=now()
+            SET status='submitted', broker_operation_id=%s, submitted_at=now(), updated_at=now()
             WHERE position_operation_id=%s AND status='intent_persisted'
             """,
-            (submission.operation_id, Jsonb(submission.raw_payload), operation_id),
+            (submission.operation_id, operation_id),
         )
     # The 202 response is acceptance only. A future invocation re-syncs the
     # exact position before changing this operation to applied.
@@ -723,12 +704,8 @@ def _submit_close(
         uncertain = isinstance(exc, BrokerPositionMutationUncertain)
         with conn.transaction():
             conn.execute(
-                "UPDATE orders SET status=%s, raw_payload_json=COALESCE(%s, raw_payload_json) WHERE order_id=%s",
-                (
-                    "submitted" if uncertain else "rejected",
-                    Jsonb(exc.raw_payload) if exc.raw_payload is not None else None,
-                    order_id,
-                ),
+                "UPDATE orders SET status=%s WHERE order_id=%s",
+                ("submitted" if uncertain else "rejected", order_id),
             )
             _terminal(
                 conn,
@@ -749,8 +726,8 @@ def _submit_close(
         )
     with conn.transaction():
         conn.execute(
-            "UPDATE orders SET broker_order_ref=%s, raw_payload_json=%s WHERE order_id=%s",
-            (submission.broker_order_ref, Jsonb(submission.raw_payload), order_id),
+            "UPDATE orders SET broker_order_ref=%s WHERE order_id=%s",
+            (submission.broker_order_ref, order_id),
         )
         conn.execute(
             """

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -19,6 +19,7 @@ from uuid import UUID, uuid4
 import psycopg
 import psycopg.rows
 from psycopg.pq import TransactionStatus
+from psycopg.types.json import Jsonb
 
 from app.providers.broker import (
     BrokerInstrumentEligibility,
@@ -30,7 +31,7 @@ from app.providers.broker import (
 from app.services.strategy_control_plane import StrategyControlError, StrategyOwnershipError, link_strategy_order
 
 _RATE_QUANTUM = Decimal("0.000001")
-_POSITION_LOCK_NAMESPACE = 2452
+_ADVISORY_HASH_SEED = 0
 
 
 class StrategyPositionManagerError(StrategyControlError):
@@ -85,7 +86,7 @@ def _position_lock(conn: psycopg.Connection[Any], broker_position_id: int) -> It
     lock_identity = f"strategy-position:{broker_position_id}"
     conn.execute(
         "SELECT pg_advisory_lock(hashtextextended(%s, %s))",
-        (lock_identity, _POSITION_LOCK_NAMESPACE),
+        (lock_identity, _ADVISORY_HASH_SEED),
     )
     conn.commit()
     try:
@@ -95,7 +96,7 @@ def _position_lock(conn: psycopg.Connection[Any], broker_position_id: int) -> It
             conn.rollback()
         unlocked = conn.execute(
             "SELECT pg_advisory_unlock(hashtextextended(%s, %s))",
-            (lock_identity, _POSITION_LOCK_NAMESPACE),
+            (lock_identity, _ADVISORY_HASH_SEED),
         ).fetchone()
         conn.commit()
         if unlocked is None or unlocked[0] is not True:
@@ -374,6 +375,27 @@ def _finish_close(conn: psycopg.Connection[Any], *, owned: _OwnedPosition, opera
     )
 
 
+def _persist_operation_response(
+    conn: psycopg.Connection[Any], *, operation_id: int, raw_payload: dict[str, Any]
+) -> None:
+    """Persist the untouched broker object before its adapter normalises it."""
+    with conn.transaction():
+        conn.execute(
+            "UPDATE strategy_position_operations SET broker_response_json=%s, updated_at=now() "
+            "WHERE position_operation_id=%s",
+            (Jsonb(raw_payload), operation_id),
+        )
+
+
+def _persist_order_response(conn: psycopg.Connection[Any], *, order_id: int, raw_payload: dict[str, Any]) -> None:
+    """Persist one close-submission response on its already-durable order."""
+    with conn.transaction():
+        conn.execute(
+            "UPDATE orders SET raw_payload_json=%s WHERE order_id=%s",
+            (Jsonb(raw_payload), order_id),
+        )
+
+
 def _resume_operation(
     conn: psycopg.Connection[Any], *, broker: BrokerProvider, owned: _OwnedPosition
 ) -> PositionManagerResult | None:
@@ -428,8 +450,20 @@ def _resume_operation(
         )
     if operation["operation_type"] == "close":
         try:
-            detail = broker.get_demo_close_order(order_id=str(operation["broker_order_ref"]))
-        except BrokerPositionMutationError:
+            detail = broker.get_demo_close_order(
+                order_id=str(operation["broker_order_ref"]),
+                persist_response=lambda raw: _persist_operation_response(
+                    conn, operation_id=operation_id, raw_payload=raw
+                ),
+            )
+        except BrokerPositionMutationError as exc:
+            if exc.raw_payload is not None:
+                with conn.transaction():
+                    conn.execute(
+                        "UPDATE strategy_position_operations SET broker_response_json=%s, updated_at=now() "
+                        "WHERE position_operation_id=%s",
+                        (Jsonb(exc.raw_payload), operation_id),
+                    )
             return PositionManagerResult(
                 owned.strategy_trade_id, owned.broker_position_id, "pending", "close_lookup_unavailable", operation_id
             )
@@ -442,6 +476,11 @@ def _resume_operation(
         with conn.transaction():
             order_status = "filled" if exact else "rejected"
             conn.execute("UPDATE orders SET status=%s WHERE order_id=%s", (order_status, operation["order_id"]))
+            conn.execute(
+                "UPDATE strategy_position_operations SET broker_response_json=%s, updated_at=now() "
+                "WHERE position_operation_id=%s",
+                (Jsonb(detail.raw_payload), operation_id),
+            )
             if exact:
                 _finish_close(
                     conn,
@@ -589,10 +628,17 @@ def _submit_edit(
             stop_loss_rate=desired_stop,
             take_profit_rate=desired_take,
             request_id=request_id,
+            persist_response=lambda raw: _persist_operation_response(conn, operation_id=operation_id, raw_payload=raw),
         )
     except BrokerPositionMutationError as exc:
         uncertain = isinstance(exc, BrokerPositionMutationUncertain)
         with conn.transaction():
+            if exc.raw_payload is not None:
+                conn.execute(
+                    "UPDATE strategy_position_operations SET broker_response_json=%s, updated_at=now() "
+                    "WHERE position_operation_id=%s",
+                    (Jsonb(exc.raw_payload), operation_id),
+                )
             _terminal(
                 conn,
                 operation_id=operation_id,
@@ -616,10 +662,11 @@ def _submit_edit(
         conn.execute(
             """
             UPDATE strategy_position_operations
-            SET status='submitted', broker_operation_id=%s, submitted_at=now(), updated_at=now()
+            SET status='submitted', broker_operation_id=%s, broker_response_json=%s,
+                submitted_at=now(), updated_at=now()
             WHERE position_operation_id=%s AND status='intent_persisted'
             """,
-            (submission.operation_id, operation_id),
+            (submission.operation_id, Jsonb(submission.raw_payload), operation_id),
         )
     # The 202 response is acceptance only. A future invocation re-syncs the
     # exact position before changing this operation to applied.
@@ -670,13 +717,18 @@ def _submit_close(
             position_id=owned.broker_position_id,
             instrument_id=owned.instrument_id,
             request_id=request_id,
+            persist_response=lambda raw: _persist_order_response(conn, order_id=order_id, raw_payload=raw),
         )
     except BrokerPositionMutationError as exc:
         uncertain = isinstance(exc, BrokerPositionMutationUncertain)
         with conn.transaction():
             conn.execute(
-                "UPDATE orders SET status=%s WHERE order_id=%s",
-                ("submitted" if uncertain else "rejected", order_id),
+                "UPDATE orders SET status=%s, raw_payload_json=COALESCE(%s, raw_payload_json) WHERE order_id=%s",
+                (
+                    "submitted" if uncertain else "rejected",
+                    Jsonb(exc.raw_payload) if exc.raw_payload is not None else None,
+                    order_id,
+                ),
             )
             _terminal(
                 conn,
@@ -696,7 +748,10 @@ def _submit_close(
             operation_id,
         )
     with conn.transaction():
-        conn.execute("UPDATE orders SET broker_order_ref=%s WHERE order_id=%s", (submission.broker_order_ref, order_id))
+        conn.execute(
+            "UPDATE orders SET broker_order_ref=%s, raw_payload_json=%s WHERE order_id=%s",
+            (submission.broker_order_ref, Jsonb(submission.raw_payload), order_id),
+        )
         conn.execute(
             """
             UPDATE strategy_position_operations

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -1,0 +1,918 @@
+"""Exact-position, demo-only strategy risk manager (#2452).
+
+The manager accepts a strategy trade and broker position id together. It never
+looks up a position by instrument, so a manual position in the same instrument
+is observational risk only and cannot be mutated. Only material PATCH/close
+intents are persisted; unchanged bars and polling heartbeats write no rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import ROUND_DOWN, Decimal
+from typing import Any, Literal, cast
+from uuid import UUID, uuid4
+
+import psycopg
+import psycopg.rows
+from psycopg.pq import TransactionStatus
+
+from app.providers.broker import (
+    BrokerInstrumentEligibility,
+    BrokerPosition,
+    BrokerPositionMutationError,
+    BrokerPositionMutationUncertain,
+    BrokerProvider,
+)
+from app.services.strategy_control_plane import StrategyControlError, StrategyOwnershipError, link_strategy_order
+
+_RATE_QUANTUM = Decimal("0.000001")
+_POSITION_LOCK_NAMESPACE = 2452
+
+
+class StrategyPositionManagerError(StrategyControlError):
+    """An exact-position mutation cannot safely proceed."""
+
+
+@dataclass(frozen=True)
+class RatchetBar:
+    """Completed causal inputs for the registered hybrid ratchet formula."""
+
+    completed_at: datetime
+    level_known_at: datetime
+    close: Decimal
+    highest_close_since_entry: Decimal
+    atr: Decimal
+    broken_resistance: Decimal
+
+
+@dataclass(frozen=True)
+class PositionManagerResult:
+    strategy_trade_id: int
+    broker_position_id: int
+    state: Literal["no_change", "submitted", "pending", "applied", "rejected", "reconcile_required"]
+    reason_code: str
+    position_operation_id: int | None = None
+
+
+@dataclass(frozen=True)
+class _OwnedPosition:
+    ownership_id: int
+    strategy_trade_id: int
+    broker_position_id: int
+    instrument_id: int
+    deployment_id: int
+    entry_stop: Decimal
+    entry_take_profit: Decimal
+    max_position_age_seconds: int | None
+    max_quote_age_seconds: int
+    ratchet_variant_id: int | None
+    break_atr_multiple: Decimal | None
+    chandelier_atr_multiple: Decimal | None
+    structure_atr_multiple: Decimal | None
+    quote_bid: Decimal | None
+    quoted_at: datetime | None
+
+
+@contextmanager
+def _position_lock(conn: psycopg.Connection[Any], broker_position_id: int) -> Iterator[None]:
+    # PostgreSQL's two-key advisory lock accepts signed 32-bit integers only,
+    # while broker position ids are valid BIGINTs. Hash the namespaced identity
+    # in PostgreSQL so every valid position id maps to one signed 64-bit key.
+    lock_identity = f"strategy-position:{broker_position_id}"
+    conn.execute(
+        "SELECT pg_advisory_lock(hashtextextended(%s, %s))",
+        (lock_identity, _POSITION_LOCK_NAMESPACE),
+    )
+    conn.commit()
+    try:
+        yield
+    finally:
+        if conn.info.transaction_status != TransactionStatus.IDLE:
+            conn.rollback()
+        unlocked = conn.execute(
+            "SELECT pg_advisory_unlock(hashtextextended(%s, %s))",
+            (lock_identity, _POSITION_LOCK_NAMESPACE),
+        ).fetchone()
+        conn.commit()
+        if unlocked is None or unlocked[0] is not True:
+            raise StrategyPositionManagerError("strategy position lock ownership was lost")
+
+
+def register_ratchet_variant(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    promotion_id: int,
+    rule_version: str,
+    break_atr_multiple: Decimal,
+    chandelier_atr_multiple: Decimal,
+    structure_atr_multiple: Decimal,
+    registered_by: str,
+    reason: str,
+) -> int:
+    """Register immutable formula constants against a promoted backtest arm."""
+    row = conn.execute(
+        """
+        SELECT p.strategy_id, p.strategy_version, p.to_stage,
+               count(pr.result_id) AS result_count,
+               count(pr.result_id) FILTER (
+                   WHERE r.position_rule_set_version = %s
+                     AND r.namespace = 'hold_out'
+                     AND r.window_start >= DATE '2022-01-01'
+               ) AS matching_recent_holdout_count
+        FROM strategy_promotions p
+        LEFT JOIN strategy_promotion_results pr ON pr.promotion_id=p.promotion_id
+        LEFT JOIN strategy_results_store r ON r.result_id=pr.result_id
+        WHERE p.promotion_id=%s
+        GROUP BY p.promotion_id
+        """,
+        (rule_version, promotion_id),
+    ).fetchone()
+    if row is None or row[0] != strategy_id or row[1] != strategy_version:
+        raise StrategyPositionManagerError("ratchet registration must match its promoted strategy variant")
+    if (
+        row[2] not in ("historical_validated", "forward_observation", "paper_enabled", "live_enabled")
+        or int(row[3]) < 1
+        or int(row[4]) < 1
+    ):
+        raise StrategyPositionManagerError("ratchet requires a promoted 2022+ hold-out backtest arm")
+    inserted = conn.execute(
+        """
+        INSERT INTO strategy_ratchet_variants (
+            strategy_id, strategy_version, promotion_id, rule_version,
+            break_atr_multiple, chandelier_atr_multiple, structure_atr_multiple,
+            registered_by, reason
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        RETURNING ratchet_variant_id
+        """,
+        (
+            strategy_id,
+            strategy_version,
+            promotion_id,
+            rule_version,
+            break_atr_multiple,
+            chandelier_atr_multiple,
+            structure_atr_multiple,
+            registered_by,
+            reason,
+        ),
+    ).fetchone()
+    assert inserted is not None
+    return int(inserted[0])
+
+
+def configure_position_manager(
+    conn: psycopg.Connection[Any],
+    *,
+    deployment_id: int,
+    max_position_age_seconds: int | None,
+    ratchet_variant_id: int | None,
+    updated_by: str,
+    reason: str,
+) -> int:
+    """Replace current paper-manager policy and append one bounded audit event."""
+    if max_position_age_seconds is not None and max_position_age_seconds <= 0:
+        raise ValueError("max_position_age_seconds must be positive")
+    deployment = conn.execute(
+        "SELECT strategy_id, strategy_version, mode FROM strategy_deployments WHERE deployment_id=%s FOR UPDATE",
+        (deployment_id,),
+    ).fetchone()
+    if deployment is None or deployment[2] != "paper":
+        raise StrategyPositionManagerError("the MVP position manager requires a paper deployment")
+    if ratchet_variant_id is not None:
+        variant = conn.execute(
+            "SELECT strategy_id, strategy_version FROM strategy_ratchet_variants WHERE ratchet_variant_id=%s",
+            (ratchet_variant_id,),
+        ).fetchone()
+        if variant is None or tuple(variant) != tuple(deployment[:2]):
+            raise StrategyPositionManagerError("ratchet variant must match the deployment strategy identity")
+    prior = conn.execute(
+        "SELECT revision FROM strategy_position_manager_policies WHERE deployment_id=%s",
+        (deployment_id,),
+    ).fetchone()
+    revision = int(prior[0]) + 1 if prior else 1
+    conn.execute(
+        """
+        INSERT INTO strategy_position_manager_policies (
+            deployment_id, revision, max_position_age_seconds,
+            ratchet_variant_id, updated_by, reason
+        ) VALUES (%s,%s,%s,%s,%s,%s)
+        ON CONFLICT (deployment_id) DO UPDATE SET
+            revision=EXCLUDED.revision,
+            max_position_age_seconds=EXCLUDED.max_position_age_seconds,
+            ratchet_variant_id=EXCLUDED.ratchet_variant_id,
+            updated_by=EXCLUDED.updated_by,
+            reason=EXCLUDED.reason,
+            updated_at=now()
+        """,
+        (deployment_id, revision, max_position_age_seconds, ratchet_variant_id, updated_by, reason),
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_position_manager_policy_events (
+            deployment_id, revision, max_position_age_seconds,
+            ratchet_variant_id, changed_by, reason
+        ) VALUES (%s,%s,%s,%s,%s,%s)
+        """,
+        (deployment_id, revision, max_position_age_seconds, ratchet_variant_id, updated_by, reason),
+    )
+    return revision
+
+
+def calculate_ratchet_stop(
+    *,
+    current_stop: Decimal,
+    bar: RatchetBar,
+    break_atr_multiple: Decimal,
+    chandelier_atr_multiple: Decimal,
+    structure_atr_multiple: Decimal,
+) -> Decimal | None:
+    """Return the registered causal candidate, or ``None`` when it did not fire."""
+    values = (
+        current_stop,
+        bar.close,
+        bar.highest_close_since_entry,
+        bar.atr,
+        bar.broken_resistance,
+        break_atr_multiple,
+        chandelier_atr_multiple,
+        structure_atr_multiple,
+    )
+    if any(not value.is_finite() or value <= 0 for value in values):
+        raise ValueError("ratchet prices and constants must be finite and positive")
+    if bar.completed_at.tzinfo is None or bar.level_known_at.tzinfo is None:
+        raise ValueError("ratchet timestamps must be timezone aware")
+    if bar.level_known_at > bar.completed_at:
+        raise ValueError("the resistance level was not causal at bar completion")
+    if bar.highest_close_since_entry < bar.close:
+        raise ValueError("highest close since entry cannot be below the completed close")
+    if bar.close < bar.broken_resistance + break_atr_multiple * bar.atr:
+        return None
+    candidate = min(
+        bar.highest_close_since_entry - chandelier_atr_multiple * bar.atr,
+        bar.broken_resistance - structure_atr_multiple * bar.atr,
+    ).quantize(_RATE_QUANTUM, rounding=ROUND_DOWN)
+    return candidate if candidate > current_stop else None
+
+
+def _load_owned(conn: psycopg.Connection[Any], *, strategy_trade_id: int, broker_position_id: int) -> _OwnedPosition:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT own.ownership_id, own.strategy_trade_id, own.broker_position_id,
+                   t.instrument_id, d.deployment_id,
+                   pre.stop_loss_rate AS entry_stop,
+                   pre.take_profit_rate AS entry_take_profit,
+                   manager.max_position_age_seconds,
+                   execution.max_quote_age_seconds,
+                   manager.ratchet_variant_id,
+                   variant.break_atr_multiple,
+                   variant.chandelier_atr_multiple,
+                   variant.structure_atr_multiple,
+                   q.bid AS quote_bid, q.quoted_at
+            FROM strategy_position_ownership own
+            JOIN strategy_trades t ON t.strategy_trade_id=own.strategy_trade_id
+            JOIN strategy_funding_decisions funding ON funding.funding_decision_id=t.funding_decision_id
+            JOIN strategy_deployments d ON d.deployment_id=funding.deployment_id AND d.mode='paper'
+            JOIN strategy_entry_preflights pre ON pre.signal_id=funding.signal_id AND pre.verdict='allocated'
+            JOIN strategy_execution_policies execution ON execution.deployment_id=d.deployment_id
+            LEFT JOIN strategy_position_manager_policies manager ON manager.deployment_id=d.deployment_id
+            LEFT JOIN strategy_ratchet_variants variant
+              ON variant.ratchet_variant_id=manager.ratchet_variant_id
+            LEFT JOIN quotes q ON q.instrument_id=t.instrument_id
+            WHERE own.strategy_trade_id=%s AND own.broker_position_id=%s AND own.status='active'
+              AND t.status IN ('open','closing','reconcile_required')
+            """,
+            (strategy_trade_id, broker_position_id),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise StrategyOwnershipError("exact active strategy position ownership is required before broker I/O")
+    return _OwnedPosition(
+        ownership_id=int(row["ownership_id"]),
+        strategy_trade_id=int(row["strategy_trade_id"]),
+        broker_position_id=int(row["broker_position_id"]),
+        instrument_id=int(row["instrument_id"]),
+        deployment_id=int(row["deployment_id"]),
+        entry_stop=Decimal(str(row["entry_stop"])),
+        entry_take_profit=Decimal(str(row["entry_take_profit"])),
+        max_position_age_seconds=(
+            int(row["max_position_age_seconds"]) if row["max_position_age_seconds"] is not None else None
+        ),
+        max_quote_age_seconds=int(row["max_quote_age_seconds"]),
+        ratchet_variant_id=(int(row["ratchet_variant_id"]) if row["ratchet_variant_id"] is not None else None),
+        break_atr_multiple=(Decimal(str(row["break_atr_multiple"])) if row["break_atr_multiple"] is not None else None),
+        chandelier_atr_multiple=(
+            Decimal(str(row["chandelier_atr_multiple"])) if row["chandelier_atr_multiple"] is not None else None
+        ),
+        structure_atr_multiple=(
+            Decimal(str(row["structure_atr_multiple"])) if row["structure_atr_multiple"] is not None else None
+        ),
+        quote_bid=Decimal(str(row["quote_bid"])) if row["quote_bid"] is not None else None,
+        quoted_at=cast(datetime | None, row["quoted_at"]),
+    )
+
+
+def _exact_broker_position(broker: BrokerProvider, owned: _OwnedPosition) -> BrokerPosition | None:
+    portfolio = broker.get_portfolio()
+    matches = [position for position in portfolio.positions if position.position_id == owned.broker_position_id]
+    if len(matches) > 1:
+        raise StrategyPositionManagerError("broker returned duplicate exact position ids")
+    if matches and matches[0].instrument_id != owned.instrument_id:
+        raise StrategyPositionManagerError("owned broker position changed instrument identity")
+    return matches[0] if matches else None
+
+
+def _eligibility_for_owned(broker: BrokerProvider, owned: _OwnedPosition) -> BrokerInstrumentEligibility:
+    response = broker.check_instrument_eligibility([owned.instrument_id])
+    matches = [row for row in response.eligibilities if row.instrument_id == owned.instrument_id]
+    if response.currency.upper() != "USD" or len(matches) != 1:
+        raise StrategyPositionManagerError("current broker eligibility is unresolved")
+    return matches[0]
+
+
+def _terminal(
+    conn: psycopg.Connection[Any],
+    *,
+    operation_id: int,
+    status: Literal["applied", "rejected", "reconcile_required"],
+    error_code: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        UPDATE strategy_position_operations
+        SET status=%s, last_error_code=%s, resolved_at=now(), updated_at=now()
+        WHERE position_operation_id=%s AND status IN ('intent_persisted','submitted')
+        """,
+        (status, error_code, operation_id),
+    )
+
+
+def _finish_close(conn: psycopg.Connection[Any], *, owned: _OwnedPosition, operation_id: int, reason: str) -> None:
+    _terminal(conn, operation_id=operation_id, status="applied")
+    conn.execute(
+        """
+        UPDATE strategy_position_ownership
+        SET status='released', released_at=now(), release_reason=%s
+        WHERE ownership_id=%s AND status='active'
+        """,
+        (reason, owned.ownership_id),
+    )
+    remaining = conn.execute(
+        "SELECT count(*) FROM strategy_position_ownership WHERE strategy_trade_id=%s AND status='active'",
+        (owned.strategy_trade_id,),
+    ).fetchone()
+    assert remaining is not None
+    conn.execute(
+        "UPDATE strategy_trades SET status=%s, updated_at=now() WHERE strategy_trade_id=%s",
+        ("closed" if int(remaining[0]) == 0 else "open", owned.strategy_trade_id),
+    )
+
+
+def _resume_operation(
+    conn: psycopg.Connection[Any], *, broker: BrokerProvider, owned: _OwnedPosition
+) -> PositionManagerResult | None:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT * FROM strategy_position_operations
+            WHERE ownership_id=%s AND status IN ('intent_persisted','submitted')
+            ORDER BY position_operation_id DESC LIMIT 1
+            """,
+            (owned.ownership_id,),
+        )
+        operation = cur.fetchone()
+    conn.commit()
+    if operation is None:
+        return None
+    operation_id = int(operation["position_operation_id"])
+    position = _exact_broker_position(broker, owned)
+    if operation["status"] == "intent_persisted":
+        # There is no edit/close lookup by request UUID. A crash can occur on
+        # either side of broker I/O, so absence/non-landing is ambiguous.
+        landed = (
+            operation["operation_type"] != "close"
+            and position is not None
+            and position.stop_loss_rate == Decimal(str(operation["desired_stop_rate"]))
+            and (
+                operation["desired_take_profit_rate"] is None
+                or position.take_profit_rate == Decimal(str(operation["desired_take_profit_rate"]))
+            )
+        )
+        with conn.transaction():
+            if landed:
+                _terminal(conn, operation_id=operation_id, status="applied")
+            else:
+                _terminal(
+                    conn,
+                    operation_id=operation_id,
+                    status="reconcile_required",
+                    error_code="crash_before_submission_identity",
+                )
+                conn.execute(
+                    "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() "
+                    "WHERE strategy_trade_id=%s",
+                    (owned.strategy_trade_id,),
+                )
+        return PositionManagerResult(
+            owned.strategy_trade_id,
+            owned.broker_position_id,
+            "applied" if landed else "reconcile_required",
+            "broker_state_matches_intent" if landed else "crash_before_submission_identity",
+            operation_id,
+        )
+    if operation["operation_type"] == "close":
+        try:
+            detail = broker.get_demo_close_order(order_id=str(operation["broker_order_ref"]))
+        except BrokerPositionMutationError:
+            return PositionManagerResult(
+                owned.strategy_trade_id, owned.broker_position_id, "pending", "close_lookup_unavailable", operation_id
+            )
+        if detail.status == "pending":
+            return PositionManagerResult(
+                owned.strategy_trade_id, owned.broker_position_id, "pending", "broker_close_pending", operation_id
+            )
+        exact_reference = detail.reference_id is None or detail.reference_id == operation["request_id"]
+        exact = detail.status == "filled" and detail.position_ids == (owned.broker_position_id,) and exact_reference
+        with conn.transaction():
+            order_status = "filled" if exact else "rejected"
+            conn.execute("UPDATE orders SET status=%s WHERE order_id=%s", (order_status, operation["order_id"]))
+            if exact:
+                _finish_close(
+                    conn,
+                    owned=owned,
+                    operation_id=operation_id,
+                    reason=str(operation["trigger_code"]),
+                )
+            else:
+                _terminal(
+                    conn,
+                    operation_id=operation_id,
+                    status="reconcile_required",
+                    error_code="close_order_did_not_affect_exact_position",
+                )
+                conn.execute(
+                    "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() "
+                    "WHERE strategy_trade_id=%s",
+                    (owned.strategy_trade_id,),
+                )
+        return PositionManagerResult(
+            owned.strategy_trade_id,
+            owned.broker_position_id,
+            "applied" if exact else "reconcile_required",
+            "exact_position_closed" if exact else "close_order_did_not_affect_exact_position",
+            operation_id,
+        )
+    landed = (
+        position is not None
+        and position.stop_loss_rate == Decimal(str(operation["desired_stop_rate"]))
+        and (
+            operation["desired_take_profit_rate"] is None
+            or position.take_profit_rate == Decimal(str(operation["desired_take_profit_rate"]))
+        )
+    )
+    if not landed:
+        return PositionManagerResult(
+            owned.strategy_trade_id, owned.broker_position_id, "pending", "broker_edit_pending", operation_id
+        )
+    with conn.transaction():
+        _terminal(conn, operation_id=operation_id, status="applied")
+    return PositionManagerResult(
+        owned.strategy_trade_id, owned.broker_position_id, "applied", "broker_edit_applied", operation_id
+    )
+
+
+def _persist_edit_intent(
+    conn: psycopg.Connection[Any],
+    *,
+    owned: _OwnedPosition,
+    operation_type: Literal["fixed_exit_repair", "stop_ratchet"],
+    trigger_code: Literal["entry_exit_gap", "causal_resistance_break"],
+    prior_stop: Decimal | None,
+    desired_stop: Decimal,
+    desired_take: Decimal | None,
+    bar: RatchetBar | None,
+) -> tuple[int, UUID]:
+    request_id = uuid4()
+    row = conn.execute(
+        """
+        INSERT INTO strategy_position_operations (
+            ownership_id, operation_type, trigger_code, request_id, status,
+            prior_stop_rate, desired_stop_rate, desired_take_profit_rate,
+            completed_bar_at, level_known_at, close_rate,
+            highest_close_since_entry, atr_rate, resistance_rate,
+            ratchet_variant_id
+        ) VALUES (%s,%s,%s,%s,'intent_persisted',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        RETURNING position_operation_id
+        """,
+        (
+            owned.ownership_id,
+            operation_type,
+            trigger_code,
+            request_id,
+            prior_stop,
+            desired_stop,
+            desired_take,
+            bar.completed_at if bar else None,
+            bar.level_known_at if bar else None,
+            bar.close if bar else None,
+            bar.highest_close_since_entry if bar else None,
+            bar.atr if bar else None,
+            bar.broken_resistance if bar else None,
+            owned.ratchet_variant_id if bar else None,
+        ),
+    ).fetchone()
+    assert row is not None
+    return int(row[0]), request_id
+
+
+def _prior_same_edit(
+    conn: psycopg.Connection[Any],
+    *,
+    owned: _OwnedPosition,
+    operation_type: Literal["fixed_exit_repair", "stop_ratchet"],
+    desired_stop: Decimal,
+    desired_take: Decimal | None,
+    bar: RatchetBar | None,
+) -> PositionManagerResult | None:
+    row = conn.execute(
+        """
+        SELECT position_operation_id, status,
+               COALESCE(last_error_code, 'prior_material_operation')
+        FROM strategy_position_operations
+        WHERE ownership_id=%s AND operation_type=%s
+          AND desired_stop_rate=%s
+          AND desired_take_profit_rate IS NOT DISTINCT FROM %s
+          AND completed_bar_at IS NOT DISTINCT FROM %s
+        ORDER BY position_operation_id DESC LIMIT 1
+        """,
+        (
+            owned.ownership_id,
+            operation_type,
+            desired_stop,
+            desired_take,
+            bar.completed_at if bar else None,
+        ),
+    ).fetchone()
+    if row is None:
+        return None
+    state: Literal["rejected", "reconcile_required"] = (
+        "reconcile_required" if row[1] == "reconcile_required" else "rejected"
+    )
+    return PositionManagerResult(
+        owned.strategy_trade_id,
+        owned.broker_position_id,
+        state,
+        str(row[2]),
+        int(row[0]),
+    )
+
+
+def _submit_edit(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    owned: _OwnedPosition,
+    operation_id: int,
+    request_id: UUID,
+    desired_stop: Decimal,
+    desired_take: Decimal | None,
+) -> PositionManagerResult:
+    try:
+        submission = broker.edit_demo_strategy_position(
+            position_id=owned.broker_position_id,
+            stop_loss_rate=desired_stop,
+            take_profit_rate=desired_take,
+            request_id=request_id,
+        )
+    except BrokerPositionMutationError as exc:
+        uncertain = isinstance(exc, BrokerPositionMutationUncertain)
+        with conn.transaction():
+            _terminal(
+                conn,
+                operation_id=operation_id,
+                status="reconcile_required" if uncertain else "rejected",
+                error_code="broker_edit_uncertain" if uncertain else "broker_edit_rejected",
+            )
+            if uncertain:
+                conn.execute(
+                    "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() "
+                    "WHERE strategy_trade_id=%s",
+                    (owned.strategy_trade_id,),
+                )
+        return PositionManagerResult(
+            owned.strategy_trade_id,
+            owned.broker_position_id,
+            "reconcile_required" if uncertain else "rejected",
+            "broker_edit_uncertain" if uncertain else "broker_edit_rejected",
+            operation_id,
+        )
+    with conn.transaction():
+        conn.execute(
+            """
+            UPDATE strategy_position_operations
+            SET status='submitted', broker_operation_id=%s, submitted_at=now(), updated_at=now()
+            WHERE position_operation_id=%s AND status='intent_persisted'
+            """,
+            (submission.operation_id, operation_id),
+        )
+    # The 202 response is acceptance only. A future invocation re-syncs the
+    # exact position before changing this operation to applied.
+    return PositionManagerResult(
+        owned.strategy_trade_id, owned.broker_position_id, "submitted", "broker_edit_accepted", operation_id
+    )
+
+
+def _submit_close(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    owned: _OwnedPosition,
+    trigger_code: Literal["timeout", "strategy_exit", "emergency_risk"],
+) -> PositionManagerResult:
+    request_id = uuid4()
+    with conn.transaction():
+        order = conn.execute(
+            """
+            INSERT INTO orders (
+                instrument_id, action, order_type, status, raw_payload_json,
+                execution_origin, strategy_request_id
+            ) VALUES (%s,'EXIT','MARKET','submitted',NULL,'strategy',%s)
+            RETURNING order_id
+            """,
+            (owned.instrument_id, request_id),
+        ).fetchone()
+        assert order is not None
+        order_id = int(order[0])
+        link_strategy_order(conn, strategy_trade_id=owned.strategy_trade_id, order_id=order_id, purpose="exit")
+        operation = conn.execute(
+            """
+            INSERT INTO strategy_position_operations (
+                ownership_id, order_id, operation_type, trigger_code, request_id, status
+            ) VALUES (%s,%s,'close',%s,%s,'intent_persisted')
+            RETURNING position_operation_id
+            """,
+            (owned.ownership_id, order_id, trigger_code, request_id),
+        ).fetchone()
+        assert operation is not None
+        operation_id = int(operation[0])
+        conn.execute(
+            "UPDATE strategy_trades SET status='closing', updated_at=now() WHERE strategy_trade_id=%s",
+            (owned.strategy_trade_id,),
+        )
+    try:
+        submission = broker.close_demo_strategy_position(
+            position_id=owned.broker_position_id,
+            instrument_id=owned.instrument_id,
+            request_id=request_id,
+        )
+    except BrokerPositionMutationError as exc:
+        uncertain = isinstance(exc, BrokerPositionMutationUncertain)
+        with conn.transaction():
+            conn.execute(
+                "UPDATE orders SET status=%s WHERE order_id=%s",
+                ("submitted" if uncertain else "rejected", order_id),
+            )
+            _terminal(
+                conn,
+                operation_id=operation_id,
+                status="reconcile_required" if uncertain else "rejected",
+                error_code="broker_close_uncertain" if uncertain else "broker_close_rejected",
+            )
+            conn.execute(
+                "UPDATE strategy_trades SET status=%s, updated_at=now() WHERE strategy_trade_id=%s",
+                ("reconcile_required" if uncertain else "open", owned.strategy_trade_id),
+            )
+        return PositionManagerResult(
+            owned.strategy_trade_id,
+            owned.broker_position_id,
+            "reconcile_required" if uncertain else "rejected",
+            "broker_close_uncertain" if uncertain else "broker_close_rejected",
+            operation_id,
+        )
+    with conn.transaction():
+        conn.execute("UPDATE orders SET broker_order_ref=%s WHERE order_id=%s", (submission.broker_order_ref, order_id))
+        conn.execute(
+            """
+            UPDATE strategy_position_operations
+            SET status='submitted', broker_order_ref=%s, submitted_at=now(), updated_at=now()
+            WHERE position_operation_id=%s
+            """,
+            (int(submission.broker_order_ref), operation_id),
+        )
+    return PositionManagerResult(
+        owned.strategy_trade_id, owned.broker_position_id, "submitted", "broker_close_accepted", operation_id
+    )
+
+
+def manage_owned_position(
+    conn: psycopg.Connection[Any],
+    *,
+    broker: BrokerProvider,
+    strategy_trade_id: int,
+    broker_position_id: int,
+    ratchet_bar: RatchetBar | None = None,
+    close_reason: Literal["strategy_exit", "emergency_risk"] | None = None,
+    now: datetime | None = None,
+) -> PositionManagerResult:
+    """Verify or de-risk one exact owned position.
+
+    Kill switches intentionally do not block this path: they block new risk,
+    while fixed-stop repair, ratcheting, timeout and explicit closes reduce
+    already-owned risk. Live credentials are refused by the provider adapter.
+    """
+    if conn.info.transaction_status != TransactionStatus.IDLE:
+        raise StrategyPositionManagerError("position management requires an idle connection")
+    observed_at = (now or datetime.now(UTC)).astimezone(UTC)
+    with _position_lock(conn, broker_position_id):
+        owned = _load_owned(conn, strategy_trade_id=strategy_trade_id, broker_position_id=broker_position_id)
+        conn.commit()
+        resumed = _resume_operation(conn, broker=broker, owned=owned)
+        if resumed is not None:
+            return resumed
+        position = _exact_broker_position(broker, owned)
+        if position is None:
+            with conn.transaction():
+                conn.execute(
+                    "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() "
+                    "WHERE strategy_trade_id=%s",
+                    (strategy_trade_id,),
+                )
+            return PositionManagerResult(
+                strategy_trade_id, broker_position_id, "reconcile_required", "owned_position_missing"
+            )
+
+        timed_out = (
+            owned.max_position_age_seconds is not None
+            and position.open_date_time is not None
+            and position.open_date_time <= observed_at - timedelta(seconds=owned.max_position_age_seconds)
+        )
+        if owned.max_position_age_seconds is not None and position.open_date_time is None:
+            with conn.transaction():
+                conn.execute(
+                    "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() "
+                    "WHERE strategy_trade_id=%s",
+                    (strategy_trade_id,),
+                )
+            return PositionManagerResult(
+                strategy_trade_id,
+                broker_position_id,
+                "reconcile_required",
+                "position_open_time_missing",
+            )
+        if close_reason is not None or timed_out:
+            eligibility = _eligibility_for_owned(broker, owned)
+            if not eligibility.allow_close_position:
+                return PositionManagerResult(
+                    strategy_trade_id, broker_position_id, "rejected", "broker_close_not_allowed"
+                )
+            return _submit_close(
+                conn,
+                broker=broker,
+                owned=owned,
+                trigger_code=close_reason or "timeout",
+            )
+
+        current_stop = position.stop_loss_rate
+        desired_stop = max(current_stop, owned.entry_stop) if current_stop is not None else owned.entry_stop
+        desired_take = owned.entry_take_profit
+        stop_gap = position.is_no_stop_loss or current_stop is None or current_stop < owned.entry_stop
+        take_gap = position.is_no_take_profit or position.take_profit_rate != desired_take
+        if stop_gap or take_gap:
+            eligibility = _eligibility_for_owned(broker, owned)
+            arms = [
+                arm
+                for arm in eligibility.leverage_configs
+                if arm.settlement_type.lower() == "real" and arm.direction.upper() == "LONG"
+            ]
+            if len(arms) != 1 or arms[0].allow_edit_stop_loss is not True or arms[0].allow_edit_take_profit is not True:
+                return PositionManagerResult(
+                    strategy_trade_id, broker_position_id, "rejected", "broker_fixed_exit_edit_not_allowed"
+                )
+            if (
+                owned.quote_bid is None
+                or owned.quoted_at is None
+                or owned.quoted_at < observed_at - timedelta(seconds=owned.max_quote_age_seconds)
+                or owned.quoted_at > observed_at + timedelta(seconds=5)
+                or desired_stop >= owned.quote_bid
+            ):
+                return PositionManagerResult(
+                    strategy_trade_id, broker_position_id, "rejected", "fixed_exit_quote_unsafe"
+                )
+            prior = _prior_same_edit(
+                conn,
+                owned=owned,
+                operation_type="fixed_exit_repair",
+                desired_stop=desired_stop,
+                desired_take=desired_take,
+                bar=None,
+            )
+            conn.commit()
+            if prior is not None:
+                return prior
+            with conn.transaction():
+                operation_id, request_id = _persist_edit_intent(
+                    conn,
+                    owned=owned,
+                    operation_type="fixed_exit_repair",
+                    trigger_code="entry_exit_gap",
+                    prior_stop=current_stop,
+                    desired_stop=desired_stop,
+                    desired_take=desired_take,
+                    bar=None,
+                )
+            return _submit_edit(
+                conn,
+                broker=broker,
+                owned=owned,
+                operation_id=operation_id,
+                request_id=request_id,
+                desired_stop=desired_stop,
+                desired_take=desired_take,
+            )
+
+        if ratchet_bar is None or owned.ratchet_variant_id is None:
+            return PositionManagerResult(strategy_trade_id, broker_position_id, "no_change", "position_protected")
+        if ratchet_bar.completed_at > observed_at:
+            raise ValueError("ratchet bar must be completed before evaluation")
+        assert current_stop is not None
+        assert owned.break_atr_multiple is not None
+        assert owned.chandelier_atr_multiple is not None
+        assert owned.structure_atr_multiple is not None
+        candidate = calculate_ratchet_stop(
+            current_stop=current_stop,
+            bar=ratchet_bar,
+            break_atr_multiple=owned.break_atr_multiple,
+            chandelier_atr_multiple=owned.chandelier_atr_multiple,
+            structure_atr_multiple=owned.structure_atr_multiple,
+        )
+        if candidate is None:
+            return PositionManagerResult(strategy_trade_id, broker_position_id, "no_change", "ratchet_not_fired")
+        if (
+            owned.quote_bid is None
+            or owned.quoted_at is None
+            or owned.quoted_at < observed_at - timedelta(seconds=owned.max_quote_age_seconds)
+            or owned.quoted_at > observed_at + timedelta(seconds=5)
+            or candidate >= owned.quote_bid
+        ):
+            return PositionManagerResult(strategy_trade_id, broker_position_id, "rejected", "ratchet_quote_unsafe")
+        eligibility = _eligibility_for_owned(broker, owned)
+        arms = [
+            arm
+            for arm in eligibility.leverage_configs
+            if arm.settlement_type.lower() == "real" and arm.direction.upper() == "LONG"
+        ]
+        if len(arms) != 1 or arms[0].allow_edit_stop_loss is not True:
+            return PositionManagerResult(
+                strategy_trade_id,
+                broker_position_id,
+                "rejected",
+                "broker_ratchet_not_allowed",
+            )
+        prior = _prior_same_edit(
+            conn,
+            owned=owned,
+            operation_type="stop_ratchet",
+            desired_stop=candidate,
+            desired_take=desired_take,
+            bar=ratchet_bar,
+        )
+        conn.commit()
+        if prior is not None:
+            return prior
+        with conn.transaction():
+            operation_id, request_id = _persist_edit_intent(
+                conn,
+                owned=owned,
+                operation_type="stop_ratchet",
+                trigger_code="causal_resistance_break",
+                prior_stop=current_stop,
+                desired_stop=candidate,
+                desired_take=desired_take,
+                bar=ratchet_bar,
+            )
+        return _submit_edit(
+            conn,
+            broker=broker,
+            owned=owned,
+            operation_id=operation_id,
+            request_id=request_id,
+            desired_stop=candidate,
+            desired_take=desired_take,
+        )
+
+
+__all__ = [
+    "PositionManagerResult",
+    "RatchetBar",
+    "StrategyPositionManagerError",
+    "calculate_ratchet_stop",
+    "configure_position_manager",
+    "manage_owned_position",
+    "register_ratchet_variant",
+]

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -110,7 +110,7 @@ GET+POST requests cannot exceed the API limit.
 - Cache static data locally (instrument IDs are immutable)
 - Batch rate requests (max 100 IDs per call; eBull uses 50 for safety)
 - Sequence per-instrument calls with throttle delay
-- Land every structured field in SQL — raw disk dumps for eToro were retired in #471 (`instruments` / `price_daily` / `quotes` / `exchanges` tables ARE the audit trail)
+- Land every structured field in SQL — raw disk dumps for eToro were retired in #471 (`instruments` / `price_daily` / `quotes` / `exchanges` tables ARE the market-data audit trail). Automated broker mutations additionally retain one small latest response object on their material operation/order row; they do not append polling payloads.
 
 ---
 

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -144,7 +144,7 @@ GET+POST requests cannot exceed the API limit.
 | DELETE | `/api/v1/trading/execution/market-open-orders/{orderId}` | Cancel pending open order | Not used (v1) |
 | POST | `/api/v1/trading/execution/market-close-orders/positions/{positionId}` | Close position — body `UnitsToDeduct` nullable → partial close (omit = full). Live doc also lists `InstrumentID` required; our impl omits it — verify on demo before relying | **Active** (full close; partial plumbed in provider, unexposed) |
 | DELETE | `/api/v1/trading/execution/market-close-orders/{orderId}` | Cancel pending close order | Not used (v1) |
-| PATCH | `/api/v2/trading/{real\|demo}/positions/{positionId}` | Edit TP/SL on one exact open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). Async acceptance `{operationId, positionId, referenceId}` — re-sync before treating as landed | Planned — required for strategy-owned ratchets |
+| PATCH | `/api/v2/trading/{real\|demo}/positions/{positionId}` | Edit TP/SL on one exact open position: `stopLossRate`, `takeProfitRate`, `stopLossType` (`fixed`\|`trailing`), `clearStopLoss`, `clearTakeProfit` (≥1 field). Async acceptance `{operationId, positionId, referenceId}` — re-sync before treating as landed | **Demo active for exact strategy-owned fixed-exit repair and registered ratchets**; real path refused |
 | POST | `/api/v2/trading/info/{real\|demo}/eligibility` | Up to 100 ids/symbols; account-specific open/close/partial-close permission, min exposure, max units, order/fill types, and leverage + SL/TP constraints by settlement/direction | **Active as a just-in-time paper gate**; response is process-local |
 | POST | `/api/v2/trading/info/{real\|demo}/costs` | What-if open cost rows for `buy` / `sellShort`: open vocabulary including spread, markup, transaction, overnight/weekend and tax; returns `lastUpdated`. Demo returned `value` while omitting documented `amount`; controlled scaling did not establish one unit equation | **Active fail-closed paper gate**: documented fresh USD `amount` only; `value`/unknown horizon refuses |
 | GET | `/api/v2/trading/info/{real\|demo}/orders:lookup` | Exactly one of numeric `orderId` or submission `referenceId`; returns status and every `positionExecutions[].positionId` with opening units/average price. Shared 60 GET/min quota | **Active for strategy reconciliation** — strict adapter, exact execution persistence and restart backlog |
@@ -153,6 +153,7 @@ GET+POST requests cannot exceed the API limit.
 | GET | `/api/v1/trading/info/portfolio` | Full portfolio: positions, orders, mirrors, credit | **Active** — portfolio sync |
 | GET | `/api/v1/trading/info/{real\|demo}/pnl` | Positions, mirrors, pending orders, credit and P&L inputs for the published cash/invested/equity formula | **Demo active as a just-in-time paper risk gate**; raw response is process-local |
 | GET | `/api/v1/trading/info/real/orders/{orderId}` | Single order status | **Active** — order polling |
+| GET | `/api/v1/trading/info/{real\|demo}/close-orders/{orderId}` | Close-order status plus exact affected `positions[].positionID` | **Demo active for exact strategy close reconciliation**; disappearance alone is not success |
 | GET | `/api/v1/trading/info/trade/history` | Trade history (`minDate` required) | Not used (v1) |
 
 ⚠ **Live portal drift, detail pages verified 2026-08-09:** both preflights are
@@ -174,6 +175,16 @@ writer. Its adapter refuses non-demo credentials and its accepted shape is
 long `buy`, `real`, market, x1, USD amount with fixed SL/TP. It validates a
 positive `orderId` and exact `referenceId == X-Request-Id`; the generic legacy
 writer remains manual and is not an automated fallback.
+
+The automated position manager is equally demo-bound. It commits one compact
+material intent before calling either exact-position endpoint, sends the stored
+request UUID, and treats PATCH acceptance as pending until a portfolio re-sync
+shows the requested fixed rates. A close is applied only when the close-order
+detail names the one owned `positionID`. There is no request-id lookup for a
+PATCH or legacy close, so a crash before the broker identity is stored becomes
+`reconcile_required`; the writer is not blindly replayed. Verified against the
+live demo endpoint pages on 2026-08-09 (the downloadable base snapshot remains
+v1.279.0 as recorded above).
 
 ### Authenticated demo census (2026-08-09)
 
@@ -690,6 +701,7 @@ persistence" for the scope-narrowed rule.
 | Universe sync service | `app/services/universe.py` |
 | Market data service | `app/services/market_data.py` |
 | Portfolio sync service | `app/services/portfolio_sync.py` |
+| Strategy position manager | `app/services/strategy_position_manager.py` |
 | Credentials service | `app/services/broker_credentials.py` |
 | Scheduled jobs | `app/workers/scheduler.py` |
 | Configuration | `app/config.py` |

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -276,8 +276,10 @@ empty** on PostgreSQL 17. It adds four narrow relations: registered variants,
 one current policy, policy revisions, and material operations. A protected
 position/bar poll writes zero rows; an actual stop change or close writes one
 compact operation and repeated rejection of the same material edit is unique.
-There is no tick, bar, eligibility, portfolio or raw broker payload copy in
-these relations.
+There is no tick, bar, eligibility or portfolio payload copy in these
+relations. Each material operation retains at most the latest small broker
+response object (and the linked close order retains its submission response),
+so auditability does not create an append-only polling heap.
 
 P&L is derived from owned trade order/fill links and broker close history; it is
 not copied into the general `positions` aggregate and not duplicated on every

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -271,6 +271,14 @@ the smallest control-plane schema is:
 | preflight observations | candidate request or changed eligibility state | 24 months; no unchanged polling rows |
 | strategy daily metrics | strategy/version/day/stage arm | durable compact aggregate |
 
+The #2452 position-manager schema measured **128 KiB including indexes when
+empty** on PostgreSQL 17. It adds four narrow relations: registered variants,
+one current policy, policy revisions, and material operations. A protected
+position/bar poll writes zero rows; an actual stop change or close writes one
+compact operation and repeated rejection of the same material edit is unique.
+There is no tick, bar, eligibility, portfolio or raw broker payload copy in
+these relations.
+
 P&L is derived from owned trade order/fill links and broker close history; it is
 not copied into the general `positions` aggregate and not duplicated on every
 signal. The strategy page uses strategy-owned rows only. The main portfolio page
@@ -380,10 +388,17 @@ are actually created.
    the full body remains process-local and one SHA-256 fingerprint is retained
    per order. Repeated polls append no JSON. No broker writer or paper allocator
    is enabled.
-7. **Paper allocator/executor:** exact strategy version, sleeve cash, current
-   preflight, SL/TP and portfolio guard; no live key path.
-8. **Owned-position manager:** exact-position exits, timeout and separately
-   registered ratchet variants; asynchronous PATCH re-sync.
+7. **Paper allocator/executor — implemented:** exact strategy version, sleeve
+   cash, current eligibility/cost/account-risk preflight, fixed SL/TP and
+   portfolio guard. The writer has one hard-coded demo path and no live-key
+   selection.
+8. **Owned-position manager — implemented:** exact-position fixed-exit repair,
+   timeout/strategy/emergency closes, and separately promoted ratchet variants.
+   Every material PATCH/close intent is durable before broker I/O; PATCH is
+   re-synced and close detail must name the owned position before application.
+   An unowned id fails before I/O, same-instrument manual positions are never
+   mutated, kill switches leave risk reduction available, and unchanged bars or
+   polling heartbeats add no database rows. Live credentials are refused.
 9. **Paper P&L and picker allocation controls:** strategy-only P&L, shadow versus
    funded capture, manual allocation changes with audit.
 10. **Live promotion:** requires minimum forward/paper evidence, reconciliation

--- a/sql/289_strategy_position_manager.sql
+++ b/sql/289_strategy_position_manager.sql
@@ -1,0 +1,130 @@
+-- 289_strategy_position_manager.sql
+--
+-- #2452 / #2437 exact-position paper manager.  The schema stores only
+-- operator policy, registered ratchet variants, and material broker mutations.
+-- Polls and unchanged bars update no rows.
+
+CREATE TABLE IF NOT EXISTS strategy_ratchet_variants (
+    ratchet_variant_id       BIGSERIAL PRIMARY KEY,
+    strategy_id              TEXT NOT NULL CHECK (strategy_id <> '' AND length(strategy_id) <= 200),
+    strategy_version         TEXT NOT NULL CHECK (strategy_version <> '' AND length(strategy_version) <= 200),
+    promotion_id             BIGINT NOT NULL
+        REFERENCES strategy_promotions(promotion_id) ON DELETE RESTRICT,
+    rule_version             TEXT NOT NULL UNIQUE CHECK (rule_version <> '' AND length(rule_version) <= 200),
+    break_atr_multiple       NUMERIC(12,8) NOT NULL CHECK (break_atr_multiple > 0),
+    chandelier_atr_multiple  NUMERIC(12,8) NOT NULL CHECK (chandelier_atr_multiple > 0),
+    structure_atr_multiple   NUMERIC(12,8) NOT NULL CHECK (structure_atr_multiple > 0),
+    registered_by            TEXT NOT NULL CHECK (registered_by <> '' AND length(registered_by) <= 200),
+    reason                   TEXT NOT NULL CHECK (reason <> '' AND length(reason) <= 1000),
+    registered_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (strategy_id, strategy_version, promotion_id)
+);
+
+COMMENT ON TABLE strategy_ratchet_variants IS
+    'A ratchet is a separately identified, promoted backtest variant. The '
+    'manager cannot enable an unregistered formula or tune constants in place.';
+
+CREATE TABLE IF NOT EXISTS strategy_position_manager_policies (
+    deployment_id              BIGINT PRIMARY KEY
+        REFERENCES strategy_deployments(deployment_id) ON DELETE RESTRICT,
+    revision                   BIGINT NOT NULL CHECK (revision >= 1),
+    max_position_age_seconds   INTEGER CHECK (max_position_age_seconds IS NULL OR max_position_age_seconds > 0),
+    ratchet_variant_id         BIGINT
+        REFERENCES strategy_ratchet_variants(ratchet_variant_id) ON DELETE RESTRICT,
+    updated_by                 TEXT NOT NULL CHECK (updated_by <> '' AND length(updated_by) <= 200),
+    reason                     TEXT NOT NULL CHECK (reason <> '' AND length(reason) <= 1000),
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS strategy_position_manager_policy_events (
+    policy_event_id            BIGSERIAL PRIMARY KEY,
+    deployment_id              BIGINT NOT NULL
+        REFERENCES strategy_deployments(deployment_id) ON DELETE RESTRICT,
+    revision                   BIGINT NOT NULL CHECK (revision >= 1),
+    max_position_age_seconds   INTEGER,
+    ratchet_variant_id         BIGINT
+        REFERENCES strategy_ratchet_variants(ratchet_variant_id) ON DELETE RESTRICT,
+    changed_by                 TEXT NOT NULL CHECK (changed_by <> '' AND length(changed_by) <= 200),
+    reason                     TEXT NOT NULL CHECK (reason <> '' AND length(reason) <= 1000),
+    changed_at                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (deployment_id, revision),
+    CHECK (max_position_age_seconds IS NULL OR max_position_age_seconds > 0)
+);
+
+-- Low cardinality: one row per actual PATCH/close intent. A
+-- manager heartbeat or a completed bar which leaves the stop unchanged writes
+-- nothing. request_id is committed before broker I/O and is immutable.
+CREATE TABLE IF NOT EXISTS strategy_position_operations (
+    position_operation_id  BIGSERIAL PRIMARY KEY,
+    ownership_id           BIGINT NOT NULL
+        REFERENCES strategy_position_ownership(ownership_id) ON DELETE RESTRICT,
+    order_id               BIGINT UNIQUE
+        REFERENCES orders(order_id) ON DELETE RESTRICT,
+    operation_type         TEXT NOT NULL CHECK (operation_type IN ('fixed_exit_repair', 'stop_ratchet', 'close')),
+    trigger_code           TEXT NOT NULL CHECK (trigger_code IN ('entry_exit_gap', 'causal_resistance_break',
+                                                                  'timeout', 'strategy_exit', 'emergency_risk')),
+    request_id             UUID NOT NULL UNIQUE,
+    status                 TEXT NOT NULL CHECK (status IN (
+        'intent_persisted', 'submitted', 'applied', 'rejected', 'reconcile_required'
+    )),
+    prior_stop_rate        NUMERIC(20,6),
+    desired_stop_rate      NUMERIC(20,6),
+    desired_take_profit_rate NUMERIC(20,6),
+    completed_bar_at       TIMESTAMPTZ,
+    level_known_at         TIMESTAMPTZ,
+    close_rate             NUMERIC(20,6),
+    highest_close_since_entry NUMERIC(20,6),
+    atr_rate               NUMERIC(20,6),
+    resistance_rate        NUMERIC(20,6),
+    ratchet_variant_id     BIGINT
+        REFERENCES strategy_ratchet_variants(ratchet_variant_id) ON DELETE RESTRICT,
+    broker_operation_id    UUID,
+    broker_order_ref       BIGINT CHECK (broker_order_ref IS NULL OR broker_order_ref > 0),
+    last_error_code        TEXT CHECK (last_error_code IS NULL OR (last_error_code <> '' AND length(last_error_code) <= 100)),
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    submitted_at           TIMESTAMPTZ,
+    resolved_at            TIMESTAMPTZ,
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (
+        (operation_type = 'close' AND order_id IS NOT NULL
+         AND desired_stop_rate IS NULL AND desired_take_profit_rate IS NULL)
+        OR
+        (operation_type IN ('fixed_exit_repair', 'stop_ratchet')
+         AND order_id IS NULL AND desired_stop_rate > 0)
+    ),
+    CHECK (
+        (operation_type = 'stop_ratchet' AND ratchet_variant_id IS NOT NULL
+         AND completed_bar_at IS NOT NULL AND level_known_at IS NOT NULL
+         AND close_rate > 0 AND highest_close_since_entry > 0 AND atr_rate > 0 AND resistance_rate > 0)
+        OR operation_type <> 'stop_ratchet'
+    ),
+    CHECK (
+        operation_type <> 'stop_ratchet'
+        OR prior_stop_rate IS NULL
+        OR desired_stop_rate > prior_stop_rate
+    ),
+    CHECK (level_known_at IS NULL OR completed_bar_at IS NULL OR level_known_at <= completed_bar_at),
+    CHECK (
+        (status IN ('intent_persisted', 'submitted') AND resolved_at IS NULL)
+        OR (status IN ('applied', 'rejected', 'reconcile_required') AND resolved_at IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_position_one_unresolved_operation
+    ON strategy_position_operations (ownership_id)
+    WHERE status IN ('intent_persisted', 'submitted');
+
+CREATE INDEX IF NOT EXISTS idx_strategy_position_operations_trade_recent
+    ON strategy_position_operations (ownership_id, position_operation_id DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_position_operation_material_identity
+    ON strategy_position_operations (
+        ownership_id, operation_type, desired_stop_rate,
+        desired_take_profit_rate, completed_bar_at
+    ) NULLS NOT DISTINCT
+    WHERE operation_type IN ('fixed_exit_repair', 'stop_ratchet');
+
+COMMENT ON TABLE strategy_position_operations IS
+    'Material exact-position PATCH/close intents only. Raw broker payloads and '
+    'poll heartbeats are intentionally excluded; unchanged checks grow no rows.';

--- a/sql/289_strategy_position_manager.sql
+++ b/sql/289_strategy_position_manager.sql
@@ -81,6 +81,7 @@ CREATE TABLE IF NOT EXISTS strategy_position_operations (
         REFERENCES strategy_ratchet_variants(ratchet_variant_id) ON DELETE RESTRICT,
     broker_operation_id    UUID,
     broker_order_ref       BIGINT CHECK (broker_order_ref IS NULL OR broker_order_ref > 0),
+    broker_response_json   JSONB,
     last_error_code        TEXT CHECK (last_error_code IS NULL OR (last_error_code <> '' AND length(last_error_code) <= 100)),
     created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
     submitted_at           TIMESTAMPTZ,
@@ -126,5 +127,5 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_strategy_position_operation_material_ident
     WHERE operation_type IN ('fixed_exit_repair', 'stop_ratchet');
 
 COMMENT ON TABLE strategy_position_operations IS
-    'Material exact-position PATCH/close intents only. Raw broker payloads and '
-    'poll heartbeats are intentionally excluded; unchanged checks grow no rows.';
+    'Material exact-position PATCH/close intents only. One latest bounded-shape '
+    'broker response may be retained; polls and unchanged checks grow no rows.';

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -400,6 +400,7 @@ class TestDemoStrategyPositionMutations:
             "positionId": 9001,
             "referenceId": str(request_id),
         }
+        persisted: list[dict[str, object]] = []
         with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
             broker._http_write = MagicMock()
             broker._http_write.patch.return_value = response
@@ -408,6 +409,7 @@ class TestDemoStrategyPositionMutations:
                 stop_loss_rate=Decimal("101.25"),
                 take_profit_rate=Decimal("120"),
                 request_id=request_id,
+                persist_response=persisted.append,
             )
             call = broker._http_write.patch.call_args
         assert call.args[0] == "/api/v2/trading/demo/positions/9001"
@@ -418,6 +420,8 @@ class TestDemoStrategyPositionMutations:
             "takeProfitRate": 120.0,
         }
         assert result.operation_id == operation_id
+        assert result.raw_payload == response.json.return_value
+        assert persisted == [response.json.return_value]
 
     def test_close_uses_exact_demo_route_and_close_lookup_proves_affected_position(self) -> None:
         request_id = UUID("f95eab17-c3ac-4948-a281-d94fd1e2764b")
@@ -431,6 +435,7 @@ class TestDemoStrategyPositionMutations:
             "errorCode": None,
             "positions": [{"positionID": 9001}],
         }
+        persisted: list[dict[str, object]] = []
         with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
             broker._http_write = MagicMock()
             broker._http_read = MagicMock()
@@ -440,13 +445,20 @@ class TestDemoStrategyPositionMutations:
                 position_id=9001,
                 instrument_id=1001,
                 request_id=request_id,
+                persist_response=persisted.append,
             )
-            resolved = broker.get_demo_close_order(order_id=submission.broker_order_ref)
+            resolved = broker.get_demo_close_order(
+                order_id=submission.broker_order_ref,
+                persist_response=persisted.append,
+            )
             close_call = broker._http_write.post.call_args
         assert close_call.args[0] == "/api/v1/trading/execution/demo/market-close-orders/positions/9001"
         assert close_call.kwargs["json"] == {"InstrumentID": 1001, "UnitsToDeduct": None}
         assert resolved.status == "filled"
         assert resolved.position_ids == (9001,)
+        assert submission.raw_payload == accepted.json.return_value
+        assert resolved.raw_payload == detail.json.return_value
+        assert persisted == [accepted.json.return_value, detail.json.return_value]
 
     def test_real_credentials_cannot_patch_or_close_strategy_positions(self) -> None:
         with EtoroBrokerProvider(api_key="k", user_key="u", env="real") as broker:

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import httpx
+import pytest
 
 from app.providers.broker import (
     BrokerMirror,
@@ -22,6 +23,7 @@ from app.providers.broker import (
     BrokerOrderNotFound,
     BrokerOrderSubmissionError,
     BrokerPortfolio,
+    BrokerPositionMutationError,
     BrokerStrategyOrder,
     BrokerWhatIfOrder,
     OrderParams,
@@ -386,6 +388,83 @@ class TestDemoStrategyOrder:
                 pass
             else:  # pragma: no cover
                 raise AssertionError("real credentials must not reach the paper writer")
+
+
+class TestDemoStrategyPositionMutations:
+    def test_edit_uses_exact_v2_demo_route_and_validates_acceptance_identity(self) -> None:
+        request_id = UUID("f95eab17-c3ac-4948-a281-d94fd1e2764b")
+        operation_id = UUID("2165467c-73b8-4d2c-ac3c-b00968f0cfe3")
+        response = MagicMock()
+        response.json.return_value = {
+            "operationId": str(operation_id),
+            "positionId": 9001,
+            "referenceId": str(request_id),
+        }
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_write.patch.return_value = response
+            result = broker.edit_demo_strategy_position(
+                position_id=9001,
+                stop_loss_rate=Decimal("101.25"),
+                take_profit_rate=Decimal("120"),
+                request_id=request_id,
+            )
+            call = broker._http_write.patch.call_args
+        assert call.args[0] == "/api/v2/trading/demo/positions/9001"
+        assert call.kwargs["headers"] == {"x-request-id": str(request_id)}
+        assert call.kwargs["json"] == {
+            "stopLossRate": 101.25,
+            "stopLossType": "fixed",
+            "takeProfitRate": 120.0,
+        }
+        assert result.operation_id == operation_id
+
+    def test_close_uses_exact_demo_route_and_close_lookup_proves_affected_position(self) -> None:
+        request_id = UUID("f95eab17-c3ac-4948-a281-d94fd1e2764b")
+        accepted = MagicMock()
+        accepted.json.return_value = {"orderForClose": {"orderID": 12346, "positionID": 9001, "statusID": 1}}
+        detail = MagicMock()
+        detail.json.return_value = {
+            "orderID": 12346,
+            "statusID": 1,
+            "referenceID": str(request_id),
+            "errorCode": None,
+            "positions": [{"positionID": 9001}],
+        }
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_write = MagicMock()
+            broker._http_read = MagicMock()
+            broker._http_write.post.return_value = accepted
+            broker._http_read.get.return_value = detail
+            submission = broker.close_demo_strategy_position(
+                position_id=9001,
+                instrument_id=1001,
+                request_id=request_id,
+            )
+            resolved = broker.get_demo_close_order(order_id=submission.broker_order_ref)
+            close_call = broker._http_write.post.call_args
+        assert close_call.args[0] == "/api/v1/trading/execution/demo/market-close-orders/positions/9001"
+        assert close_call.kwargs["json"] == {"InstrumentID": 1001, "UnitsToDeduct": None}
+        assert resolved.status == "filled"
+        assert resolved.position_ids == (9001,)
+
+    def test_real_credentials_cannot_patch_or_close_strategy_positions(self) -> None:
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="real") as broker:
+            broker._http_write = MagicMock()
+            with pytest.raises(BrokerPositionMutationError, match="demo credentials"):
+                broker.edit_demo_strategy_position(
+                    position_id=9001,
+                    stop_loss_rate=Decimal("100"),
+                    take_profit_rate=None,
+                    request_id=uuid4(),
+                )
+            with pytest.raises(BrokerPositionMutationError, match="demo credentials"):
+                broker.close_demo_strategy_position(
+                    position_id=9001,
+                    instrument_id=1001,
+                    request_id=uuid4(),
+                )
+            broker._http_write.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resilient_client.py
+++ b/tests/test_resilient_client.py
@@ -294,6 +294,19 @@ def test_post_is_throttled_and_retried(_patch_time: MagicMock) -> None:
     assert mock_httpx.build_request.call_args_list[0][0][0] == "POST"
 
 
+def test_patch_is_throttled_and_retried(_patch_time: MagicMock) -> None:
+    """PATCH requests use the shared retry path needed by position edits."""
+    r429 = _make_response(429)
+    r202 = _make_response(202)
+    client, mock_httpx = _make_client([r429, r202])
+
+    result = client.patch("/positions/1", json={"stopLossRate": 100})
+
+    assert result.status_code == 202
+    assert mock_httpx.send.call_count == 2
+    assert mock_httpx.build_request.call_args_list[0][0][0] == "PATCH"
+
+
 # ---------------------------------------------------------------------------
 # Shared throttle state
 # ---------------------------------------------------------------------------

--- a/tests/test_strategy_position_manager.py
+++ b/tests/test_strategy_position_manager.py
@@ -1,0 +1,516 @@
+"""#2452 exact-position paper manager integration tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import psycopg
+import pytest
+
+from app.providers.broker import (
+    BrokerCloseOrderDetail,
+    BrokerOrderDetail,
+    BrokerPortfolio,
+    BrokerPosition,
+    BrokerPositionCloseSubmission,
+    BrokerPositionEditSubmission,
+    BrokerPositionExecution,
+    BrokerPositionMutationError,
+)
+from app.services.strategy_control_plane import StrategyOwnershipError
+from app.services.strategy_order_reconciliation import reconcile_strategy_order
+from app.services.strategy_paper_executor import execute_fired_paper_signal
+from app.services.strategy_position_manager import (
+    RatchetBar,
+    StrategyPositionManagerError,
+    calculate_ratchet_stop,
+    configure_position_manager,
+    manage_owned_position,
+    register_ratchet_variant,
+)
+from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _broker, _seed
+
+pytestmark = pytest.mark.integration
+
+_POSITION_ID = 24520001
+_MANUAL_POSITION_ID = 24520999
+_EDIT_OPERATION_ID = UUID("2165467c-73b8-4d2c-ac3c-b00968f0cfe3")
+
+
+def _position(position_id: int, *, stop: Decimal | None, take: Decimal | None) -> BrokerPosition:
+    return BrokerPosition(
+        instrument_id=2449001,
+        units=Decimal("1"),
+        open_price=Decimal("100"),
+        current_price=Decimal("105"),
+        raw_payload={},
+        position_id=position_id,
+        open_date_time=_NOW - timedelta(days=2),
+        stop_loss_rate=stop,
+        take_profit_rate=take,
+        is_no_stop_loss=stop is None,
+        is_no_take_profit=take is None,
+    )
+
+
+def _order_detail() -> BrokerOrderDetail:
+    execution = BrokerPositionExecution(
+        position_id=_POSITION_ID,
+        state="open",
+        remaining_units=Decimal("1"),
+        opening_units=Decimal("1"),
+        average_price=Decimal("100"),
+        execution_time=_NOW,
+        fees=Decimal("0.1"),
+        raw_payload={},
+    )
+    return BrokerOrderDetail(
+        broker_order_ref="13902598",
+        reference_id=str(_REQUEST_ID),
+        status="filled",
+        broker_status="Filled",
+        instrument_id=2449001,
+        position_executions=(execution,),
+        last_update=_NOW,
+        raw_payload={"positionExecutions": [{"positionId": _POSITION_ID}]},
+    )
+
+
+def _opened_trade(
+    conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> tuple[int, int, MagicMock, BrokerPosition]:
+    signal_id = _seed(conn)
+    broker = _broker()
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+    execution = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+    assert execution.strategy_trade_id is not None and execution.order_id is not None
+    broker.lookup_order.return_value = _order_detail()
+    reconciled = reconcile_strategy_order(conn, broker=broker, order_id=execution.order_id)
+    assert reconciled.state == "resolved"
+    deployment_row = conn.execute(
+        "SELECT deployment_id FROM strategy_funding_decisions WHERE signal_id=%s", (signal_id,)
+    ).fetchone()
+    assert deployment_row is not None
+    deployment_id = int(deployment_row[0])
+    configure_position_manager(
+        conn,
+        deployment_id=deployment_id,
+        max_position_age_seconds=None,
+        ratchet_variant_id=None,
+        updated_by="test",
+        reason="exact position lifecycle",
+    )
+    conn.commit()
+    manual = _position(_MANUAL_POSITION_ID, stop=None, take=None)
+    broker.get_portfolio.return_value = BrokerPortfolio(
+        positions=(_position(_POSITION_ID, stop=None, take=None), manual),
+        available_cash=Decimal("500"),
+        raw_payload={},
+    )
+    broker.edit_demo_strategy_position.return_value = BrokerPositionEditSubmission(
+        _EDIT_OPERATION_ID, _POSITION_ID, _REQUEST_ID
+    )
+    broker.close_demo_strategy_position.return_value = BrokerPositionCloseSubmission("24521234", _POSITION_ID)
+    return execution.strategy_trade_id, deployment_id, broker, manual
+
+
+def test_unowned_position_fails_before_any_broker_io(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    trade_id, _, broker, _ = _opened_trade(ebull_test_conn, monkeypatch)
+
+    with pytest.raises(StrategyOwnershipError, match="exact active"):
+        manage_owned_position(
+            ebull_test_conn,
+            broker=broker,
+            strategy_trade_id=trade_id,
+            broker_position_id=_MANUAL_POSITION_ID,
+            now=_NOW,
+        )
+
+    broker.get_portfolio.assert_not_called()
+    broker.edit_demo_strategy_position.assert_not_called()
+    broker.close_demo_strategy_position.assert_not_called()
+
+
+def test_bigint_broker_position_id_uses_a_valid_advisory_lock(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, _, broker, _ = _opened_trade(conn, monkeypatch)
+    bigint_position_id = 2**40 + _POSITION_ID
+    conn.execute(
+        "UPDATE strategy_position_ownership SET broker_position_id=%s WHERE broker_position_id=%s",
+        (bigint_position_id, _POSITION_ID),
+    )
+    conn.commit()
+    broker.get_portfolio.return_value = BrokerPortfolio(
+        positions=(_position(bigint_position_id, stop=Decimal("95"), take=Decimal("110")),),
+        available_cash=Decimal("500"),
+        raw_payload={},
+    )
+
+    result = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=bigint_position_id,
+        now=_NOW,
+    )
+
+    assert result.state == "no_change"
+    assert result.reason_code == "position_protected"
+
+
+def test_fixed_exit_gap_is_repaired_once_and_manual_position_is_untouched(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, _, broker, manual = _opened_trade(conn, monkeypatch)
+
+    submitted = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        now=_NOW,
+    )
+
+    assert submitted.state == "submitted"
+    call = broker.edit_demo_strategy_position.call_args.kwargs
+    assert call["position_id"] == _POSITION_ID
+    assert call["stop_loss_rate"] == Decimal("95.000000")
+    assert call["take_profit_rate"] == Decimal("110.000000")
+    assert manual.stop_loss_rate is None and manual.take_profit_rate is None
+
+    broker.get_portfolio.return_value = BrokerPortfolio(
+        positions=(
+            _position(_POSITION_ID, stop=Decimal("95.000000"), take=Decimal("110.000000")),
+            manual,
+        ),
+        available_cash=Decimal("500"),
+        raw_payload={},
+    )
+    applied = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        now=_NOW,
+    )
+
+    assert applied.state == "applied"
+    broker.edit_demo_strategy_position.assert_called_once()
+    assert conn.execute("SELECT count(*) FROM strategy_position_operations").fetchone() == (1,)
+    assert conn.execute("SELECT status FROM strategy_position_operations").fetchone() == ("applied",)
+
+
+def test_rejected_patch_is_a_single_material_event_not_a_retry_heap(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, _, broker, _ = _opened_trade(conn, monkeypatch)
+    broker.edit_demo_strategy_position.side_effect = BrokerPositionMutationError("rejected")
+
+    first = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        now=_NOW,
+    )
+    second = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        now=_NOW,
+    )
+
+    assert first.state == second.state == "rejected"
+    broker.edit_demo_strategy_position.assert_called_once()
+    assert conn.execute("SELECT count(*) FROM strategy_position_operations").fetchone() == (1,)
+
+
+def test_ratchet_formula_is_causal_and_never_worsens_the_stop() -> None:
+    bar = RatchetBar(
+        completed_at=datetime(2026, 8, 7, 20, tzinfo=UTC),
+        level_known_at=datetime(2026, 8, 6, 20, tzinfo=UTC),
+        close=Decimal("111"),
+        highest_close_since_entry=Decimal("114"),
+        atr=Decimal("4"),
+        broken_resistance=Decimal("108"),
+    )
+    assert calculate_ratchet_stop(
+        current_stop=Decimal("95"),
+        bar=bar,
+        break_atr_multiple=Decimal("0.5"),
+        chandelier_atr_multiple=Decimal("3"),
+        structure_atr_multiple=Decimal("1.5"),
+    ) == Decimal("102.000000")
+    assert (
+        calculate_ratchet_stop(
+            current_stop=Decimal("103"),
+            bar=bar,
+            break_atr_multiple=Decimal("0.5"),
+            chandelier_atr_multiple=Decimal("3"),
+            structure_atr_multiple=Decimal("1.5"),
+        )
+        is None
+    )
+    with pytest.raises(ValueError, match="not causal"):
+        calculate_ratchet_stop(
+            current_stop=Decimal("95"),
+            bar=RatchetBar(
+                completed_at=bar.completed_at,
+                level_known_at=bar.completed_at + timedelta(seconds=1),
+                close=bar.close,
+                highest_close_since_entry=bar.highest_close_since_entry,
+                atr=bar.atr,
+                broken_resistance=bar.broken_resistance,
+            ),
+            break_atr_multiple=Decimal("0.5"),
+            chandelier_atr_multiple=Decimal("3"),
+            structure_atr_multiple=Decimal("1.5"),
+        )
+
+
+def test_ratchet_requires_a_registered_promoted_backtest_arm(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, deployment_id, broker, manual = _opened_trade(conn, monkeypatch)
+    promotion_row = conn.execute(
+        """
+        SELECT p.promotion_id, r.position_rule_set_version
+        FROM strategy_promotions p
+        JOIN strategy_promotion_results pr ON pr.promotion_id=p.promotion_id
+        JOIN strategy_results_store r ON r.result_id=pr.result_id
+        WHERE p.strategy_id='S-ALLOC'
+        """
+    ).fetchone()
+    assert promotion_row is not None
+    promotion_id, rule_version = promotion_row
+    variant_id = register_ratchet_variant(
+        conn,
+        strategy_id="S-ALLOC",
+        strategy_version="v1",
+        promotion_id=int(promotion_id),
+        rule_version=str(rule_version),
+        break_atr_multiple=Decimal("0.5"),
+        chandelier_atr_multiple=Decimal("3"),
+        structure_atr_multiple=Decimal("1.5"),
+        registered_by="test",
+        reason="separate promoted ratchet arm",
+    )
+    revision = configure_position_manager(
+        conn,
+        deployment_id=deployment_id,
+        max_position_age_seconds=None,
+        ratchet_variant_id=variant_id,
+        updated_by="test",
+        reason="enable only the registered arm",
+    )
+    assert revision == 2
+
+    conn.execute(
+        "UPDATE quotes SET bid=120, ask=121, last=120.5, quoted_at=%s WHERE instrument_id=2449001",
+        (_NOW,),
+    )
+    conn.commit()
+    broker.get_portfolio.return_value = BrokerPortfolio(
+        positions=(
+            _position(_POSITION_ID, stop=Decimal("95"), take=Decimal("110")),
+            manual,
+        ),
+        available_cash=Decimal("500"),
+        raw_payload={},
+    )
+    fired = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        ratchet_bar=RatchetBar(
+            completed_at=_NOW,
+            level_known_at=_NOW - timedelta(days=1),
+            close=Decimal("111"),
+            highest_close_since_entry=Decimal("114"),
+            atr=Decimal("4"),
+            broken_resistance=Decimal("108"),
+        ),
+        now=_NOW,
+    )
+    assert fired.state == "submitted"
+    assert broker.edit_demo_strategy_position.call_args.kwargs["stop_loss_rate"] == Decimal("102.000000")
+    assert conn.execute(
+        "SELECT operation_type, prior_stop_rate, desired_stop_rate FROM strategy_position_operations"
+    ).fetchone() == ("stop_ratchet", Decimal("95.000000"), Decimal("102.000000"))
+
+    with pytest.raises(StrategyPositionManagerError, match="backtest arm"):
+        register_ratchet_variant(
+            conn,
+            strategy_id="S-ALLOC",
+            strategy_version="v1",
+            promotion_id=int(promotion_id),
+            rule_version="unmeasured-rule",
+            break_atr_multiple=Decimal("0.5"),
+            chandelier_atr_multiple=Decimal("3"),
+            structure_atr_multiple=Decimal("1.5"),
+            registered_by="test",
+            reason="must fail",
+        )
+
+
+def test_exact_close_remains_available_under_kill_switch_and_reconciles(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, _, broker, manual = _opened_trade(conn, monkeypatch)
+    conn.execute("UPDATE kill_switch SET is_active=true WHERE id=true")
+    conn.commit()
+
+    submitted = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        close_reason="emergency_risk",
+        now=_NOW,
+    )
+    assert submitted.state == "submitted"
+    assert broker.close_demo_strategy_position.call_args.kwargs["position_id"] == _POSITION_ID
+
+    broker.get_demo_close_order.return_value = BrokerCloseOrderDetail(
+        broker_order_ref="24521234",
+        status="filled",
+        broker_status="1",
+        position_ids=(_POSITION_ID,),
+        reference_id=None,
+    )
+    broker.get_portfolio.return_value = BrokerPortfolio(
+        positions=(manual,), available_cash=Decimal("600"), raw_payload={}
+    )
+    applied = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        now=_NOW,
+    )
+    assert applied.state == "applied"
+    assert manual.position_id == _MANUAL_POSITION_ID
+    assert conn.execute(
+        "SELECT status, release_reason FROM strategy_position_ownership WHERE broker_position_id=%s",
+        (_POSITION_ID,),
+    ).fetchone() == ("released", "emergency_risk")
+    assert conn.execute("SELECT status FROM strategy_trades WHERE strategy_trade_id=%s", (trade_id,)).fetchone() == (
+        "closed",
+    )
+
+
+def test_configured_timeout_submits_an_exact_position_close(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, deployment_id, broker, _ = _opened_trade(conn, monkeypatch)
+    configure_position_manager(
+        conn,
+        deployment_id=deployment_id,
+        max_position_age_seconds=60,
+        ratchet_variant_id=None,
+        updated_by="test",
+        reason="short deterministic timeout",
+    )
+    conn.commit()
+
+    result = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        now=_NOW,
+    )
+
+    assert result.state == "submitted"
+    assert broker.close_demo_strategy_position.call_args.kwargs["position_id"] == _POSITION_ID
+    assert conn.execute("SELECT operation_type, trigger_code FROM strategy_position_operations").fetchone() == (
+        "close",
+        "timeout",
+    )
+
+
+def test_terminal_close_failure_can_be_retried_as_a_new_audited_intent(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, _, broker, _ = _opened_trade(conn, monkeypatch)
+    broker.close_demo_strategy_position.side_effect = [
+        BrokerPositionMutationError("temporary rejection"),
+        BrokerPositionCloseSubmission("24521235", _POSITION_ID),
+    ]
+
+    rejected = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        close_reason="emergency_risk",
+        now=_NOW,
+    )
+    retried = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        close_reason="emergency_risk",
+        now=_NOW + timedelta(seconds=1),
+    )
+
+    assert rejected.state == "rejected"
+    assert retried.state == "submitted"
+    assert broker.close_demo_strategy_position.call_count == 2
+    assert conn.execute(
+        "SELECT status FROM strategy_position_operations ORDER BY position_operation_id"
+    ).fetchall() == [("rejected",), ("submitted",)]
+
+
+def test_restart_with_unidentified_intent_fails_closed_without_retrying_broker_write(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, _, broker, _ = _opened_trade(conn, monkeypatch)
+    ownership_row = conn.execute(
+        "SELECT ownership_id FROM strategy_position_ownership WHERE broker_position_id=%s", (_POSITION_ID,)
+    ).fetchone()
+    assert ownership_row is not None
+    ownership_id = int(ownership_row[0])
+    conn.execute(
+        """
+        INSERT INTO strategy_position_operations (
+            ownership_id, operation_type, trigger_code, request_id, status,
+            prior_stop_rate, desired_stop_rate, desired_take_profit_rate
+        ) VALUES (%s,'fixed_exit_repair','entry_exit_gap',%s,'intent_persisted',NULL,95,110)
+        """,
+        (ownership_id, UUID("f95eab17-c3ac-4948-a281-d94fd1e2764b")),
+    )
+    conn.commit()
+
+    result = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        now=_NOW,
+    )
+
+    assert result.state == "reconcile_required"
+    broker.edit_demo_strategy_position.assert_not_called()
+    broker.close_demo_strategy_position.assert_not_called()
+    assert conn.execute("SELECT status FROM strategy_trades WHERE strategy_trade_id=%s", (trade_id,)).fetchone() == (
+        "reconcile_required",
+    )

--- a/tests/test_strategy_position_manager.py
+++ b/tests/test_strategy_position_manager.py
@@ -111,7 +111,7 @@ def _opened_trade(
         available_cash=Decimal("500"),
         raw_payload={},
     )
-    broker.edit_demo_strategy_position.return_value = BrokerPositionEditSubmission(
+    edit_submission = BrokerPositionEditSubmission(
         _EDIT_OPERATION_ID,
         _POSITION_ID,
         _REQUEST_ID,
@@ -121,11 +121,22 @@ def _opened_trade(
             "referenceId": str(_REQUEST_ID),
         },
     )
-    broker.close_demo_strategy_position.return_value = BrokerPositionCloseSubmission(
+    close_submission = BrokerPositionCloseSubmission(
         "24521234",
         _POSITION_ID,
         {"orderForClose": {"orderID": 24521234, "positionID": _POSITION_ID}},
     )
+
+    def _edit_position(**kwargs: Any) -> BrokerPositionEditSubmission:
+        kwargs["persist_response"](edit_submission.raw_payload)
+        return edit_submission
+
+    def _close_position(**kwargs: Any) -> BrokerPositionCloseSubmission:
+        kwargs["persist_response"](close_submission.raw_payload)
+        return close_submission
+
+    broker.edit_demo_strategy_position.side_effect = _edit_position
+    broker.close_demo_strategy_position.side_effect = _close_position
     return execution.strategy_trade_id, deployment_id, broker, manual
 
 
@@ -399,13 +410,16 @@ def test_exact_close_remains_available_under_kill_switch_and_reconciles(
     assert submitted.state == "submitted"
     assert broker.close_demo_strategy_position.call_args.kwargs["position_id"] == _POSITION_ID
 
-    broker.get_demo_close_order.return_value = BrokerCloseOrderDetail(
+    close_detail = BrokerCloseOrderDetail(
         broker_order_ref="24521234",
         status="filled",
         broker_status="1",
         position_ids=(_POSITION_ID,),
         reference_id=None,
         raw_payload={"orderID": 24521234, "statusID": 1, "positions": [{"positionID": _POSITION_ID}]},
+    )
+    broker.get_demo_close_order.side_effect = lambda **kwargs: (
+        kwargs["persist_response"](close_detail.raw_payload) or close_detail
     )
     broker.get_portfolio.return_value = BrokerPortfolio(
         positions=(manual,), available_cash=Decimal("600"), raw_payload={}

--- a/tests/test_strategy_position_manager.py
+++ b/tests/test_strategy_position_manager.py
@@ -112,9 +112,20 @@ def _opened_trade(
         raw_payload={},
     )
     broker.edit_demo_strategy_position.return_value = BrokerPositionEditSubmission(
-        _EDIT_OPERATION_ID, _POSITION_ID, _REQUEST_ID
+        _EDIT_OPERATION_ID,
+        _POSITION_ID,
+        _REQUEST_ID,
+        {
+            "operationId": str(_EDIT_OPERATION_ID),
+            "positionId": _POSITION_ID,
+            "referenceId": str(_REQUEST_ID),
+        },
     )
-    broker.close_demo_strategy_position.return_value = BrokerPositionCloseSubmission("24521234", _POSITION_ID)
+    broker.close_demo_strategy_position.return_value = BrokerPositionCloseSubmission(
+        "24521234",
+        _POSITION_ID,
+        {"orderForClose": {"orderID": 24521234, "positionID": _POSITION_ID}},
+    )
     return execution.strategy_trade_id, deployment_id, broker, manual
 
 
@@ -207,6 +218,9 @@ def test_fixed_exit_gap_is_repaired_once_and_manual_position_is_untouched(
     broker.edit_demo_strategy_position.assert_called_once()
     assert conn.execute("SELECT count(*) FROM strategy_position_operations").fetchone() == (1,)
     assert conn.execute("SELECT status FROM strategy_position_operations").fetchone() == ("applied",)
+    assert conn.execute("SELECT broker_response_json->>'operationId' FROM strategy_position_operations").fetchone() == (
+        str(_EDIT_OPERATION_ID),
+    )
 
 
 def test_rejected_patch_is_a_single_material_event_not_a_retry_heap(
@@ -391,6 +405,7 @@ def test_exact_close_remains_available_under_kill_switch_and_reconciles(
         broker_status="1",
         position_ids=(_POSITION_ID,),
         reference_id=None,
+        raw_payload={"orderID": 24521234, "statusID": 1, "positions": [{"positionID": _POSITION_ID}]},
     )
     broker.get_portfolio.return_value = BrokerPortfolio(
         positions=(manual,), available_cash=Decimal("600"), raw_payload={}
@@ -410,6 +425,13 @@ def test_exact_close_remains_available_under_kill_switch_and_reconciles(
     ).fetchone() == ("released", "emergency_risk")
     assert conn.execute("SELECT status FROM strategy_trades WHERE strategy_trade_id=%s", (trade_id,)).fetchone() == (
         "closed",
+    )
+    assert conn.execute(
+        "SELECT raw_payload_json->'orderForClose'->>'positionID' FROM orders "
+        "WHERE execution_origin='strategy' AND action='EXIT'"
+    ).fetchone() == (str(_POSITION_ID),)
+    assert conn.execute("SELECT broker_response_json->>'orderID' FROM strategy_position_operations").fetchone() == (
+        "24521234",
     )
 
 
@@ -451,7 +473,11 @@ def test_terminal_close_failure_can_be_retried_as_a_new_audited_intent(
     trade_id, _, broker, _ = _opened_trade(conn, monkeypatch)
     broker.close_demo_strategy_position.side_effect = [
         BrokerPositionMutationError("temporary rejection"),
-        BrokerPositionCloseSubmission("24521235", _POSITION_ID),
+        BrokerPositionCloseSubmission(
+            "24521235",
+            _POSITION_ID,
+            {"orderForClose": {"orderID": 24521235, "positionID": _POSITION_ID}},
+        ),
     ]
 
     rejected = manage_owned_position(


### PR DESCRIPTION
Closes #2452
Parent: #2437

## Outcome

Adds the demo-only exact-position manager for strategy-owned trades. The manager repairs missing entry exits, applies only registered/promoted causal stop ratchets, performs timeout/strategy/emergency closes, and reconciles asynchronous broker results before releasing ownership.

## Safety boundaries

- Requires the exact `(strategy_trade_id, broker_position_id)` ownership tuple before broker I/O; same-instrument manual positions remain observational only.
- Refuses real credentials in the eToro mutation adapter.
- Persists immutable request identity before broker I/O and fails closed after uncertain or unidentified outcomes.
- Keeps risk reduction usable when entry kill switches are active.
- Treats PATCH 202 as submitted, not applied, and closes ownership only after exact close-detail proof.
- Never worsens a stop; ratchets require a separately registered 2022+ hold-out backtest arm and causal completed-bar inputs.

## Database footprint

Migration 289 adds four narrowly scoped tables for immutable ratchet variants, current policy plus bounded audit events, and material position operations. Unchanged bars, portfolio polls, and raw broker payloads create no rows. The empty schema measures 128 KiB including indexes.

## Verification

- Codex independent review completed; fixed both findings (BIGINT-safe advisory lock and retryable terminal close attempts).
- Focused strategy/provider suite: 119 passed.
- Ruff, formatting, pyright, migration integrity, and diff checks passed.
- Full repository pre-push gate passed, including fast tests, smoke tests, retention/invariant lints, and frontend integrity checks.
