### PR TITLE
Capture bounded prospective eToro quote evidence

### DIFF
--- a/app/services/strategy_quote_observation.py
+++ b/app/services/strategy_quote_observation.py
@@ -250,8 +250,14 @@ def capture_active_universe_quotes(
     rows_written = 0
     if observations:
         with conn.transaction(), conn.cursor() as cur:
-            cur.executemany(_UPSERT_OBSERVATION, [asdict(observation) for observation in observations])
-            rows_written = cur.rowcount
+            # The panel is capped at 50. Sum each statement's affected count
+            # explicitly rather than depending on driver-specific executemany
+            # rowcount aggregation; ON CONFLICT no-ops must report zero.
+            for observation in observations:
+                cur.execute(_UPSERT_OBSERVATION, asdict(observation))
+                if cur.rowcount < 0:
+                    raise RuntimeError("strategy quote INSERT did not report an affected-row count")
+                rows_written += cur.rowcount
     status_counts = Counter(observation.observation_status for observation in observations)
     return QuoteCaptureReport(
         universe_version=version,

--- a/app/services/strategy_quote_observation.py
+++ b/app/services/strategy_quote_observation.py
@@ -1,0 +1,300 @@
+"""Bounded prospective best-bid/ask evidence for strategy research.
+
+The application-wide ``quotes`` table is a mutable latest snapshot.  This
+module samples only the exact active intraday research panel, once per symbol
+per five-minute bucket, so later strategy evaluation can use the spread that
+was actually observed rather than today's quote or a static estimate.
+
+Missing and invalid provider responses are durable coverage observations.  Raw
+ticks, depth and derived indicator histories are deliberately not retained.
+"""
+
+from __future__ import annotations
+
+import calendar
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any, Final, Literal
+
+import psycopg
+
+from app.providers.market_data import MarketDataProvider, Quote
+
+SAMPLE_MINUTES: Final = 5
+RETENTION_MONTHS: Final = 24
+MAX_PANEL_INSTRUMENTS: Final = 50
+
+ObservationStatus = Literal["observed", "missing", "invalid"]
+
+
+@dataclass(frozen=True)
+class QuoteMember:
+    symbol: str
+    instrument_id: int | None
+    resolution_error: str | None = None
+
+
+@dataclass(frozen=True)
+class QuoteObservation:
+    universe_version: str
+    instrument_id: int
+    sample_bucket: datetime
+    observed_at: datetime
+    quote_at: datetime | None
+    bid: Decimal | None
+    ask: Decimal | None
+    last: Decimal | None
+    spread_bps: Decimal | None
+    observation_status: ObservationStatus
+    refusal_reason: str | None
+    source: str
+
+
+@dataclass(frozen=True)
+class QuoteCaptureFailure:
+    symbol: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class QuoteCaptureReport:
+    universe_version: str
+    expected: int
+    observed: int
+    missing: int
+    invalid: int
+    rows_written: int
+    failures: tuple[QuoteCaptureFailure, ...]
+
+
+def sample_bucket(observed_at: datetime) -> datetime:
+    if observed_at.tzinfo is None:
+        raise ValueError("observed_at must be timezone-aware")
+    stamp = observed_at.astimezone(UTC)
+    return stamp.replace(minute=stamp.minute - stamp.minute % SAMPLE_MINUTES, second=0, microsecond=0)
+
+
+def _active_quote_members(conn: psycopg.Connection[Any]) -> tuple[str, tuple[QuoteMember, ...]]:
+    versions = conn.execute(
+        """
+        SELECT universe_version
+        FROM strategy_intraday_universe_versions
+        WHERE status = 'active'
+        ORDER BY universe_version
+        """
+    ).fetchall()
+    if len(versions) != 1:
+        raise RuntimeError(f"expected exactly one active intraday universe, found {len(versions)}")
+    version = str(versions[0][0])
+    rows = conn.execute(
+        """
+        SELECT member.symbol,
+               array_agg(DISTINCT instrument.instrument_id ORDER BY instrument.instrument_id)
+                   FILTER (WHERE instrument.instrument_id IS NOT NULL) AS instrument_ids
+        FROM strategy_intraday_universe_members AS member
+        LEFT JOIN instruments AS instrument
+          ON instrument.symbol = member.symbol
+         AND instrument.is_tradable = true
+        WHERE member.universe_version = %(version)s
+        GROUP BY member.symbol
+        ORDER BY member.symbol
+        """,
+        {"version": version},
+    ).fetchall()
+    if not rows:
+        raise RuntimeError(f"active intraday universe {version!r} has no members")
+    if len(rows) > MAX_PANEL_INSTRUMENTS:
+        raise RuntimeError(
+            f"active intraday universe {version!r} has {len(rows)} unique symbols; quote cap is {MAX_PANEL_INSTRUMENTS}"
+        )
+    members: list[QuoteMember] = []
+    for symbol, instrument_ids in rows:
+        ids = [int(value) for value in instrument_ids or []]
+        members.append(
+            QuoteMember(
+                symbol=str(symbol),
+                instrument_id=ids[0] if len(ids) == 1 else None,
+                resolution_error=None if len(ids) == 1 else f"expected one tradable instrument, found {len(ids)}",
+            )
+        )
+    return version, tuple(members)
+
+
+def _normalise_quote(
+    *,
+    universe_version: str,
+    instrument_id: int,
+    quote: Quote | None,
+    observed_at: datetime,
+) -> QuoteObservation:
+    bucket = sample_bucket(observed_at)
+    source = f"etoro/{universe_version}/best_bid_ask"
+    if quote is None:
+        return QuoteObservation(
+            universe_version,
+            instrument_id,
+            bucket,
+            observed_at.astimezone(UTC),
+            None,
+            None,
+            None,
+            None,
+            None,
+            "missing",
+            "provider_omitted_quote",
+            source,
+        )
+
+    refusal: str | None = None
+    if quote.timestamp.tzinfo is None:
+        refusal = "quote_timestamp_naive"
+    elif quote.bid <= 0 or quote.ask <= 0:
+        refusal = "nonpositive_bid_or_ask"
+    elif quote.ask < quote.bid:
+        refusal = "crossed_market"
+    elif quote.last is not None and quote.last <= 0:
+        refusal = "nonpositive_last"
+    if refusal is not None:
+        return QuoteObservation(
+            universe_version,
+            instrument_id,
+            bucket,
+            observed_at.astimezone(UTC),
+            None,
+            None,
+            None,
+            None,
+            None,
+            "invalid",
+            refusal,
+            source,
+        )
+
+    bid = Decimal(quote.bid)
+    ask = Decimal(quote.ask)
+    midpoint = (bid + ask) / Decimal(2)
+    return QuoteObservation(
+        universe_version,
+        instrument_id,
+        bucket,
+        observed_at.astimezone(UTC),
+        quote.timestamp.astimezone(UTC),
+        bid,
+        ask,
+        None if quote.last is None else Decimal(quote.last),
+        (ask - bid) / midpoint * Decimal(10_000),
+        "observed",
+        None,
+        source,
+    )
+
+
+_UPSERT_OBSERVATION = """
+    INSERT INTO strategy_quote_observations (
+        universe_version, instrument_id, sample_bucket, observed_at,
+        quote_at, bid, ask, last, spread_bps,
+        observation_status, refusal_reason, source
+    ) VALUES (
+        %(universe_version)s, %(instrument_id)s, %(sample_bucket)s, %(observed_at)s,
+        %(quote_at)s, %(bid)s, %(ask)s, %(last)s, %(spread_bps)s,
+        %(observation_status)s, %(refusal_reason)s, %(source)s
+    )
+    ON CONFLICT (universe_version, instrument_id, sample_bucket) DO NOTHING
+"""
+
+
+def capture_active_universe_quotes(
+    conn: psycopg.Connection[Any],
+    provider: MarketDataProvider,
+    *,
+    observed_at: datetime | None = None,
+) -> QuoteCaptureReport:
+    """Fetch one quote batch and persist one bounded observation per resolved symbol.
+
+    ``observed_at`` is a deterministic test hook. Production callers omit it:
+    capture time is taken *after* the provider response, so a request lasting
+    several seconds cannot make a newly returned quote appear to come from the
+    future.
+    """
+    if observed_at is not None and observed_at.tzinfo is None:
+        raise ValueError("observed_at must be timezone-aware")
+    version, members = _active_quote_members(conn)
+    resolved = [member for member in members if member.instrument_id is not None]
+    failures = tuple(
+        QuoteCaptureFailure(member.symbol, f"universe_resolution: {member.resolution_error}")
+        for member in members
+        if member.instrument_id is None
+    )
+    expected_ids = [int(member.instrument_id) for member in resolved if member.instrument_id is not None]
+    quotes = provider.get_quotes(expected_ids)
+    counts = Counter(quote.instrument_id for quote in quotes)
+    duplicates = sorted(instrument_id for instrument_id, count in counts.items() if count > 1)
+    extras = sorted(set(counts) - set(expected_ids))
+    if duplicates:
+        raise RuntimeError(f"provider returned duplicate quotes for {duplicates}")
+    if extras:
+        raise RuntimeError(f"provider returned out-of-scope quotes for {extras}")
+    captured_at = datetime.now(tz=UTC) if observed_at is None else observed_at
+    quote_by_id = {quote.instrument_id: quote for quote in quotes}
+    observations = [
+        _normalise_quote(
+            universe_version=version,
+            instrument_id=instrument_id,
+            quote=quote_by_id.get(instrument_id),
+            observed_at=captured_at,
+        )
+        for instrument_id in expected_ids
+    ]
+    rows_written = 0
+    if observations:
+        with conn.transaction(), conn.cursor() as cur:
+            cur.executemany(_UPSERT_OBSERVATION, [asdict(observation) for observation in observations])
+            rows_written = cur.rowcount
+    status_counts = Counter(observation.observation_status for observation in observations)
+    return QuoteCaptureReport(
+        universe_version=version,
+        expected=len(members),
+        observed=status_counts["observed"],
+        missing=status_counts["missing"],
+        invalid=status_counts["invalid"],
+        rows_written=rows_written,
+        failures=failures,
+    )
+
+
+def _months_before(value: datetime, months: int) -> datetime:
+    absolute = value.year * 12 + value.month - 1 - months
+    year, month_index = divmod(absolute, 12)
+    month = month_index + 1
+    day = min(value.day, calendar.monthrange(year, month)[1])
+    return value.replace(year=year, month=month, day=day)
+
+
+def retire_quote_observations(conn: psycopg.Connection[Any], *, as_of: datetime, dry_run: bool = True) -> int:
+    """Count or delete samples older than the fixed 24-calendar-month horizon."""
+    if as_of.tzinfo is None:
+        raise ValueError("as_of must be timezone-aware")
+    cutoff = _months_before(as_of.astimezone(UTC), RETENTION_MONTHS)
+    if dry_run:
+        row = conn.execute(
+            "SELECT count(*) FROM strategy_quote_observations WHERE sample_bucket < %s", (cutoff,)
+        ).fetchone()
+        return int(row[0]) if row else 0
+    with conn.transaction():
+        deleted = conn.execute("DELETE FROM strategy_quote_observations WHERE sample_bucket < %s", (cutoff,)).rowcount
+    return deleted
+
+
+__all__ = [
+    "MAX_PANEL_INSTRUMENTS",
+    "RETENTION_MONTHS",
+    "SAMPLE_MINUTES",
+    "QuoteCaptureFailure",
+    "QuoteCaptureReport",
+    "QuoteObservation",
+    "capture_active_universe_quotes",
+    "retire_quote_observations",
+    "sample_bucket",
+]

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -2096,9 +2096,10 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "Every five minutes during the US regular-session collection window -- fetches at "
             "most twelve predeclared eToro research windows, "
             "retains completed NYSE-RTH bars only, removes watermark overlap and records gaps "
-            "without imputation. The active versioned panel is deliberately small; storage "
-            "remains partitioned and retention-capped. Operator Run now uses the same collector "
-            "and can repair gaps outside the automatic request window."
+            "without imputation. One batch also records best bid/ask or an explicit missing/invalid "
+            "coverage row for each unique panel instrument, at most once per five-minute bucket. "
+            "The active versioned panel is deliberately small; storage remains retention-capped. "
+            "Operator Run uses the same collector and can repair bars outside the automatic window."
         ),
         cadence=Cadence.every_n_minutes(interval=5),
         catch_up_on_boot=False,
@@ -2112,7 +2113,8 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
             "Daily 07:05 UTC — after the 06:45 scan and 06:55 outcome pass, drops whole expired "
             "range partitions: negative signal detail after 90 days, 30m bars "
             "after 24 months, 5m bars after 12 months and 1m bars after 30 days. "
-            "Fired signals and daily counts are durable. Never issues a mass DELETE."
+            "Prospective five-minute quote samples expire after 24 months. Fired signals and "
+            "daily counts are durable; quote outcomes retain their compact cost attribution."
         ),
         cadence=Cadence.daily(hour=7, minute=5),
         catch_up_on_boot=False,
