### PR TITLE
Fix completed-session candle population watermark

### DIFF
--- a/app/services/job_progress.py
+++ b/app/services/job_progress.py
@@ -57,13 +57,20 @@ class JobProgress:
     candidates_seen: int | None = None
     outcomes: Mapping[str, int] = field(default_factory=dict)
     errors: Mapping[str, int] = field(default_factory=dict)
+    # Optional bounded provenance for aggregate population/session counters.
+    # It is omitted from the serialised shape when empty, preserving existing
+    # readers of the three axes above. The degradation verdict ignores it.
+    context: Mapping[str, object] = field(default_factory=dict)
 
     def as_json(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "candidates_seen": self.candidates_seen,
             "outcomes": dict(self.outcomes),
             "errors": dict(self.errors),
         }
+        if self.context:
+            payload["context"] = dict(self.context)
+        return payload
 
 
 def degradation_reason(progress: JobProgress | None) -> str | None:

--- a/app/services/market_calendar.py
+++ b/app/services/market_calendar.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, time, timedelta
 from types import MappingProxyType
 from typing import Literal, cast
 
@@ -209,6 +209,30 @@ def us_market_status(d: date) -> UsMarketStatus:
     if d in specials.half_days:
         return "half_day"
     return "open"
+
+
+def latest_completed_us_session(now: datetime) -> date:
+    """Return the latest NYSE session whose official close has passed.
+
+    ``now`` must be timezone-aware. The result is a New York civil date and
+    observes both full closures and 13:00 ET half-day closes. This is distinct
+    from "latest weekday": at 03:00 UTC on a Tuesday, Monday is the latest
+    completed session while Tuesday has not opened.
+    """
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("now must be timezone-aware")
+
+    from zoneinfo import ZoneInfo
+
+    local = now.astimezone(ZoneInfo("America/New_York"))
+    candidate = local.date()
+    status = us_market_status(candidate)
+    close_time = time(13, 0) if status == "half_day" else time(16, 0)
+    if status == "closed" or local.time().replace(tzinfo=None) < close_time:
+        candidate -= timedelta(days=1)
+    while us_market_status(candidate) == "closed":
+        candidate -= timedelta(days=1)
+    return candidate
 
 
 def us_market_reason(d: date) -> str | None:

