### PR TITLE
fix(thesis): send the whole prompt to the local model

### DIFF
--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -312,8 +312,22 @@ class OpenAICompatProvider:
             logger.info("llm: released local model %s", self.model)
 
 
+#: Probe results, keyed by base URL. ⚠ CACHED BECAUSE ``make_llm_clients`` IS
+#: DOCUMENTED AS DOING NO NETWORK I/O — ``scheduler.py``'s
+#: ``_llm_provider_resolvable`` prerequisite check calls it purely to resolve
+#: config, and a per-call round trip would turn a config gate into a
+#: connectivity gate. One probe per process per URL, so the hourly job pays it
+#: at most once. Review NITPICK on #2618.
+#:
+#: ⚠ Staleness is the accepted trade: swapping Ollama for llama.cpp at the same
+#: URL without restarting the process keeps the old answer. That is a
+#: deployment change, and the probe fails TO the OpenAI transport anyway, so the
+#: stale direction that matters degrades to the pre-#2431 behaviour.
+_OLLAMA_PROBE_CACHE: dict[str, bool] = {}
+
+
 def _endpoint_is_ollama(base_url: str) -> bool:
-    """Is this endpoint actually Ollama? Probed, never assumed (#2431).
+    """Is this endpoint actually Ollama? Probed once per process, never assumed (#2431).
 
     ``/api/version`` is Ollama's own route: llama.cpp and vLLM serve the OpenAI
     surface but not this one, so a 200 here is positive evidence rather than a
@@ -326,6 +340,9 @@ def _endpoint_is_ollama(base_url: str) -> bool:
     """
     if not is_local_llm_endpoint(base_url):
         return False
+    cached = _OLLAMA_PROBE_CACHE.get(base_url)
+    if cached is not None:
+        return cached
     try:
         # ⚠ ``rstrip('/')`` HERE and not in ``complete()`` — deliberate, not an
         # oversight (review NITPICK on #2618). This takes the RAW configured
@@ -336,8 +353,13 @@ def _endpoint_is_ollama(base_url: str) -> bool:
             timeout=LLM_RELEASE_TIMEOUT,
         )
     except httpx.HTTPError:
+        # ⚠ NOT cached. An unreachable server is a transient condition — caching
+        # it would pin the OpenAI transport for the life of the process because
+        # Ollama happened to be restarting when the first probe fired.
         return False
-    return response.status_code == 200
+    is_ollama = response.status_code == 200
+    _OLLAMA_PROBE_CACHE[base_url] = is_ollama
+    return is_ollama
 
 
 class OllamaNativeProvider(OpenAICompatProvider):

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -327,6 +327,10 @@ def _endpoint_is_ollama(base_url: str) -> bool:
     if not is_local_llm_endpoint(base_url):
         return False
     try:
+        # ⚠ ``rstrip('/')`` HERE and not in ``complete()`` — deliberate, not an
+        # oversight (review NITPICK on #2618). This takes the RAW configured
+        # ``llm_base_url``, which may carry a trailing slash; the provider works
+        # off ``self._base_url``, already normalised by ``__init__``.
         response = httpx.get(
             f"{base_url.rstrip('/').removesuffix('/v1')}/api/version",
             timeout=LLM_RELEASE_TIMEOUT,
@@ -364,8 +368,12 @@ class OllamaNativeProvider(OpenAICompatProvider):
         # truncate it silently — the defect this whole class exists to end.
         # Deliberately BEFORE the request: a 7-minute generation that was
         # doomed at byte zero should never be started.
+        # ⚠ ``>=``, not ``>``. Exactly-at-the-ceiling leaves zero headroom, and
+        # ``_CHARS_PER_TOKEN`` is a deliberate UNDER-estimate of tokens — so a
+        # prompt that merely reaches the limit on this arithmetic is over it in
+        # reality. Review NITPICK on #2618.
         estimated = (len(system) + len(user)) // _CHARS_PER_TOKEN
-        if estimated + max_tokens > LOCAL_CONTEXT_WINDOW:
+        if estimated + max_tokens >= LOCAL_CONTEXT_WINDOW:
             raise ValueError(
                 f"prompt does not fit the local context window: ~{estimated} estimated prompt tokens "
                 f"+ {max_tokens} reserved for output exceeds num_ctx={LOCAL_CONTEXT_WINDOW} "

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -39,7 +39,7 @@ import logging
 import re
 import threading
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Final, Protocol
 
 import anthropic
 import httpx
@@ -79,6 +79,39 @@ LLM_REQUEST_TIMEOUT: httpx.Timeout = httpx.Timeout(
 # work: it is not an OpenAI field and Ollama ignores it there. That is
 # why release is a separate call rather than a request parameter.
 _OLLAMA_UNLOAD_PATH = "/api/generate"
+
+# ⚠⚠ #2431 — THE SAME LESSON AS ``keep_alive`` ABOVE, AND IT COST 2,165 MEMOS.
+# ``options.num_ctx`` is not an OpenAI field either, so ``/v1/chat/completions``
+# accepts it with HTTP 200 and ignores it. Verified on this box 2026-08-12:
+# POSTing ``{"options": {"num_ctx": 12288}}`` to ``/v1`` left ``ollama ps`` at
+# ``CONTEXT 4096``. A fix written against ``/v1`` would look correct, return
+# success, and change nothing — which is exactly how this defect survived two
+# prompt revisions. The context window can only be set on the NATIVE route.
+_OLLAMA_CHAT_PATH = "/api/chat"
+
+# What the local path asks Ollama to load the model with.
+#
+# ⚠ Ollama's default is 4,096 and it TRUNCATES SILENTLY above it — no error, no
+# warning, HTTP 200. Measured 2026-08-12 across 60 instruments, the thesis
+# writer sends system+user of 5,387 / 6,352 / 7,081 tokens (min / median / max),
+# so EVERY generation overflowed. The truncated region is the front of the
+# prompt, which is where prompt v6 had just moved the subject-identity rule and
+# the ``SUBJECT:`` line — so the memo stopped naming its own company and v6
+# scored 0 of 127 where v1-v4 scored 487 of 487.
+#
+# 12,288 = the 7,081 observed maximum + the 2,048 ``max_tokens`` reservation
+# (num_ctx covers input AND output) + ~33% headroom. qwen3:14b supports 40,960;
+# the rest is left unclaimed deliberately. This box is 24 GB unified with
+# ``OLLAMA_KV_CACHE_TYPE=q8_0``, so the KV cache is ~80 KiB/token: ~0.94 GiB
+# here against ~0.31 GiB at 4,096. Raising it further costs real memory on a
+# machine that pages, and buys nothing measured.
+LOCAL_CONTEXT_WINDOW: Final = 12288
+
+# Chars per token, for the PRE-SEND check only. Deliberately crude and
+# deliberately an UNDER-estimate of tokens (real English JSON runs ~3.5-4.0
+# chars/token), because this guard exists to catch an order-of-magnitude
+# mistake, not to bill anyone.
+_CHARS_PER_TOKEN = 4
 
 # Release is best-effort housekeeping, not a generation — it must never
 # hold a job open the way a 600s decode window legitimately can.
@@ -279,6 +312,113 @@ class OpenAICompatProvider:
             logger.info("llm: released local model %s", self.model)
 
 
+def _endpoint_is_ollama(base_url: str) -> bool:
+    """Is this endpoint actually Ollama? Probed, never assumed (#2431).
+
+    ``/api/version`` is Ollama's own route: llama.cpp and vLLM serve the OpenAI
+    surface but not this one, so a 200 here is positive evidence rather than a
+    guess off the hostname.
+
+    ⚠ FAILS TO THE OPENAI TRANSPORT, deliberately. An unreachable or
+    non-Ollama endpoint keeps the contract it had before this change, so the
+    worst case of a wrong answer is the status quo rather than a broken one.
+    Remote endpoints are never probed — the question only arises locally.
+    """
+    if not is_local_llm_endpoint(base_url):
+        return False
+    try:
+        response = httpx.get(
+            f"{base_url.rstrip('/').removesuffix('/v1')}/api/version",
+            timeout=LLM_RELEASE_TIMEOUT,
+        )
+    except httpx.HTTPError:
+        return False
+    return response.status_code == 200
+
+
+class OllamaNativeProvider(OpenAICompatProvider):
+    """Ollama's own ``/api/chat`` — the only route that honours ``num_ctx``.
+
+    ⚠⚠ #2431 — THIS CLASS EXISTS FOR ONE REASON: ``/v1/chat/completions``
+    silently ignores the context window. It is a SEPARATE TYPE rather than a
+    branch inside ``OpenAICompatProvider`` because a class named for the OpenAI
+    contract must not quietly stop speaking it depending on the URL — the
+    factory chooses the transport, which is where a provider choice belongs.
+
+    Inherits the constructor and ``release_model`` (both already Ollama-aware)
+    and overrides only ``complete``. The response shape is Ollama's, so every
+    field is mapped explicitly rather than assumed:
+
+    ``message.content`` → text · ``done_reason`` → finish_reason ·
+    ``prompt_eval_count`` → prompt_tokens · ``eval_count`` → completion_tokens
+
+    ⚠ ``format: "json"`` is Ollama's own JSON mode. The OpenAI path's
+    ``response_format: {"type": "json_object"}`` is a different spelling of the
+    same requirement and is NOT accepted here.
+    """
+
+    provider_name = "ollama_native"
+
+    def complete(self, *, system: str, user: str, max_tokens: int) -> LLMCompletion:
+        # ⚠ Refuse a prompt that cannot fit rather than letting the server
+        # truncate it silently — the defect this whole class exists to end.
+        # Deliberately BEFORE the request: a 7-minute generation that was
+        # doomed at byte zero should never be started.
+        estimated = (len(system) + len(user)) // _CHARS_PER_TOKEN
+        if estimated + max_tokens > LOCAL_CONTEXT_WINDOW:
+            raise ValueError(
+                f"prompt does not fit the local context window: ~{estimated} estimated prompt tokens "
+                f"+ {max_tokens} reserved for output exceeds num_ctx={LOCAL_CONTEXT_WINDOW} "
+                f"(model={self.model}). Ollama would truncate this silently and the memo would be "
+                f"written without its instructions — see #2431."
+            )
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system + _NO_THINK_SUFFIX},
+                {"role": "user", "content": user},
+            ],
+            "stream": False,
+            "format": "json",
+            "options": {"num_ctx": LOCAL_CONTEXT_WINDOW, "num_predict": max_tokens},
+        }
+        with _LLM_CALL_SEMAPHORE:
+            response = httpx.post(
+                f"{self._base_url.removesuffix('/v1')}{_OLLAMA_CHAT_PATH}",
+                json=payload,
+                timeout=LLM_REQUEST_TIMEOUT,
+            )
+        response.raise_for_status()
+        body = response.json()
+        prompt_tokens = body.get("prompt_eval_count")
+
+        # ⚠⚠ POST-SEND confirmation, because the guard above only checks an
+        # ESTIMATE and ``_CHARS_PER_TOKEN`` can undercount. ``prompt_eval_count``
+        # is what the server actually consumed: at the window ceiling the prompt
+        # WAS truncated and this memo was written without part of its
+        # instructions.
+        #
+        # ⚠⚠ RAISES, does not log-and-return. Returning it would persist a memo
+        # known to be corrupt — which is this bug's entire signature (detect,
+        # report success, carry on). The caller's retry-once machinery gets a
+        # second attempt; a genuinely oversized prompt fails twice and lands on
+        # a ``thesis_runs`` row instead of in ``theses``.
+        if isinstance(prompt_tokens, int) and prompt_tokens >= LOCAL_CONTEXT_WINDOW:
+            raise ValueError(
+                f"prompt was truncated by the server: prompt_eval_count {prompt_tokens} reached "
+                f"num_ctx {LOCAL_CONTEXT_WINDOW} (model={self.model}). The completion was written "
+                f"without part of its instructions and must not be stored — see #2431."
+            )
+        return LLMCompletion(
+            text=normalize_completion_text((body.get("message") or {}).get("content") or ""),
+            finish_reason=body.get("done_reason") or "unknown",
+            model=body.get("model") or self.model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=body.get("eval_count"),
+        )
+
+
 class AnthropicProvider:
     """Wraps the existing bounded-timeout Anthropic SDK client (#1479).
 
@@ -380,13 +520,20 @@ def make_llm_clients(conn: psycopg.Connection[Any]) -> LLMClientPair:
         )
         if violation is not None:
             raise LLMProviderNotConfigured(violation)
+    # ⚠ #2431 — the transport is chosen HERE, explicitly, and ONLY for an
+    # endpoint PROVED to be Ollama. Ollama's native route is the only one that
+    # honours ``num_ctx`` (``/v1`` accepts the option and ignores it), which is
+    # how the writer spent two prompt revisions being silently truncated.
+    #
+    # ⚠⚠ LOCALITY IS NOT OLLAMA. ``docs/wiki/byo-llm.md`` documents BYO-LLM as
+    # any OpenAI-compatible base URL, and llama.cpp / vLLM are both commonly
+    # run on loopback. Selecting the native transport off ``is_local_llm_endpoint``
+    # alone would send Ollama-shaped requests to those servers and break a
+    # supported configuration. The probe answers the question the URL cannot.
+    provider = OllamaNativeProvider if _endpoint_is_ollama(cfg.llm_base_url) else OpenAICompatProvider
     return LLMClientPair(
-        writer=OpenAICompatProvider(
-            base_url=cfg.llm_base_url, model=cfg.llm_model_writer, api_key=settings.llm_api_key
-        ),
-        critic=OpenAICompatProvider(
-            base_url=cfg.llm_base_url, model=cfg.llm_model_critic, api_key=settings.llm_api_key
-        ),
+        writer=provider(base_url=cfg.llm_base_url, model=cfg.llm_model_writer, api_key=settings.llm_api_key),
+        critic=provider(base_url=cfg.llm_base_url, model=cfg.llm_model_critic, api_key=settings.llm_api_key),
     )
 
 

--- a/app/services/thesis.py
+++ b/app/services/thesis.py
@@ -236,7 +236,20 @@ _MAX_TOKENS_CRITIC = 2048
 # placeholder-leakage (46 memos containing "[Company] operates in the
 # [sector]") — an explicit no-placeholder rule now closes that. Context shape
 # and _validate_writer_output are unchanged.
-_PROMPT_VERSION = "v6"
+# v7 (#2431): the CONTEXT SHAPE changes and the delivery is fixed. v5 and v6
+# were never the whole story — the prompt had outgrown Ollama's default 4,096
+# window (measured 5,387/6,352/7,081 tokens min/median/max across 60
+# instruments) and was being truncated from the front, silently, on every
+# call. v6's subject anchor and no-placeholder rule were both placed in the
+# truncated region, which is why v6 scored 0 of 127 where v1-v4 scored 487 of
+# 487. ``llm_client.LOCAL_CONTEXT_WINDOW`` now sets num_ctx over the native
+# route (``/v1`` accepts the option and ignores it), with a pre-send refusal
+# and a post-send truncation check. Separately, ``prior_thesis`` no longer
+# carries ``memo_markdown``: it was the largest block AND the propagation
+# vector, feeding a wrong-company memo back in as the instrument's own prior
+# so the writer continued it. Bumped because the context shape changed —
+# memos from v6 and v7 are not comparable.
+_PROMPT_VERSION = "v7"
 
 # thesis_runs.trigger — matches the table CHECK in sql/218.
 RunTrigger = Literal["manual", "cascade", "scheduled"]
@@ -1088,11 +1101,23 @@ def _assemble_context(
     ]
 
     # Prior thesis: latest 1
+    #
+    # ⚠⚠ #2431 — ``memo_markdown`` IS DELIBERATELY NOT SELECTED. It was the
+    # single largest context block (~1,005 tokens measured) AND the propagation
+    # vector for the wrong-company defect: once one memo named the wrong
+    # company, that prose was fed back in as this instrument's own prior thesis
+    # and the writer continued it. GME v12-v17 are all about Tesla for exactly
+    # this reason — each generation inherited the last. Feeding a model its own
+    # unvalidated prose back as evidence makes any writer error self-sustaining,
+    # and the bigger prior then crowds the real evidence out of the window.
+    #
+    # The structured fields below carry the continuity this block exists for
+    # (what the last thesis CONCLUDED); the prose carried only how it said it.
     prior_row = conn.execute(
         """
         SELECT thesis_version, thesis_type, stance, confidence_score,
                buy_zone_low, buy_zone_high, base_value, bull_value, bear_value,
-               break_conditions_json, memo_markdown, created_at
+               break_conditions_json, created_at
         FROM theses
         WHERE instrument_id = %(id)s
         ORDER BY thesis_version DESC
@@ -1113,8 +1138,7 @@ def _assemble_context(
             "bull_value": _to_float(prior_row[7]),
             "bear_value": _to_float(prior_row[8]),
             "break_conditions": prior_row[9],
-            "memo_markdown": prior_row[10],
-            "created_at": prior_row[11].isoformat() if prior_row[11] else None,
+            "created_at": prior_row[10].isoformat() if prior_row[10] else None,
         }
 
     # Instrument metadata

--- a/app/workers/scheduler.py
+++ b/app/workers/scheduler.py
@@ -603,10 +603,15 @@ def _llm_provider_resolvable(conn: psycopg.Connection[Any]) -> PrerequisiteResul
 
     The local-first ``openai_compatible`` default always resolves (no key
     needed — Ollama ignores it); only ``llm_provider='anthropic'`` with no
-    ``ANTHROPIC_API_KEY`` fails. Construction is pure config resolution —
-    no network I/O. ``RuntimeConfigCorrupt`` deliberately propagates so a
-    corrupt config surfaces as a failure, never a silent skip (fail
-    closed, PR-A contract).
+    ``ANTHROPIC_API_KEY`` fails. Construction is config resolution plus, on
+    a LOCAL endpoint, at most ONE cached ``/api/version`` probe per process
+    (#2431 — it decides whether the endpoint is Ollama, which decides whether
+    ``num_ctx`` can be set at all). ⚠ The probe cannot turn this config gate
+    into a connectivity gate: it swallows every transport error and falls back
+    to the OpenAI provider, so an unreachable server resolves clients exactly
+    as before rather than raising here. ``RuntimeConfigCorrupt`` deliberately
+    propagates so a corrupt config surfaces as a failure, never a silent skip
+    (fail closed, PR-A contract).
     """
     try:
         make_llm_clients(conn)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -17,8 +17,10 @@ import pytest
 import respx
 
 from app.services.llm_client import (
+    LOCAL_CONTEXT_WINDOW,
     AnthropicProvider,
     LLMProviderNotConfigured,
+    OllamaNativeProvider,
     OpenAICompatProvider,
     make_llm_clients,
     normalize_completion_text,
@@ -28,6 +30,20 @@ from app.services.llm_client import (
 )
 
 _BASE_URL = "http://localhost:11434/v1"
+
+
+def _mock_ollama_probe(*, is_ollama: bool = True) -> None:
+    """Pin the #2431 transport probe so tests never depend on a live Ollama.
+
+    ``make_llm_clients`` asks ``/api/version`` whether a LOCAL endpoint is
+    actually Ollama (llama.cpp and vLLM serve the OpenAI surface but not that
+    route). Left unmocked these tests pass or fail depending on whether the
+    operator's Ollama happens to be running, which is not a property of the
+    code under test.
+    """
+    respx.get("http://localhost:11434/api/version").mock(
+        return_value=httpx.Response(200 if is_ollama else 404, json={"version": "0.31.1"})
+    )
 
 
 def _chat_response(
@@ -112,6 +128,98 @@ class TestNormalizeCompletionText:
 # ---------------------------------------------------------------------------
 # OpenAICompatProvider
 # ---------------------------------------------------------------------------
+
+
+def _native_response(
+    content: str,
+    *,
+    done_reason: str = "stop",
+    model: str = "qwen3:14b",
+    prompt_eval_count: int = 6421,
+    eval_count: int = 812,
+) -> dict[str, Any]:
+    """Ollama's ``/api/chat`` shape — deliberately NOT the OpenAI one."""
+    return {
+        "model": model,
+        "message": {"role": "assistant", "content": content},
+        "done": True,
+        "done_reason": done_reason,
+        "prompt_eval_count": prompt_eval_count,
+        "eval_count": eval_count,
+    }
+
+
+class TestOllamaNativeProvider:
+    """#2431 — the provider that exists because ``/v1`` ignores ``num_ctx``."""
+
+    @respx.mock
+    def test_sends_num_ctx_on_the_native_route(self) -> None:
+        route = respx.post("http://localhost:11434/api/chat").mock(
+            return_value=httpx.Response(200, json=_native_response('{"stance": "buy"}'))
+        )
+        provider = OllamaNativeProvider(base_url=_BASE_URL, model="qwen3:14b")
+        completion = provider.complete(system="sys", user="usr", max_tokens=100)
+
+        payload = json.loads(route.calls.last.request.content)
+        # The whole point: without this the server truncates at its 4096 default.
+        assert payload["options"]["num_ctx"] == LOCAL_CONTEXT_WINDOW
+        assert payload["options"]["num_predict"] == 100
+        # Ollama's JSON mode, not OpenAI's response_format spelling.
+        assert payload["format"] == "json"
+        assert "response_format" not in payload
+        assert payload["messages"][0]["content"].endswith("/no_think")
+        # The /v1 suffix is stripped — the native route is off the server root.
+        assert str(route.calls.last.request.url).endswith("/api/chat")
+
+        assert completion.text == '{"stance": "buy"}'
+        assert completion.finish_reason == "stop"
+        assert completion.prompt_tokens == 6421
+        assert completion.completion_tokens == 812
+
+    def test_refuses_a_prompt_that_cannot_fit_before_sending(self) -> None:
+        """The pre-send guard. A doomed 7-minute generation must never start."""
+        provider = OllamaNativeProvider(base_url=_BASE_URL, model="qwen3:14b")
+        oversized = "x" * (LOCAL_CONTEXT_WINDOW * 4)  # ~LOCAL_CONTEXT_WINDOW tokens on its own
+        with pytest.raises(ValueError, match="does not fit the local context window"):
+            provider.complete(system="sys", user=oversized, max_tokens=2048)
+
+    def test_output_reservation_counts_against_the_window(self) -> None:
+        """``num_ctx`` covers input AND output, so ``max_tokens`` is not free.
+
+        A prompt that fits on its own must still be refused when the reservation
+        pushes it over — the arithmetic that made 8192 too small for a 7,081
+        token prompt with a 2,048 token writer budget.
+        """
+        provider = OllamaNativeProvider(base_url=_BASE_URL, model="qwen3:14b")
+        # Comfortably under the window alone; over it once output is reserved.
+        near_limit = "x" * ((LOCAL_CONTEXT_WINDOW - 1000) * 4)
+        with pytest.raises(ValueError, match="reserved for output"):
+            provider.complete(system="", user=near_limit, max_tokens=2048)
+
+    @respx.mock
+    def test_truncation_at_the_ceiling_is_refused_not_returned(self) -> None:
+        """Post-send detector: the estimate can be wrong, the server's count is not.
+
+        ⚠ It must RAISE. Returning a completion known to be truncated would
+        persist a memo written without part of its instructions — detect,
+        report success, carry on, which is this bug's whole signature.
+        """
+        respx.post("http://localhost:11434/api/chat").mock(
+            return_value=httpx.Response(200, json=_native_response("{}", prompt_eval_count=LOCAL_CONTEXT_WINDOW))
+        )
+        provider = OllamaNativeProvider(base_url=_BASE_URL, model="qwen3:14b")
+        with pytest.raises(ValueError, match="truncated by the server"):
+            provider.complete(system="sys", user="usr", max_tokens=100)
+
+    @respx.mock
+    def test_normal_prompt_count_is_not_flagged(self) -> None:
+        """The detector must not cry wolf on a prompt that fitted."""
+        respx.post("http://localhost:11434/api/chat").mock(
+            return_value=httpx.Response(200, json=_native_response("{}", prompt_eval_count=6421))
+        )
+        provider = OllamaNativeProvider(base_url=_BASE_URL, model="qwen3:14b")
+        completion = provider.complete(system="sys", user="usr", max_tokens=100)
+        assert completion.prompt_tokens == 6421
 
 
 class TestOpenAICompatProvider:
@@ -237,6 +345,7 @@ class TestReleaseModel:
         route = respx.post(f"{_OLLAMA_ROOT}/api/generate").mock(
             return_value=httpx.Response(200, json={"done_reason": "unload"})
         )
+        _mock_ollama_probe()
         release_local_models(make_llm_clients(_config_conn(provider="openai_compatible")))
         assert route.call_count == 1
 
@@ -245,6 +354,7 @@ class TestReleaseModel:
         route = respx.post(f"{_OLLAMA_ROOT}/api/generate").mock(
             return_value=httpx.Response(200, json={"done_reason": "unload"})
         )
+        _mock_ollama_probe()
         clients = make_llm_clients(
             _config_conn(
                 provider="openai_compatible",
@@ -341,13 +451,28 @@ def _config_conn(
 
 
 class TestMakeLLMClients:
-    def test_openai_compatible_default_path(self) -> None:
+    def test_local_endpoint_resolves_to_the_native_provider(self) -> None:
+        """#2431 — a LOCAL endpoint is Ollama, and only its native route honours
+        ``num_ctx``. The default config points at localhost, so the default path
+        must be the native provider; picking the OpenAI one here is the bug that
+        truncated every thesis for two prompt revisions.
+        """
+        _mock_ollama_probe()
         clients = make_llm_clients(_config_conn(provider="openai_compatible"))
-        assert isinstance(clients.writer, OpenAICompatProvider)
-        assert isinstance(clients.critic, OpenAICompatProvider)
-        assert clients.writer.provider_name == "openai_compatible"
+        assert isinstance(clients.writer, OllamaNativeProvider)
+        assert isinstance(clients.critic, OllamaNativeProvider)
+        assert clients.writer.provider_name == "ollama_native"
         assert clients.writer.model == "qwen3:14b"
         assert clients.critic.model == "qwen3:14b"
+
+    def test_remote_endpoint_keeps_the_openai_contract(self) -> None:
+        """The converse, so the selection is pinned from both sides: a remote
+        endpoint speaks OpenAI and must NOT be handed Ollama-native fields.
+        """
+        clients = make_llm_clients(_config_conn(provider="openai_compatible", base_url="https://api.example.com/v1"))
+        assert isinstance(clients.writer, OpenAICompatProvider)
+        assert not isinstance(clients.writer, OllamaNativeProvider)
+        assert clients.writer.provider_name == "openai_compatible"
 
     def test_split_models_resolve_per_role(self) -> None:
         clients = make_llm_clients(

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -17,6 +17,7 @@ import pytest
 import respx
 
 from app.services.llm_client import (
+    _CHARS_PER_TOKEN,
     LOCAL_CONTEXT_WINDOW,
     AnthropicProvider,
     LLMProviderNotConfigured,
@@ -195,6 +196,19 @@ class TestOllamaNativeProvider:
         near_limit = "x" * ((LOCAL_CONTEXT_WINDOW - 1000) * 4)
         with pytest.raises(ValueError, match="reserved for output"):
             provider.complete(system="", user=near_limit, max_tokens=2048)
+
+    def test_exactly_at_the_ceiling_is_refused(self) -> None:
+        """Review NITPICK on #2618: ``>=``, not ``>``.
+
+        Zero headroom is not a fit, and ``_CHARS_PER_TOKEN`` under-estimates
+        tokens by design — a prompt that merely REACHES the limit on this
+        arithmetic is over it on the server's.
+        """
+        provider = OllamaNativeProvider(base_url=_BASE_URL, model="qwen3:14b")
+        max_tokens = 2048
+        exact = "x" * ((LOCAL_CONTEXT_WINDOW - max_tokens) * _CHARS_PER_TOKEN)
+        with pytest.raises(ValueError, match="does not fit the local context window"):
+            provider.complete(system="", user=exact, max_tokens=max_tokens)
 
     @respx.mock
     def test_truncation_at_the_ceiling_is_refused_not_returned(self) -> None:

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -479,6 +479,35 @@ class TestMakeLLMClients:
         assert clients.writer.model == "qwen3:14b"
         assert clients.critic.model == "qwen3:14b"
 
+    @respx.mock
+    def test_ollama_probe_is_cached_per_process(self) -> None:
+        """Review NITPICK on #2618 — ``make_llm_clients`` is documented as doing
+        no network I/O (``scheduler.py`` calls it purely to resolve config), so
+        the probe must not fire per call and turn a config gate into a
+        connectivity gate.
+        """
+        from app.services import llm_client
+
+        llm_client._OLLAMA_PROBE_CACHE.clear()
+        probe = respx.get("http://localhost:11434/api/version").mock(
+            return_value=httpx.Response(200, json={"version": "0.31.1"})
+        )
+        for _ in range(3):
+            make_llm_clients(_config_conn(provider="openai_compatible"))
+        assert probe.call_count == 1
+
+    @respx.mock
+    def test_unreachable_probe_is_not_cached(self) -> None:
+        """A restarting Ollama must not pin the OpenAI transport for the process."""
+        from app.services import llm_client
+
+        llm_client._OLLAMA_PROBE_CACHE.clear()
+        probe = respx.get("http://localhost:11434/api/version").mock(side_effect=httpx.ConnectError("down"))
+        for _ in range(2):
+            clients = make_llm_clients(_config_conn(provider="openai_compatible"))
+            assert not isinstance(clients.writer, OllamaNativeProvider)
+        assert probe.call_count == 2  # retried, not remembered
+
     def test_remote_endpoint_keeps_the_openai_contract(self) -> None:
         """The converse, so the selection is pinned from both sides: a remote
         endpoint speaks OpenAI and must NOT be handed Ollama-native fields.


### PR DESCRIPTION
## What was actually wrong

Not prompt engineering. The writer's prompt outgrew Ollama's default 4,096-token window and was truncated on every call, silently.

```
_WRITER_SYSTEM          ~2,857 tokens
GME user payload        ~3,564 tokens
total sent              ~6,421
window                   4,096
```

Across 60 instruments: 5,387 / 6,352 / 7,081 tokens (min / median / max). **60 of 60 overflowed**, which is why the failure was universal rather than sporadic.

The truncated region is the front of the prompt — exactly where prompt v6 had just placed the subject-identity rule and the `SUBJECT:` line. A model handed a headless payload emits the likeliest generic completion, which is why memos are titled `Apple Inc. (AAPL)`, `Tesla Inc. (TSLA)`, `Company A (NYSE: XYZ)` and `[Replace with Actual Company Name]`.

| prompt | context | pass rate | n |
|---|---|---:|---:|
| v1–v4 | fits 4,096 | **100%** | 487 |
| v5 (#2010) | +6 blocks → overflows | 32.0% | 2,038 |
| v6 (#2235) | fix placed in the truncated region | **0.0%** | 127 |

v6 is the proof: it "fixed" subject identity by moving the rule to the front, which is the part that gets cut. That is why it made things strictly worse.

## Why the transport changed

`num_ctx` **cannot** be set over `/v1/chat/completions`. Ollama accepts the option and ignores it — verified on this box: posting `num_ctx: 12288` to `/v1` left `ollama ps` at `CONTEXT 4096`, HTTP 200. The same lesson was already recorded in this file for `keep_alive` (*"it is not an OpenAI field and Ollama ignores it there"*); nobody connected it to the context window.

So the local path moves to Ollama's native `/api/chat` as its own provider class.

⚠ **Selected by probing `/api/version`, not by locality.** `docs/wiki/byo-llm.md` supports any OpenAI-compatible endpoint, and llama.cpp / vLLM also run on loopback — choosing off `is_local_llm_endpoint` alone would have broken a supported configuration (Codex checkpoint 2 caught this). The probe fails **to** the OpenAI transport, so a wrong answer is the status quo rather than a breakage.

## Sizing

12,288 = 7,081 observed max + 2,048 output reservation (`num_ctx` covers input **and** output, which is what makes 8,192 too small) + ~33% headroom. qwen3:14b supports 40,960; the rest is left unclaimed because KV cache is real memory on a 24 GB box. Measured: 9.8 GB loaded at 4,096 → 10 GB at 12,288, with `OLLAMA_KV_CACHE_TYPE=q8_0` already set.

## Two guards, both raising

The defect class here is a silent success, so neither guard logs-and-continues:

- **pre-send** — refuses on the estimate before starting a ~7-minute generation that was doomed at byte zero;
- **post-send** — refuses when the server's own `prompt_eval_count` reaches the ceiling, because the estimate can undercount.

⚠ The post-send guard originally logged and returned the completion. Codex checkpoint 2 flagged it as P1 and was right: returning a memo known to be truncated persists output written without part of its instructions, which is the bug rather than the fix.

## The propagation vector

`prior_thesis` no longer carries `memo_markdown`. It was the largest single block (~1,005 tokens) **and** the mechanism by which one bad memo became permanent: a wrong-company memo was fed back in as the instrument's own prior thesis and the writer continued it. GME v12–v17 are all about Tesla for this reason. The structured fields carry what the block is for; the prose carried only how it was said.

Verified `compute_thesis_diff` is fed DB rows from `app/api/theses.py`, not this dict, so the change-summary feature is unaffected.

## Verification

**Live, on the instrument that previously failed:**

| | OTEX memo title |
|---|---|
| under v6 | `### **Apple Inc. (AAPL)**` |
| 15:07 today | rejected — *"never names its subject"* |
| **under v7** | `### Open Text Corp (OTEX): A Compounder Opportunity at a Discount` |

`subject_identity_ok = true` — the first pass since 2026-08-05. Same model, same data, same instrument; only the context window and the prior-memo trim changed. `ollama ps` confirmed `CONTEXT=12288`.

⚠ **v7 is a population of one.** 100% means one memo passed. It is not a rate, and this PR does not claim one.

⚠ **Separate open question, not fixed here:** that memo's `base_value` is 59.31 against an actual price of 23.95 — a ratio of 2.48, outside the 0.4–2.0 plausibility band. Subject identity is fixed; valuation quality is a different question that one memo cannot answer. Worth watching as v7 volume accumulates.

Gates: `ruff` / `ruff format` / `pyright` clean; 45 tests pass. The suite previously passed only because Ollama happened to be running — the transport probe was hitting the real network — so it is now pinned with an explicit mock.

## Security model

Not applicable. No auth, no user input, no new external surface. The endpoint probed and called is the already-configured local inference server; the change tightens what is sent to it and adds two refusals.

## Follow-up

Regeneration of the 178 quarantined latest-per-instrument theses is **not** part of this PR. The hourly `thesis_refresh` job picks the fix up on its next run and drains at ≤5 per hour, so no bulk operation is needed. Until then #2436's quarantine keeps the wrong-company bands away from `portfolio.py`.

Closes #2431. Refs #2436. Refs #2235. Refs #2010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
