### PR TITLE
Add exact-owned strategy wealth history

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -77,6 +77,7 @@ from app.services.strategy_position_manager import (
 )
 from app.services.strategy_recent_evidence import RECENT_EVIDENCE_WINDOWS
 from app.services.strategy_result import CORPUS_VERSION
+from app.services.strategy_wealth import load_strategy_wealth_history
 from app.services.sync_orchestrator.dispatcher import publish_manual_job_request_with_conn
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
 
@@ -327,6 +328,25 @@ class StrategyPnlHistoryResponse(BaseModel):
     total_return_available: Literal[False] = False
     benchmark_comparison_available: Literal[False] = False
     points: list[StrategyPnlHistoryPoint]
+
+
+class StrategyWealthHistoryPoint(BaseModel):
+    date: date
+    principal: Decimal
+    external_flow: Decimal
+    realised_pnl: Decimal | None
+    unrealised_pnl: Decimal | None
+    total_pnl: Decimal | None
+    pot_value: Decimal | None
+    complete: bool
+    incomplete_reasons: list[str]
+
+
+class StrategyWealthHistoryResponse(BaseModel):
+    basis: Literal["exact_owned_mark_to_market_nav"] = "exact_owned_mark_to_market_nav"
+    total_return_available: Literal[False] = False
+    benchmark_comparison_available: Literal[False] = False
+    points: list[StrategyWealthHistoryPoint]
 
 
 class StrategyOwnedPosition(BaseModel):
@@ -1449,6 +1469,30 @@ def get_strategy_pnl_history(
             )
         )
     return StrategyPnlHistoryResponse(points=points)
