### PR TITLE
feat(strategy): ingest bounded official Cboe VIX context

### DIFF
--- a/app/jobs/runtime.py
+++ b/app/jobs/runtime.py
@@ -75,6 +75,7 @@ from app.services.processes.param_metadata import (
 from app.services.sync_orchestrator.types import OrchestratorFenceHeld
 from app.workers.scheduler import (
     JOB_ATTRIBUTION_SUMMARY,
+    JOB_CBOE_VIX_REFRESH,
     JOB_CUSIP_EXTID_SWEEP,
     JOB_CUSIP_UNIVERSE_BACKFILL,
     JOB_DAILY_CANDLE_REFRESH,
@@ -145,6 +146,7 @@ from app.workers.scheduler import (
     CadenceKind,
     ScheduledJob,
     attribution_summary_job,
+    cboe_vix_refresh,
     compute_next_run,
     cusip_extid_sweep,
     cusip_universe_backfill,
@@ -356,6 +358,7 @@ _INVOKERS: Final[dict[str, JobInvoker]] = {
     # the frontier watermark rather than by a DAG edge. Own "strategy_scan" lane,
     # resolved from SCHEDULED_JOBS, so no MANUAL_TRIGGER_JOB_SOURCES entry.
     JOB_STRATEGY_SIGNAL_SCAN: _adapt_zero_arg(strategy_signal_scan),
+    JOB_CBOE_VIX_REFRESH: _adapt_zero_arg(cboe_vix_refresh),
     JOB_STRATEGY_HALT_FEED_REFRESH: _adapt_zero_arg(strategy_halt_feed_refresh),
     JOB_STRATEGY_INTRADAY_HARVEST: _adapt_zero_arg(strategy_intraday_harvest),
     JOB_STRATEGY_OUTCOME_RESOLUTION: _adapt_zero_arg(strategy_outcome_resolution),

--- a/app/jobs/sources.py
+++ b/app/jobs/sources.py
@@ -98,6 +98,7 @@ Lane = Literal[
     "bootstrap",
     "finra",
     "nasdaq",
+    "cboe",
     "openfigi",
 ]
 """Source-level concurrency bucket. Operator-locked decision (#1064): same-source
@@ -118,6 +119,8 @@ the rate — it does not.
 * ``nasdaq`` — Nasdaq Trader public safety feeds. The strategy halt poll has
   its own lane so a delayed public-feed request cannot starve either broker
   execution or unrelated SEC/FINRA collection.
+* ``cboe`` — one official daily VIX history request. It is separate from the
+  broker and Nasdaq lanes because those vendors share no overlap budget.
 * ``sec_rate`` — the SEC discovery/producer jobs (per-accession fetchers +
   per-issuer ingest). They serialise under one ``JobLock`` to bound job
   overlap, NOT request rate (the HTTP floor above bounds rate). #1478

--- a/app/services/cboe_vix.py
+++ b/app/services/cboe_vix.py
@@ -1,0 +1,262 @@
+"""Bounded official Cboe VIX daily-close context (#2574).
+
+The primary source is Cboe's public VIX history CSV, not a tradable eToro
+instrument and not FRED's key-gated derivative.  Only 2021 onward is retained
+in the existing research-series store.  Raw history is copyrighted Cboe data:
+it is internal decision context with source attribution, never a UI download.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from email.utils import parsedate_to_datetime
+from typing import Any, Final
+from zoneinfo import ZoneInfo
+
+import httpx
+import psycopg
+
+from app.services.watermarks import get_watermark, set_watermark
+
+VIX_HISTORY_URL: Final = "https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv"
+VIX_SOURCE_PAGE: Final = "https://www.cboe.com/tradable_products/vix/vix_historical_data"
+RETENTION_START: Final = date(2021, 1, 1)
+VENDOR: Final = "cboe"
+VENDOR_SYMBOL: Final = "VIX"
+WATERMARK_SOURCE: Final = "cboe.vix-history"
+WATERMARK_KEY: Final = "VIX"
+SOURCE_VERSION: Final = "cboe-vix-daily-close-v1"
+LICENCE: Final = "copyrighted/cboe-internal-research-citation-required"
+_EXPECTED_HEADER: Final = ("DATE", "OPEN", "HIGH", "LOW", "CLOSE")
+_NEW_YORK: Final = ZoneInfo("America/New_York")
+
+
+class VixSourceError(ValueError):
+    """The source response cannot satisfy the frozen VIX contract."""
+
+
+@dataclass(frozen=True)
+class VixBar:
+    bar_date: date
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+
+
+@dataclass(frozen=True)
+class VixRefreshReport:
+    status: str
+    retained_bars: int
+    first_bar: date | None
+    last_bar: date | None
+    response_hash: str | None
+
+
+def _positive_decimal(raw: str, *, field: str, row_number: int) -> Decimal:
+    try:
+        value = Decimal(raw.strip())
+    except (InvalidOperation, ValueError) as exc:
+        raise VixSourceError(f"row {row_number}: {field} is not decimal") from exc
+    if not value.is_finite() or value <= 0:
+        raise VixSourceError(f"row {row_number}: {field} must be finite and positive")
+    return value
+
+
+def parse_vix_history(text: str) -> tuple[VixBar, ...]:
+    """Parse the exact Cboe schema and return the bounded ascending series."""
+    reader = csv.DictReader(io.StringIO(text))
+    if tuple(reader.fieldnames or ()) != _EXPECTED_HEADER:
+        raise VixSourceError(f"unexpected header {reader.fieldnames!r}; expected {_EXPECTED_HEADER!r}")
+
+    by_date: dict[date, VixBar] = {}
+    for row_number, row in enumerate(reader, start=2):
+        if None in row or any(row.get(field) is None for field in _EXPECTED_HEADER):
+            raise VixSourceError(f"row {row_number}: ragged source row")
+        try:
+            bar_date = datetime.strptime(str(row["DATE"]).strip(), "%m/%d/%Y").date()
+        except ValueError as exc:
+            raise VixSourceError(f"row {row_number}: DATE is not MM/DD/YYYY") from exc
+        # Cboe's 1990s history contains published OHLC anomalies (for example
+        # 1992-02-11 has OPEN > HIGH).  Those rows are deliberately outside the
+        # frozen 2021+ contract: do not let irrelevant legacy data widen or
+        # prevent the bounded load.  Retained rows still receive every check.
+        if bar_date < RETENTION_START:
+            continue
+        open_ = _positive_decimal(str(row["OPEN"]), field="OPEN", row_number=row_number)
+        high = _positive_decimal(str(row["HIGH"]), field="HIGH", row_number=row_number)
+        low = _positive_decimal(str(row["LOW"]), field="LOW", row_number=row_number)
+        close = _positive_decimal(str(row["CLOSE"]), field="CLOSE", row_number=row_number)
+        if high < max(open_, close) or low > min(open_, close) or low > high:
+            raise VixSourceError(f"row {row_number}: OHLC envelope is impossible")
+        if bar_date in by_date:
+            raise VixSourceError(f"row {row_number}: duplicate DATE {bar_date.isoformat()}")
+        by_date[bar_date] = VixBar(bar_date, open_, high, low, close)
+
+    if not by_date:
+        raise VixSourceError(f"source has no rows on or after {RETENTION_START.isoformat()}")
+    return tuple(by_date[key] for key in sorted(by_date))
+
+
+def resolve_vix_close_as_known(bars: tuple[VixBar, ...], *, decision_at: datetime) -> VixBar | None:
+    """Latest close conservatively knowable at a decision timestamp.
+
+    Historical source rows have a close date but no publication timestamp.
+    Consequently a close from New York date D becomes usable only on a later
+    New York date.  This forbids same-close lookahead even for an after-close
+    decision and is conservative relative to the scheduled fetch.
+    """
+    if decision_at.tzinfo is None or decision_at.utcoffset() is None:
+        raise ValueError("decision_at must be timezone-aware")
+    decision_date = decision_at.astimezone(_NEW_YORK).date()
+    eligible = [bar for bar in bars if bar.bar_date < decision_date]
+    return eligible[-1] if eligible else None
+
+
+def load_vix_close_as_known(conn: psycopg.Connection[Any], *, decision_at: datetime) -> VixBar | None:
+    """Load the latest causally available retained VIX close."""
+    if decision_at.tzinfo is None or decision_at.utcoffset() is None:
+        raise ValueError("decision_at must be timezone-aware")
+    decision_date = decision_at.astimezone(_NEW_YORK).date()
+    row = conn.execute(
+        """
+        SELECT d.bar_date, d.open, d.high, d.low, d.close
+        FROM research_price_series s
+        JOIN research_price_daily d USING (series_id)
+        WHERE s.vendor = %(vendor)s
+          AND s.vendor_symbol = %(symbol)s
+          AND d.bar_date < %(decision_date)s
+        ORDER BY d.bar_date DESC
+        LIMIT 1
+        """,
+        {"vendor": VENDOR, "symbol": VENDOR_SYMBOL, "decision_date": decision_date},
+    ).fetchone()
+    return None if row is None else VixBar(row[0], row[1], row[2], row[3], row[4])
+
+
+def _last_modified(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = parsedate_to_datetime(value)
+    except TypeError, ValueError, OverflowError:
+        return None
+    return parsed if parsed.tzinfo is not None else None
+
+
+def refresh_cboe_vix(conn: psycopg.Connection[Any], *, client: httpx.Client) -> VixRefreshReport:
+    """Fetch once, atomically reconcile the bounded series and watermark."""
+    if not conn.autocommit:
+        raise RuntimeError("refresh_cboe_vix requires an autocommit connection")
+
+    prior = get_watermark(conn, WATERMARK_SOURCE, WATERMARK_KEY)
+    headers: dict[str, str] = {}
+    if prior is not None and prior.watermark_at is not None and prior.watermark:
+        headers["If-Modified-Since"] = prior.watermark
+    response = client.get(VIX_HISTORY_URL, headers=headers)
+    if response.status_code == 304:
+        if prior is None:
+            raise VixSourceError("Cboe returned 304 without a prior watermark")
+        with conn.transaction():
+            set_watermark(
+                conn,
+                source=WATERMARK_SOURCE,
+                key=WATERMARK_KEY,
+                watermark=prior.watermark,
+                watermark_at=prior.watermark_at,
+                response_hash=prior.response_hash,
+            )
+        return VixRefreshReport("not_modified", 0, None, None, prior.response_hash)
+    response.raise_for_status()
+
+    body_hash = hashlib.sha256(response.content).hexdigest()
+    bars = parse_vix_history(response.text)
+    modified_literal = response.headers.get("Last-Modified") or bars[-1].bar_date.isoformat()
+    modified_at = _last_modified(response.headers.get("Last-Modified"))
+
+    with conn.transaction():
+        series_row = conn.execute(
+            """
+            INSERT INTO research_price_series
+                (vendor, vendor_symbol, upstream_source, licence, adjustment_basis,
+                 first_bar, last_bar, bar_count, created_at, updated_at)
+            VALUES (%(vendor)s, %(symbol)s, 'other', %(licence)s, 'unadjusted',
+                    %(first)s, %(last)s, %(count)s, now(), now())
+            ON CONFLICT (vendor, vendor_symbol) DO UPDATE
+               SET upstream_source = EXCLUDED.upstream_source,
+                   licence = EXCLUDED.licence,
+                   adjustment_basis = EXCLUDED.adjustment_basis,
+                   first_bar = EXCLUDED.first_bar,
+                   last_bar = EXCLUDED.last_bar,
+                   bar_count = EXCLUDED.bar_count,
+                   updated_at = now()
+            RETURNING series_id
+            """,
+            {
+                "vendor": VENDOR,
+                "symbol": VENDOR_SYMBOL,
+                "licence": LICENCE,
+                "first": bars[0].bar_date,
+                "last": bars[-1].bar_date,
+                "count": len(bars),
+            },
+        ).fetchone()
+        if series_row is None:
+            raise RuntimeError("Cboe VIX series upsert returned no series_id")
+        series_id = int(series_row[0])
+        dates = [bar.bar_date for bar in bars]
+        conn.execute(
+            """
+            DELETE FROM research_price_daily
+            WHERE series_id = %(series_id)s
+              AND bar_date >= %(retention_start)s
+              AND NOT (bar_date = ANY(%(dates)s))
+            """,
+            {"series_id": series_id, "retention_start": RETENTION_START, "dates": dates},
+        )
+        with conn.cursor() as cur:
+            cur.executemany(
+                """
+                INSERT INTO research_price_daily
+                    (series_id, bar_date, open, high, low, close, volume)
+                VALUES (%s, %s, %s, %s, %s, %s, NULL)
+                ON CONFLICT (series_id, bar_date) DO UPDATE
+                   SET open = EXCLUDED.open, high = EXCLUDED.high,
+                       low = EXCLUDED.low, close = EXCLUDED.close
+                 WHERE (research_price_daily.open, research_price_daily.high,
+                        research_price_daily.low, research_price_daily.close)
+                       IS DISTINCT FROM
+                       (EXCLUDED.open, EXCLUDED.high, EXCLUDED.low, EXCLUDED.close)
+                """,
+                [(series_id, bar.bar_date, bar.open, bar.high, bar.low, bar.close) for bar in bars],
+            )
+        set_watermark(
+            conn,
+            source=WATERMARK_SOURCE,
+            key=WATERMARK_KEY,
+            watermark=modified_literal,
+            watermark_at=modified_at,
+            response_hash=body_hash,
+        )
+    return VixRefreshReport("refreshed", len(bars), bars[0].bar_date, bars[-1].bar_date, body_hash)
+
+
+__all__ = [
+    "LICENCE",
+    "RETENTION_START",
+    "SOURCE_VERSION",
+    "VIX_HISTORY_URL",
+    "VIX_SOURCE_PAGE",
+    "VixBar",
+    "VixRefreshReport",
+    "VixSourceError",
+    "load_vix_close_as_known",
+    "parse_vix_history",
+    "refresh_cboe_vix",
+    "resolve_vix_close_as_known",
+]

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -391,6 +391,8 @@ JOB_STRATEGY_INTRADAY_HARVEST = "strategy_intraday_harvest"
 # #2507 — primary-source Nasdaq halt state. Safety input only: a fresh
 # snapshot can refuse an order but can never create trading authority.
 JOB_STRATEGY_HALT_FEED_REFRESH = "strategy_halt_feed_refresh"
+# #2574 — one bounded official daily Cboe VIX context refresh.
+JOB_CBOE_VIX_REFRESH = "cboe_vix_refresh"
 # #2450 — bounded demo execution/reconciliation/owned-position health loop.
 JOB_STRATEGY_PAPER_CYCLE = "strategy_paper_cycle"
 # #2394 §3.2 — the backtest run. MANUAL-TRIGGER-ONLY, and NOT because it is
@@ -2135,6 +2137,20 @@ SCHEDULED_JOBS: list[ScheduledJob] = [
         cadence=Cadence.every_n_minutes(interval=5),
         catch_up_on_boot=False,
         prerequisite=_strategy_halt_collection_due,
+    ),
+    ScheduledJob(
+        name=JOB_CBOE_VIX_REFRESH,
+        display_name="Cboe VIX daily context (#2574)",
+        source="cboe",
+        description=(
+            "Daily 02:12 UTC — fetches Cboe official VIX daily OHLC history once, "
+            "retains only 2021 onward as an internal non-tradable research series, "
+            "and records source hash/freshness. Historical decisions may use only "
+            "a close from an earlier New York date; no rolling indicators are stored."
+        ),
+        cadence=Cadence.daily(hour=2, minute=12),
+        catch_up_on_boot=True,
+        prerequisite=_bootstrap_complete,
     ),
     ScheduledJob(
         name=JOB_STRATEGY_PAPER_CYCLE,
@@ -5276,6 +5292,25 @@ def strategy_halt_feed_refresh() -> None:
         snapshot = _refresh_strategy_halt_feed()
         tracker.row_count = len(snapshot.halts)
         tracker.note = f"source_pub_at={snapshot.source_pub_at.isoformat()} items={len(snapshot.halts)}"
+
+
+def cboe_vix_refresh() -> None:
+    """Refresh the bounded primary-source VIX regime series (#2574)."""
+    import httpx
+
+    from app.services.cboe_vix import refresh_cboe_vix
+
+    with _tracked_job(JOB_CBOE_VIX_REFRESH) as tracker:
+        with (
+            httpx.Client(timeout=20.0, follow_redirects=True) as client,
+            connect_job(autocommit=True) as conn,
+        ):
+            report = refresh_cboe_vix(conn, client=client)
+        tracker.row_count = report.retained_bars
+        tracker.note = (
+            f"status={report.status} retained={report.retained_bars} "
+            f"range={report.first_bar or '-'}..{report.last_bar or '-'}"
+        )
 
 
 def strategy_paper_cycle() -> None:

--- a/docs/etl/sources/README.md
+++ b/docs/etl/sources/README.md
@@ -38,6 +38,7 @@ CI gate: `scripts/check_etl_source_docs.sh` enforces.
 | company_tickers_exchange | [company_tickers_exchange.md](company_tickers_exchange.md) | SEC bulk reference | ticker ↔ exchange |
 | sec_13f_securities_list | [sec_13f_securities_list.md](sec_13f_securities_list.md) | SEC bulk reference | 13F Official List |
 | etoro_candles | [etoro_candles.md](etoro_candles.md) | broker REST | market data |
+| cboe_vix | [cboe_vix.md](cboe_vix.md) | Cboe public reference | volatility-regime context |
 
 ---
 
@@ -86,6 +87,7 @@ of truth. Vocabulary:
 | company_tickers_exchange | `ResilientClient` backoff | `RuntimeError` on empty body | job-level; bundled call logs-but-doesn't-raise |
 | sec_13f_securities_list | HTTP errors propagate to caller | per-row drop (CUSIP regex miss) | job-level; defensive per-row parse |
 | etoro_candles | broker retry (429 → back-off; 5xx → retry budget) | — | 401 → token refresh; per-instrument isolated |
+| cboe_vix | HTTP failure raises; scheduler records failure and retries next due/catch-up | exact-schema or invalid-OHLC rejection; transaction rolls back | 304 → benign no-op; conditional `If-Modified-Since` |
 
 ---
 

--- a/docs/etl/sources/cboe_vix.md
+++ b/docs/etl/sources/cboe_vix.md
@@ -1,0 +1,79 @@
+# cboe_vix
+
+**Class.** Cboe public reference.
+**Form / endpoint.** Official VIX daily OHLC history CSV — `https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv`.
+
+## 1. Origin
+
+Cboe's [VIX historical-data page](https://www.cboe.com/tradable_products/vix/vix_historical_data) links the public `VIX_History.csv` download and describes it as daily closing history updated daily. `app/services/cboe_vix.py` fetches that CSV directly. This is the primary Cboe source, not the key-gated FRED derivative and not an eToro futures instrument. Cboe retains copyright: eBull stores it for attributed internal research and decision context and does not expose a raw-history download.
+
+## 2. Watermarking model
+
+`external_data_watermarks` key `(source='cboe.vix-history', key='VIX')` records `Last-Modified` (or the last bar date when the header is absent), parsed modification time when supplied, and SHA-256 response hash. A later request sends `If-Modified-Since`; HTTP 304 is a successful no-op. The data table remains the authoritative retained coverage, rather than inferring freshness from a global maximum date.
+
+## 3. Retry posture
+
+HTTP errors propagate and the tracked scheduled job records a failure. The normal scheduler retry/catch-up path revisits it; there is no aggressive in-process retry against this once-daily public file. HTTP 304 is a benign no-op. An unexpected header, ragged row, duplicate date, non-positive/non-finite number, invalid date, or impossible OHLC envelope rejects the complete response before any data mutation.
+
+## 4. Bootstrap path
+
+There is no bootstrap stage and no dependency on instrument-universe completion beyond the standard bootstrap-complete prerequisite. The first scheduled catch-up loads only bars dated 2021-01-01 onward into the existing research-series store. This is about 1,400 rows in 2026, not the source's full 1990-present history.
+
+## 5. Steady-state path
+
+`JOB_CBOE_VIX_REFRESH` runs daily at 02:12 UTC on the dedicated `cboe` lane, catches up on worker boot, and performs one conditional request. It reconciles a single bounded series. The time is after the preceding US session and does not imply that a same-date close was historically observable.
+
+## 6. Manifest insert
+
+None. This is a small job-owned reference series, not an accession/document stream, so it does not create `sec_filing_manifest` rows. Source provenance and conditional-fetch state live in `research_price_series` and `external_data_watermarks` respectively.
+
+## 7. Parser
+
+`parse_vix_history` in `app/services/cboe_vix.py` requires the exact header `DATE,OPEN,HIGH,LOW,CLOSE`, parses dates as `%m/%d/%Y`, discards pre-2021 rows, then validates retained positive finite decimals and OHLC envelopes, rejects retained duplicates, and sorts ascending. Cboe's legacy file includes at least one published 1992 OHLC anomaly; it is explicitly outside the bounded contract and cannot block or widen the retained load. `SOURCE_VERSION='cboe-vix-daily-close-v1'` freezes this contract.
+
+## 8. Observation insert
+
+One `research_price_series` row uses `(vendor='cboe', vendor_symbol='VIX')`, no `instrument_id`, `upstream_source='other'`, and an explicit Cboe/internal-research licence label. `research_price_daily` stores one nullable-volume OHLC row per retained date. The natural `(series_id, bar_date)` conflict key makes refreshes idempotent; unchanged OHLC values are not rewritten. Dates removed from the bounded upstream response are reconciled within the retained range in the same transaction.
+
+## 9. Current table refresh
+
+There is no `_current` table and no stored rolling indicator. The series row carries compact first/last/count coverage. `load_vix_close_as_known` performs an indexed descending lookup and requires `bar_date < decision_at`'s New York date. Thus date D is usable only on a later New York date, conservatively preventing same-close lookahead even for after-close simulations.
+
+## 10. Operator-visible endpoint
+
+None. VIX is machine decision context, not a raw-data product. Strategy evidence may expose the source version, as-known bar date, close, derived regime feature, and refusal reason; it must not expose or redistribute the complete raw Cboe history.
+
+## 11. Verification queries
+
+```sql
+SELECT vendor, vendor_symbol, licence, first_bar, last_bar, bar_count
+FROM research_price_series
+WHERE vendor = 'cboe' AND vendor_symbol = 'VIX';
+
+SELECT d.bar_date, d.open, d.high, d.low, d.close
+FROM research_price_series s
+JOIN research_price_daily d USING (series_id)
+WHERE s.vendor = 'cboe' AND s.vendor_symbol = 'VIX'
+ORDER BY d.bar_date DESC
+LIMIT 5;
+
+SELECT source, key, watermark, watermark_at, response_hash, updated_at
+FROM external_data_watermarks
+WHERE source = 'cboe.vix-history' AND key = 'VIX';
+```
+
+Cross-check the latest row against Cboe's linked CSV. A decision on New York date D must resolve at most D-1 (or the preceding trading date), never D.
+
+Live acceptance on 2026-08-12 loaded 1,439 rows from 2021-01-04 through 2026-08-11. The retained row payload measured 92,002 bytes; the indexed as-known lookup executed in 0.417 ms on the development database. Initial-load WAL was 4,587,384 bytes, while an immediate conditional repeat returned HTTP 304 and generated 3,744 bytes of watermark WAL. The as-known resolver returned 2026-08-10 for a 2026-08-11 New York decision and 2026-08-11 for a 2026-08-12 decision.
+
+## 12. Smoke test
+
+`tests/test_cboe_vix.py` covers exact-schema rejection, numeric/OHLC validation, duplicate rejection, retention, same-date causal refusal, transactional idempotent storage, conditional requests, and the database as-known lookup. `tests/test_workers_scheduler_registry.py` covers cadence, lane, prerequisite, catch-up, and runtime invoker registration.
+
+## 13. Known gotchas
+
+1. VIX is a volatility-regime/risk context feature, not an entry signal and not a tradable eToro position.
+2. The history file has dates but no per-row publication timestamps. The resolver therefore imposes the conservative next-New-York-date availability rule.
+3. VIX levels are non-stationary. Strategy research should use causal transforms or frozen regime bands fitted only on training data, never tune thresholds over the complete evaluation period.
+4. Cboe copyright and attribution remain applicable. Do not add a raw series export or UI history dump.
+5. Keep retention bounded to 2021 onward unless a separate, evidenced research contract justifies older regimes and accounts for the storage/validation cost.

--- a/docs/etl/sources/cboe_vix.md
+++ b/docs/etl/sources/cboe_vix.md
@@ -27,6 +27,8 @@ There is no bootstrap stage and no dependency on instrument-universe completion 
 
 None. This is a small job-owned reference series, not an accession/document stream, so it does not create `sec_filing_manifest` rows. Source provenance and conditional-fetch state live in `research_price_series` and `external_data_watermarks` respectively.
 
+The raw CSV is intentionally dropped after complete normalization. Every source field in the retained contract lands as typed SQL OHLC/date data, while the response hash, URL/version and modification watermark preserve identity. This follows the explicit #470/#471 narrowing in `docs/review-prevention-log.md`: raw persistence is redundant once SQL normalization is complete. Keeping a revised full-history CSV each day would duplicate the same ~1,439 retained observations and conflict with the bounded-storage requirement.
+
 ## 7. Parser
 
 `parse_vix_history` in `app/services/cboe_vix.py` requires the exact header `DATE,OPEN,HIGH,LOW,CLOSE`, parses dates as `%m/%d/%Y`, discards pre-2021 rows, then validates retained positive finite decimals and OHLC envelopes, rejects retained duplicates, and sorts ascending. Cboe's legacy file includes at least one published 1992 OHLC anomaly; it is explicitly outside the bounded contract and cannot block or widen the retained load. `SOURCE_VERSION='cboe-vix-daily-close-v1'` freezes this contract.

--- a/tests/test_cboe_vix.py
+++ b/tests/test_cboe_vix.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import httpx
+import psycopg
+import pytest
+
+from app.services.cboe_vix import (
+    RETENTION_START,
+    VixBar,
+    VixSourceError,
+    load_vix_close_as_known,
+    parse_vix_history,
+    refresh_cboe_vix,
+    resolve_vix_close_as_known,
+)
+
+_HEADER = "DATE,OPEN,HIGH,LOW,CLOSE\n"
+
+
+def test_parser_enforces_exact_schema_and_retention() -> None:
+    bars = parse_vix_history(
+        # Cboe contains legacy OHLC anomalies, but legacy values are outside
+        # this bounded source contract and must not prevent the retained load.
+        _HEADER + "02/11/1992,19.24,18.57,17.61,17.70\n" + "01/04/2021,24,25,23,24.5\n" + "01/05/2021,25,27,24,26\n"
+    )
+    assert [bar.bar_date for bar in bars] == [RETENTION_START.replace(day=4), RETENTION_START.replace(day=5)]
+    assert bars[-1].close == Decimal("26")
+
+
+@pytest.mark.parametrize(
+    ("text", "message"),
+    [
+        ("DATE,OPEN,HIGH,LOW,SETTLE\n01/04/2021,1,1,1,1\n", "unexpected header"),
+        (_HEADER + "bad,1,1,1,1\n", "DATE is not"),
+        (_HEADER + "01/04/2021,NaN,1,1,1\n", "finite and positive"),
+        (_HEADER + "01/04/2021,2,1,1,2\n", "envelope"),
+        (_HEADER + "01/04/2021,1,1,1,1\n01/04/2021,1,1,1,1\n", "duplicate DATE"),
+        (_HEADER + "12/31/2020,1,1,1,1\n", "no rows on or after"),
+    ],
+)
+def test_parser_refuses_malformed_or_ambiguous_source(text: str, message: str) -> None:
+    with pytest.raises(VixSourceError, match=message):
+        parse_vix_history(text)
+
+
+def test_historical_close_is_not_known_on_its_own_new_york_date() -> None:
+    bars = (
+        VixBar(date(2026, 8, 10), Decimal("15"), Decimal("16"), Decimal("14"), Decimal("15.5")),
+        VixBar(date(2026, 8, 11), Decimal("16"), Decimal("17"), Decimal("15"), Decimal("16.5")),
+    )
+    same_day_after_close = datetime(2026, 8, 11, 21, tzinfo=UTC)  # 17:00 New York
+    assert resolve_vix_close_as_known(bars, decision_at=same_day_after_close) == bars[0]
+    assert resolve_vix_close_as_known(bars, decision_at=datetime(2026, 8, 12, 14, tzinfo=UTC)) == bars[1]
+
+
+def test_causal_resolver_requires_aware_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        resolve_vix_close_as_known((), decision_at=datetime(2026, 8, 12))
+
+
+def test_refresh_reconciles_one_bounded_series_and_conditional_fetch(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    body = _HEADER + "12/31/2020,22,23,21,22.5\n" + "01/04/2021,24,25,23,24.5\n" + "01/05/2021,25,27,24,26\n"
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if len(requests) == 2:
+            return httpx.Response(304, request=request)
+        return httpx.Response(
+            200,
+            text=body,
+            headers={"Last-Modified": "Wed, 06 Jan 2021 13:00:00 GMT"},
+            request=request,
+        )
+
+    ebull_test_conn.execute("DELETE FROM external_data_watermarks WHERE source = 'cboe.vix-history'")
+    ebull_test_conn.execute("DELETE FROM research_price_series WHERE vendor = 'cboe' AND vendor_symbol = 'VIX'")
+    ebull_test_conn.commit()
+    ebull_test_conn.autocommit = True
+    try:
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            first = refresh_cboe_vix(ebull_test_conn, client=client)
+            second = refresh_cboe_vix(ebull_test_conn, client=client)
+        assert first.status == "refreshed"
+        assert first.retained_bars == 2
+        assert second.status == "not_modified"
+        assert requests[1].headers["If-Modified-Since"] == "Wed, 06 Jan 2021 13:00:00 GMT"
+
+        stored = ebull_test_conn.execute(
+            """
+            SELECT s.first_bar, s.last_bar, s.bar_count, s.instrument_id,
+                   count(d.*), min(d.bar_date), max(d.bar_date)
+            FROM research_price_series s
+            JOIN research_price_daily d USING (series_id)
+            WHERE s.vendor = 'cboe' AND s.vendor_symbol = 'VIX'
+            GROUP BY s.series_id
+            """
+        ).fetchone()
+        assert stored == (date(2021, 1, 4), date(2021, 1, 5), 2, None, 2, date(2021, 1, 4), date(2021, 1, 5))
+
+        known = load_vix_close_as_known(
+            ebull_test_conn,
+            decision_at=datetime(2021, 1, 5, 15, tzinfo=UTC),
+        )
+        assert known is not None and known.bar_date == date(2021, 1, 4)
+    finally:
+        ebull_test_conn.execute("DELETE FROM external_data_watermarks WHERE source = 'cboe.vix-history'")
+        ebull_test_conn.execute("DELETE FROM research_price_series WHERE vendor = 'cboe' AND vendor_symbol = 'VIX'")
+        ebull_test_conn.autocommit = False
+        ebull_test_conn.commit()

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -87,6 +87,7 @@ _ALLOWED_SOURCES: frozenset[Lane] = frozenset(
         # one shared throttle).
         "finra",
         "nasdaq",
+        "cboe",
         # #1526 — jobs_liveness_watchdog + jobs_retry_sweeper extracted from the
         # catch-all ``db`` lane into their own single-job lanes. On ``db`` they
         # lost the ``job_source:db`` advisory-lock race to

--- a/tests/test_workers_scheduler_registry.py
+++ b/tests/test_workers_scheduler_registry.py
@@ -121,6 +121,20 @@ class TestStrategyIntradayHarvestRegistration:
         assert job.prerequisite is scheduler._strategy_intraday_collection_due
 
 
+class TestCboeVixRegistration:
+    def test_daily_bounded_refresh_is_registered_before_strategy_scan(self) -> None:
+        job = next(item for item in SCHEDULED_JOBS if item.name == scheduler.JOB_CBOE_VIX_REFRESH)
+        assert job.source == "cboe"
+        assert job.cadence == Cadence.daily(hour=2, minute=12)
+        assert job.catch_up_on_boot is True
+        assert job.prerequisite is scheduler._bootstrap_complete
+
+    def test_manual_invoker_is_registered(self) -> None:
+        from app.jobs.runtime import _INVOKERS
+
+        assert scheduler.JOB_CBOE_VIX_REFRESH in _INVOKERS
+
+
 # ---------------------------------------------------------------------------
 # Daily candle job registration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Outcome

Adds the missing official VIX regime context as one bounded, non-tradable research series. This is context and a possible risk/refusal input; it does not create a signal or promote a strategy.

Closes #2574.

## Contract

- primary source: Cboe's public daily `VIX_History.csv`; source page, copyright/attribution and internal-only use documented
- retain only 2021 onward in existing `research_price_series` / `research_price_daily`; no migration or derived-indicator warehouse
- exact retained-row schema, decimal and OHLC validation; published legacy anomaly remains outside the frozen retention contract
- date D close becomes usable only on a later New York date, preventing same-close lookahead
- daily 02:12 UTC conditional request on a separate Cboe lane; 304 is a successful no-op
- hash/Last-Modified watermark, atomic idempotent reconciliation, runtime invoker and operator job visibility

## Live acceptance (development DB, 2026-08-12)

- official response: 1,439 retained rows, 2021-01-04 through 2026-08-11
- retained row payload: 92,002 bytes
- first-load WAL: 4,587,384 bytes; immediate 304 repeat: 3,744 bytes
- causal lookup: 0.417 ms
- 2026-08-11 decision resolved 2026-08-10; 2026-08-12 resolved 2026-08-11
- latest Cboe close cross-check: 2026-08-11 = 15.28

## Verification

- full `.githooks/pre-push`: green (ruff, pyright, structural data gates, fast suite, app-boot smoke, frontend integrity gates)
- focused VIX tests: 10 passed
- scheduler/runtime/job registry suite: passed
- ETL docs lint: clean, 25 sources
