### PR TITLE
research(backtest): attribute returns to sizing policy

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -74,10 +74,14 @@ from app.services.deflated_sharpe import (
 )
 from app.services.equity_curve import (
     BENCHMARK_RULE_ID,
+    ENTRY_WEIGHT_DRIFT_RULE_ID,
+    MONTH_END_REBALANCE_RULE_ID,
     SIZING_RULE_ID,
     LegBook,
     build_buy_and_hold_curve,
+    build_entry_weight_drift_curve,
     build_equity_curve,
+    build_month_end_rebalanced_curve,
 )
 from app.services.indicator_series import BarSeries, Universe
 from app.services.outcome_resolver import RULE_SET_VERSION as OUTCOME_RULE_SET_VERSION
@@ -386,6 +390,12 @@ class NamespaceMeasurement:
     #: guarantee, which is why the bound is stated as ``<=``.
     label_starts: array[int] = field(default_factory=lambda: array("i"))
     label_ends: array[int] = field(default_factory=lambda: array("i"))
+    #: Sizing-path diagnostics retained for rule attribution (#2430). These are
+    #: not promotion metrics; they explain whether a return changed because a
+    #: rule traded more or could not fund otherwise-identical entries.
+    rebalance_costs: float = 0.0
+    short_funded_entries: int = 0
+    traded_notional_total: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -1233,6 +1243,7 @@ def _measure_namespace(
     corpus: _Corpus,
     raw_closes_by_instrument: Mapping[int, tuple[int, array[float]]],
     wealth_closes_by_instrument: Mapping[int, tuple[int, array[float]]],
+    sizing_rule: str = SIZING_RULE_ID,
 ) -> NamespaceMeasurement | None:
     """Build this namespace's curve on its own axis and compute criterion 7's set.
 
@@ -1273,7 +1284,15 @@ def _measure_namespace(
         )
 
     dates = corpus.axis[lo : hi + 1]
-    curve = build_equity_curve(_shifted(book.book, lo), date_count=len(dates))
+    shifted = _shifted(book.book, lo)
+    if sizing_rule == SIZING_RULE_ID:
+        curve = build_equity_curve(shifted, date_count=len(dates))
+    elif sizing_rule == ENTRY_WEIGHT_DRIFT_RULE_ID:
+        curve = build_entry_weight_drift_curve(shifted, date_count=len(dates))
+    elif sizing_rule == MONTH_END_REBALANCE_RULE_ID:
+        curve = build_month_end_rebalanced_curve(shifted, dates=dates)
+    else:
+        raise ValueError(f"unknown sizing rule {sizing_rule!r}")
     instruments = frozenset(book.instruments)
     # ⚠⚠ NOT ``build_equity_curve`` — #2426. The benchmark shares this engine's
     # cost model and fill contract deliberately, but NOT its sizing rule:
@@ -1329,6 +1348,9 @@ def _measure_namespace(
         axis_last=dates[-1],
         label_starts=book.label_starts,
         label_ends=book.label_ends,
+        rebalance_costs=curve.rebalance_costs,
+        short_funded_entries=curve.short_funded_entries,
+        traded_notional_total=float(curve.traded_notional.sum()),
     )
 
 
@@ -1343,6 +1365,7 @@ def evaluate_arm(
     namespaces: Sequence[ResultNamespace],
     progress: ProgressCallback | None = None,
     return_basis: str = TOTAL_RETURN_BASIS,
+    sizing_rule: str = SIZING_RULE_ID,
 ) -> ArmMeasurement:
     """One ``(strategy, quarantine arm)`` corpus pass, end to end.
 
