### PR TITLE
fix(ta): require capital candidate admission

### DIFF
--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -243,8 +243,11 @@ def promote_strategy(
         _require_text(value, field)
     if to_stage == "live_enabled":
         raise StrategyControlError("live_enabled requires the dedicated measured live-promotion gate")
-    if to_stage in _EXTERNAL_EVIDENCE_STAGES and registered_strategy_purpose(strategy_id) == "harness_validation":
+    purpose = registered_strategy_purpose(strategy_id)
+    if to_stage in _EXTERNAL_EVIDENCE_STAGES and purpose == "harness_validation":
         raise StrategyControlError("harness-validation strategies are permanent controls and cannot be promoted")
+    if to_stage in _EXTERNAL_EVIDENCE_STAGES and purpose != "capital_candidate":
+        raise StrategyControlError("unregistered strategies cannot advance to evidence-backed deployment stages")
     if evidence_ref is not None:
         _require_text(evidence_ref, "evidence_ref")
     if len(set(result_ids)) != len(result_ids):
@@ -353,12 +356,11 @@ def configure_deployment(
         enabled=enabled,
         currency=currency,
     )
-    if (
-        registered_strategy_purpose(strategy_id) == "harness_validation"
-        and not risk_reducing
-        and (enabled or capital_limit > 0)
-    ):
+    purpose = registered_strategy_purpose(strategy_id)
+    if purpose == "harness_validation" and not risk_reducing and (enabled or capital_limit > 0):
         raise StrategyControlError("harness-validation strategies cannot receive capital authority")
+    if purpose != "capital_candidate" and not risk_reducing and (enabled or capital_limit > 0):
+        raise StrategyControlError("unregistered strategies cannot receive capital authority")
     eligible: dict[Mode, frozenset[Stage]] = {
         "paper": frozenset({"paper_enabled", "live_enabled"}),
         "live": frozenset({"live_enabled"}),

--- a/app/services/strategy_live_gate.py
+++ b/app/services/strategy_live_gate.py
@@ -480,8 +480,11 @@ def assess_live_gate(
     )
 
     refusals: list[str] = []
-    if registered_strategy_purpose(strategy_id) == "harness_validation":
+    purpose = registered_strategy_purpose(strategy_id)
+    if purpose == "harness_validation":
         refusals.append("harness_validation_only")
+    elif purpose != "capital_candidate":
+        refusals.append("strategy_not_capital_candidate")
     if policy is None:
         refusals.append("live_gate_policy_missing")
     if facts.stage != "paper_enabled":

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -656,15 +656,19 @@ def _execute_fired_paper_signal_locked(
         return existing
     signal_row = conn.execute("SELECT strategy_id FROM strategy_signals WHERE signal_id=%s", (signal_id,)).fetchone()
     conn.commit()
-    if signal_row is not None and registered_strategy_purpose(str(signal_row[0])) == "harness_validation":
+    purpose = None if signal_row is None else registered_strategy_purpose(str(signal_row[0]))
+    if signal_row is not None and purpose != "capital_candidate":
         if existing is not None:
             if existing.order_id is None:
-                raise StrategyPaperExecutionError("uncertain harness submission is missing durable order authority")
+                raise StrategyPaperExecutionError(
+                    "uncertain non-capital-candidate submission is missing durable order authority"
+                )
             reconcile_strategy_order(conn, broker=broker, order_id=existing.order_id)
             refreshed = _existing_result(conn, signal_id)
             conn.commit()
             return refreshed or existing
-        return _persist_rejection(conn, signal_id=signal_id, reason_code="harness_validation_only", now=evaluated_at)
+        reason_code = "harness_validation_only" if purpose == "harness_validation" else "strategy_not_capital_candidate"
+        return _persist_rejection(conn, signal_id=signal_id, reason_code=reason_code, now=evaluated_at)
     try:
         runtime = get_runtime_config(conn)
         kill_row = conn.execute("SELECT is_active FROM kill_switch WHERE id = true").fetchone()

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -113,6 +113,7 @@ function validationState(strategy: StrategyOverview): {
 
 const REFUSAL_LABELS: Record<string, string> = {
   harness_validation_only: "Validation control; permanently barred from capital",
+  strategy_not_capital_candidate: "Strategy has not been admitted as a capital candidate",
   strategy_not_runnable: "Rule is not runnable end to end",
   recent_evidence_incomplete: "Recent evidence windows are incomplete",
   recent_evidence_gate_refused: "Recent evidence failed its promotion gate",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,8 @@ import pathlib
 import shutil
 import tempfile
 from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any, cast
 
 # Skip lifespan catch-up in every TestClient(app) enter/exit cycle.
 # Without this, each test that enters the FastAPI lifespan fires real
@@ -62,6 +64,22 @@ from tests.fixtures.ebull_test_db import (
 from tests.fixtures.ebull_test_db import (
     ebull_test_conn as ebull_test_conn,
 )
+
+
+@pytest.fixture
+def registered_strategy_test_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Register synthetic strategy IDs used by execution integration tests.
+
+    Production has no capital candidates today.  Tests that exercise the
+    post-admission lifecycle need explicit test-only candidates; treating an
+    unknown ID as one would hide the fail-closed boundary those tests protect.
+    """
+    from app.services import strategy_control_plane
+
+    manifest = dict(strategy_control_plane.STRATEGY_MANIFEST)
+    for strategy_id in ("S-ALLOC", "S-GOV", "S-LIVE-GATE", "S-OWN"):
+        manifest[strategy_id] = cast(Any, SimpleNamespace(purpose="capital_candidate"))
+    monkeypatch.setattr(strategy_control_plane, "STRATEGY_MANIFEST", manifest)
 
 
 @pytest.fixture

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -26,7 +26,7 @@ from app.services.strategy_control_plane import (
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
 
 def _instrument(conn: psycopg.Connection[Any], instrument_id: int = 2454001) -> None:
@@ -213,6 +213,42 @@ def test_harness_control_cannot_be_promoted_or_funded(
             enabled=True,
             changed_by="operator",
             reason="must remain a control",
+        )
+
+
+def test_unregistered_strategy_cannot_cross_the_evidence_or_capital_boundary(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    promote_strategy(
+        conn,
+        strategy_id="S-UNREGISTERED",
+        strategy_version="v1",
+        to_stage="research_candidate",
+        promoted_by="operator",
+        reason="research registration alone is not capital admission",
+    )
+    with pytest.raises(StrategyControlError, match="unregistered strategies cannot advance"):
+        promote_strategy(
+            conn,
+            strategy_id="S-UNREGISTERED",
+            strategy_version="v1",
+            to_stage="historical_validated",
+            promoted_by="operator",
+            reason="must be refused before evidence lookup",
+            evidence_ref="result:test",
+            result_ids=(1,),
+        )
+    with pytest.raises(StrategyControlError, match="unregistered strategies cannot receive capital"):
+        configure_deployment(
+            conn,
+            strategy_id="S-UNREGISTERED",
+            strategy_version="v1",
+            mode="paper",
+            capital_limit=Decimal("100"),
+            enabled=True,
+            changed_by="operator",
+            reason="must not gain authority",
         )
 
 

--- a/tests/test_strategy_live_gate.py
+++ b/tests/test_strategy_live_gate.py
@@ -35,7 +35,7 @@ from app.services.strategy_live_gate import (
 )
 from tests.test_strategy_position_manager import _opened_trade
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
 _STRATEGY_ID = "S-LIVE-GATE"
 _VERSION = "live-gate-v1"

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -51,7 +51,7 @@ from tests.test_result_ledger import (
     build_result,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
 _NOW = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)  # Friday 11:00 New York
 _REQUEST_ID = UUID("1c94300c-90aa-4303-9d00-dec376d74efb")
@@ -243,6 +243,24 @@ def test_harness_signal_is_rejected_before_runtime_or_broker_checks(
 
     assert result.verdict == "rejected"
     assert result.reason_code == "harness_validation_only"
+    broker.place_demo_strategy_order.assert_not_called()
+
+
+def test_unregistered_signal_is_rejected_before_runtime_or_broker_checks(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    signal_id = _seed(ebull_test_conn)
+    ebull_test_conn.execute(
+        "UPDATE strategy_signals SET strategy_id='S-UNREGISTERED' WHERE signal_id=%s",
+        (signal_id,),
+    )
+    ebull_test_conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(ebull_test_conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "strategy_not_capital_candidate"
     broker.place_demo_strategy_order.assert_not_called()
 
 

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -15,7 +15,7 @@ from app.services.strategy_paper_runtime import refresh_strategy_health, run_str
 from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _broker, _seed
 from tests.test_strategy_position_manager import _opened_trade
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
 
 def test_cycle_refreshes_health_then_executes_one_current_paper_candidate(

--- a/tests/test_strategy_position_manager.py
+++ b/tests/test_strategy_position_manager.py
@@ -34,7 +34,7 @@ from app.services.strategy_position_manager import (
 )
 from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _broker, _seed
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
 _POSITION_ID = 24520001
 _MANUAL_POSITION_ID = 24520999


### PR DESCRIPTION
## Summary
- refuse unregistered strategies at evidence-backed promotion and positive capital-authority boundaries
- refuse unregistered signals before runtime configuration or broker I/O, while preserving reconciliation of previously uncertain orders
- expose the same fail-closed distinction in the live gate and operator refusal labels
- register synthetic capital candidates only inside the integration-test modules that exercise post-admission lifecycle behaviour

## Why
The scheduler currently derives an empty version set because the production manifest has zero capital candidates. Lower-level control/executor calls, however, treated an unknown manifest purpose (`None`) differently from a known harness strategy and could bypass that default. This closes the bypass without admitting any strategy or changing the database.

## Validation
- 164 relevant backend/API tests passed
- 16 strategy-page tests passed
- frontend typecheck passed
- targeted pyright and ruff passed
- independent Codex review found no blocking issue
- full pre-push gate passed, including repository fast suite and dev-DB smoke

Refs #2525
Refs #2437