### PR TITLE
Recover and close the rejected insider candidate

### DIFF
--- a/app/services/insider_purchase_candidate.py
+++ b/app/services/insider_purchase_candidate.py
@@ -329,6 +329,20 @@ def _load_research_resolution(conn: psycopg.Connection[Any]) -> tuple[dict[tuple
     return exact, unique
 
 
+def resolve_research_instrument(
+    issuer_cik: str,
+    issuer_symbol: str,
+    exact: Mapping[tuple[str, str], int],
+    unique: Mapping[str, int],
+) -> tuple[int | None, bool]:
+    """Resolve exact corpus symbol first; return whether CIK fallback was used."""
+    exact_match = exact.get((issuer_cik, issuer_symbol))
+    if exact_match is not None:
+        return exact_match, False
+    fallback = unique.get(issuer_cik)
+    return fallback, fallback is not None
+
+
 def enrich_point_in_time(
     conn: psycopg.Connection[Any], purchases: Sequence[PurchaseObservation]
 ) -> tuple[tuple[PurchaseObservation, ...], Counter[str]]:
@@ -350,14 +364,13 @@ def enrich_point_in_time(
     counters: Counter[str] = Counter()
     output: list[PurchaseObservation] = []
     for purchase in purchases:
-        # Market-cap weighting cannot use a combined issuer share count with
-        # one arbitrarily selected class price. A CIK with multiple corpus
-        # series is therefore refused even when the current symbol matches.
-        instrument_id = unique.get(purchase.issuer_cik)
+        instrument_id, used_fallback = resolve_research_instrument(
+            purchase.issuer_cik, purchase.issuer_symbol, exact, unique
+        )
         if instrument_id is None:
             counters["unresolved_or_multiclass_research_series"] += 1
             continue
-        if exact.get((purchase.issuer_cik, purchase.issuer_symbol)) != instrument_id:
+        if used_fallback:
             counters["unique_cik_symbol_history_fallback"] += 1
         acceptance = accepted.get(purchase.accession_number)
         if acceptance is None:
@@ -427,5 +440,6 @@ __all__ = [
     "enrich_point_in_time",
     "enrich_classified_point_in_time",
     "load_archive_purchases",
+    "resolve_research_instrument",
     "validate_archive_sequence",
 ]

--- a/app/services/insider_purchase_candidate.py
+++ b/app/services/insider_purchase_candidate.py
@@ -350,12 +350,15 @@ def enrich_point_in_time(
     counters: Counter[str] = Counter()
     output: list[PurchaseObservation] = []
     for purchase in purchases:
-        instrument_id = exact.get((purchase.issuer_cik, purchase.issuer_symbol))
-        if instrument_id is None:
-            instrument_id = unique.get(purchase.issuer_cik)
+        # Market-cap weighting cannot use a combined issuer share count with
+        # one arbitrarily selected class price. A CIK with multiple corpus
+        # series is therefore refused even when the current symbol matches.
+        instrument_id = unique.get(purchase.issuer_cik)
         if instrument_id is None:
             counters["unresolved_or_multiclass_research_series"] += 1
             continue
+        if exact.get((purchase.issuer_cik, purchase.issuer_symbol)) != instrument_id:
+            counters["unique_cik_symbol_history_fallback"] += 1
         acceptance = accepted.get(purchase.accession_number)
         if acceptance is None:
             counters["accepted_at_missing_historical_fallback"] += 1
@@ -368,7 +371,7 @@ def enrich_classified_point_in_time(
     conn: psycopg.Connection[Any], classified: Sequence[ClassifiedPurchase]
 ) -> tuple[tuple[ClassifiedPurchase, ...], Counter[str]]:
     enriched, counters = enrich_point_in_time(conn, [item.observation for item in classified])
-    by_identity = {
+    by_identity: dict[tuple[str, str, int, int], InsiderClass] = {
         (
             item.observation.accession_number,
             item.observation.filer_cik,

--- a/app/services/insider_purchase_candidate.py
+++ b/app/services/insider_purchase_candidate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import csv
 import hashlib
 import io
+import re
 import zipfile
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping, Sequence
@@ -57,6 +58,7 @@ class ClassifiedPurchase:
 @dataclass(frozen=True)
 class InsiderSourceBuild:
     purchases: tuple[PurchaseObservation, ...]
+    source_classified: tuple[ClassifiedPurchase, ...]
     classified: tuple[ClassifiedPurchase, ...]
     refusals: Mapping[str, int]
     archive_manifest_sha256: str
@@ -107,7 +109,36 @@ def _archive_manifest_sha256(paths: Sequence[Path]) -> str:
     return digest.hexdigest()
 
 
-def load_archive_purchases(paths: Sequence[Path]) -> tuple[tuple[PurchaseObservation, ...], Counter[str], str]:
+_ARCHIVE_NAME = re.compile(r"^(?P<year>\d{4})q(?P<quarter>[1-4])_form345\.zip$")
+
+
+def validate_archive_sequence(paths: Sequence[Path], *, expected_last_quarter: str) -> None:
+    """Require one contiguous, explicitly pinned 2019q1..frontier sequence."""
+    labels: list[tuple[int, int]] = []
+    for path in paths:
+        match = _ARCHIVE_NAME.fullmatch(path.name)
+        if match is None:
+            raise ValueError(f"unexpected insider archive filename: {path.name}")
+        labels.append((int(match.group("year")), int(match.group("quarter"))))
+    if len(labels) != len(set(labels)):
+        raise ValueError("duplicate insider archive quarter")
+    labels.sort()
+    expected_match = re.fullmatch(r"(?P<year>\d{4})q(?P<quarter>[1-4])", expected_last_quarter)
+    if expected_match is None:
+        raise ValueError("expected_last_quarter must be YYYYqN")
+    expected_last = (int(expected_match.group("year")), int(expected_match.group("quarter")))
+    expected: list[tuple[int, int]] = []
+    cursor = (2019, 1)
+    while cursor <= expected_last:
+        expected.append(cursor)
+        cursor = (cursor[0] + 1, 1) if cursor[1] == 4 else (cursor[0], cursor[1] + 1)
+    if labels != expected:
+        raise ValueError(f"archives must be the contiguous 2019q1..{expected_last_quarter} sequence")
+
+
+def load_archive_purchases(
+    paths: Sequence[Path], *, expected_last_quarter: str
+) -> tuple[tuple[PurchaseObservation, ...], Counter[str], str]:
     """Load eligible code-P rows from exact SEC quarterly archives.
 
     Exclusion counters are terminal and mutually exclusive over every
@@ -116,13 +147,23 @@ def load_archive_purchases(paths: Sequence[Path]) -> tuple[tuple[PurchaseObserva
     """
     if not paths:
         raise ValueError("at least one insider archive is required")
+    validate_archive_sequence(paths, expected_last_quarter=expected_last_quarter)
     missing = [path for path in paths if not path.is_file()]
     if missing:
         raise FileNotFoundError(f"insider archives missing: {missing}")
 
     counters: Counter[str] = Counter()
-    aggregated: dict[tuple[str, str, str, date, date], PurchaseObservation] = {}
-    seen_accessions: set[str] = set()
+    aggregated: dict[tuple[str, str, str, int, int, date], PurchaseObservation] = {}
+    accession_counts: Counter[str] = Counter()
+    for path in sorted(paths, key=lambda item: item.name):
+        with zipfile.ZipFile(path) as archive:
+            accession_counts.update(
+                row.get("ACCESSION_NUMBER", "").strip()
+                for row in _open_tsv(archive, "SUBMISSION.tsv")
+                if row.get("ACCESSION_NUMBER", "").strip()
+            )
+    duplicate_accessions = {accession for accession, count in accession_counts.items() if count > 1}
+    counters["duplicate_archive_accessions"] = len(duplicate_accessions)
 
     for path in sorted(paths, key=lambda item: item.name):
         with zipfile.ZipFile(path) as archive:
@@ -136,11 +177,6 @@ def load_archive_purchases(paths: Sequence[Path]) -> tuple[tuple[PurchaseObserva
                 accession = row.get("ACCESSION_NUMBER", "").strip()
                 if accession:
                     owners[accession].append(row)
-
-            archive_accessions = set(submissions)
-            duplicate_accessions = archive_accessions & seen_accessions
-            seen_accessions.update(archive_accessions)
-            counters["duplicate_archive_accessions"] += len(duplicate_accessions)
 
             for row in _open_tsv(archive, "NONDERIV_TRANS.tsv", "NON_DERIV_TRANS.tsv"):
                 counters["nonderivative_transaction_rows"] += 1
@@ -201,7 +237,14 @@ def load_archive_purchases(paths: Sequence[Path]) -> tuple[tuple[PurchaseObserva
                     counters["excluded_issuer_identity_missing"] += 1
                     continue
 
-                key = (issuer_cik, accession, filer_cik, transaction_date, filed_date)
+                key = (
+                    issuer_cik,
+                    accession,
+                    filer_cik,
+                    transaction_date.year,
+                    transaction_date.month,
+                    filed_date,
+                )
                 value = shares * price
                 existing = aggregated.get(key)
                 if existing is None:
@@ -215,7 +258,11 @@ def load_archive_purchases(paths: Sequence[Path]) -> tuple[tuple[PurchaseObserva
                         disclosed_value=value,
                     )
                 else:
-                    aggregated[key] = replace(existing, disclosed_value=existing.disclosed_value + value)
+                    aggregated[key] = replace(
+                        existing,
+                        transaction_date=min(existing.transaction_date, transaction_date),
+                        disclosed_value=existing.disclosed_value + value,
+                    )
                 counters["eligible_transaction_rows"] += 1
 
     purchases = tuple(
@@ -261,9 +308,8 @@ def classify_purchases(
 def _load_research_resolution(conn: psycopg.Connection[Any]) -> tuple[dict[tuple[str, str], int], dict[str, int]]:
     rows = conn.execute(
         """
-        SELECT lpad(e.identifier_value, 10, '0'), upper(i.symbol), s.instrument_id
+        SELECT lpad(e.identifier_value, 10, '0'), upper(s.vendor_symbol), s.instrument_id
         FROM research_price_series s
-        JOIN instruments i ON i.instrument_id = s.instrument_id
         JOIN external_identifiers e
           ON e.instrument_id = s.instrument_id
          AND e.provider = 'sec'
@@ -318,13 +364,47 @@ def enrich_point_in_time(
     return tuple(output), counters
 
 
-def build_source(conn: psycopg.Connection[Any], paths: Sequence[Path]) -> InsiderSourceBuild:
-    purchases, load_counts, manifest_digest = load_archive_purchases(paths)
-    enriched, resolution_counts = enrich_point_in_time(conn, purchases)
-    classified, classification_counts = classify_purchases(enriched)
+def enrich_classified_point_in_time(
+    conn: psycopg.Connection[Any], classified: Sequence[ClassifiedPurchase]
+) -> tuple[tuple[ClassifiedPurchase, ...], Counter[str]]:
+    enriched, counters = enrich_point_in_time(conn, [item.observation for item in classified])
+    by_identity = {
+        (
+            item.observation.accession_number,
+            item.observation.filer_cik,
+            item.observation.transaction_date.year,
+            item.observation.transaction_date.month,
+        ): item.insider_class
+        for item in classified
+    }
+    output = tuple(
+        ClassifiedPurchase(
+            observation=observation,
+            insider_class=by_identity[
+                (
+                    observation.accession_number,
+                    observation.filer_cik,
+                    observation.transaction_date.year,
+                    observation.transaction_date.month,
+                )
+            ],
+        )
+        for observation in enriched
+    )
+    return output, counters
+
+
+def build_source(
+    conn: psycopg.Connection[Any], paths: Sequence[Path], *, expected_last_quarter: str
+) -> InsiderSourceBuild:
+    purchases, load_counts, manifest_digest = load_archive_purchases(paths, expected_last_quarter=expected_last_quarter)
+    source_classified, classification_counts = classify_purchases(purchases)
+    classified, resolution_counts = enrich_classified_point_in_time(conn, source_classified)
     counts = load_counts + resolution_counts + classification_counts
+    counts["survivor_only_research_corpus_promotion_refusal"] = 1
     return InsiderSourceBuild(
-        purchases=enriched,
+        purchases=purchases,
+        source_classified=source_classified,
         classified=classified,
         refusals=dict(sorted(counts.items())),
         archive_manifest_sha256=manifest_digest,
@@ -342,5 +422,7 @@ __all__ = [
     "build_source",
     "classify_purchases",
     "enrich_point_in_time",
+    "enrich_classified_point_in_time",
     "load_archive_purchases",
+    "validate_archive_sequence",
 ]

--- a/app/services/insider_purchase_candidate.py
+++ b/app/services/insider_purchase_candidate.py
@@ -305,6 +305,20 @@ def classify_purchases(
     return tuple(classified), counters
 
 
+def build_research_resolution(
+    rows: Iterable[tuple[str, str, int]],
+) -> tuple[dict[tuple[str, str], int], dict[str, int]]:
+    """Build only unambiguous exact and unique-CIK resolution maps."""
+    exact_candidates: dict[tuple[str, str], set[int]] = defaultdict(set)
+    by_cik: dict[str, set[int]] = defaultdict(set)
+    for cik, symbol, instrument_id in rows:
+        exact_candidates[(str(cik), str(symbol))].add(int(instrument_id))
+        by_cik[str(cik)].add(int(instrument_id))
+    exact = {key: next(iter(ids)) for key, ids in exact_candidates.items() if len(ids) == 1}
+    unique = {cik: next(iter(ids)) for cik, ids in by_cik.items() if len(ids) == 1}
+    return exact, unique
+
+
 def _load_research_resolution(conn: psycopg.Connection[Any]) -> tuple[dict[tuple[str, str], int], dict[str, int]]:
     rows = conn.execute(
         """
@@ -320,13 +334,7 @@ def _load_research_resolution(conn: psycopg.Connection[Any]) -> tuple[dict[tuple
         """,
         (CORPUS_VENDORS[0],),
     ).fetchall()
-    exact: dict[tuple[str, str], int] = {}
-    by_cik: dict[str, set[int]] = defaultdict(set)
-    for cik, symbol, instrument_id in rows:
-        exact[(str(cik), str(symbol))] = int(instrument_id)
-        by_cik[str(cik)].add(int(instrument_id))
-    unique = {cik: next(iter(ids)) for cik, ids in by_cik.items() if len(ids) == 1}
-    return exact, unique
+    return build_research_resolution((str(cik), str(symbol), int(instrument_id)) for cik, symbol, instrument_id in rows)
 
 
 def resolve_research_instrument(
@@ -436,6 +444,7 @@ __all__ = [
     "InsiderSourceBuild",
     "PurchaseObservation",
     "build_source",
+    "build_research_resolution",
     "classify_purchases",
     "enrich_point_in_time",
     "enrich_classified_point_in_time",

--- a/app/services/insider_purchase_candidate.py
+++ b/app/services/insider_purchase_candidate.py
@@ -1,0 +1,346 @@
+"""Source-only construction for the preregistered #2480 candidate.
+
+This module deliberately has no price/return reader.  It can therefore be
+reviewed, tested and run before the sealed recent outcome interval is opened.
+Contract: ``docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md``.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import zipfile
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Final, Literal
+
+import psycopg
+
+from app.services.strategy_result import CORPUS_VENDORS
+
+TRIAL_ID: Final = "form4-code-p-opportunistic-purchase-v1"
+ARCHIVE_FIRST_QUARTER: Final = "2019q1"
+PRIMARY_START: Final = date(2022, 1, 1)
+MAX_FILING_LAG_DAYS: Final = 5
+
+InsiderClass = Literal["routine", "opportunistic"]
+
+
+@dataclass(frozen=True)
+class PurchaseObservation:
+    issuer_cik: str
+    issuer_symbol: str
+    accession_number: str
+    filer_cik: str
+    transaction_date: date
+    filed_date: date
+    disclosed_value: Decimal
+    accepted_at: datetime | None = None
+    instrument_id: int | None = None
+
+
+@dataclass(frozen=True)
+class ClassifiedPurchase:
+    observation: PurchaseObservation
+    insider_class: InsiderClass
+
+    @property
+    def signal_month(self) -> tuple[int, int]:
+        return self.observation.filed_date.year, self.observation.filed_date.month
+
+
+@dataclass(frozen=True)
+class InsiderSourceBuild:
+    purchases: tuple[PurchaseObservation, ...]
+    classified: tuple[ClassifiedPurchase, ...]
+    refusals: Mapping[str, int]
+    archive_manifest_sha256: str
+
+
+def _parse_date(value: str | None) -> date | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    for fmt in ("%d-%b-%Y", "%d-%b-%y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(text.title(), fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _positive_decimal(value: str | None) -> Decimal | None:
+    try:
+        parsed = Decimal((value or "").strip())
+    except InvalidOperation, ValueError:
+        return None
+    return parsed if parsed.is_finite() and parsed > 0 else None
+
+
+def _open_tsv(archive: zipfile.ZipFile, *names: str) -> Iterable[dict[str, str]]:
+    available = set(archive.namelist())
+    selected = next((name for name in names if name in available), None)
+    if selected is None:
+        selected = next(
+            (item for name in names for item in available if item.endswith("/" + name)),
+            None,
+        )
+    if selected is None:
+        raise ValueError(f"archive is missing required table {names[0]}")
+    with archive.open(selected) as raw:
+        text = io.TextIOWrapper(raw, encoding="utf-8", newline="")
+        yield from csv.DictReader(text, delimiter="\t")
+
+
+def _archive_manifest_sha256(paths: Sequence[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(paths, key=lambda item: item.name):
+        digest.update(path.name.encode())
+        digest.update(b"\0")
+        with path.open("rb") as handle:
+            digest.update(hashlib.file_digest(handle, "sha256").digest())
+    return digest.hexdigest()
+
+
+def load_archive_purchases(paths: Sequence[Path]) -> tuple[tuple[PurchaseObservation, ...], Counter[str], str]:
+    """Load eligible code-P rows from exact SEC quarterly archives.
+
+    Exclusion counters are terminal and mutually exclusive over every
+    NONDERIV_TRANS row, so ``eligible_transaction_rows + excluded_*`` reconciles
+    to ``nonderivative_transaction_rows``.
+    """
+    if not paths:
+        raise ValueError("at least one insider archive is required")
+    missing = [path for path in paths if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(f"insider archives missing: {missing}")
+
+    counters: Counter[str] = Counter()
+    aggregated: dict[tuple[str, str, str, date, date], PurchaseObservation] = {}
+    seen_accessions: set[str] = set()
+
+    for path in sorted(paths, key=lambda item: item.name):
+        with zipfile.ZipFile(path) as archive:
+            submissions = {
+                row.get("ACCESSION_NUMBER", "").strip(): row
+                for row in _open_tsv(archive, "SUBMISSION.tsv")
+                if row.get("ACCESSION_NUMBER", "").strip()
+            }
+            owners: dict[str, list[dict[str, str]]] = defaultdict(list)
+            for row in _open_tsv(archive, "REPORTINGOWNER.tsv", "REPORTING_OWNER.tsv"):
+                accession = row.get("ACCESSION_NUMBER", "").strip()
+                if accession:
+                    owners[accession].append(row)
+
+            archive_accessions = set(submissions)
+            duplicate_accessions = archive_accessions & seen_accessions
+            seen_accessions.update(archive_accessions)
+            counters["duplicate_archive_accessions"] += len(duplicate_accessions)
+
+            for row in _open_tsv(archive, "NONDERIV_TRANS.tsv", "NON_DERIV_TRANS.tsv"):
+                counters["nonderivative_transaction_rows"] += 1
+                accession = row.get("ACCESSION_NUMBER", "").strip()
+                if accession in duplicate_accessions:
+                    counters["excluded_duplicate_archive_accession"] += 1
+                    continue
+                submission = submissions.get(accession)
+                if submission is None:
+                    counters["excluded_submission_missing"] += 1
+                    continue
+                if (submission.get("DOCUMENT_TYPE") or "").strip().upper() != "4":
+                    counters["excluded_not_original_form4"] += 1
+                    continue
+                owner_rows = owners.get(accession, [])
+                if len(owner_rows) != 1:
+                    counters["excluded_joint_or_missing_owner"] += 1
+                    continue
+                filer_cik = (owner_rows[0].get("RPTOWNERCIK") or "").strip().zfill(10)
+                if not filer_cik.strip("0"):
+                    counters["excluded_filer_cik_missing"] += 1
+                    continue
+                if (row.get("TRANS_CODE") or "").strip().upper() != "P":
+                    counters["excluded_not_code_p"] += 1
+                    continue
+                if (row.get("TRANS_ACQUIRED_DISP_CD") or "").strip().upper() != "A":
+                    counters["excluded_not_acquired"] += 1
+                    continue
+                if (row.get("EQUITY_SWAP_INVOLVED") or "").strip() not in {"", "0"}:
+                    counters["excluded_equity_swap"] += 1
+                    continue
+                if (row.get("DEEMED_EXECUTION_DATE") or "").strip():
+                    counters["excluded_deemed_execution"] += 1
+                    continue
+                if (row.get("TRANS_TIMELINESS") or "").strip().upper() == "L":
+                    counters["excluded_late_flag"] += 1
+                    continue
+                shares = _positive_decimal(row.get("TRANS_SHARES"))
+                price = _positive_decimal(row.get("TRANS_PRICEPERSHARE"))
+                if shares is None or price is None:
+                    counters["excluded_nonpositive_or_missing_value"] += 1
+                    continue
+                transaction_date = _parse_date(row.get("TRANS_DATE"))
+                filed_date = _parse_date(submission.get("FILING_DATE"))
+                if transaction_date is None or filed_date is None:
+                    counters["excluded_invalid_date"] += 1
+                    continue
+                lag = (filed_date - transaction_date).days
+                if lag < 0:
+                    counters["excluded_transaction_after_filing"] += 1
+                    continue
+                if lag > MAX_FILING_LAG_DAYS:
+                    counters["excluded_filing_lag_over_five_days"] += 1
+                    continue
+                issuer_cik = (submission.get("ISSUERCIK") or "").strip().zfill(10)
+                issuer_symbol = (submission.get("ISSUERTRADINGSYMBOL") or "").strip().upper()
+                if not issuer_cik.strip("0") or not issuer_symbol:
+                    counters["excluded_issuer_identity_missing"] += 1
+                    continue
+
+                key = (issuer_cik, accession, filer_cik, transaction_date, filed_date)
+                value = shares * price
+                existing = aggregated.get(key)
+                if existing is None:
+                    aggregated[key] = PurchaseObservation(
+                        issuer_cik=issuer_cik,
+                        issuer_symbol=issuer_symbol,
+                        accession_number=accession,
+                        filer_cik=filer_cik,
+                        transaction_date=transaction_date,
+                        filed_date=filed_date,
+                        disclosed_value=value,
+                    )
+                else:
+                    aggregated[key] = replace(existing, disclosed_value=existing.disclosed_value + value)
+                counters["eligible_transaction_rows"] += 1
+
+    purchases = tuple(
+        sorted(
+            aggregated.values(),
+            key=lambda item: (item.transaction_date, item.filer_cik, item.issuer_cik, item.accession_number),
+        )
+    )
+    counters["aggregated_purchase_observations"] = len(purchases)
+    return purchases, counters, _archive_manifest_sha256(paths)
+
+
+def classify_purchases(
+    purchases: Sequence[PurchaseObservation],
+) -> tuple[tuple[ClassifiedPurchase, ...], Counter[str]]:
+    """Apply the annual, prior-three-year purchase-calendar classifier."""
+    months: dict[str, dict[int, set[int]]] = defaultdict(lambda: defaultdict(set))
+    for purchase in purchases:
+        months[purchase.filer_cik][purchase.transaction_date.year].add(purchase.transaction_date.month)
+
+    classified: list[ClassifiedPurchase] = []
+    counters: Counter[str] = Counter()
+    for purchase in purchases:
+        year = purchase.transaction_date.year
+        prior = [months[purchase.filer_cik].get(year - offset, set()) for offset in (3, 2, 1)]
+        if any(not values for values in prior):
+            counters["unclassified_missing_prior_purchase_year"] += 1
+            continue
+        insider_class: InsiderClass = "routine" if set.intersection(*prior) else "opportunistic"
+        classified.append(ClassifiedPurchase(observation=purchase, insider_class=insider_class))
+        counters[f"classified_{insider_class}"] += 1
+    classified.sort(
+        key=lambda item: (
+            item.observation.filed_date,
+            item.observation.issuer_cik,
+            item.observation.filer_cik,
+            item.observation.accession_number,
+        )
+    )
+    return tuple(classified), counters
+
+
+def _load_research_resolution(conn: psycopg.Connection[Any]) -> tuple[dict[tuple[str, str], int], dict[str, int]]:
+    rows = conn.execute(
+        """
+        SELECT lpad(e.identifier_value, 10, '0'), upper(i.symbol), s.instrument_id
+        FROM research_price_series s
+        JOIN instruments i ON i.instrument_id = s.instrument_id
+        JOIN external_identifiers e
+          ON e.instrument_id = s.instrument_id
+         AND e.provider = 'sec'
+         AND e.identifier_type = 'cik'
+         AND e.is_primary
+        WHERE s.vendor = %s
+        ORDER BY 1, 2, 3
+        """,
+        (CORPUS_VENDORS[0],),
+    ).fetchall()
+    exact: dict[tuple[str, str], int] = {}
+    by_cik: dict[str, set[int]] = defaultdict(set)
+    for cik, symbol, instrument_id in rows:
+        exact[(str(cik), str(symbol))] = int(instrument_id)
+        by_cik[str(cik)].add(int(instrument_id))
+    unique = {cik: next(iter(ids)) for cik, ids in by_cik.items() if len(ids) == 1}
+    return exact, unique
+
+
+def enrich_point_in_time(
+    conn: psycopg.Connection[Any], purchases: Sequence[PurchaseObservation]
+) -> tuple[tuple[PurchaseObservation, ...], Counter[str]]:
+    exact, unique = _load_research_resolution(conn)
+    accessions = sorted({item.accession_number for item in purchases})
+    accepted: dict[str, datetime] = {}
+    if accessions:
+        rows = conn.execute(
+            """
+            SELECT accession_number, max(accepted_at)
+            FROM sec_filing_manifest
+            WHERE accession_number = ANY(%s) AND accepted_at IS NOT NULL
+            GROUP BY accession_number
+            """,
+            (accessions,),
+        ).fetchall()
+        accepted = {str(row[0]): row[1] for row in rows}
+
+    counters: Counter[str] = Counter()
+    output: list[PurchaseObservation] = []
+    for purchase in purchases:
+        instrument_id = exact.get((purchase.issuer_cik, purchase.issuer_symbol))
+        if instrument_id is None:
+            instrument_id = unique.get(purchase.issuer_cik)
+        if instrument_id is None:
+            counters["unresolved_or_multiclass_research_series"] += 1
+            continue
+        acceptance = accepted.get(purchase.accession_number)
+        if acceptance is None:
+            counters["accepted_at_missing_historical_fallback"] += 1
+        output.append(replace(purchase, instrument_id=instrument_id, accepted_at=acceptance))
+    counters["research_series_resolved"] = len(output)
+    return tuple(output), counters
+
+
+def build_source(conn: psycopg.Connection[Any], paths: Sequence[Path]) -> InsiderSourceBuild:
+    purchases, load_counts, manifest_digest = load_archive_purchases(paths)
+    enriched, resolution_counts = enrich_point_in_time(conn, purchases)
+    classified, classification_counts = classify_purchases(enriched)
+    counts = load_counts + resolution_counts + classification_counts
+    return InsiderSourceBuild(
+        purchases=enriched,
+        classified=classified,
+        refusals=dict(sorted(counts.items())),
+        archive_manifest_sha256=manifest_digest,
+    )
+
+
+__all__ = [
+    "ARCHIVE_FIRST_QUARTER",
+    "MAX_FILING_LAG_DAYS",
+    "PRIMARY_START",
+    "TRIAL_ID",
+    "ClassifiedPurchase",
+    "InsiderSourceBuild",
+    "PurchaseObservation",
+    "build_source",
+    "classify_purchases",
+    "enrich_point_in_time",
+    "load_archive_purchases",
+]

--- a/app/services/insider_purchase_outcomes.py
+++ b/app/services/insider_purchase_outcomes.py
@@ -1,0 +1,573 @@
+"""Sealed monthly portfolio outcomes for preregistered candidate #2480."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import date, datetime
+from decimal import Decimal
+from random import Random
+from statistics import mean, median
+from typing import Any, Final
+
+import psycopg
+
+from app.services.block_bootstrap import BootstrapResult, block_bootstrap_expectancy, cluster_by_date
+from app.services.cost_model import buy_price, half_spread_for, sell_price
+from app.services.insider_purchase_candidate import PRIMARY_START, ClassifiedPurchase, InsiderClass
+from app.services.price_quarantine import RULE_SET_VERSION as QUARANTINE_RULE_SET_VERSION
+from app.services.research_comparator_snapshot import SNAPSHOT_ID
+from app.services.sector_classification import resolve_sector_spdr
+from app.services.strategy_result import CORPUS_FROZEN_LAST_BAR, CORPUS_VENDORS
+
+CONTROL_SEED: Final = 2480001
+BOOTSTRAP_SEED: Final = 2480
+MIN_ENTRY_PRICE: Final = Decimal("5")
+MIN_MEDIAN_DOLLAR_VOLUME: Final = Decimal("10000000")
+MAX_SHARE_AGE_MONTHS: Final = 15
+
+
+@dataclass(frozen=True)
+class FirmMonthSignal:
+    issuer_cik: str
+    instrument_id: int
+    insider_class: InsiderClass
+    signal_year: int
+    signal_month: int
+    accession_numbers: tuple[str, ...]
+    latest_acceptance: datetime | None
+
+    @property
+    def signal_date(self) -> date:
+        return date(self.signal_year, self.signal_month, 1)
+
+
+@dataclass(frozen=True)
+class FirmMonthWindow:
+    signal: FirmMonthSignal
+    series_id: int | None
+    entry_date: date | None
+    entry_open: Decimal | None
+    exit_date: date | None
+    exit_close: Decimal | None
+    holding_sessions: int
+    holding_usable: bool | None
+    prior_close: Decimal | None
+    prior_close_usable: bool | None
+    prior_sessions: int
+    valid_liquidity_sessions: int
+    median_dollar_volume: Decimal | None
+    shares_outstanding: Decimal | None
+    shares_filed_date: date | None
+
+
+@dataclass(frozen=True)
+class FirmMonthOutcome:
+    signal: FirmMonthSignal
+    entry_date: date
+    exit_date: date
+    net_return_pct: float
+    gross_return_pct: float
+    market_cap: Decimal
+    median_dollar_volume: Decimal
+    market_relative_pct: float | None
+    sector_relative_pct: float | None
+    sector_symbol: str | None
+
+
+@dataclass(frozen=True)
+class MonthlyPortfolioReturn:
+    entry_date: date
+    opportunistic_pct: float
+    routine_pct: float
+    spread_pct: float
+    equal_weight_spread_pct: float
+    market_relative_spread_pct: float | None
+    sector_relative_spread_pct: float | None
+    opportunistic_firms: int
+    routine_firms: int
+    unique_firms: int
+    minimum_median_dollar_volume: Decimal
+
+
+@dataclass(frozen=True)
+class PortfolioEvaluation:
+    firm_outcomes: tuple[FirmMonthOutcome, ...]
+    monthly_returns: tuple[MonthlyPortfolioReturn, ...]
+    bootstrap: BootstrapResult | None
+    refusals: Mapping[str, int]
+
+
+def build_firm_month_signals(classified: Sequence[ClassifiedPurchase]) -> tuple[FirmMonthSignal, ...]:
+    grouped: dict[tuple[str, int, InsiderClass, int, int], list[ClassifiedPurchase]] = defaultdict(list)
+    for item in classified:
+        observation = item.observation
+        if observation.instrument_id is None:
+            continue
+        key = (
+            observation.issuer_cik,
+            observation.instrument_id,
+            item.insider_class,
+            observation.filed_date.year,
+            observation.filed_date.month,
+        )
+        grouped[key].append(item)
+
+    signals: list[FirmMonthSignal] = []
+    for (issuer_cik, instrument_id, insider_class, year, month), items in grouped.items():
+        acceptances = [item.observation.accepted_at for item in items if item.observation.accepted_at is not None]
+        signals.append(
+            FirmMonthSignal(
+                issuer_cik=issuer_cik,
+                instrument_id=instrument_id,
+                insider_class=insider_class,
+                signal_year=year,
+                signal_month=month,
+                accession_numbers=tuple(sorted({item.observation.accession_number for item in items})),
+                latest_acceptance=max(acceptances, default=None),
+            )
+        )
+    return tuple(
+        sorted(
+            signals,
+            key=lambda item: (item.signal_year, item.signal_month, item.issuer_cik, item.insider_class),
+        )
+    )
+
+
+def build_matched_control_signals(
+    signals: Sequence[FirmMonthSignal], *, seed: int = CONTROL_SEED
+) -> tuple[tuple[FirmMonthSignal, ...], Mapping[str, int]]:
+    """Move each firm to another month in the same quarter before prices read."""
+    rng = Random(seed)
+    output: dict[tuple[str, InsiderClass, int, int], FirmMonthSignal] = {}
+    counters: Counter[str] = Counter()
+    for signal in signals:
+        quarter_start = ((signal.signal_month - 1) // 3) * 3 + 1
+        alternatives = [month for month in range(quarter_start, quarter_start + 3) if month != signal.signal_month]
+        control_month = alternatives[rng.randrange(len(alternatives))]
+        control = replace(
+            signal,
+            signal_month=control_month,
+            accession_numbers=tuple(f"control:{item}" for item in signal.accession_numbers),
+            latest_acceptance=None,
+        )
+        key = (control.issuer_cik, control.insider_class, control.signal_year, control.signal_month)
+        if key in output:
+            counters["control_firm_month_duplicates_suppressed"] += 1
+            continue
+        output[key] = control
+    counters["matched_control_firm_months"] = len(output)
+    counters["input_signal_firm_months"] = len(signals)
+    return tuple(sorted(output.values(), key=lambda item: (item.signal_date, item.issuer_cik))), dict(counters)
+
+
+_CREATE_TEMP_SIGNALS = """
+    CREATE TEMP TABLE insider_trial_signals (
+        event_index    INTEGER PRIMARY KEY,
+        instrument_id BIGINT NOT NULL,
+        signal_year   INTEGER NOT NULL,
+        signal_month  INTEGER NOT NULL
+    ) ON COMMIT DROP
+"""
+
+
+_WINDOW_SQL = """
+    WITH event_series AS (
+        SELECT e.*, s.series_id,
+               (make_date(e.signal_year, e.signal_month, 1) + interval '1 month')::date AS target_start,
+               (make_date(e.signal_year, e.signal_month, 1) + interval '2 months')::date AS target_end
+        FROM insider_trial_signals e
+        LEFT JOIN research_price_series s
+          ON s.instrument_id = e.instrument_id
+         AND s.vendor = %(corpus_vendor)s
+    ), target_rows AS (
+        SELECT e.event_index, d.bar_date, d.open, d.close,
+               coalesce(q.return_usable, TRUE) AS return_usable,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date) AS rn_asc,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date DESC) AS rn_desc
+        FROM event_series e
+        JOIN research_price_quarantine_coverage cov
+          ON cov.series_id = e.series_id
+         AND cov.rule_set_version = %(quarantine_version)s
+        JOIN research_price_daily d
+          ON d.series_id = e.series_id
+         AND d.bar_date >= e.target_start
+         AND d.bar_date < e.target_end
+         AND d.bar_date <= %(frontier)s
+         AND d.bar_date BETWEEN cov.first_bar AND cov.last_bar
+        LEFT JOIN research_bar_quarantine q
+          ON q.series_id = d.series_id
+         AND q.bar_date = d.bar_date
+         AND q.rule_set_version = %(quarantine_version)s
+    ), target AS (
+        SELECT event_index,
+               max(bar_date) FILTER (WHERE rn_asc = 1) AS entry_date,
+               max(open) FILTER (WHERE rn_asc = 1) AS entry_open,
+               max(bar_date) FILTER (WHERE rn_desc = 1) AS exit_date,
+               max(close) FILTER (WHERE rn_desc = 1) AS exit_close,
+               count(*) AS holding_sessions,
+               bool_and(return_usable) AS holding_usable
+        FROM target_rows GROUP BY event_index
+    ), prior_ranked AS (
+        SELECT e.event_index, d.bar_date, d.close, d.volume,
+               coalesce(q.return_usable, TRUE) AS return_usable,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date DESC) AS rn
+        FROM event_series e
+        JOIN target t USING (event_index)
+        JOIN research_price_quarantine_coverage cov
+          ON cov.series_id = e.series_id
+         AND cov.rule_set_version = %(quarantine_version)s
+        JOIN research_price_daily d
+          ON d.series_id = e.series_id
+         AND d.bar_date < t.entry_date
+         AND d.bar_date BETWEEN cov.first_bar AND cov.last_bar
+        LEFT JOIN research_bar_quarantine q
+          ON q.series_id = d.series_id
+         AND q.bar_date = d.bar_date
+         AND q.rule_set_version = %(quarantine_version)s
+    ), prior AS (
+        SELECT event_index,
+               max(close) FILTER (WHERE rn = 1) AS prior_close,
+               bool_and(return_usable) FILTER (WHERE rn = 1) AS prior_close_usable,
+               count(*) FILTER (WHERE rn <= 20) AS prior_sessions,
+               count(*) FILTER (
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+               ) AS valid_liquidity_sessions,
+               percentile_cont(0.5) WITHIN GROUP (ORDER BY close * volume) FILTER (
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+               ) AS median_dollar_volume
+        FROM prior_ranked GROUP BY event_index
+    )
+    SELECT e.event_index, e.series_id, t.entry_date, t.entry_open, t.exit_date, t.exit_close,
+           coalesce(t.holding_sessions, 0), t.holding_usable,
+           p.prior_close, p.prior_close_usable, coalesce(p.prior_sessions, 0),
+           coalesce(p.valid_liquidity_sessions, 0), p.median_dollar_volume,
+           sh.shares_outstanding, sh.filed_date
+    FROM event_series e
+    LEFT JOIN target t USING (event_index)
+    LEFT JOIN prior p USING (event_index)
+    LEFT JOIN LATERAL (
+        SELECT candidate.values[1] AS shares_outstanding, candidate.filed_date
+        FROM (
+            SELECT f.filed_date, f.concept,
+                   array_agg(DISTINCT f.val ORDER BY f.val) AS values,
+                   row_number() OVER (
+                       ORDER BY f.filed_date DESC,
+                                CASE WHEN f.concept = 'EntityCommonStockSharesOutstanding' THEN 0 ELSE 1 END,
+                                max(f.period_end) DESC
+                   ) AS rn
+            FROM financial_facts_raw f
+            WHERE f.instrument_id = e.instrument_id
+              AND f.concept IN ('EntityCommonStockSharesOutstanding', 'CommonStockSharesOutstanding')
+              AND f.val > 0
+              AND t.entry_date IS NOT NULL
+              AND f.filed_date < t.entry_date
+            GROUP BY f.filed_date, f.concept
+        ) candidate
+        WHERE candidate.rn = 1 AND cardinality(candidate.values) = 1
+    ) sh ON TRUE
+    ORDER BY e.event_index
+"""
+
+
+def load_windows(conn: psycopg.Connection[Any], signals: Sequence[FirmMonthSignal]) -> tuple[FirmMonthWindow, ...]:
+    conn.execute("DROP TABLE IF EXISTS insider_trial_signals")
+    conn.execute(_CREATE_TEMP_SIGNALS)
+    with conn.cursor() as cursor:
+        with cursor.copy(
+            "COPY insider_trial_signals (event_index, instrument_id, signal_year, signal_month) FROM STDIN"
+        ) as copy:
+            for index, signal in enumerate(signals):
+                copy.write_row((index, signal.instrument_id, signal.signal_year, signal.signal_month))
+    rows = conn.execute(
+        _WINDOW_SQL,
+        {
+            "corpus_vendor": CORPUS_VENDORS[0],
+            "quarantine_version": QUARANTINE_RULE_SET_VERSION,
+            "frontier": CORPUS_FROZEN_LAST_BAR,
+        },
+    ).fetchall()
+    return tuple(
+        FirmMonthWindow(
+            signal=signals[int(row[0])],
+            series_id=None if row[1] is None else int(row[1]),
+            entry_date=row[2],
+            entry_open=None if row[3] is None else Decimal(row[3]),
+            exit_date=row[4],
+            exit_close=None if row[5] is None else Decimal(row[5]),
+            holding_sessions=int(row[6]),
+            holding_usable=row[7],
+            prior_close=None if row[8] is None else Decimal(row[8]),
+            prior_close_usable=row[9],
+            prior_sessions=int(row[10]),
+            valid_liquidity_sessions=int(row[11]),
+            median_dollar_volume=None if row[12] is None else Decimal(row[12]),
+            shares_outstanding=None if row[13] is None else Decimal(row[13]),
+            shares_filed_date=row[14],
+        )
+        for row in rows
+    )
+
+
+def _month_distance(later: date, earlier: date) -> int:
+    return (later.year - earlier.year) * 12 + later.month - earlier.month
+
+
+def _eligible_window(window: FirmMonthWindow) -> str | None:
+    if window.entry_date is None or window.entry_open is None or window.series_id is None:
+        return "price_series_or_entry_missing"
+    if window.entry_date < PRIMARY_START:
+        return "entry_before_primary_start"
+    if window.exit_date is None or window.exit_close is None:
+        return "incomplete_target_month"
+    if window.entry_date.month != ((window.signal.signal_month % 12) + 1):
+        return "entry_not_in_next_calendar_month"
+    if not window.holding_usable or not window.prior_close_usable:
+        return "quarantined_price_window"
+    if window.entry_open < MIN_ENTRY_PRICE or window.exit_close <= 0:
+        return "nonpositive_or_sub_five_dollar_fill"
+    if window.prior_sessions != 20 or window.valid_liquidity_sessions != 20:
+        return "incomplete_prior_liquidity_window"
+    if window.median_dollar_volume is None or window.median_dollar_volume < MIN_MEDIAN_DOLLAR_VOLUME:
+        return "median_dollar_volume_below_floor"
+    if window.prior_close is None or window.prior_close <= 0:
+        return "prior_close_missing"
+    if window.shares_outstanding is None or window.shares_filed_date is None:
+        return "point_in_time_shares_missing_or_ambiguous"
+    if _month_distance(window.entry_date, window.shares_filed_date) > MAX_SHARE_AGE_MONTHS:
+        return "point_in_time_shares_stale"
+    acceptance = window.signal.latest_acceptance
+    if acceptance is not None and acceptance.date() >= window.entry_date:
+        return "acceptance_not_before_formation"
+    return None
+
+
+def _instrument_context(conn: psycopg.Connection[Any]) -> dict[int, str | None]:
+    rows = conn.execute(
+        """
+        SELECT s.instrument_id, p.sic
+        FROM research_price_series s
+        LEFT JOIN instrument_sec_profile p ON p.instrument_id = s.instrument_id
+        WHERE s.vendor = %s
+        """,
+        (CORPUS_VENDORS[0],),
+    ).fetchall()
+    return {
+        int(row[0]): (classification.spdr_symbol if (classification := resolve_sector_spdr(row[1])) else None)
+        for row in rows
+    }
+
+
+def _comparators(conn: psycopg.Connection[Any]) -> dict[str, dict[date, tuple[Decimal, Decimal]]]:
+    rows = conn.execute(
+        """
+        SELECT s.vendor_symbol, d.bar_date, d.open, d.close
+        FROM research_price_series s JOIN research_price_daily d USING (series_id)
+        WHERE s.comparator_snapshot_id = %s
+        ORDER BY s.vendor_symbol, d.bar_date
+        """,
+        (SNAPSHOT_ID,),
+    ).fetchall()
+    output: dict[str, dict[date, tuple[Decimal, Decimal]]] = defaultdict(dict)
+    for symbol, bar_date, open_price, close_price in rows:
+        output[str(symbol)][bar_date] = (Decimal(open_price), Decimal(close_price))
+    return dict(output)
+
+
+def _weighted(values: Sequence[tuple[float, Decimal]]) -> float:
+    total = sum((weight for _, weight in values), start=Decimal("0"))
+    if total <= 0:
+        raise ValueError("portfolio weight denominator is not positive")
+    return sum(value * float(weight / total) for value, weight in values)
+
+
+def _portfolio_months(
+    outcomes: Sequence[FirmMonthOutcome], refusals: Counter[str]
+) -> tuple[MonthlyPortfolioReturn, ...]:
+    grouped: dict[tuple[date, InsiderClass], list[FirmMonthOutcome]] = defaultdict(list)
+    for outcome in outcomes:
+        grouped[(outcome.entry_date, outcome.signal.insider_class)].append(outcome)
+    dates = sorted({entry_date for entry_date, _ in grouped})
+    monthly: list[MonthlyPortfolioReturn] = []
+    for entry_date in dates:
+        opportunistic = grouped.get((entry_date, "opportunistic"), [])
+        routine = grouped.get((entry_date, "routine"), [])
+        if not opportunistic or not routine:
+            refusals["primary_month_missing_one_cohort"] += 1
+            continue
+        opp_return = _weighted([(item.net_return_pct, item.market_cap) for item in opportunistic])
+        routine_return = _weighted([(item.net_return_pct, item.market_cap) for item in routine])
+        opp_equal = mean(item.net_return_pct for item in opportunistic)
+        routine_equal = mean(item.net_return_pct for item in routine)
+        market_pairs_opp = [
+            (item.market_relative_pct, item.market_cap)
+            for item in opportunistic
+            if item.market_relative_pct is not None
+        ]
+        market_pairs_routine = [
+            (item.market_relative_pct, item.market_cap) for item in routine if item.market_relative_pct is not None
+        ]
+        sector_pairs_opp = [
+            (item.sector_relative_pct, item.market_cap)
+            for item in opportunistic
+            if item.sector_relative_pct is not None
+        ]
+        sector_pairs_routine = [
+            (item.sector_relative_pct, item.market_cap) for item in routine if item.sector_relative_pct is not None
+        ]
+        market_spread = (
+            _weighted([(float(value), weight) for value, weight in market_pairs_opp])
+            - _weighted([(float(value), weight) for value, weight in market_pairs_routine])
+            if len(market_pairs_opp) == len(opportunistic) and len(market_pairs_routine) == len(routine)
+            else None
+        )
+        sector_spread = (
+            _weighted([(float(value), weight) for value, weight in sector_pairs_opp])
+            - _weighted([(float(value), weight) for value, weight in sector_pairs_routine])
+            if len(sector_pairs_opp) == len(opportunistic) and len(sector_pairs_routine) == len(routine)
+            else None
+        )
+        monthly.append(
+            MonthlyPortfolioReturn(
+                entry_date=entry_date,
+                opportunistic_pct=opp_return,
+                routine_pct=routine_return,
+                spread_pct=opp_return - routine_return,
+                equal_weight_spread_pct=opp_equal - routine_equal,
+                market_relative_spread_pct=market_spread,
+                sector_relative_spread_pct=sector_spread,
+                opportunistic_firms=len(opportunistic),
+                routine_firms=len(routine),
+                unique_firms=len({item.signal.issuer_cik for item in [*opportunistic, *routine]}),
+                minimum_median_dollar_volume=min(item.median_dollar_volume for item in [*opportunistic, *routine]),
+            )
+        )
+    return tuple(monthly)
+
+
+def evaluate_portfolios(conn: psycopg.Connection[Any], signals: Sequence[FirmMonthSignal]) -> PortfolioEvaluation:
+    windows = load_windows(conn, signals)
+    sectors = _instrument_context(conn)
+    comparators = _comparators(conn)
+    refusals: Counter[str] = Counter()
+    outcomes: list[FirmMonthOutcome] = []
+    for window in windows:
+        reason = _eligible_window(window)
+        if reason is not None:
+            refusals[reason] += 1
+            continue
+        if (
+            window.entry_date is None
+            or window.entry_open is None
+            or window.exit_date is None
+            or window.exit_close is None
+            or window.prior_close is None
+            or window.shares_outstanding is None
+            or window.median_dollar_volume is None
+        ):
+            raise RuntimeError("ineligible insider window escaped the refusal gate")
+        gross = float((window.exit_close / window.entry_open - 1) * 100)
+        half_spread = half_spread_for(window.entry_open)
+        net = float(
+            (
+                sell_price(window.exit_close, half_spread=half_spread)
+                / buy_price(window.entry_open, half_spread=half_spread)
+                - 1
+            )
+            * 100
+        )
+        market_cap = window.prior_close * window.shares_outstanding
+        spy_entry = comparators.get("SPY", {}).get(window.entry_date)
+        spy_exit = comparators.get("SPY", {}).get(window.exit_date)
+        market_relative = None
+        if spy_entry is None or spy_exit is None:
+            refusals["market_comparator_session_missing"] += 1
+        else:
+            market_relative = net - float((spy_exit[1] / spy_entry[0] - 1) * 100)
+        sector_symbol = sectors.get(window.signal.instrument_id)
+        sector_relative = None
+        if sector_symbol is None:
+            refusals["sector_mapping_missing"] += 1
+        else:
+            sector_entry = comparators.get(sector_symbol, {}).get(window.entry_date)
+            sector_exit = comparators.get(sector_symbol, {}).get(window.exit_date)
+            if sector_entry is None or sector_exit is None:
+                refusals["sector_comparator_session_missing"] += 1
+            else:
+                sector_relative = net - float((sector_exit[1] / sector_entry[0] - 1) * 100)
+        outcomes.append(
+            FirmMonthOutcome(
+                signal=window.signal,
+                entry_date=window.entry_date,
+                exit_date=window.exit_date,
+                net_return_pct=net,
+                gross_return_pct=gross,
+                market_cap=market_cap,
+                median_dollar_volume=window.median_dollar_volume,
+                market_relative_pct=market_relative,
+                sector_relative_pct=sector_relative,
+                sector_symbol=sector_symbol,
+            )
+        )
+    monthly = _portfolio_months(outcomes, refusals)
+    bootstrap = block_bootstrap_expectancy(
+        cluster_by_date([item.spread_pct for item in monthly], [item.entry_date for item in monthly]),
+        seed=BOOTSTRAP_SEED,
+    )
+    refusals["input_firm_month_signals"] = len(signals)
+    refusals["eligible_firm_month_outcomes"] = len(outcomes)
+    refusals["complete_primary_months"] = len(monthly)
+    return PortfolioEvaluation(
+        firm_outcomes=tuple(outcomes),
+        monthly_returns=monthly,
+        bootstrap=bootstrap,
+        refusals=dict(sorted(refusals.items())),
+    )
+
+
+def maximum_drawdown_pct(monthly: Sequence[MonthlyPortfolioReturn]) -> float | None:
+    if not monthly:
+        return None
+    equity = peak = 1.0
+    worst = 0.0
+    for item in monthly:
+        equity *= 1 + item.spread_pct / 100
+        peak = max(peak, equity)
+        worst = min(worst, equity / peak - 1)
+    return worst * 100
+
+
+def expected_shortfall_5_pct(monthly: Sequence[MonthlyPortfolioReturn]) -> float | None:
+    if not monthly:
+        return None
+    ordered = sorted(item.spread_pct for item in monthly)
+    return mean(ordered[: max(1, (len(ordered) + 19) // 20)])
+
+
+def profit_factor(monthly: Sequence[MonthlyPortfolioReturn]) -> float | None:
+    gains = sum(max(item.spread_pct, 0) for item in monthly)
+    losses = -sum(min(item.spread_pct, 0) for item in monthly)
+    return gains / losses if losses else None
+
+
+def median_firm_count(monthly: Sequence[MonthlyPortfolioReturn]) -> float | None:
+    return median(item.unique_firms for item in monthly) if monthly else None
+
+
+__all__ = [
+    "BOOTSTRAP_SEED",
+    "CONTROL_SEED",
+    "FirmMonthOutcome",
+    "FirmMonthSignal",
+    "MonthlyPortfolioReturn",
+    "PortfolioEvaluation",
+    "build_firm_month_signals",
+    "build_matched_control_signals",
+    "evaluate_portfolios",
+    "expected_shortfall_5_pct",
+    "maximum_drawdown_pct",
+    "median_firm_count",
+    "profit_factor",
+]

--- a/app/services/insider_purchase_outcomes.py
+++ b/app/services/insider_purchase_outcomes.py
@@ -25,7 +25,6 @@ CONTROL_SEED: Final = 2480001
 BOOTSTRAP_SEED: Final = 2480
 MIN_ENTRY_PRICE: Final = Decimal("5")
 MIN_MEDIAN_DOLLAR_VOLUME: Final = Decimal("10000000")
-MAX_SHARE_AGE_MONTHS: Final = 15
 
 
 @dataclass(frozen=True)
@@ -36,6 +35,7 @@ class FirmMonthSignal:
     signal_year: int
     signal_month: int
     accession_numbers: tuple[str, ...]
+    disclosed_value: Decimal
     latest_acceptance: datetime | None
 
     @property
@@ -59,8 +59,6 @@ class FirmMonthWindow:
     prior_sessions: int
     valid_liquidity_sessions: int
     median_dollar_volume: Decimal | None
-    shares_outstanding: Decimal | None
-    shares_filed_date: date | None
 
 
 @dataclass(frozen=True)
@@ -71,7 +69,7 @@ class FirmMonthOutcome:
     net_return_pct: float
     short_net_return_pct: float
     gross_return_pct: float
-    market_cap: Decimal
+    weight_value: Decimal
     median_dollar_volume: Decimal
     market_relative_pct: float | None
     short_market_relative_pct: float | None
@@ -129,6 +127,10 @@ def build_firm_month_signals(classified: Sequence[ClassifiedPurchase]) -> tuple[
                 signal_year=year,
                 signal_month=month,
                 accession_numbers=tuple(sorted({item.observation.accession_number for item in items})),
+                disclosed_value=sum(
+                    (item.observation.disclosed_value for item in items),
+                    start=Decimal("0"),
+                ),
                 latest_acceptance=max(acceptances, default=None),
             )
         )
@@ -265,31 +267,10 @@ _WINDOW_SQL = """
            t.entry_date, t.entry_open, t.exit_date, t.exit_close,
            coalesce(t.holding_sessions, 0), t.holding_usable,
            p.prior_close, p.prior_close_usable, coalesce(p.prior_sessions, 0),
-           coalesce(p.valid_liquidity_sessions, 0), p.median_dollar_volume,
-           sh.shares_outstanding, sh.filed_date
+           coalesce(p.valid_liquidity_sessions, 0), p.median_dollar_volume
     FROM event_series e
     LEFT JOIN target t USING (event_index)
     LEFT JOIN prior p USING (event_index)
-    LEFT JOIN LATERAL (
-        SELECT candidate.values[1] AS shares_outstanding, candidate.filed_date
-        FROM (
-            SELECT f.filed_date, f.concept,
-                   array_agg(DISTINCT f.val ORDER BY f.val) AS values,
-                   row_number() OVER (
-                       ORDER BY f.filed_date DESC,
-                                CASE WHEN f.concept = 'EntityCommonStockSharesOutstanding' THEN 0 ELSE 1 END,
-                                max(f.period_end) DESC
-                   ) AS rn
-            FROM financial_facts_raw f
-            WHERE f.instrument_id = e.instrument_id
-              AND f.concept IN ('EntityCommonStockSharesOutstanding', 'CommonStockSharesOutstanding')
-              AND f.val > 0
-              AND t.entry_date IS NOT NULL
-              AND f.filed_date < t.entry_date
-            GROUP BY f.filed_date, f.concept
-        ) candidate
-        WHERE candidate.rn = 1 AND cardinality(candidate.values) = 1
-    ) sh ON TRUE
     ORDER BY e.event_index
 """
 
@@ -327,15 +308,9 @@ def load_windows(conn: psycopg.Connection[Any], signals: Sequence[FirmMonthSigna
             prior_sessions=int(row[11]),
             valid_liquidity_sessions=int(row[12]),
             median_dollar_volume=None if row[13] is None else Decimal(row[13]),
-            shares_outstanding=None if row[14] is None else Decimal(row[14]),
-            shares_filed_date=row[15],
         )
         for row in rows
     )
-
-
-def _month_distance(later: date, earlier: date) -> int:
-    return (later.year - earlier.year) * 12 + later.month - earlier.month
 
 
 def _eligible_window(window: FirmMonthWindow) -> str | None:
@@ -359,10 +334,8 @@ def _eligible_window(window: FirmMonthWindow) -> str | None:
         return "median_dollar_volume_below_floor"
     if window.prior_close is None or window.prior_close <= 0:
         return "prior_close_missing"
-    if window.shares_outstanding is None or window.shares_filed_date is None:
-        return "point_in_time_shares_missing_or_ambiguous"
-    if _month_distance(window.entry_date, window.shares_filed_date) > MAX_SHARE_AGE_MONTHS:
-        return "point_in_time_shares_stale"
+    if not window.signal.disclosed_value.is_finite() or window.signal.disclosed_value <= 0:
+        return "disclosed_purchase_value_invalid"
     acceptance = window.signal.latest_acceptance
     if acceptance is not None and acceptance.date() >= window.entry_date:
         return "acceptance_not_before_formation"
@@ -425,28 +398,28 @@ def _portfolio_months(
         if not opportunistic or not routine:
             refusals["primary_month_missing_one_cohort"] += 1
             continue
-        opp_return = _weighted([(item.net_return_pct, item.market_cap) for item in opportunistic])
-        routine_return = _weighted([(item.net_return_pct, item.market_cap) for item in routine])
-        routine_short = _weighted([(item.short_net_return_pct, item.market_cap) for item in routine])
+        opp_return = _weighted([(item.net_return_pct, item.weight_value) for item in opportunistic])
+        routine_return = _weighted([(item.net_return_pct, item.weight_value) for item in routine])
+        routine_short = _weighted([(item.short_net_return_pct, item.weight_value) for item in routine])
         opp_equal = mean(item.net_return_pct for item in opportunistic)
         routine_short_equal = mean(item.short_net_return_pct for item in routine)
         market_pairs_opp = [
-            (item.market_relative_pct, item.market_cap)
+            (item.market_relative_pct, item.weight_value)
             for item in opportunistic
             if item.market_relative_pct is not None
         ]
         market_pairs_routine = [
-            (item.short_market_relative_pct, item.market_cap)
+            (item.short_market_relative_pct, item.weight_value)
             for item in routine
             if item.short_market_relative_pct is not None
         ]
         sector_pairs_opp = [
-            (item.sector_relative_pct, item.market_cap)
+            (item.sector_relative_pct, item.weight_value)
             for item in opportunistic
             if item.sector_relative_pct is not None
         ]
         sector_pairs_routine = [
-            (item.short_sector_relative_pct, item.market_cap)
+            (item.short_sector_relative_pct, item.weight_value)
             for item in routine
             if item.short_sector_relative_pct is not None
         ]
@@ -497,7 +470,6 @@ def evaluate_portfolios(conn: psycopg.Connection[Any], signals: Sequence[FirmMon
             or window.exit_date is None
             or window.exit_close is None
             or window.prior_close is None
-            or window.shares_outstanding is None
             or window.median_dollar_volume is None
         ):
             raise RuntimeError("ineligible insider window escaped the refusal gate")
@@ -515,7 +487,6 @@ def evaluate_portfolios(conn: psycopg.Connection[Any], signals: Sequence[FirmMon
         short_net = float(
             (entry_proceeds - buy_price(window.exit_close, half_spread=half_spread)) / entry_proceeds * 100
         )
-        market_cap = window.prior_close * window.shares_outstanding
         spy_entry = comparators.get("SPY", {}).get(window.entry_date)
         spy_exit = comparators.get("SPY", {}).get(window.exit_date)
         market_relative = None
@@ -548,7 +519,7 @@ def evaluate_portfolios(conn: psycopg.Connection[Any], signals: Sequence[FirmMon
                 net_return_pct=net,
                 short_net_return_pct=short_net,
                 gross_return_pct=gross,
-                market_cap=market_cap,
+                weight_value=window.signal.disclosed_value,
                 median_dollar_volume=window.median_dollar_volume,
                 market_relative_pct=market_relative,
                 short_market_relative_pct=short_market_relative,

--- a/app/services/insider_purchase_outcomes.py
+++ b/app/services/insider_purchase_outcomes.py
@@ -352,6 +352,7 @@ def _instrument_context(conn: psycopg.Connection[Any]) -> dict[int, str | None]:
         FROM research_price_series s
         LEFT JOIN instrument_sec_profile p ON p.instrument_id = s.instrument_id
         WHERE s.vendor = %s
+          AND s.instrument_id IS NOT NULL
         """,
         (CORPUS_VENDORS[0],),
     ).fetchall()

--- a/app/services/insider_purchase_outcomes.py
+++ b/app/services/insider_purchase_outcomes.py
@@ -147,14 +147,13 @@ def build_matched_control_signals(
     rng = Random(seed)
     output: dict[tuple[str, InsiderClass, int, int], FirmMonthSignal] = {}
     counters: Counter[str] = Counter()
-    treated = {(signal.issuer_cik, signal.insider_class, signal.signal_year, signal.signal_month) for signal in signals}
+    treated = {(signal.issuer_cik, signal.signal_year, signal.signal_month) for signal in signals}
     for signal in signals:
         quarter_start = ((signal.signal_month - 1) // 3) * 3 + 1
         alternatives = [
             month
             for month in range(quarter_start, quarter_start + 3)
-            if month != signal.signal_month
-            and (signal.issuer_cik, signal.insider_class, signal.signal_year, month) not in treated
+            if month != signal.signal_month and (signal.issuer_cik, signal.signal_year, month) not in treated
         ]
         if not alternatives:
             counters["control_cell_has_no_untreated_month"] += 1
@@ -414,7 +413,10 @@ def _portfolio_months(
 ) -> tuple[MonthlyPortfolioReturn, ...]:
     grouped: dict[tuple[date, InsiderClass], list[FirmMonthOutcome]] = defaultdict(list)
     for outcome in outcomes:
-        grouped[(outcome.entry_date, outcome.signal.insider_class)].append(outcome)
+        signal = outcome.signal
+        target_year = signal.signal_year + (1 if signal.signal_month == 12 else 0)
+        target_month = 1 if signal.signal_month == 12 else signal.signal_month + 1
+        grouped[(date(target_year, target_month, 1), signal.insider_class)].append(outcome)
     dates = sorted({entry_date for entry_date, _ in grouped})
     monthly: list[MonthlyPortfolioReturn] = []
     for entry_date in dates:

--- a/app/services/insider_purchase_outcomes.py
+++ b/app/services/insider_purchase_outcomes.py
@@ -91,6 +91,7 @@ class MonthlyPortfolioReturn:
     routine_firms: int
     unique_firms: int
     minimum_median_dollar_volume: Decimal
+    maximum_single_firm_weight_pct: float
 
 
 @dataclass(frozen=True)
@@ -147,34 +148,37 @@ def build_matched_control_signals(
 ) -> tuple[tuple[FirmMonthSignal, ...], Mapping[str, int]]:
     """Move each firm to another month in the same quarter before prices read."""
     rng = Random(seed)
-    output: dict[tuple[str, InsiderClass, int, int], FirmMonthSignal] = {}
+    output: list[FirmMonthSignal] = []
     counters: Counter[str] = Counter()
     treated = {(signal.issuer_cik, signal.signal_year, signal.signal_month) for signal in signals}
+    cells: dict[tuple[str, InsiderClass, int, int], list[FirmMonthSignal]] = defaultdict(list)
     for signal in signals:
-        quarter_start = ((signal.signal_month - 1) // 3) * 3 + 1
-        alternatives = [
-            month
-            for month in range(quarter_start, quarter_start + 3)
-            if month != signal.signal_month and (signal.issuer_cik, signal.signal_year, month) not in treated
-        ]
-        if not alternatives:
-            counters["control_cell_has_no_untreated_month"] += 1
-            continue
-        control_month = alternatives[rng.randrange(len(alternatives))]
-        control = replace(
-            signal,
-            signal_month=control_month,
-            accession_numbers=tuple(f"control:{item}" for item in signal.accession_numbers),
-            latest_acceptance=None,
+        cells[(signal.issuer_cik, signal.insider_class, signal.signal_year, (signal.signal_month - 1) // 3)].append(
+            signal
         )
-        key = (control.issuer_cik, control.insider_class, control.signal_year, control.signal_month)
-        if key in output:
-            counters["control_firm_month_duplicates_suppressed"] += 1
-            continue
-        output[key] = control
+    for (issuer_cik, _insider_class, year, quarter), cell_signals in sorted(cells.items()):
+        quarter_start = quarter * 3 + 1
+        alternatives = [
+            month for month in range(quarter_start, quarter_start + 3) if (issuer_cik, year, month) not in treated
+        ]
+        rng.shuffle(alternatives)
+        ordered_signals = sorted(cell_signals, key=lambda item: (item.signal_month, item.accession_numbers))
+        matched = min(len(ordered_signals), len(alternatives))
+        counters["control_cell_unmatched_signals"] += len(ordered_signals) - matched
+        for signal, control_month in zip(ordered_signals[:matched], alternatives[:matched], strict=True):
+            output.append(
+                replace(
+                    signal,
+                    signal_month=control_month,
+                    accession_numbers=tuple(f"control:{item}" for item in signal.accession_numbers),
+                    latest_acceptance=None,
+                )
+            )
     counters["matched_control_firm_months"] = len(output)
     counters["input_signal_firm_months"] = len(signals)
-    return tuple(sorted(output.values(), key=lambda item: (item.signal_date, item.issuer_cik))), dict(counters)
+    return tuple(sorted(output, key=lambda item: (item.signal_date, item.issuer_cik, item.insider_class))), dict(
+        counters
+    )
 
 
 _CREATE_TEMP_SIGNALS = """
@@ -245,20 +249,19 @@ _WINDOW_SQL = """
          AND q.bar_date = d.bar_date
          AND q.rule_set_version = %(quarantine_version)s
     ), prior_ranked AS (
-        SELECT event_index, bar_date, close, volume,
+        SELECT event_index, bar_date, close, volume, return_usable,
                row_number() OVER (PARTITION BY e.event_index ORDER BY e.bar_date DESC) AS rn
         FROM prior_raw e
-        WHERE e.return_usable
     ), prior AS (
         SELECT event_index,
                max(close) FILTER (WHERE rn = 1) AS prior_close,
-               TRUE AS prior_close_usable,
+               bool_and(return_usable) FILTER (WHERE rn = 1) AS prior_close_usable,
                count(*) FILTER (WHERE rn <= 20) AS prior_sessions,
                count(*) FILTER (
-                   WHERE rn <= 20 AND close > 0 AND volume IS NOT NULL AND volume > 0
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
                ) AS valid_liquidity_sessions,
                percentile_cont(0.5) WITHIN GROUP (ORDER BY close * volume) FILTER (
-                   WHERE rn <= 20 AND close > 0 AND volume IS NOT NULL AND volume > 0
+                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
                ) AS median_dollar_volume
         FROM prior_ranked GROUP BY event_index
     )
@@ -381,6 +384,13 @@ def _weighted(values: Sequence[tuple[float, Decimal]]) -> float:
     return sum(value * float(weight / total) for value, weight in values)
 
 
+def _maximum_weight_pct(outcomes: Sequence[FirmMonthOutcome]) -> float:
+    total = sum((item.weight_value for item in outcomes), start=Decimal("0"))
+    if total <= 0:
+        raise ValueError("portfolio weight denominator is not positive")
+    return float(max(item.weight_value for item in outcomes) / total * 100)
+
+
 def _portfolio_months(
     outcomes: Sequence[FirmMonthOutcome], refusals: Counter[str]
 ) -> tuple[MonthlyPortfolioReturn, ...]:
@@ -448,6 +458,10 @@ def _portfolio_months(
                 routine_firms=len(routine),
                 unique_firms=len({item.signal.issuer_cik for item in [*opportunistic, *routine]}),
                 minimum_median_dollar_volume=min(item.median_dollar_volume for item in [*opportunistic, *routine]),
+                maximum_single_firm_weight_pct=max(
+                    _maximum_weight_pct(opportunistic),
+                    _maximum_weight_pct(routine),
+                ),
             )
         )
     return tuple(monthly)

--- a/app/services/insider_purchase_outcomes.py
+++ b/app/services/insider_purchase_outcomes.py
@@ -47,6 +47,7 @@ class FirmMonthSignal:
 class FirmMonthWindow:
     signal: FirmMonthSignal
     series_id: int | None
+    target_month_complete: bool
     entry_date: date | None
     entry_open: Decimal | None
     exit_date: date | None
@@ -68,11 +69,14 @@ class FirmMonthOutcome:
     entry_date: date
     exit_date: date
     net_return_pct: float
+    short_net_return_pct: float
     gross_return_pct: float
     market_cap: Decimal
     median_dollar_volume: Decimal
     market_relative_pct: float | None
+    short_market_relative_pct: float | None
     sector_relative_pct: float | None
+    short_sector_relative_pct: float | None
     sector_symbol: str | None
 
 
@@ -143,9 +147,18 @@ def build_matched_control_signals(
     rng = Random(seed)
     output: dict[tuple[str, InsiderClass, int, int], FirmMonthSignal] = {}
     counters: Counter[str] = Counter()
+    treated = {(signal.issuer_cik, signal.insider_class, signal.signal_year, signal.signal_month) for signal in signals}
     for signal in signals:
         quarter_start = ((signal.signal_month - 1) // 3) * 3 + 1
-        alternatives = [month for month in range(quarter_start, quarter_start + 3) if month != signal.signal_month]
+        alternatives = [
+            month
+            for month in range(quarter_start, quarter_start + 3)
+            if month != signal.signal_month
+            and (signal.issuer_cik, signal.insider_class, signal.signal_year, month) not in treated
+        ]
+        if not alternatives:
+            counters["control_cell_has_no_untreated_month"] += 1
+            continue
         control_month = alternatives[rng.randrange(len(alternatives))]
         control = replace(
             signal,
@@ -182,11 +195,9 @@ _WINDOW_SQL = """
         LEFT JOIN research_price_series s
           ON s.instrument_id = e.instrument_id
          AND s.vendor = %(corpus_vendor)s
-    ), target_rows AS (
+    ), target_raw AS (
         SELECT e.event_index, d.bar_date, d.open, d.close,
-               coalesce(q.return_usable, TRUE) AS return_usable,
-               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date) AS rn_asc,
-               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date DESC) AS rn_desc
+               coalesce(q.return_usable, TRUE) AS return_usable
         FROM event_series e
         JOIN research_price_quarantine_coverage cov
           ON cov.series_id = e.series_id
@@ -201,6 +212,12 @@ _WINDOW_SQL = """
           ON q.series_id = d.series_id
          AND q.bar_date = d.bar_date
          AND q.rule_set_version = %(quarantine_version)s
+    ), target_rows AS (
+        SELECT event_index, bar_date, open, close,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY e.bar_date) AS rn_asc,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY e.bar_date DESC) AS rn_desc
+        FROM target_raw e
+        WHERE e.return_usable
     ), target AS (
         SELECT event_index,
                max(bar_date) FILTER (WHERE rn_asc = 1) AS entry_date,
@@ -208,12 +225,11 @@ _WINDOW_SQL = """
                max(bar_date) FILTER (WHERE rn_desc = 1) AS exit_date,
                max(close) FILTER (WHERE rn_desc = 1) AS exit_close,
                count(*) AS holding_sessions,
-               bool_and(return_usable) AS holding_usable
+               TRUE AS holding_usable
         FROM target_rows GROUP BY event_index
-    ), prior_ranked AS (
+    ), prior_raw AS (
         SELECT e.event_index, d.bar_date, d.close, d.volume,
-               coalesce(q.return_usable, TRUE) AS return_usable,
-               row_number() OVER (PARTITION BY e.event_index ORDER BY d.bar_date DESC) AS rn
+               coalesce(q.return_usable, TRUE) AS return_usable
         FROM event_series e
         JOIN target t USING (event_index)
         JOIN research_price_quarantine_coverage cov
@@ -227,20 +243,27 @@ _WINDOW_SQL = """
           ON q.series_id = d.series_id
          AND q.bar_date = d.bar_date
          AND q.rule_set_version = %(quarantine_version)s
+    ), prior_ranked AS (
+        SELECT event_index, bar_date, close, volume,
+               row_number() OVER (PARTITION BY e.event_index ORDER BY e.bar_date DESC) AS rn
+        FROM prior_raw e
+        WHERE e.return_usable
     ), prior AS (
         SELECT event_index,
                max(close) FILTER (WHERE rn = 1) AS prior_close,
-               bool_and(return_usable) FILTER (WHERE rn = 1) AS prior_close_usable,
+               TRUE AS prior_close_usable,
                count(*) FILTER (WHERE rn <= 20) AS prior_sessions,
                count(*) FILTER (
-                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+                   WHERE rn <= 20 AND close > 0 AND volume IS NOT NULL AND volume > 0
                ) AS valid_liquidity_sessions,
                percentile_cont(0.5) WITHIN GROUP (ORDER BY close * volume) FILTER (
-                   WHERE rn <= 20 AND return_usable AND close > 0 AND volume IS NOT NULL AND volume > 0
+                   WHERE rn <= 20 AND close > 0 AND volume IS NOT NULL AND volume > 0
                ) AS median_dollar_volume
         FROM prior_ranked GROUP BY event_index
     )
-    SELECT e.event_index, e.series_id, t.entry_date, t.entry_open, t.exit_date, t.exit_close,
+    SELECT e.event_index, e.series_id,
+           e.target_end <= date_trunc('month', CAST(%(frontier)s AS date))::date AS target_month_complete,
+           t.entry_date, t.entry_open, t.exit_date, t.exit_close,
            coalesce(t.holding_sessions, 0), t.holding_usable,
            p.prior_close, p.prior_close_usable, coalesce(p.prior_sessions, 0),
            coalesce(p.valid_liquidity_sessions, 0), p.median_dollar_volume,
@@ -293,19 +316,20 @@ def load_windows(conn: psycopg.Connection[Any], signals: Sequence[FirmMonthSigna
         FirmMonthWindow(
             signal=signals[int(row[0])],
             series_id=None if row[1] is None else int(row[1]),
-            entry_date=row[2],
-            entry_open=None if row[3] is None else Decimal(row[3]),
-            exit_date=row[4],
-            exit_close=None if row[5] is None else Decimal(row[5]),
-            holding_sessions=int(row[6]),
-            holding_usable=row[7],
-            prior_close=None if row[8] is None else Decimal(row[8]),
-            prior_close_usable=row[9],
-            prior_sessions=int(row[10]),
-            valid_liquidity_sessions=int(row[11]),
-            median_dollar_volume=None if row[12] is None else Decimal(row[12]),
-            shares_outstanding=None if row[13] is None else Decimal(row[13]),
-            shares_filed_date=row[14],
+            target_month_complete=bool(row[2]),
+            entry_date=row[3],
+            entry_open=None if row[4] is None else Decimal(row[4]),
+            exit_date=row[5],
+            exit_close=None if row[6] is None else Decimal(row[6]),
+            holding_sessions=int(row[7]),
+            holding_usable=row[8],
+            prior_close=None if row[9] is None else Decimal(row[9]),
+            prior_close_usable=row[10],
+            prior_sessions=int(row[11]),
+            valid_liquidity_sessions=int(row[12]),
+            median_dollar_volume=None if row[13] is None else Decimal(row[13]),
+            shares_outstanding=None if row[14] is None else Decimal(row[14]),
+            shares_filed_date=row[15],
         )
         for row in rows
     )
@@ -316,6 +340,8 @@ def _month_distance(later: date, earlier: date) -> int:
 
 
 def _eligible_window(window: FirmMonthWindow) -> str | None:
+    if not window.target_month_complete:
+        return "incomplete_target_month_at_corpus_frontier"
     if window.entry_date is None or window.entry_open is None or window.series_id is None:
         return "price_series_or_entry_missing"
     if window.entry_date < PRIMARY_START:
@@ -399,15 +425,18 @@ def _portfolio_months(
             continue
         opp_return = _weighted([(item.net_return_pct, item.market_cap) for item in opportunistic])
         routine_return = _weighted([(item.net_return_pct, item.market_cap) for item in routine])
+        routine_short = _weighted([(item.short_net_return_pct, item.market_cap) for item in routine])
         opp_equal = mean(item.net_return_pct for item in opportunistic)
-        routine_equal = mean(item.net_return_pct for item in routine)
+        routine_short_equal = mean(item.short_net_return_pct for item in routine)
         market_pairs_opp = [
             (item.market_relative_pct, item.market_cap)
             for item in opportunistic
             if item.market_relative_pct is not None
         ]
         market_pairs_routine = [
-            (item.market_relative_pct, item.market_cap) for item in routine if item.market_relative_pct is not None
+            (item.short_market_relative_pct, item.market_cap)
+            for item in routine
+            if item.short_market_relative_pct is not None
         ]
         sector_pairs_opp = [
             (item.sector_relative_pct, item.market_cap)
@@ -415,17 +444,19 @@ def _portfolio_months(
             if item.sector_relative_pct is not None
         ]
         sector_pairs_routine = [
-            (item.sector_relative_pct, item.market_cap) for item in routine if item.sector_relative_pct is not None
+            (item.short_sector_relative_pct, item.market_cap)
+            for item in routine
+            if item.short_sector_relative_pct is not None
         ]
         market_spread = (
             _weighted([(float(value), weight) for value, weight in market_pairs_opp])
-            - _weighted([(float(value), weight) for value, weight in market_pairs_routine])
+            + _weighted([(float(value), weight) for value, weight in market_pairs_routine])
             if len(market_pairs_opp) == len(opportunistic) and len(market_pairs_routine) == len(routine)
             else None
         )
         sector_spread = (
             _weighted([(float(value), weight) for value, weight in sector_pairs_opp])
-            - _weighted([(float(value), weight) for value, weight in sector_pairs_routine])
+            + _weighted([(float(value), weight) for value, weight in sector_pairs_routine])
             if len(sector_pairs_opp) == len(opportunistic) and len(sector_pairs_routine) == len(routine)
             else None
         )
@@ -434,8 +465,8 @@ def _portfolio_months(
                 entry_date=entry_date,
                 opportunistic_pct=opp_return,
                 routine_pct=routine_return,
-                spread_pct=opp_return - routine_return,
-                equal_weight_spread_pct=opp_equal - routine_equal,
+                spread_pct=opp_return + routine_short,
+                equal_weight_spread_pct=opp_equal + routine_short_equal,
                 market_relative_spread_pct=market_spread,
                 sector_relative_spread_pct=sector_spread,
                 opportunistic_firms=len(opportunistic),
@@ -478,16 +509,24 @@ def evaluate_portfolios(conn: psycopg.Connection[Any], signals: Sequence[FirmMon
             )
             * 100
         )
+        entry_proceeds = sell_price(window.entry_open, half_spread=half_spread)
+        short_net = float(
+            (entry_proceeds - buy_price(window.exit_close, half_spread=half_spread)) / entry_proceeds * 100
+        )
         market_cap = window.prior_close * window.shares_outstanding
         spy_entry = comparators.get("SPY", {}).get(window.entry_date)
         spy_exit = comparators.get("SPY", {}).get(window.exit_date)
         market_relative = None
+        short_market_relative = None
         if spy_entry is None or spy_exit is None:
             refusals["market_comparator_session_missing"] += 1
         else:
-            market_relative = net - float((spy_exit[1] / spy_entry[0] - 1) * 100)
+            market_return = float((spy_exit[1] / spy_entry[0] - 1) * 100)
+            market_relative = net - market_return
+            short_market_relative = short_net + market_return
         sector_symbol = sectors.get(window.signal.instrument_id)
         sector_relative = None
+        short_sector_relative = None
         if sector_symbol is None:
             refusals["sector_mapping_missing"] += 1
         else:
@@ -496,18 +535,23 @@ def evaluate_portfolios(conn: psycopg.Connection[Any], signals: Sequence[FirmMon
             if sector_entry is None or sector_exit is None:
                 refusals["sector_comparator_session_missing"] += 1
             else:
-                sector_relative = net - float((sector_exit[1] / sector_entry[0] - 1) * 100)
+                sector_return = float((sector_exit[1] / sector_entry[0] - 1) * 100)
+                sector_relative = net - sector_return
+                short_sector_relative = short_net + sector_return
         outcomes.append(
             FirmMonthOutcome(
                 signal=window.signal,
                 entry_date=window.entry_date,
                 exit_date=window.exit_date,
                 net_return_pct=net,
+                short_net_return_pct=short_net,
                 gross_return_pct=gross,
                 market_cap=market_cap,
                 median_dollar_volume=window.median_dollar_volume,
                 market_relative_pct=market_relative,
+                short_market_relative_pct=short_market_relative,
                 sector_relative_pct=sector_relative,
+                short_sector_relative_pct=short_sector_relative,
                 sector_symbol=sector_symbol,
             )
         )

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -74,7 +74,7 @@ from typing import Final
 #: Bumped whenever a trial is added or an entry's meaning changes. ⚠ Stored on
 #: the result row beside the DSR: a deflated Sharpe means nothing without the
 #: trial population it was deflated against, and that population grows.
-TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-11"
+TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-11-r2"
 
 
 @dataclass(frozen=True)
@@ -239,6 +239,11 @@ TRIAL_REGISTER: Final = TrialRegister(
             ),
             evidence="docs/proposals/ta/2026-08-09-plan-of-attack.md §2b",
             searches=101,
+        ),
+        DeclaredTrial(
+            trial_id="form4-code-p-opportunistic-purchase-v1",
+            description="Purchase-value-weighted long opportunistic Form-4 code-P buys / short routine buys, monthly.",
+            evidence="docs/proposals/ta/2026-08-10-insider-purchase-result.md; issue #2480 sealed verdict",
         ),
     ),
 )

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -243,7 +243,8 @@ TRIAL_REGISTER: Final = TrialRegister(
         DeclaredTrial(
             trial_id="form4-code-p-opportunistic-purchase-v1",
             description="Purchase-value-weighted long opportunistic Form-4 code-P buys / short routine buys, monthly.",
-            evidence="docs/proposals/ta/2026-08-10-insider-purchase-result.md; issue #2480 sealed verdict",
+            evidence="docs/proposals/ta/2026-08-10-insider-purchase-result.md; "
+            "https://github.com/Luke-Bradford/eBull/issues/2480#issuecomment-5238836691",
         ),
     ),
 )

--- a/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
+++ b/docs/proposals/ta/2026-08-10-evidence-refresh-and-capital-semantics.md
@@ -149,15 +149,21 @@ current research programme spans intraday through multi-month horizons:
   filing entries and the compatible market/sector comparator with a positive
   clustered lower confidence bound on net expectancy. Any 5/20/40-session
   diagnostic is a separately declared arm, never a best-horizon search;
-- opportunistic Form 4 code-`P` purchases (#2480) use filing acceptance as
-  knowledge time and the next executable regular-session open as entry. The
+- opportunistic Form 4 code-`P` purchases (#2480) were measured once and
+  **rejected for capital promotion**. The recent 24/36-month spreads were
+  negative, the primary confidence interval crossed zero, the timing placebo
+  did better, and concentration/tail gates failed; the immutable verdict is in
+  `2026-08-10-insider-purchase-result.md`. The frozen trial used exact filing
+  acceptance where available and a conservative end-of-filed-date boundary
+  otherwise. The
   causal adaptation of the published classifier calls an insider routine only
   after purchases in the same calendar month in each of the preceding three
   years; every other sufficiently observed insider is opportunistic, while
   insufficient history is its own refusal/control cohort. The
-  primary test is a purchase-only, monthly rebalanced value-weight portfolio
-  held for one month, against routine purchases, matched random entries and a
-  price-compatible market/sector comparator. Sales never enter the long signal;
+  primary test is a purchase-only, monthly rebalanced disclosed-purchase-value-
+  weighted portfolio held for one month, against routine purchases, matched
+  random entries and a price-compatible market/sector comparator. Sales never
+  enter the long signal;
   observed/estimated spread and slippage are charged on the next-open entry and
   monthly exit. Its primary pass metric is the opportunistic-minus-routine net
   monthly return with a positive clustered lower confidence bound; ATR exits or

--- a/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
@@ -43,8 +43,9 @@ Only a row satisfying every condition below is a purchase observation:
 CMP include officers, directors and 10% owners. This trial therefore imposes no
 post-hoc role, direct/indirect ownership or purchase-size selection. Multiple
 qualifying rows in one accession and transaction month are aggregated to one
-insider purchase observation with summed disclosed value. Trade value is audit
-metadata only and never determines inclusion, weights or thresholds.
+insider purchase observation with summed disclosed value. Trade value never
+determines inclusion or thresholds; it is the frozen split-invariant portfolio
+weight described below.
 
 An issuer is mapped to the frozen research corpus by SEC issuer CIK and exact
 reported trading symbol against the corpus-native vendor symbol. A unique-CIK
@@ -98,16 +99,20 @@ The primary monthly return is the executable long-opportunistic/short-routine
 spread; both legs pay their own round-trip costs:
 
 ```text
-opportunistic-minus-routine = value_weighted_long_net(opportunistic purchases)
-                              + value_weighted_short_net(routine purchases)
+opportunistic-minus-routine = purchase_value_weighted_long_net(opportunistic)
+                              + purchase_value_weighted_short_net(routine)
 ```
 
-Weights use market capitalisation known before formation: the most recently
-filed positive SEC common-shares count known by entry, multiplied by the prior
-usable close. A share count filed more than 15 months before entry is stale.
-Missing or stale shares and multi-class ambiguity refuse the firm-month.
-Weights are recomputed independently within each portfolio and sum to one.
-Equal-weight results are diagnostic and cannot replace the primary.
+The paper's market-cap weights cannot be reproduced honestly with this corpus:
+historical OHLC is back-adjusted for future splits, SEC share counts are
+as-reported, and `price_adjustments` contains no factors with which to put them
+on one basis. Multiplying those units would inject future split information.
+The frozen executable adaptation therefore weights each firm-month by the sum
+of its qualifying, contemporaneously disclosed `shares × transaction price`.
+These purchase-dollar weights are causal and split-invariant, but are **not**
+CMP market-cap weights and cannot inherit their headline result. Weights are
+recomputed independently within each portfolio and sum to one. Equal-weight
+results are diagnostic and cannot replace the primary.
 
 ## Prices, liquidity, costs and controls
 
@@ -128,7 +133,7 @@ Equal-weight results are diagnostic and cannot replace the primary.
 ## Sealed evidence and gate
 
 The report includes full 2022+, trailing 24/36 months, each recent calendar
-year, firm-month counts, active months, after-cost value-weight expectancy,
+year, firm-month counts, active months, after-cost purchase-value-weighted expectancy,
 month-clustered confidence interval, win rate, profit factor, worst month,
 expected shortfall, drawdown, turnover, gross concurrency/capacity proxies,
 market/sector-relative returns and every exclusion reason.

--- a/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
@@ -94,11 +94,12 @@ included once in that class's monthly portfolio. A firm may appear in both
 portfolios when distinct insiders from both classes buy it; overlap therefore
 cancels rather than being silently reassigned.
 
-The primary monthly return is:
+The primary monthly return is the executable long-opportunistic/short-routine
+spread; both legs pay their own round-trip costs:
 
 ```text
-opportunistic-minus-routine = value_weighted_net(opportunistic purchases)
-                              - value_weighted_net(routine purchases)
+opportunistic-minus-routine = value_weighted_long_net(opportunistic purchases)
+                              + value_weighted_short_net(routine purchases)
 ```
 
 Weights use market capitalisation known before formation: the most recently

--- a/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
@@ -47,9 +47,16 @@ insider purchase observation with summed disclosed value. Trade value is audit
 metadata only and never determines inclusion, weights or thresholds.
 
 An issuer is mapped to the frozen research corpus by SEC issuer CIK and exact
-reported trading symbol. A unique-CIK research series is also acceptable. An
+reported trading symbol against the corpus-native vendor symbol. A unique-CIK
+research series is also acceptable. Classification is performed across the
+complete SEC source before this mapping, so a missing current research series
+cannot erase an insider's prior history and alter their class. An
 ambiguous multi-class issuer, unresolved symbol or duplicate archive accession
 is refused rather than assigned to the most favourable listed class.
+
+The price corpus is survivor-only and cannot recover delisted outcomes. That
+limitation is a permanent promotion refusal for this trial even if the effect
+screen is favourable.
 
 ## Published classifier, made causal
 

--- a/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
@@ -103,9 +103,10 @@ opportunistic-minus-routine = value_weighted_net(opportunistic purchases)
 
 Weights use market capitalisation known before formation: the most recently
 filed positive SEC common-shares count known by entry, multiplied by the prior
-usable close. Missing or stale shares and multi-class ambiguity refuse the
-firm-month. Weights are recomputed independently within each portfolio and
-sum to one. Equal-weight results are diagnostic and cannot replace the primary.
+usable close. A share count filed more than 15 months before entry is stale.
+Missing or stale shares and multi-class ambiguity refuse the firm-month.
+Weights are recomputed independently within each portfolio and sum to one.
+Equal-weight results are diagnostic and cannot replace the primary.
 
 ## Prices, liquidity, costs and controls
 

--- a/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
+++ b/docs/proposals/ta/2026-08-10-insider-purchase-preregistration.md
@@ -1,0 +1,137 @@
+# Opportunistic insider-purchase preregistration
+
+Status: frozen before outcome measurement for #2480. Parent #2469.
+
+## Hypothesis and honest name
+
+This is a **purchase-only adaptation** of Cohen, Malloy and Pomorski (CMP),
+not a replication of their headline return. CMP classify insiders from their
+prior trading calendar and report an 82 bp/month value-weight five-factor alpha
+for a portfolio long opportunistic buys and short opportunistic sells. Their
+buy-only regression difference was about 77 bp/month. eBull deliberately does
+not infer a short signal from insider sales in this trial.
+
+The SEC's transaction code `P` means an open-market **or private** purchase.
+The free structured dataset does not separate those two cases, whereas CMP say
+they excluded private transactions. The candidate is therefore named
+"Form-4 code-P purchase" throughout and may not be represented as a pure
+exchange-purchase replication.
+
+Primary source: Lauren Cohen, Christopher Malloy and Lukasz Pomorski,
+*Decoding Inside Information*, NBER Working Paper 16454 / Journal of Finance
+67 (2012), pp. 1009-1043, especially pp. 11-12 and Table IV.
+
+## Frozen source population
+
+The source is the SEC Insider Transactions Data Sets from `2019q1` through the
+latest **complete** archive available before the sealed run. Archive filenames
+and a digest over their names and SHA-256 values identify the exact source.
+They are streamed from a bounded transient cache; no transaction history or
+derived indicator series is copied into the application database.
+
+Only a row satisfying every condition below is a purchase observation:
+
+- original Form 4 (`DOCUMENT_TYPE = '4'`), never Form 4/A or Form 5;
+- one and only one reporting owner on the accession, with a nonblank reporting
+  owner CIK; joint filings are attribution-ambiguous and refused;
+- `NONDERIV_TRANS`, transaction code `P`, acquired/disposed code `A`;
+- finite positive shares and price, no equity-swap flag and no deemed-execution
+  date; and
+- a transaction date no later than its filing date, a filing lag of at most
+  five calendar days, and no SEC `L` timeliness flag.
+
+CMP include officers, directors and 10% owners. This trial therefore imposes no
+post-hoc role, direct/indirect ownership or purchase-size selection. Multiple
+qualifying rows in one accession and transaction month are aggregated to one
+insider purchase observation with summed disclosed value. Trade value is audit
+metadata only and never determines inclusion, weights or thresholds.
+
+An issuer is mapped to the frozen research corpus by SEC issuer CIK and exact
+reported trading symbol. A unique-CIK research series is also acceptable. An
+ambiguous multi-class issuer, unresolved symbol or duplicate archive accession
+is refused rather than assigned to the most favourable listed class.
+
+## Published classifier, made causal
+
+Classification is fixed at the start of each calendar year `Y`, using only
+eligible purchases in `Y-3`, `Y-2` and `Y-1`:
+
+```text
+observed(Y)      = at least one eligible purchase in each prior year
+routine(Y)       = observed(Y) and intersection(months[Y-3], months[Y-2],
+                   months[Y-1]) is non-empty
+opportunistic(Y) = observed(Y) and not routine(Y)
+unclassified(Y)  = not observed(Y)
+```
+
+Every eligible purchase by that owner during `Y` inherits the annual label.
+This is CMP's trader-level baseline adapted to purchases only. It does not
+label a new or sparsely observed insider "opportunistic" merely because no
+routine was visible. The alternative trade-level classifier is another trial
+and is not opened here.
+
+## Knowledge time and monthly portfolio
+
+Historical archives expose filing date but not exact acceptance time. Exact
+`sec_filing_manifest.accepted_at`, where present, must not be later than the
+portfolio formation time. Otherwise the filing date is treated as an
+end-of-day knowledge boundary. Live firing requires exact acceptance and
+refuses without it.
+
+The portfolio signal month is the **filing** month, never the transaction
+month. Firms whose qualifying classified filings were known by month end `t`
+enter at the first usable regular-session open in month `t+1` and exit at the
+last usable regular-session close in that same month. This is a conservative,
+executable rendering of CMP Table IV: a firm with any qualifying purchase is
+included once in that class's monthly portfolio. A firm may appear in both
+portfolios when distinct insiders from both classes buy it; overlap therefore
+cancels rather than being silently reassigned.
+
+The primary monthly return is:
+
+```text
+opportunistic-minus-routine = value_weighted_net(opportunistic purchases)
+                              - value_weighted_net(routine purchases)
+```
+
+Weights use market capitalisation known before formation: the most recently
+filed positive SEC common-shares count known by entry, multiplied by the prior
+usable close. Missing or stale shares and multi-class ambiguity refuse the
+firm-month. Weights are recomputed independently within each portfolio and
+sum to one. Equal-weight results are diagnostic and cannot replace the primary.
+
+## Prices, liquidity, costs and controls
+
+- Outcome evidence starts 2022-01-01; older source rows form the three-year
+  classifier only. The frozen equity and comparator corpus ends 2026-07-08.
+- Entry price must be at least USD 5. The 20 sessions before entry must be
+  usable and their median close-times-volume at least USD 10m.
+- Entry and exit use the standing spread/slippage model. Dividends are absent
+  from the price corpus and no total-return claim is made.
+- SPY and the exact SIC-resolved Select Sector SPDR use comparator snapshot
+  `etoro-comparators-2026-07-08-v1`. Missing sessions or mappings are reported,
+  not imputed.
+- A deterministic matched control uses the same eligible firm in another
+  available formation month, matched on calendar year and quarter where
+  possible, with identical fill, holding, liquidity and cost treatment. The
+  random choice is made before outcome prices are read with seed `2480001`.
+
+## Sealed evidence and gate
+
+The report includes full 2022+, trailing 24/36 months, each recent calendar
+year, firm-month counts, active months, after-cost value-weight expectancy,
+month-clustered confidence interval, win rate, profit factor, worst month,
+expected shortfall, drawdown, turnover, gross concurrency/capacity proxies,
+market/sector-relative returns and every exclusion reason.
+
+The primary gate is a positive lower 95% confidence bound on the monthly
+opportunistic-minus-routine after-cost return. It must also beat the matched
+control and pass the standing stability, tail, cost, universe and execution
+gates. A 75% hit rate is neither required nor sufficient.
+
+This effect trial defines no ATR target, stop, ratchet or capital sizing.
+Passing it can only justify a separately preregistered portfolio/bracket and
+forward-shadow trial. Until then it is not added to the strategy manifest and
+cannot receive demo capital. Any negative or inconclusive result is retained in
+the global trial register; no threshold, lag, lookback, role, size or horizon is
+tuned against the same sealed interval.

--- a/docs/proposals/ta/2026-08-10-insider-purchase-result.md
+++ b/docs/proposals/ta/2026-08-10-insider-purchase-result.md
@@ -1,0 +1,66 @@
+# Opportunistic insider-purchase measured verdict
+
+Status: measured once and rejected for capital promotion under #2480.
+Preregistration: `2026-08-10-insider-purchase-preregistration.md`.
+
+## Frozen identity
+
+- trial: `form4-code-p-opportunistic-purchase-v1`
+- SEC archives: `2019q1_form345.zip` through `2026q1_form345.zip` (29
+  contiguous quarters)
+- archive manifest SHA-256:
+  `0531975fae43fa401cfdf26da42d50e383e20e0e5b72c7ed8ff5bcf8b9087d9f`
+- last complete portfolio month: 2026-04
+- source-classified purchases: 9,317
+- research-resolved classified purchases: 5,427
+- deduplicated firm-month signals: 2,839
+- complete primary portfolio months: 49
+
+## Sealed result
+
+The purchase-value-weighted long-opportunistic/short-routine primary spread
+averaged **+1.192% per month**, but its block-bootstrap 95% interval was
+**[-1.452%, +4.215%]**. The lower bound is not positive, so the primary effect
+gate fails.
+
+The timing-matched placebo averaged **+1.992% per month**. On the 46 months in
+which both portfolios were defined, primary minus placebo was **-0.721%** with
+a 95% interval of **[-5.825%, +3.930%]**. The control gate fails.
+
+Recent evidence is worse than the older full-period mean:
+
+| Window | Months | Mean/month | 95% interval | Win rate | Profit factor |
+|---|---:|---:|---:|---:|---:|
+| trailing 36 | 34 | -0.660% | [-3.581%, +2.468%] | 38.2% | 0.831 |
+| trailing 24 | 22 | -0.381% | [-3.170%, +3.090%] | 36.4% | 0.892 |
+| 2024 | 10 | -4.512% | [-9.178%, -0.112%] | 10.0% | 0.270 |
+| 2025 | 12 | +1.334% | [-2.369%, +5.727%] | 50.0% | 1.524 |
+| 2026 YTD | 4 | -3.094% | [-8.589%, +2.402%] | 25.0% | 0.312 |
+
+Full-period maximum drawdown was **-54.84%**, expected shortfall at 5% was
+**-14.29%**, and the worst month was **-14.89%**. Purchase-dollar weights
+reached **100% in one firm**, exposing unacceptable concentration. The
+equal-weight spread was **-1.148% per month**, so the favourable full-period
+weighted point estimate is not broad-based.
+
+## Decision
+
+`capital_candidate = false`. No manifest row, strategy-picker entry, bracket,
+forward resolver or allocation authority is created.
+
+The measured trial stays in the global register. It may not be rescued by
+searching role, purchase-size, filing-lag, weight-cap, holding-horizon, stop or
+target variants on the same interval. A materially new hypothesis needs a new
+preregistration and a genuinely forward cohort.
+
+Independent promotion blockers also remain: survivor-only price history,
+missing dividend total returns, historical rather than broker-proven costs,
+live exact-acceptance coverage, no registered tail bound, no bracket and no
+forward-shadow evidence.
+
+## Storage impact
+
+No application table was expanded. The 296 MB compressed SEC history was read
+from a transient source cache; only this aggregate verdict and the trial
+declaration are retained in git. No per-bar indicators, polling snapshots,
+signals or outcomes were inserted.

--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -60,7 +60,7 @@ what deserves a preregistered test; they are not backtest results.
 | --- | --- | --- | --- | --- |
 | **Broad equity beta / core allocation** | Compensation for bearing market risk; own corrected legacy comparator history measured about 6.3-6.6% annualised. This is the hurdle and no-alpha fallback, not a recent claim. | High for exact comparator total return to 2024; recent exact comparator is price return only. The main stock corpus separately has adjusted closes through 2026. | Conditional: the account-specific eligibility response must prove the proposed unleveraged instrument is the underlying product. | **Foundation, not an alpha trial.** Build correct total-return, FX, cash and dividend attribution before judging overlays. |
 | **Low-turnover cross-sectional factors** | Value, profitability/quality, investment, momentum and low-risk have extensive published priors. They can diversify a core but may be risk premia rather than arbitrage. | Medium: daily adjusted prices and SEC fundamentals exist, but point-in-time availability, delisted membership and recent total-return gaps must be closed. | Medium/high for long legs; short legs inherit CFD/borrow problems. | **Admit one simple long-only quality-plus-momentum tilt only after the foundation gate.** Monthly/quarterly turnover; no parameter sweep. Not a day-trade claim. |
-| **Opportunistic insider purchases** | A forced-information mechanism. Cohen, Malloy and Pomorski report routine trades as essentially uninformative and 82 bps/month abnormal return for opportunistic trades. | Medium/high: parser and 48,278 purchase rows exist, but 99% of usable history is 2023 onward and only 10% of purchasing insiders have three purchase-years. Filing acceptance time, not transaction date, must drive entry. | Conditional for liquid unleveraged longs; naturally low turnover. | **Priority alpha investigation because of the independent published prior and data fit, not the own-data point estimate.** Run a bounded historical-coverage pilot before authorising the full backfill, verify the exact classification, then preregister one reproduction. Current own estimates are contaminated development diagnostics and cannot rank or power the trial. |
+| **Opportunistic insider purchases** | A forced-information mechanism. Cohen, Malloy and Pomorski report routine trades as essentially uninformative and 82 bps/month abnormal return for opportunistic trades. | The causal 2019Q1–2026Q1 source and sealed 49-month reproduction are now retained in git. | Conditional for liquid unleveraged longs; naturally low turnover. | **Rejected under C-1.** The recent result was negative, the full-period interval crossed zero, placebo did better, drawdown/tail and single-name concentration failed. Preserve the family as evidence; do not retest neighbouring role/size/lag/weight/horizon/exit variants on the opened interval. |
 | **Extreme price-shock continuation (short)** | A forced-flow/information-shock hypothesis. Own searched result for shorting a >=12% one-day drop for five bars with a 20% stop showed +49 bps/trade after a 30% annual borrow stress, `t=4.83`, but had an -87% worst gap and emerged from about 100 searches. | Medium for OHLCV and event context; historical shortability and exact carry are absent. | **Blocked:** shorts are CFDs; firing names are likely hard-to-borrow and may be unavailable. Demo has no fees. | **Selected searched lead, not evidence or a prior.** Freeze the discovered rule, reconstruct its trial count, simulate portfolio tails, capture point-in-time shortability/cost, and assess only on new prospective data. Never use the searched +49 bps to calculate power or call 2020-2026 an untouched holdout. |
 | **Time-series / cross-sectional momentum** | Persistent prior across assets; crash risk rises after market declines amid high volatility and rebounds. Volatility scaling is evidence-based for this family. | High for daily research; recent total-return and PIT universe remain blockers. | Long implementation feasible; short implementation conditional. | Existing S-1/S-2 remain controls. A **new**, low-turnover factor tilt may be part of the factor trial above; do not tune the controls into candidates. |
 | **Short-term reversal / statistical arbitrage** | Usually compensation for liquidity provision; published strength rises in market stress. Exact residual versions need midpoint/factor inputs and both long/short legs. | Medium for a bounded 30m-4h on-demand spike, low for deep walk-forward and historical spread/shortability. Current daily RSI and residual-confluence implementations failed or are controls. | Low: short/carry plus roughly 50 bps round-trip economics consume the daily edge. | **Defer from the first trial budget, not for lack of any intraday history.** A future fixed replication may bootstrap the latest 1,000 REST bars, but promotion still needs prospective quotes/costs and a deeper untouched interval. No new daily-OHLC reversal variants. |
@@ -90,8 +90,9 @@ insiders. They supply priors and mechanisms, never eBull promotion evidence.
 
 ## 3. The initial research budget
 
-The first programme admits only three alpha/risk-overlay hypotheses. This is a
-budget, not a promise to produce three strategies.
+The first programme originally admitted three alpha/risk-overlay hypotheses. C-1
+has now consumed its one sealed trial and is rejected; only C-2 and C-3 remain open.
+This is a budget, not a promise to produce a strategy.
 
 ### Foundation F-0 — core and no-trade comparator
 
@@ -132,29 +133,20 @@ changes are separately identified as external flows. This is still not total ret
 distribution/cost reconciliation and the identity-safe recent benchmark remain open,
 so both return and benchmark fields continue to refuse availability.
 
-### Candidate C-1 — opportunistic insider purchase reproduction
+### Closed candidate C-1 — opportunistic insider purchase reproduction
 
-One preregistered rule, faithful to the published classification. Before the full
-backfill, sample bounded early/middle/recent accession cohorts and estimate usable
-filing, issuer, insider-identity and three-prior-year classification coverage. Stop if
-the projected recent independent population cannot power the declared minimum effect
-within the evidence horizon. Only then:
+The preregistered trial was opened once and rejected. Across 49 complete months, the
+purchase-value-weighted long-opportunistic/short-routine spread was +1.192%/month,
+but its 95% interval was [-1.452%, +4.215%]. The timing placebo did better; the
+primary-minus-placebo estimate was -0.721%. Trailing 24 and 36 months were negative,
+maximum drawdown was -54.84%, expected shortfall at 5% was -14.29%, equal weight was
+negative, and disclosed-value weights reached 100% in one issuer.
 
-1. Backfill Form 4 ownership XML to 2003 with filing acceptance timestamp, issuer,
-   security class, insider identity, role, transaction code and amendment lineage.
-2. Repair invalid transaction dates and measure parser/issuer coverage by year.
-3. Verify from the paper whether insiders without the required historical pattern
-   are opportunistic or unclassifiable; do not infer it.
-4. Freeze code `P` purchases, role exclusions, aggregation, liquidity floor,
-   next-executable fill, monthly holding/rebalance, benchmark adjustment, costs and
-   missing-data policy.
-5. Compare opportunistic purchases with routine purchases and a point-in-time
-   matched random-entry control. Use 2022 onward as primary relevance, older periods
-   as mechanism and stress evidence—not as a rescue for a recent failure.
-
-This trial is rejected if the recent conservative lower confidence bound on net
-expectancy is not positive, if the classification is not reproducible, or if results
-are concentrated in illiquid/unavailable names.
+Therefore `capital_candidate = false`. The causal source builder, sealed evaluator,
+tests, preregistration and aggregate verdict are retained in git and the trial count.
+No manifest row, strategy picker, bracket, resolver or allocation authority is
+created. The opened interval may not be mined for a rescue variant. See
+`2026-08-10-insider-purchase-result.md` and #2480.
 
 ### Candidate C-2 — frozen extreme-shock short, prospective confirmation
 
@@ -346,12 +338,11 @@ intraday REST is absent.
 
 ### Gate D-3 — bounded evidence sources
 
-1. **SEC Form 4 coverage pilot, then backfill if feasible** is the first source
-   expansion: official EDGAR submission history and stable XML are free, already
-   parsed, and directly unblock C-1. Sample bounded historical cohorts first; estimate
-   classifiable recent population and time-to-power before the full ingest. The
-   [SEC EDGAR APIs](https://www.sec.gov/search-filings/edgar-application-programming-interfaces)
-   provide public submissions and XBRL endpoints.
+1. **Do not expand Form 4 for rejected C-1.** Its 29-quarter transient source was
+   sufficient to reject the frozen reproduction and was deliberately not loaded into
+   application tables. A future Form 4 backfill requires a materially independent,
+   preregistered mechanism and a new storage/coverage case; it cannot be justified as
+   repair of C-1.
 2. **Prospective universe membership** continues. Nasdaq’s current symbol directory
    and daily list can help detect listings, delistings and corporate actions, but
    current files must not be advertised as a historical constituent archive. See the
@@ -408,8 +399,8 @@ The order is deliberately different from “build more strategies.”
    core/cash baseline.
 3. **Broker feasibility:** point-in-time product, shortability and cost preflight;
    prove demo/live semantic differences explicitly.
-4. **C-1 feasibility, data repair and preregistration:** bounded historical coverage
-   pilot; only then Form 4 backfill, classification and one sealed test.
+4. **C-1 closed:** retain its causal source/evaluator and failed aggregate verdict;
+   no backfill, picker entry or neighbouring rescue trial.
 5. **C-2 prospective contract:** portfolio tail simulation plus prospective
    shortability/cost/outcome capture; no further historical threshold search.
 6. **C-3 feasibility/preregistration:** only if point-in-time fundamentals and
@@ -460,12 +451,12 @@ The plan is ready to proceed when:
 - the operator sees the pot, benchmark/real return, risk, open automated positions,
   TP/SL/timeout, attribution and material refusals—not every ticker evaluated.
 
-The current state does **not** meet those conditions. It has enough evidence to choose
-the next bounded work, but not enough to turn on autonomous demo allocation. The most
-defensible sequence is core accounting and research-integrity repair first,
-opportunistic-insider reproduction second, and the frozen short-shock lead as a
-prospective broker-feasibility experiment. More technical-indicator combinations are
-not the next opportunity.
+The current state does **not** meet those conditions. It has enough evidence to close
+C-1 and choose the next bounded work, but not enough to turn on autonomous demo
+allocation. The defensible sequence is core accounting and research-integrity repair,
+then the frozen short-shock lead only as a prospective broker-feasibility experiment,
+with C-3 attempted only if its point-in-time data contract is feasible. More
+technical-indicator combinations are not the next opportunity.
 
 ## 10. External challenge incorporated
 

--- a/scripts/verify_2480_insider_outcomes.py
+++ b/scripts/verify_2480_insider_outcomes.py
@@ -39,6 +39,7 @@ def _print_segment(label: str, monthly: Sequence[MonthlyPortfolioReturn], seed: 
         cluster_by_date([item.spread_pct for item in monthly], [item.entry_date for item in monthly]), seed=seed
     )
     ci = "unavailable" if bootstrap is None else f"[{bootstrap.ci_low_pct:+.3f},{bootstrap.ci_high_pct:+.3f}]"
+    ess = "—" if bootstrap is None else f"{bootstrap.effective_sample_size:.1f}"
     expectancy = "—" if not monthly else f"{mean(item.spread_pct for item in monthly):+.3f}%"
     wins = "—" if not monthly else f"{sum(item.spread_pct > 0 for item in monthly) / len(monthly) * 100:.1f}%"
     pf = profit_factor(monthly)
@@ -46,12 +47,23 @@ def _print_segment(label: str, monthly: Sequence[MonthlyPortfolioReturn], seed: 
     tail = expected_shortfall_5_pct(monthly)
     eq = "—" if not monthly else f"{mean(item.equal_weight_spread_pct for item in monthly):+.3f}%"
     firms = median_firm_count(monthly)
+    worst = "—" if not monthly else f"{min(item.spread_pct for item in monthly):+.2f}%"
+    market = [item.market_relative_spread_pct for item in monthly if item.market_relative_spread_pct is not None]
+    sector = [item.sector_relative_spread_pct for item in monthly if item.sector_relative_spread_pct is not None]
+    market_text = "—" if not market else f"{mean(market):+.3f}%/{len(market)}"
+    sector_text = "—" if not sector else f"{mean(sector):+.3f}%/{len(sector)}"
+    maximum_firms = max((item.unique_firms for item in monthly), default=0)
+    minimum_liquidity = min((item.minimum_median_dollar_volume for item in monthly), default=None)
+    maximum_weight = max((item.maximum_single_firm_weight_pct for item in monthly), default=None)
     print(
-        f"{label:<22} months={len(monthly):>2} expectancy={expectancy:>9} CI={ci:<18} "
+        f"{label:<22} months={len(monthly):>2} ESS={ess:>5} expectancy={expectancy:>9} CI={ci:<18} "
         f"wins={wins:>6} PF={'—' if pf is None else f'{pf:.3f}':>6} "
         f"MDD={'—' if drawdown is None else f'{drawdown:+.2f}%':>8} "
-        f"ES5={'—' if tail is None else f'{tail:+.2f}%':>8} EW={eq:>9} "
-        f"median firms={'—' if firms is None else f'{firms:.1f}'}"
+        f"ES5={'—' if tail is None else f'{tail:+.2f}%':>8} worst={worst:>8} EW={eq:>9} "
+        f"vsSPY={market_text:>12} vsSector={sector_text:>12} "
+        f"firms median/max={'—' if firms is None else f'{firms:.1f}'}/{maximum_firms} "
+        f"minADV={'—' if minimum_liquidity is None else f'${minimum_liquidity:,.0f}'} "
+        f"maxWeight={'—' if maximum_weight is None else f'{maximum_weight:.1f}%'}"
     )
 
 
@@ -135,7 +147,25 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  {reason:<50} {count:>12,}")
     print("\npromotion refusals: survivor_only, total_return_dividends_absent, live_exact_acceptance_required,")
     print("                    bracket_not_defined, forward_shadow_absent, broker_cost_contract_unproven")
-    return 0
+    primary_effect_pass = evidence.bootstrap is not None and evidence.bootstrap.ci_low_pct > 0
+    matched_control_pass = paired_bootstrap is not None and paired_bootstrap.ci_low_pct > 0
+    full_years = {
+        year: [item for item in evidence.monthly_returns if item.entry_date.year == year]
+        for year in range(2022, last_entry.year)
+    }
+    stability_pass = bool(full_years) and all(
+        len(items) >= 10 and mean(item.spread_pct for item in items) > 0 for items in full_years.values()
+    )
+    print("\nexplicit gates")
+    print(f"  primary positive lower CI:            {'PASS' if primary_effect_pass else 'FAIL'}")
+    print(f"  primary beats matched control by CI:  {'PASS' if matched_control_pass else 'FAIL'}")
+    print(f"  completed-year sign stability:        {'PASS' if stability_pass else 'FAIL'}")
+    print("  tail threshold:                       BLOCKED — no capital-trial bound registered")
+    print("  point-in-time universe:               BLOCKED — survivor-only price corpus")
+    print("  live cost/borrow contract:             BLOCKED — historical estimate only")
+    print("  bracket and forward shadow:            BLOCKED — separate trial not defined")
+    print("  PROMOTION:                             BLOCKED")
+    return 1
 
 
 if __name__ == "__main__":

--- a/scripts/verify_2480_insider_outcomes.py
+++ b/scripts/verify_2480_insider_outcomes.py
@@ -93,7 +93,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"source-classified observations: {len(source.source_classified):,}")
     print(f"research-resolved classified observations: {len(source.classified):,}")
     print(f"deduplicated firm-month signals: {len(signals):,}")
-    print("\nmonthly opportunistic-minus-routine value-weight returns")
+    print("\nmonthly opportunistic-minus-routine disclosed-purchase-value-weighted returns")
     _print_segment("2022+ primary", evidence.monthly_returns, BOOTSTRAP_SEED)
     _print_segment("matched random", control.monthly_returns, BOOTSTRAP_SEED + 1)
     for months in (36, 24):

--- a/scripts/verify_2480_insider_outcomes.py
+++ b/scripts/verify_2480_insider_outcomes.py
@@ -1,0 +1,142 @@
+"""Open and report #2480's preregistered sealed outcome interval once."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from datetime import date
+from pathlib import Path
+from statistics import mean
+
+import psycopg
+
+from app.config import settings
+from app.services.block_bootstrap import BootstrapResult, block_bootstrap_expectancy, cluster_by_date
+from app.services.insider_purchase_candidate import build_source
+from app.services.insider_purchase_outcomes import (
+    BOOTSTRAP_SEED,
+    MonthlyPortfolioReturn,
+    PortfolioEvaluation,
+    build_firm_month_signals,
+    build_matched_control_signals,
+    evaluate_portfolios,
+    expected_shortfall_5_pct,
+    maximum_drawdown_pct,
+    median_firm_count,
+    profit_factor,
+)
+
+
+def _subtract_months(value: date, months: int) -> date:
+    absolute = value.year * 12 + value.month - 1 - months
+    year, zero_month = divmod(absolute, 12)
+    return date(year, zero_month + 1, 1)
+
+
+def _print_segment(label: str, monthly: Sequence[MonthlyPortfolioReturn], seed: int) -> None:
+    bootstrap = block_bootstrap_expectancy(
+        cluster_by_date([item.spread_pct for item in monthly], [item.entry_date for item in monthly]), seed=seed
+    )
+    ci = "unavailable" if bootstrap is None else f"[{bootstrap.ci_low_pct:+.3f},{bootstrap.ci_high_pct:+.3f}]"
+    expectancy = "—" if not monthly else f"{mean(item.spread_pct for item in monthly):+.3f}%"
+    wins = "—" if not monthly else f"{sum(item.spread_pct > 0 for item in monthly) / len(monthly) * 100:.1f}%"
+    pf = profit_factor(monthly)
+    drawdown = maximum_drawdown_pct(monthly)
+    tail = expected_shortfall_5_pct(monthly)
+    eq = "—" if not monthly else f"{mean(item.equal_weight_spread_pct for item in monthly):+.3f}%"
+    firms = median_firm_count(monthly)
+    print(
+        f"{label:<22} months={len(monthly):>2} expectancy={expectancy:>9} CI={ci:<18} "
+        f"wins={wins:>6} PF={'—' if pf is None else f'{pf:.3f}':>6} "
+        f"MDD={'—' if drawdown is None else f'{drawdown:+.2f}%':>8} "
+        f"ES5={'—' if tail is None else f'{tail:+.2f}%':>8} EW={eq:>9} "
+        f"median firms={'—' if firms is None else f'{firms:.1f}'}"
+    )
+
+
+def _paired_control_difference(
+    evidence: PortfolioEvaluation, control: PortfolioEvaluation
+) -> tuple[int, float | None, BootstrapResult | None]:
+    evidence_by_month = {item.entry_date: item.spread_pct for item in evidence.monthly_returns}
+    control_by_month = {item.entry_date: item.spread_pct for item in control.monthly_returns}
+    dates = sorted(evidence_by_month.keys() & control_by_month.keys())
+    values = [evidence_by_month[item] - control_by_month[item] for item in dates]
+    bootstrap = block_bootstrap_expectancy(cluster_by_date(values, dates), seed=BOOTSTRAP_SEED + 99)
+    return len(values), (mean(values) if values else None), bootstrap
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive-dir", type=Path, required=True)
+    parser.add_argument("--last-quarter", required=True)
+    parser.add_argument("--open-sealed-holdout", action="store_true")
+    args = parser.parse_args(argv)
+    if not args.open_sealed_holdout:
+        parser.error("pass --open-sealed-holdout only after source and outcome code are frozen and reviewed")
+    archives = sorted(args.archive_dir.glob("*_form345.zip"))
+
+    with psycopg.connect(settings.database_url) as conn:
+        source = build_source(conn, archives, expected_last_quarter=args.last_quarter)
+        signals = build_firm_month_signals(source.classified)
+        controls, control_match = build_matched_control_signals(signals)
+        evidence = evaluate_portfolios(conn, signals)
+        control = evaluate_portfolios(conn, controls)
+        conn.rollback()
+
+    if not evidence.monthly_returns:
+        raise RuntimeError("the preregistered outcome population is empty")
+    last_entry = max(item.entry_date for item in evidence.monthly_returns)
+    print("#2480 sealed outcome report")
+    print(f"archive manifest SHA-256: {source.archive_manifest_sha256}")
+    print(f"latest complete portfolio month: {last_entry:%Y-%m}")
+    print(f"source-classified observations: {len(source.source_classified):,}")
+    print(f"research-resolved classified observations: {len(source.classified):,}")
+    print(f"deduplicated firm-month signals: {len(signals):,}")
+    print("\nmonthly opportunistic-minus-routine value-weight returns")
+    _print_segment("2022+ primary", evidence.monthly_returns, BOOTSTRAP_SEED)
+    _print_segment("matched random", control.monthly_returns, BOOTSTRAP_SEED + 1)
+    for months in (36, 24):
+        start = _subtract_months(last_entry, months)
+        _print_segment(
+            f"trailing {months} months",
+            [item for item in evidence.monthly_returns if start <= item.entry_date <= last_entry],
+            BOOTSTRAP_SEED + months,
+        )
+    for year in sorted({item.entry_date.year for item in evidence.monthly_returns}):
+        _print_segment(
+            str(year),
+            [item for item in evidence.monthly_returns if item.entry_date.year == year],
+            BOOTSTRAP_SEED + year,
+        )
+
+    paired_n, paired_mean, paired_bootstrap = _paired_control_difference(evidence, control)
+    paired_ci = (
+        "unavailable"
+        if paired_bootstrap is None
+        else f"[{paired_bootstrap.ci_low_pct:+.3f},{paired_bootstrap.ci_high_pct:+.3f}]"
+    )
+    print(
+        f"\nprimary minus matched-control spread: months={paired_n} "
+        f"expectancy={'—' if paired_mean is None else f'{paired_mean:+.3f}%'} CI={paired_ci}"
+    )
+    print("declared monthly portfolio turnover: 200% per cohort (one full entry + exit)")
+    print("\nsource exclusions and census")
+    for reason, count in source.refusals.items():
+        print(f"  {reason:<50} {count:>12,}")
+    print("\noutcome refusals")
+    for reason, count in evidence.refusals.items():
+        print(f"  {reason:<50} {count:>12,}")
+    print("\ncontrol matching")
+    for reason, count in control_match.items():
+        print(f"  {reason:<50} {count:>12,}")
+    print("\ncontrol outcome refusals")
+    for reason, count in control.refusals.items():
+        print(f"  {reason:<50} {count:>12,}")
+    print("\npromotion refusals: survivor_only, total_return_dividends_absent, live_exact_acceptance_required,")
+    print("                    bracket_not_defined, forward_shadow_absent, broker_cost_contract_unproven")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2480_insider_outcomes.py
+++ b/scripts/verify_2480_insider_outcomes.py
@@ -109,7 +109,7 @@ def main(argv: list[str] | None = None) -> int:
     _print_segment("2022+ primary", evidence.monthly_returns, BOOTSTRAP_SEED)
     _print_segment("matched random", control.monthly_returns, BOOTSTRAP_SEED + 1)
     for months in (36, 24):
-        start = _subtract_months(last_entry, months)
+        start = _subtract_months(last_entry, months - 1)
         _print_segment(
             f"trailing {months} months",
             [item for item in evidence.monthly_returns if start <= item.entry_date <= last_entry],

--- a/scripts/verify_2480_insider_source.py
+++ b/scripts/verify_2480_insider_source.py
@@ -16,6 +16,7 @@ from app.services.insider_purchase_candidate import PRIMARY_START, build_source
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--archive-dir", type=Path, required=True)
+    parser.add_argument("--last-quarter", required=True, help="pinned latest available archive, YYYYqN")
     args = parser.parse_args(argv)
     archives = sorted(args.archive_dir.glob("*_form345.zip"))
     if not archives:
@@ -23,7 +24,7 @@ def main(argv: list[str] | None = None) -> int:
 
     with psycopg.connect(settings.database_url) as conn:
         conn.execute("SET TRANSACTION READ ONLY")
-        build = build_source(conn, archives)
+        build = build_source(conn, archives, expected_last_quarter=args.last_quarter)
 
     recent = [item for item in build.classified if item.observation.filed_date >= PRIMARY_START]
     classes = Counter(item.insider_class for item in recent)
@@ -31,8 +32,9 @@ def main(argv: list[str] | None = None) -> int:
     print("#2480 source-only census — no outcome prices read")
     print(f"archives: {archives[0].name} .. {archives[-1].name} ({len(archives)})")
     print(f"archive manifest SHA-256: {build.archive_manifest_sha256}")
-    print(f"eligible resolved purchase observations: {len(build.purchases):,}")
-    print(f"classified observations, all source years: {len(build.classified):,}")
+    print(f"eligible source purchase observations: {len(build.purchases):,}")
+    print(f"classified observations before universe resolution: {len(build.source_classified):,}")
+    print(f"classified observations with research series: {len(build.classified):,}")
     print(f"classified since 2022: {len(recent):,} across {len(months):,} filing months")
     print(f"recent routine={classes['routine']:,} opportunistic={classes['opportunistic']:,}")
     print("\nsource construction counters")

--- a/scripts/verify_2480_insider_source.py
+++ b/scripts/verify_2480_insider_source.py
@@ -1,0 +1,45 @@
+"""Build #2480's source-only population without reading any outcome price."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+import psycopg
+
+from app.config import settings
+from app.services.insider_purchase_candidate import PRIMARY_START, build_source
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    archives = sorted(args.archive_dir.glob("*_form345.zip"))
+    if not archives:
+        parser.error("archive directory contains no *_form345.zip files")
+
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET TRANSACTION READ ONLY")
+        build = build_source(conn, archives)
+
+    recent = [item for item in build.classified if item.observation.filed_date >= PRIMARY_START]
+    classes = Counter(item.insider_class for item in recent)
+    months = {item.signal_month for item in recent}
+    print("#2480 source-only census — no outcome prices read")
+    print(f"archives: {archives[0].name} .. {archives[-1].name} ({len(archives)})")
+    print(f"archive manifest SHA-256: {build.archive_manifest_sha256}")
+    print(f"eligible resolved purchase observations: {len(build.purchases):,}")
+    print(f"classified observations, all source years: {len(build.classified):,}")
+    print(f"classified since 2022: {len(recent):,} across {len(months):,} filing months")
+    print(f"recent routine={classes['routine']:,} opportunistic={classes['opportunistic']:,}")
+    print("\nsource construction counters")
+    for reason, count in build.refusals.items():
+        print(f"  {reason:<48} {count:>12,}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_insider_purchase_candidate.py
+++ b/tests/test_insider_purchase_candidate.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.services.insider_purchase_candidate import (
     PurchaseObservation,
+    build_research_resolution,
     classify_purchases,
     resolve_research_instrument,
     validate_archive_sequence,
@@ -80,3 +81,15 @@ def test_exact_cik_symbol_resolves_a_multi_series_issuer_before_unique_fallback(
     exact = {("0000000001", "AAA"): 1, ("0000000001", "AAB"): 2}
     assert resolve_research_instrument("0000000001", "AAB", exact, {}) == (2, False)
     assert resolve_research_instrument("0000000002", "OLD", exact, {"0000000002": 3}) == (3, True)
+
+
+def test_duplicate_exact_cik_symbol_mapping_is_refused() -> None:
+    exact, unique = build_research_resolution(
+        [
+            ("0000000001", "AAA", 1),
+            ("0000000001", "AAA", 2),
+        ]
+    )
+    assert exact == {}
+    assert unique == {}
+    assert resolve_research_instrument("0000000001", "AAA", exact, unique) == (None, False)

--- a/tests/test_insider_purchase_candidate.py
+++ b/tests/test_insider_purchase_candidate.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
+from pathlib import Path
 
-from app.services.insider_purchase_candidate import PurchaseObservation, classify_purchases
+import pytest
+
+from app.services.insider_purchase_candidate import (
+    PurchaseObservation,
+    classify_purchases,
+    validate_archive_sequence,
+)
 
 
 def _purchase(year: int, month: int, *, filer: str = "0000000001") -> PurchaseObservation:
@@ -56,3 +63,13 @@ def test_sparse_insider_is_not_mislabelled_opportunistic() -> None:
     classified, counts = classify_purchases([_purchase(2023, 1), _purchase(2025, 2)])
     assert classified == ()
     assert counts["unclassified_missing_prior_purchase_year"] == 2
+
+
+def test_archive_sequence_requires_pinned_contiguous_history() -> None:
+    paths = [
+        Path("2019q1_form345.zip"),
+        Path("2019q2_form345.zip"),
+    ]
+    validate_archive_sequence(paths, expected_last_quarter="2019q2")
+    with pytest.raises(ValueError, match="contiguous"):
+        validate_archive_sequence(paths[:1], expected_last_quarter="2019q2")

--- a/tests/test_insider_purchase_candidate.py
+++ b/tests/test_insider_purchase_candidate.py
@@ -9,6 +9,7 @@ import pytest
 from app.services.insider_purchase_candidate import (
     PurchaseObservation,
     classify_purchases,
+    resolve_research_instrument,
     validate_archive_sequence,
 )
 
@@ -73,3 +74,9 @@ def test_archive_sequence_requires_pinned_contiguous_history() -> None:
     validate_archive_sequence(paths, expected_last_quarter="2019q2")
     with pytest.raises(ValueError, match="contiguous"):
         validate_archive_sequence(paths[:1], expected_last_quarter="2019q2")
+
+
+def test_exact_cik_symbol_resolves_a_multi_series_issuer_before_unique_fallback() -> None:
+    exact = {("0000000001", "AAA"): 1, ("0000000001", "AAB"): 2}
+    assert resolve_research_instrument("0000000001", "AAB", exact, {}) == (2, False)
+    assert resolve_research_instrument("0000000002", "OLD", exact, {"0000000002": 3}) == (3, True)

--- a/tests/test_insider_purchase_candidate.py
+++ b/tests/test_insider_purchase_candidate.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.insider_purchase_candidate import PurchaseObservation, classify_purchases
+
+
+def _purchase(year: int, month: int, *, filer: str = "0000000001") -> PurchaseObservation:
+    day = date(year, month, 2)
+    return PurchaseObservation(
+        issuer_cik="0000000010",
+        issuer_symbol="ABC",
+        accession_number=f"{filer}-{year}-{month}",
+        filer_cik=filer,
+        transaction_date=day,
+        filed_date=day,
+        disclosed_value=Decimal("1000"),
+    )
+
+
+def test_classifier_uses_only_three_complete_prior_years() -> None:
+    purchases = [_purchase(2022, 2), _purchase(2023, 3), _purchase(2024, 4), _purchase(2025, 5)]
+    classified, counts = classify_purchases(purchases)
+    assert [item.insider_class for item in classified] == ["opportunistic"]
+    assert classified[0].observation.transaction_date.year == 2025
+    assert counts["unclassified_missing_prior_purchase_year"] == 3
+
+
+def test_same_month_intersection_makes_all_current_year_purchases_routine() -> None:
+    purchases = [
+        _purchase(2021, 6),
+        _purchase(2022, 2),
+        _purchase(2022, 6),
+        _purchase(2023, 6),
+        _purchase(2024, 1),
+        _purchase(2024, 11),
+    ]
+    classified, _ = classify_purchases(purchases)
+    assert [(item.observation.transaction_date.month, item.insider_class) for item in classified] == [
+        (1, "routine"),
+        (11, "routine"),
+    ]
+
+
+def test_history_is_at_insider_level_across_issuers() -> None:
+    history = [_purchase(2021, 1), _purchase(2022, 2), _purchase(2023, 3)]
+    current = _purchase(2024, 4)
+    current = PurchaseObservation(**{**current.__dict__, "issuer_cik": "0000000099"})
+    classified, _ = classify_purchases([*history, current])
+    assert len(classified) == 1
+    assert classified[0].insider_class == "opportunistic"
+
+
+def test_sparse_insider_is_not_mislabelled_opportunistic() -> None:
+    classified, counts = classify_purchases([_purchase(2023, 1), _purchase(2025, 2)])
+    assert classified == ()
+    assert counts["unclassified_missing_prior_purchase_year"] == 2

--- a/tests/test_insider_purchase_outcomes.py
+++ b/tests/test_insider_purchase_outcomes.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+from app.services.insider_purchase_candidate import ClassifiedPurchase, PurchaseObservation
+from app.services.insider_purchase_outcomes import (
+    MonthlyPortfolioReturn,
+    build_firm_month_signals,
+    build_matched_control_signals,
+    expected_shortfall_5_pct,
+    maximum_drawdown_pct,
+    profit_factor,
+)
+
+
+def _classified(insider_class: str, *, accession: str, month: int) -> ClassifiedPurchase:
+    observation = PurchaseObservation(
+        issuer_cik="0000000001",
+        issuer_symbol="ABC",
+        accession_number=accession,
+        filer_cik="0000000002",
+        transaction_date=date(2024, month, 2),
+        filed_date=date(2024, month, 4),
+        disclosed_value=Decimal("1000"),
+        accepted_at=datetime(2024, month, 4, 20, tzinfo=UTC),
+        instrument_id=7,
+    )
+    return ClassifiedPurchase(observation=observation, insider_class=insider_class)  # type: ignore[arg-type]
+
+
+def _month(value: float) -> MonthlyPortfolioReturn:
+    return MonthlyPortfolioReturn(
+        entry_date=date(2024, 1, 2),
+        opportunistic_pct=value,
+        routine_pct=0,
+        spread_pct=value,
+        equal_weight_spread_pct=value,
+        market_relative_spread_pct=None,
+        sector_relative_spread_pct=None,
+        opportunistic_firms=1,
+        routine_firms=1,
+        unique_firms=2,
+        minimum_median_dollar_volume=Decimal("10000000"),
+    )
+
+
+def test_firm_month_signals_deduplicate_accessions_but_preserve_classes() -> None:
+    signals = build_firm_month_signals(
+        [
+            _classified("opportunistic", accession="a", month=1),
+            _classified("opportunistic", accession="b", month=1),
+            _classified("routine", accession="c", month=1),
+        ]
+    )
+    assert len(signals) == 2
+    opportunistic = next(item for item in signals if item.insider_class == "opportunistic")
+    assert opportunistic.accession_numbers == ("a", "b")
+
+
+def test_control_moves_within_same_quarter_and_is_deterministic() -> None:
+    signal = build_firm_month_signals([_classified("opportunistic", accession="a", month=2)])[0]
+    first, _ = build_matched_control_signals([signal])
+    second, _ = build_matched_control_signals([signal])
+    assert first == second
+    assert first[0].signal_month in {1, 3}
+    assert first[0].signal_month != signal.signal_month
+
+
+def test_portfolio_tail_metrics_use_monthly_spread_distribution() -> None:
+    monthly = [_month(10), _month(-5), _month(4), _month(-2)]
+    assert profit_factor(monthly) == 14 / 7
+    assert expected_shortfall_5_pct(monthly) == -5
+    assert maximum_drawdown_pct(monthly) is not None
+    assert maximum_drawdown_pct(monthly) < 0  # type: ignore[operator]

--- a/tests/test_insider_purchase_outcomes.py
+++ b/tests/test_insider_purchase_outcomes.py
@@ -123,6 +123,27 @@ def test_control_never_uses_a_treated_firm_class_month() -> None:
     assert {item.signal_month for item in controls} == {3}
 
 
+def test_control_excludes_treated_months_across_both_classes() -> None:
+    signals = build_firm_month_signals(
+        [
+            _classified("opportunistic", accession="a", month=1),
+            _classified("routine", accession="b", month=2),
+        ]
+    )
+    controls, _ = build_matched_control_signals(signals)
+    assert controls
+    assert {item.signal_month for item in controls} == {3}
+
+
+def test_portfolio_groups_different_usable_entry_days_in_same_target_month() -> None:
+    opportunistic = _outcome("opportunistic", cik="1", long_net=3, short_net=-4, market_cap="1")
+    routine = _outcome("routine", cik="2", long_net=1, short_net=-2, market_cap="1")
+    routine = FirmMonthOutcome(**{**routine.__dict__, "entry_date": date(2024, 2, 2)})
+    monthly = _portfolio_months([opportunistic, routine], Counter())
+    assert len(monthly) == 1
+    assert monthly[0].entry_date == date(2024, 2, 1)
+
+
 def test_primary_weights_by_market_cap_and_charges_short_routine_leg() -> None:
     monthly = _portfolio_months(
         [

--- a/tests/test_insider_purchase_outcomes.py
+++ b/tests/test_insider_purchase_outcomes.py
@@ -87,6 +87,7 @@ def _month(value: float) -> MonthlyPortfolioReturn:
         routine_firms=1,
         unique_firms=2,
         minimum_median_dollar_volume=Decimal("10000000"),
+        maximum_single_firm_weight_pct=50,
     )
 
 
@@ -119,9 +120,10 @@ def test_control_never_uses_a_treated_firm_class_month() -> None:
             _classified("opportunistic", accession="b", month=2),
         ]
     )
-    controls, _ = build_matched_control_signals(signals)
+    controls, counts = build_matched_control_signals(signals)
     assert controls
     assert {item.signal_month for item in controls} == {3}
+    assert counts["matched_control_firm_months"] + counts["control_cell_unmatched_signals"] == len(signals)
 
 
 def test_control_excludes_treated_months_across_both_classes() -> None:
@@ -191,7 +193,8 @@ def test_partial_frontier_month_and_late_acceptance_are_refused() -> None:
 
 
 def test_sql_selects_usable_sessions_and_rejects_partial_frontier_month() -> None:
-    assert _WINDOW_SQL.count("WHERE e.return_usable") == 2
+    assert _WINDOW_SQL.count("WHERE e.return_usable") == 1
+    assert "rn <= 20 AND return_usable" in _WINDOW_SQL
     assert "target_end <= date_trunc('month'" in _WINDOW_SQL
 
 

--- a/tests/test_insider_purchase_outcomes.py
+++ b/tests/test_insider_purchase_outcomes.py
@@ -44,6 +44,7 @@ def _signal(insider_class: InsiderClass, *, cik: str, instrument_id: int = 7) ->
         signal_year=2024,
         signal_month=1,
         accession_numbers=("a",),
+        disclosed_value=Decimal("1000"),
         latest_acceptance=None,
     )
 
@@ -54,7 +55,7 @@ def _outcome(
     cik: str,
     long_net: float,
     short_net: float,
-    market_cap: str,
+    weight_value: str,
 ) -> FirmMonthOutcome:
     return FirmMonthOutcome(
         signal=_signal(insider_class, cik=cik),
@@ -63,7 +64,7 @@ def _outcome(
         net_return_pct=long_net,
         short_net_return_pct=short_net,
         gross_return_pct=long_net,
-        market_cap=Decimal(market_cap),
+        weight_value=Decimal(weight_value),
         median_dollar_volume=Decimal("20000000"),
         market_relative_pct=long_net,
         short_market_relative_pct=short_net,
@@ -136,20 +137,20 @@ def test_control_excludes_treated_months_across_both_classes() -> None:
 
 
 def test_portfolio_groups_different_usable_entry_days_in_same_target_month() -> None:
-    opportunistic = _outcome("opportunistic", cik="1", long_net=3, short_net=-4, market_cap="1")
-    routine = _outcome("routine", cik="2", long_net=1, short_net=-2, market_cap="1")
+    opportunistic = _outcome("opportunistic", cik="1", long_net=3, short_net=-4, weight_value="1")
+    routine = _outcome("routine", cik="2", long_net=1, short_net=-2, weight_value="1")
     routine = FirmMonthOutcome(**{**routine.__dict__, "entry_date": date(2024, 2, 2)})
     monthly = _portfolio_months([opportunistic, routine], Counter())
     assert len(monthly) == 1
     assert monthly[0].entry_date == date(2024, 2, 1)
 
 
-def test_primary_weights_by_market_cap_and_charges_short_routine_leg() -> None:
+def test_primary_weights_by_disclosed_value_and_charges_short_routine_leg() -> None:
     monthly = _portfolio_months(
         [
-            _outcome("opportunistic", cik="1", long_net=0, short_net=-1, market_cap="1"),
-            _outcome("opportunistic", cik="2", long_net=8, short_net=-9, market_cap="3"),
-            _outcome("routine", cik="3", long_net=4, short_net=-6, market_cap="2"),
+            _outcome("opportunistic", cik="1", long_net=0, short_net=-1, weight_value="1"),
+            _outcome("opportunistic", cik="2", long_net=8, short_net=-9, weight_value="3"),
+            _outcome("routine", cik="3", long_net=4, short_net=-6, weight_value="2"),
         ],
         Counter(),
     )
@@ -175,8 +176,6 @@ def test_partial_frontier_month_and_late_acceptance_are_refused() -> None:
         prior_sessions=20,
         valid_liquidity_sessions=20,
         median_dollar_volume=Decimal("20000000"),
-        shares_outstanding=Decimal("1000000"),
-        shares_filed_date=date(2023, 12, 1),
     )
     assert _eligible_window(window) == "incomplete_target_month_at_corpus_frontier"
     late = FirmMonthWindow(

--- a/tests/test_insider_purchase_outcomes.py
+++ b/tests/test_insider_purchase_outcomes.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+from collections import Counter
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
-from app.services.insider_purchase_candidate import ClassifiedPurchase, PurchaseObservation
+from app.services.insider_purchase_candidate import ClassifiedPurchase, InsiderClass, PurchaseObservation
 from app.services.insider_purchase_outcomes import (
+    _WINDOW_SQL,
+    FirmMonthOutcome,
+    FirmMonthSignal,
+    FirmMonthWindow,
     MonthlyPortfolioReturn,
+    _eligible_window,
+    _portfolio_months,
     build_firm_month_signals,
     build_matched_control_signals,
     expected_shortfall_5_pct,
@@ -14,7 +21,7 @@ from app.services.insider_purchase_outcomes import (
 )
 
 
-def _classified(insider_class: str, *, accession: str, month: int) -> ClassifiedPurchase:
+def _classified(insider_class: InsiderClass, *, accession: str, month: int) -> ClassifiedPurchase:
     observation = PurchaseObservation(
         issuer_cik="0000000001",
         issuer_symbol="ABC",
@@ -26,7 +33,44 @@ def _classified(insider_class: str, *, accession: str, month: int) -> Classified
         accepted_at=datetime(2024, month, 4, 20, tzinfo=UTC),
         instrument_id=7,
     )
-    return ClassifiedPurchase(observation=observation, insider_class=insider_class)  # type: ignore[arg-type]
+    return ClassifiedPurchase(observation=observation, insider_class=insider_class)
+
+
+def _signal(insider_class: InsiderClass, *, cik: str, instrument_id: int = 7) -> FirmMonthSignal:
+    return FirmMonthSignal(
+        issuer_cik=cik,
+        instrument_id=instrument_id,
+        insider_class=insider_class,
+        signal_year=2024,
+        signal_month=1,
+        accession_numbers=("a",),
+        latest_acceptance=None,
+    )
+
+
+def _outcome(
+    insider_class: InsiderClass,
+    *,
+    cik: str,
+    long_net: float,
+    short_net: float,
+    market_cap: str,
+) -> FirmMonthOutcome:
+    return FirmMonthOutcome(
+        signal=_signal(insider_class, cik=cik),
+        entry_date=date(2024, 2, 1),
+        exit_date=date(2024, 2, 29),
+        net_return_pct=long_net,
+        short_net_return_pct=short_net,
+        gross_return_pct=long_net,
+        market_cap=Decimal(market_cap),
+        median_dollar_volume=Decimal("20000000"),
+        market_relative_pct=long_net,
+        short_market_relative_pct=short_net,
+        sector_relative_pct=long_net,
+        short_sector_relative_pct=short_net,
+        sector_symbol="XLK",
+    )
 
 
 def _month(value: float) -> MonthlyPortfolioReturn:
@@ -65,6 +109,70 @@ def test_control_moves_within_same_quarter_and_is_deterministic() -> None:
     assert first == second
     assert first[0].signal_month in {1, 3}
     assert first[0].signal_month != signal.signal_month
+
+
+def test_control_never_uses_a_treated_firm_class_month() -> None:
+    signals = build_firm_month_signals(
+        [
+            _classified("opportunistic", accession="a", month=1),
+            _classified("opportunistic", accession="b", month=2),
+        ]
+    )
+    controls, _ = build_matched_control_signals(signals)
+    assert controls
+    assert {item.signal_month for item in controls} == {3}
+
+
+def test_primary_weights_by_market_cap_and_charges_short_routine_leg() -> None:
+    monthly = _portfolio_months(
+        [
+            _outcome("opportunistic", cik="1", long_net=0, short_net=-1, market_cap="1"),
+            _outcome("opportunistic", cik="2", long_net=8, short_net=-9, market_cap="3"),
+            _outcome("routine", cik="3", long_net=4, short_net=-6, market_cap="2"),
+        ],
+        Counter(),
+    )
+    assert len(monthly) == 1
+    assert monthly[0].opportunistic_pct == 6
+    assert monthly[0].routine_pct == 4
+    assert monthly[0].spread_pct == 0
+
+
+def test_partial_frontier_month_and_late_acceptance_are_refused() -> None:
+    window = FirmMonthWindow(
+        signal=_signal("opportunistic", cik="1"),
+        series_id=1,
+        target_month_complete=False,
+        entry_date=date(2024, 2, 1),
+        entry_open=Decimal("10"),
+        exit_date=date(2024, 2, 29),
+        exit_close=Decimal("11"),
+        holding_sessions=20,
+        holding_usable=True,
+        prior_close=Decimal("10"),
+        prior_close_usable=True,
+        prior_sessions=20,
+        valid_liquidity_sessions=20,
+        median_dollar_volume=Decimal("20000000"),
+        shares_outstanding=Decimal("1000000"),
+        shares_filed_date=date(2023, 12, 1),
+    )
+    assert _eligible_window(window) == "incomplete_target_month_at_corpus_frontier"
+    late = FirmMonthWindow(
+        **{
+            **window.__dict__,
+            "target_month_complete": True,
+            "signal": FirmMonthSignal(
+                **{**window.signal.__dict__, "latest_acceptance": datetime(2024, 2, 1, 12, tzinfo=UTC)}
+            ),
+        }
+    )
+    assert _eligible_window(late) == "acceptance_not_before_formation"
+
+
+def test_sql_selects_usable_sessions_and_rejects_partial_frontier_month() -> None:
+    assert _WINDOW_SQL.count("WHERE e.return_usable") == 2
+    assert "target_end <= date_trunc('month'" in _WINDOW_SQL
 
 
 def test_portfolio_tail_metrics_use_monthly_spread_distribution() -> None:

--- a/tests/test_trial_register.py
+++ b/tests/test_trial_register.py
@@ -52,7 +52,7 @@ class TestTheShippedDeclaration:
             trial for trial in TRIAL_REGISTER.trials if trial.trial_id == "short-horizon-search-session-2026-08-09"
         )
         assert family.searches == 101
-        assert TRIAL_REGISTER.declared_count == 113
+        assert TRIAL_REGISTER.declared_count == 114
 
     def test_the_discarded_arms_are_counted(self) -> None:
         """A rejected result is still a search of the data.
@@ -64,6 +64,9 @@ class TestTheShippedDeclaration:
 
     def test_the_inconclusive_pead_trial_is_counted(self) -> None:
         assert "pead-historical-sue-net-income-v1" in TRIAL_REGISTER.trial_ids
+
+    def test_the_rejected_insider_purchase_trial_is_counted(self) -> None:
+        assert "form4-code-p-opportunistic-purchase-v1" in TRIAL_REGISTER.trial_ids
 
     def test_designed_but_unevaluated_rules_are_absent(self) -> None:
         """⚠ S-5 and S-6 are specified and blocked on #2279, never run.


### PR DESCRIPTION
## Outcome\n\nRecovers #2480's completed but unmerged evidence path and prevents the rejected family from being scheduled again.\n\n- restores the frozen preregistration, causal Form-4 source classifier, sealed portfolio evaluator, verification scripts and regression tests\n- retains the aggregate measured verdict without loading the 296 MB transient SEC history into application tables\n- adds the rejected trial to the global multiplicity register (M floor 113 -> 114; register version moves)\n- corrects the Aug-11 viability plan: C-1 is closed, no Form-4 backfill/picker/bracket/resolver/allocation, and no post-hoc rescue variants on the opened interval\n\n## Why rejected\n\n- +1.192%/month primary, but 95% CI [-1.452%, +4.215%]\n- timing placebo +1.992%; primary-minus-placebo -0.721%\n- trailing 24/36 months negative\n- max drawdown -54.84%; ES5 -14.29%\n- equal weight negative; disclosed-value concentration reached 100% in one issuer\n\n## Storage\n\nNo application table expansion. The transient SEC archive remains out of the database; only code, tests, preregistration and aggregate verdict are retained.\n\n## Validation\n\n- 37 candidate/register tests pass\n- full pre-push gate green: ruff, formatting, pyright, fast tests, smoke/app boot and frontend guards\n\nRefs #2480. Refs #2525.