### PR TITLE
feat(strategy): freeze 13D challenger inference

### DIFF
--- a/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
@@ -93,6 +93,24 @@ Three challengers use the same eligible observations and timing:
    accessions and seed 2582 resolves ties; unmatched treatments remain in the
    primary result but not that paired comparison.
 
+Random-time candidates are price-covered entry sessions on the same instrument
+and in the treatment entry year-month. Any session within ten NYSE sessions on
+either side of any 13D entry for that instrument is excluded; an empty set is
+reported as unmatched. Initial-13G matching processes treatments in accession
+order within each separate rule population. Paired differences are treatment
+return minus challenger return and retain the treatment issuer and entry-session
+clusters.
+
+For each paired comparison, the evaluator reports the two-sided 95% linear
+percentile interval and a one-sided null-centred bootstrap p-value with the
+finite-resample plus-one correction. Holm's step-down procedure adjusts the
+three predeclared p-values (random time, Rule 13d-1(b), Rule 13d-1(c)); both and
+unknown 13G rules remain separately reported attribution only. Passage requires
+both a positive paired lower bound and adjusted p-value at most 0.05 for every
+gating comparison. This wording replaces the underspecified phrase
+"Holm-adjusted confidence bound": Holm defines a multiple-test procedure, not
+a unique adjusted interval construction.
+
 The initial-13G challenger is source-feasible: an outcome-free raw-document
 census found 10,419 filings with the same basic coverage (7,429 Rule 13d-1(b),
 2,262 Rule 13d-1(c), 33 carrying both and 695 unknown). Its strong February and
@@ -117,6 +135,17 @@ not claim a pristine terminal holdout: the genuinely untouched interval begins
 with filings arriving after this contract. That prospective interval is
 required because the price archive is survivor-biased and lacks historical
 broker eligibility and observed spreads.
