### PR TITLE
fix(#2678): report "not offered as the underlying" separately from "ambiguous"

### DIFF
--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -605,14 +605,20 @@ def _eligibility_reason(response: BrokerEligibilityResponse, intent: _Intent, am
     # inline version it replaces: `bool` is an `int`, so `1 in leverage_values`
     # was true for `leverageValues: [true]`, which the provider parser admits.
     arms = select_underlying_long_arms(matches[0])
-    # ⚠ Zero arms and many arms are DIFFERENT answers -- "not offered as the
-    # underlying" versus "genuinely ambiguous" -- and the shared helper now tells
-    # them apart. Both still map to this one code because `reason_code` is stored
-    # data on `strategy_entry_preflights`; re-labelling it is a data-semantics
-    # change, filed as #2678 rather than folded into #2603 item 2.
-    if len(arms) != 1:
+    # ⚠ Zero arms and many arms are DIFFERENT answers and get different codes
+    # (#2678). Zero means the broker read the request fine and this instrument is
+    # simply not offered as the underlying product on this account -- a fact about
+    # the INSTRUMENT. More than one means the response cannot be read -- a fact
+    # about the RESPONSE. Collapsing them sent triage looking for a parser bug
+    # that does not exist: SPY (3000) returns three arms, all `cfd`, so zero
+    # qualify and it filed as "ambiguous" when nothing was ambiguous.
+    if not arms:
+        return "no_underlying_arm"
+    if len(arms) > 1:
         return "eligibility_arm_ambiguous"
-    arm = arms[0]
+    # `next(iter(...))`, not `arms[0]`: pyright narrows a tuple through the two
+    # length guards above to `tuple[()]` and rejects the subscript.
+    arm = next(iter(arms))
     if arm.allow_stop_loss_take_profit is not True:
         return "fixed_exit_not_allowed"
     minimum = arm.min_position_amount or matches[0].min_position_exposure

--- a/tests/test_strategy_paper_executor.py
+++ b/tests/test_strategy_paper_executor.py
@@ -498,6 +498,7 @@ def _broker(
     undocumented_cost: bool = False,
     eligibility_currency: str = "USD",
     cost_currency: str = "USD",
+    arm_settlement_types: tuple[str, ...] = ("real",),
 ) -> MagicMock:
     broker = MagicMock(spec=BrokerProvider)
     broker.get_account_risk_snapshot.return_value = BrokerAccountRiskSnapshot(
@@ -521,9 +522,9 @@ def _broker(
                 allow_close_position=True,
                 allow_partial_close_position=True,
                 allow_trailing_stop_loss=False,
-                leverage_configs=(
+                leverage_configs=tuple(
                     BrokerLeverageConfig(
-                        settlement_type="real",
+                        settlement_type=settlement_type,
                         direction="LONG",
                         leverage_values=(1,),
                         min_position_amount=Decimal("10"),
@@ -531,7 +532,8 @@ def _broker(
                         allow_edit_take_profit=True,
                         allow_stop_loss_take_profit=True,
                         raw_payload={},
-                    ),
+                    )
+                    for settlement_type in arm_settlement_types
                 ),
                 raw_payload={},
             ),
@@ -1573,3 +1575,47 @@ def test_widening_the_supported_set_does_not_widen_what_the_broker_may_quote(
 
     assert result.verdict == "rejected"
     assert result.reason_code == "cost_currency_or_value_invalid"
+
+
+@pytest.mark.parametrize(
+    ("arm_settlement_types", "expected"),
+    [
+        # The measured SPY (3000) shape: every arm is a CFD, so zero qualify. The
+        # broker read the request perfectly; this fund is not offered as the
+        # underlying product on this account.
+        (("cfd", "cfd"), "no_underlying_arm"),
+        # Genuinely unreadable: two arms both claiming to be the underlying.
+        (("real", "real"), "eligibility_arm_ambiguous"),
+        (("real",), None),
+    ],
+    ids=["cfd_only_is_not_ambiguous", "two_real_arms_are", "one_real_arm_funds"],
+)
+def test_no_underlying_arm_is_reported_separately_from_a_genuinely_ambiguous_one(
+    ebull_test_conn: psycopg.Connection[Any],
+    arm_settlement_types: tuple[str, ...],
+    expected: str | None,
+) -> None:
+    """#2678 — zero qualifying arms and many are different answers.
+
+    Zero is a fact about the INSTRUMENT (not offered as the underlying); many is a
+    fact about the RESPONSE (we cannot read it). Filing both as
+    ``eligibility_arm_ambiguous`` sent triage looking for a parser bug that does
+    not exist.
+
+    ⚠ Safe to re-label rather than add-and-migrate because the stored vocabulary
+    is open and unread: `strategy_entry_preflights.reason_code` CHECKs only
+    non-empty/≤100 (sql/287), `strategy_funding_decisions.reason_code` is plain
+    TEXT (sql/281), the API passes `funding_reason` through as a free string, and
+    both tables held **0 rows** on dev when this shipped — measured, not assumed.
+    """
+    conn = ebull_test_conn
+    signal_id = _seed(conn)
+
+    broker = _broker(arm_settlement_types=arm_settlement_types)
+    result = execute_fired_paper_signal(conn, broker=broker, signal_id=signal_id, now=_NOW)
+
+    if expected is None:
+        assert result.verdict == "submitted"
+    else:
+        assert result.verdict == "rejected"
+        assert result.reason_code == expected


### PR DESCRIPTION
## What

`strategy_paper_executor.py::_eligibility_reason` mapped **both** "zero qualifying arms" and
"more than one qualifying arm" to the single stored reason code
`eligibility_arm_ambiguous`. They are different answers:

- **zero** — the broker read the request fine and this instrument is not offered as the
  underlying product on this account. A fact about the **instrument**.
- **more than one** — the response cannot be read. A fact about the **response**.

Measured on the demo account (#2603 item 2, `6f6eed36`): `SPY` (instrument 3000) returns
three arms, all `cfd`, so zero qualify — and it would have filed as *ambiguous*. Nothing was
ambiguous. Any triage reading that code goes looking for a parser bug that does not exist.

`no_underlying_arm` is now returned for the zero case; `eligibility_arm_ambiguous` keeps the
genuine >1 case.

## Why this is a re-label and not an add-and-migrate

The follow-up was filed (by me, on #2603) on the premise that *"`reason_code` is stored data
and historical rows stay under the old, coarser code"*. **That premise is false**, and the
measurement is the reason this is a one-file diff rather than a migration:

| what | measured |
| --- | --- |
| `strategy_entry_preflights.reason_code` | `CHECK (reason_code <> '' AND length(reason_code) <= 100)` — no closed vocabulary (`sql/287:98`) |
| `strategy_funding_decisions.reason_code` | plain `TEXT NOT NULL`, no CHECK at all (`sql/281:119`) |
| stored rows, both tables, dev | **0** — `SELECT reason_code, count(*) ... GROUP BY 1` returns empty for each |
| API consumers | `app/api/strategies.py:1730` passes `COALESCE(fd.reason_code, ...)` straight out as `funding_reason` — no grouping, no mapping. The `GROUP BY ... reason_code` at `:957` is a **different table** (`strategy_signal_daily_counts`) |
| frontend | `funding_reason: string` in `api/types.ts` — no union, no label map. `grep` for any executor reason code across `frontend/src` returns nothing |

So there is no historical row to reinterpret, no constraint to widen, and no consumer that
buckets on the old value. Recorded here because "0 rows" is exactly the argument #2670 ruled
out for a *version* bump — and it does not transfer to a version, only to a backfill. This
mints no version and reinterprets no stored row; it changes which string a future rejection
carries.

## Security model

None touched. This is a rejection label on a path that already refuses; no gate is loosened,
no new code path is reachable, and both branches still return a rejection.

## Verification

- `tests/test_strategy_paper_executor.py::test_no_underlying_arm_is_reported_separately_from_a_genuinely_ambiguous_one`
  — three cases through the real executor: `("cfd","cfd")` → `no_underlying_arm` (the measured
  SPY shape), `("real","real")` → `eligibility_arm_ambiguous`, `("real",)` → `submitted`.
  The existing `_broker` fixture gained an `arm_settlement_types` kwarg rather than a second
  fixture.
- Gates on **exit code** (this repo's pytest config suppresses the `N passed` line):
  `ruff check` 0, `ruff format --check` 0, `pyright` 0, fast tier 0, smoke 0, `-m db
  tests/test_strategy_paper_executor.py` 0.
- ⚠ `pyright` initially failed here and a `| tail -3` had hidden it — it narrows the tuple
  through both length guards to `tuple[()]` and rejects `arms[0]`. `next(iter(arms))`, with
  the reason inline so it does not get "simplified" back.

Per the review-intensity ladder this is a narrow behavioural diff with no data semantics
changed (no schema, no migration, no vocabulary constraint), so it gets self-review + the
pre-push hook + the review bot.

Closes #2678. Refs #2603.
