### PR TITLE
tech-debt(#2641): batch promote_strategy's five per-result reads

### DIFF
--- a/app/services/result_ledger.py
+++ b/app/services/result_ledger.py
@@ -506,6 +506,16 @@ _COUNT_ARM_PAIR = """
       AND result_version = ANY(%(result_versions)s)
 """
 
+#: The batch form of the above (#2641) — which versions exist, rather than how
+#: many rows. See ``_arm_pairs_present`` for why the two agree.
+_SELECT_ARM_VERSIONS = """
+    SELECT result_version
+    FROM strategy_results_store
+    WHERE strategy_id = %(strategy_id)s
+      AND strategy_version = %(strategy_version)s
+      AND result_version = ANY(%(result_versions)s::text[])
+"""
+
 #: ``sql/269``. Column order is shared with the read below and with
 #: ``_fold_row``; the round-trip test is what pins the three together.
 _FOLD_COLUMNS = """
@@ -1908,10 +1918,59 @@ def quarantine_arm_pair_present(conn: psycopg.Connection[tuple], identity: Resul
     return int(row[0]) == 2
 
 
+def _arm_pairs_present(
+    conn: psycopg.Connection[tuple], identities: Sequence[ResultIdentity]
+) -> dict[ResultIdentity, bool]:
+    """``quarantine_arm_pair_present`` for many identities, in ONE statement (#2641).
+
+    ⚠ MEMBERSHIP, NOT A COUNT — and the two are equivalent only because of
+    ``sql/262_strategy_results.sql:182``, ``UNIQUE (strategy_id,
+    strategy_version, result_version)``. The singular form asks for
+    ``count(*) == 2`` over the two arm versions, which without that constraint
+    could be satisfied by two rows of the SAME arm. Verified on the full
+    population 2026-08-13: 0 duplicate triples over 324 stored rows. If the
+    constraint is ever dropped, this batch and its singular sibling stop
+    agreeing — that is the reason to name it here rather than in a commit
+    message.
+
+    Every identity in one promotion shares a ``(strategy_id, strategy_version)``
+    by construction (they are results pinned to one version), so a single
+    predicate over the union of arm versions covers all of them; a mixed batch
+    would silently ask the wrong question, hence the assertion.
+    """
+    if not identities:
+        return {}
+    strategy_ids = {(identity.strategy_id, identity.strategy_version) for identity in identities}
+    if len(strategy_ids) != 1:
+        raise RuntimeError(f"arm-pair batch spans {len(strategy_ids)} strategy versions; expected exactly one")
+    strategy_id, strategy_version = next(iter(strategy_ids))
+    siblings = {
+        identity: replace(identity, quarantine_arm=("admitted" if identity.quarantine_arm == "masked" else "masked"))
+        for identity in identities
+    }
+    wanted = sorted({identity.version for identity in identities} | {s.version for s in siblings.values()})
+    rows = conn.execute(
+        _SELECT_ARM_VERSIONS,
+        {
+            "strategy_id": strategy_id,
+            "strategy_version": strategy_version,
+            "result_versions": wanted,
+        },
+    ).fetchall()
+    present = {str(row[0]) for row in rows}
+    return {identity: identity.version in present and siblings[identity].version in present for identity in identities}
+
+
 _SELECT_RESULT_BY_ID = f"""
     SELECT {_RESULT_COLUMNS}
     FROM strategy_results_store
     WHERE result_id = %(result_id)s
+"""  # noqa: S608 - a module-level literal, no caller input reaches the fragment
+
+_SELECT_RESULTS_BY_IDS = f"""
+    SELECT result_id, {_RESULT_COLUMNS}
+    FROM strategy_results_store
+    WHERE result_id = ANY(%(result_ids)s::bigint[])
 """  # noqa: S608 - a module-level literal, no caller input reaches the fragment
 
 
@@ -1956,16 +2015,16 @@ def stored_result_promotion_refusals(conn: psycopg.Connection[tuple], result_id:
     (``sql/262``, ``sql/335``), so this is defence in depth; the two coercions
     must not be collapsed onto the weaker one.
     """
-    row = conn.execute(_SELECT_RESULT_BY_ID, {"result_id": result_id}).fetchone()
-    if row is None:
-        # ⚠ RAISES, does not refuse. `PromotionRefusal` is a closed vocabulary
-        # of reasons a REAL result may not be promoted; "the row does not exist"
-        # is a caller error, and `promote_strategy` has already refused an
-        # unknown result_id with its own message before reaching here. Inventing
-        # a refusal code for it would put a programming error into the operator's
-        # list of things to fix about a strategy.
-        raise RuntimeError(f"no stored result row for result_id {result_id}")
-    result = _result_from_row(row)
+    return stored_result_promotion_refusals_for(conn, [result_id])[result_id]
+
+
+def _refusals_for_result(result: StrategyResult, *, arm_pair_present: bool) -> tuple[PromotionRefusal, ...]:
+    """The pure half: ``check_promotable``'s order over one rebuilt row.
+
+    Split out so the single and batch reads apply the same clauses in the same
+    order — the acceptance on #2641 is that batching changes the number of
+    statements and nothing about the verdict.
+    """
     refusals: list[PromotionRefusal] = []
     # `check_promotable`'s order, minus the blocks the transition replays from
     # their own frozen records (universe, ambiguity) or reads separately (the
@@ -1982,10 +2041,46 @@ def stored_result_promotion_refusals(conn: psycopg.Connection[tuple], result_id:
     # Criterion 9 — re-derived from the two arms' rows rather than from a
     # recorded boolean. See `quarantine_arm_pair_present` for why the recording
     # door is not the one the transition uses.
-    if not quarantine_arm_pair_present(conn, result.identity):
+    if not arm_pair_present:
         refusals.append("quarantine_arms_not_compared")
     refusals.extend(synthetic_control_promotion_refusals(result.synthetic_control))
     return tuple(refusals)
+
+
+def stored_result_promotion_refusals_for(
+    conn: psycopg.Connection[tuple], result_ids: Sequence[int]
+) -> dict[int, tuple[PromotionRefusal, ...]]:
+    """``stored_result_promotion_refusals`` for a whole batch, in TWO statements (#2641).
+
+    One row read for every result, one arm-version read for every identity —
+    where the per-result form issued two per result. The verdict, its codes and
+    their order are unchanged; only the statement count moves.
+
+    ⚠ Same ``RuntimeError`` on a missing row, and the same masking cost: a
+    corrupt or absent row anywhere in the batch now raises BEFORE any result's
+    refusals are returned, where the per-result loop would have reported the
+    earlier results first. That reordering is inherent to batching and is why it
+    is stated rather than assumed — the raise is an integrity failure either
+    way, but which one an operator sees first has changed.
+    """
+    if not result_ids:
+        return {}
+    rows = conn.execute(_SELECT_RESULTS_BY_IDS, {"result_ids": list(result_ids)}).fetchall()
+    results = {int(row[0]): _result_from_row(row[1:]) for row in rows}
+    for result_id in result_ids:
+        if result_id not in results:
+            # ⚠ RAISES, does not refuse. `PromotionRefusal` is a closed vocabulary
+            # of reasons a REAL result may not be promoted; "the row does not exist"
+            # is a caller error, and `promote_strategy` has already refused an
+            # unknown result_id with its own message before reaching here. Inventing
+            # a refusal code for it would put a programming error into the operator's
+            # list of things to fix about a strategy.
+            raise RuntimeError(f"no stored result row for result_id {result_id}")
+    pairs = _arm_pairs_present(conn, [results[result_id].identity for result_id in result_ids])
+    return {
+        result_id: _refusals_for_result(results[result_id], arm_pair_present=pairs[results[result_id].identity])
+        for result_id in result_ids
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/strategy_control_plane.py
+++ b/app/services/strategy_control_plane.py
@@ -17,7 +17,7 @@ from typing import Any, Literal, cast
 import psycopg
 import psycopg.rows
 
-from app.services.result_ledger import holdout_access_counts, stored_result_promotion_refusals
+from app.services.result_ledger import holdout_access_counts, stored_result_promotion_refusals_for
 from app.services.strategy_base_currency import (
     DEPLOYMENT_CURRENCY,
     DEPLOYMENT_CURRENCY_UNSUPPORTED,
@@ -26,10 +26,10 @@ from app.services.strategy_base_currency import (
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST, StrategyPurpose
 from app.services.strategy_promotion_evidence import evidence_refusals
-from app.services.strategy_promotion_evidence_store import load_promotion_evidence
+from app.services.strategy_promotion_evidence_store import load_promotion_evidences
 from app.services.strategy_result import holdout_count_promotion_refusals, structural_promotion_refusals
-from app.services.strategy_result_ambiguity import ambiguity_promotion_refusals, load_result_ambiguity
-from app.services.strategy_result_universe import load_result_universe, universe_promotion_refusals
+from app.services.strategy_result_ambiguity import ambiguity_promotion_refusals, load_result_ambiguities
+from app.services.strategy_result_universe import load_result_universes, universe_promotion_refusals
 
 Stage = Literal[
     "research_candidate",
@@ -550,6 +550,16 @@ def promote_strategy(
                 )
                 for row in rows
             }
+            # #2641 — every per-result record type is read for the WHOLE batch
+            # before the loop, one statement each, where the loop previously
+            # issued five round trips per pinned result. ⚠ The reordering this
+            # buys is named on `stored_result_promotion_refusals_for`: a corrupt
+            # record anywhere in the batch now raises before ANY result's
+            # refusals are gathered. Within a result nothing moves.
+            universes = load_result_universes(conn, result_ids)
+            ambiguities = load_result_ambiguities(conn, result_ids)
+            stored_refusals = stored_result_promotion_refusals_for(conn, result_ids)
+            evidences = load_promotion_evidences(conn, result_ids)
             for result_id in result_ids:
                 # #2621 — the transition REPLAYS the universe check from the
                 # frozen record instead of trusting the write-time refusal that
@@ -562,7 +572,7 @@ def promote_strategy(
                 # before raising so one missing input cannot mask the other.
                 refusals = list(
                     universe_promotion_refusals(
-                        load_result_universe(conn, result_id),
+                        universes.get(result_id),
                         evaluated_instrument_count=evaluated_count_by_result[result_id],
                     )
                 )
@@ -570,7 +580,7 @@ def promote_strategy(
                 # frozen record rather than trusted. Same shape and the same
                 # argument as the universe replay above; the record stores the
                 # comparison's INPUTS so the verdict can be disagreed with.
-                refusals.extend(ambiguity_promotion_refusals(load_result_ambiguity(conn, result_id)))
+                refusals.extend(ambiguity_promotion_refusals(ambiguities.get(result_id)))
                 # #2625 — the row's own STRUCTURAL stamps. ⚠ These were
                 # persisted and never replayed: before this, a result stamped
                 # `survivor_only` / `carry_unmodelled` / `fx_unmodelled` — which
@@ -595,9 +605,9 @@ def promote_strategy(
                 # stamps — see `stored_result_promotion_refusals` for why the
                 # read directly above is kept rather than sourced from the
                 # rebuilt object.
-                refusals.extend(stored_result_promotion_refusals(conn, result_id))
+                refusals.extend(stored_refusals[result_id])
                 refusals.extend(holdout_refusals)
-                evidence = load_promotion_evidence(conn, result_id)
+                evidence = evidences.get(result_id)
                 if evidence is None:
                     refusals.append("promotion_evidence_missing")
                 else:

--- a/app/services/strategy_promotion_evidence_store.py
+++ b/app/services/strategy_promotion_evidence_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Sequence
 from datetime import date
 from decimal import Decimal, DecimalException
 from typing import Any, cast
@@ -275,17 +276,12 @@ def _evidence_from_payload(payload: dict[str, Any]) -> PromotionEvidence:
     )
 
 
-def load_promotion_evidence(conn: psycopg.Connection[Any], result_id: int) -> PromotionEvidence | None:
-    row = conn.execute(
-        """
-        SELECT evidence_version, payload_sha256, evidence_payload
-        FROM strategy_promotion_evidence
-        WHERE result_id = %s
-        """,
-        (result_id,),
-    ).fetchone()
-    if row is None:
-        return None
+_SELECT_EVIDENCE_COLUMNS = "evidence_version, payload_sha256, evidence_payload"
+
+
+def _evidence_from_row(result_id: int, row: Any) -> PromotionEvidence:
+    """Verify and rebuild one row. Shared so the single and batch reads cannot
+    verify differently."""
     payload = row[2]
     if not isinstance(payload, dict):
         raise RuntimeError(f"promotion evidence for result {result_id} is not an object")
@@ -302,9 +298,43 @@ def load_promotion_evidence(conn: psycopg.Connection[Any], result_id: int) -> Pr
     return evidence
 
 
+def load_promotion_evidence(conn: psycopg.Connection[Any], result_id: int) -> PromotionEvidence | None:
+    row = conn.execute(
+        f"""
+        SELECT {_SELECT_EVIDENCE_COLUMNS}
+        FROM strategy_promotion_evidence
+        WHERE result_id = %s
+        """,  # noqa: S608 - module-level column literal, no caller input
+        (result_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _evidence_from_row(result_id, row)
+
+
+def load_promotion_evidences(conn: psycopg.Connection[Any], result_ids: Sequence[int]) -> dict[int, PromotionEvidence]:
+    """Every stored evidence record for ``result_ids``, in ONE statement (#2641).
+
+    Keys are only the results that HAVE one; ``promotion_evidence_missing`` is
+    the caller's name for the absent case, so a partial mapping preserves it.
+    """
+    if not result_ids:
+        return {}
+    rows = conn.execute(
+        f"""
+        SELECT result_id, {_SELECT_EVIDENCE_COLUMNS}
+        FROM strategy_promotion_evidence
+        WHERE result_id = ANY(%(result_ids)s::bigint[])
+        """,  # noqa: S608 - module-level column literal, no caller input
+        {"result_ids": list(result_ids)},
+    ).fetchall()
+    return {int(row[0]): _evidence_from_row(int(row[0]), row[1:]) for row in rows}
+
+
 __all__ = [
     "MAX_PAYLOAD_BYTES",
     "evidence_sha256",
     "load_promotion_evidence",
+    "load_promotion_evidences",
     "store_promotion_evidence",
 ]

--- a/app/services/strategy_result_ambiguity.py
+++ b/app/services/strategy_result_ambiguity.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Final, Literal
 
@@ -185,26 +186,15 @@ def store_result_ambiguity(conn: psycopg.Connection[Any], *, result_id: int, rec
     )
 
 
-def load_result_ambiguity(conn: psycopg.Connection[Any], result_id: int) -> AmbiguityRecord | None:
-    """The frozen record, hash-verified, or ``None`` when no record exists.
+_SELECT_AMBIGUITY_COLUMNS = (
+    "ambiguity_rule_version, comparison_basis, best_case_sharpe, "
+    "worst_case_sharpe, cohort_gap_threshold, payload_sha256"
+)
 
-    ⚠ Corruption RAISES rather than refuses, matching ``load_result_universe``
-    and ``load_promotion_evidence``: a record that fails its own hash is an
-    integrity failure to surface loudly, not a gate verdict to report politely.
-    The cost is named in the #2625 spec — a corrupt record aborts before the
-    other refusals are gathered, so it MASKS them.
-    """
-    row = conn.execute(
-        """
-        SELECT ambiguity_rule_version, comparison_basis, best_case_sharpe,
-               worst_case_sharpe, cohort_gap_threshold, payload_sha256
-        FROM strategy_result_ambiguity
-        WHERE result_id = %s
-        """,
-        (result_id,),
-    ).fetchone()
-    if row is None:
-        return None
+
+def _record_from_row(result_id: int, row: Any) -> AmbiguityRecord:
+    """Verify and rebuild one row. Shared so the single and batch reads cannot
+    verify differently."""
     basis = str(row[1])
     if basis not in ("shared_measurement", "arm_sharpes"):
         raise RuntimeError(f"result ambiguity record for result {result_id} has unknown basis {basis!r}")
@@ -218,6 +208,49 @@ def load_result_ambiguity(conn: psycopg.Connection[Any], result_id: int) -> Ambi
     if record_sha256(record) != str(row[5]):
         raise RuntimeError(f"result ambiguity hash mismatch for result {result_id}")
     return record
+
+
+def load_result_ambiguity(conn: psycopg.Connection[Any], result_id: int) -> AmbiguityRecord | None:
+    """The frozen record, hash-verified, or ``None`` when no record exists.
+
+    ⚠ Corruption RAISES rather than refuses, matching ``load_result_universe``
+    and ``load_promotion_evidence``: a record that fails its own hash is an
+    integrity failure to surface loudly, not a gate verdict to report politely.
+    The cost is named in the #2625 spec — a corrupt record aborts before the
+    other refusals are gathered, so it MASKS them.
+    """
+    row = conn.execute(
+        f"""
+        SELECT {_SELECT_AMBIGUITY_COLUMNS}
+        FROM strategy_result_ambiguity
+        WHERE result_id = %s
+        """,  # noqa: S608 - module-level column literal, no caller input
+        (result_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _record_from_row(result_id, row)
+
+
+def load_result_ambiguities(conn: psycopg.Connection[Any], result_ids: Sequence[int]) -> dict[int, AmbiguityRecord]:
+    """Every frozen record for ``result_ids``, in ONE statement (#2641).
+
+    Keys are only the results that HAVE a record; an absent one is already named
+    by ``ambiguity_verdict_unrecorded``, so a partial mapping preserves the
+    distinction. Same snapshot bound as ``load_result_universes``: one instant
+    for this record type, not across record types.
+    """
+    if not result_ids:
+        return {}
+    rows = conn.execute(
+        f"""
+        SELECT result_id, {_SELECT_AMBIGUITY_COLUMNS}
+        FROM strategy_result_ambiguity
+        WHERE result_id = ANY(%(result_ids)s::bigint[])
+        """,  # noqa: S608 - module-level column literal, no caller input
+        {"result_ids": list(result_ids)},
+    ).fetchall()
+    return {int(row[0]): _record_from_row(int(row[0]), row[1:]) for row in rows}
 
 
 def ambiguity_promotion_refusals(record: AmbiguityRecord | None) -> tuple[str, ...]:

--- a/app/services/strategy_result_universe.py
+++ b/app/services/strategy_result_universe.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Final
 
@@ -108,23 +109,13 @@ def store_result_universe(conn: psycopg.Connection[Any], *, result_id: int, reco
     )
 
 
-def load_result_universe(conn: psycopg.Connection[Any], result_id: int) -> ResultUniverseRecord | None:
-    """The frozen record, hash-verified, or ``None`` when no record exists.
+_SELECT_UNIVERSE_COLUMNS = "universe_rule_version, evaluated_instrument_ids, validated_universe_ids, payload_sha256"
 
-    ⚠ Corruption RAISES rather than refuses, matching ``load_promotion_evidence``:
-    a record that fails its own hash or canonical form is an integrity failure
-    to surface loudly, not a gate verdict to report politely.
-    """
-    row = conn.execute(
-        """
-        SELECT universe_rule_version, evaluated_instrument_ids, validated_universe_ids, payload_sha256
-        FROM strategy_result_universe
-        WHERE result_id = %s
-        """,
-        (result_id,),
-    ).fetchone()
-    if row is None:
-        return None
+
+def _record_from_row(result_id: int, row: Any) -> ResultUniverseRecord:
+    """Verify and rebuild one row. Shared so the single and batch reads cannot
+    verify differently — a batch that skipped the hash check would be a second
+    door onto the same record with weaker integrity."""
     evaluated = [int(item) for item in row[1]]
     universe = [int(item) for item in row[2]]
     for name, ids in (("evaluated_instrument_ids", evaluated), ("validated_universe_ids", universe)):
@@ -138,6 +129,54 @@ def load_result_universe(conn: psycopg.Connection[Any], result_id: int) -> Resul
     if record_sha256(record) != str(row[3]):
         raise RuntimeError(f"result universe hash mismatch for result {result_id}")
     return record
+
+
+def load_result_universe(conn: psycopg.Connection[Any], result_id: int) -> ResultUniverseRecord | None:
+    """The frozen record, hash-verified, or ``None`` when no record exists.
+
+    ⚠ Corruption RAISES rather than refuses, matching ``load_promotion_evidence``:
+    a record that fails its own hash or canonical form is an integrity failure
+    to surface loudly, not a gate verdict to report politely.
+    """
+    row = conn.execute(
+        f"""
+        SELECT {_SELECT_UNIVERSE_COLUMNS}
+        FROM strategy_result_universe
+        WHERE result_id = %s
+        """,  # noqa: S608 - module-level column literal, no caller input
+        (result_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    return _record_from_row(result_id, row)
+
+
+def load_result_universes(conn: psycopg.Connection[Any], result_ids: Sequence[int]) -> dict[int, ResultUniverseRecord]:
+    """Every frozen record for ``result_ids``, in ONE statement (#2641).
+
+    Keys are only the results that HAVE a record — an absent record is a state
+    the caller's refusal vocabulary already names (``universe_record_absent``),
+    so returning a partial mapping keeps that distinction rather than inventing
+    a sentinel.
+
+    ⚠ One statement means one snapshot for this record type: every result's
+    record is read at the same instant, where the per-result loop read each at a
+    slightly different one under READ COMMITTED. It does NOT put the universe,
+    ambiguity, evidence and row reads on a single snapshot between them — that
+    would need a repeatable-read transaction, and the tables are immutable by
+    trigger, so the remaining skew is unobservable rather than merely small.
+    """
+    if not result_ids:
+        return {}
+    rows = conn.execute(
+        f"""
+        SELECT result_id, {_SELECT_UNIVERSE_COLUMNS}
+        FROM strategy_result_universe
+        WHERE result_id = ANY(%(result_ids)s::bigint[])
+        """,  # noqa: S608 - module-level column literal, no caller input
+        {"result_ids": list(result_ids)},
+    ).fetchall()
+    return {int(row[0]): _record_from_row(int(row[0]), row[1:]) for row in rows}
 
 
 def universe_promotion_refusals(

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
-from typing import Any
+from typing import Any, cast
 
 import psycopg
 import psycopg.sql
@@ -16,6 +16,8 @@ from app.services.result_ledger import (
     store_holdout_result,
     store_in_sample_arm_pair,
     store_in_sample_result,
+    stored_result_promotion_refusals,
+    stored_result_promotion_refusals_for,
 )
 from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
 from app.services.strategy_control_plane import (
@@ -45,14 +47,22 @@ from app.services.strategy_promotion_evidence import (
     PromotionEvidence,
     RecentYearEvidence,
 )
-from app.services.strategy_promotion_evidence_store import store_promotion_evidence
+from app.services.strategy_promotion_evidence_store import (
+    load_promotion_evidences,
+    store_promotion_evidence,
+)
 from app.services.strategy_result import StrategyResult
 from app.services.strategy_result_ambiguity import (
     AMBIGUITY_RULE_VERSION,
     AmbiguityRecord,
+    load_result_ambiguities,
     store_result_ambiguity,
 )
-from app.services.strategy_result_universe import ResultUniverseRecord, store_result_universe
+from app.services.strategy_result_universe import (
+    ResultUniverseRecord,
+    load_result_universes,
+    store_result_universe,
+)
 from app.services.trial_register import TRIAL_REGISTER, TRIAL_REGISTER_VERSION
 from tests.test_result_ledger import (
     BOOTSTRAP_BLOCK,
@@ -1356,3 +1366,126 @@ def test_an_unsupported_currency_is_unrepresentable_at_rest(
                 (deployment.deployment_id,),
             )
     assert excinfo.value.diag.constraint_name == constraint
+
+
+class _CountingConn:
+    """A connection that records how many statements pass through ``execute``.
+
+    ⚠ Counts the CALLS this code makes, not what the server parses — which is
+    exactly the property #2641 is about. A batch that issued one statement per
+    result would be invisible to a timing assertion on an idle box and is
+    obvious here.
+    """
+
+    def __init__(self, conn: psycopg.Connection[Any]) -> None:
+        self._conn = conn
+        self.statements = 0
+
+    def execute(self, *args: Any, **kwargs: Any) -> Any:
+        self.statements += 1
+        return self._conn.execute(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+
+def _three_stored_rows(conn: psycopg.Connection[Any]) -> list[int]:
+    """Three stored in-sample rows, each its own arm pair so criterion 9 passes.
+
+    Distinct ``input_rule_set_version`` per pair: neither the metrics nor the
+    DSR is part of ``ResultIdentity``, so pairs differing only in those hash to
+    the same ``result_version`` and collide on ``strategy_results_unique``.
+    """
+    result_ids: list[int] = []
+    for index in range(3):
+        version = f"price-quarantine-v1+2641batch{index}"
+        masked = _promotable_row(
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            namespace="in_sample",
+            ambiguity_arm="worst_case",
+            quarantine_arm="masked",
+            input_rule_set_version=version,
+        )
+        admitted = _promotable_row(
+            strategy_id="S-GOV",
+            strategy_version="v1",
+            namespace="in_sample",
+            ambiguity_arm="worst_case",
+            quarantine_arm="admitted",
+            input_rule_set_version=version,
+        )
+        masked_id, _ = store_in_sample_arm_pair(conn, masked, admitted)
+        _universe_record(conn, masked_id, evaluated=frozenset({1, 2, 3}))
+        _ambiguity_record(conn, masked_id)
+        store_promotion_evidence(conn, result_id=masked_id, evidence=_passing_promotion_evidence())
+        result_ids.append(masked_id)
+    return result_ids
+
+
+def test_pinned_result_reads_do_not_scale_with_the_batch(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """#2641 — one statement per record type across the WHOLE batch.
+
+    The per-result loop issued five round trips per pinned result, so the read
+    cost was N+1 in the batch size. Asserting the count is EQUAL at N=1 and N=3
+    pins the property the issue asks for; asserting merely "fewer than before"
+    would pass for a batch that still grew.
+    """
+    conn = ebull_test_conn
+    result_ids = _three_stored_rows(conn)
+
+    def _counts(ids: list[int]) -> dict[str, int]:
+        counted: dict[str, int] = {}
+        for name, call in (
+            ("universe", load_result_universes),
+            ("ambiguity", load_result_ambiguities),
+            ("evidence", load_promotion_evidences),
+            ("stored_row", stored_result_promotion_refusals_for),
+        ):
+            proxy = _CountingConn(conn)
+            call(cast(Any, proxy), ids)
+            counted[name] = proxy.statements
+        return counted
+
+    one = _counts(result_ids[:1])
+    three = _counts(result_ids)
+
+    assert one == three, "a read that grows with the batch is the N+1 this ticket removes"
+    # The row read is two: the row itself, then criterion 9's arm versions.
+    assert three == {"universe": 1, "ambiguity": 1, "evidence": 1, "stored_row": 2}
+
+
+def test_batched_row_refusals_match_the_per_result_verdict(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """Batching changes the statement count and nothing about the verdict.
+
+    Compared against the singular entry point rather than a hard-coded list, so
+    the two cannot drift apart without this failing — a fixed expectation would
+    keep passing if BOTH sides regressed together.
+    """
+    conn = ebull_test_conn
+    result_ids = _three_stored_rows(conn)
+
+    batched = stored_result_promotion_refusals_for(conn, result_ids)
+    for result_id in result_ids:
+        assert batched[result_id] == stored_result_promotion_refusals(conn, result_id)
+
+
+def test_a_missing_row_in_the_batch_raises_rather_than_refusing(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The absent-row contract survives batching.
+
+    ⚠ It raises for the WHOLE batch now, before any result's refusals are
+    returned — the reordering named in the function's docstring. `promote_strategy`
+    refuses an unknown result_id with its own message long before reaching here,
+    so this is the caller-error path, not an operator-visible one.
+    """
+    conn = ebull_test_conn
+    result_ids = _three_stored_rows(conn)
+
+    with pytest.raises(RuntimeError, match="no stored result row for result_id 99999999"):
+        stored_result_promotion_refusals_for(conn, [*result_ids, 99999999])


### PR DESCRIPTION
## What was wrong

`promote_strategy`'s pin loop issued **five** round trips per pinned result — the #2621 universe record, the #2625 ambiguity record, the stored row (itself two: its columns, then criterion 9's arm-pair count), and the #2505 evidence record. Read cost was N+1 in the batch size.

Not urgent, and the issue says so: `strategy_promotions` holds 0 rows, the loop raises on the first failing result, and a promotion is an operator-initiated governance event. The reason to do it is the one the issue gives second — batching gives each record type **one snapshot** instead of one per result under READ COMMITTED.

## What changed

One statement per record type across the whole batch, read before the loop:

| read | statements before | after |
| --- | --- | --- |
| universe record | N | 1 |
| ambiguity record | N | 1 |
| evidence record | N | 1 |
| stored row + arm pair | 2N | 2 |

- `load_result_universes` / `load_result_ambiguities` / `load_promotion_evidences` each share the singular form's row verifier (`_record_from_row` / `_evidence_from_row`). A batch that skipped the hash check would be a second door onto the same record with weaker integrity.
- They return a **partial** mapping. An absent record is a state the refusal vocabulary already names (`universe_record_absent`, `ambiguity_verdict_unrecorded`, `promotion_evidence_missing`), so a sentinel would erase the distinction the caller depends on.
- `stored_result_promotion_refusals_for` batches the row read; the clause application moved to a pure `_refusals_for_result` so the batch and singular paths apply the same clauses in the same order. The singular entry point now delegates to it, so they cannot drift.
- `_arm_pairs_present` reads every identity's arm versions in one statement.

## The one substantive judgement — membership vs count

The singular arm-pair check asks for `count(*) == 2` over the two arm versions. The batch asks whether **both versions are present**. Those are equivalent only under `sql/262_strategy_results.sql:182`:

```sql
UNIQUE (strategy_id, strategy_version, result_version)
```

Without it, `count(*) == 2` could be satisfied by two rows of the *same* arm. Verified on the full population (dev, 2026-08-13): **0 duplicate `(strategy_id, strategy_version, result_version)` triples over 324 stored rows**, and the unique index `strategy_results_unique` is live. Named in `_arm_pairs_present`'s docstring, because dropping that constraint later would silently separate the batch from its singular sibling.

`_arm_pairs_present` also refuses a batch spanning more than one strategy version. That cannot happen through `promote_strategy` — it already raises `result_ids do not belong to <id>@<version>` before the loop — so it is defence in depth against a future caller, not a live path.

## ⚠ What this changes that the issue did not name

**Batching means pre-loading**, so a corrupt or missing record anywhere in the batch now raises *before any* result's refusals are gathered, where the per-result loop would have reported the earlier results first. The raise is an integrity failure either way (`load_result_*` corruption RAISES by design — #2625's recorded decision), but which one an operator sees first has moved. Stated in `stored_result_promotion_refusals_for`'s docstring rather than left to be discovered.

**It does NOT put the four record types on one snapshot between them.** That needs a repeatable-read transaction. All three record tables are immutable by trigger, so the residual skew is unobservable rather than merely small — worth saying, because "batched, therefore consistent" is the easy misreading.

## Tests (`tests/test_strategy_control_plane.py`)

- `test_pinned_result_reads_do_not_scale_with_the_batch` — counts statements through a wrapping connection at N=1 and N=3 and asserts they are **equal**, then pins the exact counts `{universe: 1, ambiguity: 1, evidence: 1, stored_row: 2}`. Asserting merely "fewer than before" would pass for a batch that still grew.
- `test_batched_row_refusals_match_the_per_result_verdict` — compares the batch against the **singular entry point**, not a hard-coded list, so the two cannot regress together unnoticed.
- `test_a_missing_row_in_the_batch_raises_rather_than_refusing` — the absent-row `RuntimeError` contract survives batching.

**Revert-probed:** replacing `load_result_universes`' single statement with a per-result loop fails `test_pinned_result_reads_do_not_scale_with_the_batch` and nothing else.

**Regression coverage held:** the three tests the issue names as the acceptance pins (`test_promotion_replays_the_rows_own_clauses_and_the_holdout_counts` and the #2621/#2625 replay tests) pass unchanged, along with `tests/test_result_ledger.py`, `tests/test_backtest_run.py` and `tests/test_strategy_promotion_replay.py` on the db tier.

## Verification

- Full fast tier (`-m "not db"`) green; db tier green on all four touched test modules.
- ruff / ruff format / pyright clean.
- Codex checkpoint 2: no findings.
- Full-population premise check on dev before coding (the uniqueness measurement above, plus `strategy_promotions` = 0 rows, `strategy_results_store` = 324).

## Security

No security surface: read batching inside an existing governance path, no new endpoint, no new write, no credential or broker path. The promotion gate's refusal vocabulary and fail-closed behaviour are unchanged.

Closes #2641. Refs #2639. Refs #2640. Refs #2437.