### PR TITLE
feat(strategy): add sealed 13G source population

### DIFF
--- a/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-preregistration.md
@@ -113,7 +113,9 @@ a unique adjusted interval construction.
 
 The initial-13G challenger is source-feasible: an outcome-free raw-document
 census found 10,419 filings with the same basic coverage (7,429 Rule 13d-1(b),
-2,262 Rule 13d-1(c), 33 carrying both and 695 unknown). Its strong February and
+2,263 Rule 13d-1(c), 32 carrying both and 695 unknown). Rule identity comes only
+from the structured designation element; narrative mentions elsewhere in the
+document cannot classify a filing. Its strong February and
 quarterly filing waves are why filing month and rule are exact strata rather
 than an undifferentiated placebo.
 

--- a/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
+++ b/docs/proposals/ta/2026-08-12-schedule-13d-source-census.md
@@ -109,9 +109,16 @@ separate; they are never pooled into a known regulatory rule.
 | filing year | Rule 13d-1(b) | Rule 13d-1(c) | both | unknown | total with 60 prior + 20 later days |
 |---|---:|---:|---:|---:|---:|
 | 2024 from 18 December | 3 | 49 | 1 | 4 | 57 |
-| 2025 | 3,350 | 1,418 | 21 | 486 | 5,275 |
+| 2025 | 3,350 | 1,419 | 20 | 486 | 5,275 |
 | 2026 through complete coverage | 4,076 | 795 | 11 | 205 | 5,087 |
-| **total** | **7,429** | **2,262** | **33** | **695** | **10,419** |
+| **total** | **7,429** | **2,263** | **32** | **695** | **10,419** |
+
+Rule identity is read only from the structured
+`designateRulePursuantThisScheduleFiled` XML element. A broad text search had
+previously misclassified accession `0002042569-25-000002` as `both`: its
+structured designation is Rule 13d-1(c), while a signature comment says the
+prior filing had incorrectly selected Rule 13d-1(b). No price outcome was used
+to make this correction.
 
 Initial 13Gs cluster heavily in February and at quarter/annual reporting waves.
 That source shape is why the frozen challenger matches within filing month and

--- a/scripts/evaluate_2582_schedule13d_outcomes.py
+++ b/scripts/evaluate_2582_schedule13d_outcomes.py
@@ -24,6 +24,7 @@ import psycopg
 from app.services.market_calendar import us_market_status
 from app.services.price_quarantine import RULE_SET_VERSION as QUARANTINE_RULE_SET_VERSION
 from app.services.trial_register import TRIAL_REGISTER
+from scripts.schedule13d_challengers import RULE_13G
 from scripts.verify_2582_schedule13d_preregistration import EXPECTED_SHA256, load_and_verify
 
 TRIAL_ID: Final = "c4-schedule13d-public-catalyst-v1"
@@ -49,7 +50,7 @@ class SourceEvent:
     series_adjustment_bases: tuple[str, ...]
 
     @property
-    def primary_source_refusal(self) -> str | None:
+    def unfiltered_source_refusal(self) -> str | None:
         if not self.reporter_identity_complete:
             return "reporter_identity_missing"
         if self.instrument_id is None:
@@ -60,12 +61,46 @@ class SourceEvent:
             return "research_series_missing_or_ambiguous"
         if self.series_adjustment_bases != ("split_adjusted",):
             return "research_series_adjustment_basis_unexpected"
+        return None
+
+    @property
+    def primary_source_refusal(self) -> str | None:
+        refusal = self.unfiltered_source_refusal
+        if refusal is not None:
+            return refusal
         if self.prior_active:
             return "prior_active_chain"
         if self.prior_passive:
             return "prior_passive_chain"
         if self.same_public_date_peer:
             return "same_public_date_chain_ambiguous"
+        return None
+
+
+@dataclass(frozen=True)
+class Initial13GSourceEvent:
+    accession_number: str
+    issuer_cik: str
+    instrument_id: int | None
+    public_filing_date: date
+    rule: RULE_13G
+    raw_document_count: int
+    current_security_eligible: bool
+    series_ids: tuple[int, ...]
+    series_adjustment_bases: tuple[str, ...]
+
+    @property
+    def source_refusal(self) -> str | None:
+        if self.raw_document_count != 1:
+            return "canonical_raw_document_missing_or_ambiguous"
+        if self.instrument_id is None:
+            return "instrument_mapping_missing"
+        if not self.current_security_eligible:
+            return "current_security_scope_ineligible"
+        if len(self.series_ids) != 1:
+            return "research_series_missing_or_ambiguous"
+        if self.series_adjustment_bases != ("split_adjusted",):
+            return "research_series_adjustment_basis_unexpected"
         return None
 
 
