### PR TITLE
Persist compact immutable opportunity ranking batches

### DIFF
--- a/app/services/strategy_opportunity_ranker.py
+++ b/app/services/strategy_opportunity_ranker.py
@@ -7,9 +7,16 @@ remain the responsibility of the immutable batch allocator in #2525.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
+from typing import Any
+
+import psycopg
+
+RANKING_POLICY_VERSION = "conservative-opportunity-rank-v1"
 
 
 class OpportunityRankingError(ValueError):
@@ -19,6 +26,7 @@ class OpportunityRankingError(ValueError):
 @dataclass(frozen=True)
 class RankableOpportunity:
     signal_id: int
+    forecast_id: int
     strategy_id: str
     strategy_version: str
     instrument_id: int
@@ -70,8 +78,133 @@ def rank_positive_opportunities(opportunities: list[RankableOpportunity]) -> lis
     )
 
 
+@dataclass(frozen=True)
+class RankingMember:
+    ranking_member_id: int
+    opportunity: RankableOpportunity
+    selected: bool
+
+
+def _candidate_set_digest(opportunities: list[RankableOpportunity]) -> str:
+    payload = [
+        [
+            opportunity.strategy_id,
+            opportunity.strategy_version,
+            opportunity.instrument_id,
+            opportunity.signal_bar_date.isoformat(),
+            opportunity.side,
+            opportunity.horizon_market_days,
+            opportunity.setup_version,
+            opportunity.exit_policy_version,
+            opportunity.decided_at.isoformat(),
+            format(opportunity.conservative_net_expectancy_pct.normalize(), "f"),
+        ]
+        for opportunity in opportunities
+    ]
+    encoded = json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def persist_ranking_batch(
+    conn: psycopg.Connection[Any],
+    *,
+    opportunities: list[RankableOpportunity],
+    selection_limit: int,
+    decided_at: datetime,
+) -> list[RankingMember]:
+    """Persist or reuse one narrow batch and return every ranked member."""
+    if selection_limit <= 0:
+        raise OpportunityRankingError("selection limit must be positive")
+    ranked = rank_positive_opportunities(opportunities)
+    if not ranked:
+        return []
+    selected_count = min(selection_limit, len(ranked))
+    digest = _candidate_set_digest(ranked)
+    with conn.transaction():
+        pool = conn.execute(
+            """
+            SELECT strategy_paper_pool_event_id
+            FROM strategy_paper_pool_events
+            ORDER BY strategy_paper_pool_event_id DESC LIMIT 1
+            """
+        ).fetchone()
+        if pool is None:
+            raise OpportunityRankingError("paper pool mandate is missing")
+        batch = conn.execute(
+            """
+            INSERT INTO strategy_opportunity_ranking_batches (
+                decided_at,ranking_policy_version,strategy_paper_pool_event_id,
+                selection_limit,considered_count,selected_count,candidate_set_sha256
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (
+                ranking_policy_version,strategy_paper_pool_event_id,
+                selection_limit,candidate_set_sha256
+            ) DO NOTHING
+            RETURNING ranking_batch_id
+            """,
+            (
+                decided_at,
+                RANKING_POLICY_VERSION,
+                int(pool[0]),
+                selection_limit,
+                len(ranked),
+                selected_count,
+                digest,
+            ),
+        ).fetchone()
+        if batch is None:
+            batch = conn.execute(
+                """
+                SELECT ranking_batch_id
+                FROM strategy_opportunity_ranking_batches
+                WHERE ranking_policy_version=%s
+                  AND strategy_paper_pool_event_id=%s
+                  AND selection_limit=%s AND candidate_set_sha256=%s
+                """,
+                (RANKING_POLICY_VERSION, int(pool[0]), selection_limit, digest),
+            ).fetchone()
+        if batch is None:  # pragma: no cover - conflict lookup must find the row
+            raise OpportunityRankingError("ranking batch identity was not returned")
+        batch_id = int(batch[0])
+        for rank, opportunity in enumerate(ranked, start=1):
+            selected = rank <= selected_count
+            conn.execute(
+                """
+                INSERT INTO strategy_opportunity_ranking_members (
+                    ranking_batch_id,forecast_id,rank,
+                    conservative_net_expectancy_pct,selected,reason_code
+                ) VALUES (%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (ranking_batch_id,forecast_id) DO NOTHING
+                """,
+                (
+                    batch_id,
+                    opportunity.forecast_id,
+                    rank,
+                    opportunity.conservative_net_expectancy_pct,
+                    selected,
+                    "selected_for_execution" if selected else "below_execution_batch_limit",
+                ),
+            )
+        rows = conn.execute(
+            """
+            SELECT ranking_member_id,forecast_id,selected
+            FROM strategy_opportunity_ranking_members
+            WHERE ranking_batch_id=%s
+            ORDER BY rank
+            """,
+            (batch_id,),
+        ).fetchall()
+        by_forecast = {opportunity.forecast_id: opportunity for opportunity in ranked}
+        if len(rows) != len(ranked) or sum(bool(row[2]) for row in rows) != selected_count:
+            raise OpportunityRankingError("persisted ranking batch is incomplete")
+        return [RankingMember(int(row[0]), by_forecast[int(row[1])], bool(row[2])) for row in rows]
+
+
 __all__ = [
+    "RANKING_POLICY_VERSION",
     "OpportunityRankingError",
     "RankableOpportunity",
+    "RankingMember",
+    "persist_ranking_batch",
     "rank_positive_opportunities",
 ]

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -43,6 +43,7 @@ from app.services.strategy_control_plane import (
 )
 from app.services.strategy_monitoring import load_paper_realised_pnl
 from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
