### PR TITLE
feature(#2624): show where the track record went, instead of a blank card (scopes 1 + 2)

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from typing import Literal, cast
@@ -124,15 +125,66 @@ _PRESENTATION = {
 }
 
 
+class ScanRotation(BaseModel):
+    """The scan that belongs to the version this one replaced (#2624 scope 2).
+
+    Present exactly when ``ScanHealth.status == "rotated"``. Both dates come from
+    the same ``strategy_scan_watermark`` row, so neither can be null in practice;
+    they stay optional only because the column types are.
+    """
+
+    previous_version: str
+    previous_frontier_date: date | None
+    previous_scanned_at: datetime | None
+
+
 class ScanHealth(BaseModel):
     frontier_date: date | None
     updated_at: datetime | None
-    status: Literal["never_run", "current", "stale"]
+    # ``rotated`` (#2624 scope 2): the CURRENT version has never scanned but a
+    # previous one did. Previously indistinguishable from ``never_run``, which
+    # is the operator-facing lie — after any registry-touching merge the page
+    # said a strategy with a full history had never run.
+    status: Literal["never_run", "rotated", "current", "stale"]
+    rotation: ScanRotation | None = None
     fired_entries: int = 0
     fired_exits: int = 0
     not_fired: int = 0
     not_evaluable: int = 0
     exclusions_by_reason: dict[str, int] = Field(default_factory=dict)
+
+
+class PriorVersionTrackRecord(BaseModel):
+    """A version this strategy used to run under, and why its numbers are absent.
+
+    ⚠ Deliberately carries NO ``ResultArm``, and that is a measurement, not a
+    simplification (#2624 scope 1, spec
+    ``docs/proposals/ta/2026-08-13-prior-version-track-records.md``):
+
+    * **A prior version need not be on the current measurement basis, and today
+      none is.** Grouping every stored row by its identity pins, the ones that
+      match today's constants are exactly the four CURRENT versions; each version
+      they replaced differs on at least ``cost_model_id`` and ``return_basis``.
+      Those pins ARE the result identity, so putting an old expectancy beside a
+      new one is a cross-basis splice. ⚠ This is a property of the data, not of
+      rotation: immediately after a registry-only merge the version just replaced
+      IS comparable, which is why ``comparable`` is computed per version rather
+      than assumed.
+    * **``promotion_refusals`` cannot be reconstructed.** ``_promotion_refusals``
+      computes it at read time from TODAY's gate, and what was true when the row
+      was written is not stored — so reusing ``ResultArm`` would re-judge history
+      under rules it never faced.
+
+    So this answers "where did my track record go?" and names the refusal, in the
+    posture #2602 item 5 sets for benchmark fields: never substitute.
+    """
+
+    strategy_version: str
+    result_count: int
+    last_scan_frontier_date: date | None
+    last_scan_at: datetime | None
+    comparable: bool
+    incomparable_reasons: list[str]
 
 
 class ResultArm(BaseModel):
@@ -191,6 +243,10 @@ class StrategyOverview(BaseModel):
     exclusion_reason: str | None
     scan: ScanHealth
     evidence_windows: list[EvidenceWindow]
+    prior_versions: list[PriorVersionTrackRecord]
+    # ⚠ NOT a prior-version summary, despite the name: `_RESULT_COUNTS_SQL`
+    # filters on the CURRENT versions, so this counts rows under the current
+    # version that match no declared window. Reads 0 for all four strategies.
     legacy_result_count: int
     all_recent_evidence_complete: bool
     stage: str | None
@@ -846,6 +902,53 @@ _SCAN_SQL = """
     GROUP BY w.strategy_id, w.strategy_version, w.frontier_date, w.updated_at
 """
 
+# Every stored result row for a manifest strategy that is NOT under its current
+# version, grouped by the identity pins so the reader can say WHICH pins differ
+# rather than silently dropping the row (#2624 scope 1).
+#
+# ⚠ Keyed on the PAIR `(strategy_id, strategy_version)`, not on version alone.
+# The identity hash is over registry bytes, so nothing structurally prevents two
+# strategies sharing one; `= ANY(versions)` would then leak rows across cards.
+#
+# Cheap by construction, not by luck: `strategy_results_store` is written only
+# through `result_ledger` (`:460`), i.e. once per deliberate, trial-register
+# charged run — 324 rows on dev in total, against 6.7M in `price_daily`.
+_PRIOR_VERSION_RESULTS_SQL = """
+    SELECT
+        r.strategy_id,
+        r.strategy_version,
+        r.namespace,
+        r.corpus_version,
+        r.cost_model_id,
+        r.sizing_rule,
+        r.benchmark_rule,
+        r.return_basis,
+        r.position_rule_set_version,
+        r.outcome_rule_set_version,
+        r.input_rule_set_version,
+        COUNT(*) AS count
+    FROM strategy_results_store r
+    WHERE r.strategy_id = ANY(%(strategy_ids)s)
+      AND NOT EXISTS (
+          SELECT 1 FROM unnest(%(strategy_ids)s::text[], %(versions)s::text[]) AS cur(id, version)
+          WHERE cur.id = r.strategy_id AND cur.version = r.strategy_version
+      )
+    GROUP BY 1,2,3,4,5,6,7,8,9,10,11
+"""
+
+# Watermarks for versions OTHER than the current one, newest frontier first.
+# Same pair-keying rationale as above.
+_PRIOR_VERSION_SCANS_SQL = """
+    SELECT w.strategy_id, w.strategy_version, w.frontier_date, w.updated_at
+    FROM strategy_scan_watermark w
+    WHERE w.strategy_id = ANY(%(strategy_ids)s)
+      AND NOT EXISTS (
+          SELECT 1 FROM unnest(%(strategy_ids)s::text[], %(versions)s::text[]) AS cur(id, version)
+          WHERE cur.id = w.strategy_id AND cur.version = w.strategy_version
+      )
+    ORDER BY w.strategy_id, w.frontier_date DESC, w.strategy_version DESC
+"""
+
 _EXCLUSIONS_SQL = """
     SELECT strategy_id, strategy_version, reason_code AS not_evaluable_reason,
            SUM(row_count) AS count
@@ -947,6 +1050,100 @@ def _evidence_window_counts(strategies: list[StrategyOverview]) -> tuple[int, in
     return completed, partial
 
 
+def _current_identity_pins() -> dict[str, str]:
+    """The pins a stored row must match to sit on today's measurement basis.
+
+    Exactly the equality predicates ``_RESULTS_SQL`` applies, named once so the
+    prior-version reader cannot drift from the current-version one. These ARE the
+    result identity — differing on any of them means the numbers are not
+    comparable, which is why the reader reports the difference instead of either
+    hiding the version or splicing its figures in.
+    """
+    return {
+        "namespace": "hold_out",
+        "corpus_version": CORPUS_VERSION,
+        "cost_model_id": COST_MODEL_ID,
+        "sizing_rule": SIZING_RULE_ID,
+        "benchmark_rule": BENCHMARK_RULE_ID,
+        "return_basis": TOTAL_RETURN_BASIS,
+        "position_rule_set_version": POSITION_RULE_SET_VERSION,
+        "outcome_rule_set_version": OUTCOME_RULE_SET_VERSION,
+        "input_rule_set_version": QUARANTINE_RULE_SET_VERSION,
+    }
+
+
+def build_prior_versions(
+    *,
+    result_groups: Sequence[Mapping[str, object]],
+    scan_rows: Sequence[Mapping[str, object]],
+    pins: Mapping[str, str],
+) -> dict[str, list[PriorVersionTrackRecord]]:
+    """Group prior-version evidence into one record per ``(strategy_id, version)``.
+
+    Pure so it can be table-tested without Postgres. ``result_groups`` is
+    ``_PRIOR_VERSION_RESULTS_SQL``'s output (one row per identity-pin combination),
+    ``scan_rows`` is ``_PRIOR_VERSION_SCANS_SQL``'s.
+
+    ⚠ **Stored results are the qualifier; a watermark is not.** A version that
+    scanned and stored nothing has no track record — it has a scan, and the scan
+    is what ``ScanHealth.rotation`` carries. This is also what BOUNDS the list:
+    ``strategy_results_store`` gains rows once per deliberate, trial-register
+    charged run, whereas ``strategy_scan_watermark`` gains one per scan-day per
+    version, so admitting watermark-only versions would grow the payload with
+    every registry version ever scanned. ``scan_rows`` therefore only ENRICHES a
+    result-bearing version (and separately selects the rotation at the call site).
+    Measured on dev: ``+6c7cff76dcde`` is exactly this case — scanned 2026-08-07,
+    zero stored rows.
+
+    ``comparable`` is conservative: true only when the version HAS stored rows and
+    every one of them matches every pin. A version with a mix is reported
+    incomparable, because "partly on the current basis" is not a state an operator
+    can act on. The ``has rows`` half of that is belt-and-braces given the
+    qualifier above — "comparable" over an empty set is vacuously true, and that
+    would read on the page as a track record that exists.
+
+    Ordering is ``(last_scan_at, strategy_version)`` descending, nulls last, so
+    the list is deterministic when two versions share a scan time or neither ever
+    scanned — a bare date sort is not (Codex checkpoint 1).
+    """
+    counts: dict[tuple[str, str], int] = defaultdict(int)
+    reasons: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for group in result_groups:
+        key = (str(group["strategy_id"]), str(group["strategy_version"]))
+        counts[key] += int(cast(int, group["count"]))
+        reasons[key].update(name for name, expected in pins.items() if group.get(name) != expected)
+
+    scans: dict[tuple[str, str], Mapping[str, object]] = {}
+    for row in scan_rows:
+        # Newest frontier first from the query; keep the first row per version.
+        scans.setdefault((str(row["strategy_id"]), str(row["strategy_version"])), row)
+
+    by_strategy: dict[str, list[PriorVersionTrackRecord]] = defaultdict(list)
+    for strategy_id, version in sorted(counts):
+        scan = scans.get((strategy_id, version))
+        by_strategy[strategy_id].append(
+            PriorVersionTrackRecord(
+                strategy_version=version,
+                result_count=counts.get((strategy_id, version), 0),
+                last_scan_frontier_date=None if scan is None else cast(date | None, scan["frontier_date"]),
+                last_scan_at=None if scan is None else cast(datetime | None, scan["updated_at"]),
+                comparable=bool(counts.get((strategy_id, version), 0)) and not reasons.get((strategy_id, version)),
+                incomparable_reasons=sorted(reasons.get((strategy_id, version), set())),
+            )
+        )
+
+    for records in by_strategy.values():
+        records.sort(
+            key=lambda record: (
+                record.last_scan_at is not None,
+                record.last_scan_at or datetime.min.replace(tzinfo=UTC),
+                record.strategy_version,
+            ),
+            reverse=True,
+        )
+    return by_strategy
+
+
 @router.get("/overview", response_model=StrategyOverviewResponse)
 def get_strategy_overview(
     conn: psycopg.Connection[object] = Depends(get_conn),
@@ -974,6 +1171,11 @@ def get_strategy_overview(
         scan_rows = list(cur.fetchall())
         cur.execute(_EXCLUSIONS_SQL, params)
         exclusion_rows = list(cur.fetchall())
+        prior_params = {"strategy_ids": list(versions), "versions": [versions[k] for k in versions]}
+        cur.execute(_PRIOR_VERSION_RESULTS_SQL, prior_params)
+        prior_result_rows = list(cur.fetchall())
+        cur.execute(_PRIOR_VERSION_SCANS_SQL, prior_params)
+        prior_scan_rows = list(cur.fetchall())
         cur.execute(_LATEST_CORPUS_SQL)
         latest_row = cur.fetchone()
         latest_corpus_date = None if latest_row is None else latest_row["max"]
@@ -1018,6 +1220,19 @@ def get_strategy_overview(
     exclusions: dict[str, Counter[str]] = defaultdict(Counter)
     for row in exclusion_rows:
         exclusions[str(row["strategy_id"])][str(row["not_evaluable_reason"])] += int(row["count"])
+
+    prior_versions_by_strategy = build_prior_versions(
+        result_groups=prior_result_rows,
+        scan_rows=prior_scan_rows,
+        pins=_current_identity_pins(),
+    )
+    # The rotation SELECTION rule is scope 3's, not a second one: the greatest
+    # frontier date wins, which is what `assess_scan_freshness` computes into its
+    # `fallback` basis. `_PRIOR_VERSION_SCANS_SQL` orders to match, and breaks a
+    # frontier tie on the version so the choice is deterministic.
+    previous_scan_by_strategy: dict[str, Mapping[str, object]] = {}
+    for row in prior_scan_rows:
+        previous_scan_by_strategy.setdefault(str(row["strategy_id"]), row)
 
     runnable, excluded = runnable_strategies()
     excluded_by_id = {item.strategy_id: item.reason for item in excluded}
@@ -1088,8 +1303,24 @@ def get_strategy_overview(
 
         scan_row = scan_by_strategy.get(strategy_id)
         frontier = None if scan_row is None else scan_row["frontier_date"]
-        scan_status: Literal["never_run", "current", "stale"] = (
-            "never_run"
+        # #2624 scope 2 — `rotated` splits the two states that both used to read
+        # `never_run`: the current version has no watermark, but a previous one
+        # does, so the strategy HAS run and its track record started over. The
+        # discriminator is the WATERMARK and not stored results, because results
+        # and watermarks are independent (a version can hold one without the
+        # other) and it is the scan this field describes.
+        previous_scan = previous_scan_by_strategy.get(strategy_id)
+        rotation = (
+            ScanRotation(
+                previous_version=str(previous_scan["strategy_version"]),
+                previous_frontier_date=cast(date | None, previous_scan["frontier_date"]),
+                previous_scanned_at=cast(datetime | None, previous_scan["updated_at"]),
+            )
+            if frontier is None and previous_scan is not None
+            else None
+        )
+        scan_status: Literal["never_run", "rotated", "current", "stale"] = (
+            ("rotated" if rotation is not None else "never_run")
             if frontier is None
             else "current"
             if latest_corpus_date is not None and frontier >= latest_corpus_date
@@ -1099,6 +1330,7 @@ def get_strategy_overview(
             frontier_date=frontier,
             updated_at=None if scan_row is None else scan_row["updated_at"],
             status=scan_status,
+            rotation=rotation,
             fired_entries=0 if scan_row is None else int(scan_row["fired_entries"]),
             fired_exits=0 if scan_row is None else int(scan_row["fired_exits"]),
             not_fired=0 if scan_row is None else int(scan_row["not_fired"]),
@@ -1189,6 +1421,7 @@ def get_strategy_overview(
                 exclusion_reason=excluded_by_id.get(strategy_id),
                 scan=scan,
                 evidence_windows=windows,
+                prior_versions=prior_versions_by_strategy.get(strategy_id, []),
                 legacy_result_count=result_counts.get(strategy_id, 0) - sum(len(rows) for rows in exact.values()),
                 all_recent_evidence_complete=all_complete,
                 stage=control.stage,

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -1113,10 +1113,11 @@ def build_prior_versions(
         counts[key] += int(cast(int, group["count"]))
         reasons[key].update(name for name, expected in pins.items() if group.get(name) != expected)
 
-    scans: dict[tuple[str, str], Mapping[str, object]] = {}
-    for row in scan_rows:
-        # Newest frontier first from the query; keep the first row per version.
-        scans.setdefault((str(row["strategy_id"]), str(row["strategy_version"])), row)
+    # One row per pair: `(strategy_id, strategy_version)` is the PRIMARY KEY of
+    # `strategy_scan_watermark` (sql/272:59), so this is a lookup, not a dedup.
+    scans: dict[tuple[str, str], Mapping[str, object]] = {
+        (str(row["strategy_id"]), str(row["strategy_version"])): row for row in scan_rows
+    }
 
     by_strategy: dict[str, list[PriorVersionTrackRecord]] = defaultdict(list)
     for strategy_id, version in sorted(counts):
@@ -1171,7 +1172,12 @@ def get_strategy_overview(
         scan_rows = list(cur.fetchall())
         cur.execute(_EXCLUSIONS_SQL, params)
         exclusion_rows = list(cur.fetchall())
-        prior_params = {"strategy_ids": list(versions), "versions": [versions[k] for k in versions]}
+        # Two parallel arrays `unnest`ed into current `(id, version)` pairs. Built
+        # from one `items()` pass so the pairing cannot drift on a later edit.
+        prior_params = {
+            "strategy_ids": [strategy_id for strategy_id, _ in versions.items()],
+            "versions": [version for _, version in versions.items()],
+        }
         cur.execute(_PRIOR_VERSION_RESULTS_SQL, prior_params)
         prior_result_rows = list(cur.fetchall())
         cur.execute(_PRIOR_VERSION_SCANS_SQL, prior_params)

--- a/docs/proposals/ta/2026-08-13-prior-version-track-records.md
+++ b/docs/proposals/ta/2026-08-13-prior-version-track-records.md
@@ -1,0 +1,182 @@
+# Prior-version track records on the Strategies overview (#2624 scopes 1 + 2)
+
+## Problem
+
+The identity hash covers registry BYTES (#2394 §2), so **any** registry-touching merge mints a
+new `strategy_version`, and `sql/272_strategy_scan_watermark.sql` deliberately keys the watermark
+on `(strategy_id, strategy_version)` — a new version starts *"a new track record beside the old
+one"* (its own docstring). That versioning is correct and is not being weakened here.
+
+What is broken is that "beside the old one" never renders. `get_strategy_overview` filters every
+one of its reads on `strategy_version = ANY(%(versions)s)` where `versions = _current_versions()`,
+so at a rotation the operator sees an empty card — no evidence, no scan, no history —
+indistinguishable from a broken system. At today's merge cadence (7 registry-adjacent merges in
+one day) that is the page's steady state.
+
+## Premise re-checked before designing (working-order 3c)
+
+The issue's snapshot has **healed**, and the spec is written against the current data, not the
+issue's text:
+
+```
+$ current versions vs stored rows (dev, 2026-08-13)
+  s1-time-series-momentum             +67dbf07c9d72  frontier=2026-08-11  results=32
+  s2-cross-sectional-momentum         +83967fcb1fca  frontier=2026-08-11  results=32
+  s3-mean-reversion-in-trend          +d58989368716  frontier=2026-08-11  results=32
+  s4-volatility-compression-breakout  +91aadde63f07  frontier=2026-08-11  results=32
+```
+
+A backtest re-ran under the live versions on 08-12 18:59, so the current version is populated and
+the blank page is not visible right now. **The defect is structural, not a stuck state**: it
+returns at the next registry-touching merge. Acceptance therefore has to simulate a rotation;
+"the page is blank today" is not available as evidence and must not be claimed.
+
+One correction to the issue's text, measured: `legacy_result_count` is **not** a prior-version
+summary. `_RESULT_COUNTS_SQL` filters on the current versions, so the field counts rows under the
+CURRENT version that do not match a declared window — it reads 0 for all four strategies today.
+Prior-version track records are invisible entirely, not "one integer".
+
+## Source rule — what counts as a prior track record, and why it needs no threshold
+
+A cap would be a picked number, and this repo fixes such things by construction or not at all. The
+construction comes from what the two tables mean:
+
+| table | written by | cadence |
+|---|---|---|
+| `strategy_scan_watermark` | `strategy_signal_scan` | one row per scan-day, per version — **unbounded** over time |
+| `strategy_results_store` | `result_ledger` only (`app/services/result_ledger.py:460`) | one batch per deliberate, charged, #2600-registered trial |
+
+So:
+
+- **A prior version appears in `prior_versions` when it holds ≥1 stored result row.** That is what
+  "track record" means — evidence someone paid a trial-register charge to produce. The set is
+  bounded by deliberate runs, not by merges, which is the bound the payload needs and the reason
+  no N has to be chosen. Measured today: exactly 1 prior results-bearing version per strategy.
+- **A watermark-only version is NOT a track record.** It scanned and produced no evidence. It is
+  still load-bearing for scope 2's copy, which is about the *scan*, so it is carried in the
+  rotation block instead. ⚠ The first implementation admitted them (`set(counts) | set(scans)`),
+  which contradicted this rule and reintroduced exactly the unbounded growth it exists to avoid —
+  caught at Codex checkpoint 2. `scan_rows` only ENRICHES a result-bearing version.
+
+## ⚠ Scope 1 narrowed, on measurement — a pointer, not a metrics splice
+
+The issue asks for prior-version track records *"beside the current version"*. Measured on the
+full population (324 rows, every `(strategy_id, strategy_version)` group), that cannot be shown as
+comparable numbers, and two independent facts say so:
+
+**1. No prior version is on the current measurement basis today.** ⚠ That is a property of the
+data at this moment, not of rotation — immediately after a registry-only merge the version just
+replaced IS comparable, so the flag is computed per version and never assumed. Grouping every results row by its
+identity pins: 128 of 324 match today's constants, and those 128 are exactly the four CURRENT
+versions. Every prior version differs on at least `cost_model_id`
+(`static-p75-insession-v1` vs `v2+split-adjusted-max`) and `return_basis`
+(`raw-close-price-return-v1` vs `split-dividend-adjusted-wealth-v1`); most also differ on
+`position_rule_set_version` and `outcome_rule_set_version`, and some on `benchmark_rule` and
+`namespace`. Those pins ARE `ResultIdentity`. Rendering an old expectancy beside a new one is the
+cross-basis splice the repo forbids, and it would be least visible exactly where it misleads most.
+
+**2. `promotion_refusals` cannot be reconstructed for a historical row.** It is computed at read
+time by `_promotion_refusals` from today's gate, and the values that were true when the row was
+written are not stored. Reusing `ResultArm` verbatim would therefore re-judge history under rules
+it never faced (Codex checkpoint 1).
+
+So `prior_versions` carries **no `ResultArm`**. It answers "where did my track record go?" — which
+version, how many stored results, when it last scanned, and *why its numbers are not shown* —
+naming the pins that differ. This is the same refusal-state posture #2602 item 5 fixes for
+benchmark fields: name the refusal, never substitute. It also removes the response-size question
+(the payload is O(1) per prior version, not O(arms)).
+
+## Rotation state — CONSUME scope 3's verdict, do not re-derive
+
+The first draft of this spec said "reuse" and then proposed a second derivation. That is the drift
+it claimed to avoid, and Codex flagged it.
+
+`app/services/strategy_scan_freshness.py` (#2624 scope 3, merged `b83c253e`) already owns the
+rotation model: a `current` vs `fallback` watermark basis, and the `rotated_awaiting_scan` /
+`rotated_scan_overdue` statuses.
+
+`get_strategy_overview` therefore calls `check_scan_freshness(conn)` — the same function
+`/system/status` uses — and maps its verdict onto `ScanHealth`. One rotation model, two surfaces.
+Concretely, `basis == "fallback"` IS the rotation signal (the current version has no watermark and
+some prior version does), and scope 3 already fixes the selection rule: the greatest frontier date,
+which is what `assess_scan_freshness` computes into `newest_by_strategy`.
+
+⚠ Two scan-state models exist and this does not merge them: `ScanHealth.status` grades the frontier
+against `research_price_series`' max bar, while `check_scan_freshness` grades it in trading days
+against `price_daily` with a lag tolerance. Merging them is out of scope here and is NOT done
+silently — `ScanHealth` gains `rotated` only, and the divergence is named at the call site.
+
+## Payload
+
+```python
+class ScanRotation(BaseModel):
+    previous_version: str
+    previous_frontier_date: date | None
+    previous_scanned_at: datetime | None
+
+class ScanHealth(BaseModel):
+    status: Literal["never_run", "rotated", "current", "stale"]   # "rotated" is new
+    rotation: ScanRotation | None                                  # non-null iff status == "rotated"
+    ...unchanged
+
+class PriorVersionTrackRecord(BaseModel):
+    strategy_version: str
+    result_count: int                      # stored rows under this version, any basis
+    last_scan_frontier_date: date | None
+    last_scan_at: datetime | None
+    comparable: bool                       # per version; false for all of today's
+    incomparable_reasons: list[str]        # the identity pins that differ, sorted
+
+class StrategyOverview(BaseModel):
+    prior_versions: list[PriorVersionTrackRecord]   # newest activity first
+    ...unchanged
+```
+
+Ordering is `(last_scan_at, strategy_version)` descending — `strategy_version` breaks the tie so
+the list is deterministic when two versions share a scan time or neither ever scanned.
+
+## Render (scope 2)
+
+Per control card, when `scan.status == "rotated"`:
+
+> Version rotated — scanned through {previous_frontier_date} under the previous version. New track
+> record starting.
+
+and never "never run". The frontier date is nullable in the type but cannot be null in this branch
+(a rotation is *defined* by a prior watermark existing); the copy still degrades to "under the
+previous version" rather than interpolating `null`.
+
+When `prior_versions` is non-empty the card gains a **Previous versions** block: one line per prior
+version with its short hash, stored-result count, last scan date, and the reason its numbers are
+not shown. ⚠ The rotated copy does NOT promise "previous track record below" — a rotation is
+defined by a watermark, and a watermark-only prior version contributes no `prior_versions` entry.
+The two blocks are independent and each renders on its own condition.
+
+⚠ The `scan` block is currently **not rendered anywhere in `frontend/src`** — it is typed in
+`api/types.ts:2456` and never read. Scope 2 is therefore the first render of it, not an edit to an
+existing one.
+
+## Also fixed here (the 09:01 triage's parked finding)
+
+`StrategiesPage.tsx:50` — `primaryEvidence()` matches `window.window_id === "primary"`. No such id
+exists: the declared ids are `primary-2022-plus`, `rolling-36m`, `rolling-24m`, `year-2022`,
+`year-2023`, `year-2024`, `year-2025`, `year-2026-ytd`
+(`app/services/strategy_recent_evidence.py:29`). The first branch is dead, so the function always
+falls through to "first window with `status === "complete"`". That is order-dependent and silently
+picks a **different window** whenever the primary window is `partial` while a calendar-year window
+is `complete` — the headline "Expected / trade" then describes 2022 alone while the label says
+primary. Fixed to the declared id.
+
+## Acceptance
+
+1. `/strategies/overview` carries `prior_versions` and `scan.rotation`, verified against dev.
+2. A simulated rotation — a current version with **no watermark** while a prior version has one —
+   reports `status="rotated"` with the previous frontier date, not `never_run`. ⚠ Rotation is
+   defined by the WATERMARK, not by stored results: a version can have results and no watermark,
+   or a watermark and no results, and those are independent states.
+2a. `rotation` is non-null **iff** `status == "rotated"`, asserted as an invariant test.
+2b. Prior-version rows change no current-version figure: evidence completeness, allocation
+   readiness, attribution, P&L and the promotion refusals are asserted unchanged.
+3. `/strategies` renders the rotated copy and the previous-track-record block; screenshotted,
+   scrolled to the bottom, with `scrollHeight` vs `innerHeight` checked on a 1400px viewport.
+4. `primaryEvidence()` resolves the declared id.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2443,6 +2443,31 @@ export interface StrategyEvidenceWindow {
   arms: StrategyResultArm[];
 }
 
+/** The scan belonging to the version this one replaced (#2624 scope 2). */
+export interface StrategyScanRotation {
+  previous_version: string;
+  previous_frontier_date: string | null;
+  previous_scanned_at: string | null;
+}
+
+/** A version this strategy used to run under, and why its numbers are absent.
+ *
+ * ⚠ Deliberately carries no result arms. Measured across every stored result
+ * row: each version replaced before today differs from the current measurement
+ * basis on at least `cost_model_id` and `return_basis`, and those pins ARE the
+ * result identity — so showing an old expectancy beside a new one would be a
+ * cross-basis splice. `promotion_refusals` is also computed from TODAY's gate
+ * and was never stored, so it cannot be reconstructed for a historical row.
+ * This names the refusal instead, per #2602 item 5's posture. */
+export interface StrategyPriorVersion {
+  strategy_version: string;
+  result_count: number;
+  last_scan_frontier_date: string | null;
+  last_scan_at: string | null;
+  comparable: boolean;
+  incomparable_reasons: string[];
+}
+
 export interface StrategyOverview {
   strategy_id: string;
   strategy_version: string;
@@ -2456,7 +2481,12 @@ export interface StrategyOverview {
   scan: {
     frontier_date: string | null;
     updated_at: string | null;
-    status: "never_run" | "current" | "stale";
+    /** `rotated` (#2624): the CURRENT version has never scanned but a previous
+     *  one did — the strategy HAS run and its track record started over. Used
+     *  to be reported as `never_run`, which is the operator-facing lie. */
+    status: "never_run" | "rotated" | "current" | "stale";
+    /** Non-null iff `status === "rotated"`. */
+    rotation: StrategyScanRotation | null;
     fired_entries: number;
     fired_exits: number;
     not_fired: number;
@@ -2464,6 +2494,9 @@ export interface StrategyOverview {
     exclusions_by_reason: Record<string, number>;
   };
   evidence_windows: StrategyEvidenceWindow[];
+  prior_versions: StrategyPriorVersion[];
+  /** ⚠ NOT a prior-version summary despite the name — counts rows under the
+   *  CURRENT version matching no declared window. Use `prior_versions`. */
   legacy_result_count: number;
   all_recent_evidence_complete: boolean;
   stage: string | null;

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -186,11 +186,16 @@ const OVERVIEW: StrategyOverviewResponse = {
     runnable: true,
     forward_outcome_supported: false,
     exclusion_reason: null,
-    scan: { frontier_date: "2026-08-07", updated_at: "2026-08-08T06:45:00Z", status: "current", fired_entries: 12, fired_exits: 0, not_fired: 100, not_evaluable: 0, exclusions_by_reason: {} },
+    scan: { frontier_date: "2026-08-07", updated_at: "2026-08-08T06:45:00Z", status: "current", rotation: null, fired_entries: 12, fired_exits: 0, not_fired: 100, not_evaluable: 0, exclusions_by_reason: {} },
+    // ⚠ The declared ids, from app/services/strategy_recent_evidence.py. This
+    // fixture used to say `primary` / `holdout`, neither of which the API can
+    // emit — which is why `primaryEvidence()` matching a dead id went unnoticed
+    // (#2624): the fallback branch covered for it in prod and in the test alike.
     evidence_windows: [
-      { window_id: "primary", label: "2022 onward", window_start: "2022-01-01", window_end: "2026-07-08", status: "complete", arms: [ARM] },
-      { window_id: "holdout", label: "Holdout", window_start: "2025-01-01", window_end: "2026-07-08", status: "missing", arms: [] },
+      { window_id: "primary-2022-plus", label: "Primary: 2022 onward", window_start: "2022-01-01", window_end: "2026-07-08", status: "complete", arms: [ARM] },
+      { window_id: "year-2022", label: "Calendar 2022", window_start: "2022-01-01", window_end: "2022-12-31", status: "missing", arms: [] },
     ],
+    prior_versions: [],
     legacy_result_count: 0,
     all_recent_evidence_complete: false,
     stage: null,
@@ -666,6 +671,120 @@ describe("StrategiesPage", () => {
     render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
     await userEvent.click(await screen.findByRole("checkbox", { name: "Enabled" }));
     await waitFor(() => expect(update).toHaveBeenCalledWith("s1-time-series-momentum", expect.objectContaining({ enabled: false, reason: "Paused from automated strategy workspace" })));
+  });
+
+  it("keeps the primary label on the primary window when a calendar year is the only complete one", async () => {
+    // #2624: primaryEvidence() matched window_id === "primary", which the API
+    // cannot emit (the declared id is "primary-2022-plus"), so it always fell
+    // through to "first complete window". With the primary window partial and a
+    // calendar year complete, the headline described 2022 alone under a label
+    // that said primary. The fixture's own ids hid this — they were wrong too.
+    const mixed = structuredClone(OVERVIEW);
+    const strategy = mixed.strategies[0]!;
+    strategy.evidence_windows = [
+      { ...strategy.evidence_windows[0]!, window_id: "primary-2022-plus", label: "Primary: 2022 onward", status: "partial", arms: [{ ...ARM, trade_count: 111, open_trade_count: 0, unpriced_trade_count: 0 }] },
+      { ...strategy.evidence_windows[0]!, window_id: "year-2022", label: "Calendar 2022", window_end: "2022-12-31", status: "complete", arms: [{ ...ARM, trade_count: 222, open_trade_count: 0, unpriced_trade_count: 0 }] },
+    ];
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(mixed);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    expect(screen.getByText(/Primary: 2022 onward/)).toBeInTheDocument();
+    expect(screen.getByText("111")).toBeInTheDocument();
+    expect(screen.queryByText("222")).not.toBeInTheDocument();
+  });
+
+  it("says a version rotated instead of claiming the strategy never ran", async () => {
+    // #2624: a registry-touching merge mints a new strategy_version, the
+    // watermark is keyed on it, so the CURRENT version has no scan and every
+    // evidence window reads `missing`. The page used to render that as a blank
+    // card — indistinguishable from a broken system.
+    const rotated = structuredClone(OVERVIEW);
+    const strategy = rotated.strategies[0]!;
+    strategy.scan = {
+      ...strategy.scan,
+      frontier_date: null,
+      updated_at: null,
+      status: "rotated",
+      rotation: {
+        previous_version: "strategy-registry-v1+67dbf07c9d72",
+        previous_frontier_date: "2026-08-11",
+        previous_scanned_at: "2026-08-12T18:59:01Z",
+      },
+    };
+    strategy.evidence_windows = strategy.evidence_windows.map((window) => ({ ...window, status: "missing", arms: [] }));
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(rotated);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    expect(screen.getByText("Version rotated.")).toBeInTheDocument();
+    expect(screen.getByText(/scanned through 11 Aug 2026 under the previous version/)).toBeInTheDocument();
+    expect(screen.getByText(/A new track record is starting/)).toBeInTheDocument();
+  });
+
+  it("names the basis a previous version was measured on rather than splicing its figures in", async () => {
+    // The prior version's numbers are deliberately absent: measured on a
+    // different cost model and return basis, which ARE the result identity.
+    const withHistory = structuredClone(OVERVIEW);
+    withHistory.strategies[0]!.prior_versions = [
+      {
+        strategy_version: "strategy-registry-v1+2307ee566d7b",
+        result_count: 60,
+        last_scan_frontier_date: "2026-08-07",
+        last_scan_at: "2026-08-09T06:46:00Z",
+        comparable: false,
+        incomparable_reasons: ["cost_model_id", "return_basis"],
+      },
+    ];
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(withHistory);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    expect(screen.getByText("Previous versions")).toBeInTheDocument();
+    expect(screen.getByText(/2307ee56/)).toBeInTheDocument();
+    expect(screen.getByText(/60 stored results/)).toBeInTheDocument();
+    expect(screen.getByText(/different cost model, return basis/)).toBeInTheDocument();
+  });
+
+  it("shows version history on a validation control, which is where every strategy actually renders", async () => {
+    // All four strategies are harness_validation, so ValidationControl — not
+    // EvidenceDetail — is the surface the operator sees (#2624). A candidate-only
+    // fixture cannot catch a block that is missing there.
+    const control = structuredClone(OVERVIEW);
+    const strategy = control.strategies[0]!;
+    strategy.purpose = "harness_validation";
+    strategy.scan = {
+      ...strategy.scan,
+      frontier_date: null,
+      updated_at: null,
+      status: "rotated",
+      rotation: { previous_version: "strategy-registry-v1+67dbf07c9d72", previous_frontier_date: "2026-08-11", previous_scanned_at: "2026-08-12T18:59:01Z" },
+    };
+    strategy.prior_versions = [
+      { strategy_version: "strategy-registry-v1+2307ee566d7b", result_count: 60, last_scan_frontier_date: "2026-08-07", last_scan_at: "2026-08-09T06:46:00Z", comparable: false, incomparable_reasons: ["cost_model_id"] },
+    ];
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(control);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    expect(await screen.findByText("Version rotated.")).toBeInTheDocument();
+    expect(screen.getByText("Previous versions")).toBeInTheDocument();
+    expect(screen.getByText(/different cost model/)).toBeInTheDocument();
+  });
+
+  it("shows no previous-versions block when there is no history", async () => {
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    expect(screen.queryByText("Previous versions")).not.toBeInTheDocument();
   });
 
   it("does not enable an approved strategy without assigned capital", async () => {

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -46,10 +46,94 @@ function pctPoints(value: string | null): string {
   return formatPct(parsed === null ? null : parsed / 100);
 }
 
+/** The declared id is `primary-2022-plus`, not `primary` (#2624).
+ *
+ * `app/services/strategy_recent_evidence.py` declares exactly eight ids and
+ * `primary` is not among them, so this lookup used to be dead and the function
+ * always fell through to "first window with status complete". That is
+ * order-dependent: whenever the primary window is `partial` while a calendar-year
+ * window is `complete`, the headline "Expected / trade" silently described 2022
+ * alone under a label that said primary. */
+const PRIMARY_WINDOW_ID = "primary-2022-plus";
+
 function primaryEvidence(strategy: StrategyOverview): StrategyEvidenceWindow | null {
-  return strategy.evidence_windows.find((window) => window.window_id === "primary")
+  return strategy.evidence_windows.find((window) => window.window_id === PRIMARY_WINDOW_ID)
     ?? strategy.evidence_windows.find((window) => window.status === "complete")
     ?? null;
+}
+
+/** Scope 2: say a version rotated, never "never run".
+ *
+ * A registry-touching merge mints a new `strategy_version` and the watermark is
+ * keyed on it, so the new version starts a track record beside the old one. The
+ * page used to show only the current version, so the operator saw an empty card
+ * — indistinguishable from a broken system. */
+function ScanRotationNote({ strategy }: { strategy: StrategyOverview }) {
+  const rotation = strategy.scan.rotation;
+  if (strategy.scan.status !== "rotated" || !rotation) return null;
+  const scannedThrough = rotation.previous_frontier_date
+    ? ` scanned through ${formatDate(rotation.previous_frontier_date)} under the previous version`
+    : " scanned under the previous version";
+  return (
+    <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+      <strong className="font-semibold text-slate-700 dark:text-slate-200">Version rotated.</strong>
+      {` This strategy${scannedThrough} (${shortVersion(rotation.previous_version)}). A new track record is starting; it has not scanned yet.`}
+    </p>
+  );
+}
+
+function shortVersion(version: string): string {
+  const suffix = version.split("+").pop() ?? version;
+  return suffix.slice(0, 8);
+}
+
+/** Scope 1: where the track record went, and why its numbers are not shown.
+ *
+ * Deliberately no metrics. Every version replaced before today sits on a
+ * different `cost_model_id` / `return_basis`, and those pins are the result
+ * identity — so the honest render names the difference rather than splicing an
+ * old expectancy in beside a new one. */
+function PriorVersionsBlock({ strategy }: { strategy: StrategyOverview }) {
+  if (strategy.prior_versions.length === 0) return null;
+  return (
+    <div className="mt-4 border-t border-slate-200 pt-3 dark:border-slate-800">
+      {/* One short line, not a paragraph: this block repeats on every card, and
+          the per-row reason already carries the detail. */}
+      <h4 className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+        Previous versions <span className="font-normal normal-case tracking-normal">· figures not shown, measured on another basis</span>
+      </h4>
+      <ul className="mt-2 space-y-1 text-xs text-slate-600 dark:text-slate-300">
+        {strategy.prior_versions.map((prior) => (
+          <li key={prior.strategy_version} className="tabular-nums">
+            <span className="font-mono">{shortVersion(prior.strategy_version)}</span>
+            {` · ${prior.result_count} stored result${prior.result_count === 1 ? "" : "s"}`}
+            {prior.last_scan_frontier_date ? ` · scanned through ${formatDate(prior.last_scan_frontier_date)}` : " · never scanned"}
+            {prior.comparable
+              ? " · same measurement basis"
+              : prior.incomparable_reasons.length
+                ? ` · different ${prior.incomparable_reasons.map(pinLabel).join(", ")}`
+                : " · no stored results to compare"}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const PIN_LABELS: Record<string, string> = {
+  namespace: "sample",
+  corpus_version: "corpus",
+  cost_model_id: "cost model",
+  sizing_rule: "sizing rule",
+  benchmark_rule: "benchmark",
+  return_basis: "return basis",
+  position_rule_set_version: "position rules",
+  outcome_rule_set_version: "outcome rules",
+  input_rule_set_version: "input rules",
+};
+
+function pinLabel(pin: string): string {
+  return PIN_LABELS[pin] ?? pin.replace(/_/g, " ");
 }
 
 function representativeArm(strategy: StrategyOverview): StrategyResultArm | null {
@@ -849,9 +933,16 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
   const failures = strategy.allocation_refusals.map(refusalLabel);
   const failedOutcomes = Math.max(0, strategy.attribution.resolved_entries - strategy.attribution.winning_entries);
   if (!window || !arm) {
+    // The blank card #2624 is about. A rotation lands here with EVERY window
+    // `missing`, so this branch has to explain the rotation rather than imply
+    // the research never ran.
     return (
       <div className="border-t border-slate-200 px-4 py-4 text-sm text-slate-500 dark:border-slate-800">
-        No completed valid evidence is available. {failures[0] ?? "The research run has not finished."}
+        <ScanRotationNote strategy={strategy} />
+        <p className={strategy.scan.status === "rotated" ? "mt-2" : undefined}>
+          No completed valid evidence is available under the current version. {failures[0] ?? "The research run has not finished."}
+        </p>
+        <PriorVersionsBlock strategy={strategy} />
       </div>
     );
   }
@@ -883,6 +974,7 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
         <span>Completed outcomes: <strong className="text-slate-700 dark:text-slate-200">{strategy.attribution.resolved_entries}</strong></span>
         <span>Successful / unsuccessful: <strong className="text-slate-700 dark:text-slate-200">{strategy.attribution.winning_entries} / {failedOutcomes}</strong></span>
       </div>
+      <PriorVersionsBlock strategy={strategy} />
     </div>
   );
 }
@@ -915,21 +1007,30 @@ function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
 
 function ValidationControl({ strategy }: { strategy: StrategyOverview }) {
   const arm = representativeArm(strategy);
+  // ⚠ This — NOT `EvidenceDetail` — is where the four strategies that exist are
+  // rendered, because all of them are `harness_validation` (#2624). Putting the
+  // rotation notice only on the capital-candidate path would have shipped a
+  // payload nothing displays; caught by walking the real page, not by the
+  // component tests, whose fixture is a candidate.
   return (
-    <article className="grid gap-3 border-t border-slate-200 py-3 dark:border-slate-800 sm:grid-cols-[minmax(14rem,1.5fr)_repeat(3,minmax(6rem,0.6fr))] sm:items-center">
-      <div>
-        <div className="flex flex-wrap items-center gap-2">
-          <h3 className="text-sm font-semibold">{strategy.title}</h3>
-          <Badge tone="neutral">Control</Badge>
+    <article className="border-t border-slate-200 py-3 dark:border-slate-800">
+      <div className="grid gap-3 sm:grid-cols-[minmax(14rem,1.5fr)_repeat(3,minmax(6rem,0.6fr))] sm:items-center">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-semibold">{strategy.title}</h3>
+            <Badge tone="neutral">Control</Badge>
+          </div>
+          <p className="mt-1 text-xs text-slate-500">
+            Harness evidence only · never eligible for capital
+            {strategy.forward_outcome_supported ? " · forward outcomes measured" : " · backtest only"}
+          </p>
         </div>
-        <p className="mt-1 text-xs text-slate-500">
-          Harness evidence only · never eligible for capital
-          {strategy.forward_outcome_supported ? " · forward outcomes measured" : " · backtest only"}
-        </p>
+        <div><span className="text-xs text-slate-500">Expected / trade</span><strong className="block tabular-nums">{pctPoints(arm?.expectancy_per_trade_pct ?? null)}</strong></div>
+        <div><span className="text-xs text-slate-500">Worst drawdown</span><strong className="block tabular-nums">{pctPoints(arm?.max_drawdown_pct ?? null)}</strong></div>
+        <div><span className="text-xs text-slate-500">Evidence windows</span><strong className="block tabular-nums">{completedEvidenceCount(strategy)}/{strategy.evidence_windows.length}</strong></div>
       </div>
-      <div><span className="text-xs text-slate-500">Expected / trade</span><strong className="block tabular-nums">{pctPoints(arm?.expectancy_per_trade_pct ?? null)}</strong></div>
-      <div><span className="text-xs text-slate-500">Worst drawdown</span><strong className="block tabular-nums">{pctPoints(arm?.max_drawdown_pct ?? null)}</strong></div>
-      <div><span className="text-xs text-slate-500">Evidence windows</span><strong className="block tabular-nums">{completedEvidenceCount(strategy)}/{strategy.evidence_windows.length}</strong></div>
+      <ScanRotationNote strategy={strategy} />
+      <PriorVersionsBlock strategy={strategy} />
     </article>
   );
 }

--- a/tests/test_2624_prior_version_track_records.py
+++ b/tests/test_2624_prior_version_track_records.py
@@ -1,0 +1,145 @@
+"""Prior-version track records and the rotated scan state (#2624 scopes 1 + 2).
+
+Pure (no Postgres): ``build_prior_versions`` takes the two readers' rows and
+returns the payload records, so the grouping, the comparability rule and the
+ordering are all table-testable.
+
+Spec: ``docs/proposals/ta/2026-08-13-prior-version-track-records.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from app.api.strategies import _current_identity_pins, build_prior_versions
+
+_PINS = {"namespace": "hold_out", "cost_model_id": "cost-v2", "return_basis": "total-return-v1"}
+_S = "s1-time-series-momentum"
+
+
+def _group(version: str, count: int, **overrides: str) -> dict[str, object]:
+    return {"strategy_id": _S, "strategy_version": version, "count": count, **_PINS, **overrides}
+
+
+def _scan(version: str, frontier: date, at: datetime) -> dict[str, object]:
+    return {"strategy_id": _S, "strategy_version": version, "frontier_date": frontier, "updated_at": at}
+
+
+def test_a_version_on_the_current_basis_is_comparable() -> None:
+    records = build_prior_versions(result_groups=[_group("v-old", 32)], scan_rows=[], pins=_PINS)
+
+    assert [r.strategy_version for r in records[_S]] == ["v-old"]
+    assert records[_S][0].comparable
+    assert records[_S][0].incomparable_reasons == []
+    assert records[_S][0].result_count == 32
+
+
+def test_differing_pins_are_named_not_swallowed() -> None:
+    """The refusal has to say WHICH basis differs — that is the whole payload.
+
+    Measured on dev: every version replaced before today differs on at least
+    ``cost_model_id`` and ``return_basis`` (cost model v1 -> v2+split-adjusted-max,
+    raw-close -> split-dividend-adjusted wealth). Reporting "not comparable" with
+    no reason would be the same blank the ticket exists to remove, one level down.
+    """
+    records = build_prior_versions(
+        result_groups=[_group("v-old", 32, cost_model_id="cost-v1", return_basis="raw-close-v1")],
+        scan_rows=[],
+        pins=_PINS,
+    )
+
+    assert not records[_S][0].comparable
+    assert records[_S][0].incomparable_reasons == ["cost_model_id", "return_basis"]
+
+
+def test_a_partly_matching_version_is_not_comparable() -> None:
+    """ "Partly on the current basis" is not a state an operator can act on."""
+    records = build_prior_versions(
+        result_groups=[_group("v-old", 16), _group("v-old", 4, cost_model_id="cost-v1")],
+        scan_rows=[],
+        pins=_PINS,
+    )
+
+    assert records[_S][0].result_count == 20  # every row counted, comparable or not
+    assert not records[_S][0].comparable
+    assert records[_S][0].incomparable_reasons == ["cost_model_id"]
+
+
+def test_a_watermark_only_version_is_not_a_track_record() -> None:
+    """Stored results are the qualifier; a scan is not — and that is the BOUND.
+
+    Measured on dev: ``+6c7cff76dcde`` scanned 2026-08-07 and stored zero rows.
+    ``strategy_scan_watermark`` gains a row per scan-day per version, so admitting
+    watermark-only versions would grow this list with every registry version ever
+    scanned — the unbounded growth the results-bearing rule exists to avoid.
+    The scan itself is not lost: it is what ``ScanHealth.rotation`` carries.
+    """
+    records = build_prior_versions(
+        result_groups=[],
+        scan_rows=[_scan("v-scanned-only", date(2026, 8, 7), datetime(2026, 8, 9, 6, 46, tzinfo=UTC))],
+        pins=_PINS,
+    )
+
+    assert records == {}, "a version that scanned and stored nothing has no track record"
+
+
+def test_a_watermark_enriches_a_result_bearing_version_only() -> None:
+    records = build_prior_versions(
+        result_groups=[_group("v-results", 8)],
+        scan_rows=[
+            _scan("v-results", date(2026, 8, 7), datetime(2026, 8, 9, tzinfo=UTC)),
+            _scan("v-scan-only", date(2026, 8, 11), datetime(2026, 8, 12, tzinfo=UTC)),
+        ],
+        pins=_PINS,
+    )
+
+    assert [r.strategy_version for r in records[_S]] == ["v-results"]
+    assert records[_S][0].last_scan_frontier_date == date(2026, 8, 7)
+
+
+def test_ordering_is_deterministic_when_scan_times_tie() -> None:
+    """A bare date sort is not deterministic; the version breaks the tie."""
+    same = datetime(2026, 8, 12, 18, 59, tzinfo=UTC)
+    records = build_prior_versions(
+        result_groups=[_group("v-aaa", 1), _group("v-zzz", 1)],
+        scan_rows=[_scan("v-aaa", date(2026, 8, 11), same), _scan("v-zzz", date(2026, 8, 11), same)],
+        pins=_PINS,
+    )
+
+    assert [r.strategy_version for r in records[_S]] == ["v-zzz", "v-aaa"]
+
+
+def test_never_scanned_versions_sort_after_scanned_ones() -> None:
+    records = build_prior_versions(
+        result_groups=[_group("v-never-scanned", 4), _group("v-scanned", 4)],
+        scan_rows=[_scan("v-scanned", date(2026, 8, 7), datetime(2026, 8, 9, tzinfo=UTC))],
+        pins=_PINS,
+    )
+
+    assert [r.strategy_version for r in records[_S]] == ["v-scanned", "v-never-scanned"]
+
+
+def test_records_never_cross_strategies() -> None:
+    """The identity hash is over registry bytes; nothing stops two strategies
+    sharing one, so the grouping key is the PAIR and never the version alone."""
+    shared = "strategy-registry-v1+collide"
+    records = build_prior_versions(
+        result_groups=[
+            {"strategy_id": "s1", "strategy_version": shared, "count": 3, **_PINS},
+            {"strategy_id": "s2", "strategy_version": shared, "count": 5, **_PINS},
+        ],
+        scan_rows=[],
+        pins=_PINS,
+    )
+
+    assert records["s1"][0].result_count == 3
+    assert records["s2"][0].result_count == 5
+
+
+def test_identity_pins_cover_every_equality_the_current_reader_applies() -> None:
+    """If ``_RESULTS_SQL`` gains a pin and this does not, a prior version starts
+    reporting "comparable" on a basis the current reader would have rejected."""
+    from app.api.strategies import _RESULTS_SQL
+
+    for pin in _current_identity_pins():
+        assert f"r.{pin} = " in _RESULTS_SQL, f"{pin} is pinned by the prior-version reader but not by _RESULTS_SQL"


### PR DESCRIPTION
Closes #2624.

## What was wrong

The identity hash is over registry BYTES (#2394 §2), so **any** registry-touching merge mints a new `strategy_version`, and `sql/272_strategy_scan_watermark.sql` deliberately keys the watermark on it — a new version starts *"a new track record beside the old one"*. That versioning is correct and is untouched here.

"Beside the old one" never rendered. `get_strategy_overview` filters every read on `strategy_version = ANY(current)`, so at a rotation the operator got an empty card and a scan reported `never_run`: indistinguishable from a broken system, and at 7 registry-adjacent merges in one day, the page's steady state.

## Premise re-checked before designing (working-order 3c)

The issue's snapshot has **healed** — a backtest re-ran under the live versions on 08-12 18:59, so all four now hold 32 results and a watermark. The defect is structural, not a stuck state; it returns at the next merge. Acceptance therefore simulates a rotation, and no claim is made that the page is blank today.

One correction to the issue's text: `legacy_result_count` is **not** a prior-version summary. `_RESULT_COUNTS_SQL` filters on the current versions, so it counts rows under the *current* version matching no declared window — 0 for all four. Prior-version records were invisible entirely, not "one integer".

## Scope 2 — `rotated` is not `never_run`

`ScanHealth.status` gains `rotated`, with `rotation` carrying the previous version and the date it scanned through. `never_run` keeps its literal meaning: no version ever scanned.

The selection rule is scope 3's, not a second one — the greatest frontier date, which is what `assess_scan_freshness` already computes into its `fallback` basis. `_PRIOR_VERSION_SCANS_SQL` orders to match and breaks a frontier tie on the version, so the choice is deterministic.

⚠ Two scan-state models exist and this does **not** merge them: `ScanHealth.status` grades the frontier against `research_price_series`' max bar, `check_scan_freshness` grades it in trading days against `price_daily`. Merging them is out of scope and is named at the call site rather than done silently.

## Scope 1 — a pointer, not a metrics splice

`prior_versions` lists each earlier version that holds stored results: how many, when it last scanned, and **why its figures are not shown**.

It deliberately carries **no `ResultArm`**, and that is a measurement, not a simplification:

1. **No prior version is on the current measurement basis.** Grouping all 324 stored rows by their identity pins, the 128 matching today's constants are exactly the four CURRENT versions. Every version they replaced differs on at least `cost_model_id` (`static-p75-insession-v1` → `v2+split-adjusted-max`) and `return_basis` (`raw-close-price-return-v1` → `split-dividend-adjusted-wealth-v1`); most also on the position/outcome rule-set versions, some on `benchmark_rule` and `namespace`. Those pins **are** `ResultIdentity` — an old expectancy beside a new one is the cross-basis splice the repo forbids, and it misleads exactly where it is least visible.
2. **`promotion_refusals` cannot be reconstructed.** `_promotion_refusals` computes it at read time from *today's* gate; what was true when the row was written was never stored. Reusing `ResultArm` would re-judge history under rules it never faced. (Codex checkpoint 1.)

So it names the refusal instead — the posture #2602 item 5 sets for benchmark fields: never substitute. ⚠ Comparability is computed **per version**, not assumed: right after a registry-only merge the version just replaced *is* comparable.

### The bound needs no chosen number

| table | written by | cadence |
|---|---|---|
| `strategy_scan_watermark` | `strategy_signal_scan` | one row per scan-day per version — unbounded |
| `strategy_results_store` | `result_ledger` only (`:460`) | one batch per deliberate, #2600-charged trial |

Stored results are the qualifier; a watermark is not. A version that scanned and stored nothing has no track record — it has a scan, which `rotation` carries. ⚠ The first implementation admitted watermark-only versions and so reintroduced the unbounded growth this rule exists to prevent — **caught at Codex checkpoint 2**, fixed, and pinned by a test.

## Also fixed — `primaryEvidence()` matched a dead id

`StrategiesPage.tsx` looked for `window_id === "primary"`. The API cannot emit it; the declared ids are `primary-2022-plus`, `rolling-36m`, `rolling-24m` and the five calendar windows (`app/services/strategy_recent_evidence.py:29`). The branch was dead, so it always fell through to "first window with status complete" — order-dependent, and with the primary window `partial` while a calendar year is `complete` the headline "Expected / trade" described 2022 alone under a label saying primary.

The test fixture carried the same non-existent ids, which is why it went unnoticed. Fixture now uses declared ids; a regression test asserts the primary window's number is shown and the calendar year's is not.

## Verification

**API, against the real handler on the real dev DB:**

| | scan | evidence windows | history shown |
|---|---|---|---|
| simulated rotation, before | `never_run` | 0/8 | none |
| simulated rotation, after | `rotated`, prev `67dbf07c` through 2026-08-11 | 0/8 | prior versions + differing pins |
| live data, after | `stale` | 8/8 | 1 prior version per strategy |

Invariant asserted in the same run: `rotation` is non-null **iff** `status == "rotated"`.

**Page** (`:5173`, session cookie, 1600×1400): all four control cards render the block; scroller (`MAIN`) `scrollHeight` 1997 / `clientHeight` 1344 with **slack 0** at the bottom — no dead scroll-space; no console errors. Screenshot walked top and bottom.

⚠ FE-QA caught a real defect the component tests could not: all four strategies are `harness_validation`, rendered by `ValidationControl`, which never renders `EvidenceDetail`. The first version put the block only on the capital-candidate path — a payload nothing displays. A control-path test now pins it.

**Gates:** `ruff check` / `ruff format --check` / `pyright` clean; fast tier + `tests/smoke`; db tier `tests/test_api_strategies.py`; `pnpm typecheck`; `pnpm test:unit` (1508) and `StrategiesPage.test.tsx` (25). The `primaryEvidence` test was revert-probed — restoring the dead id fails it.

## Security

No change to the security model. The endpoint's auth is unchanged, the new fields are version identifiers, counts and dates already derivable from data the same response exposes, and no new input crosses a boundary. `incomparable_reasons` emits fixed column names from a code-side map, never driver or SQL text.

## Not done here

Merging the two scan-state models, and showing prior-version *metrics* — the latter needs `promotion_refusals` persisted at write time, which is a schema change and a separate ticket if wanted.