### PR TITLE
feat(strategy): freeze 13D event statistics

### DIFF
--- a/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
+++ b/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
@@ -108,6 +108,8 @@
   "statistics": {
     "primary_estimand": "mean_net_total_return_pct",
     "confidence_interval": "two_way_pigeonhole_bootstrap_by_issuer_and_entry_session_95pct_percentile",
+    "bootstrap_weighting": "independent_multinomial_cluster_counts_product_discard_empty_intersection_until_10000_valid_draws",
+    "bootstrap_quantile_method": "linear",
     "bootstrap_seed": 2582,
     "bootstrap_resamples": 10000,
     "minimum_worthwhile_net_effect_pct": 1.0,
@@ -115,6 +117,15 @@
     "planning_alpha_two_sided": 0.05,
     "planning_power": 0.8,
     "minimum_planning_effective_sample_size": 785,
+    "effective_sample_size_definition": "min_raw_n_sample_return_variance_div_pigeonhole_bootstrap_mean_variance",
+    "recent_stability_windows": [
+      "2025-01-01_to_2025-06-30",
+      "2025-07-01_to_2025-12-31",
+      "2026-01-01_to_2026-06-30",
+      "latest_12m_2025-07-01_to_2026-06-30"
+    ],
+    "signal_strength_monotonicity_definition": "spearman_average_tie_rank_maximum_percent_of_class_vs_net_return_attribution_only",
+    "concentration_return_basis": "gross_return_before_fixed_50bps_cost_positive_part",
     "required_reports": [
       "eligible_event_count",
       "effective_sample_size",
@@ -124,7 +135,7 @@
       "average_winner_and_loser",
       "profit_factor",
       "expected_shortfall_5pct",
-      "worst_gap",
+      "worst_net_event_return",
       "concurrency",
       "sector_and_issuer_concentration",
       "result_excluding_best_1pct",

--- a/scripts/schedule13d_statistics.py
+++ b/scripts/schedule13d_statistics.py
@@ -1,0 +1,245 @@
+"""Frozen, pure statistical definitions for the sealed #2582 event study.
+
+This module has no database import and cannot open the Schedule 13D outcomes.
+It exists separately so clustering, tails, stability and concentration are
+reviewed before the trial register permits the price query.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+from math import sqrt
+from statistics import mean, median, variance
+from typing import Final
+
+import numpy as np
+
+BOOTSTRAP_SEED: Final = 2582
+BOOTSTRAP_RESAMPLES: Final = 10_000
+
+
+@dataclass(frozen=True)
+class EventOutcome:
+    accession_number: str
+    issuer_cik: str
+    entry_date: date
+    exit_date: date
+    net_return_pct: float
+    maximum_percent_of_class: float | None
+    sector: str | None = None
+
+
+@dataclass(frozen=True)
+class ClusteredEstimate:
+    mean_pct: float
+    lower_95_pct: float
+    upper_95_pct: float
+    bootstrap_standard_error_pct: float
+    effective_sample_size: float
+    resamples: int
+
+
+@dataclass(frozen=True)
+class StabilityWindow:
+    label: str
+    start: date
+    end: date
+    event_count: int
+    mean_net_return_pct: float | None
+
+
+@dataclass(frozen=True)
+class OutcomeStatistics:
+    event_count: int
+    clustered: ClusteredEstimate
+    median_net_return_pct: float
+    hit_rate_pct: float
+    average_winner_pct: float | None
+    average_loser_pct: float | None
+    profit_factor: float | None
+    expected_shortfall_5_pct: float
+    worst_net_event_return_pct: float
+    maximum_concurrency: int
+    maximum_issuer_positive_concentration_pct: float
+    maximum_sector_positive_concentration_pct: float
+    maximum_entry_session_positive_concentration_pct: float
+    excluding_best_1pct_mean_pct: float
+    signal_strength_spearman: float | None
+    signal_strength_observations: int
+    stability: tuple[StabilityWindow, ...]
+    break_even_cost_bps: float
+
+
+def two_way_pigeonhole_bootstrap(
+    outcomes: Sequence[EventOutcome],
+    *,
+    seed: int = BOOTSTRAP_SEED,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+) -> ClusteredEstimate:
+    """Bootstrap issuers and entry sessions independently with replacement.
+
+    Each observation receives the product of its issuer and entry-session
+    multinomial counts. Percentile bounds use NumPy's linear quantile method.
+    Effective sample size is ``sample variance / bootstrap variance of mean``,
+    capped at the raw event count; it is zero when clustering supplies no
+    estimable precision and never defaults to the row count.
+    """
+
+    if len(outcomes) < 2:
+        raise ValueError("clustered inference requires at least two outcomes")
+    if resamples < 2:
+        raise ValueError("resamples must be at least two")
+    values = np.asarray([item.net_return_pct for item in outcomes], dtype=np.float64)
+    if not np.all(np.isfinite(values)):
+        raise ValueError("outcome returns must all be finite")
+    issuers = sorted({item.issuer_cik for item in outcomes})
+    sessions = sorted({item.entry_date for item in outcomes})
+    issuer_index = {value: index for index, value in enumerate(issuers)}
+    session_index = {value: index for index, value in enumerate(sessions)}
+    event_issuers = np.asarray([issuer_index[item.issuer_cik] for item in outcomes])
+    event_sessions = np.asarray([session_index[item.entry_date] for item in outcomes])
+    rng = np.random.default_rng(seed)
+    estimates = np.empty(resamples, dtype=np.float64)
+    valid_draws = 0
+    attempts = 0
+    while valid_draws < resamples:
+        attempts += 1
+        if attempts > resamples * 20:
+            raise ValueError("pigeonhole bootstrap could not produce the required nonempty intersection draws")
+        issuer_counts = rng.multinomial(len(issuers), np.full(len(issuers), 1 / len(issuers)))
+        session_counts = rng.multinomial(len(sessions), np.full(len(sessions), 1 / len(sessions)))
+        weights = issuer_counts[event_issuers] * session_counts[event_sessions]
+        total_weight = int(weights.sum())
+        if total_weight == 0:
+            continue
+        estimates[valid_draws] = float(np.dot(values, weights) / total_weight)
+        valid_draws += 1
+    lower, upper = np.quantile(estimates, (0.025, 0.975), method="linear")
+    bootstrap_variance = float(np.var(estimates, ddof=1))
+    sample_variance = variance(float(value) for value in values)
+    effective_n = 0.0 if bootstrap_variance <= 0 else min(float(len(values)), sample_variance / bootstrap_variance)
+    return ClusteredEstimate(
+        mean_pct=float(np.mean(values)),
+        lower_95_pct=float(lower),
+        upper_95_pct=float(upper),
+        bootstrap_standard_error_pct=sqrt(bootstrap_variance),
+        effective_sample_size=effective_n,
+        resamples=resamples,
+    )
+
+
+def _average_rank(values: Sequence[float]) -> list[float]:
+    ordered = sorted(enumerate(values), key=lambda item: (item[1], item[0]))
+    ranks = [0.0] * len(values)
+    start = 0
+    while start < len(ordered):
+        end = start + 1
+        while end < len(ordered) and ordered[end][1] == ordered[start][1]:
+            end += 1
+        average_rank = (start + 1 + end) / 2
+        for position in range(start, end):
+            ranks[ordered[position][0]] = average_rank
+        start = end
+    return ranks
+
+
+def spearman_strength(outcomes: Sequence[EventOutcome]) -> tuple[float | None, int]:
+    pairs = [
+        (item.maximum_percent_of_class, item.net_return_pct)
+        for item in outcomes
+        if item.maximum_percent_of_class is not None
+    ]
+    if len(pairs) < 3:
+        return None, len(pairs)
+    left = np.asarray(_average_rank([float(item[0]) for item in pairs]), dtype=np.float64)
+    right = np.asarray(_average_rank([item[1] for item in pairs]), dtype=np.float64)
+    if np.std(left) == 0 or np.std(right) == 0:
+        return None, len(pairs)
+    return float(np.corrcoef(left, right)[0, 1]), len(pairs)
+
+
+def _stability(outcomes: Sequence[EventOutcome]) -> tuple[StabilityWindow, ...]:
+    windows = (
+        ("six_month_2025_h1", date(2025, 1, 1), date(2025, 6, 30)),
+        ("six_month_2025_h2", date(2025, 7, 1), date(2025, 12, 31)),
+        ("six_month_2026_h1", date(2026, 1, 1), date(2026, 6, 30)),
+        ("latest_twelve_month", date(2025, 7, 1), date(2026, 6, 30)),
+    )
+    result: list[StabilityWindow] = []
+    for label, start, end in windows:
+        values = [item.net_return_pct for item in outcomes if start <= item.entry_date <= end]
+        result.append(StabilityWindow(label, start, end, len(values), mean(values) if values else None))
+    return tuple(result)
+
+
+def _maximum_concurrency(outcomes: Sequence[EventOutcome]) -> int:
+    changes: Counter[date] = Counter()
+    for item in outcomes:
+        changes[item.entry_date] += 1
+        changes[item.exit_date + timedelta(days=1)] -= 1
+    current = maximum = 0
+    for _, change in sorted(changes.items()):
+        current += change
+        maximum = max(maximum, current)
+    return maximum
+
+
+def _positive_concentration(outcomes: Sequence[EventOutcome], *, by: str) -> float:
+    # Outcomes are net of 50 bps; concentration is preregistered on gross
+    # positive return, so add the fixed cost back before clipping at zero.
+    positive_total = sum(max(item.net_return_pct + 0.5, 0.0) for item in outcomes)
+    if positive_total <= 0:
+        return 100.0
+    grouped: defaultdict[object, float] = defaultdict(float)
+    for item in outcomes:
+        if by == "issuer":
+            key: object = item.issuer_cik
+        elif by == "sector":
+            key = item.sector or "unknown"
+        else:
+            key = item.entry_date
+        grouped[key] += max(item.net_return_pct + 0.5, 0.0)
+    return max(grouped.values(), default=0.0) / positive_total * 100
+
+
+def summarise_outcomes(
+    outcomes: Sequence[EventOutcome],
+    *,
+    seed: int = BOOTSTRAP_SEED,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+) -> OutcomeStatistics:
+    if len(outcomes) < 2:
+        raise ValueError("summary requires at least two outcomes")
+    values = [item.net_return_pct for item in outcomes]
+    if any(not np.isfinite(value) for value in values):
+        raise ValueError("outcome returns must all be finite")
+    winners = [value for value in values if value > 0]
+    losers = [value for value in values if value < 0]
+    losses = -sum(losers)
+    ordered = sorted(values)
+    tail_count = max(1, (len(ordered) + 19) // 20)
+    remove_count = max(1, (len(ordered) + 99) // 100)
+    strength, strength_n = spearman_strength(outcomes)
+    return OutcomeStatistics(
+        event_count=len(values),
+        clustered=two_way_pigeonhole_bootstrap(outcomes, seed=seed, resamples=resamples),
+        median_net_return_pct=median(values),
+        hit_rate_pct=len(winners) / len(values) * 100,
+        average_winner_pct=mean(winners) if winners else None,
+        average_loser_pct=mean(losers) if losers else None,
+        profit_factor=sum(winners) / losses if losses > 0 else None,
+        expected_shortfall_5_pct=mean(ordered[:tail_count]),
+        worst_net_event_return_pct=min(values),
+        maximum_concurrency=_maximum_concurrency(outcomes),
+        maximum_issuer_positive_concentration_pct=_positive_concentration(outcomes, by="issuer"),
+        maximum_sector_positive_concentration_pct=_positive_concentration(outcomes, by="sector"),
+        maximum_entry_session_positive_concentration_pct=_positive_concentration(outcomes, by="entry"),
+        excluding_best_1pct_mean_pct=mean(ordered[:-remove_count]),
+        signal_strength_spearman=strength,
+        signal_strength_observations=strength_n,
+        stability=_stability(outcomes),
+        break_even_cost_bps=mean(values) * 100 + 50,
+    )

--- a/scripts/verify_2582_schedule13d_preregistration.py
+++ b/scripts/verify_2582_schedule13d_preregistration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 CONTRACT = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
-EXPECTED_SHA256 = "46cf162d4c1781dcd8f1ae929425d19a2f2b50a72bda1b6269d0a021845b7e6a"
+EXPECTED_SHA256 = "277e200233095bde072eb9a7583dcb62a04325d3b8b6f43b4cd96f55f71f1e9d"
 
 
 def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
@@ -49,6 +49,9 @@ def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
     expected_n = 785
     assert round(7.84888 * (sigma / effect) ** 2) == expected_n
     assert stats["minimum_planning_effective_sample_size"] == expected_n
+    assert stats["effective_sample_size_definition"].startswith("min_raw_n")
+    assert len(stats["recent_stability_windows"]) == 4
+    assert stats["concentration_return_basis"].startswith("gross_return")
 
     digest = hashlib.sha256(raw).hexdigest()
     assert digest == EXPECTED_SHA256, f"frozen contract digest moved: {digest}"

--- a/tests/test_schedule13d_statistics.py
+++ b/tests/test_schedule13d_statistics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+
+from scripts.schedule13d_statistics import EventOutcome, summarise_outcomes, two_way_pigeonhole_bootstrap
+
+
+def _outcome(index: int, value: float, *, issuer: str | None = None, entry: date | None = None) -> EventOutcome:
+    start = entry or date(2026, 1, index + 2)
+    return EventOutcome(
+        accession_number=f"a-{index}",
+        issuer_cik=issuer or f"issuer-{index}",
+        entry_date=start,
+        exit_date=start + timedelta(days=14),
+        net_return_pct=value,
+        maximum_percent_of_class=float(index + 5),
+        sector="technology" if index % 2 else "healthcare",
+    )
+
+
+def test_two_way_bootstrap_is_deterministic_and_cluster_effective_n_is_bounded() -> None:
+    outcomes = tuple(_outcome(i, float(i - 2)) for i in range(6))
+    first = two_way_pigeonhole_bootstrap(outcomes, resamples=200)
+    second = two_way_pigeonhole_bootstrap(outcomes, resamples=200)
+    assert first == second
+    assert 0 < first.effective_sample_size <= len(outcomes)
+    assert first.lower_95_pct < first.mean_pct < first.upper_95_pct
+
+
+def test_summary_reports_tails_concentration_stability_and_break_even_cost() -> None:
+    outcomes = (
+        _outcome(0, -4.0, issuer="shared", entry=date(2025, 2, 3)),
+        _outcome(1, 1.0, issuer="shared", entry=date(2025, 8, 4)),
+        _outcome(2, 2.0, entry=date(2026, 2, 3)),
+        _outcome(3, 3.0, entry=date(2026, 3, 3)),
+    )
+    summary = summarise_outcomes(outcomes, resamples=200)
+    assert summary.hit_rate_pct == 75
+    assert summary.profit_factor == pytest.approx(1.5)
+    assert summary.expected_shortfall_5_pct == -4
+    assert summary.worst_net_event_return_pct == -4
+    assert summary.break_even_cost_bps == 100
+    assert summary.maximum_concurrency >= 1
+    assert len(summary.stability) == 4
+
+
+def test_nonpositive_book_fails_concentration_safely() -> None:
+    summary = summarise_outcomes((_outcome(0, -1), _outcome(1, -2)), resamples=100)
+    assert summary.maximum_issuer_positive_concentration_pct == 100
+    assert summary.maximum_entry_session_positive_concentration_pct == 100


### PR DESCRIPTION
Advances #2582 without opening any outcome.

- implements deterministic two-way issuer/session pigeonhole bootstrap
- derives effective sample size from clustered mean variance instead of row count
- freezes 5% expected shortfall, best-1% dependence, gross-positive concentration, overlap and break-even cost
- freezes 2025 H1/H2, 2026 H1 and latest-12m stability windows
- implements percent-of-class Spearman attribution
- clarifies the ambiguous `worst_gap` label as worst net event return

Pure statistical fixtures only; no database access exists in the new module.