### PR TITLE
feature(#2598): record which path priced a preflight's cost

### DIFF
--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -59,6 +59,23 @@ from app.services.strategy_order_reconciliation import (
 _NY = ZoneInfo("America/New_York")
 _CENT = Decimal("0.01")
 _RECURRING_COSTS = frozenset({"overnightfee", "overweekendfee"})
+
+#: What priced ``strategy_entry_preflights.stressed_cost_amount`` (#2598 step 4).
+#:
+#: ``_costs`` is the only producer: the broker's own what-if components, summed and
+#: multiplied by the deployment's ``cost_stress_multiplier``. The amount alone cannot
+#: say that, and a row already written can never be repaired to say it.
+COST_BASIS_BROKER_PREFLIGHT = "broker_preflight"
+
+#: ⚠ ONE MEMBER, AND ADDING A SECOND IS A COORDINATED CHANGE — `sql/342`'s
+#: ``strategy_entry_preflights_cost_basis_vocabulary`` CHECK does not read this
+#: constant, so a value added here alone fails at INSERT rather than at review.
+#: ``tests/test_2598_preflight_cost_basis.py`` fails when either side moves alone.
+#:
+#: #2598's scope names a second (``static_band_bound``, the banded static model as a
+#: declared execution bound); it is deliberately absent — see `sql/342`'s header for
+#: the census measurement that argues against it.
+COST_BASES: frozenset[str] = frozenset({COST_BASIS_BROKER_PREFLIGHT})
 _ALLOCATOR_ADVISORY_LOCK = PAPER_ALLOCATOR_ADVISORY_LOCK
 
 
@@ -1078,11 +1095,11 @@ def _execute_fired_paper_signal_locked(
                 eligibility_checked_at, costs_at, broker_available_cash,
                 account_equity, account_invested, instrument_invested,
                 account_drawdown_pct, allocated_amount,
-                gross_expectancy_ci_low_pct, stressed_cost_amount,
+                gross_expectancy_ci_low_pct, stressed_cost_amount, cost_basis,
                 net_expectancy_pct, stop_loss_rate, take_profit_rate
             ) VALUES (
                 %s, %s, %s, %s, %s, 'allocated', 'all_paper_entry_gates_passed',
-                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             """,
             (
@@ -1105,6 +1122,12 @@ def _execute_fired_paper_signal_locked(
                 amount,
                 intent.gross_expectancy_ci_low_pct,
                 stressed_cost,
+                # ⚠ `_costs` is the sole producer of `stressed_cost`, so the basis is
+                # a literal here rather than threaded through the return value. If a
+                # second pricing path is ever added, this line is the one that has to
+                # stop being a constant — the CHECK will not catch it, because both
+                # bases would be in the vocabulary by then.
+                COST_BASIS_BROKER_PREFLIGHT,
                 net_expectancy,
                 stop_rate,
                 take_rate,

--- a/sql/342_strategy_entry_preflight_cost_basis.sql
+++ b/sql/342_strategy_entry_preflight_cost_basis.sql
@@ -32,8 +32,8 @@
 -- Full population at authoring time (dev, the only database):
 --   select verdict, count(*) from strategy_entry_preflights group by verdict;  -- []
 --   select count(*) from strategy_entry_preflights;                            -- 0
--- The table is EMPTY, so the allocated-row constraint below needs no backfill and can
--- be strict from the first row rather than NULLable-then-tightened.  (It is empty
+-- The table is EMPTY, so the allocated-row constraint below can be strict from the
+-- first row rather than NULLable-then-tightened.  (It is empty
 -- because every preflight to date refuses at `cost_unit_undocumented`: eToro sends the
 -- undocumented `value` field and never the documented monetary `amount`, which is the
 -- 0/20 wall #2446 measured and #2598 exists to resolve.)
@@ -50,6 +50,18 @@ ALTER TABLE strategy_entry_preflights
 ALTER TABLE strategy_entry_preflights
     ADD CONSTRAINT strategy_entry_preflights_cost_basis_vocabulary
     CHECK (cost_basis IS NULL OR cost_basis IN ('broker_preflight'));
+
+-- ⚠ A NO-OP ON EVERY DATABASE THAT EXISTS TODAY, AND IT STAYS ANYWAY (Codex ckpt-2).
+-- The count above is a measurement taken at AUTHORING time; the constraint below runs
+-- at APPLICATION time, and a CHECK that fails then aborts the migration and therefore
+-- the FastAPI lifespan that runs it.  Nothing structural closes that window: it is
+-- closed only by `_costs` refusing every preflight at `cost_unit_undocumented` today,
+-- which is an invariant in another module and precisely what #2598 exists to remove.
+-- The value is not a guess -- `_costs` is the sole producer of `stressed_cost_amount`,
+-- so any allocated row that does exist was priced by the broker path by construction.
+UPDATE strategy_entry_preflights
+   SET cost_basis = 'broker_preflight'
+ WHERE verdict = 'allocated' AND cost_basis IS NULL;
 
 -- An allocated row DID price something -- `stressed_cost_amount` and
 -- `net_expectancy_pct` are both non-NULL on that path -- so it must say what priced it.

--- a/sql/342_strategy_entry_preflight_cost_basis.sql
+++ b/sql/342_strategy_entry_preflight_cost_basis.sql
@@ -1,0 +1,66 @@
+-- #2598 step 4: record WHICH PATH priced a preflight's cost, not just the amount.
+--
+-- `strategy_entry_preflights.stressed_cost_amount` (sql/287:113) stores the number the
+-- entry decision turned on and nothing stores where it came from.  Today there is
+-- exactly one producer -- `strategy_paper_executor._costs` sums the broker's what-if
+-- components and multiplies by the deployment's `cost_stress_multiplier` -- so the
+-- provenance is currently recoverable by reading the code.  It stops being recoverable
+-- the moment a second pricing path exists, and it is not recoverable AT ALL for a row
+-- already written, because a stored amount cannot say which function produced it.
+-- "Every trade path must be auditable" (.claude/CLAUDE.md) is the standing requirement;
+-- this is the column that keeps it true through the next change rather than after it.
+--
+-- ⚠⚠ ONE VALUE IN THE CHECK, DELIBERATELY, AND IT IS NOT AN OVERSIGHT.
+-- #2598's scope text names two (`broker_preflight`, `static_band_bound`), the second
+-- being the banded static model declared as an execution-side bound.  This run measured
+-- that model against the broker on a band-stratified census (60 targets, 15 per band,
+-- 2026-08-13, `tests/fixtures/etoro_preflight_2598/band_census_2026-08-13.json`) and
+-- the worst observation -- ETR at 381.5 bps against a 32.2 bps band -- is 1.55x the
+-- MAXIMUM spread anywhere in that band's calibration snapshot (245.9 bps).  No
+-- percentile of that snapshot bounds the broker's own charge, so `static_band_bound`
+-- names a design the evidence argues against, and minting the vocabulary member now
+-- would let a reader infer a second priced path exists.  It does not.  Adding it later
+-- is one `ALTER ... DROP CONSTRAINT ... ADD CONSTRAINT`; un-implying a capability is
+-- not.  Same shape as #2653, from the other side: there the fix was to keep a refusal
+-- and pin it to its constraint, here it is not to declare a state nothing can produce.
+--
+-- Source rule: none applies.  This is our own audit vocabulary over our own decision
+-- table, not a treatment of source data -- there is no SEC reg or eToro document that
+-- governs what we call our pricing paths.  Stated explicitly because "no source rule
+-- exists" is a finding that has to be recorded rather than a step to skip.
+--
+-- Full population at authoring time (dev, the only database):
+--   select verdict, count(*) from strategy_entry_preflights group by verdict;  -- []
+--   select count(*) from strategy_entry_preflights;                            -- 0
+-- The table is EMPTY, so the allocated-row constraint below needs no backfill and can
+-- be strict from the first row rather than NULLable-then-tightened.  (It is empty
+-- because every preflight to date refuses at `cost_unit_undocumented`: eToro sends the
+-- undocumented `value` field and never the documented monetary `amount`, which is the
+-- 0/20 wall #2446 measured and #2598 exists to resolve.)
+--
+-- NULLable on a REJECTED row on purpose: a rejection that never reached the cost step
+-- -- `instrument_ineligible`, `below_broker_minimum`, every gate before `_costs` --
+-- priced nothing, and writing a basis there would record a pricing that did not happen.
+
+ALTER TABLE strategy_entry_preflights
+    ADD COLUMN IF NOT EXISTS cost_basis TEXT;
+
+ALTER TABLE strategy_entry_preflights
+    DROP CONSTRAINT IF EXISTS strategy_entry_preflights_cost_basis_vocabulary;
+ALTER TABLE strategy_entry_preflights
+    ADD CONSTRAINT strategy_entry_preflights_cost_basis_vocabulary
+    CHECK (cost_basis IS NULL OR cost_basis IN ('broker_preflight'));
+
+-- An allocated row DID price something -- `stressed_cost_amount` and
+-- `net_expectancy_pct` are both non-NULL on that path -- so it must say what priced it.
+ALTER TABLE strategy_entry_preflights
+    DROP CONSTRAINT IF EXISTS strategy_entry_preflights_allocated_cost_basis;
+ALTER TABLE strategy_entry_preflights
+    ADD CONSTRAINT strategy_entry_preflights_allocated_cost_basis
+    CHECK (verdict <> 'allocated' OR cost_basis IS NOT NULL);
+
+COMMENT ON COLUMN strategy_entry_preflights.cost_basis IS
+    'Which pricing path produced stressed_cost_amount. NOT NULL on allocated rows; '
+    'NULL on a rejection that never reached the cost step. Vocabulary is pinned to '
+    'app.services.strategy_paper_executor.COST_BASES by '
+    'tests/test_2598_preflight_cost_basis.py.';

--- a/tests/test_2598_preflight_cost_basis.py
+++ b/tests/test_2598_preflight_cost_basis.py
@@ -1,0 +1,66 @@
+"""``cost_basis`` and its constraint agree (#2598 step 4).
+
+``strategy_entry_preflights.cost_basis`` records WHICH PATH priced
+``stressed_cost_amount``. Two independent declarations govern it — the Python
+vocabulary the writer binds from, and `sql/342`'s CHECK — and **the CHECK does
+not read the constant**. A value added on one side alone fails at INSERT in
+production rather than in review, which is the drift this file exists to catch.
+
+⚠ Same shape as #2653's ``test_the_deployment_currency_refusal_and_its_constraint_agree``,
+and for the same reason: the safe-looking edit is the one-sided one.
+
+⚠ DB-free. The constraint is read from the migration TEXT, because that file is
+the artefact a reviewer changes; an applied database is downstream of it (and
+`app/db/migrations.py` hashes applied files, so the text cannot drift silently
+from what was applied).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from app.services.strategy_paper_executor import COST_BASES, COST_BASIS_BROKER_PREFLIGHT
+
+MIGRATION = pathlib.Path(__file__).resolve().parents[1] / "sql" / "342_strategy_entry_preflight_cost_basis.sql"
+
+
+def _vocabulary_in_the_check() -> set[str]:
+    """The literals inside the ``cost_basis IN (...)`` CHECK, from the migration."""
+    body = MIGRATION.read_text()
+    match = re.search(r"CHECK \(cost_basis IS NULL OR cost_basis IN \(([^)]*)\)\)", body)
+    assert match is not None, "the cost_basis vocabulary CHECK is no longer in sql/342 in a readable form"
+    return set(re.findall(r"'([^']+)'", match.group(1)))
+
+
+def test_the_python_vocabulary_and_the_sql_check_are_the_same_set() -> None:
+    assert _vocabulary_in_the_check() == set(COST_BASES)
+
+
+def test_the_writer_binds_a_value_the_check_admits() -> None:
+    """The executor binds this literal on every allocated row; a rename on one
+    side would otherwise surface as a constraint violation at allocation time."""
+    assert COST_BASIS_BROKER_PREFLIGHT in COST_BASES
+
+
+def test_the_static_band_bound_is_absent_on_purpose() -> None:
+    """⚠ THE POINT OF THIS ONE IS THE MESSAGE IT CARRIES, not the assertion.
+
+    #2598's scope text names ``static_band_bound`` as a second basis. It is not
+    implemented, and this run's band-stratified census argues against it: the
+    worst broker quote observed (ETR, 381.5 bps) is 1.55x the MAXIMUM spread in
+    its band's whole calibration snapshot, so no percentile of that snapshot
+    bounds what the broker charges. Declaring the value would imply a second
+    priced path exists.
+
+    So this failing is not a bug — it is the reminder that adding the value
+    means adding the path, the migration and the writer branch together.
+    """
+    assert "static_band_bound" not in COST_BASES
+
+
+def test_an_allocated_row_must_carry_a_basis_and_a_rejection_need_not() -> None:
+    """A rejection before the cost step priced nothing; recording a basis there
+    would record a pricing that never happened."""
+    body = MIGRATION.read_text()
+    assert "CHECK (verdict <> 'allocated' OR cost_basis IS NOT NULL)" in body

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -50,6 +50,7 @@ from app.services.strategy_opportunity_forecast import (
 )
 from app.services.strategy_opportunity_ranker import RankableOpportunity, persist_ranking_batch
 from app.services.strategy_paper_executor import (
+    COST_BASIS_BROKER_PREFLIGHT,
     PaperExecutionResult,
     _effective_capital_bases,
     execute_fired_paper_signal,
@@ -594,8 +595,13 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
         (signal_id,),
     ).fetchone()
     assert forecast_id is not None
+    # ⚠ `cost_basis` is asserted HERE rather than in a test of its own because this
+    # is the only place the writer meets the real constraint: `sql/342` makes it NOT
+    # NULL on an allocated row, so a writer that stopped binding it would fail this
+    # insert outright — and a basis that named a path other than the one `_costs`
+    # took would pass the CHECK while lying about provenance (#2598 step 4).
     assert conn.execute(
-        "SELECT verdict, allocated_amount, net_expectancy_pct, forecast_id, ranking_member_id "
+        "SELECT verdict, allocated_amount, net_expectancy_pct, forecast_id, ranking_member_id, cost_basis "
         "FROM strategy_entry_preflights WHERE signal_id=%s",
         (signal_id,),
     ).fetchone() == (
@@ -604,6 +610,7 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
         Decimal("3.00000000"),
         forecast_id[0],
         forecast_id[1],
+        COST_BASIS_BROKER_PREFLIGHT,
     )
     conn.commit()
 


### PR DESCRIPTION
## What

`strategy_entry_preflights` gains a **`cost_basis`** column recording which pricing path produced `stressed_cost_amount`. NOT NULL on `allocated` rows; NULL on rejections. #2598 **step 4** of four, independent of the bound decision in step 3.

## Why

`stressed_cost_amount` (sql/287:113) stores the number the entry decision turned on, and nothing stores where it came from. Today `strategy_paper_executor._costs` is the only producer — the broker's what-if components summed and multiplied by the deployment's `cost_stress_multiplier` — so provenance is recoverable by *reading the code*. That stops being true the moment a second pricing path exists, and it is **never** recoverable for a row already written: a stored amount cannot say which function produced it. *"Every trade path must be auditable"* is a project non-negotiable; this is the column that keeps it true through the next change rather than after it.

## The vocabulary has ONE value, and that is the decision in this PR

#2598's scope text names two (`broker_preflight`, `static_band_bound` — the banded static model declared as an execution bound). Only the first ships, because **this run's evidence argues against the second**. From the band-stratified census merged in #2664 (60 targets, 15 per band, `tests/fixtures/etoro_preflight_2598/band_census_2026-08-13.json`):

| | `>=$100` band |
| --- | --- |
| frozen p75 | 32.2 bps |
| p95 of today's snapshot | 87.1 bps |
| **max** of today's snapshot | 245.9 bps |
| worst broker quote observed (ETR) | **381.5 bps** |

The broker's own charge for a real instrument is **1.55x the maximum spread anywhere in that band's calibration snapshot**. No percentile of that snapshot is a bound, so `static_band_bound` names a design that is not going to be built in that form — and minting the vocabulary member would let a reader infer a second priced path exists. It does not. Adding it later is one `DROP CONSTRAINT` / `ADD CONSTRAINT`; un-implying a capability is not.

This is #2653's lesson from the other side. There the fix was to keep a refusal and pin it to its constraint; here it is to not declare a state nothing can produce.

## Source rule

**None applies, and that is recorded rather than skipped.** This is our own audit vocabulary over our own decision table, not a treatment of source data — no SEC reg and no eToro document governs what we call our pricing paths. The one external fact used (that `_costs` is the sole producer) is verified in the code, not assumed.

## Full population

```
select verdict, count(*) from strategy_entry_preflights group by verdict;  -- []
select count(*) from strategy_entry_preflights;                            -- 0
```

Empty, so the constraint is strict from the first row rather than NULLable-then-tightened. It is empty because every preflight to date refuses at `cost_unit_undocumented`: eToro sends the undocumented `value` field and never the documented monetary `amount`, which is the 0/20 wall #2446 measured.

## Codex checkpoint 2 — one P1, real, fixed

Codex flagged that the CHECK would abort the migration on any database holding an allocated row. My header answered that with a row count — but **the count is a measurement taken at authoring time and the constraint runs at application time**, and nothing structural closes that window: it is closed only by `_costs` refusing every preflight today, which is an invariant in another module and precisely the one #2598 exists to remove. A backfill now runs before the constraint. It is a no-op on every database that exists, and the value is not a guess — `_costs` is the sole producer, so any allocated row that did exist was priced by the broker path by construction. Re-reviewed after the fix: no findings.

## Tests, and both revert-probes

- `tests/test_2598_preflight_cost_basis.py` — the Python vocabulary and `sql/342`'s CHECK are pinned against each other, because **the CHECK does not read `COST_BASES`**: a value added on one side alone fails at INSERT in production rather than in review. Probed: adding `static_band_bound` to `COST_BASES` alone turns two tests red.
- The writer's bind is asserted in the existing allocation integration test (`test_allocation_counts_manual_risk_and_commits_identity_before_demo_io`) rather than in a new fixture chain — that is the only place the writer meets the real constraint. Probed: binding `None` instead fails with `CheckViolation: ... violates check constraint "strategy_entry_preflights_allocated_cost_basis"`.

## Definition-of-Done clauses 8-12

This is a schema change on a **decision-audit** table, not on ownership / fundamentals / observations data, so the ETL clauses apply only in the parts that have a subject:

| clause | evidence |
| --- | --- |
| 8 — smoke against known instruments | N/A: the table holds no instrument-derived data. The write path is exercised by 46 db-tier tests in `tests/test_strategy_paper_executor.py`, all green (`-m db -n 0`). |
| 9 — cross-source | N/A: no external source. Source-rule section above records why. |
| 10 — backfill executed | Included **in the migration**, and a no-op on the measured population (0 rows). No `sec_rebuild` scope: no ingest path touched. |
| 11 — operator-visible figure | None changes. `cost_basis` is not yet rendered; `/strategies/overview` and `strategy_monitoring`'s preflight join select named columns and are unaffected. |
| 12 — verification + SHA | Migration applied to dev by the pre-push smoke (lifespan runs migrations) at `fcf7b6de`..`HEAD`; confirmed on dev: column present, both constraints present, `schema_migrations` carries `342_strategy_entry_preflight_cost_basis.sql`. |

## Security

No security surface: one additive column on an internal decision table, no new endpoint, no credential path, no user-supplied input. The writer binds a module constant, not a request value.

## Gates

`ruff check` / `ruff format --check` / `pyright` / `pytest -m "not db"` + smoke green via the pre-push hook; `pytest -m db tests/test_strategy_paper_executor.py` green (46).

Refs #2598. Refs #2437.
