### PR TITLE
research(strategy): census initial Schedule 13D candidate

### DIFF
--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -240,13 +240,30 @@ admission rests on the independent published factor prior and low-turnover portf
 role; the existing S-2 result is a contaminated harness observation and cannot select,
 weight or power C-3.
 
-### Reserved—not yet admitted
+### Conditional candidate C-4 — initial Schedule 13D catalyst
 
-The recent 3/5/10-session sector-residual work in #2522 is a diagnostic opportunity
-map, not automatically C-4. It may be admitted only if it states a forced-participant
-mechanism independent of the rejected daily residual-confluence model and can be
-tested without reusing its contaminated 2024-2026 decisions. Otherwise the first
-budget ends at C-3.
+The read-only #2582 census found 1,285 structured initial-13D accessions from
+2024-12-18 through 2026-08-12, 1,160 mapped research-price series and 895 events
+with 60 prior plus 20 later calendar days. All raw documents already contain Item 4;
+no outcome was opened and no new raw store is required. This is enough to write an
+exact preregistration, not enough to call the candidate viable.
+
+The family has an independent forced-participant mechanism: an active/control stake
+becomes public. It also has an unusually strong falsifier. The SEC's 2023 rule
+analysis found that, for one corporate-action subset, much of the reaction preceded
+the filing. eBull may trade only after dissemination. Moreover, 1,162 of the 1,285
+current rows are date-only, so their causal historical fill is no earlier than the
+next regular-session open.
+
+Before outcomes, #2582 must freeze campaign/conversion/repeat identity, Item 4
+purpose handling, decision clock, one comparison horizon, 13G/random challengers,
+cost arms, trial denominator and untouched terminal interval. A capital TP/SL rule
+is a separately identified executable adaptation and cannot be selected from the
+same opened outcomes. See `2026-08-12-schedule-13d-source-census.md`.
+
+The exact sector-residual replication in #2522 remains source-blocked. It does not
+become C-4 by substituting current classifications, survivor projection or fixed
+3/5/10-session exits for the published rule.
 
 ## 4. Research loops that cannot become parameter mining
 

--- a/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
+++ b/docs/proposals/ta/2026-08-11-short-horizon-opportunity-map.md
@@ -265,8 +265,9 @@ promoted candidates.
 3. Run #2522's source census against the exact sector-ETF residual contract.
    Do not open outcomes or substitute fixed 3/5/10-session exits until
    point-in-time mapping/membership and two-leg execution evidence exist.