+from app.services.strategy_opportunity_ranker import RANKING_POLICY_VERSION
 from app.services.strategy_order_reconciliation import (
     enforce_reconciliation_slo,
     ensure_strategy_request_id,
@@ -88,6 +89,7 @@ class _Intent:
     mandate_cash_reserve_pct: Decimal
     mandate_max_concurrent_positions: int
     forecast_id: int
+    ranking_member_id: int
     policy_revision: int
     ticket_sizing_mode: Literal["percent", "fixed"]
     ticket_fraction: Decimal | None
@@ -178,7 +180,13 @@ def _existing_result(conn: psycopg.Connection[Any], signal_id: int) -> PaperExec
     )
 
 
-def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime) -> tuple[_Intent | None, str | None]:
+def _load_intent(
+    conn: psycopg.Connection[Any],
+    *,
+    signal_id: int,
+    ranking_member_id: int | None,
+    now: datetime,
+) -> tuple[_Intent | None, str | None]:
     """Load DB gates as one observation; return a closed reason on absence."""
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
@@ -186,6 +194,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
             SELECT s.signal_id, s.strategy_id, s.strategy_version, s.instrument_id,
                    i.symbol, i.is_tradable, e.asset_class,
                    d.deployment_id, d.capital_limit, d.enabled, d.currency,
+                   pool.strategy_paper_pool_event_id AS current_pool_event_id,
                    pool.enabled AS pool_enabled, pool.capital_limit AS pool_limit,
                    pool.capital_mode, pool.risk_profile,
                    pool.max_portfolio_drawdown_pct AS mandate_max_drawdown_pct,
@@ -231,7 +240,10 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
                    forecast.conservative_net_expectancy_pct AS forecast_conservative_expectancy,
                    forecast.cost_model_id AS forecast_cost_model_id,
                    calibration.passed AS calibration_passed,
-                   calibration.holdout_end AS calibration_holdout_end
+                   calibration.holdout_end AS calibration_holdout_end,
+                   ranking.ranking_member_id,ranking.selected AS ranking_selected,
+                   ranking_batch.ranking_policy_version,
+                   ranking_batch.strategy_paper_pool_event_id AS ranking_pool_event_id
             FROM strategy_signals s
             JOIN instruments i ON i.instrument_id = s.instrument_id
             LEFT JOIN exchanges e ON e.exchange_id = i.exchange