+
+The crossed-cluster bootstrap follows the product-weight construction studied
+by Owen and Eckles; their result supports conservative variance estimation for
+multi-factor crossed effects rather than treating filings as independent rows.
+Holm's original sequentially rejective procedure supplies strong family-wise
+error control without assuming independent p-values.
+
+Method sources:
+
+- [Owen and Eckles, *Bootstrapping Data Arrays of Arbitrary Order*](https://doi.org/10.1214/12-AOAS547)
+- [Holm, *A Simple Sequentially Rejective Multiple Test Procedure*](https://doi.org/10.2307/4615733)
 
 ## Power and admission
 

--- a/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
+++ b/docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json
@@ -62,9 +62,9 @@
   },
   "challengers": {
     "unfiltered_eligible_13d": "same_fill_exit_cost_and_coverage",
-    "matched_random_time": "one_seeded_eligible_non_event_date_per_treatment_same_instrument_calendar_month_excluding_any_13d_plus_or_minus_10_sessions",
+    "matched_random_time": "one_sha256_seeded_price_covered_non_event_entry_session_per_treatment_same_instrument_and_treatment_entry_year_month_excluding_any_13d_entry_plus_or_minus_10_nyse_sessions_empty_set_is_unmatched",
     "random_seed": 2582,
-    "initial_13g": "match_without_replacement_and_report_separately_by_13d_1b_13d_1c_both_or_unknown_rule",
+    "initial_13g": "match_without_replacement_and_report_separately_by_13g_1b_13g_1c_both_or_unknown_rule",
     "matching": {
       "exact_fields": [
         "filing_year_month",
@@ -76,10 +76,15 @@
       "trailing_dollar_volume_bucket_usd_edges": [10000000, 25000000, 100000000, 500000000],
       "prior_20_session_market_return_pct_edges": [-5, 0, 5],
       "tie_break": "sha256_treatment_accession_challenger_accession_seed_ascending",
+      "treatment_order": "accession_number_ascending_within_each_separate_rule_population",
       "unmatched_treatment": "retain_primary_but_refuse_that_challenger_pair"
     },
     "unknown_13g_rule": "never_pool_with_known_rule",
-    "multiplicity": "holm_adjust_random_13d_1b_and_13d_1c_differences_at_family_alpha_0_05"
+    "paired_difference_inference": "treatment_return_minus_challenger_return_two_way_pigeonhole_bootstrap_by_treatment_issuer_and_treatment_entry_session",
+    "paired_confidence_interval": "two_sided_95pct_linear_percentile_interval",
+    "paired_one_sided_p_value": "null_center_bootstrap_probability_centered_mean_gte_observed_mean_with_plus_one_finite_resample_correction",
+    "multiplicity": "holm_step_down_adjust_one_sided_p_values_for_random_13g_1b_and_13g_1c_at_family_alpha_0_05",
+    "both_and_unknown_13g_rules": "report_separately_attribution_only_not_acceptance_gates"
   },
   "context": {
     "market_series": {
@@ -149,9 +154,9 @@
     "historical_pass_requires": [
       "effective_sample_size_gte_785",
       "adverse_cost_clustered_lower_bound_gt_zero",
-      "holm_adjusted_lower_bound_vs_random_gt_zero",
-      "holm_adjusted_lower_bound_vs_matched_13d_1b_gt_zero",
-      "holm_adjusted_lower_bound_vs_matched_13d_1c_gt_zero",
+      "paired_95pct_lower_bound_vs_random_gt_zero_and_holm_adjusted_one_sided_p_lte_0_05",
+      "paired_95pct_lower_bound_vs_matched_13g_1b_gt_zero_and_holm_adjusted_one_sided_p_lte_0_05",
+      "paired_95pct_lower_bound_vs_matched_13g_1c_gt_zero_and_holm_adjusted_one_sided_p_lte_0_05",
       "profit_factor_gt_one",
       "positive_result_excluding_best_1pct",
       "no_issuer_or_entry_session_supplies_20pct_or_more_of_gross_positive_return",

--- a/scripts/schedule13d_challengers.py
+++ b/scripts/schedule13d_challengers.py
@@ -1,0 +1,130 @@
+"""Pure, frozen challenger selection for the sealed Schedule 13D study.
+
+No function in this module imports the application or reads a price table.
+Selections can therefore be reviewed before the outcome gate is opened.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Final, Literal
+
+PRICE_EDGES: Final = tuple(map(Decimal, ("5", "10", "25", "50", "100")))
+LIQUIDITY_EDGES: Final = tuple(map(Decimal, ("10000000", "25000000", "100000000", "500000000")))
+MARKET_RETURN_EDGES: Final = tuple(map(Decimal, ("-5", "0", "5")))
+RULE_13G = Literal["1b", "1c", "both", "unknown"]
+
+
+@dataclass(frozen=True)
+class MatchFeatures:
+    accession_number: str
+    issuer_cik: str
+    filing_date: date
+    entry_date: date
+    entry_price: Decimal
+    trailing_median_dollar_volume: Decimal
+    prior_20_market_return_pct: Decimal
+    rule: RULE_13G | None = None
+
+
+@dataclass(frozen=True)
+class ChallengerMatch:
+    treatment_accession: str
+    challenger_accession: str
+    rule: RULE_13G
+
+
+def _bucket(value: Decimal, edges: tuple[Decimal, ...]) -> int:
+    if not value.is_finite():
+        raise ValueError("matching features must be finite")
+    return sum(value >= edge for edge in edges)
+
+
+def exact_stratum(item: MatchFeatures) -> tuple[int, int, int, int, int]:
+    """Frozen year-month and three numeric matching cells."""
+
+    return (
+        item.filing_date.year,
+        item.filing_date.month,
+        _bucket(item.entry_price, PRICE_EDGES),
+        _bucket(item.trailing_median_dollar_volume, LIQUIDITY_EDGES),
+        _bucket(item.prior_20_market_return_pct, MARKET_RETURN_EDGES),
+    )
+
+
+def _tie_break(treatment_accession: str, challenger_accession: str, *, seed: int) -> str:
+    payload = f"{treatment_accession}\x1f{challenger_accession}\x1f{seed}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def match_initial_13g_without_replacement(
+    treatments: Sequence[MatchFeatures],
+    challengers: Sequence[MatchFeatures],
+    *,
+    rule: RULE_13G,
+    seed: int = 2582,
+) -> tuple[ChallengerMatch, ...]:
+    """Greedily match exact cells in accession order with a SHA-256 tie-break.
+
+    Rule populations are intentionally separate. Unknown never enters a known
+    rule population, and a challenger accession can be consumed only once.
+    Within an exact cell candidates are otherwise interchangeable, so the
+    deterministic greedy order still obtains the maximum possible match count.
+    """
+
+    if rule not in ("1b", "1c", "both", "unknown"):
+        raise ValueError("unsupported Schedule 13G rule")
+    eligible = [item for item in challengers if item.rule == rule]
+    by_stratum: dict[tuple[int, int, int, int, int], list[MatchFeatures]] = {}
+    for item in eligible:
+        by_stratum.setdefault(exact_stratum(item), []).append(item)
+    used: set[str] = set()
+    matches: list[ChallengerMatch] = []
+    for treatment in sorted(treatments, key=lambda item: item.accession_number):
+        candidates = [
+            item for item in by_stratum.get(exact_stratum(treatment), ()) if item.accession_number not in used
+        ]
+        if not candidates:
+            continue
+        selected = min(
+            candidates,
+            key=lambda item: (
+                _tie_break(treatment.accession_number, item.accession_number, seed=seed),
+                item.accession_number,
+            ),
+        )
+        used.add(selected.accession_number)
+        matches.append(ChallengerMatch(treatment.accession_number, selected.accession_number, rule))
+    return tuple(matches)
+
+
+def select_random_time_sessions(
+    treatment_sessions: Mapping[str, Sequence[date]],
+    prohibited_sessions: Mapping[str, set[date]],
+    *,
+    seed: int = 2582,
+) -> dict[str, date]:
+    """Select one deterministic non-event entry session per treatment.
+
+    The caller supplies all price-covered candidate sessions for the same
+    instrument and treatment entry year-month. Sessions within the frozen
+    exclusion halo are removed here. Empty sets remain explicitly unmatched.
+    """
+
+    selected: dict[str, date] = {}
+    for accession in sorted(treatment_sessions):
+        allowed = sorted(set(treatment_sessions[accession]) - prohibited_sessions.get(accession, set()))
+        if not allowed:
+            continue
+        selected[accession] = min(
+            allowed,
+            key=lambda value: (
+                hashlib.sha256(f"{accession}\x1f{value.isoformat()}\x1f{seed}".encode()).hexdigest(),
+                value,
+            ),
+        )
+    return selected

--- a/scripts/schedule13d_statistics.py
+++ b/scripts/schedule13d_statistics.py
@@ -43,6 +43,26 @@ class ClusteredEstimate:
 
 
 @dataclass(frozen=True)
+class PairedDifference:
+    """One treatment-minus-challenger return difference."""
+
+    treatment_accession: str
+    treatment_issuer_cik: str
+    treatment_entry_date: date
+    difference_pct: float
+
+
+@dataclass(frozen=True)
+class DifferenceTest:
+    mean_difference_pct: float
+    lower_95_pct: float
+    upper_95_pct: float
+    one_sided_p_value: float
+    bootstrap_standard_error_pct: float
+    resamples: int
+
+
+@dataclass(frozen=True)
 class StabilityWindow:
     label: str
     start: date
@@ -73,34 +93,28 @@ class OutcomeStatistics:
     break_even_cost_bps: float
 
 
-def two_way_pigeonhole_bootstrap(
-    outcomes: Sequence[EventOutcome],
+def _pigeonhole_estimates(
+    values: np.ndarray,
+    issuer_values: Sequence[str],
+    session_values: Sequence[date],
     *,
-    seed: int = BOOTSTRAP_SEED,
-    resamples: int = BOOTSTRAP_RESAMPLES,
-) -> ClusteredEstimate:
-    """Bootstrap issuers and entry sessions independently with replacement.
-
-    Each observation receives the product of its issuer and entry-session
-    multinomial counts. Percentile bounds use NumPy's linear quantile method.
-    Effective sample size is ``sample variance / bootstrap variance of mean``,
-    capped at the raw event count; it is zero when clustering supplies no
-    estimable precision and never defaults to the row count.
-    """
-
-    if len(outcomes) < 2:
-        raise ValueError("clustered inference requires at least two outcomes")
+    seed: int,
+    resamples: int,
+) -> np.ndarray:
+    if len(values) < 2:
+        raise ValueError("clustered inference requires at least two observations")
+    if len(issuer_values) != len(values) or len(session_values) != len(values):
+        raise ValueError("every observation requires one issuer and one entry session")
     if resamples < 2:
         raise ValueError("resamples must be at least two")
-    values = np.asarray([item.net_return_pct for item in outcomes], dtype=np.float64)
     if not np.all(np.isfinite(values)):
-        raise ValueError("outcome returns must all be finite")
-    issuers = sorted({item.issuer_cik for item in outcomes})
-    sessions = sorted({item.entry_date for item in outcomes})
+        raise ValueError("observations must all be finite")
+    issuers = sorted(set(issuer_values))
+    sessions = sorted(set(session_values))
     issuer_index = {value: index for index, value in enumerate(issuers)}
     session_index = {value: index for index, value in enumerate(sessions)}
-    event_issuers = np.asarray([issuer_index[item.issuer_cik] for item in outcomes])
-    event_sessions = np.asarray([session_index[item.entry_date] for item in outcomes])
+    event_issuers = np.asarray([issuer_index[value] for value in issuer_values])
+    event_sessions = np.asarray([session_index[value] for value in session_values])
     rng = np.random.default_rng(seed)
     estimates = np.empty(resamples, dtype=np.float64)
     valid_draws = 0
@@ -117,6 +131,32 @@ def two_way_pigeonhole_bootstrap(
             continue
         estimates[valid_draws] = float(np.dot(values, weights) / total_weight)
         valid_draws += 1
+    return estimates
+
+
+def two_way_pigeonhole_bootstrap(
+    outcomes: Sequence[EventOutcome],
+    *,
+    seed: int = BOOTSTRAP_SEED,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+) -> ClusteredEstimate:
+    """Bootstrap issuers and entry sessions independently with replacement.
+
+    Each observation receives the product of its issuer and entry-session
+    multinomial counts. Percentile bounds use NumPy's linear quantile method.
+    Effective sample size is ``sample variance / bootstrap variance of mean``,
+    capped at the raw event count; it is zero when clustering supplies no
+    estimable precision and never defaults to the row count.
+    """
+
+    values = np.asarray([item.net_return_pct for item in outcomes], dtype=np.float64)
+    estimates = _pigeonhole_estimates(
+        values,
+        [item.issuer_cik for item in outcomes],
+        [item.entry_date for item in outcomes],
+        seed=seed,
+        resamples=resamples,
+    )
     lower, upper = np.quantile(estimates, (0.025, 0.975), method="linear")
     bootstrap_variance = float(np.var(estimates, ddof=1))
     sample_variance = variance(float(value) for value in values)
@@ -129,6 +169,58 @@ def two_way_pigeonhole_bootstrap(
         effective_sample_size=effective_n,
         resamples=resamples,
     )
+
+
+def paired_clustered_difference_test(
+    differences: Sequence[PairedDifference],
+    *,
+    seed: int = BOOTSTRAP_SEED,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+) -> DifferenceTest:
+    """Test a paired treatment-minus-control mean with treatment clustering.
+
+    The one-sided p-value is computed from the null-centred bootstrap
+    distribution with a plus-one finite-resample correction. The confidence
+    interval is the preregistered percentile interval of the paired mean.
+    """
+
+    values = np.asarray([item.difference_pct for item in differences], dtype=np.float64)
+    estimates = _pigeonhole_estimates(
+        values,
+        [item.treatment_issuer_cik for item in differences],
+        [item.treatment_entry_date for item in differences],
+        seed=seed,
+        resamples=resamples,
+    )
+    observed = float(np.mean(values))
+    lower, upper = np.quantile(estimates, (0.025, 0.975), method="linear")
+    centred = estimates - observed
+    p_value = (1 + int(np.count_nonzero(centred >= observed))) / (resamples + 1)
+    return DifferenceTest(
+        mean_difference_pct=observed,
+        lower_95_pct=float(lower),
+        upper_95_pct=float(upper),
+        one_sided_p_value=p_value,
+        bootstrap_standard_error_pct=float(np.std(estimates, ddof=1)),
+        resamples=resamples,
+    )
+
+
+def holm_adjust(p_values: Sequence[float]) -> tuple[float, ...]:
+    """Return Holm step-down adjusted p-values in original input order."""
+
+    if not p_values:
+        raise ValueError("at least one p-value is required")
+    if any(not np.isfinite(value) or not 0 <= value <= 1 for value in p_values):
+        raise ValueError("p-values must be finite and between zero and one")
+    ordered = sorted(enumerate(p_values), key=lambda item: (item[1], item[0]))
+    adjusted = [0.0] * len(ordered)
+    running = 0.0
+    count = len(ordered)
+    for rank, (original_index, value) in enumerate(ordered):
+        running = max(running, min(1.0, (count - rank) * value))
+        adjusted[original_index] = running
+    return tuple(adjusted)
 
 
 def _average_rank(values: Sequence[float]) -> list[float]:

--- a/scripts/verify_2582_schedule13d_preregistration.py
+++ b/scripts/verify_2582_schedule13d_preregistration.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 CONTRACT = Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")
-EXPECTED_SHA256 = "277e200233095bde072eb9a7583dcb62a04325d3b8b6f43b4cd96f55f71f1e9d"
+EXPECTED_SHA256 = "8f4424bea0581ba501d9779b93ff9268c65c6f0c899f1a66962bcb260cce895f"
 
 
 def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
@@ -35,7 +35,8 @@ def load_and_verify(path: Path = CONTRACT) -> tuple[dict[str, Any], str]:
     assert contract["context"]["market_series"]["allowed_use"].endswith("not_total_return_benchmark")
     assert contract["context"]["item4_policy"].startswith("not_used_in_v1")
     assert contract["challengers"]["matching"]["entry_price_bucket_usd_edges"] == [5, 10, 25, 50, 100]
-    assert contract["challengers"]["multiplicity"].startswith("holm_adjust")
+    assert contract["challengers"]["multiplicity"].startswith("holm_step_down_adjust")
+    assert contract["challengers"]["paired_one_sided_p_value"].startswith("null_center_bootstrap")
     assert contract["acceptance"]["historical_archive_can_promote_capital"] is False
     assert contract["storage"]["duplicate_raw_document"] is False
     assert contract["storage"]["persist_non_firing_poll_rows"] is False

--- a/tests/test_schedule13d_challengers.py
+++ b/tests/test_schedule13d_challengers.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from scripts.schedule13d_challengers import (
+    MatchFeatures,
+    exact_stratum,
+    match_initial_13g_without_replacement,
+    select_random_time_sessions,
+)
+
+
+def _features(
+    accession: str,
+    *,
+    rule: str | None = None,
+    price: str = "25",
+    entry: date = date(2026, 2, 3),
+) -> MatchFeatures:
+    return MatchFeatures(
+        accession_number=accession,
+        issuer_cik=accession,
+        filing_date=entry,
+        entry_date=entry,
+        entry_price=Decimal(price),
+        trailing_median_dollar_volume=Decimal("25000000"),
+        prior_20_market_return_pct=Decimal("0"),
+        rule=rule,  # type: ignore[arg-type]
+    )
+
+
+def test_exact_stratum_uses_right_closed_edge_assignment() -> None:
+    assert exact_stratum(_features("a", price="25"))[2:] == (3, 2, 2)
+    assert exact_stratum(_features("a", price="24.99"))[2:] == (2, 2, 2)
+    month_end = _features("a", entry=date(2026, 2, 2))
+    month_end = MatchFeatures(**{**month_end.__dict__, "filing_date": date(2026, 1, 30)})
+    assert exact_stratum(month_end)[:2] == (2026, 1)
+
+
+def test_13g_matching_is_deterministic_without_replacement_or_rule_pooling() -> None:
+    treatments = (_features("t-2"), _features("t-1"))
+    challengers = (
+        _features("c-1", rule="1b"),
+        _features("c-2", rule="1b"),
+        _features("c-unknown", rule="unknown"),
+    )
+    first = match_initial_13g_without_replacement(treatments, challengers, rule="1b")
+    second = match_initial_13g_without_replacement(tuple(reversed(treatments)), challengers, rule="1b")
+    assert first == second
+    assert len(first) == 2
+    assert len({item.challenger_accession for item in first}) == 2
+    assert "c-unknown" not in {item.challenger_accession for item in first}
+
+
+def test_random_time_selection_is_seeded_and_retains_empty_as_unmatched() -> None:
+    candidates = {
+        "t-1": (date(2026, 2, 3), date(2026, 2, 4), date(2026, 2, 5)),
+        "t-2": (date(2026, 2, 6),),
+    }
+    prohibited = {"t-1": {date(2026, 2, 4)}, "t-2": {date(2026, 2, 6)}}
+    first = select_random_time_sessions(candidates, prohibited)
+    assert first == select_random_time_sessions(candidates, prohibited)
+    assert first["t-1"] in {date(2026, 2, 3), date(2026, 2, 5)}
+    assert "t-2" not in first

--- a/tests/test_schedule13d_statistics.py
+++ b/tests/test_schedule13d_statistics.py
@@ -4,7 +4,14 @@ from datetime import date, timedelta
 
 import pytest
 
-from scripts.schedule13d_statistics import EventOutcome, summarise_outcomes, two_way_pigeonhole_bootstrap
+from scripts.schedule13d_statistics import (
+    EventOutcome,
+    PairedDifference,
+    holm_adjust,
+    paired_clustered_difference_test,
+    summarise_outcomes,
+    two_way_pigeonhole_bootstrap,
+)
 
 
 def _outcome(index: int, value: float, *, issuer: str | None = None, entry: date | None = None) -> EventOutcome:
@@ -50,3 +57,24 @@ def test_nonpositive_book_fails_concentration_safely() -> None:
     summary = summarise_outcomes((_outcome(0, -1), _outcome(1, -2)), resamples=100)
     assert summary.maximum_issuer_positive_concentration_pct == 100
     assert summary.maximum_entry_session_positive_concentration_pct == 100
+
+
+def test_paired_clustered_difference_is_deterministic_and_one_sided() -> None:
+    differences = tuple(
+        PairedDifference(f"a-{index}", f"issuer-{index}", date(2026, 1, index + 2), value)
+        for index, value in enumerate((1.0, 1.5, 2.0, 2.5, 3.0, 3.5))
+    )
+    first = paired_clustered_difference_test(differences, resamples=500)
+    second = paired_clustered_difference_test(differences, resamples=500)
+    assert first == second
+    assert first.mean_difference_pct == 2.25
+    assert first.lower_95_pct > 0
+    assert first.one_sided_p_value < 0.05
+
+
+def test_holm_adjust_is_monotone_in_sorted_p_values_and_restores_order() -> None:
+    adjusted = holm_adjust((0.03, 0.001, 0.02, 0.5))
+    assert adjusted == pytest.approx((0.06, 0.004, 0.06, 0.5))
+    assert holm_adjust((0.01,)) == (0.01,)
+    with pytest.raises(ValueError):
+        holm_adjust((float("nan"),))


### PR DESCRIPTION
Closes no issue; advances #2582.

## Outcome
- freezes deterministic Schedule 13G matching without replacement by exact preregistered strata and rule population
- freezes seeded same-instrument random-time selection with explicit unmatched outcomes
- adds paired two-way clustered treatment-minus-control inference and Holm step-down p-value adjustment
- corrects the ambiguous earlier phrase “Holm-adjusted lower bound” before any outcome is opened
- documents the primary statistical sources and retains the mechanical sealed-outcome gate

## Verification
- full local pre-push gate green (ruff, format, pyright, invariant lints, pure suite, DB smoke, frontend integrity)
- focused 23 tests green
- contract verifier reports `outcomes_read: false`

## Boundaries
No price outcome is read, no trial is registered, no database row is added, and no strategy is made capital-eligible.