### PR TITLE
docs(strategy): freeze Schedule 13D catalyst trial

### DIFF
--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -262,7 +262,9 @@ close and charges 50 bps round trip. There is deliberately no historical TP/SL:
 a capital bracket is a separately identified executable adaptation and cannot be
 selected from the same opened outcomes. The contract also pins unfiltered 13D,
 seeded same-instrument random-time and rule-stratified initial-13G challengers,
-plus attribution fields that cannot gate the result.
+plus attribution fields that cannot gate the result. Exact matching buckets,
+tie-breaking, challenger multiplicity and recent stability are part of the
+machine contract. Item 4 is hashed but deliberately not classified in v1.
 
 The 895-event source ceiling exists before chain and liquidity refusals. Against
 the declared 1% minimum worthwhile effect and 10% planning standard deviation,

--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -72,7 +72,7 @@ what deserves a preregistered test; they are not backtest results.
 | **Order-flow, market making and intraday liquidity** | Paid compensation for immediacy and inventory risk; requires trades, depth, side and latency. | Blocked: WebSocket/REST gives best prices but no reliable depth, aggressor side or historical book. | Retail API rate and latency are unsuitable for market making. | **Out of scope.** Do not proxy order-flow imbalance from OHLCV and call it the same signal. |
 | **News, filing text and LLM features** | Convert new unstructured information into a timestamped structured event; an LLM is an extractor, not a price oracle. | Low today: `filing_documents` holds URLs, not bodies; free news is incomplete and licensing-sensitive. | Neutral once a validated low-turnover event exists. | **Future data spike, not a first-round return trial.** Any extracted feature competes with a simple event baseline. |
 | **13F/crowding and FINRA short volume** | Slow ownership/crowding or forced-unwind context. 13F is delayed; daily short volume is flow, not short interest or borrow availability. | High for existing 13F and Reg SHO/FINRA-like data, but semantics limit actionability. | Low/medium as context; cannot prove an instrument can be borrowed. | **Context only.** No cloning strategy. Test only if a separately admitted mechanism requires it. |
-| **Activist ownership (Schedule 13D)** | A new control stake can create a dated catalyst distinct from delayed 13F cloning; passive 13G is not the same hypothesis. | Medium: structured 13D/G ownership exists, but point-in-time filing/class/amendment coverage and recent population need a census. | Conditional long fit. | **Reserved independent event family.** Establish published prior, 13D-versus-13G placebo and coverage before candidate admission. Do not fold it into generic 13F. |
+| **Activist ownership (Schedule 13D)** | A new control stake can create a dated catalyst distinct from delayed 13F cloning; passive 13G is not the same hypothesis. | Medium: the outcome-free census found 895 modern initial 13Ds with basic 60-prior/20-later coverage, but historical security identity remains survivor-biased and filing times are mostly date-only. | Conditional long fit. | **C-4 historical falsification preregistered; no capital candidate.** One clean-chain, next-session-open, ten-session test is frozen. A pass only permits prospective shadowing; a failure is not tuned. |
 | **Issuer capital events** | Buybacks, issuance/dilution, dividends and treasury changes alter supply or distribute cash; announcements, accounting realization and mechanical ex-date moves are different events. | Medium: XBRL buyback/treasury/share data and dividend events exist, but announcement knowledge time and completeness vary. | Conditional long fit; dividend capture must clear price adjustment and tax. | **Taxonomy only.** Split into one economically specific preregistration if a coverage census supports it; do not combine all capital events into a vote. |
 | **Listing, index and calendar flows** | Index additions/deletions, Form 25/delistings, IPO lockups, month-end and tax-loss flows can force trading on known schedules. | Low/medium: prospective listing membership and Form 25 exist; historical index membership, lockup terms and a complete event history do not. | Product/side dependent. | **Reserved/data-gated.** Current Nasdaq daily files support prospective detection, not a survivorship-free historical claim. Seasonality requires an explicit mechanism and trial charge. |
 
@@ -240,13 +240,13 @@ admission rests on the independent published factor prior and low-turnover portf
 role; the existing S-2 result is a contaminated harness observation and cannot select,
 weight or power C-3.
 
