### PR TITLE
fix(#2610): assert the throttle releases before the send, not wall-clock

### DIFF
--- a/tests/test_concurrent_fetch.py
+++ b/tests/test_concurrent_fetch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 import time
 
+import httpx
 import pytest
 
 from app.providers.concurrent_fetch import (
@@ -146,101 +147,91 @@ class TestFetchDocumentTextsClassified:
         assert fetch_document_texts_classified(_Fetcher({}), []) == {}
 
 
-class TestConcurrencyAchievesActualThroughput:
-    """Wall-clock regression guard for #726. Bot pre-flight raised
-    a concern that ``time.sleep`` inside the throttle lock would
-    serialise threads end-to-end and erase the concurrency gain.
-    Live SEC tests showed 7.5 req/s actual vs ~1 req/s sequential,
-    so the design works — but the bot's intuition is reasonable
-    enough that we want a deterministic CI check.
+class TestResponseTimeIsSpentOutsideTheThrottleLock:
+    """Regression guard for #726. Bot pre-flight raised a concern that
+    ``time.sleep`` inside the throttle lock would serialise threads
+    end-to-end and erase the concurrency gain. Live SEC tests showed
+    7.5 req/s actual vs ~1 req/s sequential, so the design works — but
+    the bot's intuition is reasonable enough that we want a CI check.
 
-    The math: with N concurrent workers, each lock holder spends
-    ``min_interval`` sleeping (since the previous holder just
-    stamped). After release, the next thread acquires and sleeps
-    ``min_interval`` again. Aggregate rate = ``1 / min_interval``
-    regardless of N (the lock IS the rate gate). Crucially, the
-    HTTP RTT happens AFTER lock release, in parallel across threads
-    — so total wall-clock for N requests with response_time R is
-    ``N * min_interval + R`` (the last request's response), NOT
-    ``N * (min_interval + R)`` which is what the sequential
-    pre-PR loop took.
+    The design property: ``_request`` calls ``_throttle_and_stamp``,
+    which acquires ``_throttle_lock``, sleeps out any remaining floor,
+    stamps and RELEASES. Only then does it call ``self._client.send``.
+    So the HTTP round trip is served concurrently across threads while
+    the *stamping* remains serialised at ``1 / min_interval``. Move the
+    send inside the lock and every request serialises behind the RTT.
+
+    ⚠ #2610 — this replaces a wall-clock assertion, twice. Both prior
+    forms compared elapsed time of a concurrent arm against a
+    sequential one (an absolute constant, then a measured ratio), and
+    both false-failed ``.githooks/pre-push`` under ordinary background
+    load: 3 of 4 attempts during PR #2609, with a sibling autonomy loop
+    on the box holding load average at 2.68-3.59. A sibling loop is a
+    NORMAL condition for this machine, so that arrangement was not
+    fixable by widening the margin. Per #2224, a gate that fails
+    randomly trains ``--no-verify``, which is strictly worse than no
+    gate — and this test sits on the fast tier, the per-push path.
+
+    ⚠⚠ The prior forms also observed the WRONG CODE. Their worker was a
+    test-local ``fire()`` that called ``rc._throttle_and_stamp()`` and
+    then slept the simulated RTT itself — so the send-outside-the-lock
+    ordering being asserted was the ordering the *test* had written, not
+    the one in ``_request``. Reinstating the send inside ``_request``'s
+    lock would not have moved either ratio. This form drives the real
+    ``rc.get()`` over ``httpx.MockTransport``, so the ordering under
+    test is the shipped one.
+
+    The assertion is now a rendezvous, not a stopwatch: N threads must
+    be inside the transport handler SIMULTANEOUSLY, which a
+    ``threading.Barrier`` decides exactly. If the send holds the
+    throttle lock, at most one thread can ever be in the handler, the
+    barrier cannot form, and the test fails on every run and every box.
+    Host load moves only how long the pass takes, not whether it passes.
     """
 
-    def test_concurrent_total_time_smaller_than_sequential(self) -> None:
+    def test_all_requests_are_in_flight_simultaneously(self) -> None:
         from concurrent.futures import ThreadPoolExecutor
 
         from app.providers.resilient_client import ResilientClient
 
-        # Simulated work: each worker stamps then sleeps RESPONSE_MS
-        # (the "HTTP RTT") OUTSIDE the lock, exactly like the real
-        # ResilientClient._request flow.
-        N_REQUESTS = 12
-        RESPONSE_MS = 0.1
+        N_REQUESTS = 4
+        # Slack over the ~N*min_interval (80 ms) the throttle floor
+        # itself costs before the last thread can reach the handler.
+        # Only ever paid in full when the barrier genuinely cannot form,
+        # i.e. on a real regression.
+        BARRIER_TIMEOUT_S = 5.0
 
-        def _make_rc() -> ResilientClient:
-            rc = ResilientClient.__new__(ResilientClient)
-            rc._min_interval = 0.02  # 20 ms floor
-            rc._last_request_at = [0.0]
-            rc._throttle_lock = threading.Lock()
-            rc._gate = None  # #1484: no cross-process gate -> exercise the in-process floor
-            return rc
+        rendezvous = threading.Barrier(N_REQUESTS)
+        never_formed = threading.Event()
+        in_handler: list[str] = []
+        handler_lock = threading.Lock()
 
-        def fire(rc: ResilientClient) -> None:
-            rc._throttle_and_stamp()  # pyright: ignore[reportPrivateUsage]
-            time.sleep(RESPONSE_MS)  # outside the lock
+        def handler(request: httpx.Request) -> httpx.Response:
+            """Stands in for the SEC round trip. Reached only after
+            ``_throttle_and_stamp`` has returned, so arriving here means
+            the caller is past the throttle."""
+            with handler_lock:
+                in_handler.append(str(request.url))
+            try:
+                rendezvous.wait(timeout=BARRIER_TIMEOUT_S)
+            except threading.BrokenBarrierError:
+                # Fewer than N_REQUESTS threads could be here at once.
+                never_formed.set()
+            return httpx.Response(200, text="ok")
 
-        # #1769 — measure the sequential baseline IN-PROCESS rather than
-        # against a precomputed constant. A constant (the old
-        # ``N*(min_interval+R)``) silently assumes an idle host: on a busy
-        # box wall-clock dilates and the concurrent run dilates with it, so
-        # an absolute threshold becomes unreachable and the test false-fails
-        # the push gate. The *ratio* concurrency buys is what we actually
-        # want to pin: it tracks host load far better than an absolute bar
-        # (both arms dilate under scheduler pressure, though not perfectly in
-        # lock-step — the concurrent arm also pays thread/lock contention).
-        # The R sleeps overlap even on a single core — sleeping needs no CPU
-        # — so a healthy design still wins regardless of contention. This is
-        # a coarse "did we preserve substantial overlap?" guard, not a fine
-        # throughput regression detector; basic overlap correctness is pinned
-        # deterministically by ``test_concurrency_actually_overlaps``.
-        # Best-of-2 on BOTH arms — symmetric sampling. Measuring sequential
-        # once but concurrent best-of-2 is one-sided: a single noise-inflated
-        # sequential run lifts the threshold, which could let a serialised
-        # regression squeak under ``sequential*0.85``. Taking the fastest of 2
-        # sequential runs too removes that hole — both arms shed transient
-        # scheduler stalls, so the ratio reflects the design, not host noise.
-        def _time_sequential() -> float:
-            rc_local = _make_rc()
-            start = time.monotonic()
-            for _ in range(N_REQUESTS):
-                fire(rc_local)
-            return time.monotonic() - start
+        with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+            rc = ResilientClient(client, min_request_interval_s=0.02)
+            with ThreadPoolExecutor(max_workers=N_REQUESTS) as pool:
+                statuses = [
+                    r.status_code for r in pool.map(lambda i: rc.get(f"https://example.test/{i}"), range(N_REQUESTS))
+                ]
 
-        sequential = min(_time_sequential() for _ in range(2))
-
-        # Best-of-2 concurrent: sheds a transient scheduler stall that would
-        # otherwise mask a genuinely-parallel design as serial. A throttle
-        # regression that serialises HTTP RTT inside the lock collapses the
-        # ratio toward ~1.0 in EVERY run, so best-of-2 still fails it.
-        def _time_concurrent() -> float:
-            rc_local = _make_rc()
-            start = time.monotonic()
-            with ThreadPoolExecutor(max_workers=8) as pool:
-                list(pool.map(lambda _: fire(rc_local), range(N_REQUESTS)))
-            return time.monotonic() - start
-
-        concurrent = min(_time_concurrent() for _ in range(2))
-
-        # Healthy design overlaps RTT across threads: ratio ~0.4 idle, ~0.68
-        # under heavy load (measured). A serialising regression -> ~1.0. The
-        # 0.85 bar sits in that gap, deliberately biased toward the looser
-        # side: a false FAIL wedges the push gate (#1769 — the exact bug this
-        # rewrite fixes), whereas a false pass is still caught by the
-        # deterministic overlap guard (``test_concurrency_actually_overlaps``).
-        assert concurrent < sequential * 0.85, (
-            f"Concurrent best {concurrent:.3f}s did not beat measured sequential "
-            f"{sequential:.3f}s by ≥15% (ratio {concurrent / sequential:.2f}) — "
-            "throttle design may be serialising HTTP RTT across threads."
+        assert statuses == [200] * N_REQUESTS
+        assert len(in_handler) == N_REQUESTS, f"expected {N_REQUESTS} sends, transport saw {len(in_handler)}"
+        assert not never_formed.is_set(), (
+            f"{N_REQUESTS} requests never overlapped inside the transport within "
+            f"{BARRIER_TIMEOUT_S}s — the throttle lock is being held across "
+            "``self._client.send``, serialising the HTTP round trip."
         )
 
 


### PR DESCRIPTION
Closes #2610.

## What was wrong

`tests/test_concurrent_fetch.py::TestConcurrencyAchievesActualThroughput::test_concurrent_total_time_smaller_than_sequential` timed a concurrent arm against a sequential one and asserted `concurrent < sequential * 0.85`. Two distinct defects:

**1. It false-failed the push gate.** It sits on the fast tier (`-m "not db"`), i.e. the per-push path. On PR #2609 it failed the pre-push gate on 3 of 4 attempts and passed standalone every time, with a sibling headless autonomy loop holding the box's load average at 2.68-3.59. Per the parallel-session guidance in `.claude/CLAUDE.md`, a sibling loop on this machine is a *normal* operating condition, so this was not fixable by widening the margin — and #2224 records that a randomly-failing gate trains `--no-verify`, which is strictly worse than no gate. This was already the second wall-clock form of the assertion: #1769 replaced an absolute constant with the measured ratio for the same reason, and the ratio false-failed too.

**2. It observed the wrong code.** Its worker was a test-local `fire()`:

```python
def fire(rc: ResilientClient) -> None:
    rc._throttle_and_stamp()
    time.sleep(RESPONSE_MS)  # outside the lock
```

`ResilientClient._request` was never called. The "response time is spent outside the throttle lock" ordering the test asserted was the ordering *the test itself had written*, not the one at `app/providers/resilient_client.py:186-195`. Reinstating the send inside `_request`'s lock could not have moved either arm's timing, because neither arm ran `_request`.

## What changed

One file, tests only. `TestResponseTimeIsSpentOutsideTheThrottleLock::test_all_requests_are_in_flight_simultaneously` replaces it, and drives the real `rc.get()` over an `httpx.MockTransport` whose handler stands in for the SEC round trip. The handler is reached only after `_throttle_and_stamp` has returned, so arrival there means the caller is past the throttle.

The assertion is a rendezvous rather than a stopwatch: `threading.Barrier(4)` inside the handler. Four threads must be in the transport *simultaneously*. If the send were held under `_throttle_lock`, handler occupancy caps at 1, the barrier cannot form, and `BrokenBarrierError` sets a flag the test asserts on. Host load moves how long a pass takes, never whether it passes.

## Verification

Revert-probe of the exact defect the test names — `with self._throttle_lock:` wrapped around `response = self._client.send(request)` in `_request` (injected via string replace with `assert s.count(old) == 1` first, so the probe cannot silently match nothing):

- **with defect:** FAILS with its own message — `AssertionError: 4 requests never overlapped inside the transport within 5.0s — the throttle lock is being held across ``self._client.send``, serialising the HTTP round trip.` Exactly one test in the file failed, so the guard is specific rather than incidentally load-bearing.
- **restored:** 0 failures.

Repeat runs: `tests/test_concurrent_fetch.py` green 3/3 consecutive runs under `-p no:randomly`.

Gates, each run separately and unpiped (a pipe returns the pipe's status):

| gate | exit |
| --- | --- |
| `uv run ruff check .` | 0 |
| `uv run ruff format --check .` | 0 |
| `uv run pyright` | 0 (0 errors, 0 warnings) |
| `uv run pytest -m "not db" -q` | 0 |
| `uv run pytest tests/smoke -q -n 0` | 0 |

Pre-push hook green (its dev-DB-size warning at 69 GB is the known-stale 60 GB threshold, non-blocking, unrelated).

## Coverage not lost

`TestRateLimitSafetyUnderConcurrency::test_throttle_lock_serialises_request_stamping` still pins the other half of the design — that stamping *is* serialised at `1 / min_interval` — so removing the throughput arm does not leave the rate ceiling unguarded.

## Scope note

Test-only, one file. No production code, no schema, no data semantics — narrow rung on the review-intensity ladder, so no Codex checkpoint-2 pass.

## Security

No security surface: no auth, no user input, no SQL, no credential handling. Test file only.
