### PR TITLE
Reclaim bounded strategy-ledger index bloat

### DIFF
--- a/docs/proposals/ta/2026-08-11-strategy-index-cleanup-result.md
+++ b/docs/proposals/ta/2026-08-11-strategy-index-cleanup-result.md
@@ -1,0 +1,72 @@
+# Strategy-ledger index cleanup result
+
+Date: 2026-08-11
+
+Issue: #2486
+
+Scope: database efficiency only; no strategy, signal, outcome or trading rule changes
+
+## Before
+
+The dev database was 63 GB with 135 GiB filesystem headroom and no running
+strategy, evidence or backtest job. The strategy relations themselves were
+small; historical write churn had left disproportionate indexes:
+
+| relation | live rows | heap | indexes | relevant index |
+| --- | ---: | ---: | ---: | --- |
+| `strategy_outcomes` | 4 | 8 kB | 23 MB | duplicate non-unique 10 MB plus unique 10 MB |
+| `strategy_signals` | 5,279 | 8.0 MB | 17 MB | unique identity index 14 MB |
+
+`idx_strategy_outcomes_signal_versions` and the constraint-owned
+`strategy_outcomes_unique` both indexed exactly
+`(signal_id, rule_set_version, input_rule_set_version)`. Repository-wide read
+enumeration found four consumers: pending-outcome selection, strategy
+monitoring, the live gate and the Strategies activity query. Every consumer
+probes equality on all three columns; none needs different ordering, included
+columns or a non-unique semantic.
+
+With sequential scans disabled solely to expose the nested lookup choice, the
+exact pending-outcome production join used the duplicate index for 108 probes
+and completed in 3.742 ms. That proves the lookup shape, not that the 10 MB
+copy is required: the unique index has the same ordered keys and cardinality
+guarantee.
+
+## Maintenance contract
+
+Migration 325:
+
+1. runs in autocommit because PostgreSQL forbids concurrent index maintenance
+   inside a transaction;
+2. drops only the structurally duplicate index with `DROP INDEX CONCURRENTLY`;
+3. rebuilds the two historically bloated unique indexes with `REINDEX INDEX
+   CONCURRENTLY`;
+4. refuses lock acquisition after five seconds and bounds each maintenance
+   statement to five minutes;
+5. remains replay-safe if interrupted: the drop is `IF EXISTS` and every
+   reindex targets the surviving constraint index by its stable name.
+
+No `VACUUM FULL`, table rewrite, row deletion or trading-state mutation is
+performed. The migration should be applied outside an active evidence/backtest
+run; the measured dev application satisfied that prerequisite.
+
+## After and verification
+
+Migration 325 completed in under one second on dev. Immediately afterwards:
+
+| relation | index bytes after | reduction from measured before |
+| --- | ---: | ---: |
+| `strategy_outcomes` | 2,441,216 (2.3 MB) | about 20.6 MB |
+| `strategy_signals` | 3,989,504 (3.8 MB) | about 13.2 MB |
+
+The four outcome rows and 5,279 signal rows were unchanged. The controlled
+pending-outcome plan switched to `strategy_outcomes_unique` for all 108 nested
+probes and completed in 0.681 ms versus 3.742 ms before. This is a small-table
+plan check, not a general latency claim; its purpose is to prove the surviving
+index supplies the production equality lookup.
+
+The real bounded `strategy_outcome_resolution` job then completed successfully,
+selecting 106 observations and writing four newly mature outcomes while leaving
+both index byte totals unchanged. There were no dead tuples. This confirms a
+representative scan/write cycle does not immediately recreate the historical
+bloat. Application boot, migration-on-clean-database and the complete repository
+gate remain the merge checks.

