### PR TITLE
Require immutable opportunity forecasts before allocation

### DIFF
--- a/app/services/strategy_opportunity_forecast.py
+++ b/app/services/strategy_opportunity_forecast.py
@@ -3,6 +3,10 @@
 Forecasts may be negative or uncalibrated so they can remain in shadow.  The
 executor separately requires current, passed calibration and positive
 conservative expectancy before any capital authority is considered.
+
+Version 1 is deliberately long-only.  Persisting the side makes that execution
+boundary auditable and leaves a versioned migration path for future short
+support without implying that borrow and carry evidence exists today.
 """
 
 from __future__ import annotations
@@ -175,14 +179,18 @@ def record_opportunity_forecast(conn: psycopg.Connection[Any], forecast: Opportu
         raise OpportunityForecastError("conservative expectancy does not reconcile")
     knowledge = conn.execute(
         """
-        SELECT s.signal_kind,s.verdict,c.holdout_end
+        SELECT s.signal_kind,s.verdict,
+               (
+                   SELECT c.holdout_end
+                   FROM strategy_forecast_calibrations c
+                   WHERE c.calibration_id=%s
+               ) AS calibration_holdout_end
         FROM strategy_signals s
-        JOIN strategy_forecast_calibrations c ON c.calibration_id=%s
         WHERE s.signal_id=%s
         """,
         (forecast.calibration_id, forecast.signal_id),
     ).fetchone()
-    if knowledge is None:
+    if knowledge is None or knowledge[2] is None:
         raise OpportunityForecastError("signal or calibration evidence is missing")
     if knowledge[0] != "entry" or knowledge[1] != "fired":
         raise OpportunityForecastError("only fired entry signals may have opportunity forecasts")

--- a/app/services/strategy_opportunity_forecast.py
+++ b/app/services/strategy_opportunity_forecast.py
@@ -1,0 +1,241 @@
+"""Immutable, decision-time opportunity forecasts for portfolio allocation.
+
+Forecasts may be negative or uncalibrated so they can remain in shadow.  The
+executor separately requires current, passed calibration and positive
+conservative expectancy before any capital authority is considered.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+
+FORECAST_POLICY_VERSION = "opportunity-forecast-v1"
+_RECONCILIATION_TOLERANCE = Decimal("0.000001")
+
+
+class OpportunityForecastError(ValueError):
+    """The proposed immutable forecast is internally inconsistent."""
+
+
+@dataclass(frozen=True)
+class ForecastCalibration:
+    calibration_id: str
+    model_version: str
+    holdout_start: date
+    holdout_end: date
+    sample_size: int
+    brier_score: Decimal
+    calibration_error: Decimal
+    passed: bool
+    evidence_ref: str
+
+
+@dataclass(frozen=True)
+class OpportunityForecast:
+    signal_id: int
+    decided_at: datetime
+    valid_through: datetime
+    horizon_market_days: int
+    setup_version: str
+    exit_policy_version: str
+    calibration_id: str
+    target_probability: Decimal
+    stop_probability: Decimal
+    timeout_probability: Decimal
+    target_net_return_pct: Decimal
+    stop_net_return_pct: Decimal
+    timeout_net_return_pct: Decimal
+    expected_duration_hours: Decimal
+    uncertainty_penalty_pct: Decimal
+    tail_penalty_pct: Decimal
+    correlation_penalty_pct: Decimal
+    cost_stress_penalty_pct: Decimal
+    conservative_net_expectancy_pct: Decimal
+    cost_model_id: str
+    forecast_policy_version: str = FORECAST_POLICY_VERSION
+
+    def reconciled_expectancy(self) -> Decimal:
+        weighted = (
+            self.target_probability * self.target_net_return_pct
+            + self.stop_probability * self.stop_net_return_pct
+            + self.timeout_probability * self.timeout_net_return_pct
+        )
+        return weighted - (
+            self.uncertainty_penalty_pct
+            + self.tail_penalty_pct
+            + self.correlation_penalty_pct
+            + self.cost_stress_penalty_pct
+        )
+
+
+def _require_text(value: str, field: str) -> None:
+    if not value.strip():
+        raise OpportunityForecastError(f"{field} must be non-empty")
+
+
+def register_forecast_calibration(conn: psycopg.Connection[Any], calibration: ForecastCalibration) -> None:
+    """Insert one frozen calibration record; an existing id is immutable."""
+    for field, value in (
+        ("calibration_id", calibration.calibration_id),
+        ("model_version", calibration.model_version),
+        ("evidence_ref", calibration.evidence_ref),
+    ):
+        _require_text(value, field)
+    if calibration.holdout_end < calibration.holdout_start:
+        raise OpportunityForecastError("calibration holdout_end must not precede holdout_start")
+    if calibration.sample_size < 100:
+        raise OpportunityForecastError("calibration requires at least 100 holdout observations")
+    for field, value in (
+        ("brier_score", calibration.brier_score),
+        ("calibration_error", calibration.calibration_error),
+    ):
+        if not value.is_finite() or not Decimal("0") <= value <= Decimal("1"):
+            raise OpportunityForecastError(f"{field} must be finite and between zero and one")
+    row = conn.execute(
+        """
+            INSERT INTO strategy_forecast_calibrations (
+                calibration_id,model_version,holdout_start,holdout_end,sample_size,
+                brier_score,calibration_error,passed,evidence_ref
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (calibration_id) DO NOTHING
+            RETURNING calibration_id
+            """,
+        (
+            calibration.calibration_id,
+            calibration.model_version,
+            calibration.holdout_start,
+            calibration.holdout_end,
+            calibration.sample_size,
+            calibration.brier_score,
+            calibration.calibration_error,
+            calibration.passed,
+            calibration.evidence_ref,
+        ),
+    ).fetchone()
+    if row is None:
+        raise OpportunityForecastError("calibration_id already exists and is immutable")
+
+
+def record_opportunity_forecast(conn: psycopg.Connection[Any], forecast: OpportunityForecast) -> int:
+    """Validate and insert one forecast for an existing fired entry signal."""
+    for field, value in (
+        ("forecast_policy_version", forecast.forecast_policy_version),
+        ("setup_version", forecast.setup_version),
+        ("exit_policy_version", forecast.exit_policy_version),
+        ("calibration_id", forecast.calibration_id),
+        ("cost_model_id", forecast.cost_model_id),
+    ):
+        _require_text(value, field)
+    if forecast.valid_through < forecast.decided_at:
+        raise OpportunityForecastError("forecast validity must not end before its decision time")
+    if not 0 < forecast.horizon_market_days <= 60:
+        raise OpportunityForecastError("forecast horizon must be between one and 60 market days")
+    probabilities = (
+        forecast.target_probability,
+        forecast.stop_probability,
+        forecast.timeout_probability,
+    )
+    if any(not value.is_finite() or value < 0 or value > 1 for value in probabilities):
+        raise OpportunityForecastError("forecast probabilities must be finite and between zero and one")
+    if abs(sum(probabilities, Decimal("0")) - Decimal("1")) > _RECONCILIATION_TOLERANCE:
+        raise OpportunityForecastError("forecast probabilities must sum to one")
+    numeric_values = (
+        forecast.target_net_return_pct,
+        forecast.stop_net_return_pct,
+        forecast.timeout_net_return_pct,
+        forecast.expected_duration_hours,
+        forecast.uncertainty_penalty_pct,
+        forecast.tail_penalty_pct,
+        forecast.correlation_penalty_pct,
+        forecast.cost_stress_penalty_pct,
+        forecast.conservative_net_expectancy_pct,
+    )
+    if any(not value.is_finite() for value in numeric_values):
+        raise OpportunityForecastError("forecast numeric values must be finite")
+    if forecast.target_net_return_pct <= 0 or forecast.stop_net_return_pct >= 0:
+        raise OpportunityForecastError("target return must be positive and stop return negative")
+    if forecast.expected_duration_hours <= 0:
+        raise OpportunityForecastError("expected duration must be positive")
+    if any(
+        value < 0
+        for value in (
+            forecast.uncertainty_penalty_pct,
+            forecast.tail_penalty_pct,
+            forecast.correlation_penalty_pct,
+            forecast.cost_stress_penalty_pct,
+        )
+    ):
+        raise OpportunityForecastError("forecast penalties cannot be negative")
+    if abs(forecast.conservative_net_expectancy_pct - forecast.reconciled_expectancy()) > _RECONCILIATION_TOLERANCE:
+        raise OpportunityForecastError("conservative expectancy does not reconcile")
+    knowledge = conn.execute(
+        """
+        SELECT s.signal_kind,s.verdict,c.holdout_end
+        FROM strategy_signals s
+        JOIN strategy_forecast_calibrations c ON c.calibration_id=%s
+        WHERE s.signal_id=%s
+        """,
+        (forecast.calibration_id, forecast.signal_id),
+    ).fetchone()
+    if knowledge is None:
+        raise OpportunityForecastError("signal or calibration evidence is missing")
+    if knowledge[0] != "entry" or knowledge[1] != "fired":
+        raise OpportunityForecastError("only fired entry signals may have opportunity forecasts")
+    if knowledge[2] >= forecast.decided_at.date():
+        raise OpportunityForecastError("calibration holdout must end before the forecast decision")
+    row = conn.execute(
+        """
+            INSERT INTO strategy_opportunity_forecasts (
+                signal_id,forecast_policy_version,decided_at,valid_through,side,
+                horizon_market_days,setup_version,exit_policy_version,calibration_id,
+                target_probability,stop_probability,timeout_probability,
+                target_net_return_pct,stop_net_return_pct,timeout_net_return_pct,
+                expected_duration_hours,uncertainty_penalty_pct,tail_penalty_pct,
+                correlation_penalty_pct,cost_stress_penalty_pct,
+                conservative_net_expectancy_pct,cost_model_id
+            ) VALUES (%s,%s,%s,%s,'long',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (signal_id) DO NOTHING
+            RETURNING forecast_id
+            """,
+        (
+            forecast.signal_id,
+            forecast.forecast_policy_version,
+            forecast.decided_at,
+            forecast.valid_through,
+            forecast.horizon_market_days,
+            forecast.setup_version,
+            forecast.exit_policy_version,
+            forecast.calibration_id,
+            forecast.target_probability,
+            forecast.stop_probability,
+            forecast.timeout_probability,
+            forecast.target_net_return_pct,
+            forecast.stop_net_return_pct,
+            forecast.timeout_net_return_pct,
+            forecast.expected_duration_hours,
+            forecast.uncertainty_penalty_pct,
+            forecast.tail_penalty_pct,
+            forecast.correlation_penalty_pct,
+            forecast.cost_stress_penalty_pct,
+            forecast.conservative_net_expectancy_pct,
+            forecast.cost_model_id,
+        ),
+    ).fetchone()
+    if row is None:
+        raise OpportunityForecastError("signal already has an immutable opportunity forecast")
+    return int(row[0])
+
+
+__all__ = [
+    "FORECAST_POLICY_VERSION",
+    "ForecastCalibration",
+    "OpportunityForecast",
+    "OpportunityForecastError",
+    "record_opportunity_forecast",
+    "register_forecast_calibration",
+]

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
 from decimal import ROUND_DOWN, Decimal
 from typing import Any, Literal, cast
 from zoneinfo import ZoneInfo
