### PR TITLE
feat(strategy): seal Schedule 13D outcome evaluator

### DIFF
--- a/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
@@ -47,8 +47,11 @@ nothing to paper trade.
 The primary population is one accession per clean campaign:
 
 - exact form `SCHEDULE 13D`;
+- public filing date comes only from `sec_filing_manifest.filed_at`; the typed
+  blockholder `filed_at` is signature/fallback provenance and is forbidden as
+  a public decision clock;
 - every reporting person contributes prior issuer/reporting-person history;
-- only strictly earlier `filed_at` timestamps establish history;
+- only strictly earlier SEC-manifest public filing dates establish history;
 - no earlier active filing, no earlier passive filing and no same-timestamp
   peer for any attached reporting person;
 - one accession is counted once even when it has joint reporters;
@@ -57,7 +60,8 @@ The primary population is one accession per clean campaign:
 
 Conversions, repeats and same-timestamp ambiguity are labelled attribution
 groups and never silently mixed into the primary estimate. Date-only rows and
-the 123 rows with a precise time deliberately share the next-session-open rule:
+rows carrying optional SEC acceptance timestamps deliberately share the
+next-session-open rule:
 the daily archive cannot simulate a causal intraday fill, and a more favourable
 fill for one subset would make the arms incomparable.
 

--- a/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
@@ -45,8 +45,9 @@ performance evidence.
 ## Read-only corpus result
 
 The census grouped `blockholder_filings` by accession so joint reporters did
-not multiply events. It joined coverage metadata only; no return, target, stop,
-winner/loser or outcome path was calculated.
+not multiply events, but takes the public filing date from
+`sec_filing_manifest.filed_at`. It joined coverage metadata only; no return,
+target, stop, winner/loser or outcome path was calculated.
 
 | filing year | initial 13D accessions | instrument mapped | research-series mapped | 60 prior + 20 later calendar days |
 |---|---:|---:|---:|---:|
@@ -63,14 +64,14 @@ must carry those source refusals.
 
 Chain shape is material:
 
-- 1,227 accessions have no strictly earlier active filing timestamp for any
+- 1,228 accessions have no strictly earlier active public filing date for any
   reporting person on
   the issuer in the retained chain;
-- 58 have an earlier active filing for at least one reporting person;
-- 46 have an earlier passive 13G-family filing for at least one reporting
+- 57 have an earlier active filing for at least one reporting person;
+- 49 have an earlier passive 13G-family filing for at least one reporting
   person;
-- 37 have another filing for the same reporter and issuer at the same retained
-  timestamp, so their within-timestamp chain order is ambiguous and is not
+- 44 have another filing for the same reporter and issuer on the same public
+  filing date, so their within-date chain order is ambiguous and is not
   invented from accession-number order;
 - the mapped accessions cover 855 distinct instruments.
 
@@ -87,11 +88,13 @@ All 1,285 initial-13D accessions have their existing
 not persist that purpose. The evaluator can parse it from the one canonical
 document on demand. It must not duplicate the narrative in another table.
 
-Only 123 accessions carry a non-midnight `filed_at`; 1,162 are date-only. The
-date-only rows cannot support a same-day or market-hours fill. Their
-fail-closed historical decision is the next regular-session open after the
-filing date. A separately proven EDGAR acceptance-time source may recover a
-more precise decision without rewriting this trial identity.
+All 1,285 accessions map to a canonical SEC-manifest public filing date; 155
+also retain an SEC acceptance timestamp. The typed blockholder `filed_at` is
+not that field: it may be an XML signature timestamp and differs from the
+manifest public date on eight accessions. It is therefore forbidden as the
+decision clock. All rows use the fail-closed next regular-session open after
+the SEC-manifest filing date; optional acceptance times do not receive a more
+favourable fill in this daily-bar trial.
 
 No typed `date_of_event` is present for these initial rows. That field is the
 private ownership-trigger date, not the public action time in any case; it may

