### PR TITLE
docs(strategy): freeze exact sector ETF residual contract

### DIFF
--- a/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
+++ b/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
@@ -12,7 +12,7 @@ arrival order.
 Candidate admission, trial budget and build order are governed by
 `2026-08-11-portfolio-alpha-viability-plan.md`. This map is a taxonomy and
 diagnostic backlog, not authority to test every row. In particular, the
-3/5/10-session sector-residual work remains reserved until it establishes a
+sector-residual work remains reserved until it establishes a
 mechanism independent of the rejected residual-confluence candidate and an
 uncontaminated evaluation interval.
 
@@ -122,28 +122,36 @@ versioned, prospective mechanism trial.
 
 ### Three to ten sessions
 
-The highest-priority daily-data research family is **sector/factor-neutral
-relative value**, because it directly models the common movement the operator
-identified. For stock `i`, fit factor exposures on data ending before the
-decision, accumulate the residual, then model its equilibrium and speed:
+The highest-priority daily-data research family to source-check is
+**sector/factor-neutral relative value**, because it directly models the common
+movement the operator identified. The primary Avellaneda-Lee contract has now
+been transcribed in
+`2026-08-12-sector-etf-residual-replication-contract.md`. For stock `i`, it fits
+the single assigned sector-ETF exposure on the 60 completed sessions ending at
+the decision close, accumulates the residual, then models its equilibrium and
+speed:
 
 ```text
 X(i,t) = cumulative residual return
 s(i,t) = (X(i,t) - equilibrium(i,t)) / equilibrium_sigma(i,t)
-half_life(i,t) = ln(2) / kappa(i,t)
+characteristic_time(i,t) = 1 / kappa(i,t)
 ```
 
-Only relationships with stable pre-decision exposure, stationary residual and
-a half-life compatible with the declared 3/5/10-session horizon enter the
-trial. Market- or sector-neutral long/short is the published economic form;
-long-only and unhedged versions are adaptations and must not inherit its
-evidence. Shortability, borrow/CFD carry and factor-leg execution are standing
-blockers for capital even if a research arm is positive.
+The paper admits `kappa > 8.4` (characteristic reversion time below about 30
+sessions), opens at `|s| > 1.25`, and exits on score reversion; it does not use
+fixed 3/5/10-session exits. Market- or sector-neutral long/short is the
+published economic form; fixed-horizon, long-only and unhedged versions are
+adaptations and must not inherit its evidence. Point-in-time sector mapping,
+survivorship-safe membership/market cap, causal next fills, shortability,
+borrow/CFD carry and factor-leg execution are source blockers before outcomes
+may be opened.
 
 Avellaneda and Lee's sector-ETF/PCA work supplies a reproducible model, but its
 1997–2007 performance decayed after 2002. It is therefore a formula source,
-not current evidence. eBull must test recent 3-, 5- and 10-session arms
-separately, after costs, without selecting the best horizon afterwards.
+not current evidence. If the source gate passes, eBull must first test the
+published score-exit rule as one frozen replication after costs. Fixed
+3/5/10-session exits are separately motivated adaptations, not a horizon menu
+from which to select a winner on the same outcomes.
 
 Da, Liu and Schaumburg likewise find that the residual component of short-term
 reversal—not raw losing returns—is the positive component in their historical
@@ -254,9 +262,9 @@ promoted candidates.
    pure completed-session multi-horizon/dispersion/common-movement mathematics
    are now implemented; candidate-owned loading, compact persistence and exact
    intraday coverage remain.
-3. Preregister a recent sector-ETF residual relative-value replication at
-   separate 3/5/10-session horizons under #2522, research-only until side/carry
-   contracts exist.
+3. Run #2522's source census against the exact sector-ETF residual contract.
+   Do not open outcomes or substitute fixed 3/5/10-session exits until
+   point-in-time mapping/membership and two-leg execution evidence exist.
 4. Complete the already-frozen 10–20 session point-in-time earnings/event
    continuation spike (#2476).
 5. Continue prospective intraday collection; run #2484 and #2485 only when

--- a/docs/proposals/ta/2026-08-12-sector-etf-residual-replication-contract.md
+++ b/docs/proposals/ta/2026-08-12-sector-etf-residual-replication-contract.md
@@ -68,7 +68,11 @@ did not materially improve this horizon and does not present its backtest.
 ## Published universe, portfolio and fill assumptions
 
 - Universe membership and the USD 1 billion minimum market capitalisation are
-  evaluated at the historical trade date, not using today's survivors.
+  evaluated at the historical trade date, not using today's survivors. This is
+  the paper's explicit anti-survivorship rule (section 1, page 4: it contrasts
+  capitalisation "at the trade date" with capitalisation when the paper was
+  written); Table 3's January 2007 cross-section is an illustrative snapshot,
+  not a fixed-universe definition.
 - Each stock belongs to one of the paper's 15 sector buckets and is regressed
   against exactly one ETF: `HHH`, `IYR`, `IYT`, `OIH`, `RKH`, `RTH`, `SMH`,
   `UTH`, `XLE`, `XLF`, `XLI`, `XLK`, `XLP`, `XLV` or `XLY`.

