### PR TITLE
feat(strategies): resumable recent evidence refresh

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -75,6 +75,7 @@ from app.services.strategy_position_manager import (
 )
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_result import CORPUS_VERSION
+from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 
 router = APIRouter(
     prefix="/strategies",
@@ -83,6 +84,8 @@ router = APIRouter(
 )
 
 logger = logging.getLogger(__name__)
+
+_STRATEGY_BACKTEST_JOB = "strategy_backtest_run"
 
 _TITLES = {
     "s1-time-series-momentum": "Time-series momentum",
@@ -254,6 +257,19 @@ class StrategyPaperPoolView(BaseModel):
     remaining_capital: Decimal
 
 
+class EvidenceRefreshView(BaseModel):
+    frozen_through: date
+    completed_windows: int
+    partial_windows: int
+    total_windows: int
+    status: Literal["idle", "queued", "running", "failed", "complete"]
+    request_id: int | None
+    requested_at: datetime | None
+    finished_at: datetime | None
+    last_error: str | None
+    progress: dict[str, object] | None
+
+
 class StrategyOverviewResponse(BaseModel):
     as_of: datetime
     demo_connection: bool
@@ -266,7 +282,14 @@ class StrategyOverviewResponse(BaseModel):
     storage_policy: Literal["fired_signals_and_material_mutations_only"] = "fired_signals_and_material_mutations_only"
     entry_block: StrategyEntryBlockView
     paper_pool: StrategyPaperPoolView
+    evidence_refresh: EvidenceRefreshView
     strategies: list[StrategyOverview]
+
+
+class EvidenceRefreshRequestResponse(BaseModel):
+    request_id: int
+    status: Literal["queued", "running"]
+    already_active: bool
 
 
 class StrategyPaperPoolUpdateRequest(BaseModel):
@@ -638,6 +661,42 @@ _EXCLUSIONS_SQL = """
 # corpus on every Strategies page load.
 _LATEST_CORPUS_SQL = "SELECT MAX(last_bar) FROM research_price_series"
 
+_LATEST_EVIDENCE_REFRESH_SQL = """
+    SELECT p.request_id, p.status AS request_status, p.requested_at, p.error_msg AS request_error,
+           j.status AS run_status, j.finished_at, j.error_msg AS run_error, j.progress_json
+    FROM pending_job_requests p
+    LEFT JOIN LATERAL (
+        SELECT status, finished_at, error_msg, progress_json
+        FROM job_runs
+        WHERE linked_request_id = p.request_id
+        ORDER BY run_id DESC
+        LIMIT 1
+    ) j ON true
+    WHERE p.job_name = %(job_name)s
+      AND p.request_kind = 'manual_job'
+      AND p.payload -> 'params' ->> 'refresh_recent' = 'true'
+    ORDER BY p.request_id DESC
+    LIMIT 1
+"""
+
+
+def _evidence_refresh_status(
+    row: dict[str, object] | None,
+) -> tuple[Literal["idle", "queued", "running", "failed", "complete"], str | None]:
+    if row is None:
+        return "idle", None
+    run_status = row["run_status"]
+    request_status = row["request_status"]
+    if run_status == "failure" or request_status == "rejected":
+        return "failed", cast(str | None, row["run_error"] or row["request_error"])
+    if run_status == "running":
+        return "running", None
+    if request_status == "completed" and run_status in {"success", "degraded"}:
+        return "complete", cast(str | None, row["run_error"])
+    if request_status in {"pending", "claimed", "dispatched"}:
+        return "queued", None
+    return "idle", None
+
 
 @router.get("/overview", response_model=StrategyOverviewResponse)
 def get_strategy_overview(
@@ -667,6 +726,8 @@ def get_strategy_overview(
         cur.execute(_LATEST_CORPUS_SQL)
         latest_row = cur.fetchone()
         latest_corpus_date = None if latest_row is None else latest_row["max"]
+        cur.execute(_LATEST_EVIDENCE_REFRESH_SQL, {"job_name": _STRATEGY_BACKTEST_JOB})
+        refresh_row = cur.fetchone()
 
     attribution_by_strategy = load_attribution(
         conn,
@@ -846,6 +907,22 @@ def get_strategy_overview(
         if all(value is not None for value in invested_values)
         else None
     )
+    runnable_rows = [item for item in strategies if item.runnable]
+    completed_windows = sum(
+        all(
+            next(window for window in item.evidence_windows if window.window_id == window_id).status == "complete"
+            for item in runnable_rows
+        )
+        for window_id in RECENT_EVIDENCE_WINDOWS
+    )
+    partial_windows = sum(
+        any(
+            next(window for window in item.evidence_windows if window.window_id == window_id).status == "partial"
+            for item in runnable_rows
+        )
+        for window_id in RECENT_EVIDENCE_WINDOWS
+    )
+    refresh_status, refresh_error = _evidence_refresh_status(refresh_row)
     return StrategyOverviewResponse(
         as_of=datetime.now(tz=UTC),
         demo_connection=settings.etoro_env == "demo",
@@ -867,8 +944,86 @@ def get_strategy_overview(
             invested_capital=invested_total,
             remaining_capital=max(paper_pool.capital_limit - reserved_total, Decimal("0")),
         ),
+        evidence_refresh=EvidenceRefreshView(
+            frozen_through=max(item.window.end for item in RECENT_EVIDENCE_WINDOWS.values()),
+            completed_windows=completed_windows,
+            partial_windows=partial_windows,
+            total_windows=len(RECENT_EVIDENCE_WINDOWS),
+            status=refresh_status,
+            request_id=None if refresh_row is None else int(refresh_row["request_id"]),
+            requested_at=None if refresh_row is None else cast(datetime, refresh_row["requested_at"]),
+            finished_at=None if refresh_row is None else cast(datetime | None, refresh_row["finished_at"]),
+            last_error=refresh_error,
+            progress=None
+            if refresh_row is None or refresh_row["progress_json"] is None
+            else cast(dict[str, object], refresh_row["progress_json"]),
+        ),
         strategies=strategies,
     )
+
+
+@router.post(
+    "/evidence-refresh",
+    response_model=EvidenceRefreshRequestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def request_evidence_refresh(
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> EvidenceRefreshRequestResponse:
+    """Queue completion of the declared recent-regime evidence denominator.
+
+    There are deliberately no window or date inputs on this surface. The job
+    skips immutable completed identities, commits each missing pinned window as
+    a restart boundary, and refuses partial identities rather than overwriting
+    an audit record.
+    """
+    with conn.transaction():
+        conn.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", ("strategy-evidence-refresh",))
+        active = conn.execute(
+            """
+            SELECT p.request_id, p.status,
+                   EXISTS (
+                       SELECT 1 FROM job_runs j
+                       WHERE j.linked_request_id = p.request_id AND j.status = 'running'
+                   ) AS running
+            FROM pending_job_requests p
+            WHERE p.job_name = %(job_name)s
+              AND p.request_kind = 'manual_job'
+              AND p.status IN ('pending', 'claimed', 'dispatched')
+              AND p.payload -> 'params' ->> 'refresh_recent' = 'true'
+              AND NOT EXISTS (
+                  SELECT 1 FROM job_runs j
+                  WHERE j.linked_request_id = p.request_id
+                    AND j.status IN ('success', 'failure', 'degraded')
+              )
+            ORDER BY p.request_id DESC
+            LIMIT 1
+            FOR UPDATE OF p
+            """,
+            {"job_name": _STRATEGY_BACKTEST_JOB},
+        ).fetchone()
+        if active is not None:
+            active_row = cast(tuple[object, object, object], active)
+            return EvidenceRefreshRequestResponse(
+                request_id=int(cast(int, active_row[0])),
+                status="running" if active_row[2] else "queued",
+                already_active=True,
+            )
+        request_id = publish_manual_job_request_with_conn(
+            conn,
+            _STRATEGY_BACKTEST_JOB,
+            requested_by=session.username,
+            payload={
+                "params": {
+                    "refresh_recent": True,
+                    "holdout_purpose": "complete declared recent-regime evidence denominator",
+                    "holdout_accessed_by": session.username,
+                },
+                "control": {"override_bootstrap_gate": False},
+            },
+        )
+    return EvidenceRefreshRequestResponse(request_id=request_id, status="queued", already_active=False)
 
 
 _FIRED_SIGNALS_SQL = """

--- a/app/services/processes/param_metadata.py
+++ b/app/services/processes/param_metadata.py
@@ -317,6 +317,16 @@ MANUAL_TRIGGER_JOB_METADATA: dict[str, tuple[ParamMetadata, ...]] = {
                 "year-2026-ytd",
             ),
         ),
+        ParamMetadata(
+            name="refresh_recent",
+            label="Complete all recent evidence",
+            help_text=(
+                "Run every missing code-pinned recent window, committing one window at a time so a restart "
+                "can resume safely. Completed evidence is never overwritten and arbitrary dates remain forbidden."
+            ),
+            field_type="bool",
+            default=False,
+        ),
     ),
     "risk_metrics_refresh": (),
     # fair_value_band_refresh — #2009 deterministic fair-value band recompute.

