### PR TITLE
Gate strategy capital on prospective forecast skill

### DIFF
--- a/app/services/strategy_forecast_assessment.py
+++ b/app/services/strategy_forecast_assessment.py
@@ -1,0 +1,548 @@
+"""Recent prospective calibration and drift assessment for opportunity forecasts.
+
+The score is deliberately about forecast honesty, not trading profitability.
+Resolved target/stop/timeout paths receive a normalized multiclass Brier score
+and a classwise adaptive-bin calibration error. Ambiguous, unresolved and
+pending paths remain explicit rates and never acquire invented labels.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from decimal import ROUND_HALF_EVEN, Decimal
+from typing import Any, Final, Literal
+
+import psycopg
+
+from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION
+from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
+
+logger = logging.getLogger(__name__)
+
+OutcomeClass = Literal["target_first", "stop_first", "timeout"]
+_CLASSES: Final[tuple[OutcomeClass, ...]] = ("target_first", "stop_first", "timeout")
+_METRIC_QUANTUM: Final = Decimal("0.00000001")
+
+
+class ForecastAssessmentError(ValueError):
+    """The proposed policy or evidence is internally inconsistent."""
+
+
+@dataclass(frozen=True)
+class ForecastAssessmentPolicy:
+    policy_id: str
+    effective_from: datetime
+    recent_window_days: int
+    minimum_resolved_forecasts: int
+    adaptive_calibration_bins: int
+    max_normalized_brier_score: Decimal
+    min_brier_skill_score: Decimal
+    max_classwise_calibration_error: Decimal
+    max_ambiguous_rate: Decimal
+    max_unresolved_rate: Decimal
+    max_pending_rate: Decimal
+    max_assessment_age_days: int
+    evidence_ref: str
+
+
+@dataclass(frozen=True)
+class ForecastObservation:
+    forecast_id: int
+    target_probability: Decimal
+    stop_probability: Decimal
+    timeout_probability: Decimal
+    outcome: OutcomeClass | None
+    terminal_state: Literal["resolved", "ambiguous", "unresolved", "pending"]
+    outcome_id: int | None = None
+
+    def __post_init__(self) -> None:
+        probabilities = self.probabilities
+        if any(not value.is_finite() or not Decimal("0") <= value <= Decimal("1") for value in probabilities):
+            raise ForecastAssessmentError("forecast probabilities must be finite and between zero and one")
+        if abs(sum(probabilities, Decimal("0")) - Decimal("1")) > Decimal("0.000001"):
+            raise ForecastAssessmentError("forecast probabilities must sum to one")
+        if (self.terminal_state == "resolved") != (self.outcome is not None):
+            raise ForecastAssessmentError("only resolved observations carry a scored outcome class")
+
+    @property
+    def probabilities(self) -> tuple[Decimal, Decimal, Decimal]:
+        return self.target_probability, self.stop_probability, self.timeout_probability
+
+
+@dataclass(frozen=True)
+class ForecastScope:
+    forecast_policy_version: str
+    model_version: str
+    calibration_id: str
+    setup_version: str
+    exit_policy_version: str
+
+
+@dataclass(frozen=True)
+class ForecastAssessment:
+    scope: ForecastScope
+    window_start: date
+    window_end: date
+    evidence_hash: str
+    total_forecasts: int
+    resolved_forecasts: int
+    target_first_count: int
+    stop_first_count: int
+    timeout_count: int
+    ambiguous_count: int
+    unresolved_count: int
+    pending_count: int
+    normalized_brier_score: Decimal | None
+    baseline_normalized_brier_score: Decimal | None
+    brier_skill_score: Decimal | None
+    max_classwise_calibration_error: Decimal | None
+    ambiguous_rate: Decimal
+    unresolved_rate: Decimal
+    pending_rate: Decimal
+    passed: bool
+    reason_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ForecastAssessmentRunReport:
+    policy_id: str | None
+    scopes_selected: int = 0
+    evidence_rows_written: int = 0
+    current_rows_refreshed: int = 0
+    passed_scopes: int = 0
+
+
+def _validate_policy(policy: ForecastAssessmentPolicy) -> None:
+    if not policy.policy_id.strip() or not policy.evidence_ref.strip():
+        raise ForecastAssessmentError("policy_id and evidence_ref must be non-empty")
+    if policy.effective_from.tzinfo is None:
+        raise ForecastAssessmentError("effective_from must be timezone-aware")
+    if not 20 <= policy.recent_window_days <= 365:
+        raise ForecastAssessmentError("recent_window_days must be between 20 and 365")
+    if policy.minimum_resolved_forecasts < 30:
+        raise ForecastAssessmentError("minimum_resolved_forecasts must be at least 30")
+    if not 2 <= policy.adaptive_calibration_bins <= 20:
+        raise ForecastAssessmentError("adaptive_calibration_bins must be between 2 and 20")
+    for field, value in (
+        ("max_normalized_brier_score", policy.max_normalized_brier_score),
+        ("max_classwise_calibration_error", policy.max_classwise_calibration_error),
+        ("max_ambiguous_rate", policy.max_ambiguous_rate),
+        ("max_unresolved_rate", policy.max_unresolved_rate),
+        ("max_pending_rate", policy.max_pending_rate),
+    ):
+        if not value.is_finite() or not Decimal("0") <= value <= Decimal("1"):
+            raise ForecastAssessmentError(f"{field} must be finite and between zero and one")
+    if not policy.min_brier_skill_score.is_finite() or not Decimal("0") < policy.min_brier_skill_score <= 1:
+        raise ForecastAssessmentError("min_brier_skill_score must be finite, positive and at most one")
+    if not 1 <= policy.max_assessment_age_days <= 7:
+        raise ForecastAssessmentError("max_assessment_age_days must be between one and seven")
+
+
+def register_assessment_policy(conn: psycopg.Connection[Any], policy: ForecastAssessmentPolicy) -> None:
+    """Register immutable thresholds; there is intentionally no seeded default."""
+    _validate_policy(policy)
+    row = conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_policies (
+            policy_id,effective_from,recent_window_days,minimum_resolved_forecasts,
+            adaptive_calibration_bins,max_normalized_brier_score,
+            min_brier_skill_score,max_classwise_calibration_error,max_ambiguous_rate,max_unresolved_rate,
+            max_pending_rate,max_assessment_age_days,evidence_ref
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ON CONFLICT (policy_id) DO NOTHING RETURNING policy_id
+        """,
+        (
+            policy.policy_id,
+            policy.effective_from,
+            policy.recent_window_days,
+            policy.minimum_resolved_forecasts,
+            policy.adaptive_calibration_bins,
+            policy.max_normalized_brier_score,
+            policy.min_brier_skill_score,
+            policy.max_classwise_calibration_error,
+            policy.max_ambiguous_rate,
+            policy.max_unresolved_rate,
+            policy.max_pending_rate,
+            policy.max_assessment_age_days,
+            policy.evidence_ref,
+        ),
+    ).fetchone()
+    if row is None:
+        raise ForecastAssessmentError("policy_id already exists and is immutable")
+
+
+def _normalized_brier(observations: Sequence[ForecastObservation]) -> Decimal:
+    error = Decimal("0")
+    for observation in observations:
+        assert observation.outcome is not None
+        for class_name, probability in zip(_CLASSES, observation.probabilities, strict=True):
+            actual = Decimal("1") if class_name == observation.outcome else Decimal("0")
+            error += (probability - actual) ** 2
+    return error / (Decimal("2") * len(observations))
+
+
+def _baseline_normalized_brier(observations: Sequence[ForecastObservation]) -> Decimal:
+    count = Decimal(len(observations))
+    frequencies = tuple(
+        Decimal(sum(item.outcome == class_name for item in observations)) / count for class_name in _CLASSES
+    )
+    error = Decimal("0")
+    for observation in observations:
+        assert observation.outcome is not None
+        for class_name, probability in zip(_CLASSES, frequencies, strict=True):
+            actual = Decimal("1") if class_name == observation.outcome else Decimal("0")
+            error += (probability - actual) ** 2
+    return error / (Decimal("2") * len(observations))
+
+
+def _adaptive_classwise_calibration_error(observations: Sequence[ForecastObservation], *, bins: int) -> Decimal:
+    """Maximum classwise ECE using deterministic equal-frequency bins."""
+    class_errors: list[Decimal] = []
+    count = len(observations)
+    for class_index, class_name in enumerate(_CLASSES):
+        ordered = sorted(observations, key=lambda item: (item.probabilities[class_index], item.forecast_id))
+        calibration_error = Decimal("0")
+        for bin_index in range(min(bins, count)):
+            start = bin_index * count // min(bins, count)
+            end = (bin_index + 1) * count // min(bins, count)
+            bucket = ordered[start:end]
+            if not bucket:
+                continue
+            mean_probability = sum((item.probabilities[class_index] for item in bucket), Decimal("0")) / len(bucket)
+            observed_rate = sum((item.outcome == class_name for item in bucket), 0) / Decimal(len(bucket))
+            calibration_error += Decimal(len(bucket)) / count * abs(mean_probability - observed_rate)
+        class_errors.append(calibration_error)
+    return max(class_errors)
+
+
+def _evidence_hash(observations: Sequence[ForecastObservation]) -> str:
+    payload = [
+        (
+            item.forecast_id,
+            item.outcome_id,
+            item.terminal_state,
+            item.outcome,
+            *(str(value) for value in item.probabilities),
+        )
+        for item in sorted(observations, key=lambda value: value.forecast_id)
+    ]
+    return hashlib.sha256(json.dumps(payload, separators=(",", ":")).encode()).hexdigest()
+
+
+def calculate_assessment(
+    *,
+    scope: ForecastScope,
+    observations: Sequence[ForecastObservation],
+    policy: ForecastAssessmentPolicy,
+    window_start: date,
+    window_end: date,
+) -> ForecastAssessment:
+    _validate_policy(policy)
+    if window_end < window_start:
+        raise ForecastAssessmentError("window_end must not precede window_start")
+    resolved = [item for item in observations if item.terminal_state == "resolved"]
+    total = len(observations)
+    counts = {class_name: sum(item.outcome == class_name for item in resolved) for class_name in _CLASSES}
+    ambiguous = sum(item.terminal_state == "ambiguous" for item in observations)
+    unresolved = sum(item.terminal_state == "unresolved" for item in observations)
+    pending = sum(item.terminal_state == "pending" for item in observations)
+    denominator = Decimal(total) if total else Decimal("1")
+    ambiguous_rate = (Decimal(ambiguous) / denominator).quantize(_METRIC_QUANTUM, rounding=ROUND_HALF_EVEN)
+    unresolved_rate = (Decimal(unresolved) / denominator).quantize(_METRIC_QUANTUM, rounding=ROUND_HALF_EVEN)
+    pending_rate = (Decimal(pending) / denominator).quantize(_METRIC_QUANTUM, rounding=ROUND_HALF_EVEN)
+    brier = _normalized_brier(resolved).quantize(_METRIC_QUANTUM, rounding=ROUND_HALF_EVEN) if resolved else None
+    baseline_brier = (
+        _baseline_normalized_brier(resolved).quantize(_METRIC_QUANTUM, rounding=ROUND_HALF_EVEN) if resolved else None
+    )
+    brier_skill = (
+        (Decimal("1") - brier / baseline_brier).quantize(_METRIC_QUANTUM, rounding=ROUND_HALF_EVEN)
+        if brier is not None and baseline_brier is not None and baseline_brier > 0
+        else None
+    )
+    calibration_error = (
+        _adaptive_classwise_calibration_error(resolved, bins=policy.adaptive_calibration_bins).quantize(
+            _METRIC_QUANTUM, rounding=ROUND_HALF_EVEN
+        )
+        if resolved
+        else None
+    )
+    reasons: list[str] = []
+    if len(resolved) < policy.minimum_resolved_forecasts:
+        reasons.append("insufficient_resolved_forecasts")
+    if brier is not None and brier > policy.max_normalized_brier_score:
+        reasons.append("normalized_brier_score_high")
+    if resolved and brier_skill is None:
+        reasons.append("brier_baseline_uninformative")
+    elif brier_skill is not None and brier_skill < policy.min_brier_skill_score:
+        reasons.append("brier_skill_below_policy")
+    if calibration_error is not None and calibration_error > policy.max_classwise_calibration_error:
+        reasons.append("classwise_calibration_error_high")
+    if ambiguous_rate > policy.max_ambiguous_rate:
+        reasons.append("ambiguous_rate_high")
+    if unresolved_rate > policy.max_unresolved_rate:
+        reasons.append("unresolved_rate_high")
+    if pending_rate > policy.max_pending_rate:
+        reasons.append("pending_rate_high")
+    return ForecastAssessment(
+        scope=scope,
+        window_start=window_start,
+        window_end=window_end,
+        evidence_hash=_evidence_hash(observations),
+        total_forecasts=total,
+        resolved_forecasts=len(resolved),
+        target_first_count=counts["target_first"],
+        stop_first_count=counts["stop_first"],
+        timeout_count=counts["timeout"],
+        ambiguous_count=ambiguous,
+        unresolved_count=unresolved,
+        pending_count=pending,
+        normalized_brier_score=brier,
+        baseline_normalized_brier_score=baseline_brier,
+        brier_skill_score=brier_skill,
+        max_classwise_calibration_error=calibration_error,
+        ambiguous_rate=ambiguous_rate,
+        unresolved_rate=unresolved_rate,
+        pending_rate=pending_rate,
+        passed=not reasons,
+        reason_codes=tuple(reasons),
+    )
+
+
+def _current_policy(conn: psycopg.Connection[Any], *, now: datetime) -> ForecastAssessmentPolicy | None:
+    row = conn.execute(
+        """
+        SELECT policy_id,effective_from,recent_window_days,minimum_resolved_forecasts,
+               adaptive_calibration_bins,max_normalized_brier_score,
+               min_brier_skill_score,max_classwise_calibration_error,max_ambiguous_rate,max_unresolved_rate,
+               max_pending_rate,max_assessment_age_days,evidence_ref
+        FROM strategy_forecast_assessment_policies
+        WHERE effective_from <= %s
+        ORDER BY effective_from DESC LIMIT 1
+        """,
+        (now,),
+    ).fetchone()
+    return None if row is None else ForecastAssessmentPolicy(*row)
+
+
+def _load_scopes(
+    conn: psycopg.Connection[Any], *, window_start: date, window_end: date
+) -> Mapping[ForecastScope, tuple[ForecastObservation, ...]]:
+    rows = conn.execute(
+        """
+        SELECT f.forecast_id,f.forecast_policy_version,c.model_version,c.calibration_id,f.setup_version,
+               f.exit_policy_version,f.target_probability,f.stop_probability,
+               f.timeout_probability,o.forecast_outcome_id,o.outcome
+        FROM strategy_opportunity_forecasts f
+        JOIN strategy_forecast_calibrations c ON c.calibration_id=f.calibration_id
+        LEFT JOIN strategy_opportunity_forecast_outcomes o
+          ON o.forecast_id=f.forecast_id
+         AND o.resolver_version=%s AND o.input_rule_set_version=%s
+        WHERE f.forecast_policy_version=%s
+          AND f.decided_at::date BETWEEN %s AND %s
+        ORDER BY f.forecast_id
+        """,
+        (RESOLVER_VERSION, QUARANTINE_RULE_SET_VERSION, FORECAST_POLICY_VERSION, window_start, window_end),
+    ).fetchall()
+    grouped: dict[ForecastScope, list[ForecastObservation]] = {}
+    for row in rows:
+        scope = ForecastScope(str(row[1]), str(row[2]), str(row[3]), str(row[4]), str(row[5]))
+        stored_outcome = row[10]
+        if stored_outcome in _CLASSES:
+            terminal_state: Literal["resolved", "ambiguous", "unresolved", "pending"] = "resolved"
+            outcome: OutcomeClass | None = stored_outcome
+        elif stored_outcome == "ambiguous":
+            terminal_state, outcome = "ambiguous", None
+        elif stored_outcome == "unresolved":
+            terminal_state, outcome = "unresolved", None
+        else:
+            terminal_state, outcome = "pending", None
+        grouped.setdefault(scope, []).append(
+            ForecastObservation(
+                forecast_id=int(row[0]),
+                target_probability=Decimal(row[6]),
+                stop_probability=Decimal(row[7]),
+                timeout_probability=Decimal(row[8]),
+                outcome_id=int(row[9]) if row[9] is not None else None,
+                outcome=outcome,
+                terminal_state=terminal_state,
+            )
+        )
+    return {scope: tuple(items) for scope, items in grouped.items()}
+
+
+def _store_assessment(
+    conn: psycopg.Connection[Any],
+    *,
+    policy: ForecastAssessmentPolicy,
+    assessment: ForecastAssessment,
+    checked_at: datetime,
+) -> tuple[int, bool]:
+    scope = assessment.scope
+    params = (
+        policy.policy_id,
+        scope.forecast_policy_version,
+        scope.model_version,
+        scope.calibration_id,
+        scope.setup_version,
+        scope.exit_policy_version,
+        RESOLVER_VERSION,
+        QUARANTINE_RULE_SET_VERSION,
+        assessment.window_start,
+        assessment.window_end,
+        assessment.evidence_hash,
+        assessment.total_forecasts,
+        assessment.resolved_forecasts,
+        assessment.target_first_count,
+        assessment.stop_first_count,
+        assessment.timeout_count,
+        assessment.ambiguous_count,
+        assessment.unresolved_count,
+        assessment.pending_count,
+        assessment.normalized_brier_score,
+        assessment.baseline_normalized_brier_score,
+        assessment.brier_skill_score,
+        assessment.max_classwise_calibration_error,
+        assessment.ambiguous_rate,
+        assessment.unresolved_rate,
+        assessment.pending_rate,
+        assessment.passed,
+        json.dumps(assessment.reason_codes),
+    )
+    row = conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessments (
+            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            resolver_version,input_rule_set_version,window_start,window_end,evidence_hash,
+            total_forecasts,resolved_forecasts,target_first_count,stop_first_count,timeout_count,
+            ambiguous_count,unresolved_count,pending_count,normalized_brier_score,
+            baseline_normalized_brier_score,brier_skill_score,
+            max_classwise_calibration_error,ambiguous_rate,unresolved_rate,pending_rate,passed,reason_codes
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb)
+        ON CONFLICT (
+            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            resolver_version,input_rule_set_version,evidence_hash
+        ) DO NOTHING RETURNING assessment_id
+        """,
+        params,
+    ).fetchone()
+    inserted = row is not None
+    if row is None:
+        row = conn.execute(
+            """
+            SELECT assessment_id FROM strategy_forecast_assessments
+            WHERE policy_id=%s AND forecast_policy_version=%s AND model_version=%s AND calibration_id=%s
+              AND setup_version=%s AND exit_policy_version=%s AND resolver_version=%s
+              AND input_rule_set_version=%s AND evidence_hash=%s
+            """,
+            (
+                policy.policy_id,
+                scope.forecast_policy_version,
+                scope.model_version,
+                scope.calibration_id,
+                scope.setup_version,
+                scope.exit_policy_version,
+                RESOLVER_VERSION,
+                QUARANTINE_RULE_SET_VERSION,
+                assessment.evidence_hash,
+            ),
+        ).fetchone()
+        assert row is not None
+    assessment_id = int(row[0])
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_current (
+            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            resolver_version,input_rule_set_version,assessment_id,checked_at
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ON CONFLICT (
+            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            resolver_version,input_rule_set_version
+        ) DO UPDATE SET assessment_id=EXCLUDED.assessment_id,checked_at=EXCLUDED.checked_at
+        """,
+        (
+            policy.policy_id,
+            scope.forecast_policy_version,
+            scope.model_version,
+            scope.calibration_id,
+            scope.setup_version,
+            scope.exit_policy_version,
+            RESOLVER_VERSION,
+            QUARANTINE_RULE_SET_VERSION,
+            assessment_id,
+            checked_at,
+        ),
+    )
+    return assessment_id, inserted
+
+
+def run_forecast_assessments(
+    conn: psycopg.Connection[Any], *, now: datetime | None = None
+) -> ForecastAssessmentRunReport:
+    if not conn.autocommit:
+        raise ForecastAssessmentError("run_forecast_assessments needs an autocommit connection")
+    observed_at = now or datetime.now(UTC)
+    if observed_at.tzinfo is None:
+        raise ForecastAssessmentError("assessment time must be timezone-aware")
+    policy = _current_policy(conn, now=observed_at)
+    if policy is None:
+        return ForecastAssessmentRunReport(policy_id=None)
+    window_end = observed_at.date()
+    window_start = window_end - timedelta(days=policy.recent_window_days - 1)
+    grouped = _load_scopes(conn, window_start=window_start, window_end=window_end)
+    written = 0
+    passed = 0
+    with conn.transaction():
+        for scope, observations in sorted(
+            grouped.items(),
+            key=lambda item: (
+                item[0].model_version,
+                item[0].calibration_id,
+                item[0].setup_version,
+                item[0].exit_policy_version,
+            ),
+        ):
+            assessment = calculate_assessment(
+                scope=scope,
+                observations=observations,
+                policy=policy,
+                window_start=window_start,
+                window_end=window_end,
+            )
+            _, inserted = _store_assessment(conn, policy=policy, assessment=assessment, checked_at=observed_at)
+            written += inserted
+            passed += assessment.passed
+    report = ForecastAssessmentRunReport(
+        policy_id=policy.policy_id,
+        scopes_selected=len(grouped),
+        evidence_rows_written=written,
+        current_rows_refreshed=len(grouped),
+        passed_scopes=passed,
+    )
+    logger.info(
+        "strategy_forecast_assessment: policy=%s scopes=%d evidence_written=%d refreshed=%d passed=%d",
+        report.policy_id,
+        report.scopes_selected,
+        report.evidence_rows_written,
+        report.current_rows_refreshed,
+        report.passed_scopes,
+    )
+    return report
+
+
+__all__ = [
+    "ForecastAssessment",
+    "ForecastAssessmentError",
+    "ForecastAssessmentPolicy",
+    "ForecastAssessmentRunReport",
+    "ForecastObservation",
+    "ForecastScope",
+    "calculate_assessment",
+    "register_assessment_policy",
+    "run_forecast_assessments",
+]

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -32,6 +32,7 @@ from app.providers.broker import (
 )
 from app.services.cost_model import COST_MODEL_ID
 from app.services.market_calendar import us_market_status
