### PR TITLE
Refuse trades with unestablished broker costs

### DIFF
--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -43,7 +43,6 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from decimal import Decimal
 from typing import Any, Literal
 
 import psycopg
@@ -58,7 +57,7 @@ from app.services.transaction_cost import (
     estimate_cost,
     get_transaction_cost_config,
     load_instrument_cost,
-    spread_pct_to_bps,
+    missing_cost_components,
 )
 
 logger = logging.getLogger(__name__)
@@ -465,18 +464,22 @@ def _check_transaction_cost(
 ) -> RuleResult:
     """Check whether the estimated transaction cost is prohibitive."""
     if cost_model_row is not None:
+        unknown = missing_cost_components(cost_model_row)
+        if unknown:
+            return RuleResult(
+                rule="transaction_cost_prohibitive",
+                passed=False,
+                detail=f"cost unavailable: {', '.join(unknown)} cost not established",
+            )
         spread_bps = cost_model_row["spread_bps"]
         overnight_rate = cost_model_row["overnight_rate"]
         fx_markup_bps = cost_model_row["fx_markup_bps"]
     elif quote is not None and quote.get("spread_pct") is not None:
-        converted = spread_pct_to_bps(quote["spread_pct"])
-        # spread_pct_to_bps returns None only when input is None, which the
-        # guard above already excluded.
-        if converted is None:  # pragma: no cover
-            raise RuntimeError("spread_pct_to_bps returned None for non-None input")
-        spread_bps = converted
-        overnight_rate = Decimal("0")
-        fx_markup_bps = Decimal("0")
+        return RuleResult(
+            rule="transaction_cost_prohibitive",
+            passed=False,
+            detail="cost unavailable: quote supplies spread only; carry and FX cost not established",
+        )
     else:
         return RuleResult(
             rule="transaction_cost_prohibitive",

--- a/app/services/execution_guard.py
+++ b/app/services/execution_guard.py
@@ -469,7 +469,7 @@ def _check_transaction_cost(
             return RuleResult(
                 rule="transaction_cost_prohibitive",
                 passed=False,
-                detail=f"cost unavailable: {', '.join(unknown)} cost not established",
+                detail=f"cost unavailable: costs not established for {', '.join(unknown)}",
             )
         spread_bps = cost_model_row["spread_bps"]
         overnight_rate = cost_model_row["overnight_rate"]

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -41,6 +41,7 @@ from app.services.transaction_cost import (
     estimate_cost,
     get_transaction_cost_config,
     load_instrument_cost,
+    missing_cost_components,
     record_estimated_cost,
     spread_pct_to_bps,
 )
@@ -770,6 +771,10 @@ class SafetyLayerDisabledError(RuntimeError):
     layer (fx_rates or portfolio_sync) disabled by the operator."""
 
 
+class TransactionCostUnavailableError(RuntimeError):
+    """BUY/ADD cannot execute while a cost component is unestablished."""
+
+
 def _assert_safety_layers_enabled_for_buy_add(
     conn: psycopg.Connection[Any],
     action: str,
@@ -789,6 +794,17 @@ def _assert_safety_layers_enabled_for_buy_add(
         raise SafetyLayerDisabledError(
             f"{' + '.join(disabled)} disabled — BUY/ADD execution aborted; re-enable the layer to proceed.",
         )
+
+
+def _assert_transaction_cost_complete_for_buy_add(
+    conn: psycopg.Connection[Any], action: str, instrument_id: int
+) -> None:
+    """Re-check cost provenance immediately before a possible broker call."""
+    if action not in ("BUY", "ADD"):
+        return
+    missing = missing_cost_components(load_instrument_cost(conn, instrument_id))
+    if missing:
+        raise TransactionCostUnavailableError(f"BUY/ADD execution aborted: {', '.join(missing)} cost not established")
 
 
 def _utcnow() -> datetime:
@@ -839,6 +855,7 @@ def execute_order(
     instrument_id: int = int(rec["instrument_id"])
     action: str = str(rec["action"])
     _assert_safety_layers_enabled_for_buy_add(conn, action)
+    _assert_transaction_cost_complete_for_buy_add(conn, action, instrument_id)
 
     # --- Step 2: determine order parameters ---
     # requested_amount is the dollar amount to invest.

--- a/app/services/order_client.py
+++ b/app/services/order_client.py
@@ -804,7 +804,9 @@ def _assert_transaction_cost_complete_for_buy_add(
         return
     missing = missing_cost_components(load_instrument_cost(conn, instrument_id))
     if missing:
-        raise TransactionCostUnavailableError(f"BUY/ADD execution aborted: {', '.join(missing)} cost not established")
+        raise TransactionCostUnavailableError(
+            f"BUY/ADD execution aborted: costs not established for {', '.join(missing)}"
+        )
 
 
 def _utcnow() -> datetime:

--- a/app/services/transaction_cost.py
+++ b/app/services/transaction_cost.py
@@ -51,6 +51,17 @@ class CostEstimate:
     prohibitive_reason: str | None
 
 
+def missing_cost_components(cost_model_row: dict[str, Any] | None) -> tuple[str, ...]:
+    """Return cost components whose applicability/amount is not established."""
+    if cost_model_row is None:
+        return ("carry", "FX")
+    return tuple(
+        name
+        for name, key in (("carry", "carry_cost_known"), ("FX", "fx_cost_known"))
+        if cost_model_row.get(key) is not True
+    )
+
+
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
@@ -255,16 +266,19 @@ def load_instrument_cost(
     """Load the active fee schedule for an instrument.
 
     Returns the most recent cost_model row where valid_to IS NULL.
-    Returns None if no cost_model row exists (caller should fall back
-    to computing spread from live quote data).
+    Returns None if no cost_model row exists. A caller may still derive spread
+    for display or audit, but execution must refuse because quote data cannot
+    establish carry or FX.
 
-    Columns: spread_bps (bps), overnight_rate (bps per day),
-    fx_pair (e.g. 'GBP/USD'), fx_markup_bps (bps, one-way).
+    Columns include explicit carry/FX completeness flags. Numeric zeros are
+    legacy-compatible placeholders and must not be interpreted as known costs
+    unless the corresponding flag is true.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT spread_bps, overnight_rate, fx_pair, fx_markup_bps
+            SELECT spread_bps, overnight_rate, fx_pair, fx_markup_bps,
+                   carry_cost_known, fx_cost_known
             FROM cost_model
             WHERE instrument_id = %(iid)s
               AND valid_to IS NULL
@@ -351,11 +365,11 @@ def seed_cost_models_from_quotes(
     - Close any existing active cost_model row (set valid_to = NOW())
     - Insert a new active row with computed spread
 
-    FX markup is set based on instrument currency:
-    - USD → 0 bps
-    - non-USD → 50 bps (eToro's typical FX markup)
-
-    Overnight rate is 0 for all instruments (real stocks, not CFDs in v1).
+    This seed measures spread only. Carry remains unknown until account-specific
+    broker eligibility proves the product is an unleveraged underlying rather
+    than a CFD. FX also remains unknown: instrument quote currency alone cannot
+    reveal which cash balance funds the order, and a pre-converted balance must
+    not be charged again.
 
     Runs within the caller's implicit transaction (psycopg v3 autocommit-off).
     The SELECT and all per-instrument writes share a single transaction
@@ -369,7 +383,7 @@ def seed_cost_models_from_quotes(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT i.instrument_id, q.spread_pct, i.currency
+            SELECT i.instrument_id, q.spread_pct
             FROM instruments i
             JOIN coverage c USING (instrument_id)
             JOIN quotes q USING (instrument_id)
@@ -387,9 +401,6 @@ def seed_cost_models_from_quotes(
             continue
 
         spread_bps = spread_pct_to_bps(row["spread_pct"])
-        currency = row["currency"] or "USD"
-        fx_markup_bps = Decimal("0") if currency == "USD" else Decimal("50")
-
         try:
             with conn.transaction():
                 with conn.cursor() as cur:
@@ -406,17 +417,16 @@ def seed_cost_models_from_quotes(
                         """
                         INSERT INTO cost_model (
                             instrument_id, spread_bps, overnight_rate,
-                            fx_pair, fx_markup_bps, source
+                            fx_pair, fx_markup_bps, carry_cost_known,
+                            fx_cost_known, source
                         ) VALUES (
                             %(iid)s, %(spread_bps)s, 0,
-                            %(fx_pair)s, %(fx_markup_bps)s, 'computed'
+                            NULL, 0, FALSE, FALSE, 'computed'
                         )
                         """,
                         {
                             "iid": row["instrument_id"],
                             "spread_bps": spread_bps,
-                            "fx_pair": None if currency == "USD" else f"{currency}/USD",
-                            "fx_markup_bps": fx_markup_bps,
                         },
                     )
             processed += 1

--- a/sql/310_cost_model_completeness.sql
+++ b/sql/310_cost_model_completeness.sql
@@ -1,0 +1,17 @@
+-- Migration 310: distinguish measured transaction costs from legacy zeros.
+--
+-- A numeric zero cannot say whether a cost was measured as zero or merely
+-- omitted.  Existing rows were created while FX was defaulted to zero for USD
+-- instruments even though the operator account is GBP-funded.  Keep the
+-- numeric columns for compatibility, but make both cost components explicitly
+-- unknown until their provenance has been established.
+
+ALTER TABLE cost_model
+    ADD COLUMN IF NOT EXISTS carry_cost_known BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS fx_cost_known BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN cost_model.carry_cost_known IS
+    'TRUE only when overnight/carry applicability and amount are established for the proposed product posture';
+COMMENT ON COLUMN cost_model.fx_cost_known IS
+    'TRUE only when the funding currency/path and FX conversion cost are established; numeric zero alone is not evidence';
+

--- a/tests/test_execution_guard.py
+++ b/tests/test_execution_guard.py
@@ -248,8 +248,17 @@ def _cost_config_cursor(
 
 
 def _cost_model_cursor(row: dict[str, Any] | None = None) -> MagicMock:
-    """Cost model row.  None = no cost_model for this instrument (use quote spread)."""
-    return _make_cursor([row] if row is not None else [])
+    """Known-complete cost row by default; callers can override its values."""
+    if row is None:
+        row = {
+            "spread_bps": Decimal("20"),
+            "overnight_rate": Decimal("0"),
+            "fx_pair": None,
+            "fx_markup_bps": Decimal("0"),
+            "carry_cost_known": True,
+            "fx_cost_known": True,
+        }
+    return _make_cursor([row])
 
 
 def _audit_cursor(decision_id: int = 99) -> MagicMock:
@@ -624,7 +633,7 @@ class TestCheckConcentration:
 class TestTransactionCostRule:
     """Tests for the transaction_cost_prohibitive guard rule."""
 
-    def test_cost_rule_passes_when_below_threshold(self) -> None:
+    def test_quote_only_cost_fails_when_below_spread_threshold(self) -> None:
         result = _check_transaction_cost(
             quote={"spread_pct": Decimal("0.20"), "spread_flag": False},
             cost_model_row=None,
@@ -634,8 +643,9 @@ class TestTransactionCostRule:
                 "default_hold_days": 90,
             },
         )
-        assert result.passed is True
+        assert result.passed is False
         assert result.rule == "transaction_cost_prohibitive"
+        assert "carry and FX" in result.detail
 
     def test_cost_rule_fails_when_above_threshold(self) -> None:
         result = _check_transaction_cost(
@@ -645,6 +655,8 @@ class TestTransactionCostRule:
                 "overnight_rate": Decimal("0"),
                 "fx_pair": None,
                 "fx_markup_bps": Decimal("0"),
+                "carry_cost_known": True,
+                "fx_cost_known": True,
             },
             cost_config={
                 "max_total_cost_bps": Decimal("150"),
@@ -655,7 +667,7 @@ class TestTransactionCostRule:
         assert result.passed is False
         assert "200" in result.detail
 
-    def test_cost_rule_uses_quote_spread_when_no_cost_model(self) -> None:
+    def test_quote_spread_cannot_stand_in_for_missing_cost_components(self) -> None:
         result = _check_transaction_cost(
             quote={"spread_pct": Decimal("1.2"), "spread_flag": True},
             cost_model_row=None,
@@ -665,9 +677,8 @@ class TestTransactionCostRule:
                 "default_hold_days": 90,
             },
         )
-        # 1.2% spread = 120 bps < 150 threshold → passes via quote fallback
-        assert result.passed is True
-        assert "120" in result.detail
+        assert result.passed is False
+        assert "carry and FX" in result.detail
 
     def test_cost_rule_fails_via_quote_spread_fallback(self) -> None:
         """Quote spread exceeds threshold when no cost_model row exists."""
@@ -680,9 +691,8 @@ class TestTransactionCostRule:
                 "default_hold_days": 90,
             },
         )
-        # 2.0% spread = 200 bps > 150 threshold → fails
         assert result.passed is False
-        assert "200" in result.detail
+        assert "carry and FX" in result.detail
 
     def test_cost_rule_fails_closed_when_no_quote(self) -> None:
         result = _check_transaction_cost(
@@ -718,6 +728,8 @@ class TestTransactionCostRule:
                 "overnight_rate": Decimal("0"),
                 "fx_pair": None,
                 "fx_markup_bps": Decimal("0"),
+                "carry_cost_known": True,
+                "fx_cost_known": True,
             },
             cost_config={
                 "max_total_cost_bps": Decimal("150"),
@@ -726,6 +738,26 @@ class TestTransactionCostRule:
             },
         )
         assert result.passed is True
+
+    def test_numeric_zero_is_not_cost_evidence(self) -> None:
+        result = _check_transaction_cost(
+            quote={"spread_pct": Decimal("0.2"), "spread_flag": False},
+            cost_model_row={
+                "spread_bps": Decimal("20"),
+                "overnight_rate": Decimal("0"),
+                "fx_pair": None,
+                "fx_markup_bps": Decimal("0"),
+                "carry_cost_known": False,
+                "fx_cost_known": False,
+            },
+            cost_config={
+                "max_total_cost_bps": Decimal("150"),
+                "min_return_vs_cost_ratio": Decimal("3.0"),
+                "default_hold_days": 90,
+            },
+        )
+        assert result.passed is False
+        assert "carry, FX" in result.detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_order_client.py
+++ b/tests/test_order_client.py
@@ -120,6 +120,10 @@ def _patch_runtime_config(monkeypatch: pytest.MonkeyPatch) -> None:
         "app.services.order_client.get_runtime_config",
         lambda _conn: _RUNTIME_DEMO,
     )
+    monkeypatch.setattr(
+        "app.services.order_client._assert_transaction_cost_complete_for_buy_add",
+        lambda _conn, _action, _instrument_id: None,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_order_client_safety_layers.py
+++ b/tests/test_order_client_safety_layers.py
@@ -9,7 +9,7 @@ import psycopg
 import pytest
 
 from app.services.layer_enabled import set_layer_enabled
-from app.services.order_client import SafetyLayerDisabledError, execute_order
+from app.services.order_client import SafetyLayerDisabledError, TransactionCostUnavailableError, execute_order
 from tests.fixtures.ebull_test_db import test_database_url as _test_database_url
 
 
@@ -95,6 +95,26 @@ def test_execute_order_aborts_buy_when_portfolio_sync_disabled() -> None:
                 execute_order(conn, rec_id, decision_id, broker=None)
         finally:
             _enable_all(conn)
+
+
+@pytest.mark.integration
+def test_execute_order_aborts_stale_approved_buy_when_costs_are_unknown() -> None:
+    with psycopg.connect(_test_database_url()) as conn:
+        _enable_all(conn)
+        rec_id, decision_id = _seed_approved_buy(conn)
+        conn.execute(
+            """
+            INSERT INTO cost_model (
+                instrument_id, spread_bps, overnight_rate, fx_markup_bps,
+                carry_cost_known, fx_cost_known, source
+            ) VALUES (999002, 20, 0, 0, FALSE, FALSE, 'computed')
+            ON CONFLICT (instrument_id) WHERE valid_to IS NULL
+            DO UPDATE SET carry_cost_known=FALSE, fx_cost_known=FALSE
+            """
+        )
+        conn.commit()
+        with pytest.raises(TransactionCostUnavailableError, match="carry, FX"):
+            execute_order(conn, rec_id, decision_id, broker=None)
 
 
 @pytest.mark.integration

--- a/tests/test_transaction_cost.py
+++ b/tests/test_transaction_cost.py
@@ -335,8 +335,8 @@ class TestSeedCostModels:
         conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cursor.fetchall.return_value = [
-            {"instrument_id": 1, "spread_pct": Decimal("0.30"), "currency": "USD"},
-            {"instrument_id": 2, "spread_pct": Decimal("0.50"), "currency": "GBP"},
+            {"instrument_id": 1, "spread_pct": Decimal("0.30")},
+            {"instrument_id": 2, "spread_pct": Decimal("0.50")},
         ]
         result = seed_cost_models_from_quotes(conn)
         assert result["processed"] == 2
@@ -349,7 +349,7 @@ class TestSeedCostModels:
         conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cursor.fetchall.return_value = [
-            {"instrument_id": 1, "spread_pct": None, "currency": "USD"},
+            {"instrument_id": 1, "spread_pct": None},
         ]
         result = seed_cost_models_from_quotes(conn)
         assert result["processed"] == 0
@@ -366,38 +366,35 @@ class TestSeedCostModels:
         assert result["processed"] == 0
         assert result["skipped"] == 0
 
-    def test_usd_instrument_gets_zero_fx_markup(self) -> None:
-        """USD instruments should have fx_markup_bps=0 and no fx_pair."""
+    def test_seeded_spread_does_not_claim_other_costs_are_known(self) -> None:
         conn = MagicMock()
         cursor = MagicMock()
         conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cursor.fetchall.return_value = [
-            {"instrument_id": 1, "spread_pct": Decimal("0.30"), "currency": "USD"},
+            {"instrument_id": 1, "spread_pct": Decimal("0.30")},
         ]
         seed_cost_models_from_quotes(conn)
         # Find the INSERT call (second execute call on the cursor)
         insert_calls = [c for c in cursor.execute.call_args_list if "INSERT INTO cost_model" in str(c)]
         assert len(insert_calls) == 1
-        params = insert_calls[0][0][1]
-        assert params["fx_markup_bps"] == Decimal("0")
-        assert params["fx_pair"] is None
+        query = str(insert_calls[0][0][0])
+        assert "NULL, 0, FALSE, FALSE, 'computed'" in query
 
-    def test_non_usd_instrument_gets_fx_markup(self) -> None:
-        """Non-USD instruments should have fx_markup_bps=50 and fx_pair set."""
+    def test_seed_does_not_invent_an_fx_pair_or_markup(self) -> None:
         conn = MagicMock()
         cursor = MagicMock()
         conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
         conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         cursor.fetchall.return_value = [
-            {"instrument_id": 2, "spread_pct": Decimal("0.50"), "currency": "GBP"},
+            {"instrument_id": 2, "spread_pct": Decimal("0.50")},
         ]
         seed_cost_models_from_quotes(conn)
         insert_calls = [c for c in cursor.execute.call_args_list if "INSERT INTO cost_model" in str(c)]
         assert len(insert_calls) == 1
         params = insert_calls[0][0][1]
-        assert params["fx_markup_bps"] == Decimal("50")
-        assert params["fx_pair"] == "GBP/USD"
+        assert "fx_markup_bps" not in params
+        assert "fx_pair" not in params
 
 
 class TestCostConfigAPI:


### PR DESCRIPTION
## Outcome

Closes the silent-zero execution path identified in #2363. A live quote can establish spread, but it cannot establish whether an account-specific product incurs carry or which cash currency funds the order.

- adds explicit `carry_cost_known` and `fx_cost_known` provenance flags to the compact per-instrument cost row
- migrates all existing numeric zeros to unknown rather than pretending they were measurements
- removes the hardcoded 50 bps non-USD FX seed and marks quote-seeded rows as spread-only
- makes the execution guard refuse missing/unknown carry or FX
- rechecks completeness immediately before BUY/ADD broker I/O, including stale previously-approved recommendations
- leaves EXIT unblocked
- adds no event, quote, feature, or heartbeat history

This does not guess eToro fees. A follow-up must prove account-specific underlying/CFD eligibility and funding-currency/conversion behavior before setting either flag true.

## Validation

- focused transaction-cost, guard and order-client unit suites green
- DB integration proves a stale approved BUY is stopped before broker I/O
- migration applied and app-boot/schema smoke green
- full pre-push gate green

Refs #2363. Refs #2525.