### PR TITLE
Rank current opportunities before bounded execution

### DIFF
--- a/app/services/strategy_opportunity_ranker.py
+++ b/app/services/strategy_opportunity_ranker.py
@@ -11,8 +11,6 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
 
-RANKING_POLICY_VERSION = "conservative-opportunity-rank-v1"
-
 
 class OpportunityRankingError(ValueError):
     """The proposed opportunity set cannot be ranked safely."""
@@ -73,7 +71,6 @@ def rank_positive_opportunities(opportunities: list[RankableOpportunity]) -> lis
 
 
 __all__ = [
-    "RANKING_POLICY_VERSION",
     "OpportunityRankingError",
     "RankableOpportunity",
     "rank_positive_opportunities",

--- a/app/services/strategy_opportunity_ranker.py
+++ b/app/services/strategy_opportunity_ranker.py
@@ -1,0 +1,80 @@
+"""Deterministic precursor to portfolio-level opportunity allocation.
+
+This ranks already-calibrated, positive conservative forecasts.  It does not
+claim to optimise a portfolio: correlation, factor and core/cash competition
+remain the responsibility of the immutable batch allocator in #2525.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+
+RANKING_POLICY_VERSION = "conservative-opportunity-rank-v1"
+
+
+class OpportunityRankingError(ValueError):
+    """The proposed opportunity set cannot be ranked safely."""
+
+
+@dataclass(frozen=True)
+class RankableOpportunity:
+    signal_id: int
+    strategy_id: str
+    strategy_version: str
+    instrument_id: int
+    signal_bar_date: date
+    side: str
+    horizon_market_days: int
+    setup_version: str
+    exit_policy_version: str
+    decided_at: datetime
+    conservative_net_expectancy_pct: Decimal
+
+    @property
+    def economic_key(self) -> tuple[str, str, int, date, str, int, str, str, datetime]:
+        """Stable identity containing no database arrival or surrogate ids."""
+        return (
+            self.strategy_id,
+            self.strategy_version,
+            self.instrument_id,
+            self.signal_bar_date,
+            self.side,
+            self.horizon_market_days,
+            self.setup_version,
+            self.exit_policy_version,
+            self.decided_at,
+        )
+
+
+def rank_positive_opportunities(opportunities: list[RankableOpportunity]) -> list[RankableOpportunity]:
+    """Return positive forecasts strongest-first with deterministic ties.
+
+    Duration is deliberately not used as an ``EV / time`` shortcut: the
+    programme contract requires portfolio simulation of overlapping capital
+    occupation before duration can influence allocation.
+    """
+    positive: list[RankableOpportunity] = []
+    seen: set[tuple[str, str, int, date, str, int, str, str, datetime]] = set()
+    for opportunity in opportunities:
+        expectancy = opportunity.conservative_net_expectancy_pct
+        if not expectancy.is_finite():
+            raise OpportunityRankingError("conservative expectancy must be finite")
+        if opportunity.economic_key in seen:
+            raise OpportunityRankingError("duplicate economic opportunity identity")
+        seen.add(opportunity.economic_key)
+        if expectancy > 0:
+            positive.append(opportunity)
+    return sorted(
+        positive,
+        key=lambda opportunity: (-opportunity.conservative_net_expectancy_pct, opportunity.economic_key),
+    )
+
+
+__all__ = [
+    "RANKING_POLICY_VERSION",
+    "OpportunityRankingError",
+    "RankableOpportunity",
+    "rank_positive_opportunities",
+]

--- a/app/services/strategy_paper_runtime.py
+++ b/app/services/strategy_paper_runtime.py
@@ -1,9 +1,9 @@
 """Bounded recurring paper-strategy operating loop (#2450).
 
 The cycle reconciles uncertain orders, refreshes five current health blocks,
-repairs/manages exact owned positions, then evaluates a small newest-first batch
-of funded candidates.  Health rows are updated in place and unchanged position
-polls add no rows.
+repairs/manages exact owned positions, then evaluates the strongest bounded
+slice of the complete current positive-forecast set. Health rows are updated in
+place and unchanged position polls add no rows.
 """
 
 from __future__ import annotations
@@ -23,6 +23,8 @@ from app.providers.broker import BrokerProvider
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
 from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
+from app.services.strategy_opportunity_ranker import RankableOpportunity, rank_positive_opportunities
 from app.services.strategy_order_reconciliation import enforce_reconciliation_slo, reconcile_backlog
 from app.services.strategy_paper_executor import execute_fired_paper_signal
 from app.services.strategy_position_manager import manage_owned_position
@@ -36,6 +38,73 @@ class StrategyPaperCycleResult:
     managed_positions: int
     evaluated_signals: int
     active_health_blocks: int
+
+
+def _load_ranked_opportunities(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_versions: Sequence[str],
+    observed_at: datetime,
+) -> list[RankableOpportunity]:
+    """Load the complete current set, then rank without surrogate identities."""
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT s.signal_id,s.strategy_id,s.strategy_version,s.instrument_id,
+                   s.signal_bar_date,f.side,f.horizon_market_days,f.setup_version,
+                   f.exit_policy_version,f.decided_at,
+                   f.conservative_net_expectancy_pct
+            FROM strategy_signals s
+            JOIN strategy_deployments d
+              ON d.strategy_id=s.strategy_id AND d.strategy_version=s.strategy_version
+             AND d.mode='paper' AND d.enabled
+            JOIN strategy_execution_policies p ON p.deployment_id=d.deployment_id
+            JOIN strategy_opportunity_forecasts f ON f.signal_id=s.signal_id
+            JOIN strategy_forecast_calibrations c ON c.calibration_id=f.calibration_id
+            JOIN LATERAL (
+              SELECT max(sp.promoted_at) AS paper_at
+              FROM strategy_promotions sp
+              WHERE sp.strategy_id=s.strategy_id
+                AND sp.strategy_version=s.strategy_version
+                AND sp.to_stage='paper_enabled'
+            ) promotion ON s.created_at >= promotion.paper_at
+            LEFT JOIN strategy_funding_decisions fd ON fd.signal_id=s.signal_id
+            WHERE s.signal_kind='entry' AND s.verdict='fired'
+              AND s.strategy_version=ANY(%(versions)s) AND fd.signal_id IS NULL
+              AND f.forecast_policy_version=%(forecast_policy)s
+              AND f.cost_model_id=%(cost_model)s
+              AND c.passed
+              AND c.holdout_end < f.decided_at::date
+              AND f.decided_at <= %(observed_at)s
+              AND f.valid_through >= %(observed_at)s
+              AND f.conservative_net_expectancy_pct > 0
+            """,
+            {
+                "versions": list(strategy_versions),
+                "forecast_policy": FORECAST_POLICY_VERSION,
+                "cost_model": COST_MODEL_ID,
+                "observed_at": observed_at,
+            },
+        )
+        rows = cur.fetchall()
+    return rank_positive_opportunities(
+        [
+            RankableOpportunity(
+                signal_id=int(row["signal_id"]),
+                strategy_id=str(row["strategy_id"]),
+                strategy_version=str(row["strategy_version"]),
+                instrument_id=int(row["instrument_id"]),
+                signal_bar_date=row["signal_bar_date"],
+                side=str(row["side"]),
+                horizon_market_days=int(row["horizon_market_days"]),
+                setup_version=str(row["setup_version"]),
+                exit_policy_version=str(row["exit_policy_version"]),
+                decided_at=row["decided_at"],
+                conservative_net_expectancy_pct=Decimal(str(row["conservative_net_expectancy_pct"])),
+            )
+            for row in rows
+        ]
+    )
 
 
 def _set_block(conn: psycopg.Connection[Any], *, source: str, active: bool, reason: str) -> None:
@@ -312,33 +381,12 @@ def run_strategy_paper_cycle(
             if entry.purpose == "capital_candidate"
         ]
     )
