### PR TITLE
fix: preserve strategy volume provenance

### DIFF
--- a/app/services/strategy_decision_context.py
+++ b/app/services/strategy_decision_context.py
@@ -31,6 +31,8 @@ class ContextDefinition:
     price_edges: tuple[str, ...] = ("5", "20", "50", "150")
     dollar_volume_edges: tuple[str, ...] = ("1000000", "10000000", "25000000", "100000000")
     trailing_volume_statistic: str = "causal_median"
+    volume_lookback_sessions: int = 20
+    volume_capacity_statistic: str = "causal_mean"
     listing_semantics: str = "primary_listing_not_execution_venue"
 
 
@@ -86,8 +88,12 @@ class MarketClassification:
 @dataclass(frozen=True)
 class DecisionInputs:
     as_traded_price: Decimal | None
+    trailing_mean_share_volume: Decimal | None
     trailing_median_share_volume: Decimal | None
+    trailing_mean_dollar_volume: Decimal | None
     trailing_median_dollar_volume: Decimal | None
+    zero_volume_frequency: Decimal | None
+    intraday_coverage: Decimal | None
     relative_volume: Decimal | None
     spread_bps: Decimal | None
     realised_volatility: Decimal | None
@@ -113,9 +119,14 @@ class DecisionContext:
     instrument_type_id: int | None
     as_traded_price: Decimal | None
     price_band: PriceBand | None
+    volume_lookback_sessions: int
+    trailing_mean_share_volume: Decimal | None
     trailing_median_share_volume: Decimal | None
+    trailing_mean_dollar_volume: Decimal | None
     trailing_median_dollar_volume: Decimal | None
     dollar_volume_band: DollarVolumeBand | None
+    zero_volume_frequency: Decimal | None
+    intraday_coverage: Decimal | None
     relative_volume: Decimal | None
     spread_bps: Decimal | None
     realised_volatility: Decimal | None
