### PR TITLE
research(#2485): freeze Stocks-in-Play data contract

### DIFF
--- a/app/services/orb_stocks_in_play_candidate.py
+++ b/app/services/orb_stocks_in_play_candidate.py
@@ -1,0 +1,96 @@
+"""Frozen published ORB / Stocks-in-Play candidate contract (#2485).
+
+This module deliberately contains no evaluator and no catalogue entry.  It
+exists to prevent a small-panel breakout from being mistaken for the published
+cross-sectional strategy while its required evidence is still unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Final, Literal
+
+
+@dataclass(frozen=True)
+class OrbStocksInPlayDefinition:
+    paper_revision: str = "2025-04-29"
+    security_type: str = "common_stock"
+    security_type_boundary: str = "ebull_adaptation_pending_paper_crsp_share_code_confirmation"
+    listing_markets: tuple[str, ...] = ("nyse", "nasdaq")
+    opening_range_minutes: int = 5
+    minimum_open_price_usd: Decimal = Decimal("5")
+    minimum_prior_mean_share_volume: Decimal = Decimal("1000000")
+    minimum_prior_atr_usd: Decimal = Decimal("0.50")
+    lookback_sessions: int = 14
+    minimum_opening_relative_volume: Decimal = Decimal("1")
+    maximum_daily_rank: int = 20
+    direction: str = "opening_candle_direction"
+    entry: str = "stop_at_opening_range_high_or_low"
+    stop_atr_fraction: Decimal = Decimal("0.10")
+    exit: str = "stop_or_regular_session_close"
+    profit_target: None = None
+    gap_filter: None = None
+    paper_risk_fraction: Decimal = Decimal("0.01")
+    ebull_maximum_leverage: Decimal = Decimal("1")
+
+
+DEFINITION: Final = OrbStocksInPlayDefinition()
+CANDIDATE_VERSION: Final = "orb-stocks-in-play-v1:" + hashlib.sha256(repr(DEFINITION).encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class ReplicationReadiness:
+    """Coverage known before any retained outcome is opened."""
+
+    point_in_time_membership: bool
+    security_type_mapping_verified: bool
+    atr_implementation_verified: bool
+    expected_prefilter_names: int
+    scanned_prefilter_names: int
+    opening_volume_names: int
+    expected_selected_names: int
+    selected_names: int
+    selected_paths: int
+    as_traded_price_basis_complete: bool
+    decision_quotes_complete: bool
+    shortability_complete: bool
+
+
+ReadinessVerdict = Literal["ready", "refused"]
+
+
+def assess_replication_readiness(value: ReplicationReadiness) -> tuple[ReadinessVerdict, tuple[str, ...]]:
+    """Refuse partial-universe and non-executable approximations by name."""
+
+    for field in ("expected_prefilter_names", "scanned_prefilter_names", "opening_volume_names"):
+        if getattr(value, field) <= 0:
+            raise ValueError(f"{field} must be positive")
+    for field in ("expected_selected_names", "selected_names", "selected_paths"):
+        if not 0 <= getattr(value, field) <= DEFINITION.maximum_daily_rank:
+            raise ValueError(f"{field} must be inside 0-{DEFINITION.maximum_daily_rank}")
+
+    reasons: list[str] = []
+    if not value.point_in_time_membership:
+        reasons.append("missing_point_in_time_membership")
+    if not value.security_type_mapping_verified:
+        reasons.append("ambiguous_published_security_type_universe")
+    if not value.atr_implementation_verified:
+        reasons.append("ambiguous_atr_implementation")
+    if value.scanned_prefilter_names != value.expected_prefilter_names:
+        reasons.append("incomplete_prefilter_cross_section")
+    if value.opening_volume_names != value.expected_prefilter_names:
+        reasons.append("incomplete_opening_volume_cross_section")
+    if value.selected_names != value.expected_selected_names:
+        reasons.append("incomplete_top20_selection")
+    if value.selected_paths != value.selected_names:
+        reasons.append("incomplete_selected_intraday_paths")
+    if not value.as_traded_price_basis_complete:
+        reasons.append("missing_as_traded_price_basis")
+    if not value.decision_quotes_complete:
+        reasons.append("missing_decision_time_etoro_quotes")
+    if not value.shortability_complete:
+        reasons.append("missing_decision_time_shortability")
+
+    return ("ready" if not reasons else "refused", tuple(reasons))

--- a/app/services/orb_stocks_in_play_candidate.py
+++ b/app/services/orb_stocks_in_play_candidate.py
@@ -70,6 +70,8 @@ def assess_replication_readiness(value: ReplicationReadiness) -> tuple[Readiness
     for field in ("expected_selected_names", "selected_names", "selected_paths"):
         if not 0 <= getattr(value, field) <= DEFINITION.maximum_daily_rank:
             raise ValueError(f"{field} must be inside 0-{DEFINITION.maximum_daily_rank}")
+    if value.expected_selected_names > value.expected_prefilter_names:
+        raise ValueError("expected_selected_names cannot exceed expected_prefilter_names")
 
     reasons: list[str] = []
     if not value.point_in_time_membership:

--- a/docs/proposals/ta/2026-08-10-opening-range-stocks-in-play-data-contract.md
+++ b/docs/proposals/ta/2026-08-10-opening-range-stocks-in-play-data-contract.md
@@ -1,0 +1,167 @@
+# Opening-range / Stocks-in-Play replication contract
+
+Date: 2026-08-10  
+Status: published rule transcribed; measurement refused until the selection
+universe and execution observations below exist  
+Issues: #2485, #2477, #2508
+
+## Decision
+
+Do not evaluate or expose an Opening Range Breakout (ORB) strategy over eBull's
+eight-name intraday research panel. That would not reproduce the published
+strategy and would give its result an invalid prior.
+
+The valuable finding in Zarattini, Barbon and Aziz is not “price crossed the
+first five-minute high/low”. It is the interaction between that rule and a
+daily, point-in-time **Stocks in Play** selection made across the US common-stock
+market. The selection must happen before a breakout is observed. Exchange,
+security type, nominal price, normal liquidity, volatility and abnormal opening
+volume are therefore inputs to the candidate, not post-hoc labels.
+
+The final paper revision was verified from the
+[authors' April 29, 2025 PDF](https://concretumgroup.com/wp-content/uploads/2026/02/A-Profitable-Day-Trading-Strategy-For-The-U.S.-Equity-Market.pdf)
+and [SSRN record](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4729284).
+Its evidence covers 2016–2023. It is prior evidence only; it is not evidence of
+performance in 2026 or at eToro.
+
+## Published rule, without adaptation
+
+The paper's point-in-time universe contains NYSE- and Nasdaq-listed equities,
+including later-delisted names. It does not publish its CRSP share-code
+whitelist, so “equities” cannot yet be mapped exactly to eToro instrument types.
+eBull's proposed executable arm predeclares common stocks only (excluding ETFs
+and other types), records that as an adaptation, and keeps exact-replication
+status refused until the paper's security-type boundary is confirmed. For each
+session and instrument the paper applies:
+
+1. opening price strictly above USD 5;
+2. arithmetic average share volume over the previous 14 completed sessions at
+   least 1,000,000 shares/day;
+3. 14-session ATR strictly above USD 0.50;
+4. first-five-minute relative volume at least 1.0, where
+   `RVOL[t] = opening_5m_volume[t] / mean(opening_5m_volume[t-14:t-1])`;
+5. retain at most the 20 eligible instruments with the highest RVOL that day;
+6. bullish first five-minute candle: buy stop at its high; bearish candle: sell
+   stop at its low; doji: no order;
+7. after entry, stop distance is 10% of the 14-session ATR; if not stopped,
+   close at the regular-session close;
+8. size each position to at most 1% portfolio loss at the stop, subject in the
+   paper to 4x maximum leverage.
+
+The paper starts with USD 25,000 and charges USD 0.0035/share. eBull's trial is
+predeclared **unlevered** and must use observed eToro bid/ask, spread and order
+costs instead. The paper specifies no profit target and no ratcheting stop.
+Adding either is a separate hypothesis and trial, not a faithful replication.
+
+The paper describes ATR's true-range components but does not publish executable
+code for this all-stock cross-sectional test. Its related single-instrument ORB
+example uses a lagged 14-session arithmetic mean of true range, but that is not
+proof that the portfolio paper used identical code. Until this is resolved from
+an authoritative implementation, ATR calculation is a named reproducibility
+ambiguity and the exact replication remains fail-closed.
+
+## What eBull has, and what it does not
+
+Already available:
+
+- 6,083 currently classified NYSE/Nasdaq common stocks in the prospective eToro
+  universe (3,618 Nasdaq and 2,465 NYSE at the 2026-08-10 census);
+- transition-only security type and primary-listing history from 2026-08-10;
+- daily OHLCV sufficient to calculate causal price, volume and ATR screens where
+  14 complete as-traded observations exist;
+- a bounded eight-name 5-minute panel and prospective eToro bid/ask observations;
+- shared cohort verification across mechanism, type, listing, price, liquidity
+  and their predeclared interactions.
+
+Missing for an honest ORB test:
+
+- a point-in-time, survivorship-safe historical NYSE/Nasdaq common-stock
+  membership source; today's eToro universe cannot be projected backwards;
+- the paper's CRSP share-code/security-type inclusion rule;
+- first-five-minute volume for the **whole prefiltered cross-section** each day;
+- post-09:35 intraday paths for the selected top 20, at sufficient resolution to
+  resolve breakout/stop ordering and gap-through fills;
+- historical decision-time eToro quotes, spreads, slippage and shortability;
+- a confirmed all-stock ATR implementation and an as-traded corporate-action
+  bridge for nominal price/ATR/volume comparability.
+
+The current collector cannot close the cross-sectional gap. eToro's candle API
+is one instrument per request and the client is deliberately limited to about
+55 reads/minute. Scanning even the currently classified 6,083 NYSE/Nasdaq common
+stocks would take about 111 minutes before retries, far beyond a 09:35 decision.
+The rates endpoint batches quotes but does not provide opening volume.
+
+## Free-data feasibility and its boundary
+
+Alpaca's [official market-data documentation](https://docs.alpaca.markets/us/v1.1/docs/about-market-data-api)
+and [FAQ](https://docs.alpaca.markets/us/docs/market-data-faq) say a free account
+can query historical SIP data when the request ends at least 15 minutes in the
+past, with history since 2016 and a 200-request/minute limit. SIP combines the
+CTA/NYSE and UTP/Nasdaq feeds; raw minute bars include OHLCV. This makes a
+**delayed historical replication feed** worth a separate credentialed spike. It
+does not solve live 09:35 discovery: free real-time equities are IEX-only, a
+small and non-comparable slice of consolidated US volume, while current SIP is
+delayed.
+
+Accordingly:
+
+- Alpaca may be used to build/replay a recent historical candidate census;
+- eToro remains the execution and executable-cost source;
+- Alpaca volume must never be mixed with eToro volume under one source label;
+- a delayed research result cannot be described as a real-time executable path;
+- no subscription will be purchased or assumed.
+
+## Bounded storage design
+
+Do not retain a full-market tick tape or every derived indicator. The minimum
+research shape is:
+
+1. one immutable daily eligibility/opening summary per instrument/session:
+   source/version, point-in-time identity, open, prior-volume mean, ATR,
+   opening-five-minute OHLCV, RVOL, eligibility/refusal and rank;
+2. raw one-minute RTH bars only for the selected top 20 plus declared controls,
+   partitioned monthly and retained for the active validation horizon;
+3. one immutable potential-fire decision with observed eToro quote status;
+4. one terminal outcome with fill assumptions, stop/close exit and cost model.
+
+At the paper's 7,000-name scale the summary ceiling is about 1.76 million rows
+per year (`7,000 × 252`), rather than roughly 688 million one-minute full-market
+rows. Selected paths are at most about 1.94 million rows/year
+(`20 × 385 × 252`) before controls. Exact bytes and query plans must be measured
+on a sample partition before enabling retention; whole expired partitions are
+dropped. Rolling ATR/RVOL/indicator series are computed causally, not stored.
+
+## Frozen analysis, once data exists
+
+The primary trial is the paper's 5-minute, top-20 selection, unlevered. The
+15/30/60-minute variants are separate trials. Report recent calendar months
+individually, a longer context window, and an untouched later interval; never
+select the best window after seeing outcomes.
+
+Required output includes after-cost expectancy and clustered confidence
+interval, profit factor, hit rate, drawdown and expected shortfall, turnover,
+capacity/concurrency, long/short attribution, spread deciles and the shared
+type/listing/price/dollar-volume interaction report. Compare against:
+
+- matched random entry after the same Stocks-in-Play selection;
+- selection-only same-direction exposure without breakout timing;
+- the unfiltered ORB base rule;
+- doubled costs and delayed/missed fills.
+
+A subgroup can explain a result but cannot rescue a failed primary trial on the
+same observations. A promising subgroup becomes a newly versioned hypothesis
+tested on later untouched data. Promotion remains refused unless the lower
+confidence bound on net expectancy is positive and the portfolio, broker,
+freshness, shortability and prospective gates all pass.
+
+## Implication for “AI trading systems”
+
+Open-source systems such as Microsoft's
+[Qlib](https://www.microsoft.com/en-us/research/publication/qlib-an-ai-oriented-quantitative-investment-platform/)
+and [FinRL](https://arxiv.org/abs/2111.09395) are useful experiment engines:
+they provide datasets, models, environments and evaluation machinery. They are
+not portable proof that a supplied policy makes money after this broker's costs.
+The reusable work is their discipline—point-in-time features, walk-forward
+evaluation, costs, baselines and reproducibility—not a pretrained “winning”
+model. Any learned model enters the same candidate ledger and must beat simple
+rules on later data without leakage before it can receive demo capital.

--- a/tests/test_orb_stocks_in_play_candidate.py
+++ b/tests/test_orb_stocks_in_play_candidate.py
@@ -103,3 +103,8 @@ def test_quiet_complete_session_can_select_fewer_than_twenty() -> None:
 def test_invalid_census_is_rejected(field: str, value: int) -> None:
     with pytest.raises(ValueError, match=field):
         assess_replication_readiness(_ready(**{field: value}))
+
+
+def test_selected_population_cannot_exceed_prefilter_population() -> None:
+    with pytest.raises(ValueError, match="expected_selected_names"):
+        assess_replication_readiness(_ready(expected_prefilter_names=3))

--- a/tests/test_orb_stocks_in_play_candidate.py
+++ b/tests/test_orb_stocks_in_play_candidate.py
@@ -1,0 +1,105 @@
+from decimal import Decimal
+
+import pytest
+
+from app.services.orb_stocks_in_play_candidate import (
+    CANDIDATE_VERSION,
+    DEFINITION,
+    ReplicationReadiness,
+    assess_replication_readiness,
+)
+
+
+def _ready(**overrides: object) -> ReplicationReadiness:
+    values: dict[str, object] = {
+        "point_in_time_membership": True,
+        "security_type_mapping_verified": True,
+        "atr_implementation_verified": True,
+        "expected_prefilter_names": 1_200,
+        "scanned_prefilter_names": 1_200,
+        "opening_volume_names": 1_200,
+        "expected_selected_names": 20,
+        "selected_names": 20,
+        "selected_paths": 20,
+        "as_traded_price_basis_complete": True,
+        "decision_quotes_complete": True,
+        "shortability_complete": True,
+    }
+    values.update(overrides)
+    return ReplicationReadiness(**values)  # type: ignore[arg-type]
+
+
+def test_definition_is_the_published_cross_section_not_a_generic_breakout() -> None:
+    assert DEFINITION.paper_revision == "2025-04-29"
+    assert DEFINITION.security_type == "common_stock"
+    assert "pending_paper_crsp_share_code_confirmation" in DEFINITION.security_type_boundary
+    assert DEFINITION.listing_markets == ("nyse", "nasdaq")
+    assert DEFINITION.minimum_open_price_usd == Decimal("5")
+    assert DEFINITION.minimum_prior_mean_share_volume == Decimal("1000000")
+    assert DEFINITION.minimum_prior_atr_usd == Decimal("0.50")
+    assert DEFINITION.minimum_opening_relative_volume == Decimal("1")
+    assert DEFINITION.maximum_daily_rank == 20
+    assert DEFINITION.stop_atr_fraction == Decimal("0.10")
+    assert DEFINITION.profit_target is None
+    assert DEFINITION.gap_filter is None
+    assert DEFINITION.ebull_maximum_leverage == Decimal("1")
+    assert CANDIDATE_VERSION.startswith("orb-stocks-in-play-v1:")
+
+
+def test_eight_name_panel_cannot_inherit_a_full_cross_section_result() -> None:
+    verdict, reasons = assess_replication_readiness(
+        _ready(scanned_prefilter_names=8, opening_volume_names=8, selected_names=8, selected_paths=8)
+    )
+    assert verdict == "refused"
+    assert reasons == (
+        "incomplete_prefilter_cross_section",
+        "incomplete_opening_volume_cross_section",
+        "incomplete_top20_selection",
+    )
+
+
+def test_missing_cost_shortability_and_rule_provenance_refuse() -> None:
+    verdict, reasons = assess_replication_readiness(
+        _ready(
+            point_in_time_membership=False,
+            security_type_mapping_verified=False,
+            atr_implementation_verified=False,
+            as_traded_price_basis_complete=False,
+            decision_quotes_complete=False,
+            shortability_complete=False,
+        )
+    )
+    assert verdict == "refused"
+    assert reasons == (
+        "missing_point_in_time_membership",
+        "ambiguous_published_security_type_universe",
+        "ambiguous_atr_implementation",
+        "missing_as_traded_price_basis",
+        "missing_decision_time_etoro_quotes",
+        "missing_decision_time_shortability",
+    )
+
+
+def test_only_complete_predeclared_inputs_are_ready() -> None:
+    assert assess_replication_readiness(_ready()) == ("ready", ())
+
+
+def test_quiet_complete_session_can_select_fewer_than_twenty() -> None:
+    assert assess_replication_readiness(_ready(expected_selected_names=3, selected_names=3, selected_paths=3)) == (
+        "ready",
+        (),
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("expected_prefilter_names", 0),
+        ("expected_selected_names", 21),
+        ("selected_names", 21),
+        ("selected_paths", -1),
+    ),
+)
+def test_invalid_census_is_rejected(field: str, value: int) -> None:
+    with pytest.raises(ValueError, match=field):
+        assess_replication_readiness(_ready(**{field: value}))


### PR DESCRIPTION
## Outcome

Freezes the final published ORB / Stocks-in-Play rule and refuses the misleading eight-name approximation.

- documents the exact rule, eToro live-scan constraint, free delayed-SIP boundary, and bounded storage shape
- adds a versioned candidate definition with no evaluator or catalogue promotion
- requires complete point-in-time cross-section, opening volume, selected paths, as-traded provenance, eToro quotes, and shortability before evaluation
- corrects the prior ticket reference to a gap selector: the paper uses relative opening volume, not an opening-gap filter

## Validation

- 9 focused tests
- ruff check and format
- pyright
- full pre-push pure-logic, smoke, and frontend integrity gates

Refs #2485. Refs #2477. Refs #2508.