### PR TITLE
fix(ta): preserve realised strategy history

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -323,6 +323,9 @@ class StrategyPnlHistoryPoint(BaseModel):
 
 
 class StrategyPnlHistoryResponse(BaseModel):
+    basis: Literal["exact_owned_realised_pnl_only"] = "exact_owned_realised_pnl_only"
+    total_return_available: Literal[False] = False
+    benchmark_comparison_available: Literal[False] = False
     points: list[StrategyPnlHistoryPoint]
 
 
@@ -1404,7 +1407,13 @@ def get_strategy_pnl_history(
     days: int = Query(default=365, ge=30, le=1825),
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> StrategyPnlHistoryResponse:
-    """Return a bounded, read-time cumulative curve from exact close events."""
+    """Return bounded cumulative realised P&L for every exact-owned lifecycle.
+
+    This is not portfolio return: capital revisions are external flows and open
+    positions need historical marks.  Old/retired strategy versions remain in
+    the shared pot, so history is deliberately not filtered to the manifest's
+    current versions.
+    """
     rows = cast(
         list[tuple[date, str, Decimal]],
         conn.execute(
@@ -1418,11 +1427,10 @@ def get_strategy_pnl_history(
         JOIN trade_events event ON event.position_id=ownership.broker_position_id
         WHERE event.event_kind='close' AND event.realized_pnl_usd IS NOT NULL
           AND event.executed_at >= now() - make_interval(days => %s)
-          AND signal.strategy_version=ANY(%s)
         GROUP BY pnl_date,signal.strategy_id
         ORDER BY pnl_date,signal.strategy_id
         """,
-            (days, list(_current_versions().values())),
+            (days,),
         ).fetchall(),
     )
     daily: dict[date, dict[str, Decimal]] = defaultdict(dict)

--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -122,6 +122,14 @@ the operator’s wealth comparison. This is not an unsourced vendor dependency:
   free series passes review, eBull reports prospective account total return beside
   price-only market context and refuses an external recent excess-return claim.
 
+Current implementation boundary, made explicit rather than inferred: the Strategies
+chart is a bounded cumulative sum of exact-owned realised broker P&L. It is not total
+return and has no benchmark comparison. Retired strategy versions remain in that
+shared-pot history; manual positions remain excluded by exact ownership. Open marks
+appear only in the current headline. A time-weighted return needs capital revisions as
+external flows plus reconciled historical open-position marks, distributions, FX and
+costs before either return field may become available.
+
 ### Candidate C-1 — opportunistic insider purchase reproduction
 
 One preregistered rule, faithful to the published classification. Before the full

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2596,6 +2596,9 @@ export interface StrategyPnlHistoryPoint {
 }
 
 export interface StrategyPnlHistoryResponse {
+  basis: "exact_owned_realised_pnl_only";
+  total_return_available: false;
+  benchmark_comparison_available: false;
   points: StrategyPnlHistoryPoint[];
 }
 

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -184,7 +184,12 @@ describe("StrategiesPage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(OVERVIEW);
-    vi.spyOn(strategiesApi, "fetchStrategyPnlHistory").mockResolvedValue({ points: [] });
+    vi.spyOn(strategiesApi, "fetchStrategyPnlHistory").mockResolvedValue({
+      basis: "exact_owned_realised_pnl_only",
+      total_return_available: false,
+      benchmark_comparison_available: false,
+      points: [],
+    });
     vi.spyOn(strategiesApi, "fetchStrategyOwnedPositions").mockResolvedValue({
       positions: [],
       live_quote_instrument_ids: [],
@@ -336,12 +341,18 @@ describe("StrategiesPage", () => {
 
   it("shows observed portfolio measures and controls for an approved strategy", async () => {
     vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(approvedOverview());
-    vi.mocked(strategiesApi.fetchStrategyPnlHistory).mockResolvedValue({ points: [{ date: "2026-08-09", total_pnl: "50", strategy_pnl: { "s1-time-series-momentum": "50" } }] });
+    vi.mocked(strategiesApi.fetchStrategyPnlHistory).mockResolvedValue({
+      basis: "exact_owned_realised_pnl_only",
+      total_return_available: false,
+      benchmark_comparison_available: false,
+      points: [{ date: "2026-08-09", total_pnl: "50", strategy_pnl: { "s1-time-series-momentum": "50" } }],
+    });
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     const performance = (await screen.findByText("Portfolio performance")).closest("section")!;
     expect(within(performance).getByText("US$50.00")).toBeInTheDocument();
     expect(within(performance).getByText("+1.25%")).toBeInTheDocument();
     expect(within(performance).getByText("+60.00%")).toBeInTheDocument();
+    expect(within(performance).getByText(/Cumulative realised P&L from exact automated positions/)).toBeInTheDocument();
     expect(screen.getByText("1 approved")).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Enabled" })).toBeEnabled();
   });

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -887,7 +887,14 @@ export function StrategiesPage() {
               ) : pnlHistory.error ? (
                 <div className="mt-6 border-t border-slate-200 pt-4 dark:border-slate-800"><SectionError onRetry={pnlHistory.refetch} /></div>
               ) : pnlHistory.data?.points.length ? (
-                <PnlChart history={pnlHistory.data.points} />
+                <>
+                  <PnlChart history={pnlHistory.data.points} />
+                  <p className="mt-2 text-xs text-slate-500">
+                    Cumulative realised P&amp;L from exact automated positions. Open-position marks are included in
+                    the headline only; total return and benchmark comparison remain unavailable until capital-flow,
+                    FX and distribution accounting reconcile.
+                  </p>
+                </>
               ) : (
                 <EmptyPnlChart />
               )}

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -21,6 +21,7 @@ from app.api.strategies import (
     get_fired_signals,
     get_strategy_overview,
     get_strategy_owned_positions,
+    get_strategy_pnl_history,
     request_evidence_refresh,
     update_strategy_allocation,
     update_strategy_paper_pool,
@@ -181,6 +182,54 @@ def test_owned_pnl_excludes_manual_same_instrument_lifecycle(
     assert pnl.invested_capital == Decimal("100")
     assert pnl.owned_position_count == 1
     assert pnl.complete
+
+
+def test_realised_history_keeps_retired_versions_and_excludes_manual_positions(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    strategy_id = "retired-strategy"
+    strategy_version = "retired-strategy-v1"
+    instrument_id = 2453091
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id) VALUES (%s, 7453091)",
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO trade_events (
+            position_id, etoro_instrument_id, instrument_id, event_kind, side,
+            units, price, executed_at, fees_usd, realized_pnl_usd, source, raw_payload
+        ) VALUES
+          (7453091, %s, %s, 'close', 'sell', 1, 17, now(), 1, 7, 'etoro_history', '{}'::jsonb),
+          (7453092, %s, %s, 'close', 'sell', 1, 900, now(), 1, 890, 'etoro_history', '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id, instrument_id, instrument_id),
+    )
+
+    response = get_strategy_pnl_history(days=365, conn=ebull_test_conn)
+
+    assert response.basis == "exact_owned_realised_pnl_only"
+    assert response.total_return_available is False
+    assert response.benchmark_comparison_available is False
+    assert len(response.points) == 1
+    assert response.points[0].total_pnl == Decimal("7")
+    assert response.points[0].strategy_pnl == {strategy_id: Decimal("7")}
 
 
 def test_strategy_positions_show_only_exact_owned_trade_with_portfolio_valuation(
@@ -754,8 +803,13 @@ def test_disabled_automatic_trading_is_visible_as_an_entry_block(
 def test_operator_allocation_uses_session_identity_and_immutable_event(
     ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    from app.services import strategy_control_plane
+
     strategy_id = "s1-time-series-momentum"
     version = _current_versions()[strategy_id]
+    admitted_manifest: dict[str, Any] = dict(strategy_control_plane.STRATEGY_MANIFEST)
+    admitted_manifest[strategy_id] = SimpleNamespace(purpose="capital_candidate")
+    monkeypatch.setattr(strategy_control_plane, "STRATEGY_MANIFEST", admitted_manifest)
     ebull_test_conn.execute(
         """
         INSERT INTO strategy_promotions (


### PR DESCRIPTION
## Summary
- preserve exact-owned realised P&L from retired and superseded strategy versions in the shared-pot history
- keep manual positions excluded through the exact ownership join
- declare the endpoint basis as realised P&L only and explicitly mark total return and benchmark comparison unavailable
- explain the same boundary beside the chart and record the required F-0 accounting inputs in the viability plan

## Why
The chart filtered events to current manifest versions, so upgrading or retiring a strategy could make genuine shared-pot P&L disappear. It was also visually easy to read the cumulative close-event line as portfolio return despite lacking external capital flows, historical open-position marks, distributions, FX and benchmark identity.

## Validation
- integration test proves retired-version P&L remains and a same-instrument manual close is excluded
- 31 strategy monitoring/API tests passed
- 16 strategy-page tests passed
- frontend typecheck, pyright and ruff passed
- full pre-push gate passed, including fast suite and dev-DB smoke

Refs #2525
Refs #2437