### PR TITLE
feat(strategy): add bounded delayed SIP source probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ COMPANIES_HOUSE_API_KEY=
 # = 25,000 mappings/min (~5 min). Free either way; key is purely speed.
 OPENFIGI_API_KEY=
 
+# Optional research-only credentials for #2520's bounded delayed historical
+# SIP qualification probe. They are never read by the application or jobs
+# process and the probe writes no market payloads or database rows.
+APCA_API_KEY_ID=
+APCA_API_SECRET_KEY=
+
 # SEC EDGAR — no API key, but fair-use policy requires a User-Agent
 # with a contact email. SEC rejects requests with placeholder domains
 # (example.com, noreply@*) and any UA missing an email address — 403

--- a/app/services/alpaca_delayed_sip_probe.py
+++ b/app/services/alpaca_delayed_sip_probe.py
@@ -236,8 +236,8 @@ def _require_tsla_forward_split(body: object) -> dict[str, object]:
     row = matching[0]
     new_rate = _decimal(row.get("new_rate"), field="new_rate")
     old_rate = _decimal(row.get("old_rate"), field="old_rate")
-    if new_rate <= 0 or old_rate <= 0 or new_rate == old_rate:
-        raise ProbeRefusal("TSLA forward split has invalid or unchanged rates")
+    if new_rate <= old_rate or old_rate <= 0:
+        raise ProbeRefusal("TSLA forward split does not increase shares")
     return {
         "name": "corporate_actions",
         "forward_splits": len(forward_splits),

--- a/app/services/alpaca_delayed_sip_probe.py
+++ b/app/services/alpaca_delayed_sip_probe.py
@@ -1,0 +1,380 @@
+"""Bounded, read-only contract probe for Alpaca delayed historical SIP data.
+
+This is research-source qualification for #2520, not a production ingestion
+provider.  It deliberately writes no database rows and never returns raw bars:
+the result contains only counts, bounds, hashes, matched reference identities
+and rate-limit headers.  A successful probe proves the configured account
+contract; docs and marketing copy do not.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Final
+
+import httpx
+
+DATA_BASE_URL: Final = "https://data.alpaca.markets"
+TRADING_BASE_URL: Final = "https://paper-api.alpaca.markets"
+MAX_HTTP_CALLS: Final = 12
+MAX_PAGES_PER_SCENARIO: Final = 2
+SOURCE_VERSION: Final = "alpaca_delayed_sip_probe_v1"
+
+_RATE_HEADERS: Final = (
+    "x-ratelimit-limit",
+    "x-ratelimit-remaining",
+    "x-ratelimit-reset",
+    "retry-after",
+)
+
+
+class ProbeRefusal(RuntimeError):
+    """The source contract could not be proven without weakening it."""
+
+
+class _CallBudget:
+    def __init__(self, maximum: int = MAX_HTTP_CALLS) -> None:
+        self.maximum = maximum
+        self.used = 0
+
+    def take(self) -> None:
+        if self.used >= self.maximum:
+            raise ProbeRefusal(f"HTTP call budget exhausted at {self.maximum}")
+        self.used += 1
+
+
+def credential_headers(*, key_id: str, secret_key: str) -> dict[str, str]:
+    """Build authentication headers after rejecting empty/placeholder secrets."""
+    key_id = key_id.strip()
+    secret_key = secret_key.strip()
+    if not key_id or not secret_key:
+        raise ProbeRefusal("APCA_API_KEY_ID and APCA_API_SECRET_KEY are both required")
+    if key_id.startswith("<") or secret_key.startswith("<"):
+        raise ProbeRefusal("placeholder Alpaca credentials are not accepted")
+    return {
+        "APCA-API-KEY-ID": key_id,
+        "APCA-API-SECRET-KEY": secret_key,
+        "User-Agent": "eBull/2520 delayed-SIP source probe",
+    }
+
+
+def _safe_error(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text[:240]
+    if isinstance(body, Mapping):
+        return str(body.get("message") or body.get("error") or sorted(body))[:240]
+    return type(body).__name__
+
+
+def _get_json(
+    client: httpx.Client,
+    budget: _CallBudget,
+    url: str,
+    *,
+    params: Mapping[str, str | int | float],
+) -> tuple[Any, Mapping[str, str]]:
+    budget.take()
+    try:
+        response = client.get(url, params=params, timeout=20.0)
+    except httpx.RequestError as exc:
+        raise ProbeRefusal(f"transport failure for {url}: {exc.__class__.__name__}") from exc
+    if response.status_code != 200:
+        raise ProbeRefusal(f"{url} returned HTTP {response.status_code}: {_safe_error(response)}")
+    try:
+        return response.json(), response.headers
+    except ValueError as exc:
+        raise ProbeRefusal(f"{url} returned non-JSON HTTP 200") from exc
+
+
+def _decimal(value: object, *, field: str) -> Decimal:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ProbeRefusal(f"bar field {field} is not numeric") from exc
+    if not parsed.is_finite():
+        raise ProbeRefusal(f"bar field {field} is not finite")
+    return parsed
+
+
+def validate_bars(rows: object) -> tuple[dict[str, object], ...]:
+    """Validate Alpaca's compact bar schema without retaining vendor payloads."""
+    if not isinstance(rows, list):
+        raise ProbeRefusal("bar response 'bars' must be a list")
+    validated: list[dict[str, object]] = []
+    previous: datetime | None = None
+    for raw in rows:
+        if not isinstance(raw, Mapping):
+            raise ProbeRefusal("every bar must be an object")
+        try:
+            stamp = datetime.fromisoformat(str(raw["t"]).replace("Z", "+00:00"))
+            open_ = _decimal(raw["o"], field="o")
+            high = _decimal(raw["h"], field="h")
+            low = _decimal(raw["l"], field="l")
+            close = _decimal(raw["c"], field="c")
+        except KeyError as exc:
+            raise ProbeRefusal(f"bar is missing {exc.args[0]!r}") from exc
+        except (TypeError, ValueError) as exc:
+            raise ProbeRefusal("bar timestamp has an invalid type") from exc
+        if stamp.tzinfo is None:
+            raise ProbeRefusal("bar timestamp must carry an offset")
+        stamp = stamp.astimezone(UTC)
+        raw_volume = raw["v"]
+        if isinstance(raw_volume, bool) or not isinstance(raw_volume, int):
+            raise ProbeRefusal("bar volume must be an integer")
+        volume = raw_volume
+        if previous is not None and stamp <= previous:
+            raise ProbeRefusal("bars are not strictly ascending")
+        if min(open_, high, low, close) <= 0:
+            raise ProbeRefusal("bar OHLC must be positive")
+        if high < max(open_, close, low) or low > min(open_, close, high):
+            raise ProbeRefusal("bar violates OHLC bounds")
+        if volume < 0:
+            raise ProbeRefusal("bar volume must be non-negative")
+        previous = stamp
+        validated.append(
+            {"t": stamp.isoformat(), "o": str(open_), "h": str(high), "l": str(low), "c": str(close), "v": volume}
+        )
+    return tuple(validated)
+
+
+def _digest(rows: tuple[dict[str, object], ...]) -> str:
+    encoded = json.dumps(rows, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _bar_summary(symbol: str, rows: tuple[dict[str, object], ...]) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "rows": len(rows),
+        "first": rows[0]["t"] if rows else None,
+        "last": rows[-1]["t"] if rows else None,
+        "sha256": _digest(rows),
+    }
+
+
+def fetch_bar_scenario(
+    client: httpx.Client,
+    budget: _CallBudget,
+    *,
+    symbol: str,
+    start: str,
+    end: str,
+    adjustment: str = "raw",
+    asof: str,
+    limit: int = 100,
+    max_pages: int = MAX_PAGES_PER_SCENARIO,
+) -> tuple[dict[str, object], dict[str, str]]:
+    """Fetch at most two pages with exact SIP/raw/as-of provenance."""
+    if adjustment not in {"raw", "split"}:
+        raise ValueError("probe adjustment must be raw or split")
+    if not 1 <= limit <= 10_000:
+        raise ValueError("limit must be between 1 and 10000")
+    params: dict[str, str | int | float] = {
+        "timeframe": "1Min",
+        "start": start,
+        "end": end,
+        "limit": limit,
+        "adjustment": adjustment,
+        "asof": asof,
+        "feed": "sip",
+        "sort": "asc",
+    }
+    all_rows: list[dict[str, object]] = []
+    seen_tokens: set[str] = set()
+    captured_headers: dict[str, str] = {}
+    pages = 0
+    while pages < max_pages:
+        body, headers = _get_json(
+            client,
+            budget,
+            f"{DATA_BASE_URL}/v2/stocks/{symbol}/bars",
+            params=params,
+        )
+        if not isinstance(body, Mapping):
+            raise ProbeRefusal("bar response must be an object")
+        page = validate_bars(body.get("bars"))
+        if all_rows and page and str(page[0]["t"]) <= str(all_rows[-1]["t"]):
+            raise ProbeRefusal("bar pagination overlapped or regressed")
+        all_rows.extend(page)
+        pages += 1
+        captured_headers.update({name: headers[name] for name in _RATE_HEADERS if name in headers})
+        token_value = body.get("next_page_token")
+        if token_value in {None, ""}:
+            break
+        token = str(token_value)
+        if token in seen_tokens:
+            raise ProbeRefusal("bar pagination token repeated")
+        seen_tokens.add(token)
+        params["page_token"] = token
+    else:
+        raise ProbeRefusal(f"{symbol} scenario exceeded the {max_pages}-page bound")
+    summary = _bar_summary(symbol, tuple(all_rows))
+    summary.update({"pages": pages, "feed": "sip", "adjustment": adjustment, "asof": asof})
+    return summary, captured_headers
+
+
+def _require_tsla_forward_split(body: object) -> dict[str, object]:
+    """Prove the filtered response contains the expected action, not just keys."""
+    if not isinstance(body, Mapping):
+        raise ProbeRefusal("corporate_actions response must be an object")
+    actions = body.get("corporate_actions")
+    if not isinstance(actions, Mapping):
+        raise ProbeRefusal("corporate_actions response is missing its action collection")
+    forward_splits = actions.get("forward_splits")
+    if not isinstance(forward_splits, list) or not forward_splits:
+        raise ProbeRefusal("TSLA scenario returned no forward split")
+    matching = [row for row in forward_splits if isinstance(row, Mapping) and row.get("symbol") == "TSLA"]
+    if not matching:
+        raise ProbeRefusal("forward-split response did not contain TSLA")
+    row = matching[0]
+    new_rate = _decimal(row.get("new_rate"), field="new_rate")
+    old_rate = _decimal(row.get("old_rate"), field="old_rate")
+    if new_rate <= 0 or old_rate <= 0 or new_rate == old_rate:
+        raise ProbeRefusal("TSLA forward split has invalid or unchanged rates")
+    return {
+        "name": "corporate_actions",
+        "forward_splits": len(forward_splits),
+        "symbol": "TSLA",
+        "new_rate": str(new_rate),
+        "old_rate": str(old_rate),
+        "ex_date": row.get("ex_date"),
+    }
+
+
+def _require_inactive_twtr(body: object) -> dict[str, object]:
+    if not isinstance(body, Mapping):
+        raise ProbeRefusal("inactive_asset response must be an object")
+    if body.get("symbol") != "TWTR" or body.get("status") != "inactive":
+        raise ProbeRefusal("TWTR did not resolve as an inactive asset")
+    return {
+        "name": "inactive_asset",
+        "symbol": "TWTR",
+        "status": "inactive",
+        "exchange": body.get("exchange"),
+    }
+
+
+@dataclass(frozen=True)
+class _BarScenario:
+    symbol: str
+    start: str
+    end: str
+    asof: str
+    limit: int = 100
+
+
+def _require_rows(summary: Mapping[str, object], *, name: str) -> None:
+    rows = summary.get("rows")
+    if not isinstance(rows, int) or rows == 0:
+        raise ProbeRefusal(f"{name} scenario returned no SIP bars")
+
+
+def run_probe(client: httpx.Client) -> dict[str, object]:
+    """Run the frozen <=12-call qualification panel and return compact evidence."""
+    budget = _CallBudget()
+    checks: list[dict[str, object]] = []
+    rate_headers: dict[str, str] = {}
+
+    scenarios = (
+        _BarScenario("AAPL", "2016-01-04T14:30:00Z", "2016-01-04T14:33:00Z", "2016-01-04", 2),
+        _BarScenario("AAPL", "2026-07-01T13:30:00Z", "2026-07-01T13:36:00Z", "2026-07-01"),
+        _BarScenario("JPM", "2026-07-01T13:30:00Z", "2026-07-01T13:36:00Z", "2026-07-01"),
+        _BarScenario("TWTR", "2022-10-20T13:30:00Z", "2022-10-20T13:36:00Z", "2022-10-20"),
+        _BarScenario("SPY", "2025-11-28T14:30:00Z", "2025-11-28T18:05:00Z", "2025-11-28"),
+    )
+    for scenario in scenarios:
+        summary, headers = fetch_bar_scenario(
+            client,
+            budget,
+            symbol=scenario.symbol,
+            start=scenario.start,
+            end=scenario.end,
+            asof=scenario.asof,
+            limit=scenario.limit,
+        )
+        _require_rows(summary, name=scenario.symbol)
+        checks.append(summary)
+        rate_headers.update(headers)
+
+    adjustment_hashes: dict[str, str] = {}
+    for adjustment in ("raw", "split"):
+        summary, headers = fetch_bar_scenario(
+            client,
+            budget,
+            symbol="TSLA",
+            start="2022-08-24T13:30:00Z",
+            end="2022-08-24T13:36:00Z",
+            adjustment=adjustment,
+            asof="2022-08-24",
+        )
+        _require_rows(summary, name=f"TSLA {adjustment}")
+        adjustment_hashes[adjustment] = str(summary["sha256"])
+        checks.append(summary)
+        rate_headers.update(headers)
+    if adjustment_hashes["raw"] == adjustment_hashes["split"]:
+        raise ProbeRefusal("TSLA raw and split-adjusted samples were identical across the declared split")
+
+    calendar, headers = _get_json(
+        client,
+        budget,
+        f"{TRADING_BASE_URL}/v2/calendar",
+        params={"start": "2025-11-28", "end": "2025-11-28"},
+    )
+    if not isinstance(calendar, list) or len(calendar) != 1 or not isinstance(calendar[0], Mapping):
+        raise ProbeRefusal("early-close calendar scenario did not return exactly one session")
+    close = str(calendar[0].get("close", ""))
+    if close != "13:00":
+        raise ProbeRefusal(f"2025-11-28 calendar did not report the expected early close: {close!r}")
+    checks.append({"name": "early_close_calendar", "date": "2025-11-28", "close": close})
+    rate_headers.update({name: headers[name] for name in _RATE_HEADERS if name in headers})
+
+    actions, headers = _get_json(
+        client,
+        budget,
+        f"{DATA_BASE_URL}/v1/corporate-actions",
+        params={
+            "symbols": "TSLA",
+            "types": "forward_split",
+            "start": "2022-08-20",
+            "end": "2022-08-31",
+            "limit": 10,
+            "sort": "asc",
+        },
+    )
+    checks.append(_require_tsla_forward_split(actions))
+    rate_headers.update({name: headers[name] for name in _RATE_HEADERS if name in headers})
+
+    inactive, headers = _get_json(
+        client,
+        budget,
+        f"{TRADING_BASE_URL}/v2/assets/TWTR",
+        params={},
+    )
+    checks.append(_require_inactive_twtr(inactive))
+    rate_headers.update({name: headers[name] for name in _RATE_HEADERS if name in headers})
+
+    return {
+        "status": "qualified",
+        "source_version": SOURCE_VERSION,
+        "calls_used": budget.used,
+        "call_budget": budget.maximum,
+        "checks": checks,
+        "rate_limit_headers": rate_headers,
+    }
+
+
+__all__ = [
+    "MAX_HTTP_CALLS",
+    "ProbeRefusal",
+    "credential_headers",
+    "fetch_bar_scenario",
+    "run_probe",
+    "validate_bars",
+]

--- a/docs/proposals/ta/2026-08-12-alpaca-delayed-sip-qualification-probe.md
+++ b/docs/proposals/ta/2026-08-12-alpaca-delayed-sip-qualification-probe.md
@@ -1,0 +1,95 @@
+# Alpaca delayed-SIP qualification probe
+
+Date: 2026-08-12
+Issue: #2520
+Status: executable probe complete; live qualification refused because no Alpaca
+credentials are configured
+
+## Source rule
+
+- Alpaca's official [market-data FAQ](https://docs.alpaca.markets/docs/market-data-faq)
+  says historical SIP data is queryable when the request ends at least 15
+  minutes in the past.
+- Alpaca's current official [historical market-data
+  overview](https://docs.alpaca.markets/docs/historical-stock-data-1) describes
+  IEX as the feed available without a subscription. Those statements do not
+  establish the entitlement of this account, so the probe must prove `feed=sip`
+  directly and must never fall back to IEX.
+- The [single-symbol bars
+  reference](https://docs.alpaca.markets/reference/stockbarsingle-1) defines the
+  `feed`, `adjustment`, `asof`, limit and pagination fields frozen below.
+- The response shape used for the corporate-action assertion is independently
+  pinned by Alpaca's [official Python SDK
+  model](https://github.com/alpacahq/alpaca-py/blob/master/alpaca/data/models/corporate_actions.py).
+
+This qualification is intentionally narrower than #2520's full acceptance
+contract. It answers whether the external account can support the next bounded
+measurement; it does not predeclare research/holdout intervals, persist an
+eligibility census or validate a strategy.
+
+## Purpose
+
+Official Alpaca pages disagree at the boundary eBull needs to rely on: the
+market-data FAQ describes historical SIP requests ending at least 15 minutes in
+the past, while the current historical-data overview describes IEX as the
+no-subscription feed. The application must not implement a market-data source
+from the more favourable sentence.
+
+`app/services/alpaca_delayed_sip_probe.py` therefore qualifies the configured
+account response directly. It is deliberately not an ingestion provider. It
+writes no database rows or files and returns only compact structural evidence:
+counts, time bounds, SHA-256 payload fingerprints, the matched split/asset
+identity and rate-limit headers.
+
+Run from the repository root after placing free-account credentials in the
+process environment:
+
+```bash
+PYTHONPATH=. uv run python scripts/probe_2520_alpaca_delayed_sip.py
+```
+
+The script reads `APCA_API_KEY_ID` and `APCA_API_SECRET_KEY`. It never includes
+either value in output or exceptions. Missing or placeholder credentials return
+exit status 2 and a JSON `refused` result.
+
+## Frozen call panel
+
+The probe is hard-capped at 12 HTTP requests and two pages per bar scenario. It
+does not retry a denied SIP request as IEX. The panel checks:
+
+- raw SIP one-minute AAPL history at the January 2016 boundary, with deliberately
+  small pagination;
+- recent raw SIP AAPL and JPM bars, covering Nasdaq- and NYSE-listed names;
+- TWTR bars before its 2022 delisting, using an explicit historical `asof`;
+- the 2025 Thanksgiving Friday session plus Alpaca's early-close calendar;
+- raw versus split-adjusted TSLA bars across its August 2022 split;
+- the corporate-action response contract for that split;
+- current inactive-asset resolution for TWTR;
+- the provider's returned rate-limit headers.
+
+Every bar must have an offset-aware, strictly ascending timestamp, finite
+positive and internally consistent OHLC, and non-negative integer volume.
+Missing rows, repeated/unfinished pagination, malformed data, HTTP errors, an
+absent/mismatched split or inactive asset, and the raw/split samples failing to
+differ are refusals. The corporate-action response shape is pinned to Alpaca's
+official Python SDK model (`corporate_actions.forward_splits`); a 200 response
+with an empty collection is not evidence.
+
+## Current result
+
+The repo, `.env` and current process contain no Alpaca credentials. The real
+invocation therefore returns:
+
+```json
+{"reason":"APCA_API_KEY_ID and APCA_API_SECRET_KEY are both required","status":"refused"}
+```
+
+That is the only honest result available without creating an external account.
+It does not prove or disprove free historical SIP entitlement. #2520 remains
+open until a credentialed run records the compact result and official terms are
+checked for the intended internal research use.
+
+Even a successful result authorises only the next bounded sample/footprint
+measurement. It does not authorise full-market retention, ORB promotion or live
+09:35 execution; #2521 has already refused the latter under the free-source
+constraint.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -3918,3 +3918,9 @@ Two things S-4 adds to the prevention above:
 - Risk: a later legitimate history-table redesign could turn either relationship one-to-many and silently multiply money inside `SUM`, even though the query itself still looks valid.
 - Prevention: establish the monetary grain explicitly before aggregation. Select distinct exact broker-position IDs before joining close events; use `EXISTS` for lifecycle-state membership when summing one funding decision's amount. Do not rely on a distant uniqueness constraint to make a money aggregation correct.
 - Enforced in: this log; `app/services/strategy_wealth.py` `owned_broker_positions` CTE; `app/services/strategy_control_plane.py::configure_paper_pool` committed-capital `EXISTS` predicates.
+
+## Corporate-action labels do not prove ratio direction (#2580, 2026-08-12)
+
+- Symptom: the delayed-SIP source probe accepted a `forward_splits` record whenever `new_rate != old_rate`; a reverse-split-shaped ratio could therefore qualify the forward-split contract.
+- Prevention: validate the economic direction as well as the provider's category. A forward split requires positive `old_rate` and `new_rate > old_rate`; unequal rates alone are insufficient.
+- Enforced in: this log; `app/services/alpaca_delayed_sip_probe.py::_require_tsla_forward_split`; `tests/test_alpaca_delayed_sip_probe.py::test_forward_split_check_requires_actual_matching_action`.

--- a/scripts/probe_2520_alpaca_delayed_sip.py
+++ b/scripts/probe_2520_alpaca_delayed_sip.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Run #2520's bounded delayed-SIP qualification probe; write no market data.
+
+PYTHONPATH=. uv run python scripts/probe_2520_alpaca_delayed_sip.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+
+from app.services.alpaca_delayed_sip_probe import ProbeRefusal, credential_headers, run_probe
+
+
+def main() -> int:
+    try:
+        headers = credential_headers(
+            key_id=os.environ.get("APCA_API_KEY_ID", ""),
+            secret_key=os.environ.get("APCA_API_SECRET_KEY", ""),
+        )
+        with httpx.Client(headers=headers, follow_redirects=False) as client:
+            result = run_probe(client)
+    except ProbeRefusal as exc:
+        print(json.dumps({"status": "refused", "reason": str(exc)}, sort_keys=True))
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_alpaca_delayed_sip_probe.py
+++ b/tests/test_alpaca_delayed_sip_probe.py
@@ -201,7 +201,11 @@ def test_complete_probe_is_bounded_and_returns_only_compact_evidence() -> None:
         ),
         (
             {"corporate_actions": {"forward_splits": [{"symbol": "TSLA", "new_rate": 1, "old_rate": 1}]}},
-            "invalid or unchanged rates",
+            "does not increase shares",
+        ),
+        (
+            {"corporate_actions": {"forward_splits": [{"symbol": "TSLA", "new_rate": 1, "old_rate": 3}]}},
+            "does not increase shares",
         ),
     ],
 )

