### PR TITLE
feat(#2476): retain causal PEAD effect screen

### DIFF
--- a/app/services/pead_candidate.py
+++ b/app/services/pead_candidate.py
@@ -1,0 +1,583 @@
+"""Point-in-time historical-SUE source construction for candidate #2476.
+
+The module deliberately stops at signal construction.  It does not know an
+outcome price and therefore can be exercised and reviewed before the sealed
+recent return interval is opened.  Source and formula contract:
+``docs/proposals/ta/2026-08-10-pead-preregistration.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from decimal import Decimal
+from math import ceil, isfinite
+from pathlib import Path
+from statistics import fmean, stdev
+from typing import Any, Final
+
+import psycopg
+
+from app.services.strategy_result import CORPUS_VENDORS
+
+TRIAL_ID: Final = "pead-historical-sue-net-income-v1"
+SOURCE_CONCEPT: Final = "NetIncomeLoss"
+SOURCE_TAXONOMY: Final = "us-gaap"
+SOURCE_UNIT: Final = "USD"
+ESTIMATION_DIFFERENCES: Final = 21
+SEASONAL_LAG: Final = 4
+REQUIRED_PRIOR_QUARTERS: Final = ESTIMATION_DIFFERENCES + SEASONAL_LAG
+THRESHOLD_LOOKBACK_CALENDAR_QUARTERS: Final = 8
+MIN_THRESHOLD_EVENTS: Final = 200
+
+
+@dataclass(frozen=True)
+class ReportedFact:
+    instrument_id: int
+    accession_number: str
+    form_type: str
+    filed_date: date
+    accepted_at: datetime | None
+    fiscal_year: int
+    fiscal_period: str
+    period_end: date
+    values: tuple[Decimal, ...]
+
+
+@dataclass(frozen=True)
+class QuarterObservation:
+    instrument_id: int
+    fiscal_year: int
+    fiscal_quarter: int
+    value: Decimal
+    filed_date: date
+    accepted_at: datetime | None
+    accession_number: str
+    source_accessions: tuple[str, ...]
+    derived_q4: bool
+
+    @property
+    def fiscal_key(self) -> int:
+        return self.fiscal_year * 4 + self.fiscal_quarter
+
+
+@dataclass(frozen=True)
+class SueEvent:
+    observation: QuarterObservation
+    sue: float
+
+    @property
+    def calendar_quarter(self) -> int:
+        return self.observation.filed_date.year * 4 + (self.observation.filed_date.month - 1) // 3 + 1
+
+
+@dataclass(frozen=True)
+class TriggeredSueEvent:
+    event: SueEvent
+    lower_threshold: float
+    upper_threshold: float
+    side: str | None
+    threshold_population: int
+
+
+@dataclass(frozen=True)
+class PeadSourceBuild:
+    observations: tuple[QuarterObservation, ...]
+    sue_events: tuple[SueEvent, ...]
+    triggers: tuple[TriggeredSueEvent, ...]
+    instrument_alternatives: Mapping[int, tuple[int, ...]]
+    refusals: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class ArchiveFactLoad:
+    facts: tuple[ReportedFact, ...]
+    archive_sha256: str
+    instrument_alternatives: Mapping[int, tuple[int, ...]]
+    refusals: Mapping[str, int]
+
+
+def _quarter_number(fiscal_period: str) -> int | None:
+    if fiscal_period in {"Q1", "Q2", "Q3"}:
+        return int(fiscal_period[1])
+    if fiscal_period == "FY":
+        return 4
+    return None
+
+
+def construct_quarters(facts: Iterable[ReportedFact]) -> tuple[tuple[QuarterObservation, ...], Counter[str]]:
+    """Build exact Q1-Q3 observations and causal residual Q4 observations."""
+    refusals: Counter[str] = Counter()
+    by_key: dict[tuple[int, int, int], list[ReportedFact]] = defaultdict(list)
+    for fact in facts:
+        quarter = _quarter_number(fact.fiscal_period)
+        if quarter is None:
+            refusals["unsupported_fiscal_period"] += 1
+            continue
+        if len(fact.values) != 1:
+            refusals["ambiguous_current_fact"] += 1
+            continue
+        if not fact.values[0].is_finite():
+            refusals["non_finite_source_value"] += 1
+            continue
+        by_key[(fact.instrument_id, fact.fiscal_year, quarter)].append(fact)
+
+    selected: dict[tuple[int, int, int], ReportedFact] = {}
+    for key, candidates in by_key.items():
+        candidates.sort(key=lambda item: (item.filed_date, item.accession_number))
+        if len(candidates) != 1:
+            # Multiple original accessions for one fiscal slot are not silently
+            # ordered into a truth.  They can be audited and fixed upstream.
+            refusals["duplicate_fiscal_slot"] += 1
+            continue
+        selected[key] = candidates[0]
+
+    observations: list[QuarterObservation] = []
+    for (instrument_id, fiscal_year, quarter), fact in sorted(selected.items()):
+        if quarter < 4:
+            observations.append(
+                QuarterObservation(
+                    instrument_id=instrument_id,
+                    fiscal_year=fiscal_year,
+                    fiscal_quarter=quarter,
+                    value=fact.values[0],
+                    filed_date=fact.filed_date,
+                    accepted_at=fact.accepted_at,
+                    accession_number=fact.accession_number,
+                    source_accessions=(fact.accession_number,),
+                    derived_q4=False,
+                )
+            )
+            continue
+
+        legs = [selected.get((instrument_id, fiscal_year, item)) for item in (1, 2, 3)]
+        if any(item is None for item in legs):
+            refusals["q4_missing_quarter_leg"] += 1
+            continue
+        prior_legs = tuple(item for item in legs if item is not None)
+        if any(item.filed_date >= fact.filed_date for item in prior_legs):
+            refusals["q4_leg_not_known_at_annual_filing"] += 1
+            continue
+        value = fact.values[0] - sum((item.values[0] for item in prior_legs), start=Decimal("0"))
+        observations.append(
+            QuarterObservation(
+                instrument_id=instrument_id,
+                fiscal_year=fiscal_year,
+                fiscal_quarter=4,
+                value=value,
+                filed_date=fact.filed_date,
+                accepted_at=fact.accepted_at,
+                accession_number=fact.accession_number,
+                source_accessions=(fact.accession_number, *(item.accession_number for item in prior_legs)),
+                derived_q4=True,
+            )
+        )
+    observations.sort(key=lambda item: (item.instrument_id, item.fiscal_key, item.filed_date))
+    return tuple(observations), refusals
+
+
+def calculate_sue_events(
+    observations: Sequence[QuarterObservation],
+) -> tuple[tuple[SueEvent, ...], Counter[str]]:
+    """Apply the frozen 21-difference seasonal random-walk model."""
+    refusals: Counter[str] = Counter()
+    by_instrument: dict[int, dict[int, QuarterObservation]] = defaultdict(dict)
+    for observation in observations:
+        if observation.fiscal_key in by_instrument[observation.instrument_id]:
+            raise ValueError("construct_quarters emitted a duplicate fiscal key")
+        by_instrument[observation.instrument_id][observation.fiscal_key] = observation
+
+    events: list[SueEvent] = []
+    for series in by_instrument.values():
+        for key in sorted(series):
+            required = range(key - REQUIRED_PRIOR_QUARTERS, key + 1)
+            if any(item not in series for item in required):
+                refusals["insufficient_consecutive_history"] += 1
+                continue
+            differences = [
+                float(series[item].value - series[item - SEASONAL_LAG].value)
+                for item in range(key - ESTIMATION_DIFFERENCES, key)
+            ]
+            if not all(isfinite(item) for item in differences):
+                refusals["non_finite_forecast_error"] += 1
+                continue
+            drift = fmean(differences)
+            dispersion = stdev(item - drift for item in differences)
+            if not isfinite(drift) or not isfinite(dispersion):
+                refusals["non_finite_forecast_error"] += 1
+                continue
+            if dispersion == 0:
+                refusals["zero_forecast_error_dispersion"] += 1
+                continue
+            current = series[key]
+            seasonal_change = float(current.value - series[key - SEASONAL_LAG].value)
+            if not isfinite(seasonal_change):
+                refusals["non_finite_forecast_error"] += 1
+                continue
+            events.append(SueEvent(observation=current, sue=(seasonal_change - drift) / dispersion))
+    events.sort(key=lambda item: (item.observation.filed_date, item.observation.instrument_id))
+    return tuple(events), refusals
+
+
+def nearest_rank(values: Sequence[float], percentile: float) -> float:
+    """Deterministic nearest-rank percentile; no interpolation or tuning."""
+    if not values:
+        raise ValueError("nearest_rank requires at least one value")
+    if not 0 < percentile <= 1:
+        raise ValueError("percentile must be in (0, 1]")
+    ordered = sorted(values)
+    return ordered[ceil(percentile * len(ordered)) - 1]
+
+
+def classify_causal_triggers(events: Sequence[SueEvent]) -> tuple[tuple[TriggeredSueEvent, ...], Counter[str]]:
+    """Rank against eight completed calendar quarters, never future peers."""
+    refusals: Counter[str] = Counter()
+    by_calendar_quarter: dict[int, list[float]] = defaultdict(list)
+    for event in events:
+        by_calendar_quarter[event.calendar_quarter].append(event.sue)
+
+    classified: list[TriggeredSueEvent] = []
+    for event in events:
+        prior = [
+            value
+            for quarter in range(
+                event.calendar_quarter - THRESHOLD_LOOKBACK_CALENDAR_QUARTERS,
+                event.calendar_quarter,
+            )
+            for value in by_calendar_quarter.get(quarter, ())
+        ]
+        if len(prior) < MIN_THRESHOLD_EVENTS:
+            refusals["thin_prior_cross_section"] += 1
+            continue
+        lower = nearest_rank(prior, 0.1)
+        upper = nearest_rank(prior, 0.9)
+        side = "long" if event.sue >= upper else "short" if event.sue <= lower else None
+        classified.append(
+            TriggeredSueEvent(
+                event=event,
+                lower_threshold=lower,
+                upper_threshold=upper,
+                side=side,
+                threshold_population=len(prior),
+            )
+        )
+    return tuple(classified), refusals
+
+
+_FACT_SQL = """
+    WITH eligible AS (
+        SELECT f.instrument_id, f.accession_number, f.form_type, f.filed_date,
+               f.fiscal_year, f.fiscal_period, f.period_start, f.period_end, f.val,
+               max(f.period_end) OVER (PARTITION BY f.instrument_id, f.accession_number) AS latest_period_end
+        FROM financial_facts_raw f
+        JOIN research_price_series s
+          ON s.instrument_id = f.instrument_id
+         AND s.vendor = %(corpus_vendor)s
+        WHERE f.taxonomy = %(taxonomy)s
+          AND f.concept = %(concept)s
+          AND f.unit = %(unit)s
+          AND f.form_type IN ('10-Q', '10-K')
+          AND f.period_start IS NOT NULL
+          AND f.fiscal_year IS NOT NULL
+          AND (
+                (f.form_type = '10-Q' AND f.fiscal_period IN ('Q1','Q2','Q3')
+                 AND f.period_end - f.period_start BETWEEN 70 AND 110)
+             OR (f.form_type = '10-K' AND f.fiscal_period = 'FY'
+                 AND f.period_end - f.period_start BETWEEN 300 AND 400)
+          )
+    ), manifest AS (
+        SELECT instrument_id, accession_number, max(accepted_at) AS accepted_at
+        FROM sec_filing_manifest
+        WHERE form IN ('10-Q', '10-K')
+        GROUP BY instrument_id, accession_number
+    )
+    SELECT e.instrument_id, e.accession_number, e.form_type, e.filed_date,
+           m.accepted_at, e.fiscal_year, e.fiscal_period, e.period_end,
+           array_agg(DISTINCT e.val ORDER BY e.val) AS values
+    FROM eligible e
+    LEFT JOIN manifest m
+      ON m.instrument_id = e.instrument_id
+     AND m.accession_number = e.accession_number
+    WHERE e.period_end = e.latest_period_end
+    GROUP BY e.instrument_id, e.accession_number, e.form_type, e.filed_date,
+             m.accepted_at, e.fiscal_year, e.fiscal_period, e.period_end
+    ORDER BY e.instrument_id, e.fiscal_year, e.fiscal_period, e.filed_date, e.accession_number
+"""
+
+
+def load_reported_facts(conn: psycopg.Connection[Any]) -> tuple[ReportedFact, ...]:
+    rows = conn.execute(
+        _FACT_SQL,
+        {
+            "corpus_vendor": CORPUS_VENDORS[0],
+            "taxonomy": SOURCE_TAXONOMY,
+            "concept": SOURCE_CONCEPT,
+            "unit": SOURCE_UNIT,
+        },
+    ).fetchall()
+    return tuple(
+        ReportedFact(
+            instrument_id=int(row[0]),
+            accession_number=str(row[1]),
+            form_type=str(row[2]),
+            filed_date=row[3],
+            accepted_at=row[4],
+            fiscal_year=int(row[5]),
+            fiscal_period=str(row[6]),
+            period_end=row[7],
+            values=tuple(Decimal(value) for value in row[8]),
+        )
+        for row in rows
+    )
+
+
+def _archive_sha256(archive_path: Path) -> str:
+    sidecar = archive_path.with_name(archive_path.name + ".sha256")
+    if not sidecar.is_file():
+        raise FileNotFoundError(f"companyfacts integrity sidecar is missing: {sidecar}")
+    value = sidecar.read_text().strip().lower()
+    if len(value) != 64 or any(item not in "0123456789abcdef" for item in value):
+        raise ValueError(f"companyfacts integrity sidecar is not a SHA-256: {sidecar}")
+    with archive_path.open("rb") as handle:
+        measured = hashlib.file_digest(handle, "sha256").hexdigest()
+    if measured != value:
+        raise ValueError(f"companyfacts archive SHA-256 mismatch: expected {value}, measured {measured}")
+    return value
+
+
+def load_archive_reported_facts(
+    conn: psycopg.Connection[Any],
+    archive_path: Path,
+) -> ArchiveFactLoad:
+    """Read the deep history transiently from the retained SEC bulk archive.
+
+    The operational table intentionally keeps only three annual and eight
+    quarterly accessions.  Relaxing that retention rule would bloat the hot
+    database for a research-only need, so this loader streams the already
+    cached public archive and retains only one declared concept in memory.
+    """
+    if not archive_path.is_file():
+        raise FileNotFoundError(f"companyfacts archive is missing: {archive_path}")
+    instrument_rows = conn.execute(
+        """
+        SELECT s.instrument_id, lpad(e.identifier_value, 10, '0') AS cik
+        FROM research_price_series s
+        JOIN external_identifiers e
+          ON e.instrument_id = s.instrument_id
+         AND e.provider = 'sec'
+         AND e.identifier_type = 'cik'
+        WHERE s.vendor = %s
+        ORDER BY s.instrument_id, e.is_primary DESC, e.identifier_value
+        """,
+        (CORPUS_VENDORS[0],),
+    ).fetchall()
+    instrument_to_cik: dict[int, str] = {}
+    ambiguous_instruments: set[int] = set()
+    refusals: Counter[str] = Counter()
+    for instrument_id_raw, cik_raw in instrument_rows:
+        instrument_id = int(instrument_id_raw)
+        cik = str(cik_raw)
+        if instrument_id in ambiguous_instruments:
+            continue
+        existing = instrument_to_cik.get(instrument_id)
+        if existing is not None and existing != cik:
+            refusals["ambiguous_instrument_cik"] += 1
+            instrument_to_cik.pop(instrument_id, None)
+            ambiguous_instruments.add(instrument_id)
+            continue
+        instrument_to_cik[instrument_id] = cik
+    by_cik: dict[str, list[int]] = defaultdict(list)
+    for instrument_id, cik in instrument_to_cik.items():
+        by_cik[cik].append(instrument_id)
+    instrument_alternatives = {min(instrument_ids): tuple(sorted(instrument_ids)) for instrument_ids in by_cik.values()}
+    refusals["share_class_source_duplicates_suppressed"] = sum(
+        len(instrument_ids) - 1 for instrument_ids in by_cik.values()
+    )
+
+    manifest_rows = conn.execute(
+        """
+        SELECT instrument_id, accession_number, max(accepted_at)
+        FROM sec_filing_manifest
+        WHERE form IN ('10-Q', '10-K')
+          AND instrument_id IS NOT NULL
+        GROUP BY instrument_id, accession_number
+        """
+    ).fetchall()
+    accepted_at = {(int(row[0]), str(row[1])): row[2] for row in manifest_rows}
+
+    facts: list[ReportedFact] = []
+    with zipfile.ZipFile(archive_path) as archive:
+        names = set(archive.namelist())
+        for cik, instrument_ids in sorted(by_cik.items()):
+            representative = min(instrument_ids)
+            entry_name = f"CIK{cik}.json"
+            if entry_name not in names:
+                refusals["cik_absent_from_companyfacts_archive"] += len(instrument_ids)
+                continue
+            try:
+                with archive.open(entry_name) as handle:
+                    payload = json.load(handle)
+                raw_items = payload["facts"][SOURCE_TAXONOMY][SOURCE_CONCEPT]["units"][SOURCE_UNIT]
+            except json.JSONDecodeError, KeyError, TypeError:
+                refusals["declared_concept_absent_or_invalid"] += len(instrument_ids)
+                continue
+
+            grouped: dict[str, list[tuple[date, date, Decimal, date, int, str, str]]] = defaultdict(list)
+            for raw in raw_items:
+                try:
+                    form_type = str(raw["form"])
+                    fiscal_period = str(raw["fp"])
+                    fiscal_year = int(raw["fy"])
+                    period_start = date.fromisoformat(str(raw["start"]))
+                    period_end = date.fromisoformat(str(raw["end"]))
+                    filed_date = date.fromisoformat(str(raw["filed"]))
+                    value = Decimal(str(raw["val"]))
+                    accession = str(raw["accn"])
+                except KeyError, TypeError, ValueError:
+                    refusals["invalid_archive_fact_item"] += 1
+                    continue
+                duration = (period_end - period_start).days
+                eligible = (form_type == "10-Q" and fiscal_period in {"Q1", "Q2", "Q3"} and 70 <= duration <= 110) or (
+                    form_type == "10-K" and fiscal_period == "FY" and 300 <= duration <= 400
+                )
+                if not eligible or not value.is_finite():
+                    continue
+                grouped[accession].append(
+                    (period_start, period_end, value, filed_date, fiscal_year, fiscal_period, form_type)
+                )
+
+            for accession, candidates in grouped.items():
+                latest_end = max(item[1] for item in candidates)
+                current = [item for item in candidates if item[1] == latest_end]
+                metadata = {(item[3], item[4], item[5], item[6]) for item in current}
+                if len(metadata) != 1:
+                    refusals["ambiguous_archive_fact_metadata"] += len(instrument_ids)
+                    continue
+                filed_date, fiscal_year, fiscal_period, form_type = next(iter(metadata))
+                values = tuple(sorted({item[2] for item in current}))
+                known_acceptances = [
+                    accepted
+                    for instrument_id in instrument_ids
+                    if (accepted := accepted_at.get((instrument_id, accession))) is not None
+                ]
+                facts.append(
+                    ReportedFact(
+                        instrument_id=representative,
+                        accession_number=accession,
+                        form_type=form_type,
+                        filed_date=filed_date,
+                        accepted_at=max(known_acceptances, default=None),
+                        fiscal_year=fiscal_year,
+                        fiscal_period=fiscal_period,
+                        period_end=latest_end,
+                        values=values,
+                    )
+                )
+    facts.sort(
+        key=lambda item: (
+            item.instrument_id,
+            item.fiscal_year,
+            item.fiscal_period,
+            item.filed_date,
+            item.accession_number,
+        )
+    )
+    return ArchiveFactLoad(
+        facts=tuple(facts),
+        archive_sha256=_archive_sha256(archive_path),
+        instrument_alternatives=instrument_alternatives,
+        refusals=dict(sorted(refusals.items())),
+    )
+
+
+def build_source(conn: psycopg.Connection[Any]) -> PeadSourceBuild:
+    facts = load_reported_facts(conn)
+    observations, quarter_refusals = construct_quarters(facts)
+    events, sue_refusals = calculate_sue_events(observations)
+    triggers, trigger_refusals = classify_causal_triggers(events)
+    refusals = quarter_refusals + sue_refusals + trigger_refusals
+    refusals["source_fact_groups"] = len(facts)
+    refusals["quarter_observations"] = len(observations)
+    refusals["sue_events"] = len(events)
+    refusals["classified_events"] = len(triggers)
+    refusals["long_triggers"] = sum(item.side == "long" for item in triggers)
+    refusals["short_triggers"] = sum(item.side == "short" for item in triggers)
+    refusals["accepted_at_present"] = sum(item.observation.accepted_at is not None for item in events)
+    return PeadSourceBuild(
+        observations=observations,
+        sue_events=events,
+        triggers=triggers,
+        instrument_alternatives={item.instrument_id: (item.instrument_id,) for item in observations},
+        refusals=dict(sorted(refusals.items())),
+    )
+
+
+def build_archive_source(conn: psycopg.Connection[Any], archive_path: Path) -> tuple[PeadSourceBuild, ArchiveFactLoad]:
+    loaded = load_archive_reported_facts(conn, archive_path)
+    observations, quarter_refusals = construct_quarters(loaded.facts)
+    events, sue_refusals = calculate_sue_events(observations)
+    triggers, trigger_refusals = classify_causal_triggers(events)
+    refusals = Counter(loaded.refusals) + quarter_refusals + sue_refusals + trigger_refusals
+    refusals["source_fact_groups"] = len(loaded.facts)
+    refusals["quarter_observations"] = len(observations)
+    refusals["sue_events"] = len(events)
+    refusals["classified_events"] = len(triggers)
+    refusals["long_triggers"] = sum(item.side == "long" for item in triggers)
+    refusals["short_triggers"] = sum(item.side == "short" for item in triggers)
+    refusals["accepted_at_present"] = sum(item.observation.accepted_at is not None for item in events)
+    build = PeadSourceBuild(
+        observations=observations,
+        sue_events=events,
+        triggers=triggers,
+        instrument_alternatives=loaded.instrument_alternatives,
+        refusals=dict(sorted(refusals.items())),
+    )
+    return build, loaded
+
+
+def expand_instrument_alternatives(
+    events: Sequence[TriggeredSueEvent],
+    alternatives: Mapping[int, tuple[int, ...]],
+) -> tuple[TriggeredSueEvent, ...]:
+    """Fan issuer-level events out only after thresholds/control selection."""
+    expanded: list[TriggeredSueEvent] = []
+    for event in events:
+        observation = event.event.observation
+        for instrument_id in alternatives.get(observation.instrument_id, (observation.instrument_id,)):
+            expanded.append(
+                replace(
+                    event,
+                    event=replace(
+                        event.event,
+                        observation=replace(observation, instrument_id=instrument_id),
+                    ),
+                )
+            )
+    return tuple(expanded)
+
+
+__all__ = [
+    "ESTIMATION_DIFFERENCES",
+    "MIN_THRESHOLD_EVENTS",
+    "REQUIRED_PRIOR_QUARTERS",
+    "PeadSourceBuild",
+    "ArchiveFactLoad",
+    "QuarterObservation",
+    "ReportedFact",
+    "SueEvent",
+    "TriggeredSueEvent",
+    "build_source",
+    "build_archive_source",
+    "calculate_sue_events",
+    "classify_causal_triggers",
+    "construct_quarters",
+    "expand_instrument_alternatives",
+    "load_reported_facts",
+    "load_archive_reported_facts",
+    "nearest_rank",
+]

--- a/app/services/pead_outcomes.py
+++ b/app/services/pead_outcomes.py
@@ -310,7 +310,7 @@ def _eligible_window(window: PriceWindow) -> str | None:
         return "incomplete_prior_liquidity_window"
     if window.median_dollar_volume is None or window.median_dollar_volume < MIN_MEDIAN_DOLLAR_VOLUME:
         return "median_dollar_volume_below_floor"
-    if window.entry_open <= 0 or window.exit_62_close <= 0:
+    if window.exit_62_close <= 0:
         return "non_positive_fill_price"
     return None
 
@@ -407,10 +407,13 @@ def evaluate_outcomes(conn: psycopg.Connection[Any], events: Sequence[TriggeredS
         candidates.sort(key=lambda item: (item.median_dollar_volume or Decimal("0"), -item.instrument_id), reverse=True)
         window = candidates[0]
         refusals["share_class_duplicates_suppressed"] += len(candidates) - 1
-        assert window.entry_date is not None
-        assert window.exit_62_date is not None
-        assert window.entry_open is not None
-        assert window.exit_62_close is not None
+        if (
+            window.entry_date is None
+            or window.exit_62_date is None
+            or window.entry_open is None
+            or window.exit_62_close is None
+        ):
+            raise RuntimeError("an ineligible PEAD price window escaped the refusal gate")
         gross, net = _net_return_pct(side, window.entry_open, window.exit_62_close)
         net_5 = _diagnostic_net_return_pct(side, window.entry_open, window.exit_5_close, window.exit_5_return_usable)
         net_20 = _diagnostic_net_return_pct(side, window.entry_open, window.exit_20_close, window.exit_20_return_usable)

--- a/app/services/pead_outcomes.py
+++ b/app/services/pead_outcomes.py
@@ -1,0 +1,561 @@
+"""Causal price windows and after-cost event outcomes for #2476.
+
+This module is separate from :mod:`pead_candidate` so source construction can
+be reviewed and run without opening the sealed return interval.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from random import Random
+from statistics import mean, median
+from typing import Any, Final
+from zoneinfo import ZoneInfo
+
+import psycopg
+
+from app.services.block_bootstrap import BootstrapResult, block_bootstrap_expectancy, cluster_by_date
+from app.services.cost_model import buy_price, half_spread_for, sell_price
+from app.services.pead_candidate import TriggeredSueEvent
+from app.services.price_quarantine import RULE_SET_VERSION as QUARANTINE_RULE_SET_VERSION
+from app.services.research_comparator_snapshot import SNAPSHOT_ID
+from app.services.sector_classification import resolve_sector_spdr
+from app.services.strategy_result import CORPUS_FROZEN_LAST_BAR, CORPUS_VENDORS
+
+PRIMARY_START: Final = date(2022, 1, 1)
+MIN_ENTRY_PRICE: Final = Decimal("5")
+MIN_MEDIAN_DOLLAR_VOLUME: Final = Decimal("10000000")
+BOOTSTRAP_SEED: Final = 2476
+CONTROL_SEED: Final = 2476001
+MARKET_TIMEZONE: Final = ZoneInfo("America/New_York")
+REGULAR_MARKET_OPEN: Final = time(9, 30)
+
+
+@dataclass(frozen=True)
+class PriceWindow:
+    event_index: int
+    instrument_id: int
+    filed_date: date
+    side: str
+    accession_number: str
+    series_id: int | None
+    entry_date: date | None
+    entry_open: Decimal | None
+    exit_5_date: date | None
+    exit_5_close: Decimal | None
+    exit_5_return_usable: bool | None
+    exit_20_date: date | None
+    exit_20_close: Decimal | None
+    exit_20_return_usable: bool | None
+    exit_40_date: date | None
+    exit_40_close: Decimal | None
+    exit_40_return_usable: bool | None
+    exit_62_date: date | None
+    exit_62_close: Decimal | None
+    entry_return_usable: bool | None
+    exit_62_return_usable: bool | None
+    prior_sessions: int
+    valid_liquidity_sessions: int
+    median_dollar_volume: Decimal | None
+
+
+@dataclass(frozen=True)
+class EventOutcome:
+    instrument_id: int
+    issuer_cik: str
+    accession_number: str
+    side: str
+    entry_date: date
+    exit_date: date
+    gross_return_pct: float
+    net_return_pct: float
+    net_return_5_pct: float | None
+    net_return_20_pct: float | None
+    net_return_40_pct: float | None
+    market_relative_net_return_pct: float | None
+    sector_relative_net_return_pct: float | None
+    sector_symbol: str | None
+
+
+@dataclass(frozen=True)
+class OutcomeSummary:
+    outcomes: tuple[EventOutcome, ...]
+    bootstrap: BootstrapResult | None
+    refusals: Mapping[str, int]
+
+    @property
+    def win_rate_pct(self) -> float | None:
+        if not self.outcomes:
+            return None
+        return sum(item.net_return_pct > 0 for item in self.outcomes) / len(self.outcomes) * 100
+
+    @property
+    def expectancy_pct(self) -> float | None:
+        return mean(item.net_return_pct for item in self.outcomes) if self.outcomes else None
+
+    @property
+    def profit_factor(self) -> float | None:
+        gains = sum(max(item.net_return_pct, 0.0) for item in self.outcomes)
+        losses = -sum(min(item.net_return_pct, 0.0) for item in self.outcomes)
+        return gains / losses if losses > 0 else None
+
+    @property
+    def worst_trade_pct(self) -> float | None:
+        return min((item.net_return_pct for item in self.outcomes), default=None)
+
+    @property
+    def expected_shortfall_5_pct(self) -> float | None:
+        if not self.outcomes:
+            return None
+        ordered = sorted(item.net_return_pct for item in self.outcomes)
+        tail_count = max(1, (len(ordered) + 19) // 20)
+        return mean(ordered[:tail_count])
+
+
+_CREATE_TEMP_EVENTS = """
+    CREATE TEMP TABLE pead_trial_events (
+        event_index      INTEGER PRIMARY KEY,
+        instrument_id    BIGINT NOT NULL,
+        filed_date       DATE NOT NULL,
+        entry_not_before DATE NOT NULL,
+        side             TEXT NOT NULL CHECK (side IN ('long','short')),
+        accession_number TEXT NOT NULL
+    ) ON COMMIT DROP
+"""
+
+_PRICE_WINDOWS_SQL = """
+    WITH event_series AS (
+        SELECT e.*, s.series_id
+        FROM pead_trial_events e
+        LEFT JOIN research_price_series s
+          ON s.instrument_id = e.instrument_id
+         AND s.vendor = %(corpus_vendor)s
+    ), forward AS (
+        SELECT e.event_index, d.bar_date, d.open, d.close,
+               coalesce(q.return_usable, TRUE) AS return_usable,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date) AS rn
+        FROM event_series e
+        JOIN research_price_quarantine_coverage cov
+          ON cov.series_id = e.series_id
+         AND cov.rule_set_version = %(quarantine_version)s
+        JOIN research_price_daily d
+          ON d.series_id = e.series_id
+         AND d.bar_date >= e.entry_not_before
+         AND d.bar_date <= %(frontier)s
+         AND d.bar_date BETWEEN cov.first_bar AND cov.last_bar
+        LEFT JOIN research_bar_quarantine q
+          ON q.series_id = d.series_id
+         AND q.bar_date = d.bar_date
+         AND q.rule_set_version = %(quarantine_version)s
+    ), pivots AS (
+        SELECT event_index,
+               max(bar_date) FILTER (WHERE rn = 1) AS entry_date,
+               max(open) FILTER (WHERE rn = 1) AS entry_open,
+               bool_and(return_usable) FILTER (WHERE rn = 1) AS entry_return_usable,
+               max(bar_date) FILTER (WHERE rn = 5) AS exit_5_date,
+               max(close) FILTER (WHERE rn = 5) AS exit_5_close,
+               bool_and(return_usable) FILTER (WHERE rn <= 5) AS exit_5_return_usable,
+               max(bar_date) FILTER (WHERE rn = 20) AS exit_20_date,
+               max(close) FILTER (WHERE rn = 20) AS exit_20_close,
+               bool_and(return_usable) FILTER (WHERE rn <= 20) AS exit_20_return_usable,
+               max(bar_date) FILTER (WHERE rn = 40) AS exit_40_date,
+               max(close) FILTER (WHERE rn = 40) AS exit_40_close,
+               bool_and(return_usable) FILTER (WHERE rn <= 40) AS exit_40_return_usable,
+               max(bar_date) FILTER (WHERE rn = 62) AS exit_62_date,
+               max(close) FILTER (WHERE rn = 62) AS exit_62_close,
+               bool_and(return_usable) FILTER (WHERE rn <= 62) AS exit_62_return_usable
+        FROM forward
+        GROUP BY event_index
+    ), prior_ranked AS (
+        SELECT e.event_index, d.close, d.volume,
+               coalesce(q.return_usable, TRUE) AS return_usable,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date DESC) AS rn
+        FROM event_series e
+        JOIN pivots p USING (event_index)
+        JOIN research_price_quarantine_coverage cov
+          ON cov.series_id = e.series_id
+         AND cov.rule_set_version = %(quarantine_version)s
+        JOIN research_price_daily d
+          ON d.series_id = e.series_id
+         AND d.bar_date < p.entry_date
+         AND d.bar_date BETWEEN cov.first_bar AND cov.last_bar
+        LEFT JOIN research_bar_quarantine q
+          ON q.series_id = d.series_id
+         AND q.bar_date = d.bar_date
+         AND q.rule_set_version = %(quarantine_version)s
+    ), liquidity AS (
+        SELECT event_index,
+               count(*) FILTER (WHERE rn <= 20) AS prior_sessions,
+               count(*) FILTER (
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+               ) AS valid_liquidity_sessions,
+               percentile_cont(0.5) WITHIN GROUP (ORDER BY close * volume) FILTER (
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+               ) AS median_dollar_volume
+        FROM prior_ranked
+        GROUP BY event_index
+    )
+    SELECT e.event_index, e.instrument_id, e.filed_date, e.side, e.accession_number,
+           e.series_id, p.entry_date, p.entry_open,
+           p.exit_5_date, p.exit_5_close, p.exit_5_return_usable,
+           p.exit_20_date, p.exit_20_close, p.exit_20_return_usable,
+           p.exit_40_date, p.exit_40_close, p.exit_40_return_usable,
+           p.exit_62_date, p.exit_62_close,
+           p.entry_return_usable, p.exit_62_return_usable,
+           coalesce(l.prior_sessions, 0), coalesce(l.valid_liquidity_sessions, 0),
+           l.median_dollar_volume
+    FROM event_series e
+    LEFT JOIN pivots p USING (event_index)
+    LEFT JOIN liquidity l USING (event_index)
+    ORDER BY e.event_index
+"""
+
+
+def load_price_windows(
+    conn: psycopg.Connection[Any],
+    events: Sequence[TriggeredSueEvent],
+) -> tuple[PriceWindow, ...]:
+    selected = [item for item in events if item.side is not None and item.event.observation.filed_date >= PRIMARY_START]
+    conn.execute("DROP TABLE IF EXISTS pead_trial_events")
+    conn.execute(_CREATE_TEMP_EVENTS)
+    with conn.cursor() as cursor:
+        with cursor.copy(
+            "COPY pead_trial_events "
+            "(event_index, instrument_id, filed_date, entry_not_before, side, accession_number) FROM STDIN"
+        ) as copy:
+            for index, item in enumerate(selected):
+                observation = item.event.observation
+                copy.write_row(
+                    (
+                        index,
+                        observation.instrument_id,
+                        observation.filed_date,
+                        earliest_entry_date(observation.filed_date, observation.accepted_at),
+                        item.side,
+                        observation.accession_number,
+                    )
+                )
+    rows = conn.execute(
+        _PRICE_WINDOWS_SQL,
+        {
+            "corpus_vendor": CORPUS_VENDORS[0],
+            "quarantine_version": QUARANTINE_RULE_SET_VERSION,
+            "frontier": CORPUS_FROZEN_LAST_BAR,
+        },
+    ).fetchall()
+    return tuple(
+        PriceWindow(
+            event_index=int(row[0]),
+            instrument_id=int(row[1]),
+            filed_date=row[2],
+            side=str(row[3]),
+            accession_number=str(row[4]),
+            series_id=None if row[5] is None else int(row[5]),
+            entry_date=row[6],
+            entry_open=None if row[7] is None else Decimal(row[7]),
+            exit_5_date=row[8],
+            exit_5_close=None if row[9] is None else Decimal(row[9]),
+            exit_5_return_usable=row[10],
+            exit_20_date=row[11],
+            exit_20_close=None if row[12] is None else Decimal(row[12]),
+            exit_20_return_usable=row[13],
+            exit_40_date=row[14],
+            exit_40_close=None if row[15] is None else Decimal(row[15]),
+            exit_40_return_usable=row[16],
+            exit_62_date=row[17],
+            exit_62_close=None if row[18] is None else Decimal(row[18]),
+            entry_return_usable=row[19],
+            exit_62_return_usable=row[20],
+            prior_sessions=int(row[21]),
+            valid_liquidity_sessions=int(row[22]),
+            median_dollar_volume=None if row[23] is None else Decimal(row[23]),
+        )
+        for row in rows
+    )
+
+
+def earliest_entry_date(filed_date: date, accepted_at: datetime | None) -> date:
+    """Return the first calendar date whose regular open follows knowledge.
+
+    The daily corpus has no intraday bars. An exact SEC acceptance strictly
+    before 09:30 New York time may use that date's open; acceptance at or after
+    the open advances the lower bound one calendar day. Missing acceptance
+    uses the preregistered conservative end-of-filed-date boundary. The price
+    join then selects the first actual market session on or after this date.
+    """
+    if accepted_at is None:
+        return filed_date + timedelta(days=1)
+    if accepted_at.tzinfo is None or accepted_at.utcoffset() is None:
+        raise ValueError("accepted_at must be timezone-aware")
+    market_time = accepted_at.astimezone(MARKET_TIMEZONE)
+    if market_time.timetz().replace(tzinfo=None) < REGULAR_MARKET_OPEN:
+        return market_time.date()
+    return market_time.date() + timedelta(days=1)
+
+
+def _eligible_window(window: PriceWindow) -> str | None:
+    if window.series_id is None or window.entry_date is None or window.entry_open is None:
+        return "price_series_or_entry_missing"
+    if window.exit_62_date is None or window.exit_62_close is None:
+        return "incomplete_62_session_outcome"
+    if not window.entry_return_usable or not window.exit_62_return_usable:
+        return "quarantined_primary_horizon"
+    if window.entry_open < MIN_ENTRY_PRICE:
+        return "entry_price_below_floor"
+    if window.prior_sessions != 20 or window.valid_liquidity_sessions != 20:
+        return "incomplete_prior_liquidity_window"
+    if window.median_dollar_volume is None or window.median_dollar_volume < MIN_MEDIAN_DOLLAR_VOLUME:
+        return "median_dollar_volume_below_floor"
+    if window.entry_open <= 0 or window.exit_62_close <= 0:
+        return "non_positive_fill_price"
+    return None
+
+
+def _net_return_pct(side: str, entry: Decimal, exit_price: Decimal) -> tuple[float, float]:
+    half_spread = half_spread_for(entry)
+    if side == "long":
+        gross = exit_price / entry - 1
+        net = sell_price(exit_price, half_spread=half_spread) / buy_price(entry, half_spread=half_spread) - 1
+    elif side == "short":
+        gross = (entry - exit_price) / entry
+        entry_proceeds = sell_price(entry, half_spread=half_spread)
+        net = (entry_proceeds - buy_price(exit_price, half_spread=half_spread)) / entry_proceeds
+    else:
+        raise ValueError(f"unknown PEAD side {side!r}")
+    return float(gross * 100), float(net * 100)
+
+
+def _diagnostic_net_return_pct(
+    side: str,
+    entry: Decimal,
+    exit_price: Decimal | None,
+    return_usable: bool | None,
+) -> float | None:
+    if exit_price is None or not return_usable or exit_price <= 0:
+        return None
+    return _net_return_pct(side, entry, exit_price)[1]
+
+
+def _load_instrument_context(conn: psycopg.Connection[Any]) -> tuple[dict[int, str], dict[int, str | None]]:
+    rows = conn.execute(
+        """
+        SELECT s.instrument_id,
+               lpad(e.identifier_value, 10, '0') AS cik,
+               p.sic
+        FROM research_price_series s
+        JOIN external_identifiers e
+          ON e.instrument_id = s.instrument_id
+         AND e.provider = 'sec'
+         AND e.identifier_type = 'cik'
+         AND e.is_primary
+        LEFT JOIN instrument_sec_profile p ON p.instrument_id = s.instrument_id
+        WHERE s.vendor = %s
+        """,
+        (CORPUS_VENDORS[0],),
+    ).fetchall()
+    cik_by_instrument = {int(row[0]): str(row[1]) for row in rows}
+    sector_by_instrument = {
+        int(row[0]): (classification.spdr_symbol if (classification := resolve_sector_spdr(row[2])) else None)
+        for row in rows
+    }
+    return cik_by_instrument, sector_by_instrument
+
+
+def _load_comparators(conn: psycopg.Connection[Any]) -> dict[str, dict[date, tuple[Decimal, Decimal]]]:
+    rows = conn.execute(
+        """
+        SELECT s.vendor_symbol, d.bar_date, d.open, d.close
+        FROM research_price_series s
+        JOIN research_price_daily d USING (series_id)
+        WHERE s.comparator_snapshot_id = %s
+        ORDER BY s.vendor_symbol, d.bar_date
+        """,
+        (SNAPSHOT_ID,),
+    ).fetchall()
+    output: dict[str, dict[date, tuple[Decimal, Decimal]]] = defaultdict(dict)
+    for symbol, bar_date, open_price, close_price in rows:
+        output[str(symbol)][bar_date] = (Decimal(open_price), Decimal(close_price))
+    return dict(output)
+
+
+def evaluate_outcomes(conn: psycopg.Connection[Any], events: Sequence[TriggeredSueEvent]) -> OutcomeSummary:
+    windows = load_price_windows(conn, events)
+    cik_by_instrument, sector_by_instrument = _load_instrument_context(conn)
+    comparators = _load_comparators(conn)
+    refusals: Counter[str] = Counter()
+
+    # One issuer filing can fan out to multiple listed share classes. Select the
+    # most liquid eligible class using only the pre-entry window.
+    grouped: dict[tuple[str, str, str], list[PriceWindow]] = defaultdict(list)
+    for window in windows:
+        reason = _eligible_window(window)
+        if reason is not None:
+            refusals[reason] += 1
+            continue
+        cik = cik_by_instrument.get(window.instrument_id)
+        if cik is None:
+            refusals["issuer_cik_missing"] += 1
+            continue
+        grouped[(cik, window.accession_number, window.side)].append(window)
+
+    outcomes: list[EventOutcome] = []
+    for (cik, accession, side), candidates in grouped.items():
+        candidates.sort(key=lambda item: (item.median_dollar_volume or Decimal("0"), -item.instrument_id), reverse=True)
+        window = candidates[0]
+        refusals["share_class_duplicates_suppressed"] += len(candidates) - 1
+        assert window.entry_date is not None
+        assert window.exit_62_date is not None
+        assert window.entry_open is not None
+        assert window.exit_62_close is not None
+        gross, net = _net_return_pct(side, window.entry_open, window.exit_62_close)
+        net_5 = _diagnostic_net_return_pct(side, window.entry_open, window.exit_5_close, window.exit_5_return_usable)
+        net_20 = _diagnostic_net_return_pct(side, window.entry_open, window.exit_20_close, window.exit_20_return_usable)
+        net_40 = _diagnostic_net_return_pct(side, window.entry_open, window.exit_40_close, window.exit_40_return_usable)
+
+        spy_entry = comparators.get("SPY", {}).get(window.entry_date)
+        spy_exit = comparators.get("SPY", {}).get(window.exit_62_date)
+        market_relative = None
+        if spy_entry is None or spy_exit is None:
+            refusals["market_comparator_session_missing"] += 1
+        else:
+            market_return = float((spy_exit[1] / spy_entry[0] - 1) * 100)
+            market_relative = net - market_return if side == "long" else net + market_return
+
+        sector_symbol = sector_by_instrument.get(window.instrument_id)
+        sector_relative = None
+        if sector_symbol is None:
+            refusals["sector_mapping_missing"] += 1
+        else:
+            sector_entry = comparators.get(sector_symbol, {}).get(window.entry_date)
+            sector_exit = comparators.get(sector_symbol, {}).get(window.exit_62_date)
+            if sector_entry is None or sector_exit is None:
+                refusals["sector_comparator_session_missing"] += 1
+            else:
+                sector_return = float((sector_exit[1] / sector_entry[0] - 1) * 100)
+                sector_relative = net - sector_return if side == "long" else net + sector_return
+
+        outcomes.append(
+            EventOutcome(
+                instrument_id=window.instrument_id,
+                issuer_cik=cik,
+                accession_number=accession,
+                side=side,
+                entry_date=window.entry_date,
+                exit_date=window.exit_62_date,
+                gross_return_pct=gross,
+                net_return_pct=net,
+                net_return_5_pct=net_5,
+                net_return_20_pct=net_20,
+                net_return_40_pct=net_40,
+                market_relative_net_return_pct=market_relative,
+                sector_relative_net_return_pct=sector_relative,
+                sector_symbol=sector_symbol,
+            )
+        )
+    outcomes.sort(key=lambda item: (item.entry_date, item.issuer_cik, item.side))
+    bootstrap = None
+    if outcomes:
+        clusters = cluster_by_date(
+            [item.net_return_pct for item in outcomes],
+            [item.entry_date for item in outcomes],
+        )
+        bootstrap = block_bootstrap_expectancy(clusters, seed=BOOTSTRAP_SEED)
+    refusals["input_signal_events"] = len(windows)
+    refusals["eligible_issuer_events"] = len(outcomes)
+    return OutcomeSummary(outcomes=tuple(outcomes), bootstrap=bootstrap, refusals=dict(sorted(refusals.items())))
+
+
+def build_matched_control_events(
+    events: Sequence[TriggeredSueEvent],
+    *,
+    seed: int = CONTROL_SEED,
+) -> tuple[tuple[TriggeredSueEvent, ...], Mapping[str, int]]:
+    """Select a deterministic one-for-one middle-SUE filing control.
+
+    Controls are matched without replacement on filing calendar quarter and
+    fiscal quarter. They inherit the signal's long/short side so direction and
+    cost arithmetic have the same composition, but their own SUE is inside the
+    causal 10th/90th-percentile thresholds. Selection reads no price or return.
+    """
+    rng = Random(seed)
+    pools: dict[tuple[int, int], list[TriggeredSueEvent]] = defaultdict(list)
+    signals: list[TriggeredSueEvent] = []
+    for event in events:
+        if event.side is None:
+            key = (event.event.calendar_quarter, event.event.observation.fiscal_quarter)
+            pools[key].append(event)
+        elif event.event.observation.filed_date >= PRIMARY_START:
+            signals.append(event)
+    for pool in pools.values():
+        pool.sort(
+            key=lambda item: (
+                item.event.observation.filed_date,
+                item.event.observation.instrument_id,
+                item.event.observation.accession_number,
+            )
+        )
+        rng.shuffle(pool)
+
+    controls: list[TriggeredSueEvent] = []
+    refusals: Counter[str] = Counter()
+    for signal in signals:
+        key = (signal.event.calendar_quarter, signal.event.observation.fiscal_quarter)
+        pool = pools.get(key)
+        if not pool:
+            refusals["matched_control_cell_exhausted"] += 1
+            continue
+        control = pool.pop()
+        controls.append(replace(control, side=signal.side))
+    controls.sort(key=lambda item: (item.event.observation.filed_date, item.event.observation.instrument_id))
+    refusals["matched_control_events"] = len(controls)
+    refusals["signal_events_to_match"] = len(signals)
+    return tuple(controls), dict(sorted(refusals.items()))
+
+
+def concurrency_counts(outcomes: Sequence[EventOutcome]) -> tuple[int, float | None]:
+    """Return maximum and median open event counts over active dates."""
+    if not outcomes:
+        return 0, None
+    deltas: dict[date, int] = defaultdict(int)
+    for item in outcomes:
+        deltas[item.entry_date] += 1
+        deltas[item.exit_date + timedelta(days=1)] -= 1
+    active = 0
+    observed: list[int] = []
+    previous: date | None = None
+    for when in sorted(deltas):
+        if previous is not None and when > previous and active > 0:
+            observed.extend([active] * (when - previous).days)
+        active += deltas[when]
+        previous = when
+    return max(observed, default=0), (float(median(observed)) if observed else None)
+
+
+def segment_outcomes(outcomes: Sequence[EventOutcome], start: date, end: date) -> tuple[EventOutcome, ...]:
+    return tuple(item for item in outcomes if start <= item.entry_date <= end)
+
+
+def median_time_to_outcome_days(outcomes: Sequence[EventOutcome]) -> float | None:
+    if not outcomes:
+        return None
+    return float(median((item.exit_date - item.entry_date).days for item in outcomes))
+
+
+__all__ = [
+    "BOOTSTRAP_SEED",
+    "CONTROL_SEED",
+    "EventOutcome",
+    "OutcomeSummary",
+    "PriceWindow",
+    "build_matched_control_events",
+    "concurrency_counts",
+    "evaluate_outcomes",
+    "earliest_entry_date",
+    "load_price_windows",
+    "median_time_to_outcome_days",
+    "segment_outcomes",
+]

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -74,7 +74,7 @@ from typing import Final
 #: Bumped whenever a trial is added or an entry's meaning changes. ⚠ Stored on
 #: the result row beside the DSR: a deflated Sharpe means nothing without the
 #: trial population it was deflated against, and that population grows.
-TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-07"
+TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-10"
 
 
 @dataclass(frozen=True)
@@ -212,6 +212,12 @@ TRIAL_REGISTER: Final = TrialRegister(
             trial_id="rsi30-20d-quarantined-research-corpus",
             description="RSI<30 → 20-day hit, causal Wilder, quarantined bars excluded (candidate 4), research corpus.",
             evidence="issue #2260 comment 2026-08-05 (full-population recompute)",
+        ),
+        DeclaredTrial(
+            trial_id="pead-historical-sue-net-income-v1",
+            description="Issuer-deduplicated historical-SUE SEC filing drift; fixed 62-session equal-gross long/short.",
+            evidence="issue #2476 comment 2026-08-10 (sealed outcome); preregistration commit 12dff916; "
+            "implementation commit 1bf78256",
         ),
     ),
 )

