### PR TITLE
Add a versioned measurable portfolio risk mandate

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -50,6 +50,7 @@ from app.services.strategy_control_plane import (
     is_risk_reducing_deployment_change,
     load_paper_pool,
     lock_strategy_control,
+    mandate_for_profile,
     promote_strategy,
 )
 from app.services.strategy_live_gate import (
@@ -257,6 +258,21 @@ class StrategyEntryBlockView(BaseModel):
     execution_block_reasons: list[str]
 
 
+class StrategyPortfolioMandateView(BaseModel):
+    configured: bool
+    policy_version: str
+    risk_profile: Literal["unconfigured", "cautious", "balanced", "growth"]
+    target_volatility_pct: Decimal | None
+    max_portfolio_drawdown_pct: Decimal | None
+    max_loss_per_position_pct: Decimal | None
+    max_daily_loss_pct: Decimal | None
+    active_risk_budget_pct: Decimal | None
+    cash_reserve_pct: Decimal | None
+    max_concurrent_positions: int | None
+    shorts_allowed: bool
+    leverage_allowed: bool
+
+
 class StrategyPaperPoolView(BaseModel):
     configured: bool
     enabled: bool
@@ -267,6 +283,28 @@ class StrategyPaperPoolView(BaseModel):
     reserved_capital: Decimal
     invested_capital: Decimal | None
     remaining_capital: Decimal | None
+    mandate: StrategyPortfolioMandateView
+    available_mandates: list[StrategyPortfolioMandateView]
+
+
+def _mandate_view(
+    risk_profile: Literal["unconfigured", "cautious", "balanced", "growth"],
+) -> StrategyPortfolioMandateView:
+    mandate = mandate_for_profile(risk_profile)
+    return StrategyPortfolioMandateView(
+        configured=mandate.configured,
+        policy_version=mandate.policy_version,
+        risk_profile=mandate.risk_profile,
+        target_volatility_pct=mandate.target_volatility_pct,
+        max_portfolio_drawdown_pct=mandate.max_portfolio_drawdown_pct,
+        max_loss_per_position_pct=mandate.max_loss_per_position_pct,
+        max_daily_loss_pct=mandate.max_daily_loss_pct,
+        active_risk_budget_pct=mandate.active_risk_budget_pct,
+        cash_reserve_pct=mandate.cash_reserve_pct,
+        max_concurrent_positions=mandate.max_concurrent_positions,
+        shorts_allowed=mandate.shorts_allowed,
+        leverage_allowed=mandate.leverage_allowed,
+    )
 
 
 class EvidenceRefreshView(BaseModel):
@@ -308,12 +346,15 @@ class StrategyPaperPoolUpdateRequest(BaseModel):
     enabled: bool
     capital_limit: Decimal = Field(ge=0, max_digits=18, decimal_places=6)
     capital_mode: Literal["fixed", "compound"] = "fixed"
+    risk_profile: Literal["unconfigured", "cautious", "balanced", "growth"]
     reason: str = Field(min_length=1, max_length=1000)
 
     @model_validator(mode="after")
     def enabled_requires_capital(self) -> StrategyPaperPoolUpdateRequest:
         if self.enabled and self.capital_limit <= 0:
             raise ValueError("enabled paper pool requires positive capital")
+        if self.enabled and self.risk_profile == "unconfigured":
+            raise ValueError("enabled paper pool requires a configured portfolio risk mandate")
         return self
 
 
@@ -1061,6 +1102,21 @@ def get_strategy_overview(
                 if effective_pool_capital is not None
                 else None
             ),
+            mandate=StrategyPortfolioMandateView(
+                configured=paper_pool.mandate.configured,
+                policy_version=paper_pool.mandate.policy_version,
+                risk_profile=paper_pool.mandate.risk_profile,
+                target_volatility_pct=paper_pool.mandate.target_volatility_pct,
+                max_portfolio_drawdown_pct=paper_pool.mandate.max_portfolio_drawdown_pct,
+                max_loss_per_position_pct=paper_pool.mandate.max_loss_per_position_pct,
+                max_daily_loss_pct=paper_pool.mandate.max_daily_loss_pct,
+                active_risk_budget_pct=paper_pool.mandate.active_risk_budget_pct,
+                cash_reserve_pct=paper_pool.mandate.cash_reserve_pct,
+                max_concurrent_positions=paper_pool.mandate.max_concurrent_positions,
+                shorts_allowed=paper_pool.mandate.shorts_allowed,
+                leverage_allowed=paper_pool.mandate.leverage_allowed,
+            ),
+            available_mandates=[_mandate_view(profile) for profile in ("cautious", "balanced", "growth")],
         ),
         evidence_refresh=EvidenceRefreshView(
             frozen_through=max(item.window.end for item in RECENT_EVIDENCE_WINDOWS.values()),
@@ -1512,16 +1568,20 @@ def update_strategy_paper_pool(
                 current_pool.enabled != body.enabled
                 or current_pool.capital_limit != body.capital_limit
                 or current_pool.capital_mode != body.capital_mode
+                or current_pool.mandate.risk_profile != body.risk_profile
             )
             automation_changed = runtime.enable_auto_trading != body.enabled
             if not pool_changed and not automation_changed:
-                raise StrategyControlError("automation change must alter enabled state, capital limit, or capital mode")
+                raise StrategyControlError(
+                    "automation change must alter enabled state, capital limit, capital mode, or mandate"
+                )
             if pool_changed:
                 configure_paper_pool(
                     conn,
                     enabled=body.enabled,
                     capital_limit=body.capital_limit,
                     capital_mode=body.capital_mode,
+                    risk_profile=body.risk_profile,
                     changed_by=session.username,
                     reason=body.reason,
                 )

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -29,9 +29,12 @@ Stage = Literal[
 ]
 Mode = Literal["paper", "live"]
 CapitalMode = Literal["fixed", "compound"]
+RiskProfile = Literal["unconfigured", "cautious", "balanced", "growth"]
 TicketSizingMode = Literal["percent", "fixed"]
 
 GOVERNANCE_GATE_VERSION = "strategy-governance-v1"
+MANDATE_POLICY_VERSION = "portfolio-mandate-v1"
+UNCONFIGURED_MANDATE_POLICY_VERSION = "portfolio-mandate-unconfigured"
 
 # Two-key Postgres advisory-lock namespace.  2454 is this issue's stable,
 # documented namespace; hashtext(strategy identity) supplies the per-version
@@ -88,18 +91,105 @@ class Deployment:
 
 
 @dataclass(frozen=True)
+class PortfolioMandate:
+    policy_version: str
+    risk_profile: RiskProfile
+    target_volatility_pct: Decimal | None
+    max_portfolio_drawdown_pct: Decimal | None
+    max_loss_per_position_pct: Decimal | None
+    max_daily_loss_pct: Decimal | None
+    active_risk_budget_pct: Decimal | None
+    cash_reserve_pct: Decimal | None
+    max_concurrent_positions: int | None
+    shorts_allowed: bool = False
+    leverage_allowed: bool = False
+
+    @property
+    def configured(self) -> bool:
+        return self.risk_profile != "unconfigured"
+
+
+UNCONFIGURED_MANDATE = PortfolioMandate(
+    policy_version=UNCONFIGURED_MANDATE_POLICY_VERSION,
+    risk_profile="unconfigured",
+    target_volatility_pct=None,
+    max_portfolio_drawdown_pct=None,
+    max_loss_per_position_pct=None,
+    max_daily_loss_pct=None,
+    active_risk_budget_pct=None,
+    cash_reserve_pct=None,
+    max_concurrent_positions=None,
+)
+
+_MANDATE_PROFILES: dict[RiskProfile, PortfolioMandate] = {
+    "unconfigured": UNCONFIGURED_MANDATE,
+    "cautious": PortfolioMandate(
+        MANDATE_POLICY_VERSION,
+        "cautious",
+        Decimal("8"),
+        Decimal("10"),
+        Decimal("0.5"),
+        Decimal("1"),
+        Decimal("10"),
+        Decimal("25"),
+        4,
+    ),
+    "balanced": PortfolioMandate(
+        MANDATE_POLICY_VERSION,
+        "balanced",
+        Decimal("12"),
+        Decimal("15"),
+        Decimal("0.75"),
+        Decimal("1.5"),
+        Decimal("20"),
+        Decimal("15"),
+        8,
+    ),
+    "growth": PortfolioMandate(
+        MANDATE_POLICY_VERSION,
+        "growth",
+        Decimal("18"),
+        Decimal("25"),
+        Decimal("1"),
+        Decimal("2.5"),
+        Decimal("30"),
+        Decimal("10"),
+        12,
+    ),
+}
+
+
+def mandate_for_profile(risk_profile: RiskProfile) -> PortfolioMandate:
+    """Resolve a presentation label to the exact immutable v1 limits.
+
+    These are operator risk ceilings, not estimated returns or fitted strategy
+    parameters.  A later policy changes ``MANDATE_POLICY_VERSION`` and writes
+    its exact limits; it never mutates the meaning of an existing event.
+    """
+    try:
+        return _MANDATE_PROFILES[risk_profile]
+    except KeyError as exc:  # pragma: no cover - guarded by Literal/Pydantic at typed boundaries
+        raise StrategyControlError(f"unknown risk profile: {risk_profile}") from exc
+
+
+@dataclass(frozen=True)
 class PaperPool:
     event_id: int | None
     enabled: bool
     capital_limit: Decimal
     currency: str = "USD"
     capital_mode: CapitalMode = "fixed"
+    mandate: PortfolioMandate = UNCONFIGURED_MANDATE
 
 
 def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
     row = conn.execute(
         """
-        SELECT strategy_paper_pool_event_id,enabled,capital_limit,currency,capital_mode
+        SELECT strategy_paper_pool_event_id,enabled,capital_limit,currency,capital_mode,
+               mandate_policy_version,risk_profile,target_volatility_pct,
+               max_portfolio_drawdown_pct,max_loss_per_position_pct,max_daily_loss_pct,
+               active_risk_budget_pct,cash_reserve_pct,max_concurrent_positions,
+               shorts_allowed,leverage_allowed
         FROM strategy_paper_pool_events
         ORDER BY strategy_paper_pool_event_id DESC
         LIMIT 1
@@ -107,7 +197,27 @@ def load_paper_pool(conn: psycopg.Connection[Any]) -> PaperPool:
     ).fetchone()
     if row is None:
         return PaperPool(None, False, Decimal("0"))
-    return PaperPool(int(row[0]), bool(row[1]), Decimal(str(row[2])), str(row[3]), cast(CapitalMode, row[4]))
+    mandate = PortfolioMandate(
+        policy_version=str(row[5]),
+        risk_profile=cast(RiskProfile, row[6]),
+        target_volatility_pct=None if row[7] is None else Decimal(str(row[7])),
+        max_portfolio_drawdown_pct=None if row[8] is None else Decimal(str(row[8])),
+        max_loss_per_position_pct=None if row[9] is None else Decimal(str(row[9])),
+        max_daily_loss_pct=None if row[10] is None else Decimal(str(row[10])),
+        active_risk_budget_pct=None if row[11] is None else Decimal(str(row[11])),
+        cash_reserve_pct=None if row[12] is None else Decimal(str(row[12])),
+        max_concurrent_positions=None if row[13] is None else int(row[13]),
+        shorts_allowed=bool(row[14]),
+        leverage_allowed=bool(row[15]),
+    )
+    return PaperPool(
+        int(row[0]),
+        bool(row[1]),
+        Decimal(str(row[2])),
+        str(row[3]),
+        cast(CapitalMode, row[4]),
+        mandate,
+    )
 
 
 def configure_paper_pool(
@@ -116,6 +226,7 @@ def configure_paper_pool(
     enabled: bool,
     capital_limit: Decimal,
     capital_mode: CapitalMode = "fixed",
+    risk_profile: RiskProfile,
     changed_by: str,
     reason: str,
 ) -> PaperPool:
@@ -126,12 +237,22 @@ def configure_paper_pool(
         raise StrategyControlError("enabled paper pool requires a positive finite USD capital limit")
     if capital_mode not in {"fixed", "compound"}:
         raise StrategyControlError("capital_mode must be fixed or compound")
+    mandate = mandate_for_profile(risk_profile)
+    if enabled and not mandate.configured:
+        raise StrategyControlError("enabled paper pool requires a configured portfolio risk mandate")
     # Conflict with the executor's session lock so a pause/lower cannot race an
     # already-sized order between its authority read and demo broker submit.
     conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
     current = load_paper_pool(conn)
-    if current.enabled == enabled and current.capital_limit == capital_limit and current.capital_mode == capital_mode:
-        raise StrategyControlError("paper pool change must alter enabled state, capital limit, or capital mode")
+    if (
+        current.enabled == enabled
+        and current.capital_limit == capital_limit
+        and current.capital_mode == capital_mode
+        and current.mandate == mandate
+    ):
+        raise StrategyControlError(
+            "paper pool change must alter enabled state, capital limit, capital mode, or mandate"
+        )
     if current.event_id is not None and capital_limit < current.capital_limit:
         # A lower principal is an external withdrawal from the virtual sleeve,
         # not merely a cosmetic limit edit.  It cannot remove money already
@@ -178,14 +299,37 @@ def configure_paper_pool(
                 raise StrategyControlError("paper principal cannot be withdrawn below committed strategy capital")
     row = conn.execute(
         """
-        INSERT INTO strategy_paper_pool_events (enabled,capital_limit,currency,capital_mode,changed_by,reason)
-        VALUES (%s,%s,'USD',%s,%s,%s)
+        INSERT INTO strategy_paper_pool_events (
+            enabled,capital_limit,currency,capital_mode,changed_by,reason,
+            mandate_policy_version,risk_profile,target_volatility_pct,
+            max_portfolio_drawdown_pct,max_loss_per_position_pct,max_daily_loss_pct,
+            active_risk_budget_pct,cash_reserve_pct,max_concurrent_positions,
+            shorts_allowed,leverage_allowed
+        )
+        VALUES (%s,%s,'USD',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         RETURNING strategy_paper_pool_event_id
         """,
-        (enabled, capital_limit, capital_mode, changed_by, reason),
+        (
+            enabled,
+            capital_limit,
+            capital_mode,
+            changed_by,
+            reason,
+            mandate.policy_version,
+            mandate.risk_profile,
+            mandate.target_volatility_pct,
+            mandate.max_portfolio_drawdown_pct,
+            mandate.max_loss_per_position_pct,
+            mandate.max_daily_loss_pct,
+            mandate.active_risk_budget_pct,
+            mandate.cash_reserve_pct,
+            mandate.max_concurrent_positions,
+            mandate.shorts_allowed,
+            mandate.leverage_allowed,
+        ),
     ).fetchone()
     assert row is not None
-    return PaperPool(int(row[0]), enabled, capital_limit, "USD", capital_mode)
+    return PaperPool(int(row[0]), enabled, capital_limit, "USD", capital_mode, mandate)
 
 
 @dataclass(frozen=True)

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -178,7 +178,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
                    i.symbol, i.is_tradable, e.asset_class,
                    d.deployment_id, d.capital_limit, d.enabled, d.currency,
                    pool.enabled AS pool_enabled, pool.capital_limit AS pool_limit,
-                   pool.capital_mode,
+                   pool.capital_mode, pool.risk_profile,
                    p.revision AS policy_revision, p.*,
                    q.quoted_at, q.ask, q.spread_flag,
                    w.updated_at AS scan_at,
@@ -218,7 +218,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
              AND d.mode = 'paper'
             LEFT JOIN strategy_execution_policies p ON p.deployment_id = d.deployment_id
             LEFT JOIN LATERAL (
-                SELECT enabled,capital_limit,capital_mode
+                SELECT enabled,capital_limit,capital_mode,risk_profile
                 FROM strategy_paper_pool_events
                 ORDER BY strategy_paper_pool_event_id DESC
                 LIMIT 1
@@ -270,6 +270,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
         (row["deployment_id"] is not None, "paper_deployment_missing"),
         (row["pool_limit"] is not None, "paper_pool_unconfigured"),
         (bool(row["pool_enabled"]), "paper_pool_disabled"),
+        (row["risk_profile"] is not None and row["risk_profile"] != "unconfigured", "portfolio_mandate_unconfigured"),
         (bool(row["enabled"]), "paper_deployment_disabled"),
         (row["currency"] == "USD", "deployment_currency_unsupported"),
         (row["policy_revision"] is not None, "execution_policy_missing"),

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -51,6 +51,7 @@ export function updateStrategyPaperPool(body: {
   enabled: boolean;
   capital_limit: string;
   capital_mode: "fixed" | "compound";
+  risk_profile: "unconfigured" | "cautious" | "balanced" | "growth";
   reason: string;
 }): Promise<StrategyPaperPool> {
   return apiFetch("/strategies/paper-pool", {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2577,6 +2577,23 @@ export interface StrategyPaperPool {
   reserved_capital: string;
   invested_capital: string | null;
   remaining_capital: string | null;
+  mandate: StrategyPortfolioMandate;
+  available_mandates: StrategyPortfolioMandate[];
+}
+
+export interface StrategyPortfolioMandate {
+  configured: boolean;
+  policy_version: string;
+  risk_profile: "unconfigured" | "cautious" | "balanced" | "growth";
+  target_volatility_pct: string | null;
+  max_portfolio_drawdown_pct: string | null;
+  max_loss_per_position_pct: string | null;
+  max_daily_loss_pct: string | null;
+  active_risk_budget_pct: string | null;
+  cash_reserve_pct: string | null;
+  max_concurrent_positions: number | null;
+  shorts_allowed: boolean;
+  leverage_allowed: boolean;
 }
 
 export interface StrategySizingUpdateResponse {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -67,6 +67,64 @@ const OVERVIEW: StrategyOverviewResponse = {
     reserved_capital: "0.000000",
     invested_capital: "0.000000",
     remaining_capital: "1000.000000",
+    mandate: {
+      configured: true,
+      policy_version: "portfolio-mandate-v1",
+      risk_profile: "balanced",
+      target_volatility_pct: "12.0000",
+      max_portfolio_drawdown_pct: "15.0000",
+      max_loss_per_position_pct: "0.7500",
+      max_daily_loss_pct: "1.5000",
+      active_risk_budget_pct: "20.0000",
+      cash_reserve_pct: "15.0000",
+      max_concurrent_positions: 8,
+      shorts_allowed: false,
+      leverage_allowed: false,
+    },
+    available_mandates: [
+      {
+        configured: true,
+        policy_version: "portfolio-mandate-v1",
+        risk_profile: "cautious",
+        target_volatility_pct: "8.0000",
+        max_portfolio_drawdown_pct: "10.0000",
+        max_loss_per_position_pct: "0.5000",
+        max_daily_loss_pct: "1.0000",
+        active_risk_budget_pct: "10.0000",
+        cash_reserve_pct: "25.0000",
+        max_concurrent_positions: 4,
+        shorts_allowed: false,
+        leverage_allowed: false,
+      },
+      {
+        configured: true,
+        policy_version: "portfolio-mandate-v1",
+        risk_profile: "balanced",
+        target_volatility_pct: "12.0000",
+        max_portfolio_drawdown_pct: "15.0000",
+        max_loss_per_position_pct: "0.7500",
+        max_daily_loss_pct: "1.5000",
+        active_risk_budget_pct: "20.0000",
+        cash_reserve_pct: "15.0000",
+        max_concurrent_positions: 8,
+        shorts_allowed: false,
+        leverage_allowed: false,
+      },
+      {
+        configured: true,
+        policy_version: "portfolio-mandate-v1",
+        risk_profile: "growth",
+        target_volatility_pct: "18.0000",
+        max_portfolio_drawdown_pct: "25.0000",
+        max_loss_per_position_pct: "1.0000",
+        max_daily_loss_pct: "2.5000",
+        active_risk_budget_pct: "30.0000",
+        cash_reserve_pct: "10.0000",
+        max_concurrent_positions: 12,
+        shorts_allowed: false,
+        leverage_allowed: false,
+      },
+    ],
   },
   evidence_refresh: {
     frozen_through: "2026-07-08",
@@ -204,7 +262,7 @@ describe("StrategiesPage", () => {
     expect(within(performance).getAllByText("—")).toHaveLength(2);
     expect(within(performance).queryByText("+1.50%")).not.toBeInTheDocument();
     expect(screen.getByText("No automated P&L yet")).toBeInTheDocument();
-    expect(screen.getByText("+1.50%")).toBeInTheDocument();
+    expect(screen.getAllByText("+1.50%")).toHaveLength(2);
     expect(screen.getByText("Not proven")).toBeInTheDocument();
   });
 
@@ -315,7 +373,23 @@ describe("StrategiesPage", () => {
     expect(input.parentElement).toHaveClass("w-48");
     fireEvent.change(input, { target: { value: "1500" } });
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(update).toHaveBeenCalledWith({ enabled: false, capital_limit: "1500.000000", capital_mode: "fixed", reason: "Automated strategy workspace update" }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ enabled: false, capital_limit: "1500.000000", capital_mode: "fixed", risk_profile: "balanced", reason: "Automated strategy workspace update" }));
+  });
+
+  it("shows exact mandate limits and submits a changed risk profile", async () => {
+    const update = vi.spyOn(strategiesApi, "updateStrategyPaperPool").mockResolvedValue({
+      ...OVERVIEW.paper_pool,
+      mandate: { ...OVERVIEW.paper_pool.mandate, risk_profile: "growth" },
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    expect(await screen.findByText("Policy ceilings, not return forecasts. Long-only and unleveraged in this version.")).toBeInTheDocument();
+    await userEvent.selectOptions(screen.getByLabelText("Risk profile"), "growth");
+    expect(screen.getByText("+18.00%")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      risk_profile: "growth",
+    })));
   });
 
   it("does not present automation as enabled while the system-wide guard is off", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -446,18 +446,26 @@ function AutomationControl({
   const [enabled, setEnabled] = useState(pool.enabled && overview.execution_enabled);
   const [limit, setLimit] = useState(pool.capital_limit);
   const [capitalMode, setCapitalMode] = useState(pool.capital_mode);
+  const [riskProfile, setRiskProfile] = useState(pool.mandate.risk_profile);
   const [saving, setSaving] = useState(false);
   const [failed, setFailed] = useState(false);
   useEffect(() => {
     setEnabled(pool.enabled && overview.execution_enabled);
     setLimit(pool.capital_limit);
     setCapitalMode(pool.capital_mode);
-  }, [pool.enabled, pool.capital_limit, pool.capital_mode, overview.execution_enabled]);
+    setRiskProfile(pool.mandate.risk_profile);
+  }, [pool.enabled, pool.capital_limit, pool.capital_mode, pool.mandate.risk_profile, overview.execution_enabled]);
   const parsed = Number(limit);
   const valid = Number.isFinite(parsed) && parsed >= 0 && (!enabled || parsed > 0);
   const effectiveEnabled = pool.enabled && overview.execution_enabled;
-  const dirty = enabled !== effectiveEnabled || parsed !== Number(pool.capital_limit) || capitalMode !== pool.capital_mode;
-  const canEnable = approvedCount > 0 && overview.execution_enabled;
+  const dirty = enabled !== effectiveEnabled
+    || parsed !== Number(pool.capital_limit)
+    || capitalMode !== pool.capital_mode
+    || riskProfile !== pool.mandate.risk_profile;
+  const canEnable = approvedCount > 0 && overview.execution_enabled && riskProfile !== "unconfigured";
+  const selectedMandate = riskProfile === pool.mandate.risk_profile && pool.mandate.configured
+    ? pool.mandate
+    : pool.available_mandates.find((mandate) => mandate.risk_profile === riskProfile) ?? null;
 
   async function save(event: FormEvent) {
     event.preventDefault();
@@ -469,6 +477,7 @@ function AutomationControl({
         enabled,
         capital_limit: parsed.toFixed(6),
         capital_mode: capitalMode,
+        risk_profile: riskProfile,
         reason: "Automated strategy workspace update",
       });
       onUpdated();
@@ -523,11 +532,39 @@ function AutomationControl({
               <option value="compound">Reinvest realised P&amp;L</option>
             </select>
           </label>
+          <label className="w-48 text-xs font-medium text-slate-600 dark:text-slate-300">
+            Risk profile
+            <select
+              value={riskProfile}
+              onChange={(event) => setRiskProfile(event.target.value as "unconfigured" | "cautious" | "balanced" | "growth")}
+              className="mt-1 min-h-11 w-full border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+            >
+              <option value="unconfigured">Choose risk profile</option>
+              <option value="cautious">Cautious</option>
+              <option value="balanced">Balanced</option>
+              <option value="growth">Growth</option>
+            </select>
+          </label>
           <button type="submit" disabled={!valid || !dirty || saving || (enabled && !canEnable)} className="min-h-11 cursor-pointer border border-blue-700 bg-blue-700 px-4 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-40">
             {saving ? "Saving…" : "Save"}
           </button>
         </div>
       </form>
+      {selectedMandate ? (
+        <div className="mt-5 border-t border-slate-200 pt-4 dark:border-slate-800">
+          <p className="text-xs text-slate-500">Policy ceilings, not return forecasts. Long-only and unleveraged in this version.</p>
+          <dl className="mt-3 grid grid-cols-2 gap-3 text-xs sm:grid-cols-4">
+            <div><dt className="text-slate-500">Target volatility</dt><dd className="font-semibold">{pctPoints(selectedMandate.target_volatility_pct)}</dd></div>
+            <div><dt className="text-slate-500">Max drawdown</dt><dd className="font-semibold">{pctPoints(selectedMandate.max_portfolio_drawdown_pct)}</dd></div>
+            <div><dt className="text-slate-500">Max loss / position</dt><dd className="font-semibold">{pctPoints(selectedMandate.max_loss_per_position_pct)}</dd></div>
+            <div><dt className="text-slate-500">Max daily loss</dt><dd className="font-semibold">{pctPoints(selectedMandate.max_daily_loss_pct)}</dd></div>
+            <div><dt className="text-slate-500">Active risk budget</dt><dd className="font-semibold">{pctPoints(selectedMandate.active_risk_budget_pct)}</dd></div>
+            <div><dt className="text-slate-500">Cash reserve</dt><dd className="font-semibold">{pctPoints(selectedMandate.cash_reserve_pct)}</dd></div>
+            <div><dt className="text-slate-500">Concurrent positions</dt><dd className="font-semibold">{selectedMandate.max_concurrent_positions}</dd></div>
+            <div><dt className="text-slate-500">Authority</dt><dd className="font-semibold">Long only · No leverage</dd></div>
+          </dl>
+        </div>
+      ) : null}
       <dl className="mt-5 grid grid-cols-2 gap-3 border-t border-slate-200 pt-4 text-xs sm:grid-cols-4 dark:border-slate-800">
         <div><dt className="text-slate-500">Risk base</dt><dd className="font-semibold tabular-nums">{money(pool.effective_capital)}</dd></div>
         <div><dt className="text-slate-500">Working</dt><dd className="font-semibold tabular-nums">{money(pool.invested_capital)}</dd></div>
@@ -538,6 +575,8 @@ function AutomationControl({
         <p className="mt-4 text-xs text-amber-700 dark:text-amber-300">
           {!overview.execution_enabled
             ? "System-wide automatic trading is off. Enable that safety control before allowing new entries."
+            : riskProfile === "unconfigured"
+              ? "Choose a risk profile before allowing new entries."
             : "Automation stays off until at least one strategy passes validation."}
         </p>
       ) : null}

--- a/sql/311_strategy_portfolio_mandate.sql
+++ b/sql/311_strategy_portfolio_mandate.sql
@@ -1,0 +1,71 @@
+-- 311_strategy_portfolio_mandate.sql
+--
+-- #2541 attaches one measurable, versioned portfolio-risk mandate to each
+-- material shared-pot revision.  This is event-shaped storage: one row per
+-- operator change, never a scheduler heartbeat.  Existing rows are explicitly
+-- legacy-unconfigured and therefore cannot authorise new entries.
+
+ALTER TABLE strategy_paper_pool_events
+    ADD COLUMN IF NOT EXISTS mandate_policy_version TEXT NOT NULL
+        DEFAULT 'portfolio-mandate-unconfigured',
+    ADD COLUMN IF NOT EXISTS risk_profile TEXT NOT NULL DEFAULT 'unconfigured',
+    ADD COLUMN IF NOT EXISTS target_volatility_pct NUMERIC(8,4),
+    ADD COLUMN IF NOT EXISTS max_portfolio_drawdown_pct NUMERIC(8,4),
+    ADD COLUMN IF NOT EXISTS max_loss_per_position_pct NUMERIC(8,4),
+    ADD COLUMN IF NOT EXISTS max_daily_loss_pct NUMERIC(8,4),
+    ADD COLUMN IF NOT EXISTS active_risk_budget_pct NUMERIC(8,4),
+    ADD COLUMN IF NOT EXISTS cash_reserve_pct NUMERIC(8,4),
+    ADD COLUMN IF NOT EXISTS max_concurrent_positions INTEGER,
+    ADD COLUMN IF NOT EXISTS shorts_allowed BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS leverage_allowed BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE strategy_paper_pool_events
+    DROP CONSTRAINT IF EXISTS strategy_paper_pool_enabled_has_mandate;
+
+-- Do not place an enabled=>configured constraint on this append-only audit
+-- table: a legacy enabled event must remain readable after deployment.  The
+-- API and executor reject an unconfigured latest event for new authority.
+ALTER TABLE strategy_paper_pool_events
+    DROP CONSTRAINT IF EXISTS strategy_paper_pool_mandate_shape;
+ALTER TABLE strategy_paper_pool_events
+    ADD CONSTRAINT strategy_paper_pool_mandate_shape CHECK (
+        (
+            risk_profile = 'unconfigured'
+            AND mandate_policy_version = 'portfolio-mandate-unconfigured'
+            AND target_volatility_pct IS NULL
+            AND max_portfolio_drawdown_pct IS NULL
+            AND max_loss_per_position_pct IS NULL
+            AND max_daily_loss_pct IS NULL
+            AND active_risk_budget_pct IS NULL
+            AND cash_reserve_pct IS NULL
+            AND max_concurrent_positions IS NULL
+            AND NOT shorts_allowed
+            AND NOT leverage_allowed
+        )
+        OR
+        (
+            risk_profile IN ('cautious', 'balanced', 'growth')
+            AND mandate_policy_version = 'portfolio-mandate-v1'
+            AND target_volatility_pct > 0 AND target_volatility_pct <= 100
+            AND max_portfolio_drawdown_pct > 0 AND max_portfolio_drawdown_pct < 100
+            AND max_loss_per_position_pct > 0 AND max_loss_per_position_pct <= 100
+            AND max_daily_loss_pct > 0 AND max_daily_loss_pct <= 100
+            AND active_risk_budget_pct > 0 AND active_risk_budget_pct <= 100
+            AND cash_reserve_pct >= 0 AND cash_reserve_pct < 100
+            AND active_risk_budget_pct + cash_reserve_pct <= 100
+            AND max_concurrent_positions > 0
+            AND NOT shorts_allowed
+            AND NOT leverage_allowed
+        )
+    );
+
+COMMENT ON COLUMN strategy_paper_pool_events.risk_profile IS
+    'Operator-facing mandate label. Exact policy limits are stored beside it; the label is not a return forecast.';
+COMMENT ON COLUMN strategy_paper_pool_events.active_risk_budget_pct IS
+    'Maximum share of effective pot capital available to active alpha risk; not a target allocation.';
+COMMENT ON COLUMN strategy_paper_pool_events.cash_reserve_pct IS
+    'Minimum uncommitted cash share of the effective pot under the selected mandate.';
+COMMENT ON COLUMN strategy_paper_pool_events.shorts_allowed IS
+    'False for portfolio-mandate-v1; requires an independently validated broker shortability/cost contract before a later policy may enable it.';
+COMMENT ON COLUMN strategy_paper_pool_events.leverage_allowed IS
+    'False for portfolio-mandate-v1; no current mandate may authorise leverage.';

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -300,6 +300,7 @@ def test_paper_principal_cannot_be_withdrawn_below_committed_capital(
         conn,
         enabled=True,
         capital_limit=Decimal("1000"),
+        risk_profile="balanced",
         changed_by="operator",
         reason="fund virtual sleeve",
     )
@@ -309,11 +310,48 @@ def test_paper_principal_cannot_be_withdrawn_below_committed_capital(
             conn,
             enabled=False,
             capital_limit=Decimal("99"),
+            risk_profile="balanced",
             changed_by="operator",
             reason="invalid withdrawal",
         )
 
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
+
+
+def test_enabled_paper_pool_requires_and_persists_exact_versioned_mandate(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    with pytest.raises(StrategyControlError, match="configured portfolio risk mandate"):
+        configure_paper_pool(
+            conn,
+            enabled=True,
+            capital_limit=Decimal("1000"),
+            risk_profile="unconfigured",
+            changed_by="operator",
+            reason="missing mandate",
+        )
+
+    pool = configure_paper_pool(
+        conn,
+        enabled=True,
+        capital_limit=Decimal("1000"),
+        risk_profile="balanced",
+        changed_by="operator",
+        reason="balanced mandate",
+    )
+
+    assert pool.mandate.policy_version == "portfolio-mandate-v1"
+    assert pool.mandate.risk_profile == "balanced"
+    assert pool.mandate.target_volatility_pct == Decimal("12")
+    assert pool.mandate.max_portfolio_drawdown_pct == Decimal("15")
+    assert pool.mandate.max_loss_per_position_pct == Decimal("0.75")
+    assert pool.mandate.max_daily_loss_pct == Decimal("1.5")
+    assert pool.mandate.active_risk_budget_pct == Decimal("20")
+    assert pool.mandate.cash_reserve_pct == Decimal("15")
+    assert pool.mandate.max_concurrent_positions == 8
+    assert not pool.mandate.shorts_allowed
+    assert not pool.mandate.leverage_allowed
 
 
 def test_same_instrument_manual_position_is_never_inferred_as_owned(

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -712,6 +712,7 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
             enabled=True,
             capital_limit=Decimal("750"),
             capital_mode="compound",
+            risk_profile="balanced",
             reason="bounded paper workspace",
         ),
         _session(),
@@ -721,6 +722,18 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     assert response.enabled
     assert response.capital_limit == Decimal("750")
     assert response.capital_mode == "compound"
+    assert response.mandate.configured
+    assert response.mandate.policy_version == "portfolio-mandate-v1"
+    assert response.mandate.risk_profile == "balanced"
+    assert response.mandate.target_volatility_pct == Decimal("12")
+    assert response.mandate.max_portfolio_drawdown_pct == Decimal("15")
+    assert response.mandate.max_loss_per_position_pct == Decimal("0.75")
+    assert response.mandate.max_daily_loss_pct == Decimal("1.5")
+    assert response.mandate.active_risk_budget_pct == Decimal("20")
+    assert response.mandate.cash_reserve_pct == Decimal("15")
+    assert response.mandate.max_concurrent_positions == 8
+    assert not response.mandate.shorts_allowed
+    assert not response.mandate.leverage_allowed
     assert response.effective_capital == Decimal("750")
     assert response.remaining_capital == Decimal("750")
     assert conn.execute(
@@ -744,6 +757,7 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
                 enabled=True,
                 capital_limit=Decimal("750"),
                 capital_mode="compound",
+                risk_profile="balanced",
                 reason="no-op must not add audit noise",
             ),
             _session(),

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -68,6 +68,7 @@ def _seed(
             conn,
             enabled=True,
             capital_limit=Decimal("2000"),
+            risk_profile="balanced",
             changed_by="test",
             reason="shared paper pool fixture",
         )
@@ -456,6 +457,7 @@ def test_shared_paper_pool_is_a_master_switch_and_hard_cap(
         conn,
         enabled=True,
         capital_limit=Decimal("25"),
+        risk_profile="balanced",
         changed_by="operator",
         reason="bounded shared pot",
     )
@@ -468,6 +470,52 @@ def test_shared_paper_pool_is_a_master_switch_and_hard_cap(
     assert result.amount == Decimal("25.00")
 
 
+def test_legacy_enabled_pool_without_mandate_cannot_authorise_an_order(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute(
+        """
+        INSERT INTO strategy_paper_pool_events (
+            enabled,capital_limit,currency,capital_mode,changed_by,reason
+        ) VALUES (true,2000,'USD','fixed','legacy','pre-mandate authority')
+        """
+    )
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "portfolio_mandate_unconfigured"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
+def test_disabled_pool_reason_precedes_unconfigured_mandate_reason(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute(
+        """
+        INSERT INTO strategy_paper_pool_events (
+            enabled,capital_limit,currency,capital_mode,changed_by,reason
+        ) VALUES (false,2000,'USD','fixed','legacy','disabled pre-mandate authority')
+        """
+    )
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.verdict == "rejected"
+    assert result.reason_code == "paper_pool_disabled"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
 def test_shared_paper_pool_excludes_future_live_reservations(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
@@ -477,6 +525,7 @@ def test_shared_paper_pool_excludes_future_live_reservations(
         conn,
         enabled=True,
         capital_limit=Decimal("26"),
+        risk_profile="balanced",
         changed_by="operator",
         reason="paper-only shared pot",
     )


### PR DESCRIPTION
Closes #2541

## Outcome
- replaces unbounded shared-pot authority with one explicit cautious/balanced/growth portfolio mandate
- stores the exact immutable v1 limits on each material audit event without adding heartbeat or market-data rows
- keeps legacy history readable but fails closed before broker access when the latest authority is unconfigured
- exposes the exact mandate through the API and a compact Strategies-page control; labels limits as risk ceilings, not return forecasts
- keeps shorts and leverage outside the current authority

## Validation
- full `bash .githooks/pre-push` green
- focused backend: 45 passed
- Strategies page: 17 passed
- dev app smoke and migration green

## Important boundary
This creates measurable operator risk authority; it does not manufacture alpha or bypass the existing zero-approved-candidate gate.