@@ -5084,22 +5086,27 @@ def strategy_observation_retention() -> None:
     from datetime import UTC, datetime
 
     from app.services.strategy_observation_storage import drop_expired_partitions
+    from app.services.strategy_quote_observation import retire_quote_observations
 
     with _tracked_job(JOB_STRATEGY_OBSERVATION_RETENTION) as tracker:
         with connect_job() as conn:
-            plan = drop_expired_partitions(conn, as_of=datetime.now(tz=UTC), dry_run=False)
-            tracker.row_count = len(plan.partitions) + plan.intraday_gap_rows
+            as_of = datetime.now(tz=UTC)
+            plan = drop_expired_partitions(conn, as_of=as_of, dry_run=False)
+            quote_rows = retire_quote_observations(conn, as_of=as_of, dry_run=False)
+            tracker.row_count = len(plan.partitions) + plan.intraday_gap_rows + quote_rows
         logger.info(
-            "strategy_observation_retention: dropped %d signal + %d intraday partitions + %d gap rows",
+            "strategy_observation_retention: dropped %d signal + %d intraday partitions + %d gap rows + %d quote rows",
             len(plan.signal_partitions),
             len(plan.intraday_partitions),
             plan.intraday_gap_rows,
+            quote_rows,
         )
 
 
 def strategy_intraday_harvest() -> None:
