### PR TITLE
feat: operate Nasdaq halt safety feed

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -129,6 +129,7 @@ from app.workers.scheduler import (
     JOB_SEC_NPORT_FILER_DIRECTORY_SYNC,
     JOB_SEED_COST_MODELS,
     JOB_STRATEGY_BACKTEST_RUN,
+    JOB_STRATEGY_HALT_FEED_REFRESH,
     JOB_STRATEGY_INTRADAY_HARVEST,
     JOB_STRATEGY_OBSERVATION_RETENTION,
     JOB_STRATEGY_OUTCOME_RESOLUTION,
@@ -199,6 +200,7 @@ from app.workers.scheduler import (
     sec_nport_filer_directory_sync,
     seed_cost_models,
     strategy_backtest_run,
+    strategy_halt_feed_refresh,
     strategy_intraday_harvest,
     strategy_observation_retention,
     strategy_outcome_resolution,
@@ -354,6 +356,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # the frontier watermark rather than by a DAG edge. Own "strategy_scan" lane,
     # resolved from SCHEDULED_JOBS, so no MANUAL_TRIGGER_JOB_SOURCES entry.
     JOB_STRATEGY_SIGNAL_SCAN: _adapt_zero_arg(strategy_signal_scan),
+    JOB_STRATEGY_HALT_FEED_REFRESH: _adapt_zero_arg(strategy_halt_feed_refresh),
     JOB_STRATEGY_INTRADAY_HARVEST: _adapt_zero_arg(strategy_intraday_harvest),
     JOB_STRATEGY_OUTCOME_RESOLUTION: _adapt_zero_arg(strategy_outcome_resolution),
     JOB_STRATEGY_OBSERVATION_RETENTION: _adapt_zero_arg(strategy_observation_retention),

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -97,6 +97,7 @@ Lane = Literal[
     "strategy_backtest",
     "bootstrap",
     "finra",
+    "nasdaq",
     "openfigi",
 ]
 """Source-level concurrency bucket. Operator-locked decision (#1064): same-source
@@ -114,6 +115,9 @@ the rate — it does not.
 * ``etoro`` — eToro REST budget. ``execute_approved_orders`` +
   ``daily_candle_refresh`` + ``strategy_intraday_harvest`` +
   ``etoro_lookups_refresh`` + ``exchanges_metadata_refresh`` serialise.
+* ``nasdaq`` — Nasdaq Trader public safety feeds. The strategy halt poll has
+  its own lane so a delayed public-feed request cannot starve either broker
+  execution or unrelated SEC/FINRA collection.
 * ``sec_rate`` — the SEC discovery/producer jobs (per-accession fetchers +
   per-issuer ingest). They serialise under one ``JobLock`` to bound job
   overlap, NOT request rate (the HTTP floor above bounds rate). #1478

--- a/app/services/strategy_halts.py
+++ b/app/services/strategy_halts.py
@@ -28,6 +28,7 @@ _NY = ZoneInfo("America/New_York")
 _MAX_BYTES = 2_000_000
 _MAX_ITEMS = 5_000
 _RETENTION_DAYS = 90
+_MAX_SOURCE_LAG = timedelta(minutes=5)
 
 
 class HaltFeedError(ValueError):
@@ -59,10 +60,16 @@ def _text(item: ET.Element, name: str, *, required: bool = False) -> str | None:
 
 
 def _market_time(date_value: str, time_value: str) -> datetime:
-    try:
-        local = datetime.strptime(f"{date_value} {time_value}", "%m/%d/%Y %H:%M:%S.%f").replace(tzinfo=_NY)
-    except ValueError as exc:
-        raise HaltFeedError("halt feed contains an invalid market timestamp") from exc
+    raw = f"{date_value} {time_value}"
+    local: datetime | None = None
+    for format_string in ("%m/%d/%Y %H:%M:%S.%f", "%m/%d/%Y %H:%M:%S"):
+        try:
+            local = datetime.strptime(raw, format_string).replace(tzinfo=_NY)
+            break
+        except ValueError:
+            continue
+    if local is None:
+        raise HaltFeedError("halt feed contains an invalid market timestamp")
     return local.astimezone(UTC)
 
 
@@ -103,7 +110,10 @@ def parse_halt_rss(payload: bytes) -> HaltSnapshot:
         halt_at = _market_time(halt_date, halt_time)
         resume_date = _text(item, "ResumptionDate")
         resume_time = _text(item, "ResumptionTradeTime")
-        if (resume_date is None) != (resume_time is None):
+        # The live feed populates ResumptionDate on some active halts before a
+        # trade-resumption time exists.  A time without a date is malformed;
+        # a date without a time is still an active halt.
+        if resume_time is not None and resume_date is None:
             raise HaltFeedError("halt feed has an incomplete resumption timestamp")
         resumed_at = _market_time(resume_date, resume_time) if resume_date and resume_time else None
         if resumed_at is not None and resumed_at < halt_at:
@@ -131,6 +141,14 @@ def store_halt_snapshot(
         raise HaltFeedError("fetched_at must be timezone-aware")
     if snapshot.source_pub_at > fetched_at + timedelta(minutes=5):
         raise HaltFeedError("halt feed pubDate is implausibly in the future")
+    if snapshot.source_pub_at < fetched_at - _MAX_SOURCE_LAG:
+        raise HaltFeedError("halt feed pubDate is stale")
+    current = conn.execute(
+        "SELECT source_pub_at FROM strategy_halt_feed_state WHERE source = %s FOR UPDATE",
+        (SOURCE,),
+    ).fetchone()
+    if current is not None and snapshot.source_pub_at < current[0]:
+        raise HaltFeedError("halt feed publication time regressed")
     with conn.cursor() as cur:
         cur.executemany(
             """
@@ -183,16 +201,20 @@ def refresh_halt_feed(
     if conn.info.transaction_status != TransactionStatus.IDLE:
         raise HaltFeedError("halt refresh requires an idle database connection")
     observed = (fetched_at or datetime.now(UTC)).astimezone(UTC)
+    snapshot = fetch_halt_snapshot(client)
+    with conn.transaction():
+        store_halt_snapshot(conn, snapshot=snapshot, fetched_at=observed)
+    return snapshot
+
+
+def fetch_halt_snapshot(client: httpx.Client) -> HaltSnapshot:
+    """Fetch and parse without requiring or holding a database connection."""
     try:
         response = client.get(NASDAQ_HALT_RSS_URL, timeout=20.0)
         response.raise_for_status()
     except httpx.HTTPError as exc:
         raise HaltFeedError("Nasdaq halt feed request failed") from exc
-    payload = response.content
-    snapshot = parse_halt_rss(payload)
-    with conn.transaction():
-        store_halt_snapshot(conn, snapshot=snapshot, fetched_at=observed)
-    return snapshot
+    return parse_halt_rss(response.content)
 
 
 __all__ = [
@@ -202,6 +224,7 @@ __all__ = [
     "NASDAQ_HALT_RSS_URL",
     "SOURCE",
     "active_halt_symbols",
+    "fetch_halt_snapshot",
     "parse_halt_rss",
     "refresh_halt_feed",
     "store_halt_snapshot",

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -26,13 +26,16 @@ from collections.abc import Callable, Generator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Final, Literal, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 from zoneinfo import ZoneInfo
 
 import psycopg
 import psycopg.rows
 import psycopg.sql
 from psycopg.types.json import Jsonb
+
+if TYPE_CHECKING:
+    from app.services.strategy_halts import HaltSnapshot
 
 from app.config import settings
 from app.db.background_write import background_write_connection
@@ -384,6 +387,9 @@ JOB_STRATEGY_OBSERVATION_RETENTION = "strategy_observation_retention"
 # the provider lane (not strategy_scan): the eToro client's request floor is
 # the rate budget, while the storage writer carries its own tier locks.
 JOB_STRATEGY_INTRADAY_HARVEST = "strategy_intraday_harvest"
+# #2507 — primary-source Nasdaq halt state. Safety input only: a fresh
+# snapshot can refuse an order but can never create trading authority.
+JOB_STRATEGY_HALT_FEED_REFRESH = "strategy_halt_feed_refresh"
 # #2450 — bounded demo execution/reconciliation/owned-position health loop.
 JOB_STRATEGY_PAPER_CYCLE = "strategy_paper_cycle"
 # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY, and NOT because it is
@@ -686,6 +692,29 @@ def _strategy_intraday_collection_due(conn: psycopg.Connection[Any]) -> Prerequi
         return (False, reason)
     if not _strategy_intraday_collection_window_open(datetime.now(tz=UTC)):
         return (False, "outside the completed US regular-session bar collection window")
+    return (True, "")
+
+
+def _strategy_halt_collection_window_open(now: datetime) -> bool:
+    """Bound automatic halt polling to the US pre-open/RTH safety window."""
+    if now.tzinfo is None:
+        raise ValueError("halt collection window requires an aware datetime")
+    local = now.astimezone(_NEW_YORK)
+    status = us_market_status(local.date())
+    if status == "closed":
+        return False
+    minute = local.hour * 60 + local.minute
+    close_minute = 13 * 60 if status == "half_day" else 16 * 60
+    return 9 * 60 <= minute <= close_minute + 15
+
+
+def _strategy_halt_collection_due(conn: psycopg.Connection[Any]) -> PrerequisiteResult:
+    """Gate scheduled polls while manual repair remains available off-hours."""
+    bootstrap_met, reason = _bootstrap_complete(conn)
+    if not bootstrap_met:
+        return (False, reason)
+    if not _strategy_halt_collection_window_open(datetime.now(tz=UTC)):
+        return (False, "outside the US pre-open/regular-session halt safety window")
     return (True, "")
 
 
@@ -2088,6 +2117,20 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         cadence=Cadence.daily(hour=7, minute=5),
         catch_up_on_boot=False,
         prerequisite=_bootstrap_complete,
+    ),
+    ScheduledJob(
+        name=JOB_STRATEGY_HALT_FEED_REFRESH,
+        display_name="Nasdaq strategy halt safety feed (#2507)",
+        source="nasdaq",
+        description=(
+            "Every five minutes from 09:00 ET through the regular/early close plus 15 minutes — "
+            "refreshes Nasdaq Trader's primary-source halt RSS into one current feed-state row "
+            "and a 90-day provider-identity history. Missing, malformed or stale publication "
+            "timestamps fail visibly; this safety feed can refuse but never create a trade."
+        ),
+        cadence=Cadence.every_n_minutes(interval=5),
+        catch_up_on_boot=False,
+        prerequisite=_strategy_halt_collection_due,
     ),
     ScheduledJob(
         name=JOB_STRATEGY_PAPER_CYCLE,
@@ -5082,6 +5125,28 @@ def strategy_intraday_harvest() -> None:
             raise RuntimeError(f"strategy_intraday_harvest: {len(report.failures)} member(s) failed: {detail}")
 
 
+def _refresh_strategy_halt_feed() -> HaltSnapshot:
+    """Fetch without a DB connection, then atomically store the snapshot."""
+    import httpx
+
+    from app.services.strategy_halts import fetch_halt_snapshot, store_halt_snapshot
+
+    with httpx.Client(follow_redirects=True) as client:
+        snapshot = fetch_halt_snapshot(client)
+    fetched_at = datetime.now(tz=UTC)
+    with connect_job() as conn, conn.transaction():
+        store_halt_snapshot(conn, snapshot=snapshot, fetched_at=fetched_at)
+    return snapshot
+
+
+def strategy_halt_feed_refresh() -> None:
+    """Refresh the bounded Nasdaq halt safety observation."""
+    with _tracked_job(JOB_STRATEGY_HALT_FEED_REFRESH) as tracker:
+        snapshot = _refresh_strategy_halt_feed()
+        tracker.row_count = len(snapshot.halts)
+        tracker.note = f"source_pub_at={snapshot.source_pub_at.isoformat()} items={len(snapshot.halts)}"
+
+
 def strategy_paper_cycle() -> None:
     """Run the bounded demo strategy lifecycle; never select live credentials."""
     from app.providers.implementations.etoro_broker import EtoroBrokerProvider
@@ -5096,13 +5161,19 @@ def strategy_paper_cycle() -> None:
         return
     api_key, user_key = creds
     with _tracked_job(JOB_STRATEGY_PAPER_CYCLE) as tracker:
+        # Refresh immediately before any entry evaluation. The independent
+        # scheduled poll keeps monitoring alive when automation is disabled;
+        # this second fail-closed read prevents same-tick job ordering or a
+        # tight policy age from making the execution cycle use stale state.
+        halt_snapshot = _refresh_strategy_halt_feed()
         with EtoroBrokerProvider(api_key=api_key, user_key=user_key, env="demo") as broker:
             with connect_job() as conn:
                 result = run_strategy_paper_cycle(conn, broker=broker)
         tracker.row_count = result.reconciled_orders + result.managed_positions + result.evaluated_signals
         tracker.note = (
             f"reconciled={result.reconciled_orders} managed={result.managed_positions} "
-            f"evaluated={result.evaluated_signals} active_blocks={result.active_health_blocks}"
+            f"evaluated={result.evaluated_signals} active_blocks={result.active_health_blocks} "
+            f"halt_source_pub_at={halt_snapshot.source_pub_at.isoformat()}"
         )
 
 

--- a/docs/proposals/ta/2026-08-10-nasdaq-halt-feed-live-repair.md
+++ b/docs/proposals/ta/2026-08-10-nasdaq-halt-feed-live-repair.md
@@ -1,0 +1,57 @@
+# Nasdaq halt feed: live validation and safety wiring
+
+Date: 2026-08-10  
+Issue: #2507
+
+## Outcome
+
+The existing Nasdaq Trader halt parser and bounded tables were not an operating
+data source: no scheduler/runtime invoker referenced the service and both dev
+tables were empty. The source is now a five-minute, operator-visible job on an
+independent `nasdaq` lane during 09:00 ET through regular/early close plus 15
+minutes. The demo execution cycle also refreshes the same primary source
+immediately before entry evaluation, so job ordering cannot turn an old halt
+snapshot into trading authority.
+
+A feed snapshot can only refuse an entry. It cannot create a signal, promote a
+candidate or authorise an order.
+
+## Live-source findings
+
+Fixture tests had missed two provider-valid shapes. The first real request
+failed closed because active halts may have `ResumptionDate` populated while
+`ResumptionTradeTime` remains empty. After correcting that contract, the next
+request failed closed because live resumption times may omit fractional
+seconds. Both variants are now explicit fixtures; a trade time without a date
+still refuses.
+
+The first successful tracked live run recorded:
+
+```text
+source_pub_at=2026-08-10T13:54:51Z
+items=38
+active halts=19
+job status=success
+```
+
+The preceding malformed-shape run remains durably visible as `failure` rather
+than being overwritten by the success.
+
+## Freshness, connections and storage
+
+- `source_pub_at` older than five minutes is refused; a new HTTP fetch cannot
+  make a cached provider payload look fresh.
+- Feed state is row-locked and a publication timestamp may never regress, so
+  concurrent scheduled/pre-execution refreshes cannot replace newer state.
+- HTTP fetch and parse complete before a database connection is acquired.
+- One feed-state row is updated in place.
+- Halt rows use the provider identity `(source, symbol, halt_at)` and are
+  upserted as resumption information arrives.
+- Resumed halt rows expire after 90 days; active halts remain until the source
+  supplies a resumption.
+- No polling payload history, heartbeat heap or derived indicator series is
+  retained.
+
+This closes the empty-source execution-safety defect. It does not validate a
+trading strategy or solve historical event coverage for the mechanism
+classifier.

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -86,6 +86,7 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # Lane disjoint from sec_rate (CDN serves both endpoints with
         # one shared throttle).
         "finra",
+        "nasdaq",
         # #1526 — jobs_liveness_watchdog + jobs_retry_sweeper extracted from the
         # catch-all ``db`` lane into their own single-job lanes. On ``db`` they
         # lost the ``job_source:db`` advisory-lock race to

--- a/tests/test_strategy_halt_scheduler_wiring.py
+++ b/tests/test_strategy_halt_scheduler_wiring.py
@@ -1,0 +1,70 @@
+"""Scheduler/runtime wiring for the primary-source strategy halt feed."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.jobs.runtime import _INVOKERS
+from app.jobs.sources import source_for
+from app.services.strategy_halts import HaltSnapshot
+from app.workers import scheduler
+from app.workers.scheduler import SCHEDULED_JOBS, Cadence
+
+
+def _job() -> scheduler.ScheduledJob:
+    return next(job for job in SCHEDULED_JOBS if job.name == scheduler.JOB_STRATEGY_HALT_FEED_REFRESH)
+
+
+def test_halt_feed_job_is_bounded_and_independently_locked() -> None:
+    job = _job()
+    assert job.cadence == Cadence.every_n_minutes(interval=5)
+    assert job.source == "nasdaq"
+    assert job.catch_up_on_boot is False
+    assert job.prerequisite is scheduler._strategy_halt_collection_due
+    assert source_for(job.name) == "nasdaq"
+    assert _INVOKERS[job.name].__wrapped__ is scheduler.strategy_halt_feed_refresh  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    ("instant", "expected"),
+    [
+        ("2026-08-10T12:59:00+00:00", False),  # 08:59 ET
+        ("2026-08-10T13:00:00+00:00", True),
+        ("2026-08-10T20:15:00+00:00", True),
+        ("2026-08-10T20:16:00+00:00", False),
+        ("2026-11-27T18:15:00+00:00", True),  # early close + 15m
+        ("2026-11-27T18:16:00+00:00", False),
+        ("2026-08-09T15:00:00+00:00", False),  # Sunday
+    ],
+)
+def test_halt_poll_window(instant: str, expected: bool) -> None:
+    assert scheduler._strategy_halt_collection_window_open(datetime.fromisoformat(instant)) is expected
+
+
+def test_halt_poll_window_requires_an_aware_time() -> None:
+    with pytest.raises(ValueError, match="aware datetime"):
+        scheduler._strategy_halt_collection_window_open(datetime(2026, 8, 10, 13, 0))
+
+
+def test_halt_job_tracks_provider_publication_and_item_count() -> None:
+    snapshot = HaltSnapshot(
+        source_pub_at=datetime(2026, 8, 10, 13, 50, tzinfo=UTC),
+        payload_sha256="0" * 64,
+        halts=(),
+    )
+    tracker = MagicMock()
+    tracker_cm = MagicMock()
+    tracker_cm.__enter__.return_value = tracker
+    tracker_cm.__exit__.return_value = False
+    with (
+        patch("app.workers.scheduler._tracked_job", return_value=tracker_cm),
+        patch("app.workers.scheduler._refresh_strategy_halt_feed", return_value=snapshot),
+    ):
+        scheduler.strategy_halt_feed_refresh()
+
+    assert tracker.row_count == 0
+    assert "source_pub_at=2026-08-10T13:50:00+00:00" in tracker.note
+    assert "items=0" in tracker.note

--- a/tests/test_strategy_halts.py
+++ b/tests/test_strategy_halts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -57,6 +58,50 @@ def test_partial_resumption_and_count_drift_fail_closed() -> None:
     ):
         with pytest.raises(HaltFeedError):
             parse_halt_rss(malformed)
+
+
+def test_provider_date_without_trade_time_remains_an_active_halt() -> None:
+    live_shape = _XML.replace(
+        b"<ndaq:ResumptionDate />",
+        b"<ndaq:ResumptionDate>08/07/2026</ndaq:ResumptionDate>",
+    )
+    snapshot = parse_halt_rss(live_shape)
+    assert snapshot.halts[0].resumed_at is None
+
+
+def test_provider_timestamp_without_fractional_seconds_is_supported() -> None:
+    live_shape = _XML.replace(b"10:00:00.000", b"10:00:00")
+    snapshot = parse_halt_rss(live_shape)
+    assert snapshot.halts[1].resumed_at == datetime(2026, 8, 7, 14, 0, tzinfo=UTC)
+
+
+def test_stale_source_publication_is_not_made_fresh_by_fetch_time(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    snapshot = parse_halt_rss(_XML)
+    with pytest.raises(HaltFeedError, match="pubDate is stale"):
+        store_halt_snapshot(
+            ebull_test_conn,
+            snapshot=snapshot,
+            fetched_at=datetime(2026, 8, 7, 15, 6, tzinfo=UTC),
+        )
+
+
+def test_feed_publication_time_cannot_regress(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    snapshot = parse_halt_rss(_XML)
+    fetched = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)
+    store_halt_snapshot(ebull_test_conn, snapshot=snapshot, fetched_at=fetched)
+    with pytest.raises(HaltFeedError, match="publication time regressed"):
+        store_halt_snapshot(
+            ebull_test_conn,
+            snapshot=replace(snapshot, source_pub_at=fetched - timedelta(minutes=1)),
+            fetched_at=fetched + timedelta(minutes=1),
+        )
+    assert ebull_test_conn.execute(
+        "SELECT source_pub_at FROM strategy_halt_feed_state WHERE source = 'nasdaq_trader_rss'"
+    ).fetchone() == (fetched,)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Issue reference

Refs #2507

## Summary

Turns the existing dormant Nasdaq Trader halt parser/tables into an operating, bounded safety source. The first live request exposed two provider-valid shapes absent from fixtures; both now parse explicitly, while malformed, stale and regressing publication state fails closed.

## Changes

- Adds an independent `nasdaq` job lane and five-minute US pre-open/RTH scheduled job with Admin Run now support.
- Registers the job end to end through scheduler/runtime/source-lock registries.
- Refreshes the same source immediately before the demo paper lifecycle evaluates entries, so same-tick ordering cannot leave a tight policy reading stale halt state.
- Accepts provider-valid date-without-trade-time active halts and timestamps with or without fractional seconds.
- Rejects a stale provider publication even after a fresh HTTP fetch and prevents publication-time regression under a row lock.
- Fetches/parses before acquiring a DB connection.
- Preserves one current state row, provider-identity halt upserts and 90-day resumed-row retention; no payload/heartbeat history.

## Live evidence

- Initial real request failed visibly on date-without-trade-time.
- Second real request failed visibly on a non-fractional timestamp.
- Corrected tracked run succeeded with 38 items, including 19 active halts; both preceding red runs remain auditable.
- A subsequent refactored run succeeded after moving HTTP outside the DB connection.

## Safety

This feed can refuse an entry but cannot create a signal, promote a candidate or authorise an order. No live-capital gate changed.

## Testing

- Focused halt/wiring/registry/scheduler suite: 140 tests passed.
- Full pre-push gate green: ruff, format, pyright, invariant lints, fast suite, smoke boot and frontend checks.
- Live primary-source fetch and tracked DB persistence exercised against dev.
