### PR TITLE
feat(#2437): expose exact strategy P&L and allocation controls

### DIFF
--- a/.claude/skills/frontend/ta-operator-surface.md
+++ b/.claude/skills/frontend/ta-operator-surface.md
@@ -93,15 +93,15 @@ column; if it has no column, it does not ship. Verify column names against
 
 | Operator-facing name | Backed by | Gate 2 — why it earns its place |
 | --- | --- | --- |
-| **Made you** | position P&L, `gross_return_pct` net of `cost_model` | the only figure most sessions need |
+| **Made you** | actual strategy arm: exact-owned `trade_events.realized_pnl_usd` + active owned mark-to-market; shadow arm: `strategy_outcomes.gross_return_pct` (gross, labelled shadow) | the only figure most sessions need; actual and shadow are never pooled |
 | **Worst dip** | `max_drawdown_pct` | what the operator *feels*; a strategy can end up and have halved on the way |
 | **Success rate** | `trade_count − losing_trade_count` over `trade_count` | "how often did it work" — the question actually asked |
 | **Per trade** | `expectancy_per_trade_pct` | decides whether it makes money at all; pair with success rate, never alone |
 | **vs buy &amp; hold** | `return_vs_buy_and_hold_pct` | the catalogue's own bar: fail it and it is not a strategy |
 | **Money working** | `exposure_time_pct` | answers "is my cash idle" |
 | **Turnaround** | `bars_held`, or `periods_per_year ÷ turnover_annualised` | half the return calculation — a fast small edge beats a slow big one |
-| **Captured** | `strategy_signals.verdict` funded ÷ fired | the missed-opportunity number |
-| **Why skipped** | `verdict` + `not_evaluable_reason` | tells the operator which lever to pull (pot size vs strategy choice) |
+| **Captured** | allocated `strategy_funding_decisions` ÷ fired entry `strategy_signals` | the missed-opportunity number; a missing legacy decision is not funded/not evaluated |
+| **Why skipped** | `strategy_funding_decisions.reason_code` (or explicit missing-decision state) | tells the operator which lever to pull (pot size vs strategy choice) |
 | **Confidence** | `deflated_sharpe` vs its threshold | one bar against one line; never the four DSR inputs on the surface |
 | Profit factor | `profit_factor` | drill-through — duplicates success rate + per trade for most readers |
 | Sharpe / Sortino / ESS / deff / block length / trial count | the DSR + bootstrap columns | **drill-through only.** These are how we know, not what we know |

--- a/.claude/skills/portfolio-manager/SKILL.md
+++ b/.claude/skills/portfolio-manager/SKILL.md
@@ -129,6 +129,12 @@ must not share an inference shortcut:
 - missing close history, ownership reconciliation, current broker position or
   positive mark is `None` with a reason, never a zero-P&L fallback.
 
+Completeness follows the whole funded ownership chain, not only the arithmetic
+arm that happens to read the missing row. If an allocated decision has no trade
+or ownership reconciliation, realised P&L, unrealised P&L, invested capital,
+total P&L and observed fees are all unknown; none may silently retain its zero
+accumulator.
+
 The canonical formulas and database budget are in
 `docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md`. The read model
 must remain write-free: a price movement or page refresh does not justify a P&L

--- a/.claude/skills/portfolio-manager/SKILL.md
+++ b/.claude/skills/portfolio-manager/SKILL.md
@@ -16,6 +16,9 @@ paths, or the review job
 `morning_candidate_review`, `app/jobs/runtime.py:294`). Also read it before
 changing a policy cap or how a score/thesis feeds an action.
 
+Also read the attribution boundary below before changing strategy-only P&L or
+joining automated positions into an operator surface.
+
 ## What it is
 
 `run_portfolio_review(conn, model_version=None)` is the one entry point:
