### PR TITLE
feat(strategy): emit bounded Schedule 13D artifact

### DIFF
--- a/scripts/run_2582_schedule13d_outcomes.py
+++ b/scripts/run_2582_schedule13d_outcomes.py
@@ -1,0 +1,37 @@
+"""One-shot stdout runner for the sealed #2582 historical falsification."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import psycopg
+
+from app.config import settings
+from scripts.evaluate_2582_schedule13d_outcomes import ACKNOWLEDGEMENT, require_outcome_gate
+from scripts.schedule13d_artifact import build_artifact
+from scripts.schedule13d_orchestrator import evaluate_historical_falsification
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--acknowledgement")
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json"),
+    )
+    args = parser.parse_args(argv)
+    gate = require_outcome_gate(acknowledgement=args.acknowledgement, contract_path=args.contract)
+    with psycopg.connect(settings.database_url) as conn:
+        report = evaluate_historical_falsification(conn, gate)
+    sys.stdout.write(build_artifact(gate, report).to_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["ACKNOWLEDGEMENT", "main"]

--- a/scripts/schedule13d_artifact.py
+++ b/scripts/schedule13d_artifact.py
@@ -1,0 +1,117 @@
+"""Auditable, bounded artifact envelope for the sealed Schedule 13D study."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final
+
+from scripts.evaluate_2582_schedule13d_outcomes import (
+    FIRST_SOURCE_DATE,
+    LAST_COMPLETE_FILING_DATE,
+    RESEARCH_VENDOR,
+    OutcomeGate,
+)
+from scripts.schedule13d_report import HistoricalFalsificationReport
+
+ARTIFACT_SCHEMA_VERSION: Final = "schedule13d-historical-falsification-artifact-v1"
+IMPLEMENTATION_FILES: Final = (
+    "scripts/evaluate_2582_schedule13d_outcomes.py",
+    "scripts/schedule13d_challengers.py",
+    "scripts/schedule13d_statistics.py",
+    "scripts/schedule13d_report.py",
+    "scripts/schedule13d_orchestrator.py",
+    "scripts/schedule13d_artifact.py",
+    "scripts/run_2582_schedule13d_outcomes.py",
+)
+
+
+def canonical_sha256(value: Any) -> str:
+    encoded = json.dumps(value, allow_nan=False, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def implementation_sha256(root: Path = Path(".")) -> str:
+    digest = hashlib.sha256()
+    for relative in IMPLEMENTATION_FILES:
+        source = root / relative
+        payload = source.read_bytes()
+        digest.update(relative.encode())
+        digest.update(b"\0")
+        digest.update(str(len(payload)).encode())
+        digest.update(b"\0")
+        digest.update(payload)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class HistoricalFalsificationArtifact:
+    artifact_schema_version: str
+    generated_at: str
+    trial_id: str
+    trial_register_version: str
+    contract_sha256: str
+    implementation_sha256: str
+    source_first_date: str
+    source_last_complete_filing_date: str
+    research_vendor: str
+    decision: str
+    report_sha256: str
+    report: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.as_dict(), allow_nan=False, indent=2, sort_keys=True) + "\n"
+
+
+def build_artifact(
+    gate: OutcomeGate,
+    report: HistoricalFalsificationReport,
+    *,
+    root: Path = Path("."),
+    generated_at: datetime | None = None,
+) -> HistoricalFalsificationArtifact:
+    timestamp = generated_at or datetime.now(UTC)
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        raise ValueError("artifact timestamp must be timezone-aware")
+    report_payload = report.as_dict()
+    return HistoricalFalsificationArtifact(
+        artifact_schema_version=ARTIFACT_SCHEMA_VERSION,
+        generated_at=timestamp.astimezone(UTC).isoformat(),
+        trial_id=gate.trial_id,
+        trial_register_version=gate.trial_register_version,
+        contract_sha256=gate.contract_sha256,
+        implementation_sha256=implementation_sha256(root),
+        source_first_date=FIRST_SOURCE_DATE.isoformat(),
+        source_last_complete_filing_date=LAST_COMPLETE_FILING_DATE.isoformat(),
+        research_vendor=RESEARCH_VENDOR,
+        decision=report.decision,
+        report_sha256=canonical_sha256(report_payload),
+        report=report_payload,
+    )
+
+
+def verify_artifact(artifact: HistoricalFalsificationArtifact, *, root: Path = Path(".")) -> None:
+    if artifact.artifact_schema_version != ARTIFACT_SCHEMA_VERSION:
+        raise ValueError("unknown Schedule 13D artifact schema")
+    if artifact.decision != artifact.report.get("decision"):
+        raise ValueError("artifact decision does not match report")
+    if canonical_sha256(artifact.report) != artifact.report_sha256:
+        raise ValueError("artifact report digest mismatch")
+    if implementation_sha256(root) != artifact.implementation_sha256:
+        raise ValueError("artifact implementation digest does not match this checkout")
+
+
+__all__ = [
+    "ARTIFACT_SCHEMA_VERSION",
+    "HistoricalFalsificationArtifact",
+    "build_artifact",
+    "canonical_sha256",
+    "implementation_sha256",
+    "verify_artifact",
+]

