### PR TITLE
feat(#2502): freeze ETF intraday momentum candidate

### DIFF
--- a/app/services/etf_intraday_momentum_candidate.py
+++ b/app/services/etf_intraday_momentum_candidate.py
@@ -1,0 +1,198 @@
+"""Frozen, data-compatible ETF intraday-momentum candidate (#2502).
+
+Gao, Han, Li and Zhou measure the return from the prior regular-session close
+to 10:00 New York and use its sign to trade the 15:30-16:00 interval.  Their
+primary data are TAQ price points and their executable rule is long/short.
+
+eBull currently has completed eToro OHLCV candles, not historical 15:30
+bid/ask quotes or shortability.  This module therefore freezes two visibly
+different things before reading retained outcomes:
+
+* the published signed direction, retained only as a replication diagnostic;
+* a long-only adaptation that fires when the opening return is positive.
+
+Neither can receive capital from this module.  A candle-open/close gross
+outcome is feasibility evidence only; promotion requires prospectively
+observed entry/exit quotes and every standing evidence/execution gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Final, Literal
+from zoneinfo import ZoneInfo
+
+from app.services.market_calendar import us_market_status
+from app.services.strategy_observation_storage import IntradayBar
+
+TRIAL_ID: Final = "etf-first-last-half-hour-long-only-v1"
+PRIMARY_SYMBOL: Final = "SPY"
+ROBUSTNESS_SYMBOLS: Final = ("QQQ", "IWM")
+MIN_COMPLETE_PRIMARY_SESSIONS: Final = 60
+_NY: Final = ZoneInfo("America/New_York")
+
+PublishedSide = Literal["long", "short"]
+AdaptationVerdict = Literal["fired_long", "not_fired"]
+
+
+class CandidateRefusal(ValueError):
+    """The supplied point-in-time observation cannot satisfy the trial."""
+
+
+@dataclass(frozen=True)
+class CandidateDefinition:
+    paper_doi: str = "10.1016/j.jfineco.2018.05.009"
+    primary_symbol: str = PRIMARY_SYMBOL
+    robustness_symbols: tuple[str, ...] = ROBUSTNESS_SYMBOLS
+    source: str = "etoro"
+    timeframe: str = "30m"
+    session: str = "NYSE regular full session; half-days excluded"
+    opening_return: str = "09:30 candle close / prior full-session 15:30 candle close - 1"
+    published_rule: str = "long if opening_return > 0 else short"
+    executable_adaptation: str = "long if opening_return > 0 else abstain"
+    decision_known_at: str = "10:00 America/New_York after completed opening candle"
+    entry_observation: str = "15:30 America/New_York quote required prospectively"
+    exit_observation: str = "16:00 America/New_York quote/confirmed close required prospectively"
+    gross_feasibility_proxy: str = "15:30 candle close / 15:30 candle open - 1"
+    minimum_complete_primary_sessions: int = MIN_COMPLETE_PRIMARY_SESSIONS
+    primary_metric: str = "after-observed-cost expectancy with session-blocked lower confidence bound > 0"
+    comparators: tuple[str, ...] = ("always-long-last-half-hour", "same-session-random-sign")
+    promotion_refusals: tuple[str, ...] = (
+        "sample_immature",
+        "historical_entry_exit_quotes_unavailable",
+        "published_short_leg_not_executable",
+        "prospective_outcome_interval_missing",
+    )
+
+
+DEFINITION: Final = CandidateDefinition()
+
+
+def definition_json() -> str:
+    return json.dumps(asdict(DEFINITION), sort_keys=True, separators=(",", ":"))
+
+
+def definition_hash() -> str:
+    payload = definition_json().encode() + b"\0" + Path(__file__).read_bytes()
+    return hashlib.sha256(payload).hexdigest()
+
+
+CANDIDATE_VERSION: Final = f"etf-intraday-momentum-v1+{definition_hash()[:12]}"
+
+
+@dataclass(frozen=True)
+class OpeningSignal:
+    symbol: str
+    instrument_id: int
+    session_date: date
+    known_at: datetime
+    prior_close: Decimal
+    opening_close: Decimal
+    opening_return: Decimal
+    published_side: PublishedSide
+    adaptation_verdict: AdaptationVerdict
+
+
+@dataclass(frozen=True)
+class GrossFeasibilityOutcome:
+    signal: OpeningSignal
+    entry_proxy: Decimal
+    exit_proxy: Decimal
+    gross_return: Decimal
+    promotion_refusals: tuple[str, ...] = DEFINITION.promotion_refusals
+
+
+def _require_bar(bar: IntradayBar, *, expected_start: time, label: str) -> None:
+    if bar.timeframe != "30m":
+        raise CandidateRefusal(f"{label} requires a 30m bar")
+    if bar.source != "etoro":
+        raise CandidateRefusal(f"{label} requires the frozen etoro source")
+    local = bar.bar_time.astimezone(_NY)
+    if local.time().replace(tzinfo=None) != expected_start:
+        raise CandidateRefusal(f"{label} must start at {expected_start.isoformat()} America/New_York")
+    if us_market_status(local.date()) != "open":
+        raise CandidateRefusal("candidate excludes closed and half-day sessions")
+
+
+def opening_signal(
+    *,
+    symbol: str,
+    prior_close_bar: IntradayBar,
+    opening_bar: IntradayBar,
+) -> OpeningSignal:
+    """Create the 10:00 decision without accepting any later-session input."""
+    normalised = symbol.strip().upper()
+    if normalised not in {PRIMARY_SYMBOL, *ROBUSTNESS_SYMBOLS}:
+        raise CandidateRefusal(f"symbol {normalised!r} is outside the preregistered ETF set")
+    _require_bar(prior_close_bar, expected_start=time(15, 30), label="prior close observation")
+    _require_bar(opening_bar, expected_start=time(9, 30), label="opening observation")
+    local = opening_bar.bar_time.astimezone(_NY)
+    prior_local = prior_close_bar.bar_time.astimezone(_NY)
+    if prior_close_bar.instrument_id != opening_bar.instrument_id:
+        raise CandidateRefusal("prior close and opening observation must share an instrument")
+    probe = prior_local.date() + timedelta(days=1)
+    while probe < local.date():
+        if us_market_status(probe) != "closed":
+            raise CandidateRefusal("prior close is not from the immediately preceding trading session")
+        probe += timedelta(days=1)
+    if probe != local.date():
+        raise CandidateRefusal("prior close must precede the opening session")
+    prior_close = prior_close_bar.close
+    opening_return = opening_bar.close / prior_close - Decimal(1)
+    published_side: PublishedSide = "long" if opening_return > 0 else "short"
+    verdict: AdaptationVerdict = "fired_long" if opening_return > 0 else "not_fired"
+    return OpeningSignal(
+        symbol=normalised,
+        instrument_id=opening_bar.instrument_id,
+        session_date=local.date(),
+        known_at=local.replace(hour=10, minute=0, second=0, microsecond=0),
+        prior_close=prior_close,
+        opening_close=opening_bar.close,
+        opening_return=opening_return,
+        published_side=published_side,
+        adaptation_verdict=verdict,
+    )
+
+
+def resolve_gross_feasibility(
+    signal: OpeningSignal,
+    *,
+    last_half_hour_bar: IntradayBar,
+) -> GrossFeasibilityOutcome:
+    """Resolve the candle proxy; never rename it an executable net return."""
+    _require_bar(last_half_hour_bar, expected_start=time(15, 30), label="last-half-hour observation")
+    local = last_half_hour_bar.bar_time.astimezone(_NY)
+    if local.date() != signal.session_date:
+        raise CandidateRefusal("opening signal and last-half-hour observation must share a session")
+    if last_half_hour_bar.instrument_id != signal.instrument_id:
+        raise CandidateRefusal("opening signal and last-half-hour observation must share an instrument")
+    gross = last_half_hour_bar.close / last_half_hour_bar.open - Decimal(1)
+    if signal.adaptation_verdict == "not_fired":
+        gross = Decimal(0)
+    return GrossFeasibilityOutcome(
+        signal=signal,
+        entry_proxy=last_half_hour_bar.open,
+        exit_proxy=last_half_hour_bar.close,
+        gross_return=gross,
+    )
+
+
+__all__ = [
+    "CANDIDATE_VERSION",
+    "DEFINITION",
+    "MIN_COMPLETE_PRIMARY_SESSIONS",
+    "PRIMARY_SYMBOL",
+    "ROBUSTNESS_SYMBOLS",
+    "CandidateRefusal",
+    "GrossFeasibilityOutcome",
+    "OpeningSignal",
+    "definition_hash",
+    "definition_json",
+    "opening_signal",
+    "resolve_gross_feasibility",
+]

--- a/docs/proposals/ta/2026-08-10-etf-intraday-momentum-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-etf-intraday-momentum-preregistration.md
@@ -1,0 +1,73 @@
+# ETF first-to-last-half-hour momentum preregistration
+
+Status: formula and source contract frozen before retained eToro outcomes are
+opened for #2502. Parent #2469.
+
+## Published hypothesis and adaptation boundary
+
+Gao, Han, Li and Zhou, *Market intraday momentum*, Journal of Financial
+Economics 129 (2018), 394–414, DOI
+[`10.1016/j.jfineco.2018.05.009`](https://doi.org/10.1016/j.jfineco.2018.05.009),
+define the first return as the prior 16:00 price to the 10:00 New York price.
+Its sign selects a long or short position at 15:30, closed at 16:00. Their
+primary SPY study uses TAQ trade/quote data through 2013. It is prior evidence,
+not a current eBull result.
+
+eBull has completed eToro OHLCV candles but no historical 15:30 bid/ask tape or
+reproducible shortability. Two arms therefore remain distinct:
+
+- `published_signed`: long when the opening return is positive, short otherwise;
+  replication diagnostic only;
+- `long_only`: long when positive and abstain otherwise; the only arm compatible
+  with the current execution direction, but it cannot inherit the paper's result.
+
+## Frozen causal formula
+
+For a full NYSE session `t`:
+
+```text
+r_open[t] = close(09:30-10:00, t) / close(15:30-16:00, prior session) - 1
+
+published side = long  if r_open[t] > 0
+                 short otherwise
+
+long-only fire = r_open[t] > 0
+```
+
+The signal is known only after the 09:30 candle completes at 10:00. A
+prospective entry uses the observed executable quote at/after 15:30 and must
+close against an observed executable quote by 16:00. The stored 15:30 candle
+open/close can produce a **gross feasibility proxy only**; it is never described
+as a fill or after-cost return.
+
+Early-close sessions, missing opening/closing intervals, gaps, forming bars,
+stale quotes and halts refuse the session. SPY is the primary instrument. QQQ
+and IWM are predeclared robustness instruments and cannot replace a failed SPY
+result. Other ETFs require a new trial identity and multiplicity budget.
+
+## Evidence gate
+
+The effect screen remains `sample_immature` until SPY has 60 complete independent
+full sessions. This is a minimum descriptive sample, not promotion. Allocation
+still requires the standing later prospective interval and at least six months
+and 30 independent fired observations.
+
+Report, without selecting a best ticker or regime:
+
+- session/refusal census and firing cadence;
+- gross candle-proxy expectancy as feasibility only;
+- prospectively observed bid/ask net expectancy and session-blocked interval;
+- hit rate, profit factor, worst interval, expected shortfall and drawdown;
+- always-long-last-half-hour and same-session random-sign comparators;
+- signal-strength calibration and results by month, volatility and volume;
+- doubled-cost, one-bar entry-delay, missed-entry and missed-close stress.
+
+Promotion requires a positive lower confidence bound after observed costs and
+all standing data, portfolio, broker and forward gates. There is no TP/SL fitted
+from these outcomes: the published thesis exits at the session close. Any stop,
+target, second-to-last-half-hour input, volatility filter or magnitude threshold
+is a separately preregistered trial on later data.
+
+The retained database footprint stays bounded to existing raw intraday bars,
+one fired/refused decision snapshot and one terminal outcome. No rolling return,
+regression or indicator series is persisted.

--- a/tests/test_etf_intraday_momentum_candidate.py
+++ b/tests/test_etf_intraday_momentum_candidate.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.etf_intraday_momentum_candidate import (
+    CANDIDATE_VERSION,
+    DEFINITION,
+    CandidateRefusal,
+    definition_json,
+    opening_signal,
+    resolve_gross_feasibility,
+)
+from app.services.strategy_observation_storage import IntradayBar
+
+
+def _bar(
+    stamp: str,
+    *,
+    open_: str = "100",
+    close: str = "101",
+    timeframe: str = "30m",
+    instrument_id: int = 1,
+    source: str = "etoro",
+) -> IntradayBar:
+    opening = Decimal(open_)
+    closing = Decimal(close)
+    return IntradayBar(
+        timeframe=timeframe,  # type: ignore[arg-type]
+        bar_time=datetime.fromisoformat(stamp).astimezone(UTC),
+        instrument_id=instrument_id,
+        open=opening,
+        high=max(opening, closing),
+        low=min(opening, closing),
+        close=closing,
+        volume=Decimal("1000000"),
+        source=source,
+    )
+
+
+def test_definition_is_stable_and_contains_no_measured_result() -> None:
+    payload = definition_json()
+    assert CANDIDATE_VERSION.startswith("etf-intraday-momentum-v1+")
+    assert DEFINITION.primary_symbol == "SPY"
+    assert DEFINITION.robustness_symbols == ("QQQ", "IWM")
+    assert "expectancy_pct" not in payload
+    assert "win_rate" not in payload
+
+
+def test_positive_opening_return_fires_long_and_resolves_only_gross_proxy() -> None:
+    signal = opening_signal(
+        symbol="spy",
+        prior_close_bar=_bar("2026-08-07T19:30:00+00:00", close="100"),
+        opening_bar=_bar("2026-08-10T13:30:00+00:00", close="102"),
+    )
+    assert signal.opening_return == Decimal("0.02")
+    assert signal.published_side == "long"
+    assert signal.adaptation_verdict == "fired_long"
+    assert signal.known_at.isoformat() == "2026-08-10T10:00:00-04:00"
+
+    outcome = resolve_gross_feasibility(
+        signal,
+        last_half_hour_bar=_bar("2026-08-10T19:30:00+00:00", open_="200", close="202"),
+    )
+    assert outcome.gross_return == Decimal("0.01")
+    assert "historical_entry_exit_quotes_unavailable" in outcome.promotion_refusals
+
+
+def test_nonpositive_opening_return_preserves_published_short_but_long_only_abstains() -> None:
+    signal = opening_signal(
+        symbol="SPY",
+        prior_close_bar=_bar("2026-08-07T19:30:00+00:00", close="100"),
+        opening_bar=_bar("2026-08-10T13:30:00+00:00", close="99"),
+    )
+    assert signal.published_side == "short"
+    assert signal.adaptation_verdict == "not_fired"
+    outcome = resolve_gross_feasibility(
+        signal,
+        last_half_hour_bar=_bar("2026-08-10T19:30:00+00:00", open_="100", close="90"),
+    )
+    assert outcome.gross_return == 0
+
+
+@pytest.mark.parametrize(
+    ("symbol", "bar", "message"),
+    [
+        ("AAPL", _bar("2026-08-10T13:30:00+00:00"), "outside the preregistered ETF set"),
+        ("SPY", _bar("2026-08-10T14:00:00+00:00"), "must start at 09:30:00"),
+        ("SPY", _bar("2026-08-10T13:30:00+00:00", timeframe="5m"), "requires a 30m bar"),
+        ("SPY", _bar("2026-11-27T14:30:00+00:00"), "excludes closed and half-day"),
+    ],
+)
+def test_wrong_universe_interval_or_session_refuses(symbol: str, bar: IntradayBar, message: str) -> None:
+    with pytest.raises(CandidateRefusal, match=message):
+        opening_signal(
+            symbol=symbol,
+            prior_close_bar=_bar("2026-08-07T19:30:00+00:00", close="100"),
+            opening_bar=bar,
+        )
+
+
+def test_last_bar_must_be_same_session_and_exact_interval() -> None:
+    signal = opening_signal(
+        symbol="SPY",
+        prior_close_bar=_bar("2026-08-07T19:30:00+00:00", close="100"),
+        opening_bar=_bar("2026-08-10T13:30:00+00:00"),
+    )
+    with pytest.raises(CandidateRefusal, match="must start at 15:30:00"):
+        resolve_gross_feasibility(
+            signal,
+            last_half_hour_bar=_bar("2026-08-10T19:00:00+00:00"),
+        )
+    with pytest.raises(CandidateRefusal, match="must share a session"):
+        resolve_gross_feasibility(
+            signal,
+            last_half_hour_bar=_bar("2026-08-11T19:30:00+00:00"),
+        )
+
+
+def test_source_instrument_and_immediate_prior_session_are_structural() -> None:
+    opening = _bar("2026-08-10T13:30:00+00:00")
+    with pytest.raises(CandidateRefusal, match="frozen etoro source"):
+        opening_signal(
+            symbol="SPY",
+            prior_close_bar=_bar("2026-08-07T19:30:00+00:00", source="other"),
+            opening_bar=opening,
+        )
+    with pytest.raises(CandidateRefusal, match="share an instrument"):
+        opening_signal(
+            symbol="SPY",
+            prior_close_bar=_bar("2026-08-07T19:30:00+00:00", instrument_id=2),
+            opening_bar=opening,
+        )
+    with pytest.raises(CandidateRefusal, match="immediately preceding trading session"):
+        opening_signal(
+            symbol="SPY",
+            prior_close_bar=_bar("2026-08-06T19:30:00+00:00"),
+            opening_bar=opening,
+        )


### PR DESCRIPTION
## Outcome

Freezes a causal, data-compatible first-to-last-half-hour ETF momentum candidate before opening retained eToro outcomes.

## Contract

- primary SPY; QQQ/IWM robustness only
- prior full-session close to completed 10:00 New York opening return
- published signed direction retained as research diagnostic
- current executable adaptation is long-only and abstains on negative opening returns
- exact completed 09:30/15:30 30m bars, eToro source, same instrument, immediate prior session and full-session calendar are structural
- candle outcome is labelled gross feasibility only; missing historical bid/ask and shortability remain promotion refusals
- no TP/SL is fitted: the published thesis has a session-close exit

## Validation

- 9 focused causal/refusal tests
- ruff, pyright and full pre-push gates green

Refs #2502. Refs #2469.