### PR TITLE
Add causal completed-session regime mathematics

### DIFF
--- a/app/services/strategy_regime_context.py
+++ b/app/services/strategy_regime_context.py
@@ -1,0 +1,420 @@
+"""Pure, compact completed-session market/sector context for #2523.
+
+These aggregates describe the environment in which a separately declared
+candidate fired.  They are not entry signals and this module does not choose a
+coverage threshold, universe, horizon, sector mapping, or trend rule after
+seeing outcomes.
+
+The caller supplies an aligned point-in-time cohort.  ``None`` is missing; it
+never becomes a zero return.  Only the aggregate result belongs in an immutable
+decision context.  The member panel is bounded source data and is not persisted
+as another indicator history.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, localcontext
+from typing import Final, Literal
+
+RegimeVerdict = Literal["usable", "refused"]
+PriceBasis = Literal["quarantine_joinable_vendor_close"]
+
+
+@dataclass(frozen=True)
+class RegimeDefinition:
+    horizons: tuple[int, ...] = (1, 3, 5, 10, 20)
+    return_formula: str = "simple_close_to_close:close_t/close_t_minus_h-1"
+    market_weighting: str = "equal_weight_valid_point_in_time_members"
+    sector_weighting: str = "equal_weight_valid_point_in_time_members"
+    dispersion_formula: str = "sample_standard_deviation_of_constituent_simple_returns"
+    trend_lookback_sessions: int = 20
+    trend_formula: str = "close_t>arithmetic_mean(close_t_minus_20...close_t_minus_1)"
+    common_movement_lookback_sessions: int = 20
+    common_movement_formula: str = "variance(equal_weight_daily_return)/mean(constituent_daily_return_variance)"
+    missing_semantics: str = "excluded_from_measure_included_in_declared_cohort_coverage"
+    price_basis: str = "quarantine_joinable_vendor_close"
+    unit_regime_rule: str = "every_transition_inside_return_or_trend_window_must_be_joinable"
+    classification_semantics: str = "caller_supplied_point_in_time_provider_industry"
+
+
+DEFINITION: Final = RegimeDefinition()
+# Decimal arithmetic can leave an economically meaningless excursion this far
+# outside [0, 1] after ratios of sample variances. Anything larger is a real
+# contract violation and is refused rather than clipped.
+_VARIANCE_SHARE_ROUNDING_EPSILON: Final = Decimal("1e-28")
+
+
+@dataclass(frozen=True)
+class RegimeMember:
+    instrument_id: int
+    provider_industry_id: int
+    # Aligned one-for-one with CompletedSessionPanel.session_dates.
+    closes: tuple[Decimal | None, ...]
+    # At index j: whether close[j-1] and close[j] share a resolved unit regime.
+    # Index zero has no predecessor and must be False.
+    return_links: tuple[bool, ...]
+
+
+@dataclass(frozen=True)
+class CompletedSessionPanel:
+    session_dates: tuple[date, ...]
+    members: tuple[RegimeMember, ...]
+    cohort_version: str
+    source_version: str
+    price_basis: PriceBasis
+
+
+@dataclass(frozen=True)
+class HorizonAggregate:
+    horizon_sessions: int
+    verdict: RegimeVerdict
+    refusal_reason: str | None
+    expected_count: int
+    observed_count: int
+    coverage: Decimal
+    equal_weight_return: Decimal | None
+    return_dispersion: Decimal | None
+    advance_share: Decimal | None
+
+
+@dataclass(frozen=True)
+class CommonMovement:
+    verdict: RegimeVerdict
+    refusal_reason: str | None
+    expected_count: int
+    balanced_count: int
+    coverage: Decimal
+    variance_share: Decimal | None
+
+
+@dataclass(frozen=True)
+class ParticipationAggregate:
+    verdict: RegimeVerdict
+    refusal_reason: str | None
+    expected_count: int
+    observed_count: int
+    coverage: Decimal
+    share: Decimal | None
+
+
+@dataclass(frozen=True)
+class SectorRegime:
+    provider_industry_id: int
+    expected_count: int
+    horizons: tuple[HorizonAggregate, ...]
+    prior_trend: ParticipationAggregate
+    common_movement: CommonMovement
+
+
+@dataclass(frozen=True)
+class CompletedSessionRegime:
+    version: str
+    cohort_version: str
+    source_version: str
+    latest_completed_session: date
+    minimum_coverage: Decimal
+    minimum_sector_members: int
+    expected_count: int
+    market_horizons: tuple[HorizonAggregate, ...]
+    prior_trend: ParticipationAggregate
+    common_movement: CommonMovement
+    sectors: tuple[SectorRegime, ...]
+
+
+def _mean(values: list[Decimal]) -> Decimal:
+    return sum(values, Decimal(0)) / Decimal(len(values))
+
+
+def _sample_variance(values: list[Decimal]) -> Decimal | None:
+    if len(values) < 2:
+        return None
+    mean = _mean(values)
+    return sum(((value - mean) ** 2 for value in values), Decimal(0)) / Decimal(len(values) - 1)
+
+
+def _sample_stddev(values: list[Decimal]) -> Decimal | None:
+    variance = _sample_variance(values)
+    if variance is None:
+        return None
+    with localcontext() as context:
+        context.prec = 34
+        return variance.sqrt()
+
+
+def _valid_close(value: Decimal | None) -> bool:
+    return value is not None and value.is_finite() and value > 0
+
+
+def _simple_return(member: RegimeMember, horizon: int) -> Decimal | None:
+    current = member.closes[-1]
+    prior = member.closes[-1 - horizon]
+    if not _valid_close(current) or not _valid_close(prior) or not all(member.return_links[-horizon:]):
+        return None
+    assert current is not None and prior is not None
+    return current / prior - 1
+
+
+def _coverage(observed: int, expected: int) -> Decimal:
+    return Decimal(observed) / Decimal(expected)
+
+
+def _horizon_aggregate(
+    members: tuple[RegimeMember, ...], *, horizon: int, minimum_coverage: Decimal
+) -> HorizonAggregate:
+    returns = [value for member in members if (value := _simple_return(member, horizon)) is not None]
+    coverage = _coverage(len(returns), len(members))
+    usable = coverage >= minimum_coverage and len(returns) >= 2
+    reason = None
+    if coverage < minimum_coverage:
+        reason = f"coverage:{len(returns)}/{len(members)}<{minimum_coverage.normalize()}"
+    elif len(returns) < 2:
+        reason = "dispersion_requires_two_members"
+    return HorizonAggregate(
+        horizon_sessions=horizon,
+        verdict="usable" if usable else "refused",
+        refusal_reason=reason,
+        expected_count=len(members),
+        observed_count=len(returns),
+        coverage=coverage,
+        equal_weight_return=_mean(returns) if usable else None,
+        return_dispersion=_sample_stddev(returns) if usable else None,
+        advance_share=(Decimal(sum(value > 0 for value in returns)) / Decimal(len(returns))) if usable else None,
+    )
+
+
+def _trend_share(members: tuple[RegimeMember, ...], *, minimum_coverage: Decimal) -> ParticipationAggregate:
+    outcomes: list[bool] = []
+    lookback = DEFINITION.trend_lookback_sessions
+    for member in members:
+        current = member.closes[-1]
+        history = member.closes[-1 - lookback : -1]
+        if (
+            not _valid_close(current)
+            or len(history) != lookback
+            or any(not _valid_close(value) for value in history)
+            or not all(member.return_links[-lookback:])
+        ):
+            continue
+        assert current is not None
+        prior = [value for value in history if value is not None]
+        outcomes.append(current > _mean(prior))
+    coverage = _coverage(len(outcomes), len(members))
+    if coverage < minimum_coverage:
+        return ParticipationAggregate(
+            verdict="refused",
+            refusal_reason=f"coverage:{len(outcomes)}/{len(members)}<{minimum_coverage.normalize()}",
+            expected_count=len(members),
+            observed_count=len(outcomes),
+            coverage=coverage,
+            share=None,
+        )
+    return ParticipationAggregate(
+        verdict="usable",
+        refusal_reason=None,
+        expected_count=len(members),
+        observed_count=len(outcomes),
+        coverage=coverage,
+        share=Decimal(sum(outcomes)) / Decimal(len(outcomes)),
+    )
+
+
+def _common_movement(members: tuple[RegimeMember, ...], *, minimum_coverage: Decimal) -> CommonMovement:
+    lookback = DEFINITION.common_movement_lookback_sessions
+    balanced: list[list[Decimal]] = []
+    for member in members:
+        closes = member.closes[-1 - lookback :]
+        if (
+            len(closes) != lookback + 1
+            or any(not _valid_close(value) for value in closes)
+            or not all(member.return_links[-lookback:])
+        ):
+            continue
+        concrete = [value for value in closes if value is not None]
+        balanced.append([concrete[index] / concrete[index - 1] - 1 for index in range(1, len(concrete))])
+
+    coverage = _coverage(len(balanced), len(members))
+    reason: str | None = None
+    if coverage < minimum_coverage:
+        reason = f"coverage:{len(balanced)}/{len(members)}<{minimum_coverage.normalize()}"
+    elif len(balanced) < 2:
+        reason = "common_movement_requires_two_members"
+    if reason is not None:
+        return CommonMovement("refused", reason, len(members), len(balanced), coverage, None)
+
+    market_returns = [_mean([returns[index] for returns in balanced]) for index in range(lookback)]
+    market_variance = _sample_variance(market_returns)
+    constituent_variances = [value for returns in balanced if (value := _sample_variance(returns)) is not None]
+    denominator = _mean(constituent_variances) if constituent_variances else Decimal(0)
+    if market_variance is None or denominator <= 0:
+        return CommonMovement(
+            "refused", "zero_or_undefined_constituent_variance", len(members), len(balanced), coverage, None
+        )
+    share = market_variance / denominator
+    # Tiny Decimal rounding excursions are not economic information.
+    if share < 0 and share > -_VARIANCE_SHARE_ROUNDING_EPSILON:
+        share = Decimal(0)
+    if share > 1 and share < 1 + _VARIANCE_SHARE_ROUNDING_EPSILON:
+        share = Decimal(1)
+    if not Decimal(0) <= share <= Decimal(1):
+        return CommonMovement(
+            "refused",
+            "variance_share_outside_unit_interval",
+            len(members),
+            len(balanced),
+            coverage,
+            None,
+        )
+    return CommonMovement("usable", None, len(members), len(balanced), coverage, share)
+
+
+def decompose_return(
+    *, instrument_return: Decimal, market_return: Decimal, sector_return: Decimal
+) -> tuple[Decimal, Decimal, Decimal]:
+    """Return market, sector-relative, and instrument-residual components."""
+    return market_return, sector_return - market_return, instrument_return - sector_return
+
+
+def measure_completed_session_regime(
+    panel: CompletedSessionPanel,
+    *,
+    minimum_coverage: Decimal,
+    minimum_sector_members: int,
+) -> CompletedSessionRegime:
+    """Measure declared context through the panel's final completed session."""
+    if not Decimal(0) < minimum_coverage <= Decimal(1):
+        raise ValueError("minimum_coverage must be inside (0, 1]")
+    if minimum_sector_members < 2:
+        raise ValueError("minimum_sector_members must be at least two")
+    if not panel.cohort_version or not panel.source_version:
+        raise ValueError("cohort_version and source_version must be non-empty")
+    if panel.price_basis != DEFINITION.price_basis:
+        raise ValueError(f"unsupported price basis {panel.price_basis!r}")
+    required_sessions = max(DEFINITION.horizons) + 1
+    if len(panel.session_dates) < required_sessions:
+        raise ValueError(f"at least {required_sessions} completed sessions are required")
+    if tuple(sorted(panel.session_dates)) != panel.session_dates or len(set(panel.session_dates)) != len(
+        panel.session_dates
+    ):
+        raise ValueError("session dates must be strictly increasing and unique")
+    if not panel.members:
+        raise ValueError("point-in-time cohort must not be empty")
+    ids = [member.instrument_id for member in panel.members]
+    if any(instrument_id <= 0 for instrument_id in ids) or len(ids) != len(set(ids)):
+        raise ValueError("member instrument IDs must be unique and positive")
+    for member in panel.members:
+        if member.provider_industry_id <= 0:
+            raise ValueError("provider industry IDs must be positive")
+        if len(member.closes) != len(panel.session_dates):
+            raise ValueError(f"instrument {member.instrument_id} is not aligned to session dates")
+        if len(member.return_links) != len(panel.session_dates) or member.return_links[0]:
+            raise ValueError(f"instrument {member.instrument_id} has invalid unit-regime link alignment")
+
+    market_horizons = tuple(
+        _horizon_aggregate(panel.members, horizon=horizon, minimum_coverage=minimum_coverage)
+        for horizon in DEFINITION.horizons
+    )
+    prior_trend = _trend_share(panel.members, minimum_coverage=minimum_coverage)
+    grouped: dict[int, list[RegimeMember]] = {}
+    for member in panel.members:
+        grouped.setdefault(member.provider_industry_id, []).append(member)
+    sectors: list[SectorRegime] = []
+    for industry_id, raw_members in sorted(grouped.items()):
+        members = tuple(raw_members)
+        sector_threshold = minimum_coverage if len(members) >= minimum_sector_members else Decimal(1)
+        sector_horizons = tuple(
+            _horizon_aggregate(members, horizon=horizon, minimum_coverage=sector_threshold)
+            for horizon in DEFINITION.horizons
+        )
+        if len(members) < minimum_sector_members:
+            sector_horizons = tuple(
+                HorizonAggregate(
+                    horizon_sessions=item.horizon_sessions,
+                    verdict="refused",
+                    refusal_reason=f"sector_members:{len(members)}<{minimum_sector_members}",
+                    expected_count=item.expected_count,
+                    observed_count=item.observed_count,
+                    coverage=item.coverage,
+                    equal_weight_return=None,
+                    return_dispersion=None,
+                    advance_share=None,
+                )
+                for item in sector_horizons
+            )
+        sector_trend = _trend_share(members, minimum_coverage=sector_threshold)
+        common = _common_movement(members, minimum_coverage=sector_threshold)
+        if len(members) < minimum_sector_members:
+            sector_trend = ParticipationAggregate(
+                "refused",
+                f"sector_members:{len(members)}<{minimum_sector_members}",
+                sector_trend.expected_count,
+                sector_trend.observed_count,
+                sector_trend.coverage,
+                None,
+            )
+            common = CommonMovement(
+                "refused",
+                f"sector_members:{len(members)}<{minimum_sector_members}",
+                common.expected_count,
+                common.balanced_count,
+                common.coverage,
+                None,
+            )
+        sectors.append(
+            SectorRegime(
+                provider_industry_id=industry_id,
+                expected_count=len(members),
+                horizons=sector_horizons,
+                prior_trend=sector_trend,
+                common_movement=common,
+            )
+        )
+    return CompletedSessionRegime(
+        version=REGIME_VERSION,
+        cohort_version=panel.cohort_version,
+        source_version=panel.source_version,
+        latest_completed_session=panel.session_dates[-1],
+        minimum_coverage=minimum_coverage,
+        minimum_sector_members=minimum_sector_members,
+        expected_count=len(panel.members),
+        market_horizons=market_horizons,
+        prior_trend=prior_trend,
+        common_movement=_common_movement(panel.members, minimum_coverage=minimum_coverage),
+        sectors=tuple(sectors),
+    )
+
+
+def _version() -> str:
+    semantic_functions = (
+        _mean,
+        _sample_variance,
+        _sample_stddev,
+        _valid_close,
+        _simple_return,
+        _coverage,
+        _horizon_aggregate,
+        _trend_share,
+        _common_movement,
+        decompose_return,
+        measure_completed_session_regime,
+    )
+    payload = repr(DEFINITION) + "".join(inspect.getsource(function) for function in semantic_functions)
+    return "completed-session-regime-v1:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+REGIME_VERSION: Final = _version()
+
+
+__all__ = [
+    "CompletedSessionPanel",
+    "CompletedSessionRegime",
+    "HorizonAggregate",
+    "ParticipationAggregate",
+    "REGIME_VERSION",
+    "RegimeMember",
+    "decompose_return",
+    "measure_completed_session_regime",
+]

