### PR TITLE
feature(#2603): the core/cash rebalance decision, sized to the band edge

### DIFF
--- a/app/services/strategy_core_allocator.py
+++ b/app/services/strategy_core_allocator.py
@@ -1,0 +1,316 @@
+"""The core/cash rebalance decision (#2603 item 3, decision half).
+
+Mandate plus observed sleeve state in, one verdict out.  Pure: no connection, no
+clock, no broker, no persistence.
+
+⚠ This module AUTHORISES NOTHING and has NO CALLER.  It is the first reader of
+``strategy_core_mandate_events`` -- which is what item 1's spec said item 3 would
+be -- but nothing calls ``evaluate_core_rebalance``, and no verdict it returns
+causes anything to happen.  #2437's R4 comment records *a control on a path the
+decision does not take* seven times over, so the state is named here rather than
+left to be inferred.  Its caller is item 3's execution half, which needs the
+operator-attended session #2603 reserves.
+
+The verdict is emphatically NOT an eligibility finding: item 2 owns the proof that
+the core instrument is the underlying product and not a CFD, and has no table yet.
+
+Spec: ``docs/proposals/ta/2026-08-13-core-cash-allocator.md``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import ROUND_DOWN, Decimal
+from typing import Literal
+
+from app.services.strategy_core_mandate import (
+    AMOUNT_PLACES,
+    AMOUNT_PRECISION,
+    CORE_MANDATE_POLICY_VERSION,
+    PERCENT_BASIS,
+    CoreMandate,
+    CoreMandateError,
+    validate_core_mandate,
+)
+
+CoreRebalanceAction = Literal["hold", "buy_core", "sell_core", "refused"]
+
+# One quantum of the NUMERIC(18,6) amount shape.  Rounding a rebalance DOWN leaves
+# a residual strictly below this, and `min_rebalance_amount > 0` on the same column
+# type is at least this, so the residual can never re-trigger on the next pass.
+_AMOUNT_QUANTUM = Decimal(1).scaleb(-AMOUNT_PLACES)
+# Exclusive upper bound on a NUMERIC(18,6) amount: 12 integer digits.
+_MAX_AMOUNT = Decimal(1).scaleb(AMOUNT_PRECISION - AMOUNT_PLACES)
+_ZERO = Decimal("0")
+
+
+@dataclass(frozen=True)
+class CoreSleeveState:
+    """The observed core sleeve: one instrument and cash, at one instant.
+
+    ⚠ Caller obligations the arithmetic depends on and this module CANNOT check.
+    The supplier warrants that both components are valued at ``as_of`` from ONE
+    snapshot rather than two; that ``core_market_value`` is that one instrument's
+    net long value with lots netted and no other holding folded in; that
+    ``cash_balance`` is settled and unreserved, with pending orders, unsettled
+    proceeds and accrued charges already deducted; and that no rebalance from a
+    previous verdict is still in flight -- this function is stateless and will
+    re-recommend an in-flight trade.
+
+    Staleness of ``as_of`` is the caller's rule to set.  This module holds no clock
+    and enforces none; ``as_of`` is carried so a verdict can be attributed to a
+    valuation instant, not so it can be judged here.
+    """
+
+    core_instrument_id: int
+    core_market_value: Decimal
+    cash_balance: Decimal
+    currency: str
+    as_of: datetime
+
+
+@dataclass(frozen=True)
+class CoreRebalanceDecision:
+    """One rebalance verdict, carrying the arithmetic that produced it."""
+
+    action: CoreRebalanceAction
+    reason_code: str | None
+    amount: Decimal
+    core_pct: Decimal | None
+    target_pct: Decimal | None
+    lower_pct: Decimal | None
+    upper_pct: Decimal | None
+    effective_floor: Decimal | None
+    floor_source: Literal["mandate", "broker"] | None
+    reserve_breached: bool | None
+    reserve_margin_pct: Decimal | None
+    """Pre-cost margin over the liquidity reserve in the state THIS VERDICT LEAVES
+    YOU IN: post-trade for a trade, current-state for a hold, None on a refusal or
+    when no weight could be computed.  One meaning, because the quantity that
+    decides whether a cost breaches the reserve must not be ambiguous between
+    three."""
+
+
+def _refused(reason_code: str) -> CoreRebalanceDecision:
+    return CoreRebalanceDecision(
+        action="refused",
+        reason_code=reason_code,
+        amount=_ZERO,
+        core_pct=None,
+        target_pct=None,
+        lower_pct=None,
+        upper_pct=None,
+        effective_floor=None,
+        floor_source=None,
+        reserve_breached=None,
+        reserve_margin_pct=None,
+    )
+
+
+def _mandate_refusal(mandate: CoreMandate | None) -> str | None:
+    """The mandate half of the precedence order, or None when it is usable.
+
+    Order matters and is a construction choice: an unsupported policy version is
+    checked BEFORE validity, because `validate_core_mandate` implements THIS
+    version's arithmetic and reporting "invalid" for a row written under a later
+    policy would blame the row for our own staleness.
+    """
+    if mandate is None:
+        # Item 1: no mandate configured is a state, not a default.
+        return "core_mandate_absent"
+    if mandate.policy_version != CORE_MANDATE_POLICY_VERSION:
+        return "core_mandate_policy_unsupported"
+    try:
+        validate_core_mandate(
+            enabled=mandate.enabled,
+            base_currency=mandate.base_currency,
+            core_instrument_id=mandate.core_instrument_id,
+            core_target_pct=mandate.core_target_pct,
+            liquidity_reserve_pct=mandate.liquidity_reserve_pct,
+            rebalance_band_pct=mandate.rebalance_band_pct,
+            min_rebalance_amount=mandate.min_rebalance_amount,
+        )
+    except CoreMandateError:
+        # `CoreMandate` is a public frozen dataclass anyone can construct, so the
+        # schema CHECKs are not reachable from here.  Without this, the spec's
+        # "a reserve breach implies a band breach" proof -- which assumes a
+        # schema-valid mandate -- would be relied on for objects it does not cover.
+        return "core_mandate_invalid"
+    if not mandate.enabled:
+        return "core_mandate_disabled"
+    if mandate.core_instrument_id is None:
+        # Unreachable via the CHECK and via validate_core_mandate; kept because the
+        # dataclass is constructible directly.
+        return "core_instrument_unset"
+    return None
+
+
+def _state_refusal(mandate: CoreMandate, state: CoreSleeveState, broker_minimum: Decimal | None) -> str | None:
+    """The state half of the precedence order, or None when it is usable."""
+    if state.currency.strip().upper() != mandate.base_currency:
+        # Otherwise the allocator weighs two currencies as if they were one.  #2363
+        # owns FX and it is unmodelled, so this refuses rather than converts.
+        return "sleeve_currency_mismatch"
+    if state.core_instrument_id != mandate.core_instrument_id:
+        return "sleeve_instrument_mismatch"
+    for value in (state.core_market_value, state.cash_balance):
+        # Finiteness first: `Decimal("NaN") < 0` raises InvalidOperation rather
+        # than returning False, so every comparison below is only safe after this.
+        if not value.is_finite():
+            return "sleeve_valuation_invalid"
+        if value < 0:
+            # Negative cash is borrowed money and leverage is barred; a negative
+            # core value is not a state this two-holding sleeve has.
+            return "sleeve_valuation_invalid"
+        # Per-component BEFORE the sum, and not merely as a shortcut: two finite
+        # components near Decimal's Emax (`Decimal("9e999999")` each) raise
+        # decimal.Overflow on the addition itself, escaping the refusal this
+        # function promises.  Bounding each first caps the sum at 2 * _MAX_AMOUNT,
+        # which cannot overflow.
+        if value >= _MAX_AMOUNT:
+            return "sleeve_valuation_invalid"
+    # Then the SLEEVE, which is the bound that carries the contract: a rebalance
+    # amount is at most the sleeve value, so this is what makes every `amount`
+    # expressible in the NUMERIC(18,6) shape and `quantize` provably unable to
+    # raise.  Not implied by the per-component check -- two components at 60% of
+    # the bound each pass it and sum past it.
+    if state.core_market_value + state.cash_balance >= _MAX_AMOUNT:
+        return "sleeve_valuation_invalid"
+    if broker_minimum is not None and (not broker_minimum.is_finite() or broker_minimum <= 0):
+        return "broker_minimum_invalid"
+    return None
+
+
+def _quantise_down(value: Decimal) -> Decimal:
+    """Round toward zero to the NUMERIC(18,6) amount shape.
+
+    ROUND_DOWN is the construction choice: it never trades MORE than the boundary
+    demands, so a rounding step cannot overshoot the near edge into the far side
+    of the band.  It leaves the state fractionally outside the band, and that
+    cannot loop -- the residual is strictly below one quantum while
+    `min_rebalance_amount > 0` on the same column type is at least one quantum, so
+    the next pass suppresses it.
+
+    Cannot raise ``InvalidOperation``: `_state_refusal` bounds the sleeve below
+    ``_MAX_AMOUNT`` and the amount is at most the sleeve, so the result needs at
+    most 18 significant digits against a default context precision of 28.
+    """
+    return value.quantize(_AMOUNT_QUANTUM, rounding=ROUND_DOWN)
+
+
+def evaluate_core_rebalance(
+    mandate: CoreMandate | None,
+    state: CoreSleeveState,
+    *,
+    broker_minimum: Decimal | None = None,
+) -> CoreRebalanceDecision:
+    """Decide whether the core sleeve needs rebalancing, and by how much.
+
+    Trades to the NEAR EDGE of the declared band, not to the target weight: under
+    proportional transaction costs the optimal policy is a no-trade region about
+    the target, and outside it one trades to the region's BOUNDARY -- Leland
+    (2000), "Optimal Portfolio Management with Transactions Costs and Capital
+    Gains Taxes", RPF-290, Haas School of Business (SSRN 206871); the region's
+    existence is Constantinides (1986) and Davis & Norman (1990).  Only the
+    boundary-targeting result is adopted: the band's WIDTH here is an operator
+    declaration, not Leland's derived optimum, and none of his magnitudes carry
+    over.  See the spec's "Source rule".
+
+    ``broker_minimum`` is optional and ``None`` means THE CALLER HAS NO APPLICABLE
+    MINIMUM TO SUPPLY, not that the broker has none.  ⚠ Whether a given broker
+    minimum applies to an incremental buy or a partial sell is the caller's
+    determination: item 1's spec cited eToro's `min_position_amount`, which is an
+    entry-path field, and nothing here establishes it governs a rebalance leg.
+
+    Returns a verdict for every input.  No refusal raises: a caller that must catch
+    to learn the mandate is disabled will eventually catch too broadly.
+    """
+    refusal = _mandate_refusal(mandate)
+    if refusal is not None:
+        return _refused(refusal)
+    assert mandate is not None  # narrowed by _mandate_refusal
+
+    refusal = _state_refusal(mandate, state, broker_minimum)
+    if refusal is not None:
+        return _refused(refusal)
+
+    sleeve_value = state.core_market_value + state.cash_balance
+    if sleeve_value == 0:
+        # A zero denominator is a state, not a division.
+        return _refused("core_sleeve_empty")
+
+    core_pct = PERCENT_BASIS * state.core_market_value / sleeve_value
+    target = mandate.core_target_pct
+    lower = target - mandate.rebalance_band_pct
+    upper = target + mandate.rebalance_band_pct
+    # A reserve breach strictly implies an upper-band breach for any schema-valid
+    # mandate (spec Q1), so this is an observable and never a second trigger.
+    reserve_breached = (PERCENT_BASIS - core_pct) < mandate.liquidity_reserve_pct
+
+    floor = mandate.min_rebalance_amount
+    floor_source: Literal["mandate", "broker"] = "mandate"
+    if broker_minimum is not None and broker_minimum > floor:
+        floor, floor_source = broker_minimum, "broker"
+
+    def _decide(
+        action: CoreRebalanceAction,
+        amount: Decimal,
+        reason_code: str | None,
+        resulting_core_pct: Decimal,
+    ) -> CoreRebalanceDecision:
+        return CoreRebalanceDecision(
+            action=action,
+            reason_code=reason_code,
+            amount=amount,
+            core_pct=core_pct,
+            target_pct=target,
+            lower_pct=lower,
+            upper_pct=upper,
+            effective_floor=floor,
+            floor_source=floor_source,
+            reserve_breached=reserve_breached,
+            reserve_margin_pct=(PERCENT_BASIS - resulting_core_pct) - mandate.liquidity_reserve_pct,
+        )
+
+    # Strictly outside, by construction: a band is an ALLOWANCE, and an allowance
+    # consumed exactly is still within it.  (Storability of the edge does not
+    # settle actionability -- see the spec's Q2, which corrects an earlier draft
+    # that claimed this was derived from the schema CHECK.)
+    if core_pct > upper:
+        edge = upper
+    elif core_pct < lower:
+        edge = lower
+    else:
+        return _decide("hold", _ZERO, None, core_pct)
+
+    # Pre-cost a core/cash trade leaves the sleeve value unchanged: cash falls by
+    # exactly what core rises by.  So the amount is the gap to the near edge.
+    target_core_value = edge * sleeve_value / PERCENT_BASIS
+    raw_amount = target_core_value - state.core_market_value
+    action: CoreRebalanceAction = "buy_core" if raw_amount > 0 else "sell_core"
+    amount = _quantise_down(abs(raw_amount))
+
+    if amount < floor:
+        # The floor wins and the breach, if any, is reported (spec Q4).  The
+        # allocator has no authority to trade through one operator declaration to
+        # satisfy another.  Reported against the CURRENT state, because no trade
+        # happens.
+        return _decide("hold", _ZERO, "below_min_rebalance_amount", core_pct)
+
+    # `amount` is a CURRENCY amount, not a quantity.  Conversion to instrument
+    # units, unit rounding and the residual that leaves belong to the execution
+    # half, as does re-solving the size against the cost actually quoted -- a
+    # cash-deducted fee leaves a sell ABOVE `upper` and can push post-trade cash
+    # below the reserve (spec Q3).  `reserve_margin_pct` is the pre-cost slack it
+    # has to work with; zero means none.
+    resulting_core_value = state.core_market_value + (amount if action == "buy_core" else -amount)
+    return _decide(action, amount, None, PERCENT_BASIS * resulting_core_value / sleeve_value)
+
+
+__all__ = [
+    "CoreRebalanceAction",
+    "CoreRebalanceDecision",
+    "CoreSleeveState",
+    "evaluate_core_rebalance",
+]

--- a/app/services/strategy_core_allocator.py
+++ b/app/services/strategy_core_allocator.py
@@ -250,6 +250,10 @@ def evaluate_core_rebalance(
 
     floor = mandate.min_rebalance_amount
     floor_source: Literal["mandate", "broker"] = "mandate"
+    # Strict `>`, so a TIE reports "mandate".  The applied value is identical
+    # either way; the mandate is named because it is the floor that always
+    # exists, and attributing an equal broker minimum would suggest the verdict
+    # would have differed without it.
     if broker_minimum is not None and broker_minimum > floor:
         floor, floor_source = broker_minimum, "broker"
 

--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -38,15 +38,21 @@ CORE_MANDATE_BASE_CURRENCY = "USD"
 # (ticket, sub) per strategy_control_plane's PAPER_ALLOCATOR_ADVISORY_LOCK.
 CORE_MANDATE_ADVISORY_LOCK = (2603, 1)
 
-_HUNDRED = Decimal("100")
+PERCENT_BASIS = Decimal("100")
 # NUMERIC(8,4) percentages and NUMERIC(18,6) amounts, matching sql/311.  Both
 # halves of each column type are enforced: scale, so a value cannot be silently
 # rounded, and precision, so an oversized one raises CoreMandateError instead of
 # Postgres' NumericValueOutOfRange.
+#
+# The amount pair and the two validators below are PUBLIC because
+# `strategy_core_allocator` sizes a rebalance in the same NUMERIC(18,6) shape
+# (#2603 item 3).  Re-declaring `6` and `18` there would be two constants that
+# must agree and nothing making them.  The percentage pair stays private: no
+# second consumer writes a NUMERIC(8,4) column.
 _PCT_PLACES = 4
 _PCT_PRECISION = 8
-_AMOUNT_PLACES = 6
-_AMOUNT_PRECISION = 18
+AMOUNT_PLACES = 6
+AMOUNT_PRECISION = 18
 
 
 class CoreMandateError(ValueError):
@@ -76,7 +82,7 @@ class CoreMandate:
     @property
     def cash_target_pct(self) -> Decimal:
         """Cash is the complement, never a stored second column."""
-        return _HUNDRED - self.core_target_pct
+        return PERCENT_BASIS - self.core_target_pct
 
 
 @dataclass(frozen=True)
@@ -99,7 +105,7 @@ def _require_text(value: str, field: str, limit: int) -> None:
         raise CoreMandateError(f"{field} exceeds {limit} characters")
 
 
-def _require_finite(value: Decimal, field: str) -> None:
+def require_finite(value: Decimal, field: str) -> None:
     """Reject NaN/Infinity before anything compares the value.
 
     Ordering constraint, not style: ``Decimal("NaN") < 0`` raises
@@ -110,7 +116,7 @@ def _require_finite(value: Decimal, field: str) -> None:
         raise CoreMandateError(f"{field} must be a finite decimal")
 
 
-def _require_storable(value: Decimal, field: str, places: int, precision: int) -> None:
+def require_storable(value: Decimal, field: str, places: int, precision: int) -> None:
     """Reject a value the column cannot hold exactly, in either direction.
 
     Scale: Postgres rounds silently to the column scale, which would store a
@@ -122,7 +128,7 @@ def _require_storable(value: Decimal, field: str, places: int, precision: int) -
     raises ``NumericValueOutOfRange`` from the driver.  Bounding it here is what
     keeps every rejection a named ``CoreMandateError``.
 
-    ⚠ Assumes ``_require_finite`` has already run: ``quantize`` on a NaN raises
+    ⚠ Assumes ``require_finite`` has already run: ``quantize`` on a NaN raises
     ``InvalidOperation``, which this would report as "too large to store".
 
     For the percentages the precision half is unreachable through
@@ -174,14 +180,14 @@ def validate_core_mandate(
     # compare a NaN; then ranges, so an out-of-range percentage reports its range
     # rather than its digit count; then storability.
     for field, value in percentages:
-        _require_finite(value, field)
-    _require_finite(min_rebalance_amount, "min_rebalance_amount")
+        require_finite(value, field)
+    require_finite(min_rebalance_amount, "min_rebalance_amount")
 
-    if core_target_pct < 0 or core_target_pct > _HUNDRED:
+    if core_target_pct < 0 or core_target_pct > PERCENT_BASIS:
         raise CoreMandateError("core_target_pct must be between 0 and 100")
-    if liquidity_reserve_pct < 0 or liquidity_reserve_pct >= _HUNDRED:
+    if liquidity_reserve_pct < 0 or liquidity_reserve_pct >= PERCENT_BASIS:
         raise CoreMandateError("liquidity_reserve_pct must be at least 0 and below 100")
-    if rebalance_band_pct <= 0 or rebalance_band_pct > _HUNDRED:
+    if rebalance_band_pct <= 0 or rebalance_band_pct > PERCENT_BASIS:
         # Zero authorises a rebalance on any drift at all, and turnover is the
         # first-order cost filter.
         raise CoreMandateError("rebalance_band_pct must be above 0 and at most 100")
@@ -189,8 +195,8 @@ def validate_core_mandate(
         raise CoreMandateError("min_rebalance_amount must be above 0")
 
     for field, value in percentages:
-        _require_storable(value, field, _PCT_PLACES, _PCT_PRECISION)
-    _require_storable(min_rebalance_amount, "min_rebalance_amount", _AMOUNT_PLACES, _AMOUNT_PRECISION)
+        require_storable(value, field, _PCT_PLACES, _PCT_PRECISION)
+    require_storable(min_rebalance_amount, "min_rebalance_amount", AMOUNT_PLACES, AMOUNT_PRECISION)
 
     if enabled and core_instrument_id is None:
         raise CoreMandateError("an enabled core mandate requires a core instrument")
@@ -199,7 +205,7 @@ def validate_core_mandate(
 
     if core_target_pct - rebalance_band_pct < 0:
         raise CoreMandateError("rebalance_band_pct wider than core_target_pct leaves the lower trigger unreachable")
-    if _HUNDRED - (core_target_pct + rebalance_band_pct) < liquidity_reserve_pct:
+    if PERCENT_BASIS - (core_target_pct + rebalance_band_pct) < liquidity_reserve_pct:
         raise CoreMandateError("rebalance_band_pct would authorise drifting through liquidity_reserve_pct")
 
     return CoreMandateValues(
@@ -332,13 +338,18 @@ def configure_core_mandate(
 
 
 __all__ = [
+    "AMOUNT_PLACES",
+    "AMOUNT_PRECISION",
     "CORE_MANDATE_ADVISORY_LOCK",
     "CORE_MANDATE_BASE_CURRENCY",
     "CORE_MANDATE_POLICY_VERSION",
+    "PERCENT_BASIS",
     "CoreMandate",
     "CoreMandateError",
     "CoreMandateValues",
     "configure_core_mandate",
     "load_core_mandate",
+    "require_finite",
+    "require_storable",
     "validate_core_mandate",
 ]

--- a/docs/proposals/ta/2026-08-13-core-cash-allocator.md
+++ b/docs/proposals/ta/2026-08-13-core-cash-allocator.md
@@ -257,7 +257,7 @@ be the provenance theatre item 1's spec refused. So it is a caller obligation: *
 | `reason_code` | `None` on an **in-band** hold — inside the band is the mandate working, and that is not a refusal. Set on a **suppressed** hold (`below_min_rebalance_amount`) and on every `refused` |
 | `amount` | non-negative `Decimal`, quantised; `0` on `hold`/`refused` |
 | `core_pct`, `target_pct`, `lower_pct`, `upper_pct` | the arithmetic the verdict used; `None` when no weight could be computed |
-| `effective_floor`, `floor_source` | the floor applied and whether `"mandate"` or `"broker"` won |
+| `effective_floor`, `floor_source` | the floor applied and whether `"mandate"` or `"broker"` won. The broker minimum wins on a **strict** `>`, so a **tie reports `"mandate"`** — the applied value is identical either way, and the mandate is named because it is the floor that always exists; attributing an equal broker minimum would suggest the verdict would have differed without it |
 | `reserve_breached` | current-state breach, `None` when no weight could be computed |
 | `reserve_margin_pct` | **the pre-cost margin over the reserve in the state this verdict leaves you in** — post-trade for a trade, current-state for a `hold`, `None` on a refusal or an uncomputable weight. One meaning, stated, because the earlier draft left it ambiguous between three |
 

--- a/docs/proposals/ta/2026-08-13-core-cash-allocator.md
+++ b/docs/proposals/ta/2026-08-13-core-cash-allocator.md
@@ -1,0 +1,316 @@
+# The core/cash rebalance decision (#2603 scope item 3, decision half)
+
+Status: proposed. The **deterministic rebalance decision** only — mandate plus observed
+sleeve state in, one verdict out. No order intent, no execution plane, no endpoint, no
+migration, no persistence.
+
+Predecessor: `docs/proposals/ta/2026-08-13-core-cash-mandate.md` (item 1, shipped as
+`sql/336` + `app/services/strategy_core_mandate.py`). That spec closes with a list titled
+*"Left to item 3 (execution semantics, recorded so they are not rediscovered)"*. This
+document answers **four** of its five entries and states precisely which half of the fifth
+it does not answer.
+
+## Why the slice stops where it does
+
+Item 3 reads *"drift outside band → order intent → the existing demo execution plane"*.
+The first arrow is arithmetic over an operator authority. The second is the execution
+plane, which item 1's spec already established **cannot be reused as-is** (Q5 below), and
+whose acceptance #2603 reserves for an operator-attended demo session.
+
+So the split is at the first arrow. What ships is `evaluate_core_rebalance`: pure — no
+connection, no clock, no broker.
+
+⚠ **No endpoint ships either, and that is a decision, not an oversight.** A read-only
+preview endpoint needs the observed sleeve state, which comes from a broker portfolio read,
+and Definition-of-Done clause 11 requires an operator-visible figure verified on the live
+endpoint after the change. A headless worktree cannot do that. An endpoint shipped without
+it would be an unverified operator surface.
+
+⚠ **This module authorises nothing.** Item 1's table now has its first reader, which is
+what that spec said item 3 would be; the reader itself has no caller. #2437's R4 comment
+records the *control on a path the decision does not take* seven times over, so the state
+is named rather than implied: **nothing calls `evaluate_core_rebalance`, and no verdict it
+returns causes anything to happen.**
+
+## Source rule
+
+The one genuine formulation choice with a published answer is **where a triggered rebalance
+trades to** — the target weight, or the near edge of the band.
+
+**Leland, Hayne E. (2000), "Optimal Portfolio Management with Transactions Costs and
+Capital Gains Taxes", Research Program in Finance working paper RPF-290, Haas School of
+Business, U.C. Berkeley (SSRN 206871).** Under proportional transaction costs the optimal
+policy is a **no-trade region** about the target proportions; when actual proportions fall
+outside it, trade **to the region's boundary, not to the target**. The existence of the
+no-trade region under proportional costs is Constantinides (1986) and Davis & Norman
+(1990); Leland is the one that answers *how far to trade*, which is the question here.
+
+We adopt the **boundary-targeting result** and nothing else. Three limits on that adoption,
+stated so a later reader cannot cite this spec for more than it says:
+
+1. **The band's width is not Leland's.** He derives the region from a cost model; ours is
+   an operator declaration, validated but never defaulted. This spec selects no threshold
+   and needs no constant.
+2. **Leland's ~50% turnover reduction does not transfer.** That figure compares his
+   optimised region against periodic rebalancing to target at matched tracking error. Our
+   region is declared, not optimised, and our trigger is threshold-based rather than
+   periodic. Neither the magnitude nor the dominance claim carries over, and neither is
+   claimed here. What carries is the *direction*: at an identical trigger, trading to the
+   near edge moves strictly less than trading to target.
+3. **The model assumptions differ** — symmetric declared band, a currency floor on trade
+   size, discrete instrument quantities, broker frictions. The mapping is one published
+   result applied to a differently-derived region, not a re-derivation of his optimum.
+
+Rebalancing to target is also a documented practice, and it is fair to note current
+Vanguard material treats the destination as a *policy parameter* (target, midpoint, or
+another interior point) rather than a settled rule. Given both are available, we take the
+one that moves least per trigger, because turnover is this repo's declared first-order cost
+filter (`.claude/skills/quant/strategy-evidence.md`).
+
+**Where no published rule governs, the choice is made by construction and labelled as
+such.** Four decisions below are of that kind and each is marked **[by construction]**:
+the strict trigger (Q2), floor-over-reserve precedence (Q4), refusal precedence, and the
+rounding direction. None is presented as derived.
+
+## The decision
+
+Denominator `V = core_market_value + cash_balance`, the core sleeve. Two holdings and
+nothing else, so weights are exact complements (item 1's spec, "Cash is derived").
+
+```
+core_pct   = 100 * core_market_value / V
+upper      = core_target_pct + rebalance_band_pct
+lower      = core_target_pct - rebalance_band_pct
+
+core_pct > upper   -> sell_core, sized to leave core_pct == upper
+core_pct < lower   -> buy_core,  sized to leave core_pct == lower
+otherwise          -> hold
+```
+
+Pre-cost, a core/cash trade leaves `V` unchanged (cash falls by exactly what core rises
+by), so the amount is the gap to the near edge:
+
+```
+raw_amount = | edge/100 * V - core_market_value |
+```
+
+`action` carries the direction; `amount` is a **non-negative magnitude in
+`base_currency`**, never a signed delta. It is a **currency amount, not a quantity** —
+conversion to instrument units, unit rounding and the residual that leaves is the execution
+half's, and is not modelled here.
+
+### Rounding **[by construction]**
+
+`raw_amount` is quantised to six decimal places with `ROUND_DOWN`, matching the
+`NUMERIC(18,6)` amount shape item 1 fixed. Rounding down **never trades more than the
+boundary demands** (it trades the same, when the value is already representable, or less),
+so a rounding step cannot overshoot the edge into the far side of the band.
+
+It does leave the state fractionally outside the band, and that cannot loop: the residual
+is strictly below one quantum, `1e-6`, while `min_rebalance_amount > 0` on a `NUMERIC(18,6)`
+column is at least `1e-6`. So on the next evaluation the residual is strictly below the
+effective floor and suppresses — for every mandate the schema can hold. Tested.
+
+### The five open questions
+
+**Q1 — a price gap can put cash below the reserve between rebalances.** It never needs a
+second trigger. For any mandate satisfying item 1's CHECKs:
+
+```
+reserve breached  <=>  cash_pct < reserve  <=>  core_pct > 100 - reserve
+sql/336 CHECK     :    100 - (core_target + band) >= reserve
+                  <=>  core_target + band <= 100 - reserve
+therefore         :    core_pct > 100 - reserve >= core_target + band  =>  core_pct > upper
+```
+
+So **a reserve breach strictly implies an upper-band breach**. The band dominates the
+reserve; a separate reserve trigger would be unreachable code.
+
+⚠ **This holds for schema-valid mandates only, and `CoreMandate` is a public frozen
+dataclass anyone can construct directly.** The allocator therefore re-runs
+`validate_core_mandate` over the mandate it is given and refuses
+`core_mandate_invalid` rather than computing on a state the proof does not cover. Without
+that step the "always" above is false, not merely unproven.
+
+The verdict still carries `reserve_breached`, because "the rebalance that would have fixed
+it was suppressed" is a state an operator has to be able to see (Q4).
+
+**Q2 — does the band trigger at equality, or strictly outside? Strictly outside. [by
+construction]** This is a choice, not a derivation: that `sql/336`'s CHECK is *written
+about* `core_target + band` shows the schema treats the edge as a storable state, but
+storability does not settle actionability, and the earlier draft of this spec claimed it
+did. The construction is that a band is an **allowance**: an allowance consumed exactly is
+still within the allowance, and drift must exceed it to spend a trade. The schema is
+consistent with that reading — at equality the reserve CHECK is satisfied, so the strict
+trigger never leaves a reserve breach unactioned (Q1's chain uses `>=` on the CHECK and
+`>` on the trigger, and holds at equality).
+
+**Two degenerate mandates make one trigger unreachable, and the schema permits both.**
+`sql/336`'s `core_target_pct - rebalance_band_pct >= 0` permits `band == target`, giving
+`lower == 0` — and `core_pct < 0` is impossible for a non-negative sleeve, so the lower
+trigger can never fire. That is exactly the "silently one-sided" state the CHECK's own
+comment says it exists to prevent; the comment is right and the comparator is off by one.
+Symmetrically, `band == 100 - target` with `reserve == 0` gives `upper == 100`, which
+`core_pct > 100` can never exceed. Both are narrow, neither is unsound arithmetic here —
+the allocator computes correctly, one side simply never triggers — and fixing the CHECK is
+a migration outside this slice. **Filed as its own ticket; recorded here so the allocator's
+behaviour on such a mandate is documented rather than surprising.**
+
+**Q3 — target or edge, and what about costs? Edge, per Leland. Costs are NOT answered
+here, and this spec does not claim they are.**
+
+What can be stated exactly, for the one cost shape the algebra covers — **a fee deducted
+from cash, not embedded in the execution price**: the fee shrinks `V`, and for a ratio
+`a/b` with `a < b`, `(a-f)/(b-f) < a/b`. So such a fee pushes post-trade cash percentage
+below its pre-cost value in both directions. Two consequences, and the earlier draft caught
+only the first:
+
+- **The reserve.** Pre-cost post-trade cash is `100 - core_target - band` on a `sell_core`,
+  which `sql/336`'s CHECK guarantees is `>= reserve` but permits to be **exactly** equal.
+  On such a mandate any fee breaches the reserve.
+- **The band itself.** A sell sized to the pre-cost upper edge lands at
+  `post_core_pct = upper·V/(V-f) > upper` — still outside the band it was meant to restore.
+  Costs threaten the trigger invariant, not only the reserve.
+
+The buy side's pre-cost margin over the reserve is `100 - core_target + band` minus
+`reserve`, which is at least `2 * band` by the CHECK. That is a statement about the
+pre-cost margin and **not** a claim that no fee can breach it: no bound on fees or floor on
+sleeve value is available here, so no such claim is made.
+
+**Why this slice does not solve it.** #2598 closed on exactly this point: the banded cost
+model is the *backtest's*, and **execution holds the broker's own number at entry time**.
+The allocator sits upstream of that number, and inventing one would repeat the mistake
+#2598 was closed to avoid. Nor is "widen the sell by the fee" the right formula — reaching
+`upper` after a cash-deducted fee `f` requires adding `upper/100 · f`, restoring the
+reserve requires adding `(1 - reserve/100) · f`, and if the fee is size-dependent it is an
+implicit equation rather than a widening at all.
+
+So the allocator returns `reserve_margin_pct` — the pre-cost margin, defined below — and
+the obligation is stated where it belongs: **the execution half must re-solve the size
+against the cost it is actually quoted, and refuse if it cannot restore both the band and
+the reserve.** A margin of zero is the signal that it has no slack to do it from.
+
+**Q4 — precedence when the floor suppresses the reserve-restoring trade. The floor wins;
+no trade; `reserve_breached` is reported. [by construction]**
+
+The allocator has no authority to trade through one operator declaration to satisfy
+another, and this repo's posture on an unresolvable gate is to refuse and name it rather
+than pick a side silently. *(The earlier draft also argued the floor exists because a
+sub-floor trade costs more than the drift it corrects. That is unsupported — an operator
+minimum may equally encode broker mechanics or policy — and it is withdrawn.)*
+
+The breach this leaves is bounded. A reserve breach implies `core_pct > 100 - reserve >=
+upper`, so the sell-to-edge amount is at least the currency shortfall:
+
+```
+sell amount = (core_pct - upper)/100 * V  >=  (core_pct - (100 - reserve))/100 * V = shortfall
+```
+
+If the sell is suppressed, the shortfall is below **the effective floor** —
+`max(min_rebalance_amount, broker minimum)`, not `min_rebalance_amount` alone, since the
+broker half may be the binding one. Two limits on reading that as safety: it is a
+**nominal** bound in `base_currency`, **not a proportional one** — on a small sleeve a
+sub-floor shortfall can still be a large share of the reserve — and it is proved on the raw
+pre-cost amount, so the implementation compares the **rounded** amount against the floor and
+the bound inherits one quantum of slack. Stated, tested, not called safe.
+
+**Q5 — the core position class. Unchanged, and still deferred.** Item 1's spec verified the
+entry/position plane cannot hold a stop-less, take-profit-less core position: `sql/287:116`
+CHECKs `stop_loss_rate > 0 AND take_profit_rate > 0` on an `allocated` verdict;
+`app/services/strategy_position_manager.py:816` makes a stop-less holding a permanent
+`fixed_exit_repair` condition; `:817` exact-matches the take-profit, so a core holding would
+need one forever. This slice emits no order intent, so it neither needs nor creates that
+class — it does not answer the question, it stays out of its way.
+
+## Contract
+
+### Input — `CoreSleeveState`
+
+| field | rule |
+| --- | --- |
+| `core_instrument_id` | `int > 0`. Must equal `mandate.core_instrument_id` or the verdict is `sleeve_instrument_mismatch` — an allocator that weighs some *other* holding as the core is the failure this closes |
+| `core_market_value` | `Decimal`, finite, `>= 0`, in `currency` |
+| `cash_balance` | `Decimal`, finite, `>= 0`, in `currency` |
+| `currency` | must equal `mandate.base_currency`; both components already converted into it |
+| `as_of` | `datetime`, one valuation instant for **both** components |
+
+**Caller obligations, stated because the arithmetic depends on them and the allocator
+cannot check them.** The supplier of a `CoreSleeveState` warrants that: both components are
+valued at `as_of` from one snapshot, not two; `core_market_value` is that one instrument's
+net long value, with lots netted and no other holding folded in; `cash_balance` is settled
+and unreserved, with pending orders, unsettled proceeds and accrued charges already
+deducted; and no rebalance from a previous verdict is still in flight — this function is
+stateless and will re-recommend an in-flight trade. `as_of` staleness is the caller's rule
+to set; the allocator holds no clock and enforces none.
+
+**Eligibility is not gated here.** Item 2 owns the proof that the core instrument is the
+underlying product and not a CFD, and it has no table yet. Adding a placeholder input would
+be the provenance theatre item 1's spec refused. So it is a caller obligation: **a
+`buy_core` verdict is not an eligibility finding, and the execution half must obtain item
+2's proof before acting on one.**
+
+### Output — `CoreRebalanceDecision`
+
+| field | rule |
+| --- | --- |
+| `action` | `"hold" \| "buy_core" \| "sell_core" \| "refused"` |
+| `reason_code` | `None` on an **in-band** hold — inside the band is the mandate working, and that is not a refusal. Set on a **suppressed** hold (`below_min_rebalance_amount`) and on every `refused` |
+| `amount` | non-negative `Decimal`, quantised; `0` on `hold`/`refused` |
+| `core_pct`, `target_pct`, `lower_pct`, `upper_pct` | the arithmetic the verdict used; `None` when no weight could be computed |
+| `effective_floor`, `floor_source` | the floor applied and whether `"mandate"` or `"broker"` won |
+| `reserve_breached` | current-state breach, `None` when no weight could be computed |
+| `reserve_margin_pct` | **the pre-cost margin over the reserve in the state this verdict leaves you in** — post-trade for a trade, current-state for a `hold`, `None` on a refusal or an uncomputable weight. One meaning, stated, because the earlier draft left it ambiguous between three |
+
+`broker_minimum` is an optional input. `None` means **the caller has no applicable minimum
+to supply**, and the mandate floor stands alone; the verdict says so via `floor_source`.
+⚠ Whether a given broker minimum applies to an incremental buy or a partial sell is the
+**caller's** determination — item 1's spec cited `min_position_amount`, which is an
+entry-path field, and nothing here establishes it governs a rebalance leg.
+
+### Refusals, in precedence order **[by construction]**
+
+A **refusal is "cannot decide"**, and it nulls the arithmetic fields because there is no
+arithmetic to report. It is a different outcome from **"decided not to trade"**, which is a
+`hold` — either in-band (no code) or suppressed by the floor (`below_min_rebalance_amount`,
+carrying the full arithmetic). Keeping the suppressed case a `hold` is what makes Q4
+observable: a refusal that nulled `reserve_breached` and `reserve_margin_pct` would hide the
+exact state Q4 exists to surface.
+
+Evaluated in this order, first match wins; one code per verdict, matching the single
+`reason_code` shape the paper executor already uses. Mandate validity precedes state
+validity because a decision computed from an invalid authority is meaningless whatever the
+state was. Within the mandate half, the **policy version is checked before validity**:
+`validate_core_mandate` implements *this* version's arithmetic, so reporting "invalid" for a
+row written under a later policy would blame the row for our own staleness.
+
+| # | code | when |
+| --- | --- | --- |
+| 1 | `core_mandate_absent` | no mandate ever configured. `load_core_mandate` returns `None`, which item 1 declared a state, not a default |
+| 2 | `core_mandate_policy_unsupported` | `policy_version` is not the one this arithmetic implements. What item 1 stamped the column *for* |
+| 3 | `core_mandate_invalid` | the mandate fails `validate_core_mandate`. Closes the directly-constructed-object hole in Q1's proof |
+| 4 | `core_mandate_disabled` | latest revision has `enabled = false` |
+| 5 | `core_instrument_unset` | enabled with no instrument. Unreachable via the CHECK and via `validate_core_mandate`; kept because the dataclass is constructible |
+| 6 | `sleeve_currency_mismatch` | observed currency is not the mandate's. Otherwise the allocator weighs two currencies as one |
+| 7 | `sleeve_instrument_mismatch` | observed instrument is not the mandate's |
+| 8 | `sleeve_valuation_invalid` | a component is non-finite or negative, or the **sleeve** reaches `NUMERIC(18,6)`'s 12 integer digits. Negative cash is borrowed money and leverage is barred (`.claude/CLAUDE.md` risk posture: *"No leverage — still barred"*); non-finite is refused before any comparison, since `Decimal("NaN") < 0` raises rather than returning False. The magnitude bound is checked **per component and then on the sum**, in that order. The sum is the bound that carries the contract — an amount is at most the sleeve, so bounding the sleeve is what makes every `amount` expressible in the shape the contract claims and makes the quantise step provably unable to raise. The per-component check is not a shortcut to it: two finite components near `Decimal`'s `Emax` raise `decimal.Overflow` **on the addition itself**, escaping the refusal entirely. Found at Codex checkpoint 2, by probe rather than by reading |
+| 9 | `broker_minimum_invalid` | a supplied broker minimum is non-finite or `<= 0` |
+| 10 | `core_sleeve_empty` | `V == 0`. A zero denominator is a state, not a division |
+
+And the one non-refusal outcome code:
+
+| code | when |
+| --- | --- |
+| `below_min_rebalance_amount` | outside the band, but the **rounded** amount is `< effective_floor`. `action` is `hold`, with the full arithmetic. Comparison is on the rounded amount because that is what would execute; equality with the floor **acts**. This also absorbs the degenerate case where rounding leaves `amount == 0`, so no zero-amount trade can ever be emitted |
+
+## What this does NOT do
+
+- No order intent, no broker call, no execution, no eligibility proof.
+- No endpoint, no job, no scheduler entry.
+- **No migration and no persistence.** The decision is recomputed from state; storing it
+  would create a verdict with a lifetime and no consumer to expire it.
+- No FX — the currency guard refuses a mismatch rather than converting. #2363 owns FX and
+  it is unmodelled.
+- No cost model, and no post-cost guarantee about either the band or the reserve (Q3).
+- No reconciliation against the broker's position list, and no staleness rule.
+
+Refs #2603. Refs #2525. Refs #2437. Refs #2598.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -4376,3 +4376,32 @@ with `verify_2598_preflight_quote_crosscheck.py --replay <fixture>`:
    Only observations at or above 10 rounding quanta count: at a $1,000 ticket SPY read
    0.4 bp against a 0.13 bp quote (3.08x), entirely rounding.
 4. **The comparison is not cross-source** — see the "independent cross-check" entry above.
+
+### A magnitude guard that bounds an AGGREGATE can be escaped by an overflow in the aggregation itself
+
+- First seen in: #2603 item 3 (PR for `app/services/strategy_core_allocator.py`), Codex
+  checkpoint 2, by probe rather than by reading.
+- Symptom: `_state_refusal` checked each component finite and non-negative, then bounded the
+  **sum** (`core_market_value + cash_balance >= _MAX_AMOUNT`) — reasoning, correctly as far as
+  it went, that two non-negative components under a bounded sum are each under it too, so a
+  per-component check was redundant. It is not redundant, because the guard has to *compute*
+  the sum to test it: two finite components near `Decimal`'s `Emax` raise `decimal.Overflow`
+  **on the addition**, before the comparison the refusal depends on ever runs.
+  `Decimal("9e999999") + Decimal("9e999999")` raises; `Decimal("1e999999") + Decimal("1e999999")`
+  does not — so the failure is reachable only in part of the input space, which is why reading
+  the code did not surface it and executing it did.
+- The general shape: **the guard's own arithmetic is unguarded.** Any refusal of the form
+  "combine these inputs, then check the combination" runs the combination on inputs nothing has
+  bounded yet. Same class as the ordering rule already logged for `Decimal("NaN") < 0` raising
+  rather than returning False — a validator whose steps are in the wrong order does not fail
+  loudly, it fails *past* its own refusal.
+- Prevention: when a validator bounds a derived quantity (a sum, product, ratio or difference),
+  bound **each input first**, then the derived quantity. Both checks stay: the per-input one
+  exists to make the derivation safe to perform, the derived one to enforce the contract, and
+  neither implies the other (two inputs at 60% of a bound each pass individually and sum past
+  it). Self-review prompt: for every comparison in a validator, ask what would happen if the
+  expression on the left *raised* — if the answer is "the caller gets an exception instead of
+  the named refusal", the operands need bounding above it.
+- Enforced in: `app/services/strategy_core_allocator.py::_state_refusal` (per-component check
+  documented as overflow-safety, not as a shortcut); `tests/test_2603_core_allocator.py`
+  parametrises `9e999999 + 9e999999` and a pair that clears the component bound but sums past it.

--- a/tests/test_2603_core_allocator.py
+++ b/tests/test_2603_core_allocator.py
@@ -211,6 +211,13 @@ def test_a_broker_minimum_below_the_mandate_floor_does_not_lower_it() -> None:
     assert (decision.effective_floor, decision.floor_source) == (Decimal("100"), "mandate")
 
 
+def test_a_tie_reports_the_mandate_as_the_floor_source() -> None:
+    """The applied value is identical either way; the mandate is the floor that
+    always exists."""
+    decision = evaluate_core_rebalance(mandate(floor="100"), sleeve("700", "300"), broker_minimum=Decimal("100"))
+    assert (decision.effective_floor, decision.floor_source) == (Decimal("100"), "mandate")
+
+
 def test_equality_with_the_floor_acts() -> None:
     decision = evaluate_core_rebalance(mandate(floor="50"), sleeve("700", "300"))
     assert (decision.action, decision.amount) == ("sell_core", Decimal("50"))

--- a/tests/test_2603_core_allocator.py
+++ b/tests/test_2603_core_allocator.py
@@ -1,0 +1,370 @@
+"""#2603 item 3: the core/cash rebalance decision.
+
+Pure-logic tier — no DB, no clock, no broker.  Spec:
+``docs/proposals/ta/2026-08-13-core-cash-allocator.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from app.services.strategy_core_allocator import (
+    CoreRebalanceDecision,
+    CoreSleeveState,
+    evaluate_core_rebalance,
+)
+from app.services.strategy_core_mandate import CORE_MANDATE_POLICY_VERSION, CoreMandate
+
+AS_OF = datetime(2026, 8, 13, 12, 0, tzinfo=UTC)
+CORE_ID = 4242
+
+
+def mandate(
+    *,
+    enabled: bool = True,
+    core_instrument_id: int | None = CORE_ID,
+    target: str = "60",
+    reserve: str = "5",
+    band: str = "5",
+    # Low enough that the default sleeve's trades clear it: a fixture floor that
+    # silently suppresses is a test that passes for the wrong reason.
+    floor: str = "1",
+    base_currency: str = "USD",
+    policy_version: str = CORE_MANDATE_POLICY_VERSION,
+) -> CoreMandate:
+    return CoreMandate(
+        event_id=1,
+        revision=1,
+        enabled=enabled,
+        base_currency=base_currency,
+        core_instrument_id=core_instrument_id,
+        core_target_pct=Decimal(target),
+        liquidity_reserve_pct=Decimal(reserve),
+        rebalance_band_pct=Decimal(band),
+        min_rebalance_amount=Decimal(floor),
+        policy_version=policy_version,
+    )
+
+
+def sleeve(core: str, cash: str, *, instrument_id: int = CORE_ID, currency: str = "USD") -> CoreSleeveState:
+    return CoreSleeveState(
+        core_instrument_id=instrument_id,
+        core_market_value=Decimal(core),
+        cash_balance=Decimal(cash),
+        currency=currency,
+        as_of=AS_OF,
+    )
+
+
+def test_in_band_holds_without_a_reason_code() -> None:
+    # 60/40 on a 60±5 mandate: dead on target.
+    decision = evaluate_core_rebalance(mandate(), sleeve("600", "400"))
+    assert decision.action == "hold"
+    assert decision.reason_code is None
+    assert decision.amount == 0
+    assert decision.core_pct == Decimal("60")
+    # Cash 40% against a 5% reserve.
+    assert decision.reserve_margin_pct == Decimal("35")
+    assert decision.reserve_breached is False
+
+
+@pytest.mark.parametrize(
+    ("core", "cash", "action", "amount"),
+    [
+        # 70% core on 60±5 -> sell to the 65 edge: 0.65*1000 - 700 = -50.
+        ("700", "300", "sell_core", "50"),
+        # 50% core on 60±5 -> buy to the 55 edge: 0.55*1000 - 500 = 50.
+        ("500", "500", "buy_core", "50"),
+    ],
+)
+def test_outside_the_band_trades_to_the_near_edge_not_the_target(
+    core: str, cash: str, action: str, amount: str
+) -> None:
+    """Leland (2000): trade to the region's boundary, not to the target.
+
+    Trading to target would move 100 in both rows; the edge moves 50.
+    """
+    decision = evaluate_core_rebalance(mandate(), sleeve(core, cash))
+    assert (decision.action, decision.amount) == (action, Decimal(amount))
+    assert decision.reason_code is None
+
+
+@pytest.mark.parametrize("core_pct", ["65", "55"])
+def test_the_band_edge_itself_is_inside_the_band(core_pct: str) -> None:
+    """Strictly outside, by construction: an allowance consumed exactly is still
+    within the allowance."""
+    core = Decimal(core_pct) * 10
+    decision = evaluate_core_rebalance(mandate(), sleeve(str(core), str(1000 - core)))
+    assert decision.action == "hold"
+    assert decision.reason_code is None
+
+
+def test_a_trade_lands_on_the_edge_it_was_sized_to() -> None:
+    decision = evaluate_core_rebalance(mandate(), sleeve("700", "300"))
+    assert decision.upper_pct == Decimal("65")
+    # Post-trade cash is 35%, against a 5% reserve.
+    assert decision.reserve_margin_pct == Decimal("30")
+
+
+# --- Q1: a reserve breach strictly implies an upper-band breach ----------------
+
+
+def test_reserve_breach_always_implies_a_band_breach() -> None:
+    """Q1's proof, exercised across the schema-valid mandate space.
+
+    For any mandate satisfying sql/336's CHECKs, `cash_pct < reserve` cannot occur
+    without `core_pct > upper`.  If it could, the allocator would need a second
+    trigger it does not have.
+    """
+    checked = 0
+    for target in range(0, 101, 5):
+        for band in range(1, 101, 3):
+            for reserve in range(0, 100, 7):
+                # sql/336's two CHECKs.
+                if target - band < 0:
+                    continue
+                if 100 - (target + band) < reserve:
+                    continue
+                spec = mandate(target=str(target), band=str(band), reserve=str(reserve), floor="0.000001")
+                for core_pct in range(0, 101):
+                    state = sleeve(str(core_pct * 10), str((100 - core_pct) * 10))
+                    decision = evaluate_core_rebalance(spec, state)
+                    if decision.action == "refused":
+                        continue
+                    checked += 1
+                    assert decision.reserve_breached is not None
+                    if decision.reserve_breached:
+                        assert decision.action == "sell_core", (
+                            f"reserve breach not caught by the band: target={target} band={band} "
+                            f"reserve={reserve} core_pct={core_pct}"
+                        )
+    assert checked > 10_000, f"coverage collapsed to {checked} states"
+
+
+def test_a_directly_constructed_invalid_mandate_is_refused_not_computed() -> None:
+    """The Q1 proof assumes a schema-valid mandate, and `CoreMandate` is a public
+    frozen dataclass anyone can construct."""
+    # Band drives the worst-case cash straight through the reserve: 100-(90+9)=1 < 20.
+    rogue = mandate(target="90", band="9", reserve="20")
+    decision = evaluate_core_rebalance(rogue, sleeve("950", "50"))
+    assert decision.action == "refused"
+    assert decision.reason_code == "core_mandate_invalid"
+    assert decision.reserve_breached is None
+
+
+# --- Q4: the floor wins, and the breach it leaves is bounded -------------------
+
+
+def test_floor_suppresses_the_trade_and_reports_the_breach_it_leaves() -> None:
+    # 96% core on a 60±5 mandate with a 4% reserve: cash 4% < 4%? no -- use 5%.
+    spec = mandate(target="60", band="5", reserve="5", floor="1000000")
+    decision = evaluate_core_rebalance(spec, sleeve("960", "40"))
+    assert decision.action == "hold"
+    assert decision.reason_code == "below_min_rebalance_amount"
+    assert decision.amount == 0
+    assert decision.reserve_breached is True
+    # Reported against the CURRENT state, because no trade happens: 4% - 5%.
+    assert decision.reserve_margin_pct == Decimal("-1")
+    assert decision.effective_floor == Decimal("1000000")
+    assert decision.floor_source == "mandate"
+
+
+def test_the_suppressed_breach_never_exceeds_the_effective_floor() -> None:
+    """Q4's bound: sell-to-edge >= the currency shortfall, so a suppressed sell
+    leaves a shortfall below the floor.
+
+    ⚠ Proved on the raw pre-cost amount; the implementation compares the ROUNDED
+    amount, so the bound carries one quantum of slack.  Asserted with that slack.
+    """
+    quantum = Decimal("0.000001")
+    for reserve in ("1", "5", "12.5"):
+        for floor in ("10", "250.5", "9999"):
+            spec = mandate(target="60", band="5", reserve=reserve, floor=floor)
+            for core in range(880, 1000):
+                state = sleeve(str(core), str(1000 - core))
+                decision = evaluate_core_rebalance(spec, state)
+                if decision.reason_code != "below_min_rebalance_amount":
+                    continue
+                if not decision.reserve_breached:
+                    continue
+                shortfall = (Decimal(reserve) - (Decimal(1000 - core) / 10)) / 100 * 1000
+                assert shortfall <= Decimal(floor) + quantum, (
+                    f"shortfall {shortfall} exceeded floor {floor} at core={core}"
+                )
+
+
+def test_a_broker_minimum_raises_the_floor_and_says_so() -> None:
+    spec = mandate(floor="10")
+    state = sleeve("700", "300")  # a 50 sell
+    assert evaluate_core_rebalance(spec, state, broker_minimum=Decimal("20")).action == "sell_core"
+    suppressed = evaluate_core_rebalance(spec, state, broker_minimum=Decimal("75"))
+    assert suppressed.action == "hold"
+    assert suppressed.reason_code == "below_min_rebalance_amount"
+    assert (suppressed.effective_floor, suppressed.floor_source) == (Decimal("75"), "broker")
+
+
+def test_a_broker_minimum_below_the_mandate_floor_does_not_lower_it() -> None:
+    decision = evaluate_core_rebalance(mandate(floor="100"), sleeve("700", "300"), broker_minimum=Decimal("1"))
+    assert (decision.effective_floor, decision.floor_source) == (Decimal("100"), "mandate")
+
+
+def test_equality_with_the_floor_acts() -> None:
+    decision = evaluate_core_rebalance(mandate(floor="50"), sleeve("700", "300"))
+    assert (decision.action, decision.amount) == ("sell_core", Decimal("50"))
+
+
+# --- rounding ------------------------------------------------------------------
+
+
+def test_rounding_down_never_overshoots_and_cannot_re_trigger() -> None:
+    """A residual below one quantum is below any storable floor, so the next pass
+    suppresses it rather than trading again."""
+    # Sleeve of 3 forces a repeating division: 0.65*3 - 2.1 = -0.15 exactly, so
+    # pick one that does not divide cleanly.
+    spec = mandate(target="60", band="5", floor="0.000001")
+    state = sleeve("7", "3")  # 70% of 10 -> sell 0.5 exactly
+    first = evaluate_core_rebalance(spec, state)
+    assert first.action == "sell_core"
+    # Apply it and re-evaluate: the post-trade state is inside the band.
+    after = sleeve(str(Decimal("7") - first.amount), str(Decimal("3") + first.amount))
+    second = evaluate_core_rebalance(spec, after)
+    assert second.action == "hold"
+    assert second.reason_code is None
+
+
+def test_a_repeating_division_rounds_down_and_settles_next_pass() -> None:
+    spec = mandate(target="33.3333", band="1", floor="0.000001")
+    state = sleeve("700", "300")
+    first = evaluate_core_rebalance(spec, state)
+    assert first.action == "sell_core"
+    assert first.amount == first.amount.quantize(Decimal("0.000001"))
+    after = sleeve(str(Decimal("700") - first.amount), str(Decimal("300") + first.amount))
+    second = evaluate_core_rebalance(spec, after)
+    assert second.action == "hold", second
+    assert second.reason_code in (None, "below_min_rebalance_amount")
+
+
+def test_no_zero_amount_trade_is_ever_emitted() -> None:
+    spec = mandate(target="60", band="5", floor="0.000001")
+    for core in range(0, 1001):
+        decision = evaluate_core_rebalance(spec, sleeve(str(core), str(1000 - core)))
+        if decision.action in ("buy_core", "sell_core"):
+            assert decision.amount > 0
+
+
+# --- refusals, in precedence order --------------------------------------------
+
+
+def test_absent_mandate_is_a_state_not_a_default() -> None:
+    decision = evaluate_core_rebalance(None, sleeve("600", "400"))
+    assert decision.reason_code == "core_mandate_absent"
+    assert decision.core_pct is None
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        (mandate(policy_version="core-mandate-v2"), "core_mandate_policy_unsupported"),
+        (mandate(enabled=False, core_instrument_id=None), "core_mandate_disabled"),
+        (mandate(target="90", band="9", reserve="20"), "core_mandate_invalid"),
+    ],
+)
+def test_mandate_refusals(spec: CoreMandate, expected: str) -> None:
+    decision = evaluate_core_rebalance(spec, sleeve("600", "400"))
+    assert decision.action == "refused"
+    assert decision.reason_code == expected
+
+
+def test_policy_version_is_checked_before_validity() -> None:
+    """A row written under a later policy must not be blamed for our staleness."""
+    stale = mandate(policy_version="core-mandate-v2", target="90", band="9", reserve="20")
+    assert evaluate_core_rebalance(stale, sleeve("600", "400")).reason_code == "core_mandate_policy_unsupported"
+
+
+def test_enabled_mandate_without_an_instrument_is_refused() -> None:
+    """Unreachable through the CHECK and the validator, reachable through the
+    dataclass — which is exactly why the guard is here."""
+    rogue = CoreMandate(
+        event_id=1,
+        revision=1,
+        enabled=True,
+        base_currency="USD",
+        core_instrument_id=None,
+        core_target_pct=Decimal("60"),
+        liquidity_reserve_pct=Decimal("5"),
+        rebalance_band_pct=Decimal("5"),
+        min_rebalance_amount=Decimal("100"),
+        policy_version=CORE_MANDATE_POLICY_VERSION,
+    )
+    # `validate_core_mandate` catches this one first, and either code is a refusal;
+    # what must not happen is a computed verdict.
+    decision = evaluate_core_rebalance(rogue, sleeve("600", "400"))
+    assert decision.action == "refused"
+    assert decision.reason_code in ("core_mandate_invalid", "core_instrument_unset")
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (sleeve("600", "400", currency="GBP"), "sleeve_currency_mismatch"),
+        (sleeve("600", "400", instrument_id=CORE_ID + 1), "sleeve_instrument_mismatch"),
+        (sleeve("-600", "400"), "sleeve_valuation_invalid"),
+        (sleeve("600", "-400"), "sleeve_valuation_invalid"),
+        (sleeve("NaN", "400"), "sleeve_valuation_invalid"),
+        (sleeve("Infinity", "400"), "sleeve_valuation_invalid"),
+        # 12 integer digits is the NUMERIC(18,6) ceiling.
+        (sleeve("999999999999", "1"), "sleeve_valuation_invalid"),
+        # Two components that each clear the bound but sum past it.
+        (sleeve("600000000000", "600000000000"), "sleeve_valuation_invalid"),
+        # Finite, and near Decimal's Emax: the SUM raises decimal.Overflow, so the
+        # per-component check must run first or the refusal never happens.
+        (sleeve("9e999999", "9e999999"), "sleeve_valuation_invalid"),
+        (sleeve("0", "0"), "core_sleeve_empty"),
+    ],
+)
+def test_state_refusals(state: CoreSleeveState, expected: str) -> None:
+    decision = evaluate_core_rebalance(mandate(), state)
+    assert decision.action == "refused"
+    assert decision.reason_code == expected
+
+
+def test_a_sleeve_just_under_the_bound_is_accepted() -> None:
+    decision = evaluate_core_rebalance(mandate(), sleeve("999999999998", "1"))
+    assert decision.action != "refused"
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "NaN", "Infinity"])
+def test_an_invalid_broker_minimum_is_refused(bad: str) -> None:
+    decision = evaluate_core_rebalance(mandate(), sleeve("700", "300"), broker_minimum=Decimal(bad))
+    assert decision.reason_code == "broker_minimum_invalid"
+
+
+def test_currency_is_compared_case_and_whitespace_insensitively() -> None:
+    decision = evaluate_core_rebalance(mandate(), sleeve("600", "400", currency=" usd "))
+    assert decision.action == "hold"
+
+
+def test_a_refusal_nulls_the_arithmetic_it_could_not_compute() -> None:
+    decision: CoreRebalanceDecision = evaluate_core_rebalance(mandate(), sleeve("0", "0"))
+    assert (decision.core_pct, decision.upper_pct, decision.lower_pct) == (None, None, None)
+    assert (decision.reserve_breached, decision.reserve_margin_pct) == (None, None)
+    assert (decision.effective_floor, decision.floor_source) == (None, None)
+
+
+# --- the degenerate mandates sql/336 permits (#2670) ---------------------------
+
+
+def test_a_band_equal_to_the_target_never_fires_the_lower_trigger() -> None:
+    """#2670: sql/336 permits `band == target`, giving `lower == 0`, which
+    `core_pct < 0` can never reach.  Documented here so the behaviour is expected
+    rather than surprising — the arithmetic is right, the mandate is weaker than
+    it declares."""
+    spec = mandate(target="20", band="20", reserve="0", floor="0.000001")
+    assert spec.core_target_pct - spec.rebalance_band_pct == 0
+    # An empty core is the most extreme underweight there is, and it still holds.
+    decision = evaluate_core_rebalance(spec, sleeve("0", "1000"))
+    assert decision.lower_pct == Decimal("0")
+    assert decision.action == "hold"


