### PR TITLE
Evaluate retained ETF intraday momentum evidence

### DIFF
--- a/app/services/etf_intraday_momentum_candidate.py
+++ b/app/services/etf_intraday_momentum_candidate.py
@@ -49,7 +49,7 @@ class CandidateDefinition:
     paper_doi: str = "10.1016/j.jfineco.2018.05.009"
     primary_symbol: str = PRIMARY_SYMBOL
     robustness_symbols: tuple[str, ...] = ROBUSTNESS_SYMBOLS
-    source: str = "etoro"
+    source: str = "etoro/<universe_version>/nyse_rth"
     timeframe: str = "30m"
     session: str = "NYSE regular full session; half-days excluded"
     opening_return: str = "09:30 candle close / prior full-session 15:30 candle close - 1"
@@ -110,13 +110,19 @@ class GrossFeasibilityOutcome:
 def _require_bar(bar: IntradayBar, *, expected_start: time, label: str) -> None:
     if bar.timeframe != "30m":
         raise CandidateRefusal(f"{label} requires a 30m bar")
-    if bar.source != "etoro":
-        raise CandidateRefusal(f"{label} requires the frozen etoro source")
+    if not is_eligible_source(bar.source):
+        raise CandidateRefusal(f"{label} requires the frozen namespaced etoro RTH source")
     local = bar.bar_time.astimezone(_NY)
     if local.time().replace(tzinfo=None) != expected_start:
         raise CandidateRefusal(f"{label} must start at {expected_start.isoformat()} America/New_York")
     if us_market_status(local.date()) != "open":
         raise CandidateRefusal("candidate excludes closed and half-day sessions")