--- a/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
+++ b/docs/proposals/ta/2026-08-08-strategy-backtest-run.md
@@ -83,7 +83,7 @@ contained delistings would have series that stop in 1998. It does not.
 | A position spanning the boundary is hold-out | §5.2, verbatim. Implemented in `strategy_result.namespace_for_position`. |
 | Result identity's members | `sql/262`'s grain comment + `ResultIdentity`. Fourteen fields; §7 below lists who supplies each. |
 | Hold-out access is logged | Criterion 5, enforced by `sql/264`'s trigger — a hold-out row with no `evaluate` record is refused by the database. |
-| `M`, the declared trial count | Criterion 6. `app/services/trial_register.TRIAL_REGISTER`, version `trial-register-2026-08-07`, **M = 11**. ⚠ Includes abandoned branches; not derivable from the manifest. |
+| `M`, the declared trial count | Criterion 6. `app/services/trial_register.TRIAL_REGISTER`, version `trial-register-2026-08-10`, **M = 12**. ⚠ Includes abandoned branches; not derivable from the manifest. |
 | The two ambiguity arms | §3.4. Both computed, both reported; a material gap blocks promotion. |
 | The two quarantine arms | Criterion 9. Both stored, through `result_ledger.store_*_arm_pair`, which makes the lone-arm state unreachable. |
 | A duplicate identity raises | §2 of the runner spec: *"raising, loudly. `DO NOTHING` would hide corpus drift"*. |