-### Conditional candidate C-4 — initial Schedule 13D catalyst
+### Preregistered falsification C-4 — initial Schedule 13D catalyst
 
 The read-only #2582 census found 1,285 structured initial-13D accessions from
 2024-12-18 through 2026-08-12, 1,160 mapped research-price series and 895 events
 with 60 prior plus 20 later calendar days. All raw documents already contain Item 4;
-no outcome was opened and no new raw store is required. This is enough to write an
-exact preregistration, not enough to call the candidate viable.
+no outcome was opened and no new raw store is required. This was enough to freeze
+one exact historical falsification, not enough to call the candidate viable.
 
 The family has an independent forced-participant mechanism: an active/control stake
 becomes public. It also has an unusually strong falsifier. The SEC's 2023 rule
@@ -255,11 +255,24 @@ the filing. eBull may trade only after dissemination. Moreover, 1,162 of the 1,2
 current rows are date-only, so their causal historical fill is no earlier than the
 next regular-session open.
 
-Before outcomes, #2582 must freeze campaign/conversion/repeat identity, Item 4
-purpose handling, decision clock, one comparison horizon, 13G/random challengers,
-cost arms, trial denominator and untouched terminal interval. A capital TP/SL rule
-is a separately identified executable adaptation and cannot be selected from the
-same opened outcomes. See `2026-08-12-schedule-13d-source-census.md`.
+The frozen C-4 primary population is a clean first active chain with no earlier
+active or passive filing and no same-timestamp ambiguity. It enters at the first
+regular-session open strictly after the filing date, exits at the tenth session
+close and charges 50 bps round trip. There is deliberately no historical TP/SL:
+a capital bracket is a separately identified executable adaptation and cannot be
+selected from the same opened outcomes. The contract also pins unfiltered 13D,
+seeded same-instrument random-time and rule-stratified initial-13G challengers,
+plus attribution fields that cannot gate the result.
+
+The 895-event source ceiling exists before chain and liquidity refusals. Against
+the declared 1% minimum worthwhile effect and 10% planning standard deviation,
+the independent-observation requirement is 785 before clustering. The result may
+therefore be inconclusive even if its mean is positive; that is not permission to
+relax the population. Historical data can only falsify or justify prospective
+shadow collection and can never promote capital because its universe is
+survivor-biased and it lacks historical broker economics. See
+`2026-08-12-schedule-13d-source-census.md` and
+`2026-08-12-schedule-13d-preregistration.md`.
 
 The exact sector-residual replication in #2522 remains source-blocked. It does not
 become C-4 by substituting current classifications, survivor projection or fixed

