### PR TITLE
Capture prospective broker account equity

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -63,6 +63,16 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
   units or FIFO order. The response also supplies opening units, average price,
   execution time and fees; retain these compact facts to prove partial-fill and
   one-to-many cardinality without storing every poll payload.
+- **Historical account balances are documented but unavailable to this demo
+  connection (verified 2026-08-11):** the live portal documents
+  `GET /api/v1/balances/history`, with at most 365 daily snapshots from the last
+  12 months and cash/invested/P&L/total-balance fields. An authenticated,
+  read-only probe using the configured demo credentials returned HTTP 403 with
+  only `errorCode` and `errorMessage`. Do not infer that demo history can be
+  backfilled. eBull instead captures one prospective daily aggregate from the
+  working `/api/v1/trading/info/demo/pnl` response; it stores no raw payload or
+  per-position duplicate. Re-probe the history endpoint before changing that
+  boundary.
 
 ## ⚠⚠ WE HAVE INTRADAY HISTORY. Read this before saying otherwise — MEASURED 2026-08-09
 

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -355,7 +355,7 @@ class AutomationReadinessView(BaseModel):
 
 
 class AccountEquityEvidenceView(BaseModel):
-    status: Literal["unavailable", "collecting", "comparable"]
+    status: Literal["unavailable", "collecting"]
     days_collected: int
     snapshot_date: date | None
     observed_at: datetime | None
@@ -367,7 +367,7 @@ class AccountEquityEvidenceView(BaseModel):
     local_eod_currency: str | None
     local_eod_value: Decimal | None
     difference: Decimal | None
-    comparable: bool
+    comparable: Literal[False]
     incomplete_reasons: list[str]
 
 

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -22,6 +22,7 @@ from app.providers.implementations.etoro_broker import EtoroBrokerProvider
 from app.security.master_key import MasterKeyError, ensure_broker_key_loaded
 from app.security.secrets_crypto import CredentialCryptoConfigError
 from app.security.sessions import SessionRow
