### PR TITLE
fix(#2508): prove candidate price-level provenance

### DIFF
--- a/app/services/strategy_decision_context.py
+++ b/app/services/strategy_decision_context.py
@@ -24,6 +24,8 @@ ListingMarket = Literal["nyse", "nasdaq", "other", "unknown"]
 CandidateVerdict = Literal["eligible", "refused"]
 PriceBand = Literal["under_5", "5_to_20", "20_to_50", "50_to_150", "150_plus"]
 DollarVolumeBand = Literal["under_1m", "1m_to_10m", "10m_to_25m", "25m_to_100m", "100m_plus"]
+AsTradedPriceBasis = Literal["observed_unadjusted", "reconstructed_unadjusted", "unknown"]
+AS_TRADED_PRICE_BASES: Final = frozenset({"observed_unadjusted", "reconstructed_unadjusted", "unknown"})
 
 
 @dataclass(frozen=True)
@@ -34,6 +36,7 @@ class ContextDefinition:
     volume_lookback_sessions: int = 20
     volume_capacity_statistic: str = "causal_mean"
     listing_semantics: str = "primary_listing_not_execution_venue"
+    eligible_price_bases: tuple[str, ...] = ("observed_unadjusted", "reconstructed_unadjusted")
 
 
 DEFINITION: Final = ContextDefinition()
@@ -88,6 +91,7 @@ class MarketClassification:
 @dataclass(frozen=True)
 class DecisionInputs:
     as_traded_price: Decimal | None
+    as_traded_price_basis: AsTradedPriceBasis | None
     trailing_mean_share_volume: Decimal | None
     trailing_median_share_volume: Decimal | None
     trailing_mean_dollar_volume: Decimal | None
@@ -118,6 +122,7 @@ class DecisionContext:
     provider_exchange_id: str | None
     instrument_type_id: int | None
     as_traded_price: Decimal | None
+    as_traded_price_basis: AsTradedPriceBasis | None
     price_band: PriceBand | None
     volume_lookback_sessions: int
     trailing_mean_share_volume: Decimal | None
@@ -137,6 +142,7 @@ class DecisionContext:
 
 _REQUIRED_INPUTS: Final = (
     "as_traded_price",
+    "as_traded_price_basis",
     "trailing_mean_share_volume",
     "trailing_median_share_volume",
     "trailing_mean_dollar_volume",
@@ -204,6 +210,8 @@ def build_decision_context(
         raise ValueError("instrument_id must be positive")
     if decision_at.tzinfo is None:
         raise ValueError("decision_at must be timezone-aware")
+    if inputs.as_traded_price_basis is not None and inputs.as_traded_price_basis not in AS_TRADED_PRICE_BASES:
+        raise ValueError(f"unknown as_traded_price_basis {inputs.as_traded_price_basis!r}")
     for name in (
         "trailing_mean_share_volume",
         "trailing_median_share_volume",
@@ -223,6 +231,8 @@ def build_decision_context(
             raise ValueError(f"{name} must be inside 0-1")
 
     missing: list[str] = [name for name in _REQUIRED_INPUTS if getattr(inputs, name) is None]
+    if inputs.as_traded_price_basis == "unknown":
+        missing.append("as_traded_price_basis")
     if classification is None:
         missing.append("point_in_time_classification")
     else:
@@ -255,6 +265,7 @@ def build_decision_context(
         provider_exchange_id=None if classification is None else classification.provider_exchange_id,
         instrument_type_id=None if classification is None else classification.instrument_type_id,
         as_traded_price=inputs.as_traded_price,
+        as_traded_price_basis=inputs.as_traded_price_basis,
         price_band=price_band,
         volume_lookback_sessions=DEFINITION.volume_lookback_sessions,
         trailing_mean_share_volume=inputs.trailing_mean_share_volume,
@@ -278,7 +289,8 @@ _INSERT_CONTEXT = """
         strategy_id, strategy_version, instrument_id, decision_at, signal_id,
         candidate_verdict, refusal_reason, context_version,
         classification_effective_from, security_type, primary_listing_market,
-        provider_exchange_id, instrument_type_id, as_traded_price, price_band,
+        provider_exchange_id, instrument_type_id, as_traded_price,
+        as_traded_price_basis, price_band,
         volume_lookback_sessions, trailing_mean_share_volume,
         trailing_median_share_volume, trailing_mean_dollar_volume,
         trailing_median_dollar_volume, dollar_volume_band,
@@ -289,7 +301,8 @@ _INSERT_CONTEXT = """
         %(strategy_id)s, %(strategy_version)s, %(instrument_id)s, %(decision_at)s, %(signal_id)s,
         %(candidate_verdict)s, %(refusal_reason)s, %(context_version)s,
         %(classification_effective_from)s, %(security_type)s, %(primary_listing_market)s,
-        %(provider_exchange_id)s, %(instrument_type_id)s, %(as_traded_price)s, %(price_band)s,
+        %(provider_exchange_id)s, %(instrument_type_id)s, %(as_traded_price)s,
+        %(as_traded_price_basis)s, %(price_band)s,
         %(volume_lookback_sessions)s, %(trailing_mean_share_volume)s,
         %(trailing_median_share_volume)s, %(trailing_mean_dollar_volume)s,
         %(trailing_median_dollar_volume)s, %(dollar_volume_band)s,
@@ -310,6 +323,7 @@ def store_decision_context(conn: psycopg.Connection[Any], context: DecisionConte
 
 
 __all__ = [
+    "AS_TRADED_PRICE_BASES",
     "CONTEXT_VERSION",
     "DecisionContext",
     "DecisionInputs",

--- a/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
+++ b/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
@@ -26,6 +26,8 @@ this table. The row contains:
 - provider security type and normalised common-stock/ETF/other classification;
 - primary listing market (NYSE/Nasdaq/other), explicitly not execution venue;
 - contemporaneous as-traded price and fixed price band;
+- explicit price-level provenance: directly observed unadjusted or reconstructed
+  from point-in-time corporate-action factors;
 - 20 completed causal sessions of mean share/dollar volume (capacity), median
   share/dollar volume (typical-day robustness), relative volume, zero-volume
   frequency, intraday coverage and dollar-volume band;
@@ -60,6 +62,9 @@ live candidate rate.
 
 - The imported classification is prospective from 2026-08-10. Historical
   backtests before that date refuse until an authoritative dated source exists.
+- An `as_traded_price` name is not evidence of its basis. Split-adjusted and
+  unknown-basis research levels are valid return inputs but are refused for
+  nominal price, transaction-cost and dollar-volume cohort attribution (#2400).
 - Primary listing affects listing rules, auctions and halt identity. It is not
   where an eToro order executed. Spread/slippage and broker execution evidence
   remain separate requirements.

--- a/sql/305_strategy_as_traded_price_provenance.sql
+++ b/sql/305_strategy_as_traded_price_provenance.sql
@@ -1,0 +1,43 @@
+-- #2508 / #2400 — prove the price level used for candidate cohorts.
+--
+-- A split-adjusted research close is valid for continuous price returns but is
+-- not the nominal price that could have traded on the historical date.  Price
+-- and dollar-volume cohorts therefore require either a directly observed
+-- unadjusted level or a reconstruction backed by point-in-time adjustments.
+
+ALTER TABLE strategy_decision_contexts
+    ADD COLUMN IF NOT EXISTS as_traded_price_basis TEXT
+        CHECK (as_traded_price_basis IN (
+            'observed_unadjusted', 'reconstructed_unadjusted', 'unknown'
+        ));
+
+ALTER TABLE strategy_decision_contexts
+    DROP CONSTRAINT strategy_decision_context_eligible_complete;
+
+ALTER TABLE strategy_decision_contexts
+    ADD CONSTRAINT strategy_decision_context_eligible_complete
+    CHECK (
+        candidate_verdict = 'refused' OR (
+            classification_effective_from IS NOT NULL
+            AND security_type IS NOT NULL AND security_type <> 'unknown'
+            AND primary_listing_market IS NOT NULL AND primary_listing_market <> 'unknown'
+            AND as_traded_price IS NOT NULL
+            AND as_traded_price_basis IN ('observed_unadjusted', 'reconstructed_unadjusted')
+            AND price_band IS NOT NULL
+            AND volume_lookback_sessions IS NOT NULL
+            AND trailing_mean_share_volume IS NOT NULL
+            AND trailing_median_share_volume IS NOT NULL
+            AND trailing_mean_dollar_volume IS NOT NULL
+            AND trailing_median_dollar_volume IS NOT NULL
+            AND dollar_volume_band IS NOT NULL
+            AND zero_volume_frequency IS NOT NULL
+            AND intraday_coverage IS NOT NULL
+            AND relative_volume IS NOT NULL AND spread_bps IS NOT NULL
+            AND realised_volatility IS NOT NULL AND gap_pct IS NOT NULL
+            AND market_sector_residual_z IS NOT NULL AND vix IS NOT NULL
+        )
+    );
+
+COMMENT ON COLUMN strategy_decision_contexts.as_traded_price_basis IS
+    'Provenance of the nominal decision-time price. Split-adjusted research '
+    'levels are not eligible for price/liquidity cohort attribution.';

--- a/tests/test_strategy_decision_context.py
+++ b/tests/test_strategy_decision_context.py
@@ -21,8 +21,8 @@ from app.services.strategy_decision_context import (
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401
 
 
-def _complete_inputs(**overrides: Decimal | None) -> DecisionInputs:
-    values: dict[str, Decimal | None] = {
+def _complete_inputs(**overrides: object) -> DecisionInputs:
+    values: dict[str, object] = {
         "as_traded_price": Decimal("49.99"),
         "trailing_mean_share_volume": Decimal("1200000"),
         "trailing_median_share_volume": Decimal("1000000"),
@@ -36,6 +36,7 @@ def _complete_inputs(**overrides: Decimal | None) -> DecisionInputs:
         "gap_pct": Decimal("-2.1"),
         "market_sector_residual_z": Decimal("-2.7"),
         "vix": Decimal("19.2"),
+        "as_traded_price_basis": "observed_unadjusted",
     }
     values.update(overrides)
     return DecisionInputs(**values)  # type: ignore[arg-type]
@@ -71,6 +72,7 @@ def test_complete_context_is_eligible() -> None:
     assert context.candidate_verdict == "eligible"
     assert context.refusal_reason is None
     assert context.price_band == "20_to_50"
+    assert context.as_traded_price_basis == "observed_unadjusted"
     assert context.dollar_volume_band == "10m_to_25m"
     assert context.volume_lookback_sessions == 20
 
@@ -93,6 +95,39 @@ def test_missing_or_unknown_point_in_time_data_refuses_by_name() -> None:
     )
     assert context.candidate_verdict == "refused"
     assert context.refusal_reason == "missing:primary_listing_market,spread_bps,vix"
+
+
+def test_adjusted_or_unproven_price_basis_refuses_cohort_attribution() -> None:
+    context = build_decision_context(
+        strategy_id="candidate-1",
+        strategy_version="sha256:abc",
+        instrument_id=1,
+        decision_at=datetime(2026, 8, 10, 14, 35, tzinfo=UTC),
+        signal_id=None,
+        classification=MarketClassification(
+            effective_from=date(2026, 8, 10),
+            security_type="common_stock",
+            primary_listing_market="nasdaq",
+            provider_exchange_id="4",
+            instrument_type_id=5,
+        ),
+        inputs=_complete_inputs(as_traded_price_basis="unknown"),
+    )
+    assert context.candidate_verdict == "refused"
+    assert context.refusal_reason == "missing:as_traded_price_basis"
+
+
+def test_unrecognised_price_basis_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unknown as_traded_price_basis"):
+        build_decision_context(
+            strategy_id="candidate-1",
+            strategy_version="sha256:abc",
+            instrument_id=1,
+            decision_at=datetime(2026, 8, 10, 14, 35, tzinfo=UTC),
+            signal_id=None,
+            classification=None,
+            inputs=_complete_inputs(as_traded_price_basis="split_adjusted"),
+        )
 
 
 def test_volume_coverage_outside_fraction_range_is_rejected() -> None:
@@ -233,6 +268,11 @@ def test_context_round_trip_and_database_completeness_guard(
     )
     context_id = store_decision_context(conn, context)
     assert context_id > 0
+    stored_basis = conn.execute(
+        "SELECT as_traded_price_basis FROM strategy_decision_contexts WHERE context_id = %s",
+        (context_id,),
+    ).fetchone()
+    assert stored_basis == ("observed_unadjusted",)
 
     with pytest.raises(psycopg.errors.CheckViolation):
         with conn.transaction():


### PR DESCRIPTION
## Outcome

Prevents split-adjusted or otherwise unproven price levels from entering strategy price, transaction-cost and dollar-volume cohort evidence.

## Changes

- require `observed_unadjusted` or `reconstructed_unadjusted` price-basis provenance for eligible decision contexts
- persist and constrain the basis in migration 305
- fail closed on unknown or unrecognised bases
- document the #2400 boundary

## Validation

- focused decision-context/cohort tests: 20 passed
- ruff and pyright clean
- full pre-push fast, smoke and frontend gates green

Refs #2508. Refs #2400.