### PR TITLE
feat: persist point-in-time strategy cohorts

### DIFF
--- a/app/services/instrument_market_classification.py
+++ b/app/services/instrument_market_classification.py
@@ -1,0 +1,209 @@
+"""Prospective point-in-time security type and listing classification (#2508)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+
+@dataclass(frozen=True)
+class ClassificationReconcileStats:
+    confirmed: int
+    opened: int
+    changed: int
+    corrected_same_day: int
+    closed: int
+
+
+def reconcile_instrument_market_classification(
+    conn: psycopg.Connection[Any],
+) -> ClassificationReconcileStats:
+    """Record current provider classifications without rewriting history.
+
+    Must run after the universe upsert/deactivation in the same transaction.
+    The record begins prospectively; no value is backfilled before the day on
+    which it was observed. A same-day correction updates the day's row because
+    daily provenance cannot establish an ordering within that date.
+    """
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        cur.execute(
+            """
+            WITH observed AS (
+                SELECT i.instrument_id, i.exchange AS provider_exchange_id,
+                       CASE
+                           WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
+                           WHEN i.exchange = '4' OR lower(coalesce(e.description, '')) = 'nasdaq' THEN 'nasdaq'
+                           ELSE CASE WHEN i.exchange IS NULL THEN 'unknown' ELSE 'other' END
+                       END AS primary_listing_market,
+                       i.instrument_type_id,
+                       CASE
+                           WHEN i.instrument_type_id = 5 OR lower(coalesce(t.description, '')) = 'stocks'
+                               THEN 'common_stock'
+                           WHEN i.instrument_type_id = 6 OR lower(coalesce(t.description, '')) = 'etf' THEN 'etf'
+                           ELSE CASE WHEN i.instrument_type_id IS NULL THEN 'unknown' ELSE 'other' END
+                       END AS security_type
+                FROM instruments i
+                LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+                LEFT JOIN etoro_instrument_types t
+                  ON t.instrument_type_id = i.instrument_type_id
+                WHERE i.is_tradable
+            )
+            UPDATE instrument_market_classification_history h
+               SET last_confirmed_on = CURRENT_DATE
+              FROM observed o
+             WHERE h.instrument_id = o.instrument_id
+               AND h.effective_to IS NULL
+               AND h.last_confirmed_on < CURRENT_DATE
+               AND (h.provider_exchange_id, h.primary_listing_market,
+                    h.instrument_type_id, h.security_type)
+                   IS NOT DISTINCT FROM
+                   (o.provider_exchange_id, o.primary_listing_market,
+                    o.instrument_type_id, o.security_type)
+            """
+        )
+        confirmed = cur.rowcount
+
+        cur.execute(
+            """
+            WITH observed AS (
+                SELECT i.instrument_id, i.exchange AS provider_exchange_id,
+                       CASE
+                           WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
+                           WHEN i.exchange = '4' OR lower(coalesce(e.description, '')) = 'nasdaq' THEN 'nasdaq'
+                           ELSE CASE WHEN i.exchange IS NULL THEN 'unknown' ELSE 'other' END
+                       END AS primary_listing_market,
+                       i.instrument_type_id,
+                       CASE
+                           WHEN i.instrument_type_id = 5 OR lower(coalesce(t.description, '')) = 'stocks'
+                               THEN 'common_stock'
+                           WHEN i.instrument_type_id = 6 OR lower(coalesce(t.description, '')) = 'etf' THEN 'etf'
+                           ELSE CASE WHEN i.instrument_type_id IS NULL THEN 'unknown' ELSE 'other' END
+                       END AS security_type
+                FROM instruments i
+                LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+                LEFT JOIN etoro_instrument_types t
+                  ON t.instrument_type_id = i.instrument_type_id
+                WHERE i.is_tradable
+            )
+            UPDATE instrument_market_classification_history h
+               SET provider_exchange_id = o.provider_exchange_id,
+                   primary_listing_market = o.primary_listing_market,
+                   instrument_type_id = o.instrument_type_id,
+                   security_type = o.security_type,
+                   last_confirmed_on = CURRENT_DATE
+              FROM observed o
+             WHERE h.instrument_id = o.instrument_id
+               AND h.effective_to IS NULL
+               AND h.effective_from = CURRENT_DATE
+               AND (h.provider_exchange_id, h.primary_listing_market,
+                    h.instrument_type_id, h.security_type)
+                   IS DISTINCT FROM
+                   (o.provider_exchange_id, o.primary_listing_market,
+                    o.instrument_type_id, o.security_type)
+            """
+        )
+        corrected_same_day = cur.rowcount
+
+        # Close a changed classification on yesterday, then open today's row.
+        # Rows first observed today were handled above and cannot reach this arm.
+        cur.execute(
+            """
+            WITH observed AS (
+                SELECT i.instrument_id, i.exchange AS provider_exchange_id,
+                       CASE
+                           WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
+                           WHEN i.exchange = '4' OR lower(coalesce(e.description, '')) = 'nasdaq' THEN 'nasdaq'
+                           ELSE CASE WHEN i.exchange IS NULL THEN 'unknown' ELSE 'other' END
+                       END AS primary_listing_market,
+                       i.instrument_type_id,
+                       CASE
+                           WHEN i.instrument_type_id = 5 OR lower(coalesce(t.description, '')) = 'stocks'
+                               THEN 'common_stock'
+                           WHEN i.instrument_type_id = 6 OR lower(coalesce(t.description, '')) = 'etf' THEN 'etf'
+                           ELSE CASE WHEN i.instrument_type_id IS NULL THEN 'unknown' ELSE 'other' END
+                       END AS security_type
+                FROM instruments i
+                LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+                LEFT JOIN etoro_instrument_types t
+                  ON t.instrument_type_id = i.instrument_type_id
+                WHERE i.is_tradable
+            )
+            UPDATE instrument_market_classification_history h
+               SET effective_to = CURRENT_DATE - 1,
+                   last_confirmed_on = CURRENT_DATE - 1
+              FROM observed o
+             WHERE h.instrument_id = o.instrument_id
+               AND h.effective_to IS NULL
+               AND h.effective_from < CURRENT_DATE
+               AND (h.provider_exchange_id, h.primary_listing_market,
+                    h.instrument_type_id, h.security_type)
+                   IS DISTINCT FROM
+                   (o.provider_exchange_id, o.primary_listing_market,
+                    o.instrument_type_id, o.security_type)
+            """
+        )
+        changed = cur.rowcount
+
+        cur.execute(
+            """
+            INSERT INTO instrument_market_classification_history (
+                instrument_id, effective_from, effective_to, last_confirmed_on,
+                provider_exchange_id, primary_listing_market,
+                instrument_type_id, security_type, source_event
+            )
+            SELECT i.instrument_id, CURRENT_DATE, NULL, CURRENT_DATE,
+                   i.exchange,
+                   CASE
+                       WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
+                       WHEN i.exchange = '4' OR lower(coalesce(e.description, '')) = 'nasdaq' THEN 'nasdaq'
+                       ELSE CASE WHEN i.exchange IS NULL THEN 'unknown' ELSE 'other' END
+                   END,
+                   i.instrument_type_id,
+                   CASE
+                       WHEN i.instrument_type_id = 5 OR lower(coalesce(t.description, '')) = 'stocks'
+                           THEN 'common_stock'
+                       WHEN i.instrument_type_id = 6 OR lower(coalesce(t.description, '')) = 'etf' THEN 'etf'
+                       ELSE CASE WHEN i.instrument_type_id IS NULL THEN 'unknown' ELSE 'other' END
+                   END,
+                   CASE WHEN EXISTS (
+                       SELECT 1 FROM instrument_market_classification_history p
+                       WHERE p.instrument_id = i.instrument_id
+                   ) THEN 'classification_change' ELSE 'imported' END
+              FROM instruments i
+              LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+              LEFT JOIN etoro_instrument_types t
+                ON t.instrument_type_id = i.instrument_type_id
+             WHERE i.is_tradable
+               AND NOT EXISTS (
+                   SELECT 1 FROM instrument_market_classification_history h
+                   WHERE h.instrument_id = i.instrument_id AND h.effective_to IS NULL
+               )
+            """
+        )
+        opened = cur.rowcount
+
+        cur.execute(
+            """
+            UPDATE instrument_market_classification_history h
+               SET effective_to = h.last_confirmed_on
+              FROM instruments i
+             WHERE i.instrument_id = h.instrument_id
+               AND NOT i.is_tradable
+               AND h.effective_to IS NULL
+            """
+        )
+        closed = cur.rowcount
+
+    return ClassificationReconcileStats(
+        confirmed=confirmed,
+        opened=opened,
+        changed=changed,
+        corrected_same_day=corrected_same_day,
+        closed=closed,
+    )
+
+
+__all__ = ["ClassificationReconcileStats", "reconcile_instrument_market_classification"]

--- a/app/services/strategy_decision_context.py
+++ b/app/services/strategy_decision_context.py
@@ -1,0 +1,279 @@
+"""Versioned, compact point-in-time context for strategy candidates (#2508).
+
+Rolling series remain in their bounded source stores. This module snapshots
+only the values that existed at one fired/refused decision so later cohort
+analysis cannot silently resolve security type, listing or liquidity from
+today's metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+from dataclasses import asdict, dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Final, Literal
+from zoneinfo import ZoneInfo
+
+import psycopg
+import psycopg.rows
+
+SecurityType = Literal["common_stock", "etf", "other", "unknown"]
+ListingMarket = Literal["nyse", "nasdaq", "other", "unknown"]
+CandidateVerdict = Literal["eligible", "refused"]
+PriceBand = Literal["under_5", "5_to_20", "20_to_50", "50_to_150", "150_plus"]
+DollarVolumeBand = Literal["under_1m", "1m_to_10m", "10m_to_25m", "25m_to_100m", "100m_plus"]
+
+
+@dataclass(frozen=True)
+class ContextDefinition:
+    price_edges: tuple[str, ...] = ("5", "20", "50", "150")
+    dollar_volume_edges: tuple[str, ...] = ("1000000", "10000000", "25000000", "100000000")
+    trailing_volume_statistic: str = "causal_median"
+    listing_semantics: str = "primary_listing_not_execution_venue"
+
+
+DEFINITION: Final = ContextDefinition()
+
+
+def _version() -> str:
+    payload = repr(DEFINITION) + inspect.getsource(price_band_for) + inspect.getsource(dollar_volume_band_for)
+    return "decision-context-v1:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def price_band_for(price: Decimal) -> PriceBand:
+    if price <= 0:
+        raise ValueError("as-traded price must be positive")
+    if price < 5:
+        return "under_5"
+    if price < 20:
+        return "5_to_20"
+    if price < 50:
+        return "20_to_50"
+    if price < 150:
+        return "50_to_150"
+    return "150_plus"
+
+
+def dollar_volume_band_for(value: Decimal) -> DollarVolumeBand:
+    if value < 0:
+        raise ValueError("trailing median dollar volume must be non-negative")
+    if value < 1_000_000:
+        return "under_1m"
+    if value < 10_000_000:
+        return "1m_to_10m"
+    if value < 25_000_000:
+        return "10m_to_25m"
+    if value < 100_000_000:
+        return "25m_to_100m"
+    return "100m_plus"
+
+
+CONTEXT_VERSION: Final = _version()
+_NEW_YORK: Final = ZoneInfo("America/New_York")
+
+
+@dataclass(frozen=True)
+class MarketClassification:
+    effective_from: date
+    security_type: SecurityType
+    primary_listing_market: ListingMarket
+    provider_exchange_id: str | None
+    instrument_type_id: int | None
+
+
+@dataclass(frozen=True)
+class DecisionInputs:
+    as_traded_price: Decimal | None
+    trailing_median_share_volume: Decimal | None
+    trailing_median_dollar_volume: Decimal | None
+    relative_volume: Decimal | None
+    spread_bps: Decimal | None
+    realised_volatility: Decimal | None
+    gap_pct: Decimal | None
+    market_sector_residual_z: Decimal | None
+    vix: Decimal | None
+
+
+@dataclass(frozen=True)
+class DecisionContext:
+    strategy_id: str
+    strategy_version: str
+    instrument_id: int
+    decision_at: datetime
+    signal_id: int | None
+    candidate_verdict: CandidateVerdict
+    refusal_reason: str | None
+    context_version: str
+    classification_effective_from: date | None
+    security_type: SecurityType | None
+    primary_listing_market: ListingMarket | None
+    provider_exchange_id: str | None
+    instrument_type_id: int | None
+    as_traded_price: Decimal | None
+    price_band: PriceBand | None
+    trailing_median_share_volume: Decimal | None
+    trailing_median_dollar_volume: Decimal | None
+    dollar_volume_band: DollarVolumeBand | None
+    relative_volume: Decimal | None
+    spread_bps: Decimal | None
+    realised_volatility: Decimal | None
+    gap_pct: Decimal | None
+    market_sector_residual_z: Decimal | None
+    vix: Decimal | None
+
+
+_REQUIRED_INPUTS: Final = (
+    "as_traded_price",
+    "trailing_median_share_volume",
+    "trailing_median_dollar_volume",
+    "relative_volume",
+    "spread_bps",
+    "realised_volatility",
+    "gap_pct",
+    "market_sector_residual_z",
+    "vix",
+)
+
+
+def load_market_classification(
+    conn: psycopg.Connection[Any], *, instrument_id: int, decision_at: datetime
+) -> MarketClassification | None:
+    """Resolve only a classification observed on the decision date.
+
+    Imported current metadata does not apply before its effective_from; a
+    historical backtest therefore refuses instead of leaking today's venue or
+    type into old trades.
+    """
+    if decision_at.tzinfo is None:
+        raise ValueError("decision_at must be timezone-aware")
+    with conn.cursor(row_factory=psycopg.rows.tuple_row) as cur:
+        row = cur.execute(
+            """
+            SELECT effective_from, security_type, primary_listing_market,
+                   provider_exchange_id, instrument_type_id
+              FROM instrument_market_classification_history
+             WHERE instrument_id = %(instrument_id)s
+               AND daterange(effective_from, effective_to, '[]') @> %(decision_date)s::date
+            """,
+            {
+                "instrument_id": instrument_id,
+                "decision_date": decision_at.astimezone(_NEW_YORK).date(),
+            },
+        ).fetchone()
+    if row is None:
+        return None
+    return MarketClassification(
+        effective_from=row[0],
+        security_type=row[1],
+        primary_listing_market=row[2],
+        provider_exchange_id=row[3],
+        instrument_type_id=row[4],
+    )
+
+
+def build_decision_context(
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    instrument_id: int,
+    decision_at: datetime,
+    signal_id: int | None,
+    classification: MarketClassification | None,
+    inputs: DecisionInputs,
+) -> DecisionContext:
+    if not strategy_id or not strategy_version:
+        raise ValueError("strategy identity must be non-empty")
+    if instrument_id <= 0:
+        raise ValueError("instrument_id must be positive")
+    if decision_at.tzinfo is None:
+        raise ValueError("decision_at must be timezone-aware")
+
+    missing: list[str] = [name for name in _REQUIRED_INPUTS if getattr(inputs, name) is None]
+    if classification is None:
+        missing.append("point_in_time_classification")
+    else:
+        if classification.security_type == "unknown":
+            missing.append("security_type")
+        if classification.primary_listing_market == "unknown":
+            missing.append("primary_listing_market")
+
+    price_band = None if inputs.as_traded_price is None else price_band_for(inputs.as_traded_price)
+    dollar_band = (
+        None
+        if inputs.trailing_median_dollar_volume is None
+        else dollar_volume_band_for(inputs.trailing_median_dollar_volume)
+    )
+    verdict: CandidateVerdict = "refused" if missing else "eligible"
+    refusal = None if not missing else "missing:" + ",".join(sorted(missing))
+
+    return DecisionContext(
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        instrument_id=instrument_id,
+        decision_at=decision_at,
+        signal_id=signal_id,
+        candidate_verdict=verdict,
+        refusal_reason=refusal,
+        context_version=CONTEXT_VERSION,
+        classification_effective_from=None if classification is None else classification.effective_from,
+        security_type=None if classification is None else classification.security_type,
+        primary_listing_market=None if classification is None else classification.primary_listing_market,
+        provider_exchange_id=None if classification is None else classification.provider_exchange_id,
+        instrument_type_id=None if classification is None else classification.instrument_type_id,
+        as_traded_price=inputs.as_traded_price,
+        price_band=price_band,
+        trailing_median_share_volume=inputs.trailing_median_share_volume,
+        trailing_median_dollar_volume=inputs.trailing_median_dollar_volume,
+        dollar_volume_band=dollar_band,
+        relative_volume=inputs.relative_volume,
+        spread_bps=inputs.spread_bps,
+        realised_volatility=inputs.realised_volatility,
+        gap_pct=inputs.gap_pct,
+        market_sector_residual_z=inputs.market_sector_residual_z,
+        vix=inputs.vix,
+    )
+
+
+_INSERT_CONTEXT = """
+    INSERT INTO strategy_decision_contexts (
+        strategy_id, strategy_version, instrument_id, decision_at, signal_id,
+        candidate_verdict, refusal_reason, context_version,
+        classification_effective_from, security_type, primary_listing_market,
+        provider_exchange_id, instrument_type_id, as_traded_price, price_band,
+        trailing_median_share_volume, trailing_median_dollar_volume,
+        dollar_volume_band, relative_volume, spread_bps, realised_volatility,
+        gap_pct, market_sector_residual_z, vix
+    ) VALUES (
+        %(strategy_id)s, %(strategy_version)s, %(instrument_id)s, %(decision_at)s, %(signal_id)s,
+        %(candidate_verdict)s, %(refusal_reason)s, %(context_version)s,
+        %(classification_effective_from)s, %(security_type)s, %(primary_listing_market)s,
+        %(provider_exchange_id)s, %(instrument_type_id)s, %(as_traded_price)s, %(price_band)s,
+        %(trailing_median_share_volume)s, %(trailing_median_dollar_volume)s,
+        %(dollar_volume_band)s, %(relative_volume)s, %(spread_bps)s, %(realised_volatility)s,
+        %(gap_pct)s, %(market_sector_residual_z)s, %(vix)s
+    )
+    RETURNING context_id
+"""
+
+
+def store_decision_context(conn: psycopg.Connection[Any], context: DecisionContext) -> int:
+    """Insert immutably; a duplicate decision is a loud research defect."""
+    row = conn.execute(_INSERT_CONTEXT, asdict(context)).fetchone()
+    if row is None:  # pragma: no cover - INSERT RETURNING always returns
+        raise RuntimeError("decision context insert returned no identity")
+    return int(row[0])
+
+
+__all__ = [
+    "CONTEXT_VERSION",
+    "DecisionContext",
+    "DecisionInputs",
+    "MarketClassification",
+    "build_decision_context",
+    "dollar_volume_band_for",
+    "load_market_classification",
+    "price_band_for",
+    "store_decision_context",
+]

--- a/app/services/universe.py
+++ b/app/services/universe.py
@@ -14,6 +14,7 @@ import psycopg
 
 from app.providers.market_data import InstrumentRecord, MarketDataProvider
 from app.services.instrument_history import reconcile_symbol_history
+from app.services.instrument_market_classification import reconcile_instrument_market_classification
 from app.services.universe_membership import reconcile_universe_membership
 
 logger = logging.getLogger(__name__)
@@ -240,6 +241,26 @@ def sync_universe(
                 membership.reopened_same_day,
                 membership.closed,
                 membership.confirmed,
+            )
+
+        classification = reconcile_instrument_market_classification(conn)
+        if any(
+            (
+                classification.confirmed,
+                classification.opened,
+                classification.changed,
+                classification.corrected_same_day,
+                classification.closed,
+            )
+        ):
+            logger.info(
+                "Universe sync: market classification confirmed=%d opened=%d changed=%d "
+                "corrected_same_day=%d closed=%d",
+                classification.confirmed,
+                classification.opened,
+                classification.changed,
+                classification.corrected_same_day,
+                classification.closed,
             )
 
     # Re-query to get accurate inserted/updated counts.

--- a/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
+++ b/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
@@ -1,0 +1,82 @@
+# Point-in-time market cohorts — implemented foundation (#2508)
+
+## Outcome
+
+Strategy evidence can now retain the security type, primary listing market,
+as-traded price band and causal liquidity/risk context that existed when a
+candidate was considered. The implementation fails closed when that context is
+not known; it does not fill a historical trade with today's instrument row.
+
+This is attribution infrastructure, not a profitable strategy and not a
+promotion of S1–S4. Its purpose is to stop an average from hiding that a rule
+worked in one market-structure cell and lost in another.
+
+## What is recorded
+
+`instrument_market_classification_history` is transition-only. The eToro
+universe refresh confirms the current row, opens a new row only if provider
+exchange or security type changes, and closes it when the instrument leaves the
+tradable universe. The initial import starts on the observation date and is
+never backdated.
+
+`strategy_decision_contexts` stores one row for a fired or explicitly refused
+candidate. Routine `not_fired` scans and rolling indicator values do not enter
+this table. The row contains:
+
+- provider security type and normalised common-stock/ETF/other classification;
+- primary listing market (NYSE/Nasdaq/other), explicitly not execution venue;
+- contemporaneous as-traded price and fixed price band;
+- causal trailing median share/dollar volume, relative volume and dollar-volume
+  band;
+- spread, realised volatility, gap, market/sector residual z-score and VIX;
+- the version hash of all bucket boundaries and semantics;
+- a named refusal when any required input is absent or unknown.
+
+The bands are descriptive, frozen diagnostics. Discovering that one band wins
+does not allow that band to be selected on the same outcomes. It creates a new
+preregistered candidate for a later untouched interval.
+
+## Measured current classification census
+
+Measured against the dev database after migrations 302–303 on 2026-08-10:
+
+| security type | primary listing | current rows |
+|---|---:|---:|
+| common stock | Nasdaq | 3,618 |
+| common stock | NYSE | 2,465 |
+| common stock | other | 4,734 |
+| ETF | Nasdaq | 110 |
+| ETF | NYSE | 390 |
+| ETF | other | 732 |
+| other | other | 646 |
+
+The 12,695-row classification history occupied 5,600 KiB including indexes.
+The empty decision-context relation occupied 48 KiB. This validates the
+transition-only storage shape; it does not yet measure context growth under a
+live candidate rate.
+
+## Important boundaries
+
+- The imported classification is prospective from 2026-08-10. Historical
+  backtests before that date refuse until an authoritative dated source exists.
+- Primary listing affects listing rules, auctions and halt identity. It is not
+  where an eToro order executed. Spread/slippage and broker execution evidence
+  remain separate requirements.
+- Exchange IDs 4/5 and instrument type IDs 5/6 are stable provider facts used
+  during bootstrap; lookup labels cross-check them but are not required to have
+  arrived first.
+- Market-cap cohorts remain refused until both as-traded price and a
+  point-in-time share count are valid.
+- No context rows exist yet because no strategy candidate is allocation-ready.
+  Generating placeholder rows would manufacture evidence and bloat the table.
+
+## Next evidence stage
+
+Join completed, identically resolved outcomes to their immutable contexts and
+emit unpooled plus type/listing/price/liquidity and declared interaction cells.
+Each cell must report trade count, date/name clustered effective sample size,
+after-cost expectancy with confidence interval, profit factor, drawdown/tail,
+hit rate, holding time, turnover, concentration and cost sensitivity. Sparse or
+directionally unstable cells refuse promotion. At least two recent purged
+walk-forward folds and a later untouched/prospective interval must agree before
+the candidate is exposed as an allocation control.

--- a/sql/302_strategy_point_in_time_context.sql
+++ b/sql/302_strategy_point_in_time_context.sql
@@ -1,0 +1,151 @@
+-- #2508 — point-in-time market classification and compact decision context.
+--
+-- Classification history is transition-only: a daily universe refresh confirms
+-- the current row and writes a new row only when type/listing changes. Decision
+-- context is one narrow row per fired/refused candidate, never one row per bar
+-- or per not-fired scan. This keeps the evidence needed to explain cohort
+-- performance without duplicating the intraday price store.
+
+CREATE TABLE IF NOT EXISTS instrument_market_classification_history (
+    instrument_id BIGINT NOT NULL
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    effective_from DATE NOT NULL,
+    effective_to DATE,
+    last_confirmed_on DATE NOT NULL,
+    provider_exchange_id TEXT,
+    primary_listing_market TEXT NOT NULL
+        CHECK (primary_listing_market IN ('nyse', 'nasdaq', 'other', 'unknown')),
+    instrument_type_id INTEGER,
+    security_type TEXT NOT NULL
+        CHECK (security_type IN ('common_stock', 'etf', 'other', 'unknown')),
+    source_event TEXT NOT NULL
+        CHECK (source_event IN ('imported', 'classification_change')),
+    PRIMARY KEY (instrument_id, effective_from),
+    CONSTRAINT instrument_market_classification_dates_ordered
+        CHECK (effective_to IS NULL OR effective_to >= effective_from),
+    CONSTRAINT instrument_market_classification_confirmed_after_start
+        CHECK (last_confirmed_on >= effective_from),
+    CONSTRAINT instrument_market_classification_closed_at_confirmation
+        CHECK (effective_to IS NULL OR effective_to = last_confirmed_on)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_instrument_market_classification_current
+    ON instrument_market_classification_history (instrument_id)
+    WHERE effective_to IS NULL;
+
+ALTER TABLE instrument_market_classification_history
+    ADD CONSTRAINT instrument_market_classification_no_overlap
+    EXCLUDE USING GIST (
+        instrument_id WITH =,
+        daterange(effective_from, effective_to, '[]') WITH &&
+    );
+
+-- Start the prospective record honestly. CURRENT_DATE is the first date on
+-- which this database can evidence the current provider classification; it is
+-- deliberately not backdated to instruments.first_seen_at.
+INSERT INTO instrument_market_classification_history (
+    instrument_id, effective_from, effective_to, last_confirmed_on,
+    provider_exchange_id, primary_listing_market, instrument_type_id,
+    security_type, source_event
+)
+SELECT i.instrument_id, CURRENT_DATE, NULL, CURRENT_DATE,
+       i.exchange,
+       CASE lower(coalesce(e.description, ''))
+           WHEN 'nyse' THEN 'nyse'
+           WHEN 'nasdaq' THEN 'nasdaq'
+           ELSE CASE WHEN i.exchange IS NULL THEN 'unknown' ELSE 'other' END
+       END,
+       i.instrument_type_id,
+       CASE lower(coalesce(t.description, ''))
+           WHEN 'stocks' THEN 'common_stock'
+           WHEN 'etf' THEN 'etf'
+           ELSE CASE WHEN i.instrument_type_id IS NULL THEN 'unknown' ELSE 'other' END
+       END,
+       'imported'
+FROM instruments i
+LEFT JOIN exchanges e ON e.exchange_id = i.exchange
+LEFT JOIN etoro_instrument_types t ON t.instrument_type_id = i.instrument_type_id
+WHERE i.is_tradable
+ON CONFLICT (instrument_id, effective_from) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS strategy_decision_contexts (
+    context_id BIGSERIAL PRIMARY KEY,
+    strategy_id TEXT NOT NULL CHECK (strategy_id <> ''),
+    strategy_version TEXT NOT NULL CHECK (strategy_version <> ''),
+    instrument_id BIGINT NOT NULL
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    decision_at TIMESTAMPTZ NOT NULL,
+    signal_id BIGINT UNIQUE REFERENCES strategy_signals(signal_id) ON DELETE CASCADE,
+    candidate_verdict TEXT NOT NULL
+        CHECK (candidate_verdict IN ('eligible', 'refused')),
+    refusal_reason TEXT,
+    context_version TEXT NOT NULL CHECK (context_version <> ''),
+    classification_effective_from DATE,
+    security_type TEXT CHECK (security_type IN ('common_stock', 'etf', 'other', 'unknown')),
+    primary_listing_market TEXT CHECK (primary_listing_market IN ('nyse', 'nasdaq', 'other', 'unknown')),
+    provider_exchange_id TEXT,
+    instrument_type_id INTEGER,
+    as_traded_price NUMERIC,
+    price_band TEXT CHECK (price_band IN ('under_5', '5_to_20', '20_to_50', '50_to_150', '150_plus')),
+    trailing_median_share_volume NUMERIC,
+    trailing_median_dollar_volume NUMERIC,
+    dollar_volume_band TEXT CHECK (dollar_volume_band IN ('under_1m', '1m_to_10m', '10m_to_25m', '25m_to_100m', '100m_plus')),
+    relative_volume NUMERIC,
+    spread_bps NUMERIC,
+    realised_volatility NUMERIC,
+    gap_pct NUMERIC,
+    market_sector_residual_z NUMERIC,
+    vix NUMERIC,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_decision_context_unique
+        UNIQUE (strategy_id, strategy_version, instrument_id, decision_at),
+    CONSTRAINT strategy_decision_context_verdict_reason
+        CHECK ((candidate_verdict = 'refused') = (refusal_reason IS NOT NULL)),
+    CONSTRAINT strategy_decision_context_positive_inputs
+        CHECK (
+            (as_traded_price IS NULL OR as_traded_price > 0)
+            AND (trailing_median_share_volume IS NULL OR trailing_median_share_volume >= 0)
+            AND (trailing_median_dollar_volume IS NULL OR trailing_median_dollar_volume >= 0)
+            AND (relative_volume IS NULL OR relative_volume >= 0)
+            AND (spread_bps IS NULL OR spread_bps >= 0)
+            AND (realised_volatility IS NULL OR realised_volatility >= 0)
+            AND (vix IS NULL OR vix >= 0)
+        ),
+    -- An eligible row is a fully attributable decision. A refused row retains
+    -- the partial evidence and named reason, allowing coverage gaps to be
+    -- counted without pretending they form a tradable cohort.
+    CONSTRAINT strategy_decision_context_eligible_complete
+        CHECK (
+            candidate_verdict = 'refused' OR (
+                classification_effective_from IS NOT NULL
+                AND security_type IS NOT NULL AND security_type <> 'unknown'
+                AND primary_listing_market IS NOT NULL AND primary_listing_market <> 'unknown'
+                AND as_traded_price IS NOT NULL AND price_band IS NOT NULL
+                AND trailing_median_share_volume IS NOT NULL
+                AND trailing_median_dollar_volume IS NOT NULL AND dollar_volume_band IS NOT NULL
+                AND relative_volume IS NOT NULL AND spread_bps IS NOT NULL
+                AND realised_volatility IS NOT NULL AND gap_pct IS NOT NULL
+                AND market_sector_residual_z IS NOT NULL AND vix IS NOT NULL
+            )
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_decision_context_candidate
+    ON strategy_decision_contexts (strategy_id, strategy_version, decision_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_decision_context_cohort
+    ON strategy_decision_contexts (
+        strategy_id, strategy_version, security_type,
+        primary_listing_market, price_band, dollar_volume_band
+    )
+    WHERE candidate_verdict = 'eligible';
+
+COMMENT ON TABLE instrument_market_classification_history IS
+    'Prospective, transition-only eToro security-type and primary-listing '
+    'classification. Imported rows begin when first observed and must never be '
+    'used to infer older history. Primary listing is not execution venue.';
+
+COMMENT ON TABLE strategy_decision_contexts IS
+    'One compact point-in-time context per fired/refused candidate; never per '
+    'bar or routine not-fired scan. Supports type/listing/price/liquidity cohort '
+    'analysis while keeping rolling inputs in their bounded source stores.';

--- a/sql/303_strategy_classification_bootstrap_ids.sql
+++ b/sql/303_strategy_classification_bootstrap_ids.sql
@@ -1,0 +1,21 @@
+-- #2508 follow-up: migration 302 can run before the optional human-readable
+-- eToro lookup rows have been refreshed. The provider IDs themselves are the
+-- stable facts (4 Nasdaq, 5 NYSE; 5 Stocks, 6 ETF), so repair only the current
+-- same-day imported rows. Future reconciles use the same ID-first rule.
+
+UPDATE instrument_market_classification_history h
+   SET primary_listing_market = CASE i.exchange
+           WHEN '4' THEN 'nasdaq'
+           WHEN '5' THEN 'nyse'
+           ELSE h.primary_listing_market
+       END,
+       security_type = CASE i.instrument_type_id
+           WHEN 5 THEN 'common_stock'
+           WHEN 6 THEN 'etf'
+           ELSE h.security_type
+       END
+  FROM instruments i
+ WHERE i.instrument_id = h.instrument_id
+   AND h.effective_to IS NULL
+   AND h.effective_from = CURRENT_DATE
+   AND h.source_event = 'imported';

--- a/tests/test_strategy_decision_context.py
+++ b/tests/test_strategy_decision_context.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.instrument_market_classification import reconcile_instrument_market_classification
+from app.services.strategy_decision_context import (
+    CONTEXT_VERSION,
+    DecisionInputs,
+    MarketClassification,
+    build_decision_context,
+    dollar_volume_band_for,
+    load_market_classification,
+    price_band_for,
+    store_decision_context,
+)
+from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
+
+
+def _complete_inputs(**overrides: Decimal | None) -> DecisionInputs:
+    values: dict[str, Decimal | None] = {
+        "as_traded_price": Decimal("49.99"),
+        "trailing_median_share_volume": Decimal("1000000"),
+        "trailing_median_dollar_volume": Decimal("24999999"),
+        "relative_volume": Decimal("1.8"),
+        "spread_bps": Decimal("7.5"),
+        "realised_volatility": Decimal("0.32"),
+        "gap_pct": Decimal("-2.1"),
+        "market_sector_residual_z": Decimal("-2.7"),
+        "vix": Decimal("19.2"),
+    }
+    values.update(overrides)
+    return DecisionInputs(**values)  # type: ignore[arg-type]
+
+
+def test_boundaries_are_explicit_and_stable() -> None:
+    assert price_band_for(Decimal("4.99")) == "under_5"
+    assert price_band_for(Decimal("5")) == "5_to_20"
+    assert price_band_for(Decimal("20")) == "20_to_50"
+    assert price_band_for(Decimal("50")) == "50_to_150"
+    assert price_band_for(Decimal("150")) == "150_plus"
+    assert dollar_volume_band_for(Decimal("9999999")) == "1m_to_10m"
+    assert dollar_volume_band_for(Decimal("10000000")) == "10m_to_25m"
+    assert CONTEXT_VERSION.startswith("decision-context-v1:")
+
+
+def test_complete_context_is_eligible() -> None:
+    context = build_decision_context(
+        strategy_id="candidate-1",
+        strategy_version="sha256:abc",
+        instrument_id=1,
+        decision_at=datetime(2026, 8, 10, 14, 35, tzinfo=UTC),
+        signal_id=None,
+        classification=MarketClassification(
+            effective_from=date(2026, 8, 10),
+            security_type="common_stock",
+            primary_listing_market="nasdaq",
+            provider_exchange_id="4",
+            instrument_type_id=5,
+        ),
+        inputs=_complete_inputs(),
+    )
+    assert context.candidate_verdict == "eligible"
+    assert context.refusal_reason is None
+    assert context.price_band == "20_to_50"
+    assert context.dollar_volume_band == "10m_to_25m"
+
+
+def test_missing_or_unknown_point_in_time_data_refuses_by_name() -> None:
+    context = build_decision_context(
+        strategy_id="candidate-1",
+        strategy_version="sha256:abc",
+        instrument_id=1,
+        decision_at=datetime(2026, 8, 10, 14, 35, tzinfo=UTC),
+        signal_id=None,
+        classification=MarketClassification(
+            effective_from=date(2026, 8, 10),
+            security_type="common_stock",
+            primary_listing_market="unknown",
+            provider_exchange_id=None,
+            instrument_type_id=5,
+        ),
+        inputs=_complete_inputs(vix=None, spread_bps=None),
+    )
+    assert context.candidate_verdict == "refused"
+    assert context.refusal_reason == "missing:primary_listing_market,spread_bps,vix"
+
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_instrument(conn: psycopg.Connection[tuple[Any, ...]], iid: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id, symbol, company_name, exchange, currency,
+            is_tradable, instrument_type_id, first_seen_at, last_seen_at
+        ) VALUES (%s, %s, 'Context Test', '4', 'USD', TRUE, 5, NOW(), NOW())
+        """,
+        (iid, f"CTX{iid}"),
+    )
+
+
+def test_reconcile_records_prospective_classification_and_same_day_correction(
+    ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    iid = 2_508_001
+    _seed_instrument(conn, iid)
+    stats = reconcile_instrument_market_classification(conn)
+    assert stats.opened == 1
+
+    row = conn.execute(
+        """
+        SELECT primary_listing_market, security_type, source_event
+        FROM instrument_market_classification_history
+        WHERE instrument_id = %s
+        """,
+        (iid,),
+    ).fetchone()
+    assert row == ("nasdaq", "common_stock", "imported")
+
+    conn.execute("UPDATE instruments SET exchange = '5', instrument_type_id = 6 WHERE instrument_id = %s", (iid,))
+    stats = reconcile_instrument_market_classification(conn)
+    assert stats.corrected_same_day == 1
+    rows = conn.execute(
+        """
+        SELECT primary_listing_market, security_type
+        FROM instrument_market_classification_history
+        WHERE instrument_id = %s
+        """,
+        (iid,),
+    ).fetchall()
+    assert rows == [("nyse", "etf")]
+
+
+def test_current_metadata_cannot_leak_into_historical_decision(
+    ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    iid = 2_508_002
+    _seed_instrument(conn, iid)
+    reconcile_instrument_market_classification(conn)
+
+    historical = datetime.now(UTC) - timedelta(days=1)
+    assert load_market_classification(conn, instrument_id=iid, decision_at=historical) is None
+    assert load_market_classification(conn, instrument_id=iid, decision_at=datetime.now(UTC)) is not None
+
+
+def test_later_classification_change_closes_prior_row_without_overlap(
+    ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    iid = 2_508_004
+    _seed_instrument(conn, iid)
+    conn.execute("UPDATE instruments SET exchange = '5', instrument_type_id = 6 WHERE instrument_id = %s", (iid,))
+    conn.execute(
+        """
+        INSERT INTO instrument_market_classification_history (
+            instrument_id, effective_from, effective_to, last_confirmed_on,
+            provider_exchange_id, primary_listing_market, instrument_type_id,
+            security_type, source_event
+        ) VALUES (
+            %s, CURRENT_DATE - 1, NULL, CURRENT_DATE - 1,
+            '4', 'nasdaq', 5, 'common_stock', 'imported'
+        )
+        """,
+        (iid,),
+    )
+
+    stats = reconcile_instrument_market_classification(conn)
+    assert stats.changed == 1
+    assert stats.opened == 1
+    rows = conn.execute(
+        """
+        SELECT effective_from, effective_to, primary_listing_market, security_type
+        FROM instrument_market_classification_history
+        WHERE instrument_id = %s
+        ORDER BY effective_from
+        """,
+        (iid,),
+    ).fetchall()
+    current_date_row = conn.execute("SELECT CURRENT_DATE").fetchone()
+    assert current_date_row is not None
+    current_date = current_date_row[0]
+    assert rows == [
+        (current_date - timedelta(days=1), current_date - timedelta(days=1), "nasdaq", "common_stock"),
+        (current_date, None, "nyse", "etf"),
+    ]
+
+
+def test_context_round_trip_and_database_completeness_guard(
+    ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    iid = 2_508_003
+    _seed_instrument(conn, iid)
+    reconcile_instrument_market_classification(conn)
+    decision_at = datetime.now(UTC)
+    classification = load_market_classification(conn, instrument_id=iid, decision_at=decision_at)
+    assert classification is not None
+    context = build_decision_context(
+        strategy_id="candidate-db",
+        strategy_version="sha256:def",
+        instrument_id=iid,
+        decision_at=decision_at,
+        signal_id=None,
+        classification=classification,
+        inputs=_complete_inputs(),
+    )
+    context_id = store_decision_context(conn, context)
+    assert context_id > 0
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with conn.transaction():
+            conn.execute(
+                """
+                INSERT INTO strategy_decision_contexts (
+                    strategy_id, strategy_version, instrument_id, decision_at,
+                    candidate_verdict, context_version
+                ) VALUES ('bad', 'v1', %s, NOW() + interval '1 second', 'eligible', 'v1')
+                """,
+                (iid,),
+            )

--- a/tests/test_strategy_decision_context.py
+++ b/tests/test_strategy_decision_context.py
@@ -90,9 +90,6 @@ def test_missing_or_unknown_point_in_time_data_refuses_by_name() -> None:
     assert context.refusal_reason == "missing:primary_listing_market,spread_bps,vix"
 
 
-pytestmark = pytest.mark.integration
-
-
 def _seed_instrument(conn: psycopg.Connection[tuple[Any, ...]], iid: int) -> None:
     conn.execute(
         """
@@ -105,6 +102,7 @@ def _seed_instrument(conn: psycopg.Connection[tuple[Any, ...]], iid: int) -> Non
     )
 
 
+@pytest.mark.integration
 def test_reconcile_records_prospective_classification_and_same_day_correction(
     ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
 ) -> None:
@@ -138,6 +136,7 @@ def test_reconcile_records_prospective_classification_and_same_day_correction(
     assert rows == [("nyse", "etf")]
 
 
+@pytest.mark.integration
 def test_current_metadata_cannot_leak_into_historical_decision(
     ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
 ) -> None:
@@ -151,6 +150,7 @@ def test_current_metadata_cannot_leak_into_historical_decision(
     assert load_market_classification(conn, instrument_id=iid, decision_at=datetime.now(UTC)) is not None
 
 
+@pytest.mark.integration
 def test_later_classification_change_closes_prior_row_without_overlap(
     ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
 ) -> None:
@@ -193,6 +193,7 @@ def test_later_classification_change_closes_prior_row_without_overlap(
     ]
 
 
+@pytest.mark.integration
 def test_context_round_trip_and_database_completeness_guard(
     ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
 ) -> None:


### PR DESCRIPTION
## Outcome

Adds the compact point-in-time attribution foundation for #2508. Strategy research can now distinguish common stocks from ETFs, NYSE from Nasdaq primary listings, and as-traded price/liquidity regimes without resolving historical decisions from today's instrument metadata.

## What changed

- transition-only instrument market classification history, maintained by the eToro universe sync
- one immutable context row per fired/refused candidate; routine not-fired scans and rolling series are not duplicated
- versioned price and dollar-volume bands plus spread, realised volatility, gap, residual and VIX inputs
- fail-closed eligibility when classification or any required causal input is missing
- bootstrap correction uses stable eToro IDs before optional lookup labels arrive
- measured dev census and storage evidence

## Evidence

- 12,695 current classifications occupy 5,600 KiB including indexes
- 3,618 Nasdaq stocks; 2,465 NYSE stocks; 110 Nasdaq ETFs; 390 NYSE ETFs; other provider classes remain separate
- zero candidate-context rows: no placeholder evidence is manufactured before a candidate exists
- full pre-push gate green, including app boot, migrations/schema drift, pyright, ruff and test suites
- focused point-in-time/cohort suite: 7 passed

## Boundaries

- primary listing is not execution venue
- history begins prospectively; pre-observation backtests refuse
- this does not promote any strategy or claim alpha
- the shared cohort/interaction outcome report remains follow-up work under #2508

Refs #2508 #2507 #2400 #2477