### PR TITLE
feat(strategy): attach causal VIX decision provenance

### DIFF
--- a/app/services/strategy_decision_context.py
+++ b/app/services/strategy_decision_context.py
@@ -11,13 +11,17 @@ from __future__ import annotations
 import hashlib
 import inspect
 from dataclasses import asdict, dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any, Final, Literal
 from zoneinfo import ZoneInfo
 
 import psycopg
 import psycopg.rows
+
+from app.services.cboe_vix import SOURCE_VERSION as CBOE_VIX_SOURCE_VERSION
+from app.services.cboe_vix import load_vix_close_as_known
+from app.services.market_calendar import us_market_status
 
 SecurityType = Literal["common_stock", "etf", "other", "unknown"]
 ListingMarket = Literal["nyse", "nasdaq", "other", "unknown"]
@@ -39,6 +43,8 @@ class ContextDefinition:
     sector_semantics: str = "provider_stocks_industry_not_gics"
     sector_source: str = "prospective_instrument_market_classification_history"
     eligible_price_bases: tuple[str, ...] = ("observed_unadjusted", "reconstructed_unadjusted")
+    vix_source_version: str = CBOE_VIX_SOURCE_VERSION
+    vix_availability: str = "prior_new_york_session_only"
 
 
 DEFINITION: Final = ContextDefinition()
@@ -46,7 +52,7 @@ DEFINITION: Final = ContextDefinition()
 
 def _version() -> str:
     payload = repr(DEFINITION) + inspect.getsource(price_band_for) + inspect.getsource(dollar_volume_band_for)
-    return "decision-context-v2:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
+    return "decision-context-v3:" + hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
 def price_band_for(price: Decimal) -> PriceBand:
@@ -92,6 +98,21 @@ class MarketClassification:
 
 
 @dataclass(frozen=True)
+class DecisionVix:
+    close: Decimal | None
+    bar_date: date | None
+    source_version: str | None
+    refusal_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        complete = self.close is not None and self.bar_date is not None and bool(self.source_version)
+        if complete == (self.refusal_reason is not None):
+            raise ValueError("VIX context must be either complete or carry one refusal reason")
+        if self.close is not None and (not self.close.is_finite() or self.close <= 0):
+            raise ValueError("VIX close must be finite and positive")
+
+
+@dataclass(frozen=True)
 class DecisionInputs:
     as_traded_price: Decimal | None
     as_traded_price_basis: AsTradedPriceBasis | None
@@ -106,7 +127,7 @@ class DecisionInputs:
     realised_volatility: Decimal | None
     gap_pct: Decimal | None
     market_sector_residual_z: Decimal | None
-    vix: Decimal | None
+    vix: DecisionVix | None
 
 
 @dataclass(frozen=True)
@@ -142,6 +163,8 @@ class DecisionContext:
     gap_pct: Decimal | None
     market_sector_residual_z: Decimal | None
     vix: Decimal | None
