### PR TITLE
feature(#2623): carry the holding period through to the metric set

### DIFF
--- a/app/services/backtest_run.py
+++ b/app/services/backtest_run.py
@@ -869,6 +869,8 @@ class _NamespaceBook:
     book: LegBook = field(default_factory=LegBook)
     returns: array[float] = field(default_factory=lambda: array("d"))
     entry_dates: list[date] = field(default_factory=list)
+    #: Positionally parallel to `entry_dates`; `TradeReturns` enforces that.
+    exit_dates: list[date] = field(default_factory=list)
     instruments: set[int] = field(default_factory=set)
     positions: int = 0
     open_at_end: int = 0
@@ -1123,8 +1125,14 @@ def _absorb(
             continue
         assert row.exit_price_net is not None and row.net_return_pct is not None
 
+        # ⚠ `close_bar_date` is nullable but `realised` is set True ONLY in this
+        # branch, so a realised trade provably has one. Bound here rather than
+        # re-narrowed at the append below: the guarantee is structural, and
+        # re-deriving it there would let the two drift apart (#2623 gap 1).
+        close_bar_date: date | None = None
         if position.close_bar_date is not None:
-            exit_index = axis_pos.get(position.close_bar_date)
+            close_bar_date = position.close_bar_date
+            exit_index = axis_pos.get(close_bar_date)
             realised = True
         else:
             book.open_at_end += 1
@@ -1170,8 +1178,12 @@ def _absorb(
             marks=list(wealth_span),
         )
         if realised:
+            assert close_bar_date is not None  # realised is set only where it is bound
             book.returns.append((exit_price - entry_price) / entry_price * 100.0)
             book.entry_dates.append(position.entry_fill_bar_date)
+            # #2623 gap 1. The exit bar was never lost here — the namespace split
+            # above already reads it — only never carried into the metric set.
+            book.exit_dates.append(close_bar_date)
 
 
 @dataclass(frozen=True)
@@ -1347,6 +1359,7 @@ def _measure_namespace(
         trades=TradeReturns(
             net_return_pct=tuple(book.returns),
             entry_fill_date=tuple(book.entry_dates),
+            exit_bar_date=tuple(book.exit_dates),
             open_count=book.open_at_end,
             unpriced_count=sum(book.excluded.values()),
         ),

--- a/app/services/result_ledger.py
+++ b/app/services/result_ledger.py
@@ -412,7 +412,7 @@ _RESULT_COLUMNS = """
     bootstrap_resamples, bootstrap_seed, bootstrap_design_effect, bootstrap_model_id,
     dsr_trade_sharpe, dsr_skewness, dsr_kurtosis, dsr_expected_max_sharpe, dsr_independent_trials,
     dsr_average_trial_correlation, dsr_trial_sharpe_variance, dsr_measured_trials, dsr_model_id,
-    trial_register_version,
+    trial_register_version, median_hold_days, hold_days_p25, hold_days_p75,
     synthetic_control_model_id, synthetic_control_size, synthetic_control_root_seed,
     synthetic_control_mean_return_pct, synthetic_control_mean_return_ci_low_pct,
     synthetic_control_mean_return_ci_high_pct, synthetic_control_sharpe_percentile,
@@ -440,6 +440,7 @@ _RESULT_VALUES = """
     %(dsr_trade_sharpe)s, %(dsr_skewness)s, %(dsr_kurtosis)s, %(dsr_expected_max_sharpe)s,
     %(dsr_independent_trials)s, %(dsr_average_trial_correlation)s, %(dsr_trial_sharpe_variance)s,
     %(dsr_measured_trials)s, %(dsr_model_id)s, %(trial_register_version)s,
+    %(median_hold_days)s, %(hold_days_p25)s, %(hold_days_p75)s,
     %(synthetic_control_model_id)s, %(synthetic_control_size)s, %(synthetic_control_root_seed)s,
     %(synthetic_control_mean_return_pct)s, %(synthetic_control_mean_return_ci_low_pct)s,
     %(synthetic_control_mean_return_ci_high_pct)s, %(synthetic_control_sharpe_percentile)s,
@@ -589,6 +590,11 @@ def _row_params(result: StrategyResult) -> dict[str, object]:
         "total_return_pct": _numeric(metrics.total_return_pct),
         "buy_and_hold_return_pct": _numeric(metrics.buy_and_hold_return_pct),
         "metric_set_id": metrics.metric_set_id,
+        # #2623 gap 1. NULL-preserving: these are legitimately absent on a result
+        # with no realised trades, and `sql/347`'s CHECK ties that to metric_set_id.
+        "median_hold_days": _numeric(metrics.median_hold_days),
+        "hold_days_p25": _numeric(metrics.hold_days_p25),
+        "hold_days_p75": _numeric(metrics.hold_days_p75),
         # ⚠ sql/265's criterion-3 block. All nine columns (including
         # `effective_sample_size` above) are bound by
         # `strategy_results_bootstrap_all_or_nothing`, so omitting these eight
@@ -757,6 +763,11 @@ def _result_from_row(row: Sequence[object]) -> StrategyResult:
         dsr_measured_trials,
         dsr_model_id,
         trial_register_version,
+        # ⚠ POSITION MATTERS: this tuple is unpacked from `_RESULT_COLUMNS`, so
+        # the order here must match that constant exactly, not read naturally.
+        median_hold_days,
+        hold_days_p25,
+        hold_days_p75,
         synthetic_control_model_id,
         synthetic_control_size,
         synthetic_control_root_seed,
@@ -833,6 +844,12 @@ def _result_from_row(row: Sequence[object]) -> StrategyResult:
         bootstrap_seed=None if bootstrap_seed is None else int(bootstrap_seed),  # type: ignore[arg-type]
         bootstrap_design_effect=_as_float(bootstrap_design_effect),  # type: ignore[arg-type]
         bootstrap_model_id=None if bootstrap_model_id is None else str(bootstrap_model_id),
+        # #2623 gap 1 — NULL-preserving for the same reason the bootstrap block
+        # above is: a legacy `criterion7-v1` row genuinely has no holding period,
+        # and `float(None)` would raise while `0.0` would invent a same-day close.
+        median_hold_days=_as_float(median_hold_days),  # type: ignore[arg-type]
+        hold_days_p25=_as_float(hold_days_p25),  # type: ignore[arg-type]
+        hold_days_p75=_as_float(hold_days_p75),  # type: ignore[arg-type]
     )
     # ⚠ sql/266, and the same NULL-preserving rule as the bootstrap block above.
     # The set is all-or-nothing, so ONE probe decides it — `dsr_model_id`, which

--- a/app/services/strategy_statistics.py
+++ b/app/services/strategy_statistics.py
@@ -45,6 +45,7 @@ calendar year, inflating Sharpe by ``sqrt(365/196) = 1.37x``. See
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 from typing import Final
@@ -64,7 +65,18 @@ DAYS_PER_YEAR: Final = 365.25
 #: row's provenance in the same spirit as ``COST_MODEL_ID``: a change to any
 #: definition below is a change to what a stored number MEANS, and a reader
 #: holding a two-year-old row needs to know which definition produced it.
-METRIC_SET_ID: Final = "criterion7-v1"
+#: ⚠⚠ BUMPED v1 → v2 by #2623 gap 1, which added the three holding-period fields.
+#: A version denotes a RULE SET, not a row population (#2670) — a row carrying
+#: metrics `criterion7-v1` never defined cannot truthfully keep that stamp, even
+#: though no pre-existing metric changed value.
+#:
+#: Nothing gates on this VALUE (verified across `app/`, `sql/`, `frontend/src`:
+#: written at `strategy_result.py`, read back at `result_ledger.py`, constrained
+#: only by `CHECK (metric_set_id <> '')` in `sql/263`). What the bump BUYS is that
+#: a null holding period is readable: on a `criterion7-v1` row it is legitimate and
+#: permanent, on a `criterion7-v2` row it is a writer defect unless there are no
+#: realised trades. `sql/347` enforces exactly that.
+METRIC_SET_ID: Final = "criterion7-v2"
 
 
 @dataclass(frozen=True)
@@ -90,6 +102,17 @@ class TradeReturns:
     #: a default would let a caller silently produce a metric set with no
     #: effective sample size and no error.
     entry_fill_date: tuple[date, ...]
+    #: The bar each trade CLOSED on, positionally parallel to the two above.
+    #: #2623 gap 1 — the "expected turnaround" statistic is derived from this.
+    #:
+    #: ⚠ NAMED `exit_bar_date`, NOT `exit_fill_date`. The producers hold
+    #: `position.close_bar_date` and a permuted exit bar respectively — close
+    #: bars, not execution fills. Calling it a fill would quietly equate the two.
+    #:
+    #: ⚠ REQUIRED, not defaulted, for the same reason `entry_fill_date` is: a
+    #: default lets a caller silently produce a metric set whose holding period
+    #: is missing, with no error anywhere.
+    exit_bar_date: tuple[date, ...]
     #: Positions still open at the window end, and positions whose close
     #: carried no price. Counted, never dropped (§3.2 rule 5).
     open_count: int
@@ -101,6 +124,24 @@ class TradeReturns:
                 f"{len(self.net_return_pct)} returns against {len(self.entry_fill_date)} entry dates — the two are "
                 "positionally parallel, and a mismatch would cluster returns under the wrong dates"
             )
+        if len(self.exit_bar_date) != len(self.entry_fill_date):
+            raise ValueError(
+                f"{len(self.exit_bar_date)} exit dates against {len(self.entry_fill_date)} entry dates — the two are "
+                "positionally parallel, and a mismatch would pair holds across different trades"
+            )
+        # A same-day close is legal and holds for 0 days; an exit BEFORE its own
+        # entry is a producer bug, and it must not reach a statistic that would
+        # average it into a plausible-looking median.
+        for index, (entry, exit_bar) in enumerate(zip(self.entry_fill_date, self.exit_bar_date, strict=True)):
+            if exit_bar < entry:
+                raise ValueError(f"trade {index} exits {exit_bar} before it enters {entry}")
+
+    @property
+    def hold_days(self) -> tuple[int, ...]:
+        """Calendar days held per realised trade. See `compute_metrics`' header."""
+        return tuple(
+            (exit_bar - entry).days for entry, exit_bar in zip(self.entry_fill_date, self.exit_bar_date, strict=True)
+        )
 
 
 @dataclass(frozen=True)
@@ -159,6 +200,23 @@ class StrategyMetrics:
     bootstrap_seed: int | None = None
     bootstrap_design_effect: float | None = None
     bootstrap_model_id: str | None = None
+
+    # --- #2623 gap 1: the "expected turnaround" statistic ------------------
+    #: Calendar days held per REALISED trade, at the 25th/50th/75th percentile.
+    #:
+    #: ⚠⚠ RIGHT-CENSORED, and the direction of the resulting bias is NOT
+    #: determinable a priori. `TradeReturns` is realised-only, so a position
+    #: still open at the window end contributes nothing — and such a position may
+    #: be long-running OR merely recently entered. The censoring is informative;
+    #: informative censoring does not fix a sign. Render `open_trade_count` AND
+    #: `unpriced_trade_count` beside these, never the median alone.
+    #:
+    #: ⚠ Null exactly when there are no realised trades. On a `criterion7-v1` row
+    #: they are null because the statistic did not exist; `sql/347` is what keeps
+    #: those two cases apart. See METRIC_SET_ID.
+    median_hold_days: float | None = None
+    hold_days_p25: float | None = None
+    hold_days_p75: float | None = None
     metric_set_id: str = METRIC_SET_ID
 
     def __post_init__(self) -> None:
@@ -167,6 +225,26 @@ class StrategyMetrics:
         if self.losing_trade_count > self.trade_count:
             raise ValueError(
                 f"{self.losing_trade_count} losing trades out of {self.trade_count} — a subset cannot exceed its set"
+            )
+        holds = (self.hold_days_p25, self.median_hold_days, self.hold_days_p75)
+        # All-or-nothing: a partial triple means the derivation half-ran, which is
+        # a defect that would otherwise render as a plausible single number.
+        if any(value is None for value in holds) and any(value is not None for value in holds):
+            raise ValueError(f"holding-period percentiles are all-or-nothing, got {holds}")
+        if all(value is not None for value in holds):
+            p25, median, p75 = (float(value) for value in holds if value is not None)
+            if not 0 <= p25 <= median <= p75:
+                raise ValueError(f"holding-period percentiles must be ordered and non-negative, got {holds}")
+        # ⚠ The same rule `sql/347` enforces, applied HERE so a defect fails at
+        # construction with a named field rather than as an integrity error
+        # mid-batch. A row stamped with the CURRENT metric set claims to carry
+        # the current set's members, so with realised trades the triple is not
+        # optional. A legacy `criterion7-v1` object reconstructed from an old
+        # stored row keeps its own stamp and is untouched by this.
+        if self.metric_set_id == METRIC_SET_ID and self.trade_count > 0 and self.median_hold_days is None:
+            raise ValueError(
+                f"{self.trade_count} realised trades stamped {self.metric_set_id} with no holding period — "
+                "the stamp says this metric set carries one"
             )
         if (self.profit_factor is None) != (self.losing_trade_count == 0):
             raise ValueError(
@@ -413,6 +491,7 @@ def compute_metrics(
             seed=bootstrap_seed,
         )
 
+    holds = _hold_percentiles(trades.hold_days)
     return StrategyMetrics(
         expectancy_per_trade_pct=expectancy,
         profit_factor=profit_factor,
@@ -441,7 +520,32 @@ def compute_metrics(
         bootstrap_seed=bootstrap.seed if bootstrap else None,
         bootstrap_design_effect=bootstrap.design_effect if bootstrap else None,
         bootstrap_model_id=bootstrap.model_id if bootstrap else None,
+        median_hold_days=holds[1],
+        hold_days_p25=holds[0],
+        hold_days_p75=holds[2],
     )
+
+
+def _hold_percentiles(hold_days: Sequence[int]) -> tuple[float | None, float | None, float | None]:
+    """(p25, median, p75) calendar days held, or three Nones with no realised trades.
+
+    ⚠ ``method="linear"`` is numpy's default and is stated anyway, because the
+    point of the choice is that it MATCHES Postgres ``percentile_cont`` — which is
+    what the live path already uses for the same quantity in the same unit
+    (``strategy_monitoring._ATTRIBUTION_SQL``'s ``median_days_to_outcome``). Two
+    adjacent figures on one catalog row disagreeing on identical data because one
+    interpolates and the other picks a nearest rank is the failure being avoided.
+    ``tests/test_strategy_holding_period_db.py`` pins the two engines together.
+
+    ⚠ CALENDAR days, not bars. ``strategy_outcomes.bars_held`` is the competing
+    documented unit and is deliberately not followed: a bar count is not a
+    turnaround an operator can plan against, since five bars is a week or a
+    fortnight depending on halts and holidays. Same reasoning as the live path.
+    """
+    if not hold_days:
+        return (None, None, None)
+    p25, median, p75 = np.percentile(np.asarray(hold_days, dtype=np.float64), [25, 50, 75], method="linear")
+    return (float(p25), float(median), float(p75))
 
 
 __all__ = [

--- a/app/services/synthetic_control_run.py
+++ b/app/services/synthetic_control_run.py
@@ -478,7 +478,7 @@ def run_cohort(
     members: list[MemberOutcome] = []
     for index in range(cohort_size):
         rng = np.random.Generator(np.random.PCG64(member_seed(index)))
-        book, returns, entry_dates = _place_member(rng, collector.placements, axis=axis)
+        book, returns, entry_dates, exit_dates = _place_member(rng, collector.placements, axis=axis)
         if len(book) != expected:
             # ⚠ EQUALITY, per member. The permutation preserves the trade count
             # by construction, so a mismatch is the one failure mode it can have
@@ -498,6 +498,7 @@ def run_cohort(
             trades=TradeReturns(
                 net_return_pct=tuple(returns),
                 entry_fill_date=tuple(entry_dates),
+                exit_bar_date=tuple(exit_dates),
                 open_count=0,
                 unpriced_count=0,
             ),
@@ -547,11 +548,12 @@ def _place_member(
     placements: Sequence[SeriesPlacement],
     *,
     axis: Sequence[date],
-) -> tuple[LegBook, array[float], list[date]]:
+) -> tuple[LegBook, array[float], list[date], list[date]]:
     """One member: the same holds, redrawn entry bars, everything else fixed."""
     book = LegBook()
     returns: array[float] = array("d")
     entry_dates: list[date] = []
+    exit_dates: list[date] = []
     for placement in placements:
         entries, permuted = place_entries(rng, eligible=int(placement.panel.size), holds=placement.holds)
         entry_price = net_entry_prices(placement.adjusted_open[entries], np.full(entries.size, _HALF_SPREAD))
@@ -574,7 +576,9 @@ def _place_member(
             )
             returns.append(float((exit_price[leg] - entry_price[leg]) / entry_price[leg] * 100.0))
             entry_dates.append(axis[entry_index])
-    return book, returns, entry_dates
+            # #2623 gap 1 — the permuted exit bar, already in scope above.
+            exit_dates.append(axis[exit_index])
+    return book, returns, entry_dates, exit_dates
 
 
 __all__ = [

--- a/docs/proposals/ta/2026-08-14-strategy-holding-period.md
+++ b/docs/proposals/ta/2026-08-14-strategy-holding-period.md
@@ -1,0 +1,211 @@
+# Strategy holding period — the "expected turnaround" number
+
+Issue: #2623 gap 1. Gap 2 shipped as `df1fa062`; gap 3 (catalog view) renders both.
+
+Rung: corpus-adjacent — a new derived statistic on the backtest metric set, a metric-set
+version bump, and three nullable result columns. ⚠ **Populate forward only.** No
+backfill, no re-run.
+
+## 1. The premise, verified — and the sizing risk it carried is gone
+
+The ticket says *"the backtest resolves every trade and discards the duration"*. True at
+the metric layer: `strategy_statistics.TradeReturns` carries `net_return_pct` and
+`entry_fill_date` as positionally parallel tuples under a length invariant, and **no exit
+axis**. So `compute_metrics` cannot produce a holding statistic however many columns are
+added downstream — adding the result columns first would be an R4 orphan.
+
+The 2026-08-13 triage left one thing unmeasured, and it was the one that decided the
+size: *"whether the exit bar is in scope at the producer, or has already been dropped
+further upstream."*
+
+**Measured: both producers hold it, at the append site itself.**
+
+- `app/services/backtest_run.py:1174` appends `position.entry_fill_bar_date`. The same
+  `position` object's `close_bar_date` is read **three lines above** at `:1105`, and
+  `exit_index` is computed at `:1164` and handed to `book.add_leg`.
+- `app/services/synthetic_control_run.py:576` appends `axis[entry_index]` with
+  `exit_index` already in scope on the line above.
+
+## 2. The surface this actually touches
+
+⚠ A first draft of this spec called it "four steps and no more". That was wrong — it
+counted the data path and forgot the ledger round-trip and the view. The real list:
+
+| # | file | change |
+| --- | --- | --- |
+| 1 | `strategy_statistics.TradeReturns` | third parallel tuple `exit_bar_date` + invariants |
+| 2 | `strategy_statistics.compute_metrics` / `StrategyMetrics` | derive + carry three fields |
+| 3 | `strategy_statistics.METRIC_SET_ID` | `criterion7-v1` → `criterion7-v2` (§4) |
+| 4 | `backtest_run.py:1174` | thread `position.close_bar_date` |
+| 5 | `synthetic_control_run.py:_place_member` | accumulate + **return** exit dates; its signature and caller change |
+| 6 | `sql/347` | three nullable columns, view recreate, CHECKs |
+| 7 | `result_ledger.py:410/436/591` | writer: column list, placeholders, params |
+| 8 | `result_ledger.py:741/822` | **reader**: select list and `StrategyMetrics(...)` reconstruction |
+
+⚠ (8) is the one a "just add a column" reading drops. Writing a column without adding it
+to the read path leaves the value stored and unreadable, which looks like a writer bug
+from every consumer.
+
+## 3. Source rule
+
+No published formulation exists for a strategy's "expected turnaround" — it is an
+operator-facing descriptive statistic, not a literature quantity. Fixed by construction,
+each choice anchored to something already in this repo.
+
+### 3.1 Unit: calendar days
+
+`exit_bar_date - entry_bar_date`. The operator asked for *"expected turn around times"* —
+how long capital is tied up, which is wall clock.
+
+⚠ **Reconciling `bars_held`, which is the competing documented unit.**
+`strategy_outcomes.bars_held` stores duration in BARS. It is not dismissed as "a
+different statistic" — it is a different *population* (the live signal-outcome path, per
+fired signal) measured on a different axis, and the reason to diverge from it is that a
+bar count is not a turnaround an operator can plan against: 5 bars is a week or a
+fortnight depending on halts and holidays. The live attribution path already made this
+same call — `strategy_monitoring._ATTRIBUTION_SQL`'s `median_days_to_outcome` is
+`percentile_cont(0.5) WITHIN GROUP (ORDER BY (o.exit_bar_date - s.fill_bar_date))`,
+Postgres date subtraction, so calendar days.
+
+⚠ That precedent fixes the UNIT and nothing more. It is **not** the same statistic: it
+measures resolved signal outcomes across funded *and* rejected entries, filtered on
+`gross_return_pct IS NOT NULL`, whereas this measures costed, realised backtest positions
+on net returns with different exclusions. Same unit, different population — the catalog
+must not label them as one number.
+
+### 3.2 Percentile method: linear interpolation
+
+`np.percentile(..., method="linear")` — numpy's default, and the same definition as
+Postgres `percentile_cont`. That equality is the reason to state it: §3.1's live
+statistic uses `percentile_cont`, and a different method here would make two adjacent
+catalog figures disagree on identical data. `strategy_statistics` has no existing
+percentile to inherit from — checked — so this is chosen rather than assumed, and a test
+pins the two engines against each other on even and odd sizes and on duplicates.
+
+### 3.3 Population: realised trades only, and it is right-censored
+
+`TradeReturns` is **realised-only by construction** (§3.4 of the bounded-backtester
+spec): an open position, an `ambiguous` close and an `unresolved` outcome are each
+*"excluded, counted"* from the trade-level metrics while staying on the equity curve.
+
+⚠⚠ **The excluded set is right-censored, and the direction of the resulting bias is NOT
+determinable a priori.** A first draft asserted the median is biased *downward* because
+"the still-open positions are precisely the long-held ones". That is unfounded: a
+position opened shortly before the window end is still open and has a *short* elapsed
+duration. Censoring here is informative — whether a trade is still open correlates with
+how long it runs — but informative censoring does not fix a sign. The honest statement is
+that the reported median is over closed trades only and the censored set could pull it
+either way.
+
+So it is **labelled, not corrected**. Both exclusion counters already exist on
+`strategy_results_store` and both must render beside the median in gap 3:
+`open_trade_count` (still open at window end) and `unpriced_trade_count` (closed but
+carrying no usable price). ⚠ Showing only `open_trade_count` misstates the gap — they are
+separate exclusions and neither implies the other.
+
+## 4. `METRIC_SET_ID` moves to `criterion7-v2`, and that is what makes the nulls readable
+
+`METRIC_SET_ID` is stored per result row. Its documented job is to identify **which
+definitions** a stored metric set holds, so a row carrying three metrics that
+`criterion7-v1` never defined cannot truthfully keep that stamp. This is #2670's lesson
+exactly: *a version denotes a rule set, not a row population.* A first draft argued the
+bump was unnecessary because no existing metric changes; that confuses "no value moved"
+with "the set is the same set".
+
+**Verified safe:** nothing gates on the *value*. `grep` across `app/`, `sql/` and
+`frontend/src` finds `metric_set_id` only written (`strategy_result.py:1088`,
+`result_ledger.py:591`) and read back (`result_ledger.py:822`); its only constraint is
+`CHECK (metric_set_id <> '')` (`sql/263:161`). No promotion rule, index or comparison
+filters on it.
+
+⚠⚠ **And the bump is not just correctness bookkeeping — it is the null-provenance
+discriminator.** Without it, a null holding period on a future row is indistinguishable
+from a legitimate legacy null, so a writer defect would be invisible. With it the rule is
+exact and enforceable in the database:
+
+```
+CHECK (metric_set_id <> 'criterion7-v2'
+       OR trade_count = 0
+       OR median_hold_days IS NOT NULL)
+```
+
+- `criterion7-v1` row → three nulls, legitimate and permanent (§5).
+- `criterion7-v2` row with realised trades → the triple is **required**.
+- `criterion7-v2` row with `trade_count = 0` → nulls, legitimate.
+
+⚠ Written with `<>` on a NOT NULL column, so the `NULL = 'x'` trap that bit #2603 item 2
+does not apply here — `metric_set_id` is `SET NOT NULL` (`sql/263:105`). Stated because
+the shape is the one that failed before.
+
+Legacy reads are unaffected: the reader maps a null column to `None`, and
+`StrategyMetrics` carries the three as `float | None`.
+
+## 5. ⚠⚠ Populate forward only — this must not become a re-run
+
+`strategy_results_store` holds **324 rows**, every one written without a duration.
+Backfilling requires **re-running the backtests**, which mints results under current pins
+— the trial-register-charging path #2599's declaration contract and #2616's pre-cutoff
+rerun gate govern, and which an unattended run must not open.
+
+So the columns ship nullable, future runs populate them, and all 324 existing rows read
+`null` until someone runs a backtest. Gap 3 renders that as *"not measured for this
+result version"*, naming `criterion7-v1` — which its own scope already requires, since
+empty states must say **why**.
+
+⚠ No claim is made here about what the hold distribution will look like. A first draft
+argued from trade counts (min 433, median 6,005) that "the percentiles are not going to
+be noise". Trade count does not establish temporal support — a large correlated
+population can rest on few distinct dates — and the hold distribution is not stored,
+which is the entire point of this ticket. Nothing to measure it on yet, so nothing is
+asserted.
+
+## 6. Invariants
+
+On `TradeReturns.__post_init__`, beside the existing length check:
+
+- all three axes the same length (extends the existing invariant to the third tuple);
+- `exit_bar_date[i] >= entry_bar_date[i]` for every `i` — a same-day close is legal
+  (hold 0), an exit *before* its entry is a producer bug and must not reach a statistic.
+
+On `StrategyMetrics.__post_init__`:
+
+- the triple is all-present or all-absent — a partial triple means a derivation half-ran;
+- `p25 <= median <= p75`, and all three `>= 0`.
+
+## 7. Verification
+
+- Pure table tests: no realised trades → all three `None`; a known distribution → the
+  three percentiles at their linear-interpolation values; **even and odd** population
+  sizes; duplicate durations; a same-day hold reading `0`; a single trade giving
+  `p25 == median == p75`; a weekend-spanning hold counting calendar days.
+- The exit axis is **required** — constructing `TradeReturns` without it fails, mirroring
+  the existing argument for `entry_fill_date`.
+- Rejection tests for each §6 invariant, one per invariant so a failure names the rule.
+- A parity test asserting `np.percentile(..., "linear")` equals Postgres `percentile_cont`
+  on the same inputs (§3.2).
+- Producer tests asserting each derived duration against its **originating** position /
+  placement, not merely that the tuples are the same length — positional arrival cannot
+  prove semantic correspondence.
+- DB: a ledger **round-trip** (write then read reconstructs the three values), a
+  view-mediated insert/select proving the recreated view exposes the columns, and both
+  CHECK directions from §4.
+- ⚠ **No full-population A/B arm is run and none is claimed.** The change adds a statistic
+  and alters no existing one; the only stored field that changes value is
+  `metric_set_id`, deliberately (§4). Stated rather than left as an unrun gate. A re-run
+  to populate is out of scope per §5.
+
+## 8. Migration notes (`sql/347`)
+
+Follows `sql/335`'s sequence, which records the traps:
+
+- `SET LOCAL lock_timeout = '5s'` — a pending `AccessExclusiveLock` queues *ahead* of new
+  readers, so an ALTER merely waiting behind the live `strategy_backtest_run` job blocks
+  every subsequent SELECT on the relation.
+- `strategy_results` is a **VIEW** over the store and `SELECT *` is expanded at creation,
+  so it must be recreated or the new columns are invisible through it — and
+  `ALTER VIEW ... SET (check_option = 'cascaded')` restored afterwards, because
+  `CREATE OR REPLACE` drops it.
+- The columns are **nullable with no default**, which is what makes this rolling-safe:
+  `strategy_backtest_run` is a live job, so between the migration applying and the daemon
+  picking up new code an old writer inserts without them — legal against a nullable
+  column, and the §4 CHECK still holds because that writer stamps `criterion7-v1`.

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -4599,3 +4599,60 @@ with `verify_2598_preflight_quote_crosscheck.py --replay <fixture>`:
   (`core_eligibility_underlying_is_complete`, with the reasoning inline);
   `tests/test_2603_core_eligibility_db.py::test_an_underlying_row_cannot_be_incomplete`
   (revert-probed: swapping `IS NOT DISTINCT FROM` back to `=` turns the two NULL cases red).
+
+### One enum explaining several nullable values is lossy the moment two of them can be null independently
+
+- First seen in: #2623 gap 2 (2026-08-14, PR #2681), review bot on the first push.
+- Symptom: a field named `rate_unavailable_reason` explained why *either* of two derived
+  values was null. The bot found a reachable state it could not express — a version scanned
+  over several days on which every bar was `not_evaluable` has a perfectly good date axis, so
+  its weekly rate is a real `0.00`, while its share-of-evaluable is genuinely unknowable. The
+  reason field read `None` (correct for the rate) and the null share shipped with nothing
+  saying why, breaking the API's own stated "null is not zero, and the API says which"
+  contract.
+- Root cause: the two nulls have **independent causes**. One enum can only ever describe the
+  value it was named after; the other borrows it and is silently wrong whenever they differ.
+  Adding a third member to the single enum does not fix it — it mislabels the row as though
+  the *rate* were the unavailable thing.
+- The tell, and it is visible without running anything: **the reason field is named after ONE
+  of the values it serves.** `rate_unavailable_reason` sitting beside both
+  `fired_share_of_evaluable` and `entries_per_calendar_week` is the smell.
+- Prevention: when one enum explains several nullable values, ask whether any two of them can
+  be null **independently**. If they can, split the enum — one reason per nullable value — and
+  assert the correspondence in **both** directions over a parametrised set of states: a value
+  is `None` if and only if its reason is not. A test asserting only "this value is null here"
+  passes while the reason is missing, which is exactly how the gap survived the first review.
+- Enforced in: this log; `app/services/strategy_monitoring.py` (`share_unavailable_reason` /
+  `weekly_rate_unavailable_reason`, with the independence argument on `derive_fire_rate`);
+  `tests/test_strategy_fire_rate.py::TestEveryNullNamesItsReason`.
+
+### Three positional lists that must agree, edited separately — the INSERT column list, its placeholders, and the reader's unpack tuple
+
+- First seen in: #2623 gap 1 (2026-08-14). Adding three columns to `strategy_results_store`.
+- Symptom: values landed in the **wrong columns**. `median_hold_days` was written into the
+  DSR block, because the three column names were appended to `_RESULT_COLUMNS` after
+  `trial_register_version` while the three placeholders were inserted after
+  `%(bootstrap_model_id)s` — a different position in the same statement. Then the same
+  mistake again, mirrored: the reader's unpack tuple got them at the END while
+  `_RESULT_COLUMNS` (which is shared by the INSERT *and* the SELECT) had them in the middle,
+  so the round trip reconstructed a metric set with no holding period.
+- Why it is easy: nothing types these. The column list, the placeholder list and the unpack
+  tuple are three separately-edited sequences whose only contract is positional, they are
+  tens of lines apart, and both a name and a `%(name)s` read as self-describing at the point
+  of edit. `psycopg` binds placeholders BY NAME, which makes it feel order-independent — the
+  ORDER that matters is the one against the column list, not against the params dict.
+- What caught it, and what did not: types and lint were clean. The write-side misalignment was
+  caught by an unrelated pre-existing `CHECK` (`strategy_results_dsr_all_or_nothing`) firing
+  on a row whose DSR block had been half-filled by the shifted values; the read-side one by a
+  round-trip test. **A schema without all-or-nothing CHECKs would have stored the shifted row
+  silently.**
+- Prevention: after adding a column to a wide INSERT, **count the entries in the column list
+  and the placeholder list and confirm the new names occupy the same ordinal in each**, then
+  do the same against the reader's unpack. Where a constant is shared between the INSERT and a
+  SELECT (`_RESULT_COLUMNS` is), the unpack tuple must match THAT constant, not read
+  naturally. Always land a round-trip test — write then read then compare — for any new stored
+  field; a write-only test passes on a misaligned read.
+- Enforced in: this log; `app/services/result_ledger.py` (a comment on the unpack stating that
+  its order is `_RESULT_COLUMNS`' and not a natural one);
+  `tests/test_strategy_holdout_namespace.py`'s existing round-trip tests, which is what went
+  red.

--- a/scripts/verify_2240_random_entry_cohort.py
+++ b/scripts/verify_2240_random_entry_cohort.py
@@ -651,6 +651,7 @@ def cohort(*, cache_root: Path, label: str, first: int, last: int, zero_cost: bo
         book = LegBook()
         returns: list[float] = []
         entry_dates: list[date] = []
+        exit_dates: list[date] = []
         for s in range(series_count):
             lo, hi = int(holds_offset[s]), int(holds_offset[s + 1])
             if lo == hi:
@@ -685,6 +686,7 @@ def cohort(*, cache_root: Path, label: str, first: int, last: int, zero_cost: bo
                 )
                 returns.append(float((exit_net[leg] - entry_net[leg]) / entry_net[leg] * 100.0))
                 entry_dates.append(axis[int(entry_panel[leg])])
+                exit_dates.append(axis[int(exit_panel[leg])])
         # R1 — equality, per member, on the whole book.
         if len(book) != expected_trades:
             problems.append(f"R1 member {index}: {len(book):,} legs against the strategy's {expected_trades:,}")
@@ -695,6 +697,7 @@ def cohort(*, cache_root: Path, label: str, first: int, last: int, zero_cost: bo
             trades=TradeReturns(
                 net_return_pct=tuple(returns),
                 entry_fill_date=tuple(entry_dates),
+                exit_bar_date=tuple(exit_dates),
                 open_count=0,
                 unpriced_count=0,
             ),

--- a/scripts/verify_2240_statistics.py
+++ b/scripts/verify_2240_statistics.py
@@ -184,6 +184,7 @@ class _Sleeve:
         # reason for clustering is that signals correlate across instruments on
         # the same day, which is a statement about the day they FIRED.
         self.entry_dates: list[date] = []
+        self.exit_dates: list[date] = []
         self.positions = 0
         self.open_at_end = 0
         self.excluded: Counter[str] = Counter()
@@ -287,8 +288,10 @@ class _Sleeve:
                 marks=marks,
             )
             if realised:
+                assert position.close_bar_date is not None  # `realised` is set only where it is present
                 self.returns.append(float(row.net_return_pct))
                 self.entry_dates.append(position.entry_fill_bar_date)
+                self.exit_dates.append(position.close_bar_date)
 
     def report(self, *, axis: tuple[date, ...], benchmark_curve: EquityCurve) -> StrategyMetrics | None:
         started = time.monotonic()
@@ -326,6 +329,7 @@ class _Sleeve:
                 trades=TradeReturns(
                     net_return_pct=tuple(self.returns),
                     entry_fill_date=tuple(self.entry_dates),
+                    exit_bar_date=tuple(self.exit_dates),
                     open_count=self.open_at_end,
                     unpriced_count=sum(self.excluded.values()),
                 ),

--- a/sql/347_strategy_result_holding_period.sql
+++ b/sql/347_strategy_result_holding_period.sql
@@ -1,0 +1,119 @@
+-- 347_strategy_result_holding_period.sql
+--
+-- #2623 gap 1 — the operator's "expected turnaround" number.
+-- Spec: docs/proposals/ta/2026-08-14-strategy-holding-period.md.
+-- Derivation: app/services/strategy_statistics.py (`_hold_percentiles`).
+-- Writer + reader: app/services/result_ledger.py.
+--
+--
+-- ⚠⚠ POPULATE FORWARD ONLY. THIS MIGRATION DELIBERATELY BACKFILLS NOTHING.
+-- ---------------------------------------------------------------------------
+-- `strategy_results_store` holds 324 rows, every one written before the
+-- holding period was carried through `TradeReturns`. There is no way to derive
+-- it from a stored row — the per-trade exit dates were never persisted, only
+-- aggregated away — so a backfill would mean RE-RUNNING the backtests. A re-run
+-- mints results under current pins, which is the trial-register-charging path
+-- #2599's declaration contract and #2616's pre-cutoff rerun gate govern. It is
+-- not something a migration may trigger and not something an unattended run may
+-- open. Existing rows read NULL, permanently, and that is correct.
+--
+--
+-- ⚠⚠ WHICH IS WHY `metric_set_id` MOVED TO `criterion7-v2`.
+-- ---------------------------------------------------------------------------
+-- Without the bump, a NULL holding period on a row written TOMORROW would be
+-- indistinguishable from a legitimate legacy NULL, so a writer defect would be
+-- permanently invisible. With it the rule is exact, and the CHECK below is what
+-- makes it enforceable rather than a convention:
+--
+--   * `criterion7-v1` row  -> NULL triple, legitimate and permanent.
+--   * `criterion7-v2` row with realised trades -> the triple is REQUIRED.
+--   * `criterion7-v2` row with `trade_count = 0` -> NULL triple, legitimate.
+--
+-- The bump is also just true: a version denotes a RULE SET, not a row
+-- population (#2670), and a row carrying three metrics that `criterion7-v1`
+-- never defined cannot honestly keep that stamp. Verified before bumping that
+-- nothing gates on the VALUE — `metric_set_id` is written by
+-- strategy_result.py, read back by result_ledger.py, and constrained only by
+-- `CHECK (metric_set_id <> '')` in sql/263. No promotion rule, index or
+-- comparison reads it.
+--
+-- ⚠ The CHECK is written with `<>` against a NOT NULL column (sql/263 sets it),
+-- so the `NULL = 'x'` trap that #2603 item 2 admitted does not apply here. Said
+-- out loud because that is exactly the shape that failed before: a constraint
+-- passes unless its expression is FALSE, and `NULL <> 'x'` is NULL.
+--
+--
+-- ⚠ NULLABLE WITH NO DEFAULT, WHICH IS WHAT MAKES THIS ROLLING-SAFE.
+-- `strategy_backtest_run` is a live job (sql/335 measured it), so between this
+-- migration applying and the daemon picking up the new code an old writer will
+-- INSERT without these columns. That is legal against a nullable column, and
+-- the CHECK still holds for it because that writer stamps `criterion7-v1`.
+
+BEGIN;
+
+-- ⚠ sql/335's lesson, inherited rather than rediscovered: a PENDING
+-- AccessExclusiveLock queues AHEAD of new readers, so an ALTER merely waiting
+-- behind the live backtest job blocks every subsequent SELECT on the relation.
+-- A bounded timeout turns that into a clean, retryable failure.
+SET LOCAL lock_timeout = '5s';
+
+ALTER TABLE strategy_results_store
+    ADD COLUMN IF NOT EXISTS median_hold_days NUMERIC,
+    ADD COLUMN IF NOT EXISTS hold_days_p25    NUMERIC,
+    ADD COLUMN IF NOT EXISTS hold_days_p75    NUMERIC;
+
+COMMENT ON COLUMN strategy_results_store.median_hold_days IS
+    'Median CALENDAR days held per REALISED trade (#2623 gap 1). ⚠ Calendar, not '
+    'bars: strategy_outcomes.bars_held is the competing unit and is deliberately '
+    'not followed, because five bars is a week or a fortnight depending on halts '
+    'and holidays. Matches the unit the live path already reports in '
+    'strategy_monitoring''s median_days_to_outcome — same unit, DIFFERENT '
+    'population, so the two must never be labelled as one number. '
+    '⚠⚠ RIGHT-CENSORED: positions still open at the window end contribute '
+    'nothing, and the direction of that bias is NOT determinable a priori. Render '
+    'open_trade_count AND unpriced_trade_count beside it, never the median alone.';
+
+COMMENT ON COLUMN strategy_results_store.hold_days_p25 IS
+    '25th percentile of calendar days held, linear interpolation (numpy '
+    '"linear" == Postgres percentile_cont, chosen so this and the live '
+    'median_days_to_outcome cannot disagree on identical data). Same censoring '
+    'caveat as median_hold_days.';
+
+COMMENT ON COLUMN strategy_results_store.hold_days_p75 IS
+    '75th percentile of calendar days held. Same method and caveat as '
+    'hold_days_p25.';
+
+-- All-or-nothing: a partial triple means the derivation half-ran, which would
+-- otherwise render as a single plausible number with no tell.
+ALTER TABLE strategy_results_store
+    ADD CONSTRAINT strategy_results_hold_all_or_nothing CHECK (
+        num_nulls(median_hold_days, hold_days_p25, hold_days_p75) IN (0, 3)
+    );
+
+-- Ordered and non-negative. A same-day close holds for 0 days, which is legal.
+ALTER TABLE strategy_results_store
+    ADD CONSTRAINT strategy_results_hold_ordered CHECK (
+        median_hold_days IS NULL
+        OR (0 <= hold_days_p25 AND hold_days_p25 <= median_hold_days
+            AND median_hold_days <= hold_days_p75)
+    );
+
+-- The provenance rule the metric_set_id bump exists to make enforceable.
+ALTER TABLE strategy_results_store
+    ADD CONSTRAINT strategy_results_hold_required_from_v2 CHECK (
+        metric_set_id <> 'criterion7-v2'
+        OR trade_count = 0
+        OR median_hold_days IS NOT NULL
+    );
+
+-- ⚠ SELECT * is expanded at creation, so the view must be recreated to expose
+-- the new columns, and the check option restored — CREATE OR REPLACE drops it
+-- (sql/335's sequence, same reason).
+CREATE OR REPLACE VIEW strategy_results AS
+    SELECT *
+    FROM strategy_results_store
+    WHERE namespace = 'in_sample';
+
+ALTER VIEW strategy_results SET (check_option = 'cascaded');
+
+COMMIT;

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -128,6 +128,11 @@ def _metrics(*, sharpe: float = 0.5, ess: float | None = 100.0) -> StrategyMetri
         bootstrap_seed=BACKTEST_BOOTSTRAP_SEED if present else None,
         bootstrap_design_effect=2.0 if present else None,
         bootstrap_model_id="c3-block-bootstrap-v1" if present else None,
+        # #2623 gap 1 — required alongside a non-zero trade_count under the
+        # current METRIC_SET_ID.
+        hold_days_p25=3.0,
+        median_hold_days=8.0,
+        hold_days_p75=21.0,
     )
 
 
@@ -1009,6 +1014,11 @@ class TestNamespaceAxis:
         for offset, value in enumerate((20.0, -5.0, 7.5, -2.0)):
             book.returns.append(value)
             book.entry_dates.append(axis[3 + offset])
+            # #2623 gap 1 — the three axes are positionally parallel and
+            # `TradeReturns` refuses a short one, so a hand-built book has to
+            # fill this too. Exit one bar after entry; the durations are not
+            # what this test is about.
+            book.exit_dates.append(axis[4 + offset])
         outcome = _measure_namespace(
             "in_sample",
             book,
@@ -1046,6 +1056,7 @@ class TestNamespaceAxis:
         )
         book.returns.append(20.0)
         book.entry_dates.append(axis[3])
+        book.exit_dates.append(axis[4])
         with pytest.raises(RuntimeError, match="no effective sample size"):
             _measure_namespace(
                 "in_sample",

--- a/tests/test_quarantine_sensitivity.py
+++ b/tests/test_quarantine_sensitivity.py
@@ -111,6 +111,12 @@ def _metrics(**overrides: object) -> StrategyMetrics:
         "periods_per_year": 196.0,
         "total_return_pct": 40.0,
         "buy_and_hold_return_pct": 42.0,
+        # #2623 gap 1. ⚠ NOT one of criterion 7's twelve, so `compare_metrics`
+        # deliberately does not compare it — present here only because
+        # `StrategyMetrics` requires it alongside a non-zero trade_count.
+        "hold_days_p25": 3.0,
+        "median_hold_days": 8.0,
+        "hold_days_p75": 21.0,
     }
     base.update(overrides)
     return StrategyMetrics(**base)  # type: ignore[arg-type]

--- a/tests/test_result_ledger.py
+++ b/tests/test_result_ledger.py
@@ -170,6 +170,14 @@ def build_metrics(**overrides: object) -> StrategyMetrics:
         "periods_per_year": 251.66446,
         "total_return_pct": -100.0,
         "buy_and_hold_return_pct": 989443125.1,
+        # #2623 gap 1. Awkward and ORDERED, for the same reason as the rest:
+        # a p25/median/p75 of 1/2/3 would survive a conversion bug that these
+        # do not. Required here because `trade_count` is non-zero and the set is
+        # stamped with the current METRIC_SET_ID — `StrategyMetrics` refuses that
+        # combination without a holding period, and so does `sql/347`.
+        "hold_days_p25": 2.0281745,
+        "median_hold_days": 11.83094627,
+        "hold_days_p75": 40.5017283,
     }
     base.update(overrides)
     return StrategyMetrics(**base)  # type: ignore[arg-type]

--- a/tests/test_strategy_holding_period.py
+++ b/tests/test_strategy_holding_period.py
@@ -1,0 +1,120 @@
+"""#2623 gap 1 — the holding-period statistic ("expected turnaround").
+
+Spec: ``docs/proposals/ta/2026-08-14-strategy-holding-period.md``.
+
+Pure cases only. The ledger round-trip, the recreated view and the `sql/347`
+CHECKs live in ``test_strategy_holding_period_db.py`` — ``tests/conftest.py``
+marks a whole MODULE ``db`` when its source touches psycopg, so co-locating them
+would drop every case below off the fast push gate.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.strategy_statistics import METRIC_SET_ID, TradeReturns, _hold_percentiles
+
+
+def _trades(pairs: list[tuple[date, date]]) -> TradeReturns:
+    return TradeReturns(
+        net_return_pct=tuple(1.0 for _ in pairs),
+        entry_fill_date=tuple(entry for entry, _ in pairs),
+        exit_bar_date=tuple(exit_bar for _, exit_bar in pairs),
+        open_count=0,
+        unpriced_count=0,
+    )
+
+
+class TestHoldDays:
+    def test_duration_is_calendar_days_not_trading_bars(self) -> None:
+        # Fri 2026-08-07 -> Mon 2026-08-10 is ONE trading bar and THREE calendar
+        # days. The spec picks calendar days deliberately (§3.1), so a weekend
+        # is the case that distinguishes the two units.
+        trades = _trades([(date(2026, 8, 7), date(2026, 8, 10))])
+        assert trades.hold_days == (3,)
+
+    def test_a_same_day_close_holds_for_zero_days(self) -> None:
+        assert _trades([(date(2026, 8, 10), date(2026, 8, 10))]).hold_days == (0,)
+
+
+class TestTradeReturnsInvariants:
+    def test_exit_axis_is_required_not_defaulted(self) -> None:
+        # Same argument the existing `entry_fill_date` comment makes: a default
+        # would let a caller silently produce a metric set with no holding
+        # period and no error anywhere.
+        with pytest.raises(TypeError, match="exit_bar_date"):
+            TradeReturns(  # type: ignore[call-arg]
+                net_return_pct=(1.0,),
+                entry_fill_date=(date(2026, 8, 10),),
+                open_count=0,
+                unpriced_count=0,
+            )
+
+    def test_exit_axis_must_be_parallel_to_the_entry_axis(self) -> None:
+        with pytest.raises(ValueError, match="positionally parallel"):
+            TradeReturns(
+                net_return_pct=(1.0, 2.0),
+                entry_fill_date=(date(2026, 8, 10), date(2026, 8, 11)),
+                exit_bar_date=(date(2026, 8, 12),),
+                open_count=0,
+                unpriced_count=0,
+            )
+
+    def test_an_exit_before_its_own_entry_is_refused(self) -> None:
+        # A producer bug. Left through, it contributes a negative duration that
+        # averages into a median which still looks entirely plausible.
+        with pytest.raises(ValueError, match="exits .* before it enters"):
+            _trades([(date(2026, 8, 10), date(2026, 8, 9))])
+
+    def test_the_refusal_names_the_offending_trade(self) -> None:
+        with pytest.raises(ValueError, match="trade 2 exits"):
+            _trades(
+                [
+                    (date(2026, 8, 3), date(2026, 8, 4)),
+                    (date(2026, 8, 3), date(2026, 8, 5)),
+                    (date(2026, 8, 10), date(2026, 8, 9)),
+                ]
+            )
+
+
+class TestPercentiles:
+    def test_no_realised_trades_gives_three_nulls(self) -> None:
+        assert _hold_percentiles(()) == (None, None, None)
+
+    def test_a_single_trade_collapses_all_three(self) -> None:
+        assert _hold_percentiles((7,)) == (7.0, 7.0, 7.0)
+
+    def test_odd_sized_population(self) -> None:
+        # [1,2,3,4,5]: p25 = 2, median = 3, p75 = 4 under linear interpolation.
+        assert _hold_percentiles((1, 2, 3, 4, 5)) == (2.0, 3.0, 4.0)
+
+    def test_even_sized_population_interpolates_rather_than_picking_a_rank(self) -> None:
+        # [1,2,3,4]: linear gives p25 = 1.75, median = 2.5, p75 = 3.25. A
+        # nearest-rank method would return whole numbers here, so this is the
+        # case that pins the method (§3.2).
+        assert _hold_percentiles((1, 2, 3, 4)) == (1.75, 2.5, 3.25)
+
+    def test_duplicates_do_not_disturb_the_ordering(self) -> None:
+        p25, median, p75 = _hold_percentiles((5, 5, 5, 5, 5))
+        assert (p25, median, p75) == (5.0, 5.0, 5.0)
+
+    def test_input_order_does_not_matter(self) -> None:
+        assert _hold_percentiles((5, 1, 4, 2, 3)) == _hold_percentiles((1, 2, 3, 4, 5))
+
+    def test_zero_holds_are_a_real_measurement_not_an_absence(self) -> None:
+        # Every trade closing same-day is a legitimate 0, and must not read as
+        # "not measured" — which is why the null case is keyed on an EMPTY
+        # population rather than on a falsy median.
+        assert _hold_percentiles((0, 0, 0)) == (0.0, 0.0, 0.0)
+
+
+class TestMetricSetId:
+    def test_bumped_to_v2_because_the_metric_set_gained_members(self) -> None:
+        # A version denotes a RULE SET, not a row population (#2670): a row
+        # carrying metrics `criterion7-v1` never defined cannot keep that stamp.
+        # ⚠ This is also what makes a null holding period readable — `sql/347`
+        # requires the triple on a v2 row with realised trades, so a legacy null
+        # and a writer defect are distinguishable.
+        assert METRIC_SET_ID == "criterion7-v2"

--- a/tests/test_strategy_holding_period_db.py
+++ b/tests/test_strategy_holding_period_db.py
@@ -1,0 +1,166 @@
+"""#2623 gap 1 — what ``sql/347`` did to the schema, and the percentile parity.
+
+⚠ THE MIGRATION'S EFFECTS AND THE CROSS-ENGINE CHECK, NOT THE PYTHON RULE. The
+derivation is covered by pure tests in ``test_strategy_holding_period``; these
+assert what a Python test structurally cannot see — that the view EXPOSES the
+three columns, that each CHECK refuses what it was written to refuse, and that
+numpy's linear percentile and Postgres' ``percentile_cont`` agree.
+
+⚠ In its own ``_db`` module deliberately, following ``test_2363_carry_fx_split_db``:
+``ebull_test_conn`` in a test source db-marks the WHOLE module at collection, so
+mixing these with pure tests would drag the fast tier onto Postgres.
+"""
+
+from typing import Any, LiteralString
+
+import numpy as np
+import psycopg
+import psycopg.sql
+import pytest
+
+
+@pytest.mark.parametrize("column", ["median_hold_days", "hold_days_p25", "hold_days_p75"])
+def test_the_columns_are_nullable_with_no_default(ebull_test_conn: psycopg.Connection[Any], column: str) -> None:
+    """Nullable and undefaulted is what makes the migration rolling-safe.
+
+    ``strategy_backtest_run`` is a live job, so between the migration applying
+    and the daemon picking up new code an old writer INSERTs without these
+    columns. That is legal against a nullable column — and a DEFAULT would be
+    actively wrong here, because any value it invented would be a holding period
+    nobody measured.
+    """
+    row = ebull_test_conn.execute(
+        """
+        SELECT is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_name = 'strategy_results_store' AND column_name = %(column)s
+        """,
+        {"column": column},
+    ).fetchone()
+    assert row is not None, f"strategy_results_store.{column} does not exist — sql/347 did not apply"
+    is_nullable, column_default = row
+    assert is_nullable == "YES"
+    assert column_default is None
+
+
+@pytest.mark.parametrize("column", ["median_hold_days", "hold_days_p25", "hold_days_p75"])
+def test_the_in_sample_view_exposes_the_new_columns(ebull_test_conn: psycopg.Connection[Any], column: str) -> None:
+    """``strategy_results`` is a VIEW and ``SELECT *`` is expanded at creation.
+
+    A column added to the store is invisible through the view until the view is
+    recreated, so a reader going through the view would see a column that is not
+    there. The catalog (#2623 gap 3) reads this surface.
+    """
+    row = ebull_test_conn.execute(
+        """
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'strategy_results' AND column_name = %(column)s
+        """,
+        {"column": column},
+    ).fetchone()
+    assert row is not None, f"the view does not expose {column} — sql/347 did not recreate it"
+
+
+def test_the_view_still_carries_its_cascaded_check_option(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """``CREATE OR REPLACE VIEW`` DROPS the check option, so it must be restored.
+
+    Losing it is silent: the view keeps working and simply stops refusing writes
+    that fall outside its own predicate.
+    """
+    row = ebull_test_conn.execute(
+        "SELECT check_option FROM information_schema.views WHERE table_name = 'strategy_results'"
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "CASCADED"
+
+
+class TestTheChecks:
+    """Each CHECK refuses what it was written to refuse.
+
+    ⚠ Asserted one per constraint rather than once in aggregate: a single
+    "bad rows are rejected" test passes when only one of three constraints
+    exists, which is the state a partially-applied migration leaves behind.
+    """
+
+    @staticmethod
+    def _update(conn: psycopg.Connection[Any], assignments: LiteralString) -> None:
+        result_id = conn.execute("SELECT min(result_id) FROM strategy_results_store").fetchone()
+        if result_id is None or result_id[0] is None:
+            pytest.skip("no stored result to probe the constraints against")
+        # ⚠ `assignments` is typed `LiteralString`, so only a source literal can
+        # reach it — no runtime-built fragment can. The row id stays a bound
+        # parameter.
+        conn.execute(
+            psycopg.sql.SQL("UPDATE strategy_results_store SET {} WHERE result_id = %(id)s").format(
+                psycopg.sql.SQL(assignments)
+            ),
+            {"id": result_id[0]},
+        )
+
+    def test_a_partial_triple_is_refused(self, ebull_test_conn: psycopg.Connection[Any]) -> None:
+        # A half-run derivation would otherwise render as one plausible number.
+        with pytest.raises(psycopg.errors.CheckViolation):
+            self._update(ebull_test_conn, "median_hold_days=1, hold_days_p25=NULL, hold_days_p75=2")
+
+    def test_an_unordered_triple_is_refused(self, ebull_test_conn: psycopg.Connection[Any]) -> None:
+        with pytest.raises(psycopg.errors.CheckViolation):
+            self._update(ebull_test_conn, "median_hold_days=1, hold_days_p25=5, hold_days_p75=2")
+
+    def test_a_negative_hold_is_refused(self, ebull_test_conn: psycopg.Connection[Any]) -> None:
+        with pytest.raises(psycopg.errors.CheckViolation):
+            self._update(ebull_test_conn, "median_hold_days=-1, hold_days_p25=-2, hold_days_p75=0")
+
+    def test_a_v2_row_with_realised_trades_must_carry_the_triple(
+        self, ebull_test_conn: psycopg.Connection[Any]
+    ) -> None:
+        """The provenance rule the ``METRIC_SET_ID`` bump exists to make enforceable.
+
+        Without it a null on a future row is indistinguishable from a legitimate
+        legacy null, so a writer defect would be permanently invisible.
+        """
+        with pytest.raises(psycopg.errors.CheckViolation):
+            self._update(ebull_test_conn, "metric_set_id='criterion7-v2'")
+
+    def test_a_legacy_v1_row_may_keep_its_nulls(self, ebull_test_conn: psycopg.Connection[Any]) -> None:
+        # The 324 stored rows are all `criterion7-v1` and cannot be backfilled
+        # without a register-charging re-run, so this direction MUST stay legal.
+        self._update(ebull_test_conn, "metric_set_id='criterion7-v1'")
+
+    def test_a_zero_day_hold_is_accepted(self, ebull_test_conn: psycopg.Connection[Any]) -> None:
+        # Every trade closing same-day is a real measurement, not an absence.
+        self._update(ebull_test_conn, "median_hold_days=0, hold_days_p25=0, hold_days_p75=0")
+
+
+@pytest.mark.parametrize(
+    "holds",
+    [
+        pytest.param([1, 2, 3, 4, 5], id="odd"),
+        pytest.param([1, 2, 3, 4], id="even-interpolates"),
+        pytest.param([5, 5, 5, 5], id="duplicates"),
+        pytest.param([0, 0, 1], id="zero-holds"),
+        pytest.param([7], id="single"),
+        pytest.param([2, 9, 9, 1, 40, 3, 3], id="skewed"),
+    ],
+)
+def test_numpy_linear_matches_postgres_percentile_cont(
+    ebull_test_conn: psycopg.Connection[Any], holds: list[int]
+) -> None:
+    """§3.2's whole reason for naming the method.
+
+    The live path reports the same quantity in the same unit via
+    ``percentile_cont`` (``strategy_monitoring``'s ``median_days_to_outcome``).
+    If the two engines disagreed, two adjacent figures on one catalog row would
+    differ on identical data — so the equality is pinned rather than assumed.
+    """
+    row = ebull_test_conn.execute(
+        """
+        SELECT percentile_cont(0.25) WITHIN GROUP (ORDER BY d),
+               percentile_cont(0.5)  WITHIN GROUP (ORDER BY d),
+               percentile_cont(0.75) WITHIN GROUP (ORDER BY d)
+        FROM unnest(%(holds)s::numeric[]) AS t(d)
+        """,
+        {"holds": holds},
+    ).fetchone()
+    assert row is not None
+    expected = np.percentile(np.asarray(holds, dtype=np.float64), [25, 50, 75], method="linear")
+    assert [float(value) for value in row] == pytest.approx(list(expected))

--- a/tests/test_strategy_holding_period_db.py
+++ b/tests/test_strategy_holding_period_db.py
@@ -117,9 +117,34 @@ class TestTheChecks:
 
         Without it a null on a future row is indistinguishable from a legitimate
         legacy null, so a writer defect would be permanently invisible.
+
+        ⚠ The precondition is ESTABLISHED, not inherited. Mutating only
+        ``metric_set_id`` would lean on the probed row happening to have
+        ``trade_count > 0`` and null hold columns — and if that ever stopped
+        holding, the test would pass for the wrong reason and stop guarding
+        anything. So the row is put into the exact state under test first.
         """
+        self._update(
+            ebull_test_conn,
+            "metric_set_id='criterion7-v1', trade_count=5, losing_trade_count=0, profit_factor=NULL, "
+            "median_hold_days=NULL, hold_days_p25=NULL, hold_days_p75=NULL",
+        )
         with pytest.raises(psycopg.errors.CheckViolation):
             self._update(ebull_test_conn, "metric_set_id='criterion7-v2'")
+
+    def test_a_v2_row_with_no_realised_trades_may_keep_its_nulls(
+        self, ebull_test_conn: psycopg.Connection[Any]
+    ) -> None:
+        """The other side of the same CHECK, and it has to stay legal.
+
+        A window in which nothing traded produces a genuine zero-trade result;
+        refusing it would make that unstorable under the current metric set.
+        """
+        self._update(
+            ebull_test_conn,
+            "metric_set_id='criterion7-v2', trade_count=0, losing_trade_count=0, profit_factor=NULL, "
+            "median_hold_days=NULL, hold_days_p25=NULL, hold_days_p75=NULL",
+        )
 
     def test_a_legacy_v1_row_may_keep_its_nulls(self, ebull_test_conn: psycopg.Connection[Any]) -> None:
         # The 324 stored rows are all `criterion7-v1` and cannot be backfilled

--- a/tests/test_strategy_result.py
+++ b/tests/test_strategy_result.py
@@ -141,6 +141,11 @@ def _metrics(**overrides: object) -> StrategyMetrics:
         "bootstrap_seed": 20260807,
         "bootstrap_design_effect": 2.44,
         "bootstrap_model_id": "c3-block-bootstrap-v1",
+        # #2623 gap 1 — required alongside a non-zero trade_count under the
+        # current METRIC_SET_ID.
+        "hold_days_p25": 3.0,
+        "median_hold_days": 8.0,
+        "hold_days_p75": 21.0,
     }
     base.update(overrides)
     return StrategyMetrics(**base)  # type: ignore[arg-type]

--- a/tests/test_strategy_statistics.py
+++ b/tests/test_strategy_statistics.py
@@ -63,9 +63,13 @@ def _trades(
     # a single shared date would collapse the whole trade list into one cluster
     # and quietly make every bootstrap in this file degenerate.
     entry_dates = dates if dates is not None else [date(2020, 1, 1) + timedelta(days=i) for i in range(len(returns))]
+    # Default exits are one day after their own entry, so the helper's trades all
+    # hold for exactly 1 day and every existing caller keeps a valid exit axis.
+    exit_dates = [day + timedelta(days=1) for day in entry_dates]
     return TradeReturns(
         net_return_pct=tuple(returns),
         entry_fill_date=tuple(entry_dates),
+        exit_bar_date=tuple(exit_dates),
         open_count=open_count,
         unpriced_count=unpriced_count,
     )
@@ -357,6 +361,9 @@ class TestMetricsRefuse:
             "periods_per_year": 251.7,
             "total_return_pct": 21.0,
             "buy_and_hold_return_pct": 22.5,
+            "hold_days_p25": 3.0,
+            "median_hold_days": 8.0,
+            "hold_days_p75": 21.0,
         }
         base.update(overrides)
         return StrategyMetrics(**base)  # type: ignore[arg-type]
@@ -481,6 +488,7 @@ class TestTradeReturnsParallelism:
             TradeReturns(
                 net_return_pct=(1.0, 2.0, 3.0),
                 entry_fill_date=(date(2020, 1, 1), date(2020, 1, 2)),
+                exit_bar_date=(date(2020, 1, 1), date(2020, 1, 2)),
                 open_count=0,
                 unpriced_count=0,
             )
@@ -510,6 +518,9 @@ class TestBootstrapFieldsAreAllOrNothing:
             "periods_per_year": 251.7,
             "total_return_pct": 21.0,
             "buy_and_hold_return_pct": 22.5,
+            "hold_days_p25": 3.0,
+            "median_hold_days": 8.0,
+            "hold_days_p75": 21.0,
             "effective_sample_size": 41.0,
             "expectancy_ci_low_pct": -0.2,
             "expectancy_ci_high_pct": 1.1,

--- a/tests/test_synthetic_control_run.py
+++ b/tests/test_synthetic_control_run.py
@@ -270,6 +270,7 @@ def _sleeve_metrics(*, exits_on_spike: bool) -> StrategyMetrics:
     book = LegBook()
     returns: list[float] = []
     entry_dates: list[date] = []
+    exit_dates: list[date] = []
     for series_index in range(_SERIES):
         series = _series(series_index)
         prices = _prices(series_index)
@@ -293,6 +294,8 @@ def _sleeve_metrics(*, exits_on_spike: bool) -> StrategyMetrics:
             )
             returns.append(float(row.net_return_pct or 0.0))
             entry_dates.append(row.position.entry_fill_bar_date)
+            assert row.position.close_bar_date is not None
+            exit_dates.append(row.position.close_bar_date)
     low, high = min(book.entry_index), max(book.exit_index)
     dates = AXIS[low : high + 1]
     return compute_metrics(
@@ -301,6 +304,7 @@ def _sleeve_metrics(*, exits_on_spike: bool) -> StrategyMetrics:
         trades=TradeReturns(
             net_return_pct=tuple(returns),
             entry_fill_date=tuple(entry_dates),
+            exit_bar_date=tuple(exit_dates),
             open_count=0,
             unpriced_count=0,
         ),


### PR DESCRIPTION
## What this is

#2623 **gap 1** — the operator's *"expected turnaround"* number. Gap 2 (fire rate) shipped as `df1fa062`; gap 3 (catalog view) renders both. #2623 stays open.

Spec: `docs/proposals/ta/2026-08-14-strategy-holding-period.md`.

## The premise, and the sizing risk it carried

`strategy_statistics.TradeReturns` carried `net_return_pct` and `entry_fill_date` as parallel tuples and **no exit axis**, so `compute_metrics` could not produce a holding statistic however many columns were added downstream — adding the result columns first would have been an R4 orphan.

The 2026-08-13 triage left one thing unmeasured and it decided the size: *"whether the exit bar is in scope at the producer, or has already been dropped further upstream."* **It is in scope, at the append site itself:**

- `backtest_run.py:1174` appends `entry_fill_bar_date`; the same object's `close_bar_date` is read **three lines above** at `:1105`.
- `synthetic_control_run.py:576` appends `axis[entry_index]` with `exit_index` in scope on the line above.

⚠ The spec's first draft then called this "four steps and no more". That was wrong and Codex caught it — it counted the data path and forgot the ledger round-trip and the view. The real surface is 8 sites, tabulated in §2.

## Source rule

No published formulation exists for "expected turnaround" — stated, and fixed by construction with each choice anchored to something already here.

**Unit: calendar days.** ⚠ `strategy_outcomes.bars_held` is the competing *documented* unit and is deliberately not followed: a bar count is not a turnaround anyone can plan against, since five bars is a week or a fortnight depending on halts and holidays. The live path already made the same call — `strategy_monitoring._ATTRIBUTION_SQL`'s `median_days_to_outcome` uses Postgres date subtraction.

⚠ That precedent fixes the **unit and nothing more**. It is *not* the same statistic: it measures resolved signal outcomes across funded *and* rejected entries filtered on `gross_return_pct IS NOT NULL`, whereas this measures costed realised backtest positions on net returns. The catalog must not label them as one number.

**Percentiles: `method="linear"`**, because that is the same definition as `percentile_cont` — so the two figures cannot disagree on identical data. Pinned by a cross-engine test over odd, even, duplicate, zero, single and skewed populations.

**Population: realised trades only, right-censored.** ⚠⚠ The spec's first draft claimed the median is biased *downward* because "the still-open positions are precisely the long-held ones". **Unfounded, and corrected** — a position opened shortly before the window end is also still open and has a *short* elapsed duration. Censoring here is informative, but informative censoring does not fix a sign. So it is labelled, not corrected: `open_trade_count` **and** `unpriced_trade_count` must both render beside the median (they are separate exclusions; neither implies the other).

## `METRIC_SET_ID` → `criterion7-v2`

A version denotes a **rule set**, not a row population (#2670): a row carrying three metrics `criterion7-v1` never defined cannot keep that stamp, even though no pre-existing metric changed value. I had argued the opposite; Codex flipped it.

**Verified safe before bumping** — nothing gates on the value. Across `app/`, `sql/`, `frontend/src` it is only written (`strategy_result.py:1088`), read back (`result_ledger.py:822`), and constrained by `CHECK (metric_set_id <> '')`.

⚠⚠ **And the bump is not bookkeeping — it is the null-provenance discriminator.** Without it a null holding period on a future row is indistinguishable from a legitimate legacy null, so a writer defect is permanently invisible. `sql/347` makes the rule enforceable:

```sql
CHECK (metric_set_id <> 'criterion7-v2' OR trade_count = 0 OR median_hold_days IS NOT NULL)
```

Also enforced in Python (`StrategyMetrics.__post_init__`) so a defect fails at construction with a named field rather than as an integrity error mid-batch. ⚠ Written with `<>` against a `NOT NULL` column, so the `NULL = 'x'` trap that bit #2603 item 2 does not apply — noted in the migration because that is exactly the shape that failed before.

## ⚠⚠ Populate forward only

All **324** stored rows read `null`, permanently. Backfilling requires re-running the backtests, which mints results under current pins — the trial-register-charging path #2599's declaration contract and #2616's pre-cutoff rerun gate govern, and which an unattended run must not open. Gap 3 renders it as *"not measured for this result version"*, naming `criterion7-v1`.

⚠ The spec's first draft argued from trade counts (min 433, median 6,005) that "the percentiles are not going to be noise". **Dropped** — trade count does not establish temporal support, and the hold distribution is not stored, which is the entire point of the ticket. Nothing to measure it on yet, so nothing asserted.

## ⚠⚠ A real bug in this diff, and what caught it

Values landed in the **wrong columns**: `median_hold_days` was written into the DSR block, because the three names were appended to `_RESULT_COLUMNS` after `trial_register_version` while the placeholders went in after `%(bootstrap_model_id)s`. Then the mirror image — the reader's unpack tuple had them at the end while `_RESULT_COLUMNS` (shared by the INSERT *and* the SELECT) had them mid-list, so the round trip reconstructed a metric set with no holding period.

Types and lint were clean throughout. The write-side misalignment was caught by an **unrelated pre-existing** `strategy_results_dsr_all_or_nothing` CHECK firing on the shifted row; the read-side by a round-trip test. A schema without all-or-nothing CHECKs would have stored it silently. Prevention-log entry added.

## Codex

**Checkpoint 1 earned heavily** — it found the `METRIC_SET_ID` omission, the `strategy_results` view needing recreation, the missing reader round-trip, the unjustified bias direction, the `exit_fill_date` misnomer (producers hold *close bars*, not fills — renamed `exit_bar_date`), the `open_trade_count`-alone denominator, and the two overclaims listed above. All verified against source before accepting. Checkpoint 2 on the diff: no findings.

**Rebutted, with citations, recorded in spec §5:** *"a completed scan writing zero rows would be census-invisible"* — not reachable, `assert_census_complete` fails the job on a short leg (scan spec §9, *"a mismatch is a failure, not a log line"*). And *"future-dated rows enter all-history unbounded"* — the scan runs in arrears and writes the bar before the frontier.

## Verification

| gate | result |
| --- | --- |
| ruff / format / pyright | green (exit code, not piped output) |
| fast tier + smoke | green |
| **full DB tier**, 20 file-scoped batches | **all 20 exit 0** |
| migration applied to dev | `347_strategy_result_holding_period.sql` |

Constraint behaviour probed directly on dev inside a transaction that was **rolled back** (dev data untouched):

| probe | outcome |
| --- | --- |
| partial triple | REJECTED |
| unordered (`p25 > median`) | REJECTED |
| negative hold | REJECTED |
| `criterion7-v2` + trades, no hold | REJECTED |
| valid triple | accepted |
| same-day hold (`0,0,0`) | accepted |

Confirmed on dev: the view exposes all three columns, all 324 rows are `criterion7-v1` with null holds, and the CHECK is satisfied.

⚠ Criterion 7's **twelve are unchanged** — the holding period is not one of them, so `quarantine_sensitivity.compare_metrics` correctly does not compare it and `test_every_criterion_7_metric_is_compared` still asserts 12.

## What this does NOT do

- **No backfill and no re-run** (above). The columns are empty until a backtest runs.
- **No full-population A/B arm**, and none is claimed. The change adds a statistic and alters no existing one; the only stored field whose value changes is `metric_set_id`, deliberately. Stated rather than left as an unrun gate.
- **No UI.** Gap 3 is where these become operator-visible.

## Security

No new input, no new write path, no credential or broker surface. One migration adding three nullable columns plus CHECKs, and a derived statistic over data the same code path already held.

Refs #2623. Refs #2437.
