### PR TITLE
fix(#2666): make a slow drain distinguishable from a reload that never fired

### DIFF
--- a/app/jobs/dev_reload.py
+++ b/app/jobs/dev_reload.py
@@ -66,6 +66,14 @@ _DRAIN_TIMEOUT_S: Final[float] = 180.0
 # already gone; this only covers the wait() round-trip.
 _KILL_REAP_TIMEOUT_S: Final[float] = 10.0
 
+# How often to report progress while draining (#2666). A drain that runs
+# the full _DRAIN_TIMEOUT_S is three minutes of silence between "SIGTERM
+# -> pid N" and the respawn, and an observer polling PIDs across that
+# window sees an unchanged PID and concludes the reload never fired. It
+# did; it is mid-drain. Periodic INFO makes "still working" distinguish
+# itself from "never started".
+_DRAIN_PROGRESS_S: Final[float] = 15.0
+
 # After a SIGKILL the fence connection is closed by the OS, not by the
 # daemon, so Postgres only drops the advisory lock once it notices the
 # dead session. Same one-second settle stack-restart.sh uses.
@@ -112,6 +120,41 @@ def changes_are_stale(paths: Iterable[str], spawn_time: float) -> bool:
     return True
 
 
+def running_commit() -> str:
+    """The commit the child is about to run, or ``"unknown"`` (#2666).
+
+    The supervisor's own output is then enough to answer "which commit is the
+    running worker on", which is the property that was missing: PID polling
+    across a slow drain cannot distinguish a reload in progress from one that
+    never fired, and re-detaching the main checkout at ``origin/main`` is exactly
+    how a merged service change is meant to reach this daemon.
+
+    ⚠ ``GIT_*`` is scrubbed from the child environment.  A git hook exports
+    ``GIT_DIR`` (and friends) into everything it runs, so this call would resolve
+    against the HOOK's repository rather than ``_REPO_ROOT`` whenever the daemon
+    -- or a test exercising it -- is reached from under one.  Same trap as #2658.
+
+    Never raises: a missing git, a non-repo checkout or a slow disk degrades to
+    ``"unknown"``.  A reload must not be blocked by its own log line.
+    """
+    env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+            env=env,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return "unknown"
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
 def _spawn_child() -> tuple[subprocess.Popen[bytes], float]:
     """Spawn the daemon, returning it with the wall-time it was started.
 
@@ -123,7 +166,7 @@ def _spawn_child() -> tuple[subprocess.Popen[bytes], float]:
     extra reload. Same principle as the deleted-path case — a redundant
     restart is always preferable to silently-stale code.
     """
-    logger.info("jobs dev-reload: starting %s", " ".join(_CHILD_ARGV))
+    logger.info("jobs dev-reload: starting %s at commit %s", " ".join(_CHILD_ARGV), running_commit())
     spawn_time = time.time()
     return subprocess.Popen(_CHILD_ARGV, cwd=_REPO_ROOT), spawn_time
 
@@ -143,16 +186,35 @@ def _stop_child(proc: subprocess.Popen[bytes]) -> None:
     except ProcessLookupError:
         proc.wait()
         return
-    try:
-        proc.wait(timeout=_DRAIN_TIMEOUT_S)
+    # Wait in _DRAIN_PROGRESS_S slices rather than one long block, so a slow
+    # drain reports itself (#2666).  The deadline is computed once: slicing must
+    # not extend the total budget, which is what a naive per-slice timeout would
+    # do.
+    deadline = started + _DRAIN_TIMEOUT_S
+    drained = False
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            proc.wait(timeout=min(_DRAIN_PROGRESS_S, remaining))
+            drained = True
+            break
+        except subprocess.TimeoutExpired:
+            logger.info(
+                "jobs dev-reload: pid %d still draining, %.0fs of %.0fs elapsed",
+                proc.pid,
+                time.monotonic() - started,
+                _DRAIN_TIMEOUT_S,
+            )
+    if drained:
         logger.info("jobs dev-reload: drained cleanly in %.1fs", time.monotonic() - started)
         return
-    except subprocess.TimeoutExpired:
-        logger.warning(
-            "jobs dev-reload: pid %d still draining after %.0fs — escalating to SIGKILL",
-            proc.pid,
-            _DRAIN_TIMEOUT_S,
-        )
+    logger.warning(
+        "jobs dev-reload: pid %d still draining after %.0fs — escalating to SIGKILL",
+        proc.pid,
+        _DRAIN_TIMEOUT_S,
+    )
     proc.kill()
     try:
         proc.wait(timeout=_KILL_REAP_TIMEOUT_S)

--- a/tests/jobs/test_dev_reload.py
+++ b/tests/jobs/test_dev_reload.py
@@ -1,4 +1,4 @@
-"""#2144 — dev jobs-daemon auto-reload: stale-batch suppression.
+"""#2144 / #2666 — dev jobs-daemon auto-reload: stale-batch suppression and drain visibility.
 
 Pure-logic only (no DB, no subprocess). The one non-obvious decision in
 the supervisor is whether a change batch delivered *after* a restart
@@ -10,9 +10,17 @@ second full drain for nothing.
 
 from __future__ import annotations
 
+import logging
 import os
+import signal
+import subprocess
+import time
 from pathlib import Path
+from typing import Any, cast
 
+import pytest
+
+from app.jobs import dev_reload
 from app.jobs.dev_reload import changes_are_stale
 
 
@@ -59,3 +67,82 @@ def test_deleted_path_does_not_mask_a_newer_sibling(tmp_path: Path) -> None:
         _touch(tmp_path / "fresh.py", 1001.0),
     ]
     assert changes_are_stale(paths, spawn_time=1000.0) is False
