### PR TITLE
feature(#2598): price the preflight from the field eToro actually sends

### DIFF
--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -22,6 +22,7 @@ from psycopg.pq import TransactionStatus
 
 from app.providers.broker import (
     BrokerAccountRiskSnapshot,
+    BrokerCostComponent,
     BrokerEligibilityResponse,
     BrokerOrderSubmissionError,
     BrokerOrderSubmissionUncertain,
@@ -60,22 +61,27 @@ _NY = ZoneInfo("America/New_York")
 _CENT = Decimal("0.01")
 _RECURRING_COSTS = frozenset({"overnightfee", "overweekendfee"})
 
-#: What priced ``strategy_entry_preflights.stressed_cost_amount`` (#2598 step 4).
+#: What priced ``strategy_entry_preflights.stressed_cost_amount`` (#2598 steps 3-4).
 #:
-#: ``_costs`` is the only producer: the broker's own what-if components, summed and
-#: multiplied by the deployment's ``cost_stress_multiplier``. The amount alone cannot
-#: say that, and a row already written can never be repaired to say it.
-COST_BASIS_BROKER_PREFLIGHT = "broker_preflight"
+#: ``_costs`` is the only producer — the broker's own what-if components, summed and
+#: multiplied by the deployment's ``cost_stress_multiplier`` — but WHICH FIELD carried
+#: the money is the audit fact that matters, because one of the two is off-spec.
+#: ``amount`` is documented; ``value`` is not, and is what the live demo response
+#: actually sends. A row already written can never be repaired to say which it was.
+COST_BASIS_BROKER_PREFLIGHT_AMOUNT = "broker_preflight_amount"
+COST_BASIS_BROKER_PREFLIGHT_VALUE = "broker_preflight_value"
 
-#: ⚠ ONE MEMBER, AND ADDING A SECOND IS A COORDINATED CHANGE — `sql/342`'s
+#: ⚠ BOTH MEMBERS ARE REACHABLE — each is returned by its own branch of
+#: ``_component_amount``, and both branches are tested. That is the bar this set is
+#: held to: #2598's scope also names ``static_band_bound`` (the banded static model as
+#: a declared execution bound) and it is deliberately absent, because no code produces
+#: it and the census measurement argues against ever writing one (`sql/342` header).
+#:
+#: ⚠ ADDING A MEMBER IS A COORDINATED CHANGE — `sql/343`'s
 #: ``strategy_entry_preflights_cost_basis_vocabulary`` CHECK does not read this
 #: constant, so a value added here alone fails at INSERT rather than at review.
 #: ``tests/test_2598_preflight_cost_basis.py`` fails when either side moves alone.
-#:
-#: #2598's scope names a second (``static_band_bound``, the banded static model as a
-#: declared execution bound); it is deliberately absent — see `sql/342`'s header for
-#: the census measurement that argues against it.
-COST_BASES: frozenset[str] = frozenset({COST_BASIS_BROKER_PREFLIGHT})
+COST_BASES: frozenset[str] = frozenset({COST_BASIS_BROKER_PREFLIGHT_AMOUNT, COST_BASIS_BROKER_PREFLIGHT_VALUE})
 _ALLOCATOR_ADVISORY_LOCK = PAPER_ALLOCATOR_ADVISORY_LOCK
 
 
@@ -609,13 +615,56 @@ def _eligibility_reason(response: BrokerEligibilityResponse, intent: _Intent, am
     return None
 
 
+@dataclass(frozen=True)
+class _CostAssessment:
+    """A priced preflight, WITH the field its money came out of.
+
+    ⚠ The basis is part of the result rather than re-derived at the INSERT, because
+    the caller cannot see which field each component used and would have to guess.
+    """
+
+    stressed: Decimal
+    net: Decimal
+    basis: str
+
+
+def _component_amount(component: BrokerCostComponent) -> tuple[Decimal, str] | None:
+    """The component's monetary amount and which field carried it, or ``None``.
+
+    ⚠⚠ eToro SHIPS THE DENOMINATOR OF A FIELD IT DOES NOT SHIP. Verified against the
+    live portal 2026-08-13 (`.claude/skills/data-sources/etoro-api.md` protocol): the
+    documented row is ``costType`` + ``amount`` (*"the monetary value of this cost
+    component, expressed in currency"*) + ``currency`` (*"ISO 4217 currency code in
+    which amount is denominated"*), and ``value`` appears NOWHERE in the docs. The
+    live demo response carries keys ``['costType', 'currency', 'value']`` — ``amount``
+    is absent as a KEY, not present-and-null — with ``currency`` returned as ``USD``.
+
+    Accepting ``value`` is #2598 scope 4, and it rests on a measurement rather than on
+    the drift being tolerable: over 60 instruments stratified across the four cost
+    bands, ``value / ticket`` lands on our separately observed quoted spread at a
+    population median of **0.995x** (`--replay
+    tests/fixtures/etoro_preflight_2598/band_census_2026-08-13.json`), the rounding
+    quantum behaves as a monetary field must and a rate cannot, and ``currency`` is
+    present on every observation. ⚠ That decodes the UNIT only — both sides trace to
+    eToro, so it is not corroboration of the spread's LEVEL.
+
+    ⚠ BOTH FIELDS PRESENT IS STILL A REFUSAL. It has never been observed, the two
+    could disagree, and there is no documented rule for which wins.
+    """
+    if component.amount is not None and component.value is None:
+        return component.amount, COST_BASIS_BROKER_PREFLIGHT_AMOUNT
+    if component.amount is None and component.value is not None:
+        return component.value, COST_BASIS_BROKER_PREFLIGHT_VALUE
+    return None
+
+
 def _costs(
     response: BrokerWhatIfCostResponse,
     *,
     intent: _Intent,
     amount: Decimal,
     now: datetime,
-) -> tuple[Decimal, Decimal] | str:
+) -> _CostAssessment | str:
     if response.instrument_id != intent.instrument_id or not _age_ok(
         response.last_updated, now=now, max_seconds=intent.max_cost_age_seconds
     ):
@@ -623,20 +672,36 @@ def _costs(
     total = Decimal("0")
     if not response.costs:
         return "costs_missing"
+    bases: set[str] = set()
     for component in response.costs:
-        if component.amount is None or component.value is not None:
+        resolved = _component_amount(component)
+        if resolved is None:
             return "cost_unit_undocumented"
+        component_amount, basis = resolved
+        bases.add(basis)
         # Equality against the deployment currency for the reason given in
         # `_eligibility_reason`: this is the loop whose `total +=` would otherwise add
         # two currencies together.
-        if component.currency.upper() != intent.currency or component.amount < 0:
+        if component.currency.upper() != intent.currency or component_amount < 0:
             return "cost_currency_or_value_invalid"
-        if component.cost_type.replace("_", "").lower() in _RECURRING_COSTS and component.amount > 0:
+        # ⚠⚠ THIS READS THE RESOLVED AMOUNT, AND THAT IS THE WHOLE CARE IN THIS
+        # FUNCTION. It used to read `component.amount`, which was guaranteed non-NULL
+        # only because the refusal above rejected every row that lacked it. Now that
+        # `value` is accepted, an `overnightFee` carrying its charge in `value` would
+        # compare `None > 0` — a TypeError at best, and at worst a rewrite that
+        # skipped the row and let an unmodelled carry through the gate that exists to
+        # stop it (#2363's standing refusal).
+        if component.cost_type.replace("_", "").lower() in _RECURRING_COSTS and component_amount > 0:
             return "recurring_cost_horizon_unmodelled"
-        total += component.amount
+        total += component_amount
+    if len(bases) != 1:
+        # ⚠ A MIXED response is unobserved and unexplained: summing a documented field
+        # and an off-spec one into a single total assumes they mean the same thing,
+        # which is exactly what has not been established for a response that uses both.
+        return "cost_unit_undocumented"
     stressed = total * intent.cost_stress_multiplier
     net = intent.gross_expectancy_ci_low_pct - (stressed / amount * Decimal("100"))
-    return stressed, net
+    return _CostAssessment(stressed=stressed, net=net, basis=bases.pop())
 
 
 def _observe_local_mandate_risk(
@@ -1043,7 +1108,7 @@ def _execute_fired_paper_signal_locked(
         return _persist_rejection(
             conn, signal_id=signal_id, reason_code=assessed, now=evaluated_at, intent=intent, risk=risk
         )
-    stressed_cost, net_expectancy = assessed
+    stressed_cost, net_expectancy = assessed.stressed, assessed.net
     if net_expectancy < intent.min_net_expectancy_pct:
         return _persist_rejection(
             conn,
@@ -1122,12 +1187,10 @@ def _execute_fired_paper_signal_locked(
                 amount,
                 intent.gross_expectancy_ci_low_pct,
                 stressed_cost,
-                # ⚠ `_costs` is the sole producer of `stressed_cost`, so the basis is
-                # a literal here rather than threaded through the return value. If a
-                # second pricing path is ever added, this line is the one that has to
-                # stop being a constant — the CHECK will not catch it, because both
-                # bases would be in the vocabulary by then.
-                COST_BASIS_BROKER_PREFLIGHT,
+                # ⚠ From the assessment, never re-derived here: this INSERT cannot
+                # see which field each cost component used, so a literal at this line
+                # would be a second, unverifiable claim about the same response.
+                assessed.basis,
                 net_expectancy,
                 stop_rate,
                 take_rate,

--- a/sql/343_strategy_entry_preflight_cost_basis_field.sql
+++ b/sql/343_strategy_entry_preflight_cost_basis_field.sql
@@ -1,0 +1,59 @@
+-- #2598 step 3: split `cost_basis` by WHICH FIELD carried the money.
+--
+-- `sql/342` (merged hours earlier, same day) shipped a single-member vocabulary,
+-- `broker_preflight`, on the correct-at-the-time reasoning that `_costs` is the only
+-- producer of `stressed_cost_amount`.  Step 3 makes that insufficient rather than
+-- wrong: the executor now accepts eToro's UNDOCUMENTED `value` field as the documented
+-- monetary `amount`, so "the broker preflight priced it" no longer says which contract
+-- was actually read.  One of the two is off-spec, and that is precisely the fact an
+-- audit of a trade path needs to carry.
+--
+--   broker_preflight_amount   the DOCUMENTED field
+--   broker_preflight_value    the off-spec field the live demo response actually sends
+--
+-- Source rule: the live portal, fetched 2026-08-13 per the
+-- `.claude/skills/data-sources/etoro-api.md` protocol (llms.txt ->
+-- `api-reference/trading--demo/get-what-if-trading-cost-breakdown.md`, WebFetch never
+-- curl).  Documented cost-row fields are `costType` + `amount` ("The monetary value of
+-- this cost component, expressed in currency") + `currency` ("ISO 4217 currency code in
+-- which amount is denominated").  `value` appears NOWHERE in the documentation.  The
+-- live demo response carries keys ['costType', 'currency', 'value'] -- `amount` absent
+-- as a KEY, not present-and-null -- with `currency` returned as USD, i.e. it ships the
+-- denominator of a field it does not ship.
+--
+-- Both members are REACHABLE: each is returned by its own branch of
+-- `strategy_paper_executor._component_amount`, and both branches are tested.  That is
+-- the bar `sql/342`'s header set when it declined to mint `static_band_bound` -- a
+-- vocabulary member with no producer implies a capability that does not exist.
+--
+-- Full population at authoring time (dev, the only database):
+--   select count(*) from strategy_entry_preflights;                            -- 0
+--   select cost_basis, count(*) from strategy_entry_preflights group by 1;     -- []
+-- Still empty -- `cost_unit_undocumented` refused every preflight up to this migration,
+-- which is the wall this step exists to remove.  The rename is therefore free; it costs
+-- a rewrite of exactly zero stored rows.  The UPDATE below is nonetheless included for
+-- `sql/342`'s reason: the count is measured at AUTHORING time and the constraint runs at
+-- APPLICATION time, and between the two sits a jobs daemon that this very change makes
+-- capable of writing an allocated row.
+
+UPDATE strategy_entry_preflights
+   SET cost_basis = 'broker_preflight_amount'
+ WHERE cost_basis = 'broker_preflight';
+
+ALTER TABLE strategy_entry_preflights
+    DROP CONSTRAINT IF EXISTS strategy_entry_preflights_cost_basis_vocabulary;
+ALTER TABLE strategy_entry_preflights
+    ADD CONSTRAINT strategy_entry_preflights_cost_basis_vocabulary
+    CHECK (cost_basis IS NULL OR cost_basis IN ('broker_preflight_amount', 'broker_preflight_value'));
+
+-- ⚠ `strategy_entry_preflights_allocated_cost_basis` (sql/342) is NOT touched: an
+-- allocated row must still carry a basis, and that rule is independent of the
+-- vocabulary's membership.
+
+COMMENT ON COLUMN strategy_entry_preflights.cost_basis IS
+    'Which pricing path produced stressed_cost_amount, AND which response field carried '
+    'it: broker_preflight_amount is the documented eToro field, broker_preflight_value '
+    'the off-spec one it actually sends (#2598). NOT NULL on allocated rows; NULL on a '
+    'rejection that never reached the cost step. Vocabulary is pinned to '
+    'app.services.strategy_paper_executor.COST_BASES by '
+    'tests/test_2598_preflight_cost_basis.py.';

--- a/tests/test_2598_preflight_cost_basis.py
+++ b/tests/test_2598_preflight_cost_basis.py
@@ -19,17 +19,28 @@ from __future__ import annotations
 
 import pathlib
 import re
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
 
-from app.services.strategy_paper_executor import COST_BASES, COST_BASIS_BROKER_PREFLIGHT
+from app.services.strategy_paper_executor import (
+    COST_BASES,
+    COST_BASIS_BROKER_PREFLIGHT_AMOUNT,
+    COST_BASIS_BROKER_PREFLIGHT_VALUE,
+)
 
-MIGRATION = pathlib.Path(__file__).resolve().parents[1] / "sql" / "342_strategy_entry_preflight_cost_basis.sql"
+SQL = pathlib.Path(__file__).resolve().parents[1] / "sql"
+#: ⚠ The VOCABULARY moved to sql/343 (#2598 step 3 split it by which response field
+#: carried the money); the allocated-row rule still lives in sql/342 and is untouched.
+MIGRATION = SQL / "343_strategy_entry_preflight_cost_basis_field.sql"
+ALLOCATED_RULE_MIGRATION = SQL / "342_strategy_entry_preflight_cost_basis.sql"
 
 
 def _vocabulary_in_the_check() -> set[str]:
     """The literals inside the ``cost_basis IN (...)`` CHECK, from the migration."""
     body = MIGRATION.read_text()
     match = re.search(r"CHECK \(cost_basis IS NULL OR cost_basis IN \(([^)]*)\)\)", body)
-    assert match is not None, "the cost_basis vocabulary CHECK is no longer in sql/342 in a readable form"
+    assert match is not None, "the cost_basis vocabulary CHECK is no longer in sql/343 in a readable form"
     return set(re.findall(r"'([^']+)'", match.group(1)))
 
 
@@ -37,10 +48,10 @@ def test_the_python_vocabulary_and_the_sql_check_are_the_same_set() -> None:
     assert _vocabulary_in_the_check() == set(COST_BASES)
 
 
-def test_the_writer_binds_a_value_the_check_admits() -> None:
-    """The executor binds this literal on every allocated row; a rename on one
-    side would otherwise surface as a constraint violation at allocation time."""
-    assert COST_BASIS_BROKER_PREFLIGHT in COST_BASES
+def test_both_members_are_reachable_and_admitted() -> None:
+    """Each is returned by its own branch of ``_component_amount``; a rename on
+    one side would surface as a constraint violation at allocation time."""
+    assert {COST_BASIS_BROKER_PREFLIGHT_AMOUNT, COST_BASIS_BROKER_PREFLIGHT_VALUE} == set(COST_BASES)
 
 
 def test_the_static_band_bound_is_absent_on_purpose() -> None:
@@ -62,5 +73,154 @@ def test_the_static_band_bound_is_absent_on_purpose() -> None:
 def test_an_allocated_row_must_carry_a_basis_and_a_rejection_need_not() -> None:
     """A rejection before the cost step priced nothing; recording a basis there
     would record a pricing that never happened."""
-    body = MIGRATION.read_text()
-    assert "CHECK (verdict <> 'allocated' OR cost_basis IS NOT NULL)" in body
+    assert "CHECK (verdict <> 'allocated' OR cost_basis IS NOT NULL)" in ALLOCATED_RULE_MIGRATION.read_text()
+    # sql/343 owns the VOCABULARY only. Redefining the allocated-row rule there would
+    # split one invariant across two migrations, where the later silently wins.
+    assert "ADD CONSTRAINT strategy_entry_preflights_allocated_cost_basis" not in MIGRATION.read_text()
+
+
+# --- the narrowing itself (#2598 step 3) ------------------------------------------
+#
+# ⚠ `_costs` is the gate that decides whether real money is committed, and it is pure
+# over its arguments, so it is table-tested here rather than only through the db-tier
+# executor path. The intent is built with every field spelled out: a factory that
+# defaulted them would silently absorb a new one.
+
+_NOW = datetime(2026, 8, 13, 15, 0, tzinfo=UTC)
+
+
+def _intent(**overrides: Any) -> Any:
+    from app.services.strategy_paper_executor import _Intent
+
+    base: dict[str, Any] = {
+        "signal_id": 1,
+        "strategy_id": "s1",
+        "strategy_version": "v1",
+        "instrument_id": 1001,
+        "symbol": "AAPL",
+        "deployment_id": 1,
+        "currency": "USD",
+        "deployment_limit": Decimal("1000"),
+        "pool_limit": Decimal("1000"),
+        "capital_mode": "fixed",
+        "pool_reserved": Decimal("0"),
+        "mandate_max_drawdown_pct": Decimal("10"),
+        "mandate_max_loss_per_position_pct": Decimal("1"),
+        "mandate_max_daily_loss_pct": Decimal("2"),
+        "mandate_active_risk_budget_pct": Decimal("5"),
+        "mandate_cash_reserve_pct": Decimal("5"),
+        "mandate_max_concurrent_positions": 5,
+        "forecast_id": 1,
+        "ranking_member_id": 1,
+        "policy_revision": 1,
+        "ticket_sizing_mode": "fixed",
+        "ticket_fraction": None,
+        "fixed_ticket_amount": Decimal("1000"),
+        "max_ticket_amount": Decimal("1000"),
+        "stop_loss_pct": Decimal("5"),
+        "take_profit_pct": Decimal("10"),
+        "max_quote_age_seconds": 60,
+        "max_scan_age_seconds": 60,
+        "max_halt_feed_age_seconds": 60,
+        "max_cost_age_seconds": 3600,
+        "max_reconciliation_age_seconds": 60,
+        "max_instrument_exposure_pct": Decimal("10"),
+        "max_portfolio_exposure_pct": Decimal("50"),
+        "max_drawdown_pct": Decimal("10"),
+        "min_net_expectancy_pct": Decimal("0"),
+        "cost_stress_multiplier": Decimal("2"),
+        "quote_at": _NOW,
+        "ask": Decimal("100"),
+        "scan_at": _NOW,
+        "halt_feed_at": _NOW,
+        "gross_expectancy_ci_low_pct": Decimal("3"),
+        "reserved": Decimal("0"),
+    }
+    base.update(overrides)
+    return _Intent(**base)
+
+
+def _component(cost_type: str, *, amount: str | None = None, value: str | None = None, currency: str = "USD") -> Any:
+    from app.providers.broker import BrokerCostComponent
+
+    return BrokerCostComponent(
+        cost_type=cost_type,
+        amount=None if amount is None else Decimal(amount),
+        value=None if value is None else Decimal(value),
+        currency=currency,
+        raw_payload={},
+    )
+
+
+def _response(*components: Any) -> Any:
+    from app.providers.broker import BrokerWhatIfCostResponse
+
+    return BrokerWhatIfCostResponse(
+        instrument_id=1001, symbol="AAPL", costs=tuple(components), last_updated=_NOW, raw_payload={}
+    )
+
+
+def _assess(*components: Any) -> Any:
+    from app.services.strategy_paper_executor import _costs
+
+    return _costs(_response(*components), intent=_intent(), amount=Decimal("1000"), now=_NOW)
+
+
+class TestWhichFieldCarriedTheMoney:
+    def test_the_undocumented_value_field_is_accepted_and_recorded_as_such(self) -> None:
+        """What the live demo response actually sends: keys are
+        ``['costType', 'currency', 'value']``, ``amount`` absent as a KEY."""
+        assessed = _assess(_component("marketSpread", value="0.30"))
+        assert assessed.basis == COST_BASIS_BROKER_PREFLIGHT_VALUE
+        assert assessed.stressed == Decimal("0.60")  # x2 stress multiplier
+
+    def test_the_documented_amount_field_is_accepted_and_recorded_as_such(self) -> None:
+        """The contract eToro publishes. Unreachable on today's responses, but it is
+        a real branch — this is what makes the second vocabulary member honest."""
+        assessed = _assess(_component("marketSpread", amount="0.30"))
+        assert assessed.basis == COST_BASIS_BROKER_PREFLIGHT_AMOUNT
+
+    def test_both_fields_present_is_still_a_refusal(self) -> None:
+        """Never observed, and the two could disagree with no documented winner."""
+        assert _assess(_component("marketSpread", amount="0.30", value="0.30")) == "cost_unit_undocumented"
+
+    def test_neither_field_present_is_a_refusal(self) -> None:
+        assert _assess(_component("marketSpread")) == "cost_unit_undocumented"
+
+    def test_a_response_mixing_the_two_conventions_is_a_refusal(self) -> None:
+        """⚠ Summing a documented field and an off-spec one into one total assumes
+        they mean the same thing, which is exactly what a mixed response leaves open."""
+        assert (
+            _assess(_component("marketSpread", value="0.30"), _component("markup", amount="0.10"))
+            == "cost_unit_undocumented"
+        )
+
+
+class TestTheRefusalsThatMustSurviveTheNarrowing:
+    def test_a_recurring_cost_carried_in_value_still_refuses(self) -> None:
+        """⚠⚠ THE TRAP IN THIS CHANGE. The recurring-cost gate used to read
+        ``component.amount``, non-NULL only because the old refusal rejected every row
+        without it. Reading the unresolved field once ``value`` is accepted would
+        compare ``None > 0`` — and a rewrite that skipped the row instead would let an
+        unmodelled carry through the gate that exists to stop it (#2363)."""
+        assert (
+            _assess(_component("marketSpread", value="0.30"), _component("overnightFee", value="0.50"))
+            == "recurring_cost_horizon_unmodelled"
+        )
+
+    def test_a_zero_recurring_cost_does_not_refuse(self) -> None:
+        """0.0 on every observation to date; refusing it would refuse every response.
+        ⚠ It is not evidence carry IS zero — 68 observations of unleveraged LONG."""
+        assert (
+            _assess(_component("marketSpread", value="0.30"), _component("overnightFee", value="0.0")).basis
+            == COST_BASIS_BROKER_PREFLIGHT_VALUE
+        )
+
+    def test_a_negative_value_is_invalid(self) -> None:
+        assert _assess(_component("marketSpread", value="-0.30")) == "cost_currency_or_value_invalid"
+
+    def test_a_foreign_currency_is_invalid_even_when_the_field_is_readable(self) -> None:
+        assert _assess(_component("marketSpread", value="0.30", currency="EUR")) == "cost_currency_or_value_invalid"
+
+    def test_an_empty_cost_list_is_still_costs_missing(self) -> None:
+        assert _assess() == "costs_missing"

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -50,7 +50,7 @@ from app.services.strategy_opportunity_forecast import (
 )
 from app.services.strategy_opportunity_ranker import RankableOpportunity, persist_ranking_batch
 from app.services.strategy_paper_executor import (
-    COST_BASIS_BROKER_PREFLIGHT,
+    COST_BASIS_BROKER_PREFLIGHT_VALUE,
     PaperExecutionResult,
     _effective_capital_bases,
     execute_fired_paper_signal,
@@ -544,10 +544,15 @@ def _broker(
         instrument_id=2449001,
         symbol="TALLOC",
         costs=(
+            # ⚠ THE DEFAULT IS THE LIVE SHAPE, not the documented one (#2598 step 3):
+            # eToro sends `value` and omits `amount` as a key, so the happy path here
+            # exercises what the broker actually returns. `undocumented_cost=True` is
+            # now the shape that REMAINS undocumented -- both fields present, which has
+            # never been observed and has no documented rule for which one wins.
             BrokerCostComponent(
                 cost_type="marketSpread",
-                amount=None if undocumented_cost else Decimal("0.5"),
-                value=Decimal("0.5") if undocumented_cost else None,
+                amount=Decimal("0.5") if undocumented_cost else None,
+                value=Decimal("0.5"),
                 currency=cost_currency,
                 raw_payload={},
             ),
@@ -610,7 +615,7 @@ def test_allocation_counts_manual_risk_and_commits_identity_before_demo_io(
         Decimal("3.00000000"),
         forecast_id[0],
         forecast_id[1],
-        COST_BASIS_BROKER_PREFLIGHT,
+        COST_BASIS_BROKER_PREFLIGHT_VALUE,
     )
     conn.commit()
 
@@ -1259,6 +1264,10 @@ def test_shared_paper_pool_excludes_future_live_reservations(
 def test_undocumented_cost_units_refuse_before_any_order_exists(
     ebull_test_conn: psycopg.Connection[Any],
 ) -> None:
+    """⚠ WHAT COUNTS AS UNDOCUMENTED MOVED (#2598 step 3). A `value`-only row is now
+    priced -- that is the live shape, and its unit was decoded on a 60-instrument
+    census. The refusal remains for a row carrying BOTH fields, which has never been
+    observed and has no documented rule for which one wins."""
     signal_id = _seed(ebull_test_conn)
     broker = _broker(undocumented_cost=True)
 


### PR DESCRIPTION
## What

The paper executor now prices a preflight from the field eToro **actually sends**. `cost_unit_undocumented` is narrowed to the states that are genuinely undocumented, and `cost_basis` records which of the two fields carried the money.

#2598 **step 3** — the last of four. Steps 1, 2 and 4 merged earlier today (#2663, #2664, #2665).

## Why

`_costs` refused on `component.amount is None or component.value is not None`, which fires on **every** preflight — `strategy_entry_preflights` holds 0 rows, and #2446 measured the same wall as "0/20 usable". The refusal was correct while the unit was unknown. It is now known.

### Source rule — the live portal, fetched 2026-08-13

Per `.claude/skills/data-sources/etoro-api.md`'s protocol (`llms.txt` → `api-reference/trading--demo/get-what-if-trading-cost-breakdown.md`, WebFetch, never curl):

- documented cost-row fields are **`costType`, `amount`, `currency`** — `amount` is *"The monetary value of this cost component, expressed in currency"*, `currency` is *"ISO 4217 currency code in which **amount** is denominated"*;
- **`value` appears nowhere in the documentation.**

### What the live demo response contains

```
TOP-LEVEL KEYS: ['costs', 'instrumentId', 'lastUpdated', 'symbol']
  markup         keys=['costType', 'currency', 'value']  amount=None value=0.0  currency='USD'
  marketSpread   keys=['costType', 'currency', 'value']  amount=None value=0.03 currency='USD'
  overnightFee   keys=['costType', 'currency', 'value']  amount=None value=0.0  currency='USD'
```

⚠ **`amount` is absent as a KEY, not present-and-null**, while `currency` — documented as the denomination *of `amount`* — is returned and is `USD`. The response ships the denominator of a field it does not ship.

### Why `value` may be read as that `amount`

Not because the drift is tolerable — because it was measured. From #2664's census: over **60 instruments stratified across the four cost bands**, `value / ticket` lands on our separately observed quoted spread at a population **median of 0.995x**; the rounding quantum behaves as a monetary field must and a rate cannot (agreement at $1,000, absent at $100); `currency` is present and `USD` on every observation.

⚠ **That decodes the UNIT and nothing else.** Both sides of the ratio trace to eToro (`quotes` is written by `market_data._upsert_quote` from the same venue), so it is not corroboration of any spread's *level* — see the prevention-log entry merged in #2667.

## Still refused — three states, deliberately

| state | why |
| --- | --- |
| **both** `amount` and `value` present | never observed, the two could disagree, and no documented rule says which wins |
| **neither** present | unchanged |
| a response **mixing** the conventions across components | summing a documented field and an off-spec one into one total assumes they mean the same thing, which is exactly what a mixed response leaves open |

Untouched and still fail-closed: `costs_stale_or_mismatched`, `costs_missing`, `cost_currency_or_value_invalid`, `recurring_cost_horizon_unmodelled`, `costs_unavailable`, and the absent-row rule (an omitted `marketSpread` is not a zero).

## ⚠⚠ The trap in this change, and the test that pins it

The recurring-cost gate read `component.amount`:

```python
if component.cost_type... in _RECURRING_COSTS and component.amount > 0:
    return "recurring_cost_horizon_unmodelled"
```

`amount` was non-`None` there **only because the refusal above rejected every row that lacked it**. Once `value` is accepted, an `overnightFee` carrying its charge in `value` compares `None > 0` — a `TypeError` at best, and at worst a rewrite that skipped the row and let an unmodelled carry through the gate that exists to stop it (#2363's standing refusal). It now reads the resolved amount, pinned by `test_a_recurring_cost_carried_in_value_still_refuses`.

## Scope — what this does NOT do

- **It does not make any strategy promotable.** `survivor_only` and `carry_unmodelled` are untouched.
- **It does not enable autonomous trading.** Signals fire from deployments, of which there are **0**; the operator creates those. Long/x1/real remains the only reachable product/side — `_eligibility_reason` already requires `direction == "LONG"`, `1 in arm.leverage_values` and `settlement_type == "real"`.
- **It does not validate any cost level**, only the unit.
- **`overnightFee = 0.0` is not evidence carry is zero.** 68 observations of unleveraged long stock. The short side is #2363's, and the census measured `sellShort` up to 218 bps — 3x the dearest long.

## `cost_basis` splits by field (sql/343)

`sql/342` (merged hours earlier) shipped `broker_preflight`. Step 3 makes that insufficient rather than wrong: "the broker preflight priced it" no longer says which contract was read, and one of the two is off-spec.

- `broker_preflight_amount` — the documented field
- `broker_preflight_value` — the off-spec field the live response actually sends

**Both are reachable**, each from its own branch of `_component_amount`, both tested — which is the bar `sql/342` set when it declined to mint `static_band_bound`. The vocabulary CHECK does not read `COST_BASES`, so the two are pinned against each other by test.

## Tests

`tests/test_2598_preflight_cost_basis.py` grows from 4 to 15 pure-logic cases, table-testing `_costs` directly — it is the gate that decides whether money is committed, and it is pure over its arguments. The intent fixture spells out every field rather than defaulting them, so a new field breaks the test loudly.

⚠ **One existing test changed meaning, and that is the change, not collateral.** `_broker(undocumented_cost=True)` used to mean "`value` only"; that shape is now priced. The fixture's **default** is now the live shape (`value` only, `amount` absent), so the main allocation integration test exercises what the broker actually returns and asserts `cost_basis = broker_preflight_value`; `undocumented_cost=True` now means both fields present, which still refuses.

## Verification

| clause | evidence |
| --- | --- |
| local gates | `ruff check` / `ruff format --check` / `pyright` (0 errors) / full fast tier `-m "not db"` green |
| db tier | `pytest -m db tests/test_strategy_paper_executor.py -n 0` — 46 green |
| migration applied on dev | via the pre-push smoke (lifespan runs migrations); `schema_migrations` carries `343_...`, and the constraint reads `cost_basis = ANY (ARRAY['broker_preflight_amount', 'broker_preflight_value'])` |
| population after | `select cost_basis, count(*) from strategy_entry_preflights group by 1` → `[]` (still 0 rows; nothing back-dated) |
| Codex ckpt-2 | run with the new migration staged — no findings |

## Security

No new credential path, no new endpoint, no user-supplied input. The change makes a **fail-closed gate slightly less closed**, on measured evidence, in one direction only: a cost row whose unit is now decoded is priced instead of refused. The three genuinely-ambiguous states still refuse, and every other refusal is untouched. Nothing here can place an order that a deployment did not authorise.

Refs #2598. Refs #2437. Refs #2363.