--- a/tests/test_run_2582_schedule13d_outcomes.py
+++ b/tests/test_run_2582_schedule13d_outcomes.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.evaluate_2582_schedule13d_outcomes import ACKNOWLEDGEMENT, OutcomeGateRefusal
+from scripts.run_2582_schedule13d_outcomes import main
+
+
+def test_runner_refuses_before_database_connection_while_trial_is_unregistered() -> None:
+    with pytest.raises(OutcomeGateRefusal, match="absent from trial-register"):
+        main(
+            [
+                "--acknowledgement",
+                ACKNOWLEDGEMENT,
+                "--contract",
+                str(Path("docs/proposals/ta/contracts/schedule13d-public-catalyst-v1.json")),
+            ]
+        )

--- a/tests/test_schedule13d_artifact.py
+++ b/tests/test_schedule13d_artifact.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import pytest
+
+from scripts.evaluate_2582_schedule13d_outcomes import OutcomeGate
+from scripts.schedule13d_artifact import build_artifact, verify_artifact
+
+
+class _Report:
+    decision = "inconclusive"
+
+    def as_dict(self) -> dict[str, object]:
+        return {"decision": self.decision, "primary": {"event_count": 10}}
+
+
+def test_artifact_pins_gate_corpus_implementation_and_report_digest() -> None:
+    gate = OutcomeGate("c" * 64, "trial-register-test", "trial-test")
+    artifact = build_artifact(
+        gate,
+        _Report(),  # type: ignore[arg-type]
+        generated_at=datetime(2026, 8, 12, 9, 0, tzinfo=UTC),
+    )
+    assert artifact.trial_id == "trial-test"
+    assert artifact.contract_sha256 == "c" * 64
+    assert len(artifact.implementation_sha256) == 64
+    assert artifact.source_first_date == "2024-12-18"
+    assert artifact.source_last_complete_filing_date == "2026-06-18"
+    assert json.loads(artifact.to_json())["report"]["primary"]["event_count"] == 10
+    verify_artifact(artifact)
+
+
+def test_artifact_verifier_refuses_report_or_decision_tampering() -> None:
+    artifact = build_artifact(
+        OutcomeGate("c" * 64, "register", "trial"),
+        _Report(),  # type: ignore[arg-type]
+        generated_at=datetime(2026, 8, 12, 9, 0, tzinfo=UTC),
+    )
+    with pytest.raises(ValueError, match="digest"):
+        verify_artifact(replace(artifact, report={"decision": "inconclusive"}))
+    with pytest.raises(ValueError, match="decision"):
+        verify_artifact(replace(artifact, decision="pass"))
+    with pytest.raises(ValueError, match="implementation"):
+        verify_artifact(replace(artifact, implementation_sha256="0" * 64))
+
+
+def test_artifact_requires_an_aware_timestamp() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        build_artifact(
+            OutcomeGate("c" * 64, "register", "trial"),
+            _Report(),  # type: ignore[arg-type]
+            generated_at=datetime(2026, 8, 12, 9, 0),
+        )


### PR DESCRIPTION
## Outcome

Adds the final one-shot stdout runner and a tamper-evident artifact envelope for the sealed #2582 Schedule 13D historical falsification. The artifact pins the preregistered trial identity and contract digest, frozen source interval/vendor, implementation digest, report digest, decision, and full bounded report.

This does **not** open outcomes. The existing trial-register and explicit acknowledgement locks remain authoritative, and the runner refuses before connecting to Postgres while the trial is unregistered.

## Why

The previously merged evaluator can produce the sealed decision, but it needed one auditable, storage-neutral boundary so the eventual one-time result can be captured without ad-hoc queries or mutable database state. Hashing the implementation set and report makes the emitted result traceable to the reviewed code and detects later report/code tampering.

## Security and data model

- Connects through the existing application database configuration only after both outcome locks pass.
- Reuses the read-only, repeatable-read orchestrator; no durable database tables or result rows are written.
- Emits JSON to stdout only; no implicit artifact file is created or overwritten.
- Rejects naive timestamps and verifies schema, decision, report digest, and implementation digest.
- Does not weaken trial registration, acknowledgement, eligibility, matching, statistical, or second-lock constraints.

## Validation

- Full repository pre-push gate green: ruff, formatting, pyright, shell/invariant lints, pure-logic suite, smoke suite, and frontend integrity checks.
- Focused Schedule 13D suite green: 40 tests across artifact, runner, orchestrator, report, statistics, challengers, and evaluator.
- Tree clean; diff check green.

Refs #2582