### PR DESCRIPTION
## What this is

The buildable half of #2603 **scope item 3**. Items 1 and 4 shipped earlier today (`2308ec6d`, `0219c1c1`); this is the deterministic rebalance **decision** — mandate plus observed sleeve state in, one verdict out. Pure: no connection, no clock, no broker, no persistence, **no migration**.

Spec: `docs/proposals/ta/2026-08-13-core-cash-allocator.md`.

## Why it stops where it does

Item 3 reads *"drift outside band → order intent → the existing demo execution plane"*. The first arrow is arithmetic over an operator authority. The second is the execution plane, which item 1's spec already verified **cannot be reused as-is** (Q5 below), and whose acceptance #2603 explicitly reserves for an operator-attended demo session. The split is at the first arrow.

⚠ **No endpoint ships, and that is a decision.** A read-only preview endpoint needs the observed sleeve state, which comes from a broker portfolio read, and Definition-of-Done clause 11 requires an operator-visible figure verified on the live endpoint after the change. A headless worktree cannot do that, and an endpoint shipped without it would be an unverified operator surface.

⚠ **This module authorises nothing and has no caller.** It is the first *reader* of `strategy_core_mandate_events` — which is what item 1's spec said item 3 would be — but nothing calls `evaluate_core_rebalance`, and no verdict causes anything to happen. #2437's R4 comment records *a control on a path the decision does not take* seven times over, so the state is named in the module docstring and the spec rather than left to be inferred.