+
+
+@router.get("/wealth-history", response_model=StrategyWealthHistoryResponse)
+def get_strategy_wealth_history(
+    days: int = Query(default=365, ge=30, le=1825),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> StrategyWealthHistoryResponse:
+    """Return principal plus realised and historical open marks for the sleeve."""
+    return StrategyWealthHistoryResponse(
+        points=[
+            StrategyWealthHistoryPoint(
+                date=point.date,
+                principal=point.principal,
+                external_flow=point.external_flow,
+                realised_pnl=point.realised_pnl,
+                unrealised_pnl=point.unrealised_pnl,
+                total_pnl=point.total_pnl,
+                pot_value=point.pot_value,
+                complete=point.complete,
+                incomplete_reasons=list(point.incomplete_reasons),
+            )
+            for point in load_strategy_wealth_history(conn, days=days)
+        ]
+    )
 
 
 @router.put("/paper-pool", response_model=StrategyPaperPoolView)

--- a/app/services/portfolio_eod.py
+++ b/app/services/portfolio_eod.py
@@ -48,6 +48,10 @@ class PositionInput:
     amount: Decimal
     open_rate: Decimal
     is_buy: bool
+    # Native-currency P&L -> broker USD conversion fixed by the broker at
+    # entry.  Kept separate from display FX: strategy accounting is USD even
+    # when the operator views the main portfolio in GBP/EUR.
+    open_conversion_rate: Decimal = Decimal("1")
 
 
 @dataclass(frozen=True)
@@ -59,6 +63,7 @@ class PositionResult:
     close: Decimal | None
     value_display: Decimal | None
     price_status: PriceStatus
+    unrealised_pnl_usd: Decimal | None = None
 
 
 @dataclass(frozen=True)
@@ -112,13 +117,25 @@ def compute_eod_equity(
         # but stays correct if a leveraged/short row ever appears.
         if p.is_buy:
             value_native = p.amount + p.units * (p.close - p.open_rate)
+            pnl_native = p.units * (p.close - p.open_rate)
         else:
             value_native = p.amount + p.units * (p.open_rate - p.close)
+            pnl_native = p.units * (p.open_rate - p.close)
+        unrealised_pnl_usd = pnl_native * p.open_conversion_rate
         if p.native_ccy is None:
             # No currency to convert from → cannot price into display ccy.
             no_fx += 1
             results.append(
-                PositionResult(p.position_id, p.instrument_id, p.units, p.native_ccy, p.close, None, "no_fx")
+                PositionResult(
+                    p.position_id,
+                    p.instrument_id,
+                    p.units,
+                    p.native_ccy,
+                    p.close,
+                    None,
+                    "no_fx",
+                    unrealised_pnl_usd,
+                )
             )
             continue
         try:
@@ -128,13 +145,31 @@ def compute_eod_equity(
         except FxRateNotFound:
             no_fx += 1
             results.append(
-                PositionResult(p.position_id, p.instrument_id, p.units, p.native_ccy, p.close, None, "no_fx")
+                PositionResult(
+                    p.position_id,
+                    p.instrument_id,
+                    p.units,
+                    p.native_ccy,
+                    p.close,
+                    None,
+                    "no_fx",
+                    unrealised_pnl_usd,
+                )
             )
             continue
         positions_value += value_display
         priced += 1
         results.append(
-            PositionResult(p.position_id, p.instrument_id, p.units, p.native_ccy, p.close, value_display, "priced")
+            PositionResult(
+                p.position_id,
+                p.instrument_id,
+                p.units,
+                p.native_ccy,
+                p.close,
+                value_display,
+                "priced",
+                unrealised_pnl_usd,
+            )
         )
 
     cash_value = Decimal("0")
@@ -196,6 +231,7 @@ def _read_positions(conn: psycopg.Connection[Any], snapshot_date: date) -> list[
                 b.units,
                 b.amount,
                 b.open_rate,
+                b.open_conversion_rate,
                 b.is_buy,
                 i.currency AS native_ccy,
                 (
@@ -223,6 +259,7 @@ def _read_positions(conn: psycopg.Connection[Any], snapshot_date: date) -> list[
             amount=Decimal(str(r["amount"])),
             open_rate=Decimal(str(r["open_rate"])),
             is_buy=bool(r["is_buy"]),
+            open_conversion_rate=Decimal(str(r["open_conversion_rate"])),
         )
         for r in rows
     ]
@@ -343,8 +380,9 @@ def _write_snapshot(
                 """
                 INSERT INTO portfolio_eod_position_snapshots (
                     snapshot_date, position_id, instrument_id, units,
-                    close_price, native_currency, value_display, price_status
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    close_price, native_currency, value_display, price_status,
+                    unrealised_pnl_usd
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 [
                     (
@@ -356,6 +394,7 @@ def _write_snapshot(
                         r.native_ccy,
                         r.value_display,
                         r.price_status,
+                        r.unrealised_pnl_usd,
                     )
                     for r in equity.position_results
                 ],

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -132,6 +132,40 @@ def configure_paper_pool(
     current = load_paper_pool(conn)
     if current.enabled == enabled and current.capital_limit == capital_limit and current.capital_mode == capital_mode:
         raise StrategyControlError("paper pool change must alter enabled state, capital limit, or capital mode")
+    if current.event_id is not None and capital_limit < current.capital_limit:
+        # A lower principal is an external withdrawal from the virtual sleeve,
+        # not merely a cosmetic limit edit.  It cannot remove money already
+        # committed to an allocated lifecycle.  Realised losses reduce the
+        # withdrawable balance; known profits count only in compound mode.
+        committed_row = conn.execute(
+            """
+            SELECT COALESCE(SUM(decision.amount), 0)
+            FROM strategy_funding_decisions decision
+            JOIN strategy_deployments deployment
+              ON deployment.deployment_id=decision.deployment_id
+             AND deployment.mode='paper'
+            LEFT JOIN strategy_trades trade
+              ON trade.funding_decision_id=decision.funding_decision_id
+            WHERE decision.verdict='allocated'
+              AND (trade.strategy_trade_id IS NULL OR trade.status NOT IN ('closed', 'failed'))
+            """
+        ).fetchone()
+        assert committed_row is not None
+        committed = Decimal(str(committed_row[0]))
+        if committed:
+            # Local import keeps the governance module independent at import
+            # time while reusing the exact-owned, fail-closed reconciliation.
+            from app.services.strategy_monitoring import load_paper_realised_pnl
+
+            realised = load_paper_realised_pnl(conn)
+            if realised is None:
+                raise StrategyControlError("paper principal cannot be withdrawn while realised P&L is incomplete")
+            realised_delta = sum(realised.values(), Decimal("0"))
+            if capital_mode == "fixed":
+                realised_delta = min(realised_delta, Decimal("0"))
+            effective_after = max(Decimal("0"), capital_limit + realised_delta)
+            if effective_after < committed:
+                raise StrategyControlError("paper principal cannot be withdrawn below committed strategy capital")
     row = conn.execute(
         """
         INSERT INTO strategy_paper_pool_events (enabled,capital_limit,currency,capital_mode,changed_by,reason)

--- a/app/services/strategy_wealth.py
+++ b/app/services/strategy_wealth.py
@@ -1,0 +1,140 @@
+"""Compact, exact-owned strategy-pot wealth history.
+
+The strategy sleeve does not duplicate quotes or positions.  It joins the
+main portfolio's once-per-session position evidence to durable exact broker
+position ownership, then adds reconciled close P&L and the configured USD
+principal.  Missing marks or close P&L make a point incomplete; they are never
+coerced to zero.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+
+
+@dataclass(frozen=True)
+class StrategyWealthPoint:
+    date: date
+    principal: Decimal
+    external_flow: Decimal
+    realised_pnl: Decimal | None
+    unrealised_pnl: Decimal | None
+    total_pnl: Decimal | None
+    pot_value: Decimal | None
+    complete: bool
+    incomplete_reasons: tuple[str, ...]
+
+
+_WEALTH_SQL = """
+    WITH snapshots AS (
+        SELECT snapshot_date, computed_at
+        FROM portfolio_eod_snapshots
+        WHERE snapshot_date >= CURRENT_DATE - %(days)s
+    ), owned_marks AS (
+        SELECT snap.snapshot_date,
+               COUNT(own.ownership_id) AS expected_positions,
+               COUNT(pos.position_id) AS observed_positions,
+               COUNT(pos.position_id) FILTER (
+                   WHERE pos.position_id IS NOT NULL AND pos.unrealised_pnl_usd IS NULL
+               ) AS missing_marks,
+               COALESCE(SUM(pos.unrealised_pnl_usd), 0) AS unrealised_pnl
+        FROM snapshots snap
+        LEFT JOIN strategy_position_ownership own
+          ON (own.claimed_at AT TIME ZONE 'UTC')::date <= snap.snapshot_date
+         AND (own.released_at IS NULL OR (own.released_at AT TIME ZONE 'UTC')::date > snap.snapshot_date)
+        LEFT JOIN portfolio_eod_position_snapshots pos
+          ON pos.snapshot_date=snap.snapshot_date
+         AND pos.position_id=own.broker_position_id
+        GROUP BY snap.snapshot_date
+    ), realised AS (
+        SELECT snap.snapshot_date,
+               COALESCE(SUM(event.realized_pnl_usd), 0) AS realised_pnl,
+               COUNT(*) FILTER (
+                   WHERE event.event_id IS NOT NULL AND event.realized_pnl_usd IS NULL
+               ) AS missing_realised
+        FROM snapshots snap
+        LEFT JOIN strategy_position_ownership own ON TRUE
+        LEFT JOIN trade_events event
+          ON event.position_id=own.broker_position_id
+         AND event.event_kind='close'
+         AND (event.executed_at AT TIME ZONE 'UTC')::date <= snap.snapshot_date
+        GROUP BY snap.snapshot_date
+    ), released_without_close AS (
+        SELECT snap.snapshot_date, COUNT(own.ownership_id) AS missing_closes
+        FROM snapshots snap
+        JOIN strategy_position_ownership own
+          ON own.status='released'
+         AND (own.released_at AT TIME ZONE 'UTC')::date <= snap.snapshot_date
+        LEFT JOIN trade_events event
+          ON event.position_id=own.broker_position_id AND event.event_kind='close'
+        WHERE event.event_id IS NULL
+        GROUP BY snap.snapshot_date
+    )
+    SELECT snap.snapshot_date,
+           COALESCE(pool.capital_limit, 0) AS principal,
+           marks.expected_positions, marks.observed_positions, marks.missing_marks,
+           marks.unrealised_pnl, realised.realised_pnl, realised.missing_realised,
+           COALESCE(missing.missing_closes, 0) AS missing_closes
+    FROM snapshots snap
+    JOIN owned_marks marks USING (snapshot_date)
+    JOIN realised USING (snapshot_date)
+    LEFT JOIN released_without_close missing USING (snapshot_date)
+    LEFT JOIN LATERAL (
+        SELECT capital_limit
+        FROM strategy_paper_pool_events
+        WHERE (changed_at AT TIME ZONE 'UTC')::date <= snap.snapshot_date
+        ORDER BY strategy_paper_pool_event_id DESC
+        LIMIT 1
+    ) pool ON TRUE
+    ORDER BY snap.snapshot_date
+"""
+
+
+def load_strategy_wealth_history(conn: psycopg.Connection[Any], *, days: int = 365) -> list[StrategyWealthPoint]:
+    """Read a bounded daily strategy NAV series without periodic extra rows."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_WEALTH_SQL, {"days": days})
+        rows = list(cur.fetchall())
+
+    points: list[StrategyWealthPoint] = []
+    previous_principal = Decimal("0")
+    for row in rows:
+        principal = Decimal(str(row["principal"]))
+        reasons: list[str] = []
+        if int(row["observed_positions"]) != int(row["expected_positions"]):
+            reasons.append("owned_position_snapshot_missing")
+        if int(row["missing_marks"]):
+            reasons.append("owned_position_mark_missing")
+        if int(row["missing_realised"]):
+            reasons.append("realised_pnl_missing_from_history")
+        if int(row["missing_closes"]):
+            reasons.append("released_position_missing_close_history")
+
+        complete = not reasons
+        realised = Decimal(str(row["realised_pnl"])) if complete else None
+        unrealised = Decimal(str(row["unrealised_pnl"])) if complete else None
+        total = realised + unrealised if realised is not None and unrealised is not None else None
+        points.append(
+            StrategyWealthPoint(
+                date=row["snapshot_date"],
+                principal=principal,
+                external_flow=principal - previous_principal,
+                realised_pnl=realised,
+                unrealised_pnl=unrealised,
+                total_pnl=total,
+                pot_value=principal + total if total is not None else None,
+                complete=complete,
+                incomplete_reasons=tuple(reasons),
+            )
+        )
+        previous_principal = principal
+    return points
+
+
+__all__ = ["StrategyWealthPoint", "load_strategy_wealth_history"]

--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -122,13 +122,15 @@ the operator’s wealth comparison. This is not an unsourced vendor dependency:
   free series passes review, eBull reports prospective account total return beside
   price-only market context and refuses an external recent excess-return claim.
 
-Current implementation boundary, made explicit rather than inferred: the Strategies
-chart is a bounded cumulative sum of exact-owned realised broker P&L. It is not total
-return and has no benchmark comparison. Retired strategy versions remain in that
-shared-pot history; manual positions remain excluded by exact ownership. Open marks
-appear only in the current headline. A time-weighted return needs capital revisions as
-external flows plus reconciled historical open-position marks, distributions, FX and
-costs before either return field may become available.
+Current implementation boundary, made explicit rather than inferred: the legacy
+realised series remains available for audit, while the Strategies chart reads the
+main portfolio's compact EOD position evidence and joins it to exact automated
+ownership. It therefore shows daily realised plus historical open P&L without a
+second quote, feature or per-position strategy store. Manual positions are excluded
+structurally; missing marks/closes create a gap rather than zero. Pool-principal
+changes are separately identified as external flows. This is still not total return:
+distribution/cost reconciliation and the identity-safe recent benchmark remain open,
+so both return and benchmark fields continue to refuse availability.
 
 ### Candidate C-1 — opportunistic insider purchase reproduction
 

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -30,7 +30,7 @@ export function fetchFiredSignals(cursor: number | null, strategyId?: string): P
 }
 
 export function fetchStrategyPnlHistory(): Promise<StrategyPnlHistoryResponse> {
-  return apiFetch("/strategies/pnl-history");
+  return apiFetch("/strategies/wealth-history");
 }
 
 export function fetchStrategyOwnedPositions(): Promise<StrategyOwnedPositionsResponse> {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2591,12 +2591,18 @@ export interface StrategySizingUpdateResponse {
 
 export interface StrategyPnlHistoryPoint {
   date: string;
-  total_pnl: string;
-  strategy_pnl: Record<string, string>;
+  principal: string;
+  external_flow: string;
+  realised_pnl: string | null;
+  unrealised_pnl: string | null;
+  total_pnl: string | null;
+  pot_value: string | null;
+  complete: boolean;
+  incomplete_reasons: string[];
 }
 
 export interface StrategyPnlHistoryResponse {
-  basis: "exact_owned_realised_pnl_only";
+  basis: "exact_owned_mark_to_market_nav";
   total_return_available: false;
   benchmark_comparison_available: false;
   points: StrategyPnlHistoryPoint[];

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -185,7 +185,7 @@ describe("StrategiesPage", () => {
     vi.restoreAllMocks();
     vi.spyOn(strategiesApi, "fetchStrategyOverview").mockResolvedValue(OVERVIEW);
     vi.spyOn(strategiesApi, "fetchStrategyPnlHistory").mockResolvedValue({
-      basis: "exact_owned_realised_pnl_only",
+      basis: "exact_owned_mark_to_market_nav",
       total_return_available: false,
       benchmark_comparison_available: false,
       points: [],
@@ -342,17 +342,27 @@ describe("StrategiesPage", () => {
   it("shows observed portfolio measures and controls for an approved strategy", async () => {
     vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(approvedOverview());
     vi.mocked(strategiesApi.fetchStrategyPnlHistory).mockResolvedValue({
-      basis: "exact_owned_realised_pnl_only",
+      basis: "exact_owned_mark_to_market_nav",
       total_return_available: false,
       benchmark_comparison_available: false,
-      points: [{ date: "2026-08-09", total_pnl: "50", strategy_pnl: { "s1-time-series-momentum": "50" } }],
+      points: [{
+        date: "2026-08-09",
+        principal: "1000",
+        external_flow: "1000",
+        realised_pnl: "40",
+        unrealised_pnl: "10",
+        total_pnl: "50",
+        pot_value: "1050",
+        complete: true,
+        incomplete_reasons: [],
+      }],
     });
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     const performance = (await screen.findByText("Portfolio performance")).closest("section")!;
     expect(within(performance).getByText("US$50.00")).toBeInTheDocument();
     expect(within(performance).getByText("+1.25%")).toBeInTheDocument();
     expect(within(performance).getByText("+60.00%")).toBeInTheDocument();
-    expect(within(performance).getByText(/Cumulative realised P&L from exact automated positions/)).toBeInTheDocument();
+    expect(within(performance).getByText(/Daily realised plus open P&L from exact automated positions/)).toBeInTheDocument();
     expect(screen.getByText("1 approved")).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Enabled" })).toBeEnabled();
   });

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -207,7 +207,7 @@ function PnlTooltip({
   );
 }
 
-function PnlChart({ history }: { history: Array<{ date: string; total_pnl: string }> }) {
+function PnlChart({ history }: { history: Array<{ date: string; total_pnl: string | null }> }) {
   const theme = useChartTheme();
   const data = history.map((point) => ({ date: point.date, pnl: number(point.total_pnl) }));
   return (
@@ -230,7 +230,7 @@ function EmptyPnlChart() {
       <div className="bg-white/90 px-5 py-3 dark:bg-slate-900/90">
         <p className="text-sm font-medium text-slate-700 dark:text-slate-200">No automated P&amp;L yet</p>
         <p className="mt-1 max-w-sm text-xs text-slate-500">
-          The performance line begins when an automated position records a result.
+          The performance line begins after the first end-of-day strategy-pot snapshot.
         </p>
       </div>
     </div>
@@ -890,9 +890,10 @@ export function StrategiesPage() {
                 <>
                   <PnlChart history={pnlHistory.data.points} />
                   <p className="mt-2 text-xs text-slate-500">
-                    Cumulative realised P&amp;L from exact automated positions. Open-position marks are included in
-                    the headline only; total return and benchmark comparison remain unavailable until capital-flow,
-                    FX and distribution accounting reconcile.
+                    Daily realised plus open P&amp;L from exact automated positions; manual positions are excluded.
+                    Gaps mean an owned mark or close could not reconcile. Capital changes are recorded separately
+                    from performance; total return and benchmark comparison remain unavailable until distribution
+                    and benchmark accounting reconcile.
                   </p>
                 </>
               ) : (

--- a/sql/308_strategy_eod_unrealised_pnl.sql
+++ b/sql/308_strategy_eod_unrealised_pnl.sql
@@ -1,0 +1,12 @@
+-- 308_strategy_eod_unrealised_pnl.sql
+--
+-- F-0 portfolio truth: preserve the USD unrealised P&L already calculated
+-- while the broker position exists.  Exact strategy ownership can then join
+-- this compact, once-per-session evidence without copying quotes, features or
+-- broker payloads into another strategy-specific time series.
+
+ALTER TABLE portfolio_eod_position_snapshots
+    ADD COLUMN IF NOT EXISTS unrealised_pnl_usd NUMERIC(20,4);
+
+COMMENT ON COLUMN portfolio_eod_position_snapshots.unrealised_pnl_usd IS
+    'Causal EOD mark minus open basis in broker USD, using the position open conversion rate. NULL means the mark was unavailable; it must never be read as zero.';

--- a/sql/309_strategy_pool_principal_semantics.sql
+++ b/sql/309_strategy_pool_principal_semantics.sql
@@ -1,0 +1,8 @@
+-- 309_strategy_pool_principal_semantics.sql
+--
+-- F-0 portfolio truth: the configured amount is both the virtual sleeve's
+-- contributed principal and its execution authority.  A material change in
+-- that amount is therefore an external flow for performance accounting.
+
+COMMENT ON TABLE strategy_paper_pool_events IS
+    'Material operator revisions to shared paper strategy principal and its execution authority. Capital-limit deltas are external strategy-pot flows; enabled/mode-only revisions have zero flow. No scheduler heartbeat writes.';

--- a/tests/test_portfolio_eod.py
+++ b/tests/test_portfolio_eod.py
@@ -24,6 +24,7 @@ def _pos(
     amount: str = "0",
     open_rate: str = "0",
     is_buy: bool = True,
+    open_conversion_rate: str = "1",
 ) -> PositionInput:
     # Defaults amount=open_rate=0 reduce MTM (amount + units*(close-open_rate))
     # to units*close — the unleveraged-long identity the FX/counter tests assert.
@@ -37,6 +38,7 @@ def _pos(
         amount=Decimal(amount),
         open_rate=Decimal(open_rate),
         is_buy=is_buy,
+        open_conversion_rate=Decimal(open_conversion_rate),
     )
 
 
@@ -76,6 +78,35 @@ class TestComputeEodEquity:
             [_pos(1, "5", "GBP", "8", amount="100", open_rate="10", is_buy=False)], [], "GBP", RATES
         )
         assert eq.positions_value == Decimal("110")
+
+    def test_preserves_strategy_unrealised_pnl_in_broker_usd(self) -> None:
+        eq = compute_eod_equity(
+            [
+                _pos(
+                    1,
+                    "5",
+                    "GBP",
+                    "12",
+                    amount="100",
+                    open_rate="10",
+                    open_conversion_rate="1.25",
+                )
+            ],
+            [],
+            "GBP",
+            RATES,
+        )
+        assert eq.position_results[0].unrealised_pnl_usd == Decimal("12.50")
+
+    def test_missing_display_fx_does_not_discard_known_usd_pnl(self) -> None:
+        eq = compute_eod_equity(
+            [_pos(1, "5", "EUR", "12", amount="100", open_rate="10", open_conversion_rate="1.10")],
+            [],
+            "GBP",
+            RATES,
+        )
+        assert eq.position_results[0].price_status == "no_fx"
+        assert eq.position_results[0].unrealised_pnl_usd == Decimal("11.00")
 
     def test_mtm_equals_units_close_for_unleveraged_long(self) -> None:
         # amount == units*open_rate → MTM collapses to units*mark (the v1 case).

--- a/tests/test_portfolio_eod_db.py
+++ b/tests/test_portfolio_eod_db.py
@@ -83,6 +83,7 @@ def test_read_positions_carries_close_forward(ebull_test_conn: psycopg.Connectio
     assert rows[0].close == Decimal("20")
     assert rows[0].native_ccy == "USD"
     assert rows[0].units == Decimal("3")
+    assert rows[0].open_conversion_rate == Decimal("1")
 
 
 def test_read_positions_excludes_synthetic_ids(ebull_test_conn: psycopg.Connection[Any]) -> None:  # noqa: F811
@@ -233,9 +234,11 @@ def test_write_snapshot_is_idempotent(ebull_test_conn: psycopg.Connection[Any]) 
         "SELECT COUNT(*), MAX(total_value) FROM portfolio_eod_snapshots WHERE snapshot_date = %s", (d,)
     ).fetchone()
     pos_row = conn.execute(
-        "SELECT COUNT(*) FROM portfolio_eod_position_snapshots WHERE snapshot_date = %s", (d,)
+        "SELECT COUNT(*), MAX(unrealised_pnl_usd) FROM portfolio_eod_position_snapshots WHERE snapshot_date = %s",
+        (d,),
     ).fetchone()
     assert snap_row is not None and pos_row is not None
     assert snap_row[0] == 1
     assert pos_row[0] == 1
+    assert pos_row[1] is None
     assert snap_row[1] == Decimal("18.00")

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -16,6 +16,7 @@ from app.services.strategy_control_plane import (
     assert_exact_position_owned,
     claim_exact_position,
     configure_deployment,
+    configure_paper_pool,
     create_strategy_trade,
     current_stage,
     decide_funding,
@@ -285,6 +286,34 @@ def test_deployment_has_one_current_row_and_complete_history(
     assert conn.execute(
         "SELECT revision, capital_limit, enabled FROM strategy_deployment_events ORDER BY revision"
     ).fetchall() == [(1, Decimal("1000.000000"), True), (2, Decimal("750.000000"), False)]
+
+
+def test_paper_principal_cannot_be_withdrawn_below_committed_capital(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    _instrument(conn)
+    signal_id = _signal(conn)
+    _paper_stage(conn)
+    _deployment_and_trade(conn, signal_id)
+    configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("1000"),
+        changed_by="operator",
+        reason="fund virtual sleeve",
+    )
+
+    with pytest.raises(StrategyControlError, match="below committed strategy capital"):
+        configure_paper_pool(
+            conn,
+            enabled=False,
+            capital_limit=Decimal("99"),
+            changed_by="operator",
+            reason="invalid withdrawal",
+        )
+
+    assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
 
 
 def test_same_instrument_manual_position_is_never_inferred_as_owned(

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -232,6 +232,85 @@ def test_realised_history_keeps_retired_versions_and_excludes_manual_positions(
     assert response.points[0].strategy_pnl == {strategy_id: Decimal("7")}
 
 
+def test_wealth_history_combines_principal_realised_and_eod_open_marks_without_manual_positions(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    from app.api.strategies import get_strategy_wealth_history
+
+    strategy_id = "wealth-strategy"
+    strategy_version = "wealth-strategy-v1"
+    instrument_id = 2453093
+    _instrument(ebull_test_conn, instrument_id)
+    signal_id = _signal(
+        ebull_test_conn,
+        instrument_id=instrument_id,
+        strategy_id=strategy_id,
+        strategy_version=strategy_version,
+        signal_date="2026-08-01",
+        fill_price=Decimal("10"),
+    )
+    deployment_id = _deployment(ebull_test_conn, strategy_id, strategy_version)
+    trade_id = _funded_trade(
+        ebull_test_conn,
+        signal_id=signal_id,
+        deployment_id=deployment_id,
+        instrument_id=instrument_id,
+    )
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id, broker_position_id) VALUES (%s, 7453093)",
+        (trade_id,),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_paper_pool_events
+            (enabled, capital_limit, currency, capital_mode, changed_by, reason)
+        VALUES (true, 1000, 'USD', 'fixed', 'test', 'fund sleeve')
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO trade_events (
+            position_id, etoro_instrument_id, instrument_id, event_kind, side,
+            units, price, executed_at, fees_usd, realized_pnl_usd, source, raw_payload
+        ) VALUES (7453093, %s, %s, 'close', 'sell', 1, 17, now(), 1, 7, 'etoro_history', '{}'::jsonb)
+        """,
+        (instrument_id, instrument_id),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO portfolio_eod_snapshots (
+            snapshot_date, display_currency, total_value, positions_value, cash_value,
+            positions_total, positions_priced, computed_at
+        ) VALUES (CURRENT_DATE, 'GBP', 9999, 9999, 0, 2, 2, now())
+        """
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO portfolio_eod_position_snapshots (
+            snapshot_date, position_id, instrument_id, units, close_price,
+            native_currency, value_display, price_status, unrealised_pnl_usd
+        ) VALUES
+          (CURRENT_DATE, 7453093, %s, 1, 20, 'USD', 20, 'priced', 10),
+          (CURRENT_DATE, 7453094, %s, 1, 999, 'USD', 999, 'priced', 999)
+        """,
+        (instrument_id, instrument_id),
+    )
+
+    response = get_strategy_wealth_history(days=365, conn=ebull_test_conn)
+
+    assert response.basis == "exact_owned_mark_to_market_nav"
+    assert response.total_return_available is False
+    assert len(response.points) == 1
+    point = response.points[0]
+    assert point.principal == Decimal("1000")
+    assert point.external_flow == Decimal("1000")
+    assert point.realised_pnl == Decimal("7")
+    assert point.unrealised_pnl == Decimal("10")
+    assert point.total_pnl == Decimal("17")
+    assert point.pot_value == Decimal("1017")
+    assert point.complete
+
+
 def test_strategy_positions_show_only_exact_owned_trade_with_portfolio_valuation(
     ebull_test_conn: psycopg.Connection[tuple],
 ) -> None:


### PR DESCRIPTION
## Outcome\n\nAdvances #2525 F-0 portfolio truth without adding a strategy quote/feature dump.\n\n- preserves broker-USD unrealised P&L on the existing once-per-session portfolio position snapshot\n- derives daily strategy-pot principal, exact-owned realised P&L, exact-owned historical open marks, total P&L and wealth value\n- excludes manual positions structurally and emits gaps for missing marks/closes instead of zeros\n- treats pool-principal changes as external flows and refuses withdrawals below committed automated capital\n- switches the Strategies performance chart from close-only realised history to exact-owned EOD mark-to-market history\n- keeps total-return and benchmark claims unavailable until distributions/costs and an identity-safe recent benchmark reconcile\n\n## Storage\n\nOne nullable numeric column on rows already written once per EOD position snapshot. No new quote, feature, heartbeat, or strategy-position time-series table.\n\n## Validation\n\n- full local pre-push gate green (ruff, formatting, pyright, fast tests, smoke/app boot, frontend guards)\n- affected backend suites: 50 passed\n- Strategies UI: 16 passed; TypeScript clean\n\nRefs #2525