### PR TITLE
feat(strategies): record point-in-time sector context

### DIFF
--- a/app/services/instrument_market_classification.py
+++ b/app/services/instrument_market_classification.py
@@ -1,4 +1,4 @@
-"""Prospective point-in-time security type and listing classification (#2508)."""
+"""Prospective point-in-time type, listing and provider industry (#2508/#2523)."""
 
 from __future__ import annotations
 
@@ -34,6 +34,12 @@ def reconcile_instrument_market_classification(
             WITH observed AS (
                 SELECT i.instrument_id, i.exchange AS provider_exchange_id,
                        CASE
+                           WHEN i.sector ~ '^[0-9]+$'
+                            AND i.sector::BIGINT BETWEEN 1 AND 2147483647
+                               THEN i.sector::INTEGER
+                           ELSE NULL
+                       END AS provider_industry_id,
+                       CASE
                            WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
                            WHEN i.exchange = '4' OR lower(coalesce(e.description, '')) = 'nasdaq' THEN 'nasdaq'
                            ELSE CASE WHEN i.exchange IS NULL THEN 'unknown' ELSE 'other' END
@@ -52,16 +58,16 @@ def reconcile_instrument_market_classification(
                 WHERE i.is_tradable
             )
             UPDATE instrument_market_classification_history h
-               SET last_confirmed_on = CURRENT_DATE
+               SET last_confirmed_on = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
               FROM observed o
              WHERE h.instrument_id = o.instrument_id
                AND h.effective_to IS NULL
-               AND h.last_confirmed_on < CURRENT_DATE
-               AND (h.provider_exchange_id, h.primary_listing_market,
-                    h.instrument_type_id, h.security_type)
+               AND h.last_confirmed_on < (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
+               AND (h.provider_exchange_id, h.provider_industry_id,
+                    h.primary_listing_market, h.instrument_type_id, h.security_type)
                    IS NOT DISTINCT FROM
-                   (o.provider_exchange_id, o.primary_listing_market,
-                    o.instrument_type_id, o.security_type)
+                   (o.provider_exchange_id, o.provider_industry_id,
+                    o.primary_listing_market, o.instrument_type_id, o.security_type)
             """
         )
         confirmed = cur.rowcount
@@ -70,6 +76,12 @@ def reconcile_instrument_market_classification(
             """
             WITH observed AS (
                 SELECT i.instrument_id, i.exchange AS provider_exchange_id,
+                       CASE
+                           WHEN i.sector ~ '^[0-9]+$'
+                            AND i.sector::BIGINT BETWEEN 1 AND 2147483647
+                               THEN i.sector::INTEGER
+                           ELSE NULL
+                       END AS provider_industry_id,
                        CASE
                            WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
                            WHEN i.exchange = '4' OR lower(coalesce(e.description, '')) = 'nasdaq' THEN 'nasdaq'
@@ -90,19 +102,20 @@ def reconcile_instrument_market_classification(
             )
             UPDATE instrument_market_classification_history h
                SET provider_exchange_id = o.provider_exchange_id,
+                   provider_industry_id = o.provider_industry_id,
                    primary_listing_market = o.primary_listing_market,
                    instrument_type_id = o.instrument_type_id,
                    security_type = o.security_type,
-                   last_confirmed_on = CURRENT_DATE
+                   last_confirmed_on = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
               FROM observed o
              WHERE h.instrument_id = o.instrument_id
                AND h.effective_to IS NULL
-               AND h.effective_from = CURRENT_DATE
-               AND (h.provider_exchange_id, h.primary_listing_market,
-                    h.instrument_type_id, h.security_type)
+               AND h.effective_from = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
+               AND (h.provider_exchange_id, h.provider_industry_id,
+                    h.primary_listing_market, h.instrument_type_id, h.security_type)
                    IS DISTINCT FROM
-                   (o.provider_exchange_id, o.primary_listing_market,
-                    o.instrument_type_id, o.security_type)
+                   (o.provider_exchange_id, o.provider_industry_id,
+                    o.primary_listing_market, o.instrument_type_id, o.security_type)
             """
         )
         corrected_same_day = cur.rowcount
@@ -113,6 +126,12 @@ def reconcile_instrument_market_classification(
             """
             WITH observed AS (
                 SELECT i.instrument_id, i.exchange AS provider_exchange_id,
+                       CASE
+                           WHEN i.sector ~ '^[0-9]+$'
+                            AND i.sector::BIGINT BETWEEN 1 AND 2147483647
+                               THEN i.sector::INTEGER
+                           ELSE NULL
+                       END AS provider_industry_id,
                        CASE
                            WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
                            WHEN i.exchange = '4' OR lower(coalesce(e.description, '')) = 'nasdaq' THEN 'nasdaq'
@@ -132,17 +151,17 @@ def reconcile_instrument_market_classification(
                 WHERE i.is_tradable
             )
             UPDATE instrument_market_classification_history h
-               SET effective_to = CURRENT_DATE - 1,
-                   last_confirmed_on = CURRENT_DATE - 1
+               SET effective_to = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date - 1,
+                   last_confirmed_on = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date - 1
               FROM observed o
              WHERE h.instrument_id = o.instrument_id
                AND h.effective_to IS NULL
-               AND h.effective_from < CURRENT_DATE
-               AND (h.provider_exchange_id, h.primary_listing_market,
-                    h.instrument_type_id, h.security_type)
+               AND h.effective_from < (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
+               AND (h.provider_exchange_id, h.provider_industry_id,
+                    h.primary_listing_market, h.instrument_type_id, h.security_type)
                    IS DISTINCT FROM
-                   (o.provider_exchange_id, o.primary_listing_market,
-                    o.instrument_type_id, o.security_type)
+                   (o.provider_exchange_id, o.provider_industry_id,
+                    o.primary_listing_market, o.instrument_type_id, o.security_type)
             """
         )
         changed = cur.rowcount
@@ -152,9 +171,13 @@ def reconcile_instrument_market_classification(
             INSERT INTO instrument_market_classification_history (
                 instrument_id, effective_from, effective_to, last_confirmed_on,
                 provider_exchange_id, primary_listing_market,
-                instrument_type_id, security_type, source_event
+                instrument_type_id, security_type, source_event,
+                provider_industry_id
             )
-            SELECT i.instrument_id, CURRENT_DATE, NULL, CURRENT_DATE,
+            SELECT i.instrument_id,
+                   (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date,
+                   NULL,
+                   (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date,
                    i.exchange,
                    CASE
                        WHEN i.exchange = '5' OR lower(coalesce(e.description, '')) = 'nyse' THEN 'nyse'
@@ -171,7 +194,13 @@ def reconcile_instrument_market_classification(
                    CASE WHEN EXISTS (
                        SELECT 1 FROM instrument_market_classification_history p
                        WHERE p.instrument_id = i.instrument_id
-                   ) THEN 'classification_change' ELSE 'imported' END
+                   ) THEN 'classification_change' ELSE 'imported' END,
+                   CASE
+                       WHEN i.sector ~ '^[0-9]+$'
+                        AND i.sector::BIGINT BETWEEN 1 AND 2147483647
+                           THEN i.sector::INTEGER
+                       ELSE NULL
+                   END
               FROM instruments i
               LEFT JOIN exchanges e ON e.exchange_id = i.exchange
               LEFT JOIN etoro_instrument_types t

--- a/app/services/strategy_decision_context.py
+++ b/app/services/strategy_decision_context.py
@@ -36,6 +36,8 @@ class ContextDefinition:
     volume_lookback_sessions: int = 20
     volume_capacity_statistic: str = "causal_mean"
     listing_semantics: str = "primary_listing_not_execution_venue"
+    sector_semantics: str = "provider_stocks_industry_not_gics"
+    sector_source: str = "prospective_instrument_market_classification_history"
     eligible_price_bases: tuple[str, ...] = ("observed_unadjusted", "reconstructed_unadjusted")
 
 
@@ -44,7 +46,7 @@ DEFINITION: Final = ContextDefinition()
 
 def _version() -> str:
     payload = repr(DEFINITION) + inspect.getsource(price_band_for) + inspect.getsource(dollar_volume_band_for)
-    return "decision-context-v1:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+    return "decision-context-v2:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
 def price_band_for(price: Decimal) -> PriceBand:
@@ -86,6 +88,7 @@ class MarketClassification:
     primary_listing_market: ListingMarket
     provider_exchange_id: str | None
     instrument_type_id: int | None
+    provider_industry_id: int | None
 
 
 @dataclass(frozen=True)
@@ -121,6 +124,7 @@ class DecisionContext:
     primary_listing_market: ListingMarket | None
     provider_exchange_id: str | None
     instrument_type_id: int | None
+    provider_industry_id: int | None
     as_traded_price: Decimal | None
     as_traded_price_basis: AsTradedPriceBasis | None
     price_band: PriceBand | None
@@ -173,7 +177,8 @@ def load_market_classification(
         row = cur.execute(
             """
             SELECT effective_from, security_type, primary_listing_market,
-                   provider_exchange_id, instrument_type_id
+                   provider_exchange_id, instrument_type_id,
+                   provider_industry_id
               FROM instrument_market_classification_history
              WHERE instrument_id = %(instrument_id)s
                AND daterange(effective_from, effective_to, '[]') @> %(decision_date)s::date
@@ -191,6 +196,7 @@ def load_market_classification(
         primary_listing_market=row[2],
         provider_exchange_id=row[3],
         instrument_type_id=row[4],
+        provider_industry_id=row[5],
     )
 
 
@@ -240,6 +246,8 @@ def build_decision_context(
             missing.append("security_type")
         if classification.primary_listing_market == "unknown":
             missing.append("primary_listing_market")
+        if classification.provider_industry_id is None:
+            missing.append("provider_industry_id")
 
     price_band = None if inputs.as_traded_price is None else price_band_for(inputs.as_traded_price)
     dollar_band = (
@@ -264,6 +272,7 @@ def build_decision_context(
         primary_listing_market=None if classification is None else classification.primary_listing_market,
         provider_exchange_id=None if classification is None else classification.provider_exchange_id,
         instrument_type_id=None if classification is None else classification.instrument_type_id,
+        provider_industry_id=None if classification is None else classification.provider_industry_id,
         as_traded_price=inputs.as_traded_price,
         as_traded_price_basis=inputs.as_traded_price_basis,
         price_band=price_band,
@@ -289,7 +298,8 @@ _INSERT_CONTEXT = """
         strategy_id, strategy_version, instrument_id, decision_at, signal_id,
         candidate_verdict, refusal_reason, context_version,
         classification_effective_from, security_type, primary_listing_market,
-        provider_exchange_id, instrument_type_id, as_traded_price,
+        provider_exchange_id, instrument_type_id, provider_industry_id,
+        as_traded_price,
         as_traded_price_basis, price_band,
         volume_lookback_sessions, trailing_mean_share_volume,
         trailing_median_share_volume, trailing_mean_dollar_volume,
@@ -301,7 +311,8 @@ _INSERT_CONTEXT = """
         %(strategy_id)s, %(strategy_version)s, %(instrument_id)s, %(decision_at)s, %(signal_id)s,
         %(candidate_verdict)s, %(refusal_reason)s, %(context_version)s,
         %(classification_effective_from)s, %(security_type)s, %(primary_listing_market)s,
-        %(provider_exchange_id)s, %(instrument_type_id)s, %(as_traded_price)s,
+        %(provider_exchange_id)s, %(instrument_type_id)s, %(provider_industry_id)s,
+        %(as_traded_price)s,
         %(as_traded_price_basis)s, %(price_band)s,
         %(volume_lookback_sessions)s, %(trailing_mean_share_volume)s,
         %(trailing_median_share_volume)s, %(trailing_mean_dollar_volume)s,

--- a/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
+++ b/docs/proposals/ta/2026-08-10-point-in-time-market-cohorts.md
@@ -3,7 +3,8 @@
 ## Outcome
 
 Strategy evidence can now retain the security type, primary listing market,
-as-traded price band and causal liquidity/risk context that existed when a
+provider stocks-industry assignment, as-traded price band and causal
+liquidity/risk context that existed when a
 candidate was considered. The implementation fails closed when that context is
 not known; it does not fill a historical trade with today's instrument row.
 
@@ -25,6 +26,8 @@ this table. The row contains:
 
 - provider security type and normalised common-stock/ETF/other classification;
 - primary listing market (NYSE/Nasdaq/other), explicitly not execution venue;
+- prospective eToro stocks-industry ID, explicitly not a historical GICS
+  sector and never backfilled from later mutable instrument metadata;
 - contemporaneous as-traded price and fixed price band;
 - explicit price-level provenance: directly observed unadjusted or reconstructed
   from point-in-time corporate-action factors;
@@ -58,6 +61,20 @@ The empty decision-context relation occupied 48 KiB. This validates the
 transition-only storage shape; it does not yet measure context growth under a
 live candidate rate.
 
+On 2026-08-12, #2523 extended the transition identity with the provider
+stocks-industry assignment. The current NYSE/Nasdaq common-stock cohort had
+4,351/6,083 known assignments (71.53%) across nine provider categories; 1,732
+remain explicitly unknown. The one-time honest observation boundary closed the
+12,695 previous current rows and opened 12,695 sector-aware rows instead of
+rewriting the older interval. Total classification-history size became 8,176
+KiB including indexes; the still-empty decision-context table remained 48 KiB.
+Future storage is transition-only, not one row per instrument/day.
+
+This work also aligned classification writes to the America/New_York market
+date already used by decision lookup. The prior UTC `CURRENT_DATE` writer made
+a new row invisible between 00:00 UTC and New York midnight. Clean-install and
+integration fixtures now pin the common market-date boundary.
+
 ## Important boundaries
 
 - The imported classification is prospective from 2026-08-10. Historical
@@ -68,6 +85,9 @@ live candidate rate.
 - Primary listing affects listing rules, auctions and halt identity. It is not
   where an eToro order executed. Spread/slippage and broker execution evidence
   remain separate requirements.
+- The provider industry is coarse and incomplete. A sector-dependent candidate
+  refuses its missing 28.47%; it may not substitute today's label or silently
+  analyse the observed 71.53% as the whole market.
 - Exchange IDs 4/5 and instrument type IDs 5/6 are stable provider facts used
   during bootstrap; lookup labels cross-check them but are not required to have
   arrived first.

--- a/docs/proposals/ta/2026-08-12-etoro-search-snapshot.md
+++ b/docs/proposals/ta/2026-08-12-etoro-search-snapshot.md
@@ -67,11 +67,12 @@ select a more favourable universe after seeing outcomes.
 ## What this does and does not unblock
 
 This removes the quota objection to cheap broad screening and supplies a tested
-prospective current-session breadth primitive for liquid declared cohorts. It
-does not complete #2523: causal 1/3/5/10-session market and sector returns,
-percent-above-trend, residual dispersion/common-factor state, exact event state
-and historical point-in-time membership still require their declared sources
-and fixture reconciliation.
+prospective current-session breadth primitive for liquid declared cohorts. The
+subsequent point-in-time-sector increment records the current eToro
+stocks-industry assignment prospectively and refuses unknown assignments. It
+still does not complete #2523: causal 1/3/5/10-session market and sector
+returns, percent-above-trend, residual dispersion/common-factor state and exact
+event state still require their declared formulas and fixture reconciliation.
 
 It also does not make S1–S4 viable. The corrected after-cost evidence remains
 negative/weak, so the strategy catalogue must stay empty until a preregistered

--- a/sql/328_strategy_point_in_time_sector.sql
+++ b/sql/328_strategy_point_in_time_sector.sql
@@ -1,0 +1,84 @@
+-- #2523 — extend prospective market classification with provider industry.
+--
+-- instruments.sector is eToro's stocks-industry ID, despite the legacy column
+-- name.  It is current mutable metadata, so it may not be projected backwards.
+-- Existing current rows that began before this migration are closed yesterday
+-- and reopened today; a row first observed today is corrected in place.  Future
+-- universe syncs write a transition only when the provider assignment changes.
+
+ALTER TABLE instrument_market_classification_history
+    ADD COLUMN IF NOT EXISTS provider_industry_id INTEGER;
+
+-- Migration 302 originally used the database UTC date while decision lookup
+-- has always used America/New_York. If a clean install reaches this migration
+-- between 00:00 and 04:00/05:00 UTC, its just-imported row is one market day in
+-- the future. Correct only that untouched initial row; no historical transition
+-- can satisfy source_event=imported plus effective_from > New York today.
+UPDATE instrument_market_classification_history h
+   SET effective_from = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date,
+       last_confirmed_on = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
+ WHERE h.effective_to IS NULL
+   AND h.source_event = 'imported'
+   AND h.effective_from > (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date;
+
+-- Same-day rows have no finer ordering available and may be corrected safely.
+UPDATE instrument_market_classification_history h
+   SET provider_industry_id = CASE
+           WHEN i.sector ~ '^[0-9]+$' AND i.sector::BIGINT BETWEEN 1 AND 2147483647
+               THEN i.sector::INTEGER
+           ELSE NULL
+       END,
+       last_confirmed_on = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
+  FROM instruments i
+ WHERE i.instrument_id = h.instrument_id
+   AND h.effective_to IS NULL
+   AND h.effective_from = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date;
+
+-- Older classification rows must not acquire today's sector retrospectively.
+WITH closed AS (
+    UPDATE instrument_market_classification_history h
+       SET effective_to = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date - 1,
+           last_confirmed_on = (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date - 1
+     WHERE h.effective_to IS NULL
+       AND h.effective_from < (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
+    RETURNING h.instrument_id, h.provider_exchange_id,
+              h.primary_listing_market, h.instrument_type_id,
+              h.security_type
+)
+INSERT INTO instrument_market_classification_history (
+    instrument_id, effective_from, effective_to, last_confirmed_on,
+    provider_exchange_id, primary_listing_market, instrument_type_id,
+    security_type, source_event, provider_industry_id
+)
+SELECT c.instrument_id,
+       (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date,
+       NULL,
+       (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date,
+       c.provider_exchange_id, c.primary_listing_market, c.instrument_type_id,
+       c.security_type, 'classification_change',
+       CASE
+           WHEN i.sector ~ '^[0-9]+$' AND i.sector::BIGINT BETWEEN 1 AND 2147483647
+               THEN i.sector::INTEGER
+           ELSE NULL
+       END
+  FROM closed c
+  JOIN instruments i USING (instrument_id);
+
+ALTER TABLE strategy_decision_contexts
+    ADD COLUMN IF NOT EXISTS provider_industry_id INTEGER;
+
+ALTER TABLE strategy_decision_contexts
+    ADD CONSTRAINT strategy_decision_context_v2_sector_complete
+    CHECK (
+        candidate_verdict = 'refused'
+        OR context_version NOT LIKE 'decision-context-v2:%'
+        OR provider_industry_id IS NOT NULL
+    );
+
+COMMENT ON COLUMN instrument_market_classification_history.provider_industry_id IS
+    'Prospectively observed eToro stocks-industry ID. NULL means unknown/not '
+    'applicable and must not be filled from later instruments metadata.';
+
+COMMENT ON COLUMN strategy_decision_contexts.provider_industry_id IS
+    'Provider industry copied from the point-in-time classification of this '
+    'fired/refused decision; never resolved later from instruments.sector.';

--- a/tests/test_strategy_decision_context.py
+++ b/tests/test_strategy_decision_context.py
@@ -50,7 +50,7 @@ def test_boundaries_are_explicit_and_stable() -> None:
     assert price_band_for(Decimal("150")) == "150_plus"
     assert dollar_volume_band_for(Decimal("9999999")) == "1m_to_10m"
     assert dollar_volume_band_for(Decimal("10000000")) == "10m_to_25m"
-    assert CONTEXT_VERSION.startswith("decision-context-v1:")
+    assert CONTEXT_VERSION.startswith("decision-context-v2:")
 
 
 def test_complete_context_is_eligible() -> None:
@@ -66,6 +66,7 @@ def test_complete_context_is_eligible() -> None:
             primary_listing_market="nasdaq",
             provider_exchange_id="4",
             instrument_type_id=5,
+            provider_industry_id=8,
         ),
         inputs=_complete_inputs(),
     )
@@ -90,11 +91,33 @@ def test_missing_or_unknown_point_in_time_data_refuses_by_name() -> None:
             primary_listing_market="unknown",
             provider_exchange_id=None,
             instrument_type_id=5,
+            provider_industry_id=8,
         ),
         inputs=_complete_inputs(vix=None, spread_bps=None),
     )
     assert context.candidate_verdict == "refused"
     assert context.refusal_reason == "missing:primary_listing_market,spread_bps,vix"
+
+
+def test_missing_point_in_time_sector_refuses_instead_of_using_current_metadata() -> None:
+    context = build_decision_context(
+        strategy_id="candidate-1",
+        strategy_version="sha256:abc",
+        instrument_id=1,
+        decision_at=datetime(2026, 8, 10, 14, 35, tzinfo=UTC),
+        signal_id=None,
+        classification=MarketClassification(
+            effective_from=date(2026, 8, 10),
+            security_type="common_stock",
+            primary_listing_market="nasdaq",
+            provider_exchange_id="4",
+            instrument_type_id=5,
+            provider_industry_id=None,
+        ),
+        inputs=_complete_inputs(),
+    )
+    assert context.candidate_verdict == "refused"
+    assert context.refusal_reason == "missing:provider_industry_id"
 
 
 def test_adjusted_or_unproven_price_basis_refuses_cohort_attribution() -> None:
@@ -110,6 +133,7 @@ def test_adjusted_or_unproven_price_basis_refuses_cohort_attribution() -> None:
             primary_listing_market="nasdaq",
             provider_exchange_id="4",
             instrument_type_id=5,
+            provider_industry_id=8,
         ),
         inputs=_complete_inputs(as_traded_price_basis="unknown"),
     )
@@ -147,9 +171,9 @@ def _seed_instrument(conn: psycopg.Connection[tuple[Any, ...]], iid: int) -> Non
     conn.execute(
         """
         INSERT INTO instruments (
-            instrument_id, symbol, company_name, exchange, currency,
+            instrument_id, symbol, company_name, exchange, currency, sector,
             is_tradable, instrument_type_id, first_seen_at, last_seen_at
-        ) VALUES (%s, %s, 'Context Test', '4', 'USD', TRUE, 5, NOW(), NOW())
+        ) VALUES (%s, %s, 'Context Test', '4', 'USD', '8', TRUE, 5, NOW(), NOW())
         """,
         (iid, f"CTX{iid}"),
     )
@@ -167,26 +191,33 @@ def test_reconcile_records_prospective_classification_and_same_day_correction(
 
     row = conn.execute(
         """
-        SELECT primary_listing_market, security_type, source_event
+        SELECT primary_listing_market, security_type, provider_industry_id,
+               source_event, effective_from,
+               (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date
         FROM instrument_market_classification_history
         WHERE instrument_id = %s
         """,
         (iid,),
     ).fetchone()
-    assert row == ("nasdaq", "common_stock", "imported")
+    assert row is not None
+    assert row[:4] == ("nasdaq", "common_stock", 8, "imported")
+    assert row[4] == row[5]
 
-    conn.execute("UPDATE instruments SET exchange = '5', instrument_type_id = 6 WHERE instrument_id = %s", (iid,))
+    conn.execute(
+        "UPDATE instruments SET exchange = '5', instrument_type_id = 6, sector = '5' WHERE instrument_id = %s",
+        (iid,),
+    )
     stats = reconcile_instrument_market_classification(conn)
     assert stats.corrected_same_day == 1
     rows = conn.execute(
         """
-        SELECT primary_listing_market, security_type
+        SELECT primary_listing_market, security_type, provider_industry_id
         FROM instrument_market_classification_history
         WHERE instrument_id = %s
         """,
         (iid,),
     ).fetchall()
-    assert rows == [("nyse", "etf")]
+    assert rows == [("nyse", "etf", 5)]
 
 
 @pytest.mark.integration
@@ -218,7 +249,10 @@ def test_later_classification_change_closes_prior_row_without_overlap(
             provider_exchange_id, primary_listing_market, instrument_type_id,
             security_type, source_event
         ) VALUES (
-            %s, CURRENT_DATE - 1, NULL, CURRENT_DATE - 1,
+            %s,
+            (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date - 1,
+            NULL,
+            (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date - 1,
             '4', 'nasdaq', 5, 'common_stock', 'imported'
         )
         """,
@@ -237,7 +271,7 @@ def test_later_classification_change_closes_prior_row_without_overlap(
         """,
         (iid,),
     ).fetchall()
-    current_date_row = conn.execute("SELECT CURRENT_DATE").fetchone()
+    current_date_row = conn.execute("SELECT (CURRENT_TIMESTAMP AT TIME ZONE 'America/New_York')::date").fetchone()
     assert current_date_row is not None
     current_date = current_date_row[0]
     assert rows == [
@@ -273,6 +307,13 @@ def test_context_round_trip_and_database_completeness_guard(
         (context_id,),
     ).fetchone()
     assert stored_basis == ("observed_unadjusted",)
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with conn.transaction():
+            conn.execute(
+                "UPDATE strategy_decision_contexts SET provider_industry_id = NULL WHERE context_id = %s",
+                (context_id,),
+            )
 
     with pytest.raises(psycopg.errors.CheckViolation):
         with conn.transaction():


### PR DESCRIPTION
## Outcome

Adds the prospective provider-industry identity required for sector-relative candidate context under #2523, without projecting today's classification into historical backtests.

- records eToro stocks-industry ID as part of transition-only market classification
- closes the prior interval and opens a sector-aware interval at the observation boundary
- includes the point-in-time value in compact fired/refused decision context v2
- refuses v2 sector-dependent eligibility when the assignment is unknown
- enforces that refusal at the database boundary while preserving legacy v1 rows
- fixes the writer's UTC `CURRENT_DATE` vs New York decision-date mismatch found during boundary testing

This is coarse eToro provider classification, not GICS and not an execution venue.

## Measured coverage and storage

Current NYSE/Nasdaq common stocks:

- known provider industry: 4,351 / 6,083 (71.53%)
- unknown/refused: 1,732 / 6,083 (28.47%)
- nine populated provider categories

The honest one-time boundary closed 12,695 old current rows and opened 12,695 sector-aware rows. Total classification history is 8,176 KiB including indexes; the empty decision-context table remains 48 KiB. Future growth is transition-only, never one row per instrument/day.

The decision lookup uses the existing primary key: measured execution 0.057 ms / 7 cached buffers, so no extra index was added.

## Verification

- migration applied and rerun cleanly on dev
- database constraint validated
- 57 focused decision/universe tests
- full pyright, ruff and format checks
- full repository pre-push fast suite and app-boot smoke suite

No strategy is promoted and no historical sector claim is created.

Refs #2523, #2508
