### PR TITLE
feature(#2623): render the strategy catalog facts, each blank naming its own reason

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -223,6 +223,23 @@ class ResultArm(BaseModel):
     turnover_annualised: Decimal
     return_vs_buy_and_hold_pct: Decimal
     deflated_sharpe: Decimal | None
+    # #2623 gap 1. ⚠ The three hold figures are null for every one of the 324
+    # stored rows and stay that way: they populate FORWARD ONLY, because
+    # backfilling means re-running the backtests, which charges the trial
+    # register (#2599/#2616). `metric_set_id` is what makes that null readable —
+    # `criterion7-v1` is a row written before the measurement existed, whereas a
+    # null under `criterion7-v2` is a writer defect (`sql/347` CHECKs it). The
+    # reader must render those two differently, so the id ships with them.
+    #
+    # ⚠ `median_hold_days` must never be displayed alone. It is right-censored
+    # and the direction of the bias is NOT determinable a priori — a position
+    # opened just before the window end is still open and short — so
+    # `open_trade_count` and `unpriced_trade_count` belong beside it. They are
+    # separate exclusions and neither implies the other.
+    metric_set_id: str
+    median_hold_days: Decimal | None
+    hold_days_p25: Decimal | None
+    hold_days_p75: Decimal | None
     promotion_refusals: list[str]
 
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2431,6 +2431,17 @@ export interface StrategyResultArm {
   turnover_annualised: string;
   return_vs_buy_and_hold_pct: string;
   deflated_sharpe: string | null;
+  /** Which metric set produced this row (#2623 gap 1). `criterion7-v1` predates
+   *  the holding-period measurement, so its null hold figures mean "not measured
+   *  for this result version" — NOT zero and NOT a defect. Every stored row reads
+   *  `criterion7-v1` today; the columns populate forward only, as backtests run. */
+  metric_set_id: string;
+  /** ⚠ Never render alone. Right-censored, and the bias direction is not
+   *  determinable a priori, so `open_trade_count` AND `unpriced_trade_count`
+   *  belong beside it — separate exclusions, neither implying the other. */
+  median_hold_days: string | null;
+  hold_days_p25: string | null;
+  hold_days_p75: string | null;
   promotion_refusals: string[];
 }
 
@@ -2501,10 +2512,35 @@ export interface StrategyOverview {
   all_recent_evidence_complete: boolean;
   stage: string | null;
   attribution: StrategyAttribution;
+  fire_rate: StrategyFireRate;
   pnl: StrategyPnl;
   allocation: StrategyAllocation;
   allocation_ready: boolean;
   allocation_refusals: string[];
+}
+
+/** How often the entry rule fires, from the durable census (#2623 gap 2).
+ *
+ * ⚠ `fired_share_of_evaluable` is the COMPARABLE number — dimensionless, so a
+ * growing universe does not move it. `entries_per_calendar_week` is throughput
+ * and is universe-size-dependent by design, so it must not be the headline.
+ *
+ * ⚠ The two nulls are INDEPENDENT and carry their own reasons: a version scanned
+ * across several days on which every bar was `not_evaluable` has a real 0.00/week
+ * rate and no share at all. Render each reason; never collapse them to a blank. */
+export interface StrategyFireRate {
+  universe: string;
+  scanned_days: number;
+  fired_days: number;
+  fired_entry_signals: number;
+  evaluable_entry_decisions: number;
+  not_evaluable_entry_decisions: number;
+  fired_share_of_evaluable: string | null;
+  entries_per_calendar_week: string | null;
+  first_scanned_bar: string | null;
+  last_scanned_bar: string | null;
+  share_unavailable_reason: "never_scanned" | "no_evaluable_decisions" | null;
+  weekly_rate_unavailable_reason: "never_scanned" | "single_scan_day" | null;
 }
 
 export interface StrategyAttribution {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -39,6 +39,13 @@ const ARM: StrategyResultArm = {
   turnover_annualised: "4",
   return_vs_buy_and_hold_pct: "2",
   deflated_sharpe: "0.8",
+  // Matches every one of the 324 stored rows: written before the holding period
+  // was measured, so the three hold figures are null and the cell must say which
+  // result version that is rather than showing a blank or a zero (#2623 gap 1).
+  metric_set_id: "criterion7-v1",
+  median_hold_days: null,
+  hold_days_p25: null,
+  hold_days_p75: null,
   promotion_refusals: [],
 };
 
@@ -220,6 +227,23 @@ const OVERVIEW: StrategyOverviewResponse = {
       average_slippage_pct: null,
       average_stressed_cost_usd: null,
       max_observed_account_drawdown_pct: null,
+    },
+    // Mirrors what all four strategies actually return today: a share IS present
+    // (0.5210 / 0.0000 / 0.0039 / 0.0340 on dev), while every one of them has a
+    // single scan day and so has no weekly rate at all.
+    fire_rate: {
+      universe: "validated_us_equity",
+      scanned_days: 1,
+      fired_days: 1,
+      fired_entry_signals: 1740,
+      evaluable_entry_decisions: 3340,
+      not_evaluable_entry_decisions: 620,
+      fired_share_of_evaluable: "0.5210",
+      entries_per_calendar_week: null,
+      first_scanned_bar: "2026-08-12",
+      last_scanned_bar: "2026-08-12",
+      share_unavailable_reason: null,
+      weekly_rate_unavailable_reason: "single_scan_day",
     },
     pnl: { currency: "USD", strategy_trade_count: 0, owned_position_count: 0, active_position_count: 0, close_event_count: 0, invested_capital: "0", realised_pnl: "0", unrealised_pnl: "0", total_pnl: "0", observed_fees: "0", complete: true, incomplete_reasons: [] },
     allocation: { deployment_id: null, capital_limit: "0", currency: "USD", enabled: false, revision: null, reserved_capital: "0", invested_capital: "0", remaining_capital: "0", policy_configured: false, max_drawdown_limit_pct: null, ticket_sizing_mode: null, ticket_value: null, max_ticket_amount: null },
@@ -777,6 +801,72 @@ describe("StrategiesPage", () => {
     expect(await screen.findByText("Version rotated.")).toBeInTheDocument();
     expect(screen.getByText("Previous versions")).toBeInTheDocument();
     expect(screen.getByText(/different cost model/)).toBeInTheDocument();
+  });
+
+  it("names the reason for each blank catalog fact, on the surface every strategy renders through", async () => {
+    // ⚠ `harness_validation`, so `ValidationControl` — all four real strategies
+    // are controls, and a candidate-only fixture cannot prove the block is on the
+    // surface the operator sees (#2624). This is the day-one state exactly: a
+    // share but no weekly rate, and a pre-`criterion7-v2` result row.
+    const control = structuredClone(OVERVIEW);
+    control.strategies[0]!.purpose = "harness_validation";
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(control);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    // The share renders; the weekly rate names its own independent reason.
+    // ⚠ Unsigned. `formatPct`'s `exceptZero` would render this "+52.10%", which
+    // reads as a change in the share rather than the share itself.
+    expect(await screen.findByText("52.10%")).toBeInTheDocument();
+    expect(screen.getByText("1 scan day — needs a span")).toBeInTheDocument();
+    // The holding period's blank is explained by the RESULT VERSION, not by
+    // either fire-rate reason, and must not read as a zero.
+    expect(screen.getByText("Not measured")).toBeInTheDocument();
+    expect(screen.getByText(/Result version criterion7-v1/)).toBeInTheDocument();
+  });
+
+  it("never shows a median holding period without both of its exclusion counts", async () => {
+    // The median is right-censored and the bias direction is not determinable a
+    // priori, so open and unpriced counts are separate exclusions that must both
+    // appear beside it — neither implies the other.
+    const measured = structuredClone(OVERVIEW);
+    const strategy = measured.strategies[0]!;
+    strategy.purpose = "harness_validation";
+    const arm = strategy.evidence_windows[0]!.arms[0]!;
+    arm.metric_set_id = "criterion7-v2";
+    arm.median_hold_days = "6.5";
+    arm.hold_days_p25 = "3";
+    arm.hold_days_p75 = "14";
+    arm.open_trade_count = 4;
+    arm.unpriced_trade_count = 2;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(measured);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    expect(await screen.findByText("6.5 days")).toBeInTheDocument();
+    expect(screen.getByText("3–14 typical · 4 open, 2 unpriced excluded")).toBeInTheDocument();
+  });
+
+  it("counts backtest trades without subtracting exclusions that were never in the total", async () => {
+    // `trade_count = len(net_returns)` and `backtest_run` appends a return only
+    // on a realised close, so open and unpriced positions are reported alongside
+    // it, never inside it. Subtracting them understated 300 of the 324 stored
+    // rows. 12 trades with 4 open and 2 unpriced must still read 12, not 6.
+    const censored = structuredClone(OVERVIEW);
+    const arm = censored.strategies[0]!.evidence_windows[0]!.arms[0]!;
+    arm.open_trade_count = 4;
+    arm.unpriced_trade_count = 2;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(censored);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+    await userEvent.click(await screen.findByRole("button", { name: "View evidence" }));
+
+    const trades = screen.getByText("Trades").parentElement!;
+    expect(within(trades).getByText("12")).toBeInTheDocument();
+    expect(within(trades).getByText("4 open, 2 unpriced excluded")).toBeInTheDocument();
   });
 
   it("shows no previous-versions block when there is no history", async () => {

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -826,6 +826,28 @@ describe("StrategiesPage", () => {
     expect(screen.getByText(/Result version criterion7-v1/)).toBeInTheDocument();
   });
 
+  it("distinguishes a result version that never measured the hold from one that closed no trades", async () => {
+    // The other branch of the same blank. `sql/347` permits a null median under
+    // `criterion7-v2` ONLY when trade_count is 0, so under the current version an
+    // empty cell means "closed nothing" — a different claim from "we never
+    // measured this", and the operator must not read one as the other.
+    const measured = structuredClone(OVERVIEW);
+    const strategy = measured.strategies[0]!;
+    strategy.purpose = "harness_validation";
+    const arm = strategy.evidence_windows[0]!.arms[0]!;
+    arm.metric_set_id = "criterion7-v2";
+    arm.median_hold_days = null;
+    arm.trade_count = 0;
+    arm.losing_trade_count = 0;
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(measured);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    expect(await screen.findByText("No completed trades")).toBeInTheDocument();
+    expect(screen.queryByText(/Result version/)).not.toBeInTheDocument();
+  });
+
   it("never shows a median holding period without both of its exclusion counts", async () => {
     // The median is right-censored and the bias direction is not determinable a
     // priori, so open and unpriced counts are separate exclusions that must both

--- a/frontend/src/pages/StrategiesPage.test.tsx
+++ b/frontend/src/pages/StrategiesPage.test.tsx
@@ -849,6 +849,24 @@ describe("StrategiesPage", () => {
     expect(screen.getByText("3–14 typical · 4 open, 2 unpriced excluded")).toBeInTheDocument();
   });
 
+  it("reports the non-losing share rather than calling a breakeven trade a win", async () => {
+    // `strategy_statistics` counts a losing trade as `value < 0.0` STRICTLY and
+    // stores no winning count, so `trade_count - losing_trade_count` includes
+    // breakevens. 12 trades with 3 losing is 9 NOT AT A LOSS — labelling that a
+    // win rate would report a flat close as a win.
+    const control = structuredClone(OVERVIEW);
+    control.strategies[0]!.purpose = "harness_validation";
+    vi.mocked(strategiesApi.fetchStrategyOverview).mockResolvedValue(control);
+
+    render(<MemoryRouter><StrategiesPage /></MemoryRouter>);
+    await userEvent.click(await screen.findByText("Research & validation"));
+
+    expect(await screen.findByText("Not lost")).toBeInTheDocument();
+    expect(screen.getByText("75.00%")).toBeInTheDocument();
+    expect(screen.getByText("9 of 12 not at a loss")).toBeInTheDocument();
+    expect(screen.queryByText("Won")).not.toBeInTheDocument();
+  });
+
   it("counts backtest trades without subtracting exclusions that were never in the total", async () => {
     // `trade_count = len(net_returns)` and `backtest_run` appends a return only
     // on a realised close, so open and unpriced positions are reported alongside

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -251,18 +251,27 @@ function StrategyCatalogFacts({
   // ⚠ `trade_count` is ALREADY the resolved count — `backtest_run` appends a
   // return only on a realised close, so open and unpriced positions were never
   // in it. Subtracting them here (as this page used to) understates the figure.
-  const wins = arm ? arm.trade_count - arm.losing_trade_count : 0;
-  // Unsigned for the same reason as the share: a win rate is a composition.
-  const successValue = arm && arm.trade_count > 0 ? formatUnsignedPct(wins / arm.trade_count) : "—";
+  //
+  // ⚠⚠ "Not lost", NOT "won", and the label is the fix rather than a hedge.
+  // `strategy_statistics` computes `losing_trades` as `value < 0.0` strictly, so
+  // a breakeven trade is in `trade_count` and in neither the losing count nor any
+  // stored winning count — there is no winning count. `trade_count - losing` is
+  // therefore the NON-LOSING share, and calling it a win rate would report a
+  // breakeven as a win. A true win rate needs a strictly-positive count stored at
+  // the producer, which is a metric-set change and populate-forward-only; naming
+  // what we actually have is the #2602-item-5 posture: never substitute.
+  const notLost = arm ? arm.trade_count - arm.losing_trade_count : 0;
+  // Unsigned for the same reason as the share: a not-lost rate is a composition.
+  const successValue = arm && arm.trade_count > 0 ? formatUnsignedPct(notLost / arm.trade_count) : "—";
   const successNote = arm && arm.trade_count > 0
-    ? `${formatNumber(wins, 0)} of ${formatNumber(arm.trade_count, 0)} backtest trades`
+    ? `${formatNumber(notLost, 0)} of ${formatNumber(arm.trade_count, 0)} not at a loss`
     : "No completed backtest trades";
 
   return (
     <dl className="mt-2 flex flex-wrap gap-x-6 gap-y-2 text-xs">
       <CatalogFact label="Fires" value={firesValue} note={firesNote} />
       <CatalogFact label="Turnaround" value={turnaroundValue} note={turnaroundNote} />
-      <CatalogFact label="Won" value={successValue} note={successNote} />
+      <CatalogFact label="Not lost" value={successValue} note={successNote} />
     </dl>
   );
 }

--- a/frontend/src/pages/StrategiesPage.tsx
+++ b/frontend/src/pages/StrategiesPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/api/strategies";
 import type {
   StrategyEvidenceWindow,
+  StrategyFireRate,
   StrategyOverview,
   StrategyOverviewResponse,
   StrategyOwnedPosition,
@@ -26,7 +27,7 @@ import { LiveQuoteProvider, useLiveTick } from "@/components/quotes/LiveQuotePro
 import { EmptyState } from "@/components/states/EmptyState";
 import { Badge } from "@/components/ui/Badge";
 import { Modal } from "@/components/ui/Modal";
-import { formatDate, formatMoney, formatNumber, formatPct } from "@/lib/format";
+import { formatDate, formatMoney, formatNumber, formatPct, formatUnsignedPct } from "@/lib/format";
 import { useAsync } from "@/lib/useAsync";
 import { useChartTheme } from "@/lib/useChartTheme";
 import { liveTickPriceIn } from "@/lib/useLiveQuote";
@@ -144,6 +145,126 @@ function representativeArm(strategy: StrategyOverview): StrategyResultArm | null
 
 function completedEvidenceCount(strategy: StrategyOverview): number {
   return strategy.evidence_windows.filter((window) => window.status === "complete").length;
+}
+
+/** The metric set that carries a holding period, mirroring
+ *  `app/services/strategy_statistics.py::METRIC_SET_ID`. A row stamped with
+ *  anything else predates the measurement, which is a DIFFERENT statement from
+ *  "this strategy holds for zero days" — hence naming the version in the cell. */
+const HOLD_PERIOD_METRIC_SET = "criterion7-v2";
+
+const SHARE_UNAVAILABLE_LABELS: Record<
+  NonNullable<StrategyFireRate["share_unavailable_reason"]>,
+  string
+> = {
+  never_scanned: "Not scanned yet",
+  no_evaluable_decisions: "No evaluable decisions",
+};
+
+const WEEKLY_RATE_UNAVAILABLE_LABELS: Record<
+  NonNullable<StrategyFireRate["weekly_rate_unavailable_reason"]>,
+  string
+> = {
+  never_scanned: "Not scanned yet",
+  single_scan_day: "1 scan day — needs a span",
+};
+
+function CatalogFact({ label, value, note }: { label: string; value: string; note: string }) {
+  return (
+    <div>
+      <dt className="text-[10px] uppercase tracking-wider text-slate-500">{label}</dt>
+      <dd className="tabular-nums text-slate-700 dark:text-slate-200">{value}</dd>
+      <dd className="text-[10px] text-slate-500">{note}</dd>
+    </div>
+  );
+}
+
+/** The catalog facts #2623 asks for: how often the rule fires, how long it holds,
+ *  and how often it won — on every card, because all four strategies today are
+ *  `harness_validation` and so render through `ValidationControl` (#2624).
+ *
+ * ⚠⚠ `median_hold_days` is deliberately unreachable without its two exclusion
+ * counts. The median is right-censored and the direction of that bias is NOT
+ * determinable a priori — a position opened just before the window end is still
+ * open and also short — so `open_trade_count` and `unpriced_trade_count` are
+ * separate exclusions, neither implying the other. Keeping all three in one
+ * component is what makes "never render the median alone" structural rather than
+ * a convention the next edit can forget.
+ *
+ * ⚠ Every blank names its OWN reason. The three nulls are independent: the fire
+ * share and the weekly rate carry separate reason enums (#2623 gap 2), and the
+ * holding period's blank is explained by `metric_set_id`, not by either of them. */
+function StrategyCatalogFacts({
+  strategy,
+  arm,
+}: {
+  strategy: StrategyOverview;
+  arm: StrategyResultArm | null;
+}) {
+  const fireRate = strategy.fire_rate;
+  const share = number(fireRate.fired_share_of_evaluable);
+  const perWeek = number(fireRate.entries_per_calendar_week);
+  const shareReason = fireRate.share_unavailable_reason;
+  const weeklyReason = fireRate.weekly_rate_unavailable_reason;
+  const median = arm ? number(arm.median_hold_days) : null;
+  const p25 = arm ? number(arm.hold_days_p25) : null;
+  const p75 = arm ? number(arm.hold_days_p75) : null;
+  const excluded = arm ? arm.open_trade_count + arm.unpriced_trade_count : 0;
+
+  // The SHARE is the headline because it is dimensionless. `entries_per_calendar_week`
+  // is throughput and rises with the universe, so leading on it would make a
+  // strategy look busier purely because more instruments were listed.
+  const firesValue = share === null
+    ? (shareReason ? SHARE_UNAVAILABLE_LABELS[shareReason] : "—")
+    // ⚠ UNSIGNED. A fire propensity is a composition, not a return, and
+    // `formatPct` carries `signDisplay: "exceptZero"` — it would render a
+    // perfectly ordinary 52% share as "+52.10%".
+    : formatUnsignedPct(share);
+  const firesNote = perWeek === null
+    ? (weeklyReason ? WEEKLY_RATE_UNAVAILABLE_LABELS[weeklyReason] : "No weekly rate")
+    : `${formatNumber(perWeek, 2)} / week`;
+
+  let turnaroundValue: string;
+  let turnaroundNote: string;
+  if (arm === null) {
+    turnaroundValue = "—";
+    turnaroundNote = "No completed evidence";
+  } else if (median === null) {
+    // Two different nulls. A pre-`criterion7-v2` row was written before the
+    // holding period was measured at all; a row stamped WITH it and still null
+    // simply closed no trades (`sql/347` allows that case and no other).
+    turnaroundValue = "Not measured";
+    turnaroundNote = arm.metric_set_id === HOLD_PERIOD_METRIC_SET
+      ? "No completed trades"
+      : `Result version ${arm.metric_set_id}`;
+    if (excluded > 0) {
+      turnaroundNote += ` · ${formatNumber(arm.open_trade_count, 0)} open, ${formatNumber(arm.unpriced_trade_count, 0)} unpriced`;
+    }
+  } else {
+    turnaroundValue = `${formatNumber(median, 1)} days`;
+    const range = p25 !== null && p75 !== null
+      ? `${formatNumber(p25, 1)}–${formatNumber(p75, 1)} typical`
+      : "No range";
+    turnaroundNote = `${range} · ${formatNumber(arm.open_trade_count, 0)} open, ${formatNumber(arm.unpriced_trade_count, 0)} unpriced excluded`;
+  }
+
+  // ⚠ `trade_count` is ALREADY the resolved count — `backtest_run` appends a
+  // return only on a realised close, so open and unpriced positions were never
+  // in it. Subtracting them here (as this page used to) understates the figure.
+  const wins = arm ? arm.trade_count - arm.losing_trade_count : 0;
+  // Unsigned for the same reason as the share: a win rate is a composition.
+  const successValue = arm && arm.trade_count > 0 ? formatUnsignedPct(wins / arm.trade_count) : "—";
+  const successNote = arm && arm.trade_count > 0
+    ? `${formatNumber(wins, 0)} of ${formatNumber(arm.trade_count, 0)} backtest trades`
+    : "No completed backtest trades";
+
+  return (
+    <dl className="mt-2 flex flex-wrap gap-x-6 gap-y-2 text-xs">
+      <CatalogFact label="Fires" value={firesValue} note={firesNote} />
+      <CatalogFact label="Turnaround" value={turnaroundValue} note={turnaroundNote} />
+      <CatalogFact label="Won" value={successValue} note={successNote} />
+    </dl>
+  );
 }
 
 function validationState(strategy: StrategyOverview): {
@@ -915,6 +1036,7 @@ function ApprovedStrategy({
           </Badge>
         </div>
         <p className="mt-1 max-w-md text-xs text-slate-500">{strategy.description}</p>
+        <StrategyCatalogFacts strategy={strategy} arm={representativeArm(strategy)} />
         <StrategySizingControl strategy={strategy} onUpdated={onUpdated} />
       </div>
       <div><span className="text-xs text-slate-500">P&amp;L</span><strong className="block tabular-nums">{money(strategy.pnl.total_pnl)}</strong></div>
@@ -946,7 +1068,16 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
       </div>
     );
   }
-  const resolved = Math.max(0, arm.trade_count - arm.open_trade_count - arm.unpriced_trade_count);
+  // ⚠ `trade_count` IS the resolved count and always was. `backtest_run` appends
+  // to `book.returns` only inside `if realised`, and `trade_count = len(net_returns)`,
+  // so open and unpriced positions were never summands — they are reported
+  // ALONGSIDE it, never inside it. Subtracting them double-counted the exclusion
+  // and understated the headline on 300 of the 324 stored rows, by up to 2,296
+  // trades. Measured with:
+  //   select count(*) filter (where open_trade_count + unpriced_trade_count > 0),
+  //          max(open_trade_count + unpriced_trade_count)
+  //   from strategy_results_store;
+  const resolved = arm.trade_count;
   return (
     <div className="border-t border-slate-200 px-4 py-4 dark:border-slate-800">
       <div className="grid gap-5 lg:grid-cols-[1.3fr_1fr]">
@@ -954,7 +1085,11 @@ function EvidenceDetail({ strategy }: { strategy: StrategyOverview }) {
           <h4 className="text-xs font-semibold uppercase tracking-wider text-slate-500">Primary evidence</h4>
           <p className="mt-1 text-xs text-slate-500">{window.label} · {formatDate(window.window_start)}–{formatDate(window.window_end)} · pessimistic execution arm</p>
           <dl className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
-            <div><dt className="text-xs text-slate-500">Trades</dt><dd className="font-semibold tabular-nums">{formatNumber(resolved, 0)}</dd></div>
+            <div>
+              <dt className="text-xs text-slate-500">Trades</dt>
+              <dd className="font-semibold tabular-nums">{formatNumber(resolved, 0)}</dd>
+              <dd className="text-[10px] text-slate-500">{formatNumber(arm.open_trade_count, 0)} open, {formatNumber(arm.unpriced_trade_count, 0)} unpriced excluded</dd>
+            </div>
             <div><dt className="text-xs text-slate-500">Profit factor</dt><dd className="font-semibold tabular-nums">{formatNumber(number(arm.profit_factor), 2)}</dd></div>
             <div><dt className="text-xs text-slate-500">Vs buy &amp; hold</dt><dd className="font-semibold tabular-nums">{pctPoints(arm.return_vs_buy_and_hold_pct)}</dd></div>
             <div><dt className="text-xs text-slate-500">Deflated Sharpe</dt><dd className="font-semibold tabular-nums">{formatNumber(number(arm.deflated_sharpe), 2)}</dd></div>
@@ -992,6 +1127,7 @@ function ResearchCandidate({ strategy }: { strategy: StrategyOverview }) {
         <div>
           <div className="flex flex-wrap items-center gap-2"><h3 className="text-sm font-semibold">{strategy.title}</h3><Badge tone={validation.tone}>{validation.label}</Badge></div>
           <p className="mt-1 max-w-lg text-xs text-slate-500">{validation.explanation}</p>
+          <StrategyCatalogFacts strategy={strategy} arm={arm} />
         </div>
         <div><span className="text-xs text-slate-500">Expected / trade</span><strong className="block tabular-nums">{pctPoints(arm?.expectancy_per_trade_pct ?? null)}</strong><span className="text-[10px] text-slate-500">After modelled costs</span></div>
         <div><span className="text-xs text-slate-500">95% range</span><strong className="block text-xs tabular-nums">{ci}</strong><span className="text-[10px] text-slate-500">Must clear 0%</span></div>
@@ -1024,6 +1160,7 @@ function ValidationControl({ strategy }: { strategy: StrategyOverview }) {
             Harness evidence only · never eligible for capital
             {strategy.forward_outcome_supported ? " · forward outcomes measured" : " · backtest only"}
           </p>
+          <StrategyCatalogFacts strategy={strategy} arm={arm} />
         </div>
         <div><span className="text-xs text-slate-500">Expected / trade</span><strong className="block tabular-nums">{pctPoints(arm?.expectancy_per_trade_pct ?? null)}</strong></div>
         <div><span className="text-xs text-slate-500">Worst drawdown</span><strong className="block tabular-nums">{pctPoints(arm?.max_drawdown_pct ?? null)}</strong></div>

--- a/tests/test_api_strategies.py
+++ b/tests/test_api_strategies.py
@@ -227,6 +227,10 @@ def test_result_arm_accepts_valid_undefined_downside_metrics() -> None:
         turnover_annualised=Decimal("1"),
         return_vs_buy_and_hold_pct=Decimal("1"),
         deflated_sharpe=None,
+        metric_set_id="criterion7-v1",
+        median_hold_days=None,
+        hold_days_p25=None,
+        hold_days_p75=None,
         promotion_refusals=[],
     )
 

--- a/tests/test_metric_set_id_frontend_contract.py
+++ b/tests/test_metric_set_id_frontend_contract.py
@@ -1,0 +1,52 @@
+"""``METRIC_SET_ID`` must agree between the producer and the page that reads it.
+
+Pure-logic (no DB, no app boot). Same shape as
+``test_correction_kind_vocab_contract`` and the same recurring class the prevention
+log calls "contract-field wired into one model not its sibling".
+
+``StrategiesPage.tsx`` decides what an EMPTY holding-period cell means by comparing
+``metric_set_id`` against a literal it declares itself:
+
+  * ``criterion7-v2`` with no median  -> "No completed trades"
+  * anything else                     -> "Result version <id>", i.e. written before
+                                         the measurement existed
+
+Those two sentences are not interchangeable — one says the strategy closed nothing,
+the other says we never measured it. A backend rename of ``METRIC_SET_ID`` would send
+every freshly-written row down the second branch, telling the operator the current
+result version is unmeasured. Nothing else would fail: TypeScript cannot see a Python
+constant, and the branch is only reachable on data that does not exist yet (#2623
+populates the columns forward only), so no fixture would catch it either.
+
+Read as text rather than by importing anything from the frontend, for the same reason
+the sibling test reads its producer by AST: what matters is that the literal in the
+shipped file agrees, not that some render path happened to exercise it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.services.strategy_statistics import METRIC_SET_ID
+
+_REPO = Path(__file__).resolve().parents[1]
+_PAGE = _REPO / "frontend" / "src" / "pages" / "StrategiesPage.tsx"
+
+_DECLARATION = re.compile(r'const HOLD_PERIOD_METRIC_SET = "([^"]+)";')
+
+
+def test_frontend_hold_period_metric_set_matches_the_producer() -> None:
+    source = _PAGE.read_text()
+    match = _DECLARATION.search(source)
+    assert match is not None, (
+        f"{_PAGE.relative_to(_REPO)} no longer declares HOLD_PERIOD_METRIC_SET. If the constant moved, "
+        "move this assertion with it — do not delete it: it is the only thing tying the page's "
+        "'not measured for this result version' branch to the producer."
+    )
+    assert match.group(1) == METRIC_SET_ID, (
+        f"{_PAGE.relative_to(_REPO)} pins HOLD_PERIOD_METRIC_SET to {match.group(1)!r} but "
+        f"strategy_statistics.METRIC_SET_ID is {METRIC_SET_ID!r}. While these disagree the page reports "
+        "every row written under the CURRENT version as 'not measured for this result version', which is "
+        "a different claim from 'no completed trades' and is false."
+    )


### PR DESCRIPTION
Closes #2623. Refs #2437. Refs #2525.

Gap 3, the last piece of the ticket. Gaps 1 (`49492b09`) and 2 (`df1fa062`) built
the fields; this surfaces them and gives every missing value a reason instead of a
blank.

## What changed

**Backend** — `ResultArm` gains `metric_set_id` and the three holding-period
columns. `_RESULTS_SQL` already selects them (`SELECT r.*`) and arms are built by
`{field: row[field] for field in ResultArm.model_fields}`, so the model *is* the
projection contract; the four declarations are the whole change. Column names were
verified against `information_schema`, not against the sibling dataclass — a typo
there is a runtime `KeyError`, not an import error.

**Frontend** — a `StrategyCatalogFacts` block on every strategy card: fires,
expected turnaround, and the non-losing share.

## Three rendering constraints, made structural rather than conventional

- **`median_hold_days` is unreachable without both exclusion counts.** It is
  right-censored and the bias direction is *not* determinable a priori — a position
  opened just before the window end is still open and also short — so
  `open_trade_count` and `unpriced_trade_count` are separate exclusions, neither
  implying the other. All three live in one component, so a later edit cannot
  separate them.
- **`fired_share_of_evaluable` is the headline, not `entries_per_calendar_week`.**
  The share is dimensionless; the weekly rate rises with universe size and would
  make a strategy look busier because more instruments were listed.
- **Each blank names its own reason.** The fire share, the weekly rate and the
  holding period are three independent nulls with three separate explanations.

Rendered on `ValidationControl` as well as the candidate paths: all four strategies
are `harness_validation`, so a candidate-only change would have shipped a payload
nothing displays (#2624's lesson).

## Full-population verification

Not a sample — all four strategies and all 324 stored rows:

| check | query | result |
| --- | --- | --- |
| stored result versions | `select metric_set_id, count(*), count(median_hold_days) from strategy_results_store group by 1` | `criterion7-v1, 324, 0` — every row hits the "not measured" state |
| fire share | `load_fire_rate` over the four current versions | `0.5210 / 0.0000 / 0.0039 / 0.0340` — present for all four |
| weekly rate | same | null for all four, reason `single_scan_day` |

⚠ This **corrects the ticket's triage table**, which implied the `share_unavailable_reason`
empty states render on day one. They do not — the share has a real value on every
strategy. Both branches are still implemented and tested, but the states that
actually render today are `single_scan_day` and `criterion7-v1`.

## Two defects found while building it

**1. Double-subtracted trade count** (`StrategiesPage.tsx:949`). The page computed
`trade_count - open_trade_count - unpriced_trade_count`. But `backtest_run.py:1180`
appends to `book.returns` only inside `if realised`, and
`strategy_statistics.py:451` sets `trade_count = len(net_returns)` — so open and
unpriced positions were **never summands**. They are reported alongside the count,
not inside it.

Blast radius, measured on the full population:

```sql
select count(*),
       count(*) filter (where open_trade_count + unpriced_trade_count > 0),
       max(open_trade_count + unpriced_trade_count)
from strategy_results_store;
-- 324 | 300 | 2296
```

300 of 324 rows understated the headline, by up to 2,296 trades. Fixed here rather
than filed because it is change-coupled: the new turnaround cell renders those same
two counts, so leaving it would have made one card contradict itself.

**2. Signed percentage on a composition.** `formatPct` carries
`signDisplay: "exceptZero"` and rendered the fire share as `+52.10%`.
`formatUnsignedPct` exists for exactly this — its docstring says *"Returns are
signed; compositions are not."* Caught by a test asserting the exact user-visible
string.

## Codex checkpoint 2

Found one P2, fixed in `8305c2ff`: `strategy_statistics` computes `losing_trades` as
`value < 0.0` **strictly** and stores no winning count, so
`trade_count - losing_trade_count` counts breakeven trades as wins. There is no
stored win count to substitute — adding one is a metric-set change and
populate-forward-only — so the label now states what the arithmetic actually is
("Not lost", "N of M not at a loss") rather than reporting a figure we do not have.
This is the #2602 item 5 posture: never substitute.

## Change-coupled FE-QA (`/strategies`, real page, real data)

Walked the running dev stack at `8305c2ff`, dev session minted directly (the old
`dev_browser_session.py` is gone).

- All four cards render; every blank names its reason. Rendered values:
  `52.10% / 0.00% / 0.39% / 3.40%` fires, all `1 scan day — needs a span`, all
  `Not measured · Result version criterion7-v1`.
- **Figure spot-checked against the API for the representative arm**
  (`worst_case` + `masked`, `primary-2022-plus`): page shows `21.58%` and
  `126,005 of 583,848 not at a loss`; API gives `trade_count 583848`,
  `losing_trade_count 457843` → `126,005 / 583,848 = 21.58%`. Exclusions
  `2,253 open, 26 unpriced` match exactly.
- **Layout integrity** on a 1400px-tall viewport, scrolled to the bottom. ⚠ The real
  scroller is `MAIN.flex-1.overflow-auto`, not `document.scrollingElement` — measuring
  the latter reports `scrollHeight === innerHeight` and says nothing. On the real
  scroller: `scrollHeight 2149`, content bottom `2125`, **24px** dead space, i.e.
  container padding, not an #1858-class void.
- Dark mode clean; no console errors.

## Security model

Not applicable. Read-only additions to an already-authenticated overview endpoint
(four columns the same query already selected) plus presentational frontend. No new
input, no new write path, no change to authorisation.

## Not done

The holding-period columns stay null on all 324 stored rows, permanently. They
populate **forward only** — backfilling means re-running the backtests, which mints
results under current pins and charges the trial register (#2599/#2616). That is not
something a migration or an unattended run may open. The cells fill as backtests run,
and until then correctly read "not measured for this result version".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
