### PR TITLE
fix(#2488): bound recent evidence checkpoints

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -53,11 +53,11 @@ import math
 import time
 from array import array
 from collections import Counter
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
-from typing import Any, Final
+from typing import Any, Final, Literal, cast
 
 import numpy as np
 import psycopg
@@ -81,7 +81,7 @@ from app.services.equity_curve import (
 )
 from app.services.indicator_series import BarSeries, Universe
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
-from app.services.outcome_resolver import UnresolvedReason, resolve_outcome
+from app.services.outcome_resolver import ExitLevels, UnresolvedReason, resolve_outcome
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.position_builder import (
     EntryFill,
@@ -96,7 +96,7 @@ from app.services.position_costing import CostedPosition, cost_positions
 from app.services.price_segments import (
     load_unresolved_breaks,
     segment_end_index,
-    segment_for_index,
+    series_segment_bounds,
 )
 from app.services.price_structure import StructureBar
 from app.services.research_price_structure_store import (
@@ -145,6 +145,54 @@ from app.services.walk_forward import (
 )
 
 logger = logging.getLogger(__name__)
+
+BacktestPhase = Literal["corpus", "ranking", "evaluation", "deflation", "write"]
+
+
+@dataclass(frozen=True)
+class BacktestProgressEvent:
+    """One transient checkpoint; never evidence completion or a result row."""
+
+    phase: BacktestPhase
+    strategy_id: str | None = None
+    quarantine_arm: QuarantineArm | None = None
+    ambiguity_arm: AmbiguityArm | None = None
+    series_seen: int = 0
+    series_total: int | None = None
+
+
+ProgressCallback = Callable[[BacktestProgressEvent], None]
+
+
+def _emit_progress(callback: ProgressCallback | None, event: BacktestProgressEvent) -> None:
+    if callback is not None:
+        callback(event)
+
+
+def _emit_series_progress(
+    callback: ProgressCallback | None,
+    *,
+    phase: Literal["ranking", "evaluation"],
+    entry: StrategyEntry,
+    quarantine_arm: QuarantineArm,
+    ambiguity_arm: AmbiguityArm | None,
+    series_seen: int,
+    series_total: int,
+) -> None:
+    """Bound callback overhead while guaranteeing an early and final tick."""
+    if series_seen == 1 or series_seen == series_total or series_seen % 25 == 0:
+        _emit_progress(
+            callback,
+            BacktestProgressEvent(
+                phase=phase,
+                strategy_id=entry.strategy_id,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=ambiguity_arm,
+                series_seen=series_seen,
+                series_total=series_total,
+            ),
+        )
+
 
 #: The research corpus is survivor-only (#2284) and every row this job writes
 #: inherits that label (#2288). ⚠ It is BOTH the ``Universe`` hashed into
@@ -477,10 +525,10 @@ def runnable_strategies(
         entry = manifest[strategy_id]
         regime = _regime_for(entry, calendar)
         if not regime.level_based:
-            if entry.exit_levels is not None:
+            if entry.exit_levels is not None or entry.exit_levels_batch is not None:
                 raise RuntimeError(
-                    f"{strategy_id} supplies exit levels for a non-level regime — the declared close source and "
-                    "its consumer disagree"
+                    f"{strategy_id} supplies scalar or batch exit levels for a non-level regime — the declared "
+                    "close source and its consumer disagree"
                 )
             runnable.append(strategy_id)
             continue
@@ -575,8 +623,45 @@ def _resolved_level_outcomes(
     spans both. The resolver therefore emits ``ambiguous`` and this adapter
     converts only those rows to the declared best/worst sensitivity price.
     """
-    if entry.exit_levels is None:
-        raise ValueError(f"{entry.strategy_id} is level-based but declares no exit-level factory")
+    return _resolved_level_outcomes_for_arms(
+        entry,
+        entries,
+        series=series,
+        ambiguity_arms=(ambiguity_arm,),
+        quarantine_arm=quarantine_arm,
+        unresolved_breaks=unresolved_breaks,
+    )[ambiguity_arm]
+
+
+def _resolved_level_outcomes_for_arms(
+    entry: StrategyEntry,
+    entries: Sequence[EntryFill],
+    *,
+    series: BarSeries,
+    ambiguity_arms: Sequence[AmbiguityArm],
+    quarantine_arm: QuarantineArm,
+    unresolved_breaks: Sequence[date],
+) -> dict[AmbiguityArm, list[ResolvedOutcome]]:
+    """Resolve one filled population once, then project declared OHLC arms.
+
+    Only a genuinely ambiguous daily bar differs between ``best_case`` and
+    ``worst_case``. Signal fills, causal levels, gap outcomes, expiry and
+    unresolved reasons are shared facts. Each returned list is nevertheless a
+    distinct mutable container so later position/book accumulation cannot leak
+    between arms.
+    """
+    requested = tuple(ambiguity_arms)
+    if not requested or len(set(requested)) != len(requested):
+        raise ValueError("ambiguity_arms must be a non-empty sequence without duplicates")
+    unknown = {arm for arm in requested if arm not in AMBIGUITY_ARMS}
+    if unknown:
+        raise ValueError(f"unknown ambiguity arms {sorted(unknown)}")
+    levels_by_entry = _exit_levels_for_entries(
+        entry,
+        entries,
+        series=series,
+        unresolved_breaks=unresolved_breaks,
+    )
     bar_index = {when: index for index, when in enumerate(series.dates)}
     missing_reason: UnresolvedReason = "quarantined_bar" if quarantine_arm == "masked" else "missing_bar_data"
     masked_reasons: dict[int, UnresolvedReason] = {
@@ -584,21 +669,23 @@ def _resolved_level_outcomes(
         for index, row in enumerate(series.rows)
         if any(row.get(field) is None for field in ("open", "high", "low", "close"))
     }
-    resolved: list[ResolvedOutcome] = []
-    for fill in entries:
-        signal_index = bar_index[fill.signal_bar_date]
+    resolved: dict[AmbiguityArm, list[ResolvedOutcome]] = {arm: [] for arm in requested}
+    for fill, levels in zip(entries, levels_by_entry, strict=True):
+        if isinstance(levels, str):
+            for ambiguity_arm in requested:
+                resolved[ambiguity_arm].append(
+                    ResolvedOutcome(
+                        signal_id=fill.signal_id,
+                        rule_set_version=OUTCOME_RULE_SET_VERSION,
+                        input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+                        outcome="unresolved",
+                        exit_bar_date=None,
+                        exit_price=None,
+                        reason=levels,
+                    )
+                )
+            continue
         fill_index = bar_index[fill.fill_bar_date]
-        signal_series, local_signal_index = segment_for_index(
-            series,
-            index=signal_index,
-            unresolved_breaks=unresolved_breaks,
-        )
-        levels = entry.exit_levels(
-            signal_series,
-            signal_index=local_signal_index,
-            entry_price=fill.fill_price,
-            universe=BACKTEST_UNIVERSE,
-        )
         position_segment_end = segment_end_index(
             series,
             fill_index=fill_index,
@@ -612,28 +699,87 @@ def _resolved_level_outcomes(
             masked_bar_reasons=masked_reasons,
             segment_end_index=position_segment_end,
         )
-        outcome_name = outcome.outcome
-        exit_price = outcome.exit_price
-        if outcome_name == "ambiguous":
-            outcome_name = "tp_hit" if ambiguity_arm == "best_case" else "sl_hit"
-            exit_price = levels.take_profit if ambiguity_arm == "best_case" else levels.stop_loss
-        resolved.append(
-            ResolvedOutcome(
-                signal_id=fill.signal_id,
-                rule_set_version=OUTCOME_RULE_SET_VERSION,
-                input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
-                outcome=outcome_name,
-                exit_bar_date=outcome.exit_bar_date,
-                exit_price=exit_price,
-                reason=outcome.reason,
-                unresolved_until_bar_date=(
-                    series.dates[position_segment_end + 1]
-                    if outcome.reason == "series_break" and position_segment_end is not None
-                    else None
+        for ambiguity_arm in requested:
+            outcome_name = outcome.outcome
+            exit_price = outcome.exit_price
+            if outcome_name == "ambiguous":
+                outcome_name = "tp_hit" if ambiguity_arm == "best_case" else "sl_hit"
+                exit_price = levels.take_profit if ambiguity_arm == "best_case" else levels.stop_loss
+            resolved[ambiguity_arm].append(
+                ResolvedOutcome(
+                    signal_id=fill.signal_id,
+                    rule_set_version=OUTCOME_RULE_SET_VERSION,
+                    input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+                    outcome=outcome_name,
+                    exit_bar_date=outcome.exit_bar_date,
+                    exit_price=exit_price,
+                    reason=outcome.reason,
+                    unresolved_until_bar_date=(
+                        series.dates[position_segment_end + 1]
+                        if outcome.reason == "series_break" and position_segment_end is not None
+                        else None
+                    ),
                 ),
             )
-        )
     return resolved
+
+
+def _exit_levels_for_entries(
+    entry: StrategyEntry,
+    entries: Sequence[EntryFill],
+    *,
+    series: BarSeries,
+    unresolved_breaks: Sequence[date],
+) -> tuple[ExitLevels | UnresolvedReason, ...]:
+    """Build level objects in entry order, batching only within one segment.
+
+    Indicators restart at every unresolved scale break. Grouping by the exact
+    half-open segment preserves that reset while avoiding one full ATR pass per
+    entry. The scalar manifest factory remains the mandatory fallback and test
+    oracle.
+    """
+    if entry.exit_levels is None:
+        raise ValueError(f"{entry.strategy_id} is level-based but declares no exit-level factory")
+    if not entries:
+        return ()
+    bar_index = {when: index for index, when in enumerate(series.dates)}
+    indexed = [(position, fill, bar_index[fill.signal_bar_date]) for position, fill in enumerate(entries)]
+    unassigned = object()
+    built: list[ExitLevels | UnresolvedReason | object] = [unassigned] * len(entries)
+    for start, end in series_segment_bounds(series, unresolved_breaks=unresolved_breaks):
+        segment_entries = [(position, fill, index - start) for position, fill, index in indexed if start <= index < end]
+        if not segment_entries:
+            continue
+        signal_series = BarSeries(dates=series.dates[start:end], rows=series.rows[start:end])
+        requests = tuple((local_index, fill.fill_price) for _, fill, local_index in segment_entries)
+        if entry.exit_levels_batch is not None:
+            levels = tuple(
+                entry.exit_levels_batch(
+                    signal_series,
+                    requests=requests,
+                    universe=BACKTEST_UNIVERSE,
+                )
+            )
+        else:
+            levels = tuple(
+                entry.exit_levels(
+                    signal_series,
+                    signal_index=local_index,
+                    entry_price=fill.fill_price,
+                    universe=BACKTEST_UNIVERSE,
+                )
+                for _, fill, local_index in segment_entries
+            )
+        if len(levels) != len(segment_entries):
+            raise RuntimeError(
+                f"{entry.strategy_id} batch exit factory returned {len(levels)} levels for "
+                f"{len(segment_entries)} requests"
+            )
+        for (position, _fill, _local_index), level in zip(segment_entries, levels, strict=True):
+            built[position] = level
+    if any(level is unassigned for level in built):
+        raise RuntimeError(f"{entry.strategy_id} could not assign an exit bracket to every filled entry")
+    return cast(tuple[ExitLevels | UnresolvedReason, ...], tuple(built))
 
 
 def _mark_index(series: BarSeries, *, window: Window, not_before: date) -> int | None:
@@ -1150,6 +1296,7 @@ def evaluate_arm(
     ambiguity_arm: AmbiguityArm | None,
     identity: StrategyIdentity,
     namespaces: Sequence[ResultNamespace],
+    progress: ProgressCallback | None = None,
 ) -> ArmMeasurement:
     """One ``(strategy, quarantine arm)`` corpus pass, end to end.
 
@@ -1179,16 +1326,41 @@ def evaluate_arm(
     ranking: _CrossSection | None = None
 
     if entry.strategy_class == "cross_sectional":
-        ranking = _rank_cross_section(conn, entry, corpus=corpus, quarantine_arm=quarantine_arm)
+        ranking = _rank_cross_section(
+            conn,
+            entry,
+            corpus=corpus,
+            quarantine_arm=quarantine_arm,
+            progress=progress,
+        )
 
     evaluated = 0
-    for instrument_id, series_id in corpus.pairs:
+    total = len(corpus.pairs)
+    for series_seen, (instrument_id, series_id) in enumerate(corpus.pairs, start=1):
         masked = load_masked_series(conn, series_id, arm=quarantine_arm)
         if not masked.bars:
+            _emit_series_progress(
+                progress,
+                phase="evaluation",
+                entry=entry,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=ambiguity_arm,
+                series_seen=series_seen,
+                series_total=total,
+            )
             continue
         series = _to_series(masked.bars)
         indices = [corpus.axis_pos[when] for when in series.dates if when in corpus.axis_pos]
         if len(indices) < 2:
+            _emit_series_progress(
+                progress,
+                phase="evaluation",
+                entry=entry,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=ambiguity_arm,
+                series_seen=series_seen,
+                series_total=total,
+            )
             continue
         evaluated += 1
         first_axis_index, last_axis_index = indices[0], indices[-1]
@@ -1248,6 +1420,15 @@ def evaluate_arm(
             close_sources=close_sources,
             discarded=discarded,
         )
+        _emit_series_progress(
+            progress,
+            phase="evaluation",
+            entry=entry,
+            quarantine_arm=quarantine_arm,
+            ambiguity_arm=ambiguity_arm,
+            series_seen=series_seen,
+            series_total=total,
+        )
 
     measured: dict[ResultNamespace, NamespaceMeasurement] = {}
     for name in namespaces:
@@ -1270,6 +1451,167 @@ def evaluate_arm(
         series_evaluated=evaluated,
         elapsed_s=time.monotonic() - started,
     )
+
+
+def evaluate_level_arms(
+    conn: psycopg.Connection[Any],
+    entry: StrategyEntry,
+    *,
+    corpus: _Corpus,
+    quarantine_arm: QuarantineArm,
+    identity: StrategyIdentity,
+    namespaces: Sequence[ResultNamespace],
+    progress: ProgressCallback | None = None,
+) -> tuple[ArmMeasurement, ...]:
+    """Evaluate both daily-OHLC ambiguity projections from one corpus pass.
+
+    The two arms differ only where one daily bar spans both fixed levels. They
+    therefore share immutable series reads, signal rows, fill ids, causal level
+    construction and the raw resolver outcome. Namespace books, close-source
+    counters and discarded-position counters remain arm-local, so the two
+    measurements cannot influence one another after that common evidence.
+    """
+    started = time.monotonic()
+    regime = _regime_for(entry, corpus.axis)
+    if not regime.level_based:
+        raise ValueError(f"{entry.strategy_id} is not level-based and has no ambiguity arms to share")
+    books: dict[AmbiguityArm, dict[ResultNamespace, _NamespaceBook]] = {
+        ambiguity: {name: _NamespaceBook(records_label_windows=(name == "in_sample")) for name in namespaces}
+        for ambiguity in AMBIGUITY_ARM_ORDER
+    }
+    close_sources: dict[AmbiguityArm, Counter[str]] = {ambiguity: Counter() for ambiguity in AMBIGUITY_ARM_ORDER}
+    discarded: dict[AmbiguityArm, Counter[str]] = {ambiguity: Counter() for ambiguity in AMBIGUITY_ARM_ORDER}
+    closes_by_instrument: dict[int, tuple[int, array[float]]] = {}
+    ranking = (
+        _rank_cross_section(
+            conn,
+            entry,
+            corpus=corpus,
+            quarantine_arm=quarantine_arm,
+            progress=progress,
+        )
+        if entry.strategy_class == "cross_sectional"
+        else None
+    )
+
+    evaluated = 0
+    total = len(corpus.pairs)
+    for series_seen, (instrument_id, series_id) in enumerate(corpus.pairs, start=1):
+        masked = load_masked_series(conn, series_id, arm=quarantine_arm)
+        if not masked.bars:
+            _emit_series_progress(
+                progress,
+                phase="evaluation",
+                entry=entry,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=None,
+                series_seen=series_seen,
+                series_total=total,
+            )
+            continue
+        series = _to_series(masked.bars)
+        indices = [corpus.axis_pos[when] for when in series.dates if when in corpus.axis_pos]
+        if len(indices) < 2:
+            _emit_series_progress(
+                progress,
+                phase="evaluation",
+                entry=entry,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=None,
+                series_seen=series_seen,
+                series_total=total,
+            )
+            continue
+        evaluated += 1
+        first_axis_index, last_axis_index = indices[0], indices[-1]
+        closes = [float("nan")] * (last_axis_index - first_axis_index + 1)
+        for when, row in zip(series.dates, series.rows, strict=True):
+            slot = corpus.axis_pos.get(when)
+            close = row.get("close")
+            if slot is not None and close is not None:
+                closes[slot - first_axis_index] = float(close)
+        # Read-only after construction. Both namespace measurements must mark
+        # against the same observations; no arm mutates this array.
+        closes_by_instrument[instrument_id] = (first_axis_index, array("d", closes))
+
+        signals = _signals_for(
+            entry,
+            series,
+            instrument_id=instrument_id,
+            ranking=ranking,
+            unresolved_breaks=corpus.unresolved_breaks.get(instrument_id, ()),
+        )
+        rows = resolve_fills(signals, series=series, identity=identity, instrument_id=instrument_id)
+        entries, exits = _fills(rows, instrument_id)
+        outcomes = _resolved_level_outcomes_for_arms(
+            entry,
+            entries,
+            series=series,
+            ambiguity_arms=AMBIGUITY_ARM_ORDER,
+            quarantine_arm=quarantine_arm,
+            unresolved_breaks=corpus.unresolved_breaks.get(instrument_id, ()),
+        )
+        for ambiguity in AMBIGUITY_ARM_ORDER:
+            built = build_positions(
+                strategy_id=entry.strategy_id,
+                strategy_version=identity.version,
+                entries=entries,
+                exits=exits,
+                outcomes=outcomes[ambiguity],
+                outcome_pin=_OUTCOME_PIN,
+                series={instrument_id: series},
+                regime=regime,
+                window=corpus.window,
+            )
+            _absorb(
+                list(cost_positions(built.positions)),
+                series=series,
+                window=corpus.window,
+                axis_pos=corpus.axis_pos,
+                closes=closes,
+                first_axis_index=first_axis_index,
+                instrument_id=instrument_id,
+                books=books[ambiguity],
+                close_sources=close_sources[ambiguity],
+                discarded=discarded[ambiguity],
+            )
+        _emit_series_progress(
+            progress,
+            phase="evaluation",
+            entry=entry,
+            quarantine_arm=quarantine_arm,
+            ambiguity_arm=None,
+            series_seen=series_seen,
+            series_total=total,
+        )
+
+    elapsed = time.monotonic() - started
+    measurements: list[ArmMeasurement] = []
+    for ambiguity in AMBIGUITY_ARM_ORDER:
+        measured: dict[ResultNamespace, NamespaceMeasurement] = {}
+        for name in namespaces:
+            outcome = _measure_namespace(
+                name,
+                books[ambiguity][name],
+                corpus=corpus,
+                closes_by_instrument=closes_by_instrument,
+            )
+            if outcome is not None:
+                measured[name] = outcome
+        measurements.append(
+            ArmMeasurement(
+                strategy_id=entry.strategy_id,
+                strategy_version=identity.version,
+                ambiguity_arm=ambiguity,
+                quarantine_arm=quarantine_arm,
+                namespaces=measured,
+                holdout_positions_discarded=discarded[ambiguity].get("hold_out", 0),
+                close_sources=dict(close_sources[ambiguity]),
+                series_evaluated=evaluated,
+                elapsed_s=elapsed,
+            )
+        )
+    return tuple(measurements)
 
 
 @dataclass(frozen=True)
@@ -1342,6 +1684,7 @@ def _rank_cross_section(
     *,
     corpus: _Corpus,
     quarantine_arm: QuarantineArm,
+    progress: ProgressCallback | None = None,
 ) -> _CrossSection:
     """Sub-pass A: stage every member and rank each decision date's cross-section.
 
@@ -1361,12 +1704,31 @@ def _rank_cross_section(
         raise RuntimeError(f"{entry.strategy_id} is cross_sectional but returned no decision calendar")
 
     scores: dict[date, dict[int, float]] = {}
-    for instrument_id, series_id in corpus.pairs:
+    total = len(corpus.pairs)
+    for series_seen, (instrument_id, series_id) in enumerate(corpus.pairs, start=1):
         masked = load_masked_series(conn, series_id, arm=quarantine_arm)
         if not masked.bars:
+            _emit_series_progress(
+                progress,
+                phase="ranking",
+                entry=entry,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=None,
+                series_seen=series_seen,
+                series_total=total,
+            )
             continue
         series = _to_series(masked.bars)
         if len(series) < 2:
+            _emit_series_progress(
+                progress,
+                phase="ranking",
+                entry=entry,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=None,
+                series_seen=series_seen,
+                series_total=total,
+            )
             continue
         staged = segmented_member(
             entry,
@@ -1378,6 +1740,15 @@ def _rank_cross_section(
         )
         for when, value in staged.scores.items():
             scores.setdefault(when, {})[instrument_id] = value
+        _emit_series_progress(
+            progress,
+            phase="ranking",
+            entry=entry,
+            quarantine_arm=quarantine_arm,
+            ambiguity_arm=None,
+            series_seen=series_seen,
+            series_total=total,
+        )
 
     winners: dict[date, frozenset[int]] = {}
     thin: set[date] = set()
@@ -1679,6 +2050,7 @@ def _expected_refusals(
     *,
     holdout_requested: bool,
     deflated: bool,
+    purpose: StrategyPurpose = "capital_candidate",
     ambiguity_material: bool | None = False,
     prior_holdout_evaluations: int = 0,
 ) -> frozenset[PromotionRefusal]:
@@ -1699,6 +2071,8 @@ def _expected_refusals(
     buy-and-hold run rejected here after a full corpus pass.
     """
     expected = set(STANDING_REFUSALS)
+    if purpose == "harness_validation":
+        expected.add("harness_validation_only")
     if not holdout_requested and prior_holdout_evaluations <= 0:
         expected.add("holdout_never_evaluated")
     if not deflated:
@@ -1754,6 +2128,7 @@ def run_backtest(
     limit: int | None = None,
     evaluation_window: Window | None = None,
     manifest: Mapping[str, StrategyEntry] = STRATEGY_MANIFEST,
+    progress: ProgressCallback | None = None,
 ) -> BacktestRunReport:
     """Evaluate every runnable strategy and persist criterion 9's arm pairs.
 
@@ -1793,7 +2168,16 @@ def run_backtest(
     if not runnable:
         raise RuntimeError("no manifest strategy is runnable — every entry is blocked, so there is nothing to store")
 
+    _emit_progress(progress, BacktestProgressEvent(phase="corpus"))
     corpus = load_corpus(conn, limit=limit, evaluation_window=evaluation_window)
+    _emit_progress(
+        progress,
+        BacktestProgressEvent(
+            phase="corpus",
+            series_seen=len(corpus.pairs),
+            series_total=len(corpus.pairs),
+        ),
+    )
     identities = {
         entry_id: manifest[entry_id].identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
         for entry_id in runnable
@@ -1840,24 +2224,37 @@ def run_backtest(
     arms: list[ArmMeasurement] = []
     for entry_id in runnable:
         regime = _regime_for(manifest[entry_id], corpus.axis)
-        ambiguity_arms: tuple[AmbiguityArm | None, ...] = AMBIGUITY_ARM_ORDER if regime.level_based else (None,)
         for quarantine in QUARANTINE_ARM_ORDER:
-            for ambiguity in ambiguity_arms:
-                measurement = evaluate_arm(
+            if regime.level_based:
+                measurements = evaluate_level_arms(
                     conn,
                     manifest[entry_id],
                     corpus=corpus,
                     quarantine_arm=quarantine,
-                    ambiguity_arm=ambiguity,
                     identity=identities[entry_id],
                     namespaces=namespaces,
+                    progress=progress,
                 )
+            else:
+                measurements = (
+                    evaluate_arm(
+                        conn,
+                        manifest[entry_id],
+                        corpus=corpus,
+                        quarantine_arm=quarantine,
+                        ambiguity_arm=None,
+                        identity=identities[entry_id],
+                        namespaces=namespaces,
+                        progress=progress,
+                    ),
+                )
+            for measurement in measurements:
                 _assert_ambiguity_contract(measurement)
                 arms.append(measurement)
                 logger.info(
                     "strategy_backtest_run: %s/%s/%s evaluated %d series in %.1fs — %s, hold-out discarded %d",
                     entry_id,
-                    ambiguity or "shared",
+                    measurement.ambiguity_arm or "shared",
                     quarantine,
                     measurement.series_evaluated,
                     measurement.elapsed_s,
@@ -1866,6 +2263,7 @@ def run_backtest(
                 )
 
     # 2. Deflate once per (namespace, quarantine arm) group.
+    _emit_progress(progress, BacktestProgressEvent(phase="deflation"))
     by_group: dict[tuple[ResultNamespace, AmbiguityArm, QuarantineArm], dict[str, NamespaceMeasurement]] = {}
     for ambiguity in AMBIGUITY_ARM_ORDER:
         for measurement in arms:
@@ -1891,6 +2289,7 @@ def run_backtest(
             )
 
     # 3. Write, one transaction per arm pair.
+    _emit_progress(progress, BacktestProgressEvent(phase="write"))
     validated = frozenset(corpus.universe)
     written = _write_rows(
         conn,
@@ -2146,6 +2545,7 @@ def _write_rows(
         expected = _expected_refusals(
             holdout_requested=holdout_requested,
             deflated=result.deflated is not None,
+            purpose=result.purpose,
             ambiguity_material=ambiguity_material,
             prior_holdout_evaluations=evaluations,
         )
@@ -2329,6 +2729,7 @@ def _preflight_gate(
             expected = _expected_refusals(
                 holdout_requested=holdout_requested,
                 deflated=result.deflated is not None,
+                purpose=result.purpose,
                 ambiguity_material=ambiguity_material,
                 prior_holdout_evaluations=prior_holdout.get(
                     (result.identity.strategy_id, result.identity.strategy_version), 0

--- a/app/services/outcome_resolver.py
+++ b/app/services/outcome_resolver.py
@@ -67,13 +67,15 @@ OutcomeClass = Literal["tp_hit", "sl_hit", "expired", "ambiguous", "unresolved"]
 #: ⚠ CLOSED vocabulary, for criterion 9's "measure what you reject": free text
 #: cannot be counted. ``series_break`` and ``quarantined_bar`` are criterion 8's
 #: own names and are pinned against ``strategy_registry`` by test.
-#: ``window_truncated`` and ``missing_bar_data`` are OURS and are flagged as
-#: additions rather than smuggled in — see the spec's §3.4.
+#: ``window_truncated``, ``missing_bar_data`` and ``unorderable_exit_levels``
+#: are OURS and are flagged as additions rather than smuggled in — see the
+#: spec's §3.4.
 UnresolvedReason = Literal[
     "window_truncated",
     "series_break",
     "quarantined_bar",
     "missing_bar_data",
+    "unorderable_exit_levels",
 ]
 
 #: ⚠ One member in v1, and it is not decoration. S5 (#2245) established that a
@@ -92,7 +94,7 @@ RESOLUTION_METHODS: frozenset[str] = frozenset(get_args(ResolutionMethod))
 #: Ours, kept as an explicit subtraction so adopting a parent code later cannot
 #: silently land on our side of the line. Same construction as
 #: ``strategy_registry.OUR_ADDITIONAL_REASON_CODES``.
-OUR_ADDITIONAL_REASONS: frozenset[str] = frozenset({"window_truncated", "missing_bar_data"})
+OUR_ADDITIONAL_REASONS: frozenset[str] = frozenset({"window_truncated", "missing_bar_data", "unorderable_exit_levels"})
 INHERITED_REASONS: frozenset[str] = UNRESOLVED_REASONS - OUR_ADDITIONAL_REASONS
 
 #: Outcomes that book a trade. The other two — ``ambiguous`` and ``unresolved``

--- a/app/services/strategy_exit_levels_batch.py
+++ b/app/services/strategy_exit_levels_batch.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from decimal import Decimal
+from math import isfinite
 
 from app.services.indicator_series import BarSeries, Universe, atr_series
 from app.services.outcome_resolver import ExitLevels, UnresolvedReason
@@ -46,6 +47,9 @@ def s4_exit_levels_batch(
         value = atr.values[signal_index]
         if value is None or value <= 0:
             raise ValueError(f"ATR{ATR_PERIOD} is unavailable or non-positive at signal index {signal_index}")
+        if not isfinite(value):
+            levels.append("unorderable_exit_levels")
+            continue
         distance = Decimal(str(value))
         stop = entry_price - Decimal(str(ATR_STOP_MULTIPLE)) * distance
         target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE)) * distance

--- a/app/services/strategy_exit_levels_batch.py
+++ b/app/services/strategy_exit_levels_batch.py
@@ -1,0 +1,59 @@
+"""Result-equivalent batch adapters for strategy-owned exit-level factories.
+
+This module is deliberately outside ``app.services.strategies``. Strategy
+modules hash their own source into ``StrategyIdentity``; a runner-only
+optimisation must not mint a new strategy version. The scalar factory remains
+the semantic owner and oracle, while this adapter shares only its immutable
+indicator calculation across requests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+from app.services.indicator_series import BarSeries, Universe, atr_series
+from app.services.outcome_resolver import ExitLevels, UnresolvedReason
+from app.services.strategies.s4_volatility_compression_breakout import (
+    ATR_PERIOD,
+    ATR_STOP_MULTIPLE,
+    ATR_TARGET_MULTIPLE,
+    MAX_HOLD_BARS,
+)
+
+
+def s4_exit_levels_batch(
+    series: BarSeries,
+    *,
+    requests: Sequence[tuple[int, Decimal]],
+    universe: Universe,
+) -> tuple[ExitLevels | UnresolvedReason, ...]:
+    """Build S-4 brackets for several fills from one Wilder ATR pass.
+
+    Each request keeps its scalar semantics: ATR is read at the causal signal
+    index and the bracket is centred on that request's next-open entry price.
+    Output is positional so duplicate requests remain distinct.
+    """
+    atr = atr_series(series, period=ATR_PERIOD, universe=universe)
+    levels: list[ExitLevels | UnresolvedReason] = []
+    for signal_index, entry_price in requests:
+        if not 0 <= signal_index < len(series):
+            raise ValueError(f"signal_index {signal_index} is outside the {len(series)}-bar series")
+        if not entry_price.is_finite():
+            raise ValueError(f"entry_price must be finite, got {entry_price}")
+        if entry_price <= 0:
+            raise ValueError(f"entry_price must be positive, got {entry_price}")
+        value = atr.values[signal_index]
+        if value is None or value <= 0:
+            raise ValueError(f"ATR{ATR_PERIOD} is unavailable or non-positive at signal index {signal_index}")
+        distance = Decimal(str(value))
+        stop = entry_price - Decimal(str(ATR_STOP_MULTIPLE)) * distance
+        target = entry_price + Decimal(str(ATR_TARGET_MULTIPLE)) * distance
+        if not target.is_finite() or not stop.is_finite() or stop <= 0 or stop >= entry_price or target <= entry_price:
+            levels.append("unorderable_exit_levels")
+            continue
+        levels.append(ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=MAX_HOLD_BARS))
+    return tuple(levels)
+
+
+__all__ = ["s4_exit_levels_batch"]

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -66,15 +66,15 @@ into per-strategy ``if`` branches — the same defect in a new location.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Set
+from collections.abc import Iterable, Mapping, Sequence, Set
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from types import MappingProxyType
 from typing import Literal, Protocol, get_args
 
 from app.services.indicator_series import BarSeries, Universe
-from app.services.outcome_resolver import ExitLevels
+from app.services.outcome_resolver import ExitLevels, UnresolvedReason
 from app.services.position_builder import ExitRegime
 from app.services.strategies.s1_time_series_momentum import S1_STRATEGY_ID, s1_identity, s1_signals
 from app.services.strategies.s2_cross_sectional_momentum import (
@@ -94,6 +94,7 @@ from app.services.strategies.s4_volatility_compression_breakout import (
     s4_identity,
     s4_signals,
 )
+from app.services.strategy_exit_levels_batch import s4_exit_levels_batch
 from app.services.strategy_registry import (
     SIGNAL_KINDS,
     CrossSectionalMember,
@@ -197,7 +198,19 @@ class ExitLevelsFactory(Protocol):
         signal_index: int,
         entry_price: Decimal,
         universe: Universe,
-    ) -> ExitLevels: ...
+    ) -> ExitLevels | UnresolvedReason: ...
+
+
+class ExitLevelsBatchFactory(Protocol):
+    """A level strategy's brackets for several fills in one immutable series."""
+
+    def __call__(
+        self,
+        series: BarSeries,
+        *,
+        requests: Sequence[tuple[int, Decimal]],
+        universe: Universe,
+    ) -> Sequence[ExitLevels | UnresolvedReason]: ...
 
 
 @dataclass(frozen=True)
@@ -230,6 +243,9 @@ class StrategyEntry:
     #: Level-based only. Its absence is a named runner exclusion rather than a
     #: silent max-hold fallback.
     exit_levels: ExitLevelsFactory | None = None
+    #: Optional result-equivalent batch form. It may share immutable indicator
+    #: work, never entry-specific prices or signal indices.
+    exit_levels_batch: ExitLevelsBatchFactory | None = None
 
     def __post_init__(self) -> None:
         if not self.strategy_id.strip():
@@ -272,6 +288,10 @@ class StrategyEntry:
                 )
         if self.min_participants is not None and self.min_participants < 1:
             raise ValueError(f"min_participants must be at least 1, got {self.min_participants}")
+        if self.exit_levels_batch is not None and self.exit_levels is None:
+            raise ValueError(
+                f"{self.strategy_id} declares batch exit levels without the scalar factory used as its oracle"
+            )
 
 
 def _no_decision_calendar(calendar: Iterable[date]) -> frozenset[date] | None:
@@ -372,14 +392,30 @@ def _s4_exit_levels(
     signal_index: int,
     entry_price: Decimal,
     universe: Universe,
-) -> ExitLevels:
+) -> ExitLevels | UnresolvedReason:
     """Adapt S-4's hashed strategy values to the versioned outcome contract."""
-    target, stop, max_hold = s4_exit_bracket(
-        series,
-        signal_index=signal_index,
-        entry_price=entry_price,
-        universe=universe,
-    )
+    if not entry_price.is_finite():
+        raise ValueError(f"entry_price must be finite, got {entry_price}")
+    try:
+        target, stop, max_hold = s4_exit_bracket(
+            series,
+            signal_index=signal_index,
+            entry_price=entry_price,
+            universe=universe,
+        )
+    except InvalidOperation:
+        # A non-finite causal ATR cannot yield a broker-orderable bracket. The
+        # entry itself was validated above, so this is not hiding a bad fill.
+        return "unorderable_exit_levels"
+    except ValueError as exc:
+        # The hashed scalar factory deliberately refuses a non-positive stop.
+        # That is a data-dependent, countable no-order outcome. Invalid indices,
+        # prices and missing ATR remain programmer/data invariants and fatal.
+        if "not broker-orderable" not in str(exc):
+            raise
+        return "unorderable_exit_levels"
+    if not target.is_finite() or not stop.is_finite() or stop >= entry_price or target <= entry_price:
+        return "unorderable_exit_levels"
     return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
 
 
@@ -436,6 +472,7 @@ STRATEGY_MANIFEST: Mapping[str, StrategyEntry] = MappingProxyType(
             decision_calendar=_no_decision_calendar,
             signals=_s4_signals,
             exit_levels=_s4_exit_levels,
+            exit_levels_batch=s4_exit_levels_batch,
         ),
     }
 )
@@ -446,6 +483,7 @@ __all__ = [
     "STRATEGY_MANIFEST",
     "DecisionCalendar",
     "ExitRegimeFactory",
+    "ExitLevelsBatchFactory",
     "ExitLevelsFactory",
     "IdentityFactory",
     "MemberStager",

--- a/app/services/strategy_manifest.py
+++ b/app/services/strategy_manifest.py
@@ -69,7 +69,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence, Set
 from dataclasses import dataclass
 from datetime import date
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal
 from types import MappingProxyType
 from typing import Literal, Protocol, get_args
 
@@ -393,30 +393,31 @@ def _s4_exit_levels(
     entry_price: Decimal,
     universe: Universe,
 ) -> ExitLevels | UnresolvedReason:
-    """Adapt S-4's hashed strategy values to the versioned outcome contract."""
-    if not entry_price.is_finite():
-        raise ValueError(f"entry_price must be finite, got {entry_price}")
-    try:
-        target, stop, max_hold = s4_exit_bracket(
-            series,
-            signal_index=signal_index,
-            entry_price=entry_price,
-            universe=universe,
-        )
-    except InvalidOperation:
-        # A non-finite causal ATR cannot yield a broker-orderable bracket. The
-        # entry itself was validated above, so this is not hiding a bad fill.
-        return "unorderable_exit_levels"
-    except ValueError as exc:
-        # The hashed scalar factory deliberately refuses a non-positive stop.
-        # That is a data-dependent, countable no-order outcome. Invalid indices,
-        # prices and missing ATR remain programmer/data invariants and fatal.
-        if "not broker-orderable" not in str(exc):
-            raise
-        return "unorderable_exit_levels"
-    if not target.is_finite() or not stop.is_finite() or stop >= entry_price or target <= entry_price:
-        return "unorderable_exit_levels"
-    return ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+    """Adapt S-4's hashed scalar oracle to the outcome reason contract.
+
+    The batch adapter owns the typed refusal because changing the hashed S-4
+    module merely to add an exception class would mint a new strategy version.
+    For an orderable bracket the original scalar factory is still called and
+    compared exactly, so the optimisation cannot silently become the formula.
+    """
+    (batched,) = s4_exit_levels_batch(
+        series,
+        requests=((signal_index, entry_price),),
+        universe=universe,
+    )
+    if batched == "unorderable_exit_levels":
+        return batched
+
+    target, stop, max_hold = s4_exit_bracket(
+        series,
+        signal_index=signal_index,
+        entry_price=entry_price,
+        universe=universe,
+    )
+    scalar = ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+    if scalar != batched:
+        raise RuntimeError("S-4 scalar and batch exit-level factories disagree")
+    return scalar
 
 
 #: Every strategy in the catalogue, keyed by ``strategy_id``.

--- a/app/services/strategy_outcome_resolution.py
+++ b/app/services/strategy_outcome_resolution.py
@@ -142,6 +142,17 @@ def _resolve_fill(
         entry_price=fill.fill_price,
         universe=fill.universe,
     )
+    if isinstance(levels, str):
+        return OutcomeRow.from_outcome(
+            fill.signal_id,
+            Outcome(
+                outcome="unresolved",
+                resolution_method="daily_bar",
+                rule_set_version=OUTCOME_RULE_SET_VERSION,
+                reason=levels,
+            ),
+            input_rule_set_version=QUARANTINE_RULE_SET_VERSION,
+        )
     outcome = resolve_outcome(
         series=series,
         fill_index=fill_index,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import time
 from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
@@ -5018,6 +5019,164 @@ def strategy_paper_cycle() -> None:
         )
 
 
+_BACKTEST_PROGRESS_FLUSH_SECONDS: Final = 5.0
+
+
+class _BacktestProgressWriter:
+    """Best-effort transient telemetry on a connection outside evidence work."""
+
+    def __init__(
+        self,
+        conn: psycopg.Connection[Any],
+        *,
+        run_id: int,
+        total_windows: int,
+        already_complete: int,
+    ) -> None:
+        self._conn: psycopg.Connection[Any] | None = conn
+        self._run_id = run_id
+        self._total_windows = total_windows
+        self._already_complete = already_complete
+        self._completed = 0
+        self._window_id: str | None = None
+        self._last_flush = 0.0
+        self._last_stage: tuple[object, ...] | None = None
+
+    def start_window(self, window_id: str) -> None:
+        self._window_id = window_id
+        self._last_stage = None
+
+    def __call__(self, event: object) -> None:
+        from app.services.backtest_run import BacktestProgressEvent
+
+        if not isinstance(event, BacktestProgressEvent) or self._conn is None:
+            return
+        stage = (
+            event.phase,
+            event.strategy_id,
+            event.quarantine_arm,
+            event.ambiguity_arm,
+        )
+        now = time.monotonic()
+        stage_changed = stage != self._last_stage
+        final_tick = event.series_total is not None and event.series_seen == event.series_total
+        if not stage_changed and not final_tick and now - self._last_flush < _BACKTEST_PROGRESS_FLUSH_SECONDS:
+            return
+        payload = self._payload(
+            active={
+                "window_id": self._window_id,
+                "phase": event.phase,
+                "strategy_id": event.strategy_id,
+                "quarantine_arm": event.quarantine_arm,
+                "ambiguity_arm": event.ambiguity_arm,
+                "series_seen": event.series_seen,
+                "series_total": event.series_total,
+            }
+        )
+        try:
+            self._conn.execute(
+                """
+                UPDATE job_runs
+                   SET progress_json = %(progress)s,
+                       processed_count = %(processed)s,
+                       target_count = %(target)s,
+                       last_progress_at = now()
+                 WHERE run_id = %(run_id)s AND status = 'running'
+                """,
+                {
+                    "progress": Jsonb(payload),
+                    "processed": event.series_seen,
+                    "target": event.series_total,
+                    "run_id": self._run_id,
+                },
+            )
+        except Exception:
+            # Telemetry happens after the job row exists and is never evidence.
+            # Disabling it cannot turn committed or in-flight evidence into a
+            # failure, and avoids repeated pool/lock pressure after one fault.
+            logger.warning("strategy evidence progress telemetry disabled after write failure", exc_info=True)
+            self.close()
+            return
+        self._last_flush = now
+        self._last_stage = stage
+
+    def record_window_commit(self, *, rows_written: int, completed: int) -> bool:
+        """Publish only a checkpoint the evidence connection already committed."""
+        if self._conn is None:
+            return False
+        self._completed = completed
+        try:
+            self._conn.execute(
+                """
+                UPDATE job_runs
+                   SET row_count = %(rows)s,
+                       progress_json = %(progress)s,
+                       processed_count = 0,
+                       target_count = NULL,
+                       last_progress_at = now()
+                 WHERE run_id = %(run_id)s AND status = 'running'
+                """,
+                {
+                    "rows": rows_written,
+                    "progress": Jsonb(self._payload(active=None)),
+                    "run_id": self._run_id,
+                },
+            )
+        except Exception:
+            logger.warning("strategy evidence checkpoint telemetry disabled after write failure", exc_info=True)
+            self.close()
+            return False
+        return True
+
+    def _payload(self, *, active: Mapping[str, object] | None) -> dict[str, object]:
+        return {
+            "candidates_seen": self._total_windows,
+            "outcomes": {
+                "already_complete": self._already_complete,
+                "completed": self._completed,
+            },
+            "errors": {},
+            "active": None if active is None else dict(active),
+        }
+
+    def close(self) -> None:
+        conn, self._conn = self._conn, None
+        if conn is None:
+            return
+        try:
+            conn.close()
+        except Exception:
+            logger.warning("failed to close strategy evidence progress connection", exc_info=True)
+
+
+def _open_backtest_progress_writer(
+    *,
+    run_id: int,
+    total_windows: int,
+    already_complete: int,
+) -> _BacktestProgressWriter | None:
+    if run_id <= 0:
+        return None
+    try:
+        # One short-lived connection for the refresh, not one connection per
+        # heartbeat. Tight SQL/lock bounds make telemetry unable to queue behind
+        # the evidence writer or amplify a saturated connection pool.
+        conn = connect_job(
+            autocommit=True,
+            connect_timeout=3,
+            options="-c statement_timeout=2000 -c lock_timeout=500",
+        )
+    except Exception:
+        logger.warning("strategy evidence progress telemetry unavailable", exc_info=True)
+        return None
+    return _BacktestProgressWriter(
+        conn,
+        run_id=run_id,
+        total_windows=total_windows,
+        already_complete=already_complete,
+    )
+
+
 def strategy_backtest_run(params: Mapping[str, Any]) -> None:
     """Persist criterion 9's arm pairs for every runnable strategy (#2394 §3.2).
 
@@ -5078,46 +5237,65 @@ def strategy_backtest_run(params: Mapping[str, Any]) -> None:
                     )
                 rows_written = 0
                 newly_completed = 0
-                for window_id, item in RECENT_EVIDENCE_WINDOWS.items():
-                    if window_id in complete:
-                        continue
-                    report = run_backtest(
-                        conn,
-                        holdout_purpose=_optional_str(params.get("holdout_purpose")),
-                        holdout_accessed_by=_optional_str(params.get("holdout_accessed_by")),
-                        trial_register_version=_optional_str(params.get("trial_register_version")),
-                        evaluation_window=item.window,
-                    )
-                    # A window is the restart boundary. The ledger identities
-                    # are immutable, so keeping earlier windows uncommitted
-                    # would make an hours-long refresh start from zero.
-                    conn.commit()
-                    rows_written += report.rows_written
-                    newly_completed += 1
-                    tracker.row_count = rows_written
-                    tracker.progress = JobProgress(
-                        candidates_seen=len(RECENT_EVIDENCE_WINDOWS),
-                        outcomes={
-                            "already_complete": len(complete),
-                            "completed": newly_completed,
-                        },
-                    )
-                    if tracker.run_id:
-                        conn.execute(
-                            """
-                            UPDATE job_runs
-                            SET row_count = %(rows)s,
-                                progress_json = %(progress)s,
-                                last_progress_at = now()
-                            WHERE run_id = %(run_id)s AND status = 'running'
-                            """,
-                            {
-                                "rows": rows_written,
-                                "progress": Jsonb(tracker.progress.as_json()),
-                                "run_id": tracker.run_id,
+                progress_writer = _open_backtest_progress_writer(
+                    run_id=tracker.run_id,
+                    total_windows=len(RECENT_EVIDENCE_WINDOWS),
+                    already_complete=len(complete),
+                )
+                try:
+                    for window_id, item in RECENT_EVIDENCE_WINDOWS.items():
+                        if window_id in complete:
+                            continue
+                        if progress_writer is not None:
+                            progress_writer.start_window(window_id)
+                        report = run_backtest(
+                            conn,
+                            holdout_purpose=_optional_str(params.get("holdout_purpose")),
+                            holdout_accessed_by=_optional_str(params.get("holdout_accessed_by")),
+                            trial_register_version=_optional_str(params.get("trial_register_version")),
+                            evaluation_window=item.window,
+                            progress=progress_writer,
+                        )
+                        # A window is the restart boundary. The ledger identities
+                        # are immutable, so keeping earlier windows uncommitted
+                        # would make an hours-long refresh start from zero.
+                        conn.commit()
+                        rows_written += report.rows_written
+                        newly_completed += 1
+                        tracker.row_count = rows_written
+                        tracker.progress = JobProgress(
+                            candidates_seen=len(RECENT_EVIDENCE_WINDOWS),
+                            outcomes={
+                                "already_complete": len(complete),
+                                "completed": newly_completed,
                             },
                         )
-                        conn.commit()
+                        checkpoint_recorded = progress_writer is not None and progress_writer.record_window_commit(
+                            rows_written=rows_written,
+                            completed=newly_completed,
+                        )
+                        if tracker.run_id and not checkpoint_recorded:
+                            # Fallback after telemetry connection failure. This
+                            # runs only after the evidence commit and therefore
+                            # cannot expose a partial immutable window.
+                            conn.execute(
+                                """
+                                UPDATE job_runs
+                                SET row_count = %(rows)s,
+                                    progress_json = %(progress)s,
+                                    last_progress_at = now()
+                                WHERE run_id = %(run_id)s AND status = 'running'
+                                """,
+                                {
+                                    "rows": rows_written,
+                                    "progress": Jsonb(tracker.progress.as_json()),
+                                    "run_id": tracker.run_id,
+                                },
+                            )
+                            conn.commit()
+                finally:
+                    if progress_writer is not None:
+                        progress_writer.close()
                 tracker.row_count = rows_written
                 tracker.progress = JobProgress(
                     candidates_seen=len(RECENT_EVIDENCE_WINDOWS),

--- a/docs/proposals/ta/2026-08-06-outcome-resolver.md
+++ b/docs/proposals/ta/2026-08-06-outcome-resolver.md
@@ -135,7 +135,8 @@ corpus ends first, see §3.4.
 ### 3.4 `unresolved` — OUR addition, flagged as one
 
 The parent's outcome vocabulary is four classes. None of them describes "we
-entered and the evidence runs out", and there are four ways that happens:
+entered but no defensible exit can be booked"; five terminal reasons make that
+refusal countable:
 
 | reason | when | whose |
 | --- | --- | --- |
@@ -143,6 +144,7 @@ entered and the evidence runs out", and there are four ways that happens:
 | `series_break` | the window would cross out of the fill bar's segment | criterion 10 |
 | `quarantined_bar` | the caller has declared a bar in the window unusable | criterion 8 |
 | `missing_bar_data` | a field we must read is `NULL` and the caller declared no reason | ours |
+| `unorderable_exit_levels` | the strategy's causal formula cannot produce a finite positive broker-orderable bracket | ours |
 
 ⚠ `expired` must NOT absorb `window_truncated`. A trade whose corpus ends on
 bar 10 of a 20-bar window is not a trade that reached expiry — recording it as
@@ -166,6 +168,12 @@ that the quarantine rules never looked at is a data gap, and calling it a
 quarantine verdict would collapse the two. ⚠ Phase 3c widened `no_fill_bar` to
 cover a NULL open and flagged the widening; **this spec does not repeat that
 compromise**, because here the case is not measured-zero.
+
+`unorderable_exit_levels` is also ours. It is terminal for that filled signal:
+no exit price or return is invented, the refusal is counted, and the remaining
+batch continues. In particular, an S-4 stop at or below zero is never clamped
+to a broker minimum. The same versioned vocabulary applies to the historical
+runner and the forward resolver.
 
 **`unresolved` is excluded from the win rate exactly as `ambiguous` is, and
 both counts are reported per criterion 9.** An outcome class that is excluded

--- a/docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md
+++ b/docs/proposals/ta/2026-08-08-strategy-runner-and-manifest.md
@@ -212,9 +212,10 @@ Each of these was a Codex ckpt-1 finding and each needs settling before code:
   `outcome_ledger.select_pending_fills()`, not "prior open signals" as first written.
 - **`strategy_outcomes` keys on `(rule_set_version, input_rule_set_version)`** — the daily
   scan must declare both, and the first draft named neither.
-- **Immature windows need a policy.** A signal whose max-hold has not elapsed is not an
-  outcome; `window_truncated` / `missing_bar_data` / `quarantined_bar` / `series_break` all
-  have to resolve to something explicit rather than being skipped.
+- **Immature or unorderable outcomes need a policy.** A signal whose max-hold has not elapsed
+  is not an outcome; `window_truncated` / `missing_bar_data` / `quarantined_bar` /
+  `series_break` / `unorderable_exit_levels` all have to resolve to something explicit rather
+  than being skipped.
 - **S-4 needs exit levels fixed at signal time** — a manifest of `(identity, signals)` alone
   cannot express that, which is part of why §2's operational contract exists.
 

--- a/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
+++ b/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
@@ -46,6 +46,39 @@ Only compact aggregate results and hold-out access records are retained.
 Indicators, positions and returns are recomputed from the existing research
 bars while the job runs; no additional per-bar metric store is introduced.
 
+### Bounded refresh checkpoints
+
+A running refresh exposes its active pinned window, phase, strategy, quarantine
+arm and series count through transient `job_runs` progress. That heartbeat is
+not evidence: before the result transaction commits it may not advance
+`row_count`, the completed-window count or any result identity. One completed
+window remains the smallest restart/cancellation boundary.
+
+Transient progress uses one bounded, autocommit connection for the refresh,
+separate from the evidence transaction. It is throttled and fail-soft; losing
+telemetry removes operator visibility but cannot abort, commit or reclassify the
+backtest. A post-commit checkpoint may advance the completed count only after
+the immutable arm-pair writers have completed and the evidence connection's
+commit has returned.
+
+The runner may share immutable calculations only where exact arm equivalence is
+proved. In particular, S-4's two daily-OHLC ambiguity arms share series reads,
+signals, fill identifiers, causal ATR brackets and the raw resolver verdict;
+only genuinely ambiguous rows are projected to best/worst exits. Namespace
+books and all mutable counters remain arm-local. S-4's strategy module and
+identity are unchanged: the batch adapter lives outside the hashed strategy
+source and is tested against the scalar factory. Full history, corpus
+membership, dates, parameters, costs, trial membership and result/write order
+are not performance controls.
+
+An S-4 bracket is broker-orderable only when both finite levels are positive,
+the stop is below entry and take profit is above entry. A signal whose causal
+ATR produces any other bracket is recorded as the terminal
+`unorderable_exit_levels` refusal in both ambiguity arms. The runner must not
+clamp or otherwise invent a level, and one refused signal must not abort the
+remaining strategy, window or evidence refresh. The same refusal vocabulary
+and rule-set version apply to historical and forward outcome resolution.
+
 ## What qualifies a strategy
 
 Win rate is descriptive, not a promotion target. A 75% win rate can be created

--- a/scripts/benchmark_2488_evidence_refresh.py
+++ b/scripts/benchmark_2488_evidence_refresh.py
@@ -1,0 +1,196 @@
+"""Reproduce #2488's S-4 equivalence and full-window timing evidence.
+
+Read-only in ``compare-s4`` mode. ``full-run`` lets the production writer
+execute inside one outer transaction, hashes every resulting store field, then
+rolls the transaction back and verifies that the physical result count is
+unchanged. PostgreSQL sequences are non-transactional, so the latter can leave
+harmless identifier gaps even though it retains no evidence rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import json
+import resource
+import time
+from array import array
+from dataclasses import replace
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+from app.config import settings
+from app.services.backtest_run import (
+    AMBIGUITY_ARM_ORDER,
+    BACKTEST_UNIVERSE,
+    evaluate_arm,
+    evaluate_level_arms,
+    load_corpus,
+    run_backtest,
+)
+from app.services.cost_model import COST_MODEL_ID
+from app.services.research_price_structure_store import QuarantineArm
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_recent_evidence import recent_evidence_window
+
+_S4 = "s4-volatility-compression-breakout"
+
+
+def _jsonable(value: object) -> object:
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {field.name: _jsonable(getattr(value, field.name)) for field in dataclasses.fields(value)}
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, array):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        return sorted(_jsonable(item) for item in value)  # type: ignore[type-var]
+    if isinstance(value, Decimal):
+        return str(value)
+    if hasattr(value, "isoformat"):
+        return value.isoformat()  # type: ignore[union-attr]
+    return value
+
+
+def _digest(value: object) -> str:
+    payload = json.dumps(_jsonable(value), sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _resources(started_wall: float, started_cpu: float) -> dict[str, object]:
+    return {
+        "wall_seconds": time.monotonic() - started_wall,
+        "cpu_seconds": time.process_time() - started_cpu,
+        "peak_rss_bytes": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
+    }
+
+
+def compare_s4(*, window_id: str, quarantine_arm: QuarantineArm, limit: int | None) -> dict[str, object]:
+    window = recent_evidence_window(window_id).window
+    entry = STRATEGY_MANIFEST[_S4]
+    scalar_entry = replace(entry, exit_levels_batch=None)
+    identity = entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+    with psycopg.connect(settings.database_url) as conn:
+        corpus = load_corpus(conn, limit=limit, evaluation_window=window)
+        reference_started_wall = time.monotonic()
+        reference_started_cpu = time.process_time()
+        reference = tuple(
+            evaluate_arm(
+                conn,
+                scalar_entry,
+                corpus=corpus,
+                quarantine_arm=quarantine_arm,
+                ambiguity_arm=ambiguity,
+                identity=identity,
+                namespaces=("hold_out",),
+            )
+            for ambiguity in AMBIGUITY_ARM_ORDER
+        )
+        reference_resources = _resources(reference_started_wall, reference_started_cpu)
+
+        optimized_started_wall = time.monotonic()
+        optimized_started_cpu = time.process_time()
+        optimized = evaluate_level_arms(
+            conn,
+            entry,
+            corpus=corpus,
+            quarantine_arm=quarantine_arm,
+            identity=identity,
+            namespaces=("hold_out",),
+        )
+        optimized_resources = _resources(optimized_started_wall, optimized_started_cpu)
+
+    reference_exact = tuple(replace(item, elapsed_s=0.0) for item in reference)
+    optimized_exact = tuple(replace(item, elapsed_s=0.0) for item in optimized)
+    return {
+        "mode": "compare-s4",
+        "window_id": window_id,
+        "quarantine_arm": quarantine_arm,
+        "series": len(corpus.pairs),
+        "limit": limit,
+        "reference": {**reference_resources, "measurement_sha256": _digest(reference_exact)},
+        "optimized": {**optimized_resources, "measurement_sha256": _digest(optimized_exact)},
+        "exact_equal_excluding_elapsed": reference_exact == optimized_exact,
+    }
+
+
+def full_run(*, window_id: str) -> dict[str, object]:
+    window = recent_evidence_window(window_id).window
+    started_wall = time.monotonic()
+    started_cpu = time.process_time()
+    with psycopg.connect(settings.database_url) as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            before_row = cursor.execute("SELECT count(*) AS count FROM strategy_results_store").fetchone()
+        if before_row is None:  # pragma: no cover - aggregate always returns one row
+            raise RuntimeError("strategy result count query returned no row")
+        before = int(before_row["count"])
+        report = run_backtest(
+            conn,
+            holdout_purpose="issue #2488 benchmark; transaction rolled back",
+            holdout_accessed_by="codex benchmark",
+            evaluation_window=window,
+        )
+        result_versions = [row.result_version for row in report.rows]
+        with conn.cursor(row_factory=dict_row) as cursor:
+            rows = cursor.execute(
+                """
+                SELECT *
+                  FROM strategy_results_store
+                 WHERE result_version = ANY(%(result_versions)s)
+                 ORDER BY strategy_id, namespace, ambiguity_arm, quarantine_arm
+                """,
+                {"result_versions": result_versions},
+            ).fetchall()
+        if len(rows) != report.rows_written:
+            raise RuntimeError(
+                f"production report built {report.rows_written} rows but the exact result identities read back "
+                f"{len(rows)} rows"
+            )
+        row_digest = _digest([dict(row) for row in rows])
+        conn.rollback()
+        with conn.cursor(row_factory=dict_row) as cursor:
+            after_row = cursor.execute("SELECT count(*) AS count FROM strategy_results_store").fetchone()
+        if after_row is None:  # pragma: no cover - aggregate always returns one row
+            raise RuntimeError("strategy result count query returned no row after rollback")
+        after = int(after_row["count"])
+    return {
+        "mode": "full-run",
+        "window_id": window_id,
+        "rows_built": report.rows_written,
+        "store_rows_hashed": len(rows),
+        "store_rows_sha256": row_digest,
+        "physical_rows_before": before,
+        "physical_rows_after_rollback": after,
+        "rollback_preserved_store": before == after,
+        "nontransactional_sequence_ids_may_have_advanced": True,
+        **_resources(started_wall, started_cpu),
+        "stage_seconds": {
+            f"{arm.strategy_id}/{arm.ambiguity_arm or 'shared'}/{arm.quarantine_arm}": arm.elapsed_s
+            for arm in report.arms
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("compare-s4", "full-run"))
+    parser.add_argument("--window", default="year-2026-ytd")
+    parser.add_argument("--arm", choices=("admitted", "masked"), default="admitted")
+    parser.add_argument("--limit", type=int)
+    args = parser.parse_args()
+    result: dict[str, Any]
+    if args.mode == "compare-s4":
+        result = compare_s4(window_id=args.window, quarantine_arm=args.arm, limit=args.limit)
+    else:
+        result = full_run(window_id=args.window)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/296_strategy_outcomes_unorderable_exit_levels.sql
+++ b/sql/296_strategy_outcomes_unorderable_exit_levels.sql
@@ -1,0 +1,26 @@
+-- #2489 — one unorderable S-4 bracket must not abort the evidence or forward
+-- outcome batch. The existing bounded ledger gets one new closed refusal code;
+-- no rows, metrics or time-series stores are added.
+--
+-- Live constraint inspected before authoring (2026-08-10):
+--   window_truncated, series_break, quarantined_bar, missing_bar_data
+-- This preserves that complete union and appends only
+-- unorderable_exit_levels.
+
+BEGIN;
+
+ALTER TABLE strategy_outcomes
+    DROP CONSTRAINT strategy_outcomes_reason_check;
+
+ALTER TABLE strategy_outcomes
+    ADD CONSTRAINT strategy_outcomes_reason_check CHECK (
+        reason IS NULL OR reason IN (
+            'window_truncated',
+            'series_break',
+            'quarantined_bar',
+            'missing_bar_data',
+            'unorderable_exit_levels'
+        )
+    );
+
+COMMIT;

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -46,6 +46,8 @@ from app.services.backtest_run import (
     build_in_sample_split,
     build_result,
     deflate_group,
+    evaluate_arm,
+    evaluate_level_arms,
     runnable_strategies,
 )
 from app.services.cost_model import COST_MODEL_ID
@@ -54,7 +56,12 @@ from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID, LegBook
 from app.services.indicator_series import BarSeries
 from app.services.position_builder import RULE_SET_VERSION as POSITION_RULE_SET_VERSION
 from app.services.position_builder import Window
-from app.services.research_price_structure_store import QUARANTINE_ARMS, QUARANTINE_RULE_SET_VERSION
+from app.services.price_structure import StructureBar
+from app.services.research_price_structure_store import (
+    QUARANTINE_ARMS,
+    QUARANTINE_RULE_SET_VERSION,
+    MaskedSeries,
+)
 from app.services.signal_ledger import LedgerRow
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_result import (
@@ -169,7 +176,10 @@ class TestRunnableStrategies:
         from app.services.strategy_manifest import STRATEGY_MANIFEST
 
         s4 = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
-        manifest = {**STRATEGY_MANIFEST, s4.strategy_id: replace(s4, exit_levels=None)}
+        manifest = {
+            **STRATEGY_MANIFEST,
+            s4.strategy_id: replace(s4, exit_levels=None, exit_levels_batch=None),
+        }
         monkeypatch.setattr(backtest_run, "_demonstrate_level_refusal", lambda entry, regime: None)
         with pytest.raises(RuntimeError, match="did NOT refuse"):
             runnable_strategies(manifest)
@@ -190,6 +200,88 @@ class TestArmVocabularyCoverage:
         this pins that the two are not accidentally coupled.
         """
         assert QUARANTINE_ARM_ORDER[0] == "admitted"
+
+
+class TestLevelArmSharedPass:
+    """The S-4 fast path is result-equivalent to two isolated arm passes."""
+
+    @staticmethod
+    def _fixture() -> tuple[_Corpus, MaskedSeries]:
+        start = date(2022, 1, 3)
+        dates = tuple(start + timedelta(days=index) for index in range(220))
+        bars = tuple(
+            StructureBar(
+                bar_date=when,
+                open=Decimal(str(100 + index)),
+                high=Decimal(str(100 + index + (20 if index == 150 else 1))),
+                low=Decimal(str(100 + index - (20 if index == 150 else 1))),
+                close=Decimal(str(100 + index)),
+                volume=1000,
+            )
+            for index, when in enumerate(dates)
+        )
+        corpus = _Corpus(
+            universe=(1,),
+            axis=dates,
+            axis_pos={when: index for index, when in enumerate(dates)},
+            pairs=((1, 10),),
+            evaluation_start=dates[0],
+            evaluation_end=dates[-1],
+        )
+        return corpus, MaskedSeries(
+            series_id=10,
+            bars=bars,
+            range_masked=0,
+            return_masked=0,
+            range_flagged=0,
+            return_flagged=0,
+            bars_flagged=0,
+            arm="admitted",
+        )
+
+    def test_shared_pass_matches_isolated_measurements_and_loads_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        corpus, loaded = self._fixture()
+        entry = STRATEGY_MANIFEST["s4-volatility-compression-breakout"]
+        identity = entry.identity(universe="survivor_only", cost_model_id=COST_MODEL_ID)
+        calls: list[int] = []
+
+        def load(_conn: object, series_id: int, *, arm: str) -> MaskedSeries:
+            calls.append(series_id)
+            return replace(loaded, arm=arm)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(backtest_run, "load_masked_series", load)
+        isolated = tuple(
+            evaluate_arm(
+                object(),  # type: ignore[arg-type]
+                entry,
+                corpus=corpus,
+                quarantine_arm="admitted",
+                ambiguity_arm=ambiguity,
+                identity=identity,
+                namespaces=("hold_out",),
+            )
+            for ambiguity in AMBIGUITY_ARM_ORDER
+        )
+        assert calls == [10, 10]
+
+        calls.clear()
+        shared = evaluate_level_arms(
+            object(),  # type: ignore[arg-type]
+            entry,
+            corpus=corpus,
+            quarantine_arm="admitted",
+            identity=identity,
+            namespaces=("hold_out",),
+        )
+
+        assert calls == [10]
+        assert tuple(replace(item, elapsed_s=0.0) for item in shared) == tuple(
+            replace(item, elapsed_s=0.0) for item in isolated
+        )
+        assert shared[0].namespaces["hold_out"].metrics != shared[1].namespaces["hold_out"].metrics
 
 
 class TestHoldoutPairing:
@@ -232,6 +324,13 @@ class TestExpectedRefusals:
 
     def test_full_holdout_run_with_a_dsr_leaves_only_the_three_standing_refusals(self) -> None:
         assert _expected_refusals(holdout_requested=True, deflated=True) == STANDING_REFUSALS
+
+    def test_harness_validation_purpose_is_predicted_before_the_write(self) -> None:
+        assert _expected_refusals(
+            holdout_requested=True,
+            deflated=True,
+            purpose="harness_validation",
+        ) == STANDING_REFUSALS | {"harness_validation_only"}
 
     def test_in_sample_run_adds_holdout_never_evaluated(self) -> None:
         assert _expected_refusals(holdout_requested=False, deflated=True) == STANDING_REFUSALS | {

--- a/tests/test_outcome_ledger.py
+++ b/tests/test_outcome_ledger.py
@@ -32,6 +32,7 @@ from app.services.outcome_resolver import (
 from app.services.technical_analysis import OHLCVRow
 
 _MIGRATION = Path(__file__).resolve().parents[1] / "sql" / "256_strategy_outcomes.sql"
+_REASON_MIGRATION = Path(__file__).resolve().parents[1] / "sql" / "296_strategy_outcomes_unorderable_exit_levels.sql"
 
 _VERSIONS = {"rule_set_version": "outcome-resolver-v1+abc123", "input_rule_set_version": "price-quarantine-v1+def456"}
 
@@ -284,7 +285,7 @@ class TestMigrationVocabularyContract:
         assert self._check_members("resolution_method") == set(RESOLUTION_METHODS)
 
     def test_unresolved_reasons(self) -> None:
-        text = _MIGRATION.read_text()
+        text = _REASON_MIGRATION.read_text()
         match = re.search(r"reason IS NULL OR reason IN \(([^)]*)\)", text, re.DOTALL)
         assert match is not None
         assert set(re.findall(r"'([^']+)'", match.group(1))) == set(UNRESOLVED_REASONS)

--- a/tests/test_outcome_resolver.py
+++ b/tests/test_outcome_resolver.py
@@ -444,7 +444,11 @@ def test_the_inherited_reason_codes_match_the_registrys_spelling() -> None:
     (#2218) exists for."""
     assert INHERITED_REASONS <= NOT_EVALUABLE_REASONS
     assert INHERITED_REASONS == {"series_break", "quarantined_bar"}
-    assert OUR_ADDITIONAL_REASONS == {"window_truncated", "missing_bar_data"}
+    assert OUR_ADDITIONAL_REASONS == {
+        "window_truncated",
+        "missing_bar_data",
+        "unorderable_exit_levels",
+    }
     assert OUR_ADDITIONAL_REASONS | INHERITED_REASONS == UNRESOLVED_REASONS
     assert not OUR_ADDITIONAL_REASONS & NOT_EVALUABLE_REASONS
 

--- a/tests/test_strategy_outcome_resolution.py
+++ b/tests/test_strategy_outcome_resolution.py
@@ -120,6 +120,26 @@ def test_a_masked_required_field_is_counted_not_silently_dropped() -> None:
     assert (row.outcome, row.reason, row.gross_return_pct) == ("unresolved", "quarantined_bar", None)
 
 
+def test_unorderable_exit_levels_are_terminal_without_aborting_the_batch() -> None:
+    series = _series((Decimal("1"), Decimal("0.5")), (Decimal("1"), Decimal("0.5")))
+    entry = cast(
+        StrategyEntry,
+        SimpleNamespace(
+            strategy_id="test-level",
+            exit_levels=lambda _series, *, signal_index, entry_price, universe: "unorderable_exit_levels",
+        ),
+    )
+
+    row = _resolve_fill(entry, _fill(series), series=series, unresolved_breaks=())
+
+    assert row is not None
+    assert (row.outcome, row.reason, row.gross_return_pct) == (
+        "unresolved",
+        "unorderable_exit_levels",
+        None,
+    )
+
+
 def test_precomputed_masked_reasons_are_reused_for_an_instrument(monkeypatch: pytest.MonkeyPatch) -> None:
     series = _series((Decimal("105"), Decimal("95")), (None, Decimal("95")))
     monkeypatch.setattr(

--- a/tests/test_strategy_recent_evidence.py
+++ b/tests/test_strategy_recent_evidence.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from app.api.strategies import _evidence_window_counts
+from app.services.backtest_run import BacktestProgressEvent
 from app.services.processes.param_metadata import MANUAL_TRIGGER_JOB_METADATA
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS, recent_evidence_window
 from app.services.strategy_result import EVALUATION_WINDOW_END, HOLDOUT_BOUNDARY
@@ -131,6 +132,182 @@ def test_refresh_recent_refuses_partial_immutable_window(
                 "holdout_accessed_by": "operator",
             }
         )
+
+
+def test_refresh_progress_is_transient_until_evidence_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = SimpleNamespace(row_count=None, run_id=9, progress=None, note=None)
+    conn = MagicMock()
+    events: list[str] = []
+    conn.commit.side_effect = lambda: events.append("evidence_commit")
+    missing = next(reversed(RECENT_EVIDENCE_WINDOWS))
+
+    class Writer:
+        def start_window(self, window_id: str) -> None:
+            events.append(f"start:{window_id}")
+
+        def __call__(self, event: BacktestProgressEvent) -> None:
+            events.append(f"progress:{event.phase}")
+
+        def record_window_commit(self, *, rows_written: int, completed: int) -> bool:
+            events.append(f"checkpoint:{rows_written}:{completed}")
+            return True
+
+        def close(self) -> None:
+            events.append("closed")
+
+    writer = Writer()
+
+    @contextmanager
+    def tracked(_job_name: str) -> Iterator[SimpleNamespace]:
+        yield tracker
+
+    @contextmanager
+    def connected() -> Iterator[MagicMock]:
+        yield conn
+
+    def run_backtest(_conn: object, **kwargs: object) -> SimpleNamespace:
+        progress = kwargs["progress"]
+        assert callable(progress)
+        progress(BacktestProgressEvent(phase="evaluation", series_seen=25, series_total=100))
+        return SimpleNamespace(rows_written=16)
+
+    monkeypatch.setattr(scheduler, "_tracked_job", tracked)
+    monkeypatch.setattr(scheduler, "connect_job", connected)
+    monkeypatch.setattr(
+        scheduler,
+        "_recent_evidence_completion",
+        lambda _conn: (set(RECENT_EVIDENCE_WINDOWS) - {missing}, set()),
+    )
+    monkeypatch.setattr(scheduler, "_open_backtest_progress_writer", lambda **_kwargs: writer)
+    monkeypatch.setattr("app.services.backtest_run.run_backtest", run_backtest)
+
+    scheduler.strategy_backtest_run(
+        {
+            "refresh_recent": True,
+            "holdout_purpose": "declared recent evidence",
+            "holdout_accessed_by": "operator",
+        }
+    )
+
+    assert events == [
+        f"start:{missing}",
+        "progress:evaluation",
+        "evidence_commit",
+        "checkpoint:16:1",
+        "closed",
+    ]
+    assert conn.execute.call_count == 0
+
+
+def test_refresh_failure_before_commit_never_publishes_a_window_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = SimpleNamespace(row_count=None, run_id=9, progress=None, note=None)
+    conn = MagicMock()
+    events: list[str] = []
+
+    class Writer:
+        def start_window(self, window_id: str) -> None:
+            events.append(f"start:{window_id}")
+
+        def __call__(self, _event: BacktestProgressEvent) -> None:
+            events.append("progress")
+
+        def record_window_commit(self, *, rows_written: int, completed: int) -> bool:
+            events.append(f"checkpoint:{rows_written}:{completed}")
+            return True
+
+        def close(self) -> None:
+            events.append("closed")
+
+    @contextmanager
+    def tracked(_job_name: str) -> Iterator[SimpleNamespace]:
+        yield tracker
+
+    @contextmanager
+    def connected() -> Iterator[MagicMock]:
+        yield conn
+
+    monkeypatch.setattr(scheduler, "_tracked_job", tracked)
+    monkeypatch.setattr(scheduler, "connect_job", connected)
+    monkeypatch.setattr(scheduler, "_recent_evidence_completion", lambda _conn: (set(), set()))
+    monkeypatch.setattr(scheduler, "_open_backtest_progress_writer", lambda **_kwargs: Writer())
+
+    def fail(_conn: object, **kwargs: object) -> None:
+        progress = kwargs["progress"]
+        assert callable(progress)
+        progress(BacktestProgressEvent(phase="evaluation", series_seen=25, series_total=100))
+        raise RuntimeError("cancelled before evidence commit")
+
+    monkeypatch.setattr("app.services.backtest_run.run_backtest", fail)
+
+    with pytest.raises(RuntimeError, match="cancelled before evidence commit"):
+        scheduler.strategy_backtest_run(
+            {
+                "refresh_recent": True,
+                "holdout_purpose": "declared recent evidence",
+                "holdout_accessed_by": "operator",
+            }
+        )
+
+    assert events == [f"start:{next(iter(RECENT_EVIDENCE_WINDOWS))}", "progress", "closed"]
+    conn.commit.assert_not_called()
+
+
+def test_progress_writer_failure_is_non_fatal_and_disables_future_writes() -> None:
+    conn = MagicMock()
+    conn.execute.side_effect = RuntimeError("telemetry unavailable")
+    writer = scheduler._BacktestProgressWriter(  # noqa: SLF001 - the failure boundary is the contract under test
+        conn,
+        run_id=9,
+        total_windows=8,
+        already_complete=0,
+    )
+    writer.start_window("primary-2022-plus")
+    event = BacktestProgressEvent(phase="evaluation", series_seen=25, series_total=100)
+
+    writer(event)
+    writer(event)
+
+    assert conn.execute.call_count == 1
+    conn.close.assert_called_once_with()
+
+
+def test_progress_writer_does_not_claim_window_completion_before_commit() -> None:
+    conn = MagicMock()
+    writer = scheduler._BacktestProgressWriter(  # noqa: SLF001 - SQL/payload boundary under test
+        conn,
+        run_id=9,
+        total_windows=8,
+        already_complete=2,
+    )
+    writer.start_window("rolling-24m")
+
+    writer(
+        BacktestProgressEvent(
+            phase="evaluation",
+            strategy_id="s4-volatility-compression-breakout",
+            quarantine_arm="masked",
+            series_seen=50,
+            series_total=100,
+        )
+    )
+
+    sql, params = conn.execute.call_args.args
+    assert "row_count" not in sql
+    payload = params["progress"].obj
+    assert payload["outcomes"] == {"already_complete": 2, "completed": 0}
+    assert payload["active"] == {
+        "window_id": "rolling-24m",
+        "phase": "evaluation",
+        "strategy_id": "s4-volatility-compression-breakout",
+        "quarantine_arm": "masked",
+        "ambiguity_arm": None,
+        "series_seen": 50,
+        "series_total": 100,
+    }
 
 
 def test_overview_counts_missing_members_and_empty_runnable_set_without_crashing() -> None:

--- a/tests/test_strategy_s4.py
+++ b/tests/test_strategy_s4.py
@@ -32,8 +32,10 @@ from pathlib import Path
 import pytest
 
 import app.services.strategies.s4_volatility_compression_breakout as s4_module
+import app.services.strategy_exit_levels_batch as batch_module
 from app.services.cost_model import COST_MODEL_ID
 from app.services.indicator_series import BarSeries, IndicatorSeries, atr_series
+from app.services.outcome_resolver import ExitLevels
 from app.services.signal_ledger import resolve_fills
 from app.services.strategies.s4_volatility_compression_breakout import (
     ATR_PERIOD,
@@ -49,6 +51,8 @@ from app.services.strategies.s4_volatility_compression_breakout import (
     s4_identity,
     s4_signals,
 )
+from app.services.strategy_exit_levels_batch import s4_exit_levels_batch
+from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_registry import StrategySignal
 from app.services.technical_analysis import OHLCVRow
 
@@ -597,6 +601,72 @@ class TestExitLevels:
                 entry_price=Decimal("3"),
                 universe=UNIVERSE,
             )
+
+    def test_manifest_adapter_turns_the_scalar_refusal_into_a_countable_reason(self) -> None:
+        factory = STRATEGY_MANIFEST[S4_STRATEGY_ID].exit_levels
+        assert factory is not None
+
+        actual = factory(
+            _bars(RISING),
+            signal_index=150,
+            entry_price=Decimal("3"),
+            universe=UNIVERSE,
+        )
+
+        assert actual == "unorderable_exit_levels"
+
+    def test_batch_matches_scalar_brackets_and_computes_atr_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        series = _bars(RISING)
+        requests = (
+            (150, Decimal("300")),
+            (175, Decimal("325")),
+            (200, Decimal("350")),
+        )
+        expected = tuple(
+            s4_exit_bracket(
+                series,
+                signal_index=signal_index,
+                entry_price=entry_price,
+                universe=UNIVERSE,
+            )
+            for signal_index, entry_price in requests
+        )
+        calls = 0
+        original = batch_module.atr_series
+
+        def counted_atr(*args: object, **kwargs: object) -> IndicatorSeries:
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(batch_module, "atr_series", counted_atr)
+
+        actual = s4_exit_levels_batch(series, requests=requests, universe=UNIVERSE)
+        assert len(actual) == len(expected)
+        assert (
+            tuple(
+                (item.take_profit, item.stop_loss, item.max_hold_bars)
+                for item in actual
+                if isinstance(item, ExitLevels)
+            )
+            == expected
+        )
+        assert calls == 1
+
+    def test_batch_counts_an_unorderable_stop_without_hiding_other_levels(self) -> None:
+        series = _bars(RISING)
+
+        actual = s4_exit_levels_batch(
+            series,
+            requests=((150, Decimal("3")), (175, Decimal("325"))),
+            universe=UNIVERSE,
+        )
+
+        assert actual[0] == "unorderable_exit_levels"
+        assert isinstance(actual[1], ExitLevels)
 
 
 class TestLastBar:

--- a/tests/test_strategy_s4.py
+++ b/tests/test_strategy_s4.py
@@ -33,6 +33,7 @@ import pytest
 
 import app.services.strategies.s4_volatility_compression_breakout as s4_module
 import app.services.strategy_exit_levels_batch as batch_module
+import app.services.strategy_manifest as manifest_module
 from app.services.cost_model import COST_MODEL_ID
 from app.services.indicator_series import BarSeries, IndicatorSeries, atr_series
 from app.services.outcome_resolver import ExitLevels
@@ -615,6 +616,46 @@ class TestExitLevels:
 
         assert actual == "unorderable_exit_levels"
 
+    def test_manifest_adapter_keeps_the_hashed_scalar_factory_as_exact_oracle(self) -> None:
+        factory = STRATEGY_MANIFEST[S4_STRATEGY_ID].exit_levels
+        assert factory is not None
+        series = _bars(RISING)
+
+        actual = factory(
+            series,
+            signal_index=150,
+            entry_price=Decimal("300"),
+            universe=UNIVERSE,
+        )
+        target, stop, max_hold = s4_exit_bracket(
+            series,
+            signal_index=150,
+            entry_price=Decimal("300"),
+            universe=UNIVERSE,
+        )
+
+        assert actual == ExitLevels(take_profit=target, stop_loss=stop, max_hold_bars=max_hold)
+
+    def test_manifest_adapter_does_not_swallow_an_unrelated_scalar_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        factory = STRATEGY_MANIFEST[S4_STRATEGY_ID].exit_levels
+        assert factory is not None
+
+        def fail_scalar(*args: object, **kwargs: object) -> tuple[Decimal, Decimal, int]:
+            raise ValueError("unrelated scalar defect")
+
+        monkeypatch.setattr(manifest_module, "s4_exit_bracket", fail_scalar)
+
+        with pytest.raises(ValueError, match="unrelated scalar defect"):
+            factory(
+                _bars(RISING),
+                signal_index=150,
+                entry_price=Decimal("300"),
+                universe=UNIVERSE,
+            )
+
     def test_batch_matches_scalar_brackets_and_computes_atr_once(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -667,6 +708,27 @@ class TestExitLevels:
 
         assert actual[0] == "unorderable_exit_levels"
         assert isinstance(actual[1], ExitLevels)
+
+    def test_batch_classifies_a_nonfinite_atr_as_an_unorderable_level(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        series = _bars(RISING)
+        values: list[float | None] = [None] * len(series)
+        values[150] = float("nan")
+        monkeypatch.setattr(
+            batch_module,
+            "atr_series",
+            lambda *args, **kwargs: IndicatorSeries(values=tuple(values), universe=UNIVERSE),
+        )
+
+        actual = s4_exit_levels_batch(
+            series,
+            requests=((150, Decimal("300")),),
+            universe=UNIVERSE,
+        )
+
+        assert actual == ("unorderable_exit_levels",)
 
 
 class TestLastBar:

--- a/var/perf_baselines/2488-599e1acbef44617721fca34274ff2b7c01ac2cd5.json
+++ b/var/perf_baselines/2488-599e1acbef44617721fca34274ff2b7c01ac2cd5.json
@@ -1,0 +1,82 @@
+{
+  "trials": [
+    {
+      "wall_ms": 8194.30087506771,
+      "reference_wall_ms": 110594.9040830601,
+      "quarantine_arm": "admitted",
+      "series": 50,
+      "exact_equal_excluding_elapsed": true,
+      "measurement_sha256": "3fa34ea1f1ba7041b5f5586932bd2ad2750feeccde6a2a862ca42fbcb43b7a27"
+    },
+    {
+      "wall_ms": 7676.310833077878,
+      "reference_wall_ms": 105430.23383407854,
+      "quarantine_arm": "admitted",
+      "series": 50,
+      "exact_equal_excluding_elapsed": true,
+      "measurement_sha256": "3fa34ea1f1ba7041b5f5586932bd2ad2750feeccde6a2a862ca42fbcb43b7a27"
+    },
+    {
+      "wall_ms": 7592.242166865617,
+      "reference_wall_ms": 96100.80337501131,
+      "quarantine_arm": "masked",
+      "series": 50,
+      "exact_equal_excluding_elapsed": true,
+      "measurement_sha256": "0df2c954a1ae7482aa455c701e8665797616b08e9136db9ad2c9b861b89413cb"
+    }
+  ],
+  "median_ms": 7676.310833077878,
+  "reference_median_ms": 105430.23383407854,
+  "fingerprint": {
+    "pg_version": "17.9 (Debian 17.9-1.pgdg13+1)",
+    "host": "Lukes-Mac-mini.lan",
+    "shared_buffers": "2GB",
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O"
+  },
+  "full_population": {
+    "commit": "599e1acbef44617721fca34274ff2b7c01ac2cd5",
+    "window_id": "year-2026-ytd",
+    "window_start": "2026-01-01",
+    "window_end": "2026-07-08",
+    "series_pairs": 5266,
+    "rows_built": 16,
+    "store_rows_hashed": 16,
+    "store_rows_sha256": "8b2546611ec9a076e8ab32e7f1cca5d4fb7d3d2e705cc02657e060b43df9bc1b",
+    "physical_rows_before": 132,
+    "physical_rows_after_rollback": 132,
+    "rollback_preserved_store": true,
+    "wall_ms": 1873039.9675830267,
+    "cpu_ms": 1482458.7720000001,
+    "peak_rss_bytes": 161939456,
+    "stage_seconds": {
+      "s1-time-series-momentum/shared/admitted": 199.4929853749927,
+      "s1-time-series-momentum/shared/masked": 201.33461741590872,
+      "s2-cross-sectional-momentum/shared/admitted": 196.86219599982724,
+      "s2-cross-sectional-momentum/shared/masked": 200.38445912487805,
+      "s3-mean-reversion-in-trend/shared/admitted": 192.33832162502222,
+      "s3-mean-reversion-in-trend/shared/masked": 196.6004258338362,
+      "s4-volatility-compression-breakout/best_case/admitted": 342.4823659998365,
+      "s4-volatility-compression-breakout/worst_case/admitted": 342.4823659998365,
+      "s4-volatility-compression-breakout/best_case/masked": 342.0032262499444,
+      "s4-volatility-compression-breakout/worst_case/masked": 342.0032262499444
+    }
+  },
+  "raw_successful_superset_hash_trial": {
+    "note": "Writer and rollback succeeded, but the readback hashed 12 older rows sharing the window in addition to the 16 new identities; retained as raw timing only.",
+    "wall_ms": 2038914.6464581136,
+    "cpu_ms": 1588599.043,
+    "peak_rss_bytes": 151666688,
+    "rows_built": 16,
+    "store_rows_hashed": 28,
+    "physical_rows_before": 132,
+    "physical_rows_after_rollback": 132
+  },
+  "observed_baseline": {
+    "request_id": 266,
+    "run_id": 86888,
+    "wall_ms": 3600279.0,
+    "rows_committed": 0,
+    "outcome": "failure",
+    "error": "S-4 causal 2xATR stop was non-positive for an entry at 0.7159900069236755"
+  }
+}

--- a/var/perf_baselines/2488-599e1acbef44617721fca34274ff2b7c01ac2cd5.manifest.yaml
+++ b/var/perf_baselines/2488-599e1acbef44617721fca34274ff2b7c01ac2cd5.manifest.yaml
@@ -1,0 +1,17 @@
+fixture_label: dev_frozen_research_corpus_year_2026_ytd
+target_table: null
+row_counts:
+  research_price_daily: 25920971
+  research_price_series: 7709
+  validated_series_pairs: 5266
+  strategy_results_store_before: 132
+  strategy_results_store_after_rollback: 132
+window_id: year-2026-ytd
+window_start: 2026-01-01
+window_end: 2026-07-08
+strategy_count: 4
+namespace_count: 1
+ambiguity_identity_count: 2
+quarantine_arm_count: 2
+planned_result_rows: 16
+corpus_storage_note: indicators, positions, returns, and equity curves were recomputed and not persisted

--- a/var/perf_baselines/2488-599e1acbef44617721fca34274ff2b7c01ac2cd5.txt
+++ b/var/perf_baselines/2488-599e1acbef44617721fca34274ff2b7c01ac2cd5.txt
@@ -1,0 +1,31 @@
+EXPLAIN (ANALYZE, BUFFERS, COSTS, FORMAT TEXT)
+Representative unchanged per-series loader query, series_id=1
+
+Merge Left Join  (cost=1032.80..1043.58 rows=550 width=58) (actual time=28.037..28.820 rows=6695 loops=1)
+  Merge Cond: (d.bar_date = q.bar_date)
+  Buffers: shared hit=22 read=111
+  ->  Sort  (cost=1032.52..1033.89 rows=550 width=64) (actual time=27.966..28.159 rows=6695 loops=1)
+        Sort Key: d.bar_date
+        Sort Method: quicksort  Memory: 765kB
+        Buffers: shared hit=20 read=111
+        ->  Nested Loop  (cost=0.84..1007.48 rows=550 width=64) (actual time=1.095..26.016 rows=6695 loops=1)
+              Buffers: shared hit=20 read=111
+              ->  Index Scan using research_price_quarantine_coverage_pkey on research_price_quarantine_coverage cov  (cost=0.28..8.30 rows=1 width=16) (actual time=0.269..0.270 rows=1 loops=1)
+                    Index Cond: (series_id = '1'::smallint)
+                    Filter: (rule_set_version = 'price-quarantine-v1+d0423dbd9cb5'::text)
+                    Buffers: shared hit=6
+              ->  Index Scan using research_price_daily_pkey on research_price_daily d  (cost=0.56..993.68 rows=550 width=64) (actual time=0.819..25.140 rows=6695 loops=1)
+                    Index Cond: ((series_id = '1'::smallint) AND (bar_date >= cov.first_bar) AND (bar_date <= cov.last_bar))
+                    Buffers: shared hit=14 read=111
+  ->  Index Scan using research_bar_quarantine_pkey on research_bar_quarantine q  (cost=0.28..8.30 rows=1 width=14) (actual time=0.065..0.065 rows=0 loops=1)
+        Index Cond: (series_id = '1'::smallint)
+        Filter: (rule_set_version = 'price-quarantine-v1+d0423dbd9cb5'::text)
+        Buffers: shared hit=2
+Planning:
+  Buffers: shared hit=307
+Planning Time: 2.667 ms
+Execution Time: 29.166 ms
+
+The changed hotspot is Python-side S-4 causal ATR/bracket and ambiguity-arm
+recomputation, not this SQL shape. Raw A/B and full-population timings are in
+the sibling JSON artifact.


### PR DESCRIPTION
## Issue reference

Closes #2488
Fixes #2489
Fixes #2490
Refs #2469

## Summary

Makes the first recent-evidence window complete and observable without changing strategy parameters, corpus membership, trial membership, or the statistical denominator. It batches only result-equivalent S-4 immutable work, counts unorderable brackets instead of aborting the batch, and preserves all four controls as permanently unfundable harness validation.

## Changes

- Shares one S-4 corpus/signals/fills/raw-outcome pass across daily-OHLC ambiguity projections while retaining independent books and counters.
- Keeps the hashed S-4 strategy source byte-identical; the scalar factory remains the oracle and a runner-only batch adapter computes causal ATR once per price segment.
- Adds the closed `unorderable_exit_levels` terminal refusal to historical and forward outcome resolution; no stop is clamped or invented.
- Corrects pre/post-write refusal prediction so `harness_validation_only` remains attached to all four controls.
- Adds throttled fail-soft progress for active window, phase, strategy, arms, and series counts on one bounded telemetry connection; completion advances only after evidence commit.
- Updates the outcome constraint/specs and adds a transactional full-window benchmark that hashes exact result identities and rolls back all rows.

## Security and audit model

No broker order placement or execution endpoint is touched. The forward resolver only classifies an unorderable bracket as terminal unresolved; all four current strategies retain `harness_validation_only` and cannot receive capital. Telemetry cannot commit, reclassify, or roll back evidence, and disables itself after its first connection/write fault.

## Runtime evidence

- Failed baseline request 266 / run 86888: about 60 minutes, zero committed rows, aborted on one negative S-4 stop.
- Three 50-series real-corpus scalar-versus-batch trials were exact on every nested measurement field except elapsed time. Optimized wall: 8.19s / 7.68s / 7.59s; scalar wall: 110.59s / 105.43s / 96.10s.
- Full `year-2026-ytd` population: 5,266 series pairs, 16 exact result rows, 1,873.04s wall, 1,482.46s CPU, 161,939,456-byte peak RSS. Exact store digest `8b2546611ec9a076e8ab32e7f1cca5d4fb7d3d2e705cc02657e060b43df9bc1b`; physical rows 132 before and 132 after rollback.
- Artifacts: `var/perf_baselines/2488-599e1acbef44617721fca34274ff2b7c01ac2cd5.{txt,json,manifest.yaml}`.

## Sibling-shape audit

Only S-4 is level-based and can share best/worst ambiguity facts. S1-S3 retain the reference evaluator. Quarantine arms remain separate because they intentionally consume different field values; S2 retains its required ranking and evaluation passes. No persisted indicator, position, return, curve, or polling-history table was added.

## Rollback criteria

Revert if the scalar/batch measurement hashes diverge, a refresh writes anything other than the planned 16-row recent-window denominator, precommit telemetry advances `row_count`/completed, memory exceeds the measured envelope materially, or an unorderable fill contributes an exit price/return. The batch adapter is isolated and can be removed while retaining the scalar refusal path.

## Post-deploy SLO

A recent window must expose a progress heartbeat during evaluation, commit exactly 16 immutable result rows or none, and resume from the last committed window. On the measured dev corpus, investigate if the first window exceeds 40 minutes or peak RSS exceeds 256 MB under comparable load. Telemetry failure alone must not fail evidence.

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pyright`
- [x] `uv run pytest -m "not db"` — 7,231 passed, 14 skipped
- [x] `uv run pytest tests/smoke` — 154 passed, 3 skipped
- [x] `uv run pytest -n 0 -m db -q tests/test_outcome_ledger_db.py tests/test_strategy_outcome_resolution.py` — 35 passed
- [x] Dev migration reports no pending files; migration SHA and live closed reason constraint match.
- [x] Two independent uncommitted-diff reviews reported no actionable defects.
- [x] Pre-push hook repeated repository gates successfully.

## Checklist

- [x] Branch follows `feature/NNN-short-description`.
- [x] No raw user input reaches SQL without parameterisation.
- [x] No order placement path or execution guard is changed.
- [x] S-4 source identity, full history, costs, trial membership, arm order, and write order are preserved.
- [x] CI checks must pass before merge.