### PR TITLE
feature(#2623): derive the entry fire rate from the durable census, not the sparse signal ledger

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -69,12 +69,15 @@ from app.services.strategy_live_gate import (
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_monitoring import (
+    FireRateUnavailableReason,
     StrategyAttribution,
     StrategyControlState,
+    StrategyFireRate,
     StrategyPnl,
     load_attribution,
     load_control_state,
     load_entry_block_state,
+    load_fire_rate,
     load_owned_pnl,
     realised_pnl_for_keys,
 )
@@ -251,6 +254,7 @@ class StrategyOverview(BaseModel):
     all_recent_evidence_complete: bool
     stage: str | None
     attribution: StrategyAttributionView
+    fire_rate: StrategyFireRateView
     pnl: StrategyPnlView
     allocation: StrategyAllocationView
     allocation_ready: bool
@@ -278,6 +282,32 @@ class StrategyAttributionView(BaseModel):
     average_slippage_pct: Decimal | None
     average_stressed_cost_usd: Decimal | None
     max_observed_account_drawdown_pct: Decimal | None
+
+
+class StrategyFireRateView(BaseModel):
+    """Entry fire evidence for the current version, from the durable census.
+
+    Source and construction: ``app/services/strategy_monitoring.py::derive_fire_rate``
+    and ``docs/proposals/ta/2026-08-14-strategy-fire-rate.md``. #2623 gap 2.
+
+    ⚠ ``fired_share_of_evaluable`` is the comparable number — dimensionless, so
+    universe size does not move it. ``entries_per_calendar_week`` is throughput and
+    is universe-size-dependent by design; it is ``None`` until the version has a
+    bar-date axis that can carry a rate, and ``rate_unavailable_reason`` says which
+    of the two reasons applies.
+    """
+
+    universe: str
+    scanned_days: int
+    fired_days: int
+    fired_entry_signals: int
+    evaluable_entry_decisions: int
+    not_evaluable_entry_decisions: int
+    fired_share_of_evaluable: Decimal | None
+    entries_per_calendar_week: Decimal | None
+    first_scanned_bar: date | None
+    last_scanned_bar: date | None
+    rate_unavailable_reason: FireRateUnavailableReason | None
 
 
 class StrategyPnlView(BaseModel):
@@ -1208,6 +1238,9 @@ def get_strategy_overview(
         outcome_version=OUTCOME_RULE_SET_VERSION,
         input_version=QUARANTINE_RULE_SET_VERSION,
     )
+    # Current versions only: a strategy_version is a rule set, so pooling two
+    # would average two arithmetics into one rate (#2670's lesson).
+    fire_rate_by_strategy = load_fire_rate(conn, versions=version_values)
     pnl_versions = sorted({*version_values, *(version for _strategy_id, version in paper_deployment_keys)})
     pnl_by_strategy = load_owned_pnl(conn, versions=pnl_versions)
     control_by_strategy = load_control_state(conn, versions=version_values)
@@ -1355,6 +1388,9 @@ def get_strategy_overview(
         )
         key = (strategy_id, versions[strategy_id])
         attribution = attribution_by_strategy.get(key, StrategyAttribution())
+        # A key absent from the census has never been scanned, which the default
+        # `rate_unavailable_reason` states rather than reading as a zero rate.
+        fire_rate = fire_rate_by_strategy.get(key, StrategyFireRate())
         pnl = pnl_by_strategy.get(key, StrategyPnl())
         control = control_by_strategy.get(key, StrategyControlState())
         allocation_refusals: list[str] = []
@@ -1432,6 +1468,7 @@ def get_strategy_overview(
                 all_recent_evidence_complete=all_complete,
                 stage=control.stage,
                 attribution=StrategyAttributionView(**attribution.__dict__),
+                fire_rate=StrategyFireRateView(**fire_rate.__dict__),
                 pnl=StrategyPnlView(
                     currency="USD",
                     strategy_trade_count=pnl.strategy_trade_count,

--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -69,11 +69,12 @@ from app.services.strategy_live_gate import (
 )
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_monitoring import (
-    FireRateUnavailableReason,
+    ShareUnavailableReason,
     StrategyAttribution,
     StrategyControlState,
     StrategyFireRate,
     StrategyPnl,
+    WeeklyRateUnavailableReason,
     load_attribution,
     load_control_state,
     load_entry_block_state,
@@ -293,8 +294,11 @@ class StrategyFireRateView(BaseModel):
     ⚠ ``fired_share_of_evaluable`` is the comparable number — dimensionless, so
     universe size does not move it. ``entries_per_calendar_week`` is throughput and
     is universe-size-dependent by design; it is ``None`` until the version has a
-    bar-date axis that can carry a rate, and ``rate_unavailable_reason`` says which
-    of the two reasons applies.
+    bar-date axis that can carry a rate.
+
+    ⚠ Each nullable value carries its OWN reason, because the two nulls are
+    independent: a version scanned over several days on which every bar was
+    ``not_evaluable`` rates at ``0.00``/week and has no share at all.
     """
 
     universe: str
@@ -307,7 +311,8 @@ class StrategyFireRateView(BaseModel):
     entries_per_calendar_week: Decimal | None
     first_scanned_bar: date | None
     last_scanned_bar: date | None
-    rate_unavailable_reason: FireRateUnavailableReason | None
+    share_unavailable_reason: ShareUnavailableReason | None
+    weekly_rate_unavailable_reason: WeeklyRateUnavailableReason | None
 
 
 class StrategyPnlView(BaseModel):

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -28,7 +28,14 @@ _DAYS_PER_WEEK: Final = 7
 _SHARE_PRECISION: Final = Decimal("0.0001")
 _RATE_PRECISION: Final = Decimal("0.01")
 
-FireRateUnavailableReason = Literal["never_scanned", "single_scan_day"]
+#: Why `fired_share_of_evaluable` is null. `no_evaluable_decisions` means every bar
+#: was `not_evaluable`, so the strategy was never offered a decision — its propensity
+#: is unknown rather than zero.
+ShareUnavailableReason = Literal["never_scanned", "no_evaluable_decisions"]
+
+#: Why `entries_per_calendar_week` is null. Independent of the share's reason: a
+#: multi-day all-`not_evaluable` version rates at 0.00/week and has no share at all.
+WeeklyRateUnavailableReason = Literal["never_scanned", "single_scan_day"]
 
 
 @dataclass(frozen=True)
@@ -79,7 +86,10 @@ class StrategyFireRate:
     entries_per_calendar_week: Decimal | None = None
     first_scanned_bar: date | None = None
     last_scanned_bar: date | None = None
-    rate_unavailable_reason: FireRateUnavailableReason | None = "never_scanned"
+    #: Each nullable value above names its own reason. Invariant, both directions:
+    #: a value is None if and only if its reason is not.
+    share_unavailable_reason: ShareUnavailableReason | None = "never_scanned"
+    weekly_rate_unavailable_reason: WeeklyRateUnavailableReason | None = "never_scanned"
 
 
 @dataclass(frozen=True)
@@ -336,25 +346,37 @@ def derive_fire_rate(
     the weekly rate is ``None`` for all four. That is the refusal working, not a
     gap — the prior versions carry 5-date axes and rate fine.
 
-    ``rate_unavailable_reason`` exists because ``None`` would otherwise mean three
-    things at once, and #2623 scope 3 requires an empty state to say which.
+    ⚠⚠ THE TWO NULLS NEED TWO REASONS, BECAUSE THEY ARE INDEPENDENT. A version
+    with two or more scanned days on which EVERY bar was ``not_evaluable`` has a
+    computable weekly rate (no fires over a real span is ``0.00``) and an
+    UNCOMPUTABLE share — its propensity is unknown, not zero, because it was never
+    offered a decision. One enum cannot carry both, so a single
+    ``rate_unavailable_reason`` left that share null with nothing saying why. Each
+    nullable value names its own reason, and the invariant is exact in both
+    directions: a value is ``None`` if and only if its reason is not.
     """
     if scanned_days == 0:
-        return StrategyFireRate(rate_unavailable_reason="never_scanned")
+        return StrategyFireRate(
+            share_unavailable_reason="never_scanned",
+            weekly_rate_unavailable_reason="never_scanned",
+        )
 
     share: Decimal | None = None
+    share_reason: ShareUnavailableReason | None = None
     if evaluable_entry_decisions > 0:
         share = (Decimal(fired_entry_signals) / Decimal(evaluable_entry_decisions)).quantize(_SHARE_PRECISION)
+    else:
+        share_reason = "no_evaluable_decisions"
 
     per_week: Decimal | None = None
-    reason: FireRateUnavailableReason | None = None
+    weekly_reason: WeeklyRateUnavailableReason | None = None
     # `periods_per_year`'s own guard, at the week scale: an axis needs two distinct
     # dates and a positive span before any rate can be measured off it.
     span_days = 0
     if first_scanned_bar is not None and last_scanned_bar is not None:
         span_days = (last_scanned_bar - first_scanned_bar).days
     if scanned_days < 2 or span_days <= 0:
-        reason = "single_scan_day"
+        weekly_reason = "single_scan_day"
     else:
         per_week = (Decimal(fired_entry_signals) * Decimal(_DAYS_PER_WEEK) / Decimal(span_days)).quantize(
             _RATE_PRECISION
@@ -370,7 +392,8 @@ def derive_fire_rate(
         entries_per_calendar_week=per_week,
         first_scanned_bar=first_scanned_bar,
         last_scanned_bar=last_scanned_bar,
-        rate_unavailable_reason=reason,
+        share_unavailable_reason=share_reason,
+        weekly_rate_unavailable_reason=weekly_reason,
     )
 
 
@@ -717,12 +740,13 @@ def load_entry_block_state(conn: psycopg.Connection[Any]) -> StrategyEntryBlockS
 
 
 __all__ = [
-    "FireRateUnavailableReason",
+    "ShareUnavailableReason",
     "StrategyAttribution",
     "StrategyControlState",
     "StrategyEntryBlockState",
     "StrategyFireRate",
     "StrategyPnl",
+    "WeeklyRateUnavailableReason",
     "derive_fire_rate",
     "load_attribution",
     "load_control_state",

--- a/app/services/strategy_monitoring.py
+++ b/app/services/strategy_monitoring.py
@@ -11,14 +11,24 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Final, Literal
 
 import psycopg
 import psycopg.rows
 
+from app.services.strategy_signal_scan import SCAN_UNIVERSE
 from app.services.valuation import resolve_quote_price
+
+#: Calendar days per week. Not a trading-day convention — the weekly rate divides
+#: by the measured CALENDAR span of the scanned-bar axis, exactly as
+#: ``strategy_statistics.periods_per_year`` divides by ``span_days / 365.25``.
+_DAYS_PER_WEEK: Final = 7
+_SHARE_PRECISION: Final = Decimal("0.0001")
+_RATE_PRECISION: Final = Decimal("0.01")
+
+FireRateUnavailableReason = Literal["never_scanned", "single_scan_day"]
 
 
 @dataclass(frozen=True)
@@ -43,6 +53,33 @@ class StrategyAttribution:
     average_slippage_pct: Decimal | None = None
     average_stressed_cost_usd: Decimal | None = None
     max_observed_account_drawdown_pct: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class StrategyFireRate:
+    """How often a strategy version fired an entry, from the durable census.
+
+    Defaults describe a version the scan has never reached — which is the state a
+    freshly-rotated version is in, so it must be representable rather than absent.
+    """
+
+    #: #2288's labelling contract: a metric computed on a survivor-only universe is
+    #: marked as such. The census carries no `universe` column and does not need
+    #: one — a universe change mints a new `strategy_version` (`strategy_signal_scan`),
+    #: and this reads one version at a time, so every row was written under this label.
+    universe: str = SCAN_UNIVERSE
+    scanned_days: int = 0
+    fired_days: int = 0
+    fired_entry_signals: int = 0
+    evaluable_entry_decisions: int = 0
+    #: Reported, not hidden: these are excluded from `fired_share_of_evaluable`'s
+    #: denominator, and an exclusion nobody can see is an exclusion nobody checks.
+    not_evaluable_entry_decisions: int = 0
+    fired_share_of_evaluable: Decimal | None = None
+    entries_per_calendar_week: Decimal | None = None
+    first_scanned_bar: date | None = None
+    last_scanned_bar: date | None = None
+    rate_unavailable_reason: FireRateUnavailableReason | None = "never_scanned"
 
 
 @dataclass(frozen=True)
@@ -216,6 +253,150 @@ def load_attribution(
             max_observed_account_drawdown_pct=row["max_observed_account_drawdown_pct"],
         )
     return result
+
+
+#: Entry-signal census aggregates for one strategy version. The population is
+#: ``strategy_signal_daily_counts`` — the DURABLE census — and NOT
+#: ``strategy_signals``. See ``derive_fire_rate`` for why that distinction is the
+#: whole point of this query.
+#:
+#: ⚠ ``sum(...) FILTER`` returns NULL, not 0, for a version with no matching
+#: bucket. s2 has no fired bucket at all, so an uncoalesced numerator reports a
+#: scanned strategy as unmeasured. Coalesced here rather than at the call site so
+#: the pure derivation never has to distinguish "absent bucket" from "no rows".
+_FIRE_RATE_SQL = """
+    SELECT strategy_id, strategy_version,
+           COUNT(DISTINCT signal_bar_date) AS scanned_days,
+           COUNT(DISTINCT signal_bar_date) FILTER (WHERE verdict = 'fired')
+               AS fired_days,
+           COALESCE(SUM(row_count) FILTER (WHERE verdict = 'fired'), 0)
+               AS fired_entry_signals,
+           COALESCE(SUM(row_count) FILTER (WHERE verdict IN ('fired', 'not_fired')), 0)
+               AS evaluable_entry_decisions,
+           COALESCE(SUM(row_count) FILTER (WHERE verdict = 'not_evaluable'), 0)
+               AS not_evaluable_entry_decisions,
+           MIN(signal_bar_date) AS first_scanned_bar,
+           MAX(signal_bar_date) AS last_scanned_bar
+    FROM strategy_signal_daily_counts
+    WHERE signal_kind = 'entry' AND strategy_version = ANY(%(versions)s)
+    GROUP BY strategy_id, strategy_version
+"""
+
+
+def derive_fire_rate(
+    *,
+    scanned_days: int,
+    fired_days: int,
+    fired_entry_signals: int,
+    evaluable_entry_decisions: int,
+    not_evaluable_entry_decisions: int,
+    first_scanned_bar: date | None,
+    last_scanned_bar: date | None,
+) -> StrategyFireRate:
+    """Turn one version's entry-census aggregates into the two rates.
+
+    Spec: ``docs/proposals/ta/2026-08-14-strategy-fire-rate.md``. Issue #2623 gap 2.
+
+    ⚠⚠ THE SOURCE IS THE CENSUS BECAUSE ``strategy_signals`` IS SPARSE. Fired rows
+    stay in ``strategy_signals`` durably because outcomes refer to ``signal_id``;
+    routine negatives are pruned to a 90-day partition and survive only as
+    ``strategy_signal_daily_counts`` rows. So ``strategy_signals`` can see only the
+    days on which something fired — a correct numerator over an unusable
+    denominator. Measured on the full population 2026-08-14: it shows 1 bar date
+    where the census shows 5 on four of nine version keys (a **5x** overstatement),
+    and s2 — which scanned and fired nothing — has no rows in it at all, so it
+    would vanish from the surface rather than read an honest zero. See
+    ``docs/review-prevention-log.md`` on a sparse table's storage predicate being
+    part of the census definition.
+
+    ⚠⚠ TWO RATES, BECAUSE THEY ANSWER DIFFERENT QUESTIONS AND NEITHER SUBSTITUTES.
+
+    ``fired_share_of_evaluable`` is the propensity: what fraction of the decisions
+    the strategy was actually able to make came out ``fired``. Dimensionless, so
+    universe growth does not move it. ``not_evaluable`` decisions are excluded from
+    its denominator — those bars were never judged (``insufficient_warmup``,
+    ``no_fill_bar`` and six siblings, ``sql/276:20``), and counting them as declined
+    opportunities would suppress the share for a chance never offered.
+
+    ``entries_per_calendar_week`` is the throughput: how many opportunities land per
+    week of market. It is universe-size-dependent BY DESIGN — the operator trades
+    this universe — which is exactly why it cannot stand alone as "the fire rate".
+
+    ⚠⚠ THE WEEKLY RATE IS MEASURED OFF THE BAR-DATE AXIS AND REFUSES A ONE-DAY
+    AXIS. It is NOT ``fires per scanned day x 5``. ``strategy_statistics`` settled
+    this class of decision already: *"the annualisation factor is measured off the
+    date axis, never the 252 convention … 252 is a convention, not a source rule"*,
+    and ``periods_per_year`` raises rather than invent a span for a single-date
+    axis, because *"inventing one would put a divide-by-zero behind a plausible
+    number"*. A frozen trading-week constant is that same mistake at the week
+    scale, so the span comes off the axis and a rate that the axis cannot carry is
+    ``None`` with a stated reason.
+
+    ⚠ Every current strategy version holds exactly one scanned bar date today, so
+    the weekly rate is ``None`` for all four. That is the refusal working, not a
+    gap — the prior versions carry 5-date axes and rate fine.
+
+    ``rate_unavailable_reason`` exists because ``None`` would otherwise mean three
+    things at once, and #2623 scope 3 requires an empty state to say which.
+    """
+    if scanned_days == 0:
+        return StrategyFireRate(rate_unavailable_reason="never_scanned")
+
+    share: Decimal | None = None
+    if evaluable_entry_decisions > 0:
+        share = (Decimal(fired_entry_signals) / Decimal(evaluable_entry_decisions)).quantize(_SHARE_PRECISION)
+
+    per_week: Decimal | None = None
+    reason: FireRateUnavailableReason | None = None
+    # `periods_per_year`'s own guard, at the week scale: an axis needs two distinct
+    # dates and a positive span before any rate can be measured off it.
+    span_days = 0
+    if first_scanned_bar is not None and last_scanned_bar is not None:
+        span_days = (last_scanned_bar - first_scanned_bar).days
+    if scanned_days < 2 or span_days <= 0:
+        reason = "single_scan_day"
+    else:
+        per_week = (Decimal(fired_entry_signals) * Decimal(_DAYS_PER_WEEK) / Decimal(span_days)).quantize(
+            _RATE_PRECISION
+        )
+
+    return StrategyFireRate(
+        scanned_days=scanned_days,
+        fired_days=fired_days,
+        fired_entry_signals=fired_entry_signals,
+        evaluable_entry_decisions=evaluable_entry_decisions,
+        not_evaluable_entry_decisions=not_evaluable_entry_decisions,
+        fired_share_of_evaluable=share,
+        entries_per_calendar_week=per_week,
+        first_scanned_bar=first_scanned_bar,
+        last_scanned_bar=last_scanned_bar,
+        rate_unavailable_reason=reason,
+    )
+
+
+def load_fire_rate(
+    conn: psycopg.Connection[Any], *, versions: Sequence[str]
+) -> dict[tuple[str, str], StrategyFireRate]:
+    """Entry fire evidence per ``(strategy_id, strategy_version)`` from the census.
+
+    A key absent from the result has never been scanned; the caller supplies
+    ``StrategyFireRate()``, whose default ``rate_unavailable_reason`` says so.
+    """
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_FIRE_RATE_SQL, {"versions": list(versions)})
+        rows = cur.fetchall()
+    return {
+        (str(row["strategy_id"]), str(row["strategy_version"])): derive_fire_rate(
+            scanned_days=int(row["scanned_days"]),
+            fired_days=int(row["fired_days"]),
+            fired_entry_signals=int(row["fired_entry_signals"]),
+            evaluable_entry_decisions=int(row["evaluable_entry_decisions"]),
+            not_evaluable_entry_decisions=int(row["not_evaluable_entry_decisions"]),
+            first_scanned_bar=row["first_scanned_bar"],
+            last_scanned_bar=row["last_scanned_bar"],
+        )
+        for row in rows
+    }
 
 
 _OWNED_LIFECYCLE_SQL = """
@@ -536,12 +717,16 @@ def load_entry_block_state(conn: psycopg.Connection[Any]) -> StrategyEntryBlockS
 
 
 __all__ = [
+    "FireRateUnavailableReason",
     "StrategyAttribution",
     "StrategyControlState",
     "StrategyEntryBlockState",
+    "StrategyFireRate",
     "StrategyPnl",
+    "derive_fire_rate",
     "load_attribution",
     "load_control_state",
     "load_entry_block_state",
+    "load_fire_rate",
     "load_owned_pnl",
 ]

--- a/docs/proposals/ta/2026-08-14-strategy-fire-rate.md
+++ b/docs/proposals/ta/2026-08-14-strategy-fire-rate.md
@@ -135,18 +135,29 @@ observation about the current four strategies.
 
 ## 3. Null is not zero, and the API says which
 
-| state | `scanned_days` | `fired_share_of_evaluable` | `entries_per_calendar_week` | `rate_unavailable_reason` |
-| --- | --- | --- | --- | --- |
-| never scanned (new version) | 0 | `null` | `null` | `never_scanned` |
-| one scan day | ≥1 | value | `null` | `single_scan_day` |
-| scanned, never fired | ≥2 | `0.0000` | `0.00` | `null` |
-| normal | ≥2 | value | value | `null` |
+| state | `scanned_days` | `fired_share_of_evaluable` | `share_unavailable_reason` | `entries_per_calendar_week` | `weekly_rate_unavailable_reason` |
+| --- | --- | --- | --- | --- | --- |
+| never scanned (new version) | 0 | `null` | `never_scanned` | `null` | `never_scanned` |
+| one scan day | 1 | value | `null` | `null` | `single_scan_day` |
+| multi-day, all `not_evaluable` | ≥2 | `null` | `no_evaluable_decisions` | `0.00` | `null` |
+| scanned, never fired | ≥2 | `0.0000` | `null` | `0.00` | `null` |
+| normal | ≥2 | value | `null` | value | `null` |
 
-`rate_unavailable_reason` exists because `null` otherwise means three different things
-and gap 3 requires empty states to say *which*. ⚠ `sum(row_count) FILTER (WHERE verdict
-= 'fired')` returns **NULL**, not `0`, when a version has no fired bucket at all — s2 is
-exactly that today — so the numerator is coalesced. Getting that wrong reports a scanned
-strategy as unmeasured.
+A reason exists per nullable value because `null` otherwise means several things and gap
+3 requires empty states to say *which*. **Invariant, asserted both directions: a value is
+`null` if and only if its reason is not.**
+
+⚠⚠ **The two nulls are independent, so one reason field cannot serve both.** The third
+row is the proof: a version scanned over several days on which every bar was
+`not_evaluable` has a perfectly good axis — the weekly rate is a real `0.00` — while its
+share is unknowable, because the strategy was never offered a decision. A first draft
+carried a single `rate_unavailable_reason` tracking only the axis, which left that share
+`null` with nothing saying why, breaking this section's own contract. Caught by the
+review bot on PR #2681.
+
+⚠ `sum(row_count) FILTER (WHERE verdict = 'fired')` returns **NULL**, not `0`, when a
+version has no fired bucket at all — s2 is exactly that today — so the numerator is
+coalesced in SQL. Getting that wrong reports a scanned strategy as unmeasured.
 
 ## 4. What ships
 
@@ -165,7 +176,8 @@ matching `load_attribution`'s existing shape — one query, keyed
 | `fired_share_of_evaluable` | §2.2, 4 dp, `null` when no evaluable decisions |
 | `entries_per_calendar_week` | §2.1, 2 dp, `null` per the table above |
 | `first_scanned_bar` / `last_scanned_bar` | the axis the rate is measured on |
-| `rate_unavailable_reason` | `never_scanned` \| `single_scan_day` \| `null` |
+| `share_unavailable_reason` | `never_scanned` \| `no_evaluable_decisions` \| `null` |
+| `weekly_rate_unavailable_reason` | `never_scanned` \| `single_scan_day` \| `null` |
 
 Quantised with `Decimal.quantize` at the stated precision so the JSON is stable rather
 than a repeating expansion.
@@ -196,7 +208,8 @@ than a repeating expansion.
 Pure-logic table tests over the derivation (the loader splits into a pure
 `derive_fire_rate` and a thin query, so every row of §3's table is a unit case):
 never-scanned, single-scan-day, scanned-never-fired (NULL numerator coalesced), zero
-evaluable decisions, a multi-day axis, and `fired_days <= scanned_days`.
+evaluable decisions over a multi-day axis, a multi-day axis, and a parametrised
+both-directions check that every null value names its reason and no present value does.
 
 One DB test that the loader reads the census and not `strategy_signals`, on a fixture
 where the two disagree on days — the 5-vs-1 shape measured in §1.
@@ -204,4 +217,4 @@ where the two disagree on days — the 5-vs-1 shape measured in §1.
 Dev: `GET /strategies/overview` on the live `:8000`. Expected from §1's measurements —
 s1 `fired_share_of_evaluable = 0.5210` (1,740 / 3,340), s2 `0.0000` (0 / 3,273), s3
 `0.0039` (13 / 3,330), s4 `0.0340` (186 / 5,468), and
-`rate_unavailable_reason = single_scan_day` on all four.
+`weekly_rate_unavailable_reason = single_scan_day` on all four.

--- a/docs/proposals/ta/2026-08-14-strategy-fire-rate.md
+++ b/docs/proposals/ta/2026-08-14-strategy-fire-rate.md
@@ -1,0 +1,207 @@
+# Strategy fire rate — how often a strategy fires, read from the durable census
+
+Issue: #2623 gap 2. Scope: this gap only. Gap 1 (holding-period statistics) is a
+corpus change and stays out; gap 3 (catalog view) needs 1 and 2 to render.
+
+Rung: behavioural change with data semantics — a new derived metric on an existing
+read endpoint. No migration, no re-run, no trial-register interaction.
+
+## 1. The premise the ticket states, falsified
+
+> "Wire the scan census into it or derive fires/week from `strategy_signals` history
+> at read time."
+
+The second route is the cheap one and it is **wrong on the denominator**.
+`strategy_signals` is a SPARSE table by design (`app/services/strategy_observation_storage.py`
+module docstring): fired rows stay durable because outcomes and trade ownership refer
+to `signal_id`, while routine negatives are retained for 90 days in monthly partitions
+of `strategy_signal_observations` and represented durably **only** by
+`strategy_signal_daily_counts`.
+
+Full population — every `(strategy_id, strategy_version)` key in either table, entries
+only, dev 2026-08-14. Not a sample:
+
+| strategy | version | bar dates in `strategy_signals` | bar dates in census | fired (both) |
+| --- | --- | --- | --- | --- |
+| s1 | `…ee566d7b` | 1 | **5** | 1,722 |
+| s1 | `…f07c9d72` | 1 | 1 | 1,740 |
+| s2 | `…7fcb1fca` | **absent** | 1 | 0 |
+| s2 | `…89fd873d` | **absent** | **5** | 0 |
+| s3 | `…01d3736e` | 1 | **5** | 11 |
+| s3 | `…89368716` | 1 | 1 | 13 |
+| s4 | `…d32dc4e4` | 1 | **5** | 108 |
+| s4 | `…ff76dcde` | 1 | **5** | 108 |
+| s4 | `…dde63f07` | 1 | 1 | 186 |
+
+```sql
+WITH sig AS (SELECT strategy_id,strategy_version,count(DISTINCT signal_bar_date) days
+             FROM strategy_signals WHERE signal_kind='entry' GROUP BY 1,2),
+     cen AS (SELECT strategy_id,strategy_version,count(DISTINCT signal_bar_date) days
+             FROM strategy_signal_daily_counts WHERE signal_kind='entry' GROUP BY 1,2)
+SELECT * FROM cen FULL JOIN sig USING (strategy_id,strategy_version);
+```
+
+Two consequences, both operator-visible:
+
+1. **The fired counts agree exactly on all nine keys; only the days disagree.** So
+   `strategy_signals` is a correct numerator and an unusable denominator. Dividing by
+   the days it can see overstates the rate **5×** on four of the nine keys.
+2. **s2 is invisible.** It scanned and fired nothing, so it has no `strategy_signals`
+   rows at all. Sourced from there it would be absent from the catalog; sourced from
+   the census it reads an honest **0**. "Scanned, never fired" and "never scanned" are
+   different states and only the census separates them.
+
+`docs/review-prevention-log.md` § *"On a SPARSE table, the storage predicate is part of
+the census definition — and it is the part nobody reads"*, firing on live data.
+
+## 2. Source rule
+
+Two of the three decisions below are fixed by a rule this repo already wrote down. The
+third has no published formulation and is fixed by construction, which is stated rather
+than left implicit.
+
+### 2.1 The rate axis — settled, and it is not `×5`
+
+`app/services/strategy_statistics.py:9` — *"⚠⚠ THE ANNUALISATION FACTOR IS MEASURED OFF
+THE DATE AXIS, NEVER THE 252 CONVENTION … picking one is exactly the 'am I about to pick
+a threshold, ratio or window' trigger in `.claude/CLAUDE.md`. No published rule fixes it
+— 252 is a convention, not a source rule."* `periods_per_year` implements it as
+`(len(dates) - 1) / (span_days / 365.25)` and **raises** on an axis of fewer than two
+dates: *"a single date has no span, and inventing one would put a divide-by-zero behind
+a plausible number."*
+
+A first draft of this spec scaled by a frozen `TRADING_DAYS_PER_WEEK = 5`. That is the
+252 convention in miniature and the rule above governs it directly. Replaced:
+
+```
+entries_per_calendar_week = fired_entry_signals / (span_days / 7)
+    where span_days = last_scanned_bar - first_scanned_bar
+```
+
+measured off the scanned-bar axis itself, and **`null` when that axis cannot carry a
+rate** — fewer than two distinct scanned bar dates, or a zero span. No minimum-span
+constant is picked; the refusal is the existing rule's, applied at the week scale
+instead of the year scale.
+
+⚠ Consequence, measured: every current strategy version has exactly **one** scanned bar
+date, so `entries_per_calendar_week` is `null` for all four today. That is the correct
+output, not a gap — it is the same refusal `periods_per_year` already makes, and it
+resolves itself as the scan accrues days. The prior versions with 5-date axes show the
+metric works the moment a version outlives one scan.
+
+⚠ The axis is **bar dates**, not scan runs. A catch-up run can write several bar dates
+at once, so `scanned_days` counts market days evaluated, not job invocations. That is
+the right axis for "how many signals per week of market", which is the question asked.
+
+### 2.2 The propensity denominator — the census carries it, so use it
+
+Counting fires per day answers "how much lands in my lap" and is not a rate: a day on
+which one instrument was evaluated weighs the same as a day on which 5,000 were, so
+universe growth moves the number with no change in strategy behaviour. The census stores
+`row_count` for **all three verdicts**, so the dimensionless form is available directly:
+
+```
+fired_share_of_evaluable = fired / (fired + not_fired)
+```
+
+`not_evaluable` is excluded from the denominator. Those bars were not judged — the
+closed reason vocabulary is `missing_volume`, `insufficient_warmup`, `no_fill_bar` and
+five siblings (`sql/276:20`) — so counting them as opportunities the strategy declined
+would suppress the share as though it had been offered a chance it never got.
+
+Both quantities ship. They answer different halves of the operator's question and
+neither substitutes for the other.
+
+### 2.3 Entries only — structural, not a corpus fact
+
+`signal_kind = 'entry'`. An entry is an opportunity to commit capital, which is what
+"how often might they fire" asks; an exit is management of capital already committed and
+its frequency is a property of the open book. This is a definitional split, not an
+observation about the current four strategies.
+
+### 2.4 Population and version scope
+
+- **Population** — `strategy_signal_daily_counts` (`sql/276_strategy_observation_storage.sql:11`),
+  the durable census. NOT `strategy_signals`.
+- **Version scope** — the CURRENT `strategy_version` only, over all of its census
+  history. A version is a rule set (#2670); pooling two averages two arithmetics.
+- **Universe label** — `survivor_only`, from `strategy_signal_scan.SCAN_UNIVERSE`, per
+  #2288's contract that a metric computed on a survivor-only universe is marked as such.
+  The census has no `universe` column, but it does not need one here: a universe change
+  is a new `strategy_version` by construction (`strategy_signal_scan.py` — *"The switch
+  to a point-in-time population is a NEW `universe` value, hence a new
+  `strategy_version`"*), and this query filters to one version, so every row it reads
+  was written under the label it reports.
+
+## 3. Null is not zero, and the API says which
+
+| state | `scanned_days` | `fired_share_of_evaluable` | `entries_per_calendar_week` | `rate_unavailable_reason` |
+| --- | --- | --- | --- | --- |
+| never scanned (new version) | 0 | `null` | `null` | `never_scanned` |
+| one scan day | ≥1 | value | `null` | `single_scan_day` |
+| scanned, never fired | ≥2 | `0.0000` | `0.00` | `null` |
+| normal | ≥2 | value | value | `null` |
+
+`rate_unavailable_reason` exists because `null` otherwise means three different things
+and gap 3 requires empty states to say *which*. ⚠ `sum(row_count) FILTER (WHERE verdict
+= 'fired')` returns **NULL**, not `0`, when a version has no fired bucket at all — s2 is
+exactly that today — so the numerator is coalesced. Getting that wrong reports a scanned
+strategy as unmeasured.
+
+## 4. What ships
+
+`app/services/strategy_monitoring.py` gains `load_fire_rate(conn, *, versions)`,
+matching `load_attribution`'s existing shape — one query, keyed
+`(strategy_id, strategy_version)`. `StrategyOverview` gains a `fire_rate` view:
+
+| field | meaning |
+| --- | --- |
+| `universe` | `survivor_only` (§2.4) |
+| `scanned_days` | distinct entry bar dates in the census for this version |
+| `fired_days` | of those, days with ≥1 fired entry |
+| `fired_entry_signals` | total fired entry signals |
+| `evaluable_entry_decisions` | `fired + not_fired` decisions |
+| `not_evaluable_entry_decisions` | excluded from the denominator, reported so the exclusion is visible |
+| `fired_share_of_evaluable` | §2.2, 4 dp, `null` when no evaluable decisions |
+| `entries_per_calendar_week` | §2.1, 2 dp, `null` per the table above |
+| `first_scanned_bar` / `last_scanned_bar` | the axis the rate is measured on |
+| `rate_unavailable_reason` | `never_scanned` \| `single_scan_day` \| `null` |
+
+Quantised with `Decimal.quantize` at the stated precision so the JSON is stable rather
+than a repeating expansion.
+
+## 5. Edge cases considered and rejected as unreachable
+
+- **A completed scan that wrote zero rows** would be census-invisible (`row_count > 0`
+  is a CHECK) and indistinguishable from never-scanned. Not reachable through a
+  successful scan: `assert_census_complete` (`strategy_signal_scan.py:791`) compares the
+  censused count against the eligible population it computed and **fails the job** on a
+  short leg — scan spec §9, *"a mismatch is a failure, not a log line"*.
+- **Future-dated census rows** would enter "all history" unbounded. Not reachable: the
+  scan runs in arrears and writes the bar *before* the frontier
+  (`strategy_signal_scan.py` module docstring §1).
+
+## 6. Not in scope
+
+- `strategy_opportunity_forecasts` stays at 0 rows. Its `expected_duration_hours` is a
+  forecast field needing gap 1's duration work behind it; this metric is observed
+  history, and writing observed history into a forecast table would mislabel it.
+- `StrategyAttribution.signals_last_30_days` is left alone. It counts the same sparse
+  table against a 30-calendar-day filter, so it carries the same denominator weakness in
+  a milder form. Changing it moves an existing operator-visible figure and belongs in
+  its own ticket rather than being smuggled into this one.
+
+## 7. Verification
+
+Pure-logic table tests over the derivation (the loader splits into a pure
+`derive_fire_rate` and a thin query, so every row of §3's table is a unit case):
+never-scanned, single-scan-day, scanned-never-fired (NULL numerator coalesced), zero
+evaluable decisions, a multi-day axis, and `fired_days <= scanned_days`.
+
+One DB test that the loader reads the census and not `strategy_signals`, on a fixture
+where the two disagree on days — the 5-vs-1 shape measured in §1.
+
+Dev: `GET /strategies/overview` on the live `:8000`. Expected from §1's measurements —
+s1 `fired_share_of_evaluable = 0.5210` (1,740 / 3,340), s2 `0.0000` (0 / 3,273), s3
+`0.0039` (13 / 3,330), s4 `0.0340` (186 / 5,468), and
+`rate_unavailable_reason = single_scan_day` on all four.

--- a/tests/test_strategy_fire_rate.py
+++ b/tests/test_strategy_fire_rate.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
+import pytest
+
 from app.services.strategy_monitoring import StrategyFireRate, derive_fire_rate
 
 
@@ -37,14 +39,16 @@ class TestUnavailableReason:
 
     def test_never_scanned_reports_the_reason_not_a_zero_rate(self) -> None:
         rate = _derive(scanned_days=0, fired_days=0, fired_entry_signals=0, evaluable_entry_decisions=0)
-        assert rate.rate_unavailable_reason == "never_scanned"
+        assert rate.share_unavailable_reason == "never_scanned"
+        assert rate.weekly_rate_unavailable_reason == "never_scanned"
         assert rate.fired_share_of_evaluable is None
         assert rate.entries_per_calendar_week is None
 
     def test_default_state_is_never_scanned(self) -> None:
         # The API substitutes this for a key absent from the census, so the
         # default must be the honest "no evidence" state, not an implied zero.
-        assert StrategyFireRate().rate_unavailable_reason == "never_scanned"
+        assert StrategyFireRate().share_unavailable_reason == "never_scanned"
+        assert StrategyFireRate().weekly_rate_unavailable_reason == "never_scanned"
         assert StrategyFireRate().fired_share_of_evaluable is None
 
     def test_single_scan_day_gives_a_share_but_refuses_a_weekly_rate(self) -> None:
@@ -57,12 +61,15 @@ class TestUnavailableReason:
             first_scanned_bar=date(2026, 8, 10),
             last_scanned_bar=date(2026, 8, 10),
         )
-        assert rate.rate_unavailable_reason == "single_scan_day"
+        assert rate.weekly_rate_unavailable_reason == "single_scan_day"
         assert rate.entries_per_calendar_week is None
+        # The share needs no axis, so one scan day still measures it.
         assert rate.fired_share_of_evaluable == Decimal("0.5210")
+        assert rate.share_unavailable_reason is None
 
     def test_a_measurable_axis_carries_no_reason(self) -> None:
-        assert _derive().rate_unavailable_reason is None
+        assert _derive().weekly_rate_unavailable_reason is None
+        assert _derive().share_unavailable_reason is None
 
 
 class TestScannedButNeverFired:
@@ -72,11 +79,18 @@ class TestScannedButNeverFired:
         rate = _derive(fired_days=0, fired_entry_signals=0, evaluable_entry_decisions=3_273)
         assert rate.fired_share_of_evaluable == Decimal("0.0000")
         assert rate.entries_per_calendar_week == Decimal("0.00")
-        assert rate.rate_unavailable_reason is None
+        assert rate.share_unavailable_reason is None
+        assert rate.weekly_rate_unavailable_reason is None
 
-    def test_no_evaluable_decisions_leaves_the_share_null(self) -> None:
-        # A day on which every bar was `not_evaluable`: the strategy was never
+    def test_no_evaluable_decisions_leaves_the_share_null_WITH_a_reason(self) -> None:
+        # Every bar `not_evaluable` across a MULTI-DAY axis: the strategy was never
         # offered a decision, so its propensity is unknown rather than zero.
+        #
+        # ⚠ This is the state that showed one reason field cannot serve both nulls.
+        # The axis here is perfectly good, so the weekly rate is a real 0.00 — while
+        # the share is null. A single `rate_unavailable_reason` read `None` here and
+        # left the null share unexplained, breaking the spec's own "null is not zero,
+        # and the API says which" contract. Caught by the review bot on PR #2681.
         rate = _derive(
             fired_days=0,
             fired_entry_signals=0,
@@ -84,6 +98,9 @@ class TestScannedButNeverFired:
             not_evaluable_entry_decisions=2_438,
         )
         assert rate.fired_share_of_evaluable is None
+        assert rate.share_unavailable_reason == "no_evaluable_decisions"
+        assert rate.entries_per_calendar_week == Decimal("0.00")
+        assert rate.weekly_rate_unavailable_reason is None
         assert rate.not_evaluable_entry_decisions == 2_438
 
 
@@ -109,7 +126,7 @@ class TestWeeklyRateIsMeasuredOffTheAxis:
             first_scanned_bar=date(2026, 8, 3),
             last_scanned_bar=date(2026, 8, 4),
         )
-        assert rate.rate_unavailable_reason is None
+        assert rate.weekly_rate_unavailable_reason is None
         assert rate.entries_per_calendar_week == Decimal("14.00")
 
     def test_repeated_scans_of_one_date_still_have_no_span(self) -> None:
@@ -121,8 +138,38 @@ class TestWeeklyRateIsMeasuredOffTheAxis:
             first_scanned_bar=date(2026, 8, 4),
             last_scanned_bar=date(2026, 8, 4),
         )
-        assert rate.rate_unavailable_reason == "single_scan_day"
+        assert rate.weekly_rate_unavailable_reason == "single_scan_day"
         assert rate.entries_per_calendar_week is None
+
+
+class TestEveryNullNamesItsReason:
+    """The contract the two reason fields exist to keep, asserted both directions.
+
+    A null value with no reason is an unexplained blank on the operator's page,
+    which #2623 scope 3 forbids; a reason beside a present value is a contradiction.
+    """
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            pytest.param({"scanned_days": 0, "fired_entry_signals": 0, "evaluable_entry_decisions": 0}, id="never"),
+            pytest.param(
+                {
+                    "scanned_days": 1,
+                    "first_scanned_bar": date(2026, 8, 10),
+                    "last_scanned_bar": date(2026, 8, 10),
+                },
+                id="one-day",
+            ),
+            pytest.param({"evaluable_entry_decisions": 0, "fired_entry_signals": 0}, id="none-evaluable"),
+            pytest.param({}, id="fully-measured"),
+            pytest.param({"fired_entry_signals": 0, "fired_days": 0}, id="scanned-never-fired"),
+        ],
+    )
+    def test_value_is_none_iff_its_reason_is_not(self, overrides: dict[str, object]) -> None:
+        rate = _derive(**overrides)
+        assert (rate.fired_share_of_evaluable is None) is (rate.share_unavailable_reason is not None)
+        assert (rate.entries_per_calendar_week is None) is (rate.weekly_rate_unavailable_reason is not None)
 
 
 class TestReportedCounts:

--- a/tests/test_strategy_fire_rate.py
+++ b/tests/test_strategy_fire_rate.py
@@ -1,0 +1,139 @@
+"""#2623 gap 2 — the entry fire rate derived from the durable scan census.
+
+Spec: ``docs/proposals/ta/2026-08-14-strategy-fire-rate.md``.
+
+The derivation is pure, so every row of the spec's §3 state table is a unit case.
+
+⚠ The loader's DB test lives in ``test_strategy_fire_rate_db.py`` and not here on
+purpose: ``tests/conftest.py::_module_source_touches_db`` marks a whole MODULE
+``db`` when its source touches psycopg, so one DB test in this file would drop
+every case below off the fast push gate.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.strategy_monitoring import StrategyFireRate, derive_fire_rate
+
+
+def _derive(**overrides: object) -> StrategyFireRate:
+    kwargs: dict[str, object] = {
+        "scanned_days": 5,
+        "fired_days": 3,
+        "fired_entry_signals": 100,
+        "evaluable_entry_decisions": 1_000,
+        "not_evaluable_entry_decisions": 0,
+        "first_scanned_bar": date(2026, 7, 28),
+        "last_scanned_bar": date(2026, 8, 4),
+    }
+    kwargs.update(overrides)
+    return derive_fire_rate(**kwargs)  # type: ignore[arg-type]
+
+
+class TestUnavailableReason:
+    """§3's table: `None` would otherwise mean three different things."""
+
+    def test_never_scanned_reports_the_reason_not_a_zero_rate(self) -> None:
+        rate = _derive(scanned_days=0, fired_days=0, fired_entry_signals=0, evaluable_entry_decisions=0)
+        assert rate.rate_unavailable_reason == "never_scanned"
+        assert rate.fired_share_of_evaluable is None
+        assert rate.entries_per_calendar_week is None
+
+    def test_default_state_is_never_scanned(self) -> None:
+        # The API substitutes this for a key absent from the census, so the
+        # default must be the honest "no evidence" state, not an implied zero.
+        assert StrategyFireRate().rate_unavailable_reason == "never_scanned"
+        assert StrategyFireRate().fired_share_of_evaluable is None
+
+    def test_single_scan_day_gives_a_share_but_refuses_a_weekly_rate(self) -> None:
+        # This is every current strategy version's state as at 2026-08-14.
+        rate = _derive(
+            scanned_days=1,
+            fired_days=1,
+            fired_entry_signals=1_740,
+            evaluable_entry_decisions=3_340,
+            first_scanned_bar=date(2026, 8, 10),
+            last_scanned_bar=date(2026, 8, 10),
+        )
+        assert rate.rate_unavailable_reason == "single_scan_day"
+        assert rate.entries_per_calendar_week is None
+        assert rate.fired_share_of_evaluable == Decimal("0.5210")
+
+    def test_a_measurable_axis_carries_no_reason(self) -> None:
+        assert _derive().rate_unavailable_reason is None
+
+
+class TestScannedButNeverFired:
+    """The distinction the whole ticket turns on. s2 is this row of the table."""
+
+    def test_zero_fires_over_a_real_axis_is_a_measurement_not_an_absence(self) -> None:
+        rate = _derive(fired_days=0, fired_entry_signals=0, evaluable_entry_decisions=3_273)
+        assert rate.fired_share_of_evaluable == Decimal("0.0000")
+        assert rate.entries_per_calendar_week == Decimal("0.00")
+        assert rate.rate_unavailable_reason is None
+
+    def test_no_evaluable_decisions_leaves_the_share_null(self) -> None:
+        # A day on which every bar was `not_evaluable`: the strategy was never
+        # offered a decision, so its propensity is unknown rather than zero.
+        rate = _derive(
+            fired_days=0,
+            fired_entry_signals=0,
+            evaluable_entry_decisions=0,
+            not_evaluable_entry_decisions=2_438,
+        )
+        assert rate.fired_share_of_evaluable is None
+        assert rate.not_evaluable_entry_decisions == 2_438
+
+
+class TestWeeklyRateIsMeasuredOffTheAxis:
+    """Not `fires per scanned day x 5` — see `strategy_statistics`' settled rule."""
+
+    def test_rate_divides_by_the_calendar_span_not_the_scanned_day_count(self) -> None:
+        # 100 fires over 5 scanned days spanning 7 calendar days is 100/week.
+        # A `fires per scanned day x 5` construction would say 100/5*5 = 100 too,
+        # so the discriminating case is a span that is NOT a round week.
+        assert _derive().entries_per_calendar_week == Decimal("100.00")
+
+    def test_a_sparse_axis_is_not_treated_as_contiguous(self) -> None:
+        # 5 scanned days over a 14-day span: the scan missed days, and the
+        # throughput the operator actually saw is halved accordingly.
+        rate = _derive(first_scanned_bar=date(2026, 7, 21), last_scanned_bar=date(2026, 8, 4))
+        assert rate.entries_per_calendar_week == Decimal("50.00")
+
+    def test_two_day_axis_is_the_shortest_that_carries_a_rate(self) -> None:
+        rate = _derive(
+            scanned_days=2,
+            fired_entry_signals=2,
+            first_scanned_bar=date(2026, 8, 3),
+            last_scanned_bar=date(2026, 8, 4),
+        )
+        assert rate.rate_unavailable_reason is None
+        assert rate.entries_per_calendar_week == Decimal("14.00")
+
+    def test_repeated_scans_of_one_date_still_have_no_span(self) -> None:
+        # `scanned_days` counts DISTINCT bar dates, so this shape cannot arise
+        # from the query — but a zero span must refuse regardless of the count,
+        # or the guard depends on two facts agreeing rather than on the axis.
+        rate = _derive(
+            scanned_days=4,
+            first_scanned_bar=date(2026, 8, 4),
+            last_scanned_bar=date(2026, 8, 4),
+        )
+        assert rate.rate_unavailable_reason == "single_scan_day"
+        assert rate.entries_per_calendar_week is None
+
+
+class TestReportedCounts:
+    def test_raw_counts_pass_through_for_the_catalog_to_show_provenance(self) -> None:
+        rate = _derive(not_evaluable_entry_decisions=2_450)
+        assert (rate.scanned_days, rate.fired_days) == (5, 3)
+        assert rate.fired_entry_signals == 100
+        assert rate.evaluable_entry_decisions == 1_000
+        assert rate.not_evaluable_entry_decisions == 2_450
+        assert rate.first_scanned_bar == date(2026, 7, 28)
+        assert rate.last_scanned_bar == date(2026, 8, 4)
+
+    def test_universe_is_labelled_per_2288(self) -> None:
+        assert _derive().universe == "survivor_only"

--- a/tests/test_strategy_fire_rate_db.py
+++ b/tests/test_strategy_fire_rate_db.py
@@ -1,0 +1,69 @@
+"""#2623 gap 2 — the fire-rate loader reads the census, not the sparse ledger.
+
+Separated from ``test_strategy_fire_rate.py`` because the ``db`` marker is applied
+per MODULE (``tests/conftest.py``), and the pure derivation cases belong on the
+fast gate. Spec: ``docs/proposals/ta/2026-08-14-strategy-fire-rate.md``.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import psycopg
+import pytest
+
+from app.services.strategy_monitoring import load_fire_rate
+
+
+@pytest.mark.db
+class TestLoaderReadsTheCensus:
+    """The one thing a pure test cannot prove: WHICH table is read.
+
+    ``strategy_signals`` retains only fired rows durably, so it can see only the
+    days on which something fired. The fixture below reproduces the shape measured
+    on the full population — a version whose negatives outlive its fires — and the
+    two sources disagree on the denominator by 5x.
+    """
+
+    def test_scanned_days_come_from_the_census_not_the_sparse_signal_table(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        conn = ebull_test_conn
+        version = "test-fire-rate-v1+census"
+        with conn.cursor() as cur:
+            # One fired day, four further days on which the strategy was
+            # evaluated and did not fire. `strategy_signals` would see 1 day.
+            cur.execute(
+                """
+                INSERT INTO strategy_signal_daily_counts
+                    (strategy_id, strategy_version, signal_bar_date,
+                     signal_kind, verdict, reason_code, row_count)
+                VALUES
+                    ('s-test', %(v)s, DATE '2026-07-28', 'entry', 'fired',     '', 40),
+                    ('s-test', %(v)s, DATE '2026-07-29', 'entry', 'not_fired', '', 10),
+                    ('s-test', %(v)s, DATE '2026-07-30', 'entry', 'not_fired', '', 10),
+                    ('s-test', %(v)s, DATE '2026-08-03', 'entry', 'not_fired', '', 10),
+                    ('s-test', %(v)s, DATE '2026-08-04', 'entry', 'not_fired', '', 10),
+                    -- An exit leg on a date the entry axis does not contain:
+                    -- it must not extend the entry span or the rate is diluted.
+                    ('s-test', %(v)s, DATE '2026-08-20', 'exit',  'fired',     '', 99)
+                """,
+                {"v": version},
+            )
+            rates = load_fire_rate(conn, versions=[version])
+
+        rate = rates[("s-test", version)]
+        assert rate.scanned_days == 5, "census days, not the 1 day strategy_signals retains"
+        assert rate.fired_days == 1
+        assert rate.fired_entry_signals == 40
+        assert rate.evaluable_entry_decisions == 80
+        assert rate.last_scanned_bar == date(2026, 8, 4), "the exit leg must not extend the entry axis"
+        # 40 fires over a 7-day span.
+        assert rate.entries_per_calendar_week == Decimal("40.00")
+        assert rate.fired_share_of_evaluable == Decimal("0.5000")
+
+    def test_a_version_absent_from_the_census_is_absent_from_the_result(
+        self, ebull_test_conn: psycopg.Connection[tuple]
+    ) -> None:
+        assert load_fire_rate(ebull_test_conn, versions=["test-fire-rate-v1+never-scanned"]) == {}

--- a/tests/test_strategy_fire_rate_db.py
+++ b/tests/test_strategy_fire_rate_db.py
@@ -62,6 +62,8 @@ class TestLoaderReadsTheCensus:
         # 40 fires over a 7-day span.
         assert rate.entries_per_calendar_week == Decimal("40.00")
         assert rate.fired_share_of_evaluable == Decimal("0.5000")
+        assert rate.share_unavailable_reason is None
+        assert rate.weekly_rate_unavailable_reason is None
 
     def test_a_version_absent_from_the_census_is_absent_from_the_result(
         self, ebull_test_conn: psycopg.Connection[tuple]


### PR DESCRIPTION
## What this is

#2623 gap 2 — fire frequency for the strategy catalog, derived at read time. No
migration, no re-run, no trial-register interaction. Gaps 1 (holding-period
statistics, corpus rung) and 3 (catalog view) are out of scope and #2623 stays open.

Spec: `docs/proposals/ta/2026-08-14-strategy-fire-rate.md`.

## The ticket's proposed source is wrong on the denominator

> "…or derive fires/week from `strategy_signals` history at read time."

`strategy_signals` is **sparse by design** (`app/services/strategy_observation_storage.py`
module docstring): fired rows stay durable because outcomes and trade ownership refer to
`signal_id`, while routine negatives are retained 90 days in monthly partitions of
`strategy_signal_observations` and survive durably **only** as
`strategy_signal_daily_counts` rows.

Full population — every `(strategy_id, strategy_version)` key in either table, entries
only, dev 2026-08-14. Not a sample:

| strategy | version | bar dates in `strategy_signals` | bar dates in census | fired (both) |
| --- | --- | --- | --- | --- |
| s1 | `…ee566d7b` | 1 | **5** | 1,722 |
| s1 | `…f07c9d72` | 1 | 1 | 1,740 |
| s2 | `…7fcb1fca` | **absent** | 1 | 0 |
| s2 | `…89fd873d` | **absent** | **5** | 0 |
| s3 | `…01d3736e` | 1 | **5** | 11 |
| s3 | `…89368716` | 1 | 1 | 13 |
| s4 | `…d32dc4e4` | 1 | **5** | 108 |
| s4 | `…ff76dcde` | 1 | **5** | 108 |
| s4 | `…dde63f07` | 1 | 1 | 186 |

```sql
WITH sig AS (SELECT strategy_id,strategy_version,count(DISTINCT signal_bar_date) days
             FROM strategy_signals WHERE signal_kind='entry' GROUP BY 1,2),
     cen AS (SELECT strategy_id,strategy_version,count(DISTINCT signal_bar_date) days
             FROM strategy_signal_daily_counts WHERE signal_kind='entry' GROUP BY 1,2)
SELECT * FROM cen FULL JOIN sig USING (strategy_id,strategy_version);
```

The fired counts agree **exactly** on all nine keys; only the days disagree. So
`strategy_signals` is a correct numerator over an unusable denominator — a **5×**
overstatement on four of nine keys. And s2 scanned and fired nothing, so it has no rows
there at all: sourced from `strategy_signals` it would be absent from the catalog rather
than reading an honest `0`. "Scanned, never fired" and "never scanned" are different
states and only the census separates them.

`docs/review-prevention-log.md` § *"On a SPARSE table, the storage predicate is part of
the census definition"*, firing on live data rather than hypothetically.

## Source rule

Two of three decisions are fixed by a rule already written down here; the third has no
published formulation and is fixed by construction and said so.

**The rate axis is settled and it is not `×5`.** `app/services/strategy_statistics.py:9`
— *"⚠⚠ THE ANNUALISATION FACTOR IS MEASURED OFF THE DATE AXIS, NEVER THE 252 CONVENTION
… picking one is exactly the 'am I about to pick a threshold, ratio or window' trigger"*
— and `periods_per_year` **raises** on a sub-two-date axis because *"inventing one would
put a divide-by-zero behind a plausible number"*. The first draft of this spec froze
`TRADING_DAYS_PER_WEEK = 5`; that is the 252 convention at the week scale. Replaced with
`fired / (span_days / 7)` measured off the scanned-bar axis, `null` when the axis cannot
carry a rate. No constant is picked; the refusal is the existing rule's.

**Two rates, because they answer different questions.** `fired_share_of_evaluable` is
the propensity — dimensionless, so universe growth does not move it. `not_evaluable`
decisions are excluded from its denominator: those bars were never judged
(`insufficient_warmup`, `no_fill_bar` and six siblings, `sql/276:20`), and counting them
as declined opportunities suppresses the share for a chance never offered.
`entries_per_calendar_week` is throughput and is universe-size-dependent **by design** —
the operator trades this universe — which is exactly why it cannot stand alone.

**Entries only**, structurally: an entry is an opportunity to commit capital, an exit is
management of capital already committed.

**Universe label** `survivor_only` per #2288. The census has no `universe` column and
does not need one: a universe change mints a new `strategy_version`, and this reads one
version at a time.

## Null is not zero, and the API says which

| state | `scanned_days` | `fired_share_of_evaluable` | `entries_per_calendar_week` | `rate_unavailable_reason` |
| --- | --- | --- | --- | --- |
| never scanned | 0 | `null` | `null` | `never_scanned` |
| one scan day | ≥1 | value | `null` | `single_scan_day` |
| scanned, never fired | ≥2 | `0.0000` | `0.00` | `null` |
| normal | ≥2 | value | value | `null` |

`rate_unavailable_reason` exists because `null` would otherwise mean three things, and
#2623 scope 3 requires empty states to say *which*. ⚠ `sum(row_count) FILTER (WHERE
verdict='fired')` returns **NULL**, not `0`, for a version with no fired bucket — s2
today — so the numerator is coalesced in SQL. Getting that wrong reports a scanned
strategy as unmeasured.

## Codex

**Checkpoint 1 (spec) earned twice, both structural.** It caught that
`COUNT(DISTINCT signal_bar_date)` alone is throughput and not a rate (a day evaluating
one instrument weighing the same as one evaluating 5,000), which added the propensity
denominator; and it found the `×5` scaling contradicting `strategy_statistics`'
documented axis rule, which I had not cited. It also caught a real internal
contradiction — I had written that s2 would verify at `scanned_days = 5`, which is its
**prior** version; the current one has 1. All three verified against source before
accepting. Checkpoint 2 on the diff: no findings.

**Rebutted:** *"a completed scan writing zero rows is census-invisible and
indistinguishable from never-scanned"* — not reachable through a successful scan.
`assert_census_complete` (`strategy_signal_scan.py:791`) compares the censused count
against the eligible population and **fails the job** on a short leg (scan spec §9, *"a
mismatch is a failure, not a log line"*). Recorded in the spec's §5 rather than guarded
against. Same for future-dated rows: the scan runs in arrears and writes the bar before
the frontier.

## Verification

- **Lint / format / pyright / fast tier / smoke** — all green on exit code, not piped
  output (#2279's recommitted trap).
- **DB tier** — `test_api_strategies`, `test_strategy_monitoring`,
  `test_strategy_observation_storage`, `test_strategy_control_plane` and the new
  `test_strategy_fire_rate_db` all pass.
- **Pure tests** deliberately live in a separate module from the DB test:
  `tests/conftest.py::_module_source_touches_db` marks a whole module `db` when its
  source touches psycopg, so co-locating them would drop 12 pure cases off the fast gate.
- **Dev-verified** against the real dev DB through the endpoint function itself
  (`:8000` serves `~/Dev/eBull`, not this worktree — the documented exception). Observed,
  matching the spec's predictions exactly:

| strategy | fired / evaluable | share | week | reason |
| --- | --- | --- | --- | --- |
| s1 | 1,740 / 3,340 | `0.5210` | `null` | `single_scan_day` |
| s2 | 0 / 3,273 | `0.0000` | `null` | `single_scan_day` |
| s3 | 13 / 3,330 | `0.0039` | `null` | `single_scan_day` |
| s4 | 186 / 5,468 | `0.0340` | `null` | `single_scan_day` |

s2 reading an honest `0.0000` rather than being absent is the whole point of the source
change. The weekly rate being `null` on all four is the axis refusal working, not a gap
— the prior versions carry 5-date axes and rate fine, so it resolves itself as the scan
accrues days.

## What this does NOT do

- It does not populate `strategy_opportunity_forecasts` (still 0 rows). That table's
  `expected_duration_hours` is a **forecast** field needing gap 1's duration work behind
  it; this metric is observed history, and writing observed history there would mislabel it.
- It does not fix `StrategyAttribution.signals_last_30_days`, which counts the same
  sparse table against a 30-calendar-day filter and so carries a milder form of the same
  denominator weakness. Changing it moves an existing operator-visible figure and belongs
  in its own ticket rather than being smuggled into this one.
- It ships no UI. Gap 3's catalog view is where these fields become operator-visible.

## Security

No new input, no new write path, no new credential or broker surface. One additional
read-only aggregate over a table the same endpoint already reads, under the endpoint's
existing session/service-token auth.

Refs #2623. Refs #2437.