--- a/docs/proposals/ta/2026-08-10-pead-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-pead-preregistration.md
@@ -40,10 +40,10 @@ extraordinary items.
 - Q4 is the as-known annual duration fact of 300-400 days less the same fiscal
   year's three exact, earlier as-filed quarters. Missing or ambiguous legs
   refuse the quarter.
-- A SUE needs 25 consecutive fiscal quarters: four seasonal lags plus the 21
-  prior seasonal differences used to estimate drift and dispersion. No shorter
-  history, zero dispersion, non-finite value or discontinuous fiscal sequence
-  is imputed.
+- A SUE needs the current quarter plus 25 consecutive prior fiscal quarters:
+  four seasonal lags plus the 21 prior seasonal differences used to estimate
+  drift and dispersion. No shorter history, zero dispersion, non-finite value
+  or discontinuous fiscal sequence is imputed.
 
 ## Knowledge time and fill
 
@@ -55,9 +55,10 @@ than `filed_date`. That fallback is deliberately late and causal; it is never
 allowed to fill on the filing date. Live observation requires `accepted_at` and
 refuses without it.
 
-Entry is the next eligible session open. The primary exit is the close after 62
-completed sessions. Five-, 20- and 40-session outcomes are declared diagnostics
-and cannot replace the primary result after measurement.
+Entry is the next eligible session open. The primary exit is the close of the
+62nd eligible session, counting the entry session as session one. Five-, 20-
+and 40-session outcomes use the same counting convention, are declared
+diagnostics and cannot replace the primary result after measurement.
 
 ## Causal cross-sectional trigger
 