## Source rule

The one formulation choice with a published answer is **where a triggered rebalance trades to** — target, or near band edge.

**Leland, Hayne E. (2000), "Optimal Portfolio Management with Transactions Costs and Capital Gains Taxes", RPF-290, Haas School of Business, U.C. Berkeley (SSRN 206871).** Under proportional transaction costs the optimal policy is a **no-trade region** about the target proportions; outside it, trade **to the region's boundary, not to the target**. Region existence is Constantinides (1986) and Davis & Norman (1990).

Three limits on the adoption, stated in the spec so it cannot later be cited for more:

1. **The band's width is not Leland's** — his is derived from a cost model, ours is an operator declaration. No threshold is selected here and no constant is invented.
2. **His ~50% turnover reduction does not transfer** — that compares his *optimised* region against *periodic* rebalancing to target. Ours is declared and threshold-triggered. What carries is the direction only: at an identical trigger, trading to the near edge moves strictly less.
3. **The model assumptions differ** — symmetric declared band, currency floor, discrete quantities, broker frictions.

Where no published rule governs, the choice is made **by construction** and labelled as such in the spec. Four are: the strict trigger, floor-over-reserve precedence, refusal precedence, and the rounding direction.

## The five questions item 1's spec left for item 3

Four answered, one explicitly not.

