### PR TITLE
feat(#2621): persist the frozen universe; replay the check in promote_strategy

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -117,7 +117,10 @@ from app.services.result_ledger import (
     store_walk_forward_folds,
 )
 from app.services.signal_ledger import LedgerRow, resolve_fills
-from app.services.strategies.validated_universe import load_validated_universe
+from app.services.strategies.validated_universe import (
+    VALIDATED_UNIVERSE_RULE_VERSION,
+    load_validated_universe,
+)
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyEntry, StrategyPurpose
 from app.services.strategy_registry import StrategyIdentity, StrategySignal
 from app.services.strategy_result import (
@@ -136,6 +139,11 @@ from app.services.strategy_result import (
     StrategyResult,
     check_promotable,
     namespace_for_position,
+)
+from app.services.strategy_result_universe import (
+    ResultUniverseRecord,
+    load_result_universe,
+    store_result_universe,
 )
 from app.services.strategy_segmented_evaluation import segmented_member, segmented_signals
 from app.services.strategy_statistics import StrategyMetrics, TradeReturns, compute_metrics
@@ -2789,13 +2797,20 @@ def _write_rows(
     for strategy_id, namespace, ambiguity, masked, admitted in pending:
         if namespace == "hold_out":
             assert holdout_purpose is not None and holdout_accessed_by is not None
-            ids = store_holdout_arm_pair(
-                conn,
-                masked,
-                admitted,
-                accessed_by=holdout_accessed_by,
-                purpose=holdout_purpose,
-            )
+            # ⚠ The universe record joins the pair's own transaction as a
+            # savepoint member (the pair writer's ``conn.transaction()`` nests),
+            # so "a result row without its frozen universe" is unreachable
+            # through this writer rather than merely refused later (#2621).
+            with conn.transaction():
+                ids = store_holdout_arm_pair(
+                    conn,
+                    masked,
+                    admitted,
+                    accessed_by=holdout_accessed_by,
+                    purpose=holdout_purpose,
+                )
+                for result_id, result in zip(ids, (masked, admitted), strict=True):
+                    _store_universe_record(conn, result_id, result, arms=arms, validated=validated)
             stored.extend((result_id, result, 0) for result_id, result in zip(ids, (masked, admitted), strict=True))
             continue
         # ⚠ ONE SPLIT PER ARM, NOT PER PAIR. The two rows of a pair differ in
@@ -2815,6 +2830,7 @@ def _write_rows(
                     result_id,
                     splits.get(split_key) or splits[shared_key],
                 )
+                _store_universe_record(conn, result_id, result, arms=arms, validated=validated)
                 stored.append((result_id, result, folds))
 
     # Criterion 8 — RE-MEASURED on every written row, with the hold-out counts
@@ -2831,11 +2847,23 @@ def _write_rows(
             counts_cache[key] = (counts.holdout_evaluations, counts.recorded_accesses)
         evaluations, accesses = counts_cache[key]
         ambiguity_material = _ambiguity_material_for(arms, result)
+        # ⚠ The universe inputs are READ BACK from the frozen record, not taken
+        # from memory — the same argument that reads the hold-out counts off the
+        # database. The re-measure then verifies exactly what the promotion
+        # transition will load (#2621); a missing or divergent record makes the
+        # refusal cross-check below fail loudly instead of surfacing months
+        # later as an unpromotable row.
+        record = load_result_universe(conn, result_id)
+        if record is None:
+            raise RuntimeError(
+                f"{identity.strategy_id} {identity.namespace}/{identity.quarantine_arm} stored without its frozen "
+                "universe record — the writer must freeze the gate's inputs in the pair's own transaction"
+            )
         outcome = check_promotable(
             _candidate(
                 result,
-                validated=validated,
-                evaluated=_evaluated_ids(arms, result),
+                validated=record.validated_universe_ids,
+                evaluated=record.evaluated_instrument_ids,
                 holdout_evaluations=evaluations,
                 recorded_accesses=accesses,
                 ambiguity_material=ambiguity_material,
@@ -2979,6 +3007,41 @@ def _evaluated_ids(arms: Sequence[ArmMeasurement], result: StrategyResult) -> fr
                 return outcome.evaluated_instrument_ids
     raise RuntimeError(  # pragma: no cover - every stored row came from a measurement
         f"no measurement matches the stored row {result.identity.version}"
+    )
+
+
+def _store_universe_record(
+    conn: psycopg.Connection[Any],
+    result_id: int,
+    result: StrategyResult,
+    *,
+    arms: Sequence[ArmMeasurement],
+    validated: frozenset[int],
+) -> None:
+    """Freeze the row's universe inputs in the pair's own transaction (#2621).
+
+    The evaluated set comes from ``_evaluated_ids`` — the same source the
+    write-time gate consumes — and the universe is the run's single
+    ``load_validated_universe`` read (``corpus.universe``). The count assertion
+    pins the record to the row it describes BEFORE the insert: the two are equal
+    by construction today (both are views of one ``NamespaceMeasurement``), and
+    a drift would otherwise surface only at the promotion transition, as an
+    ``evaluated_universe_count_mismatch`` refusal on a row already committed.
+    """
+    evaluated = _evaluated_ids(arms, result)
+    if len(evaluated) != result.evaluated_instrument_count:
+        raise RuntimeError(
+            f"{result.identity.version} would freeze {len(evaluated)} evaluated instruments against a row "
+            f"claiming {result.evaluated_instrument_count} — the universe record must describe its own row"
+        )
+    store_result_universe(
+        conn,
+        result_id=result_id,
+        record=ResultUniverseRecord(
+            universe_rule_version=VALIDATED_UNIVERSE_RULE_VERSION,
+            evaluated_instrument_ids=evaluated,
+            validated_universe_ids=validated,
+        ),
     )
 
 

--- a/app/services/strategies/validated_universe.py
+++ b/app/services/strategies/validated_universe.py
@@ -35,9 +35,17 @@ scope"; it does not stop anything.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 import psycopg
+
+#: Names the definition below for records that freeze this universe (#2621).
+#: ⚠ Bump when the DEFINITION changes (the predicates, not this module's
+#: comments) — a frozen ``strategy_result_universe`` record carries the version
+#: its ids were produced under, and the promotion transition refuses versions it
+#: does not recognise rather than re-interpreting them. Same shape as
+#: ``TRIAL_REGISTER_VERSION``.
+VALIDATED_UNIVERSE_RULE_VERSION: Final = "validated-universe-us-stocks-v1"
 
 #: The ``etoro_instrument_types.description`` of the one type in scope.
 #: ⚠ Resolved through the table rather than written as ``instrument_type_id = 5``.
@@ -105,6 +113,7 @@ def load_validated_universe(conn: psycopg.Connection[Any]) -> tuple[int, ...]:
 __all__ = [
     "STOCKS_TYPE_DESCRIPTION",
     "US_EQUITY_ASSET_CLASS",
+    "VALIDATED_UNIVERSE_RULE_VERSION",
     "load_validated_universe",
     "resolve_stocks_type_id",
 ]

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -20,6 +20,7 @@ import psycopg.rows
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyPurpose
 from app.services.strategy_promotion_evidence import evidence_refusals
 from app.services.strategy_promotion_evidence_store import load_promotion_evidence
+from app.services.strategy_result_universe import load_result_universe, universe_promotion_refusals
 
 Stage = Literal[
     "research_candidate",
@@ -423,6 +424,14 @@ def promote_strategy(
     Evidence is pinned, never inferred from a current metric.  Result ids must
     belong to this exact strategy version.  Global auto/live switches are not
     read here and therefore cannot create or advance a promotion.
+
+    Evidence stages replay two persisted records per pinned result: the #2505
+    edge-evidence record and the #2621 frozen-universe record
+    (``evaluated ⊆ validated`` as the run loaded it — never today's
+    ``load_validated_universe``, whose ``is_tradable`` filter would let a later
+    delisting retroactively invalidate a passing result). A result stored
+    without either record refuses; this is the fail-closed replacement for
+    trusting that the sole writer ran ``check_promotable`` at write time.
     """
     for value, field in (
         (strategy_id, "strategy_id"),
@@ -457,7 +466,7 @@ def promote_strategy(
     if result_ids:
         rows = conn.execute(
             """
-            SELECT result_id, profit_factor
+            SELECT result_id, profit_factor, evaluated_instrument_count
             FROM strategy_results_store
             WHERE strategy_id = %s AND strategy_version = %s
               AND result_id = ANY(%s)
@@ -472,17 +481,34 @@ def promote_strategy(
             )
         if to_stage in _RESULT_EVIDENCE_STAGES:
             profit_factor_by_result = {int(row[0]): None if row[1] is None else Decimal(str(row[1])) for row in rows}
+            evaluated_count_by_result = {int(row[0]): int(row[2]) for row in rows}
             for result_id in result_ids:
+                # #2621 — the transition REPLAYS the universe check from the
+                # frozen record instead of trusting the write-time refusal that
+                # died with ``WrittenRow``. Frozen at result time, deliberately:
+                # today's date enters this gate only where a validity window was
+                # declared (the cost staleness clause inside
+                # ``evidence_refusals``); the universe declares none, and the
+                # order-time rule against the CURRENT universe is the execution
+                # guard's, not promotion's. Both refusal lists are gathered
+                # before raising so one missing input cannot mask the other.
+                refusals = list(
+                    universe_promotion_refusals(
+                        load_result_universe(conn, result_id),
+                        evaluated_instrument_count=evaluated_count_by_result[result_id],
+                    )
+                )
                 evidence = load_promotion_evidence(conn, result_id)
                 if evidence is None:
-                    raise StrategyControlError(
-                        f"result {result_id} fails promotion evidence: promotion_evidence_missing"
+                    refusals.append("promotion_evidence_missing")
+                else:
+                    refusals.extend(
+                        evidence_refusals(
+                            evidence,
+                            profit_factor=profit_factor_by_result[result_id],
+                            as_of=date.today(),
+                        )
                     )
-                refusals = evidence_refusals(
-                    evidence,
-                    profit_factor=profit_factor_by_result[result_id],
-                    as_of=date.today(),
-                )
                 if refusals:
                     raise StrategyControlError(f"result {result_id} fails promotion evidence: {', '.join(refusals)}")
 

--- a/app/services/strategy_result_universe.py
+++ b/app/services/strategy_result_universe.py
@@ -1,0 +1,177 @@
+"""Frozen universe inputs for the promotion transition (#2621).
+
+``check_promotable``'s universe clause compares two sets that no relation held:
+the result's evaluated instrument ids and the §4.0 validated universe the run
+loaded. The refusal it produced was returned in ``WrittenRow.refusals`` and
+died with the writer's return value, so ``promote_strategy`` — the transition
+that authorises ``historical_validated`` — could not re-detect a result whose
+evaluated set left the universe. This module persists both sets, immutable and
+hashed (the ``sql/327`` promotion-evidence shape), and gives the transition a
+pure refusal function over the frozen record.
+
+⚠ FROZEN AT RESULT TIME, NEVER TODAY'S ``load_validated_universe`` (#2621 scope
+item 3). Three reasons, recorded because picking silently is the defect the
+issue names:
+
+- the transition re-derives refusals from frozen records; today's date enters
+  that gate only where a validity window was DECLARED (``cost_observed_on`` /
+  ``cost_valid_through``). The universe declares no validity window, so a
+  today-check would be an undeclared freshness rule.
+- today's universe filters on ``is_tradable`` — today's listing state — so a
+  re-check against it retroactively invalidates a passing historical result on
+  any delisting, while the survivorship-free corpus (#2597, the only basis
+  ``universe_basis_not_survivorship_free`` will ever pass) deliberately
+  evaluates delisted names.
+- enforcement against the CURRENT universe belongs to the execution guard at
+  order time (§4.0 allocation invariant 2), not to evidence admission.
+
+⚠ WHAT THE RE-CHECK DOES AND DOES NOT PROVE. Both frozen sets come from the
+same writer, so replaying the subtraction does NOT certify the writer was
+honest at write time — the write-time criterion-8 cross-check raise does that.
+What persistence buys: a result stored by any OTHER path refuses
+(``evaluated_universe_unrecorded``); the record is immutable and independently
+auditable (against ``instrument_universe_membership``, #2290, as-of the result
+window); the record must agree with the row's own ``evaluated_instrument_count``;
+and the check stays replayable after the live universe has moved on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Final
+
+import psycopg
+
+from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
+
+#: The versions the transition knows how to interpret. ⚠ FAIL CLOSED IS AN
+#: ALLOWLIST: when the §4.0 definition evolves the constant bumps, old records
+#: refuse ``evaluated_universe_rule_unrecognised``, and the successor decides
+#: explicitly whether to re-admit the old version — never a silent reread under
+#: new semantics. Same shape as ``trial_register_superseded``.
+RECOGNISED_UNIVERSE_RULE_VERSIONS: Final[frozenset[str]] = frozenset({VALIDATED_UNIVERSE_RULE_VERSION})
+
+
+@dataclass(frozen=True)
+class ResultUniverseRecord:
+    """The two frozen sets plus the definition version they were produced under."""
+
+    universe_rule_version: str
+    evaluated_instrument_ids: frozenset[int]
+    validated_universe_ids: frozenset[int]
+
+    def __post_init__(self) -> None:
+        if not self.universe_rule_version:
+            raise ValueError("universe_rule_version must be non-empty")
+        for name in ("evaluated_instrument_ids", "validated_universe_ids"):
+            if any(type(item) is not int for item in getattr(self, name)):
+                raise ValueError(f"{name} must contain only ints")
+
+
+def _canonical_payload(record: ResultUniverseRecord) -> bytes:
+    """One byte-stable encoding — JSON, not ad-hoc joins, so a rule version
+    containing any delimiter cannot make two records hash alike."""
+    return json.dumps(
+        {
+            "universe_rule_version": record.universe_rule_version,
+            "evaluated_instrument_ids": sorted(record.evaluated_instrument_ids),
+            "validated_universe_ids": sorted(record.validated_universe_ids),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+
+
+def record_sha256(record: ResultUniverseRecord) -> str:
+    return hashlib.sha256(_canonical_payload(record)).hexdigest()
+
+
+def store_result_universe(conn: psycopg.Connection[Any], *, result_id: int, record: ResultUniverseRecord) -> None:
+    """Insert one frozen record. Runs in the CALLER's transaction — the writer
+    stores it atomically with the result's arm pair."""
+    conn.execute(
+        """
+        INSERT INTO strategy_result_universe (
+            result_id, universe_rule_version, evaluated_instrument_ids,
+            validated_universe_ids, payload_sha256
+        ) VALUES (%s, %s, %s, %s, %s)
+        """,
+        (
+            result_id,
+            record.universe_rule_version,
+            sorted(record.evaluated_instrument_ids),
+            sorted(record.validated_universe_ids),
+            record_sha256(record),
+        ),
+    )
+
+
+def load_result_universe(conn: psycopg.Connection[Any], result_id: int) -> ResultUniverseRecord | None:
+    """The frozen record, hash-verified, or ``None`` when no record exists.
+
+    ⚠ Corruption RAISES rather than refuses, matching ``load_promotion_evidence``:
+    a record that fails its own hash or canonical form is an integrity failure
+    to surface loudly, not a gate verdict to report politely.
+    """
+    row = conn.execute(
+        """
+        SELECT universe_rule_version, evaluated_instrument_ids, validated_universe_ids, payload_sha256
+        FROM strategy_result_universe
+        WHERE result_id = %s
+        """,
+        (result_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    evaluated = [int(item) for item in row[1]]
+    universe = [int(item) for item in row[2]]
+    for name, ids in (("evaluated_instrument_ids", evaluated), ("validated_universe_ids", universe)):
+        if ids != sorted(set(ids)):
+            raise RuntimeError(f"result universe {name} is not sorted-unique for result {result_id}")
+    record = ResultUniverseRecord(
+        universe_rule_version=str(row[0]),
+        evaluated_instrument_ids=frozenset(evaluated),
+        validated_universe_ids=frozenset(universe),
+    )
+    if record_sha256(record) != str(row[3]):
+        raise RuntimeError(f"result universe hash mismatch for result {result_id}")
+    return record
+
+
+def universe_promotion_refusals(
+    record: ResultUniverseRecord | None, *, evaluated_instrument_count: int
+) -> tuple[str, ...]:
+    """Every universe reason the transition may not promote this result.
+
+    Pure, returns ALL refusals rather than the first (the ``check_promotable``
+    contract). The two set clauses reuse that gate's own codes; the three new
+    codes name states only the transition can see — a record that is absent,
+    frozen under a version this code cannot interpret, or inconsistent with the
+    row it claims to describe.
+    """
+    if record is None:
+        return ("evaluated_universe_unrecorded",)
+    refusals: list[str] = []
+    if record.universe_rule_version not in RECOGNISED_UNIVERSE_RULE_VERSIONS:
+        refusals.append("evaluated_universe_rule_unrecognised")
+    if len(record.evaluated_instrument_ids) != evaluated_instrument_count:
+        refusals.append("evaluated_universe_count_mismatch")
+    # ⚠ Same two clauses, same order, as ``check_promotable`` — an empty
+    # evaluated set is refused separately because ``set() - anything`` is empty.
+    if not record.evaluated_instrument_ids:
+        refusals.append("no_instruments_evaluated")
+    elif record.evaluated_instrument_ids - record.validated_universe_ids:
+        refusals.append("instrument_outside_validated_universe")
+    return tuple(refusals)
+
+
+__all__ = [
+    "RECOGNISED_UNIVERSE_RULE_VERSIONS",
+    "ResultUniverseRecord",
+    "load_result_universe",
+    "record_sha256",
+    "store_result_universe",
+    "universe_promotion_refusals",
+]

--- a/docs/proposals/ta/2026-08-12-promotion-edge-evidence-contract.md
+++ b/docs/proposals/ta/2026-08-12-promotion-edge-evidence-contract.md
@@ -136,16 +136,18 @@ scope definition lives in one place,
 `set() - anything` is empty, so a result over no instruments would otherwise
 satisfy the subset test while being no evidence at all.
 
-⚠⚠ **THE PROMOTION TRANSITION DOES NOT RE-CHECK THIS (#2621).**
-`promote_strategy` never calls `check_promotable`; it validates result-id
-ownership and then the compact evidence record above. It cannot re-derive the
-universe check either — the refusal is returned in `WrittenRow.refusals` and
-never persisted, and the result store carries `evaluated_instrument_count` but
-not the ids. This is the section's own scope boundary below, instantiated: an
-input the transition cannot independently replay. Not fail-open today only
-because `run_backtest` is the sole writer, which is the same "would become
-fail-open as soon as a candidate is registered" shape #2505 closed for viability
-evidence. #2621 owns closing it for the universe input.
+**The promotion transition re-checks this since #2621 (2026-08-12).**
+`run_backtest` freezes each result's universe inputs in
+`strategy_result_universe` (evaluated ids + the run's loaded universe,
+immutable + hashed, in the pair's own transaction), and `promote_strategy`
+replays `evaluated ⊆ validated` from the frozen record for every pinned result
+at the evidence stages — a result without a record refuses
+`evaluated_universe_unrecorded`, closing the same "fail-open as soon as a
+candidate is registered" shape #2505 closed for viability evidence. ⚠ The
+replay is against the universe FROZEN at result time, never today's
+`load_validated_universe`; the reasons are recorded in
+`app/services/strategy_result_universe.py`. The remaining non-persisted gate
+inputs are the scope boundary below, unchanged.
 
 **What this bounds for #2363, and what it does not.** Every instrument in the
 validated universe is quoted in USD — asserted, not merely displayed, on the

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -858,12 +858,19 @@ paths and only the first is enforced today:
   `_Corpus.universe` → the candidate at `:2837`). The scope definition itself is
   `app/services/strategies/validated_universe.py`, pinned by
   `tests/test_validated_universe.py`.
-- **The promotion transition — NOT enforced (#2621).**
-  `strategy_control_plane.promote_strategy` never calls `check_promotable`, and
-  structurally cannot re-derive it: the refusal is returned in
-  `WrittenRow.refusals` and never persisted, and `strategy_results_store` stores
-  `evaluated_instrument_count` but not the ids. Not fail-open today only because
-  `run_backtest` is the sole writer. #2621 owns closing it.
+- **The promotion transition — enforced since #2621 (2026-08-12).**
+  `run_backtest` freezes each result's universe inputs in
+  `strategy_result_universe` (evaluated ids + the validated universe as the run
+  loaded it, immutable + hashed, written in the pair's own transaction), and
+  `promote_strategy` replays `evaluated ⊆ validated` from that record for every
+  pinned result at the evidence stages. A pinned result without a record —
+  every pre-#2621 row, and anything a non-`run_backtest` writer inserts —
+  refuses `evaluated_universe_unrecorded`. ⚠ The replay is against the universe
+  FROZEN AT RESULT TIME, deliberately: today's `is_tradable` would let a later
+  delisting retroactively invalidate a passing result, and the order-time rule
+  against the CURRENT universe is the execution guard's (phase 7), not
+  promotion's. The decision and its reasons live in
+  `app/services/strategy_result_universe.py`'s module docstring.
 
 **Why the restriction exists.** Every survivorship-free price source found *so
 far* is US-only, and Form 25 delisting evidence is US-only

--- a/sql/334_strategy_result_universe.sql
+++ b/sql/334_strategy_result_universe.sql
@@ -1,0 +1,52 @@
+-- #2621: freeze the universe inputs of the result-production gate so the
+-- promotion transition can replay ``evaluated ⊆ validated`` itself, instead of
+-- trusting a refusal that was returned in ``WrittenRow.refusals`` and died with
+-- the writer's return value.
+--
+-- One row per result, written in the same transaction as the result's arm
+-- pair. Both arrays are stored sorted ascending and unique (the loader
+-- verifies; a record that fails that is corruption, not a refusal).
+--
+-- ⚠ The record freezes the universe AS THE RUN LOADED IT (#2621 scope item 3:
+-- frozen at result time, never today's `load_validated_universe`). The
+-- transition replays the evidence-time check; enforcement against the CURRENT
+-- universe is the execution guard's order-time job (§4.0 allocation
+-- invariant 2), not promotion's. `universe_rule_version` names the definition
+-- the ids were produced under, so the definition can evolve without
+-- re-interpreting old records.
+--
+-- ⚠ The cardinality bounds are a size backstop, not a population claim: the
+-- §4.0 validated universe measures ~6.7k instruments today and moves with
+-- every sync_universe run. A future definition that legitimately exceeds the
+-- bound arrives with a new rule version and its own migration.
+
+CREATE TABLE IF NOT EXISTS strategy_result_universe (
+    result_id                BIGINT PRIMARY KEY
+        REFERENCES strategy_results_store(result_id) ON DELETE RESTRICT,
+    universe_rule_version    TEXT NOT NULL CHECK (universe_rule_version <> ''),
+    evaluated_instrument_ids BIGINT[] NOT NULL
+        CHECK (cardinality(evaluated_instrument_ids) <= 20000),
+    validated_universe_ids   BIGINT[] NOT NULL
+        CHECK (cardinality(validated_universe_ids) <= 20000),
+    payload_sha256           TEXT NOT NULL CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE strategy_result_universe IS
+    'One immutable frozen-universe record per strategy result (#2621): the '
+    'evaluated instrument ids and the §4.0 validated universe as loaded by the '
+    'run that wrote the result. promote_strategy replays the universe check '
+    'from this record; a pinned result without one refuses '
+    'evaluated_universe_unrecorded.';
+
+CREATE OR REPLACE FUNCTION refuse_strategy_result_universe_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'strategy result universe records are immutable; create a new result identity';
+END $$;
+
+DROP TRIGGER IF EXISTS trg_strategy_result_universe_immutable
+    ON strategy_result_universe;
+CREATE TRIGGER trg_strategy_result_universe_immutable
+BEFORE UPDATE OR DELETE ON strategy_result_universe
+FOR EACH ROW EXECUTE FUNCTION refuse_strategy_result_universe_mutation();

--- a/sql/334_strategy_result_universe.sql
+++ b/sql/334_strategy_result_universe.sql
@@ -24,12 +24,14 @@ CREATE TABLE IF NOT EXISTS strategy_result_universe (
     result_id                BIGINT PRIMARY KEY
         REFERENCES strategy_results_store(result_id) ON DELETE RESTRICT,
     universe_rule_version    TEXT NOT NULL CHECK (universe_rule_version <> ''),
-    evaluated_instrument_ids BIGINT[] NOT NULL
-        CHECK (cardinality(evaluated_instrument_ids) <= 20000),
-    validated_universe_ids   BIGINT[] NOT NULL
-        CHECK (cardinality(validated_universe_ids) <= 20000),
+    evaluated_instrument_ids BIGINT[] NOT NULL,
+    validated_universe_ids   BIGINT[] NOT NULL,
     payload_sha256           TEXT NOT NULL CHECK (payload_sha256 ~ '^[0-9a-f]{64}$'),
-    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- One bound for both arrays so the two cannot drift independently.
+    CONSTRAINT strategy_result_universe_size_backstop CHECK (
+        GREATEST(cardinality(evaluated_instrument_ids), cardinality(validated_universe_ids)) <= 20000
+    )
 );
 
 COMMENT ON TABLE strategy_result_universe IS

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -12,6 +12,7 @@ import pytest
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
 from app.services.result_ledger import store_in_sample_result
+from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
 from app.services.strategy_control_plane import (
     StrategyControlError,
     StrategyOwnershipError,
@@ -40,6 +41,7 @@ from app.services.strategy_promotion_evidence import (
     RecentYearEvidence,
 )
 from app.services.strategy_promotion_evidence_store import store_promotion_evidence
+from app.services.strategy_result_universe import ResultUniverseRecord, store_result_universe
 from tests.test_result_ledger import build_metrics, build_result
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
@@ -110,6 +112,25 @@ def _passing_promotion_evidence(*, lower_bound: str = "0.1") -> PromotionEvidenc
         outcome_contrasts=tuple(
             OutcomeContrast(role, 60, 40, Decimal("1"), Decimal("0"), Decimal("1"))
             for role in sorted(REQUIRED_CONTRASTS)
+        ),
+    )
+
+
+def _universe_record(
+    conn: psycopg.Connection[Any],
+    result_id: int,
+    *,
+    evaluated: frozenset[int] = frozenset({1, 2, 3}),
+    universe: frozenset[int] = frozenset({1, 2, 3, 4, 5}),
+) -> None:
+    """The #2621 frozen-universe record a pinned result must carry to promote."""
+    store_result_universe(
+        conn,
+        result_id=result_id,
+        record=ResultUniverseRecord(
+            universe_rule_version=VALIDATED_UNIVERSE_RULE_VERSION,
+            evaluated_instrument_ids=evaluated,
+            validated_universe_ids=universe,
         ),
     )
 
@@ -280,8 +301,10 @@ def test_historical_validation_requires_passing_edge_evidence(
         strategy_version="v1",
         namespace="in_sample",
         metrics=build_metrics(profit_factor=1.2),
+        evaluated_instrument_count=3,
     )
     result_id = store_in_sample_result(conn, result)
+    _universe_record(conn, result_id)
 
     with pytest.raises(StrategyControlError, match="promotion_evidence_missing"):
         promote_strategy(
@@ -318,8 +341,10 @@ def test_historical_validation_requires_passing_edge_evidence(
         namespace="in_sample",
         ambiguity_arm="best_case",
         metrics=build_metrics(profit_factor=1.2),
+        evaluated_instrument_count=3,
     )
     passing_result_id = store_in_sample_result(conn, passing_result)
+    _universe_record(conn, passing_result_id)
     store_promotion_evidence(
         conn,
         result_id=passing_result_id,
@@ -348,6 +373,80 @@ def test_historical_validation_requires_passing_edge_evidence(
             evidence_ref="result:test-failing-forward",
             result_ids=(result_id,),
         )
+
+
+def test_promotion_replays_the_frozen_universe_check(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """#2621 — a result whose evaluated set left the §4.0 validated universe
+    cannot reach ``historical_validated`` through ``promote_strategy``, and a
+    result stored without its frozen record refuses rather than passing on
+    trust in the writer."""
+    conn = ebull_test_conn
+    promote_strategy(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        to_stage="research_candidate",
+        promoted_by="operator",
+        reason="register candidate",
+    )
+
+    def _result_id(ambiguity_arm: str, quarantine_arm: str) -> int:
+        result = build_result(
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            namespace="in_sample",
+            ambiguity_arm=ambiguity_arm,
+            quarantine_arm=quarantine_arm,
+            metrics=build_metrics(profit_factor=1.2),
+            evaluated_instrument_count=2,
+        )
+        result_id = store_in_sample_result(conn, result)
+        store_promotion_evidence(conn, result_id=result_id, evidence=_passing_promotion_evidence())
+        return result_id
+
+    def _refuses(result_id: int, code: str) -> None:
+        with pytest.raises(StrategyControlError, match=code):
+            promote_strategy(
+                conn,
+                strategy_id="S-GOV",
+                strategy_version="v1",
+                to_stage="historical_validated",
+                promoted_by="operator",
+                reason="universe re-check must refuse",
+                evidence_ref="result:test-universe",
+                result_ids=(result_id,),
+            )
+        assert current_stage(conn, "S-GOV", "v1") == "research_candidate"
+
+    # No frozen record at all — evidence alone must not be enough.
+    _refuses(_result_id("worst_case", "masked"), "evaluated_universe_unrecorded")
+
+    # Evaluated set leaves the frozen universe.
+    outside_id = _result_id("worst_case", "admitted")
+    _universe_record(conn, outside_id, evaluated=frozenset({1, 99}), universe=frozenset({1, 2, 3}))
+    _refuses(outside_id, "instrument_outside_validated_universe")
+
+    # Record that does not describe its own row.
+    mismatched_id = _result_id("best_case", "masked")
+    _universe_record(conn, mismatched_id, evaluated=frozenset({1, 2, 3}), universe=frozenset({1, 2, 3}))
+    _refuses(mismatched_id, "evaluated_universe_count_mismatch")
+
+    # A consistent subset record plus passing evidence promotes.
+    passing_id = _result_id("best_case", "admitted")
+    _universe_record(conn, passing_id, evaluated=frozenset({1, 2}), universe=frozenset({1, 2, 3}))
+    promotion = promote_strategy(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        to_stage="historical_validated",
+        promoted_by="operator",
+        reason="frozen universe replay passes",
+        evidence_ref="result:test-universe-passing",
+        result_ids=(passing_id,),
+    )
+    assert promotion.to_stage == "historical_validated"
 
 
 def test_harness_control_cannot_be_promoted_or_funded(

--- a/tests/test_strategy_result_universe.py
+++ b/tests/test_strategy_result_universe.py
@@ -1,0 +1,94 @@
+"""#2621 — the frozen-universe refusal function and canonical form (pure tier).
+
+⚠ Lives in the PURE-tier module and is imported by the DB-tier one
+(``tests/test_strategy_result_universe_db.py``), never the other way round —
+the conftest db-marks a module whose source references the DB fixtures, and a
+pure test that leaves the fast tier is a gate that stopped running on push.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
+from app.services.strategy_result_universe import (
+    ResultUniverseRecord,
+    record_sha256,
+    universe_promotion_refusals,
+)
+
+
+def build_universe_record(
+    *,
+    version: str = VALIDATED_UNIVERSE_RULE_VERSION,
+    evaluated: frozenset[int] = frozenset({1, 2, 3}),
+    universe: frozenset[int] = frozenset({1, 2, 3, 4, 5}),
+) -> ResultUniverseRecord:
+    return ResultUniverseRecord(
+        universe_rule_version=version,
+        evaluated_instrument_ids=evaluated,
+        validated_universe_ids=universe,
+    )
+
+
+class TestTheRefusalFunction:
+    def test_a_consistent_subset_record_passes(self) -> None:
+        assert universe_promotion_refusals(build_universe_record(), evaluated_instrument_count=3) == ()
+
+    def test_no_record_is_the_one_lone_refusal(self) -> None:
+        assert universe_promotion_refusals(None, evaluated_instrument_count=3) == ("evaluated_universe_unrecorded",)
+
+    def test_an_unrecognised_rule_version_refuses(self) -> None:
+        refusals = universe_promotion_refusals(
+            build_universe_record(version="validated-universe-v0"), evaluated_instrument_count=3
+        )
+        assert refusals == ("evaluated_universe_rule_unrecognised",)
+
+    def test_a_record_that_disagrees_with_its_row_refuses(self) -> None:
+        refusals = universe_promotion_refusals(build_universe_record(), evaluated_instrument_count=4)
+        assert refusals == ("evaluated_universe_count_mismatch",)
+
+    def test_an_empty_evaluated_set_is_not_vacuously_inside(self) -> None:
+        refusals = universe_promotion_refusals(
+            build_universe_record(evaluated=frozenset()), evaluated_instrument_count=0
+        )
+        assert refusals == ("no_instruments_evaluated",)
+
+    def test_an_instrument_outside_the_frozen_universe_refuses(self) -> None:
+        refusals = universe_promotion_refusals(
+            build_universe_record(evaluated=frozenset({1, 99})), evaluated_instrument_count=2
+        )
+        assert refusals == ("instrument_outside_validated_universe",)
+
+    def test_all_refusals_are_returned_not_the_first(self) -> None:
+        refusals = universe_promotion_refusals(
+            build_universe_record(version="validated-universe-v0", evaluated=frozenset({99})),
+            evaluated_instrument_count=7,
+        )
+        assert refusals == (
+            "evaluated_universe_rule_unrecognised",
+            "evaluated_universe_count_mismatch",
+            "instrument_outside_validated_universe",
+        )
+
+
+class TestTheCanonicalForm:
+    def test_the_hash_is_order_independent(self) -> None:
+        assert record_sha256(build_universe_record(evaluated=frozenset({3, 1, 2}))) == record_sha256(
+            build_universe_record(evaluated=frozenset({1, 2, 3}))
+        )
+
+    def test_a_delimiter_in_the_version_cannot_collide_two_records(self) -> None:
+        # JSON framing, not joined CSV: a version carrying the join character
+        # must not hash like a different version with different ids.
+        first = build_universe_record(version='v",1', evaluated=frozenset({1}))
+        second = build_universe_record(version="v", evaluated=frozenset({1, 2}))
+        assert record_sha256(first) != record_sha256(second)
+
+    def test_an_empty_version_is_refused_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="universe_rule_version must be non-empty"):
+            build_universe_record(version="")
+
+    def test_a_boolean_id_is_refused_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="must contain only ints"):
+            build_universe_record(evaluated=frozenset({True, 2}))

--- a/tests/test_strategy_result_universe_db.py
+++ b/tests/test_strategy_result_universe_db.py
@@ -1,0 +1,92 @@
+"""#2621 — the frozen-universe store against a real Postgres (DB tier)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.result_ledger import store_in_sample_result
+from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
+from app.services.strategy_result_universe import (
+    load_result_universe,
+    record_sha256,
+    store_result_universe,
+)
+from tests.test_result_ledger import build_result
+from tests.test_strategy_result_universe import build_universe_record
+
+pytestmark = pytest.mark.integration
+
+
+def _stored_result_id(conn: psycopg.Connection[Any]) -> int:
+    return store_in_sample_result(conn, build_result(namespace="in_sample", evaluated_instrument_count=3))
+
+
+def test_round_trip(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    conn = ebull_test_conn
+    result_id = _stored_result_id(conn)
+    store_result_universe(conn, result_id=result_id, record=build_universe_record())
+    assert load_result_universe(conn, result_id) == build_universe_record()
+
+
+def test_a_result_without_a_record_loads_none(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    conn = ebull_test_conn
+    result_id = _stored_result_id(conn)
+    assert load_result_universe(conn, result_id) is None
+
+
+def test_the_record_is_immutable(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    conn = ebull_test_conn
+    result_id = _stored_result_id(conn)
+    store_result_universe(conn, result_id=result_id, record=build_universe_record())
+    with pytest.raises(psycopg.errors.RaiseException, match="immutable"):
+        with conn.transaction():
+            conn.execute(
+                "UPDATE strategy_result_universe SET universe_rule_version = 'edited' WHERE result_id = %s",
+                (result_id,),
+            )
+    with pytest.raises(psycopg.errors.RaiseException, match="immutable"):
+        with conn.transaction():
+            conn.execute("DELETE FROM strategy_result_universe WHERE result_id = %s", (result_id,))
+
+
+def test_a_tampered_hash_raises_rather_than_refusing(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    # Corruption is an integrity failure to surface loudly, not a gate
+    # verdict — same contract as load_promotion_evidence.
+    conn = ebull_test_conn
+    result_id = _stored_result_id(conn)
+    conn.execute(
+        """
+        INSERT INTO strategy_result_universe (
+            result_id, universe_rule_version, evaluated_instrument_ids,
+            validated_universe_ids, payload_sha256
+        ) VALUES (%s, %s, %s, %s, %s)
+        """,
+        (result_id, VALIDATED_UNIVERSE_RULE_VERSION, [1, 2, 3], [1, 2, 3, 4, 5], "0" * 64),
+    )
+    with pytest.raises(RuntimeError, match="hash mismatch"):
+        load_result_universe(conn, result_id)
+
+
+def test_a_non_canonical_array_raises(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    conn = ebull_test_conn
+    result_id = _stored_result_id(conn)
+    conn.execute(
+        """
+        INSERT INTO strategy_result_universe (
+            result_id, universe_rule_version, evaluated_instrument_ids,
+            validated_universe_ids, payload_sha256
+        ) VALUES (%s, %s, %s, %s, %s)
+        """,
+        (
+            result_id,
+            VALIDATED_UNIVERSE_RULE_VERSION,
+            [3, 1, 1],
+            [1, 2, 3, 4, 5],
+            record_sha256(build_universe_record()),
+        ),
+    )
+    with pytest.raises(RuntimeError, match="not sorted-unique"):
+        load_result_universe(conn, result_id)


### PR DESCRIPTION
Closes #2621. Refs #2605. Refs #2505. Refs #2437. Refs #2625.

## What

`check_promotable`'s universe refusal was computed at result-write time, returned in `WrittenRow.refusals`, and never persisted — so `promote_strategy`, the transition that authorises `historical_validated`, could not re-detect a result whose evaluated set left the §4.0 validated universe, and structurally could not (the store held `evaluated_instrument_count`, not the ids).

- **sql/334** — `strategy_result_universe`: one immutable, hashed record per result (evaluated ids + the validated universe as the run loaded it + a rule version), the sql/327 promotion-evidence shape, with the same UPDATE/DELETE-refusing trigger and a cardinality backstop.
- **`app/services/strategy_result_universe.py`** — store/load (hash-verified, canonical-form-verified) + pure `universe_promotion_refusals` returning ALL refusals: `evaluated_universe_unrecorded` / `evaluated_universe_rule_unrecognised` / `evaluated_universe_count_mismatch` / `no_instruments_evaluated` / `instrument_outside_validated_universe` (last two reuse `check_promotable`'s own codes and clause order).
- **`backtest_run._write_rows`** — freezes the record in the pair's own transaction (hold-out path now wraps the pair writer, whose own `conn.transaction()` nests as a savepoint), with a pre-insert assertion that the record describes its row. The criterion-8 re-measure loop now READS BACK the frozen record and feeds `check_promotable` from it, so the write-time cross-check verifies exactly what the transition will load — a missing/divergent record fails the run loudly.
- **`strategy_control_plane.promote_strategy`** — at the evidence stages, replays the universe check from the frozen record per pinned result; universe and edge-evidence refusal lists are gathered before raising so one missing input cannot mask the other. Message shape unchanged (`result N fails promotion evidence: codes`).
- Docs: settled-decisions "where it binds" and the promotion-contract §"Validated universe scope" both said "transition NOT enforced" — corrected in the same PR.

## The decision #2621 said must not be made silently (scope item 3)

**Replay against the universe FROZEN at result time, never today's `load_validated_universe`.**

1. The transition gate re-derives refusals from frozen records; today's date enters it only where a validity window was DECLARED (`cost_observed_on`/`cost_valid_through`). The universe declares no validity window — a today-check would be an undeclared freshness rule.
2. Today's universe filters on `is_tradable` (today's listing state): a re-check against it retroactively invalidates a passing historical result on any delisting, while the survivorship-free corpus (#2597 — the only basis `universe_basis_not_survivorship_free` will ever pass) deliberately evaluates delisted names.
3. Enforcement against the CURRENT universe at capital time is the execution guard's order-time job (§4.0 allocation invariant 2, phase 7), not evidence admission's.

Honest bound, stated in the module docstring: both frozen sets come from the same writer, so the replay does not certify write-time honesty (the write-time criterion-8 raise does that). It buys: any OTHER writer/direct insert refuses; an immutable hashed input independently auditable against `instrument_universe_membership` (#2290); row/record consistency; and a check that stays replayable after the universe moves. Rule-version governance is a fail-closed allowlist (`RECOGNISED_UNIVERSE_RULE_VERSIONS`) — the `trial_register_superseded` shape.

## Scope item 5

Answered on #2625 (filed from this branch): one follow-up ticket, because the remaining inputs share a policy blocker (three divergent temporal rules + hold-out reads being audited events), not five schemas. `ambiguity_material` is the one input that is persisted nowhere.

## Effect on existing rows (measured this run, dev DB)

`strategy_promotion_evidence` = 0 rows, `strategy_promotions` = 0 rows, `strategy_results_store` = 244 rows — every legacy row already refuses `promotion_evidence_missing` at the transition, and now additionally `evaluated_universe_unrecorded`. That is the intended fail-closed posture, not a migration gap: a pre-#2621 row's universe inputs genuinely were not persisted, and re-running the backtest is the way to mint promotable evidence.

## Verification

- Gates (each separate, exit-code gated): `ruff check` 0 · `ruff format --check` 0 · `pyright` 0 · `pytest -m "not db" -q` 0 · `pytest tests/smoke -q` 0.
- Touched DB-tier modules: `pytest -m db tests/test_strategy_control_plane.py tests/test_strategy_result_universe_db.py tests/test_result_ledger.py tests/test_strategy_promotion_evidence_store.py tests/test_strategy_result_folds.py` → exit 0.
- Migration applied to dev DB (`Applied 1 migration(s): ['334_strategy_result_universe.sql']`); table columns verified live.
- **Revert-probes** (inject defect → test FAILS → restore → passes, anchor `count == 1` asserted): (1) `promote_strategy` universe check removed → `test_promotion_replays_the_frozen_universe_check` fails; (2) subset clause neutered → `test_an_instrument_outside_the_frozen_universe_refuses` fails; (3) loader hash check removed → `test_a_tampered_hash_raises_rather_than_refusing` fails.
- New acceptance test (issue item 4): `test_promotion_replays_the_frozen_universe_check` — unrecorded / outside-universe / count-mismatch each refuse with the stage pinned at `research_candidate`, and a consistent subset record + passing evidence promotes.
- ⚠ `_write_rows` itself has no test harness (none existed before this PR either); its coupling is enforced at runtime instead — the criterion-8 loop now raises if a written row's frozen record is missing or diverges from the predicted refusal set.
- Codex checkpoint 1 (plan): 30 findings triaged — combined-refusal ordering, canonical JSON preimage, size CHECK, pre-insert assertion, stale function name, test-audit all adopted. Codex checkpoint 2 (diff, `--base origin/main`, all files committed): no findings.
- Not run: full-population A/B — no existing rows are rewritten or reinterpreted; the new table starts empty and only `run_backtest` writes it. DoD clauses 8–12 (ownership/filings ETL) do not apply to this control-plane surface.

## Security model

No external surface. This narrows an internal authorisation path: promotion to capital-evidence stages now requires a persisted, immutable, hash-verified record instead of trust in the sole writer. Fail-closed for absent/unknown-version/inconsistent records; corruption raises rather than refusing (the `load_promotion_evidence` contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)