### PR TITLE
feat(strategy): require promotion edge evidence

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -227,7 +227,7 @@ RESULT_SCOPE: Final = "sleeve"
 #: input.
 BACKTEST_BOOTSTRAP_SEED: Final = 20260808
 
-#: §9 — the three refusals no invocation of this job can close, whatever it
+#: §9/#2505 — the four refusals no invocation of this job can close, whatever it
 #: measures. ``universe_basis_not_survivorship_free`` is blocked on #2284's
 #: corpus purchase, ``carry_unmodelled`` on #2277's carry measurement, and
 #: ``synthetic_control_not_run`` on a stage this cut does not contain (§9: the
@@ -237,12 +237,13 @@ BACKTEST_BOOTSTRAP_SEED: Final = 20260808
 #: ⚠ The job cannot make anything promotable, and that is correct rather than a
 #: shortfall — §6 of the bounded-backtester spec states the intended initial
 #: state in those words. What it changes is that the refusals become SPECIFIC
-#: AND FEW instead of eight-of-eight.
+#: AND FEW instead of a generic failure.
 STANDING_REFUSALS: Final[frozenset[PromotionRefusal]] = frozenset(
     {
         "universe_basis_not_survivorship_free",
         "carry_unmodelled",
         "synthetic_control_not_run",
+        "promotion_evidence_missing",
     }
 )
 

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import date
 from decimal import Decimal
 from typing import Any, Literal, cast
 
