### PR TITLE
feat: harvest bounded eToro intraday evidence

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -129,6 +129,7 @@ from app.workers.scheduler import (
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
     JOB_STRATEGY_BACKTEST_RUN,
+    JOB_STRATEGY_INTRADAY_HARVEST,
     JOB_STRATEGY_OBSERVATION_RETENTION,
     JOB_STRATEGY_OUTCOME_RESOLUTION,
     JOB_STRATEGY_PAPER_CYCLE,
@@ -198,6 +199,7 @@ from app.workers.scheduler import (
     sec_nport_filer_directory_sync,
     seed_cost_models,
     strategy_backtest_run,
+    strategy_intraday_harvest,
     strategy_observation_retention,
     strategy_outcome_resolution,
     strategy_paper_cycle,
@@ -352,6 +354,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # the frontier watermark rather than by a DAG edge. Own "strategy_scan" lane,
     # resolved from SCHEDULED_JOBS, so no MANUAL_TRIGGER_JOB_SOURCES entry.
     JOB_STRATEGY_SIGNAL_SCAN: _adapt_zero_arg(strategy_signal_scan),
+    JOB_STRATEGY_INTRADAY_HARVEST: _adapt_zero_arg(strategy_intraday_harvest),
     JOB_STRATEGY_OUTCOME_RESOLUTION: _adapt_zero_arg(strategy_outcome_resolution),
     JOB_STRATEGY_OBSERVATION_RETENTION: _adapt_zero_arg(strategy_observation_retention),
     JOB_STRATEGY_PAPER_CYCLE: _adapt_zero_arg(strategy_paper_cycle),

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -112,8 +112,8 @@ the rate — it does not.
 
 * ``init`` — universe-sync only. Pre-everything fence; one job total.
 * ``etoro`` — eToro REST budget. ``execute_approved_orders`` +
-  ``daily_candle_refresh`` + ``etoro_lookups_refresh`` +
-  ``exchanges_metadata_refresh`` serialise.
+  ``daily_candle_refresh`` + ``strategy_intraday_harvest`` +
+  ``etoro_lookups_refresh`` + ``exchanges_metadata_refresh`` serialise.
 * ``sec_rate`` — the SEC discovery/producer jobs (per-accession fetchers +
   per-issuer ingest). They serialise under one ``JobLock`` to bound job
   overlap, NOT request rate (the HTTP floor above bounds rate). #1478
@@ -345,7 +345,9 @@ when one overruns). Scheduled-only, so NOT added to the
   writer of the signal/count/observation relations and scan watermark; the
   outcome resolver stores one terminal row per fired signal/version and never
   stores immature polling state; the retention sibling drops only expired leaf
-  partitions after both producers;
+  partitions after both producers. Intraday harvesting uses the ``etoro`` lane,
+  and both its writer and this retention job take the same per-tier transaction
+  advisory locks before touching intraday partitions;
   reads ``price_daily`` / ``price_bar_quarantine`` MVCC-safe. ⚠ The lane is
   load-bearing for CORRECTNESS here, unlike the two above where it is a
   starvation fix: ``store_signals`` has no ``ON CONFLICT``, so two overlapping

--- a/app/services/strategy_intraday_harvest.py
+++ b/app/services/strategy_intraday_harvest.py
@@ -1,0 +1,342 @@
+"""Bounded prospective eToro intraday research harvester.
+
+The provider has no date anchor, so retained history can only grow from repeated
+recent-window fetches.  This service reads one predeclared active universe,
+filters forming and non-RTH candles, removes overlap at the durable watermark,
+records (but never fills) gaps, and delegates all bar writes/caps/retention
+invariants to :mod:`strategy_observation_storage`.
+
+Refs #2477. Schema: ``sql/298_strategy_intraday_harvest.sql``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from decimal import Decimal
+from typing import Any, Final, cast
+from zoneinfo import ZoneInfo
+
+import psycopg
+
+from app.providers.market_data import IntradayBar as ProviderBar
+from app.providers.market_data import IntradayInterval, MarketDataProvider
+from app.services.market_calendar import us_market_status
+from app.services.strategy_observation_storage import (
+    INTRADAY_TIERS,
+    IntradayBar,
+    Timeframe,
+    store_intraday_bars,
+)
+
+MAX_REQUESTS_PER_RUN: Final = 12
+MAX_PROVIDER_BARS: Final = 1_000
+_OVERLAP_BARS: Final = 3
+_NY: Final = ZoneInfo("America/New_York")
+_INTERVALS: Final[dict[Timeframe, IntradayInterval]] = {
+    "30m": "ThirtyMinutes",
+    "5m": "FiveMinutes",
+    "1m": "OneMinute",
+}
+
+
+@dataclass(frozen=True)
+class HarvestMember:
+    universe_version: str
+    ordinal: int
+    timeframe: Timeframe
+    symbol: str
+    instrument_id: int | None
+    resolution_error: str | None = None
+
+
+@dataclass(frozen=True)
+class HarvestFailure:
+    timeframe: Timeframe
+    symbol: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class HarvestReport:
+    universe_version: str
+    selected: int
+    fetched: int
+    completed_rth: int
+    written: int
+    gaps_recorded: int
+    failures: tuple[HarvestFailure, ...]
+
+
+def _session_bounds(value: date) -> tuple[datetime, datetime] | None:
+    status = us_market_status(value)
+    if status == "closed":
+        return None
+    close = time(13) if status == "half_day" else time(16)
+    return (
+        datetime.combine(value, time(9, 30), tzinfo=_NY).astimezone(UTC),
+        datetime.combine(value, close, tzinfo=_NY).astimezone(UTC),
+    )
+
+
+def _completed_rth_bars(
+    bars: Sequence[ProviderBar],
+    *,
+    timeframe: Timeframe,
+    observed_at: datetime,
+) -> list[ProviderBar]:
+    """Return unique completed NYSE-session bars, refusing conflicting duplicates."""
+    if observed_at.tzinfo is None:
+        raise ValueError("observed_at must be timezone-aware")
+    duration = timedelta(minutes=INTRADAY_TIERS[timeframe].minutes_per_bar)
+    by_time: dict[datetime, ProviderBar] = {}
+    for bar in bars:
+        if bar.timestamp.tzinfo is None:
+            raise ValueError("provider returned a timezone-naive intraday timestamp")
+        stamp = bar.timestamp.astimezone(UTC)
+        if stamp + duration > observed_at.astimezone(UTC):
+            continue
+        bounds = _session_bounds(stamp.astimezone(_NY).date())
+        if bounds is None or stamp < bounds[0] or stamp + duration > bounds[1]:
+            continue
+        prior = by_time.get(stamp)
+        if prior is not None and prior != bar:
+            raise ValueError(f"provider returned conflicting duplicate candle at {stamp.isoformat()}")
+        by_time[stamp] = bar
+    return [by_time[key] for key in sorted(by_time)]
+
+
+def _fetch_count(*, timeframe: Timeframe, watermark: datetime | None, observed_at: datetime) -> int:
+    if watermark is None:
+        return MAX_PROVIDER_BARS
+    elapsed = observed_at.astimezone(UTC) - watermark.astimezone(UTC)
+    duration = timedelta(minutes=INTRADAY_TIERS[timeframe].minutes_per_bar)
+    estimated = int(elapsed / duration) + _OVERLAP_BARS
+    return min(MAX_PROVIDER_BARS, max(_OVERLAP_BARS, estimated))
+
+
+def _gap_ranges(
+    stamps: Sequence[datetime],
+    *,
+    timeframe: Timeframe,
+    watermark: datetime | None,
+) -> tuple[tuple[datetime, datetime], ...]:
+    """Detect missing intervals inside an observed RTH path; never infer overnight gaps."""
+    if not stamps:
+        return ()
+    duration = timedelta(minutes=INTRADAY_TIERS[timeframe].minutes_per_bar)
+    ordered = sorted(stamp.astimezone(UTC) for stamp in stamps)
+    points = ([watermark.astimezone(UTC)] if watermark is not None else []) + ordered
+    gaps: list[tuple[datetime, datetime]] = []
+    for left, right in zip(points, points[1:], strict=False):
+        if left.astimezone(_NY).date() != right.astimezone(_NY).date():
+            continue
+        if right > left + duration:
+            gaps.append((left + duration, right))
+    return tuple(gaps)
+
+
+def _active_members(conn: psycopg.Connection[Any]) -> tuple[str, list[HarvestMember], int]:
+    versions = conn.execute(
+        """
+        SELECT universe_version
+        FROM strategy_intraday_universe_versions
+        WHERE status = 'active'
+        ORDER BY universe_version
+        """
+    ).fetchall()
+    if len(versions) != 1:
+        raise RuntimeError(f"expected exactly one active intraday universe, found {len(versions)}")
+    version = str(versions[0][0])
+    rows = conn.execute(
+        """
+        SELECT member.ordinal, member.timeframe, member.symbol,
+               array_agg(instrument.instrument_id ORDER BY instrument.instrument_id)
+                   FILTER (WHERE instrument.instrument_id IS NOT NULL) AS instrument_ids
+        FROM strategy_intraday_universe_members AS member
+        LEFT JOIN instruments AS instrument
+          ON instrument.symbol = member.symbol
+         AND instrument.is_tradable = true
+        WHERE member.universe_version = %(version)s
+        GROUP BY member.ordinal, member.timeframe, member.symbol
+        ORDER BY member.ordinal
+        """,
+        {"version": version},
+    ).fetchall()
+    cursor_row = conn.execute(
+        "SELECT last_ordinal FROM strategy_intraday_harvest_cursors WHERE universe_version = %s",
+        (version,),
+    ).fetchone()
+    cursor = int(cursor_row[0]) if cursor_row else 0
+    members: list[HarvestMember] = []
+    for ordinal, timeframe, symbol, instrument_ids in rows:
+        ids = [int(value) for value in instrument_ids or []]
+        members.append(
+            HarvestMember(
+                version,
+                int(ordinal),
+                cast(Timeframe, str(timeframe)),
+                str(symbol),
+                ids[0] if len(ids) == 1 else None,
+                None if len(ids) == 1 else f"expected one tradable instrument, found {len(ids)}",
+            )
+        )
+    if not members:
+        raise RuntimeError(f"active intraday universe {version!r} has no members")
+    return version, members, cursor
+
+
+def _round_robin(members: Sequence[HarvestMember], *, cursor: int, limit: int) -> list[HarvestMember]:
+    if limit <= 0:
+        raise ValueError("request limit must be positive")
+    start = next((index for index, member in enumerate(members) if member.ordinal > cursor), 0)
+    width = min(limit, len(members))
+    return [members[(start + offset) % len(members)] for offset in range(width)]
+
+
+def _watermark(conn: psycopg.Connection[Any], member: HarvestMember) -> datetime | None:
+    if member.instrument_id is None:
+        raise RuntimeError(f"cannot read a watermark for unresolved member {member.symbol}")
+    row = conn.execute(
+        """
+        SELECT last_bar_time
+        FROM strategy_intraday_watermarks
+        WHERE timeframe = %(timeframe)s AND instrument_id = %(instrument_id)s
+        """,
+        {"timeframe": member.timeframe, "instrument_id": member.instrument_id},
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _record_gaps(
+    conn: psycopg.Connection[Any],
+    *,
+    member: HarvestMember,
+    gaps: Sequence[tuple[datetime, datetime]],
+    observed_at: datetime,
+) -> int:
+    if member.instrument_id is None:
+        raise RuntimeError(f"cannot record gaps for unresolved member {member.symbol}")
+    if not gaps:
+        return 0
+    with conn.transaction():
+        with conn.cursor() as cur:
+            cur.executemany(
+                """
+                INSERT INTO strategy_intraday_gaps (
+                    universe_version, timeframe, instrument_id,
+                    gap_start, gap_end, first_detected_at, last_detected_at
+                ) VALUES (
+                    %(version)s, %(timeframe)s, %(instrument_id)s,
+                    %(gap_start)s, %(gap_end)s, %(observed_at)s, %(observed_at)s
+                )
+                ON CONFLICT (universe_version, timeframe, instrument_id, gap_start, gap_end)
+                DO UPDATE SET last_detected_at = EXCLUDED.last_detected_at
+                """,
+                [
+                    {
+                        "version": member.universe_version,
+                        "timeframe": member.timeframe,
+                        "instrument_id": member.instrument_id,
+                        "gap_start": gap[0],
+                        "gap_end": gap[1],
+                        "observed_at": observed_at,
+                    }
+                    for gap in gaps
+                ],
+            )
+    return len(gaps)
+
+
+def _advance_cursor(conn: psycopg.Connection[Any], member: HarvestMember) -> None:
+    with conn.transaction():
+        conn.execute(
+            """
+            INSERT INTO strategy_intraday_harvest_cursors (universe_version, last_ordinal, updated_at)
+            VALUES (%(version)s, %(ordinal)s, now())
+            ON CONFLICT (universe_version) DO UPDATE
+               SET last_ordinal = EXCLUDED.last_ordinal,
+                   updated_at = now()
+            """,
+            {"version": member.universe_version, "ordinal": member.ordinal},
+        )
+
+
+def run_intraday_harvest(
+    conn: psycopg.Connection[Any],
+    provider: MarketDataProvider,
+    *,
+    observed_at: datetime,
+    max_requests: int = MAX_REQUESTS_PER_RUN,
+) -> HarvestReport:
+    """Fetch one bounded round-robin slice of the active research universe."""
+    if observed_at.tzinfo is None:
+        raise ValueError("observed_at must be timezone-aware")
+    version, members, cursor = _active_members(conn)
+    selected = _round_robin(members, cursor=cursor, limit=min(max_requests, MAX_REQUESTS_PER_RUN))
+    fetched = completed = written = gaps_recorded = 0
+    failures: list[HarvestFailure] = []
+    for member in selected:
+        if member.resolution_error is not None or member.instrument_id is None:
+            failures.append(
+                HarvestFailure(
+                    member.timeframe,
+                    member.symbol,
+                    f"universe_resolution: {member.resolution_error or 'instrument id missing'}",
+                )
+            )
+            _advance_cursor(conn, member)
+            continue
+        try:
+            watermark = _watermark(conn, member)
+            provider_bars = provider.get_intraday_candles(
+                member.instrument_id,
+                _INTERVALS[member.timeframe],
+                _fetch_count(timeframe=member.timeframe, watermark=watermark, observed_at=observed_at),
+            )
+            fetched += len(provider_bars)
+            rth = _completed_rth_bars(provider_bars, timeframe=member.timeframe, observed_at=observed_at)
+            completed += len(rth)
+            new = [bar for bar in rth if watermark is None or bar.timestamp.astimezone(UTC) > watermark]
+            gaps = _gap_ranges([bar.timestamp for bar in new], timeframe=member.timeframe, watermark=watermark)
+            rows = [
+                IntradayBar(
+                    timeframe=member.timeframe,
+                    bar_time=bar.timestamp.astimezone(UTC),
+                    instrument_id=member.instrument_id,
+                    open=Decimal(bar.open),
+                    high=Decimal(bar.high),
+                    low=Decimal(bar.low),
+                    close=Decimal(bar.close),
+                    volume=None if bar.volume is None else Decimal(bar.volume),
+                    source=f"etoro/{version}/nyse_rth",
+                )
+                for bar in new
+            ]
+            report = store_intraday_bars(conn, rows, observed_at=observed_at)
+            written += report.rows_written
+            gaps_recorded += _record_gaps(conn, member=member, gaps=gaps, observed_at=observed_at.astimezone(UTC))
+        except Exception as exc:
+            failures.append(HarvestFailure(member.timeframe, member.symbol, f"{type(exc).__name__}: {exc}"))
+        finally:
+            _advance_cursor(conn, member)
+    return HarvestReport(
+        universe_version=version,
+        selected=len(selected),
+        fetched=fetched,
+        completed_rth=completed,
+        written=written,
+        gaps_recorded=gaps_recorded,
+        failures=tuple(failures),
+    )
+
+
+__all__ = [
+    "MAX_PROVIDER_BARS",
+    "MAX_REQUESTS_PER_RUN",
+    "HarvestFailure",
+    "HarvestMember",
+    "HarvestReport",
+    "run_intraday_harvest",
+]

--- a/app/services/strategy_intraday_harvest.py
+++ b/app/services/strategy_intraday_harvest.py
@@ -318,7 +318,10 @@ def run_intraday_harvest(
             written += report.rows_written
             gaps_recorded += _record_gaps(conn, member=member, gaps=gaps, observed_at=observed_at.astimezone(UTC))
         except Exception as exc:
-            failures.append(HarvestFailure(member.timeframe, member.symbol, f"{type(exc).__name__}: {exc}"))
+            # Provider messages can contain request URLs, identifiers or
+            # upstream response fragments. Persist the stable exception class
+            # for diagnosis without copying those internals into job_runs.
+            failures.append(HarvestFailure(member.timeframe, member.symbol, type(exc).__name__))
         finally:
             _advance_cursor(conn, member)
     return HarvestReport(

--- a/app/services/strategy_observation_storage.py
+++ b/app/services/strategy_observation_storage.py
@@ -636,13 +636,9 @@ def _partition_names(conn: psycopg.Connection[Any]) -> tuple[str, ...]:
     return tuple(str(row[0]) for row in rows)
 
 
-def retention_plan(conn: psycopg.Connection[Any], *, as_of: datetime) -> RetentionPlan:
-    """Return only leaf relations whose entire bound is outside retention."""
-    if as_of.tzinfo is None:
-        raise ValueError("as_of must be timezone-aware")
-    today = as_of.astimezone(UTC).date()
-    signal_cutoff = today - timedelta(days=SIGNAL_DETAIL_RETENTION_DAYS)
-    intraday_cutoffs = {
+def _intraday_retention_cutoffs(today: date) -> dict[Timeframe, date]:
+    """Resolve each tier's day/month policy to one exclusive date cutoff."""
+    return {
         timeframe: (
             today - timedelta(days=tier.retention_days)
             if tier.retention_days is not None
@@ -650,6 +646,15 @@ def retention_plan(conn: psycopg.Connection[Any], *, as_of: datetime) -> Retenti
         )
         for timeframe, tier in INTRADAY_TIERS.items()
     }
+
+
+def retention_plan(conn: psycopg.Connection[Any], *, as_of: datetime) -> RetentionPlan:
+    """Return only leaf relations whose entire bound is outside retention."""
+    if as_of.tzinfo is None:
+        raise ValueError("as_of must be timezone-aware")
+    today = as_of.astimezone(UTC).date()
+    signal_cutoff = today - timedelta(days=SIGNAL_DETAIL_RETENTION_DAYS)
+    intraday_cutoffs = _intraday_retention_cutoffs(today)
     signal: list[str] = []
     intraday: list[str] = []
     for name in _partition_names(conn):
@@ -699,14 +704,7 @@ def drop_expired_partitions(conn: psycopg.Connection[Any], *, as_of: datetime, d
             # second boundary. A caller can never supply a relation name.
             conn.execute(psycopg.sql.SQL("DROP TABLE {}").format(psycopg.sql.Identifier(name)))
         today = as_of.astimezone(UTC).date()
-        intraday_cutoffs = {
-            timeframe: (
-                today - timedelta(days=tier.retention_days)
-                if tier.retention_days is not None
-                else _months_before(today, cast(int, tier.retention_months))
-            )
-            for timeframe, tier in INTRADAY_TIERS.items()
-        }
+        intraday_cutoffs = _intraday_retention_cutoffs(today)
         deleted_gaps = conn.execute(
             """
             DELETE FROM strategy_intraday_gaps

--- a/app/services/strategy_observation_storage.py
+++ b/app/services/strategy_observation_storage.py
@@ -127,6 +127,7 @@ class IntradayStorageReport:
 class RetentionPlan:
     signal_partitions: tuple[str, ...]
     intraday_partitions: tuple[str, ...]
+    intraday_gap_rows: int = 0
 
     @property
     def partitions(self) -> tuple[str, ...]:
@@ -667,7 +668,21 @@ def retention_plan(conn: psycopg.Connection[Any], *, as_of: datetime) -> Retenti
             end = date(int(match[1]), int(match[2]), int(match[3])) + timedelta(days=1)
             if end <= intraday_cutoffs["1m"]:
                 intraday.append(name)
-    return RetentionPlan(tuple(signal), tuple(intraday))
+    gap_row = conn.execute(
+        """
+        SELECT count(*)
+        FROM strategy_intraday_gaps
+        WHERE (timeframe = '30m' AND gap_end <= %(cutoff_30m)s)
+           OR (timeframe = '5m'  AND gap_end <= %(cutoff_5m)s)
+           OR (timeframe = '1m'  AND gap_end <= %(cutoff_1m)s)
+        """,
+        {
+            "cutoff_30m": datetime.combine(intraday_cutoffs["30m"], datetime.min.time(), tzinfo=UTC),
+            "cutoff_5m": datetime.combine(intraday_cutoffs["5m"], datetime.min.time(), tzinfo=UTC),
+            "cutoff_1m": datetime.combine(intraday_cutoffs["1m"], datetime.min.time(), tzinfo=UTC),
+        },
+    ).fetchone()
+    return RetentionPlan(tuple(signal), tuple(intraday), int(gap_row[0]) if gap_row else 0)
 
 
 def drop_expired_partitions(conn: psycopg.Connection[Any], *, as_of: datetime, dry_run: bool = True) -> RetentionPlan:
@@ -683,6 +698,30 @@ def drop_expired_partitions(conn: psycopg.Connection[Any], *, as_of: datetime, d
             # patterns in ``retention_plan``; Identifier handles quoting as a
             # second boundary. A caller can never supply a relation name.
             conn.execute(psycopg.sql.SQL("DROP TABLE {}").format(psycopg.sql.Identifier(name)))
+        today = as_of.astimezone(UTC).date()
+        intraday_cutoffs = {
+            timeframe: (
+                today - timedelta(days=tier.retention_days)
+                if tier.retention_days is not None
+                else _months_before(today, cast(int, tier.retention_months))
+            )
+            for timeframe, tier in INTRADAY_TIERS.items()
+        }
+        deleted_gaps = conn.execute(
+            """
+            DELETE FROM strategy_intraday_gaps
+            WHERE (timeframe = '30m' AND gap_end <= %(cutoff_30m)s)
+               OR (timeframe = '5m'  AND gap_end <= %(cutoff_5m)s)
+               OR (timeframe = '1m'  AND gap_end <= %(cutoff_1m)s)
+            """,
+            {
+                "cutoff_30m": datetime.combine(intraday_cutoffs["30m"], datetime.min.time(), tzinfo=UTC),
+                "cutoff_5m": datetime.combine(intraday_cutoffs["5m"], datetime.min.time(), tzinfo=UTC),
+                "cutoff_1m": datetime.combine(intraday_cutoffs["1m"], datetime.min.time(), tzinfo=UTC),
+            },
+        ).rowcount
+        if deleted_gaps != plan.intraday_gap_rows:
+            raise RuntimeError(f"deleted {deleted_gaps} intraday gap rows against planned {plan.intraday_gap_rows}")
         # Watermarks are bounded control metadata, not observations. Releasing
         # one only after every retained bar for the tier/instrument has expired
         # permits deliberate universe rotation without weakening the cap.

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Final, Literal, cast
+from zoneinfo import ZoneInfo
 
 import psycopg
 import psycopg.rows
@@ -58,6 +59,7 @@ from app.services.execution_guard import evaluate_recommendation
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
 from app.services.job_progress import JobProgress, degradation_reason
 from app.services.llm_client import LLMProviderNotConfigured, make_llm_clients, release_local_models
+from app.services.market_calendar import us_market_status
 from app.services.market_data import most_recent_trading_day, refresh_market_data, refresh_quotes
 from app.services.mf_directory import refresh_mf_directory
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
@@ -652,6 +654,39 @@ def _bootstrap_complete(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
     ):
         return (True, "")
     return (False, "first-install bootstrap not complete; visit /admin to run")
+
+
+_NEW_YORK = ZoneInfo("America/New_York")
+
+
+def _strategy_intraday_collection_window_open(now: datetime) -> bool:
+    """Whether a scheduled harvest can collect a newly completed US bar.
+
+    The provider returns extended-hours candles, but this evidence panel owns
+    NYSE regular-session bars only.  Start at 09:35 ET, after the first 5m bar
+    can have completed, and leave ten minutes after the regular/early close for
+    provider publication lag.  Manual ``Run now`` bypasses prerequisites, so an
+    operator can still repair a gap outside this automatic request window.
+    """
+    if now.tzinfo is None:
+        raise ValueError("intraday collection window requires an aware datetime")
+    local = now.astimezone(_NEW_YORK)
+    status = us_market_status(local.date())
+    if status == "closed":
+        return False
+    minute = local.hour * 60 + local.minute
+    close_minute = 13 * 60 if status == "half_day" else 16 * 60
+    return 9 * 60 + 35 <= minute <= close_minute + 10
+
+
+def _strategy_intraday_collection_due(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """Gate automatic provider calls to bootstrap-complete US sessions."""
+    bootstrap_met, reason = _bootstrap_complete(conn)
+    if not bootstrap_met:
+        return (False, reason)
+    if not _strategy_intraday_collection_window_open(datetime.now(tz=UTC)):
+        return (False, "outside the completed US regular-session bar collection window")
+    return (True, "")
 
 
 def _has_actionable_recommendations(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
@@ -2029,14 +2064,16 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         display_name="Strategy intraday evidence harvest (#2477)",
         source="etoro",
         description=(
-            "Every five minutes -- fetches at most twelve predeclared eToro research windows, "
+            "Every five minutes during the US regular-session collection window -- fetches at "
+            "most twelve predeclared eToro research windows, "
             "retains completed NYSE-RTH bars only, removes watermark overlap and records gaps "
             "without imputation. The active versioned panel is deliberately small; storage "
-            "remains partitioned and retention-capped. Operator Run now uses the same path."
+            "remains partitioned and retention-capped. Operator Run now uses the same collector "
+            "and can repair gaps outside the automatic request window."
         ),
         cadence=Cadence.every_n_minutes(interval=5),
         catch_up_on_boot=False,
-        prerequisite=_bootstrap_complete,
+        prerequisite=_strategy_intraday_collection_due,
     ),
     ScheduledJob(
         name=JOB_STRATEGY_OBSERVATION_RETENTION,

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -378,6 +378,10 @@ JOB_STRATEGY_OUTCOME_RESOLUTION = "strategy_outcome_resolution"
 # #2448 — range-partition retention. Shares ``strategy_scan`` so a partition
 # cannot be dropped while the scanner is inserting into it.
 JOB_STRATEGY_OBSERVATION_RETENTION = "strategy_observation_retention"
+# #2477 -- prospective, bounded eToro intraday research collection.  Shares
+# the provider lane (not strategy_scan): the eToro client's request floor is
+# the rate budget, while the storage writer carries its own tier locks.
+JOB_STRATEGY_INTRADAY_HARVEST = "strategy_intraday_harvest"
 # #2450 — bounded demo execution/reconciliation/owned-position health loop.
 JOB_STRATEGY_PAPER_CYCLE = "strategy_paper_cycle"
 # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY, and NOT because it is
@@ -2017,6 +2021,20 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "row per signal and rule-version pair, processed round-robin in a bounded batch."
         ),
         cadence=Cadence.daily(hour=6, minute=55),
+        catch_up_on_boot=False,
+        prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_STRATEGY_INTRADAY_HARVEST,
+        display_name="Strategy intraday evidence harvest (#2477)",
+        source="etoro",
+        description=(
+            "Every five minutes -- fetches at most twelve predeclared eToro research windows, "
+            "retains completed NYSE-RTH bars only, removes watermark overlap and records gaps "
+            "without imputation. The active versioned panel is deliberately small; storage "
+            "remains partitioned and retention-capped. Operator Run now uses the same path."
+        ),
+        cadence=Cadence.every_n_minutes(interval=5),
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
     ),
@@ -4990,12 +5008,41 @@ def strategy_observation_retention() -> None:
     with _tracked_job(JOB_STRATEGY_OBSERVATION_RETENTION) as tracker:
         with connect_job() as conn:
             plan = drop_expired_partitions(conn, as_of=datetime.now(tz=UTC), dry_run=False)
-            tracker.row_count = len(plan.partitions)
+            tracker.row_count = len(plan.partitions) + plan.intraday_gap_rows
         logger.info(
-            "strategy_observation_retention: dropped %d signal + %d intraday partitions",
+            "strategy_observation_retention: dropped %d signal + %d intraday partitions + %d gap rows",
             len(plan.signal_partitions),
             len(plan.intraday_partitions),
+            plan.intraday_gap_rows,
         )
+
+
+def strategy_intraday_harvest() -> None:
+    """Collect one bounded slice of completed eToro intraday evidence."""
+    from app.services.strategy_intraday_harvest import run_intraday_harvest
+
+    creds = _load_etoro_credentials(JOB_STRATEGY_INTRADAY_HARVEST)
+    if creds is None:
+        _record_prereq_skip(JOB_STRATEGY_INTRADAY_HARVEST, "etoro credentials missing")
+        return
+    api_key, user_key = creds
+    with _tracked_job(JOB_STRATEGY_INTRADAY_HARVEST) as tracker:
+        with (
+            EtoroMarketDataProvider(api_key=api_key, user_key=user_key, env=settings.etoro_env) as provider,
+            # Each instrument is an independent durable unit: a bad/unsupported
+            # member must not roll back bars already collected for its peers.
+            connect_job(autocommit=True) as conn,
+        ):
+            report = run_intraday_harvest(conn, provider, observed_at=datetime.now(tz=UTC))
+        tracker.row_count = report.written
+        tracker.note = (
+            f"universe={report.universe_version} selected={report.selected} fetched={report.fetched} "
+            f"completed_rth={report.completed_rth} written={report.written} "
+            f"gaps={report.gaps_recorded} failures={len(report.failures)}"
+        )
+        if report.failures:
+            detail = "; ".join(f"{failure.timeframe}/{failure.symbol}: {failure.reason}" for failure in report.failures)
+            raise RuntimeError(f"strategy_intraday_harvest: {len(report.failures)} member(s) failed: {detail}")
 
 
 def strategy_paper_cycle() -> None:

--- a/docs/proposals/ta/2026-08-10-etoro-intraday-harvest-evidence.md
+++ b/docs/proposals/ta/2026-08-10-etoro-intraday-harvest-evidence.md
@@ -12,6 +12,11 @@ completed NYSE regular-session bars, filters overlap at the durable watermark,
 and records missing interval ranges without imputation. Gap rows expire on the
 same tier horizon as the bars they describe.
 
+Automatic requests are gated to 09:35 ET through ten minutes after the regular
+or early close. This prevents an every-five-minute schedule consuming provider
+budget when no new RTH bar can exist. The operator-triggered path deliberately
+bypasses the scheduling prerequisite so it can repair gaps out of hours.
+
 This is evidence collection, not a promoted strategy. Demo allocation remains
 fail-closed.
 
@@ -27,6 +32,11 @@ fail-closed.
 The price descriptions document the selection contrast; candidate evaluation
 must derive the contemporaneous as-traded band at each decision. It must not
 reuse today's price or venue as a historical fact.
+
+NYSE/Nasdaq above means the current **primary listing market**, not execution
+venue. An NMS stock may execute on another exchange, ATS or broker-dealer
+internaliser. Listing-market cohorts cannot stand in for broker routing,
+spread, slippage or venue-level execution quality.
 
 ## First live provider run
 
@@ -54,6 +64,10 @@ belonged to CENN; one each belonged to QQQ 30m and IWM 5m. They remain gaps.
 An immediate identical end-to-end scheduled rerun fetched 6,571 provider bars,
 wrote zero rows and recorded zero new gaps. Its `job_runs` row was `success`,
 proving overlap idempotence through the real provider/job/database path.
+
+The first in-session V2 pass at 09:35 ET wrote 18 newly completed bars across
+the bounded 12-member slice with zero failures. This confirms the incremental
+path against live-session rather than historical-only responses.
 
 After activating V2 and running two bounded passes, dev held:
 

--- a/docs/proposals/ta/2026-08-10-etoro-intraday-harvest-evidence.md
+++ b/docs/proposals/ta/2026-08-10-etoro-intraday-harvest-evidence.md
@@ -69,6 +69,13 @@ The first in-session V2 pass at 09:35 ET wrote 18 newly completed bars across
 the bounded 12-member slice with zero failures. This confirms the incremental
 path against live-session rather than historical-only responses.
 
+A second in-session tracked pass at 09:40 ET measured 20,184 WAL bytes for the
+whole job while writing four new bars (5,046 bytes/new bar at this very small
+increment). The total includes fixed `job_runs`, cursor, index and commit WAL,
+so bytes-per-row is intentionally conservative and should not be extrapolated
+linearly. More importantly for operational load, the complete bounded fire was
+about 20 KiB and succeeded with zero gaps or member failures.
+
 After activating V2 and running two bounded passes, dev held:
 
 ```text
@@ -102,7 +109,8 @@ RTH rows under the already-enforced tier horizons and per-day caps:
 Linearising the first real footprint gives a planning envelope below roughly
 60 MiB. Retention still drops whole expired partitions; the collector adds no
 tick, quote-history or derived-indicator heap. This projection must be replaced
-by measured full-window bytes/WAL/latency as the prospective store matures.
+by measured full-window bytes/latency as the prospective store matures; live
+incremental WAL now has the initial bounded-fire measurement above.
 
 ## Refusals and limitations
 

--- a/docs/proposals/ta/2026-08-10-etoro-intraday-harvest-evidence.md
+++ b/docs/proposals/ta/2026-08-10-etoro-intraday-harvest-evidence.md
@@ -1,0 +1,104 @@
+# Bounded eToro intraday harvest: implementation and first evidence
+
+Date: 2026-08-10  
+Issues: #2477, #2508
+
+## Outcome
+
+The existing partitioned `strategy_intraday_bars` store now has a scheduled and
+operator-triggerable producer. The producer reads one immutable active research
+universe, fetches at most twelve eToro windows per five-minute run, retains only
+completed NYSE regular-session bars, filters overlap at the durable watermark,
+and records missing interval ranges without imputation. Gap rows expire on the
+same tier horizon as the bars they describe.
+
+This is evidence collection, not a promoted strategy. Demo allocation remains
+fail-closed.
+
+## Active prospective panel
+
+`ETORO-RTH-V2` declares 18 symbol/timeframe windows across eight instruments:
+
+- ETFs: SPY (NYSE), QQQ (Nasdaq), IWM (NYSE);
+- Nasdaq stocks: AAPL (liquid/high nominal price), CENN (sub-$5/low volume);
+- NYSE stocks: F (about $14), KO (about $87), JPM (about $356);
+- all eight at 30m and 5m; SPY and AAPL only at 1m.
+
+The price descriptions document the selection contrast; candidate evaluation
+must derive the contemporaneous as-traded band at each decision. It must not
+reuse today's price or venue as a historical fact.
+
+## First live provider run
+
+The first V1 run completed at about 13:05 UTC and measured:
+
+```text
+selected=12
+provider bars fetched=11,761
+completed RTH bars written=5,760
+member failures=0
+gap ranges recorded=350
+```
+
+The provider's 1,000-bar response includes extended hours. After explicit RTH
+filtering, the usable first window was materially smaller than the raw count:
+
+- 1m: 479 rows / two instruments, part of 2026-08-07;
+- 5m: 2,463 rows / five instruments, earliest 2026-07-06;
+- 30m: 2,818 rows / five instruments, earliest 2026-04-07.
+
+The variation in earliest date is itself evidence: sparse instruments do not
+have one candle for every nominal interval. Of the 350 initial gap ranges, 348
+belonged to CENN; one each belonged to QQQ 30m and IWM 5m. They remain gaps.
+
+An immediate identical end-to-end scheduled rerun fetched 6,571 provider bars,
+wrote zero rows and recorded zero new gaps. Its `job_runs` row was `success`,
+proving overlap idempotence through the real provider/job/database path.
+
+After activating V2 and running two bounded passes, dev held:
+
+```text
+7,561 completed bars total
+  1m:   479 rows / 2 instruments
+  5m: 3,413 rows / 8 instruments
+ 30m: 3,669 rows / 8 instruments
+
+partition leaves: 8
+heap + indexes + table overhead: 1,688 KiB
+latest two V2 jobs: success, 851 and 950 rows written
+```
+
+A representative AAPL 5m August range read returned 234 rows in 1.616 ms using
+the inherited compact index, with 39 KiB sort memory. This is an early small-
+population measurement, not a full-retention latency claim.
+
+## Storage bound
+
+The active panel has a conservative maximum of approximately 233,064 retained
+RTH rows under the already-enforced tier horizons and per-day caps:
+
+```text
+30m: 8 * 13 * 504 sessions       =  52,416
+ 5m: 8 * 78 * 252 sessions       = 157,248
+ 1m: 2 * 390 * 30 calendar days  =  23,400  (deliberately conservative)
+                                      -------
+                                      233,064
+```
+
+Linearising the first real footprint gives a planning envelope below roughly
+60 MiB. Retention still drops whole expired partitions; the collector adds no
+tick, quote-history or derived-indicator heap. This projection must be replaced
+by measured full-window bytes/WAL/latency as the prospective store matures.
+
+## Refusals and limitations
+
+- The provider has no historical date anchor. Missing history cannot be
+  reconstructed from this endpoint and no candidate may claim it.
+- Only NYSE RTH is retained. Extended-hours hypotheses require a distinct
+  version/session contract and storage-budget decision.
+- Current quotes are not historical spreads or depth. Intraday OHLCV does not
+  prove queue position or stop-market slippage.
+- Symbol resolution must produce exactly one currently tradable instrument.
+  A missing/ambiguous member fails visibly while healthy peers remain durable.
+- Active universe membership is database-enforced immutable. Expansion creates
+  a new version; it cannot rewrite the earlier evidence identity.

--- a/sql/298_strategy_intraday_harvest.sql
+++ b/sql/298_strategy_intraday_harvest.sql
@@ -1,0 +1,100 @@
+-- 298_strategy_intraday_harvest.sql
+--
+-- #2477 -- bounded, versioned eToro intraday research collection.
+--
+-- Membership is symbolic so a clean install can declare the research universe
+-- before the eToro universe has populated instrument ids.  The harvester
+-- resolves each symbol point-in-time and refuses missing or ambiguous matches.
+-- Observations continue to live only in the partitioned/capped tables created
+-- by 276-278; this migration adds compact control and gap metadata, not another
+-- bar store.
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_universe_versions (
+    universe_version TEXT PRIMARY KEY,
+    provider          TEXT NOT NULL CHECK (provider = 'etoro'),
+    session_rule      TEXT NOT NULL CHECK (session_rule = 'nyse_rth'),
+    status            TEXT NOT NULL CHECK (status IN ('draft', 'active', 'retired')),
+    rationale         TEXT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    activated_at      TIMESTAMPTZ,
+    retired_at        TIMESTAMPTZ,
+    CONSTRAINT strategy_intraday_universe_status_times CHECK (
+        (status = 'draft' AND activated_at IS NULL AND retired_at IS NULL)
+        OR (status = 'active' AND activated_at IS NOT NULL AND retired_at IS NULL)
+        OR (status = 'retired' AND activated_at IS NOT NULL AND retired_at IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_strategy_intraday_one_active_universe
+    ON strategy_intraday_universe_versions ((status))
+    WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_universe_members (
+    universe_version TEXT NOT NULL REFERENCES strategy_intraday_universe_versions(universe_version),
+    ordinal          SMALLINT NOT NULL CHECK (ordinal > 0),
+    timeframe        TEXT NOT NULL CHECK (timeframe IN ('30m', '5m', '1m')),
+    symbol           TEXT NOT NULL CHECK (symbol = upper(symbol) AND btrim(symbol) <> ''),
+    purpose          TEXT NOT NULL CHECK (btrim(purpose) <> ''),
+    PRIMARY KEY (universe_version, timeframe, symbol),
+    UNIQUE (universe_version, ordinal)
+);
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_harvest_cursors (
+    universe_version TEXT PRIMARY KEY REFERENCES strategy_intraday_universe_versions(universe_version),
+    last_ordinal     SMALLINT NOT NULL DEFAULT 0 CHECK (last_ordinal >= 0),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS strategy_intraday_gaps (
+    universe_version TEXT NOT NULL REFERENCES strategy_intraday_universe_versions(universe_version),
+    timeframe        TEXT NOT NULL CHECK (timeframe IN ('30m', '5m', '1m')),
+    instrument_id    BIGINT NOT NULL REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    gap_start        TIMESTAMPTZ NOT NULL,
+    gap_end          TIMESTAMPTZ NOT NULL,
+    first_detected_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_detected_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_intraday_gap_order CHECK (gap_end > gap_start),
+    PRIMARY KEY (universe_version, timeframe, instrument_id, gap_start, gap_end)
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_intraday_gaps_recent
+    ON strategy_intraday_gaps (last_detected_at DESC);
+
+INSERT INTO strategy_intraday_universe_versions (
+    universe_version, provider, session_rule, status, rationale, activated_at
+) VALUES (
+    'ETORO-RTH-V1',
+    'etoro',
+    'nyse_rth',
+    'active',
+    'Small prospective research panel: liquid ETFs, one liquid equity and one low-volume contrast. #2477.',
+    now()
+) ON CONFLICT DO NOTHING;
+
+INSERT INTO strategy_intraday_universe_members (
+    universe_version, ordinal, timeframe, symbol, purpose
+) VALUES
+    ('ETORO-RTH-V1',  1, '30m', 'SPY',  'liquid market control'),
+    ('ETORO-RTH-V1',  2, '30m', 'QQQ',  'liquid growth-market control'),
+    ('ETORO-RTH-V1',  3, '30m', 'IWM',  'liquid small-cap market control'),
+    ('ETORO-RTH-V1',  4, '30m', 'AAPL', 'liquid individual-equity control'),
+    ('ETORO-RTH-V1',  5, '30m', 'CENN', 'low-volume individual-equity contrast'),
+    ('ETORO-RTH-V1',  6, '5m',  'SPY',  'liquid market execution path'),
+    ('ETORO-RTH-V1',  7, '5m',  'QQQ',  'liquid growth-market execution path'),
+    ('ETORO-RTH-V1',  8, '5m',  'IWM',  'liquid small-cap execution path'),
+    ('ETORO-RTH-V1',  9, '5m',  'AAPL', 'liquid equity execution path'),
+    ('ETORO-RTH-V1', 10, '5m',  'CENN', 'low-volume equity execution contrast'),
+    ('ETORO-RTH-V1', 11, '1m',  'SPY',  'liquid market micro-path'),
+    ('ETORO-RTH-V1', 12, '1m',  'AAPL', 'liquid equity micro-path')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO strategy_intraday_harvest_cursors (universe_version, last_ordinal)
+VALUES ('ETORO-RTH-V1', 0)
+ON CONFLICT DO NOTHING;
+
+COMMENT ON TABLE strategy_intraday_universe_versions IS
+    'Immutable/versioned scope for bounded prospective intraday research. At most one version is active. #2477.';
+COMMENT ON TABLE strategy_intraday_universe_members IS
+    'Predeclared symbolic eToro collection members; no all-instrument crawl. #2477.';
+COMMENT ON TABLE strategy_intraday_gaps IS
+    'Compact missing completed-RTH interval ranges detected by the harvester; gaps are never imputed. #2477.';

--- a/sql/299_strategy_intraday_universe_immutability.sql
+++ b/sql/299_strategy_intraday_universe_immutability.sql
@@ -1,0 +1,73 @@
+-- 299_strategy_intraday_universe_immutability.sql
+--
+-- A #2477 universe version is a research identity. Membership and
+-- interpretation may be assembled while draft, but after activation only
+-- one-way retirement is legal. Any changed scope receives a new version.
+
+CREATE OR REPLACE FUNCTION enforce_strategy_intraday_universe_immutability()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        IF OLD.status = 'draft' THEN
+            RETURN OLD;
+        END IF;
+        RAISE EXCEPTION 'active/retired intraday universe versions are immutable';
+    END IF;
+    IF OLD.status = 'draft' THEN
+        IF NEW.universe_version <> OLD.universe_version
+           OR NEW.provider <> OLD.provider
+           OR NEW.session_rule <> OLD.session_rule
+           OR NEW.rationale <> OLD.rationale
+           OR NEW.status NOT IN ('draft', 'active') THEN
+            RAISE EXCEPTION 'draft intraday universe identity is immutable; only activation is allowed';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF OLD.status = 'active'
+       AND NEW.status = 'retired'
+       AND NEW.universe_version = OLD.universe_version
+       AND NEW.provider = OLD.provider
+       AND NEW.session_rule = OLD.session_rule
+       AND NEW.rationale = OLD.rationale
+       AND NEW.activated_at = OLD.activated_at THEN
+        RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'active/retired intraday universe versions are immutable';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_strategy_intraday_universe_immutable
+    ON strategy_intraday_universe_versions;
+CREATE TRIGGER trg_strategy_intraday_universe_immutable
+BEFORE UPDATE OR DELETE ON strategy_intraday_universe_versions
+FOR EACH ROW EXECUTE FUNCTION enforce_strategy_intraday_universe_immutability();
+
+CREATE OR REPLACE FUNCTION enforce_strategy_intraday_members_draft_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    target_version TEXT;
+    target_status TEXT;
+BEGIN
+    target_version := CASE WHEN TG_OP = 'DELETE' THEN OLD.universe_version ELSE NEW.universe_version END;
+    SELECT status INTO target_status
+    FROM strategy_intraday_universe_versions
+    WHERE universe_version = target_version;
+    IF target_status IS DISTINCT FROM 'draft' THEN
+        RAISE EXCEPTION 'intraday universe members are mutable only while their version is draft';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_strategy_intraday_members_draft_only
+    ON strategy_intraday_universe_members;
+CREATE TRIGGER trg_strategy_intraday_members_draft_only
+BEFORE INSERT OR UPDATE OR DELETE ON strategy_intraday_universe_members
+FOR EACH ROW EXECUTE FUNCTION enforce_strategy_intraday_members_draft_only();

--- a/sql/300_strategy_intraday_universe_v2.sql
+++ b/sql/300_strategy_intraday_universe_v2.sql
@@ -1,0 +1,50 @@
+-- 300_strategy_intraday_universe_v2.sql
+--
+-- #2477/#2508 -- retain the small V1 evidence identity, then broaden the
+-- prospective panel with explicit NYSE stock and nominal-price contrasts.
+-- The new scope is a new immutable version; V1 rows/gaps remain attributable.
+
+UPDATE strategy_intraday_universe_versions
+SET status = 'retired', retired_at = now()
+WHERE universe_version = 'ETORO-RTH-V1'
+  AND status = 'active';
+
+INSERT INTO strategy_intraday_universe_versions (
+    universe_version, provider, session_rule, status, rationale
+) VALUES (
+    'ETORO-RTH-V2',
+    'etoro',
+    'nyse_rth',
+    'draft',
+    'Prospective stock/ETF, Nasdaq/NYSE, nominal-price and liquidity research contrasts. #2477/#2508.'
+);
+
+INSERT INTO strategy_intraday_universe_members (
+    universe_version, ordinal, timeframe, symbol, purpose
+) VALUES
+    ('ETORO-RTH-V2',  1, '30m', 'SPY',  'NYSE liquid broad-market ETF control'),
+    ('ETORO-RTH-V2',  2, '30m', 'QQQ',  'Nasdaq liquid growth ETF control'),
+    ('ETORO-RTH-V2',  3, '30m', 'IWM',  'NYSE liquid small-cap ETF control'),
+    ('ETORO-RTH-V2',  4, '30m', 'AAPL', 'Nasdaq liquid high-price stock control'),
+    ('ETORO-RTH-V2',  5, '30m', 'CENN', 'Nasdaq sub-$5 low-volume stock contrast'),
+    ('ETORO-RTH-V2',  6, '30m', 'F',    'NYSE $5-$20 liquid stock contrast'),
+    ('ETORO-RTH-V2',  7, '30m', 'KO',   'NYSE $50-$150 liquid stock contrast'),
+    ('ETORO-RTH-V2',  8, '30m', 'JPM',  'NYSE above-$150 liquid stock contrast'),
+    ('ETORO-RTH-V2',  9, '5m',  'SPY',  'NYSE liquid broad-market execution path'),
+    ('ETORO-RTH-V2', 10, '5m',  'QQQ',  'Nasdaq liquid growth execution path'),
+    ('ETORO-RTH-V2', 11, '5m',  'IWM',  'NYSE liquid small-cap execution path'),
+    ('ETORO-RTH-V2', 12, '5m',  'AAPL', 'Nasdaq liquid high-price execution path'),
+    ('ETORO-RTH-V2', 13, '5m',  'CENN', 'Nasdaq low-volume execution contrast'),
+    ('ETORO-RTH-V2', 14, '5m',  'F',    'NYSE low-price liquid execution contrast'),
+    ('ETORO-RTH-V2', 15, '5m',  'KO',   'NYSE mid-price liquid execution contrast'),
+    ('ETORO-RTH-V2', 16, '5m',  'JPM',  'NYSE high-price liquid execution contrast'),
+    ('ETORO-RTH-V2', 17, '1m',  'SPY',  'liquid market micro-path'),
+    ('ETORO-RTH-V2', 18, '1m',  'AAPL', 'liquid stock micro-path');
+
+INSERT INTO strategy_intraday_harvest_cursors (universe_version, last_ordinal)
+VALUES ('ETORO-RTH-V2', 0);
+
+UPDATE strategy_intraday_universe_versions
+SET status = 'active', activated_at = now()
+WHERE universe_version = 'ETORO-RTH-V2'
+  AND status = 'draft';

--- a/sql/301_strategy_intraday_gap_retention.sql
+++ b/sql/301_strategy_intraday_gap_retention.sql
@@ -1,0 +1,8 @@
+-- 301_strategy_intraday_gap_retention.sql
+--
+-- #2477 -- gap metadata follows the same tier horizon as the bars it
+-- describes. This compact index supports the daily bounded delete; bars still
+-- expire by whole partition and retain their BRIN-only read shape.
+
+CREATE INDEX IF NOT EXISTS idx_strategy_intraday_gaps_timeframe_end
+    ON strategy_intraday_gaps (timeframe, gap_end);

--- a/tests/test_strategy_intraday_harvest.py
+++ b/tests/test_strategy_intraday_harvest.py
@@ -214,7 +214,7 @@ def test_harvest_reports_member_failure_without_writing(ebull_test_conn: psycopg
     assert report.written == 0
     assert len(report.failures) == 1
     assert report.failures[0].symbol == "HARVEST"
-    assert "provider down" in report.failures[0].reason
+    assert report.failures[0].reason == "RuntimeError"
 
 
 def test_unresolved_member_does_not_erase_healthy_peer(ebull_test_conn: psycopg.Connection[tuple]) -> None:

--- a/tests/test_strategy_intraday_harvest.py
+++ b/tests/test_strategy_intraday_harvest.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.providers.market_data import IntradayBar as ProviderBar
+from app.providers.market_data import MarketDataProvider
+from app.services.strategy_intraday_harvest import (
+    _completed_rth_bars,
+    _fetch_count,
+    _gap_ranges,
+    run_intraday_harvest,
+)
+
+
+def _bar(stamp: str, close: str = "100") -> ProviderBar:
+    value = Decimal(close)
+    return ProviderBar(
+        timestamp=datetime.fromisoformat(stamp),
+        open=value,
+        high=value + 1,
+        low=value - 1,
+        close=value,
+        volume=100,
+    )
+
+
+def test_completed_rth_filters_extended_and_forming_bars() -> None:
+    observed = datetime.fromisoformat("2026-08-07T14:00:00+00:00")
+    bars = [
+        _bar("2026-08-07T12:00:00+00:00"),  # pre-market
+        _bar("2026-08-07T13:30:00+00:00"),
+        _bar("2026-08-07T13:55:00+00:00"),  # closes exactly at observed_at
+        _bar("2026-08-07T14:00:00+00:00"),  # still forming
+    ]
+
+    kept = _completed_rth_bars(bars, timeframe="5m", observed_at=observed)
+
+    assert [bar.timestamp for bar in kept] == [bars[1].timestamp, bars[2].timestamp]
+
+
+def test_gap_detection_never_calls_an_overnight_a_gap() -> None:
+    stamps = [
+        datetime.fromisoformat("2026-08-07T19:55:00+00:00"),
+        datetime.fromisoformat("2026-08-10T13:30:00+00:00"),
+        datetime.fromisoformat("2026-08-10T13:40:00+00:00"),
+    ]
+
+    assert _gap_ranges(stamps, timeframe="5m", watermark=None) == (
+        (
+            datetime.fromisoformat("2026-08-10T13:35:00+00:00"),
+            datetime.fromisoformat("2026-08-10T13:40:00+00:00"),
+        ),
+    )
+
+
+def test_fetch_count_is_small_for_incremental_and_bounded_for_backfill() -> None:
+    observed = datetime.fromisoformat("2026-08-07T14:00:00+00:00")
+    assert _fetch_count(timeframe="5m", watermark=None, observed_at=observed) == 1_000
+    assert (
+        _fetch_count(
+            timeframe="5m",
+            watermark=datetime.fromisoformat("2026-08-07T13:50:00+00:00"),
+            observed_at=observed,
+        )
+        == 5
+    )
+    assert (
+        _fetch_count(
+            timeframe="1m",
+            watermark=datetime.fromisoformat("2026-01-01T00:00:00+00:00"),
+            observed_at=observed,
+        )
+        == 1_000
+    )
+
+
+def test_seeded_active_panel_is_cross_market_and_bounded(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    version = ebull_test_conn.execute(
+        "SELECT universe_version FROM strategy_intraday_universe_versions WHERE status = 'active'"
+    ).fetchone()
+    counts = ebull_test_conn.execute(
+        """
+        SELECT timeframe, count(*)
+        FROM strategy_intraday_universe_members
+        WHERE universe_version = 'ETORO-RTH-V2'
+        GROUP BY timeframe ORDER BY timeframe
+        """
+    ).fetchall()
+    symbols = {
+        row[0]
+        for row in ebull_test_conn.execute(
+            """
+            SELECT DISTINCT symbol
+            FROM strategy_intraday_universe_members
+            WHERE universe_version = 'ETORO-RTH-V2'
+            """
+        ).fetchall()
+    }
+
+    assert version == ("ETORO-RTH-V2",)
+    assert counts == [("1m", 2), ("30m", 8), ("5m", 8)]
+    assert symbols == {"SPY", "QQQ", "IWM", "AAPL", "CENN", "F", "KO", "JPM"}
+
+
+def _activate_test_universe(
+    conn: psycopg.Connection[tuple], *, instrument_id: int, include_missing: bool = False
+) -> None:
+    conn.execute(
+        """
+        UPDATE strategy_intraday_universe_versions
+        SET status = 'retired', retired_at = now()
+        WHERE status = 'active'
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency, is_tradable
+        ) VALUES (%s, 'HARVEST', 'Harvest Fixture', 'test', 'USD', true)
+        ON CONFLICT (instrument_id) DO NOTHING
+        """,
+        (instrument_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_intraday_universe_versions (
+            universe_version, provider, session_rule, status, rationale, activated_at
+        ) VALUES ('TEST-RTH-V1', 'etoro', 'nyse_rth', 'draft', 'fixture', NULL)
+        """
+    )
+    if include_missing:
+        conn.execute(
+            """
+            INSERT INTO strategy_intraday_universe_members (
+                universe_version, ordinal, timeframe, symbol, purpose
+            ) VALUES ('TEST-RTH-V1', 2, '5m', 'MISSING-HARVEST', 'resolution refusal fixture')
+            """
+        )
+    conn.execute(
+        """
+        INSERT INTO strategy_intraday_universe_members (
+            universe_version, ordinal, timeframe, symbol, purpose
+        ) VALUES ('TEST-RTH-V1', 1, '5m', 'HARVEST', 'fixture')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_intraday_harvest_cursors (universe_version, last_ordinal)
+        VALUES ('TEST-RTH-V1', 0)
+        """
+    )
+    conn.execute(
+        """
+        UPDATE strategy_intraday_universe_versions
+        SET status = 'active', activated_at = now()
+        WHERE universe_version = 'TEST-RTH-V1'
+        """
+    )
+
+
+def test_harvest_writes_completed_rth_once_and_records_gap(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    instrument_id = 2_477_001
+    _activate_test_universe(ebull_test_conn, instrument_id=instrument_id)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_intraday_candles.return_value = [
+        _bar("2026-08-07T12:00:00+00:00"),
+        _bar("2026-08-07T13:30:00+00:00"),
+        _bar("2026-08-07T13:35:00+00:00"),
+        _bar("2026-08-07T13:45:00+00:00"),
+        _bar("2026-08-07T14:00:00+00:00"),
+    ]
+    observed = datetime.fromisoformat("2026-08-07T14:00:00+00:00")
+
+    first = run_intraday_harvest(ebull_test_conn, provider, observed_at=observed, max_requests=1)
+    second = run_intraday_harvest(ebull_test_conn, provider, observed_at=observed, max_requests=1)
+
+    assert first.written == 3
+    assert first.gaps_recorded == 1
+    assert first.failures == ()
+    assert second.written == 0
+    assert second.gaps_recorded == 0
+    assert second.failures == ()
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_intraday_bars WHERE timeframe = '5m' AND instrument_id = %s",
+        (instrument_id,),
+    ).fetchone() == (3,)
+    assert ebull_test_conn.execute(
+        "SELECT gap_start, gap_end FROM strategy_intraday_gaps WHERE instrument_id = %s",
+        (instrument_id,),
+    ).fetchone() == (
+        datetime.fromisoformat("2026-08-07T13:40:00+00:00"),
+        datetime.fromisoformat("2026-08-07T13:45:00+00:00"),
+    )
+
+
+def test_harvest_reports_member_failure_without_writing(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    instrument_id = 2_477_002
+    _activate_test_universe(ebull_test_conn, instrument_id=instrument_id)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_intraday_candles.side_effect = RuntimeError("provider down")
+
+    report = run_intraday_harvest(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.now(tz=UTC),
+        max_requests=1,
+    )
+
+    assert report.written == 0
+    assert len(report.failures) == 1
+    assert report.failures[0].symbol == "HARVEST"
+    assert "provider down" in report.failures[0].reason
+
+
+def test_unresolved_member_does_not_erase_healthy_peer(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    instrument_id = 2_477_003
+    _activate_test_universe(ebull_test_conn, instrument_id=instrument_id, include_missing=True)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_intraday_candles.return_value = [_bar("2026-08-07T13:30:00+00:00")]
+
+    report = run_intraday_harvest(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.fromisoformat("2026-08-07T13:40:00+00:00"),
+        max_requests=2,
+    )
+
+    assert report.written == 1
+    assert len(report.failures) == 1
+    assert report.failures[0].symbol == "MISSING-HARVEST"
+    assert report.failures[0].reason == "universe_resolution: expected one tradable instrument, found 0"
+
+
+def test_active_universe_membership_is_immutable(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    _activate_test_universe(ebull_test_conn, instrument_id=2_477_004)
+
+    with pytest.raises(psycopg.errors.RaiseException, match="mutable only while.*draft"):
+        with ebull_test_conn.transaction():
+            ebull_test_conn.execute(
+                """
+                INSERT INTO strategy_intraday_universe_members (
+                    universe_version, ordinal, timeframe, symbol, purpose
+                ) VALUES ('TEST-RTH-V1', 2, '5m', 'LATE', 'must be rejected')
+                """
+            )

--- a/tests/test_strategy_observation_storage.py
+++ b/tests/test_strategy_observation_storage.py
@@ -324,12 +324,25 @@ def test_retention_drops_whole_expired_partitions_and_keeps_current(
         """,
         (first,),
     )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_intraday_gaps (
+            universe_version, timeframe, instrument_id, gap_start, gap_end
+        ) VALUES (
+            'ETORO-RTH-V2', '1m', %s,
+            TIMESTAMPTZ '2020-01-01 10:01:00+00',
+            TIMESTAMPTZ '2020-01-01 10:02:00+00'
+        )
+        """,
+        (first,),
+    )
 
     plan = drop_expired_partitions(ebull_test_conn, as_of=as_of)
     assert expired_signal in plan.signal_partitions
     assert expired_intraday in plan.intraday_partitions
     assert current_signal not in plan.partitions
     assert current_intraday not in plan.partitions
+    assert plan.intraday_gap_rows == 1
 
     dropped = drop_expired_partitions(ebull_test_conn, as_of=as_of, dry_run=False)
     assert dropped == plan
@@ -355,5 +368,9 @@ def test_retention_drops_whole_expired_partitions_and_keeps_current(
         )
     assert ebull_test_conn.execute(
         "SELECT count(*) FROM strategy_intraday_watermarks WHERE timeframe = '1m' AND instrument_id = %s",
+        (first,),
+    ).fetchone() == (0,)
+    assert ebull_test_conn.execute(
+        "SELECT count(*) FROM strategy_intraday_gaps WHERE instrument_id = %s",
         (first,),
     ).fetchone() == (0,)

--- a/tests/test_workers_scheduler_registry.py
+++ b/tests/test_workers_scheduler_registry.py
@@ -88,6 +88,39 @@ class TestThesisRefreshRegistration:
         assert scheduler.JOB_THESIS_REFRESH in _INVOKERS
 
 
+class TestStrategyIntradayHarvestRegistration:
+    """#2477 automatic calls are bounded to completed US-session bars."""
+
+    def _job(self) -> scheduler.ScheduledJob:
+        return next(job for job in SCHEDULED_JOBS if job.name == scheduler.JOB_STRATEGY_INTRADAY_HARVEST)
+
+    @pytest.mark.parametrize(
+        ("instant", "expected"),
+        [
+            ("2026-08-10T13:34:00+00:00", False),  # 09:34 ET, first 5m bar incomplete
+            ("2026-08-10T13:35:00+00:00", True),
+            ("2026-08-10T20:10:00+00:00", True),  # ten-minute provider-lag allowance
+            ("2026-08-10T20:11:00+00:00", False),
+            ("2026-08-09T15:00:00+00:00", False),  # Sunday
+            ("2026-12-25T15:00:00+00:00", False),  # Christmas closure
+            ("2026-11-27T18:10:00+00:00", True),  # early close + ten minutes
+            ("2026-11-27T18:11:00+00:00", False),
+        ],
+    )
+    def test_automatic_collection_window(self, instant: str, expected: bool) -> None:
+        assert scheduler._strategy_intraday_collection_window_open(datetime.fromisoformat(instant)) is expected
+
+    def test_naive_datetime_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="aware datetime"):
+            scheduler._strategy_intraday_collection_window_open(datetime(2026, 8, 10, 13, 35))
+
+    def test_registered_without_boot_catchup(self) -> None:
+        job = self._job()
+        assert job.cadence == Cadence.every_n_minutes(interval=5)
+        assert job.catch_up_on_boot is False
+        assert job.prerequisite is scheduler._strategy_intraday_collection_due
+
+
 # ---------------------------------------------------------------------------
 # Daily candle job registration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue reference

Closes #2477

## Summary

Turns the existing empty, bounded intraday bar store into a real prospective eToro evidence pipeline. It uses a small immutable research panel spanning stock/ETF, Nasdaq/NYSE, nominal-price and liquidity contrasts, while leaving every strategy and demo-capital gate unchanged.

## Changes

- Adds immutable versioned research universes, a compact round-robin cursor and retained gap metadata.
- Seeds active `ETORO-RTH-V2`: 18 timeframe windows over SPY/QQQ/IWM/AAPL/CENN/F/KO/JPM; maximum 12 requests per run.
- Fetches through the existing rate-limited/retrying eToro client and shared `etoro` job lane every five minutes; the existing Admin `Run now` path invokes the same job.
- Retains only completed NYSE RTH/half-day bars, normalises UTC, filters watermark overlap and records missing interval ranges without imputation.
- Isolates member failures while surfacing the overall job red; active-universe ambiguity/missing symbols fail visibly.
- Expires gap metadata on the same timeframe horizon as bar partitions.
- Records first live-provider coverage, storage and query evidence in `docs/proposals/ta/2026-08-10-etoro-intraday-harvest-evidence.md`.

## Security and audit model

No execution path touched. This PR collects research evidence only; it creates no signals, promotions, allocations or orders. Demo execution remains fail-closed under the existing promotion and broker gates. Credentials continue through the encrypted credential loader and provider audit path. Queries and writes are parameterised.

## Measured live evidence

- Initial real-provider pass: 11,761 provider bars fetched; 5,760 completed RTH bars written; 350 gaps; zero member failures.
- Immediate rerun: zero writes and zero new gaps, proving real-provider overlap idempotence.
- After V2 activation: 7,561 bars, eight instruments, eight leaf partitions, 1,688 KiB total footprint.
- Latest V2 jobs both succeeded and wrote 851 / 950 rows.
- Conservative fixed-panel retention ceiling: ~233,064 rows / planning envelope below ~60 MiB.
- AAPL 5m August query: 234 rows in 1.616 ms at the current small population.

## Testing

- [x] Tested locally against Docker PostgreSQL stack
- [x] New service logic exercised with realistic inputs and edge cases (empty results, API errors)
- [x] No raw user input reaches the DB without parameterisation
- [x] 14 collector/storage database tests pass
- [x] Real eToro provider and tracked scheduler paths exercised against dev
- [x] Full DB tier: 4,909 passed / 4 skipped; five persistent unrelated failures reproduced on clean `origin/main`, three xdist failures passed serially
- [x] Full pre-push gate green, including fast suite and smoke boot

## Checklist

- [x] Branch named `feature/NNN-short-description` or `fix/NNN-short-description`
- [x] Raw API payloads persisted before normalisation (where applicable) — N/A; existing eToro structured-table audit decision retained, no raw dump introduced
- [x] Score model version / thesis version stamped on any new output rows — N/A; no score/thesis rows
- [x] No order placement path bypasses execution guard
- [x] `uv run ruff check .` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run pyright` passes
- [ ] CI checks pass

