### PR TITLE
fix(strategies): guard evidence window aggregation

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -698,6 +698,31 @@ def _evidence_refresh_status(
     return "idle", None
 
 
+def _evidence_window_counts(strategies: list[StrategyOverview]) -> tuple[int, int]:
+    """Return complete and partial pinned windows across runnable strategies.
+
+    A missing member is missing evidence, never an exception. With no runnable
+    strategies there is no evidence population, so the completed denominator
+    is zero rather than vacuously all eight.
+    """
+    statuses = [
+        {window.window_id: window.status for window in strategy.evidence_windows}
+        for strategy in strategies
+        if strategy.runnable
+    ]
+    if not statuses:
+        return 0, 0
+    completed = sum(
+        all(strategy_windows.get(window_id) == "complete" for strategy_windows in statuses)
+        for window_id in RECENT_EVIDENCE_WINDOWS
+    )
+    partial = sum(
+        any(strategy_windows.get(window_id) == "partial" for strategy_windows in statuses)
+        for window_id in RECENT_EVIDENCE_WINDOWS
+    )
+    return completed, partial
+
+
 @router.get("/overview", response_model=StrategyOverviewResponse)
 def get_strategy_overview(
     conn: psycopg.Connection[object] = Depends(get_conn),
@@ -907,21 +932,7 @@ def get_strategy_overview(
         if all(value is not None for value in invested_values)
         else None
     )
-    runnable_rows = [item for item in strategies if item.runnable]
-    completed_windows = sum(
-        all(
-            next(window for window in item.evidence_windows if window.window_id == window_id).status == "complete"
-            for item in runnable_rows
-        )
-        for window_id in RECENT_EVIDENCE_WINDOWS
-    )
-    partial_windows = sum(
-        any(
-            next(window for window in item.evidence_windows if window.window_id == window_id).status == "partial"
-            for item in runnable_rows
-        )
-        for window_id in RECENT_EVIDENCE_WINDOWS
-    )
+    completed_windows, partial_windows = _evidence_window_counts(strategies)
     refresh_status, refresh_error = _evidence_refresh_status(refresh_row)
     return StrategyOverviewResponse(
         as_of=datetime.now(tz=UTC),

--- a/tests/test_strategy_recent_evidence.py
+++ b/tests/test_strategy_recent_evidence.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from app.api.strategies import _evidence_window_counts
 from app.services.processes.param_metadata import MANUAL_TRIGGER_JOB_METADATA
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS, recent_evidence_window
 from app.services.strategy_result import EVALUATION_WINDOW_END, HOLDOUT_BOUNDARY
@@ -130,3 +131,14 @@ def test_refresh_recent_refuses_partial_immutable_window(
                 "holdout_accessed_by": "operator",
             }
         )
+
+
+def test_overview_counts_missing_members_and_empty_runnable_set_without_crashing() -> None:
+    missing_member = SimpleNamespace(
+        runnable=True,
+        evidence_windows=[SimpleNamespace(window_id="primary-2022-plus", status="complete")],
+    )
+    excluded = SimpleNamespace(runnable=False, evidence_windows=[])
+
+    assert _evidence_window_counts([missing_member]) == (1, 0)  # type: ignore[list-item]
+    assert _evidence_window_counts([excluded]) == (0, 0)  # type: ignore[list-item]


### PR DESCRIPTION
Follow-up to #2470 and #2469. Disposes the automated review warning by treating a missing pinned member as missing evidence and a zero-runnable population as 0/8, with a prevention test.\n\nValidation: pre-push gate green; targeted strategy tests 23 passed; ruff and pyright green.