### PR TITLE
fix(strategies): count only resolvable outcomes

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -178,6 +178,7 @@ class StrategyOverview(BaseModel):
     description: str
     exit_timing: str
     runnable: bool
+    forward_outcome_supported: bool
     exclusion_reason: str | None
     scan: ScanHealth
     evidence_windows: list[EvidenceWindow]
@@ -941,6 +942,7 @@ def get_strategy_overview(
                 description=_PRESENTATION.get(strategy_id, ("Evidence-backed automated strategy.", "Rule based"))[0],
                 exit_timing=_PRESENTATION.get(strategy_id, ("Evidence-backed automated strategy.", "Rule based"))[1],
                 runnable=strategy_id in runnable,
+                forward_outcome_supported=entry.exit_levels is not None,
                 exclusion_reason=excluded_by_id.get(strategy_id),
                 scan=scan,
                 evidence_windows=windows,

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2450,6 +2450,7 @@ export interface StrategyOverview {
   description: string;
   exit_timing: string;
   runnable: boolean;
+  forward_outcome_supported: boolean;
   exclusion_reason: string | null;
   scan: {
     frontier_date: string | null;

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -88,6 +88,7 @@ const OVERVIEW: StrategyOverviewResponse = {
     description: "Follows established price trends and exits when the trend turns.",
     exit_timing: "Until the trend turns",
     runnable: true,
+    forward_outcome_supported: false,
     exclusion_reason: null,
     scan: { frontier_date: "2026-08-07", updated_at: "2026-08-08T06:45:00Z", status: "current", fired_entries: 12, fired_exits: 0, not_fired: 100, not_evaluable: 0, exclusions_by_reason: {} },
     evidence_windows: [
@@ -158,6 +159,7 @@ function approvedOverview(): StrategyOverviewResponse {
     paper_pool: { ...OVERVIEW.paper_pool, enabled: true, reserved_capital: "250", invested_capital: "200", remaining_capital: "750" },
     strategies: [{
       ...strategy,
+      forward_outcome_supported: true,
       all_recent_evidence_complete: true,
       stage: "paper_enabled",
       attribution: {
@@ -226,9 +228,38 @@ describe("StrategiesPage", () => {
     });
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     expect(await screen.findByText("Validation controls")).toBeInTheDocument();
-    expect(screen.getByText("Harness evidence only · never eligible for capital")).toBeInTheDocument();
+    expect(screen.getByText("Harness evidence only · never eligible for capital · backtest only")).toBeInTheDocument();
     expect(screen.getByText("No capital candidates yet")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "View evidence" })).not.toBeInTheDocument();
+  });
+
+  it("counts only strategies with a forward outcome resolver as open observations", async () => {
+    const strategy = OVERVIEW.strategies[0]!;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      strategies: [
+        strategy,
+        {
+          ...strategy,
+          strategy_id: "s4-volatility-compression-breakout",
+          title: "Volatility compression breakout",
+          forward_outcome_supported: true,
+          attribution: {
+            ...strategy.attribution,
+            fired_entries: 108,
+            resolved_entries: 2,
+            winning_entries: 1,
+            win_rate: "0.5",
+            shadow_average_return_pct: "0.0509",
+          },
+        },
+      ],
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const validation = (await screen.findByText("Forward signal validation")).closest("section")!;
+    expect(within(validation).getByText("106")).toBeInTheDocument();
+    expect(within(validation).getByText("2")).toBeInTheDocument();
+    expect(within(validation).getAllByText("1", { selector: "dd" })).toHaveLength(2);
   });
 
   it("does not present a legacy enabled harness deployment as approved", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -131,17 +131,18 @@ function refusalLabel(refusal: string): string {
 
 function aggregate(overview: StrategyOverviewResponse) {
   const pnlValues = overview.strategies.map((strategy) => number(strategy.pnl.total_pnl));
-  const resolved = overview.strategies.reduce(
+  const forwardStrategies = overview.strategies.filter((strategy) => strategy.forward_outcome_supported);
+  const resolved = forwardStrategies.reduce(
     (sum, strategy) => sum + strategy.attribution.resolved_entries,
     0,
   );
-  const winners = overview.strategies.reduce(
+  const winners = forwardStrategies.reduce(
     (sum, strategy) => sum + strategy.attribution.winning_entries,
     0,
   );
   let weightedReturn = 0;
   let averageReturnKnown = resolved > 0;
-  for (const strategy of overview.strategies) {
+  for (const strategy of forwardStrategies) {
     if (strategy.attribution.resolved_entries === 0) continue;
     const average = number(strategy.attribution.shadow_average_return_pct);
     if (average === null) {
@@ -150,7 +151,7 @@ function aggregate(overview: StrategyOverviewResponse) {
     }
     weightedReturn += average * strategy.attribution.resolved_entries;
   }
-  const fired = overview.strategies.reduce(
+  const fired = forwardStrategies.reduce(
     (sum, strategy) => sum + strategy.attribution.fired_entries,
     0,
   );
@@ -801,7 +802,10 @@ function ValidationControl({ strategy }: { strategy: StrategyOverview }) {
           <h3 className="text-sm font-semibold">{strategy.title}</h3>
           <Badge tone="neutral">Control</Badge>
         </div>
-        <p className="mt-1 text-xs text-slate-500">Harness evidence only · never eligible for capital</p>
+        <p className="mt-1 text-xs text-slate-500">
+          Harness evidence only · never eligible for capital
+          {strategy.forward_outcome_supported ? " · forward outcomes measured" : " · backtest only"}
+        </p>
       </div>
       <div><span className="text-xs text-slate-500">Expected / trade</span><strong className="block tabular-nums">{pctPoints(arm?.expectancy_per_trade_pct ?? null)}</strong></div>
       <div><span className="text-xs text-slate-500">Worst drawdown</span><strong className="block tabular-nums">{pctPoints(arm?.max_drawdown_pct ?? null)}</strong></div>

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -327,3 +327,17 @@ def test_overview_maps_only_exact_current_holdout_provenance(
     assert primary.arms[0].sortino is None
     assert primary.arms[0].profit_factor is None
     assert strategy.legacy_result_count == 2
+
+
+def test_overview_declares_only_level_strategies_forward_resolvable(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    overview = get_strategy_overview(ebull_test_conn)
+    support = {item.strategy_id: item.forward_outcome_supported for item in overview.strategies}
+
+    assert support == {
+        "s1-time-series-momentum": False,
+        "s2-cross-sectional-momentum": False,
+        "s3-mean-reversion-in-trend": False,
+        "s4-volatility-compression-breakout": True,
+    }


### PR DESCRIPTION
Part of #2469

## Outcome

The Strategies headline no longer counts signals from controls whose forward exit path is not implemented as permanently open observations. The API declares the current forward-resolution capability from the same manifest field consumed by the resolver; the UI aggregates only that population and labels each validation control as forward-measured or backtest-only.

## Measured dev result

Current causal S4 scan: 108 fired entries, 2 terminal outcomes (1 TP, 1 SL), 106 immature. S1/S3 signals remain auditable but no longer inflate the open-observation headline while their signal-pair forward resolver is absent.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m "not db"` — 7,221 passed
- `uv run pytest tests/smoke` — 154 passed
- `uv run pytest -q tests/test_api_strategies.py` — 12 passed
- `pnpm --dir frontend typecheck`
- `pnpm --dir frontend test:unit` — 1,501 passed
- `codex exec review --base origin/main` — no findings

## Storage

No schema or additional data rows. This is a read-model correction only.