@@ -1360,6 +1383,8 @@ def evaluate_arm(
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
+    if sizing_rule not in {SIZING_RULE_ID, ENTRY_WEIGHT_DRIFT_RULE_ID, MONTH_END_REBALANCE_RULE_ID}:
+        raise ValueError(f"unknown sizing rule {sizing_rule!r}")
     regime = _regime_for(entry, corpus.axis)
     if regime.level_based != (ambiguity_arm is not None):
         raise ValueError(
@@ -1495,6 +1520,7 @@ def evaluate_arm(
             corpus=corpus,
             raw_closes_by_instrument=raw_closes_by_instrument,
             wealth_closes_by_instrument=wealth_closes_by_instrument,
+            sizing_rule=sizing_rule,
         )
         if outcome is not None:
             measured[name] = outcome
@@ -1521,6 +1547,7 @@ def evaluate_level_arms(
     namespaces: Sequence[ResultNamespace],
     progress: ProgressCallback | None = None,
     return_basis: str = TOTAL_RETURN_BASIS,
+    sizing_rule: str = SIZING_RULE_ID,
 ) -> tuple[ArmMeasurement, ...]:
     """Evaluate both daily-OHLC ambiguity projections from one corpus pass.
 
@@ -1533,6 +1560,8 @@ def evaluate_level_arms(
     started = time.monotonic()
     if return_basis not in {LEGACY_RETURN_BASIS, TOTAL_RETURN_BASIS}:
         raise ValueError(f"unknown return basis {return_basis!r}")
+    if sizing_rule not in {SIZING_RULE_ID, ENTRY_WEIGHT_DRIFT_RULE_ID, MONTH_END_REBALANCE_RULE_ID}:
+        raise ValueError(f"unknown sizing rule {sizing_rule!r}")
     regime = _regime_for(entry, corpus.axis)
     if not regime.level_based:
         raise ValueError(f"{entry.strategy_id} is not level-based and has no ambiguity arms to share")
@@ -1666,6 +1695,7 @@ def evaluate_level_arms(
                 corpus=corpus,
                 raw_closes_by_instrument=raw_closes_by_instrument,
                 wealth_closes_by_instrument=wealth_closes_by_instrument,
+                sizing_rule=sizing_rule,
             )
             if outcome is not None:
                 measured[name] = outcome

--- a/app/services/equity_curve.py
+++ b/app/services/equity_curve.py
@@ -60,7 +60,9 @@ recomputed fill could be expressed. The caller resolves them from the ledger.
 from __future__ import annotations
 
 from array import array
+from collections.abc import Sequence
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Final
 
 import numpy as np
@@ -95,6 +97,18 @@ import numpy.typing as npt
 #:      ``cash >= 0`` hold by construction rather than by tolerance, and the
 #:      under-investment that leaves is exactly the cost charged.
 SIZING_RULE_ID: Final = "equal_weight_concurrent_v1"
+
+#: Research arm for #2430. A new position receives the same causal entry-time
+#: target as v1 (equity divided by the post-entry concurrent count), but every
+#: holding is then left to drift until its ledger exit. It is deliberately not
+#: the production ``SIZING_RULE_ID`` and cannot inherit production evidence.
+ENTRY_WEIGHT_DRIFT_RULE_ID: Final = "entry_weight_drift_v1"
+
+#: #2430's implementable middle arm: positions still enter and exit at their
+#: ledger fills, but the synthetic equalisation trade is allowed only at a
+#: panel-calendar month end. It separates ordinary portfolio maintenance from
+#: v1's accidental coupling of turnover to how often any name opens or closes.
+MONTH_END_REBALANCE_RULE_ID: Final = "calendar_month_end_equal_weight_v1"
 
 #: How criterion 7's buy-and-hold BENCHMARK is composed. ⚠ FROZEN AND HASHED —
 #: it is ``ResultIdentity.benchmark_rule``, and it exists as a separate id for
@@ -273,13 +287,15 @@ class EquityCurve:
                 raise ValueError(f"{name} has {len(other)} entries against {n} dates")
 
 
-def build_equity_curve(
+def _build_strategy_curve(
     book: LegBook,
     *,
     date_count: int,
     starting_equity: float = 1.0,
+    rebalance_events: bool,
+    scheduled_rebalance_indices: frozenset[int] = frozenset(),
 ) -> EquityCurve:
-    """Walk the date axis once, applying ``SIZING_RULE_ID``.
+    """Shared strategy walk; ``rebalance_events`` is the #2430 A/B switch.
 
     ⚠⚠ ORDER WITHIN A DATE IS FIXED AND IS §3.2 RULE 4: **exits, then entries,
     then the mark, then the rebalance.** *"An exit row whose fill bar equals a
@@ -466,7 +482,8 @@ def build_equity_curve(
         #    a target the frozen leg can never move to and force every tradeable
         #    leg to absorb the shortfall, which is a different sizing rule.
         tradeable = [leg for leg in open_legs if leg not in frozen]
-        if event and tradeable:
+        rebalance_now = (rebalance_events and event) or day in scheduled_rebalance_indices
+        if rebalance_now and tradeable:
             held = 0.0
             for leg in tradeable:
                 held += units[leg] * last_price[leg]
@@ -512,6 +529,69 @@ def build_equity_curve(
         short_funded_entries=short_funded,
         stale_marks=stale_marks,
         unrealised_held=len(frozen),
+    )
+
+
+def build_equity_curve(
+    book: LegBook,
+    *,
+    date_count: int,
+    starting_equity: float = 1.0,
+) -> EquityCurve:
+    """Walk the date axis once, applying production ``SIZING_RULE_ID``."""
+    return _build_strategy_curve(
+        book,
+        date_count=date_count,
+        starting_equity=starting_equity,
+        rebalance_events=True,
+    )
+
+
+def build_entry_weight_drift_curve(
+    book: LegBook,
+    *,
+    date_count: int,
+    starting_equity: float = 1.0,
+) -> EquityCurve:
+    """#2430 arm: equal entry-time targets, then no synthetic rebalance trades.
+
+    Entries and exits keep their exact stored net fills and ordering. New
+    positions use the same causal target and cash cap as production v1. The
+    only removed operation is step 4's event-date equalisation, so the result
+    isolates how much return, drawdown and turnover that rule contributes.
+    """
+    return _build_strategy_curve(
+        book,
+        date_count=date_count,
+        starting_equity=starting_equity,
+        rebalance_events=False,
+    )
+
+
+def build_month_end_rebalanced_curve(
+    book: LegBook,
+    *,
+    dates: Sequence[date],
+    starting_equity: float = 1.0,
+) -> EquityCurve:
+    """#2430 arm: restore equal weight only at each panel-calendar month end."""
+    if any(later <= earlier for earlier, later in zip(dates, dates[1:], strict=False)):
+        raise ValueError("dates must be strictly increasing for a causal month-end calendar")
+    # A boundary is observable only when the next panel date belongs to a new
+    # month.  The final date may merely be a truncated evaluation boundary
+    # (for example 8 July), so treating it as a month-end would add a synthetic
+    # trade with no forward holding period and contaminate the comparison.
+    month_ends = frozenset(
+        index
+        for index, when in enumerate(dates[:-1])
+        if (dates[index + 1].year, dates[index + 1].month) != (when.year, when.month)
+    )
+    return _build_strategy_curve(
+        book,
+        date_count=len(dates),
+        starting_equity=starting_equity,
+        rebalance_events=False,
+        scheduled_rebalance_indices=month_ends,
     )
 
 
@@ -687,9 +767,13 @@ def build_buy_and_hold_curve(
 
 __all__ = [
     "BENCHMARK_RULE_ID",
+    "ENTRY_WEIGHT_DRIFT_RULE_ID",
+    "MONTH_END_REBALANCE_RULE_ID",
     "SIZING_RULE_ID",
     "EquityCurve",
     "LegBook",
     "build_buy_and_hold_curve",
+    "build_entry_weight_drift_curve",
     "build_equity_curve",
+    "build_month_end_rebalanced_curve",
 ]

--- a/docs/proposals/ta/2026-08-07-bounded-backtester.md
+++ b/docs/proposals/ta/2026-08-07-bounded-backtester.md
@@ -674,6 +674,16 @@ return on almost no capital at work"*.
   > position takes 100% of a flat pot, so the second is funded at zero and every
   > subsequent one too. It is not a viable reading of the clause.
 
+  > **2026-08-12 attribution result (#2430):** the frozen v1 identity remains
+  > necessary for reproducibility, but it must not be mistaken for a recommended
+  > production allocation policy. Full-population recent-window A/B showed that
+  > event-driven equalisation materially damages high-turnover S-1/S-3/S-4.
+  > Entry-weight drift and calendar-month-end alternatives reduced that damage,
+  > but none made the controls capital-worthy; drift also starved later signals.
+  > S-2 remained below its passive hurdle under the funded monthly arm. See
+  > `2026-08-12-sizing-rule-attribution-result.md`. Any replacement is a distinct
+  > v2 identity and requires its own validation rather than rewriting v1 results.
+
 ---
 
 ## 6. #2288's remaining clauses land here

--- a/docs/proposals/ta/2026-08-12-sizing-rule-attribution-result.md
+++ b/docs/proposals/ta/2026-08-12-sizing-rule-attribution-result.md
@@ -1,0 +1,103 @@
+# Strategy sizing-rule attribution result (#2430)
+
+Status: full-population research complete on 2026-08-12; no sizing rule
+promoted.
+
+## Decision
+
+`equal_weight_concurrent_v1` damages high-turnover strategies because every
+entry or exit can resize the entire tradeable book. It is not, however, the
+reason the current broad strategy controls lack alpha.
+
+Two causal research arms were measured without changing signals, fills, exits,
+costs, quarantine, total-return prices or the matched buy-and-hold benchmark:
+
+1. `entry_weight_drift_v1` sets a causal entry-time allocation and never sells
+   an existing position to fund or equalise another one.
+2. `calendar_month_end_equal_weight_v1` permits new entries from available cash
+   and restores equal weight only on an observed panel month boundary.
+
+Neither arm is a production strategy identity, persistence option, API option
+or UI picker. Production remains unchanged. A later sizing v2 requires its own
+identity and validation; historical v1 evidence must remain attributable to
+v1.
+
+## Full-population evidence
+
+Both comparisons used the pinned `primary-2022-plus` window, 2022-01-01 through
+2026-07-08, the `masked` quarantine arm, split/dividend-adjusted wealth, and all
+5,266 corpus series (5,264 evaluable per strategy). Position counts, realised
+trade counts and matched benchmark returns were identical across each pair.
+
+### Entry-weight drift
+
+| Strategy | Production return | Drift return | Drift vs buy/hold | Drift Sharpe | Drift max DD | Production / drift turnover | Short-funded entries | Verdict |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| S-1 time-series momentum | -82.94% | -75.28% | -108.58 pp | -1.54 | -77.63% | 86.76 / 71.35 | 92,009 | fails; severe capital starvation |
+| S-2 cross-sectional momentum | +47.83% | +92.78% | +19.09 pp | +0.66 | -31.58% | 3.88 / 2.55 | 1,276 | diagnostic improvement, not deployable |
+| S-3 mean reversion in trend | -47.43% | -33.00% | -90.25 pp | -0.28 | -45.68% | 46.02 / 20.78 | 1,633 | fails |
+| S-4 breakout, best case | -49.14% | -15.97% | -44.39 pp | -0.15 | -36.81% | 33.03 / 19.38 | 12,972 | fails even optimistically |
+| S-4 breakout, worst case | -51.93% | -20.75% | -49.17 pp | -0.23 | -39.54% | 33.07 / 19.38 | 12,972 | fails |
+
+The S-2 headline cannot be accepted as alpha. The arm could not fund 1,276 of
+6,463 entries, so it changed effective participation by refusing later signals
+when cash was already committed. Its Sharpe remained weak and drawdown worsened
+slightly. This arm isolates the cost of continuous maintenance; it is not a
+viable capital policy.
+
+### Calendar-month-end equal weight
+
+| Strategy | Production return | Monthly return | Monthly vs buy/hold | Monthly Sharpe | Monthly max DD | Production / monthly turnover | Short-funded entries | Verdict |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| S-1 time-series momentum | -82.94% | -76.86% | -110.16 pp | -1.64 | -78.51% | 86.76 / 76.63 | 54,895 | fails |
+| S-2 cross-sectional momentum | +47.83% | +44.91% | -28.78 pp | +0.46 | -30.28% | 3.88 / 4.04 | 123 | fails passive and risk hurdles |
+| S-3 mean reversion in trend | -47.43% | -39.90% | -97.15 pp | -0.36 | -47.67% | 46.02 / 24.60 | 1,655 | fails |
+| S-4 breakout, best case | -49.14% | -23.13% | -51.55 pp | -0.25 | -43.25% | 33.03 / 22.34 | 14,134 | fails even optimistically |
+| S-4 breakout, worst case | -51.93% | -27.42% | -55.84 pp | -0.33 | -45.64% | 33.07 / 22.34 | 14,137 | fails |
+
+Monthly maintenance sharply reduced S-3/S-4 turnover and rebalance cost, yet
+did not make either strategy profitable. It reduced S-1's loss only modestly
+and left extreme turnover. S-2 funded more signals than production but returned
+2.92 percentage points less, remained 28.78 points behind its matched passive
+book and had Sharpe 0.46. No arm passes a capital gate.
+
+## Boundary correction
+
+The first monthly run was deliberately stopped after review found that the
+truncated final evaluation date (2026-07-08) was being labelled a month-end.
+That would create a synthetic rebalance with no forward holding period. The
+rule now schedules a rebalance only when the next observed panel date belongs
+to a different month. A regression test freezes this causal boundary before
+the full result above was produced.
+
+## What this settles
+
+- Event-driven equalisation is an unsuitable default for broad, high-turnover
+  books and must be reconsidered before any future strategy is promoted.
+- Removing that churn does not rescue the four current controls. S-1, S-3 and
+  S-4 fail at the signal/exit level; S-2 remains below its passive hurdle with
+  weak risk-adjusted performance.
+- A return improvement caused by funding fewer signals is not strategy alpha.
+- These four entries remain harness controls, not choices to which a user
+  should allocate capital.
+- The next alpha work should remain on pre-registered conditional mechanisms,
+  regime/cohort discrimination and prospective calibration. It should not tune
+  these four broad controls or their sizing until one happens to look good.
+
+## Reproduction and storage
+
+The read-only verifier is:
+
+```bash
+PYTHONPATH=. uv run python scripts/verify_2430_sizing_rule_ab.py \
+  --window primary-2022-plus
+```
+
+Pass `--rules equal_weight_concurrent_v1 calendar_month_end_equal_weight_v1`
+to reproduce the exact monthly comparison above. The verifier refuses unknown,
+duplicate or non-production-first arms and fails on any change in result keys,
+position count, trade count or matched benchmark.
+
+No result row, event row or bar row is written. This work adds no table, index,
+column or retained market-data payload, so database size and runtime API queries
+are unaffected.

--- a/scripts/verify_2430_sizing_rule_ab.py
+++ b/scripts/verify_2430_sizing_rule_ab.py
@@ -1,0 +1,212 @@
+"""Read-only full-population A/B for #2430's strategy sizing rule.
+
+The sizing arms re-run the same registered strategy, quarantine, total-return
+prices, fills, exits and costs. They differ only after a position event:
+
+* ``equal_weight_concurrent_v1`` restores equal weight across tradeable legs;
+* ``entry_weight_drift_v1`` leaves entry-time allocations untouched until exit;
+* ``calendar_month_end_equal_weight_v1`` restores equal weight only at month end.
+
+No result or access row is written. A limited run is smoke evidence only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import asdict
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.services.backtest_run import (
+    BACKTEST_UNIVERSE,
+    ArmMeasurement,
+    BacktestProgressEvent,
+    evaluate_arm,
+    evaluate_level_arms,
+    load_corpus,
+    runnable_strategies,
+)
+from app.services.cost_model import COST_MODEL_ID
+from app.services.equity_curve import (
+    ENTRY_WEIGHT_DRIFT_RULE_ID,
+    MONTH_END_REBALANCE_RULE_ID,
+    SIZING_RULE_ID,
+)
+from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_recent_evidence import recent_evidence_window
+
+_RULES = (SIZING_RULE_ID, ENTRY_WEIGHT_DRIFT_RULE_ID, MONTH_END_REBALANCE_RULE_ID)
+_METRICS = (
+    "total_return_pct",
+    "max_drawdown_pct",
+    "turnover_annualised",
+    "sharpe",
+    "cagr_pct",
+    "exposure_time_pct",
+    "buy_and_hold_return_pct",
+    "return_vs_buy_and_hold_pct",
+)
+
+
+def _progress(rule: str):
+    last: dict[tuple[str | None, str], int] = {}
+
+    def emit(event: BacktestProgressEvent) -> None:
+        if event.phase not in {"ranking", "evaluation"} or event.strategy_id is None:
+            return
+        key = (event.strategy_id, event.phase)
+        if event.series_seen not in {1, event.series_total} and event.series_seen - last.get(key, 0) < 500:
+            return
+        last[key] = event.series_seen
+        print(
+            f"{rule} {event.strategy_id} {event.phase} {event.series_seen:,}/{event.series_total or 0:,}",
+            flush=True,
+        )
+
+    return emit
+
+
+def _run_rule(
+    conn: psycopg.Connection[Any],
+    *,
+    corpus: Any,
+    rule: str,
+) -> dict[tuple[str, str], ArmMeasurement]:
+    runnable, excluded = runnable_strategies()
+    if excluded:
+        print(f"excluded manifest entries: {[item.strategy_id for item in excluded]}", flush=True)
+    measured: dict[tuple[str, str], ArmMeasurement] = {}
+    for strategy_id in runnable:
+        entry = STRATEGY_MANIFEST[strategy_id]
+        identity = entry.identity(universe=BACKTEST_UNIVERSE, cost_model_id=COST_MODEL_ID)
+        print(f"starting {rule} {strategy_id}", flush=True)
+        if entry.exit_regime(entry.decision_calendar(corpus.axis)).level_based:
+            arms = evaluate_level_arms(
+                conn,
+                entry,
+                corpus=corpus,
+                quarantine_arm="masked",
+                identity=identity,
+                namespaces=("hold_out",),
+                progress=_progress(rule),
+                sizing_rule=rule,
+            )
+        else:
+            arms = (
+                evaluate_arm(
+                    conn,
+                    entry,
+                    corpus=corpus,
+                    quarantine_arm="masked",
+                    ambiguity_arm=None,
+                    identity=identity,
+                    namespaces=("hold_out",),
+                    progress=_progress(rule),
+                    sizing_rule=rule,
+                ),
+            )
+        for arm in arms:
+            measured[(strategy_id, arm.ambiguity_arm or "not_applicable")] = arm
+    return measured
+
+
+def verify(window_id: str, *, limit: int | None, rules: tuple[str, ...] = _RULES) -> dict[str, object]:
+    if len(rules) < 2 or rules[0] != SIZING_RULE_ID or len(set(rules)) != len(rules):
+        raise ValueError(f"rules must be unique and start with the production baseline {SIZING_RULE_ID!r}")
+    if any(rule not in _RULES for rule in rules):
+        raise ValueError(f"unknown sizing rule in {rules!r}")
+    started = time.monotonic()
+    window = recent_evidence_window(window_id).window
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET TRANSACTION READ ONLY")
+        corpus = load_corpus(conn, limit=limit, evaluation_window=window)
+        by_rule = {rule: _run_rule(conn, corpus=corpus, rule=rule) for rule in rules}
+
+    baseline_keys = set(by_rule[SIZING_RULE_ID])
+    if any(set(by_rule[rule]) != baseline_keys for rule in rules[1:]):
+        raise RuntimeError("sizing arms did not produce the same strategy/ambiguity keys")
+
+    comparisons: list[dict[str, object]] = []
+    for alternative_rule in rules[1:]:
+        for key in sorted(baseline_keys):
+            production_arm = by_rule[SIZING_RULE_ID][key]
+            alternative_arm = by_rule[alternative_rule][key]
+            production = production_arm.namespaces.get("hold_out")
+            alternative = alternative_arm.namespaces.get("hold_out")
+            if production is None or alternative is None:
+                raise RuntimeError(f"{key} produced no hold-out measurement")
+            if production.position_count != alternative.position_count:
+                raise RuntimeError(f"{key} changed position count across sizing arms")
+            if production.metrics.trade_count != alternative.metrics.trade_count:
+                raise RuntimeError(f"{key} changed realised trade count across sizing arms")
+            if production.metrics.buy_and_hold_return_pct != alternative.metrics.buy_and_hold_return_pct:
+                raise RuntimeError(f"{key} changed its matched benchmark across sizing arms")
+
+            item: dict[str, object] = {
+                "strategy_id": key[0],
+                "ambiguity_arm": key[1],
+                "baseline_rule": SIZING_RULE_ID,
+                "alternative_rule": alternative_rule,
+                "position_count": production.position_count,
+                "trade_count": production.metrics.trade_count,
+                "series_evaluated": production_arm.series_evaluated,
+                "baseline_elapsed_seconds": production_arm.elapsed_s,
+                "alternative_elapsed_seconds": alternative_arm.elapsed_s,
+                "path_diagnostics": {
+                    SIZING_RULE_ID: {
+                        "rebalance_costs": production.rebalance_costs,
+                        "short_funded_entries": production.short_funded_entries,
+                        "traded_notional_total": production.traded_notional_total,
+                    },
+                    alternative_rule: {
+                        "rebalance_costs": alternative.rebalance_costs,
+                        "short_funded_entries": alternative.short_funded_entries,
+                        "traded_notional_total": alternative.traded_notional_total,
+                    },
+                },
+                "metrics": {},
+            }
+            metric_comparisons: dict[str, object] = {}
+            production_values = asdict(production.metrics)
+            alternative_values = asdict(alternative.metrics)
+            for metric in _METRICS:
+                baseline_value = production_values[metric]
+                alternative_value = alternative_values[metric]
+                metric_comparisons[metric] = {
+                    SIZING_RULE_ID: baseline_value,
+                    alternative_rule: alternative_value,
+                    "delta": alternative_value - baseline_value,
+                }
+            item["metrics"] = metric_comparisons
+            comparisons.append(item)
+
+    return {
+        "issue": 2430,
+        "window_id": window_id,
+        "window_start": window.start.isoformat(),
+        "window_end": window.end.isoformat(),
+        "limited_smoke": limit is not None,
+        "series": len(corpus.pairs),
+        "quarantine_arm": "masked",
+        "return_basis": "split-dividend-adjusted-wealth-v1",
+        "rules": list(rules),
+        "elapsed_seconds": time.monotonic() - started,
+        "comparisons": comparisons,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--window", default="primary-2022-plus")
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--rules", nargs="+", choices=_RULES, default=list(_RULES))
+    args = parser.parse_args()
+    print(json.dumps(verify(args.window, limit=args.limit, rules=tuple(args.rules)), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_equity_curve.py
+++ b/tests/test_equity_curve.py
@@ -12,20 +12,29 @@ test asserts the module agrees with them.
 from __future__ import annotations
 
 import math
+from datetime import date
 
 import pytest
 
 from app.services.equity_curve import (
     BENCHMARK_RULE_ID,
+    ENTRY_WEIGHT_DRIFT_RULE_ID,
+    MONTH_END_REBALANCE_RULE_ID,
     SIZING_RULE_ID,
     LegBook,
     build_buy_and_hold_curve,
+    build_entry_weight_drift_curve,
     build_equity_curve,
+    build_month_end_rebalanced_curve,
 )
 
 #: §5.4's declared v1 rule, transcribed from
 #: ``docs/proposals/ta/2026-08-07-bounded-backtester.md``.
 SPEC_SIZING_RULE = "equal_weight_concurrent_v1"
+
+#: #2430's frozen research arm. It is deliberately not production evidence.
+SPEC_ENTRY_WEIGHT_DRIFT_RULE = "entry_weight_drift_v1"
+SPEC_MONTH_END_REBALANCE_RULE = "calendar_month_end_equal_weight_v1"
 
 #: #2426's benchmark rule, transcribed from
 #: ``docs/proposals/ta/2026-08-08-buy-and-hold-benchmark.md`` §2.4.
@@ -69,6 +78,14 @@ def _leg(
 class TestSpecConstants:
     def test_the_sizing_rule_id_is_the_declared_one(self) -> None:
         assert SIZING_RULE_ID == SPEC_SIZING_RULE
+
+    def test_the_drift_arm_has_a_distinct_declared_identity(self) -> None:
+        assert ENTRY_WEIGHT_DRIFT_RULE_ID == SPEC_ENTRY_WEIGHT_DRIFT_RULE
+        assert ENTRY_WEIGHT_DRIFT_RULE_ID != SIZING_RULE_ID
+
+    def test_the_month_end_arm_has_a_distinct_declared_identity(self) -> None:
+        assert MONTH_END_REBALANCE_RULE_ID == SPEC_MONTH_END_REBALANCE_RULE
+        assert MONTH_END_REBALANCE_RULE_ID not in {SIZING_RULE_ID, ENTRY_WEIGHT_DRIFT_RULE_ID}
 
 
 class TestLegBookRefuses:
@@ -320,6 +337,69 @@ class TestRebalance:
         curve = build_equity_curve(book, date_count=10)
         cash = curve.equity - curve.invested
         assert min(cash) >= -1e-12, f"cash went to {min(cash)} — the rebalance borrowed"
+
+
+class TestEntryWeightDriftArm:
+    def test_simultaneous_entries_start_with_the_same_weights_as_production(self) -> None:
+        book = LegBook()
+        _leg(book, entry=0, exit_=2, entry_price=100.0, exit_price=100.0, marks=[100.0] * 3)
+        _leg(book, entry=0, exit_=2, entry_price=50.0, exit_price=50.0, marks=[50.0] * 3)
+        production = build_equity_curve(book, date_count=3)
+        drift = build_entry_weight_drift_curve(book, date_count=3)
+        assert drift.equity.tolist() == pytest.approx(production.equity.tolist())
+        assert drift.short_funded_entries == 0
+
+    def test_a_later_entry_cannot_be_funded_by_selling_an_existing_winner(self) -> None:
+        """The exact #2430 discriminator: production trims A at B's entry event;
+        the drift arm cannot spend that synthetic sale and reports B as short
+        funded. Signals, fills, marks and exit prices are otherwise identical."""
+        book = LegBook()
+        _leg(book, entry=0, exit_=3, entry_price=100.0, exit_price=200.0, marks=[100.0, 200.0, 200.0, 200.0])
+        _leg(book, entry=1, exit_=3, entry_price=100.0, exit_price=200.0, marks=[100.0, 150.0, 200.0])
+        production = build_equity_curve(book, date_count=4)
+        drift = build_entry_weight_drift_curve(book, date_count=4)
+        assert drift.rebalance_costs == 0.0
+        assert drift.short_funded_entries == 1
+        assert drift.traded_notional.sum() < production.traded_notional.sum()
+        assert drift.equity[-1] < production.equity[-1]
+
+
+class TestMonthEndRebalanceArm:
+    def test_it_defers_equalisation_from_an_entry_event_to_month_end(self) -> None:
+        dates = (date(2024, 1, 2), date(2024, 1, 3), date(2024, 1, 31), date(2024, 2, 1))
+        book = LegBook()
+        _leg(book, entry=0, exit_=3, entry_price=100.0, exit_price=100.0, marks=[100.0] * 4, half_spread=0.01)
+        _leg(book, entry=1, exit_=3, entry_price=100.0, exit_price=100.0, marks=[100.0] * 3, half_spread=0.01)
+        production = build_equity_curve(book, date_count=len(dates))
+        monthly = build_month_end_rebalanced_curve(book, dates=dates)
+        assert production.traded_notional[1] > 0.0
+        assert monthly.traded_notional[1] == 0.0
+        assert monthly.traded_notional[2] > 0.0
+        assert monthly.rebalance_costs > 0.0
+
+    def test_it_does_not_invent_a_month_end_at_a_truncated_window_boundary(self) -> None:
+        dates = (date(2024, 7, 1), date(2024, 7, 8))
+        book = LegBook()
+        _leg(
+            book,
+            entry=0,
+            exit_=1,
+            entry_price=100.0,
+            exit_price=100.0,
+            marks=[100.0] * 2,
+            realised=False,
+        )
+        _leg(book, entry=1, exit_=1, entry_price=100.0, exit_price=100.0, marks=[100.0])
+        monthly = build_month_end_rebalanced_curve(book, dates=dates)
+        assert monthly.rebalance_costs == 0.0
+        assert monthly.short_funded_entries == 1
+
+    def test_it_refuses_an_unordered_calendar(self) -> None:
+        with pytest.raises(ValueError, match="strictly increasing"):
+            build_month_end_rebalanced_curve(
+                LegBook(),
+                dates=(date(2024, 1, 3), date(2024, 1, 2)),
+            )
 
 
 class TestHalts:


### PR DESCRIPTION
## Summary

- add immutable entry-drift and calendar-month-end sizing research arms without changing the production identity
- add a read-only paired full-population verifier with funding, turnover, and rebalance-cost diagnostics
- record the 2022-2026 evidence and the non-promotion decision
- fix and regression-test the truncated-window month-end boundary caught during review

## Result

Event-driven equalisation is materially harmful for high-turnover books, but it is not the missing alpha. Monthly sizing leaves S-1 at -76.86%, S-3 at -39.90%, and conservative S-4 at -27.42%. S-2 returns +44.91% but trails its matched buy-and-hold book by 28.78 points with Sharpe 0.46. No arm is promoted or exposed through persistence, API, or UI.

The no-rebalance arm improves S-2 to +92.78%, but it cannot fund 1,276 of 6,463 entries; this is participation drift, not deployable alpha.

## Validation

- full paired verifier: 5,266 corpus series, 5,264 evaluated per strategy, 2022-01-01 through 2026-07-08
- focused engine/backtest suite: 131 passed
- repository pre-push gate: green (ruff, format, pyright, shell/static invariants, pure tests, dev-DB smoke, schema drift, frontend integrity)
- local Codex review: no actionable correctness finding
- no schema or retained-data change

Closes #2430