### PR TITLE
Correct completed-session anchoring for partial candle runs

### DIFF
--- a/app/services/strategy_regime_context.py
+++ b/app/services/strategy_regime_context.py
@@ -69,6 +69,12 @@ class CompletedSessionPanel:
 
 
 @dataclass(frozen=True)
+class ReferenceSessionCoverage:
+    session_date: date
+    observed_count: int
+
+
+@dataclass(frozen=True)
 class HorizonAggregate:
     horizon_sessions: int
     verdict: RegimeVerdict
@@ -160,6 +166,47 @@ def _simple_return(member: RegimeMember, horizon: int) -> Decimal | None:
 
 def _coverage(observed: int, expected: int) -> Decimal:
     return Decimal(observed) / Decimal(expected)
+
+
+def select_completed_session_dates(
+    observations: tuple[ReferenceSessionCoverage, ...],
+    *,
+    expected_count: int,
+    minimum_anchor_coverage: Decimal,
+    required_sessions: int,
+) -> tuple[date, ...]:
+    """Anchor on the latest broadly populated reference-market session.
+
+    A provider can publish a reference instrument before the wider universe is
+    complete. The latest date alone is therefore not a completed-session
+    contract. Once the anchor is chosen, every prior reference date is retained
+    even when its coverage is poor; skipping a sparse middle session would
+    silently change every horizon instead of letting downstream coverage fail.
+    """
+    if expected_count <= 0:
+        raise ValueError("expected_count must be positive")
+    if not Decimal(0) < minimum_anchor_coverage <= Decimal(1):
+        raise ValueError("minimum_anchor_coverage must be inside (0, 1]")
+    if required_sessions <= 0:
+        raise ValueError("required_sessions must be positive")
+    dates = tuple(item.session_date for item in observations)
+    if dates != tuple(sorted(dates)) or len(dates) != len(set(dates)):
+        raise ValueError("reference session observations must be strictly increasing and unique")
+    for item in observations:
+        if not 0 <= item.observed_count <= expected_count:
+            raise ValueError("reference session observed_count must be inside 0..expected_count")
+    anchors = [
+        index
+        for index, item in enumerate(observations)
+        if _coverage(item.observed_count, expected_count) >= minimum_anchor_coverage
+    ]
+    if not anchors:
+        raise ValueError("no reference session reaches minimum anchor coverage")
+    anchor_index = anchors[-1]
+    first_index = anchor_index - required_sessions + 1
+    if first_index < 0:
+        raise ValueError(f"fewer than {required_sessions} reference sessions exist through the covered anchor")
+    return dates[first_index : anchor_index + 1]
 
 
 def _horizon_aggregate(
@@ -395,6 +442,7 @@ def _version() -> str:
         _valid_close,
         _simple_return,
         _coverage,
+        select_completed_session_dates,
         _horizon_aggregate,
         _trend_share,
         _common_movement,
@@ -414,7 +462,9 @@ __all__ = [
     "HorizonAggregate",
     "ParticipationAggregate",
     "REGIME_VERSION",
+    "ReferenceSessionCoverage",
     "RegimeMember",
     "decompose_return",
     "measure_completed_session_regime",
+    "select_completed_session_dates",
 ]

--- a/docs/proposals/ta/2026-08-12-completed-session-regime-math.md
+++ b/docs/proposals/ta/2026-08-12-completed-session-regime-math.md
@@ -114,32 +114,53 @@ collapsed to **9 / 4,351 (0.21%)**. That approach is rejected. eToro daily bars
 also do not use New York civil dates consistently (a Monday session may carry a
 Sunday provider date), so filtering weekdays would introduce a second error.
 
-The corrected check pins the provider SPY series (`instrument_id=3000`, asserted
-as the ETF identity) as the completed-session calendar:
+The first corrected check pinned the provider SPY series (`instrument_id=3000`,
+asserted as the ETF identity) as the session calendar but incorrectly excluded
+every bar carrying the quarantine's five-day `provisional` flag. That flag does
+not mean “unusable close”: it means a magnitude-triggered transition inside the
+window cannot yet use partial turnover to decide T3. Ordinary recent returns are
+valid; a stored deferred/quarantined transition still makes its link unusable.
+
+Removing that over-rejection exposed the opposite trap. A later failed candle
+run had committed only **551 / 4,351** 2026-08-11 cohort rows, while SPY already
+carried that label. Maximum reference date was therefore not a completed broad
+session. The frozen calendar rule is now:
+
+1. take ordered quarantine-usable SPY provider dates;
+2. anchor on the latest date whose quarantine-usable cohort close coverage
+   reaches the candidate's predeclared floor;
+3. retain the preceding 20 SPY dates exactly, even if a middle date has poor
+   coverage, so a missing session cannot be skipped to improve an outcome.
+
+The 80% value below remains an illustrative feasibility floor rather than a
+promoted candidate parameter:
 
 | measure | observed result |
 |---|---:|
 | point-in-time members with provider industry | 4,351 |
 | completed source sessions | 21 |
-| latest quarantine-complete provider session | 2026-08-05 |
+| latest broadly complete provider session | 2026-08-10 |
+| partial later session excluded at anchor | 2026-08-11: 551 / 4,351 (12.66%) |
 | 1-session endpoint + joinable-unit coverage | 80.602% |
-| 3-session endpoint + joinable-unit coverage | 80.602% |
-| 5-session endpoint + joinable-unit coverage | 80.487% |
-| 10-session endpoint + joinable-unit coverage | 80.487% |
-| 20-session endpoint + joinable-unit coverage | 80.464% |
-| balanced 21-close/trend/unit coverage | 80.257% |
+| 3-session endpoint + joinable-unit coverage | 80.533% |
+| 5-session endpoint + joinable-unit coverage | 80.418% |
+| 10-session endpoint + joinable-unit coverage | 80.257% |
+| 20-session endpoint + joinable-unit coverage | 80.188% |
+| balanced 21-close/trend/unit coverage | 80.188% |
 | provider industries / with at least 20 members | 9 / 8 |
-| representative database load / pure calculation | 1.428s / 0.116s |
+| representative database load / pure calculation | 3.155s / 0.114s |
 
-The 2026-08-05 frontier is intentional: newer raw bars exist, but the current
-fail-closed quarantine coverage does not yet admit them. A runtime candidate
-must report this staleness and refuse rather than silently reading unchecked
-2026-08-11 bars.
+The quarantine refresh itself was healthy: its 2026-08-11 run succeeded over
+12,192 instruments. The daily-candle audit showed a subsequent orphaned run at
+11:51 UTC; its owning worker died without terminal status after incrementally
+writing the 551 rows. The session anchor prevents those rows from masquerading
+as a completed denominator. A candidate must still report the 2026-08-10
+frontier and refuse if its own staleness contract requires a later session.
 
-The unit-regime mask removed only a small fraction of members but moved the
-descriptive common-variance share from 3.45% to 5.60%. Neither value is a trade
-signal; the sensitivity demonstrates why corporate-action joins are mandatory
-before regime attribution rather than an optional cleanup after it.
+The unit-regime and corrected-session rules materially change the descriptive
+common-variance value. None of those values is a trade signal; the sensitivity
+demonstrates why corporate-action joins and completed-session identity are
+mandatory before regime attribution rather than optional cleanup afterward.
 
 ## Storage and product impact
 

--- a/scripts/verify_2523_regime_context.py
+++ b/scripts/verify_2523_regime_context.py
@@ -21,53 +21,78 @@ from app.config import settings
 from app.services.price_quarantine import RULE_SET_VERSION
 from app.services.strategy_regime_context import (
     CompletedSessionPanel,
+    ReferenceSessionCoverage,
     RegimeMember,
     measure_completed_session_regime,
+    select_completed_session_dates,
 )
 
-_SQL = """
-WITH cohort AS (
+_COHORT_CTE = """
+cohort AS (
     SELECT h.instrument_id, h.provider_industry_id
       FROM instrument_market_classification_history h
      WHERE h.effective_to IS NULL
        AND h.security_type = 'common_stock'
        AND h.primary_listing_market IN ('nyse', 'nasdaq')
        AND h.provider_industry_id IS NOT NULL
-), sessions AS (
-    -- eToro's daily bar label is not a civil NYSE date (Monday sessions can
-    -- carry a Sunday date), so a weekday filter would be wrong.  Use the
-    -- declared SPY provider series as the session calendar instead of a union
-    -- in which a handful of sparse foreign/off-calendar bars create fake
-    -- sessions.  Instrument 3000 is asserted below by the verification query.
-    SELECT p.price_date
-      FROM price_daily p
-      JOIN price_quarantine_coverage cov
-        ON cov.instrument_id = p.instrument_id
-       AND cov.rule_set_version = %(rule_set_version)s
-       AND p.price_date BETWEEN cov.first_bar AND cov.last_bar
-      LEFT JOIN price_bar_quarantine q
-        ON q.instrument_id = p.instrument_id
-       AND q.price_date = p.price_date
-       AND q.rule_set_version = %(rule_set_version)s
-     WHERE p.instrument_id = 3000
-       AND p.close > 0
-       AND COALESCE(q.return_usable, TRUE)
-       AND NOT COALESCE(q.provisional, FALSE)
-     ORDER BY p.price_date DESC
-     LIMIT 21
+)
+"""
+
+# eToro's daily bar label is not a civil NYSE date, so a weekday filter is
+# wrong. SPY supplies the ordered provider-session labels. Cross-sectional
+# coverage separately decides whether the latest label is complete enough to
+# anchor; it does not remove sparse dates from the middle of a horizon.
+_REFERENCE_SQL = f"""
+WITH {_COHORT_CTE}
+SELECT reference.price_date,
+       count(cohort_price.instrument_id) FILTER (
+           WHERE cohort_price.close > 0
+             AND cohort_cov.instrument_id IS NOT NULL
+             AND COALESCE(cohort_q.return_usable, TRUE)
+       ) AS observed_count,
+       (SELECT count(*) FROM cohort) AS expected_count
+  FROM price_daily reference
+  JOIN price_quarantine_coverage reference_cov
+    ON reference_cov.instrument_id = reference.instrument_id
+   AND reference_cov.rule_set_version = %(rule_set_version)s
+   AND reference.price_date BETWEEN reference_cov.first_bar AND reference_cov.last_bar
+  LEFT JOIN price_bar_quarantine reference_q
+    ON reference_q.instrument_id = reference.instrument_id
+   AND reference_q.price_date = reference.price_date
+   AND reference_q.rule_set_version = %(rule_set_version)s
+ CROSS JOIN cohort c
+  LEFT JOIN price_daily cohort_price
+    ON cohort_price.instrument_id = c.instrument_id
+   AND cohort_price.price_date = reference.price_date
+  LEFT JOIN price_quarantine_coverage cohort_cov
+    ON cohort_cov.instrument_id = c.instrument_id
+   AND cohort_cov.rule_set_version = %(rule_set_version)s
+   AND cohort_price.price_date BETWEEN cohort_cov.first_bar AND cohort_cov.last_bar
+  LEFT JOIN price_bar_quarantine cohort_q
+    ON cohort_q.instrument_id = c.instrument_id
+   AND cohort_q.price_date = cohort_price.price_date
+   AND cohort_q.rule_set_version = %(rule_set_version)s
+ WHERE reference.instrument_id = 3000
+   AND reference.close > 0
+   AND COALESCE(reference_q.return_usable, TRUE)
+ GROUP BY reference.price_date
+ ORDER BY reference.price_date
+"""
+
+_PANEL_SQL = f"""
+WITH {_COHORT_CTE}, sessions AS (
+    SELECT unnest(%(session_dates)s::date[]) AS price_date
 )
 SELECT c.instrument_id, c.provider_industry_id, s.price_date,
        CASE WHEN p.close > 0
                   AND cov.instrument_id IS NOT NULL
                   AND COALESCE(q.return_usable, TRUE)
