### PR TITLE
feat(#2499): freeze residual confluence trial

### DIFF
--- a/app/services/residual_confluence_candidate.py
+++ b/app/services/residual_confluence_candidate.py
@@ -1,0 +1,416 @@
+"""Causal feature and trade contract for research candidate #2499.
+
+This module deliberately contains no database loader, outcome reader, fitted
+coefficient or strategy-manifest entry.  It freezes the transformation that
+must be reviewed and tested before the recent outcome interval is opened.
+
+The candidate asks whether a stock-specific daily shock, after removing market
+and sector returns, has short-horizon reversal value when its completed candle,
+abnormal volume, liquidity and market-volatility context are considered
+together.  Five differently named price indicators are not independent
+confirmation; the one interaction below is fixed before measurement.
+
+Spec: ``docs/proposals/ta/2026-08-10-residual-confluence-preregistration.md``.
+Refs #2499, parent #2469.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+from statistics import median
+from typing import Final, Literal
+
+import numpy as np
+
+from app.services.cost_model import COST_MODEL_ID
+from app.services.research_comparator_snapshot import SNAPSHOT_ID
+from app.services.strategy_result import CORPUS_VERSION
+
+OLS_LOOKBACK: Final = 126
+RESIDUAL_VOL_LOOKBACK: Final = 20
+VOLUME_LOOKBACK: Final = 20
+MARKET_VOL_SHORT_LOOKBACK: Final = 20
+MARKET_VOL_LONG_LOOKBACK: Final = 252
+ATR_PERIOD: Final = 14
+
+MIN_SIGNAL_CLOSE: Final = Decimal("20")
+MIN_MEDIAN_DOLLAR_VOLUME: Final = Decimal("10000000")
+TARGET_ATR_MULTIPLE: Final = Decimal("1.5")
+STOP_ATR_MULTIPLE: Final = Decimal("1.0")
+MAX_HOLD_SESSIONS: Final = 5
+
+MODEL_FAMILY: Final = "multinomial-logistic"
+MODEL_L2_PENALTY: Final = Decimal("1.0")
+MODEL_CALIBRATION: Final = "none-fail-on-poor-raw-calibration"
+MODEL_OPTIMIZER: Final = "full-batch-gradient-descent-v1"
+MODEL_LEARNING_RATE: Final = Decimal("0.1")
+MODEL_MAX_ITERATIONS: Final = 10_000
+MODEL_GRADIENT_TOLERANCE: Final = Decimal("1e-9")
+MODEL_FEATURE_NAMES: Final = (
+    "shock_z",
+    "close_location",
+    "abnormal_volume",
+    "log_dollar_liquidity",
+    "market_stress",
+    "shock_x_location_x_volume",
+)
+
+
+class FeatureRefusal(ValueError):
+    """The point-in-time input cannot support the frozen feature contract."""
+
+
+@dataclass(frozen=True)
+class CandidateDefinition:
+    corpus_version: str = CORPUS_VERSION
+    comparator_snapshot_id: str = SNAPSHOT_ID
+    cost_model_id: str = COST_MODEL_ID
+    direction: str = "long_reversal"
+    ols_lookback: int = OLS_LOOKBACK
+    residual_vol_lookback: int = RESIDUAL_VOL_LOOKBACK
+    volume_lookback: int = VOLUME_LOOKBACK
+    market_vol_short_lookback: int = MARKET_VOL_SHORT_LOOKBACK
+    market_vol_long_lookback: int = MARKET_VOL_LONG_LOOKBACK
+    atr_period: int = ATR_PERIOD
+    min_signal_close: str = str(MIN_SIGNAL_CLOSE)
+    min_median_dollar_volume: str = str(MIN_MEDIAN_DOLLAR_VOLUME)
+    target_atr_multiple: str = str(TARGET_ATR_MULTIPLE)
+    stop_atr_multiple: str = str(STOP_ATR_MULTIPLE)
+    max_hold_sessions: int = MAX_HOLD_SESSIONS
+    model_family: str = MODEL_FAMILY
+    model_l2_penalty: str = str(MODEL_L2_PENALTY)
+    model_calibration: str = MODEL_CALIBRATION
+    model_optimizer: str = MODEL_OPTIMIZER
+    model_learning_rate: str = str(MODEL_LEARNING_RATE)
+    model_max_iterations: int = MODEL_MAX_ITERATIONS
+    model_gradient_tolerance: str = str(MODEL_GRADIENT_TOLERANCE)
+    model_features: tuple[str, ...] = MODEL_FEATURE_NAMES
+    feature_standardisation: str = "training-fold-mean-and-sample-std"
+    interaction_basis: str = "raw-shock_z*raw-close_location*raw-abnormal_volume"
+    outcome_classes: tuple[str, ...] = ("target_first", "stop_first", "timeout")
+    primary_start: str = "2022-01-01"
+
+
+DEFINITION: Final = CandidateDefinition()
+
+
+def definition_json() -> str:
+    """Canonical, reviewable identity.  No measured result enters this value."""
+    return json.dumps(asdict(DEFINITION), sort_keys=True, separators=(",", ":"))
+
+
+def definition_hash() -> str:
+    return hashlib.sha256(definition_json().encode()).hexdigest()
+
+
+CANDIDATE_VERSION: Final = f"residual-confluence-v1+{definition_hash()[:12]}"
+
+
+@dataclass(frozen=True)
+class ResidualConfluenceFeatures:
+    alpha: float
+    beta_market: float
+    beta_sector: float
+    residual_return: float
+    residual_volatility: float
+    shock_z: float
+    close_location: float
+    abnormal_volume: float
+    log_dollar_liquidity: float
+    market_stress: float
+    shock_x_location_x_volume: float
+
+    @property
+    def model_row(self) -> tuple[float, ...]:
+        return (
+            self.shock_z,
+            self.close_location,
+            self.abnormal_volume,
+            self.log_dollar_liquidity,
+            self.market_stress,
+            self.shock_x_location_x_volume,
+        )
+
+
+@dataclass(frozen=True)
+class ExitBracket:
+    target_price: Decimal
+    stop_price: Decimal
+    max_hold_sessions: int = MAX_HOLD_SESSIONS
+
+
+OutcomeClass = Literal["target_first", "stop_first", "timeout"]
+OUTCOME_CLASSES: Final[tuple[OutcomeClass, ...]] = ("target_first", "stop_first", "timeout")
+
+
+@dataclass(frozen=True)
+class FeatureStandardisation:
+    means: tuple[float, ...]
+    sample_stds: tuple[float, ...]
+
+    def transform(self, row: Sequence[float]) -> tuple[float, ...]:
+        if len(row) != len(MODEL_FEATURE_NAMES):
+            raise FeatureRefusal(f"model row requires {len(MODEL_FEATURE_NAMES)} features, got {len(row)}")
+        values = np.asarray(row, dtype=float)
+        if not np.isfinite(values).all():
+            raise FeatureRefusal("model row contains a missing or non-finite feature")
+        return tuple((values - np.asarray(self.means)) / np.asarray(self.sample_stds))
+
+
+@dataclass(frozen=True)
+class FittedConfluenceModel:
+    standardisation: FeatureStandardisation
+    # One softmax row per OUTCOME_CLASSES member; intercept is column zero.
+    weights: tuple[tuple[float, ...], ...]
+    iterations: int
+
+    def probabilities(self, row: Sequence[float]) -> dict[OutcomeClass, float]:
+        standardised = self.standardisation.transform(row)
+        design = np.asarray((1.0, *standardised), dtype=float)
+        scores = np.asarray(self.weights, dtype=float) @ design
+        scores -= float(np.max(scores))
+        exponentials = np.exp(scores)
+        probabilities = exponentials / float(np.sum(exponentials))
+        return {label: float(probabilities[index]) for index, label in enumerate(OUTCOME_CLASSES)}
+
+
+def _finite_vector(name: str, values: Sequence[float], *, exact: int) -> np.ndarray:
+    if len(values) != exact:
+        raise FeatureRefusal(f"{name} requires exactly {exact} observations, got {len(values)}")
+    array = np.asarray(values, dtype=float)
+    if array.shape != (exact,) or not np.isfinite(array).all():
+        raise FeatureRefusal(f"{name} contains a missing or non-finite observation")
+    return array
+
+
+def _finite_scalar(name: str, value: float) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise FeatureRefusal(f"{name} is non-finite")
+    return result
+
+
+def compute_features(
+    *,
+    prior_instrument_returns: Sequence[float],
+    prior_market_returns: Sequence[float],
+    prior_sector_returns: Sequence[float],
+    prior_market_stress_returns: Sequence[float],
+    prior_volumes: Sequence[float],
+    prior_dollar_volumes: Sequence[float],
+    signal_instrument_return: float,
+    signal_market_return: float,
+    signal_sector_return: float,
+    signal_open: float,
+    signal_high: float,
+    signal_low: float,
+    signal_close: float,
+    signal_volume: float,
+) -> ResidualConfluenceFeatures:
+    """Compute the completed signal-bar snapshot using prior history only.
+
+    The two-factor OLS and every trailing scale end at ``t-1``.  Only the
+    explicitly named signal values come from completed bar ``t``.  In
+    particular, neither a next-session open nor an outcome price is accepted by
+    this function, making that common leakage route impossible at the API.
+    """
+    instrument = _finite_vector("prior_instrument_returns", prior_instrument_returns, exact=OLS_LOOKBACK)
+    market = _finite_vector("prior_market_returns", prior_market_returns, exact=OLS_LOOKBACK)
+    sector = _finite_vector("prior_sector_returns", prior_sector_returns, exact=OLS_LOOKBACK)
+    market_stress_history = _finite_vector(
+        "prior_market_stress_returns", prior_market_stress_returns, exact=MARKET_VOL_LONG_LOOKBACK
+    )
+    volumes = _finite_vector("prior_volumes", prior_volumes, exact=VOLUME_LOOKBACK)
+    dollar_volumes = _finite_vector("prior_dollar_volumes", prior_dollar_volumes, exact=VOLUME_LOOKBACK)
+
+    if np.any(volumes <= 0) or np.any(dollar_volumes <= 0):
+        raise FeatureRefusal("prior volume and dollar-volume observations must be positive")
+
+    design = np.column_stack((np.ones(OLS_LOOKBACK), market, sector))
+    if int(np.linalg.matrix_rank(design)) != design.shape[1]:
+        raise FeatureRefusal("market and sector OLS design is rank deficient")
+    coefficients, *_ = np.linalg.lstsq(design, instrument, rcond=None)
+    alpha, beta_market, beta_sector = (float(item) for item in coefficients)
+    residual_history = instrument - design @ coefficients
+    residual_volatility = float(np.std(residual_history[-RESIDUAL_VOL_LOOKBACK:], ddof=1))
+    # An exact factor combination leaves only floating-point solver residue
+    # (~1e-18 in the fixture), not an economically meaningful volatility
+    # scale.  Machine epsilon is a numerical zero guard, not a fitted strategy
+    # threshold.
+    if not math.isfinite(residual_volatility) or residual_volatility <= np.finfo(float).eps:
+        raise FeatureRefusal("trailing residual volatility is unavailable or non-positive")
+
+    current_instrument = _finite_scalar("signal_instrument_return", signal_instrument_return)
+    current_market = _finite_scalar("signal_market_return", signal_market_return)
+    current_sector = _finite_scalar("signal_sector_return", signal_sector_return)
+    residual_return = current_instrument - alpha - beta_market * current_market - beta_sector * current_sector
+    shock_z = residual_return / residual_volatility
+
+    open_price = _finite_scalar("signal_open", signal_open)
+    high = _finite_scalar("signal_high", signal_high)
+    low = _finite_scalar("signal_low", signal_low)
+    close = _finite_scalar("signal_close", signal_close)
+    volume = _finite_scalar("signal_volume", signal_volume)
+    if min(open_price, high, low, close, volume) <= 0:
+        raise FeatureRefusal("signal OHLCV values must be positive")
+    if high < max(open_price, close) or low > min(open_price, close) or high <= low:
+        raise FeatureRefusal("signal bar has an invalid or zero-range OHLC envelope")
+    if Decimal(str(close)) < MIN_SIGNAL_CLOSE:
+        raise FeatureRefusal(f"signal close is below the frozen {MIN_SIGNAL_CLOSE} USD floor")
+
+    median_volume = float(median(float(item) for item in volumes))
+    median_dollar_volume = float(median(float(item) for item in dollar_volumes))
+    if Decimal(str(median_dollar_volume)) < MIN_MEDIAN_DOLLAR_VOLUME:
+        raise FeatureRefusal("trailing median dollar volume is below the frozen liquidity floor")
+    abnormal_volume = math.log(volume / median_volume)
+    log_dollar_liquidity = math.log(median_dollar_volume)
+    close_location = (2.0 * close - high - low) / (high - low)
+
+    short_market_vol = float(np.std(market_stress_history[-MARKET_VOL_SHORT_LOOKBACK:], ddof=1))
+    long_market_vol = float(np.std(market_stress_history, ddof=1))
+    if not math.isfinite(short_market_vol) or not math.isfinite(long_market_vol) or long_market_vol <= 0:
+        raise FeatureRefusal("market-stress volatility scale is unavailable or non-positive")
+    market_stress = short_market_vol / long_market_vol
+
+    result = ResidualConfluenceFeatures(
+        alpha=alpha,
+        beta_market=beta_market,
+        beta_sector=beta_sector,
+        residual_return=residual_return,
+        residual_volatility=residual_volatility,
+        shock_z=shock_z,
+        close_location=close_location,
+        abnormal_volume=abnormal_volume,
+        log_dollar_liquidity=log_dollar_liquidity,
+        market_stress=market_stress,
+        shock_x_location_x_volume=shock_z * close_location * abnormal_volume,
+    )
+    if not all(math.isfinite(item) for item in result.model_row):
+        raise FeatureRefusal("computed model feature is non-finite")
+    return result
+
+
+def build_exit_bracket(*, entry_price: Decimal, signal_atr: Decimal) -> ExitBracket:
+    """Fix the candidate's long bracket from ATR known on signal bar ``t``."""
+    if not entry_price.is_finite() or entry_price <= 0:
+        raise FeatureRefusal("entry price must be positive and finite")
+    if not signal_atr.is_finite() or signal_atr <= 0:
+        raise FeatureRefusal("signal ATR must be positive and finite")
+    target = entry_price + TARGET_ATR_MULTIPLE * signal_atr
+    stop = entry_price - STOP_ATR_MULTIPLE * signal_atr
+    if stop <= 0:
+        raise FeatureRefusal("ATR stop is non-positive and cannot be broker-orderable")
+    return ExitBracket(target_price=target, stop_price=stop)
+
+
+def _training_matrix(rows: Sequence[Sequence[float]]) -> tuple[np.ndarray, FeatureStandardisation]:
+    matrix = np.asarray(rows, dtype=float)
+    expected_columns = len(MODEL_FEATURE_NAMES)
+    if matrix.ndim != 2 or matrix.shape[1:] != (expected_columns,):
+        raise FeatureRefusal(f"training matrix requires shape (n, {expected_columns})")
+    if matrix.shape[0] < 2 or not np.isfinite(matrix).all():
+        raise FeatureRefusal("training matrix needs at least two finite rows")
+    means = np.mean(matrix, axis=0)
+    sample_stds = np.std(matrix, axis=0, ddof=1)
+    if not np.isfinite(sample_stds).all() or np.any(sample_stds <= np.finfo(float).eps):
+        raise FeatureRefusal("training feature has zero or unavailable sample variation")
+    standardisation = FeatureStandardisation(
+        tuple(float(item) for item in means), tuple(float(item) for item in sample_stds)
+    )
+    transformed = (matrix - means) / sample_stds
+    return np.column_stack((np.ones(matrix.shape[0]), transformed)), standardisation
+
+
+def fit_model(
+    rows: Sequence[Sequence[float]],
+    labels: Sequence[OutcomeClass],
+) -> FittedConfluenceModel:
+    """Fit the frozen deterministic softmax model on one training fold only.
+
+    The objective is mean multiclass cross-entropy plus
+    ``0.5 * L2 * sum(non_intercept_weight**2)``.  Standardisation is learned
+    from these rows and travels with the fitted model; callers cannot supply a
+    full-period scale that would leak validation or holdout observations.
+    """
+    design, standardisation = _training_matrix(rows)
+    if len(labels) != design.shape[0]:
+        raise FeatureRefusal(f"training labels count {len(labels)} does not match row count {design.shape[0]}")
+    unknown = set(labels) - set(OUTCOME_CLASSES)
+    if unknown:
+        raise FeatureRefusal(f"unknown outcome class(es): {sorted(unknown)}")
+    missing = set(OUTCOME_CLASSES) - set(labels)
+    if missing:
+        raise FeatureRefusal(f"training fold is missing outcome class(es): {sorted(missing)}")
+
+    class_index = {label: index for index, label in enumerate(OUTCOME_CLASSES)}
+    target = np.zeros((design.shape[0], len(OUTCOME_CLASSES)), dtype=float)
+    target[np.arange(design.shape[0]), [class_index[label] for label in labels]] = 1.0
+    weights = np.zeros((len(OUTCOME_CLASSES), design.shape[1]), dtype=float)
+    learning_rate = float(MODEL_LEARNING_RATE)
+    penalty = float(MODEL_L2_PENALTY)
+    tolerance = float(MODEL_GRADIENT_TOLERANCE)
+
+    for iteration in range(1, MODEL_MAX_ITERATIONS + 1):
+        scores = design @ weights.T
+        scores -= np.max(scores, axis=1, keepdims=True)
+        exponentials = np.exp(scores)
+        probabilities = exponentials / np.sum(exponentials, axis=1, keepdims=True)
+        gradient = (probabilities - target).T @ design / design.shape[0]
+        gradient[:, 1:] += penalty * weights[:, 1:]
+        weights -= learning_rate * gradient
+        if float(np.max(np.abs(gradient))) <= tolerance:
+            return FittedConfluenceModel(
+                standardisation=standardisation,
+                weights=tuple(tuple(float(value) for value in row) for row in weights),
+                iterations=iteration,
+            )
+    raise FeatureRefusal(f"multinomial model did not converge in {MODEL_MAX_ITERATIONS} frozen iterations")
+
+
+def expected_net_value_pct(
+    probabilities: dict[OutcomeClass, float],
+    *,
+    target_payoff_pct: float,
+    stop_loss_pct: float,
+    expected_timeout_payoff_pct: float,
+    total_cost_pct: float,
+) -> float:
+    """Apply the declared probability-to-trade equation, without a threshold."""
+    if set(probabilities) != set(OUTCOME_CLASSES):
+        raise FeatureRefusal("net EV requires exactly the three declared outcome probabilities")
+    values = tuple(probabilities[label] for label in OUTCOME_CLASSES)
+    if any(not math.isfinite(item) or item < 0 or item > 1 for item in values) or not math.isclose(
+        sum(values), 1.0, rel_tol=0, abs_tol=1e-9
+    ):
+        raise FeatureRefusal("outcome probabilities must be finite, bounded and sum to one")
+    payoffs = (target_payoff_pct, stop_loss_pct, expected_timeout_payoff_pct, total_cost_pct)
+    if any(not math.isfinite(float(item)) for item in payoffs) or stop_loss_pct < 0 or total_cost_pct < 0:
+        raise FeatureRefusal("net EV payoffs/costs are invalid")
+    return (
+        probabilities["target_first"] * target_payoff_pct
+        - probabilities["stop_first"] * stop_loss_pct
+        + probabilities["timeout"] * expected_timeout_payoff_pct
+        - total_cost_pct
+    )
+
+
+__all__ = [
+    "ATR_PERIOD",
+    "CANDIDATE_VERSION",
+    "DEFINITION",
+    "FeatureRefusal",
+    "FittedConfluenceModel",
+    "MODEL_FEATURE_NAMES",
+    "ResidualConfluenceFeatures",
+    "build_exit_bracket",
+    "compute_features",
+    "definition_hash",
+    "definition_json",
+    "expected_net_value_pct",
+    "fit_model",
+]

--- a/app/services/residual_confluence_candidate.py
+++ b/app/services/residual_confluence_candidate.py
@@ -154,6 +154,17 @@ class FeatureStandardisation:
     means: tuple[float, ...]
     sample_stds: tuple[float, ...]
 
+    def __post_init__(self) -> None:
+        expected = len(MODEL_FEATURE_NAMES)
+        if len(self.means) != expected or len(self.sample_stds) != expected:
+            raise FeatureRefusal(f"standardisation requires {expected} means and sample standard deviations")
+        means = np.asarray(self.means, dtype=float)
+        sample_stds = np.asarray(self.sample_stds, dtype=float)
+        if not np.isfinite(means).all() or not np.isfinite(sample_stds).all():
+            raise FeatureRefusal("standardisation contains a non-finite value")
+        if np.any(sample_stds <= np.finfo(float).eps):
+            raise FeatureRefusal("standardisation sample deviation is zero or unavailable")
+
     def transform(self, row: Sequence[float]) -> tuple[float, ...]:
         if len(row) != len(MODEL_FEATURE_NAMES):
             raise FeatureRefusal(f"model row requires {len(MODEL_FEATURE_NAMES)} features, got {len(row)}")
@@ -253,13 +264,16 @@ def compute_features(
     open_price = _finite_scalar("signal_open", signal_open)
     high = _finite_scalar("signal_high", signal_high)
     low = _finite_scalar("signal_low", signal_low)
+    signal_close_decimal = Decimal(str(signal_close))
+    if not signal_close_decimal.is_finite():
+        raise FeatureRefusal("signal_close is non-finite")
     close = _finite_scalar("signal_close", signal_close)
     volume = _finite_scalar("signal_volume", signal_volume)
     if min(open_price, high, low, close, volume) <= 0:
         raise FeatureRefusal("signal OHLCV values must be positive")
     if high < max(open_price, close) or low > min(open_price, close) or high <= low:
         raise FeatureRefusal("signal bar has an invalid or zero-range OHLC envelope")
-    if Decimal(str(close)) < MIN_SIGNAL_CLOSE:
+    if signal_close_decimal < MIN_SIGNAL_CLOSE:
         raise FeatureRefusal(f"signal close is below the frozen {MIN_SIGNAL_CLOSE} USD floor")
 
     median_volume = float(median(float(item) for item in volumes))

--- a/app/services/residual_confluence_candidate.py
+++ b/app/services/residual_confluence_candidate.py
@@ -60,6 +60,9 @@ MODEL_FEATURE_NAMES: Final = (
     "shock_x_location_x_volume",
 )
 
+OutcomeClass = Literal["target_first", "stop_first", "timeout"]
+OUTCOME_CLASSES: Final[tuple[OutcomeClass, ...]] = ("target_first", "stop_first", "timeout")
+
 
 class FeatureRefusal(ValueError):
     """The point-in-time input cannot support the frozen feature contract."""
@@ -92,7 +95,9 @@ class CandidateDefinition:
     model_features: tuple[str, ...] = MODEL_FEATURE_NAMES
     feature_standardisation: str = "training-fold-mean-and-sample-std"
     interaction_basis: str = "raw-shock_z*raw-close_location*raw-abnormal_volume"
-    outcome_classes: tuple[str, ...] = ("target_first", "stop_first", "timeout")
+    market_history_alignment: str = "factor-market-is-last-126-of-required-prior-252"
+    liquidity_input: str = "prior-20-close*volume-computed-in-feature-engine"
+    outcome_classes: tuple[str, ...] = OUTCOME_CLASSES
     primary_start: str = "2022-01-01"
 
 
@@ -142,10 +147,6 @@ class ExitBracket:
     target_price: Decimal
     stop_price: Decimal
     max_hold_sessions: int = MAX_HOLD_SESSIONS
-
-
-OutcomeClass = Literal["target_first", "stop_first", "timeout"]
-OUTCOME_CLASSES: Final[tuple[OutcomeClass, ...]] = ("target_first", "stop_first", "timeout")
 
 
 @dataclass(frozen=True)
@@ -200,9 +201,8 @@ def compute_features(
     prior_instrument_returns: Sequence[float],
     prior_market_returns: Sequence[float],
     prior_sector_returns: Sequence[float],
-    prior_market_stress_returns: Sequence[float],
+    prior_closes: Sequence[float],
     prior_volumes: Sequence[float],
-    prior_dollar_volumes: Sequence[float],
     signal_instrument_return: float,
     signal_market_return: float,
     signal_sector_return: float,
@@ -220,16 +220,15 @@ def compute_features(
     this function, making that common leakage route impossible at the API.
     """
     instrument = _finite_vector("prior_instrument_returns", prior_instrument_returns, exact=OLS_LOOKBACK)
-    market = _finite_vector("prior_market_returns", prior_market_returns, exact=OLS_LOOKBACK)
+    market_history = _finite_vector("prior_market_returns", prior_market_returns, exact=MARKET_VOL_LONG_LOOKBACK)
+    market = market_history[-OLS_LOOKBACK:]
     sector = _finite_vector("prior_sector_returns", prior_sector_returns, exact=OLS_LOOKBACK)
-    market_stress_history = _finite_vector(
-        "prior_market_stress_returns", prior_market_stress_returns, exact=MARKET_VOL_LONG_LOOKBACK
-    )
+    closes = _finite_vector("prior_closes", prior_closes, exact=VOLUME_LOOKBACK)
     volumes = _finite_vector("prior_volumes", prior_volumes, exact=VOLUME_LOOKBACK)
-    dollar_volumes = _finite_vector("prior_dollar_volumes", prior_dollar_volumes, exact=VOLUME_LOOKBACK)
 
-    if np.any(volumes <= 0) or np.any(dollar_volumes <= 0):
-        raise FeatureRefusal("prior volume and dollar-volume observations must be positive")
+    if np.any(closes <= 0) or np.any(volumes <= 0):
+        raise FeatureRefusal("prior close and volume observations must be positive")
+    dollar_volumes = closes * volumes
 
     design = np.column_stack((np.ones(OLS_LOOKBACK), market, sector))
     if int(np.linalg.matrix_rank(design)) != design.shape[1]:
@@ -271,8 +270,8 @@ def compute_features(
     log_dollar_liquidity = math.log(median_dollar_volume)
     close_location = (2.0 * close - high - low) / (high - low)
 
-    short_market_vol = float(np.std(market_stress_history[-MARKET_VOL_SHORT_LOOKBACK:], ddof=1))
-    long_market_vol = float(np.std(market_stress_history, ddof=1))
+    short_market_vol = float(np.std(market_history[-MARKET_VOL_SHORT_LOOKBACK:], ddof=1))
+    long_market_vol = float(np.std(market_history, ddof=1))
     if not math.isfinite(short_market_vol) or not math.isfinite(long_market_vol) or long_market_vol <= 0:
         raise FeatureRefusal("market-stress volatility scale is unavailable or non-positive")
     market_stress = short_market_vol / long_market_vol

--- a/docs/proposals/ta/2026-08-10-residual-confluence-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-residual-confluence-preregistration.md
@@ -1,0 +1,144 @@
+# Residual-shock confluence candidate preregistration
+
+Status: feature and model definition frozen before outcome measurement for
+#2499. Parent #2469.
+
+## Hypothesis and scope
+
+This is a **long short-horizon residual-reversal** test. It asks whether an
+instrument-specific negative daily shock has target-before-stop information
+when the completed candle location, abnormal volume, liquidity and market
+volatility state are consumed together. It is not a vote across technical
+indicators and does not inherit evidence from S-1 through S-4.
+
+The economic hypothesis is liquidity provision after a stock-specific shock.
+Nagel's short-term-reversal evidence makes market stress a declared conditioner;
+Gu, Kelly and Xiu motivate a small interaction of price trend, liquidity and
+volatility. Neither paper establishes that this exact retail-costed rule works.
+
+## Frozen identities and universe
+
+- equity corpus: `paperswithbacktest/Stocks-Daily-Price@2026-07-08`;
+- comparator snapshot: `etoro-comparators-2026-07-08-v1`;
+- US common equities with exact research `instrument_id`, SEC SIC to sector-SPDR
+  mapping, market/sector comparator sessions and quarantine coverage;
+- signal close at least USD 20;
+- prior-20-session median dollar volume at least USD 10m;
+- survivor-only and unresolved delisting limitations remain explicit promotion
+  refusals; this trial cannot relabel the corpus survivorship-free.
+
+Every constant and identity is emitted by
+`app.services.residual_confluence_candidate.definition_json()` and SHA-256
+fingerprinted. No measured coefficient or outcome enters that identity.
+
+## Point-in-time features
+
+All returns are log returns on exact common sessions. At completed session `t`,
+fit this OLS on exactly `t-126..t-1`:
+
+```text
+r_i,d = alpha + beta_market*r_market,d + beta_sector*r_sector,d + epsilon_d
+```
+
+The current residual includes the fitted intercept (a correction recorded on
+#2499 before outcome access):
+
+```text
+residual_t       = r_i,t - alpha - beta_market*r_market,t
+                         - beta_sector*r_sector,t
+sigma_resid_t    = sample_std(epsilon[t-20..t-1])
+shock_z_t        = residual_t / sigma_resid_t
+close_location_t = (2*close_t - high_t - low_t) / (high_t - low_t)
+abnormal_volume  = ln(volume_t / median(volume[t-20..t-1]))
+liquidity        = ln(median(close*volume[t-20..t-1]))
+market_stress    = sample_std(r_market[t-20..t-1])
+                   / sample_std(r_market[t-252..t-1])
+```
+
+The 252-session market history is mandatory. The earlier issue wording that
+mentioned only 126 sessions was corrected before measurement. Missing exact
+sessions, rank-deficient market/sector regressors, zero residual volatility,
+zero-range candles, non-positive volume or non-finite inputs refuse the row.
+
+## Fixed model
+
+The first model is multinomial logistic regression for
+`target_first | stop_first | timeout`, with L2 penalty exactly `1.0`. Its
+objective is mean multiclass cross-entropy plus `0.5 * L2` times the sum of
+squared non-intercept weights. It uses deterministic full-batch gradient descent
+(learning rate 0.1, at most 10,000 iterations, maximum absolute gradient at most
+1e-9). These optimiser values affect reproduction, not candidate selection.
+Every
+continuous column is standardised using training-fold mean and sample standard
+deviation only. The columns are exactly:
+
+```text
+shock_z
+close_location
+abnormal_volume
+log_dollar_liquidity
+market_stress
+shock_z * close_location * abnormal_volume
+```
+
+The interaction is formed from the raw three features and is then standardised
+like the other columns. No subset, threshold, sign, transformation, penalty,
+tree or barrier search is permitted. There is no post-hoc probability
+calibrator in v1: raw multinomial probabilities must pass Brier, log-loss and
+calibration checks or the candidate fails.
+
+## Entry and outcome
+
+- direction: long only;
+- fill: next executable session open after signal `t`;
+- target: entry plus 1.5 times Wilder ATR14 known at `t`;
+- stop: entry minus 1.0 times the same ATR14;
+- timeout: close of the fifth subsequent trading session, counting the entry
+  session as session one;
+- a gap through a barrier fills at the first executable open;
+- a daily bar touching target and stop is retained in separate best/worst arms
+  and never resolved optimistically.
+
+Net expected value is:
+
+```text
+p_target*target_payoff - p_stop*stop_loss
++ p_timeout*expected_timeout_payoff
+- spread - slippage - carry - FX
+```
+
+A feature match is not pending. After a completed bar it either produces a
+positive lower estimate of net EV or records a refusal. Before completion there
+is no signal.
+
+## Validation and one-read rule
+
+- primary relevance begins 2022-01-01;
+- use calendar-blocked walk-forward training with purging and embargo at least
+  five sessions;
+- keep one untouched terminal interval; once read, it is contaminated forever;
+- report latest 24/36 months and each recent calendar year separately;
+- older history is stress evidence only;
+- compare raw-return shock, market-only residual, market+sector residual and
+  matched random entries as declared arms with family-wise error treatment;
+- bootstrap calendar blocks at least five sessions and cluster same-day events;
+- report expectancy and confidence interval, target/stop/timeout calibration,
+  profit factor, drawdown, expected shortfall, worst gap, turnover, concurrency,
+  concentration and result excluding the best 1%;
+- report monotonicity by predicted-EV decile, MAE/MFE, one-session entry delay,
+  stressed cost and fixed-seed missed-trade diagnostics;
+- every year/regime/liquidity/sector/strength slice is diagnostic. A successful
+  post-hoc slice becomes a new preregistered future trial and cannot promote
+  this one.
+
+## Promotion and storage
+
+Historical success promotes only to zero-capital forward observation. Capital
+still requires a positive lower confidence bound on after-cost expectancy,
+stable recent slices, acceptable calibration/tails/capacity, current eToro
+eligibility and cost inputs, exact order/position reconciliation and every
+standing live gate.
+
+Persist only the immutable definition/evidence, one fired/refused feature
+snapshot, one terminal outcome and material execution events. Do not persist
+rolling features, every no-op evaluation, polling history or model snapshots.

--- a/docs/proposals/ta/2026-08-10-residual-confluence-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-residual-confluence-preregistration.md
@@ -59,6 +59,11 @@ The 252-session market history is mandatory. The earlier issue wording that
 mentioned only 126 sessions was corrected before measurement. Missing exact
 sessions, rank-deficient market/sector regressors, zero residual volatility,
 zero-range candles, non-positive volume or non-finite inputs refuse the row.
+The factor regression consumes the final 126 observations of that same
+252-session market vector; callers cannot supply two inconsistent market
+histories. Dollar volume is computed inside the feature engine from the same 20
+prior closes and volumes rather than accepted as a second, potentially
+inconsistent input.
 
 ## Fixed model
 

--- a/tests/test_residual_confluence_candidate.py
+++ b/tests/test_residual_confluence_candidate.py
@@ -33,11 +33,10 @@ def _inputs() -> dict[str, object]:
     instrument = [0.0001 + 1.2 * m + 0.7 * s + e for m, s, e in zip(market, sector, residual, strict=True)]
     return {
         "prior_instrument_returns": instrument,
-        "prior_market_returns": market,
+        "prior_market_returns": market_stress,
         "prior_sector_returns": sector,
-        "prior_market_stress_returns": market_stress,
+        "prior_closes": [30.0 + i / 10 for i in range(20)],
         "prior_volumes": [1_000_000 + i * 1_000 for i in range(20)],
-        "prior_dollar_volumes": [30_000_000 + i * 100_000 for i in range(20)],
         "signal_instrument_return": -0.025,
         "signal_market_return": -0.004,
         "signal_sector_return": -0.006,
@@ -51,8 +50,8 @@ def _inputs() -> dict[str, object]:
 
 def test_definition_is_complete_stable_and_contains_no_measured_result() -> None:
     payload = definition_json()
-    assert definition_hash() == "a64d0683dd125367150c1a3746094a08cc015bbff524741abe0a909863e97bbd"
-    assert CANDIDATE_VERSION == "residual-confluence-v1+a64d0683dd12"
+    assert definition_hash() == "a5084b66774625c0ff3fec05c238c05dae75b8663ddfd7b269265d134ccca0d8"
+    assert CANDIDATE_VERSION == "residual-confluence-v1+a5084b667746"
     assert DEFINITION.market_vol_long_lookback == 252
     assert DEFINITION.model_features == MODEL_FEATURE_NAMES
     assert "expectancy" not in payload
@@ -97,10 +96,10 @@ def test_appending_future_values_cannot_change_snapshot() -> None:
 @pytest.mark.parametrize(
     ("field", "replacement", "message"),
     [
-        ("prior_market_stress_returns", [0.01] * 251, "exactly 252"),
+        ("prior_market_returns", [0.01] * 251, "exactly 252"),
         ("prior_sector_returns", [0.0] * 126, "rank deficient"),
         ("prior_volumes", [0.0] * 20, "must be positive"),
-        ("prior_dollar_volumes", [1_000_000.0] * 20, "liquidity floor"),
+        ("prior_closes", [0.9] * 20, "liquidity floor"),
         ("signal_high", 24.0, "OHLC envelope"),
         ("signal_volume", float("nan"), "non-finite"),
     ],
@@ -126,7 +125,7 @@ def test_price_floor_is_checked_after_a_valid_ohlc_envelope() -> None:
 
 def test_zero_residual_volatility_is_refused() -> None:
     inputs = _inputs()
-    market = inputs["prior_market_returns"]
+    market = inputs["prior_market_returns"][-126:]  # type: ignore[index]
     sector = inputs["prior_sector_returns"]
     inputs["prior_instrument_returns"] = [
         0.0001 + 1.2 * m + 0.7 * s
@@ -148,7 +147,7 @@ def test_bracket_is_fixed_from_signal_atr_and_refuses_unorderable_stop() -> None
 def test_market_stress_is_sample_std_ratio_not_level_or_future_return() -> None:
     inputs = _inputs()
     features = compute_features(**inputs)  # type: ignore[arg-type]
-    history = np.asarray(inputs["prior_market_stress_returns"], dtype=float)
+    history = np.asarray(inputs["prior_market_returns"], dtype=float)
     expected = float(np.std(history[-20:], ddof=1) / np.std(history, ddof=1))
     assert features.market_stress == pytest.approx(expected)
 

--- a/tests/test_residual_confluence_candidate.py
+++ b/tests/test_residual_confluence_candidate.py
@@ -11,6 +11,7 @@ from app.services.residual_confluence_candidate import (
     DEFINITION,
     MODEL_FEATURE_NAMES,
     FeatureRefusal,
+    FeatureStandardisation,
     build_exit_bracket,
     compute_features,
     definition_hash,
@@ -123,6 +124,18 @@ def test_price_floor_is_checked_after_a_valid_ohlc_envelope() -> None:
         compute_features(**inputs)  # type: ignore[arg-type]
 
 
+def test_price_floor_uses_original_decimal_without_float_round_trip() -> None:
+    inputs = _inputs()
+    inputs.update(
+        signal_open=Decimal("20"),
+        signal_high=Decimal("20.5"),
+        signal_low=Decimal("19.5"),
+        signal_close=Decimal("19.999999999999999999"),
+    )
+    with pytest.raises(FeatureRefusal, match="20 USD floor"):
+        compute_features(**inputs)  # type: ignore[arg-type]
+
+
 def test_zero_residual_volatility_is_refused() -> None:
     inputs = _inputs()
     market = inputs["prior_market_returns"][-126:]  # type: ignore[index]
@@ -198,6 +211,22 @@ def test_model_refuses_zero_variation_missing_class_and_unknown_label() -> None:
     bad_labels[0] = "profit"
     with pytest.raises(FeatureRefusal, match="unknown outcome"):
         fit_model(rows, bad_labels)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("means", "sample_stds", "message"),
+    [
+        ((0.0,) * 5, (1.0,) * 6, "requires 6"),
+        ((0.0,) * 6, (1.0,) * 5, "requires 6"),
+        ((0.0,) * 5 + (float("nan"),), (1.0,) * 6, "non-finite"),
+        ((0.0,) * 6, (1.0,) * 5 + (0.0,), "zero or unavailable"),
+    ],
+)
+def test_standardisation_cannot_be_constructed_with_unsafe_scales(
+    means: tuple[float, ...], sample_stds: tuple[float, ...], message: str
+) -> None:
+    with pytest.raises(FeatureRefusal, match=message):
+        FeatureStandardisation(means, sample_stds)
 
 
 def test_expected_net_value_uses_all_outcomes_and_costs() -> None:

--- a/tests/test_residual_confluence_candidate.py
+++ b/tests/test_residual_confluence_candidate.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+
+import numpy as np
+import pytest
+
+from app.services.residual_confluence_candidate import (
+    CANDIDATE_VERSION,
+    DEFINITION,
+    MODEL_FEATURE_NAMES,
+    FeatureRefusal,
+    build_exit_bracket,
+    compute_features,
+    definition_hash,
+    definition_json,
+    expected_net_value_pct,
+    fit_model,
+)
+
+
+def _inputs() -> dict[str, object]:
+    market_stress = [0.001 + 0.0002 * math.sin(i / 7) for i in range(252)]
+    market = market_stress[-126:]
+    sector = [0.0005 + 0.0003 * math.cos(i / 9) for i in range(126)]
+    # Make a non-zero residual exactly orthogonal to the OLS design so this
+    # fixture can independently pin alpha/betas rather than merely repeat the
+    # implementation's least-squares answer.
+    design = np.column_stack((np.ones(126), market, sector))
+    raw_residual = np.asarray([0.0004 * math.sin(i / 5) for i in range(126)])
+    residual = raw_residual - design @ np.linalg.lstsq(design, raw_residual, rcond=None)[0]
+    instrument = [0.0001 + 1.2 * m + 0.7 * s + e for m, s, e in zip(market, sector, residual, strict=True)]
+    return {
+        "prior_instrument_returns": instrument,
+        "prior_market_returns": market,
+        "prior_sector_returns": sector,
+        "prior_market_stress_returns": market_stress,
+        "prior_volumes": [1_000_000 + i * 1_000 for i in range(20)],
+        "prior_dollar_volumes": [30_000_000 + i * 100_000 for i in range(20)],
+        "signal_instrument_return": -0.025,
+        "signal_market_return": -0.004,
+        "signal_sector_return": -0.006,
+        "signal_open": 26.0,
+        "signal_high": 27.0,
+        "signal_low": 24.0,
+        "signal_close": 24.5,
+        "signal_volume": 2_500_000,
+    }
+
+
+def test_definition_is_complete_stable_and_contains_no_measured_result() -> None:
+    payload = definition_json()
+    assert definition_hash() == "a64d0683dd125367150c1a3746094a08cc015bbff524741abe0a909863e97bbd"
+    assert CANDIDATE_VERSION == "residual-confluence-v1+a64d0683dd12"
+    assert DEFINITION.market_vol_long_lookback == 252
+    assert DEFINITION.model_features == MODEL_FEATURE_NAMES
+    assert "expectancy" not in payload
+    assert "coefficient" not in payload
+
+
+def test_features_recover_prior_factor_model_and_use_current_completed_bar() -> None:
+    features = compute_features(**_inputs())  # type: ignore[arg-type]
+    assert features.alpha == pytest.approx(0.0001, abs=1e-9)
+    assert features.beta_market == pytest.approx(1.2, abs=1e-9)
+    assert features.beta_sector == pytest.approx(0.7, abs=1e-9)
+    assert features.residual_return == pytest.approx(-0.0161, abs=1e-9)
+    assert features.shock_z < 0
+    assert features.close_location == pytest.approx(-2 / 3)
+    assert features.abnormal_volume > 0
+    assert features.market_stress > 0
+    assert features.shock_x_location_x_volume == pytest.approx(
+        features.shock_z * features.close_location * features.abnormal_volume
+    )
+    assert features.model_row == (
+        features.shock_z,
+        features.close_location,
+        features.abnormal_volume,
+        features.log_dollar_liquidity,
+        features.market_stress,
+        features.shock_x_location_x_volume,
+    )
+
+
+def test_appending_future_values_cannot_change_snapshot() -> None:
+    inputs = _inputs()
+    baseline = compute_features(**inputs)  # type: ignore[arg-type]
+    # The API requires exact causal windows. Passing an appended outcome/future
+    # value is refused instead of being silently truncated into the calculation.
+    future = dict(inputs)
+    future["prior_instrument_returns"] = [*inputs["prior_instrument_returns"], 99.0]  # type: ignore[misc]
+    with pytest.raises(FeatureRefusal, match="exactly 126"):
+        compute_features(**future)  # type: ignore[arg-type]
+    assert compute_features(**inputs) == baseline  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement", "message"),
+    [
+        ("prior_market_stress_returns", [0.01] * 251, "exactly 252"),
+        ("prior_sector_returns", [0.0] * 126, "rank deficient"),
+        ("prior_volumes", [0.0] * 20, "must be positive"),
+        ("prior_dollar_volumes", [1_000_000.0] * 20, "liquidity floor"),
+        ("signal_high", 24.0, "OHLC envelope"),
+        ("signal_volume", float("nan"), "non-finite"),
+    ],
+)
+def test_missing_or_unsafe_feature_input_fails_closed(field: str, replacement: object, message: str) -> None:
+    inputs = _inputs()
+    inputs[field] = replacement
+    with pytest.raises(FeatureRefusal, match=message):
+        compute_features(**inputs)  # type: ignore[arg-type]
+
+
+def test_price_floor_is_checked_after_a_valid_ohlc_envelope() -> None:
+    inputs = _inputs()
+    inputs.update(
+        signal_open=Decimal("19.75"),
+        signal_high=Decimal("20.5"),
+        signal_low=Decimal("19"),
+        signal_close=Decimal("19.99"),
+    )
+    with pytest.raises(FeatureRefusal, match="20 USD floor"):
+        compute_features(**inputs)  # type: ignore[arg-type]
+
+
+def test_zero_residual_volatility_is_refused() -> None:
+    inputs = _inputs()
+    market = inputs["prior_market_returns"]
+    sector = inputs["prior_sector_returns"]
+    inputs["prior_instrument_returns"] = [
+        0.0001 + 1.2 * m + 0.7 * s
+        for m, s in zip(market, sector, strict=True)  # type: ignore[arg-type]
+    ]
+    with pytest.raises(FeatureRefusal, match="residual volatility"):
+        compute_features(**inputs)  # type: ignore[arg-type]
+
+
+def test_bracket_is_fixed_from_signal_atr_and_refuses_unorderable_stop() -> None:
+    bracket = build_exit_bracket(entry_price=Decimal("25"), signal_atr=Decimal("2"))
+    assert bracket.target_price == Decimal("28.0")
+    assert bracket.stop_price == Decimal("23.0")
+    assert bracket.max_hold_sessions == 5
+    with pytest.raises(FeatureRefusal, match="non-positive"):
+        build_exit_bracket(entry_price=Decimal("1"), signal_atr=Decimal("2"))
+
+
+def test_market_stress_is_sample_std_ratio_not_level_or_future_return() -> None:
+    inputs = _inputs()
+    features = compute_features(**inputs)  # type: ignore[arg-type]
+    history = np.asarray(inputs["prior_market_stress_returns"], dtype=float)
+    expected = float(np.std(history[-20:], ddof=1) / np.std(history, ddof=1))
+    assert features.market_stress == pytest.approx(expected)
+
+
+def _model_population() -> tuple[list[tuple[float, ...]], list[str]]:
+    rows: list[tuple[float, ...]] = []
+    labels: list[str] = []
+    for index in range(90):
+        shock = -2.0 + index * 4.0 / 89.0
+        location = math.sin(index / 7)
+        abnormal_volume = math.cos(index / 11)
+        row = (
+            shock,
+            location,
+            abnormal_volume,
+            17.0 + index / 100,
+            0.8 + index / 200,
+            shock * location * abnormal_volume,
+        )
+        rows.append(row)
+        labels.append("target_first" if shock < -0.6 else "stop_first" if shock > 0.6 else "timeout")
+    return rows, labels
+
+
+def test_fitted_model_is_deterministic_training_only_and_probabilities_sum_to_one() -> None:
+    rows, labels = _model_population()
+    first = fit_model(rows, labels)  # type: ignore[arg-type]
+    second = fit_model(rows, labels)  # type: ignore[arg-type]
+    assert first == second
+    probabilities = first.probabilities(rows[0])
+    assert sum(probabilities.values()) == pytest.approx(1.0)
+    assert probabilities["target_first"] > probabilities["stop_first"]
+    # A future/holdout row is transformed by, but cannot alter, the stored
+    # training-fold means and scales.
+    baseline_standardisation = first.standardisation
+    first.probabilities((99, 0, 0, 18, 1, 0))
+    assert first.standardisation == baseline_standardisation
+
+
+def test_model_refuses_zero_variation_missing_class_and_unknown_label() -> None:
+    rows, labels = _model_population()
+    flat = [tuple(1.0 for _ in MODEL_FEATURE_NAMES) for _ in labels]
+    with pytest.raises(FeatureRefusal, match="zero or unavailable"):
+        fit_model(flat, labels)  # type: ignore[arg-type]
+    with pytest.raises(FeatureRefusal, match="missing outcome"):
+        fit_model(rows[:20], ["target_first"] * 20)  # type: ignore[arg-type]
+    bad_labels = list(labels)
+    bad_labels[0] = "profit"
+    with pytest.raises(FeatureRefusal, match="unknown outcome"):
+        fit_model(rows, bad_labels)  # type: ignore[arg-type]
+
+
+def test_expected_net_value_uses_all_outcomes_and_costs() -> None:
+    result = expected_net_value_pct(
+        {"target_first": 0.55, "stop_first": 0.30, "timeout": 0.15},
+        target_payoff_pct=3.0,
+        stop_loss_pct=2.0,
+        expected_timeout_payoff_pct=-0.2,
+        total_cost_pct=0.25,
+    )
+    assert result == pytest.approx(0.77)
+    with pytest.raises(FeatureRefusal, match="sum to one"):
+        expected_net_value_pct(
+            {"target_first": 0.8, "stop_first": 0.8, "timeout": 0.1},
+            target_payoff_pct=3,
+            stop_loss_pct=2,
+            expected_timeout_payoff_pct=0,
+            total_cost_pct=0.2,
+        )


### PR DESCRIPTION
## Issue reference

Refs #2499
Refs #2469

## Summary

Freezes the causal feature, model and bracket contract for the first explicit independent-factor confluence candidate before any outcome is opened.

- removes market and sector returns with a prior-only 126-session factor regression;
- derives that factor window from the same exact 252-session market history used for market stress;
- combines residual shock, completed-candle location, abnormal volume, internally derived dollar liquidity and market stress through one declared interaction;
- fails closed on missing, rank-deficient, inconsistent or unsafe input;
- freezes a deterministic training-fold-only multinomial model for target-first, stop-first and timeout probabilities;
- freezes a 1.5xATR target, 1.0xATR stop and five-session timeout;
- fingerprints the complete data/cost/feature/model definition as `residual-confluence-v1+a5084b667746`;
- contains no DB write, outcome read, strategy manifest entry, fitted coefficient or capital path.

## Pre-outcome corrections retained in history

Review found and corrected four contract weaknesses before outcome access:

1. market-stress normalisation requires 252 prior market returns, not only the 126 factor-regression sessions;
2. the current residual must subtract the OLS intercept because the declared regression includes one;
3. factor regression and market-stress histories must be aligned from one exact market vector, while dollar liquidity must be derived from the supplied closes and volumes;
4. close-boundary and feature-standardisation inputs must preserve exact values and refuse unsafe manually constructed scales.

The corrections and superseded fingerprints remain visible on #2499 and in separate commits.

## Validation

- [x] 21 focused causal/model tests pass
- [x] exact-window API refuses appended future observations
- [x] training standardisation cannot consume validation/holdout rows or accept unsafe scales
- [x] invalid OHLCV, liquidity, factor rank, residual scale and ATR stop fail closed
- [x] exact close-floor boundary, deterministic probabilities and net-EV equation are pinned
- [x] full repository pre-push gate passes (Ruff, formatting, Pyright, fast tests, smoke, repository lints and frontend gates)

## Database/security impact

None. This PR adds pure code, tests and a preregistration document. It stores no rows and cannot reach the broker. Outcome construction and the one-read report follow only after this commit is merged, preserving the historical ordering evidence.
