### PR TITLE
Bind forecast barriers to executed TP and SL

### DIFF
--- a/app/services/strategy_opportunity_forecast.py
+++ b/app/services/strategy_opportunity_forecast.py
@@ -45,6 +45,8 @@ class OpportunityForecast:
     decided_at: datetime
     valid_through: datetime
     horizon_market_days: int
+    target_barrier_pct: Decimal
+    stop_barrier_pct: Decimal
     setup_version: str
     exit_policy_version: str
     calibration_id: str
@@ -139,6 +141,14 @@ def record_opportunity_forecast(conn: psycopg.Connection[Any], forecast: Opportu
         raise OpportunityForecastError("forecast validity must not end before its decision time")
     if not 0 < forecast.horizon_market_days <= 60:
         raise OpportunityForecastError("forecast horizon must be between one and 60 market days")
+    for field, value, upper, inclusive in (
+        ("target_barrier_pct", forecast.target_barrier_pct, Decimal("1000"), True),
+        ("stop_barrier_pct", forecast.stop_barrier_pct, Decimal("100"), False),
+    ):
+        upper_ok = value <= upper if inclusive else value < upper
+        if not value.is_finite() or value <= 0 or not upper_ok:
+            comparator = "at most" if inclusive else "below"
+            raise OpportunityForecastError(f"{field} must be finite, positive and {comparator} {upper}")
     probabilities = (
         forecast.target_probability,
         forecast.stop_probability,
@@ -200,13 +210,14 @@ def record_opportunity_forecast(conn: psycopg.Connection[Any], forecast: Opportu
         """
             INSERT INTO strategy_opportunity_forecasts (
                 signal_id,forecast_policy_version,decided_at,valid_through,side,
-                horizon_market_days,setup_version,exit_policy_version,calibration_id,
+                horizon_market_days,target_barrier_pct,stop_barrier_pct,
+                setup_version,exit_policy_version,calibration_id,
                 target_probability,stop_probability,timeout_probability,
                 target_net_return_pct,stop_net_return_pct,timeout_net_return_pct,
                 expected_duration_hours,uncertainty_penalty_pct,tail_penalty_pct,
                 correlation_penalty_pct,cost_stress_penalty_pct,
                 conservative_net_expectancy_pct,cost_model_id
-            ) VALUES (%s,%s,%s,%s,'long',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            ) VALUES (%s,%s,%s,%s,'long',%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
             ON CONFLICT (signal_id) DO NOTHING
             RETURNING forecast_id
             """,
@@ -216,6 +227,8 @@ def record_opportunity_forecast(conn: psycopg.Connection[Any], forecast: Opportu
             forecast.decided_at,
             forecast.valid_through,
             forecast.horizon_market_days,
+            forecast.target_barrier_pct,
+            forecast.stop_barrier_pct,
             forecast.setup_version,
             forecast.exit_policy_version,
             forecast.calibration_id,

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -237,6 +237,8 @@ def _load_intent(
                    forecast.forecast_id,forecast.forecast_policy_version,
                    forecast.decided_at AS forecast_decided_at,
                    forecast.valid_through AS forecast_valid_through,
+                   forecast.target_barrier_pct AS forecast_target_barrier_pct,
+                   forecast.stop_barrier_pct AS forecast_stop_barrier_pct,
                    forecast.conservative_net_expectancy_pct AS forecast_conservative_expectancy,
                    forecast.cost_model_id AS forecast_cost_model_id,
                    calibration.passed AS calibration_passed,
@@ -337,6 +339,24 @@ def _load_intent(
         (bool(row["calibration_passed"]), "opportunity_calibration_not_passed"),
         (row["forecast_cost_model_id"] == COST_MODEL_ID, "opportunity_forecast_cost_model_stale"),
         (
+            row["forecast_target_barrier_pct"] is not None
+            and Decimal(str(row["forecast_target_barrier_pct"])).is_finite()
+            and Decimal(str(row["forecast_target_barrier_pct"])) > 0,
+            "opportunity_forecast_barriers_missing",
+        ),
+        (
+            row["forecast_stop_barrier_pct"] is not None
+            and Decimal(str(row["forecast_stop_barrier_pct"])).is_finite()
+            and Decimal(str(row["forecast_stop_barrier_pct"])) > 0,
+            "opportunity_forecast_barriers_missing",
+        ),
+        (
+            row["forecast_stop_barrier_pct"] is not None
+            and row["stop_loss_pct"] is not None
+            and Decimal(str(row["forecast_stop_barrier_pct"])) <= Decimal(str(row["stop_loss_pct"])),
+            "opportunity_forecast_stop_exceeds_policy",
+        ),
+        (
             row["forecast_conservative_expectancy"] is not None
             and Decimal(str(row["forecast_conservative_expectancy"])) > 0,
             "opportunity_forecast_expectancy_not_positive",
@@ -411,8 +431,8 @@ def _load_intent(
             Decimal(str(row["fixed_ticket_amount"])) if row["fixed_ticket_amount"] is not None else None
         ),
         max_ticket_amount=Decimal(str(row["max_ticket_amount"])),
-        stop_loss_pct=Decimal(str(row["stop_loss_pct"])),
-        take_profit_pct=Decimal(str(row["take_profit_pct"])),
+        stop_loss_pct=Decimal(str(row["forecast_stop_barrier_pct"])),
+        take_profit_pct=Decimal(str(row["forecast_target_barrier_pct"])),
         max_quote_age_seconds=int(row["max_quote_age_seconds"]),
         max_scan_age_seconds=int(row["max_scan_age_seconds"]),
         max_halt_feed_age_seconds=int(row["max_halt_feed_age_seconds"]),

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -342,13 +342,13 @@ def _load_intent(
             row["forecast_target_barrier_pct"] is not None
             and Decimal(str(row["forecast_target_barrier_pct"])).is_finite()
             and Decimal(str(row["forecast_target_barrier_pct"])) > 0,
-            "opportunity_forecast_barriers_missing",
+            "opportunity_forecast_target_barrier_missing",
         ),
         (
             row["forecast_stop_barrier_pct"] is not None
             and Decimal(str(row["forecast_stop_barrier_pct"])).is_finite()
             and Decimal(str(row["forecast_stop_barrier_pct"])) > 0,
-            "opportunity_forecast_barriers_missing",
+            "opportunity_forecast_stop_barrier_missing",
         ),
         (
             row["forecast_stop_barrier_pct"] is not None

--- a/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
+++ b/docs/proposals/ta/2026-08-11-autonomous-opportunity-engine.md
@@ -232,6 +232,13 @@ causal volatility/structure. They are not moved until a desired historical win
 rate appears. A 3-session forecast and a 10-session forecast are distinct
 trials and competing uses of capital.
 
+The target/stop barrier percentages are frozen separately from their
+conditional **net** payoffs. #2551 makes those exact barriers part of every new
+forecast and uses them for loss-at-stop sizing and the submitted broker TP/SL.
+A generic deployment default may cap risk but may not silently replace the
+geometry whose probabilities authorised the order. Legacy forecasts without
+barriers fail closed.
+
 Where useful, prediction is staged:
 
 1. market direction and volatility state;

--- a/sql/314_strategy_forecast_barriers.sql
+++ b/sql/314_strategy_forecast_barriers.sql
@@ -1,0 +1,25 @@
+-- 314_strategy_forecast_barriers.sql
+--
+-- #2551: bind the triple-barrier experiment to the order it authorises.
+-- Nullable preserves historical forecasts; the writer requires both for new
+-- rows and the executor rejects legacy NULL geometry before broker access.
+
+ALTER TABLE strategy_opportunity_forecasts
+    ADD COLUMN IF NOT EXISTS target_barrier_pct NUMERIC(12,8),
+    ADD COLUMN IF NOT EXISTS stop_barrier_pct NUMERIC(12,8);
+
+ALTER TABLE strategy_opportunity_forecasts
+    DROP CONSTRAINT IF EXISTS strategy_opportunity_forecast_barrier_shape;
+ALTER TABLE strategy_opportunity_forecasts
+    ADD CONSTRAINT strategy_opportunity_forecast_barrier_shape CHECK (
+        (target_barrier_pct IS NULL AND stop_barrier_pct IS NULL)
+        OR (
+            target_barrier_pct > 0 AND target_barrier_pct <= 1000
+            AND stop_barrier_pct > 0 AND stop_barrier_pct < 100
+        )
+    );
+
+COMMENT ON COLUMN strategy_opportunity_forecasts.target_barrier_pct IS
+    'Gross price distance above entry used by the target-first path label; distinct from the conditional after-cost payoff.';
+COMMENT ON COLUMN strategy_opportunity_forecasts.stop_barrier_pct IS
+    'Gross price distance below entry used by loss-at-stop sizing and the stop-first path label; distinct from the conditional after-cost payoff.';

--- a/tests/test_strategy_opportunity_forecast.py
+++ b/tests/test_strategy_opportunity_forecast.py
@@ -28,6 +28,8 @@ def _forecast() -> OpportunityForecast:
         decided_at=decided_at,
         valid_through=decided_at + timedelta(days=5),
         horizon_market_days=5,
+        target_barrier_pct=Decimal("4"),
+        stop_barrier_pct=Decimal("2"),
         setup_version="setup-v1",
         exit_policy_version="exit-v1",
         calibration_id="calibration-v1",
@@ -62,6 +64,16 @@ def test_conservative_expectancy_must_reconcile_before_database_access() -> None
     forecast = replace(_forecast(), conservative_net_expectancy_pct=Decimal("1.41"))
 
     with pytest.raises(OpportunityForecastError, match="does not reconcile"):
+        record_opportunity_forecast(conn, forecast)
+
+    conn.execute.assert_not_called()
+
+
+def test_barrier_geometry_is_required_before_database_access() -> None:
+    conn = MagicMock(spec=psycopg.Connection[Any])
+    forecast = replace(_forecast(), stop_barrier_pct=Decimal("0"))
+
+    with pytest.raises(OpportunityForecastError, match="stop_barrier_pct"):
         record_opportunity_forecast(conn, forecast)
 
     conn.execute.assert_not_called()

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -210,6 +210,8 @@ def _seed(
             decided_at=_NOW,
             valid_through=_NOW + timedelta(days=7),
             horizon_market_days=5,
+            target_barrier_pct=Decimal("10"),
+            stop_barrier_pct=Decimal("5"),
             setup_version="test-setup-v1",
             exit_policy_version="test-exit-v1",
             calibration_id="test-calibration-v1",
@@ -622,6 +624,8 @@ def test_immutable_forecast_duplicate_does_not_abort_the_callers_transaction(
                 decided_at=_NOW,
                 valid_through=_NOW + timedelta(days=7),
                 horizon_market_days=5,
+                target_barrier_pct=Decimal("10"),
+                stop_barrier_pct=Decimal("5"),
                 setup_version="test-setup-v1",
                 exit_policy_version="test-exit-v1",
                 calibration_id="test-calibration-v1",
@@ -783,6 +787,69 @@ def test_mandate_loss_at_stop_reduces_position_size(
 
     assert result.verdict == "submitted"
     assert result.amount == Decimal("100.00")
+
+
+def test_forecast_barriers_drive_loss_sizing_and_submitted_tp_sl(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute("UPDATE strategy_opportunity_forecasts SET target_barrier_pct=4,stop_barrier_pct=2")
+    conn.execute("UPDATE strategy_paper_pool_events SET max_loss_per_position_pct=0.1")
+    conn.commit()
+    broker = _broker()
+    broker.get_account_risk_snapshot.return_value = BrokerAccountRiskSnapshot(
+        available_cash=Decimal("2000"),
+        total_invested=Decimal("0"),
+        unrealized_pnl=Decimal("0"),
+        equity=Decimal("2000"),
+        instrument_investments=(),
+        observed_at=_NOW,
+        raw_payload={},
+    )
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.amount == Decimal("100.00")
+    order = broker.place_demo_strategy_order.call_args.args[0]
+    assert order.stop_loss_rate == Decimal("98.000000")
+    assert order.take_profit_rate == Decimal("104.000000")
+    assert conn.execute(
+        "SELECT stop_loss_rate,take_profit_rate FROM strategy_entry_preflights WHERE signal_id=%s",
+        (signal_id,),
+    ).fetchone() == (Decimal("98.000000"), Decimal("104.000000"))
+
+
+@pytest.mark.parametrize(
+    ("target_barrier", "stop_barrier", "reason_code"),
+    [
+        (None, None, "opportunity_forecast_barriers_missing"),
+        (Decimal("10"), Decimal("6"), "opportunity_forecast_stop_exceeds_policy"),
+    ],
+)
+def test_invalid_forecast_barrier_geometry_refuses_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+    target_barrier: Decimal | None,
+    stop_barrier: Decimal | None,
+    reason_code: str,
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    conn.execute(
+        """
+        UPDATE strategy_opportunity_forecasts
+        SET target_barrier_pct=%s,stop_barrier_pct=%s
+        """,
+        (target_barrier, stop_barrier),
+    )
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    assert result.reason_code == reason_code
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
 
 
 def test_mandate_position_loss_below_broker_minimum_refuses_without_submission(

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -823,7 +823,7 @@ def test_forecast_barriers_drive_loss_sizing_and_submitted_tp_sl(
 @pytest.mark.parametrize(
     ("target_barrier", "stop_barrier", "reason_code"),
     [
-        (None, None, "opportunity_forecast_barriers_missing"),
+        (None, None, "opportunity_forecast_target_barrier_missing"),
         (Decimal("10"), Decimal("6"), "opportunity_forecast_stop_exceeds_policy"),
     ],
 )

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -57,6 +57,8 @@ def _add_weaker_newer_forecast(conn: psycopg.Connection[tuple]) -> int:
             decided_at=_NOW,
             valid_through=_NOW + timedelta(days=7),
             horizon_market_days=5,
+            target_barrier_pct=Decimal("10"),
+            stop_barrier_pct=Decimal("5"),
             setup_version="weaker-setup-v1",
             exit_policy_version="test-exit-v1",
             calibration_id="test-calibration-v1",


### PR DESCRIPTION
Closes #2551

## Outcome
- separates exact target/stop price geometry from conditional after-cost forecast payoffs
- requires barrier geometry on every new forecast while preserving legacy rows as unreadable authority
- uses forecast stop distance for portfolio loss sizing and exact forecast target/stop for broker order rates
- refuses missing geometry or a stop beyond the execution policy ceiling before broker access

## Validation
- `bash .githooks/pre-push`
- focused forecast/executor/runtime tests including +4%/-2% exact order and sizing proof