+
+
+# --- #2666: a slow drain must not look like a reload that never fired ---------
+
+
+class _FakeProc:
+    """A child that ignores SIGTERM for `hangs_for` wait() calls."""
+
+    def __init__(self, hangs_for: int) -> None:
+        self.pid = 4242
+        self._hangs_left = hangs_for
+        self.signals: list[int] = []
+        self.killed = False
+        self._alive = True
+
+    def poll(self) -> int | None:
+        return None if self._alive else 0
+
+    def send_signal(self, signum: int) -> None:
+        self.signals.append(signum)
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self._hangs_left > 0:
+            self._hangs_left -= 1
+            # Sleep the slice before raising, as a real Popen.wait does. Without
+            # it the supervisor's deadline loop spins in microseconds and the
+            # budget under test is never actually consumed.
+            time.sleep(timeout or 0.0)
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout or 0.0)
+        self._alive = False
+        return 0
+
+    def kill(self) -> None:
+        self.killed = True
+        self._hangs_left = 0
+
+
+def test_a_slow_drain_reports_progress_instead_of_going_silent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#2666's real gap: three minutes of silence between SIGTERM and the
+    respawn reads, to a PID-polling observer, as 'the reload never fired'."""
+    monkeypatch.setattr(dev_reload, "_DRAIN_TIMEOUT_S", 1.0)
+    monkeypatch.setattr(dev_reload, "_DRAIN_PROGRESS_S", 0.01)
+    proc = _FakeProc(hangs_for=3)
+    with caplog.at_level(logging.INFO, logger=dev_reload.__name__):
+        dev_reload._stop_child(cast(Any, proc))
+    progress = [r for r in caplog.records if "still draining," in r.message]
+    assert progress, "a slow drain emitted no progress line"
+    assert proc.signals == [signal.SIGTERM]
+    assert not proc.killed, "drained before the deadline, so no escalation"
+
+
+def test_slicing_the_wait_does_not_extend_the_drain_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Waiting in slices must not turn one 180s budget into N x 180s."""
+    monkeypatch.setattr(dev_reload, "_DRAIN_TIMEOUT_S", 0.2)
+    monkeypatch.setattr(dev_reload, "_DRAIN_PROGRESS_S", 0.02)
+    monkeypatch.setattr(dev_reload, "_POST_KILL_SETTLE_S", 0.0)
+    proc = _FakeProc(hangs_for=10_000)  # never drains
+    started = time.monotonic()
+    dev_reload._stop_child(cast(Any, proc))
+    elapsed = time.monotonic() - started
+    assert proc.killed, "a child past the deadline must be escalated"
+    # Generous ceiling: the assertion is that the budget is BOUNDED, not a
+    # wall-clock ratio (a timing ratio is a host measurement, not a property).
+    assert elapsed < 5.0, f"drain budget was not bounded: {elapsed:.2f}s"
+
+
+def test_running_commit_ignores_an_inherited_git_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A git hook exports GIT_DIR into everything it runs, so an unscrubbed call
+    would resolve against the hook's repo rather than ours (#2658's trap)."""
+    monkeypatch.setenv("GIT_DIR", "/nonexistent/hook.git")
+    monkeypatch.setenv("GIT_WORK_TREE", "/nonexistent")
+    assert dev_reload.running_commit() != "unknown"
+
+
+def test_running_commit_degrades_rather_than_raising(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(dev_reload, "_REPO_ROOT", tmp_path)  # not a git repo
+    assert dev_reload.running_commit() == "unknown"


### PR DESCRIPTION
## The premise is falsified — watchfiles delivers the checkout

#2666 records that the jobs `dev_reload` supervisor did not respawn after `git checkout` rewrote `app/**`, but did within ~10s of a `touch`, and offers three untested candidate directions (FSEvents vs git's write-then-rename, `PythonFilter` on a large batch, a `_DRAIN_TIMEOUT_S` interaction). The ticket was right not to claim a cause. **The first two are ruled out by measurement, and the third is the answer — but not as an interaction, as the plain designed behaviour.**

Measured in isolation: a scratch git repo, the **same `watch()` arguments this module uses** (`PythonFilter()`, `rust_timeout=1000`, `yield_on_timeout=True`), and no jobs daemon — a second one would hit the singleton advisory fence. Four phases, 4s settle each:

| phase | mtime moved | batches | latency | payload |
| --- | --- | --- | --- | --- |
| `git checkout --detach <older>` | yes | **1** | 0.47s | `{added, deleted}` on the same path |
| `touch` (the documented workaround) | yes | 1 | 0.25s | `{added}` |
| `git checkout` back | yes | 1 | 0.32s | `{added, deleted}` |
| plain in-place write | yes | 1 | 0.34s | `{added}` |

So the rust watcher, `PythonFilter` and FSEvents' handling of git's rewrite are all clear. `changes_are_stale` is clear too, by inspection of the recorded numbers: the rewritten file's mtime (17:41:34) is hours newer than the child's spawn time (14:12:31), which is the **not-stale** branch — `return False`, reload.

## What actually happened

The drain escalation, on the ticket's own timestamps and this module's own constants:

```
checkout -> respawn, observed             182s   (17:41:34 -> 17:44:36)
_DRAIN_TIMEOUT_S + _POST_KILL_SETTLE_S    181s   (180.0 + 1.0)
residual                                    1s   (watcher latency measured at
                                                  0.47s; reap bound 10s)
```

The reload fired immediately. The child ignored SIGTERM for the full three-minute drain, was SIGKILLed, settled, and respawned at +182s. The `touch` at 17:44:2x landed **~14s before a respawn that was already inbound** and was credited with causing it. The observation window in the ticket (17:41:34 → 17:43:59, 2m25s) closes 35 seconds *before* the escalation was due, which is why the PID looked frozen.

⚠ **Not directly confirmed, and I am not claiming it is.** The supervisor's stdout for that session was a VS Code terminal and is gone. This is the explanation consistent with every recorded timestamp and with the measured watcher behaviour; it is not a log line. What *is* directly measured is the falsification above.

## So what is the defect

Not the reload. **The three minutes of silence.** Between `SIGTERM -> pid N, draining (max 180s)` and the respawn the supervisor says nothing, so an observer polling PIDs across that window sees an unchanged PID and reasonably concludes the reload never fired. That is also what #2666's own acceptance asks for — *"the daemon exposing its running commit would make the staleness observable rather than invisible, which is the property actually missing"*.

Two changes, both in `app/jobs/dev_reload.py`:

**1. A slow drain reports itself.** `_stop_child` waits in `_DRAIN_PROGRESS_S` (15s) slices instead of one 180s block, logging elapsed-vs-budget at INFO. ⚠ The deadline is computed **once**, before the loop — slicing must not turn one 180s budget into N × 180s, which is what a naive per-slice timeout would do. Pinned by a test.

**2. `running_commit()`** names the commit each child is spawned at, so the supervisor's own output answers "which commit is the running worker on" without inferring it from a PID. Never raises: missing git, a non-repo checkout or a slow disk all degrade to `"unknown"` — a reload must not be blocked by its own log line.

⚠ It scrubs `GIT_*` from the subprocess environment. **A git hook exports `GIT_DIR` into everything it runs**, so an unscrubbed `git rev-parse` resolves against the *hook's* repository rather than `_REPO_ROOT` — the #2658 trap, which surfaced there as tests passing everywhere except under the push gate. Pinned by a test that sets `GIT_DIR=/nonexistent/hook.git` and asserts the answer is still real.

## Scope — what this does NOT do

- **No change to reload semantics.** Same trigger, same `changes_are_stale`, same drain budget, same escalation, same singleton-fence ordering. Only what is *reported* changes.
- **No new endpoint or status table.** The ticket floats "the daemon exposing its running commit"; this puts it in the supervisor's log, which is where the drain evidence already is and needs no schema. A queryable surface is a larger change and would want its own ticket.
- **The workaround in `.claude/CLAUDE.md`** (`touch` after re-detaching) is left alone. It is harmless, and on this evidence it was never necessary — but the honest reason to keep it is that the drain still takes up to three minutes, so a `touch` remains a cheap way to be sure.

## Testing

`tests/jobs/test_dev_reload.py` (previously `changes_are_stale` only) gains four:

- a slow drain emits progress and does **not** escalate when it finishes inside the budget;
- the sliced wait stays bounded and escalates a child that never drains;
- `running_commit()` ignores an inherited `GIT_DIR` / `GIT_WORK_TREE`;
- a non-repo `_REPO_ROOT` degrades to `"unknown"` rather than raising.

⚠ The bounded-budget test asserts a **decidable event** (`proc.killed`) plus a generous ceiling, not a wall-clock ratio — per #2610, a timing ratio is a host measurement, not a property. The fake child sleeps its slice before raising `TimeoutExpired`, as a real `Popen.wait` does; without that the deadline loop spins in microseconds and the budget under test is never consumed (caught by the test failing).

Gates: `ruff check` / `ruff format --check` / `pyright` / `pytest -m "not db"` / `tests/smoke` green, unpiped. Codex checkpoint 2: no findings.

**Definition-of-Done clauses 8-12 do not apply** — no ETL, parser, schema migration or ownership/observations data; this is a dev-only supervisor's logging.

## Security

No new surface. `running_commit()` adds one subprocess call, argv-list (no shell), fixed arguments, no user-controlled input, `cwd` pinned to `_REPO_ROOT`, 5s timeout, output used only in a log line. It **narrows** environment inheritance by scrubbing `GIT_*`. The module remains a pass-through outside a dev-like `app_env`, so none of this runs in production.

Refs #2666. Refs #2144. Refs #2658.
