### PR TITLE
Guard strategy money aggregates from join fanout

### DIFF
--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -141,13 +141,23 @@ def configure_paper_pool(
             """
             SELECT COALESCE(SUM(decision.amount), 0)
             FROM strategy_funding_decisions decision
-            JOIN strategy_deployments deployment
-              ON deployment.deployment_id=decision.deployment_id
-             AND deployment.mode='paper'
-            LEFT JOIN strategy_trades trade
-              ON trade.funding_decision_id=decision.funding_decision_id
             WHERE decision.verdict='allocated'
-              AND (trade.strategy_trade_id IS NULL OR trade.status NOT IN ('closed', 'failed'))
+              AND EXISTS (
+                  SELECT 1 FROM strategy_deployments deployment
+                  WHERE deployment.deployment_id=decision.deployment_id
+                    AND deployment.mode='paper'
+              )
+              AND (
+                  NOT EXISTS (
+                      SELECT 1 FROM strategy_trades trade
+                      WHERE trade.funding_decision_id=decision.funding_decision_id
+                  )
+                  OR EXISTS (
+                      SELECT 1 FROM strategy_trades trade
+                      WHERE trade.funding_decision_id=decision.funding_decision_id
+                        AND trade.status NOT IN ('closed', 'failed')
+                  )
+              )
             """
         ).fetchone()
         assert committed_row is not None

--- a/app/services/strategy_wealth.py
+++ b/app/services/strategy_wealth.py
@@ -52,6 +52,12 @@ _WEALTH_SQL = """
           ON pos.snapshot_date=snap.snapshot_date
          AND pos.position_id=own.broker_position_id
         GROUP BY snap.snapshot_date
+    ), owned_broker_positions AS (
+        -- broker_position_id is UNIQUE in the ownership ledger today.  Keep
+        -- the aggregation boundary explicit so a future history-table shape
+        -- cannot multiply one close event before SUM(realized_pnl_usd).
+        SELECT DISTINCT broker_position_id
+        FROM strategy_position_ownership
     ), realised AS (
         SELECT snap.snapshot_date,
                COALESCE(SUM(event.realized_pnl_usd), 0) AS realised_pnl,
@@ -59,14 +65,14 @@ _WEALTH_SQL = """
                    WHERE event.event_id IS NOT NULL AND event.realized_pnl_usd IS NULL
                ) AS missing_realised
         FROM snapshots snap
-        LEFT JOIN strategy_position_ownership own ON TRUE
+        LEFT JOIN owned_broker_positions own ON TRUE
         LEFT JOIN trade_events event
           ON event.position_id=own.broker_position_id
          AND event.event_kind='close'
          AND (event.executed_at AT TIME ZONE 'UTC')::date <= snap.snapshot_date
         GROUP BY snap.snapshot_date
     ), released_without_close AS (
-        SELECT snap.snapshot_date, COUNT(own.ownership_id) AS missing_closes
+        SELECT snap.snapshot_date, COUNT(DISTINCT own.broker_position_id) AS missing_closes
         FROM snapshots snap
         JOIN strategy_position_ownership own
           ON own.status='released'

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -3911,3 +3911,10 @@ Two things S-4 adds to the prevention above:
 - Root cause: the boundary was attached to the feature being added (S-4 level outcomes) instead of to the property it protects (every price-derived state consumer). The result looked fail-closed at the outcome layer while other strategies still admitted cross-scale inputs.
 - Prevention: when adding a structural corpus boundary, enumerate every consumer of the affected series contract, including alternate per-series and cross-sectional paths. A branch-specific test is insufficient; pin at least one consumer on each distinct path and assert both the final pre-boundary bar and post-boundary warm-up behaviour.
 - Enforced in: this log; `app/services/backtest_run.py::_signals_for` and `::_stage_cross_sectional_segments`; `tests/test_backtest_run.py::TestSeriesBreakBoundary` (per-series S-4 and cross-sectional S-2 restart cases).
+
+## Aggregate the entity grain before joining its history (#2531, 2026-08-11)
+
+- Symptom: review flagged strategy realised P&L and committed capital queries whose current joins are one-to-one only because `strategy_position_ownership.broker_position_id` and `strategy_trades.funding_decision_id` are schema-`UNIQUE`.
+- Risk: a later legitimate history-table redesign could turn either relationship one-to-many and silently multiply money inside `SUM`, even though the query itself still looks valid.
+- Prevention: establish the monetary grain explicitly before aggregation. Select distinct exact broker-position IDs before joining close events; use `EXISTS` for lifecycle-state membership when summing one funding decision's amount. Do not rely on a distant uniqueness constraint to make a money aggregation correct.
+- Enforced in: this log; `app/services/strategy_wealth.py` `owned_broker_positions` CTE; `app/services/strategy_control_plane.py::configure_paper_pool` committed-capital `EXISTS` predicates.


### PR DESCRIPTION
## Outcome\n\nFollow-up to #2531 and its automated review.\n\n- pre-aggregates exact broker-position ownership before summing close P&L\n- uses membership EXISTS predicates before summing one funding decision amount\n- records the monetary-grain prevention rule for future history-table changes\n\nThe current schema already enforces both joins as one-to-one with UNIQUE constraints; this makes correctness explicit and robust if those storage shapes later evolve.\n\n## Validation\n\nFull local pre-push gate green, including pyright, fast tests, smoke/app boot and frontend guards.\n\nRefs #2525