@@ -174,6 +209,85 @@ def load_source_events(conn: psycopg.Connection[Any]) -> tuple[SourceEvent, ...]
             current_security_eligible=bool(row[9]),
             series_ids=tuple(int(value) for value in row[10]),
             series_adjustment_bases=tuple(str(value) for value in row[11]),
+        )
+        for row in rows
+    )
+
+
+_INITIAL_13G_SOURCE_SQL: LiteralString = """
+WITH initial_accessions AS (
+    SELECT b.accession_number,
+           min(b.issuer_cik) AS issuer_cik,
+           max(b.instrument_id) FILTER (WHERE b.instrument_id IS NOT NULL) AS instrument_id,
+           m.filed_at::date AS public_filing_date
+    FROM blockholder_filings b
+    JOIN sec_filing_manifest m USING (accession_number)
+    WHERE b.submission_type = 'SCHEDULE 13G'
+      AND m.filed_at::date BETWEEN %(first_source_date)s AND %(last_complete_filing_date)s
+    GROUP BY b.accession_number, m.filed_at::date
+), raw_flags AS (
+    SELECT r.accession_number,
+           count(*) AS raw_document_count,
+           bool_or(r.payload ~* '<([[:alnum:]_]+:)?designateRulePursuantThisScheduleFiled[^>]*>'
+               '[[:space:]]*Rule[[:space:]]+13d-1\\(b\\)[[:space:]]*'
+               '</([[:alnum:]_]+:)?designateRulePursuantThisScheduleFiled>') AS rule_1b,
+           bool_or(r.payload ~* '<([[:alnum:]_]+:)?designateRulePursuantThisScheduleFiled[^>]*>'
+               '[[:space:]]*Rule[[:space:]]+13d-1\\(c\\)[[:space:]]*'
+               '</([[:alnum:]_]+:)?designateRulePursuantThisScheduleFiled>') AS rule_1c
+    FROM filing_raw_documents r
+    WHERE r.document_kind = 'primary_doc_13dg'
+    GROUP BY r.accession_number
+)
+SELECT a.accession_number, a.issuer_cik, a.instrument_id,
+       a.public_filing_date,
+       CASE
+         WHEN coalesce(raw.rule_1b, false) AND coalesce(raw.rule_1c, false) THEN 'both'
+         WHEN coalesce(raw.rule_1b, false) THEN '1b'
+         WHEN coalesce(raw.rule_1c, false) THEN '1c'
+         ELSE 'unknown'
+       END AS rule,
+       coalesce(raw.raw_document_count, 0) AS raw_document_count,
+       coalesce(i.is_tradable, false)
+           AND i.instrument_type_id = 5
+           AND i.exchange IN ('4', '5') AS current_security_eligible,
+       coalesce(array_agg(s.series_id ORDER BY s.series_id)
+           FILTER (WHERE s.series_id IS NOT NULL), '{}') AS series_ids,
+       coalesce(array_agg(s.adjustment_basis ORDER BY s.series_id)
+           FILTER (WHERE s.series_id IS NOT NULL), '{}') AS series_adjustment_bases
+FROM initial_accessions a
+LEFT JOIN raw_flags raw USING (accession_number)
+LEFT JOIN instruments i ON i.instrument_id = a.instrument_id
+LEFT JOIN research_price_series s
+  ON s.instrument_id = a.instrument_id AND s.vendor = %(research_vendor)s
+GROUP BY a.accession_number, a.issuer_cik, a.instrument_id,
+         a.public_filing_date, raw.rule_1b, raw.rule_1c,
+         raw.raw_document_count, i.is_tradable, i.instrument_type_id, i.exchange
+ORDER BY a.public_filing_date, a.accession_number
+"""
+
+
+def load_initial_13g_source_events(conn: psycopg.Connection[Any]) -> tuple[Initial13GSourceEvent, ...]:
+    """Build the passive-filing challenger population without loading prices."""
+
+    rows = conn.execute(
+        _INITIAL_13G_SOURCE_SQL,
+        {
+            "research_vendor": RESEARCH_VENDOR,
+            "first_source_date": FIRST_SOURCE_DATE,
+            "last_complete_filing_date": LAST_COMPLETE_FILING_DATE,
+        },
+    ).fetchall()
+    return tuple(
+        Initial13GSourceEvent(
+            accession_number=str(row[0]),
+            issuer_cik=str(row[1]),
+            instrument_id=None if row[2] is None else int(row[2]),
+            public_filing_date=row[3],
+            rule=row[4],
+            raw_document_count=int(row[5]),
+            current_security_eligible=bool(row[6]),
+            series_ids=tuple(int(value) for value in row[7]),
+            series_adjustment_bases=tuple(str(value) for value in row[8]),
         )
         for row in rows
     )