+from app.services.account_equity_evidence import load_account_equity_evidence
 from app.services.backtest_run import BACKTEST_UNIVERSE, runnable_strategies
 from app.services.broker_credentials import (
     CredentialDecryptError,
@@ -353,6 +354,23 @@ class AutomationReadinessView(BaseModel):
     blockers: list[str]
 
 
+class AccountEquityEvidenceView(BaseModel):
+    status: Literal["unavailable", "collecting", "comparable"]
+    days_collected: int
+    snapshot_date: date | None
+    observed_at: datetime | None
+    currency: str | None
+    official_equity: Decimal | None
+    official_available_cash: Decimal | None
+    official_total_invested: Decimal | None
+    official_unrealised_pnl: Decimal | None
+    local_eod_currency: str | None
+    local_eod_value: Decimal | None
+    difference: Decimal | None
+    comparable: bool
+    incomplete_reasons: list[str]
+
+
 class StrategyOverviewResponse(BaseModel):
     as_of: datetime
     demo_connection: bool
@@ -366,6 +384,7 @@ class StrategyOverviewResponse(BaseModel):
     entry_block: StrategyEntryBlockView
     paper_pool: StrategyPaperPoolView
     automation_readiness: AutomationReadinessView
+    account_equity_evidence: AccountEquityEvidenceView
     evidence_refresh: EvidenceRefreshView
     strategies: list[StrategyOverview]
 
@@ -949,6 +968,10 @@ def get_strategy_overview(
     control_by_strategy = load_control_state(conn, versions=version_values)
     entry_block = load_entry_block_state(conn)
     paper_pool = load_paper_pool(conn)
+    account_equity = load_account_equity_evidence(
+        conn,
+        environment=cast(Literal["demo", "real"], settings.etoro_env),
+    )
 
     results_by_strategy: dict[str, list[dict[str, object]]] = defaultdict(list)
     for row in result_rows:
@@ -1281,6 +1304,22 @@ def get_strategy_overview(
             weakest_brier_skill_score=min(skill_scores, default=None),
             worst_classwise_calibration_error=max(calibration_errors, default=None),
             blockers=readiness_blockers,
+        ),
+        account_equity_evidence=AccountEquityEvidenceView(
+            status=account_equity.status,
+            days_collected=account_equity.days_collected,
+            snapshot_date=account_equity.snapshot_date,
+            observed_at=account_equity.observed_at,
+            currency=account_equity.currency,
+            official_equity=account_equity.official_equity,
+            official_available_cash=account_equity.official_available_cash,
+            official_total_invested=account_equity.official_total_invested,
+            official_unrealised_pnl=account_equity.official_unrealised_pnl,
+            local_eod_currency=account_equity.local_eod_currency,
+            local_eod_value=account_equity.local_eod_value,
+            difference=account_equity.difference,
+            comparable=account_equity.comparable,
+            incomplete_reasons=list(account_equity.incomplete_reasons),
         ),
         evidence_refresh=EvidenceRefreshView(
             frozen_through=max(item.window.end for item in RECENT_EVIDENCE_WINDOWS.values()),

--- a/app/services/account_equity_evidence.py
+++ b/app/services/account_equity_evidence.py
@@ -1,0 +1,168 @@
+"""Compact official account-equity evidence for Foundation F-0 (#2559)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+import psycopg
+
+from app.providers.broker import BrokerAccountRiskSnapshot
+
+SOURCE_VERSION = "etoro-pnl-v1"
+
+
+class AccountEquityEvidenceError(ValueError):
+    """An official account snapshot cannot be trusted or persisted."""
+
+
+@dataclass(frozen=True)
+class AccountEquityEvidence:
+    status: Literal["unavailable", "collecting", "comparable"]
+    days_collected: int
+    snapshot_date: date | None
+    observed_at: datetime | None
+    currency: str | None
+    official_equity: Decimal | None
+    official_available_cash: Decimal | None
+    official_total_invested: Decimal | None
+    official_unrealised_pnl: Decimal | None
+    local_eod_currency: str | None
+    local_eod_value: Decimal | None
+    difference: Decimal | None
+    comparable: bool
+    incomplete_reasons: tuple[str, ...]
+
+
+def _validate_snapshot(snapshot: BrokerAccountRiskSnapshot) -> None:
+    values = (
+        snapshot.available_cash,
+        snapshot.total_invested,
+        snapshot.unrealized_pnl,
+        snapshot.equity,
+    )
+    if snapshot.observed_at.tzinfo is None:
+        raise AccountEquityEvidenceError("observed_at must be timezone-aware")
+    if not all(value.is_finite() for value in values):
+        raise AccountEquityEvidenceError("account equity values must be finite")
+    if snapshot.available_cash < 0 or snapshot.total_invested < 0 or snapshot.equity <= 0:
+        raise AccountEquityEvidenceError("account equity values are outside safe bounds")
+    if snapshot.equity != snapshot.available_cash + snapshot.total_invested + snapshot.unrealized_pnl:
+        raise AccountEquityEvidenceError("account equity components do not reconcile")
+
+
+def record_account_equity_snapshot(
+    conn: psycopg.Connection[Any],
+    *,
+    environment: Literal["demo", "real"],
+    snapshot: BrokerAccountRiskSnapshot,
+) -> bool:
+    """Store at most the newest official observation for one UTC day."""
+    _validate_snapshot(snapshot)
+    observed_at = snapshot.observed_at.astimezone(UTC)
+    row = conn.execute(
+        """
+        INSERT INTO broker_account_equity_snapshots (
+            environment,snapshot_date,observed_at,source_version,currency,
+            available_cash,total_invested,unrealised_pnl,equity
+        ) VALUES (%s,%s,%s,%s,'USD',%s,%s,%s,%s)
+        ON CONFLICT (environment,snapshot_date) DO UPDATE SET
+            observed_at=EXCLUDED.observed_at,
+            source_version=EXCLUDED.source_version,
+            available_cash=EXCLUDED.available_cash,
+            total_invested=EXCLUDED.total_invested,
+            unrealised_pnl=EXCLUDED.unrealised_pnl,
+            equity=EXCLUDED.equity,
+            recorded_at=now()
+        WHERE EXCLUDED.observed_at > broker_account_equity_snapshots.observed_at
+          AND broker_account_equity_snapshots.snapshot_date=(now() AT TIME ZONE 'UTC')::date
+        RETURNING snapshot_date
+        """,
+        (
+            environment,
+            observed_at.date(),
+            observed_at,
+            SOURCE_VERSION,
+            snapshot.available_cash,
+            snapshot.total_invested,
+            snapshot.unrealized_pnl,
+            snapshot.equity,
+        ),
+    ).fetchone()
+    return row is not None
+
+
+def load_account_equity_evidence(
+    conn: psycopg.Connection[Any], *, environment: Literal["demo", "real"]
+) -> AccountEquityEvidence:
+    """Return the latest official/local comparison with explicit caveats."""
+    row = conn.execute(
+        """
+        WITH latest AS (
+            SELECT *,count(*) OVER () AS days_collected
+            FROM broker_account_equity_snapshots
+            WHERE environment=%s
+            ORDER BY snapshot_date DESC
+            LIMIT 1
+        )
+        SELECT latest.days_collected,latest.snapshot_date,latest.observed_at,latest.currency,
+               latest.available_cash,latest.total_invested,latest.unrealised_pnl,latest.equity,
+               local.display_currency,local.total_value,local.positions_no_price,
+               local.positions_no_fx,local.cash_no_fx_currencies,local.computed_at
+        FROM latest
+        LEFT JOIN portfolio_eod_snapshots local ON local.snapshot_date=latest.snapshot_date
+        """,
+        (environment,),
+    ).fetchone()
+    if row is None:
+        return AccountEquityEvidence(
+            status="unavailable",
+            days_collected=0,
+            snapshot_date=None,
+            observed_at=None,
+            currency=None,
+            official_equity=None,
+            official_available_cash=None,
+            official_total_invested=None,
+            official_unrealised_pnl=None,
+            local_eod_currency=None,
+            local_eod_value=None,
+            difference=None,
+            comparable=False,
+            incomplete_reasons=("official_account_equity_missing",),
+        )
+
+    observed_at = row[2]
+    local_value = Decimal(str(row[9])) if row[9] is not None else None
+    official_equity = Decimal(str(row[7]))
+    reasons: list[str] = []
+    if local_value is None:
+        reasons.append("same_day_local_eod_snapshot_missing")
+    else:
+        if row[8] != row[3]:
+            reasons.append("local_eod_currency_mismatch")
+        if any(int(value or 0) > 0 for value in row[10:13]):
+            reasons.append("local_eod_valuation_incomplete")
+        # computed_at is when the local job ran, not when its closing prices
+        # were effective. Do not call these totals reconciled until the local
+        # valuation carries a defensible effective market timestamp.
+        reasons.append("local_eod_effective_time_unknown")
+    comparable = not reasons
+    return AccountEquityEvidence(
+        status="comparable" if comparable else "collecting",
+        days_collected=int(row[0]),
+        snapshot_date=row[1],
+        observed_at=observed_at,
+        currency=str(row[3]),
+        official_equity=official_equity,
+        official_available_cash=Decimal(str(row[4])),
+        official_total_invested=Decimal(str(row[5])),
+        official_unrealised_pnl=Decimal(str(row[6])),
+        local_eod_currency=None if row[8] is None else str(row[8]),
+        local_eod_value=local_value,
+        difference=official_equity - local_value if local_value is not None and row[8] == row[3] else None,
+        comparable=comparable,
+        incomplete_reasons=tuple(reasons),
+    )

--- a/app/services/account_equity_evidence.py
+++ b/app/services/account_equity_evidence.py
@@ -20,7 +20,7 @@ class AccountEquityEvidenceError(ValueError):
 
 @dataclass(frozen=True)
 class AccountEquityEvidence:
-    status: Literal["unavailable", "collecting", "comparable"]
+    status: Literal["unavailable", "collecting"]
     days_collected: int
     snapshot_date: date | None
     observed_at: datetime | None
@@ -32,7 +32,7 @@ class AccountEquityEvidence:
     local_eod_currency: str | None
     local_eod_value: Decimal | None
     difference: Decimal | None
-    comparable: bool
+    comparable: Literal[False]
     incomplete_reasons: tuple[str, ...]
 
 
@@ -49,7 +49,9 @@ def _validate_snapshot(snapshot: BrokerAccountRiskSnapshot) -> None:
         raise AccountEquityEvidenceError("account equity values must be finite")
     if snapshot.available_cash < 0 or snapshot.total_invested < 0 or snapshot.equity <= 0:
         raise AccountEquityEvidenceError("account equity values are outside safe bounds")
-    if snapshot.equity != snapshot.available_cash + snapshot.total_invested + snapshot.unrealized_pnl:
+    if abs(snapshot.equity - snapshot.available_cash - snapshot.total_invested - snapshot.unrealized_pnl) > Decimal(
+        "0.000001"
+    ):
         raise AccountEquityEvidenceError("account equity components do not reconcile")
 
 
@@ -109,8 +111,10 @@ def load_account_equity_evidence(
         )
         SELECT latest.days_collected,latest.snapshot_date,latest.observed_at,latest.currency,
                latest.available_cash,latest.total_invested,latest.unrealised_pnl,latest.equity,
-               local.display_currency,local.total_value,local.positions_no_price,
-               local.positions_no_fx,local.cash_no_fx_currencies,local.computed_at
+               local.display_currency,local.total_value,
+               coalesce(local.positions_no_price,0) > 0
+                 OR coalesce(local.positions_no_fx,0) > 0
+                 OR coalesce(local.cash_no_fx_currencies,0) > 0 AS local_valuation_incomplete
         FROM latest
         LEFT JOIN portfolio_eod_snapshots local ON local.snapshot_date=latest.snapshot_date
         """,
@@ -143,15 +147,14 @@ def load_account_equity_evidence(
     else:
         if row[8] != row[3]:
             reasons.append("local_eod_currency_mismatch")
-        if any(int(value or 0) > 0 for value in row[10:13]):
+        if bool(row[10]):
             reasons.append("local_eod_valuation_incomplete")
         # computed_at is when the local job ran, not when its closing prices
         # were effective. Do not call these totals reconciled until the local
         # valuation carries a defensible effective market timestamp.
         reasons.append("local_eod_effective_time_unknown")
-    comparable = not reasons
     return AccountEquityEvidence(
-        status="comparable" if comparable else "collecting",
+        status="collecting",
         days_collected=int(row[0]),
         snapshot_date=row[1],
         observed_at=observed_at,
@@ -163,6 +166,6 @@ def load_account_equity_evidence(
         local_eod_currency=None if row[8] is None else str(row[8]),
         local_eod_value=local_value,
         difference=official_equity - local_value if local_value is not None and row[8] == row[3] else None,
-        comparable=comparable,
+        comparable=False,
         incomplete_reasons=tuple(reasons),
     )

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -3899,6 +3899,7 @@ def daily_portfolio_sync() -> None:
     if credentials are missing.
     """
     from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+    from app.services.account_equity_evidence import record_account_equity_snapshot
 
     creds = _load_etoro_credentials(JOB_DAILY_PORTFOLIO_SYNC)
     if creds is None:
@@ -3921,9 +3922,31 @@ def daily_portfolio_sync() -> None:
             # None on fetch failure — positions still sync; the
             # unmoved watermark re-covers the window next tick.
             trade_history = fetch_trade_history_safely(broker, history_min_date)
+            account_snapshot = None
+            if settings.etoro_env == "demo":
+                try:
+                    account_snapshot = broker.get_account_risk_snapshot()
+                except Exception:
+                    logger.warning(
+                        "Portfolio sync: official account-equity evidence unavailable; portfolio sync will continue",
+                        exc_info=True,
+                    )
 
         with connect_job() as conn:
             result = sync_portfolio(conn, portfolio, trade_history=trade_history)
+            if account_snapshot is not None:
+                try:
+                    # sync_portfolio has already opened the outer transaction;
+                    # this nested context is a savepoint so evidence failure
+                    # cannot roll back the primary portfolio refresh.
+                    with conn.transaction():
+                        record_account_equity_snapshot(conn, environment="demo", snapshot=account_snapshot)
+                except Exception:
+                    logger.warning(
+                        "Portfolio sync: official account-equity evidence could not be stored; "
+                        "portfolio sync will continue",
+                        exc_info=True,
+                    )
 
             # Auto-promote held instruments to Tier 1 so market data,
             # FX rates, and downstream jobs fire for them. Without this,

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -229,6 +229,26 @@ Automated paper entry uses the fixed path
 real/demo environment prefix. Demo account risk uses
 `/api/v1/trading/info/demo/pnl` and applies the published formulas below.
 
+### Account-balance history — documented, demo access refused
+
+The live portal documented `GET /api/v1/balances/history` on 2026-08-11. It
+returns no more than 365 daily observations from the preceding 12 months, with
+cash, invested, profit/loss and total-balance fields in the requested display
+currency. A read-only authenticated probe with eBull's configured demo
+credentials returned HTTP 403 and only the standard error keys. Consequently,
+eBull does not claim or synthesize a historical broker-equity backfill.
+
+Foundation F-0 starts a compact prospective ledger from the working
+`/api/v1/trading/info/demo/pnl` endpoint instead: one observation per UTC day
+and environment, aggregate monetary fields only, with no raw response or
+per-position duplication. The newest observation wins within the current UTC
+day. The local EOD row currently records its computation time, not the effective
+time of every closing price, so a same-date difference remains diagnostic and
+must not be labelled reconciled. A collection failure must not block the
+existing portfolio sync.
+
+Primary page: `balances/get-historical-balance-snapshots`.
+
 ### Agent portfolios (copy-trading management)
 
 | Method | Path | Description | eBull status |

--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -115,6 +115,12 @@ Until F-0 reconciles to broker statements, no claim to beat the S&P 500, inflati
 buy-and-hold is valid. Price-only SPY remains useful for market context but not for
 the operator’s wealth comparison. This is not an unsourced vendor dependency:
 
+- issue #2559 begins prospective reconciliation with one official aggregate
+  account-equity observation per UTC day. The documented 12-month eToro balance
+  history endpoint returned 403 for the configured demo account on 2026-08-11,
+  so no historical broker NAV is invented; the working demo P&L endpoint seeds
+  the ledger from the next portfolio sync;
+
 - historical benchmark comparison through the frozen 2024 frontier uses the exact
   legacy comparator's adjusted close and keeps its identity separate; the main stock
   corpus's adjusted closes continue through 2026 but cannot be silently substituted

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2574,6 +2574,22 @@ export interface StrategyOverviewResponse {
     worst_classwise_calibration_error: string | null;
     blockers: string[];
   };
+  account_equity_evidence: {
+    status: "unavailable" | "collecting" | "comparable";
+    days_collected: number;
+    snapshot_date: string | null;
+    observed_at: string | null;
+    currency: string | null;
+    official_equity: string | null;
+    official_available_cash: string | null;
+    official_total_invested: string | null;
+    official_unrealised_pnl: string | null;
+    local_eod_currency: string | null;
+    local_eod_value: string | null;
+    difference: string | null;
+    comparable: boolean;
+    incomplete_reasons: string[];
+  };
   evidence_refresh: {
     frozen_through: string;
     completed_windows: number;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2575,7 +2575,7 @@ export interface StrategyOverviewResponse {
     blockers: string[];
   };
   account_equity_evidence: {
-    status: "unavailable" | "collecting" | "comparable";
+    status: "unavailable" | "collecting";
     days_collected: number;
     snapshot_date: string | null;
     observed_at: string | null;
@@ -2587,7 +2587,7 @@ export interface StrategyOverviewResponse {
     local_eod_currency: string | null;
     local_eod_value: string | null;
     difference: string | null;
-    comparable: boolean;
+    comparable: false;
     incomplete_reasons: string[];
   };
   evidence_refresh: {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -77,6 +77,22 @@ const OVERVIEW: StrategyOverviewResponse = {
     worst_classwise_calibration_error: null,
     blockers: ["historical_validation_incomplete"],
   },
+  account_equity_evidence: {
+    status: "unavailable",
+    days_collected: 0,
+    snapshot_date: null,
+    observed_at: null,
+    currency: null,
+    official_equity: null,
+    official_available_cash: null,
+    official_total_invested: null,
+    official_unrealised_pnl: null,
+    local_eod_currency: null,
+    local_eod_value: null,
+    difference: null,
+    comparable: false,
+    incomplete_reasons: ["official_account_equity_missing"],
+  },
   paper_pool: {
     configured: true,
     enabled: false,
@@ -304,6 +320,35 @@ describe("StrategiesPage", () => {
     expect(screen.getByText("No automated P&L yet")).toBeInTheDocument();
     expect(screen.getAllByText("+1.50%")).toHaveLength(2);
     expect(screen.getByText("Not proven")).toBeInTheDocument();
+    expect(screen.getByText("Official account equity starts collecting with the next portfolio sync.")).toBeInTheDocument();
+  });
+
+  it("shows broker account evidence without presenting it as automated return", async () => {
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
+      ...OVERVIEW,
+      account_equity_evidence: {
+        status: "comparable",
+        days_collected: 3,
+        snapshot_date: "2026-08-11",
+        observed_at: "2026-08-11T19:00:00Z",
+        currency: "USD",
+        official_equity: "1025.00",
+        official_available_cash: "525.00",
+        official_total_invested: "400.00",
+        official_unrealised_pnl: "100.00",
+        local_eod_currency: "USD",
+        local_eod_value: "1020.00",
+        difference: "5.00",
+        comparable: true,
+        incomplete_reasons: [],
+      },
+    });
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    const performance = (await screen.findByText("Portfolio performance")).closest("section")!;
+    expect(within(performance).getByText("3 daily official snapshots")).toBeInTheDocument();
+    expect(within(performance).getByText("US$1,025.00")).toBeInTheDocument();
+    expect(within(performance).getByText("US$5.00")).toBeInTheDocument();
+    expect(within(performance).getByText("No automated P&L yet")).toBeInTheDocument();
   });
 
   it("separates unapproved research from selectable strategies", async () => {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -327,7 +327,7 @@ describe("StrategiesPage", () => {
     vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue({
       ...OVERVIEW,
       account_equity_evidence: {
-        status: "comparable",
+        status: "collecting",
         days_collected: 3,
         snapshot_date: "2026-08-11",
         observed_at: "2026-08-11T19:00:00Z",
@@ -339,15 +339,15 @@ describe("StrategiesPage", () => {
         local_eod_currency: "USD",
         local_eod_value: "1020.00",
         difference: "5.00",
-        comparable: true,
-        incomplete_reasons: [],
+        comparable: false,
+        incomplete_reasons: ["local_eod_effective_time_unknown"],
       },
     });
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     const performance = (await screen.findByText("Portfolio performance")).closest("section")!;
     expect(within(performance).getByText("3 daily official snapshots")).toBeInTheDocument();
     expect(within(performance).getByText("US$1,025.00")).toBeInTheDocument();
-    expect(within(performance).getByText("US$5.00")).toBeInTheDocument();
+    expect(within(performance).getByText("Reconciliation collecting")).toBeInTheDocument();
     expect(within(performance).getByText("No automated P&L yet")).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -226,6 +226,49 @@ function AutomationReadiness({ overview }: { overview: StrategyOverviewResponse 
   );
 }
 
+function AccountEvidence({ overview }: { overview: StrategyOverviewResponse }) {
+  const evidence = overview.account_equity_evidence;
+  const currency = evidence.currency ?? "USD";
+  if (evidence.status === "unavailable") {
+    return (
+      <div className="mt-5 border-t border-slate-200 pt-3 text-xs text-slate-500 dark:border-slate-800">
+        <span className="font-medium text-slate-700 dark:text-slate-300">Account evidence</span>
+        <span className="ml-2">Official account equity starts collecting with the next portfolio sync.</span>
+      </div>
+    );
+  }
+  return (
+    <div className="mt-5 flex flex-wrap items-end justify-between gap-3 border-t border-slate-200 pt-3 text-xs dark:border-slate-800">
+      <div>
+        <span className="font-medium text-slate-700 dark:text-slate-300">Account evidence</span>
+        <span className="ml-2 text-slate-500">
+          {evidence.days_collected} daily official {evidence.days_collected === 1 ? "snapshot" : "snapshots"}
+        </span>
+      </div>
+      <div className="flex gap-5 text-right">
+        <div>
+          <span className="block text-slate-500">Broker equity</span>
+          <strong>{formatMoney(evidence.official_equity === null ? null : Number(evidence.official_equity), currency)}</strong>
+        </div>
+        {evidence.local_eod_value !== null ? (
+          <div>
+            <span className="block text-slate-500">Local valuation</span>
+            <strong>{formatMoney(Number(evidence.local_eod_value), evidence.local_eod_currency ?? currency)}</strong>
+          </div>
+        ) : null}
+        {evidence.comparable && evidence.difference !== null ? (
+          <div>
+            <span className="block text-slate-500">Difference</span>
+            <strong>{formatMoney(Number(evidence.difference), currency)}</strong>
+          </div>
+        ) : (
+          <div className="self-end text-amber-700 dark:text-amber-300">Reconciliation collecting</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function PnlTooltip({
   active,
   payload,
@@ -970,6 +1013,7 @@ export function StrategiesPage() {
               ) : (
                 <EmptyPnlChart />
               )}
+              <AccountEvidence overview={overview.data} />
             </section>
             <AutomationControl overview={overview.data} onUpdated={overview.refetch} />
           </div>

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -256,14 +256,7 @@ function AccountEvidence({ overview }: { overview: StrategyOverviewResponse }) {
             <strong>{formatMoney(Number(evidence.local_eod_value), evidence.local_eod_currency ?? currency)}</strong>
           </div>
         ) : null}
-        {evidence.comparable && evidence.difference !== null ? (
-          <div>
-            <span className="block text-slate-500">Difference</span>
-            <strong>{formatMoney(Number(evidence.difference), currency)}</strong>
-          </div>
-        ) : (
-          <div className="self-end text-amber-700 dark:text-amber-300">Reconciliation collecting</div>
-        )}
+        <div className="self-end text-amber-700 dark:text-amber-300">Reconciliation collecting</div>
       </div>
     </div>
   );

--- a/sql/324_broker_account_equity_snapshots.sql
+++ b/sql/324_broker_account_equity_snapshots.sql
@@ -1,0 +1,24 @@
+-- 324_broker_account_equity_snapshots.sql
+--
+-- #2559: compact prospective F-0 account evidence from eToro's official P&L
+-- endpoint. One row per environment/UTC day; no raw broker payload, positions,
+-- prices, indicators or polling history are duplicated here.
+
+CREATE TABLE broker_account_equity_snapshots (
+    environment       TEXT NOT NULL CHECK (environment IN ('demo','real')),
+    snapshot_date     DATE NOT NULL,
+    observed_at       TIMESTAMPTZ NOT NULL,
+    source_version    TEXT NOT NULL CHECK (source_version <> ''),
+    currency          TEXT NOT NULL CHECK (currency = 'USD'),
+    available_cash    NUMERIC(20,6) NOT NULL CHECK (available_cash >= 0),
+    total_invested    NUMERIC(20,6) NOT NULL CHECK (total_invested >= 0),
+    unrealised_pnl    NUMERIC(20,6) NOT NULL,
+    equity            NUMERIC(20,6) NOT NULL CHECK (equity > 0),
+    recorded_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (environment,snapshot_date),
+    CHECK (snapshot_date = (observed_at AT TIME ZONE 'UTC')::date),
+    CHECK (abs(equity - (available_cash + total_invested + unrealised_pnl)) <= 0.000001)
+);
+
+COMMENT ON TABLE broker_account_equity_snapshots IS
+    'One official prospective account-equity observation per UTC day. Raw P&L payload and per-position facts are deliberately not retained.';

--- a/tests/fixtures/ebull_test_db.py
+++ b/tests/fixtures/ebull_test_db.py
@@ -168,6 +168,9 @@ _PLANNER_TABLES: tuple[str, ...] = (
     # #1594 — EOD equity snapshots (child → parent; parent → instruments).
     "portfolio_eod_position_snapshots",
     "portfolio_eod_snapshots",
+    # #2559 — one compact official broker-equity row per environment/day.
+    # Standalone by design: account evidence is not tied to an instrument.
+    "broker_account_equity_snapshots",
     # #1594 — dated FX (standalone, no FK). Listed so DB tests inserting FX
     # rows don't leak across tests (Codex ckpt-3).
     "fx_rates_daily",

--- a/tests/test_account_equity_evidence.py
+++ b/tests/test_account_equity_evidence.py
@@ -1,0 +1,143 @@
+"""Prospective broker account-equity evidence remains compact and fail-closed."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.providers.broker import BrokerAccountRiskSnapshot
+from app.services.account_equity_evidence import (
+    AccountEquityEvidenceError,
+    load_account_equity_evidence,
+    record_account_equity_snapshot,
+)
+
+
+def _snapshot(
+    *, observed_at: datetime, cash: str = "500", invested: str = "400", pnl: str = "100"
+) -> BrokerAccountRiskSnapshot:
+    available_cash = Decimal(cash)
+    total_invested = Decimal(invested)
+    unrealized_pnl = Decimal(pnl)
+    return BrokerAccountRiskSnapshot(
+        available_cash=available_cash,
+        total_invested=total_invested,
+        unrealized_pnl=unrealized_pnl,
+        equity=available_cash + total_invested + unrealized_pnl,
+        instrument_investments=(),
+        observed_at=observed_at,
+        raw_payload={"not": "persisted"},
+    )
+
+
+def test_empty_account_equity_evidence_is_explicit(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
+    assert evidence.status == "unavailable"
+    assert evidence.days_collected == 0
+    assert evidence.incomplete_reasons == ("official_account_equity_missing",)
+
+
+def test_newest_same_day_observation_wins_without_appending(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    now = datetime.now(UTC).replace(microsecond=0)
+    first = _snapshot(observed_at=now - timedelta(minutes=2))
+    latest = _snapshot(observed_at=now, cash="525")
+    assert record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=first)
+    assert not record_account_equity_snapshot(
+        ebull_test_conn,
+        environment="demo",
+        snapshot=replace(first, observed_at=now - timedelta(minutes=3)),
+    )
+    assert record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=latest)
+
+    row = ebull_test_conn.execute(
+        "SELECT count(*),max(equity) FROM broker_account_equity_snapshots WHERE environment='demo'"
+    ).fetchone()
+    assert row == (1, Decimal("1025.000000"))
+
+
+def test_historical_observation_is_immutable(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    yesterday = datetime.now(UTC).replace(microsecond=0) - timedelta(days=1)
+    first = _snapshot(observed_at=yesterday)
+    assert record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=first)
+    assert not record_account_equity_snapshot(
+        ebull_test_conn,
+        environment="demo",
+        snapshot=_snapshot(observed_at=yesterday + timedelta(minutes=2), cash="600"),
+    )
+
+
+@pytest.mark.parametrize(
+    "snapshot",
+    [
+        _snapshot(observed_at=datetime.now(UTC), cash="NaN"),
+        _snapshot(observed_at=datetime.now(UTC), cash="-1"),
+        replace(_snapshot(observed_at=datetime.now(UTC)), equity=Decimal("999")),
+        _snapshot(observed_at=datetime.now()),
+    ],
+)
+def test_invalid_official_values_fail_closed(
+    ebull_test_conn: psycopg.Connection[tuple], snapshot: BrokerAccountRiskSnapshot
+) -> None:
+    with pytest.raises(AccountEquityEvidenceError):
+        record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=snapshot)
+
+
+def test_local_total_remains_diagnostic_until_effective_time_is_known(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    observed = datetime.now(UTC).replace(microsecond=0)
+    snapshot = _snapshot(observed_at=observed)
+    record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=snapshot)
+    ebull_test_conn.execute(
+        """
+        INSERT INTO portfolio_eod_snapshots (
+          snapshot_date,display_currency,total_value,positions_value,cash_value,
+          positions_total,positions_priced,computed_at
+        ) VALUES (%s,'USD',995,495,500,1,1,%s)
+        """,
+        (observed.date(), observed + timedelta(minutes=1)),
+    )
+
+    evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
+    assert evidence.status == "collecting"
+    assert evidence.days_collected == 1
+    assert evidence.official_equity == Decimal("1000.000000")
+    assert evidence.local_eod_value == Decimal("995.0000")
+    assert evidence.local_eod_currency == "USD"
+    assert evidence.difference == Decimal("5.000000")
+    assert evidence.incomplete_reasons == ("local_eod_effective_time_unknown",)
+
+
+def test_incomplete_local_valuation_exposes_reasons_not_false_comparison(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    observed = datetime.now(UTC).replace(microsecond=0)
+    record_account_equity_snapshot(
+        ebull_test_conn,
+        environment="demo",
+        snapshot=_snapshot(observed_at=observed),
+    )
+    ebull_test_conn.execute(
+        """
+        INSERT INTO portfolio_eod_snapshots (
+          snapshot_date,display_currency,total_value,positions_value,cash_value,
+          positions_total,positions_priced,positions_no_price,computed_at
+        ) VALUES (%s,'GBP',900,400,500,1,0,1,%s)
+        """,
+        (observed.date(), observed - timedelta(hours=1)),
+    )
+    evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
+    assert evidence.status == "collecting"
+    assert not evidence.comparable
+    assert evidence.difference is None
+    assert set(evidence.incomplete_reasons) == {
+        "local_eod_currency_mismatch",
+        "local_eod_valuation_incomplete",
+        "local_eod_effective_time_unknown",
+    }

--- a/tests/test_account_equity_evidence.py
+++ b/tests/test_account_equity_evidence.py
@@ -72,6 +72,16 @@ def test_historical_observation_is_immutable(ebull_test_conn: psycopg.Connection
     )
 
 
+def test_sub_micro_unit_component_rounding_is_accepted(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    snapshot = replace(
+        _snapshot(observed_at=datetime.now(UTC)),
+        equity=Decimal("1000.000001"),
+    )
+    assert record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=snapshot)
+
+
 @pytest.mark.parametrize(
     "snapshot",
     [

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -237,6 +237,8 @@ def test_empty_ledgers_still_return_all_manifest_strategies(
     assert overview.automation_readiness.state == "no_capital_candidates"
     assert overview.automation_readiness.capital_candidate_count == 0
     assert overview.automation_readiness.resolved_forecasts == 0
+    assert overview.account_equity_evidence.status == "unavailable"
+    assert overview.account_equity_evidence.days_collected == 0
     s4 = next(item for item in overview.strategies if item.strategy_id == "s4-volatility-compression-breakout")
     assert s4.runnable
     assert s4.exclusion_reason is None


### PR DESCRIPTION
Closes #2559

## Outcome
- captures one compact official demo account-equity observation per UTC day during portfolio sync
- keeps portfolio sync non-blocking if broker collection or evidence storage fails
- exposes honest collecting/reconciliation status on the Strategies overview
- documents that eToro balance history is officially available but returned 403 for the configured demo account
- stores aggregate monetary facts only: no raw payload, prices, indicators, or duplicated positions

## Accounting boundary
The local EOD snapshot does not yet carry the effective timestamp of its closing prices. Same-date differences remain diagnostic and are never labelled reconciled until that provenance exists.

## Validation
- full pre-push gate green
- focused PostgreSQL evidence and strategy API tests green
- strict eToro broker parser tests green
- 19 Strategies page tests and frontend typecheck green
- local Codex review clean after fixing time-alignment and currency-labelling findings

## Storage
The empty relation is 16 kB locally; a representative row is 96 bytes before page/index overhead. Cardinality is bounded to one row per environment/day.