**Q1 — can a price gap put cash below the reserve between rebalances?** It never needs a second trigger. For any mandate satisfying `sql/336`'s CHECKs:

```
reserve breached <=> core_pct > 100 - reserve
sql/336 CHECK    :  core_target + band <= 100 - reserve
therefore        :  core_pct > 100 - reserve >= core_target + band  =>  core_pct > upper
```

A reserve breach **strictly implies** an upper-band breach; the band dominates the reserve, and a separate reserve trigger would be unreachable code.

⚠ The proof assumes a schema-valid mandate and `CoreMandate` is a public frozen dataclass anyone can construct, so the allocator **re-runs `validate_core_mandate`** and refuses `core_mandate_invalid` rather than computing on a state the proof does not cover. Without that the "always" is false, not merely unproven.

**Q2 — equality or strictly outside? Strictly outside [by construction].** The first draft of the spec claimed this was *derived* from `sql/336`'s CHECK. It is not, and Codex checkpoint 1 said so: storability of the edge does not settle actionability. The construction is that a band is an **allowance**, and an allowance consumed exactly is still within it. The schema is consistent with that reading.

**Q3 — target or edge, and what about costs? Edge. Costs are NOT answered, and this PR does not claim they are.** For the one shape the algebra covers — a fee deducted from cash, not embedded in price — `(a-f)/(b-f) < a/b`, so such a fee lowers post-trade cash percentage in both directions. Two consequences, and the first draft caught only one:

