### PR TITLE
feat: orchestrate sealed Schedule 13D outcomes

### DIFF
--- a/scripts/evaluate_2582_schedule13d_outcomes.py
+++ b/scripts/evaluate_2582_schedule13d_outcomes.py
@@ -302,8 +302,26 @@ CREATE TEMP TABLE schedule13d_trial_sessions (
     series_id BIGINT NOT NULL,
     bar_date DATE NOT NULL,
     PRIMARY KEY (event_index, session_ordinal)
-) ON COMMIT DROP
+) ON COMMIT PRESERVE ROWS
 """
+
+
+def prepare_price_window_workspace(conn: psycopg.Connection[Any]) -> None:
+    """Create the connection-local workspace before the read-only outcome transaction.
+
+    PostgreSQL permits DML on an existing temporary table in a read-only
+    transaction but forbids CREATE/DROP/TRUNCATE.  Requiring an idle fresh
+    connection keeps the commit boundary explicit and lets all durable-table
+    outcome reads run under one read-only snapshot.
+    """
+
+    if conn.info.transaction_status != psycopg.pq.TransactionStatus.IDLE:
+        raise OutcomeGateRefusal("price workspace preparation requires an idle connection")
+    existing = conn.execute("SELECT to_regclass('pg_temp.schedule13d_trial_sessions')").fetchone()
+    if existing is None or existing[0] is None:
+        conn.execute(_CREATE_TEMP_SESSIONS)
+    conn.commit()
+
 
 _PRICE_WINDOWS_SQL: LiteralString = """
 WITH joined AS (
@@ -410,8 +428,10 @@ def _load_requested_price_windows(
     _verify_market_series(conn)
     if len(requests) > 32_767:
         raise OutcomeGateRefusal("price-window request exceeds frozen SMALLINT event bound")
-    conn.execute("DROP TABLE IF EXISTS schedule13d_trial_sessions")
-    conn.execute(_CREATE_TEMP_SESSIONS)
+    prepared = conn.execute("SELECT to_regclass('pg_temp.schedule13d_trial_sessions')").fetchone()
+    if prepared is None or prepared[0] is None:
+        raise OutcomeGateRefusal("connection-local price workspace was not prepared")
+    conn.execute("DELETE FROM schedule13d_trial_sessions")
     with conn.cursor() as cursor:
         with cursor.copy(
             "COPY schedule13d_trial_sessions (event_index, session_ordinal, series_id, bar_date) FROM STDIN"

--- a/scripts/schedule13d_orchestrator.py
+++ b/scripts/schedule13d_orchestrator.py
@@ -1,0 +1,88 @@
+"""Gate-protected orchestration for the frozen Schedule 13D study.
+
+The module has no CLI and cannot construct an outcome gate.  It only coordinates
+the already reviewed source, price, challenger and report primitives after a
+caller has crossed that boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, LiteralString
+
+import psycopg
+
+from scripts.evaluate_2582_schedule13d_outcomes import (
+    OutcomeGate,
+    SourceEvent,
+    load_initial_13g_price_windows,
+    load_initial_13g_source_events,
+    load_price_windows,
+    load_random_time_price_windows,
+    load_source_events,
+    prepare_price_window_workspace,
+)
+from scripts.schedule13d_report import HistoricalFalsificationReport, build_historical_falsification_report
+
+_CURRENT_SECTOR_SQL: LiteralString = """
+SELECT i.instrument_id,
+       coalesce(esi.name, 'provider_industry_id:' || i.sector) AS sector_label
+FROM instruments i
+LEFT JOIN etoro_stocks_industries esi
+  ON esi.industry_id::text = i.sector
+WHERE i.instrument_id = ANY(%(instrument_ids)s::bigint[])
+  AND i.sector IS NOT NULL
+ORDER BY i.instrument_id
+"""
+
+
+def load_current_sector_labels(conn: psycopg.Connection[Any], events: Sequence[SourceEvent]) -> dict[int, str]:
+    """Load current provider sectors for concentration attribution only.
+
+    These are explicitly not point-in-time classifications and cannot gate the
+    candidate or define a rescuing subgroup.  A missing lookup label retains the
+    stable provider-industry id rather than merging it into another sector.
+    """
+
+    instrument_ids = sorted({event.instrument_id for event in events if event.instrument_id is not None})
+    if not instrument_ids:
+        return {}
+    rows = conn.execute(_CURRENT_SECTOR_SQL, {"instrument_ids": instrument_ids}).fetchall()
+    return {int(instrument_id): str(label) for instrument_id, label in rows}
+
+
+def evaluate_historical_falsification(
+    conn: psycopg.Connection[Any], gate: OutcomeGate
+) -> HistoricalFalsificationReport:
+    """Evaluate every frozen arm once and return one aggregate report.
+
+    The transaction is read-only for durable tables.  The shared price loader's
+    bounded temporary table remains permissible, while accidental application
+    writes fail closed at PostgreSQL.
+    """
+
+    prepare_price_window_workspace(conn)
+    conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+    source_events = load_source_events(conn)
+    initial_13g_sources = load_initial_13g_source_events(conn)
+    primary_windows = load_price_windows(conn, gate, source_events, population="primary")
+    unfiltered_windows = load_price_windows(conn, gate, source_events, population="unfiltered")
+    random_windows = load_random_time_price_windows(conn, gate, source_events)
+    initial_13g_windows = load_initial_13g_price_windows(conn, gate, initial_13g_sources)
+    sectors = load_current_sector_labels(conn, source_events)
+    return build_historical_falsification_report(
+        source_events=source_events,
+        initial_13g_sources=initial_13g_sources,
+        primary_windows=primary_windows,
+        unfiltered_windows=unfiltered_windows,
+        random_windows=random_windows,
+        initial_13g_windows=initial_13g_windows,
+        sector_by_instrument=sectors,
+    )
+
+
+__all__ = [
+    "_CURRENT_SECTOR_SQL",
+    "evaluate_historical_falsification",
+    "load_current_sector_labels",
+]

--- a/scripts/schedule13d_orchestrator.py
+++ b/scripts/schedule13d_orchestrator.py
@@ -63,22 +63,25 @@ def evaluate_historical_falsification(
 
     prepare_price_window_workspace(conn)
     conn.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
-    source_events = load_source_events(conn)
-    initial_13g_sources = load_initial_13g_source_events(conn)
-    primary_windows = load_price_windows(conn, gate, source_events, population="primary")
-    unfiltered_windows = load_price_windows(conn, gate, source_events, population="unfiltered")
-    random_windows = load_random_time_price_windows(conn, gate, source_events)
-    initial_13g_windows = load_initial_13g_price_windows(conn, gate, initial_13g_sources)
-    sectors = load_current_sector_labels(conn, source_events)
-    return build_historical_falsification_report(
-        source_events=source_events,
-        initial_13g_sources=initial_13g_sources,
-        primary_windows=primary_windows,
-        unfiltered_windows=unfiltered_windows,
-        random_windows=random_windows,
-        initial_13g_windows=initial_13g_windows,
-        sector_by_instrument=sectors,
-    )
+    try:
+        source_events = load_source_events(conn)
+        initial_13g_sources = load_initial_13g_source_events(conn)
+        primary_windows = load_price_windows(conn, gate, source_events, population="primary")
+        unfiltered_windows = load_price_windows(conn, gate, source_events, population="unfiltered")
+        random_windows = load_random_time_price_windows(conn, gate, source_events)
+        initial_13g_windows = load_initial_13g_price_windows(conn, gate, initial_13g_sources)
+        sectors = load_current_sector_labels(conn, source_events)
+        return build_historical_falsification_report(
+            source_events=source_events,
+            initial_13g_sources=initial_13g_sources,
+            primary_windows=primary_windows,
+            unfiltered_windows=unfiltered_windows,
+            random_windows=random_windows,
+            initial_13g_windows=initial_13g_windows,
+            sector_by_instrument=sectors,
+        )
+    finally:
+        conn.rollback()
 
 
 __all__ = [

--- a/tests/test_evaluate_2582_schedule13d_outcomes.py
+++ b/tests/test_evaluate_2582_schedule13d_outcomes.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
+import psycopg
 import pytest
 
 from scripts.evaluate_2582_schedule13d_outcomes import (
     _ALL_13D_PUBLIC_DATES_SQL,
+    _CREATE_TEMP_SESSIONS,
     _INITIAL_13G_SOURCE_SQL,
     _SOURCE_EVENTS_SQL,
     ACKNOWLEDGEMENT,
@@ -21,6 +24,7 @@ from scripts.evaluate_2582_schedule13d_outcomes import (
     match_tie_break,
     next_regular_session_strictly_after,
     nth_regular_session,
+    prepare_price_window_workspace,
     regular_sessions_ending_before,
     require_outcome_gate,
     required_event_sessions,
@@ -64,6 +68,62 @@ def test_random_placebo_halo_source_is_outcome_free_and_includes_amendments() ->
     assert "'schedule 13d', 'schedule 13d/a'" in lowered
     assert "sec_filing_manifest" in lowered
     assert "research_price_daily" not in lowered
+
+
+def test_price_workspace_survives_commit_for_one_read_only_outcome_snapshot() -> None:
+    assert "ON COMMIT PRESERVE ROWS" in _CREATE_TEMP_SESSIONS
+    assert "ON COMMIT DROP" not in _CREATE_TEMP_SESSIONS
+
+
+class _WorkspaceInfo:
+    transaction_status = psycopg.pq.TransactionStatus.IDLE
+
+
+class _WorkspaceConnection:
+    info = _WorkspaceInfo()
+
+    def __init__(self, *, existing: bool = False) -> None:
+        self.executed: list[str] = []
+        self.committed = False
+        self.existing = existing
+
+    def execute(self, query: str) -> Any:
+        self.executed.append(query)
+        if "to_regclass" in query:
+            return _WorkspaceResult(("schedule13d_trial_sessions" if self.existing else None,))
+        return None
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+class _WorkspaceResult:
+    def __init__(self, row: tuple[str | None]) -> None:
+        self.row = row
+
+    def fetchone(self) -> tuple[str | None]:
+        return self.row
+
+
+def test_price_workspace_preparation_has_an_explicit_pre_outcome_commit() -> None:
+    conn = _WorkspaceConnection()
+    prepare_price_window_workspace(conn)  # type: ignore[arg-type]
+    assert conn.executed == ["SELECT to_regclass('pg_temp.schedule13d_trial_sessions')", _CREATE_TEMP_SESSIONS]
+    assert conn.committed
+
+
+def test_price_workspace_preparation_reuses_an_idle_connection() -> None:
+    conn = _WorkspaceConnection(existing=True)
+    prepare_price_window_workspace(conn)  # type: ignore[arg-type]
+    assert conn.executed == ["SELECT to_regclass('pg_temp.schedule13d_trial_sessions')"]
+    assert conn.committed
+
+
+def test_price_workspace_refuses_to_commit_a_caller_owned_transaction() -> None:
+    conn = _WorkspaceConnection()
+    conn.info.transaction_status = psycopg.pq.TransactionStatus.INTRANS
+    with pytest.raises(OutcomeGateRefusal, match="idle connection"):
+        prepare_price_window_workspace(conn)  # type: ignore[arg-type]
 
 
 def test_gate_refuses_even_with_ack_until_trial_is_declared() -> None:

--- a/tests/test_schedule13d_orchestrator.py
+++ b/tests/test_schedule13d_orchestrator.py
@@ -4,6 +4,8 @@ from datetime import date
 from decimal import Decimal
 from typing import Any
 
+import pytest
+
 from scripts import schedule13d_orchestrator as subject
 from scripts.evaluate_2582_schedule13d_outcomes import OutcomeGate, SourceEvent
 
@@ -36,12 +38,16 @@ class _Result:
 class _Connection:
     def __init__(self) -> None:
         self.statements: list[tuple[str, object | None]] = []
+        self.rolled_back = False
 
     def execute(self, query: str, params: object | None = None) -> _Result:
         self.statements.append((query, params))
         if "FROM instruments i" in query:
             return _Result([(42, "Technology"), (43, "provider_industry_id:9")])
         return _Result([])
+
+    def rollback(self) -> None:
+        self.rolled_back = True
 
 
 def test_current_sector_labels_are_current_attribution_and_keep_provider_fallback() -> None:
@@ -91,8 +97,19 @@ def test_orchestrator_is_read_only_and_loads_every_arm_before_one_report(monkeyp
     result = subject.evaluate_historical_falsification(conn, gate)  # type: ignore[arg-type]
 
     assert result == "aggregate"
+    assert conn.rolled_back
     assert conn.statements[0] == ("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY", None)
     assert calls == ["workspace", "sources", "13g_sources", "primary", "unfiltered", "random", "13g_prices"]
     assert captured["sector_by_instrument"] == {42: "Technology"}
     assert captured["primary_windows"] == ("primary",)
     assert captured["unfiltered_windows"] == ("unfiltered",)
+
+
+def test_orchestrator_rolls_back_its_snapshot_when_evaluation_raises(monkeypatch: Any) -> None:
+    conn = _Connection()
+    monkeypatch.setattr(subject, "prepare_price_window_workspace", lambda _conn: None)
+    monkeypatch.setattr(subject, "load_source_events", lambda _conn: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        subject.evaluate_historical_falsification(conn, OutcomeGate("hash", "register", "trial"))  # type: ignore[arg-type]
+    assert conn.rolled_back

--- a/tests/test_schedule13d_orchestrator.py
+++ b/tests/test_schedule13d_orchestrator.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from scripts import schedule13d_orchestrator as subject
+from scripts.evaluate_2582_schedule13d_outcomes import OutcomeGate, SourceEvent
+
+
+def _source() -> SourceEvent:
+    return SourceEvent(
+        accession_number="t-1",
+        issuer_cik="issuer-1",
+        instrument_id=42,
+        public_filing_date=date(2026, 2, 2),
+        maximum_percent_of_class=Decimal("7.5"),
+        prior_active=False,
+        prior_passive=False,
+        same_public_date_peer=False,
+        reporter_identity_complete=True,
+        current_security_eligible=True,
+        series_ids=(99,),
+        series_adjustment_bases=("split_adjusted",),
+    )
+
+
+class _Result:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self._rows
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.statements: list[tuple[str, object | None]] = []
+
+    def execute(self, query: str, params: object | None = None) -> _Result:
+        self.statements.append((query, params))
+        if "FROM instruments i" in query:
+            return _Result([(42, "Technology"), (43, "provider_industry_id:9")])
+        return _Result([])
+
+
+def test_current_sector_labels_are_current_attribution_and_keep_provider_fallback() -> None:
+    conn = _Connection()
+    labels = subject.load_current_sector_labels(conn, (_source(),))  # type: ignore[arg-type]
+    assert labels == {42: "Technology", 43: "provider_industry_id:9"}
+    query, params = conn.statements[-1]
+    assert "etoro_stocks_industries" in query
+    assert params == {"instrument_ids": [42]}
+
+
+def test_orchestrator_is_read_only_and_loads_every_arm_before_one_report(monkeypatch: Any) -> None:
+    conn = _Connection()
+    gate = OutcomeGate("hash", "register", "trial")
+    source = (_source(),)
+    calls: list[str] = []
+
+    monkeypatch.setattr(subject, "load_source_events", lambda _conn: calls.append("sources") or source)
+    monkeypatch.setattr(subject, "prepare_price_window_workspace", lambda _conn: calls.append("workspace"))
+    monkeypatch.setattr(subject, "load_initial_13g_source_events", lambda _conn: calls.append("13g_sources") or ())
+
+    def price(_conn: Any, _gate: Any, _events: Any, *, population: str) -> tuple[str, ...]:
+        calls.append(population)
+        return (population,)
+
+    monkeypatch.setattr(subject, "load_price_windows", price)
+    monkeypatch.setattr(
+        subject,
+        "load_random_time_price_windows",
+        lambda _conn, _gate, _events: calls.append("random") or ("random",),
+    )
+    monkeypatch.setattr(
+        subject,
+        "load_initial_13g_price_windows",
+        lambda _conn, _gate, _events: calls.append("13g_prices") or ("13g",),
+    )
+    monkeypatch.setattr(subject, "load_current_sector_labels", lambda _conn, _events: {42: "Technology"})
+
+    captured: dict[str, Any] = {}
+
+    def report(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "aggregate"
+
+    monkeypatch.setattr(subject, "build_historical_falsification_report", report)
+
+    result = subject.evaluate_historical_falsification(conn, gate)  # type: ignore[arg-type]
+
+    assert result == "aggregate"
+    assert conn.statements[0] == ("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY", None)
+    assert calls == ["workspace", "sources", "13g_sources", "primary", "unfiltered", "random", "13g_prices"]
+    assert captured["sector_by_instrument"] == {42: "Technology"}
+    assert captured["primary_windows"] == ("primary",)
+    assert captured["unfiltered_windows"] == ("unfiltered",)


### PR DESCRIPTION
## Outcome\n\nCompletes the reviewed, still-sealed outcome orchestration for #2582 without registering or running the trial.\n\n- evaluates clean and unfiltered 13D, seeded same-instrument random time, and all rule-separated initial-13G arms through the shared price path\n- prepares one connection-local temp workspace, then evaluates every arm under one `REPEATABLE READ READ ONLY` snapshot\n- supports safe workspace reuse; durable application tables remain database-enforced read-only\n- resolves current eToro provider-industry labels for concentration attribution only, never eligibility or subgroup rescue\n- returns the one bounded aggregate report and adds no schema or persistent event rows\n\n## Validation\n\n- 27 focused evaluator/orchestrator/report tests pass serially\n- live dev-Postgres probe confirmed workspace reuse, temp COPY, repeatable-read isolation, and read-only durable transaction state\n- ruff and pyright pass\n- independent review found and prompted fixes for snapshot isolation and workspace reuse; amended re-review found no actionable defects\n- complete pre-push gate passed, including whole fast suite and real app boot\n\nThe trial register and evaluator second lock remain unchanged; no price outcome has been opened.\n\nAdvances #2582.