--- a/sql/325_strategy_ledger_index_cleanup.sql
+++ b/sql/325_strategy_ledger_index_cleanup.sql
@@ -1,0 +1,23 @@
+-- runner: autocommit
+-- #2486 — the UNIQUE constraint index already supplies the exact
+-- (signal_id, rule_set_version, input_rule_set_version) lookup used by all
+-- four strategy_outcomes readers. The duplicate non-unique index had 111,204
+-- scans but was structurally interchangeable and occupied 10 MB for four live
+-- rows after historical churn.
+--
+-- CONCURRENTLY keeps reads and writes available. The migration is deliberately
+-- autocommit and idempotent: if a timeout interrupts it after the drop, the next
+-- run can safely replay the drop and both reindexes. The two compact unique
+-- indexes are rebuilt to reclaim pre-bounded-ledger pages (14 MB and 10 MB on
+-- dev before this migration). Five-second lock acquisition refuses rather than
+-- disrupting an active workload; the five-minute statement limit bounds the
+-- maintenance operation.
+SET lock_timeout = '5s';
+SET statement_timeout = '5min';
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_strategy_outcomes_signal_versions;
+REINDEX INDEX CONCURRENTLY strategy_outcomes_unique;
+REINDEX INDEX CONCURRENTLY strategy_signals_unique;
+
+RESET statement_timeout;
+RESET lock_timeout;

--- a/tests/test_strategy_index_cleanup.py
+++ b/tests/test_strategy_index_cleanup.py
@@ -1,0 +1,39 @@
+"""The bounded strategy ledgers keep one useful index per lookup shape."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import psycopg
+
+
+def test_duplicate_outcome_index_is_removed_but_unique_lookup_remains(
+    ebull_test_conn: psycopg.Connection,
+) -> None:
+    indexes = {
+        str(row[0]): str(row[1])
+        for row in ebull_test_conn.execute(
+            """
+            SELECT indexname,indexdef
+            FROM pg_indexes
+            WHERE schemaname='public' AND tablename='strategy_outcomes'
+            """
+        ).fetchall()
+    }
+
+    assert "idx_strategy_outcomes_signal_versions" not in indexes
+    assert "strategy_outcomes_unique" in indexes
+    assert "UNIQUE INDEX" in indexes["strategy_outcomes_unique"]
+    assert "(signal_id, rule_set_version, input_rule_set_version)" in indexes["strategy_outcomes_unique"]
+
+
+def test_cleanup_is_bounded_concurrent_and_replay_safe() -> None:
+    migration = Path(__file__).resolve().parents[1] / "sql" / "325_strategy_ledger_index_cleanup.sql"
+    sql = migration.read_text()
+
+    assert sql.lstrip().startswith("-- runner: autocommit")
+    assert "DROP INDEX CONCURRENTLY IF EXISTS idx_strategy_outcomes_signal_versions" in sql
+    assert "REINDEX INDEX CONCURRENTLY strategy_outcomes_unique" in sql
+    assert "REINDEX INDEX CONCURRENTLY strategy_signals_unique" in sql
+    assert "lock_timeout = '5s'" in sql
+    assert "statement_timeout = '5min'" in sql


### PR DESCRIPTION
## Outcome\nRemoves one structurally duplicate outcome index and concurrently rebuilds the two historically bloated strategy identity indexes. No rows or trading decisions change.\n\n## Measured dev result\n- outcome indexes: 23 MB -> 2.3 MB\n- signal indexes: 17 MB -> 3.8 MB\n- outcome/signal rows preserved\n- production equality lookup switched to the surviving unique index\n- bounded outcome resolver succeeded, wrote four mature outcomes, and index bytes did not regrow\n\n## Safety\n- `DROP INDEX CONCURRENTLY IF EXISTS`\n- `REINDEX INDEX CONCURRENTLY`\n- 5s lock timeout; 5min statement timeout\n- idempotent autocommit migration\n- no `VACUUM FULL`, table rewrite, row deletion, or strategy-state mutation\n- applied only after proving no strategy/evidence/backtest job was running and 135 GiB filesystem headroom existed\n\n## Validation\n- migration succeeds on dev and clean test databases\n- focused ledger/schema tests pass\n- full repository gate passes\n- local Codex review approves\n\nCloses #2486\n