### PR TITLE
research(#2499): reject residual confluence candidate

### DIFF
--- a/app/services/residual_confluence_evaluation.py
+++ b/app/services/residual_confluence_evaluation.py
@@ -1,0 +1,462 @@
+"""Read-only recent-outcome construction for residual confluence candidate #2499.
+
+This module is pure.  It does not select a profitable threshold, persist a
+feature history, register a strategy, or reach an order path.  It turns one
+already-masked price segment and exact comparator closes into the immutable
+candidate observations consumed by the one-read verifier.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+import numpy as np
+
+from app.services.cost_model import buy_price, half_spread_for, sell_price
+from app.services.indicator_series import BarSeries, atr_series
+from app.services.residual_confluence_candidate import (
+    ATR_PERIOD,
+    MARKET_VOL_LONG_LOOKBACK,
+    MARKET_VOL_SHORT_LOOKBACK,
+    MAX_HOLD_SESSIONS,
+    MIN_MEDIAN_DOLLAR_VOLUME,
+    MIN_SIGNAL_CLOSE,
+    MODEL_FEATURE_NAMES,
+    OLS_LOOKBACK,
+    RESIDUAL_VOL_LOOKBACK,
+    STOP_ATR_MULTIPLE,
+    TARGET_ATR_MULTIPLE,
+    VOLUME_LOOKBACK,
+    OutcomeClass,
+    expected_net_value_from_net_payoffs_pct,
+    fit_model,
+)
+
+ObservedClass = Literal["target_first", "stop_first", "timeout", "ambiguous"]
+
+
+@dataclass(frozen=True)
+class CandidateObservation:
+    instrument_id: int
+    signal_date: date
+    entry_date: date
+    exit_date: date
+    model_row: tuple[float, ...]
+    observed_class: ObservedClass
+    target_net_payoff_pct: float
+    stop_net_payoff_pct: float
+    realised_net_return_pct: float | None
+
+    def label_for_arm(
+        self, arm: Literal["best_case", "worst_case"]
+    ) -> Literal["target_first", "stop_first", "timeout"]:
+        if self.observed_class == "ambiguous":
+            return "target_first" if arm == "best_case" else "stop_first"
+        return self.observed_class
+
+    def return_for_arm(self, arm: Literal["best_case", "worst_case"]) -> float:
+        if self.observed_class == "ambiguous":
+            return self.target_net_payoff_pct if arm == "best_case" else self.stop_net_payoff_pct
+        if self.realised_net_return_pct is None:  # pragma: no cover - dataclass construction is internal
+            raise RuntimeError("a resolved non-ambiguous observation has no return")
+        return self.realised_net_return_pct
+
+
+@dataclass(frozen=True)
+class ExtractionCensus:
+    bars_seen: int = 0
+    eligible_features: int = 0
+    non_negative_shock: int = 0
+    incomplete_outcome: int = 0
+    uneconomic_bracket: int = 0
+    observations: int = 0
+
+
+@dataclass(frozen=True)
+class EvDecile:
+    rank: int
+    count: int
+    mean_predicted_ev_pct: float
+    realised_expectancy_pct: float
+    win_rate_pct: float
+
+
+@dataclass(frozen=True)
+class FoldEvaluation:
+    test_start: date
+    test_end: date
+    ambiguity_arm: Literal["best_case", "worst_case"]
+    training_count: int
+    test_candidate_count: int
+    accepted_count: int
+    overlap_suppressed: int
+    win_rate_pct: float | None
+    expectancy_pct: float | None
+    profit_factor: float | None
+    brier_score: float
+    log_loss: float
+    mean_predicted_ev_pct: float | None
+    baseline_count: int
+    baseline_expectancy_pct: float | None
+    baseline_win_rate_pct: float | None
+    max_entry_date_share_pct: float | None
+    observed_class_counts: tuple[tuple[str, int], ...]
+    feature_win_loss_standardised_differences: tuple[tuple[str, float], ...]
+    ev_deciles: tuple[EvDecile, ...]
+    returns: tuple[float, ...]
+    entry_dates: tuple[date, ...]
+
+
+def _log_returns(closes: Sequence[Decimal | None]) -> np.ndarray:
+    result = np.full(len(closes), np.nan, dtype=float)
+    for index in range(1, len(closes)):
+        previous, current = closes[index - 1], closes[index]
+        if previous is None or current is None or previous <= 0 or current <= 0:
+            continue
+        result[index] = math.log(float(current / previous))
+    return result
+
+
+def _net_return_pct(entry: Decimal, exit_: Decimal) -> float:
+    half_spread = half_spread_for(entry)
+    paid = buy_price(entry, half_spread=half_spread)
+    received = sell_price(exit_, half_spread=half_spread)
+    return float((received - paid) / paid * Decimal(100))
+
+
+def _resolve(
+    series: BarSeries,
+    *,
+    signal_index: int,
+    atr: float,
+) -> tuple[ObservedClass, int, Decimal, Decimal, Decimal | None] | None:
+    fill_index = signal_index + 1
+    timeout_index = fill_index + MAX_HOLD_SESSIONS - 1
+    if timeout_index >= len(series):
+        return None
+    entry = series.rows[fill_index].get("open")
+    if entry is None or entry <= 0:
+        return None
+    target = entry + TARGET_ATR_MULTIPLE * Decimal(str(atr))
+    stop = entry - STOP_ATR_MULTIPLE * Decimal(str(atr))
+    if stop <= 0:
+        return None
+    for index in range(fill_index, timeout_index + 1):
+        row = series.rows[index]
+        open_, high, low = row.get("open"), row.get("high"), row.get("low")
+        if open_ is None or high is None or low is None or min(open_, high, low) <= 0:
+            return None
+        if open_ <= stop:
+            return "stop_first", index, entry, target, open_
+        if open_ >= target:
+            return "target_first", index, entry, target, open_
+        if low <= stop and high >= target:
+            return "ambiguous", index, entry, target, None
+        if low <= stop:
+            return "stop_first", index, entry, target, stop
+        if high >= target:
+            return "target_first", index, entry, target, target
+    timeout_close = series.rows[timeout_index].get("close")
+    if timeout_close is None or timeout_close <= 0:
+        return None
+    return "timeout", timeout_index, entry, target, timeout_close
+
+
+def extract_segment_observations(
+    *,
+    instrument_id: int,
+    series: BarSeries,
+    market_closes: Mapping[date, Decimal],
+    sector_closes: Mapping[date, Decimal],
+) -> tuple[tuple[CandidateObservation, ...], ExtractionCensus]:
+    """Evaluate exact causal windows in one scale-homogeneous segment."""
+    if instrument_id <= 0:
+        raise ValueError("instrument_id must be positive")
+    # "Exact common sessions" means the intersection of the three observed
+    # calendars, not requiring one provider to carry every date another does.
+    # A masked instrument close remains on this axis as None and poisons every
+    # return window that uses it; only a genuinely absent comparator session is
+    # omitted from the shared calendar.
+    common_indices = [
+        index for index, bar_date in enumerate(series.dates) if bar_date in market_closes and bar_date in sector_closes
+    ]
+    common_instrument_closes = [series.rows[index].get("close") for index in common_indices]
+    common_market_closes = [market_closes[series.dates[index]] for index in common_indices]
+    common_sector_closes = [sector_closes[series.dates[index]] for index in common_indices]
+    instrument_returns = _log_returns(common_instrument_closes)
+    market_returns = _log_returns(common_market_closes)
+    sector_returns = _log_returns(common_sector_closes)
+    atr_values = atr_series(series, universe="survivor_only", period=ATR_PERIOD).values
+    rows: list[CandidateObservation] = []
+    eligible = non_negative = incomplete = uneconomic = 0
+
+    # A signal at i needs market return i-252, which itself needs the aligned
+    # close at i-253. Exact windows are refused rather than shortened.
+    for common_position in range(MARKET_VOL_LONG_LOOKBACK + 1, len(common_indices)):
+        index = common_indices[common_position]
+        row = series.rows[index]
+        open_, high, low, close, volume = (
+            row.get("open"),
+            row.get("high"),
+            row.get("low"),
+            row.get("close"),
+            row.get("volume"),
+        )
+        if any(value is None for value in (open_, high, low, close, volume)):
+            continue
+        assert open_ is not None and high is not None and low is not None and close is not None and volume is not None
+        if (
+            min(open_, high, low, close, volume) <= 0
+            or high < max(open_, close)
+            or low > min(open_, close)
+            or high <= low
+        ):
+            continue
+        if close < MIN_SIGNAL_CLOSE:
+            continue
+        atr = atr_values[index]
+        if atr is None or atr <= 0:
+            continue
+
+        market_history = market_returns[common_position - MARKET_VOL_LONG_LOOKBACK : common_position]
+        market = market_history[-OLS_LOOKBACK:]
+        sector = sector_returns[common_position - OLS_LOOKBACK : common_position]
+        instrument = instrument_returns[common_position - OLS_LOOKBACK : common_position]
+        current = (
+            instrument_returns[common_position],
+            market_returns[common_position],
+            sector_returns[common_position],
+        )
+        if not all(np.isfinite(values).all() for values in (market_history, sector, instrument)) or not all(
+            math.isfinite(value) for value in current
+        ):
+            continue
+        design = np.column_stack((np.ones(OLS_LOOKBACK), market, sector))
+        if int(np.linalg.matrix_rank(design)) != design.shape[1]:
+            continue
+        coefficients, *_ = np.linalg.lstsq(design, instrument, rcond=None)
+        residual_history = instrument - design @ coefficients
+        residual_vol = float(np.std(residual_history[-RESIDUAL_VOL_LOOKBACK:], ddof=1))
+        if not math.isfinite(residual_vol) or residual_vol <= np.finfo(float).eps:
+            continue
+        residual = float(current[0] - coefficients[0] - coefficients[1] * current[1] - coefficients[2] * current[2])
+        shock_z = residual / residual_vol
+
+        prior = series.rows[index - VOLUME_LOOKBACK : index]
+        prior_closes = [item.get("close") for item in prior]
+        prior_volumes = [item.get("volume") for item in prior]
+        if any(value is None or value <= 0 for value in (*prior_closes, *prior_volumes)):
+            continue
+        median_volume = float(np.median(np.asarray(prior_volumes, dtype=float)))
+        dollar_volumes = np.asarray(prior_closes, dtype=float) * np.asarray(prior_volumes, dtype=float)
+        median_dollar_volume = float(np.median(dollar_volumes))
+        if Decimal(str(median_dollar_volume)) < MIN_MEDIAN_DOLLAR_VOLUME:
+            continue
+        short_vol = float(np.std(market_history[-MARKET_VOL_SHORT_LOOKBACK:], ddof=1))
+        long_vol = float(np.std(market_history, ddof=1))
+        if not math.isfinite(short_vol) or not math.isfinite(long_vol) or long_vol <= 0:
+            continue
+        close_location = float((Decimal(2) * close - high - low) / (high - low))
+        abnormal_volume = math.log(float(volume) / median_volume)
+        liquidity = math.log(median_dollar_volume)
+        stress = short_vol / long_vol
+        model_row = (
+            shock_z,
+            close_location,
+            abnormal_volume,
+            liquidity,
+            stress,
+            shock_z * close_location * abnormal_volume,
+        )
+        if not all(math.isfinite(value) for value in model_row):
+            continue
+        eligible += 1
+        if shock_z >= 0:
+            non_negative += 1
+            continue
+        resolution = _resolve(series, signal_index=index, atr=atr)
+        if resolution is None:
+            incomplete += 1
+            continue
+        outcome, exit_index, entry, target, exit_price = resolution
+        stop = entry - STOP_ATR_MULTIPLE * Decimal(str(atr))
+        target_payoff = _net_return_pct(entry, target)
+        stop_payoff = _net_return_pct(entry, stop)
+        if target_payoff <= 0 or stop_payoff >= 0:
+            uneconomic += 1
+            continue
+        realised = None if exit_price is None else _net_return_pct(entry, exit_price)
+        rows.append(
+            CandidateObservation(
+                instrument_id=instrument_id,
+                signal_date=series.dates[index],
+                entry_date=series.dates[index + 1],
+                exit_date=series.dates[exit_index],
+                model_row=model_row,
+                observed_class=outcome,
+                target_net_payoff_pct=target_payoff,
+                stop_net_payoff_pct=stop_payoff,
+                realised_net_return_pct=realised,
+            )
+        )
+    return tuple(rows), ExtractionCensus(
+        bars_seen=len(series),
+        eligible_features=eligible,
+        non_negative_shock=non_negative,
+        incomplete_outcome=incomplete,
+        uneconomic_bracket=uneconomic,
+        observations=len(rows),
+    )
+
+
+def evaluate_anchored_fold(
+    observations: tuple[CandidateObservation, ...],
+    *,
+    test_start: date,
+    test_end: date,
+    ambiguity_arm: Literal["best_case", "worst_case"],
+) -> FoldEvaluation:
+    """Fit on completed prior outcomes and apply the frozen positive-EV rule."""
+    if test_end < test_start:
+        raise ValueError("test interval is inverted")
+    training = tuple(item for item in observations if item.exit_date < test_start)
+    testing = tuple(item for item in observations if test_start <= item.signal_date <= test_end)
+    if not training:
+        raise ValueError(f"no completed training observations before {test_start}")
+    if not testing:
+        raise ValueError(f"no candidate observations in {test_start}/{test_end}")
+    labels: tuple[OutcomeClass, ...] = tuple(item.label_for_arm(ambiguity_arm) for item in training)
+    model = fit_model(tuple(item.model_row for item in training), labels)
+    timeout_returns = [
+        item.return_for_arm(ambiguity_arm) for item, label in zip(training, labels, strict=True) if label == "timeout"
+    ]
+    if not timeout_returns:
+        raise ValueError("training fold has no timeout payoff")
+    mean_timeout = sum(timeout_returns) / len(timeout_returns)
+
+    squared_errors = 0.0
+    log_loss = 0.0
+    ordered = sorted(testing, key=lambda item: (item.signal_date, item.instrument_id))
+    probabilities_by_id: dict[int, dict[Literal["target_first", "stop_first", "timeout"], float]] = {}
+    predicted_ev_by_id: dict[int, float] = {}
+    for item in ordered:
+        probabilities = model.probabilities(item.model_row)
+        probabilities_by_id[id(item)] = probabilities
+        predicted_ev_by_id[id(item)] = expected_net_value_from_net_payoffs_pct(
+            probabilities,
+            target_net_payoff_pct=item.target_net_payoff_pct,
+            stop_net_payoff_pct=item.stop_net_payoff_pct,
+            mean_timeout_net_payoff_pct=mean_timeout,
+        )
+        actual = item.label_for_arm(ambiguity_arm)
+        squared_errors += sum((probability - (label == actual)) ** 2 for label, probability in probabilities.items())
+        log_loss -= math.log(max(probabilities[actual], np.finfo(float).tiny))
+
+    baseline: list[CandidateObservation] = []
+    baseline_available: dict[int, date] = {}
+    for item in ordered:
+        if item.signal_date <= baseline_available.get(item.instrument_id, date.min):
+            continue
+        baseline.append(item)
+        baseline_available[item.instrument_id] = item.exit_date
+
+    accepted: list[CandidateObservation] = []
+    next_available: dict[int, date] = {}
+    overlap_suppressed = 0
+    for item in ordered:
+        if item.signal_date <= next_available.get(item.instrument_id, date.min):
+            overlap_suppressed += 1
+            continue
+        expected_value = predicted_ev_by_id[id(item)]
+        if expected_value <= 0:
+            continue
+        accepted.append(item)
+        next_available[item.instrument_id] = item.exit_date
+
+    returns = tuple(item.return_for_arm(ambiguity_arm) for item in accepted)
+    wins = sum(value > 0 for value in returns)
+    gains = sum(value for value in returns if value > 0)
+    losses = -sum(value for value in returns if value < 0)
+    baseline_returns = tuple(item.return_for_arm(ambiguity_arm) for item in baseline)
+    baseline_wins = sum(value > 0 for value in baseline_returns)
+    accepted_predictions = tuple(predicted_ev_by_id[id(item)] for item in accepted)
+    entry_date_counts: dict[date, int] = {}
+    for entry_date in (item.entry_date for item in accepted):
+        entry_date_counts[entry_date] = entry_date_counts.get(entry_date, 0) + 1
+    class_counts: dict[str, int] = {}
+    for item in accepted:
+        label = item.label_for_arm(ambiguity_arm)
+        class_counts[label] = class_counts.get(label, 0) + 1
+
+    feature_differences: list[tuple[str, float]] = []
+    if any(value > 0 for value in returns) and any(value <= 0 for value in returns):
+        matrix = np.asarray([item.model_row for item in accepted], dtype=float)
+        win_mask = np.asarray([value > 0 for value in returns], dtype=bool)
+        pooled_std = np.std(matrix, axis=0, ddof=1)
+        differences = np.divide(
+            np.mean(matrix[win_mask], axis=0) - np.mean(matrix[~win_mask], axis=0),
+            pooled_std,
+            out=np.zeros_like(pooled_std),
+            where=pooled_std > np.finfo(float).eps,
+        )
+        feature_differences = list(zip(MODEL_FEATURE_NAMES, (float(value) for value in differences), strict=True))
+
+    deciles: list[EvDecile] = []
+    # Rank the same non-overlapping opportunity set used by the unfiltered
+    # challenger. Otherwise serial repeats from one instrument can manufacture
+    # apparent model discrimination and make the deciles incomparable.
+    ranked_indices = np.argsort([predicted_ev_by_id[id(item)] for item in baseline])
+    for rank, indices in enumerate(np.array_split(ranked_indices, min(10, len(ranked_indices))), start=1):
+        bucket = [baseline[int(index)] for index in indices]
+        bucket_returns = [item.return_for_arm(ambiguity_arm) for item in bucket]
+        deciles.append(
+            EvDecile(
+                rank=rank,
+                count=len(bucket),
+                mean_predicted_ev_pct=sum(predicted_ev_by_id[id(item)] for item in bucket) / len(bucket),
+                realised_expectancy_pct=sum(bucket_returns) / len(bucket_returns),
+                win_rate_pct=sum(value > 0 for value in bucket_returns) / len(bucket_returns) * 100,
+            )
+        )
+    return FoldEvaluation(
+        test_start=test_start,
+        test_end=test_end,
+        ambiguity_arm=ambiguity_arm,
+        training_count=len(training),
+        test_candidate_count=len(testing),
+        accepted_count=len(accepted),
+        overlap_suppressed=overlap_suppressed,
+        win_rate_pct=None if not returns else wins / len(returns) * 100,
+        expectancy_pct=None if not returns else sum(returns) / len(returns),
+        profit_factor=None if losses == 0 else gains / losses,
+        brier_score=squared_errors / len(testing),
+        log_loss=log_loss / len(testing),
+        mean_predicted_ev_pct=(
+            None if not accepted_predictions else sum(accepted_predictions) / len(accepted_predictions)
+        ),
+        baseline_count=len(baseline_returns),
+        baseline_expectancy_pct=None if not baseline_returns else sum(baseline_returns) / len(baseline_returns),
+        baseline_win_rate_pct=None if not baseline_returns else baseline_wins / len(baseline_returns) * 100,
+        max_entry_date_share_pct=(None if not accepted else max(entry_date_counts.values()) / len(accepted) * 100),
+        observed_class_counts=tuple(sorted(class_counts.items())),
+        feature_win_loss_standardised_differences=tuple(feature_differences),
+        ev_deciles=tuple(deciles),
+        returns=returns,
+        entry_dates=tuple(item.entry_date for item in accepted),
+    )
+
+
+__all__ = [
+    "CandidateObservation",
+    "ExtractionCensus",
+    "EvDecile",
+    "FoldEvaluation",
+    "ObservedClass",
+    "evaluate_anchored_fold",
+    "extract_segment_observations",
+]

--- a/app/services/residual_confluence_evaluation.py
+++ b/app/services/residual_confluence_evaluation.py
@@ -158,8 +158,13 @@ def _resolve(
         if low <= stop and high >= target:
             return "ambiguous", index, entry, target, None
         if low <= stop:
+            # Daily OHLC cannot recover the stop-market execution price after
+            # an intrabar trigger. The frozen development proxy is the stop
+            # level; unobserved adverse slippage remains a promotion refusal.
             return "stop_first", index, entry, target, stop
         if high >= target:
+            # A touched sell limit is valued at its limit, not the unknown
+            # potentially better intrabar price. This is conservative.
             return "target_first", index, entry, target, target
     timeout_close = series.rows[timeout_index].get("close")
     if timeout_close is None or timeout_close <= 0:

--- a/docs/proposals/ta/2026-08-10-residual-confluence-development-result.md
+++ b/docs/proposals/ta/2026-08-10-residual-confluence-development-result.md
@@ -1,0 +1,145 @@
+# Residual-confluence development result
+
+Status: **rejected in development**. Candidate #2499 must not enter the
+strategy manifest, capital picker, forward scanner or order path.
+
+## Frozen identity and run scope
+
+- candidate: `residual-confluence-v1+946d549861cc`;
+- research corpus: `paperswithbacktest/Stocks-Daily-Price@2026-07-08`;
+- comparator snapshot: `etoro-comparators-2026-07-08-v1`;
+- quarantine rules: `price-quarantine-v1+d0423dbd9cb5`;
+- static cost model is applied to entry and every conditional exit;
+- anchored prior-only training; calendar 2024 and 2025 development tests;
+- 2,000 circular block-bootstrap resamples, clustered by entry date, seed
+  `20260810`;
+- development frontier: **2025-12-31**;
+- intended 2026 terminal holdout: **contaminated by discarded diagnostic runs
+  and permanently ineligible as untouched evidence**.
+
+The verifier is read-only. It created no feature, outcome, strategy, capital or
+order rows. The corrected run streamed 4,229,543 development bars and retained only in-memory
+candidate observations and aggregate output.
+
+## Primary masked-data result
+
+| Test | Ambiguity | Trades | Win rate | Expectancy | 95% block CI | Profit factor | Effective n |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| 2024 | best | 11,789 | 48.38% | +0.036% | −0.678% to +0.686% | 1.02 | 290.9 |
+| 2024 | worst | 9,793 | 49.06% | +0.073% | −0.716% to +0.715% | 1.03 | 245.5 |
+| 2025 | best | 787 | 49.17% | +0.223% | −2.642% to +2.815% | 1.08 | 31.7 |
+| 2025 | worst | 421 | 43.23% | **−1.332%** | −4.288% to +2.202% | **0.66** | 18.9 |
+
+All four intervals cross zero. The conservative 2025 arm is negative before
+carry and FX, which remain unmodelled promotion refusals. Brier scores are
+0.647–0.653 and multiclass log loss 1.071–1.079; neither supports a claim of
+strong probability discrimination.
+
+Extraction census:
+
+- 960,214 computable feature rows;
+- 475,395 rejected because the residual shock was not negative;
+- 4,675 refused because the five-session outcome was incomplete by the
+  development frontier;
+- 1 refused because the 1.5×ATR target could not clear the frozen spread;
+- 480,143 resolved negative-shock observations;
+- 178 series refused because SEC SIC could not resolve to a sector comparator.
+
+The nominal trade counts materially overstate independent evidence. Same-day
+and serial clustering reduces 11,789 accepted 2024 trades to effective n 291.
+The worst-case 2025 arm accepts only 421 trades across 29 entry dates and has
+effective n 19, making the apparent point estimate both negative and unstable.
+
+## What separated the selected trades from the rest
+
+The model did reject a broadly losing opportunity set. Applying the same
+instrument-overlap rule without the model produced after-spread expectancy of
+−0.322% in 2024 and −0.330% in 2025 (best ambiguity arm), versus +0.036% and
++0.223% for the model-selected subsets. This is selection activity, but it is
+not sufficient evidence of a tradable edge.
+
+The decisive detail is that ranking broke at the exact action boundary:
+
+- the broad top predicted-EV decile realised +0.140% in 2024 and +0.312% in
+  2025 under the favourable ambiguity arm;
+- under the conservative arm the broad top decile realised +0.127% and
+  +0.191%;
+- yet the much narrower observations whose predicted EV actually crossed zero
+  realised **−1.332%** in conservative 2025, with 36.1% of accepted trades
+  entering on one date.
+
+The model therefore showed coarse ranking information but failed precisely
+where it claimed a trade should be placed. Predicted positive EV was +0.045%,
+while realised expectancy was −1.332%. That is not calibration suitable for
+capital.
+
+Nor is there a stable winning signature to retain. Standardised winner/loser
+feature differences were generally small in 2024 apart from market stress
+(about +0.25 standard deviations). In 2025, the larger differences shifted to
+abnormal volume (−0.36), liquidity (+0.25), market stress (+0.25), shock
+(+0.20) and candle location (−0.13). Those are outcome-derived diagnostics,
+not a coherent invariant rule, and cannot be turned into thresholds on this
+data without creating a new overfit candidate.
+
+## Quarantine sensitivity
+
+Admitting stored quarantined values changes 336 observations out of roughly
+480k and does not repair the result:
+
+| Test | Ambiguity | Trades | Win rate | Expectancy | 95% block CI | Profit factor | Effective n |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| 2024 | best | 11,778 | 48.36% | +0.030% | −0.625% to +0.571% | 1.01 | 341.7 |
+| 2024 | worst | 9,791 | 49.07% | +0.071% | −0.716% to +0.716% | 1.03 | 245.0 |
+| 2025 | best | 779 | 49.17% | +0.223% | −2.716% to +2.798% | 1.08 | 32.3 |
+| 2025 | worst | 412 | 42.48% | **−1.486%** | −4.374% to +2.091% | **0.62** | 19.3 |
+
+The failure is therefore not caused by conservative quarantine masking.
+
+## Evidence still missing
+
+This rejection does not pretend to complete the original promotion contract.
+The development verifier did not freeze a membership hash for the resolved
+instrument universe, did not execute the raw-shock, market-only residual and
+matched-random challenger arms, and did not model slippage, carry or FX. It
+also does not yet produce portfolio drawdown, expected shortfall or capacity
+evidence. Any one of those omissions would independently refuse promotion even
+if the point estimate had looked attractive.
+
+Issue #2505 makes those challenger, attribution and integrity outputs mandatory
+for future candidates. The diagnostics above answer why this model failed at
+its own action boundary; they do not establish causal importance for any one
+feature. A winner/loser difference observed after outcomes is not a formula.
+
+## Corrections made before accepting a result
+
+Diagnostic execution exposed three integrity issues; affected results were
+discarded:
+
+1. “exact common sessions” was initially implemented as requiring the
+   instrument and both comparators to have identical calendars. The corrected
+   implementation forms their exact observed-session intersection and still
+   lets a masked instrument close poison every return window that consumes it.
+2. A low-volatility 1.5×ATR target can be smaller than the frozen spread. Such
+   a bracket is now counted as `uneconomic_bracket` and refused before model
+   scoring; a target touch is never mislabeled as a profitable trade.
+3. The first corrected processes bounded reported folds to 2024/2025 but loaded
+   bars through the 2026 corpus frontier to resolve late-2025 observations.
+   That is still holdout access. The verifier now makes 2026 inaccessible and
+   refuses outcomes incomplete at 2025-12-31. The prior access is disclosed;
+   the intended 2026 holdout will never be described as untouched.
+
+Unit coverage pins scalar/vector feature parity, calendar intersection,
+quarantine/missing-data refusal, ambiguous arms, incomplete outcomes,
+after-spread bracket viability, anchored training and overlap suppression.
+
+## Decision
+
+Reject v1. Do not compute or report a 2026 result: a development candidate that
+already has no positive lower expectancy bound and fails its conservative 2025
+arm cannot be rescued by contaminated evidence.
+
+Do not post-hoc change the shock threshold, barriers, model, direction or
+preferred ambiguity arm. Any narrower regime suggested by these results is a
+new preregistered candidate and needs new future data. The next research work
+should prefer a genuinely independent catalyst or microstructure hypothesis,
+not another combination of transformations of the same daily OHLCV path.

--- a/docs/proposals/ta/2026-08-10-residual-confluence-development-result.md
+++ b/docs/proposals/ta/2026-08-10-residual-confluence-development-result.md
@@ -105,6 +105,12 @@ also does not yet produce portfolio drawdown, expected shortfall or capacity
 evidence. Any one of those omissions would independently refuse promotion even
 if the point estimate had looked attractive.
 
+In particular, daily OHLC can identify a single intrabar stop touch but cannot
+recover the eventual stop-market fill. The development result uses the frozen
+stop level plus static spread and therefore does not claim stop-slippage
+precision. A future executable study needs intraday quote/trade observations or
+an adverse slippage sensitivity arm.
+
 Issue #2505 makes those challenger, attribution and integrity outputs mandatory
 for future candidates. The diagnostics above answer why this model failed at
 its own action boundary; they do not establish causal importance for any one

--- a/scripts/verify_2499_residual_confluence.py
+++ b/scripts/verify_2499_residual_confluence.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Read-only development evaluation for preregistered candidate #2499.
+
+The contaminated 2026 interval is intentionally inaccessible here.  This first cut
+must survive both 2024 and 2025 development folds, masked/admitted quarantine
+sensitivity and best/worst daily-bar ambiguity before a separately reviewed
+one-read holdout command is added.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from collections import Counter
+from dataclasses import asdict
+from datetime import date
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+
+from app.config import settings
+from app.services.block_bootstrap import block_bootstrap_expectancy, cluster_by_date
+from app.services.indicator_series import BarSeries
+from app.services.price_quarantine import RULE_SET_VERSION as QUARANTINE_RULE_SET_VERSION
+from app.services.price_segments import load_unresolved_breaks, series_segment_bounds
+from app.services.research_comparator_snapshot import SNAPSHOT_ID, load_comparator_closes
+from app.services.residual_confluence_candidate import CANDIDATE_VERSION
+from app.services.residual_confluence_evaluation import (
+    CandidateObservation,
+    ExtractionCensus,
+    evaluate_anchored_fold,
+    extract_segment_observations,
+)
+from app.services.sector_classification import resolve_sector_spdr
+from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategy_result import CORPUS_VENDORS
+from app.services.technical_analysis import OHLCVRow
+
+QuarantineArm = Literal["masked", "admitted"]
+AmbiguityArm = Literal["best_case", "worst_case"]
+RECENT_START = date(2022, 4, 1)
+DEVELOPMENT_END = date(2025, 12, 31)
+BOOTSTRAP_SEED = 20260810
+
+_SERIES_SQL = """
+    SELECT s.series_id, s.instrument_id, p.sic
+    FROM research_price_series s
+    LEFT JOIN instrument_sec_profile p ON p.instrument_id = s.instrument_id
+    WHERE s.vendor = %(vendor)s
+      AND s.comparator_snapshot_id IS NULL
+      AND s.instrument_id = ANY(%(instrument_ids)s)
+    ORDER BY s.instrument_id, s.series_id
+"""
+
+_RECENT_SQL = """
+    SELECT d.bar_date, d.open, d.high, d.low, d.close, d.volume,
+           COALESCE(q.range_usable, TRUE), COALESCE(q.return_usable, TRUE)
+    FROM research_price_daily d
+    JOIN research_price_quarantine_coverage cov
+      ON cov.series_id = d.series_id
+     AND cov.rule_set_version = %(quarantine_version)s
+     AND d.bar_date BETWEEN cov.first_bar AND cov.last_bar
+    LEFT JOIN research_bar_quarantine q
+      ON q.series_id = d.series_id
+     AND q.bar_date = d.bar_date
+     AND q.rule_set_version = %(quarantine_version)s
+    WHERE d.series_id = %(series_id)s
+      AND d.bar_date >= %(recent_start)s
+      AND d.bar_date <= %(frontier)s
+    ORDER BY d.bar_date
+"""
+
+
+def _series(rows: list[tuple[Any, ...]], *, arm: QuarantineArm) -> BarSeries:
+    dates: list[date] = []
+    bars: list[OHLCVRow] = []
+    admit = arm == "admitted"
+    for bar_date, open_, high, low, close, volume, range_usable, return_usable in rows:
+        dates.append(bar_date)
+        bars.append(
+            OHLCVRow(
+                open=(Decimal(open_) if open_ is not None and (admit or open_ > 0) else None),  # type: ignore[typeddict-item]
+                high=Decimal(high) if high is not None and (admit or range_usable) else None,  # type: ignore[typeddict-item]
+                low=Decimal(low) if low is not None and (admit or range_usable) else None,  # type: ignore[typeddict-item]
+                close=Decimal(close) if close is not None and (admit or return_usable) else None,  # type: ignore[typeddict-item]
+                volume=None if volume is None else int(volume),
+            )
+        )
+    return BarSeries(dates=tuple(dates), rows=tuple(bars))
+
+
+def _add_census(left: ExtractionCensus, right: ExtractionCensus) -> ExtractionCensus:
+    return ExtractionCensus(
+        bars_seen=left.bars_seen + right.bars_seen,
+        eligible_features=left.eligible_features + right.eligible_features,
+        non_negative_shock=left.non_negative_shock + right.non_negative_shock,
+        incomplete_outcome=left.incomplete_outcome + right.incomplete_outcome,
+        uneconomic_bracket=left.uneconomic_bracket + right.uneconomic_bracket,
+        observations=left.observations + right.observations,
+    )
+
+
+def _bootstrap_payload(returns: tuple[float, ...], dates: tuple[date, ...]) -> dict[str, Any] | None:
+    result = block_bootstrap_expectancy(cluster_by_date(returns, dates), seed=BOOTSTRAP_SEED)
+    return None if result is None else asdict(result)
+
+
+def run(*, quarantine_arm: QuarantineArm) -> dict[str, Any]:
+    started = time.monotonic()
+    observations: list[CandidateObservation] = []
+    census = ExtractionCensus()
+    skipped_sector = 0
+    empty_series = 0
+    with psycopg.connect(
+        settings.database_url,
+        application_name="ebull-verify-2499",
+        options="-c default_transaction_read_only=on",
+    ) as conn:
+        conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+        universe = load_validated_universe(conn)
+        series_rows = conn.execute(
+            _SERIES_SQL, {"vendor": CORPUS_VENDORS[0], "instrument_ids": list(universe)}
+        ).fetchall()
+        breaks = load_unresolved_breaks(conn, universe)
+        market = load_comparator_closes(conn, snapshot_id=SNAPSHOT_ID, symbol="SPY", through_date=DEVELOPMENT_END)
+        sectors = {
+            symbol: load_comparator_closes(conn, snapshot_id=SNAPSHOT_ID, symbol=symbol, through_date=DEVELOPMENT_END)
+            for symbol in ("XLB", "XLC", "XLE", "XLF", "XLI", "XLK", "XLP", "XLRE", "XLU", "XLV", "XLY")
+        }
+        for position, (series_id, instrument_id, sic) in enumerate(series_rows, start=1):
+            classification = resolve_sector_spdr(sic)
+            if classification is None:
+                skipped_sector += 1
+                continue
+            raw = conn.execute(
+                _RECENT_SQL,
+                {
+                    "series_id": int(series_id),
+                    "quarantine_version": QUARANTINE_RULE_SET_VERSION,
+                    "recent_start": RECENT_START,
+                    "frontier": DEVELOPMENT_END,
+                },
+            ).fetchall()
+            if not raw:
+                empty_series += 1
+                continue
+            loaded = _series(raw, arm=quarantine_arm)
+            for start, end in series_segment_bounds(loaded, unresolved_breaks=breaks.get(int(instrument_id), ())):
+                segment = BarSeries(dates=loaded.dates[start:end], rows=loaded.rows[start:end])
+                extracted, segment_census = extract_segment_observations(
+                    instrument_id=int(instrument_id),
+                    series=segment,
+                    market_closes=market,
+                    sector_closes=sectors[classification.spdr_symbol],
+                )
+                observations.extend(extracted)
+                census = _add_census(census, segment_census)
+            if position == 1 or position % 100 == 0 or position == len(series_rows):
+                print(
+                    f"series={position}/{len(series_rows)} observations={len(observations)} "
+                    f"elapsed={time.monotonic() - started:.1f}s",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+    folds: list[dict[str, Any]] = []
+    population = tuple(observations)
+    year_counts = Counter(item.signal_date.year for item in population)
+    print(
+        f"observation_years={dict(sorted(year_counts.items()))} "
+        f"range={min((item.signal_date for item in population), default=None)}/"
+        f"{max((item.signal_date for item in population), default=None)}",
+        file=sys.stderr,
+        flush=True,
+    )
+    for ambiguity_arm in ("best_case", "worst_case"):
+        for test_start, test_end in (
+            (date(2024, 1, 1), date(2024, 12, 31)),
+            (date(2025, 1, 1), date(2025, 12, 31)),
+        ):
+            evaluation = evaluate_anchored_fold(
+                population,
+                test_start=test_start,
+                test_end=test_end,
+                ambiguity_arm=ambiguity_arm,
+            )
+            payload = asdict(evaluation)
+            payload.pop("returns")
+            payload.pop("entry_dates")
+            payload["bootstrap"] = _bootstrap_payload(evaluation.returns, evaluation.entry_dates)
+            folds.append(payload)
+    return {
+        "candidate_version": CANDIDATE_VERSION,
+        "corpus_vendor": CORPUS_VENDORS[0],
+        "comparator_snapshot": SNAPSHOT_ID,
+        "quarantine_rule_set": QUARANTINE_RULE_SET_VERSION,
+        "quarantine_arm": quarantine_arm,
+        "development_end": DEVELOPMENT_END,
+        "terminal_holdout_accessed_by_this_run": False,
+        "series_count": len(series_rows),
+        "skipped_unmapped_sector": skipped_sector,
+        "empty_or_uncovered_series": empty_series,
+        "extraction_census": asdict(census),
+        "folds": folds,
+        "elapsed_seconds": time.monotonic() - started,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quarantine-arm", choices=("masked", "admitted"), required=True)
+    args = parser.parse_args()
+    print(json.dumps(run(quarantine_arm=args.quarantine_arm), sort_keys=True, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_2499_residual_confluence.py
+++ b/scripts/verify_2499_residual_confluence.py
@@ -82,6 +82,9 @@ def _series(rows: list[tuple[Any, ...]], *, arm: QuarantineArm) -> BarSeries:
         dates.append(bar_date)
         bars.append(
             OHLCVRow(
+                # Quarantine intentionally has no open-price verdict axis.
+                # The shared masking contract retains positive opens and
+                # masks non-positive opens by value (#2354).
                 open=(Decimal(open_) if open_ is not None and (admit or open_ > 0) else None),  # type: ignore[typeddict-item]
                 high=Decimal(high) if high is not None and (admit or range_usable) else None,  # type: ignore[typeddict-item]
                 low=Decimal(low) if low is not None and (admit or range_usable) else None,  # type: ignore[typeddict-item]

--- a/tests/test_residual_confluence_evaluation.py
+++ b/tests/test_residual_confluence_evaluation.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.indicator_series import BarSeries
+from app.services.residual_confluence_candidate import compute_features
+from app.services.residual_confluence_evaluation import (
+    CandidateObservation,
+    evaluate_anchored_fold,
+    extract_segment_observations,
+)
+from app.services.technical_analysis import OHLCVRow
+
+
+def _fixture(
+    *, ambiguous: bool = False, signal_return: float = -0.05
+) -> tuple[BarSeries, dict[date, Decimal], dict[date, Decimal], int]:
+    count = 272
+    signal_index = 260
+    dates = tuple(date(2023, 1, 1) + timedelta(days=index) for index in range(count))
+    market_returns = [0.0004 * math.sin(index / 7) + 0.0001 for index in range(count)]
+    sector_returns = [0.0005 * math.cos(index / 11) - 0.0001 for index in range(count)]
+    residuals = [0.0007 * math.sin(index / 5) for index in range(count)]
+    instrument_returns = [
+        0.00005 + 1.2 * market + 0.7 * sector + residual
+        for market, sector, residual in zip(market_returns, sector_returns, residuals, strict=True)
+    ]
+    instrument_returns[signal_index] = signal_return
+
+    def levels(returns: list[float], start: Decimal) -> list[Decimal]:
+        values = [start]
+        for value in returns[1:]:
+            values.append(values[-1] * Decimal(str(math.exp(value))))
+        return values
+
+    market_levels = levels(market_returns, Decimal("400"))
+    sector_levels = levels(sector_returns, Decimal("100"))
+    instrument_levels = levels(instrument_returns, Decimal("50"))
+    rows: list[OHLCVRow] = []
+    for index, close in enumerate(instrument_levels):
+        open_ = close
+        rows.append(
+            OHLCVRow(
+                open=open_,
+                high=open_ + Decimal("1"),
+                low=open_ - Decimal("1"),
+                close=close,
+                volume=1_000_000 + index * 100,
+            )
+        )
+    fill = instrument_levels[signal_index + 1]
+    rows[signal_index + 1] = OHLCVRow(
+        open=fill,
+        high=fill + Decimal("10"),
+        low=fill - (Decimal("10") if ambiguous else Decimal("0.5")),
+        close=fill,
+        volume=1_000_000,
+    )
+    return (
+        BarSeries(dates=dates, rows=tuple(rows)),
+        dict(zip(dates, market_levels, strict=True)),
+        dict(zip(dates, sector_levels, strict=True)),
+        signal_index,
+    )
+
+
+def test_extraction_matches_scalar_feature_contract_and_resolves_target() -> None:
+    series, market_closes, sector_closes, signal_index = _fixture()
+    observations, census = extract_segment_observations(
+        instrument_id=42,
+        series=series,
+        market_closes=market_closes,
+        sector_closes=sector_closes,
+    )
+    observation = next(item for item in observations if item.signal_date == series.dates[signal_index])
+    instrument_returns = [
+        math.log(float(series.rows[index]["close"] / series.rows[index - 1]["close"]))
+        for index in range(1, len(series))
+    ]
+    market_returns = [
+        math.log(float(market_closes[series.dates[index]] / market_closes[series.dates[index - 1]]))
+        for index in range(1, len(series))
+    ]
+    sector_returns = [
+        math.log(float(sector_closes[series.dates[index]] / sector_closes[series.dates[index - 1]]))
+        for index in range(1, len(series))
+    ]
+    prior_volumes = [series.rows[index]["volume"] for index in range(signal_index - 20, signal_index)]
+    signal_volume = series.rows[signal_index]["volume"]
+    assert all(value is not None for value in prior_volumes) and signal_volume is not None
+    scalar = compute_features(
+        prior_instrument_returns=instrument_returns[signal_index - 127 : signal_index - 1],
+        prior_market_returns=market_returns[signal_index - 253 : signal_index - 1],
+        prior_sector_returns=sector_returns[signal_index - 127 : signal_index - 1],
+        prior_closes=[float(series.rows[index]["close"]) for index in range(signal_index - 20, signal_index)],
+        prior_volumes=[float(value) for value in prior_volumes if value is not None],
+        signal_instrument_return=instrument_returns[signal_index - 1],
+        signal_market_return=market_returns[signal_index - 1],
+        signal_sector_return=sector_returns[signal_index - 1],
+        signal_open=float(series.rows[signal_index]["open"]),
+        signal_high=float(series.rows[signal_index]["high"]),
+        signal_low=float(series.rows[signal_index]["low"]),
+        signal_close=float(series.rows[signal_index]["close"]),
+        signal_volume=float(signal_volume),
+    )
+    assert observation.model_row == pytest.approx(scalar.model_row)
+    assert observation.observed_class == "target_first"
+    assert observation.realised_net_return_pct is not None
+    assert observation.target_net_payoff_pct > 0
+    assert observation.stop_net_payoff_pct < 0
+    assert census.observations == len(observations)
+
+
+def test_ambiguous_bar_remains_two_explicit_arms() -> None:
+    series, market_closes, sector_closes, signal_index = _fixture(ambiguous=True)
+    observations, _ = extract_segment_observations(
+        instrument_id=42,
+        series=series,
+        market_closes=market_closes,
+        sector_closes=sector_closes,
+    )
+    observation = next(item for item in observations if item.signal_date == series.dates[signal_index])
+    assert observation.observed_class == "ambiguous"
+    assert observation.realised_net_return_pct is None
+    assert observation.label_for_arm("best_case") == "target_first"
+    assert observation.label_for_arm("worst_case") == "stop_first"
+    assert observation.return_for_arm("best_case") > 0
+    assert observation.return_for_arm("worst_case") < 0
+
+
+def test_missing_exact_comparator_session_refuses_affected_window() -> None:
+    series, market_closes, sector_closes, signal_index = _fixture()
+    del market_closes[series.dates[signal_index]]
+    observations, _ = extract_segment_observations(
+        instrument_id=42,
+        series=series,
+        market_closes=market_closes,
+        sector_closes=sector_closes,
+    )
+    assert all(item.signal_date != series.dates[signal_index] for item in observations)
+
+
+def test_extra_instrument_session_is_omitted_without_poisoning_common_axis() -> None:
+    series, market_closes, sector_closes, signal_index = _fixture()
+    del market_closes[series.dates[signal_index - 10]]
+    del sector_closes[series.dates[signal_index - 10]]
+    observations, _ = extract_segment_observations(
+        instrument_id=42,
+        series=series,
+        market_closes=market_closes,
+        sector_closes=sector_closes,
+    )
+    assert any(item.signal_date == series.dates[signal_index] for item in observations)
+
+
+def test_incomplete_frontier_outcomes_are_refused_and_counted() -> None:
+    series, market_closes, sector_closes, _ = _fixture()
+    observations, census = extract_segment_observations(
+        instrument_id=42,
+        series=BarSeries(dates=series.dates[:263], rows=series.rows[:263]),
+        market_closes=market_closes,
+        sector_closes=sector_closes,
+    )
+    assert census.incomplete_outcome > 0
+    assert all(item.exit_date <= series.dates[262] for item in observations)
+
+
+def test_target_that_cannot_clear_frozen_spread_is_refused() -> None:
+    series, market_closes, sector_closes, _ = _fixture(signal_return=-0.001)
+    narrow_rows = tuple(
+        OHLCVRow(
+            open=row["close"],
+            high=row["close"] + Decimal("0.001"),
+            low=row["close"] - Decimal("0.001"),
+            close=row["close"],
+            volume=row["volume"],
+        )
+        for row in series.rows
+    )
+    observations, census = extract_segment_observations(
+        instrument_id=42,
+        series=BarSeries(dates=series.dates, rows=narrow_rows),
+        market_closes=market_closes,
+        sector_closes=sector_closes,
+    )
+    assert not observations
+    assert census.uneconomic_bracket > 0
+
+
+def _model_observations() -> tuple[CandidateObservation, ...]:
+    observations: list[CandidateObservation] = []
+    classes = ("target_first", "stop_first", "timeout")
+    for index in range(36):
+        signal = date(2023, 1, 2) + timedelta(days=index * 7)
+        outcome = classes[index % 3]
+        realised = 2.0 if outcome == "target_first" else -1.5 if outcome == "stop_first" else -0.2
+        observations.append(
+            CandidateObservation(
+                instrument_id=index % 5 + 1,
+                signal_date=signal,
+                entry_date=signal + timedelta(days=1),
+                exit_date=signal + timedelta(days=3),
+                model_row=(
+                    -0.1 - index / 20,
+                    math.sin(index),
+                    math.cos(index / 2),
+                    16.0 + index / 100,
+                    0.8 + index / 200,
+                    math.sin(index / 3),
+                ),
+                observed_class=outcome,  # type: ignore[arg-type]
+                target_net_payoff_pct=2.0,
+                stop_net_payoff_pct=-1.5,
+                realised_net_return_pct=realised,
+            )
+        )
+    for index in range(9):
+        signal = date(2024, 1, 2) + timedelta(days=index // 3)
+        outcome = classes[index % 3]
+        realised = 2.0 if outcome == "target_first" else -1.5 if outcome == "stop_first" else -0.2
+        observations.append(
+            CandidateObservation(
+                instrument_id=index % 3 + 1,
+                signal_date=signal,
+                entry_date=signal + timedelta(days=1),
+                exit_date=signal + timedelta(days=3),
+                model_row=(
+                    -0.2 - index / 10,
+                    math.sin(index + 1),
+                    math.cos(index / 2 + 1),
+                    16.5 + index / 100,
+                    0.9 + index / 100,
+                    math.sin(index / 3 + 1),
+                ),
+                observed_class=outcome,  # type: ignore[arg-type]
+                target_net_payoff_pct=4.0,
+                stop_net_payoff_pct=-1.0,
+                realised_net_return_pct=realised,
+            )
+        )
+    return tuple(observations)
+
+
+def test_anchored_fold_trains_only_on_completed_prior_outcomes_and_suppresses_overlap() -> None:
+    observations = _model_observations()
+    evaluation = evaluate_anchored_fold(
+        observations,
+        test_start=date(2024, 1, 1),
+        test_end=date(2024, 12, 31),
+        ambiguity_arm="worst_case",
+    )
+    assert evaluation.training_count == 36
+    assert evaluation.test_candidate_count == 9
+    assert evaluation.accepted_count <= evaluation.test_candidate_count
+    assert evaluation.overlap_suppressed > 0
+    assert math.isfinite(evaluation.brier_score)
+    assert math.isfinite(evaluation.log_loss)
+    assert len(evaluation.returns) == len(evaluation.entry_dates) == evaluation.accepted_count
+    assert evaluation.baseline_count > 0
+    assert evaluation.baseline_expectancy_pct is not None
+    assert evaluation.max_entry_date_share_pct is not None
+    assert sum(count for _, count in evaluation.observed_class_counts) == evaluation.accepted_count
+    assert len(evaluation.ev_deciles) == min(10, evaluation.baseline_count)
+    assert sum(bucket.count for bucket in evaluation.ev_deciles) == evaluation.baseline_count


### PR DESCRIPTION
## Outcome

Rejects residual-confluence candidate #2499 before it can enter the strategy catalogue, scanner, capital or order paths. Adds a bounded read-only development verifier and records the detailed reason it fails.

## Evidence

- Corrected development frontier is 2025-12-31; no 2026 bars are accessible to the final verifier.
- Masked 2025 conservative arm: 421 accepted trades, 43.23% win rate, -1.332% expectancy, profit factor 0.66, clustered 95% CI -4.288% to +2.202%.
- All four masked fold/ambiguity confidence intervals cross zero.
- An unfiltered same-overlap baseline loses about 0.32%-0.35% per trade, but the model's ranking fails at its actual EV>0 action boundary.
- 36.1% of conservative 2025 accepted trades enter on one date; effective n is only 19.
- Quarantine admission does not repair the failure.

## Integrity disclosure

Two discarded diagnostic processes loaded bars beyond 2025 while constructing observations. Although they did not report a 2026 fold, that is terminal holdout access. The report permanently marks the intended 2026 holdout contaminated; it will not be used to rescue this candidate.

## Verification

- 29 focused candidate/evaluator tests pass.
- Full pre-push gate passes: Ruff, formatting, Pyright, repository lints, fast suite, smoke suite and frontend integrity checks.
- Both masked and admitted read-only verifier arms completed against the frozen corpus/comparator snapshot.

Closes #2499. Refs #2469 and #2505.