-    """Collect one bounded slice of completed eToro intraday evidence."""
+    """Collect bounded completed bars and prospective eToro quote evidence."""
     from app.services.strategy_intraday_harvest import run_intraday_harvest
+    from app.services.strategy_quote_observation import capture_active_universe_quotes
 
     creds = _load_etoro_credentials(JOB_STRATEGY_INTRADAY_HARVEST)
     if creds is None:
@@ -5113,16 +5120,27 @@ def strategy_intraday_harvest() -> None:
             # member must not roll back bars already collected for its peers.
             connect_job(autocommit=True) as conn,
         ):
-            report = run_intraday_harvest(conn, provider, observed_at=datetime.now(tz=UTC))
-        tracker.row_count = report.written
+            observed_at = datetime.now(tz=UTC)
+            report = run_intraday_harvest(conn, provider, observed_at=observed_at)
+            quote_report = capture_active_universe_quotes(conn, provider)
+        tracker.row_count = report.written + quote_report.rows_written
         tracker.note = (
             f"universe={report.universe_version} selected={report.selected} fetched={report.fetched} "
             f"completed_rth={report.completed_rth} written={report.written} "
-            f"gaps={report.gaps_recorded} failures={len(report.failures)}"
+            f"gaps={report.gaps_recorded} quote_expected={quote_report.expected} "
+            f"quote_observed={quote_report.observed} quote_missing={quote_report.missing} "
+            f"quote_invalid={quote_report.invalid} quote_written={quote_report.rows_written} "
+            f"failures={len(report.failures) + len(quote_report.failures)}"
         )