-    candidates = conn.execute(
-        """
-        SELECT s.signal_id
-        FROM strategy_signals s
-        JOIN strategy_deployments d
-          ON d.strategy_id=s.strategy_id AND d.strategy_version=s.strategy_version
-         AND d.mode='paper' AND d.enabled
-        JOIN strategy_execution_policies p ON p.deployment_id=d.deployment_id
-        JOIN LATERAL (
-          SELECT max(sp.promoted_at) AS paper_at
-          FROM strategy_promotions sp
-          WHERE sp.strategy_id=s.strategy_id
-            AND sp.strategy_version=s.strategy_version
-            AND sp.to_stage='paper_enabled'
-        ) promotion ON s.created_at >= promotion.paper_at
-        LEFT JOIN strategy_funding_decisions fd ON fd.signal_id=s.signal_id
-        WHERE s.signal_kind='entry' AND s.verdict='fired'
-          AND s.strategy_version=ANY(%s) AND fd.signal_id IS NULL
-        ORDER BY s.signal_id DESC
-        LIMIT %s
-        """,
-        (versions, signal_limit),
-    ).fetchall()
+    candidates = _load_ranked_opportunities(conn, strategy_versions=versions, observed_at=observed_at)
     conn.commit()
-    for (signal_id,) in candidates:
-        execute_fired_paper_signal(conn, broker=broker, signal_id=int(signal_id), now=observed_at)
-    return StrategyPaperCycleResult(len(reconciled), managed, len(candidates), active_blocks)
+    selected = candidates[:signal_limit]
+    for opportunity in selected:
+        execute_fired_paper_signal(conn, broker=broker, signal_id=opportunity.signal_id, now=observed_at)
+    return StrategyPaperCycleResult(len(reconciled), managed, len(selected), active_blocks)
 
 
 __all__ = ["StrategyPaperCycleResult", "refresh_strategy_health", "run_strategy_paper_cycle"]

