### PR TITLE
fix(#2674): contain a failed health probe in a savepoint, not just a try/except

### DIFF
--- a/.claude/skills/ops-monitor/SKILL.md
+++ b/.claude/skills/ops-monitor/SKILL.md
@@ -145,11 +145,23 @@ subsystem is dead, confirm it in-process before writing it into a ticket.**
 
 Missing critical source data, stale timestamps beyond threshold, or
 contradictory evidence must surface as an EXPLICIT signal — never a neutral
-default. `check_all_layers` wraps each layer query in try/except and emits
-`LayerHealth(status="error", detail=<fixed string>)` per broken layer rather
-than 500-ing the whole report or silently reporting "fresh" (prevention-log #70:
-never let an infra fault degrade into a silent HTTP 200). Treat silent failure as
-failure; prefer noisy ops to false confidence; record enough detail to debug.
+default. `check_all_layers` runs each layer query in its own **SAVEPOINT**
+(`with conn.transaction():`) and emits `LayerHealth(status="error",
+detail=<fixed string>)` per broken layer rather than 500-ing the whole report or
+silently reporting "fresh" (prevention-log #70: never let an infra fault degrade
+into a silent HTTP 200). Treat silent failure as failure; prefer noisy ops to
+false confidence; record enough detail to debug.
+
+⚠ **The savepoint is the containment; a bare try/except is NOT** (#2674, fixed
+2026-08-13). `get_conn` hands out a non-autocommit pooled connection, so a failed
+query leaves the transaction ABORTED and every later statement raises
+`InFailedSqlTransaction` — one broken layer used to fail all eight and then 503
+the endpoint (measured on dev: the poisoned `_read_jobs_boot_error` trips the
+handler's guard), or 500 it via `_build_credential_health_summary`, which runs
+outside that guard. The same rule binds every best-effort probe sharing the
+connection (`_stalled_job_names`, `_jobs_process_down`, `check_scan_freshness`).
+When testing one, the post-condition must be a SUBSEQUENT statement — asserting
+the `error` row alone passes against the broken version.
 
 ## Orchestrator / sync health signals — real failure vs expected noise
 

--- a/app/api/system.py
+++ b/app/api/system.py
@@ -389,13 +389,20 @@ def _stalled_job_names(conn: psycopg.Connection[object], now: datetime) -> set[s
     headline degradation is a nice-to-have, not load-bearing for the page. Uses
     the SAME orchestrator exclusion as the watchdog: ``orchestrator_*`` jobs write
     ``sync_runs`` not ``job_runs`` and would otherwise false-stall.
+
+    ⚠ The savepoint is what makes "degrades gracefully" true (#2674): on the
+    non-autocommit pooled connection, a bare catch leaves the transaction aborted
+    and the NEXT probe fails — here that is ``_build_credential_health_summary``,
+    which runs outside the handler's guard and would 500 the page this function
+    is promising not to 503.
     """
     try:
         from app.services.job_liveness import find_stalled_jobs
 
         excluded = {JOB_ORCHESTRATOR_FULL_SYNC, JOB_ORCHESTRATOR_HIGH_FREQUENCY_SYNC}
         jobs = [(j.name, j.cadence) for j in SCHEDULED_JOBS if j.name not in excluded]
-        return {s.job_name for s in find_stalled_jobs(conn, jobs, now)}
+        with conn.transaction():
+            return {s.job_name for s in find_stalled_jobs(conn, jobs, now)}
     except Exception:
         logger.warning("get_system_status: stall probe failed; headline stall signal omitted", exc_info=True)
         return set()
@@ -615,9 +622,14 @@ def _jobs_process_down(conn: psycopg.Connection[object], now: datetime) -> bool:
     page. Best-effort: any failure returns ``False`` so a probe error never
     503s ``/system/status`` — the headline degradation is a nice-to-have, the
     per-layer rows already carry the underlying fault.
+
+    ⚠ Savepoint per #2674, same reason as ``_stalled_job_names``: catching the
+    exception without rolling back leaves the shared connection aborted, so the
+    "never 503s" promise held only until the next probe ran.
     """
     try:
-        return _build_jobs_process_health(conn, now).state == "down"
+        with conn.transaction():
+            return _build_jobs_process_health(conn, now).state == "down"
     except Exception:
         logger.warning(
             "get_system_status: jobs-process heartbeat probe failed; engine-down signal omitted",
@@ -665,6 +677,22 @@ def _build_credential_health_summary(conn: psycopg.Connection[object]) -> Creden
     Falls back to MISSING when no operator yet so the admin UI shows
     the "save credentials in Settings" path on a fresh install rather
     than misreporting VALID.
+
+    ⚠ This is the function #2674 was reported ON: it runs OUTSIDE
+    ``get_system_status``'s 503 guard, so anything it raises is an HTTP
+    **500**. Two changes keep that from happening:
+
+    * ``sole_operator_id`` is now inside the guarded block. It previously
+      caught only the two operator-cardinality errors, so a DB-level fault
+      on the same lookup — poisoned transaction or otherwise — escaped and
+      500'd the page.
+    * the reads run in a SAVEPOINT, so a failure here leaves the connection
+      usable for the caller rather than merely the exception caught.
+
+    MISSING on a read failure is the SAME verdict the inner catch already
+    reported, not a new one — an honest 503 on a DB-level fault is
+    ``get_conn``'s job (``app/db/__init__.py``), which fires before any
+    handler code runs.
     """
     from app.services.credential_health import (
         CredentialHealth,
@@ -677,26 +705,27 @@ def _build_credential_health_summary(conn: psycopg.Connection[object]) -> Creden
         sole_operator_id,
     )
 
+    worst_health: CredentialHealth | None = None
+    recovered_at = None
+    last_error = None
     try:
-        op_id = sole_operator_id(conn)
-    except NoOperatorError:
+        # No early `return` inside the savepoint (prevention log, "Early return
+        # inside `with conn.transaction()`"): an empty `environments` leaves
+        # `worst_health` None and falls through to the same MISSING below.
+        with conn.transaction():
+            op_id = sole_operator_id(conn)
+            for env in _operator_environments(conn, op_id):
+                env_health = get_operator_credential_health(conn, operator_id=op_id, environment=env)
+                if worst_health is None or _is_worse(env_health, worst_health):
+                    worst_health = env_health
+
+            if worst_health is not None:
+                recovered_at = get_last_recovered_at(conn, operator_id=op_id)
+                last_error = (
+                    _latest_credential_error(conn, op_id) if worst_health == CredentialHealth.REJECTED else None
+                )
+    except NoOperatorError, AmbiguousOperatorError:
         return CredentialHealthSummary(state="missing")
-    except AmbiguousOperatorError:
-        return CredentialHealthSummary(state="missing")
-
-    try:
-        environments = _operator_environments(conn, op_id)
-        if not environments:
-            return CredentialHealthSummary(state="missing")
-
-        worst_health: CredentialHealth | None = None
-        for env in environments:
-            env_health = get_operator_credential_health(conn, operator_id=op_id, environment=env)
-            if worst_health is None or _is_worse(env_health, worst_health):
-                worst_health = env_health
-
-        recovered_at = get_last_recovered_at(conn, operator_id=op_id)
-        last_error = _latest_credential_error(conn, op_id) if worst_health == CredentialHealth.REJECTED else None
     except Exception:
         logger.exception("credential_health summary lookup failed; reporting missing")
         return CredentialHealthSummary(state="missing")

--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -362,7 +362,7 @@ def check_all_layers(
 ) -> list[LayerHealth]:
     """Check staleness for every monitored data layer.
 
-    Each per-layer query is wrapped in a try/except so a single broken layer
+    Each per-layer query runs in its own SAVEPOINT so a single broken layer
     (e.g. table missing during a partial migration) yields a ``LayerHealth``
     with ``status="error"`` instead of bubbling out and 500-ing the entire
     operator visibility endpoint.
@@ -370,12 +370,27 @@ def check_all_layers(
     Prevention-log #70: never let an infra-level fault degrade into a silent
     HTTP 200; here we surface it per-layer so the operator can see *which*
     layer failed, while the rest of the report still renders.
+
+    ⚠ ``conn.transaction()`` is what makes that last clause TRUE, and the
+    try/except alone did not (#2674).  ``get_conn`` hands out a NON-autocommit
+    pooled connection, so a failed query leaves Postgres' transaction ABORTED;
+    catching the Python exception does not clear it, and every later statement on
+    the same connection raises ``InFailedSqlTransaction``.  So ONE broken layer
+    used to fail all eight — seven of them for a reason unrelated to their own
+    health, which also hides which layer started it — and then took out
+    ``check_job_health`` and ``_build_credential_health_summary`` downstream, i.e.
+    exactly the whole-endpoint failure this containment exists to prevent.
+
+    The general shape, for the next reader: **a try/except around a DB call
+    contains the exception, not the transaction.**  It reads as correct at the
+    call site because the damage lands on an unrelated later statement.
     """
     now = now or _utcnow()
     results: list[LayerHealth] = []
     for layer in ALL_LAYERS:
         try:
-            results.append(check_layer_staleness(conn, layer, now=now))
+            with conn.transaction():
+                results.append(check_layer_staleness(conn, layer, now=now))
         except Exception:
             # Full exception detail goes to the server-side log only.
             # The `detail` field is surfaced verbatim in the API response,

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -4538,3 +4538,34 @@ with `verify_2598_preflight_quote_crosscheck.py --replay <fixture>`:
 - Enforced in: `sql/345_price_daily_price_date_index.sql` (header carries all three
   measurements and states that the index alone is insufficient);
   `app/services/strategy_scan_freshness.py::_RECENT_TRADING_DATES`.
+
+### A `try/except` around a DB call contains the exception, not the transaction
+
+- First seen in: #2624 scope 3 (Codex checkpoint 2, in new code), then #2674 (the same defect
+  already shipped in `check_all_layers`, `_stalled_job_names`, `_jobs_process_down` and
+  `_build_credential_health_summary`).
+- Symptom: `check_all_layers`' docstring promised "the rest of the report still renders" and
+  it did not. `get_conn` hands out a **non-autocommit** pooled connection, so a failed query
+  leaves Postgres' transaction ABORTED; catching the Python exception does not clear that, and
+  every later statement on the same connection raises `InFailedSqlTransaction`. Measured on
+  dev: `caught: UndefinedTable` → `subsequent query RAISES: InFailedSqlTransaction`; the same
+  failure inside `conn.transaction()` → `after savepoint: OK`. So ONE broken layer failed all
+  eight — seven of them for a reason unrelated to their own health, which also hides which
+  layer started it — and then took out `_build_credential_health_summary`, which runs outside
+  the handler's 503 guard, turning a per-layer `error` row into an HTTP **500** on the page
+  whose entire job is to stay readable when something is broken.
+- The general shape: **containment on a transactional connection is `with conn.transaction():`
+  (a savepoint), not `try/except`.** The bare catch reads as correct at the call site precisely
+  because the damage lands on an unrelated later statement.
+- Prevention: any `try/except` whose justification is "best-effort, must not fail the caller"
+  around a DB call on a **caller-supplied** connection needs the savepoint. Grep the handler
+  for every probe that shares one connection and check each — the fault propagates forward, so
+  the LAST reader is where it surfaces and the FIRST is where it starts. ⚠ A test asserting the
+  returned `error` row PASSES against the broken version (`check_all_layers`' pre-existing
+  `test_single_layer_failure_does_not_abort_others` did); the post-condition that distinguishes
+  contained from poisoned is a **subsequent statement on the same connection**.
+- Enforced in: `app/services/ops_monitor.py::check_all_layers`;
+  `app/api/system.py::_stalled_job_names` / `_jobs_process_down` /
+  `_build_credential_health_summary`; `app/services/strategy_scan_freshness.py::check_scan_freshness`;
+  `tests/test_2674_status_probe_containment.py`;
+  `tests/test_ops_monitor.py::TestCheckAllLayers::test_a_failed_layer_leaves_the_connection_usable`.

--- a/tests/test_2674_status_probe_containment.py
+++ b/tests/test_2674_status_probe_containment.py
@@ -1,0 +1,113 @@
+"""`/system/status` probe containment on a shared transactional connection (#2674).
+
+The defect these pin: **a `try/except` around a DB call contains the exception,
+not the transaction.** ``get_conn`` hands out a NON-autocommit pooled
+connection, so a failed query leaves Postgres' transaction aborted; catching the
+Python exception does not clear it, and every later statement on that connection
+raises ``InFailedSqlTransaction``. The damage therefore lands on an unrelated
+later probe, which is why the broken code reads as correct at the call site.
+
+Measured on dev before the fix:
+
+    caught: UndefinedTable
+    subsequent query RAISES: InFailedSqlTransaction
+    --- same failure inside conn.transaction() ---
+    caught in savepoint: UndefinedTable
+    after savepoint: OK
+
+Kept pure (no Postgres) so these sit in the fast tier: the fakes below model the
+one rule that matters — statements raise while ``aborted`` is set, and only the
+savepoint rollback clears it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.api.system import (
+    _build_credential_health_summary,
+    _jobs_process_down,
+    _stalled_job_names,
+)
+
+_NOW = datetime(2026, 8, 13, 12, 0, 0, tzinfo=UTC)
+
+
+class _FakeTransaction:
+    def __init__(self, conn: FakeConn) -> None:
+        self._conn = conn
+
+    def __enter__(self) -> _FakeTransaction:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        if exc_type is not None:
+            self._conn.aborted = False  # the savepoint rollback
+        return False
+
+
+class FakeConn:
+    """A connection that models Postgres' aborted-transaction rule.
+
+    Any statement poisons the transaction on the way out; every later
+    statement then fails with ``InFailedSqlTransaction`` until a savepoint
+    rollback clears it. That is the whole behaviour under test.
+    """
+
+    def __init__(self) -> None:
+        self.aborted = False
+
+    def transaction(self) -> _FakeTransaction:
+        return _FakeTransaction(self)
+
+    def blow_up(self) -> None:
+        if self.aborted:
+            raise RuntimeError("InFailedSqlTransaction")
+        self.aborted = True
+        raise RuntimeError("relation does not exist")
+
+    def next_statement_ok(self) -> bool:
+        return not self.aborted
+
+
+def test_stalled_job_probe_leaves_the_connection_usable(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConn()
+    monkeypatch.setattr(
+        "app.services.job_liveness.find_stalled_jobs",
+        lambda c, jobs, now: c.blow_up(),
+    )
+
+    assert _stalled_job_names(conn, _NOW) == set()  # type: ignore[arg-type]
+    assert conn.next_statement_ok(), "a failed stall probe left the transaction aborted"
+
+
+def test_jobs_process_probe_leaves_the_connection_usable(monkeypatch: pytest.MonkeyPatch) -> None:
+    conn = FakeConn()
+    monkeypatch.setattr(
+        "app.api.system._build_jobs_process_health",
+        lambda c, now: c.blow_up(),
+    )
+
+    assert _jobs_process_down(conn, _NOW) is False  # type: ignore[arg-type]
+    assert conn.next_statement_ok(), "a failed heartbeat probe left the transaction aborted"
+
+
+def test_credential_summary_reports_missing_instead_of_500ing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The endpoint-level consequence, at the function it actually lands on.
+
+    ``_build_credential_health_summary`` runs OUTSIDE ``get_system_status``'s
+    503 guard, and its ``sole_operator_id`` lookup previously caught only the
+    two operator-cardinality errors — so a DB-level fault there (the poisoned
+    transaction, before the fix upstream; its own fault, after) escaped as an
+    HTTP 500 on the page whose entire job is to stay readable when something
+    is broken.
+    """
+    conn = FakeConn()
+    monkeypatch.setattr("app.services.operators.sole_operator_id", lambda c: c.blow_up())
+
+    summary = _build_credential_health_summary(conn)  # type: ignore[arg-type]
+
+    assert summary.state == "missing"
+    assert conn.next_statement_ok(), "a failed credential lookup left the transaction aborted"

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -197,6 +197,80 @@ class TestCheckAllLayers:
             if layer != "universe":
                 assert status == "ok", f"layer {layer} should be ok, got {status}"
 
+    def test_a_failed_layer_leaves_the_connection_usable(self) -> None:
+        """The containment claim tested as CONTAINMENT, not as a caught error (#2674).
+
+        ``get_conn`` hands out a NON-autocommit pooled connection, so a failed
+        query leaves Postgres' transaction aborted and catching the Python
+        exception does not clear it — every later statement raises
+        ``InFailedSqlTransaction``. So the broken version failed ALL eight
+        layers off ONE bad table (seven of them for a reason unrelated to their
+        own health, which also hides which layer started it) and then 500'd
+        ``/system/status`` via ``_build_credential_health_summary``.
+
+        The fake models exactly that rule: statements raise while ``aborted``
+        is set, and only the savepoint rollback clears it. Note
+        ``test_single_layer_failure_does_not_abort_others`` above PASSES
+        against the broken version — asserting the ``error`` row cannot
+        distinguish contained from poisoned, so the post-condition here is a
+        SUBSEQUENT statement.
+        """
+
+        class _FakeTransaction:
+            def __init__(self, conn: _FakeConn) -> None:
+                self._conn = conn
+
+            def __enter__(self) -> _FakeTransaction:
+                return self
+
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> bool:
+                if exc_type is not None:
+                    self._conn.aborted = False  # the savepoint rollback
+                return False
+
+        class _FakeCursor:
+            def __init__(self, conn: _FakeConn) -> None:
+                self._conn = conn
+
+            def __enter__(self) -> _FakeCursor:
+                return self
+
+            def __exit__(self, *_exc: object) -> bool:
+                return False
+
+            def execute(self, *_args: object, **_kwargs: object) -> None:
+                if self._conn.aborted:
+                    raise RuntimeError("InFailedSqlTransaction")
+                if self._conn.queries == 0:  # the one genuinely broken layer
+                    self._conn.aborted = True
+                    self._conn.queries += 1
+                    raise RuntimeError("relation 'instruments' does not exist")
+                self._conn.queries += 1
+
+            def fetchone(self) -> dict[str, Any]:
+                return {"latest": _NOW - timedelta(hours=1)}
+
+        class _FakeConn:
+            def __init__(self) -> None:
+                self.aborted = False
+                self.queries = 0
+
+            def transaction(self) -> _FakeTransaction:
+                return _FakeTransaction(self)
+
+            def cursor(self, **_kwargs: object) -> _FakeCursor:
+                return _FakeCursor(self)
+
+        conn = _FakeConn()
+        results = check_all_layers(conn, now=_NOW)  # type: ignore[arg-type]
+
+        status_map = {r.layer: r.status for r in results}
+        assert status_map["universe"] == "error"
+        # Exactly ONE error: the seven healthy layers are not collateral damage.
+        assert sum(1 for s in status_map.values() if s == "error") == 1
+        # The post-condition that distinguishes contained from poisoned.
+        assert not conn.aborted, "a failed layer left the connection in an aborted transaction"
+
     def test_mixed_status_layers(self) -> None:
         # universe: fresh, prices: stale, rest: empty
         fresh = _NOW - timedelta(hours=1)


### PR DESCRIPTION
## What

`app/services/ops_monitor.py::check_all_layers` promised in its docstring that a single broken layer yields one `status="error"` row while *"the rest of the report still renders"*. On the connection `/system/status` actually uses, it did not.

`get_conn` (`app/db/__init__.py`) hands out a **non-autocommit** pooled connection. A failed query leaves Postgres' transaction ABORTED, and catching the Python exception does not clear it — every later statement on that connection raises `InFailedSqlTransaction`. So the fault propagates forward through every probe sharing the connection, and lands somewhere with no visible link to the cause.

**A `try/except` around a DB call contains the exception, not the transaction.**

## Measured, on the real dev DB

One layer query repointed at a missing table, calling the real `get_system_status` handler on a real non-autocommit connection:

| | layers | error rows | outcome |
|---|---|---|---|
| before | 8 | **8** | **HTTP 503** |
| after | 8 | **1** (`universe`) | **HTTP 200** — `credential_health=valid`, `engine_down=False`, 4 scan-freshness rows |

Seven of those eight failed for a reason unrelated to their own health, which also hides which layer started it. The 503 comes from the poisoned `_read_jobs_boot_error` tripping the handler's own guard; when the poisoning lands *after* that guard closes it is a **500** via `_build_credential_health_summary`, which is how the issue was originally observed. Either way the whole page dies — the exact failure the containment exists to prevent.

The primitive, confirmed directly:

```
autocommit: False
caught: UndefinedTable
subsequent query RAISES: InFailedSqlTransaction
--- same failure inside conn.transaction() ---
caught in savepoint: UndefinedTable
after savepoint: OK
```

## Change

Every best-effort probe on the shared connection now runs in its own SAVEPOINT (`with conn.transaction():`), which rolls back to the savepoint on failure and leaves the connection usable:

- `ops_monitor.check_all_layers` — per layer
- `system._stalled_job_names`
- `system._jobs_process_down`

`system._build_credential_health_summary` gets the savepoint **plus** one behavioural change: its `sole_operator_id` lookup moves inside the guarded block. It previously caught only `NoOperatorError` / `AmbiguousOperatorError`, so a DB-level fault on that lookup escaped as an HTTP 500 — on the page whose entire job is to stay readable when something is broken. It now reports `missing`, which is the verdict its own inner catch already returned for any read failure, not a new one; an honest 503 on a DB-level fault is `get_conn`'s job and fires before any handler code runs. The empty-`environments` early return is hoisted out of the `with` block (prevention log, "Early return inside `with conn.transaction()`").

**Checked, not assumed** (the issue asked for this explicitly): the handler's other two DB calls, `check_job_health` and `_read_jobs_boot_error`, sit inside the documented 503 guard and make no containment claim, so they are deliberately unchanged. `check_scan_freshness` was already fixed in #2624 scope 3.

No `conn.commit()` is added anywhere: these are read-only probes on a caller-supplied connection, so the "savepoint release does not commit the outer transaction" trap does not apply — the caller owns the lifecycle.

## Tests

`tests/test_2674_status_probe_containment.py` (3 tests, **fast tier** — pure, no Postgres) and `tests/test_ops_monitor.py::TestCheckAllLayers::test_a_failed_layer_leaves_the_connection_usable`.

⚠ The post-condition in each is a **subsequent statement on the same connection**, not the returned `error` row. That distinction is the whole point: the pre-existing `test_single_layer_failure_does_not_abort_others` asserts the error row and **passes against the broken version**, which is precisely why this defect shipped and sat.

Revert-probed, each savepoint removed in turn:

- `check_all_layers` → `assert 8 == 1` (all eight layers error)
- the three `system.py` probes → all three fail on `left the transaction aborted`

## Verification

- `ruff check` / `ruff format --check` / `pyright`: clean
- fast tier (`-m "not db"`) + `tests/smoke`: pass
- db tier, touched modules: `tests/test_ops_monitor.py` + `tests/test_api_system.py`, 78 tests, pass
- Codex checkpoint 2 (`review --base origin/main`): no actionable findings
- dev-verify: the before/after table above is the real handler against the real dev DB, not a fixture

## Security

No change to the security model. The `error` detail stays the fixed `LAYER_QUERY_FAILED_DETAIL_TEMPLATE` string (prevention-log #86: no driver/SQL text in response bodies) — full detail goes to the server log only. The credential-summary change reports `missing` where it previously 500'd; it exposes nothing new and no new code path reads credentials.

## Prevention

- `docs/review-prevention-log.md` — new entry: *"A `try/except` around a DB call contains the exception, not the transaction"*
- `.claude/skills/ops-monitor/SKILL.md` — the "Failure conditions" section said `check_all_layers` "wraps each layer query in try/except", which was both stale and the wrong lesson

Closes #2674. Refs #2624.