-4. Complete the already-frozen 10–20 session point-in-time earnings/event
-   continuation spike (#2476).
+4. Freeze #2582's exact initial-Schedule-13D trial after its successful source
+   census. The already-open #2476 PEAD trial is inconclusive and closed; do not
+   reopen its outcomes or describe it as pending work.
 5. Continue prospective intraday collection; run #2484 and #2485 only when
    their exact input universes exist. Do not wait for them before learning from
    daily 1–20 session outcomes.

--- a/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
@@ -58,10 +58,11 @@ must carry those source refusals.
 
 Chain shape is material:
 
-- 961 accessions are the first initial-13D label in their current
-  `(filer, issuer)` chain;
-- 324 repeat that label in an existing chain;
-- 644 have an earlier 13G in the current chain;
+- 1,216 accessions have no earlier active filing for any reporting person on
+  the issuer in the retained chain;
+- 69 have an earlier active filing for at least one reporting person;
+- 47 have an earlier passive 13G-family filing for at least one reporting
+  person;
 - the mapped accessions cover 855 distinct instruments.
 
 Those figures do not yet prove the chain identity is economically correct.

--- a/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
@@ -1,0 +1,131 @@
+# Initial Schedule 13D catalyst source census
+
+Date: 2026-08-12
+Issue: #2582
+Status: source-feasible for preregistration; outcomes unopened
+
+## Decision
+
+An initial Schedule 13D is the first untested short-horizon event family in the
+current repository with both an independent economic mechanism and enough
+recent causal source coverage to justify an exact preregistration. It is not a
+strategy, promotion or promise of positive returns. The next question is
+specifically whether any return remains available **after** public filing and a
+causal retail fill.
+
+The family is preferable to adding another indicator vote. A Schedule 13D
+reports an active/control stake; an initial Schedule 13G is a passive or
+qualified-investor disclosure and can act as a stratified challenger. The
+candidate observes the disclosure, not the activist's earlier private purchase.
+
+Primary prior and falsifier:
+
+- Brav, Jiang, Partnoy and Thomas, [Hedge Fund Activism, Corporate Governance,
+  and Firm Performance](https://onlinelibrary.wiley.com/doi/10.1111/j.1540-6261.2008.01373.x),
+  report positive older-sample announcement-window abnormal returns, with
+  material variation across events and objectives.
+- The SEC's [2023 final-rule economic
+  analysis](https://www.sec.gov/files/rules/final/2023/33-11253.pdf) finds that,
+  in one analysed corporate-action subset, most market reaction occurred near
+  the ownership trigger rather than after the later filing. That is direct
+  evidence against assuming the public filing leaves a tradable edge.
+- The SEC's [current rule
+  summary](https://www.sec.gov/newsroom/press-releases/2023-219) records the
+  shortened initial-13D deadline and structured-data requirement. The modern
+  2024-2026 corpus is a different disclosure regime from the older studies.
+
+These publications supply the mechanism and the falsifier, not current eBull
+performance evidence.
+
+## Read-only corpus result
+
+The census grouped `blockholder_filings` by accession so joint reporters did
+not multiply events. It joined coverage metadata only; no return, target, stop,
+winner/loser or outcome path was calculated.
+
+| filing year | initial 13D accessions | instrument mapped | research-series mapped | 60 prior + 20 later calendar days |
+|---|---:|---:|---:|---:|
+| 2024 from 18 December | 25 | 24 | 24 | 24 |
+| 2025 | 757 | 727 | 691 | 575 |
+| 2026 through 12 August | 503 | 457 | 445 | 296 |
+| **total** | **1,285** | **1,208** | **1,160** | **895** |
+
+The research archive ends on 2026-07-08; 89 mapped 2026 events therefore lack
+20 later calendar days. They are incomplete, not zero-return observations.
+Across all retained 13D/G initial and amendment forms, the ingest audit has
+41,166 successful accessions, 3,566 partials and 26 failures. A trial census
+must carry those source refusals.
+
+Chain shape is material:
+
+- 961 accessions are the first initial-13D label in their current
+  `(filer, issuer)` chain;
+- 324 repeat that label in an existing chain;
+- 644 have an earlier 13G in the current chain;
+- the mapped accessions cover 855 distinct instruments.
+
+Those figures do not yet prove the chain identity is economically correct.
+They prove that blindly treating 1,285 rows as independent new campaigns would
+be wrong. First 13D, repeat campaign and 13G-to-13D conversion require explicit
+causal identities and separate attribution.
+
+## Timestamp and Item 4 result
+
+All 1,285 initial-13D accessions have their existing
+`primary_doc_13dg` raw XML. Every retained document contains structured
+`item4` / `transactionPurpose` text, but the current typed blockholder row does
+not persist that purpose. The evaluator can parse it from the one canonical
+document on demand. It must not duplicate the narrative in another table.
+
+Only 123 accessions carry a non-midnight `filed_at`; 1,162 are date-only. The
+date-only rows cannot support a same-day or market-hours fill. Their
+fail-closed historical decision is the next regular-session open after the
+filing date. A separately proven EDGAR acceptance-time source may recover a
+more precise decision without rewriting this trial identity.
+
+No typed `date_of_event` is present for these initial rows. That field is the
+private ownership-trigger date, not the public action time in any case; it may
+measure disclosure lag but can never authorise a pre-filing trade.
+
+## Storage impact
+
+The canonical 13D/G raw store already contains 44,732 deduplicated documents,
+about 409 MB of uncompressed payload bytes. The candidate adds no raw document,
+price, indicator or per-poll history. During research it reads the existing
+document by accession and emits one bounded report. If later admitted to
+prospective shadowing, only a compact purpose category/version/hash belongs on
+a fired or refused decision; routine non-firings remain aggregate counts.
+
+## Required preregistration before outcomes
+
+1. Freeze the first-campaign/conversion/repeat-chain identity and fixture-test
+   amendment collapse. Do not allow joint reporters or amendments to multiply
+   independent observations.
+2. Freeze an Item 4 purpose taxonomy from the source schema and a
+   deterministic `unknown` refusal. Purpose categories are attribution unless
+   one primary category is independently selected before outcomes.
+3. Freeze the public-decision clock. Date-only history enters no earlier than
+   the next regular-session open. Same-close and trigger-date fills are
+   forbidden.
+4. Freeze one published-effect comparison horizon before measurement. A
+   capital bracket is a separate executable adaptation: it needs an
+   independently declared risk objective and later untouched evidence, not a
+   search over targets and stops on the same outcomes.
+5. Use initial 13G, matched random timing and an unfiltered eligible-event arm
+   as same-population challengers. Different 13G filer types and reporting
+   deadlines must be stratified; the annual institutional filing wave is not a
+   naive placebo for an immediate 13D.
+6. Predeclare market/sector residual return, liquidity, price, volatility and
+   filing-time regime as attribution/risk controls. They do not become a grid
+   of confirming indicators.
+7. Charge adverse spread/slippage historically and observed eToro bid/ask in
+   prospective shadowing. Unknown product, eligibility or cost remains a
+   refusal.
+8. Reserve a terminal recent interval, declare the complete trial denominator
+   and calculate the sample/power requirement from a minimum worthwhile net
+   effect—not from older published means or the unopened local outcomes.
+
+Promotion still requires a positive adverse-cost clustered lower bound,
+acceptable tails and concentration, calibrated EV ranking, improved
+mandate-level portfolio contribution, prospective shadow evidence and demo
+execution. A high hit rate or positive mean cannot pass by itself.

--- a/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
@@ -58,11 +58,15 @@ must carry those source refusals.
 
 Chain shape is material:
 
-- 1,216 accessions have no earlier active filing for any reporting person on
+- 1,227 accessions have no strictly earlier active filing timestamp for any
+  reporting person on
   the issuer in the retained chain;
-- 69 have an earlier active filing for at least one reporting person;
-- 47 have an earlier passive 13G-family filing for at least one reporting
+- 58 have an earlier active filing for at least one reporting person;
+- 46 have an earlier passive 13G-family filing for at least one reporting
   person;
+- 37 have another filing for the same reporter and issuer at the same retained
+  timestamp, so their within-timestamp chain order is ambiguous and is not
+  invented from accession-number order;
 - the mapped accessions cover 855 distinct instruments.
 
 Those figures do not yet prove the chain identity is economically correct.

--- a/scripts/verify_2582_schedule13d_census.py
+++ b/scripts/verify_2582_schedule13d_census.py
@@ -1,0 +1,201 @@
+"""Read-only initial Schedule 13D source census for #2582.
+
+This command deliberately reads no price bars or forward returns. It measures
+event identity, document/timestamp availability and research-series coverage
+metadata before a trading rule or outcome window is frozen.
+
+Run from the repository root:
+
+    PYTHONPATH=. uv run python scripts/verify_2582_schedule13d_census.py
+    PYTHONPATH=. uv run python scripts/verify_2582_schedule13d_census.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, LiteralString, cast
+
+import psycopg
+from psycopg.rows import dict_row
+from psycopg.sql import SQL
+
+from app.config import settings
+
+_VENDOR = "paperswithbacktest/Stocks-Daily-Price"
+
+_YEARLY_COVERAGE: LiteralString = """
+WITH accessions AS (
+    SELECT accession_number,
+           min(filed_at) AS filed_at,
+           max(instrument_id) FILTER (WHERE instrument_id IS NOT NULL) AS instrument_id
+    FROM blockholder_filings
+    WHERE submission_type = 'SCHEDULE 13D'
+    GROUP BY accession_number
+), covered AS (
+    SELECT a.*,
+           s.series_id,
+           s.first_bar,
+           s.last_bar,
+           s.first_bar <= a.filed_at::date - 60
+               AND s.last_bar >= a.filed_at::date + 20 AS covered_60_20
+    FROM accessions a
+    LEFT JOIN research_price_series s
+      ON s.instrument_id = a.instrument_id
+     AND s.vendor = %(vendor)s
+)
+SELECT extract(year FROM filed_at)::int AS filing_year,
+       count(*) AS accessions,
+       count(instrument_id) AS instrument_mapped,
+       count(series_id) AS research_series_mapped,
+       count(*) FILTER (WHERE covered_60_20) AS covered_60_prior_20_later,
+       count(*) FILTER (
+           WHERE series_id IS NOT NULL AND last_bar < filed_at::date + 20
+       ) AS outcome_window_incomplete,
+       count(*) FILTER (
+           WHERE series_id IS NOT NULL AND first_bar > filed_at::date - 60
+       ) AS prior_window_incomplete
+FROM covered
+GROUP BY 1
+ORDER BY 1
+"""
+
+_CHAIN_SHAPE: LiteralString = """
+WITH accessions AS (
+    SELECT accession_number,
+           min(filer_id) AS filer_id,
+           min(issuer_cik) AS issuer_cik,
+           min(filed_at) AS filed_at,
+           max(instrument_id) FILTER (WHERE instrument_id IS NOT NULL) AS instrument_id
+    FROM blockholder_filings
+    WHERE submission_type = 'SCHEDULE 13D'
+    GROUP BY accession_number
+), ranked AS (
+    SELECT a.*,
+           row_number() OVER (
+               PARTITION BY filer_id, issuer_cik
+               ORDER BY filed_at, accession_number
+           ) AS chain_rank,
+           EXISTS (
+               SELECT 1
+               FROM blockholder_filings prior
+               WHERE prior.filer_id = a.filer_id
+                 AND prior.issuer_cik = a.issuer_cik
+                 AND prior.status = 'passive'
+                 AND prior.filed_at < a.filed_at
+           ) AS prior_13g
+    FROM accessions a
+)
+SELECT count(*) AS accessions,
+       count(*) FILTER (WHERE chain_rank = 1) AS first_13d_per_chain,
+       count(*) FILTER (WHERE chain_rank > 1) AS repeated_initial_label,
+       count(*) FILTER (WHERE prior_13g) AS prior_13g,
+       count(DISTINCT instrument_id) AS mapped_instruments
+FROM ranked
+"""
+
+_SOURCE_SHAPE: LiteralString = """
+WITH accessions AS (
+    SELECT accession_number,
+           min(filed_at) AS filed_at,
+           max(date_of_event) AS date_of_event
+    FROM blockholder_filings
+    WHERE submission_type = 'SCHEDULE 13D'
+    GROUP BY accession_number
+)
+SELECT count(*) AS accessions,
+       count(date_of_event) AS event_date_present,
+       count(*) FILTER (WHERE filed_at::time <> time '00:00') AS precise_filing_time,
+       count(*) FILTER (WHERE filed_at::time = time '00:00') AS date_only_filing_time,
+       count(raw.payload) AS raw_document_present,
+       count(*) FILTER (
+           WHERE raw.payload ~* '<([[:alnum:]_]+:)?item4([ >])'
+             AND raw.payload ~* '<([[:alnum:]_]+:)?transactionPurpose([ >])'
+       ) AS structured_item4_present
+FROM accessions a
+LEFT JOIN filing_raw_documents raw
+  ON raw.accession_number = a.accession_number
+ AND raw.document_kind = 'primary_doc_13dg'
+"""
+
+_INGEST_STATUS: LiteralString = """
+SELECT status, count(*) AS accessions
+FROM blockholder_filings_ingest_log
+GROUP BY status
+ORDER BY status
+"""
+
+_RAW_STORAGE: LiteralString = """
+SELECT count(*) AS documents,
+       sum(byte_count) AS uncompressed_payload_bytes,
+       round(avg(byte_count))::bigint AS average_document_bytes
+FROM filing_raw_documents
+WHERE document_kind = 'primary_doc_13dg'
+"""
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, (date, datetime, Decimal)):
+        return str(value)
+    raise TypeError(f"cannot JSON-encode {type(value).__name__}")
+
+
+def _one(conn: psycopg.Connection[dict[str, Any]], query: LiteralString) -> dict[str, Any]:
+    row = conn.execute(SQL(query)).fetchone()
+    if row is None:
+        raise RuntimeError("Schedule 13D census aggregate returned no row")
+    return row
+
+
+def build_census(conn: psycopg.Connection[dict[str, Any]]) -> dict[str, object]:
+    """Return bounded source metadata; never load a research price bar."""
+
+    yearly = conn.execute(_YEARLY_COVERAGE, {"vendor": _VENDOR}).fetchall()
+    return {
+        "outcomes_read": False,
+        "research_vendor": _VENDOR,
+        "yearly_coverage": yearly,
+        "chain_shape": _one(conn, _CHAIN_SHAPE),
+        "source_shape": _one(conn, _SOURCE_SHAPE),
+        "ingest_status": conn.execute(_INGEST_STATUS).fetchall(),
+        "raw_storage": _one(conn, _RAW_STORAGE),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    raw_conn = psycopg.connect(
+        settings.database_url,
+        row_factory=dict_row,  # pyright: ignore[reportCallIssue, reportArgumentType]
+    )
+    with cast(psycopg.Connection[dict[str, Any]], raw_conn) as conn:
+        conn.execute("SET TRANSACTION READ ONLY")
+        report = build_census(conn)
+
+    if args.json:
+        print(json.dumps(report, default=_json_default, indent=2, sort_keys=True))
+        return 0
+
+    print("#2582 INITIAL SCHEDULE 13D SOURCE CENSUS — NO OUTCOMES READ")
+    for row in report["yearly_coverage"]:  # type: ignore[union-attr]
+        print(
+            f"{row['filing_year']}: accessions={row['accessions']:,} "
+            f"instrument_mapped={row['instrument_mapped']:,} "
+            f"series_mapped={row['research_series_mapped']:,} "
+            f"covered_60_20={row['covered_60_prior_20_later']:,}"
+        )
+    print("chain shape:", json.dumps(report["chain_shape"], default=_json_default, sort_keys=True))
+    print("source shape:", json.dumps(report["source_shape"], default=_json_default, sort_keys=True))
+    print("ingest status:", json.dumps(report["ingest_status"], default=_json_default, sort_keys=True))
+    print("raw storage:", json.dumps(report["raw_storage"], default=_json_default, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_2582_schedule13d_census.py
+++ b/scripts/verify_2582_schedule13d_census.py
@@ -21,7 +21,6 @@ from typing import Any, LiteralString, cast
 
 import psycopg
 from psycopg.rows import dict_row
-from psycopg.sql import SQL
 
 from app.config import settings
 
@@ -144,7 +143,7 @@ def _json_default(value: object) -> str:
 
 
 def _one(conn: psycopg.Connection[dict[str, Any]], query: LiteralString) -> dict[str, Any]:
-    row = conn.execute(SQL(query)).fetchone()
+    row = conn.execute(query).fetchone()
     if row is None:
         raise RuntimeError("Schedule 13D census aggregate returned no row")
     return row

--- a/scripts/verify_2582_schedule13d_census.py
+++ b/scripts/verify_2582_schedule13d_census.py
@@ -88,23 +88,29 @@ WITH initial_accessions AS (
            coalesce(
                bool_or(status = 'active') OVER (
                    PARTITION BY issuer_cik, reporter_identity
-                   ORDER BY filed_at, accession_number
-                   ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                   ORDER BY filed_at
+                   RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                   EXCLUDE GROUP
                ), false
            ) AS prior_13d,
            coalesce(
                bool_or(status = 'passive') OVER (
                    PARTITION BY issuer_cik, reporter_identity
-                   ORDER BY filed_at, accession_number
-                   ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                   ORDER BY filed_at
+                   RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                   EXCLUDE GROUP
                ), false
-           ) AS prior_13g
+           ) AS prior_13g,
+           count(*) OVER (
+               PARTITION BY issuer_cik, reporter_identity, filed_at
+           ) > 1 AS same_timestamp_peer
     FROM reporter_events r
 ), classified AS (
     SELECT a.accession_number,
            a.instrument_id,
            bool_or(h.prior_13d) AS prior_13d,
-           bool_or(h.prior_13g) AS prior_13g
+           bool_or(h.prior_13g) AS prior_13g,
+           bool_or(h.same_timestamp_peer) AS ambiguous_chain_order
     FROM initial_accessions a
     JOIN reporter_history h USING (accession_number)
     WHERE h.submission_type = 'SCHEDULE 13D'
@@ -114,6 +120,7 @@ SELECT count(*) AS accessions,
        count(*) FILTER (WHERE NOT prior_13d) AS first_13d_per_chain,
        count(*) FILTER (WHERE prior_13d) AS repeated_initial_label,
        count(*) FILTER (WHERE prior_13g) AS prior_13g,
+       count(*) FILTER (WHERE ambiguous_chain_order) AS ambiguous_chain_order,
        count(DISTINCT instrument_id) AS mapped_instruments
 FROM classified
 """

--- a/scripts/verify_2582_schedule13d_census.py
+++ b/scripts/verify_2582_schedule13d_census.py
@@ -63,37 +63,59 @@ ORDER BY 1
 """
 
 _CHAIN_SHAPE: LiteralString = """
-WITH accessions AS (
+WITH initial_accessions AS (
     SELECT accession_number,
-           min(filer_id) AS filer_id,
            min(issuer_cik) AS issuer_cik,
            min(filed_at) AS filed_at,
            max(instrument_id) FILTER (WHERE instrument_id IS NOT NULL) AS instrument_id
     FROM blockholder_filings
     WHERE submission_type = 'SCHEDULE 13D'
     GROUP BY accession_number
-), ranked AS (
-    SELECT a.*,
-           row_number() OVER (
-               PARTITION BY filer_id, issuer_cik
-               ORDER BY filed_at, accession_number
-           ) AS chain_rank,
-           EXISTS (
-               SELECT 1
-               FROM blockholder_filings prior
-               WHERE prior.filer_id = a.filer_id
-                 AND prior.issuer_cik = a.issuer_cik
-                 AND prior.status = 'passive'
-                 AND prior.filed_at < a.filed_at
+), reporter_events AS (
+    SELECT DISTINCT accession_number,
+           issuer_cik,
+           coalesce(reporter_cik, reporter_name) AS reporter_identity,
+           filed_at,
+           submission_type,
+           status
+    FROM blockholder_filings
+    WHERE submission_type IN (
+        'SCHEDULE 13D', 'SCHEDULE 13D/A',
+        'SCHEDULE 13G', 'SCHEDULE 13G/A'
+    )
+), reporter_history AS (
+    SELECT r.*,
+           coalesce(
+               bool_or(status = 'active') OVER (
+                   PARTITION BY issuer_cik, reporter_identity
+                   ORDER BY filed_at, accession_number
+                   ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+               ), false
+           ) AS prior_13d,
+           coalesce(
+               bool_or(status = 'passive') OVER (
+                   PARTITION BY issuer_cik, reporter_identity
+                   ORDER BY filed_at, accession_number
+                   ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+               ), false
            ) AS prior_13g
-    FROM accessions a
+    FROM reporter_events r
+), classified AS (
+    SELECT a.accession_number,
+           a.instrument_id,
+           bool_or(h.prior_13d) AS prior_13d,
+           bool_or(h.prior_13g) AS prior_13g
+    FROM initial_accessions a
+    JOIN reporter_history h USING (accession_number)
+    WHERE h.submission_type = 'SCHEDULE 13D'
+    GROUP BY a.accession_number, a.instrument_id
 )
 SELECT count(*) AS accessions,
-       count(*) FILTER (WHERE chain_rank = 1) AS first_13d_per_chain,
-       count(*) FILTER (WHERE chain_rank > 1) AS repeated_initial_label,
+       count(*) FILTER (WHERE NOT prior_13d) AS first_13d_per_chain,
+       count(*) FILTER (WHERE prior_13d) AS repeated_initial_label,
        count(*) FILTER (WHERE prior_13g) AS prior_13g,
        count(DISTINCT instrument_id) AS mapped_instruments
-FROM ranked
+FROM classified
 """
 
 _SOURCE_SHAPE: LiteralString = """

--- a/tests/test_verify_2582_schedule13d_census.py
+++ b/tests/test_verify_2582_schedule13d_census.py
@@ -96,4 +96,19 @@ def test_joint_accession_uses_every_reporter_chain(ebull_test_conn: psycopg.Conn
     )
 
     row = ebull_test_conn.execute(_CHAIN_SHAPE).fetchone()
-    assert row == (3, 2, 1, 1, 0)
+    assert row == (3, 2, 1, 1, 0, 0)
+
+
+def test_same_timestamp_does_not_invent_chain_order(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    filed_at = datetime(2025, 2, 3, tzinfo=UTC)
+    for accession in ("0000000006-25-000001", "0000000006-25-000002"):
+        _seed(
+            ebull_test_conn,
+            accession=accession,
+            submission_type="SCHEDULE 13D",
+            reporter_cik="0000000006",
+            filed_at=filed_at,
+        )
+
+    row = ebull_test_conn.execute(_CHAIN_SHAPE).fetchone()
+    assert row == (2, 2, 0, 0, 2, 0)

--- a/tests/test_verify_2582_schedule13d_census.py
+++ b/tests/test_verify_2582_schedule13d_census.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import psycopg
+
+from scripts.verify_2582_schedule13d_census import _CHAIN_SHAPE
+
+
+def _seed(
+    conn: psycopg.Connection[tuple],
+    *,
+    accession: str,
+    submission_type: str,
+    reporter_cik: str,
+    filed_at: datetime,
+) -> int:
+    filer_cik = "".join(character for character in accession if character.isdigit())[-10:]
+    conn.execute(
+        "INSERT INTO blockholder_filers (cik, name) VALUES (%s, %s)",
+        (filer_cik, f"Filer {accession}"),
+    )
+    status = "active" if submission_type.startswith("SCHEDULE 13D") else "passive"
+    conn.execute(
+        """
+        INSERT INTO blockholder_filings (
+            filer_id, accession_number, submission_type, status,
+            issuer_cik, issuer_cusip, reporter_cik, reporter_no_cik,
+            reporter_name, filed_at
+        )
+        SELECT filer_id, %s, %s, %s, '0000000789', '999999999',
+               %s, FALSE, %s, %s
+        FROM blockholder_filers WHERE cik = %s
+        """,
+        (
+            accession,
+            submission_type,
+            status,
+            reporter_cik,
+            f"Reporter {reporter_cik}",
+            filed_at,
+            filer_cik,
+        ),
+    )
+    row = conn.execute("SELECT filer_id FROM blockholder_filers WHERE cik = %s", (filer_cik,)).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def test_joint_accession_uses_every_reporter_chain(ebull_test_conn: psycopg.Connection[tuple]) -> None:
+    """A non-primary joint reporter's history must classify the accession."""
+
+    _seed(
+        ebull_test_conn,
+        accession="0000000001-25-000001",
+        submission_type="SCHEDULE 13G",
+        reporter_cik="0000000002",
+        filed_at=datetime(2025, 1, 2, tzinfo=UTC),
+    )
+    _seed(
+        ebull_test_conn,
+        accession="0000000003-25-000001",
+        submission_type="SCHEDULE 13D",
+        reporter_cik="0000000003",
+        filed_at=datetime(2025, 1, 3, tzinfo=UTC),
+    )
+    _seed(
+        ebull_test_conn,
+        accession="0000000004-25-000001",
+        submission_type="SCHEDULE 13D",
+        reporter_cik="0000000004",
+        filed_at=datetime(2025, 1, 4, tzinfo=UTC),
+    )
+    # Add two reporters to one initial 13D. Reporter 2 carries the prior 13G;
+    # reporter 3 carries the prior 13D. Neither is the current primary filer.
+    current_filer_id = _seed(
+        ebull_test_conn,
+        accession="0000000005-25-000001",
+        submission_type="SCHEDULE 13D",
+        reporter_cik="0000000002",
+        filed_at=datetime(2025, 1, 5, tzinfo=UTC),
+    )
+    # The unique accession/reporter index permits this joint-reporter row, but
+    # _seed would try to insert the same primary filer again. Insert only row 2.
+    ebull_test_conn.execute(
+        """
+        INSERT INTO blockholder_filings (
+            filer_id, accession_number, submission_type, status,
+            issuer_cik, issuer_cusip, reporter_cik, reporter_no_cik,
+            reporter_name, filed_at
+        ) VALUES (%s, '0000000005-25-000001', 'SCHEDULE 13D', 'active',
+                  '0000000789', '999999999', '0000000003', FALSE,
+                  'Reporter 3', TIMESTAMPTZ '2025-01-05 00:00:00+00')
+        """,
+        (current_filer_id,),
+    )
+
+    row = ebull_test_conn.execute(_CHAIN_SHAPE).fetchone()
+    assert row == (3, 2, 1, 1, 0)


### PR DESCRIPTION
## Outcome

Makes initial Schedule 13D disclosures the first source-feasible untested event candidate, without calling it viable or opening outcomes. Replaces the stale ordered-programme instruction to continue the already-closed PEAD trial.

Refs #2582. Refs #2469.

## Evidence

- 1,285 deduplicated initial 13D accessions from the modern structured frontier; 1,160 research-series maps; 895 with 60 prior plus 20 later calendar days.
- causal reporter-aware chain census: 1,227 have no strictly earlier active timestamp for any attached reporter/issuer; 58 have earlier active history; 46 have earlier passive 13G-family history; 37 have same-timestamp ambiguity; 855 mapped instruments.
- all 1,285 canonical raw documents contain structured Item 4; no duplicate raw store is proposed.
- only 123 accessions have precise filing times; 1,162 are date-only and therefore refuse any fill earlier than the next regular-session open.
- SEC evidence is carried as a falsifier: much of the reaction in one corporate-action subset occurred before public filing.

The verifier uses a read-only transaction and coverage metadata only. It never queries `research_price_daily` or an outcome ledger and emits `outcomes_read: false`.

## Review resolution

- FIXED `6f217607`: manual review found `min(filer_id)` discarded joint reporters. History is now per `(issuer, reporter identity)` and every attached reporter aggregates back to one accession.
- FIXED latest commit: self-review found accession order could invent chronology among date-only same-day filings. Window frames now include only strictly earlier timestamps (`EXCLUDE GROUP`) and expose 37 ambiguous accessions.
- DB fixtures pin both cases. Mutation check: forcing `prior_13d=false` makes the joint fixture fail `(3,3,0,1,0,0)` versus `(3,2,1,1,0,0)`.

## Storage / safety

No schema or data write. Existing raw 13D/G storage is 44,732 deduplicated documents / 409,254,319 uncompressed bytes. A future shadow candidate may persist only a compact category/version/hash on a fired/refused decision; no copied Item 4, indicator history or polling snapshots.

## Testing

- `PYTHONPATH=. uv run python scripts/verify_2582_schedule13d_census.py --json`
- `uv run pytest -q tests/test_verify_2582_schedule13d_census.py` — 2 passed locally against PostgreSQL
- mutation proved: forced broken reporter aggregation failed the fixture
- ruff + pyright: green
- full pre-push gate: green on preceding SHA; rerunning on latest push