@@ -126,8 +137,12 @@ class DecisionContext:
 
 _REQUIRED_INPUTS: Final = (
     "as_traded_price",
+    "trailing_mean_share_volume",
     "trailing_median_share_volume",
+    "trailing_mean_dollar_volume",
     "trailing_median_dollar_volume",
+    "zero_volume_frequency",
+    "intraday_coverage",
     "relative_volume",
     "spread_bps",
     "realised_volatility",
@@ -189,6 +204,23 @@ def build_decision_context(
         raise ValueError("instrument_id must be positive")
     if decision_at.tzinfo is None:
         raise ValueError("decision_at must be timezone-aware")
+    for name in (
+        "trailing_mean_share_volume",
+        "trailing_median_share_volume",
+        "trailing_mean_dollar_volume",
+        "trailing_median_dollar_volume",
+        "relative_volume",
+        "spread_bps",
+        "realised_volatility",
+        "vix",
+    ):
+        value = getattr(inputs, name)
+        if value is not None and value < 0:
+            raise ValueError(f"{name} must be non-negative")
+    for name in ("zero_volume_frequency", "intraday_coverage"):
+        value = getattr(inputs, name)
+        if value is not None and not 0 <= value <= 1:
+            raise ValueError(f"{name} must be inside 0-1")
 
     missing: list[str] = [name for name in _REQUIRED_INPUTS if getattr(inputs, name) is None]
     if classification is None:
@@ -224,9 +256,14 @@ def build_decision_context(
         instrument_type_id=None if classification is None else classification.instrument_type_id,
         as_traded_price=inputs.as_traded_price,
         price_band=price_band,
+        volume_lookback_sessions=DEFINITION.volume_lookback_sessions,
+        trailing_mean_share_volume=inputs.trailing_mean_share_volume,
         trailing_median_share_volume=inputs.trailing_median_share_volume,
+        trailing_mean_dollar_volume=inputs.trailing_mean_dollar_volume,
         trailing_median_dollar_volume=inputs.trailing_median_dollar_volume,
         dollar_volume_band=dollar_band,
+        zero_volume_frequency=inputs.zero_volume_frequency,
+        intraday_coverage=inputs.intraday_coverage,
         relative_volume=inputs.relative_volume,
         spread_bps=inputs.spread_bps,
         realised_volatility=inputs.realised_volatility,
@@ -242,16 +279,22 @@ _INSERT_CONTEXT = """
         candidate_verdict, refusal_reason, context_version,
         classification_effective_from, security_type, primary_listing_market,
         provider_exchange_id, instrument_type_id, as_traded_price, price_band,
-        trailing_median_share_volume, trailing_median_dollar_volume,
-        dollar_volume_band, relative_volume, spread_bps, realised_volatility,
+        volume_lookback_sessions, trailing_mean_share_volume,
+        trailing_median_share_volume, trailing_mean_dollar_volume,
+        trailing_median_dollar_volume, dollar_volume_band,
+        zero_volume_frequency, intraday_coverage,
+        relative_volume, spread_bps, realised_volatility,
         gap_pct, market_sector_residual_z, vix
     ) VALUES (
         %(strategy_id)s, %(strategy_version)s, %(instrument_id)s, %(decision_at)s, %(signal_id)s,
         %(candidate_verdict)s, %(refusal_reason)s, %(context_version)s,
         %(classification_effective_from)s, %(security_type)s, %(primary_listing_market)s,
         %(provider_exchange_id)s, %(instrument_type_id)s, %(as_traded_price)s, %(price_band)s,
-        %(trailing_median_share_volume)s, %(trailing_median_dollar_volume)s,
-        %(dollar_volume_band)s, %(relative_volume)s, %(spread_bps)s, %(realised_volatility)s,
+        %(volume_lookback_sessions)s, %(trailing_mean_share_volume)s,
+        %(trailing_median_share_volume)s, %(trailing_mean_dollar_volume)s,
+        %(trailing_median_dollar_volume)s, %(dollar_volume_band)s,
+        %(zero_volume_frequency)s, %(intraday_coverage)s,
+        %(relative_volume)s, %(spread_bps)s, %(realised_volatility)s,
         %(gap_pct)s, %(market_sector_residual_z)s, %(vix)s
     )
     RETURNING context_id

--- a/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
+++ b/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
@@ -26,8 +26,9 @@ this table. The row contains:
 - provider security type and normalised common-stock/ETF/other classification;
 - primary listing market (NYSE/Nasdaq/other), explicitly not execution venue;
 - contemporaneous as-traded price and fixed price band;
-- causal trailing median share/dollar volume, relative volume and dollar-volume
-  band;
+- 20 completed causal sessions of mean share/dollar volume (capacity), median
+  share/dollar volume (typical-day robustness), relative volume, zero-volume
+  frequency, intraday coverage and dollar-volume band;
 - spread, realised volatility, gap, market/sector residual z-score and VIX;
 - the version hash of all bucket boundaries and semantics;
 - a named refusal when any required input is absent or unknown.

--- a/sql/304_strategy_volume_context_provenance.sql
+++ b/sql/304_strategy_volume_context_provenance.sql
@@ -1,0 +1,53 @@
+-- #2508 — complete volume provenance for point-in-time decision contexts.
+-- Mean ADV is the capacity convention; median volume is the robust typical-day
+-- baseline. Both need the causal lookback and coverage record to be comparable.
+
+ALTER TABLE strategy_decision_contexts
+    ADD COLUMN IF NOT EXISTS volume_lookback_sessions INTEGER,
+    ADD COLUMN IF NOT EXISTS trailing_mean_share_volume NUMERIC,
+    ADD COLUMN IF NOT EXISTS trailing_mean_dollar_volume NUMERIC,
+    ADD COLUMN IF NOT EXISTS zero_volume_frequency NUMERIC,
+    ADD COLUMN IF NOT EXISTS intraday_coverage NUMERIC;
+
+ALTER TABLE strategy_decision_contexts
+    ADD CONSTRAINT strategy_decision_context_volume_provenance_valid
+    CHECK (
+        (volume_lookback_sessions IS NULL OR volume_lookback_sessions > 0)
+        AND (trailing_mean_share_volume IS NULL OR trailing_mean_share_volume >= 0)
+        AND (trailing_mean_dollar_volume IS NULL OR trailing_mean_dollar_volume >= 0)
+        AND (zero_volume_frequency IS NULL OR zero_volume_frequency BETWEEN 0 AND 1)
+        AND (intraday_coverage IS NULL OR intraday_coverage BETWEEN 0 AND 1)
+    );
+
+ALTER TABLE strategy_decision_contexts
+    DROP CONSTRAINT strategy_decision_context_eligible_complete;
+
+ALTER TABLE strategy_decision_contexts
+    ADD CONSTRAINT strategy_decision_context_eligible_complete
+    CHECK (
+        candidate_verdict = 'refused' OR (
+            classification_effective_from IS NOT NULL
+            AND security_type IS NOT NULL AND security_type <> 'unknown'
+            AND primary_listing_market IS NOT NULL AND primary_listing_market <> 'unknown'
+            AND as_traded_price IS NOT NULL AND price_band IS NOT NULL
+            AND volume_lookback_sessions IS NOT NULL
+            AND trailing_mean_share_volume IS NOT NULL
+            AND trailing_median_share_volume IS NOT NULL
+            AND trailing_mean_dollar_volume IS NOT NULL
+            AND trailing_median_dollar_volume IS NOT NULL
+            AND dollar_volume_band IS NOT NULL
+            AND zero_volume_frequency IS NOT NULL
+            AND intraday_coverage IS NOT NULL
+            AND relative_volume IS NOT NULL AND spread_bps IS NOT NULL
+            AND realised_volatility IS NOT NULL AND gap_pct IS NOT NULL
+            AND market_sector_residual_z IS NOT NULL AND vix IS NOT NULL
+        )
+    );
+
+COMMENT ON COLUMN strategy_decision_contexts.volume_lookback_sessions IS
+    'Completed causal sessions used by both mean and median volume baselines; '
+    'versioned by strategy_decision_context.CONTEXT_VERSION.';
+
+COMMENT ON COLUMN strategy_decision_contexts.intraday_coverage IS
+    'Observed / expected completed intraday bars in the declared lookback, 0-1; '
+    'an eligible context cannot hide partial feed coverage.';

--- a/tests/test_strategy_decision_context.py
+++ b/tests/test_strategy_decision_context.py
@@ -24,8 +24,12 @@ from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
 def _complete_inputs(**overrides: Decimal | None) -> DecisionInputs:
     values: dict[str, Decimal | None] = {
         "as_traded_price": Decimal("49.99"),
+        "trailing_mean_share_volume": Decimal("1200000"),
         "trailing_median_share_volume": Decimal("1000000"),
+        "trailing_mean_dollar_volume": Decimal("30000000"),
         "trailing_median_dollar_volume": Decimal("24999999"),
+        "zero_volume_frequency": Decimal("0"),
+        "intraday_coverage": Decimal("1"),
         "relative_volume": Decimal("1.8"),
         "spread_bps": Decimal("7.5"),
         "realised_volatility": Decimal("0.32"),
@@ -68,6 +72,7 @@ def test_complete_context_is_eligible() -> None:
     assert context.refusal_reason is None
     assert context.price_band == "20_to_50"
     assert context.dollar_volume_band == "10m_to_25m"
+    assert context.volume_lookback_sessions == 20
 
 
 def test_missing_or_unknown_point_in_time_data_refuses_by_name() -> None:
@@ -88,6 +93,19 @@ def test_missing_or_unknown_point_in_time_data_refuses_by_name() -> None:
     )
     assert context.candidate_verdict == "refused"
     assert context.refusal_reason == "missing:primary_listing_market,spread_bps,vix"
+
+
+def test_volume_coverage_outside_fraction_range_is_rejected() -> None:
+    with pytest.raises(ValueError, match="intraday_coverage must be inside 0-1"):
+        build_decision_context(
+            strategy_id="candidate-1",
+            strategy_version="sha256:abc",
+            instrument_id=1,
+            decision_at=datetime(2026, 8, 10, 14, 35, tzinfo=UTC),
+            signal_id=None,
+            classification=None,
+            inputs=_complete_inputs(intraday_coverage=Decimal("1.01")),
+        )
 
 
 def _seed_instrument(conn: psycopg.Connection[tuple[Any, ...]], iid: int) -> None:


### PR DESCRIPTION
## Outcome

Closes the volume-provenance gap found while reviewing #2508 after PR #2512. A candidate now records both mean ADV (capacity) and median volume (typical-day robustness), with an explicit 20-completed-session causal lookback, zero-volume frequency and intraday coverage.

## Why both

A one-day news spike can inflate the mean while leaving the median representative of normal liquidity. Mean and median therefore answer different execution questions; storing only one hid that distinction. Relative volume without its baseline window was also not reproducible.

## Guardrails

- all new inputs are required for an eligible context
- fractions are constrained to 0-1 in Python and PostgreSQL
- absent fields remain named refusals
- still one row per fired/refused candidate; no rolling series or routine not-fired scans are copied
- empty decision-context table remains 48 KiB after the additive schema

## Verification

- 4 pure fast-lane tests passed
- 7 focused context tests passed
- migration content and schema-drift checks passed
- full pre-push gate green, including app boot

Refs #2508