-                  AND NOT COALESCE(q.provisional, FALSE)
             THEN p.close
             ELSE NULL
        END AS close,
        p.close > 0
            AND cov.instrument_id IS NOT NULL
            AND COALESCE(q.return_usable, TRUE)
-           AND NOT COALESCE(q.provisional, FALSE)
            AND tq.instrument_id IS NULL
            AND b.instrument_id IS NULL AS return_link_usable
   FROM cohort c
@@ -94,7 +119,7 @@ SELECT c.instrument_id, c.provider_industry_id, s.price_date,
 """
 
 
-def _load(conn: psycopg.Connection[Any]) -> CompletedSessionPanel:
+def _load(conn: psycopg.Connection[Any], *, minimum_session_coverage: Decimal) -> CompletedSessionPanel:
     reference = conn.execute("SELECT symbol, instrument_type_id FROM instruments WHERE instrument_id = 3000").fetchone()
     if reference != ("SPY", 6):
         raise RuntimeError(f"reference calendar identity drifted: expected SPY ETF (3000, 6), got {reference!r}")
@@ -105,10 +130,30 @@ def _load(conn: psycopg.Connection[Any]) -> CompletedSessionPanel:
     if frontiers is None:
         raise RuntimeError("could not pin price unit-regime frontiers")
     break_frontier, adjustment_frontier = frontiers
-    rows = conn.execute(_SQL, {"rule_set_version": RULE_SET_VERSION}).fetchall()
+    reference_rows = conn.execute(_REFERENCE_SQL, {"rule_set_version": RULE_SET_VERSION}).fetchall()
+    if not reference_rows:
+        raise RuntimeError("reference calendar has no quarantine-covered sessions")
+    expected_counts = {int(row[2]) for row in reference_rows}
+    if len(expected_counts) != 1:
+        raise RuntimeError(f"point-in-time cohort count changed inside one snapshot: {sorted(expected_counts)!r}")
+    expected_count = expected_counts.pop()
+    dates = select_completed_session_dates(
+        tuple(ReferenceSessionCoverage(row[0], int(row[1])) for row in reference_rows),
+        expected_count=expected_count,
+        minimum_anchor_coverage=minimum_session_coverage,
+        required_sessions=21,
+    )
+    rows = conn.execute(
+        _PANEL_SQL,
+        {
+            "rule_set_version": RULE_SET_VERSION,
+            "session_dates": list(dates),
+        },
+    ).fetchall()
     if not rows:
         raise RuntimeError("current point-in-time cohort has no usable completed-session rows")
-    dates = tuple(sorted({row[2] for row in rows}))
+    if tuple(sorted({row[2] for row in rows})) != dates:
+        raise RuntimeError("loaded panel did not preserve the selected reference sessions")
     grouped: dict[tuple[int, int], dict[date, Decimal | None]] = {}
     links: dict[tuple[int, int], dict[date, bool]] = {}
     for instrument_id, industry_id, session_date, close, return_link_usable in rows:
@@ -135,14 +180,15 @@ def _load(conn: psycopg.Connection[Any]) -> CompletedSessionPanel:
 
 
 def main() -> None:
+    minimum_coverage = Decimal("0.80")
     started = time.perf_counter()
     with psycopg.connect(settings.database_url) as conn:
         conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
-        panel = _load(conn)
+        panel = _load(conn, minimum_session_coverage=minimum_coverage)
     loaded = time.perf_counter()
     result = measure_completed_session_regime(
         panel,
-        minimum_coverage=Decimal("0.80"),
+        minimum_coverage=minimum_coverage,
         minimum_sector_members=20,
     )
     finished = time.perf_counter()
@@ -153,6 +199,7 @@ def main() -> None:
                 "formula_version": result.version,
                 "latest_completed_session": result.latest_completed_session.isoformat(),
                 "sessions": len(panel.session_dates),
+                "minimum_session_coverage": str(minimum_coverage),
                 "expected_members": result.expected_count,
                 "trend_coverage": str(result.prior_trend.coverage),
                 "common_movement": {

--- a/tests/test_strategy_regime_context.py
+++ b/tests/test_strategy_regime_context.py
@@ -9,9 +9,11 @@ import pytest
 from app.services.strategy_regime_context import (
     REGIME_VERSION,
     CompletedSessionPanel,
+    ReferenceSessionCoverage,
     RegimeMember,
     decompose_return,
     measure_completed_session_regime,
+    select_completed_session_dates,
 )
 
 
@@ -233,6 +235,52 @@ def test_unsorted_or_duplicate_sessions_are_rejected() -> None:
             _panel(_member(1, 10, _rising(100)), dates=tuple(sessions)),
             minimum_coverage=Decimal("1"),
             minimum_sector_members=2,
+        )
+
+
+def test_session_anchor_ignores_a_partial_latest_reference_date() -> None:
+    observations = tuple(
+        ReferenceSessionCoverage(session_date, 90 if index < 21 else 12)
+        for index, session_date in enumerate(_dates(22))
+    )
+    selected = select_completed_session_dates(
+        observations,
+        expected_count=100,
+        minimum_anchor_coverage=Decimal("0.8"),
+        required_sessions=21,
+    )
+    assert selected == _dates(21)
+
+
+def test_session_anchor_keeps_a_sparse_middle_reference_date() -> None:
+    observations = tuple(
+        ReferenceSessionCoverage(session_date, 10 if index == 8 else 90)
+        for index, session_date in enumerate(_dates(21))
+    )
+    selected = select_completed_session_dates(
+        observations,
+        expected_count=100,
+        minimum_anchor_coverage=Decimal("0.8"),
+        required_sessions=21,
+    )
+    assert selected == _dates(21)
+    assert selected[8] == observations[8].session_date
+
+
+def test_session_anchor_refuses_without_coverage_or_history() -> None:
+    with pytest.raises(ValueError, match="no reference session"):
+        select_completed_session_dates(
+            tuple(ReferenceSessionCoverage(day, 7) for day in _dates(21)),
+            expected_count=10,
+            minimum_anchor_coverage=Decimal("0.8"),
+            required_sessions=21,
+        )
+    with pytest.raises(ValueError, match="fewer than 22"):
+        select_completed_session_dates(
+            tuple(ReferenceSessionCoverage(day, 10) for day in _dates(21)),
+            expected_count=10,
+            minimum_anchor_coverage=Decimal("0.8"),
+            required_sessions=22,
         )
 
 


### PR DESCRIPTION
## Outcome

Corrects the live #2523 feasibility contract after auditing the apparent stale quarantine frontier.

The quarantine refresh was healthy (12,192 instruments on 2026-08-11). Two distinct semantics had been conflated:

- a recent bar marked `provisional` is not automatically an unusable close; only a stored deferred/quarantined transition invalidates the return link;
- a reference ETF carrying the latest provider date does not prove the broad cross-section is complete.

A failed incremental candle run committed 551/4,351 cohort rows for 2026-08-11 before its worker died. The new versioned pure calendar primitive anchors on the latest SPY provider session that reaches a predeclared cohort coverage floor, then retains every preceding reference session (including sparse middle dates) so it cannot skip missing evidence to improve horizons.

## Measured result

At the illustrative 80% floor:

- 2026-08-11 is correctly excluded as partial: 551/4,351 (12.66%)
- latest broad session is 2026-08-10
- 1/3/5/10/20-session coverage is 80.602/80.533/80.418/80.257/80.188%
- balanced trend/common-movement coverage is 80.188%
- no DB or UI writes

## Verification

- 18 focused tests, including partial latest date and sparse middle-session retention
- full pre-push pure suite and smoke boot
- ruff/format/pyright/frontend integrity gates
- repeatable-read live feasibility run

Refs #2523 #2240