### PR TITLE
feat(strategies): show and close exact-owned positions

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections import Counter, defaultdict
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -9,15 +10,24 @@ from typing import Literal, cast
 
 import psycopg
 import psycopg.rows
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from psycopg.pq import TransactionStatus
 from pydantic import BaseModel, Field, model_validator
 
 from app.api.auth import require_session, require_session_or_service_token
+from app.api.portfolio import get_portfolio
 from app.config import settings
 from app.db import get_conn
+from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+from app.security.master_key import MasterKeyError, ensure_broker_key_loaded
+from app.security.secrets_crypto import CredentialCryptoConfigError
 from app.security.sessions import SessionRow
 from app.services.backtest_run import BACKTEST_UNIVERSE, runnable_strategies
+from app.services.broker_credentials import (
+    CredentialDecryptError,
+    CredentialNotFound,
+    load_credential_for_provider_use,
+)
 from app.services.cost_model import COST_MODEL_ID
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
@@ -32,6 +42,7 @@ from app.services.runtime_config import (
 from app.services.strategy_control_plane import (
     PAPER_ALLOCATOR_ADVISORY_LOCK,
     StrategyControlError,
+    StrategyOwnershipError,
     configure_deployment,
     configure_paper_pool,
     current_stage,
@@ -58,6 +69,10 @@ from app.services.strategy_monitoring import (
     load_entry_block_state,
     load_owned_pnl,
 )
+from app.services.strategy_position_manager import (
+    StrategyPositionManagerError,
+    manage_owned_position,
+)
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_result import CORPUS_VERSION
 
@@ -66,6 +81,8 @@ router = APIRouter(
     tags=["strategies"],
     dependencies=[Depends(require_session_or_service_token)],
 )
+
+logger = logging.getLogger(__name__)
 
 _TITLES = {
     "s1-time-series-momentum": "Time-series momentum",
@@ -272,6 +289,44 @@ class StrategyPnlHistoryPoint(BaseModel):
 
 class StrategyPnlHistoryResponse(BaseModel):
     points: list[StrategyPnlHistoryPoint]
+
+
+class StrategyOwnedPosition(BaseModel):
+    strategy_trade_id: int
+    broker_position_id: int
+    strategy_id: str
+    strategy_version: str
+    strategy_title: str
+    instrument_id: int
+    symbol: str
+    company_name: str | None
+    direction: Literal["long", "short"] | None
+    units: Decimal | None
+    assigned_value: Decimal | None
+    current_value: Decimal | None
+    unrealised_pnl: Decimal | None
+    unrealised_return_pct: Decimal | None
+    open_rate: Decimal | None
+    current_price: Decimal | None
+    stop_loss_rate: Decimal | None
+    take_profit_rate: Decimal | None
+    opened_at: datetime | None
+    currency: str
+    trade_status: Literal["open", "closing", "reconcile_required"]
+    valuation_available: bool
+
+
+class StrategyOwnedPositionsResponse(BaseModel):
+    positions: list[StrategyOwnedPosition]
+    live_quote_instrument_ids: list[int]
+
+
+class StrategyPositionCloseResponse(BaseModel):
+    strategy_trade_id: int
+    broker_position_id: int
+    state: Literal["submitted", "pending", "applied"]
+    reason_code: str
+    operation_id: int | None
 
 
 class FiredSignal(BaseModel):
@@ -898,6 +953,200 @@ def get_fired_signals(
         rows = list(cur.fetchall())
     items = [FiredSignal(**row) for row in rows]
     return FiredSignalsResponse(items=items, next_cursor=items[-1].signal_id if len(items) == limit else None)
+
+
+@router.get("/positions", response_model=StrategyOwnedPositionsResponse)
+def get_strategy_owned_positions(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyOwnedPositionsResponse:
+    """Return only exact, active automated positions.
+
+    Valuation is deliberately sourced through the Portfolio contract so the
+    same broker position cannot show a different assigned value or P&L on the
+    two pages.  Ownership metadata remains visible if the local broker snapshot
+    is temporarily missing; that is a reconciliation state, not a reason to
+    infer ownership from another position in the same instrument.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT ownership.strategy_trade_id,ownership.broker_position_id,
+                   trade.status AS trade_status,
+                   signal.strategy_id,signal.strategy_version,
+                   instrument.instrument_id,instrument.symbol,instrument.company_name
+            FROM strategy_position_ownership ownership
+            JOIN strategy_trades trade
+              ON trade.strategy_trade_id=ownership.strategy_trade_id
+            JOIN strategy_funding_decisions funding
+              ON funding.funding_decision_id=trade.funding_decision_id
+            JOIN strategy_signals signal ON signal.signal_id=funding.signal_id
+            JOIN instruments instrument ON instrument.instrument_id=trade.instrument_id
+            WHERE ownership.status='active'
+              AND trade.status IN ('open','closing','reconcile_required')
+            ORDER BY ownership.claimed_at DESC,ownership.ownership_id DESC
+            """
+        )
+        rows = list(cur.fetchall())
+
+    portfolio = get_portfolio(conn)
+    broker_positions = {trade.position_id: trade for position in portfolio.positions for trade in position.trades}
+    positions: list[StrategyOwnedPosition] = []
+    for row in rows:
+        broker_position_id = int(row["broker_position_id"])
+        broker_position = broker_positions.get(broker_position_id)
+        assigned = Decimal(str(broker_position.amount)) if broker_position is not None else None
+        unrealised = Decimal(str(broker_position.unrealized_pnl)) if broker_position is not None else None
+        return_pct = (
+            unrealised / assigned * Decimal("100")
+            if unrealised is not None and assigned is not None and assigned != 0
+            else None
+        )
+        strategy_id = str(row["strategy_id"])
+        positions.append(
+            StrategyOwnedPosition(
+                strategy_trade_id=int(row["strategy_trade_id"]),
+                broker_position_id=broker_position_id,
+                strategy_id=strategy_id,
+                strategy_version=str(row["strategy_version"]),
+                strategy_title=_TITLES.get(strategy_id, strategy_id),
+                instrument_id=int(row["instrument_id"]),
+                symbol=str(row["symbol"]),
+                company_name=(str(row["company_name"]) if row["company_name"] is not None else None),
+                direction=("long" if broker_position.is_buy else "short") if broker_position is not None else None,
+                units=Decimal(str(broker_position.units)) if broker_position is not None else None,
+                assigned_value=assigned,
+                current_value=(Decimal(str(broker_position.market_value)) if broker_position is not None else None),
+                unrealised_pnl=unrealised,
+                unrealised_return_pct=return_pct,
+                open_rate=Decimal(str(broker_position.open_rate)) if broker_position is not None else None,
+                current_price=(
+                    Decimal(str(broker_position.current_price))
+                    if broker_position is not None and broker_position.current_price is not None
+                    else None
+                ),
+                stop_loss_rate=(
+                    Decimal(str(broker_position.stop_loss_rate))
+                    if broker_position is not None and broker_position.stop_loss_rate is not None
+                    else None
+                ),
+                take_profit_rate=(
+                    Decimal(str(broker_position.take_profit_rate))
+                    if broker_position is not None and broker_position.take_profit_rate is not None
+                    else None
+                ),
+                opened_at=broker_position.open_date_time if broker_position is not None else None,
+                currency=broker_position.currency if broker_position is not None else "USD",
+                trade_status=cast(Literal["open", "closing", "reconcile_required"], row["trade_status"]),
+                valuation_available=broker_position is not None,
+            )
+        )
+    return StrategyOwnedPositionsResponse(
+        positions=positions,
+        live_quote_instrument_ids=sorted({position.instrument_id for position in positions}),
+    )
+
+
+def _load_strategy_broker_credentials(
+    conn: psycopg.Connection[object],
+    *,
+    request: Request,
+    session: SessionRow,
+) -> tuple[str, str]:
+    audit_pool = getattr(request.app.state, "audit_pool", None)
+    try:
+        if not ensure_broker_key_loaded(conn):
+            raise CredentialCryptoConfigError("broker credential key is unavailable")
+        api_key = load_credential_for_provider_use(
+            conn,
+            operator_id=session.operator_id,
+            provider="etoro",
+            label="api_key",
+            environment="demo",
+            caller="strategy_operator_close",
+            audit_pool=audit_pool,
+        )
+        conn.commit()
+        user_key = load_credential_for_provider_use(
+            conn,
+            operator_id=session.operator_id,
+            provider="etoro",
+            label="user_key",
+            environment="demo",
+            caller="strategy_operator_close",
+            audit_pool=audit_pool,
+        )
+        conn.commit()
+    except CredentialNotFound as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Demo broker credentials are not configured.",
+        ) from exc
+    except (CredentialDecryptError, CredentialCryptoConfigError, MasterKeyError) as exc:
+        logger.error("strategy operator close: credential loading failed", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Demo broker credentials could not be loaded.",
+        ) from exc
+    return api_key, user_key
+
+
+@router.post(
+    "/positions/{strategy_trade_id}/{broker_position_id}/close",
+    response_model=StrategyPositionCloseResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def close_strategy_owned_position(
+    strategy_trade_id: int,
+    broker_position_id: int,
+    request: Request,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyPositionCloseResponse:
+    """Submit a full close for one exact demo strategy-owned position."""
+    if settings.etoro_env != "demo":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Strategy position close is available only for the demo account.",
+        )
+    owned = conn.execute(
+        """
+        SELECT 1
+        FROM strategy_position_ownership ownership
+        JOIN strategy_trades trade
+          ON trade.strategy_trade_id=ownership.strategy_trade_id
+        WHERE ownership.strategy_trade_id=%s
+          AND ownership.broker_position_id=%s
+          AND ownership.status='active'
+          AND trade.status IN ('open','closing','reconcile_required')
+        """,
+        (strategy_trade_id, broker_position_id),
+    ).fetchone()
+    if owned is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Strategy-owned position not found.")
+
+    api_key, user_key = _load_strategy_broker_credentials(conn, request=request, session=session)
+    conn.commit()
+    try:
+        with EtoroBrokerProvider(api_key=api_key, user_key=user_key, env="demo") as broker:
+            result = manage_owned_position(
+                conn,
+                broker=broker,
+                strategy_trade_id=strategy_trade_id,
+                broker_position_id=broker_position_id,
+                close_reason="operator_close",
+            )
+    except (StrategyOwnershipError, StrategyPositionManagerError) as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    if result.state not in ("submitted", "pending", "applied"):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=result.reason_code)
+    return StrategyPositionCloseResponse(
+        strategy_trade_id=result.strategy_trade_id,
+        broker_position_id=result.broker_position_id,
+        state=result.state,
+        reason_code=result.reason_code,
+        operation_id=result.position_operation_id,
+    )
 
 
 @router.get("/pnl-history", response_model=StrategyPnlHistoryResponse)

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -661,7 +661,7 @@ def _submit_close(
     *,
     broker: BrokerProvider,
     owned: _OwnedPosition,
-    trigger_code: Literal["timeout", "strategy_exit", "emergency_risk"],
+    trigger_code: Literal["timeout", "strategy_exit", "emergency_risk", "operator_close"],
 ) -> PositionManagerResult:
     request_id = uuid4()
     with conn.transaction():
@@ -749,7 +749,7 @@ def manage_owned_position(
     strategy_trade_id: int,
     broker_position_id: int,
     ratchet_bar: RatchetBar | None = None,
-    close_reason: Literal["strategy_exit", "emergency_risk"] | None = None,
+    close_reason: Literal["strategy_exit", "emergency_risk", "operator_close"] | None = None,
     now: datetime | None = None,
 ) -> PositionManagerResult:
     """Verify or de-risk one exact owned position.

--- a/docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md
+++ b/docs/superpowers/specs/2026-08-04-ta-strategy-platform-design.md
@@ -379,7 +379,7 @@ presets" (#1917, `frontend/information-architecture` skill).
 | market heat map | `/research?view=heatmap` | same universe rendered as a treemap; first consumer of the spine |
 | per-instrument TA workings + signal history | `/instrument/:symbol/chart` (**exists**) | overlays belong on the chart, not a new page |
 | strategy performance (win rate, frequency, sample size, CI) | **new route** | keyed on *strategy*, not instrument — a different noun, so not a hub preset |
-| paper portfolio + capital allocation | **route distinct from `/portfolio`** | demo and live money must never share a surface |
+| automated portfolio subset + capital allocation | **strategy route, with the same positions also present in `/portfolio`** | the strategy route is an ownership-filtered control lens, not a second broker portfolio |
 | collector health, strategy enable/disable, kill switch | `/admin`, `/admin/ingest-health` | `ProcessesTable` / `JobsTable` exist; the collector becomes a monitored process |
 
 ### 4.1 Product semantics correction (#2464, 2026-08-10)
@@ -418,6 +418,30 @@ current daily-close rules, because that changes the rule and its evidence.
 The three result levels from the validity proposal remain separate everywhere:
 per-signal outcome, per-strategy sleeve performance, and total automated-pot
 performance. Only the latter belongs in the workspace hero.
+
+### 4.2 Exact-owned position contract (#2467, 2026-08-10)
+
+The workspace includes a compact open-position table only when an automated
+trade owns an active broker position. Each row shows the instrument, strategy,
+assigned and current value, unrealised P&L and return, actual broker stop loss,
+take profit and lifecycle state. Valuation must be the same contract used by
+`/portfolio`; the strategy route must not create a competing valuation formula
+or persist periodic valuation snapshots.
+
+Ownership is resolved only by the exact
+`(strategy_trade_id, broker_position_id)` row in
+`strategy_position_ownership`. Instrument, FIFO and “only position in this
+ticker” inference are forbidden because a manual and automated position may
+coexist in the same instrument. The main Portfolio therefore continues to show
+both positions while the strategy workspace shows only the automated subset.
+
+An operator close from this table is a full, demo-only, risk-reducing action.
+It remains available while new entries or the automated pot are paused, routes
+through the existing exact-owned position manager, and writes the bounded
+material-operation reason `operator_close`. The row remains `closing` until the
+exact broker close order reconciles; only reconciliation releases ownership,
+closes the strategy trade and feeds realised strategy P&L. No position history
+or quote history table is introduced by this surface.
 
 ## 5. Phases
 

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -4,8 +4,10 @@ import type {
   AllocationUpdateResponse,
   FiredSignalsResponse,
   StrategyOverviewResponse,
+  StrategyOwnedPositionsResponse,
   StrategyPaperPool,
   StrategyPnlHistoryResponse,
+  StrategyPositionCloseResponse,
 } from "@/api/types";
 
 export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
@@ -23,6 +25,20 @@ export function fetchFiredSignals(cursor: number | null, strategyId?: string): P
 
 export function fetchStrategyPnlHistory(): Promise<StrategyPnlHistoryResponse> {
   return apiFetch("/strategies/pnl-history");
+}
+
+export function fetchStrategyOwnedPositions(): Promise<StrategyOwnedPositionsResponse> {
+  return apiFetch("/strategies/positions");
+}
+
+export function closeStrategyOwnedPosition(
+  strategyTradeId: number,
+  brokerPositionId: number,
+): Promise<StrategyPositionCloseResponse> {
+  return apiFetch(
+    `/strategies/positions/${strategyTradeId}/${brokerPositionId}/close`,
+    { method: "POST" },
+  );
 }
 
 export function updateStrategyPaperPool(body: {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2563,6 +2563,44 @@ export interface StrategyPnlHistoryResponse {
   points: StrategyPnlHistoryPoint[];
 }
 
+export interface StrategyOwnedPosition {
+  strategy_trade_id: number;
+  broker_position_id: number;
+  strategy_id: string;
+  strategy_version: string;
+  strategy_title: string;
+  instrument_id: number;
+  symbol: string;
+  company_name: string | null;
+  direction: "long" | "short" | null;
+  units: string | null;
+  assigned_value: string | null;
+  current_value: string | null;
+  unrealised_pnl: string | null;
+  unrealised_return_pct: string | null;
+  open_rate: string | null;
+  current_price: string | null;
+  stop_loss_rate: string | null;
+  take_profit_rate: string | null;
+  opened_at: string | null;
+  currency: string;
+  trade_status: "open" | "closing" | "reconcile_required";
+  valuation_available: boolean;
+}
+
+export interface StrategyOwnedPositionsResponse {
+  positions: StrategyOwnedPosition[];
+  live_quote_instrument_ids: number[];
+}
+
+export interface StrategyPositionCloseResponse {
+  strategy_trade_id: number;
+  broker_position_id: number;
+  state: "submitted" | "pending" | "applied";
+  reason_code: string;
+  operation_id: number | null;
+}
+
 export interface FiredSignal {
   signal_id: number;
   strategy_id: string;

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as strategiesApi from "@/api/strategies";
-import type { StrategyOverviewResponse, StrategyResultArm } from "@/api/types";
+import type { StrategyOverviewResponse, StrategyOwnedPosition, StrategyResultArm } from "@/api/types";
 import { StrategiesPage } from "@/pages/StrategiesPage";
 
 const ARM: StrategyResultArm = {
@@ -110,6 +110,31 @@ const OVERVIEW: StrategyOverviewResponse = {
   }],
 };
 
+const OWNED_POSITION: StrategyOwnedPosition = {
+  strategy_trade_id: 41,
+  broker_position_id: 7001,
+  strategy_id: "s1-time-series-momentum",
+  strategy_version: "strategy-registry-v1+abc",
+  strategy_title: "Time-series momentum",
+  instrument_id: 101,
+  symbol: "ACME",
+  company_name: "Acme Corp",
+  direction: "long",
+  units: "5",
+  assigned_value: "100",
+  current_value: "110",
+  unrealised_pnl: "10",
+  unrealised_return_pct: "10",
+  open_rate: "10",
+  current_price: "12",
+  stop_loss_rate: "9",
+  take_profit_rate: "14",
+  opened_at: "2026-08-08T12:00:00Z",
+  currency: "USD",
+  trade_status: "open",
+  valuation_available: true,
+};
+
 function approvedOverview(): StrategyOverviewResponse {
   const strategy = OVERVIEW.strategies[0]!;
   return {
@@ -142,6 +167,10 @@ describe("StrategiesPage", () => {
     vi.restoreAllMocks();
     vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(OVERVIEW);
     vi.spyOn(strategiesApi, "fetchStrategyPnlHistory").mockResolvedValue({ points: [] });
+    vi.spyOn(strategiesApi, "fetchStrategyOwnedPositions").mockResolvedValue({
+      positions: [],
+      live_quote_instrument_ids: [],
+    });
   });
 
   it("keeps unapproved backtests out of portfolio performance", async () => {
@@ -216,6 +245,42 @@ describe("StrategiesPage", () => {
     expect(within(performance).getByText("+60.00%")).toBeInTheDocument();
     expect(screen.getByText("1 approved")).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Enabled" })).toBeEnabled();
+  });
+
+  it("shows a compact portfolio row for each exact automated position", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(approvedOverview());
+    vi.mocked(strategiesApi.fetchStrategyOwnedPositions).mockResolvedValue({
+      positions: [OWNED_POSITION],
+      live_quote_instrument_ids: [101],
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const section = (await screen.findByText("Open automated positions")).closest("section")!;
+    expect(within(section).getByText("ACME")).toBeInTheDocument();
+    expect(within(section).getByText("US$100.00")).toBeInTheDocument();
+    expect(within(section).getByText("US$110.00")).toBeInTheDocument();
+    expect(within(section).getByText("+10.00%")).toBeInTheDocument();
+    expect(within(section).getByText("US$9.00")).toBeInTheDocument();
+    expect(within(section).getByText("US$14.00")).toBeInTheDocument();
+  });
+
+  it("submits an exact strategy-aware close and explains that manual positions are untouched", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(approvedOverview());
+    vi.mocked(strategiesApi.fetchStrategyOwnedPositions).mockResolvedValue({
+      positions: [OWNED_POSITION],
+      live_quote_instrument_ids: [101],
+    });
+    const close = vi.spyOn(strategiesApi, "closeStrategyOwnedPosition").mockResolvedValue({
+      strategy_trade_id: 41,
+      broker_position_id: 7001,
+      state: "submitted",
+      reason_code: "broker_close_accepted",
+      operation_id: 88,
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByRole("button", { name: "Close" }));
+    expect(screen.getByText("A separate manual position in ACME is not part of this request and will remain untouched.")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Close position" }));
+    await waitFor(() => expect(close).toHaveBeenCalledWith(41, 7001));
   });
 
   it("toggles an approved strategy for the next run", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -3,7 +3,9 @@ import type { FormEvent } from "react";
 import { Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 import {
+  closeStrategyOwnedPosition,
   fetchStrategyOverview,
+  fetchStrategyOwnedPositions,
   fetchStrategyPnlHistory,
   updateStrategyAllocation,
   updateStrategyPaperPool,
@@ -12,15 +14,20 @@ import type {
   StrategyEvidenceWindow,
   StrategyOverview,
   StrategyOverviewResponse,
+  StrategyOwnedPosition,
   StrategyResultArm,
 } from "@/api/types";
+import { ApiError } from "@/api/client";
 import { ChartTooltip } from "@/components/charts/ChartTooltip";
 import { SectionError, SectionSkeleton } from "@/components/dashboard/Section";
+import { LiveQuoteProvider, useLiveTick } from "@/components/quotes/LiveQuoteProvider";
 import { EmptyState } from "@/components/states/EmptyState";
 import { Badge } from "@/components/ui/Badge";
+import { Modal } from "@/components/ui/Modal";
 import { formatDate, formatMoney, formatNumber, formatPct } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
 import { useChartTheme } from "@/lib/useChartTheme";
+import { liveTickPriceIn } from "@/lib/useLiveQuote";
 
 function number(value: string | null): number | null {
   if (value === null) return null;
@@ -214,6 +221,202 @@ function EmptyPnlChart() {
         </p>
       </div>
     </div>
+  );
+}
+
+function StrategyPositionRow({
+  position,
+  onClose,
+}: {
+  position: StrategyOwnedPosition;
+  onClose: (position: StrategyOwnedPosition) => void;
+}) {
+  const tick = useLiveTick(position.instrument_id);
+  const livePrice = liveTickPriceIn(tick, position.currency);
+  const snapshotPrice = number(position.current_price);
+  const parsedLivePrice = livePrice === null ? null : Number(livePrice.value);
+  const currentPrice = parsedLivePrice !== null && Number.isFinite(parsedLivePrice)
+    ? parsedLivePrice
+    : snapshotPrice;
+  const assigned = number(position.assigned_value);
+  const units = number(position.units);
+  const openRate = number(position.open_rate);
+  const liveValuationAvailable = assigned !== null
+    && units !== null
+    && openRate !== null
+    && currentPrice !== null
+    && position.direction !== null;
+  const currentValue = liveValuationAvailable
+    ? assigned + units * (
+      position.direction === "long" ? currentPrice - openRate : openRate - currentPrice
+    )
+    : number(position.current_value);
+  const pnl = currentValue !== null && assigned !== null
+    ? currentValue - assigned
+    : number(position.unrealised_pnl);
+  const pnlRatio = pnl !== null && assigned !== null && assigned !== 0 ? pnl / assigned : null;
+  const closing = position.trade_status === "closing";
+  const needsReconciliation = position.trade_status === "reconcile_required" || !position.valuation_available;
+
+  return (
+    <tr className="border-t border-slate-200 dark:border-slate-800">
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <strong className="text-sm">{position.symbol}</strong>
+          <Badge tone={closing ? "info" : needsReconciliation ? "warn" : "neutral"}>
+            {closing ? "Closing" : needsReconciliation ? "Check required" : position.direction ?? "Owned"}
+          </Badge>
+        </div>
+        <span className="mt-0.5 block max-w-48 truncate text-xs text-slate-500">
+          {position.company_name ?? `Position #${position.broker_position_id}`}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+        <span className="block font-medium text-slate-800 dark:text-slate-100">{position.strategy_title}</span>
+        <span className="text-slate-500">Opened {formatDate(position.opened_at)}</span>
+      </td>
+      <td className="px-4 py-3 text-right text-sm tabular-nums">{formatMoney(assigned, position.currency)}</td>
+      <td className="px-4 py-3 text-right text-sm tabular-nums">{formatMoney(currentValue, position.currency)}</td>
+      <td className={`px-4 py-3 text-right text-sm font-semibold tabular-nums ${pnl !== null && pnl < 0 ? "text-red-600 dark:text-red-300" : pnl !== null && pnl > 0 ? "text-emerald-700 dark:text-emerald-300" : ""}`}>
+        <span className="block">{formatMoney(pnl, position.currency)}</span>
+        <span className="text-xs">{formatPct(pnlRatio)}</span>
+      </td>
+      <td className="px-4 py-3 text-right text-sm tabular-nums">
+        <span className="block">{formatMoney(number(position.stop_loss_rate), position.currency)}</span>
+        <span className="text-[10px] text-slate-500">Stop loss</span>
+      </td>
+      <td className="px-4 py-3 text-right text-sm tabular-nums">
+        <span className="block">{formatMoney(number(position.take_profit_rate), position.currency)}</span>
+        <span className="text-[10px] text-slate-500">Take profit</span>
+      </td>
+      <td className="px-4 py-3 text-right">
+        <button
+          type="button"
+          disabled={closing}
+          onClick={() => onClose(position)}
+          className="min-h-11 cursor-pointer border border-slate-300 px-3 text-xs font-medium hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
+        >
+          {closing ? "Closing…" : "Close"}
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+function OpenStrategyPositions({
+  positions,
+  onClose,
+}: {
+  positions: StrategyOwnedPosition[];
+  onClose: (position: StrategyOwnedPosition) => void;
+}) {
+  return (
+    <section className="border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex flex-wrap items-start justify-between gap-2 px-5 py-4">
+        <div>
+          <h2 className="text-sm font-semibold">Open automated positions</h2>
+          <p className="mt-1 text-xs text-slate-500">
+            Exact strategy-owned trades only. They also remain visible in the main Portfolio.
+          </p>
+        </div>
+        <span className="text-xs text-slate-500">{positions.length} open</span>
+      </div>
+      {positions.length === 0 ? (
+        <div className="border-t border-slate-200 px-5 py-5 text-sm text-slate-500 dark:border-slate-800">
+          No automated positions are open. This section appears when an approved strategy receives a broker position.
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[64rem]">
+            <thead className="border-t border-slate-200 text-left text-[10px] font-semibold uppercase tracking-wider text-slate-500 dark:border-slate-800">
+              <tr>
+                <th className="px-4 py-2">Position</th>
+                <th className="px-4 py-2">Strategy</th>
+                <th className="px-4 py-2 text-right">Assigned</th>
+                <th className="px-4 py-2 text-right">Current</th>
+                <th className="px-4 py-2 text-right">Gain / loss</th>
+                <th className="px-4 py-2 text-right">SL</th>
+                <th className="px-4 py-2 text-right">TP</th>
+                <th className="px-4 py-2"><span className="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              {positions.map((position) => (
+                <StrategyPositionRow
+                  key={`${position.strategy_trade_id}:${position.broker_position_id}`}
+                  position={position}
+                  onClose={onClose}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StrategyCloseModal({
+  position,
+  onRequestClose,
+  onAccepted,
+}: {
+  position: StrategyOwnedPosition | null;
+  onRequestClose: () => void;
+  onAccepted: () => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useEffect(() => {
+    setSubmitting(false);
+    setError(null);
+  }, [position]);
+
+  async function submit() {
+    if (position === null || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await closeStrategyOwnedPosition(position.strategy_trade_id, position.broker_position_id);
+      onAccepted();
+      onRequestClose();
+    } catch (caught) {
+      setError(caught instanceof ApiError ? caught.message : "The close request could not be submitted.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      isOpen={position !== null}
+      onRequestClose={submitting ? () => undefined : onRequestClose}
+      label={`Close ${position?.symbol ?? "automated position"}`}
+    >
+      {position ? (
+        <div className="space-y-4">
+          <div>
+            <h2 className="text-base font-semibold">Close {position.symbol}</h2>
+            <p className="mt-1 text-xs text-slate-500">
+              {position.strategy_title} · broker position #{position.broker_position_id}
+            </p>
+          </div>
+          <p className="text-sm text-slate-700 dark:text-slate-200">
+            This submits a full close to the connected demo account. The strategy will show this position as Closing until the exact broker order reconciles.
+          </p>
+          <p className="text-xs text-slate-500">
+            A separate manual position in {position.symbol} is not part of this request and will remain untouched.
+          </p>
+          {error ? <p role="alert" className="text-xs text-red-700 dark:text-red-300">{error}</p> : null}
+          <div className="flex justify-end gap-2 border-t border-slate-200 pt-4 dark:border-slate-800">
+            <button type="button" disabled={submitting} onClick={onRequestClose} className="min-h-11 cursor-pointer border border-slate-300 px-4 text-sm disabled:opacity-50 dark:border-slate-700">Cancel</button>
+            <button type="button" disabled={submitting} onClick={() => void submit()} className="min-h-11 cursor-pointer border border-red-700 bg-red-700 px-4 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50">
+              {submitting ? "Submitting…" : "Close position"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </Modal>
   );
 }
 
@@ -495,6 +698,8 @@ function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
 export function StrategiesPage() {
   const overview = useAsync(fetchStrategyOverview, []);
   const pnlHistory = useAsync(fetchStrategyPnlHistory, []);
+  const ownedPositions = useAsync(fetchStrategyOwnedPositions, []);
+  const [closeFor, setCloseFor] = useState<StrategyOwnedPosition | null>(null);
   const summary = useMemo(() => overview.data ? aggregate(overview.data) : null, [overview.data]);
   const approvedStrategies = overview.data?.strategies.filter((strategy) => strategy.allocation_ready || strategy.allocation.enabled) ?? [];
   const researchCandidates = overview.data?.strategies.filter((strategy) => !strategy.allocation_ready && !strategy.allocation.enabled) ?? [];
@@ -553,6 +758,16 @@ export function StrategiesPage() {
             <AutomationControl overview={overview.data} approvedCount={summary.approved} onUpdated={overview.refetch} />
           </div>
 
+          {ownedPositions.loading ? (
+            <SectionSkeleton rows={3} />
+          ) : ownedPositions.error ? (
+            <SectionError onRetry={ownedPositions.refetch} />
+          ) : ownedPositions.data ? (
+            <LiveQuoteProvider instrumentIds={ownedPositions.data.live_quote_instrument_ids}>
+              <OpenStrategyPositions positions={ownedPositions.data.positions} onClose={setCloseFor} />
+            </LiveQuoteProvider>
+          ) : null}
+
           <SignalValidation overview={overview.data} />
 
           <section>
@@ -588,6 +803,16 @@ export function StrategiesPage() {
               {researchCandidates.map((strategy) => <ResearchCandidate key={strategy.strategy_id} strategy={strategy} />)}
             </div>
           </section>
+
+          <StrategyCloseModal
+            position={closeFor}
+            onRequestClose={() => setCloseFor(null)}
+            onAccepted={() => {
+              ownedPositions.refetch();
+              overview.refetch();
+              pnlHistory.refetch();
+            }}
+          />
         </>
       ) : null}
     </div>

--- a/sql/292_strategy_operator_position_close.sql
+++ b/sql/292_strategy_operator_position_close.sql
@@ -1,0 +1,24 @@
+-- 292_strategy_operator_position_close.sql
+--
+-- #2467 — operator-requested closes use the existing exact-owned position
+-- manager.  This adds one bounded audit reason to the material-operation
+-- ledger; it creates no quote, valuation, or position-history storage.
+
+ALTER TABLE strategy_position_operations
+    DROP CONSTRAINT IF EXISTS strategy_position_operations_trigger_code_check;
+
+ALTER TABLE strategy_position_operations
+    ADD CONSTRAINT strategy_position_operations_trigger_code_check CHECK (
+        trigger_code IN (
+            'entry_exit_gap',
+            'causal_resistance_break',
+            'timeout',
+            'strategy_exit',
+            'emergency_risk',
+            'operator_close'
+        )
+    );
+
+COMMENT ON COLUMN strategy_position_operations.trigger_code IS
+    'Why a material exact-position mutation occurred. operator_close is a '
+    'session-authenticated full close from the automated strategy workspace.';

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -4,19 +4,23 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import psycopg
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 from app.api.strategies import (
     AllocationUpdateRequest,
     StrategyPaperPoolUpdateRequest,
     _current_versions,
+    close_strategy_owned_position,
     get_fired_signals,
     get_strategy_overview,
+    get_strategy_owned_positions,
     update_strategy_allocation,
     update_strategy_paper_pool,
 )
@@ -29,6 +33,7 @@ from app.services.strategy_monitoring import (
     load_entry_block_state,
     load_owned_pnl,
 )
+from app.services.strategy_position_manager import PositionManagerResult
 
 
 def _instrument(conn: psycopg.Connection[Any], instrument_id: int) -> None:
@@ -174,6 +179,171 @@ def test_owned_pnl_excludes_manual_same_instrument_lifecycle(
     assert pnl.invested_capital == Decimal("100")
     assert pnl.owned_position_count == 1
     assert pnl.complete
+
+
+def test_strategy_positions_show_only_exact_owned_trade_with_portfolio_valuation(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "monitoring-owned"
+    strategy_version = "monitoring-owned-v1"
+    instrument_id = 2453011
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO broker_positions (
+            position_id, instrument_id, is_buy, units, initial_units, amount,
+            initial_amount_in_dollars, open_rate, open_conversion_rate,
+            open_date_time, stop_loss_rate, take_profit_rate, raw_payload
+        ) VALUES
+          (7011, %s, true, 5, 5, 100, 100, 10, 1, now(), 9, 14, '{}'::jsonb),
+          (7012, %s, true, 8, 8, 80, 80, 10, 1, now(), NULL, NULL, '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id),
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id) VALUES (%s, 7011)",
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last) VALUES (%s, now(), 11.9, 12.1, 12)",
+        (instrument_id,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO positions (
+            instrument_id, open_date, avg_cost, current_units, cost_basis, source
+        ) VALUES (%s, DATE '2026-08-01', 10, 13, 180, 'broker_sync')
+        """,
+        (instrument_id,),
+    )
+
+    response = get_strategy_owned_positions(ebull_test_conn)
+
+    assert len(response.positions) == 1
+    position = response.positions[0]
+    assert position.strategy_trade_id == trade_id
+    assert position.broker_position_id == 7011
+    assert position.assigned_value == Decimal("100.0")
+    assert position.current_value == Decimal("110.0")
+    assert position.unrealised_pnl == Decimal("10.0")
+    assert position.unrealised_return_pct == Decimal("10.0")
+    assert position.stop_loss_rate == Decimal("9.0")
+    assert position.take_profit_rate == Decimal("14.0")
+    assert response.live_quote_instrument_ids == [instrument_id]
+
+
+def test_strategy_position_close_passes_both_exact_ids_to_owned_manager(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    instrument_id = 2453012
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id="operator-close",
+        strategy_version="operator-close-v1",
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, "operator-close", "operator-close-v1")
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id) VALUES (%s, 7021)",
+        (trade_id,),
+    )
+    ebull_test_conn.commit()
+    request = Request({"type": "http", "app": SimpleNamespace(state=SimpleNamespace())})
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
+    monkeypatch.setattr(
+        "app.api.strategies._load_strategy_broker_credentials",
+        lambda *_args, **_kwargs: ("api", "user"),
+    )
+    provider = MagicMock()
+    provider.__enter__.return_value = MagicMock()
+    monkeypatch.setattr("app.api.strategies.EtoroBrokerProvider", lambda **_kwargs: provider)
+    managed: dict[str, object] = {}
+
+    def _manage(_conn: object, **kwargs: object) -> PositionManagerResult:
+        managed.update(kwargs)
+        return PositionManagerResult(trade_id, 7021, "submitted", "broker_close_accepted", 81)
+
+    monkeypatch.setattr("app.api.strategies.manage_owned_position", _manage)
+
+    response = close_strategy_owned_position(
+        trade_id,
+        7021,
+        request,
+        _session(),
+        ebull_test_conn,
+    )
+
+    assert response.state == "submitted"
+    assert managed["strategy_trade_id"] == trade_id
+    assert managed["broker_position_id"] == 7021
+    assert managed["close_reason"] == "operator_close"
+
+
+def test_strategy_position_close_rejects_unowned_same_instrument_id_before_broker_io(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    instrument_id = 2453013
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id="operator-close",
+        strategy_version="operator-close-v1",
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, "operator-close", "operator-close-v1")
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id) VALUES (%s, 7031)",
+        (trade_id,),
+    )
+    ebull_test_conn.commit()
+    request = Request({"type": "http", "app": SimpleNamespace(state=SimpleNamespace())})
+    credentials = MagicMock()
+    monkeypatch.setattr("app.api.strategies.settings.etoro_env", "demo")
+    monkeypatch.setattr("app.api.strategies._load_strategy_broker_credentials", credentials)
+
+    with pytest.raises(HTTPException) as exc:
+        close_strategy_owned_position(
+            trade_id,
+            7032,
+            request,
+            _session(),
+            ebull_test_conn,
+        )
+
+    assert exc.value.status_code == 404
+    credentials.assert_not_called()
 
 
 def test_missing_owned_mark_is_unknown_not_zero(

--- a/tests/test_strategy_position_manager.py
+++ b/tests/test_strategy_position_manager.py
@@ -455,6 +455,30 @@ def test_exact_close_remains_available_under_kill_switch_and_reconciles(
     )
 
 
+def test_operator_close_records_its_reason_and_never_targets_manual_same_instrument_position(
+    ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    trade_id, _, broker, manual = _opened_trade(conn, monkeypatch)
+
+    result = manage_owned_position(
+        conn,
+        broker=broker,
+        strategy_trade_id=trade_id,
+        broker_position_id=_POSITION_ID,
+        close_reason="operator_close",
+        now=_NOW,
+    )
+
+    assert result.state == "submitted"
+    assert broker.close_demo_strategy_position.call_args.kwargs["position_id"] == _POSITION_ID
+    assert manual.position_id == _MANUAL_POSITION_ID
+    assert conn.execute("SELECT operation_type, trigger_code FROM strategy_position_operations").fetchone() == (
+        "close",
+        "operator_close",
+    )
+
+
 def test_configured_timeout_submits_an_exact_position_close(
     ebull_test_conn: psycopg.Connection[Any], monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #2467

## Outcome
- adds a compact, live-valued automated-position table to the Strategies workspace
- shows assigned/current value, unrealised P&L and return, actual broker SL/TP, owning strategy, and lifecycle state
- keeps the same positions in the main Portfolio while filtering this surface by exact strategy ownership
- submits full demo closes through the audited exact-position manager with `operator_close` provenance
- keeps rows in Closing until exact broker reconciliation releases ownership and updates strategy P&L

## Safety and storage
- requires browser-session auth and demo environment for close mutations
- requires exact `(strategy_trade_id, broker_position_id)` active ownership; never infers by instrument/FIFO
- same-instrument manual positions are explicitly covered by backend tests
- adds no snapshot/history table; one material operation row is written only when a close is submitted

## Validation
- full pre-push gate green: ruff, pyright, fast tests, smoke, frontend integrity gates
- 26 focused backend strategy monitoring/position-manager tests pass
- 1,498 frontend tests pass
- frontend typecheck and production build pass
- dev migration applied and the empty positions read measured at 13 ms