--- a/app/services/market_data.py
+++ b/app/services/market_data.py
@@ -387,6 +387,7 @@ def refresh_market_data(
     skip_quotes: bool = False,
     force_backfill: bool = False,
     consecutive_failure_limit: int = _CANDLE_BATCH_ABORT_LIMIT,
+    fresh_through: date | None = None,
 ) -> MarketRefreshSummary:
     """
     For each instrument: fetch candles, upsert to price_daily, compute
@@ -414,6 +415,11 @@ def refresh_market_data(
     counts attempted fetches — a freshness-skipped instrument is neutral; a
     reachable response (clean fetch or a 404) resets the counter. Pass
     ``<= 0`` to disable the breaker (walk every instrument regardless).
+
+    ``fresh_through`` is the caller's completed provider-session boundary.
+    When omitted, the legacy weekday/date boundary remains in force. Long
+    scheduled sweeps must pass it explicitly so a pre-open retry does not
+    fetch and retain a forming same-day candle merely because UTC advanced.
 
     Raw provider responses are persisted by the provider before being returned.
 
@@ -444,6 +450,7 @@ def refresh_market_data(
     spread_flags_set = 0
 
     today = date.today()
+    freshness_target = fresh_through or most_recent_trading_day(today)
     candles_skipped = 0
     candles_failed = 0
 
@@ -469,14 +476,14 @@ def refresh_market_data(
     consecutive_systemic_failures = 0
     adjustment_refetches = 0
     for idx, (instrument_id, symbol) in enumerate(instruments, start=1):
-        if not force_backfill and _candles_are_fresh(conn, instrument_id, today):
+        if not force_backfill and _candles_are_fresh(conn, instrument_id, today, fresh_through=freshness_target):
             candles_skipped += 1
             report_progress(idx, total)
             continue
         if force_backfill:
             fetch_count = lookback_days
         else:
-            fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=today)
+            fetch_count = _candles_fetch_count(conn, instrument_id, default=lookback_days, today=freshness_target)
         upserted = 0
         computed = 0
         adjustment_detected = False
@@ -491,6 +498,13 @@ def refresh_market_data(
             last_bar_before = _last_bar(conn, instrument_id)
             with conn.transaction():
                 bars = provider.get_daily_candles(instrument_id, fetch_count)
+                if fresh_through is not None:
+                    # A pre-open/manual retry can receive a forming candle for
+                    # a civil date beyond the declared completed-session
+                    # boundary. Keep the provider response in its bounded raw
+                    # audit store, but never publish that forming value as a
+                    # daily close in price_daily (#2572).
+                    bars = [bar for bar in bars if bar.price_date <= fresh_through]
                 # #2066 split-cliff guard: provider history is back-adjusted
                 # at fetch time, so a future split re-bases every bar — but an
                 # incremental fetch only rewrites the overlap window, leaving
@@ -512,6 +526,8 @@ def refresh_market_data(
                             lookback_days,
                         )
                         bars = provider.get_daily_candles(instrument_id, lookback_days)
+                        if fresh_through is not None:
+                            bars = [bar for bar in bars if bar.price_date <= fresh_through]
                         # An empty heal re-fetch wrote nothing — a heal is
                         # only a heal if the series was actually rewritten.
                         adjustment_detected = bool(bars)
@@ -662,6 +678,8 @@ def _candles_are_fresh(
     conn: psycopg.Connection,  # type: ignore[type-arg]
     instrument_id: int,
     today: date,
+    *,
+    fresh_through: date | None = None,
 ) -> bool:
     """Return True if price_daily already has the most recent trading day's candle."""
     row = conn.execute(
@@ -675,7 +693,7 @@ def _candles_are_fresh(
     if row is None or row[0] is None:
         return False
     latest_date: date = row[0]
-    return latest_date >= most_recent_trading_day(today)
+    return latest_date >= (fresh_through or most_recent_trading_day(today))
 
 
 # Incremental fetch window in bars — yesterday + today + one

--- a/app/services/processes/watermarks.py
+++ b/app/services/processes/watermarks.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from typing import Any
 
 import psycopg
@@ -270,22 +270,45 @@ def _resolve_universe_sync_epoch(
 def _resolve_candle_offset(
     conn: psycopg.Connection[Any],
 ) -> ProcessWatermark | None:
-    """Candle refresh watermark: global MAX(price_date) FROM price_daily.
+    """Candle refresh watermark: declared completed provider session.
 
-    Spec lists ``instrument_market_data_refresh.last_synced_at`` as the
-    source, but that table does not exist in this repo — the daily
-    candle refresh writes directly to ``price_daily``. The operator
-    surface still wants a single "resume from" cursor; use the global
-    MAX so a stale sweep is visible at a glance. Per-instrument cursor
-    fan-out (which would let the resolver report "12 of 1547
-    instruments awaiting next poll") is deferred to a follow-up.
+    New candle runs checkpoint their aggregate scope/session in the existing
+    ``job_runs.progress_json`` before fetching. Prefer that declared boundary:
+    raw ``MAX(price_date)`` can be a forming or partial newest date after an
+    orphaned per-instrument-commit sweep (#2572). Legacy runs fall back to MAX.
 
-    Cursor is the ISO date string. ``last_advanced_at`` is the
-    ``price_date`` coerced to a UTC midnight so the ProcessWatermark
-    contract (TIMESTAMPTZ field) holds — ``price_daily`` does not
-    carry a writer-side updated_at.
+    Cursor is the ISO date string. New checkpoints use the run start as
+    ``last_advanced_at``; the legacy fallback coerces ``price_date`` to UTC
+    midnight because ``price_daily`` has no writer timestamp.
     """
     with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            """
+            SELECT started_at,
+                   progress_json #>> '{context,provider_session}' AS provider_session,
+                   progress_json #>> '{context,population_status}' AS population_status,
+                   progress_json #>> '{outcomes,usable}' AS usable,
+                   progress_json #>> '{candidates_seen}' AS declared
+            FROM job_runs
+            WHERE job_name = 'daily_candle_refresh'
+              AND progress_json #>> '{context,contract_version}' = 'candle-population-watermark-v1'
+            ORDER BY started_at DESC, run_id DESC
+            LIMIT 1
+            """
+        )
+        checkpoint = cur.fetchone()
+        if checkpoint is not None and checkpoint["provider_session"] is not None:
+            provider_session = date.fromisoformat(str(checkpoint["provider_session"]))
+            status = str(checkpoint["population_status"] or "unknown")
+            usable = str(checkpoint["usable"] or "0")
+            declared = str(checkpoint["declared"] or "0")
+            return ProcessWatermark(
+                cursor_kind="instrument_offset",
+                cursor_value=provider_session.isoformat(),
+                human=f"Candles {status} for {provider_session.isoformat()} ({usable}/{declared} usable)",
+                last_advanced_at=checkpoint["started_at"],
+            )
+
         cur.execute("SELECT MAX(price_date) AS max_date FROM price_daily")
         row = cur.fetchone()
     if row is None or row["max_date"] is None:

--- a/app/services/sync_orchestrator/content_predicates.py
+++ b/app/services/sync_orchestrator/content_predicates.py
@@ -9,17 +9,17 @@ chunk 7 retires that module these are the surviving content checks.
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, datetime
 from typing import Any
 
 import psycopg
 
 
 def candles_content_ok(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
-    """Every Tier 1/2 instrument must have a candle for the most recent trading day."""
-    from app.services.market_data import most_recent_trading_day
+    """Every Tier 1/2 instrument must reach the last completed US session."""
+    from app.services.market_calendar import latest_completed_us_session
 
-    trading_day = most_recent_trading_day(date.today())
+    trading_day = latest_completed_us_session(datetime.now(UTC))
     # `i.is_tradable = TRUE` matches the filter in `daily_candle_refresh`
     # (app/workers/scheduler.py). Without it, a delisted instrument that
     # still carries tier 1/2 coverage would permanently fail this

--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -18,7 +18,7 @@ BEFORE ordering would hide a newer failure behind an older success.
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import psycopg
@@ -118,11 +118,11 @@ def candles_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
     if not audit_fresh:
         return False, audit_detail
     # Content check: every T1/T2 instrument must have a candle for the
-    # most recent trading day. Per-instrument query avoids the false-pass
+    # last completed US session. Per-instrument query avoids the false-pass
     # of global MAX(price_date) when the table is uniformly stale.
-    from app.services.market_data import most_recent_trading_day
+    from app.services.market_calendar import latest_completed_us_session
 
-    trading_day = most_recent_trading_day(date.today())
+    trading_day = latest_completed_us_session(datetime.now(UTC))
     row = conn.execute(
         """
         SELECT COUNT(*) AS missing

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -20,6 +20,7 @@ catch-up-on-boot and tests.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 import time
 from collections.abc import Callable, Generator, Mapping, Sequence
@@ -62,8 +63,8 @@ from app.services.execution_guard import evaluate_recommendation
 from app.services.filings import FilingsRefreshSummary, refresh_filings, upsert_cik_mapping
 from app.services.job_progress import JobProgress, degradation_reason
 from app.services.llm_client import LLMProviderNotConfigured, make_llm_clients, release_local_models
-from app.services.market_calendar import us_market_status
-from app.services.market_data import most_recent_trading_day, refresh_market_data, refresh_quotes
+from app.services.market_calendar import latest_completed_us_session, us_market_status
+from app.services.market_data import refresh_market_data, refresh_quotes
 from app.services.mf_directory import refresh_mf_directory
 from app.services.operators import AmbiguousOperatorError, NoOperatorError, sole_operator_id
 from app.services.ops_monitor import (
@@ -2454,6 +2455,16 @@ class _JobTracker:
         self.note: str | None = None
         self.progress: JobProgress | None = None
 
+    def checkpoint_progress(self) -> None:
+        """Persist an in-flight aggregate before a long, partial-commit sweep."""
+        if self.run_id <= 0 or self.progress is None:
+            return
+        with background_write_connection(autocommit=False) as conn:
+            conn.execute(
+                "UPDATE job_runs SET progress_json = %(progress)s WHERE run_id = %(run_id)s",
+                {"progress": Jsonb(self.progress.as_json()), "run_id": self.run_id},
+            )
+
 
 def _finish_tracked(conn: psycopg.Connection[Any], tracker: _JobTracker) -> None:
     """Write the non-failure terminal row for a tracked job (#2218).
@@ -2796,8 +2807,8 @@ BENCHMARK_SYMBOLS: frozenset[str] = frozenset(
 # The maintenance predicate must stay FRESHNESS-based, never
 # existence-based: an exclusion that expires keeps the instrument in
 # scope tomorrow, an exclusion that latches makes this a seeder again.
-# `%(fresh_through)s` is `most_recent_trading_day` — the SAME boundary
-# `_candles_are_fresh` uses to decide whether to spend a request — so
+# `%(fresh_through)s` is the last officially completed US session — the SAME
+# boundary passed to `_candles_are_fresh` when deciding whether to fetch — so
 # scope membership and the per-instrument freshness skip cannot drift.
 # SUPPLY-LESS DE-PRIORITISATION (#2262). An instrument whose series has
 # not advanced on %(supply_misses)s consecutive attempted fetches stops
@@ -2861,9 +2872,10 @@ def daily_candle_refresh() -> None:
 
     Fired by the orchestrator full sync (03:00 UTC) as the ``candles``
     DataLayer — NOT the "22:00 UTC after US close" this docstring used
-    to claim; there is no ``ScheduledJob`` entry for it. See
-    ``market_data.most_recent_trading_day`` for what the earlier start
-    means for same-day bars. Watchlist scope
+    to claim; there is no ``ScheduledJob`` entry for it. The run freezes the
+    last officially completed NYSE session, so it neither requires nor stores
+    a forming same-day bar merely because the UTC civil date advanced.
+    Watchlist scope
     (spec §1.3 bullet 2) lands once the watchlist table exists
     (Phase 3.2). High-frequency held-position refresh (5-min cadence
     during market hours) is Phase 4 (live quotes).
@@ -2952,12 +2964,17 @@ def daily_candle_refresh() -> None:
             # benchmark are fetched first, so if the batch circuit-breaker
             # (#1833) trips part-way through a long T3 sweep, the scoped
             # instruments that must be current already are.
+            # The run fires at 03:00 UTC, before the same civil day's US
+            # session. A weekday label is therefore not a completed-session
+            # watermark. Freeze the official last completed NYSE session once
+            # for scope selection and the aggregate population record (#2572).
+            completed_session = latest_completed_us_session(datetime.now(UTC))
             t3_rows = conn.execute(
                 _T3_CANDLE_SELECT,
                 {
                     "limit": _T3_CANDLE_BATCH_SIZE,
                     "benchmark_symbols": sorted(BENCHMARK_SYMBOLS),
-                    "fresh_through": most_recent_trading_day(date.today()),
+                    "fresh_through": completed_session,
                     "supply_misses": _T3_SUPPLY_LESS_MISSES,
                     "supply_recheck": _T3_SUPPLY_LESS_RECHECK,
                 },
@@ -3011,6 +3028,27 @@ def daily_candle_refresh() -> None:
             )
 
             instruments = ordered
+            scope_fingerprint = hashlib.sha256(
+                ",".join(str(instrument_id) for instrument_id, _ in instruments).encode()
+            ).hexdigest()[:16]
+            watermark_context: dict[str, object] = {
+                "contract_version": "candle-population-watermark-v1",
+                "source_version": f"etoro/{settings.etoro_env}/daily-candles-v1",
+                "scope_version": "daily-candle-refresh-resolved-v1",
+                "scope_fingerprint": scope_fingerprint,
+                "provider_session": completed_session.isoformat(),
+                "population_status": "running",
+            }
+            tracker.progress = JobProgress(
+                candidates_seen=len(instruments),
+                outcomes={"attempted": 0, "successful": 0, "usable": 0, "unavailable": 0},
+                errors={"failed": 0},
+                context=watermark_context,
+            )
+            # Per-instrument commits intentionally survive a worker restart.
+            # Persist the denominator first so an orphaned sweep cannot leave
+            # partial bars with no population identity.
+            tracker.checkpoint_progress()
             # skip_quotes=True: quote freshness is owned by ``quotes_refresh``
             # (hourly @ :23, #2271) — NOT by fx_rates_refresh, which gave up
             # its batch-quote phase in #502 and which this comment named as
@@ -3018,7 +3056,47 @@ def daily_candle_refresh() -> None:
             # is still right on its own merits: a 70-minute candle sweep would
             # stamp instruments quoted at wildly different times, and the
             # instruments it touches last would carry the stalest marks.
-            summary = refresh_market_data(provider, conn, instruments, skip_quotes=True)
+            summary = refresh_market_data(
+                provider,
+                conn,
+                instruments,
+                skip_quotes=True,
+                fresh_through=completed_session,
+            )
+            usable_row = conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM (
+                    SELECT instrument_id
+                    FROM price_daily
+                    WHERE instrument_id = ANY(%(instrument_ids)s)
+                      AND price_date >= %(provider_session)s
+                    GROUP BY instrument_id
+                ) AS usable
+                """,
+                {
+                    "instrument_ids": [instrument_id for instrument_id, _ in instruments],
+                    "provider_session": completed_session,
+                },
+            ).fetchone()
+            usable = int(usable_row[0]) if usable_row is not None else 0
+            attempted = len(instruments) - summary.candles_skipped
+            successful = attempted - summary.candles_failed
+            unavailable = len(instruments) - usable
+            tracker.progress = JobProgress(
+                candidates_seen=len(instruments),
+                outcomes={
+                    "attempted": attempted,
+                    "successful": successful,
+                    "usable": usable,
+                    "unavailable": unavailable,
+                },
+                errors={"failed": summary.candles_failed},
+                context={
+                    **watermark_context,
+                    "population_status": "partial" if summary.candles_failed or unavailable else "complete",
+                },
+            )
         tracker.row_count = summary.candle_rows_upserted
 
     logger.info(

--- a/docs/proposals/ta/2026-08-12-candle-population-watermark.md
+++ b/docs/proposals/ta/2026-08-12-candle-population-watermark.md
@@ -1,0 +1,72 @@
+# Completed-session candle population watermark
+
+Issue: #2572
+
+## Finding
+
+`daily_candle_refresh` commits each instrument independently so a restart does
+not discard several hours of valid work. A later failed/orphaned run can
+therefore leave a small population on a newer `price_date`. On 2026-08-12 the
+newest date existed for 551 of the 4,351-name current US research cohort while
+the prior provider session existed for 3,508. SPY and raw `MAX(price_date)` both
+named the thin date, so neither proved population completion.
+
+The refresh also runs at 03:00 UTC. On a Tuesday that is 23:00 New York on
+Monday: Monday is complete and Tuesday has not opened. The former weekday-only
+freshness rule nevertheless named Tuesday. A manual/pre-open retry could fetch
+and publish a forming Tuesday candle as though it were a close.
+
+## Contract
+
+The run freezes `latest_completed_us_session(now)` once. The resolver uses the
+NYSE holiday calendar and official 16:00 ET regular / 13:00 ET half-day close.
+That same date controls T3 scope, per-instrument freshness and the maximum daily
+candle allowed into `price_daily` for the run. A provider response beyond the
+boundary remains in the provider's bounded raw audit path but is not published
+as a completed close.
+
+Before the long sweep, the existing `job_runs.progress_json` row is checkpointed
+with:
+
+- contract/source/scope versions and a hash of the ordered instrument IDs;
+- completed provider session and `population_status=running`;
+- declared count and zeroed attempted/successful/usable/unavailable/failed
+  counters.
+
+After the sweep, one aggregate coverage query finalises those counters. A
+worker orphan leaves the initial checkpoint beside the failed run, making the
+partial state explicit. There is no new table, migration, per-instrument
+telemetry or derived-series retention.
+
+`unavailable` is `declared - usable`; it may overlap a failed attempt because
+the usable measure is the database state at the terminal boundary, while
+failed describes this run's operation. `successful` counts clean attempted
+fetches and excludes freshness skips. These axes must not be summed.
+
+## Consumer audit
+
+| Consumer | Partial-newest-date safety | Disposition |
+|---|---|---|
+| candle T3 scope and per-instrument skip | unsafe before this change | both now share the completed-session boundary |
+| process candle watermark | unsafe global maximum | reads the aggregate checkpoint; legacy runs retain a MAX fallback |
+| orchestrator T1/T2 content gates | per-instrument, but wrong pre-open civil date | now require the last completed US session |
+| strategy signal scan | safe | already uses a modal frontier plus a frozen coverage floor |
+| completed-session regime context | safe | already selects the latest reference session meeting declared cohort coverage and preserves intervening sparse dates |
+| thesis outcomes | safe for its single-instrument maturity question | per-instrument maximum; a newer valid/partial bar merely advances that instrument |
+| market-data supply/freshness helpers | safe with explicit boundary | maxima are per instrument, and scheduled refresh now supplies the boundary |
+| scoring freshness | operational liveness only, but global newest can cause an early rerun | follow-up: compare against the declared session rather than raw MAX |
+| fair-value batch anchor | unsafe | follow-up: replace global MAX with a declared population frontier before the next batch materialisation |
+| legacy ops `prices` age | unsafe as a population/completion claim | treat as liveness-only until switched to aggregate watermark |
+
+Portfolio/T1-T2 freshness and broad research completeness remain different
+questions. This run watermark describes the resolved refresh scope; a strategy
+must still declare its own point-in-time cohort and coverage floor. It may not
+interpret a successful job, SPY presence or the aggregate full-scope ratio as
+evidence that its research population is complete.
+
+## Verification
+
+Fixtures cover 03:00 UTC, regular close, half-day close, timezone refusal,
+forming-bar exclusion, initial checkpoint ordering, exact terminal counters,
+failed-attempt accounting and the process-watermark preference over a raw
+partial maximum.

--- a/tests/test_daily_candle_refresh.py
+++ b/tests/test_daily_candle_refresh.py
@@ -19,7 +19,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.market_data import most_recent_trading_day
 from app.workers.scheduler import (
     _T3_CANDLE_BATCH_SIZE,
     _T3_SUPPLY_LESS_MISSES,
@@ -33,6 +32,7 @@ def _make_mock_conn(
     t3_rows: list[tuple[int, str]],
     held_rows: list[tuple[int, str]] | None = None,
     benchmark_rows: list[tuple[int, str]] | None = None,
+    usable_count: int = 0,
 ) -> MagicMock:
     """Mock connection that returns held_rows / tier12_rows / benchmark_rows /
     t3_rows in the order the handler executes them
@@ -46,7 +46,9 @@ def _make_mock_conn(
     result_bm.fetchall.return_value = benchmark_rows or []
     result_t3 = MagicMock()
     result_t3.fetchall.return_value = t3_rows
-    conn.execute.side_effect = [result_held, result_12, result_bm, result_t3]
+    result_usable = MagicMock()
+    result_usable.fetchone.return_value = (usable_count,)
+    conn.execute.side_effect = [result_held, result_12, result_bm, result_t3, result_usable]
     conn.__enter__ = MagicMock(return_value=conn)
     conn.__exit__ = MagicMock(return_value=False)
     return conn
@@ -122,6 +124,7 @@ class TestDailyCandleRefreshT3Bootstrap:
         """Candle refresh must pass skip_quotes=True per quote ownership rule."""
         mock_refresh = self._run([(1, "AAPL")], [])
         assert mock_refresh.call_args[1]["skip_quotes"] is True
+        assert mock_refresh.call_args[1]["fresh_through"] is not None
 
     def test_empty_t3_batch_still_refreshes_tier12(self) -> None:
         """When no T3 instruments qualify, only T1/T2 are refreshed."""
@@ -177,6 +180,7 @@ class TestDailyCandleRefreshT3Bootstrap:
             patch(_PATCHES["provider_cls"], return_value=mock_provider),
             patch(_PATCHES["connect"], return_value=mock_conn),
             patch(_PATCHES["refresh"], return_value=mock_summary),
+            patch("app.workers.scheduler.latest_completed_us_session", return_value=date(2026, 8, 10)),
         ):
             daily_candle_refresh()
 
@@ -196,7 +200,7 @@ class TestDailyCandleRefreshT3Bootstrap:
             # request. A scope predicate looser than the skip predicate
             # burns requests on instruments that are then skipped; tighter,
             # and the series it excludes never get refreshed at all.
-            "fresh_through": most_recent_trading_day(date.today()),
+            "fresh_through": date(2026, 8, 10),
             # #2262 — supply-less de-prioritisation. The exclusion EXPIRES
             # (re-probe after supply_recheck) rather than latching, so a
             # relisted or newly-supplied instrument returns to scope on its
@@ -407,6 +411,86 @@ class TestDailyCandleRefreshEmptyFetchDisambiguation:
             )
         assert any("no new bars" in r.message for r in caplog.records if r.levelname == "INFO")
         assert not any(r.levelname == "WARNING" and "FAILED" in r.message for r in caplog.records)
+
+
+def test_candle_population_watermark_is_checkpointed_before_refresh_and_finalised() -> None:
+    """#2572: an orphan keeps a declared denominator; completion adds exact coverage."""
+    # One of the two resolved instruments has the completed provider session.
+    mock_conn = _make_mock_conn([(1, "AAPL"), (2, "MSFT")], [], usable_count=1)
+    mock_provider = MagicMock()
+    mock_provider.__enter__ = MagicMock(return_value=mock_provider)
+    mock_provider.__exit__ = MagicMock(return_value=False)
+    mock_tracker = MagicMock()
+    mock_tracker.__enter__ = MagicMock(return_value=mock_tracker)
+    mock_tracker.__exit__ = MagicMock(return_value=False)
+    summary = MagicMock(
+        candle_rows_upserted=3,
+        instruments_refreshed=2,
+        features_computed=2,
+        quotes_updated=0,
+        quotes_skipped=0,
+        spread_flags_set=0,
+        candles_skipped=0,
+        candles_failed=0,
+    )
+
+    def observe_checkpoint(*args: object, **kwargs: object) -> MagicMock:
+        initial = mock_tracker.progress
+        assert initial.candidates_seen == 2
+        assert initial.context["provider_session"] == "2026-08-10"
+        assert initial.context["population_status"] == "running"
+        assert initial.outcomes == {"attempted": 0, "successful": 0, "usable": 0, "unavailable": 0}
+        return summary
+
+    with (
+        patch(_PATCHES["creds"], return_value=("key", "ukey")),
+        patch(_PATCHES["tracked"], return_value=mock_tracker),
+        patch(_PATCHES["provider_cls"], return_value=mock_provider),
+        patch(_PATCHES["connect"], return_value=mock_conn),
+        patch(_PATCHES["refresh"], side_effect=observe_checkpoint),
+        patch("app.workers.scheduler.latest_completed_us_session", return_value=date(2026, 8, 10)),
+    ):
+        daily_candle_refresh()
+
+    mock_tracker.checkpoint_progress.assert_called_once_with()
+    final = mock_tracker.progress
+    assert final.outcomes == {"attempted": 2, "successful": 2, "usable": 1, "unavailable": 1}
+    assert final.errors == {"failed": 0}
+    assert final.context["population_status"] == "partial"
+    assert len(final.context["scope_fingerprint"]) == 16
+
+
+def test_candle_population_watermark_records_failed_attempts_without_double_counting() -> None:
+    mock_conn = _make_mock_conn([(1, "AAPL"), (2, "MSFT"), (3, "GME")], [], usable_count=2)
+    mock_provider = MagicMock()
+    mock_provider.__enter__ = MagicMock(return_value=mock_provider)
+    mock_provider.__exit__ = MagicMock(return_value=False)
+    mock_tracker = MagicMock()
+    mock_tracker.__enter__ = MagicMock(return_value=mock_tracker)
+    mock_tracker.__exit__ = MagicMock(return_value=False)
+    summary = MagicMock(
+        candle_rows_upserted=1,
+        instruments_refreshed=3,
+        features_computed=1,
+        quotes_updated=0,
+        quotes_skipped=0,
+        spread_flags_set=0,
+        candles_skipped=1,
+        candles_failed=1,
+    )
+    with (
+        patch(_PATCHES["creds"], return_value=("key", "ukey")),
+        patch(_PATCHES["tracked"], return_value=mock_tracker),
+        patch(_PATCHES["provider_cls"], return_value=mock_provider),
+        patch(_PATCHES["connect"], return_value=mock_conn),
+        patch(_PATCHES["refresh"], return_value=summary),
+        patch("app.workers.scheduler.latest_completed_us_session", return_value=date(2026, 8, 10)),
+    ):
+        daily_candle_refresh()
+
+    final = mock_tracker.progress
+    assert final.outcomes == {"attempted": 2, "successful": 1, "usable": 2, "unavailable": 1}
+    assert final.errors == {"failed": 1}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_job_progress.py
+++ b/tests/test_job_progress.py
@@ -109,6 +109,18 @@ def test_progress_serialises_with_its_three_axes_intact() -> None:
     }
 
 
+def test_progress_serialises_optional_population_context_without_changing_default_shape() -> None:
+    progress = JobProgress(
+        candidates_seen=10,
+        outcomes={"usable": 8},
+        context={"provider_session": "2026-08-10", "population_status": "partial"},
+    )
+    assert progress.as_json()["context"] == {
+        "provider_session": "2026-08-10",
+        "population_status": "partial",
+    }
+
+
 def test_negative_counts_are_not_treated_as_opposites() -> None:
     """Codex ckpt-3. A negative count is nonsense in either bucket, but under
     truthiness it degraded on the error side and read as PROGRESS on the

--- a/tests/test_market_calendar_status.py
+++ b/tests/test_market_calendar_status.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime
+
+import pytest
 
 from app.api.calendar import _day_reason, _day_type
-from app.services.market_calendar import us_market_status
+from app.services.market_calendar import latest_completed_us_session, us_market_status
 
 
 class TestUsMarketStatus:
@@ -24,6 +26,23 @@ class TestUsMarketStatus:
 
     def test_normal_weekday_open(self) -> None:
         assert us_market_status(date(2026, 6, 23)) == "open"  # plain Tuesday
+
+
+class TestLatestCompletedUsSession:
+    def test_0300_utc_full_sync_names_the_prior_session(self) -> None:
+        assert latest_completed_us_session(datetime(2026, 8, 11, 3, tzinfo=UTC)) == date(2026, 8, 10)
+
+    def test_regular_session_becomes_complete_at_official_close(self) -> None:
+        assert latest_completed_us_session(datetime(2026, 8, 11, 19, 59, tzinfo=UTC)) == date(2026, 8, 10)
+        assert latest_completed_us_session(datetime(2026, 8, 11, 20, 0, tzinfo=UTC)) == date(2026, 8, 11)
+
+    def test_half_day_uses_1300_new_york_close(self) -> None:
+        assert latest_completed_us_session(datetime(2026, 11, 27, 17, 59, tzinfo=UTC)) == date(2026, 11, 25)
+        assert latest_completed_us_session(datetime(2026, 11, 27, 18, 0, tzinfo=UTC)) == date(2026, 11, 27)
+
+    def test_naive_datetime_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="timezone-aware"):
+            latest_completed_us_session(datetime(2026, 8, 11, 20, 0))
 
 
 class TestDayType:

--- a/tests/test_market_data.py
+++ b/tests/test_market_data.py
@@ -1223,6 +1223,44 @@ class TestRefreshMarketDataForceBackfill:
         assert summary.candles_failed == 0
         assert summary.candle_rows_upserted == 0
 
+    def test_completed_session_boundary_excludes_forming_future_candle(self) -> None:
+        """#2572: a retry may fetch today's forming bar; it is not a close."""
+        from unittest.mock import patch
+
+        from app.services.market_data import refresh_market_data
+
+        completed = date(2026, 8, 10)
+        provider = MagicMock()
+        provider.get_daily_candles.return_value = [
+            OHLCVBar(completed, Decimal("10"), Decimal("11"), Decimal("9"), Decimal("10.5"), 1000),
+            OHLCVBar(date(2026, 8, 11), Decimal("10.5"), Decimal("12"), Decimal("10"), Decimal("11"), 500),
+        ]
+        conn = MagicMock(autocommit=True)
+        transaction = MagicMock()
+        transaction.__enter__ = MagicMock(return_value=transaction)
+        transaction.__exit__ = MagicMock(return_value=False)
+        conn.transaction.return_value = transaction
+
+        with (
+            patch("app.services.market_data._candles_are_fresh", return_value=False),
+            patch("app.services.market_data._candles_fetch_count", return_value=3),
+            patch("app.services.market_data._last_bar", return_value=None),
+            patch("app.services.market_data._upsert_candles", return_value=1) as upsert,
+            patch("app.services.market_data._compute_and_store_features", return_value=0),
+            patch("app.services.market_data._record_supply_outcome"),
+        ):
+            summary = refresh_market_data(
+                provider,
+                conn,
+                instruments=[(42, "AAPL")],
+                skip_quotes=True,
+                fresh_through=completed,
+            )
+
+        written_bars = upsert.call_args.args[2]
+        assert [bar.price_date for bar in written_bars] == [completed]
+        assert summary.candle_rows_upserted == 1
+
     def test_fetch_exception_counted_in_candles_failed(self) -> None:
         """#1293: a candle fetch that raises increments candles_failed (the
         silent-failure signal — eToro session lapse / API outage)."""

--- a/tests/test_sync_orchestrator_freshness.py
+++ b/tests/test_sync_orchestrator_freshness.py
@@ -244,7 +244,7 @@ class TestCandlesIsFresh:
             [(now - timedelta(hours=1), "success", None, timedelta(hours=1).total_seconds()), (3,)]
         )
         monkeypatch.setattr(
-            "app.services.market_data.most_recent_trading_day",
+            "app.services.market_calendar.latest_completed_us_session",
             lambda _: date(2026, 4, 16),
         )
         fresh, detail = candles_is_fresh(conn)
@@ -257,7 +257,7 @@ class TestCandlesIsFresh:
             [(now - timedelta(hours=1), "success", None, timedelta(hours=1).total_seconds()), (0,)]
         )
         monkeypatch.setattr(
-            "app.services.market_data.most_recent_trading_day",
+            "app.services.market_calendar.latest_completed_us_session",
             lambda _: date(2026, 4, 16),
         )
         fresh, _ = candles_is_fresh(conn)

--- a/tests/test_watermark_resolver.py
+++ b/tests/test_watermark_resolver.py
@@ -239,6 +239,34 @@ def test_resolve_candle_offset_round_trip(
     assert "Resume from candles" in wm.human
 
 
+def test_resolve_candle_offset_prefers_declared_session_over_partial_price_max(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    ebull_test_conn.execute(
+        """
+        INSERT INTO job_runs (job_name, started_at, finished_at, status, progress_json)
+        VALUES (
+            'daily_candle_refresh', now(), now(), 'success',
+            '{"candidates_seen": 4351,
+              "outcomes": {"attempted": 4351, "successful": 4351, "usable": 3508, "unavailable": 843},
+              "errors": {"failed": 0},
+              "context": {"contract_version": "candle-population-watermark-v1",
+                            "provider_session": "2026-08-10", "population_status": "partial"}}'::jsonb
+        )
+        """
+    )
+    ebull_test_conn.commit()
+
+    wm = resolve_watermark(
+        ebull_test_conn,
+        process_id="daily_candle_refresh",
+        mechanism="scheduled_job",
+    )
+    assert wm is not None
+    assert wm.cursor_value == "2026-08-10"
+    assert wm.human == "Candles partial for 2026-08-10 (3508/4351 usable)"
+
+
 # ---------------------------------------------------------------------------
 # NPORT — accession cursor (n_port_ingest_log)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Outcome

Prevents a partial or forming newest daily candle date from masquerading as a completed market population.

- freezes the last officially completed NYSE session, including holidays and 13:00 ET half days
- uses that boundary for T3 scope, per-instrument freshness, and filtering forming future candles out of `price_daily`
- checkpoints one compact per-run aggregate in existing `job_runs.progress_json`: declared scope/fingerprint, provider session, attempted, successful, usable, unavailable, failed and population state
- leaves an explicit `running` checkpoint when a partial-commit sweep is orphaned
- makes the operator candle watermark prefer the declared session over raw `MAX(price_date)`
- aligns both orchestrator candle content gates to the completed session
- audits all current `MAX(price_date)` consumers and documents remaining unsafe legacy consumers

No migration, new table, per-instrument telemetry, or derived-series retention.

## Measured defect

An orphaned retry left 551/4,351 current US cohort names on 2026-08-11 while broad usable coverage reached only 2026-08-10. SPY and global `MAX(price_date)` both named the thin date. The scheduled 03:00 UTC run also previously treated the new UTC weekday as due before its US session opened.

## Verification

- 233 focused related tests passed
- full pre-push lint/format/pyright/chokepoint suite passed
- full non-DB fast test tier passed
- app/dev-DB smoke suite passed
- frontend integrity gates passed

Closes #2572.