### PR TITLE
docs(strategy): refuse unsupported live ORB discovery

### DIFF
--- a/docs/proposals/ta/2026-08-10-opening-range-stocks-in-play-data-contract.md
+++ b/docs/proposals/ta/2026-08-10-opening-range-stocks-in-play-data-contract.md
@@ -1,9 +1,9 @@
 # Opening-range / Stocks-in-Play replication contract
 
 Date: 2026-08-10  
-Status: published rule transcribed; measurement refused until the selection
-universe and execution observations below exist  
-Issues: #2485, #2477, #2508
+Status: delayed research measurement remains blocked on #2520; live execution
+is refused after the no-subscription source audit in #2521
+Issues: #2485, #2477, #2508, #2520, #2521
 
 ## Decision
 
@@ -85,11 +85,22 @@ Missing for an honest ORB test:
 - a confirmed all-stock ATR implementation and an as-traded corporate-action
   bridge for nominal price/ATR/volume comparability.
 
-The current collector cannot close the cross-sectional gap. eToro's candle API
-is one instrument per request and the client is deliberately limited to about
-55 reads/minute. Scanning even the currently classified 6,083 NYSE/Nasdaq common
-stocks would take about 111 minutes before retries, far beyond a 09:35 decision.
-The rates endpoint batches quotes but does not provide opening volume.
+The current collector cannot close the cross-sectional gap. eToro's official
+candle contract is one instrument per request. Its current documented
+market-data quota is 120 requests per 60 seconds, shared by candles, rates,
+instrument metadata and search. Scanning even the currently classified 6,083
+NYSE/Nasdaq common stocks therefore has a theoretical lower bound of about 51
+minutes before latency, other market-data calls, retries and validation, far
+beyond a 09:35 decision. The rates endpoint batches up to 100 instruments but
+provides bid, ask, last execution and margin/conversion fields, not volume. The
+WebSocket instrument topic carries the same price family and no volume.
+
+The separate #2521 audit found no documented bulk candle, opening-volume,
+screener or market-mover endpoint. Personalized market recommendations return
+only a list of instrument IDs and publish neither a complete cross-section nor
+a reproducible volume ranking. They are not a Stocks-in-Play input. See
+`2026-08-12-free-live-opening-volume-source-result.md` for the evidence and
+refusal.
 
 ## Free-data feasibility and its boundary
 
@@ -100,8 +111,10 @@ past, with history since 2016 and a 200-request/minute limit. SIP combines the
 CTA/NYSE and UTP/Nasdaq feeds; raw minute bars include OHLCV. This makes a
 **delayed historical replication feed** worth a separate credentialed spike. It
 does not solve live 09:35 discovery: free real-time equities are IEX-only, a
-small and non-comparable slice of consolidated US volume, while current SIP is
-delayed.
+single-exchange and non-comparable slice of consolidated US volume, while
+current SIP is delayed. Alpaca's current official pages are inconsistent about
+the free historical entitlement, so #2520 must prove the exact account response
+with credentials before any implementation assumes access.
 
 Accordingly:
 
@@ -110,6 +123,11 @@ Accordingly:
 - Alpaca volume must never be mixed with eToro volume under one source label;
 - a delayed research result cannot be described as a real-time executable path;
 - no subscription will be purchased or assumed.
+
+No demo order may be emitted from this candidate until a later version proves a
+complete decision-time discovery source. A positive delayed backtest would
+justify continued prospective observation; it would not clear this execution
+refusal.
 
 ## Bounded storage design
 

--- a/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
+++ b/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
@@ -82,7 +82,7 @@ stale quote, unknown shortability or an uneconomic bracket.
 
 | family | observable mechanism | exact data need | current decision |
 | --- | --- | --- | --- |