+from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
 from app.services.runtime_config import RuntimeConfigCorrupt, get_runtime_config
 from app.services.strategy_control_plane import (
     PAPER_ALLOCATOR_ADVISORY_LOCK,
@@ -41,6 +42,7 @@ from app.services.strategy_control_plane import (
     link_strategy_order,
     registered_strategy_purpose,
 )
+from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
 from app.services.strategy_monitoring import load_paper_realised_pnl
 from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
 from app.services.strategy_opportunity_ranker import RANKING_POLICY_VERSION
@@ -242,7 +244,13 @@ def _load_intent(
                    forecast.conservative_net_expectancy_pct AS forecast_conservative_expectancy,
                    forecast.cost_model_id AS forecast_cost_model_id,
                    calibration.passed AS calibration_passed,
+                   calibration.model_version AS calibration_model_version,
                    calibration.holdout_end AS calibration_holdout_end,
+                   assessment_policy.policy_id AS assessment_policy_id,
+                   assessment_policy.max_assessment_age_days,
+                   current_assessment.checked_at AS prospective_assessment_checked_at,
+                   prospective_assessment.assessment_id AS prospective_assessment_id,
+                   prospective_assessment.passed AS prospective_assessment_passed,
                    ranking.ranking_member_id,ranking.selected AS ranking_selected,
                    ranking_batch.ranking_policy_version,
                    ranking_batch.strategy_paper_pool_event_id AS ranking_pool_event_id
@@ -299,13 +307,38 @@ def _load_intent(
             LEFT JOIN strategy_opportunity_forecasts forecast ON forecast.signal_id=s.signal_id
             LEFT JOIN strategy_forecast_calibrations calibration
               ON calibration.calibration_id=forecast.calibration_id
+            LEFT JOIN LATERAL (
+                SELECT policy_id,max_assessment_age_days
+                FROM strategy_forecast_assessment_policies
+                WHERE effective_from <= %s
+                ORDER BY effective_from DESC LIMIT 1
+            ) assessment_policy ON true
+            LEFT JOIN strategy_forecast_assessment_current current_assessment
+             ON current_assessment.policy_id=assessment_policy.policy_id
+             AND current_assessment.forecast_policy_version=forecast.forecast_policy_version
+             AND current_assessment.model_version=calibration.model_version
+             AND current_assessment.calibration_id=calibration.calibration_id
+             AND current_assessment.setup_version=forecast.setup_version
+             AND current_assessment.exit_policy_version=forecast.exit_policy_version
+             AND current_assessment.resolver_version=%s
+             AND current_assessment.input_rule_set_version=%s
+            LEFT JOIN strategy_forecast_assessments prospective_assessment
+              ON prospective_assessment.assessment_id=current_assessment.assessment_id
+             AND prospective_assessment.policy_id=current_assessment.policy_id
+             AND prospective_assessment.forecast_policy_version=current_assessment.forecast_policy_version
+             AND prospective_assessment.model_version=current_assessment.model_version
+             AND prospective_assessment.calibration_id=current_assessment.calibration_id
+             AND prospective_assessment.setup_version=current_assessment.setup_version
+             AND prospective_assessment.exit_policy_version=current_assessment.exit_policy_version
+             AND prospective_assessment.resolver_version=current_assessment.resolver_version
+             AND prospective_assessment.input_rule_set_version=current_assessment.input_rule_set_version
             LEFT JOIN strategy_opportunity_ranking_members ranking
               ON ranking.ranking_member_id=%s AND ranking.forecast_id=forecast.forecast_id
             LEFT JOIN strategy_opportunity_ranking_batches ranking_batch
               ON ranking_batch.ranking_batch_id=ranking.ranking_batch_id
             WHERE s.signal_id = %s AND s.signal_kind = 'entry' AND s.verdict = 'fired'
             """,
-            (ranking_member_id, signal_id),
+            (now, FORECAST_OUTCOME_RESOLVER_VERSION, QUARANTINE_RULE_SET_VERSION, ranking_member_id, signal_id),
         )
         row = cur.fetchone()
     if row is None:
@@ -337,6 +370,9 @@ def _load_intent(
         (row["forecast_id"] is not None, "opportunity_forecast_missing"),
         (row["forecast_policy_version"] == FORECAST_POLICY_VERSION, "opportunity_forecast_policy_stale"),
         (bool(row["calibration_passed"]), "opportunity_calibration_not_passed"),
+        (row["assessment_policy_id"] is not None, "opportunity_assessment_policy_missing"),
+        (row["prospective_assessment_id"] is not None, "opportunity_assessment_missing"),
+        (bool(row["prospective_assessment_passed"]), "opportunity_assessment_not_passed"),
         (row["forecast_cost_model_id"] == COST_MODEL_ID, "opportunity_forecast_cost_model_stale"),
         (
             row["forecast_target_barrier_pct"] is not None
@@ -403,6 +439,12 @@ def _load_intent(
         or cast(date, row["calibration_holdout_end"]) >= forecast_decided_at.date()
     ):
         return None, "opportunity_calibration_knowledge_time_invalid"
+    if row["prospective_assessment_checked_at"] is None or not _age_ok(
+        cast(datetime, row["prospective_assessment_checked_at"]),
+        now=now,
+        max_seconds=int(row["max_assessment_age_days"]) * 86_400,
+    ):
+        return None, "opportunity_assessment_stale"
     if not _session_is_open(now):
         return None, "market_session_closed"
     return _Intent(

--- a/app/services/strategy_paper_runtime.py
+++ b/app/services/strategy_paper_runtime.py
@@ -22,6 +22,8 @@ from psycopg.pq import TransactionStatus
 from app.providers.broker import BrokerProvider
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
+from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
 from app.services.strategy_opportunity_ranker import (
@@ -66,6 +68,35 @@ def _load_ranked_opportunities(
             JOIN strategy_opportunity_forecasts f ON f.signal_id=s.signal_id
             JOIN strategy_forecast_calibrations c ON c.calibration_id=f.calibration_id
             JOIN LATERAL (
+              SELECT policy_id,max_assessment_age_days
+              FROM strategy_forecast_assessment_policies
+              WHERE effective_from <= %(observed_at)s
+              ORDER BY effective_from DESC LIMIT 1
+            ) assessment_policy ON true
+            JOIN strategy_forecast_assessment_current current_assessment
+             ON current_assessment.policy_id=assessment_policy.policy_id
+             AND current_assessment.forecast_policy_version=f.forecast_policy_version
+             AND current_assessment.model_version=c.model_version
+             AND current_assessment.calibration_id=c.calibration_id
+             AND current_assessment.setup_version=f.setup_version
+             AND current_assessment.exit_policy_version=f.exit_policy_version
+             AND current_assessment.resolver_version=%(outcome_resolver)s
+             AND current_assessment.input_rule_set_version=%(input_rule_set)s
+             AND current_assessment.checked_at >= %(observed_at)s
+                 - assessment_policy.max_assessment_age_days * interval '1 day'
+             AND current_assessment.checked_at <= %(observed_at)s + interval '5 seconds'
+            JOIN strategy_forecast_assessments prospective_assessment
+              ON prospective_assessment.assessment_id=current_assessment.assessment_id
+             AND prospective_assessment.policy_id=current_assessment.policy_id
+             AND prospective_assessment.forecast_policy_version=current_assessment.forecast_policy_version
+             AND prospective_assessment.model_version=current_assessment.model_version
+             AND prospective_assessment.calibration_id=current_assessment.calibration_id
+             AND prospective_assessment.setup_version=current_assessment.setup_version
+             AND prospective_assessment.exit_policy_version=current_assessment.exit_policy_version
+             AND prospective_assessment.resolver_version=current_assessment.resolver_version
+             AND prospective_assessment.input_rule_set_version=current_assessment.input_rule_set_version
+             AND prospective_assessment.passed
+            JOIN LATERAL (
               SELECT max(sp.promoted_at) AS paper_at
               FROM strategy_promotions sp
               WHERE sp.strategy_id=s.strategy_id
@@ -88,6 +119,8 @@ def _load_ranked_opportunities(
                 "forecast_policy": FORECAST_POLICY_VERSION,
                 "cost_model": COST_MODEL_ID,
                 "observed_at": observed_at,
+                "outcome_resolver": FORECAST_OUTCOME_RESOLVER_VERSION,
+                "input_rule_set": QUARANTINE_RULE_SET_VERSION,
             },
         )
         rows = cur.fetchall()

--- a/app/services/strategy_paper_runtime.py
+++ b/app/services/strategy_paper_runtime.py
@@ -84,6 +84,8 @@ def _load_ranked_opportunities(
              AND current_assessment.input_rule_set_version=%(input_rule_set)s
              AND current_assessment.checked_at >= %(observed_at)s
                  - assessment_policy.max_assessment_age_days * interval '1 day'
+             -- Tolerate only scheduler/allocator clock skew inside one cycle;
+             -- this is not permission to consume future assessment evidence.
              AND current_assessment.checked_at <= %(observed_at)s + interval '5 seconds'
             JOIN strategy_forecast_assessments prospective_assessment
               ON prospective_assessment.assessment_id=current_assessment.assessment_id

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -5070,6 +5070,7 @@ def strategy_signal_scan() -> None:
 
 def strategy_outcome_resolution() -> None:
     """Resolve mature forward brackets without persisting immature windows."""
+    from app.services.strategy_forecast_assessment import run_forecast_assessments
     from app.services.strategy_forecast_outcome_resolution import run_forecast_outcome_resolution
     from app.services.strategy_outcome_resolution import run_outcome_resolution
 
@@ -5077,14 +5078,18 @@ def strategy_outcome_resolution() -> None:
         with connect_job(autocommit=True) as conn:
             report = run_outcome_resolution(conn)
             forecast_report = run_forecast_outcome_resolution(conn)
-        tracker.row_count = report.written + forecast_report.written
+            assessment_report = run_forecast_assessments(conn)
+        tracker.row_count = report.written + forecast_report.written + assessment_report.evidence_rows_written
         tracker.note = (
             f"selected={report.selected} written={report.written} "
             f"immature={report.immature} ambiguous={report.ambiguous}; "
             f"forecasts_selected={forecast_report.selected} "
             f"forecasts_written={forecast_report.written} "
             f"forecasts_immature={forecast_report.immature} "
-            f"forecasts_ambiguous={forecast_report.ambiguous}"
+            f"forecasts_ambiguous={forecast_report.ambiguous}; "
+            f"assessment_policy={assessment_report.policy_id or 'missing'} "
+            f"assessment_scopes={assessment_report.scopes_selected} "
+            f"assessment_passed={assessment_report.passed_scopes}"
         )
 
 

--- a/docs/proposals/ta/2026-08-11-prospective-forecast-calibration.md
+++ b/docs/proposals/ta/2026-08-11-prospective-forecast-calibration.md
@@ -1,0 +1,87 @@
+# Prospective forecast calibration and drift authority (#2555)
+
+Status: implemented behind an unseeded immutable policy. No policy means no
+capital authority.
+
+## Question this answers
+
+For forecasts issued recently under one exact model/setup/exit-policy scope,
+did the stated target/stop/timeout probabilities agree with what subsequently
+happened, and are they still better than a no-feature recent base-rate
+forecast?
+
+This is not a profitability score. Path returns remain gross, and broker costs
+remain a separate execution-time contract.
+
+## Frozen mathematics
+
+For resolved observation `i`, probability vector `p_i`, and one-hot outcome
+`y_i`, the normalized three-class Brier score is:
+
+`B = sum_i sum_k (p_ik - y_ik)^2 / (2N)`
+
+The factor of two fixes the three-class score to `[0, 1]`. Brier is a strictly
+proper scoring rule: truthful probabilities minimise expected loss. See
+[Gneiting and Raftery (2007)](https://doi.org/10.1198/016214506000001437).
+
+Absolute error is not sufficient. The same cohort is scored using its
+empirical target/stop/timeout frequencies as a constant no-feature forecast.
+Forecast skill is:
+
+`skill = 1 - model_Brier / base_rate_Brier`
+
+Capital policy must set a strictly positive minimum skill. Equality with a
+no-feature forecast is not useful predictive evidence. A single-class recent cohort
+has a perfect base-rate score of zero; skill is undefined and authority fails
+closed rather than dividing by zero or claiming an easy win.
+
+Calibration error is the maximum classwise expected calibration error across
+target, stop and timeout. Each class uses deterministic equal-frequency
+(adaptive) bins; bin count is part of immutable policy. This choice is explicit
+because ECE conclusions are sensitive to class conditioning and binning, while
+adaptive bins are more stable than fixed-width bins in the empirical study
+[Measuring Calibration in Deep Learning](https://arxiv.org/abs/1904.01685).
+Histogram calibration is sample-inefficient, so minimum sample and bin count
+cannot be treated as decoration; see
+[Verified Uncertainty Calibration](https://arxiv.org/abs/1909.10155).
+
+## Refusals and denominators
+
+Only `target_first`, `stop_first`, and `timeout` enter Brier/calibration scores.
+`ambiguous` and `unresolved` are explicit terminal refusal rates. Forecasts
+without a terminal row are the pending rate. All three use total forecasts in
+the recent decision-time cohort as denominator and each has a preregistered
+maximum.
+
+An assessment passes only when all of these pass:
+
+- minimum resolved sample;
+- maximum normalized Brier score;
+- minimum non-negative Brier skill versus recent class frequencies;
+- maximum classwise adaptive-bin calibration error;
+- maximum ambiguous, unresolved, and pending rates.
+
+There is deliberately no default policy row. Thresholds must be registered
+with an evidence reference and effective time; changing a threshold requires a
+new policy identity.
+
+## Recency, identity, and storage
+
+The cohort is selected by forecast decision date inside the policy's recent
+window and grouped by forecast-policy, calibration model, exact immutable
+calibration record, setup, and exit policy. The calibration ID is part of the
+scope so one recalibration can never authorise another that happens to reuse a
+model label. Outcomes must match the current resolver and quarantine-input
+versions.
+
+Immutable assessment rows are keyed by the exact policy/scope/version tuple and
+a hash of forecast IDs, probabilities, terminal outcome IDs, and states. An
+unchanged daily run reuses that evidence row and updates one bounded current
+pointer. A forecast resolving or entering/leaving the recent cohort changes the
+hash and creates one new evidence row. No bars, feature vectors, polling rows,
+or per-instrument activity feed are copied.
+
+Ranking and execution both require the latest effective policy's matching
+assessment to pass and its current pointer to remain within the policy's age
+limit. Missing policy, missing assessment, failed assessment, and stale
+assessment are separate fail-closed reasons before broker access.

--- a/sql/317_strategy_forecast_assessments.sql
+++ b/sql/317_strategy_forecast_assessments.sql
@@ -1,0 +1,93 @@
+-- 317_strategy_forecast_assessments.sql
+--
+-- #2555: preregistered recent prospective probability assessment. Immutable
+-- evidence rows deduplicate unchanged cohorts; one bounded current pointer per
+-- forecast scope can be refreshed without appending scheduler heartbeats.
+
+CREATE TABLE IF NOT EXISTS strategy_forecast_assessment_policies (
+    policy_id                      TEXT PRIMARY KEY CHECK (policy_id <> ''),
+    effective_from                 TIMESTAMPTZ NOT NULL UNIQUE,
+    recent_window_days             INTEGER NOT NULL CHECK (recent_window_days BETWEEN 20 AND 365),
+    minimum_resolved_forecasts     INTEGER NOT NULL CHECK (minimum_resolved_forecasts >= 30),
+    adaptive_calibration_bins      INTEGER NOT NULL CHECK (adaptive_calibration_bins BETWEEN 2 AND 20),
+    max_normalized_brier_score     NUMERIC(12,8) NOT NULL CHECK (max_normalized_brier_score BETWEEN 0 AND 1),
+    max_classwise_calibration_error NUMERIC(12,8) NOT NULL CHECK (max_classwise_calibration_error BETWEEN 0 AND 1),
+    max_ambiguous_rate             NUMERIC(12,8) NOT NULL CHECK (max_ambiguous_rate BETWEEN 0 AND 1),
+    max_unresolved_rate            NUMERIC(12,8) NOT NULL CHECK (max_unresolved_rate BETWEEN 0 AND 1),
+    max_pending_rate               NUMERIC(12,8) NOT NULL CHECK (max_pending_rate BETWEEN 0 AND 1),
+    max_assessment_age_days        INTEGER NOT NULL CHECK (max_assessment_age_days BETWEEN 1 AND 7),
+    evidence_ref                   TEXT NOT NULL CHECK (evidence_ref <> ''),
+    created_at                     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS strategy_forecast_assessments (
+    assessment_id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    policy_id                      TEXT NOT NULL
+        REFERENCES strategy_forecast_assessment_policies(policy_id) ON DELETE RESTRICT,
+    forecast_policy_version        TEXT NOT NULL CHECK (forecast_policy_version <> ''),
+    model_version                  TEXT NOT NULL CHECK (model_version <> ''),
+    setup_version                  TEXT NOT NULL CHECK (setup_version <> ''),
+    exit_policy_version            TEXT NOT NULL CHECK (exit_policy_version <> ''),
+    resolver_version               TEXT NOT NULL CHECK (resolver_version <> ''),
+    input_rule_set_version         TEXT NOT NULL CHECK (input_rule_set_version <> ''),
+    window_start                   DATE NOT NULL,
+    window_end                     DATE NOT NULL CHECK (window_end >= window_start),
+    evidence_hash                  TEXT NOT NULL CHECK (evidence_hash <> ''),
+    total_forecasts                INTEGER NOT NULL CHECK (total_forecasts >= 0),
+    resolved_forecasts             INTEGER NOT NULL CHECK (resolved_forecasts >= 0),
+    target_first_count             INTEGER NOT NULL CHECK (target_first_count >= 0),
+    stop_first_count               INTEGER NOT NULL CHECK (stop_first_count >= 0),
+    timeout_count                  INTEGER NOT NULL CHECK (timeout_count >= 0),
+    ambiguous_count                INTEGER NOT NULL CHECK (ambiguous_count >= 0),
+    unresolved_count               INTEGER NOT NULL CHECK (unresolved_count >= 0),
+    pending_count                  INTEGER NOT NULL CHECK (pending_count >= 0),
+    normalized_brier_score         NUMERIC(12,8) CHECK (normalized_brier_score BETWEEN 0 AND 1),
+    max_classwise_calibration_error NUMERIC(12,8) CHECK (max_classwise_calibration_error BETWEEN 0 AND 1),
+    ambiguous_rate                 NUMERIC(12,8) NOT NULL CHECK (ambiguous_rate BETWEEN 0 AND 1),
+    unresolved_rate                NUMERIC(12,8) NOT NULL CHECK (unresolved_rate BETWEEN 0 AND 1),
+    pending_rate                   NUMERIC(12,8) NOT NULL CHECK (pending_rate BETWEEN 0 AND 1),
+    passed                         BOOLEAN NOT NULL,
+    reason_codes                   JSONB NOT NULL CHECK (jsonb_typeof(reason_codes)='array'),
+    recorded_at                    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (
+        policy_id,forecast_policy_version,model_version,setup_version,
+        exit_policy_version,resolver_version,input_rule_set_version,evidence_hash
+    ),
+    CHECK (resolved_forecasts = target_first_count + stop_first_count + timeout_count),
+    CHECK (total_forecasts = resolved_forecasts + ambiguous_count + unresolved_count + pending_count),
+    CHECK ((resolved_forecasts = 0) = (normalized_brier_score IS NULL)),
+    CHECK ((resolved_forecasts = 0) = (max_classwise_calibration_error IS NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_forecast_assessments_scope
+    ON strategy_forecast_assessments (
+        policy_id,forecast_policy_version,model_version,setup_version,exit_policy_version,
+        resolver_version,input_rule_set_version,assessment_id DESC
+    );
+
+CREATE TABLE IF NOT EXISTS strategy_forecast_assessment_current (
+    policy_id                      TEXT NOT NULL
+        REFERENCES strategy_forecast_assessment_policies(policy_id) ON DELETE RESTRICT,
+    forecast_policy_version        TEXT NOT NULL,
+    model_version                  TEXT NOT NULL,
+    setup_version                  TEXT NOT NULL,
+    exit_policy_version            TEXT NOT NULL,
+    resolver_version               TEXT NOT NULL,
+    input_rule_set_version         TEXT NOT NULL,
+    assessment_id                  BIGINT NOT NULL
+        REFERENCES strategy_forecast_assessments(assessment_id) ON DELETE RESTRICT,
+    checked_at                     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (
+        policy_id,forecast_policy_version,model_version,setup_version,
+        exit_policy_version,resolver_version,input_rule_set_version
+    )
+);
+
+COMMENT ON TABLE strategy_forecast_assessment_policies IS
+    'Immutable operator-preregistered prospective forecast trust thresholds; deliberately has no passing seed default.';
+COMMENT ON TABLE strategy_forecast_assessments IS
+    'Deduplicated recent-cohort probability evidence. Normalized multiclass Brier = sum squared class errors / (2N).';
+COMMENT ON COLUMN strategy_forecast_assessments.max_classwise_calibration_error IS
+    'Maximum adaptive-bin expected calibration error across target, stop and timeout classes.';
+COMMENT ON TABLE strategy_forecast_assessment_current IS
+    'One bounded freshness pointer per exact forecast scope; scheduler checks do not append heartbeat evidence.';

--- a/sql/318_strategy_forecast_brier_skill.sql
+++ b/sql/318_strategy_forecast_brier_skill.sql
@@ -1,0 +1,30 @@
+-- 318_strategy_forecast_brier_skill.sql
+--
+-- #2555 review: absolute probability error is not enough. Capital authority
+-- also requires positive skill against the recent cohort's empirical class
+-- frequencies (the strongest no-feature climatology available for that cohort).
+
+ALTER TABLE strategy_forecast_assessment_policies
+    ADD COLUMN IF NOT EXISTS min_brier_skill_score NUMERIC(12,8) NOT NULL
+        CHECK (min_brier_skill_score BETWEEN 0 AND 1);
+
+ALTER TABLE strategy_forecast_assessments
+    ADD COLUMN IF NOT EXISTS baseline_normalized_brier_score NUMERIC(12,8)
+        CHECK (baseline_normalized_brier_score BETWEEN 0 AND 1),
+    ADD COLUMN IF NOT EXISTS brier_skill_score NUMERIC
+        CHECK (brier_skill_score <= 1);
+
+ALTER TABLE strategy_forecast_assessments
+    ADD CONSTRAINT strategy_forecast_assessment_baseline_shape CHECK (
+        (resolved_forecasts = 0) = (baseline_normalized_brier_score IS NULL)
+        AND (brier_skill_score IS NULL) = (
+            resolved_forecasts = 0 OR baseline_normalized_brier_score = 0
+        )
+    );
+
+COMMENT ON COLUMN strategy_forecast_assessment_policies.min_brier_skill_score IS
+    'Minimum 1 - model normalized Brier / empirical-class-frequency normalized Brier; non-negative by policy.';
+COMMENT ON COLUMN strategy_forecast_assessments.baseline_normalized_brier_score IS
+    'Normalized multiclass Brier of the same recent cohort under its empirical class-frequency forecast.';
+COMMENT ON COLUMN strategy_forecast_assessments.brier_skill_score IS
+    '1 - model score / baseline score. NULL when the recent cohort is single-class and its baseline is perfect.';

--- a/sql/319_strategy_forecast_assessment_calibration_scope.sql
+++ b/sql/319_strategy_forecast_assessment_calibration_scope.sql
@@ -1,0 +1,38 @@
+-- 319_strategy_forecast_assessment_calibration_scope.sql
+--
+-- #2555 review: model_version alone cannot prove that two immutable
+-- calibration records are interchangeable. The feature has no assessment rows
+-- yet, so add the exact calibration identity without inventing a backfill.
+
+ALTER TABLE strategy_forecast_assessments
+    ADD COLUMN IF NOT EXISTS calibration_id TEXT NOT NULL
+        REFERENCES strategy_forecast_calibrations(calibration_id) ON DELETE RESTRICT;
+
+ALTER TABLE strategy_forecast_assessments
+    DROP CONSTRAINT strategy_forecast_assessments_policy_id_forecast_policy_ver_key;
+ALTER TABLE strategy_forecast_assessments
+    ADD CONSTRAINT strategy_forecast_assessments_evidence_unique UNIQUE (
+        policy_id,forecast_policy_version,model_version,calibration_id,setup_version,
+        exit_policy_version,resolver_version,input_rule_set_version,evidence_hash
+    );
+
+DROP INDEX IF EXISTS idx_strategy_forecast_assessments_scope;
+CREATE INDEX idx_strategy_forecast_assessments_scope
+    ON strategy_forecast_assessments (
+        policy_id,forecast_policy_version,model_version,calibration_id,setup_version,
+        exit_policy_version,resolver_version,input_rule_set_version,assessment_id DESC
+    );
+
+ALTER TABLE strategy_forecast_assessment_current
+    ADD COLUMN IF NOT EXISTS calibration_id TEXT NOT NULL
+        REFERENCES strategy_forecast_calibrations(calibration_id) ON DELETE RESTRICT;
+ALTER TABLE strategy_forecast_assessment_current
+    DROP CONSTRAINT strategy_forecast_assessment_current_pkey;
+ALTER TABLE strategy_forecast_assessment_current
+    ADD PRIMARY KEY (
+        policy_id,forecast_policy_version,model_version,calibration_id,setup_version,
+        exit_policy_version,resolver_version,input_rule_set_version
+    );
+
+COMMENT ON COLUMN strategy_forecast_assessments.calibration_id IS
+    'Exact immutable historical calibration evidence used by every forecast in this prospective cohort.';

--- a/sql/320_strategy_forecast_positive_skill_policy.sql
+++ b/sql/320_strategy_forecast_positive_skill_policy.sql
@@ -1,0 +1,12 @@
+-- 320_strategy_forecast_positive_skill_policy.sql
+--
+-- #2555 final challenge: equality with a no-feature base-rate forecast is not
+-- evidence of useful forecasting skill. Require every registered policy to
+-- demand a strictly positive improvement.
+
+ALTER TABLE strategy_forecast_assessment_policies
+    DROP CONSTRAINT strategy_forecast_assessment_polici_min_brier_skill_score_check;
+ALTER TABLE strategy_forecast_assessment_policies
+    ADD CONSTRAINT strategy_forecast_assessment_policy_positive_skill CHECK (
+        min_brier_skill_score > 0 AND min_brier_skill_score <= 1
+    );

--- a/sql/321_strategy_forecast_brier_skill_precision.sql
+++ b/sql/321_strategy_forecast_brier_skill_precision.sql
@@ -1,0 +1,7 @@
+-- 321_strategy_forecast_brier_skill_precision.sql
+--
+-- #2555 review: keep the proper-score skill metric at the same deterministic
+-- storage precision as the Brier and calibration metrics it is derived from.
+
+ALTER TABLE strategy_forecast_assessments
+    ALTER COLUMN brier_skill_score TYPE NUMERIC(12,8);

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -212,6 +212,9 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # reference both it and signals, so those children are derived; the parent
     # itself cannot be discovered from an existing inbound-FK root.
     "strategy_forecast_calibrations",
+    # #2555 — immutable prospective-assessment policy is a standalone root;
+    # assessment evidence and bounded current pointers are FK descendants.
+    "strategy_forecast_assessment_policies",
     # #2553 — the forecast outcome round-robin cursor is standalone. Outcome
     # rows are discovered through their FK to forecasts/signals.
     "strategy_forecast_outcome_cursor",

--- a/tests/test_strategy_forecast_assessment.py
+++ b/tests/test_strategy_forecast_assessment.py
@@ -1,0 +1,268 @@
+"""Recent prospective forecast assessment: proper scores, explicit refusals."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_forecast_assessment import (
+    ForecastAssessmentError,
+    ForecastAssessmentPolicy,
+    ForecastObservation,
+    ForecastScope,
+    calculate_assessment,
+    register_assessment_policy,
+    run_forecast_assessments,
+)
+from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION
+from tests.fixtures.ebull_test_db import test_database_url
+
+_SCOPE = ForecastScope("opportunity-forecast-v1", "model-v1", "calibration-v1", "setup-v1", "exit-v1")
+
+
+def _policy(**overrides: object) -> ForecastAssessmentPolicy:
+    values = {
+        "policy_id": "assessment-policy-v1",
+        "effective_from": datetime(2026, 8, 1, tzinfo=UTC),
+        "recent_window_days": 90,
+        "minimum_resolved_forecasts": 30,
+        "adaptive_calibration_bins": 5,
+        "max_normalized_brier_score": Decimal("0.20"),
+        "min_brier_skill_score": Decimal("0.01"),
+        "max_classwise_calibration_error": Decimal("0.10"),
+        "max_ambiguous_rate": Decimal("0.05"),
+        "max_unresolved_rate": Decimal("0.05"),
+        "max_pending_rate": Decimal("0.20"),
+        "max_assessment_age_days": 2,
+        "evidence_ref": "ticket:2555",
+    }
+    values.update(overrides)
+    return ForecastAssessmentPolicy(**values)  # type: ignore[arg-type]
+
+
+def _observation(
+    forecast_id: int,
+    *,
+    probabilities: tuple[str, str, str] = ("1", "0", "0"),
+    outcome: str | None = "target_first",
+    terminal_state: str = "resolved",
+) -> ForecastObservation:
+    return ForecastObservation(
+        forecast_id=forecast_id,
+        target_probability=Decimal(probabilities[0]),
+        stop_probability=Decimal(probabilities[1]),
+        timeout_probability=Decimal(probabilities[2]),
+        outcome=outcome,  # type: ignore[arg-type]
+        terminal_state=terminal_state,  # type: ignore[arg-type]
+        outcome_id=forecast_id if terminal_state != "pending" else None,
+    )
+
+
+def _calculate(observations: list[ForecastObservation], policy: ForecastAssessmentPolicy | None = None):
+    return calculate_assessment(
+        scope=_SCOPE,
+        observations=observations,
+        policy=policy or _policy(),
+        window_start=date(2026, 5, 14),
+        window_end=date(2026, 8, 11),
+    )
+
+
+def _perfect_observations(count: int) -> list[ForecastObservation]:
+    classes = (
+        (("1", "0", "0"), "target_first"),
+        (("0", "1", "0"), "stop_first"),
+        (("0", "0", "1"), "timeout"),
+    )
+    return [
+        _observation(index, probabilities=classes[(index - 1) % 3][0], outcome=classes[(index - 1) % 3][1])
+        for index in range(1, count + 1)
+    ]
+
+
+def test_perfect_probabilities_pass_a_sufficient_recent_sample() -> None:
+    assessment = _calculate(_perfect_observations(30))
+    assert assessment.passed
+    assert assessment.reason_codes == ()
+    assert assessment.normalized_brier_score == 0
+    assert assessment.baseline_normalized_brier_score is not None
+    assert assessment.baseline_normalized_brier_score.quantize(Decimal("0.00000001")) == Decimal("0.33333333")
+    assert assessment.brier_skill_score == 1
+    assert assessment.max_classwise_calibration_error == 0
+    assert (assessment.resolved_forecasts, assessment.target_first_count) == (30, 10)
+
+
+def test_normalized_multiclass_brier_penalises_confident_wrong_forecasts() -> None:
+    observations = [
+        _observation(
+            index,
+            probabilities=("0.95", "0.05", "0"),
+            outcome="stop_first",
+        )
+        for index in range(1, 31)
+    ]
+    assessment = _calculate(observations)
+    assert assessment.normalized_brier_score == Decimal("0.9025")
+    assert "normalized_brier_score_high" in assessment.reason_codes
+    assert "classwise_calibration_error_high" in assessment.reason_codes
+    assert not assessment.passed
+
+
+def test_small_apparently_perfect_sample_has_no_authority() -> None:
+    assessment = _calculate(_perfect_observations(5))
+    assert assessment.normalized_brier_score == 0
+    assert assessment.reason_codes == ("insufficient_resolved_forecasts",)
+    assert not assessment.passed
+
+
+def test_ambiguous_unresolved_and_pending_are_rates_not_synthetic_classes() -> None:
+    observations = _perfect_observations(30)
+    observations.extend(
+        (
+            _observation(31, outcome=None, terminal_state="ambiguous"),
+            _observation(32, outcome=None, terminal_state="unresolved"),
+            _observation(33, outcome=None, terminal_state="pending"),
+        )
+    )
+    assessment = _calculate(
+        observations,
+        _policy(max_ambiguous_rate=Decimal("0.02"), max_unresolved_rate=Decimal("0.02")),
+    )
+    assert assessment.resolved_forecasts == 30
+    assert assessment.total_forecasts == 33
+    assert assessment.ambiguous_rate == Decimal("0.03030303")
+    assert assessment.unresolved_rate == Decimal("0.03030303")
+    assert assessment.pending_rate == Decimal("0.03030303")
+    assert assessment.reason_codes == ("ambiguous_rate_high", "unresolved_rate_high")
+
+
+def test_evidence_identity_is_order_independent_but_changes_with_resolution() -> None:
+    pending = _observation(2, outcome=None, terminal_state="pending")
+    first = _calculate([_observation(1), pending])
+    reordered = _calculate([pending, _observation(1)])
+    resolved = _calculate([_observation(1), _observation(2)])
+    assert first.evidence_hash == reordered.evidence_hash
+    assert first.evidence_hash != resolved.evidence_hash
+
+
+def test_observation_rejects_probability_or_state_shape_errors() -> None:
+    with pytest.raises(ForecastAssessmentError, match="sum to one"):
+        _observation(1, probabilities=("0.8", "0.3", "0"))
+    with pytest.raises(ForecastAssessmentError, match="only resolved"):
+        _observation(1, outcome="target_first", terminal_state="ambiguous")
+    with pytest.raises(ForecastAssessmentError, match="min_brier_skill_score"):
+        _calculate(_perfect_observations(30), _policy(min_brier_skill_score=Decimal("0")))
+
+
+def test_policy_is_immutable_and_no_policy_means_no_assessment_authority(
+    ebull_test_conn: psycopg.Connection[object],
+) -> None:
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_forecast_assessment_policies").fetchone() == (0,)
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
+        assert run_forecast_assessments(conn, now=datetime(2026, 8, 11, tzinfo=UTC)).policy_id is None
+        register_assessment_policy(conn, _policy())
+        with pytest.raises(ForecastAssessmentError, match="already exists"):
+            register_assessment_policy(conn, _policy(max_pending_rate=Decimal("0.5")))
+        report = run_forecast_assessments(conn, now=datetime(2026, 8, 11, tzinfo=UTC))
+    assert (report.policy_id, report.scopes_selected, report.evidence_rows_written) == (
+        "assessment-policy-v1",
+        0,
+        0,
+    )
+
+
+def test_run_scores_a_real_recent_cohort_once_then_refreshes_only_current_pointer(
+    ebull_test_conn: psycopg.Connection[object],
+) -> None:
+    assert ebull_test_conn.execute("SELECT count(*) FROM strategy_forecast_assessment_policies").fetchone() == (0,)
+    with psycopg.connect(test_database_url(), autocommit=True) as conn:
+        conn.execute("INSERT INTO exchanges (exchange_id,country,asset_class) VALUES ('2555','US','us_equity')")
+        conn.execute(
+            "INSERT INTO instruments (instrument_id,symbol,company_name,exchange,currency,is_tradable) "
+            "VALUES (2555001,'FCAL','Forecast calibration test','2555','USD',true)"
+        )
+        conn.execute(
+            """
+            INSERT INTO strategy_forecast_calibrations (
+                calibration_id,model_version,holdout_start,holdout_end,sample_size,
+                brier_score,calibration_error,passed,evidence_ref
+            ) VALUES ('cal-2555','model-2555','2026-01-01','2026-06-30',100,0.18,0.04,true,'test')
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO strategy_signals (
+                strategy_id,strategy_version,instrument_id,signal_bar_date,signal_kind,
+                verdict,fill_bar_date,fill_price,universe,input_rule_set_versions
+            )
+            SELECT 'S-FCAL','v1',2555001,DATE '2026-07-01'+n,'entry','fired',
+                   DATE '2026-07-02'+n,100,'survivor_only','{"indicator_series":"rules-v1"}'::jsonb
+            FROM generate_series(0,29) n
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO strategy_opportunity_forecasts (
+                signal_id,forecast_policy_version,decided_at,valid_through,side,
+                horizon_market_days,target_barrier_pct,stop_barrier_pct,setup_version,
+                exit_policy_version,calibration_id,target_probability,stop_probability,
+                timeout_probability,target_net_return_pct,stop_net_return_pct,
+                timeout_net_return_pct,expected_duration_hours,uncertainty_penalty_pct,
+                tail_penalty_pct,correlation_penalty_pct,cost_stress_penalty_pct,
+                conservative_net_expectancy_pct,cost_model_id
+            )
+            SELECT signal_id,'opportunity-forecast-v1',signal_bar_date::timestamp + interval '20 hours',
+                   signal_bar_date::timestamp + interval '7 days','long',5,10,5,'setup-2555',
+                   'exit-2555','cal-2555',
+                   CASE WHEN class_no=0 THEN 1 ELSE 0 END,
+                   CASE WHEN class_no=1 THEN 1 ELSE 0 END,
+                   CASE WHEN class_no=2 THEN 1 ELSE 0 END,
+                   4,-2,0,24,0.2,0.1,0.1,0.1,
+                   CASE WHEN class_no=0 THEN 3.5 WHEN class_no=1 THEN -2.5 ELSE -0.5 END,
+                   'cost-v1'
+            FROM (
+                SELECT s.*, (row_number() OVER (ORDER BY signal_id)-1) % 3 AS class_no
+                FROM strategy_signals s WHERE strategy_id='S-FCAL'
+            ) ranked
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO strategy_opportunity_forecast_outcomes (
+                forecast_id,resolver_version,input_rule_set_version,outcome,exit_bar_date,
+                exit_price,market_bars_held,gross_return_pct
+            )
+            SELECT forecast_id,%s,%s,
+                   CASE class_no WHEN 0 THEN 'target_first' WHEN 1 THEN 'stop_first' ELSE 'timeout' END,
+                   s.fill_bar_date,
+                   CASE class_no WHEN 0 THEN 110 WHEN 1 THEN 95 ELSE 100 END,
+                   0,CASE class_no WHEN 0 THEN 0.1 WHEN 1 THEN -0.05 ELSE 0 END
+            FROM (
+                SELECT f.*, (row_number() OVER (ORDER BY forecast_id)-1) %% 3 AS class_no
+                FROM strategy_opportunity_forecasts f
+            ) f
+            JOIN strategy_signals s ON s.signal_id=f.signal_id
+            """,
+            (RESOLVER_VERSION, QUARANTINE_RULE_SET_VERSION),
+        )
+        register_assessment_policy(
+            conn,
+            _policy(),
+        )
+
+        first = run_forecast_assessments(conn, now=datetime(2026, 8, 11, tzinfo=UTC))
+        second = run_forecast_assessments(conn, now=datetime(2026, 8, 12, tzinfo=UTC))
+
+        assert (first.scopes_selected, first.evidence_rows_written, first.passed_scopes) == (1, 1, 1)
+        assert (second.scopes_selected, second.evidence_rows_written, second.current_rows_refreshed) == (1, 0, 1)
+        assert conn.execute("SELECT count(*) FROM strategy_forecast_assessments").fetchone() == (1,)
+        assert conn.execute(
+            "SELECT resolved_forecasts,normalized_brier_score,passed FROM strategy_forecast_assessments"
+        ).fetchone() == (30, Decimal("0E-8"), True)
+        assert conn.execute("SELECT checked_at FROM strategy_forecast_assessment_current").fetchone() == (
+            datetime(2026, 8, 12, tzinfo=UTC),
+        )

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -28,6 +28,7 @@ from app.providers.broker import (
     BrokerWhatIfCostResponse,
 )
 from app.services.cost_model import COST_MODEL_ID
+from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
 from app.services.result_ledger import store_holdout_result
 from app.services.strategy_control_plane import (
     configure_deployment,
@@ -37,8 +38,10 @@ from app.services.strategy_control_plane import (
     decide_funding,
     link_strategy_order,
 )
+from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_opportunity_forecast import (
+    FORECAST_POLICY_VERSION,
     ForecastCalibration,
     OpportunityForecast,
     OpportunityForecastError,
@@ -64,6 +67,66 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strat
 
 _NOW = datetime(2026, 8, 7, 15, 0, tzinfo=UTC)  # Friday 11:00 New York
 _REQUEST_ID = UUID("1c94300c-90aa-4303-9d00-dec376d74efb")
+
+
+def _authorise_forecast_scope(
+    conn: psycopg.Connection[Any], *, setup_version: str, checked_at: datetime = _NOW
+) -> None:
+    """Explicit synthetic prospective authority for executor plumbing tests."""
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_policies (
+            policy_id,effective_from,recent_window_days,minimum_resolved_forecasts,
+            adaptive_calibration_bins,max_normalized_brier_score,
+            min_brier_skill_score,max_classwise_calibration_error,max_ambiguous_rate,max_unresolved_rate,
+            max_pending_rate,max_assessment_age_days,evidence_ref
+        ) VALUES ('test-assessment-policy-v1',%s - interval '1 day',90,30,5,0.2,0.01,0.1,0.05,0.05,0.2,2,
+                  'synthetic executor fixture only')
+        ON CONFLICT (policy_id) DO NOTHING
+        """,
+        (checked_at,),
+    )
+    assessment = conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessments (
+            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            resolver_version,input_rule_set_version,window_start,window_end,evidence_hash,
+            total_forecasts,resolved_forecasts,target_first_count,stop_first_count,timeout_count,
+            ambiguous_count,unresolved_count,pending_count,normalized_brier_score,
+            baseline_normalized_brier_score,brier_skill_score,max_classwise_calibration_error,
+            ambiguous_rate,unresolved_rate,pending_rate,passed,reason_codes
+        ) VALUES (
+            'test-assessment-policy-v1',%s,'test-model-v1','test-calibration-v1',%s,'test-exit-v1',%s,%s,
+            %s::date-89,%s::date,'synthetic-' || %s,30,30,10,10,10,0,0,0,0,0.33333333,1,0,0,0,0,true,'[]'::jsonb
+        ) RETURNING assessment_id
+        """,
+        (
+            FORECAST_POLICY_VERSION,
+            setup_version,
+            FORECAST_OUTCOME_RESOLVER_VERSION,
+            QUARANTINE_RULE_SET_VERSION,
+            checked_at,
+            checked_at,
+            setup_version,
+        ),
+    ).fetchone()
+    assert assessment is not None
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_current (
+            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            resolver_version,input_rule_set_version,assessment_id,checked_at
+        ) VALUES ('test-assessment-policy-v1',%s,'test-model-v1','test-calibration-v1',%s,'test-exit-v1',%s,%s,%s,%s)
+        """,
+        (
+            FORECAST_POLICY_VERSION,
+            setup_version,
+            FORECAST_OUTCOME_RESOLVER_VERSION,
+            QUARANTINE_RULE_SET_VERSION,
+            int(assessment[0]),
+            checked_at,
+        ),
+    )
 
 
 def _seed(
@@ -230,6 +293,7 @@ def _seed(
             cost_model_id=COST_MODEL_ID,
         ),
     )
+    _authorise_forecast_scope(conn, setup_version="test-setup-v1")
     persist_ranking_batch(
         conn,
         opportunities=[
@@ -599,6 +663,51 @@ def test_invalid_opportunity_evidence_refuses_before_broker_access(
     decision_time = _NOW + timedelta(seconds=1) if reason_code == "opportunity_forecast_not_current" else _NOW
 
     result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=decision_time)
+
+    assert result.reason_code == reason_code
+    broker.get_account_risk_snapshot.assert_not_called()
+    broker.place_demo_strategy_order.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("invalidity", "reason_code"),
+    [
+        ("policy", "opportunity_assessment_policy_missing"),
+        ("missing", "opportunity_assessment_missing"),
+        ("calibration_scope", "opportunity_assessment_missing"),
+        ("failed", "opportunity_assessment_not_passed"),
+        ("stale", "opportunity_assessment_stale"),
+    ],
+)
+def test_prospective_assessment_refuses_before_broker_access(
+    ebull_test_conn: psycopg.Connection[Any],
+    invalidity: str,
+    reason_code: str,
+) -> None:
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+    if invalidity == "policy":
+        conn.execute("UPDATE strategy_forecast_assessment_policies SET effective_from=%s + interval '1 day'", (_NOW,))
+    elif invalidity == "missing":
+        conn.execute("DELETE FROM strategy_forecast_assessment_current")
+    elif invalidity == "calibration_scope":
+        conn.execute(
+            """
+            INSERT INTO strategy_forecast_calibrations (
+                calibration_id,model_version,holdout_start,holdout_end,sample_size,
+                brier_score,calibration_error,passed,evidence_ref
+            ) VALUES ('other-calibration','test-model-v1','2026-01-01','2026-07-31',500,0.18,0.04,true,'test')
+            """
+        )
+        conn.execute("UPDATE strategy_forecast_assessment_current SET calibration_id='other-calibration'")
+    elif invalidity == "failed":
+        conn.execute("UPDATE strategy_forecast_assessments SET passed=false")
+    else:
+        conn.execute("UPDATE strategy_forecast_assessment_current SET checked_at=%s - interval '3 days'", (_NOW,))
+    conn.commit()
+    broker = _broker()
+
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
 
     assert result.reason_code == reason_code
     broker.get_account_risk_snapshot.assert_not_called()

--- a/tests/test_strategy_paper_runtime.py
+++ b/tests/test_strategy_paper_runtime.py
@@ -20,7 +20,7 @@ from app.services.strategy_paper_runtime import (
     refresh_strategy_health,
     run_strategy_paper_cycle,
 )
-from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _broker, _seed
+from tests.test_strategy_paper_executor import _NOW, _REQUEST_ID, _authorise_forecast_scope, _broker, _seed
 from tests.test_strategy_position_manager import _opened_trade
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
@@ -77,6 +77,7 @@ def _add_weaker_newer_forecast(conn: psycopg.Connection[tuple]) -> int:
             cost_model_id=COST_MODEL_ID,
         ),
     )
+    _authorise_forecast_scope(conn, setup_version="weaker-setup-v1")
     conn.commit()
     return int(signal[0])
 


### PR DESCRIPTION
Closes #2555

## What changed
- adds immutable operator-preregistered recent forecast assessment policies with no seeded passing default
- scores exact forecast/calibration/setup/exit cohorts with normalized multiclass Brier score, positive skill versus recent empirical base rates, and adaptive classwise calibration error
- records ambiguity, unresolved and pending rates explicitly and deduplicates unchanged evidence while refreshing one bounded current pointer
- runs assessment after daily forecast outcome resolution
- excludes unassessed, failed, mismatched or stale scopes before ranking and refuses them again before any broker access

## Evidence and design
- proper scores: Gneiting and Raftery (2007), doi:10.1198/016214506000001437
- calibration measurement: Nixon et al. (2019), arXiv:1904.01685; Kumar et al. (2019), arXiv:1909.10155
- thresholds are intentionally not guessed or seeded; current production authority remains zero until a prospective policy is registered and an exact recent cohort passes
- database growth is bounded: unchanged cohorts reuse immutable evidence and only one current row exists per exact scope

## Validation
- full pre-push gate green twice on 22e3e6ae
- ruff, format, pyright, full fast suite and smoke suite green
- application boot applied migrations 317-320 to the development database; all recorded content hashes match
- live dry run with no registered policy returned zero scopes and zero authority
- development database size warning remains 63 GB and is non-blocking
