### PR TITLE
tech-debt(#2653): keep the deployment-currency refusal, and pin it to its constraint

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1138,6 +1138,22 @@ def get_strategy_overview(
             allocation_refusals.append("execution_policy_missing")
         if scan.status != "current":
             allocation_refusals.append("scan_not_current")
+        # ⚠ CANNOT FIRE TODAY, DELIBERATELY KEPT (#2653). `control.currency` is
+        # 'USD' for every strategy, by three independent routes: `sql/338`'s
+        # `CHECK (currency = 'USD')` on `strategy_deployments` when a row exists,
+        # `load_control_state`'s `str(row["currency"] or "USD")` when the LEFT
+        # JOIN misses, and `StrategyControlState.currency`'s own default when the
+        # key is absent entirely. So this reads as live protection in the
+        # refusal vocabulary while being unreachable — which is the cost #2653
+        # filed, and the reason it is named here rather than left to be
+        # rediscovered.
+        #
+        # It stays because it is the chokepoint a WIDENING is supposed to trip.
+        # `strategy_base_currency` lists this line among the sites to revisit
+        # when support grows; widen the CHECK to two currencies while the
+        # constant names one and this is the branch that refuses the third.
+        # `test_the_deployment_currency_refusal_and_its_constraint_agree` fails
+        # the moment either side moves alone.
         if control.currency not in SUPPORTED_DEPLOYMENT_CURRENCIES:
             allocation_refusals.append(DEPLOYMENT_CURRENCY_UNSUPPORTED)
         if entry.purpose == "capital_candidate" and not allocation_refusals:

--- a/app/services/strategy_base_currency.py
+++ b/app/services/strategy_base_currency.py
@@ -36,7 +36,17 @@ DEPLOYMENT_CURRENCY = "USD"
 #   strategy_paper_executor.py:374                 stored-deployment membership gate
 #   strategy_paper_executor.py:555                 broker eligibility currency == intent
 #   strategy_paper_executor.py:593                 cost component currency == intent
-#   app/api/strategies.py:1129                     allocation_refusals membership gate
+#   app/api/strategies.get_strategy_overview       allocation_refusals membership gate
+#
+# ⚠ THAT LAST SITE CANNOT FIRE TODAY and is kept precisely for this widening
+# (#2653).  `control.currency` is 'USD' for every strategy by three routes -- the
+# CHECK above when a deployment row exists, `load_control_state`'s
+# `str(row["currency"] or "USD")` when the LEFT JOIN misses, and
+# `StrategyControlState.currency`'s own default when the key is absent -- so it
+# reads as live protection while being unreachable.  Widen the CHECK past this
+# constant and it becomes the branch that refuses the difference.
+# `test_the_deployment_currency_refusal_and_its_constraint_agree` fails when
+# either side moves alone.
 #
 # The two executor equality sites are equality ON PURPOSE: see `_eligibility_reason`.
 # Also revisit, though they are NOT bound to this constant: sql/290:96 +

--- a/tests/test_strategy_control_plane.py
+++ b/tests/test_strategy_control_plane.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date
 from decimal import Decimal
 from typing import Any, cast
@@ -10,6 +11,7 @@ import psycopg
 import psycopg.sql
 import pytest
 
+from app.api.strategies import get_strategy_overview
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
 from app.services.result_ledger import (
@@ -20,6 +22,10 @@ from app.services.result_ledger import (
     stored_result_promotion_refusals_for,
 )
 from app.services.strategies.validated_universe import VALIDATED_UNIVERSE_RULE_VERSION
+from app.services.strategy_base_currency import (
+    DEPLOYMENT_CURRENCY_UNSUPPORTED,
+    SUPPORTED_DEPLOYMENT_CURRENCIES,
+)
 from app.services.strategy_control_plane import (
     StrategyControlError,
     StrategyOwnershipError,
@@ -1366,6 +1372,65 @@ def test_an_unsupported_currency_is_unrepresentable_at_rest(
                 (deployment.deployment_id,),
             )
     assert excinfo.value.diag.constraint_name == constraint
+
+
+@pytest.mark.parametrize(
+    ("table", "constraint"),
+    [
+        ("strategy_deployments", "strategy_deployments_currency_supported"),
+        ("strategy_deployment_events", "strategy_deployment_events_currency_supported"),
+    ],
+)
+def test_the_deployment_currency_refusal_and_its_constraint_agree(
+    ebull_test_conn: psycopg.Connection[Any],
+    table: str,
+    constraint: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2653 — the CHECK and ``SUPPORTED_DEPLOYMENT_CURRENCIES`` must move together.
+
+    ``deployment_currency_unsupported`` on ``/strategies/overview`` cannot fire
+    while the CHECK admits exactly the one currency the constant names: the
+    predicate is false for every row that can exist. The branch is kept as the
+    chokepoint a WIDENING trips, and this is what stops the two sides drifting —
+    widen the constraint alone and the refusal quietly becomes live for a state
+    nobody meant to allow; widen the constant alone and the refusal is dead
+    again for the currency that was just added.
+
+    ⚠ Reads the constraint's own text from ``pg_constraint`` rather than probing
+    an insert. A probe can only show that ONE currency is refused; the drift this
+    guards against is the admitted SET changing, which the definition states and
+    a probe cannot.
+    """
+    conn = ebull_test_conn
+    row = conn.execute(
+        """
+        SELECT pg_get_constraintdef(c.oid)
+        FROM pg_constraint c
+        JOIN pg_class t ON t.oid = c.conrelid
+        WHERE t.relname = %s AND c.conname = %s
+        """,
+        (table, constraint),
+    ).fetchone()
+    assert row is not None, f"{constraint} is missing from {table} — sql/338 did not apply"
+
+    definition = str(row[0])
+    admitted = {code for code in re.findall(r"'([^']*)'", definition)}
+    assert admitted == set(SUPPORTED_DEPLOYMENT_CURRENCIES), (
+        f"{constraint} admits {sorted(admitted)} but SUPPORTED_DEPLOYMENT_CURRENCIES is "
+        f"{sorted(SUPPORTED_DEPLOYMENT_CURRENCIES)}; see the branch in app/api/strategies.py "
+        "that refuses the difference"
+    )
+
+    # ⚠ And the branch is live WIRING, not decoration. Without this the test
+    # above would pass just as well against a deleted branch — which is the one
+    # outcome #2653 weighed and rejected. Widening the constant is the only way
+    # to reach it from a test, because the state it refuses is unrepresentable
+    # at rest by the very constraint just asserted.
+    monkeypatch.setattr("app.api.strategies.SUPPORTED_DEPLOYMENT_CURRENCIES", frozenset({"CHF"}))
+    overview = get_strategy_overview(conn)
+    assert overview.strategies, "no strategies in the overview — the assertion below would be vacuous"
+    assert all(DEPLOYMENT_CURRENCY_UNSUPPORTED in row.allocation_refusals for row in overview.strategies)
 
 
 class _CountingConn:


### PR DESCRIPTION
## The measurement

`app/api/strategies.py` appends `deployment_currency_unsupported` to `allocation_refusals` when `control.currency` is outside `SUPPORTED_DEPLOYMENT_CURRENCIES`. **It cannot fire.** The issue named one reason; there are three, and two of them are in the read path itself rather than a layer down:

| route | why `control.currency` is `"USD"` |
| --- | --- |
| a deployment row exists | `sql/338_strategy_deployment_currency.sql:31` — `CHECK (currency = 'USD')` |
| the LEFT JOIN misses (no deployment) | `load_control_state`: `currency=str(row["currency"] or "USD")` |
| the key is absent entirely | `StrategyControlState.currency` defaults to `"USD"` |

`SUPPORTED_DEPLOYMENT_CURRENCIES` is `frozenset({"USD"})`. So the predicate is false for every state that can be reached, and the branch reads as live protection in the overview's refusal vocabulary while being unreachable — the cost the issue filed.

## The decision: option 2 + 3, not option 1

The issue offered three (delete / comment / pin). **Kept**, because it is the chokepoint a *widening* is supposed to trip. `strategy_base_currency` already lists this site among those to revisit when currency support grows; widen the CHECK to two currencies while the constant names one, and this is the branch that refuses the third. Deleting it removes a step a documented procedure expects to be there.

The real defect is not the branch — it is that nothing connected it to the constraint that makes it dead, so either side could move alone and nobody would learn.

## What stops it rotting

`test_the_deployment_currency_refusal_and_its_constraint_agree` (both the current-state and event tables):

1. Reads the constraint's own definition from `pg_constraint` and asserts the set of currencies it admits **equals** `SUPPORTED_DEPLOYMENT_CURRENCIES`. Reading the definition rather than probing an insert is deliberate: a probe can only show that one currency is refused, while the drift being guarded is the admitted *set* changing.
2. Patches the constant and drives `get_strategy_overview` to prove the branch is live wiring rather than decoration. Without this, step 1 would pass just as well against a deleted branch — which is the outcome this ticket weighed and rejected.

**Revert-probed both halves:**

- delete the branch → both parametrisations fail;
- widen `SUPPORTED_DEPLOYMENT_CURRENCIES` to `{"USD", "EUR"}` alone → both fail with `strategy_deployments_currency_supported admits ['USD'] but SUPPORTED_DEPLOYMENT_CURRENCIES is ['EUR', 'USD']; see the branch in app/api/strategies.py that refuses the difference`.

## The sibling the issue asked about

`strategy_paper_pool_events.currency` (`sql/290:96`) carries the same `CHECK (currency = 'USD')`, but there is **no read-side refusal over it** — `PaperPool.currency` is read and rendered, never gated. So there is no dead-refusal twin to keep in step, and nothing changed there.

## Incidental

`strategy_base_currency`'s coordination comment named this site by **line number** (`app/api/strategies.py:1129`), which had already drifted to 1141. Replaced with the function name.

## Scope

Comments and one test. `git diff --stat origin/main...HEAD` is 3 files, +92/-1, and **no behaviour changes** — which is why this sits below the review ladder's "behavioural change with data semantics" rung and did not take a Codex pre-push pass.

## Verification

- db tier green on `tests/test_strategy_control_plane.py`, `tests/test_strategy_base_currency.py`, `tests/test_strategy_monitoring.py`.
- ruff / ruff format / pyright clean (0 errors).

## Security

No security surface. The change is documentation plus a test; the refusal it documents is a fail-closed gate whose behaviour is unchanged, and no credential, broker or authorisation path is touched.

Closes #2653. Refs #2648. Refs #2363. Refs #2437.