@@ -110,3 +113,23 @@ Policy constants (single source of truth for `docs/trading-policy.md`; `portfoli
   insufficient-data HOLD cap, a CONSIDERED row with its block reason — **never
   paper over them with a neutral default**. `run_portfolio_review` does not raise
   on partial data: the affected name is held or blocked, reason in its rationale.
+
+## Managed-strategy attribution boundary (#2453)
+
+The account portfolio and managed-strategy P&L answer different questions and
+must not share an inference shortcut:
+
+- account-wide portfolio = manual + automated positions;
+- strategy P&L = exact `strategy_position_ownership.broker_position_id` joined
+  to broker history/current position state;
+- instrument, symbol, time, FIFO or order proximity is never ownership;
+- realised P&L is broker `trade_events.realized_pnl_usd` for exact owned close
+  events; unrealised P&L is the active exact position marked with the standard
+  positive quote/daily hierarchy; and
+- missing close history, ownership reconciliation, current broker position or
+  positive mark is `None` with a reason, never a zero-P&L fallback.
+
+The canonical formulas and database budget are in
+`docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md`. The read model
+must remain write-free: a price movement or page refresh does not justify a P&L
+snapshot row.

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -24,6 +24,7 @@ from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERS
 from app.services.strategy_control_plane import (
     StrategyControlError,
     configure_deployment,
+    is_risk_reducing_deployment_change,
     lock_strategy_control,
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST
@@ -158,7 +159,7 @@ class StrategyPnlView(BaseModel):
 class StrategyAllocationView(BaseModel):
     deployment_id: int | None
     capital_limit: Decimal
-    currency: Literal["USD"] = "USD"
+    currency: str
     enabled: bool
     revision: int | None
     reserved_capital: Decimal
@@ -235,7 +236,7 @@ class AllocationUpdateResponse(BaseModel):
     strategy_version: str
     deployment_id: int
     capital_limit: Decimal
-    currency: Literal["USD"] = "USD"
+    currency: str
     enabled: bool
     revision: int
 
@@ -545,6 +546,7 @@ def get_strategy_overview(
                 allocation=StrategyAllocationView(
                     deployment_id=control.deployment_id,
                     capital_limit=control.capital_limit,
+                    currency=control.currency,
                     enabled=control.enabled,
                     revision=control.revision,
                     reserved_capital=control.reserved_capital,
@@ -680,10 +682,13 @@ def update_strategy_allocation(
             lock_strategy_control(conn, strategy_id, current_version)
             overview = get_strategy_overview(conn)
             row = next(item for item in overview.strategies if item.strategy_id == strategy_id)
-            risk_reducing = (
-                row.allocation.deployment_id is not None
-                and body.capital_limit <= row.allocation.capital_limit
-                and (not body.enabled or row.allocation.enabled)
+            risk_reducing = row.allocation.deployment_id is not None and is_risk_reducing_deployment_change(
+                current_capital_limit=row.allocation.capital_limit,
+                current_enabled=row.allocation.enabled,
+                current_currency=row.allocation.currency,
+                capital_limit=body.capital_limit,
+                enabled=body.enabled,
+                currency=row.allocation.currency,
             )
             if not row.allocation_ready and not risk_reducing:
                 raise HTTPException(
@@ -702,7 +707,7 @@ def update_strategy_allocation(
                 enabled=body.enabled,
                 changed_by=session.username,
                 reason=body.reason,
-                currency="USD",
+                currency=row.allocation.currency,
             )
     except StrategyControlError as exc:
         raise HTTPException(status_code=409, detail="allocation update refused") from exc
@@ -711,6 +716,7 @@ def update_strategy_allocation(
         strategy_version=current_version,
         deployment_id=deployment.deployment_id,
         capital_limit=deployment.capital_limit,
+        currency=row.allocation.currency,
         enabled=deployment.enabled,
         revision=deployment.revision,
     )

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -681,9 +681,9 @@ def update_strategy_allocation(
             overview = get_strategy_overview(conn)
             row = next(item for item in overview.strategies if item.strategy_id == strategy_id)
             risk_reducing = (
-                not body.enabled
-                and row.allocation.deployment_id is not None
+                row.allocation.deployment_id is not None
                 and body.capital_limit <= row.allocation.capital_limit
+                and (not body.enabled or row.allocation.enabled)
             )
             if not row.allocation_ready and not risk_reducing:
                 raise HTTPException(

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1,10 +1,4 @@
-"""Read-only strategy evidence and fired-signal monitoring (#2447).
-
-This surface intentionally has no mutation route.  It reports the current
-manifest denominator, exact-version recent evidence, scan health, and every
-fired signal whether or not capital was available.  Allocation and execution
-remain disabled until later tickets add ownership-safe broker reconciliation.
-"""
+"""Strategy evidence, exact-owned P&L, attribution and allocation (#2447/#2453)."""
 
 from __future__ import annotations
 
@@ -15,18 +9,33 @@ from typing import Literal, cast
 
 import psycopg
 import psycopg.rows
-from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, model_validator
 
-from app.api.auth import require_session_or_service_token
+from app.api.auth import require_session, require_session_or_service_token
 from app.db import get_conn
+from app.security.sessions import SessionRow
 from app.services.backtest_run import BACKTEST_UNIVERSE, runnable_strategies
 from app.services.cost_model import COST_MODEL_ID
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_control_plane import (
+    StrategyControlError,
+    configure_deployment,
+    lock_strategy_control,
+)
 from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_monitoring import (
+    StrategyAttribution,
+    StrategyControlState,
+    StrategyPnl,
+    load_attribution,
+    load_control_state,
+    load_entry_block_state,
+    load_owned_pnl,
+)
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_result import CORPUS_VERSION
 
@@ -104,15 +113,76 @@ class StrategyOverview(BaseModel):
     evidence_windows: list[EvidenceWindow]
     legacy_result_count: int
     all_recent_evidence_complete: bool
-    allocation_ready: bool = False
+    stage: str | None
+    attribution: StrategyAttributionView
+    pnl: StrategyPnlView
+    allocation: StrategyAllocationView
+    allocation_ready: bool
     allocation_refusals: list[str]
+
+
+class StrategyAttributionView(BaseModel):
+    fired_entries: int
+    funded_entries: int
+    rejected_entries: int
+    resolved_entries: int
+    shadow_average_return_pct: Decimal | None
+    funded_shadow_average_return_pct: Decimal | None
+    rejected_shadow_average_return_pct: Decimal | None
+    opportunity_gap_pct: Decimal | None
+    funded_capture_rate: Decimal | None
+    filled_entries: int
+    broker_rejected_entries: int
+    fill_rate: Decimal | None
+    broker_rejection_rate: Decimal | None
+    average_slippage_pct: Decimal | None
+    average_stressed_cost_usd: Decimal | None
+    max_observed_account_drawdown_pct: Decimal | None
+
+
+class StrategyPnlView(BaseModel):
+    currency: Literal["USD"] = "USD"
+    strategy_trade_count: int
+    owned_position_count: int
+    active_position_count: int
+    close_event_count: int
+    invested_capital: Decimal | None
+    realised_pnl: Decimal | None
+    unrealised_pnl: Decimal | None
+    total_pnl: Decimal | None
+    observed_fees: Decimal | None
+    complete: bool
+    incomplete_reasons: list[str]
+
+
+class StrategyAllocationView(BaseModel):
+    deployment_id: int | None
+    capital_limit: Decimal
+    currency: Literal["USD"] = "USD"
+    enabled: bool
+    revision: int | None
+    reserved_capital: Decimal
+    invested_capital: Decimal | None
+    remaining_capital: Decimal
+    policy_configured: bool
+    max_drawdown_limit_pct: Decimal | None
+
+
+class StrategyEntryBlockView(BaseModel):
+    new_entries_blocked: bool
+    global_kill_active: bool
+    global_kill_reason: str | None
+    global_kill_activated_at: datetime | None
+    global_kill_activated_by: str | None
+    execution_block_reasons: list[str]
 
 
 class StrategyOverviewResponse(BaseModel):
     as_of: datetime
-    observation_stage: Literal["forward_observation"] = "forward_observation"
-    execution_enabled: bool = False
-    storage_policy: str = "aggregate_results_only"
+    execution_enabled: bool
+    live_execution_enabled: bool
+    storage_policy: Literal["fired_signals_and_material_mutations_only"] = "fired_signals_and_material_mutations_only"
+    entry_block: StrategyEntryBlockView
     strategies: list[StrategyOverview]
 
 
@@ -133,14 +203,41 @@ class FiredSignal(BaseModel):
     exit_price: Decimal | None
     gross_return_pct: Decimal | None
     outcome_reason: str | None
-    observation_stage: Literal["forward_observation"] = "forward_observation"
-    funding_status: Literal["unfunded"] = "unfunded"
-    funding_reason: Literal["execution_not_enabled"] = "execution_not_enabled"
+    funding_status: Literal["funded", "rejected", "not_applicable"]
+    funding_reason: str
+    funded_amount: Decimal | None
+    strategy_trade_id: int | None
+    execution_status: str | None
+    actual_fill_price: Decimal | None
+    slippage_pct: Decimal | None
 
 
 class FiredSignalsResponse(BaseModel):
     items: list[FiredSignal]
     next_cursor: int | None
+
+
+class AllocationUpdateRequest(BaseModel):
+    strategy_version: str = Field(min_length=1, max_length=200)
+    capital_limit: Decimal = Field(ge=0, max_digits=18, decimal_places=6)
+    enabled: bool
+    reason: str = Field(min_length=1, max_length=1000)
+
+    @model_validator(mode="after")
+    def enabled_requires_capital(self) -> AllocationUpdateRequest:
+        if self.enabled and self.capital_limit <= 0:
+            raise ValueError("enabled allocation requires positive capital")
+        return self
+
+
+class AllocationUpdateResponse(BaseModel):
+    strategy_id: str
+    strategy_version: str
+    deployment_id: int
+    capital_limit: Decimal
+    currency: Literal["USD"] = "USD"
+    enabled: bool
+    revision: int
 
 
 def _current_versions() -> dict[str, str]:
@@ -269,8 +366,9 @@ def get_strategy_overview(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> StrategyOverviewResponse:
     versions = _current_versions()
+    version_values = list(versions.values())
     params = {
-        "versions": list(versions.values()),
+        "versions": version_values,
         "corpus_version": CORPUS_VERSION,
         "cost_model_id": COST_MODEL_ID,
         "sizing_rule": SIZING_RULE_ID,
@@ -291,6 +389,16 @@ def get_strategy_overview(
         cur.execute(_LATEST_CORPUS_SQL)
         latest_row = cur.fetchone()
         latest_corpus_date = None if latest_row is None else latest_row["max"]
+
+    attribution_by_strategy = load_attribution(
+        conn,
+        versions=version_values,
+        outcome_version=OUTCOME_RULE_SET_VERSION,
+        input_version=QUARANTINE_RULE_SET_VERSION,
+    )
+    pnl_by_strategy = load_owned_pnl(conn, versions=version_values)
+    control_by_strategy = load_control_state(conn, versions=version_values)
+    entry_block = load_entry_block_state(conn)
 
     results_by_strategy: dict[str, list[dict[str, object]]] = defaultdict(list)
     for row in result_rows:
@@ -382,11 +490,39 @@ def get_strategy_overview(
             exclusions_by_reason=dict(exclusions[strategy_id]),
         )
         all_complete = all(window.status == "complete" for window in windows)
-        allocation_refusals = ["execution_not_enabled", "broker_cost_unknown"]
+        evidence_refused = any(arm.promotion_refusals for window in windows for arm in window.arms)
+        evidence_not_positive = (
+            any(
+                arm.expectancy_ci_low_pct is None or arm.expectancy_ci_low_pct <= 0
+                for window in windows
+                for arm in window.arms
+            )
+            or not windows
+        )
+        key = (strategy_id, versions[strategy_id])
+        attribution = attribution_by_strategy.get(key, StrategyAttribution())
+        pnl = pnl_by_strategy.get(key, StrategyPnl())
+        control = control_by_strategy.get(key, StrategyControlState())
+        allocation_refusals: list[str] = []
         if strategy_id not in runnable:
             allocation_refusals.append("strategy_not_runnable")
         if not all_complete:
             allocation_refusals.append("recent_evidence_incomplete")
+        if evidence_refused:
+            allocation_refusals.append("recent_evidence_gate_refused")
+        if evidence_not_positive:
+            allocation_refusals.append("recent_net_expectancy_not_positive")
+        if control.stage not in {"paper_enabled", "live_enabled"}:
+            allocation_refusals.append("paper_promotion_missing")
+        if not control.pinned_evidence_ready:
+            allocation_refusals.append("pinned_promotion_evidence_invalid")
+        if not control.policy_configured:
+            allocation_refusals.append("execution_policy_missing")
+        if scan.status != "current":
+            allocation_refusals.append("scan_not_current")
+        if control.currency != "USD":
+            allocation_refusals.append("deployment_currency_unsupported")
+        remaining = max(control.capital_limit - control.reserved_capital, Decimal("0"))
         strategies.append(
             StrategyOverview(
                 strategy_id=strategy_id,
@@ -398,25 +534,96 @@ def get_strategy_overview(
                 evidence_windows=windows,
                 legacy_result_count=result_counts.get(strategy_id, 0) - sum(len(rows) for rows in exact.values()),
                 all_recent_evidence_complete=all_complete,
+                stage=control.stage,
+                attribution=StrategyAttributionView(**attribution.__dict__),
+                pnl=StrategyPnlView(
+                    **{
+                        **pnl.__dict__,
+                        "incomplete_reasons": list(pnl.incomplete_reasons),
+                    }
+                ),
+                allocation=StrategyAllocationView(
+                    deployment_id=control.deployment_id,
+                    capital_limit=control.capital_limit,
+                    enabled=control.enabled,
+                    revision=control.revision,
+                    reserved_capital=control.reserved_capital,
+                    invested_capital=pnl.invested_capital,
+                    remaining_capital=remaining,
+                    policy_configured=control.policy_configured,
+                    max_drawdown_limit_pct=control.max_drawdown_limit_pct,
+                ),
+                allocation_ready=not allocation_refusals,
                 allocation_refusals=allocation_refusals,
             )
         )
-    return StrategyOverviewResponse(as_of=datetime.now(tz=UTC), strategies=strategies)
+    return StrategyOverviewResponse(
+        as_of=datetime.now(tz=UTC),
+        execution_enabled=entry_block.auto_trading_enabled,
+        live_execution_enabled=entry_block.live_trading_enabled,
+        entry_block=StrategyEntryBlockView(
+            new_entries_blocked=entry_block.new_entries_blocked,
+            global_kill_active=entry_block.global_kill_active,
+            global_kill_reason=entry_block.global_kill_reason,
+            global_kill_activated_at=entry_block.global_kill_activated_at,
+            global_kill_activated_by=entry_block.global_kill_activated_by,
+            execution_block_reasons=list(entry_block.execution_block_reasons),
+        ),
+        strategies=strategies,
+    )
 
 
 _FIRED_SIGNALS_SQL = """
+    WITH entry_execution AS (
+        SELECT sto.strategy_trade_id,
+               SUM(e.opening_units * e.average_price)
+                   / NULLIF(SUM(e.opening_units), 0) AS average_price
+        FROM strategy_trade_orders sto
+        JOIN strategy_order_position_executions e ON e.order_id = sto.order_id
+        WHERE sto.purpose = 'entry'
+          AND e.opening_units > 0 AND e.average_price > 0
+        GROUP BY sto.strategy_trade_id
+    ), entry_order AS (
+        SELECT DISTINCT ON (sto.strategy_trade_id)
+               sto.strategy_trade_id, ord.status
+        FROM strategy_trade_orders sto
+        JOIN orders ord ON ord.order_id = sto.order_id
+        WHERE sto.purpose = 'entry'
+        ORDER BY sto.strategy_trade_id, sto.linked_at DESC, sto.order_id DESC
+    )
     SELECT
         s.signal_id, s.strategy_id, s.strategy_version, s.instrument_id,
         i.symbol, i.company_name, s.signal_bar_date, s.signal_kind,
         s.fill_bar_date, s.fill_price, s.universe,
         o.outcome, o.exit_bar_date, o.exit_price, o.gross_return_pct,
-        o.reason AS outcome_reason
+        o.reason AS outcome_reason,
+        CASE
+            WHEN s.signal_kind <> 'entry' THEN 'not_applicable'
+            WHEN fd.verdict = 'allocated' THEN 'funded'
+            ELSE 'rejected'
+        END AS funding_status,
+        CASE
+            WHEN s.signal_kind <> 'entry' THEN 'capital_not_required_for_exit'
+            ELSE COALESCE(fd.reason_code, 'not_evaluated_by_allocator')
+        END AS funding_reason,
+        fd.amount AS funded_amount,
+        t.strategy_trade_id,
+        CASE
+            WHEN ee.average_price IS NOT NULL THEN 'filled'
+            ELSE COALESCE(eo.status, t.status)
+        END AS execution_status,
+        ee.average_price AS actual_fill_price,
+        ((ee.average_price - s.fill_price) / NULLIF(s.fill_price, 0)) * 100 AS slippage_pct
     FROM strategy_signals s
     JOIN instruments i ON i.instrument_id = s.instrument_id
     LEFT JOIN strategy_outcomes o
       ON o.signal_id = s.signal_id
      AND o.rule_set_version = %(outcome_version)s
      AND o.input_rule_set_version = %(input_version)s
+    LEFT JOIN strategy_funding_decisions fd ON fd.signal_id = s.signal_id
+    LEFT JOIN strategy_trades t ON t.funding_decision_id = fd.funding_decision_id
+    LEFT JOIN entry_execution ee ON ee.strategy_trade_id = t.strategy_trade_id
+    LEFT JOIN entry_order eo ON eo.strategy_trade_id = t.strategy_trade_id
     WHERE s.verdict = 'fired'
       AND s.strategy_version = ANY(%(versions)s)
       AND (%(cursor)s::bigint IS NULL OR s.signal_id < %(cursor)s)
@@ -443,6 +650,70 @@ def get_fired_signals(
         rows = list(cur.fetchall())
     items = [FiredSignal(**row) for row in rows]
     return FiredSignalsResponse(items=items, next_cursor=items[-1].signal_id if len(items) == limit else None)
+
+
+@router.put(
+    "/{strategy_id}/allocation",
+    response_model=AllocationUpdateResponse,
+    status_code=status.HTTP_200_OK,
+)
+def update_strategy_allocation(
+    strategy_id: str,
+    body: AllocationUpdateRequest,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> AllocationUpdateResponse:
+    """Apply one operator-authenticated paper capital ceiling revision.
+
+    Evidence-invalid strategies may only move toward safety by disabling and
+    not increasing their existing ceiling.  The service appends the immutable
+    deployment event in the same transaction as the current-state update.
+    """
+    current_version = _current_versions().get(strategy_id)
+    if current_version is None:
+        raise HTTPException(status_code=404, detail="strategy not found")
+    if body.strategy_version != current_version:
+        raise HTTPException(status_code=409, detail="strategy version changed; refresh required")
+
+    try:
+        with conn.transaction():
+            lock_strategy_control(conn, strategy_id, current_version)
+            overview = get_strategy_overview(conn)
+            row = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+            risk_reducing = (
+                not body.enabled
+                and row.allocation.deployment_id is not None
+                and body.capital_limit <= row.allocation.capital_limit
+            )
+            if not row.allocation_ready and not risk_reducing:
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "reason": "allocation_unavailable",
+                        "refusals": row.allocation_refusals,
+                    },
+                )
+            deployment = configure_deployment(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=current_version,
+                mode="paper",
+                capital_limit=body.capital_limit,
+                enabled=body.enabled,
+                changed_by=session.username,
+                reason=body.reason,
+                currency="USD",
+            )
+    except StrategyControlError as exc:
+        raise HTTPException(status_code=409, detail="allocation update refused") from exc
+    return AllocationUpdateResponse(
+        strategy_id=strategy_id,
+        strategy_version=current_version,
+        deployment_id=deployment.deployment_id,
+        capital_limit=deployment.capital_limit,
+        enabled=deployment.enabled,
+        revision=deployment.revision,
+    )
 
 
 __all__ = ["router"]

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -250,22 +250,27 @@ def configure_deployment(
 
     _lock_strategy(conn, strategy_id, strategy_version)
     stage = current_stage(conn, strategy_id, strategy_version)
-    eligible: dict[Mode, frozenset[Stage]] = {
-        "paper": frozenset({"paper_enabled", "live_enabled"}),
-        "live": frozenset({"live_enabled"}),
-    }
-    if enabled and stage not in eligible[mode]:
-        raise StrategyControlError(f"{mode} deployment cannot be enabled at stage {stage!r}")
-
     existing = conn.execute(
         """
-        SELECT deployment_id, revision
+        SELECT deployment_id, revision, capital_limit, enabled, currency
         FROM strategy_deployments
         WHERE strategy_id = %s AND strategy_version = %s AND mode = %s
         FOR UPDATE
         """,
         (strategy_id, strategy_version, mode),
     ).fetchone()
+    risk_reducing = (
+        existing is not None
+        and capital_limit <= Decimal(str(existing[2]))
+        and (not enabled or bool(existing[3]))
+        and currency == str(existing[4])
+    )
+    eligible: dict[Mode, frozenset[Stage]] = {
+        "paper": frozenset({"paper_enabled", "live_enabled"}),
+        "live": frozenset({"live_enabled"}),
+    }
+    if enabled and stage not in eligible[mode] and not risk_reducing:
+        raise StrategyControlError(f"{mode} deployment cannot be enabled at stage {stage!r}")
     if existing is None:
         revision = 1
         row = conn.execute(

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -119,6 +119,19 @@ def lock_strategy_control(conn: psycopg.Connection[Any], strategy_id: str, strat
     _lock_strategy(conn, strategy_id, strategy_version)
 
 
+def is_risk_reducing_deployment_change(
+    *,
+    current_capital_limit: Decimal,
+    current_enabled: bool,
+    current_currency: str,
+    capital_limit: Decimal,
+    enabled: bool,
+    currency: str,
+) -> bool:
+    """Return whether a deployment change cannot add capital authority."""
+    return capital_limit <= current_capital_limit and (not enabled or current_enabled) and currency == current_currency
+
+
 def current_stage(conn: psycopg.Connection[Any], strategy_id: str, strategy_version: str) -> Stage | None:
     row = conn.execute(
         """
@@ -259,11 +272,13 @@ def configure_deployment(
         """,
         (strategy_id, strategy_version, mode),
     ).fetchone()
-    risk_reducing = (
-        existing is not None
-        and capital_limit <= Decimal(str(existing[2]))
-        and (not enabled or bool(existing[3]))
-        and currency == str(existing[4])
+    risk_reducing = existing is not None and is_risk_reducing_deployment_change(
+        current_capital_limit=Decimal(str(existing[2])),
+        current_enabled=bool(existing[3]),
+        current_currency=str(existing[4]),
+        capital_limit=capital_limit,
+        enabled=enabled,
+        currency=currency,
     )
     eligible: dict[Mode, frozenset[Stage]] = {
         "paper": frozenset({"paper_enabled", "live_enabled"}),
@@ -725,6 +740,7 @@ __all__ = [
     "create_strategy_trade",
     "current_stage",
     "decide_funding",
+    "is_risk_reducing_deployment_change",
     "link_strategy_order",
     "lock_strategy_control",
     "promote_strategy",

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -109,6 +109,16 @@ def _lock_strategy(conn: psycopg.Connection[Any], strategy_id: str, strategy_ver
     )
 
 
+def lock_strategy_control(conn: psycopg.Connection[Any], strategy_id: str, strategy_version: str) -> None:
+    """Serialize a compound governance read/write with promotion changes.
+
+    Callers that must evaluate evidence before invoking a control-plane
+    mutation acquire this transaction lock first.  The internal mutation lock
+    is re-entrant within the same transaction.
+    """
+    _lock_strategy(conn, strategy_id, strategy_version)
+
+
 def current_stage(conn: psycopg.Connection[Any], strategy_id: str, strategy_version: str) -> Stage | None:
     row = conn.execute(
         """
@@ -711,6 +721,7 @@ __all__ = [
     "current_stage",
     "decide_funding",
     "link_strategy_order",
+    "lock_strategy_control",
     "promote_strategy",
     "record_order_position_execution",
     "release_exact_position",

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -83,7 +83,7 @@ class StrategyEntryBlockState:
 
     @property
     def new_entries_blocked(self) -> bool:
-        return self.global_kill_active or bool(self.execution_block_reasons)
+        return self.global_kill_active or bool(self.execution_block_reasons) or not self.auto_trading_enabled
 
 
 _ATTRIBUTION_SQL = """
@@ -447,6 +447,8 @@ def load_entry_block_state(conn: psycopg.Connection[Any]) -> StrategyEntryBlockS
         return StrategyEntryBlockState(True, "kill switch state unavailable", None, None, blocks, False, False)
     if runtime is None:
         blocks = (*blocks, "runtime configuration unavailable")
+    elif not bool(runtime["enable_auto_trading"]):
+        blocks = (*blocks, "automatic trading disabled")
     return StrategyEntryBlockState(
         global_kill_active=bool(kill["is_active"]),
         global_kill_reason=str(kill["reason"]) if kill["reason"] is not None else None,

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -304,6 +304,8 @@ def load_owned_pnl(conn: psycopg.Connection[Any], *, versions: Sequence[str]) ->
             unrealised += direction * units * (mark - open_rate) * conversion
 
         realised_known = not {
+            "funding_not_reconciled_to_trade",
+            "trade_not_reconciled_to_position",
             "realised_pnl_missing_from_history",
             "released_position_missing_close_history",
         }.intersection(reasons)
@@ -318,7 +320,12 @@ def load_owned_pnl(conn: psycopg.Connection[Any], *, versions: Sequence[str]) ->
             "trade_not_reconciled_to_position",
             "active_position_missing_from_broker_snapshot",
         }.intersection(reasons)
-        fees_known = "fees_missing_from_history" not in reasons
+        fees_known = not {
+            "funding_not_reconciled_to_trade",
+            "trade_not_reconciled_to_position",
+            "released_position_missing_close_history",
+            "fees_missing_from_history",
+        }.intersection(reasons)
         realised_value = realised if realised_known else None
         unrealised_value = unrealised if unrealised_known else None
         result[key] = StrategyPnl(

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -1,0 +1,463 @@
+"""Read models for strategy attribution and exact-owned P&L (#2453).
+
+The strategy surface deliberately derives from existing compact ledgers.  It
+does not snapshot quotes, copy broker payloads, or write periodic P&L rows.
+Manual positions are excluded structurally: a broker position contributes only
+when its exact id is present in ``strategy_position_ownership``.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+from app.services.valuation import resolve_quote_price
+
+
+@dataclass(frozen=True)
+class StrategyAttribution:
+    fired_entries: int = 0
+    funded_entries: int = 0
+    rejected_entries: int = 0
+    resolved_entries: int = 0
+    shadow_average_return_pct: Decimal | None = None
+    funded_shadow_average_return_pct: Decimal | None = None
+    rejected_shadow_average_return_pct: Decimal | None = None
+    opportunity_gap_pct: Decimal | None = None
+    funded_capture_rate: Decimal | None = None
+    filled_entries: int = 0
+    broker_rejected_entries: int = 0
+    fill_rate: Decimal | None = None
+    broker_rejection_rate: Decimal | None = None
+    average_slippage_pct: Decimal | None = None
+    average_stressed_cost_usd: Decimal | None = None
+    max_observed_account_drawdown_pct: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class StrategyPnl:
+    currency: str = "USD"
+    strategy_trade_count: int = 0
+    owned_position_count: int = 0
+    active_position_count: int = 0
+    close_event_count: int = 0
+    invested_capital: Decimal | None = Decimal("0")
+    realised_pnl: Decimal | None = Decimal("0")
+    unrealised_pnl: Decimal | None = Decimal("0")
+    total_pnl: Decimal | None = Decimal("0")
+    observed_fees: Decimal | None = Decimal("0")
+    complete: bool = True
+    incomplete_reasons: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class StrategyControlState:
+    stage: str | None = None
+    pinned_evidence_ready: bool = False
+    deployment_id: int | None = None
+    capital_limit: Decimal = Decimal("0")
+    currency: str = "USD"
+    enabled: bool = False
+    revision: int | None = None
+    reserved_capital: Decimal = Decimal("0")
+    policy_configured: bool = False
+    max_drawdown_limit_pct: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class StrategyEntryBlockState:
+    global_kill_active: bool
+    global_kill_reason: str | None
+    global_kill_activated_at: datetime | None
+    global_kill_activated_by: str | None
+    execution_block_reasons: tuple[str, ...]
+    auto_trading_enabled: bool
+    live_trading_enabled: bool
+
+    @property
+    def new_entries_blocked(self) -> bool:
+        return self.global_kill_active or bool(self.execution_block_reasons)
+
+
+_ATTRIBUTION_SQL = """
+    WITH entry_execution AS (
+        SELECT sto.strategy_trade_id,
+               SUM(e.opening_units * e.average_price)
+                   / NULLIF(SUM(e.opening_units), 0) AS average_price
+        FROM strategy_trade_orders sto
+        JOIN strategy_order_position_executions e ON e.order_id = sto.order_id
+        WHERE sto.purpose = 'entry'
+          AND e.opening_units > 0 AND e.average_price > 0
+        GROUP BY sto.strategy_trade_id
+    ), entry_order AS (
+        SELECT DISTINCT ON (sto.strategy_trade_id)
+               sto.strategy_trade_id, o.status
+        FROM strategy_trade_orders sto
+        JOIN orders o ON o.order_id = sto.order_id
+        WHERE sto.purpose = 'entry'
+        ORDER BY sto.strategy_trade_id, sto.linked_at DESC, sto.order_id DESC
+    )
+    SELECT s.strategy_id, s.strategy_version,
+           COUNT(*) AS fired_entries,
+           COUNT(*) FILTER (WHERE fd.verdict = 'allocated') AS funded_entries,
+           COUNT(*) FILTER (WHERE fd.verdict IS DISTINCT FROM 'allocated') AS rejected_entries,
+           COUNT(*) FILTER (WHERE o.gross_return_pct IS NOT NULL) AS resolved_entries,
+           AVG(o.gross_return_pct) AS shadow_average_return_pct,
+           AVG(o.gross_return_pct) FILTER (WHERE fd.verdict = 'allocated')
+               AS funded_shadow_average_return_pct,
+           AVG(o.gross_return_pct) FILTER (WHERE fd.verdict IS DISTINCT FROM 'allocated')
+               AS rejected_shadow_average_return_pct,
+           COUNT(*) FILTER (WHERE fd.verdict = 'allocated' AND ee.average_price IS NOT NULL)
+               AS filled_entries,
+           COUNT(*) FILTER (
+               WHERE fd.verdict = 'allocated'
+                 AND ee.average_price IS NULL
+                 AND eo.status = 'rejected'
+           )
+               AS broker_rejected_entries,
+           AVG(((ee.average_price - s.fill_price) / NULLIF(s.fill_price, 0)) * 100)
+               FILTER (WHERE fd.verdict = 'allocated' AND ee.average_price IS NOT NULL)
+               AS average_slippage_pct,
+           AVG(pre.stressed_cost_amount) FILTER (WHERE pre.stressed_cost_amount IS NOT NULL)
+               AS average_stressed_cost_usd,
+           MAX(pre.account_drawdown_pct) AS max_observed_account_drawdown_pct
+    FROM strategy_signals s
+    LEFT JOIN strategy_outcomes o
+      ON o.signal_id = s.signal_id
+     AND o.rule_set_version = %(outcome_version)s
+     AND o.input_rule_set_version = %(input_version)s
+    LEFT JOIN strategy_funding_decisions fd ON fd.signal_id = s.signal_id
+    LEFT JOIN strategy_trades t ON t.funding_decision_id = fd.funding_decision_id
+    LEFT JOIN entry_execution ee ON ee.strategy_trade_id = t.strategy_trade_id
+    LEFT JOIN entry_order eo ON eo.strategy_trade_id = t.strategy_trade_id
+    LEFT JOIN strategy_entry_preflights pre ON pre.signal_id = s.signal_id
+    WHERE s.verdict = 'fired' AND s.signal_kind = 'entry'
+      AND s.strategy_version = ANY(%(versions)s)
+    GROUP BY s.strategy_id, s.strategy_version
+"""
+
+
+def load_attribution(
+    conn: psycopg.Connection[Any],
+    *,
+    versions: Sequence[str],
+    outcome_version: str,
+    input_version: str,
+) -> dict[tuple[str, str], StrategyAttribution]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            _ATTRIBUTION_SQL,
+            {
+                "versions": versions,
+                "outcome_version": outcome_version,
+                "input_version": input_version,
+            },
+        )
+        rows = cur.fetchall()
+    result: dict[tuple[str, str], StrategyAttribution] = {}
+    for row in rows:
+        fired = int(row["fired_entries"])
+        funded = int(row["funded_entries"])
+        funded_shadow = row["funded_shadow_average_return_pct"]
+        rejected_shadow = row["rejected_shadow_average_return_pct"]
+        filled = int(row["filled_entries"])
+        broker_rejected = int(row["broker_rejected_entries"])
+        result[(str(row["strategy_id"]), str(row["strategy_version"]))] = StrategyAttribution(
+            fired_entries=fired,
+            funded_entries=funded,
+            rejected_entries=int(row["rejected_entries"]),
+            resolved_entries=int(row["resolved_entries"]),
+            shadow_average_return_pct=row["shadow_average_return_pct"],
+            funded_shadow_average_return_pct=funded_shadow,
+            rejected_shadow_average_return_pct=rejected_shadow,
+            opportunity_gap_pct=(
+                rejected_shadow - funded_shadow if rejected_shadow is not None and funded_shadow is not None else None
+            ),
+            funded_capture_rate=Decimal(funded) / Decimal(fired) if fired else None,
+            filled_entries=filled,
+            broker_rejected_entries=broker_rejected,
+            fill_rate=Decimal(filled) / Decimal(funded) if funded else None,
+            broker_rejection_rate=Decimal(broker_rejected) / Decimal(funded) if funded else None,
+            average_slippage_pct=row["average_slippage_pct"],
+            average_stressed_cost_usd=row["average_stressed_cost_usd"],
+            max_observed_account_drawdown_pct=row["max_observed_account_drawdown_pct"],
+        )
+    return result
+
+
+_OWNED_LIFECYCLE_SQL = """
+    WITH closes AS (
+        SELECT position_id, COUNT(*) AS close_event_count,
+               SUM(realized_pnl_usd) AS realised_pnl,
+               SUM(fees_usd) AS fees,
+               BOOL_AND(realized_pnl_usd IS NOT NULL) AS pnl_complete,
+               BOOL_AND(fees_usd IS NOT NULL) AS fees_complete
+        FROM trade_events
+        WHERE event_kind = 'close'
+        GROUP BY position_id
+    )
+    SELECT s.strategy_id, s.strategy_version, t.strategy_trade_id, t.status AS trade_status,
+           own.ownership_id, own.broker_position_id, own.status AS ownership_status,
+           bp.position_id AS active_broker_position_id, bp.is_buy, bp.units, bp.amount,
+           bp.open_rate, bp.open_conversion_rate, bp.total_fees,
+           q.last, q.bid, q.ask, pd.close AS daily_close,
+           COALESCE(c.close_event_count, 0) AS close_event_count,
+           c.realised_pnl, c.fees, c.pnl_complete, c.fees_complete
+    FROM strategy_funding_decisions fd
+    JOIN strategy_signals s ON s.signal_id = fd.signal_id
+    LEFT JOIN strategy_trades t ON t.funding_decision_id = fd.funding_decision_id
+    LEFT JOIN strategy_position_ownership own ON own.strategy_trade_id = t.strategy_trade_id
+    LEFT JOIN broker_positions bp ON bp.position_id = own.broker_position_id
+    LEFT JOIN quotes q ON q.instrument_id = bp.instrument_id
+    LEFT JOIN LATERAL (
+        SELECT p.close
+        FROM price_daily p
+        WHERE p.instrument_id = bp.instrument_id AND p.close IS NOT NULL
+        ORDER BY p.price_date DESC
+        LIMIT 1
+    ) pd ON TRUE
+    LEFT JOIN closes c ON c.position_id = own.broker_position_id
+    WHERE fd.verdict = 'allocated' AND s.strategy_version = ANY(%(versions)s)
+    ORDER BY s.strategy_id, s.strategy_version, t.strategy_trade_id, own.ownership_id
+"""
+
+
+def _mark(row: dict[str, Any]) -> Decimal | None:
+    price = resolve_quote_price(
+        float(row["last"]) if row["last"] is not None else None,
+        float(row["bid"]) if row["bid"] is not None else None,
+        float(row["ask"]) if row["ask"] is not None else None,
+    )
+    if price is not None:
+        return Decimal(str(price))
+    daily = row["daily_close"]
+    return Decimal(str(daily)) if daily is not None and Decimal(str(daily)) > 0 else None
+
+
+def load_owned_pnl(conn: psycopg.Connection[Any], *, versions: Sequence[str]) -> dict[tuple[str, str], StrategyPnl]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_OWNED_LIFECYCLE_SQL, {"versions": versions})
+        rows = list(cur.fetchall())
+
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[(str(row["strategy_id"]), str(row["strategy_version"]))].append(row)
+
+    result: dict[tuple[str, str], StrategyPnl] = {}
+    for key, strategy_rows in grouped.items():
+        realised = Decimal("0")
+        unrealised = Decimal("0")
+        invested = Decimal("0")
+        fees = Decimal("0")
+        reasons: set[str] = set()
+        ownership_count = 0
+        active_count = 0
+        close_count = 0
+        trade_ids: set[int] = set()
+        for row in strategy_rows:
+            if row["strategy_trade_id"] is None:
+                reasons.add("funding_not_reconciled_to_trade")
+                continue
+            trade_ids.add(int(row["strategy_trade_id"]))
+            ownership_id = row["ownership_id"]
+            if ownership_id is None:
+                if row["trade_status"] != "failed":
+                    reasons.add("trade_not_reconciled_to_position")
+                continue
+            ownership_count += 1
+            row_close_count = int(row["close_event_count"])
+            close_count += row_close_count
+            if row_close_count:
+                if row["pnl_complete"] is True:
+                    realised += Decimal(str(row["realised_pnl"]))
+                else:
+                    reasons.add("realised_pnl_missing_from_history")
+                if row["fees_complete"] is True:
+                    fees += Decimal(str(row["fees"]))
+                else:
+                    reasons.add("fees_missing_from_history")
+            elif row["ownership_status"] == "released":
+                reasons.add("released_position_missing_close_history")
+
+            if row["ownership_status"] != "active":
+                continue
+            active_count += 1
+            if row["active_broker_position_id"] is None:
+                reasons.add("active_position_missing_from_broker_snapshot")
+                continue
+            invested += Decimal(str(row["amount"]))
+            mark = _mark(row)
+            if mark is None:
+                reasons.add("active_position_mark_unavailable")
+                continue
+            units = Decimal(str(row["units"]))
+            open_rate = Decimal(str(row["open_rate"]))
+            conversion = Decimal(str(row["open_conversion_rate"]))
+            direction = Decimal("1") if bool(row["is_buy"]) else Decimal("-1")
+            unrealised += direction * units * (mark - open_rate) * conversion
+
+        realised_known = not {
+            "realised_pnl_missing_from_history",
+            "released_position_missing_close_history",
+        }.intersection(reasons)
+        unrealised_known = not {
+            "funding_not_reconciled_to_trade",
+            "trade_not_reconciled_to_position",
+            "active_position_missing_from_broker_snapshot",
+            "active_position_mark_unavailable",
+        }.intersection(reasons)
+        invested_known = not {
+            "funding_not_reconciled_to_trade",
+            "trade_not_reconciled_to_position",
+            "active_position_missing_from_broker_snapshot",
+        }.intersection(reasons)
+        fees_known = "fees_missing_from_history" not in reasons
+        realised_value = realised if realised_known else None
+        unrealised_value = unrealised if unrealised_known else None
+        result[key] = StrategyPnl(
+            strategy_trade_count=len(trade_ids),
+            owned_position_count=ownership_count,
+            active_position_count=active_count,
+            close_event_count=close_count,
+            invested_capital=invested if invested_known else None,
+            realised_pnl=realised_value,
+            unrealised_pnl=unrealised_value,
+            total_pnl=(
+                realised_value + unrealised_value
+                if realised_value is not None and unrealised_value is not None
+                else None
+            ),
+            observed_fees=fees if fees_known else None,
+            complete=not reasons,
+            incomplete_reasons=tuple(sorted(reasons)),
+        )
+    return result
+
+
+_CONTROL_SQL = """
+    WITH current_stage AS (
+        SELECT DISTINCT ON (strategy_id, strategy_version)
+               strategy_id, strategy_version, to_stage
+        FROM strategy_promotions
+        WHERE strategy_version = ANY(%(versions)s)
+        ORDER BY strategy_id, strategy_version, promotion_id DESC
+    ), strategy_keys AS (
+        SELECT strategy_id, strategy_version FROM current_stage
+        UNION
+        SELECT strategy_id, strategy_version
+        FROM strategy_deployments
+        WHERE strategy_version = ANY(%(versions)s) AND mode = 'paper'
+    ), pinned AS (
+        SELECT p.strategy_id, p.strategy_version,
+               COUNT(*) AS result_count,
+               COUNT(*) FILTER (WHERE
+                   r.expectancy_ci_low_pct IS NOT NULL
+                   AND r.namespace = 'hold_out'
+                   AND r.window_start >= DATE '2022-01-01'
+                   AND r.universe_basis = 'survivorship_free'
+                   AND r.carry_unmodelled = false
+                   AND r.trial_count IS NOT NULL
+                   AND r.deflated_sharpe IS NOT NULL
+                   AND r.effective_sample_size IS NOT NULL
+                   AND r.synthetic_control_passed = true
+               ) AS qualified_result_count
+        FROM strategy_promotions p
+        JOIN strategy_promotion_results pr ON pr.promotion_id = p.promotion_id
+        JOIN strategy_results_store r ON r.result_id = pr.result_id
+        WHERE p.strategy_version = ANY(%(versions)s)
+        GROUP BY p.strategy_id, p.strategy_version
+    ), reserved AS (
+        SELECT fd.deployment_id, COALESCE(SUM(fd.amount), 0) AS amount
+        FROM strategy_funding_decisions fd
+        LEFT JOIN strategy_trades t ON t.funding_decision_id = fd.funding_decision_id
+        WHERE fd.verdict = 'allocated'
+          AND (t.strategy_trade_id IS NULL OR t.status NOT IN ('closed', 'failed'))
+        GROUP BY fd.deployment_id
+    )
+    SELECT keys.strategy_id, keys.strategy_version, cs.to_stage,
+           COALESCE(pin.result_count, 0) AS result_count,
+           COALESCE(pin.qualified_result_count, 0) AS qualified_result_count,
+           d.deployment_id, d.capital_limit, d.currency, d.enabled, d.revision,
+           COALESCE(res.amount, 0) AS reserved_capital,
+           (pol.deployment_id IS NOT NULL) AS policy_configured,
+           pol.max_drawdown_pct AS max_drawdown_limit_pct
+    FROM strategy_keys keys
+    LEFT JOIN current_stage cs USING (strategy_id, strategy_version)
+    LEFT JOIN pinned pin USING (strategy_id, strategy_version)
+    LEFT JOIN strategy_deployments d
+      ON d.strategy_id = keys.strategy_id AND d.strategy_version = keys.strategy_version
+     AND d.mode = 'paper'
+    LEFT JOIN reserved res ON res.deployment_id = d.deployment_id
+    LEFT JOIN strategy_execution_policies pol ON pol.deployment_id = d.deployment_id
+"""
+
+
+def load_control_state(
+    conn: psycopg.Connection[Any], *, versions: Sequence[str]
+) -> dict[tuple[str, str], StrategyControlState]:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_CONTROL_SQL, {"versions": versions})
+        rows = cur.fetchall()
+    return {
+        (str(row["strategy_id"]), str(row["strategy_version"])): StrategyControlState(
+            stage=str(row["to_stage"]) if row["to_stage"] is not None else None,
+            pinned_evidence_ready=(
+                int(row["result_count"]) > 0 and int(row["qualified_result_count"]) == int(row["result_count"])
+            ),
+            deployment_id=int(row["deployment_id"]) if row["deployment_id"] is not None else None,
+            capital_limit=Decimal(str(row["capital_limit"] or 0)),
+            currency=str(row["currency"] or "USD"),
+            enabled=bool(row["enabled"]),
+            revision=int(row["revision"]) if row["revision"] is not None else None,
+            reserved_capital=Decimal(str(row["reserved_capital"])),
+            policy_configured=bool(row["policy_configured"]),
+            max_drawdown_limit_pct=(
+                Decimal(str(row["max_drawdown_limit_pct"])) if row["max_drawdown_limit_pct"] is not None else None
+            ),
+        )
+        for row in rows
+    }
+
+
+def load_entry_block_state(conn: psycopg.Connection[Any]) -> StrategyEntryBlockState:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute("SELECT is_active, reason, activated_at, activated_by FROM kill_switch ORDER BY id DESC LIMIT 1")
+        kill = cur.fetchone()
+        cur.execute("SELECT reason FROM strategy_execution_blocks WHERE active ORDER BY source")
+        blocks = tuple(str(row["reason"]) for row in cur.fetchall())
+        cur.execute("SELECT enable_auto_trading, enable_live_trading FROM runtime_config ORDER BY id DESC LIMIT 1")
+        runtime = cur.fetchone()
+    # Missing singleton rows are fail-closed and visible rather than treated as
+    # disabled-but-healthy configuration.
+    if kill is None:
+        return StrategyEntryBlockState(True, "kill switch state unavailable", None, None, blocks, False, False)
+    if runtime is None:
+        blocks = (*blocks, "runtime configuration unavailable")
+    return StrategyEntryBlockState(
+        global_kill_active=bool(kill["is_active"]),
+        global_kill_reason=str(kill["reason"]) if kill["reason"] is not None else None,
+        global_kill_activated_at=kill["activated_at"],
+        global_kill_activated_by=(str(kill["activated_by"]) if kill["activated_by"] is not None else None),
+        execution_block_reasons=blocks,
+        auto_trading_enabled=bool(runtime["enable_auto_trading"]) if runtime is not None else False,
+        live_trading_enabled=bool(runtime["enable_live_trading"]) if runtime is not None else False,
+    )
+
+
+__all__ = [
+    "StrategyAttribution",
+    "StrategyControlState",
+    "StrategyEntryBlockState",
+    "StrategyPnl",
+    "load_attribution",
+    "load_control_state",
+    "load_entry_block_state",
+    "load_owned_pnl",
+]

--- a/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
+++ b/docs/proposals/ta/2026-08-09-strategy-automation-control-plane.md
@@ -401,8 +401,18 @@ are actually created.
    An unowned id fails before I/O, same-instrument manual positions are never
    mutated, kill switches leave risk reduction available, and unchanged bars or
    polling heartbeats add no database rows. Live credentials are refused.
-9. **Paper P&L and picker allocation controls:** strategy-only P&L, shadow versus
-   funded capture, manual allocation changes with audit.
+9. **Paper P&L and picker allocation controls — implemented:** strategy-only
+   realised P&L is the sum of close-history net profit for exact owned broker
+   position ids; unrealised P&L uses only active exact ownership and a positive
+   live/daily mark. Missing lifecycle evidence is unknown, never zero, and
+   same-instrument manual positions are structurally excluded. The picker shows
+   allocation-unbiased shadow results, funded capture, fills/rejections,
+   slippage, skipped-versus-funded comparison, sleeve usage and explicit
+   refusal state. Operator/session-authenticated paper ceiling changes reuse
+   the immutable deployment event ledger; evidence-invalid versions may only
+   be disabled/reduced. The read model adds no schema or periodic P&L writer.
+   Formula, storage and test register:
+   `2026-08-09-strategy-paper-pnl-allocation.md`.
 10. **Live promotion:** requires minimum forward/paper evidence, reconciliation
     SLOs, kill drills and an explicit operator action in addition to both global
     switches.

--- a/docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md
+++ b/docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md
@@ -71,8 +71,9 @@ with a complete immutable `strategy_deployment_events` revision. There is no
 automatic allocation optimiser or winner-chasing job.
 
 If evidence becomes invalid, a new/increased allocation is refused. An
-existing allocation can still be disabled and reduced: evidence failure must
-never trap capital in an enabled sleeve.
+existing allocation can still be disabled and/or have its ceiling reduced;
+a disabled allocation cannot be re-enabled through this exception. Evidence
+failure must never trap capital in an enabled sleeve.
 
 Global kill and reconciliation block state is visible in the picker and blocks
 new order entry in the executor. It does not erase the allocation audit and it

--- a/docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md
+++ b/docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md
@@ -1,0 +1,116 @@
+# Strategy paper P&L, attribution and allocation controls (#2453)
+
+Status: implemented MVP on 2026-08-09. This is control-plane slice 9 of
+`2026-08-09-strategy-automation-control-plane.md`.
+
+## Decision boundary
+
+The strategy page has two independent performance arms:
+
+```text
+every fired entry -> immutable outcome -> shadow performance
+                  -> funding verdict -> exact owned lifecycle -> actual P&L
+```
+
+Changing a deployment ceiling never changes a signal, outcome, funding
+decision, fill or ownership row. This makes the shadow record immune to later
+allocation changes and keeps selection/capture bias measurable.
+
+The account portfolio remains the complete manual plus automated view. The
+strategy view is a strict subset selected by exact broker position ownership;
+it does not modify or feed the account-wide calculation.
+
+## Formula and provenance register
+
+All percentages below are stored percentage points unless explicitly called a
+fraction.
+
+| Operator figure | Formula | Durable provenance | Unknown rule |
+| --- | --- | --- | --- |
+| Realised strategy P&L | `Σ close.realized_pnl_usd` | `strategy_position_ownership.broker_position_id = trade_events.position_id`, close events only | null if a released owned position has no close history or any close has null P&L |
+| Unrealised strategy P&L | `direction × units × (mark − open_rate) × open_conversion_rate` | active exact ownership joined to `broker_positions`; mark from current `quotes`, then latest `price_daily` | null if ownership is unreconciled, the broker snapshot is missing, or no positive mark exists |
+| Total strategy P&L | realised + unrealised | the two figures above | null unless both arms are known |
+| Shadow per signal | `AVG(strategy_outcomes.gross_return_pct)` | every resolved fired entry under the current resolver/input versions | null when no outcomes have resolved |
+| Captured | allocated fired entries / all fired entries | immutable `strategy_funding_decisions`; missing legacy decision is displayed as not funded / not evaluated | null when no entry has fired |
+| Filled | allocated entries with a positive exact detailed-lookup execution / allocated entries | `strategy_order_position_executions` reached only through the strategy entry order | null when no entry was allocated |
+| Broker rejection rate | allocated entry orders rejected / allocated entries | exact strategy entry order status | null when no entry was allocated |
+| Slippage | `AVG((actual weighted fill − expected fill) / expected fill × 100)` | detailed entry executions versus `strategy_signals.fill_price`; current strategies are long-only | null without a reconciled fill |
+| Skipped versus funded | average rejected shadow return − average funded shadow return | simultaneous shadow outcomes split by immutable funding verdict | null until both groups have a resolved outcome; this is a selection comparison, not a cash-profit claim |
+
+`quotes.last` must be strictly positive. Otherwise the standard positive
+bid/ask midpoint is used, then the latest positive daily close. Unlike the
+account page's cost-basis display fallback, strategy attribution reports an
+unavailable mark as unknown so a lack of market evidence cannot look like zero
+P&L.
+
+Manual positions cannot enter a strategy formula by instrument match, FIFO,
+symbol or temporal proximity. A same-instrument manual position has no
+`strategy_position_ownership` row and is therefore outside the query
+denominator.
+
+## Allocation gate
+
+The picker permits a positive/new paper allocation only when the exact current
+strategy version is runnable and all of the following are true:
+
+- every declared primary 2022+ and rolling 24/36-month arm is complete;
+- the arms have no promotion refusal and their lower expectancy bounds remain
+  positive after the registered cost model;
+- the current stage is `paper_enabled` or `live_enabled`;
+- pinned promotion results pass the same recent, survivorship, carry, trial,
+  effective-sample-size, DSR and synthetic-control contract used by the paper
+  executor;
+- the scan frontier is current;
+- an explicit execution policy exists; and
+- the deployment currency is USD for the MVP.
+
+The request pins `strategy_version`; stale browser state receives a conflict
+instead of changing a newly deployed version. Operator identity comes only
+from the authenticated session. `strategy_deployments` is updated together
+with a complete immutable `strategy_deployment_events` revision. There is no
+automatic allocation optimiser or winner-chasing job.
+
+If evidence becomes invalid, a new/increased allocation is refused. An
+existing allocation can still be disabled and reduced: evidence failure must
+never trap capital in an enabled sleeve.
+
+Global kill and reconciliation block state is visible in the picker and blocks
+new order entry in the executor. It does not erase the allocation audit and it
+does not remove exact-position risk reduction.
+
+## Database and performance impact
+
+This slice adds **no table, column, payload or periodic writer**. It is a read
+model over bounded/existing ledgers:
+
+- fired signals and outcomes already retained by the observation policy;
+- one funding/preflight row per fired entry;
+- one current deployment plus immutable operator-authored revisions;
+- exact order executions, position ownership and material position operations;
+- the existing single-account `trade_events` ledger (hundreds of rows/year);
+- current quote/position rows and bounded daily prices.
+
+Repeated page refreshes and P&L changes write zero rows. There is therefore no
+new retention job or database-growth allowance. Existing keys/indexes cover the
+joins: unique funding decision per signal, trade-order indexes, unique broker
+position ownership, the partial trade-event open/close indexes, current quote
+PK and daily-price PK. A future material scale change must be demonstrated with
+`EXPLAIN (ANALYZE, BUFFERS)` before adding an aggregate snapshot table.
+
+Dev-DB measurement on 2026-08-09 (warm cache, exact current versions) was
+9.673 ms for attribution, 0.090 ms for owned P&L, 0.109 ms for controls and
+0.515 ms for the 50-row signal page; all four reported zero shared-block reads.
+These are evidence for the read model, not a production latency SLO.
+
+## Validation
+
+The integration matrix pins:
+
+- different P&L on a strategy and manual position sharing one instrument;
+- manual lifecycle exclusion from strategy totals;
+- an unavailable mark returning null rather than zero;
+- funded/rejected shadow attribution and exact fill slippage;
+- identical shadow statistics before and after an allocation change;
+- evidence-invalid allocation producing no deployment or audit row; and
+- a successful update taking `changed_by` from the real session and appending
+  the immutable event.

--- a/docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md
+++ b/docs/proposals/ta/2026-08-09-strategy-paper-pnl-allocation.md
@@ -73,7 +73,9 @@ automatic allocation optimiser or winner-chasing job.
 If evidence becomes invalid, a new/increased allocation is refused. An
 existing allocation can still be disabled and/or have its ceiling reduced;
 a disabled allocation cannot be re-enabled through this exception. Evidence
-failure must never trap capital in an enabled sleeve.
+failure must never trap capital in an enabled sleeve. A legacy non-USD sleeve
+preserves its currency during such a reduction; it cannot be converted or
+newly enabled because USD remains the only supported allocation currency.
 
 Global kill and reconciliation block state is visible in the picker and blocks
 new order entry in the executor. It does not erase the allocation audit and it

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,5 +1,10 @@
 import { apiFetch } from "@/api/client";
-import type { FiredSignalsResponse, StrategyOverviewResponse } from "@/api/types";
+import type {
+  AllocationUpdateRequest,
+  AllocationUpdateResponse,
+  FiredSignalsResponse,
+  StrategyOverviewResponse,
+} from "@/api/types";
 
 export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
   return apiFetch("/strategies/overview");
@@ -10,4 +15,14 @@ export function fetchFiredSignals(cursor: number | null): Promise<FiredSignalsRe
   if (cursor !== null) params.set("cursor", String(cursor));
   const query = params.size === 0 ? "" : `?${params.toString()}`;
   return apiFetch(`/strategies/signals${query}`);
+}
+
+export function updateStrategyAllocation(
+  strategyId: string,
+  request: AllocationUpdateRequest,
+): Promise<AllocationUpdateResponse> {
+  return apiFetch(`/strategies/${encodeURIComponent(strategyId)}/allocation`, {
+    method: "PUT",
+    body: JSON.stringify(request),
+  });
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2457,15 +2457,76 @@ export interface StrategyOverview {
   evidence_windows: StrategyEvidenceWindow[];
   legacy_result_count: number;
   all_recent_evidence_complete: boolean;
-  allocation_ready: false;
+  stage: string | null;
+  attribution: StrategyAttribution;
+  pnl: StrategyPnl;
+  allocation: StrategyAllocation;
+  allocation_ready: boolean;
   allocation_refusals: string[];
+}
+
+export interface StrategyAttribution {
+  fired_entries: number;
+  funded_entries: number;
+  rejected_entries: number;
+  resolved_entries: number;
+  shadow_average_return_pct: string | null;
+  funded_shadow_average_return_pct: string | null;
+  rejected_shadow_average_return_pct: string | null;
+  opportunity_gap_pct: string | null;
+  funded_capture_rate: string | null;
+  filled_entries: number;
+  broker_rejected_entries: number;
+  fill_rate: string | null;
+  broker_rejection_rate: string | null;
+  average_slippage_pct: string | null;
+  average_stressed_cost_usd: string | null;
+  max_observed_account_drawdown_pct: string | null;
+}
+
+export interface StrategyPnl {
+  currency: "USD";
+  strategy_trade_count: number;
+  owned_position_count: number;
+  active_position_count: number;
+  close_event_count: number;
+  invested_capital: string | null;
+  realised_pnl: string | null;
+  unrealised_pnl: string | null;
+  total_pnl: string | null;
+  observed_fees: string | null;
+  complete: boolean;
+  incomplete_reasons: string[];
+}
+
+export interface StrategyAllocation {
+  deployment_id: number | null;
+  capital_limit: string;
+  currency: "USD";
+  enabled: boolean;
+  revision: number | null;
+  reserved_capital: string;
+  invested_capital: string | null;
+  remaining_capital: string;
+  policy_configured: boolean;
+  max_drawdown_limit_pct: string | null;
+}
+
+export interface StrategyEntryBlock {
+  new_entries_blocked: boolean;
+  global_kill_active: boolean;
+  global_kill_reason: string | null;
+  global_kill_activated_at: string | null;
+  global_kill_activated_by: string | null;
+  execution_block_reasons: string[];
 }
 
 export interface StrategyOverviewResponse {
   as_of: string;
-  observation_stage: "forward_observation";
-  execution_enabled: false;
-  storage_policy: "aggregate_results_only";
+  execution_enabled: boolean;
+  live_execution_enabled: boolean;
+  storage_policy: "fired_signals_and_material_mutations_only";
+  entry_block: StrategyEntryBlock;
   strategies: StrategyOverview[];
 }
 
@@ -2486,12 +2547,33 @@ export interface FiredSignal {
   exit_price: string | null;
   gross_return_pct: string | null;
   outcome_reason: string | null;
-  observation_stage: "forward_observation";
-  funding_status: "unfunded";
-  funding_reason: "execution_not_enabled";
+  funding_status: "funded" | "rejected" | "not_applicable";
+  funding_reason: string;
+  funded_amount: string | null;
+  strategy_trade_id: number | null;
+  execution_status: string | null;
+  actual_fill_price: string | null;
+  slippage_pct: string | null;
 }
 
 export interface FiredSignalsResponse {
   items: FiredSignal[];
   next_cursor: number | null;
+}
+
+export interface AllocationUpdateRequest {
+  strategy_version: string;
+  capital_limit: string;
+  enabled: boolean;
+  reason: string;
+}
+
+export interface AllocationUpdateResponse {
+  strategy_id: string;
+  strategy_version: string;
+  deployment_id: number;
+  capital_limit: string;
+  currency: "USD";
+  enabled: boolean;
+  revision: number;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2502,7 +2502,7 @@ export interface StrategyPnl {
 export interface StrategyAllocation {
   deployment_id: number | null;
   capital_limit: string;
-  currency: "USD";
+  currency: string;
   enabled: boolean;
   revision: number | null;
   reserved_capital: string;
@@ -2573,7 +2573,7 @@ export interface AllocationUpdateResponse {
   strategy_version: string;
   deployment_id: number;
   capital_limit: string;
-  currency: "USD";
+  currency: string;
   enabled: boolean;
   revision: number;
 }

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -14,12 +14,12 @@ const OVERVIEW: StrategyOverviewResponse = {
   live_execution_enabled: false,
   storage_policy: "fired_signals_and_material_mutations_only",
   entry_block: {
-    new_entries_blocked: false,
+    new_entries_blocked: true,
     global_kill_active: false,
     global_kill_reason: null,
     global_kill_activated_at: null,
     global_kill_activated_by: null,
-    execution_block_reasons: [],
+    execution_block_reasons: ["automatic trading disabled"],
   },
   strategies: [
     {
@@ -150,6 +150,7 @@ describe("StrategiesPage", () => {
     expect(await screen.findByText("Volatility compression breakout")).toBeInTheDocument();
     expect(screen.getByText(/Backtest exclusion:/)).toBeInTheDocument();
     expect(screen.getByText("AAA")).toBeInTheDocument();
+    expect(screen.getByText("New strategy entries are blocked")).toBeInTheDocument();
     expect(screen.getByText("Not funded")).toBeInTheDocument();
     expect(screen.getByText("Not evaluated by allocator")).toBeInTheDocument();
   });

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -220,6 +220,54 @@ describe("StrategiesPage", () => {
     expect(screen.getByLabelText("Reason for this audited change")).toBeEnabled();
   });
 
+  it("allows an enabled evidence-invalid sleeve to reduce without disabling", async () => {
+    const base = OVERVIEW.strategies[0]!;
+    const strategy = {
+      ...base,
+      allocation: {
+        ...base.allocation,
+        deployment_id: 7,
+        capital_limit: "250.000000",
+        enabled: true,
+        revision: 2,
+      },
+    };
+    vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue({
+      ...OVERVIEW,
+      strategies: [strategy],
+    });
+    vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue(SIGNALS);
+    const update = vi.spyOn(strategiesApi, "updateStrategyAllocation").mockResolvedValue({
+      strategy_id: strategy.strategy_id,
+      strategy_version: strategy.strategy_version,
+      deployment_id: 7,
+      capital_limit: "200.000000",
+      currency: "USD",
+      enabled: true,
+      revision: 3,
+    });
+    render(
+      <MemoryRouter>
+        <StrategiesPage />
+      </MemoryRouter>,
+    );
+
+    const limit = await screen.findByLabelText("Maximum USD capital");
+    await userEvent.clear(limit);
+    await userEvent.type(limit, "200");
+    await userEvent.type(screen.getByLabelText("Reason for this audited change"), "reduce risk");
+    await userEvent.click(screen.getByRole("button", { name: "Save allocation" }));
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith(strategy.strategy_id, {
+        strategy_version: strategy.strategy_version,
+        capital_limit: "200.000000",
+        enabled: true,
+        reason: "reduce risk",
+      }),
+    );
+  });
+
   it("sends an explicit audited allocation and refetches the picker", async () => {
     const base = OVERVIEW.strategies[0]!;
     const available: StrategyOverviewResponse = {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -10,9 +10,17 @@ import { StrategiesPage } from "@/pages/StrategiesPage";
 
 const OVERVIEW: StrategyOverviewResponse = {
   as_of: "2026-08-09T12:00:00Z",
-  observation_stage: "forward_observation",
   execution_enabled: false,
-  storage_policy: "aggregate_results_only",
+  live_execution_enabled: false,
+  storage_policy: "fired_signals_and_material_mutations_only",
+  entry_block: {
+    new_entries_blocked: false,
+    global_kill_active: false,
+    global_kill_reason: null,
+    global_kill_activated_at: null,
+    global_kill_activated_by: null,
+    execution_block_reasons: [],
+  },
   strategies: [
     {
       strategy_id: "s4-volatility-compression-breakout",
@@ -42,8 +50,53 @@ const OVERVIEW: StrategyOverviewResponse = {
       ],
       legacy_result_count: 0,
       all_recent_evidence_complete: false,
+      stage: null,
+      attribution: {
+        fired_entries: 108,
+        funded_entries: 0,
+        rejected_entries: 108,
+        resolved_entries: 0,
+        shadow_average_return_pct: null,
+        funded_shadow_average_return_pct: null,
+        rejected_shadow_average_return_pct: null,
+        opportunity_gap_pct: null,
+        funded_capture_rate: "0",
+        filled_entries: 0,
+        broker_rejected_entries: 0,
+        fill_rate: null,
+        broker_rejection_rate: null,
+        average_slippage_pct: null,
+        average_stressed_cost_usd: null,
+        max_observed_account_drawdown_pct: null,
+      },
+      pnl: {
+        currency: "USD",
+        strategy_trade_count: 0,
+        owned_position_count: 0,
+        active_position_count: 0,
+        close_event_count: 0,
+        invested_capital: "0",
+        realised_pnl: "0",
+        unrealised_pnl: "0",
+        total_pnl: "0",
+        observed_fees: "0",
+        complete: true,
+        incomplete_reasons: [],
+      },
+      allocation: {
+        deployment_id: null,
+        capital_limit: "0",
+        currency: "USD",
+        enabled: false,
+        revision: null,
+        reserved_capital: "0",
+        invested_capital: "0",
+        remaining_capital: "0",
+        policy_configured: false,
+        max_drawdown_limit_pct: null,
+      },
       allocation_ready: false,
-      allocation_refusals: ["execution_not_enabled", "recent_evidence_incomplete"],
+      allocation_refusals: ["recent_evidence_incomplete"],
     },
   ],
 };
@@ -67,9 +120,13 @@ const SIGNALS: FiredSignalsResponse = {
       exit_price: null,
       gross_return_pct: null,
       outcome_reason: null,
-      observation_stage: "forward_observation",
-      funding_status: "unfunded",
-      funding_reason: "execution_not_enabled",
+      funding_status: "rejected",
+      funding_reason: "not_evaluated_by_allocator",
+      funded_amount: null,
+      strategy_trade_id: null,
+      execution_status: null,
+      actual_fill_price: null,
+      slippage_pct: null,
     },
   ],
   next_cursor: 42,
@@ -93,7 +150,8 @@ describe("StrategiesPage", () => {
     expect(await screen.findByText("Volatility compression breakout")).toBeInTheDocument();
     expect(screen.getByText(/Backtest exclusion:/)).toBeInTheDocument();
     expect(screen.getByText("AAA")).toBeInTheDocument();
-    expect(screen.getByText("unfunded · execution disabled")).toBeInTheDocument();
+    expect(screen.getByText("Not funded")).toBeInTheDocument();
+    expect(screen.getByText("Not evaluated by allocator")).toBeInTheDocument();
   });
 
   it("uses the server cursor when the operator requests older signals", async () => {
@@ -120,5 +178,101 @@ describe("StrategiesPage", () => {
     expect(await screen.findByText("No registered strategies")).toBeInTheDocument();
     expect(screen.getByText("No fired signals")).toBeInTheDocument();
     expect(screen.getByText(/current strategy versions have not fired/i)).toBeInTheDocument();
+  });
+
+  it("keeps allocation controls visible but disabled when evidence is unavailable", async () => {
+    vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(OVERVIEW);
+    vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue(SIGNALS);
+    render(
+      <MemoryRouter>
+        <StrategiesPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("button", { name: "Save allocation" })).toBeDisabled();
+    expect(screen.getByText(/Allocation needs complete recent evidence/i)).toBeInTheDocument();
+  });
+
+  it("keeps an existing disabled allocation editable for risk reduction", async () => {
+    const base = OVERVIEW.strategies[0]!;
+    vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue({
+      ...OVERVIEW,
+      strategies: [
+        {
+          ...base,
+          allocation: {
+            ...base.allocation,
+            deployment_id: 7,
+            capital_limit: "250.000000",
+            revision: 2,
+          },
+        },
+      ],
+    });
+    vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue(SIGNALS);
+    render(
+      <MemoryRouter>
+        <StrategiesPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByLabelText("Maximum USD capital")).toBeEnabled();
+    expect(screen.getByLabelText("Reason for this audited change")).toBeEnabled();
+  });
+
+  it("sends an explicit audited allocation and refetches the picker", async () => {
+    const base = OVERVIEW.strategies[0]!;
+    const available: StrategyOverviewResponse = {
+      ...OVERVIEW,
+      strategies: [
+        {
+          ...base,
+          runnable: true,
+          exclusion_reason: null,
+          stage: "paper_enabled",
+          allocation_ready: true,
+          allocation_refusals: [],
+          allocation: {
+            ...base.allocation,
+            deployment_id: 7,
+            policy_configured: true,
+          },
+        },
+      ],
+    };
+    const availableStrategy = available.strategies[0]!;
+    const overview = vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(available);
+    vi.spyOn(strategiesApi, "fetchFiredSignals").mockResolvedValue(SIGNALS);
+    const update = vi.spyOn(strategiesApi, "updateStrategyAllocation").mockResolvedValue({
+      strategy_id: availableStrategy.strategy_id,
+      strategy_version: availableStrategy.strategy_version,
+      deployment_id: 7,
+      capital_limit: "250.000000",
+      currency: "USD",
+      enabled: true,
+      revision: 2,
+    });
+    render(
+      <MemoryRouter>
+        <StrategiesPage />
+      </MemoryRouter>,
+    );
+
+    const limit = await screen.findByLabelText("Maximum USD capital");
+    await userEvent.clear(limit);
+    await userEvent.type(limit, "250");
+    await userEvent.click(screen.getByLabelText("Enabled"));
+    await userEvent.type(screen.getByLabelText("Reason for this audited change"), "bounded paper sleeve");
+    await userEvent.click(screen.getByRole("button", { name: "Save allocation" }));
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith(availableStrategy.strategy_id, {
+        strategy_version: availableStrategy.strategy_version,
+        capital_limit: "250.000000",
+        enabled: true,
+        reason: "bounded paper sleeve",
+      }),
+    );
+    await waitFor(() => expect(overview).toHaveBeenCalledTimes(2));
   });
 });

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -193,7 +193,7 @@ function AllocationControl({
       </div>
       <div className="grid gap-3 sm:grid-cols-[minmax(0,12rem)_auto_minmax(0,1fr)_auto] sm:items-end">
         <label className="text-xs font-medium text-slate-600 dark:text-slate-300">
-          Maximum USD capital
+          Maximum {strategy.allocation.currency} capital
           <input
             type="number"
             min="0"
@@ -284,10 +284,10 @@ function StrategyPanel({ strategy, onUpdated }: { readonly strategy: StrategyOve
           value={fraction(attribution.fill_rate)}
           detail={`${formatNumber(attribution.broker_rejected_entries, 0)} broker rejected`}
         />
-        <Metric label="Allocated ceiling" value={money(strategy.allocation.capital_limit, "USD")} />
-        <Metric label="Reserved" value={money(strategy.allocation.reserved_capital, "USD")} />
-        <Metric label="Currently invested" value={money(strategy.allocation.invested_capital, "USD")} />
-        <Metric label="Remaining" value={money(strategy.allocation.remaining_capital, "USD")} />
+        <Metric label="Allocated ceiling" value={money(strategy.allocation.capital_limit, strategy.allocation.currency)} />
+        <Metric label="Reserved" value={money(strategy.allocation.reserved_capital, strategy.allocation.currency)} />
+        <Metric label="Currently invested" value={money(strategy.allocation.invested_capital, strategy.allocation.currency)} />
+        <Metric label="Remaining" value={money(strategy.allocation.remaining_capital, strategy.allocation.currency)} />
       </div>
 
       {strategy.exclusion_reason ? (

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -1,34 +1,72 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
 
 import {
   fetchFiredSignals,
   fetchStrategyOverview,
+  updateStrategyAllocation,
 } from "@/api/strategies";
-import type { StrategyEvidenceWindow, StrategyOverview } from "@/api/types";
+import type {
+  StrategyEntryBlock,
+  StrategyEvidenceWindow,
+  StrategyOverview,
+} from "@/api/types";
 import { Section, SectionError, SectionSkeleton } from "@/components/dashboard/Section";
 import { EmptyState } from "@/components/states/EmptyState";
-import { formatDate, formatNumber } from "@/lib/format";
+import { Badge, type BadgeTone } from "@/components/ui/Badge";
+import { formatDate, formatMoney, formatNumber, formatPct } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
 
-function number(value: string | null, suffix = ""): string {
-  if (value === null) return "—";
+function decimal(value: string | null): number | null {
+  if (value === null) return null;
   const parsed = Number(value);
-  return Number.isFinite(parsed) ? `${formatNumber(parsed, 2)}${suffix}` : "—";
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function pctPoints(value: string | null): string {
+  const parsed = decimal(value);
+  return formatPct(parsed === null ? null : parsed / 100);
+}
+
+function fraction(value: string | null): string {
+  return formatPct(decimal(value));
+}
+
+function money(value: string | null, currency = "USD"): string {
+  return formatMoney(decimal(value), currency);
+}
+
+function humanizeCode(value: string): string {
+  const text = value.replaceAll("_", " ");
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function shadowOutcome(value: string | null): string {
+  if (value === null) return "Pending";
+  if (value === "tp_hit") return "Reached its goal";
+  if (value === "sl_hit" || value === "expired") return "Didn't reach its goal";
+  if (value === "ambiguous") return "Could not determine";
+  return "Not resolved";
+}
+
+function statusTone(status: "missing" | "partial" | "complete"): BadgeTone {
+  if (status === "complete") return "ok";
+  if (status === "partial") return "warn";
+  return "neutral";
 }
 
 function EvidenceTable({ windows }: { readonly windows: StrategyEvidenceWindow[] }) {
   return (
     <div className="overflow-x-auto">
-      <table className="min-w-full text-left text-xs">
+      <table className="min-w-full text-left text-sm">
         <thead className="text-slate-500 dark:text-slate-400">
           <tr>
-            <th className="pb-2 pr-4 font-medium">Window</th>
-            <th className="pb-2 pr-4 font-medium">Status</th>
-            <th className="pb-2 pr-4 font-medium">Trades</th>
-            <th className="pb-2 pr-4 font-medium">Expectancy</th>
-            <th className="pb-2 pr-4 font-medium">Sharpe</th>
-            <th className="pb-2 pr-4 font-medium">Max drawdown</th>
-            <th className="pb-2 font-medium">Refusals</th>
+            <th className="px-2 py-2 font-medium">Recent test window</th>
+            <th className="px-2 py-2 font-medium">Coverage</th>
+            <th className="px-2 py-2 text-right font-medium">Trades</th>
+            <th className="px-2 py-2 text-right font-medium">Per trade</th>
+            <th className="px-2 py-2 text-right font-medium">Worst dip</th>
+            <th className="px-2 py-2 font-medium">Evidence decision</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -36,25 +74,31 @@ function EvidenceTable({ windows }: { readonly windows: StrategyEvidenceWindow[]
             const representative = window.arms.find(
               (arm) => arm.ambiguity_arm === "worst_case" && arm.quarantine_arm === "masked",
             );
+            const refused = representative ? representative.promotion_refusals.length > 0 : true;
             return (
               <tr key={window.window_id}>
-                <td className="py-2 pr-4">
+                <td className="px-2 py-2">
                   <div className="font-medium text-slate-800 dark:text-slate-200">{window.label}</div>
-                  <div className="text-slate-500">
+                  <div className="text-xs text-slate-500">
                     {formatDate(window.window_start)}–{formatDate(window.window_end)}
                   </div>
                 </td>
-                <td className="py-2 pr-4">{window.status}</td>
-                <td className="py-2 pr-4 tabular-nums">{representative?.trade_count ?? "—"}</td>
-                <td className="py-2 pr-4 tabular-nums">
-                  {number(representative?.expectancy_per_trade_pct ?? null, "%")}
+                <td className="px-2 py-2">
+                  <Badge tone={statusTone(window.status)}>{window.status}</Badge>
                 </td>
-                <td className="py-2 pr-4 tabular-nums">{number(representative?.sharpe ?? null)}</td>
-                <td className="py-2 pr-4 tabular-nums">
-                  {number(representative?.max_drawdown_pct ?? null, "%")}
+                <td className="px-2 py-2 text-right tabular-nums">
+                  {representative?.trade_count ?? "—"}
                 </td>
-                <td className="max-w-xs py-2 text-slate-500">
-                  {representative?.promotion_refusals.join(", ") ?? "Recent evidence not computed"}
+                <td className="px-2 py-2 text-right tabular-nums">
+                  {pctPoints(representative?.expectancy_per_trade_pct ?? null)}
+                </td>
+                <td className="px-2 py-2 text-right tabular-nums">
+                  {pctPoints(representative?.max_drawdown_pct ?? null)}
+                </td>
+                <td className="px-2 py-2">
+                  <Badge tone={representative === undefined ? "neutral" : refused ? "risk" : "ok"}>
+                    {representative === undefined ? "Not measured" : refused ? "Not eligible" : "Passed"}
+                  </Badge>
                 </td>
               </tr>
             );
@@ -65,84 +109,268 @@ function EvidenceTable({ windows }: { readonly windows: StrategyEvidenceWindow[]
   );
 }
 
-function StrategyPanel({ strategy }: { readonly strategy: StrategyOverview }) {
+function Metric({ label, value, detail }: { label: string; value: string; detail?: string }) {
   return (
-    <article className="border-t border-slate-200 pt-3 dark:border-slate-800">
-      <header className="mb-3 flex items-baseline justify-between gap-2">
-        <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{strategy.title}</h2>
-        <span className="text-xs text-slate-500 dark:text-slate-400">
-          {strategy.runnable ? "runnable" : "excluded"} · scan {strategy.scan.status} · frontier{" "}
-          {formatDate(strategy.scan.frontier_date)}
-        </span>
-      </header>
-      <div className="mb-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
-        <div>
-          <div className="text-xs text-slate-500">Fired entries</div>
-          <div className="tabular-nums">{formatNumber(strategy.scan.fired_entries, 0)}</div>
-        </div>
-        <div>
-          <div className="text-xs text-slate-500">Fired exits</div>
-          <div className="tabular-nums">{formatNumber(strategy.scan.fired_exits, 0)}</div>
-        </div>
-        <div>
-          <div className="text-xs text-slate-500">Not evaluable</div>
-          <div className="tabular-nums">{formatNumber(strategy.scan.not_evaluable, 0)}</div>
-        </div>
-        <div>
-          <div className="text-xs text-slate-500">Legacy result rows</div>
-          <div className="tabular-nums">{formatNumber(strategy.legacy_result_count, 0)}</div>
-        </div>
+    <div className="border-t border-slate-200 pt-2 dark:border-slate-800">
+      <div className="text-xs text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="mt-1 text-sm font-semibold tabular-nums text-slate-800 dark:text-slate-200">
+        {value}
       </div>
-      {strategy.exclusion_reason ? (
-        <p className="mb-3 text-xs text-amber-700 dark:text-amber-400">
-          Backtest exclusion: {strategy.exclusion_reason}
+      {detail ? <div className="mt-0.5 text-xs text-slate-500">{detail}</div> : null}
+    </div>
+  );
+}
+
+function AllocationControl({
+  strategy,
+  onUpdated,
+}: {
+  readonly strategy: StrategyOverview;
+  readonly onUpdated: () => void;
+}) {
+  const [limit, setLimit] = useState(strategy.allocation.capital_limit);
+  const [enabled, setEnabled] = useState(strategy.allocation.enabled);
+  const [reason, setReason] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setLimit(strategy.allocation.capital_limit);
+    setEnabled(strategy.allocation.enabled);
+  }, [strategy.allocation.capital_limit, strategy.allocation.enabled, strategy.allocation.revision]);
+
+  const parsedLimit = Number(limit);
+  const canReduceRisk =
+    strategy.allocation.deployment_id !== null &&
+    !enabled &&
+    parsedLimit <= Number(strategy.allocation.capital_limit);
+  const canSubmit =
+    !submitting &&
+    reason.trim().length > 0 &&
+    Number.isFinite(parsedLimit) &&
+    parsedLimit >= 0 &&
+    (!enabled || parsedLimit > 0) &&
+    (strategy.allocation_ready || canReduceRisk);
+  const controlsAvailable = strategy.allocation_ready || strategy.allocation.deployment_id !== null;
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setFailed(false);
+    setSaved(false);
+    try {
+      await updateStrategyAllocation(strategy.strategy_id, {
+        strategy_version: strategy.strategy_version,
+        capital_limit: parsedLimit.toFixed(6),
+        enabled,
+        reason: reason.trim(),
+      });
+      setReason("");
+      setSaved(true);
+      onUpdated();
+    } catch (error) {
+      console.error("Strategy allocation update failed:", error);
+      setFailed(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={(event) => void submit(event)} className="mt-4 border-t border-slate-200 pt-3 dark:border-slate-800">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Capital allocation</h3>
+          <p className="mt-1 text-xs text-slate-500">
+            Operator-set ceiling only. Capital is never moved automatically between strategies.
+          </p>
+        </div>
+        <Badge tone={strategy.allocation_ready ? "ok" : "risk"}>
+          {strategy.allocation_ready ? "Available" : "Unavailable"}
+        </Badge>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,12rem)_auto_minmax(0,1fr)_auto] sm:items-end">
+        <label className="text-xs font-medium text-slate-600 dark:text-slate-300">
+          Maximum USD capital
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            value={limit}
+            disabled={!controlsAvailable || submitting}
+            onChange={(event) => setLimit(event.target.value)}
+            className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-2 py-2 text-sm tabular-nums outline-none focus:border-blue-600 focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-950 dark:focus:ring-blue-900"
+          />
+        </label>
+        <label className="flex min-h-11 cursor-pointer items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+          <input
+            type="checkbox"
+            checked={enabled}
+            disabled={!controlsAvailable || submitting}
+            onChange={(event) => setEnabled(event.target.checked)}
+            className="h-4 w-4"
+          />
+          Enabled
+        </label>
+        <label className="text-xs font-medium text-slate-600 dark:text-slate-300">
+          Reason for this audited change
+          <input
+            type="text"
+            maxLength={1000}
+            value={reason}
+            disabled={!controlsAvailable || submitting}
+            onChange={(event) => setReason(event.target.value)}
+            className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-2 py-2 text-sm outline-none focus:border-blue-600 focus:ring-2 focus:ring-blue-200 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-950 dark:focus:ring-blue-900"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="min-h-11 cursor-pointer border border-blue-700 bg-blue-700 px-3 py-2 text-sm font-medium text-white transition-colors duration-200 hover:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-40 dark:focus:ring-blue-900"
+        >
+          {submitting ? "Saving…" : "Save allocation"}
+        </button>
+      </div>
+      {!strategy.allocation_ready ? (
+        <p className="mt-2 text-xs text-red-700 dark:text-red-300">
+          Allocation needs complete recent evidence, a paper promotion, a pinned passing result, a current scan,
+          and an execution policy. Existing allocations can still be disabled.
         </p>
       ) : null}
+      {failed ? <p className="mt-2 text-xs text-red-700 dark:text-red-300">The allocation was not changed. Refresh and try again.</p> : null}
+      {saved ? <p className="mt-2 text-xs text-emerald-700 dark:text-emerald-300">Allocation revision saved and audited.</p> : null}
+    </form>
+  );
+}
+
+function StrategyPanel({ strategy, onUpdated }: { readonly strategy: StrategyOverview; readonly onUpdated: () => void }) {
+  const pnl = strategy.pnl;
+  const attribution = strategy.attribution;
+  return (
+    <article className="border-t border-slate-200 pt-3 dark:border-slate-800">
+      <header className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{strategy.title}</h2>
+          <Badge tone={strategy.runnable ? "info" : "neutral"}>{strategy.runnable ? "Runnable" : "Excluded"}</Badge>
+          <Badge tone={strategy.allocation.enabled ? "ok" : "neutral"}>
+            {strategy.allocation.enabled ? "Funded" : "Shadow only"}
+          </Badge>
+        </div>
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          {strategy.stage ?? "not promoted"} · scan {strategy.scan.status} · frontier {formatDate(strategy.scan.frontier_date)}
+        </span>
+      </header>
+
+      <div className="mb-4 grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-4">
+        <Metric
+          label="Made you"
+          value={money(pnl.total_pnl, pnl.currency)}
+          detail={pnl.complete ? "Exact owned lifecycle" : "Incomplete broker evidence"}
+        />
+        <Metric
+          label="Shadow per signal"
+          value={pctPoints(attribution.shadow_average_return_pct)}
+          detail={`${formatNumber(attribution.resolved_entries, 0)} resolved · gross price move`}
+        />
+        <Metric
+          label="Captured"
+          value={fraction(attribution.funded_capture_rate)}
+          detail={`${formatNumber(attribution.funded_entries, 0)} of ${formatNumber(attribution.fired_entries, 0)} entries`}
+        />
+        <Metric
+          label="Filled"
+          value={fraction(attribution.fill_rate)}
+          detail={`${formatNumber(attribution.broker_rejected_entries, 0)} broker rejected`}
+        />
+        <Metric label="Allocated ceiling" value={money(strategy.allocation.capital_limit, "USD")} />
+        <Metric label="Reserved" value={money(strategy.allocation.reserved_capital, "USD")} />
+        <Metric label="Currently invested" value={money(strategy.allocation.invested_capital, "USD")} />
+        <Metric label="Remaining" value={money(strategy.allocation.remaining_capital, "USD")} />
+      </div>
+
+      {strategy.exclusion_reason ? (
+        <p className="mb-3 text-xs text-amber-700 dark:text-amber-300">Backtest exclusion: {strategy.exclusion_reason}</p>
+      ) : null}
       <EvidenceTable windows={strategy.evidence_windows} />
+
       <details className="mt-3 text-xs text-slate-500">
-        <summary className="cursor-pointer">Allocation refusals and provenance</summary>
-        <p className="mt-2">{strategy.allocation_refusals.join(", ")}</p>
+        <summary className="cursor-pointer">Attribution and evidence detail</summary>
+        <div className="mt-2 grid gap-2 sm:grid-cols-2">
+          <p>Funded shadow gross result: {pctPoints(attribution.funded_shadow_average_return_pct)}</p>
+          <p>Skipped shadow gross result: {pctPoints(attribution.rejected_shadow_average_return_pct)}</p>
+          <p>Skipped minus funded: {pctPoints(attribution.opportunity_gap_pct)}</p>
+          <p>Average slippage: {pctPoints(attribution.average_slippage_pct)}</p>
+          <p>Average stressed entry cost: {money(attribution.average_stressed_cost_usd, "USD")}</p>
+          <p>Highest observed account drawdown: {pctPoints(attribution.max_observed_account_drawdown_pct)}</p>
+        </div>
+        {pnl.incomplete_reasons.length > 0 ? <p className="mt-2">P&amp;L gaps: {pnl.incomplete_reasons.join(", ")}</p> : null}
+        <p className="mt-2">Allocation refusals: {strategy.allocation_refusals.join(", ") || "none"}</p>
         <p className="mt-1 break-all">Strategy version: {strategy.strategy_version}</p>
       </details>
+
+      <AllocationControl strategy={strategy} onUpdated={onUpdated} />
     </article>
+  );
+}
+
+function EntryBlockBanner({ state, stale }: { readonly state: StrategyEntryBlock; readonly stale: boolean }) {
+  if (!state.new_entries_blocked) return null;
+  return (
+    <div className="border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+      <div className="font-semibold">New strategy entries are blocked</div>
+      <div className="mt-1 text-xs">
+        {state.global_kill_reason ?? (state.execution_block_reasons.join(", ") || "A safety gate is active.")}
+        {stale ? " (stale — refreshing)" : ""}
+      </div>
+    </div>
   );
 }
 
 export function StrategiesPage() {
   const [cursor, setCursor] = useState<number | null>(null);
   const [cursorHistory, setCursorHistory] = useState<Array<number | null>>([]);
+  const [cachedEntryBlock, setCachedEntryBlock] = useState<StrategyEntryBlock | null>(null);
   const overview = useAsync(fetchStrategyOverview, []);
+  // useAsync captures fn via a ref — a fresh arrow per render is safe.
   const signals = useAsync(() => fetchFiredSignals(cursor), [cursor]);
+
+  useEffect(() => {
+    if (overview.data !== null) setCachedEntryBlock(overview.data.entry_block);
+  }, [overview.data]);
+  const displayedEntryBlock = overview.data?.entry_block ?? cachedEntryBlock;
 
   return (
     <div className="space-y-6">
       <header>
         <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-100">Strategies</h1>
         <p className="mt-1 max-w-4xl text-sm text-slate-600 dark:text-slate-400">
-          Read-only forward observation. Every current-version fired signal is shown whether funded or
-          unfunded; historical backtests remain separate. Allocation and broker execution are disabled.
+          Monitor every fired signal, compare the simultaneous shadow record with funded trades, and set audited
+          paper-capital ceilings. Manual positions remain in the account portfolio and never enter strategy P&amp;L.
         </p>
       </header>
 
-      <Section title="Strategy evidence" action="Exact current versions">
+      {displayedEntryBlock ? (
+        <EntryBlockBanner state={displayedEntryBlock} stale={overview.data === null} />
+      ) : null}
+
+      <Section title="Strategy picker" action="Exact current versions">
         {overview.loading ? <SectionSkeleton rows={8} /> : null}
         {overview.error ? <SectionError onRetry={overview.refetch} /> : null}
         {overview.data?.strategies.length === 0 ? (
-          <EmptyState
-            title="No registered strategies"
-            description="Add a strategy to the manifest before evidence can be monitored."
-          />
+          <EmptyState title="No registered strategies" description="Add a strategy to the manifest before evidence can be monitored." />
         ) : null}
         {overview.data && overview.data.strategies.length > 0 ? (
           <div className="space-y-6">
             {overview.data.strategies.map((strategy) => (
-              <StrategyPanel key={strategy.strategy_id} strategy={strategy} />
+              <StrategyPanel key={strategy.strategy_id} strategy={strategy} onUpdated={overview.refetch} />
             ))}
           </div>
         ) : null}
       </Section>
 
-      <Section title="Fired signals" action="Forward observation · all unfunded">
+      <Section title="Fired signals" action="Funded, rejected and shadow outcomes">
         {signals.loading ? <SectionSkeleton rows={6} /> : null}
         {signals.error ? <SectionError onRetry={signals.refetch} /> : null}
         {signals.data?.items.length === 0 ? (
@@ -151,37 +379,46 @@ export function StrategiesPage() {
         {signals.data && signals.data.items.length > 0 ? (
           <>
             <div className="overflow-x-auto">
-              <table className="min-w-full text-left text-xs">
+              <table className="min-w-full text-left text-sm">
                 <thead className="text-slate-500 dark:text-slate-400">
                   <tr>
-                    <th className="pb-2 pr-4 font-medium">Signal</th>
-                    <th className="pb-2 pr-4 font-medium">Instrument</th>
-                    <th className="pb-2 pr-4 font-medium">Fill</th>
-                    <th className="pb-2 pr-4 font-medium">Outcome</th>
-                    <th className="pb-2 font-medium">Funding</th>
+                    <th className="px-2 py-2 font-medium">Signal</th>
+                    <th className="px-2 py-2 font-medium">Instrument</th>
+                    <th className="px-2 py-2 text-right font-medium">Expected fill</th>
+                    <th className="px-2 py-2 text-right font-medium">Actual fill</th>
+                    <th className="px-2 py-2 font-medium">Shadow outcome</th>
+                    <th className="px-2 py-2 font-medium">Capital decision</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
                   {signals.data.items.map((signal) => (
                     <tr key={signal.signal_id}>
-                      <td className="py-2 pr-4">
+                      <td className="px-2 py-2">
                         <div>{signal.strategy_id}</div>
-                        <div className="text-slate-500">
-                          {signal.signal_kind} · {formatDate(signal.signal_bar_date)}
-                        </div>
+                        <div className="text-xs text-slate-500">{signal.signal_kind} · {formatDate(signal.signal_bar_date)}</div>
                       </td>
-                      <td className="py-2 pr-4">
+                      <td className="px-2 py-2">
                         <div className="font-medium">{signal.symbol}</div>
-                        <div className="text-slate-500">{signal.company_name ?? `#${signal.instrument_id}`}</div>
+                        <div className="text-xs text-slate-500">{signal.company_name ?? `#${signal.instrument_id}`}</div>
                       </td>
-                      <td className="py-2 pr-4 tabular-nums">
-                        {formatDate(signal.fill_bar_date)} · {number(signal.fill_price)}
+                      <td className="px-2 py-2 text-right tabular-nums">
+                        <div>{formatNumber(decimal(signal.fill_price), 4)}</div>
+                        <div className="text-xs text-slate-500">{formatDate(signal.fill_bar_date)}</div>
                       </td>
-                      <td className="py-2 pr-4">
-                        {signal.outcome ?? "pending"}
-                        {signal.gross_return_pct ? ` · ${number(signal.gross_return_pct, "%")}` : ""}
+                      <td className="px-2 py-2 text-right tabular-nums">
+                        <div>{formatNumber(decimal(signal.actual_fill_price), 4)}</div>
+                        <div className="text-xs text-slate-500">slippage {pctPoints(signal.slippage_pct)}</div>
                       </td>
-                      <td className="py-2 text-slate-500">unfunded · execution disabled</td>
+                      <td className="px-2 py-2">
+                        <div>{shadowOutcome(signal.outcome)}</div>
+                        <div className="text-xs tabular-nums text-slate-500">{pctPoints(signal.gross_return_pct)}</div>
+                      </td>
+                      <td className="px-2 py-2">
+                        <Badge tone={signal.funding_status === "funded" ? "ok" : signal.funding_status === "rejected" ? "risk" : "neutral"}>
+                          {signal.funding_status === "funded" ? "Funded" : signal.funding_status === "rejected" ? "Not funded" : "No capital needed"}
+                        </Badge>
+                        <div className="mt-1 text-xs text-slate-500">{humanizeCode(signal.funding_reason)}</div>
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -196,7 +433,7 @@ export function StrategiesPage() {
                   setCursorHistory((history) => history.slice(0, -1));
                   setCursor(previous);
                 }}