--- a/tests/test_evaluate_2582_schedule13d_outcomes.py
+++ b/tests/test_evaluate_2582_schedule13d_outcomes.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import pytest
 
 from scripts.evaluate_2582_schedule13d_outcomes import (
+    _INITIAL_13G_SOURCE_SQL,
     _SOURCE_EVENTS_SQL,
     ACKNOWLEDGEMENT,
+    Initial13GSourceEvent,
     OutcomeGateRefusal,
     PriceWindow,
     SourceEvent,
@@ -37,6 +39,17 @@ def test_source_population_uses_public_manifest_clock_and_cannot_read_prices() -
     assert "m.filed_at::date" in lowered
     assert "research_price_daily" not in lowered
     assert "b.filed_at" not in lowered
+    assert "between %(first_source_date)s and %(last_complete_filing_date)s" in lowered
+
+
+def test_13g_challenger_source_is_frozen_outcome_free_and_rule_separated() -> None:
+    lowered = _INITIAL_13G_SOURCE_SQL.lower()
+    assert "b.submission_type = 'schedule 13g'" in lowered
+    assert "sec_filing_manifest" in lowered
+    assert "filing_raw_documents" in lowered
+    assert "designaterulepursuantthisschedulefiled" in lowered
+    assert "[[:space:]]*rule[[:space:]]+13d-1" in lowered
+    assert "research_price_daily" not in lowered
     assert "between %(first_source_date)s and %(last_complete_filing_date)s" in lowered
 
 
@@ -107,6 +120,7 @@ def _source_event(**changes: object) -> SourceEvent:
 
 def test_primary_source_refusal_is_explicit_and_fail_closed() -> None:
     assert _source_event().primary_source_refusal is None
+    assert _source_event(prior_passive=True).unfiltered_source_refusal is None
     assert _source_event(prior_passive=True).primary_source_refusal == "prior_passive_chain"
     assert _source_event(series_ids=(1, 2)).primary_source_refusal == "research_series_missing_or_ambiguous"
     assert (
@@ -114,6 +128,31 @@ def test_primary_source_refusal_is_explicit_and_fail_closed() -> None:
         == "research_series_adjustment_basis_unexpected"
     )
     assert _source_event(reporter_identity_complete=False).primary_source_refusal == "reporter_identity_missing"
+
+
+def _13g_source(**changes: object) -> Initial13GSourceEvent:
+    values: dict[str, object] = {
+        "accession_number": "0000000001-26-000002",
+        "issuer_cik": "0000000001",
+        "instrument_id": 42,
+        "public_filing_date": date(2026, 2, 2),
+        "rule": "1b",
+        "raw_document_count": 1,
+        "current_security_eligible": True,
+        "series_ids": (99,),
+        "series_adjustment_bases": ("split_adjusted",),
+    }
+    values.update(changes)
+    return Initial13GSourceEvent(**values)  # type: ignore[arg-type]
+
+
+def test_initial_13g_source_refusal_is_explicit_and_unknown_rule_is_retained() -> None:
+    assert _13g_source().source_refusal is None
+    assert _13g_source(rule="unknown").source_refusal is None
+    assert _13g_source(raw_document_count=0).source_refusal == "canonical_raw_document_missing_or_ambiguous"
+    assert _13g_source(series_adjustment_bases=("raw",)).source_refusal == (
+        "research_series_adjustment_basis_unexpected"
+    )
 
 
 def test_required_sessions_are_exact_and_do_not_skip_market_dates() -> None:


### PR DESCRIPTION
Advances #2582.

## Outcome
- adds the outcome-free initial Schedule 13G challenger population from canonical SEC manifest and raw XML
- separates Rule 13d-1(b), Rule 13d-1(c), both and unknown without pooling
- scopes rule identity to the structured `designateRulePursuantThisScheduleFiled` element, preventing narrative false classifications
- applies current eToro stock/exchange/tradability and unique split-adjusted research-series source gates
- separates unfiltered eligible 13D source refusals from the clean-chain primary refusal
- corrects and reproduces the preregistered basic-coverage census: 7,429 / 2,263 / 32 / 695

## Review correction
Independent review caught accession `0002042569-25-000002`: the structured designation is Rule 1(c), while signature comments mention its prior erroneous Rule 1(b) selection. The old broad census called it `both`; this PR corrects it without reading prices.

## Verification
- 25 focused tests green
- ruff and pyright green
- full pre-push gate green, including application boot against dev DB

## Boundaries
This reads no `research_price_daily` row, opens no outcome, adds no schema or retained row, and does not register or promote the trial.