- **the reserve** — pre-cost post-trade cash on a `sell_core` is `100 - target - band`, which the CHECK guarantees is `>= reserve` but **permits to be exactly equal**, so on such a mandate any fee breaches it;
- **the band itself** — a sell sized to the pre-cost upper edge lands at `upper·V/(V-f) > upper`, still outside the band it was meant to restore.

#2598 closed on precisely the point that execution holds the broker's own number at entry time; inventing one here would repeat the mistake it was closed to avoid. Nor is "widen by the fee" the formula (reaching `upper` needs `+upper/100·f`, restoring the reserve needs `+(1-reserve/100)·f`, and a size-dependent fee makes it an implicit equation). So the verdict returns `reserve_margin_pct` — the pre-cost slack — and the obligation is stated where it belongs: **the execution half must re-solve the size against the cost it is quoted, and refuse if it cannot restore both.**

**Q4 — precedence when the floor suppresses the reserve-restoring trade. The floor wins, no trade, `reserve_breached` reported [by construction].** The allocator has no authority to trade through one operator declaration to satisfy another. The breach it leaves is bounded: sell-to-edge `>=` the currency shortfall, so a suppressed sell leaves a shortfall below **the effective floor** — `max(mandate, broker)`, not the mandate floor alone. ⚠ Nominal, **not proportional**: on a small sleeve a sub-floor shortfall can still be a large share of the reserve. Not called safe.