@@ -75,6 +76,12 @@ The equal-gross long-short arm is the published-family primary comparison. It
 remains research-only because free historical borrow availability and eToro
 CFD carry are absent. The long-only arm is reported independently and cannot
 inherit a long-short result.
+
+Equal-gross expectancy is one half of the long-arm mean plus one half of the
+short-arm mean, regardless of retained event-count imbalance. Its interval
+combines separate date-clustered 97.5% marginal intervals with Bonferroni
+bounds, providing at least 95% joint coverage without assuming the arms are
+independent.
 
 ## Universe, prices and costs
 
@@ -107,11 +114,27 @@ inherit a long-short result.
 
 ## Required report and pass gate
 
-The retained result includes the complete exclusion census, event and date
-cluster counts, after-cost expectancy with a date-clustered confidence
-interval, win rate, profit factor, drawdown, expected shortfall/worst trade,
-turnover, concurrency/capacity, year/regime stability, market/sector-relative
-return and a matched random-filing control under identical fills and costs.
+The retained effect-screen result includes the complete exclusion census,
+event and date-cluster counts, after-cost expectancy with a date-clustered
+confidence interval, win rate, profit factor, expected shortfall/worst trade,
+holding duration, observed event concurrency, year stability,
+market/sector-relative return and a matched random-filing control under
+identical fills and costs.
+
+The control is selected before prices are read, one-for-one without replacement
+from causally classified middle-SUE filings. It is matched on filing calendar
+quarter and fiscal quarter using seed `2476001`, then inherits the paired
+signal's long/short direction. The same price, liquidity, quarantine and cost
+filters apply. A depleted match cell is counted, never replaced from another
+period.
+
+This effect spike intentionally defines no capital sizing path. Portfolio-level
+drawdown, exposure, turnover and dollar capacity are therefore `not_measured`,
+not inferred from independently compounded overlapping event returns, and each
+is a promotion refusal. If the effect screen passes, a separately
+preregistered fixed-cap portfolio trial must define those quantities and the
+bracket before any paper allocation. This staging prevents a sizing choice made
+after seeing event returns from flattering the same trial.
 
 This one declared arm is appended to the global prior-trial register when it is
 measured. A negative or inconclusive result remains retained. No threshold,

