### PR TITLE
fix(#2499): freeze executable EV decision

### DIFF
--- a/app/services/residual_confluence_candidate.py
+++ b/app/services/residual_confluence_candidate.py
@@ -99,6 +99,14 @@ class CandidateDefinition:
     liquidity_input: str = "prior-20-close*volume-computed-in-feature-engine"
     outcome_classes: tuple[str, ...] = OUTCOME_CLASSES
     primary_start: str = "2022-01-01"
+    candidate_filter: str = "shock_z<0"
+    trade_decision: str = "predicted-net-ev>0"
+    payoff_basis: str = "after-static-spread-per-outcome"
+    timeout_payoff: str = "training-fold-mean-net-timeout-return"
+    same_instrument_overlap: str = "first-accepted-signal-wins-until-exit"
+    walk_forward_tests: tuple[str, ...] = ("2024-01-01/2024-12-31", "2025-01-01/2025-12-31")
+    terminal_holdout: str = "2026-01-01/2026-07-08"
+    fold_training: str = "anchored-prior-only-outcomes-complete-before-test"
 
 
 DEFINITION: Final = CandidateDefinition()
@@ -412,6 +420,35 @@ def expected_net_value_pct(
     )
 
 
+def expected_net_value_from_net_payoffs_pct(
+    probabilities: dict[OutcomeClass, float],
+    *,
+    target_net_payoff_pct: float,
+    stop_net_payoff_pct: float,
+    mean_timeout_net_payoff_pct: float,
+) -> float:
+    """Expected return when each class payoff already includes both spreads.
+
+    The target and stop payoffs come from the signal's fixed bracket and entry
+    price.  The timeout payoff is the training fold's mean net return among
+    timeout-labelled rows.  Carry and FX remain unavailable and therefore
+    remain promotion refusals rather than being silently treated as zero.
+    """
+    if set(probabilities) != set(OUTCOME_CLASSES):
+        raise FeatureRefusal("net EV requires exactly the three declared outcome probabilities")
+    values = tuple(probabilities[label] for label in OUTCOME_CLASSES)
+    if any(not math.isfinite(item) or item < 0 or item > 1 for item in values) or not math.isclose(
+        sum(values), 1.0, rel_tol=0, abs_tol=1e-9
+    ):
+        raise FeatureRefusal("outcome probabilities must be finite, bounded and sum to one")
+    payoffs = (target_net_payoff_pct, stop_net_payoff_pct, mean_timeout_net_payoff_pct)
+    if any(not math.isfinite(float(item)) for item in payoffs):
+        raise FeatureRefusal("net outcome payoff is non-finite")
+    if target_net_payoff_pct <= 0 or stop_net_payoff_pct >= 0:
+        raise FeatureRefusal("target net payoff must be positive and stop net payoff negative")
+    return sum(probability * payoff for probability, payoff in zip(values, payoffs, strict=True))
+
+
 __all__ = [
     "ATR_PERIOD",
     "CANDIDATE_VERSION",
@@ -425,5 +462,6 @@ __all__ = [
     "definition_hash",
     "definition_json",
     "expected_net_value_pct",
+    "expected_net_value_from_net_payoffs_pct",
     "fit_model",
 ]

--- a/docs/proposals/ta/2026-08-10-residual-confluence-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-residual-confluence-preregistration.md
@@ -113,8 +113,30 @@ p_target*target_payoff - p_stop*stop_loss
 ```
 
 A feature match is not pending. After a completed bar it either produces a
-positive lower estimate of net EV or records a refusal. Before completion there
-is no signal.
+positive predicted net EV or records a refusal. Before completion there is no
+signal. The cohort-level after-cost expectancy confidence interval—not an
+invented per-row confidence bound—is the promotion gate.
+
+The executable decision contract, fixed before outcome access, is:
+
+- only rows with `shock_z < 0` enter the candidate population;
+- target and stop class payoffs are calculated after applying the frozen static
+  half-spread to the entry and the corresponding gross exit;
+- the timeout class payoff is the mean after-spread timeout return learned from
+  the training fold only;
+- act exactly when the three class probabilities times those three net payoffs
+  sum to greater than zero; no EV threshold is searched;
+- after one signal is accepted for an instrument, later signals in that
+  instrument are suppressed through its exit session.
+
+Because the frozen eToro comparator snapshot begins in 2022 and the feature
+contract needs 252 prior sessions, the exact anchored evaluation is: train on
+all eligible prior rows whose outcomes completed before 2024 and test calendar
+2024; extend training through 2024 and test calendar 2025; then train through
+2025 and read 2026-01-01 through the frozen 2026-07-08 frontier once as the
+terminal holdout. The last five frontier sessions without a complete outcome
+are refused. This is a recent-data constraint, not a claim that 2022 itself can
+produce signals.
 
 ## Validation and one-read rule
 

--- a/tests/test_residual_confluence_candidate.py
+++ b/tests/test_residual_confluence_candidate.py
@@ -16,6 +16,7 @@ from app.services.residual_confluence_candidate import (
     compute_features,
     definition_hash,
     definition_json,
+    expected_net_value_from_net_payoffs_pct,
     expected_net_value_pct,
     fit_model,
 )
@@ -51,8 +52,8 @@ def _inputs() -> dict[str, object]:
 
 def test_definition_is_complete_stable_and_contains_no_measured_result() -> None:
     payload = definition_json()
-    assert definition_hash() == "a5084b66774625c0ff3fec05c238c05dae75b8663ddfd7b269265d134ccca0d8"
-    assert CANDIDATE_VERSION == "residual-confluence-v1+a5084b667746"
+    assert definition_hash() == "946d549861ccca18e1e0d78a1615815e97a989afd45009de12aabf7e0384fc26"
+    assert CANDIDATE_VERSION == "residual-confluence-v1+946d549861cc"
     assert DEFINITION.market_vol_long_lookback == 252
     assert DEFINITION.model_features == MODEL_FEATURE_NAMES
     assert "expectancy" not in payload
@@ -245,4 +246,21 @@ def test_expected_net_value_uses_all_outcomes_and_costs() -> None:
             stop_loss_pct=2,
             expected_timeout_payoff_pct=0,
             total_cost_pct=0.2,
+        )
+
+
+def test_expected_net_value_from_net_payoffs_uses_exact_class_payoffs() -> None:
+    result = expected_net_value_from_net_payoffs_pct(
+        {"target_first": 0.55, "stop_first": 0.30, "timeout": 0.15},
+        target_net_payoff_pct=2.7,
+        stop_net_payoff_pct=-2.2,
+        mean_timeout_net_payoff_pct=-0.4,
+    )
+    assert result == pytest.approx(0.765)
+    with pytest.raises(FeatureRefusal, match="stop net payoff negative"):
+        expected_net_value_from_net_payoffs_pct(
+            {"target_first": 0.55, "stop_first": 0.30, "timeout": 0.15},
+            target_net_payoff_pct=2.7,
+            stop_net_payoff_pct=0.1,
+            mean_timeout_net_payoff_pct=-0.4,
         )


### PR DESCRIPTION
## Issue reference

Refs #2499
Refs #2469

## Summary

Closes the last implementation-choice gap in the residual-confluence preregistration before any outcome interval is read.

- limits the candidate population to negative residual shocks;
- defines the decision as predicted after-spread net EV greater than zero, with no threshold search;
- derives target/stop net payoffs from the fixed bracket and frozen spread model;
- learns only the mean timeout net payoff from each training fold;
- suppresses overlapping accepted positions in the same instrument;
- fixes anchored calendar tests for 2024 and 2025 and an untouched 2026 terminal holdout;
- moves the definition fingerprint to `residual-confluence-v1+946d549861cc`.

This PR reads and writes no database data, fits no measured coefficient and reports no outcome. It exists so the subsequent verifier cannot choose these semantics after seeing which implementation looks profitable.

## Validation

- [x] 22 focused tests pass
- [x] exact net-payoff EV equation is pinned
- [x] malformed probabilities/payoff signs fail closed
- [x] full repository pre-push gate is green