--- a/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
+++ b/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
@@ -249,8 +249,11 @@ promoted candidates.
 
 1. Keep S-1..S-4 as controls and label their true horizons; do not tune them
    into short-horizon candidates.
-2. Complete #2507's point-in-time mechanism state and add the missing compact
-   breadth/dispersion/multi-horizon context inputs under #2523.
+2. Complete #2507's point-in-time mechanism state and finish #2523's production
+   path. Broad snapshot breadth, prospective provider-industry identity and
+   pure completed-session multi-horizon/dispersion/common-movement mathematics
+   are now implemented; candidate-owned loading, compact persistence and exact
+   intraday coverage remain.
 3. Preregister a recent sector-ETF residual relative-value replication at
    separate 3/5/10-session horizons under #2522, research-only until side/carry
    contracts exist.

--- a/docs/proposals/ta/2026-08-12-completed-session-regime-math.md
+++ b/docs/proposals/ta/2026-08-12-completed-session-regime-math.md
@@ -1,0 +1,189 @@
+# Completed-session market and sector regime mathematics (#2523)
+
+Date: 2026-08-12  
+Status: formula and read-only feasibility foundation; no candidate promoted
+
+## Decision
+
+Add one versioned pure calculator for compact market/sector **context** over
+1, 3, 5, 10 and 20 completed provider sessions. It receives an aligned,
+caller-frozen point-in-time cohort and returns aggregate direction, breadth,
+dispersion, prior-trend participation and common-movement state. It neither
+selects a trade nor writes an indicator history.
+
+This distinction is load-bearing. Published evidence supports dispersion and
+correlation as descriptions of market state and, in some samples, predictors
+at longer horizons. It does not establish that combining them with RSI or a
+moving average produces a profitable one-to-20-session rule. A 2024
+comprehensive replication reports that the Pollet-Wilson average-correlation
+predictor lost significance on its broader sample, had negative out-of-sample
+R-squared, and produced poor investment performance. These values therefore
+remain conditioning/risk variables until a separately preregistered mechanism
+passes recent untouched and prospective tests.
+
+## Frozen formulas
+
+For point-in-time cohort member `i`, final completed provider session `t`, and
+horizon `h` in `{1,3,5,10,20}`:
+
+```text
+R(i,t,h) = close(i,t) / close(i,t-h) - 1
+R(m,t,h) = arithmetic mean of valid R(i,t,h)
+dispersion(m,t,h) = sample standard deviation of valid R(i,t,h)
+breadth(m,t,h) = count(R(i,t,h) > 0) / count(valid R(i,t,h))
+```
+
+Every provider-close transition inside `t-h...t` must also be joinable under
+the pinned quarantine/series-break state. Endpoint availability alone is not
+enough: a return crossing an unresolved split, ADR-ratio change or vendor
+rescale is missing. The same rule covers every link used by the prior-trend and
+common-movement windows. The calculator accepts only the explicitly named
+`quarantine_joinable_vendor_close` basis; a raw unlabelled close panel is
+rejected.
+
+The same formulas are applied within the point-in-time provider industry. The
+instrument decomposition is exact:
+
+```text
+instrument return
+  = market return
+  + (sector return - market return)
+  + (instrument return - sector return)
+```
+
+This makes market, sector-relative and idiosyncratic movement auditable without
+pretending the coarse eToro industry taxonomy is GICS or an executable sector
+ETF hedge.
+
+Prior-trend participation is deliberately causal and descriptive:
+
+```text
+above_prior_20(i,t)
+  = close(i,t) > mean(close(i,t-20), ..., close(i,t-1))
+```
+
+The final close is not allowed to move its own baseline. “Percent above a
+moving average” has not been admitted as independent alpha; the measure tells
+us whether current direction is broadly established or narrow.
+
+The 20-session common-movement value is:
+
+```text
+daily_market_return(d) = mean_i daily_return(i,d)
+common_variance_share
+  = variance_d(daily_market_return(d))
+    / mean_i(variance_d(daily_return(i,d)))
+```
+
+It uses only members with a balanced 21-close panel. It is bounded to `[0,1]`
+and measures the share of average constituent variance surviving equal-weight
+diversification. It is **not** labelled average correlation or first-principal-
+component share: unequal constituent volatilities make those different
+statistics. A future candidate needing one of those exact quantities must
+freeze and implement it separately.
+
+## Knowledge time, missingness and coverage
+
+- The caller supplies the completed-session calendar, cohort version, raw
+  source version and point-in-time provider industry. The calculator never
+  reads current classifications or later constituents.
+- A missing/non-positive/non-finite endpoint excludes the member from that
+  measure but remains in the declared coverage denominator. It never becomes a
+  zero return, unchanged stock or zero volatility.
+- An unresolved or provisional unit-regime transition has the same fail-closed
+  treatment. The verification source pins both the quarantine rule version and
+  break/adjustment frontiers in a repeatable-read transaction.
+- The candidate supplies its coverage threshold before outcomes. Below it, the
+  aggregate is refused and values are `NULL`, not a partial number wearing a
+  warning.
+- Dispersion and common movement require at least two members. Sectors below a
+  candidate-supplied minimum size are refused, even at 100% coverage.
+- All 21 dates must be strictly increasing and every member must align exactly
+  to them. The calculator contains no wall-clock fallback.
+
+## Live-corpus feasibility result
+
+`scripts/verify_2523_regime_context.py` performed a read-only check against the
+current NYSE/Nasdaq common-stock classification with a known provider industry,
+the current quarantine rule set, and an 80% illustrative feasibility floor.
+This threshold is not a candidate threshold and no outcome was accessed.
+
+The first implementation used the union of observed stock dates. It admitted
+sparse provider dates contributed by nine names: 3- and 10-session coverage
+collapsed to **9 / 4,351 (0.21%)**. That approach is rejected. eToro daily bars
+also do not use New York civil dates consistently (a Monday session may carry a
+Sunday provider date), so filtering weekdays would introduce a second error.
+
+The corrected check pins the provider SPY series (`instrument_id=3000`, asserted
+as the ETF identity) as the completed-session calendar:
+
+| measure | observed result |
+|---|---:|
+| point-in-time members with provider industry | 4,351 |
+| completed source sessions | 21 |
+| latest quarantine-complete provider session | 2026-08-05 |
+| 1-session endpoint + joinable-unit coverage | 80.602% |
+| 3-session endpoint + joinable-unit coverage | 80.602% |
+| 5-session endpoint + joinable-unit coverage | 80.487% |
+| 10-session endpoint + joinable-unit coverage | 80.487% |
+| 20-session endpoint + joinable-unit coverage | 80.464% |
+| balanced 21-close/trend/unit coverage | 80.257% |
+| provider industries / with at least 20 members | 9 / 8 |
+| representative database load / pure calculation | 1.428s / 0.116s |
+
+The 2026-08-05 frontier is intentional: newer raw bars exist, but the current
+fail-closed quarantine coverage does not yet admit them. A runtime candidate
+must report this staleness and refuse rather than silently reading unchecked
+2026-08-11 bars.
+
+The unit-regime mask removed only a small fraction of members but moved the
+descriptive common-variance share from 3.45% to 5.60%. Neither value is a trade
+signal; the sensitivity demonstrates why corporate-action joins are mandatory
+before regime attribution rather than an optional cleanup after it.
+
+## Storage and product impact
+
+This increment adds no table, index, migration, derived row, WAL or UI element.
+The 4,351-by-21 panel exists only for the calculation and is released. A later
+decision-context migration should copy only:
+
+- five market horizon aggregates;
+- the candidate instrument's one sector aggregate at each horizon;
+- market and selected-sector breadth/trend/dispersion/common-movement values;
+- formula, cohort/source, session frontier, denominator and refusal identity.
+
+It must not persist all nine sectors per instrument, per-bar rolling values, or
+routine not-fired scans. This is the measured path that keeps the 63 GB database
+warning from becoming an excuse for another feature warehouse.
+
+## What remains blocked
+
+1. A production loader needs a candidate-owned calendar and exact cohort, not
+   the verification script's broad feasibility cohort.
+2. Only current/prospective provider industry is known. Historical decisions
+   before the observation boundary cannot use today's sector.
+3. Event-mechanism state from #2507 and exact intraday coverage remain missing.
+4. The coarse nine-industry mapping does not complete #2522's sector-ETF hedge
+   contract.
+5. These aggregates need candidate-specific recent OOS attribution before any
+   claim that a condition improves expectancy, loss tails or calibration.
+
+The honest runtime catalogue therefore remains empty.
+
+## Primary research references
+
+- Connolly and Stivers, [Information content and other characteristics of the
+  daily cross-sectional dispersion in stock returns](https://doi.org/10.1016/j.jempfin.2005.02.001)
+  — defines broad daily return dispersion as cross-sectional standard deviation
+  and studies it primarily as volatility information.
+- Campbell and Lettau, [Dispersion and Volatility in Stock Returns: An Empirical
+  Investigation](https://www.nber.org/papers/w7144) — separates market,
+  industry-relative and firm-relative dispersion.
+- Pollet and Wilson, [Average correlation and stock market
+  returns](https://doi.org/10.1016/j.jfineco.2010.02.011) — motivates common
+  movement as distinct from individual variance; its original forecast horizon
+  is quarterly, not a one-day entry.
+- Goyal, Welch and Zafirov, [A Comprehensive Look at the Empirical Performance
+  of Equity Premium Prediction](https://doi.org/10.1093/rfs/hhae060) — broad
+  updated replication and the reason correlation is not treated as deployable
+  alpha here.

--- a/docs/proposals/ta/2026-08-12-etoro-search-snapshot.md
+++ b/docs/proposals/ta/2026-08-12-etoro-search-snapshot.md
@@ -70,9 +70,12 @@ This removes the quota objection to cheap broad screening and supplies a tested
 prospective current-session breadth primitive for liquid declared cohorts. The
 subsequent point-in-time-sector increment records the current eToro
 stocks-industry assignment prospectively and refuses unknown assignments. It
-still does not complete #2523: causal 1/3/5/10-session market and sector
-returns, percent-above-trend, residual dispersion/common-factor state and exact
-event state still require their declared formulas and fixture reconciliation.
+is followed by a completed-session increment that freezes and fixture-tests
+causal 1/3/5/10/20-session market/sector returns, percent-above-prior-trend,
+cross-sectional dispersion and a precisely labelled common-variance share. It
+also exposes a provider-session-calendar trap in the live corpus. #2523 is
+still incomplete: a candidate-owned production loader, compact persistence,
+exact event state and intraday coverage remain outstanding.
 
 It also does not make S1–S4 viable. The corrected after-cost evidence remains
 negative/weak, so the strategy catalogue must stay empty until a preregistered

--- a/scripts/verify_2523_regime_context.py
+++ b/scripts/verify_2523_regime_context.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Read-only live-corpus feasibility check for #2523 regime aggregates.
+
+This is deliberately not a production loader.  It measures the current
+point-in-time cohort and the existing fail-closed quarantine coverage without
+writing derived history.  A candidate still owns its calendar, cohort and
+coverage threshold.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+
+from app.config import settings
+from app.services.price_quarantine import RULE_SET_VERSION
+from app.services.strategy_regime_context import (
+    CompletedSessionPanel,
+    RegimeMember,
+    measure_completed_session_regime,
+)
+
+_SQL = """
+WITH cohort AS (
+    SELECT h.instrument_id, h.provider_industry_id
+      FROM instrument_market_classification_history h
+     WHERE h.effective_to IS NULL
+       AND h.security_type = 'common_stock'
+       AND h.primary_listing_market IN ('nyse', 'nasdaq')
+       AND h.provider_industry_id IS NOT NULL
+), sessions AS (
+    -- eToro's daily bar label is not a civil NYSE date (Monday sessions can
+    -- carry a Sunday date), so a weekday filter would be wrong.  Use the
+    -- declared SPY provider series as the session calendar instead of a union
+    -- in which a handful of sparse foreign/off-calendar bars create fake
+    -- sessions.  Instrument 3000 is asserted below by the verification query.
+    SELECT p.price_date
+      FROM price_daily p
+      JOIN price_quarantine_coverage cov
+        ON cov.instrument_id = p.instrument_id
+       AND cov.rule_set_version = %(rule_set_version)s
+       AND p.price_date BETWEEN cov.first_bar AND cov.last_bar
+      LEFT JOIN price_bar_quarantine q
+        ON q.instrument_id = p.instrument_id
+       AND q.price_date = p.price_date
+       AND q.rule_set_version = %(rule_set_version)s
+     WHERE p.instrument_id = 3000
+       AND p.close > 0
+       AND COALESCE(q.return_usable, TRUE)
+       AND NOT COALESCE(q.provisional, FALSE)
+     ORDER BY p.price_date DESC
+     LIMIT 21
+)
+SELECT c.instrument_id, c.provider_industry_id, s.price_date,
+       CASE WHEN p.close > 0
+                  AND cov.instrument_id IS NOT NULL
+                  AND COALESCE(q.return_usable, TRUE)
+                  AND NOT COALESCE(q.provisional, FALSE)
+            THEN p.close
+            ELSE NULL
+       END AS close,
+       p.close > 0
+           AND cov.instrument_id IS NOT NULL
+           AND COALESCE(q.return_usable, TRUE)
+           AND NOT COALESCE(q.provisional, FALSE)
+           AND tq.instrument_id IS NULL
+           AND b.instrument_id IS NULL AS return_link_usable
+  FROM cohort c
+ CROSS JOIN sessions s
+  LEFT JOIN price_daily p
+    ON p.instrument_id = c.instrument_id
+   AND p.price_date = s.price_date
+  LEFT JOIN price_quarantine_coverage cov
+    ON cov.instrument_id = p.instrument_id
+   AND cov.rule_set_version = %(rule_set_version)s
+   AND p.price_date BETWEEN cov.first_bar AND cov.last_bar
+  LEFT JOIN price_bar_quarantine q
+    ON q.instrument_id = p.instrument_id
+   AND q.price_date = p.price_date
+   AND q.rule_set_version = %(rule_set_version)s
+  LEFT JOIN price_transition_quarantine tq
+    ON tq.instrument_id = c.instrument_id
+   AND tq.price_date = s.price_date
+   AND tq.rule_set_version = %(rule_set_version)s
+  LEFT JOIN price_series_break b
+    ON b.instrument_id = c.instrument_id
+   AND b.break_date = s.price_date
+ ORDER BY c.instrument_id, s.price_date
+"""
+
+
+def _load(conn: psycopg.Connection[Any]) -> CompletedSessionPanel:
+    reference = conn.execute("SELECT symbol, instrument_type_id FROM instruments WHERE instrument_id = 3000").fetchone()
+    if reference != ("SPY", 6):
+        raise RuntimeError(f"reference calendar identity drifted: expected SPY ETF (3000, 6), got {reference!r}")
+    frontiers = conn.execute(
+        "SELECT (SELECT max(break_id) FROM price_series_break), "
+        "       (SELECT max(adjustment_id) FROM price_adjustments)"
+    ).fetchone()
+    if frontiers is None:
+        raise RuntimeError("could not pin price unit-regime frontiers")
+    break_frontier, adjustment_frontier = frontiers
+    rows = conn.execute(_SQL, {"rule_set_version": RULE_SET_VERSION}).fetchall()
+    if not rows:
+        raise RuntimeError("current point-in-time cohort has no usable completed-session rows")
+    dates = tuple(sorted({row[2] for row in rows}))
+    grouped: dict[tuple[int, int], dict[date, Decimal | None]] = {}
+    links: dict[tuple[int, int], dict[date, bool]] = {}
+    for instrument_id, industry_id, session_date, close, return_link_usable in rows:
+        grouped.setdefault((instrument_id, industry_id), {})[session_date] = close
+        links.setdefault((instrument_id, industry_id), {})[session_date] = return_link_usable
+    members = tuple(
+        RegimeMember(
+            instrument_id=instrument_id,
+            provider_industry_id=industry_id,
+            closes=tuple(by_date.get(session_date) for session_date in dates),
+            return_links=(False,) + tuple(links[(instrument_id, industry_id)].get(day, False) for day in dates[1:]),
+        )
+        for (instrument_id, industry_id), by_date in grouped.items()
+    )
+    return CompletedSessionPanel(
+        session_dates=dates,
+        members=members,
+        cohort_version="current-pit-nyse-nasdaq-common-with-provider-industry+spy-calendar-3000",
+        source_version=(
+            f"price_daily+{RULE_SET_VERSION}+break<={break_frontier or 0}+adjustment<={adjustment_frontier or 0}"
+        ),
+        price_basis="quarantine_joinable_vendor_close",
+    )
+
+
+def main() -> None:
+    started = time.perf_counter()
+    with psycopg.connect(settings.database_url) as conn:
+        conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        panel = _load(conn)
+    loaded = time.perf_counter()
+    result = measure_completed_session_regime(
+        panel,
+        minimum_coverage=Decimal("0.80"),
+        minimum_sector_members=20,
+    )
+    finished = time.perf_counter()
+    print(
+        json.dumps(
+            {
+                "read_only": True,
+                "formula_version": result.version,
+                "latest_completed_session": result.latest_completed_session.isoformat(),
+                "sessions": len(panel.session_dates),
+                "expected_members": result.expected_count,
+                "trend_coverage": str(result.prior_trend.coverage),
+                "common_movement": {
+                    "verdict": result.common_movement.verdict,
+                    "coverage": str(result.common_movement.coverage),
+                    "variance_share": (
+                        None
+                        if result.common_movement.variance_share is None
+                        else str(result.common_movement.variance_share)
+                    ),
+                },
+                "horizons": [
+                    {
+                        "sessions": item.horizon_sessions,
+                        "verdict": item.verdict,
+                        "coverage": str(item.coverage),
+                    }
+                    for item in result.market_horizons
+                ],
+                "sectors": len(result.sectors),
+                "sectors_at_least_20_members": sum(sector.expected_count >= 20 for sector in result.sectors),
+                "load_seconds": round(loaded - started, 3),
+                "compute_seconds": round(finished - loaded, 3),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_strategy_regime_context.py
+++ b/tests/test_strategy_regime_context.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.services.strategy_regime_context import (
+    REGIME_VERSION,
+    CompletedSessionPanel,
+    RegimeMember,
+    decompose_return,
+    measure_completed_session_regime,
+)
+
+
+def _dates(count: int = 21) -> tuple[date, ...]:
+    first = date(2026, 7, 1)
+    return tuple(first + timedelta(days=index) for index in range(count))
+
+
+def _member(
+    instrument_id: int,
+    industry_id: int,
+    closes: Sequence[str | None],
+) -> RegimeMember:
+    return RegimeMember(
+        instrument_id=instrument_id,
+        provider_industry_id=industry_id,
+        closes=tuple(None if value is None else Decimal(value) for value in closes),
+        return_links=(False,) + (True,) * (len(closes) - 1),
+    )
+
+
+def _panel(*members: RegimeMember, dates: tuple[date, ...] | None = None) -> CompletedSessionPanel:
+    return CompletedSessionPanel(
+        session_dates=_dates() if dates is None else dates,
+        members=tuple(members),
+        cohort_version="liquid-us-common-v1",
+        source_version="fixture-v1",
+        price_basis="quarantine_joinable_vendor_close",
+    )
+
+
+def _rising(start: int, step: int = 1) -> list[str]:
+    return [str(start + step * index) for index in range(21)]
+
+
+def test_exact_horizon_returns_breadth_dispersion_and_prior_trend() -> None:
+    result = measure_completed_session_regime(
+        _panel(_member(1, 10, _rising(100)), _member(2, 10, _rising(200, -1))),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+
+    one = result.market_horizons[0]
+    expected_a = Decimal(120) / Decimal(119) - 1
+    expected_b = Decimal(180) / Decimal(181) - 1
+    assert one.verdict == "usable"
+    assert one.equal_weight_return == (expected_a + expected_b) / 2
+    assert one.advance_share == Decimal("0.5")
+    assert one.return_dispersion is not None and one.return_dispersion > 0
+    assert result.prior_trend.share == Decimal("0.5")
+    assert result.prior_trend.coverage == Decimal(1)
+    assert result.version == REGIME_VERSION
+
+
+def test_horizons_are_exactly_1_3_5_10_20_completed_sessions() -> None:
+    result = measure_completed_session_regime(
+        _panel(_member(1, 10, _rising(100)), _member(2, 10, _rising(100))),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+    assert [item.horizon_sessions for item in result.market_horizons] == [1, 3, 5, 10, 20]
+    assert result.market_horizons[-1].equal_weight_return == Decimal("0.2")
+
+
+def test_missing_endpoint_is_not_a_zero_return_and_can_refuse_coverage() -> None:
+    incomplete = _rising(100)
+    incomplete[-1] = None  # type: ignore[assignment]
+    result = measure_completed_session_regime(
+        _panel(
+            _member(1, 10, _rising(100)),
+            _member(2, 10, incomplete),
+            _member(3, 10, _rising(300)),
+        ),
+        minimum_coverage=Decimal("0.8"),
+        minimum_sector_members=2,
+    )
+    one = result.market_horizons[0]
+    assert one.verdict == "refused"
+    assert one.observed_count == 2
+    assert one.coverage == Decimal(2) / Decimal(3)
+    assert one.equal_weight_return is None
+    assert one.refusal_reason == "coverage:2/3<0.8"
+
+
+def test_missing_in_middle_only_affects_measures_that_consume_it() -> None:
+    values = _rising(100)
+    values[8] = None  # type: ignore[assignment]
+    result = measure_completed_session_regime(
+        _panel(_member(1, 10, values), _member(2, 10, _rising(200))),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+    assert all(item.verdict == "usable" for item in result.market_horizons)
+    assert result.prior_trend.verdict == "refused"
+    assert result.prior_trend.share is None
+    assert result.prior_trend.observed_count == 1
+    assert result.prior_trend.refusal_reason == "coverage:1/2<1"
+    assert result.common_movement.verdict == "refused"
+    assert result.common_movement.balanced_count == 1
+
+
+def test_sector_uses_only_its_point_in_time_members_and_reports_relative_component() -> None:
+    result = measure_completed_session_regime(
+        _panel(
+            _member(1, 10, _rising(100, 2)),
+            _member(2, 10, _rising(200, 2)),
+            _member(3, 20, _rising(300, -1)),
+            _member(4, 20, _rising(400, -1)),
+        ),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+    market = result.market_horizons[0].equal_weight_return
+    sector = result.sectors[0].horizons[0].equal_weight_return
+    assert market is not None and sector is not None and sector > market
+    instrument = Decimal(140) / Decimal(138) - 1
+    components = decompose_return(instrument_return=instrument, market_return=market, sector_return=sector)
+    assert sum(components, Decimal(0)) == instrument
+
+
+def test_tiny_sector_refuses_instead_of_publishing_one_name_regime() -> None:
+    result = measure_completed_session_regime(
+        _panel(
+            _member(1, 10, _rising(100)),
+            _member(2, 10, _rising(200)),
+            _member(3, 20, _rising(300)),
+        ),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+    tiny = next(sector for sector in result.sectors if sector.provider_industry_id == 20)
+    assert all(item.verdict == "refused" for item in tiny.horizons)
+    assert all(item.refusal_reason == "sector_members:1<2" for item in tiny.horizons)
+    assert tiny.prior_trend.share is None
+    assert tiny.prior_trend.refusal_reason == "sector_members:1<2"
+    assert tiny.common_movement.verdict == "refused"
+
+
+def test_common_movement_is_one_for_identical_paths() -> None:
+    result = measure_completed_session_regime(
+        _panel(_member(1, 10, _rising(100)), _member(2, 10, _rising(100))),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+    assert result.common_movement.verdict == "usable"
+    assert result.common_movement.variance_share == Decimal(1)
+
+
+def test_common_movement_cancels_for_opposing_equal_return_paths() -> None:
+    # These are generated from alternating +/-1% returns so the equal-weight
+    # daily return is exactly zero while each constituent varies.
+    first = [Decimal(100)]
+    second = [Decimal(100)]
+    for index in range(20):
+        move = Decimal("0.01") if index % 2 == 0 else Decimal("-0.01")
+        first.append(first[-1] * (1 + move))
+        second.append(second[-1] * (1 - move))
+    result = measure_completed_session_regime(
+        _panel(
+            RegimeMember(1, 10, tuple(first), (False,) + (True,) * 20),
+            RegimeMember(2, 10, tuple(second), (False,) + (True,) * 20),
+        ),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+    assert result.common_movement.verdict == "usable"
+    assert result.common_movement.variance_share == Decimal(0)
+
+
+def test_unresolved_unit_break_invalidates_every_window_that_crosses_it() -> None:
+    links = [False] + [True] * 20
+    links[-2] = False
+    result = measure_completed_session_regime(
+        _panel(
+            RegimeMember(1, 10, tuple(Decimal(value) for value in _rising(100)), tuple(links)),
+            _member(2, 10, _rising(200)),
+        ),
+        minimum_coverage=Decimal("1"),
+        minimum_sector_members=2,
+    )
+    assert result.market_horizons[0].verdict == "usable"
+    assert result.market_horizons[1].verdict == "refused"
+    assert result.market_horizons[1].observed_count == 1
+    assert result.prior_trend.verdict == "refused"
+    assert result.common_movement.verdict == "refused"
+
+
+@pytest.mark.parametrize(
+    ("panel", "message"),
+    [
+        (_panel(_member(1, 10, _rising(100)), dates=_dates(20)), "at least 21"),
+        (
+            _panel(
+                _member(1, 10, _rising(100)),
+                _member(1, 10, _rising(200)),
+            ),
+            "unique and positive",
+        ),
+        (
+            _panel(RegimeMember(1, 10, tuple(Decimal(1) for _ in range(20)), (False,) + (True,) * 19)),
+            "not aligned",
+        ),
+    ],
+)
+def test_invalid_panels_fail_closed(panel: CompletedSessionPanel, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        measure_completed_session_regime(
+            panel,
+            minimum_coverage=Decimal("1"),
+            minimum_sector_members=2,
+        )
+
+
+def test_unsorted_or_duplicate_sessions_are_rejected() -> None:
+    sessions = list(_dates())
+    sessions[-1] = sessions[-2]
+    with pytest.raises(ValueError, match="strictly increasing"):
+        measure_completed_session_regime(
+            _panel(_member(1, 10, _rising(100)), dates=tuple(sessions)),
+            minimum_coverage=Decimal("1"),
+            minimum_sector_members=2,
+        )
+
+
+@pytest.mark.parametrize("threshold", [Decimal(0), Decimal("1.01")])
+def test_invalid_coverage_threshold_is_rejected(threshold: Decimal) -> None:
+    with pytest.raises(ValueError, match="inside"):
+        measure_completed_session_regime(
+            _panel(_member(1, 10, _rising(100))),
+            minimum_coverage=threshold,
+            minimum_sector_members=2,
+        )


### PR DESCRIPTION
## Outcome

Adds a versioned, pure market/sector context calculator for #2523 without creating an indicator warehouse or promoting a strategy.

- exact 1/3/5/10/20 completed-session equal-weight returns, breadth and cross-sectional dispersion
- prior-20-session trend participation with a prior-only baseline
- precisely labelled common-variance share (not mislabelled average correlation/PCA)
- point-in-time provider-industry grouping with candidate-owned coverage and sector-size thresholds
- explicit vendor-close price basis and fail-closed unit-regime links so split/rescale boundaries cannot contaminate returns
- exact market + sector-relative + instrument-residual decomposition
- read-only live feasibility verifier and primary-evidence design note

## Measured result

Current PIT NYSE/Nasdaq common-stock cohort with provider industry: 4,351 names. Against the quarantine-complete SPY provider calendar, all five endpoint windows have about 80.5% coverage; balanced 21-close/unit coverage is 80.257%. Load is about 1.4s and pure calculation about 0.12s. No table, migration, index, derived row, WAL, or UI activity dump is added.

The verifier also caught two consequential defects before runtime wiring:

1. a union calendar admitted sparse non-session provider dates and collapsed some horizons to 0.21% coverage;
2. endpoint-only returns crossed unresolved price-unit breaks. Masking those links materially changed common-movement state despite excluding few members.

Raw bars reach 2026-08-11, but fail-closed quarantine evidence currently reaches only 2026-08-05. A live candidate must therefore refuse as stale today.

## Boundaries

These are context/risk variables, not alpha signals. Updated published replication does not support treating average correlation as a profitable short-horizon trigger. Candidate-owned production loading, compact persistence, event state, intraday coverage, and recent candidate-specific OOS attribution remain open. The runtime candidate catalogue stays empty.

## Verification

- 15 focused tests
- ruff + format
- pyright
- full pre-push pure test suite
- smoke app boot against dev DB
- frontend integrity gates
- read-only live-corpus feasibility run

Refs #2523 #2507 #2522