+
+
+def is_eligible_source(source: str) -> bool:
+    """Accept only the harvester's durable, universe-versioned RTH provenance."""
+    parts = source.split("/")
+    return len(parts) == 3 and parts[0] == "etoro" and bool(parts[1]) and parts[2] == "nyse_rth"
 
 
 def opening_signal(
@@ -193,6 +199,7 @@ __all__ = [
     "OpeningSignal",
     "definition_hash",
     "definition_json",
+    "is_eligible_source",
     "opening_signal",
     "resolve_gross_feasibility",
 ]

--- a/app/services/etf_intraday_momentum_evaluation.py
+++ b/app/services/etf_intraday_momentum_evaluation.py
@@ -1,0 +1,267 @@
+"""Read-only retained-data census for the frozen ETF intraday trial (#2502).
+
+This is deliberately not a backtest runner or a catalogue publisher.  It reads
+the bars already retained for the exact active-universe members, applies the
+pre-registered candidate unchanged, and reports gross candle-proxy evidence.
+No row is written and no result from here can make a strategy allocatable.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date, time, timedelta
+from decimal import Decimal
+from typing import Any, Final
+from zoneinfo import ZoneInfo
+
+import psycopg
+
+from app.services.block_bootstrap import BootstrapResult, block_bootstrap_expectancy, cluster_by_date
+from app.services.etf_intraday_momentum_candidate import (
+    CANDIDATE_VERSION,
+    MIN_COMPLETE_PRIMARY_SESSIONS,
+    PRIMARY_SYMBOL,
+    ROBUSTNESS_SYMBOLS,
+    CandidateRefusal,
+    is_eligible_source,
+    opening_signal,
+    resolve_gross_feasibility,
+)
+from app.services.market_calendar import us_market_status
+from app.services.strategy_observation_storage import IntradayBar
+
+_NY: Final = ZoneInfo("America/New_York")
+_SYMBOLS: Final = (PRIMARY_SYMBOL, *ROBUSTNESS_SYMBOLS)
+_BOOTSTRAP_SEED: Final = 2502
+
+
+@dataclass(frozen=True)
+class ReturnSummary:
+    observations: int
+    expectancy_pct: float | None
+    hit_rate_pct: float | None
+    profit_factor: float | None
+    worst_return_pct: float | None
+    expected_shortfall_5_pct: float | None
+    bootstrap: BootstrapResult | None
+
+
+@dataclass(frozen=True)
+class SymbolEvaluation:
+    symbol: str
+    first_session: date | None
+    last_session: date | None
+    candidate_sessions: int
+    complete_outcomes: int
+    fired_long: int
+    fired_cadence_pct: float | None
+    refusals: tuple[tuple[str, int], ...]
+    long_only: ReturnSummary
+    always_long: ReturnSummary
+    published_signed: ReturnSummary
+
+
+@dataclass(frozen=True)
+class CandidateEvaluation:
+    candidate_version: str
+    universe_version: str
+    symbols: tuple[SymbolEvaluation, ...]
+    promotion_refusals: tuple[str, ...]
+
+    @property
+    def primary(self) -> SymbolEvaluation:
+        return next(item for item in self.symbols if item.symbol == PRIMARY_SYMBOL)
+
+
+def _full_sessions(start: date, end: date) -> Iterable[date]:
+    current = start
+    while current <= end:
+        if us_market_status(current) == "open":
+            yield current
+        current += timedelta(days=1)
+
+
+def _summarise(returns: Sequence[float], dates: Sequence[date], *, seed: int) -> ReturnSummary:
+    if not returns:
+        return ReturnSummary(0, None, None, None, None, None, None)
+    positives = sum(value for value in returns if value > 0.0)
+    losses = abs(sum(value for value in returns if value < 0.0))
+    tail_size = max(1, math.ceil(len(returns) * 0.05))
+    bootstrap = block_bootstrap_expectancy(cluster_by_date(returns, dates), seed=seed)
+    return ReturnSummary(
+        observations=len(returns),
+        expectancy_pct=sum(returns) / len(returns),
+        hit_rate_pct=100.0 * sum(value > 0.0 for value in returns) / len(returns),
+        profit_factor=positives / losses if losses > 0.0 else None,
+        worst_return_pct=min(returns),
+        expected_shortfall_5_pct=sum(sorted(returns)[:tail_size]) / tail_size,
+        bootstrap=bootstrap,
+    )
+
+
+def evaluate_symbol(symbol: str, bars: Sequence[IntradayBar]) -> SymbolEvaluation:
+    """Evaluate one symbol without inspecting or mutating any external state."""
+    normalised = symbol.strip().upper()
+    if normalised not in _SYMBOLS:
+        raise ValueError(f"symbol {normalised!r} is outside the frozen candidate")
+    relevant = [bar for bar in bars if bar.timeframe == "30m" and is_eligible_source(bar.source)]
+    if not relevant:
+        empty = _summarise([], [], seed=0)
+        return SymbolEvaluation(normalised, None, None, 0, 0, 0, None, (), empty, empty, empty)
+
+    by_point: dict[tuple[date, time], IntradayBar] = {}
+    local_dates: list[date] = []
+    for bar in relevant:
+        local = bar.bar_time.astimezone(_NY)
+        key = (local.date(), local.time().replace(tzinfo=None))
+        if key in by_point:
+            raise ValueError(f"duplicate retained {normalised} 30m bar at {key}")
+        by_point[key] = bar
+        local_dates.append(local.date())
+
+    first, last = min(local_dates), max(local_dates)
+    sessions = tuple(_full_sessions(first, last))
+    refusals: Counter[str] = Counter()
+    fired_returns: list[float] = []
+    fired_dates: list[date] = []
+    always_returns: list[float] = []
+    complete_dates: list[date] = []
+    signed_returns: list[float] = []
+
+    for session in sessions:
+        opening = by_point.get((session, time(9, 30)))
+        final = by_point.get((session, time(15, 30)))
+        if opening is None:
+            refusals["missing_opening_bar"] += 1
+            continue
+        if final is None:
+            refusals["missing_last_half_hour_bar"] += 1
+            continue
+
+        prior_date = session - timedelta(days=1)
+        while prior_date >= first and us_market_status(prior_date) == "closed":
+            prior_date -= timedelta(days=1)
+        prior = by_point.get((prior_date, time(15, 30))) if prior_date >= first else None
+        if prior is None:
+            refusals["missing_prior_full_session_close"] += 1
+            continue
+
+        try:
+            signal = opening_signal(symbol=normalised, prior_close_bar=prior, opening_bar=opening)
+            outcome = resolve_gross_feasibility(signal, last_half_hour_bar=final)
+        except CandidateRefusal as exc:
+            refusals[f"candidate_refusal:{exc}"] += 1
+            continue
+
+        last_return = float((final.close / final.open - Decimal(1)) * Decimal(100))
+        always_returns.append(last_return)
+        complete_dates.append(session)
+        signed_returns.append(last_return if signal.published_side == "long" else -last_return)
+        if signal.adaptation_verdict == "fired_long":
+            fired_returns.append(float(outcome.gross_return * Decimal(100)))
+            fired_dates.append(session)
+
+    complete = len(complete_dates)
+    fired = len(fired_dates)
+    return SymbolEvaluation(
+        symbol=normalised,
+        first_session=first,
+        last_session=last,
+        candidate_sessions=len(sessions),
+        complete_outcomes=complete,
+        fired_long=fired,
+        fired_cadence_pct=100.0 * fired / complete if complete else None,
+        refusals=tuple(sorted(refusals.items())),
+        long_only=_summarise(fired_returns, fired_dates, seed=_BOOTSTRAP_SEED),
+        always_long=_summarise(always_returns, complete_dates, seed=_BOOTSTRAP_SEED + 1),
+        published_signed=_summarise(signed_returns, complete_dates, seed=_BOOTSTRAP_SEED + 2),
+    )
+
+
+def evaluate_candidate(
+    universe_version: str, bars_by_symbol: Mapping[str, Sequence[IntradayBar]]
+) -> CandidateEvaluation:
+    symbols = tuple(evaluate_symbol(symbol, bars_by_symbol.get(symbol, ())) for symbol in _SYMBOLS)
+    primary = symbols[0]
+    refusals = [
+        "historical_entry_exit_quotes_unavailable",
+        "published_short_leg_not_executable",
+        "prospective_outcome_interval_missing",
+    ]
+    if primary.complete_outcomes < MIN_COMPLETE_PRIMARY_SESSIONS:
+        refusals.insert(0, "sample_immature")
+    if primary.long_only.bootstrap is None:
+        refusals.append("effective_sample_size_not_computed")
+    return CandidateEvaluation(CANDIDATE_VERSION, universe_version, symbols, tuple(refusals))
+
+
+def load_retained_bars(conn: psycopg.Connection[Any]) -> tuple[str, dict[str, tuple[IntradayBar, ...]]]:
+    """Read exact resolved active-universe members; never fall back by symbol."""
+    versions = conn.execute(
+        """SELECT universe_version FROM strategy_intraday_universe_versions
+           WHERE status = 'active' ORDER BY universe_version"""
+    ).fetchall()
+    if len(versions) != 1:
+        raise RuntimeError(f"expected exactly one active intraday universe, found {len(versions)}")
+    version = str(versions[0][0])
+    rows = conn.execute(
+        """
+        WITH resolved AS (
+            SELECT member.symbol,
+                   array_agg(instrument.instrument_id ORDER BY instrument.instrument_id)
+                       FILTER (WHERE instrument.instrument_id IS NOT NULL) AS instrument_ids
+            FROM strategy_intraday_universe_members AS member
+            LEFT JOIN instruments AS instrument
+              ON instrument.symbol = member.symbol AND instrument.is_tradable = true
+            WHERE member.universe_version = %(version)s
+              AND member.timeframe = '30m'
+              AND member.symbol = ANY(%(symbols)s)
+            GROUP BY member.symbol
+        )
+        SELECT resolved.symbol, bar.bar_time, bar.instrument_id,
+               bar.open, bar.high, bar.low, bar.close, bar.volume, bar.source
+        FROM resolved
+        JOIN strategy_intraday_bars AS bar
+          ON bar.instrument_id = resolved.instrument_ids[1]
+         AND bar.timeframe = '30m'
+         AND bar.source LIKE 'etoro/%%/nyse_rth'
+        WHERE cardinality(resolved.instrument_ids) = 1
+        ORDER BY resolved.symbol, bar.bar_time
+        """,
+        {"version": version, "symbols": list(_SYMBOLS)},
+    ).fetchall()
+    grouped: defaultdict[str, list[IntradayBar]] = defaultdict(list)
+    for symbol, stamp, instrument_id, open_, high, low, close, volume, source in rows:
+        grouped[str(symbol)].append(
+            IntradayBar(
+                "30m",
+                stamp,
+                int(instrument_id),
+                Decimal(str(open_)),
+                Decimal(str(high)),
+                Decimal(str(low)),
+                Decimal(str(close)),
+                None if volume is None else Decimal(str(volume)),
+                str(source),
+            )
+        )
+    return version, {symbol: tuple(values) for symbol, values in grouped.items()}
+
+
+def evaluate_retained_candidate(conn: psycopg.Connection[Any]) -> CandidateEvaluation:
+    version, bars = load_retained_bars(conn)
+    return evaluate_candidate(version, bars)
+
+
+__all__ = [
+    "CandidateEvaluation",
+    "ReturnSummary",
+    "SymbolEvaluation",
+    "evaluate_candidate",
+    "evaluate_retained_candidate",
+    "evaluate_symbol",
+    "load_retained_bars",
+]

--- a/app/services/etf_intraday_momentum_evaluation.py
+++ b/app/services/etf_intraday_momentum_evaluation.py
@@ -152,8 +152,11 @@ def evaluate_symbol(symbol: str, bars: Sequence[IntradayBar]) -> SymbolEvaluatio
         try:
             signal = opening_signal(symbol=normalised, prior_close_bar=prior, opening_bar=opening)
             outcome = resolve_gross_feasibility(signal, last_half_hour_bar=final)
-        except CandidateRefusal as exc:
-            refusals[f"candidate_refusal:{exc}"] += 1
+        except CandidateRefusal:
+            # Required-point absence has stable codes above. Any remaining
+            # structural refusal is one operational class; exception prose is
+            # deliberately not a dimension because it may contain row detail.
+            refusals["candidate_structural_refusal"] += 1
             continue
 
         last_return = float((final.close / final.open - Decimal(1)) * Decimal(100))

--- a/docs/proposals/ta/2026-08-10-etf-intraday-momentum-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-etf-intraday-momentum-preregistration.md
@@ -3,6 +3,13 @@
 Status: formula and source contract frozen before retained eToro outcomes are
 opened for #2502. Parent #2469.
 
+Source-contract correction, still before an outcome was loaded: the harvester
+stores provenance as `etoro/<universe_version>/nyse_rth`, not the bare `etoro`
+label originally written in the candidate module. The first read-only census
+therefore returned zero eligible rows. The contract and candidate hash were
+corrected to require that namespaced RTH form before rerunning the census; the
+formula, instruments, dates, thresholds and outcome fields were unchanged.
+
 ## Published hypothesis and adaptation boundary
 
 Gao, Han, Li and Zhou, *Market intraday momentum*, Journal of Financial

--- a/docs/proposals/ta/2026-08-10-etf-intraday-momentum-retained-census.md
+++ b/docs/proposals/ta/2026-08-10-etf-intraday-momentum-retained-census.md
@@ -1,0 +1,68 @@
+# ETF intraday momentum retained-data census
+
+Status: rejected for allocation; read-only gross feasibility result for #2502.
+This is not a promoted backtest result and creates no database rows.
+
+## Evaluation identity
+
+- Candidate: `etf-intraday-momentum-v1+0b3804ab4111`
+- Active universe: `ETORO-RTH-V2`
+- Run date: 2026-08-10
+- Source accepted: retained `etoro/<universe_version>/nyse_rth` 30-minute bars only
+- Primary instrument: SPY; QQQ and IWM are predeclared robustness checks
+- Outcome: 15:30 candle close/open gross return proxy, not a fill or net return
+
+The first census attempt selected no rows because the frozen source label said
+bare `etoro`, while the harvester durably stores the universe-versioned source
+above. No outcome was loaded. The source contract and candidate hash were
+corrected before this run; formula, instruments, dates and thresholds did not
+change. The database driver also returns OHLC columns as floats, so the
+read-only loader now normalises them to `Decimal` at its boundary.
+
+## Result
+
+| Instrument | Complete sessions | Long fires | Cadence | Gross expectancy | Hit rate | Profit factor | 95% block-bootstrap CI | Worst | ES 5% |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| SPY | 20 | 12 | 60.0% | -0.0388% | 33.3% | 0.295 | [-0.0825%, 0.0035%] | -0.1775% | -0.1775% |
+| QQQ | 20 | 11 | 55.0% | -0.0765% | 36.4% | 0.338 | [-0.1500%, -0.0097%] | -0.3884% | -0.3884% |
+| IWM | 69 | 41 | 59.4% | 0.0201% | 56.1% | 1.241 | [-0.0482%, 0.0914%] | -0.7199% | -0.4648% |
+
+SPY's always-long last-half-hour comparator was -0.0414% gross expectancy
+across 20 observations. The published signed SPY diagnostic was -0.0051% with
+a 35.0% hit rate and confidence interval [-0.0825%, 0.1089%]. QQQ's long-only
+confidence interval is wholly negative. IWM's small positive point estimate is
+not distinguishable from zero and its always-long comparator was itself
+positive at 0.0137%; robustness instruments cannot rescue a failed primary.
+
+## Data census
+
+- SPY and QQQ cover 2026-07-10 through 2026-08-10. Each has 22 candidate
+  sessions, one missing prior full-session close, and one missing final candle
+  (the in-progress run date).
+- IWM covers 2026-04-17 through 2026-08-10. Of 79 candidate sessions, 69 have
+  complete required observations; five lack the final candle, two lack the
+  opening candle, and three lack the prior full-session close.
+- No missing interval becomes a zero return. It is counted as a refusal.
+- No non-fired long-only session becomes a trade. Published short outcomes are
+  reported only in the separate diagnostic.
+
+## Decision and remaining gates
+
+Do not add this candidate to the strategy manifest, make it selectable, or let
+it receive demo capital. SPY is below the 60-complete-session descriptive floor
+and the 30-fired-observation/six-month prospective minimum. More importantly,
+the presently observed primary gross result is negative before spread,
+slippage, financing or missed fills. The standing refusals remain:
+
+- `sample_immature`
+- `historical_entry_exit_quotes_unavailable`
+- `published_short_leg_not_executable`
+- `prospective_outcome_interval_missing`
+
+The pre-registration also asks for drawdown, random-sign inference, strength
+calibration, month/volatility/volume views and execution stresses. Those must
+not be improvised after this outcome was seen. Any filters, thresholds, stop,
+target or alternate holding interval now require a new trial identity, a
+frozen analysis plan and later untouched data. Retained prospectively observed
+quotes are still required before any gross-positive future candidate can make
+an after-cost claim.

--- a/tests/test_etf_intraday_momentum_candidate.py
+++ b/tests/test_etf_intraday_momentum_candidate.py
@@ -23,7 +23,7 @@ def _bar(
     close: str = "101",
     timeframe: str = "30m",
     instrument_id: int = 1,
-    source: str = "etoro",
+    source: str = "etoro/ETORO-RTH-V1/nyse_rth",
 ) -> IntradayBar:
     opening = Decimal(open_)
     closing = Decimal(close)
@@ -121,7 +121,7 @@ def test_last_bar_must_be_same_session_and_exact_interval() -> None:
 
 def test_source_instrument_and_immediate_prior_session_are_structural() -> None:
     opening = _bar("2026-08-10T13:30:00+00:00")
-    with pytest.raises(CandidateRefusal, match="frozen etoro source"):
+    with pytest.raises(CandidateRefusal, match="frozen namespaced etoro RTH source"):
         opening_signal(
             symbol="SPY",
             prior_close_bar=_bar("2026-08-07T19:30:00+00:00", source="other"),

--- a/tests/test_etf_intraday_momentum_evaluation.py
+++ b/tests/test_etf_intraday_momentum_evaluation.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.services.etf_intraday_momentum_evaluation import (
+    evaluate_candidate,
+    evaluate_symbol,
+    load_retained_bars,
+)
+from app.services.strategy_observation_storage import IntradayBar
+
+_NY = ZoneInfo("America/New_York")
+
+
+def _bar(
+    day: date,
+    hour: int,
+    minute: int,
+    *,
+    open_: str,
+    close: str,
+    instrument_id: int = 11,
+    source: str = "etoro/ETORO-RTH-V1/nyse_rth",
+) -> IntradayBar:
+    opening = Decimal(open_)
+    closing = Decimal(close)
+    return IntradayBar(
+        timeframe="30m",
+        bar_time=datetime(day.year, day.month, day.day, hour, minute, tzinfo=_NY).astimezone(UTC),
+        instrument_id=instrument_id,
+        open=opening,
+        high=max(opening, closing),
+        low=min(opening, closing),
+        close=closing,
+        volume=Decimal("1000"),
+        source=source,
+    )
+
+
+def _two_outcome_sessions() -> list[IntradayBar]:
+    monday = date(2026, 7, 13)
+    tuesday = date(2026, 7, 14)
+    wednesday = date(2026, 7, 15)
+    return [
+        _bar(monday, 15, 30, open_="99", close="100"),
+        _bar(tuesday, 9, 30, open_="100", close="102"),
+        _bar(tuesday, 15, 30, open_="100", close="101"),
+        _bar(wednesday, 9, 30, open_="101", close="100"),
+        _bar(wednesday, 15, 30, open_="100", close="98"),
+    ]
+
+
+def test_separates_fired_long_from_always_long_and_published_signed() -> None:
+    result = evaluate_symbol("SPY", _two_outcome_sessions())
+
+    assert result.complete_outcomes == 2
+    assert result.fired_long == 1
+    assert result.fired_cadence_pct == 50.0
+    assert result.long_only.observations == 1
+    assert result.long_only.expectancy_pct == pytest.approx(1.0)
+    assert result.long_only.hit_rate_pct == 100.0
+    assert result.always_long.observations == 2
+    assert result.always_long.expectancy_pct == pytest.approx(-0.5)
+    assert result.published_signed.expectancy_pct == pytest.approx(1.5)
+    assert result.published_signed.hit_rate_pct == 100.0
+
+
+def test_missing_required_interval_is_a_refusal_not_a_zero_return() -> None:
+    bars = _two_outcome_sessions()
+    bars = [
+        bar
+        for bar in bars
+        if bar.bar_time.astimezone(_NY).date() != date(2026, 7, 15) or bar.bar_time.astimezone(_NY).hour != 15
+    ]
+
+    result = evaluate_symbol("SPY", bars)
+
+    assert result.complete_outcomes == 1
+    assert dict(result.refusals)["missing_last_half_hour_bar"] == 1
+    assert result.long_only.observations == 1
+
+
+def test_non_frozen_source_is_not_silently_used() -> None:
+    bars = _two_outcome_sessions()
+    tuesday = date(2026, 7, 14)
+    bars.append(_bar(tuesday, 9, 30, open_="100", close="150", source="other"))
+
+    result = evaluate_symbol("SPY", bars)
+
+    assert result.complete_outcomes == 2
+    assert result.long_only.expectancy_pct == pytest.approx(1.0)
+
+
+def test_later_unregistered_bar_cannot_change_the_outcome() -> None:
+    bars = _two_outcome_sessions()
+    baseline = evaluate_symbol("SPY", bars)
+    bars.append(_bar(date(2026, 7, 14), 14, 0, open_="1", close="10000"))
+
+    observed = evaluate_symbol("SPY", bars)
+
+    assert observed.long_only == baseline.long_only
+    assert observed.always_long == baseline.always_long
+    assert observed.published_signed == baseline.published_signed
+
+
+def test_candidate_remains_immature_and_unpromotable() -> None:
+    result = evaluate_candidate("universe-v1", {"SPY": _two_outcome_sessions()})
+
+    assert "sample_immature" in result.promotion_refusals
+    assert "historical_entry_exit_quotes_unavailable" in result.promotion_refusals
+    assert "published_short_leg_not_executable" in result.promotion_refusals
+    assert "prospective_outcome_interval_missing" in result.promotion_refusals
+    assert result.symbols[1].complete_outcomes == 0
+
+
+class _Rows:
+    def __init__(self, rows: list[tuple[object, ...]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return self._rows
+
+
+class _Connection:
+    def __init__(self, bar_row: tuple[object, ...]) -> None:
+        self.bar_row = bar_row
+        self.calls: list[tuple[str, object]] = []
+
+    def execute(self, query: str, params: object = None) -> _Rows:
+        self.calls.append((query, params))
+        if "FROM strategy_intraday_universe_versions" in query:
+            return _Rows([("active-v1",)])
+        return _Rows([self.bar_row])
+
+
+def test_loader_uses_exact_resolved_active_universe_member() -> None:
+    bar = _bar(date(2026, 7, 13), 15, 30, open_="99", close="100")
+    # PostgreSQL's retained OHLC columns decode as floats in production. The
+    # candidate's Decimal arithmetic must not depend on Decimal-only fixtures.
+    row = ("SPY", bar.bar_time, 11, 99.0, 100.0, 99.0, 100.0, 1000.0, bar.source)
+    conn = _Connection(row)
+
+    version, grouped = load_retained_bars(conn)  # type: ignore[arg-type]
+
+    assert version == "active-v1"
+    assert grouped["SPY"] == (bar,)
+    sql, params = conn.calls[1]
+    assert "cardinality(resolved.instrument_ids) = 1" in sql
+    assert "bar.source LIKE 'etoro/%%/nyse_rth'" in sql
+    assert params == {"version": "active-v1", "symbols": ["SPY", "QQQ", "IWM"]}


### PR DESCRIPTION
Closes #2502

## Outcome

Adds a read-only retained-data census for the frozen ETF first/last-half-hour candidate. It does not write evidence rows, publish a manifest entry, or enable allocation.

The primary SPY long-only adaptation is rejected on current retained evidence: 12 fires, 33.3% hit rate, -0.0388% gross expectancy, PF 0.295, block-bootstrap 95% CI [-0.0825%, 0.0035%]. QQQ is negative; IWM is mildly positive but its CI crosses zero and cannot rescue the primary.

## Changes

- resolves exact active-universe instruments and namespaced retained eToro RTH provenance
- normalises production float OHLC values to Decimal at the loader boundary
- separates complete outcomes, fired long trades, always-long comparator, and published signed diagnostic
- reports cadence, expectancy, hit rate, PF, worst interval, ES5, session-blocked CI/ESS, and explicit refusals
- records the immutable census and keeps every promotion gate closed

## Validation

- focused tests: 15 passed
- full pre-push gate: green (ruff, format, pyright, invariant lints, fast tests, smoke tests, frontend integrity checks)
- dev DB warning remains non-blocking at 63 GB; this evaluator adds zero DB rows