--- a/app/services/sync_orchestrator/dispatcher.py
+++ b/app/services/sync_orchestrator/dispatcher.py
@@ -305,13 +305,71 @@ def reset_stale_in_flight(
     to ``pending`` so boot-drain replays them. Singleton-fence
     invariant guarantees the rows are not held by a live process.
 
-    Skips rows whose linked job_runs / sync_runs already reached a
-    terminal status — those completed before the crash and must not
-    double-run.
+    First reconciles rows whose linked ``job_runs`` / ``sync_runs`` already
+    reached a terminal status.  A successful linked run completes the queue
+    request; a failed linked run rejects it with the recorded error.  This is
+    not cosmetic: leaving such a request ``claimed``/``dispatched`` makes it
+    look active forever and can block later operator work even though boot's
+    orphan reaper has already proved that no worker owns it.
+
+    Rows without a terminal linked run are then reset for replay.  The two
+    actions are deliberately in this order so completed work is never run
+    twice.
 
     Returns the number of rows reset.
     """
     with conn.cursor() as cur:
+        cur.execute(
+            """
+            WITH latest AS (
+                SELECT DISTINCT ON (linked_request_id)
+                       linked_request_id, status, error_msg
+                FROM job_runs
+                WHERE linked_request_id IS NOT NULL
+                  AND status IN ('success', 'failure', 'degraded')
+                ORDER BY linked_request_id, run_id DESC
+            )
+            UPDATE pending_job_requests pjr
+            SET status = CASE
+                    WHEN latest.status IN ('success', 'degraded') THEN 'completed'
+                    ELSE 'rejected'
+                END,
+                error_msg = CASE
+                    WHEN latest.status = 'failure'
+                    THEN COALESCE(latest.error_msg, 'linked job failed before queue finalisation')
+                    ELSE pjr.error_msg
+                END
+            FROM latest
+            WHERE pjr.request_id = latest.linked_request_id
+              AND pjr.status IN ('claimed', 'dispatched')
+              AND pjr.claimed_by IS DISTINCT FROM %(current_boot_id)s
+            """,
+            {"current_boot_id": current_boot_id},
+        )
+        cur.execute(
+            """
+            WITH latest AS (
+                SELECT DISTINCT ON (linked_request_id)
+                       linked_request_id, status, error_category
+                FROM sync_runs
+                WHERE linked_request_id IS NOT NULL
+                  AND status IN ('complete', 'failed', 'partial', 'cancelled')
+                ORDER BY linked_request_id, sync_run_id DESC
+            )
+            UPDATE pending_job_requests pjr
+            SET status = CASE WHEN latest.status = 'complete' THEN 'completed' ELSE 'rejected' END,
+                error_msg = CASE
+                    WHEN latest.status <> 'complete'
+                    THEN COALESCE(latest.error_category, 'linked sync did not complete')
+                    ELSE pjr.error_msg
+                END
+            FROM latest
+            WHERE pjr.request_id = latest.linked_request_id
+              AND pjr.status IN ('claimed', 'dispatched')
+              AND pjr.claimed_by IS DISTINCT FROM %(current_boot_id)s
+            """,
+            {"current_boot_id": current_boot_id},
+        )
         cur.execute(
             """
             UPDATE pending_job_requests pjr

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -25,7 +25,7 @@ from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Final, Literal
+from typing import Any, Final, Literal, cast
 
 import psycopg
 import psycopg.rows
@@ -5016,6 +5016,9 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
       silently deflate against a register that has moved.
     * ``evidence_window`` (enum) — one pinned recent-evidence window. Raw dates
       are never accepted; selecting one also requires the audited hold-out pair.
+    * ``refresh_recent`` (bool) — complete every missing pinned recent window.
+      Each window commits independently, so a killed process resumes at the
+      next missing identity. Existing evidence is immutable and skipped.
 
     ⚠ ``row_count`` is RESULT ROWS written. Zero is never a success here: the
     service raises if a runnable strategy produced no row, because an absent row
@@ -5027,12 +5030,78 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
     insert of a pair would commit before the second failed.
     """
     from app.services.backtest_run import run_backtest
-    from app.services.strategy_recent_evidence import recent_evidence_window
+    from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS, recent_evidence_window
 
     with _tracked_job(JOB_STRATEGY_BACKTEST_RUN) as tracker:
+        refresh_recent = params.get("refresh_recent") is True
         evidence_window_id = _optional_str(params.get("evidence_window"))
+        if refresh_recent and (evidence_window_id is not None or _optional_str(params.get("strategy_id")) is not None):
+            raise ValueError("refresh_recent cannot be combined with evidence_window or strategy_id")
         evaluation_window = None if evidence_window_id is None else recent_evidence_window(evidence_window_id).window
         with connect_job() as conn:
+            if refresh_recent:
+                complete, partial = _recent_evidence_completion(conn)
+                if partial:
+                    raise RuntimeError(
+                        "recent evidence contains partial immutable windows "
+                        f"{sorted(partial)}; operator repair is required before a safe resume"
+                    )
+                rows_written = 0
+                newly_completed = 0
+                for window_id, item in RECENT_EVIDENCE_WINDOWS.items():
+                    if window_id in complete:
+                        continue
+                    report = run_backtest(
+                        conn,
+                        holdout_purpose=_optional_str(params.get("holdout_purpose")),
+                        holdout_accessed_by=_optional_str(params.get("holdout_accessed_by")),
+                        trial_register_version=_optional_str(params.get("trial_register_version")),
+                        evaluation_window=item.window,
+                    )
+                    # A window is the restart boundary. The ledger identities
+                    # are immutable, so keeping earlier windows uncommitted
+                    # would make an hours-long refresh start from zero.
+                    conn.commit()
+                    rows_written += report.rows_written
+                    newly_completed += 1
+                    tracker.row_count = rows_written
+                    tracker.progress = JobProgress(
+                        candidates_seen=len(RECENT_EVIDENCE_WINDOWS),
+                        outcomes={
+                            "already_complete": len(complete),
+                            "completed": newly_completed,
+                        },
+                    )
+                    if tracker.run_id:
+                        conn.execute(
+                            """
+                            UPDATE job_runs
+                            SET row_count = %(rows)s,
+                                progress_json = %(progress)s,
+                                last_progress_at = now()
+                            WHERE run_id = %(run_id)s AND status = 'running'
+                            """,
+                            {
+                                "rows": rows_written,
+                                "progress": Jsonb(tracker.progress.as_json()),
+                                "run_id": tracker.run_id,
+                            },
+                        )
+                        conn.commit()
+                tracker.row_count = rows_written
+                tracker.progress = JobProgress(
+                    candidates_seen=len(RECENT_EVIDENCE_WINDOWS),
+                    outcomes={
+                        "already_complete": len(complete),
+                        "completed": newly_completed,
+                    },
+                )
+                tracker.note = (
+                    "all pinned recent evidence was already complete"
+                    if newly_completed == 0
+                    else f"completed {newly_completed} missing recent evidence window(s)"
+                )
+                return
             report = run_backtest(
                 conn,
                 strategy_id=_optional_str(params.get("strategy_id")),
@@ -5042,6 +5111,74 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
                 evaluation_window=evaluation_window,
             )
             tracker.row_count = report.rows_written
+
+
+def _recent_evidence_completion(
+    conn: psycopg.Connection[Any],
+) -> tuple[set[str], set[str]]:
+    """Return structurally complete and partial pinned recent windows.
+
+    Expected result versions use the writer's complete immutable identity.
+    Counting dates alone could mistake stale cost, corpus or rule-set rows for
+    current evidence.
+    """
+    from app.services.backtest_run import BACKTEST_UNIVERSE, RESULT_SCOPE, runnable_strategies
+    from app.services.cost_model import COST_MODEL_ID
+    from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
+    from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+    from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
+    from app.services.research_price_structure_store import (
+        QUARANTINE_ARMS,
+        QUARANTINE_RULE_SET_VERSION,
+        QuarantineArm,
+    )
+    from app.services.strategy_manifest import STRATEGY_MANIFEST
+    from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
+    from app.services.strategy_result import AMBIGUITY_ARMS, CORPUS_VERSION, AmbiguityArm, ResultIdentity
+
+    runnable, _excluded = runnable_strategies()
+    expected: dict[str, set[str]] = {}
+    for window_id, item in RECENT_EVIDENCE_WINDOWS.items():
+        versions: set[str] = set()
+        for strategy_id in runnable:
+            entry = STRATEGY_MANIFEST[strategy_id]
+            strategy_version = entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+            for ambiguity_arm in AMBIGUITY_ARMS:
+                for quarantine_arm in QUARANTINE_ARMS:
+                    versions.add(
+                        ResultIdentity(
+                            strategy_id=strategy_id,
+                            strategy_version=strategy_version,
+                            result_scope=RESULT_SCOPE,
+                            namespace="hold_out",
+                            ambiguity_arm=cast(AmbiguityArm, ambiguity_arm),
+                            quarantine_arm=cast(QuarantineArm, quarantine_arm),
+                            sizing_rule=SIZING_RULE_ID,
+                            benchmark_rule=BENCHMARK_RULE_ID,
+                            cost_model_id=COST_MODEL_ID,
+                            corpus_version=CORPUS_VERSION,
+                            window_start=item.window.start,
+                            window_end=item.window.end,
+                            position_rule_set_version=POSITION_RULE_SET_VERSION,
+                            outcome_rule_set_version=OUTCOME_RULE_SET_VERSION,
+                            input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+                        ).version
+                    )
+        expected[window_id] = versions
+
+    all_versions = [version for versions in expected.values() for version in versions]
+    existing = {
+        str(row[0])
+        for row in conn.execute(
+            "SELECT result_version FROM strategy_results_store WHERE result_version = ANY(%s)",
+            (all_versions,),
+        ).fetchall()
+    }
+    complete = {window_id for window_id, versions in expected.items() if versions and versions <= existing}
+    partial = {
+        window_id for window_id, versions in expected.items() if versions & existing and not versions <= existing
+    }
+    return complete, partial
 
 
 def _optional_str(value: object) -> str | None:

--- a/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
+++ b/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
@@ -1,0 +1,93 @@
+# Strategy evidence refresh and capital semantics
+
+Status: implementation contract for #2469. This narrows, and does not weaken,
+the validation and execution gates in the existing TA specifications.
+
+## Operator promise
+
+The Strategies page separates three facts:
+
+1. live signal observation, which advances with the validated market-data
+   frontier;
+2. frozen research evidence, currently ending **2026-07-08** under
+   `CORPUS_VERSION`; and
+3. allocation/execution approval, which remains unavailable until every
+   evidence, cost, risk and broker-contract gate passes.
+
+“Refresh evidence” means complete the declared recent-regime denominator. It
+does not append today's data to the frozen corpus, select arbitrary dates, or
+replace an existing result. Advancing the frozen date is a deliberate corpus
+re-freeze: the corpus version moves and old results remain attributable to the
+old version.
+
+## Recent denominator
+
+The required windows remain code-pinned:
+
+- 2022 onward;
+- rolling 36 and 24 months;
+- calendar 2022, 2023, 2024 and 2025; and
+- 2026 year-to-frozen-date.
+
+One refresh evaluates the full runnable strategy set in each missing window so
+Deflated Sharpe uses the registered measured trials. Each completed window is
+committed as a restart boundary. A later run skips exact completed result
+identities. A partial immutable window is an operator-repair condition, never
+an invitation to overwrite the audit trail.
+
+Only compact aggregate results and hold-out access records are retained.
+Indicators, positions and returns are recomputed from the existing research
+bars while the job runs; no additional per-bar metric store is introduced.
+
+## What qualifies a strategy
+
+Win rate is descriptive, not a promotion target. A 75% win rate can be created
+by taking tiny profits against rare catastrophic losses and is therefore not a
+safety claim. Promotion continues to require, at minimum:
+
+- positive after-cost expectancy whose confidence interval excludes zero;
+- declared-trial/Deflated-Sharpe evidence and random-entry control;
+- stable recent-window performance, drawdown and tail-loss bounds;
+- point-in-time universe, quarantine and ambiguity-arm completeness;
+- measured broker costs, financing/borrow where applicable, and executable
+  stop/take-profit semantics; and
+- current signal scan plus approved paper execution policy.
+
+No rule is enabled merely because the UI can display it or a historical win
+rate exceeds a threshold.
+
+## Capital model (next implementation slice)
+
+The shared pot will carry an explicit mode:
+
+- `fixed`: the configured principal is the hard strategy-system ceiling;
+  profits do not increase it and losses reduce what remains available;
+- `compound`: the risk base is configured principal plus reconciled realised
+  strategy P&L; open marks never increase buying power, and incomplete P&L
+  reconciliation blocks new entries.
+
+Each approved strategy will carry an explicit ticket mode:
+
+- `fixed`: one configured currency amount per accepted signal; or
+- `percent`: one configured fraction of its effective allocated base, still
+  bounded by the shared remaining pot, per-instrument exposure, drawdown and
+  broker cash limits.
+
+These settings configure sizing only. They cannot bypass approval, health,
+cost, freshness, ownership or kill-switch gates. Manual portfolio positions
+remain outside strategy capital ownership and lifecycle decisions.
+
+## Candidate expansion
+
+The four current manifest rows are research controls, not a claim that only
+four trading ideas exist. New short-horizon candidates enter as registered,
+disabled trials. Current evidence supports investigating intraday residual
+reversal and carefully defined extreme-move reversal; the internal post-drop
+short result is a discovery candidate, not a clean hold-out result. Opening
+range breakout remains a cost-sensitivity spike. Order-flow imbalance is out
+of scope until a free source provides causal depth/aggressor data.
+
+Long/short support also requires borrow availability, financing, gap-through
+loss treatment, broker short eligibility and direction-aware signal/outcome/
+execution schemas. Leverage remains out of scope until the unlevered demo
+lifecycle passes forward observation and kill drills.

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -4,6 +4,7 @@ import type {
   AllocationUpdateResponse,
   FiredSignalsResponse,
   StrategyOverviewResponse,
+  StrategyEvidenceRefreshResponse,
   StrategyOwnedPositionsResponse,
   StrategyPaperPool,
   StrategyPnlHistoryResponse,
@@ -12,6 +13,10 @@ import type {
 
 export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
   return apiFetch("/strategies/overview");
+}
+
+export function requestStrategyEvidenceRefresh(): Promise<StrategyEvidenceRefreshResponse> {
+  return apiFetch("/strategies/evidence-refresh", { method: "POST" });
 }
 
 export function fetchFiredSignals(cursor: number | null, strategyId?: string): Promise<FiredSignalsResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2540,7 +2540,25 @@ export interface StrategyOverviewResponse {
   storage_policy: "fired_signals_and_material_mutations_only";
   entry_block: StrategyEntryBlock;
   paper_pool: StrategyPaperPool;
+  evidence_refresh: {
+    frozen_through: string;
+    completed_windows: number;
+    partial_windows: number;
+    total_windows: number;
+    status: "idle" | "queued" | "running" | "failed" | "complete";
+    request_id: number | null;
+    requested_at: string | null;
+    finished_at: string | null;
+    last_error: string | null;
+    progress: Record<string, unknown> | null;
+  };
   strategies: StrategyOverview[];
+}
+
+export interface StrategyEvidenceRefreshResponse {
+  request_id: number;
+  status: "queued" | "running";
+  already_active: boolean;
 }
 
 export interface StrategyPaperPool {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -65,6 +65,18 @@ const OVERVIEW: StrategyOverviewResponse = {
     invested_capital: "0.000000",
     remaining_capital: "1000.000000",
   },
+  evidence_refresh: {
+    frozen_through: "2026-07-08",
+    completed_windows: 1,
+    partial_windows: 0,
+    total_windows: 8,
+    status: "idle",
+    request_id: null,
+    requested_at: null,
+    finished_at: null,
+    last_error: null,
+    progress: null,
+  },
   strategies: [{
     strategy_id: "s1-time-series-momentum",
     strategy_version: "strategy-registry-v1+abc",
@@ -225,6 +237,20 @@ describe("StrategiesPage", () => {
     expect(screen.getByText("• Recent evidence windows are incomplete")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Next" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Previous" })).not.toBeInTheDocument();
+  });
+
+  it("queues the fixed recent-evidence denominator from the research header", async () => {
+    const refresh = vi.spyOn(strategiesApi, "requestStrategyEvidenceRefresh").mockResolvedValue({
+      request_id: 42,
+      status: "queued",
+      already_active: false,
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+
+    expect(await screen.findByText(/Evidence 1\/8/)).toHaveTextContent("frozen through 08 Jul 2026");
+    await userEvent.click(screen.getByRole("button", { name: "Refresh evidence" }));
+
+    await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
   });
 
   it("summarises fired observations without rendering a ticker activity feed", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -7,6 +7,7 @@ import {
   fetchStrategyOverview,
   fetchStrategyOwnedPositions,
   fetchStrategyPnlHistory,
+  requestStrategyEvidenceRefresh,
   updateStrategyAllocation,
   updateStrategyPaperPool,
 } from "@/api/strategies";
@@ -700,9 +701,24 @@ export function StrategiesPage() {
   const pnlHistory = useAsync(fetchStrategyPnlHistory, []);
   const ownedPositions = useAsync(fetchStrategyOwnedPositions, []);
   const [closeFor, setCloseFor] = useState<StrategyOwnedPosition | null>(null);
+  const [refreshingEvidence, setRefreshingEvidence] = useState(false);
+  const [refreshEvidenceError, setRefreshEvidenceError] = useState<string | null>(null);
   const summary = useMemo(() => overview.data ? aggregate(overview.data) : null, [overview.data]);
   const approvedStrategies = overview.data?.strategies.filter((strategy) => strategy.allocation_ready || strategy.allocation.enabled) ?? [];
   const researchCandidates = overview.data?.strategies.filter((strategy) => !strategy.allocation_ready && !strategy.allocation.enabled) ?? [];
+
+  async function refreshEvidence() {
+    setRefreshingEvidence(true);
+    setRefreshEvidenceError(null);
+    try {
+      await requestStrategyEvidenceRefresh();
+      await overview.refetch();
+    } catch (error) {
+      setRefreshEvidenceError(error instanceof ApiError ? error.message : "Could not queue evidence refresh.");
+    } finally {
+      setRefreshingEvidence(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -797,8 +813,37 @@ export function StrategiesPage() {
                   These rules are measured, not selectable. Current evaluation uses completed daily bars; it does not predict which rule is about to fire.
                 </p>
               </div>
-              <span className="text-xs text-slate-500">{researchCandidates.length} candidates</span>
+              <div className="flex items-center gap-3 text-xs text-slate-500">
+                <span>
+                  Evidence {overview.data.evidence_refresh.completed_windows}/{overview.data.evidence_refresh.total_windows}
+                  {overview.data.evidence_refresh.partial_windows ? ` · ${overview.data.evidence_refresh.partial_windows} partial` : ""}
+                  {` · frozen through ${formatDate(overview.data.evidence_refresh.frozen_through)}`}
+                </span>
+                <button
+                  type="button"
+                  className="border border-slate-300 px-3 py-1.5 font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-900"
+                  disabled={refreshingEvidence || overview.data.evidence_refresh.status === "queued" || overview.data.evidence_refresh.status === "running" || overview.data.evidence_refresh.partial_windows > 0}
+                  onClick={refreshEvidence}
+                >
+                  {refreshingEvidence || overview.data.evidence_refresh.status === "queued"
+                    ? "Refresh queued"
+                    : overview.data.evidence_refresh.status === "running"
+                      ? "Refreshing…"
+                      : "Refresh evidence"}
+                </button>
+              </div>
             </div>
+            {refreshEvidenceError ? <p className="mb-3 text-xs text-red-600 dark:text-red-400">{refreshEvidenceError}</p> : null}
+            {overview.data.evidence_refresh.status === "failed" ? (
+              <p className="mb-3 text-xs text-red-600 dark:text-red-400">
+                Last refresh failed: {overview.data.evidence_refresh.last_error ?? "See process history."}
+              </p>
+            ) : null}
+            {overview.data.evidence_refresh.partial_windows > 0 ? (
+              <p className="mb-3 text-xs text-amber-700 dark:text-amber-300">
+                A partial immutable window needs operator repair before refresh can resume.
+              </p>
+            ) : null}
             <div className="space-y-2">
               {researchCandidates.map((strategy) => <ResearchCandidate key={strategy.strategy_id} strategy={strategy} />)}
             </div>

--- a/tests/test_jobs_queue_recovery.py
+++ b/tests/test_jobs_queue_recovery.py
@@ -96,7 +96,7 @@ def test_manual_job_with_terminal_run_not_replayed(
     _dev_conn: psycopg.Connection[Any],
     _cleanup_requests: list[int],
 ) -> None:
-    """Branch (a): completed manual_job rows stay 'dispatched'."""
+    """Branch (a): completed manual_job rows become terminal queue rows."""
     request_id = publish_manual_job_request("fundamentals_sync")
     _cleanup_requests.append(request_id)
     _force_to_dispatched(_dev_conn, request_id)
@@ -115,14 +115,14 @@ def test_manual_job_with_terminal_run_not_replayed(
         cur.execute("SELECT status FROM pending_job_requests WHERE request_id=%s", (request_id,))
         row = cur.fetchone()
     assert row is not None
-    assert row[0] == "dispatched"
+    assert row[0] == "completed"
 
 
 def test_sync_with_terminal_sync_run_not_replayed(
     _dev_conn: psycopg.Connection[Any],
     _cleanup_requests: list[int],
 ) -> None:
-    """Branch (b): completed sync rows stay 'dispatched'."""
+    """Branch (b): completed sync rows become terminal queue rows."""
     request_id = publish_sync_request(SyncScope.behind(), trigger="manual")
     _cleanup_requests.append(request_id)
     _force_to_dispatched(_dev_conn, request_id)
@@ -141,7 +141,7 @@ def test_sync_with_terminal_sync_run_not_replayed(
         cur.execute("SELECT status FROM pending_job_requests WHERE request_id=%s", (request_id,))
         row = cur.fetchone()
     assert row is not None
-    assert row[0] == "dispatched"
+    assert row[0] == "completed"
 
 
 def test_sync_with_running_sync_run_is_replayed(

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -21,6 +21,7 @@ from app.api.strategies import (
     get_fired_signals,
     get_strategy_overview,
     get_strategy_owned_positions,
+    request_evidence_refresh,
     update_strategy_allocation,
     update_strategy_paper_pool,
 )
@@ -607,6 +608,32 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
         )
     assert exc_info.value.status_code == 409
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
+
+
+def test_evidence_refresh_queues_one_fixed_pinned_request(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    conn.commit()
+
+    first = request_evidence_refresh(_session("research-operator"), conn)
+    second = request_evidence_refresh(_session("research-operator"), conn)
+
+    assert first.status == "queued"
+    assert not first.already_active
+    assert second.request_id == first.request_id
+    assert second.already_active
+    row = conn.execute(
+        "SELECT requested_by,payload FROM pending_job_requests WHERE request_id=%s",
+        (first.request_id,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "research-operator"
+    assert row[1]["params"] == {
+        "refresh_recent": True,
+        "holdout_purpose": "complete declared recent-regime evidence denominator",
+        "holdout_accessed_by": "research-operator",
+    }
 
 
 def test_missing_evidence_refuses_new_allocation_without_writing_audit(

--- a/tests/test_strategy_recent_evidence.py
+++ b/tests/test_strategy_recent_evidence.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import date
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -63,3 +64,69 @@ def test_invalid_window_is_recorded_inside_the_job_tracking_context(
         scheduler.strategy_backtest_run({"evidence_window": "searched-favourable-dates"})
 
     assert events == ["entered:strategy_backtest_run", "exited:strategy_backtest_run"]
+
+
+def test_refresh_recent_skips_complete_windows_and_commits_each_missing_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = SimpleNamespace(row_count=None, run_id=0, progress=None, note=None)
+    conn = MagicMock()
+
+    @contextmanager
+    def tracked(_job_name: str) -> Iterator[SimpleNamespace]:
+        yield tracker
+
+    @contextmanager
+    def connected() -> Iterator[MagicMock]:
+        yield conn
+
+    calls: list[object] = []
+
+    def run_backtest(_conn: object, **kwargs: object) -> SimpleNamespace:
+        calls.append(kwargs["evaluation_window"])
+        return SimpleNamespace(rows_written=12)
+
+    monkeypatch.setattr(scheduler, "_tracked_job", tracked)
+    monkeypatch.setattr(scheduler, "connect_job", connected)
+    monkeypatch.setattr(scheduler, "_recent_evidence_completion", lambda _conn: ({"primary-2022-plus"}, set()))
+    monkeypatch.setattr("app.services.backtest_run.run_backtest", run_backtest)
+
+    scheduler.strategy_backtest_run(
+        {
+            "refresh_recent": True,
+            "holdout_purpose": "declared recent evidence",
+            "holdout_accessed_by": "operator",
+        }
+    )
+
+    assert len(calls) == len(RECENT_EVIDENCE_WINDOWS) - 1
+    assert conn.commit.call_count == len(calls)
+    assert tracker.row_count == len(calls) * 12
+    assert tracker.progress.outcomes == {"already_complete": 1, "completed": len(calls)}
+
+
+def test_refresh_recent_refuses_partial_immutable_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = SimpleNamespace(row_count=None, run_id=0, progress=None, note=None)
+
+    @contextmanager
+    def tracked(_job_name: str) -> Iterator[SimpleNamespace]:
+        yield tracker
+
+    @contextmanager
+    def connected() -> Iterator[MagicMock]:
+        yield MagicMock()
+
+    monkeypatch.setattr(scheduler, "_tracked_job", tracked)
+    monkeypatch.setattr(scheduler, "connect_job", connected)
+    monkeypatch.setattr(scheduler, "_recent_evidence_completion", lambda _conn: (set(), {"rolling-36m"}))
+
+    with pytest.raises(RuntimeError, match="partial immutable windows"):
+        scheduler.strategy_backtest_run(
+            {
+                "refresh_recent": True,
+                "holdout_purpose": "declared recent evidence",
+                "holdout_accessed_by": "operator",
+            }
+        )

--- a/tests/test_sync_orchestrator_dispatcher.py
+++ b/tests/test_sync_orchestrator_dispatcher.py
@@ -239,13 +239,11 @@ def test_reset_stale_in_flight_revives_orphaned_rows(
     assert row[0] == "pending"
 
 
-def test_reset_stale_in_flight_skips_completed_runs(
+def test_reset_stale_in_flight_finalises_completed_runs(
     _dev_conn: psycopg.Connection[Any],
     _cleanup_requests: list[int],
 ) -> None:
-    """A row whose linked_request_id matches a terminal job_runs row
-    must NOT be reset — the work already completed before the crash.
-    """
+    """A terminal linked run finalises rather than replays its queue row."""
     request_id = publish_manual_job_request("fundamentals_sync")
     _cleanup_requests.append(request_id)
 
@@ -283,7 +281,7 @@ def test_reset_stale_in_flight_skips_completed_runs(
             )
             row = cur.fetchone()
         assert row is not None
-        assert row[0] == "dispatched"  # NOT reset
+        assert row[0] == "completed"
     finally:
         with _dev_conn.cursor() as cur:
             cur.execute("DELETE FROM job_runs WHERE run_id=%s", (run_id,))


### PR DESCRIPTION
Closes part of #2469.\n\nAdds an operator-triggered, resumable refresh for the eight code-pinned recent evidence windows; shows frozen-through/completion/failure state on Strategies; refuses arbitrary dates, overwrite, and partial immutable windows; and reconciles orphaned terminal queue requests at boot.\n\nValidation:\n- targeted backend strategy/queue suite: 36 passed\n- frontend strategy page: 12 passed\n- frontend unit suite: 1496 passed\n- frontend typecheck/dark/pills/charts/build: passed\n- pyright + ruff: passed\n- full backend suite reached 100%; 6 shared-DB parallel isolation failures all pass when rerun together in isolation