### PR TITLE
feat(#2639): the promotion transition replays its last three inputs

### DIFF
--- a/app/services/result_ledger.py
+++ b/app/services/result_ledger.py
@@ -66,8 +66,12 @@ from app.services.prereg_contract import (
 )
 from app.services.random_entry_cohort import SyntheticControl
 from app.services.strategy_result import (
+    PromotionRefusal,
     ResultIdentity,
     StrategyResult,
+    deflation_promotion_refusals,
+    purpose_promotion_refusals,
+    synthetic_control_promotion_refusals,
 )
 from app.services.strategy_statistics import StrategyMetrics
 from app.services.walk_forward import (
@@ -411,20 +415,30 @@ _SELECT_HOLDOUT = f"""
     ORDER BY result_version, result_scope, ambiguity_arm, quarantine_arm
 """  # noqa: S608 - as above
 
-_COUNT_HOLDOUT_RESULTS = """
-    SELECT count(*)
-    FROM strategy_results_store
-    WHERE strategy_id = %(strategy_id)s
-      AND strategy_version = %(strategy_version)s
-      AND namespace = 'hold_out'
-"""
-
-_COUNT_EVALUATE_ACCESSES = """
-    SELECT count(*)
-    FROM strategy_holdout_accesses
-    WHERE strategy_id = %(strategy_id)s
-      AND strategy_version = %(strategy_version)s
-      AND access_kind = 'evaluate'
+#: ⚠⚠ ONE STATEMENT, TWO SCALAR SUBQUERIES, AND THAT IS THE POINT (#2639). The
+#: two counts used to run as separate statements, which under READ COMMITTED is
+#: two snapshots — so a ``store_holdout_result`` committing between them could
+#: return a pair that never simultaneously existed. The direction that matters
+#: is ``accesses < evaluations``, a false ``holdout_accesses_unrecorded``, and
+#: it fires exactly when a hold-out row lands between the two reads.
+#:
+#: ⚠ This buys ONE snapshot for the pair, not atomicity with whatever the caller
+#: does next. ``promote_strategy`` decides on counts that were true when read;
+#: the hold-out writers do not take its advisory lock, so a write may still
+#: commit between the count and the promotion INSERT. Named as a bound on #2639
+#: rather than assumed away.
+_COUNT_HOLDOUT_EVALUATIONS_AND_ACCESSES = """
+    SELECT
+        (SELECT count(*)
+           FROM strategy_results_store
+          WHERE strategy_id = %(strategy_id)s
+            AND strategy_version = %(strategy_version)s
+            AND namespace = 'hold_out'),
+        (SELECT count(*)
+           FROM strategy_holdout_accesses
+          WHERE strategy_id = %(strategy_id)s
+            AND strategy_version = %(strategy_version)s
+            AND access_kind = 'evaluate')
 """
 
 #: ⚠ Counts BOTH sibling versions in one statement rather than probing twice —
@@ -1443,13 +1457,22 @@ def holdout_access_counts(
     strategy_id: str,
     strategy_version: str,
 ) -> HoldoutAccessCounts:
-    """``PromotionCandidate``'s two hold-out inputs. See ``HoldoutAccessCounts``."""
-    params = {"strategy_id": strategy_id, "strategy_version": strategy_version}
-    evaluations = conn.execute(_COUNT_HOLDOUT_RESULTS, params).fetchone()
-    accesses = conn.execute(_COUNT_EVALUATE_ACCESSES, params).fetchone()
-    if evaluations is None or accesses is None:  # pragma: no cover - count() always returns a row
+    """``PromotionCandidate``'s two hold-out inputs. See ``HoldoutAccessCounts``.
+
+    ⚠ RECORDS NOTHING — two pure ``COUNT``s, so it is safe to call from the
+    promotion transition. #2639's inventory originally said otherwise; the
+    function that records is ``quarantine_arms_compared``, and only on a
+    ``hold_out`` identity.
+
+    ⚠ ONE STATEMENT, ONE SNAPSHOT. See ``_COUNT_HOLDOUT_EVALUATIONS_AND_ACCESSES``.
+    """
+    row = conn.execute(
+        _COUNT_HOLDOUT_EVALUATIONS_AND_ACCESSES,
+        {"strategy_id": strategy_id, "strategy_version": strategy_version},
+    ).fetchone()
+    if row is None:  # pragma: no cover - count() always returns a row
         raise RuntimeError("count query returned no row")
-    return HoldoutAccessCounts(holdout_evaluations=int(evaluations[0]), recorded_accesses=int(accesses[0]))
+    return HoldoutAccessCounts(holdout_evaluations=int(row[0]), recorded_accesses=int(row[1]))
 
 
 # ---------------------------------------------------------------------------
@@ -1571,7 +1594,6 @@ def quarantine_arms_compared(
     namespace, and an optional audit field is one a caller learns it needed at
     the moment it cannot supply one.
     """
-    sibling = replace(identity, quarantine_arm=("admitted" if identity.quarantine_arm == "masked" else "masked"))
     if identity.namespace == "hold_out":
         record_holdout_access(
             conn,
@@ -1584,6 +1606,37 @@ def quarantine_arms_compared(
                 purpose=purpose,
             ),
         )
+    return quarantine_arm_pair_present(conn, identity)
+
+
+def quarantine_arm_pair_present(conn: psycopg.Connection[tuple], identity: ResultIdentity) -> bool:
+    """The same count as ``quarantine_arms_compared``, RECORDING NOTHING (#2639).
+
+    ⚠⚠ THE ONLY DIFFERENCE IS THE ACCESS RECORD, AND THAT IS WHY IT IS SPLIT
+    OUT RATHER THAN COPIED. ``quarantine_arms_compared`` is the door for a
+    caller ASKING THE DATABASE ABOUT THE WITHHELD SIDE, where *looking is the
+    event criterion 5 governs*. The promotion transition is not such a caller:
+    it holds a result it has already pinned, it already reads that row's own
+    columns, and promotion is not an evaluation. A transition that recorded here
+    would write one ``read`` row per promotion attempt into the log it is
+    auditing — the prevention-log rule *"it must not ask the database a question
+    it is the answer to"*, one layer further out. The verdict is identical
+    either way, so a second copy of the count would be a second thing to keep in
+    step for no gain.
+
+    ⚠ THE SIBLING IS DERIVED, NEVER NAMED. ``ResultIdentity.version`` is a hash
+    of the whole identity, so the flipped-arm version is the ONLY row that can
+    satisfy the pair — which is what a stored ``sibling_result_id`` pointer
+    (#2639's first draft, killed at Codex checkpoint 1) would have given up: a
+    pointer is chosen by the writer and can name a compatible row that is not
+    the one the identity admits.
+
+    ⚠ MONOTONE, WHICH IS WHY THE POLICY CALLS THIS ``frozen`` rather than
+    ``today``. Both arms are rows written at result time and the store has no
+    delete path, so the answer moves only from "one arm" to "both arms". Nothing
+    about today's world enters it.
+    """
+    sibling = replace(identity, quarantine_arm=("admitted" if identity.quarantine_arm == "masked" else "masked"))
     row = conn.execute(
         _COUNT_ARM_PAIR,
         {
@@ -1595,6 +1648,86 @@ def quarantine_arms_compared(
     if row is None:  # pragma: no cover - count() always returns a row
         raise RuntimeError("arm-pair count query returned no row")
     return int(row[0]) == 2
+
+
+_SELECT_RESULT_BY_ID = f"""
+    SELECT {_RESULT_COLUMNS}
+    FROM strategy_results_store
+    WHERE result_id = %(result_id)s
+"""  # noqa: S608 - a module-level literal, no caller input reaches the fragment
+
+
+def stored_result_promotion_refusals(conn: psycopg.Connection[tuple], result_id: int) -> tuple[PromotionRefusal, ...]:
+    """Every refusal the STORED ROW itself decides, for the transition (#2639).
+
+    ``promote_strategy`` cannot call ``check_promotable`` — it holds a
+    ``result_id``, not a ``StrategyResult`` — so #2625 replayed the structural
+    stamps and left the purpose, deflation, effective-sample-size and
+    synthetic-control clauses trusting a write-time verdict that died with
+    ``WrittenRow``. All of them are columns on the row the caller has already
+    pinned. This rebuilds the row through the existing ``_result_from_row`` and
+    applies the SAME pure functions ``check_promotable`` applies, in its order.
+
+    ⚠⚠ IT RETURNS CODES AND NEVER A ``StrategyResult``, DELIBERATELY. A public
+    ``load_result_by_id`` would be a new UNAUDITED DOOR TO THE WITHHELD SIDE —
+    ``read_holdout_results`` is the sanctioned one and it records the access
+    first, and 300 of the 324 stored rows are ``hold_out``. Keeping the withheld
+    numbers inside this module and handing the transition a refusal list means
+    this function cannot become that door.
+
+    ⚠ Reading a pinned row's own columns is not a new governance cost:
+    ``promote_strategy`` already selects six of them, and
+    ``holdout_access_counts`` already counts these rows, neither recording an
+    access.
+
+    ⚠ ``_result_from_row`` RAISES where the gate refuses — on a ``result_version``
+    that does not match the identity it carries, on a stored
+    ``synthetic_control_passed`` that disagrees with its own inputs, and on a
+    partially-written DSR or control block. That is ``load_result_ambiguity``'s
+    precedent (corruption is an integrity failure to surface loudly, not a gate
+    verdict to report politely) and it carries the same named cost: the raise
+    aborts before the other refusals are gathered, so it MASKS them. Verified on
+    the full population 2026-08-13 — 324 of 324 stored rows reconstruct, so no
+    stored row takes that path today.
+
+    ⚠ THE STRUCTURAL STAMPS ARE NOT RETURNED HERE. ``promote_strategy`` keeps its
+    own read of ``universe_basis`` / ``carry_unmodelled`` / ``fx_unmodelled``
+    because it coerces a NULL cost stamp to ``True`` (unmodelled), while
+    ``_result_from_row`` coerces with ``bool(...)``, which reads NULL as
+    *modelled* — fail-open on a Tier 1 refusal. Both columns are ``NOT NULL``
+    (``sql/262``, ``sql/335``), so this is defence in depth; the two coercions
+    must not be collapsed onto the weaker one.
+    """
+    row = conn.execute(_SELECT_RESULT_BY_ID, {"result_id": result_id}).fetchone()
+    if row is None:
+        # ⚠ RAISES, does not refuse. `PromotionRefusal` is a closed vocabulary
+        # of reasons a REAL result may not be promoted; "the row does not exist"
+        # is a caller error, and `promote_strategy` has already refused an
+        # unknown result_id with its own message before reaching here. Inventing
+        # a refusal code for it would put a programming error into the operator's
+        # list of things to fix about a strategy.
+        raise RuntimeError(f"no stored result row for result_id {result_id}")
+    result = _result_from_row(row)
+    refusals: list[PromotionRefusal] = []
+    # `check_promotable`'s order, minus the blocks the transition replays from
+    # their own frozen records (universe, ambiguity) or reads separately (the
+    # structural stamps, the #2505 evidence).
+    refusals.extend(purpose_promotion_refusals(result.purpose))
+    refusals.extend(
+        deflation_promotion_refusals(
+            deflated_sharpe=result.deflated_sharpe,
+            trial_count=result.trial_count,
+            deflated=result.deflated,
+            effective_sample_size=result.metrics.effective_sample_size,
+        )
+    )
+    # Criterion 9 — re-derived from the two arms' rows rather than from a
+    # recorded boolean. See `quarantine_arm_pair_present` for why the recording
+    # door is not the one the transition uses.
+    if not quarantine_arm_pair_present(conn, result.identity):
+        refusals.append("quarantine_arms_not_compared")
+    refusals.extend(synthetic_control_promotion_refusals(result.synthetic_control))
+    return tuple(refusals)
 
 
 # ---------------------------------------------------------------------------
@@ -1764,6 +1897,7 @@ __all__ = [
     "freeze_preregistration",
     "holdout_access_counts",
     "load_preregistration",
+    "quarantine_arm_pair_present",
     "quarantine_arms_compared",
     "read_holdout_results",
     "read_walk_forward_folds",
@@ -1774,6 +1908,7 @@ __all__ = [
     "store_in_sample_arm_pair",
     "store_in_sample_result",
     "store_walk_forward_folds",
+    "stored_result_promotion_refusals",
     "supersede_preregistration",
     "verify_outcome_access_provenance",
 ]

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -17,6 +17,7 @@ from typing import Any, Literal, cast
 import psycopg
 import psycopg.rows
 
+from app.services.result_ledger import holdout_access_counts, stored_result_promotion_refusals
 from app.services.strategy_base_currency import (
     DEPLOYMENT_CURRENCY,
     DEPLOYMENT_CURRENCY_UNSUPPORTED,
@@ -26,7 +27,7 @@ from app.services.strategy_base_currency import (
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyPurpose
 from app.services.strategy_promotion_evidence import evidence_refusals
 from app.services.strategy_promotion_evidence_store import load_promotion_evidence
-from app.services.strategy_result import structural_promotion_refusals
+from app.services.strategy_result import holdout_count_promotion_refusals, structural_promotion_refusals
 from app.services.strategy_result_ambiguity import ambiguity_promotion_refusals, load_result_ambiguity
 from app.services.strategy_result_universe import load_result_universe, universe_promotion_refusals
 
@@ -446,14 +447,23 @@ def promote_strategy(
     replacement for trusting that the sole writer ran ``check_promotable`` at
     write time.
 
-    ⚠ WHAT IS STILL *NOT* REPLAYED, because a partial gate read as a whole one
-    is how #2621 happened: the hold-out evaluation/access counts, criterion 9's
-    quarantine-arm comparison, and the deflation / effective-sample-size /
-    synthetic-control clauses. Each is classified — with its reason and its
-    temporal rule — in ``app.services.strategy_promotion_replay``, and
-    ``unenforced_candidate_fields`` returns the current set, and #2639 tracks
-    closing it. Do not add an input here without classifying it there; a test
-    enforces that.
+    #2639 closed the remainder: criterion 5's two counts (against TODAY's
+    ledger, because a frozen pair is blind to a later unrecorded look),
+    criterion 9's arm pair (re-derived from the identity hash, not from a
+    recorded boolean), and the row's own purpose / deflation /
+    effective-sample-size / §9 clauses. ``unenforced_candidate_fields()`` is now
+    empty.
+
+    ⚠ WHAT THIS STILL DOES NOT DO. The counts are read once and are not atomic
+    with the INSERT below — the hold-out writers do not take this function's
+    advisory lock, so a hold-out row may commit between the read and the
+    promotion. And a corrupt stored row RAISES out of
+    ``stored_result_promotion_refusals`` rather than refusing, which aborts
+    before the remaining refusals are gathered and therefore masks them.
+
+    Every input's temporal rule and whether the transition applies it are
+    declared in ``app.services.strategy_promotion_replay``. Do not add an input
+    here without classifying it there; a test enforces that.
     """
     for value, field in (
         (strategy_id, "strategy_id"),
@@ -503,6 +513,23 @@ def promote_strategy(
                 f"result_ids do not belong to {strategy_id}@{strategy_version}: {sorted(missing)}"
             )
         if to_stage in _RESULT_EVIDENCE_STAGES:
+            # #2639 — criterion 5's two counts, read ONCE for the whole
+            # transition. They are scoped to (strategy_id, strategy_version),
+            # which is exactly what this call promotes, so they are a property
+            # of the promotion rather than of any one pinned result — and every
+            # result's refusal list carries them so that the raise names them.
+            #
+            # ⚠ AGAINST TODAY'S COUNTS, NOT A FROZEN PAIR. Freezing defeats the
+            # criterion: a pair frozen at result time is blind to a later
+            # unrecorded look at the same version's hold-out, which is the leak
+            # criterion 5 exists to catch. `holdout_access_counts` records
+            # nothing, so asking is safe. Reasoning in
+            # `app.services.strategy_promotion_replay`.
+            counts = holdout_access_counts(conn, strategy_id, strategy_version)
+            holdout_refusals = holdout_count_promotion_refusals(
+                holdout_evaluations=counts.holdout_evaluations,
+                recorded_accesses=counts.recorded_accesses,
+            )
             profit_factor_by_result = {int(row[0]): None if row[1] is None else Decimal(str(row[1])) for row in rows}
             evaluated_count_by_result = {int(row[0]): int(row[2]) for row in rows}
             # ⚠ A NULL COST STAMP READS AS *UNMODELLED*, NEVER AS MODELLED.
@@ -560,6 +587,16 @@ def promote_strategy(
                         fx_unmodelled=fx_unmodelled,
                     )
                 )
+                # #2639 — the row's OWN remaining clauses: its stamped purpose,
+                # criteria 6 and 3, criterion 9's arm pair and §9's acceptance.
+                # Every one is a column on the row already pinned above, and
+                # every one was trusting the write-time verdict that died with
+                # `WrittenRow`. ⚠ Deliberately does NOT return the structural
+                # stamps — see `stored_result_promotion_refusals` for why the
+                # read directly above is kept rather than sourced from the
+                # rebuilt object.
+                refusals.extend(stored_result_promotion_refusals(conn, result_id))
+                refusals.extend(holdout_refusals)
                 evidence = load_promotion_evidence(conn, result_id)
                 if evidence is None:
                     refusals.append("promotion_evidence_missing")

--- a/app/services/strategy_promotion_replay.py
+++ b/app/services/strategy_promotion_replay.py
@@ -23,17 +23,37 @@ The vocabulary is three rules and no more:
     describes a measurement rather than a live condition.
 
 ``today``
-    Deliberately re-evaluated against the current world — and legitimate ONLY
-    where the stored record DECLARES a validity window or is explicitly
-    supersedable. A today-check on anything else is an undeclared freshness
-    rule, which is how a passing historical result silently stops passing.
+    Deliberately re-evaluated against the current world. Legitimate ONLY in one
+    of THREE declared shapes; anywhere else it is an undeclared freshness rule,
+    which is how a passing historical result silently stops passing.
+
+    1. the stored record DECLARES its own validity window
+       (``promotion_evidence``: ``cost_observed_on`` / ``cost_valid_through``);
+    2. the stored record is explicitly supersedable;
+    3. the record is an append-only AUDIT LOG, the clause is a comparison
+       between that log and the rows it audits, and the criterion the clause
+       serves requires the comparison to be CURRENT (the two hold-out counts
+       against ``strategy_holdout_accesses``).
+
+    ⚠ Shape 3 was added by #2639 and is worded this narrowly on purpose. The
+    draft form — "a ledger of our own conduct" — would admit any mutable
+    operational counter, which is most of the database. All three clauses
+    together are the restriction, and ``TestTodayIsRestricted`` still pins the
+    exact member set, so a fourth today-check fails the test whatever it claims
+    about itself.
 
 ``not_re_read``
-    Neither persisted nor re-derived. Tracked by #2639. ⚠⚠ THIS IS A GAP, NOT A SOLUTION: the
+    Neither persisted nor re-derived. ⚠⚠ THIS IS A GAP, NOT A SOLUTION: the
     transition does not enforce that clause at all, and is still trusting a
     write-time verdict that died with ``WrittenRow``. It is spelled out as its
     own rule rather than left off the table so that it cannot be mistaken for
     coverage.
+
+    ⚠ NO INPUT CARRIES IT TODAY — #2639 closed the last three, and
+    ``unenforced_candidate_fields()`` returns an empty set. The rule stays in the
+    vocabulary because the next unclassifiable input needs an honest label to
+    land on, and deleting it would leave the alternative of mislabelling that
+    input ``frozen``, which reads as coverage.
 
 ⚠ ``replayed_at_transition`` is a SEPARATE axis from the rule, and the two must
 not be conflated: "this input's temporal rule is frozen" and "the transition
@@ -76,14 +96,22 @@ REPLAY_TEMPORAL_POLICY: Final[Mapping[str, ReplayPolicyEntry]] = {
     "result": ReplayPolicyEntry(
         rule="frozen",
         replayed_at_transition=True,
-        source="strategy_results_store columns (universe_basis, carry_unmodelled, fx_unmodelled)",
+        source=(
+            "strategy_results_store — the structural stamps read directly by promote_strategy, the rest "
+            "through result_ledger.stored_result_promotion_refusals (#2639)"
+        ),
         reason=(
             "The row's stamps are immutable once written, so replaying them needs no record beyond the row. "
-            "#2625 wires the three STRUCTURAL stamps through the shared structural_promotion_refusals — the "
+            "⚠ ONE FIELD, EIGHT CLAUSES, so 'replayed' is enumerated rather than asserted: universe_basis / "
+            "carry_unmodelled / fx_unmodelled through the shared structural_promotion_refusals (#2625, the "
             "same single copy #2599's preregistration freeze calls, so the transition and the freeze cannot "
-            "drift. ⚠ PARTIAL: the deflation, effective-sample-size and synthetic-control clauses are "
-            "columns on the same row and are still NOT replayed; they need their model objects rebuilt, "
-            "which is follow-up work, not a different temporal rule."
+            "drift); purpose through purpose_promotion_refusals; deflated_sharpe / trial_count / "
+            "trial_register_superseded / effective_sample_size through deflation_promotion_refusals; the two "
+            "§9 verdicts through synthetic_control_promotion_refusals (#2639). Every one of those functions "
+            "is the copy check_promotable itself calls. ⚠ trial_register_superseded compares a frozen column "
+            "against the CURRENT TRIAL_REGISTER constant, which does not make the field 'today' — see "
+            "promotion_evidence, where it is the current DATE that does. A register supersession "
+            "invalidating older results is deliberate."
         ),
     ),
     "evaluated_instrument_ids": ReplayPolicyEntry(
@@ -126,38 +154,51 @@ REPLAY_TEMPORAL_POLICY: Final[Mapping[str, ReplayPolicyEntry]] = {
         ),
     ),
     "holdout_evaluations": ReplayPolicyEntry(
-        rule="not_re_read",
-        replayed_at_transition=False,
-        source="none — strategy_holdout_accesses is not consulted by the transition",
+        rule="today",
+        replayed_at_transition=True,
+        source="result_ledger.holdout_access_counts (#2639), read live at the transition",
         reason=(
-            "⚠ A GAP. result_ledger.holdout_access_counts is two pure COUNT statements and records nothing, "
-            "so re-reading is SAFE — the issue's inventory table said otherwise and was wrong (the function "
-            "that records is quarantine_arms_compared, and only on a hold_out identity). What blocks it is "
-            "not safety but an undecided temporal rule: both counts are scoped to "
-            "(strategy_id, strategy_version) rather than to a result, so a later hold-out evaluation "
-            "retroactively changes what a replay of an OLDER pinned result would see. Frozen-at-result-time "
-            "and today's-count genuinely differ, and neither is obviously right. Left explicitly undecided "
-            "rather than answered silently."
+            "⚠⚠ TODAY BECAUSE FROZEN DEFEATS CRITERION 5, not because today is convenient. Both counts are "
+            "scoped to (strategy_id, strategy_version), so a pair frozen when result #1 was written records "
+            "the hold-out looks that had happened BY THEN: a strategy that later evaluates its hold-out four "
+            "more times without recording an access would replay result #1 as (1, 1) — consistent, "
+            "promotable, and blind to precisely the repeated unlogged look the criterion exists to catch. "
+            "The retroactivity #2621 rejected for the universe is the DESIRED behaviour here, because the "
+            "later event is our own conduct on this strategy version and not a change in the outside world. "
+            "Qualifies under today-shape 3: an append-only audit log, a clause comparing that log against "
+            "the rows it audits, and a criterion that requires the comparison to be current. ⚠ Re-reading "
+            "is SAFE — holdout_access_counts is pure COUNTs and records nothing; #2639's inventory said "
+            "otherwise and was wrong. ⚠ The clause is strategy-version-wide, so one unrecorded evaluation "
+            "blocks every result of that version — check_promotable's own behaviour, inherited not invented "
+            "— and it heals as well as blocks, since a record written later moves the answer back."
         ),
     ),
     "recorded_accesses": ReplayPolicyEntry(
-        rule="not_re_read",
-        replayed_at_transition=False,
-        source="none — strategy_holdout_accesses is not consulted by the transition",
-        reason="The other half of the same undecided count; see holdout_evaluations.",
+        rule="today",
+        replayed_at_transition=True,
+        source="result_ledger.holdout_access_counts (#2639), read live at the transition",
+        reason=(
+            "The other half of the same comparison; see holdout_evaluations. ⚠ Both sides move: an access "
+            "inserted later changes the answer as surely as an evaluation does, which is what makes the "
+            "clause a self-consistency check on the log rather than a freshness rule about the world."
+        ),
     ),
     "quarantine_arms_compared": ReplayPolicyEntry(
-        rule="not_re_read",
-        replayed_at_transition=False,
-        source="none — result_ledger.quarantine_arms_compared is not called by the transition",
+        rule="frozen",
+        replayed_at_transition=True,
+        source="strategy_results_store — both arms' rows, via result_ledger.quarantine_arm_pair_present (#2639)",
         reason=(
-            "⚠ A GAP, and the one input where re-reading has a real governance cost. On a hold_out identity "
-            "that function RECORDS a 'read' access, because looking is the event criterion 5 governs — and "
-            "300 of the 324 stored results are hold_out. A transition that called it would write one audit "
-            "row per promotion attempt into the log it is auditing. ⚠ It would NOT change the verdict: the "
-            "recorded kind is 'read' and _COUNT_EVALUATE_ACCESSES filters access_kind = 'evaluate'. The "
-            "argument is that the trail becomes a count of our own automation, not that the arithmetic "
-            "breaks. Closing this means persisting the comparison at result time, the #2621 move."
+            "⚠ FROZEN AND NOT TODAY: both arms are rows written at result time and the store has no delete "
+            "path, so the derived answer is monotone — it moves only from 'one arm' to 'both arms' when a "
+            "sibling with the identical identity-minus-arm is stored. Nothing about today's world enters it. "
+            "⚠⚠ THE TRANSITION DOES NOT CALL quarantine_arms_compared, which RECORDS a 'read' access on a "
+            "hold_out identity (300 of 324 stored rows) and would turn the audit trail into a count of our "
+            "own automation — 'it must not ask the database a question it is the answer to', one layer out. "
+            "The counting half is split into quarantine_arm_pair_present, which records nothing; the "
+            "recording door stays the one criterion 5 governs, and promotion is not an evaluation. ⚠ The "
+            "sibling is DERIVED from the identity hash, never named by a stored pointer: a pointer is chosen "
+            "by the writer and can name a compatible row that is not the one the identity admits. #2639's "
+            "first draft proposed that pointer table; Codex checkpoint 1 killed it."
         ),
     ),
 }
@@ -178,6 +219,11 @@ def unenforced_candidate_fields() -> frozenset[str]:
 
     Not a failure — it is the honest inventory of what ``promote_strategy``
     still takes on trust, and a test pins it so the set cannot grow unnoticed.
+
+    ⚠ EMPTY SINCE #2639, and the function stays because the invariant it pins is
+    the useful part: an input added to ``PromotionCandidate`` and classified
+    without being wired lands here and fails a test, instead of arriving as a
+    gate clause nobody applies.
     """
     return frozenset(name for name, entry in REPLAY_TEMPORAL_POLICY.items() if not entry.replayed_at_transition)
 

--- a/app/services/strategy_result.py
+++ b/app/services/strategy_result.py
@@ -843,6 +843,125 @@ def structural_promotion_refusals(
     return tuple(refusals)
 
 
+def purpose_promotion_refusals(purpose: str | None) -> tuple[PromotionRefusal, ...]:
+    """A harness-validation control is never promotable, whatever it measured.
+
+    ⚠ EXTRACTED SO THE TRANSITION CAN REPLAY IT (#2639). ``promote_strategy``
+    refuses on ``registered_strategy_purpose`` — the MANIFEST's purpose — while
+    the pinned ROW carries its own stamped one, and nothing compared them. They
+    agree today (all 324 stored rows and all four registered strategies are
+    ``harness_validation``, measured 2026-08-13), but the moment a manifest entry
+    becomes ``capital_candidate`` its older harness rows are pinnable and the
+    transition would not notice.
+    """
+    return ("harness_validation_only",) if purpose == "harness_validation" else ()
+
+
+def holdout_count_promotion_refusals(
+    *, holdout_evaluations: int, recorded_accesses: int
+) -> tuple[PromotionRefusal, ...]:
+    """Criterion 5, from the two counts ``holdout_access_counts`` returns (#2639).
+
+    ⚠ IMPLEMENTED STRICTER THAN THE LITERAL WORDING, deliberately. Read
+    literally, "more than once" would let a SINGLE unrecorded evaluation pass —
+    and a single unrecorded look at the hold-out is exactly the governance
+    failure criterion 5 describes, just the first one. The rule applied is that
+    every evaluation must have an access record.
+
+    ⚠⚠ THE TRANSITION REPLAYS THIS AGAINST TODAY'S COUNTS, NOT AGAINST A FROZEN
+    PAIR, and freezing would DEFEAT the criterion. Both counts are scoped to
+    ``(strategy_id, strategy_version)``, so a pair frozen when result #1 was
+    written records the looks that had happened by then: a strategy that later
+    evaluates its hold-out four more times without recording would replay
+    result #1 as ``(1, 1)`` — consistent, promotable, and blind to precisely the
+    repeated unlogged look this clause exists to catch. The reasoning is
+    recorded in full in ``app.services.strategy_promotion_replay``.
+    """
+    if holdout_evaluations < 1:
+        return ("holdout_never_evaluated",)
+    if recorded_accesses < holdout_evaluations:
+        return ("holdout_accesses_unrecorded",)
+    return ()
+
+
+def deflation_promotion_refusals(
+    *,
+    deflated_sharpe: object | None,
+    trial_count: int | None,
+    deflated: DeflatedSharpeResult | None,
+    effective_sample_size: float | None,
+) -> tuple[PromotionRefusal, ...]:
+    """Criteria 6 and 3, from the values a stored row also carries (#2639).
+
+    ⚠ THE ONE COPY, called by ``check_promotable`` and by the transition's
+    ``result_ledger.stored_result_promotion_refusals`` — the extraction argument
+    ``structural_promotion_refusals`` makes. A second hand-written copy would
+    drift the first time the deflation rule changed.
+
+    ⚠ FOUR INDEPENDENT ``if``s, never an ``elif`` and never an early return. A
+    DSR with no trial count is as refused as no DSR at all, and both may fire at
+    once; the gate's contract is that every reason is returned.
+
+    ⚠ ``trial_register_superseded`` is guarded on ``deflated_sharpe is not
+    None``, NOT on ``deflated``. A row with a probability but no reconstructed
+    object is exactly the state the clause is for, and guarding on the object
+    would let it pass.
+
+    ⚠ ``deflated_sharpe`` is typed ``object`` because the only thing done with
+    it is a ``None`` test: in memory it is a float, off a stored row it is a
+    psycopg ``Decimal``, and narrowing the type here would force a conversion
+    that the clause does not need and that could raise where the gate refuses.
+    """
+    refusals: list[PromotionRefusal] = []
+
+    # Criterion 6 — "DSR not computed, or computed on an undeclared trial
+    # count". Independent checks: a DSR with no trial count is as refused as no
+    # DSR at all, because the count is what the deflation divides by.
+    if deflated_sharpe is None:
+        refusals.append("deflated_sharpe_not_computed")
+    if trial_count is None:
+        refusals.append("trial_count_undeclared")
+    if deflated_sharpe is not None and (
+        deflated is None
+        or deflated.trial_register_version != TRIAL_REGISTER_VERSION
+        or deflated.declared_trials != TRIAL_REGISTER.declared_count
+    ):
+        refusals.append("trial_register_superseded")
+
+    # Criterion 3 — the effective sample size that criterion 6's deflation
+    # consumes. ⚠ Checked SEPARATELY from the DSR: a DSR present with no
+    # effective sample size is a DSR deflated on a nominal n, and criterion 3
+    # forbids reporting a nominal n anywhere. Stage 5e's block bootstrap fills
+    # it; until then this refusal fires on every result.
+    if effective_sample_size is None:
+        refusals.append("effective_sample_size_not_computed")
+
+    return tuple(refusals)
+
+
+def synthetic_control_promotion_refusals(control: SyntheticControl | None) -> tuple[PromotionRefusal, ...]:
+    """§9's acceptance, from the control a stored row also carries (#2639).
+
+    ⚠ THE COHORT-LEVEL AND STRATEGY-LEVEL FAILURES ARE REPORTED SEPARATELY AND
+    BOTH CAN FIRE: a cohort that shows edge invalidates the scale, and a Sharpe
+    below the threshold is not evidence on any scale. Returning only the first
+    would hide from an operator that one broken cohort is blocking every
+    strategy.
+
+    ⚠ DERIVED FROM THE CONTROL'S OWN PROPERTIES, never from the row's stored
+    ``synthetic_control_passed``. That column is the CONJUNCTION, so reading it
+    would collapse the two codes into one and lose which threshold failed.
+    """
+    if control is None:
+        return ("synthetic_control_not_run",)
+    refusals: list[PromotionRefusal] = []
+    if not control.mean_return_ci_contains_zero:
+        refusals.append("synthetic_control_cohort_shows_edge")
+    if not control.sharpe_exceeds_cohort:
+        refusals.append("synthetic_control_sharpe_below_cohort")
+    return tuple(refusals)
+
+
 def check_promotable(candidate: PromotionCandidate) -> tuple[PromotionRefusal, ...]:
     """Every reason this result may not be promoted. Empty means promotable.
 
@@ -858,8 +977,7 @@ def check_promotable(candidate: PromotionCandidate) -> tuple[PromotionRefusal, .
     refusals: list[PromotionRefusal] = []
     result = candidate.result
 
-    if result.purpose == "harness_validation":
-        refusals.append("harness_validation_only")
+    refusals.extend(purpose_promotion_refusals(result.purpose))
 
     # §6 clause 2 (universe basis) and §5.1 (carry). Both are decided by the
     # stamps alone, so they live in `structural_promotion_refusals` — the same
@@ -885,39 +1003,26 @@ def check_promotable(candidate: PromotionCandidate) -> tuple[PromotionRefusal, .
         refusals.append("instrument_outside_validated_universe")
 
     # Criterion 5 — "hold-out never evaluated, or evaluated more than once
-    # without a recorded access".
-    #
-    # ⚠ IMPLEMENTED STRICTER THAN THE LITERAL WORDING, deliberately. Read
-    # literally, "more than once" would let a SINGLE unrecorded evaluation
-    # pass — and a single unrecorded look at the hold-out is exactly the
-    # governance failure criterion 5 describes, just the first one. The rule
-    # applied is that every evaluation must have an access record.
-    if candidate.holdout_evaluations < 1:
-        refusals.append("holdout_never_evaluated")
-    elif candidate.recorded_accesses < candidate.holdout_evaluations:
-        refusals.append("holdout_accesses_unrecorded")
+    # without a recorded access", in `holdout_count_promotion_refusals` so the
+    # promotion transition applies the same single copy (#2639).
+    refusals.extend(
+        holdout_count_promotion_refusals(
+            holdout_evaluations=candidate.holdout_evaluations,
+            recorded_accesses=candidate.recorded_accesses,
+        )
+    )
 
-    # Criterion 6 — "DSR not computed, or computed on an undeclared trial
-    # count". Independent checks: a DSR with no trial count is as refused as no
-    # DSR at all, because the count is what the deflation divides by.
-    if result.deflated_sharpe is None:
-        refusals.append("deflated_sharpe_not_computed")
-    if result.trial_count is None:
-        refusals.append("trial_count_undeclared")
-    if result.deflated_sharpe is not None and (
-        result.deflated is None
-        or result.deflated.trial_register_version != TRIAL_REGISTER_VERSION
-        or result.deflated.declared_trials != TRIAL_REGISTER.declared_count
-    ):
-        refusals.append("trial_register_superseded")
-
-    # Criterion 3 — the effective sample size that criterion 6's deflation
-    # consumes. ⚠ Checked SEPARATELY from the DSR: a DSR present with no
-    # effective sample size is a DSR deflated on a nominal n, and criterion 3
-    # forbids reporting a nominal n anywhere. Stage 5e's block bootstrap fills
-    # it; until then this refusal fires on every result.
-    if result.metrics.effective_sample_size is None:
-        refusals.append("effective_sample_size_not_computed")
+    # Criteria 6 and 3, in `deflation_promotion_refusals` — the same single copy
+    # the promotion transition replays off the stored row (#2639), for the
+    # reason `structural_promotion_refusals` above is shared.
+    refusals.extend(
+        deflation_promotion_refusals(
+            deflated_sharpe=result.deflated_sharpe,
+            trial_count=result.trial_count,
+            deflated=result.deflated,
+            effective_sample_size=result.metrics.effective_sample_size,
+        )
+    )
 
     # §3.4 — the ambiguity arms. ⚠ NOT one of §6's five bullets; its source is
     # §3.4's "the result is `ambiguity_material` and is not promotable", and it
@@ -935,19 +1040,9 @@ def check_promotable(candidate: PromotionCandidate) -> tuple[PromotionRefusal, .
     if not candidate.quarantine_arms_compared:
         refusals.append("quarantine_arms_not_compared")
 
-    # §9 — the harness's own acceptance, read per result. ⚠ THE COHORT-LEVEL
-    # AND STRATEGY-LEVEL FAILURES ARE REPORTED SEPARATELY AND BOTH CAN FIRE:
-    # a cohort that shows edge invalidates the scale, and a Sharpe below the
-    # threshold is not evidence on any scale. Returning only the first would
-    # hide from an operator that one broken cohort is blocking every strategy.
-    control = result.synthetic_control
-    if control is None:
-        refusals.append("synthetic_control_not_run")
-    else:
-        if not control.mean_return_ci_contains_zero:
-            refusals.append("synthetic_control_cohort_shows_edge")
-        if not control.sharpe_exceeds_cohort:
-            refusals.append("synthetic_control_sharpe_below_cohort")
+    # §9 — the harness's own acceptance, read per result. Shared with the
+    # transition's replay (#2639); the two-code split is argued there.
+    refusals.extend(synthetic_control_promotion_refusals(result.synthetic_control))
 
     # #2505 — positive mean return is not enough. The candidate must have a
     # positive clustered lower bound, measured tails/concentration, complete
@@ -1032,8 +1127,12 @@ __all__ = [
     "StrategyResult",
     "UniverseBasis",
     "check_promotable",
+    "deflation_promotion_refusals",
+    "holdout_count_promotion_refusals",
     "is_promotable",
+    "purpose_promotion_refusals",
     "structural_promotion_refusals",
+    "synthetic_control_promotion_refusals",
     "namespace_for_bar",
     "namespace_for_position",
     "namespace_for_signal",

--- a/docs/proposals/ta/2026-08-13-promotion-replay-remainder.md
+++ b/docs/proposals/ta/2026-08-13-promotion-replay-remainder.md
@@ -1,0 +1,258 @@
+# Closing the promotion transition's remaining replay gaps (#2639)
+
+Follow-up to #2625, which declared `REPLAY_TEMPORAL_POLICY` and closed the universe,
+ambiguity and structural-stamp halves. `unenforced_candidate_fields()` still returns
+`{holdout_evaluations, recorded_accesses, quarantine_arms_compared}`, and the `result`
+entry carries a `⚠ PARTIAL` — the deflation, effective-sample-size and synthetic-control
+clauses are columns on `strategy_results_store` and are not replayed.
+
+Target: `unenforced_candidate_fields() == frozenset()` and the PARTIAL note gone.
+
+⚠ **No migration.** The first draft of this spec proposed one (`strategy_result_quarantine_pair`,
+a per-result pointer at the sibling arm). Codex checkpoint 1 killed it — see Half B.
+
+## Measured first (dev, at branch point `36c97f18`, 2026-08-13)
+
+```
+strategy_results_store                                        324
+  namespace = 'hold_out'                                      300
+  namespace = 'in_sample'                                      24
+  purpose   = 'harness_validation'                            324
+  quarantine_arm = 'masked' / 'admitted'                  162 / 162
+  with a stored flipped-arm sibling                           324
+strategy_holdout_accesses                                     304
+  access_kind = 'evaluate'                                    300
+strategy_promotions                                             0
+strategy_promotion_results                                      0
+strategy_result_universe                                        0
+strategy_result_ambiguity                                       0
+distinct (strategy_id, strategy_version)                        8
+rows with dsr_model_id                                        268
+rows with effective_sample_size                               324
+rows with synthetic_control_model_id                            0
+```
+
+Per `(strategy_id, strategy_version)`, hold-out rows and `evaluate` accesses are equal on
+all eight (52/52, 32/32, 32/32, 52/52, 52/52, 32/32, 16/16, 32/32). So criterion 5's count
+clause passes today on every strategy version, and every result still refuses on
+`universe_record_missing`, `ambiguity_verdict_unrecorded`, `synthetic_control_not_run`,
+`harness_validation_only` and the structural stamps. Nothing is promotable and nothing
+becomes promotable here — this is enforcement, not admission.
+
+**Full-population reconstruction check.** All 324 rows rebuild through
+`result_ledger._result_from_row` without raising (324 ok / 0 failed), which is the read
+path Half C adds. Re-derive with the probe in `scripts/verify_2639_promotion_replay.py`.
+
+## Half A — the hold-out counts. The temporal rule, decided.
+
+⚠ **Correcting the inherited premise first.** #2625's policy entry says re-reading is safe
+and that is right: `result_ledger.holdout_access_counts` (`:1441`) is two pure `COUNT`
+statements, and the function that RECORDS is `quarantine_arms_compared` (`:1547`), only on
+a `hold_out` identity. Re-verified at `36c97f18`.
+
+**Decision: `today`.** Both counts are read live at the transition, not frozen at result
+time.
+
+The argument is not preference, it is that **frozen defeats criterion 5**. The counts are
+scoped to `(strategy_id, strategy_version)`, so a count frozen when result #1 was written
+records the hold-out looks that had happened *by then*. A strategy that later evaluates its
+hold-out four more times without recording an access would replay result #1 as `(1, 1)` —
+consistent, promotable, and blind to precisely the repeated unlogged look criterion 5
+exists to catch. The retroactivity that #2621 rejected for the universe is the desired
+behaviour here: a later unrecorded evaluation SHOULD block a promotion that has not
+happened yet.
+
+The transition is also the counts' natural scope: `promote_strategy` promotes a
+`(strategy_id, strategy_version)`, which is exactly what the counts are keyed on.
+
+⚠ **Three consequences, stated rather than discovered later.**
+
+- **The clause is strategy-version-wide, not per-result.** One unrecorded hold-out
+  evaluation blocks promotion of *every* result of that version, across namespaces, scopes
+  and windows. That is `check_promotable`'s own behaviour — the field is on
+  `PromotionCandidate`, not on `StrategyResult` — and the transition inherits it rather than
+  inventing it.
+- **The rule heals as well as blocks.** A missing access recorded later, or a hold-out
+  evaluation that arrives after a version had none, moves the answer from refuse to pass.
+  Criterion 5 asks that every evaluation carry a record; it does not ask when the record was
+  written.
+- **Reading it live changes the answer as accesses are inserted, not only as evaluations
+  are.** Both sides move.
+
+### This widens the `today` restriction, deliberately and narrowly
+
+`REPLAY_TEMPORAL_POLICY`'s current rule is that `today` is legitimate only where the stored
+record "DECLARES a validity window or is explicitly supersedable", and
+`TestTodayIsRestricted` pins `today == {"promotion_evidence"}`. That wording named the two
+shapes that existed; its actual content is that **a today-check must name what can change
+the answer, and that change must be one the criterion wants to invalidate on.** What it
+guards against is an *undeclared* freshness rule.
+
+Three qualifying shapes, not two:
+
+1. the record declares its own validity window (`promotion_evidence`:
+   `cost_observed_on` / `cost_valid_through`);
+2. the record is explicitly supersedable;
+3. **the record is an append-only AUDIT LOG, the clause is a comparison between that log
+   and the rows it audits, and the criterion the clause serves requires the comparison to
+   be current** (`holdout_evaluations` / `recorded_accesses` against
+   `strategy_holdout_accesses`).
+
+⚠ Shape 3 is written this narrowly on purpose. "A ledger of our own conduct" — the first
+draft's wording — would admit any mutable operational counter, which is most of the
+database. The three clauses together are the restriction: an audit log, a
+log-versus-audited-rows comparison, and a criterion that asks for currency.
+`TestTodayIsRestricted` still pins the exact member set, so a fourth today-check fails the
+test whatever it claims about itself.
+
+### Snapshot: what is and is not guaranteed
+
+Two `COUNT`s as two statements is two READ COMMITTED snapshots, so a concurrent
+`store_holdout_result` between them can return a pair that never simultaneously existed —
+and the direction that matters is `accesses < evaluations`, a false
+`holdout_accesses_unrecorded`. Fixed: one statement, two scalar subqueries, one snapshot.
+
+⚠ **That does not make the counts atomic with the promotion INSERT, and this spec does not
+claim it does.** `_lock_strategy` takes an advisory lock keyed on the strategy version;
+`store_holdout_result` does not take it, so a hold-out write may commit after the count
+statement and before the promotion row lands. The promotion is then decided on counts that
+were true when read. Closing that would mean putting the same advisory lock on the hold-out
+writers, which is a change to the write path and outside this ticket — recorded on #2639 as
+a known bound rather than silently assumed away.
+
+## Half B — criterion 9's quarantine comparison
+
+**Re-derived from the two result rows, not from a new record. No migration.**
+
+Half C already rebuilds the pinned row through `_result_from_row`, which yields its
+`ResultIdentity`. The sibling arm's `result_version` is that identity with
+`quarantine_arm` flipped — a pure hash, the same derivation
+`result_ledger.quarantine_arms_compared` performs — so the presence of both arms is one
+`COUNT` over `strategy_results_store` and costs nothing extra.
+
+⚠ **Why not the pointer table the ticket proposed.** A per-result
+`sibling_result_id` lets the WRITER choose which sibling to name. The transition would then
+verify the sibling it was handed, not that the named sibling is the only one the identity
+admits — strictly weaker than today's derivation, which cannot be pointed anywhere else
+because the version is a hash of the identity. Codex checkpoint 1 raised this along with
+asymmetric pointers, multiple candidate siblings, and the fact that the record would
+witness a pointer insertion rather than a pair write. Dropping the table removes all four.
+
+⚠ **The transition does NOT call `result_ledger.quarantine_arms_compared`.** On a
+`hold_out` identity that function records a `read` access, and 300 of 324 stored rows are
+`hold_out`, so a transition calling it would write one audit row per promotion attempt into
+the log it is auditing — the prevention-log rule *"it must not ask the database a question
+it is the answer to"* (`docs/review-prevention-log.md`, the `_candidate` entry), one layer
+further out. Instead the counting half is extracted into `quarantine_arm_pair_present`,
+which records nothing, and `quarantine_arms_compared` records and then calls it. One copy
+of the count; two doors, and the door that records stays the one criterion 5 governs.
+Promotion is not an evaluation of the withheld side.
+
+⚠ **Rule: `frozen`.** Both arms' rows are records written at result time, and
+`strategy_results_store` has no delete path — so the derived answer is monotone, moving
+only from "one arm" to "both arms" when a sibling with the identical identity-minus-arm is
+stored. Nothing about today's world enters it.
+
+Refusal code: `quarantine_arms_not_compared`, the gate's own. No new code, because there is
+no new record whose absence needs its own name.
+
+## Half C — the row's own remaining clauses
+
+`check_promotable`'s purpose / criterion 6 / criterion 3 / §9 blocks read `result.purpose`,
+`result.deflated_sharpe`, `result.trial_count`, `result.deflated`,
+`result.metrics.effective_sample_size` and `result.synthetic_control`. Every one is a column
+on the row the transition already pins.
+
+Three pure functions extracted from `check_promotable` **and called by it**, so there is one
+copy — the `structural_promotion_refusals` move:
+
+- `purpose_promotion_refusals(purpose)` → `harness_validation_only`
+- `deflation_promotion_refusals(*, deflated_sharpe, trial_count, deflated, effective_sample_size)`
+  → `deflated_sharpe_not_computed`, `trial_count_undeclared`, `trial_register_superseded`,
+  `effective_sample_size_not_computed`
+- `synthetic_control_promotion_refusals(control)` → `synthetic_control_not_run`,
+  `synthetic_control_cohort_shows_edge`, `synthetic_control_sharpe_below_cohort`
+
+⚠ Three functions and not one, because the blocks are **not contiguous** in
+`check_promotable` — the universe and hold-out clauses sit after purpose, and §3.4's
+ambiguity and criterion 9's sit between deflation and §9. Merging them would reorder the
+returned refusals, and the order is the spec's.
+
+⚠ Each helper keeps `check_promotable`'s body VERBATIM: three independent `if`s in the
+deflation helper (never `elif`, never an early return), `trial_register_superseded` guarded
+on `deflated_sharpe is not None` and not on `deflated`, and the two §9 codes independent so
+both can fire.
+
+### The row's own `purpose` is a second axis, and it is not currently checked
+
+`promote_strategy` refuses on `registered_strategy_purpose(strategy_id)` — the MANIFEST's
+purpose. The row carries its own stamped `purpose`, and nothing compares them. Measured: all
+324 stored rows are `harness_validation`, and all four registered strategies are
+`harness_validation` today, so they agree. The moment a strategy's manifest entry becomes
+`capital_candidate`, its existing `harness_validation`-stamped rows become pinnable and the
+transition would not refuse them, while `check_promotable` would. Same shape as the seven
+M9 defects: the control exists on a path the decision does not take. Closed by replaying the
+row's own purpose.
+
+### The read path
+
+`result_ledger.stored_result_promotion_refusals(conn, result_id)` selects `_RESULT_COLUMNS`,
+rebuilds through the existing `_result_from_row`, and returns **only refusal codes** — the
+purpose, deflation and §9 blocks, in `check_promotable`'s order, plus the arm-pair clause
+from Half B.
+
+⚠ **It returns codes and never a `StrategyResult`, deliberately.** A public
+`load_result_by_id` would be a new unaudited door to the withheld side —
+`read_holdout_results` is the sanctioned one and it records the access first. Keeping the
+withheld numbers inside `result_ledger` and handing the transition a refusal list means the
+new function cannot become that door.
+
+⚠ Reading the row's own columns for a result the caller has already pinned is not a new
+governance cost: `promote_strategy` already selects six columns off these rows, and
+`holdout_access_counts` already counts them, neither recording an access.
+
+⚠ **`_result_from_row` RAISES where `check_promotable` refuses**, on three states: a
+`result_version` that does not match the identity it carries, a `synthetic_control_passed`
+that disagrees with its own stored inputs, and a partially-written DSR or control block.
+That is the `load_result_ambiguity` precedent — corruption is an integrity failure to
+surface loudly, not a gate verdict to report politely — and it carries the same named cost:
+the raise aborts before the other refusals are gathered, so it masks them. Verified on the
+full population: 324/324 rows reconstruct, so no stored row takes that path today.
+
+⚠ **The transition keeps its own read of the structural stamps and does NOT source them
+from the rebuilt object.** `_result_from_row` coerces `carry_unmodelled` with `bool(...)`,
+so a NULL would read as *modelled* — fail-open on a Tier 1 refusal. The transition's
+existing read coerces NULL to `True`. Both columns are `NOT NULL` in `sql/262` and
+`sql/335`, so this is defence in depth, but the failure direction is silent and the two
+coercions must not be collapsed onto the weaker one.
+
+### `result` stays `frozen`
+
+`trial_register_superseded` compares the row's stored `trial_register_version` /
+`declared_trials` against the CURRENT `TRIAL_REGISTER_VERSION` /
+`TRIAL_REGISTER.declared_count`. That is a frozen field compared against a code constant,
+which the `promotion_evidence` entry already declares does not make a field `today` — what
+makes that one `today` is that its replay depends on the current DATE. A register
+supersession bumping a constant and invalidating older results is the deliberate
+supersession behaviour `check_promotable` already has.
+
+⚠ `result` is a coarse policy key — one field carrying eight clauses. #2625 chose to key on
+`PromotionCandidate` fields because that is the structural shape a new gate input arrives
+as, and that stands. The mitigation is that the entry's reason now enumerates the clauses
+and says which function replays each, so "the field is replayed" is checkable rather than
+asserted.
+
+## Acceptance
+
+1. `unenforced_candidate_fields() == frozenset()`; `TestTheGapIsCounted` updated, not
+   deleted.
+2. The `result` entry's `⚠ PARTIAL` note is gone.
+3. `TestTodayIsRestricted` pins `{promotion_evidence, holdout_evaluations,
+   recorded_accesses}` with each member's qualifying shape.
+4. `check_promotable`'s returned refusal tuples are unchanged by the extraction, pinned by
+   the existing `tests/test_strategy_result.py` suite plus a test asserting each helper's
+   output is a contiguous slice of the gate's.
+5. Full-population: every stored row reconstructs, and `promote_strategy` exercised against
+   dev inside a rolled-back transaction shows the new refusals firing.
+6. `docs/settled-decisions.md`'s #2625 entry amended: the gap set is empty and the `today`
+   restriction has three shapes.

--- a/docs/settled-decisions.md
+++ b/docs/settled-decisions.md
@@ -965,7 +965,7 @@ depends on either reading.
 
 ---
 
-## The promotion transition's replay policy (#2625, settled 2026-08-13)
+## The promotion transition's replay policy (#2625, settled 2026-08-13; completed by #2639)
 
 `check_promotable` runs at RESULT PRODUCTION. `promote_strategy` cannot call it
 — it has no `StrategyResult` to hand it, and two of the gate's inputs cost an
@@ -981,18 +981,27 @@ Three rules, and no fourth:
   from today's world. The default. Covers the universe (#2621), the §3.4
   ambiguity comparison (#2625) and the row's own structural stamps.
 - **`today`** — re-evaluated against the current world, and legitimate **ONLY**
-  where the stored record DECLARES a validity window or is explicitly
-  supersedable. Exactly one input qualifies: `promotion_evidence`, whose
-  `cost_observed_on` / `cost_valid_through` say when executable costs go stale.
-  A today-check on anything else is an undeclared freshness rule — the reason
-  #2621 froze the universe instead of re-loading it. **A test pins this set to
-  one member**, so a second today-check cannot be added quietly.
+  in one of **three declared shapes**. A today-check outside them is an
+  undeclared freshness rule — the reason #2621 froze the universe instead of
+  re-loading it. **A test pins the exact member set**, so a fourth cannot be
+  added quietly.
+  1. the record DECLARES its own validity window — `promotion_evidence`, whose
+     `cost_observed_on` / `cost_valid_through` say when executable costs go stale;
+  2. the record is explicitly supersedable;
+  3. **(#2639)** the record is an append-only AUDIT LOG, the clause is a
+     comparison between that log and the rows it audits, and the criterion the
+     clause serves requires the comparison to be CURRENT — criterion 5's
+     `holdout_evaluations` / `recorded_accesses` against
+     `strategy_holdout_accesses`. ⚠ Worded this narrowly on purpose: the draft
+     form "a ledger of our own conduct" would admit any mutable operational
+     counter, which is most of the database.
 - **`not_re_read`** — neither persisted nor re-derived. ⚠⚠ **THIS NAMES A GAP,
   NOT COVERAGE.** The transition does not enforce that clause at all and still
-  trusts a write-time verdict that died with `WrittenRow`. Currently
-  `holdout_evaluations`, `recorded_accesses` and `quarantine_arms_compared`;
-  `unenforced_candidate_fields()` returns the set and a test pins it so it
-  cannot grow unnoticed. Closing it is #2639.
+  trusts a write-time verdict that died with `WrittenRow`. ⚠ **The set is EMPTY
+  since #2639** and `unenforced_candidate_fields()` returns `frozenset()`; the
+  rule stays in the vocabulary so the next unclassifiable input has an honest
+  label to land on, and the assertion stays so a newly-classified-but-unwired
+  input fails a test rather than arriving as a clause nobody applies.
 
 The policy lives in `app/services/strategy_promotion_replay.py` with a reason on
 every entry. **Do not add an input to the transition without classifying it
@@ -1007,19 +1016,79 @@ second is false. Before #2625, `grep` for
 returned **nothing** — the stamps were persisted and never read, so Tier 1's
 refusals could all close and promotion still would not consult them.
 
-⚠ Why not just replay the whole gate: the only code that rebuilds a
-`StrategyResult` from the store is `result_ledger._result_from_row`, reachable
-only through `read_holdout_results`, which RECORDS an access before it reads.
-300 of the 324 stored results are `hold_out`. And the gate has no single as-of —
-some inputs are frozen and one is today, which one `check_promotable(candidate)`
-call cannot express.
+⚠ Why not just replay the whole gate: the gate has no single as-of — most
+inputs are frozen and three are today — which one `check_promotable(candidate)`
+call cannot express. #2639 does rebuild the row through
+`result_ledger._result_from_row`, but behind
+`stored_result_promotion_refusals`, which returns **refusal codes and never a
+`StrategyResult`**: a public `load_result_by_id` would be a new unaudited door
+to the withheld side, and 300 of the 324 stored results are `hold_out`.
+`read_holdout_results` stays the sanctioned door and still records first.
+
+### What #2639 added (2026-08-13)
+
+- **Criterion 5's two counts replay against TODAY**, because **frozen defeats
+  the criterion**: both counts are scoped to `(strategy_id, strategy_version)`,
+  so a pair frozen at result time is blind to a later unrecorded look at the
+  same version's hold-out — which is the leak criterion 5 exists to catch. The
+  clause is strategy-version-wide (one unrecorded evaluation blocks every result
+  of that version) and it heals as well as blocks. `holdout_access_counts` is
+  now ONE statement with two scalar subqueries, so the pair comes from one
+  snapshot. ⚠ It is **not** atomic with the promotion INSERT — the hold-out
+  writers do not take `promote_strategy`'s advisory lock — and that bound is
+  stated rather than assumed away.
+- **Criterion 9's arm pair is RE-DERIVED from the identity hash**, not recorded.
+  `result_ledger.quarantine_arm_pair_present` does the count and records
+  nothing; `quarantine_arms_compared` records and then calls it, so the door
+  that writes a `read` access stays the one criterion 5 governs and the
+  transition does not write into the log it is auditing. ⚠ **A stored
+  `sibling_result_id` pointer was the first design and was killed at Codex
+  checkpoint 1**: a pointer is chosen by the writer and can name a compatible
+  row that is not the one the identity admits, whereas
+  `ResultIdentity.version` is a hash and admits exactly one sibling.
+- **The row's own purpose, deflation, effective-sample-size and §9 clauses**
+  replay through four pure functions — `purpose_promotion_refusals`,
+  `holdout_count_promotion_refusals`, `deflation_promotion_refusals`,
+  `synthetic_control_promotion_refusals` — which are the copies
+  `check_promotable` itself calls, the `structural_promotion_refusals` move.
+- ⚠ **The row's own `purpose` was a latent gap.** `promote_strategy` refuses on
+  `registered_strategy_purpose` — the MANIFEST's — and never compared it to the
+  row's stamp. Measured 2026-08-13: all 324 stored rows and all four registered
+  strategies are `harness_validation`, so they agree today; the moment a
+  manifest entry becomes `capital_candidate`, its older harness-stamped rows
+  become pinnable. Same M9 shape — the control exists on a path the decision
+  does not take.
+- ⚠ **`result` stays `frozen`.** `trial_register_superseded` compares a frozen
+  column against the CURRENT `TRIAL_REGISTER` constant; a frozen-field-versus-
+  constant comparison does not make a field `today` (what makes
+  `promotion_evidence` today is the current DATE).
+- ⚠ **The transition keeps its OWN read of the structural stamps.**
+  `_result_from_row` coerces `carry_unmodelled` with `bool(...)`, so a NULL
+  would read as *modelled* — fail-open on a Tier 1 refusal — while the
+  transition's read coerces NULL to `True`. Both columns are `NOT NULL`
+  (`sql/262`, `sql/335`), so this is defence in depth; the two coercions must
+  not be collapsed onto the weaker one.
+- ⚠ **A corrupt row RAISES rather than refusing**, per `load_result_ambiguity`'s
+  precedent, which aborts before the remaining refusals are gathered and so
+  MASKS them. Verified on the full population: 324 of 324 rows reconstruct.
 
 **Blast radius when settled:** `strategy_promotions` held **0 rows** and
 `strategy_result_ambiguity` **0 rows** against 324 results (measured 2026-08-13),
 so all 324 refuse `ambiguity_verdict_unrecorded` and nothing existing was
 promotable to begin with.
 
-**Refs** #2625, #2621, #2505, #2599, #2437.
+**Blast radius of #2639**, measured on dev over the full population with
+`PYTHONPATH=. uv run python scripts/verify_2639_promotion_replay.py --all`:
+324 of 324 rows reconstruct; the new row-level census is 324
+`harness_validation_only`, 324 `synthetic_control_not_run`, 204
+`trial_register_superseded`, 56 `deflated_sharpe_not_computed`, 56
+`trial_count_undeclared`, and **0 `quarantine_arms_not_compared`** — every row's
+flipped-arm sibling is stored. **0 of 324 rows become less refused**, which is
+the direction that matters: a replay closing a gap must only ever ADD refusals.
+Criterion 5's clause passes on all eight `(strategy_id, strategy_version)` pairs
+(evaluations equal accesses on every one).
+
+**Refs** #2639, #2625, #2621, #2505, #2599, #2437.
 
 ---
 

--- a/scripts/verify_2639_promotion_replay.py
+++ b/scripts/verify_2639_promotion_replay.py
@@ -1,0 +1,181 @@
+"""Full-population verification of #2639's promotion-transition replays.
+
+    PYTHONPATH=. uv run python scripts/verify_2639_promotion_replay.py --all
+
+⚠ READ-ONLY. Every arm is a SELECT; nothing is written and no transaction is
+opened, so this cannot alter dev state. The write path — ``promote_strategy``
+raising on each replayed refusal — is exercised in
+``tests/test_strategy_control_plane.py::test_promotion_replays_the_rows_own_clauses_and_the_holdout_counts``
+against the test database, which is where a fixture may legitimately promote.
+It CANNOT be exercised against dev's own rows: all four registered strategies
+are ``harness_validation``, and ``promote_strategy`` refuses those at the
+manifest check before any result is read (arm R4 asserts exactly that).
+
+⚠ NEVER PIPE THIS INTO ``head``/``tail``. A pipe returns the pipe's status, so a
+failure reads as success, and it buffers the progress lines (`.claude/CLAUDE.md`).
+Redirect to a file and read the file.
+
+THE ARMS
+--------
+``--reconstruct``  R1. Every stored row rebuilds through ``_result_from_row``,
+                   which is the read path ``stored_result_promotion_refusals``
+                   depends on. A row that does not reconstruct RAISES at the
+                   transition and masks the other refusals, so "how many" is the
+                   number that matters and a sample cannot answer it.
+``--refusals``     R2. The refusal census the transition would now produce, over
+                   the FULL population. ⚠ The point is the direction: this must
+                   only ever ADD refusals to rows that already refuse. A row
+                   that this makes promotable would be a fail-open change.
+``--counts``       R3. Criterion 5's two counts per ``(strategy_id,
+                   strategy_version)`` — the pair the transition now reads live.
+``--promote``      R4. Asserts the dev population cannot reach the result-level
+                   replays at all, and says why.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+
+import psycopg
+
+from app.config import settings
+from app.services import result_ledger
+from app.services.strategy_control_plane import (
+    StrategyControlError,
+    promote_strategy,
+    registered_strategy_purpose,
+)
+from app.services.strategy_result import holdout_count_promotion_refusals
+
+
+def _connect() -> psycopg.Connection[tuple]:
+    return psycopg.connect(settings.database_url)
+
+
+def _result_ids(conn: psycopg.Connection[tuple]) -> list[int]:
+    return [int(row[0]) for row in conn.execute("SELECT result_id FROM strategy_results_store ORDER BY result_id")]
+
+
+def reconstruct(conn: psycopg.Connection[tuple]) -> bool:
+    print("R1 — every stored row reconstructs through _result_from_row")
+    ids = _result_ids(conn)
+    failures: dict[str, list[int]] = collections.defaultdict(list)
+    for result_id in ids:
+        row = conn.execute(result_ledger._SELECT_RESULT_BY_ID, {"result_id": result_id}).fetchone()
+        assert row is not None
+        try:
+            result_ledger._result_from_row(row)
+        except Exception as exc:  # noqa: BLE001 - the census is the point
+            failures[f"{type(exc).__name__}: {exc}"[:160]].append(result_id)
+    ok = len(ids) - sum(len(v) for v in failures.values())
+    print(f"    rows {len(ids)}  reconstructed {ok}  failed {sum(len(v) for v in failures.values())}")
+    for message, bad in failures.items():
+        print(f"      {len(bad):5}  {message}  e.g. result_id={bad[0]}")
+    return not failures
+
+
+def refusals(conn: psycopg.Connection[tuple]) -> bool:
+    print("R2 — the transition's row-level refusal census, full population")
+    ids = _result_ids(conn)
+    census: collections.Counter[str] = collections.Counter()
+    clean = 0
+    for result_id in ids:
+        codes = result_ledger.stored_result_promotion_refusals(conn, result_id)
+        census.update(codes)
+        if not codes:
+            clean += 1
+    print(f"    rows {len(ids)}")
+    for code, count in sorted(census.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"      {count:5}  {code}")
+    print(f"    rows this replay would NOT refuse: {clean}")
+    # ⚠ Not an acceptance on `clean == 0`: a clean row here is not promotable,
+    # because the structural stamps, the frozen universe and ambiguity records
+    # and the #2505 evidence are checked separately by the transition. The
+    # assertion is that this arm RAN over every row, which the count above says.
+    return True
+
+
+def counts(conn: psycopg.Connection[tuple]) -> bool:
+    print("R3 — criterion 5's two counts per (strategy_id, strategy_version)")
+    versions = conn.execute(
+        "SELECT DISTINCT strategy_id, strategy_version FROM strategy_results_store ORDER BY 1, 2"
+    ).fetchall()
+    ok = True
+    for strategy_id, strategy_version in versions:
+        pair = result_ledger.holdout_access_counts(conn, str(strategy_id), str(strategy_version))
+        codes = holdout_count_promotion_refusals(
+            holdout_evaluations=pair.holdout_evaluations,
+            recorded_accesses=pair.recorded_accesses,
+        )
+        print(
+            f"    {strategy_id:36} {strategy_version:32} "
+            f"evaluations={pair.holdout_evaluations:4} accesses={pair.recorded_accesses:4} "
+            f"{'->  ' + ', '.join(codes) if codes else '->  (clause passes)'}"
+        )
+        ok = ok and pair.recorded_accesses >= pair.holdout_evaluations
+    return ok
+
+
+def promote(conn: psycopg.Connection[tuple]) -> bool:
+    """R4 — the dev population cannot reach the result-level replays, and why.
+
+    ⚠ This is a NEGATIVE result reported rather than a gap papered over. Every
+    registered strategy is ``harness_validation``, so ``promote_strategy``
+    refuses before it reads a result. Asserting that keeps the reason visible:
+    if a manifest entry later becomes ``capital_candidate``, this arm changes
+    its message and the row-level replays become reachable on dev.
+    """
+    print("R4 — promote_strategy against the dev population")
+    versions = conn.execute(
+        "SELECT DISTINCT strategy_id, strategy_version FROM strategy_results_store ORDER BY 1, 2"
+    ).fetchall()
+    ok = True
+    for strategy_id, strategy_version in versions:
+        purpose = registered_strategy_purpose(str(strategy_id))
+        try:
+            promote_strategy(
+                conn,
+                strategy_id=str(strategy_id),
+                strategy_version=str(strategy_version),
+                to_stage="historical_validated",
+                promoted_by="scripts/verify_2639_promotion_replay.py",
+                reason="verification probe — expected to refuse",
+                evidence_ref="verify:2639",
+                result_ids=(),
+            )
+        except StrategyControlError as exc:
+            print(f"    {strategy_id:36} purpose={purpose!s:20} refused: {exc}")
+            continue
+        print(f"    {strategy_id:36} purpose={purpose!s:20} ⚠ DID NOT REFUSE")
+        ok = False
+    return ok
+
+
+_ARMS = {"reconstruct": reconstruct, "refusals": refusals, "counts": counts, "promote": promote}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in _ARMS:
+        parser.add_argument(f"--{name}", action="store_true")
+    parser.add_argument("--all", action="store_true")
+    args = parser.parse_args()
+    selected = [name for name in _ARMS if getattr(args, name) or args.all]
+    if not selected:
+        parser.error("pick at least one arm, or --all")
+    # ⚠ AUTOCOMMIT, and the R4 arm is the reason: promote_strategy is expected
+    # to raise, and a raise inside an open transaction would leave the session
+    # in an aborted state for the arms after it. Nothing here writes, so
+    # autocommit costs nothing.
+    with _connect() as conn:
+        conn.autocommit = True
+        results = {name: _ARMS[name](conn) for name in selected}
+    print()
+    for name, ok in results.items():
+        print(f"{'PASS' if ok else 'FAIL'}  {name}")
+    return 0 if all(results.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_2639_promotion_replay.py
+++ b/scripts/verify_2639_promotion_replay.py
@@ -17,11 +17,10 @@ Redirect to a file and read the file.
 
 THE ARMS
 --------
-``--reconstruct``  R1. Every stored row rebuilds through ``_result_from_row``,
-                   which is the read path ``stored_result_promotion_refusals``
-                   depends on. A row that does not reconstruct RAISES at the
-                   transition and masks the other refusals, so "how many" is the
-                   number that matters and a sample cannot answer it.
+``--reconstruct``  R1. Every stored row survives ``stored_result_promotion_refusals``
+                   without raising. A row that does not reconstruct RAISES at
+                   the transition and masks the other refusals, so "how many" is
+                   the number that matters and a sample cannot answer it.
 ``--refusals``     R2. The refusal census the transition would now produce, over
                    the FULL population. ⚠ The point is the direction: this must
                    only ever ADD refusals to rows that already refuse. A row
@@ -40,7 +39,7 @@ import collections
 import psycopg
 
 from app.config import settings
-from app.services import result_ledger
+from app.services.result_ledger import holdout_access_counts, stored_result_promotion_refusals
 from app.services.strategy_control_plane import (
     StrategyControlError,
     promote_strategy,
@@ -58,18 +57,25 @@ def _result_ids(conn: psycopg.Connection[tuple]) -> list[int]:
 
 
 def reconstruct(conn: psycopg.Connection[tuple]) -> bool:
-    print("R1 — every stored row reconstructs through _result_from_row")
+    """R1 — every stored row survives the transition's own read path.
+
+    ⚠ GOES THROUGH THE PUBLIC ``stored_result_promotion_refusals`` RATHER THAN
+    ``_result_from_row``, and not only to avoid reaching into a private name.
+    The failure this arm is looking for is a row that RAISES at the transition
+    and so masks the other refusals, and the only faithful way to ask that is to
+    call the thing the transition calls. Reconstruction is what raises inside
+    it, so a raise here is a reconstruction failure by construction.
+    """
+    print("R1 — every stored row survives stored_result_promotion_refusals without raising")
     ids = _result_ids(conn)
     failures: dict[str, list[int]] = collections.defaultdict(list)
     for result_id in ids:
-        row = conn.execute(result_ledger._SELECT_RESULT_BY_ID, {"result_id": result_id}).fetchone()
-        assert row is not None
         try:
-            result_ledger._result_from_row(row)
+            stored_result_promotion_refusals(conn, result_id)
         except Exception as exc:  # noqa: BLE001 - the census is the point
             failures[f"{type(exc).__name__}: {exc}"[:160]].append(result_id)
     ok = len(ids) - sum(len(v) for v in failures.values())
-    print(f"    rows {len(ids)}  reconstructed {ok}  failed {sum(len(v) for v in failures.values())}")
+    print(f"    rows {len(ids)}  clean read {ok}  raised {sum(len(v) for v in failures.values())}")
     for message, bad in failures.items():
         print(f"      {len(bad):5}  {message}  e.g. result_id={bad[0]}")
     return not failures
@@ -81,7 +87,7 @@ def refusals(conn: psycopg.Connection[tuple]) -> bool:
     census: collections.Counter[str] = collections.Counter()
     clean = 0
     for result_id in ids:
-        codes = result_ledger.stored_result_promotion_refusals(conn, result_id)
+        codes = stored_result_promotion_refusals(conn, result_id)
         census.update(codes)
         if not codes:
             clean += 1
@@ -103,7 +109,7 @@ def counts(conn: psycopg.Connection[tuple]) -> bool:
     ).fetchall()
     ok = True
     for strategy_id, strategy_version in versions:
-        pair = result_ledger.holdout_access_counts(conn, str(strategy_id), str(strategy_version))
+        pair = holdout_access_counts(conn, str(strategy_id), str(strategy_version))
         codes = holdout_count_promotion_refusals(
             holdout_evaluations=pair.holdout_evaluations,
             recorded_accesses=pair.recorded_accesses,

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -12,7 +12,11 @@ import pytest
 
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
-from app.services.result_ledger import store_in_sample_result
+from app.services.result_ledger import (
+    store_holdout_result,
+    store_in_sample_arm_pair,
+    store_in_sample_result,
+)
 from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
 from app.services.strategy_control_plane import (
     StrategyControlError,
@@ -42,13 +46,21 @@ from app.services.strategy_promotion_evidence import (
     RecentYearEvidence,
 )
 from app.services.strategy_promotion_evidence_store import store_promotion_evidence
+from app.services.strategy_result import StrategyResult
 from app.services.strategy_result_ambiguity import (
     AMBIGUITY_RULE_VERSION,
     AmbiguityRecord,
     store_result_ambiguity,
 )
 from app.services.strategy_result_universe import ResultUniverseRecord, store_result_universe
-from tests.test_result_ledger import build_metrics, build_result
+from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
+from tests.test_result_ledger import (
+    BOOTSTRAP_BLOCK,
+    build_control,
+    build_deflated,
+    build_metrics,
+    build_result,
+)
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("registered_strategy_test_candidates")]
 
@@ -168,6 +180,109 @@ _PROMOTABLE_STAMPS: dict[str, Any] = {
     "carry_unmodelled": False,
     "fx_unmodelled": False,
 }
+
+
+def _promotable_row(**overrides: Any) -> StrategyResult:
+    """A row that clears the clauses #2639 taught the transition to replay.
+
+    ⚠ THE OPT-IN GOT WIDER, and every part of it is a real refusal the shared
+    helpers now apply at the transition rather than only at result production:
+
+    - the DSR must name TODAY's register — ``build_deflated`` defaults to
+      ``declared_trials=11`` under ``trial-register-2026-08-07``, both
+      superseded, which is ``trial_register_superseded``;
+    - the criterion-3 block must be present, or ``effective_sample_size_not_computed``;
+    - §9's control must clear BOTH thresholds — ``build_control`` deliberately
+      builds one that fails, because that is the shape today's pipeline
+      produces, so a promotable fixture has to move the cohort side. ⚠ Only the
+      COHORT side: ``StrategyResult`` binds the two strategy-side figures to
+      ``metrics``.
+    """
+    deflated = build_deflated(
+        declared_trials=TRIAL_REGISTER.declared_count,
+        trial_register_version=TRIAL_REGISTER_VERSION,
+    )
+    metrics = build_metrics(profit_factor=1.2, **BOOTSTRAP_BLOCK)
+    base: dict[str, Any] = {
+        "metrics": metrics,
+        "deflated": deflated,
+        "trial_count": deflated.declared_trials,
+        "deflated_sharpe": Decimal(repr(deflated.deflated_sharpe)),
+        "synthetic_control": build_control(
+            metrics,
+            mean_return_ci_low_pct=-1.0,
+            mean_return_ci_high_pct=1.0,
+            cohort_sharpe_threshold=-9.0,
+        ),
+        "evaluated_instrument_count": 3,
+        **_PROMOTABLE_STAMPS,
+    }
+    base.update(overrides)
+    return build_result(**base)
+
+
+def _promotable_pair(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+    ambiguity_arm: str = "worst_case",
+    **overrides: Any,
+) -> int:
+    """Store BOTH quarantine arms and return the masked one's ``result_id``.
+
+    ⚠ #2639 — criterion 9 is satisfied by the COMPARISON, and the transition now
+    re-derives it from the flipped-arm identity hash. A lone arm refuses
+    ``quarantine_arms_not_compared`` however clean it is otherwise, so a fixture
+    that means to promote must write the pair.
+
+    ⚠ ``result_scope="portfolio"`` BY DEFAULT, and it is load-bearing rather
+    than arbitrary: the tests that call this also write single-armed rows to
+    isolate a refusal, and neither the metrics, the DSR nor the control is part
+    of ``ResultIdentity`` — so a pair sharing the callers' arms would hash to an
+    existing ``result_version`` and hit ``strategy_results_unique``. The scope
+    is an identity member and separates them.
+    """
+    shared: dict[str, Any] = {
+        "strategy_id": strategy_id,
+        "strategy_version": strategy_version,
+        "namespace": "in_sample",
+        "result_scope": "portfolio",
+        "ambiguity_arm": ambiguity_arm,
+        **overrides,
+    }
+    masked = _promotable_row(quarantine_arm="masked", **shared)
+    admitted = _promotable_row(quarantine_arm="admitted", **shared)
+    masked_id, _ = store_in_sample_arm_pair(conn, masked, admitted)
+    return masked_id
+
+
+def _recorded_holdout_evaluation(
+    conn: psycopg.Connection[Any],
+    *,
+    strategy_id: str,
+    strategy_version: str,
+) -> None:
+    """One hold-out evaluation WITH its ``evaluate`` access, for criterion 5.
+
+    ⚠ #2639 — the transition now reads ``holdout_access_counts`` live, so a
+    strategy version whose hold-out was never evaluated refuses
+    ``holdout_never_evaluated``. That is ``check_promotable``'s own rule; the
+    transition had simply never applied it. ``store_holdout_result`` writes the
+    access first because ``sql/264``'s trigger requires it.
+    """
+    store_holdout_result(
+        conn,
+        _promotable_row(
+            strategy_id=strategy_id,
+            strategy_version=strategy_version,
+            namespace="hold_out",
+            ambiguity_arm="best_case",
+            quarantine_arm="admitted",
+        ),
+        accessed_by="tests/test_strategy_control_plane.py",
+        purpose="#2639 criterion 5 fixture",
+    )
 
 
 def _instrument(conn: psycopg.Connection[Any], instrument_id: int = 2454001) -> None:
@@ -372,16 +487,17 @@ def test_historical_validation_requires_passing_edge_evidence(
             result_ids=(result_id,),
         )
 
-    passing_result = build_result(
+    # ⚠ The passing row also has to clear #2639's replays now — the arm pair,
+    # criterion 5's live counts, the DSR against today's register and §9's
+    # control. The failing rows above stay single-armed on purpose: they isolate
+    # the #2505 evidence refusal this test is about.
+    _recorded_holdout_evaluation(conn, strategy_id="S-GOV", strategy_version="v1")
+    passing_result_id = _promotable_pair(
+        conn,
         strategy_id="S-GOV",
         strategy_version="v1",
-        namespace="in_sample",
         ambiguity_arm="best_case",
-        metrics=build_metrics(profit_factor=1.2),
-        evaluated_instrument_count=3,
-        **_PROMOTABLE_STAMPS,
     )
-    passing_result_id = store_in_sample_result(conn, passing_result)
     _universe_record(conn, passing_result_id)
     _ambiguity_record(conn, passing_result_id)
     store_promotion_evidence(
@@ -474,8 +590,21 @@ def test_promotion_replays_the_frozen_universe_check(
     _universe_record(conn, mismatched_id, evaluated=frozenset({1, 2, 3}), universe=frozenset({1, 2, 3}))
     _refuses(mismatched_id, "evaluated_universe_count_mismatch")
 
-    # A consistent subset record plus passing evidence promotes.
-    passing_id = _result_id("best_case", "admitted")
+    # A consistent subset record plus passing evidence promotes. ⚠ The passing
+    # row must now also clear #2639's replays — the arm pair, criterion 5's
+    # counts, the DSR against today's register and §9's control — so it is built
+    # through `_promotable_pair` rather than the single-row `_result_id` above,
+    # which exists to isolate the universe refusals.
+    _recorded_holdout_evaluation(conn, strategy_id="S-GOV", strategy_version="v1")
+    passing_id = _promotable_pair(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        ambiguity_arm="best_case",
+        evaluated_instrument_count=2,
+    )
+    store_promotion_evidence(conn, result_id=passing_id, evidence=_passing_promotion_evidence())
+    _ambiguity_record(conn, passing_id)
     _universe_record(conn, passing_id, evaluated=frozenset({1, 2}), universe=frozenset({1, 2, 3}))
     promotion = promote_strategy(
         conn,
@@ -560,7 +689,15 @@ def test_promotion_replays_the_ambiguity_record_and_the_structural_stamps(
     # ⚠ Routed through the SHARED `structural_promotion_refusals`, so this also
     # pins that the transition and #2599's preregistration freeze read one copy
     # of the rule rather than two that can drift.
-    passing = _result_id("best_case", "admitted")
+    _recorded_holdout_evaluation(conn, strategy_id="S-GOV", strategy_version="v1")
+    passing = _promotable_pair(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        ambiguity_arm="best_case",
+    )
+    _universe_record(conn, passing)
+    store_promotion_evidence(conn, result_id=passing, evidence=_passing_promotion_evidence())
     _ambiguity_record(conn, passing)
     promotion = promote_strategy(
         conn,
@@ -570,6 +707,156 @@ def test_promotion_replays_the_ambiguity_record_and_the_structural_stamps(
         promoted_by="operator",
         reason="ambiguity and structural replays pass",
         evidence_ref="result:test-2625-passing",
+        result_ids=(passing,),
+    )
+    assert promotion.to_stage == "historical_validated"
+
+
+def test_promotion_replays_the_rows_own_clauses_and_the_holdout_counts(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """#2639 — the last inputs `promote_strategy` took on trust.
+
+    ⚠⚠ EVERY REFUSAL BELOW WAS ALREADY IN `check_promotable` AND THE TRANSITION
+    SIMPLY NEVER APPLIED IT. That is the #2621 defect surviving in the clauses
+    #2625 stopped short of: a result stamped `harness_validation`, carrying no
+    DSR, deflated against a superseded register, missing its criterion-3 sample
+    size, missing §9's control, missing criterion 9's second arm, or belonging
+    to a version whose hold-out was never evaluated, could all be pinned to a
+    promotion without the transition looking.
+
+    ⚠ The clean row is built ONCE and each case breaks exactly one thing, so a
+    refusal is attributable. ⚠ Each case carries its own
+    `input_rule_set_version` because neither the metrics, the DSR nor the
+    control is part of `ResultIdentity` — two cases differing only in those hash
+    to the SAME `result_version` and collide on `strategy_results_unique`.
+    """
+    conn = ebull_test_conn
+    promote_strategy(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        to_stage="research_candidate",
+        promoted_by="operator",
+        reason="register candidate",
+    )
+
+    def _records(result_id: int) -> int:
+        _universe_record(conn, result_id, evaluated=frozenset({1, 2, 3}))
+        _ambiguity_record(conn, result_id)
+        store_promotion_evidence(conn, result_id=result_id, evidence=_passing_promotion_evidence())
+        return result_id
+
+    def _refuses(result_id: int, code: str) -> None:
+        with pytest.raises(StrategyControlError, match=code):
+            promote_strategy(
+                conn,
+                strategy_id="S-GOV",
+                strategy_version="v1",
+                to_stage="historical_validated",
+                promoted_by="operator",
+                reason="the row's own clauses must refuse",
+                evidence_ref="result:test-2639",
+                result_ids=(result_id,),
+            )
+        assert current_stage(conn, "S-GOV", "v1") == "research_candidate"
+
+    # Criterion 9 — one arm is not a comparison, however clean the row is.
+    lone = _records(
+        store_in_sample_result(
+            conn,
+            _promotable_row(
+                strategy_id="S-GOV",
+                strategy_version="v1",
+                namespace="in_sample",
+                ambiguity_arm="worst_case",
+                quarantine_arm="masked",
+                input_rule_set_version="price-quarantine-v1+2639lone000",
+            ),
+        )
+    )
+    _refuses(lone, "quarantine_arms_not_compared")
+
+    # The row's OWN purpose, which the transition never read: it refuses on
+    # `registered_strategy_purpose` — the MANIFEST's — and S-GOV is a
+    # capital_candidate, so a harness-stamped row reached the gate untouched.
+    harness = _records(
+        _promotable_pair(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            ambiguity_arm="worst_case",
+            purpose="harness_validation",
+            input_rule_set_version="price-quarantine-v1+2639harness",
+        )
+    )
+    _refuses(harness, "harness_validation_only")
+
+    # Criterion 6 — deflated against a register that has since moved on.
+    superseded_dsr = build_deflated(
+        declared_trials=TRIAL_REGISTER.declared_count,
+        trial_register_version="trial-register-2026-08-07",
+    )
+    superseded = _records(
+        _promotable_pair(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            ambiguity_arm="best_case",
+            input_rule_set_version="price-quarantine-v1+2639stale00",
+            deflated=superseded_dsr,
+            trial_count=superseded_dsr.declared_trials,
+            deflated_sharpe=Decimal(repr(superseded_dsr.deflated_sharpe)),
+        )
+    )
+    _refuses(superseded, "trial_register_superseded")
+
+    # Criteria 6, 3 and §9 together — the shape today's pipeline writes.
+    bare = _records(
+        _promotable_pair(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            ambiguity_arm="best_case",
+            input_rule_set_version="price-quarantine-v1+2639bare000",
+            deflated=None,
+            trial_count=None,
+            deflated_sharpe=None,
+            metrics=build_metrics(profit_factor=1.2),
+            synthetic_control=None,
+        )
+    )
+    _refuses(bare, "deflated_sharpe_not_computed")
+    _refuses(bare, "effective_sample_size_not_computed")
+    _refuses(bare, "synthetic_control_not_run")
+
+    # Criterion 5 — read LIVE, so a version whose hold-out was never evaluated
+    # refuses even with every frozen record in place.
+    passing = _records(
+        _promotable_pair(
+            conn,
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            ambiguity_arm="worst_case",
+            input_rule_set_version="price-quarantine-v1+2639pass000",
+        )
+    )
+    _refuses(passing, "holdout_never_evaluated")
+
+    # ⚠⚠ THE SAME PINNED RESULT, UNCHANGED, NOW PROMOTES — because the count it
+    # depends on is a property of the STRATEGY VERSION and is read at the
+    # transition, not frozen into the row. That is the whole content of the
+    # `today` classification: a hold-out evaluation recorded afterwards moves
+    # the verdict, and so would an unrecorded one, in the other direction.
+    _recorded_holdout_evaluation(conn, strategy_id="S-GOV", strategy_version="v1")
+    promotion = promote_strategy(
+        conn,
+        strategy_id="S-GOV",
+        strategy_version="v1",
+        to_stage="historical_validated",
+        promoted_by="operator",
+        reason="every replayed clause passes",
+        evidence_ref="result:test-2639-passing",
         result_ids=(passing,),
     )
     assert promotion.to_stage == "historical_validated"

--- a/tests/test_strategy_promotion_replay.py
+++ b/tests/test_strategy_promotion_replay.py
@@ -63,26 +63,40 @@ class TestTodayIsRestricted:
         a future author cannot quietly add a second today-check.
         """
         today = {name for name, entry in REPLAY_TEMPORAL_POLICY.items() if entry.rule == "today"}
-        assert today == {"promotion_evidence"}, (
-            "a new input replays against TODAY — justify it by naming the validity window the stored record "
-            "declares (promotion_evidence declares cost_observed_on / cost_valid_through), or classify it frozen"
+        assert today == {
+            # shape 1 — the record declares its own validity window
+            # (cost_observed_on / cost_valid_through).
+            "promotion_evidence",
+            # shape 3 (#2639) — an append-only audit log, a clause comparing it
+            # against the rows it audits, and a criterion (5) that requires the
+            # comparison to be current. Frozen here would be blind to a later
+            # unrecorded look at the same version's hold-out.
+            "holdout_evaluations",
+            "recorded_accesses",
+        }, (
+            "a new input replays against TODAY — justify it under one of the three shapes in "
+            "app/services/strategy_promotion_replay.py's module docstring (a declared validity window, "
+            "explicit supersession, or an append-only audit log whose self-consistency is the clause), "
+            "or classify it frozen"
         )
 
 
 class TestTheGapIsCounted:
-    def test_the_unenforced_set_is_exactly_the_known_gap(self) -> None:
+    def test_the_unenforced_set_is_empty(self) -> None:
         """⚠⚠ NOT_RE_READ IS A GAP, NOT COVERAGE — and this pins its size.
 
-        These three inputs are neither persisted nor re-derived, so
-        ``promote_strategy`` still trusts a write-time verdict that died with
-        ``WrittenRow`` — the exact defect #2621 was filed about, surviving where
-        re-reading has a governance cost. The set is asserted rather than
-        described so that it cannot GROW unnoticed: a new unenforced input is a
-        test failure, and shrinking it is the follow-up work.
+        It was ``{holdout_evaluations, recorded_accesses,
+        quarantine_arms_compared}`` under #2625 and is EMPTY since #2639: the
+        counts replay against today's ledger, the arm pair is re-derived from the
+        identity hash, and the row's own clauses go through the same pure
+        functions ``check_promotable`` calls.
+
+        ⚠ The assertion stays after the set emptied, and that is the point — an
+        input added to ``PromotionCandidate`` and classified without being wired
+        lands in this set and fails HERE, rather than arriving as a gate clause
+        nobody applies. Edit it deliberately; do not delete it.
         """
-        assert unenforced_candidate_fields() == frozenset(
-            {"holdout_evaluations", "recorded_accesses", "quarantine_arms_compared"}
-        )
+        assert unenforced_candidate_fields() == frozenset()
 
     def test_every_unenforced_field_is_classified_not_re_read(self) -> None:
         # The two axes must agree: an input the transition does not replay is

--- a/tests/test_strategy_result.py
+++ b/tests/test_strategy_result.py
@@ -54,10 +54,14 @@ from app.services.strategy_result import (
     ResultIdentity,
     StrategyResult,
     check_promotable,
+    deflation_promotion_refusals,
+    holdout_count_promotion_refusals,
     is_promotable,
     namespace_for_bar,
     namespace_for_position,
     namespace_for_signal,
+    purpose_promotion_refusals,
+    synthetic_control_promotion_refusals,
 )
 from app.services.strategy_statistics import StrategyMetrics
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
@@ -1049,3 +1053,209 @@ class TestPromotionGateReportsEverything:
         before = replace(candidate)
         check_promotable(candidate)
         assert candidate == before
+
+
+# ---------------------------------------------------------------------------
+# #2639 — the shared clause helpers
+# ---------------------------------------------------------------------------
+
+
+def _contains_in_order(whole: tuple[str, ...], part: tuple[str, ...]) -> bool:
+    """``part`` appears in ``whole`` as a CONTIGUOUS run, in the same order."""
+    if not part:
+        return True
+    return any(whole[i : i + len(part)] == part for i in range(len(whole) - len(part) + 1))
+
+
+#: Which codes each extracted helper OWNS. ⚠ Written out rather than derived
+#: from the helper's own output: a derivation would agree with whatever the
+#: helper does, including emitting nothing, and the equivalence test below needs
+#: an independent statement of what the gate is expected to delegate.
+_HELPER_CODES: dict[str, frozenset[str]] = {
+    "purpose": frozenset({"harness_validation_only"}),
+    "holdout": frozenset({"holdout_never_evaluated", "holdout_accesses_unrecorded"}),
+    "deflation": frozenset(
+        {
+            "deflated_sharpe_not_computed",
+            "trial_count_undeclared",
+            "trial_register_superseded",
+            "effective_sample_size_not_computed",
+        }
+    ),
+    "synthetic": frozenset(
+        {
+            "synthetic_control_not_run",
+            "synthetic_control_cohort_shows_edge",
+            "synthetic_control_sharpe_below_cohort",
+        }
+    ),
+}
+
+
+def _helper_outputs(candidate: PromotionCandidate) -> dict[str, tuple[str, ...]]:
+    result = candidate.result
+    return {
+        "purpose": purpose_promotion_refusals(result.purpose),
+        "holdout": holdout_count_promotion_refusals(
+            holdout_evaluations=candidate.holdout_evaluations,
+            recorded_accesses=candidate.recorded_accesses,
+        ),
+        "deflation": deflation_promotion_refusals(
+            deflated_sharpe=result.deflated_sharpe,
+            trial_count=result.trial_count,
+            deflated=result.deflated,
+            effective_sample_size=result.metrics.effective_sample_size,
+        ),
+        "synthetic": synthetic_control_promotion_refusals(result.synthetic_control),
+    }
+
+
+def _equivalence_candidates() -> list[PromotionCandidate]:
+    """One candidate per state the extracted clauses can reach, plus the extremes."""
+    superseded = _deflated_result(trial_register_version="trial-register-v0-superseded")
+    # ⚠ Only the COHORT side may be varied here. ``StrategyResult`` binds the
+    # control's strategy_sharpe / strategy_return_pct to ``metrics``, so moving
+    # them raises at construction instead of producing the refusal under test.
+    edge_control = _passing_control(mean_return_ci_low_pct=0.5, mean_return_ci_high_pct=1.5)
+    weak_control = _passing_control(cohort_sharpe_threshold=9.0)
+    return [
+        _clean_candidate(),
+        _clean_candidate(result=_result(**_CLEAN_RESULT_FIELDS, synthetic_control=None)),
+        _clean_candidate(result=_result(**_CLEAN_RESULT_FIELDS, synthetic_control=edge_control)),
+        _clean_candidate(result=_result(**_CLEAN_RESULT_FIELDS, synthetic_control=weak_control)),
+        _clean_candidate(holdout_evaluations=0, recorded_accesses=0),
+        _clean_candidate(holdout_evaluations=3, recorded_accesses=2),
+        _clean_candidate(
+            result=_result(
+                **{**_CLEAN_RESULT_FIELDS, "deflated": superseded},
+                synthetic_control=_passing_control(),
+            )
+        ),
+        _clean_candidate(
+            result=_result(
+                **{
+                    **_CLEAN_RESULT_FIELDS,
+                    "purpose": "harness_validation",
+                    "deflated_sharpe": None,
+                    "trial_count": None,
+                    "deflated": None,
+                    # ⚠ The whole bootstrap set, not the ESS alone —
+                    # `StrategyMetrics` refuses a partial one.
+                    "metrics": _metrics_without_bootstrap(),
+                },
+                synthetic_control=None,
+            )
+        ),
+        # The everything-broken shape: no clause is masked by another.
+        PromotionCandidate(
+            result=_result(purpose="harness_validation", universe_basis="", carry_unmodelled=True),
+            evaluated_instrument_ids=frozenset(),
+            validated_universe_ids=frozenset(),
+        ),
+    ]
+
+
+class TestTheExtractedClauseHelpersAreTheGate:
+    """⚠⚠ #2639 EXTRACTED FOUR CLAUSE BLOCKS SO THE PROMOTION TRANSITION CAN
+    REPLAY THEM OFF A STORED ROW — and an extraction is only safe while it is
+    provably the same rule.
+
+    ``promote_strategy`` holds a ``result_id``, not a ``StrategyResult``, so it
+    cannot call ``check_promotable``; it calls these helpers instead. A second
+    hand-written copy is exactly what ``structural_promotion_refusals`` was
+    extracted to prevent, and the failure would be silent in the worst
+    direction — the transition passing a result the gate refuses.
+
+    Two properties, and both are needed. Membership alone would tolerate the
+    blocks being reordered (the spec's order is what makes a missing check
+    visible as a missing block); order alone would tolerate the gate dropping a
+    code the helper still emits.
+    """
+
+    @pytest.mark.parametrize("candidate", _equivalence_candidates())
+    def test_each_helper_emits_exactly_the_codes_the_gate_emits(self, candidate: PromotionCandidate) -> None:
+        gate = set(check_promotable(candidate))
+        for name, output in _helper_outputs(candidate).items():
+            assert set(output) == gate & _HELPER_CODES[name], (
+                f"{name}: the helper and check_promotable disagree about this candidate — the transition "
+                "would reach a different verdict from the gate"
+            )
+
+    @pytest.mark.parametrize("candidate", _equivalence_candidates())
+    def test_each_helper_s_output_is_a_contiguous_run_of_the_gate_s(self, candidate: PromotionCandidate) -> None:
+        gate = check_promotable(candidate)
+        for name, output in _helper_outputs(candidate).items():
+            assert _contains_in_order(gate, output), (
+                f"{name}: {output} is not a contiguous in-order run of {gate} — the extraction has "
+                "reordered the spec's blocks"
+            )
+
+    def test_no_code_is_owned_by_two_helpers(self) -> None:
+        seen: set[str] = set()
+        for codes in _HELPER_CODES.values():
+            assert not (seen & codes)
+            seen |= codes
+
+    def test_every_owned_code_is_in_the_closed_vocabulary(self) -> None:
+        for codes in _HELPER_CODES.values():
+            assert codes <= PROMOTION_REFUSALS
+
+    def test_the_deflation_clauses_are_independent_and_all_fire_together(self) -> None:
+        """⚠ FOUR ``if``s, never an ``elif``. A DSR with no trial count is as
+        refused as no DSR at all, and an ``elif`` chain would report one reason
+        where four apply — which is the "how far is this from promotable"
+        number an operator actually reads."""
+        assert set(
+            deflation_promotion_refusals(
+                deflated_sharpe=0.9,
+                trial_count=None,
+                deflated=None,
+                effective_sample_size=None,
+            )
+        ) == {"trial_count_undeclared", "trial_register_superseded", "effective_sample_size_not_computed"}
+
+    def test_trial_register_supersession_is_guarded_on_the_probability_not_the_object(self) -> None:
+        """⚠ A row with a stored ``deflated_sharpe`` and no reconstructed object
+        is exactly the state the clause is for. Guarding on ``deflated`` instead
+        would let it through."""
+        assert "trial_register_superseded" in deflation_promotion_refusals(
+            deflated_sharpe=0.9, trial_count=11, deflated=None, effective_sample_size=1000.0
+        )
+        assert "trial_register_superseded" not in deflation_promotion_refusals(
+            deflated_sharpe=None, trial_count=11, deflated=None, effective_sample_size=1000.0
+        )
+
+    def test_a_decimal_deflated_sharpe_is_accepted_as_a_presence(self) -> None:
+        """⚠ Off a stored row the probability arrives as psycopg's NUMERIC →
+        ``Decimal``, not a float. The clause is a ``None`` test and must not
+        narrow the type into a conversion that could raise where the gate
+        refuses."""
+        assert "deflated_sharpe_not_computed" not in deflation_promotion_refusals(
+            deflated_sharpe=Decimal("0.9"), trial_count=11, deflated=None, effective_sample_size=1000.0
+        )
+
+    def test_both_synthetic_control_thresholds_can_fail_at_once(self) -> None:
+        """⚠ Derived from the control's own properties, never from the row's
+        stored ``synthetic_control_passed`` — that column is the CONJUNCTION, so
+        reading it would collapse the two codes and lose which threshold failed."""
+        control = _passing_control(
+            mean_return_ci_low_pct=0.5,
+            mean_return_ci_high_pct=1.5,
+            strategy_sharpe=0.01,
+            cohort_sharpe_threshold=9.0,
+        )
+        assert synthetic_control_promotion_refusals(control) == (
+            "synthetic_control_cohort_shows_edge",
+            "synthetic_control_sharpe_below_cohort",
+        )
+
+    def test_a_single_unrecorded_holdout_evaluation_refuses(self) -> None:
+        """⚠ Criterion 5 read literally would allow one unrecorded look. The rule
+        applied is that EVERY evaluation carries a record."""
+        assert holdout_count_promotion_refusals(holdout_evaluations=1, recorded_accesses=0) == (
+            "holdout_accesses_unrecorded",
+        )
+        assert holdout_count_promotion_refusals(holdout_evaluations=0, recorded_accesses=0) == (
+            "holdout_never_evaluated",
+        )
+        assert holdout_count_promotion_refusals(holdout_evaluations=2, recorded_accesses=2) == ()


### PR DESCRIPTION
## What

`unenforced_candidate_fields()` returned `{holdout_evaluations, recorded_accesses, quarantine_arms_compared}` and the policy's `result` entry carried a `⚠ PARTIAL` — the deflation, effective-sample-size and synthetic-control clauses are columns on `strategy_results_store` and were not replayed. All four are now replayed at the transition. **The set is empty.**

This is the remainder #2625 declared and deferred. `check_promotable` runs at RESULT PRODUCTION; `promote_strategy` cannot call it, so each input is replayed individually — #2621 did the universe, #2505 the edge evidence, #2625 the §3.4 ambiguity and the structural stamps.

**No migration.** The first draft proposed one; Codex checkpoint 1 killed it (below).

## The three halves

### A — criterion 5's counts replay against TODAY

**Frozen defeats the criterion.** Both counts are scoped to `(strategy_id, strategy_version)`, so a pair frozen when result #1 was written records the hold-out looks that had happened *by then*. A strategy that later evaluates its hold-out four more times without recording an access would replay result #1 as `(1, 1)` — consistent, promotable, and blind to precisely the repeated unlogged look criterion 5 exists to catch. The retroactivity #2621 rejected for the universe is the *desired* behaviour here, because the later event is our own conduct on this strategy version and not a change in the outside world.

Three consequences, stated rather than discovered later: the clause is strategy-version-wide (one unrecorded evaluation blocks every result of that version — `check_promotable`'s own behaviour, inherited not invented); it heals as well as blocks; and both sides move, since a later access changes the answer as surely as a later evaluation.

This **widens the `today` restriction** from two shapes to three. The rule's actual content is that a today-check must name what can change the answer and that the change is one the criterion wants to invalidate on. Shape 3 is deliberately narrow — *an append-only audit log, a clause comparing that log against the rows it audits, and a criterion requiring the comparison to be current*. The draft form ("a ledger of our own conduct") would admit any mutable operational counter, which is most of the database. `TestTodayIsRestricted` still pins the exact member set.

Also fixed in passing: `holdout_access_counts` ran its two `COUNT`s as two statements, which under READ COMMITTED is two snapshots — a `store_holdout_result` committing between them returns a pair that never simultaneously existed, in the direction that produces a false `holdout_accesses_unrecorded`. Now one statement, two scalar subqueries.

### B — criterion 9's arm pair, re-derived rather than recorded

The ticket proposed persisting a `sibling_result_id` pointer at result time. **Codex checkpoint 1 killed it**: a pointer is chosen by the WRITER, so the transition would verify the sibling it was handed rather than that the named sibling is the only one the identity admits — strictly weaker than `ResultIdentity.version`, which is a hash and admits exactly one. Codex also raised asymmetric pointers, multiple candidate siblings, and that the record would witness a pointer insertion rather than a pair write. Dropping the table removes all four and the migration with them.

Instead the counting half of `quarantine_arms_compared` is split into `quarantine_arm_pair_present`, which **records nothing**; `quarantine_arms_compared` records and then calls it. One copy of the count, two doors. The transition uses the non-recording one because on a `hold_out` identity (300 of 324 stored rows) the recording door writes a `read` access — *"it must not ask the database a question it is the answer to"* (prevention log, the `_candidate` entry), one layer further out. Promotion is not an evaluation of the withheld side.

Classified `frozen`, not `today`: both arms are rows written at result time and the store has no delete path, so the answer is monotone — it moves only from "one arm" to "both arms".

### C — the row's own clauses

Four pure functions extracted from `check_promotable` **and called by it**, the `structural_promotion_refusals` move: `purpose_promotion_refusals`, `holdout_count_promotion_refusals`, `deflation_promotion_refusals`, `synthetic_control_promotion_refusals`. Four and not one because the blocks are not contiguous in the gate — the universe and hold-out clauses sit after purpose, and §3.4's ambiguity and criterion 9's sit between deflation and §9. Merging would reorder the returned refusals, and the order is the spec's.

The transition reaches them through `result_ledger.stored_result_promotion_refusals(conn, result_id)`, which rebuilds the row through the existing `_result_from_row` and **returns only refusal codes, never a `StrategyResult`** — a public `load_result_by_id` would be a new unaudited door to the withheld side, and `read_holdout_results` is the sanctioned one that records first.

**The row's own `purpose` was a latent gap.** `promote_strategy` refuses on `registered_strategy_purpose` — the MANIFEST's — and never compared it to the row's stamp. Measured: all 324 stored rows and all four registered strategies are `harness_validation`, so they agree today; the moment a manifest entry becomes `capital_candidate`, its older harness-stamped rows become pinnable and the transition would not notice while `check_promotable` would. The same M9 shape as the eight defects R4 recorded on #2437 — the control exists on a path the decision does not take.

## Full-population verification (dev, `scripts/verify_2639_promotion_replay.py --all`)

Read-only; every arm is a SELECT.

```
R1  rows 324   reconstructed 324   failed 0
R2  the transition's new row-level census, all 324 rows:
        324  harness_validation_only
        324  synthetic_control_not_run
        204  trial_register_superseded
         56  deflated_sharpe_not_computed
         56  trial_count_undeclared
          0  quarantine_arms_not_compared
    rows this replay would NOT refuse: 0
R3  criterion 5 per (strategy_id, strategy_version) — 8 versions, evaluations == accesses on every one
        52/52  32/32  32/32  52/52  52/52  32/32  16/16  32/32
R4  promote_strategy on every dev version: refused at the manifest check
        ("harness-validation strategies are permanent controls")
```

**The direction is the safety argument: 0 of 324 rows become less refused.** A replay that closes a gap must only ever ADD refusals; a single row moving from refuse to clean would be fail-open and no unit test would show it. `0 quarantine_arms_not_compared` is the stronger form of the sibling check — the identity-hash derivation finds the flipped-arm row for all 324.

R4 is a negative result reported rather than papered over: the dev population cannot reach the result-level replays at all, because every registered strategy is `harness_validation`. If a manifest entry later becomes `capital_candidate`, that arm changes its message.

## What this does NOT do

- **The counts are not atomic with the promotion INSERT.** `_lock_strategy` takes an advisory lock keyed on the strategy version; the hold-out writers do not take it, so a hold-out row may commit after the count statement and before the promotion lands. One statement buys one snapshot for the *pair*, not for the transition. Closing it means putting the same lock on the write path, which is outside this ticket — recorded on the issue as a known bound.
- **A corrupt stored row RAISES rather than refusing**, per `load_result_ambiguity`'s precedent, which aborts before the remaining refusals are gathered and therefore MASKS them. 324/324 reconstruct, so no stored row takes that path today.
- **The transition keeps its own read of the structural stamps** and does not source them from the rebuilt object. `_result_from_row` coerces `carry_unmodelled` with `bool(...)`, so a NULL reads as *modelled* — fail-open on a Tier 1 refusal — while the transition's read coerces NULL to `True`. Both columns are `NOT NULL` (`sql/262`, `sql/335`), so it is defence in depth; the two coercions must not be collapsed onto the weaker one.
- **`result` stays `frozen`.** `trial_register_superseded` compares a frozen column against the CURRENT `TRIAL_REGISTER` constant. A frozen-field-versus-constant comparison does not make a field `today` — what makes `promotion_evidence` today is the current DATE.
- Nothing becomes promotable. This is enforcement, not admission.

## Tests

`tests/test_strategy_result.py::TestTheExtractedClauseHelpersAreTheGate` is the guard on the refactor: for nine candidates spanning every state the extracted clauses reach, each helper's output must equal `set(check_promotable(c)) & <the codes it owns>` **and** appear as a contiguous in-order run of the gate's output. Membership alone would tolerate the blocks being reordered; order alone would tolerate the gate dropping a code the helper still emits.

`tests/test_strategy_control_plane.py::test_promotion_replays_the_rows_own_clauses_and_the_holdout_counts` is the DB-tier integration test — each new clause refusing at the transition, ending with the *same pinned result* promoting once a hold-out evaluation is recorded, which is the whole content of the `today` classification.

Three existing tests that reached a successful promotion now needed real evidence for the clauses they had been silently skipping (the arm pair, criterion 5's counts, a DSR against today's register, a passing §9 control). Their fixtures were widened — `_promotable_row` / `_promotable_pair` / `_recorded_holdout_evaluation` — not their assertions. The single-armed rows in those tests stay single-armed on purpose: they isolate the refusal each test is about.

**Revert-probed, 11 injected defects, each confirmed to FAIL the guarding test and be restored:** an `elif` chain in the deflation block; the gate reading the `synthetic_control_passed` conjunction instead of the two codes; `trial_register_superseded` guarded on the object rather than the probability; §9 returning only the first threshold failure; criterion 5 read literally (one unrecorded evaluation allowed); a classified-but-unwired input; a fourth today-check; the transition dropping `stored_result_promotion_refusals`; the transition dropping the counts; `quarantine_arm_pair_present` always true; and the counts pair desynchronised.

## Gates

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"` · `pytest tests/smoke` — all exit 0, each run separately. DB tier green on `test_strategy_holdout_namespace`, `test_strategy_control_plane`, `test_strategy_promotion_evidence_store`, `test_strategy_live_gate`, `test_2634_prereg_supersession_db`.

Codex checkpoint 1 on the spec reshaped Half B and tightened Half A's wording (see above). Checkpoint 2 on the staged diff: no findings.

## Security

No new external input, no new endpoint, no credential path. The change is strictly narrowing — it adds refusals to a governance transition and removes none.

Closes #2639. Refs #2625. Refs #2621. Refs #2437.