@@ -30,6 +30,7 @@ from app.providers.broker import (
     BrokerWhatIfCostResponse,
     BrokerWhatIfOrder,
 )
+from app.services.cost_model import COST_MODEL_ID
 from app.services.market_calendar import us_market_status
 from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
 from app.services.strategy_control_plane import (
@@ -41,6 +42,7 @@ from app.services.strategy_control_plane import (
     registered_strategy_purpose,
 )
 from app.services.strategy_monitoring import load_paper_realised_pnl
+from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
 from app.services.strategy_order_reconciliation import (
     enforce_reconciliation_slo,
     ensure_strategy_request_id,
@@ -85,6 +87,7 @@ class _Intent:
     mandate_active_risk_budget_pct: Decimal
     mandate_cash_reserve_pct: Decimal
     mandate_max_concurrent_positions: int
+    forecast_id: int
     policy_revision: int
     ticket_sizing_mode: Literal["percent", "fixed"]
     ticket_fraction: Decimal | None
@@ -221,7 +224,14 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
                          AND (st.strategy_trade_id IS NULL OR st.status NOT IN ('closed', 'failed'))
                    ) AS pool_reserved,
                    evidence.result_count, evidence.qualified_result_count,
-                   evidence.expectancy_ci_low_pct
+                   evidence.expectancy_ci_low_pct,
+                   forecast.forecast_id,forecast.forecast_policy_version,
+                   forecast.decided_at AS forecast_decided_at,
+                   forecast.valid_through AS forecast_valid_through,
+                   forecast.conservative_net_expectancy_pct AS forecast_conservative_expectancy,
+                   forecast.cost_model_id AS forecast_cost_model_id,
+                   calibration.passed AS calibration_passed,
+                   calibration.holdout_end AS calibration_holdout_end
             FROM strategy_signals s
             JOIN instruments i ON i.instrument_id = s.instrument_id
             LEFT JOIN exchanges e ON e.exchange_id = i.exchange
@@ -272,6 +282,9 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
                 WHERE promotion.strategy_id = s.strategy_id
                   AND promotion.strategy_version = s.strategy_version
             ) evidence ON true