*(An earlier draft also argued the floor exists because a sub-floor trade costs more than the drift it corrects. Unsupported — an operator minimum may equally encode broker mechanics — and withdrawn.)*

**Q5 — the core position class. Still deferred, not answered.** Item 1's spec verified `sql/287:116` CHECKs `stop_loss_rate > 0 AND take_profit_rate > 0` on an `allocated` verdict, `strategy_position_manager.py:816` makes a stop-less holding a permanent `fixed_exit_repair` condition, and `:817` exact-matches the take-profit. This slice emits no order intent, so it neither needs nor creates that class.

## Contract

`CoreSleeveState` carries `core_instrument_id`, `core_market_value`, `cash_balance`, `currency`, `as_of`. Caller obligations the arithmetic depends on and the module cannot check are stated explicitly on the dataclass: one snapshot for both components, one instrument netted with nothing else folded in, settled and unreserved cash, and no rebalance already in flight (the function is stateless and will re-recommend one). **Eligibility is not gated** — item 2 owns that proof and has no table yet, so a `buy_core` verdict is explicitly *not* an eligibility finding.

`CoreRebalanceDecision` carries the arithmetic that produced it. `reserve_margin_pct` has **one** meaning — the pre-cost margin in the state the verdict leaves you in — because the first draft left it ambiguous between three.