@@ -17,6 +18,8 @@ import psycopg
 import psycopg.rows
 
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyPurpose
+from app.services.strategy_promotion_evidence import evidence_refusals
+from app.services.strategy_promotion_evidence_store import load_promotion_evidence
 
 Stage = Literal[
     "research_candidate",
@@ -32,7 +35,7 @@ CapitalMode = Literal["fixed", "compound"]
 RiskProfile = Literal["unconfigured", "cautious", "balanced", "growth"]
 TicketSizingMode = Literal["percent", "fixed"]
 
-GOVERNANCE_GATE_VERSION = "strategy-governance-v1"
+GOVERNANCE_GATE_VERSION = "strategy-governance-v2+edge-evidence"
 MANDATE_POLICY_VERSION = "portfolio-mandate-v1"
 UNCONFIGURED_MANDATE_POLICY_VERSION = "portfolio-mandate-unconfigured"
 
@@ -454,7 +457,7 @@ def promote_strategy(
     if result_ids:
         rows = conn.execute(
             """
-            SELECT result_id
+            SELECT result_id, profit_factor
             FROM strategy_results_store
             WHERE strategy_id = %s AND strategy_version = %s
               AND result_id = ANY(%s)
@@ -467,6 +470,21 @@ def promote_strategy(
             raise StrategyControlError(
                 f"result_ids do not belong to {strategy_id}@{strategy_version}: {sorted(missing)}"
             )
+        if to_stage in _RESULT_EVIDENCE_STAGES:
+            profit_factor_by_result = {int(row[0]): None if row[1] is None else Decimal(str(row[1])) for row in rows}
+            for result_id in result_ids:
+                evidence = load_promotion_evidence(conn, result_id)
+                if evidence is None:
+                    raise StrategyControlError(
+                        f"result {result_id} fails promotion evidence: promotion_evidence_missing"
+                    )
+                refusals = evidence_refusals(
+                    evidence,
+                    profit_factor=profit_factor_by_result[result_id],
+                    as_of=date.today(),
+                )
+                if refusals:
+                    raise StrategyControlError(f"result {result_id} fails promotion evidence: {', '.join(refusals)}")
 
     row = conn.execute(
         """

--- a/app/services/strategy_promotion_evidence.py
+++ b/app/services/strategy_promotion_evidence.py
@@ -1,0 +1,410 @@
+"""Compact, immutable edge-attribution evidence required by #2505.
+
+The result ledger already proves how a backtest was produced.  This contract
+proves why a candidate is economically actionable: it survives costs and tails,
+ranks later outcomes, and beats predeclared simpler explanations on the same
+observations and fills.  It deliberately stores aggregates rather than feature
+histories or polling snapshots.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, DecimalException
+from typing import Final, Literal
+
+EVIDENCE_VERSION: Final = "promotion-edge-evidence-v1"
+
+ChallengerRole = Literal[
+    "raw_instrument_shock",
+    "market_residual",
+    "market_sector_residual",
+    "matched_random_entries",
+    "unfiltered_eligible_signals",
+]
+
+REQUIRED_CHALLENGERS: Final[frozenset[ChallengerRole]] = frozenset(
+    {
+        "raw_instrument_shock",
+        "market_residual",
+        "market_sector_residual",
+        "matched_random_entries",
+        "unfiltered_eligible_signals",
+    }
+)
+
+CostInput = Literal["spread", "slippage", "financing", "fx", "broker_eligibility"]
+REQUIRED_COST_INPUTS: Final[frozenset[CostInput]] = frozenset(
+    {"spread", "slippage", "financing", "fx", "broker_eligibility"}
+)
+
+ContrastDimension = Literal[
+    "feature_score",
+    "execution_cost",
+    "entry_gap",
+    "liquidity",
+    "market_stress",
+    "sector_concentration",
+    "date_concentration",
+    "instrument_concentration",
+]
+REQUIRED_CONTRASTS: Final[frozenset[ContrastDimension]] = frozenset(
+    {
+        "feature_score",
+        "execution_cost",
+        "entry_gap",
+        "liquidity",
+        "market_stress",
+        "sector_concentration",
+        "date_concentration",
+        "instrument_concentration",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ChallengerEvidence:
+    """One frozen simpler explanation measured on the candidate's exact path."""
+
+    role: ChallengerRole
+    observation_count: int
+    expectancy_pct: Decimal
+    candidate_minus_challenger_pct: Decimal
+    same_observations_and_fills: bool
+    causal_observation_rule_version: str
+    fill_rule_version: str
+    overlap_rule_version: str
+
+    def __post_init__(self) -> None:
+        if self.role not in REQUIRED_CHALLENGERS:
+            raise ValueError(f"unknown challenger role {self.role!r}")
+        if type(self.observation_count) is not int or self.observation_count < 1:
+            raise ValueError("challenger observation_count must be positive")
+        if type(self.same_observations_and_fills) is not bool:
+            raise ValueError("challenger same_observations_and_fills must be a boolean")
+        if not self.causal_observation_rule_version or not self.fill_rule_version or not self.overlap_rule_version:
+            raise ValueError("challenger causal observation, fill and overlap rule versions must be non-empty")
+        if not self.expectancy_pct.is_finite() or not self.candidate_minus_challenger_pct.is_finite():
+            raise ValueError("challenger metrics must be finite")
+
+
+@dataclass(frozen=True)
+class ExpectedValueBucket:
+    """One predeclared forecast rank and its later realised expectancy."""
+
+    rank: int
+    observation_count: int
+    forecast_ev_pct: Decimal
+    realised_expectancy_pct: Decimal
+
+    def __post_init__(self) -> None:
+        if type(self.rank) is not int or self.rank < 1:
+            raise ValueError("EV bucket rank must be positive")
+        if type(self.observation_count) is not int or self.observation_count < 1:
+            raise ValueError("EV bucket observation_count must be positive")
+        if not self.forecast_ev_pct.is_finite() or not self.realised_expectancy_pct.is_finite():
+            raise ValueError("EV bucket metrics must be finite")
+
+
+@dataclass(frozen=True)
+class OutcomeContrast:
+    """Bounded aggregate difference between profitable and losing outcomes."""
+
+    dimension: ContrastDimension
+    profitable_count: int
+    losing_count: int
+    profitable_mean: Decimal
+    losing_mean: Decimal
+    profitable_minus_losing: Decimal
+
+    def __post_init__(self) -> None:
+        if self.dimension not in REQUIRED_CONTRASTS:
+            raise ValueError(f"unknown outcome contrast dimension {self.dimension!r}")
+        if type(self.profitable_count) is not int or type(self.losing_count) is not int:
+            raise ValueError("outcome contrast counts must be integers")
+        if self.profitable_count < 1 or self.losing_count < 1:
+            raise ValueError("outcome contrast requires profitable and losing observations")
+        if any(
+            not value.is_finite() for value in (self.profitable_mean, self.losing_mean, self.profitable_minus_losing)
+        ):
+            raise ValueError("outcome contrast metrics must be finite")
+        if self.profitable_mean - self.losing_mean != self.profitable_minus_losing:
+            raise ValueError("outcome contrast difference must equal profitable_mean - losing_mean")
+
+
+@dataclass(frozen=True)
+class RecentYearEvidence:
+    """One recent calendar year's bounded after-cost stability evidence."""
+
+    year: int
+    observation_count: int
+    after_cost_expectancy_pct: Decimal
+    expectancy_ci_low_pct: Decimal
+    risk_limits_passed: bool
+
+    def __post_init__(self) -> None:
+        if self.year < 2000 or self.year > 9999:
+            raise ValueError("recent evidence year must be four digits and post-1999")
+        if type(self.observation_count) is not int or self.observation_count < 1:
+            raise ValueError("recent year observation_count must be a positive integer")
+        if type(self.risk_limits_passed) is not bool:
+            raise ValueError("recent year risk_limits_passed must be a boolean")
+        if not self.after_cost_expectancy_pct.is_finite() or not self.expectancy_ci_low_pct.is_finite():
+            raise ValueError("recent year expectancy metrics must be finite")
+        if self.expectancy_ci_low_pct > self.after_cost_expectancy_pct:
+            raise ValueError("recent year expectancy lower bound cannot exceed its point estimate")
+
+
+@dataclass(frozen=True)
+class PromotionEvidence:
+    """The bounded #2505 evidence record paired one-to-one with a result row."""
+
+    evidence_version: str
+    causal_observation_rule_version: str
+    fill_rule_version: str
+    overlap_rule_version: str
+    after_cost_expectancy_ci_low_pct: Decimal
+    max_drawdown_pct: Decimal
+    expected_shortfall_5_pct: Decimal
+    worst_gap_pct: Decimal
+    excluding_best_1_expectancy_pct: Decimal
+    recent_year_stable: bool
+    recent_years_evaluated: int
+    recent_year_evidence: tuple[RecentYearEvidence, ...]
+    max_date_contribution_pct: Decimal
+    max_name_contribution_pct: Decimal
+    max_sector_contribution_pct: Decimal
+    max_concurrency: int
+    capacity_usd: Decimal
+    risk_limits_version: str
+    risk_limits_passed: bool
+    probability_calibration_passed: bool
+    path_diagnostics_complete: bool
+    outcome_count: int
+    profitable_outcome_count: int
+    losing_outcome_count: int
+    flat_outcome_count: int
+    target_first_count: int
+    stop_first_count: int
+    timeout_count: int
+    ambiguous_path_count: int
+    observed_cost_inputs: frozenset[CostInput]
+    cost_observed_on: date
+    cost_valid_through: date
+    cost_source_version: str
+    spread_bps: Decimal
+    slippage_bps: Decimal
+    financing_bps_per_day: Decimal
+    fx_bps: Decimal
+    broker_eligible: bool
+    challengers: tuple[ChallengerEvidence, ...]
+    ev_buckets: tuple[ExpectedValueBucket, ...]
+    outcome_contrasts: tuple[OutcomeContrast, ...]
+
+    def __post_init__(self) -> None:
+        if self.evidence_version != EVIDENCE_VERSION:
+            raise ValueError(f"evidence_version must be {EVIDENCE_VERSION!r}")
+        if not self.risk_limits_version:
+            raise ValueError("risk_limits_version must be non-empty")
+        if not self.causal_observation_rule_version or not self.fill_rule_version or not self.overlap_rule_version:
+            raise ValueError("candidate causal observation, fill and overlap rule versions must be non-empty")
+        for name in (
+            "recent_year_stable",
+            "risk_limits_passed",
+            "probability_calibration_passed",
+            "path_diagnostics_complete",
+            "broker_eligible",
+        ):
+            if type(getattr(self, name)) is not bool:
+                raise ValueError(f"{name} must be a boolean")
+        for name in (
+            "recent_years_evaluated",
+            "max_concurrency",
+            "outcome_count",
+            "profitable_outcome_count",
+            "losing_outcome_count",
+            "flat_outcome_count",
+            "target_first_count",
+            "stop_first_count",
+            "timeout_count",
+            "ambiguous_path_count",
+        ):
+            if type(getattr(self, name)) is not int:
+                raise ValueError(f"{name} must be an integer")
+        numeric = {
+            "after_cost_expectancy_ci_low_pct": self.after_cost_expectancy_ci_low_pct,
+            "max_drawdown_pct": self.max_drawdown_pct,
+            "expected_shortfall_5_pct": self.expected_shortfall_5_pct,
+            "worst_gap_pct": self.worst_gap_pct,
+            "excluding_best_1_expectancy_pct": self.excluding_best_1_expectancy_pct,
+            "max_date_contribution_pct": self.max_date_contribution_pct,
+            "max_name_contribution_pct": self.max_name_contribution_pct,
+            "max_sector_contribution_pct": self.max_sector_contribution_pct,
+            "capacity_usd": self.capacity_usd,
+            "spread_bps": self.spread_bps,
+            "slippage_bps": self.slippage_bps,
+            "financing_bps_per_day": self.financing_bps_per_day,
+            "fx_bps": self.fx_bps,
+        }
+        if any(not value.is_finite() for value in numeric.values()):
+            raise ValueError("promotion evidence metrics must be finite")
+        for name in ("max_date_contribution_pct", "max_name_contribution_pct", "max_sector_contribution_pct"):
+            value = numeric[name]
+            if value < 0 or value > 100:
+                raise ValueError(f"{name} must lie in [0, 100]")
+        if self.max_drawdown_pct > 0 or self.expected_shortfall_5_pct > 0 or self.worst_gap_pct > 0:
+            raise ValueError("tail losses must be reported as non-positive percentages")
+        if self.max_concurrency < 1:
+            raise ValueError("max_concurrency must be positive")
+        if self.recent_years_evaluated < 0:
+            raise ValueError("recent_years_evaluated must be non-negative")
+        if self.capacity_usd <= 0:
+            raise ValueError("capacity_usd must be positive")
+        if min(self.spread_bps, self.slippage_bps, self.fx_bps) < 0:
+            raise ValueError("spread, slippage and FX costs must be non-negative")
+        if not self.cost_source_version:
+            raise ValueError("cost_source_version must be non-empty")
+        if self.cost_valid_through < self.cost_observed_on:
+            raise ValueError("cost_valid_through cannot precede cost_observed_on")
+        path_counts = (self.outcome_count, self.target_first_count, self.stop_first_count, self.timeout_count)
+        if any(value < 0 for value in (*path_counts, self.ambiguous_path_count)):
+            raise ValueError("path counts must be non-negative")
+        if self.target_first_count + self.stop_first_count + self.timeout_count != self.outcome_count:
+            raise ValueError("target/stop/timeout counts must partition outcome_count")
+        if self.profitable_outcome_count + self.losing_outcome_count + self.flat_outcome_count != self.outcome_count:
+            raise ValueError("profitable/losing/flat counts must partition outcome_count")
+        if self.ambiguous_path_count > self.outcome_count:
+            raise ValueError("ambiguous_path_count cannot exceed outcome_count")
+        if not self.observed_cost_inputs <= REQUIRED_COST_INPUTS:
+            raise ValueError("observed_cost_inputs contains an unknown cost input")
+        roles = [item.role for item in self.challengers]
+        if len(roles) != len(set(roles)):
+            raise ValueError("challenger roles must be unique")
+        dimensions = [item.dimension for item in self.outcome_contrasts]
+        if len(dimensions) != len(set(dimensions)):
+            raise ValueError("outcome contrast dimensions must be unique")
+        years = [item.year for item in self.recent_year_evidence]
+        if years != sorted(set(years)):
+            raise ValueError("recent year evidence must have unique ascending years")
+        if len(years) > 5:
+            raise ValueError("recent year evidence is capped at five aggregate years")
+        if self.recent_years_evaluated != len(years):
+            raise ValueError("recent_years_evaluated must equal the stored recent-year evidence count")
+        ranks = [item.rank for item in self.ev_buckets]
+        if len(ranks) > 10:
+            raise ValueError("EV bucket evidence is capped at ten aggregate buckets")
+        if ranks != list(range(1, len(ranks) + 1)):
+            raise ValueError("EV bucket ranks must be contiguous and ascending from one")
+
+
+def evidence_refusals(
+    evidence: PromotionEvidence,
+    *,
+    profit_factor: Decimal | float | None,
+    as_of: date,
+) -> tuple[str, ...]:
+    """Return every #2505 refusal; an empty tuple is necessary, not sufficient."""
+
+    refusals: list[str] = []
+    if evidence.after_cost_expectancy_ci_low_pct <= 0:
+        refusals.append("expectancy_lower_bound_not_positive")
+    if profit_factor is None:
+        refusals.append("profit_factor_not_computed")
+    else:
+        try:
+            finite_profit_factor = profit_factor if isinstance(profit_factor, Decimal) else Decimal(str(profit_factor))
+        except DecimalException, ValueError:
+            refusals.append("profit_factor_invalid")
+        else:
+            if not finite_profit_factor.is_finite():
+                refusals.append("profit_factor_invalid")
+            elif finite_profit_factor <= 1:
+                refusals.append("profit_factor_not_above_one")
+    if not evidence.recent_year_stable or any(
+        item.after_cost_expectancy_pct <= 0 or not item.risk_limits_passed for item in evidence.recent_year_evidence
+    ):
+        refusals.append("recent_year_instability")
+    if (
+        evidence.recent_years_evaluated < 2
+        or not evidence.recent_year_evidence
+        or evidence.recent_year_evidence[-1].year < as_of.year - 1
+        or evidence.recent_year_evidence[-1].year > as_of.year
+        or sum(item.observation_count for item in evidence.recent_year_evidence) > evidence.outcome_count
+    ):
+        refusals.append("recent_year_evidence_incomplete")
+    if evidence.excluding_best_1_expectancy_pct <= 0:
+        refusals.append("excluding_best_1_not_positive")
+    if not evidence.risk_limits_passed:
+        refusals.append("tail_or_concentration_limits_failed")
+    if not evidence.probability_calibration_passed:
+        refusals.append("probability_calibration_failed")
+    if not evidence.path_diagnostics_complete or evidence.outcome_count < 1:
+        refusals.append("path_diagnostics_incomplete")
+    if evidence.observed_cost_inputs != REQUIRED_COST_INPUTS:
+        refusals.append("executable_cost_inputs_missing")
+    if evidence.cost_observed_on > as_of or as_of > evidence.cost_valid_through:
+        refusals.append("executable_cost_inputs_stale")
+    if not evidence.broker_eligible:
+        refusals.append("broker_ineligible")
+
+    by_role = {item.role: item for item in evidence.challengers}
+    if set(by_role) != REQUIRED_CHALLENGERS:
+        refusals.append("challenger_evidence_incomplete")
+    else:
+        if any(
+            not item.same_observations_and_fills
+            or item.causal_observation_rule_version != evidence.causal_observation_rule_version
+            or item.fill_rule_version != evidence.fill_rule_version
+            or item.overlap_rule_version != evidence.overlap_rule_version
+            or (
+                item.observation_count != evidence.outcome_count
+                if item.role != "unfiltered_eligible_signals"
+                else item.observation_count < evidence.outcome_count
+            )
+            for item in by_role.values()
+        ):
+            refusals.append("challenger_population_not_comparable")
+        if any(item.candidate_minus_challenger_pct <= 0 for item in by_role.values()):
+            refusals.append("candidate_does_not_beat_challengers")
+
+    if (
+        len(evidence.ev_buckets) < 3
+        or sum(item.observation_count for item in evidence.ev_buckets) != evidence.outcome_count
+    ):
+        refusals.append("ev_bucket_evidence_incomplete")
+    else:
+        forecasts = [item.forecast_ev_pct for item in evidence.ev_buckets]
+        realised = [item.realised_expectancy_pct for item in evidence.ev_buckets]
+        forecast_monotonic = all(later >= earlier for earlier, later in zip(forecasts, forecasts[1:], strict=False))
+        realised_monotonic = all(later >= earlier for earlier, later in zip(realised, realised[1:], strict=False))
+        discriminating = realised[-1] > realised[0] and forecasts[-1] > forecasts[0]
+        if not forecast_monotonic or not realised_monotonic or not discriminating:
+            refusals.append("ev_bucket_ranking_not_monotonic")
+
+    contrasts = {item.dimension: item for item in evidence.outcome_contrasts}
+    if set(contrasts) != REQUIRED_CONTRASTS:
+        refusals.append("outcome_contrast_evidence_incomplete")
+    elif any(
+        item.profitable_count != evidence.profitable_outcome_count or item.losing_count != evidence.losing_outcome_count
+        for item in contrasts.values()
+    ):
+        refusals.append("outcome_contrast_population_not_comparable")
+    return tuple(refusals)
+
+
+__all__ = [
+    "EVIDENCE_VERSION",
+    "REQUIRED_CHALLENGERS",
+    "REQUIRED_COST_INPUTS",
+    "REQUIRED_CONTRASTS",
+    "ChallengerEvidence",
+    "ChallengerRole",
+    "CostInput",
+    "ContrastDimension",
+    "ExpectedValueBucket",
+    "OutcomeContrast",
+    "PromotionEvidence",
+    "RecentYearEvidence",
+    "evidence_refusals",
+]

--- a/app/services/strategy_promotion_evidence_store.py
+++ b/app/services/strategy_promotion_evidence_store.py
@@ -1,0 +1,310 @@
+"""Persistence for #2505's single bounded aggregate evidence record."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import date
+from decimal import Decimal, DecimalException
+from typing import Any, cast
+
+import psycopg
+
+from app.services.strategy_promotion_evidence import (
+    ChallengerEvidence,
+    ChallengerRole,
+    ContrastDimension,
+    CostInput,
+    ExpectedValueBucket,
+    OutcomeContrast,
+    PromotionEvidence,
+    RecentYearEvidence,
+)
+
+MAX_PAYLOAD_BYTES = 65_536
+
+
+def _payload(evidence: PromotionEvidence) -> dict[str, object]:
+    return {
+        "after_cost_expectancy_ci_low_pct": str(evidence.after_cost_expectancy_ci_low_pct),
+        "ambiguous_path_count": evidence.ambiguous_path_count,
+        "capacity_usd": str(evidence.capacity_usd),
+        "causal_observation_rule_version": evidence.causal_observation_rule_version,
+        "cost_observed_on": evidence.cost_observed_on.isoformat(),
+        "cost_source_version": evidence.cost_source_version,
+        "cost_valid_through": evidence.cost_valid_through.isoformat(),
+        "challengers": [
+            {
+                "candidate_minus_challenger_pct": str(item.candidate_minus_challenger_pct),
+                "causal_observation_rule_version": item.causal_observation_rule_version,
+                "expectancy_pct": str(item.expectancy_pct),
+                "fill_rule_version": item.fill_rule_version,
+                "observation_count": item.observation_count,
+                "role": item.role,
+                "same_observations_and_fills": item.same_observations_and_fills,
+                "overlap_rule_version": item.overlap_rule_version,
+            }
+            for item in evidence.challengers
+        ],
+        "ev_buckets": [
+            {
+                "forecast_ev_pct": str(item.forecast_ev_pct),
+                "observation_count": item.observation_count,
+                "rank": item.rank,
+                "realised_expectancy_pct": str(item.realised_expectancy_pct),
+            }
+            for item in evidence.ev_buckets
+        ],
+        "evidence_version": evidence.evidence_version,
+        "excluding_best_1_expectancy_pct": str(evidence.excluding_best_1_expectancy_pct),
+        "expected_shortfall_5_pct": str(evidence.expected_shortfall_5_pct),
+        "financing_bps_per_day": str(evidence.financing_bps_per_day),
+        "flat_outcome_count": evidence.flat_outcome_count,
+        "fill_rule_version": evidence.fill_rule_version,
+        "fx_bps": str(evidence.fx_bps),
+        "max_concurrency": evidence.max_concurrency,
+        "max_drawdown_pct": str(evidence.max_drawdown_pct),
+        "max_date_contribution_pct": str(evidence.max_date_contribution_pct),
+        "max_name_contribution_pct": str(evidence.max_name_contribution_pct),
+        "max_sector_contribution_pct": str(evidence.max_sector_contribution_pct),
+        "observed_cost_inputs": sorted(evidence.observed_cost_inputs),
+        "outcome_count": evidence.outcome_count,
+        "overlap_rule_version": evidence.overlap_rule_version,
+        "outcome_contrasts": [
+            {
+                "dimension": item.dimension,
+                "losing_count": item.losing_count,
+                "losing_mean": str(item.losing_mean),
+                "profitable_count": item.profitable_count,
+                "profitable_mean": str(item.profitable_mean),
+                "profitable_minus_losing": str(item.profitable_minus_losing),
+            }
+            for item in evidence.outcome_contrasts
+        ],
+        "path_diagnostics_complete": evidence.path_diagnostics_complete,
+        "broker_eligible": evidence.broker_eligible,
+        "profitable_outcome_count": evidence.profitable_outcome_count,
+        "losing_outcome_count": evidence.losing_outcome_count,
+        "probability_calibration_passed": evidence.probability_calibration_passed,
+        "recent_year_stable": evidence.recent_year_stable,
+        "recent_year_evidence": [
+            {
+                "after_cost_expectancy_pct": str(item.after_cost_expectancy_pct),
+                "expectancy_ci_low_pct": str(item.expectancy_ci_low_pct),
+                "observation_count": item.observation_count,
+                "risk_limits_passed": item.risk_limits_passed,
+                "year": item.year,
+            }
+            for item in evidence.recent_year_evidence
+        ],
+        "recent_years_evaluated": evidence.recent_years_evaluated,
+        "risk_limits_passed": evidence.risk_limits_passed,
+        "risk_limits_version": evidence.risk_limits_version,
+        "slippage_bps": str(evidence.slippage_bps),
+        "spread_bps": str(evidence.spread_bps),
+        "stop_first_count": evidence.stop_first_count,
+        "target_first_count": evidence.target_first_count,
+        "timeout_count": evidence.timeout_count,
+        "worst_gap_pct": str(evidence.worst_gap_pct),
+    }
+
+
+def _canonical(payload: dict[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def _jsonb_text_size(payload: dict[str, object]) -> int:
+    """Bytes PostgreSQL's ``jsonb::text`` representation will occupy.
+
+    JSONB adds one space after each comma and colon and emits UTF-8 rather than
+    ASCII escape sequences. Key order cannot alter the byte count. Keeping this
+    separate from the compact canonical hash prevents the writer accepting a
+    payload which the database's identical 64 KiB policy then rejects.
+    """
+    return len(json.dumps(payload, sort_keys=True, separators=(", ", ": "), ensure_ascii=False).encode())
+
+
+def evidence_sha256(evidence: PromotionEvidence) -> str:
+    return hashlib.sha256(_canonical(_payload(evidence))).hexdigest()
+
+
+def store_promotion_evidence(
+    conn: psycopg.Connection[Any],
+    *,
+    result_id: int,
+    evidence: PromotionEvidence,
+) -> None:
+    """Append one record; duplicates and later mutations are refused by SQL."""
+    if result_id < 1:
+        raise ValueError("result_id must be positive")
+    payload = _payload(evidence)
+    encoded = _canonical(payload)
+    if _jsonb_text_size(payload) > MAX_PAYLOAD_BYTES:
+        raise ValueError(f"promotion evidence payload exceeds {MAX_PAYLOAD_BYTES} bytes")
+    conn.execute(
+        """
+        INSERT INTO strategy_promotion_evidence (
+            result_id, evidence_version, payload_sha256, evidence_payload
+        ) VALUES (%s, %s, %s, %s::jsonb)
+        """,
+        (result_id, evidence.evidence_version, hashlib.sha256(encoded).hexdigest(), encoded.decode()),
+    )
+
+
+def _text(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"promotion evidence {key} must be a string")
+    return value
+
+
+def _boolean(payload: dict[str, Any], key: str) -> bool:
+    value = payload.get(key)
+    if type(value) is not bool:
+        raise ValueError(f"promotion evidence {key} must be a boolean")
+    return value
+
+
+def _integer(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if type(value) is not int:
+        raise ValueError(f"promotion evidence {key} must be an integer")
+    return value
+
+
+def _object_list(payload: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    value = payload.get(key)
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise ValueError(f"promotion evidence {key} must be an array of objects")
+    return value
+
+
+def _string_list(payload: dict[str, Any], key: str) -> list[str]:
+    value = payload.get(key)
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValueError(f"promotion evidence {key} must be an array of strings")
+    return value
+
+
+def _evidence_from_payload(payload: dict[str, Any]) -> PromotionEvidence:
+    challengers = _object_list(payload, "challengers")
+    ev_buckets = _object_list(payload, "ev_buckets")
+    outcome_contrasts = _object_list(payload, "outcome_contrasts")
+    recent_year_evidence = _object_list(payload, "recent_year_evidence")
+    return PromotionEvidence(
+        evidence_version=_text(payload, "evidence_version"),
+        causal_observation_rule_version=_text(payload, "causal_observation_rule_version"),
+        fill_rule_version=_text(payload, "fill_rule_version"),
+        overlap_rule_version=_text(payload, "overlap_rule_version"),
+        after_cost_expectancy_ci_low_pct=Decimal(_text(payload, "after_cost_expectancy_ci_low_pct")),
+        max_drawdown_pct=Decimal(_text(payload, "max_drawdown_pct")),
+        expected_shortfall_5_pct=Decimal(_text(payload, "expected_shortfall_5_pct")),
+        worst_gap_pct=Decimal(_text(payload, "worst_gap_pct")),
+        excluding_best_1_expectancy_pct=Decimal(_text(payload, "excluding_best_1_expectancy_pct")),
+        recent_year_stable=_boolean(payload, "recent_year_stable"),
+        recent_years_evaluated=_integer(payload, "recent_years_evaluated"),
+        recent_year_evidence=tuple(
+            RecentYearEvidence(
+                year=_integer(item, "year"),
+                observation_count=_integer(item, "observation_count"),
+                after_cost_expectancy_pct=Decimal(_text(item, "after_cost_expectancy_pct")),
+                expectancy_ci_low_pct=Decimal(_text(item, "expectancy_ci_low_pct")),
+                risk_limits_passed=_boolean(item, "risk_limits_passed"),
+            )
+            for item in recent_year_evidence
+        ),
+        max_date_contribution_pct=Decimal(_text(payload, "max_date_contribution_pct")),
+        max_name_contribution_pct=Decimal(_text(payload, "max_name_contribution_pct")),
+        max_sector_contribution_pct=Decimal(_text(payload, "max_sector_contribution_pct")),
+        max_concurrency=_integer(payload, "max_concurrency"),
+        capacity_usd=Decimal(_text(payload, "capacity_usd")),
+        risk_limits_version=_text(payload, "risk_limits_version"),
+        risk_limits_passed=_boolean(payload, "risk_limits_passed"),
+        probability_calibration_passed=_boolean(payload, "probability_calibration_passed"),
+        path_diagnostics_complete=_boolean(payload, "path_diagnostics_complete"),
+        outcome_count=_integer(payload, "outcome_count"),
+        profitable_outcome_count=_integer(payload, "profitable_outcome_count"),
+        losing_outcome_count=_integer(payload, "losing_outcome_count"),
+        flat_outcome_count=_integer(payload, "flat_outcome_count"),
+        target_first_count=_integer(payload, "target_first_count"),
+        stop_first_count=_integer(payload, "stop_first_count"),
+        timeout_count=_integer(payload, "timeout_count"),
+        ambiguous_path_count=_integer(payload, "ambiguous_path_count"),
+        observed_cost_inputs=frozenset(cast(CostInput, item) for item in _string_list(payload, "observed_cost_inputs")),
+        cost_observed_on=date.fromisoformat(_text(payload, "cost_observed_on")),
+        cost_valid_through=date.fromisoformat(_text(payload, "cost_valid_through")),
+        cost_source_version=_text(payload, "cost_source_version"),
+        spread_bps=Decimal(_text(payload, "spread_bps")),
+        slippage_bps=Decimal(_text(payload, "slippage_bps")),
+        financing_bps_per_day=Decimal(_text(payload, "financing_bps_per_day")),
+        fx_bps=Decimal(_text(payload, "fx_bps")),
+        broker_eligible=_boolean(payload, "broker_eligible"),
+        challengers=tuple(
+            ChallengerEvidence(
+                role=cast(ChallengerRole, _text(item, "role")),
+                observation_count=_integer(item, "observation_count"),
+                expectancy_pct=Decimal(_text(item, "expectancy_pct")),
+                candidate_minus_challenger_pct=Decimal(_text(item, "candidate_minus_challenger_pct")),
+                same_observations_and_fills=_boolean(item, "same_observations_and_fills"),
+                causal_observation_rule_version=_text(item, "causal_observation_rule_version"),
+                fill_rule_version=_text(item, "fill_rule_version"),
+                overlap_rule_version=_text(item, "overlap_rule_version"),
+            )
+            for item in challengers
+        ),
+        ev_buckets=tuple(
+            ExpectedValueBucket(
+                rank=_integer(item, "rank"),
+                observation_count=_integer(item, "observation_count"),
+                forecast_ev_pct=Decimal(_text(item, "forecast_ev_pct")),
+                realised_expectancy_pct=Decimal(_text(item, "realised_expectancy_pct")),
+            )
+            for item in ev_buckets
+        ),
+        outcome_contrasts=tuple(
+            OutcomeContrast(
+                dimension=cast(ContrastDimension, _text(item, "dimension")),
+                profitable_count=_integer(item, "profitable_count"),
+                losing_count=_integer(item, "losing_count"),
+                profitable_mean=Decimal(_text(item, "profitable_mean")),
+                losing_mean=Decimal(_text(item, "losing_mean")),
+                profitable_minus_losing=Decimal(_text(item, "profitable_minus_losing")),
+            )
+            for item in outcome_contrasts
+        ),
+    )
+
+
+def load_promotion_evidence(conn: psycopg.Connection[Any], result_id: int) -> PromotionEvidence | None:
+    row = conn.execute(
+        """
+        SELECT evidence_version, payload_sha256, evidence_payload
+        FROM strategy_promotion_evidence
+        WHERE result_id = %s
+        """,
+        (result_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    payload = row[2]
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"promotion evidence for result {result_id} is not an object")
+    encoded = _canonical(payload)
+    actual_hash = hashlib.sha256(encoded).hexdigest()
+    if actual_hash != str(row[1]):
+        raise RuntimeError(f"promotion evidence hash mismatch for result {result_id}")
+    try:
+        evidence = _evidence_from_payload(payload)
+    except (DecimalException, KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"promotion evidence payload is invalid for result {result_id}: {exc}") from exc
+    if evidence.evidence_version != str(row[0]):
+        raise RuntimeError(f"promotion evidence version mismatch for result {result_id}")
+    return evidence
+
+
+__all__ = [
+    "MAX_PAYLOAD_BYTES",
+    "evidence_sha256",
+    "load_promotion_evidence",
+    "store_promotion_evidence",
+]

--- a/app/services/strategy_result.py
+++ b/app/services/strategy_result.py
@@ -71,13 +71,14 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
-from typing import Final, Literal, get_args
+from typing import Final, Literal, cast, get_args
 
 from app.services.cost_model import COST_MODEL_ID
 from app.services.deflated_sharpe import DeflatedSharpeResult
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
 from app.services.random_entry_cohort import SyntheticControl
 from app.services.research_price_structure_store import QUARANTINE_ARMS, QuarantineArm
+from app.services.strategy_promotion_evidence import PromotionEvidence, evidence_refusals
 from app.services.strategy_statistics import METRIC_SET_ID, StrategyMetrics
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
 
@@ -291,6 +292,27 @@ PromotionRefusal = Literal[
     "synthetic_control_not_run",
     "synthetic_control_cohort_shows_edge",
     "synthetic_control_sharpe_below_cohort",
+    "promotion_evidence_missing",
+    "expectancy_lower_bound_not_positive",
+    "profit_factor_not_computed",
+    "profit_factor_invalid",
+    "profit_factor_not_above_one",
+    "recent_year_instability",
+    "recent_year_evidence_incomplete",
+    "excluding_best_1_not_positive",
+    "tail_or_concentration_limits_failed",
+    "probability_calibration_failed",
+    "path_diagnostics_incomplete",
+    "executable_cost_inputs_missing",
+    "executable_cost_inputs_stale",
+    "broker_ineligible",
+    "challenger_evidence_incomplete",
+    "challenger_population_not_comparable",
+    "candidate_does_not_beat_challengers",
+    "ev_bucket_evidence_incomplete",
+    "ev_bucket_ranking_not_monotonic",
+    "outcome_contrast_evidence_incomplete",
+    "outcome_contrast_population_not_comparable",
 ]
 PROMOTION_REFUSALS: frozenset[str] = frozenset(get_args(PromotionRefusal))
 
@@ -738,6 +760,9 @@ class PromotionCandidate:
     #: missing and stops there. Compare ``ambiguity_material`` directly above,
     #: which DOES carry a magnitude verdict because §3.4 declares one.
     quarantine_arms_compared: bool = False
+    #: #2505's compact viability and edge-attribution record. A result without
+    #: it may be reproducible backtest evidence but cannot be capital evidence.
+    promotion_evidence: PromotionEvidence | None = None
 
 
 def check_promotable(candidate: PromotionCandidate) -> tuple[PromotionRefusal, ...]:
@@ -849,6 +874,24 @@ def check_promotable(candidate: PromotionCandidate) -> tuple[PromotionRefusal, .
             refusals.append("synthetic_control_cohort_shows_edge")
         if not control.sharpe_exceeds_cohort:
             refusals.append("synthetic_control_sharpe_below_cohort")
+
+    # #2505 — positive mean return is not enough. The candidate must have a
+    # positive clustered lower bound, measured tails/concentration, complete
+    # executable costs, calibrated ranking and same-path challenger attribution.
+    evidence = candidate.promotion_evidence
+    if evidence is None:
+        refusals.append("promotion_evidence_missing")
+    else:
+        refusals.extend(
+            cast(
+                tuple[PromotionRefusal, ...],
+                evidence_refusals(
+                    evidence,
+                    profit_factor=result.metrics.profit_factor,
+                    as_of=result.identity.window_end,
+                ),
+            )
+        )
 
     return tuple(refusals)
 

--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -254,6 +254,11 @@ Every candidate moves through the same loop. A loop can change a specification o
 before its outcome is observed. After outcome access, a change creates a new trial,
 new version and new untouched future interval.
 
+Implementation note (2026-08-12, #2505): the result-to-historical-validation
+transition now requires the compact immutable viability and same-path challenger
+record defined in `2026-08-12-promotion-edge-evidence-contract.md`. A pinned
+result ID or prose evidence reference alone can no longer cross that boundary.
+
 | loop | question | output | failure action |
 | --- | --- | --- | --- |
 | 0. Mechanism | Who is forced, slow, constrained or compensated, and why should the payoff persist after discovery? | One-page hypothesis, published prior, falsifiers and family identity. | Reject ideas whose rationale is only a chart resemblance or indicator vote. |

--- a/docs/proposals/ta/2026-08-12-promotion-edge-evidence-contract.md
+++ b/docs/proposals/ta/2026-08-12-promotion-edge-evidence-contract.md
@@ -1,0 +1,159 @@
+# Promotion viability and edge-attribution contract (#2505)
+
+Status: implemented 2026-08-12. This is a promotion refusal contract, not a
+claim that any current candidate passes it.
+
+## Decision
+
+A reproducible backtest result is necessary but no longer sufficient to cross
+from `research_candidate` to `historical_validated`. The transition must pin one
+or more immutable result rows and every pinned result must carry a complete,
+passing `promotion-edge-evidence-v1` record.
+
+This closes a real control-plane gap. `promote_strategy()` previously verified
+that result IDs belonged to the exact strategy version, but it did not require
+economic viability or edge-attribution evidence. There are currently zero
+registered capital candidates, so this did not authorise a bad allocation. It
+would have become fail-open as soon as a future candidate was registered.
+
+## Required viability evidence
+
+The compact record carries and the shared gate enforces:
+
+- after-cost clustered-bootstrap expectancy lower bound strictly above zero;
+- measured profit factor strictly above one;
+- maximum drawdown, expected shortfall, worst gap, expectancy excluding the
+  best 1%, portfolio concurrency and USD capacity;
+- the best-1%-excluded expectancy remaining strictly positive;
+- at least two recent years evaluated, with each year's population,
+  after-cost expectancy, lower confidence bound and risk verdict—not only a
+  declared recent-year stability boolean;
+- actual maximum date, instrument and sector contribution percentages;
+- a versioned candidate/mandate risk-limit verdict covering drawdown, tails and
+  concentration;
+- complete target-first, stop-first and timeout counts, with ambiguity count,
+  and a non-empty resolved population;
+- probability calibration and at least three ordered forecast-EV buckets whose
+  realised expectancy is monotonic and discriminating; and
+- explicit spread, slippage, daily financing and FX values, their source and
+  observation/valid-through dates, and current broker eligibility; and
+- the complete profitable-versus-losing population and eight bounded aggregate
+  contrasts: model feature score, execution cost, entry gap, liquidity, market
+  stress, and sector/date/instrument concentration.
+
+Missing is not zero and does not reduce a score. Each dimension has a distinct
+refusal code so an operator can see what must be measured or repaired.
+
+## Required edge attribution
+
+Every candidate must carry exactly one of each predeclared challenger role:
+
+1. raw instrument shock;
+2. market-only residual;
+3. market-plus-sector residual;
+4. matched random entries; and
+5. unfiltered eligible signals under the same overlap rule.
+
+Each challenger records population size, expectancy, candidate-minus-
+challenger expectancy and whether it used the exact same causal observations
+and fills. Candidate and challenger records pin the causal observation, fill
+and overlap rule versions; a label alone cannot assert comparability. Matched
+challenger populations must equal the candidate's resolved outcome count. The
+unfiltered-eligible population may be larger, but must use the identical
+overlap rule and cannot be smaller. A missing challenger, rule mismatch,
+population mismatch or non-positive candidate delta refuses promotion. The
+ordered EV buckets must likewise partition the whole candidate population; a
+favourable subset cannot stand in for ranking evidence. A model therefore
+cannot claim edge merely because a broad market move, selection filter,
+overlap rule or random timing also made money.
+
+Every contrast carries both population counts, both means and their exact
+difference. All eight must use the evidence record's complete profitable and
+losing populations. This makes differences diagnostic without persisting a
+feature matrix or allowing a favourable feature subset to masquerade as the
+whole comparison.
+
+The challenger vocabulary is intentionally strict for the current short-
+horizon residual/shock candidate family. A materially different mechanism must
+declare an equivalently strong versioned challenger contract rather than fill
+these roles with labels that do not apply.
+
+## Storage and database impact
+
+Migration `327_strategy_promotion_evidence.sql` creates one append-only row per
+`strategy_results_store.result_id`:
+
+- primary-key/FK lookup only; no secondary or JSON index;
+- canonical SHA-256 payload identity;
+- update and delete rejected by a database trigger;
+- hard 64 KiB JSON ceiling in both writer and database; and
+- aggregate diagnostics only—no bar features, rolling indicators, non-firing
+  scans, polling snapshots or raw broker payloads.
+
+Measured before implementation, dev held 196 result rows and the result store
+used 548,864 bytes. A representative complete evidence record serialises to
+4,357 compact bytes, about 0.85 MB if every existing result had one. Even the artificial
+hard ceiling would bound the current population near 12.25 MiB. Normal operation
+should remain close to the representative shape.
+
+## Integrity properties
+
+- The Python constructor refuses non-finite metrics, invalid loss signs,
+  malformed path partitions, duplicate challengers, unknown cost inputs,
+  non-contiguous EV ranks and more than ten aggregate EV buckets.
+- The loader verifies the canonical SHA-256 and strictly checks JSON scalar
+  types; a raw string such as `"false"` cannot become truthy evidence.
+- A result can receive one record only. Corrected evidence requires a new result
+  identity, preserving the old failed/incomplete record.
+- The historical promotion transition loads the exact pinned record and returns
+  all economic refusal codes. Forward-observation promotion rechecks every
+  newly pinned result as well. A prose `evidence_ref` cannot substitute for it.
+- No evidence endpoint or Strategies-page panel is added. Failed controls and
+  research candidates remain out of the money-first product surface.
+
+## Scope boundary
+
+This contract closes #2505's viability/attribution gap. It does not create
+alpha, repair survivor-only history, supply broker cost data, or promote any of
+S-1 through S-4. The pure result gate continues to enforce holdout access,
+trial count, effective sample size, ambiguity, quarantine and synthetic
+controls when results are produced. The control-plane transition now
+additionally enforces this persisted contract. This change does not pretend
+that the older gate's non-persisted set-valued inputs can be reconstructed from
+a result ID; making every one of those inputs independently replayable at the
+transition remains a separate control-plane hardening task.
+
+## First worked example: #2499
+
+The rejected residual-confluence development result is the first contract
+walk-through, not a passing example. Its published evidence maps to these
+independent refusals:
+
+- `expectancy_lower_bound_not_positive`: all four development intervals cross
+  zero and conservative 2025 expectancy is -1.332%;
+- `recent_year_instability` and `probability_calibration_failed`: the action
+  boundary loses in conservative 2025 despite positive predicted EV;
+- `tail_or_concentration_limits_failed`: 36.1% of accepted 2025 trades enter on
+  one date, while portfolio drawdown, expected shortfall and capacity were not
+  produced;
+- `executable_cost_inputs_missing`: slippage, financing, FX and current quote
+  evidence were explicitly absent;
+- `challenger_evidence_incomplete`: raw-shock, market-only and matched-random
+  arms were not run; and
+- `outcome_contrast_evidence_incomplete`: feature differences were reported,
+  but the cost, gap, sector/date/name and other required same-population
+  contrasts were not.
+
+The source result also records the material integrity incident: diagnostic
+processes loaded bars through the intended 2026 holdout, so that interval is
+permanently contaminated and cannot validate a rescued variant. No evidence
+row is fabricated for #2499 because its verifier deliberately wrote no strategy
+result and several mandatory populations were never measured. The immutable
+audit remains in `2026-08-10-residual-confluence-development-result.md`.
+
+The long-only historical-SUE follow-up (#2493) was reviewed as the next possible
+candidate and deliberately not pulled forward: its positive observation is at
+62 sessions, while its 5/20/40-session diagnostics are negative and the recent
+interval is already opened. Building it as the short-horizon answer would be
+another instance of selecting the next favourable number. It remains a
+separate long-horizon, prospective-only research option.

--- a/sql/327_strategy_promotion_evidence.sql
+++ b/sql/327_strategy_promotion_evidence.sql
@@ -1,0 +1,31 @@
+-- #2505: one compact immutable viability/edge-attribution record per result.
+-- This is aggregate evidence only: no per-bar features, non-firing scans,
+-- polling snapshots or raw broker payloads belong here.
+
+CREATE TABLE IF NOT EXISTS strategy_promotion_evidence (
+    result_id        BIGINT PRIMARY KEY
+        REFERENCES strategy_results_store(result_id) ON DELETE RESTRICT,
+    evidence_version TEXT NOT NULL CHECK (evidence_version <> ''),
+    payload_sha256   TEXT NOT NULL CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
+    evidence_payload JSONB NOT NULL
+        CHECK (jsonb_typeof(evidence_payload) = 'object')
+        CHECK (octet_length(evidence_payload::text) <= 65536),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE strategy_promotion_evidence IS
+    'One immutable <=64 KiB aggregate #2505 evidence record per strategy result: '
+    'lower-bound viability, tails/concentration, calibration, EV buckets, exact '
+    'same-path challengers and executable-cost completeness. No feature heap.';
+
+CREATE OR REPLACE FUNCTION refuse_strategy_promotion_evidence_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'strategy promotion evidence is immutable; create a new result identity';
+END $$;
+
+DROP TRIGGER IF EXISTS trg_strategy_promotion_evidence_immutable
+    ON strategy_promotion_evidence;
+CREATE TRIGGER trg_strategy_promotion_evidence_immutable
+BEFORE UPDATE OR DELETE ON strategy_promotion_evidence
+FOR EACH ROW EXECUTE FUNCTION refuse_strategy_promotion_evidence_mutation();

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -327,7 +327,7 @@ class TestOptionalStr:
 class TestExpectedRefusals:
     """§9's table, as the projection the run gates on."""
 
-    def test_full_holdout_run_with_a_dsr_leaves_only_the_three_standing_refusals(self) -> None:
+    def test_full_holdout_run_with_a_dsr_leaves_only_the_standing_refusals(self) -> None:
         assert _expected_refusals(holdout_requested=True, deflated=True) == STANDING_REFUSALS
 
     def test_harness_validation_purpose_is_predicted_before_the_write(self) -> None:
@@ -381,11 +381,12 @@ class TestExpectedRefusals:
             "trial_count_undeclared",
         }
 
-    def test_the_three_standing_refusals_are_the_ones_this_cut_cannot_close(self) -> None:
+    def test_the_standing_refusals_are_the_ones_this_cut_cannot_close(self) -> None:
         assert STANDING_REFUSALS == {
             "universe_basis_not_survivorship_free",
             "carry_unmodelled",
             "synthetic_control_not_run",
+            "promotion_evidence_missing",
         }
 
 

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 from typing import Any
 
@@ -10,6 +11,7 @@ import pytest
 
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
+from app.services.result_ledger import store_in_sample_result
 from app.services.strategy_control_plane import (
     StrategyControlError,
     StrategyOwnershipError,
@@ -26,8 +28,90 @@ from app.services.strategy_control_plane import (
     release_exact_position,
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST
+from app.services.strategy_promotion_evidence import (
+    EVIDENCE_VERSION,
+    REQUIRED_CHALLENGERS,
+    REQUIRED_CONTRASTS,
+    REQUIRED_COST_INPUTS,
+    ChallengerEvidence,
+    ExpectedValueBucket,
+    OutcomeContrast,
+    PromotionEvidence,
+    RecentYearEvidence,
+)
+from app.services.strategy_promotion_evidence_store import store_promotion_evidence
+from tests.test_result_ledger import build_metrics, build_result
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
+
+
+def _passing_promotion_evidence(*, lower_bound: str = "0.1") -> PromotionEvidence:
+    return PromotionEvidence(
+        evidence_version=EVIDENCE_VERSION,
+        causal_observation_rule_version="causal-v1",
+        fill_rule_version="fills-v1",
+        overlap_rule_version="overlap-v1",
+        after_cost_expectancy_ci_low_pct=Decimal(lower_bound),
+        max_drawdown_pct=Decimal("-8"),
+        expected_shortfall_5_pct=Decimal("-3"),
+        worst_gap_pct=Decimal("-5"),
+        excluding_best_1_expectancy_pct=Decimal("0.2"),
+        recent_year_stable=True,
+        recent_years_evaluated=3,
+        recent_year_evidence=(
+            RecentYearEvidence(2024, 34, Decimal("0.2"), Decimal("-0.1"), True),
+            RecentYearEvidence(2025, 33, Decimal("0.3"), Decimal("0.0"), True),
+            RecentYearEvidence(2026, 33, Decimal("0.4"), Decimal("0.1"), True),
+        ),
+        max_date_contribution_pct=Decimal("8"),
+        max_name_contribution_pct=Decimal("7"),
+        max_sector_contribution_pct=Decimal("20"),
+        max_concurrency=12,
+        capacity_usd=Decimal("100000"),
+        risk_limits_version="test-risk-v1",
+        risk_limits_passed=True,
+        probability_calibration_passed=True,
+        path_diagnostics_complete=True,
+        outcome_count=100,
+        profitable_outcome_count=60,
+        losing_outcome_count=40,
+        flat_outcome_count=0,
+        target_first_count=40,
+        stop_first_count=30,
+        timeout_count=30,
+        ambiguous_path_count=2,
+        observed_cost_inputs=REQUIRED_COST_INPUTS,
+        cost_observed_on=date.today(),
+        cost_valid_through=date.today(),
+        cost_source_version="etoro-quote-v1",
+        spread_bps=Decimal("8"),
+        slippage_bps=Decimal("5"),
+        financing_bps_per_day=Decimal("1"),
+        fx_bps=Decimal("2"),
+        broker_eligible=True,
+        challengers=tuple(
+            ChallengerEvidence(
+                role,
+                100,
+                Decimal("0.1"),
+                Decimal("0.2"),
+                True,
+                "causal-v1",
+                "fills-v1",
+                "overlap-v1",
+            )
+            for role in sorted(REQUIRED_CHALLENGERS)
+        ),
+        ev_buckets=(
+            ExpectedValueBucket(1, 34, Decimal("-0.2"), Decimal("-0.1")),
+            ExpectedValueBucket(2, 33, Decimal("0.1"), Decimal("0.2")),
+            ExpectedValueBucket(3, 33, Decimal("0.4"), Decimal("0.5")),
+        ),
+        outcome_contrasts=tuple(
+            OutcomeContrast(role, 60, 40, Decimal("1"), Decimal("0"), Decimal("1"))
+            for role in sorted(REQUIRED_CONTRASTS)
+        ),
+    )
 
 
 def _instrument(conn: psycopg.Connection[Any], instrument_id: int = 2454001) -> None:
@@ -177,6 +261,93 @@ def test_promotion_is_ordered_explicit_and_evidenced(
     # Runtime switches are deliberately irrelevant to governance state.
     conn.execute("UPDATE runtime_config SET enable_auto_trading = true, enable_live_trading = true WHERE id = true")
     assert current_stage(conn, "S-GOV", "v1") == "research_candidate"
+
+
+def test_historical_validation_requires_passing_edge_evidence(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    conn = ebull_test_conn
+    promote_strategy(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        to_stage="research_candidate",
+        promoted_by="operator",
+        reason="register candidate",
+    )
+    result = build_result(
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        namespace="in_sample",
+        metrics=build_metrics(profit_factor=1.2),
+    )
+    result_id = store_in_sample_result(conn, result)
+
+    with pytest.raises(StrategyControlError, match="promotion_evidence_missing"):
+        promote_strategy(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            to_stage="historical_validated",
+            promoted_by="operator",
+            reason="must not validate a bare result",
+            evidence_ref="result:test",
+            result_ids=(result_id,),
+        )
+
+    store_promotion_evidence(
+        conn,
+        result_id=result_id,
+        evidence=_passing_promotion_evidence(lower_bound="0"),
+    )
+    with pytest.raises(StrategyControlError, match="expectancy_lower_bound_not_positive"):
+        promote_strategy(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            to_stage="historical_validated",
+            promoted_by="operator",
+            reason="present but failing evidence is still a refusal",
+            evidence_ref="result:test",
+            result_ids=(result_id,),
+        )
+
+    passing_result = build_result(
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        namespace="in_sample",
+        ambiguity_arm="best_case",
+        metrics=build_metrics(profit_factor=1.2),
+    )
+    passing_result_id = store_in_sample_result(conn, passing_result)
+    store_promotion_evidence(
+        conn,
+        result_id=passing_result_id,
+        evidence=_passing_promotion_evidence(),
+    )
+    promotion = promote_strategy(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        to_stage="historical_validated",
+        promoted_by="operator",
+        reason="all #2505 evidence passes",
+        evidence_ref="result:test-passing",
+        result_ids=(passing_result_id,),
+    )
+    assert promotion.to_stage == "historical_validated"
+
+    with pytest.raises(StrategyControlError, match="expectancy_lower_bound_not_positive"):
+        promote_strategy(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            to_stage="forward_observation",
+            promoted_by="operator",
+            reason="later evidence stages cannot introduce a failing result",
+            evidence_ref="result:test-failing-forward",
+            result_ids=(result_id,),
+        )
 
 
 def test_harness_control_cannot_be_promoted_or_funded(

--- a/tests/test_strategy_holdout_namespace.py
+++ b/tests/test_strategy_holdout_namespace.py
@@ -497,6 +497,8 @@ def test_the_counts_move_the_promotion_gate_off_holdout_never_evaluated(
             # synthetic control, so §9's null distribution does not exist for
             # this row and its Sharpe has no scale to be read against.
             "synthetic_control_not_run",
+            # #2505: reproducible performance is still not attributable edge.
+            "promotion_evidence_missing",
         }
 
 

--- a/tests/test_strategy_promotion_evidence.py
+++ b/tests/test_strategy_promotion_evidence.py
@@ -1,0 +1,254 @@
+"""#2505's bounded viability and edge-attribution contract."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.services.strategy_promotion_evidence import (
+    EVIDENCE_VERSION,
+    REQUIRED_CHALLENGERS,
+    REQUIRED_CONTRASTS,
+    REQUIRED_COST_INPUTS,
+    ChallengerEvidence,
+    ExpectedValueBucket,
+    OutcomeContrast,
+    PromotionEvidence,
+    RecentYearEvidence,
+    evidence_refusals,
+)
+
+_AS_OF = date(2026, 8, 12)
+
+
+def _challenger(role: str, **overrides: object) -> ChallengerEvidence:
+    values: dict[str, object] = {
+        "role": role,
+        "observation_count": 50,
+        "expectancy_pct": Decimal("0.1"),
+        "candidate_minus_challenger_pct": Decimal("0.2"),
+        "same_observations_and_fills": True,
+        "causal_observation_rule_version": "causal-v1",
+        "fill_rule_version": "fills-v1",
+        "overlap_rule_version": "overlap-v1",
+    }
+    values.update(overrides)
+    return ChallengerEvidence(**values)  # type: ignore[arg-type]
+
+
+def _evidence(**overrides: object) -> PromotionEvidence:
+    values: dict[str, object] = {
+        "evidence_version": EVIDENCE_VERSION,
+        "causal_observation_rule_version": "causal-v1",
+        "fill_rule_version": "fills-v1",
+        "overlap_rule_version": "overlap-v1",
+        "after_cost_expectancy_ci_low_pct": Decimal("0.1"),
+        "max_drawdown_pct": Decimal("-8"),
+        "expected_shortfall_5_pct": Decimal("-3"),
+        "worst_gap_pct": Decimal("-5"),
+        "excluding_best_1_expectancy_pct": Decimal("0.2"),
+        "recent_year_stable": True,
+        "recent_years_evaluated": 3,
+        "recent_year_evidence": (
+            RecentYearEvidence(2024, 50, Decimal("0.2"), Decimal("-0.1"), True),
+            RecentYearEvidence(2025, 50, Decimal("0.3"), Decimal("0.0"), True),
+            RecentYearEvidence(2026, 50, Decimal("0.4"), Decimal("0.1"), True),
+        ),
+        "max_date_contribution_pct": Decimal("8"),
+        "max_name_contribution_pct": Decimal("7"),
+        "max_sector_contribution_pct": Decimal("20"),
+        "max_concurrency": 12,
+        "capacity_usd": Decimal("100000"),
+        "risk_limits_version": "test-risk-v1",
+        "risk_limits_passed": True,
+        "probability_calibration_passed": True,
+        "path_diagnostics_complete": True,
+        "outcome_count": 150,
+        "profitable_outcome_count": 80,
+        "losing_outcome_count": 70,
+        "flat_outcome_count": 0,
+        "target_first_count": 60,
+        "stop_first_count": 45,
+        "timeout_count": 45,
+        "ambiguous_path_count": 2,
+        "observed_cost_inputs": REQUIRED_COST_INPUTS,
+        "cost_observed_on": date(2026, 8, 11),
+        "cost_valid_through": date(2026, 8, 13),
+        "cost_source_version": "etoro-quote-v1",
+        "spread_bps": Decimal("8"),
+        "slippage_bps": Decimal("5"),
+        "financing_bps_per_day": Decimal("1"),
+        "fx_bps": Decimal("2"),
+        "broker_eligible": True,
+        "challengers": tuple(_challenger(role, observation_count=150) for role in sorted(REQUIRED_CHALLENGERS)),
+        "ev_buckets": (
+            ExpectedValueBucket(1, 50, Decimal("-0.2"), Decimal("-0.1")),
+            ExpectedValueBucket(2, 50, Decimal("0.1"), Decimal("0.2")),
+            ExpectedValueBucket(3, 50, Decimal("0.4"), Decimal("0.5")),
+        ),
+        "outcome_contrasts": tuple(
+            OutcomeContrast(role, 80, 70, Decimal("1"), Decimal("0"), Decimal("1"))
+            for role in sorted(REQUIRED_CONTRASTS)
+        ),
+    }
+    values.update(overrides)
+    return PromotionEvidence(**values)  # type: ignore[arg-type]
+
+
+def test_complete_evidence_clears_its_own_gate() -> None:
+    assert evidence_refusals(_evidence(), profit_factor=1.2, as_of=_AS_OF) == ()
+
+
+@pytest.mark.parametrize(
+    ("override", "refusal"),
+    [
+        ({"after_cost_expectancy_ci_low_pct": Decimal("0")}, "expectancy_lower_bound_not_positive"),
+        ({"recent_year_stable": False}, "recent_year_instability"),
+        (
+            {
+                "recent_years_evaluated": 1,
+                "recent_year_evidence": (RecentYearEvidence(2026, 50, Decimal("0.4"), Decimal("0.1"), True),),
+            },
+            "recent_year_evidence_incomplete",
+        ),
+        ({"excluding_best_1_expectancy_pct": Decimal("0")}, "excluding_best_1_not_positive"),
+        ({"risk_limits_passed": False}, "tail_or_concentration_limits_failed"),
+        ({"probability_calibration_passed": False}, "probability_calibration_failed"),
+        ({"path_diagnostics_complete": False}, "path_diagnostics_incomplete"),
+        ({"observed_cost_inputs": frozenset({"spread"})}, "executable_cost_inputs_missing"),
+    ],
+)
+def test_each_missing_viability_dimension_fails_closed(override: dict[str, object], refusal: str) -> None:
+    assert refusal in evidence_refusals(_evidence(**override), profit_factor=1.2, as_of=_AS_OF)
+
+
+def test_profit_factor_must_be_measured_and_above_break_even() -> None:
+    assert "profit_factor_not_computed" in evidence_refusals(_evidence(), profit_factor=None, as_of=_AS_OF)
+    assert "profit_factor_not_above_one" in evidence_refusals(_evidence(), profit_factor=1.0, as_of=_AS_OF)
+    assert "profit_factor_invalid" in evidence_refusals(_evidence(), profit_factor=float("nan"), as_of=_AS_OF)
+    assert "profit_factor_invalid" in evidence_refusals(_evidence(), profit_factor=float("inf"), as_of=_AS_OF)
+
+
+def test_recent_stability_uses_the_stored_year_values_not_only_a_boolean() -> None:
+    evidence = _evidence()
+    unstable = replace(
+        evidence,
+        recent_year_evidence=(
+            *evidence.recent_year_evidence[:-1],
+            replace(
+                evidence.recent_year_evidence[-1],
+                after_cost_expectancy_pct=Decimal("-0.01"),
+                expectancy_ci_low_pct=Decimal("-0.1"),
+            ),
+        ),
+    )
+    assert "recent_year_instability" in evidence_refusals(unstable, profit_factor=1.2, as_of=_AS_OF)
+
+
+def test_all_five_challengers_are_required_on_the_same_path() -> None:
+    evidence = _evidence()
+    incomplete = replace(evidence, challengers=evidence.challengers[:-1])
+    assert "challenger_evidence_incomplete" in evidence_refusals(incomplete, profit_factor=1.2, as_of=_AS_OF)
+
+    incomparable = replace(
+        evidence,
+        challengers=(replace(evidence.challengers[0], same_observations_and_fills=False), *evidence.challengers[1:]),
+    )
+    assert "challenger_population_not_comparable" in evidence_refusals(incomparable, profit_factor=1.2, as_of=_AS_OF)
+
+    wrong_population = replace(
+        evidence,
+        challengers=(replace(evidence.challengers[0], observation_count=149), *evidence.challengers[1:]),
+    )
+    assert "challenger_population_not_comparable" in evidence_refusals(
+        wrong_population, profit_factor=1.2, as_of=_AS_OF
+    )
+
+    wrong_rules = replace(
+        evidence,
+        challengers=(
+            replace(evidence.challengers[0], overlap_rule_version="overlap-v2"),
+            *evidence.challengers[1:],
+        ),
+    )
+    assert "challenger_population_not_comparable" in evidence_refusals(wrong_rules, profit_factor=1.2, as_of=_AS_OF)
+
+
+def test_candidate_must_beat_every_predeclared_challenger() -> None:
+    evidence = _evidence()
+    challengers = (
+        replace(evidence.challengers[0], candidate_minus_challenger_pct=Decimal("0")),
+        *evidence.challengers[1:],
+    )
+    assert "candidate_does_not_beat_challengers" in evidence_refusals(
+        replace(evidence, challengers=challengers), profit_factor=1.2, as_of=_AS_OF
+    )
+
+
+def test_ev_buckets_must_rank_realised_outcomes_not_only_forecasts() -> None:
+    reversed_realisation = replace(
+        _evidence(),
+        ev_buckets=(
+            ExpectedValueBucket(1, 50, Decimal("-0.2"), Decimal("0.3")),
+            ExpectedValueBucket(2, 50, Decimal("0.1"), Decimal("0.2")),
+            ExpectedValueBucket(3, 50, Decimal("0.4"), Decimal("0.1")),
+        ),
+    )
+    assert "ev_bucket_ranking_not_monotonic" in evidence_refusals(reversed_realisation, profit_factor=1.2, as_of=_AS_OF)
+
+    malformed_forecast_ranks = replace(
+        _evidence(),
+        ev_buckets=(
+            ExpectedValueBucket(1, 50, Decimal("0"), Decimal("-0.1")),
+            ExpectedValueBucket(2, 50, Decimal("100"), Decimal("0.2")),
+            ExpectedValueBucket(3, 50, Decimal("1"), Decimal("0.5")),
+        ),
+    )
+    assert "ev_bucket_ranking_not_monotonic" in evidence_refusals(
+        malformed_forecast_ranks, profit_factor=1.2, as_of=_AS_OF
+    )
+
+    partial_population = replace(_evidence(), ev_buckets=_evidence().ev_buckets[:-1])
+    assert "ev_bucket_evidence_incomplete" in evidence_refusals(partial_population, profit_factor=1.2, as_of=_AS_OF)
+
+
+def test_cost_values_must_be_current_and_broker_eligible() -> None:
+    stale = evidence_refusals(_evidence(cost_valid_through=date(2026, 8, 11)), profit_factor=1.2, as_of=_AS_OF)
+    assert "executable_cost_inputs_stale" in stale
+    assert "broker_ineligible" in evidence_refusals(_evidence(broker_eligible=False), profit_factor=1.2, as_of=_AS_OF)
+
+
+def test_all_outcome_contrasts_cover_the_same_profit_and_loss_populations() -> None:
+    evidence = _evidence()
+    assert "outcome_contrast_evidence_incomplete" in evidence_refusals(
+        replace(evidence, outcome_contrasts=evidence.outcome_contrasts[:-1]),
+        profit_factor=1.2,
+        as_of=_AS_OF,
+    )
+    wrong_population = replace(
+        evidence,
+        outcome_contrasts=(
+            replace(evidence.outcome_contrasts[0], profitable_count=79),
+            *evidence.outcome_contrasts[1:],
+        ),
+    )
+    assert "outcome_contrast_population_not_comparable" in evidence_refusals(
+        wrong_population, profit_factor=1.2, as_of=_AS_OF
+    )
+
+
+def test_constructor_refuses_unbounded_or_ambiguous_shapes() -> None:
+    with pytest.raises(ValueError, match="contiguous"):
+        _evidence(ev_buckets=(ExpectedValueBucket(2, 50, Decimal("0"), Decimal("0")),))
+    with pytest.raises(ValueError, match="unique"):
+        first = _evidence().challengers[0]
+        _evidence(challengers=(first, first))
+    with pytest.raises(ValueError, match="non-positive"):
+        _evidence(worst_gap_pct=Decimal("1"))
+    with pytest.raises(ValueError, match="must be a boolean"):
+        _evidence(recent_year_stable="false")
+    with pytest.raises(ValueError, match="same_observations_and_fills must be a boolean"):
+        _challenger("raw_instrument_shock", same_observations_and_fills="false")

--- a/tests/test_strategy_promotion_evidence_store.py
+++ b/tests/test_strategy_promotion_evidence_store.py
@@ -1,0 +1,201 @@
+"""DB boundary for #2505's one-row-per-result aggregate evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import replace
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.result_ledger import store_in_sample_result
+from app.services.strategy_promotion_evidence import (
+    EVIDENCE_VERSION,
+    REQUIRED_CHALLENGERS,
+    REQUIRED_CONTRASTS,
+    REQUIRED_COST_INPUTS,
+    ChallengerEvidence,
+    ExpectedValueBucket,
+    OutcomeContrast,
+    PromotionEvidence,
+    RecentYearEvidence,
+)
+from app.services.strategy_promotion_evidence_store import (
+    MAX_PAYLOAD_BYTES,
+    _jsonb_text_size,
+    _payload,
+    load_promotion_evidence,
+    store_promotion_evidence,
+)
+from tests.test_result_ledger import build_result
+
+
+def _evidence() -> PromotionEvidence:
+    return PromotionEvidence(
+        evidence_version=EVIDENCE_VERSION,
+        causal_observation_rule_version="causal-v1",
+        fill_rule_version="fills-v1",
+        overlap_rule_version="overlap-v1",
+        after_cost_expectancy_ci_low_pct=Decimal("0.123456789"),
+        max_drawdown_pct=Decimal("-8.5"),
+        expected_shortfall_5_pct=Decimal("-3.25"),
+        worst_gap_pct=Decimal("-5.75"),
+        excluding_best_1_expectancy_pct=Decimal("0.44"),
+        recent_year_stable=True,
+        recent_years_evaluated=3,
+        recent_year_evidence=(
+            RecentYearEvidence(2024, 40, Decimal("0.2"), Decimal("-0.1"), True),
+            RecentYearEvidence(2025, 40, Decimal("0.3"), Decimal("0.0"), True),
+            RecentYearEvidence(2026, 40, Decimal("0.4"), Decimal("0.1"), True),
+        ),
+        max_date_contribution_pct=Decimal("8.1"),
+        max_name_contribution_pct=Decimal("7.2"),
+        max_sector_contribution_pct=Decimal("19.3"),
+        max_concurrency=12,
+        capacity_usd=Decimal("123456.78"),
+        risk_limits_version="risk-v1+abc",
+        risk_limits_passed=True,
+        probability_calibration_passed=True,
+        path_diagnostics_complete=True,
+        outcome_count=120,
+        profitable_outcome_count=70,
+        losing_outcome_count=50,
+        flat_outcome_count=0,
+        target_first_count=48,
+        stop_first_count=36,
+        timeout_count=36,
+        ambiguous_path_count=2,
+        observed_cost_inputs=REQUIRED_COST_INPUTS,
+        cost_observed_on=date(2026, 8, 11),
+        cost_valid_through=date(2026, 8, 13),
+        cost_source_version="etoro-quote-v1",
+        spread_bps=Decimal("8"),
+        slippage_bps=Decimal("5"),
+        financing_bps_per_day=Decimal("1"),
+        fx_bps=Decimal("2"),
+        broker_eligible=True,
+        challengers=tuple(
+            ChallengerEvidence(
+                role,
+                120,
+                Decimal("0.1"),
+                Decimal("0.2"),
+                True,
+                "causal-v1",
+                "fills-v1",
+                "overlap-v1",
+            )
+            for role in sorted(REQUIRED_CHALLENGERS)
+        ),
+        ev_buckets=(
+            ExpectedValueBucket(1, 40, Decimal("-0.2"), Decimal("-0.1")),
+            ExpectedValueBucket(2, 40, Decimal("0.1"), Decimal("0.2")),
+            ExpectedValueBucket(3, 40, Decimal("0.4"), Decimal("0.5")),
+        ),
+        outcome_contrasts=tuple(
+            OutcomeContrast(role, 70, 50, Decimal("1"), Decimal("0"), Decimal("1"))
+            for role in sorted(REQUIRED_CONTRASTS)
+        ),
+    )
+
+
+def _result_id(conn: psycopg.Connection[tuple]) -> int:
+    return store_in_sample_result(conn, build_result(namespace="in_sample"))
+
+
+def test_evidence_round_trips_exactly_and_absence_is_explicit(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    assert load_promotion_evidence(ebull_test_conn, 999_999_999) is None
+    result_id = _result_id(ebull_test_conn)
+    evidence = _evidence()
+    store_promotion_evidence(ebull_test_conn, result_id=result_id, evidence=evidence)
+    assert load_promotion_evidence(ebull_test_conn, result_id) == evidence
+
+
+def test_one_result_cannot_accumulate_evidence_rewrites(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    result_id = _result_id(ebull_test_conn)
+    store_promotion_evidence(ebull_test_conn, result_id=result_id, evidence=_evidence())
+    with pytest.raises(psycopg.errors.UniqueViolation):
+        store_promotion_evidence(
+            ebull_test_conn,
+            result_id=result_id,
+            evidence=replace(_evidence(), after_cost_expectancy_ci_low_pct=Decimal("99")),
+        )
+
+
+@pytest.mark.parametrize("verb", ["UPDATE", "DELETE"])
+def test_evidence_is_immutable_in_the_database(ebull_test_conn: psycopg.Connection[tuple], verb: str) -> None:
+    result_id = _result_id(ebull_test_conn)
+    store_promotion_evidence(ebull_test_conn, result_id=result_id, evidence=_evidence())
+    with pytest.raises(psycopg.errors.RaiseException, match="immutable"):
+        if verb == "UPDATE":
+            ebull_test_conn.execute(
+                "UPDATE strategy_promotion_evidence SET evidence_version='rewrite' WHERE result_id=%s",
+                (result_id,),
+            )
+        else:
+            ebull_test_conn.execute("DELETE FROM strategy_promotion_evidence WHERE result_id=%s", (result_id,))
+
+
+def test_payload_has_a_database_and_writer_size_ceiling(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    result_id = _result_id(ebull_test_conn)
+    huge_version = "v" * MAX_PAYLOAD_BYTES
+    with pytest.raises(ValueError, match="exceeds"):
+        store_promotion_evidence(
+            ebull_test_conn,
+            result_id=result_id,
+            evidence=replace(_evidence(), risk_limits_version=huge_version),
+        )
+
+
+def test_database_also_refuses_an_oversized_raw_payload(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    result_id = _result_id(ebull_test_conn)
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(
+            """
+            INSERT INTO strategy_promotion_evidence (
+                result_id, evidence_version, payload_sha256, evidence_payload
+            ) VALUES (%s, %s, %s, %s::jsonb)
+            """,
+            (result_id, EVIDENCE_VERSION, "0" * 64, json.dumps({"padding": "x" * MAX_PAYLOAD_BYTES})),
+        )
+
+
+def test_writer_size_measure_matches_postgres_jsonb_text(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    payload = _payload(replace(_evidence(), risk_limits_version="risk-£-é-v1"))
+    compact = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    row = ebull_test_conn.execute(
+        "SELECT octet_length((%s::jsonb)::text)",
+        (compact,),
+    ).fetchone()
+    assert row is not None
+    assert _jsonb_text_size(payload) == int(row[0])
+
+
+def test_loader_fails_closed_on_a_raw_malformed_payload(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    result_id = _result_id(ebull_test_conn)
+    payload = {"evidence_version": EVIDENCE_VERSION, "recent_year_stable": "false"}
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_promotion_evidence (
+            result_id, evidence_version, payload_sha256, evidence_payload
+        ) VALUES (%s, %s, %s, %s::jsonb)
+        """,
+        (result_id, EVIDENCE_VERSION, hashlib.sha256(encoded).hexdigest(), encoded.decode()),
+    )
+    with pytest.raises(RuntimeError, match="payload is invalid"):
+        load_promotion_evidence(ebull_test_conn, result_id)
+
+
+def test_no_secondary_index_is_created_for_the_one_to_one_lookup(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    indexes = ebull_test_conn.execute(
+        "SELECT indexname FROM pg_indexes WHERE tablename='strategy_promotion_evidence' ORDER BY indexname"
+    ).fetchall()
+    assert indexes == [("strategy_promotion_evidence_pkey",)]

--- a/tests/test_strategy_result.py
+++ b/tests/test_strategy_result.py
@@ -24,6 +24,17 @@ import pytest
 
 from app.services.deflated_sharpe import DeflatedSharpeResult
 from app.services.random_entry_cohort import SyntheticControl
+from app.services.strategy_promotion_evidence import (
+    EVIDENCE_VERSION,
+    REQUIRED_CHALLENGERS,
+    REQUIRED_CONTRASTS,
+    REQUIRED_COST_INPUTS,
+    ChallengerEvidence,
+    ExpectedValueBucket,
+    OutcomeContrast,
+    PromotionEvidence,
+    RecentYearEvidence,
+)
 from app.services.strategy_result import (
     BENCHMARK_RULE,
     CORPUS_VERSION,
@@ -230,6 +241,77 @@ _CLEAN_RESULT_FIELDS: dict[str, object] = {
 }
 
 
+def _passing_promotion_evidence(**overrides: object) -> PromotionEvidence:
+    base: dict[str, object] = {
+        "evidence_version": EVIDENCE_VERSION,
+        "causal_observation_rule_version": "causal-v1",
+        "fill_rule_version": "fills-v1",
+        "overlap_rule_version": "overlap-v1",
+        "after_cost_expectancy_ci_low_pct": Decimal("0.1"),
+        "max_drawdown_pct": Decimal("-8"),
+        "expected_shortfall_5_pct": Decimal("-3"),
+        "worst_gap_pct": Decimal("-5"),
+        "excluding_best_1_expectancy_pct": Decimal("0.2"),
+        "recent_year_stable": True,
+        "recent_years_evaluated": 3,
+        "recent_year_evidence": (
+            RecentYearEvidence(2024, 34, Decimal("0.2"), Decimal("-0.1"), True),
+            RecentYearEvidence(2025, 33, Decimal("0.3"), Decimal("0.0"), True),
+            RecentYearEvidence(2026, 33, Decimal("0.4"), Decimal("0.1"), True),
+        ),
+        "max_date_contribution_pct": Decimal("8"),
+        "max_name_contribution_pct": Decimal("7"),
+        "max_sector_contribution_pct": Decimal("20"),
+        "max_concurrency": 12,
+        "capacity_usd": Decimal("100000"),
+        "risk_limits_version": "test-risk-v1",
+        "risk_limits_passed": True,
+        "probability_calibration_passed": True,
+        "path_diagnostics_complete": True,
+        "outcome_count": 100,
+        "profitable_outcome_count": 60,
+        "losing_outcome_count": 40,
+        "flat_outcome_count": 0,
+        "target_first_count": 40,
+        "stop_first_count": 30,
+        "timeout_count": 30,
+        "ambiguous_path_count": 2,
+        "observed_cost_inputs": REQUIRED_COST_INPUTS,
+        "cost_observed_on": date(2026, 7, 8),
+        "cost_valid_through": date(2026, 8, 13),
+        "cost_source_version": "etoro-quote-v1",
+        "spread_bps": Decimal("8"),
+        "slippage_bps": Decimal("5"),
+        "financing_bps_per_day": Decimal("1"),
+        "fx_bps": Decimal("2"),
+        "broker_eligible": True,
+        "challengers": tuple(
+            ChallengerEvidence(
+                role=role,
+                observation_count=100,
+                expectancy_pct=Decimal("0.1"),
+                candidate_minus_challenger_pct=Decimal("0.2"),
+                same_observations_and_fills=True,
+                causal_observation_rule_version="causal-v1",
+                fill_rule_version="fills-v1",
+                overlap_rule_version="overlap-v1",
+            )
+            for role in sorted(REQUIRED_CHALLENGERS)
+        ),
+        "ev_buckets": (
+            ExpectedValueBucket(1, 34, Decimal("-0.2"), Decimal("-0.1")),
+            ExpectedValueBucket(2, 33, Decimal("0.1"), Decimal("0.2")),
+            ExpectedValueBucket(3, 33, Decimal("0.4"), Decimal("0.5")),
+        ),
+        "outcome_contrasts": tuple(
+            OutcomeContrast(role, 60, 40, Decimal("1"), Decimal("0"), Decimal("1"))
+            for role in sorted(REQUIRED_CONTRASTS)
+        ),
+    }
+    base.update(overrides)
+    return PromotionEvidence(**base)  # type: ignore[arg-type]
+
+
 def _clean_candidate(**overrides: object) -> PromotionCandidate:
     """A candidate that passes EVERY check — the only shape ``check_promotable`` clears.
 
@@ -246,6 +328,7 @@ def _clean_candidate(**overrides: object) -> PromotionCandidate:
         "recorded_accesses": 1,
         "ambiguity_material": False,
         "quarantine_arms_compared": True,
+        "promotion_evidence": _passing_promotion_evidence(),
     }
     base.update(overrides)
     return PromotionCandidate(**base)  # type: ignore[arg-type]
@@ -789,6 +872,15 @@ class TestPromotionGateRefusals:
         candidate = _clean_candidate(result=_result(**_CLEAN_RESULT_FIELDS, synthetic_control=control))
         assert set(check_promotable(candidate)) == {"synthetic_control_sharpe_below_cohort"}
 
+    def test_missing_edge_attribution_evidence_refuses_an_otherwise_clean_candidate(self) -> None:
+        assert check_promotable(_clean_candidate(promotion_evidence=None)) == ("promotion_evidence_missing",)
+
+    def test_edge_attribution_failures_are_returned_by_the_shared_gate(self) -> None:
+        evidence = _passing_promotion_evidence(after_cost_expectancy_ci_low_pct=Decimal("0"))
+        assert check_promotable(_clean_candidate(promotion_evidence=evidence)) == (
+            "expectancy_lower_bound_not_positive",
+        )
+
     def test_both_synthetic_failures_are_reported_together(self) -> None:
         """⚠ NOT the first one. An operator seeing only the strategy-level code
         would tune the strategy against a cohort that invalidates every result
@@ -912,6 +1004,7 @@ class TestPromotionGateReportsEverything:
             "ambiguity_arms_not_compared",
             "quarantine_arms_not_compared",
             "synthetic_control_not_run",
+            "promotion_evidence_missing",
         }
 
     def test_todays_real_pipeline_state_is_refused(self) -> None:
@@ -933,6 +1026,7 @@ class TestPromotionGateReportsEverything:
             "ambiguity_arms_not_compared",
             "quarantine_arms_not_compared",
             "synthetic_control_not_run",
+            "promotion_evidence_missing",
         }
         assert is_promotable(candidate) is False
 


### PR DESCRIPTION
## Outcome

Strategy results can no longer cross into historical validation or forward observation on a pinned result ID and a prose evidence reference alone. Every pinned result must carry one immutable, bounded, passing viability and edge-attribution record.

## What is enforced

- positive after-cost clustered lower expectancy bound and profit factor above one;
- explicit drawdown, expected shortfall, worst gap, best-1%-excluded result, concentration, concurrency and capacity;
- bounded recent-year populations and results, including freshness and stability;
- complete target/stop/timeout and profit/loss/flat populations;
- current spread, slippage, financing, FX and broker eligibility values with source and validity dates;
- five predeclared challengers with matching causal, fill and overlap rule versions;
- whole-population, monotonic predicted-EV buckets;
- eight bounded profitable-vs-losing contrasts covering feature score, costs, gaps, liquidity, stress and concentration.

Missing, stale, non-finite, mismatched or weak evidence produces distinct refusal codes. #2499 is documented as the first failed worked example, including its contaminated 2026 holdout. No existing S-1..S-4 control is promoted.

## Storage

One append-only JSON aggregate per result, primary-key lookup only, no JSON/secondary indexes, SHA-256 identity, immutable trigger, and a matching 64 KiB writer/database ceiling. Representative payload: 4,357 bytes (about 0.85 MB for the current 196-result population). No bars, rolling features, non-firing scans or broker payloads are retained.

## Validation

- focused strategy/control/database suite: 271 tests green
- repository pre-push gate: green (ruff, format, pyright, shell/static invariants, pure suite, DB smoke, frontend integrity)
- repeated local Codex review: final pass found no correctness issue

Closes #2505