+            LEFT JOIN strategy_opportunity_forecasts forecast ON forecast.signal_id=s.signal_id
+            LEFT JOIN strategy_forecast_calibrations calibration
+              ON calibration.calibration_id=forecast.calibration_id
             WHERE s.signal_id = %s AND s.signal_kind = 'entry' AND s.verdict = 'fired'
             """,
             (signal_id,),
@@ -303,6 +316,15 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
         (bool(row["enabled"]), "paper_deployment_disabled"),
         (row["currency"] == "USD", "deployment_currency_unsupported"),
         (row["policy_revision"] is not None, "execution_policy_missing"),
+        (row["forecast_id"] is not None, "opportunity_forecast_missing"),
+        (row["forecast_policy_version"] == FORECAST_POLICY_VERSION, "opportunity_forecast_policy_stale"),
+        (bool(row["calibration_passed"]), "opportunity_calibration_not_passed"),
+        (row["forecast_cost_model_id"] == COST_MODEL_ID, "opportunity_forecast_cost_model_stale"),
+        (
+            row["forecast_conservative_expectancy"] is not None
+            and Decimal(str(row["forecast_conservative_expectancy"])) > 0,
+            "opportunity_forecast_expectancy_not_positive",
+        ),
         (not bool(row["execution_blocked"]), "execution_block_active"),
         (row["quoted_at"] is not None and row["ask"] is not None, "quote_missing"),
         (
@@ -332,6 +354,15 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
         return None, "scan_stale"
     if not _age_ok(halt_feed_at, now=now, max_seconds=int(row["max_halt_feed_age_seconds"])):
         return None, "halt_feed_stale"
+    forecast_decided_at = cast(datetime, row["forecast_decided_at"])
+    forecast_valid_through = cast(datetime, row["forecast_valid_through"])
+    if forecast_decided_at > now or forecast_valid_through < now:
+        return None, "opportunity_forecast_not_current"
+    if (
+        row["calibration_holdout_end"] is None
+        or cast(date, row["calibration_holdout_end"]) >= forecast_decided_at.date()
+    ):
+        return None, "opportunity_calibration_knowledge_time_invalid"
     if not _session_is_open(now):
         return None, "market_session_closed"
     return _Intent(
@@ -351,6 +382,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
         mandate_active_risk_budget_pct=Decimal(str(row["mandate_active_risk_budget_pct"])),
         mandate_cash_reserve_pct=Decimal(str(row["mandate_cash_reserve_pct"])),
         mandate_max_concurrent_positions=int(row["mandate_max_concurrent_positions"]),
+        forecast_id=int(row["forecast_id"]),
         policy_revision=int(row["policy_revision"]),
         ticket_sizing_mode=cast(Literal["percent", "fixed"], row["ticket_sizing_mode"]),
         ticket_fraction=Decimal(str(row["ticket_fraction"])) if row["ticket_fraction"] is not None else None,
@@ -397,16 +429,17 @@ def _persist_rejection(
         conn.execute(
             """
             INSERT INTO strategy_entry_preflights (
-                signal_id, deployment_id, policy_revision, verdict, reason_code,
+                signal_id, deployment_id, policy_revision, forecast_id, verdict, reason_code,
                 evaluated_at, quote_at, scan_at, halt_feed_at,
                 broker_available_cash, account_equity, account_invested,
                 instrument_invested, gross_expectancy_ci_low_pct
-            ) VALUES (%s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 signal_id,
                 intent.deployment_id if intent else None,
                 intent.policy_revision if intent else None,
+                intent.forecast_id if intent else None,
                 reason_code,
                 now,
                 intent.quote_at if intent else None,
@@ -920,7 +953,7 @@ def _execute_fired_paper_signal_locked(
         conn.execute(
             """
             INSERT INTO strategy_entry_preflights (
-                signal_id, deployment_id, policy_revision, verdict, reason_code,
+                signal_id, deployment_id, policy_revision, forecast_id, verdict, reason_code,
                 evaluated_at, quote_at, scan_at, halt_feed_at,
                 eligibility_checked_at, costs_at, broker_available_cash,
                 account_equity, account_invested, instrument_invested,
@@ -928,7 +961,7 @@ def _execute_fired_paper_signal_locked(
                 gross_expectancy_ci_low_pct, stressed_cost_amount,
                 net_expectancy_pct, stop_loss_rate, take_profit_rate
             ) VALUES (
-                %s, %s, %s, 'allocated', 'all_paper_entry_gates_passed',
+                %s, %s, %s, %s, 'allocated', 'all_paper_entry_gates_passed',
                 %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             """,
@@ -936,6 +969,7 @@ def _execute_fired_paper_signal_locked(
                 signal_id,
                 intent.deployment_id,
                 intent.policy_revision,
+                intent.forecast_id,
                 evaluated_at,
                 intent.quote_at,
                 intent.scan_at,

--- a/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
+++ b/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
@@ -443,11 +443,20 @@ comparative selection are the system's purpose.
 
 ## Acceptance before hands-off demo trading
 
+Implementation status (2026-08-11): the portfolio mandate and its pre-trade
+risk ceilings are enforced. #2545 adds the compact immutable forecast contract
+and makes a current, passed calibration plus positive conservative after-cost
+expectancy mandatory before broker access. It does **not** manufacture a
+forecast from the four research harnesses: no production candidate currently
+has a calibrated forecast generator, and the batch allocator and prospective
+outcome monitor below remain required. The safe current behaviour is therefore
+to place no autonomous trades.
+
 - [ ] Every funded order points to one reproducible forecast, policy and batch
   allocation decision.
 - [ ] Total portfolio return reconciles into benchmark, active, hedge/cash, FX
   and cost attribution; S&P comparison uses total return in base currency.
-- [ ] Risk-profile labels resolve to immutable measurable mandate limits.
+- [x] Risk-profile labels resolve to immutable measurable mandate limits.
 - [ ] All simultaneous opportunities are compared; database arrival order has
   no effect, proved by permutation tests.
 - [ ] Predictions are calibrated on later data and monitored prospectively.

--- a/sql/312_strategy_opportunity_forecasts.sql
+++ b/sql/312_strategy_opportunity_forecasts.sql
@@ -1,0 +1,78 @@
+-- 312_strategy_opportunity_forecasts.sql
+--
+-- #2545: one compact, immutable forecast per fired entry decision.  These
+-- tables store decision-bearing evidence only; feature vectors and non-firing
+-- heartbeats remain outside the database.
+
+CREATE TABLE IF NOT EXISTS strategy_forecast_calibrations (
+    calibration_id             TEXT PRIMARY KEY CHECK (calibration_id <> ''),
+    model_version              TEXT NOT NULL CHECK (model_version <> ''),
+    holdout_start              DATE NOT NULL,
+    holdout_end                DATE NOT NULL CHECK (holdout_end >= holdout_start),
+    sample_size                INTEGER NOT NULL CHECK (sample_size >= 100),
+    brier_score                NUMERIC(12,8) NOT NULL CHECK (brier_score >= 0 AND brier_score <= 1),
+    calibration_error          NUMERIC(12,8) NOT NULL CHECK (calibration_error >= 0 AND calibration_error <= 1),
+    passed                     BOOLEAN NOT NULL,
+    evidence_ref               TEXT NOT NULL CHECK (evidence_ref <> ''),
+    recorded_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS strategy_opportunity_forecasts (
+    forecast_id                       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    signal_id                         BIGINT NOT NULL UNIQUE
+        REFERENCES strategy_signals(signal_id) ON DELETE RESTRICT,
+    forecast_policy_version           TEXT NOT NULL CHECK (forecast_policy_version <> ''),
+    decided_at                        TIMESTAMPTZ NOT NULL,
+    valid_through                     TIMESTAMPTZ NOT NULL CHECK (valid_through >= decided_at),
+    side                              TEXT NOT NULL CHECK (side = 'long'),
+    horizon_market_days               INTEGER NOT NULL CHECK (horizon_market_days > 0 AND horizon_market_days <= 60),
+    setup_version                     TEXT NOT NULL CHECK (setup_version <> ''),
+    exit_policy_version               TEXT NOT NULL CHECK (exit_policy_version <> ''),
+    calibration_id                    TEXT NOT NULL
+        REFERENCES strategy_forecast_calibrations(calibration_id) ON DELETE RESTRICT,
+    target_probability                NUMERIC(12,8) NOT NULL CHECK (target_probability >= 0 AND target_probability <= 1),
+    stop_probability                  NUMERIC(12,8) NOT NULL CHECK (stop_probability >= 0 AND stop_probability <= 1),
+    timeout_probability               NUMERIC(12,8) NOT NULL CHECK (timeout_probability >= 0 AND timeout_probability <= 1),
+    target_net_return_pct             NUMERIC(12,8) NOT NULL CHECK (target_net_return_pct > 0),
+    stop_net_return_pct               NUMERIC(12,8) NOT NULL CHECK (stop_net_return_pct < 0),
+    timeout_net_return_pct            NUMERIC(12,8) NOT NULL,
+    expected_duration_hours           NUMERIC(12,4) NOT NULL CHECK (expected_duration_hours > 0),
+    uncertainty_penalty_pct           NUMERIC(12,8) NOT NULL CHECK (uncertainty_penalty_pct >= 0),
+    tail_penalty_pct                  NUMERIC(12,8) NOT NULL CHECK (tail_penalty_pct >= 0),
+    correlation_penalty_pct           NUMERIC(12,8) NOT NULL CHECK (correlation_penalty_pct >= 0),
+    cost_stress_penalty_pct           NUMERIC(12,8) NOT NULL CHECK (cost_stress_penalty_pct >= 0),
+    conservative_net_expectancy_pct   NUMERIC(12,8) NOT NULL,
+    cost_model_id                     TEXT NOT NULL CHECK (cost_model_id <> ''),
+    created_at                        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT strategy_opportunity_forecast_probability_sum CHECK (
+        abs(target_probability + stop_probability + timeout_probability - 1) <= 0.000001
+    ),
+    CONSTRAINT strategy_opportunity_forecast_expectancy_reconciles CHECK (
+        abs(
+            conservative_net_expectancy_pct - (
+                target_probability * target_net_return_pct
+                + stop_probability * stop_net_return_pct
+                + timeout_probability * timeout_net_return_pct
+                - uncertainty_penalty_pct
+                - tail_penalty_pct
+                - correlation_penalty_pct
+                - cost_stress_penalty_pct
+            )
+        ) <= 0.000001
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_opportunity_forecasts_validity
+    ON strategy_opportunity_forecasts (valid_through, forecast_id);
+
+ALTER TABLE strategy_entry_preflights
+    ADD COLUMN IF NOT EXISTS forecast_id BIGINT
+        REFERENCES strategy_opportunity_forecasts(forecast_id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_entry_preflights_forecast
+    ON strategy_entry_preflights (forecast_id) WHERE forecast_id IS NOT NULL;
+
+COMMENT ON TABLE strategy_opportunity_forecasts IS
+    'One immutable decision-bearing forecast per fired entry signal; never a heartbeat or feature store.';
+COMMENT ON COLUMN strategy_opportunity_forecasts.conservative_net_expectancy_pct IS
+    'After-cost probability-weighted return less frozen uncertainty, tail, correlation and cost-stress penalties.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -208,6 +208,10 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # event stream. It intentionally has no FK to a deployment, so the inbound
     # FK closure cannot discover it from the strategy roots above.
     "strategy_paper_pool_events",
+    # #2545 — calibration evidence is an immutable standalone root. Forecasts
+    # reference both it and signals, so those children are derived; the parent
+    # itself cannot be discovered from an existing inbound-FK root.
+    "strategy_forecast_calibrations",
     # #2448/#2449 — bounded strategy current-state roots have no FKs. Their
     # signal/deployment children are derived by the planner from roots above.
     "strategy_scan_watermark",

--- a/tests/test_strategy_opportunity_forecast.py
+++ b/tests/test_strategy_opportunity_forecast.py
@@ -1,0 +1,87 @@
+"""Unit boundaries for immutable opportunity-forecast mathematics."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import psycopg
+import pytest
+
+from app.services.cost_model import COST_MODEL_ID
+from app.services.strategy_opportunity_forecast import (
+    ForecastCalibration,
+    OpportunityForecast,
+    OpportunityForecastError,
+    record_opportunity_forecast,
+    register_forecast_calibration,
+)
+
+
+def _forecast() -> OpportunityForecast:
+    decided_at = datetime(2026, 8, 7, 15, tzinfo=UTC)
+    return OpportunityForecast(
+        signal_id=1,
+        decided_at=decided_at,
+        valid_through=decided_at + timedelta(days=5),
+        horizon_market_days=5,
+        setup_version="setup-v1",
+        exit_policy_version="exit-v1",
+        calibration_id="calibration-v1",
+        target_probability=Decimal("0.60"),
+        stop_probability=Decimal("0.25"),
+        timeout_probability=Decimal("0.15"),
+        target_net_return_pct=Decimal("4"),
+        stop_net_return_pct=Decimal("-2"),
+        timeout_net_return_pct=Decimal("0"),
+        expected_duration_hours=Decimal("24"),
+        uncertainty_penalty_pct=Decimal("0.20"),
+        tail_penalty_pct=Decimal("0.10"),
+        correlation_penalty_pct=Decimal("0.10"),
+        cost_stress_penalty_pct=Decimal("0.10"),
+        conservative_net_expectancy_pct=Decimal("1.40"),
+        cost_model_id=COST_MODEL_ID,
+    )
+
+
+def test_probability_sum_is_rejected_before_database_access() -> None:
+    conn = MagicMock(spec=psycopg.Connection[Any])
+    forecast = replace(_forecast(), timeout_probability=Decimal("0.14"))
+
+    with pytest.raises(OpportunityForecastError, match="sum to one"):
+        record_opportunity_forecast(conn, forecast)
+
+    conn.execute.assert_not_called()
+
+
+def test_conservative_expectancy_must_reconcile_before_database_access() -> None:
+    conn = MagicMock(spec=psycopg.Connection[Any])
+    forecast = replace(_forecast(), conservative_net_expectancy_pct=Decimal("1.41"))
+
+    with pytest.raises(OpportunityForecastError, match="does not reconcile"):
+        record_opportunity_forecast(conn, forecast)
+
+    conn.execute.assert_not_called()
+
+
+def test_calibration_requires_a_meaningful_holdout_sample() -> None:
+    conn = MagicMock(spec=psycopg.Connection[Any])
+    calibration = ForecastCalibration(
+        calibration_id="calibration-v1",
+        model_version="model-v1",
+        holdout_start=date(2026, 1, 1),
+        holdout_end=date(2026, 7, 31),
+        sample_size=99,
+        brier_score=Decimal("0.18"),
+        calibration_error=Decimal("0.04"),
+        passed=False,
+        evidence_ref="test evidence",
+    )
+
+    with pytest.raises(OpportunityForecastError, match="at least 100"):
+        register_forecast_calibration(conn, calibration)
+
+    conn.execute.assert_not_called()

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -27,6 +27,7 @@ from app.providers.broker import (
     BrokerProvider,
     BrokerWhatIfCostResponse,
 )
+from app.services.cost_model import COST_MODEL_ID
 from app.services.result_ledger import store_holdout_result
 from app.services.strategy_control_plane import (
     configure_deployment,
@@ -37,6 +38,13 @@ from app.services.strategy_control_plane import (
     link_strategy_order,
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_opportunity_forecast import (
+    ForecastCalibration,
+    OpportunityForecast,
+    OpportunityForecastError,
+    record_opportunity_forecast,
+    register_forecast_calibration,
+)
 from app.services.strategy_paper_executor import (
     PaperExecutionResult,
     _effective_capital_bases,
@@ -180,6 +188,45 @@ def _seed(
         """
     ).fetchone()
     assert signal is not None
+    register_forecast_calibration(
+        conn,
+        ForecastCalibration(
+            calibration_id="test-calibration-v1",
+            model_version="test-model-v1",
+            holdout_start=date(2026, 1, 1),
+            holdout_end=date(2026, 7, 31),
+            sample_size=500,
+            brier_score=Decimal("0.18"),
+            calibration_error=Decimal("0.04"),
+            passed=True,
+            evidence_ref="synthetic executor fixture only",
+        ),
+    )
+    record_opportunity_forecast(
+        conn,
+        OpportunityForecast(
+            signal_id=int(signal[0]),
+            decided_at=_NOW,
+            valid_through=_NOW + timedelta(days=7),
+            horizon_market_days=5,
+            setup_version="test-setup-v1",
+            exit_policy_version="test-exit-v1",
+            calibration_id="test-calibration-v1",
+            target_probability=Decimal("0.6"),
+            stop_probability=Decimal("0.2"),
+            timeout_probability=Decimal("0.2"),
+            target_net_return_pct=Decimal("4"),
+            stop_net_return_pct=Decimal("-2"),
+            timeout_net_return_pct=Decimal("0"),
+            expected_duration_hours=Decimal("24"),
+            uncertainty_penalty_pct=Decimal("0.2"),
+            tail_penalty_pct=Decimal("0.1"),
+            correlation_penalty_pct=Decimal("0.1"),
+            cost_stress_penalty_pct=Decimal("0.1"),
+            conservative_net_expectancy_pct=Decimal("1.5"),
+            cost_model_id=COST_MODEL_ID,
+        ),
+    )
     conn.execute(
         "INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last, spread_pct, spread_flag) "
         "VALUES (2449001, %s, 99, 100, 99.5, 1, false)",
@@ -398,15 +445,114 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
         "SELECT strategy_request_id, execution_origin, broker_order_ref FROM orders WHERE order_id=%s",
         (result.order_id,),
     ).fetchone() == (_REQUEST_ID, "strategy", "13902598")
-    assert conn.execute(
-        "SELECT verdict, allocated_amount, net_expectancy_pct FROM strategy_entry_preflights WHERE signal_id=%s",
+    forecast_id = conn.execute(
+        "SELECT forecast_id FROM strategy_opportunity_forecasts WHERE signal_id=%s",
         (signal_id,),
-    ).fetchone() == ("allocated", Decimal("50.000000"), Decimal("3.00000000"))
+    ).fetchone()
+    assert forecast_id is not None
+    assert conn.execute(
+        "SELECT verdict, allocated_amount, net_expectancy_pct, forecast_id "
+        "FROM strategy_entry_preflights WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == ("allocated", Decimal("50.000000"), Decimal("3.00000000"), forecast_id[0])
     conn.commit()
 
     # Retry is read-only and cannot submit a duplicate.
     assert execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW).order_id == result.order_id
     broker.place_demo_strategy_order.assert_called_once()
+
+
+def test_missing_opportunity_forecast_refuses_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute("DELETE FROM strategy_opportunity_forecasts WHERE signal_id=%s", (signal_id,))
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.reason_code == "opportunity_forecast_missing"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+    assert conn.execute(
+        "SELECT forecast_id FROM strategy_entry_preflights WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == (None,)
+
+
+@pytest.mark.parametrize(
+    ("invalidity", "reason_code"),
+    [
+        ("calibration", "opportunity_calibration_not_passed"),
+        ("cost", "opportunity_forecast_cost_model_stale"),
+        ("expiry", "opportunity_forecast_not_current"),
+    ],
+)
+def test_invalid_opportunity_evidence_refuses_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+    invalidity: str,
+    reason_code: str,
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    if invalidity == "calibration":
+        conn.execute("UPDATE strategy_forecast_calibrations SET passed=false")
+    elif invalidity == "cost":
+        conn.execute("UPDATE strategy_opportunity_forecasts SET cost_model_id='obsolete-cost-model'")
+    else:
+        conn.execute("UPDATE strategy_opportunity_forecasts SET valid_through=decided_at")
+    conn.commit()
+    broker = _broker()
+    decision_time = _NOW + timedelta(seconds=1) if reason_code == "opportunity_forecast_not_current" else _NOW
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=decision_time)
+
+    assert result.reason_code == reason_code
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
+def test_immutable_forecast_duplicate_does_not_abort_the_callers_transaction(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    existing = conn.execute(
+        "SELECT forecast_id FROM strategy_opportunity_forecasts WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone()
+    assert existing is not None
+
+    with pytest.raises(OpportunityForecastError, match="immutable opportunity forecast"):
+        record_opportunity_forecast(
+            conn,
+            OpportunityForecast(
+                signal_id=signal_id,
+                decided_at=_NOW,
+                valid_through=_NOW + timedelta(days=7),
+                horizon_market_days=5,
+                setup_version="test-setup-v1",
+                exit_policy_version="test-exit-v1",
+                calibration_id="test-calibration-v1",
+                target_probability=Decimal("0.6"),
+                stop_probability=Decimal("0.2"),
+                timeout_probability=Decimal("0.2"),
+                target_net_return_pct=Decimal("4"),
+                stop_net_return_pct=Decimal("-2"),
+                timeout_net_return_pct=Decimal("0"),
+                expected_duration_hours=Decimal("24"),
+                uncertainty_penalty_pct=Decimal("0.2"),
+                tail_penalty_pct=Decimal("0.1"),
+                correlation_penalty_pct=Decimal("0.1"),
+                cost_stress_penalty_pct=Decimal("0.1"),
+                conservative_net_expectancy_pct=Decimal("1.5"),
+                cost_model_id=COST_MODEL_ID,
+            ),
+        )
+
+    assert conn.execute("SELECT count(*) FROM strategy_opportunity_forecasts").fetchone() == (1,)
 
 
 def test_fixed_ticket_mode_requests_a_currency_amount_before_risk_caps(


### PR DESCRIPTION
Closes #2545

## Outcome
- adds one compact immutable forecast and calibration evidence contract per fired entry signal
- requires current passed calibration, current cost model, and positive conservative after-cost expectancy before broker access
- records the exact forecast on every attributable preflight without storing feature vectors or heartbeat rows
- documents that no production candidate currently supplies these forecasts, so the truthful safe state remains no autonomous trade

## Validation
- `bash .githooks/pre-push`
- 34 focused forecast/executor tests