A **refusal is "cannot decide"** and nulls the arithmetic. **"Decided not to trade"** is a `hold`: in-band (no code) or floor-suppressed (`below_min_rebalance_amount`, carrying the full arithmetic). Keeping the suppressed case a `hold` is what makes Q4 observable — a refusal would null the very fields Q4 exists to surface.

Refusal precedence (first match wins): `core_mandate_absent` → `core_mandate_policy_unsupported` → `core_mandate_invalid` → `core_mandate_disabled` → `core_instrument_unset` → `sleeve_currency_mismatch` → `sleeve_instrument_mismatch` → `sleeve_valuation_invalid` → `broker_minimum_invalid` → `core_sleeve_empty`. Policy version precedes validity because `validate_core_mandate` implements *this* version's arithmetic, and reporting "invalid" for a row written under a later policy would blame the row for our own staleness.

## Codex checkpoints

**Checkpoint 1 (spec)** returned ~20 findings and materially changed the design. The load-bearing ones: Q2 was presented as derived when it is a construction choice; the Q4 bound is the **effective** floor, not `min_rebalance_amount`; a cash-deducted fee threatens **the band** as well as the reserve; the Q1 proof does not cover a directly-constructed `CoreMandate`; `reserve_margin_pct` was ambiguous; `amount` was described as signed but computed as a magnitude; the "plausible fee cannot breach the buy side" claim was unsupported and is withdrawn. Also flagged two degenerate mandates `sql/336` permits — filed as **#2670**, not fixed here (it needs a migration).