-                className="border border-slate-300 px-3 py-1 text-xs disabled:opacity-40 dark:border-slate-700"
+                className="min-h-11 cursor-pointer border border-slate-300 px-3 py-2 text-xs transition-colors duration-200 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:hover:bg-slate-800 dark:focus:ring-blue-900"
               >
                 Newer
               </button>
@@ -207,7 +444,7 @@ export function StrategiesPage() {
                   setCursorHistory((history) => [...history, cursor]);
                   setCursor(signals.data?.next_cursor ?? null);
                 }}
-                className="border border-slate-300 px-3 py-1 text-xs disabled:opacity-40 dark:border-slate-700"
+                className="min-h-11 cursor-pointer border border-slate-300 px-3 py-2 text-xs transition-colors duration-200 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-blue-300 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:hover:bg-slate-800 dark:focus:ring-blue-900"
               >
                 Older
               </button>

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -143,8 +143,8 @@ function AllocationControl({
   const parsedLimit = Number(limit);
   const canReduceRisk =
     strategy.allocation.deployment_id !== null &&
-    !enabled &&
-    parsedLimit <= Number(strategy.allocation.capital_limit);
+    parsedLimit <= Number(strategy.allocation.capital_limit) &&
+    (!enabled || strategy.allocation.enabled);
   const canSubmit =
     !submitting &&
     reason.trim().length > 0 &&

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -412,7 +412,7 @@ def test_evidence_invalid_enabled_allocation_can_reduce_without_disabling(
     version = _current_versions()[strategy_id]
     deployment_id = _deployment(ebull_test_conn, strategy_id, version)
     ebull_test_conn.execute(
-        "UPDATE strategy_deployments SET enabled=true WHERE deployment_id=%s",
+        "UPDATE strategy_deployments SET enabled=true, currency='EUR' WHERE deployment_id=%s",
         (deployment_id,),
     )
     ebull_test_conn.commit()
@@ -431,10 +431,11 @@ def test_evidence_invalid_enabled_allocation_can_reduce_without_disabling(
 
     assert response.enabled
     assert response.capital_limit == Decimal("500")
+    assert response.currency == "EUR"
     assert ebull_test_conn.execute(
-        "SELECT capital_limit, enabled FROM strategy_deployment_events WHERE deployment_id=%s",
+        "SELECT capital_limit, currency, enabled FROM strategy_deployment_events WHERE deployment_id=%s",
         (deployment_id,),
-    ).fetchone() == (Decimal("500.000000"), True)
+    ).fetchone() == (Decimal("500.000000"), "EUR", True)
 
 
 def test_disabled_pre_promotion_deployment_remains_visible_for_risk_reduction(
@@ -460,6 +461,18 @@ def test_missing_runtime_singleton_is_visible_as_an_entry_block(
 
     assert state.new_entries_blocked
     assert state.execution_block_reasons == ("runtime configuration unavailable",)
+    assert not state.auto_trading_enabled
+
+
+def test_disabled_automatic_trading_is_visible_as_an_entry_block(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.execute("UPDATE runtime_config SET enable_auto_trading=false")
+
+    state = load_entry_block_state(ebull_test_conn)
+
+    assert state.new_entries_blocked
+    assert "automatic trading disabled" in state.execution_block_reasons
     assert not state.auto_trading_enabled
 
 

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -218,6 +218,41 @@ def test_missing_owned_mark_is_unknown_not_zero(
     assert "active_position_mark_unavailable" in pnl.incomplete_reasons
 
 
+def test_unreconciled_funding_makes_all_owned_money_unknown(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "monitoring-unreconciled"
+    strategy_version = "monitoring-unreconciled-v1"
+    instrument_id = 2453005
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_funding_decisions (
+            signal_id, deployment_id, verdict, amount, reason_code
+        ) VALUES (%s, %s, 'allocated', 100, 'awaiting_reconciliation')
+        """,
+        (signal_id, deployment_id),
+    )
+
+    pnl = load_owned_pnl(ebull_test_conn, versions=[strategy_version])[(strategy_id, strategy_version)]
+
+    assert pnl.realised_pnl is None
+    assert pnl.unrealised_pnl is None
+    assert pnl.total_pnl is None
+    assert pnl.invested_capital is None
+    assert pnl.observed_fees is None
+    assert pnl.incomplete_reasons == ("funding_not_reconciled_to_trade",)
+
+
 def test_shadow_statistics_do_not_depend_on_later_allocation_configuration(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
@@ -368,6 +403,38 @@ def test_missing_evidence_refuses_new_allocation_without_writing_audit(
         "SELECT count(*) FROM strategy_deployments WHERE strategy_id=%s", (strategy_id,)
     ).fetchone() == (0,)
     assert ebull_test_conn.execute("SELECT count(*) FROM strategy_deployment_events").fetchone() == (0,)
+
+
+def test_evidence_invalid_enabled_allocation_can_reduce_without_disabling(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    version = _current_versions()[strategy_id]
+    deployment_id = _deployment(ebull_test_conn, strategy_id, version)
+    ebull_test_conn.execute(
+        "UPDATE strategy_deployments SET enabled=true WHERE deployment_id=%s",
+        (deployment_id,),
+    )
+    ebull_test_conn.commit()
+
+    response = update_strategy_allocation(
+        strategy_id,
+        AllocationUpdateRequest(
+            strategy_version=version,
+            capital_limit=Decimal("500"),
+            enabled=True,
+            reason="reduce risk while evidence is unavailable",
+        ),
+        _session(),
+        ebull_test_conn,
+    )
+
+    assert response.enabled
+    assert response.capital_limit == Decimal("500")
+    assert ebull_test_conn.execute(
+        "SELECT capital_limit, enabled FROM strategy_deployment_events WHERE deployment_id=%s",
+        (deployment_id,),
+    ).fetchone() == (Decimal("500.000000"), True)
 
 
 def test_disabled_pre_promotion_deployment_remains_visible_for_risk_reduction(

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -1,0 +1,444 @@
+"""#2453 exact-owned P&L and allocation-unbiased attribution tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+import psycopg
+import pytest
+from fastapi import HTTPException
+
+from app.api.strategies import (
+    AllocationUpdateRequest,
+    _current_versions,
+    get_fired_signals,
+    get_strategy_overview,
+    update_strategy_allocation,
+)
+from app.security.sessions import SessionRow
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_monitoring import (
+    load_attribution,
+    load_control_state,
+    load_entry_block_state,
+    load_owned_pnl,
+)
+
+
+def _instrument(conn: psycopg.Connection[Any], instrument_id: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (instrument_id, symbol, company_name, currency, is_tradable)
+        VALUES (%s, %s, %s, 'USD', true)
+        """,
+        (instrument_id, f"M{instrument_id}", f"Monitor {instrument_id}"),
+    )
+
+
+def _signal(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    strategy_id: str,
+    strategy_version: str,
+    signal_date: str,
+    fill_price: Decimal,
+) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id, strategy_version, instrument_id, signal_bar_date,
+            signal_kind, verdict, fill_bar_date, fill_price, universe,
+            input_rule_set_versions
+        ) VALUES (%s, %s, %s, %s, 'entry', 'fired', %s::date + 1,
+                  %s, 'survivorship_free',
+                  '{"indicator_series":"rules-v1"}'::jsonb)
+        RETURNING signal_id
+        """,
+        (strategy_id, strategy_version, instrument_id, signal_date, signal_date, fill_price),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _deployment(conn: psycopg.Connection[Any], strategy_id: str, strategy_version: str) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO strategy_deployments (
+            strategy_id, strategy_version, mode, capital_limit, currency,
+            enabled, revision, updated_by, reason
+        ) VALUES (%s, %s, 'paper', 1000, 'USD', false, 1, 'tester', 'monitoring test')
+        RETURNING deployment_id
+        """,
+        (strategy_id, strategy_version),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _funded_trade(conn: psycopg.Connection[Any], *, signal_id: int, deployment_id: int, instrument_id: int) -> int:
+    decision = conn.execute(
+        """
+        INSERT INTO strategy_funding_decisions (
+            signal_id, deployment_id, verdict, amount, reason_code
+        ) VALUES (%s, %s, 'allocated', 100, 'test_funded')
+        RETURNING funding_decision_id
+        """,
+        (signal_id, deployment_id),
+    ).fetchone()
+    assert decision is not None
+    trade = conn.execute(
+        """
+        INSERT INTO strategy_trades (funding_decision_id, instrument_id, status)
+        VALUES (%s, %s, 'open') RETURNING strategy_trade_id
+        """,
+        (decision[0], instrument_id),
+    ).fetchone()
+    assert trade is not None
+    return int(trade[0])
+
+
+def test_owned_pnl_excludes_manual_same_instrument_lifecycle(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "monitoring-owned"
+    strategy_version = "monitoring-owned-v1"
+    instrument_id = 2453001
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO broker_positions (
+            position_id, instrument_id, is_buy, units, initial_units, amount,
+            initial_amount_in_dollars, open_rate, open_conversion_rate,
+            open_date_time, raw_payload
+        ) VALUES
+          (7001, %s, true, 5, 10, 100, 100, 10, 1, now(), '{}'::jsonb),
+          (7002, %s, true, 8, 8, 80, 80, 10, 1, now(), '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_position_ownership (
+            strategy_trade_id, broker_position_id, status
+        ) VALUES (%s, 7001, 'active')
+        """,
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last)
+        VALUES (%s, now(), 11.9, 12.1, 12)
+        """,
+        (instrument_id,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO trade_events (
+            position_id, etoro_instrument_id, instrument_id, event_kind, side,
+            units, price, executed_at, fees_usd, realized_pnl_usd, source, raw_payload
+        ) VALUES
+          (7001, %s, %s, 'close', 'sell', 5, 12, now(), 1.25, 12.50, 'etoro_history', '{}'::jsonb),
+          (7002, %s, %s, 'close', 'sell', 8, 30, now(), 20, 999, 'etoro_history', '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id, instrument_id, instrument_id),
+    )
+
+    pnl = load_owned_pnl(ebull_test_conn, versions=[strategy_version])[(strategy_id, strategy_version)]
+
+    assert pnl.realised_pnl == Decimal("12.50")
+    assert pnl.unrealised_pnl == Decimal("10")
+    assert pnl.total_pnl == Decimal("22.50")
+    assert pnl.observed_fees == Decimal("1.25")
+    assert pnl.invested_capital == Decimal("100")
+    assert pnl.owned_position_count == 1
+    assert pnl.complete
+
+
+def test_missing_owned_mark_is_unknown_not_zero(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "monitoring-missing-mark"
+    strategy_version = "monitoring-missing-mark-v1"
+    instrument_id = 2453002
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO broker_positions (
+            position_id, instrument_id, is_buy, units, amount,
+            initial_amount_in_dollars, open_rate, open_conversion_rate,
+            open_date_time, raw_payload
+        ) VALUES (7101, %s, true, 5, 100, 100, 10, 1, now(), '{}'::jsonb)
+        """,
+        (instrument_id,),
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id) VALUES (%s, 7101)",
+        (trade_id,),
+    )
+
+    pnl = load_owned_pnl(ebull_test_conn, versions=[strategy_version])[(strategy_id, strategy_version)]
+
+    assert pnl.unrealised_pnl is None
+    assert pnl.total_pnl is None
+    assert "active_position_mark_unavailable" in pnl.incomplete_reasons
+
+
+def test_shadow_statistics_do_not_depend_on_later_allocation_configuration(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "monitoring-shadow"
+    strategy_version = "monitoring-shadow-v1"
+    instrument_id = 2453003
+    _instrument(ebull_test_conn, instrument_id)
+    funded_signal = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("100"),
+    )
+    rejected_signal = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-03",
+        fill_price=Decimal("100"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=funded_signal,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    order = ebull_test_conn.execute(
+        """
+        INSERT INTO orders (
+            instrument_id, action, order_type, requested_amount, status, execution_origin
+        ) VALUES (%s, 'BUY', 'MARKET', 100, 'rejected', 'strategy') RETURNING order_id
+        """,
+        (instrument_id,),
+    ).fetchone()
+    assert order is not None
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_trade_orders (strategy_trade_id, order_id, purpose)
+        VALUES (%s, %s, 'entry')
+        """,
+        (trade_id, order[0]),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_order_position_executions (
+            order_id, broker_position_id, opening_units, average_price
+        ) VALUES (%s, 7201, 1, 101)
+        """,
+        (order[0],),
+    )
+    for signal_id, result in ((funded_signal, Decimal("10")), (rejected_signal, Decimal("-4"))):
+        ebull_test_conn.execute(
+            """
+            INSERT INTO strategy_outcomes (
+                signal_id, rule_set_version, input_rule_set_version, outcome,
+                resolution_method, exit_bar_date, exit_price, bars_held, gross_return_pct
+            ) VALUES (%s, %s, %s, 'expired', 'daily_bar', '2026-08-08', 100, 3, %s)
+            """,
+            (signal_id, OUTCOME_RULE_SET_VERSION, QUARANTINE_RULE_SET_VERSION, result),
+        )
+
+    before = load_attribution(
+        ebull_test_conn,
+        versions=[strategy_version],
+        outcome_version=OUTCOME_RULE_SET_VERSION,
+        input_version=QUARANTINE_RULE_SET_VERSION,
+    )[(strategy_id, strategy_version)]
+    ebull_test_conn.execute(
+        "UPDATE strategy_deployments SET capital_limit=750, revision=2 WHERE deployment_id=%s",
+        (deployment_id,),
+    )
+    after = load_attribution(
+        ebull_test_conn,
+        versions=[strategy_version],
+        outcome_version=OUTCOME_RULE_SET_VERSION,
+        input_version=QUARANTINE_RULE_SET_VERSION,
+    )[(strategy_id, strategy_version)]
+
+    assert before == after
+    assert before.shadow_average_return_pct == Decimal("3")
+    assert before.funded_shadow_average_return_pct == Decimal("10")
+    assert before.rejected_shadow_average_return_pct == Decimal("-4")
+    assert before.opportunity_gap_pct == Decimal("-14")
+    assert before.funded_capture_rate == Decimal("0.5")
+    assert before.fill_rate == Decimal("1")
+    assert before.broker_rejected_entries == 0
+    assert before.broker_rejection_rate == Decimal("0")
+    assert before.average_slippage_pct == Decimal("1")
+
+
+def test_unprocessed_current_entry_is_visible_as_not_funded_with_reason(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    strategy_version = _current_versions()[strategy_id]
+    instrument_id = 2453004
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+
+    response = get_fired_signals(cursor=None, limit=50, conn=ebull_test_conn)
+    signal = next(item for item in response.items if item.signal_id == signal_id)
+
+    assert signal.funding_status == "rejected"
+    assert signal.funding_reason == "not_evaluated_by_allocator"
+    assert signal.funded_amount is None
+
+
+def _session(username: str = "allocation-operator") -> SessionRow:
+    now = datetime.now(UTC)
+    return SessionRow("test-session", uuid4(), username, now + timedelta(hours=1), now)
+
+
+def test_missing_evidence_refuses_new_allocation_without_writing_audit(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    version = _current_versions()[strategy_id]
+    ebull_test_conn.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_strategy_allocation(
+            strategy_id,
+            AllocationUpdateRequest(
+                strategy_version=version,
+                capital_limit=Decimal("100"),
+                enabled=False,
+                reason="test unavailable evidence",
+            ),
+            _session(),
+            ebull_test_conn,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert isinstance(exc_info.value.detail, dict)
+    assert exc_info.value.detail.get("reason") == "allocation_unavailable"
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_deployments WHERE strategy_id=%s", (strategy_id,)
+    ).fetchone() == (0,)
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_deployment_events").fetchone() == (0,)
+
+
+def test_disabled_pre_promotion_deployment_remains_visible_for_risk_reduction(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    version = _current_versions()[strategy_id]
+    deployment_id = _deployment(ebull_test_conn, strategy_id, version)
+
+    state = load_control_state(ebull_test_conn, versions=[version])[(strategy_id, version)]
+
+    assert state.stage is None
+    assert state.deployment_id == deployment_id
+    assert not state.enabled
+
+
+def test_missing_runtime_singleton_is_visible_as_an_entry_block(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.execute("DELETE FROM runtime_config")
+
+    state = load_entry_block_state(ebull_test_conn)
+
+    assert state.new_entries_blocked
+    assert state.execution_block_reasons == ("runtime configuration unavailable",)
+    assert not state.auto_trading_enabled
+
+
+def test_operator_allocation_uses_session_identity_and_immutable_event(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    strategy_id = "s1-time-series-momentum"
+    version = _current_versions()[strategy_id]
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_promotions (
+            strategy_id, strategy_version, from_stage, to_stage, gate_version,
+            evidence_ref, promoted_by, reason
+        ) VALUES
+          (%s, %s, NULL, 'research_candidate', 'test-v1', NULL, 'test', 'registered'),
+          (%s, %s, 'research_candidate', 'historical_validated', 'test-v1', 'e:hist', 'test', 'validated'),
+          (%s, %s, 'historical_validated', 'forward_observation', 'test-v1', 'e:fwd', 'test', 'observe'),
+          (%s, %s, 'forward_observation', 'paper_enabled', 'test-v1', 'e:paper', 'test', 'paper')
+        """,
+        (strategy_id, version, strategy_id, version, strategy_id, version, strategy_id, version),
+    )
+    overview = get_strategy_overview(ebull_test_conn)
+    strategy = next(row for row in overview.strategies if row.strategy_id == strategy_id)
+    strategy.allocation_ready = True
+    strategy.allocation_refusals = []
+    monkeypatch.setattr("app.api.strategies.get_strategy_overview", lambda _conn: overview)
+    ebull_test_conn.commit()
+
+    response = update_strategy_allocation(
+        strategy_id,
+        AllocationUpdateRequest(
+            strategy_version=version,
+            capital_limit=Decimal("250"),
+            enabled=True,
+            reason="bounded paper sleeve",
+        ),
+        _session("real-session-user"),
+        ebull_test_conn,
+    )
+
+    assert response.enabled
+    assert response.capital_limit == Decimal("250")
+    assert ebull_test_conn.execute(
+        """
+        SELECT capital_limit, enabled, changed_by, reason
+        FROM strategy_deployment_events WHERE deployment_id=%s
+        """,
+        (response.deployment_id,),
+    ).fetchone() == (Decimal("250.000000"), True, "real-session-user", "bounded paper sleeve")


### PR DESCRIPTION
Closes #2453
Refs #2437

## Outcome

Adds the operator-facing paper strategy accounting slice:

- exact-owned realised/unrealised strategy P&L, structurally excluding manual same-instrument positions;
- allocation-unbiased shadow outcomes, funded capture, fill/rejection, slippage and stressed-cost attribution;
- every fired signal shown with a capital verdict/reason and later shadow outcome;
- session-authenticated paper capital ceiling changes with immutable audit events;
- fail-closed allocation readiness and visible kill/reconciliation/runtime blocks;
- a compact strategy picker using existing ledgers, with no P&L snapshots or new schema.

Broker execution behavior is unchanged. Live execution remains unavailable pending #2450.

## Safety and data semantics

- Ownership is exact `strategy_position_ownership.broker_position_id`; instrument/symbol/FIFO inference is never used.
- Missing ownership, close history, broker snapshot, fee or positive mark is null with a reason, never zero.
- A recorded exact fill wins over a stale order status; the schema still enforces one entry order per trade.
- Allocation increases require complete recent evidence, positive lower expectancy bounds, paper/live promotion, qualifying pinned evidence, current scan and an explicit policy.
- Evidence-invalid allocations can only be disabled/reduced.
- Readiness evaluation and deployment mutation share the strategy advisory lock and transaction.
- Operator identity comes from the authenticated session; the browser cannot supply it.

## Database budget

No table, column, periodic writer or quote/P&L history is added. Refresh and market-price changes write zero rows.

Warm dev-DB plans for exact current versions:

| Read model | Measured time |
| --- | ---: |
| Attribution | 9.673 ms |
| Exact-owned P&L | 0.090 ms |
| Controls | 0.109 ms |
| 50 fired signals | 0.515 ms |

All reported zero shared-block reads. Existing signal retention and exact ledger indexes remain the storage boundary.

## Operator-figure review

| Figure | Decision | Reason |
| --- | --- | --- |
| Made you | Keep headline | Exact-owned actual P&L with completeness provenance |
| Shadow per signal | Keep headline | Allocation-independent gross price move, explicitly labelled gross |
| Captured | Keep headline | Funded entries / all fired entries |
| Filled | Keep headline | Exact detailed executions / funded entries |
| Evidence mechanisms | Demote | Visible in evidence table/details, not headline |
| Refusal codes | Demote | Human status first; exact codes retained in details |

## Validation

- Independent staged Codex review: clean after resolving fill-vs-stale-status attribution.
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- focused strategy backend: 47 tests passed before final review; #2453/API subset: 17 passed after final changes
- frontend strategy page: 6 passed
- frontend full unit suite: 1,490 passed
- frontend typecheck, dark-mode, pill and chart integrity gates passed
- full non-DB fast suite passed
- smoke/app-boot/schema-drift suite passed
- pre-push parity/retention/ownership/source-to-sink gates passed

The pre-push hook emitted the existing non-blocking dev database warning at 63 GB; this change adds no schema or periodic data and its measured read model stays within the documented budget.