@@ -240,7 +252,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
              AND d.mode = 'paper'
             LEFT JOIN strategy_execution_policies p ON p.deployment_id = d.deployment_id
             LEFT JOIN LATERAL (
-                SELECT enabled,capital_limit,capital_mode,risk_profile,
+                SELECT strategy_paper_pool_event_id,enabled,capital_limit,capital_mode,risk_profile,
                        max_portfolio_drawdown_pct,max_loss_per_position_pct,
                        max_daily_loss_pct,active_risk_budget_pct,cash_reserve_pct,
                        max_concurrent_positions
@@ -285,9 +297,13 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
             LEFT JOIN strategy_opportunity_forecasts forecast ON forecast.signal_id=s.signal_id
             LEFT JOIN strategy_forecast_calibrations calibration
               ON calibration.calibration_id=forecast.calibration_id
+            LEFT JOIN strategy_opportunity_ranking_members ranking
+              ON ranking.ranking_member_id=%s AND ranking.forecast_id=forecast.forecast_id
+            LEFT JOIN strategy_opportunity_ranking_batches ranking_batch
+              ON ranking_batch.ranking_batch_id=ranking.ranking_batch_id
             WHERE s.signal_id = %s AND s.signal_kind = 'entry' AND s.verdict = 'fired'
             """,
-            (signal_id,),
+            (ranking_member_id, signal_id),
         )
         row = cur.fetchone()
     if row is None:
@@ -325,6 +341,10 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
             and Decimal(str(row["forecast_conservative_expectancy"])) > 0,
             "opportunity_forecast_expectancy_not_positive",
         ),
+        (row["ranking_member_id"] is not None, "opportunity_ranking_member_missing"),
+        (bool(row["ranking_selected"]), "opportunity_ranking_member_not_selected"),
+        (row["ranking_policy_version"] == RANKING_POLICY_VERSION, "opportunity_ranking_policy_stale"),
+        (row["ranking_pool_event_id"] == row["current_pool_event_id"], "opportunity_ranking_mandate_stale"),
         (not bool(row["execution_blocked"]), "execution_block_active"),
         (row["quoted_at"] is not None and row["ask"] is not None, "quote_missing"),
         (
@@ -383,6 +403,7 @@ def _load_intent(conn: psycopg.Connection[Any], *, signal_id: int, now: datetime
         mandate_cash_reserve_pct=Decimal(str(row["mandate_cash_reserve_pct"])),
         mandate_max_concurrent_positions=int(row["mandate_max_concurrent_positions"]),
         forecast_id=int(row["forecast_id"]),
+        ranking_member_id=int(row["ranking_member_id"]),
         policy_revision=int(row["policy_revision"]),
         ticket_sizing_mode=cast(Literal["percent", "fixed"], row["ticket_sizing_mode"]),
         ticket_fraction=Decimal(str(row["ticket_fraction"])) if row["ticket_fraction"] is not None else None,
@@ -429,17 +450,19 @@ def _persist_rejection(
         conn.execute(
             """
             INSERT INTO strategy_entry_preflights (
-                signal_id, deployment_id, policy_revision, forecast_id, verdict, reason_code,
+                signal_id, deployment_id, policy_revision, forecast_id, ranking_member_id,
+                verdict, reason_code,
                 evaluated_at, quote_at, scan_at, halt_feed_at,
                 broker_available_cash, account_equity, account_invested,
                 instrument_invested, gross_expectancy_ci_low_pct
-            ) VALUES (%s, %s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, 'rejected', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 signal_id,
                 intent.deployment_id if intent else None,
                 intent.policy_revision if intent else None,
                 intent.forecast_id if intent else None,
+                intent.ranking_member_id if intent else None,
                 reason_code,
                 now,
                 intent.quote_at if intent else None,
@@ -796,6 +819,7 @@ def _execute_fired_paper_signal_locked(
     *,
     broker: BrokerProvider,
     signal_id: int,
+    ranking_member_id: int | None,
     now: datetime | None = None,
 ) -> PaperExecutionResult:
     """Evaluate and, only if every gate aligns, submit one demo order."""
@@ -855,7 +879,12 @@ def _execute_fired_paper_signal_locked(
         if health.active_block:
             return _persist_rejection(conn, signal_id=signal_id, reason_code="reconciliation_overdue", now=evaluated_at)
 
-    intent, reason = _load_intent(conn, signal_id=signal_id, now=evaluated_at)
+    intent, reason = _load_intent(
+        conn,
+        signal_id=signal_id,
+        ranking_member_id=ranking_member_id,
+        now=evaluated_at,
+    )
     conn.commit()
     if intent is None:
         return _persist_rejection(
@@ -953,7 +982,8 @@ def _execute_fired_paper_signal_locked(
         conn.execute(
             """
             INSERT INTO strategy_entry_preflights (
-                signal_id, deployment_id, policy_revision, forecast_id, verdict, reason_code,
+                signal_id, deployment_id, policy_revision, forecast_id, ranking_member_id,
+                verdict, reason_code,
                 evaluated_at, quote_at, scan_at, halt_feed_at,
                 eligibility_checked_at, costs_at, broker_available_cash,
                 account_equity, account_invested, instrument_invested,
@@ -961,7 +991,7 @@ def _execute_fired_paper_signal_locked(
                 gross_expectancy_ci_low_pct, stressed_cost_amount,
                 net_expectancy_pct, stop_loss_rate, take_profit_rate
             ) VALUES (
-                %s, %s, %s, %s, 'allocated', 'all_paper_entry_gates_passed',
+                %s, %s, %s, %s, %s, 'allocated', 'all_paper_entry_gates_passed',
                 %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             """,
@@ -970,6 +1000,7 @@ def _execute_fired_paper_signal_locked(
                 intent.deployment_id,
                 intent.policy_revision,
                 intent.forecast_id,
+                intent.ranking_member_id,
                 evaluated_at,
                 intent.quote_at,
                 intent.scan_at,
@@ -1060,13 +1091,35 @@ def execute_fired_paper_signal(
     *,
     broker: BrokerProvider,
     signal_id: int,
+    ranking_member_id: int | None = None,
     now: datetime | None = None,
 ) -> PaperExecutionResult:
     """Serialize and evaluate one fired signal against whole-account demo risk."""
     if conn.info.transaction_status != TransactionStatus.IDLE:
         raise StrategyPaperExecutionError("paper execution requires an idle connection")
+    if ranking_member_id is None:
+        row = conn.execute(
+            """
+            SELECT member.ranking_member_id
+            FROM strategy_opportunity_ranking_members member
+            JOIN strategy_opportunity_forecasts forecast
+              ON forecast.forecast_id=member.forecast_id
+            WHERE forecast.signal_id=%s AND member.selected
+            ORDER BY member.ranking_batch_id DESC
+            LIMIT 1
+            """,
+            (signal_id,),
+        ).fetchone()
+        conn.commit()
+        ranking_member_id = int(row[0]) if row is not None else None
     with _allocator_lock(conn):
-        return _execute_fired_paper_signal_locked(conn, broker=broker, signal_id=signal_id, now=now)
+        return _execute_fired_paper_signal_locked(
+            conn,
+            broker=broker,
+            signal_id=signal_id,
+            ranking_member_id=ranking_member_id,
+            now=now,
+        )
 
 
 __all__ = ["PaperExecutionResult", "StrategyPaperExecutionError", "execute_fired_paper_signal"]

--- a/app/services/strategy_paper_runtime.py
+++ b/app/services/strategy_paper_runtime.py
@@ -24,7 +24,11 @@ from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
-from app.services.strategy_opportunity_ranker import RankableOpportunity, rank_positive_opportunities
+from app.services.strategy_opportunity_ranker import (
+    RankableOpportunity,
+    persist_ranking_batch,
+    rank_positive_opportunities,
+)
 from app.services.strategy_order_reconciliation import enforce_reconciliation_slo, reconcile_backlog
 from app.services.strategy_paper_executor import execute_fired_paper_signal
 from app.services.strategy_position_manager import manage_owned_position
@@ -50,7 +54,7 @@ def _load_ranked_opportunities(
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
         cur.execute(
             """
-            SELECT s.signal_id,s.strategy_id,s.strategy_version,s.instrument_id,
+            SELECT s.signal_id,f.forecast_id,s.strategy_id,s.strategy_version,s.instrument_id,
                    s.signal_bar_date,f.side,f.horizon_market_days,f.setup_version,
                    f.exit_policy_version,f.decided_at,
                    f.conservative_net_expectancy_pct
@@ -95,6 +99,7 @@ def _load_ranked_opportunities(
         [
             RankableOpportunity(
                 signal_id=int(row["signal_id"]),
+                forecast_id=int(row["forecast_id"]),
                 strategy_id=str(row["strategy_id"]),
                 strategy_version=str(row["strategy_version"]),
                 instrument_id=int(row["instrument_id"]),
@@ -386,10 +391,21 @@ def run_strategy_paper_cycle(
         ]
     )
     candidates = _load_ranked_opportunities(conn, strategy_versions=versions, observed_at=observed_at)
-    selected = candidates[:signal_limit]
-    for opportunity in selected:
-        execute_fired_paper_signal(conn, broker=broker, signal_id=opportunity.signal_id, now=observed_at)
-    return StrategyPaperCycleResult(len(reconciled), managed, len(selected), active_blocks)
+    members = persist_ranking_batch(
+        conn,
+        opportunities=candidates,
+        selection_limit=signal_limit,
+        decided_at=observed_at,
+    )
+    for member in members:
+        execute_fired_paper_signal(
+            conn,
+            broker=broker,
+            signal_id=member.opportunity.signal_id,
+            ranking_member_id=member.ranking_member_id,
+            now=observed_at,
+        )
+    return StrategyPaperCycleResult(len(reconciled), managed, len(members), active_blocks)
 
 
 __all__ = ["StrategyPaperCycleResult", "refresh_strategy_health", "run_strategy_paper_cycle"]

--- a/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
+++ b/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
@@ -170,10 +170,13 @@ arrival-order path: the runtime now loads the complete current, calibrated,
 positive-forecast set, ranks it by conservative after-cost expectancy with an
 economic-key tie break, and only then applies its bounded execution limit.
 
-That is a safety precursor, not the finished allocator. It still does not
-produce one immutable target portfolio or jointly optimise correlation, factor
-exposure, capital duration, core/cash competition and aggregate opportunity
-cost. Those remain blocking requirements below.
+That is a safety precursor, not the finished allocator. #2549 makes each
+opportunity-bearing ranking set compact and immutable, records selected and
+declined reasons, deduplicates unchanged polling cycles, and links execution
+preflight to the exact selected member. It still does not produce a target
+portfolio or jointly optimise correlation, factor exposure, capital duration,
+core/cash competition and aggregate opportunity cost. Those remain blocking
+requirements below.
 
 This is not presently a capital defect because the strategy manifest contains
 no `capital_candidate`. It becomes a blocking defect before the second candidate
@@ -453,9 +456,10 @@ risk ceilings are enforced. #2545 adds the compact immutable forecast contract
 and makes a current, passed calibration plus positive conservative after-cost
 expectancy mandatory before broker access. It does **not** manufacture a
 forecast from the four research harnesses: no production candidate currently
-has a calibrated forecast generator, and the batch allocator and prospective
-outcome monitor below remain required. The safe current behaviour is therefore
-to place no autonomous trades.
+has a calibrated forecast generator. The ranking batch is now auditable, but
+target-portfolio optimisation and the prospective outcome monitor below remain
+required. The safe current behaviour is therefore to place no autonomous
+trades.
 
 - [ ] Every funded order points to one reproducible forecast, policy and batch
   allocation decision.

--- a/sql/313_strategy_opportunity_ranking_batches.sql
+++ b/sql/313_strategy_opportunity_ranking_batches.sql
@@ -1,0 +1,63 @@
+-- 313_strategy_opportunity_ranking_batches.sql
+--
+-- #2549: compact immutable evidence for opportunity-bearing ranking cycles.
+-- An unchanged candidate set reuses its digest; empty polling cycles write no
+-- row and no feature vectors or heartbeat payloads are retained.
+
+CREATE TABLE IF NOT EXISTS strategy_opportunity_ranking_batches (
+    ranking_batch_id              BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    decided_at                    TIMESTAMPTZ NOT NULL,
+    ranking_policy_version        TEXT NOT NULL CHECK (ranking_policy_version <> ''),
+    strategy_paper_pool_event_id  BIGINT NOT NULL
+        REFERENCES strategy_paper_pool_events(strategy_paper_pool_event_id) ON DELETE RESTRICT,
+    selection_limit               INTEGER NOT NULL CHECK (selection_limit > 0),
+    considered_count              INTEGER NOT NULL CHECK (considered_count > 0),
+    selected_count                INTEGER NOT NULL CHECK (
+        selected_count > 0 AND selected_count <= considered_count
+    ),
+    candidate_set_sha256          TEXT NOT NULL CHECK (candidate_set_sha256 ~ '^[0-9a-f]{64}$'),
+    created_at                    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (
+        ranking_policy_version,strategy_paper_pool_event_id,
+        selection_limit,candidate_set_sha256
+    )
+);
+
+CREATE TABLE IF NOT EXISTS strategy_opportunity_ranking_members (
+    ranking_member_id             BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    ranking_batch_id              BIGINT NOT NULL
+        REFERENCES strategy_opportunity_ranking_batches(ranking_batch_id) ON DELETE RESTRICT,
+    forecast_id                   BIGINT NOT NULL
+        REFERENCES strategy_opportunity_forecasts(forecast_id) ON DELETE RESTRICT,
+    rank                          INTEGER NOT NULL CHECK (rank > 0),
+    conservative_net_expectancy_pct NUMERIC(12,8) NOT NULL CHECK (
+        conservative_net_expectancy_pct > 0
+    ),
+    selected                      BOOLEAN NOT NULL,
+    reason_code                   TEXT NOT NULL CHECK (
+        reason_code IN ('selected_for_execution','below_execution_batch_limit')
+    ),
+    UNIQUE (ranking_batch_id,forecast_id),
+    UNIQUE (ranking_batch_id,rank),
+    CHECK (
+        (selected AND reason_code='selected_for_execution')
+        OR (NOT selected AND reason_code='below_execution_batch_limit')
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_opportunity_ranking_batches_recent
+    ON strategy_opportunity_ranking_batches (decided_at DESC,ranking_batch_id DESC);
+CREATE INDEX IF NOT EXISTS idx_strategy_opportunity_ranking_members_forecast
+    ON strategy_opportunity_ranking_members (forecast_id,ranking_batch_id DESC);
+
+ALTER TABLE strategy_entry_preflights
+    ADD COLUMN IF NOT EXISTS ranking_member_id BIGINT
+        REFERENCES strategy_opportunity_ranking_members(ranking_member_id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_strategy_entry_preflights_ranking_member
+    ON strategy_entry_preflights (ranking_member_id) WHERE ranking_member_id IS NOT NULL;
+
+COMMENT ON TABLE strategy_opportunity_ranking_batches IS
+    'One deduplicated immutable header per materially distinct positive opportunity set; never a polling heartbeat.';
+COMMENT ON TABLE strategy_opportunity_ranking_members IS
+    'Narrow ranked forecast decisions, including the reason each current positive opportunity was selected or declined.';

--- a/tests/test_strategy_opportunity_ranker.py
+++ b/tests/test_strategy_opportunity_ranker.py
@@ -18,6 +18,7 @@ from app.services.strategy_opportunity_ranker import (
 def _opportunity(*, signal_id: int, instrument_id: int, expectancy: str) -> RankableOpportunity:
     return RankableOpportunity(
         signal_id=signal_id,
+        forecast_id=signal_id + 1000,
         strategy_id="candidate-a",
         strategy_version="v1",
         instrument_id=instrument_id,

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -45,6 +45,7 @@ from app.services.strategy_opportunity_forecast import (
     record_opportunity_forecast,
     register_forecast_calibration,
 )
+from app.services.strategy_opportunity_ranker import RankableOpportunity, persist_ranking_batch
 from app.services.strategy_paper_executor import (
     PaperExecutionResult,
     _effective_capital_bases,
@@ -202,7 +203,7 @@ def _seed(
             evidence_ref="synthetic executor fixture only",
         ),
     )
-    record_opportunity_forecast(
+    forecast_id = record_opportunity_forecast(
         conn,
         OpportunityForecast(
             signal_id=int(signal[0]),
@@ -226,6 +227,27 @@ def _seed(
             conservative_net_expectancy_pct=Decimal("1.5"),
             cost_model_id=COST_MODEL_ID,
         ),
+    )
+    persist_ranking_batch(
+        conn,
+        opportunities=[
+            RankableOpportunity(
+                signal_id=int(signal[0]),
+                forecast_id=forecast_id,
+                strategy_id="S-ALLOC",
+                strategy_version="v1",
+                instrument_id=2449001,
+                signal_bar_date=date(2026, 8, 5),
+                side="long",
+                horizon_market_days=5,
+                setup_version="test-setup-v1",
+                exit_policy_version="test-exit-v1",
+                decided_at=_NOW,
+                conservative_net_expectancy_pct=Decimal("1.5"),
+            )
+        ],
+        selection_limit=5,
+        decided_at=_NOW,
     )
     conn.execute(
         "INSERT INTO quotes (instrument_id, quoted_at, bid, ask, last, spread_pct, spread_flag) "
@@ -273,6 +295,43 @@ def _seed(
     )
     conn.commit()
     return int(signal[0])
+
+
+def _rerank_signal(conn: psycopg.Connection[Any], signal_id: int) -> None:
+    row = conn.execute(
+        """
+        SELECT f.forecast_id,s.strategy_id,s.strategy_version,s.instrument_id,
+               s.signal_bar_date,f.side,f.horizon_market_days,f.setup_version,
+               f.exit_policy_version,f.decided_at,f.conservative_net_expectancy_pct
+        FROM strategy_signals s
+        JOIN strategy_opportunity_forecasts f ON f.signal_id=s.signal_id
+        WHERE s.signal_id=%s
+        """,
+        (signal_id,),
+    ).fetchone()
+    assert row is not None
+    persist_ranking_batch(
+        conn,
+        opportunities=[
+            RankableOpportunity(
+                signal_id=signal_id,
+                forecast_id=int(row[0]),
+                strategy_id=str(row[1]),
+                strategy_version=str(row[2]),
+                instrument_id=int(row[3]),
+                signal_bar_date=row[4],
+                side=str(row[5]),
+                horizon_market_days=int(row[6]),
+                setup_version=str(row[7]),
+                exit_policy_version=str(row[8]),
+                decided_at=row[9],
+                conservative_net_expectancy_pct=Decimal(str(row[10])),
+            )
+        ],
+        selection_limit=5,
+        decided_at=_NOW,
+    )
+    conn.commit()
 
 
 def _existing_allocated_trade(
@@ -446,15 +505,26 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
         (result.order_id,),
     ).fetchone() == (_REQUEST_ID, "strategy", "13902598")
     forecast_id = conn.execute(
-        "SELECT forecast_id FROM strategy_opportunity_forecasts WHERE signal_id=%s",
+        """
+        SELECT f.forecast_id,m.ranking_member_id
+        FROM strategy_opportunity_forecasts f
+        JOIN strategy_opportunity_ranking_members m ON m.forecast_id=f.forecast_id
+        WHERE f.signal_id=%s AND m.selected
+        """,
         (signal_id,),
     ).fetchone()
     assert forecast_id is not None
     assert conn.execute(
-        "SELECT verdict, allocated_amount, net_expectancy_pct, forecast_id "
+        "SELECT verdict, allocated_amount, net_expectancy_pct, forecast_id, ranking_member_id "
         "FROM strategy_entry_preflights WHERE signal_id=%s",
         (signal_id,),
-    ).fetchone() == ("allocated", Decimal("50.000000"), Decimal("3.00000000"), forecast_id[0])
+    ).fetchone() == (
+        "allocated",
+        Decimal("50.000000"),
+        Decimal("3.00000000"),
+        forecast_id[0],
+        forecast_id[1],
+    )
     conn.commit()
 
     # Retry is read-only and cannot submit a duplicate.
@@ -467,6 +537,8 @@ def test_missing_opportunity_forecast_refuses_before_broker_access(
 ) -> None:
     conn = ebull_test_conn
     signal_id = _seed(conn)
+    conn.execute("DELETE FROM strategy_opportunity_ranking_members")
+    conn.execute("DELETE FROM strategy_opportunity_ranking_batches")
     conn.execute("DELETE FROM strategy_opportunity_forecasts WHERE signal_id=%s", (signal_id,))
     conn.commit()
     broker = _broker()
@@ -480,6 +552,23 @@ def test_missing_opportunity_forecast_refuses_before_broker_access(
         "SELECT forecast_id FROM strategy_entry_preflights WHERE signal_id=%s",
         (signal_id,),
     ).fetchone() == (None,)
+
+
+def test_unbatched_opportunity_refuses_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute("DELETE FROM strategy_opportunity_ranking_members")
+    conn.execute("DELETE FROM strategy_opportunity_ranking_batches")
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.reason_code == "opportunity_ranking_member_missing"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -653,6 +742,7 @@ def test_shared_paper_pool_is_a_master_switch_and_hard_cap(
         changed_by="operator",
         reason="bounded shared pot",
     )
+    _rerank_signal(conn, signal_id)
     conn.commit()
     broker = _broker()
     broker.get_account_risk_snapshot.return_value = BrokerAccountRiskSnapshot(
@@ -917,6 +1007,7 @@ def test_shared_paper_pool_excludes_future_live_reservations(
         changed_by="operator",
         reason="paper-only shared pot",
     )
+    _rerank_signal(conn, signal_id)
     live_signal = conn.execute(
         """
         INSERT INTO strategy_signals (

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -13,6 +13,8 @@ from psycopg.pq import TransactionStatus
 from app.services.cost_model import COST_MODEL_ID
 from app.services.strategy_live_gate import assess_live_gate
 from app.services.strategy_opportunity_forecast import OpportunityForecast, record_opportunity_forecast
+from app.services.strategy_opportunity_ranker import persist_ranking_batch
+from app.services.strategy_paper_executor import execute_fired_paper_signal
 from app.services.strategy_paper_runtime import (
     _load_ranked_opportunities,
     refresh_strategy_health,
@@ -118,7 +120,7 @@ def test_runtime_ranks_the_complete_set_before_applying_its_execution_limit(
     executed: list[int] = []
     monkeypatch.setattr(
         "app.services.strategy_paper_runtime.execute_fired_paper_signal",
-        lambda _conn, *, broker, signal_id, now: executed.append(signal_id),
+        lambda _conn, *, broker, signal_id, ranking_member_id, now: executed.append(signal_id),
     )
 
     result = run_strategy_paper_cycle(
@@ -130,8 +132,69 @@ def test_runtime_ranks_the_complete_set_before_applying_its_execution_limit(
         strategy_versions=["v1"],
     )
 
-    assert result.evaluated_signals == 1
-    assert executed == [stronger_older]
+    assert result.evaluated_signals == 2
+    assert executed == [stronger_older, weaker_newer]
+    assert conn.execute("SELECT count(*) FROM strategy_opportunity_ranking_batches").fetchone() == (2,)
+    assert conn.execute(
+        """
+        SELECT s.signal_id,m.rank,m.selected,m.reason_code
+        FROM strategy_opportunity_ranking_members m
+        JOIN strategy_opportunity_forecasts f ON f.forecast_id=m.forecast_id
+        JOIN strategy_signals s ON s.signal_id=f.signal_id
+        WHERE m.ranking_batch_id=(
+          SELECT max(ranking_batch_id) FROM strategy_opportunity_ranking_batches
+        ) ORDER BY m.rank
+        """
+    ).fetchall() == [
+        (stronger_older, 1, True, "selected_for_execution"),
+        (weaker_newer, 2, False, "below_execution_batch_limit"),
+    ]
+    conn.commit()
+
+    run_strategy_paper_cycle(
+        conn,
+        broker=_broker(),
+        signal_limit=1,
+        position_limit=1,
+        now=_NOW,
+        strategy_versions=["v1"],
+    )
+    assert conn.execute("SELECT count(*) FROM strategy_opportunity_ranking_batches").fetchone() == (2,)
+    assert conn.execute("SELECT count(*) FROM strategy_opportunity_ranking_members").fetchone() == (3,)
+
+
+def test_declined_ranking_member_cannot_reach_broker_access(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    _seed(conn)
+    weaker_signal = _add_weaker_newer_forecast(conn)
+    ranked = _load_ranked_opportunities(conn, strategy_versions=["v1"], observed_at=_NOW)
+    persist_ranking_batch(conn, opportunities=ranked, selection_limit=1, decided_at=_NOW)
+    declined = conn.execute(
+        """
+        SELECT m.ranking_member_id
+        FROM strategy_opportunity_ranking_members m
+        JOIN strategy_opportunity_forecasts f ON f.forecast_id=m.forecast_id
+        WHERE f.signal_id=%s AND NOT m.selected
+        """,
+        (weaker_signal,),
+    ).fetchone()
+    assert declined is not None
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(
+        conn,
+        broker=broker,
+        signal_id=weaker_signal,
+        ranking_member_id=int(declined[0]),
+        now=_NOW,
+    )
+
+    assert result.reason_code == "opportunity_ranking_member_not_selected"
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
 
 
 def test_stale_forecast_cannot_consume_the_bounded_ranked_set(


### PR DESCRIPTION
Closes #2549

## Outcome
- persists one narrow immutable ranking header/member set for each materially distinct positive opportunity set
- hashes sorted economic identities, records selected and declined reasons, and reuses unchanged batches
- sends both selected and declined members through fail-closed local preflight so every forecast gets one durable funding outcome without repeated-cycle row growth
- requires the exact selected member and unchanged mandate before broker access; allocated preflight links forecast and batch member

This remains ranking/audit infrastructure, not the still-required target-portfolio correlation/factor/core optimiser and not an alpha claim.

## Validation
- `bash .githooks/pre-push`
- 55 focused ranking/runtime/executor/position lifecycle tests