--- a/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
@@ -1,0 +1,119 @@
+# Schedule 13D public-catalyst preregistration
+
+Date: 2026-08-12  
+Issue: #2582  
+Machine contract: `contracts/schedule13d-public-catalyst-v1.json`  
+Status: frozen for implementation review; outcomes still unopened
+
+## Verdict before measurement
+
+This is a bounded attempt to falsify one mechanism, not a fifth visible
+strategy. The current four strategy rows are harness controls and the completed
+2022-plus holdout confirms that none should receive capital. This candidate
+gets a separate identity and can be rejected without altering those controls.
+
+The old activism literature is only a prior. Brav, Jiang, Partnoy and Thomas
+report that roughly half of their 2001-2006 announcement-window abnormal return
+occurred before filing, about two percentage points occurred on filing day and
+the day after, and the cumulative abnormal return continued rising through day
+20. The same paper reports a median activist holding period near a year; it is
+not evidence for a scalp. The SEC subsequently shortened the initial 13D
+deadline from ten calendar days to five business days, with the modern rule
+effective before this structured corpus. The retained 2024-2026 population must
+therefore stand on its own.
+
+Sources:
+
+- [SEC modernisation release](https://www.sec.gov/newsroom/press-releases/2023-219)
+- [SEC adopting release and economic analysis](https://www.sec.gov/files/rules/final/2023/33-11253.pdf)
+- [Brav, Jiang, Partnoy and Thomas](https://business.columbia.edu/sites/default/files-efs/pubfiles/4132/jiang_activism.pdf)
+
+## Exact question
+
+For a liquid US common stock whose clean first active Schedule 13D becomes
+public, does buying at the first regular-session open strictly after the filing
+date and selling at the tenth session close produce positive total return after
+50 basis points round trip?
+
+Ten sessions is the only historical holding horizon. There is no historical
+stop or profit target. Searching brackets at the same time as the edge would
+change the question and multiply trials. If the result passes, maximum adverse
+and favourable excursion may inform a **newly frozen** bracket, which must then
+survive untouched prospective shadow evidence. Until that later gate, there is
+nothing to paper trade.
+
+## Population and causality
+
+The primary population is one accession per clean campaign:
+
+- exact form `SCHEDULE 13D`;
+- every reporting person contributes prior issuer/reporting-person history;
+- only strictly earlier `filed_at` timestamps establish history;
+- no earlier active filing, no earlier passive filing and no same-timestamp
+  peer for any attached reporting person;
+- one accession is counted once even when it has joint reporters;
+- mapped liquid US common equity with 60 prior sessions and complete outcome
+  coverage.
+
+Conversions, repeats and same-timestamp ambiguity are labelled attribution
+groups and never silently mixed into the primary estimate. Date-only rows and
+the 123 rows with a precise time deliberately share the next-session-open rule:
+the daily archive cannot simulate a causal intraday fill, and a more favourable
+fill for one subset would make the arms incomparable.
+
+Eligibility is known before entry: at least $5 at the proposed open and at
+least $10 million trailing median daily dollar volume over 20 completed
+sessions. Missing identity, security type, OHLCV or corporate-action treatment
+is a refusal, not a dropped observation.
+
+## Returns, controls and multiple testing
+
+Execution uses raw open and close. Total return applies the change in
+`adj_close / close` across those execution dates, so splits and distributions
+are not silently ignored. The primary result charges 50 bps round trip and also
+reports the cost at which expectancy reaches zero.
+
+Three challengers use the same eligible observations and timing:
+
+1. all otherwise eligible 13Ds, showing whether chain cleaning creates the
+   claim;
+2. one seeded non-event date on the same instrument and calendar month;
+3. initial 13Gs, kept separate by Rule 13d-1(b), Rule 13d-1(c), or unknown and
+   matched without replacement on pre-event properties.
+
+Market, volatility, exchange, liquidity, price, purpose and prior-return fields
+are attribution. They may explain a failure or define prospective risk, but
+cannot rescue a failed primary result by selecting a winning slice. Signal
+strength monotonicity is reported only for predeclared continuous source fields;
+it does not authorise a threshold search.
+
+The complete modern archive is one historical falsification interval. It does
+not claim a pristine terminal holdout: the genuinely untouched interval begins
+with filings arriving after this contract. That prospective interval is
+required because the price archive is survivor-biased and lacks historical
+broker eligibility and observed spreads.
+
+## Power and admission
+
+The planning target is a 1.0% net ten-session effect, 10% event-return standard
+deviation, two-sided 5% alpha and 80% power. The normal approximation requires
+785 independent observations. The source census has only 895 events with basic
+60-prior/20-later coverage before chain, liquidity and identity refusals, so the
+trial is likely underpowered for that target after clustering. This limitation
+is declared before returns: a wide interval is `inconclusive`, not evidence of
+no effect and not permission to relax filters.
+
+Historical passage requires all of the following: adverse-cost clustered lower
+bound above zero, profit factor above one, positive return after removing the
+best 1%, no issuer/session concentration dependency and no material challenger
+or regime contradiction. Even a pass cannot authorise capital. It only permits
+a separate bracket/sizing contract and prospective shadow collection. A failure
+is retained without a purpose, threshold, horizon or regime rescue.
+
+## Storage and product boundary
+
+The evaluator reads the existing canonical 13D/G document and daily price
+archive. It creates no copied raw filing, indicator history, per-bar feature
+table or non-firing poll log. Its retained research output is one bounded
+aggregate artifact. The Strategies page should continue to show zero approved
+strategies unless a later candidate clears every capital gate.

--- a/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
@@ -78,14 +78,25 @@ Three challengers use the same eligible observations and timing:
 1. all otherwise eligible 13Ds, showing whether chain cleaning creates the
    claim;
 2. one seeded non-event date on the same instrument and calendar month;
-3. initial 13Gs, kept separate by Rule 13d-1(b), Rule 13d-1(c), or unknown and
-   matched without replacement on pre-event properties.
+3. initial 13Gs, kept separate by Rule 13d-1(b), Rule 13d-1(c), both, or
+   unknown and matched without replacement within filing month, fixed price,
+   dollar-volume and prior-market-return buckets. A SHA-256 ordering over both
+   accessions and seed 2582 resolves ties; unmatched treatments remain in the
+   primary result but not that paired comparison.
+
+The initial-13G challenger is source-feasible: an outcome-free raw-document
+census found 10,419 filings with the same basic coverage (7,429 Rule 13d-1(b),
+2,262 Rule 13d-1(c), 33 carrying both and 695 unknown). Its strong February and
+quarterly filing waves are why filing month and rule are exact strata rather
+than an undifferentiated placebo.
 
 Market, volatility, exchange, liquidity, price, purpose and prior-return fields
 are attribution. They may explain a failure or define prospective risk, but
 cannot rescue a failed primary result by selecting a winning slice. Signal
-strength monotonicity is reported only for predeclared continuous source fields;
-it does not authorise a threshold search.
+strength monotonicity is reported only for the accession's maximum disclosed
+percent of class; it does not authorise a threshold search. Item 4 text is not
+classified in v1: its presence and document hash are audited, but a subjective
+post-outcome purpose taxonomy cannot enter this trial.
 
 The complete modern archive is one historical falsification interval. It does
 not claim a pristine terminal holdout: the genuinely untouched interval begins
@@ -103,12 +114,17 @@ trial is likely underpowered for that target after clustering. This limitation
 is declared before returns: a wide interval is `inconclusive`, not evidence of
 no effect and not permission to relax filters.
 
-Historical passage requires all of the following: adverse-cost clustered lower
-bound above zero, profit factor above one, positive return after removing the
-best 1%, no issuer/session concentration dependency and no material challenger
-or regime contradiction. Even a pass cannot authorise capital. It only permits
-a separate bracket/sizing contract and prospective shadow collection. A failure
-is retained without a purpose, threshold, horizon or regime rescue.
+Historical passage requires effective sample size of at least 785, an
+adverse-cost clustered lower bound above zero, Holm-adjusted positive
+differences versus random time and the separately matched Rule 13d-1(b) and
+13d-1(c) challengers, profit factor above one, positive return after removing
+the best 1%, no issuer or entry session supplying 20% of gross positive return,
+and positive recent stability (the latest and at least two of three
+non-overlapping six-month means). Even a pass cannot authorise capital. This
+event study reports concurrency but not portfolio drawdown or turnover: those
+numbers require a capital-allocation rule that does not yet exist. A pass only
+permits a separate bracket/sizing contract and prospective shadow collection.
+A failure is retained without a purpose, threshold, horizon or regime rescue.
 
 ## Storage and product boundary
 

--- a/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
@@ -97,6 +97,24 @@ No typed `date_of_event` is present for these initial rows. That field is the
 private ownership-trigger date, not the public action time in any case; it may
 measure disclosure lag but can never authorise a pre-filing trade.
 
+## Initial 13G challenger feasibility
+
+The same outcome-free coverage join and structured-document rule labels found
+the following initial-13G challenger ceiling. `Both` and `unknown` remain
+separate; they are never pooled into a known regulatory rule.
+
+| filing year | Rule 13d-1(b) | Rule 13d-1(c) | both | unknown | total with 60 prior + 20 later days |
+|---|---:|---:|---:|---:|---:|
+| 2024 from 18 December | 3 | 49 | 1 | 4 | 57 |
+| 2025 | 3,350 | 1,418 | 21 | 486 | 5,275 |
+| 2026 through complete coverage | 4,076 | 795 | 11 | 205 | 5,087 |
+| **total** | **7,429** | **2,262** | **33** | **695** | **10,419** |
+
+Initial 13Gs cluster heavily in February and at quarter/annual reporting waves.
+That source shape is why the frozen challenger matches within filing month and
+reports Rule 13d-1(b) and Rule 13d-1(c) separately. It does not establish that a
+matched passive filing is an economically perfect counterfactual.
+
 ## Storage impact
 
 The canonical 13D/G raw store already contains 44,732 deduplicated documents,

--- a/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
@@ -4,6 +4,11 @@ Date: 2026-08-12
 Issue: #2582
 Status: source-feasible for preregistration; outcomes unopened
 
+The exact follow-on contract is now frozen in
+`2026-08-12-schedule-13d-preregistration.md` and
+`contracts/schedule13d-public-catalyst-v1.json`. This census remains source
+evidence and does not inherit any return result.
+
 ## Decision
 
 An initial Schedule 13D is the first untested short-horizon event family in the

--- a/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
+++ b/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
@@ -53,10 +53,24 @@
   },
   "challengers": {
     "unfiltered_eligible_13d": "same_fill_exit_cost_and_coverage",
-    "matched_random_time": "one_seeded_non_event_date_per_treatment_same_instrument_calendar_month",
+    "matched_random_time": "one_seeded_eligible_non_event_date_per_treatment_same_instrument_calendar_month_excluding_any_13d_plus_or_minus_10_sessions",
     "random_seed": 2582,
-    "initial_13g": "report_separately_by_13d_1b_13d_1c_or_unknown_rule_then_match_without_replacement_on_filing_month_price_dollar_volume_and_market_return_buckets",
-    "unknown_13g_rule": "never_pool_with_known_rule"
+    "initial_13g": "match_without_replacement_and_report_separately_by_13d_1b_13d_1c_both_or_unknown_rule",
+    "matching": {
+      "exact_fields": [
+        "filing_year_month",
+        "entry_price_bucket",
+        "trailing_dollar_volume_bucket",
+        "prior_20_session_market_return_bucket"
+      ],
+      "entry_price_bucket_usd_edges": [5, 10, 25, 50, 100],
+      "trailing_dollar_volume_bucket_usd_edges": [10000000, 25000000, 100000000, 500000000],
+      "prior_20_session_market_return_pct_edges": [-5, 0, 5],
+      "tie_break": "sha256_treatment_accession_challenger_accession_seed_ascending",
+      "unmatched_treatment": "retain_primary_but_refuse_that_challenger_pair"
+    },
+    "unknown_13g_rule": "never_pool_with_known_rule",
+    "multiplicity": "holm_adjust_random_13d_1b_and_13d_1c_differences_at_family_alpha_0_05"
   },
   "context": {
     "predeclared_attribution_only": [
@@ -68,14 +82,15 @@
       "prior_20_session_stock_return",
       "prior_20_session_market_return",
       "market_return_over_holding_window",
-      "item4_purpose_category"
+      "maximum_percent_of_class_across_accession_reporters"
     ],
     "context_may_gate_primary_result": false,
-    "subgroup_selection_after_outcome": "forbidden"
+    "subgroup_selection_after_outcome": "forbidden",
+    "item4_policy": "not_used_in_v1_beyond_required_source_presence_and_document_hash"
   },
   "statistics": {
     "primary_estimand": "mean_net_total_return_pct",
-    "confidence_interval": "two_way_issuer_and_entry_session_cluster_bootstrap_95pct",
+    "confidence_interval": "two_way_pigeonhole_bootstrap_by_issuer_and_entry_session_95pct_percentile",
     "bootstrap_seed": 2582,
     "bootstrap_resamples": 10000,
     "minimum_worthwhile_net_effect_pct": 1.0,
@@ -93,9 +108,7 @@
       "profit_factor",
       "expected_shortfall_5pct",
       "worst_gap",
-      "maximum_drawdown",
       "concurrency",
-      "turnover",
       "sector_and_issuer_concentration",
       "result_excluding_best_1pct",
       "rolling_6_month_result",
@@ -106,11 +119,16 @@
   },
   "acceptance": {
     "historical_pass_requires": [
+      "effective_sample_size_gte_785",
       "adverse_cost_clustered_lower_bound_gt_zero",
+      "holm_adjusted_lower_bound_vs_random_gt_zero",
+      "holm_adjusted_lower_bound_vs_matched_13d_1b_gt_zero",
+      "holm_adjusted_lower_bound_vs_matched_13d_1c_gt_zero",
       "profit_factor_gt_one",
       "positive_result_excluding_best_1pct",
-      "no_single_issuer_or_session_drives_result",
-      "no_material_challenger_or_regime_contradiction"
+      "no_issuer_or_entry_session_supplies_20pct_or_more_of_gross_positive_return",
+      "latest_nonoverlapping_6_month_mean_positive",
+      "at_least_two_of_three_nonoverlapping_6_month_means_positive"
     ],
     "historical_archive_can_promote_capital": false,
     "next_stage_if_passed": "freeze_bracket_and_sizing_then_collect_untouched_prospective_shadow",

--- a/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
+++ b/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
@@ -1,0 +1,125 @@
+{
+  "candidate_id": "c4-schedule13d-public-catalyst",
+  "contract_version": "schedule13d-public-catalyst-v1",
+  "decision": "historical_falsification_only",
+  "hypothesis": "A clean first public Schedule 13D has positive ten-session total return after a causal retail fill and adverse costs.",
+  "source": {
+    "form": "SCHEDULE 13D",
+    "document_kind": "primary_doc_13dg",
+    "first_source_date": "2024-12-18",
+    "last_complete_filing_date": "2026-06-18",
+    "research_vendor": "paperswithbacktest/Stocks-Daily-Price"
+  },
+  "event_identity": {
+    "unit": "one accession_number",
+    "reporter_identity": "reporter_cik_else_normalized_reporter_name",
+    "issuer_identity": "issuer_cik",
+    "joint_reporter_rule": "union_history_across_every_reporter_then_count_accession_once",
+    "prior_history_order": "strictly_earlier_filed_at_only",
+    "primary_population": "no_prior_active_and_no_prior_passive_and_no_same_timestamp_peer",
+    "separate_attribution_only": [
+      "prior_passive_13g_to_13d_conversion",
+      "prior_active_repeat",
+      "same_timestamp_chain_ambiguous"
+    ]
+  },
+  "eligibility": {
+    "instrument_mapping_required": true,
+    "research_series_mapping_required": true,
+    "minimum_prior_daily_sessions": 60,
+    "minimum_entry_price_usd": 5.0,
+    "minimum_trailing_20_session_median_dollar_volume_usd": 10000000,
+    "security_scope": "US_listed_common_equity",
+    "unknown_security_type": "refuse",
+    "missing_or_nonpositive_ohlcv": "refuse",
+    "corporate_action_ambiguity": "refuse"
+  },
+  "decision_clock": {
+    "historical_fill": "first_regular_session_open_strictly_after_filing_date",
+    "date_only_policy": "never_same_day",
+    "precise_timestamp_policy": "same_next_session_rule_for_daily_corpus_comparability",
+    "same_close_fill": "forbidden"
+  },
+  "position": {
+    "side": "long",
+    "entry": "raw_open_at_historical_fill",
+    "exit": "raw_close_of_tenth_regular_session_including_entry_session_as_session_one",
+    "holding_sessions": 10,
+    "stop_loss": null,
+    "take_profit": null,
+    "return_basis": "raw_execution_prices_with_adj_close_over_close_total_return_factor",
+    "round_trip_adverse_cost_bps": 50,
+    "break_even_cost_bps_reported": true
+  },
+  "challengers": {
+    "unfiltered_eligible_13d": "same_fill_exit_cost_and_coverage",
+    "matched_random_time": "one_seeded_non_event_date_per_treatment_same_instrument_calendar_month",
+    "random_seed": 2582,
+    "initial_13g": "report_separately_by_13d_1b_13d_1c_or_unknown_rule_then_match_without_replacement_on_filing_month_price_dollar_volume_and_market_return_buckets",
+    "unknown_13g_rule": "never_pool_with_known_rule"
+  },
+  "context": {
+    "predeclared_attribution_only": [
+      "filing_year_month",
+      "exchange",
+      "entry_price_bucket",
+      "trailing_dollar_volume_bucket",
+      "trailing_20_session_realised_volatility_bucket",
+      "prior_20_session_stock_return",
+      "prior_20_session_market_return",
+      "market_return_over_holding_window",
+      "item4_purpose_category"
+    ],
+    "context_may_gate_primary_result": false,
+    "subgroup_selection_after_outcome": "forbidden"
+  },
+  "statistics": {
+    "primary_estimand": "mean_net_total_return_pct",
+    "confidence_interval": "two_way_issuer_and_entry_session_cluster_bootstrap_95pct",
+    "bootstrap_seed": 2582,
+    "bootstrap_resamples": 10000,
+    "minimum_worthwhile_net_effect_pct": 1.0,
+    "planning_return_standard_deviation_pct": 10.0,
+    "planning_alpha_two_sided": 0.05,
+    "planning_power": 0.8,
+    "minimum_planning_effective_sample_size": 785,
+    "required_reports": [
+      "eligible_event_count",
+      "effective_sample_size",
+      "mean_and_median_net_return",
+      "confidence_interval",
+      "hit_rate",
+      "average_winner_and_loser",
+      "profit_factor",
+      "expected_shortfall_5pct",
+      "worst_gap",
+      "maximum_drawdown",
+      "concurrency",
+      "turnover",
+      "sector_and_issuer_concentration",
+      "result_excluding_best_1pct",
+      "rolling_6_month_result",
+      "rolling_12_month_result",
+      "signal_strength_monotonicity",
+      "break_even_cost"
+    ]
+  },
+  "acceptance": {
+    "historical_pass_requires": [
+      "adverse_cost_clustered_lower_bound_gt_zero",
+      "profit_factor_gt_one",
+      "positive_result_excluding_best_1pct",
+      "no_single_issuer_or_session_drives_result",
+      "no_material_challenger_or_regime_contradiction"
+    ],
+    "historical_archive_can_promote_capital": false,
+    "next_stage_if_passed": "freeze_bracket_and_sizing_then_collect_untouched_prospective_shadow",
+    "next_stage_if_failed": "retain_rejection_without_threshold_horizon_purpose_or_regime_rescue"
+  },
+  "storage": {
+    "duplicate_raw_document": false,
+    "persist_non_firing_poll_rows": false,
+    "research_output": "one_bounded_aggregate_artifact",
+    "prospective_output_if_authorised": "one_compact_fired_or_refused_decision_with_category_version_and_hash"
+  }
+}

--- a/scripts/verify_2582_schedule13d_preregistration.py
+++ b/scripts/verify_2582_schedule13d_preregistration.py
@@ -22,9 +22,13 @@ def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
     assert contract["position"]["round_trip_adverse_cost_bps"] == 50
     assert contract["decision_clock"]["same_close_fill"] == "forbidden"
     assert contract["context"]["context_may_gate_primary_result"] is False
+    assert contract["context"]["item4_policy"].startswith("not_used_in_v1")
+    assert contract["challengers"]["matching"]["entry_price_bucket_usd_edges"] == [5, 10, 25, 50, 100]
+    assert contract["challengers"]["multiplicity"].startswith("holm_adjust")
     assert contract["acceptance"]["historical_archive_can_promote_capital"] is False
     assert contract["storage"]["duplicate_raw_document"] is False
     assert contract["storage"]["persist_non_firing_poll_rows"] is False
+    assert "maximum_drawdown" not in contract["statistics"]["required_reports"]
 
     stats = contract["statistics"]
     effect = float(stats["minimum_worthwhile_net_effect_pct"]) / 100

--- a/scripts/verify_2582_schedule13d_preregistration.py
+++ b/scripts/verify_2582_schedule13d_preregistration.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 CONTRACT = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
+EXPECTED_SHA256 = "5a65e2d1e113cc66301cef625a99f999034ad3b2423635dc4d1657c3813ae6b7"
 
 
 def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
@@ -40,6 +41,7 @@ def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
     assert stats["minimum_planning_effective_sample_size"] == expected_n
 
     digest = hashlib.sha256(raw).hexdigest()
+    assert digest == EXPECTED_SHA256, f"frozen contract digest moved: {digest}"
     return contract, digest
 
 

--- a/scripts/verify_2582_schedule13d_preregistration.py
+++ b/scripts/verify_2582_schedule13d_preregistration.py
@@ -1,0 +1,59 @@
+"""Verify #2582's frozen, outcome-free Schedule 13D candidate contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+CONTRACT = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
+
+
+def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
+    raw = path.read_bytes()
+    contract = json.loads(raw)
+
+    assert contract["contract_version"] == "schedule13d-public-catalyst-v1"
+    assert contract["decision"] == "historical_falsification_only"
+    assert contract["position"]["holding_sessions"] == 10
+    assert contract["position"]["stop_loss"] is None
+    assert contract["position"]["take_profit"] is None
+    assert contract["position"]["round_trip_adverse_cost_bps"] == 50
+    assert contract["decision_clock"]["same_close_fill"] == "forbidden"
+    assert contract["context"]["context_may_gate_primary_result"] is False
+    assert contract["acceptance"]["historical_archive_can_promote_capital"] is False
+    assert contract["storage"]["duplicate_raw_document"] is False
+    assert contract["storage"]["persist_non_firing_poll_rows"] is False
+
+    stats = contract["statistics"]
+    effect = float(stats["minimum_worthwhile_net_effect_pct"]) / 100
+    sigma = float(stats["planning_return_standard_deviation_pct"]) / 100
+    # z(.975) + z(.8), squared. Ceiling of 7.84888 * 400 is 3,140 for
+    # 0.5%; here sigma/effect is 10, producing 784.888 -> 785.
+    expected_n = 785
+    assert round(7.84888 * (sigma / effect) ** 2) == expected_n
+    assert stats["minimum_planning_effective_sample_size"] == expected_n
+
+    digest = hashlib.sha256(raw).hexdigest()
+    return contract, digest
+
+
+def main() -> int:
+    contract, digest = load_and_verify()
+    print(
+        json.dumps(
+            {
+                "candidate_id": contract["candidate_id"],
+                "contract_version": contract["contract_version"],
+                "outcomes_read": False,
+                "sha256": digest,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_2582_schedule13d_preregistration.py
+++ b/tests/test_verify_2582_schedule13d_preregistration.py
@@ -15,6 +15,7 @@ def test_contract_is_fail_closed_and_outcome_free() -> None:
     assert contract["event_identity"]["prior_history_order"] == "strictly_earlier_filed_at_only"
     assert contract["eligibility"]["unknown_security_type"] == "refuse"
     assert contract["challengers"]["unknown_13g_rule"] == "never_pool_with_known_rule"
+    assert contract["challengers"]["matching"]["tie_break"].startswith("sha256_")
     assert contract["acceptance"]["next_stage_if_failed"].startswith("retain_rejection")
 
 

--- a/tests/test_verify_2582_schedule13d_preregistration.py
+++ b/tests/test_verify_2582_schedule13d_preregistration.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_2582_schedule13d_preregistration import load_and_verify
+
+
+def test_contract_is_fail_closed_and_outcome_free() -> None:
+    contract, digest = load_and_verify()
+
+    assert len(digest) == 64
+    assert contract["event_identity"]["prior_history_order"] == "strictly_earlier_filed_at_only"
+    assert contract["eligibility"]["unknown_security_type"] == "refuse"
+    assert contract["challengers"]["unknown_13g_rule"] == "never_pool_with_known_rule"
+    assert contract["acceptance"]["next_stage_if_failed"].startswith("retain_rejection")
+
+
+def test_verifier_rejects_a_bracket_smuggled_into_the_historical_trial(tmp_path: Path) -> None:
+    source = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
+    contract = json.loads(source.read_text())
+    contract["position"]["stop_loss"] = "2_atr"
+    mutated = tmp_path / "contract.json"
+    mutated.write_text(json.dumps(contract))
+
+    with pytest.raises(AssertionError):
+        load_and_verify(mutated)

--- a/tests/test_verify_2582_schedule13d_preregistration.py
+++ b/tests/test_verify_2582_schedule13d_preregistration.py
@@ -28,3 +28,14 @@ def test_verifier_rejects_a_bracket_smuggled_into_the_historical_trial(tmp_path:
 
     with pytest.raises(AssertionError):
         load_and_verify(mutated)
+
+
+def test_verifier_rejects_an_otherwise_unchecked_contract_mutation(tmp_path: Path) -> None:
+    source = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
+    contract = json.loads(source.read_text())
+    contract["hypothesis"] = "changed after outcomes"
+    mutated = tmp_path / "contract.json"
+    mutated.write_text(json.dumps(contract))
+
+    with pytest.raises(AssertionError, match="frozen contract digest moved"):
+        load_and_verify(mutated)


### PR DESCRIPTION
## Outcome

Freezes #2582 before any Schedule 13D price outcome is opened.

- one clean-chain first-13D population
- causal next-session-open fill and one ten-session exit
- 50 bps adverse round-trip cost
- no historical TP/SL or subgroup rescue search
- unfiltered 13D, seeded random-time, and rule-stratified 13G challengers
- declared power limit, rejection path, storage-neutral output

The historical archive can only falsify or justify prospective shadowing; it cannot promote capital.

## Validation

- full pre-push gate: green
- independent `codex exec review --base main`: no actionable defects
- contract digest: `e880feb2bb8b7b69c9edf9965474aa8c7390811254d2cb2158646017308f6dbf`

Refs #2582