+    vix_bar_date: date | None
+    vix_source_version: str | None
 
 
 _REQUIRED_INPUTS: Final = (
@@ -158,8 +181,27 @@ _REQUIRED_INPUTS: Final = (
     "realised_volatility",
     "gap_pct",
     "market_sector_residual_z",
-    "vix",
 )
+
+
+def _prior_us_session(decision_at: datetime) -> date:
+    candidate = decision_at.astimezone(_NEW_YORK).date() - timedelta(days=1)
+    while us_market_status(candidate) == "closed":
+        candidate -= timedelta(days=1)
+    return candidate
+
+
+def load_decision_vix(conn: psycopg.Connection[Any], *, decision_at: datetime) -> DecisionVix:
+    """Resolve the exact prior-session Cboe close or a typed refusal."""
+    if decision_at.tzinfo is None or decision_at.utcoffset() is None:
+        raise ValueError("decision_at must be timezone-aware")
+    expected = _prior_us_session(decision_at)
+    bar = load_vix_close_as_known(conn, decision_at=decision_at)
+    if bar is None:
+        return DecisionVix(None, None, None, "missing_source")
+    if bar.bar_date != expected:
+        return DecisionVix(None, None, None, f"stale_source:{bar.bar_date.isoformat()}<expected:{expected.isoformat()}")
+    return DecisionVix(bar.close, bar.bar_date, CBOE_VIX_SOURCE_VERSION)
 
 
 def load_market_classification(
@@ -226,7 +268,6 @@ def build_decision_context(
         "relative_volume",
         "spread_bps",
         "realised_volatility",
-        "vix",
     ):
         value = getattr(inputs, name)
         if value is not None and value < 0:
@@ -237,6 +278,10 @@ def build_decision_context(
             raise ValueError(f"{name} must be inside 0-1")
 
     missing: list[str] = [name for name in _REQUIRED_INPUTS if getattr(inputs, name) is None]
+    if inputs.vix is None:
+        missing.append("vix")
+    elif inputs.vix.refusal_reason is not None:
+        missing.append(f"vix_{inputs.vix.refusal_reason}")
     if inputs.as_traded_price_basis == "unknown":
         missing.append("as_traded_price_basis")
     if classification is None:
@@ -289,7 +334,9 @@ def build_decision_context(
         realised_volatility=inputs.realised_volatility,
         gap_pct=inputs.gap_pct,
         market_sector_residual_z=inputs.market_sector_residual_z,
-        vix=inputs.vix,
+        vix=None if inputs.vix is None else inputs.vix.close,
+        vix_bar_date=None if inputs.vix is None else inputs.vix.bar_date,
+        vix_source_version=None if inputs.vix is None else inputs.vix.source_version,
     )
 
 
@@ -306,7 +353,8 @@ _INSERT_CONTEXT = """
         trailing_median_dollar_volume, dollar_volume_band,
         zero_volume_frequency, intraday_coverage,
         relative_volume, spread_bps, realised_volatility,
-        gap_pct, market_sector_residual_z, vix
+        gap_pct, market_sector_residual_z, vix, vix_bar_date,
+        vix_source_version
     ) VALUES (
         %(strategy_id)s, %(strategy_version)s, %(instrument_id)s, %(decision_at)s, %(signal_id)s,
         %(candidate_verdict)s, %(refusal_reason)s, %(context_version)s,
@@ -319,7 +367,8 @@ _INSERT_CONTEXT = """
         %(trailing_median_dollar_volume)s, %(dollar_volume_band)s,
         %(zero_volume_frequency)s, %(intraday_coverage)s,
         %(relative_volume)s, %(spread_bps)s, %(realised_volatility)s,
-        %(gap_pct)s, %(market_sector_residual_z)s, %(vix)s
+        %(gap_pct)s, %(market_sector_residual_z)s, %(vix)s, %(vix_bar_date)s,
+        %(vix_source_version)s
     )
     RETURNING context_id
 """
@@ -338,10 +387,12 @@ __all__ = [
     "CONTEXT_VERSION",
     "DecisionContext",
     "DecisionInputs",
+    "DecisionVix",
     "MarketClassification",
     "build_decision_context",
     "dollar_volume_band_for",
     "load_market_classification",
+    "load_decision_vix",
     "price_band_for",
     "store_decision_context",
 ]

--- a/docs/etl/sources/cboe_vix.md
+++ b/docs/etl/sources/cboe_vix.md
@@ -43,7 +43,7 @@ There is no `_current` table and no stored rolling indicator. The series row car
 
 ## 10. Operator-visible endpoint
 
-None. VIX is machine decision context, not a raw-data product. Strategy evidence may expose the source version, as-known bar date, close, derived regime feature, and refusal reason; it must not expose or redistribute the complete raw Cboe history.
+None. VIX is machine decision context, not a raw-data product. `load_decision_vix` resolves the exact prior-NYSE-session close into `DecisionVix`; eligible fired/refused context rows snapshot only `vix`, `vix_bar_date` and `vix_source_version`. Missing or stale coverage produces a typed refusal. Strategy evidence may expose those provenance fields and the refusal reason; it must not expose or redistribute the complete raw Cboe history.
 
 ## 11. Verification queries
 
@@ -67,6 +67,8 @@ WHERE source = 'cboe.vix-history' AND key = 'VIX';
 Cross-check the latest row against Cboe's linked CSV. A decision on New York date D must resolve at most D-1 (or the preceding trading date), never D.
 
 Live acceptance on 2026-08-12 loaded 1,439 rows from 2021-01-04 through 2026-08-11. The retained row payload measured 92,002 bytes; the indexed as-known lookup executed in 0.417 ms on the development database. Initial-load WAL was 4,587,384 bytes, while an immediate conditional repeat returned HTTP 304 and generated 3,744 bytes of watermark WAL. The as-known resolver returned 2026-08-10 for a 2026-08-11 New York decision and 2026-08-11 for a 2026-08-12 decision.
+
+Decision-context acceptance on 2026-08-12 resolved close 15.28 / bar 2026-08-11 / source `cboe-vix-daily-close-v1` from the live store. The two added provenance scalars measure 28 bytes over an all-null composite fixture (52 versus 24 bytes), are written only on fired/refused decisions, add no index, and left the empty context table at 49,152 bytes. The follow-up constraint migration generated 12,096 WAL bytes; the live lookup measured 1.44 ms on that run.
 
 ## 12. Smoke test
 

--- a/docs/proposals/ta/2026-08-12-cboe-vix-decision-context.md
+++ b/docs/proposals/ta/2026-08-12-cboe-vix-decision-context.md
@@ -1,0 +1,18 @@
+# Cboe VIX decision-context result
+
+Issues: #2577, #2523, #2507. Source ingestion: #2574 / PR #2576.
+
+## Result
+
+The official bounded Cboe daily series is now a causally loadable regime input, not merely an available dataset. A strategy decision receives exactly one of:
+
+- a complete close, as-known bar date and frozen source version for the prior NYSE session; or
+- a named `missing_source` / `stale_source` refusal.
+
+Date D is excluded on all decisions made on New York date D, including after the close. Weekends and NYSE holidays resolve to the previous open session. A context identity bump to `decision-context-v3` makes the new availability semantics explicit. Database constraints require eligible v3 rows to carry the complete VIX triplet and preserve v2/v3 point-in-time sector completeness.
+
+## Storage and scope
+
+No rolling VIX indicators, raw-history versions, new index, routine not-fired rows or per-instrument VIX copies are added. Only fired/refused candidate contexts may store the two new provenance scalars beside the existing numeric value. On the development database the pair measured 28 marginal bytes in a composite fixture; the empty table remained 49,152 bytes after migration.
+
+This closes a context-integrity gap. It does not turn VIX into a directional signal, repair a rejected candidate, add a capital candidate, or authorise the four harness controls to trade.

--- a/sql/329_strategy_decision_vix_provenance.sql
+++ b/sql/329_strategy_decision_vix_provenance.sql
@@ -1,0 +1,28 @@
+-- #2577 / #2523 — a VIX number without its as-known date and source identity
+-- is not auditable decision context.  Add two compact scalars only to the
+-- fired/refused context table; rolling values remain in the bounded Cboe store.
+
+ALTER TABLE strategy_decision_contexts
+    ADD COLUMN IF NOT EXISTS vix_bar_date DATE,
+    ADD COLUMN IF NOT EXISTS vix_source_version TEXT;
+
+ALTER TABLE strategy_decision_contexts
+    ADD CONSTRAINT strategy_decision_context_v3_vix_complete
+    CHECK (
+        context_version NOT LIKE 'decision-context-v3:%'
+        OR candidate_verdict = 'refused'
+        OR (
+            vix IS NOT NULL
+            AND vix_bar_date IS NOT NULL
+            AND vix_source_version IS NOT NULL
+            AND vix_source_version <> ''
+        )
+    );
+
+COMMENT ON COLUMN strategy_decision_contexts.vix_bar_date IS
+    'Cboe VIX close date causally available at this fired/refused decision. '
+    'Decision-context-v3 eligibility requires the prior NYSE session.';
+
+COMMENT ON COLUMN strategy_decision_contexts.vix_source_version IS
+    'Frozen source/parser contract that produced vix and vix_bar_date; no '
+    'rolling VIX feature history is copied into decision contexts.';

--- a/sql/330_strategy_decision_v3_sector_complete.sql
+++ b/sql/330_strategy_decision_v3_sector_complete.sql
@@ -1,0 +1,17 @@
+-- #2577 — migration 328 scoped prospective-sector completeness to context v2.
+-- Carry that existing invariant over the v3 identity bump; a new context
+-- version must never silently shed a prior eligibility requirement.
+
+ALTER TABLE strategy_decision_contexts
+    DROP CONSTRAINT strategy_decision_context_v2_sector_complete;
+
+ALTER TABLE strategy_decision_contexts
+    ADD CONSTRAINT strategy_decision_context_v2_v3_sector_complete
+    CHECK (
+        candidate_verdict = 'refused'
+        OR (
+            context_version NOT LIKE 'decision-context-v2:%'
+            AND context_version NOT LIKE 'decision-context-v3:%'
+        )
+        OR provider_industry_id IS NOT NULL
+    );

--- a/sql/331_strategy_decision_vix_triplet.sql
+++ b/sql/331_strategy_decision_vix_triplet.sql
@@ -1,0 +1,20 @@
+-- #2577 — mirror DecisionVix's complete-or-refused shape at the database
+-- boundary.  Refused v3 rows carry either the complete observed triplet or
+-- three NULLs plus their named refusal; partial provenance is never valid.
+
+ALTER TABLE strategy_decision_contexts
+    ADD CONSTRAINT strategy_decision_context_v3_vix_triplet
+    CHECK (
+        context_version NOT LIKE 'decision-context-v3:%'
+        OR (
+            vix IS NULL
+            AND vix_bar_date IS NULL
+            AND vix_source_version IS NULL
+        )
+        OR (
+            vix IS NOT NULL
+            AND vix_bar_date IS NOT NULL
+            AND vix_source_version IS NOT NULL
+            AND vix_source_version <> ''
+        )
+    );

--- a/tests/test_strategy_decision_context.py
+++ b/tests/test_strategy_decision_context.py
@@ -11,9 +11,11 @@ from app.services.instrument_market_classification import reconcile_instrument_m
 from app.services.strategy_decision_context import (
     CONTEXT_VERSION,
     DecisionInputs,
+    DecisionVix,
     MarketClassification,
     build_decision_context,
     dollar_volume_band_for,
+    load_decision_vix,
     load_market_classification,
     price_band_for,
     store_decision_context,
@@ -35,7 +37,11 @@ def _complete_inputs(**overrides: object) -> DecisionInputs:
         "realised_volatility": Decimal("0.32"),
         "gap_pct": Decimal("-2.1"),
         "market_sector_residual_z": Decimal("-2.7"),
-        "vix": Decimal("19.2"),
+        "vix": DecisionVix(
+            Decimal("19.2"),
+            date(2026, 8, 7),
+            "cboe-vix-daily-close-v1",
+        ),
         "as_traded_price_basis": "observed_unadjusted",
     }
     values.update(overrides)
@@ -50,7 +56,7 @@ def test_boundaries_are_explicit_and_stable() -> None:
     assert price_band_for(Decimal("150")) == "150_plus"
     assert dollar_volume_band_for(Decimal("9999999")) == "1m_to_10m"
     assert dollar_volume_band_for(Decimal("10000000")) == "10m_to_25m"
-    assert CONTEXT_VERSION.startswith("decision-context-v2:")
+    assert CONTEXT_VERSION.startswith("decision-context-v3:")
 
 
 def test_complete_context_is_eligible() -> None:
@@ -76,6 +82,9 @@ def test_complete_context_is_eligible() -> None:
     assert context.as_traded_price_basis == "observed_unadjusted"
     assert context.dollar_volume_band == "10m_to_25m"
     assert context.volume_lookback_sessions == 20
+    assert context.vix == Decimal("19.2")
+    assert context.vix_bar_date == date(2026, 8, 7)
+    assert context.vix_source_version == "cboe-vix-daily-close-v1"
 
 
 def test_missing_or_unknown_point_in_time_data_refuses_by_name() -> None:
@@ -118,6 +127,33 @@ def test_missing_point_in_time_sector_refuses_instead_of_using_current_metadata(
     )
     assert context.candidate_verdict == "refused"
     assert context.refusal_reason == "missing:provider_industry_id"
+
+
+def test_stale_vix_refuses_by_provenance_reason() -> None:
+    context = build_decision_context(
+        strategy_id="candidate-1",
+        strategy_version="sha256:abc",
+        instrument_id=1,
+        decision_at=datetime(2026, 8, 11, 14, 35, tzinfo=UTC),
+        signal_id=None,
+        classification=MarketClassification(
+            effective_from=date(2026, 8, 10),
+            security_type="common_stock",
+            primary_listing_market="nasdaq",
+            provider_exchange_id="4",
+            instrument_type_id=5,
+            provider_industry_id=8,
+        ),
+        inputs=_complete_inputs(vix=DecisionVix(None, None, None, "stale_source:2026-08-07<expected:2026-08-10")),
+    )
+    assert context.candidate_verdict == "refused"
+    assert context.refusal_reason == "missing:vix_stale_source:2026-08-07<expected:2026-08-10"
+    assert context.vix is None and context.vix_bar_date is None
+
+
+def test_partial_vix_provenance_is_invalid() -> None:
+    with pytest.raises(ValueError, match="either complete"):
+        DecisionVix(Decimal("19"), None, "cboe-vix-daily-close-v1")
 
 
 def test_adjusted_or_unproven_price_basis_refuses_cohort_attribution() -> None:
@@ -177,6 +213,61 @@ def _seed_instrument(conn: psycopg.Connection[tuple[Any, ...]], iid: int) -> Non
         """,
         (iid, f"CTX{iid}"),
     )
+
+
+def _seed_vix(conn: psycopg.Connection[tuple[Any, ...]], *bars: tuple[date, Decimal]) -> None:
+    row = conn.execute(
+        """
+        INSERT INTO research_price_series (
+            vendor, vendor_symbol, upstream_source, licence, adjustment_basis,
+            first_bar, last_bar, bar_count
+        ) VALUES ('cboe', 'VIX', 'other', 'fixture', 'unadjusted', %s, %s, %s)
+        RETURNING series_id
+        """,
+        (bars[0][0], bars[-1][0], len(bars)),
+    ).fetchone()
+    assert row is not None
+    with conn.cursor() as cur:
+        cur.executemany(
+            """
+            INSERT INTO research_price_daily (series_id, bar_date, open, high, low, close)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            """,
+            [(row[0], when, close, close, close, close) for when, close in bars],
+        )
+
+
+@pytest.mark.integration
+def test_vix_loader_requires_exact_prior_nyse_session_and_ignores_same_day(
+    ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
+) -> None:
+    conn = ebull_test_conn
+    _seed_vix(
+        conn,
+        (date(2026, 8, 7), Decimal("17")),
+        (date(2026, 8, 10), Decimal("18")),
+    )
+
+    # Monday resolves Friday, both before and after Monday's close. The
+    # same-date Monday source row cannot leak into either decision.
+    before_close = load_decision_vix(conn, decision_at=datetime(2026, 8, 10, 15, tzinfo=UTC))
+    after_close = load_decision_vix(conn, decision_at=datetime(2026, 8, 10, 22, tzinfo=UTC))
+    assert before_close == after_close == DecisionVix(Decimal("17"), date(2026, 8, 7), "cboe-vix-daily-close-v1")
+
+    tuesday = load_decision_vix(conn, decision_at=datetime(2026, 8, 11, 15, tzinfo=UTC))
+    assert tuesday == DecisionVix(Decimal("18"), date(2026, 8, 10), "cboe-vix-daily-close-v1")
+
+
+@pytest.mark.integration
+def test_vix_loader_returns_typed_stale_refusal(
+    ebull_test_conn: psycopg.Connection[tuple[Any, ...]],  # noqa: F811
+) -> None:
+    _seed_vix(ebull_test_conn, (date(2026, 8, 7), Decimal("17")))
+    result = load_decision_vix(
+        ebull_test_conn,
+        decision_at=datetime(2026, 8, 11, 15, tzinfo=UTC),
+    )
+    assert result == DecisionVix(None, None, None, "stale_source:2026-08-07<expected:2026-08-10")
 
 
 @pytest.mark.integration
@@ -303,15 +394,42 @@ def test_context_round_trip_and_database_completeness_guard(
     context_id = store_decision_context(conn, context)
     assert context_id > 0
     stored_basis = conn.execute(
-        "SELECT as_traded_price_basis FROM strategy_decision_contexts WHERE context_id = %s",
+        """
+        SELECT as_traded_price_basis, vix, vix_bar_date, vix_source_version
+        FROM strategy_decision_contexts WHERE context_id = %s
+        """,
         (context_id,),
     ).fetchone()
-    assert stored_basis == ("observed_unadjusted",)
+    assert stored_basis == (
+        "observed_unadjusted",
+        Decimal("19.2"),
+        date(2026, 8, 7),
+        "cboe-vix-daily-close-v1",
+    )
 
     with pytest.raises(psycopg.errors.CheckViolation):
         with conn.transaction():
             conn.execute(
                 "UPDATE strategy_decision_contexts SET provider_industry_id = NULL WHERE context_id = %s",
+                (context_id,),
+            )
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with conn.transaction():
+            conn.execute(
+                "UPDATE strategy_decision_contexts SET vix_bar_date = NULL WHERE context_id = %s",
+                (context_id,),
+            )
+
+    with pytest.raises(psycopg.errors.CheckViolation):
+        with conn.transaction():
+            conn.execute(
+                """
+                UPDATE strategy_decision_contexts
+                   SET candidate_verdict = 'refused', refusal_reason = 'fixture',
+                       vix_bar_date = NULL
+                 WHERE context_id = %s
+                """,
                 (context_id,),
             )
 


### PR DESCRIPTION
## Outcome

Consumes #2574's official bounded Cboe series in the compact candidate context. A VIX number cannot make a decision eligible without its causal bar date and frozen source identity.

Closes #2577. Advances #2523 and #2507.

## Contract

- `DecisionVix` is either a complete close/date/source triplet or a typed missing/stale refusal
- loader requires the exact prior NYSE session, including weekends/holidays
- date D is excluded from every New York date-D decision, including after close
- decision identity bumps to v3; missing/stale VIX refuses rather than becoming zero
- database requires v3 eligible triplet completeness and forbids partial triplets even on refused rows
- v2/v3 point-in-time sector completeness remains enforced across the identity bump
- only two compact provenance scalars join existing fired/refused contexts; no index, rolling feature history, not-fired rows or instrument copies

## Dev acceptance (2026-08-12)

- live resolution: close 15.28, bar 2026-08-11, `cboe-vix-daily-close-v1`
- context table rows: 0; relation size stayed 49,152 bytes after migration
- provenance pair fixture: 52 bytes complete vs 24 bytes all-null (28 marginal bytes)
- live lookup: 1.44 ms on measured run
- constraint follow-up migration: 12,096 WAL bytes
- migrations 329/330/331 applied with content hashes verified exactly against files

## Verification

- focused source/context/schema/app-boot suite: 31 passed
- context + schema regression after final triplet constraint: 16 passed
- full `.githooks/pre-push`: green (ruff, pyright, structural data gates, full fast suite, app-boot smoke, frontend integrity)
