### PR TITLE
fix(#2670): make both band triggers reachable, not merely in range

### DIFF
--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -24,7 +24,12 @@ from typing import Any
 
 import psycopg
 
-CORE_MANDATE_POLICY_VERSION = "core-mandate-v1"
+# v2 as of #2670, which made both band triggers REACHABLE rather than merely in
+# range.  Bumped even though the table held 0 rows: a version denotes a rule set,
+# not a row population, and `CoreMandate` is publicly constructible, so a v1
+# mandate can exist without ever having been stored and changes validity across
+# that tightening.  Leaving the stamp would make one string mean two arithmetics.
+CORE_MANDATE_POLICY_VERSION = "core-mandate-v2"
 
 # Locked to USD by this module's own schema CHECK (sql/336:26), and deliberately NOT
 # bound to `strategy_base_currency.DEPLOYMENT_CURRENCY` (#2603 item 4): the core mandate
@@ -203,8 +208,23 @@ def validate_core_mandate(
     if core_instrument_id is not None and core_instrument_id <= 0:
         raise CoreMandateError("core_instrument_id must be a positive instrument id")
 
-    if core_target_pct - rebalance_band_pct < 0:
-        raise CoreMandateError("rebalance_band_pct wider than core_target_pct leaves the lower trigger unreachable")
+    # Both band bounds are STRICT (#2670).  `core_pct` is bounded to [0,100] for a
+    # non-negative sleeve and the allocator's triggers are strict, so `lower == 0`
+    # and `upper == 100` are comparators that cannot become true -- a declared
+    # two-sided band that is silently one-sided.  Equality is the dead point on
+    # each side, not a boundary case, which is why `<= 0` and `>= PERCENT_BASIS`
+    # rather than `< 0` and `> PERCENT_BASIS`.
+    if core_target_pct - rebalance_band_pct <= 0:
+        raise CoreMandateError("rebalance_band_pct must be below core_target_pct or the lower trigger is unreachable")
+    if core_target_pct + rebalance_band_pct >= PERCENT_BASIS:
+        raise CoreMandateError(
+            "core_target_pct + rebalance_band_pct must be below 100 or the upper trigger is unreachable"
+        )
+    # Kept separate from the bound above and deliberately NOT strict: at equality
+    # the reserve is exactly satisfied at the worst case the band authorises,
+    # which is a legitimate (pre-cost) mandate.  Not implied by the upper bound
+    # either -- that buys only positive worst-case cash, not cash of at least a
+    # positive reserve.
     if PERCENT_BASIS - (core_target_pct + rebalance_band_pct) < liquidity_reserve_pct:
         raise CoreMandateError("rebalance_band_pct would authorise drifting through liquidity_reserve_pct")
 

--- a/docs/proposals/ta/2026-08-13-core-cash-mandate.md
+++ b/docs/proposals/ta/2026-08-13-core-cash-mandate.md
@@ -139,6 +139,138 @@ arm, and that check sits on the active-entry path which item 3 cannot reuse anyw
 execution is `max(declared, broker minimum at the time)` — the broker half, and what to do
 when it is unavailable or has risen, is item 3's to build.
 
+### Amendment (#2670): both band triggers must be REACHABLE, not merely in range
+
+The two CHECKs above were written to keep both triggers inside `[0, 100]`. That is a
+weaker property than the one the first CHECK's own comment claims, and both comparators
+admit a mandate whose declared two-sided band is silently one-sided.
+
+`core_pct = 100 · core_mv / (core_mv + cash)` with both components non-negative (leverage
+is barred, and a negative core value is not a state this sleeve has), so `core_pct` is
+bounded to `[0, 100]`. The triggers are strict (Q2 of the allocator spec). Therefore:
+
+| trigger | fires when | REACHABLE iff |
+| --- | --- | --- |
+| lower | `core_pct < target - band` | `target - band > 0` |
+| upper | `core_pct > target + band` | `target + band < 100` |
+
+Both shipped comparators are non-strict at exactly the dead point:
+
+- `core_target_pct - rebalance_band_pct >= 0` admits `band == target` ⇒ `lower == 0` ⇒
+  the lower trigger is `core_pct < 0`, unreachable — *including* by "the core going to
+  zero", which the comment names as the surviving case. `core_pct = 0` is not `< 0`.
+- `100 - (core_target_pct + rebalance_band_pct) >= liquidity_reserve_pct` admits
+  `band == 100 - target` when `reserve == 0` ⇒ `upper == 100` ⇒ the upper trigger is
+  `core_pct > 100`, unreachable.
+
+Measured on dev — the only database (`sql/338`'s header records the same), and 0 rows in
+this table, so this is the whole population: `t=20, b=20, r=0` and `t=60, b=40, r=0` both
+INSERT successfully today, and `evaluate_core_rebalance` returns `hold` on each at the
+extreme state (core at 0% and core at 100% respectively) — the trigger does not fire even
+where it is arithmetically most able to. `ADD CONSTRAINT` is therefore a plain add with
+nothing to repair; on any database that did hold a degenerate row the migration would fail
+loudly rather than silently drop it, which is the correct outcome.
+
+**Reachable is not actionable, and this amendment only buys the first.** `min_rebalance_amount`
+(and the broker floor item 3 adds) can still suppress every triggering trade on a small
+enough sleeve; the allocator reports that as `hold` + `below_min_rebalance_amount`. What is
+fixed here is a comparator that cannot become true at all, which no floor is involved in.
+
+**Granularity: `NUMERIC(8,4)` makes each bound need `0.0001` of clearance.** The strict
+inequalities are over a discrete lattice, so the smallest feasible mandate is
+`target = 0.0002, band = 0.0001` and the largest feasible upper edge is `99.9999`. That is a
+real representational exclusion, not a rounding artefact — `t = 99.9999, b = 0.0001, r = 0`
+is storable today and gives `upper = 100.0000` exactly, which is the upper-side worked
+example at the boundary.
+
+**The fix is a third constraint, NOT a strictening of the reserve CHECK.** The reserve
+CHECK must stay `>=`: `t=60, b=30, r=10` satisfies it at equality, is a legitimate mandate
+(the reserve is exactly satisfied at the worst case the band authorises), and its upper
+trigger is reachable at `90 < 100`. Strictening it would reject that. The unreachability at
+`r=0` comes from the *combination*, so the reachability property gets its own named
+constraint and the reserve keeps its own:
+
+```
+strategy_core_mandate_band_within_range     : core_target_pct - rebalance_band_pct > 0
+strategy_core_mandate_band_upper_reachable  : core_target_pct + rebalance_band_pct < 100
+strategy_core_mandate_band_respects_reserve : UNCHANGED (>=)
+```
+
+The reserve CHECK stays necessary and is not made redundant by the new upper bound:
+`upper < 100` buys only *positive* cash at the worst case, not cash of at least a positive
+reserve. The implication runs the other way — `reserve > 0` implies `upper < 100`, so the
+new constraint bites only at `reserve == 0`. Kept explicit rather than collapsed into the
+reserve CHECK: two different properties, two different names in
+`CheckViolation.diag.constraint_name`.
+
+⚠ Under the combined strict invariants several of the shipped per-column CHECKs are now
+*implied* — `core_target_pct >= 0`, `core_target_pct <= 100`, `rebalance_band_pct <= 100`
+and `liquidity_reserve_pct < 100` all follow. They are kept: a per-column violation reports
+which column is out of range, which a composite one cannot, and the redundancy costs a
+comparison. Named here so a later reader does not remove one believing it load-bearing, or
+keep one believing it independent.
+
+**Q1's proof is untouched.** It chains through `band_respects_reserve`, which does not
+change; the two new bounds only tighten the set of mandates it quantifies over.
+
+**What this forbids that was previously storable:** `band == target` under any target
+(lower dead), and `target + band == 100` with `reserve == 0` (upper dead). ⚠ It does NOT
+newly forbid `core_target_pct = 100` — the shipped reserve CHECK already rejects that for
+any `band > 0`, since `100 - (100 + band) < 0 <= reserve`. Measured: rejected on
+`strategy_core_mandate_band_respects_reserve`.
+
+Both forbidden shapes are **one-sided intents**, and the case for refusing them is
+structural rather than a judgement about what an operator may want. `rebalance_band_pct` is
+a single symmetric number applied to both sides; a one-sided mandate is not expressible in
+that column at all. Arriving at one by choosing a value that makes a comparator dead is an
+accident of arithmetic, not a declaration — and nothing downstream can tell it apart from a
+two-sided intent. If a genuinely one-sided band (liquidation-only, accumulation-only) is
+ever wanted, it needs its own declared shape, which is a migration and a new policy version.
+
+⚠ Separately: a zero-slack mandate such as `t=60, b=30, r=10` is legitimate **pre-cost**
+only. At the upper edge it has no room for a fee or slippage, which is the allocator spec's
+Q3 problem, not this one — the amendment establishes the trigger can fire, not that the
+resulting trade fits inside the reserve.
+
+**`CORE_MANDATE_POLICY_VERSION` IS bumped to `core-mandate-v2`.** The "Source rule" section
+above says a change to the invariants is "a migration plus a new version, never a
+redefinition of the old one", and this is squarely that. An earlier draft of this amendment
+argued for an exception on the grounds that the table holds 0 rows, so nothing could be
+reinterpreted. That is wrong twice, and Codex checkpoint 1 caught both:
+
+- **A version denotes a rule set, not a row population.** `core-mandate-v2` denotes the
+  stricter admissible set whether or not any row is written under it. The `sql/342`
+  vocabulary-minting caution does not transfer: that declined a state *nothing could
+  produce*, whereas every future mandate is produced under v2.
+- **Persistence is not the only carrier.** `CoreMandate` is a public frozen dataclass and
+  `validate_core_mandate` is a public function, so a v1 mandate can exist without ever
+  having been stored — in a test, a cached input, a retried command, a directly constructed
+  object. Such an object goes from valid to `core_mandate_invalid` across this change. Under
+  an unchanged stamp that is one version string meaning two different arithmetics, which is
+  exactly the silent reinterpretation the stamp exists to prevent.
+
+So `sql/344` re-issues the `policy_version` CHECK as `= 'core-mandate-v2'`. v1 rows become
+unstorable, which is intended: a v1 row is one written under looser arithmetic, and there
+are none to preserve. The allocator's `core_mandate_policy_unsupported` refusal is what a
+directly-constructed v1 object now meets, and it is checked *before* validity precisely so
+the v1 object is reported as stale-policy rather than blamed as invalid
+(`strategy_core_allocator.py::_mandate_refusal`).
+
+⚠ **That CHECK aborts the migration — and boot — on any database holding a v1 revision,
+even one that satisfies the new band bounds.** Codex checkpoint 2 raised this as a P1. The
+abort is intended, so `sql/344` states the precondition as a `DO` block that raises a named
+error with the row count and the remedy, rather than letting it surface as a
+`CheckViolation` on a bookkeeping stamp. Codex's proposed remedy — permit both versions at
+rest so history stays readable — was **measured and rejected**: `load_core_mandate` reads
+only the latest revision and `_mandate_refusal` refuses any version but the current one, so
+a permitted v1 row is storable and refused by the table's only consumer. `sql/311`'s
+legacy-readability carve-out does not transfer either; `sql/336`'s header records that this
+table constrains from row one *because* it has no legacy rows, which is still true.
+
+`sql/336` itself is NOT edited: `app/db/migrations.py:160-172` fails the whole run on a
+content-hash drift for an applied file. The corrected reasoning lives in `sql/344`'s header
+and its re-issued `COMMENT ON`.
+
 ## Denominator: what the percentages are shares of
 
 All three percentages are shares of **one core-sleeve denominator**, and every CHECK above

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -4405,3 +4405,62 @@ with `verify_2598_preflight_quote_crosscheck.py --replay <fixture>`:
 - Enforced in: `app/services/strategy_core_allocator.py::_state_refusal` (per-component check
   documented as overflow-safety, not as a shortcut); `tests/test_2603_core_allocator.py`
   parametrises `9e999999 + 9e999999` and a pair that clears the component bound but sums past it.
+
+### An IN-RANGE bound is not a REACHABLE bound — a non-strict CHECK can leave a strict downstream comparator dead
+
+- First seen in: #2670 (`sql/336_strategy_core_mandate.sql`), found at #2603 item 3's Codex
+  checkpoint 1 while reviewing the allocator that consumes the constraint.
+- Symptom: two schema CHECKs written to keep a rebalance band's triggers "inside `[0,100]`"
+  each admitted the value at which one trigger can never fire. `core_target_pct -
+  rebalance_band_pct >= 0` permits `lower == 0`, and the allocator's trigger is
+  `core_pct < lower` — unreachable for a non-negative sleeve, *including* by the core going to
+  zero, which the CHECK's own comment named as the surviving case (`0` is not `< 0`). The
+  comment described a guarantee the comparator did not provide, and nothing failed: the
+  allocator computed correctly on such a mandate, one side simply never triggered.
+- The general shape: **a write-time bound and a read-time comparator are two different
+  inequalities, and the boundary value is where they disagree.** A constraint keeping a
+  derived quantity in a *closed* range is compatible with a consumer testing it with a
+  *strict* comparator, which makes the range's endpoint a value the consumer can never act on.
+  Nothing downstream can tell such a row apart from a genuinely one-sided intent, so it is a
+  write-time authority defect rather than a computation bug — which is exactly why no test
+  caught it.
+- Prevention: when adding a CHECK on a quantity some other module compares against, write down
+  the consumer's comparator and solve for reachability, not for range. Concretely: for a strict
+  `x < L` the bound is `L > min(x)`, not `L >= min(x)`. Then state in the migration what the
+  constraint forbids that was previously storable — an empty answer means the CHECK is
+  redundant, and a surprising one means it is not the constraint you thought.
+- Enforced in: `sql/344_core_mandate_trigger_reachability.sql` (both bounds strict, header
+  derives reachability from the consumer's comparators);
+  `app/services/strategy_core_mandate.py::validate_core_mandate`;
+  `tests/test_2603_core_mandate.py::test_a_band_whose_trigger_can_never_fire_is_refused` plus
+  `::test_the_narrowest_mandates_with_both_triggers_live_are_accepted`, which pins the
+  tightening at exactly one `NUMERIC(8,4)` quantum so a later over-correction fails.
+
+### "0 stored rows" does not excuse a version bump — a version denotes a RULE SET, not a row population
+
+- First seen in: #2670, at Codex checkpoint 1, against a spec amendment that had argued the
+  opposite at length.
+- Symptom: tightening `strategy_core_mandate_events`' invariants over an empty table, I argued
+  `CORE_MANDATE_POLICY_VERSION` need not move because no row was written under the old
+  arithmetic, so nothing could be silently reinterpreted — and cited `sql/342`'s refusal to
+  mint a vocabulary member nothing could produce as support. Both halves are wrong. `sql/342`
+  declined a state nothing could *produce*; here every future mandate is produced under the new
+  rules, so `v2` denotes a live rule set, not an empty one. And persistence is not the only
+  carrier: `CoreMandate` is a public frozen dataclass and `validate_core_mandate` a public
+  function, so a `v1` mandate can exist in a test, a cached input or a retried command without
+  ever having been stored — and goes from valid to `core_mandate_invalid` across the change.
+  One version string, two arithmetics, which is the exact silent reinterpretation the stamp
+  exists to prevent.
+- The general shape: **the question a version stamp answers is "under which rules was this
+  object judged", and objects outnumber rows.** Reaching for the row count is reaching for the
+  easiest measurement rather than the governing one, and it reads as evidence because it *is* a
+  real number — it just answers a different question.
+- Prevention: when a change alters what a validator accepts, bump the version regardless of row
+  count, and justify any exception by naming every carrier of the old rules (stored rows,
+  constructible objects, fixtures, cached requests) rather than by counting one of them. If the
+  governing spec states the rule unconditionally, follow it — proposing a carve-out at the
+  moment it first costs something is the weakest possible time to weaken a rule.
+- Enforced in: `app/services/strategy_core_mandate.py` (`core-mandate-v2`, with the reasoning on
+  the constant); `sql/344_core_mandate_trigger_reachability.sql` (re-issued `policy_version`
+  CHECK + `COMMENT ON`); `tests/test_2603_core_mandate.py::test_the_policy_version_records_which_arithmetic_wrote_the_row`;
+  `tests/test_2603_core_mandate_db.py` parametrises a `v1` row as a rejected raw INSERT.

--- a/sql/344_core_mandate_trigger_reachability.sql
+++ b/sql/344_core_mandate_trigger_reachability.sql
@@ -1,0 +1,137 @@
+-- 344_core_mandate_trigger_reachability.sql
+--
+-- #2670.  sql/336's two band CHECKs each admit a mandate on which one of the
+-- band's two triggers can NEVER fire -- the exact state the first CHECK's own
+-- comment says it exists to prevent.  Both comparators are non-strict at
+-- precisely the dead point.
+--
+-- `core_pct = 100 * core_mv / (core_mv + cash)` with both components
+-- non-negative (leverage is barred; a negative core value is not a state this
+-- two-holding sleeve has), so core_pct is bounded to [0,100].  The allocator's
+-- triggers are strict (allocator spec Q2).  Therefore:
+--
+--   lower trigger  core_pct < target - band   reachable IFF  target - band > 0
+--   upper trigger  core_pct > target + band   reachable IFF  target + band < 100
+--
+-- sql/336 shipped `>= 0` and (via the reserve CHECK at reserve = 0) `<= 100`.
+-- Measured on dev, the only database: `t=20,b=20,r=0` and `t=60,b=40,r=0` both
+-- INSERT today, and `evaluate_core_rebalance` returns `hold` on each at the
+-- extreme state (core at 0% and at 100%) -- the trigger does not fire even
+-- where it is arithmetically most able to.
+--
+-- `select count(*) from strategy_core_mandate_events` -> 0 rows, so both
+-- constraints validate with nothing to repair.  Plain ADD, not NOT VALID:
+-- there is no row for a deferred validation to spare.  On a database that DID
+-- hold a degenerate row this would fail loudly, which is the correct outcome.
+--
+-- ⚠ `strategy_core_mandate_band_respects_reserve` is deliberately UNCHANGED and
+-- stays non-strict.  `t=60,b=30,r=10` satisfies it at equality, is a legitimate
+-- (pre-cost) mandate, and its upper trigger is reachable at 90 < 100.
+-- Strictening it would reject that.  The unreachability at reserve = 0 comes
+-- from the COMBINATION, so reachability gets its own named constraint and the
+-- reserve keeps its own -- two properties, two names in
+-- psycopg.errors.CheckViolation.diag.constraint_name.  Nor is the reserve CHECK
+-- made redundant: `upper < 100` buys only POSITIVE worst-case cash, not cash of
+-- at least a positive reserve.  The implication runs the other way (reserve > 0
+-- implies upper < 100), so the new constraint bites only at reserve = 0.
+--
+-- ⚠ sql/336 is NOT edited: app/db/migrations.py:160-172 fails the entire run on
+-- a content-hash drift for an already-applied file.  Its `--` comment therefore
+-- still describes a guarantee it did not provide; this header and the re-issued
+-- COMMENT ON below are the correction.
+--
+-- NUMERIC(8,4) makes the strict inequalities discrete: each bound needs 0.0001
+-- of clearance, so the smallest feasible mandate is target 0.0002 / band 0.0001
+-- and the largest feasible upper edge is 99.9999.  A representational
+-- exclusion, stated rather than discovered.
+--
+-- Does NOT newly forbid `core_target_pct = 100`: the shipped reserve CHECK
+-- already rejects it for any band > 0, since 100 - (100 + band) < 0 <= reserve.
+--
+-- Q1 of the allocator spec ("a reserve breach strictly implies an upper-band
+-- breach") chains through the reserve CHECK, which does not change; the two new
+-- bounds only tighten the set of mandates it quantifies over.
+--
+-- Spec: docs/proposals/ta/2026-08-13-core-cash-mandate.md, "Amendment (#2670)".
+
+ALTER TABLE strategy_core_mandate_events
+    DROP CONSTRAINT strategy_core_mandate_band_within_range;
+
+ALTER TABLE strategy_core_mandate_events
+    ADD CONSTRAINT strategy_core_mandate_band_within_range
+    CHECK (core_target_pct - rebalance_band_pct > 0);
+
+ALTER TABLE strategy_core_mandate_events
+    ADD CONSTRAINT strategy_core_mandate_band_upper_reachable
+    CHECK (core_target_pct + rebalance_band_pct < 100);
+
+-- The policy version bump.  Changing the invariants is "a migration plus a new
+-- version, never a redefinition of the old one" (item 1's spec, Source rule),
+-- and this is squarely that.  0 stored rows does NOT excuse it: a version
+-- denotes a RULE SET, not a row population, and `CoreMandate` is a public frozen
+-- dataclass, so a v1 mandate can exist without ever having been stored (a test,
+-- a cached input, a retried command) and goes from valid to invalid across this
+-- change.  Leaving the stamp alone would make one version string mean two
+-- different arithmetics -- the silent reinterpretation the stamp exists to
+-- prevent.  v1 rows become unstorable, which is intended: a v1 row is one
+-- written under looser arithmetic and there are none to preserve.
+--
+-- ⚠ This ABORTS the migration -- and therefore boot -- on any database that DID
+-- configure a mandate under v1, EVEN IF that mandate satisfies the new band
+-- bounds.  That is deliberate and the abort is the point, so the precondition is
+-- stated as a named failure rather than left to surface as an opaque
+-- CheckViolation on a constraint whose subject is a bookkeeping stamp.  Raised
+-- at Codex checkpoint 2 (#2670).
+--
+-- The remedy Codex proposed -- permit both versions at rest so history stays
+-- readable -- was measured and rejected.  `load_core_mandate` reads only the
+-- LATEST revision, and `strategy_core_allocator._mandate_refusal` returns
+-- `core_mandate_policy_unsupported` for any version but the current one.  So a
+-- permitted v1 row is a state that is storable and that the table's ONLY
+-- consumer refuses: a dead state, which is the class this milestone keeps
+-- finding.  sql/311's legacy-readability carve-out does not transfer either --
+-- sql/336's own header records that this table constrains from row one BECAUSE
+-- it has no legacy rows, which is still true.
+DO $$
+DECLARE
+    superseded bigint;
+BEGIN
+    SELECT count(*) INTO superseded
+    FROM strategy_core_mandate_events
+    WHERE policy_version <> 'core-mandate-v2';
+    IF superseded > 0 THEN
+        RAISE EXCEPTION
+            'sql/344: % core mandate revision(s) carry a superseded policy_version', superseded
+            USING HINT =
+                'Each was written under looser band arithmetic (#2670). Decide per row whether '
+                'it still expresses the operator intent under the new bounds, then either '
+                'append a fresh revision under core-mandate-v2 and delete the superseded rows, '
+                'or re-stamp them deliberately. Do NOT widen this CHECK to admit v1: the '
+                'allocator refuses any version but the current one, so such a row is storable '
+                'and unusable.';
+    END IF;
+END $$;
+
+ALTER TABLE strategy_core_mandate_events
+    DROP CONSTRAINT strategy_core_mandate_events_policy_version_check;
+
+ALTER TABLE strategy_core_mandate_events
+    ADD CONSTRAINT strategy_core_mandate_events_policy_version_check
+    CHECK (policy_version = 'core-mandate-v2');
+
+COMMENT ON COLUMN strategy_core_mandate_events.rebalance_band_pct IS
+    'Allowed drift in PERCENTAGE POINTS of core weight, absolute (not relative to target). '
+    'Bounded so BOTH triggers are REACHABLE, not merely in range (#2670): band < target and '
+    'band < 100 - target, strictly. A band equal to either leaves that side''s comparator '
+    'unable to become true for a non-negative sleeve, which makes a declared two-sided band '
+    'silently one-sided -- and a one-sided intent is not expressible in a single symmetric '
+    'column, so it must not be reachable by accident. Strictly positive: a zero band '
+    'authorises a rebalance on any drift, and turnover is the first-order cost filter.';
+
+COMMENT ON COLUMN strategy_core_mandate_events.policy_version IS
+    'Stamps which arithmetic the row was written under so a later policy is detectable per '
+    'row. core-mandate-v2 as of #2670, which made both band triggers reachable; v1 rows are '
+    'no longer storable and none existed. A version string does not freeze a CHECK: changing '
+    'the invariants is a migration plus a new version, never a redefinition of this one -- '
+    'and 0 stored rows does not excuse the bump, because CoreMandate is publicly '
+    'constructible and a never-stored v1 object changes validity across such a change.';

--- a/tests/test_2603_core_allocator.py
+++ b/tests/test_2603_core_allocator.py
@@ -123,8 +123,14 @@ def test_reserve_breach_always_implies_a_band_breach() -> None:
     for target in range(0, 101, 5):
         for band in range(1, 101, 3):
             for reserve in range(0, 100, 7):
-                # sql/336's two CHECKs.
-                if target - band < 0:
+                # The schema's three band CHECKs, as of sql/344.  Kept in step
+                # with the migration deliberately: filtering by the allocator's
+                # own refusal instead would let the enumerated space silently
+                # follow the code under test, and a tightening would then narrow
+                # coverage rather than fail.
+                if target - band <= 0:
+                    continue
+                if target + band >= 100:
                     continue
                 if 100 - (target + band) < reserve:
                     continue
@@ -132,8 +138,10 @@ def test_reserve_breach_always_implies_a_band_breach() -> None:
                 for core_pct in range(0, 101):
                     state = sleeve(str(core_pct * 10), str((100 - core_pct) * 10))
                     decision = evaluate_core_rebalance(spec, state)
-                    if decision.action == "refused":
-                        continue
+                    assert decision.action != "refused", (
+                        f"a schema-valid mandate was refused ({decision.reason_code}): "
+                        f"target={target} band={band} reserve={reserve} core_pct={core_pct}"
+                    )
                     checked += 1
                     assert decision.reserve_breached is not None
                     if decision.reserve_breached:
@@ -274,7 +282,10 @@ def test_absent_mandate_is_a_state_not_a_default() -> None:
 @pytest.mark.parametrize(
     ("spec", "expected"),
     [
-        (mandate(policy_version="core-mandate-v2"), "core_mandate_policy_unsupported"),
+        # v3 is a LATER policy; v1 is the one #2670 superseded. Both unsupported,
+        # for opposite reasons, and the refusal must not distinguish them.
+        (mandate(policy_version="core-mandate-v3"), "core_mandate_policy_unsupported"),
+        (mandate(policy_version="core-mandate-v1"), "core_mandate_policy_unsupported"),
         (mandate(enabled=False, core_instrument_id=None), "core_mandate_disabled"),
         (mandate(target="90", band="9", reserve="20"), "core_mandate_invalid"),
     ],
@@ -287,7 +298,7 @@ def test_mandate_refusals(spec: CoreMandate, expected: str) -> None:
 
 def test_policy_version_is_checked_before_validity() -> None:
     """A row written under a later policy must not be blamed for our staleness."""
-    stale = mandate(policy_version="core-mandate-v2", target="90", band="9", reserve="20")
+    stale = mandate(policy_version="core-mandate-v3", target="90", band="9", reserve="20")
     assert evaluate_core_rebalance(stale, sleeve("600", "400")).reason_code == "core_mandate_policy_unsupported"
 
 
@@ -361,17 +372,46 @@ def test_a_refusal_nulls_the_arithmetic_it_could_not_compute() -> None:
     assert (decision.effective_floor, decision.floor_source) == (None, None)
 
 
-# --- the degenerate mandates sql/336 permits (#2670) ---------------------------
+# --- the degenerate mandates, now refused at the source (#2670) ----------------
+#
+# These two shapes were storable under sql/336 and reached the allocator, which
+# computed correctly on them while one trigger could never fire.  sql/344 makes
+# both unstorable and `validate_core_mandate` rejects them, so the allocator now
+# meets them only as directly-constructed objects — and refuses.  The tests are
+# kept (rather than deleted with the defect) because the dataclass is public: the
+# refusal is the only thing standing between a degenerate mandate and a verdict
+# computed on a band that is silently one-sided.
 
 
-def test_a_band_equal_to_the_target_never_fires_the_lower_trigger() -> None:
-    """#2670: sql/336 permits `band == target`, giving `lower == 0`, which
-    `core_pct < 0` can never reach.  Documented here so the behaviour is expected
-    rather than surprising — the arithmetic is right, the mandate is weaker than
-    it declares."""
-    spec = mandate(target="20", band="20", reserve="0", floor="0.000001")
-    assert spec.core_target_pct - spec.rebalance_band_pct == 0
-    # An empty core is the most extreme underweight there is, and it still holds.
+@pytest.mark.parametrize(
+    ("spec", "dead_side"),
+    [
+        # band == target -> lower == 0, and `core_pct < 0` is unreachable.
+        (mandate(target="20", band="20", reserve="0", floor="0.000001"), "lower"),
+        # target + band == 100 at reserve 0 -> upper == 100, `core_pct > 100`
+        # unreachable.  Storable under sql/336; rejected by sql/344.
+        (mandate(target="60", band="40", reserve="0", floor="0.000001"), "upper"),
+    ],
+)
+def test_a_mandate_with_a_dead_trigger_is_refused_not_computed(spec: CoreMandate, dead_side: str) -> None:
+    """#2670. The extreme state on the dead side is the probe: an empty core is
+    the most extreme underweight there is, and a fully-invested one the most
+    extreme overweight, so if the trigger were merely *narrow* rather than dead
+    this would fire."""
+    extreme = sleeve("0", "1000") if dead_side == "lower" else sleeve("1000", "0")
+    decision = evaluate_core_rebalance(spec, extreme)
+    assert decision.action == "refused"
+    assert decision.reason_code == "core_mandate_invalid"
+
+
+def test_the_dead_trigger_refusal_is_what_changed_and_not_the_arithmetic() -> None:
+    """Guards the claim in sql/344's header that the allocator was never wrong.
+
+    The same band width one quantum inside the dead point is storable, reaches
+    the arithmetic, and fires — so the refusal above is about reachability and
+    not about narrow bands.
+    """
+    spec = mandate(target="20", band="19.9999", reserve="0", floor="0.000001")
     decision = evaluate_core_rebalance(spec, sleeve("0", "1000"))
-    assert decision.lower_pct == Decimal("0")
-    assert decision.action == "hold"
+    assert decision.lower_pct == Decimal("0.0001")
+    assert decision.action == "buy_core"

--- a/tests/test_2603_core_mandate.py
+++ b/tests/test_2603_core_mandate.py
@@ -11,6 +11,7 @@ import pytest
 
 from app.services.strategy_core_mandate import (
     CORE_MANDATE_BASE_CURRENCY,
+    CORE_MANDATE_POLICY_VERSION,
     CoreMandate,
     CoreMandateError,
     validate_core_mandate,
@@ -50,10 +51,21 @@ def test_cash_is_the_complement_and_never_a_second_stored_value() -> None:
         liquidity_reserve_pct=Decimal("20"),
         rebalance_band_pct=Decimal("5"),
         min_rebalance_amount=Decimal("25"),
-        policy_version="core-mandate-v1",
+        policy_version=CORE_MANDATE_POLICY_VERSION,
     )
     assert mandate.cash_target_pct == Decimal("40")
     assert mandate.core_target_pct + mandate.cash_target_pct == Decimal("100")
+
+
+def test_the_policy_version_records_which_arithmetic_wrote_the_row() -> None:
+    """#2670 bumped this, and the bump is the point rather than an incident.
+
+    A version denotes a RULE SET, not a row population, so 0 stored rows did not
+    excuse leaving it: ``CoreMandate`` is publicly constructible, so a v1 mandate
+    can exist without ever having been stored and changes validity across the
+    tightening. Pinned so a later invariant change cannot land without one.
+    """
+    assert CORE_MANDATE_POLICY_VERSION == "core-mandate-v2"
 
 
 def test_a_band_that_drifts_through_the_reserve_is_refused() -> None:
@@ -83,7 +95,7 @@ def test_a_band_wider_than_the_target_is_refused() -> None:
     core 4 with a 5pp band puts the lower trigger below zero, unreachable short
     of the core going to nothing. Reserve is 0 here so only the range rule fires.
     """
-    with pytest.raises(CoreMandateError, match="lower trigger unreachable"):
+    with pytest.raises(CoreMandateError, match="lower trigger is unreachable"):
         validate_core_mandate(
             **{
                 **_VALID,
@@ -92,6 +104,86 @@ def test_a_band_wider_than_the_target_is_refused() -> None:
                 "liquidity_reserve_pct": Decimal("0"),
             }
         )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        # band == target -> lower == 0, and `core_pct < 0` is unreachable for a
+        # non-negative sleeve, INCLUDING by the core going to zero: 0 is not < 0.
+        (
+            {
+                "core_target_pct": Decimal("20"),
+                "rebalance_band_pct": Decimal("20"),
+                "liquidity_reserve_pct": Decimal("0"),
+            },
+            "lower trigger is unreachable",
+        ),
+        # target + band == 100 at reserve 0 -> upper == 100, and `core_pct > 100`
+        # is unreachable for a sleeve whose cash cannot go negative.
+        (
+            {
+                "core_target_pct": Decimal("60"),
+                "rebalance_band_pct": Decimal("40"),
+                "liquidity_reserve_pct": Decimal("0"),
+            },
+            "upper trigger is unreachable",
+        ),
+        # The granularity boundary on the upper side: NUMERIC(8,4) means
+        # 99.9999 + 0.0001 lands exactly on the dead point. Storable under
+        # sql/336, refused by sql/344.
+        (
+            {
+                "core_target_pct": Decimal("99.9999"),
+                "rebalance_band_pct": Decimal("0.0001"),
+                "liquidity_reserve_pct": Decimal("0"),
+            },
+            "upper trigger is unreachable",
+        ),
+    ],
+)
+def test_a_band_whose_trigger_can_never_fire_is_refused(overrides: dict[str, Decimal], message: str) -> None:
+    """#2670. Equality is the DEAD POINT on each side, not a boundary case.
+
+    ``core_pct = 100 * core_mv / (core_mv + cash)`` is bounded to [0,100] for a
+    non-negative sleeve and both allocator triggers are strict, so ``lower == 0``
+    and ``upper == 100`` are comparators that cannot become true. A mandate
+    holding one is weaker than the two-sided band it declares, and nothing
+    downstream can tell it apart from a genuinely one-sided intent.
+    """
+    with pytest.raises(CoreMandateError, match=message):
+        validate_core_mandate(**{**_VALID, **overrides})
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        # One quantum inside each dead point, which is what makes the tests above
+        # about REACHABILITY rather than about narrow bands.
+        {
+            "core_target_pct": Decimal("20"),
+            "rebalance_band_pct": Decimal("19.9999"),
+            "liquidity_reserve_pct": Decimal("0"),
+        },
+        {
+            "core_target_pct": Decimal("60"),
+            "rebalance_band_pct": Decimal("39.9999"),
+            "liquidity_reserve_pct": Decimal("0"),
+        },
+        # The smallest mandate NUMERIC(8,4) can express at all: both bounds need
+        # 0.0001 of clearance, so this is target 0.0002 / band 0.0001.
+        {
+            "core_target_pct": Decimal("0.0002"),
+            "rebalance_band_pct": Decimal("0.0001"),
+            "liquidity_reserve_pct": Decimal("0"),
+        },
+    ],
+)
+def test_the_narrowest_mandates_with_both_triggers_live_are_accepted(overrides: dict[str, Decimal]) -> None:
+    """#2670 tightened a bound; it must not have moved it further than one quantum."""
+    values = validate_core_mandate(**{**_VALID, **overrides})
+    assert values.core_target_pct - values.rebalance_band_pct > 0
+    assert values.core_target_pct + values.rebalance_band_pct < Decimal("100")
 
 
 def test_a_zero_band_is_refused() -> None:

--- a/tests/test_2603_core_mandate_db.py
+++ b/tests/test_2603_core_mandate_db.py
@@ -11,13 +11,16 @@ source db-marks the WHOLE module at collection, so mixing these with pure tests
 would drag the fast tier onto Postgres.
 """
 
+import re
 from decimal import Decimal
-from typing import Any
+from pathlib import Path
+from typing import Any, LiteralString, cast
 
 import psycopg
 import pytest
 
 from app.services.strategy_core_mandate import (
+    CORE_MANDATE_POLICY_VERSION,
     CoreMandateError,
     configure_core_mandate,
     load_core_mandate,
@@ -31,7 +34,7 @@ INSERT INTO strategy_core_mandate_events (
 ) VALUES (
     1,%(enabled)s,%(base_currency)s,%(core_instrument_id)s,%(core_target_pct)s,
     %(liquidity_reserve_pct)s,%(rebalance_band_pct)s,%(min_rebalance_amount)s,
-    'core-mandate-v1','test','test'
+    %(policy_version)s,'test','test'
 )
 """
 
@@ -43,7 +46,29 @@ _VALID_ROW: dict[str, Any] = {
     "liquidity_reserve_pct": Decimal("20"),
     "rebalance_band_pct": Decimal("5"),
     "min_rebalance_amount": Decimal("25"),
+    # Parameterised rather than inlined so the #2670 bump is exercised as a
+    # CHECK and not merely assumed: a literal here would make a stale version
+    # untestable at the only layer that can still be handed one.
+    "policy_version": CORE_MANDATE_POLICY_VERSION,
 }
+
+
+def _migration_precondition_block() -> LiteralString:
+    """sql/344's superseded-version guard, read from the SHIPPED file.
+
+    Read rather than re-typed on purpose: a test that restates the SQL it is
+    checking passes when the migration and the copy drift apart, which is the
+    tautology the prevention log already names for constants.
+
+    The ``cast`` is the one thing a file read costs: psycopg's ``execute`` takes
+    a ``LiteralString`` so caller-controlled SQL cannot reach it. Sound here and
+    nowhere near a request path — the source is a repo-controlled migration this
+    process already executes verbatim at boot, and nothing interpolates into it.
+    """
+    sql = Path("sql/344_core_mandate_trigger_reachability.sql").read_text(encoding="utf-8")
+    match = re.search(r"^DO \$\$.*?^END \$\$;$", sql, re.S | re.M)
+    assert match is not None, "sql/344 no longer contains a DO-block precondition"
+    return cast("LiteralString", match.group(0))
 
 
 def _seed_instrument(conn: psycopg.Connection[Any]) -> int:
@@ -66,6 +91,45 @@ def test_the_reference_row_inserts(ebull_test_conn: psycopg.Connection[Any]) -> 
 
 
 @pytest.mark.parametrize(
+    "overrides",
+    [
+        # #2670 tightened two bounds; these pin that it did not tighten a third.
+        # Worst-case cash exactly equal to a POSITIVE reserve stays storable —
+        # band_respects_reserve is deliberately still `>=`, and the upper trigger
+        # is live at 90 < 100.
+        {
+            "core_target_pct": Decimal("60"),
+            "rebalance_band_pct": Decimal("30"),
+            "liquidity_reserve_pct": Decimal("10"),
+        },
+        # One NUMERIC(8,4) quantum inside each dead point.
+        {
+            "core_target_pct": Decimal("20"),
+            "rebalance_band_pct": Decimal("19.9999"),
+            "liquidity_reserve_pct": Decimal("0"),
+        },
+        {
+            "core_target_pct": Decimal("60"),
+            "rebalance_band_pct": Decimal("39.9999"),
+            "liquidity_reserve_pct": Decimal("0"),
+        },
+    ],
+)
+def test_mandates_one_quantum_inside_the_dead_points_still_insert(
+    ebull_test_conn: psycopg.Connection[Any], overrides: dict[str, Any]
+) -> None:
+    """A tightening is only correct if it stops exactly where it says it does.
+
+    Raw SQL on purpose, per this module's contract: these bound the MIGRATION,
+    so a later one that over-corrected to `>=` on the reserve — or moved either
+    strict bound by more than a quantum — fails here rather than silently
+    shrinking what an operator can declare.
+    """
+    ebull_test_conn.execute(_INSERT, {**_VALID_ROW, **overrides})
+    assert load_core_mandate(ebull_test_conn) is not None
+
+
+@pytest.mark.parametrize(
     "overrides,constraint",
     [
         # core 60 + band 25 leaves 15 cash against a 20 reserve.
@@ -82,6 +146,42 @@ def test_the_reference_row_inserts(ebull_test_conn: psycopg.Connection[Any]) -> 
             },
             "strategy_core_mandate_band_within_range",
         ),
+        # #2670, lower dead point: band == target gives lower == 0, and
+        # `core_pct < 0` is unreachable. sql/336 stored this; sql/344 refuses it.
+        (
+            {
+                "core_target_pct": Decimal("20"),
+                "rebalance_band_pct": Decimal("20"),
+                "liquidity_reserve_pct": Decimal("0"),
+            },
+            "strategy_core_mandate_band_within_range",
+        ),
+        # #2670, upper dead point: target + band == 100 at reserve 0 gives
+        # upper == 100, and `core_pct > 100` is unreachable. Note it clears
+        # band_respects_reserve at equality, which is why it needs its own name.
+        (
+            {
+                "core_target_pct": Decimal("60"),
+                "rebalance_band_pct": Decimal("40"),
+                "liquidity_reserve_pct": Decimal("0"),
+            },
+            "strategy_core_mandate_band_upper_reachable",
+        ),
+        # The same dead point at NUMERIC(8,4) granularity.
+        (
+            {
+                "core_target_pct": Decimal("99.9999"),
+                "rebalance_band_pct": Decimal("0.0001"),
+                "liquidity_reserve_pct": Decimal("0"),
+            },
+            "strategy_core_mandate_band_upper_reachable",
+        ),
+        # #2670's version bump, enforced at rest: a row written under the looser
+        # v1 arithmetic is no longer storable.
+        (
+            {"policy_version": "core-mandate-v1"},
+            "strategy_core_mandate_events_policy_version_check",
+        ),
         # Enabled with no instrument to hold.
         ({"enabled": True}, "strategy_core_mandate_enabled_has_instrument"),
     ],
@@ -92,6 +192,43 @@ def test_the_named_checks_reject_raw_inserts(
     with pytest.raises(psycopg.errors.CheckViolation) as caught:
         ebull_test_conn.execute(_INSERT, {**_VALID_ROW, **overrides})
     assert caught.value.diag.constraint_name == constraint
+    ebull_test_conn.rollback()
+
+
+def test_the_migration_precondition_is_a_no_op_on_a_clean_database(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The control: without it, the test below could pass on a broken block."""
+    ebull_test_conn.execute(_migration_precondition_block())
+
+
+def test_the_migration_precondition_names_superseded_rows_rather_than_aborting_opaquely(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """#2670, raised at Codex checkpoint 2.
+
+    sql/344's `policy_version = 'core-mandate-v2'` CHECK aborts the migration —
+    and boot — on any database holding a v1 revision, even one satisfying the new
+    band bounds. That abort is intended, so the guard exists to make it a named,
+    actionable failure instead of a `CheckViolation` on a bookkeeping stamp.
+
+    Exercised by dropping the CHECK inside this transaction, which is the only
+    way to create the state the guard is for now that the CHECK forbids it. DDL
+    is transactional in Postgres, so the rollback restores it.
+    """
+    ebull_test_conn.execute(
+        "ALTER TABLE strategy_core_mandate_events DROP CONSTRAINT strategy_core_mandate_events_policy_version_check"
+    )
+    ebull_test_conn.execute(_INSERT, {**_VALID_ROW, "policy_version": "core-mandate-v1"})
+
+    with pytest.raises(psycopg.errors.RaiseException) as caught:
+        ebull_test_conn.execute(_migration_precondition_block())
+
+    assert "superseded policy_version" in str(caught.value)
+    # The count, so the operator learns the size of the problem from the message.
+    assert "1 core mandate revision(s)" in str(caught.value)
+    # And the remedy, including the one Codex proposed and the reason it is wrong.
+    assert "storable and unusable" in (caught.value.diag.message_hint or "")
     ebull_test_conn.rollback()
 
 


### PR DESCRIPTION
## What

`sql/336`'s two band CHECKs each admitted a mandate on which one of the band's two triggers can **never fire** — the exact state the first CHECK's own comment says it exists to prevent. Both comparators are non-strict at precisely the dead point.

`core_pct = 100 · core_mv / (core_mv + cash)` is bounded to `[0,100]` for a non-negative sleeve (leverage is barred; a negative core value is not a state this sleeve has), and the allocator's triggers are strict (allocator spec Q2). So:

| trigger | fires when | reachable iff | sql/336 admitted |
| --- | --- | --- | --- |
| lower | `core_pct < target - band` | `target - band > 0` | `>= 0`, so `lower == 0` |
| upper | `core_pct > target + band` | `target + band < 100` | `upper == 100` at `reserve == 0` |

## Premise verification (dev — the only database, 0 rows in the table, so this is the whole population)

| mandate | before | after |
| --- | --- | --- |
| `t=20, b=20, r=0` (lower dead) | **STORABLE**; allocator returns `hold` with core at **0%** | rejected, `strategy_core_mandate_band_within_range` |
| `t=60, b=40, r=0` (upper dead) | **STORABLE**; allocator returns `hold` with core at **100%** | rejected, `strategy_core_mandate_band_upper_reachable` |
| `t=99.9999, b=0.0001, r=0` (upper dead at NUMERIC(8,4) granularity) | STORABLE | rejected, `..._band_upper_reachable` |
| `t=60, b=30, r=10` (reserve satisfied at equality) | STORABLE | **still storable** |
| `t=20, b=19.9999, r=0` / `t=60, b=39.9999, r=0` (one quantum inside each dead point) | STORABLE | **still storable** |
| `t=0.0002, b=0.0001, r=0` (smallest expressible) | STORABLE | **still storable** |
| `policy_version = 'core-mandate-v1'` | STORABLE | rejected, `..._policy_version_check` |

The allocator was never wrong — it computed correctly on a degenerate mandate, one side simply never triggered. This is a **write-time authority defect**: the mandate was storable while being a weaker object than it declares, and nothing downstream could tell it apart from a genuinely one-sided intent.

## What changed

- **`sql/344`** — both band bounds strict, in two separately-named constraints so a lower-side and an upper-side violation stay distinguishable in `CheckViolation.diag.constraint_name`.
- **`strategy_core_mandate_band_respects_reserve` is deliberately UNCHANGED** and stays `>=`. `t=60, b=30, r=10` satisfies it at equality, is a legitimate (pre-cost) mandate, and its upper trigger is live at `90 < 100`; strictening it would reject that. It is also not redundant: `upper < 100` buys only *positive* worst-case cash, not cash of at least a *positive* reserve. The implication runs the other way, so the new constraint bites only at `reserve == 0`.
- **`validate_core_mandate`** mirrors both, so an operator gets a named `CoreMandateError` rather than a raw constraint violation.
- **`CORE_MANDATE_POLICY_VERSION` → `core-mandate-v2`**, and the CHECK with it.
- **`sql/336` is NOT edited** — `app/db/migrations.py:160-172` fails the whole run on a content-hash drift for an applied file. Its `--` comment therefore still describes a guarantee it did not provide; `sql/344`'s header and the re-issued `COMMENT ON` are the correction.

### Why the version bump, at 0 rows

An earlier draft argued for an exception on the grounds that nothing could be reinterpreted. Wrong twice:

- **A version denotes a rule set, not a row population.** `core-mandate-v2` denotes the stricter admissible set whether or not any row is written under it. `sql/342`'s vocabulary-minting caution does not transfer — that declined a state *nothing could produce*.
- **Persistence is not the only carrier.** `CoreMandate` is a public frozen dataclass and `validate_core_mandate` a public function, so a v1 mandate can exist in a test, a cached input or a retried command without ever having been stored — and goes from valid to `core_mandate_invalid` across this change. One version string, two arithmetics.

## What this forbids that was previously storable

`band == target` under any target, and `target + band == 100` at `reserve == 0`. ⚠ It does **not** newly forbid `core_target_pct = 100` — the shipped reserve CHECK already rejected that for any `band > 0`. Both forbidden shapes are one-sided intents, and the case for refusing them is structural: `rebalance_band_pct` is a single symmetric number, so a one-sided mandate is not expressible in that column at all. Arriving at one by choosing a value that makes a comparator dead is an accident of arithmetic, not a declaration. A genuinely one-sided band would need its own declared shape — a migration and a new policy version.

## Q1 of the allocator spec is untouched

"A reserve breach strictly implies an upper-band breach" chains through `band_respects_reserve`, which does not change; the two new bounds only tighten the set it quantifies over. `test_reserve_breach_always_implies_a_band_breach`'s generator was updated to enumerate the **new** schema-valid space and now asserts no schema-valid mandate is refused — previously it filtered by the allocator's own refusal, which would let the enumerated space silently follow the code under test.

## Codex

- **Checkpoint 1 (spec)** — killed a false claim (`target = 100` was never storable; verified rejected on `..._band_respects_reserve`) and **flipped the version decision** with the publicly-constructible-object argument above. Also surfaced the `NUMERIC(8,4)` granularity consequence: each bound needs `0.0001` of clearance, so the smallest feasible mandate is `target 0.0002 / band 0.0001`.
- **Checkpoint 2 (diff)** — P1: the version CHECK aborts the migration, and boot, on any database holding a v1 revision *even if it satisfies the new band bounds*.
  - **Concern accepted.** The abort is intended, but it should not surface as an opaque `CheckViolation` on a bookkeeping stamp. `sql/344` now states the precondition as a `DO` block raising a named error carrying the row count and the remedy.
  - **Proposed remedy measured and rejected.** Permitting both versions at rest would ship a state that is storable and that the table's only consumer refuses: `load_core_mandate` reads only the latest revision, and `_mandate_refusal` returns `core_mandate_policy_unsupported` for any version but the current one. `sql/311`'s legacy-readability carve-out does not transfer either — `sql/336`'s header records that this table constrains from row one *because* it has no legacy rows, which is still true.

## Tests

- `test_2603_core_mandate.py` — both dead points refused (incl. at granularity), and the narrowest live mandates on each side accepted, pinning the tightening at **exactly one quantum** so a later over-correction fails.
- `test_2603_core_mandate_db.py` — the two new constraints and the version CHECK as raw-INSERT rejections; the three one-quantum-inside mandates as accepted inserts; and the migration precondition exercised by **reading the `DO` block out of the shipped `sql/344`** rather than restating it, so migration and test cannot drift apart.
- `test_2603_core_allocator.py` — the degenerate mandates now assert `refused` / `core_mandate_invalid` (kept rather than deleted with the defect: the dataclass is public, so the refusal is the only thing between a degenerate mandate and a verdict on a silently one-sided band), plus a control at one quantum inside the dead point that still fires. `core-mandate-v1` and a hypothetical `v3` both parametrised as unsupported — opposite reasons, same refusal.

## Definition-of-Done clauses 8–12

Not applicable: this is a schema migration, but not one affecting ownership / fundamentals / observations data, and there is no parser, ETL or ingest path in the diff. The table holds 0 rows and has no backfill. `ALTER ... ADD CONSTRAINT` validated with nothing to repair; on a database that did hold a degenerate row it would fail loudly, which is the correct outcome.

Verified at `03031aad`: migration reverted and **replayed from the sql/336 state** on dev after the checkpoint-2 amendment (rather than the hash being nulled), lint / format / pyright clean, fast tier + smoke green, `-m db tests/test_2603_core_mandate_db.py` green.

## Security

No security surface. No user input reaches the new SQL; the one `cast("LiteralString", …)` is over text read from a repo-controlled migration file in a test, and nothing interpolates into it.

## Prevention

Two entries in `docs/review-prevention-log.md`:

- **An IN-RANGE bound is not a REACHABLE bound** — a write-time constraint and a read-time comparator are two different inequalities, and the boundary value is where they disagree. Prevention: solve for the consumer's comparator, then state what the constraint forbids that was previously storable.
- **"0 stored rows" does not excuse a version bump** — a version denotes a rule set, and objects outnumber rows. Reaching for the row count is reaching for the easiest measurement rather than the governing one.

Closes #2670
Refs #2603