### PR TITLE
feat(strategies): resolve mature forward outcomes

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -128,6 +128,7 @@ from app.workers.scheduler import (
     JOB_SEED_COST_MODELS,
     JOB_STRATEGY_BACKTEST_RUN,
     JOB_STRATEGY_OBSERVATION_RETENTION,
+    JOB_STRATEGY_OUTCOME_RESOLUTION,
     JOB_STRATEGY_PAPER_CYCLE,
     JOB_STRATEGY_SIGNAL_SCAN,
     JOB_THESIS_BREAK_SCAN,
@@ -196,6 +197,7 @@ from app.workers.scheduler import (
     seed_cost_models,
     strategy_backtest_run,
     strategy_observation_retention,
+    strategy_outcome_resolution,
     strategy_paper_cycle,
     strategy_signal_scan,
     thesis_break_scan,
@@ -348,6 +350,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # the frontier watermark rather than by a DAG edge. Own "strategy_scan" lane,
     # resolved from SCHEDULED_JOBS, so no MANUAL_TRIGGER_JOB_SOURCES entry.
     JOB_STRATEGY_SIGNAL_SCAN: _adapt_zero_arg(strategy_signal_scan),
+    JOB_STRATEGY_OUTCOME_RESOLUTION: _adapt_zero_arg(strategy_outcome_resolution),
     JOB_STRATEGY_OBSERVATION_RETENTION: _adapt_zero_arg(strategy_observation_retention),
     JOB_STRATEGY_PAPER_CYCLE: _adapt_zero_arg(strategy_paper_cycle),
     # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY and NOT in

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -339,10 +339,13 @@ when one overruns). Scheduled-only, so NOT added to the
   orchestrator adapter inner-JobLock AND the operator manual-trigger path. NOT
   in SCHEDULED_JOBS (the DAG layer's cadence/freshness gate the run), so NOT
   added to the ``bootstrap_stages.lane`` CHECK.
-* ``strategy_scan`` — ``strategy_signal_scan`` (#2394 §3.1) plus
-  ``strategy_observation_retention`` (#2448). The DB-only producer is sole
+* ``strategy_scan`` — ``strategy_signal_scan`` (#2394 §3.1), bounded forward
+  ``strategy_outcome_resolution`` (#2474), plus
+  ``strategy_observation_retention`` (#2448). The DB-only producers are sole
   writer of the signal/count/observation relations and scan watermark; the
-  retention sibling drops only expired leaf partitions after the scan;
+  outcome resolver stores one terminal row per fired signal/version and never
+  stores immature polling state; the retention sibling drops only expired leaf
+  partitions after both producers;
   reads ``price_daily`` / ``price_bar_quarantine`` MVCC-safe. ⚠ The lane is
   load-bearing for CORRECTNESS here, unlike the two above where it is a
   starvation fix: ``store_signals`` has no ``ON CONFLICT``, so two overlapping

--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -52,13 +52,11 @@ import logging
 import math
 import time
 from array import array
-from bisect import bisect_left
 from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
-from itertools import pairwise
 from typing import Any, Final
 
 import numpy as np
@@ -95,6 +93,11 @@ from app.services.position_builder import (
     build_positions,
 )
 from app.services.position_costing import CostedPosition, cost_positions
+from app.services.price_segments import (
+    load_unresolved_breaks,
+    segment_end_index,
+    segment_for_index,
+)
 from app.services.price_structure import StructureBar
 from app.services.research_price_structure_store import (
     QUARANTINE_ARMS,
@@ -111,7 +114,7 @@ from app.services.result_ledger import (
 from app.services.signal_ledger import LedgerRow, resolve_fills
 from app.services.strategies.validated_universe import load_validated_universe
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry
-from app.services.strategy_registry import StagedMember, StrategyIdentity, StrategySignal, stage_cross_sectional_member
+from app.services.strategy_registry import StrategyIdentity, StrategySignal
 from app.services.strategy_result import (
     AMBIGUITY_ARMS,
     CORPUS_VERSION,
@@ -127,6 +130,7 @@ from app.services.strategy_result import (
     check_promotable,
     namespace_for_position,
 )
+from app.services.strategy_segmented_evaluation import segmented_member, segmented_signals
 from app.services.strategy_statistics import StrategyMetrics, TradeReturns, compute_metrics
 from app.services.technical_analysis import OHLCVRow
 from app.services.trial_register import TRIAL_REGISTER
@@ -243,14 +247,6 @@ _SERIES_SQL = """
     FROM research_price_series
     WHERE instrument_id = ANY(%(ids)s)
     ORDER BY instrument_id, series_id
-"""
-
-_UNRESOLVED_BREAKS_SQL = """
-    SELECT instrument_id, break_date
-    FROM price_series_break
-    WHERE instrument_id = ANY(%(ids)s)
-      AND resolved_by IS NULL
-    ORDER BY instrument_id, break_date
 """
 
 #: The IN-SAMPLE axis and its per-date bar count — criterion 5's fold cut is
@@ -592,7 +588,7 @@ def _resolved_level_outcomes(
     for fill in entries:
         signal_index = bar_index[fill.signal_bar_date]
         fill_index = bar_index[fill.fill_bar_date]
-        signal_series, local_signal_index = _segment_for_index(
+        signal_series, local_signal_index = segment_for_index(
             series,
             index=signal_index,
             unresolved_breaks=unresolved_breaks,
@@ -603,7 +599,7 @@ def _resolved_level_outcomes(
             entry_price=fill.fill_price,
             universe=BACKTEST_UNIVERSE,
         )
-        segment_end_index = _segment_end_index(
+        position_segment_end = segment_end_index(
             series,
             fill_index=fill_index,
             unresolved_breaks=unresolved_breaks,
@@ -614,7 +610,7 @@ def _resolved_level_outcomes(
             entry_price=fill.fill_price,
             levels=levels,
             masked_bar_reasons=masked_reasons,
-            segment_end_index=segment_end_index,
+            segment_end_index=position_segment_end,
         )
         outcome_name = outcome.outcome
         exit_price = outcome.exit_price
@@ -631,64 +627,13 @@ def _resolved_level_outcomes(
                 exit_price=exit_price,
                 reason=outcome.reason,
                 unresolved_until_bar_date=(
-                    series.dates[segment_end_index + 1]
-                    if outcome.reason == "series_break" and segment_end_index is not None
+                    series.dates[position_segment_end + 1]
+                    if outcome.reason == "series_break" and position_segment_end is not None
                     else None
                 ),
             )
         )
     return resolved
-
-
-def _segment_end_index(
-    series: BarSeries,
-    *,
-    fill_index: int,
-    unresolved_breaks: Sequence[date],
-) -> int | None:
-    """Last bar before the next unresolved scale break after this fill.
-
-    ``break_date`` names the first date at the new scale. A fill on that date is
-    already inside the new segment, so only a strictly later break bounds it.
-    ``bisect_left`` also handles a break date absent from this vendor series:
-    the segment still ends on the final stored bar preceding the transition.
-    """
-    if not 0 <= fill_index < len(series):
-        raise ValueError(f"fill_index {fill_index} is outside the {len(series)}-bar series")
-    for start, end in _series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
-        if start <= fill_index < end:
-            return None if end == len(series) else end - 1
-    raise RuntimeError(f"fill_index {fill_index} belongs to no price segment")
-
-
-def _series_segment_bounds(
-    series: BarSeries,
-    *,
-    unresolved_breaks: Sequence[date],
-) -> tuple[tuple[int, int], ...]:
-    """Half-open bar-index ranges separated by unresolved scale transitions."""
-    ordered = tuple(unresolved_breaks)
-    if tuple(sorted(ordered)) != ordered or len(set(ordered)) != len(ordered):
-        raise ValueError("unresolved break dates must be unique and ordered")
-    cuts = {0, len(series)}
-    cuts.update(bisect_left(series.dates, break_date) for break_date in ordered)
-    ordered_cuts = sorted(cuts)
-    return tuple((start, end) for start, end in pairwise(ordered_cuts) if start < end)
-
-
-def _segment_for_index(
-    series: BarSeries,
-    *,
-    index: int,
-    unresolved_breaks: Sequence[date],
-) -> tuple[BarSeries, int]:
-    """The one independent indicator segment containing ``index``."""
-    if not 0 <= index < len(series):
-        raise ValueError(f"index {index} is outside the {len(series)}-bar series")
-    for start, end in _series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
-        if start <= index < end:
-            return BarSeries(dates=series.dates[start:end], rows=series.rows[start:end]), index - start
-    raise RuntimeError(f"index {index} belongs to no price segment")
 
 
 def _mark_index(series: BarSeries, *, window: Window, not_before: date) -> int | None:
@@ -1057,10 +1002,7 @@ def load_corpus(
     if limit is not None:
         pairs = pairs[:limit]
     included_ids = sorted({instrument_id for instrument_id, _series_id in pairs})
-    break_rows = conn.execute(_UNRESOLVED_BREAKS_SQL, {"ids": included_ids}).fetchall() if included_ids else []
-    unresolved_breaks: dict[int, list[date]] = {}
-    for instrument_id, break_date in break_rows:
-        unresolved_breaks.setdefault(int(instrument_id), []).append(break_date)
+    unresolved_breaks = load_unresolved_breaks(conn, included_ids)
 
     in_sample = conn.execute(
         _INSAMPLE_AXIS_SQL,
@@ -1091,7 +1033,7 @@ def load_corpus(
         evaluation_end=window.end,
         in_sample_axis=in_sample_axis,
         in_sample_bar_counts=tuple(int(row[1]) for row in in_sample),
-        unresolved_breaks={instrument_id: tuple(dates) for instrument_id, dates in unresolved_breaks.items()},
+        unresolved_breaks=unresolved_breaks,
     )
 
 
@@ -1358,35 +1300,20 @@ def _signals_for(
 ) -> list[StrategySignal]:
     """One instrument's whole-series verdicts, per-series or cross-sectional."""
     if entry.signals is not None:
-        if unresolved_breaks:
-            signals: list[StrategySignal] = []
-            for start, end in _series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
-                segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
-                signals.extend(
-                    StrategySignal(
-                        verdict=signal.verdict,
-                        signal_index=signal.signal_index + start,
-                        kind=signal.kind,
-                        reason=signal.reason,
-                    )
-                    for signal in entry.signals(
-                        segment,
-                        universe=BACKTEST_UNIVERSE,
-                        masked_reason="quarantined_bar",
-                    )
-                )
-            per_kind = Counter(signal.kind for signal in signals)
-            if not per_kind or any(count != len(series) for count in per_kind.values()):
-                raise RuntimeError(
-                    f"{entry.strategy_id} produced segmented verdict counts {dict(per_kind)} for {len(series)} bars"
-                )
-            return signals
-        return entry.signals(series, universe=BACKTEST_UNIVERSE, masked_reason="quarantined_bar")
+        return segmented_signals(
+            entry,
+            series,
+            universe=BACKTEST_UNIVERSE,
+            masked_reason="quarantined_bar",
+            unresolved_breaks=unresolved_breaks,
+        )
     assert entry.member is not None and ranking is not None
-    staged = _stage_cross_sectional_segments(
+    staged = segmented_member(
         entry,
         series,
-        decision_dates=ranking.decision_dates,
+        panel_decision_dates=ranking.decision_dates,
+        universe=BACKTEST_UNIVERSE,
+        masked_reason="quarantined_bar",
         unresolved_breaks=unresolved_breaks,
     )
     signals: list[StrategySignal] = []
@@ -1407,48 +1334,6 @@ def _signals_for(
         fired = instrument_id in ranking.winners.get(when, frozenset())
         signals.append(StrategySignal(verdict="fired" if fired else "not_fired", signal_index=index, kind="entry"))
     return signals
-
-
-def _stage_cross_sectional_segments(
-    entry: StrategyEntry,
-    series: BarSeries,
-    *,
-    decision_dates: frozenset[date],
-    unresolved_breaks: Sequence[date],
-) -> StagedMember:
-    """Stage one ranked member with indicator state restarted at scale breaks."""
-    assert entry.member is not None
-    bounds = _series_segment_bounds(series, unresolved_breaks=unresolved_breaks)
-    verdicts: list[StrategySignal | None] = []
-    scores: dict[date, float] = {}
-    for start, end in bounds:
-        segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
-        staged = stage_cross_sectional_member(
-            entry.member(
-                segment,
-                panel_decision_dates=decision_dates,
-                universe=BACKTEST_UNIVERSE,
-                masked_reason="quarantined_bar",
-            )
-        )
-        verdicts.extend(
-            None
-            if verdict is None
-            else StrategySignal(
-                verdict=verdict.verdict,
-                signal_index=verdict.signal_index + start,
-                kind=verdict.kind,
-                reason=verdict.reason,
-            )
-            for verdict in staged.verdicts
-        )
-        overlap = scores.keys() & staged.scores.keys()
-        if overlap:  # pragma: no cover - BarSeries dates and segments are disjoint
-            raise RuntimeError(f"{entry.strategy_id} produced duplicate segmented score dates {sorted(overlap)}")
-        scores.update(staged.scores)
-    if len(verdicts) != len(series):
-        raise RuntimeError(f"{entry.strategy_id} staged {len(verdicts)} segmented bars for {len(series)} inputs")
-    return StagedMember(verdicts=tuple(verdicts), scores=scores)
 
 
 def _rank_cross_section(
@@ -1483,10 +1368,12 @@ def _rank_cross_section(
         series = _to_series(masked.bars)
         if len(series) < 2:
             continue
-        staged = _stage_cross_sectional_segments(
+        staged = segmented_member(
             entry,
             series,
-            decision_dates=decision_dates,
+            panel_decision_dates=decision_dates,
+            universe=BACKTEST_UNIVERSE,
+            masked_reason="quarantined_bar",
             unresolved_breaks=corpus.unresolved_breaks.get(instrument_id, ()),
         )
         for when, value in staged.scores.items():

--- a/app/services/outcome_ledger.py
+++ b/app/services/outcome_ledger.py
@@ -215,7 +215,11 @@ _PENDING = """
       AND s.signal_kind = 'entry'
       AND s.verdict = 'fired'
       AND o.outcome_id IS NULL
-    ORDER BY s.instrument_id, s.signal_bar_date
+      AND s.signal_id > %(after_signal_id)s
+      AND (%(at_or_before_signal_id)s::bigint IS NULL
+           OR s.signal_id <= %(at_or_before_signal_id)s::bigint)
+    ORDER BY s.signal_id
+    LIMIT %(limit)s
 """
 
 
@@ -226,6 +230,9 @@ def select_pending_fills(
     strategy_version: str,
     rule_set_version: str,
     input_rule_set_version: str,
+    limit: int | None = None,
+    after_signal_id: int = 0,
+    at_or_before_signal_id: int | None = None,
 ) -> list[PendingFill]:
     """Every fired entry for one strategy version still unresolved at this version pair.
 
@@ -249,6 +256,15 @@ def select_pending_fills(
     time resolving, that one decides what may be stored. A caller that built its
     own list still cannot write an outcome for an exit.
     """
+    if limit is not None and limit < 1:
+        raise ValueError(f"limit must be positive or None, got {limit}")
+    if after_signal_id < 0:
+        raise ValueError(f"after_signal_id must be non-negative, got {after_signal_id}")
+    if at_or_before_signal_id is not None and at_or_before_signal_id <= after_signal_id:
+        raise ValueError(
+            "at_or_before_signal_id must be greater than after_signal_id when supplied, "
+            f"got {at_or_before_signal_id} <= {after_signal_id}"
+        )
     with conn.cursor() as cur:
         cur.execute(
             _PENDING,
@@ -257,6 +273,9 @@ def select_pending_fills(
                 "strategy_version": strategy_version,
                 "rule_set_version": rule_set_version,
                 "input_rule_set_version": input_rule_set_version,
+                "limit": limit,
+                "after_signal_id": after_signal_id,
+                "at_or_before_signal_id": at_or_before_signal_id,
             },
         )
         rows = cur.fetchall()

--- a/app/services/price_segments.py
+++ b/app/services/price_segments.py
@@ -1,0 +1,94 @@
+"""Shared unresolved price-scale segmentation for strategy consumers.
+
+``price_series_break.break_date`` is the first date at the new scale. Bars on
+either side remain usable inside their own segment; indicators and positions
+must not span the boundary. The loader is intentionally sparse and bounded to
+the requested instruments.
+"""
+
+from __future__ import annotations
+
+from bisect import bisect_left
+from collections.abc import Mapping, Sequence
+from datetime import date
+from itertools import pairwise
+from typing import Any
+
+import psycopg
+
+from app.services.indicator_series import BarSeries
+
+_UNRESOLVED_BREAKS_SQL = """
+    SELECT instrument_id, break_date
+    FROM price_series_break
+    WHERE instrument_id = ANY(%(instrument_ids)s)
+      AND resolved_by IS NULL
+    ORDER BY instrument_id, break_date
+"""
+
+
+def load_unresolved_breaks(
+    conn: psycopg.Connection[Any], instrument_ids: Sequence[int]
+) -> Mapping[int, tuple[date, ...]]:
+    """Return unresolved scale transitions for only ``instrument_ids``."""
+    ids = sorted(set(instrument_ids))
+    if not ids:
+        return {}
+    rows = conn.execute(_UNRESOLVED_BREAKS_SQL, {"instrument_ids": ids}).fetchall()
+    grouped: dict[int, list[date]] = {}
+    for instrument_id, break_date in rows:
+        grouped.setdefault(int(instrument_id), []).append(break_date)
+    return {instrument_id: tuple(dates) for instrument_id, dates in grouped.items()}
+
+
+def series_segment_bounds(
+    series: BarSeries,
+    *,
+    unresolved_breaks: Sequence[date],
+) -> tuple[tuple[int, int], ...]:
+    """Half-open bar-index ranges separated by unresolved scale transitions."""
+    ordered = tuple(unresolved_breaks)
+    if tuple(sorted(ordered)) != ordered or len(set(ordered)) != len(ordered):
+        raise ValueError("unresolved break dates must be unique and ordered")
+    cuts = {0, len(series)}
+    cuts.update(bisect_left(series.dates, break_date) for break_date in ordered)
+    ordered_cuts = sorted(cuts)
+    return tuple((start, end) for start, end in pairwise(ordered_cuts) if start < end)
+
+
+def segment_for_index(
+    series: BarSeries,
+    *,
+    index: int,
+    unresolved_breaks: Sequence[date],
+) -> tuple[BarSeries, int]:
+    """Return the independent segment containing ``index`` and its local index."""
+    if not 0 <= index < len(series):
+        raise ValueError(f"index {index} is outside the {len(series)}-bar series")
+    for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
+        if start <= index < end:
+            return BarSeries(dates=series.dates[start:end], rows=series.rows[start:end]), index - start
+    raise RuntimeError(f"index {index} belongs to no price segment")
+
+
+def segment_end_index(
+    series: BarSeries,
+    *,
+    fill_index: int,
+    unresolved_breaks: Sequence[date],
+) -> int | None:
+    """Return the last stored bar before the next break after ``fill_index``."""
+    if not 0 <= fill_index < len(series):
+        raise ValueError(f"fill_index {fill_index} is outside the {len(series)}-bar series")
+    for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
+        if start <= fill_index < end:
+            return None if end == len(series) else end - 1
+    raise RuntimeError(f"fill_index {fill_index} belongs to no price segment")
+
+
+__all__ = [
+    "load_unresolved_breaks",
+    "segment_end_index",
+    "segment_for_index",
+    "series_segment_bounds",
+]

--- a/app/services/strategy_live_gate.py
+++ b/app/services/strategy_live_gate.py
@@ -295,7 +295,7 @@ def assess_live_gate(
         cur.execute(
             """
             SELECT
-              count(*) FILTER (WHERE o.signal_id IS NOT NULL
+              count(*) FILTER (WHERE o.gross_return_pct IS NOT NULL
                                 AND s.created_at >= %(forward_at)s
                                 AND s.created_at < %(paper_at)s
                                 AND s.signal_bar_date >= %(forward_date)s) AS forward_resolved,

--- a/app/services/strategy_outcome_resolution.py
+++ b/app/services/strategy_outcome_resolution.py
@@ -103,6 +103,7 @@ def _resolve_fill(
     *,
     series: BarSeries,
     unresolved_breaks: Sequence[date],
+    masked_bar_reasons: Mapping[int, UnresolvedReason] | None = None,
 ) -> OutcomeRow | None:
     """Return a terminal row, or ``None`` while the forward window is immature."""
     if entry.exit_levels is None:
@@ -114,12 +115,12 @@ def _resolve_fill(
         )
     signal_index = _locate_signal_index(series.dates, fill.signal_bar_date)
     fill_index = locate_fill_index(series, fill.fill_bar_date)
-    signal_segment_end = segment_end_index(
+    signal_scale_segment_end = segment_end_index(
         series,
         fill_index=signal_index,
         unresolved_breaks=unresolved_breaks,
     )
-    if signal_segment_end is not None and fill_index > signal_segment_end:
+    if signal_scale_segment_end is not None and fill_index > signal_scale_segment_end:
         return OutcomeRow.from_outcome(
             fill.signal_id,
             Outcome(
@@ -146,7 +147,7 @@ def _resolve_fill(
         fill_index=fill_index,
         entry_price=fill.fill_price,
         levels=levels,
-        masked_bar_reasons=_masked_reasons(series.rows),
+        masked_bar_reasons=masked_bar_reasons if masked_bar_reasons is not None else _masked_reasons(series.rows),
         segment_end_index=segment_end_index(
             series,
             fill_index=fill_index,
@@ -273,12 +274,14 @@ def run_outcome_resolution(
         immature = 0
         for instrument_id, instrument_fills in sorted(by_instrument.items()):
             series = load_masked_bars(conn, instrument_id).series
+            masked_bar_reasons = _masked_reasons(series.rows)
             for fill in instrument_fills:
                 row = _resolve_fill(
                     entry,
                     fill,
                     series=series,
                     unresolved_breaks=breaks.get(instrument_id, ()),
+                    masked_bar_reasons=masked_bar_reasons,
                 )
                 if row is None:
                     immature += 1

--- a/app/services/strategy_outcome_resolution.py
+++ b/app/services/strategy_outcome_resolution.py
@@ -1,0 +1,334 @@
+"""Resolve mature forward strategy signals into a bounded durable track record.
+
+The daily signal scan records a fired decision and its causal next-open fill.
+This service revisits only level-based entries whose current version has no
+outcome at the current resolver/input-rule pair. An incomplete holding window is
+not an outcome: it is left pending and retried after more bars arrive.
+
+Storage is deliberately one terminal row per fired signal and version pair. No
+polling snapshots or immature rows are appended, so growth is bounded by the
+number of decisions the strategies actually fire.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Final
+
+import psycopg
+
+from app.services.cost_model import COST_MODEL_ID
+from app.services.indicator_series import BarSeries
+from app.services.outcome_ledger import OutcomeRow, PendingFill, locate_fill_index, select_pending_fills, store_outcomes
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.outcome_resolver import Outcome, UnresolvedReason, resolve_outcome
+from app.services.price_masked_bars import MASKED_REASON, QUARANTINE_RULE_SET_VERSION, load_masked_bars
+from app.services.price_segments import load_unresolved_breaks, segment_end_index, segment_for_index
+from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_LIMIT: Final = 1_000
+
+_READ_CURSOR_SQL = """
+    SELECT last_signal_id
+    FROM strategy_outcome_cursor
+    WHERE strategy_id = %(strategy_id)s
+      AND strategy_version = %(strategy_version)s
+      AND rule_set_version = %(rule_set_version)s
+      AND input_rule_set_version = %(input_rule_set_version)s
+"""
+
+_WRITE_CURSOR_SQL = """
+    INSERT INTO strategy_outcome_cursor (
+        strategy_id, strategy_version, rule_set_version,
+        input_rule_set_version, last_signal_id, updated_at
+    ) VALUES (
+        %(strategy_id)s, %(strategy_version)s, %(rule_set_version)s,
+        %(input_rule_set_version)s, %(last_signal_id)s, now()
+    )
+    ON CONFLICT (strategy_id, strategy_version, rule_set_version, input_rule_set_version)
+    DO UPDATE SET last_signal_id = EXCLUDED.last_signal_id, updated_at = now()
+"""
+
+
+@dataclass(frozen=True)
+class StrategyOutcomeResult:
+    strategy_id: str
+    strategy_version: str
+    selected: int = 0
+    written: int = 0
+    immature: int = 0
+    ambiguous: int = 0
+    outcomes: Mapping[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OutcomeResolutionReport:
+    selected: int = 0
+    written: int = 0
+    immature: int = 0
+    ambiguous: int = 0
+    skipped_non_level_strategies: int = 0
+    per_strategy: tuple[StrategyOutcomeResult, ...] = ()
+
+
+def _masked_reasons(series_rows: Sequence[Mapping[str, object]]) -> dict[int, UnresolvedReason]:
+    """Name unavailable resolver inputs from the fail-closed live loader."""
+    return {
+        index: MASKED_REASON
+        for index, row in enumerate(series_rows)
+        if any(row.get(field) is None for field in ("open", "high", "low", "close"))
+    }
+
+
+def _locate_signal_index(series_dates: Sequence[date], signal_bar_date: date) -> int:
+    try:
+        return series_dates.index(signal_bar_date)
+    except ValueError:
+        raise ValueError(
+            f"signal_bar_date {signal_bar_date} is absent from the current live series; "
+            "the durable signal and its input corpus no longer agree"
+        ) from None
+
+
+def _resolve_fill(
+    entry: StrategyEntry,
+    fill: PendingFill,
+    *,
+    series: BarSeries,
+    unresolved_breaks: Sequence[date],
+) -> OutcomeRow | None:
+    """Return a terminal row, or ``None`` while the forward window is immature."""
+    if entry.exit_levels is None:
+        raise ValueError(f"{entry.strategy_id} is level-based but has no exit-level factory")
+    if fill.universe != SCAN_UNIVERSE:
+        raise ValueError(
+            f"signal {fill.signal_id} carries universe {fill.universe!r}, expected current scan universe "
+            f"{SCAN_UNIVERSE!r}"
+        )
+    signal_index = _locate_signal_index(series.dates, fill.signal_bar_date)
+    fill_index = locate_fill_index(series, fill.fill_bar_date)
+    signal_segment_end = segment_end_index(
+        series,
+        fill_index=signal_index,
+        unresolved_breaks=unresolved_breaks,
+    )
+    if signal_segment_end is not None and fill_index > signal_segment_end:
+        return OutcomeRow.from_outcome(
+            fill.signal_id,
+            Outcome(
+                outcome="unresolved",
+                resolution_method="daily_bar",
+                rule_set_version=OUTCOME_RULE_SET_VERSION,
+                reason="series_break",
+            ),
+            input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+        )
+    signal_segment, local_signal_index = segment_for_index(
+        series,
+        index=signal_index,
+        unresolved_breaks=unresolved_breaks,
+    )
+    levels = entry.exit_levels(
+        signal_segment,
+        signal_index=local_signal_index,
+        entry_price=fill.fill_price,
+        universe=fill.universe,
+    )
+    outcome = resolve_outcome(
+        series=series,
+        fill_index=fill_index,
+        entry_price=fill.fill_price,
+        levels=levels,
+        masked_bar_reasons=_masked_reasons(series.rows),
+        segment_end_index=segment_end_index(
+            series,
+            fill_index=fill_index,
+            unresolved_breaks=unresolved_breaks,
+        ),
+    )
+    if outcome.outcome == "unresolved" and outcome.reason == "window_truncated":
+        return None
+    return OutcomeRow.from_outcome(
+        fill.signal_id,
+        outcome,
+        input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+    )
+
+
+def _cursor_params(strategy_id: str, strategy_version: str) -> dict[str, str]:
+    return {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "rule_set_version": OUTCOME_RULE_SET_VERSION,
+        "input_rule_set_version": QUARANTINE_RULE_SET_VERSION,
+    }
+
+
+def _read_cursor(conn: psycopg.Connection[Any], *, strategy_id: str, strategy_version: str) -> int:
+    row = conn.execute(_READ_CURSOR_SQL, _cursor_params(strategy_id, strategy_version)).fetchone()
+    return 0 if row is None else int(row[0])
+
+
+def _write_cursor(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    last_signal_id: int,
+) -> None:
+    conn.execute(
+        _WRITE_CURSOR_SQL,
+        {**_cursor_params(strategy_id, strategy_version), "last_signal_id": last_signal_id},
+    )
+
+
+def _select_round_robin(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    cursor: int,
+    limit: int,
+) -> list[PendingFill]:
+    """Select after ``cursor``, then wrap once without repeating a row."""
+    fills = select_pending_fills(
+        conn,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        rule_set_version=OUTCOME_RULE_SET_VERSION,
+        input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+        limit=limit,
+        after_signal_id=cursor,
+    )
+    if len(fills) < limit and cursor > 0:
+        fills.extend(
+            select_pending_fills(
+                conn,
+                strategy_id=strategy_id,
+                strategy_version=strategy_version,
+                rule_set_version=OUTCOME_RULE_SET_VERSION,
+                input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+                limit=limit - len(fills),
+                after_signal_id=0,
+                at_or_before_signal_id=cursor,
+            )
+        )
+    return fills
+
+
+def run_outcome_resolution(
+    conn: psycopg.Connection[Any],
+    *,
+    manifest: Mapping[str, StrategyEntry] = STRATEGY_MANIFEST,
+    batch_limit: int = DEFAULT_BATCH_LIMIT,
+) -> OutcomeResolutionReport:
+    """Resolve a round-robin batch of current-version forward fills.
+
+    The connection is autocommit for the same reason as the signal scan: each
+    strategy owns a real top-level transaction, so one faulty strategy cannot
+    roll back healthy strategies or leave a partial batch committed.
+    """
+    if not conn.autocommit:
+        raise ValueError("run_outcome_resolution needs an autocommit connection for per-strategy commits")
+    if batch_limit < 1:
+        raise ValueError(f"batch_limit must be positive, got {batch_limit}")
+
+    level_entries = [(strategy_id, entry) for strategy_id, entry in sorted(manifest.items()) if entry.exit_levels]
+    if len(level_entries) > batch_limit:
+        raise ValueError(
+            f"batch_limit {batch_limit} is smaller than the {len(level_entries)} level strategies; "
+            "at least one slot per strategy is required to prevent starvation"
+        )
+    remaining = batch_limit
+    results: list[StrategyOutcomeResult] = []
+    skipped = len(manifest) - len(level_entries)
+    for index, (strategy_id, entry) in enumerate(level_entries):
+        regime = entry.exit_regime(entry.decision_calendar(()))
+        if not regime.level_based:
+            raise ValueError(f"{strategy_id} declares exit levels but its exit regime is not level-based")
+        strategies_left = len(level_entries) - index
+        allowance = max(1, remaining // strategies_left)
+        identity = entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID)
+        cursor = _read_cursor(conn, strategy_id=strategy_id, strategy_version=identity.version)
+        fills = _select_round_robin(
+            conn,
+            strategy_id=strategy_id,
+            strategy_version=identity.version,
+            cursor=cursor,
+            limit=allowance,
+        )
+        remaining -= len(fills)
+        by_instrument: dict[int, list[PendingFill]] = {}
+        for fill in fills:
+            by_instrument.setdefault(fill.instrument_id, []).append(fill)
+        breaks = load_unresolved_breaks(conn, sorted(by_instrument))
+        rows: list[OutcomeRow] = []
+        immature = 0
+        for instrument_id, instrument_fills in sorted(by_instrument.items()):
+            series = load_masked_bars(conn, instrument_id).series
+            for fill in instrument_fills:
+                row = _resolve_fill(
+                    entry,
+                    fill,
+                    series=series,
+                    unresolved_breaks=breaks.get(instrument_id, ()),
+                )
+                if row is None:
+                    immature += 1
+                else:
+                    rows.append(row)
+        with conn.transaction():
+            written = store_outcomes(conn, rows)
+            if fills:
+                _write_cursor(
+                    conn,
+                    strategy_id=strategy_id,
+                    strategy_version=identity.version,
+                    last_signal_id=fills[-1].signal_id,
+                )
+        outcomes = Counter(row.outcome for row in rows)
+        results.append(
+            StrategyOutcomeResult(
+                strategy_id=strategy_id,
+                strategy_version=identity.version,
+                selected=len(fills),
+                written=written,
+                immature=immature,
+                ambiguous=outcomes["ambiguous"],
+                outcomes=dict(sorted(outcomes.items())),
+            )
+        )
+
+    report = OutcomeResolutionReport(
+        selected=sum(item.selected for item in results),
+        written=sum(item.written for item in results),
+        immature=sum(item.immature for item in results),
+        ambiguous=sum(item.ambiguous for item in results),
+        skipped_non_level_strategies=skipped,
+        per_strategy=tuple(results),
+    )
+    logger.info(
+        "strategy_outcome_resolution: selected=%d written=%d immature=%d ambiguous=%d skipped_non_level=%d limit=%d",
+        report.selected,
+        report.written,
+        report.immature,
+        report.ambiguous,
+        report.skipped_non_level_strategies,
+        batch_limit,
+    )
+    return report
+
+
+__all__ = [
+    "DEFAULT_BATCH_LIMIT",
+    "OutcomeResolutionReport",
+    "StrategyOutcomeResult",
+    "run_outcome_resolution",
+]

--- a/app/services/strategy_segmented_evaluation.py
+++ b/app/services/strategy_segmented_evaluation.py
@@ -1,0 +1,95 @@
+"""Strategy evaluation with indicator state isolated by price-scale segment."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from datetime import date
+
+from app.services.indicator_series import BarSeries, Universe
+from app.services.price_segments import series_segment_bounds
+from app.services.strategy_manifest import StrategyEntry
+from app.services.strategy_registry import (
+    NotEvaluableReason,
+    StagedMember,
+    StrategySignal,
+    stage_cross_sectional_member,
+)
+
+
+def segmented_signals(
+    entry: StrategyEntry,
+    series: BarSeries,
+    *,
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    unresolved_breaks: Sequence[date],
+) -> list[StrategySignal]:
+    """Evaluate every per-series leg with fresh state inside each segment."""
+    if entry.signals is None:
+        raise ValueError(f"{entry.strategy_id} has no per-series signal function")
+    signals: list[StrategySignal] = []
+    for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
+        segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
+        signals.extend(
+            StrategySignal(
+                verdict=signal.verdict,
+                signal_index=signal.signal_index + start,
+                kind=signal.kind,
+                reason=signal.reason,
+            )
+            for signal in entry.signals(segment, universe=universe, masked_reason=masked_reason)
+        )
+    per_kind = Counter(signal.kind for signal in signals)
+    if not per_kind or any(count != len(series) for count in per_kind.values()):
+        raise RuntimeError(
+            f"{entry.strategy_id} produced segmented verdict counts {dict(per_kind)} for {len(series)} bars"
+        )
+    return signals
+
+
+def segmented_member(
+    entry: StrategyEntry,
+    series: BarSeries,
+    *,
+    panel_decision_dates: frozenset[date],
+    universe: Universe,
+    masked_reason: NotEvaluableReason,
+    unresolved_breaks: Sequence[date],
+) -> StagedMember:
+    """Stage one ranked member with fresh state inside each scale segment."""
+    if entry.member is None:
+        raise ValueError(f"{entry.strategy_id} has no cross-sectional member function")
+    verdicts: list[StrategySignal | None] = []
+    scores: dict[date, float] = {}
+    for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
+        segment = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
+        staged = stage_cross_sectional_member(
+            entry.member(
+                segment,
+                panel_decision_dates=panel_decision_dates,
+                universe=universe,
+                masked_reason=masked_reason,
+            )
+        )
+        verdicts.extend(
+            None
+            if verdict is None
+            else StrategySignal(
+                verdict=verdict.verdict,
+                signal_index=verdict.signal_index + start,
+                kind=verdict.kind,
+                reason=verdict.reason,
+            )
+            for verdict in staged.verdicts
+        )
+        overlap = scores.keys() & staged.scores.keys()
+        if overlap:  # pragma: no cover - BarSeries dates and segments are disjoint
+            raise RuntimeError(f"{entry.strategy_id} produced duplicate segmented score dates {sorted(overlap)}")
+        scores.update(staged.scores)
+    if len(verdicts) != len(series):
+        raise RuntimeError(f"{entry.strategy_id} staged {len(verdicts)} segmented bars for {len(series)} inputs")
+    return StagedMember(verdicts=tuple(verdicts), scores=scores)
+
+
+__all__ = ["segmented_member", "segmented_signals"]

--- a/app/services/strategy_signal_scan.py
+++ b/app/services/strategy_signal_scan.py
@@ -26,11 +26,10 @@ rather than argued (``scripts/verify_2394_signal_scan_cost.py``, full population
    function* and ``StrategyIdentity`` records no K. The measured 0/3290 and
    0/2033 disagreement at K=250/750 is a negative result about this corpus's
    depth, not a licence.
-4. **Signals only.** ``strategy_outcomes`` is fed exclusively by the level-based
-   resolver, S-4 is the only ``level_based`` strategy, and nothing in ``app/``
-   constructs an ``ExitLevels``. Worse, an outcome stored for an immature window
-   drops that signal out of ``select_pending_fills`` **permanently**. Outcome
-   resolution is a separate job on a separate ticket.
+4. **Signals only.** Outcome resolution remains a separate scheduled job. It
+   consumes only level-based entries with a manifest-owned ``ExitLevels``
+   factory and deliberately leaves an immature window pending: storing it would
+   drop that signal out of ``select_pending_fills`` **permanently**.
 
 ⚠ IT DOES NOT BACKFILL, AND THE COLD-START RULE IS WHERE THAT IS ENFORCED. See
 ``write_window_indices``: with no watermark the scan writes the single
@@ -58,6 +57,7 @@ from app.services.price_masked_bars import (
     load_masked_bars,
     load_union_calendar,
 )
+from app.services.price_segments import load_unresolved_breaks
 from app.services.signal_ledger import LedgerRow, resolve_fills
 from app.services.strategies.validated_universe import load_validated_universe
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry
@@ -67,8 +67,8 @@ from app.services.strategy_registry import (
     StrategyIdentity,
     StrategySignal,
     Verdict,
-    stage_cross_sectional_member,
 )
+from app.services.strategy_segmented_evaluation import segmented_member, segmented_signals
 
 logger = logging.getLogger(__name__)
 
@@ -468,6 +468,7 @@ def run_signal_scan(
     eligible = sorted(
         instrument_id for instrument_id, span in spans.items() if span.last_bar == frontier.bar_date and span.bars >= 2
     )
+    unresolved_breaks = load_unresolved_breaks(conn, eligible)
     at_frontier = sum(1 for span in spans.values() if span.last_bar == frontier.bar_date)
 
     watermarks = read_watermarks(conn)
@@ -563,7 +564,14 @@ def run_signal_scan(
                 continue
             expected[plan.entry.strategy_id] += len(window)
             if plan.entry.strategy_class == "per_series":
-                _scan_per_series(plan, series, instrument_id, window, rows[plan.entry.strategy_id])
+                _scan_per_series(
+                    plan,
+                    series,
+                    instrument_id,
+                    window,
+                    rows[plan.entry.strategy_id],
+                    unresolved_breaks=unresolved_breaks.get(instrument_id, ()),
+                )
             else:
                 assert panel_dates is not None
                 _stage_cross_sectional(
@@ -574,6 +582,7 @@ def run_signal_scan(
                     panel_dates=panel_dates,
                     pending=pending[plan.entry.strategy_id],
                     scores=scores[plan.entry.strategy_id],
+                    unresolved_breaks=unresolved_breaks.get(instrument_id, ()),
                 )
 
     for plan in cross_sectional:
@@ -619,6 +628,8 @@ def _scan_per_series(
     instrument_id: int,
     window: range,
     out: list[LedgerRow],
+    *,
+    unresolved_breaks: Sequence[date] = (),
 ) -> None:
     """Full-history recompute, filtered to the window, resolved through the writer.
 
@@ -634,8 +645,13 @@ def _scan_per_series(
     ``signal_index``, so a subset of signals against the full series resolves
     each fill from the same bar it always would.
     """
-    assert plan.entry.signals is not None
-    signals = plan.entry.signals(series, universe=SCAN_UNIVERSE, masked_reason=MASKED_REASON)
+    signals = segmented_signals(
+        plan.entry,
+        series,
+        universe=SCAN_UNIVERSE,
+        masked_reason=MASKED_REASON,
+        unresolved_breaks=unresolved_breaks,
+    )
     windowed = [signal for signal in signals if signal.signal_index in window]
     out.extend(resolve_fills(windowed, series=series, identity=plan.identity, instrument_id=instrument_id))
 
@@ -649,6 +665,7 @@ def _stage_cross_sectional(
     panel_dates: frozenset[date],
     pending: dict[int, _PendingMember],
     scores: dict[date, dict[int, float]],
+    unresolved_breaks: Sequence[date] = (),
 ) -> None:
     """Everything decidable about one member without seeing the others.
 
@@ -658,14 +675,14 @@ def _stage_cross_sectional(
     would re-implement the staging pass, which is how a census and the strategy
     it measures come to disagree."*
     """
-    assert plan.entry.member is not None
-    member = plan.entry.member(
+    staged = segmented_member(
+        plan.entry,
         series,
         panel_decision_dates=panel_dates,
         universe=SCAN_UNIVERSE,
         masked_reason=MASKED_REASON,
+        unresolved_breaks=unresolved_breaks,
     )
-    staged = stage_cross_sectional_member(member)
 
     start = window.start
     trimmed = BarSeries(dates=series.dates[start:], rows=series.rows[start:])

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -370,6 +370,9 @@ JOB_PRICE_QUARANTINE_REFRESH = "price_quarantine_refresh"
 # if candles have not moved, the frontier has not moved, and the watermark makes
 # the run a no-op. See app/services/strategy_signal_scan.py.
 JOB_STRATEGY_SIGNAL_SCAN = "strategy_signal_scan"
+# #2474 — bounded forward outcome resolver. Shares ``strategy_scan`` so it
+# cannot race the signal producer or retention while selecting immutable fills.
+JOB_STRATEGY_OUTCOME_RESOLUTION = "strategy_outcome_resolution"
 # #2448 — range-partition retention. Shares ``strategy_scan`` so a partition
 # cannot be dropped while the scanner is inserting into it.
 JOB_STRATEGY_OBSERVATION_RETENTION = "strategy_observation_retention"
@@ -1983,10 +1986,9 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "refusals. Resumes from a per-(strategy_id, "
             "strategy_version) frontier watermark, so a re-run on the "
             "same frontier is a no-op and a market holiday neither "
-            "writes nor wedges. Signals only: outcome resolution is a "
-            "separate job (nothing in app/ builds an ExitLevels, and "
-            "an outcome stored for an immature window would drop the "
-            "signal from select_pending_fills permanently). Spec "
+            "writes nor wedges. Signals only: the 06:55 outcome job "
+            "consumes manifest-owned level brackets and leaves immature "
+            "windows pending rather than storing a false terminal result. Spec "
             "docs/proposals/ta/2026-08-08-strategy-signal-scan.md."
         ),
         # After the 03:00 orchestrator_full_sync has driven candles →
@@ -2003,11 +2005,25 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         prerequisite=_bootstrap_complete,
     ),
     ScheduledJob(
+        name=JOB_STRATEGY_OUTCOME_RESOLUTION,
+        display_name="Strategy forward outcome resolution (#2474)",
+        source="strategy_scan",
+        description=(
+            "Daily 06:55 UTC — after the signal scan, resolves mature current-version "
+            "level-based fills against the fail-closed live corpus. Incomplete windows "
+            "remain pending without a database write; terminal outcomes are one immutable "
+            "row per signal and rule-version pair, processed round-robin in a bounded batch."
+        ),
+        cadence=Cadence.daily(hour=6, minute=55),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
         name=JOB_STRATEGY_OBSERVATION_RETENTION,
         display_name="Strategy observation retention (#2448)",
         source="strategy_scan",
         description=(
-            "Daily 07:05 UTC — after the 06:45 signal scan, drops whole expired "
+            "Daily 07:05 UTC — after the 06:45 scan and 06:55 outcome pass, drops whole expired "
             "range partitions: negative signal detail after 90 days, 30m bars "
             "after 24 months, 5m bars after 12 months and 1m bars after 30 days. "
             "Fired signals and daily counts are durable. Never issues a mass DELETE."
@@ -4945,6 +4961,20 @@ def strategy_signal_scan() -> None:
         # run would be recorded green with a strategy silently dark.
         if failed:
             raise RuntimeError(f"strategy_signal_scan: {len(failed)} strategy(ies) failed: {failed}")
+
+
+def strategy_outcome_resolution() -> None:
+    """Resolve mature forward brackets without persisting immature windows."""
+    from app.services.strategy_outcome_resolution import run_outcome_resolution
+
+    with _tracked_job(JOB_STRATEGY_OUTCOME_RESOLUTION) as tracker:
+        with connect_job(autocommit=True) as conn:
+            report = run_outcome_resolution(conn)
+        tracker.row_count = report.written
+        tracker.note = (
+            f"selected={report.selected} written={report.written} "
+            f"immature={report.immature} ambiguous={report.ambiguous}"
+        )
 
 
 def strategy_observation_retention() -> None:

--- a/docs/proposals/ta/2026-08-10-forward-strategy-outcomes.md
+++ b/docs/proposals/ta/2026-08-10-forward-strategy-outcomes.md
@@ -1,0 +1,80 @@
+# Forward strategy outcomes — validated implementation (#2474)
+
+Status: implemented and regression-tested on branch `feature/2474-forward-outcomes`.
+
+## Decision
+
+The shadow track record is a two-stage pipeline:
+
+1. `strategy_signal_scan` records each causal decision and its next-open fill.
+2. `strategy_outcome_resolution` revisits current-version, level-based fills and
+   records the first terminal result supported by the live fail-closed corpus.
+
+The resolver runs daily at 06:55 UTC, after the 06:45 signal scan and before
+07:05 retention. Both jobs share the `strategy_scan` source lock.
+
+## Maturity and ambiguity
+
+`window_truncated` means the future has not happened yet. It is not written to
+`strategy_outcomes`; the fill remains pending and is retried after more bars
+arrive. A decisive target/stop, expiry, masked required field, series boundary,
+or daily both-touch is terminal and is stored once at
+`(signal_id, outcome_rule_set_version, quarantine_rule_set_version)`.
+
+A both-touch daily bar remains `ambiguous`, has no synthetic price or return,
+and is excluded from resolved-performance counts. The live gate counts only
+outcomes carrying `gross_return_pct`, rather than treating any audit row as a
+measured result.
+
+## Corpus and causality
+
+The job uses the same `load_masked_bars` path, current quarantine version,
+survivor-only universe label and manifest-owned strategy identity as the live
+scan. Indicator state and holding windows are bounded by unresolved
+`price_series_break` transitions. Brackets are produced from the signal's own
+price segment and from values available at signal/fill time; the resolver never
+derives strategy parameters.
+
+Only strategies with a manifest-owned `exit_levels` factory are eligible. At
+implementation time this is S-4. Signal-pair and calendar-exit strategies need
+their own forward position resolver before their shadow returns can be treated
+as comparable evidence.
+
+## Bounded storage and work
+
+- Pending selection is capped at 1,000 fills per run and advances through signal
+  IDs with a round-robin cursor, so permanently immature/delisted instruments
+  cannot starve later resolvable fills.
+- Bars are loaded once per instrument in the selected batch.
+- No heartbeat or pending-window rows are appended.
+- Terminal storage is one immutable row per signal and version pair.
+- Re-resolution requires a resolver or quarantine version change, preserving
+  the prior row alongside the new interpretation.
+
+Database growth is therefore proportional to fired signals, not to the number
+of instruments, bars, or scheduler polls. Cursor state is one mutable row per
+strategy/resolver/input-version identity; it does not append on each poll.
+
+## Pinned validation
+
+Automated tests cover:
+
+- an immature window remaining absent and retryable;
+- target resolution;
+- daily both-touch remaining unpriced and excluded from the live sample;
+- quarantine refusal;
+- price-scale boundary refusal;
+- oldest-first batch limits and invalid-limit rejection;
+- shared segmentation for per-series and cross-sectional strategy state; and
+- scheduler/runtime registration.
+
+The production path was also exercised against the development database with
+the current manifest. With no signals at the new S-4 strategy version it
+correctly reported a zero-write success rather than inventing a backfill.
+
+## Explicit non-goals
+
+This closes measurement plumbing; it does not make an unproven strategy safe to
+fund. Deployment remains fail-closed until recent historical evidence, forward
+resolved observations and the paper-stage controls all pass their existing
+gates. No 75% win-rate guarantee is introduced.

--- a/sql/294_strategy_outcome_cursor.sql
+++ b/sql/294_strategy_outcome_cursor.sql
@@ -1,0 +1,32 @@
+-- 294_strategy_outcome_cursor.sql
+--
+-- Bounded round-robin progress for forward strategy outcome resolution (#2474).
+-- An immature/delisted fill remains pending by design. Without a cursor, a
+-- full oldest batch of such rows would be selected forever and starve every
+-- later fill. This table is bounded metadata: one mutable row per strategy and
+-- resolver/input-version identity, never one row per poll or instrument.
+
+CREATE TABLE IF NOT EXISTS strategy_outcome_cursor (
+    strategy_id           TEXT        NOT NULL,
+    strategy_version      TEXT        NOT NULL,
+    rule_set_version      TEXT        NOT NULL,
+    input_rule_set_version TEXT       NOT NULL,
+    last_signal_id        BIGINT      NOT NULL,
+    updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (
+        strategy_id,
+        strategy_version,
+        rule_set_version,
+        input_rule_set_version
+    ),
+    CONSTRAINT strategy_outcome_cursor_versions_non_empty CHECK (
+        strategy_id <> '' AND
+        strategy_version <> '' AND
+        rule_set_version <> '' AND
+        input_rule_set_version <> ''
+    ),
+    CONSTRAINT strategy_outcome_cursor_signal_non_negative CHECK (last_signal_id >= 0)
+);
+
+COMMENT ON TABLE strategy_outcome_cursor IS
+    'One bounded round-robin cursor per strategy/outcome/input version; prevents immature fills starving later outcomes. #2474.';

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -40,7 +40,6 @@ from app.services.backtest_run import (
     _measure_namespace,
     _NamespaceBook,
     _namespaces_for_window,
-    _segment_end_index,
     _shifted,
     _signals_for,
     assert_no_existing_results,
@@ -67,6 +66,7 @@ from app.services.strategy_result import (
     ResultIdentity,
     StrategyResult,
 )
+from app.services.strategy_segmented_evaluation import segmented_member
 from app.services.strategy_statistics import StrategyMetrics
 from app.services.trial_register import TRIAL_REGISTER
 from app.services.walk_forward import FOLD_COUNT, WALK_FORWARD_MODEL_ID
@@ -1228,51 +1228,7 @@ class TestFills:
 
 
 class TestSeriesBreakBoundary:
-    """An unresolved transition bounds only positions opened before it."""
-
-    @staticmethod
-    def _series() -> BarSeries:
-        dates = tuple(date(2020, 1, day) for day in (1, 2, 4, 5))
-        row = {"open": Decimal("10"), "high": Decimal("11"), "low": Decimal("9"), "close": Decimal("10")}
-        return BarSeries(dates=dates, rows=(row, row, row, row))  # type: ignore[arg-type]
-
-    def test_the_last_pre_break_bar_bounds_an_earlier_fill(self) -> None:
-        assert (
-            _segment_end_index(
-                self._series(),
-                fill_index=0,
-                unresolved_breaks=(date(2020, 1, 4),),
-            )
-            == 1
-        )
-
-    def test_a_fill_on_the_break_date_is_inside_the_new_segment(self) -> None:
-        assert (
-            _segment_end_index(
-                self._series(),
-                fill_index=2,
-                unresolved_breaks=(date(2020, 1, 4),),
-            )
-            is None
-        )
-
-    def test_a_break_date_missing_from_vendor_bars_still_ends_the_old_segment(self) -> None:
-        assert (
-            _segment_end_index(
-                self._series(),
-                fill_index=0,
-                unresolved_breaks=(date(2020, 1, 3),),
-            )
-            == 1
-        )
-
-    def test_breaks_must_be_unique_and_ordered(self) -> None:
-        with pytest.raises(ValueError, match="unique and ordered"):
-            _segment_end_index(
-                self._series(),
-                fill_index=0,
-                unresolved_breaks=(date(2020, 1, 4), date(2020, 1, 3)),
-            )
+    """Every strategy computation restarts at an unresolved transition."""
 
     def test_s4_restarts_state_and_warmup_after_a_break(self) -> None:
         dates = tuple(date(2020, 1, 1) + timedelta(days=index) for index in range(260))
@@ -1313,16 +1269,20 @@ class TestSeriesBreakBoundary:
         series = BarSeries(dates=dates, rows=rows)  # type: ignore[arg-type]
         entry = STRATEGY_MANIFEST["s2-cross-sectional-momentum"]
         decision_dates = frozenset(dates)
-        whole = backtest_run._stage_cross_sectional_segments(  # noqa: SLF001
+        whole = segmented_member(
             entry,
             series,
-            decision_dates=decision_dates,
+            panel_decision_dates=decision_dates,
+            universe="survivor_only",
+            masked_reason="quarantined_bar",
             unresolved_breaks=(),
         )
-        segmented = backtest_run._stage_cross_sectional_segments(  # noqa: SLF001
+        segmented = segmented_member(
             entry,
             series,
-            decision_dates=decision_dates,
+            panel_decision_dates=decision_dates,
+            universe="survivor_only",
+            masked_reason="quarantined_bar",
             unresolved_breaks=(dates[300],),
         )
         assert whole.verdicts[400] is None

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -32,7 +32,7 @@ from app.services.processes.param_metadata import (
     materialise_scheduled_params,
     validate_job_params,
 )
-from app.workers.scheduler import SCHEDULED_JOBS
+from app.workers.scheduler import JOB_STRATEGY_OUTCOME_RESOLUTION, SCHEDULED_JOBS
 
 _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
     {
@@ -168,6 +168,15 @@ class TestScheduledJobSourceField:
     def test_every_source_is_valid_lane(self) -> None:
         bad = [(j.name, j.source) for j in SCHEDULED_JOBS if j.source not in _ALLOWED_SOURCES]
         assert not bad, f"jobs with invalid source: {bad}"
+
+    def test_forward_outcomes_run_between_signal_scan_and_retention_on_the_same_lane(self) -> None:
+        job = next(item for item in SCHEDULED_JOBS if item.name == JOB_STRATEGY_OUTCOME_RESOLUTION)
+        assert (job.source, job.cadence.kind, job.cadence.hour, job.cadence.minute) == (
+            "strategy_scan",
+            "daily",
+            6,
+            55,
+        )
 
     def test_no_legacy_sec_lane_leak(self) -> None:
         """Regression — pre-#1020 catch-all lane='sec' MUST NOT appear in source keys.

--- a/tests/test_outcome_ledger_db.py
+++ b/tests/test_outcome_ledger_db.py
@@ -433,6 +433,59 @@ class TestSelectPendingFills:
         assert {fill.universe for fill in fills} == {"survivor_only"}
         assert all(fill.fill_price == Decimal("100") for fill in fills)
 
+    def test_the_signal_id_batch_is_bounded(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        signals: dict[str, int],
+    ) -> None:
+        fills = select_pending_fills(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_STRATEGY_VERSION,
+            rule_set_version=_RULE_SET,
+            input_rule_set_version=_INPUT_RULE_SET,
+            limit=1,
+        )
+        assert len(fills) == 1
+        assert fills[0].signal_id == signals["fired_entry"]
+        assert fills[0].signal_bar_date == date(2024, 1, 2)
+
+    def test_cursor_bounds_select_the_next_slice(
+        self,
+        ebull_test_conn: psycopg.Connection[tuple],
+        signals: dict[str, int],
+    ) -> None:
+        after_first = select_pending_fills(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_STRATEGY_VERSION,
+            rule_set_version=_RULE_SET,
+            input_rule_set_version=_INPUT_RULE_SET,
+            after_signal_id=signals["fired_entry"],
+        )
+        wrapped = select_pending_fills(
+            ebull_test_conn,
+            strategy_id=_STRATEGY_ID,
+            strategy_version=_STRATEGY_VERSION,
+            rule_set_version=_RULE_SET,
+            input_rule_set_version=_INPUT_RULE_SET,
+            after_signal_id=0,
+            at_or_before_signal_id=signals["fired_entry"],
+        )
+        assert [fill.signal_id for fill in after_first] == [signals["second_fired_entry"]]
+        assert [fill.signal_id for fill in wrapped] == [signals["fired_entry"]]
+
+    def test_non_positive_limit_is_refused(self, ebull_test_conn: psycopg.Connection[tuple]) -> None:
+        with pytest.raises(ValueError, match="limit must be positive"):
+            select_pending_fills(
+                ebull_test_conn,
+                strategy_id=_STRATEGY_ID,
+                strategy_version=_STRATEGY_VERSION,
+                rule_set_version=_RULE_SET,
+                input_rule_set_version=_INPUT_RULE_SET,
+                limit=0,
+            )
+
     def test_another_strategy_version_is_out_of_scope(
         self, ebull_test_conn: psycopg.Connection[tuple], signals: dict[str, int]
     ) -> None:

--- a/tests/test_price_segments.py
+++ b/tests/test_price_segments.py
@@ -1,0 +1,36 @@
+"""Pure price-scale segment boundary tests."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import BarSeries
+from app.services.price_segments import segment_end_index, segment_for_index, series_segment_bounds
+
+
+def _series() -> BarSeries:
+    dates = tuple(date(2020, 1, day) for day in (1, 2, 4, 5))
+    row = {"open": Decimal("10"), "high": Decimal("11"), "low": Decimal("9"), "close": Decimal("10")}
+    return BarSeries(dates=dates, rows=(row, row, row, row))  # type: ignore[arg-type]
+
+
+def test_a_missing_break_date_still_splits_at_the_first_later_stored_bar() -> None:
+    assert series_segment_bounds(_series(), unresolved_breaks=(date(2020, 1, 3),)) == ((0, 2), (2, 4))
+    assert segment_end_index(_series(), fill_index=0, unresolved_breaks=(date(2020, 1, 3),)) == 1
+
+
+def test_a_fill_on_the_break_bar_is_inside_the_new_segment() -> None:
+    assert segment_end_index(_series(), fill_index=2, unresolved_breaks=(date(2020, 1, 4),)) is None
+    segment, local_index = segment_for_index(_series(), index=2, unresolved_breaks=(date(2020, 1, 4),))
+    assert (segment.dates, local_index) == ((date(2020, 1, 4), date(2020, 1, 5)), 0)
+
+
+def test_breaks_must_be_unique_and_ordered() -> None:
+    with pytest.raises(ValueError, match="unique and ordered"):
+        series_segment_bounds(
+            _series(),
+            unresolved_breaks=(date(2020, 1, 4), date(2020, 1, 3)),
+        )

--- a/tests/test_strategy_live_gate.py
+++ b/tests/test_strategy_live_gate.py
@@ -19,6 +19,8 @@ from app.api.strategies import (
     execute_live_kill_drill,
 )
 from app.security.sessions import SessionRow
+from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
+from app.services.price_quarantine import RULE_SET_VERSION as QUARANTINE_RULE_SET_VERSION
 from app.services.strategy_control_plane import (
     StrategyControlError,
     configure_deployment,
@@ -170,6 +172,18 @@ def test_report_names_every_missing_measured_prerequisite_and_live_writer_block(
         """,
         (_STRATEGY_ID, _VERSION),
     )
+    conn.execute(
+        """
+        INSERT INTO strategy_outcomes (
+          signal_id,rule_set_version,input_rule_set_version,outcome,
+          resolution_method,exit_bar_date,bars_held
+        )
+        SELECT signal_id,%s,%s,'ambiguous','daily_bar',fill_bar_date,0
+        FROM strategy_signals
+        WHERE strategy_id=%s AND strategy_version=%s
+        """,
+        (OUTCOME_RULE_SET_VERSION, QUARANTINE_RULE_SET_VERSION, _STRATEGY_ID, _VERSION),
+    )
 
     report = assess_live_gate(
         conn,
@@ -189,6 +203,8 @@ def test_report_names_every_missing_measured_prerequisite_and_live_writer_block(
         "live_capital_exceeds_preregistered_cap",
         "live_strategy_broker_contract_not_validated",
     }.issubset(report.refusal_codes)
+    # A both-touch daily bar has no known P&L and must not satisfy the resolved
+    # performance sample merely because it has a terminal audit row.
     assert report.facts.forward_resolved_signals == 0
     assert report.facts.paper_closed_trades == 0
     assert report.facts.active_owned_instrument_count == 0

--- a/tests/test_strategy_outcome_resolution.py
+++ b/tests/test_strategy_outcome_resolution.py
@@ -1,0 +1,161 @@
+"""Forward outcome resolution: mature once, never persist an immature poll."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import cast
+
+import psycopg
+import pytest
+
+from app.services.indicator_series import BarSeries
+from app.services.outcome_ledger import PendingFill
+from app.services.outcome_resolver import ExitLevels
+from app.services.strategy_manifest import StrategyEntry
+from app.services.strategy_outcome_resolution import _read_cursor, _resolve_fill, _select_round_robin, _write_cursor
+
+
+def _series(*ranges: tuple[Decimal | None, Decimal | None]) -> BarSeries:
+    dates = tuple(date(2026, 8, 1) + timedelta(days=index) for index in range(len(ranges)))
+    rows = tuple(
+        {
+            "open": Decimal("100"),
+            "high": high,
+            "low": low,
+            "close": Decimal("100"),
+            "volume": Decimal("1000"),
+        }
+        for high, low in ranges
+    )
+    return BarSeries(dates=dates, rows=rows)  # type: ignore[arg-type]
+
+
+def _entry(*, max_hold_bars: int = 2) -> StrategyEntry:
+    levels = ExitLevels(
+        take_profit=Decimal("110"),
+        stop_loss=Decimal("90"),
+        max_hold_bars=max_hold_bars,
+    )
+    return cast(
+        StrategyEntry,
+        SimpleNamespace(
+            strategy_id="test-level",
+            exit_levels=lambda _series, *, signal_index, entry_price, universe: levels,
+        ),
+    )
+
+
+def _fill(series: BarSeries) -> PendingFill:
+    return PendingFill(
+        signal_id=7,
+        instrument_id=42,
+        signal_bar_date=series.dates[0],
+        fill_bar_date=series.dates[1],
+        fill_price=Decimal("100"),
+        universe="survivor_only",
+    )
+
+
+def test_an_immature_window_is_left_pending_without_a_row() -> None:
+    series = _series((Decimal("105"), Decimal("95")), (Decimal("105"), Decimal("95")))
+    assert _resolve_fill(_entry(), _fill(series), series=series, unresolved_breaks=()) is None
+
+
+def test_a_decisive_target_is_stored_as_a_booked_outcome() -> None:
+    series = _series((Decimal("105"), Decimal("95")), (Decimal("111"), Decimal("95")))
+    row = _resolve_fill(_entry(), _fill(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.exit_bar_date, row.gross_return_pct) == (
+        "tp_hit",
+        series.dates[1],
+        Decimal("0.1"),
+    )
+
+
+def test_same_bar_both_touch_remains_ambiguous_and_unbooked() -> None:
+    series = _series((Decimal("105"), Decimal("95")), (Decimal("111"), Decimal("89")))
+    row = _resolve_fill(_entry(), _fill(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.exit_bar_date, row.gross_return_pct) == (
+        "ambiguous",
+        series.dates[1],
+        None,
+    )
+
+
+def test_a_scale_break_is_terminal_but_never_priced_across_scales() -> None:
+    series = _series(
+        (Decimal("105"), Decimal("95")),
+        (Decimal("105"), Decimal("95")),
+        (Decimal("111"), Decimal("89")),
+    )
+    row = _resolve_fill(
+        _entry(),
+        _fill(series),
+        series=series,
+        unresolved_breaks=(series.dates[2],),
+    )
+    assert row is not None
+    assert (row.outcome, row.reason, row.gross_return_pct) == ("unresolved", "series_break", None)
+
+
+def test_a_break_between_signal_and_fill_is_terminal_before_levels_are_mixed() -> None:
+    series = _series((Decimal("105"), Decimal("95")), (Decimal("150"), Decimal("100")))
+    row = _resolve_fill(
+        _entry(),
+        _fill(series),
+        series=series,
+        unresolved_breaks=(series.dates[1],),
+    )
+    assert row is not None
+    assert (row.outcome, row.reason, row.gross_return_pct) == ("unresolved", "series_break", None)
+
+
+def test_a_masked_required_field_is_counted_not_silently_dropped() -> None:
+    series = _series((Decimal("105"), Decimal("95")), (None, Decimal("95")))
+    row = _resolve_fill(_entry(), _fill(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.reason, row.gross_return_pct) == ("unresolved", "quarantined_bar", None)
+
+
+def test_round_robin_wraps_after_the_cursor_without_repeating(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[tuple[int, int | None, int]] = []
+
+    def select(_conn: object, **kwargs: object) -> list[PendingFill]:
+        after = cast(int, kwargs["after_signal_id"])
+        ceiling = cast(int | None, kwargs.get("at_or_before_signal_id"))
+        limit = cast(int, kwargs["limit"])
+        seen.append((after, ceiling, limit))
+        ids = [8] if after == 7 else [2, 3]
+        return [
+            PendingFill(
+                signal_id=signal_id,
+                instrument_id=42,
+                signal_bar_date=date(2026, 8, 1),
+                fill_bar_date=date(2026, 8, 2),
+                fill_price=Decimal("100"),
+                universe="survivor_only",
+            )
+            for signal_id in ids[:limit]
+        ]
+
+    monkeypatch.setattr("app.services.strategy_outcome_resolution.select_pending_fills", select)
+    fills = _select_round_robin(
+        cast(psycopg.Connection[object], object()),
+        strategy_id="test",
+        strategy_version="v1",
+        cursor=7,
+        limit=3,
+    )
+    assert [fill.signal_id for fill in fills] == [8, 2, 3]
+    assert seen == [(7, None, 3), (0, 7, 2)]
+
+
+def test_cursor_is_one_mutable_row_per_version_pair(ebull_test_conn: psycopg.Connection[object]) -> None:
+    assert _read_cursor(ebull_test_conn, strategy_id="test", strategy_version="v1") == 0
+    _write_cursor(ebull_test_conn, strategy_id="test", strategy_version="v1", last_signal_id=10)
+    _write_cursor(ebull_test_conn, strategy_id="test", strategy_version="v1", last_signal_id=3)
+    assert _read_cursor(ebull_test_conn, strategy_id="test", strategy_version="v1") == 3
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_outcome_cursor").fetchone() == (1,)

--- a/tests/test_strategy_outcome_resolution.py
+++ b/tests/test_strategy_outcome_resolution.py
@@ -120,6 +120,25 @@ def test_a_masked_required_field_is_counted_not_silently_dropped() -> None:
     assert (row.outcome, row.reason, row.gross_return_pct) == ("unresolved", "quarantined_bar", None)
 
 
+def test_precomputed_masked_reasons_are_reused_for_an_instrument(monkeypatch: pytest.MonkeyPatch) -> None:
+    series = _series((Decimal("105"), Decimal("95")), (None, Decimal("95")))
+    monkeypatch.setattr(
+        "app.services.strategy_outcome_resolution._masked_reasons",
+        lambda _rows: pytest.fail("masked reasons were recomputed per fill"),
+    )
+
+    row = _resolve_fill(
+        _entry(),
+        _fill(series),
+        series=series,
+        unresolved_breaks=(),
+        masked_bar_reasons={1: "quarantined_bar"},
+    )
+
+    assert row is not None
+    assert (row.outcome, row.reason) == ("unresolved", "quarantined_bar")
+
+
 def test_round_robin_wraps_after_the_cursor_without_repeating(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: list[tuple[int, int | None, int]] = []
 


### PR DESCRIPTION
## Outcome

Completes the forward shadow-measurement loop for manifest-owned level strategies without persisting immature polling state.

- schedules a bounded 06:55 UTC outcome pass after the daily signal scan
- resolves current-version S-4 fills with the same fail-closed live corpus and causal ATR bracket
- leaves `window_truncated` fills pending; stores terminal target/stop/expiry/ambiguity/refusal once
- shares unresolved price-scale segmentation across backtest and live scan consumers
- records cross-scale signal/fill as an unpriced `series_break` refusal
- advances a one-row-per-version round-robin cursor so delisted/immature fills cannot starve later evidence
- excludes ambiguous/unpriced rows from the live gate resolved-performance sample
- documents the storage and maturity contract

## Database shape

`strategy_outcome_cursor` is bounded current state: one mutable row per strategy/outcome/input-version identity. There are no per-poll or per-instrument heartbeat rows. Terminal outcomes remain one immutable row per fired signal/version pair.

## Validation

- repository ruff + format + pyright gates pass
- full fast pre-push tier passes
- 154 smoke tests pass (3 skipped)
- focused DB/service/scheduler tests pass
- local Codex review found and drove fixes for cross-scale fills and immature-batch starvation; follow-up review found no correctness issue

Closes #2474.
Refs #2469.
Refs #2240.
