### PR TITLE
Reject extreme-shock strategy at portfolio level

### DIFF
--- a/app/services/extreme_shock_portfolio.py
+++ b/app/services/extreme_shock_portfolio.py
@@ -1,0 +1,295 @@
+"""Portfolio stress mechanics for the frozen C-2 extreme-shock candidate.
+
+This module does not discover signals.  It accepts the already-frozen trade paths
+and answers the different question the original per-trade study could not answer:
+what happens when clustered signals compete for one unleveraged capital pot?
+
+The implementation is deliberately pure and has no persistence side effects.  The
+historical interval was searched, so its output is development/stress evidence only.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import date
+from math import isfinite
+from typing import Final
+
+UNKNOWN_SECTOR: Final = "__unknown__"
+
+
+@dataclass(frozen=True)
+class ShockTradePath:
+    """One frozen signal and its causal marked path, before costs."""
+
+    trade_id: str
+    series_id: int
+    entry_date: date
+    exit_date: date
+    sector: str | None
+    # End-of-session cumulative gross return on the short notional.  The final
+    # item is the executable stop/timeout return and must be on ``exit_date``.
+    cumulative_returns: tuple[tuple[date, float], ...]
+
+    def __post_init__(self) -> None:
+        if not self.trade_id:
+            raise ValueError("trade_id must not be blank")
+        if not self.cumulative_returns:
+            raise ValueError("cumulative_returns must not be empty")
+        dates = tuple(item[0] for item in self.cumulative_returns)
+        if dates != tuple(sorted(set(dates))):
+            raise ValueError("path dates must be unique and increasing")
+        if dates[0] != self.entry_date or dates[-1] != self.exit_date:
+            raise ValueError("path must span entry_date through exit_date")
+        if any(not isfinite(item[1]) for item in self.cumulative_returns):
+            raise ValueError("path returns must be finite")
+
+
+@dataclass(frozen=True)
+class PortfolioStressConfig:
+    """Frozen capital/risk policy; fractions are proportions of current equity."""
+
+    per_name_cap: float
+    gross_cap: float = 1.0
+    sector_cap: float | None = 0.25
+    round_trip_cost: float = 0.005
+    carry_cost: float = 0.00574
+
+    def __post_init__(self) -> None:
+        if not 0 < self.per_name_cap <= 1:
+            raise ValueError("per_name_cap must be in (0, 1]")
+        if not 0 < self.gross_cap <= 1:
+            raise ValueError("gross_cap must be in (0, 1]; C-2 does not permit leverage")
+        if self.sector_cap is not None and not 0 < self.sector_cap <= self.gross_cap:
+            raise ValueError("sector_cap must be in (0, gross_cap] or None")
+        if self.round_trip_cost < 0 or self.carry_cost < 0:
+            raise ValueError("costs must not be negative")
+
+
+@dataclass(frozen=True)
+class PortfolioStressResult:
+    per_name_cap: float
+    sector_cap: float | None
+    start_date: date
+    end_date: date
+    candidate_trades: int
+    funded_trades: int
+    unfunded_trades: int
+    ending_return: float
+    annualized_return: float
+    max_drawdown: float
+    worst_day: float
+    expected_shortfall_5: float
+    max_concurrent: int
+    max_gross_exposure: float
+    max_sector_exposure: float | None
+    unknown_sector_funded_pct: float
+    capital_weighted_trade_return: float
+    annual_returns: tuple[tuple[int, float], ...]
+    stress_date: date | None
+    one_name_loss_stressed_max_drawdown: float
+    one_name_loss_stressed_ending_return: float
+
+
+@dataclass
+class _Position:
+    trade: ShockTradePath
+    notional: float
+    previous_net_return: float = 0.0
+
+
+def _maximum_drawdown(equities: list[float]) -> float:
+    peak = equities[0]
+    worst = 0.0
+    for value in equities:
+        peak = max(peak, value)
+        if peak > 0:
+            worst = min(worst, value / peak - 1.0)
+    return worst
+
+
+def _annualized_return(start: date, end: date, ending_equity: float) -> float:
+    years = max((end - start).days / 365.25, 1 / 365.25)
+    if ending_equity <= 0:
+        return -1.0
+    return ending_equity ** (1.0 / years) - 1.0
+
+
+def _allocate_batch(
+    candidates: list[ShockTradePath],
+    *,
+    equity: float,
+    active: dict[str, _Position],
+    config: PortfolioStressConfig,
+) -> dict[str, float]:
+    """Allocate one entry batch symmetrically, independent of input order.
+
+    All candidates have the same frozen signal and no causal rank score.  Equal
+    pro-rata allocation is therefore the only non-invented tie-break.  Unknown
+    sectors share one conservative concentration bucket.
+    """
+
+    if equity <= 0 or not candidates:
+        return {}
+    existing_gross = sum(position.notional for position in active.values())
+    global_room = max(0.0, equity * config.gross_cap - existing_gross)
+    if global_room <= 0:
+        return {}
+
+    sector_used: dict[str, float] = defaultdict(float)
+    for position in active.values():
+        sector_used[position.trade.sector or UNKNOWN_SECTOR] += position.notional
+    counts = Counter(candidate.sector or UNKNOWN_SECTOR for candidate in candidates)
+    equal_global = global_room / len(candidates)
+    per_name = equity * config.per_name_cap
+    allocations: dict[str, float] = {}
+    for candidate in sorted(candidates, key=lambda item: item.trade_id):
+        amount = min(per_name, equal_global)
+        if config.sector_cap is not None:
+            key = candidate.sector or UNKNOWN_SECTOR
+            sector_room = max(0.0, equity * config.sector_cap - sector_used[key])
+            amount = min(amount, sector_room / counts[key])
+        if amount > 0:
+            allocations[candidate.trade_id] = amount
+    return allocations
+
+
+def _net_mark(trade: ShockTradePath, index: int, config: PortfolioStressConfig) -> float:
+    gross = trade.cumulative_returns[index][1]
+    steps = len(trade.cumulative_returns)
+    elapsed_fraction = (index + 1) / steps
+    cost = config.round_trip_cost / 2 + config.carry_cost * elapsed_fraction
+    if index == steps - 1:
+        cost += config.round_trip_cost / 2
+    return gross - cost
+
+
+def simulate_extreme_shock_portfolio(
+    trades: list[ShockTradePath],
+    config: PortfolioStressConfig,
+) -> PortfolioStressResult:
+    """Simulate one unleveraged, compounding pot and a simultaneous -100% shock."""
+
+    if not trades:
+        raise ValueError("at least one trade is required")
+    ids = [trade.trade_id for trade in trades]
+    if len(ids) != len(set(ids)):
+        raise ValueError("trade_id values must be unique")
+
+    entries: dict[date, list[ShockTradePath]] = defaultdict(list)
+    marks: dict[date, list[tuple[ShockTradePath, int]]] = defaultdict(list)
+    for trade in trades:
+        entries[trade.entry_date].append(trade)
+        for index, (mark_date, _) in enumerate(trade.cumulative_returns):
+            marks[mark_date].append((trade, index))
+    calendar = sorted(set(entries) | set(marks))
+
+    equity = 1.0
+    active: dict[str, _Position] = {}
+    equities = [equity]
+    daily_returns: list[float] = []
+    gross_exposures: list[float] = []
+    concurrent: list[int] = []
+    max_sector_exposure: float | None = 0.0 if config.sector_cap is not None else None
+    funded = 0
+    unknown_funded = 0
+    funded_notional = 0.0
+    terminal_pnl = 0.0
+    peak_gross_date: date | None = None
+    peak_position_notional = 0.0
+
+    for current_date in calendar:
+        allocations = _allocate_batch(entries.get(current_date, []), equity=equity, active=active, config=config)
+        for trade in entries.get(current_date, []):
+            notional = allocations.get(trade.trade_id)
+            if notional is None:
+                continue
+            active[trade.trade_id] = _Position(trade=trade, notional=notional)
+            funded += 1
+            funded_notional += notional
+            unknown_funded += trade.sector is None
+
+        gross = sum(position.notional for position in active.values())
+        gross_ratio = gross / equity if equity > 0 else float("inf")
+        gross_exposures.append(gross_ratio)
+        concurrent.append(len(active))
+        if peak_gross_date is None or gross_ratio > max(gross_exposures[:-1], default=-1.0):
+            peak_gross_date = current_date
+            peak_position_notional = max((position.notional for position in active.values()), default=0.0)
+
+        if max_sector_exposure is not None and equity > 0:
+            by_sector: dict[str, float] = defaultdict(float)
+            for position in active.values():
+                by_sector[position.trade.sector or UNKNOWN_SECTOR] += position.notional
+            max_sector_exposure = max(
+                max_sector_exposure,
+                max((value / equity for value in by_sector.values()), default=0.0),
+            )
+
+        prior_equity = equity
+        current_marks = sorted(marks.get(current_date, []), key=lambda item: item[0].trade_id)
+        for trade, index in current_marks:
+            position = active.get(trade.trade_id)
+            if position is None:
+                continue
+            net = _net_mark(trade, index, config)
+            equity += position.notional * (net - position.previous_net_return)
+            position.previous_net_return = net
+        daily_returns.append(equity / prior_equity - 1.0 if prior_equity > 0 else -1.0)
+        equities.append(equity)
+
+        for trade, index in current_marks:
+            if index == len(trade.cumulative_returns) - 1:
+                position = active.pop(trade.trade_id, None)
+                if position is not None:
+                    terminal_pnl += position.notional * position.previous_net_return
+
+    sorted_days = sorted(daily_returns)
+    tail_count = max(1, int(len(sorted_days) * 0.05))
+    observed_drawdown = _maximum_drawdown(equities)
+
+    # Structural jump test: on the most crowded day, one largest allocation loses
+    # its full notional in addition to the observed path.  This is not a probability
+    # forecast; it asks whether the sizing policy survives the declared scenario.
+    stress_equities = list(equities)
+    if peak_gross_date is not None and peak_position_notional > 0:
+        stress_index = calendar.index(peak_gross_date) + 1
+        for index in range(stress_index, len(stress_equities)):
+            stress_equities[index] -= peak_position_notional
+    stressed_ending = stress_equities[-1]
+    returns_by_year: dict[int, float] = defaultdict(lambda: 1.0)
+    for current_date, daily_return in zip(calendar, daily_returns, strict=True):
+        returns_by_year[current_date.year] *= 1.0 + daily_return
+
+    return PortfolioStressResult(
+        per_name_cap=config.per_name_cap,
+        sector_cap=config.sector_cap,
+        start_date=calendar[0],
+        end_date=calendar[-1],
+        candidate_trades=len(trades),
+        funded_trades=funded,
+        unfunded_trades=len(trades) - funded,
+        ending_return=equity - 1.0,
+        annualized_return=_annualized_return(calendar[0], calendar[-1], equity),
+        max_drawdown=observed_drawdown,
+        worst_day=min(daily_returns),
+        expected_shortfall_5=sum(sorted_days[:tail_count]) / tail_count,
+        max_concurrent=max(concurrent),
+        max_gross_exposure=max(gross_exposures),
+        max_sector_exposure=max_sector_exposure,
+        unknown_sector_funded_pct=unknown_funded / funded if funded else 0.0,
+        capital_weighted_trade_return=terminal_pnl / funded_notional if funded_notional else 0.0,
+        annual_returns=tuple((year, growth - 1.0) for year, growth in sorted(returns_by_year.items())),
+        stress_date=peak_gross_date,
+        one_name_loss_stressed_max_drawdown=_maximum_drawdown(stress_equities),
+        one_name_loss_stressed_ending_return=stressed_ending - 1.0,
+    )
+
+
+__all__ = [
+    "PortfolioStressConfig",
+    "PortfolioStressResult",
+    "ShockTradePath",
+    "simulate_extreme_shock_portfolio",
+]

--- a/app/services/extreme_shock_portfolio.py
+++ b/app/services/extreme_shock_portfolio.py
@@ -197,6 +197,7 @@ def simulate_extreme_shock_portfolio(
     funded_notional = 0.0
     terminal_pnl = 0.0
     peak_gross_date: date | None = None
+    peak_gross_ratio = -1.0
     peak_position_notional = 0.0
 
     for current_date in calendar:
@@ -208,14 +209,15 @@ def simulate_extreme_shock_portfolio(
             active[trade.trade_id] = _Position(trade=trade, notional=notional)
             funded += 1
             funded_notional += notional
-            unknown_funded += trade.sector is None
+            unknown_funded += int(trade.sector is None)
 
         gross = sum(position.notional for position in active.values())
         gross_ratio = gross / equity if equity > 0 else float("inf")
         gross_exposures.append(gross_ratio)
         concurrent.append(len(active))
-        if peak_gross_date is None or gross_ratio > max(gross_exposures[:-1], default=-1.0):
+        if gross_ratio > peak_gross_ratio:
             peak_gross_date = current_date
+            peak_gross_ratio = gross_ratio
             peak_position_notional = max((position.notional for position in active.values()), default=0.0)
 
         if max_sector_exposure is not None and equity > 0:

--- a/app/services/trial_register.py
+++ b/app/services/trial_register.py
@@ -74,7 +74,7 @@ from typing import Final
 #: Bumped whenever a trial is added or an entry's meaning changes. ⚠ Stored on
 #: the result row beside the DSR: a deflated Sharpe means nothing without the
 #: trial population it was deflated against, and that population grows.
-TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-11-r2"
+TRIAL_REGISTER_VERSION: Final = "trial-register-2026-08-11-r3"
 
 
 @dataclass(frozen=True)
@@ -238,6 +238,15 @@ TRIAL_REGISTER: Final = TrialRegister(
             ),
             evidence="docs/proposals/ta/2026-08-09-plan-of-attack.md §2b",
             searches=101,
+        ),
+        DeclaredTrial(
+            trial_id="extreme-shock-portfolio-sizing-stress-v1",
+            description=(
+                "Frozen extreme-shock event stream under four per-name caps, each with and without the "
+                "declared 25% sector cap; all eight capital-weighted arms were rejected."
+            ),
+            evidence="docs/proposals/ta/2026-08-11-extreme-shock-portfolio-result.md; issue #2481",
+            searches=8,
         ),
         DeclaredTrial(
             trial_id="form4-code-p-opportunistic-purchase-v1",

--- a/docs/proposals/ta/2026-08-11-extreme-shock-portfolio-result.md
+++ b/docs/proposals/ta/2026-08-11-extreme-shock-portfolio-result.md
@@ -1,0 +1,112 @@
+# C-2 extreme-shock portfolio result — rejected
+
+Date: 2026-08-11  
+Issue: #2481  
+Trial identity: `extreme-shock-portfolio-sizing-stress-v1`  
+Trial register: `trial-register-2026-08-11-r3`
+
+## Verdict
+
+Reject C-2 as a capital candidate and do not start its 60-session prospective
+shortability/cost census. The attractive per-event-day mean does not survive the
+capital-allocation problem an operator actually faces. Every one of the eight
+declared sizing/concentration arms lost money after the existing adverse cost
+sensitivity, with maximum drawdowns between 40.68% and 69.05%.
+
+This is a one-way rejection. The 2020–2026 interval was searched and cannot validate
+a positive result, but a failure under the frozen rule and declared portfolio
+constraints is sufficient to stop spending data, broker quota and research trials on
+the family. Do not rescue it by selecting a cap, threshold, hold, stop, era, sector or
+event subset from these opened outcomes.
+
+## Frozen input and accounting
+
+The signal was not changed from the searched development lead:
+
+- prior close at least $20 and prior 20-session median dollar volume at least $10m;
+- completed close-to-close fall of at least 12%;
+- enter short at the next adjusted open;
+- exit after five bars, or at a 20% stop first;
+- a gap through the stop exits at the adjusted open, never the stop price;
+- no leverage at entry;
+- 50 bps round trip plus 57.4 bps adverse carry (8.2 bps × seven financed-day
+  equivalents).
+
+The simulation funds a single compounding pot. Same-date signals have no frozen
+causal ranking feature, so available capital is split symmetrically rather than by
+arrival order. Gross exposure is capped at 100% when entries are funded. Four
+predeclared per-name cap sensitivities (0.5%, 1%, 2%, 5%) are each run with a 25%
+sector cap and without it. Those eight evaluations are now charged to the trial
+register; the C-2 family floor is 109 and the repository-wide declared floor is 122.
+
+Sector labels are current and incomplete, not historical point-in-time identities.
+Unknown sectors therefore share one conservative bucket in the capped arms. The
+uncapped arms show that this imperfect control is not the cause of rejection.
+
+## Reconciliation
+
+The extractor reads 7,709 non-comparator research series and produces the same 8,049
+trades as the earlier stop study. The flat trade mean is +136.33 bps gross; giving
+each of 1,368 event days equal weight reproduces the previously reported +156.81 bps
+gross and +49.41 bps after the adverse cost sensitivity. Median gross return is
++74.06 bps, win rate 52.28%, and worst trade -8,749.18 bps.
+
+This reconciliation matters: the rejection is not a sign error or a changed signal.
+It is the difference between a statistical average and capital that is scarce when
+signals cluster.
+
+## Portfolio results
+
+`wt trade` is the final net result weighted by the notional the portfolio could
+actually assign. `DD + wipe` adds a simultaneous -100% loss on one largest funded
+position at peak gross exposure. Caps apply at entry; ratios can drift slightly above
+them after losses before positions close.
+
+| name cap | sector cap | funded | total return | annualised | wt trade | max drawdown | worst day | ES 5% | max concurrent | DD + wipe |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0.5% | 25% | 8,045 | -14.81% | -2.47% | -0.43% | -41.02% | -13.93% | -1.74% | 1,209 | -41.14% |
+| 0.5% | none | 8,045 | -13.76% | -2.28% | -0.39% | -40.68% | -14.02% | -1.74% | 1,209 | -40.79% |
+| 1.0% | 25% | 8,049 | -34.12% | -6.30% | -0.63% | -54.97% | -14.08% | -2.80% | 1,210 | -55.44% |
+| 1.0% | none | 8,045 | -34.49% | -6.38% | -0.63% | -55.77% | -14.50% | -2.88% | 1,209 | -55.91% |
+| 2.0% | 25% | 8,036 | -38.73% | -7.36% | -0.43% | -59.69% | -14.07% | -3.86% | 1,210 | -60.99% |
+| 2.0% | none | 8,047 | -47.72% | -9.62% | -0.55% | -66.86% | -16.87% | -4.17% | 1,210 | -68.24% |
+| 5.0% | 25% | 7,924 | -26.28% | -4.64% | -0.15% | -64.07% | -16.24% | -5.20% | 1,210 | -64.07% |
+| 5.0% | none | 8,015 | -22.97% | -3.99% | -0.13% | -69.05% | -18.13% | -5.71% | 1,210 | -71.63% |
+
+For the declared 1%/25% diagnostic arm, calendar returns are +0.20% (2020), -11.88%
+(2021), -18.53% (2022), +2.17% (2023), +1.09% (2024), +5.09% (2025) and -15.62%
+(2026 through the corpus frontier). This is neither reliably recent nor regime
+stable.
+
+The mechanism of failure is allocation-weighting. As many as 596 signals enter on
+one date and 1,210 overlap. The event-day statistic gives a 596-name crash cluster
+the same weight as a quiet one-signal day. A finite pot cannot do that: it divides
+capital across the cluster while quieter events receive materially larger positions.
+Once returns are weighted by executable notional, every arm is negative. Sector
+coverage is 46.7% by series and 85.4% across fired signals, but sector-capped and
+uncapped arms both fail.
+
+## Remaining broker/data gaps do not justify continuation
+
+The eToro eligibility and what-if-cost adapters exist, but the measured cost payload
+has undocumented units and stale observations. Carry, FX and exact shortability are
+therefore fail-closed. Historical point-in-time sector membership and shortability
+are also absent. These gaps could only make the observed short result less reliable;
+they cannot repair a negative capital-weighted result without selecting a new rule.
+
+Consequently C-2 gets no manifest row, allocation authority, picker, demo order or
+prospective high-volume store. Existing bounded quote/cost infrastructure remains
+available for a future independently preregistered candidate. No new database table
+or retained event dump is introduced by this result.
+
+## Reproduce
+
+```text
+PYTHONPATH=. uv run python scripts/verify_2481_extreme_shock_portfolio.py
+uv run pytest -q tests/test_extreme_shock_portfolio.py tests/test_trial_register.py
+```
+
+The verification script is read-only. Portfolio mechanics are pure functions in
+`app/services/extreme_shock_portfolio.py`; tests pin no-leverage input, symmetric
+batch allocation, unknown-sector concentration, cost accrual and the structural
+single-name loss scenario.

--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -61,7 +61,7 @@ what deserves a preregistered test; they are not backtest results.
 | **Broad equity beta / core allocation** | Compensation for bearing market risk; own corrected legacy comparator history measured about 6.3-6.6% annualised. This is the hurdle and no-alpha fallback, not a recent claim. | High for exact comparator total return to 2024; recent exact comparator is price return only. The main stock corpus separately has adjusted closes through 2026. | Conditional: the account-specific eligibility response must prove the proposed unleveraged instrument is the underlying product. | **Foundation, not an alpha trial.** Build correct total-return, FX, cash and dividend attribution before judging overlays. |
 | **Low-turnover cross-sectional factors** | Value, profitability/quality, investment, momentum and low-risk have extensive published priors. They can diversify a core but may be risk premia rather than arbitrage. | Medium: daily adjusted prices and SEC fundamentals exist, but point-in-time availability, delisted membership and recent total-return gaps must be closed. | Medium/high for long legs; short legs inherit CFD/borrow problems. | **Admit one simple long-only quality-plus-momentum tilt only after the foundation gate.** Monthly/quarterly turnover; no parameter sweep. Not a day-trade claim. |
 | **Opportunistic insider purchases** | A forced-information mechanism. Cohen, Malloy and Pomorski report routine trades as essentially uninformative and 82 bps/month abnormal return for opportunistic trades. | The causal 2019Q1–2026Q1 source and sealed 49-month reproduction are now retained in git. | Conditional for liquid unleveraged longs; naturally low turnover. | **Rejected under C-1.** The recent result was negative, the full-period interval crossed zero, placebo did better, drawdown/tail and single-name concentration failed. Preserve the family as evidence; do not retest neighbouring role/size/lag/weight/horizon/exit variants on the opened interval. |
-| **Extreme price-shock continuation (short)** | A forced-flow/information-shock hypothesis. Own searched result for shorting a >=12% one-day drop for five bars with a 20% stop showed +49 bps/trade after a 30% annual borrow stress, `t=4.83`, but had an -87% worst gap and emerged from about 100 searches. | Medium for OHLCV and event context; historical shortability and exact carry are absent. | **Blocked:** shorts are CFDs; firing names are likely hard-to-borrow and may be unavailable. Demo has no fees. | **Selected searched lead, not evidence or a prior.** Freeze the discovered rule, reconstruct its trial count, simulate portfolio tails, capture point-in-time shortability/cost, and assess only on new prospective data. Never use the searched +49 bps to calculate power or call 2020-2026 an untouched holdout. |
+| **Extreme price-shock continuation (short)** | A forced-flow/information-shock hypothesis. The searched event-day result was +49 bps after adverse assumed costs, but had an -87% worst gap and emerged from 101 searches. | Historical OHLCV can reproduce the event stream; historical shortability, exact carry and point-in-time sectors are absent. | **Blocked independently:** measured broker costs remain unusable and shorts are CFDs. | **Rejected under C-2.** All eight frozen capital-allocation arms lost 13.76%–47.72%, with 40.68%–69.05% drawdowns. The event-day mean vanished when finite capital was assigned across as many as 596 same-day signals. Preserve the family and do not rescue it with a threshold, cap, era or sector subset. |
 | **Time-series / cross-sectional momentum** | Persistent prior across assets; crash risk rises after market declines amid high volatility and rebounds. Volatility scaling is evidence-based for this family. | High for daily research; recent total-return and PIT universe remain blockers. | Long implementation feasible; short implementation conditional. | Existing S-1/S-2 remain controls. A **new**, low-turnover factor tilt may be part of the factor trial above; do not tune the controls into candidates. |
 | **Short-term reversal / statistical arbitrage** | Usually compensation for liquidity provision; published strength rises in market stress. Exact residual versions need midpoint/factor inputs and both long/short legs. | Medium for a bounded 30m-4h on-demand spike, low for deep walk-forward and historical spread/shortability. Current daily RSI and residual-confluence implementations failed or are controls. | Low: short/carry plus roughly 50 bps round-trip economics consume the daily edge. | **Defer from the first trial budget, not for lack of any intraday history.** A future fixed replication may bootstrap the latest 1,000 REST bars, but promotion still needs prospective quotes/costs and a deeper untouched interval. No new daily-OHLC reversal variants. |
 | **Breakout / opening range / volatility compression** | May exploit delayed institutional flow in “stocks in play”; requires opening-range, relative-volume and gap selection together. ATR is risk scale, not alpha. | Medium for recent 30m-4h context but low for opening-range depth: 1m/5m REST reaches days and the prospective quote panel is tiny. | Low under present costs; published ORB assumptions are orders of magnitude cheaper than the repo’s broker estimate. | **Defer/rejection replication only.** On-demand REST can run a bounded recent falsification, but not a deep promotion backtest. Do not promote S-4 or a bare breakout; require sufficient spread observations and exact stock-in-play inputs. |
@@ -91,7 +91,7 @@ insiders. They supply priors and mechanisms, never eBull promotion evidence.
 ## 3. The initial research budget
 
 The first programme originally admitted three alpha/risk-overlay hypotheses. C-1
-has now consumed its one sealed trial and is rejected; only C-2 and C-3 remain open.
+and C-2 are now rejected; only C-3 remains open.
 This is a budget, not a promise to produce a strategy.
 
 ### Foundation F-0 — core and no-trade comparator
@@ -148,10 +148,27 @@ No manifest row, strategy picker, bracket, resolver or allocation authority is
 created. The opened interval may not be mined for a rescue variant. See
 `2026-08-10-insider-purchase-result.md` and #2480.
 
-### Candidate C-2 — frozen extreme-shock short, prospective confirmation
+### Closed candidate C-2 — frozen extreme-shock short
 
-Do not tune the >=12% drop, five-session hold or 20% stop. The historical sample has
-already been searched and is development evidence only.
+Do not tune the >=12% drop, five-session hold or 20% stop. The historical sample was
+searched and the frozen portfolio test is now rejected.
+
+The exact 8,049-trade stream reconciled to the earlier +156.81 bps event-day gross
+mean and +49.41 bps after the adverse assumed cost. That statistic was not investable:
+as many as 596 signals fired on one date and 1,210 overlapped. Across four declared
+per-name caps with and without a 25% sector cap, capital-weighted trade return was
+negative, total return ranged from -13.76% to -47.72%, and maximum drawdown ranged
+from -40.68% to -69.05%. See `2026-08-11-extreme-shock-portfolio-result.md`.
+
+The eight allocation arms are charged to the trial register, taking the C-2 family
+floor to 109 and the repository-wide declared floor to 122. Missing broker cost,
+shortability and point-in-time sector evidence can only weaken this result; it cannot
+repair a negative capital-weighted outcome without selecting a new rule. Therefore
+the planned prospective census is cancelled and no candidate/runtime state is
+created.
+
+The pre-result contract below remains as the audit record of what would have been
+required to continue:
 
 Before collecting outcomes:
 
@@ -175,8 +192,8 @@ Before collecting outcomes:
    independently clustered firings. Stop if it exceeds the 24-month detailed quote
    retention/relevance window; do not collect indefinitely.
 
-If shortability or adverse costs remove the edge, close the family for this broker.
-Do not search a neighbouring threshold to rescue it.
+Capital allocation removed the edge before broker feasibility could promote it, so
+the family is closed. Do not search a neighbouring threshold to rescue it.
 
 ### Candidate C-3 — one low-turnover long-only factor tilt
 
@@ -401,8 +418,8 @@ The order is deliberately different from “build more strategies.”
    prove demo/live semantic differences explicitly.
 4. **C-1 closed:** retain its causal source/evaluator and failed aggregate verdict;
    no backfill, picker entry or neighbouring rescue trial.
-5. **C-2 prospective contract:** portfolio tail simulation plus prospective
-   shortability/cost/outcome capture; no further historical threshold search.
+5. **C-2 closed:** retain the frozen event extractor, portfolio simulator, trial
+   charge and failed aggregate verdict; no prospective census or rescue search.
 6. **C-3 feasibility/preregistration:** only if point-in-time fundamentals and
    membership make the factor trial honest.
 7. **Viability report:** compare every admitted candidate with F-0 and no trade.
@@ -452,11 +469,10 @@ The plan is ready to proceed when:
   TP/SL/timeout, attribution and material refusals—not every ticker evaluated.
 
 The current state does **not** meet those conditions. It has enough evidence to close
-C-1 and choose the next bounded work, but not enough to turn on autonomous demo
-allocation. The defensible sequence is core accounting and research-integrity repair,
-then the frozen short-shock lead only as a prospective broker-feasibility experiment,
-with C-3 attempted only if its point-in-time data contract is feasible. More
-technical-indicator combinations are not the next opportunity.
+C-1 and C-2, but not enough to turn on autonomous demo allocation. The defensible
+sequence is core accounting and research-integrity repair, then C-3 only if its
+point-in-time data contract is feasible. More technical-indicator combinations are
+not the next opportunity.
 
 ## 10. External challenge incorporated
 

--- a/scripts/verify_2481_extreme_shock_portfolio.py
+++ b/scripts/verify_2481_extreme_shock_portfolio.py
@@ -1,0 +1,212 @@
+"""Portfolio/tail stress for frozen candidate C-2 (#2481).
+
+Run from the repository root:
+
+    PYTHONPATH=. uv run python scripts/verify_2481_extreme_shock_portfolio.py
+
+This is NOT a new alpha test.  The >=12% drop, next-open short, five-bar hold,
+20% gap-aware stop and eligibility floor are copied unchanged from the searched
+development result.  The script asks whether that fixed event stream can coexist
+inside one unleveraged portfolio under deterministic capital constraints.
+
+Nothing is written.  Contemporary sector labels are incomplete and are not
+point-in-time history, so the output reports their coverage and cannot prove the
+historical sector-concentration gate.  Unknown sectors share one conservative
+bucket in the sector-capped arm.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from datetime import date
+
+import numpy as np
+import psycopg
+
+from app.config import settings
+from app.services.extreme_shock_portfolio import (
+    PortfolioStressConfig,
+    ShockTradePath,
+    simulate_extreme_shock_portfolio,
+)
+from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
+
+START = "2020-01-01"
+DROP = -0.12
+HOLD = 5
+STOP = 0.20
+MIN_PRICE = 20.0
+MIN_DOLLAR_VOL = 10_000_000.0
+ROUND_TRIP_COST = 0.005
+# Existing adverse sensitivity: 8.2 bps x seven financed-day equivalents.
+CARRY_COST = 0.00082 * 7
+PER_NAME_CAPS = (0.005, 0.01, 0.02, 0.05)
+SECTOR_CAP = 0.25
+
+_SERIES = """
+    SELECT s.series_id, i.sector
+    FROM research_price_series s
+    LEFT JOIN instruments i ON i.instrument_id = s.instrument_id
+    WHERE s.comparator_snapshot_id IS NULL
+      AND EXISTS (
+          SELECT 1 FROM research_price_daily d
+          WHERE d.series_id = s.series_id AND d.bar_date >= %(start)s
+      )
+    ORDER BY s.series_id
+"""
+
+_BARS = """
+    SELECT bar_date, open, high, close, adj_close, volume
+    FROM research_price_daily
+    WHERE series_id = %(series_id)s AND bar_date >= %(start)s
+      AND open > 0 AND high > 0 AND close > 0 AND adj_close > 0
+    ORDER BY bar_date
+"""
+
+
+def _extract_paths(conn: psycopg.Connection[tuple]) -> tuple[list[ShockTradePath], int, int]:
+    series = conn.execute(_SERIES, {"start": START}).fetchall()
+    paths: list[ShockTradePath] = []
+    classified_series = sum(row[1] is not None for row in series)
+
+    for number, (series_id, sector) in enumerate(series, start=1):
+        bars = conn.execute(_BARS, {"series_id": series_id, "start": START}).fetchall()
+        if len(bars) < 60:
+            continue
+        dates = [row[0] for row in bars]
+        opens = np.asarray([float(row[1]) for row in bars])
+        highs = np.asarray([float(row[2]) for row in bars])
+        closes = np.asarray([float(row[3]) for row in bars])
+        adjusted = np.asarray([float(row[4]) for row in bars])
+        volumes = np.asarray([float(row[5] or 0.0) for row in bars])
+        factor = adjusted / closes
+        adjusted_open = opens * factor
+        adjusted_high = highs * factor
+        returns = np.empty_like(adjusted)
+        returns[0] = np.nan
+        returns[1:] = adjusted[1:] / adjusted[:-1] - 1.0
+        dollar_volume = closes * volumes
+
+        for signal_index in range(21, len(closes) - HOLD - 1):
+            if returns[signal_index] > DROP or closes[signal_index] < MIN_PRICE:
+                continue
+            if float(np.median(dollar_volume[signal_index - 20 : signal_index])) < MIN_DOLLAR_VOL:
+                continue
+            entry_index = signal_index + 1
+            entry = adjusted_open[entry_index]
+            if not np.isfinite(entry) or entry <= 0:
+                continue
+            stop_level = entry * (1.0 + STOP)
+            path: list[tuple[date, float]] = []
+            for index in range(entry_index, signal_index + HOLD + 1):
+                exit_price = adjusted[index]
+                terminal = index == signal_index + HOLD
+                if adjusted_open[index] >= stop_level:
+                    exit_price = adjusted_open[index]
+                    terminal = True
+                elif adjusted_high[index] >= stop_level:
+                    exit_price = stop_level
+                    terminal = True
+                path.append((dates[index], -(exit_price / entry - 1.0)))
+                if terminal:
+                    break
+            paths.append(
+                ShockTradePath(
+                    trade_id=f"{series_id}:{dates[entry_index].isoformat()}",
+                    series_id=int(series_id),
+                    entry_date=dates[entry_index],
+                    exit_date=path[-1][0],
+                    sector=str(sector) if sector is not None else None,
+                    cumulative_returns=tuple(path),
+                )
+            )
+        if number % 1000 == 0:
+            print(f"  extracted {number:,}/{len(series):,} series", flush=True)
+    return paths, len(series), classified_series
+
+
+def _fmt_pct(value: float | None) -> str:
+    return "—" if value is None else f"{value * 100:+.2f}%"
+
+
+def main() -> int:
+    with psycopg.connect(settings.database_url) as conn:
+        paths, series_count, classified_series = _extract_paths(conn)
+    if not paths:
+        print("REFUSED: the frozen rule produced no paths", file=sys.stderr)
+        return 2
+
+    entry_counts = Counter(path.entry_date for path in paths)
+    signal_sector_known = sum(path.sector is not None for path in paths)
+    search_floor = sum(
+        item.searches
+        for item in TRIAL_REGISTER.trials
+        if item.trial_id in {"short-horizon-search-session-2026-08-09", "extreme-shock-portfolio-sizing-stress-v1"}
+    )
+
+    print("\nC-2 FROZEN EXTREME-SHOCK PORTFOLIO STRESS")
+    print(f"rule: drop <= {DROP:.0%}; next-open short; {HOLD}-bar timeout; {STOP:.0%} gap-aware stop; no leverage")
+    print(f"cost sensitivity: {ROUND_TRIP_COST * 1e4:.0f} bps round trip + {CARRY_COST * 1e4:.1f} bps adverse carry")
+    print(
+        f"trial register: {TRIAL_REGISTER_VERSION}; C-2 searched/evaluated-family floor={search_floor}; "
+        "this interval is NOT a holdout"
+    )
+    print(
+        f"source: {series_count:,} non-comparator series; current sector coverage "
+        f"{classified_series:,}/{series_count:,} ({classified_series / series_count:.1%})"
+    )
+    print(
+        f"signals: {len(paths):,}; {len(entry_counts):,} entry days; max same-day batch "
+        f"{max(entry_counts.values()):,}; signal sector coverage {signal_sector_known / len(paths):.1%}"
+    )
+    print("⚠ sector labels are current/incomplete, not point-in-time; they constrain stress only.")
+
+    header = (
+        f"{'name cap':>9}{'sector':>9}{'funded':>10}{'return':>11}{'ann.':>10}"
+        f"{'wt trade':>10}{'max DD':>10}{'worst day':>12}{'ES5':>10}{'max n':>8}{'gross':>9}"
+        f"{'sector':>9}{'unknown':>10}{'DD + wipe':>11}"
+    )
+    print("\n" + header)
+    print("-" * len(header))
+    primary_result = None
+    for cap in PER_NAME_CAPS:
+        for sector_cap in (SECTOR_CAP, None):
+            result = simulate_extreme_shock_portfolio(
+                paths,
+                PortfolioStressConfig(
+                    per_name_cap=cap,
+                    sector_cap=sector_cap,
+                    round_trip_cost=ROUND_TRIP_COST,
+                    carry_cost=CARRY_COST,
+                ),
+            )
+            if cap == 0.01 and sector_cap == SECTOR_CAP:
+                primary_result = result
+            label = "25%" if sector_cap is not None else "none"
+            print(
+                f"{cap:>8.1%}{label:>9}{result.funded_trades:>8,}/{len(paths):<1}"
+                f"{_fmt_pct(result.ending_return):>11}{_fmt_pct(result.annualized_return):>10}"
+                f"{_fmt_pct(result.capital_weighted_trade_return):>10}"
+                f"{_fmt_pct(result.max_drawdown):>10}{_fmt_pct(result.worst_day):>12}"
+                f"{_fmt_pct(result.expected_shortfall_5):>10}{result.max_concurrent:>8}"
+                f"{result.max_gross_exposure:>8.1%}{_fmt_pct(result.max_sector_exposure):>9}"
+                f"{result.unknown_sector_funded_pct:>9.1%}{_fmt_pct(result.one_name_loss_stressed_max_drawdown):>11}"
+            )
+
+    assert primary_result is not None
+    annual = "  ".join(f"{year} {_fmt_pct(value)}" for year, value in primary_result.annual_returns)
+    print(f"\n1% name / 25% sector diagnostic calendar returns: {annual}")
+
+    print("\nINTERPRETATION CONTRACT")
+    print("- The cap rows are declared sizing sensitivities, not alternatives from which to select a winner.")
+    print("- 'DD + wipe' adds a simultaneous -100% loss to one largest position on peak-exposure day.")
+    print("- Caps apply when an entry is funded; peak gross/sector ratios can drift above them after losses.")
+    print("- Positive historical return cannot promote C-2: 109 family evaluations, no clean holdout, incomplete PIT")
+    print("  identity, and unavailable/stale broker short cost/availability remain binding blockers.")
+    print("- Negative or structurally ruinous rows may reject C-2 without prospective trading.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_extreme_shock_portfolio.py
+++ b/tests/test_extreme_shock_portfolio.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from app.services.extreme_shock_portfolio import (
+    PortfolioStressConfig,
+    ShockTradePath,
+    simulate_extreme_shock_portfolio,
+)
+
+DAY = date(2026, 1, 5)
+
+
+def _trade(
+    trade_id: str,
+    *,
+    result: float = 0.10,
+    sector: str | None = "technology",
+    entry_offset: int = 0,
+    duration: int = 1,
+) -> ShockTradePath:
+    entry = DAY + timedelta(days=entry_offset)
+    marks = tuple((entry + timedelta(days=index), result * (index + 1) / duration) for index in range(duration))
+    return ShockTradePath(
+        trade_id=trade_id,
+        series_id=int(trade_id.removeprefix("t")),
+        entry_date=entry,
+        exit_date=marks[-1][0],
+        sector=sector,
+        cumulative_returns=marks,
+    )
+
+
+def test_rejects_leverage_and_malformed_paths() -> None:
+    with pytest.raises(ValueError, match="does not permit leverage"):
+        PortfolioStressConfig(per_name_cap=0.1, gross_cap=1.01)
+    with pytest.raises(ValueError, match="span entry_date"):
+        ShockTradePath(
+            trade_id="bad",
+            series_id=1,
+            entry_date=DAY,
+            exit_date=DAY + timedelta(days=1),
+            sector=None,
+            cumulative_returns=((DAY, 0.0),),
+        )
+
+
+def test_equal_signal_batch_is_permutation_invariant() -> None:
+    trades = [_trade("t1", result=0.10, sector="a"), _trade("t2", result=-0.05, sector="b")]
+    config = PortfolioStressConfig(per_name_cap=0.5, sector_cap=None, round_trip_cost=0, carry_cost=0)
+
+    forwards = simulate_extreme_shock_portfolio(trades, config)
+    backwards = simulate_extreme_shock_portfolio(list(reversed(trades)), config)
+
+    assert forwards == backwards
+    assert forwards.funded_trades == 2
+    assert forwards.max_gross_exposure == pytest.approx(1.0)
+    assert forwards.ending_return == pytest.approx(0.025)
+    assert forwards.capital_weighted_trade_return == pytest.approx(0.025)
+    assert forwards.annual_returns[0][0] == 2026
+    assert forwards.annual_returns[0][1] == pytest.approx(0.025)
+
+
+def test_sector_cap_treats_unknown_as_one_conservative_bucket() -> None:
+    trades = [_trade("t1", sector=None), _trade("t2", sector=None)]
+    result = simulate_extreme_shock_portfolio(
+        trades,
+        PortfolioStressConfig(per_name_cap=0.5, sector_cap=0.25, round_trip_cost=0, carry_cost=0),
+    )
+
+    assert result.max_sector_exposure == pytest.approx(0.25)
+    assert result.max_gross_exposure == pytest.approx(0.25)
+    assert result.unknown_sector_funded_pct == 1.0
+
+
+def test_costs_are_charged_once_across_a_multi_mark_path() -> None:
+    trade = _trade("t1", result=0.10, duration=2)
+    result = simulate_extreme_shock_portfolio(
+        [trade],
+        PortfolioStressConfig(
+            per_name_cap=1.0,
+            sector_cap=None,
+            round_trip_cost=0.005,
+            carry_cost=0.006,
+        ),
+    )
+
+    assert result.ending_return == pytest.approx(0.089)
+    assert result.max_gross_exposure == pytest.approx(1.0)
+
+
+def test_declared_one_name_wipeout_worsens_the_observed_portfolio() -> None:
+    result = simulate_extreme_shock_portfolio(
+        [_trade("t1", result=0.10)],
+        PortfolioStressConfig(per_name_cap=0.5, sector_cap=None, round_trip_cost=0, carry_cost=0),
+    )
+
+    assert result.max_drawdown == 0.0
+    assert result.ending_return == pytest.approx(0.05)
+    assert result.one_name_loss_stressed_ending_return == pytest.approx(-0.45)
+    assert result.one_name_loss_stressed_max_drawdown == pytest.approx(-0.45)

--- a/tests/test_trial_register.py
+++ b/tests/test_trial_register.py
@@ -52,7 +52,13 @@ class TestTheShippedDeclaration:
             trial for trial in TRIAL_REGISTER.trials if trial.trial_id == "short-horizon-search-session-2026-08-09"
         )
         assert family.searches == 101
-        assert TRIAL_REGISTER.declared_count == 114
+        assert TRIAL_REGISTER.declared_count == 122
+
+    def test_the_rejected_extreme_shock_sizing_arms_are_counted(self) -> None:
+        family = next(
+            trial for trial in TRIAL_REGISTER.trials if trial.trial_id == "extreme-shock-portfolio-sizing-stress-v1"
+        )
+        assert family.searches == 8
 
     def test_the_discarded_arms_are_counted(self) -> None:
         """A rejected result is still a search of the data.


### PR DESCRIPTION
Closes #2481.

## Outcome

The frozen >=12% one-day-drop short does **not** survive finite-capital portfolio construction and is now rejected rather than exposed for demo execution.

- Reproduces the 8,049 trades and +156.81 bp event-day gross / +49.41 bp adverse-cost statistic.
- Simulates one unleveraged compounding pot with symmetric same-day funding, four declared name caps, 25% sector-capped and uncapped arms, gap-through stops, adverse carry, and a one-name -100% stress.
- All eight arms lose 13.76%–47.72%; max drawdown is 40.68%–69.05%.
- Shows why: up to 596 signals fire together and 1,210 overlap. Event-day equal weighting flatters clusters that a finite pot must dilute; executable capital-weighted trade return is negative in every arm.
- Adds all eight evaluations to the trial register (repo floor 122), records the permanent rejection, and updates the viability plan. No database tables, runtime candidate, strategy picker, or prospective event dump are added.

## Verification

- `PYTHONPATH=. uv run python scripts/verify_2481_extreme_shock_portfolio.py`
- `uv run pytest -q tests/test_extreme_shock_portfolio.py tests/test_trial_register.py tests/test_deflated_sharpe.py tests/test_strategy_result.py`
- full `.githooks/pre-push` (ruff, format, pyright, fast suite, DB smoke, frontend gates) green

The existing non-blocking dev DB warning remains: 63 GB > 60 GB.