--- a/docs/proposals/ta/2026-08-10-pead-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-pead-preregistration.md
@@ -1,0 +1,123 @@
+# Point-in-time SEC filing-drift preregistration
+
+Status: frozen before outcome measurement for #2476. Parent #2469.
+
+## Hypothesis and honest name
+
+This is a **historical-SUE SEC filing-drift** test, not an analyst-surprise
+strategy and not a conventional earnings-announcement feed. eBull has no free
+point-in-time analyst consensus. SEC facts may also arrive after a separate
+issuer press release, so this test can miss part or all of the immediate
+announcement response. Neither limitation may be renamed away if the result is
+favourable.
+
+The published construction is Jegadeesh and Livnat's rolling seasonal random
+walk with drift. For firm `j` and fiscal quarter `t`:
+
+```text
+D[j,q]       = X[j,q] - X[j,q-4]
+delta[j,t]   = mean(D[j,q]) for q = t-21 .. t-1
+sigma[j,t]   = sample_stddev(D[j,q] - delta[j,t]) over the same 21 values
+SUE[j,t]     = (X[j,t] - X[j,t-4] - delta[j,t]) / sigma[j,t]
+```
+
+Source: Jegadeesh and Livnat, *Post-Earnings-Announcement Drift: The Role of
+Revenue Surprises*, equations 1 and 2. The paper estimates quarters `t-21`
+through `t-1` and standardises by forecast-error volatility. This adaptation
+uses as-filed SEC net income because eBull does not hold Compustat income before
+extraordinary items.
+
+## Frozen source construction
+
+- Taxonomy `us-gaap`, concept `NetIncomeLoss`, unit `USD` only.
+- Original forms `10-Q` and `10-K` only. An amendment is retained as evidence
+  but never becomes a second signal and never rewrites an earlier quarter.
+- Every value must be tied to the exact accession that first reported it.
+  Later comparative facts, canonical latest-period rows and comma-joined source
+  references are forbidden because they leak restatements backwards.
+- Q1-Q3 use one unambiguous duration fact of 70-110 days ending on the filing's
+  latest reported period end.
+- Q4 is the as-known annual duration fact of 300-400 days less the same fiscal
+  year's three exact, earlier as-filed quarters. Missing or ambiguous legs
+  refuse the quarter.
+- A SUE needs 25 consecutive fiscal quarters: four seasonal lags plus the 21
+  prior seasonal differences used to estimate drift and dispersion. No shorter
+  history, zero dispersion, non-finite value or discontinuous fiscal sequence
+  is imputed.
+
+## Knowledge time and fill
+
+`sec_filing_manifest.accepted_at` is the preferred knowledge timestamp. The
+current database retains it for only a small recent subset. When it is absent,
+historical evaluation uses the SEC `filed_date` as an end-of-day boundary and
+may fill only at the first research-corpus session whose date is strictly later
+than `filed_date`. That fallback is deliberately late and causal; it is never
+allowed to fill on the filing date. Live observation requires `accepted_at` and
+refuses without it.
+
+Entry is the next eligible session open. The primary exit is the close after 62
+completed sessions. Five-, 20- and 40-session outcomes are declared diagnostics
+and cannot replace the primary result after measurement.
+
+## Causal cross-sectional trigger
+
+An event cannot know the final decile of a calendar quarter that is still in
+progress. The executable adaptation therefore derives thresholds only from
+SUEs in the eight **completed** calendar quarters before the event's calendar
+quarter. At least 200 eligible prior events are required. Thresholds use the
+nearest-rank 10th and 90th percentiles with no interpolation.
+
+- long arm: current SUE at or above the frozen trailing 90th percentile;
+- short arm: current SUE at or below the frozen trailing 10th percentile;
+- middle events are observed controls, not signals.
+
+The equal-gross long-short arm is the published-family primary comparison. It
+remains research-only because free historical borrow availability and eToro
+CFD carry are absent. The long-only arm is reported independently and cannot
+inherit a long-short result.
+
+## Universe, prices and costs
+
+- US common-equity research series with an exact `instrument_id`; survivor-only
+  is stamped and blocks promotion under the standing gate.
+- Entry price at least USD 5 and prior-20-session median dollar volume at least
+  USD 10m, computed strictly before entry.
+- Equity OHLC uses the immutable primary research corpus through 2026-07-08.
+- SPY and the exact SIC-resolved Select Sector SPDR use comparator snapshot
+  `etoro-comparators-2026-07-08-v1`. Missing exact sessions or sector mapping
+  refuse sector-relative evidence; they are never forward-filled or replaced.
+- Raw, SPY-relative and sector-relative price returns are reported. No
+  dividend-adjusted claim is made.
+- Observed/estimated entry and exit spread plus slippage use the standing cost
+  model. Short carry is not zero: it is unavailable and blocks promotion.
+- No leverage, stop, target or ratchet is inferred. A bracket is a separate
+  preregistered trial after this fixed-horizon effect establishes positive
+  after-cost expectancy. Until then there is no executable capital candidate.
+
+## Evidence windows and one-read rule
+
+- Source/feature history may begin before 2022 solely to form the 25-quarter
+  SUE history.
+- Primary outcome evidence starts 2022-01-01.
+- Results report the latest 24 months, latest 36 months, each calendar year and
+  the full 2022+ interval separately. Older outcomes are stress evidence only.
+- The final recent interval that has a complete 62-session outcome at the
+  frozen frontier is sealed before measurement and read once. Any later rule
+  change mints a new trial and may not reuse that interval as an unseen holdout.
+
+## Required report and pass gate
+
+The retained result includes the complete exclusion census, event and date
+cluster counts, after-cost expectancy with a date-clustered confidence
+interval, win rate, profit factor, drawdown, expected shortfall/worst trade,
+turnover, concurrency/capacity, year/regime stability, market/sector-relative
+return and a matched random-filing control under identical fills and costs.
+
+This one declared arm is appended to the global prior-trial register when it is
+measured. A negative or inconclusive result remains retained. No threshold,
+lookback, horizon or conditioner search follows it under the same identity.
+
+Promotion is refused unless the lower confidence bound on after-cost
+expectancy is positive and every standing evidence, universe, cost, tail,
+capacity, holdout, execution and accounting gate passes. A win rate above 75%
+is neither required nor sufficient.

