### PR TITLE
Fix live eToro account-equity collection envelope

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -73,6 +73,12 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
   working `/api/v1/trading/info/demo/pnl` response; it stores no raw payload or
   per-position duplicate. Re-probe the history endpoint before changing that
   boundary.
+- **The live P&L payload has a required envelope (verified 2026-08-11):** the
+  HTTP-200 response contains a top-level `clientPortfolio` object. Formula
+  inputs live inside it, including singular `credit`, `positions`, `mirrors`,
+  `ordersForOpen`, and `orders`. Fixtures must preserve this observed shape.
+  Fail closed if the envelope or a required component is absent; never flatten
+  speculatively or turn response drift into zero account equity.
 
 ## ⚠⚠ WE HAVE INTRADAY HISTORY. Read this before saying otherwise — MEASURED 2026-08-09
 

--- a/app/providers/implementations/etoro_broker.py
+++ b/app/providers/implementations/etoro_broker.py
@@ -1151,7 +1151,12 @@ def _parse_account_risk_snapshot(
     *,
     observed_at: datetime,
 ) -> BrokerAccountRiskSnapshot:
-    """Apply eToro's published cash/invested/equity formulas exactly."""
+    """Apply eToro's published cash/invested/equity formulas exactly.
+
+    The live v1 endpoint wraps the formula inputs in ``clientPortfolio``.
+    Keep that envelope strict so an HTTP-200 error or a future response-shape
+    change cannot be mistaken for a zero/healthy account.
+    """
 
     def _array(parent: dict[str, Any], key: str) -> list[Any]:
         value = parent.get(key)
@@ -1188,11 +1193,14 @@ def _parse_account_risk_snapshot(
         return value
 
     try:
-        credit = _money(raw, "credits")
-        positions = _array(raw, "positions")
-        mirrors = _array(raw, "mirrors")
-        open_orders = _array(raw, "ordersForOpen")
-        orders = _array(raw, "orders")
+        portfolio = raw.get("clientPortfolio")
+        if not isinstance(portfolio, dict):
+            raise TradingPreflightParseError("account P&L clientPortfolio must be an object")
+        credit = _money(portfolio, "credit")
+        positions = _array(portfolio, "positions")
+        mirrors = _array(portfolio, "mirrors")
+        open_orders = _array(portfolio, "ordersForOpen")
+        orders = _array(portfolio, "orders")
         investments: dict[int, Decimal] = {}
         total_invested = Decimal("0")
         unrealized = Decimal("0")

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -228,6 +228,10 @@ Automated paper entry uses the fixed path
 `/api/v2/trading/execution/demo/orders`; it is intentionally not formed from a
 real/demo environment prefix. Demo account risk uses
 `/api/v1/trading/info/demo/pnl` and applies the published formulas below.
+The live response shape was verified on 2026-08-11: formula inputs are nested
+under the required `clientPortfolio` object and available cash starts from its
+singular `credit` field. The provider rejects an absent/malformed envelope or
+missing component array; it does not interpret response drift as a zero balance.
 
 ### Account-balance history — documented, demo access refused
 

--- a/tests/test_broker_provider.py
+++ b/tests/test_broker_provider.py
@@ -155,25 +155,27 @@ FIXTURE_WHAT_IF_COST_RESPONSE = {
 }
 
 FIXTURE_ACCOUNT_PNL_RESPONSE = {
-    "credits": 1000,
-    "positions": [
-        {"instrumentId": 1001, "amount": 200, "unrealizedPnL": {"pnL": 20}},
-        {"instrumentId": 1002, "amount": 100, "unrealizedPnL": {"pnL": -5}},
-    ],
-    "mirrors": [
-        {
-            "availableAmount": 50,
-            "closedPositionsNetProfit": 10,
-            "positions": [
-                {"instrumentId": 1001, "amount": 25, "unrealizedPnL": {"pnL": 2}},
-            ],
-        }
-    ],
-    "ordersForOpen": [
-        {"instrumentId": 1001, "mirrorID": 0, "amount": 40, "totalExternalCosts": 1},
-        {"instrumentId": 1002, "mirrorID": 99, "amount": 999, "totalExternalCosts": 999},
-    ],
-    "orders": [{"instrumentId": 1002, "amount": 30}],
+    "clientPortfolio": {
+        "credit": 1000,
+        "positions": [
+            {"instrumentID": 1001, "amount": 200, "unrealizedPnL": {"pnL": 20}},
+            {"instrumentID": 1002, "amount": 100, "unrealizedPnL": {"pnL": -5}},
+        ],
+        "mirrors": [
+            {
+                "availableAmount": 50,
+                "closedPositionsNetProfit": 10,
+                "positions": [
+                    {"instrumentID": 1001, "amount": 25, "unrealizedPnL": {"pnL": 2}},
+                ],
+            }
+        ],
+        "ordersForOpen": [
+            {"instrumentID": 1001, "mirrorID": 0, "amount": 40, "totalExternalCosts": 1},
+            {"instrumentID": 1002, "mirrorID": 99, "amount": 999, "totalExternalCosts": 999},
+        ],
+        "orders": [{"instrumentID": 1002, "amount": 30}],
+    }
 }
 
 
@@ -327,7 +329,12 @@ class TestStrategyAccountRisk:
 
     def test_account_risk_fails_closed_on_partial_pnl_shape(self) -> None:
         mock_resp = MagicMock()
-        mock_resp.json.return_value = {**FIXTURE_ACCOUNT_PNL_RESPONSE, "orders": None}
+        mock_resp.json.return_value = {
+            "clientPortfolio": {
+                **FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"],
+                "orders": None,
+            }
+        }
         with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
             broker._http_read = MagicMock()
             broker._http_read.get.return_value = mock_resp
@@ -337,6 +344,19 @@ class TestStrategyAccountRisk:
                 assert "orders" in str(exc)
             else:  # pragma: no cover
                 raise AssertionError("partial P&L response must fail closed")
+
+    def test_account_risk_fails_closed_without_live_envelope(self) -> None:
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = FIXTURE_ACCOUNT_PNL_RESPONSE["clientPortfolio"]
+        with EtoroBrokerProvider(api_key="k", user_key="u", env="demo") as broker:
+            broker._http_read = MagicMock()
+            broker._http_read.get.return_value = mock_resp
+            try:
+                broker.get_account_risk_snapshot()
+            except TradingPreflightParseError as exc:
+                assert "clientPortfolio" in str(exc)
+            else:  # pragma: no cover
+                raise AssertionError("unwrapped P&L response must fail closed")
 
 
 class TestDemoStrategyOrder:


### PR DESCRIPTION
## Outcome\nRepairs the prospective official account-equity collector against the verified live eToro demo P&L response. The first real collection now succeeds and writes one compact, reconciled daily observation.\n\n## Changes\n- require the live `clientPortfolio` response envelope\n- use eToro's documented singular `credit` field\n- retain strict required-array and numeric validation\n- replace the misleading unwrapped fixture with the observed key shape\n- document the verified 2026-08-11 contract in both eToro references\n\n## Validation\n- focused provider/evidence tests pass\n- full pre-push gate passes\n- local Codex review found no regression\n- real `daily_portfolio_sync` completed against configured demo credentials\n- stored row count: 1; USD/source constraints and component reconciliation all pass\n- no response values were logged; no raw or per-position payload is stored\n\nCloses #2561\n