### PR TITLE
feature(#2624): alert when a strategy's live version has no track record (scope 3)

### DIFF
--- a/app/api/system.py
+++ b/app/api/system.py
@@ -35,6 +35,7 @@ runtime is available, falling back to the declared cadence computation
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from datetime import UTC, date, datetime
 from typing import Literal
 
@@ -68,6 +69,12 @@ from app.services.processes import (
     scheduled_adapter,
 )
 from app.services.processes.health_verdict import verdict_for_row
+from app.services.strategy_scan_freshness import (
+    ScanFreshnessBasis,
+    ScanFreshnessStatus,
+    StrategyScanFreshness,
+    check_scan_freshness,
+)
 from app.workers.scheduler import (
     JOB_ORCHESTRATOR_FULL_SYNC,
     JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC,
@@ -153,6 +160,30 @@ class JobsBootError(BaseModel):
     at: datetime
 
 
+class StrategyScanFreshnessResponse(BaseModel):
+    """Is this strategy's shadow track record keeping up with the corpus (#2624)?
+
+    The arithmetic is carried, not just the colour: an operator seeing ``stale``
+    needs ``frontier_date`` / ``corpus_date`` / ``lag_bars`` to tell "the scan
+    stopped" from "the version rotated" without opening a psql session.
+
+    ``lag_bars`` is in TRADING days, and ``lag_exact`` is false when the watermark
+    predates the loaded window — the true lag is then larger than the number
+    shown, which is why the flag exists rather than a plausible-looking figure.
+    """
+
+    strategy_id: str
+    strategy_version: str
+    status: ScanFreshnessStatus
+    basis: ScanFreshnessBasis | None = None
+    frontier_date: date | None = None
+    corpus_date: date | None = None
+    lag_bars: int | None = None
+    lag_exact: bool = True
+    max_lag_bars: int
+    detail: str | None = None
+
+
 class SystemStatusResponse(BaseModel):
     checked_at: datetime
     overall_status: OverallStatus
@@ -160,6 +191,10 @@ class SystemStatusResponse(BaseModel):
     jobs: list[JobHealthResponse]
     kill_switch: KillSwitchStateResponse
     credential_health: CredentialHealthSummary
+    # #2624 scope 3. Additive: existing clients ignore it. One entry per strategy
+    # in STRATEGY_MANIFEST, always — a strategy with no verdict is a strategy
+    # nothing reports on.
+    strategy_scan_freshness: list[StrategyScanFreshnessResponse] = []
     # Populated when the jobs process most-recently failed to boot
     # because of a hard-fail boot-guard condition (today: missing
     # operator row). NULL on healthy systems. Wired in Stream A PR-A.
@@ -259,6 +294,21 @@ def _layer_to_response(lh: LayerHealth) -> LayerHealthResponse:
     )
 
 
+def _scan_freshness_to_response(entry: StrategyScanFreshness) -> StrategyScanFreshnessResponse:
+    return StrategyScanFreshnessResponse(
+        strategy_id=entry.strategy_id,
+        strategy_version=entry.strategy_version,
+        status=entry.status,
+        basis=entry.basis,
+        frontier_date=entry.frontier_date,
+        corpus_date=entry.corpus_date,
+        lag_bars=entry.lag_bars,
+        lag_exact=entry.lag_exact,
+        max_lag_bars=entry.max_lag_bars,
+        detail=entry.detail,
+    )
+
+
 def _job_health_to_response(name: str, jh: JobHealth) -> JobHealthResponse:
     return JobHealthResponse(
         name=name,
@@ -276,6 +326,7 @@ def _derive_overall_status(
     stalled_job_names: set[str] | None = None,
     *,
     jobs_process_down: bool = False,
+    scan_freshness: Sequence[StrategyScanFreshness] = (),
 ) -> OverallStatus:
     """Worst-of(components).
 
@@ -287,6 +338,7 @@ def _derive_overall_status(
     - any job "failure"    → "down"
     - any job stalled (silently stopped firing) → "degraded"  (#1510 / T4)
     - any layer "stale"/"empty" → "degraded"
+    - any strategy scan alerting → "degraded"  (#2624 scope 3)
     - any job currently "running" → "degraded"
     - otherwise → "ok"
 
@@ -318,6 +370,11 @@ def _derive_overall_status(
     if stalled_job_names:
         return "degraded"
     if any(layer.status in ("stale", "empty") for layer in layers):
+        return "degraded"
+    # #2624 scope 3 — a strategy whose live identity version has no track record
+    # within reach of the corpus. "degraded", never "down": it is recoverable by
+    # the next scan, and "down" is reserved for "nothing is updating".
+    if any(entry.is_alerting for entry in scan_freshness):
         return "degraded"
     if any(job.last_status == "running" for job in jobs):
         return "degraded"
@@ -516,12 +573,20 @@ def get_system_status(
     # verdicts. Best-effort: a probe failure must not 503 the status page.
     engine_down = _jobs_process_down(conn, now)
 
+    # #2624 scope 3 — the signal nothing else carries: the scan job SUCCEEDED and
+    # a strategy's live identity version still has no track record within reach of
+    # the corpus. `check_job_health` sees a failed run; this sees a green one that
+    # left a strategy dark. Contains its own failures (returns an `error` row), so
+    # it cannot 503 the page, matching the per-layer containment above.
+    scan_freshness = check_scan_freshness(conn)
+
     overall = _derive_overall_status(
         layers,
         jobs,
         bool(ks["is_active"]),
         stalled_job_names,
         jobs_process_down=engine_down,
+        scan_freshness=scan_freshness,
     )
 
     return SystemStatusResponse(
@@ -536,6 +601,7 @@ def get_system_status(
             reason=ks.get("reason"),
         ),
         credential_health=_build_credential_health_summary(conn),
+        strategy_scan_freshness=[_scan_freshness_to_response(entry) for entry in scan_freshness],
         jobs_boot_error=jobs_boot_error,
         engine_down=engine_down,
     )

--- a/app/services/strategy_scan_freshness.py
+++ b/app/services/strategy_scan_freshness.py
@@ -32,12 +32,15 @@ Spec: ``docs/proposals/ops/2026-08-13-strategy-scan-freshness.md``
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date
 from typing import Any, Literal
 
 import psycopg
+
+logger = logging.getLogger(__name__)
 
 ScanFreshnessStatus = Literal[
     "ok",
@@ -266,9 +269,6 @@ def check_scan_freshness(conn: psycopg.Connection[Any]) -> list[StrategyScanFres
     both ways on dev: bare catch → the following ``SELECT 1`` raises; inside a
     savepoint → it succeeds. Raised by Codex at checkpoint 2.
     """
-    import logging
-
-    logger = logging.getLogger(__name__)
     try:
         with conn.transaction():
             current_versions, watermarks, trading_dates = read_scan_freshness_inputs(conn)

--- a/app/services/strategy_scan_freshness.py
+++ b/app/services/strategy_scan_freshness.py
@@ -1,0 +1,301 @@
+"""Is each strategy's shadow track record keeping up with the corpus? (#2624 scope 3)
+
+The signal nothing else carries: ``strategy_signal_scan`` **succeeded** and the
+strategy's CURRENT identity version still has no track record within reach of the
+price frontier.  ``check_job_health`` sees a failed or stalled run; the layer
+checks see a stale corpus; neither sees a green job that left the live version
+dark, which is the #2218 invisible-no-op class #2624 is about.
+
+⚠ Deliberately NOT a ``_STALENESS_THRESHOLDS`` row.  ``check_layer_staleness``
+ages one table against one constant, and a plain ``strategy_signals`` layer on
+that framework would fire on every registry-touching merge — a fresh version
+legitimately has no rows yet.
+
+⚠ The observable is the WATERMARK, not the signal.  Measured on dev 2026-08-13:
+``s2-cross-sectional-momentum`` has **zero** ``strategy_signals`` rows under any
+version while carrying a watermark at ``2026-08-11``.  A signal is an output whose
+emptiness is a legitimate outcome (``scheduler.py::strategy_signal_scan``: *"zero
+is a legitimate success"*), so ageing signals would fire permanently for s2 and
+could never clear.
+
+⚠ There is NO "while prices are fresh" conjunct, and #2624's text asking for one
+cannot be honoured as written: ``_LAYER_QUERIES["prices"]`` ages
+``MAX(price_date)::timestamptz`` — midnight of the last trading date — against a
+4-hour threshold, so the prices layer reads ``stale`` from ~04:00 UTC daily and all
+weekend, on a healthy system.  Gating on it would ship a check that never
+evaluates.  It is also unnecessary: the lag is measured in TRADING DAYS against
+``price_daily`` itself, so a corpus that stops advancing cannot grow the lag.  The
+suppression is structural rather than conditional.
+
+Spec: ``docs/proposals/ops/2026-08-13-strategy-scan-freshness.md``
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Literal
+
+import psycopg
+
+ScanFreshnessStatus = Literal[
+    "ok",
+    "stale",
+    "rotated_awaiting_scan",
+    "rotated_scan_overdue",
+    "frontier_regressed",
+    "never_scanned",
+    "error",
+]
+
+#: Which watermark the lag was measured from.  ``current`` is the live identity
+#: version; ``fallback`` is the newest watermark on ANY version of that strategy,
+#: used when the live version has none yet.
+ScanFreshnessBasis = Literal["current", "fallback"]
+
+# Trading bars of lag a healthy scan may show.  Derived, not chosen (spec "Source
+# rule"):
+#   1  the by-design arrears -- SCHEDULED_JOBS[strategy_signal_scan] runs "one bar
+#      in ARREARS", so a healthy frontier is ALWAYS one bar behind the corpus;
+#   1  one missed daily 06:45 UTC tick, matching _STALENESS_THRESHOLDS' own stated
+#      convention ("2 days allows for a missed night").
+# Alert strictly above.  ⚠ Detection latency is not the same number: baseline 1 +
+# one missed session reads 2 and stays healthy, so the check turns red only once a
+# SECOND missed bar appears in price_daily.
+_MAX_SCAN_LAG_BARS = 2
+
+# How many recent trading dates the reader loads.  Bounds the query and the lag we
+# can report EXACTLY; a basis older than the window reports the window size with
+# `lag_exact=False` rather than a number that looks precise and is not.
+_TRADING_DATE_WINDOW = 30
+
+# ⚠ ``never_scanned`` is deliberately NOT here, and the reason is a decision this
+# repo already settled one component over.  ``_derive_overall_status``' own
+# docstring: *"Jobs with `last_status is None` (no runs ever recorded) are
+# deliberately NOT treated as degraded on their own — a fresh deploy would
+# otherwise always report 'degraded' purely because no jobs have fired yet …
+# A fresh deploy will still report 'degraded' via the empty data layers, which is
+# the more meaningful signal anyway."*  ``never_scanned`` is the strategy-scan
+# analogue of exactly that, so it reports the state without claiming a fault.
+# Caught by `test_api_system`'s healthy-system fixtures reading ``degraded``.
+#
+# The 2026-08-12 symptom this ticket exists for is NOT affected: that is
+# ``rotated_scan_overdue``, which by definition has prior watermarks.
+_ALERTING_STATUSES: frozenset[str] = frozenset({"stale", "rotated_scan_overdue", "frontier_regressed", "error"})
+
+# A LOOSE INDEX SCAN, not a `DISTINCT ... LIMIT`, and the difference is the point.
+# `/system/status` is polled, so this runs constantly; the cost must not scale with
+# the corpus.  Measured on dev (6,755,721 rows, 1,995 distinct dates, 30-date
+# window), each form after `ANALYZE`:
+#
+#   SELECT DISTINCT price_date … ORDER BY … LIMIT 30
+#     without idx_price_daily_price_date : Parallel Seq Scan, 70,183 buffers, 279 ms
+#     with it                            : Limit->Unique->Index Scan Backward,
+#                                          93,734 buffers, 57 ms warm / 523 ms cold
+#   this recursive form                  : 130 buffers, 1.0 ms
+#
+# The index alone is not enough because `Unique` over an index scan still walks
+# EVERY ROW of each of the 30 dates -- ~3,400 instruments each -- so its cost grows
+# with instruments-per-date, which is the growth Codex flagged at checkpoint 2.
+# The recursion instead does exactly ``window`` ``max()`` probes, each an
+# index-only backward scan, so the cost is a function of the WINDOW and nothing
+# else.  ⚠ The ``n`` counter is load-bearing: without it the recursion runs to
+# corpus exhaustion (1,995 iterations) because an outer LIMIT cannot stop a
+# recursive CTE.  Requires sql/345.
+_RECENT_TRADING_DATES = """
+WITH RECURSIVE d(price_date, n) AS (
+    SELECT max(price_date), 1 FROM price_daily
+    UNION ALL
+    SELECT (SELECT max(p.price_date) FROM price_daily p WHERE p.price_date < d.price_date), d.n + 1
+    FROM d WHERE d.price_date IS NOT NULL AND d.n < %(window)s
+)
+SELECT price_date FROM d WHERE price_date IS NOT NULL ORDER BY price_date
+"""
+
+
+@dataclass(frozen=True)
+class StrategyScanFreshness:
+    """One strategy's verdict, carrying the arithmetic that produced it."""
+
+    strategy_id: str
+    strategy_version: str
+    status: ScanFreshnessStatus
+    basis: ScanFreshnessBasis | None
+    frontier_date: date | None
+    corpus_date: date | None
+    lag_bars: int | None
+    lag_exact: bool
+    max_lag_bars: int
+    detail: str | None = None
+
+    @property
+    def is_alerting(self) -> bool:
+        return self.status in _ALERTING_STATUSES
+
+
+def _lag_bars(basis: date, trading_dates: Sequence[date]) -> tuple[int, bool]:
+    """Trading dates strictly after ``basis``, and whether that count is exact.
+
+    Inexact when ``basis`` predates the loaded window: the true lag is at least
+    the window size, which already exceeds any threshold, and reporting the window
+    size as if it were the real number would be a derived statistic that is wrong
+    in the place an operator trusts most.
+    """
+    lag = sum(1 for day in trading_dates if day > basis)
+    return lag, basis >= trading_dates[0]
+
+
+def assess_scan_freshness(
+    *,
+    current_versions: Mapping[str, str],
+    watermarks: Mapping[tuple[str, str], date],
+    trading_dates: Sequence[date],
+) -> list[StrategyScanFreshness]:
+    """Pure verdict for every strategy in ``current_versions``.
+
+    ``trading_dates`` is the recent distinct ``price_daily`` dates, ASCENDING.
+    ``watermarks`` is ``read_watermarks``' shape, keyed ``(strategy_id, version)``.
+
+    Returns one entry per strategy, always — a strategy with no verdict is a
+    strategy nothing reports on.
+    """
+    corpus_date = trading_dates[-1] if trading_dates else None
+    newest_by_strategy: dict[str, date] = {}
+    for (strategy_id, _version), frontier in watermarks.items():
+        seen = newest_by_strategy.get(strategy_id)
+        if seen is None or frontier > seen:
+            newest_by_strategy[strategy_id] = frontier
+
+    results: list[StrategyScanFreshness] = []
+    for strategy_id in sorted(current_versions):
+        version = current_versions[strategy_id]
+        current = watermarks.get((strategy_id, version))
+        fallback = newest_by_strategy.get(strategy_id)
+        basis_date = current if current is not None else fallback
+        basis: ScanFreshnessBasis | None = (
+            None if basis_date is None else ("current" if current is not None else "fallback")
+        )
+
+        def _verdict(
+            status: ScanFreshnessStatus,
+            *,
+            lag: int | None = None,
+            exact: bool = True,
+            detail: str | None = None,
+        ) -> StrategyScanFreshness:
+            return StrategyScanFreshness(
+                strategy_id=strategy_id,
+                strategy_version=version,
+                status=status,
+                basis=basis,
+                frontier_date=basis_date,
+                corpus_date=corpus_date,
+                lag_bars=lag,
+                lag_exact=exact,
+                max_lag_bars=_MAX_SCAN_LAG_BARS,
+                detail=detail,
+            )
+
+        if basis_date is None:
+            # No watermark under ANY version. One state, one meaning -- "no track
+            # record at all" -- which also absorbs a renamed strategy_id and a
+            # purged history, and does not claim to say which.
+            results.append(_verdict("never_scanned"))
+            continue
+        if corpus_date is None:
+            # Reachable only before the corpus exists (pre-bootstrap). Contained
+            # rather than raising: an unassessable strategy must still get a row.
+            results.append(_verdict("error", detail="no price corpus to measure against"))
+            continue
+        if basis_date > corpus_date:
+            # The corpus went BACKWARDS under a completed scan -- a rewash, a
+            # restore, a rule-set bump that emptied the coverage table.
+            # `run_signal_scan` has its own branch for this
+            # (strategy_signal_scan.py:492, "declining to write"). It must be
+            # tested BEFORE the lag, which a regressed corpus makes read 0 and
+            # therefore healthy.
+            results.append(_verdict("frontier_regressed", lag=0, detail="watermark is ahead of the price corpus"))
+            continue
+
+        lag, exact = _lag_bars(basis_date, trading_dates)
+        breached = lag > _MAX_SCAN_LAG_BARS
+        if basis == "current":
+            results.append(_verdict("stale" if breached else "ok", lag=lag, exact=exact))
+        else:
+            # The live version has no track record yet. Ageing the newest
+            # watermark on any version answers the question that matters --
+            # "has this strategy scanned recently" -- without a rotation
+            # timestamp, which strategy_scan_watermark does not store.
+            results.append(
+                _verdict("rotated_scan_overdue" if breached else "rotated_awaiting_scan", lag=lag, exact=exact)
+            )
+    return results
+
+
+def read_scan_freshness_inputs(
+    conn: psycopg.Connection[Any],
+) -> tuple[dict[str, str], dict[tuple[str, str], date], list[date]]:
+    """The three measured inputs, so the verdict itself stays pure and testable."""
+    from app.services.cost_model import COST_MODEL_ID
+    from app.services.strategy_manifest import STRATEGY_MANIFEST
+    from app.services.strategy_signal_scan import SCAN_UNIVERSE, read_watermarks
+
+    current_versions = {
+        strategy_id: entry.identity(universe=SCAN_UNIVERSE, cost_model_id=COST_MODEL_ID).version
+        for strategy_id, entry in STRATEGY_MANIFEST.items()
+    }
+    watermarks = read_watermarks(conn)
+    trading_dates = [row[0] for row in conn.execute(_RECENT_TRADING_DATES, {"window": _TRADING_DATE_WINDOW}).fetchall()]
+    return current_versions, watermarks, trading_dates
+
+
+def check_scan_freshness(conn: psycopg.Connection[Any]) -> list[StrategyScanFreshness]:
+    """Read the inputs and return one verdict per strategy.
+
+    Never raises: a reader failure yields one ``error`` row, so a probe failure
+    cannot 503 the whole status endpoint.
+
+    ⚠ ``conn.transaction()`` is the containment, and a bare ``try/except`` is NOT.
+    ``get_conn`` hands out a NON-autocommit pooled connection, so a failed query
+    leaves Postgres' transaction ABORTED; catching the exception does not clear
+    that, and the next statement on the same connection raises
+    ``InFailedSqlTransaction``. In ``get_system_status`` the next statement is
+    ``_build_credential_health_summary(conn)``, which sits OUTSIDE the handler's
+    try — so the "contained" error row would have become an HTTP 500. Verified
+    both ways on dev: bare catch → the following ``SELECT 1`` raises; inside a
+    savepoint → it succeeds. Raised by Codex at checkpoint 2.
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+    try:
+        with conn.transaction():
+            current_versions, watermarks, trading_dates = read_scan_freshness_inputs(conn)
+    except Exception:
+        logger.exception("check_scan_freshness: failed to read inputs")
+        return [
+            StrategyScanFreshness(
+                strategy_id="*",
+                strategy_version="",
+                status="error",
+                basis=None,
+                frontier_date=None,
+                corpus_date=None,
+                lag_bars=None,
+                lag_exact=False,
+                max_lag_bars=_MAX_SCAN_LAG_BARS,
+                detail="scan freshness query failed (see server logs)",
+            )
+        ]
+    return assess_scan_freshness(current_versions=current_versions, watermarks=watermarks, trading_dates=trading_dates)
+
+
+__all__ = [
+    "ScanFreshnessBasis",
+    "ScanFreshnessStatus",
+    "StrategyScanFreshness",
+    "assess_scan_freshness",
+    "check_scan_freshness",
+    "read_scan_freshness_inputs",
+]

--- a/docs/proposals/ops/2026-08-13-strategy-scan-freshness.md
+++ b/docs/proposals/ops/2026-08-13-strategy-scan-freshness.md
@@ -1,0 +1,175 @@
+# The strategy-scan freshness check (#2624 scope 3)
+
+Scope 3 of #2624, and **only** scope 3. Scopes 1 and 2 change the overview payload and the
+page that renders it; this is a backend check with no render, independently verifiable
+against `:8000`, which is why it is separable. #2624 stays open.
+
+## Two premises in the ticket are falsified, and both change the design
+
+### 1. The signal table is the wrong observable
+
+> a freshness check that alerts on "current version has no signal newer than N days …"
+
+Measured on dev, 2026-08-13. `strategy_signals` grouped by `(strategy_id,
+strategy_version)` returns rows for s1, s3 and s4 only. **s2-cross-sectional-momentum has
+zero rows under any version** — including `+83967fcb1fca`, the current one, which carries a
+watermark at `frontier_date = 2026-08-11` written `2026-08-12 18:59:02`. s2 scans
+successfully and emits nothing.
+
+A signal is an **output whose emptiness is a legitimate outcome**, and the scan job's own
+docstring says so (`scheduler.py::strategy_signal_scan`: *"`row_count` is signals WRITTEN,
+and zero is a legitimate success"*). Ageing signals would fire permanently for s2 and could
+never clear — the false-positive class the ticket rules out, one table over from where it
+looked for it.
+
+**`strategy_scan_watermark` is the observable that means "a scan ran".** It gets a row per
+`(strategy_id, strategy_version)` on every successful scan regardless of signal count, which
+is exactly why s2 has one and no signals.
+
+### 2. "…while prices are fresh" cannot be built on the prices layer, and is not needed
+
+The obvious reading — conjoin `check_layer_staleness(conn, "prices") == ok` — ships a check
+that never evaluates. Measured 2026-08-13 19:10 UTC on a healthy system:
+
+```
+prices layer NOW: stale   latest 2026-08-12 00:00:00+00   age 1 day 19:10:14   max_age 4:00:00
+```
+
+`_LAYER_QUERIES["prices"]` is `MAX(price_date)::timestamptz`, i.e. **midnight of the last
+trading date**, aged against a **4-hour** threshold. It is therefore `stale` from ~04:00 UTC
+every day and for the whole of every weekend. A conjunct on it would suppress this check
+essentially always, which is a control that cannot fire.
+
+**The conjunct is unnecessary, not merely unbuildable.** Measuring the lag in *trading days
+against `price_daily` itself* makes the check self-suppressing by construction: a corpus that
+stops advancing cannot grow the lag, so a price outage holds the strategy at its current lag
+instead of blaming the scan for it. The ticket's conjunct was compensating for a calendar-day
+formulation this spec does not use. The prices layer keeps its own alarm; this one does not
+restate it.
+
+## Source rule
+
+No published formulation governs this, so per `.claude/CLAUDE.md` the threshold is fixed **by
+construction**, with the construction stated rather than the number picked. Every term is a
+property of the scan job:
+
+| term | value | where it comes from |
+| --- | --- | --- |
+| by-design arrears | 1 trading bar | `SCHEDULED_JOBS[strategy_signal_scan].description`: *"Runs one bar in ARREARS: a signal on the last bar of a series has no t+1"*. A healthy frontier is **always** one bar behind the corpus. |
+| tolerance for one missed run | 1 trading bar | the job runs **daily at 06:45 UTC**, so one missed tick costs exactly one bar. Matches `_STALENESS_THRESHOLDS`' own convention — *"2 days allows for a missed night"*. |
+| **`_MAX_SCAN_LAG_BARS`** | **2** | the sum. Alert strictly above it. |
+
+`lag = count(distinct price_date) from price_daily where price_date > basis_frontier`.
+
+⚠ **Trading days, not calendar days.** That is what removes the weekend from the threshold
+rather than padding it away: over a weekend `price_daily` does not advance either, so a
+healthy Monday reads the same `1` it read on Friday. A calendar threshold would have to
+absorb a three-day weekend plus holidays and would then be too loose to catch a two-day
+outage — the failure it exists to catch.
+
+⚠ **Detection latency, stated so it is not mistaken for the tolerance.** Strict `> 2` means
+the baseline `1` plus one missed session reads `2` and stays healthy; the check turns red
+only once a *second* missed bar becomes visible in `price_daily`. So "one missed run of
+tolerance" is the design intent and "red on the second missed bar's appearance" is the
+observable behaviour. Raised by Codex at checkpoint 1.
+
+Verified against the live steady state: all four strategies read lag **1** today
+(`price_daily` max `2026-08-12`, current-version frontier `2026-08-11`, one distinct trading
+date between them). The healthy value is the by-design arrears, so the threshold sits one
+missed run above the observed norm.
+
+## The basis frontier, and why the fallback is sound
+
+Per strategy in `STRATEGY_MANIFEST`, against its **current** identity version:
+
+```
+basis = frontier_date for (strategy, current_version)          -- "current"
+     or max(frontier_date) over all versions of that strategy  -- "fallback"
+```
+
+The fallback is what makes a rotation legible. `strategy_scan_watermark` stores **no
+rotation timestamp**, so a state machine keyed on "how long since the version rotated" is not
+buildable from this table — Codex raised this at checkpoint 1 and it is correct.
+
+It is also the wrong question. Whether a strategy is dark because a version rotated or
+because the job is broken, the operator-visible truth is the same: **no scan under this
+strategy has reached within N bars of the corpus.** Ageing the newest watermark on *any*
+version measures exactly that and needs no rotation time. The status name then records which
+basis was used, so a rotation is distinguishable from an outage without the classification
+depending on it.
+
+## States, and that each is reachable
+
+| status | condition | alert? |
+| --- | --- | --- |
+| `ok` | current-version watermark, lag ≤ 2 | no |
+| `stale` | current-version watermark, lag > 2 | **yes** |
+| `rotated_awaiting_scan` | no current-version watermark; fallback basis, lag ≤ 2 | no — #2624's "new track record starting" |
+| `rotated_scan_overdue` | no current-version watermark; fallback basis, lag > 2 | **yes** — the 2026-08-12 symptom |
+| `frontier_regressed` | basis frontier is **ahead** of `price_daily`'s max | **yes** |
+| `never_scanned` | no watermark under any version | no — see below |
+| `error` | the reader raised | **yes** |
+
+⚠ **`never_scanned` reports but does not alert, and that is a decision this repo already
+settled one component over.** `_derive_overall_status`' own docstring refuses to degrade the
+headline for a job with `last_status is None`: *"a fresh deploy would otherwise always
+report 'degraded' purely because no jobs have fired yet … A fresh deploy will still report
+'degraded' via the empty data layers, which is the more meaningful signal anyway."*
+`never_scanned` is the strategy-scan analogue of exactly that. The first draft alerted on it
+and `test_api_system`'s healthy-system fixtures — which stage no watermarks — went
+`degraded`, which is how it surfaced. The 2026-08-12 symptom is unaffected: that is
+`rotated_scan_overdue`, which by definition has prior watermarks.
+
+⚠ Reachability checked for each, because a state nothing can produce is the defect this
+milestone keeps finding (`sql/342`, #2653):
+
+- `ok` — the live state of all four strategies today.
+- `rotated_awaiting_scan` — the state between a registry-touching merge and the next 06:45
+  tick. **A rotation does not trigger a scan**: `strategy_signal_scan` is a scheduled daily
+  job with no rotation hook, so a new version has no track record for up to ~24h. Without
+  this state the check would fire on every registry merge, which is the false positive the
+  #2624 triage warned about.
+- `rotated_scan_overdue` — #2624's own 2026-08-12 measurement: four versions rotated, 0 rows
+  under them, `max signal_bar_date 2026-08-06` against a corpus days ahead.
+- `stale` — the daily job missing twice.
+- `frontier_regressed` — **not hypothetical**: `run_signal_scan` has an explicit branch for
+  it (`strategy_signal_scan.py:492`, *"the corpus regressed … declining to write"*) covering
+  a rewash, a restore, or a rule-set bump that emptied the coverage table. Codex flagged that
+  the first draft's `ok` would have swallowed this; it would have, and silently, since a
+  regressed corpus makes the lag read `0`.
+- `never_scanned` — a strategy newly added to `STRATEGY_MANIFEST`. ⚠ It also absorbs a
+  renamed `strategy_id` and a purged watermark history; the state means "no track record at
+  all" and does not claim to say why.
+- `error` — any reader failure.
+
+The statuses are evaluated in the order listed and are mutually exclusive by construction:
+`frontier_regressed` is tested before the lag comparison, and the current/fallback split is
+a total partition on "does a current-version watermark exist".
+
+## What this deliberately does NOT restate
+
+- **Job failure.** `check_job_health(conn, "strategy_signal_scan")` already surfaces a failed
+  or stalled run. The distinct signal here is the one nothing else has: the job **succeeded**
+  and left the current version with no track record — the #2218 invisible-no-op class the
+  ticket names.
+- **Price-corpus health.** The `prices` layer owns it, and see above.
+- **Kill switch.** `overall_status` is already `down` while it is active, so a scan alarm
+  under it would be redundant noise.
+- **Per-strategy enablement.** `STRATEGY_MANIFEST` is the set of live strategies and carries
+  no enabled flag, so there is nothing to filter on. If one is added, this check must gain a
+  filter with it.
+
+## Shape
+
+- A **pure** function over already-measured inputs — the manifest's current versions, the
+  watermark rows, and the corpus trading dates. Table-tested with no DB, per the repo's
+  lean-test rule. The reader is one query.
+- Surfaced on `/system/status` as a new `strategy_scan_freshness` list, one entry per
+  strategy, each carrying its status, basis, `frontier_date` and lag — so the operator sees
+  the arithmetic, not just a colour.
+- Folded into `overall_status` as a **degraded** contributor, never `down`. An alert that
+  reaches no headline is a control on a path the decision does not take (#2437 R4); `down` is
+  reserved for "nothing is updating".
+- **Contained like the per-layer checks**: a reader failure yields `status = "error"` for the
+  strategies rather than a 503 on the whole status endpoint, matching `check_all_layers`'
+  existing per-layer containment. Additive response field, so existing clients are unaffected.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -4464,3 +4464,77 @@ with `verify_2598_preflight_quote_crosscheck.py --replay <fixture>`:
   the constant); `sql/344_core_mandate_trigger_reachability.sql` (re-issued `policy_version`
   CHECK + `COMMENT ON`); `tests/test_2603_core_mandate.py::test_the_policy_version_records_which_arithmetic_wrote_the_row`;
   `tests/test_2603_core_mandate_db.py` parametrises a `v1` row as a rejected raw INSERT.
+
+### An output whose EMPTINESS is a legitimate outcome cannot be aged — age the artefact that records the ATTEMPT
+
+- First seen in: #2624 scope 3, whose own ticket text proposed the unbuildable version.
+- Symptom: the ticket asked for an alert on *"current version has no **signal** newer than N
+  days"*. Measured on dev: `s2-cross-sectional-momentum` has **zero** `strategy_signals` rows
+  under any version, while carrying a current-version watermark at `2026-08-11` written the
+  day before. It scans successfully and fires nothing — and the scan job's own docstring says
+  so (*"`row_count` is signals WRITTEN, and zero is a legitimate success"*). A signal-aged
+  check would have alerted on s2 permanently, with no input that could ever clear it: the
+  exact false-positive class the ticket's own text ruled out, one table over from where it
+  looked.
+- The general shape: **a freshness check needs a record of the attempt, not of the result.**
+  Results are allowed to be empty; attempts are not. Where a pipeline writes both — a
+  watermark and a payload, a run row and its rows, a scan and its hits — the payload is a
+  measure of what the world contained and only the attempt is a measure of whether the system
+  ran. Ageing the payload conflates "nothing happened" with "nothing was found".
+- Prevention: before ageing a table, ask what a **healthy empty** looks like in it. If a
+  legitimate run can leave zero rows, that table cannot carry the freshness signal — find the
+  one the run writes unconditionally. Test it with the real empty case, not a synthetic one:
+  s2 exists and would have failed any check written against the ticket as stated.
+- Enforced in: `app/services/strategy_scan_freshness.py` (keyed on
+  `strategy_scan_watermark`, with the s2 measurement in the module docstring);
+  `tests/test_2624_strategy_scan_freshness.py::test_a_strategy_that_emits_no_signals_is_still_healthy`.
+
+### A conjunct on an existing health signal inherits that signal's SEMANTICS, not its name
+
+- First seen in: #2624 scope 3, at Codex checkpoint 1.
+- Symptom: the ticket's condition was *"… while prices are fresh"*, and the obvious build is
+  `and check_layer_staleness(conn, "prices").status == "ok"`. Measured on a healthy system at
+  2026-08-13 19:10 UTC: **that layer reads `stale`**. `_LAYER_QUERIES["prices"]` is
+  `MAX(price_date)::timestamptz` — *midnight of the last trading date* — aged against a
+  **4-hour** threshold, so it is stale from ~04:00 UTC every day and for every weekend. The
+  conjunct would have suppressed the new check essentially always: a control that cannot fire,
+  shipped green, with a plausible-sounding reason in its own docstring.
+- The general shape: **a named health signal is a threshold over a specific column, and the
+  name is a summary of the intent rather than of the semantics.** Reusing it as a term in a
+  new predicate imports the column, the cast and the threshold — which were chosen for a
+  different question. "prices are fresh" and "`prices` layer is ok" are not the same
+  proposition and were never meant to be.
+- Prevention: before ANDing an existing check into a new one, **evaluate it against live data
+  and read its actual distribution**, not its name — one call. If it is not `ok` in normal
+  operation, the conjunct is a suppressor. Then ask whether the guard is needed at all: here
+  it was not, because measuring the lag in *trading days against `price_daily` itself* makes
+  the check self-suppressing by construction — a corpus that stops advancing cannot grow the
+  lag. **A structural suppression beats a conditional one, and removes the term rather than
+  fixing it.**
+- Enforced in: `app/services/strategy_scan_freshness.py` (module docstring records the
+  measurement and the absence of the conjunct);
+  `docs/proposals/ops/2026-08-13-strategy-scan-freshness.md`.
+
+### An index is not automatically the fix for a seq scan — `Unique` over an index still walks every row of each distinct value
+
+- First seen in: #2624 scope 3, Codex checkpoint 2 (which flagged the seq scan correctly and
+  proposed the index).
+- Symptom: `SELECT DISTINCT price_date … ORDER BY price_date DESC LIMIT 30` on a polled health
+  endpoint seq-scanned all 6,755,721 `price_daily` rows (70,183 buffers, 279 ms). Adding the
+  obvious `price_date` index turned it into `Limit -> Unique -> Index Scan Backward`, which
+  **stops after the 30th distinct date and still reads every row of each of them** — ~3,400
+  instruments per date: 93,734 buffers, 57 ms warm and 523 ms cold. It traded a cost that
+  grows with the corpus for one that grows with rows-per-key, which is the same regression a
+  season later. A loose index scan (recursive `max()` walk, one probe per distinct value) is
+  130 buffers and 1.0 ms.
+- The general shape: **an index changes how rows are FOUND, not how many are READ.** For a
+  low-cardinality leading column, `DISTINCT`/`Unique` is O(rows), not O(distinct values),
+  whichever access path serves it.
+- Prevention: `EXPLAIN (ANALYZE, BUFFERS)` the remedy, not just the defect, and compare
+  **buffers** rather than milliseconds — a warm cache hides the read volume that a cold one
+  will not. When the query wants distinct values of a low-cardinality column, reach for the
+  loose index scan; the counter in its recursive term is load-bearing, since an outer `LIMIT`
+  cannot stop a recursive CTE.
+- Enforced in: `sql/345_price_daily_price_date_index.sql` (header carries all three
+  measurements and states that the index alone is insufficient);
+  `app/services/strategy_scan_freshness.py::_RECENT_TRADING_DATES`.

--- a/sql/345_price_daily_price_date_index.sql
+++ b/sql/345_price_daily_price_date_index.sql
@@ -1,0 +1,59 @@
+-- 345_price_daily_price_date_index.sql
+--
+-- #2624 scope 3.  `strategy_scan_freshness` needs the most recent N distinct
+-- trading dates on every `/system/status` poll, and `price_daily`'s only
+-- price_date-bearing index is the PK `(instrument_id, price_date)` -- wrong
+-- leading column, so a date-first query cannot use it.
+--
+-- Measured on dev BEFORE this index (6,755,721 rows, 1,995 distinct dates):
+--
+--   EXPLAIN (ANALYZE, BUFFERS)
+--   SELECT price_date FROM (
+--       SELECT DISTINCT price_date FROM price_daily ORDER BY price_date DESC LIMIT 30
+--   ) r ORDER BY price_date;
+--
+--   ->  Parallel Seq Scan on price_daily  (actual rows=2,251,907 loops=3)
+--       Buffers: shared hit=335 read=69830
+--   Execution Time: 279.348 ms
+--
+-- A full-corpus seq scan on an operator health endpoint that is polled is a
+-- regression that grows with the corpus.  Raised by Codex at checkpoint 2.
+--
+-- ⚠ THE INDEX ALONE DOES NOT FIX IT, and measuring the remedy is what showed
+-- that.  With the index the same query becomes Limit -> Unique -> Index Scan
+-- Backward, which stops after the 30th distinct date but still walks EVERY ROW
+-- of each of those dates -- ~3,400 instruments each:
+--
+--   Buffers: shared hit=83781 read=9953   Execution: 57 ms warm / 523 ms cold
+--
+-- i.e. it trades a cost that grows with the corpus for one that grows with
+-- instruments-per-date, which is the same regression a season later.  The
+-- consumer therefore uses a LOOSE INDEX SCAN (a recursive `max()` walk, see
+-- `strategy_scan_freshness._RECENT_TRADING_DATES`), which does exactly N probes:
+--
+--   Buffers: shared hit=129 read=1        Execution: 1.0 ms
+--
+-- This index is what makes those probes index-only; the recursion is what makes
+-- them 30 instead of 100,000.  Neither works without the other.
+--
+-- Deliberately NOT a covering/INCLUDE index and not composite: the only consumer
+-- reads the date alone, and every extra column would be paid on every
+-- price_daily write for nothing.  `price_daily` is append-mostly on a daily
+-- cadence, so the write cost of one narrow index is a single-digit-percent
+-- overhead on the daily refresh, not a per-tick cost.
+--
+-- ⚠ NOT `CREATE INDEX CONCURRENTLY`: this runner applies each migration inside a
+-- transaction (app/db/migrations.py:194) and CONCURRENTLY cannot run in one.
+-- The blocking build is acceptable at this size -- measured 3.4s on dev -- and
+-- the alternative is the `-- runner: autocommit` directive, which trades the
+-- migration's own atomicity for a lock this table does not need protecting from
+-- at the point migrations run (boot, before the schedulers start).
+
+CREATE INDEX IF NOT EXISTS idx_price_daily_price_date
+    ON price_daily (price_date);
+
+COMMENT ON INDEX idx_price_daily_price_date IS
+    'Date-leading companion to the (instrument_id, price_date) PK. Added for '
+    '#2624 scope 3, whose recent-distinct-trading-dates probe runs on every '
+    '/system/status poll and seq-scanned the whole corpus without it (279ms, '
+    'measured). Also usable by any corpus-frontier query that leads on date.';

--- a/tests/test_2624_strategy_scan_freshness.py
+++ b/tests/test_2624_strategy_scan_freshness.py
@@ -1,0 +1,274 @@
+"""#2624 scope 3 — the strategy-scan freshness verdict, as pure policy.
+
+No DB: the rule is arithmetic over three measured inputs, and the reader is one
+query. Per the repo's lean-test guidance, the decision is extracted into a pure
+function and table-tested rather than staged in Postgres.
+
+⚠ The premise these tests exist to hold is that the observable is the WATERMARK,
+not the signal. Measured on dev 2026-08-13, ``s2-cross-sectional-momentum`` has
+zero ``strategy_signals`` rows under any version while carrying a current-version
+watermark — so a signal-aged check would alert on it forever and never clear.
+``test_a_strategy_that_emits_no_signals_is_still_healthy`` is that case.
+"""
+
+from datetime import date
+
+import pytest
+
+from app.services.strategy_scan_freshness import (
+    StrategyScanFreshness,
+    assess_scan_freshness,
+    check_scan_freshness,
+)
+
+# 10 consecutive weekday "trading dates", ascending, ending 2026-08-12 — the live
+# corpus frontier on the day this was written.
+_TRADING_DATES = [
+    date(2026, 7, 30),
+    date(2026, 7, 31),
+    date(2026, 8, 3),
+    date(2026, 8, 4),
+    date(2026, 8, 5),
+    date(2026, 8, 6),
+    date(2026, 8, 7),
+    date(2026, 8, 10),
+    date(2026, 8, 11),
+    date(2026, 8, 12),
+]
+
+_S1 = "s1-time-series-momentum"
+_CURRENT = "strategy-registry-v1+67dbf07c9d72"
+_PRIOR = "strategy-registry-v1+2307ee566d7b"
+
+
+def _assess(
+    watermarks: dict[tuple[str, str], date],
+    *,
+    trading_dates: list[date] | None = None,
+    versions: dict[str, str] | None = None,
+) -> StrategyScanFreshness:
+    results = assess_scan_freshness(
+        current_versions=versions if versions is not None else {_S1: _CURRENT},
+        watermarks=watermarks,
+        trading_dates=_TRADING_DATES if trading_dates is None else trading_dates,
+    )
+    assert len(results) == 1
+    return results[0]
+
+
+def test_the_healthy_steady_state_is_one_bar_of_lag() -> None:
+    """The by-design arrears IS the healthy value, not a tolerance spent.
+
+    ``strategy_signal_scan`` runs one bar in arrears because a signal on the last
+    bar of a series has no t+1, so a frontier level with the corpus would be the
+    anomaly. Pinned against the live reading: corpus 2026-08-12, frontier
+    2026-08-11, lag 1.
+    """
+    verdict = _assess({(_S1, _CURRENT): date(2026, 8, 11)})
+    assert (verdict.status, verdict.basis, verdict.lag_bars) == ("ok", "current", 1)
+    assert verdict.corpus_date == date(2026, 8, 12)
+    assert not verdict.is_alerting
+
+
+def test_a_strategy_that_emits_no_signals_is_still_healthy() -> None:
+    """The s2 case, and the whole reason the watermark is the observable.
+
+    Nothing in this input mentions signals — which is the point: a strategy that
+    scans and fires nothing is indistinguishable here from one that fires
+    thousands, because both advance the watermark. #2624's proposed signal-aged
+    check would have alerted on s2 permanently and could never have cleared.
+    """
+    verdict = _assess(
+        {("s2-cross-sectional-momentum", _CURRENT): date(2026, 8, 11)},
+        versions={"s2-cross-sectional-momentum": _CURRENT},
+    )
+    assert verdict.status == "ok"
+
+
+@pytest.mark.parametrize(
+    ("frontier", "expected_lag", "expected_status"),
+    [
+        # The arrears bar.
+        (date(2026, 8, 11), 1, "ok"),
+        # One missed daily tick — still inside tolerance, by construction.
+        (date(2026, 8, 10), 2, "ok"),
+        # The second missed bar becoming visible is what turns it red. This is
+        # the detection latency the spec states, distinct from the tolerance.
+        (date(2026, 8, 7), 3, "stale"),
+        (date(2026, 7, 30), 9, "stale"),
+    ],
+)
+def test_the_threshold_sits_exactly_one_missed_run_above_the_arrears(
+    frontier: date, expected_lag: int, expected_status: str
+) -> None:
+    verdict = _assess({(_S1, _CURRENT): frontier})
+    assert (verdict.lag_bars, verdict.status) == (expected_lag, expected_status)
+    assert verdict.max_lag_bars == 2
+
+
+def test_the_lag_is_trading_days_so_a_weekend_does_not_move_it() -> None:
+    """What makes the threshold weekend-immune rather than weekend-padded.
+
+    ``price_daily`` does not advance over a weekend either, so Friday's frontier
+    read against Monday's corpus is the same 1 it read on Friday. A calendar
+    threshold would have to absorb a three-day weekend and would then be too
+    loose to catch the two-day outage it exists for.
+    """
+    friday_to_monday = _assess({(_S1, _CURRENT): date(2026, 8, 7)}, trading_dates=_TRADING_DATES[:8])
+    assert (friday_to_monday.corpus_date, friday_to_monday.lag_bars) == (date(2026, 8, 10), 1)
+    assert friday_to_monday.status == "ok"
+
+
+def test_a_rotation_with_a_recent_prior_scan_is_not_an_alert() -> None:
+    """The state between a registry-touching merge and the next 06:45 tick.
+
+    A rotation does NOT trigger a scan — the job is a scheduled daily one with no
+    rotation hook — so the live version has no track record for up to ~24h.
+    Without this state the check fires on every registry-touching merge, which is
+    the false positive #2624's own text rules out.
+    """
+    verdict = _assess({(_S1, _PRIOR): date(2026, 8, 11)})
+    assert (verdict.status, verdict.basis, verdict.lag_bars) == ("rotated_awaiting_scan", "fallback", 1)
+    assert not verdict.is_alerting
+
+
+def test_a_rotation_whose_prior_scan_is_also_behind_alerts() -> None:
+    """#2624's measured 2026-08-12 symptom, which is what this ticket is for.
+
+    Four versions rotated, 0 rows under them, max signal bar days behind. The
+    verdict does not need a rotation timestamp — ``strategy_scan_watermark``
+    stores none — because the operator-visible truth is the same either way: no
+    scan under this strategy has reached within reach of the corpus.
+    """
+    verdict = _assess({(_S1, _PRIOR): date(2026, 8, 6)})
+    assert (verdict.status, verdict.basis, verdict.lag_bars) == ("rotated_scan_overdue", "fallback", 4)
+    assert verdict.is_alerting
+
+
+def test_the_newest_prior_version_wins_the_fallback() -> None:
+    """Two stale versions and one recent one must not read as stale."""
+    verdict = _assess(
+        {
+            (_S1, _PRIOR): date(2026, 8, 11),
+            (_S1, "strategy-registry-v1+000000000000"): date(2026, 7, 30),
+        }
+    )
+    assert (verdict.status, verdict.frontier_date) == ("rotated_awaiting_scan", date(2026, 8, 11))
+
+
+def test_a_watermark_ahead_of_the_corpus_is_a_regression_not_health() -> None:
+    """A rewash, a restore, or a rule-set bump that emptied the coverage table.
+
+    ``run_signal_scan`` has its own branch for this (``declining to write``). It
+    MUST be tested before the lag comparison: a regressed corpus makes the lag
+    read 0, which is the healthiest number there is. Caught by Codex at
+    checkpoint 1, where the first draft's ``ok`` swallowed it silently.
+    """
+    verdict = _assess({(_S1, _CURRENT): date(2026, 8, 20)})
+    assert verdict.status == "frontier_regressed"
+    assert verdict.is_alerting
+
+
+def test_a_strategy_with_no_watermark_under_any_version_is_never_scanned() -> None:
+    """Reported, but NOT alerting — a decision this repo already settled.
+
+    ``_derive_overall_status``' docstring refuses to degrade the headline for a
+    job with no runs ever recorded, because a fresh deploy would then always read
+    degraded for having not started yet, and the empty data layers are the more
+    meaningful signal. ``never_scanned`` is the strategy-scan analogue.
+
+    Found by ``test_api_system``'s healthy-system fixtures, which have no
+    watermarks at all and began reading ``degraded`` when this status alerted.
+    The 2026-08-12 symptom the ticket exists for is unaffected: that is
+    ``rotated_scan_overdue``, which by definition has prior watermarks.
+    """
+    verdict = _assess({})
+    assert (verdict.status, verdict.basis, verdict.frontier_date) == ("never_scanned", None, None)
+    assert not verdict.is_alerting
+
+
+def test_an_empty_corpus_is_contained_rather_than_raising() -> None:
+    """Reachable only pre-bootstrap, and an unassessable strategy still gets a row."""
+    verdict = _assess({(_S1, _CURRENT): date(2026, 8, 11)}, trading_dates=[])
+    assert verdict.status == "error"
+    assert verdict.detail is not None
+
+
+def test_a_lag_beyond_the_loaded_window_is_reported_as_inexact() -> None:
+    """A number that looks precise and is not would be the worse failure.
+
+    The reader loads a bounded window, so a watermark older than it cannot yield
+    a true lag. The status is unaffected — it is over the threshold either way —
+    but ``lag_exact`` marks the figure as a lower bound rather than letting the
+    operator read the window size as the answer.
+    """
+    verdict = _assess({(_S1, _CURRENT): date(2026, 1, 5)})
+    assert (verdict.status, verdict.lag_bars, verdict.lag_exact) == ("stale", len(_TRADING_DATES), False)
+
+
+def test_every_manifest_strategy_gets_exactly_one_verdict() -> None:
+    """A strategy with no verdict is a strategy nothing reports on."""
+    versions = {"a": "v1", "b": "v1", "c": "v1"}
+    results = assess_scan_freshness(
+        current_versions=versions,
+        watermarks={("a", "v1"): date(2026, 8, 11)},
+        trading_dates=_TRADING_DATES,
+    )
+    assert [entry.strategy_id for entry in results] == ["a", "b", "c"]
+    assert [entry.status for entry in results] == ["ok", "never_scanned", "never_scanned"]
+
+
+def test_a_failed_probe_leaves_the_connection_usable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The containment claim, tested as CONTAINMENT and not just as a caught error.
+
+    ``get_conn`` hands out a NON-autocommit connection, so a failed query leaves
+    Postgres' transaction aborted and catching the exception does not clear it —
+    the next statement raises ``InFailedSqlTransaction``. In
+    ``get_system_status`` that next statement is
+    ``_build_credential_health_summary``, which sits outside the handler's guard,
+    so a bare try/except would turn the intended ``error`` row into an HTTP 500.
+
+    The fake connection models exactly that rule: statements raise while
+    ``aborted`` is set, and only ``rollback`` (what ``conn.transaction()`` issues
+    on the savepoint) clears it. Asserting ``status == "error"`` alone would pass
+    against the broken version, which is why the post-condition is a SUBSEQUENT
+    query rather than the returned row.
+    """
+
+    class _FakeTransaction:
+        def __init__(self, conn: _FakeConn) -> None:
+            self._conn = conn
+
+        def __enter__(self) -> _FakeTransaction:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+            if exc_type is not None:
+                self._conn.aborted = False  # the savepoint rollback
+            return False
+
+    class _FakeConn:
+        def __init__(self) -> None:
+            self.aborted = False
+
+        def transaction(self) -> _FakeTransaction:
+            return _FakeTransaction(self)
+
+        def execute(self, *_args: object, **_kwargs: object) -> object:
+            if self.aborted:
+                raise RuntimeError("InFailedSqlTransaction")
+            self.aborted = True
+            raise RuntimeError("probe blew up")
+
+    conn = _FakeConn()
+    monkeypatch.setattr(
+        "app.services.strategy_scan_freshness.read_scan_freshness_inputs",
+        lambda c: c.execute("SELECT 1"),
+    )
+
+    verdicts = check_scan_freshness(conn)  # type: ignore[arg-type]
+
+    assert [v.status for v in verdicts] == ["error"]
+    assert verdicts[0].is_alerting
+    # The post-condition that actually distinguishes contained from poisoned.
+    assert not conn.aborted, "a failed probe left the connection in an aborted transaction"


### PR DESCRIPTION
**Scope 3 of #2624 only. The ticket stays OPEN** — scopes 1 and 2 change the overview payload and the page that renders it, and `:5173` is down in this worktree, so the change-coupled FE-QA rule cannot be satisfied for them. Scope 3 has no render and is verifiable against `:8000`, which is why it separates cleanly (per the 18:33 triage on the issue).

## What this adds

The signal nothing else carries: `strategy_signal_scan` **succeeded** and a strategy's current identity version still has no track record within reach of the corpus. `check_job_health` sees a *failed* run; the layer checks see a stale corpus; neither sees a green job that left the live version dark — the #2218 invisible-no-op class this ticket is about.

## Two premises in the ticket are falsified, and both changed the design

### 1. The signal table is the wrong observable

The ticket asks for *"current version has no **signal** newer than N days"*. Measured on dev:

| strategy | current version | signals | watermark |
| --- | --- | --- | --- |
| s1 | `+67dbf07c9d72` | 3,109 | 2026-08-11 |
| **s2** | `+83967fcb1fca` | **0 under any version** | **2026-08-11** |
| s3 | `+d58989368716` | 1,950 | 2026-08-11 |
| s4 | `+91aadde63f07` | 186 | 2026-08-11 |

s2 scans successfully and emits nothing. A signal is an **output whose emptiness is a legitimate outcome** — `scheduler.py::strategy_signal_scan`'s own docstring: *"`row_count` is signals WRITTEN, and zero is a legitimate success"*. Ageing signals would have alerted on s2 permanently with no input that could ever clear it: the false-positive class the ticket's own text rules out, one table over from where it looked.

`strategy_scan_watermark` records the **attempt** — a row per `(strategy_id, strategy_version)` on every successful scan regardless of signal count, which is exactly why s2 has one.

### 2. "…while prices are fresh" cannot be built on the prices layer, and is not needed

The obvious build is `and check_layer_staleness(conn, "prices") == ok`. Measured 2026-08-13 19:10 UTC on a healthy system:

```
prices layer NOW: stale   latest 2026-08-12 00:00:00+00   age 1 day 19:10:14   max_age 4:00:00
```

`_LAYER_QUERIES["prices"]` is `MAX(price_date)::timestamptz` — **midnight of the last trading date** — aged against a **4-hour** threshold, so that layer is `stale` from ~04:00 UTC every day and for every weekend. The conjunct would have suppressed this check essentially always: a control that cannot fire, shipped green.

It is also **unnecessary**. Measuring the lag in *trading days against `price_daily` itself* is self-suppressing by construction — a corpus that stops advancing cannot grow the lag, so a price outage holds a strategy at its current lag rather than blaming the scan for it. A structural suppression beats a conditional one, and removes the term instead of fixing it.

## Source rule — the threshold is derived, not picked

No published formulation governs this, so it is fixed by construction with the construction stated:

| term | value | where it comes from |
| --- | --- | --- |
| by-design arrears | 1 trading bar | the job's own description: *"Runs one bar in ARREARS: a signal on the last bar of a series has no t+1"* |
| one missed run | 1 trading bar | daily at 06:45 UTC, so one missed tick costs one bar. Matches `_STALENESS_THRESHOLDS`' own convention (*"2 days allows for a missed night"*) |
| `_MAX_SCAN_LAG_BARS` | **2** | the sum. Alert strictly above. |

**Trading days, not calendar days** — that is what removes the weekend from the threshold rather than padding it away; `price_daily` does not advance over a weekend either, so a healthy Monday reads the same `1` it read on Friday. A calendar threshold would have to absorb a three-day weekend plus holidays and would then be too loose to catch the two-day outage it exists for.

⚠ Detection latency is **not** the same number, and the spec says so: baseline `1` + one missed session reads `2` and stays healthy, so the check turns red only once a *second* missed bar becomes visible.

Verified live: all four strategies read lag **1** (corpus `2026-08-12`, frontier `2026-08-11`).

## States, all reachable

`ok` · `stale` · `rotated_awaiting_scan` · `rotated_scan_overdue` · `frontier_regressed` · `never_scanned` · `error`

- **A rotation does not trigger a scan** — the job is a scheduled daily one with no rotation hook, so a new version has no track record for up to ~24h. `rotated_awaiting_scan` is that window and does not alert; without it the check would fire on every registry-touching merge, which is the false positive the triage warned about.
- `rotated_scan_overdue` is #2624's measured 08-12 symptom.
- **`never_scanned` reports but does NOT alert** — `_derive_overall_status`' own docstring already settles this shape: *"a fresh deploy would otherwise always report 'degraded' purely because no jobs have fired yet … the empty data layers [are] the more meaningful signal anyway."* The first draft alerted, and `test_api_system`'s healthy-system fixtures went `degraded`, which is how it surfaced.
- **`strategy_scan_watermark` stores no rotation timestamp**, so the classification deliberately does not depend on one: it ages the newest watermark on *any* version, which answers the question that matters — has this strategy scanned recently — whether it is dark from a rotation or from an outage.

## Codex

**Checkpoint 1** added `frontier_regressed`, which the first draft's `ok` swallowed **silently**: a regressed corpus makes the lag read `0`, the healthiest number there is, and `run_signal_scan` has its own branch for that case (*"the corpus regressed … declining to write"*). It also showed the rotation-timestamp gap above, and the `prices`-layer defect.

**Checkpoint 2** raised two P1s. Both confirmed by measurement, both fixed:

1. **Full-corpus seq scan on a polled endpoint.** `EXPLAIN (ANALYZE, BUFFERS)`: Parallel Seq Scan over 6,755,721 rows, **70,183 buffers, 279 ms**.
   ⚠ **Its proposed remedy was measured too, and the index alone does not fix it.** With `idx_price_daily_price_date` the query becomes `Limit -> Unique -> Index Scan Backward`, which stops after the 30th distinct date but still reads *every row* of each — ~3,400 instruments per date: **93,734 buffers, 57 ms warm / 523 ms cold**. That trades a cost growing with the corpus for one growing with rows-per-key. The reader therefore uses a **loose index scan** (recursive `max()` walk, one probe per distinct date): **130 buffers, 1.0 ms**. The index makes those probes index-only; the recursion makes them 30 instead of 100,000 — neither works without the other. End-to-end `check_scan_freshness` is ~2 ms per poll after warm-up.
2. **A bare `try/except` is not containment on a transactional connection.** `get_conn` hands out a non-autocommit connection, so a failed query leaves the transaction aborted and catching the exception does not clear it; the next statement raises `InFailedSqlTransaction`, and in `get_system_status` that next statement is `_build_credential_health_summary`, which sits *outside* the handler's guard — so the intended `error` row would have become an HTTP 500. Verified both ways on dev; fixed with `conn.transaction()`.

## Verification

- Exercised end-to-end against the **real dev DB** through the handler's own path (`check_scan_freshness` → `_scan_freshness_to_response` → `_derive_overall_status`): four `ok` rows, and `overall_status` is `degraded` **both with and without** the new contributor — i.e. no false alarm introduced. It is already degraded because the `prices` layer is stale, which is the pre-existing normal state.
- `sql/345` applied, then **reverted and replayed from scratch** after the checkpoint-2 amendment rather than nulling its content hash.
- Lint / format / pyright clean; fast tier + smoke green; `-m db tests/test_api_system.py tests/test_ops_monitor.py` green.

## Tests

Pure table tests (no DB), per the repo's lean-test rule — every state, both threshold boundaries, the weekend case, the s2 zero-signal case, and the inexact-lag reporting. The containment test's post-condition is a **subsequent query on the connection**, not the returned row, because asserting `status == "error"` alone passes against the broken version.

## Filed, not fixed here

**#2674** — `check_all_layers` has the identical containment defect, pre-existing: one failing layer poisons the transaction, so all eight report `error` and `/system/status` then 500s in `_build_credential_health_summary`. Its docstring promises *"the rest of the report still renders"*. Filed separately rather than folded in, since the fix touches a different module on a shared health path.

## Security

No new surface. The endpoint keeps its existing `require_session_or_service_token` router dependency; the new field carries dates, counts and a fixed-string detail — no driver text, SQL fragments or table names, matching the existing per-layer `detail` discipline.

## Prevention

Three entries in `docs/review-prevention-log.md`:

- **An output whose emptiness is a legitimate outcome cannot be aged** — age the artefact that records the *attempt*, not the *result*. Test with the real empty case; s2 exists.
- **A conjunct on an existing health signal inherits that signal's semantics, not its name** — evaluate it against live data before ANDing it in, then ask whether it is needed at all.
- **An index is not automatically the fix for a seq scan** — `Unique` over an index still walks every row of each distinct value. Compare *buffers*, not milliseconds; a warm cache hides the read volume.

Refs #2624. Refs #2674. Refs #2218.