### PR TITLE
fix(strategy): pin executable 13D source identities

### DIFF
--- a/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
+++ b/docs/proposals/ta/2026-08-11-portfolio-alpha-viability-plan.md
@@ -272,7 +272,9 @@ the independent-observation requirement is 785 before clustering. The result may
 therefore be inconclusive even if its mean is positive; that is not permission to
 relax the population. Historical data can only falsify or justify prospective
 shadow collection and can never promote capital because its universe is
-survivor-biased and it lacks historical broker economics. See
+survivor-biased, its stock classification is current-only and it lacks
+historical broker economics. Recent market context is pinned to the price-only
+SPY series 7713 and is not a total-return benchmark. See
 `2026-08-12-schedule-13d-source-census.md` and
 `2026-08-12-schedule-13d-preregistration.md`.
 

--- a/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
@@ -30,7 +30,7 @@ Sources:
 
 ## Exact question
 
-For a liquid US common stock whose clean first active Schedule 13D becomes
+For a liquid current eToro stock on Nasdaq or NYSE whose clean first active Schedule 13D becomes
 public, does buying at the first regular-session open strictly after the filing
 date and selling at the tenth session close produce positive total return after
 50 basis points round trip?
@@ -52,8 +52,8 @@ The primary population is one accession per clean campaign:
 - no earlier active filing, no earlier passive filing and no same-timestamp
   peer for any attached reporting person;
 - one accession is counted once even when it has joint reporters;
-- mapped liquid US common equity with 60 prior sessions and complete outcome
-  coverage.
+- mapped currently tradable eToro `Stocks` type on exchange id 4 (Nasdaq) or
+  5 (NYSE), with 60 prior sessions and complete outcome coverage.
 
 Conversions, repeats and same-timestamp ambiguity are labelled attribution
 groups and never silently mixed into the primary estimate. Date-only rows and
@@ -65,6 +65,11 @@ Eligibility is known before entry: at least $5 at the proposed open and at
 least $10 million trailing median daily dollar volume over 20 completed
 sessions. Missing identity, security type, OHLCV or corporate-action treatment
 is a refusal, not a dropped observation.
+
+The security classification is a current eToro snapshot, not point-in-time
+proof that every historical security was a common share. The historical result
+therefore remains survivor-biased and cannot promote capital even if every
+return test passes.
 
 ## Returns, controls and multiple testing
 
@@ -97,6 +102,11 @@ strength monotonicity is reported only for the accession's maximum disclosed
 percent of class; it does not authorise a threshold search. Item 4 text is not
 classified in v1: its presence and document hash are audited, but a subjective
 post-outcome purpose taxonomy cannot enter this trial.
+
+Market matching and attribution use exactly research series 7713, the
+`etoro-comparators-2026-07-08-v1` SPY snapshot, on price-only close-to-close
+returns. Its `adj_close` is unavailable, so it is not called a total-return
+benchmark and cannot support an excess-wealth claim.
 
 The complete modern archive is one historical falsification interval. It does
 not claim a pristine terminal holdout: the genuinely untouched interval begins

--- a/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
+++ b/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
@@ -29,7 +29,9 @@
     "minimum_prior_daily_sessions": 60,
     "minimum_entry_price_usd": 5.0,
     "minimum_trailing_20_session_median_dollar_volume_usd": 10000000,
-    "security_scope": "US_listed_common_equity",
+    "security_scope": "current_tradable_etoro_instrument_type_5_Stocks_and_exchange_id_4_Nasdaq_or_5_NYSE",
+    "current_is_tradable_required": true,
+    "historical_security_identity_limit": "current_snapshot_only_not_point_in_time_common_share_proof",
     "unknown_security_type": "refuse",
     "missing_or_nonpositive_ohlcv": "refuse",
     "corporate_action_ambiguity": "refuse"
@@ -73,6 +75,14 @@
     "multiplicity": "holm_adjust_random_13d_1b_and_13d_1c_differences_at_family_alpha_0_05"
   },
   "context": {
+    "market_series": {
+      "series_id": 7713,
+      "vendor": "etoro/etoro-comparators-2026-07-08-v1",
+      "vendor_symbol": "SPY",
+      "comparator_snapshot_id": "etoro-comparators-2026-07-08-v1",
+      "return_basis": "price_only_close_to_close",
+      "allowed_use": "matching_and_attribution_only_not_total_return_benchmark"
+    },
     "predeclared_attribution_only": [
       "filing_year_month",
       "exchange",

--- a/scripts/verify_2582_schedule13d_preregistration.py
+++ b/scripts/verify_2582_schedule13d_preregistration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 CONTRACT = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
-EXPECTED_SHA256 = "5a65e2d1e113cc66301cef625a99f999034ad3b2423635dc4d1657c3813ae6b7"
+EXPECTED_SHA256 = "e0fc00c8bddb5813db038cae37839252b0a79556a51bab002120887827f3a791"
 
 
 def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
@@ -22,7 +22,12 @@ def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
     assert contract["position"]["take_profit"] is None
     assert contract["position"]["round_trip_adverse_cost_bps"] == 50
     assert contract["decision_clock"]["same_close_fill"] == "forbidden"
+    assert contract["eligibility"]["security_scope"].startswith("current_tradable_etoro_instrument_type_5")
+    assert contract["eligibility"]["current_is_tradable_required"] is True
+    assert contract["eligibility"]["historical_security_identity_limit"].startswith("current_snapshot_only")
     assert contract["context"]["context_may_gate_primary_result"] is False
+    assert contract["context"]["market_series"]["series_id"] == 7713
+    assert contract["context"]["market_series"]["allowed_use"].endswith("not_total_return_benchmark")
     assert contract["context"]["item4_policy"].startswith("not_used_in_v1")
     assert contract["challengers"]["matching"]["entry_price_bucket_usd_edges"] == [5, 10, 25, 50, 100]
     assert contract["challengers"]["multiplicity"].startswith("holm_adjust")

--- a/tests/test_verify_2582_schedule13d_preregistration.py
+++ b/tests/test_verify_2582_schedule13d_preregistration.py
@@ -14,6 +14,7 @@ def test_contract_is_fail_closed_and_outcome_free() -> None:
     assert len(digest) == 64
     assert contract["event_identity"]["prior_history_order"] == "strictly_earlier_filed_at_only"
     assert contract["eligibility"]["unknown_security_type"] == "refuse"
+    assert contract["context"]["market_series"]["return_basis"] == "price_only_close_to_close"
     assert contract["challengers"]["unknown_13g_rule"] == "never_pool_with_known_rule"
     assert contract["challengers"]["matching"]["tie_break"].startswith("sha256_")
     assert contract["acceptance"]["next_stage_if_failed"].startswith("retain_rejection")


### PR DESCRIPTION
## Outcome

Closes two pre-outcome identity gaps in #2582:

- replaces an unprovable historical `common equity` claim with the exact current broker scope: currently tradable eToro `Stocks`, Nasdaq/NYSE only
- pins recent market matching/context to SPY series 7713 / `etoro-comparators-2026-07-08-v1`, explicitly price-only and forbidden as a total-return benchmark

The complete contract digest moves and remains fail-closed. No 13D price outcome was opened.

## Validation

- preregistration verifier emits `outcomes_read=false`, SHA-256 `e0fc00c8bddb5813db038cae37839252b0a79556a51bab002120887827f3a791`
- 3 focused tests pass
- ruff, pyright and diff check pass
- independent Codex review identified missing `is_tradable`; corrected before push

Refs #2582