--- a/tests/test_alpaca_delayed_sip_probe.py
+++ b/tests/test_alpaca_delayed_sip_probe.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import httpx
+import pytest
+
+import app.services.alpaca_delayed_sip_probe as probe
+
+
+def _bar(stamp: datetime, *, scale: int = 1) -> dict[str, object]:
+    return {
+        "t": stamp.isoformat().replace("+00:00", "Z"),
+        "o": 100 * scale,
+        "h": 102 * scale,
+        "l": 99 * scale,
+        "c": 101 * scale,
+        "v": 1_000 // scale,
+    }
+
+
+def test_credentials_fail_closed_without_printing_secret_values() -> None:
+    with pytest.raises(probe.ProbeRefusal, match="both required"):
+        probe.credential_headers(key_id="", secret_key="secret")
+    with pytest.raises(probe.ProbeRefusal, match="placeholder"):
+        probe.credential_headers(key_id="<key>", secret_key="secret")
+
+    headers = probe.credential_headers(key_id="id-value", secret_key="secret-value")
+
+    assert headers["APCA-API-KEY-ID"] == "id-value"
+    assert headers["APCA-API-SECRET-KEY"] == "secret-value"
+
+
+def test_bar_validation_rejects_bad_bounds_and_nonascending_rows() -> None:
+    first = datetime.fromisoformat("2026-07-01T13:30:00+00:00")
+    bad = _bar(first)
+    bad["h"] = 98
+    with pytest.raises(probe.ProbeRefusal, match="OHLC bounds"):
+        probe.validate_bars([bad])
+
+    with pytest.raises(probe.ProbeRefusal, match="strictly ascending"):
+        probe.validate_bars([_bar(first), _bar(first)])
+
+    fractional_volume = _bar(first)
+    fractional_volume["v"] = 1.5
+    with pytest.raises(probe.ProbeRefusal, match="volume must be an integer"):
+        probe.validate_bars([fractional_volume])
+
+    naive_timestamp = _bar(first)
+    naive_timestamp["t"] = "2026-07-01T13:30:00"
+    with pytest.raises(probe.ProbeRefusal, match="timestamp must carry an offset"):
+        probe.validate_bars([naive_timestamp])
+
+
+def test_fetch_bar_scenario_follows_bounded_pagination_and_pins_contract() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        token = request.url.params.get("page_token")
+        start = datetime.fromisoformat("2016-01-04T14:30:00+00:00")
+        rows = [_bar(start + timedelta(minutes=2 if token else 0))]
+        return httpx.Response(
+            200,
+            json={"bars": rows, "next_page_token": None if token else "next"},
+            headers={"x-ratelimit-limit": "200"},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        summary, headers = probe.fetch_bar_scenario(
+            client,
+            probe._CallBudget(),
+            symbol="AAPL",
+            start="2016-01-04T14:30:00Z",
+            end="2016-01-04T14:36:00Z",
+            asof="2016-01-04",
+            limit=1,
+        )
+
+    assert summary["rows"] == 2
+    assert summary["pages"] == 2
+    assert headers == {"x-ratelimit-limit": "200"}
+    assert len(requests) == 2
+    assert requests[0].url.params["feed"] == "sip"
+    assert requests[0].url.params["adjustment"] == "raw"
+    assert requests[0].url.params["asof"] == "2016-01-04"
+    assert requests[1].url.params["page_token"] == "next"
+
+
+def test_fetch_refuses_entitlement_failure_without_retrying_or_weakening_feed() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(403, json={"message": "subscription does not permit SIP"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(probe.ProbeRefusal, match="HTTP 403.*does not permit SIP"):
+            probe.fetch_bar_scenario(
+                client,
+                probe._CallBudget(),
+                symbol="AAPL",
+                start="2026-07-01T13:30:00Z",
+                end="2026-07-01T13:36:00Z",
+                asof="2026-07-01",
+            )
+
+    assert len(requests) == 1
+    assert requests[0].url.params["feed"] == "sip"
+
+
+def test_fetch_refuses_to_report_an_incomplete_bounded_page_set() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        start = datetime.fromisoformat("2016-01-04T14:30:00+00:00")
+        offset = 1 if request.url.params.get("page_token") else 0
+        next_token = "more-2" if offset else "more-1"
+        return httpx.Response(
+            200,
+            json={"bars": [_bar(start + timedelta(minutes=offset))], "next_page_token": next_token},
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(probe.ProbeRefusal, match="exceeded the 2-page bound"):
+            probe.fetch_bar_scenario(
+                client,
+                probe._CallBudget(),
+                symbol="AAPL",
+                start="2016-01-04T14:30:00Z",
+                end="2016-01-04T14:33:00Z",
+                asof="2016-01-04",
+                limit=1,
+            )
+
+
+def test_complete_probe_is_bounded_and_returns_only_compact_evidence() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        path = request.url.path
+        if path.endswith("/calendar"):
+            return httpx.Response(200, json=[{"date": "2025-11-28", "open": "09:30", "close": "13:00"}])
+        if path.endswith("/corporate-actions"):
+            return httpx.Response(
+                200,
+                json={
+                    "corporate_actions": {
+                        "forward_splits": [
+                            {
+                                "id": "split",
+                                "symbol": "TSLA",
+                                "new_rate": 3,
+                                "old_rate": 1,
+                                "ex_date": "2022-08-25",
+                            }
+                        ]
+                    }
+                },
+            )
+        if path.endswith("/assets/TWTR"):
+            return httpx.Response(
+                200,
+                json={"symbol": "TWTR", "status": "inactive", "exchange": "NYSE", "id": "asset-id"},
+            )
+        if "/bars" in path:
+            start = datetime.fromisoformat(request.url.params["start"].replace("Z", "+00:00"))
+            token = request.url.params.get("page_token")
+            offset = 2 if token else 0
+            scale = 3 if request.url.params.get("adjustment") == "split" else 1
+            body: dict[str, object] = {"bars": [_bar(start + timedelta(minutes=offset), scale=scale)]}
+            if request.url.params.get("limit") == "2" and token is None:
+                body["next_page_token"] = "page-2"
+            return httpx.Response(
+                200,
+                json=body,
+                headers={"x-ratelimit-limit": "200", "x-ratelimit-remaining": str(200 - calls)},
+            )
+        raise AssertionError(f"unexpected probe URL {request.url}")
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        result = probe.run_probe(client)
+
+    assert result["status"] == "qualified"
+    assert result["calls_used"] == 11
+    assert result["call_budget"] == 12
+    assert calls == 11
+    assert result["rate_limit_headers"]["x-ratelimit-limit"] == "200"  # type: ignore[index]
+    rendered = str(result)
+    assert "APCA-API" not in rendered
+    assert "secret" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("body", "message"),
+    [
+        ({"corporate_actions": {"forward_splits": []}}, "no forward split"),
+        (
+            {"corporate_actions": {"forward_splits": [{"symbol": "AAPL", "new_rate": 4, "old_rate": 1}]}},
+            "did not contain TSLA",
+        ),
+        (
+            {"corporate_actions": {"forward_splits": [{"symbol": "TSLA", "new_rate": 1, "old_rate": 1}]}},
+            "invalid or unchanged rates",
+        ),
+    ],
+)
+def test_forward_split_check_requires_actual_matching_action(body: object, message: str) -> None:
+    with pytest.raises(probe.ProbeRefusal, match=message):
+        probe._require_tsla_forward_split(body)
+
+
+def test_inactive_asset_check_requires_twtr_and_inactive_status() -> None:
+    with pytest.raises(probe.ProbeRefusal, match="did not resolve as an inactive asset"):
+        probe._require_inactive_twtr({"symbol": "TWTR", "status": "active"})
+
+    summary = probe._require_inactive_twtr({"symbol": "TWTR", "status": "inactive", "exchange": "NYSE"})
+
+    assert summary == {"name": "inactive_asset", "symbol": "TWTR", "status": "inactive", "exchange": "NYSE"}
+
+
+def test_call_budget_fails_before_an_unbounded_request() -> None:
+    budget = probe._CallBudget(maximum=1)
+    budget.take()
+
+    with pytest.raises(probe.ProbeRefusal, match="budget exhausted"):
+        budget.take()


### PR DESCRIPTION
## Outcome

Adds the bounded, read-only credential probe needed to test the first acceptance boundary of #2520 without treating favourable provider documentation as entitlement proof.

## Contract

- hard cap: 12 HTTP calls and 2 pages per bar scenario
- pins `feed=sip`, `adjustment`, `asof`, pagination and source version; never falls back to IEX
- validates old/recent Nasdaq and NYSE bars, pre-delisting TWTR, the 2025 early close, TSLA raw/split semantics, the actual TSLA forward-split record, inactive-symbol resolution and rate-limit headers
- refuses malformed/empty/overlapping bars, unfinished pagination, HTTP denial, wrong metadata, or identical raw/split evidence
- returns only compact counts/bounds/hashes/reference identities; writes no files, database rows or raw market payloads
- records official-source rules and the deliberate boundary between this probe and full #2520 acceptance

## Current live result

The repo, `.env`, and current process have no Alpaca credentials. The actual command therefore fails closed as designed:

```json
{"reason":"APCA_API_KEY_ID and APCA_API_SECRET_KEY are both required","status":"refused"}
```

This PR does **not** close #2520 and does not approve ORB, delayed SIP ingestion, paper orders or production execution. A credentialed compact result is still required before the bounded storage/footprint sample.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest -m 'not db' -q`
- `uv run pytest tests/smoke -q`
- full repository pre-push gate
- invariant mutation: disabled OHLC-bound refusal, observed its focused test fail, restored it and observed pass
- `PYTHONPATH=. uv run python scripts/probe_2520_alpaca_delayed_sip.py` -> exit 2 / compact refusal above

Refs #2520. Refs #2485. Refs #2521.