--- a/app/services/strategy_paper_runtime.py
+++ b/app/services/strategy_paper_runtime.py
@@ -87,6 +87,10 @@ def _load_ranked_opportunities(
             },
         )
         rows = cur.fetchall()
+    # End the read transaction before pure validation/ranking can fail. A
+    # duplicate economic identity must fail closed without leaving this pooled
+    # connection in a transaction or touching already-committed health state.
+    conn.commit()
     return rank_positive_opportunities(
         [
             RankableOpportunity(
@@ -382,7 +386,6 @@ def run_strategy_paper_cycle(
         ]
     )
     candidates = _load_ranked_opportunities(conn, strategy_versions=versions, observed_at=observed_at)
-    conn.commit()
     selected = candidates[:signal_limit]
     for opportunity in selected:
         execute_fired_paper_signal(conn, broker=broker, signal_id=opportunity.signal_id, now=observed_at)

--- a/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
+++ b/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
@@ -155,20 +155,25 @@ decisions add more value than their costs and mistakes. It does not grow because
 the engine is forced to trade daily. If no proven active opportunity exists,
 the mandate-defined core/cash allocation is preferable to inventing one.
 
-## The current architectural gap
+## The original arrival-order gap and its bounded replacement
 
-`strategy_paper_runtime.run_strategy_paper_cycle` currently selects unfunded
-fired signals using:
+Before #2547, `strategy_paper_runtime.run_strategy_paper_cycle` selected
+unfunded fired signals using:
 
 ```sql
 ORDER BY s.signal_id DESC
 LIMIT :signal_limit
 ```
 
-and invokes `execute_fired_paper_signal` for each row. This is newest-first
-processing, not opportunity selection. It does not compare simultaneous signals
-by expected value, uncertainty, loss distribution, capital duration,
-correlation, spread or remaining risk budget.
+and invoked `execute_fired_paper_signal` for each row. #2547 removes that
+arrival-order path: the runtime now loads the complete current, calibrated,
+positive-forecast set, ranks it by conservative after-cost expectancy with an
+economic-key tie break, and only then applies its bounded execution limit.
+
+That is a safety precursor, not the finished allocator. It still does not
+produce one immutable target portfolio or jointly optimise correlation, factor
+exposure, capital duration, core/cash competition and aggregate opportunity
+cost. Those remain blocking requirements below.
 
 This is not presently a capital defect because the strategy manifest contains
 no `capital_candidate`. It becomes a blocking defect before the second candidate

--- a/tests/test_strategy_opportunity_ranker.py
+++ b/tests/test_strategy_opportunity_ranker.py
@@ -1,0 +1,59 @@
+"""Determinism and refusal boundaries for opportunity ranking."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.strategy_opportunity_ranker import (
+    OpportunityRankingError,
+    RankableOpportunity,
+    rank_positive_opportunities,
+)
+
+
+def _opportunity(*, signal_id: int, instrument_id: int, expectancy: str) -> RankableOpportunity:
+    return RankableOpportunity(
+        signal_id=signal_id,
+        strategy_id="candidate-a",
+        strategy_version="v1",
+        instrument_id=instrument_id,
+        signal_bar_date=date(2026, 8, 10),
+        side="long",
+        horizon_market_days=5,
+        setup_version="setup-v1",
+        exit_policy_version="exit-v1",
+        decided_at=datetime(2026, 8, 11, 14, tzinfo=UTC),
+        conservative_net_expectancy_pct=Decimal(expectancy),
+    )
+
+
+def test_stronger_opportunity_wins_regardless_of_input_and_signal_id_order() -> None:
+    weak = _opportunity(signal_id=900, instrument_id=1, expectancy="0.2")
+    strong = _opportunity(signal_id=1, instrument_id=2, expectancy="1.1")
+
+    forward = rank_positive_opportunities([weak, strong])
+    reverse = rank_positive_opportunities([replace(strong, signal_id=999), replace(weak, signal_id=2)])
+
+    assert [item.instrument_id for item in forward] == [2, 1]
+    assert [item.economic_key for item in forward] == [item.economic_key for item in reverse]
+
+
+def test_ties_use_economic_identity_and_non_positive_values_abstain() -> None:
+    later_key = _opportunity(signal_id=1, instrument_id=20, expectancy="0.5")
+    earlier_key = _opportunity(signal_id=999, instrument_id=10, expectancy="0.5")
+    no_trade = _opportunity(signal_id=3, instrument_id=30, expectancy="0")
+
+    ranked = rank_positive_opportunities([later_key, no_trade, earlier_key])
+
+    assert [item.instrument_id for item in ranked] == [10, 20]
+
+
+def test_duplicate_economic_identity_fails_closed() -> None:
+    opportunity = _opportunity(signal_id=1, instrument_id=10, expectancy="0.5")
+
+    with pytest.raises(OpportunityRankingError, match="duplicate economic"):
+        rank_positive_opportunities([opportunity, replace(opportunity, signal_id=2)])

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -153,6 +153,7 @@ def test_stale_forecast_cannot_consume_the_bounded_ranked_set(
     ranked = _load_ranked_opportunities(conn, strategy_versions=["v1"], observed_at=_NOW)
 
     assert [opportunity.signal_id for opportunity in ranked] == [current_signal]
+    assert conn.info.transaction_status == TransactionStatus.IDLE
 
 
 def test_broker_outage_and_drawdown_unknown_block_entries_without_row_growth(

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -10,12 +10,71 @@ import psycopg
 import pytest
 from psycopg.pq import TransactionStatus
 
+from app.services.cost_model import COST_MODEL_ID
 from app.services.strategy_live_gate import assess_live_gate
-from app.services.strategy_paper_runtime import refresh_strategy_health, run_strategy_paper_cycle
+from app.services.strategy_opportunity_forecast import OpportunityForecast, record_opportunity_forecast
+from app.services.strategy_paper_runtime import (
+    _load_ranked_opportunities,
+    refresh_strategy_health,
+    run_strategy_paper_cycle,
+)
 from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _broker, _seed
 from tests.test_strategy_position_manager import _opened_trade
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
+
+
+def _add_weaker_newer_forecast(conn: psycopg.Connection[tuple]) -> int:
+    conn.execute(
+        """
+        INSERT INTO instruments (
+            instrument_id,symbol,company_name,exchange,currency,is_tradable
+        ) VALUES (2449002,'TWEAK','Weaker newer test','2','USD',true)
+        """
+    )
+    signal = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id,strategy_version,instrument_id,signal_bar_date,
+            signal_kind,verdict,fill_bar_date,fill_price,universe,
+            input_rule_set_versions,created_at
+        ) VALUES (
+            'S-ALLOC','v1',2449002,'2026-08-05','entry','fired',
+            '2026-08-06',100,'survivor_only','{"indicator_series":"rules-v1"}'::jsonb,
+            (SELECT max(promoted_at)+interval '1 second' FROM strategy_promotions
+             WHERE strategy_id='S-ALLOC' AND strategy_version='v1'
+               AND to_stage='paper_enabled')
+        ) RETURNING signal_id
+        """
+    ).fetchone()
+    assert signal is not None
+    record_opportunity_forecast(
+        conn,
+        OpportunityForecast(
+            signal_id=int(signal[0]),
+            decided_at=_NOW,
+            valid_through=_NOW + timedelta(days=7),
+            horizon_market_days=5,
+            setup_version="weaker-setup-v1",
+            exit_policy_version="test-exit-v1",
+            calibration_id="test-calibration-v1",
+            target_probability=Decimal("0.4"),
+            stop_probability=Decimal("0.3"),
+            timeout_probability=Decimal("0.3"),
+            target_net_return_pct=Decimal("4"),
+            stop_net_return_pct=Decimal("-2"),
+            timeout_net_return_pct=Decimal("0"),
+            expected_duration_hours=Decimal("24"),
+            uncertainty_penalty_pct=Decimal("0.2"),
+            tail_penalty_pct=Decimal("0.1"),
+            correlation_penalty_pct=Decimal("0.1"),
+            cost_stress_penalty_pct=Decimal("0.1"),
+            conservative_net_expectancy_pct=Decimal("0.5"),
+            cost_model_id=COST_MODEL_ID,
+        ),
+    )
+    conn.commit()
+    return int(signal[0])
 
 
 def test_cycle_refreshes_health_then_executes_one_current_paper_candidate(
@@ -47,6 +106,53 @@ def test_cycle_refreshes_health_then_executes_one_current_paper_candidate(
         ("quote_freshness", False),
         ("scan_freshness", False),
     ]
+
+
+def test_runtime_ranks_the_complete_set_before_applying_its_execution_limit(
+    ebull_test_conn: psycopg.Connection[tuple], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    conn = ebull_test_conn
+    stronger_older = _seed(conn)
+    weaker_newer = _add_weaker_newer_forecast(conn)
+    assert weaker_newer > stronger_older
+    executed: list[int] = []
+    monkeypatch.setattr(
+        "app.services.strategy_paper_runtime.execute_fired_paper_signal",
+        lambda _conn, *, broker, signal_id, now: executed.append(signal_id),
+    )
+
+    result = run_strategy_paper_cycle(
+        conn,
+        broker=_broker(),
+        signal_limit=1,
+        position_limit=1,
+        now=_NOW,
+        strategy_versions=["v1"],
+    )
+
+    assert result.evaluated_signals == 1
+    assert executed == [stronger_older]
+
+
+def test_stale_forecast_cannot_consume_the_bounded_ranked_set(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    current_signal = _seed(conn)
+    stale_signal = _add_weaker_newer_forecast(conn)
+    conn.execute(
+        """
+        UPDATE strategy_opportunity_forecasts
+        SET decided_at=%s,valid_through=%s
+        WHERE signal_id=%s
+        """,
+        (_NOW - timedelta(days=2), _NOW - timedelta(days=1), stale_signal),
+    )
+    conn.commit()
+
+    ranked = _load_ranked_opportunities(conn, strategy_versions=["v1"], observed_at=_NOW)
+
+    assert [opportunity.signal_id for opportunity in ranked] == [current_signal]
 
 
 def test_broker_outage_and_drawdown_unknown_block_entries_without_row_growth(


### PR DESCRIPTION
Closes #2547

## Outcome
- removes newest-signal/id ordering and pre-ranking LIMIT from the paper runtime
- loads the complete current calibrated positive-forecast set and ranks strongest conservative after-cost expectancy first
- uses a stable economic identity for ties and fails closed on duplicate economic opportunities
- proves a stronger older opportunity defeats a weaker newer one and stale/non-positive forecasts cannot consume the bounded set

This is explicitly a safety precursor to #2525's immutable portfolio batch optimiser, not a claim that correlation, factor, core/cash or duration allocation is complete.

## Validation
- `bash .githooks/pre-push`
- 53 focused ranker/runtime/executor/position-manager tests
