### PR TITLE
research(#2537): close C-3 on point-in-time source gate

### DIFF
--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -91,7 +91,9 @@ insiders. They supply priors and mechanisms, never eBull promotion evidence.
 ## 3. The initial research budget
 
 The first programme originally admitted three alpha/risk-overlay hypotheses. C-1
-and C-2 are now rejected; only C-3 remains open.
+and C-2 are now rejected. C-3 has now failed its point-in-time source gate, so
+the first bounded candidate budget is closed with zero promotable alpha
+candidates. See `2026-08-11-quality-momentum-feasibility-result.md`.
 This is a budget, not a promise to produce a strategy.
 
 ### Foundation F-0 — core and no-trade comparator
@@ -196,6 +198,17 @@ Capital allocation removed the edge before broker feasibility could promote it, 
 the family is closed. Do not search a neighbouring threshold to rescue it.
 
 ### Candidate C-3 — one low-turnover long-only factor tilt
+
+**Disposition (2026-08-11): deferred before outcome access.** The #2537
+full-population census found 7,709 archive series but only 5,269 identity maps,
+zero archive CIKs, and point-in-time membership beginning only on 2026-08-10.
+The operational SEC table's three-annual-accession retention leaves the
+optimistic quality-input upper bound at 0.0%, 0.0%, 0.0%, 0.3%, 28.6%, 33.4%
+and 31.3% of active archive series on the 2020–2026 June decision dates. The
+free SEC bulk archive can repair retained accounting depth for identified
+issuers; it cannot restore the absent dead-name price and historical membership
+population. No factor return was inspected. Do not backtest C-3 on mapped
+survivors or current membership and do not add it to the runtime catalogue.
 
 The purpose is to ask whether a simple monthly or quarterly cross-sectional overlay
 improves F-0, not to discover a daily entry trick. Freeze one specification from the
@@ -420,8 +433,10 @@ The order is deliberately different from “build more strategies.”
    no backfill, picker entry or neighbouring rescue trial.
 5. **C-2 closed:** retain the frozen event extractor, portfolio simulator, trial
    charge and failed aggregate verdict; no prospective census or rescue search.
-6. **C-3 feasibility/preregistration:** only if point-in-time fundamentals and
-   membership make the factor trial honest.
+6. **C-3 deferred:** #2537 measured that point-in-time fundamentals, dead-name
+   prices and historical membership do not make the factor trial honest. Retain
+   prospective collection; do not preregister or backtest until the independent
+   source contract in its result is met.
 7. **Viability report:** compare every admitted candidate with F-0 and no trade.
    Select all independent passers; select none if none pass.
 8. **Opportunity allocator:** implement #2525 only after at least one candidate passes
@@ -469,10 +484,11 @@ The plan is ready to proceed when:
   TP/SL/timeout, attribution and material refusals—not every ticker evaluated.
 
 The current state does **not** meet those conditions. It has enough evidence to close
-C-1 and C-2, but not enough to turn on autonomous demo allocation. The defensible
-sequence is core accounting and research-integrity repair, then C-3 only if its
-point-in-time data contract is feasible. More technical-indicator combinations are
-not the next opportunity.
+C-1 and C-2 and defer C-3 before outcome access, but not enough to turn on autonomous
+demo allocation. The first bounded candidate budget therefore ends at zero promotable
+alpha candidates. The defensible sequence is core accounting, research-integrity and
+prospective-source work while the mandate remains in F-0/cash; more technical-indicator
+combinations are not the next opportunity.
 
 ## 10. External challenge incorporated
 

--- a/docs/proposals/ta/2026-08-11-quality-momentum-feasibility-result.md
+++ b/docs/proposals/ta/2026-08-11-quality-momentum-feasibility-result.md
@@ -1,0 +1,108 @@
+# Quality-plus-momentum point-in-time feasibility result
+
+Status: **deferred / do not backtest from the current corpus**. This is the
+source-only result for #2537 and candidate C-3. No return, rank, threshold,
+weight, factor sort, or portfolio outcome was read to reach it.
+
+Reproduce the full-population census with:
+
+```bash
+PYTHONPATH=. uv run python scripts/verify_2537_c3_feasibility.py
+```
+
+## What has evidence behind it
+
+C-3 was not invented from this repo's returns. The published prior is real:
+
+- Kenneth French's momentum construction ranks on prior 2–12 month return and
+  forms value-weighted portfolios with NYSE breakpoints.
+- Kenneth French's operating-profitability portfolios use revenues less cost
+  of goods sold, interest expense and SG&A, divided by book equity, with the
+  previous fiscal year's accounting data available by the June formation date.
+- Novy-Marx's simpler gross-profitability measure is gross profit divided by
+  assets. AQR's broader quality formulation combines profitability, growth,
+  safety and payout, but needs substantially more point-in-time data.
+
+Primary references:
+
+- [Kenneth French momentum factor details](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/Data_Library/det_mom_factor_daily.html)
+- [Kenneth French operating-profitability portfolio details](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library/det_port_form_op.html)
+- [Novy-Marx, The Other Side of Value](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=1598056)
+- [AQR, Quality Minus Junk](https://www.aqr.com/Insights/Research/Working-Paper/Quality-Minus-Junk)
+
+Those publications support a factor hypothesis. They do not establish that
+eBull's current data can reproduce it without leakage, or that loading a known
+risk premium would generate broker-executable alpha after costs.
+
+## Measured source state
+
+The 2026-08-11 development corpus contains 7,709 non-comparator price series.
+Only 5,269 (68.3%) map to an instrument; 2,440 are unresolved, no archive row
+carries a CIK, and only two carry a dated delisting. The free archive is a
+Yahoo-derived snapshot keyed by live symbols. The repository's previously
+measured acceptance test found no series served as a distinct delisted history.
+That shape is fatal to a cross-sectional sort: a missing failed or acquired name
+changes the rank and therefore changes which surviving name is selected.
+
+`instrument_universe_membership` correctly refuses to invent history. Its
+12,695 rows all begin on 2026-08-10; 12,687 are `imported`, whose true start is
+explicitly unknown. It can support future prospective membership, not a
+2020–2026 backtest.
+
+The operational SEC table is also deliberately not a research warehouse. For
+all 4,183 instruments with a 10-K-family filing it holds a median and maximum of
+three distinct annual accessions, exactly the retention cap. The available SEC
+bulk Company Facts archive can reconstruct deeper as-filed facts for issuers it
+can identify, and should remain the free source if a future research corpus is
+built. It cannot restore absent delisted price histories or historical tradable
+membership.
+
+## Optimistic accounting-input upper bound
+
+For each 30 June decision date, the census counts an active archive series as
+quality-ready when any 10-K/10-K-A filed by then and no more than 548 days old
+contains assets plus either gross profit or revenue and cost of revenue for the
+same period. This is deliberately generous: it does not yet require common
+stock, valid positive values, consistent accession, liquidity, sector,
+volatility, costs, or portfolio eligibility. A production gate can only reduce
+these counts.
+
+| decision date | active archive | identity mapped | optimistic quality-ready | share of archive | share of mapped |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 2020-06-30 | 4,000 | 3,547 | 0 | 0.0% | 0.0% |
+| 2021-06-30 | 4,623 | 4,036 | 0 | 0.0% | 0.0% |
+| 2022-06-30 | 5,055 | 4,367 | 1 | 0.0% | 0.0% |
+| 2023-06-30 | 5,243 | 4,504 | 14 | 0.3% | 0.3% |
+| 2024-06-30 | 5,515 | 4,684 | 1,575 | 28.6% | 33.6% |
+| 2025-06-30 | 6,065 | 4,999 | 2,025 | 33.4% | 40.5% |
+| 2026-06-30 | 6,865 | 5,066 | 2,147 | 31.3% | 42.4% |
+
+The recent rows are not a usable recent validation window. They still select
+from mapped/current survivors, omit historical membership, and cover less than
+half even of the mapped population. Zero-filling missing accounting values or
+ranking only complete cases would make missingness an undeclared alpha input.
+
+## Decision and bounded ways to reopen it
+
+Do not implement C-3, expose it as a strategy, or spend a trial on the current
+corpus. Do not substitute today's eToro universe, today's instrument mapping,
+or the existing contaminated S-2 result. Candidate C-3 is deferred and the
+first bounded candidate budget ends with zero promotable alpha candidates.
+
+It may reopen only after one of these independently auditable source contracts
+exists:
+
+1. a licensed point-in-time US common-equity price and membership corpus that
+   includes dead names, corporate actions and stable security identity, joined
+   to as-filed SEC facts; or
+2. enough prospectively recorded membership, facts and total-return history to
+   power a newly preregistered trial without historical backfill.
+
+The first is not available from the free sources already exhaustively tested in
+this repository; the second takes years rather than enabling paper allocation
+tomorrow. Recording prospectively remains useful, but elapsed time must never
+be treated as automatic promotion.
+
+This disposition is a successful safety result: the published factor family
+remains plausible, while this application is prevented from presenting a
+survivor-biased simulation as evidence that it can manage money.

--- a/scripts/verify_2537_c3_feasibility.py
+++ b/scripts/verify_2537_c3_feasibility.py
@@ -1,0 +1,201 @@
+"""Read-only point-in-time data census for candidate C-3 (#2537).
+
+Run from the repository root:
+
+    PYTHONPATH=. uv run python scripts/verify_2537_c3_feasibility.py
+
+This script deliberately reads no forward returns and performs no factor sort.  It
+asks whether the existing free corpus can support an honest historical
+quality-plus-momentum trial before a specification is frozen.  The quality count
+is an optimistic upper bound: it accepts either reported gross profit or
+revenue-minus-cost-of-revenue and does not yet impose value validity, common-stock,
+liquidity, sector, or portfolio eligibility gates.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+
+import psycopg
+
+from app.config import settings
+
+DECISION_DATES = tuple(date(year, 6, 30) for year in range(2020, 2027))
+
+_ARCHIVE_TOTAL = """
+    SELECT count(*) AS series,
+           count(instrument_id) AS mapped,
+           count(cik) AS cik,
+           count(delisting_date) AS dated_delistings,
+           min(first_bar) AS first_bar,
+           max(last_bar) AS last_bar
+    FROM research_price_series
+    WHERE comparator_snapshot_id IS NULL
+"""
+
+_ARCHIVE_BY_LAST_YEAR = """
+    SELECT extract(year FROM last_bar)::int AS last_year,
+           count(*) AS series,
+           count(instrument_id) AS mapped
+    FROM research_price_series
+    WHERE comparator_snapshot_id IS NULL
+    GROUP BY 1
+    ORDER BY 1
+"""
+
+_MEMBERSHIP = """
+    SELECT count(*) AS rows,
+           count(DISTINCT instrument_id) AS instruments,
+           min(effective_from) AS first_effective_from,
+           max(effective_from) AS last_effective_from,
+           count(*) FILTER (WHERE source_event = 'imported') AS imported
+    FROM instrument_universe_membership
+"""
+
+_ANNUAL_RETENTION = """
+    SELECT count(*) AS instruments,
+           max(accessions) AS maximum_accessions,
+           percentile_cont(0.5) WITHIN GROUP (ORDER BY accessions) AS median_accessions,
+           count(*) FILTER (WHERE accessions > 3) AS above_retention_cap
+    FROM (
+        SELECT instrument_id, count(DISTINCT accession_number) AS accessions
+        FROM financial_facts_raw
+        WHERE form_type IN ('10-K', '10-K/A')
+        GROUP BY instrument_id
+    ) retained
+"""
+
+# This is intentionally permissive.  Facts only need to have been filed by the
+# decision date, belong to an annual filing/period ending before it, and be no
+# older than 548 days.  Grouping after the decision-date predicate permits an
+# earlier original filing even when a later amendment exists.  Any production
+# quality measure would reject more rows, never add rows to this upper bound.
+_DECISION_DATE_COVERAGE = """
+    WITH decision_dates(decision_date) AS (
+        SELECT unnest(%(decision_dates)s::date[])
+    ),
+    active AS (
+        SELECT d.decision_date, s.series_id, s.instrument_id
+        FROM decision_dates d
+        JOIN research_price_series s
+          ON s.comparator_snapshot_id IS NULL
+         AND s.first_bar <= d.decision_date
+         AND s.last_bar >= d.decision_date
+    ),
+    annual AS (
+        SELECT d.decision_date,
+               f.instrument_id,
+               f.period_end,
+               bool_or(f.concept = 'Assets') AS has_assets,
+               bool_or(f.concept = 'GrossProfit')
+                   OR (
+                       bool_or(f.concept = ANY(%(revenue_concepts)s::text[]))
+                       AND bool_or(f.concept = ANY(%(cost_concepts)s::text[]))
+                   ) AS has_gross_profit
+        FROM decision_dates d
+        JOIN financial_facts_raw f
+          ON f.filed_date <= d.decision_date
+         AND f.filed_date > d.decision_date - INTERVAL '548 days'
+         AND f.period_end < d.decision_date
+        WHERE f.form_type IN ('10-K', '10-K/A')
+          AND f.concept = ANY(%(quality_concepts)s::text[])
+        GROUP BY d.decision_date, f.instrument_id, f.period_end
+    ),
+    quality_ready AS (
+        SELECT DISTINCT decision_date, instrument_id
+        FROM annual
+        WHERE has_assets AND has_gross_profit
+    )
+    SELECT a.decision_date,
+           count(*) AS active_archive,
+           count(a.instrument_id) AS identity_mapped,
+           count(q.instrument_id) AS quality_ready
+    FROM active a
+    LEFT JOIN quality_ready q
+      ON q.decision_date = a.decision_date
+     AND q.instrument_id = a.instrument_id
+    GROUP BY a.decision_date
+    ORDER BY a.decision_date
+"""
+
+_REVENUE_CONCEPTS = (
+    "RevenueFromContractWithCustomerExcludingAssessedTax",
+    "RevenueFromContractWithCustomerIncludingAssessedTax",
+    "Revenues",
+    "SalesRevenueNet",
+)
+_COST_CONCEPTS = ("CostOfGoodsAndServicesSold", "CostOfRevenue")
+_QUALITY_CONCEPTS = ("Assets", "GrossProfit", *_REVENUE_CONCEPTS, *_COST_CONCEPTS)
+
+
+def _pct(numerator: int, denominator: int) -> str:
+    return "—" if denominator == 0 else f"{numerator / denominator:.1%}"
+
+
+def main() -> int:
+    with psycopg.connect(settings.database_url) as conn:
+        archive = conn.execute(_ARCHIVE_TOTAL).fetchone()
+        last_years = conn.execute(_ARCHIVE_BY_LAST_YEAR).fetchall()
+        membership = conn.execute(_MEMBERSHIP).fetchone()
+        retention = conn.execute(_ANNUAL_RETENTION).fetchone()
+        coverage = conn.execute(
+            _DECISION_DATE_COVERAGE,
+            {
+                "decision_dates": list(DECISION_DATES),
+                "revenue_concepts": list(_REVENUE_CONCEPTS),
+                "cost_concepts": list(_COST_CONCEPTS),
+                "quality_concepts": list(_QUALITY_CONCEPTS),
+            },
+        ).fetchall()
+
+    if archive is None or membership is None or retention is None:
+        print("REFUSED: a feasibility census returned no aggregate row", file=sys.stderr)
+        return 2
+
+    series, mapped, cik, dated_delistings, first_bar, last_bar = archive
+    membership_rows, membership_instruments, membership_first, membership_last, imported = membership
+    retained_instruments, maximum_accessions, median_accessions, above_cap = retention
+
+    print("#2537 C-3 POINT-IN-TIME FEASIBILITY — NO OUTCOMES READ")
+    print("\nPRICE / IDENTITY")
+    print(f"archive series:                 {series:>10,}")
+    print(f"identity mapped:                {mapped:>10,}  ({_pct(mapped, series)})")
+    print(f"unresolved:                     {series - mapped:>10,}  ({_pct(series - mapped, series)})")
+    print(f"archive CIK present:            {cik:>10,}")
+    print(f"dated delistings:               {dated_delistings:>10,}")
+    print(f"bar envelope:                   {first_bar} through {last_bar}")
+    print("last-bar-year mapping:")
+    for year, year_series, year_mapped in last_years:
+        print(f"  {year}: {year_mapped:>5,}/{year_series:<5,} ({_pct(year_mapped, year_series)})")
+
+    print("\nPOINT-IN-TIME MEMBERSHIP")
+    print(f"rows / instruments:             {membership_rows:,} / {membership_instruments:,}")
+    print(f"effective-from envelope:        {membership_first} through {membership_last}")
+    print(f"imported (true start unknown):  {imported:,}")
+
+    print("\nRETAINED SEC ANNUAL HISTORY")
+    print(f"instruments with 10-K family:   {retained_instruments:,}")
+    print(f"accessions median / maximum:    {median_accessions:g} / {maximum_accessions}")
+    print(f"instruments above 3-accession cap: {above_cap:,}")
+
+    print("\nOPTIMISTIC QUALITY INPUT UPPER BOUND")
+    print(f"{'date':<12}{'active':>9}{'mapped':>10}{'quality':>10}{'archive %':>12}{'mapped %':>11}")
+    for decision_date, active_count, mapped_count, quality_count in coverage:
+        print(
+            f"{decision_date!s:<12}{active_count:>9,}{mapped_count:>10,}{quality_count:>10,}"
+            f"{_pct(quality_count, active_count):>12}{_pct(quality_count, mapped_count):>11}"
+        )
+
+    print("\nDISPOSITION: DEFER / DO NOT BACKTEST")
+    print("- C-3 is a cross-sectional rank; unresolved/dead names alter every surviving rank.")
+    print("- Membership begins in 2026 and imported rows explicitly do not reveal their true start.")
+    print("- The hot SEC table is capped at three annual accessions, so 2020-2023 quality coverage")
+    print("  is not a historical point-in-time population even under this deliberately loose upper bound.")
+    print("- Today’s mapped identities or current universe must not be backfilled into prior dates.")
+    print("- No parameter, return, factor sort, or portfolio outcome was inspected by this census.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Outcome
Closes the first bounded alpha candidate budget without fabricating a quality-plus-momentum backtest. The published factor prior remains credible, but the current free corpus cannot validate a cross-sectional allocation without survivorship and membership leakage.

## Evidence
- Adds a read-only full-population census; no outcomes or factor ranks are read.
- Measures 7,709 archive series, 5,269 identity maps, zero archive CIKs, and only two dated delistings.
- Confirms all 12,695 membership rows begin 2026-08-10 and 12,687 have unknown imported starts.
- Confirms the hot SEC table is capped at three 10-K-family accessions; optimistic quality-ready archive coverage is effectively zero through 2023 and 28.6-33.4% in 2024-2026.
- Records why the free SEC bulk archive can repair accounting depth but cannot repair missing dead-name prices or historical membership.

## Product effect
- No runtime strategy, signal rows, database table, or UI picker is added.
- C-3 is deferred before outcome access; mapped survivors/current membership are forbidden as substitutes.
- The mandate remains fail-closed in F-0/cash with zero promotable alpha candidates.

## Verification
- PYTHONPATH=. uv run python scripts/verify_2537_c3_feasibility.py
- bash .githooks/pre-push (green; existing non-blocking 63GB dev DB warning)

Closes #2537
Parent #2240