### PR TITLE
feature(#2603): prove the core instrument is the underlying product, not a CFD (item 2)

### DIFF
--- a/app/services/broker_settlement_arms.py
+++ b/app/services/broker_settlement_arms.py
@@ -1,0 +1,91 @@
+"""What counts as the UNDERLYING product, in one place.
+
+eToro's eligibility response documents a closed four-value ``settlementType``
+vocabulary, each with the provider's own definition (live portal 2026-08-13,
+``trading--demo/check-instrument-trading-eligibility``):
+
+===============  ==========================================================
+``real``         "the real instrument held in full value"
+``realFutures``  "the real future contract, which is a derivative of an
+                 underlying instrument"
+``marginTrade``  "the real instrument held with only a portion of its value
+                 called margin (leveraged asset)"
+``cfd``          "contract for difference, which is a derivative following
+                 the underlying instrument"
+===============  ==========================================================
+
+Exactly one of those is ownership at full value.  ``marginTrade`` IS the real
+instrument, but leveraged, which the standing no-leverage posture bars; the
+other two are derivatives by the provider's own wording.
+
+Two callers share this definition: ``strategy_core_eligibility`` (#2603 item 2's
+proof) and ``strategy_paper_executor._eligibility_reason`` (strategy entry arm
+selection).  Two copies of "what counts as the underlying" is exactly the drift
+#2437 keeps recording, so it lives here rather than in either.
+
+⚠ This is arm SELECTION only, and is deliberately narrower than any caller's
+full eligibility rule.  The executor additionally requires exactly one matching
+row, an ``allowStopLossTakeProfit`` arm and a satisfied minimum; a core sleeve is
+a stop-less indefinite holding and must not inherit an entry rule.  Calling this
+does not make a caller eligible to trade.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from app.providers.broker import BrokerInstrumentEligibility, BrokerLeverageConfig
+
+# The one settlement type that means ownership at full value.
+UNDERLYING_SETTLEMENT_TYPE = "real"
+UNDERLYING_DIRECTION = "long"
+UNLEVERAGED_LEVERAGE = 1
+
+
+def offers_unleveraged(leverage_values: Iterable[object]) -> bool:
+    """True when the arm offers x1.
+
+    ⚠ ``bool`` is a subclass of ``int`` in Python, so a naive ``1 in values`` is
+    true for ``leverageValues: [true]`` -- and the provider parser admits that,
+    because ``isinstance(True, int)`` passes its integer check.  Malformed broker
+    data must not be able to prove x1 eligibility.
+    """
+    return any(value == UNLEVERAGED_LEVERAGE and not isinstance(value, bool) for value in leverage_values)
+
+
+def is_underlying_long_arm(arm: BrokerLeverageConfig) -> bool:
+    """True when this arm is the underlying product, held long, unleveraged.
+
+    Compared case-insensitively: the documented vocabulary is the provider's
+    promise, not ours to depend on, and the demo response already answers its
+    response-level ``currency`` in lower case where the request sent upper.
+    Anything that is not ``real`` is not the underlying, including a value that
+    is not in the documented vocabulary at all -- unknown fails closed.
+    """
+    return (
+        arm.settlement_type.strip().lower() == UNDERLYING_SETTLEMENT_TYPE
+        and arm.direction.strip().lower() == UNDERLYING_DIRECTION
+        and offers_unleveraged(arm.leverage_values)
+    )
+
+
+def select_underlying_long_arms(
+    row: BrokerInstrumentEligibility,
+) -> tuple[BrokerLeverageConfig, ...]:
+    """Every arm on ``row`` that is the underlying product, held long, unleveraged.
+
+    Returns all matches rather than one: zero and many are different answers, and
+    a caller that cannot tell them apart reports "ambiguous" for an instrument
+    that is simply not offered as the underlying.
+    """
+    return tuple(arm for arm in row.leverage_configs if is_underlying_long_arm(arm))
+
+
+__all__ = [
+    "UNDERLYING_DIRECTION",
+    "UNDERLYING_SETTLEMENT_TYPE",
+    "UNLEVERAGED_LEVERAGE",
+    "is_underlying_long_arm",
+    "offers_unleveraged",
+    "select_underlying_long_arms",
+]

--- a/app/services/broker_settlement_arms.py
+++ b/app/services/broker_settlement_arms.py
@@ -49,8 +49,19 @@ def offers_unleveraged(leverage_values: Iterable[object]) -> bool:
     true for ``leverageValues: [true]`` -- and the provider parser admits that,
     because ``isinstance(True, int)`` passes its integer check.  Malformed broker
     data must not be able to prove x1 eligibility.
+
+    ⚠⚠ A boolean anywhere in the array disqualifies the WHOLE arm, not just that
+    entry.  Rejecting only the entry would let ``[1, true]`` qualify on its
+    genuine ``1``, and the qualifying arm's ``leverage_values`` is then PROJECTED
+    into storage -- where ``int(True)`` is ``1``, so the stored evidence would
+    claim the broker sent ``[1, 1]``.  Refusing the arm is what keeps a
+    projection from asserting something the response never contained; it also
+    fails closed, which is the right bias for an array we cannot read.
     """
-    return any(value == UNLEVERAGED_LEVERAGE and not isinstance(value, bool) for value in leverage_values)
+    values = list(leverage_values)
+    if any(isinstance(value, bool) for value in values):
+        return False
+    return any(value == UNLEVERAGED_LEVERAGE for value in values)
 
 
 def is_underlying_long_arm(arm: BrokerLeverageConfig) -> bool:

--- a/app/services/strategy_core_eligibility.py
+++ b/app/services/strategy_core_eligibility.py
@@ -1,0 +1,444 @@
+"""The account-specific core-instrument eligibility proof (#2603 item 2).
+
+Does a candidate core instrument exist on THIS account as the underlying product,
+or only as a CFD?  The question cannot be answered from anything we store about
+the instrument: SPY (3000) and SPY.RTH (3417) are the same fund -- identical
+``company_name``, identical ``maxUnitsPerOrder`` -- and only SPY.RTH carries a
+``real``/``long``/x1 arm.  Eligibility is per-account regulatory state that
+changes without notice, so the answer belongs to a dated observation.
+
+⚠⚠ **This is a WRITE-TIME gate and must never be cited as an execution control.**
+``require_core_eligibility`` refuses a mandate WRITE that names an unproved core
+instrument.  It does not, and cannot, stop anything trading: an enabled mandate
+stays enabled after its proof ages out or is superseded by a failing observation.
+Item 3 re-proves at execution time.  #2437's R4 comment records *a control that
+exists, is tested, and sits on a path the decision does not take* nine times over,
+so the boundary is named here rather than left to be inferred.
+
+⚠ Sizing is recorded, not decided.  ``min_position_amount`` /
+``min_position_exposure`` / ``max_units_per_order`` are stored as observed facts
+and no effective minimum is derived: the executor's
+``arm.min_position_amount or row.min_position_exposure`` precedence has no
+citation in the provider's documentation, and a missing floor is an order-sizing
+gap rather than evidence about what the product IS.
+
+Spec: ``docs/proposals/ta/2026-08-13-core-eligibility-proof.md``
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+
+import psycopg
+
+from app.providers.broker import BrokerEligibilityResponse
+from app.services.broker_settlement_arms import select_underlying_long_arms
+
+CORE_ELIGIBILITY_POLICY_VERSION = "core-eligibility-v1"
+
+# Fixed BY CONSTRUCTION: no published formulation governs it and the eligibility
+# response documents no freshness field of its own (verified on the live portal
+# 2026-08-13 -- the what-if COST endpoint has `lastUpdated`, eligibility does
+# not).  So the only measurable age is the age of OUR observation, and 24h is the
+# coarsest window under which a proof cannot outlive more than one intervening
+# trading session.  Re-proving is one request against a dedicated 20/min
+# endpoint, so this is a CEILING on staleness, not a target.
+CORE_ELIGIBILITY_MAX_AGE = timedelta(hours=24)
+
+# Everything here quotes and requests USD.  Held as a constant rather than a
+# literal so the #2603 item 4 currency lift has one place to look; note this is
+# the currency the PROOF was requested in, which is a different question from the
+# deployment-currency equality `_eligibility_reason` enforces.
+CORE_ELIGIBILITY_REQUEST_CURRENCY = "USD"
+
+CoreEligibilityVerdict = Literal["underlying", "not_underlying", "unresolved"]
+
+# Closed vocabulary, mirrored by the CHECK in sql/346.  `unresolved` means the
+# response did not answer the question; `not_underlying` means it answered and
+# the answer is no.  Only the second is a fact about the instrument.
+UNRESOLVED_REASONS = frozenset(
+    {
+        "instrument_not_resolved",
+        "eligibility_row_ambiguous",
+        "eligibility_currency_mismatch",
+        "eligibility_arm_ambiguous",
+    }
+)
+NOT_UNDERLYING_REASONS = frozenset({"instrument_not_open", "no_underlying_arm"})
+CORE_ELIGIBILITY_REASONS = UNRESOLVED_REASONS | NOT_UNDERLYING_REASONS
+
+
+class CoreEligibilityError(RuntimeError):
+    """A core instrument has no usable eligibility proof."""
+
+
+@dataclass(frozen=True)
+class CoreEligibilityAssessment:
+    """One evaluated eligibility response, before it is stored.
+
+    Pure product of ``evaluate_core_eligibility``; carries every column
+    ``record_core_eligibility_proof`` writes so the evaluation can be tested
+    without a database and the INSERT holds no second opinion.
+    """
+
+    verdict: CoreEligibilityVerdict
+    reason_code: str | None
+    response_currency: str
+    settlement_type: str | None
+    direction: str | None
+    leverage_values: tuple[int, ...] | None
+    qualifying_arm_count: int
+    allow_open_position: bool | None
+    allow_close_position: bool | None
+    allow_partial_close_position: bool | None
+    min_position_amount: Decimal | None
+    min_position_exposure: Decimal | None
+    max_units_per_order: Decimal | None
+    response_digest: str
+
+
+@dataclass(frozen=True)
+class CoreEligibilityProof:
+    """A stored observation, as read back."""
+
+    proof_id: int
+    instrument_id: int
+    operator_id: UUID
+    provider: str
+    environment: str
+    api_key_credential_id: UUID
+    user_key_credential_id: UUID
+    observed_at: Any
+    verdict: CoreEligibilityVerdict
+    reason_code: str | None
+    age_seconds: Decimal
+    policy_version: str
+
+
+def response_digest(raw: dict[str, Any]) -> str:
+    """SHA-256 over the canonicalised WHOLE response.
+
+    The whole response and not the instrument row, because response-level facts
+    (``currency``, ``notFoundInstrumentIds``) are part of the evidence.  That is
+    only sound because a proof requests exactly one instrument.
+
+    ``allow_nan=False`` turns a non-finite number into an error rather than
+    invalid JSON.  Sorted keys make the digest immune to field REORDERING but not
+    to field ADDITION -- deliberately: an added field is drift this provider has
+    shipped before, and re-proving costs one request.
+    """
+    canonical = json.dumps(raw, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _positive_or_none(value: Decimal | None) -> Decimal | None:
+    """Keep a broker-quoted bound only when it is finite and positive.
+
+    The provider may OMIT a minimum; it may not assert a non-positive or
+    non-finite one, and sql/346 refuses to store one either.  Dropping it to NULL
+    keeps the observation storable while recording "not quoted", which is what a
+    nonsense value actually tells us.
+    """
+    if value is None or not value.is_finite() or value <= 0:
+        return None
+    return value
+
+
+def evaluate_core_eligibility(
+    response: BrokerEligibilityResponse,
+    *,
+    instrument_id: int,
+    requested_currency: str = CORE_ELIGIBILITY_REQUEST_CURRENCY,
+) -> CoreEligibilityAssessment:
+    """Decide whether *instrument_id* is offered as the underlying product.
+
+    Pure: no connection, no clock, no broker.  Order of tests is the order in
+    which a response stops being able to answer -- not-found before row count,
+    row count before currency, currency before arms -- so a row that is both
+    resolved and listed as not-found reports the more specific failure.
+    """
+    digest = response_digest(response.raw_payload)
+    base: dict[str, Any] = {
+        "response_currency": response.currency,
+        "settlement_type": None,
+        "direction": None,
+        "leverage_values": None,
+        "qualifying_arm_count": 0,
+        "allow_open_position": None,
+        "allow_close_position": None,
+        "allow_partial_close_position": None,
+        "min_position_amount": None,
+        "min_position_exposure": None,
+        "max_units_per_order": None,
+        "response_digest": digest,
+    }
+
+    matches = [row for row in response.eligibilities if row.instrument_id == instrument_id]
+    if instrument_id in response.not_found_instrument_ids or not matches:
+        return CoreEligibilityAssessment(verdict="unresolved", reason_code="instrument_not_resolved", **base)
+    if len(matches) > 1:
+        return CoreEligibilityAssessment(verdict="unresolved", reason_code="eligibility_row_ambiguous", **base)
+
+    row = matches[0]
+    base.update(
+        allow_open_position=row.allow_open_position,
+        allow_close_position=row.allow_close_position,
+        allow_partial_close_position=row.allow_partial_close_position,
+        min_position_exposure=_positive_or_none(row.min_position_exposure),
+        max_units_per_order=_positive_or_none(row.max_units_per_order),
+    )
+
+    if response.currency.strip().upper() != requested_currency.strip().upper():
+        return CoreEligibilityAssessment(verdict="unresolved", reason_code="eligibility_currency_mismatch", **base)
+
+    arms = select_underlying_long_arms(row)
+    base["qualifying_arm_count"] = len(arms)
+    if not row.allow_open_position:
+        return CoreEligibilityAssessment(verdict="not_underlying", reason_code="instrument_not_open", **base)
+    if len(arms) != 1:
+        # Zero and many are DIFFERENT answers: "not offered as the underlying" is
+        # a fact about the instrument, "more than one qualifying arm" is a
+        # response we cannot read. Collapsing them is what makes the executor's
+        # single `eligibility_arm_ambiguous` misleading for the SPY case.
+        if arms:
+            return CoreEligibilityAssessment(verdict="unresolved", reason_code="eligibility_arm_ambiguous", **base)
+        return CoreEligibilityAssessment(verdict="not_underlying", reason_code="no_underlying_arm", **base)
+
+    arm = next(iter(arms))
+    base.update(
+        settlement_type=arm.settlement_type.strip().lower(),
+        direction=arm.direction.strip().lower(),
+        leverage_values=tuple(int(value) for value in arm.leverage_values),
+        min_position_amount=_positive_or_none(arm.min_position_amount),
+    )
+    return CoreEligibilityAssessment(verdict="underlying", reason_code=None, **base)
+
+
+def record_core_eligibility_proof(
+    conn: psycopg.Connection[Any],
+    *,
+    assessment: CoreEligibilityAssessment,
+    instrument_id: int,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
+    api_key_credential_id: UUID,
+    user_key_credential_id: UUID,
+    recorded_by: str,
+    requested_currency: str = CORE_ELIGIBILITY_REQUEST_CURRENCY,
+) -> int:
+    """Append one observation and return its id.
+
+    ⚠ A transport failure writes NOTHING.  The caller must not funnel a provider
+    exception into this function: absence of evidence stored as an observation
+    turns "we could not ask" into "the broker said".
+
+    ``observed_at`` is deliberately absent from the signature -- it is the
+    database's ``now()``, so no caller can extend a proof's validity by declaring
+    its age.
+    """
+    row = conn.execute(
+        """
+        INSERT INTO strategy_core_eligibility_proofs (
+            instrument_id, operator_id, provider, environment,
+            api_key_credential_id, user_key_credential_id,
+            verdict, reason_code, requested_currency, response_currency,
+            settlement_type, direction, leverage_values, qualifying_arm_count,
+            allow_open_position, allow_close_position, allow_partial_close_position,
+            min_position_amount, min_position_exposure, max_units_per_order,
+            response_digest, policy_version, recorded_by
+        )
+        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        RETURNING core_eligibility_proof_id
+        """,
+        (
+            instrument_id,
+            operator_id,
+            provider,
+            environment,
+            api_key_credential_id,
+            user_key_credential_id,
+            assessment.verdict,
+            assessment.reason_code,
+            requested_currency,
+            assessment.response_currency,
+            assessment.settlement_type,
+            assessment.direction,
+            list(assessment.leverage_values) if assessment.leverage_values is not None else None,
+            assessment.qualifying_arm_count,
+            assessment.allow_open_position,
+            assessment.allow_close_position,
+            assessment.allow_partial_close_position,
+            assessment.min_position_amount,
+            assessment.min_position_exposure,
+            assessment.max_units_per_order,
+            assessment.response_digest,
+            CORE_ELIGIBILITY_POLICY_VERSION,
+            recorded_by,
+        ),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def load_latest_core_eligibility_proof(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
+) -> CoreEligibilityProof | None:
+    """The newest observation for this instrument on this account, or None.
+
+    Age is computed in SQL against the same ``now()`` the caller's transaction
+    sees, so a freshness decision cannot straddle two clocks.
+    """
+    row = conn.execute(
+        """
+        SELECT core_eligibility_proof_id, instrument_id, operator_id, provider, environment,
+               api_key_credential_id, user_key_credential_id, observed_at, verdict, reason_code,
+               EXTRACT(EPOCH FROM (now() - observed_at))::numeric AS age_seconds, policy_version
+        FROM strategy_core_eligibility_proofs
+        WHERE instrument_id = %s AND operator_id = %s AND provider = %s AND environment = %s
+        ORDER BY observed_at DESC, core_eligibility_proof_id DESC
+        LIMIT 1
+        """,
+        (instrument_id, operator_id, provider, environment),
+    ).fetchone()
+    if row is None:
+        return None
+    return CoreEligibilityProof(
+        proof_id=int(row[0]),
+        instrument_id=int(row[1]),
+        operator_id=row[2],
+        provider=str(row[3]),
+        environment=str(row[4]),
+        api_key_credential_id=row[5],
+        user_key_credential_id=row[6],
+        observed_at=row[7],
+        verdict=str(row[8]),  # type: ignore[arg-type]
+        reason_code=None if row[9] is None else str(row[9]),
+        age_seconds=Decimal(str(row[10])),
+        policy_version=str(row[11]),
+    )
+
+
+def _live_credential_ids(
+    conn: psycopg.Connection[Any],
+    *,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
+) -> tuple[UUID, UUID]:
+    """The live ``(api_key, user_key)`` credential ids for this account.
+
+    ``broker_credentials_unique_active`` (sql/019) is unique on
+    ``(operator_id, provider, label, environment) WHERE revoked_at IS NULL``, so
+    at most one of each exists and this cannot return an arbitrary pick.
+
+    ⚠ ``FOR SHARE``, and it is load-bearing rather than defensive.  The caller's
+    advisory lock serialises MANDATE writers against each other; it says nothing
+    about a concurrent credential swap.  Without the row lock, a replacement that
+    commits between this read and the caller's INSERT would leave an enabled
+    mandate authorised by a proof belonging to the account that just went away --
+    exactly the inheritance the credential columns exist to prevent.  ``FOR
+    SHARE`` blocks the revoking UPDATE until the caller commits, and since the
+    partial unique index refuses a second live row per label, blocking the revoke
+    blocks the whole swap.  Shared, not exclusive: concurrent readers of the same
+    account are not a hazard, only a writer is.
+    """
+    rows = conn.execute(
+        """
+        SELECT label, id FROM broker_credentials
+        WHERE operator_id = %s AND provider = %s AND environment = %s
+          AND revoked_at IS NULL AND label IN ('api_key','user_key')
+        FOR SHARE
+        """,
+        (operator_id, provider, environment),
+    ).fetchall()
+    live = {str(label): value for label, value in rows}
+    if "api_key" not in live or "user_key" not in live:
+        raise CoreEligibilityError(
+            f"no live {provider} {environment} credential pair for this operator; "
+            "an eligibility proof cannot be attributed to an account that has none"
+        )
+    return live["api_key"], live["user_key"]
+
+
+def require_core_eligibility(
+    conn: psycopg.Connection[Any],
+    *,
+    instrument_id: int,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
+) -> CoreEligibilityProof:
+    """Raise unless this instrument has a fresh, passing, same-account proof.
+
+    Four separate ways to fail, each named, because "ineligible" would hide which
+    one happened:
+
+    * no observation at all;
+    * the newest observation says the instrument is not the underlying product,
+      or could not be resolved;
+    * the newest observation was taken under DIFFERENT credentials -- a swap can
+      put another eToro account behind the same operator/environment triple, and
+      inheriting the old account's proof is exactly the silent failure the
+      credential columns exist to prevent;
+    * the newest observation has aged past ``CORE_ELIGIBILITY_MAX_AGE``.  A proof
+      observed EXACTLY ``MAX_AGE`` ago is still fresh; the comparison is ``<=``.
+    """
+    proof = load_latest_core_eligibility_proof(
+        conn,
+        instrument_id=instrument_id,
+        operator_id=operator_id,
+        provider=provider,
+        environment=environment,
+    )
+    if proof is None:
+        raise CoreEligibilityError(
+            f"instrument {instrument_id} has no {provider} {environment} eligibility proof; "
+            "a core instrument must be proved to be the underlying product, not a CFD"
+        )
+    if proof.verdict != "underlying":
+        raise CoreEligibilityError(
+            f"instrument {instrument_id} eligibility proof {proof.proof_id} is {proof.verdict} ({proof.reason_code})"
+        )
+    api_key_id, user_key_id = _live_credential_ids(
+        conn, operator_id=operator_id, provider=provider, environment=environment
+    )
+    if (proof.api_key_credential_id, proof.user_key_credential_id) != (api_key_id, user_key_id):
+        raise CoreEligibilityError(
+            f"instrument {instrument_id} eligibility proof {proof.proof_id} was observed under "
+            "credentials that are no longer live; re-prove against the current account"
+        )
+    max_age_seconds = Decimal(int(CORE_ELIGIBILITY_MAX_AGE.total_seconds()))
+    if proof.age_seconds > max_age_seconds:
+        raise CoreEligibilityError(
+            f"instrument {instrument_id} eligibility proof {proof.proof_id} is "
+            f"{proof.age_seconds:.0f}s old, past the {max_age_seconds}s maximum"
+        )
+    return proof
+
+
+__all__ = [
+    "CORE_ELIGIBILITY_MAX_AGE",
+    "CORE_ELIGIBILITY_POLICY_VERSION",
+    "CORE_ELIGIBILITY_REASONS",
+    "CORE_ELIGIBILITY_REQUEST_CURRENCY",
+    "CoreEligibilityAssessment",
+    "CoreEligibilityError",
+    "CoreEligibilityProof",
+    "evaluate_core_eligibility",
+    "load_latest_core_eligibility_proof",
+    "record_core_eligibility_proof",
+    "require_core_eligibility",
+    "response_digest",
+]

--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -345,7 +345,13 @@ def configure_core_mandate(
         # Inside the lock and inside this transaction, so the freshness test and
         # the INSERT see the same `now()` -- transaction-start time is constant,
         # which is what removes the check-then-write window.
-        assert values.core_instrument_id is not None  # guaranteed by validate_core_mandate
+        # ⚠ NOT an `assert`. `validate_core_mandate` does guarantee this, but
+        # `python -O` strips asserts, and the surviving code would then call the
+        # gate with `instrument_id=None` -- which fails closed only because no
+        # proof can match NULL. A check standing between a caller and an
+        # authorisation must not be removable by an interpreter flag.
+        if values.core_instrument_id is None:
+            raise CoreMandateError("an enabled core mandate must name a core instrument")
         require_core_eligibility(
             conn,
             instrument_id=values.core_instrument_id,

--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -5,9 +5,13 @@ outside a declared band.  Event-shaped like the other capital authorities in
 ``strategy_control_plane``: one append-only row per operator change.
 
 ⚠ This module AUTHORISES NOTHING.  Nothing reads ``strategy_core_mandate_events``
-yet -- the allocator (#2603 item 3) is its first consumer, the eligibility proof
-(item 2) owns its own evidence shape, and no endpoint is wired.  It is state, not
-a gate, and must not be cited as one until something calls it.
+to act -- the allocator (#2603 item 3) is its first such consumer and no endpoint
+is wired.  It is state, not a gate, and must not be cited as one.
+
+What it now DOES do is refuse to record an unproved authority: as of item 2,
+``configure_core_mandate`` requires a fresh account-specific proof that an
+enabled mandate's core instrument is the underlying product and not a CFD.  That
+is a constraint on WRITES, not a control on trading -- see its docstring.
 
 ``CoreMandateError`` is deliberately standalone rather than a
 ``StrategyControlError`` subclass: no endpoint maps this path yet, so inheriting
@@ -21,8 +25,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import ROUND_DOWN, Decimal, InvalidOperation
 from typing import Any
+from uuid import UUID
 
 import psycopg
+
+from app.services.strategy_core_eligibility import require_core_eligibility
 
 # v2 as of #2670, which made both band triggers REACHABLE rather than merely in
 # range.  Bumped even though the table held 0 rows: a version denotes a rule set,
@@ -293,12 +300,32 @@ def configure_core_mandate(
     min_rebalance_amount: Decimal,
     changed_by: str,
     reason: str,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
     base_currency: str = CORE_MANDATE_BASE_CURRENCY,
 ) -> CoreMandate:
     """Append one material core/cash mandate revision.
 
     No parameter can record an eligibility proof: item 2 owns that evidence shape
     and gets its own table, so a mandate cannot claim proof it does not have.
+    What it must do instead is REQUIRE one that exists independently -- an
+    ENABLED mandate is refused unless its ``core_instrument_id`` has a fresh,
+    passing, same-account proof that the instrument is the underlying product and
+    not a CFD (``strategy_core_eligibility.require_core_eligibility``).
+
+    ``operator_id`` / ``provider`` / ``environment`` are required because a gate
+    that cannot name the account cannot select the right proof; eligibility is
+    per-account regulatory state, not an instrument attribute.
+
+    ⚠ A DISABLED mandate is not gated, and MAY still name an instrument --
+    ``strategy_core_mandate_enabled_has_instrument`` is one-directional. It is
+    ungated because it authorises nothing; re-enabling it passes the gate like
+    any other enable.
+
+    ⚠ This is a write-time gate only. It does not keep an already-enabled mandate
+    proved: a stored mandate outlives its proof, and item 3 re-proves at
+    execution time.
     """
     _require_text(changed_by, "changed_by", 200)
     _require_text(reason, "reason", 1000)
@@ -314,6 +341,18 @@ def configure_core_mandate(
     # Serialise revision allocation; the UNIQUE on revision is the backstop, not
     # the mechanism.
     conn.execute("SELECT pg_advisory_xact_lock(%s, %s)", CORE_MANDATE_ADVISORY_LOCK)
+    if values.enabled:
+        # Inside the lock and inside this transaction, so the freshness test and
+        # the INSERT see the same `now()` -- transaction-start time is constant,
+        # which is what removes the check-then-write window.
+        assert values.core_instrument_id is not None  # guaranteed by validate_core_mandate
+        require_core_eligibility(
+            conn,
+            instrument_id=values.core_instrument_id,
+            operator_id=operator_id,
+            provider=provider,
+            environment=environment,
+        )
     current = load_core_mandate(conn)
     if current is not None and not _is_material_change(current, values):
         raise CoreMandateError("core mandate change must alter at least one mandate value")

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -31,6 +31,7 @@ from app.providers.broker import (
     BrokerWhatIfCostResponse,
     BrokerWhatIfOrder,
 )
+from app.services.broker_settlement_arms import select_underlying_long_arms
 from app.services.cost_model import COST_MODEL_ID
 from app.services.market_calendar import us_market_status
 from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
@@ -599,11 +600,16 @@ def _eligibility_reason(response: BrokerEligibilityResponse, intent: _Intent, am
     matches = [row for row in response.eligibilities if row.instrument_id == intent.instrument_id]
     if len(matches) != 1 or not matches[0].allow_open_position:
         return "instrument_ineligible"
-    arms = [
-        arm
-        for arm in matches[0].leverage_configs
-        if arm.settlement_type.lower() == "real" and arm.direction.upper() == "LONG" and 1 in arm.leverage_values
-    ]
+    # One definition of "the underlying product, held long, unleveraged", shared
+    # with #2603 item 2's core eligibility proof. It is also stricter than the
+    # inline version it replaces: `bool` is an `int`, so `1 in leverage_values`
+    # was true for `leverageValues: [true]`, which the provider parser admits.
+    arms = select_underlying_long_arms(matches[0])
+    # ⚠ Zero arms and many arms are DIFFERENT answers -- "not offered as the
+    # underlying" versus "genuinely ambiguous" -- and the shared helper now tells
+    # them apart. Both still map to this one code because `reason_code` is stored
+    # data on `strategy_entry_preflights`; re-labelling it is a data-semantics
+    # change, filed as #2678 rather than folded into #2603 item 2.
     if len(arms) != 1:
         return "eligibility_arm_ambiguous"
     arm = arms[0]

--- a/docs/proposals/ta/2026-08-13-core-eligibility-proof.md
+++ b/docs/proposals/ta/2026-08-13-core-eligibility-proof.md
@@ -1,0 +1,308 @@
+# Core instrument eligibility proof — #2603 item 2
+
+The account-specific proof that a candidate core instrument is the **underlying product,
+not a CFD**, with the freshness rule that follows from eligibility not being immutable.
+
+Item 1 (`2026-08-13-core-cash-mandate.md`) deliberately shipped no eligibility columns:
+*"a timestamp plus a product-type label cannot prove 'underlying, not CFD': that needs
+account identity, the eligibility arm, the raw response reference and a freshness rule.
+Item 2 owns that evidence shape and gets its own table."* This is that shape.
+
+## Source rule
+
+`POST /api/v2/trading/info/{demo|real}/eligibility`, live portal fetched 2026-08-13 via
+`https://api-portal.etoro.com/api-reference/trading--demo/check-instrument-trading-eligibility.md`
+(WebFetch — `curl` is Cloudflare-blocked; see `.claude/skills/data-sources/etoro-api.md`).
+`LeverageConfiguration.settlementType` is a **documented closed vocabulary of four**, each
+with the provider's own definition:
+
+| value | eToro's documented definition |
+| --- | --- |
+| `real` | "the real instrument held in full value" |
+| `realFutures` | "the real future contract, which is a derivative of an underlying instrument" |
+| `marginTrade` | "the real instrument held with only a portion of its value called margin (leveraged asset)" |
+| `cfd` | "contract for difference, which is a derivative following the underlying instrument" |
+
+So "underlying, not a CFD" is **not** inferred here — it is read off the provider's own
+definitions. Exactly one value means ownership at full value: `real`.
+
+- `realFutures` and `cfd` are derivatives by the provider's own wording.
+- `marginTrade` **is** the real instrument, but held on margin — barred by the standing
+  no-leverage posture in `.claude/CLAUDE.md`, not by this vocabulary.
+
+`direction` is documented as `long` | `short`. The qualifying arm is therefore
+`settlementType == "real"` **and** `direction == "long"` **and** `1 ∈ leverageValues`.
+
+⚠ **The vocabulary is documented-closed, but it is read case-insensitively and an
+unrecognised value fails closed.** A closed vocabulary is the provider's promise, not ours
+to rely on: anything that is not `real` is not the underlying, including a value that does
+not appear in the table above. Observed values are lowercased before storage so the stored
+vocabulary is closed even if the wire one drifts.
+
+**No freshness field is documented on this response** — verified on the same page: no
+`lastUpdated`, no `asOf`. The what-if *cost* endpoint has one; eligibility does not. So the
+freshness rule cannot be sourced and is fixed by construction, below.
+
+## Full-population measurement (2026-08-13, demo account)
+
+Reproduce — do not quote these figures from this file:
+
+```bash
+PYTHONPATH=. uv run python scripts/prove_2603_core_eligibility.py census
+```
+
+Whole tradable universe, 12,728 ids, 128 requests inside the documented 20/min dedicated
+budget, 0 errors, 12,725 resolved (3 `notFoundInstrumentIds`):
+
+| type | resolved | with a `real`/`long`/x1 arm |
+| --- | --- | --- |
+| Stocks | 10,847 | 10,771 |
+| **ETF** | **1,232** | **703** |
+| Crypto | 332 | 223 |
+| Commodity / Indices | 234 | 0 (`realFutures` only) |
+
+⚠ **A five-name sample got this exactly wrong and the full population corrected it.**
+SPY, VOO, IVV, VTI and QQQ each return `cfd` arms only, which reads as "no ETF is available
+as the underlying". The population says 703 of 1,232 ETFs are. Of those 703, **37 are
+USD-quoted and 666 are not** (GBP 263 of 264, EUR, AUD 14 of 14, HKD 4 of 4, AED, CAD — the
+census prints the split). This is `.claude/CLAUDE.md`'s full-population rule doing its job
+on a **descriptive** claim, not on a gate.
+
+⚠⚠ **Scope of that measurement, stated because it bounds every claim above.** It is one
+account, one environment (`demo`), one instant. Eligibility is account and regulatory
+state, so none of it generalises to the real environment, to another account, or to
+tomorrow. That is not a caveat on the finding — it *is* the finding, and it is why this
+ticket ships a per-account proof rather than an instrument attribute.
+
+### The finding that decides the shape of this ticket
+
+`SPY` and `SPY.RTH` are **the same fund, listed twice**, and only one of them is ownable:
+
+| | `SPY` | `SPY.RTH` |
+| --- | --- | --- |
+| `instrument_id` | 3000 | 3417 |
+| `exchange` | 5 | 33 |
+| `company_name` | State Street SPDR S&P 500 ETF | State Street SPDR S&P 500 ETF |
+| `maxUnitsPerOrder` | 134.0 | 134.0 |
+| x1 long arm | **`cfd`** | **`real`** |
+| other arms | `cfd`/short x1-x20, `cfd`/long x2-x20 | identical |
+
+Naming `SPY` as the core instrument buys a contract for difference. Naming `SPY.RTH` buys
+the fund. **For this pair, no column of `instruments` separates them** — same
+`company_name`, `instrument_type_id`, `currency` and `country`; they differ on `symbol`
+suffix and `exchange`, and neither of those is a rule: exchange 33 holds 4 ETFs of which 2
+have a `real` arm, exchange 5 holds 390 of which 26 do, and `AAPL` carries a `real` arm
+with no suffix at all. ⚠ That is a statement about this pair plus two venue counts — it is
+**not** a full-population claim that no stored attribute could ever discriminate, and it is
+not offered as one.
+
+`QQQ.RTH` (3418) and `CSPX.L` (3434, GBP) behave the same way and are recorded as further
+candidates, not as a recommendation. **This spec selects no core instrument.** It makes a
+selection checkable.
+
+## Schema — `sql/346_core_eligibility_proofs.sql`
+
+`strategy_core_eligibility_proofs`, append-only. One row per observation, never updated. A
+failing observation is stored exactly as a passing one is: an observation is evidence.
+
+**Exactly one instrument per proof.** The recorder requests one id and the response is
+therefore entirely about that instrument, which is what lets a single `response_digest`
+stand as the whole evidence.
+
+### Account identity
+
+The triple `(operator_id, provider, environment)` names the account —
+`broker_credentials_unique_active` (sql/019) is unique on
+`(operator_id, provider, label, environment) WHERE revoked_at IS NULL`, so that triple has
+at most one live `api_key` row and one live `user_key` row. It is deliberately **not**
+`broker_credentials.id` alone: an eToro account is *two* credential rows, so no single row
+identifies it.
+
+But the triple is stable across a credential swap, and swapping in keys for a **different**
+eToro account would let the new account silently inherit the old one's proofs. So the proof
+also stores `api_key_credential_id` and `user_key_credential_id`, and the reader requires
+them to equal the currently-live pair. Rotating credentials invalidates every prior proof
+by construction rather than by a rule someone has to remember.
+
+⚠ **Known limit, stated rather than papered over.** These columns record which credentials
+the recorder *used*; nothing can stop a caller writing a row that asserts an account it
+never contacted. The table is evidence of an observation, not an attestation of one.
+
+### Columns
+
+| column | why |
+| --- | --- |
+| `instrument_id` | FK to `instruments`, `ON DELETE RESTRICT` — evidence outlives tidying |
+| `operator_id` / `provider` / `environment` | account identity |
+| `api_key_credential_id` / `user_key_credential_id` | the live pair used, per above |
+| `observed_at` | `DEFAULT now()`, **never a parameter** — a caller that supplies its own observation time can extend a proof's validity at will |
+| `verdict` | `underlying` \| `not_underlying` \| `unresolved` |
+| `reason_code` | closed six-value vocabulary, below |
+| `requested_currency` / `response_currency` | the request asks USD; the demo response answers `"usd"`, so the comparison is case-insensitive and the observed value is stored verbatim |
+| `settlement_type` / `direction` / `leverage_values` | the matched arm — NULL unless the verdict is `underlying`, because there is no matched arm otherwise |
+| `qualifying_arm_count` | so "exactly one qualifying arm" stays checkable after the fact, which a projection of the selected arm alone cannot show |
+| `allow_open_position` / `allow_close_position` / `allow_partial_close_position` | observed permissions |
+| `min_position_amount` / `min_position_exposure` / `max_units_per_order` | observed sizing facts |
+| `response_digest` | SHA-256 of the whole response |
+| `policy_version` / `recorded_by` | which rule set produced the verdict, and which caller observed it |
+
+### `response_digest` — the raw response reference, without the payload
+
+`sql/287`'s comment records the standing rule that *"raw broker/feed payloads are not
+persisted"*. The digest is SHA-256 over
+`json.dumps(raw, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)`
+of the entire parsed response — so it covers response-level facts (`currency`,
+`notFoundInstrumentIds`) that an instrument-row digest would miss, and `allow_nan=False`
+turns a non-finite number into an error instead of invalid JSON.
+
+⚠ **The tradeoff, chosen deliberately.** Sorting keys makes the digest immune to field
+*reordering* but not to field *addition*: a new provider field moves it even though nothing
+about eligibility changed. That is the direction to fail in — re-proving is one request, and
+a digest that ignored unknown fields would be silent about exactly the drift this skill's
+own history (documented `amount` → undocumented `value`) says to expect. The
+canonicalisation is pinned by `policy_version`; changing it is a new version, never a
+redefinition, or digests stop being comparable across the change.
+
+### Verdicts and the closed reason vocabulary
+
+`unresolved` means the response did not answer the question. `not_underlying` means it
+answered and the answer is no. The split matters because only the second is a fact about
+the instrument.
+
+| verdict | `reason_code` | when |
+| --- | --- | --- |
+| `unresolved` | `instrument_not_resolved` | id in `notFoundInstrumentIds`, or no matching row |
+| `unresolved` | `eligibility_row_ambiguous` | more than one row for the requested id |
+| `unresolved` | `eligibility_currency_mismatch` | `response.currency` ≠ requested |
+| `unresolved` | `eligibility_arm_ambiguous` | more than one qualifying arm |
+| `not_underlying` | `instrument_not_open` | `allowOpenPosition` false |
+| `not_underlying` | `no_underlying_arm` | zero qualifying arms — the SPY case |
+| `underlying` | *NULL* | exactly one qualifying arm on an openable row |
+
+⚠ **A transport failure writes no row.** An exception from the provider is the absence of
+evidence; persisting it as an observation would turn "we could not ask" into "the broker
+said". The recorder propagates and stores nothing.
+
+### Constraints
+
+- `(verdict = 'underlying') = (reason_code IS NULL)` — both directions, so a pass cannot
+  carry a reason and a failure cannot omit one.
+- `verdict = 'underlying'` implies `settlement_type = 'real'`, `direction = 'long'`,
+  `allow_open_position`, `qualifying_arm_count = 1`, `1 = ANY(leverage_values)` and
+  `upper(response_currency) = requested_currency`. Storing the projection is not enough:
+  without these, a row can look like a pass and not be one.
+- `verdict <> 'underlying'` implies `settlement_type`, `direction` and `leverage_values`
+  are all NULL — a failing row must not carry pass-shaped evidence.
+- Every stored minimum/maximum is `> 0` when present. The provider may omit them; it may
+  not assert a non-positive one.
+
+**Sizing is recorded, not decided.** `min_position_amount`, `min_position_exposure` and
+`max_units_per_order` are stored as observed facts and **no effective minimum is derived**.
+`_eligibility_reason` computes `arm.min_position_amount or row.min_position_exposure`, but
+that precedence has no citation in the provider's documentation, and a missing minimum is
+an order-sizing gap rather than evidence about what the product *is*. Making it a condition
+of `underlying` would conflate the two: a genuine `real`/`long`/x1 arm is the underlying
+product whether or not the response quoted a floor. Item 3 owns sizing and inherits both
+numbers. The same reasoning keeps `allow_close_position` and `allowStopLossTakeProfit` out
+of the verdict — a core sleeve does need to be sellable, but that is an execution property.
+
+Index on `(instrument_id, operator_id, provider, environment, observed_at DESC)`.
+
+## Freshness — fixed by construction, since no source rule exists
+
+`CORE_ELIGIBILITY_MAX_AGE = 24 hours`, frozen in
+`CORE_ELIGIBILITY_POLICY_VERSION = "core-eligibility-v1"`. A proof observed exactly
+`MAX_AGE` ago is still fresh: the comparison is `now() - observed_at <= MAX_AGE`, stated
+here because #2670 is the standing lesson that a boundary nobody wrote down is a boundary
+two pieces of code will disagree about.
+
+No published formulation governs this and the provider supplies no freshness field, so per
+`.claude/CLAUDE.md` the constant is fixed **by construction**, and the construction is what
+is defended rather than the number:
+
+1. Eligibility is account and regulatory state. It can change without notice and the
+   response carries no timestamp, so the only age measurable is the age of **our
+   observation**.
+2. 24 hours is the coarsest window under which a proof cannot outlive more than one
+   intervening trading session.
+3. Re-proving is cheap and bounded — one instrument is one request against a dedicated
+   20/min endpoint — so the constant is a **ceiling on staleness, not a target**. A caller
+   that re-proves every time is always correct and never rate-limited.
+
+⚠ It is a window, not an alarm. Nothing polls; a proof simply stops satisfying
+`require_core_eligibility` once it ages out.
+
+## The shared arm predicate — `app/services/broker_settlement_arms.py`
+
+`select_underlying_long_arms(row) -> tuple[BrokerLeverageConfig, ...]` returns every arm
+that is the underlying product, held long, unleveraged. One definition, two callers: this
+proof, and `strategy_paper_executor.py::_eligibility_reason`, which today spells the same
+triple out inline. Two copies of "what counts as the underlying" is the drift #2437 keeps
+recording.
+
+⚠ **The helper is arm SELECTION only, and is deliberately narrower than
+`_eligibility_reason`.** The executor additionally requires exactly one matching row, an
+`allowStopLossTakeProfit` arm and a satisfied minimum; those stay in the executor, because
+a core sleeve is a stop-less indefinite holding and must not inherit an entry rule.
+Calling the helper does not make a caller eligible to trade.
+
+⚠⚠ **`bool` is an `int` in Python, so `1 in leverage_values` is true for
+`leverageValues: [true]`** — and the provider parser admits it, because
+`isinstance(True, int)`. The helper tests `value == 1 and not isinstance(value, bool)`.
+Malformed broker data must not be able to prove x1 eligibility. This hardens the executor's
+existing path too, which is one of the reasons the definition moves rather than duplicates.
+
+⚠ **The executor's stored reason vocabulary does not change.** `_eligibility_reason` maps
+both "zero qualifying arms" and "more than one" to `eligibility_arm_ambiguous` exactly as
+it does today, even though the helper now distinguishes them. `strategy_entry_preflights.reason_code`
+is stored data; re-labelling it is a data-semantics change and is filed separately.
+
+## Wiring — one real consumer, chosen so this is not another R4 orphan
+
+`configure_core_mandate` refuses to append an **enabled** mandate unless the named
+`core_instrument_id` has a passing, unexpired proof for the account. `strategy_core_mandate`'s
+own docstring reserved this: *"No parameter can record an eligibility proof: item 2 owns
+that evidence shape and gets its own table, so a mandate cannot claim proof it does not
+have."* The mandate cannot claim it, so it must require one that exists independently.
+
+The writer gains required `operator_id` / `provider` / `environment` parameters, because a
+gate that cannot name the account cannot select the right proof. `configure_core_mandate`
+has no production caller today (tests only), so the signature change costs nothing.
+
+- The gate is the **selection** point: the mandate is where a core instrument is named, so
+  it is where naming a CFD has to fail.
+- The gate stays offline. It reads a table and makes no broker call, so the writer keeps
+  its pure-DB test surface and cannot fail on a network.
+- **No TOCTOU.** The check runs inside the writer's existing `pg_advisory_xact_lock`
+  transaction and both the check and the row's `observed_at` comparison use `now()`, which
+  is transaction-start time and therefore constant across check and insert.
+- A **disabled** mandate is not gated. ⚠ `strategy_core_mandate_enabled_has_instrument` is
+  `NOT enabled OR core_instrument_id IS NOT NULL`, so a disabled mandate *may* still name an
+  instrument — the earlier claim that it "names nothing" would have been wrong. It is
+  ungated because it authorises nothing, and no code reads a disabled mandate's instrument;
+  re-enabling it goes through the gate like any other enable.
+
+**This is not a `policy_version` bump, and the discriminator is worth stating.** #2670
+settled that *a version denotes a rule set, not a row population*, so "0 rows" never
+excuses leaving a version alone. It does not apply here on two counts. First,
+`validate_core_mandate` — the arithmetic the mandate's version stamps — is untouched, and
+every already-constructible `CoreMandate` remains valid with the identical meaning; the
+mechanical test is that the change does not edit that function, and it does not. Second,
+the rule set that *did* change is versioned: it is `core-eligibility-v1`, stamped on the
+proof row that the gate reads. A new rule set with its own version string is not an
+unversioned change.
+
+## What this does NOT do
+
+- **It selects no core instrument.** It makes a selection checkable.
+- **It does not decide `SPY` vs `SPY.RTH`.** It records that only one of them passes.
+- **It runs on no schedule.** No job, no cadence, no re-proof loop.
+- ⚠⚠ **It is a WRITE-TIME gate and must never be cited as an execution control.** An
+  enabled mandate stays enabled after its proof ages out or is superseded by a failing
+  observation — the gate constrains what may be written, not what may be traded. Item 3
+  must re-prove at execution time; the module docstring says so, so the next reader cannot
+  infer otherwise. Naming this is the whole of #2437's R4 lesson applied to my own slice.
+- **It grants no order path.** Nothing here submits, sizes or authorises a trade, and every
+  broker call it makes is the informational eligibility endpoint.
+- **It does not touch the real environment.** Every measurement is `demo`; the
+  `environment` column exists so a demo proof can never be read as a real one.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -4569,3 +4569,33 @@ with `verify_2598_preflight_quote_crosscheck.py --replay <fixture>`:
   `_build_credential_health_summary`; `app/services/strategy_scan_freshness.py::check_scan_freshness`;
   `tests/test_2674_status_probe_containment.py`;
   `tests/test_ops_monitor.py::TestCheckAllLayers::test_a_failed_layer_leaves_the_connection_usable`.
+
+### A CHECK constraint passes on NULL, so `col = 'x'` does not require `col = 'x'`
+
+- First seen in: #2603 item 2 (`sql/346_core_eligibility_proofs.sql`), caught by the module's
+  own DB test before review.
+- Symptom: `CONSTRAINT ... CHECK (verdict <> 'underlying' OR (settlement_type = 'real' AND ...))`
+  was written to refuse a row that *looks* like a pass and is not one — a stored eligibility
+  proof asserting `underlying` while carrying no matched arm. It admitted exactly that row.
+  Postgres CHECKs are satisfied unless the expression evaluates to **FALSE**, and
+  `NULL = 'real'` is NULL, not FALSE. Two of the six parametrised cases
+  (`settlement_type=None`, `direction=None`) went straight through the constraint whose entire
+  purpose was to stop them.
+- The general shape: **a completeness constraint on nullable columns must use NULL-safe
+  comparison.** `settlement_type IS NOT DISTINCT FROM 'real'` returns FALSE on NULL and is the
+  fix; `col IS NOT NULL AND col = 'x'` is equivalent and noisier. `col IS TRUE` is already
+  NULL-safe (unlike a bare `col`), and `1 = ANY(arr)` needs an explicit `arr IS NOT NULL`
+  conjunct for the same reason.
+- ⚠ The trap is specific to the constraint direction that matters. On a `verdict <> 'x' OR
+  (...)` shape the NULL leaks through the arm that is supposed to be strict, so the constraint
+  keeps refusing every case you thought to test *except* the omission it exists to catch —
+  which is the case a writer bug actually produces.
+- Prevention: for any CHECK of the form "when this row claims X, these columns must be
+  populated and equal to Y", parametrise a test over **each column set to NULL individually**,
+  not just over wrong values. A wrong value is refused by plain equality; only the NULL case
+  discriminates. If every column in the implication is `NOT NULL`, say so in a comment so the
+  next reader does not have to re-derive that the trap does not apply.
+- Enforced in: this log; `sql/346_core_eligibility_proofs.sql`
+  (`core_eligibility_underlying_is_complete`, with the reasoning inline);
+  `tests/test_2603_core_eligibility_db.py::test_an_underlying_row_cannot_be_incomplete`
+  (revert-probed: swapping `IS NOT DISTINCT FROM` back to `=` turns the two NULL cases red).

--- a/scripts/prove_2603_core_eligibility.py
+++ b/scripts/prove_2603_core_eligibility.py
@@ -1,0 +1,253 @@
+"""#2603 item 2 -- observe and record core-instrument eligibility proofs.
+
+Two modes, both READ-ONLY against the broker:
+
+``prove SYMBOL [SYMBOL ...]``
+    One informational eligibility request per instrument, each recorded as one
+    append-only row in ``strategy_core_eligibility_proofs``.  This is also the
+    revalidation instrument: a proof ages out after
+    ``CORE_ELIGIBILITY_MAX_AGE`` and re-proving is re-running this.
+
+``census``
+    The full-population measurement the spec's figures come from.  Reproduces
+    them rather than trusting a number written down, per
+    ``.claude/CLAUDE.md``'s "never hardcode a derived statistic" rule.
+
+⚠ Only ``POST /trading/info/{env}/eligibility`` is called.  Nothing here submits,
+sizes or authorises an order, and no position or order state is touched.
+
+⚠ A transport failure records NOTHING.  Storing "we could not ask" as an
+observation would turn absence of evidence into broker evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from collections import Counter
+from typing import Any
+from uuid import UUID
+
+import psycopg
+
+from app.config import settings
+from app.providers.implementations.etoro_broker import EtoroBrokerProvider
+from app.security.master_key import ensure_broker_key_loaded
+from app.services.broker_credentials import load_credential_for_provider_use
+from app.services.broker_settlement_arms import select_underlying_long_arms
+from app.services.operators import sole_operator_id
+from app.services.strategy_core_eligibility import (
+    CORE_ELIGIBILITY_REQUEST_CURRENCY,
+    evaluate_core_eligibility,
+    record_core_eligibility_proof,
+)
+
+logger = logging.getLogger("prove_2603_core_eligibility")
+
+PROVIDER = "etoro"
+RECORDED_BY = "prove_2603_core_eligibility"
+# eToro documents the eligibility endpoint at 20 requests/minute DEDICATED and at
+# most 100 ids per request (live portal 2026-08-13).  3.2s between requests keeps
+# a 128-batch census inside that budget with headroom.
+BATCH_SIZE = 100
+REQUEST_INTERVAL_S = 3.2
+
+
+def _credentials(conn: psycopg.Connection[Any], *, operator_id: UUID, environment: str) -> tuple[str, str, UUID, UUID]:
+    """Plaintext keys plus the credential-row ids the proof is attributed to."""
+    ensure_broker_key_loaded(conn)
+    api_key = load_credential_for_provider_use(
+        conn,
+        operator_id=operator_id,
+        provider=PROVIDER,
+        label="api_key",
+        environment=environment,
+        caller=RECORDED_BY,
+    )
+    conn.commit()
+    user_key = load_credential_for_provider_use(
+        conn,
+        operator_id=operator_id,
+        provider=PROVIDER,
+        label="user_key",
+        environment=environment,
+        caller=RECORDED_BY,
+    )
+    conn.commit()
+    rows = conn.execute(
+        """
+        SELECT label, id FROM broker_credentials
+        WHERE operator_id = %s AND provider = %s AND environment = %s
+          AND revoked_at IS NULL AND label IN ('api_key','user_key')
+        """,
+        (operator_id, PROVIDER, environment),
+    ).fetchall()
+    live = {str(label): value for label, value in rows}
+    return api_key, user_key, live["api_key"], live["user_key"]
+
+
+def _prove(args: argparse.Namespace) -> int:
+    with psycopg.connect(settings.database_url) as conn:
+        operator_id = sole_operator_id(conn)
+        api_key, user_key, api_key_id, user_key_id = _credentials(
+            conn, operator_id=operator_id, environment=args.environment
+        )
+        rows = conn.execute(
+            "SELECT instrument_id, symbol FROM instruments WHERE symbol = ANY(%s)",
+            (list(args.symbols),),
+        ).fetchall()
+        conn.commit()
+        found = {str(symbol): int(instrument_id) for instrument_id, symbol in rows}
+        missing = [symbol for symbol in args.symbols if symbol not in found]
+        if missing:
+            logger.error("unknown symbols (not in `instruments`): %s", ", ".join(missing))
+            return 1
+
+        results: list[dict[str, object]] = []
+        for symbol in args.symbols:
+            instrument_id = found[symbol]
+            # One instrument per request, deliberately: the proof digests the
+            # WHOLE response, which is only sound when the response is about
+            # exactly this instrument.
+            with EtoroBrokerProvider(api_key=api_key, user_key=user_key, env=args.environment) as broker:
+                response = broker.check_instrument_eligibility([instrument_id])
+            assessment = evaluate_core_eligibility(
+                response,
+                instrument_id=instrument_id,
+                requested_currency=CORE_ELIGIBILITY_REQUEST_CURRENCY,
+            )
+            with conn.transaction():
+                proof_id = record_core_eligibility_proof(
+                    conn,
+                    assessment=assessment,
+                    instrument_id=instrument_id,
+                    operator_id=operator_id,
+                    provider=PROVIDER,
+                    environment=args.environment,
+                    api_key_credential_id=api_key_id,
+                    user_key_credential_id=user_key_id,
+                    recorded_by=RECORDED_BY,
+                )
+            results.append(
+                {
+                    "symbol": symbol,
+                    "instrument_id": instrument_id,
+                    "proof_id": proof_id,
+                    "verdict": assessment.verdict,
+                    "reason_code": assessment.reason_code,
+                    "qualifying_arm_count": assessment.qualifying_arm_count,
+                    "settlement_type": assessment.settlement_type,
+                    "min_position_amount": str(assessment.min_position_amount),
+                    "min_position_exposure": str(assessment.min_position_exposure),
+                    "response_digest": assessment.response_digest[:16] + "...",
+                }
+            )
+            time.sleep(REQUEST_INTERVAL_S)
+
+    print(json.dumps({"environment": args.environment, "proofs": results}, indent=2))
+    return 0
+
+
+def _census(args: argparse.Namespace) -> int:
+    """Measure the whole tradable universe's settlement arms.
+
+    Reports the arm vocabulary per instrument type, and for ETFs the currency
+    split -- the two figures the spec cites.  Every number printed here is
+    computed at run time; none is written down anywhere.
+    """
+    with psycopg.connect(settings.database_url) as conn:
+        operator_id = sole_operator_id(conn)
+        api_key, user_key, _, _ = _credentials(conn, operator_id=operator_id, environment=args.environment)
+        universe = conn.execute(
+            """
+            SELECT instrument_id, symbol, instrument_type_id, upper(currency)
+            FROM instruments WHERE is_tradable ORDER BY instrument_id
+            """
+        ).fetchall()
+        type_names = dict(conn.execute("SELECT instrument_type_id, name FROM etoro_instrument_types").fetchall())
+        conn.commit()
+
+    meta = {int(row[0]): row for row in universe}
+    ids = sorted(meta)
+    resolved: Counter[int] = Counter()
+    underlying: Counter[int] = Counter()
+    arms: Counter[str] = Counter()
+    etf_by_ccy: Counter[str] = Counter()
+    etf_underlying_by_ccy: Counter[str] = Counter()
+    not_found = 0
+
+    for start in range(0, len(ids), BATCH_SIZE):
+        chunk = ids[start : start + BATCH_SIZE]
+        with EtoroBrokerProvider(api_key=api_key, user_key=user_key, env=args.environment) as broker:
+            response = broker.check_instrument_eligibility(chunk)
+        not_found += len(response.not_found_instrument_ids)
+        for row in response.eligibilities:
+            _, _, type_id, currency = meta[row.instrument_id]
+            type_id = int(type_id)
+            currency = str(currency)
+            resolved[type_id] += 1
+            for arm in row.leverage_configs:
+                arms[f"{type_names.get(type_id, type_id)}:{arm.settlement_type}/{arm.direction}"] += 1
+            is_underlying = bool(select_underlying_long_arms(row))
+            if is_underlying:
+                underlying[type_id] += 1
+            if type_id == 6:
+                etf_by_ccy[currency] += 1
+                if is_underlying:
+                    etf_underlying_by_ccy[currency] += 1
+        logger.info("resolved %d/%d", sum(resolved.values()), len(ids))
+        time.sleep(REQUEST_INTERVAL_S)
+
+    print(
+        json.dumps(
+            {
+                "environment": args.environment,
+                "requested": len(ids),
+                "resolved": sum(resolved.values()),
+                "not_found": not_found,
+                "by_type": {
+                    str(type_names.get(type_id, type_id)): {
+                        "resolved": count,
+                        "with_underlying_long_x1_arm": underlying[type_id],
+                    }
+                    for type_id, count in sorted(resolved.items())
+                },
+                "etf_by_currency": {
+                    currency: {
+                        "resolved": count,
+                        "with_underlying_long_x1_arm": etf_underlying_by_ccy[currency],
+                    }
+                    for currency, count in etf_by_ccy.most_common()
+                },
+                "arm_vocabulary": dict(sorted(arms.items())),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--environment",
+        default="demo",
+        choices=("demo", "real"),
+        help="broker environment the proof is attributed to (default: demo)",
+    )
+    sub = parser.add_subparsers(dest="mode", required=True)
+    prove = sub.add_parser("prove", help="record one proof per symbol")
+    prove.add_argument("symbols", nargs="+")
+    prove.set_defaults(func=_prove)
+    census = sub.add_parser("census", help="measure the whole tradable universe")
+    census.set_defaults(func=_census)
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sql/346_core_eligibility_proofs.sql
+++ b/sql/346_core_eligibility_proofs.sql
@@ -1,0 +1,151 @@
+-- 346_core_eligibility_proofs.sql
+--
+-- #2603 item 2.  The account-specific proof that a candidate core instrument is
+-- the UNDERLYING product and not a CFD.
+--
+-- Source rule: eToro's own documented `settlementType` vocabulary
+-- (POST /api/v2/trading/info/{demo|real}/eligibility, live portal 2026-08-13) --
+--   real         "the real instrument held in full value"
+--   realFutures  "the real future contract, which is a derivative ..."
+--   marginTrade  "the real instrument held with only a portion of its value ..."
+--   cfd          "contract for difference, which is a derivative ..."
+-- Exactly one of those is ownership at full value.  `marginTrade` IS the real
+-- instrument but is leveraged, which the standing no-leverage posture bars.
+--
+-- Why a proof and not an attribute on `instruments`: SPY (3000) and SPY.RTH
+-- (3417) are the SAME fund -- identical company_name and maxUnitsPerOrder -- and
+-- only SPY.RTH carries a `real`/`long`/x1 arm.  Nothing stored about the
+-- instrument separates them, and eligibility is per-account regulatory state
+-- that changes without notice, so the answer belongs to an observation.
+--
+-- APPEND-ONLY.  One row per observation, never updated.  A failing observation
+-- is stored exactly as a passing one is: an observation is evidence.
+--
+-- ⚠ This is a WRITE-TIME gate for `configure_core_mandate` and NOTHING ELSE.  An
+-- enabled mandate stays enabled after its proof ages out.  It must never be
+-- cited as an execution control; item 3 re-proves at execution time.
+--
+-- Spec: docs/proposals/ta/2026-08-13-core-eligibility-proof.md
+
+CREATE TABLE IF NOT EXISTS strategy_core_eligibility_proofs (
+    core_eligibility_proof_id    BIGSERIAL PRIMARY KEY,
+    instrument_id                BIGINT NOT NULL
+                                 REFERENCES instruments(instrument_id) ON DELETE RESTRICT,
+    -- Account identity.  NOT a single broker_credentials row: an eToro account is
+    -- two rows (api_key + user_key), so only the triple names it.
+    operator_id                  UUID NOT NULL
+                                 REFERENCES operators(operator_id) ON DELETE CASCADE,
+    provider                     TEXT NOT NULL CHECK (provider = 'etoro'),
+    environment                  TEXT NOT NULL CHECK (environment IN ('demo', 'real')),
+    -- The live pair actually used.  The triple above survives a credential swap,
+    -- so without these a DIFFERENT eToro account swapped in under the same
+    -- operator/environment would silently inherit these proofs.
+    api_key_credential_id        UUID NOT NULL
+                                 REFERENCES broker_credentials(id) ON DELETE RESTRICT,
+    user_key_credential_id       UUID NOT NULL
+                                 REFERENCES broker_credentials(id) ON DELETE RESTRICT,
+    -- DEFAULT now() and never a parameter: a caller that supplies its own
+    -- observation time can extend a proof's validity at will.
+    observed_at                  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    verdict                      TEXT NOT NULL
+                                 CHECK (verdict IN ('underlying', 'not_underlying', 'unresolved')),
+    reason_code                  TEXT CHECK (reason_code IN (
+                                     'instrument_not_resolved',
+                                     'eligibility_row_ambiguous',
+                                     'eligibility_currency_mismatch',
+                                     'eligibility_arm_ambiguous',
+                                     'instrument_not_open',
+                                     'no_underlying_arm'
+                                 )),
+    requested_currency           TEXT NOT NULL CHECK (requested_currency = 'USD'),
+    -- Stored verbatim: the demo response answers 'usd', so comparison is
+    -- case-insensitive but the observation is not rewritten.
+    response_currency            TEXT NOT NULL CHECK (char_length(response_currency) BETWEEN 1 AND 10),
+    -- The matched arm.  NULL unless the verdict is `underlying`, because there is
+    -- no matched arm otherwise.
+    settlement_type              TEXT CHECK (settlement_type = 'real'),
+    direction                    TEXT CHECK (direction = 'long'),
+    leverage_values              INTEGER[],
+    -- Kept so "exactly one qualifying arm" stays checkable after the fact; a
+    -- projection of the selected arm alone cannot show it.
+    qualifying_arm_count         SMALLINT NOT NULL CHECK (qualifying_arm_count >= 0),
+    allow_open_position          BOOLEAN,
+    allow_close_position         BOOLEAN,
+    allow_partial_close_position BOOLEAN,
+    -- Observed sizing facts.  NO effective minimum is derived here: the
+    -- `arm.min_position_amount or row.min_position_exposure` precedence the
+    -- executor uses has no citation in the provider's documentation, and a
+    -- missing floor is an order-sizing gap rather than evidence about what the
+    -- product IS.  Item 3 owns sizing and inherits both numbers.
+    min_position_amount          NUMERIC(18,6) CHECK (min_position_amount IS NULL OR min_position_amount > 0),
+    min_position_exposure        NUMERIC(18,6) CHECK (min_position_exposure IS NULL OR min_position_exposure > 0),
+    max_units_per_order          NUMERIC(18,6) CHECK (max_units_per_order IS NULL OR max_units_per_order > 0),
+    -- SHA-256 over the WHOLE canonicalised response, not the instrument row: it
+    -- has to cover `currency` and `notFoundInstrumentIds` too.  The recorder
+    -- requests exactly one instrument, which is what lets one response digest
+    -- stand as the whole evidence.  Raw payloads are not persisted (sql/287).
+    response_digest              TEXT NOT NULL CHECK (response_digest ~ '^[0-9a-f]{64}$'),
+    policy_version               TEXT NOT NULL CHECK (policy_version = 'core-eligibility-v1'),
+    recorded_by                  TEXT NOT NULL CHECK (char_length(recorded_by) BETWEEN 1 AND 100),
+
+    -- Both directions: a pass cannot carry a reason and a failure cannot omit one.
+    CONSTRAINT core_eligibility_reason_iff_not_underlying
+        CHECK ((verdict = 'underlying') = (reason_code IS NULL)),
+
+    -- Storing the projection is not enough -- without this a row can look like a
+    -- pass and not be one.
+    --
+    -- ⚠ `IS NOT DISTINCT FROM`, not `=`.  A CHECK passes on NULL, and
+    -- `NULL = 'real'` is NULL rather than false -- so plain equality would admit
+    -- an `underlying` row with a NULL settlement_type, which is precisely the
+    -- pass-shaped-but-not-a-pass row this constraint exists to refuse.  Same for
+    -- `direction`; `allow_open_position IS TRUE` is already NULL-safe, and the
+    -- `leverage_values IS NOT NULL` conjunct guards `= ANY` for the same reason.
+    CONSTRAINT core_eligibility_underlying_is_complete
+        CHECK (
+            verdict <> 'underlying'
+            OR (
+                settlement_type IS NOT DISTINCT FROM 'real'
+                AND direction IS NOT DISTINCT FROM 'long'
+                AND allow_open_position IS TRUE
+                AND qualifying_arm_count = 1
+                AND leverage_values IS NOT NULL
+                AND 1 = ANY (leverage_values)
+                AND upper(response_currency) = requested_currency
+            )
+        ),
+
+    -- A failing row must not carry pass-shaped evidence.
+    CONSTRAINT core_eligibility_failure_carries_no_arm
+        CHECK (
+            verdict = 'underlying'
+            OR (settlement_type IS NULL AND direction IS NULL AND leverage_values IS NULL)
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_core_eligibility_proofs_latest
+    ON strategy_core_eligibility_proofs
+       (instrument_id, operator_id, provider, environment, observed_at DESC);
+
+COMMENT ON TABLE strategy_core_eligibility_proofs IS
+    'Append-only account-specific observations of whether an instrument is offered as the '
+    'UNDERLYING product (#2603 item 2). Evidence of an observation, not an attestation of '
+    'one: the credential columns record which keys the recorder used, and nothing can stop '
+    'a caller asserting an account it never contacted. Write-time gate only -- an enabled '
+    'mandate outlives its proof, so this is never an execution control.';
+COMMENT ON COLUMN strategy_core_eligibility_proofs.observed_at IS
+    'Our clock, not the broker''s -- the eligibility response documents no lastUpdated/asOf '
+    'field (verified on the live portal 2026-08-13). DB-generated so a caller cannot extend '
+    'a proof''s validity by declaring its age.';
+COMMENT ON COLUMN strategy_core_eligibility_proofs.verdict IS
+    '`unresolved` = the response did not answer the question; `not_underlying` = it answered '
+    'and the answer is no. Only the second is a fact about the instrument.';
+COMMENT ON COLUMN strategy_core_eligibility_proofs.response_digest IS
+    'SHA-256 of json.dumps(raw, sort_keys=True, separators=(",",":"), ensure_ascii=False, '
+    'allow_nan=False). Sorted keys make it immune to field REORDERING but not to field '
+    'ADDITION -- deliberately, because an added field is drift this provider has shipped '
+    'before (documented `amount` -> undocumented `value`) and re-proving costs one request. '
+    'The canonicalisation is pinned by policy_version; changing it is a new version, never a '
+    'redefinition, or digests stop being comparable across the change.';
+COMMENT ON COLUMN strategy_core_eligibility_proofs.min_position_amount IS
+    'Observed, not decided. No effective minimum is derived here -- see the table body.';

--- a/tests/test_2603_core_eligibility.py
+++ b/tests/test_2603_core_eligibility.py
@@ -128,6 +128,22 @@ def test_a_boolean_true_does_not_prove_x1_eligibility() -> None:
     assert offers_unleveraged((1,))
 
 
+def test_a_boolean_disqualifies_the_whole_arm_not_just_that_entry() -> None:
+    """⚠ ``[1, true]`` must not qualify on its genuine ``1``.
+
+    A qualifying arm's ``leverage_values`` is PROJECTED into storage, and
+    ``int(True)`` is ``1`` -- so an arm admitted on the real entry would store
+    ``[1, 1]`` and assert the broker sent something it never did. Refusing the
+    arm is what stops the projection lying.
+    """
+    assert not offers_unleveraged((1, True))
+    assert not is_underlying_long_arm(arm(leverage_values=(1, True)))
+    assert (
+        evaluate_core_eligibility(response(row(arm(leverage_values=(1, True)))), instrument_id=INSTRUMENT).reason_code
+        == "no_underlying_arm"
+    )
+
+
 def test_zero_and_many_qualifying_arms_are_distinguishable() -> None:
     """The helper returns ALL matches so callers can tell them apart."""
     assert select_underlying_long_arms(row(arm(settlement_type="cfd"))) == ()

--- a/tests/test_2603_core_eligibility.py
+++ b/tests/test_2603_core_eligibility.py
@@ -1,0 +1,299 @@
+"""#2603 item 2 — the arm predicate and the eligibility verdict, as pure logic.
+
+No database and no broker: everything here is a function of one parsed response.
+The storage backstop and the mandate gate live in
+``test_2603_core_eligibility_db``.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.providers.broker import (
+    BrokerEligibilityResponse,
+    BrokerInstrumentEligibility,
+    BrokerLeverageConfig,
+)
+from app.services.broker_settlement_arms import (
+    is_underlying_long_arm,
+    offers_unleveraged,
+    select_underlying_long_arms,
+)
+from app.services.strategy_core_eligibility import (
+    CORE_ELIGIBILITY_REASONS,
+    UNRESOLVED_REASONS,
+    evaluate_core_eligibility,
+    response_digest,
+)
+
+INSTRUMENT = 3417
+
+
+def arm(
+    settlement_type: str = "real",
+    direction: str = "long",
+    leverage_values: tuple[object, ...] = (1,),
+    min_position_amount: Decimal | None = Decimal("10"),
+) -> BrokerLeverageConfig:
+    return BrokerLeverageConfig(
+        settlement_type=settlement_type,
+        direction=direction,
+        leverage_values=leverage_values,  # type: ignore[arg-type]
+        min_position_amount=min_position_amount,
+        allow_edit_stop_loss=True,
+        allow_edit_take_profit=True,
+        allow_stop_loss_take_profit=True,
+        raw_payload={},
+    )
+
+
+def row(
+    *arms: BrokerLeverageConfig,
+    instrument_id: int = INSTRUMENT,
+    allow_open_position: bool = True,
+    min_position_exposure: Decimal | None = Decimal("10"),
+    max_units_per_order: Decimal | None = Decimal("134"),
+) -> BrokerInstrumentEligibility:
+    return BrokerInstrumentEligibility(
+        instrument_id=instrument_id,
+        symbol="SPY.RTH",
+        min_position_exposure=min_position_exposure,
+        max_units_per_order=max_units_per_order,
+        allow_open_position=allow_open_position,
+        allow_close_position=True,
+        allow_partial_close_position=True,
+        allow_trailing_stop_loss=True,
+        leverage_configs=tuple(arms),
+        raw_payload={},
+    )
+
+
+def response(
+    *rows: BrokerInstrumentEligibility,
+    currency: str = "usd",
+    not_found: tuple[int, ...] = (),
+    raw: dict[str, object] | None = None,
+) -> BrokerEligibilityResponse:
+    return BrokerEligibilityResponse(
+        currency=currency,
+        eligibilities=tuple(rows),
+        not_found_instrument_ids=not_found,
+        not_found_symbols=(),
+        raw_payload=raw if raw is not None else {"currency": currency},
+    )
+
+
+# --------------------------------------------------------------------------
+# The shared arm predicate
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "settlement_type",
+    ["cfd", "realFutures", "marginTrade", "something_the_portal_has_not_documented"],
+)
+def test_only_real_is_the_underlying_product(settlement_type: str) -> None:
+    """Every other documented value is a derivative or is leveraged.
+
+    ``marginTrade`` IS the real instrument, so it is here for a reason the
+    vocabulary alone does not give: it is held on margin, which the standing
+    no-leverage posture bars. The undocumented value pins fail-closed.
+    """
+    assert not is_underlying_long_arm(arm(settlement_type=settlement_type))
+
+
+def test_the_vocabulary_is_read_case_insensitively() -> None:
+    """The live demo response answers `usd` where the request sent `USD`."""
+    assert is_underlying_long_arm(arm(settlement_type=" REAL ", direction="LONG"))
+
+
+def test_a_short_arm_is_not_the_core_holding() -> None:
+    assert not is_underlying_long_arm(arm(direction="short"))
+
+
+def test_a_leveraged_only_arm_is_not_unleveraged() -> None:
+    assert not is_underlying_long_arm(arm(leverage_values=(2, 5, 10, 20)))
+
+
+def test_a_boolean_true_does_not_prove_x1_eligibility() -> None:
+    """⚠ ``bool`` subclasses ``int``, so ``1 in (True,)`` is True.
+
+    The provider parser accepts ``leverageValues: [true]`` because
+    ``isinstance(True, int)`` passes its integer check, so without this guard
+    malformed broker data proves unleveraged eligibility. Revert-probe: drop the
+    ``not isinstance(value, bool)`` conjunct and this goes green the wrong way.
+    """
+    assert not offers_unleveraged((True,))
+    assert not is_underlying_long_arm(arm(leverage_values=(True,)))
+    assert offers_unleveraged((1,))
+
+
+def test_zero_and_many_qualifying_arms_are_distinguishable() -> None:
+    """The helper returns ALL matches so callers can tell them apart."""
+    assert select_underlying_long_arms(row(arm(settlement_type="cfd"))) == ()
+    assert len(select_underlying_long_arms(row(arm(), arm()))) == 2
+
+
+# --------------------------------------------------------------------------
+# The verdict
+# --------------------------------------------------------------------------
+
+
+def test_the_spy_rth_shape_proves_the_underlying() -> None:
+    """The measured SPY.RTH arm set: one real/long/x1 beside two CFD arms."""
+    assessment = evaluate_core_eligibility(
+        response(
+            row(
+                arm(),
+                arm(settlement_type="cfd", direction="short", leverage_values=(1, 2, 5, 10, 20)),
+                arm(settlement_type="cfd", leverage_values=(2, 5, 10, 20)),
+            )
+        ),
+        instrument_id=INSTRUMENT,
+    )
+    assert assessment.verdict == "underlying"
+    assert assessment.reason_code is None
+    assert assessment.settlement_type == "real"
+    assert assessment.direction == "long"
+    assert assessment.qualifying_arm_count == 1
+    assert assessment.leverage_values == (1,)
+
+
+def test_the_plain_spy_shape_is_not_underlying_rather_than_ambiguous() -> None:
+    """SPY's x1 long arm is a CFD, so the answer is a fact about the instrument.
+
+    ``eligibility_arm_ambiguous`` would say the response could not be read. It
+    was read perfectly: this fund is not offered as the underlying product.
+    """
+    assessment = evaluate_core_eligibility(
+        response(
+            row(
+                arm(settlement_type="cfd"),
+                arm(settlement_type="cfd", direction="short", leverage_values=(1, 2, 5, 10, 20)),
+                arm(settlement_type="cfd", leverage_values=(2, 5, 10, 20)),
+            )
+        ),
+        instrument_id=INSTRUMENT,
+    )
+    assert assessment.verdict == "not_underlying"
+    assert assessment.reason_code == "no_underlying_arm"
+    assert assessment.qualifying_arm_count == 0
+    assert assessment.settlement_type is None
+
+
+def test_a_failing_verdict_carries_no_arm_projection() -> None:
+    """sql/346 refuses pass-shaped evidence on a failing row; so does the evaluator."""
+    assessment = evaluate_core_eligibility(response(row(arm(), arm())), instrument_id=INSTRUMENT)
+    assert assessment.verdict == "unresolved"
+    assert assessment.reason_code == "eligibility_arm_ambiguous"
+    assert (assessment.settlement_type, assessment.direction, assessment.leverage_values) == (
+        None,
+        None,
+        None,
+    )
+    # But the count survives, which is what makes "exactly one arm" checkable later.
+    assert assessment.qualifying_arm_count == 2
+
+
+def test_a_not_found_instrument_is_unresolved_not_a_finding() -> None:
+    assessment = evaluate_core_eligibility(response(not_found=(INSTRUMENT,)), instrument_id=INSTRUMENT)
+    assert (assessment.verdict, assessment.reason_code) == (
+        "unresolved",
+        "instrument_not_resolved",
+    )
+
+
+def test_not_found_wins_over_a_row_that_also_came_back() -> None:
+    """A response asserting both is not readable; report the more specific failure."""
+    assessment = evaluate_core_eligibility(response(row(arm()), not_found=(INSTRUMENT,)), instrument_id=INSTRUMENT)
+    assert assessment.reason_code == "instrument_not_resolved"
+
+
+def test_duplicate_rows_for_one_id_are_unresolved() -> None:
+    assessment = evaluate_core_eligibility(response(row(arm()), row(arm())), instrument_id=INSTRUMENT)
+    assert assessment.reason_code == "eligibility_row_ambiguous"
+
+
+def test_a_currency_the_request_did_not_ask_for_is_unresolved() -> None:
+    """The minimums are denominated in it, so a mismatch makes them unreadable."""
+    assessment = evaluate_core_eligibility(response(row(arm()), currency="gbp"), instrument_id=INSTRUMENT)
+    assert assessment.reason_code == "eligibility_currency_mismatch"
+
+
+def test_a_closed_instrument_is_not_underlying() -> None:
+    assessment = evaluate_core_eligibility(response(row(arm(), allow_open_position=False)), instrument_id=INSTRUMENT)
+    assert (assessment.verdict, assessment.reason_code) == ("not_underlying", "instrument_not_open")
+
+
+def test_a_missing_minimum_does_not_block_the_product_proof() -> None:
+    """Product identity is not order sizing.
+
+    A genuine real/long/x1 arm IS the underlying product whether or not the
+    response quoted a floor. Requiring one would conflate what the product is
+    with whether an order can be sized, which is item 3's question.
+    """
+    assessment = evaluate_core_eligibility(
+        response(row(arm(min_position_amount=None), min_position_exposure=None)),
+        instrument_id=INSTRUMENT,
+    )
+    assert assessment.verdict == "underlying"
+    assert assessment.min_position_amount is None
+    assert assessment.min_position_exposure is None
+
+
+@pytest.mark.parametrize("bogus", [Decimal("0"), Decimal("-1"), Decimal("NaN")])
+def test_a_non_positive_or_non_finite_bound_is_recorded_as_not_quoted(bogus: Decimal) -> None:
+    """The provider may OMIT a minimum; it may not assert a nonsense one.
+
+    Dropping it to NULL keeps the observation storable (sql/346 refuses ``<= 0``)
+    and records what the value actually tells us.
+    """
+    assessment = evaluate_core_eligibility(
+        response(row(arm(min_position_amount=bogus), min_position_exposure=bogus)),
+        instrument_id=INSTRUMENT,
+    )
+    assert assessment.verdict == "underlying"
+    assert assessment.min_position_amount is None
+    assert assessment.min_position_exposure is None
+
+
+def test_every_reason_the_evaluator_can_emit_is_in_the_closed_vocabulary() -> None:
+    """The frozenset mirrors sql/346's CHECK; a new code must land in both."""
+    emitted = {
+        evaluate_core_eligibility(payload, instrument_id=INSTRUMENT).reason_code
+        for payload in (
+            response(not_found=(INSTRUMENT,)),
+            response(row(arm()), row(arm())),
+            response(row(arm()), currency="gbp"),
+            response(row(arm(), arm())),
+            response(row(arm(), allow_open_position=False)),
+            response(row(arm(settlement_type="cfd"))),
+        )
+    }
+    assert emitted == CORE_ELIGIBILITY_REASONS
+    assert UNRESOLVED_REASONS < CORE_ELIGIBILITY_REASONS
+
+
+# --------------------------------------------------------------------------
+# The digest
+# --------------------------------------------------------------------------
+
+
+def test_the_digest_ignores_key_order_but_not_a_new_field() -> None:
+    """Deliberate asymmetry, stated in sql/346.
+
+    Reordering is not drift; an ADDED field is, and this provider has shipped
+    exactly that before (documented ``amount`` → undocumented ``value``).
+    """
+    a = response_digest({"currency": "usd", "eligibilities": []})
+    b = response_digest({"eligibilities": [], "currency": "usd"})
+    c = response_digest({"currency": "usd", "eligibilities": [], "newField": 1})
+    assert a == b
+    assert a != c
+    assert len(a) == 64
+
+
+def test_a_non_finite_number_is_an_error_not_a_digest() -> None:
+    """``allow_nan=False``: NaN would otherwise serialise to invalid JSON."""
+    with pytest.raises(ValueError):
+        response_digest({"currency": "usd", "value": float("nan")})

--- a/tests/test_2603_core_eligibility_db.py
+++ b/tests/test_2603_core_eligibility_db.py
@@ -1,0 +1,554 @@
+"""#2603 item 2 — what ``sql/346`` enforces, and what the mandate gate refuses.
+
+⚠ THE MIGRATION'S BACKSTOP, NOT THE PYTHON RULE. The verdict arithmetic is
+covered by pure tests in ``test_2603_core_eligibility``; the CHECK tests here
+INSERT **raw SQL that bypasses the evaluator**, because a constraint that only
+ever sees pre-validated values is not demonstrably a backstop at all.
+
+⚠ In its own ``_db`` module deliberately: the string ``ebull_test_conn`` in a
+test source db-marks the WHOLE module at collection.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+
+from app.services.strategy_core_eligibility import (
+    CORE_ELIGIBILITY_MAX_AGE,
+    CORE_ELIGIBILITY_POLICY_VERSION,
+    CoreEligibilityAssessment,
+    CoreEligibilityError,
+    record_core_eligibility_proof,
+    require_core_eligibility,
+)
+from app.services.strategy_core_mandate import CoreMandateError, configure_core_mandate
+
+INSTRUMENT_ID = 920604
+DIGEST = "a" * 64
+
+_INSERT = """
+INSERT INTO strategy_core_eligibility_proofs (
+    instrument_id, operator_id, provider, environment,
+    api_key_credential_id, user_key_credential_id,
+    verdict, reason_code, requested_currency, response_currency,
+    settlement_type, direction, leverage_values, qualifying_arm_count,
+    allow_open_position, response_digest, policy_version, recorded_by
+) VALUES (
+    %(instrument_id)s, %(operator_id)s, 'etoro', 'demo',
+    %(api_key_credential_id)s, %(user_key_credential_id)s,
+    %(verdict)s, %(reason_code)s, 'USD', %(response_currency)s,
+    %(settlement_type)s, %(direction)s, %(leverage_values)s, %(qualifying_arm_count)s,
+    %(allow_open_position)s, %(response_digest)s, %(policy_version)s, 'test'
+)
+"""
+
+
+def _seed_instrument(conn: psycopg.Connection[Any]) -> int:
+    """``is_tradable`` listed explicitly per #1233 §6.2 (chokepoint lint)."""
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (%s,'CORE.ELIG','Core Eligibility Test',TRUE) ON CONFLICT DO NOTHING",
+        (INSTRUMENT_ID,),
+    )
+    return INSTRUMENT_ID
+
+
+def _seed_account(conn: psycopg.Connection[Any], *, environment: str = "demo") -> tuple[UUID, UUID, UUID]:
+    """One operator plus its live ``api_key``/``user_key`` pair.
+
+    The ciphertext is a placeholder: nothing here decrypts, and these tests are
+    about which credential ROW a proof is attributed to.
+    """
+    operator_id = uuid4()
+    conn.execute(
+        "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s,%s,'x')",
+        (operator_id, f"op_{operator_id.hex[:8]}"),
+    )
+    ids: list[UUID] = []
+    for label in ("api_key", "user_key"):
+        row = conn.execute(
+            """
+            INSERT INTO broker_credentials
+                (operator_id, provider, label, environment, ciphertext, last_four, key_version)
+            VALUES (%s,'etoro',%s,%s,'\\x00'::bytea,'0000',1)
+            RETURNING id
+            """,
+            (operator_id, label, environment),
+        ).fetchone()
+        assert row is not None
+        ids.append(row[0])
+    return operator_id, ids[0], ids[1]
+
+
+def _pass_row(operator_id: UUID, api_key_id: UUID, user_key_id: UUID) -> dict[str, Any]:
+    return {
+        "instrument_id": INSTRUMENT_ID,
+        "operator_id": operator_id,
+        "api_key_credential_id": api_key_id,
+        "user_key_credential_id": user_key_id,
+        "verdict": "underlying",
+        "reason_code": None,
+        "response_currency": "usd",
+        "settlement_type": "real",
+        "direction": "long",
+        "leverage_values": [1],
+        "qualifying_arm_count": 1,
+        "allow_open_position": True,
+        "response_digest": DIGEST,
+        "policy_version": CORE_ELIGIBILITY_POLICY_VERSION,
+    }
+
+
+def _account(conn: psycopg.Connection[Any]) -> tuple[UUID, UUID, UUID]:
+    _seed_instrument(conn)
+    return _seed_account(conn)
+
+
+# --------------------------------------------------------------------------
+# sql/346 as a backstop
+# --------------------------------------------------------------------------
+
+
+def test_the_reference_row_inserts(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """The control. Without it a CHECK test could pass for the wrong reason."""
+    ebull_test_conn.execute(_INSERT, _pass_row(*_account(ebull_test_conn)))
+    ebull_test_conn.rollback()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("settlement_type", None),
+        ("direction", None),
+        ("allow_open_position", False),
+        ("qualifying_arm_count", 2),
+        ("leverage_values", [2, 5]),
+        ("response_currency", "gbp"),
+    ],
+)
+def test_an_underlying_row_cannot_be_incomplete(
+    ebull_test_conn: psycopg.Connection[Any], field: str, value: Any
+) -> None:
+    """Storing the projection is not enough: each of these looks like a pass.
+
+    ``response_currency='gbp'`` is in the list because the minimums are
+    denominated in it — an ``underlying`` verdict quoted in a currency the
+    request did not ask for is not a readable proof.
+    """
+    row = {**_pass_row(*_account(ebull_test_conn)), field: value}
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(_INSERT, row)
+    ebull_test_conn.rollback()
+
+
+def test_a_failing_row_cannot_carry_pass_shaped_evidence(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    row = {
+        **_pass_row(*_account(ebull_test_conn)),
+        "verdict": "not_underlying",
+        "reason_code": "no_underlying_arm",
+    }
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(_INSERT, row)
+    ebull_test_conn.rollback()
+
+
+@pytest.mark.parametrize(
+    ("verdict", "reason_code"),
+    [("underlying", "no_underlying_arm"), ("not_underlying", None)],
+)
+def test_the_reason_is_present_exactly_when_the_verdict_fails(
+    ebull_test_conn: psycopg.Connection[Any], verdict: str, reason_code: str | None
+) -> None:
+    """Both directions: a pass cannot carry a reason, a failure cannot omit one."""
+    row = {
+        **_pass_row(*_account(ebull_test_conn)),
+        "verdict": verdict,
+        "reason_code": reason_code,
+        "settlement_type": None if verdict != "underlying" else "real",
+        "direction": None if verdict != "underlying" else "long",
+        "leverage_values": None if verdict != "underlying" else [1],
+    }
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(_INSERT, row)
+    ebull_test_conn.rollback()
+
+
+def test_an_undeclared_reason_code_is_refused(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """The SQL vocabulary mirrors the Python frozenset; both must move together."""
+    row = {
+        **_pass_row(*_account(ebull_test_conn)),
+        "verdict": "unresolved",
+        "reason_code": "made_up_reason",
+        "settlement_type": None,
+        "direction": None,
+        "leverage_values": None,
+    }
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(_INSERT, row)
+    ebull_test_conn.rollback()
+
+
+def test_evidence_outlives_tidying(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """``ON DELETE RESTRICT`` on the instrument FK: a proof is not collateral."""
+    row = ebull_test_conn.execute(
+        """
+        SELECT rc.delete_rule FROM information_schema.referential_constraints rc
+        JOIN information_schema.table_constraints tc
+          ON tc.constraint_name = rc.constraint_name
+        WHERE tc.table_name = 'strategy_core_eligibility_proofs'
+          AND rc.delete_rule = 'RESTRICT'
+        LIMIT 1
+        """
+    ).fetchone()
+    assert row is not None
+
+
+# --------------------------------------------------------------------------
+# The freshness / attribution rules
+# --------------------------------------------------------------------------
+
+
+def _require(conn: psycopg.Connection[Any], operator_id: UUID) -> Any:
+    return require_core_eligibility(
+        conn,
+        instrument_id=INSTRUMENT_ID,
+        operator_id=operator_id,
+        provider="etoro",
+        environment="demo",
+    )
+
+
+def test_a_fresh_passing_proof_satisfies_the_requirement(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    proof = _require(ebull_test_conn, operator_id)
+    assert proof.verdict == "underlying"
+    assert proof.policy_version == CORE_ELIGIBILITY_POLICY_VERSION
+    ebull_test_conn.rollback()
+
+
+def test_no_observation_at_all_is_its_own_refusal(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    operator_id, _, _ = _account(ebull_test_conn)
+    with pytest.raises(CoreEligibilityError, match="no etoro demo eligibility proof"):
+        _require(ebull_test_conn, operator_id)
+    ebull_test_conn.rollback()
+
+
+def test_only_the_newest_observation_counts(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """A later failure supersedes an earlier pass — evidence is not cumulative."""
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    ebull_test_conn.execute(
+        _INSERT,
+        {
+            **_pass_row(operator_id, api_key_id, user_key_id),
+            "verdict": "not_underlying",
+            "reason_code": "no_underlying_arm",
+            "settlement_type": None,
+            "direction": None,
+            "leverage_values": None,
+        },
+    )
+    with pytest.raises(CoreEligibilityError, match="not_underlying"):
+        _require(ebull_test_conn, operator_id)
+    ebull_test_conn.rollback()
+
+
+def test_a_proof_exactly_at_the_boundary_is_still_fresh(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """⚠ #2670's lesson: a boundary nobody writes down is one two readers disagree on.
+
+    The comparison is ``age <= MAX_AGE``, so exactly ``MAX_AGE`` passes and one
+    second past it does not. Both sides asserted, because only the pair pins it.
+    """
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    ebull_test_conn.execute(
+        "UPDATE strategy_core_eligibility_proofs SET observed_at = now() - %s",
+        (CORE_ELIGIBILITY_MAX_AGE,),
+    )
+    assert _require(ebull_test_conn, operator_id).verdict == "underlying"
+
+    ebull_test_conn.execute(
+        "UPDATE strategy_core_eligibility_proofs SET observed_at = now() - %s",
+        (CORE_ELIGIBILITY_MAX_AGE + timedelta(seconds=1),),
+    )
+    with pytest.raises(CoreEligibilityError, match="past the"):
+        _require(ebull_test_conn, operator_id)
+    ebull_test_conn.rollback()
+
+
+def test_a_credential_swap_invalidates_every_prior_proof(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The account triple survives a swap; a DIFFERENT eToro account must not
+    inherit the old one's proofs. Revoking and re-adding changes the row ids,
+    which is what makes the invalidation structural rather than remembered."""
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    assert _require(ebull_test_conn, operator_id).verdict == "underlying"
+
+    ebull_test_conn.execute("UPDATE broker_credentials SET revoked_at = now() WHERE operator_id = %s", (operator_id,))
+    for label in ("api_key", "user_key"):
+        ebull_test_conn.execute(
+            """
+            INSERT INTO broker_credentials
+                (operator_id, provider, label, environment, ciphertext, last_four, key_version)
+            VALUES (%s,'etoro',%s,'demo','\\x00'::bytea,'0000',1)
+            """,
+            (operator_id, label),
+        )
+    with pytest.raises(CoreEligibilityError, match="no longer live"):
+        _require(ebull_test_conn, operator_id)
+    ebull_test_conn.rollback()
+
+
+def test_an_account_with_no_live_pair_cannot_hold_a_proof(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    ebull_test_conn.execute(
+        "UPDATE broker_credentials SET revoked_at = now() WHERE operator_id = %s AND label='user_key'",
+        (operator_id,),
+    )
+    with pytest.raises(CoreEligibilityError, match="no live etoro demo credential pair"):
+        _require(ebull_test_conn, operator_id)
+    ebull_test_conn.rollback()
+
+
+def test_a_proof_does_not_cross_environments(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """A demo proof must never be readable as a real one."""
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    with pytest.raises(CoreEligibilityError, match="no etoro real eligibility proof"):
+        require_core_eligibility(
+            ebull_test_conn,
+            instrument_id=INSTRUMENT_ID,
+            operator_id=operator_id,
+            provider="etoro",
+            environment="real",
+        )
+    ebull_test_conn.rollback()
+
+
+def test_the_recorder_takes_no_observation_time(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """``observed_at`` is the database's ``now()``.
+
+    A caller that could declare its own observation time could extend a proof's
+    validity at will, so the parameter does not exist.
+    """
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    proof_id = record_core_eligibility_proof(
+        ebull_test_conn,
+        assessment=CoreEligibilityAssessment(
+            verdict="underlying",
+            reason_code=None,
+            response_currency="usd",
+            settlement_type="real",
+            direction="long",
+            leverage_values=(1,),
+            qualifying_arm_count=1,
+            allow_open_position=True,
+            allow_close_position=True,
+            allow_partial_close_position=True,
+            min_position_amount=Decimal("10"),
+            min_position_exposure=Decimal("10"),
+            max_units_per_order=Decimal("134"),
+            response_digest=DIGEST,
+        ),
+        instrument_id=INSTRUMENT_ID,
+        operator_id=operator_id,
+        provider="etoro",
+        environment="demo",
+        api_key_credential_id=api_key_id,
+        user_key_credential_id=user_key_id,
+        recorded_by="test",
+    )
+    row = ebull_test_conn.execute(
+        "SELECT observed_at <= now(), observed_at > now() - interval '1 minute' "
+        "FROM strategy_core_eligibility_proofs WHERE core_eligibility_proof_id = %s",
+        (proof_id,),
+    ).fetchone()
+    assert row == (True, True)
+    ebull_test_conn.rollback()
+
+
+# --------------------------------------------------------------------------
+# The mandate gate — the one consumer
+# --------------------------------------------------------------------------
+
+
+def _configure(conn: psycopg.Connection[Any], operator_id: UUID, *, enabled: bool = True) -> Any:
+    return configure_core_mandate(
+        conn,
+        enabled=enabled,
+        core_instrument_id=INSTRUMENT_ID,
+        core_target_pct=Decimal("60"),
+        liquidity_reserve_pct=Decimal("20"),
+        rebalance_band_pct=Decimal("5"),
+        min_rebalance_amount=Decimal("25"),
+        changed_by="test",
+        reason="core/cash mandate",
+        operator_id=operator_id,
+        provider="etoro",
+        environment="demo",
+    )
+
+
+def test_an_enabled_mandate_is_refused_without_a_proof(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """Naming a CFD as the core instrument has to fail at the selection point."""
+    operator_id, _, _ = _account(ebull_test_conn)
+    with pytest.raises(CoreEligibilityError, match="underlying product, not a CFD"):
+        _configure(ebull_test_conn, operator_id)
+    ebull_test_conn.rollback()
+
+
+def test_an_enabled_mandate_is_refused_on_a_failing_proof(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The plain-SPY case: the response was read fine and the answer is no."""
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(
+        _INSERT,
+        {
+            **_pass_row(operator_id, api_key_id, user_key_id),
+            "verdict": "not_underlying",
+            "reason_code": "no_underlying_arm",
+            "settlement_type": None,
+            "direction": None,
+            "leverage_values": None,
+        },
+    )
+    with pytest.raises(CoreEligibilityError, match="no_underlying_arm"):
+        _configure(ebull_test_conn, operator_id)
+    ebull_test_conn.rollback()
+
+
+def test_an_enabled_mandate_is_accepted_on_a_fresh_passing_proof(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    mandate = _configure(ebull_test_conn, operator_id)
+    assert mandate.revision == 1 and mandate.enabled
+    ebull_test_conn.rollback()
+
+
+def test_a_disabled_mandate_is_not_gated(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """⚠ It MAY still name an instrument — ``..._enabled_has_instrument`` is
+    one-directional — and is ungated because it authorises nothing."""
+    operator_id, _, _ = _account(ebull_test_conn)
+    mandate = _configure(ebull_test_conn, operator_id, enabled=False)
+    assert not mandate.enabled
+    assert mandate.core_instrument_id == INSTRUMENT_ID
+    ebull_test_conn.rollback()
+
+
+def test_re_enabling_a_disabled_mandate_passes_through_the_gate(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The hole a write-time gate would otherwise leave: name it while disabled,
+    then flip the flag."""
+    operator_id, _, _ = _account(ebull_test_conn)
+    _configure(ebull_test_conn, operator_id, enabled=False)
+    with pytest.raises(CoreEligibilityError):
+        _configure(ebull_test_conn, operator_id, enabled=True)
+    ebull_test_conn.rollback()
+
+
+def test_the_gate_does_not_move_the_mandate_policy_version(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """A precondition on WRITES is not a change to the arithmetic the version stamps.
+
+    #2670 settled that 0 rows never excuses leaving a version alone — but that
+    applies to a change in what a stored row MEANS. Every ``CoreMandate`` remains
+    valid here with the identical meaning; the rule set that did change carries
+    its own version (``core-eligibility-v1``) on the proof row.
+    """
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    mandate = _configure(ebull_test_conn, operator_id)
+    assert mandate.policy_version == "core-mandate-v2"
+    ebull_test_conn.rollback()
+
+
+def test_a_refused_mandate_writes_no_row(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """⚠ The post-condition is a SUBSEQUENT statement, not the raised error.
+
+    A test that only asserts the exception passes against a version that raises
+    AFTER inserting (#2674's lesson). The advisory lock is taken before the gate,
+    so this also pins that the refusal happens before any append.
+    """
+    operator_id, _, _ = _account(ebull_test_conn)
+    with pytest.raises(CoreEligibilityError):
+        _configure(ebull_test_conn, operator_id)
+    remaining = ebull_test_conn.execute("SELECT count(*) FROM strategy_core_mandate_events").fetchone()
+    assert remaining == (0,)
+    ebull_test_conn.rollback()
+
+
+def test_the_mandate_error_type_is_not_swallowed(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """``CoreEligibilityError`` is not a ``CoreMandateError``: an eligibility
+    refusal is about the ACCOUNT, not about the mandate's arithmetic, and a
+    caller that catches only the latter must not silently treat it as valid."""
+    operator_id, _, _ = _account(ebull_test_conn)
+    with pytest.raises(CoreEligibilityError):
+        _configure(ebull_test_conn, operator_id)
+    assert not issubclass(CoreEligibilityError, CoreMandateError)
+    ebull_test_conn.rollback()
+
+
+def test_the_gate_blocks_a_concurrent_credential_swap(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """⚠ The mandate advisory lock serialises MANDATE writers, not credential swaps.
+
+    Without ``FOR SHARE`` on the live pair, a revoke committing between the
+    freshness read and the mandate INSERT leaves an enabled mandate authorised by
+    the account that just went away. The post-condition is a SECOND connection's
+    behaviour, not this one's return value: a test that only re-read the ids here
+    would pass against the unlocked version.
+    """
+    from tests.fixtures.ebull_test_db import test_database_url
+
+    operator_id, api_key_id, user_key_id = _account(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _pass_row(operator_id, api_key_id, user_key_id))
+    ebull_test_conn.commit()
+
+    # Hold the gate's read open, as `configure_core_mandate` does between the
+    # check and its INSERT.
+    assert _require(ebull_test_conn, operator_id).verdict == "underlying"
+
+    with psycopg.connect(test_database_url()) as other:
+        other.execute("SET LOCAL lock_timeout = '1s'")
+        with pytest.raises(psycopg.errors.LockNotAvailable):
+            other.execute(
+                "UPDATE broker_credentials SET revoked_at = now() WHERE operator_id = %s",
+                (operator_id,),
+            )
+        other.rollback()
+
+    ebull_test_conn.rollback()
+    ebull_test_conn.execute("DELETE FROM strategy_core_eligibility_proofs")
+    ebull_test_conn.execute("DELETE FROM broker_credentials WHERE operator_id = %s", (operator_id,))
+    ebull_test_conn.execute("DELETE FROM operators WHERE operator_id = %s", (operator_id,))
+    ebull_test_conn.commit()

--- a/tests/test_2603_core_mandate_db.py
+++ b/tests/test_2603_core_mandate_db.py
@@ -15,6 +15,7 @@ import re
 from decimal import Decimal
 from pathlib import Path
 from typing import Any, LiteralString, cast
+from uuid import uuid4
 
 import psycopg
 import pytest
@@ -82,6 +83,49 @@ def _seed_instrument(conn: psycopg.Connection[Any]) -> int:
         "VALUES (920603,'CORE.TEST','Core Mandate Test',TRUE) ON CONFLICT DO NOTHING"
     )
     return 920603
+
+
+def _seed_proved_account(conn: psycopg.Connection[Any], instrument_id: int) -> dict[str, Any]:
+    """An operator with a live credential pair and a passing eligibility proof.
+
+    #2603 item 2 gates an ENABLED mandate on one; the gate itself is covered in
+    ``test_2603_core_eligibility_db``, so this is only the setup the writer's own
+    revision behaviour now needs.
+    """
+    operator_id = uuid4()
+    conn.execute(
+        "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s,%s,'x')",
+        (operator_id, f"op_{operator_id.hex[:8]}"),
+    )
+    credential_ids: list[Any] = []
+    for label in ("api_key", "user_key"):
+        row = conn.execute(
+            """
+            INSERT INTO broker_credentials
+                (operator_id, provider, label, environment, ciphertext, last_four, key_version)
+            VALUES (%s,'etoro',%s,'demo','\\x00'::bytea,'0000',1)
+            RETURNING id
+            """,
+            (operator_id, label),
+        ).fetchone()
+        assert row is not None
+        credential_ids.append(row[0])
+    conn.execute(
+        """
+        INSERT INTO strategy_core_eligibility_proofs (
+            instrument_id, operator_id, provider, environment,
+            api_key_credential_id, user_key_credential_id,
+            verdict, requested_currency, response_currency,
+            settlement_type, direction, leverage_values, qualifying_arm_count,
+            allow_open_position, response_digest, policy_version, recorded_by
+        ) VALUES (
+            %s,%s,'etoro','demo',%s,%s,'underlying','USD','usd','real','long',
+            ARRAY[1],1,TRUE,%s,'core-eligibility-v1','test'
+        )
+        """,
+        (instrument_id, operator_id, credential_ids[0], credential_ids[1], "a" * 64),
+    )
+    return {"operator_id": operator_id, "provider": "etoro", "environment": "demo"}
 
 
 def test_the_reference_row_inserts(ebull_test_conn: psycopg.Connection[Any]) -> None:
@@ -308,6 +352,7 @@ def test_the_writer_appends_revisions_and_refuses_a_no_op(
     """
     assert load_core_mandate(ebull_test_conn) is None
     instrument_id = _seed_instrument(ebull_test_conn)
+    account = _seed_proved_account(ebull_test_conn, instrument_id)
 
     first = configure_core_mandate(
         ebull_test_conn,
@@ -319,6 +364,7 @@ def test_the_writer_appends_revisions_and_refuses_a_no_op(
         min_rebalance_amount=Decimal("25"),
         changed_by="test",
         reason="initial core/cash mandate",
+        **account,
     )
     assert first.revision == 1
     assert first.cash_target_pct == Decimal("40")
@@ -333,6 +379,7 @@ def test_the_writer_appends_revisions_and_refuses_a_no_op(
         min_rebalance_amount=Decimal("25"),
         changed_by="test",
         reason="raise the core weight",
+        **account,
     )
     assert second.revision == 2
     assert load_core_mandate(ebull_test_conn) == second
@@ -348,5 +395,6 @@ def test_the_writer_appends_revisions_and_refuses_a_no_op(
             min_rebalance_amount=Decimal("25"),
             changed_by="test",
             reason="no material change",
+            **account,
         )
     ebull_test_conn.rollback()


### PR DESCRIPTION
## What this is

#2603 **item 2**: the account-specific proof that a candidate core instrument is the
**underlying product, not a CFD**, with its own evidence table and a declared
freshness/revalidation rule.

Item 1 deliberately shipped no eligibility columns and said why
(`docs/proposals/ta/2026-08-13-core-cash-mandate.md`): *"a timestamp plus a product-type
label cannot prove 'underlying, not CFD': that needs account identity, the eligibility arm,
the raw response reference and a freshness rule. Item 2 owns that evidence shape and gets
its own table."* This is that shape.

Spec: `docs/proposals/ta/2026-08-13-core-eligibility-proof.md`.

## Source rule

`POST /api/v2/trading/info/{demo|real}/eligibility`, live portal fetched 2026-08-13
(`trading--demo/check-instrument-trading-eligibility`, via WebFetch — `curl` is
Cloudflare-blocked). `LeverageConfiguration.settlementType` is a **documented closed
vocabulary of four**, each with the provider's own definition:

| value | eToro's documented definition |
| --- | --- |
| `real` | "the real instrument held in full value" |
| `realFutures` | "the real future contract, which is a derivative of an underlying instrument" |
| `marginTrade` | "the real instrument held with only a portion of its value called margin (leveraged asset)" |
| `cfd` | "contract for difference, which is a derivative following the underlying instrument" |

"Underlying, not a CFD" is therefore **read off the provider's definitions, not inferred**.
Exactly one value is ownership at full value. `marginTrade` *is* the real instrument but is
leveraged, which the standing no-leverage posture bars — not the vocabulary.

**The response documents no freshness field** (no `lastUpdated`, no `asOf`; the what-if
*cost* endpoint has one, eligibility does not), so the freshness rule cannot be sourced and
is fixed **by construction** — 24h, with the construction stated rather than the number
defended, and frozen in `core-eligibility-v1`.

## The finding that decided the design

`SPY` (3000) and `SPY.RTH` (3417) are **the same fund, listed twice**, and only one is
ownable:

| | `SPY` | `SPY.RTH` |
| --- | --- | --- |
| `company_name` | State Street SPDR S&P 500 ETF | State Street SPDR S&P 500 ETF |
| `maxUnitsPerOrder` | 134.0 | 134.0 |
| x1 long arm | **`cfd`** | **`real`** |

Naming `SPY` as the core instrument buys a contract for difference. **No column of
`instruments` separates them** for this pair, and no venue/suffix rule recovers it either
(exchange 33: 4 ETFs, 2 with a `real` arm; exchange 5: 390 ETFs, 26; `AAPL` has one with no
suffix). The discriminator exists **only** in the account-specific eligibility response —
which is why this ships as a dated proof rather than an instrument attribute.

## ⚠ Full-population measurement, and a sample that got it wrong

A five-name sample (SPY, VOO, IVV, VTI, QQQ — all CFD-only) reads as *"no ETF is available
as the underlying"*. The full population says otherwise. Whole tradable universe, 12,728
ids, 128 requests inside the documented 20/min dedicated budget, 0 errors, 12,725 resolved:

| type | resolved | with a `real`/`long`/x1 arm |
| --- | --- | --- |
| Stocks | 10,847 | 10,771 |
| **ETF** | **1,232** | **703** |
| Crypto | 332 | 223 |
| Commodity / Indices | 234 | 0 (`realFutures` only) |

Of the 703 ETFs, **37 are USD-quoted and 666 are not**. Reproduce (nothing is hardcoded in
prose — the script computes it):

```bash
PYTHONPATH=. uv run python scripts/prove_2603_core_eligibility.py census
```

⚠⚠ **Scope of that measurement, because it bounds every claim above:** one account, one
environment (`demo`), one instant. Eligibility is account and regulatory state, so none of
it generalises to `real`, to another account, or to tomorrow. That is not a caveat on the
finding — it *is* the finding, and it is the argument for a per-account proof.

## What changed

- **`sql/346_core_eligibility_proofs.sql`** — append-only observation log. Account identity
  is `(operator_id, provider, environment)` (an eToro account is *two* credential rows, so
  no single row names it), plus the `api_key`/`user_key` row ids that produced the
  observation, so a credential swap invalidates prior proofs structurally rather than by a
  remembered rule. `observed_at` is `DEFAULT now()` and **not a parameter** — a caller that
  declares its own observation time can extend a proof's validity at will.
- **`app/services/broker_settlement_arms.py`** — one definition of "the underlying product,
  held long, unleveraged", shared with `strategy_paper_executor::_eligibility_reason`, which
  spelled the same triple out inline. Deliberately narrower than the executor's full rule
  (arm selection only; the SL/TP and minimum checks stay there, because a core sleeve is a
  stop-less indefinite holding and must not inherit an entry rule).
- **`app/services/strategy_core_eligibility.py`** — pure `evaluate_core_eligibility`,
  `record_core_eligibility_proof`, `load_latest_...`, `require_core_eligibility`.
- **`configure_core_mandate`** now refuses an **enabled** mandate whose `core_instrument_id`
  has no fresh, passing, same-account proof. It gains required `operator_id` / `provider` /
  `environment` (no production caller today, tests only). The gate reads a table and makes
  no broker call, so the writer keeps its pure-DB test surface.

### Three things worth a reviewer's attention

**`bool` is an `int`, so `1 in leverage_values` was true for `leverageValues: [true]`.** The
provider parser admits it (`isinstance(True, int)` passes its integer check), so malformed
broker data could prove x1 eligibility. The shared helper tests
`value == 1 and not isinstance(value, bool)`, which hardens the executor's existing path too
— one of the reasons the definition moved rather than being copied.

**A CHECK passes on NULL, so `col = 'x'` does not require `col = 'x'`.** The
`core_eligibility_underlying_is_complete` constraint exists to refuse a row claiming
`underlying` while carrying no matched arm — and admitted exactly that, because
`NULL = 'real'` is NULL, not FALSE. Caught by this PR's own parametrised DB test (2 of 6
cases), fixed with `IS NOT DISTINCT FROM`, and extracted to
`docs/review-prevention-log.md`.

**Sizing is recorded, not decided.** `min_position_amount` / `min_position_exposure` /
`max_units_per_order` are stored as observed facts and **no effective minimum is derived**.
The executor's `arm.min or row.min_exposure` precedence has no citation in the provider's
docs, and a missing floor is an order-sizing gap rather than evidence about what the product
*is* — requiring one for `underlying` would conflate the two. Item 3 owns sizing and
inherits both numbers.

## Security model

Broker access is **informational only**: `POST /trading/info/{env}/eligibility`. Nothing
here submits, sizes or authorises an order, and no order or position state is touched —
inside the loop's hard rules and outside `unattended_guard`'s mutating surface by
construction (#2645).

Secrets: the script decrypts the demo `api_key`/`user_key` through
`load_credential_for_provider_use` (audited on every decryption) and the proof stores only
credential **row ids**, never material. ⚠ Stated as a known limit rather than papered over:
those columns record which credentials the recorder *used*; nothing prevents a caller
writing a row asserting an account it never contacted. The table is evidence of an
observation, not an attestation of one.

## Verification

| clause | what was done |
| --- | --- |
| Source rule | Live portal fetched 2026-08-13; `settlementType` vocabulary quoted verbatim in the spec, `sql/346` header and `broker_settlement_arms` docstring |
| Full population | 12,728 ids / 128 requests / 0 errors, reproducible via `... census` |
| Migration applied | `PYTHONPATH=. uv run python scripts/migrate.py` → `Applied 1 migration(s): ['346_core_eligibility_proofs.sql']` on dev |
| Live proof recorded | `... prove SPY SPY.RTH QQQ.RTH CSPX.L` → `SPY` `not_underlying/no_underlying_arm` (0 qualifying arms); `SPY.RTH`, `QQQ.RTH`, `CSPX.L` all `underlying`, `real`, 1 arm |
| Gate end-to-end on dev | Against those real proofs: `SPY REFUSED — proof 1 is not_underlying (no_underlying_arm)`; `SPY.RTH ACCEPTED revision=1 enabled=True`. Run inside a transaction and rolled back — **0 mandate rows before and after**, no dev state left behind |
| Concurrency | `FOR SHARE` revert-probed: removing it turns `test_the_gate_blocks_a_concurrent_credential_swap` red with `DID NOT RAISE` |
| Gates | `ruff check` / `ruff format --check` / `pyright` clean; fast tier + smoke green; `-m db` green for `test_2603_core_eligibility_db`, `test_2603_core_mandate_db`, `test_2603_core_allocator`, `test_2603_core_mandate`, `test_strategy_paper_executor`, `test_verify_2437_trading_preflight` |
| Codex | ckpt-1 on the spec (62 findings; the shape changed — minimum dropped from the verdict, proof bound to credential ids, whole-response digest, DB-generated `observed_at`). ckpt-2 on the diff found one real P2 — a check-then-write window against **credential replacement**, which the mandate advisory lock does not cover — fixed with `FOR SHARE` |

⚠ Clauses 8-12 of the ETL Definition of Done do not bind: this touches no ownership,
fundamentals or observations data and needs no `sec_rebuild`.

## What this does NOT do

- **It selects no core instrument.** It makes a selection checkable, and records that only
  one of `SPY`/`SPY.RTH` passes.
- ⚠⚠ **It is a WRITE-TIME gate and must never be cited as an execution control.** An enabled
  mandate stays enabled after its proof ages out or is superseded by a failing observation.
  Item 3 re-proves at execution time; the module docstring and the table comment both say
  so, so the next reader cannot infer otherwise. This is #2437's R4 lesson applied to my own
  slice.
- **No schedule, no job, no endpoint, no re-proof loop.**
- **The executor's stored reason vocabulary is unchanged.** `_eligibility_reason` still maps
  both "zero qualifying arms" and "more than one" to `eligibility_arm_ambiguous`, even
  though the shared helper distinguishes them — `strategy_entry_preflights.reason_code` is
  stored data. Filed as **#2678**.

## Owed, not done

⚠ `.claude/skills/data-sources/etoro-api.md` should gain the `settlementType` vocabulary and
the "no freshness field on eligibility" fact. **The edit was refused by a write permission
on `.claude/` in this worktree**, so it is flagged here rather than routed around. The
substance is captured in-repo and reviewable in the spec, `sql/346`'s header and
`broker_settlement_arms`'s docstring; the skill edit should land in a follow-up from a
checkout that can write there.

Refs #2603. Refs #2437. Refs #2678.
