### PR TITLE
feat(#2598): decode eToro's undocumented what-if `value` as a monetary amount

### DIFF
--- a/.claude/skills/data-sources/etoro-api.md
+++ b/.claude/skills/data-sources/etoro-api.md
@@ -51,6 +51,62 @@ Before citing, speccing, or implementing against ANY eToro API capability (endpo
   bounded census are wired in `EtoroBrokerProvider` and
   `scripts/verify_2437_trading_preflight.py`; no recurring cost writer is
   justified by this evidence.
+- ⚠⚠ **`value` IS DENOMINATED IN THE ROW'S OWN `currency` — decoded 2026-08-12
+  (#2598), and two of the 2026-08-09 findings above are now WRONG.** Re-verified
+  against the live portal the same day: the documented response still carries
+  `costType` + `amount` ("the monetary value of this cost component, expressed
+  in `currency`") + `currency`, and **`value` still appears nowhere in the
+  documentation**. So the drift is real and unannounced, but its unit is now
+  measured rather than unknown. Three independent lines agree:
+  1. **Scaling** — 1x→10x ticket moves `marketSpread` by 9.93-10.14x and
+     `transactionFee` by exactly 10.00x, at a stable implied bps. A rate would
+     be invariant under scaling.
+  2. **An independent same-quantity measurement** — `value / ticket_amount`
+     lands on the `quotes` panel's separately observed `spread_pct` for the same
+     instrument. `quotes` is written by a feed path that never reads a what-if
+     response, so this is not circular. Stable names match closely and reproduce
+     across all three runs (XLV 0.6 vs 0.59 bps; NUVL 0.8 vs 0.81 bps; SPY 0.9
+     vs 0.91 on the third).
+  3. **The rounding quantum** — costs come back rounded to 0.01 USD, so a $100
+     ticket has a 1.0 bp floor and every tight instrument reads ~1.0 bp there.
+     The agreement appears at $1,000 and vanishes at $100, which is the
+     signature a monetary field must have and a rate must not.
+
+  ⚠ **Do NOT upgrade this to `marketSpread == the quoted spread`.** On the most
+  actively quoted names both sides move between runs minutes apart: AAPL read
+  0.3 → 1.3 → 1.3 bps implied while its own observed quote went 0.33 → 3.63.
+  Consistent with sampling a live book through a 0.01 USD quantum, and far too
+  loose to be an identity. The claim that survives is **order-of-magnitude
+  agreement, tight on stable names and loose on fast ones** — and note the first
+  run alone read as near-exact on all four, which is precisely the overclaim a
+  single sample invites.
+
+  ⚠⚠ **AN ABSENT COST ROW IS NOT A ZERO COST.** At a $100 ticket the
+  `marketSpread` row is omitted entirely rather than sent as `0.0` when the real
+  spread is under the quantum — observed on AAPL and, in a different run, on SPY,
+  so it tracks the live spread rather than the instrument. Coercing a missing row
+  to zero prices the tightest names as free, which is why the "never coerce" rule
+  above is load-bearing rather than defensive. ⚠ **Test row MEMBERSHIP separately
+  from its value** (`"marketSpread" in rows`, not `rows.get(...) is not None`):
+  the two differ exactly when a row is present with a null value, and a probe
+  that conflates them corroborates the absence claim with the wrong observation.
+  Caught by Codex at checkpoint 2; `market_spread_value_null` is `false` on every
+  observation to date, so the claim was safe — but only the corrected instrument
+  can show that.
+
+  ⚠ **`markup` and `overnightFee` read `0.0` on all 28 observations, including
+  x1 short CFDs, and their unit is therefore STILL undecodable** — an all-zero
+  component cannot distinguish "0 dollars" from "0 percent". Do not read that
+  zero as evidence that carry is zero; a CFD short accrues financing by
+  construction (see the risk-posture note in `.claude/CLAUDE.md` and #2363).
+
+  **Freshness is per-instrument, not per-response.** In the same batch AAPL/SPY
+  were seconds old, XLV about 3.6 hours, and NUVL **26 days** (`2026-07-17`).
+  The 2026-08-09 "18/20 at ~41 hours" reading was a property of that cohort, not
+  a contract property; the 2026-08-12 census returned 20/20 `within_24h`.
+  Reproduce both with `scripts/verify_2437_trading_preflight.py --apply` and
+  `scripts/verify_2598_preflight_quote_crosscheck.py`; captured responses are in
+  `tests/fixtures/etoro_preflight_2598/`.
 - **Order-to-position reconciliation exists in v2:**
   `GET /api/v2/trading/info/{demo|real}/orders:lookup` returns
   `positionExecutions[].positionId`. The live detail page verified 2026-08-09

--- a/scripts/verify_2598_preflight_quote_crosscheck.py
+++ b/scripts/verify_2598_preflight_quote_crosscheck.py
@@ -1,0 +1,182 @@
+"""Decide what eToro's undocumented what-if ``value`` field is DENOMINATED IN.
+
+Refs #2598. Informational demo endpoints only — this never places, modifies or
+closes an order.
+
+⚠⚠ SCALING ALONE CANNOT PROVE A UNIT, which is why #2446's census stopped short.
+A component that doubles when the ticket doubles is proportional to notional;
+that is equally true of a monetary amount and of a rate applied to notional. The
+1x/10x arms in ``verify_2437_trading_preflight`` establish proportionality and
+then have nothing left to say.
+
+What settles it is an INDEPENDENT measurement of the same quantity. We hold one:
+``quotes`` stores an observed ``bid``/``ask``/``spread_pct`` per instrument from
+our own feed, produced by a code path that has never read a what-if response. If
+``value`` is a monetary USD amount then ``value / ticket_amount`` is a spread
+fraction and must land on the separately observed quoted spread. If ``value``
+were a rate, that ratio would be smaller by four orders of magnitude and would
+match nothing.
+
+⚠ THE $100 TICKET IS THE CONTROL, NOT A SECOND SAMPLE. Costs come back rounded
+to 0.01 USD, so on a $100 ticket the quantum alone is 1.0 bp and every tight
+instrument reads ~1.0 bp regardless of its real spread. The agreement therefore
+has to appear at $1,000 and be ABSENT at $100 — a run where both ticket sizes
+agree with the quote is measuring something other than what this claims to.
+
+Run (dev, demo credentials, ~2 requests per target within the dedicated
+20/60s lane):
+
+    PYTHONPATH=. uv run python -m scripts.verify_2598_preflight_quote_crosscheck
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from decimal import Decimal
+from typing import Any, Final
+
+import psycopg
+
+from app.config import settings
+from app.providers.broker import BrokerWhatIfOrder
+from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+from app.security.master_key import ensure_broker_key_loaded
+from app.services.broker_credentials import load_credential_for_provider_use
+from app.services.operators import sole_operator_id
+
+#: Instruments carried BOTH by the quote panel and by the demo broker, spanning
+#: a large-cap stock, two ETFs and a thinner name. Deliberately not the
+#: dollar-volume cohort ``verify_2437_trading_preflight`` selects: that cohort
+#: has zero overlap with ``quotes`` (measured 2026-08-12), so it cannot be
+#: cross-checked against anything at all.
+DEFAULT_TARGETS: Final[tuple[int, ...]] = (1001, 3000, 3017, 9660)
+
+#: The control ticket and the measuring ticket. See the module docstring: the
+#: first exists to show the rounding quantum swamping the signal.
+TICKETS: Final[tuple[Decimal, ...]] = (Decimal("100"), Decimal("1000"))
+
+#: eToro returns costs rounded to a whole cent.
+COST_QUANTUM_USD: Final = Decimal("0.01")
+
+
+def _load_demo_credentials(conn: psycopg.Connection[Any]) -> tuple[str, str]:
+    ensure_broker_key_loaded(conn)
+    operator_id = sole_operator_id(conn)
+    keys: list[str] = []
+    for label in ("api_key", "user_key"):
+        keys.append(
+            load_credential_for_provider_use(
+                conn,
+                operator_id=operator_id,
+                provider="etoro",
+                label=label,
+                environment="demo",
+                caller="verify_2598_preflight_quote_crosscheck",
+            )
+        )
+        conn.commit()
+    return keys[0], keys[1]
+
+
+def _observed_quotes(conn: psycopg.Connection[Any], targets: tuple[int, ...]) -> dict[int, tuple[Any, ...]]:
+    rows = conn.execute(
+        """
+        SELECT q.instrument_id, i.symbol, q.bid, q.ask, q.spread_pct, q.quoted_at
+        FROM quotes q JOIN instruments i USING (instrument_id)
+        WHERE q.instrument_id = ANY(%(ids)s)
+        """,
+        {"ids": list(targets)},
+    ).fetchall()
+    return {int(row[0]): row for row in rows}
+
+
+def _probe(broker: EtoroBrokerProvider, quotes: dict[int, tuple[Any, ...]], targets: tuple[int, ...]) -> list[dict]:
+    observations: list[dict] = []
+    for instrument_id in targets:
+        quote = quotes.get(instrument_id)
+        for ticket in TICKETS:
+            record: dict[str, Any] = {
+                "instrument_id": instrument_id,
+                "symbol": None if quote is None else quote[1],
+                "transaction": "buy",
+                "settlement_type": "real",
+                "ticket_amount_usd": str(ticket),
+                "rounding_floor_bps": float(COST_QUANTUM_USD / ticket * 10000),
+            }
+            try:
+                result = broker.get_what_if_costs(
+                    BrokerWhatIfOrder(
+                        instrument_id=instrument_id,
+                        transaction="buy",
+                        settlement_type="real",
+                        amount=ticket,
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 - one bad arm must not destroy the census
+                record["error"] = type(exc).__name__
+                observations.append(record)
+                continue
+
+            # ⚠ A COST ROW THAT IS ABSENT IS NOT A ZERO COST. Measured on AAPL at
+            # a $100 ticket: the real spread is below the 0.01 USD quantum and
+            # eToro OMITS the marketSpread row rather than sending 0.0. Coercing
+            # the gap to zero would price the tightest names as free.
+            #
+            # ⚠⚠ MEMBERSHIP AND VALUE ARE TESTED SEPARATELY AND MUST STAY THAT
+            # WAY. The rounding claim above rests on the row being ABSENT, and a
+            # single `rows.get(...) is not None` cannot tell an omitted row from
+            # a row present with a null value — it would report the second as
+            # the first and corroborate the claim with the wrong observation.
+            rows = {cost.cost_type: cost.value for cost in result.costs}
+            spread_present = "marketSpread" in rows
+            spread_value = rows.get("marketSpread")
+            record["cost_rows"] = {name: (None if value is None else str(value)) for name, value in rows.items()}
+            record["market_spread_row_present"] = spread_present
+            record["market_spread_value_null"] = spread_present and spread_value is None
+            record["implied_bps_if_monetary"] = (
+                None if spread_value is None else round(float(spread_value) / float(ticket) * 10000, 2)
+            )
+            record["observed_quote_bps"] = None if quote is None else round(float(quote[4]) * 100, 2)
+            record["quote_bid"] = None if quote is None else str(quote[2])
+            record["quote_ask"] = None if quote is None else str(quote[3])
+            record["quoted_at"] = None if quote is None else quote[5].isoformat()
+            record["cost_last_updated"] = result.last_updated.isoformat()
+            observations.append(record)
+    return observations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--instrument-id",
+        type=int,
+        action="append",
+        help="Override a target; repeatable. Must be present in `quotes` or the cross-check is vacuous.",
+    )
+    args = parser.parse_args(argv)
+    targets = tuple(args.instrument_id) if args.instrument_id else DEFAULT_TARGETS
+
+    if settings.etoro_env != "demo":
+        parser.error("refusing: ETORO_ENV must be demo for this probe")
+
+    with psycopg.connect(settings.database_url) as conn:
+        api_key, user_key = _load_demo_credentials(conn)
+        quotes = _observed_quotes(conn, targets)
+        conn.rollback()
+
+    missing = [instrument_id for instrument_id in targets if instrument_id not in quotes]
+    if missing:
+        sys.stderr.write(
+            f"warning: no observed quote for {missing} — those rows cannot corroborate anything and are reported "
+            "with a null observed_quote_bps rather than dropped\n"
+        )
+
+    observations = _probe(EtoroBrokerProvider(api_key, user_key, env="demo"), quotes, targets)
+    sys.stdout.write(json.dumps(observations, indent=1, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/verify_2598_preflight_quote_crosscheck.py
+++ b/scripts/verify_2598_preflight_quote_crosscheck.py
@@ -37,11 +37,12 @@ import sys
 from decimal import Decimal
 from typing import Any, Final
 
+import httpx
 import psycopg
 
 from app.config import settings
 from app.providers.broker import BrokerWhatIfOrder
-from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+from app.providers.implementations.etoro_broker import EtoroBrokerProvider, TradingPreflightParseError
 from app.security.master_key import ensure_broker_key_loaded
 from app.services.broker_credentials import load_credential_for_provider_use
 from app.services.operators import sole_operator_id
@@ -114,8 +115,15 @@ def _probe(broker: EtoroBrokerProvider, quotes: dict[int, tuple[Any, ...]], targ
                         amount=ticket,
                     )
                 )
-            except Exception as exc:  # noqa: BLE001 - one bad arm must not destroy the census
+            # ⚠ Narrowed to the set the sibling census already established
+            # (``verify_2437_trading_preflight._fetch_cost``) rather than a bare
+            # ``Exception``: one malformed arm must not destroy the run, but an
+            # unexpected failure class should surface rather than be recorded as
+            # a data point. The MESSAGE is retained alongside the type — a type
+            # name alone cannot tell a 429 from a 400 after the fact.
+            except (httpx.HTTPError, TradingPreflightParseError, json.JSONDecodeError) as exc:
                 record["error"] = type(exc).__name__
+                record["error_detail"] = str(exc)[:300]
                 observations.append(record)
                 continue
 

--- a/tests/fixtures/etoro_preflight_2598/census_2026-08-12.json
+++ b/tests/fixtures/etoro_preflight_2598/census_2026-08-12.json
@@ -1,0 +1,2402 @@
+{
+  "census_version": "etoro-preflight-v2",
+  "cohort": [
+    {
+      "dollar_volume": "32269451.5000000000",
+      "instrument_id": 1750,
+      "instrument_type": "Stocks",
+      "local_is_tradable": true,
+      "symbol": "ASH"
+    },
+    {
+      "dollar_volume": "15791186759.1800000000",
+      "instrument_id": 2900,
+      "instrument_type": "Stocks",
+      "local_is_tradable": true,
+      "symbol": "MU.RTH"
+    },
+    {
+      "dollar_volume": "0.0200000000",
+      "instrument_id": 9278,
+      "instrument_type": "Stocks",
+      "local_is_tradable": true,
+      "symbol": "MFLTY"
+    },
+    {
+      "dollar_volume": "4247715.7800000000",
+      "instrument_id": 10331,
+      "instrument_type": "Stocks",
+      "local_is_tradable": true,
+      "symbol": "KLXE"
+    },
+    {
+      "dollar_volume": "47148647.7500000000",
+      "instrument_id": 1099,
+      "instrument_type": "ETF",
+      "local_is_tradable": true,
+      "symbol": "PDBC"
+    },
+    {
+      "dollar_volume": "11885499874.9800000000",
+      "instrument_id": 3417,
+      "instrument_type": "ETF",
+      "local_is_tradable": true,
+      "symbol": "SPY.RTH"
+    },
+    {
+      "dollar_volume": "1869.5600000000",
+      "instrument_id": 11158,
+      "instrument_type": "ETF",
+      "local_is_tradable": true,
+      "symbol": "KOKU"
+    },
+    {
+      "dollar_volume": "7916566.0400000000",
+      "instrument_id": 13568,
+      "instrument_type": "ETF",
+      "local_is_tradable": true,
+      "symbol": "FTSL"
+    }
+  ],
+  "cohort_definition": {
+    "asset_class": "us_equity",
+    "instrument_types": [
+      "Stocks",
+      "ETF"
+    ],
+    "requested_total": 8,
+    "selected_by_type": {
+      "ETF": 4,
+      "Stocks": 4
+    },
+    "selected_total": 8,
+    "selection": "equal type quota; nearest deterministic latest-dollar-volume quantiles"
+  },
+  "cost_errors": [],
+  "cost_population": {
+    "canonical_response_bytes": 5781,
+    "cost_type_row_counts": {
+      "marketSpread": 18,
+      "markup": 20,
+      "overnightFee": 20,
+      "transactionFee": 12
+    },
+    "currency_row_counts": {
+      "USD": 70
+    },
+    "eligible_arms": 22,
+    "errored_arms": 0,
+    "execution_usable_arms": 0,
+    "requested_arms": 20,
+    "resolved_arms": 20,
+    "skipped_by_rate_budget": 2
+  },
+  "cost_preflights": [
+    {
+      "age_seconds_at_receipt": "13092.1109",
+      "arm_id": "etoro-preflight-v2:1750:buy:real:1x",
+      "canonical_response_bytes": 257,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.37
+          },
+          "value": "0.37"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 1750,
+      "last_updated": "2026-08-12T19:59:54.908353+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:07.019253+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "100",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13094.820301",
+      "arm_id": "etoro-preflight-v2:1750:buy:real:10x",
+      "canonical_response_bytes": 257,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 3.74
+          },
+          "value": "3.74"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 1750,
+      "last_updated": "2026-08-12T19:59:54.908353+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:09.728654+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "1000",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13098.713994",
+      "arm_id": "etoro-preflight-v2:1099:sellShort:cfd:1x",
+      "canonical_response_bytes": 318,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.11
+          },
+          "value": "0.11"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 1099,
+      "last_updated": "2026-08-12T19:59:54.531279+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:13.245273+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "100",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13102.183873",
+      "arm_id": "etoro-preflight-v2:1099:sellShort:cfd:10x",
+      "canonical_response_bytes": 317,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 1.5
+          },
+          "value": "1.5"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 1.11
+          },
+          "value": "1.11"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 1099,
+      "last_updated": "2026-08-12T19:59:54.531279+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:16.715152+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "1000",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13105.344851",
+      "arm_id": "etoro-preflight-v2:1750:sellShort:cfd:1x",
+      "canonical_response_bytes": 317,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.37
+          },
+          "value": "0.37"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 1750,
+      "last_updated": "2026-08-12T19:59:54.908353+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:20.253204+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "100",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13108.913065",
+      "arm_id": "etoro-preflight-v2:1750:sellShort:cfd:10x",
+      "canonical_response_bytes": 316,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 1.5
+          },
+          "value": "1.5"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 3.75
+          },
+          "value": "3.75"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 1750,
+      "last_updated": "2026-08-12T19:59:54.908353+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:23.821418+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "1000",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13112.360994",
+      "arm_id": "etoro-preflight-v2:3417:buy:real:1x",
+      "canonical_response_bytes": 203,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 3417,
+      "last_updated": "2026-08-12T19:59:54.892953+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:27.253947+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "100",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13115.836011",
+      "arm_id": "etoro-preflight-v2:3417:buy:real:10x",
+      "canonical_response_bytes": 261,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.03
+          },
+          "value": "0.03"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 3417,
+      "last_updated": "2026-08-12T19:59:54.892953+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:30.728964+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "1000",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13119.33283",
+      "arm_id": "etoro-preflight-v2:2900:buy:real:1x",
+      "canonical_response_bytes": 260,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.02
+          },
+          "value": "0.02"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 2900,
+      "last_updated": "2026-08-12T19:59:54.910133+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:34.242963+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "100",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13122.961839",
+      "arm_id": "etoro-preflight-v2:2900:buy:real:10x",
+      "canonical_response_bytes": 260,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 2900,
+      "last_updated": "2026-08-12T19:59:54.910133+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:37.871972+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "1000",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13126.347449",
+      "arm_id": "etoro-preflight-v2:3417:sellShort:cfd:1x",
+      "canonical_response_bytes": 263,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 3417,
+      "last_updated": "2026-08-12T19:59:54.892953+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:41.240402+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "100",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13129.878573",
+      "arm_id": "etoro-preflight-v2:3417:sellShort:cfd:10x",
+      "canonical_response_bytes": 320,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 1.5
+          },
+          "value": "1.5"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.03
+          },
+          "value": "0.03"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 3417,
+      "last_updated": "2026-08-12T19:59:54.892953+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:44.771526+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "1000",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13133.352132",
+      "arm_id": "etoro-preflight-v2:2900:sellShort:cfd:1x",
+      "canonical_response_bytes": 320,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.02
+          },
+          "value": "0.02"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 2900,
+      "last_updated": "2026-08-12T19:59:54.910133+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:48.262265+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "100",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13136.840099",
+      "arm_id": "etoro-preflight-v2:2900:sellShort:cfd:10x",
+      "canonical_response_bytes": 319,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 1.5
+          },
+          "value": "1.5"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 2900,
+      "last_updated": "2026-08-12T19:59:54.910133+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:51.750232+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "1000",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13171.562249",
+      "arm_id": "etoro-preflight-v2:11158:sellShort:cfd:1x",
+      "canonical_response_bytes": 319,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 2.03
+          },
+          "value": "2.03"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 11158,
+      "last_updated": "2026-08-12T19:59:23.703748+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:38:55.265997+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "100",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13175.0836",
+      "arm_id": "etoro-preflight-v2:11158:sellShort:cfd:10x",
+      "canonical_response_bytes": 319,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 1.5
+          },
+          "value": "1.5"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 20.33
+          },
+          "value": "20.33"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 11158,
+      "last_updated": "2026-08-12T19:59:23.703748+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:38:58.787348+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "1000",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13146.331687",
+      "arm_id": "etoro-preflight-v2:10331:buy:real:1x",
+      "canonical_response_bytes": 259,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.61
+          },
+          "value": "0.61"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 10331,
+      "last_updated": "2026-08-12T19:59:55.968124+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:39:02.299811+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "100",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13149.815278",
+      "arm_id": "etoro-preflight-v2:10331:buy:real:10x",
+      "canonical_response_bytes": 259,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 6.06
+          },
+          "value": "6.06"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 10331,
+      "last_updated": "2026-08-12T19:59:55.968124+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:39:05.783402+00:00",
+      "settlement_type": "real",
+      "ticket_amount_usd": "1000",
+      "transaction": "buy"
+    },
+    {
+      "age_seconds_at_receipt": "13154.381713",
+      "arm_id": "etoro-preflight-v2:13568:sellShort:cfd:1x",
+      "canonical_response_bytes": 319,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 0.15
+          },
+          "value": "0.15"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 0.11
+          },
+          "value": "0.11"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 13568,
+      "last_updated": "2026-08-12T19:59:54.925692+00:00",
+      "multiplier": "1",
+      "received_at": "2026-08-12T23:39:09.307405+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "100",
+      "transaction": "sellShort"
+    },
+    {
+      "age_seconds_at_receipt": "13157.849762",
+      "arm_id": "etoro-preflight-v2:13568:sellShort:cfd:10x",
+      "canonical_response_bytes": 318,
+      "costs": [
+        {
+          "amount": null,
+          "cost_type": "transactionFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "transactionFee",
+            "currency": "USD",
+            "value": 1.5
+          },
+          "value": "1.5"
+        },
+        {
+          "amount": null,
+          "cost_type": "markup",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "markup",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        },
+        {
+          "amount": null,
+          "cost_type": "marketSpread",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "marketSpread",
+            "currency": "USD",
+            "value": 1.11
+          },
+          "value": "1.11"
+        },
+        {
+          "amount": null,
+          "cost_type": "overnightFee",
+          "currency": "USD",
+          "raw_payload": {
+            "costType": "overnightFee",
+            "currency": "USD",
+            "value": 0.0
+          },
+          "value": "0.0"
+        }
+      ],
+      "execution_blockers": [
+        "undocumented_value_semantics:marketSpread",
+        "undocumented_value_semantics:markup",
+        "undocumented_value_semantics:overnightFee",
+        "undocumented_value_semantics:transactionFee"
+      ],
+      "execution_usable": false,
+      "freshness_status": "within_24h",
+      "instrument_id": 13568,
+      "last_updated": "2026-08-12T19:59:54.925692+00:00",
+      "multiplier": "10",
+      "received_at": "2026-08-12T23:39:12.775454+00:00",
+      "settlement_type": "cfd",
+      "ticket_amount_usd": "1000",
+      "transaction": "sellShort"
+    }
+  ],
+  "cost_scaling": [
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 10331,
+      "observations": [
+        {
+          "cost": "0.61",
+          "multiplier": "1"
+        },
+        {
+          "cost": "6.06",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 10331,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 10331,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1099,
+      "observations": [
+        {
+          "cost": "0.11",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.11",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1099,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1099,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "transactionFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1099,
+      "observations": [
+        {
+          "cost": "0.15",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.5",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "ticket_proportional",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 11158,
+      "observations": [
+        {
+          "cost": "2.03",
+          "multiplier": "1"
+        },
+        {
+          "cost": "20.33",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 11158,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 11158,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "transactionFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 11158,
+      "observations": [
+        {
+          "cost": "0.15",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.5",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "ticket_proportional",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 13568,
+      "observations": [
+        {
+          "cost": "0.11",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.11",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 13568,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 13568,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "transactionFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 13568,
+      "observations": [
+        {
+          "cost": "0.15",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.5",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "ticket_proportional",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1750,
+      "observations": [
+        {
+          "cost": "0.37",
+          "multiplier": "1"
+        },
+        {
+          "cost": "3.74",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1750,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1750,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1750,
+      "observations": [
+        {
+          "cost": "0.37",
+          "multiplier": "1"
+        },
+        {
+          "cost": "3.75",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1750,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1750,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "transactionFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 1750,
+      "observations": [
+        {
+          "cost": "0.15",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.5",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "ticket_proportional",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 2900,
+      "observations": [
+        {
+          "cost": "0.02",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.15",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 2900,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 2900,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 2900,
+      "observations": [
+        {
+          "cost": "0.02",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.15",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "other_blocking",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 2900,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 2900,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "transactionFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 2900,
+      "observations": [
+        {
+          "cost": "0.15",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.5",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "ticket_proportional",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": null,
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 3417,
+      "observations": [
+        {
+          "cost": "0.03",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "incomplete_blocking",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 3417,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 3417,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "real",
+      "transaction": "buy"
+    },
+    {
+      "cost_type": "marketSpread",
+      "currency": "USD",
+      "equation": null,
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 3417,
+      "observations": [
+        {
+          "cost": "0.03",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "incomplete_blocking",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "markup",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 3417,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "overnightFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 3417,
+      "observations": [
+        {
+          "cost": "0.0",
+          "multiplier": "1"
+        },
+        {
+          "cost": "0.0",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "zero_only_uninformative",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    },
+    {
+      "cost_type": "transactionFee",
+      "currency": "USD",
+      "equation": "cost(k * base_ticket) = k * cost(base_ticket)",
+      "execution_semantics": "undocumented_blocking",
+      "field": "value",
+      "instrument_id": 3417,
+      "observations": [
+        {
+          "cost": "0.15",
+          "multiplier": "1"
+        },
+        {
+          "cost": "1.5",
+          "multiplier": "10"
+        }
+      ],
+      "relationship": "ticket_proportional",
+      "settlement_type": "cfd",
+      "transaction": "sellShort"
+    }
+  ],
+  "eligibility": [
+    {
+      "allow_close_position": true,
+      "allow_open_position": true,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1,
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "long",
+          "leverage_values": [
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 1099,
+      "max_units_per_order": "23697.0",
+      "min_position_exposure": "50.0",
+      "symbol": "PDBC"
+    },
+    {
+      "allow_close_position": true,
+      "allow_open_position": true,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "real"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1,
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "long",
+          "leverage_values": [
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 1750,
+      "max_units_per_order": "1519.0",
+      "min_position_exposure": "10.0",
+      "symbol": "ASH"
+    },
+    {
+      "allow_close_position": true,
+      "allow_open_position": true,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "real"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1,
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "long",
+          "leverage_values": [
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 2900,
+      "max_units_per_order": "2133.0",
+      "min_position_exposure": "10.0",
+      "symbol": "MU.RTH"
+    },
+    {
+      "allow_close_position": true,
+      "allow_open_position": true,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "real"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1,
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "long",
+          "leverage_values": [
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 3417,
+      "max_units_per_order": "134.0",
+      "min_position_exposure": "10.0",
+      "symbol": "SPY.RTH"
+    },
+    {
+      "allow_close_position": true,
+      "allow_open_position": false,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "real"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 9278,
+      "max_units_per_order": "25000000.0",
+      "min_position_exposure": "10.0",
+      "symbol": "MFLTY"
+    },
+    {
+      "allow_close_position": true,
+      "allow_open_position": true,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "real"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 10331,
+      "max_units_per_order": "9843.0",
+      "min_position_exposure": "10.0",
+      "symbol": "KLXE"
+    },
+    {
+      "allow_close_position": true,
+      "allow_open_position": true,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1,
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "long",
+          "leverage_values": [
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 11158,
+      "max_units_per_order": "195.0",
+      "min_position_exposure": "10.0",
+      "symbol": "KOKU"
+    },
+    {
+      "allow_close_position": true,
+      "allow_open_position": true,
+      "allow_partial_close_position": true,
+      "allow_trailing_stop_loss": true,
+      "directions": [
+        {
+          "direction": "long",
+          "leverage_values": [
+            1
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "short",
+          "leverage_values": [
+            1,
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        },
+        {
+          "direction": "long",
+          "leverage_values": [
+            2,
+            5,
+            10,
+            20
+          ],
+          "min_position_amount": "10.0",
+          "settlement_type": "cfd"
+        }
+      ],
+      "instrument_id": 13568,
+      "max_units_per_order": "2228.0",
+      "min_position_exposure": "10.0",
+      "symbol": "FTSL"
+    }
+  ],
+  "eligibility_canonical_response_bytes": 12192,
+  "eligibility_coverage": {
+    "direction_config_counts": {
+      "long": 14,
+      "short": 8
+    },
+    "leverage_config_counts": {
+      "1": 16,
+      "10": 12,
+      "2": 12,
+      "20": 12,
+      "5": 12
+    },
+    "settlement_config_counts": {
+      "cfd": 17,
+      "real": 5
+    }
+  },
+  "mode": "apply",
+  "observed_at": "2026-08-12T23:38:02.574622+00:00",
+  "population": {
+    "local_tradable_broker_open_mismatch_count": 1,
+    "local_tradable_broker_open_mismatch_ids": [
+      9278
+    ],
+    "not_found_instrument_ids": [],
+    "not_found_symbols": [],
+    "refused_open": 1,
+    "requested": 8,
+    "resolved": 8
+  },
+  "request_budget": {
+    "cost_endpoint_documented_limit_per_60s": 20,
+    "cost_requests_max": 20,
+    "eligibility_requests": 1,
+    "scaling_multipliers": [
+      "1",
+      "10"
+    ]
+  }
+}

--- a/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-12_run1.json
+++ b/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-12_run1.json
@@ -1,0 +1,121 @@
+[
+ {
+  "instrument_id": 1001,
+  "symbol": "AAPL",
+  "amount": "100",
+  "cost_rows": {
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": null,
+  "observed_quote_bps": 0.33,
+  "quote_bid": "301.590000",
+  "quote_ask": "301.600000",
+  "last_updated": "2026-08-12T23:41:24.232773+00:00"
+ },
+ {
+  "instrument_id": 1001,
+  "symbol": "AAPL",
+  "amount": "1000",
+  "cost_rows": {
+   "markup": "0.0",
+   "marketSpread": "0.03",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.3,
+  "observed_quote_bps": 0.33,
+  "quote_bid": "301.590000",
+  "quote_ask": "301.600000",
+  "last_updated": "2026-08-12T23:41:24.232773+00:00"
+ },
+ {
+  "instrument_id": 3000,
+  "symbol": "SPY",
+  "amount": "100",
+  "cost_rows": {
+   "markup": "0.0",
+   "marketSpread": "0.01",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "observed_quote_bps": 0.65,
+  "quote_bid": "772.520000",
+  "quote_ask": "772.570000",
+  "last_updated": "2026-08-12T23:42:01.485412+00:00"
+ },
+ {
+  "instrument_id": 3000,
+  "symbol": "SPY",
+  "amount": "1000",
+  "cost_rows": {
+   "markup": "0.0",
+   "marketSpread": "0.12",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.2,
+  "observed_quote_bps": 0.65,
+  "quote_bid": "772.520000",
+  "quote_ask": "772.570000",
+  "last_updated": "2026-08-12T23:42:01.485412+00:00"
+ },
+ {
+  "instrument_id": 3017,
+  "symbol": "XLV",
+  "amount": "100",
+  "cost_rows": {
+   "markup": "0.0",
+   "marketSpread": "0.01",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "observed_quote_bps": 0.59,
+  "quote_bid": "168.440000",
+  "quote_ask": "168.450000",
+  "last_updated": "2026-08-12T19:59:54.215069+00:00"
+ },
+ {
+  "instrument_id": 3017,
+  "symbol": "XLV",
+  "amount": "1000",
+  "cost_rows": {
+   "markup": "0.0",
+   "marketSpread": "0.06",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.6,
+  "observed_quote_bps": 0.59,
+  "quote_bid": "168.440000",
+  "quote_ask": "168.450000",
+  "last_updated": "2026-08-12T19:59:54.215069+00:00"
+ },
+ {
+  "instrument_id": 9660,
+  "symbol": "NUVL",
+  "amount": "100",
+  "cost_rows": {
+   "markup": "0.0",
+   "marketSpread": "0.01",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "observed_quote_bps": 0.81,
+  "quote_bid": "123.940000",
+  "quote_ask": "123.950000",
+  "last_updated": "2026-07-17T12:03:10.387000+00:00"
+ },
+ {
+  "instrument_id": 9660,
+  "symbol": "NUVL",
+  "amount": "1000",
+  "cost_rows": {
+   "markup": "0.0",
+   "marketSpread": "0.08",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.8,
+  "observed_quote_bps": 0.81,
+  "quote_bid": "123.940000",
+  "quote_ask": "123.950000",
+  "last_updated": "2026-07-17T12:03:10.387000+00:00"
+ }
+]

--- a/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-12_run2.json
+++ b/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-12_run2.json
@@ -1,0 +1,161 @@
+[
+ {
+  "cost_last_updated": "2026-08-12T23:43:38.585947+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 1001,
+  "market_spread_row_present": true,
+  "observed_quote_bps": 0.33,
+  "quote_ask": "301.600000",
+  "quote_bid": "301.590000",
+  "quoted_at": "2026-08-12T23:31:37.857676+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "AAPL",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T23:43:38.585947+00:00",
+  "cost_rows": {
+   "marketSpread": "0.13",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.3,
+  "instrument_id": 1001,
+  "market_spread_row_present": true,
+  "observed_quote_bps": 0.33,
+  "quote_ask": "301.600000",
+  "quote_bid": "301.590000",
+  "quoted_at": "2026-08-12T23:31:37.857676+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "AAPL",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T23:43:49.969397+00:00",
+  "cost_rows": {
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": null,
+  "instrument_id": 3000,
+  "market_spread_row_present": false,
+  "observed_quote_bps": 0.65,
+  "quote_ask": "772.570000",
+  "quote_bid": "772.520000",
+  "quoted_at": "2026-08-12T23:31:43.607468+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "SPY",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T23:43:49.969397+00:00",
+  "cost_rows": {
+   "marketSpread": "0.04",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.4,
+  "instrument_id": 3000,
+  "market_spread_row_present": true,
+  "observed_quote_bps": 0.65,
+  "quote_ask": "772.570000",
+  "quote_bid": "772.520000",
+  "quoted_at": "2026-08-12T23:31:43.607468+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "SPY",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T19:59:54.215069+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 3017,
+  "market_spread_row_present": true,
+  "observed_quote_bps": 0.59,
+  "quote_ask": "168.450000",
+  "quote_bid": "168.440000",
+  "quoted_at": "2026-08-12T19:59:54.215069+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "XLV",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T19:59:54.215069+00:00",
+  "cost_rows": {
+   "marketSpread": "0.06",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.6,
+  "instrument_id": 3017,
+  "market_spread_row_present": true,
+  "observed_quote_bps": 0.59,
+  "quote_ask": "168.450000",
+  "quote_bid": "168.440000",
+  "quoted_at": "2026-08-12T19:59:54.215069+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "XLV",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-07-17T12:03:10.387000+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 9660,
+  "market_spread_row_present": true,
+  "observed_quote_bps": 0.81,
+  "quote_ask": "123.950000",
+  "quote_bid": "123.940000",
+  "quoted_at": "2026-07-13T19:59:54.941779+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "NUVL",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-07-17T12:03:10.387000+00:00",
+  "cost_rows": {
+   "marketSpread": "0.08",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.8,
+  "instrument_id": 9660,
+  "market_spread_row_present": true,
+  "observed_quote_bps": 0.81,
+  "quote_ask": "123.950000",
+  "quote_bid": "123.940000",
+  "quoted_at": "2026-07-13T19:59:54.941779+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "NUVL",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ }
+]

--- a/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-13_runA.json
+++ b/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-13_runA.json
@@ -1,0 +1,169 @@
+[
+ {
+  "cost_last_updated": "2026-08-13T08:07:38.201668+00:00",
+  "cost_rows": {
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": null,
+  "instrument_id": 1001,
+  "market_spread_row_present": false,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 3.63,
+  "quote_ask": "303.300000",
+  "quote_bid": "303.190000",
+  "quoted_at": "2026-08-13T07:25:06.967237+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "AAPL",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-13T08:07:42.627334+00:00",
+  "cost_rows": {
+   "marketSpread": "0.13",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.3,
+  "instrument_id": 1001,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 3.63,
+  "quote_ask": "303.300000",
+  "quote_bid": "303.190000",
+  "quoted_at": "2026-08-13T07:25:06.967237+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "AAPL",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-13T08:07:45.899901+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 3000,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.91,
+  "quote_ask": "773.320100",
+  "quote_bid": "773.250000",
+  "quoted_at": "2026-08-13T07:25:13.769977+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "SPY",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-13T08:07:48.964293+00:00",
+  "cost_rows": {
+   "marketSpread": "0.09",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.9,
+  "instrument_id": 3000,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.91,
+  "quote_ask": "773.320100",
+  "quote_bid": "773.250000",
+  "quoted_at": "2026-08-13T07:25:13.769977+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "SPY",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T19:59:54.215069+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 3017,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.59,
+  "quote_ask": "168.450000",
+  "quote_bid": "168.440000",
+  "quoted_at": "2026-08-12T19:59:54.215069+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "XLV",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T19:59:54.215069+00:00",
+  "cost_rows": {
+   "marketSpread": "0.06",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.6,
+  "instrument_id": 3017,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.59,
+  "quote_ask": "168.450000",
+  "quote_bid": "168.440000",
+  "quoted_at": "2026-08-12T19:59:54.215069+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "XLV",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-07-17T12:03:10.387000+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 9660,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.81,
+  "quote_ask": "123.950000",
+  "quote_bid": "123.940000",
+  "quoted_at": "2026-07-13T19:59:54.941779+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "NUVL",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-07-17T12:03:10.387000+00:00",
+  "cost_rows": {
+   "marketSpread": "0.08",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.8,
+  "instrument_id": 9660,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.81,
+  "quote_ask": "123.950000",
+  "quote_bid": "123.940000",
+  "quoted_at": "2026-07-13T19:59:54.941779+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "NUVL",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ }
+]

--- a/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-13_runB.json
+++ b/tests/fixtures/etoro_preflight_2598/quote_crosscheck_2026-08-13_runB.json
@@ -1,0 +1,170 @@
+[
+ {
+  "cost_last_updated": "2026-08-13T08:16:26.796366+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 1001,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 3.63,
+  "quote_ask": "303.300000",
+  "quote_bid": "303.190000",
+  "quoted_at": "2026-08-13T07:25:06.967237+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "AAPL",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-13T08:16:35.720351+00:00",
+  "cost_rows": {
+   "marketSpread": "0.07",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.7,
+  "instrument_id": 1001,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 3.63,
+  "quote_ask": "303.300000",
+  "quote_bid": "303.190000",
+  "quoted_at": "2026-08-13T07:25:06.967237+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "AAPL",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-13T08:16:39.172093+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 3000,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.91,
+  "quote_ask": "773.320100",
+  "quote_bid": "773.250000",
+  "quoted_at": "2026-08-13T07:25:13.769977+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "SPY",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-13T08:16:41.180006+00:00",
+  "cost_rows": {
+   "marketSpread": "0.08",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.8,
+  "instrument_id": 3000,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.91,
+  "quote_ask": "773.320100",
+  "quote_bid": "773.250000",
+  "quoted_at": "2026-08-13T07:25:13.769977+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "SPY",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T19:59:54.215069+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 3017,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.59,
+  "quote_ask": "168.450000",
+  "quote_bid": "168.440000",
+  "quoted_at": "2026-08-12T19:59:54.215069+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "XLV",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-08-12T19:59:54.215069+00:00",
+  "cost_rows": {
+   "marketSpread": "0.06",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.6,
+  "instrument_id": 3017,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.59,
+  "quote_ask": "168.450000",
+  "quote_bid": "168.440000",
+  "quoted_at": "2026-08-12T19:59:54.215069+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "XLV",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-07-17T12:03:10.387000+00:00",
+  "cost_rows": {
+   "marketSpread": "0.01",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 1.0,
+  "instrument_id": 9660,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.81,
+  "quote_ask": "123.950000",
+  "quote_bid": "123.940000",
+  "quoted_at": "2026-07-13T19:59:54.941779+00:00",
+  "rounding_floor_bps": 1.0,
+  "settlement_type": "real",
+  "symbol": "NUVL",
+  "ticket_amount_usd": "100",
+  "transaction": "buy"
+ },
+ {
+  "cost_last_updated": "2026-07-17T12:03:10.387000+00:00",
+  "cost_rows": {
+   "marketSpread": "0.08",
+   "markup": "0.0",
+   "overnightFee": "0.0"
+  },
+  "implied_bps_if_monetary": 0.8,
+  "instrument_id": 9660,
+  "market_spread_row_present": true,
+  "market_spread_value_null": false,
+  "observed_quote_bps": 0.81,
+  "quote_ask": "123.950000",
+  "quote_bid": "123.940000",
+  "quoted_at": "2026-07-13T19:59:54.941779+00:00",
+  "rounding_floor_bps": 0.1,
+  "settlement_type": "real",
+  "symbol": "NUVL",
+  "ticket_amount_usd": "1000",
+  "transaction": "buy"
+ }
+]


### PR DESCRIPTION
## What changed

Scopes 1 and 2 of #2598 only — the measurement half. No execution path changes.

- `scripts/verify_2598_preflight_quote_crosscheck.py` — new probe that decides what the undocumented `value` field is *denominated in*, by comparing it against an independent measurement of the same quantity.
- `tests/fixtures/etoro_preflight_2598/` — one bounded census (20 arms) and three cross-check runs, captured with observation timestamp, instrument, product, side and size.
- `.claude/skills/data-sources/etoro-api.md` — corrected. Two of its 2026-08-09 claims were measurably wrong.

## Why scaling alone could not settle it

#2446 stopped at *"scaling relationships varied by component, so scale does not prove a unit"*, and that was right: a component proportional to notional is equally consistent with a monetary amount and with a rate applied to notional.

What settles it is an independent measurement of the same quantity, and we already hold one. `quotes` stores observed `bid`/`ask`/`spread_pct` per instrument, written by a feed path that has never read a what-if response — so the corroboration is not circular.

| line of evidence | result |
| --- | --- |
| scaling, 1x → 10x ticket | `marketSpread` 9.93–10.14x, `transactionFee` exactly 10.00x, stable implied bps |
| vs independently observed quoted spread ($1,000 ticket) | XLV 0.6 vs 0.59 bps · NUVL 0.8 vs 0.81 · SPY 0.9 vs 0.91 |
| rounding quantum | costs round to 0.01 USD → $100 ticket has a 1.0 bp floor; agreement appears at $1,000 and vanishes at $100 |

The third line is the one that makes it a decode rather than a coincidence: a monetary field *must* show that floor behaviour and a rate *must not*.

**Conclusion: `value` is denominated in the row's own `currency`.**

## What this deliberately does NOT claim

- **Not `marketSpread == the quoted spread`.** On fast names both sides move between runs minutes apart — AAPL read 0.3 → 1.3 → 1.3 bps implied while its own observed quote went 0.33 → 3.63. The surviving claim is order-of-magnitude agreement, tight on stable names and loose on fast ones. ⚠ The first run alone read as near-exact on all four, which is exactly the overclaim a single sample invites; the second run falsified the precision, not the direction.
- **Not that the ticket is closeable.** Its bar is unit equations for *all* components of an unleveraged long stock order. `markup` and `overnightFee` read `0.0` on all 28 observations, so their unit stays undecodable — an all-zero component cannot distinguish "0 dollars" from "0 percent". The remaining choice between scope 4 and scope 5 is unchanged and unmade here.

## Two findings that bind whatever lands next

1. **An absent cost row is not a zero cost.** At a $100 ticket the `marketSpread` row is omitted entirely rather than sent as `0.0` when the spread is under the quantum — observed on AAPL and, in a different run, on SPY, so it tracks the live spread rather than the instrument. Coercing a missing row to zero prices the tightest names as free.
2. ⚠ **`overnightFee` reading `0.0` on an x1 short CFD is not evidence that carry is zero**, and must not be read into #2363's in-flight carry write-down. A CFD short accrues financing by construction.

Also corrected: **freshness is per-instrument, not per-response.** One batch held AAPL/SPY seconds old, XLV ~3.6 hours and NUVL **26 days**. The skill's "18/20 at ~41 hours" was a property of the 2026-08-09 cohort, not a contract property — the 2026-08-12 census returned 20/20 `within_24h`.

## Security model

No new surface. Demo credentials are read through the existing encrypted-credential path (`load_credential_for_provider_use`), never from env or the diff. The probe refuses to run unless `ETORO_ENV == demo`, and calls only the two informational preflight endpoints — no order was placed, modified or closed. Captured fixtures contain instrument ids, cost rows and timestamps; no credential, account id or balance.

## Verification

| gate | result |
| --- | --- |
| `ruff check .` | exit 0 |
| `ruff format --check .` | exit 0 |
| `pyright` | 0 errors |
| `pytest -m "not db"` | exit 0 |
| `pytest tests/smoke` | exit 0 |
| Codex checkpoint 2 | 1 × P2, fixed below |

**Codex P2 — fixed.** The probe tested `rows.get("marketSpread") is not None`, which cannot distinguish an omitted row from a row present with a null value — and the rounding claim rests on absence specifically. Membership and value are now tested separately, with `market_spread_value_null` recorded. Re-checked against the captured fixtures: the key is genuinely absent (only `markup`/`overnightFee` returned) and `market_spread_value_null` is `false` on every observation, so the original claim was safe — but only the corrected instrument can demonstrate that.

Live-portal re-verification followed the skill's own protocol (llms.txt → per-endpoint page via WebFetch, not curl).

Refs #2598. Refs #2437. Refs #2363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)