--- a/docs/proposals/ta/2026-08-12-sector-etf-residual-replication-contract.md
+++ b/docs/proposals/ta/2026-08-12-sector-etf-residual-replication-contract.md
@@ -1,0 +1,171 @@
+# Sector-ETF residual replication contract
+
+Date: 2026-08-12
+Issue: #2522
+Status: primary rule transcribed; outcome access refused by point-in-time and
+execution-source gaps
+
+## Decision
+
+Do not implement the proposed fixed 3-, 5- and 10-session rules as though they
+were Avellaneda and Lee replications. The paper does not use those fixed exits.
+It recomputes a stock/sector-ETF residual model daily, opens on a standardised
+residual excursion and closes when the score returns toward equilibrium or the
+estimated process stops meeting its speed test.
+
+The exact published rule is worth preserving as a formula source. It is not
+current evidence: its actual-ETF test covers 2002-2007, its thresholds were
+selected on an earlier part of that sample, average reported Sharpe for
+2003-2007 was 0.6, and the authors explicitly report degradation. No result is
+opened until the source gaps below are closed or a separately named adaptation
+is preregistered with its own prior and trial identity.
+
+Primary source: Avellaneda and Lee, [Statistical Arbitrage in the U.S. Equities
+Market](https://math.nyu.edu/~avellane/AvellanedaLeeStatArb20090616.pdf),
+especially sections 3-5 and appendix 9.
+
+## Published calculation
+
+At each decision close `t`, for each stock `i` and its assigned sector ETF
+`I(i)`, use the 60 completed daily simple returns ending at `t`:
+
+```text
+R_stock[n] = beta_0 + beta_i * R_etf[n] + epsilon[n]
+X[k] = sum(epsilon[1:k])
+X[n+1] = a + b * X[n] + zeta[n+1]
+
+kappa = -log(b) * 252
+m = a / (1 - b)
+sigma_eq = sqrt(variance(zeta) / (1 - b^2))
+s = (X[60] - centered_m) / sigma_eq
+```
+
+The OLS residuals make `X[60] = 0` in the paper's construction. Its final
+implementation centres `m` by subtracting the cross-sectional mean of
+`a / (1-b)` before calculating the score. The model is admissible only when
+`0 < b < 0.9672`, equivalently `kappa > 252/30 = 8.4`; otherwise no new trade
+opens and an existing trade closes. This is a maximum estimated characteristic
+mean-reversion time of about 30 sessions, not a fixed 3/5/10-session holding
+rule. The paper notes an average estimated reversion time around seven days,
+but that descriptive result is not a parameter.
+
+The pure mean-reversion actions are:
+
+| state | rule | position |
+|---|---|---|
+| open long | `s < -1.25` | long USD 1 stock, short `beta_i` USD sector ETF |
+| open short | `s > +1.25` | short USD 1 stock, long `beta_i` USD sector ETF |
+| close long | `s > -0.50` | unwind both legs |
+| close short | `s < +0.75` | unwind both legs |
+| invalid model | speed test fails | refuse entry / close existing position |
+
+The `+0.75` short-close asymmetry was chosen because it performed slightly
+better in the paper's training period. It must therefore be charged as a
+selected historical prior, not presented as a timeless mathematical constant.
+The drift-modified score is not a second candidate: the paper reports that it
+did not materially improve this horizon and does not present its backtest.
+
+## Published universe, portfolio and fill assumptions
+
+- Universe membership and the USD 1 billion minimum market capitalisation are
+  evaluated at the historical trade date, not using today's survivors.
+- Each stock belongs to one of the paper's 15 sector buckets and is regressed
+  against exactly one ETF: `HHH`, `IYR`, `IYT`, `OIH`, `RKH`, `RTH`, `SMH`,
+  `UTH`, `XLE`, `XLF`, `XLI`, `XLK`, `XLP`, `XLV` or `XLY`.
+- Signals and parameters are recalculated daily. The paper assumes the trade
+  fills at the same closing price used to calculate that day's signal, includes
+  dividends in P&L, beta-hedges each sector daily and charges 5 bp each time a
+  position changes (10 bp round trip).
+- Its portfolio is leveraged and sizes each active stock by a shared equity
+  fraction. eBull's no-leverage rule and broker-specific stock/CFD economics
+  are separate execution constraints; the published return cannot be copied
+  into an unhedged single-stock position.
+
+The same-close fill is not executable evidence for eBull. A signal requiring
+the completed close cannot submit at that already-consumed close. The faithful
+economic adaptation must use the next executable stock and ETF quotes and
+charge both legs, or prove a causal pre-close signal/MOC contract as a separate
+trial. Optimistic same-close results may be reported only as a paper-comparison
+arm and can never authorise capital.
+
+## Current eBull source gate
+
+Already present:
+
+- causal daily price paths and unit-regime quarantine;
+- a bounded recent comparator snapshot containing SPY and all eleven current
+  Select Sector SPDRs through 2026-07-08;
+- pure completed-session market/industry context mathematics;
+- prospective security-type, listing and provider-industry observations from
+  2026-08-10 onward;
+- current quotes and exact strategy/manual-position ownership separation.
+
+Missing for either an exact replication or a defensible recent adaptation:
+
+1. The paper's point-in-time 15-bucket stock-to-ETF mapping. eBull's nine
+   provider industries and eleven current SPDRs are different taxonomies; no
+   current label may be projected into historical decisions.
+2. Point-in-time historical universe membership and a causal market-cap floor
+   for the complete stock population, including later-dead names. The current
+   research archive is not a survivorship-safe substitute.
+3. Next-executable stock and hedge-leg bid/ask evidence at each historical
+   decision. A daily candle close cannot prove a two-leg fill or the paper's
+   10 bp round trip under eToro.
+4. Historical shortability, product identity, CFD carry and side-specific
+   broker costs for both the stock and hedge. Missing inputs cannot become zero
+   cost or assumed availability.
+5. A recent untouched interval after any adapted mapping and execution rule is
+   frozen. Reusing the already-open residual/shock outcomes to select mapping,
+   score or horizon would be another search.
+
+### Free-source result
+
+A targeted official-source check found no free source that closes the first two
+gaps:
+
+- the SEC's [ticker/exchange association
+  files](https://www.sec.gov/search-filings/edgar-search-assistance/accessing-edgar-data)
+  are periodically updated search aids for current associations, and the SEC
+  explicitly does not guarantee their accuracy or scope;
+- Nasdaq Trader's [symbol directory
+  definition](https://www.nasdaqtrader.com/trader.aspx?id=symboldirdefs) describes
+  files updated throughout the current day, not a historical point-in-time
+  membership archive;
+- current Select Sector SPDR holdings are an S&P 500 subset under the modern
+  eleven-sector taxonomy, not the paper's historical USD 1 billion stock
+  universe or its 15 buckets;
+- CRSP's official [research-product
+  description](https://www.crsp.org/research/) documents the required permanent
+  identity, inactive-security and corporate-event continuity, but it is a
+  commercial research data product and is outside the no-subscription boundary.
+
+SEC filing SIC values could support a separately defined causal industry
+adaptation for identified filers. They cannot manufacture exchange membership,
+dead-name price history or the paper's stock-to-ETF taxonomy, so that route is
+not labelled an exact or complete replacement.
+
+These are source failures before they are strategy failures. Consequently the
+candidate remains outside `STRATEGY_MANIFEST`, the allocation engine and the
+operator page. It creates no table, derived residual history or database row.
+
+## Admissible next step
+
+Run a read-only source census before any outcome calculation:
+
+- prove whether a free, licensable point-in-time sector/universe source can map
+  the recent complete population without survivor projection; the current
+  official-source result is `not_found`, so a new source must first falsify that
+  finding;
+- report coverage by session, exchange, security type, price, market cap and
+  mapping/refusal reason;
+- prove both sides and product/cost contracts for a small current eToro panel;
+- predeclare whether the trial is the obsolete 15-ETF replication or a current
+  11-SPDR adaptation, plus the causal next-fill rule;
+- make the published score-exit rule the primary arm. Fixed 3/5/10-session
+  timeouts, unhedged longs or market-plus-sector regressions are separately
+  named adaptations and separately charged trials.
+
+Only after that census passes may code calculate outcomes. Promotion would
+still require positive conservative after-cost expectancy on later data,
+acceptable tails and drawdown, factor neutrality, capacity, and prospective
+demo evidence. A high hit rate alone is not an admission rule.


### PR DESCRIPTION
## Outcome

Corrects #2522 against the primary Avellaneda-Lee paper before any outcome code or backtest is written.

## Findings

- the published rule is a daily 60-session stock/assigned-sector-ETF regression plus OU residual score, not a fixed 3/5/10-session strategy
- admissibility requires `0 < b < 0.9672` / `kappa > 8.4`; entries use `|s| > 1.25`, exits use score reversion (`-0.50` long / `+0.75` short) or model invalidation
- the short-exit asymmetry and other thresholds came from the paper's historical training interval and are priors, not mathematical constants
- each stock trade carries its beta hedge; long-only, unhedged, market-plus-sector and fixed-horizon versions are separate adaptations
- the paper consumes the same close used for signal calculation; eBull must use a causal next fill (or separately prove a pre-close/MOC rule), charge both legs and preserve the optimistic paper arm only for comparison

## Source feasibility result

Outcome access remains refused. Existing free sources do not provide the paper's point-in-time 15-bucket mapping, complete inactive-name universe and trade-date market-cap history. SEC/Nasdaq association files are current aids; modern SPDRs use a different eleven-sector/S&P-500 taxonomy; CRSP documents the required continuity but is a commercial product outside the no-subscription boundary.

The change creates no strategy, table, stored feature, backtest result, manifest entry or capital path. It replaces the misleading build order with a source census and exact causal contract.

## Verification

- primary PDF sections 3-5 and appendix 9 transcribed directly
- official SEC, Nasdaq Trader, State Street and CRSP source capabilities checked
- `git diff --check`
- full repository pre-push gate

Refs #2522. Refs #2469. Refs #2523.