-        if report.failures:
-            detail = "; ".join(f"{failure.timeframe}/{failure.symbol}: {failure.reason}" for failure in report.failures)
-            raise RuntimeError(f"strategy_intraday_harvest: {len(report.failures)} member(s) failed: {detail}")
+        if report.failures or quote_report.failures:
+            detail = "; ".join(
+                [f"{failure.timeframe}/{failure.symbol}: {failure.reason}" for failure in report.failures]
+                + [f"quote/{failure.symbol}: {failure.reason}" for failure in quote_report.failures]
+            )
+            raise RuntimeError(
+                "strategy_intraday_harvest: "
+                f"{len(report.failures) + len(quote_report.failures)} member(s) failed: {detail}"
+            )
 
 
 def _refresh_strategy_halt_feed() -> HaltSnapshot:

--- a/docs/proposals/ta/2026-08-10-prospective-quote-capture.md
+++ b/docs/proposals/ta/2026-08-10-prospective-quote-capture.md
@@ -1,0 +1,103 @@
+# Bounded prospective eToro quote capture
+
+Status: implemented evidence prerequisite for #2484 and #2485; no strategy is
+promoted or allocation-enabled by this collector.
+
+## Why this exists
+
+`quotes` owns one mutable latest snapshot per instrument. It is suitable for a
+freshness-gated current decision but cannot prove the bid, ask or spread that
+was observable at an earlier signal, entry or exit. Retained OHLCV candles are
+not a replacement for executable quotes.
+
+The existing five-minute intraday evidence job now makes one additional batch
+quote request for the unique symbols in the exact active research universe.
+It records the first observation within each five-minute bucket. The row is
+immutable, so a later run cannot replace a 15:30 observation with information
+from 15:34. The
+automatic job runs only from the first completed regular-session bar through
+the existing ten-minute close-lag allowance; an operator-triggered run uses the
+same collector and may record an out-of-session sample, which downstream trial
+session rules must refuse when irrelevant.
+
+## Storage and coverage contract
+
+`strategy_quote_observations` contains:
+
+- active universe version, exact instrument and five-minute sample bucket;
+- application observation time and provider quote time separately;
+- best bid, ask, optional last and directly calculated spread basis points;
+- `observed`, `missing` or `invalid` status and a stable refusal code;
+- universe-versioned eToro source provenance.
+
+A provider omission is a `missing` row, never a zero spread. Non-positive,
+crossed or timezone-naive quotes are `invalid` rows with price fields removed.
+Duplicate or out-of-scope provider IDs refuse the whole batch. Symbol
+resolution must produce exactly one currently tradable instrument; healthy
+peers remain collectable and the job fails visibly for the unresolved member.
+
+The table does not assert that a quote was fresh enough for a candidate. Quote
+age, allowed entry delay, session, halt state and side-aware fill rules belong
+to the preregistered trial. Retaining `quote_at` and `observed_at` lets those
+rules be applied without rewriting history.
+
+## Bound and retention
+
+The current panel has eight unique instruments. At one sample per five-minute
+regular-session bucket and 504 sessions over 24 months, its conservative bound
+is:
+
+```text
+8 instruments * 78 buckets * 504 sessions = 314,496 rows
+```
+
+Repeated/manual runs within one bucket are no-ops rather than appends or
+updates.
+The daily strategy-observation retention job deletes samples older than 24
+calendar months using the indexed bucket column. Completed outcome rows retain
+compact cost attribution separately; raw quote samples are not durable
+forever. There is no all-instrument subscription, tick tape, order book, depth
+history or derived-spread series.
+
+## What this unlocks—and what it does not
+
+Once sufficient prospective coverage accrues, candidate evaluation can use a
+long entry at observed ask and exit at observed bid (the reverse for shorts),
+measure spread by instrument/time/regime, count collection gaps, and apply
+candidate-specific freshness and delayed-entry stress.
+
+It does not provide queue position, fill probability, stop-market gap
+slippage, shortability, borrow fees or CFD financing. Those remain independent
+fail-closed gates. Historical periods before this collector started still have
+no observed eToro quote evidence and must not be backfilled from current rows.
+
+## First live evidence
+
+The first production integration pass exposed two defects before any strategy
+consumed a row:
+
+1. capture time had been taken before the network request, making fresh provider
+   timestamps appear about 13 seconds in the future;
+2. a later run in the same bucket could replace the earlier observation, which
+   would let a 15:34 quote overwrite evidence intended for 15:30.
+
+Capture time is now taken after the response and PostgreSQL rejects all row
+updates. The eight pre-contract development rows were deleted by exact universe
+and bucket after verifying the count, then recollected under the final contract.
+They had no signal or outcome consumer.
+
+The 16:05 UTC automatic run then completed through the real provider, scheduler
+and database path:
+
+```text
+expected=8 observed=8 missing=0 invalid=0 rows_written=8
+two immutable buckets / 16 rows total
+table + indexes = 64 KiB
+```
+
+The observation also proves why `observed` must not mean `fresh`. AAPL, F, IWM
+and KO provider times were within one second of capture. SPY, QQQ and JPM were
+about 13.7 minutes old, while low-volume CENN was about 94 minutes old. The
+collector preserves all of them and their timestamps; a candidate-specific
+freshness gate must refuse the latter observations rather than charging their
+displayed spreads as executable costs.

