### PR TITLE
fix(strategy): cost adjusted research prices conservatively

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -62,7 +62,7 @@ from typing import Any, Final, Literal, cast
 import numpy as np
 import psycopg
 
-from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, half_spread_for
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, UNKNOWN_NOMINAL_PRICE_BAND
 from app.services.deflated_sharpe import (
     MIN_MEASURED_TRIALS,
     DeflatedSharpeResult,
@@ -1035,7 +1035,9 @@ def _benchmark_book(
         exit_wealth = float(wealth_window[exit_offset])
         if entry_close <= 0.0 or entry_wealth <= 0.0 or exit_wealth <= 0.0:
             continue
-        half = half_spread_for(Decimal(repr(entry_close)))
+        # The corpus OHLC is split-adjusted and has no point-in-time split
+        # factors.  It cannot honestly choose a nominal-price cost band (#2400).
+        half = UNKNOWN_NOMINAL_PRICE_BAND.half_spread
         book.add(
             entry_index=start + entry_offset - lo,
             exit_index=start + exit_offset - lo,
@@ -1491,7 +1493,7 @@ def evaluate_arm(
             window=corpus.window,
         )
         _absorb(
-            list(cost_positions(built.positions)),
+            list(cost_positions(built.positions, price_basis="split_adjusted")),
             series=series,
             window=corpus.window,
             axis_pos=corpus.axis_pos,
@@ -1663,7 +1665,7 @@ def evaluate_level_arms(
                 window=corpus.window,
             )
             _absorb(
-                list(cost_positions(built.positions)),
+                list(cost_positions(built.positions, price_basis="split_adjusted")),
                 series=series,
                 window=corpus.window,
                 axis_pos=corpus.axis_pos,

--- a/app/services/cost_model.py
+++ b/app/services/cost_model.py
@@ -34,19 +34,18 @@ nothing averages it as performance.
 NOT charged: carry (eToro's overnight/weekend CFD fee) and FX. Both are
 ``None``, not zero — see ``CARRY_BPS``.
 
-⚠ THE BAND IS KEYED ON THE **ENTRY** FILL PRICE AND FIXED FOR THE LIFE OF THE
-POSITION, and that is enforced by the shape of this API rather than documented:
-``half_spread_for`` is the only function that reads a price to choose a band,
-and ``buy_price`` / ``sell_price`` take the resulting ``half_spread`` as an
-argument. A caller cannot re-key mid-hold without passing a second half-spread
-it had to compute on purpose. §5.1: *"the cost is a property of the trade, and
-re-keying mid-hold would make the cost depend on the outcome"*.
+For an **as-traded** entry price the band is keyed on that entry and fixed for
+the life of the position. A split-adjusted research price cannot select a
+nominal threshold, so ``cost_band_for`` uses the maximum calibrated band. In
+both cases ``buy_price`` / ``sell_price`` take the selected ``half_spread`` as
+an argument; a caller cannot accidentally re-key mid-hold.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Literal, get_args
 
 #: ⚠ FROZEN. A recalibration ships under a NEW id — §5.1: *"so a recalibration
 #: is a new strategy version rather than a silent improvement (criterion 11)"*.
@@ -55,7 +54,13 @@ from decimal import Decimal
 #: admits only quotes captured inside a real NYSE session, resolved from
 #: ``market_calendar`` rather than from a UTC-hour literal (see
 #: ``SESSION_RULE``).
-COST_MODEL_ID = "static-p75-insession-v1"
+COST_MODEL_ID = "static-p75-insession-v2+split-adjusted-max"
+
+#: Whether a price can honestly select a nominal-price spread band.  The
+#: research corpus is split-adjusted, not as-traded; treating those two as the
+#: same is #2400's two-sided cost-attribution error.
+PriceBasis = Literal["as_traded", "split_adjusted"]
+PRICE_BASES: frozenset[str] = frozenset(get_args(PriceBasis))
 
 #: When the frozen table below was measured, and against what.
 #:
@@ -218,6 +223,12 @@ BANDS: tuple[PriceBand, ...] = (
     PriceBand(label=">=$100", lower=Decimal("100"), upper=None, p75_spread_pct=Decimal("0.322"), sample_size=210),
 )
 
+#: A split-adjusted historical price cannot select a nominal price band without
+#: the point-in-time split factor.  The corpus has no such factors, so use the
+#: most expensive measured band.  This is an adverse sensitivity suitable for
+#: falsification, not a claim that the resulting cost is the historical quote.
+UNKNOWN_NOMINAL_PRICE_BAND: PriceBand = max(BANDS, key=lambda band: band.p75_spread_pct)
+
 
 def _check_bands_are_total(bands: tuple[PriceBand, ...]) -> None:
     """Every positive price falls in exactly one band, or this module will not import.
@@ -274,6 +285,23 @@ def half_spread_for(entry_fill_price: Decimal) -> Decimal:
     return band_for(entry_fill_price).half_spread
 
 
+def cost_band_for(entry_fill_price: Decimal, *, price_basis: PriceBasis) -> PriceBand:
+    """Select a cost band without confusing adjusted and nominal prices.
+
+    ``as_traded`` may use the price thresholds. ``split_adjusted`` cannot: in
+    the absence of a point-in-time split factor it receives the maximum frozen
+    spread.  The price is still validated because callers must never cost a
+    non-price, even when its scale cannot choose a band.
+    """
+    if price_basis not in PRICE_BASES:
+        raise ValueError(f"unknown price basis {price_basis!r}; must be one of {sorted(PRICE_BASES)}")
+    if entry_fill_price <= 0:
+        raise ValueError(f"price must be > 0 to carry a cost band, got {entry_fill_price}")
+    if price_basis == "split_adjusted":
+        return UNKNOWN_NOMINAL_PRICE_BAND
+    return band_for(entry_fill_price)
+
+
 def buy_price(price: Decimal, *, half_spread: Decimal) -> Decimal:
     """§5.1's buy side: ``fill_price × (1 + h)``.
 
@@ -314,10 +342,14 @@ __all__ = [
     "CARRY_UNMODELLED",
     "COST_MODEL_ID",
     "FX_BPS",
+    "PRICE_BASES",
     "SESSION_RULE",
     "PriceBand",
+    "PriceBasis",
+    "UNKNOWN_NOMINAL_PRICE_BAND",
     "band_for",
     "buy_price",
+    "cost_band_for",
     "half_spread_for",
     "sell_price",
 ]

--- a/app/services/position_costing.py
+++ b/app/services/position_costing.py
@@ -26,7 +26,15 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import Literal, get_args
 
-from app.services.cost_model import COST_MODEL_ID, band_for, buy_price, half_spread_for, sell_price
+from app.services.cost_model import (
+    COST_MODEL_ID,
+    PRICE_BASES,
+    PriceBasis,
+    band_for,
+    buy_price,
+    cost_band_for,
+    sell_price,
+)
 from app.services.position_builder import Position
 
 #: Why a position carries no return even though it carries a cost band.
@@ -64,6 +72,9 @@ class CostedPosition:
 
     position: Position
     cost_model_id: str
+    price_basis: PriceBasis
+    #: A nominal band for ``as_traded`` or ``max:<band>`` when the nominal
+    #: price is unavailable. The latter must not read like observed history.
     band_label: str
     #: ``h`` — one side, as a fraction. Keyed on the ENTRY fill price (§5.1) and
     #: applied to BOTH sides, so a position crossing a band boundary mid-hold
@@ -78,6 +89,16 @@ class CostedPosition:
     uncosted_reason: UncostedReason | None
 
     def __post_init__(self) -> None:
+        if self.price_basis not in PRICE_BASES:
+            raise ValueError(f"unknown price basis {self.price_basis!r}; must be one of {sorted(PRICE_BASES)}")
+        expected_band = cost_band_for(self.position.entry_fill_price, price_basis=self.price_basis)
+        expected_label = expected_band.label if self.price_basis == "as_traded" else f"max:{expected_band.label}"
+        if self.band_label != expected_label or self.half_spread != expected_band.half_spread:
+            raise ValueError(
+                f"position on signal {self.position.entry_signal_id}: "
+                f"cost basis {(self.band_label, self.half_spread)!r} "
+                f"does not match {self.price_basis} entry basis {(expected_label, expected_band.half_spread)!r}"
+            )
         if self.exit_basis is not None and self.exit_basis not in EXIT_BASES:
             raise ValueError(f"unknown exit basis {self.exit_basis!r}; must be one of {sorted(EXIT_BASES)}")
         if self.uncosted_reason is not None and self.uncosted_reason not in UNCOSTED_REASONS:
@@ -148,15 +169,15 @@ def _exit_leg(position: Position) -> tuple[Decimal | None, ExitBasis | None, Unc
     return position.mark_price, "mark", None
 
 
-def cost_position(position: Position) -> CostedPosition:
+def cost_position(position: Position, *, price_basis: PriceBasis) -> CostedPosition:
     """Charge the half-spread on one position. Pure; reads no database.
 
-    ⚠ ``half_spread_for`` is called ONCE, on the entry fill price, and the same
-    ``h`` goes to both sides — §5.1's *"the band is keyed on the ENTRY fill
-    price, fixed for the life of the position"*.
+    ``price_basis`` is mandatory: nominal prices select their calibrated band;
+    split-adjusted research prices cannot and receive the maximum band. The
+    selected ``h`` goes to both sides and never re-keys during the position.
     """
-    half_spread = half_spread_for(position.entry_fill_price)
-    band = band_for(position.entry_fill_price)
+    band = cost_band_for(position.entry_fill_price, price_basis=price_basis)
+    half_spread = band.half_spread
     entry_net = buy_price(position.entry_fill_price, half_spread=half_spread)
 
     exit_gross, exit_basis, uncosted = _exit_leg(position)
@@ -172,7 +193,8 @@ def cost_position(position: Position) -> CostedPosition:
     return CostedPosition(
         position=position,
         cost_model_id=COST_MODEL_ID,
-        band_label=band.label,
+        price_basis=price_basis,
+        band_label=band.label if price_basis == "as_traded" else f"max:{band.label}",
         half_spread=half_spread,
         entry_price_net=entry_net,
         exit_price_gross=exit_gross,
@@ -184,9 +206,9 @@ def cost_position(position: Position) -> CostedPosition:
     )
 
 
-def cost_positions(positions: Iterable[Position]) -> tuple[CostedPosition, ...]:
+def cost_positions(positions: Iterable[Position], *, price_basis: PriceBasis) -> tuple[CostedPosition, ...]:
     """``cost_position`` over a set, preserving order."""
-    return tuple(cost_position(position) for position in positions)
+    return tuple(cost_position(position, price_basis=price_basis) for position in positions)
 
 
 def band_crossings(costed: Sequence[CostedPosition]) -> int:
@@ -197,9 +219,14 @@ def band_crossings(costed: Sequence[CostedPosition]) -> int:
     so a crossing is correct behaviour, not a defect. It is counted because the
     count is how big the deliberate approximation is, and a narrowing that is
     not counted is a narrowing asserted harmless.
+
+    Split-adjusted prices are skipped: their numeric thresholds are not nominal
+    bands, so calling a movement between them a crossing would repeat #2400.
     """
     crossings = 0
     for row in costed:
+        if row.price_basis != "as_traded":
+            continue
         if row.exit_price_gross is None:
             continue
         if band_for(row.exit_price_gross).label != row.band_label:

--- a/docs/proposals/ta/2026-08-07-bounded-backtester.md
+++ b/docs/proposals/ta/2026-08-07-bounded-backtester.md
@@ -392,11 +392,13 @@ table below is kept as the design record, not as a live number.
   half-spread for the band. Net return is computed from those adjusted prices,
   never by subtracting a cost from `gross_return_pct` — `sql/256` names that
   column GROSS precisely so nothing averages it as performance.
-- **The band is keyed on the ENTRY fill price**, fixed for the life of the
-  position. A position that crosses a band boundary does not re-key: the cost is
-  a property of the trade, and re-keying mid-hold would make the cost depend on
-  the outcome.
-- **Frozen as `cost_model_id = "static-p75-insession-v1"`**, so a recalibration
+- **The band is keyed on the ENTRY fill price only when that price is
+  as-traded.** Research OHLC is split-adjusted and the corpus has no historical
+  split factors, so it cannot honestly select a nominal-price band. Such rows
+  use the maximum calibrated band as an adverse falsification arm (#2400),
+  fixed for the life of the position.
+- **Frozen as `cost_model_id =
+  "static-p75-insession-v2+split-adjusted-max"`**, so the basis-policy change
   is a new strategy version rather than a silent improvement (criterion 11).
 - **FX is a declared field, and setting it to zero requires a fact not yet
   established.** §4.0 restricts the validated universe to `us_equity`, which
@@ -772,7 +774,7 @@ verification.
 | stage | what | depends on |
 | --- | --- | --- |
 | **5a** | **Position construction** — §3 in full: the three regimes, the §3.1 pyramiding rule, version pinning, `ambiguous` as terminal, same-bar ordering, S-2's drop-out close. Pure function over ledger rows. | resolver version selection (an input, not new code) |
-| **5b** | **Cost model** — table + `static-p75-insession-v1` per §5.1, `carry_bps` NULL, session resolved from the exchange calendar. Threads `cost_model_id` through the four `*_identity()` functions in place of `"undeclared-v0"`. | 5a |
+| **5b** | **Cost model** — frozen table plus an explicit price-basis policy; split-adjusted research prices use the maximum band under `static-p75-insession-v2+split-adjusted-max` (#2400). `carry_bps` remains NULL and the session is resolved from the exchange calendar. | 5a |
 | **5c** | **Result model + #2288 clauses 2–4** — the result table, basis `NOT NULL` no default, corpus version, and the promotion-refusal function. | 5b |
 | **5d** | **Statistics** — criterion 7's full metric set on the equity curve; the `vectorbt` adoption decision (§4) is taken here against 5a's trade list. | 5c |
 | **5e** | **Validity gates** — frozen hold-out namespace with access logging (criterion 5), purged walk-forward + embargo (§5.3, including S-1's declared bound), block bootstrap clustered by date (criterion 3), Deflated Sharpe with a declared trial count (criterion 6), quarantine sensitivity arm (criterion 9), and the 1,000-strategy random-entry synthetic control. | 5d |

--- a/docs/proposals/ta/2026-08-10-residual-confluence-development-result.md
+++ b/docs/proposals/ta/2026-08-10-residual-confluence-development-result.md
@@ -9,7 +9,8 @@ strategy manifest, capital picker, forward scanner or order path.
 - research corpus: `paperswithbacktest/Stocks-Daily-Price@2026-07-08`;
 - comparator snapshot: `etoro-comparators-2026-07-08-v1`;
 - quarantine rules: `price-quarantine-v1+d0423dbd9cb5`;
-- static cost model is applied to entry and every conditional exit;
+- static cost model `static-p75-insession-v1` is applied to entry and every
+  conditional exit;
 - anchored prior-only training; calendar 2024 and 2025 development tests;
 - 2,000 circular block-bootstrap resamples, clustered by entry date, seed
   `20260810`;
@@ -20,6 +21,12 @@ strategy manifest, capital picker, forward scanner or order path.
 The verifier is read-only. It created no feature, outcome, strategy, capital or
 order rows. The corrected run streamed 4,229,543 development bars and retained only in-memory
 candidate observations and aggregate output.
+
+⚠ #2400 later invalidated v1's use of split-adjusted prices as nominal cost-band
+keys. The cost-policy change intentionally moved the frozen candidate to
+`residual-confluence-v1+32dae77ea948`; that version has not been evaluated.
+This page remains the historical rejection record for `+946d549861cc`, not
+evidence for the new identity.
 
 ## Primary masked-data result
 

--- a/docs/proposals/ta/2026-08-12-split-adjusted-cost-basis.md
+++ b/docs/proposals/ta/2026-08-12-split-adjusted-cost-basis.md
@@ -1,0 +1,90 @@
+# Split-adjusted research prices and nominal transaction-cost bands
+
+**Status:** implemented as a conservative research correction  
+**Issue:** #2400  
+**Scope:** research/backtest costing only; no live-order path and no schema change
+
+## Decision
+
+Every costing caller declares one of two price bases:
+
+- `as_traded`: the entry price may select the frozen nominal-price spread band;
+- `split_adjusted`: the historical nominal price is unknown, so the maximum
+  calibrated spread band (`<$5`, 1.450% round trip) is charged.
+
+The policy is part of
+`cost_model_id = static-p75-insession-v2+split-adjusted-max`, so every strategy
+identity moves. A result produced under v1 cannot be mistaken for a corrected
+result.
+
+This is an **adverse falsification arm**, not reconstructed historical cost.
+It deliberately prefers false negatives to a favourable cost assumption. A
+strategy unable to survive it is not worth advancing; survival does not prove
+that its actual fills were obtainable.
+
+## Evidence and rejected alternatives
+
+The linked corpus contains 5,269 split-adjusted series and zero
+`price_adjustments` rows. There is therefore no point-in-time split factor with
+which to reconstruct as-traded price. The issue census found both directions of
+the error: reverse splits can undercharge distressed microcaps, while forward
+splits can overcharge old large-cap history. Reading the adjusted number as a
+nominal level is invalid regardless of aggregate direction.
+
+- Reconstructing nominal prices was rejected because the required source data
+  is absent; inferring factors would manufacture evidence.
+- Continuing to select a band from adjusted price was rejected because it
+  silently assigns precise but economically meaningless costs.
+- Dropping only visibly extreme series was rejected because an arbitrary
+  threshold leaves the same category error below the threshold.
+
+## Boundaries that remain
+
+This correction does not make the frozen quote sample representative. It is
+mostly closing-hour data from nine summer dates; carry and FX remain unknown.
+The promotion evidence contract therefore still requires fresh, dated broker
+cost evidence before a strategy can become capital-eligible.
+
+It also does **not** repair strategy eligibility rules expressed as nominal
+price thresholds (for example S-2's `$1` floor). Those must either receive a
+point-in-time as-traded price source or be replaced with a scale-invariant,
+point-in-time liquidity rule. Until then they remain declared limitations, not
+supporting evidence.
+
+## Storage and operations
+
+No database table, column, index, or retained observation is added. The basis
+is an in-memory property of each costed position and the policy is carried by
+the immutable cost-model identity stored on the existing result. Database size
+impact is zero; old results remain historically attributable to v1 and are not
+rewritten.
+
+The whole-corpus verification command is:
+
+```bash
+PYTHONPATH=. uv run python scripts/verify_2240_cost_model.py --positions
+```
+
+It must cover every validated linked research series, report zero costing
+property violations, and show the v2 model identity before corrected backtests
+are accepted.
+
+## Whole-corpus result (2026-08-12)
+
+The command above completed over all 5,266 validated linked series and
+3,163,173 positions with zero property violations.
+
+| strategy | prior v1 net win rate | corrected adverse-arm net win rate | median net trade |
+| --- | ---: | ---: | ---: |
+| S-1 time-series momentum | 31.628% | **19.264%** | **-143 bp** |
+| S-3 mean reversion in trend | 51.591% | **46.879%** | **-50 bp** |
+
+S-1's 3,133,100 realised closes lost 22.978 percentage points of win rate
+relative to gross. S-3's 27,782 realised closes lost 8.131 points. These are not
+viable promotion results and must not be shown as capital-ready metadata.
+
+The comparison is diagnostic rather than an estimate of true historical cost:
+v1 scrambled bands in both directions, while v2 applies the maximum band to
+every adjusted trade. Its useful conclusion is narrower and strong: neither
+candidate survives the adverse cost arm, so obtaining exact historical nominal
+prices cannot be deferred in order to promote either one.

--- a/scripts/verify_2240_cost_model.py
+++ b/scripts/verify_2240_cost_model.py
@@ -75,9 +75,9 @@ from app.services.cost_model import (
     COST_MODEL_ID,
     FX_BPS,
     SESSION_RULE,
+    UNKNOWN_NOMINAL_PRICE_BAND,
     _check_bands_are_total,
     band_for,
-    half_spread_for,
 )
 from app.services.market_calendar import us_market_status
 from app.services.position_builder import Window, build_positions
@@ -271,12 +271,13 @@ class _CostTally:
                     f"{self.label}/{position.instrument_id}: P1 uncharged entry — net {row.entry_price_net} "
                     f"does not exceed gross {position.entry_fill_price}"
                 )
-            # P3 — the band is the ENTRY band, checked against the source price.
-            expected = half_spread_for(position.entry_fill_price)
-            if row.half_spread != expected:
+            # P3 — adjusted research prices receive the declared adverse band;
+            # they never pretend their numeric value is a nominal price.
+            expected = UNKNOWN_NOMINAL_PRICE_BAND.half_spread
+            if row.price_basis != "split_adjusted" or row.half_spread != expected:
                 problems.append(
-                    f"{self.label}/{position.instrument_id}: P3 band key — half_spread {row.half_spread} against "
-                    f"{expected} for an entry at {position.entry_fill_price}"
+                    f"{self.label}/{position.instrument_id}: P3 basis — {(row.price_basis, row.half_spread)!r} against "
+                    f"split_adjusted/{expected} for an entry at {position.entry_fill_price}"
                 )
             # P4 — priced or reasoned, never both and never neither. (The row's
             # own __post_init__ already refuses the mixed state; this counts it.)
@@ -297,7 +298,7 @@ class _CostTally:
                         f"{row.gross_return_pct}"
                     )
                 assert row.exit_price_gross is not None
-                if band_for(row.exit_price_gross).label != row.band_label:
+                if row.price_basis == "as_traded" and band_for(row.exit_price_gross).label != row.band_label:
                     self.crossings += 1
                 if row.exit_basis == "close":
                     self.closed_priced += 1
@@ -332,7 +333,7 @@ class _CostTally:
             print(f"        exit basis {basis:<10} {count:>10,}")
         for reason, count in self.uncosted.most_common():
             print(f"        uncosted {reason:<12} {count:>10,}")
-        print(f"      band crossings         {self.crossings:>12,}   (entry band kept; §5.1)")
+        print("      nominal band crossings          n/a   (split-adjusted price basis)")
         for label, count in self.entry_bands.most_common():
             share = 100.0 * count / self.positions if self.positions else 0.0
             print(f"        entry band {label:<10} {count:>10,}   {share:6.3f}%")
@@ -431,7 +432,7 @@ def positions(*, limit: int | None) -> int:
                     regime=regime,
                     window=window,
                 )
-                costed = cost_positions(built.positions)
+                costed = cost_positions(built.positions, price_basis="split_adjusted")
                 # P4 — conservation across the layer boundary.
                 if len(costed) != len(built.positions):
                     problems.append(

--- a/scripts/verify_2240_quarantine_sensitivity.py
+++ b/scripts/verify_2240_quarantine_sensitivity.py
@@ -412,7 +412,7 @@ def _absorb_series(
             window=window,
         )
         sleeves[label].absorb(
-            list(cost_positions(built.positions)),
+            list(cost_positions(built.positions, price_basis="split_adjusted")),
             series=series,
             window=window,
             axis_pos=axis_pos,

--- a/scripts/verify_2240_random_entry_cohort.py
+++ b/scripts/verify_2240_random_entry_cohort.py
@@ -85,7 +85,7 @@ import numpy.typing as npt
 import psycopg
 
 from app.config import settings
-from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, half_spread_for
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, UNKNOWN_NOMINAL_PRICE_BAND
 from app.services.equity_curve import SIZING_RULE_ID, EquityCurve, LegBook, build_equity_curve
 from app.services.indicator_series import BarSeries
 from app.services.position_builder import Window, build_positions
@@ -484,7 +484,7 @@ def _absorb_series(
         eligible_bar.append(index)
         eligible_panel.append(slot)
         eligible_open.append(float(bar_open))
-        eligible_half.append(float(half_spread_for(bar_open)))
+        eligible_half.append(float(UNKNOWN_NOMINAL_PRICE_BAND.half_spread))
 
     bar_to_ordinal = {bar: ordinal for ordinal, bar in enumerate(eligible_bar)}
     warm_start: dict[str, int] = {}
@@ -530,7 +530,7 @@ def _absorb_series(
             regime=regime,
             window=window,
         )
-        costed = list(cost_positions(built.positions))
+        costed = list(cost_positions(built.positions, price_basis="split_adjusted"))
         sleeves[label].absorb(
             costed,
             series=series,

--- a/scripts/verify_2240_statistics.py
+++ b/scripts/verify_2240_statistics.py
@@ -91,7 +91,7 @@ import numpy as np
 import psycopg
 
 from app.config import settings
-from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, half_spread_for
+from app.services.cost_model import CARRY_UNMODELLED, COST_MODEL_ID, UNKNOWN_NOMINAL_PRICE_BAND
 from app.services.deflated_sharpe import (
     MIN_MEASURED_TRIALS,
     TradeMoments,
@@ -598,10 +598,8 @@ def _benchmark_leg(
     the window, so it is fixed by construction — and computing it with different
     machinery would attribute the machinery's difference to the strategy.
 
-    ⚠ It is charged the SAME cost model: one round trip at the entry band's
-    half-spread. A cost-free benchmark would make every strategy look worse by
-    exactly the amount the cost model charges, which is a comparison of cost
-    models rather than of strategies.
+    ⚠ It is charged the SAME adverse split-adjusted-price cost arm as the
+    strategy. A cost-free benchmark would compare cost models, not strategies.
     """
     usable = [i for i in range(len(series)) if series.rows[i].get("close") is not None]
     if len(usable) < 2:
@@ -615,7 +613,7 @@ def _benchmark_leg(
     exit_index = axis_pos.get(series.dates[last])
     if entry_index is None or exit_index is None or exit_index <= entry_index:
         return
-    half = half_spread_for(entry_close)
+    half = UNKNOWN_NOMINAL_PRICE_BAND.half_spread
     one = Decimal(1)
     book.add(
         entry_index=entry_index,
@@ -757,7 +755,7 @@ def curve(*, limit: int | None) -> int:
                     regime=regime,
                     window=window,
                 )
-                costed = list(cost_positions(built.positions))
+                costed = list(cost_positions(built.positions, price_basis="split_adjusted"))
                 # P6 — conservation across the layer boundary.
                 if len(costed) != len(built.positions):
                     sleeves[label].problems.append(

--- a/scripts/verify_2394_backtest_run.py
+++ b/scripts/verify_2394_backtest_run.py
@@ -544,7 +544,7 @@ def arm(*, limit: int | None, strategy_id: str) -> int:
                 regime=regime,
                 window=window,
             )
-            costed: list[CostedPosition] = list(cost_positions(built.positions))
+            costed: list[CostedPosition] = list(cost_positions(built.positions, price_basis="split_adjusted"))
             evaluate_s += time.monotonic() - mark
 
             # A2 / A3 — the §5.2 partition and the close-source census, taken on

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -52,7 +52,7 @@ from app.services.backtest_run import (
     evaluate_level_arms,
     runnable_strategies,
 )
-from app.services.cost_model import COST_MODEL_ID
+from app.services.cost_model import COST_MODEL_ID, UNKNOWN_NOMINAL_PRICE_BAND
 from app.services.deflated_sharpe import DSR_MODEL_ID, TradeMoments
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID, LegBook
 from app.services.indicator_series import BarSeries
@@ -750,7 +750,7 @@ class TestBenchmarkBook:
         assert book.exit_price[0] < 15.0
         assert book.half_spread[0] > 0.0
 
-    def test_raw_close_selects_the_spread_but_adjusted_close_measures_wealth(self) -> None:
+    def test_split_adjusted_close_uses_the_maximum_spread_and_wealth_close_measures_return(self) -> None:
         book = _benchmark_book(
             instruments=frozenset({1}),
             raw_closes_by_instrument={1: (0, array("d", [10.0, 11.0]))},
@@ -760,6 +760,7 @@ class TestBenchmarkBook:
         )
         assert book.entry_price[0] > 100.0
         assert book.exit_price[0] < 120.0
+        assert book.half_spread[0] == float(UNKNOWN_NOMINAL_PRICE_BAND.half_spread)
         assert book.marks.tolist() == [100.0, 120.0]
 
     def test_non_finite_wealth_observation_excludes_the_benchmark_leg(self) -> None:
@@ -812,7 +813,7 @@ class TestTotalReturnStrategyLeg:
         )
         books = {"hold_out": _NamespaceBook()}
         _absorb(
-            [cost_position(position)],
+            [cost_position(position, price_basis="split_adjusted")],
             series=series,
             window=Window(entry_day, exit_day),
             axis_pos={entry_day: 0, exit_day: 1},

--- a/tests/test_cost_model.py
+++ b/tests/test_cost_model.py
@@ -21,11 +21,14 @@ from app.services.cost_model import (
     CARRY_UNMODELLED,
     COST_MODEL_ID,
     FX_BPS,
+    PRICE_BASES,
+    UNKNOWN_NOMINAL_PRICE_BAND,
     PriceBand,
     _check_bands_are_total,
     _check_half_spread,
     band_for,
     buy_price,
+    cost_band_for,
     half_spread_for,
     sell_price,
 )
@@ -45,7 +48,7 @@ SPEC_BANDS: tuple[tuple[str, str | None, str | None, str, int], ...] = (
     (">=$100", "100", None, "0.322", 210),
 )
 
-SPEC_COST_MODEL_ID = "static-p75-insession-v1"
+SPEC_COST_MODEL_ID = "static-p75-insession-v2+split-adjusted-max"
 
 
 class TestTheFrozenTable:
@@ -105,6 +108,24 @@ class TestBandLookup:
 
     def test_half_spread_for_reads_the_entry_price_band(self) -> None:
         assert half_spread_for(Decimal("50")) == Decimal("0.509") / 200
+
+    def test_split_adjusted_price_uses_the_maximum_band_not_its_numeric_band(self) -> None:
+        assert cost_band_for(Decimal("500"), price_basis="split_adjusted") is UNKNOWN_NOMINAL_PRICE_BAND
+        assert UNKNOWN_NOMINAL_PRICE_BAND.p75_spread_pct == max(b.p75_spread_pct for b in BANDS)
+
+    def test_as_traded_price_can_select_its_nominal_band(self) -> None:
+        assert cost_band_for(Decimal("500"), price_basis="as_traded").label == ">=$100"
+
+    def test_an_unknown_basis_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="unknown price basis"):
+            cost_band_for(Decimal("50"), price_basis="raw")  # type: ignore[arg-type]
+
+    def test_split_adjusted_still_requires_a_positive_price(self) -> None:
+        with pytest.raises(ValueError, match="must be > 0"):
+            cost_band_for(Decimal("0"), price_basis="split_adjusted")
+
+    def test_the_basis_vocabulary_is_closed(self) -> None:
+        assert PRICE_BASES == {"as_traded", "split_adjusted"}
 
 
 class TestTheBandTableIsTotal:

--- a/tests/test_position_costing.py
+++ b/tests/test_position_costing.py
@@ -12,14 +12,27 @@ from decimal import Decimal
 
 import pytest
 
-from app.services.cost_model import COST_MODEL_ID, half_spread_for
+from app.services.cost_model import COST_MODEL_ID, UNKNOWN_NOMINAL_PRICE_BAND, half_spread_for
 from app.services.position_builder import Position
 from app.services.position_costing import (
     CostedPosition,
     band_crossings,
-    cost_position,
-    cost_positions,
 )
+from app.services.position_costing import (
+    cost_position as _cost_position,
+)
+from app.services.position_costing import (
+    cost_positions as _cost_positions,
+)
+
+
+def cost_position(position: Position) -> CostedPosition:
+    """Synthetic fixtures use nominal, as-traded prices unless stated."""
+    return _cost_position(position, price_basis="as_traded")
+
+
+def cost_positions(positions: list[Position]) -> tuple[CostedPosition, ...]:
+    return _cost_positions(positions, price_basis="as_traded")
 
 
 def _position(**overrides: object) -> Position:
@@ -132,6 +145,21 @@ class TestTheBandIsKeyedOnTheEntryPrice:
         assert band_crossings(rows) == 0
 
 
+class TestSplitAdjustedPriceBasis:
+    def test_it_uses_the_maximum_cost_band_regardless_of_adjusted_price(self) -> None:
+        low = _cost_position(_position(entry_fill_price=Decimal("4")), price_basis="split_adjusted")
+        high = _cost_position(_position(entry_fill_price=Decimal("500")), price_basis="split_adjusted")
+        assert low.band_label == high.band_label == f"max:{UNKNOWN_NOMINAL_PRICE_BAND.label}"
+        assert low.half_spread == high.half_spread == UNKNOWN_NOMINAL_PRICE_BAND.half_spread
+        assert low.price_basis == high.price_basis == "split_adjusted"
+
+    def test_adjusted_prices_do_not_claim_nominal_band_crossings(self) -> None:
+        row = _cost_position(
+            _position(entry_fill_price=Decimal("500"), close_price=Decimal("4")), price_basis="split_adjusted"
+        )
+        assert band_crossings([row]) == 0
+
+
 class TestAnOpenPosition:
     def test_the_mark_is_charged_the_exit_side(self) -> None:
         """§3.2 rule 5: the mark is *"minus one side of the cost model (the exit
@@ -205,6 +233,7 @@ class TestRowInvariants:
         fields: dict[str, object] = {
             "position": position,
             "cost_model_id": COST_MODEL_ID,
+            "price_basis": "as_traded",
             "band_label": ">=$100",
             "half_spread": h,
             "entry_price_net": position.entry_fill_price * (1 + h),
@@ -283,6 +312,18 @@ class TestRowInvariants:
                 net_return_pct=None,
                 uncosted_reason="dunno",
             )
+
+    def test_an_unknown_price_basis_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown price basis"):
+            self._costed(price_basis="adjusted-ish")
+
+    def test_a_band_label_that_disagrees_with_the_basis_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="does not match as_traded entry basis"):
+            self._costed(band_label="max:<$5")
+
+    def test_a_half_spread_that_disagrees_with_the_basis_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="does not match as_traded entry basis"):
+            self._costed(half_spread=Decimal("0.01"), entry_price_net=Decimal("101"))
 
 
 class TestCostPositionsPreservesOrder:

--- a/tests/test_residual_confluence_candidate.py
+++ b/tests/test_residual_confluence_candidate.py
@@ -52,8 +52,8 @@ def _inputs() -> dict[str, object]:
 
 def test_definition_is_complete_stable_and_contains_no_measured_result() -> None:
     payload = definition_json()
-    assert definition_hash() == "946d549861ccca18e1e0d78a1615815e97a989afd45009de12aabf7e0384fc26"
-    assert CANDIDATE_VERSION == "residual-confluence-v1+946d549861cc"
+    assert definition_hash() == "32dae77ea948d553589b98f42feb117f3efee25871e37c21aa0b3741a60e97d1"
+    assert CANDIDATE_VERSION == "residual-confluence-v1+32dae77ea948"
     assert DEFINITION.market_vol_long_lookback == 252
     assert DEFINITION.model_features == MODEL_FEATURE_NAMES
     assert "expectancy" not in payload


### PR DESCRIPTION
## Outcome

Eliminates #2400s category error: split-adjusted research prices can no longer select nominal-price transaction-cost bands. Every costing caller now declares `as_traded` or `split_adjusted`; adjusted research receives the maximum frozen band as an explicitly adverse falsification arm.

The policy is versioned as `static-p75-insession-v2+split-adjusted-max`, so all strategy and preregistered candidate identities move and stale v1 evidence cannot be presented as current. No schema, migration, retained observation, backfill or database growth is introduced.

## Whole-corpus evidence

`PYTHONPATH=. uv run python scripts/verify_2240_cost_model.py --positions` completed over all 5,266 validated linked series and 3,163,173 positions with zero property violations.

| strategy | v1 net win rate | corrected adverse-arm net win rate | median net trade |
| --- | ---: | ---: | ---: |
| S-1 time-series momentum | 31.628% | 19.264% | -143 bp |
| S-3 mean reversion in trend | 51.591% | 46.879% | -50 bp |

Neither candidate is capital-ready. The new figures are conservative falsification evidence, not reconstructed historical costs; point-in-time as-traded price, fresh broker costs, carry and FX remain required before promotion.

## Verification

- repository pre-push gate green: ruff, formatting, pyright, structural lints, full pure suite, DB boot smoke and frontend integrity checks
- 5,266-series full-population census: zero violations
- Codex review against `origin/main`: no findings; 188 focused tests passed in its sandbox

Closes #2400. Refs #2240, #2505 and #2508.