--- a/scripts/verify_2476_pead_outcomes.py
+++ b/scripts/verify_2476_pead_outcomes.py
@@ -1,0 +1,192 @@
+"""Open and report #2476's sealed recent return interval exactly once."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from collections.abc import Sequence
+from datetime import date
+from statistics import mean
+
+import psycopg
+
+from app.config import settings
+from app.security.master_key import resolve_data_dir
+from app.services.block_bootstrap import block_bootstrap_expectancy, cluster_by_date
+from app.services.pead_candidate import build_archive_source, expand_instrument_alternatives
+from app.services.pead_outcomes import (
+    BOOTSTRAP_SEED,
+    EventOutcome,
+    OutcomeSummary,
+    build_matched_control_events,
+    concurrency_counts,
+    evaluate_outcomes,
+    median_time_to_outcome_days,
+)
+
+
+def _subtract_months(value: date, months: int) -> date:
+    absolute = value.year * 12 + value.month - 1 - months
+    year, zero_month = divmod(absolute, 12)
+    month = zero_month + 1
+    day = min(value.day, 28)
+    return date(year, month, day)
+
+
+def _summary(outcomes: Sequence[EventOutcome], seed: int) -> OutcomeSummary:
+    bootstrap = None
+    if outcomes:
+        bootstrap = block_bootstrap_expectancy(
+            cluster_by_date(
+                [item.net_return_pct for item in outcomes],
+                [item.entry_date for item in outcomes],
+            ),
+            seed=seed,
+        )
+    return OutcomeSummary(outcomes=tuple(outcomes), bootstrap=bootstrap, refusals={})
+
+
+def _print_segment(label: str, outcomes: Sequence[EventOutcome], seed: int) -> None:
+    summary = _summary(outcomes, seed)
+    market = [
+        item.market_relative_net_return_pct for item in outcomes if item.market_relative_net_return_pct is not None
+    ]
+    sector = [
+        item.sector_relative_net_return_pct for item in outcomes if item.sector_relative_net_return_pct is not None
+    ]
+    interval = (
+        "unavailable"
+        if summary.bootstrap is None
+        else f"[{summary.bootstrap.ci_low_pct:+.3f}, {summary.bootstrap.ci_high_pct:+.3f}]"
+    )
+    expectancy = "—" if summary.expectancy_pct is None else f"{summary.expectancy_pct:+.3f}%"
+    win_rate = "—" if summary.win_rate_pct is None else f"{summary.win_rate_pct:.2f}%"
+    profit_factor = "—" if summary.profit_factor is None else f"{summary.profit_factor:.3f}"
+    worst = "—" if summary.worst_trade_pct is None else f"{summary.worst_trade_pct:+.2f}%"
+    expected_shortfall = (
+        "—" if summary.expected_shortfall_5_pct is None else f"{summary.expected_shortfall_5_pct:+.2f}%"
+    )
+    market_mean = "—" if not market else f"{mean(market):+.3f}%"
+    sector_mean = "—" if not sector else f"{mean(sector):+.3f}%"
+    date_clusters = len({item.entry_date for item in outcomes})
+    maximum_concurrent, median_concurrent = concurrency_counts(outcomes)
+    median_open = "—" if median_concurrent is None else f"{median_concurrent:.1f}"
+    holding_days = median_time_to_outcome_days(outcomes)
+    holding = "—" if holding_days is None else f"{holding_days:.0f}d"
+    diagnostics: list[str] = []
+    for horizon, attribute in ((5, "net_return_5_pct"), (20, "net_return_20_pct"), (40, "net_return_40_pct")):
+        values = [value for item in outcomes if (value := getattr(item, attribute)) is not None]
+        diagnostics.append(f"d{horizon}={'—' if not values else f'{mean(values):+.3f}%'}")
+    print(
+        f"{label:<22} events={len(outcomes):>5,} dates={date_clusters:>4,} expectancy={expectancy:>9} "
+        f"CI={interval:<19} "
+        f"wins={win_rate:>7} PF={profit_factor:>6} worst={worst:>9} ES5={expected_shortfall:>9} "
+        f"vsSPY={market_mean:>9} vsSector={sector_mean:>9} hold={holding} "
+        f"concurrency={median_open}/{maximum_concurrent} {' '.join(diagnostics)}"
+    )
+
+
+def _print_equal_gross_primary(outcomes: Sequence[EventOutcome], seed: int) -> None:
+    """Report 50% long / 50% short expectancy with a conservative joint CI."""
+    long = [item for item in outcomes if item.side == "long"]
+    short = [item for item in outcomes if item.side == "short"]
+    if not long or not short:
+        print("equal-gross primary    unavailable — one side has no retained outcomes")
+        return
+    long_bootstrap = block_bootstrap_expectancy(
+        cluster_by_date([item.net_return_pct for item in long], [item.entry_date for item in long]),
+        seed=seed,
+        confidence=0.975,
+    )
+    short_bootstrap = block_bootstrap_expectancy(
+        cluster_by_date([item.net_return_pct for item in short], [item.entry_date for item in short]),
+        seed=seed + 1,
+        confidence=0.975,
+    )
+    point = (mean(item.net_return_pct for item in long) + mean(item.net_return_pct for item in short)) / 2
+    if long_bootstrap is None or short_bootstrap is None:
+        interval = "unavailable"
+    else:
+        # Bonferroni: two 97.5% marginal intervals provide at least 95% joint
+        # coverage without pretending the long and short arms are independent.
+        low = (long_bootstrap.ci_low_pct + short_bootstrap.ci_low_pct) / 2
+        high = (long_bootstrap.ci_high_pct + short_bootstrap.ci_high_pct) / 2
+        interval = f"[{low:+.3f}, {high:+.3f}]"
+    dates = len({item.entry_date for item in outcomes})
+    print(
+        f"equal-gross primary    long={len(long):,} short={len(short):,} dates={dates:,} "
+        f"expectancy={point:+.3f}% CI={interval} (Bonferroni 95% joint)"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--open-sealed-holdout",
+        action="store_true",
+        help="required acknowledgement: this reads the preregistered recent outcomes",
+    )
+    args = parser.parse_args(argv)
+    if not args.open_sealed_holdout:
+        parser.error("pass --open-sealed-holdout only after the source and outcome code are frozen and tested")
+
+    archive = resolve_data_dir() / "sec" / "bulk" / "companyfacts.zip"
+    with psycopg.connect(settings.database_url) as conn:
+        source, loaded = build_archive_source(conn, archive)
+        control_events, control_match = build_matched_control_events(source.triggers)
+        signal_events = expand_instrument_alternatives(source.triggers, source.instrument_alternatives)
+        expanded_controls = expand_instrument_alternatives(control_events, source.instrument_alternatives)
+        evaluated = evaluate_outcomes(conn, signal_events)
+        control_evaluated = evaluate_outcomes(conn, expanded_controls)
+        conn.rollback()  # discard the temporary event relation explicitly
+
+    outcomes = evaluated.outcomes
+    if not outcomes:
+        raise RuntimeError("the preregistered outcome population is empty")
+    last_entry = max(item.entry_date for item in outcomes)
+    print("#2476 sealed outcome report")
+    print(f"companyfacts SHA-256: {loaded.archive_sha256}")
+    print(f"latest complete entry: {last_entry}")
+    print(f"source SUE events: {len(source.sue_events):,}; classified: {len(source.triggers):,}")
+    print()
+    _print_equal_gross_primary(outcomes, BOOTSTRAP_SEED + 100)
+    _print_segment("2022+ all", outcomes, BOOTSTRAP_SEED)
+    _print_segment("2022+ long", [item for item in outcomes if item.side == "long"], BOOTSTRAP_SEED + 1)
+    _print_segment("2022+ short", [item for item in outcomes if item.side == "short"], BOOTSTRAP_SEED + 2)
+    _print_segment("matched control", control_evaluated.outcomes, BOOTSTRAP_SEED + 3)
+    for months in (36, 24):
+        start = _subtract_months(last_entry, months)
+        _print_segment(
+            f"trailing {months} months",
+            [item for item in outcomes if start <= item.entry_date <= last_entry],
+            BOOTSTRAP_SEED + months,
+        )
+    for year in sorted({item.entry_date.year for item in outcomes}):
+        _print_segment(
+            str(year),
+            [item for item in outcomes if item.entry_date.year == year],
+            BOOTSTRAP_SEED + year,
+        )
+
+    print("\nsource exclusions and census")
+    for reason, count in source.refusals.items():
+        print(f"  {reason:<42} {count:>10,}")
+    print("\noutcome refusals")
+    for reason, count in evaluated.refusals.items():
+        print(f"  {reason:<42} {count:>10,}")
+    print("\ncontrol matching")
+    for reason, count in control_match.items():
+        print(f"  {reason:<42} {count:>10,}")
+    print("\ncontrol outcome refusals")
+    for reason, count in control_evaluated.refusals.items():
+        print(f"  {reason:<42} {count:>10,}")
+    side_counts = Counter(item.side for item in outcomes)
+    print(f"\nretained outcomes: long={side_counts['long']:,} short={side_counts['short']:,}")
+    print("promotion refusals: portfolio_drawdown_not_measured, exposure_not_measured,")
+    print("                    turnover_not_measured, dollar_capacity_not_measured, carry_unmodelled, survivor_only")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2476_pead_source.py
+++ b/scripts/verify_2476_pead_source.py
@@ -1,0 +1,85 @@
+"""Build the preregistered #2476 point-in-time source and print its census.
+
+This command does not load any outcome price and cannot inspect the sealed
+recent return interval.  It is safe to run while the source construction is
+being reviewed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+import psycopg
+
+from app.config import settings
+from app.security.master_key import resolve_data_dir
+from app.services.pead_candidate import build_archive_source, build_source
+from app.services.strategy_result import CORPUS_VENDORS
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--operational-retained-only",
+        action="store_true",
+        help="diagnose the hot-table retention horizon instead of the deep bulk archive",
+    )
+    parser.add_argument(
+        "--archive",
+        type=Path,
+        default=resolve_data_dir() / "sec" / "bulk" / "companyfacts.zip",
+    )
+    args = parser.parse_args(argv)
+    with psycopg.connect(settings.database_url) as conn:
+        population = conn.execute(
+            """
+            SELECT count(*), count(DISTINCT m.instrument_id),
+                   count(*) FILTER (WHERE m.accepted_at IS NOT NULL)
+            FROM sec_filing_manifest m
+            JOIN research_price_series s
+              ON s.instrument_id = m.instrument_id
+             AND s.vendor = %s
+            WHERE m.form IN ('10-Q', '10-K')
+              AND m.filed_at >= TIMESTAMPTZ '2022-01-01 00:00:00+00'
+            """,
+            (CORPUS_VENDORS[0],),
+        ).fetchone()
+        if population is None:
+            raise RuntimeError("SEC filing population census returned no row")
+        if args.operational_retained_only:
+            build = build_source(conn)
+            archive_sha256 = None
+        else:
+            build, loaded = build_archive_source(conn, args.archive)
+            archive_sha256 = loaded.archive_sha256
+
+    recent_observations = [item for item in build.observations if item.filed_date.year >= 2022]
+    recent_events = [item for item in build.sue_events if item.observation.filed_date.year >= 2022]
+    recent_classified = [item for item in build.triggers if item.event.observation.filed_date.year >= 2022]
+    recent_sides = Counter(item.side or "control" for item in recent_classified)
+
+    print("#2476 source-only census — no outcomes read")
+    print(f"source: {'operational retained tables' if archive_sha256 is None else args.archive}")
+    if archive_sha256 is not None:
+        print(f"companyfacts archive SHA-256:             {archive_sha256}")
+    print(f"manifest original 10-Q/10-K since 2022: {int(population[0]):,}")
+    print(f"manifest instruments since 2022:         {int(population[1]):,}")
+    print(f"exact accepted_at present:               {int(population[2]):,}")
+    print(f"as-filed quarter observations since 2022:{len(recent_observations):>10,}")
+    print(f"21-difference SUE events since 2022:     {len(recent_events):>10,}")
+    print(f"causally classified events since 2022:   {len(recent_classified):>10,}")
+    print(
+        "classified sides since 2022:            "
+        f"long={recent_sides['long']:,} short={recent_sides['short']:,} control={recent_sides['control']:,}"
+    )
+    print("\nall source construction counters")
+    for reason, count in build.refusals.items():
+        print(f"  {reason:<42} {count:>10,}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pead_candidate.py
+++ b/tests/test_pead_candidate.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from statistics import fmean, stdev
+
+import pytest
+
+from app.services.pead_candidate import (
+    MIN_THRESHOLD_EVENTS,
+    QuarterObservation,
+    ReportedFact,
+    SueEvent,
+    _archive_sha256,
+    calculate_sue_events,
+    classify_causal_triggers,
+    construct_quarters,
+    expand_instrument_alternatives,
+    nearest_rank,
+)
+
+
+def _fact(
+    fiscal_year: int,
+    fiscal_period: str,
+    value: str,
+    *,
+    accession: str | None = None,
+    filed_month: int | None = None,
+) -> ReportedFact:
+    quarter = 4 if fiscal_period == "FY" else int(fiscal_period[1])
+    month = filed_month or quarter * 3
+    return ReportedFact(
+        instrument_id=7,
+        accession_number=accession or f"{fiscal_year}-{fiscal_period}",
+        form_type="10-K" if fiscal_period == "FY" else "10-Q",
+        filed_date=date(fiscal_year + (quarter == 4), month if quarter < 4 else 2, 15),
+        accepted_at=None,
+        fiscal_year=fiscal_year,
+        fiscal_period=fiscal_period,
+        period_end=date(fiscal_year, quarter * 3, 1),
+        values=(Decimal(value),),
+    )
+
+
+def test_q4_is_the_as_known_annual_residual() -> None:
+    observations, refusals = construct_quarters(
+        [_fact(2024, "Q1", "10"), _fact(2024, "Q2", "20"), _fact(2024, "Q3", "30"), _fact(2024, "FY", "100")]
+    )
+    q4 = next(item for item in observations if item.fiscal_quarter == 4)
+    assert q4.value == Decimal("40")
+    assert q4.derived_q4 is True
+    assert q4.source_accessions == ("2024-FY", "2024-Q1", "2024-Q2", "2024-Q3")
+    assert refusals == {}
+
+
+def test_missing_or_ambiguous_source_facts_are_refused() -> None:
+    ambiguous = _fact(2024, "Q1", "10")
+    ambiguous = ReportedFact(**{**ambiguous.__dict__, "values": (Decimal("10"), Decimal("11"))})
+    observations, refusals = construct_quarters([ambiguous, _fact(2024, "FY", "100")])
+    assert observations == ()
+    assert refusals["ambiguous_current_fact"] == 1
+    assert refusals["q4_missing_quarter_leg"] == 1
+
+
+def test_non_finite_source_fact_is_refused() -> None:
+    invalid = _fact(2024, "Q1", "NaN")
+    observations, refusals = construct_quarters([invalid])
+    assert observations == ()
+    assert refusals["non_finite_source_value"] == 1
+
+
+def test_duplicate_original_fiscal_slot_is_not_ordered_into_a_truth() -> None:
+    observations, refusals = construct_quarters(
+        [_fact(2024, "Q1", "10", accession="first"), _fact(2024, "Q1", "10", accession="second")]
+    )
+    assert observations == ()
+    assert refusals["duplicate_fiscal_slot"] == 1
+
+
+def _observation(key: int, value: int, instrument_id: int = 7) -> QuarterObservation:
+    fiscal_year, zero_quarter = divmod(key, 4)
+    fiscal_quarter = zero_quarter + 1
+    return QuarterObservation(
+        instrument_id=instrument_id,
+        fiscal_year=fiscal_year,
+        fiscal_quarter=fiscal_quarter,
+        value=Decimal(value),
+        filed_date=date(2020 + key % 6, fiscal_quarter * 3, 1),
+        accepted_at=None,
+        accession_number=f"a-{key}",
+        source_accessions=(f"a-{key}",),
+        derived_q4=fiscal_quarter == 4,
+    )
+
+
+def test_sue_uses_exactly_21_prior_seasonal_differences() -> None:
+    # Keys 100..125 provide the required current quarter plus 25-quarter
+    # history. Quadratic values make the forecast-error dispersion non-zero.
+    observations = [_observation(key, key * key) for key in range(100, 126)]
+    events, refusals = calculate_sue_events(observations)
+    assert len(events) == 1
+    current_key = 125
+    differences = [float(key * key - (key - 4) * (key - 4)) for key in range(current_key - 21, current_key)]
+    drift = fmean(differences)
+    dispersion = stdev(item - drift for item in differences)
+    expected = (float(current_key * current_key - (current_key - 4) * (current_key - 4)) - drift) / dispersion
+    assert events[0].sue == expected
+    assert refusals["insufficient_consecutive_history"] == 25
+
+
+def test_a_gap_in_fiscal_history_refuses_the_later_sue() -> None:
+    observations = [_observation(key, key * key) for key in range(100, 126) if key != 110]
+    events, refusals = calculate_sue_events(observations)
+    assert events == ()
+    assert refusals["insufficient_consecutive_history"] == 25
+
+
+def _event(calendar_quarter: int, sue: float, instrument_id: int) -> SueEvent:
+    year, zero_quarter = divmod(calendar_quarter - 1, 4)
+    quarter = zero_quarter + 1
+    observation = QuarterObservation(
+        instrument_id=instrument_id,
+        fiscal_year=2020,
+        fiscal_quarter=1,
+        value=Decimal("1"),
+        filed_date=date(year, quarter * 3, 1),
+        accepted_at=None,
+        accession_number=f"event-{calendar_quarter}-{instrument_id}",
+        source_accessions=(f"event-{calendar_quarter}-{instrument_id}",),
+        derived_q4=False,
+    )
+    return SueEvent(observation=observation, sue=sue)
+
+
+def test_trigger_threshold_uses_completed_quarters_only() -> None:
+    target_quarter = 2025 * 4 + 1
+    prior = [_event(target_quarter - 1, float(item), item + 1) for item in range(MIN_THRESHOLD_EVENTS)]
+    target = _event(target_quarter, 1_000.0, 10_001)
+    same_quarter_future_peer = _event(target_quarter, 1_000_000.0, 10_002)
+    classified, refusals = classify_causal_triggers([*prior, target, same_quarter_future_peer])
+    target_result = next(item for item in classified if item.event.observation.instrument_id == 10_001)
+    assert target_result.upper_threshold == nearest_rank([float(item) for item in range(MIN_THRESHOLD_EVENTS)], 0.9)
+    assert target_result.side == "long"
+    assert target_result.threshold_population == MIN_THRESHOLD_EVENTS
+    assert refusals["thin_prior_cross_section"] == MIN_THRESHOLD_EVENTS
+
+
+def test_nearest_rank_is_not_interpolated() -> None:
+    assert nearest_rank([1.0, 2.0, 100.0], 0.5) == 2.0
+
+
+def test_share_classes_expand_only_after_one_issuer_signal_exists() -> None:
+    event = _event(2025 * 4 + 1, 3.0, 10)
+    triggered, _ = classify_causal_triggers(
+        [*[_event(2025 * 4, float(item), item + 100) for item in range(MIN_THRESHOLD_EVENTS)], event]
+    )
+    signal = next(item for item in triggered if item.event.observation.instrument_id == 10)
+    expanded = expand_instrument_alternatives((signal,), {10: (10, 11)})
+    assert [item.event.observation.instrument_id for item in expanded] == [10, 11]
+    assert all(item.event.sue == signal.event.sue for item in expanded)
+
+
+def test_archive_digest_is_measured_not_merely_read_from_sidecar(tmp_path: Path) -> None:
+    archive = tmp_path / "companyfacts.zip"
+    archive.write_bytes(b"declared archive bytes")
+    archive.with_name("companyfacts.zip.sha256").write_text("0" * 64)
+    with pytest.raises(ValueError, match="archive SHA-256 mismatch"):
+        _archive_sha256(archive)

--- a/tests/test_pead_outcomes.py
+++ b/tests/test_pead_outcomes.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.pead_candidate import QuarterObservation, SueEvent, TriggeredSueEvent
+from app.services.pead_outcomes import (
+    EventOutcome,
+    OutcomeSummary,
+    _net_return_pct,
+    build_matched_control_events,
+    concurrency_counts,
+    earliest_entry_date,
+    segment_outcomes,
+)
+
+
+def _outcome(entry: date, net: float) -> EventOutcome:
+    return EventOutcome(
+        instrument_id=1,
+        issuer_cik="0000000001",
+        accession_number=f"a-{entry}",
+        side="long",
+        entry_date=entry,
+        exit_date=date(entry.year, min(entry.month + 2, 12), entry.day),
+        gross_return_pct=net,
+        net_return_pct=net,
+        net_return_5_pct=None,
+        net_return_20_pct=None,
+        net_return_40_pct=None,
+        market_relative_net_return_pct=None,
+        sector_relative_net_return_pct=None,
+        sector_symbol=None,
+    )
+
+
+def test_costs_reduce_both_long_and_short_returns() -> None:
+    long_gross, long_net = _net_return_pct("long", Decimal("100"), Decimal("110"))
+    short_gross, short_net = _net_return_pct("short", Decimal("100"), Decimal("90"))
+    assert long_gross == 10.0
+    assert short_gross == 10.0
+    assert long_net < long_gross
+    assert short_net < short_gross
+
+
+def test_short_return_direction_is_not_a_long_sign_flip() -> None:
+    _, profitable = _net_return_pct("short", Decimal("100"), Decimal("80"))
+    _, losing = _net_return_pct("short", Decimal("100"), Decimal("120"))
+    assert profitable > 0
+    assert losing < 0
+    assert abs(losing) > profitable
+
+
+def test_summary_reports_trade_distribution_without_fabricating_bootstrap() -> None:
+    summary = OutcomeSummary(
+        outcomes=(
+            _outcome(date(2024, 1, 2), 10.0),
+            _outcome(date(2024, 2, 2), -5.0),
+            _outcome(date(2024, 3, 2), -1.0),
+        ),
+        bootstrap=None,
+        refusals={},
+    )
+    assert summary.expectancy_pct == 4 / 3
+    assert summary.win_rate_pct == pytest.approx(100 / 3)
+    assert summary.profit_factor == 10 / 6
+    assert summary.worst_trade_pct == -5.0
+    assert summary.expected_shortfall_5_pct == -5.0
+
+
+def test_segments_are_closed_and_use_entry_date() -> None:
+    outcomes = tuple(_outcome(date(2024, month, 2), float(month)) for month in (1, 2, 3))
+    assert segment_outcomes(outcomes, date(2024, 2, 2), date(2024, 3, 2)) == outcomes[1:]
+
+
+def test_exact_acceptance_time_controls_the_earliest_open() -> None:
+    filed = date(2024, 6, 3)
+    assert earliest_entry_date(filed, datetime(2024, 6, 3, 13, 29, tzinfo=UTC)) == filed
+    assert earliest_entry_date(filed, datetime(2024, 6, 3, 13, 30, tzinfo=UTC)) == date(2024, 6, 4)
+    assert earliest_entry_date(filed, None) == date(2024, 6, 4)
+
+
+def test_naive_acceptance_time_is_refused() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        earliest_entry_date(date(2024, 6, 3), datetime(2024, 6, 3, 8, 0))
+
+
+def test_concurrency_counts_overlapping_calendar_spans() -> None:
+    outcomes = (
+        _outcome(date(2024, 1, 2), 1.0),
+        _outcome(date(2024, 2, 2), 1.0),
+    )
+    maximum, median_open = concurrency_counts(outcomes)
+    assert maximum == 2
+    assert median_open is not None
+    assert 1 <= median_open <= 2
+
+
+def _trigger(instrument_id: int, sue: float, side: str | None) -> TriggeredSueEvent:
+    observation = QuarterObservation(
+        instrument_id=instrument_id,
+        fiscal_year=2024,
+        fiscal_quarter=2,
+        value=Decimal("1"),
+        filed_date=date(2024, 5, instrument_id),
+        accepted_at=None,
+        accession_number=f"accession-{instrument_id}",
+        source_accessions=(f"accession-{instrument_id}",),
+        derived_q4=False,
+    )
+    return TriggeredSueEvent(
+        event=SueEvent(observation=observation, sue=sue),
+        lower_threshold=-2.0,
+        upper_threshold=2.0,
+        side=side,
+        threshold_population=200,
+    )
+
+
+def test_matched_controls_are_one_for_one_and_inherit_direction() -> None:
+    events = (
+        _trigger(1, 3.0, "long"),
+        _trigger(2, -3.0, "short"),
+        _trigger(3, 0.1, None),
+        _trigger(4, -0.1, None),
+    )
+    controls, census = build_matched_control_events(events, seed=7)
+    assert len(controls) == 2
+    assert {item.side for item in controls} == {"long", "short"}
+    assert {item.event.observation.instrument_id for item in controls} == {3, 4}
+    assert census == {"matched_control_events": 2, "signal_events_to_match": 2}

--- a/tests/test_trial_register.py
+++ b/tests/test_trial_register.py
@@ -54,6 +54,9 @@ class TestTheShippedDeclaration:
         """
         assert any(trial.startswith("rsi30") for trial in TRIAL_REGISTER.trial_ids)
 
+    def test_the_inconclusive_pead_trial_is_counted(self) -> None:
+        assert "pead-historical-sue-net-income-v1" in TRIAL_REGISTER.trial_ids
+
     def test_designed_but_unevaluated_rules_are_absent(self) -> None:
         """⚠ S-5 and S-6 are specified and blocked on #2279, never run.
 


### PR DESCRIPTION
Closes #2476.

## What changed

- freezes a published historical-SUE formulation over exact as-filed SEC `NetIncomeLoss` facts;
- streams the cached SEC companyfacts archive for deep history without expanding the hot database;
- deduplicates SEC issuers before causal percentile classification, then expands share classes only for causal liquidity selection;
- applies exact acceptance-time or conservative filed-date fill boundaries, price/liquidity floors, full-horizon quarantine and the frozen cost model;
- measures the fixed 62-session equal-gross long/short primary arm, separate long and short arms, 5/20/40-session diagnostics, SPY/sector relative returns, a seeded matched filing control and complete refusal census;
- appends the measured trial to the global trial register, raising M from 11 to 12.

## Why

The four visible strategies are harness-validation strategies and are not evidence-backed capital candidates. This spike tests a distinct, published fundamental anomaly without analyst-consensus data, future restatements, threshold search or database bloat.

The sealed result did **not** pass promotion: equal-gross expectancy was +0.440% with Bonferroni 95% joint CI [-2.866%, +3.763%]. The long-only arm was positive (+2.676%, CI [+0.141%, +5.005%]) but cannot inherit a pass from the failed primary identity. Full evidence is retained on issue #2476; follow-up is #2493.

## Invariants checked

- preregistration and implementation were committed before the single holdout read;
- controls were selected before any price query;
- historical missing `accepted_at` fills only after `filed_date`; live observation still requires exact acceptance time;
- one issuer filing contributes once to SUE thresholds and control matching;
- no later comparative fact or amendment rewrites an earlier signal;
- no parameter, horizon, TP, SL or trailing rule was selected after viewing results;
- archive bytes are hashed and checked against the retained SHA-256 sidecar;
- no persistent outcome rows or rolling indicators are added.

## Failure paths considered

Missing/ambiguous facts, fiscal gaps, duplicate slots, non-finite values, missing exact price sessions, incomplete 62-session outcomes, quarantined paths, low price/liquidity, missing comparators and depleted control cells are counted or refused. Survivor-only evidence, unmodelled carry/FX, portfolio sizing/drawdown/turnover/capacity and a bracket remain explicit promotion blockers.

## Security and audit model

No order, broker, allocation, deployment or execution path is touched. The outcome evaluator uses transaction-scoped temporary rows and explicitly rolls them back. The candidate is not added to the executable manifest.

## Tests added

Focused tests cover causal Q4 construction, exact 21-difference SUE arithmetic, discontinuous history, completed-quarter thresholds, issuer/share-class expansion timing, archive integrity, exact acceptance-time fills, side-aware costs, tail summaries, concurrency and deterministic matched controls.

Pre-push gate: Ruff and formatting clean, Pyright clean, 7,265 non-DB tests passed, 154 smoke tests passed, all repository chokepoint lints passed.

## Conscious tradeoffs

This is an effect screen, not a portfolio backtest. It intentionally refuses portfolio drawdown, turnover, capacity and paper allocation until a separately preregistered sizing trial exists. The short arm remains research-only. The free corpus is survivor-only and therefore still blocks capital promotion under the standing gate.

## Tech debt opened

- #2493: long-only historical-SUE portfolio and forward-shadow trial.