### PR TITLE
Resolve immutable opportunity forecasts against price paths

### DIFF
--- a/app/services/strategy_forecast_outcome_resolution.py
+++ b/app/services/strategy_forecast_outcome_resolution.py
@@ -1,0 +1,308 @@
+"""Resolve immutable opportunity forecasts against subsequent price paths.
+
+Each forecast owns the bracket and horizon that informed capital ranking.  This
+service observes that exact decision prospectively, using the shared causal
+daily-bar resolver.  It stores one terminal row and no polling heartbeats;
+immature windows remain absent and are retried by a bounded round-robin scan.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Final
+
+import psycopg
+
+from app.services.indicator_series import BarSeries
+from app.services.outcome_ledger import locate_fill_index
+from app.services.outcome_resolver import RULE_SET_VERSION as PATH_RULE_SET_VERSION
+from app.services.outcome_resolver import ExitLevels, Outcome, UnresolvedReason, resolve_outcome
+from app.services.price_masked_bars import MASKED_REASON, QUARANTINE_RULE_SET_VERSION, load_masked_bars
+from app.services.price_segments import load_unresolved_breaks, segment_end_index
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BATCH_LIMIT: Final = 1_000
+RESOLVER_ID: Final = "forecast-outcome-resolver-v1"
+
+
+def _code_hash() -> str:
+    return hashlib.sha256(Path(__file__).read_bytes()).hexdigest()[:12]
+
+
+# This service owns forecast-to-bracket mapping; the shared resolver owns OHLC
+# touch ordering and timeout fills. Both identities are required: otherwise an
+# edit to gap/touch semantics could reinterpret an old forecast under the same
+# supposedly immutable outcome key.
+RESOLVER_VERSION: Final = f"{RESOLVER_ID}+{_code_hash()}+path-{PATH_RULE_SET_VERSION}"
+
+_READ_CURSOR_SQL = "SELECT last_forecast_id FROM strategy_forecast_outcome_cursor WHERE id=TRUE"
+_WRITE_CURSOR_SQL = """
+    INSERT INTO strategy_forecast_outcome_cursor (id,last_forecast_id,updated_at)
+    VALUES (TRUE,%s,now())
+    ON CONFLICT (id) DO UPDATE
+    SET last_forecast_id=EXCLUDED.last_forecast_id,updated_at=now()
+"""
+_SELECT_SQL = """
+    SELECT f.forecast_id,s.instrument_id,s.fill_bar_date,s.fill_price,
+           f.target_barrier_pct,f.stop_barrier_pct,f.horizon_market_days
+    FROM strategy_opportunity_forecasts f
+    JOIN strategy_signals s ON s.signal_id=f.signal_id
+    LEFT JOIN strategy_opportunity_forecast_outcomes o
+      ON o.forecast_id=f.forecast_id
+     AND o.resolver_version=%(resolver_version)s
+     AND o.input_rule_set_version=%(input_rule_set_version)s
+    WHERE s.verdict='fired'
+      AND s.signal_kind='entry'
+      AND s.fill_bar_date IS NOT NULL
+      AND s.fill_price IS NOT NULL
+      AND f.target_barrier_pct IS NOT NULL
+      AND f.stop_barrier_pct IS NOT NULL
+      AND o.forecast_outcome_id IS NULL
+      AND f.forecast_id > %(after_forecast_id)s
+      AND (%(at_or_before_forecast_id)s::bigint IS NULL
+           OR f.forecast_id <= %(at_or_before_forecast_id)s)
+    ORDER BY f.forecast_id
+    LIMIT %(limit)s
+"""
+_INSERT_SQL = """
+    INSERT INTO strategy_opportunity_forecast_outcomes (
+        forecast_id,resolver_version,input_rule_set_version,outcome,reason,
+        exit_bar_date,exit_price,market_bars_held,gross_return_pct
+    ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+    ON CONFLICT (forecast_id,resolver_version,input_rule_set_version) DO NOTHING
+    RETURNING forecast_outcome_id
+"""
+
+
+@dataclass(frozen=True)
+class PendingForecast:
+    forecast_id: int
+    instrument_id: int
+    fill_bar_date: date
+    fill_price: Decimal
+    target_barrier_pct: Decimal
+    stop_barrier_pct: Decimal
+    horizon_market_days: int
+
+
+@dataclass(frozen=True)
+class ForecastOutcomeRow:
+    forecast_id: int
+    outcome: str
+    reason: str | None
+    exit_bar_date: date | None
+    exit_price: Decimal | None
+    market_bars_held: int | None
+    gross_return_pct: Decimal | None
+
+    @classmethod
+    def from_outcome(cls, forecast_id: int, outcome: Outcome) -> ForecastOutcomeRow:
+        mapped = {
+            "tp_hit": "target_first",
+            "sl_hit": "stop_first",
+            "expired": "timeout",
+            "ambiguous": "ambiguous",
+            "unresolved": "unresolved",
+        }
+        return cls(
+            forecast_id=forecast_id,
+            outcome=mapped[outcome.outcome],
+            reason=outcome.reason,
+            exit_bar_date=outcome.exit_bar_date,
+            exit_price=outcome.exit_price,
+            market_bars_held=outcome.bars_held,
+            gross_return_pct=outcome.gross_return_pct,
+        )
+
+
+@dataclass(frozen=True)
+class ForecastOutcomeResolutionReport:
+    selected: int = 0
+    written: int = 0
+    immature: int = 0
+    ambiguous: int = 0
+    outcomes: Mapping[str, int] = field(default_factory=dict)
+
+
+def _masked_reasons(rows: Sequence[Mapping[str, object]]) -> dict[int, UnresolvedReason]:
+    return {
+        index: MASKED_REASON
+        for index, row in enumerate(rows)
+        if any(row.get(field) is None for field in ("open", "high", "low", "close"))
+    }
+
+
+def _resolve_forecast(
+    forecast: PendingForecast,
+    *,
+    series: BarSeries,
+    unresolved_breaks: Sequence[date],
+    masked_bar_reasons: Mapping[int, UnresolvedReason] | None = None,
+) -> ForecastOutcomeRow | None:
+    """Return one terminal observation, or ``None`` until the horizon matures."""
+    fill_index = locate_fill_index(series, forecast.fill_bar_date)
+    hundred = Decimal("100")
+    levels = ExitLevels(
+        take_profit=forecast.fill_price * (Decimal("1") + forecast.target_barrier_pct / hundred),
+        stop_loss=forecast.fill_price * (Decimal("1") - forecast.stop_barrier_pct / hundred),
+        max_hold_bars=forecast.horizon_market_days,
+    )
+    outcome = resolve_outcome(
+        series=series,
+        fill_index=fill_index,
+        entry_price=forecast.fill_price,
+        levels=levels,
+        masked_bar_reasons=masked_bar_reasons if masked_bar_reasons is not None else _masked_reasons(series.rows),
+        segment_end_index=segment_end_index(
+            series,
+            fill_index=fill_index,
+            unresolved_breaks=unresolved_breaks,
+        ),
+    )
+    if outcome.outcome == "unresolved" and outcome.reason == "window_truncated":
+        return None
+    return ForecastOutcomeRow.from_outcome(forecast.forecast_id, outcome)
+
+
+def _read_cursor(conn: psycopg.Connection[Any]) -> int:
+    row = conn.execute(_READ_CURSOR_SQL).fetchone()
+    return 0 if row is None else int(row[0])
+
+
+def _write_cursor(conn: psycopg.Connection[Any], last_forecast_id: int) -> None:
+    conn.execute(_WRITE_CURSOR_SQL, (last_forecast_id,))
+
+
+def _select(
+    conn: psycopg.Connection[Any],
+    *,
+    after_forecast_id: int,
+    limit: int,
+    at_or_before_forecast_id: int | None = None,
+) -> list[PendingForecast]:
+    rows = conn.execute(
+        _SELECT_SQL,
+        {
+            "resolver_version": RESOLVER_VERSION,
+            "input_rule_set_version": QUARANTINE_RULE_SET_VERSION,
+            "after_forecast_id": after_forecast_id,
+            "at_or_before_forecast_id": at_or_before_forecast_id,
+            "limit": limit,
+        },
+    ).fetchall()
+    return [
+        PendingForecast(
+            forecast_id=int(row[0]),
+            instrument_id=int(row[1]),
+            fill_bar_date=row[2],
+            fill_price=Decimal(row[3]),
+            target_barrier_pct=Decimal(row[4]),
+            stop_barrier_pct=Decimal(row[5]),
+            horizon_market_days=int(row[6]),
+        )
+        for row in rows
+    ]
+
+
+def _select_round_robin(conn: psycopg.Connection[Any], *, cursor: int, limit: int) -> list[PendingForecast]:
+    forecasts = _select(conn, after_forecast_id=cursor, limit=limit)
+    if len(forecasts) < limit and cursor > 0:
+        forecasts.extend(
+            _select(
+                conn,
+                after_forecast_id=0,
+                at_or_before_forecast_id=cursor,
+                limit=limit - len(forecasts),
+            )
+        )
+    return forecasts
+
+
+def _store(conn: psycopg.Connection[Any], rows: Sequence[ForecastOutcomeRow]) -> int:
+    written = 0
+    for row in rows:
+        inserted = conn.execute(
+            _INSERT_SQL,
+            (
+                row.forecast_id,
+                RESOLVER_VERSION,
+                QUARANTINE_RULE_SET_VERSION,
+                row.outcome,
+                row.reason,
+                row.exit_bar_date,
+                row.exit_price,
+                row.market_bars_held,
+                row.gross_return_pct,
+            ),
+        ).fetchone()
+        written += inserted is not None
+    return written
+
+
+def run_forecast_outcome_resolution(
+    conn: psycopg.Connection[Any], *, batch_limit: int = DEFAULT_BATCH_LIMIT
+) -> ForecastOutcomeResolutionReport:
+    if not conn.autocommit:
+        raise ValueError("run_forecast_outcome_resolution needs an autocommit connection")
+    if batch_limit < 1:
+        raise ValueError(f"batch_limit must be positive, got {batch_limit}")
+
+    cursor = _read_cursor(conn)
+    forecasts = _select_round_robin(conn, cursor=cursor, limit=batch_limit)
+    by_instrument: dict[int, list[PendingForecast]] = {}
+    for forecast in forecasts:
+        by_instrument.setdefault(forecast.instrument_id, []).append(forecast)
+    breaks = load_unresolved_breaks(conn, sorted(by_instrument))
+    rows: list[ForecastOutcomeRow] = []
+    immature = 0
+    for instrument_id, instrument_forecasts in sorted(by_instrument.items()):
+        series = load_masked_bars(conn, instrument_id).series
+        masked = _masked_reasons(series.rows)
+        for forecast in instrument_forecasts:
+            row = _resolve_forecast(
+                forecast,
+                series=series,
+                unresolved_breaks=breaks.get(instrument_id, ()),
+                masked_bar_reasons=masked,
+            )
+            if row is None:
+                immature += 1
+            else:
+                rows.append(row)
+    with conn.transaction():
+        written = _store(conn, rows)
+        if forecasts:
+            _write_cursor(conn, forecasts[-1].forecast_id)
+    outcomes = Counter(row.outcome for row in rows)
+    report = ForecastOutcomeResolutionReport(
+        selected=len(forecasts),
+        written=written,
+        immature=immature,
+        ambiguous=outcomes["ambiguous"],
+        outcomes=dict(sorted(outcomes.items())),
+    )
+    logger.info(
+        "strategy_forecast_outcome_resolution: selected=%d written=%d immature=%d ambiguous=%d limit=%d",
+        report.selected,
+        report.written,
+        report.immature,
+        report.ambiguous,
+        batch_limit,
+    )
+    return report
+
+
+__all__ = [
+    "DEFAULT_BATCH_LIMIT",
+    "ForecastOutcomeResolutionReport",
+    "RESOLVER_VERSION",
+    "run_forecast_outcome_resolution",
+]

--- a/app/services/strategy_forecast_outcome_resolution.py
+++ b/app/services/strategy_forecast_outcome_resolution.py
@@ -103,6 +103,19 @@ class ForecastOutcomeRow:
     market_bars_held: int | None
     gross_return_pct: Decimal | None
 
+    def __post_init__(self) -> None:
+        terminal = {"target_first", "stop_first", "timeout", "ambiguous", "unresolved"}
+        if self.outcome not in terminal:
+            raise ValueError(f"unknown forecast outcome {self.outcome!r}")
+        if (self.outcome == "unresolved") != (self.reason is not None):
+            raise ValueError("a reason is required exactly when a forecast outcome is unresolved")
+        located = (self.exit_bar_date is not None) + (self.market_bars_held is not None)
+        if located != (0 if self.outcome == "unresolved" else 2):
+            raise ValueError("unresolved outcomes have no exit location; all other outcomes require one")
+        priced = (self.exit_price is not None) + (self.gross_return_pct is not None)
+        if priced != (2 if self.outcome in {"target_first", "stop_first", "timeout"} else 0):
+            raise ValueError("only target, stop and timeout outcomes carry both an exit price and return")
+
     @classmethod
     def from_outcome(cls, forecast_id: int, outcome: Outcome) -> ForecastOutcomeRow:
         mapped = {
@@ -280,6 +293,10 @@ def run_forecast_outcome_resolution(
     with conn.transaction():
         written = _store(conn, rows)
         if forecasts:
+            # The final ID is deliberately not max(...). After a wrap the last
+            # row is in the lower range; persisting it lets the next run move
+            # through that range. Persisting the maximum would wrap to the same
+            # low rows repeatedly and starve IDs between the two ranges.
             _write_cursor(conn, forecasts[-1].forecast_id)
     outcomes = Counter(row.outcome for row in rows)
     report = ForecastOutcomeResolutionReport(

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -2080,9 +2080,10 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         source="strategy_scan",
         description=(
             "Daily 06:55 UTC — after the signal scan, resolves mature current-version "
-            "level-based fills against the fail-closed live corpus. Incomplete windows "
-            "remain pending without a database write; terminal outcomes are one immutable "
-            "row per signal and rule-version pair, processed round-robin in a bounded batch."
+            "level-based fills and immutable opportunity forecasts against the fail-closed "
+            "live corpus. Incomplete windows remain pending without a database write; "
+            "terminal outcomes are one immutable row per decision and rule-version pair, "
+            "processed round-robin in bounded batches."
         ),
         cadence=Cadence.daily(hour=6, minute=55),
         catch_up_on_boot=False,
@@ -5069,15 +5070,21 @@ def strategy_signal_scan() -> None:
 
 def strategy_outcome_resolution() -> None:
     """Resolve mature forward brackets without persisting immature windows."""
+    from app.services.strategy_forecast_outcome_resolution import run_forecast_outcome_resolution
     from app.services.strategy_outcome_resolution import run_outcome_resolution
 
     with _tracked_job(JOB_STRATEGY_OUTCOME_RESOLUTION) as tracker:
         with connect_job(autocommit=True) as conn:
             report = run_outcome_resolution(conn)
-        tracker.row_count = report.written
+            forecast_report = run_forecast_outcome_resolution(conn)
+        tracker.row_count = report.written + forecast_report.written
         tracker.note = (
             f"selected={report.selected} written={report.written} "
-            f"immature={report.immature} ambiguous={report.ambiguous}"
+            f"immature={report.immature} ambiguous={report.ambiguous}; "
+            f"forecasts_selected={forecast_report.selected} "
+            f"forecasts_written={forecast_report.written} "
+            f"forecasts_immature={forecast_report.immature} "
+            f"forecasts_ambiguous={forecast_report.ambiguous}"
         )
 
 

--- a/docs/proposals/ta/2026-08-10-forward-strategy-outcomes.md
+++ b/docs/proposals/ta/2026-08-10-forward-strategy-outcomes.md
@@ -72,6 +72,35 @@ The production path was also exercised against the development database with
 the current manifest. With no signals at the new S-4 strategy version it
 correctly reported a zero-write success rather than inventing a backfill.
 
+## Opportunity-forecast outcomes (#2553)
+
+The same scheduled job also resolves every immutable opportunity forecast
+against the forecast's own `target_barrier_pct`, `stop_barrier_pct`, and
+`horizon_market_days`. This is deliberately separate from the generic
+strategy outcome: the bracket that ranked and sized a possible order is the
+bracket whose probability claim must be tested. Reconstructing a later bracket
+from a mutable strategy manifest would test a different decision.
+
+Forecast outcomes use the shared causal OHLC rules (including gap-through,
+daily both-touch ambiguity, quarantine masking, next-open timeout, and price
+scale boundaries) and map them to `target_first`, `stop_first`, `timeout`,
+`ambiguous`, or counted `unresolved`. One row is stored per exact
+forecast/resolver/input-version identity. Immature forecasts have no row and a
+single round-robin cursor prevents them starving later mature forecasts.
+
+This adds no feature snapshots and copies no bars. Storage grows by at most one
+terminal row per fired forecast/version, with one mutable cursor for the whole
+resolver. `gross_return_pct` is observed gross price return in the existing
+outcome-resolver convention (for example `0.10` means 10%); it is not net P&L
+and cannot replace reconciled broker costs. The duplicate lookup index found in
+review is dropped by migration 316 because the unique constraint already owns
+the same index shape.
+
+These rows are prospective calibration evidence, not capital authority. A
+subsequent assessment must compare stated class probabilities with observed
+classes over a recent, preregistered window and fail closed on insufficient
+sample, calibration drift, or unresolved/ambiguous evidence.
+
 ## Explicit non-goals
 
 This closes measurement plumbing; it does not make an unproven strategy safe to

--- a/sql/315_strategy_forecast_outcomes.sql
+++ b/sql/315_strategy_forecast_outcomes.sql
@@ -1,0 +1,54 @@
+-- 315_strategy_forecast_outcomes.sql
+--
+-- #2553: one compact terminal path result per immutable opportunity forecast.
+-- Immature windows have no row and are retried; polling and source bars are not
+-- copied into this ledger.
+
+CREATE TABLE IF NOT EXISTS strategy_opportunity_forecast_outcomes (
+    forecast_outcome_id        BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    forecast_id                BIGINT NOT NULL
+        REFERENCES strategy_opportunity_forecasts(forecast_id) ON DELETE RESTRICT,
+    resolver_version           TEXT NOT NULL CHECK (resolver_version <> ''),
+    input_rule_set_version     TEXT NOT NULL CHECK (input_rule_set_version <> ''),
+    outcome                    TEXT NOT NULL CHECK (
+        outcome IN ('target_first','stop_first','timeout','ambiguous','unresolved')
+    ),
+    reason                     TEXT CHECK (
+        reason IS NULL OR reason IN (
+            'series_break','quarantined_bar','missing_bar_data','unorderable_exit_levels'
+        )
+    ),
+    exit_bar_date              DATE,
+    exit_price                 NUMERIC,
+    market_bars_held           INTEGER CHECK (market_bars_held IS NULL OR market_bars_held >= 0),
+    gross_return_pct           NUMERIC,
+    resolved_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (forecast_id,resolver_version,input_rule_set_version),
+    CHECK ((outcome='unresolved') = (reason IS NOT NULL)),
+    CHECK (
+        (exit_bar_date IS NULL) = (outcome='unresolved')
+        AND (market_bars_held IS NULL) = (outcome='unresolved')
+    ),
+    CHECK (
+        (exit_price IS NULL) = (outcome IN ('ambiguous','unresolved'))
+        AND (gross_return_pct IS NULL) = (outcome IN ('ambiguous','unresolved'))
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_forecast_outcomes_forecast
+    ON strategy_opportunity_forecast_outcomes (forecast_id,resolver_version,input_rule_set_version);
+CREATE INDEX IF NOT EXISTS idx_strategy_forecast_outcomes_calibration
+    ON strategy_opportunity_forecast_outcomes (resolver_version,input_rule_set_version,outcome,forecast_id);
+
+CREATE TABLE IF NOT EXISTS strategy_forecast_outcome_cursor (
+    id                         BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    last_forecast_id           BIGINT NOT NULL CHECK (last_forecast_id >= 0),
+    updated_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE strategy_opportunity_forecast_outcomes IS
+    'One immutable terminal target/stop/timeout path result per exact forecast and resolver/input version; no immature or polling rows.';
+COMMENT ON COLUMN strategy_opportunity_forecast_outcomes.gross_return_pct IS
+    'Observed gross price return only. It is not represented as net performance and cannot substitute for reconciled costs.';
+COMMENT ON TABLE strategy_forecast_outcome_cursor IS
+    'Single mutable round-robin cursor preventing immature forecasts from starving later mature forecasts.';

--- a/sql/316_drop_redundant_forecast_outcome_index.sql
+++ b/sql/316_drop_redundant_forecast_outcome_index.sql
@@ -1,0 +1,8 @@
+-- 316_drop_redundant_forecast_outcome_index.sql
+--
+-- #2553 review: the UNIQUE constraint on
+-- (forecast_id,resolver_version,input_rule_set_version) already owns an index
+-- with exactly the lookup shape created explicitly by sql/315. Keep one copy:
+-- every terminal forecast should cost one row, not duplicate index storage.
+
+DROP INDEX IF EXISTS idx_strategy_forecast_outcomes_forecast;

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -212,6 +212,9 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # reference both it and signals, so those children are derived; the parent
     # itself cannot be discovered from an existing inbound-FK root.
     "strategy_forecast_calibrations",
+    # #2553 — the forecast outcome round-robin cursor is standalone. Outcome
+    # rows are discovered through their FK to forecasts/signals.
+    "strategy_forecast_outcome_cursor",
     # #2448/#2449 — bounded strategy current-state roots have no FKs. Their
     # signal/deployment children are derived by the planner from roots above.
     "strategy_scan_watermark",

--- a/tests/test_strategy_forecast_outcome_resolution.py
+++ b/tests/test_strategy_forecast_outcome_resolution.py
@@ -1,0 +1,243 @@
+"""Forecast-owned target/stop/horizon outcomes are causal, compact and retryable."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any, cast
+
+import psycopg
+
+from app.services.indicator_series import BarSeries
+from app.services.strategy_forecast_outcome_resolution import (
+    ForecastOutcomeRow,
+    PendingForecast,
+    _read_cursor,
+    _resolve_forecast,
+    _select,
+    _select_round_robin,
+    _store,
+    _write_cursor,
+)
+
+
+def _series(*ranges: tuple[Decimal | None, Decimal | None, Decimal | None]) -> BarSeries:
+    dates = tuple(date(2026, 8, 1) + timedelta(days=index) for index in range(len(ranges)))
+    rows = tuple(
+        {
+            "open": bar_open,
+            "high": high,
+            "low": low,
+            "close": bar_open,
+            "volume": Decimal("1000"),
+        }
+        for bar_open, high, low in ranges
+    )
+    return BarSeries(dates=dates, rows=rows)  # type: ignore[arg-type]
+
+
+def _forecast(series: BarSeries, *, horizon: int = 2) -> PendingForecast:
+    return PendingForecast(
+        forecast_id=7,
+        instrument_id=42,
+        fill_bar_date=series.dates[0],
+        fill_price=Decimal("100"),
+        target_barrier_pct=Decimal("10"),
+        stop_barrier_pct=Decimal("5"),
+        horizon_market_days=horizon,
+    )
+
+
+def test_forecast_target_uses_its_exact_barrier() -> None:
+    series = _series(
+        (Decimal("100"), Decimal("111"), Decimal("99")),
+        (Decimal("100"), Decimal("101"), Decimal("99")),
+    )
+    row = _resolve_forecast(_forecast(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.exit_price, row.gross_return_pct, row.market_bars_held) == (
+        "target_first",
+        Decimal("110"),
+        Decimal("0.1"),
+        0,
+    )
+
+
+def test_forecast_stop_uses_its_exact_barrier() -> None:
+    series = _series(
+        (Decimal("100"), Decimal("101"), Decimal("94")),
+        (Decimal("100"), Decimal("101"), Decimal("99")),
+    )
+    row = _resolve_forecast(_forecast(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.exit_price, row.gross_return_pct) == (
+        "stop_first",
+        Decimal("95"),
+        Decimal("-0.05"),
+    )
+
+
+def test_same_bar_target_and_stop_is_not_scored_in_either_direction() -> None:
+    series = _series(
+        (Decimal("100"), Decimal("111"), Decimal("94")),
+        (Decimal("100"), Decimal("101"), Decimal("99")),
+    )
+    row = _resolve_forecast(_forecast(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.exit_bar_date, row.exit_price, row.gross_return_pct) == (
+        "ambiguous",
+        series.dates[0],
+        None,
+        None,
+    )
+
+
+def test_timeout_exits_at_the_next_open_after_the_horizon() -> None:
+    series = _series(
+        (Decimal("100"), Decimal("101"), Decimal("99")),
+        (Decimal("100"), Decimal("102"), Decimal("98")),
+        (Decimal("103"), Decimal("104"), Decimal("102")),
+    )
+    row = _resolve_forecast(_forecast(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.exit_bar_date, row.exit_price, row.gross_return_pct) == (
+        "timeout",
+        series.dates[2],
+        Decimal("103"),
+        Decimal("0.03"),
+    )
+
+
+def test_immature_horizon_writes_no_terminal_row() -> None:
+    series = _series(
+        (Decimal("100"), Decimal("101"), Decimal("99")),
+        (Decimal("100"), Decimal("102"), Decimal("98")),
+    )
+    assert _resolve_forecast(_forecast(series), series=series, unresolved_breaks=()) is None
+
+
+def test_quarantined_required_range_is_counted_as_unresolved() -> None:
+    series = _series(
+        (Decimal("100"), None, Decimal("99")),
+        (Decimal("100"), Decimal("102"), Decimal("98")),
+    )
+    row = _resolve_forecast(_forecast(series), series=series, unresolved_breaks=())
+    assert row is not None
+    assert (row.outcome, row.reason, row.gross_return_pct) == ("unresolved", "quarantined_bar", None)
+
+
+def test_scale_break_is_terminal_and_never_crosses_price_units() -> None:
+    series = _series(
+        (Decimal("100"), Decimal("101"), Decimal("99")),
+        (Decimal("100"), Decimal("102"), Decimal("98")),
+        (Decimal("10"), Decimal("12"), Decimal("8")),
+    )
+    row = _resolve_forecast(
+        _forecast(series),
+        series=series,
+        unresolved_breaks=(series.dates[2],),
+    )
+    assert row is not None
+    assert (row.outcome, row.reason, row.gross_return_pct) == ("unresolved", "series_break", None)
+
+
+def test_round_robin_wraps_without_repeating(monkeypatch: object) -> None:
+    from pytest import MonkeyPatch
+
+    patcher = cast(MonkeyPatch, monkeypatch)
+    seen: list[tuple[int, int | None, int]] = []
+
+    def select(_conn: object, **kwargs: object) -> list[PendingForecast]:
+        after = cast(int, kwargs["after_forecast_id"])
+        ceiling = cast(int | None, kwargs.get("at_or_before_forecast_id"))
+        limit = cast(int, kwargs["limit"])
+        seen.append((after, ceiling, limit))
+        ids = [8] if after == 7 else [2, 3]
+        return [
+            PendingForecast(
+                forecast_id=forecast_id,
+                instrument_id=42,
+                fill_bar_date=date(2026, 8, 1),
+                fill_price=Decimal("100"),
+                target_barrier_pct=Decimal("10"),
+                stop_barrier_pct=Decimal("5"),
+                horizon_market_days=2,
+            )
+            for forecast_id in ids[:limit]
+        ]
+
+    patcher.setattr("app.services.strategy_forecast_outcome_resolution._select", select)
+    rows = _select_round_robin(cast(psycopg.Connection[object], object()), cursor=7, limit=3)
+    assert [row.forecast_id for row in rows] == [8, 2, 3]
+    assert seen == [(7, None, 3), (0, 7, 2)]
+
+
+def test_cursor_is_one_bounded_mutable_row(ebull_test_conn: psycopg.Connection[object]) -> None:
+    assert _read_cursor(ebull_test_conn) == 0
+    _write_cursor(ebull_test_conn, 10)
+    _write_cursor(ebull_test_conn, 3)
+    assert _read_cursor(ebull_test_conn) == 3
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_forecast_outcome_cursor").fetchone() == (1,)
+
+
+def test_terminal_forecast_is_selected_and_stored_once(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    conn = ebull_test_conn
+    conn.execute("INSERT INTO exchanges (exchange_id,country,asset_class) VALUES ('2553','US','us_equity')")
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,exchange,currency,is_tradable) "
+        "VALUES (2553001,'FOUT','Forecast outcome test','2553','USD',true)"
+    )
+    signal_id = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id,strategy_version,instrument_id,signal_bar_date,signal_kind,
+            verdict,fill_bar_date,fill_price,universe,input_rule_set_versions
+        ) VALUES (
+            'S-FOUT','v1',2553001,'2026-08-01','entry','fired','2026-08-02',100,
+            'survivor_only','{"indicator_series":"rules-v1"}'::jsonb
+        ) RETURNING signal_id
+        """
+    ).fetchone()
+    assert signal_id is not None
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_calibrations (
+            calibration_id,model_version,holdout_start,holdout_end,sample_size,
+            brier_score,calibration_error,passed,evidence_ref
+        ) VALUES ('cal-2553','model-v1','2026-01-01','2026-07-31',100,0.2,0.05,true,'test')
+        """
+    )
+    forecast_id = conn.execute(
+        """
+        INSERT INTO strategy_opportunity_forecasts (
+            signal_id,forecast_policy_version,decided_at,valid_through,side,
+            horizon_market_days,target_barrier_pct,stop_barrier_pct,setup_version,
+            exit_policy_version,calibration_id,target_probability,stop_probability,
+            timeout_probability,target_net_return_pct,stop_net_return_pct,
+            timeout_net_return_pct,expected_duration_hours,uncertainty_penalty_pct,
+            tail_penalty_pct,correlation_penalty_pct,cost_stress_penalty_pct,
+            conservative_net_expectancy_pct,cost_model_id
+        ) VALUES (
+            %s,'policy-v1','2026-08-01 20:00Z','2026-08-03 20:00Z','long',2,10,5,
+            'setup-v1','exit-v1','cal-2553',0.5,0.25,0.25,10,-5,0,24,0,0,0,0,3.75,'cost-v1'
+        ) RETURNING forecast_id
+        """,
+        (int(signal_id[0]),),
+    ).fetchone()
+    assert forecast_id is not None
+    selected = _select(conn, after_forecast_id=0, limit=10)
+    assert [row.forecast_id for row in selected] == [int(forecast_id[0])]
+
+    terminal = ForecastOutcomeRow(
+        forecast_id=int(forecast_id[0]),
+        outcome="target_first",
+        reason=None,
+        exit_bar_date=date(2026, 8, 2),
+        exit_price=Decimal("110"),
+        market_bars_held=0,
+        gross_return_pct=Decimal("0.1"),
+    )
+    assert _store(conn, [terminal]) == 1
+    assert _store(conn, [terminal]) == 0
+    assert _select(conn, after_forecast_id=0, limit=10) == []
+    assert conn.execute("SELECT count(*) FROM strategy_opportunity_forecast_outcomes").fetchone() == (1,)

--- a/tests/test_strategy_forecast_outcome_resolution.py
+++ b/tests/test_strategy_forecast_outcome_resolution.py
@@ -90,6 +90,7 @@ def test_same_bar_target_and_stop_is_not_scored_in_either_direction() -> None:
         None,
         None,
     )
+    assert row.reason is None
 
 
 def test_timeout_exits_at_the_next_open_after_the_horizon() -> None:
@@ -228,16 +229,21 @@ def test_terminal_forecast_is_selected_and_stored_once(ebull_test_conn: psycopg.
     selected = _select(conn, after_forecast_id=0, limit=10)
     assert [row.forecast_id for row in selected] == [int(forecast_id[0])]
 
-    terminal = ForecastOutcomeRow(
-        forecast_id=int(forecast_id[0]),
-        outcome="target_first",
-        reason=None,
-        exit_bar_date=date(2026, 8, 2),
-        exit_price=Decimal("110"),
-        market_bars_held=0,
-        gross_return_pct=Decimal("0.1"),
+    outcomes = (
+        ForecastOutcomeRow(
+            int(forecast_id[0]), "target_first", None, date(2026, 8, 2), Decimal("110"), 0, Decimal("0.1")
+        ),
+        ForecastOutcomeRow(
+            int(forecast_id[0]), "stop_first", None, date(2026, 8, 2), Decimal("95"), 0, Decimal("-0.05")
+        ),
+        ForecastOutcomeRow(int(forecast_id[0]), "timeout", None, date(2026, 8, 4), Decimal("103"), 2, Decimal("0.03")),
+        ForecastOutcomeRow(int(forecast_id[0]), "ambiguous", None, date(2026, 8, 2), None, 0, None),
+        ForecastOutcomeRow(int(forecast_id[0]), "unresolved", "series_break", None, None, None, None),
     )
-    assert _store(conn, [terminal]) == 1
-    assert _store(conn, [terminal]) == 0
+    for terminal in outcomes:
+        assert _store(conn, [terminal]) == 1
+        assert _store(conn, [terminal]) == 0
+        conn.execute("DELETE FROM strategy_opportunity_forecast_outcomes WHERE forecast_id=%s", (forecast_id[0],))
+    assert _store(conn, [outcomes[0]]) == 1
     assert _select(conn, after_forecast_id=0, limit=10) == []
     assert conn.execute("SELECT count(*) FROM strategy_opportunity_forecast_outcomes").fetchone() == (1,)


### PR DESCRIPTION
## Outcome

Adds the compact prospective evidence loop required to verify whether each ranked opportunity forecast actually hit its own target, stop, or timeout after firing.

- resolves forecast-owned target, stop, and horizon with existing causal daily OHLC rules
- records one immutable terminal row per forecast, resolver, and input version
- leaves immature windows absent and retryable through a bounded round-robin cursor
- counts ambiguous, quarantined, and price-scale-break evidence without inventing returns
- runs in the existing daily strategy outcome job
- drops a redundant index so storage remains compact
- documents that observed gross path return is not net P&L or capital authority

## Validation

- full pre-push gate green twice
- focused resolver, scheduler registration, and PostgreSQL idempotency tests green
- dev DB migrations applied with matching hashes
- dev resolver dry run selected zero and wrote zero because there are no current forecasts; no synthetic backfill

Closes #2553