**Checkpoint 2 (diff)** found one real P2, by probe rather than by reading: `_state_refusal` bounded the **sum** and reasoned a per-component check was redundant. It is not — two finite components near `Decimal`'s `Emax` raise `decimal.Overflow` **on the addition**, before the comparison the refusal depends on. `Decimal("9e999999") + Decimal("9e999999")` raises; `1e999999 + 1e999999` does not, so only part of the input space is affected, which is why reading missed it. Fixed by bounding each component first, then the sum; both checks stay and neither implies the other.

Extracted to `docs/review-prevention-log.md` as *"A magnitude guard that bounds an AGGREGATE can be escaped by an overflow in the aggregation itself"* — the general shape being that **the guard's own arithmetic is unguarded**.

## Testing

`tests/test_2603_core_allocator.py`, 41 pure-logic tests, no DB:

- Q1's proof exercised across **>10,000** schema-valid mandate/state combinations, asserting a reserve breach is never seen without a `sell_core` (the test fails if coverage collapses).
- Q4's bound asserted over the suppressed-sell space, with the one-quantum slack the rounded-vs-raw comparison introduces stated in the test.
- Edge-not-target: 70% and 50% core on a 60±5 mandate each move 50, where target-rebalancing would move 100.
- Rounding: `ROUND_DOWN` never overshoots, and the sub-quantum residual cannot re-trigger, because `min_rebalance_amount > 0` on a `NUMERIC(18,6)` column is at least one quantum.
- No zero-amount trade is emitted anywhere in the state space.
- Every refusal, including the Codex-found overflow pair and a component pair that clears the per-component bound but sums past it.
- The #2670 degenerate mandate, so its behaviour is documented rather than surprising.

Gates: `ruff check` / `ruff format --check` / `pyright` / `pytest -m "not db"` / `tests/smoke` all green, unpiped (a pipe returns the pipe's status).

**Definition-of-Done clauses 8-12 do not apply**: no ETL, no parser, no schema migration, no ownership/observations data, nothing to backfill. The change is pure logic with no persistence and no operator-visible surface.

## Security

No new surface. No endpoint, no job, no broker call, no credential path, no SQL, no persisted state, no user-controlled input. The only behavioural reach is that a public dataclass is now re-validated before its values are used, which narrows rather than widens what the module will compute on.

## Also in this diff

`PERCENT_BASIS`, `AMOUNT_PLACES`, `AMOUNT_PRECISION` and the two numeric validators in `strategy_core_mandate` become public. The allocator sizes in the same `NUMERIC(18,6)` shape, and re-declaring `6` and `18` in a second module would be two constants that must agree with nothing making them. The percentage pair stays private — no second consumer writes a `NUMERIC(8,4)` column.

Refs #2603. Refs #2525. Refs #2437. Refs #2598. Refs #2670.
