### PR TITLE
feat(strategies): add bounded eToro breadth snapshot

### DIFF
--- a/app/providers/implementations/etoro.py
+++ b/app/providers/implementations/etoro.py
@@ -2,30 +2,36 @@
 eToro market data provider.
 
 Implements MarketDataProvider against the real eToro public API.
-Raw API response disk dumps were retired in #471 — every structured
-field lands in SQL (``instruments``, ``price_daily``, ``quotes``,
-``exchanges``), and those tables are the audit trail (see
+Raw API response disk dumps were retired in #471. Durable structured
+fields land in SQL (``instruments``, ``price_daily``, ``quotes``,
+``exchanges``), and those tables are the audit trail outside the two bounded
+ephemeral cases below (see
 ``docs/review-prevention-log.md`` §"Raw payload persistence" for
 the scope-narrowed rule).
 
-**Intraday candle carve-out (#600).** ``get_intraday_candles`` is
-the one method on this class whose result is NOT mirrored to a SQL
-table. Intraday bars are ephemeral chart-UI data — they do not
+**Bounded ephemeral carve-outs.** ``get_intraday_candles`` returns ephemeral
+chart-UI data — it does not
 drive scoring, thesis, recommendations, orders, dividends, or tax,
 so the SQL-as-audit-trail invariant does not apply. The pass-through
 is gated by a TTL cache (``app/services/intraday_candles.py``) and
 the API endpoint is auth-gated to keep external quota traceable.
 Persisting intraday rows would expand the audit / sync surface
 without analytical value; the no-persistence design is locked at
-epic #585 and reviewed by Codex pre-implementation. This is the
-**only** sanctioned exception to the structured-fields-land-in-SQL
-rule for this provider — adding more requires reopening the design.
+epic #585 and reviewed by Codex pre-implementation.
+
+``get_broad_market_snapshot`` is the second narrow exception (#2523). It is a
+two-page, collection-time screening cross-section with no per-row source
+timestamp or bid/ask. Routine rows are never evidence and are not persisted;
+only aggregate coverage and the existing compact fired/refused decision context
+may survive. A shortlisted instrument still requires a timestamped quote. Any
+additional exception requires reopening this design.
 
 Auth: three-header scheme (x-api-key, x-user-key, x-request-id).
 Base URL: https://public-api.etoro.com (configurable via settings.etoro_base_url).
 """
 
 import logging
+import math
 from collections.abc import Mapping
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -36,12 +42,14 @@ import httpx
 
 from app.config import settings
 from app.providers.market_data import (
+    BroadMarketSnapshot,
     ExchangeRecord,
     InstrumentRecord,
     InstrumentTypeRecord,
     IntradayBar,
     IntradayInterval,
     MarketDataProvider,
+    MarketSnapshotInstrument,
     OHLCVBar,
     Quote,
     StocksIndustryRecord,
@@ -55,9 +63,19 @@ logger = logging.getLogger(__name__)
 # eToro returns 500 on a chunk containing a problematic ID.
 _RATES_BATCH_SIZE = 50
 
-# eToro rate limit: 60 GET requests per minute (rolling window).
-# 1.1s inter-request interval ≈ 55 req/min — ~8% headroom.
+# eToro's market-data endpoints share 120 requests per rolling minute.  Keep
+# the older conservative pacing here because other processes use the same user
+# key and ResilientClient's gate is process-local, not account-global.
 _ETORO_READ_INTERVAL_S = 1.1
+
+_SEARCH_PAGE_SIZE = 10_000
+_SEARCH_MAX_PAGES = 2
+_SEARCH_FIELDS = (
+    "instrumentId,currentRate,dailyPriceChange,weeklyPriceChange,"
+    "monthlyPriceChange,isCurrentlyTradable,isExchangeOpen,"
+    "isActiveInPlatform,isBuyEnabled,internalIndustryId,sectorNameId,"
+    "popularityUniques7Day,traders7DayChange,buyHoldingPct,sellHoldingPct"
+)
 
 
 class EtoroMarketDataProvider(MarketDataProvider):
@@ -125,6 +143,92 @@ class EtoroMarketDataProvider(MarketDataProvider):
         response.raise_for_status()
         raw = response.json()
         return _normalise_instruments(raw)
+
+    def get_broad_market_snapshot(self) -> BroadMarketSnapshot:
+        """Fetch eToro's projected search catalogue in complete pages.
+
+        Live verification on 2026-08-12 found that the documented
+        ``pageNumber`` parameter is ignored while ``page`` paginates.  The
+        response's reported page and total are therefore checked on every
+        request.  Search rows have no source timestamp or bid/ask and remain
+        screening-only; callers join exact local IDs and confirm shortlisted
+        candidates through ``get_quotes``.
+
+        The result is intentionally not persisted wholesale.  Strategy code
+        may retain aggregate coverage plus the compact context of a genuinely
+        fired/refused candidate, avoiding a second quote/indicator warehouse.
+        """
+        observed_from = datetime.now(UTC)
+        expected_total: int | None = None
+        raw_item_count = 0
+        discarded_items = 0
+        records: list[MarketSnapshotInstrument] = []
+        seen_ids: set[int] = set()
+        page = 1
+
+        while True:
+            response = self._http.get(
+                "/api/v1/market-data/search",
+                params={
+                    "fields": _SEARCH_FIELDS,
+                    "pageSize": _SEARCH_PAGE_SIZE,
+                    "page": page,
+                },
+                headers=self._request_headers(),
+            )
+            response.raise_for_status()
+            raw = response.json()
+            if not isinstance(raw, dict):
+                raise ValueError(f"Expected dict from eToro search endpoint, got {type(raw)}")
+
+            reported_page = raw.get("page")
+            total_items = raw.get("totalItems")
+            items = raw.get("items")
+            if reported_page != page:
+                raise ValueError(f"eToro search returned page {reported_page!r}, expected {page}")
+            if not isinstance(total_items, int) or total_items < 0:
+                raise ValueError(f"eToro search returned invalid totalItems {total_items!r}")
+            if not isinstance(items, list):
+                raise ValueError("eToro search response items must be a list")
+            if expected_total is None:
+                expected_total = total_items
+            elif total_items != expected_total:
+                raise ValueError(
+                    f"eToro search totalItems changed during pagination: {expected_total} -> {total_items}"
+                )
+
+            raw_item_count += len(items)
+            for item in items:
+                record = _normalise_market_snapshot_instrument(item)
+                if record is None:
+                    discarded_items += 1
+                    continue
+                if record.instrument_id in seen_ids:
+                    raise ValueError(f"eToro search repeated instrumentId {record.instrument_id}")
+                seen_ids.add(record.instrument_id)
+                records.append(record)
+
+            pages = max(1, math.ceil(total_items / _SEARCH_PAGE_SIZE))
+            if pages > _SEARCH_MAX_PAGES:
+                raise ValueError(
+                    f"eToro search reported {total_items} rows across {pages} pages; "
+                    f"bounded adapter permits {_SEARCH_MAX_PAGES}"
+                )
+            if page >= pages:
+                break
+            page += 1
+
+        if expected_total is None:  # pragma: no cover - first response always assigns
+            raise RuntimeError("eToro search pagination did not initialise")
+        if raw_item_count != expected_total:
+            raise ValueError(f"eToro search pagination incomplete: received {raw_item_count} of {expected_total} rows")
+        return BroadMarketSnapshot(
+            observed_from=observed_from,
+            observed_to=datetime.now(UTC),
+            reported_total_items=expected_total,
+            discarded_items=discarded_items,
+            instruments=tuple(records),
+        )
 
     def get_instrument_types(self) -> list[InstrumentTypeRecord]:
         """Fetch eToro's instrument-types lookup catalogue.
@@ -378,6 +482,35 @@ def _normalise_instrument(item: Mapping[str, object]) -> InstrumentRecord | None
         country=None,  # not available in instruments endpoint
         is_tradable=True,  # only tradable instruments are returned by the API
         instrument_type_id=_int_or_none(item.get("instrumentTypeID")),
+    )
+
+
+def _normalise_market_snapshot_instrument(item: object) -> MarketSnapshotInstrument | None:
+    """Normalise one projected search row without inventing absent values."""
+    if not isinstance(item, Mapping):
+        return None
+    instrument_id = _positive_int_or_none(item.get("instrumentId"))
+    if instrument_id is None:
+        return None
+    current_rate = _decimal_or_none(item.get("currentRate"))
+    if current_rate is not None and current_rate <= 0:
+        current_rate = None
+    return MarketSnapshotInstrument(
+        instrument_id=instrument_id,
+        current_rate=current_rate,
+        daily_price_change_pct=_decimal_or_none(item.get("dailyPriceChange")),
+        weekly_price_change_pct=_decimal_or_none(item.get("weeklyPriceChange")),
+        monthly_price_change_pct=_decimal_or_none(item.get("monthlyPriceChange")),
+        is_currently_tradable=_bool_or_none(item.get("isCurrentlyTradable")),
+        is_exchange_open=_bool_or_none(item.get("isExchangeOpen")),
+        is_active_in_platform=_bool_or_none(item.get("isActiveInPlatform")),
+        is_buy_enabled=_bool_or_none(item.get("isBuyEnabled")),
+        industry_id=_positive_int_or_none(item.get("internalIndustryId")),
+        sector_id=_positive_int_or_none(item.get("sectorNameId")),
+        popularity_uniques_7d=_decimal_or_none(item.get("popularityUniques7Day")),
+        traders_7d_change=_decimal_or_none(item.get("traders7DayChange")),
+        buy_holding_pct=_decimal_or_none(item.get("buyHoldingPct")),
+        sell_holding_pct=_decimal_or_none(item.get("sellHoldingPct")),
     )
 
 
@@ -714,3 +847,22 @@ def _int_or_none(value: object) -> int | None:
         return result if result != 0 else None
     except ValueError, ArithmeticError:
         return None
+
+
+def _positive_int_or_none(value: object) -> int | None:
+    result = _int_or_none(value)
+    return result if result is not None and result > 0 else None
+
+
+def _decimal_or_none(value: object) -> Decimal | None:
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        result = Decimal(str(value))
+    except ValueError, ArithmeticError:
+        return None
+    return result if result.is_finite() else None
+
+
+def _bool_or_none(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None

--- a/app/providers/market_data.py
+++ b/app/providers/market_data.py
@@ -125,6 +125,51 @@ class Quote:
     conversion_rate: Decimal | None = None
 
 
+@dataclass(frozen=True)
+class MarketSnapshotInstrument:
+    """One projected row from a provider's broad market catalogue.
+
+    This is screening context, not an executable quote: provider search rows
+    do not carry a per-instrument timestamp or a bid/ask pair.  Any candidate
+    selected from this snapshot must still pass the normal fresh-quote gate.
+    Price-change values are percentages in the provider's published units.
+    """
+
+    instrument_id: int
+    current_rate: Decimal | None
+    daily_price_change_pct: Decimal | None
+    weekly_price_change_pct: Decimal | None
+    monthly_price_change_pct: Decimal | None
+    is_currently_tradable: bool | None
+    is_exchange_open: bool | None
+    is_active_in_platform: bool | None
+    is_buy_enabled: bool | None
+    industry_id: int | None
+    sector_id: int | None
+    popularity_uniques_7d: Decimal | None
+    traders_7d_change: Decimal | None
+    buy_holding_pct: Decimal | None
+    sell_holding_pct: Decimal | None
+
+
+@dataclass(frozen=True)
+class BroadMarketSnapshot:
+    """A completed, paginated broad-market observation.
+
+    ``observed_from``/``observed_to`` expose the collection interval rather
+    than pretending thousands of projected values share one source timestamp.
+    ``reported_total_items`` includes provider rows with invalid/non-positive
+    IDs; those rows are counted in ``discarded_items`` and never enter
+    ``instruments``.
+    """
+
+    observed_from: datetime
+    observed_to: datetime
+    reported_total_items: int
+    discarded_items: int
+    instruments: tuple[MarketSnapshotInstrument, ...]
+
+
 class MarketDataProvider(ABC):
     """
     Interface for market data: tradable universe, candles, and quotes.
@@ -222,4 +267,13 @@ class MarketDataProvider(ABC):
 
         Instruments that are not recognised or not currently quoted
         are silently omitted from the result list.
+        """
+
+    @abstractmethod
+    def get_broad_market_snapshot(self) -> BroadMarketSnapshot:
+        """Return a bounded provider-wide screening snapshot.
+
+        The snapshot is not a quote source and must not be used directly for
+        order pricing. Implementations must complete and validate every page;
+        partial pagination is an error rather than a smaller apparent market.
         """

--- a/app/services/strategy_market_snapshot.py
+++ b/app/services/strategy_market_snapshot.py
@@ -1,0 +1,123 @@
+"""Fail-closed breadth from an ephemeral broad-market snapshot (#2523).
+
+The provider catalogue is never a quote or a complete security master.  This
+module measures it only against a caller-supplied, predeclared point-in-time
+cohort and exposes the missing denominator.  It does not persist routine scan
+rows; a candidate may copy the resulting compact aggregate into its immutable
+decision context.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Final, Literal
+
+from app.providers.market_data import BroadMarketSnapshot
+
+BreadthVerdict = Literal["usable", "refused"]
+
+
+@dataclass(frozen=True)
+class BreadthDefinition:
+    provider_change_unit: str = "percentage_points"
+    sign_rule: str = "positive_advance_negative_decline_exact_zero_unchanged"
+    share_denominator: str = "known_change_rows"
+    coverage_denominator: str = "caller_supplied_point_in_time_cohort"
+    impossible_lower_change_pct: str = "-100"
+    missing_semantics: str = "excluded_from_breadth_share_but_included_in_coverage_denominator"
+
+
+DEFINITION: Final = BreadthDefinition()
+
+
+@dataclass(frozen=True)
+class SnapshotBreadth:
+    version: str
+    verdict: BreadthVerdict
+    refusal_reason: str | None
+    expected_count: int
+    observed_count: int
+    coverage: Decimal
+    advance_count: int
+    decline_count: int
+    unchanged_count: int
+    advance_share: Decimal | None
+    decline_share: Decimal | None
+    unchanged_share: Decimal | None
+
+
+def measure_daily_breadth(
+    snapshot: BroadMarketSnapshot,
+    *,
+    expected_instrument_ids: tuple[int, ...],
+    minimum_coverage: Decimal,
+) -> SnapshotBreadth:
+    """Measure daily direction only when a frozen cohort is sufficiently seen.
+
+    ``minimum_coverage`` is deliberately supplied by the candidate contract;
+    this shared function does not choose a threshold after seeing outcomes.
+    Values below -100% are impossible one-session returns and count as missing.
+    Positive extremes are not winsorised: changing them cannot affect the sign
+    statistic, and an arbitrary outcome-dependent trim would add a hidden rule.
+    """
+    if not Decimal("0") < minimum_coverage <= Decimal("1"):
+        raise ValueError("minimum_coverage must be inside (0, 1]")
+    if not expected_instrument_ids:
+        raise ValueError("expected_instrument_ids must not be empty")
+    if any(instrument_id <= 0 for instrument_id in expected_instrument_ids):
+        raise ValueError("expected instrument IDs must be positive")
+    expected = set(expected_instrument_ids)
+    if len(expected) != len(expected_instrument_ids):
+        raise ValueError("expected instrument IDs must be unique")
+
+    changes_by_id: dict[int, Decimal] = {}
+    seen_ids: set[int] = set()
+    for row in snapshot.instruments:
+        if row.instrument_id not in expected:
+            continue
+        if row.instrument_id in seen_ids:
+            raise ValueError(f"snapshot contains duplicate instrument ID {row.instrument_id}")
+        seen_ids.add(row.instrument_id)
+        if row.daily_price_change_pct is not None and row.daily_price_change_pct >= Decimal(
+            DEFINITION.impossible_lower_change_pct
+        ):
+            changes_by_id[row.instrument_id] = row.daily_price_change_pct
+    changes = list(changes_by_id.values())
+    observed = len(changes)
+    coverage = Decimal(observed) / Decimal(len(expected))
+    advances = sum(value > 0 for value in changes)
+    declines = sum(value < 0 for value in changes)
+    unchanged = observed - advances - declines
+    denominator = Decimal(observed) if observed else None
+    verdict: BreadthVerdict = "usable" if coverage >= minimum_coverage else "refused"
+    refusal_reason = (
+        None if verdict == "usable" else f"coverage:{observed}/{len(expected)}<{minimum_coverage.normalize()}"
+    )
+    return SnapshotBreadth(
+        version=BREADTH_VERSION,
+        verdict=verdict,
+        refusal_reason=refusal_reason,
+        expected_count=len(expected),
+        observed_count=observed,
+        coverage=coverage,
+        advance_count=advances,
+        decline_count=declines,
+        unchanged_count=unchanged,
+        advance_share=None if denominator is None else Decimal(advances) / denominator,
+        decline_share=None if denominator is None else Decimal(declines) / denominator,
+        unchanged_share=None if denominator is None else Decimal(unchanged) / denominator,
+    )
+
+
+def _version() -> str:
+    payload = repr(DEFINITION) + inspect.getsource(measure_daily_breadth)
+    return "snapshot-breadth-v1:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+BREADTH_VERSION: Final = _version()
+
+
+__all__ = ["BREADTH_VERSION", "SnapshotBreadth", "measure_daily_breadth"]

--- a/docs/etoro-api-reference.md
+++ b/docs/etoro-api-reference.md
@@ -130,7 +130,7 @@ GET+POST requests cannot exceed the API limit.
 | GET | `/api/v1/market-data/instruments/rates` | Live bid/ask/last for up to 100 IDs | **Active** — quote refresh |
 | GET | `/api/v1/market-data/instruments/{id}/history/candles/{dir}/{interval}/{count}` | OHLCV candles (max 1000) | **Active** — daily candles |
 | GET | `/api/v1/market-data/instruments/history/closing-price` | Bulk closing prices (daily/weekly/monthly) | Not used — candles preferred |
-| GET | `/api/v1/market-data/search` | Search instruments with field projection | Not used — full universe synced |
+| GET | `/api/v1/market-data/search` | Paginated projected market snapshot | **Screening adapter** — two complete pages; never an execution quote |
 | GET | `/api/v1/market-data/exchanges` | Exchange ID → name mapping | Not used — IDs stored raw |
 | GET | `/api/v1/market-data/instrument-types` | Asset class ID → name mapping | Not used — IDs stored raw |
 | GET | `/api/v1/market-data/stocks-industries` | Industry ID → name mapping | Not used — IDs stored raw |
@@ -341,6 +341,23 @@ Primary page: `balances/get-historical-balance-snapshots`.
 | `isBuyEnabled` | bool | Buy orders accepted |
 | `currentRate` | float | Available via search |
 | `dailyPriceChange` | float | Available via search |
+
+The live search contract was reverified on 2026-08-12 against the
+[official endpoint reference](https://api-portal.etoro.com/api-reference/market-data/search-for-instruments).
+Despite that page documenting `pageNumber`, the live API ignores it; `page=2`
+returns page 2 and the response `page` must match. `pageSize=10000` returned
+12,187 rows in two pages (10,000 + 2,187) in 8.493 seconds. One provider row
+had a negative ID and was discarded; 12,185 normalised rows supplied both
+`currentRate` and `dailyPriceChange`.
+
+Search is not the full `/instruments` universe and carries no per-row quote
+timestamp or bid/ask. On the same dev census it covered 3,591/6,083 current
+NYSE/Nasdaq common-stock classifications; coverage rose to 1,480/1,601
+(92.44%) after the independently computed ≥$5 and ≥$25m recent-dollar-volume
+cohort, and 637/669 (95.22%) above $100m. Therefore callers must join an exact
+point-in-time local cohort, report the denominator and fail closed below their
+preregistered threshold. Search values may screen or form aggregate context;
+fresh `/instruments/rates` quotes remain mandatory before a candidate or order.
 
 ### Live rates (from `/market-data/instruments/rates`)
 

--- a/docs/proposals/ta/2026-08-12-etoro-search-snapshot.md
+++ b/docs/proposals/ta/2026-08-12-etoro-search-snapshot.md
@@ -1,0 +1,78 @@
+# eToro broad snapshot — useful screening, incomplete evidence (#2523)
+
+Date: 2026-08-12  
+Status: implemented provider foundation; no strategy promoted
+
+## Decision
+
+Use eToro search as a cheap, ephemeral cross-sectional screening input, not as
+a quote, a security master or an indicator warehouse. Fetch every reported
+page, join exact provider IDs to a predeclared point-in-time cohort, measure the
+known denominator and refuse breadth below the candidate's frozen coverage
+threshold. Confirm every shortlisted candidate through timestamped bid/ask
+rates and the normal execution gates.
+
+The official [Search for Instruments](https://api-portal.etoro.com/api-reference/market-data/search-for-instruments)
+contract exposes projected current rate, daily/weekly/monthly movement,
+platform/trading state, industry/sector and eToro crowd-position fields. The
+official endpoint page declares a shared 120-request/60-second market-data
+pool. This materially improves on a 122-request full rates sweep, but does not
+turn the fields into alpha.
+
+## Authenticated demo findings
+
+The following read-only checks used the configured demo account; credential
+access was audited and no secrets or raw responses were retained.
+
+| check | measured result |
+|---|---:|
+| projected page size requested/returned | 10,000 |
+| total reported search rows | 12,187 |
+| complete pages using live `page` parameter | 10,000 + 2,187 |
+| adapter wall time | 8.493 seconds |
+| normalised positive-ID rows | 12,186 |
+| rows with current rate and daily change | 12,185 |
+| current NYSE/Nasdaq common-stock IDs matched | 3,591 / 6,083 (59.03%) |
+| with 20-session price/volume evidence | 3,537 / 3,994 (88.56%) |
+| ≥$5 and ≥$25m recent dollar volume | 1,480 / 1,601 (92.44%) |
+| ≥$5 and ≥$100m recent dollar volume | 637 / 669 (95.22%) |
+
+The documented `pageNumber=2` returned reported page 1 again. The live
+`page=2` parameter returned reported page 2. The adapter asserts response page,
+stable total, full row count and unique positive IDs so this drift cannot
+silently truncate the market.
+
+The daily-change cross-section contained extreme values (full matched cohort
+range -92.95% to +12,500%). Breadth uses only sign and treats below -100% as
+invalid; it does not winsorise outcomes until they look convenient. Corporate
+actions can still change a sign, so candidate research must reconcile its exact
+cohort against known actions. The source has no per-instrument timestamp.
+
+## Storage and runtime contract
+
+- No new table or migration. The two-page snapshot lives for one scanner cycle.
+- Routine instrument rows and not-fired evaluations are discarded.
+- Retain only aggregate coverage/breadth for the evaluation and the existing
+  compact immutable context of a genuinely fired/refused candidate.
+- The provider records collection start/end because the rows do not share a
+  source timestamp.
+- Search `currentRate` never overwrites `quotes` and never authorises an order.
+- A fresh timestamped, two-sided rate and broker preflight remain mandatory.
+
+`strategy_market_snapshot.measure_daily_breadth` makes the coverage denominator,
+threshold, sign rule, missing semantics and formula version explicit. The
+caller supplies its frozen cohort and threshold; this shared layer does not
+select a more favourable universe after seeing outcomes.
+
+## What this does and does not unblock
+
+This removes the quota objection to cheap broad screening and supplies a tested
+prospective current-session breadth primitive for liquid declared cohorts. It
+does not complete #2523: causal 1/3/5/10-session market and sector returns,
+percent-above-trend, residual dispersion/common-factor state, exact event state
+and historical point-in-time membership still require their declared sources
+and fixture reconciliation.
+
+It also does not make S1–S4 viable. The corrected after-cost evidence remains
+negative/weak, so the strategy catalogue must stay empty until a preregistered
+candidate passes recent purged walk-forward, untouched and prospective gates.

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -22,6 +22,7 @@ from app.providers.implementations.etoro import (
     _normalise_instruments,
     _normalise_intraday_candle,
     _normalise_intraday_candles,
+    _normalise_market_snapshot_instrument,
     _normalise_rate,
     _normalise_rates,
 )
@@ -114,6 +115,24 @@ FIXTURE_RATE_2 = {
 
 FIXTURE_RATES_RESPONSE = {"rates": [FIXTURE_RATE, FIXTURE_RATE_2]}
 
+FIXTURE_MARKET_SNAPSHOT = {
+    "instrumentId": 1001,
+    "currentRate": 305.1,
+    "dailyPriceChange": 0.0623,
+    "weeklyPriceChange": 2.1,
+    "monthlyPriceChange": 4.2,
+    "isCurrentlyTradable": True,
+    "isExchangeOpen": True,
+    "isActiveInPlatform": True,
+    "isBuyEnabled": True,
+    "internalIndustryId": 42,
+    "sectorNameId": 7,
+    "popularityUniques7Day": 1234,
+    "traders7DayChange": -3,
+    "buyHoldingPct": 91.5,
+    "sellHoldingPct": 8.5,
+}
+
 
 # ---------------------------------------------------------------------------
 # Instrument normalisation
@@ -167,6 +186,36 @@ class TestNormaliseInstruments:
         raw = {"instrumentDisplayDatas": [FIXTURE_INSTRUMENT, "not a dict", {}]}
         records = _normalise_instruments(raw)
         assert len(records) == 1
+
+
+class TestNormaliseMarketSnapshotInstrument:
+    def test_projected_values_preserve_provider_units(self) -> None:
+        row = _normalise_market_snapshot_instrument(FIXTURE_MARKET_SNAPSHOT)
+        assert row is not None
+        assert row.instrument_id == 1001
+        assert row.current_rate == Decimal("305.1")
+        assert row.daily_price_change_pct == Decimal("0.0623")
+        assert row.is_exchange_open is True
+        assert row.industry_id == 42
+        assert row.buy_holding_pct == Decimal("91.5")
+
+    @pytest.mark.parametrize("instrument_id", [None, 0, -1, "bad"])
+    def test_invalid_provider_id_is_discarded(self, instrument_id: object) -> None:
+        assert _normalise_market_snapshot_instrument({**FIXTURE_MARKET_SNAPSHOT, "instrumentId": instrument_id}) is None
+
+    def test_missing_and_non_finite_optional_values_remain_unknown(self) -> None:
+        row = _normalise_market_snapshot_instrument(
+            {
+                "instrumentId": 1001,
+                "currentRate": 0,
+                "dailyPriceChange": "NaN",
+                "isCurrentlyTradable": 1,
+            }
+        )
+        assert row is not None
+        assert row.current_rate is None
+        assert row.daily_price_change_pct is None
+        assert row.is_currently_tradable is None
 
 
 # ---------------------------------------------------------------------------
@@ -509,6 +558,106 @@ class TestGetQuotesChunking:
             # raw-persistence path was retired now that SQL coverage
             # is complete. Error diagnostics live in the log line via
             # exc_info instead.
+
+
+class TestGetBroadMarketSnapshot:
+    def test_one_page_uses_live_page_parameter_and_tracks_discarded_rows(self) -> None:
+        from app.providers.implementations.etoro import EtoroMarketDataProvider
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "page": 1,
+            "pageSize": 10_000,
+            "totalItems": 2,
+            "items": [FIXTURE_MARKET_SNAPSHOT, {"instrumentId": -100000}],
+        }
+        with EtoroMarketDataProvider(api_key="k", user_key="u") as provider:
+            provider._http = MagicMock()
+            provider._http.get.return_value = response
+            snapshot = provider.get_broad_market_snapshot()
+            params = provider._http.get.call_args.kwargs["params"]
+
+        assert params["page"] == 1
+        assert "pageNumber" not in params
+        assert snapshot.reported_total_items == 2
+        assert snapshot.discarded_items == 1
+        assert [row.instrument_id for row in snapshot.instruments] == [1001]
+        assert snapshot.observed_from <= snapshot.observed_to
+
+    def test_fetches_every_reported_page(self) -> None:
+        from app.providers.implementations.etoro import EtoroMarketDataProvider
+
+        first = MagicMock()
+        first.raise_for_status = MagicMock()
+        first.json.return_value = {
+            "page": 1,
+            "pageSize": 10_000,
+            "totalItems": 10_001,
+            "items": [{"instrumentId": i} for i in range(1, 10_001)],
+        }
+        second = MagicMock()
+        second.raise_for_status = MagicMock()
+        second.json.return_value = {
+            "page": 2,
+            "pageSize": 10_000,
+            "totalItems": 10_001,
+            "items": [{"instrumentId": 10_001}],
+        }
+        with EtoroMarketDataProvider(api_key="k", user_key="u") as provider:
+            provider._http = MagicMock()
+            provider._http.get.side_effect = [first, second]
+            snapshot = provider.get_broad_market_snapshot()
+            requested_pages = [call.kwargs["params"]["page"] for call in provider._http.get.call_args_list]
+
+        assert len(snapshot.instruments) == 10_001
+        assert requested_pages == [1, 2]
+
+    def test_refuses_incomplete_pagination(self) -> None:
+        from app.providers.implementations.etoro import EtoroMarketDataProvider
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"page": 1, "pageSize": 10_000, "totalItems": 3, "items": []}
+        with EtoroMarketDataProvider(api_key="k", user_key="u") as provider:
+            provider._http = MagicMock()
+            provider._http.get.return_value = response
+            with pytest.raises(ValueError, match="pagination incomplete"):
+                provider.get_broad_market_snapshot()
+
+    def test_refuses_duplicate_ids(self) -> None:
+        from app.providers.implementations.etoro import EtoroMarketDataProvider
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "page": 1,
+            "pageSize": 10_000,
+            "totalItems": 2,
+            "items": [{"instrumentId": 1001}, {"instrumentId": 1001}],
+        }
+        with EtoroMarketDataProvider(api_key="k", user_key="u") as provider:
+            provider._http = MagicMock()
+            provider._http.get.return_value = response
+            with pytest.raises(ValueError, match="repeated instrumentId"):
+                provider.get_broad_market_snapshot()
+
+    def test_refuses_unbounded_page_count(self) -> None:
+        from app.providers.implementations.etoro import EtoroMarketDataProvider
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "page": 1,
+            "pageSize": 10_000,
+            "totalItems": 20_001,
+            "items": [],
+        }
+        with EtoroMarketDataProvider(api_key="k", user_key="u") as provider:
+            provider._http = MagicMock()
+            provider._http.get.return_value = response
+            with pytest.raises(ValueError, match="bounded adapter permits 2"):
+                provider.get_broad_market_snapshot()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_strategy_market_snapshot.py
+++ b/tests/test_strategy_market_snapshot.py
@@ -1,0 +1,88 @@
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.providers.market_data import BroadMarketSnapshot, MarketSnapshotInstrument
+from app.services.strategy_market_snapshot import BREADTH_VERSION, measure_daily_breadth
+
+
+def _row(instrument_id: int, change: str | None) -> MarketSnapshotInstrument:
+    return MarketSnapshotInstrument(
+        instrument_id=instrument_id,
+        current_rate=None,
+        daily_price_change_pct=None if change is None else Decimal(change),
+        weekly_price_change_pct=None,
+        monthly_price_change_pct=None,
+        is_currently_tradable=None,
+        is_exchange_open=None,
+        is_active_in_platform=None,
+        is_buy_enabled=None,
+        industry_id=None,
+        sector_id=None,
+        popularity_uniques_7d=None,
+        traders_7d_change=None,
+        buy_holding_pct=None,
+        sell_holding_pct=None,
+    )
+
+
+def _snapshot(*rows: MarketSnapshotInstrument) -> BroadMarketSnapshot:
+    now = datetime(2026, 8, 12, 12, tzinfo=UTC)
+    return BroadMarketSnapshot(now, now, len(rows), 0, rows)
+
+
+def test_complete_cohort_reports_sign_shares() -> None:
+    result = measure_daily_breadth(
+        _snapshot(_row(1, "1.5"), _row(2, "-0.2"), _row(3, "0")),
+        expected_instrument_ids=(1, 2, 3),
+        minimum_coverage=Decimal("0.90"),
+    )
+    assert result.version == BREADTH_VERSION
+    assert result.verdict == "usable"
+    assert result.coverage == 1
+    assert result.advance_share == Decimal(1) / Decimal(3)
+    assert result.decline_share == Decimal(1) / Decimal(3)
+    assert result.unchanged_share == Decimal(1) / Decimal(3)
+
+
+def test_partial_cross_section_refuses_with_exact_denominator() -> None:
+    result = measure_daily_breadth(
+        _snapshot(_row(1, "1"), _row(2, None), _row(999, "2")),
+        expected_instrument_ids=(1, 2, 3),
+        minimum_coverage=Decimal("0.90"),
+    )
+    assert result.verdict == "refused"
+    assert result.coverage == Decimal(1) / Decimal(3)
+    assert result.refusal_reason == "coverage:1/3<0.9"
+    assert result.advance_share == 1
+
+
+def test_impossible_negative_return_counts_as_missing() -> None:
+    result = measure_daily_breadth(
+        _snapshot(_row(1, "-100.01"), _row(2, "4")),
+        expected_instrument_ids=(1, 2),
+        minimum_coverage=Decimal("1"),
+    )
+    assert result.observed_count == 1
+    assert result.verdict == "refused"
+
+
+@pytest.mark.parametrize("threshold", [Decimal("0"), Decimal("-0.1"), Decimal("1.01")])
+def test_invalid_coverage_threshold_rejected(threshold: Decimal) -> None:
+    with pytest.raises(ValueError, match="minimum_coverage"):
+        measure_daily_breadth(_snapshot(_row(1, "1")), expected_instrument_ids=(1,), minimum_coverage=threshold)
+
+
+def test_duplicate_expected_ids_rejected() -> None:
+    with pytest.raises(ValueError, match="unique"):
+        measure_daily_breadth(_snapshot(_row(1, "1")), expected_instrument_ids=(1, 1), minimum_coverage=Decimal("1"))
+
+
+def test_duplicate_snapshot_ids_rejected() -> None:
+    with pytest.raises(ValueError, match="duplicate instrument ID"):
+        measure_daily_breadth(
+            _snapshot(_row(1, "1"), _row(1, "2")),
+            expected_instrument_ids=(1,),
+            minimum_coverage=Decimal("1"),
+        )


### PR DESCRIPTION
## Outcome

Adds a tested, quota-safe eToro broad-market screening primitive for #2523 without creating an indicator warehouse or promoting a strategy.

- fetches the projected search catalogue in two bounded, validated pages
- uses the live `page` parameter after authenticated evidence showed documented `pageNumber` is ignored
- rejects unstable totals, wrong pages, incomplete responses, duplicates and invalid IDs
- exposes collection start/end because search rows have no per-row timestamp or bid/ask
- adds versioned advance/decline breadth against a caller-supplied point-in-time cohort
- reports exact coverage and fails closed below the candidate's preregistered threshold
- never persists routine universe rows and never substitutes search rate for a fresh two-sided quote

## Authenticated demo evidence

- 12,187 reported rows in 10,000 + 2,187 pages
- 12,186 valid positive IDs; one explicit discard
- 12,185 rows with current rate and daily change
- 8.493s adapter wall time
- 3,591/6,083 current NYSE/Nasdaq common-stock classifications covered
- 1,480/1,601 (92.44%) in the independently computed >=$5, >=$25m recent-dollar-volume cohort
- 637/669 (95.22%) at >=$100m/day

The source remains incomplete and has extreme daily-change values, so breadth is screening/context only. Fresh `/instruments/rates`, broker eligibility, causal candidate inputs and execution gates remain mandatory.

## Database impact

None: no migration, table, index, backfill or routine row retention.

## Verification

- live authenticated demo adapter probe
- `uv run ruff check ...`
- `uv run pyright`
- focused provider/breadth tests
- full `.githooks/pre-push` fast suite and smoke suite

Refs #2523, #2508