-| Stocks-in-Play opening-range breakout | abnormal opening participation followed by a first-range break | full-market opening 5-minute volume, selected intraday paths, quotes and shortability | exact contract frozen in #2485; eight-name imitation refused; free delayed/realtime source work in #2520/#2521 |
+| Stocks-in-Play opening-range breakout | abnormal opening participation followed by a first-range break | full-market opening 5-minute volume, selected intraday paths, quotes and shortability | exact contract frozen in #2485; eight-name imitation refused; #2521 found no qualifying free live discovery source, while delayed-history access remains unproved in #2520 |
 | 30-minute residual reversal | provide liquidity against an extreme stock-specific move after removing intraday factors | broad, continuously covered bid/ask midpoints and factor cross-section | exact replication in #2484; collect prospectively, do not substitute candles |
 | same-clock intraday continuation | a stock's return in one half-hour predicts the same half-hour on later days | broad half-hour cross-section with stable session clock and execution quotes | independent research family, but lower priority until broad intraday data exists |
 | first-to-last-half-hour ETF momentum | overnight/first-half-hour ETF return predicts the final half-hour | exact ETF interval bars and executable costs | recent eToro test rejected; do not generalise it to stocks |

--- a/docs/proposals/ta/2026-08-12-free-live-opening-volume-source-result.md
+++ b/docs/proposals/ta/2026-08-12-free-live-opening-volume-source-result.md
@@ -1,0 +1,103 @@
+# Free live opening-volume source result
+
+Date: 2026-08-12  
+Issue: #2521  
+Decision: **refused** — no no-subscription source currently proves the complete
+09:35 ET consolidated-volume rank required by #2485
+
+## Question
+
+Can eBull identify the published Opening Range Breakout candidate's top 20
+Stocks in Play across the whole eligible US-stock cross-section close enough to
+09:35 ET to place demo orders, without buying a data subscription?
+
+This is not a generic search for active tickers. The frozen selector ranks each
+eligible stock by first-five-minute volume relative to its own previous 14
+opening intervals. A partial venue, delayed list, personalized recommendation
+or current-universe shortcut changes the strategy.
+
+## Official eToro capability audit
+
+The complete eToro documentation index was inspected on 2026-08-12. Its market
+data surface contains exchanges, instrument types/display data, historical
+closing prices, current rates, one-instrument candle history, instrument search
+and stock industries. It documents no bulk candle, opening-volume, screener or
+market-mover endpoint.
+
+The relevant contracts are:
+
+- [candle history](https://api-portal.etoro.com/api-reference/market-data/get-instrument-candle-history):
+  one `instrumentId` in the path, up to 1,000 OHLCV candles, under the shared
+  market-data quota of 120 requests per 60 seconds;
+- [instrument rates](https://api-portal.etoro.com/api-reference/market-data/get-instrument-market-rates):
+  up to 100 instrument IDs, returning bid, ask, last execution and
+  margin/conversion price fields, but no volume;
+- [WebSocket instrument topics](https://api-portal.etoro.com/core/websocket/topics):
+  per-instrument bid, ask, last execution and related price fields, but no
+  trade size, cumulative volume or candle;
+- [market recommendations](https://api-portal.etoro.com/api-reference/watchlists/get-market-recommendations):
+  a personalized list of instrument IDs, with no declared selection timestamp,
+  population, volume measure or rank calculation.
+
+At the measured 6,083 currently classified NYSE/Nasdaq common stocks, the
+single-instrument candle contract needs at least 51 minutes even at the full
+documented shared-quota ceiling (`ceil(6,083 / 120)`). That lower bound excludes
+network latency, competing rates/search calls, retries, missing-name handling
+and the time needed to rank. The repo's deliberately lower operational client
+rate makes the live result slower, not faster.
+
+The batched rates and WebSocket paths cannot replace this scan because a price
+update count is not consolidated share volume. Recommendations cannot replace
+it because their undisclosed personalized selection cannot be reproduced or
+shown to match the paper's point-in-time cross-section.
+
+## Other free-source boundary
+
+Alpaca's official market-data FAQ says historical SIP requests ending at least
+15 minutes in the past can be available without a paid subscription, while its
+current historical-data page describes IEX as the no-subscription feed. That
+entitlement conflict is why #2520 requires a bounded credentialed account probe
+rather than an assumed integration.
+
+Both official pages agree on the live distinction that matters here: free
+real-time equities are IEX, whereas consolidated SIP coverage is delayed or a
+subscription product. IEX is one exchange and cannot be asserted to preserve a
+top-20 rank defined on consolidated US trading volume. A parity claim would
+need complete simultaneous SIP observations and a predeclared displacement
+test; none exists.
+
+Two other plausible official provider surfaces also fail the exact boundary:
+
+- [Twelve Data's US coverage statement](https://support.twelvedata.com/en/articles/9935903-us-equities-market-data)
+  says its default real-time feed covers listed symbols but represents about 5%
+  of US trading activity; full-market coverage is a separately licensed
+  product. Its free Basic plan also has eight API credits per minute. Neither a
+  partial-volume rank nor that quota can reproduce the consolidated top 20.
+- [Alpha Vantage's official documentation](https://www.alphavantage.co/documentation/)
+  states that real-time and 15-minute-delayed US data require premium
+  membership, its bulk real-time quote endpoint is premium, and its standard
+  free quote is end-of-day. It therefore supplies no free 09:35 input.
+
+Other public websites were not accepted merely because they display “most
+active” lists. The acceptance contract requires an authoritative, legally
+reusable feed with known venue composition, complete prefiltered coverage,
+deterministic timing and an operational interface. No such no-subscription
+source was identified in the official provider surfaces above.
+
+## Consequence
+
+- Close #2521 as a documented refusal, not an implementation backlog.
+- Keep #2520 open solely for delayed historical falsification. A successful
+  delayed test does not make #2485 executable at 09:35.
+- Keep the eight-name eToro intraday panel as collection and execution-cost
+  instrumentation. It is not an ORB return sample.
+- Do not ingest a full-market tick or minute-bar heap. If a qualifying live
+  source appears later, retain one opening summary per instrument/session and
+  selected top-20 paths under the already frozen bounded design.
+- Do not expose ORB as an allocation option and do not emit a demo order until
+  a new source version clears complete coverage, rank parity, timeliness and
+  eToro quote/shortability gates prospectively.
+
+This refusal says the published candidate is not currently automatable under
+the no-subscription constraint. It is not evidence that ORB itself loses money;
+that remains a separate delayed falsification question.


### PR DESCRIPTION
## Outcome

Closes #2521 with a documented refusal: under the no-subscription constraint, eBull cannot currently reproduce the published 09:35 ET consolidated-volume Stocks-in-Play rank, so ORB must not be exposed for demo allocation or order emission.

## Evidence

- eToro candle history is one instrument per request and shares a documented 120 requests / 60 seconds market-data quota. The 6,083-name census therefore has a theoretical floor of ~51 minutes.
- eToro rates batch 100 IDs and its WebSocket streams price fields, but neither supplies volume.
- eToro recommendations are personalized ID lists, not a reproducible full-cross-section opening-volume rank.
- Alpaca's free real-time equities are IEX rather than consolidated SIP; its delayed historical entitlement remains a credentialed #2520 question.
- Twelve Data documents ~5% default real-time US volume coverage; Alpha Vantage requires premium entitlement for real-time/delayed US data.

## Contract changes

- correct the stale 55/min operational estimate to the current official 120/min theoretical ceiling without pretending it makes the scan viable;
- separate delayed falsification (#2520) from live executability (#2521);
- preserve bounded storage and explicitly bar demo orders even after a positive delayed backtest until a complete timely source is proven.

## Verification

Full pre-push gate green: ruff, formatting, pyright, shell/static invariants, pure suite, DB smoke suite, and frontend integrity checks. No schema or stored rows are added.