--- a/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
+++ b/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
@@ -6,6 +6,9 @@
   "source": {
     "form": "SCHEDULE 13D",
     "document_kind": "primary_doc_13dg",
+    "public_filing_date_source": "sec_filing_manifest.filed_at",
+    "accepted_timestamp_optional_source": "sec_filing_manifest.accepted_at",
+    "blockholder_filed_at_policy": "signature_or_fallback_provenance_only_never_public_decision_clock",
     "first_source_date": "2024-12-18",
     "last_complete_filing_date": "2026-06-18",
     "research_vendor": "paperswithbacktest/Stocks-Daily-Price"
@@ -15,7 +18,7 @@
     "reporter_identity": "reporter_cik_else_normalized_reporter_name",
     "issuer_identity": "issuer_cik",
     "joint_reporter_rule": "union_history_across_every_reporter_then_count_accession_once",
-    "prior_history_order": "strictly_earlier_filed_at_only",
+    "prior_history_order": "strictly_earlier_sec_manifest_public_filing_date_only",
     "primary_population": "no_prior_active_and_no_prior_passive_and_no_same_timestamp_peer",
     "separate_attribution_only": [
       "prior_passive_13g_to_13d_conversion",
@@ -38,6 +41,7 @@
   },
   "decision_clock": {
     "historical_fill": "first_regular_session_open_strictly_after_filing_date",
+    "filing_date_field": "sec_filing_manifest.filed_at_date",
     "date_only_policy": "never_same_day",
     "precise_timestamp_policy": "same_next_session_rule_for_daily_corpus_comparability",
     "same_close_fill": "forbidden"

--- a/scripts/evaluate_2582_schedule13d_outcomes.py
+++ b/scripts/evaluate_2582_schedule13d_outcomes.py
@@ -1,0 +1,141 @@
+"""Fail-closed evaluator primitives for the frozen #2582 Schedule 13D trial.
+
+The real outcome command is intentionally unusable until the candidate has an
+entry in ``app.services.trial_register``.  That entry is only added after this
+code has been reviewed.  Keeping source selection, session selection and return
+math here lets us test the causal machinery without querying a single price
+bar.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Final
+
+from app.services.market_calendar import us_market_status
+from app.services.trial_register import TRIAL_REGISTER
+from scripts.verify_2582_schedule13d_preregistration import EXPECTED_SHA256, load_and_verify
+
+TRIAL_ID: Final = "c4-schedule13d-public-catalyst-v1"
+ACKNOWLEDGEMENT: Final = "OPEN-2582-SEALED-OUTCOMES"
+
+
+class OutcomeGateRefusal(RuntimeError):
+    """The sealed outcome boundary was not explicitly and correctly opened."""
+
+
+@dataclass(frozen=True)
+class OutcomeGate:
+    contract_sha256: str
+    trial_register_version: str
+    trial_id: str
+
+
+def require_outcome_gate(*, acknowledgement: str | None, contract_path: Path) -> OutcomeGate:
+    """Refuse unless the reviewed contract and declared trial are both exact."""
+
+    if acknowledgement != ACKNOWLEDGEMENT:
+        raise OutcomeGateRefusal(
+            "sealed outcomes remain closed; pass the exact acknowledgement only after evaluator review"
+        )
+    _contract, digest = load_and_verify(contract_path)
+    if digest != EXPECTED_SHA256:
+        raise OutcomeGateRefusal("contract digest does not match the reviewed preregistration")
+    if TRIAL_ID not in TRIAL_REGISTER.trial_ids:
+        raise OutcomeGateRefusal(
+            f"{TRIAL_ID} is absent from {TRIAL_REGISTER.version}; declare the price-data search before reading outcomes"
+        )
+    return OutcomeGate(digest, TRIAL_REGISTER.version, TRIAL_ID)
+
+
+def next_regular_session_strictly_after(filing_date: date) -> date:
+    """The first NYSE session after the filing civil date; never same-day."""
+
+    candidate = filing_date + timedelta(days=1)
+    while us_market_status(candidate) == "closed":
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def nth_regular_session(first_session: date, n: int) -> date:
+    """Return session ``n`` with ``first_session`` counted as session one."""
+
+    if n < 1:
+        raise ValueError("n must be positive")
+    if us_market_status(first_session) == "closed":
+        raise ValueError("first_session is not a regular trading session")
+    candidate = first_session
+    found = 1
+    while found < n:
+        candidate += timedelta(days=1)
+        if us_market_status(candidate) != "closed":
+            found += 1
+    return candidate
+
+
+def total_return_pct(
+    *,
+    entry_open: Decimal,
+    entry_close: Decimal,
+    entry_adj_close: Decimal,
+    exit_close: Decimal,
+    exit_adj_close: Decimal,
+    adverse_cost_bps: int = 50,
+) -> Decimal:
+    """Causal open-to-close total return using the vendor adjustment factors.
+
+    ``adj_close / close`` is observed at entry and exit.  A split or dividend
+    between them changes the factor ratio.  Missing/non-positive inputs refuse;
+    silently falling back to raw close would corrupt corporate-action cases.
+    """
+
+    values = (entry_open, entry_close, entry_adj_close, exit_close, exit_adj_close)
+    if any(not value.is_finite() or value <= 0 for value in values):
+        raise ValueError("return inputs must all be finite and positive")
+    if adverse_cost_bps < 0:
+        raise ValueError("adverse_cost_bps cannot be negative")
+    entry_factor = entry_adj_close / entry_close
+    exit_factor = exit_adj_close / exit_close
+    gross = (exit_close / entry_open) * (exit_factor / entry_factor) - Decimal(1)
+    return (gross - Decimal(adverse_cost_bps) / Decimal(10_000)) * Decimal(100)
+
+
+def bucket(value: Decimal, edges: tuple[Decimal, ...]) -> int:
+    """Stable half-open bucket index: values equal to an edge enter its right cell."""
+
+    if not value.is_finite():
+        raise ValueError("bucket value must be finite")
+    return sum(value >= edge for edge in edges)
+
+
+def match_tie_break(treatment_accession: str, challenger_accession: str, *, seed: int = 2582) -> str:
+    payload = f"{treatment_accession}\x1f{challenger_accession}\x1f{seed}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--acknowledgement")
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json"),
+    )
+    args = parser.parse_args(argv)
+    gate = require_outcome_gate(acknowledgement=args.acknowledgement, contract_path=args.contract)
+    # Deliberate second lock.  This PR establishes and tests the outcome
+    # boundary; it does not yet contain the reviewed database evaluator.
+    raise OutcomeGateRefusal(
+        "gate satisfied but database outcome evaluator is not present; no price query was executed: "
+        + json.dumps(gate.__dict__, sort_keys=True)
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_2582_schedule13d_census.py
+++ b/scripts/verify_2582_schedule13d_census.py
@@ -28,34 +28,35 @@ _VENDOR = "paperswithbacktest/Stocks-Daily-Price"
 
 _YEARLY_COVERAGE: LiteralString = """
 WITH accessions AS (
-    SELECT accession_number,
-           min(filed_at) AS filed_at,
-           max(instrument_id) FILTER (WHERE instrument_id IS NOT NULL) AS instrument_id
-    FROM blockholder_filings
-    WHERE submission_type = 'SCHEDULE 13D'
-    GROUP BY accession_number
+    SELECT b.accession_number,
+           m.filed_at AS public_filed_at,
+           max(b.instrument_id) FILTER (WHERE b.instrument_id IS NOT NULL) AS instrument_id
+    FROM blockholder_filings b
+    JOIN sec_filing_manifest m USING (accession_number)
+    WHERE b.submission_type = 'SCHEDULE 13D'
+    GROUP BY b.accession_number, m.filed_at
 ), covered AS (
     SELECT a.*,
            s.series_id,
            s.first_bar,
            s.last_bar,
-           s.first_bar <= a.filed_at::date - 60
-               AND s.last_bar >= a.filed_at::date + 20 AS covered_60_20
+           s.first_bar <= a.public_filed_at::date - 60
+               AND s.last_bar >= a.public_filed_at::date + 20 AS covered_60_20
     FROM accessions a
     LEFT JOIN research_price_series s
       ON s.instrument_id = a.instrument_id
      AND s.vendor = %(vendor)s
 )
-SELECT extract(year FROM filed_at)::int AS filing_year,
+SELECT extract(year FROM public_filed_at)::int AS filing_year,
        count(*) AS accessions,
        count(instrument_id) AS instrument_mapped,
        count(series_id) AS research_series_mapped,
        count(*) FILTER (WHERE covered_60_20) AS covered_60_prior_20_later,
        count(*) FILTER (
-           WHERE series_id IS NOT NULL AND last_bar < filed_at::date + 20
+           WHERE series_id IS NOT NULL AND last_bar < public_filed_at::date + 20
        ) AS outcome_window_incomplete,
        count(*) FILTER (
-           WHERE series_id IS NOT NULL AND first_bar > filed_at::date - 60
+           WHERE series_id IS NOT NULL AND first_bar > public_filed_at::date - 60
        ) AS prior_window_incomplete
 FROM covered
 GROUP BY 1
@@ -64,22 +65,25 @@ ORDER BY 1
 
 _CHAIN_SHAPE: LiteralString = """
 WITH initial_accessions AS (
-    SELECT accession_number,
-           min(issuer_cik) AS issuer_cik,
-           min(filed_at) AS filed_at,
-           max(instrument_id) FILTER (WHERE instrument_id IS NOT NULL) AS instrument_id
-    FROM blockholder_filings
-    WHERE submission_type = 'SCHEDULE 13D'
-    GROUP BY accession_number
+    SELECT b.accession_number,
+           min(b.issuer_cik) AS issuer_cik,
+           m.filed_at::date AS public_filing_date,
+           max(b.instrument_id) FILTER (WHERE b.instrument_id IS NOT NULL) AS instrument_id
+    FROM blockholder_filings b
+    JOIN sec_filing_manifest m USING (accession_number)
+    WHERE b.submission_type = 'SCHEDULE 13D'
+    GROUP BY b.accession_number, m.filed_at::date
 ), reporter_events AS (
-    SELECT DISTINCT accession_number,
-           issuer_cik,
-           coalesce(reporter_cik, reporter_name) AS reporter_identity,
-           filed_at,
-           submission_type,
-           status
-    FROM blockholder_filings
-    WHERE submission_type IN (
+    SELECT DISTINCT b.accession_number,
+           b.issuer_cik,
+           coalesce(b.reporter_cik, lower(regexp_replace(trim(b.reporter_name), '\\s+', ' ', 'g')))
+               AS reporter_identity,
+           m.filed_at::date AS public_filing_date,
+           b.submission_type,
+           b.status
+    FROM blockholder_filings b
+    JOIN sec_filing_manifest m USING (accession_number)
+    WHERE b.submission_type IN (
         'SCHEDULE 13D', 'SCHEDULE 13D/A',
         'SCHEDULE 13G', 'SCHEDULE 13G/A'
     )
@@ -88,7 +92,7 @@ WITH initial_accessions AS (
            coalesce(
                bool_or(status = 'active') OVER (
                    PARTITION BY issuer_cik, reporter_identity
-                   ORDER BY filed_at
+                   ORDER BY public_filing_date
                    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                    EXCLUDE GROUP
                ), false
@@ -96,13 +100,13 @@ WITH initial_accessions AS (
            coalesce(
                bool_or(status = 'passive') OVER (
                    PARTITION BY issuer_cik, reporter_identity
-                   ORDER BY filed_at
+                   ORDER BY public_filing_date
                    RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                    EXCLUDE GROUP
                ), false
            ) AS prior_13g,
            count(*) OVER (
-               PARTITION BY issuer_cik, reporter_identity, filed_at
+               PARTITION BY issuer_cik, reporter_identity, public_filing_date
            ) > 1 AS same_timestamp_peer
     FROM reporter_events r
 ), classified AS (
@@ -127,17 +131,22 @@ FROM classified
 
 _SOURCE_SHAPE: LiteralString = """
 WITH accessions AS (
-    SELECT accession_number,
-           min(filed_at) AS filed_at,
-           max(date_of_event) AS date_of_event
-    FROM blockholder_filings
-    WHERE submission_type = 'SCHEDULE 13D'
-    GROUP BY accession_number
+    SELECT b.accession_number,
+           m.filed_at AS public_filed_at,
+           m.accepted_at AS public_accepted_at,
+           min(b.filed_at) AS typed_signature_or_manifest_time,
+           max(b.date_of_event) AS date_of_event
+    FROM blockholder_filings b
+    JOIN sec_filing_manifest m USING (accession_number)
+    WHERE b.submission_type = 'SCHEDULE 13D'
+    GROUP BY b.accession_number, m.filed_at, m.accepted_at
 )
 SELECT count(*) AS accessions,
        count(date_of_event) AS event_date_present,
-       count(*) FILTER (WHERE filed_at::time <> time '00:00') AS precise_filing_time,
-       count(*) FILTER (WHERE filed_at::time = time '00:00') AS date_only_filing_time,
+       count(public_accepted_at) AS sec_acceptance_time_present,
+       count(*) FILTER (WHERE public_accepted_at IS NULL) AS public_date_only,
+       count(*) FILTER (WHERE typed_signature_or_manifest_time::date <> public_filed_at::date)
+           AS typed_time_disagrees_with_public_date,
        count(raw.payload) AS raw_document_present,
        count(*) FILTER (
            WHERE raw.payload ~* '<([[:alnum:]_]+:)?item4([ >])'

--- a/scripts/verify_2582_schedule13d_preregistration.py
+++ b/scripts/verify_2582_schedule13d_preregistration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 CONTRACT = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
-EXPECTED_SHA256 = "e0fc00c8bddb5813db038cae37839252b0a79556a51bab002120887827f3a791"
+EXPECTED_SHA256 = "dd076ab7601eec37b12fd5958c24012b23bb1490e2ccd4d48a62d72f0c87ccf8"
 
 
 def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
@@ -22,6 +22,9 @@ def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
     assert contract["position"]["take_profit"] is None
     assert contract["position"]["round_trip_adverse_cost_bps"] == 50
     assert contract["decision_clock"]["same_close_fill"] == "forbidden"
+    assert contract["source"]["public_filing_date_source"] == "sec_filing_manifest.filed_at"
+    assert contract["source"]["blockholder_filed_at_policy"].endswith("never_public_decision_clock")
+    assert contract["decision_clock"]["filing_date_field"] == "sec_filing_manifest.filed_at_date"
     assert contract["eligibility"]["security_scope"].startswith("current_tradable_etoro_instrument_type_5")
     assert contract["eligibility"]["current_is_tradable_required"] is True
     assert contract["eligibility"]["historical_security_identity_limit"].startswith("current_snapshot_only")

--- a/tests/test_evaluate_2582_schedule13d_outcomes.py
+++ b/tests/test_evaluate_2582_schedule13d_outcomes.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from scripts.evaluate_2582_schedule13d_outcomes import (
+    ACKNOWLEDGEMENT,
+    OutcomeGateRefusal,
+    bucket,
+    match_tie_break,
+    next_regular_session_strictly_after,
+    nth_regular_session,
+    require_outcome_gate,
+    total_return_pct,
+)
+
+
+def test_gate_refuses_without_explicit_acknowledgement() -> None:
+    with pytest.raises(OutcomeGateRefusal, match="remain closed"):
+        require_outcome_gate(
+            acknowledgement=None,
+            contract_path=Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json"),
+        )
+
+
+def test_gate_refuses_even_with_ack_until_trial_is_declared() -> None:
+    with pytest.raises(OutcomeGateRefusal, match="absent from trial-register"):
+        require_outcome_gate(
+            acknowledgement=ACKNOWLEDGEMENT,
+            contract_path=Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json"),
+        )
+
+
+def test_next_session_is_strict_and_observes_weekend_and_holiday() -> None:
+    assert next_regular_session_strictly_after(date(2026, 7, 2)) == date(2026, 7, 6)
+    assert next_regular_session_strictly_after(date(2026, 8, 10)) == date(2026, 8, 11)
+    assert nth_regular_session(date(2026, 7, 6), 10) == date(2026, 7, 17)
+
+
+def test_total_return_uses_adjustment_factor_and_subtracts_adverse_cost() -> None:
+    # Raw price halves, but the 2-for-1 adjustment factor doubles: zero gross.
+    result = total_return_pct(
+        entry_open=Decimal("100"),
+        entry_close=Decimal("100"),
+        entry_adj_close=Decimal("50"),
+        exit_close=Decimal("50"),
+        exit_adj_close=Decimal("50"),
+    )
+    assert result == Decimal("-0.500")
+
+
+@pytest.mark.parametrize("bad", [Decimal("0"), Decimal("NaN"), Decimal("-1")])
+def test_total_return_refuses_bad_adjustment_inputs(bad: Decimal) -> None:
+    with pytest.raises(ValueError):
+        total_return_pct(
+            entry_open=Decimal("10"),
+            entry_close=bad,
+            entry_adj_close=Decimal("10"),
+            exit_close=Decimal("11"),
+            exit_adj_close=Decimal("11"),
+        )
+
+
+def test_matching_helpers_are_boundary_stable_and_deterministic() -> None:
+    edges = tuple(map(Decimal, ("5", "10", "25")))
+    assert bucket(Decimal("9.99"), edges) == 1
+    assert bucket(Decimal("10"), edges) == 2
+    assert match_tie_break("a", "b") == match_tie_break("a", "b")
+    assert match_tie_break("a", "b") != match_tie_break("a", "c")

--- a/tests/test_verify_2582_schedule13d_preregistration.py
+++ b/tests/test_verify_2582_schedule13d_preregistration.py
@@ -12,7 +12,7 @@ def test_contract_is_fail_closed_and_outcome_free() -> None:
     contract, digest = load_and_verify()
 
     assert len(digest) == 64
-    assert contract["event_identity"]["prior_history_order"] == "strictly_earlier_filed_at_only"
+    assert contract["event_identity"]["prior_history_order"].startswith("strictly_earlier_sec_manifest")
     assert contract["eligibility"]["unknown_security_type"] == "refuse"
     assert contract["context"]["market_series"]["return_basis"] == "price_only_close_to_close"
     assert contract["challengers"]["unknown_13g_rule"] == "never_pool_with_known_rule"


### PR DESCRIPTION
Closes the first evaluator checkpoint for #2582.

- refuses outcome access until the exact frozen contract and declared trial agree
- pins strictly-next-session entry and tenth-session exit
- tests corporate-action-aware total-return math and deterministic matching helpers
- deliberately contains no database outcome query yet

The active recent-window backtest continues independently; this PR does not alter loaded application code or open any Schedule 13D outcome.