### PR TITLE
Add audited strategy capital modes

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -44,6 +44,7 @@ from app.services.strategy_control_plane import (
     StrategyControlError,
     StrategyOwnershipError,
     configure_deployment,
+    configure_execution_policy,
     configure_paper_pool,
     current_stage,
     is_risk_reducing_deployment_change,
@@ -68,6 +69,7 @@ from app.services.strategy_monitoring import (
     load_control_state,
     load_entry_block_state,
     load_owned_pnl,
+    realised_pnl_for_keys,
 )
 from app.services.strategy_position_manager import (
     StrategyPositionManagerError,
@@ -236,6 +238,9 @@ class StrategyAllocationView(BaseModel):
     remaining_capital: Decimal
     policy_configured: bool
     max_drawdown_limit_pct: Decimal | None
+    ticket_sizing_mode: Literal["percent", "fixed"] | None
+    ticket_value: Decimal | None
+    max_ticket_amount: Decimal | None
 
 
 class StrategyEntryBlockView(BaseModel):
@@ -251,10 +256,12 @@ class StrategyPaperPoolView(BaseModel):
     configured: bool
     enabled: bool
     capital_limit: Decimal
+    capital_mode: Literal["fixed", "compound"]
+    effective_capital: Decimal | None
     currency: Literal["USD"] = "USD"
     reserved_capital: Decimal
     invested_capital: Decimal | None
-    remaining_capital: Decimal
+    remaining_capital: Decimal | None
 
 
 class EvidenceRefreshView(BaseModel):
@@ -295,6 +302,7 @@ class EvidenceRefreshRequestResponse(BaseModel):
 class StrategyPaperPoolUpdateRequest(BaseModel):
     enabled: bool
     capital_limit: Decimal = Field(ge=0, max_digits=18, decimal_places=6)
+    capital_mode: Literal["fixed", "compound"] = "fixed"
     reason: str = Field(min_length=1, max_length=1000)
 
     @model_validator(mode="after")
@@ -404,6 +412,32 @@ class AllocationUpdateResponse(BaseModel):
     currency: str
     enabled: bool
     revision: int
+
+
+class StrategySizingUpdateRequest(BaseModel):
+    strategy_version: str = Field(min_length=1, max_length=200)
+    ticket_sizing_mode: Literal["percent", "fixed"]
+    ticket_value: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    max_ticket_amount: Decimal = Field(gt=0, max_digits=18, decimal_places=6)
+    reason: str = Field(min_length=1, max_length=1000)
+
+    @model_validator(mode="after")
+    def valid_shape(self) -> StrategySizingUpdateRequest:
+        if self.ticket_sizing_mode == "percent" and self.ticket_value > 100:
+            raise ValueError("percent ticket value must be in (0, 100]")
+        if self.ticket_sizing_mode == "fixed" and self.max_ticket_amount < self.ticket_value:
+            raise ValueError("fixed ticket value cannot exceed its hard maximum")
+        return self
+
+
+class StrategySizingUpdateResponse(BaseModel):
+    strategy_id: str
+    strategy_version: str
+    deployment_id: int
+    revision: int
+    ticket_sizing_mode: Literal["percent", "fixed"]
+    ticket_value: Decimal
+    max_ticket_amount: Decimal
 
 
 class LiveGatePolicyRequest(BaseModel):
@@ -753,6 +787,8 @@ def get_strategy_overview(
         latest_corpus_date = None if latest_row is None else latest_row["max"]
         cur.execute(_LATEST_EVIDENCE_REFRESH_SQL, {"job_name": _STRATEGY_BACKTEST_JOB})
         refresh_row = cur.fetchone()
+        cur.execute("SELECT DISTINCT strategy_id,strategy_version FROM strategy_deployments WHERE mode='paper'")
+        paper_deployment_keys = [(str(row["strategy_id"]), str(row["strategy_version"])) for row in cur.fetchall()]
 
     attribution_by_strategy = load_attribution(
         conn,
@@ -760,7 +796,8 @@ def get_strategy_overview(
         outcome_version=OUTCOME_RULE_SET_VERSION,
         input_version=QUARANTINE_RULE_SET_VERSION,
     )
-    pnl_by_strategy = load_owned_pnl(conn, versions=version_values)
+    pnl_versions = sorted({*version_values, *(version for _strategy_id, version in paper_deployment_keys)})
+    pnl_by_strategy = load_owned_pnl(conn, versions=pnl_versions)
     control_by_strategy = load_control_state(conn, versions=version_values)
     entry_block = load_entry_block_state(conn)
     paper_pool = load_paper_pool(conn)
@@ -904,10 +941,18 @@ def get_strategy_overview(
                 stage=control.stage,
                 attribution=StrategyAttributionView(**attribution.__dict__),
                 pnl=StrategyPnlView(
-                    **{
-                        **pnl.__dict__,
-                        "incomplete_reasons": list(pnl.incomplete_reasons),
-                    }
+                    currency="USD",
+                    strategy_trade_count=pnl.strategy_trade_count,
+                    owned_position_count=pnl.owned_position_count,
+                    active_position_count=pnl.active_position_count,
+                    close_event_count=pnl.close_event_count,
+                    invested_capital=pnl.invested_capital,
+                    realised_pnl=pnl.realised_pnl,
+                    unrealised_pnl=pnl.unrealised_pnl,
+                    total_pnl=pnl.total_pnl,
+                    observed_fees=pnl.observed_fees,
+                    complete=pnl.complete,
+                    incomplete_reasons=list(pnl.incomplete_reasons),
                 ),
                 allocation=StrategyAllocationView(
                     deployment_id=control.deployment_id,
@@ -920,6 +965,16 @@ def get_strategy_overview(
                     remaining_capital=remaining,
                     policy_configured=control.policy_configured,
                     max_drawdown_limit_pct=control.max_drawdown_limit_pct,
+                    ticket_sizing_mode=cast(
+                        Literal["percent", "fixed"] | None,
+                        control.ticket_sizing_mode,
+                    ),
+                    ticket_value=(
+                        control.ticket_fraction * Decimal("100")
+                        if control.ticket_sizing_mode == "percent" and control.ticket_fraction is not None
+                        else control.fixed_ticket_amount
+                    ),
+                    max_ticket_amount=control.max_ticket_amount,
                 ),
                 allocation_ready=not allocation_refusals,
                 allocation_refusals=allocation_refusals,
@@ -931,6 +986,13 @@ def get_strategy_overview(
         sum((value for value in invested_values if value is not None), Decimal("0"))
         if all(value is not None for value in invested_values)
         else None
+    )
+    paper_realised = realised_pnl_for_keys(pnl_by_strategy, paper_deployment_keys)
+    realised_delta = None if paper_realised is None else sum(paper_realised.values(), Decimal("0"))
+    if realised_delta is not None and paper_pool.capital_mode == "fixed":
+        realised_delta = min(realised_delta, Decimal("0"))
+    effective_pool_capital = (
+        max(Decimal("0"), paper_pool.capital_limit + realised_delta) if realised_delta is not None else None
     )
     completed_windows, partial_windows = _evidence_window_counts(strategies)
     refresh_status, refresh_error = _evidence_refresh_status(refresh_row)
@@ -951,9 +1013,15 @@ def get_strategy_overview(
             configured=paper_pool.event_id is not None,
             enabled=paper_pool.enabled,
             capital_limit=paper_pool.capital_limit,
+            capital_mode=paper_pool.capital_mode,
+            effective_capital=effective_pool_capital,
             reserved_capital=reserved_total,
             invested_capital=invested_total,
-            remaining_capital=max(paper_pool.capital_limit - reserved_total, Decimal("0")),
+            remaining_capital=(
+                max(effective_pool_capital - reserved_total, Decimal("0"))
+                if effective_pool_capital is not None
+                else None
+            ),
         ),
         evidence_refresh=EvidenceRefreshView(
             frozen_through=max(item.window.end for item in RECENT_EVIDENCE_WINDOWS.values()),
@@ -1372,15 +1440,20 @@ def update_strategy_paper_pool(
             conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
             current_pool = load_paper_pool(conn)
             runtime = get_runtime_config(conn)
-            pool_changed = current_pool.enabled != body.enabled or current_pool.capital_limit != body.capital_limit
+            pool_changed = (
+                current_pool.enabled != body.enabled
+                or current_pool.capital_limit != body.capital_limit
+                or current_pool.capital_mode != body.capital_mode
+            )
             automation_changed = runtime.enable_auto_trading != body.enabled
             if not pool_changed and not automation_changed:
-                raise StrategyControlError("automation change must alter enabled state or capital limit")
+                raise StrategyControlError("automation change must alter enabled state, capital limit, or capital mode")
             if pool_changed:
                 configure_paper_pool(
                     conn,
                     enabled=body.enabled,
                     capital_limit=body.capital_limit,
+                    capital_mode=body.capital_mode,
                     changed_by=session.username,
                     reason=body.reason,
                 )
@@ -1461,6 +1534,72 @@ def update_strategy_allocation(
         currency=row.allocation.currency,
         enabled=deployment.enabled,
         revision=deployment.revision,
+    )
+
+
+@router.put(
+    "/{strategy_id}/sizing",
+    response_model=StrategySizingUpdateResponse,
+)
+def update_strategy_sizing(
+    strategy_id: str,
+    body: StrategySizingUpdateRequest,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategySizingUpdateResponse:
+    """Revise only an existing policy's per-signal sizing semantics."""
+    _require_current_strategy_version(strategy_id, body.strategy_version)
+    try:
+        with conn.transaction():
+            lock_strategy_control(conn, strategy_id, body.strategy_version)
+            overview = get_strategy_overview(conn)
+            strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
+            deployment_id = strategy.allocation.deployment_id
+            current_max = strategy.allocation.max_ticket_amount
+            if deployment_id is None or not strategy.allocation.policy_configured or current_max is None:
+                raise StrategyControlError("an execution policy must exist before sizing can be revised")
+            if not strategy.allocation_ready:
+                raise StrategyControlError("sizing cannot be revised while strategy evidence or controls are invalid")
+            with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+                cur.execute(
+                    "SELECT * FROM strategy_execution_policies WHERE deployment_id=%s FOR UPDATE",
+                    (deployment_id,),
+                )
+                current = cur.fetchone()
+            if current is None:
+                raise StrategyControlError("execution policy disappeared during sizing update")
+            policy = configure_execution_policy(
+                conn,
+                deployment_id=deployment_id,
+                ticket_sizing_mode=body.ticket_sizing_mode,
+                ticket_fraction=(body.ticket_value / Decimal("100") if body.ticket_sizing_mode == "percent" else None),
+                fixed_ticket_amount=(body.ticket_value if body.ticket_sizing_mode == "fixed" else None),
+                max_ticket_amount=body.max_ticket_amount,
+                stop_loss_pct=Decimal(str(current["stop_loss_pct"])),
+                take_profit_pct=Decimal(str(current["take_profit_pct"])),
+                max_quote_age_seconds=int(current["max_quote_age_seconds"]),
+                max_scan_age_seconds=int(current["max_scan_age_seconds"]),
+                max_halt_feed_age_seconds=int(current["max_halt_feed_age_seconds"]),
+                max_cost_age_seconds=int(current["max_cost_age_seconds"]),
+                max_reconciliation_age_seconds=int(current["max_reconciliation_age_seconds"]),
+                max_instrument_exposure_pct=Decimal(str(current["max_instrument_exposure_pct"])),
+                max_portfolio_exposure_pct=Decimal(str(current["max_portfolio_exposure_pct"])),
+                max_drawdown_pct=Decimal(str(current["max_drawdown_pct"])),
+                min_net_expectancy_pct=Decimal(str(current["min_net_expectancy_pct"])),
+                cost_stress_multiplier=Decimal(str(current["cost_stress_multiplier"])),
+                changed_by=session.username,
+                reason=body.reason,
+            )
+    except StrategyControlError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return StrategySizingUpdateResponse(
+        strategy_id=strategy_id,
+        strategy_version=body.strategy_version,
+        deployment_id=deployment_id,
+        revision=policy.revision,
+        ticket_sizing_mode=body.ticket_sizing_mode,
+        ticket_value=body.ticket_value,
+        max_ticket_amount=body.max_ticket_amount,
     )
 
 

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1549,25 +1549,40 @@ def update_strategy_sizing(
 ) -> StrategySizingUpdateResponse:
     """Revise only an existing policy's per-signal sizing semantics."""
     _require_current_strategy_version(strategy_id, body.strategy_version)
+    overview = get_strategy_overview(conn)
+    strategy = next((item for item in overview.strategies if item.strategy_id == strategy_id), None)
+    if strategy is None:
+        conn.rollback()
+        raise HTTPException(status_code=409, detail="strategy overview changed; refresh required")
+    if not strategy.allocation_ready:
+        conn.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail="sizing cannot be revised while strategy evidence or controls are invalid",
+        )
+    # End the read-only overview transaction before taking the control lock so
+    # the lock is held only for the one policy row revision below.
+    conn.rollback()
     try:
         with conn.transaction():
             lock_strategy_control(conn, strategy_id, body.strategy_version)
-            overview = get_strategy_overview(conn)
-            strategy = next(item for item in overview.strategies if item.strategy_id == strategy_id)
-            deployment_id = strategy.allocation.deployment_id
-            current_max = strategy.allocation.max_ticket_amount
-            if deployment_id is None or not strategy.allocation.policy_configured or current_max is None:
-                raise StrategyControlError("an execution policy must exist before sizing can be revised")
-            if not strategy.allocation_ready:
-                raise StrategyControlError("sizing cannot be revised while strategy evidence or controls are invalid")
+            if current_stage(conn, strategy_id, body.strategy_version) not in {"paper_enabled", "live_enabled"}:
+                raise StrategyControlError("strategy is no longer approved for sizing")
             with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
                 cur.execute(
-                    "SELECT * FROM strategy_execution_policies WHERE deployment_id=%s FOR UPDATE",
-                    (deployment_id,),
+                    """
+                    SELECT p.*
+                    FROM strategy_deployments d
+                    JOIN strategy_execution_policies p USING (deployment_id)
+                    WHERE d.strategy_id=%s AND d.strategy_version=%s AND d.mode='paper'
+                    FOR UPDATE OF d,p
+                    """,
+                    (strategy_id, body.strategy_version),
                 )
                 current = cur.fetchone()
             if current is None:
-                raise StrategyControlError("execution policy disappeared during sizing update")
+                raise StrategyControlError("paper execution policy is unavailable")
+            deployment_id = int(current["deployment_id"])
             policy = configure_execution_policy(
                 conn,
                 deployment_id=deployment_id,

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -26,6 +26,8 @@ Stage = Literal[
     "retired",
 ]
 Mode = Literal["paper", "live"]
+CapitalMode = Literal["fixed", "compound"]
+TicketSizingMode = Literal["percent", "fixed"]
 
 GOVERNANCE_GATE_VERSION = "strategy-governance-v1"
 
@@ -84,12 +86,13 @@ class PaperPool:
     enabled: bool
     capital_limit: Decimal
     currency: str = "USD"
+    capital_mode: CapitalMode = "fixed"
 
 
 def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
     row = conn.execute(
         """
-        SELECT strategy_paper_pool_event_id,enabled,capital_limit,currency
+        SELECT strategy_paper_pool_event_id,enabled,capital_limit,currency,capital_mode
         FROM strategy_paper_pool_events
         ORDER BY strategy_paper_pool_event_id DESC
         LIMIT 1
@@ -97,7 +100,7 @@ def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
     ).fetchone()
     if row is None:
         return PaperPool(None, False, Decimal("0"))
-    return PaperPool(int(row[0]), bool(row[1]), Decimal(str(row[2])), str(row[3]))
+    return PaperPool(int(row[0]), bool(row[1]), Decimal(str(row[2])), str(row[3]), cast(CapitalMode, row[4]))
 
 
 def configure_paper_pool(
@@ -105,6 +108,7 @@ def configure_paper_pool(
     *,
     enabled: bool,
     capital_limit: Decimal,
+    capital_mode: CapitalMode = "fixed",
     changed_by: str,
     reason: str,
 ) -> PaperPool:
@@ -113,29 +117,33 @@ def configure_paper_pool(
     _require_text(reason, "reason")
     if not capital_limit.is_finite() or capital_limit < 0 or (enabled and capital_limit <= 0):
         raise StrategyControlError("enabled paper pool requires a positive finite USD capital limit")
+    if capital_mode not in {"fixed", "compound"}:
+        raise StrategyControlError("capital_mode must be fixed or compound")
     # Conflict with the executor's session lock so a pause/lower cannot race an
     # already-sized order between its authority read and demo broker submit.
     conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
     current = load_paper_pool(conn)
-    if current.enabled == enabled and current.capital_limit == capital_limit:
-        raise StrategyControlError("paper pool change must alter enabled state or capital limit")
+    if current.enabled == enabled and current.capital_limit == capital_limit and current.capital_mode == capital_mode:
+        raise StrategyControlError("paper pool change must alter enabled state, capital limit, or capital mode")
     row = conn.execute(
         """
-        INSERT INTO strategy_paper_pool_events (enabled,capital_limit,currency,changed_by,reason)
-        VALUES (%s,%s,'USD',%s,%s)
+        INSERT INTO strategy_paper_pool_events (enabled,capital_limit,currency,capital_mode,changed_by,reason)
+        VALUES (%s,%s,'USD',%s,%s,%s)
         RETURNING strategy_paper_pool_event_id
         """,
-        (enabled, capital_limit, changed_by, reason),
+        (enabled, capital_limit, capital_mode, changed_by, reason),
     ).fetchone()
     assert row is not None
-    return PaperPool(int(row[0]), enabled, capital_limit)
+    return PaperPool(int(row[0]), enabled, capital_limit, "USD", capital_mode)
 
 
 @dataclass(frozen=True)
 class ExecutionPolicy:
     deployment_id: int
     revision: int
-    ticket_fraction: Decimal
+    ticket_sizing_mode: TicketSizingMode
+    ticket_fraction: Decimal | None
+    fixed_ticket_amount: Decimal | None
     max_ticket_amount: Decimal
     stop_loss_pct: Decimal
     take_profit_pct: Decimal
@@ -403,8 +411,10 @@ def configure_execution_policy(
     conn: psycopg.Connection[Any],
     *,
     deployment_id: int,
-    ticket_fraction: Decimal,
+    ticket_fraction: Decimal | None,
     max_ticket_amount: Decimal,
+    ticket_sizing_mode: TicketSizingMode = "percent",
+    fixed_ticket_amount: Decimal | None = None,
     stop_loss_pct: Decimal,
     take_profit_pct: Decimal,
     max_quote_age_seconds: int,
@@ -428,8 +438,18 @@ def configure_execution_policy(
     """
     for value, field in ((changed_by, "changed_by"), (reason, "reason")):
         _require_text(value, field)
-    if not (Decimal("0") < ticket_fraction <= Decimal("1")):
-        raise StrategyControlError("ticket_fraction must be in (0, 1]")
+    if ticket_sizing_mode == "percent":
+        if ticket_fraction is None or not (Decimal("0") < ticket_fraction <= Decimal("1")):
+            raise StrategyControlError("percent ticket_fraction must be in (0, 1]")
+        if fixed_ticket_amount is not None:
+            raise StrategyControlError("percent sizing cannot carry fixed_ticket_amount")
+    elif ticket_sizing_mode == "fixed":
+        if ticket_fraction is not None:
+            raise StrategyControlError("fixed sizing cannot carry ticket_fraction")
+        if fixed_ticket_amount is None or not fixed_ticket_amount.is_finite() or fixed_ticket_amount <= 0:
+            raise StrategyControlError("fixed_ticket_amount must be positive and finite")
+    else:
+        raise StrategyControlError("ticket_sizing_mode must be percent or fixed")
     if max_ticket_amount <= 0:
         raise StrategyControlError("max_ticket_amount must be positive")
     if not (Decimal("0") < stop_loss_pct < Decimal("100")) or take_profit_pct <= 0:
@@ -468,7 +488,9 @@ def configure_execution_policy(
     values = (
         deployment_id,
         revision,
+        ticket_sizing_mode,
         ticket_fraction,
+        fixed_ticket_amount,
         max_ticket_amount,
         stop_loss_pct,
         take_profit_pct,
@@ -488,17 +510,19 @@ def configure_execution_policy(
     conn.execute(
         """
         INSERT INTO strategy_execution_policies (
-            deployment_id, revision, ticket_fraction, max_ticket_amount,
+            deployment_id, revision, ticket_sizing_mode, ticket_fraction, fixed_ticket_amount, max_ticket_amount,
             stop_loss_pct, take_profit_pct, max_quote_age_seconds,
             max_scan_age_seconds, max_halt_feed_age_seconds,
             max_cost_age_seconds, max_reconciliation_age_seconds,
             max_instrument_exposure_pct, max_portfolio_exposure_pct,
             max_drawdown_pct, min_net_expectancy_pct,
             cost_stress_multiplier, updated_by, reason
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (deployment_id) DO UPDATE SET
             revision = EXCLUDED.revision,
+            ticket_sizing_mode = EXCLUDED.ticket_sizing_mode,
             ticket_fraction = EXCLUDED.ticket_fraction,
+            fixed_ticket_amount = EXCLUDED.fixed_ticket_amount,
             max_ticket_amount = EXCLUDED.max_ticket_amount,
             stop_loss_pct = EXCLUDED.stop_loss_pct,
             take_profit_pct = EXCLUDED.take_profit_pct,
@@ -520,18 +544,18 @@ def configure_execution_policy(
     conn.execute(
         """
         INSERT INTO strategy_execution_policy_events (
-            deployment_id, revision, ticket_fraction, max_ticket_amount,
+            deployment_id, revision, ticket_sizing_mode, ticket_fraction, fixed_ticket_amount, max_ticket_amount,
             stop_loss_pct, take_profit_pct, max_quote_age_seconds,
             max_scan_age_seconds, max_halt_feed_age_seconds,
             max_cost_age_seconds, max_reconciliation_age_seconds,
             max_instrument_exposure_pct, max_portfolio_exposure_pct,
             max_drawdown_pct, min_net_expectancy_pct,
             cost_stress_multiplier, changed_by, reason
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """,
         values,
     )
-    return ExecutionPolicy(*values[:16])
+    return ExecutionPolicy(*values[:18])
 
 
 def decide_funding(

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -59,6 +59,10 @@ class StrategyPnl:
     observed_fees: Decimal | None = Decimal("0")
     complete: bool = True
     incomplete_reasons: tuple[str, ...] = ()
+    # Completed close events remain usable for bankroll accounting while a
+    # different newly allocated order is awaiting reconciliation. The public
+    # realised_pnl stays conservative and may still be unknown in that state.
+    reconciled_realised_pnl: Decimal = Decimal("0")
 
 
 @dataclass(frozen=True)
@@ -73,6 +77,10 @@ class StrategyControlState:
     reserved_capital: Decimal = Decimal("0")
     policy_configured: bool = False
     max_drawdown_limit_pct: Decimal | None = None
+    ticket_sizing_mode: str | None = None
+    ticket_fraction: Decimal | None = None
+    fixed_ticket_amount: Decimal | None = None
+    max_ticket_amount: Decimal | None = None
 
 
 @dataclass(frozen=True)
@@ -362,8 +370,46 @@ def load_owned_pnl(conn: psycopg.Connection[Any], *, versions: Sequence[str]) ->
             observed_fees=fees if fees_known else None,
             complete=not reasons,
             incomplete_reasons=tuple(sorted(reasons)),
+            reconciled_realised_pnl=realised,
         )
     return result
+
+
+def realised_pnl_for_keys(
+    pnl_by_strategy: dict[tuple[str, str], StrategyPnl],
+    keys: Sequence[tuple[str, str]],
+) -> dict[tuple[str, str], Decimal] | None:
+    """Project reconciled realised values, failing closed on any unknown."""
+    result: dict[tuple[str, str], Decimal] = {}
+    for key in keys:
+        pnl = pnl_by_strategy.get(key, StrategyPnl())
+        if {
+            "realised_pnl_missing_from_history",
+            "released_position_missing_close_history",
+        }.intersection(pnl.incomplete_reasons):
+            return None
+        result[key] = pnl.reconciled_realised_pnl
+    return result
+
+
+def load_paper_realised_pnl(conn: psycopg.Connection[Any]) -> dict[tuple[str, str], Decimal] | None:
+    """Return exact-owned realised P&L for every paper deployment.
+
+    Old strategy versions remain part of the shared pot after they are retired;
+    limiting this calculation to the current manifest would make realised gains
+    or losses disappear from the capital base. ``None`` is fail-closed whenever
+    any deployed lifecycle cannot be reconciled completely.
+    """
+    rows = conn.execute(
+        """
+        SELECT DISTINCT strategy_id,strategy_version
+        FROM strategy_deployments
+        WHERE mode='paper'
+        """
+    ).fetchall()
+    keys = [(str(row[0]), str(row[1])) for row in rows]
+    pnl_by_strategy = load_owned_pnl(conn, versions=sorted({version for _strategy_id, version in keys}))
+    return realised_pnl_for_keys(pnl_by_strategy, keys)
 
 
 _CONTROL_SQL = """
@@ -412,7 +458,9 @@ _CONTROL_SQL = """
            d.deployment_id, d.capital_limit, d.currency, d.enabled, d.revision,
            COALESCE(res.amount, 0) AS reserved_capital,
            (pol.deployment_id IS NOT NULL) AS policy_configured,
-           pol.max_drawdown_pct AS max_drawdown_limit_pct
+           pol.max_drawdown_pct AS max_drawdown_limit_pct,
+           pol.ticket_sizing_mode, pol.ticket_fraction,
+           pol.fixed_ticket_amount, pol.max_ticket_amount
     FROM strategy_keys keys
     LEFT JOIN current_stage cs USING (strategy_id, strategy_version)
     LEFT JOIN pinned pin USING (strategy_id, strategy_version)
@@ -445,6 +493,14 @@ def load_control_state(
             policy_configured=bool(row["policy_configured"]),
             max_drawdown_limit_pct=(
                 Decimal(str(row["max_drawdown_limit_pct"])) if row["max_drawdown_limit_pct"] is not None else None
+            ),
+            ticket_sizing_mode=(str(row["ticket_sizing_mode"]) if row["ticket_sizing_mode"] is not None else None),
+            ticket_fraction=(Decimal(str(row["ticket_fraction"])) if row["ticket_fraction"] is not None else None),
+            fixed_ticket_amount=(
+                Decimal(str(row["fixed_ticket_amount"])) if row["fixed_ticket_amount"] is not None else None
+            ),
+            max_ticket_amount=(
+                Decimal(str(row["max_ticket_amount"])) if row["max_ticket_amount"] is not None else None
             ),
         )
         for row in rows

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -39,6 +39,7 @@ from app.services.strategy_control_plane import (
     decide_funding,
     link_strategy_order,
 )
+from app.services.strategy_monitoring import load_paper_realised_pnl
 from app.services.strategy_order_reconciliation import (
     enforce_reconciliation_slo,
     ensure_strategy_request_id,
@@ -74,9 +75,12 @@ class _Intent:
     deployment_id: int
     deployment_limit: Decimal
     pool_limit: Decimal
+    capital_mode: Literal["fixed", "compound"]
     pool_reserved: Decimal
     policy_revision: int
-    ticket_fraction: Decimal
+    ticket_sizing_mode: Literal["percent", "fixed"]
+    ticket_fraction: Decimal | None
+    fixed_ticket_amount: Decimal | None
     max_ticket_amount: Decimal
     stop_loss_pct: Decimal
     take_profit_pct: Decimal
@@ -172,6 +176,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
                    i.symbol, i.is_tradable, e.asset_class,
                    d.deployment_id, d.capital_limit, d.enabled, d.currency,
                    pool.enabled AS pool_enabled, pool.capital_limit AS pool_limit,
+                   pool.capital_mode,
                    p.revision AS policy_revision, p.*,
                    q.quoted_at, q.ask, q.spread_flag,
                    w.updated_at AS scan_at,
@@ -211,7 +216,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
              AND d.mode = 'paper'
             LEFT JOIN strategy_execution_policies p ON p.deployment_id = d.deployment_id
             LEFT JOIN LATERAL (
-                SELECT enabled,capital_limit
+                SELECT enabled,capital_limit,capital_mode
                 FROM strategy_paper_pool_events
                 ORDER BY strategy_paper_pool_event_id DESC
                 LIMIT 1
@@ -306,9 +311,14 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
         deployment_id=int(row["deployment_id"]),
         deployment_limit=Decimal(str(row["capital_limit"])),
         pool_limit=Decimal(str(row["pool_limit"])),
+        capital_mode=cast(Literal["fixed", "compound"], row["capital_mode"]),
         pool_reserved=Decimal(str(row["pool_reserved"])),
         policy_revision=int(row["policy_revision"]),
-        ticket_fraction=Decimal(str(row["ticket_fraction"])),
+        ticket_sizing_mode=cast(Literal["percent", "fixed"], row["ticket_sizing_mode"]),
+        ticket_fraction=Decimal(str(row["ticket_fraction"])) if row["ticket_fraction"] is not None else None,
+        fixed_ticket_amount=(
+            Decimal(str(row["fixed_ticket_amount"])) if row["fixed_ticket_amount"] is not None else None
+        ),
         max_ticket_amount=Decimal(str(row["max_ticket_amount"])),
         stop_loss_pct=Decimal(str(row["stop_loss_pct"])),
         take_profit_pct=Decimal(str(row["take_profit_pct"])),
@@ -462,7 +472,11 @@ def _risk_and_amount(
     assert pending_row is not None
     pending_total = Decimal(str(pending_row[0]))
     pending_instrument = Decimal(str(pending_row[1]))
+    capital_bases = _effective_capital_bases(conn, intent)
     conn.commit()
+    if isinstance(capital_bases, str):
+        return capital_bases
+    deployment_base, pool_base = capital_bases
     with conn.transaction():
         row = conn.execute(
             "SELECT equity_high_water FROM strategy_paper_account_risk_state WHERE id = true FOR UPDATE"
@@ -484,8 +498,8 @@ def _risk_and_amount(
         )
     if drawdown > intent.max_drawdown_pct:
         return "account_drawdown_limit"
-    deployment_remaining = max(Decimal("0"), intent.deployment_limit - intent.reserved)
-    pool_remaining = max(Decimal("0"), intent.pool_limit - intent.pool_reserved)
+    deployment_remaining = max(Decimal("0"), deployment_base - intent.reserved)
+    pool_remaining = max(Decimal("0"), pool_base - intent.pool_reserved)
     portfolio_capacity = max(
         Decimal("0"),
         risk.equity * intent.max_portfolio_exposure_pct / Decimal("100") - risk.total_invested - pending_total,
@@ -494,8 +508,16 @@ def _risk_and_amount(
         Decimal("0"),
         risk.equity * intent.max_instrument_exposure_pct / Decimal("100") - current_instrument - pending_instrument,
     )
+    if intent.ticket_sizing_mode == "fixed":
+        if intent.fixed_ticket_amount is None:
+            return "execution_policy_invalid"
+        requested_ticket = intent.fixed_ticket_amount
+    else:
+        if intent.ticket_fraction is None:
+            return "execution_policy_invalid"
+        requested_ticket = deployment_base * intent.ticket_fraction
     amount = min(
-        intent.deployment_limit * intent.ticket_fraction,
+        requested_ticket,
         intent.max_ticket_amount,
         deployment_remaining,
         pool_remaining,
@@ -506,6 +528,26 @@ def _risk_and_amount(
     if amount <= 0:
         return "risk_capacity_exhausted"
     return amount, current_instrument, drawdown
+
+
+def _effective_capital_bases(
+    conn: psycopg.Connection[Any],
+    intent: _Intent,
+) -> tuple[Decimal, Decimal] | str:
+    """Resolve capped or compounding bases from realised P&L, never open marks."""
+    realised_by_strategy = load_paper_realised_pnl(conn)
+    if realised_by_strategy is None:
+        return "realised_pnl_incomplete"
+
+    strategy_realised = realised_by_strategy.get((intent.strategy_id, intent.strategy_version), Decimal("0"))
+    pool_realised = sum(realised_by_strategy.values(), Decimal("0"))
+    if intent.capital_mode == "fixed":
+        strategy_realised = min(strategy_realised, Decimal("0"))
+        pool_realised = min(pool_realised, Decimal("0"))
+    return (
+        max(Decimal("0"), intent.deployment_limit + strategy_realised),
+        max(Decimal("0"), intent.pool_limit + pool_realised),
+    )
 
 
 def _resume_uncertain_submission(

--- a/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
+++ b/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
@@ -56,17 +56,21 @@ safety claim. Promotion continues to require, at minimum:
 No rule is enabled merely because the UI can display it or a historical win
 rate exceeds a threshold.
 
-## Capital model (next implementation slice)
+## Capital model
 
-The shared pot will carry an explicit mode:
+The shared pot carries an explicit, audited mode:
 
 - `fixed`: the configured principal is the hard strategy-system ceiling;
-  profits do not increase it and losses reduce what remains available;
+  net realised profits do not increase it and net realised losses reduce what
+  remains available;
 - `compound`: the risk base is configured principal plus reconciled realised
-  strategy P&L; open marks never increase buying power, and incomplete P&L
-  reconciliation blocks new entries.
+  strategy P&L.
 
-Each approved strategy will carry an explicit ticket mode:
+Open marks never increase buying power. In either mode, incomplete realised
+P&L reconciliation blocks new entries because an unknown loss must not be
+subsidised by the wider broker account.
+
+Each approved strategy carries an explicit, revisioned ticket mode:
 
 - `fixed`: one configured currency amount per accepted signal; or
 - `percent`: one configured fraction of its effective allocated base, still

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -9,6 +9,7 @@ import type {
   StrategyPaperPool,
   StrategyPnlHistoryResponse,
   StrategyPositionCloseResponse,
+  StrategySizingUpdateResponse,
 } from "@/api/types";
 
 export function fetchStrategyOverview(): Promise<StrategyOverviewResponse> {
@@ -49,9 +50,26 @@ export function closeStrategyOwnedPosition(
 export function updateStrategyPaperPool(body: {
   enabled: boolean;
   capital_limit: string;
+  capital_mode: "fixed" | "compound";
   reason: string;
 }): Promise<StrategyPaperPool> {
   return apiFetch("/strategies/paper-pool", {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+export function updateStrategySizing(
+  strategyId: string,
+  body: {
+    strategy_version: string;
+    ticket_sizing_mode: "percent" | "fixed";
+    ticket_value: string;
+    max_ticket_amount: string;
+    reason: string;
+  },
+): Promise<StrategySizingUpdateResponse> {
+  return apiFetch(`/strategies/${encodeURIComponent(strategyId)}/sizing`, {
     method: "PUT",
     body: JSON.stringify(body),
   });

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2519,6 +2519,9 @@ export interface StrategyAllocation {
   remaining_capital: string;
   policy_configured: boolean;
   max_drawdown_limit_pct: string | null;
+  ticket_sizing_mode: "percent" | "fixed" | null;
+  ticket_value: string | null;
+  max_ticket_amount: string | null;
 }
 
 export interface StrategyEntryBlock {
@@ -2565,10 +2568,22 @@ export interface StrategyPaperPool {
   configured: boolean;
   enabled: boolean;
   capital_limit: string;
+  capital_mode: "fixed" | "compound";
+  effective_capital: string | null;
   currency: "USD";
   reserved_capital: string;
   invested_capital: string | null;
-  remaining_capital: string;
+  remaining_capital: string | null;
+}
+
+export interface StrategySizingUpdateResponse {
+  strategy_id: string;
+  strategy_version: string;
+  deployment_id: number;
+  revision: number;
+  ticket_sizing_mode: "percent" | "fixed";
+  ticket_value: string;
+  max_ticket_amount: string;
 }
 
 export interface StrategyPnlHistoryPoint {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -60,6 +60,8 @@ const OVERVIEW: StrategyOverviewResponse = {
     configured: true,
     enabled: false,
     capital_limit: "1000.000000",
+    capital_mode: "fixed",
+    effective_capital: "1000.000000",
     currency: "USD",
     reserved_capital: "0.000000",
     invested_capital: "0.000000",
@@ -116,7 +118,7 @@ const OVERVIEW: StrategyOverviewResponse = {
       max_observed_account_drawdown_pct: null,
     },
     pnl: { currency: "USD", strategy_trade_count: 0, owned_position_count: 0, active_position_count: 0, close_event_count: 0, invested_capital: "0", realised_pnl: "0", unrealised_pnl: "0", total_pnl: "0", observed_fees: "0", complete: true, incomplete_reasons: [] },
-    allocation: { deployment_id: null, capital_limit: "0", currency: "USD", enabled: false, revision: null, reserved_capital: "0", invested_capital: "0", remaining_capital: "0", policy_configured: false, max_drawdown_limit_pct: null },
+    allocation: { deployment_id: null, capital_limit: "0", currency: "USD", enabled: false, revision: null, reserved_capital: "0", invested_capital: "0", remaining_capital: "0", policy_configured: false, max_drawdown_limit_pct: null, ticket_sizing_mode: null, ticket_value: null, max_ticket_amount: null },
     allocation_ready: false,
     allocation_refusals: ["recent_evidence_incomplete", "paper_promotion_missing", "execution_policy_missing"],
   }],
@@ -167,7 +169,7 @@ function approvedOverview(): StrategyOverviewResponse {
         shadow_average_return_pct: "1.25",
       },
       pnl: { ...strategy.pnl, strategy_trade_count: 3, owned_position_count: 3, active_position_count: 1, close_event_count: 2, invested_capital: "200", realised_pnl: "40", unrealised_pnl: "10", total_pnl: "50" },
-      allocation: { deployment_id: 7, capital_limit: "1000", currency: "USD", enabled: true, revision: 2, reserved_capital: "250", invested_capital: "200", remaining_capital: "750", policy_configured: true, max_drawdown_limit_pct: "5" },
+      allocation: { deployment_id: 7, capital_limit: "1000", currency: "USD", enabled: true, revision: 2, reserved_capital: "250", invested_capital: "200", remaining_capital: "750", policy_configured: true, max_drawdown_limit_pct: "5", ticket_sizing_mode: "percent", ticket_value: "20", max_ticket_amount: "500" },
       allocation_ready: true,
       allocation_refusals: [],
     }],
@@ -213,7 +215,7 @@ describe("StrategiesPage", () => {
     expect(input.parentElement).toHaveClass("w-48");
     fireEvent.change(input, { target: { value: "1500" } });
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(update).toHaveBeenCalledWith({ enabled: false, capital_limit: "1500.000000", reason: "Automated strategy workspace update" }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ enabled: false, capital_limit: "1500.000000", capital_mode: "fixed", reason: "Automated strategy workspace update" }));
   });
 
   it("does not present automation as enabled while the system-wide guard is off", async () => {
@@ -271,6 +273,36 @@ describe("StrategiesPage", () => {
     expect(within(performance).getByText("+60.00%")).toBeInTheDocument();
     expect(screen.getByText("1 approved")).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Enabled" })).toBeEnabled();
+  });
+
+  it("keeps per-signal sizing behind the approved strategy disclosure", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(approvedOverview());
+    const update = vi.spyOn(strategiesApi, "updateStrategySizing").mockResolvedValue({
+      strategy_id: "s1-time-series-momentum",
+      strategy_version: "strategy-registry-v1+abc",
+      deployment_id: 7,
+      revision: 3,
+      ticket_sizing_mode: "fixed",
+      ticket_value: "75",
+      max_ticket_amount: "100",
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+
+    await userEvent.click(await screen.findByText(/Per signal: 20%/));
+    await userEvent.selectOptions(screen.getByLabelText("Method"), "fixed");
+    fireEvent.change(screen.getByLabelText("Amount"), { target: { value: "75" } });
+    fireEvent.change(screen.getByLabelText("Hard max USD"), { target: { value: "100" } });
+    const save = screen.getByRole("button", { name: "Save sizing" });
+    expect(save).toBeEnabled();
+    await userEvent.click(save);
+
+    await waitFor(() => expect(update).toHaveBeenCalledWith("s1-time-series-momentum", {
+      strategy_version: "strategy-registry-v1+abc",
+      ticket_sizing_mode: "fixed",
+      ticket_value: "75.000000",
+      max_ticket_amount: "100.000000",
+      reason: "Per-signal sizing updated from automated strategy workspace",
+    }));
   });
 
   it("shows a compact portfolio row for each exact automated position", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -10,6 +10,7 @@ import {
   requestStrategyEvidenceRefresh,
   updateStrategyAllocation,
   updateStrategyPaperPool,
+  updateStrategySizing,
 } from "@/api/strategies";
 import type {
   StrategyEvidenceWindow,
@@ -433,16 +434,18 @@ function AutomationControl({
   const pool = overview.paper_pool;
   const [enabled, setEnabled] = useState(pool.enabled && overview.execution_enabled);
   const [limit, setLimit] = useState(pool.capital_limit);
+  const [capitalMode, setCapitalMode] = useState(pool.capital_mode);
   const [saving, setSaving] = useState(false);
   const [failed, setFailed] = useState(false);
   useEffect(() => {
     setEnabled(pool.enabled && overview.execution_enabled);
     setLimit(pool.capital_limit);
-  }, [pool.enabled, pool.capital_limit, overview.execution_enabled]);
+    setCapitalMode(pool.capital_mode);
+  }, [pool.enabled, pool.capital_limit, pool.capital_mode, overview.execution_enabled]);
   const parsed = Number(limit);
   const valid = Number.isFinite(parsed) && parsed >= 0 && (!enabled || parsed > 0);
   const effectiveEnabled = pool.enabled && overview.execution_enabled;
-  const dirty = enabled !== effectiveEnabled || parsed !== Number(pool.capital_limit);
+  const dirty = enabled !== effectiveEnabled || parsed !== Number(pool.capital_limit) || capitalMode !== pool.capital_mode;
   const canEnable = approvedCount > 0 && overview.execution_enabled;
 
   async function save(event: FormEvent) {
@@ -454,6 +457,7 @@ function AutomationControl({
       await updateStrategyPaperPool({
         enabled,
         capital_limit: parsed.toFixed(6),
+        capital_mode: capitalMode,
         reason: "Automated strategy workspace update",
       });
       onUpdated();
@@ -497,12 +501,24 @@ function AutomationControl({
               className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-3 py-2 text-sm tabular-nums dark:border-slate-700 dark:bg-slate-950"
             />
           </label>
+          <label className="w-52 text-xs font-medium text-slate-600 dark:text-slate-300">
+            Profit treatment
+            <select
+              value={capitalMode}
+              onChange={(event) => setCapitalMode(event.target.value as "fixed" | "compound")}
+              className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+            >
+              <option value="fixed">Keep principal limit fixed</option>
+              <option value="compound">Reinvest realised P&amp;L</option>
+            </select>
+          </label>
           <button type="submit" disabled={!valid || !dirty || saving || (enabled && !canEnable)} className="min-h-11 cursor-pointer border border-blue-700 bg-blue-700 px-4 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-40">
             {saving ? "Saving…" : "Save"}
           </button>
         </div>
       </form>
-      <dl className="mt-5 grid grid-cols-3 gap-3 border-t border-slate-200 pt-4 text-xs dark:border-slate-800">
+      <dl className="mt-5 grid grid-cols-2 gap-3 border-t border-slate-200 pt-4 text-xs sm:grid-cols-4 dark:border-slate-800">
+        <div><dt className="text-slate-500">Risk base</dt><dd className="font-semibold tabular-nums">{money(pool.effective_capital)}</dd></div>
         <div><dt className="text-slate-500">Working</dt><dd className="font-semibold tabular-nums">{money(pool.invested_capital)}</dd></div>
         <div><dt className="text-slate-500">Reserved</dt><dd className="font-semibold tabular-nums">{money(pool.reserved_capital)}</dd></div>
         <div><dt className="text-slate-500">Available</dt><dd className="font-semibold tabular-nums">{money(pool.remaining_capital)}</dd></div>
@@ -596,6 +612,77 @@ function StrategyToggle({
   );
 }
 
+function StrategySizingControl({ strategy, onUpdated }: { strategy: StrategyOverview; onUpdated: () => void }) {
+  const allocation = strategy.allocation;
+  const [mode, setMode] = useState<"percent" | "fixed">(allocation.ticket_sizing_mode ?? "percent");
+  const [value, setValue] = useState(allocation.ticket_value ?? "");
+  const [maximum, setMaximum] = useState(allocation.max_ticket_amount ?? "");
+  const [saving, setSaving] = useState(false);
+  const [failed, setFailed] = useState(false);
+  useEffect(() => {
+    setMode(allocation.ticket_sizing_mode ?? "percent");
+    setValue(allocation.ticket_value ?? "");
+    setMaximum(allocation.max_ticket_amount ?? "");
+  }, [allocation.ticket_sizing_mode, allocation.ticket_value, allocation.max_ticket_amount]);
+  const parsedValue = Number(value);
+  const parsedMaximum = Number(maximum);
+  const valid = Number.isFinite(parsedValue) && parsedValue > 0
+    && Number.isFinite(parsedMaximum) && parsedMaximum > 0
+    && (mode !== "percent" || parsedValue <= 100)
+    && (mode !== "fixed" || parsedMaximum >= parsedValue);
+
+  async function save(event: FormEvent) {
+    event.preventDefault();
+    if (!valid || saving) return;
+    setSaving(true);
+    setFailed(false);
+    try {
+      await updateStrategySizing(strategy.strategy_id, {
+        strategy_version: strategy.strategy_version,
+        ticket_sizing_mode: mode,
+        ticket_value: parsedValue.toFixed(6),
+        max_ticket_amount: parsedMaximum.toFixed(6),
+        reason: "Per-signal sizing updated from automated strategy workspace",
+      });
+      onUpdated();
+    } catch (error) {
+      console.error("Strategy sizing update failed:", error);
+      setFailed(true);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!allocation.policy_configured) return null;
+  return (
+    <details className="mt-2 text-xs text-slate-500">
+      <summary className="cursor-pointer">
+        Per signal: {allocation.ticket_sizing_mode === "fixed" ? money(allocation.ticket_value) : `${allocation.ticket_value ?? "—"}%`}
+        {allocation.max_ticket_amount ? ` · max ${money(allocation.max_ticket_amount)}` : ""}
+      </summary>
+      <form onSubmit={(event) => void save(event)} className="mt-3 flex flex-wrap items-end gap-2">
+        <label>
+          Method
+          <select value={mode} onChange={(event) => setMode(event.target.value as "percent" | "fixed")} className="mt-1 block min-h-10 border border-slate-300 bg-white px-2 dark:border-slate-700 dark:bg-slate-950">
+            <option value="percent">Percent</option>
+            <option value="fixed">Fixed USD</option>
+          </select>
+        </label>
+        <label>
+          {mode === "percent" ? "Percent" : "Amount"}
+          <input type="number" min="0.01" max={mode === "percent" ? "100" : undefined} step="0.01" value={value} onChange={(event) => setValue(event.target.value)} className="mt-1 block min-h-10 w-24 border border-slate-300 bg-white px-2 tabular-nums dark:border-slate-700 dark:bg-slate-950" />
+        </label>
+        <label>
+          Hard max USD
+          <input type="number" min="0.01" step="0.01" value={maximum} onChange={(event) => setMaximum(event.target.value)} className="mt-1 block min-h-10 w-28 border border-slate-300 bg-white px-2 tabular-nums dark:border-slate-700 dark:bg-slate-950" />
+        </label>
+        <button type="submit" disabled={!valid || saving} className="min-h-10 border border-slate-300 px-3 font-medium text-slate-700 disabled:opacity-40 dark:border-slate-700 dark:text-slate-200">{saving ? "Saving…" : "Save sizing"}</button>
+      </form>
+      {failed ? <p className="mt-2 text-red-700 dark:text-red-300">Sizing was not changed.</p> : null}
+    </details>
+  );
+}
+
 function ApprovedStrategy({
   strategy,
   poolLimit,
@@ -615,6 +702,7 @@ function ApprovedStrategy({
           </Badge>
         </div>
         <p className="mt-1 max-w-md text-xs text-slate-500">{strategy.description}</p>
+        <StrategySizingControl strategy={strategy} onUpdated={onUpdated} />
       </div>
       <div><span className="text-xs text-slate-500">P&amp;L</span><strong className="block tabular-nums">{money(strategy.pnl.total_pnl)}</strong></div>
       <div><span className="text-xs text-slate-500">Completed</span><strong className="block tabular-nums">{formatNumber(strategy.attribution.resolved_entries, 0)}</strong></div>

--- a/sql/293_strategy_capital_modes.sql
+++ b/sql/293_strategy_capital_modes.sql
@@ -1,0 +1,59 @@
+-- 293_strategy_capital_modes.sql
+--
+-- #2469 makes the two money semantics explicit and auditable. Existing rows
+-- preserve their historical meaning: a fixed principal ceiling and a
+-- percentage ticket bounded by max_ticket_amount.
+
+ALTER TABLE strategy_paper_pool_events
+    ADD COLUMN IF NOT EXISTS capital_mode TEXT NOT NULL DEFAULT 'fixed';
+
+ALTER TABLE strategy_paper_pool_events
+    DROP CONSTRAINT IF EXISTS strategy_paper_pool_capital_mode_check;
+ALTER TABLE strategy_paper_pool_events
+    ADD CONSTRAINT strategy_paper_pool_capital_mode_check
+    CHECK (capital_mode IN ('fixed', 'compound'));
+
+ALTER TABLE strategy_execution_policies
+    ADD COLUMN IF NOT EXISTS ticket_sizing_mode TEXT NOT NULL DEFAULT 'percent',
+    ADD COLUMN IF NOT EXISTS fixed_ticket_amount NUMERIC(18,6);
+
+ALTER TABLE strategy_execution_policies
+    ALTER COLUMN ticket_fraction DROP NOT NULL;
+ALTER TABLE strategy_execution_policies
+    DROP CONSTRAINT IF EXISTS strategy_execution_policies_ticket_fraction_check;
+ALTER TABLE strategy_execution_policies
+    DROP CONSTRAINT IF EXISTS strategy_execution_policy_ticket_shape;
+ALTER TABLE strategy_execution_policies
+    ADD CONSTRAINT strategy_execution_policy_ticket_shape CHECK (
+        (ticket_sizing_mode = 'percent'
+         AND ticket_fraction > 0 AND ticket_fraction <= 1
+         AND fixed_ticket_amount IS NULL)
+        OR
+        (ticket_sizing_mode = 'fixed'
+         AND ticket_fraction IS NULL
+         AND fixed_ticket_amount > 0)
+    );
+
+ALTER TABLE strategy_execution_policy_events
+    ADD COLUMN IF NOT EXISTS ticket_sizing_mode TEXT NOT NULL DEFAULT 'percent',
+    ADD COLUMN IF NOT EXISTS fixed_ticket_amount NUMERIC(18,6);
+
+ALTER TABLE strategy_execution_policy_events
+    ALTER COLUMN ticket_fraction DROP NOT NULL;
+ALTER TABLE strategy_execution_policy_events
+    DROP CONSTRAINT IF EXISTS strategy_execution_policy_event_ticket_shape;
+ALTER TABLE strategy_execution_policy_events
+    ADD CONSTRAINT strategy_execution_policy_event_ticket_shape CHECK (
+        (ticket_sizing_mode = 'percent'
+         AND ticket_fraction > 0 AND ticket_fraction <= 1
+         AND fixed_ticket_amount IS NULL)
+        OR
+        (ticket_sizing_mode = 'fixed'
+         AND ticket_fraction IS NULL
+         AND fixed_ticket_amount > 0)
+    );
+
+COMMENT ON COLUMN strategy_paper_pool_events.capital_mode IS
+    'fixed: principal is the hard ceiling; compound: reconciled realised strategy P&L changes the risk base.';
+COMMENT ON COLUMN strategy_execution_policies.ticket_sizing_mode IS
+    'percent sizes from the effective deployment base; fixed uses fixed_ticket_amount. Both remain risk capped.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -204,6 +204,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     "strategy_live_gate_policies",
     # #2451 — bounded current kill state has no FK by design.
     "strategy_execution_blocks",
+    # #2469 — the shared paper-pool current state is an append-only standalone
+    # event stream. It intentionally has no FK to a deployment, so the inbound
+    # FK closure cannot discover it from the strategy roots above.
+    "strategy_paper_pool_events",
     # #2448/#2449 — bounded strategy current-state roots have no FKs. Their
     # signal/deployment children are derived by the planner from roots above.
     "strategy_scan_watermark",

--- a/tests/smoke/test_strategy_control_lock_discipline.py
+++ b/tests/smoke/test_strategy_control_lock_discipline.py
@@ -1,0 +1,15 @@
+"""Structural guards for short strategy control-plane lock scopes."""
+
+from __future__ import annotations
+
+import inspect
+
+from app.api.strategies import update_strategy_sizing
+
+
+def test_sizing_overview_and_lookup_complete_before_control_lock() -> None:
+    source = inspect.getsource(update_strategy_sizing)
+
+    assert source.index("overview = get_strategy_overview(conn)") < source.index("lock_strategy_control(")
+    assert "next((item for item in overview.strategies if item.strategy_id == strategy_id), None)" in source
+    assert source.index("conn.rollback()") < source.index("lock_strategy_control(")

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -28,6 +28,7 @@ from app.api.strategies import (
 from app.security.sessions import SessionRow
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
 from app.services.research_price_structure_store import QUARANTINE_RULE_SET_VERSION
+from app.services.runtime_config import get_runtime_config, update_runtime_config
 from app.services.strategy_monitoring import (
     load_attribution,
     load_control_state,
@@ -567,11 +568,22 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:
     conn = ebull_test_conn
+    # runtime_config is a deliberately persistent singleton, unlike the
+    # per-test pool event stream. Establish the transition this test asserts
+    # when an earlier executor test enabled automation.
+    if get_runtime_config(conn).enable_auto_trading:
+        update_runtime_config(
+            conn,
+            updated_by="test-precondition",
+            reason="establish disabled automation precondition",
+            enable_auto_trading=False,
+        )
     conn.commit()
     response = update_strategy_paper_pool(
         StrategyPaperPoolUpdateRequest(
             enabled=True,
             capital_limit=Decimal("750"),
+            capital_mode="compound",
             reason="bounded paper workspace",
         ),
         _session(),
@@ -580,10 +592,12 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
 
     assert response.enabled
     assert response.capital_limit == Decimal("750")
+    assert response.capital_mode == "compound"
+    assert response.effective_capital == Decimal("750")
     assert response.remaining_capital == Decimal("750")
     assert conn.execute(
-        "SELECT enabled,capital_limit,changed_by,reason FROM strategy_paper_pool_events"
-    ).fetchone() == (True, Decimal("750.000000"), "allocation-operator", "bounded paper workspace")
+        "SELECT enabled,capital_limit,capital_mode,changed_by,reason FROM strategy_paper_pool_events"
+    ).fetchone() == (True, Decimal("750.000000"), "compound", "allocation-operator", "bounded paper workspace")
     assert conn.execute("SELECT enable_auto_trading FROM runtime_config WHERE id=TRUE").fetchone() == (True,)
     assert conn.execute(
         """
@@ -601,6 +615,7 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
             StrategyPaperPoolUpdateRequest(
                 enabled=True,
                 capital_limit=Decimal("750"),
+                capital_mode="compound",
                 reason="no-op must not add audit noise",
             ),
             _session(),

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -347,7 +347,7 @@ def test_fixed_ticket_mode_requests_a_currency_amount_before_risk_caps(
         """
         SELECT ticket_sizing_mode,ticket_fraction,fixed_ticket_amount,max_ticket_amount
         FROM strategy_execution_policy_events
-        ORDER BY strategy_execution_policy_event_id DESC LIMIT 1
+        ORDER BY policy_event_id DESC LIMIT 1
         """
     ).fetchone() == ("fixed", None, Decimal("125.000000"), Decimal("500.000000"))
 

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -7,7 +7,7 @@ from datetime import UTC, date, datetime
 from decimal import Decimal
 from threading import Barrier, Event
 from time import sleep
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock
 from uuid import UUID
 
@@ -35,7 +35,11 @@ from app.services.strategy_control_plane import (
     decide_funding,
     link_strategy_order,
 )
-from app.services.strategy_paper_executor import PaperExecutionResult, execute_fired_paper_signal
+from app.services.strategy_paper_executor import (
+    PaperExecutionResult,
+    _effective_capital_bases,
+    execute_fired_paper_signal,
+)
 from tests.fixtures.ebull_test_db import test_database_url
 from tests.test_result_ledger import (
     BOOTSTRAP_BLOCK,
@@ -51,7 +55,12 @@ _NOW = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)  # Friday 11:00 New York
 _REQUEST_ID = UUID("1c94300c-90aa-4303-9d00-dec376d74efb")
 
 
-def _seed(conn: psycopg.Connection[Any], *, auto: bool = True) -> int:
+def _seed(
+    conn: psycopg.Connection[Any],
+    *,
+    auto: bool = True,
+    ticket_sizing_mode: str = "percent",
+) -> int:
     if conn.execute("SELECT 1 FROM strategy_paper_pool_events LIMIT 1").fetchone() is None:
         configure_paper_pool(
             conn,
@@ -136,7 +145,9 @@ def _seed(conn: psycopg.Connection[Any], *, auto: bool = True) -> int:
     configure_execution_policy(
         conn,
         deployment_id=deployment.deployment_id,
-        ticket_fraction=Decimal("0.20"),
+        ticket_sizing_mode=cast(Any, ticket_sizing_mode),
+        ticket_fraction=Decimal("0.20") if ticket_sizing_mode == "percent" else None,
+        fixed_ticket_amount=Decimal("125") if ticket_sizing_mode == "fixed" else None,
         max_ticket_amount=Decimal("500"),
         stop_loss_pct=Decimal("5"),
         take_profit_pct=Decimal("10"),
@@ -310,6 +321,73 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
     # Retry is read-only and cannot submit a duplicate.
     assert execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW).order_id == result.order_id
     broker.place_demo_strategy_order.assert_called_once()
+
+
+def test_fixed_ticket_mode_requests_a_currency_amount_before_risk_caps(
+    ebull_test_conn: psycopg.Connection[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signal_id = _seed(ebull_test_conn, ticket_sizing_mode="fixed")
+    broker = _broker()
+    broker.get_account_risk_snapshot.return_value = BrokerAccountRiskSnapshot(
+        available_cash=Decimal("600"),
+        total_invested=Decimal("0"),
+        unrealized_pnl=Decimal("0"),
+        equity=Decimal("1000"),
+        instrument_investments=(),
+        observed_at=_NOW,
+        raw_payload={},
+    )
+    monkeypatch.setattr("app.services.strategy_order_reconciliation.uuid4", lambda: _REQUEST_ID)
+
+    result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.amount == Decimal("125.00")
+    assert ebull_test_conn.execute(
+        """
+        SELECT ticket_sizing_mode,ticket_fraction,fixed_ticket_amount,max_ticket_amount
+        FROM strategy_execution_policy_events
+        ORDER BY strategy_execution_policy_event_id DESC LIMIT 1
+        """
+    ).fetchone() == ("fixed", None, Decimal("125.000000"), Decimal("500.000000"))
+
+
+def test_capital_modes_use_realised_owned_pnl_and_refuse_unknown_pnl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = MagicMock()
+    intent = MagicMock(
+        capital_mode="compound",
+        deployment_limit=Decimal("1000"),
+        pool_limit=Decimal("2000"),
+        strategy_id="S-ALLOC",
+        strategy_version="v1",
+    )
+    monkeypatch.setattr(
+        "app.services.strategy_paper_executor.load_paper_realised_pnl",
+        lambda _conn: {
+            ("S-ALLOC", "v1"): Decimal("100"),
+            ("S-OTHER", "v2"): Decimal("-25"),
+        },
+    )
+    assert _effective_capital_bases(conn, intent) == (Decimal("1100"), Decimal("2075"))
+
+    intent.capital_mode = "fixed"
+    assert _effective_capital_bases(conn, intent) == (Decimal("1000"), Decimal("2000"))
+    monkeypatch.setattr(
+        "app.services.strategy_paper_executor.load_paper_realised_pnl",
+        lambda _conn: {
+            ("S-ALLOC", "v1"): Decimal("-100"),
+            ("S-OTHER", "v2"): Decimal("25"),
+        },
+    )
+    assert _effective_capital_bases(conn, intent) == (Decimal("900"), Decimal("1925"))
+
+    monkeypatch.setattr(
+        "app.services.strategy_paper_executor.load_paper_realised_pnl",
+        lambda _conn: None,
+    )
+    assert _effective_capital_bases(conn, intent) == "realised_pnl_incomplete"
 
 
 def test_disabled_global_switch_keeps_an_unfunded_shadow_arm(


### PR DESCRIPTION
## Outcome

Adds the explicit bankroll and per-signal sizing semantics from #2469 without weakening any evidence or execution gate.

- fixed bankroll mode caps gains but carries realised losses forward
- compound mode reinvests reconciled realised strategy P&L only
- incomplete realised P&L blocks entries; manual and open positions never enlarge strategy capital
- approved strategies can use revisioned fixed-USD or percentage tickets, both under existing hard risk caps
- Strategies overview shows effective risk base and keeps sizing controls behind approved strategy disclosure
- migration preserves existing fixed-principal/percentage behavior and adds audited event fields

## Validation

- full pre-push gate: green
- targeted backend integration + schema smoke: green
- Strategies page tests: 13 passed
- frontend typecheck: green

Refs #2469