--- a/sql/306_strategy_quote_observations.sql
+++ b/sql/306_strategy_quote_observations.sql
@@ -1,0 +1,62 @@
+-- #2485 / #2484 -- bounded prospective eToro best-bid/ask evidence.
+--
+-- `quotes` is intentionally one mutable current row per instrument.  It cannot
+-- establish the cost that was observable at a historical decision or fill.
+-- This table samples only the predeclared active intraday research panel, at
+-- most once per instrument per five-minute bucket, and expires after 24
+-- months.  Missing/invalid responses are rows too: absence is not a zero
+-- spread and collection coverage must remain measurable.
+
+CREATE TABLE IF NOT EXISTS strategy_quote_observations (
+    universe_version   TEXT NOT NULL
+        REFERENCES strategy_intraday_universe_versions(universe_version) ON DELETE RESTRICT,
+    instrument_id      BIGINT NOT NULL
+        REFERENCES instruments(instrument_id) ON DELETE CASCADE,
+    sample_bucket      TIMESTAMPTZ NOT NULL,
+    observed_at        TIMESTAMPTZ NOT NULL,
+    quote_at           TIMESTAMPTZ,
+    bid                NUMERIC(18,6),
+    ask                NUMERIC(18,6),
+    last               NUMERIC(18,6),
+    spread_bps         NUMERIC(18,8),
+    observation_status TEXT NOT NULL
+        CHECK (observation_status IN ('observed', 'missing', 'invalid')),
+    refusal_reason     TEXT CHECK (refusal_reason IS NULL OR (
+        btrim(refusal_reason) <> '' AND length(refusal_reason) <= 100
+    )),
+    source             TEXT NOT NULL CHECK (source ~ '^etoro/[^/]+/best_bid_ask$'),
+    PRIMARY KEY (universe_version, instrument_id, sample_bucket),
+    CONSTRAINT strategy_quote_observation_bucket CHECK (
+        date_trunc('minute', sample_bucket) = sample_bucket
+        AND mod(extract(minute FROM sample_bucket)::integer, 5) = 0
+        AND observed_at >= sample_bucket
+        AND observed_at < sample_bucket + interval '5 minutes'
+    ),
+    CONSTRAINT strategy_quote_observation_shape CHECK (
+        (
+            observation_status = 'observed'
+            AND refusal_reason IS NULL
+            AND quote_at IS NOT NULL
+            AND bid > 0 AND ask > 0 AND ask >= bid
+            AND spread_bps IS NOT NULL AND spread_bps >= 0
+            AND (last IS NULL OR last > 0)
+        ) OR (
+            observation_status IN ('missing', 'invalid')
+            AND refusal_reason IS NOT NULL
+            AND quote_at IS NULL AND bid IS NULL AND ask IS NULL
+            AND last IS NULL AND spread_bps IS NULL
+        )
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_quote_observations_retention
+    ON strategy_quote_observations (sample_bucket);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_quote_observations_lookup
+    ON strategy_quote_observations (instrument_id, sample_bucket DESC)
+    WHERE observation_status = 'observed';
+
+COMMENT ON TABLE strategy_quote_observations IS
+    'Five-minute prospective best-bid/ask samples for the bounded active '
+    'strategy research panel. Latest observation within a forming bucket wins; '
+    'missing/invalid coverage is explicit; rows expire after 24 months.';

--- a/sql/307_strategy_quote_observation_immutability.sql
+++ b/sql/307_strategy_quote_observation_immutability.sql
@@ -1,0 +1,25 @@
+-- #2485 / #2484 -- the first quote observation in a five-minute bucket is
+-- evidence. A later scheduler/manual run must not replace it with a quote that
+-- knows more of the bucket. Deletes remain available only for the declared
+-- retention path.
+
+CREATE OR REPLACE FUNCTION reject_strategy_quote_observation_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'strategy quote observations are immutable; insert the next five-minute bucket';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_strategy_quote_observation_immutable
+    ON strategy_quote_observations;
+
+CREATE TRIGGER trg_strategy_quote_observation_immutable
+BEFORE UPDATE ON strategy_quote_observations
+FOR EACH ROW EXECUTE FUNCTION reject_strategy_quote_observation_update();
+
+COMMENT ON TABLE strategy_quote_observations IS
+    'Five-minute prospective best-bid/ask samples for the bounded active '
+    'strategy research panel. First observation in a bucket is immutable; '
+    'missing/invalid coverage is explicit; rows expire after 24 months.';

--- a/tests/test_strategy_quote_observation.py
+++ b/tests/test_strategy_quote_observation.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.providers.market_data import MarketDataProvider, Quote
+from app.services.strategy_quote_observation import (
+    capture_active_universe_quotes,
+    retire_quote_observations,
+    sample_bucket,
+)
+
+
+def _quote(instrument_id: int, stamp: str, *, bid: str = "99", ask: str = "101") -> Quote:
+    return Quote(
+        instrument_id=instrument_id,
+        timestamp=datetime.fromisoformat(stamp),
+        bid=Decimal(bid),
+        ask=Decimal(ask),
+        last=Decimal("100"),
+    )
+
+
+def _activate_quote_universe(
+    conn: psycopg.Connection[tuple], *, include_missing_resolution: bool = False
+) -> tuple[int, int]:
+    first_id, second_id = 2_485_001, 2_485_002
+    conn.execute(
+        "UPDATE strategy_intraday_universe_versions SET status = 'retired', retired_at = now() WHERE status = 'active'"
+    )
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO instruments (
+                instrument_id, symbol, company_name, exchange, currency, is_tradable
+            ) VALUES (%s, %s, %s, 'test', 'USD', true)
+            ON CONFLICT (instrument_id) DO NOTHING
+            """,
+            [(first_id, "QFIRST", "Quote First"), (second_id, "QSECOND", "Quote Second")],
+        )
+    conn.execute(
+        """
+        INSERT INTO strategy_intraday_universe_versions (
+            universe_version, provider, session_rule, status, rationale
+        ) VALUES ('TEST-QUOTE-V1', 'etoro', 'nyse_rth', 'draft', 'quote fixture')
+        """
+    )
+    members = [
+        (1, "5m", "QFIRST"),
+        (2, "30m", "QFIRST"),
+        (3, "5m", "QSECOND"),
+    ]
+    if include_missing_resolution:
+        members.append((4, "5m", "QMISSING"))
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO strategy_intraday_universe_members (
+                universe_version, ordinal, timeframe, symbol, purpose
+            ) VALUES ('TEST-QUOTE-V1', %s, %s, %s, 'fixture')
+            """,
+            members,
+        )
+    conn.execute(
+        """
+        UPDATE strategy_intraday_universe_versions
+        SET status = 'active', activated_at = now()
+        WHERE universe_version = 'TEST-QUOTE-V1'
+        """
+    )
+    return first_id, second_id
+
+
+def test_sample_bucket_is_utc_five_minute_and_requires_timezone() -> None:
+    assert sample_bucket(datetime.fromisoformat("2026-08-10T14:37:59.123456+01:00")) == datetime.fromisoformat(
+        "2026-08-10T13:35:00+00:00"
+    )
+    with pytest.raises(ValueError, match="timezone-aware"):
+        sample_bucket(datetime(2026, 8, 10, 13, 35))
+
+
+def test_production_capture_timestamp_is_taken_after_provider_returns(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_id, second_id = _activate_quote_universe(ebull_test_conn)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_quotes.return_value = [
+        _quote(first_id, "2026-08-10T13:35:09+00:00"),
+        _quote(second_id, "2026-08-10T13:35:09+00:00"),
+    ]
+
+    class _Clock:
+        @staticmethod
+        def now(*, tz: object) -> datetime:
+            assert tz is UTC
+            return datetime.fromisoformat("2026-08-10T13:35:10+00:00")
+
+    monkeypatch.setattr("app.services.strategy_quote_observation.datetime", _Clock)
+
+    capture_active_universe_quotes(ebull_test_conn, provider)
+
+    assert ebull_test_conn.execute(
+        "SELECT min(observed_at - quote_at), max(observed_at - quote_at) FROM strategy_quote_observations"
+    ).fetchone() == (timedelta(seconds=1), timedelta(seconds=1))
+
+
+def test_capture_is_unique_per_symbol_not_per_timeframe_and_records_missing(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    first_id, second_id = _activate_quote_universe(ebull_test_conn)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_quotes.return_value = [_quote(first_id, "2026-08-10T13:36:01+00:00")]
+
+    report = capture_active_universe_quotes(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.fromisoformat("2026-08-10T13:36:05+00:00"),
+    )
+
+    assert report.expected == 2
+    assert report.observed == 1
+    assert report.missing == 1
+    assert report.invalid == 0
+    assert report.rows_written == 2
+    assert report.failures == ()
+    provider.get_quotes.assert_called_once_with([first_id, second_id])
+    assert ebull_test_conn.execute(
+        """
+        SELECT instrument_id, observation_status, refusal_reason, spread_bps, source
+        FROM strategy_quote_observations ORDER BY instrument_id
+        """
+    ).fetchall() == [
+        (first_id, "observed", None, Decimal("200.00000000"), "etoro/TEST-QUOTE-V1/best_bid_ask"),
+        (second_id, "missing", "provider_omitted_quote", None, "etoro/TEST-QUOTE-V1/best_bid_ask"),
+    ]
+
+
+def test_first_observation_in_bucket_is_immutable_and_rerun_does_not_grow(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    first_id, second_id = _activate_quote_universe(ebull_test_conn)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_quotes.return_value = [
+        _quote(first_id, "2026-08-10T13:35:10+00:00"),
+        _quote(second_id, "2026-08-10T13:35:10+00:00"),
+    ]
+    capture_active_universe_quotes(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.fromisoformat("2026-08-10T13:35:12+00:00"),
+    )
+    provider.get_quotes.return_value = [
+        _quote(first_id, "2026-08-10T13:39:00+00:00", bid="100", ask="102"),
+        _quote(second_id, "2026-08-10T13:39:00+00:00"),
+    ]
+
+    second = capture_active_universe_quotes(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.fromisoformat("2026-08-10T13:39:05+00:00"),
+    )
+
+    assert second.rows_written == 0
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_quote_observations").fetchone() == (2,)
+    assert ebull_test_conn.execute(
+        "SELECT bid, observed_at FROM strategy_quote_observations WHERE instrument_id = %s", (first_id,)
+    ).fetchone() == (Decimal("99.000000"), datetime.fromisoformat("2026-08-10T13:35:12+00:00"))
+    with pytest.raises(psycopg.errors.RaiseException, match="quote observations are immutable"):
+        with ebull_test_conn.transaction():
+            ebull_test_conn.execute(
+                "UPDATE strategy_quote_observations SET bid = 98 WHERE instrument_id = %s", (first_id,)
+            )
+
+
+def test_invalid_quote_and_unresolved_member_are_explicit(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    first_id, second_id = _activate_quote_universe(ebull_test_conn, include_missing_resolution=True)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_quotes.return_value = [
+        _quote(first_id, "2026-08-10T13:35:01+00:00"),
+        _quote(second_id, "2026-08-10T13:35:01+00:00", bid="101", ask="100"),
+    ]
+
+    report = capture_active_universe_quotes(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.fromisoformat("2026-08-10T13:35:02+00:00"),
+    )
+
+    assert report.expected == 3
+    assert report.observed == 1
+    assert report.invalid == 1
+    assert report.failures[0].symbol == "QMISSING"
+    assert report.failures[0].reason == "universe_resolution: expected one tradable instrument, found 0"
+    assert ebull_test_conn.execute(
+        "SELECT refusal_reason FROM strategy_quote_observations WHERE instrument_id = %s", (second_id,)
+    ).fetchone() == ("crossed_market",)
+
+
+def test_provider_duplicate_or_out_of_scope_quote_refuses_batch(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    first_id, _ = _activate_quote_universe(ebull_test_conn)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_quotes.return_value = [
+        _quote(first_id, "2026-08-10T13:35:01+00:00"),
+        _quote(first_id, "2026-08-10T13:35:02+00:00"),
+    ]
+    with pytest.raises(RuntimeError, match="duplicate quotes"):
+        capture_active_universe_quotes(
+            ebull_test_conn,
+            provider,
+            observed_at=datetime.fromisoformat("2026-08-10T13:35:03+00:00"),
+        )
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_quote_observations").fetchone() == (0,)
+
+
+def test_quote_retention_is_exactly_twenty_four_calendar_months(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    first_id, second_id = _activate_quote_universe(ebull_test_conn)
+    provider = MagicMock(spec=MarketDataProvider)
+    provider.get_quotes.return_value = [
+        _quote(first_id, "2024-08-09T13:35:00+00:00"),
+        _quote(second_id, "2024-08-09T13:35:00+00:00"),
+    ]
+    capture_active_universe_quotes(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.fromisoformat("2024-08-09T13:35:01+00:00"),
+    )
+    provider.get_quotes.return_value = [
+        _quote(first_id, "2024-08-10T13:35:00+00:00"),
+        _quote(second_id, "2024-08-10T13:35:00+00:00"),
+    ]
+    capture_active_universe_quotes(
+        ebull_test_conn,
+        provider,
+        observed_at=datetime.fromisoformat("2024-08-10T13:35:01+00:00"),
+    )
+    as_of = datetime.fromisoformat("2026-08-10T13:35:00+00:00")
+
+    assert retire_quote_observations(ebull_test_conn, as_of=as_of) == 2
+    assert retire_quote_observations(ebull_test_conn, as_of=as_of, dry_run=False) == 2
+    assert ebull_test_conn.execute(
+        "SELECT sample_bucket FROM strategy_quote_observations ORDER BY sample_bucket LIMIT 1"
+    ).fetchone() == (datetime.fromisoformat("2024-08-10T13:35:00+00:00"),)


### PR DESCRIPTION
Refs #2485. Refs #2484.

## Outcome

Adds the missing prospective cost-evidence path for the exact active intraday research panel. This does not promote a strategy or enable allocation.

The existing five-minute intraday harvest now makes one bounded batch quote request for the eight unique panel symbols and records one immutable observation per instrument/bucket. Missing and malformed quotes are explicit coverage rows. The 24-month retention path bounds the current panel at about 314,496 rows; no all-market tick tape or derived series is stored.

## Live evidence

The final contract has run through the real provider/scheduler/dev database for two buckets: 16 rows, 8/8 observed each bucket, 0 missing, 0 invalid, 64 KiB current relation footprint. It exposed real freshness differences: AAPL/F/IWM/KO were sub-second while SPY/QQQ/JPM were about 14 minutes old and CENN about 94 minutes old. Downstream candidates must apply their frozen freshness rule; `observed` deliberately does not mean executable.

Live validation also caught and fixed two lookahead defects before any consumer existed: capture time is now taken after the response, and PostgreSQL rejects updates so a later 15:34 run cannot replace the first 15:30 bucket observation. Eight pre-contract development rows were deleted by exact version/bucket and recollected; no signal or outcome referenced them.

## Validation

- focused storage/harvest/retention/scheduler/migration/smoke tests: 98 passed
- full pre-push gate green: ruff, format, pyright, invariant lints, fast tests, dev-DB app boot, frontend integrity
- demo allocation remains fail-closed
- existing dev DB 63 GB warning remains; this relation is currently 64 KiB