### PR TITLE
Expose honest automation readiness

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -327,6 +327,7 @@ AutomationReadinessState = Literal[
     "prospective_evidence_missing",
     "prospective_evidence_failed",
     "prospective_evidence_stale",
+    "candidate_evidence_incomplete",
     "ready",
 ]
 
@@ -1204,7 +1205,7 @@ def get_strategy_overview(
         readiness_state = "prospective_evidence_stale"
         readiness_blockers = ["prospective_assessment_stale"]
     elif not prospectively_ready_count:
-        readiness_state = "prospective_evidence_missing"
+        readiness_state = "candidate_evidence_incomplete"
         readiness_blockers = ["no_historically_ready_candidate_has_fresh_prospective_evidence"]
     else:
         readiness_state = "ready"
@@ -1722,7 +1723,6 @@ def update_strategy_paper_pool(
 ) -> StrategyPaperPoolView:
     """Set the shared strategy ceiling and its higher-level automation flag."""
     try:
-        conn.rollback()
         readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
         conn.rollback()
         with conn.transaction():

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections import Counter, defaultdict
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import Literal, cast
 
@@ -320,6 +320,38 @@ class EvidenceRefreshView(BaseModel):
     progress: dict[str, object] | None
 
 
+AutomationReadinessState = Literal[
+    "no_capital_candidates",
+    "historical_validation_incomplete",
+    "assessment_policy_missing",
+    "prospective_evidence_missing",
+    "prospective_evidence_failed",
+    "prospective_evidence_stale",
+    "ready",
+]
+
+
+class AutomationReadinessView(BaseModel):
+    ready: bool
+    state: AutomationReadinessState
+    capital_candidate_count: int
+    historically_ready_candidate_count: int
+    prospectively_ready_candidate_count: int
+    assessment_policy_id: str | None
+    assessed_scope_count: int
+    passed_scope_count: int
+    fresh_passed_scope_count: int
+    resolved_forecasts: int
+    target_first_count: int
+    stop_first_count: int
+    timeout_count: int
+    latest_checked_at: datetime | None
+    worst_normalized_brier_score: Decimal | None
+    weakest_brier_skill_score: Decimal | None
+    worst_classwise_calibration_error: Decimal | None
+    blockers: list[str]
+
+
 class StrategyOverviewResponse(BaseModel):
     as_of: datetime
     demo_connection: bool
@@ -332,6 +364,7 @@ class StrategyOverviewResponse(BaseModel):
     storage_policy: Literal["fired_signals_and_material_mutations_only"] = "fired_signals_and_material_mutations_only"
     entry_block: StrategyEntryBlockView
     paper_pool: StrategyPaperPoolView
+    automation_readiness: AutomationReadinessView
     evidence_refresh: EvidenceRefreshView
     strategies: list[StrategyOverview]
 
@@ -788,6 +821,32 @@ _LATEST_EVIDENCE_REFRESH_SQL = """
     LIMIT 1
 """
 
+_CURRENT_FORECAST_ASSESSMENTS_SQL = """
+    SELECT p.policy_id,p.max_assessment_age_days,
+           c.strategy_id,c.strategy_version,c.checked_at,
+           a.passed,a.resolved_forecasts,a.target_first_count,a.stop_first_count,a.timeout_count,
+           a.normalized_brier_score,a.brier_skill_score,a.max_classwise_calibration_error
+    FROM strategy_forecast_assessment_policies p
+    JOIN strategy_forecast_assessment_current c ON c.policy_id=p.policy_id
+    JOIN strategy_forecast_assessments a
+      ON a.assessment_id=c.assessment_id
+     AND a.policy_id=c.policy_id
+     AND a.strategy_id=c.strategy_id
+     AND a.strategy_version=c.strategy_version
+     AND a.forecast_policy_version=c.forecast_policy_version
+     AND a.model_version=c.model_version
+     AND a.calibration_id=c.calibration_id
+     AND a.setup_version=c.setup_version
+     AND a.exit_policy_version=c.exit_policy_version
+     AND a.resolver_version=c.resolver_version
+     AND a.input_rule_set_version=c.input_rule_set_version
+    WHERE p.policy_id = (
+        SELECT policy_id FROM strategy_forecast_assessment_policies
+        WHERE effective_from <= %(as_of)s
+        ORDER BY effective_from DESC LIMIT 1
+    )
+"""
+
 
 def _evidence_refresh_status(
     row: dict[str, object] | None,
@@ -836,6 +895,7 @@ def _evidence_window_counts(strategies: list[StrategyOverview]) -> tuple[int, in
 def get_strategy_overview(
     conn: psycopg.Connection[object] = Depends(get_conn),
 ) -> StrategyOverviewResponse:
+    as_of = datetime.now(tz=UTC)
     versions = _current_versions()
     version_values = list(versions.values())
     params = {
@@ -862,6 +922,18 @@ def get_strategy_overview(
         latest_corpus_date = None if latest_row is None else latest_row["max"]
         cur.execute(_LATEST_EVIDENCE_REFRESH_SQL, {"job_name": _STRATEGY_BACKTEST_JOB})
         refresh_row = cur.fetchone()
+        cur.execute(
+            """
+            SELECT policy_id,max_assessment_age_days
+            FROM strategy_forecast_assessment_policies
+            WHERE effective_from <= %s
+            ORDER BY effective_from DESC LIMIT 1
+            """,
+            (as_of,),
+        )
+        assessment_policy_row = cur.fetchone()
+        cur.execute(_CURRENT_FORECAST_ASSESSMENTS_SQL, {"as_of": as_of})
+        assessment_rows = list(cur.fetchall())
         cur.execute("SELECT DISTINCT strategy_id,strategy_version FROM strategy_deployments WHERE mode='paper'")
         paper_deployment_keys = [(str(row["strategy_id"]), str(row["strategy_version"])) for row in cur.fetchall()]
 
@@ -888,6 +960,11 @@ def get_strategy_overview(
 
     runnable, excluded = runnable_strategies()
     excluded_by_id = {item.strategy_id: item.reason for item in excluded}
+    assessments_by_strategy: dict[tuple[str, str], list[dict[str, object]]] = defaultdict(list)
+    for row in assessment_rows:
+        assessments_by_strategy[(str(row["strategy_id"]), str(row["strategy_version"]))].append(row)
+    assessment_policy_id = None if assessment_policy_row is None else str(assessment_policy_row["policy_id"])
+    historically_ready_keys: set[tuple[str, str]] = set()
     strategies: list[StrategyOverview] = []
     for strategy_id in sorted(STRATEGY_MANIFEST):
         entry = STRATEGY_MANIFEST[strategy_id]
@@ -1002,6 +1079,25 @@ def get_strategy_overview(
             allocation_refusals.append("scan_not_current")
         if control.currency != "USD":
             allocation_refusals.append("deployment_currency_unsupported")
+        if entry.purpose == "capital_candidate" and not allocation_refusals:
+            historically_ready_keys.add(key)
+        if entry.purpose == "capital_candidate":
+            current_assessments = assessments_by_strategy[key]
+            if assessment_policy_row is None:
+                allocation_refusals.append("prospective_assessment_policy_missing")
+            elif not current_assessments:
+                allocation_refusals.append("prospective_assessment_missing")
+            else:
+                passed_assessments = [row for row in current_assessments if bool(row["passed"])]
+                if not passed_assessments:
+                    allocation_refusals.append("prospective_assessment_not_passed")
+                elif not any(
+                    cast(datetime, row["checked_at"])
+                    >= as_of - timedelta(days=cast(int, row["max_assessment_age_days"]))
+                    and cast(datetime, row["checked_at"]) <= as_of + timedelta(seconds=5)
+                    for row in passed_assessments
+                ):
+                    allocation_refusals.append("prospective_assessment_stale")
         remaining = max(control.capital_limit - control.reserved_capital, Decimal("0"))
         strategies.append(
             StrategyOverview(
@@ -1076,8 +1172,52 @@ def get_strategy_overview(
     )
     completed_windows, partial_windows = _evidence_window_counts(strategies)
     refresh_status, refresh_error = _evidence_refresh_status(refresh_row)
+    capital_candidates = [item for item in strategies if item.purpose == "capital_candidate"]
+    capital_candidate_keys = {(item.strategy_id, item.strategy_version) for item in capital_candidates}
+    candidate_assessments = [
+        row for key, rows in assessments_by_strategy.items() if key in capital_candidate_keys for row in rows
+    ]
+    passed_assessments = [row for row in candidate_assessments if bool(row["passed"])]
+    fresh_passed_assessments = [
+        row
+        for row in passed_assessments
+        if cast(datetime, row["checked_at"]) >= as_of - timedelta(days=cast(int, row["max_assessment_age_days"]))
+        and cast(datetime, row["checked_at"]) <= as_of + timedelta(seconds=5)
+    ]
+    prospectively_ready_count = sum(item.allocation_ready for item in capital_candidates)
+    if not capital_candidates:
+        readiness_state: AutomationReadinessState = "no_capital_candidates"
+        readiness_blockers = ["no_capital_candidates"]
+    elif not historically_ready_keys:
+        readiness_state = "historical_validation_incomplete"
+        readiness_blockers = ["historical_validation_incomplete"]
+    elif assessment_policy_row is None:
+        readiness_state = "assessment_policy_missing"
+        readiness_blockers = ["prospective_assessment_policy_missing"]
+    elif not candidate_assessments:
+        readiness_state = "prospective_evidence_missing"
+        readiness_blockers = ["prospective_assessment_missing"]
+    elif not passed_assessments:
+        readiness_state = "prospective_evidence_failed"
+        readiness_blockers = ["prospective_assessment_not_passed"]
+    elif not fresh_passed_assessments:
+        readiness_state = "prospective_evidence_stale"
+        readiness_blockers = ["prospective_assessment_stale"]
+    elif not prospectively_ready_count:
+        readiness_state = "prospective_evidence_missing"
+        readiness_blockers = ["no_historically_ready_candidate_has_fresh_prospective_evidence"]
+    else:
+        readiness_state = "ready"
+        readiness_blockers = []
+
+    def _metric_values(field: str) -> list[Decimal]:
+        return [Decimal(str(row[field])) for row in candidate_assessments if row[field] is not None]
+
+    brier_scores = _metric_values("normalized_brier_score")
+    skill_scores = _metric_values("brier_skill_score")
+    calibration_errors = _metric_values("max_classwise_calibration_error")
     return StrategyOverviewResponse(
-        as_of=datetime.now(tz=UTC),
+        as_of=as_of,
         demo_connection=settings.etoro_env == "demo",
         execution_enabled=entry_block.auto_trading_enabled,
         live_execution_enabled=entry_block.live_trading_enabled,
@@ -1117,6 +1257,29 @@ def get_strategy_overview(
                 leverage_allowed=paper_pool.mandate.leverage_allowed,
             ),
             available_mandates=[_mandate_view(profile) for profile in ("cautious", "balanced", "growth")],
+        ),
+        automation_readiness=AutomationReadinessView(
+            ready=readiness_state == "ready",
+            state=readiness_state,
+            capital_candidate_count=len(capital_candidates),
+            historically_ready_candidate_count=len(historically_ready_keys),
+            prospectively_ready_candidate_count=prospectively_ready_count,
+            assessment_policy_id=assessment_policy_id,
+            assessed_scope_count=len(candidate_assessments),
+            passed_scope_count=len(passed_assessments),
+            fresh_passed_scope_count=len(fresh_passed_assessments),
+            resolved_forecasts=sum(cast(int, row["resolved_forecasts"]) for row in candidate_assessments),
+            target_first_count=sum(cast(int, row["target_first_count"]) for row in candidate_assessments),
+            stop_first_count=sum(cast(int, row["stop_first_count"]) for row in candidate_assessments),
+            timeout_count=sum(cast(int, row["timeout_count"]) for row in candidate_assessments),
+            latest_checked_at=max(
+                (cast(datetime, row["checked_at"]) for row in candidate_assessments),
+                default=None,
+            ),
+            worst_normalized_brier_score=max(brier_scores, default=None),
+            weakest_brier_skill_score=min(skill_scores, default=None),
+            worst_classwise_calibration_error=max(calibration_errors, default=None),
+            blockers=readiness_blockers,
         ),
         evidence_refresh=EvidenceRefreshView(
             frozen_through=max(item.window.end for item in RECENT_EVIDENCE_WINDOWS.values()),
@@ -1560,9 +1723,13 @@ def update_strategy_paper_pool(
     """Set the shared strategy ceiling and its higher-level automation flag."""
     try:
         conn.rollback()
+        readiness = get_strategy_overview(conn).automation_readiness if body.enabled else None
+        conn.rollback()
         with conn.transaction():
             conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", PAPER_ALLOCATOR_ADVISORY_LOCK)
             current_pool = load_paper_pool(conn)
+            if body.enabled and not current_pool.enabled and readiness is not None and not readiness.ready:
+                raise StrategyControlError("automation cannot be enabled: " + ", ".join(readiness.blockers))
             runtime = get_runtime_config(conn)
             pool_changed = (
                 current_pool.enabled != body.enabled

--- a/app/services/strategy_forecast_assessment.py
+++ b/app/services/strategy_forecast_assessment.py
@@ -77,6 +77,8 @@ class ForecastObservation:
 
 @dataclass(frozen=True)
 class ForecastScope:
+    strategy_id: str
+    strategy_version: str
     forecast_policy_version: str
     model_version: str
     calibration_id: str
@@ -335,10 +337,12 @@ def _load_scopes(
 ) -> Mapping[ForecastScope, tuple[ForecastObservation, ...]]:
     rows = conn.execute(
         """
-        SELECT f.forecast_id,f.forecast_policy_version,c.model_version,c.calibration_id,f.setup_version,
+        SELECT f.forecast_id,s.strategy_id,s.strategy_version,f.forecast_policy_version,
+               c.model_version,c.calibration_id,f.setup_version,
                f.exit_policy_version,f.target_probability,f.stop_probability,
                f.timeout_probability,o.forecast_outcome_id,o.outcome
         FROM strategy_opportunity_forecasts f
+        JOIN strategy_signals s ON s.signal_id=f.signal_id
         JOIN strategy_forecast_calibrations c ON c.calibration_id=f.calibration_id
         LEFT JOIN strategy_opportunity_forecast_outcomes o
           ON o.forecast_id=f.forecast_id
@@ -351,8 +355,8 @@ def _load_scopes(
     ).fetchall()
     grouped: dict[ForecastScope, list[ForecastObservation]] = {}
     for row in rows:
-        scope = ForecastScope(str(row[1]), str(row[2]), str(row[3]), str(row[4]), str(row[5]))
-        stored_outcome = row[10]
+        scope = ForecastScope(*(str(row[index]) for index in range(1, 8)))
+        stored_outcome = row[12]
         if stored_outcome in _CLASSES:
             terminal_state: Literal["resolved", "ambiguous", "unresolved", "pending"] = "resolved"
             outcome: OutcomeClass | None = stored_outcome
@@ -365,10 +369,10 @@ def _load_scopes(
         grouped.setdefault(scope, []).append(
             ForecastObservation(
                 forecast_id=int(row[0]),
-                target_probability=Decimal(row[6]),
-                stop_probability=Decimal(row[7]),
-                timeout_probability=Decimal(row[8]),
-                outcome_id=int(row[9]) if row[9] is not None else None,
+                target_probability=Decimal(row[8]),
+                stop_probability=Decimal(row[9]),
+                timeout_probability=Decimal(row[10]),
+                outcome_id=int(row[11]) if row[11] is not None else None,
                 outcome=outcome,
                 terminal_state=terminal_state,
             )
@@ -386,6 +390,8 @@ def _store_assessment(
     scope = assessment.scope
     params = (
         policy.policy_id,
+        scope.strategy_id,
+        scope.strategy_version,
         scope.forecast_policy_version,
         scope.model_version,
         scope.calibration_id,
@@ -417,15 +423,17 @@ def _store_assessment(
     row = conn.execute(
         """
         INSERT INTO strategy_forecast_assessments (
-            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,
             resolver_version,input_rule_set_version,window_start,window_end,evidence_hash,
             total_forecasts,resolved_forecasts,target_first_count,stop_first_count,timeout_count,
             ambiguous_count,unresolved_count,pending_count,normalized_brier_score,
             baseline_normalized_brier_score,brier_skill_score,
             max_classwise_calibration_error,ambiguous_rate,unresolved_rate,pending_rate,passed,reason_codes
-        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb)
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb)
         ON CONFLICT (
-            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,
             resolver_version,input_rule_set_version,evidence_hash
         ) DO NOTHING RETURNING assessment_id
         """,
@@ -436,12 +444,15 @@ def _store_assessment(
         row = conn.execute(
             """
             SELECT assessment_id FROM strategy_forecast_assessments
-            WHERE policy_id=%s AND forecast_policy_version=%s AND model_version=%s AND calibration_id=%s
+            WHERE policy_id=%s AND strategy_id=%s AND strategy_version=%s
+              AND forecast_policy_version=%s AND model_version=%s AND calibration_id=%s
               AND setup_version=%s AND exit_policy_version=%s AND resolver_version=%s
               AND input_rule_set_version=%s AND evidence_hash=%s
             """,
             (
                 policy.policy_id,
+                scope.strategy_id,
+                scope.strategy_version,
                 scope.forecast_policy_version,
                 scope.model_version,
                 scope.calibration_id,
@@ -457,16 +468,20 @@ def _store_assessment(
     conn.execute(
         """
         INSERT INTO strategy_forecast_assessment_current (
-            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,
             resolver_version,input_rule_set_version,assessment_id,checked_at
-        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         ON CONFLICT (
-            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,
             resolver_version,input_rule_set_version
         ) DO UPDATE SET assessment_id=EXCLUDED.assessment_id,checked_at=EXCLUDED.checked_at
         """,
         (
             policy.policy_id,
+            scope.strategy_id,
+            scope.strategy_version,
             scope.forecast_policy_version,
             scope.model_version,
             scope.calibration_id,
@@ -501,6 +516,8 @@ def run_forecast_assessments(
         for scope, observations in sorted(
             grouped.items(),
             key=lambda item: (
+                item[0].strategy_id,
+                item[0].strategy_version,
                 item[0].model_version,
                 item[0].calibration_id,
                 item[0].setup_version,

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -315,6 +315,8 @@ def _load_intent(
             ) assessment_policy ON true
             LEFT JOIN strategy_forecast_assessment_current current_assessment
              ON current_assessment.policy_id=assessment_policy.policy_id
+             AND current_assessment.strategy_id=s.strategy_id
+             AND current_assessment.strategy_version=s.strategy_version
              AND current_assessment.forecast_policy_version=forecast.forecast_policy_version
              AND current_assessment.model_version=calibration.model_version
              AND current_assessment.calibration_id=calibration.calibration_id
@@ -325,6 +327,8 @@ def _load_intent(
             LEFT JOIN strategy_forecast_assessments prospective_assessment
               ON prospective_assessment.assessment_id=current_assessment.assessment_id
              AND prospective_assessment.policy_id=current_assessment.policy_id
+             AND prospective_assessment.strategy_id=current_assessment.strategy_id
+             AND prospective_assessment.strategy_version=current_assessment.strategy_version
              AND prospective_assessment.forecast_policy_version=current_assessment.forecast_policy_version
              AND prospective_assessment.model_version=current_assessment.model_version
              AND prospective_assessment.calibration_id=current_assessment.calibration_id

--- a/app/services/strategy_paper_runtime.py
+++ b/app/services/strategy_paper_runtime.py
@@ -75,6 +75,8 @@ def _load_ranked_opportunities(
             ) assessment_policy ON true
             JOIN strategy_forecast_assessment_current current_assessment
              ON current_assessment.policy_id=assessment_policy.policy_id
+             AND current_assessment.strategy_id=s.strategy_id
+             AND current_assessment.strategy_version=s.strategy_version
              AND current_assessment.forecast_policy_version=f.forecast_policy_version
              AND current_assessment.model_version=c.model_version
              AND current_assessment.calibration_id=c.calibration_id
@@ -88,8 +90,10 @@ def _load_ranked_opportunities(
              -- this is not permission to consume future assessment evidence.
              AND current_assessment.checked_at <= %(observed_at)s + interval '5 seconds'
             JOIN strategy_forecast_assessments prospective_assessment
-              ON prospective_assessment.assessment_id=current_assessment.assessment_id
+             ON prospective_assessment.assessment_id=current_assessment.assessment_id
              AND prospective_assessment.policy_id=current_assessment.policy_id
+             AND prospective_assessment.strategy_id=current_assessment.strategy_id
+             AND prospective_assessment.strategy_version=current_assessment.strategy_version
              AND prospective_assessment.forecast_policy_version=current_assessment.forecast_policy_version
              AND prospective_assessment.model_version=current_assessment.model_version
              AND prospective_assessment.calibration_id=current_assessment.calibration_id

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2555,6 +2555,7 @@ export interface StrategyOverviewResponse {
       | "prospective_evidence_missing"
       | "prospective_evidence_failed"
       | "prospective_evidence_stale"
+      | "candidate_evidence_incomplete"
       | "ready";
     capital_candidate_count: number;
     historically_ready_candidate_count: number;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2546,6 +2546,33 @@ export interface StrategyOverviewResponse {
   storage_policy: "fired_signals_and_material_mutations_only";
   entry_block: StrategyEntryBlock;
   paper_pool: StrategyPaperPool;
+  automation_readiness: {
+    ready: boolean;
+    state:
+      | "no_capital_candidates"
+      | "historical_validation_incomplete"
+      | "assessment_policy_missing"
+      | "prospective_evidence_missing"
+      | "prospective_evidence_failed"
+      | "prospective_evidence_stale"
+      | "ready";
+    capital_candidate_count: number;
+    historically_ready_candidate_count: number;
+    prospectively_ready_candidate_count: number;
+    assessment_policy_id: string | null;
+    assessed_scope_count: number;
+    passed_scope_count: number;
+    fresh_passed_scope_count: number;
+    resolved_forecasts: number;
+    target_first_count: number;
+    stop_first_count: number;
+    timeout_count: number;
+    latest_checked_at: string | null;
+    worst_normalized_brier_score: string | null;
+    weakest_brier_skill_score: string | null;
+    worst_classwise_calibration_error: string | null;
+    blockers: string[];
+  };
   evidence_refresh: {
     frozen_through: string;
     completed_windows: number;

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -57,6 +57,26 @@ const OVERVIEW: StrategyOverviewResponse = {
     global_kill_activated_by: null,
     execution_block_reasons: [],
   },
+  automation_readiness: {
+    ready: false,
+    state: "historical_validation_incomplete",
+    capital_candidate_count: 1,
+    historically_ready_candidate_count: 0,
+    prospectively_ready_candidate_count: 0,
+    assessment_policy_id: null,
+    assessed_scope_count: 0,
+    passed_scope_count: 0,
+    fresh_passed_scope_count: 0,
+    resolved_forecasts: 0,
+    target_first_count: 0,
+    stop_first_count: 0,
+    timeout_count: 0,
+    latest_checked_at: null,
+    worst_normalized_brier_score: null,
+    weakest_brier_skill_score: null,
+    worst_classwise_calibration_error: null,
+    blockers: ["historical_validation_incomplete"],
+  },
   paper_pool: {
     configured: true,
     enabled: false,
@@ -214,6 +234,26 @@ function approvedOverview(): StrategyOverviewResponse {
   const strategy = OVERVIEW.strategies[0]!;
   return {
     ...OVERVIEW,
+    automation_readiness: {
+      ...OVERVIEW.automation_readiness,
+      ready: true,
+      state: "ready",
+      historically_ready_candidate_count: 1,
+      prospectively_ready_candidate_count: 1,
+      assessment_policy_id: "assessment-policy-v1",
+      assessed_scope_count: 1,
+      passed_scope_count: 1,
+      fresh_passed_scope_count: 1,
+      resolved_forecasts: 30,
+      target_first_count: 18,
+      stop_first_count: 7,
+      timeout_count: 5,
+      latest_checked_at: "2026-08-09T11:00:00Z",
+      worst_normalized_brier_score: "0.12",
+      weakest_brier_skill_score: "0.18",
+      worst_classwise_calibration_error: "0.06",
+      blockers: [],
+    },
     paper_pool: { ...OVERVIEW.paper_pool, enabled: true, reserved_capital: "250", invested_capital: "200", remaining_capital: "750" },
     strategies: [{
       ...strategy,
@@ -268,7 +308,8 @@ describe("StrategiesPage", () => {
 
   it("separates unapproved research from selectable strategies", async () => {
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
-    expect(await screen.findByText("No capital candidates are approved for automation.")).toBeInTheDocument();
+    expect(await screen.findByText("Automation is not ready")).toBeInTheDocument();
+    expect(screen.getByText("Candidate research has not cleared the recent after-cost validation gates.")).toBeInTheDocument();
     expect(screen.queryByText("Approved & managed strategies")).not.toBeInTheDocument();
     const research = screen.getByText("Research & validation").closest("details")!;
     expect(research).not.toHaveAttribute("open");
@@ -402,6 +443,16 @@ describe("StrategiesPage", () => {
     expect(master).not.toBeChecked();
     expect(master).toBeDisabled();
     expect(screen.getByText("System-wide automatic trading is off. Enable that safety control before allowing new entries.")).toBeInTheDocument();
+  });
+
+  it("shows compact prospective evidence when automation is ready", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(approvedOverview());
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+
+    const readiness = (await screen.findByText("Automation evidence is current")).closest("section")!;
+    expect(within(readiness).getByText("30")).toBeInTheDocument();
+    expect(within(readiness).getAllByText("1")).toHaveLength(2);
+    expect(screen.getByRole("checkbox", { name: "Allow new automated entries" })).not.toBeDisabled();
   });
 
   it("shows stable primary evidence without paging through missing windows", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -125,6 +125,10 @@ const REFUSAL_LABELS: Record<string, string> = {
   carry_unmodelled: "Holding and financing costs are not modelled",
   trial_register_superseded: "Evidence does not match the current experiment register",
   synthetic_control_not_run: "Random-entry control has not passed",
+  prospective_assessment_policy_missing: "Prospective forecast acceptance limits are missing",
+  prospective_assessment_missing: "No current prospective forecast assessment exists",
+  prospective_assessment_not_passed: "Recent forecast probabilities failed validation",
+  prospective_assessment_stale: "Prospective forecast validation is stale",
 };
 
 function refusalLabel(refusal: string): string {
@@ -186,6 +190,38 @@ function Metric({ label, value, hint }: { label: string; value: string; hint?: s
       </strong>
       {hint ? <span className="mt-0.5 block text-xs text-slate-500">{hint}</span> : null}
     </div>
+  );
+}
+
+const READINESS_COPY: Record<StrategyOverviewResponse["automation_readiness"]["state"], string> = {
+  no_capital_candidates: "No validated capital candidate exists. Research controls are measuring the machinery only.",
+  historical_validation_incomplete: "Candidate research has not cleared the recent after-cost validation gates.",
+  assessment_policy_missing: "Prospective forecast acceptance limits have not been registered.",
+  prospective_evidence_missing: "A historically valid candidate is waiting for prospective forecast outcomes.",
+  prospective_evidence_failed: "Recent forecast probabilities did not remain accurate enough to receive capital.",
+  prospective_evidence_stale: "The last passing prospective assessment is no longer current.",
+  ready: "At least one candidate has current historical, execution and prospective forecast authority.",
+};
+
+function AutomationReadiness({ overview }: { overview: StrategyOverviewResponse }) {
+  const readiness = overview.automation_readiness;
+  return (
+    <section className={`border px-5 py-4 ${readiness.ready ? "border-emerald-300 bg-emerald-50 dark:border-emerald-800 dark:bg-emerald-950/30" : "border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30"}`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-semibold">{readiness.ready ? "Automation evidence is current" : "Automation is not ready"}</h2>
+            <Badge tone={readiness.ready ? "ok" : "warn"}>{readiness.prospectively_ready_candidate_count} ready</Badge>
+          </div>
+          <p className="mt-1 max-w-3xl text-xs text-slate-600 dark:text-slate-300">{READINESS_COPY[readiness.state]}</p>
+        </div>
+        <div className="grid grid-cols-3 gap-5 text-right text-xs">
+          <div><span className="block text-slate-500">Candidates</span><strong className="tabular-nums">{readiness.capital_candidate_count}</strong></div>
+          <div><span className="block text-slate-500">Outcomes scored</span><strong className="tabular-nums">{readiness.resolved_forecasts}</strong></div>
+          <div><span className="block text-slate-500">Fresh passing scopes</span><strong className="tabular-nums">{readiness.fresh_passed_scope_count}</strong></div>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -435,11 +471,9 @@ function StrategyCloseModal({
 
 function AutomationControl({
   overview,
-  approvedCount,
   onUpdated,
 }: {
   overview: StrategyOverviewResponse;
-  approvedCount: number;
   onUpdated: () => void;
 }) {
   const pool = overview.paper_pool;
@@ -462,7 +496,7 @@ function AutomationControl({
     || parsed !== Number(pool.capital_limit)
     || capitalMode !== pool.capital_mode
     || riskProfile !== pool.mandate.risk_profile;
-  const canEnable = approvedCount > 0 && overview.execution_enabled && riskProfile !== "unconfigured";
+  const canEnable = overview.automation_readiness.ready && overview.execution_enabled && riskProfile !== "unconfigured";
   const selectedMandate = riskProfile === pool.mandate.risk_profile && pool.mandate.configured
     ? pool.mandate
     : pool.available_mandates.find((mandate) => mandate.risk_profile === riskProfile) ?? null;
@@ -896,12 +930,7 @@ export function StrategiesPage() {
         <SectionError onRetry={overview.refetch} />
       ) : overview.data && summary ? (
         <>
-          {summary.approved === 0 ? (
-            <div className="flex flex-wrap items-center justify-between gap-2 border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
-              <span><strong>No capital candidates are approved for automation.</strong> Validation controls cannot use capital.</span>
-              <span className="text-xs">0 ready</span>
-            </div>
-          ) : null}
+          <AutomationReadiness overview={overview.data} />
           {!overview.data.demo_connection && !overview.data.live_strategy_activation_available ? (
             <div className="border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
               <strong>Real-money strategy activation is unavailable.</strong>
@@ -941,7 +970,7 @@ export function StrategiesPage() {
                 <EmptyPnlChart />
               )}
             </section>
-            <AutomationControl overview={overview.data} approvedCount={summary.approved} onUpdated={overview.refetch} />
+            <AutomationControl overview={overview.data} onUpdated={overview.refetch} />
           </div>
 
           {ownedPositions.loading ? (

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -200,6 +200,7 @@ const READINESS_COPY: Record<StrategyOverviewResponse["automation_readiness"]["s
   prospective_evidence_missing: "A historically valid candidate is waiting for prospective forecast outcomes.",
   prospective_evidence_failed: "Recent forecast probabilities did not remain accurate enough to receive capital.",
   prospective_evidence_stale: "The last passing prospective assessment is no longer current.",
+  candidate_evidence_incomplete: "No historically valid candidate has a fresh passing forecast assessment yet.",
   ready: "At least one candidate has current historical, execution and prospective forecast authority.",
 };
 

--- a/sql/322_strategy_forecast_assessment_strategy_scope.sql
+++ b/sql/322_strategy_forecast_assessment_strategy_scope.sql
@@ -1,0 +1,41 @@
+-- 322_strategy_forecast_assessment_strategy_scope.sql
+--
+-- #2557: a setup label is not a strategy identity. Bind prospective forecast
+-- authority to the exact strategy and version that emitted the signal so two
+-- strategies cannot accidentally share an assessment scope.
+
+ALTER TABLE strategy_forecast_assessments
+    ADD COLUMN strategy_id TEXT NOT NULL,
+    ADD COLUMN strategy_version TEXT NOT NULL;
+
+ALTER TABLE strategy_forecast_assessments
+    DROP CONSTRAINT strategy_forecast_assessments_evidence_unique;
+ALTER TABLE strategy_forecast_assessments
+    ADD CONSTRAINT strategy_forecast_assessments_evidence_unique UNIQUE (
+        policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+        calibration_id,setup_version,exit_policy_version,resolver_version,
+        input_rule_set_version,evidence_hash
+    );
+
+DROP INDEX idx_strategy_forecast_assessments_scope;
+CREATE INDEX idx_strategy_forecast_assessments_scope
+    ON strategy_forecast_assessments (
+        policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+        calibration_id,setup_version,exit_policy_version,resolver_version,
+        input_rule_set_version,assessment_id DESC
+    );
+
+ALTER TABLE strategy_forecast_assessment_current
+    ADD COLUMN strategy_id TEXT NOT NULL,
+    ADD COLUMN strategy_version TEXT NOT NULL;
+ALTER TABLE strategy_forecast_assessment_current
+    DROP CONSTRAINT strategy_forecast_assessment_current_pkey;
+ALTER TABLE strategy_forecast_assessment_current
+    ADD PRIMARY KEY (
+        policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+        calibration_id,setup_version,exit_policy_version,resolver_version,
+        input_rule_set_version
+    );
+
+COMMENT ON COLUMN strategy_forecast_assessments.strategy_version IS
+    'Exact immutable strategy identity that emitted every signal in this cohort.';

--- a/sql/322_strategy_forecast_assessment_strategy_scope.sql
+++ b/sql/322_strategy_forecast_assessment_strategy_scope.sql
@@ -5,8 +5,49 @@
 -- strategies cannot accidentally share an assessment scope.
 
 ALTER TABLE strategy_forecast_assessments
-    ADD COLUMN strategy_id TEXT NOT NULL,
-    ADD COLUMN strategy_version TEXT NOT NULL;
+    ADD COLUMN strategy_id TEXT,
+    ADD COLUMN strategy_version TEXT;
+
+-- Older assessment rows did not carry strategy identity. Recover it only when
+-- the frozen cohort maps to one exact strategy/version and its row count
+-- reconciles. An ambiguous derived assessment must lose authority and be
+-- rebuilt by the scheduler; assigning a placeholder could authorise the wrong
+-- strategy.
+WITH recoverable AS (
+    SELECT a.assessment_id,
+           min(s.strategy_id) AS strategy_id,
+           min(s.strategy_version) AS strategy_version
+    FROM strategy_forecast_assessments a
+    JOIN strategy_opportunity_forecasts f
+      ON f.forecast_policy_version=a.forecast_policy_version
+     AND f.setup_version=a.setup_version
+     AND f.exit_policy_version=a.exit_policy_version
+     AND f.calibration_id=a.calibration_id
+     AND f.decided_at::date BETWEEN a.window_start AND a.window_end
+    JOIN strategy_forecast_calibrations c
+      ON c.calibration_id=f.calibration_id AND c.model_version=a.model_version
+    JOIN strategy_signals s ON s.signal_id=f.signal_id
+    GROUP BY a.assessment_id,a.total_forecasts
+    HAVING count(*)=a.total_forecasts
+       AND count(DISTINCT (s.strategy_id,s.strategy_version))=1
+)
+UPDATE strategy_forecast_assessments a
+SET strategy_id=recoverable.strategy_id,
+    strategy_version=recoverable.strategy_version
+FROM recoverable
+WHERE recoverable.assessment_id=a.assessment_id;
+
+DELETE FROM strategy_forecast_assessment_current current_assessment
+WHERE EXISTS (
+    SELECT 1 FROM strategy_forecast_assessments assessment
+    WHERE assessment.assessment_id=current_assessment.assessment_id
+      AND assessment.strategy_id IS NULL
+);
+DELETE FROM strategy_forecast_assessments WHERE strategy_id IS NULL;
+
+ALTER TABLE strategy_forecast_assessments
+    ALTER COLUMN strategy_id SET NOT NULL,
+    ALTER COLUMN strategy_version SET NOT NULL;
 
 ALTER TABLE strategy_forecast_assessments
     DROP CONSTRAINT strategy_forecast_assessments_evidence_unique;
@@ -26,8 +67,16 @@ CREATE INDEX idx_strategy_forecast_assessments_scope
     );
 
 ALTER TABLE strategy_forecast_assessment_current
-    ADD COLUMN strategy_id TEXT NOT NULL,
-    ADD COLUMN strategy_version TEXT NOT NULL;
+    ADD COLUMN strategy_id TEXT,
+    ADD COLUMN strategy_version TEXT;
+UPDATE strategy_forecast_assessment_current current_assessment
+SET strategy_id=assessment.strategy_id,
+    strategy_version=assessment.strategy_version
+FROM strategy_forecast_assessments assessment
+WHERE assessment.assessment_id=current_assessment.assessment_id;
+ALTER TABLE strategy_forecast_assessment_current
+    ALTER COLUMN strategy_id SET NOT NULL,
+    ALTER COLUMN strategy_version SET NOT NULL;
 ALTER TABLE strategy_forecast_assessment_current
     DROP CONSTRAINT strategy_forecast_assessment_current_pkey;
 ALTER TABLE strategy_forecast_assessment_current

--- a/sql/323_strategy_forecast_brier_skill_range.sql
+++ b/sql/323_strategy_forecast_brier_skill_range.sql
@@ -1,0 +1,9 @@
+-- 323_strategy_forecast_brier_skill_range.sql
+--
+-- #2557 follow-up to review migration 321: Brier skill is bounded above by
+-- one but unbounded below as the empirical baseline score approaches zero.
+-- The service still quantizes values to eight decimal places; an unbounded
+-- NUMERIC integer range prevents a large imbalanced cohort from overflowing.
+
+ALTER TABLE strategy_forecast_assessments
+    ALTER COLUMN brier_skill_score TYPE NUMERIC;

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -233,6 +233,10 @@ def test_empty_ledgers_still_return_all_manifest_strategies(
     assert all(item.scan.status == "never_run" for item in overview.strategies)
     assert all(not item.all_recent_evidence_complete for item in overview.strategies)
     assert all(len(item.evidence_windows) == 8 for item in overview.strategies)
+    assert not overview.automation_readiness.ready
+    assert overview.automation_readiness.state == "no_capital_candidates"
+    assert overview.automation_readiness.capital_candidate_count == 0
+    assert overview.automation_readiness.resolved_forecasts == 0
     s4 = next(item for item in overview.strategies if item.strategy_id == "s4-volatility-compression-breakout")
     assert s4.runnable
     assert s4.exclusion_reason is None

--- a/tests/test_migration_322_strategy_forecast_scope.py
+++ b/tests/test_migration_322_strategy_forecast_scope.py
@@ -1,8 +1,10 @@
 """Migration 322 safely attributes or invalidates legacy assessment rows."""
 
 from pathlib import Path
+from typing import LiteralString, cast
 
 import psycopg
+from psycopg import sql
 
 _MIGRATION = Path(__file__).resolve().parents[1] / "sql/322_strategy_forecast_assessment_strategy_scope.sql"
 
@@ -86,7 +88,7 @@ def test_migration_322_handles_populated_legacy_tables(ebull_test_conn: psycopg.
         """
     )
 
-    conn.execute(_MIGRATION.read_text())
+    conn.execute(sql.SQL(cast(LiteralString, _MIGRATION.read_text())))
 
     assert conn.execute(
         "SELECT assessment_id,strategy_id,strategy_version FROM strategy_forecast_assessments"

--- a/tests/test_migration_322_strategy_forecast_scope.py
+++ b/tests/test_migration_322_strategy_forecast_scope.py
@@ -1,0 +1,103 @@
+"""Migration 322 safely attributes or invalidates legacy assessment rows."""
+
+from pathlib import Path
+
+import psycopg
+
+_MIGRATION = Path(__file__).resolve().parents[1] / "sql/322_strategy_forecast_assessment_strategy_scope.sql"
+
+
+def test_migration_322_handles_populated_legacy_tables(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    conn = ebull_test_conn
+    conn.execute("SET LOCAL search_path=pg_temp")
+    conn.execute(
+        "CREATE TEMP TABLE strategy_forecast_calibrations (calibration_id text PRIMARY KEY, model_version text)"
+    )
+    conn.execute(
+        "CREATE TEMP TABLE strategy_signals (signal_id bigint PRIMARY KEY, strategy_id text, strategy_version text)"
+    )
+    conn.execute(
+        """
+        CREATE TEMP TABLE strategy_opportunity_forecasts (
+            forecast_id bigint PRIMARY KEY, signal_id bigint, forecast_policy_version text,
+            setup_version text, exit_policy_version text, calibration_id text, decided_at timestamptz
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TEMP TABLE strategy_forecast_assessments (
+            assessment_id bigint PRIMARY KEY, policy_id text, forecast_policy_version text,
+            model_version text, calibration_id text, setup_version text, exit_policy_version text,
+            resolver_version text, input_rule_set_version text, window_start date, window_end date,
+            evidence_hash text, total_forecasts integer,
+            CONSTRAINT strategy_forecast_assessments_evidence_unique UNIQUE (
+                policy_id,forecast_policy_version,model_version,calibration_id,setup_version,
+                exit_policy_version,resolver_version,input_rule_set_version,evidence_hash
+            )
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX idx_strategy_forecast_assessments_scope ON strategy_forecast_assessments (
+            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,
+            exit_policy_version,resolver_version,input_rule_set_version,assessment_id DESC
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TEMP TABLE strategy_forecast_assessment_current (
+            policy_id text, forecast_policy_version text, model_version text, calibration_id text,
+            setup_version text, exit_policy_version text, resolver_version text,
+            input_rule_set_version text, assessment_id bigint, checked_at timestamptz,
+            PRIMARY KEY (
+                policy_id,forecast_policy_version,model_version,calibration_id,setup_version,
+                exit_policy_version,resolver_version,input_rule_set_version
+            )
+        )
+        """
+    )
+    conn.execute("INSERT INTO strategy_forecast_calibrations VALUES ('cal','model')")
+    conn.execute("INSERT INTO strategy_signals VALUES (1,'S-A','v1'),(2,'S-A','v1'),(3,'S-B','v1')")
+    conn.execute(
+        """
+        INSERT INTO strategy_opportunity_forecasts VALUES
+          (1,1,'forecast-v1','exact','exit-v1','cal','2026-08-01T12:00:00Z'),
+          (2,2,'forecast-v1','mixed','exit-v1','cal','2026-08-01T12:00:00Z'),
+          (3,3,'forecast-v1','mixed','exit-v1','cal','2026-08-02T12:00:00Z')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessments VALUES
+          (10,'policy','forecast-v1','model','cal','exact','exit-v1','resolver','rules',
+           '2026-08-01','2026-08-02','hash-1',1),
+          (20,'policy','forecast-v1','model','cal','mixed','exit-v1','resolver','rules',
+           '2026-08-01','2026-08-02','hash-2',2)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO strategy_forecast_assessment_current VALUES
+          ('policy','forecast-v1','model','cal','exact','exit-v1','resolver','rules',10,now()),
+          ('policy','forecast-v1','model','cal','mixed','exit-v1','resolver','rules',20,now())
+        """
+    )
+
+    conn.execute(_MIGRATION.read_text())
+
+    assert conn.execute(
+        "SELECT assessment_id,strategy_id,strategy_version FROM strategy_forecast_assessments"
+    ).fetchall() == [(10, "S-A", "v1")]
+    assert conn.execute(
+        "SELECT assessment_id,strategy_id,strategy_version FROM strategy_forecast_assessment_current"
+    ).fetchall() == [(10, "S-A", "v1")]
+    assert conn.execute(
+        """
+        SELECT is_nullable FROM information_schema.columns
+        WHERE table_schema LIKE 'pg_temp%%' AND table_name='strategy_forecast_assessments'
+          AND column_name='strategy_id'
+        """
+    ).fetchone() == ("NO",)

--- a/tests/test_strategy_forecast_assessment.py
+++ b/tests/test_strategy_forecast_assessment.py
@@ -21,7 +21,15 @@ from app.services.strategy_forecast_assessment import (
 from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION
 from tests.fixtures.ebull_test_db import test_database_url
 
-_SCOPE = ForecastScope("opportunity-forecast-v1", "model-v1", "calibration-v1", "setup-v1", "exit-v1")
+_SCOPE = ForecastScope(
+    "S-ASSESS",
+    "strategy-v1",
+    "opportunity-forecast-v1",
+    "model-v1",
+    "calibration-v1",
+    "setup-v1",
+    "exit-v1",
+)
 
 
 def _policy(**overrides: object) -> ForecastAssessmentPolicy:
@@ -110,6 +118,18 @@ def test_normalized_multiclass_brier_penalises_confident_wrong_forecasts() -> No
     assert "normalized_brier_score_high" in assessment.reason_codes
     assert "classwise_calibration_error_high" in assessment.reason_codes
     assert not assessment.passed
+
+
+def test_brier_skill_preserves_large_negative_evidence_without_clipping() -> None:
+    observations = [
+        _observation(index, probabilities=("0", "1", "0"), outcome="target_first") for index in range(1, 20_001)
+    ]
+    observations.append(_observation(20_001, probabilities=("1", "0", "0"), outcome="stop_first"))
+
+    assessment = _calculate(observations)
+
+    assert assessment.brier_skill_score is not None
+    assert assessment.brier_skill_score < Decimal("-10000")
 
 
 def test_small_apparently_perfect_sample_has_no_authority() -> None:

--- a/tests/test_strategy_monitoring.py
+++ b/tests/test_strategy_monitoring.py
@@ -694,8 +694,19 @@ def _session(username: str = "allocation-operator") -> SessionRow:
 
 def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
     ebull_test_conn: psycopg.Connection[tuple],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     conn = ebull_test_conn
+    actual_overview = get_strategy_overview
+
+    def ready_overview(connection: psycopg.Connection[object]):
+        overview = actual_overview(connection)
+        overview.automation_readiness = overview.automation_readiness.model_copy(
+            update={"ready": True, "state": "ready", "blockers": []}
+        )
+        return overview
+
+    monkeypatch.setattr("app.api.strategies.get_strategy_overview", ready_overview)
     # runtime_config is a deliberately persistent singleton, unlike the
     # per-test pool event stream. Establish the transition this test asserts
     # when an earlier executor test enabled automation.
@@ -765,6 +776,37 @@ def test_shared_paper_pool_is_one_audited_human_event_and_overview_state(
         )
     assert exc_info.value.status_code == 409
     assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (1,)
+
+
+def test_shared_paper_pool_refuses_activation_without_a_ready_candidate(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    conn = ebull_test_conn
+    if get_runtime_config(conn).enable_auto_trading:
+        update_runtime_config(
+            conn,
+            updated_by="test-precondition",
+            reason="establish disabled automation precondition",
+            enable_auto_trading=False,
+        )
+    conn.commit()
+
+    with pytest.raises(HTTPException) as exc_info:
+        update_strategy_paper_pool(
+            StrategyPaperPoolUpdateRequest(
+                enabled=True,
+                capital_limit=Decimal("750"),
+                capital_mode="fixed",
+                risk_profile="balanced",
+                reason="must fail without capital authority",
+            ),
+            _session(),
+            conn,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "no_capital_candidates" in str(exc_info.value.detail)
+    assert conn.execute("SELECT count(*) FROM strategy_paper_pool_events").fetchone() == (0,)
 
 
 def test_evidence_refresh_queues_one_fixed_pinned_request(

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -89,14 +89,15 @@ def _authorise_forecast_scope(
     assessment = conn.execute(
         """
         INSERT INTO strategy_forecast_assessments (
-            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,
             resolver_version,input_rule_set_version,window_start,window_end,evidence_hash,
             total_forecasts,resolved_forecasts,target_first_count,stop_first_count,timeout_count,
             ambiguous_count,unresolved_count,pending_count,normalized_brier_score,
             baseline_normalized_brier_score,brier_skill_score,max_classwise_calibration_error,
             ambiguous_rate,unresolved_rate,pending_rate,passed,reason_codes
         ) VALUES (
-            'test-assessment-policy-v1',%s,'test-model-v1','test-calibration-v1',%s,'test-exit-v1',%s,%s,
+            'test-assessment-policy-v1','S-ALLOC','v1',%s,'test-model-v1','test-calibration-v1',%s,'test-exit-v1',%s,%s,
             %s::date-89,%s::date,'synthetic-' || %s,30,30,10,10,10,0,0,0,0,0.33333333,1,0,0,0,0,true,'[]'::jsonb
         ) RETURNING assessment_id
         """,
@@ -114,9 +115,13 @@ def _authorise_forecast_scope(
     conn.execute(
         """
         INSERT INTO strategy_forecast_assessment_current (
-            policy_id,forecast_policy_version,model_version,calibration_id,setup_version,exit_policy_version,
+            policy_id,strategy_id,strategy_version,forecast_policy_version,model_version,
+            calibration_id,setup_version,exit_policy_version,
             resolver_version,input_rule_set_version,assessment_id,checked_at
-        ) VALUES ('test-assessment-policy-v1',%s,'test-model-v1','test-calibration-v1',%s,'test-exit-v1',%s,%s,%s,%s)
+        ) VALUES (
+            'test-assessment-policy-v1','S-ALLOC','v1',%s,'test-model-v1',
+            'test-calibration-v1',%s,'test-exit-v1',%s,%s,%s,%s
+        )
         """,
         (
             FORECAST_POLICY_VERSION,
@@ -674,6 +679,7 @@ def test_invalid_opportunity_evidence_refuses_before_broker_access(
     [
         ("policy", "opportunity_assessment_policy_missing"),
         ("missing", "opportunity_assessment_missing"),
+        ("strategy_scope", "opportunity_assessment_missing"),
         ("calibration_scope", "opportunity_assessment_missing"),
         ("failed", "opportunity_assessment_not_passed"),
         ("stale", "opportunity_assessment_stale"),
@@ -690,6 +696,8 @@ def test_prospective_assessment_refuses_before_broker_access(
         conn.execute("UPDATE strategy_forecast_assessment_policies SET effective_from=%s + interval '1 day'", (_NOW,))
     elif invalidity == "missing":
         conn.execute("DELETE FROM strategy_forecast_assessment_current")
+    elif invalidity == "strategy_scope":
+        conn.execute("UPDATE strategy_forecast_assessment_current SET strategy_id='S-OTHER'")
     elif invalidity == "calibration_scope":
         conn.execute(
             """


### PR DESCRIPTION
Closes #2557

## What changed
- adds one compact portfolio-level readiness contract with candidate, resolved-outcome and fresh-passing-scope counts
- makes prospective assessment evidence exact to strategy id and immutable strategy version as well as model, calibration, setup and exit versions
- adds prospective assessment refusals to each capital candidate and disables activation until at least one candidate clears every gate
- enforces the same readiness refusal in the paper-pool API, so direct requests cannot bypass the UI
- replaces the generic zero-approved banner with an explicit readiness state; research controls remain collapsed and non-selectable
- preserves unbounded negative Brier skill storage because skill is bounded above but not below; service values remain quantized to eight decimals

## Current development truth
- readiness: no_capital_candidates
- capital candidates: 0
- prospectively ready: 0
- scored outcomes: 0
- four manifest entries remain harness_validation controls
- overview warm median: 12.3 ms across four warm calls
- assessment tables: 32 kB evidence and 16 kB current pointer

## Validation
- full pre-push gate green on 3cc8fd6c
- 91 focused backend tests green
- frontend typecheck and 18 Strategies page tests green
- full 1,504-test frontend suite green
- application smoke boot green against development DB
- migrations 322 and 323 applied with matching content hashes
