### PR TITLE
feature(#2598): report the bounding statistics beside the frozen p75

### DIFF
--- a/scripts/verify_2240_cost_model.py
+++ b/scripts/verify_2240_cost_model.py
@@ -198,9 +198,7 @@ def _freeze_ready(value: Decimal) -> Decimal:
     return value.quantize(_FREEZE_QUANTUM, rounding=ROUND_CEILING)
 
 
-def _report_bounding_statistics(
-    by_band: dict[str, list[Decimal]], *, top_hour: int | None, top_count: int
-) -> None:
+def _report_bounding_statistics(by_band: dict[str, list[Decimal]], *, top_hour: int | None, top_count: int) -> None:
     """Print the BOUNDING statistics beside the frozen p75 (#2598 scope 5, step 1).
 
     ⚠⚠ WHY THIS TABLE EXISTS, IN ONE LINE: **a p75 is not a bound.** #2598 scope

--- a/scripts/verify_2240_cost_model.py
+++ b/scripts/verify_2240_cost_model.py
@@ -26,6 +26,13 @@ the frozen one. Session membership comes from ``market_calendar``, never from
   OPTIMISTIC (charging less than today's measurement) so a real recalibration
   decision has the number in front of it.
 
+  ⚠ It also prints a SECOND, bounding table — p95 and the sample max, with the
+  freeze-ready (ROUND_CEILING, 0.001 pp) form of each. #2598 scope 5 asks for
+  the banded model to become the declared execution-side conservative bound,
+  and a p75 cannot be one: a quarter of its population exceeds it by
+  construction. Reported, never adopted — adopting a column is a new
+  ``COST_MODEL_ID``. See ``_report_bounding_statistics``.
+
 ``--positions`` — cost every position S-1 and S-3 produce over the §4.0
 validated universe, through the real path (``s1_signals`` / ``s3_signals`` →
 ``signal_ledger.resolve_fills`` → ``build_positions`` → ``cost_positions``), and
@@ -60,7 +67,7 @@ from collections import Counter
 from collections.abc import Sequence
 from datetime import date, datetime
 from datetime import time as clock_time
-from decimal import Decimal
+from decimal import ROUND_CEILING, Decimal
 from zoneinfo import ZoneInfo
 
 import psycopg
@@ -149,18 +156,97 @@ def _in_session(quoted_at: datetime) -> bool:
     return SESSION_OPEN <= local.time() < close
 
 
-def _p75_disc(values: Sequence[Decimal]) -> Decimal:
-    """The discrete p75 — an OBSERVED spread, never an interpolation.
+def _percentile_disc(values: Sequence[Decimal], *, percentile: int) -> Decimal:
+    """A discrete percentile — an OBSERVED spread, never an interpolation.
 
     ⚠ Stated because it is a choice with no published rule, so it is fixed by
     construction and frozen with the model: ``percentile_disc`` semantics, the
-    smallest observed value whose cumulative share reaches 0.75. An interpolated
-    p75 is a number no instrument was ever quoted at, and the model claims to
-    charge a spread somebody actually saw.
+    smallest observed value whose cumulative share reaches ``percentile/100``.
+    An interpolated percentile is a number no instrument was ever quoted at, and
+    the model claims to charge a spread somebody actually saw.
+
+    ⚠ INTEGER ARITHMETIC, not ``q * n`` in float. ``ceil(n × p / 100)`` is exact
+    here; the float form is off by one wherever ``q * n`` lands a ulp below an
+    integer, and the value it then selects is the neighbouring observation
+    rather than an approximation of the right one. ``percentile=100`` is the
+    sample maximum, which is the same rule at its limit rather than a special
+    case.
     """
+    if not 1 <= percentile <= 100:
+        raise ValueError(f"percentile must be in 1..100, got {percentile}")
+    if not values:
+        # ⚠ Explicit, because the index arithmetic below lands on -1 for an
+        # empty sequence and would return the LAST element of nothing — i.e.
+        # IndexError, from a function whose job is to answer a question about a
+        # sample that does not exist. Callers band their quotes first and must
+        # report "no sample" themselves.
+        raise ValueError(f"cannot take the p{percentile} of an empty sample")
     ordered = sorted(values)
-    index = min(len(ordered) - 1, max(0, -(-len(ordered) * 3 // 4) - 1))
+    index = min(len(ordered) - 1, max(0, -(-len(ordered) * percentile // 100) - 1))
     return ordered[index]
+
+
+#: The freeze quantum and its direction, restated from ``cost_model``'s BANDS
+#: note so a recalibration candidate is printed in the form it would be frozen
+#: in: 0.001 percentage points (0.1 bp), ROUND_CEILING, so the frozen model is
+#: never CHEAPER than the measurement it came from.
+_FREEZE_QUANTUM = Decimal("0.001")
+
+
+def _freeze_ready(value: Decimal) -> Decimal:
+    """The value as it would enter ``BANDS`` — quantised AWAY from zero cost."""
+    return value.quantize(_FREEZE_QUANTUM, rounding=ROUND_CEILING)
+
+
+def _report_bounding_statistics(
+    by_band: dict[str, list[Decimal]], *, top_hour: int | None, top_count: int
+) -> None:
+    """Print the BOUNDING statistics beside the frozen p75 (#2598 scope 5, step 1).
+
+    ⚠⚠ WHY THIS TABLE EXISTS, IN ONE LINE: **a p75 is not a bound.** #2598 scope
+    5 asks for the banded model to become *"the declared execution-side
+    conservative bound"* for unleveraged long stock, and a 75th percentile is
+    exceeded by a quarter of its own population BY CONSTRUCTION. That is a
+    property of the statistic, not of the sample, so no amount of extra
+    calibration data repairs it — only a different statistic does. This arm
+    computes the two candidates the ticket names (p95, or the sample max) over
+    the same population, the same session rule and the same freeze discipline,
+    so the recalibration decision has its numbers in front of it.
+
+    ⚠ NOTHING IS FROZEN HERE. Adopting a column ships a NEW ``COST_MODEL_ID``
+    (``cost_model``'s own rule — a change to what is charged is a new model, not
+    a silent improvement), which moves every strategy version and supersedes
+    every stored result under the current id. The freeze-ready column is printed
+    so that decision is a copy, not a hand-quantisation.
+
+    ⚠ THE MAX IS A SAMPLE MAX. ``quotes`` holds one row per instrument,
+    overwritten on every refresh, so this is the widest spread in ONE snapshot
+    of a fraction of the universe — an upper bound on what was observed, never
+    on what can occur. The caveat line prints the n and the capture-hour
+    concentration it rests on, because that is what decides how much of the
+    trading day it has ever seen.
+    """
+    print("\n  ⚠ p75 is not a bound — a quarter of the population exceeds it by construction (#2598 scope 5).")
+    print("  band          n   p75 today   p95 today   max today   p95 frozen-ready   max frozen-ready   p95/frozen")
+    for band in BANDS:
+        values = by_band[band.label]
+        if not values:
+            print(f"  {band.label:<10} {0:>4}   {'—':>9}   {'—':>9}   {'—':>9}   {'—':>16}   {'—':>16}   {'—':>10}")
+            continue
+        p75 = _percentile_disc(values, percentile=75)
+        p95 = _percentile_disc(values, percentile=95)
+        widest = _percentile_disc(values, percentile=100)
+        uplift = (p95 / band.p75_spread_pct).quantize(Decimal("0.01"))
+        print(
+            f"  {band.label:<10} {len(values):>4}   {p75:>9}   {p95:>9}   {widest:>9}   "
+            f"{_freeze_ready(p95):>16}   {_freeze_ready(widest):>16}   {uplift:>9}x"
+        )
+    priced = sum(len(values) for values in by_band.values())
+    hour = f"UTC {top_hour}" if top_hour is not None else "—"
+    print(
+        f"  ⚠ sample max over {priced:,} priced in-session quotes, {top_count:,} of them at {hour} — "
+        "one hour of one snapshot, not a population maximum"
+    )
 
 
 def calibrate() -> int:
@@ -223,12 +309,14 @@ def calibrate() -> int:
                 f"{band.half_spread_pct:>11}   NO SAMPLE"
             )
             continue
-        today = _p75_disc(values)
+        today = _percentile_disc(values, percentile=75)
         verdict = "OPTIMISTIC" if band.p75_spread_pct < today else "conservative"
         print(
             f"  {band.label:<10} {len(values):>7}   {today:>10}   {band.p75_spread_pct:>10}   "
             f"{band.half_spread_pct:>11}   {verdict}"
         )
+
+    _report_bounding_statistics(by_band, top_hour=top_hour, top_count=top_count)
 
     print(
         f"\n  carry_bps {CARRY_BPS}   fx_bps {FX_BPS}   "

--- a/tests/test_verify_2240_cost_model_statistics.py
+++ b/tests/test_verify_2240_cost_model_statistics.py
@@ -1,0 +1,98 @@
+"""The calibration arm's statistics, as pure logic (#2598 scope 5, step 1).
+
+Spec: ``docs/proposals/ta/2026-08-07-bounded-backtester.md`` §5.1. The band
+table itself is pinned in ``tests/test_cost_model.py``; what is pinned HERE is
+the arithmetic that would produce the next one — the discrete-percentile rule
+and the freeze quantisation.
+
+⚠ Worth its own file because the numbers this arm prints are candidates for a
+frozen literal. An off-by-one in the percentile index does not fail anything: it
+selects the neighbouring observation, prints a plausible number, and that number
+becomes a model somebody charges. There is no downstream assertion that would
+catch it.
+
+⚠ DB-free by design. Both functions are pure over a sequence of ``Decimal``.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+
+import pytest
+
+from scripts.verify_2240_cost_model import _freeze_ready, _percentile_disc
+
+
+def _decimals(*values: str) -> list[Decimal]:
+    return [Decimal(value) for value in values]
+
+
+class TestTheDiscretePercentile:
+    """``percentile_disc``: the smallest OBSERVED value reaching the share."""
+
+    def test_it_returns_an_observed_value_and_never_an_interpolation(self) -> None:
+        """The model claims to charge a spread somebody was actually quoted."""
+        sample = _decimals("1.0", "2.0", "3.0", "4.0")
+        for percentile in range(1, 101):
+            assert _percentile_disc(sample, percentile=percentile) in sample
+
+    @pytest.mark.parametrize(
+        ("percentile", "expected"),
+        [
+            (25, "1.0"),  # ceil(4 × 0.25) = 1 -> the 1st smallest
+            (50, "2.0"),
+            (75, "3.0"),
+            (100, "4.0"),
+        ],
+    )
+    def test_the_index_is_ceil_n_times_p(self, percentile: int, expected: str) -> None:
+        assert _percentile_disc(_decimals("4.0", "1.0", "3.0", "2.0"), percentile=percentile) == Decimal(expected)
+
+    def test_p100_is_the_sample_maximum(self) -> None:
+        """The same rule at its limit, not a special case — so the bounding
+        table's ``max`` column cannot drift away from its percentile siblings."""
+        sample = _decimals("0.5", "9.25", "3.0")
+        assert _percentile_disc(sample, percentile=100) == max(sample)
+
+    def test_the_index_is_exact_where_the_float_form_is_off_by_one(self) -> None:
+        """⚠ THE REGRESSION THIS FILE EXISTS FOR.
+
+        ``0.07 * 100`` is ``7.000000000000001`` in binary floating point, so
+        ``ceil`` of it is 8 and the float form selects the WRONG observation —
+        silently, and only for the percentiles where the product lands a ulp
+        above an integer. Integer arithmetic has no such case.
+        """
+        assert math.ceil(0.07 * 100) == 8, "the float hazard this test pins has changed"
+        sample = [Decimal(n) for n in range(1, 101)]
+        assert _percentile_disc(sample, percentile=7) == Decimal(7)
+
+    def test_a_single_observation_is_its_own_every_percentile(self) -> None:
+        assert _percentile_disc(_decimals("1.45"), percentile=95) == Decimal("1.45")
+
+    def test_an_empty_sample_is_refused_rather_than_wrapping_to_the_last_element(self) -> None:
+        with pytest.raises(ValueError, match="empty sample"):
+            _percentile_disc([], percentile=95)
+
+    @pytest.mark.parametrize("percentile", [0, -1, 101])
+    def test_a_percentile_outside_one_to_a_hundred_is_refused(self, percentile: int) -> None:
+        with pytest.raises(ValueError, match="percentile must be in 1..100"):
+            _percentile_disc(_decimals("1.0"), percentile=percentile)
+
+
+class TestTheFreezeQuantisation:
+    """ROUND_CEILING to 0.001 pp — the frozen model is never CHEAPER."""
+
+    def test_it_never_rounds_a_cost_down(self) -> None:
+        """The one direction that flatters a result. Criterion 2 puts the model
+        deliberately at the pessimistic end."""
+        for raw in _decimals("2.461538", "6.863905", "0.0000001", "12.421053", "0.399838"):
+            assert _freeze_ready(raw) >= raw
+
+    def test_it_lands_on_the_declared_quantum(self) -> None:
+        assert _freeze_ready(Decimal("2.461538")) == Decimal("2.462")
+        assert _freeze_ready(Decimal("0.871489")) == Decimal("0.872")
+
+    def test_an_already_quantised_value_is_unchanged(self) -> None:
+        """A re-freeze of the current table must not inflate it by a quantum."""
+        assert _freeze_ready(Decimal("1.450")) == Decimal("1.450")


### PR DESCRIPTION
## What

`--calibrate` now prints a second, **bounding** table beside the existing p75 drift table: p95 and the sample max per band, each in its freeze-ready form, plus the uplift over the frozen p75.

This is #2598 scope 5 **step 1** of four. It changes no production code path and no `COST_MODEL_ID`.

## Why

Scope 5 asks for the banded static model to become *"the declared execution-side conservative bound"* for unleveraged long stock. `static-p75-insession-v2+split-adjusted-max` cannot be one: **a 75th percentile is exceeded by a quarter of its own population by construction.** That is a property of the statistic, not of the sample, so more calibration data does not repair it — only a different statistic does. The recalibration decision needs the candidate numbers in front of it, computed rather than hand-derived.

## Measured (dev, read-only, 2026-08-13)

`PYTHONPATH=. uv run python scripts/verify_2240_cost_model.py --calibrate`, exit 0, 1,569 in-session quotes over the 6,741-instrument §4.0 validated universe:

| band | n | p75 today | p95 today | max today | p95 freeze-ready | max freeze-ready | p95 / frozen p75 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `<$5` | 83 | 2.461538 | 6.863905 | 9.261577 | 6.864 | 9.262 | **4.73x** |
| `$5-20` | 272 | 1.024832 | 4.290553 | 12.421053 | 4.291 | 12.422 | **7.51x** |
| `$20-100` | 747 | 0.634921 | 2.131634 | 7.820633 | 2.132 | 7.821 | **4.19x** |
| `>=$100` | 463 | 0.399838 | 0.871489 | 2.458978 | 0.872 | 2.459 | **2.71x** |

Two things this run surfaced that were not previously on the ticket:

1. **The frozen p75 reads OPTIMISTIC in all four bands today** — not by a rounding margin: 1.450 against 2.461538, 0.571 against 1.024832, 0.509 against 0.634921, 0.322 against 0.399838.
2. **Today's snapshot concentrates at UTC 14 (10:00 ET, the opening hour), 1,517 of 1,569** — where the frozen calibration's `CALIBRATION_LIMITS` records 1,149 of 1,159 at UTC 19 (15:00-15:59 ET, the closing hour). Same one-hour-of-the-day defect, opposite direction of bias. Part of the gap above is therefore *when the snapshot was taken*, not drift in the market, and neither snapshot has ever observed most of the trading day. The caveat line prints the n and the hour so the max is never read as a population maximum.

Adopting either column is a new `COST_MODEL_ID` (the module's own rule — *a change to what is charged is a new model, not a silent improvement*), which supersedes all 128 stored rows under the current id. **Nothing here adopts one.** Reported, with the freeze-ready quantisation applied so the decision is a copy rather than a hand-quantisation.

## How

- `_p75_disc` → `_percentile_disc(values, *, percentile)`, keeping `percentile_disc` semantics (the smallest observed value whose cumulative share reaches the quantile) — the model claims to charge a spread somebody was actually quoted, so an interpolated percentile is the wrong statistic here. `percentile=100` is the sample max under the same rule rather than a special case.
- **Integer arithmetic**, `ceil(n x p / 100)` via `-(-n * p // 100)`, not `ceil(q * n)` in float. `0.07 * 100` is `7.000000000000001`, so the float form selects the neighbouring observation for any percentile whose product lands a ulp above an integer. Pinned by test, and revert-probed: restoring the float form turns exactly that test red (`assert Decimal('8') == Decimal('7')`).
- An empty sample raises rather than letting the index arithmetic land on `-1` and return the last element of nothing.
- `_freeze_ready` applies the table's declared quantisation (0.001 pp, `ROUND_CEILING`) so a candidate is never printed *cheaper* than the measurement it came from.

## Tests

`tests/test_verify_2240_cost_model_statistics.py`, 15 pure-logic cases, no DB. Worth its own file for one reason: an off-by-one in a percentile index fails nothing downstream — it prints a plausible number, and that number becomes a model somebody charges.

## Security

No security surface. Read-only script, no new endpoint, no credential path, no user input. The one database statement is the pre-existing parameterised `_QUOTES_SQL` read.

## Gates

`ruff check` / `ruff format --check` / `pyright` / `pytest -m "not db"` + smoke all green via the pre-push hook. Codex checkpoint 2 run on the branch diff: no findings.

## Not in this PR — the remaining three steps of scope 5

2. Re-run the eToro preflight comparison against a recalibrated table on a population census, not the four names currently on the issue.
3. The code change: the recalibrated table declared as the execution bound for unleveraged long stock, the quote panel named in code as its validation source, `cost_unit_undocumented` routed to it for that product/side only, new `COST_MODEL_ID`.
4. A `cost_basis` column on `strategy_entry_preflights` — it stores `stressed_cost_amount` with nothing recording which path priced it.

Refs #2598. Refs #2437.
