### PR TITLE
feature(#2603): record the core rebalance verdict, including the ones that cannot be stored

### DIFF
--- a/app/services/strategy_core_allocator.py
+++ b/app/services/strategy_core_allocator.py
@@ -3,13 +3,16 @@
 Mandate plus observed sleeve state in, one verdict out.  Pure: no connection, no
 clock, no broker, no persistence.
 
-⚠ This module AUTHORISES NOTHING and has NO CALLER.  It is the first reader of
-``strategy_core_mandate_events`` -- which is what item 1's spec said item 3 would
-be -- but nothing calls ``evaluate_core_rebalance``, and no verdict it returns
-causes anything to happen.  #2437's R4 comment records *a control on a path the
-decision does not take* seven times over, so the state is named here rather than
-left to be inferred.  Its caller is item 3's execution half, which needs the
-operator-attended session #2603 reserves.
+⚠ This module AUTHORISES NOTHING, and that has not changed -- but "has NO CALLER",
+which this docstring said until #2684, has.  ``record_core_rebalance_intent``
+now calls ``evaluate_core_rebalance`` and stores the verdict in
+``strategy_core_rebalance_intents``.  That table is itself read by nothing and
+referenced by nothing, so no verdict returned here still causes anything to
+happen; the chain is one link longer and equally inert.  #2437's R4 comment
+records *a control on a path the decision does not take* seven times over, so the
+state is named here rather than left to be inferred, and re-stated each time it
+moves.  The acting caller is item 3's executor, which needs the operator-attended
+session #2603 reserves.
 
 The verdict is emphatically NOT an eligibility finding: item 2 owns the proof that
 the core instrument is the underlying product and not a CFD, and has no table yet.
@@ -35,6 +38,30 @@ from app.services.strategy_core_mandate import (
 )
 
 CoreRebalanceAction = Literal["hold", "buy_core", "sell_core", "refused"]
+
+#: The closed vocabulary of reasons a verdict can carry.  Declared as a `Literal`
+#: rather than left as `str` so it is a SINGLE SOURCE and not a convention: every
+#: `return "..."` site below is checked against it by pyright, so a new code
+#: cannot be introduced without appearing here.
+#:
+#: ⚠ `sql/348`'s `reason_code` CHECK must list exactly these, and cannot import
+#: them.  `test_the_migration_reason_codes_match_the_allocator_vocabulary` binds
+#: the two in both directions -- which is the enforcement, since a stored value
+#: the allocator can produce but the column refuses is an unwritable verdict, and
+#: the trap that class of defect causes is the one this table was shaped around.
+CoreRebalanceReasonCode = Literal[
+    "core_mandate_absent",
+    "core_mandate_policy_unsupported",
+    "core_mandate_invalid",
+    "core_mandate_disabled",
+    "core_instrument_unset",
+    "sleeve_currency_mismatch",
+    "sleeve_instrument_mismatch",
+    "sleeve_valuation_invalid",
+    "broker_minimum_invalid",
+    "core_sleeve_empty",
+    "below_min_rebalance_amount",
+]
 
 # One quantum of the NUMERIC(18,6) amount shape.  Rounding a rebalance DOWN leaves
 # a residual strictly below this, and `min_rebalance_amount > 0` on the same column
@@ -75,7 +102,7 @@ class CoreRebalanceDecision:
     """One rebalance verdict, carrying the arithmetic that produced it."""
 
     action: CoreRebalanceAction
-    reason_code: str | None
+    reason_code: CoreRebalanceReasonCode | None
     amount: Decimal
     core_pct: Decimal | None
     target_pct: Decimal | None
@@ -92,7 +119,7 @@ class CoreRebalanceDecision:
     three."""
 
 
-def _refused(reason_code: str) -> CoreRebalanceDecision:
+def _refused(reason_code: CoreRebalanceReasonCode) -> CoreRebalanceDecision:
     return CoreRebalanceDecision(
         action="refused",
         reason_code=reason_code,
@@ -108,7 +135,7 @@ def _refused(reason_code: str) -> CoreRebalanceDecision:
     )
 
 
-def _mandate_refusal(mandate: CoreMandate | None) -> str | None:
+def _mandate_refusal(mandate: CoreMandate | None) -> CoreRebalanceReasonCode | None:
     """The mandate half of the precedence order, or None when it is usable.
 
     Order matters and is a construction choice: an unsupported policy version is
@@ -146,7 +173,9 @@ def _mandate_refusal(mandate: CoreMandate | None) -> str | None:
     return None
 
 
-def _state_refusal(mandate: CoreMandate, state: CoreSleeveState, broker_minimum: Decimal | None) -> str | None:
+def _state_refusal(
+    mandate: CoreMandate, state: CoreSleeveState, broker_minimum: Decimal | None
+) -> CoreRebalanceReasonCode | None:
     """The state half of the precedence order, or None when it is usable."""
     if state.currency.strip().upper() != mandate.base_currency:
         # Otherwise the allocator weighs two currencies as if they were one.  #2363
@@ -260,7 +289,7 @@ def evaluate_core_rebalance(
     def _decide(
         action: CoreRebalanceAction,
         amount: Decimal,
-        reason_code: str | None,
+        reason_code: CoreRebalanceReasonCode | None,
         resulting_core_pct: Decimal,
     ) -> CoreRebalanceDecision:
         return CoreRebalanceDecision(
@@ -315,6 +344,7 @@ def evaluate_core_rebalance(
 __all__ = [
     "CoreRebalanceAction",
     "CoreRebalanceDecision",
+    "CoreRebalanceReasonCode",
     "CoreSleeveState",
     "evaluate_core_rebalance",
 ]

--- a/app/services/strategy_core_rebalance_intent.py
+++ b/app/services/strategy_core_rebalance_intent.py
@@ -50,6 +50,11 @@ from app.services.strategy_core_mandate import (
 _MAX_AMOUNT: Final = Decimal(1).scaleb(AMOUNT_PRECISION - AMOUNT_PLACES)
 _AMOUNT_QUANTUM: Final = Decimal(1).scaleb(-AMOUNT_PLACES)
 
+#: The observed-currency column's length bound, mirroring ``sql/348``.  A value
+#: over it is not an observation worth keeping verbatim; it is a caller bug, and
+#: the reason code still records that the currency was the thing wrong with it.
+_CURRENCY_LIMIT: Final = 16
+
 #: The INSERT column list, in order.  ⚠ ONE tuple, from which both the column list
 #: and the ``%(name)s`` block are generated, because #2623 shipped a value into the
 #: wrong block by maintaining those two lists (and a reader tuple) separately:
@@ -120,6 +125,27 @@ def _storable_or_none(value: Decimal) -> Decimal | None:
     return value.quantize(_AMOUNT_QUANTUM, rounding=ROUND_DOWN)
 
 
+def _storable_currency_or_none(value: str) -> str | None:
+    """The observed currency in the column's shape, or None when it has none.
+
+    The same rule as ``_storable_or_none``, on the column where it is easiest to
+    forget it applies. ``_state_refusal`` compares
+    ``state.currency.strip().upper()`` to the mandate's base currency, so a BLANK
+    or absurdly long observed currency is a reachable
+    ``sleeve_currency_mismatch`` -- and storing it into a NOT NULL non-blank
+    column would make that refusal the one row that cannot be written.
+
+    Not stripped or upper-cased on the way in: what was OBSERVED is the evidence,
+    and normalising it here would hide the difference between a caller sending
+    ``"usd"`` and one sending ``" USD "``.
+    """
+    if not value.strip():
+        return None
+    if len(value) > _CURRENCY_LIMIT:
+        return None
+    return value
+
+
 def record_core_rebalance_intent(
     conn: psycopg.Connection[Any],
     *,
@@ -153,7 +179,7 @@ def record_core_rebalance_intent(
         "allocator_policy_version": CORE_MANDATE_POLICY_VERSION,
         "recorded_by": recorded_by,
         "core_instrument_id": state.core_instrument_id,
-        "currency": state.currency,
+        "currency": _storable_currency_or_none(state.currency),
         "core_market_value": _storable_or_none(state.core_market_value),
         "cash_balance": _storable_or_none(state.cash_balance),
         "state_as_of": state.as_of,

--- a/app/services/strategy_core_rebalance_intent.py
+++ b/app/services/strategy_core_rebalance_intent.py
@@ -1,0 +1,187 @@
+"""Persist one core/cash rebalance evaluation (#2603 item 3, execution half, step 1).
+
+`evaluate_core_rebalance` is pure and, until this module, had no caller.  This is
+that caller: load the live mandate, evaluate against an observed sleeve, write one
+append-only row.
+
+⚠⚠ AUTHORISES NOTHING, and mechanically so rather than by promise: no table has a
+foreign key to ``strategy_core_rebalance_intents`` and no other module reads it, so
+no code path can turn a row here into an order.  ``tests/test_core_rebalance_intent_
+has_no_readers.py`` asserts both halves.  The reading side arrives with the slice
+that adds the trade linkage and the position-manager change together -- in that
+order deliberately, because a writable core trade the manager cannot see is worse
+than no core trade at all (#2437's standing pattern).
+
+⚠ What this does NOT provide, so it is an owed obligation rather than a silence:
+no in-flight suppression (the allocator is stateless and will re-recommend a trade
+already in flight), no expiry, and no eligibility proof -- ``sql/346``'s gate is
+write-time on ``configure_core_mandate`` and explicitly not an execution control.
+The executor re-proves at submission, bounds ``evaluated_at``, and keys one trade
+per intent.
+
+Spec: ``docs/proposals/ta/2026-08-14-core-rebalance-intent.md``
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import ROUND_DOWN, Decimal
+from typing import Any, Final
+
+import psycopg
+
+from app.services.strategy_core_allocator import (
+    CoreRebalanceDecision,
+    CoreSleeveState,
+    evaluate_core_rebalance,
+)
+from app.services.strategy_core_mandate import (
+    AMOUNT_PLACES,
+    AMOUNT_PRECISION,
+    CORE_MANDATE_POLICY_VERSION,
+    load_core_mandate,
+)
+
+#: Exclusive magnitude bound of the NUMERIC(18,6) amount shape: 12 integer digits.
+#: Deliberately the SAME bound ``_state_refusal`` applies to each sleeve component,
+#: which is what makes "a non-refused verdict is always storable" true by
+#: construction rather than by hope.
+_MAX_AMOUNT: Final = Decimal(1).scaleb(AMOUNT_PRECISION - AMOUNT_PLACES)
+_AMOUNT_QUANTUM: Final = Decimal(1).scaleb(-AMOUNT_PLACES)
+
+#: The INSERT column list, in order.  ⚠ ONE tuple, from which both the column list
+#: and the ``%(name)s`` block are generated, because #2623 shipped a value into the
+#: wrong block by maintaining those two lists (and a reader tuple) separately:
+#: psycopg binds by NAME, which makes the order feel irrelevant, but the order that
+#: matters is against the column list.  Adding a column here cannot desynchronise
+#: them.
+_INTENT_COLUMNS: Final[tuple[str, ...]] = (
+    "core_mandate_event_id",
+    "allocator_policy_version",
+    "recorded_by",
+    "core_instrument_id",
+    "currency",
+    "core_market_value",
+    "cash_balance",
+    "state_as_of",
+    "action",
+    "reason_code",
+    "amount",
+    "core_pct",
+    "target_pct",
+    "lower_pct",
+    "upper_pct",
+    "effective_floor",
+    "floor_source",
+    "reserve_breached",
+    "reserve_margin_pct",
+)
+
+_INSERT_INTENT: Final = (
+    "INSERT INTO strategy_core_rebalance_intents ("
+    + ", ".join(_INTENT_COLUMNS)
+    + ") VALUES ("
+    + ", ".join(f"%({column})s" for column in _INTENT_COLUMNS)
+    + ") RETURNING core_rebalance_intent_id, evaluated_at"
+)
+
+
+@dataclass(frozen=True)
+class CoreRebalanceIntent:
+    """One stored evaluation: the verdict, plus where and when it landed."""
+
+    core_rebalance_intent_id: int
+    evaluated_at: datetime
+    core_mandate_event_id: int | None
+    decision: CoreRebalanceDecision
+
+
+def _storable_or_none(value: Decimal) -> Decimal | None:
+    """The observed value in the column's shape, or None when it has none.
+
+    NULL is not "missing" here -- it is "the observation could not be represented
+    in NUMERIC(18,6), and ``reason_code`` says what was wrong with it".  The
+    refusals that produce such a value (``sleeve_valuation_invalid``, and the
+    currency/instrument mismatches that are checked BEFORE it) are precisely the
+    ones whose evidence would otherwise be the single row that cannot be written.
+
+    Rounding rather than refusing on excess SCALE is the deliberate half.
+    ``_state_refusal`` bounds finiteness and magnitude but says nothing about
+    decimal places, so an ordinary broker valuation carrying nine of them reaches
+    a perfectly valid ``buy_core`` -- refusing it would make a successful verdict
+    unstorable, which is the bug this function exists to avoid, inverted.
+    ``ROUND_DOWN`` matches the allocator's own rounding direction.
+    """
+    if not value.is_finite():
+        return None
+    if abs(value) >= _MAX_AMOUNT:
+        return None
+    return value.quantize(_AMOUNT_QUANTUM, rounding=ROUND_DOWN)
+
+
+def record_core_rebalance_intent(
+    conn: psycopg.Connection[Any],
+    *,
+    state: CoreSleeveState,
+    recorded_by: str,
+) -> CoreRebalanceIntent:
+    """Evaluate the live mandate against ``state`` and store the verdict.
+
+    Writes inside the caller's transaction and does not commit: the evaluation and
+    its record are one fact, and a caller that has more to do in the same unit of
+    work must be able to roll both back together.
+
+    A refusal is a RETURNED verdict, never a raise -- the allocator's own posture,
+    so a caller never has to catch in order to learn that the mandate is disabled.
+
+    ⚠ ``broker_minimum`` is deliberately not a parameter, though
+    ``evaluate_core_rebalance`` accepts one.  This slice performs no broker I/O and
+    so cannot SOURCE a minimum; accepting one would store a caller assertion with
+    no provenance and no record of which provider rule was applied -- and whether
+    eToro's ``min_position_amount`` even governs an incremental buy or a partial
+    sell is unsettled (the allocator's docstring flags it).  The executor holds the
+    eligibility response and can answer it with evidence.  Consequence, so it is
+    not later read as a defect: ``floor_source`` can only be ``mandate`` here, and
+    ``broker_minimum_invalid`` is unreachable.
+    """
+    mandate = load_core_mandate(conn)
+    decision = evaluate_core_rebalance(mandate, state)
+
+    params: dict[str, Any] = {
+        "core_mandate_event_id": None if mandate is None else mandate.event_id,
+        "allocator_policy_version": CORE_MANDATE_POLICY_VERSION,
+        "recorded_by": recorded_by,
+        "core_instrument_id": state.core_instrument_id,
+        "currency": state.currency,
+        "core_market_value": _storable_or_none(state.core_market_value),
+        "cash_balance": _storable_or_none(state.cash_balance),
+        "state_as_of": state.as_of,
+        "action": decision.action,
+        "reason_code": decision.reason_code,
+        "amount": decision.amount,
+        "core_pct": decision.core_pct,
+        "target_pct": decision.target_pct,
+        "lower_pct": decision.lower_pct,
+        "upper_pct": decision.upper_pct,
+        "effective_floor": decision.effective_floor,
+        "floor_source": decision.floor_source,
+        "reserve_breached": decision.reserve_breached,
+        "reserve_margin_pct": decision.reserve_margin_pct,
+    }
+    row = conn.execute(_INSERT_INTENT, params).fetchone()
+    if row is None:
+        raise RuntimeError("strategy_core_rebalance_intents INSERT did not return a row")
+
+    return CoreRebalanceIntent(
+        core_rebalance_intent_id=int(row[0]),
+        evaluated_at=row[1],
+        core_mandate_event_id=None if mandate is None else mandate.event_id,
+        decision=decision,
+    )
+
+
+__all__ = [
+    "CoreRebalanceIntent",
+    "record_core_rebalance_intent",
+]

--- a/docs/proposals/ta/2026-08-14-core-rebalance-intent.md
+++ b/docs/proposals/ta/2026-08-14-core-rebalance-intent.md
@@ -1,0 +1,253 @@
+# The core rebalance intent record (#2603 scope item 3, execution half — step 1)
+
+`evaluate_core_rebalance` is pure and has no caller. This slice gives it one, and gives
+the verdict somewhere durable to land: `strategy_core_rebalance_intents`, the
+mandate-driven analogue of `strategy_entry_preflights`.
+
+⚠ **It authorises nothing and submits nothing.** No broker call, no order, no position,
+no trade row. See "What this does NOT do" for why that is mechanical here and not a
+promise.
+
+## Why the queue's description of the blocker was wrong
+
+#2437's R4 comment and #2603's own prior note describe item 3's execution half as gated
+by *"the core position class (`sql/287:116` / `strategy_position_manager.py:816-817`
+block a stop-less, take-profit-less holding)"* — i.e. two CHECK-shaped exemptions.
+
+That is not the binding constraint. `sql/287` declares, and the applied dev schema
+confirms:
+
+| column | nullable |
+| --- | --- |
+| `strategy_entry_preflights.signal_id` (also the PK) | NO |
+| `strategy_funding_decisions.signal_id` | NO |
+| `strategy_trades.funding_decision_id` | NO (also UNIQUE) |
+
+and `strategy_position_manager.py:279-283` is an INNER JOIN through all three. A
+mandate-driven holding has no `signal_id`, so it cannot be written at all — and if the
+two CHECKs were exempted, it would be **dropped by the join rather than exempted by the
+manager**: no age-out, no reconcile, no close path, while looking managed.
+
+## The design decision: an exclusive arc, not a sibling path
+
+Two options were on the issue. Both are rejected in their stated form.
+
+**Option 1 — synthesise a `strategy_signals` row per rebalance.** Rejected, and *not*
+for the reason recorded. The prior note said `strategy_signal_daily_counts` "is populated
+from `strategy_signals` verdicts", so a synthetic signal would contaminate #2623 gap 2's
+fire-rate denominators. **That mechanism is false.** The census is written by
+`strategy_observation_storage.py:148` straight from scan observations, and
+`signal_ledger.py:296` is the only `INSERT INTO strategy_signals` **in this repository**
+(the claim is a grep over our own writers, which is the population for it — it says
+nothing about hand-run SQL). They are two writers off one scan, not a derivation, so a
+synthetic signal would not reach the census.
+
+The real objection is semantic, and it is the ticket's own. #2603 scope clause 5:
+*"**Explicitly NO alpha input**: reads mandate + current positions only; never reads
+`strategy_signals`."* The clause separates two populations — signal-derived decisions and
+mandate-derived ones — and writing a rebalance into the signal table merges them from the
+other side, defeating the separation the clause exists to create. Every downstream
+consumer of `strategy_signals` (outcome attribution, the live gate, monitoring) would
+then have to re-separate them by a predicate none of them currently carries.
+
+The NOT NULL columns are a *symptom* of that, not the argument: `strategy_id`,
+`strategy_version`, `signal_bar_date`, `signal_kind`, `universe` and
+`input_rule_set_versions` are all required and none has a mandate-side meaning, so every
+one would be a fabricated value in an audit table.
+
+**Option 2 — a sibling ownership path with its own manager pass.** Rejected as stated.
+The objection is narrower than "two managers": separate *selection* need not duplicate
+management logic, and a shared trades table does not by itself guarantee one lifecycle.
+What a separate key does guarantee is that **every existing query that reaches a position
+through `strategy_trades` must be dual-written** — measured this run, that is five
+modules (`strategy_position_manager`, `strategy_paper_executor`, `strategy_control_plane`,
+`strategy_monitoring`, `strategy_live_gate`) plus `app/api/strategies.py`. Each one that
+is missed is a core position invisible to reconciliation, gating or status, which is the
+same failure the exemption produced.
+
+**Adopted: one exclusive arc.** `strategy_trades.funding_decision_id` becomes nullable
+and gains a sibling `core_rebalance_intent_id`, with exactly one of the two non-null.
+Consumers that must see both arms then change by relaxing a join rather than by acquiring
+a second query, and one that is missed fails loudly on a NULL rather than silently on an
+absent row.
+
+⚠ **The arc is NOT in this slice.** It is inert without the manager change and dangerous
+without it — it would make exactly the invisible-but-writable core trade this document
+opens by rejecting. Arc and manager land together in the next slice, against
+`strategy_core_rebalance_intents` as the FK target, which is why the intent record comes
+first.
+
+## Source rule
+
+The record's *content* is fixed by `CoreRebalanceDecision`, which
+`docs/proposals/ta/2026-08-13-core-cash-allocator.md` already sources (band-boundary
+targeting from Leland 2000, no-trade region from Constantinides 1986 / Davis & Norman
+1990). Nothing is re-derived here: this slice stores the fields that type already has,
+one column each, and adds no arithmetic.
+
+Three treatment decisions are this document's own and are fixed **by construction**, since
+no external rule governs any of them:
+
+- **Append-only, one row per evaluation, including holds and refusals.** Same posture as
+  `strategy_core_eligibility_proofs` (`sql/346`): a verdict is evidence. Storing only
+  actionable verdicts would make "the mandate was evaluated and declined to trade"
+  indistinguishable from "the mandate was never evaluated" — and a core sleeve that has
+  correctly held for a month is the normal case, so the silent state would be the common
+  one.
+- **The governing mandate revision is stored as an FK to `strategy_core_mandate_events`,
+  not copied.** That table is already append-only and versioned, so the join is lossless;
+  copying `core_target_pct` and friends would create a second place for them to disagree.
+  The *derived* band edges (`target_pct`, `lower_pct`, `upper_pct`) ARE stored, because
+  they are the allocator's output and reconstructing them would re-run its arithmetic to
+  audit its arithmetic.
+- **The observed state inputs are stored as observed, with no FK and no coercion** — see
+  "The unstorable-input trap" below, which is the reason this needed deciding at all.
+
+## The unstorable-input trap **[by construction]**
+
+`_state_refusal` refuses `sleeve_valuation_invalid` on a component that is non-finite,
+negative, or `>= _MAX_AMOUNT` (10^12), and `sleeve_currency_mismatch` /
+`sleeve_instrument_mismatch` are checked **before** it — so a refusal row can carry a
+`Decimal("NaN")` or a 10^30 valuation.
+
+Naively storing the three state inputs into `NUMERIC(18,6)` therefore fails on exactly
+the refusals that exist to catch an unrepresentable valuation: the INSERT raises
+`numeric field overflow` and the evidence for the failure is the one row that cannot be
+written. Another instance of #2437's standing pattern — *the control cannot express a
+state the system can reach*.
+
+Construction: **`core_market_value` and `cash_balance` are NULLABLE, and NULL means "the
+observed value was not representable in this column's shape; the reason code says what
+was wrong with it".** Enforceable half: a NULL in either column implies
+`action = 'refused'`, because every non-refused path has already passed `_state_refusal`
+and is therefore storable. That is a CHECK, not a comment.
+
+`core_instrument_id` is stored as a plain `BIGINT` with **no FK to `instruments`**, for
+the same reason: on `sleeve_instrument_mismatch` the observed id is whatever the caller
+supplied and need not resolve. It is an observed input, not a resolved reference.
+
+## Contract
+
+### Writer
+
+```python
+record_core_rebalance_intent(
+    conn, *, state: CoreSleeveState, recorded_by: str,
+) -> CoreRebalanceIntent
+```
+
+Loads the live mandate via `load_core_mandate`, calls `evaluate_core_rebalance`, inserts
+one row inside the caller's transaction, and returns it with its id. Pure DB — no broker,
+no clock beyond `now()`.
+
+A refusal is a returned verdict, not a raise — the allocator's own posture, so a caller
+never has to catch to learn the mandate is disabled.
+
+⚠ **`broker_minimum` is deliberately NOT a parameter of this writer**, though the
+allocator accepts one. This slice has no broker I/O, so it has no way to *source* a
+minimum; accepting one would store a caller assertion with no provenance and no record of
+which provider rule was applied. The allocator's own docstring already flags that whether
+eToro's `min_position_amount` governs an incremental buy or a partial sell is unsettled.
+The executor holds the eligibility response and can answer it with evidence; this writer
+passes `None`, which the allocator defines as *the caller has no applicable minimum to
+supply*. Consequence, stated so it is not read as a finding: `floor_source` can only be
+`'mandate'` in this slice, and `broker_minimum_invalid` is unreachable. The column and
+the enum still admit both, because the executor will produce them.
+
+### Stored columns
+
+`core_rebalance_intent_id`, `evaluated_at`, `core_mandate_event_id`,
+`allocator_policy_version`, `recorded_by`; the observed state
+(`core_instrument_id`, `core_market_value`, `cash_balance`, `currency`, `state_as_of`);
+and all **eleven** `CoreRebalanceDecision` fields — `action`, `reason_code`, `amount`,
+and the **eight** derived ones (`core_pct`, `target_pct`, `lower_pct`, `upper_pct`,
+`effective_floor`, `floor_source`, `reserve_breached`, `reserve_margin_pct`).
+
+⚠ `allocator_policy_version` is `CORE_MANDATE_POLICY_VERSION` — the version **this
+evaluation ran under**, which is always ours and always known. The *mandate's* own
+`policy_version` is on the event row and is deliberately not copied: on
+`core_mandate_policy_unsupported` the two differ, and one column called `policy_version`
+could not say which it held.
+
+### Constraints **[by construction]**
+
+Every equality below whose left side is nullable is written `IS NOT DISTINCT FROM`.
+`docs/review-prevention-log.md` records this trap twice in eight days (#2679
+`settlement_type = 'real'`, #2602 `sql/341` `currency = 'USD'`): a CHECK passes on NULL,
+so `col = 'x'` does not require `col = 'x'`, and the constraint admits precisely the
+omission it was written to catch.
+
+1. `action IN ('hold', 'buy_core', 'sell_core', 'refused')`.
+2. `reason_code` is a closed enum of the allocator's eleven codes:
+   `core_mandate_absent`, `core_mandate_policy_unsupported`, `core_mandate_invalid`,
+   `core_mandate_disabled`, `core_instrument_unset`, `sleeve_currency_mismatch`,
+   `sleeve_instrument_mismatch`, `sleeve_valuation_invalid`, `broker_minimum_invalid`,
+   `core_sleeve_empty`, `below_min_rebalance_amount`.
+3. `refused` ⟺ `reason_code IS NOT NULL` **and** `amount = 0` **and** all eight derived
+   fields are NULL. A refusal computed no weights, so a non-NULL derived field on a
+   refusal is a writer bug and not a value judgement.
+4. `hold` ⟹ `amount = 0` and all eight derived fields NOT NULL. ⚠ **A hold MAY carry a
+   `reason_code`, and it is not an error**: `strategy_core_allocator.py:303` returns
+   `_decide("hold", _ZERO, "below_min_rebalance_amount", core_pct)` when the gap to the
+   band edge is under the floor. Constrained to that one code — no other code can reach
+   a hold.
+5. `buy_core` / `sell_core` ⟹ `amount > 0`, `reason_code IS NULL`, all eight derived
+   fields NOT NULL.
+6. `floor_source IN ('mandate', 'broker')`, NULL exactly when `action = 'refused'`
+   (covered by constraint 3's derived-field clause; named because it is the one derived
+   field that is not numeric).
+7. Band ordering, on the non-refused arm: `lower_pct <= target_pct <= upper_pct` and
+   `effective_floor > 0`. Both hold by construction in the allocator
+   (`lower = target - band`, `upper = target + band`, `band > 0`,
+   `min_rebalance_amount > 0`); the CHECK is what makes a writer that reorders the
+   positional column list fail loudly. ⚠ That is not hypothetical — #2623 shipped a
+   value into the wrong block through exactly that mistake, and an unrelated
+   all-or-nothing CHECK is what caught it.
+8. `core_mandate_event_id` is **nullable**, NULL exactly when
+   `reason_code = 'core_mandate_absent'` — the only verdict reachable with no mandate
+   row to point at. Every other refusal has a loaded `CoreMandate` and therefore an
+   `event_id`. FK `ON DELETE RESTRICT`, matching `sql/346`: an evidence row may not be
+   orphaned by deleting what it cites.
+9. `state_as_of <= evaluated_at`. A valuation from the future is a caller bug, and the
+   allocator holds no clock to catch it.
+10. `core_market_value IS NULL OR cash_balance IS NULL` ⟹ `action = 'refused'`
+    (the unstorable-input rule above).
+11. `currency`, `recorded_by`, `allocator_policy_version`: NOT NULL, length-bounded,
+    non-blank.
+
+One constraint test per NULL-bearing combination, not just the happy path — per the
+prevention-log generalisation that a test asserting only the happy path cannot see a
+NULL leak.
+
+## What this does NOT do
+
+- No broker I/O, no order, no position, no trade row, no API endpoint, no UI.
+- **"Authorises nothing" is mechanical here, not a promise.** No table has an FK to
+  `strategy_core_rebalance_intents` and no module reads it, so no code path can turn one
+  into an action. Both halves are asserted by a test rather than left to the docstring —
+  the same shape as the existing check that no file under `scripts/` reaches a mutating
+  broker method. The FK arrives in the next slice, together with the manager that makes
+  the resulting position visible.
+- **No in-flight suppression, and no expiry.** `evaluate_core_rebalance`'s docstring
+  warns it is stateless and will re-recommend a trade already in flight; repeated calls
+  against unchanged state produce several separately-shaped `buy_core` rows, and an
+  intent recorded a month ago reads identically to one recorded now. Nothing here fixes
+  that and nothing here can — suppression needs the trade linkage. **Owed by the next
+  slice, explicitly:** one trade per intent (UNIQUE) so one intent cannot be executed
+  twice; a "no open core trade" precondition so a second intent cannot be executed while
+  the first is live; and a freshness bound on `evaluated_at` at submission, so a stale
+  intent is not mistaken for current authority. Recorded as an obligation with an owner
+  rather than as a silence.
+- **No eligibility re-proof.** `sql/346`'s gate is write-time on `configure_core_mandate`
+  and explicitly not an execution control; an enabled mandate stays enabled after its
+  proof ages out. The executor re-proves at submission and must bind the intent to the
+  exact proof, account and credential pair it used. An intent carries no proof and must
+  not be read as carrying one.
+- **No position-lifecycle rules for the core arm.** Whether a core holding ages out,
+  ratchets, closes on mandate disable or instrument change, aggregates with an existing
+  holding of the same instrument, or handles partial lots — all unanswered, all owned by
+  the manager slice. The answer is expected to be "reconcile and close yes, stop/take and
+  age-out no", because a stop on a benchmark holding converts a mandate into a strategy;
+  that is a recommendation, not a decision, and it is not made here.
+
+Refs #2603. Refs #2437. Refs #2525.

--- a/docs/proposals/ta/2026-08-14-core-rebalance-intent.md
+++ b/docs/proposals/ta/2026-08-14-core-rebalance-intent.md
@@ -126,6 +126,31 @@ and is therefore storable. That is a CHECK, not a comment.
 the same reason: on `sleeve_instrument_mismatch` the observed id is whatever the caller
 supplied and need not resolve. It is an observed input, not a resolved reference.
 
+⚠ **`currency` is the same trap and the first draft walked straight into it** — caught by
+Codex at checkpoint 2, *after* the valuation columns had already been shaped for exactly
+this. `_state_refusal` compares `state.currency.strip().upper()` to the mandate's base
+currency, so a blank or over-long observed currency is a reachable
+`sleeve_currency_mismatch`; a `NOT NULL` non-blank column would have made that refusal
+the one row that cannot be written. It is nullable under the same rule. **Generalisation
+worth carrying: the trap is not about numeric overflow. It is that any column shaped to
+the VALID domain cannot hold the observation that was refused for being outside it —
+and a text column with a non-blank CHECK is that shape just as much as a `NUMERIC(18,6)`
+is.**
+
+The observed currency is stored **unnormalised** — not stripped, not upper-cased. What
+was observed is the evidence, and normalising would hide the difference between a caller
+sending `"USD"` and one sending `" usd "`.
+
+### `evaluated_at` is `clock_timestamp()`, not `now()` **[by construction]**
+
+Also Codex checkpoint 2. `now()` is **transaction** start time, so a writer called inside
+a transaction that opened before the sleeve was valued would stamp the evaluation earlier
+than the observation it evaluated — and the `state_as_of <= evaluated_at` CHECK would then
+reject a perfectly fresh snapshot for no reason but the caller's transaction boundary. The
+wall clock at insert is what "when this was evaluated" means. It stays a `DEFAULT` and
+never a parameter, per `sql/346`: a caller supplying its own evaluation time can backdate
+a verdict at will.
+
 ## Contract
 
 ### Writer
@@ -210,10 +235,15 @@ omission it was written to catch.
    orphaned by deleting what it cites.
 9. `state_as_of <= evaluated_at`. A valuation from the future is a caller bug, and the
    allocator holds no clock to catch it.
-10. `core_market_value IS NULL OR cash_balance IS NULL` ⟹ `action = 'refused'`
-    (the unstorable-input rule above).
-11. `currency`, `recorded_by`, `allocator_policy_version`: NOT NULL, length-bounded,
-    non-blank.
+10. A NULL in `core_market_value`, `cash_balance` **or** `currency` ⟹
+    `action = 'refused'` (the unstorable-observation rule above). All three are
+    representable on a non-refused path by construction, because `_state_refusal` has
+    already required the currency to match and both valuations to be finite and inside
+    the amount bound.
+11. `recorded_by` and `allocator_policy_version`: NOT NULL, length-bounded, non-blank —
+    unconditionally, because unlike the observation columns these are the writer's own
+    values and a blank one is a bug in us, not evidence about the caller. `currency` is
+    length-bounded and non-blank **when present**.
 
 One constraint test per NULL-bearing combination, not just the happy path — per the
 prevention-log generalisation that a test asserting only the happy path cannot see a

--- a/docs/review-prevention-log.md
+++ b/docs/review-prevention-log.md
@@ -4656,3 +4656,70 @@ with `verify_2598_preflight_quote_crosscheck.py --replay <fixture>`:
   its order is `_RESULT_COLUMNS`' and not a natural one);
   `tests/test_strategy_holdout_namespace.py`'s existing round-trip tests, which is what went
   red.
+
+### A column shaped to the VALID domain cannot store the observation that was refused for leaving it
+
+- First seen in: #2603 item 3 step 1 (2026-08-14), `sql/348_core_rebalance_intents.sql`.
+  Twice in one diff, on two different column types — which is why this is filed as its own
+  entry rather than as an instance of an overflow gotcha.
+- Symptom: `strategy_core_rebalance_intents` stores one row per rebalance evaluation,
+  **including refusals**, because a verdict is evidence. But `_state_refusal` refuses
+  `sleeve_valuation_invalid` on a component that is non-finite or `>= 10^12`, and
+  `sleeve_currency_mismatch` on a blank or over-long currency. Storing those observations
+  into `NUMERIC(18,6) NOT NULL` and `TEXT NOT NULL CHECK (btrim(currency) <> '')`
+  respectively makes the INSERT raise — so the evidence for an unrepresentable observation
+  is exactly the row that cannot be written. #2437's standing pattern: *the control cannot
+  express a state the system can reach.*
+- Why it is easy, and why catching it once is not enough: the numeric case reads as an
+  overflow bug and gets fixed as one. The **text** case is the same defect and does not look
+  like it — a non-blank CHECK feels like hygiene, not like a domain restriction. The first
+  draft here shaped the two valuation columns correctly for this exact reason and then wrote
+  `currency TEXT NOT NULL CHECK (btrim(currency) <> '')` twenty lines later. The trigger is
+  not "could this number overflow"; it is **"is this column shaped to the values I accept,
+  on a table that also stores the ones I reject".**
+- What caught it, and what did not: the numeric half was caught by writing the spec's
+  refusal-storage section — i.e. by thinking about it in advance. The currency half survived
+  that, survived self-review, survived `ruff`/`pyright`, and survived a 48-case constraint
+  test suite that included `("blank_currency", {"currency": ""})` as a **rejection** case —
+  the test asserted the CHECK worked, which it did; nobody asked whether the writer could
+  reach it. Codex checkpoint 2 found it. **A constraint test that only asserts a bad value
+  is refused cannot see that a legitimate writer path produces that value.**
+- Prevention: for any table that stores refusals/rejections alongside accepted rows, list the
+  refusal reason codes and, for each, ask which observed column the refusal is ABOUT. Every
+  such column must be able to hold the value that triggered its own refusal — in practice
+  nullable, with `NULL` meaning "no representation in this column's shape; the reason code
+  says what was wrong" and an enforceable `NULL ⟹ refused` CHECK. Store observations
+  **unnormalised**; normalising on the way in hides the difference the refusal was about.
+  ⚠ Distinguish the writer's OWN fields (`recorded_by`, a policy version) — those stay
+  `NOT NULL` and non-blank unconditionally, because a blank one is a bug in us rather than
+  evidence about the caller.
+- Enforced in: this log; `sql/348_core_rebalance_intents.sql` (three nullable observation
+  columns with the reason stated at each, plus
+  `core_rebalance_intent_null_observation_implies_refused`);
+  `app/services/strategy_core_rebalance_intent.py::_storable_or_none` and
+  `_storable_currency_or_none`; `tests/test_2603_core_rebalance_intent_db.py`
+  (`test_an_unstorable_valuation_is_recorded_rather_than_lost`,
+  `test_a_nan_valuation_is_recorded_rather_than_raising`,
+  `test_an_unstorable_currency_is_recorded_rather_than_lost` — all three drive the REAL
+  writer, which is what the rejection-only cases could not do).
+
+### `now()` in a DEFAULT is transaction start time, and a freshness CHECK against it rejects fresh data
+
+- First seen in: #2603 item 3 step 1 (2026-08-14), `sql/348`, found by Codex checkpoint 2.
+- Symptom: `evaluated_at TIMESTAMPTZ NOT NULL DEFAULT now()` alongside
+  `CHECK (state_as_of <= evaluated_at)`. A writer called inside a transaction that opened
+  before the sleeve snapshot was taken stamps the evaluation at the **transaction's** start,
+  which is earlier than the observation it just evaluated — so the constraint rejects a
+  perfectly current snapshot for no reason but the caller's transaction boundary. The longer
+  the enclosing unit of work, the wider the window.
+- Why it is easy: `now()` reads as "the current time" and is the repo's habitual default. It
+  is only wrong where the value is compared against something the caller measured *during*
+  the same transaction — which is precisely what an as-of / observed-at column is.
+- Prevention: when a `DEFAULT now()` column is compared in a CHECK against a caller-supplied
+  timestamp, use `clock_timestamp()` (wall clock at insert) or `statement_timestamp()`.
+  Keep it a DEFAULT and never a parameter regardless — a caller supplying its own stamp can
+  backdate the record at will (`sql/346`'s rule). Test it by opening the transaction,
+  `SELECT pg_sleep(...)`, and inserting a row whose as-of falls between `now()` and
+  `clock_timestamp()`; assert `now() < clock_timestamp()` first so the test cannot go inert.
+- Enforced in: this log; `sql/348_core_rebalance_intents.sql`;
+  `tests/test_2603_core_rebalance_intent_db.py::test_a_snapshot_taken_after_the_transaction_opened_is_not_future_dated`.

--- a/sql/348_core_rebalance_intents.sql
+++ b/sql/348_core_rebalance_intents.sql
@@ -1,0 +1,216 @@
+-- 348_core_rebalance_intents.sql
+--
+-- #2603 item 3, execution half, step 1.  One durable record per core/cash
+-- rebalance EVALUATION -- the mandate-driven analogue of
+-- `strategy_entry_preflights`, which is signal-driven and cannot carry this.
+--
+-- ⚠⚠ THIS TABLE AUTHORISES NOTHING, and that is mechanical rather than a
+-- promise: no table has a foreign key to it and no module reads it, so no code
+-- path can turn a row into an action.  The reading side arrives in the next
+-- slice together with the position-manager change that makes the resulting
+-- position visible -- deliberately in that order, because a writable core trade
+-- the manager cannot see is worse than no core trade at all.
+--
+-- Why not a synthetic `strategy_signals` row instead: #2603 scope clause 5 says
+-- the core path "reads mandate + current positions only; never reads
+-- `strategy_signals`".  That clause separates two populations, and writing a
+-- rebalance into the signal table merges them from the other side -- every
+-- consumer of `strategy_signals` would then need a predicate none of them
+-- carries.  (Six of its columns are also NOT NULL with no mandate-side meaning,
+-- but that is the symptom, not the argument.)
+--
+-- APPEND-ONLY.  One row per evaluation, INCLUDING holds and refusals: a verdict
+-- is evidence, and a core sleeve correctly holding for a month is the normal
+-- case, so suppressing holds would make the common state indistinguishable from
+-- "never evaluated".  Same posture as `strategy_core_eligibility_proofs`
+-- (sql/346).
+--
+-- Spec: docs/proposals/ta/2026-08-14-core-rebalance-intent.md
+
+CREATE TABLE IF NOT EXISTS strategy_core_rebalance_intents (
+    core_rebalance_intent_id BIGSERIAL PRIMARY KEY,
+    -- DEFAULT now() and never a parameter: a caller supplying its own evaluation
+    -- time can backdate or extend a verdict at will (sql/346's rule, same reason).
+    evaluated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- The mandate revision that GOVERNED this evaluation, by reference and never
+    -- copied: `strategy_core_mandate_events` is already append-only and
+    -- versioned, so the join is lossless, and copying core_target_pct and friends
+    -- would create a second place for them to disagree.
+    --
+    -- NULLABLE, and NULL for exactly one verdict: `core_mandate_absent`, where
+    -- there is no revision to point at.  Every other refusal loaded a
+    -- `CoreMandate` and therefore has an event id.  Enforced below.
+    core_mandate_event_id    BIGINT
+                             REFERENCES strategy_core_mandate_events(core_mandate_event_id)
+                             ON DELETE RESTRICT,
+    -- The version THIS EVALUATION ran under -- always ours, always known.  The
+    -- mandate's own policy_version lives on the event row and is deliberately not
+    -- copied: on `core_mandate_policy_unsupported` the two differ, and one column
+    -- named `policy_version` could not say which of them it held.
+    allocator_policy_version TEXT NOT NULL CHECK (btrim(allocator_policy_version) <> ''
+                                                  AND length(allocator_policy_version) <= 64),
+    recorded_by              TEXT NOT NULL CHECK (btrim(recorded_by) <> ''
+                                                  AND length(recorded_by) <= 128),
+
+    ---------------------------------------------------------------------------
+    -- The observed sleeve, stored AS OBSERVED.
+    ---------------------------------------------------------------------------
+    -- No FK to `instruments`: on a `sleeve_instrument_mismatch` refusal the id is
+    -- whatever the caller supplied and need not resolve.  This is an observed
+    -- input, not a resolved reference.
+    core_instrument_id       BIGINT NOT NULL,
+    currency                 TEXT NOT NULL CHECK (btrim(currency) <> ''
+                                                  AND length(currency) <= 16),
+    -- ⚠⚠ NULLABLE, and the reason is the whole point.  `_state_refusal` refuses
+    -- `sleeve_valuation_invalid` on a component that is non-finite, negative or
+    -- >= 10^12, and the currency/instrument mismatches are checked BEFORE it --
+    -- so a refusal row can legitimately carry Decimal("NaN") or 10^30.  Storing
+    -- those into NUMERIC(18,6) raises `numeric field overflow`, which would make
+    -- the evidence for an unrepresentable valuation the one row that cannot be
+    -- written: the control unable to express a state the system reaches.
+    --
+    -- So NULL here means "the observed value was not representable in this
+    -- column's shape; reason_code says what was wrong with it".  The enforceable
+    -- half is the CHECK below -- a NULL implies `refused`, because every
+    -- non-refused path has already passed `_state_refusal` and is storable.
+    --
+    -- ⚠ A storable value with more than 6 decimal places is ROUNDED to fit, so a
+    -- stored input need not reproduce the stored output to the last place.  That
+    -- is immaterial at the 7th decimal of a currency valuation and is not a
+    -- refusal.
+    core_market_value        NUMERIC(18,6),
+    cash_balance             NUMERIC(18,6),
+    state_as_of              TIMESTAMPTZ NOT NULL,
+
+    ---------------------------------------------------------------------------
+    -- The verdict: every field of `CoreRebalanceDecision`, one column each.
+    ---------------------------------------------------------------------------
+    action                   TEXT NOT NULL
+                             CHECK (action IN ('hold', 'buy_core', 'sell_core', 'refused')),
+    -- Closed enum of the allocator's eleven codes.  `broker_minimum_invalid` is
+    -- unreachable until the executor supplies a broker minimum; admitted here
+    -- because that writer is the next slice, not because it can occur now.
+    reason_code              TEXT CHECK (reason_code IN (
+                                 'core_mandate_absent',
+                                 'core_mandate_policy_unsupported',
+                                 'core_mandate_invalid',
+                                 'core_mandate_disabled',
+                                 'core_instrument_unset',
+                                 'sleeve_currency_mismatch',
+                                 'sleeve_instrument_mismatch',
+                                 'sleeve_valuation_invalid',
+                                 'broker_minimum_invalid',
+                                 'core_sleeve_empty',
+                                 'below_min_rebalance_amount'
+                             )),
+    amount                   NUMERIC(18,6) NOT NULL CHECK (amount >= 0),
+    -- Computed percentages get the repo's computed-percentage shape
+    -- (NUMERIC(12,8), as `strategy_entry_preflights.account_drawdown_pct`).  The
+    -- band edges are mandate-derived and get the mandate's own NUMERIC(8,4), so
+    -- they store exactly rather than being re-rounded.
+    core_pct                 NUMERIC(12,8),
+    target_pct               NUMERIC(8,4),
+    lower_pct                NUMERIC(8,4),
+    upper_pct                NUMERIC(8,4),
+    effective_floor          NUMERIC(18,6),
+    floor_source             TEXT CHECK (floor_source IN ('mandate', 'broker')),
+    reserve_breached         BOOLEAN,
+    -- Signed: negative IS the breach.
+    reserve_margin_pct       NUMERIC(12,8),
+
+    ---------------------------------------------------------------------------
+    -- Shape, per action.  A CASE rather than an OR-of-implications: `action` is
+    -- NOT NULL and its enum is closed, so every row takes exactly one branch and
+    -- there is no arm a NULL can slip through.  ⚠ Every comparison inside a
+    -- branch is either IS [NOT] NULL or on a NOT NULL column -- a bare `col = x`
+    -- on a nullable column passes on NULL and would admit the omission the
+    -- constraint exists to catch (docs/review-prevention-log.md, #2679 and
+    -- sql/341).
+    ---------------------------------------------------------------------------
+    CONSTRAINT core_rebalance_intent_shape_matches_action CHECK (
+        CASE action
+            WHEN 'refused' THEN
+                -- A refusal computed no weights, so a non-NULL derived field is a
+                -- writer bug rather than a value judgement.
+                reason_code IS NOT NULL
+                AND amount = 0
+                AND core_pct IS NULL AND target_pct IS NULL AND lower_pct IS NULL
+                AND upper_pct IS NULL AND effective_floor IS NULL
+                AND floor_source IS NULL AND reserve_breached IS NULL
+                AND reserve_margin_pct IS NULL
+            WHEN 'hold' THEN
+                -- ⚠ A hold MAY carry a reason code and it is not an error:
+                -- strategy_core_allocator.py:303 returns a hold with
+                -- `below_min_rebalance_amount` when the gap to the band edge is
+                -- under the floor.  Constrained to that one code.
+                amount = 0
+                AND (reason_code IS NULL OR reason_code = 'below_min_rebalance_amount')
+                AND core_pct IS NOT NULL AND target_pct IS NOT NULL
+                AND lower_pct IS NOT NULL AND upper_pct IS NOT NULL
+                AND effective_floor IS NOT NULL AND floor_source IS NOT NULL
+                AND reserve_breached IS NOT NULL AND reserve_margin_pct IS NOT NULL
+                AND lower_pct <= target_pct AND target_pct <= upper_pct
+                AND effective_floor > 0
+            ELSE  -- buy_core / sell_core
+                amount > 0
+                AND reason_code IS NULL
+                AND core_pct IS NOT NULL AND target_pct IS NOT NULL
+                AND lower_pct IS NOT NULL AND upper_pct IS NOT NULL
+                AND effective_floor IS NOT NULL AND floor_source IS NOT NULL
+                AND reserve_breached IS NOT NULL AND reserve_margin_pct IS NOT NULL
+                AND lower_pct <= target_pct AND target_pct <= upper_pct
+                AND effective_floor > 0
+        END
+    ),
+    -- The band ordering above is true by construction in the allocator
+    -- (lower = target - band, upper = target + band, band > 0; floor is
+    -- min_rebalance_amount > 0 or a strictly greater broker minimum).  It is
+    -- constrained anyway because #2623 shipped a value into the wrong block by
+    -- appending columns at a different ordinal in the INSERT list, the
+    -- placeholder block and the reader tuple -- psycopg binds by NAME, so it
+    -- feels order-free, and an unrelated all-or-nothing CHECK is what caught it.
+
+    -- Exactly one verdict is reachable with no mandate row to cite.  Both sides
+    -- are non-NULL booleans, so `=` is safe; `IS NOT DISTINCT FROM` on the right
+    -- is what keeps a NULL reason_code from leaking through as unknown.
+    CONSTRAINT core_rebalance_intent_event_absent_only_when_mandate_absent CHECK (
+        (core_mandate_event_id IS NULL)
+        = (reason_code IS NOT DISTINCT FROM 'core_mandate_absent')
+    ),
+    -- An unstorable observed valuation implies a refusal (see above).
+    CONSTRAINT core_rebalance_intent_null_valuation_implies_refused CHECK (
+        (core_market_value IS NOT NULL AND cash_balance IS NOT NULL)
+        OR action = 'refused'
+    ),
+    -- A valuation from the future is a caller bug; the allocator holds no clock
+    -- and cannot catch it.
+    CONSTRAINT core_rebalance_intent_state_not_after_evaluation CHECK (
+        state_as_of <= evaluated_at
+    )
+);
+
+-- The read the next slice needs: the latest intent, and the latest ACTIONABLE
+-- intent, for the freshness bound the executor must apply.
+CREATE INDEX IF NOT EXISTS strategy_core_rebalance_intents_evaluated_at_idx
+    ON strategy_core_rebalance_intents (evaluated_at DESC);
+
+COMMENT ON TABLE strategy_core_rebalance_intents IS
+    'One durable record per core/cash rebalance evaluation (#2603 item 3). '
+    'Append-only; holds and refusals are stored exactly as trades are, because a '
+    'verdict is evidence. AUTHORISES NOTHING: nothing references it and nothing '
+    'reads it, and it carries no eligibility proof -- the executor re-proves at '
+    'submission. Provides no in-flight suppression and no expiry; both are owed '
+    'by the slice that adds the trade linkage.';
+
+COMMENT ON COLUMN strategy_core_rebalance_intents.core_market_value IS
+    'Observed core value, or NULL when the observed value was not representable '
+    'in NUMERIC(18,6) -- reason_code then says what was wrong with it. NULL '
+    'implies action = refused.';
+
+COMMENT ON COLUMN strategy_core_rebalance_intents.cash_balance IS
+    'Observed settled cash, or NULL when not representable -- see core_market_value.';
+
+COMMENT ON COLUMN strategy_core_rebalance_intents.allocator_policy_version IS
+    'The policy version THIS evaluation ran under (always ours). The mandate''s '
+    'own policy_version is on the referenced event row and differs on a '
+    'core_mandate_policy_unsupported verdict.';

--- a/sql/348_core_rebalance_intents.sql
+++ b/sql/348_core_rebalance_intents.sql
@@ -29,9 +29,16 @@
 
 CREATE TABLE IF NOT EXISTS strategy_core_rebalance_intents (
     core_rebalance_intent_id BIGSERIAL PRIMARY KEY,
-    -- DEFAULT now() and never a parameter: a caller supplying its own evaluation
-    -- time can backdate or extend a verdict at will (sql/346's rule, same reason).
-    evaluated_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- DEFAULT and never a parameter: a caller supplying its own evaluation time
+    -- can backdate or extend a verdict at will (sql/346's rule, same reason).
+    --
+    -- ⚠ `clock_timestamp()`, NOT `now()`.  `now()` is TRANSACTION start time, so a
+    -- writer called inside a transaction that opened before the sleeve was valued
+    -- would stamp an evaluation EARLIER than the observation it evaluated -- and
+    -- the `state_as_of <= evaluated_at` CHECK below would then reject a perfectly
+    -- fresh snapshot for no reason but the caller's transaction boundary.  The
+    -- wall clock at insert is what "when this was evaluated" means.
+    evaluated_at             TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
     -- The mandate revision that GOVERNED this evaluation, by reference and never
     -- copied: `strategy_core_mandate_events` is already append-only and
     -- versioned, so the join is lossless, and copying core_target_pct and friends
@@ -59,8 +66,16 @@ CREATE TABLE IF NOT EXISTS strategy_core_rebalance_intents (
     -- whatever the caller supplied and need not resolve.  This is an observed
     -- input, not a resolved reference.
     core_instrument_id       BIGINT NOT NULL,
-    currency                 TEXT NOT NULL CHECK (btrim(currency) <> ''
-                                                  AND length(currency) <= 16),
+    -- ⚠ NULLABLE for the SAME reason as the two valuations below, and the reason
+    -- is easy to miss on a text column.  `_state_refusal` compares
+    -- `state.currency.strip().upper()` to the mandate's base currency, so a BLANK
+    -- or absurdly long observed currency is refused as `sleeve_currency_mismatch`
+    -- -- and a NOT NULL non-blank CHECK here would then make that refusal the one
+    -- row that cannot be written, which is the exact trap the valuation columns
+    -- were shaped to avoid.
+    currency                 TEXT CHECK (currency IS NULL
+                                         OR (btrim(currency) <> ''
+                                             AND length(currency) <= 16)),
     -- ⚠⚠ NULLABLE, and the reason is the whole point.  `_state_refusal` refuses
     -- `sleeve_valuation_invalid` on a component that is non-finite, negative or
     -- >= 10^12, and the currency/instrument mismatches are checked BEFORE it --
@@ -177,9 +192,12 @@ CREATE TABLE IF NOT EXISTS strategy_core_rebalance_intents (
         (core_mandate_event_id IS NULL)
         = (reason_code IS NOT DISTINCT FROM 'core_mandate_absent')
     ),
-    -- An unstorable observed valuation implies a refusal (see above).
-    CONSTRAINT core_rebalance_intent_null_valuation_implies_refused CHECK (
-        (core_market_value IS NOT NULL AND cash_balance IS NOT NULL)
+    -- An unstorable OBSERVATION -- of either kind -- implies a refusal.  Every
+    -- non-refused path has already passed `_state_refusal`, which requires the
+    -- currency to match the mandate's and both valuations to be finite and inside
+    -- the amount bound, so all three are representable there by construction.
+    CONSTRAINT core_rebalance_intent_null_observation_implies_refused CHECK (
+        (core_market_value IS NOT NULL AND cash_balance IS NOT NULL AND currency IS NOT NULL)
         OR action = 'refused'
     ),
     -- A valuation from the future is a caller bug; the allocator holds no clock

--- a/tests/test_2603_core_rebalance_intent.py
+++ b/tests/test_2603_core_rebalance_intent.py
@@ -20,8 +20,8 @@ from pathlib import Path
 import pytest
 
 from app.services.strategy_core_rebalance_intent import (
-    _INTENT_COLUMNS,
     _INSERT_INTENT,
+    _INTENT_COLUMNS,
     _storable_or_none,
 )
 
@@ -95,9 +95,7 @@ def test_the_insert_column_list_and_placeholder_block_cannot_disagree() -> None:
     placeholders = re.search(r"VALUES \((.*?)\) RETURNING", _INSERT_INTENT, re.S)
     assert columns is not None and placeholders is not None
     assert [c.strip() for c in columns.group(1).split(",")] == list(_INTENT_COLUMNS)
-    assert [p.strip() for p in placeholders.group(1).split(",")] == [
-        f"%({column})s" for column in _INTENT_COLUMNS
-    ]
+    assert [p.strip() for p in placeholders.group(1).split(",")] == [f"%({column})s" for column in _INTENT_COLUMNS]
 
 
 def test_no_module_outside_the_writer_reads_the_intents_table() -> None:

--- a/tests/test_2603_core_rebalance_intent.py
+++ b/tests/test_2603_core_rebalance_intent.py
@@ -13,12 +13,15 @@ mutating broker method.
 
 from __future__ import annotations
 
+import ast
 import re
 from decimal import Decimal
 from pathlib import Path
+from typing import get_args
 
 import pytest
 
+from app.services.strategy_core_allocator import CoreRebalanceReasonCode
 from app.services.strategy_core_rebalance_intent import (
     _INSERT_INTENT,
     _INTENT_COLUMNS,
@@ -98,6 +101,36 @@ def test_the_insert_column_list_and_placeholder_block_cannot_disagree() -> None:
     assert [p.strip() for p in placeholders.group(1).split(",")] == [f"%({column})s" for column in _INTENT_COLUMNS]
 
 
+def _mentions_table_in_code(path: Path) -> bool:
+    """True when the table name appears in a string the module EXECUTES.
+
+    A plain substring scan also fires on a comment or a docstring that merely
+    names the table — which the next slice's manager change will certainly do
+    while still not reading it. ``ast`` drops ``#`` comments for free; docstrings
+    survive as ``Constant`` nodes, so they are subtracted explicitly by identity.
+
+    A SQL string and a docstring are the same node TYPE and differ only by
+    position, which is why this is positional rather than heuristic.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    docstrings = {
+        id(node.body[0].value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef)
+        and node.body
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    }
+    return any(
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and _TABLE in node.value
+        and id(node) not in docstrings
+        for node in ast.walk(tree)
+    )
+
+
 def test_no_module_outside_the_writer_reads_the_intents_table() -> None:
     """The enforceable half of "authorises nothing".
 
@@ -107,9 +140,7 @@ def test_no_module_outside_the_writer_reads_the_intents_table() -> None:
     and the position-manager change rather than on its own.
     """
     offenders = [
-        str(path)
-        for path in Path("app").rglob("*.py")
-        if str(path) != _WRITER and _TABLE in path.read_text(encoding="utf-8")
+        str(path) for path in Path("app").rglob("*.py") if str(path) != _WRITER and _mentions_table_in_code(path)
     ]
     assert offenders == [], (
         f"{_TABLE} gained a reader outside {_WRITER}: {offenders}. "
@@ -129,3 +160,34 @@ def test_no_table_references_the_intents_table() -> None:
         if re.search(rf"REFERENCES\s+{_TABLE}\b", path.read_text(encoding="utf-8"))
     ]
     assert referencing == [], f"a table now references {_TABLE}: {referencing}"
+
+
+def test_the_migration_reason_codes_match_the_allocator_vocabulary() -> None:
+    """The single source the ``reason_code`` CHECK cannot import.
+
+    SQL has no way to reference ``CoreRebalanceReasonCode``, so the migration
+    restates it — and a restatement drifts. This binds the two in BOTH
+    directions, which is what makes it enforcement rather than documentation:
+
+    * a code the allocator can return but the column refuses is an **unwritable
+      verdict**, the exact failure class this table was shaped around;
+    * a code the column admits but the allocator cannot produce is dead
+      vocabulary that a later reader will treat as reachable.
+
+    Not a tautology: the ``Literal`` is checked by pyright against every
+    ``return "..."`` site in the allocator, and the CHECK list is parsed from the
+    shipped migration file rather than re-typed here.
+    """
+    sql = Path("sql/348_core_rebalance_intents.sql").read_text(encoding="utf-8")
+    block = re.search(r"reason_code\s+TEXT CHECK \(reason_code IN \((.*?)\)\)", sql, re.S)
+    assert block is not None, "sql/348 no longer declares a reason_code IN (...) CHECK"
+    in_migration = set(re.findall(r"'([a-z_]+)'", block.group(1)))
+    in_allocator = set(get_args(CoreRebalanceReasonCode))
+
+    assert in_allocator - in_migration == set(), (
+        "the allocator can return codes sql/348 refuses, so those verdicts cannot "
+        f"be stored: {sorted(in_allocator - in_migration)}"
+    )
+    assert in_migration - in_allocator == set(), (
+        f"sql/348 admits codes the allocator cannot produce: {sorted(in_migration - in_allocator)}"
+    )

--- a/tests/test_2603_core_rebalance_intent.py
+++ b/tests/test_2603_core_rebalance_intent.py
@@ -1,0 +1,133 @@
+"""#2603 item 3 step 1 — the pure half of the rebalance-intent writer.
+
+Two things are covered here and nowhere else: ``_storable_or_none``'s asymmetry
+(round on scale, NULL on magnitude/finiteness), and the claim in the module and
+migration headers that this table AUTHORISES NOTHING.
+
+⚠ The second is a test rather than a docstring on purpose. "Nothing reads it" is
+the only thing making a durable ``buy_core`` record safe to ship before an
+executor exists, and a promise in prose cannot fail when someone adds a reader.
+Same shape as the existing check that no file under ``scripts/`` reaches a
+mutating broker method.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from app.services.strategy_core_rebalance_intent import (
+    _INTENT_COLUMNS,
+    _INSERT_INTENT,
+    _storable_or_none,
+)
+
+_WRITER = "app/services/strategy_core_rebalance_intent.py"
+_TABLE = "strategy_core_rebalance_intents"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Exact at six places: unchanged.
+        (Decimal("1234.567890"), Decimal("1234.567890")),
+        (Decimal("0"), Decimal("0.000000")),
+        # More scale than the column holds: ROUNDED, not refused. `_state_refusal`
+        # bounds finiteness and magnitude but says nothing about decimal places,
+        # so a nine-place broker valuation reaches a perfectly valid `buy_core` —
+        # refusing it would make a SUCCESSFUL verdict unstorable.
+        (Decimal("1234.567890123"), Decimal("1234.567890")),
+        # ROUND_DOWN, matching the allocator's own direction — toward zero on
+        # both signs, so neither is quietly enlarged.
+        (Decimal("-1.9999999"), Decimal("-1.999999")),
+        # Negative is storable and IS the evidence: `_state_refusal` refuses it,
+        # so it can only reach a refusal row, where recording it is the point.
+        (Decimal("-500"), Decimal("-500.000000")),
+        # One quantum below the magnitude bound.
+        (Decimal("999999999999.999999"), Decimal("999999999999.999999")),
+    ],
+)
+def test_storable_values_round_rather_than_vanish(value: Decimal, expected: Decimal) -> None:
+    assert _storable_or_none(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # The refusals these produce (`sleeve_valuation_invalid`, and the
+        # currency/instrument mismatches checked BEFORE it) are exactly the rows
+        # whose evidence would otherwise be unwritable: NUMERIC(18,6) raises
+        # `numeric field overflow` and the control cannot express the state.
+        Decimal("NaN"),
+        Decimal("Infinity"),
+        Decimal("-Infinity"),
+        Decimal("1000000000000"),  # the bound itself is exclusive
+        Decimal("1e30"),
+        Decimal("-1e30"),
+    ],
+)
+def test_unrepresentable_values_become_null_rather_than_raising(value: Decimal) -> None:
+    assert _storable_or_none(value) is None
+
+
+def test_finiteness_is_checked_before_magnitude() -> None:
+    """Ordering, not style: ``abs(Decimal("NaN")) >= x`` raises InvalidOperation.
+
+    Swapping the two guards in the writer turns this from None into an
+    uncaught ``decimal.InvalidOperation`` at the first NaN valuation.
+    """
+    assert _storable_or_none(Decimal("NaN")) is None
+    assert _storable_or_none(Decimal("sNaN")) is None
+
+
+def test_the_insert_column_list_and_placeholder_block_cannot_disagree() -> None:
+    """Both are generated from ``_INTENT_COLUMNS``, so this pins the generation.
+
+    #2623 shipped a value into the wrong block by maintaining the column list,
+    the ``%(name)s`` block and a reader tuple separately — psycopg binds by NAME,
+    which makes the order feel irrelevant, but the order that matters is the
+    placeholder block against the column list.
+    """
+    columns = re.search(rf"INSERT INTO {_TABLE} \((.*?)\) VALUES", _INSERT_INTENT, re.S)
+    placeholders = re.search(r"VALUES \((.*?)\) RETURNING", _INSERT_INTENT, re.S)
+    assert columns is not None and placeholders is not None
+    assert [c.strip() for c in columns.group(1).split(",")] == list(_INTENT_COLUMNS)
+    assert [p.strip() for p in placeholders.group(1).split(",")] == [
+        f"%({column})s" for column in _INTENT_COLUMNS
+    ]
+
+
+def test_no_module_outside_the_writer_reads_the_intents_table() -> None:
+    """The enforceable half of "authorises nothing".
+
+    A durable ``buy_core`` row is only safe to ship ahead of an executor because
+    nothing can act on it. When the executor lands it will read this table, and
+    this test is what forces that change to arrive alongside the trade linkage
+    and the position-manager change rather than on its own.
+    """
+    offenders = [
+        str(path)
+        for path in Path("app").rglob("*.py")
+        if str(path) != _WRITER and _TABLE in path.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], (
+        f"{_TABLE} gained a reader outside {_WRITER}: {offenders}. "
+        "It authorises nothing only while nothing reads it — see #2603 item 3."
+    )
+
+
+def test_no_table_references_the_intents_table() -> None:
+    """The other half: an FK would let a row here become a row somewhere real.
+
+    The next slice adds exactly that FK, from ``strategy_trades``, together with
+    the manager change. Until then a reference is the whole hazard.
+    """
+    referencing = [
+        path.name
+        for path in Path("sql").glob("*.sql")
+        if re.search(rf"REFERENCES\s+{_TABLE}\b", path.read_text(encoding="utf-8"))
+    ]
+    assert referencing == [], f"a table now references {_TABLE}: {referencing}"

--- a/tests/test_2603_core_rebalance_intent_db.py
+++ b/tests/test_2603_core_rebalance_intent_db.py
@@ -1,0 +1,413 @@
+"""#2603 item 3 step 1 — what ``sql/348`` enforces, and the writer's round trip.
+
+⚠ THE MIGRATION'S BACKSTOP, NOT THE PYTHON RULE. Every rejection case below
+INSERTs raw SQL that bypasses ``record_core_rebalance_intent``, because a CHECK
+that only ever sees writer-produced values is not demonstrably a backstop at all —
+a later migration relaxing one would be invisible.
+
+⚠ One case per NULL-BEARING combination, not just the happy path. A CHECK passes
+on NULL, so ``col = 'x'`` does not require ``col = 'x'``; the constraint keeps
+refusing every wrong VALUE you thought to test and admits the OMISSION it exists
+to catch, which is what a writer bug actually produces
+(``docs/review-prevention-log.md``: #2679, and ``sql/341``).
+
+⚠ In its own ``_db`` module deliberately: the string ``ebull_test_conn`` in a test
+source db-marks the WHOLE module at collection.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import pytest
+
+from app.services.strategy_core_allocator import CoreSleeveState
+from app.services.strategy_core_mandate import CORE_MANDATE_POLICY_VERSION
+from app.services.strategy_core_rebalance_intent import record_core_rebalance_intent
+
+_INSERT = """
+INSERT INTO strategy_core_rebalance_intents (
+    core_mandate_event_id, allocator_policy_version, recorded_by,
+    core_instrument_id, currency, core_market_value, cash_balance, state_as_of,
+    action, reason_code, amount, core_pct, target_pct, lower_pct, upper_pct,
+    effective_floor, floor_source, reserve_breached, reserve_margin_pct
+) VALUES (
+    %(core_mandate_event_id)s, %(allocator_policy_version)s, %(recorded_by)s,
+    %(core_instrument_id)s, %(currency)s, %(core_market_value)s,
+    %(cash_balance)s, %(state_as_of)s,
+    %(action)s, %(reason_code)s, %(amount)s, %(core_pct)s, %(target_pct)s,
+    %(lower_pct)s, %(upper_pct)s, %(effective_floor)s, %(floor_source)s,
+    %(reserve_breached)s, %(reserve_margin_pct)s
+)
+"""
+
+_INSTRUMENT_ID = 920604
+
+#: A valuation instant safely before ``now()``. Fixed rather than relative so the
+#: row is deterministic; the ``state_as_of <= evaluated_at`` CHECK is real and a
+#: same-day wall-clock literal trips it depending on the hour the suite runs.
+_PAST = datetime(2026, 1, 2, 9, 0, tzinfo=UTC)
+
+#: A schema-valid HOLD, in band. Every rejection case below is this row with one
+#: field moved, so a failure names the field rather than the row.
+_HOLD: dict[str, Any] = {
+    "core_mandate_event_id": None,  # filled by the fixture
+    "allocator_policy_version": CORE_MANDATE_POLICY_VERSION,
+    "recorded_by": "test",
+    "core_instrument_id": _INSTRUMENT_ID,
+    "currency": "USD",
+    "core_market_value": Decimal("600.000000"),
+    "cash_balance": Decimal("400.000000"),
+    "state_as_of": _PAST,
+    "action": "hold",
+    "reason_code": None,
+    "amount": Decimal("0"),
+    "core_pct": Decimal("60"),
+    "target_pct": Decimal("60"),
+    "lower_pct": Decimal("55"),
+    "upper_pct": Decimal("65"),
+    "effective_floor": Decimal("25"),
+    "floor_source": "mandate",
+    "reserve_breached": False,
+    "reserve_margin_pct": Decimal("20"),
+}
+
+_DERIVED = (
+    "core_pct",
+    "target_pct",
+    "lower_pct",
+    "upper_pct",
+    "effective_floor",
+    "floor_source",
+    "reserve_breached",
+    "reserve_margin_pct",
+)
+
+
+def _seed_mandate(conn: psycopg.Connection[Any]) -> int:
+    """One instrument and one enabled mandate revision to point the FK at."""
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (%s,'CORE.INTENT','Core Intent Test',TRUE) ON CONFLICT DO NOTHING",
+        (_INSTRUMENT_ID,),
+    )
+    row = conn.execute(
+        """
+        INSERT INTO strategy_core_mandate_events (
+            revision,enabled,base_currency,core_instrument_id,core_target_pct,
+            liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
+            policy_version,changed_by,reason
+        ) VALUES (1,TRUE,'USD',%s,60,20,5,25,%s,'test','test')
+        RETURNING core_mandate_event_id
+        """,
+        (_INSTRUMENT_ID, CORE_MANDATE_POLICY_VERSION),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _row(event_id: int, **overrides: Any) -> dict[str, Any]:
+    return {**_HOLD, "core_mandate_event_id": event_id, **overrides}
+
+
+def test_the_reference_hold_inserts(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    event_id = _seed_mandate(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _row(event_id))
+
+
+def test_a_hold_may_carry_the_floor_suppression_reason(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """⚠ NOT an error, and the constraint set nearly said it was.
+
+    ``strategy_core_allocator.py:303`` returns
+    ``_decide("hold", _ZERO, "below_min_rebalance_amount", core_pct)`` when the gap
+    to the band edge is under the floor. A ``hold ⟹ reason_code IS NULL`` rule
+    would have made the allocator's own output unstorable.
+    """
+    event_id = _seed_mandate(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _row(event_id, reason_code="below_min_rebalance_amount"))
+
+
+def test_a_buy_inserts(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    event_id = _seed_mandate(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _row(event_id, action="buy_core", amount=Decimal("50")))
+
+
+def test_a_mandate_absent_refusal_inserts_with_no_event_and_no_valuation(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The one verdict with no revision to cite, carrying unrepresentable inputs.
+
+    Both NULLs together: this is the row the naive design could not write at all.
+    """
+    _seed_mandate(ebull_test_conn)
+    ebull_test_conn.execute(
+        _INSERT,
+        {
+            **_HOLD,
+            "core_mandate_event_id": None,
+            "action": "refused",
+            "reason_code": "core_mandate_absent",
+            "amount": Decimal("0"),
+            "core_market_value": None,
+            "cash_balance": None,
+            **dict.fromkeys(_DERIVED),
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "overrides"),
+    [
+        # --- refused: no weights were computed, so a derived field is a writer bug
+        *[
+            (
+                f"refused_with_{field}",
+                {
+                    "action": "refused",
+                    "reason_code": "core_mandate_disabled",
+                    **dict.fromkeys(_DERIVED),
+                    field: _HOLD[field],
+                },
+            )
+            for field in _DERIVED
+        ],
+        (
+            "refused_without_reason",
+            {"action": "refused", "reason_code": None, **dict.fromkeys(_DERIVED)},
+        ),
+        (
+            "refused_with_amount",
+            {
+                "action": "refused",
+                "reason_code": "core_mandate_disabled",
+                "amount": Decimal("1"),
+                **dict.fromkeys(_DERIVED),
+            },
+        ),
+        # --- hold
+        ("hold_with_amount", {"amount": Decimal("1")}),
+        ("hold_with_a_foreign_reason", {"reason_code": "core_sleeve_empty"}),
+        # ⚠ The OMISSION case, one per derived field. This is what a writer bug
+        # produces, and what a happy-path-only test cannot see.
+        *[(f"hold_missing_{field}", {field: None}) for field in _DERIVED],
+        ("hold_with_band_inverted", {"lower_pct": Decimal("70")}),
+        ("hold_with_target_above_upper", {"upper_pct": Decimal("55")}),
+        ("hold_with_zero_floor", {"effective_floor": Decimal("0")}),
+        # --- buy / sell
+        ("buy_with_zero_amount", {"action": "buy_core", "amount": Decimal("0")}),
+        (
+            "buy_with_a_reason",
+            {"action": "buy_core", "amount": Decimal("50"), "reason_code": "core_sleeve_empty"},
+        ),
+        (
+            "sell_missing_floor_source",
+            {"action": "sell_core", "amount": Decimal("50"), "floor_source": None},
+        ),
+        # --- enums
+        ("unknown_action", {"action": "rebalance"}),
+        ("unknown_reason", {"reason_code": "made_up", "action": "hold"}),
+        ("unknown_floor_source", {"floor_source": "operator"}),
+        # --- the null-valuation rule: unstorable inputs imply a refusal
+        ("hold_with_null_core_value", {"core_market_value": None}),
+        ("hold_with_null_cash", {"cash_balance": None}),
+        (
+            "buy_with_null_cash",
+            {"action": "buy_core", "amount": Decimal("50"), "cash_balance": None},
+        ),
+        # --- temporal
+        (
+            "state_after_evaluation",
+            {"state_as_of": datetime.now(UTC) + timedelta(hours=1)},
+        ),
+        # --- text shape
+        ("blank_recorded_by", {"recorded_by": "   "}),
+        ("blank_currency", {"currency": ""}),
+        ("blank_policy_version", {"allocator_policy_version": ""}),
+    ],
+)
+def test_the_checks_reject_raw_inserts(
+    ebull_test_conn: psycopg.Connection[Any], label: str, overrides: dict[str, Any]
+) -> None:
+    event_id = _seed_mandate(ebull_test_conn)
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(_INSERT, _row(event_id, **overrides))
+
+
+@pytest.mark.parametrize(
+    ("label", "event_id_is_null", "reason_code", "action"),
+    [
+        # The event id is absent for EXACTLY one verdict. Both directions, because
+        # a one-directional rule admits the other half silently.
+        ("absent_without_event_is_required", False, "core_mandate_absent", "refused"),
+        ("other_refusal_needs_an_event", True, "core_mandate_disabled", "refused"),
+        ("a_hold_needs_an_event", True, None, "hold"),
+    ],
+)
+def test_the_event_link_is_absent_for_exactly_one_verdict(
+    ebull_test_conn: psycopg.Connection[Any],
+    label: str,
+    event_id_is_null: bool,
+    reason_code: str | None,
+    action: str,
+) -> None:
+    event_id = _seed_mandate(ebull_test_conn)
+    overrides: dict[str, Any] = {"action": action, "reason_code": reason_code}
+    if action == "refused":
+        overrides.update(dict.fromkeys(_DERIVED))
+        overrides["amount"] = Decimal("0")
+    row = _row(event_id, **overrides)
+    if event_id_is_null:
+        row["core_mandate_event_id"] = None
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(_INSERT, row)
+
+
+def test_the_mandate_event_fk_restricts_deletes(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """An evidence row may not be orphaned by deleting what it cites."""
+    event_id = _seed_mandate(ebull_test_conn)
+    ebull_test_conn.execute(_INSERT, _row(event_id))
+    with pytest.raises(psycopg.errors.ForeignKeyViolation):
+        ebull_test_conn.execute(
+            "DELETE FROM strategy_core_mandate_events WHERE core_mandate_event_id=%s",
+            (event_id,),
+        )
+
+
+def test_the_writer_stores_the_verdict_it_returns(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """Round trip through the real writer against the real mandate.
+
+    600/400 against a 60% target with a 5-point band is exactly in band, so the
+    verdict is a hold — and the stored row must carry the same numbers the
+    returned decision does, which is what a positional-list mistake breaks.
+    """
+    event_id = _seed_mandate(ebull_test_conn)
+    intent = record_core_rebalance_intent(
+        ebull_test_conn,
+        state=CoreSleeveState(
+            core_instrument_id=_INSTRUMENT_ID,
+            core_market_value=Decimal("600"),
+            cash_balance=Decimal("400"),
+            currency="USD",
+            as_of=_PAST,
+        ),
+        recorded_by="test",
+    )
+    assert intent.decision.action == "hold"
+    assert intent.core_mandate_event_id == event_id
+
+    row = ebull_test_conn.execute(
+        "SELECT action, core_pct, target_pct, lower_pct, upper_pct, amount, "
+        "floor_source, core_market_value, allocator_policy_version "
+        "FROM strategy_core_rebalance_intents WHERE core_rebalance_intent_id=%s",
+        (intent.core_rebalance_intent_id,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "hold"
+    assert row[1] == intent.decision.core_pct
+    assert row[2] == Decimal("60.0000")
+    assert row[3] == Decimal("55.0000")
+    assert row[4] == Decimal("65.0000")
+    assert row[5] == Decimal("0.000000")
+    # `broker_minimum` is not a parameter of this writer, so the floor is always
+    # the mandate's own — stated as an assertion so the executor slice that
+    # widens it has to change a test rather than slip past one.
+    assert row[6] == "mandate"
+    assert row[7] == Decimal("600.000000")
+    assert row[8] == CORE_MANDATE_POLICY_VERSION
+
+
+def test_an_unstorable_valuation_is_recorded_rather_than_lost(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The trap the NULL semantics exists for, end to end through the writer.
+
+    A 10^30 cash balance refuses ``sleeve_valuation_invalid``. Storing it into
+    NUMERIC(18,6) would raise ``numeric field overflow``, making the evidence for
+    an unrepresentable valuation the one row that cannot be written.
+    """
+    _seed_mandate(ebull_test_conn)
+    intent = record_core_rebalance_intent(
+        ebull_test_conn,
+        state=CoreSleeveState(
+            core_instrument_id=_INSTRUMENT_ID,
+            core_market_value=Decimal("600"),
+            cash_balance=Decimal("1e30"),
+            currency="USD",
+            as_of=_PAST,
+        ),
+        recorded_by="test",
+    )
+    assert intent.decision.action == "refused"
+    assert intent.decision.reason_code == "sleeve_valuation_invalid"
+
+    row = ebull_test_conn.execute(
+        "SELECT cash_balance, core_market_value, reason_code "
+        "FROM strategy_core_rebalance_intents WHERE core_rebalance_intent_id=%s",
+        (intent.core_rebalance_intent_id,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] is None
+    # The representable component is still stored: NULL is per-column and means
+    # "this value had no representation", not "the observation was discarded".
+    assert row[1] == Decimal("600.000000")
+    assert row[2] == "sleeve_valuation_invalid"
+
+
+def test_a_nan_valuation_is_recorded_rather_than_raising(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """``Decimal("NaN")`` is the other unrepresentable shape, and the one that
+    would reach ``InvalidOperation`` if finiteness were checked after magnitude."""
+    _seed_mandate(ebull_test_conn)
+    intent = record_core_rebalance_intent(
+        ebull_test_conn,
+        state=CoreSleeveState(
+            core_instrument_id=_INSTRUMENT_ID,
+            core_market_value=Decimal("NaN"),
+            cash_balance=Decimal("400"),
+            currency="USD",
+            as_of=_PAST,
+        ),
+        recorded_by="test",
+    )
+    assert intent.decision.reason_code == "sleeve_valuation_invalid"
+    row = ebull_test_conn.execute(
+        "SELECT core_market_value FROM strategy_core_rebalance_intents "
+        "WHERE core_rebalance_intent_id=%s",
+        (intent.core_rebalance_intent_id,),
+    ).fetchone()
+    assert row is not None and row[0] is None
+
+
+def test_no_mandate_configured_records_the_absent_verdict(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The FK-nullable path through the real writer, with nothing seeded."""
+    ebull_test_conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (%s,'CORE.INTENT','Core Intent Test',TRUE) ON CONFLICT DO NOTHING",
+        (_INSTRUMENT_ID,),
+    )
+    intent = record_core_rebalance_intent(
+        ebull_test_conn,
+        state=CoreSleeveState(
+            core_instrument_id=_INSTRUMENT_ID,
+            core_market_value=Decimal("600"),
+            cash_balance=Decimal("400"),
+            currency="USD",
+            as_of=_PAST,
+        ),
+        recorded_by="test",
+    )
+    assert intent.decision.action == "refused"
+    assert intent.decision.reason_code == "core_mandate_absent"
+    assert intent.core_mandate_event_id is None

--- a/tests/test_2603_core_rebalance_intent_db.py
+++ b/tests/test_2603_core_rebalance_intent_db.py
@@ -212,9 +212,10 @@ def test_a_mandate_absent_refusal_inserts_with_no_event_and_no_valuation(
         ("unknown_action", {"action": "rebalance"}),
         ("unknown_reason", {"reason_code": "made_up", "action": "hold"}),
         ("unknown_floor_source", {"floor_source": "operator"}),
-        # --- the null-valuation rule: unstorable inputs imply a refusal
+        # --- the null-observation rule: unstorable inputs imply a refusal
         ("hold_with_null_core_value", {"core_market_value": None}),
         ("hold_with_null_cash", {"cash_balance": None}),
+        ("hold_with_null_currency", {"currency": None}),
         (
             "buy_with_null_cash",
             {"action": "buy_core", "amount": Decimal("50"), "cash_balance": None},
@@ -381,8 +382,7 @@ def test_a_nan_valuation_is_recorded_rather_than_raising(
     )
     assert intent.decision.reason_code == "sleeve_valuation_invalid"
     row = ebull_test_conn.execute(
-        "SELECT core_market_value FROM strategy_core_rebalance_intents "
-        "WHERE core_rebalance_intent_id=%s",
+        "SELECT core_market_value FROM strategy_core_rebalance_intents WHERE core_rebalance_intent_id=%s",
         (intent.core_rebalance_intent_id,),
     ).fetchone()
     assert row is not None and row[0] is None
@@ -411,3 +411,96 @@ def test_no_mandate_configured_records_the_absent_verdict(
     assert intent.decision.action == "refused"
     assert intent.decision.reason_code == "core_mandate_absent"
     assert intent.core_mandate_event_id is None
+
+
+def test_an_unstorable_currency_is_recorded_rather_than_lost(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The same trap as the valuations, on the column where it is easiest to miss.
+
+    A blank currency never matches the mandate's base currency, so
+    ``_state_refusal`` returns ``sleeve_currency_mismatch`` — and a NOT NULL
+    non-blank column would then make that refusal the one row that cannot be
+    written. Caught by Codex checkpoint 2 after the valuation columns had already
+    been shaped for exactly this.
+    """
+    _seed_mandate(ebull_test_conn)
+    intent = record_core_rebalance_intent(
+        ebull_test_conn,
+        state=CoreSleeveState(
+            core_instrument_id=_INSTRUMENT_ID,
+            core_market_value=Decimal("600"),
+            cash_balance=Decimal("400"),
+            currency="   ",
+            as_of=_PAST,
+        ),
+        recorded_by="test",
+    )
+    assert intent.decision.action == "refused"
+    assert intent.decision.reason_code == "sleeve_currency_mismatch"
+
+    row = ebull_test_conn.execute(
+        "SELECT currency, core_market_value FROM strategy_core_rebalance_intents WHERE core_rebalance_intent_id=%s",
+        (intent.core_rebalance_intent_id,),
+    ).fetchone()
+    assert row is not None
+    assert row[0] is None
+    assert row[1] == Decimal("600.000000")
+
+
+def test_the_observed_currency_is_stored_unnormalised(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """What was OBSERVED is the evidence: ``" usd "`` matches and is stored as sent.
+
+    Normalising on the way in would hide the difference between a caller sending
+    ``"USD"`` and one sending ``" usd "`` — which is the kind of thing an
+    unexplained mismatch a month from now turns on.
+    """
+    _seed_mandate(ebull_test_conn)
+    intent = record_core_rebalance_intent(
+        ebull_test_conn,
+        state=CoreSleeveState(
+            core_instrument_id=_INSTRUMENT_ID,
+            core_market_value=Decimal("600"),
+            cash_balance=Decimal("400"),
+            currency=" usd ",
+            as_of=_PAST,
+        ),
+        recorded_by="test",
+    )
+    assert intent.decision.action == "hold"
+    row = ebull_test_conn.execute(
+        "SELECT currency FROM strategy_core_rebalance_intents WHERE core_rebalance_intent_id=%s",
+        (intent.core_rebalance_intent_id,),
+    ).fetchone()
+    assert row is not None and row[0] == " usd "
+
+
+def test_a_snapshot_taken_after_the_transaction_opened_is_not_future_dated(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """``evaluated_at`` defaults to ``clock_timestamp()``, not ``now()``.
+
+    ``now()`` is TRANSACTION start time. A writer called inside a transaction that
+    opened before the sleeve was valued would stamp the evaluation earlier than
+    the observation, and the ``state_as_of <= evaluated_at`` CHECK would reject a
+    perfectly fresh snapshot for no reason but the caller's transaction boundary.
+
+    The 50ms sleep pins the transaction start well behind the wall clock, so the
+    10ms-after-``now()`` snapshot is unambiguously inside the window ``now()``
+    rejects and ``clock_timestamp()`` accepts.
+    """
+    event_id = _seed_mandate(ebull_test_conn)  # opens the transaction
+    ebull_test_conn.execute("SELECT pg_sleep(0.05)")
+    row = ebull_test_conn.execute("SELECT now() + interval '10 milliseconds', now() < clock_timestamp()").fetchone()
+    assert row is not None
+    snapshot_at, clock_has_advanced = row
+    assert clock_has_advanced, "transaction time did not lag the wall clock; test is inert"
+
+    ebull_test_conn.execute(_INSERT, _row(event_id, state_as_of=snapshot_at))
+    stored = ebull_test_conn.execute(
+        "SELECT evaluated_at > now() FROM strategy_core_rebalance_intents "
+        "ORDER BY core_rebalance_intent_id DESC LIMIT 1"
+    ).fetchone()
+    assert stored is not None and stored[0] is True


### PR DESCRIPTION
## What this is

#2603 item 3's **execution half, step 1**. `evaluate_core_rebalance` merged pure with no
caller (its own docstring said so). This adds the caller, and
`strategy_core_rebalance_intents` for the verdict to land in — the mandate-driven analogue
of `strategy_entry_preflights`, which is signal-driven and cannot carry this.

⚠ **Authorises nothing, and mechanically rather than by promise.** No broker I/O, no order,
no position, no trade row, no endpoint, no UI. No table has an FK to the new one and no
module reads it, so no code path can turn a row into an action. Both halves are asserted
by tests, not left to a docstring.

## The blocker on the queue was described wrongly, and the correction changes the shape

#2437's R4 comment and #2603's own prior note describe this work as gated by *"the core
position class (`sql/287:116` / `strategy_position_manager.py:816-817` block a stop-less,
take-profit-less holding)"* — i.e. two CHECK-shaped exemptions. Re-measured against
`sql/287` and the applied dev schema:

| column | nullable |
| --- | --- |
| `strategy_entry_preflights.signal_id` (also the PK) | NO |
| `strategy_funding_decisions.signal_id` | NO |
| `strategy_trades.funding_decision_id` | NO (also UNIQUE) |

`strategy_position_manager.py:279-283` is an INNER JOIN through all three. A mandate-driven
holding has no `signal_id`, so it cannot be written at all — and exempting the two CHECKs
would leave it **dropped by the join rather than exempted by the manager**: no age-out, no
reconcile, no close path, while looking managed.

## The design decision, settled

Both options recorded on the issue are rejected in their stated form.

**Option 1 — synthesise a `strategy_signals` row.** Rejected, and *not* for the reason
recorded. The prior note said `strategy_signal_daily_counts` "is populated from
`strategy_signals` verdicts", so a synthetic signal would contaminate #2623 gap 2's
fire-rate denominators. **That mechanism is false**: the census is written by
`strategy_observation_storage.py:148` straight from scan observations, and
`signal_ledger.py:296` is the only `INSERT INTO strategy_signals` in the repo. Two writers
off one scan, not a derivation.

The real objection is the ticket's own scope clause 5 — *"reads mandate + current positions
only; never reads `strategy_signals`"*. That clause separates two populations; writing a
rebalance into the signal table merges them from the other side, and every consumer of
`strategy_signals` would need a predicate none of them carries. Its six NOT NULL columns
with no mandate-side meaning are the symptom, not the argument.

**Option 2 — a sibling ownership path with its own manager pass.** Rejected. Not because
"two managers" is inevitable, but because a separate key means **every query that reaches a
position through `strategy_trades` must be dual-written** — measured: five modules
(`strategy_position_manager`, `strategy_paper_executor`, `strategy_control_plane`,
`strategy_monitoring`, `strategy_live_gate`) plus `app/api/strategies.py`. Each one missed
is a core position invisible to reconciliation or gating.

**Adopted: one exclusive arc** on `strategy_trades` — `funding_decision_id` becomes
nullable with a sibling `core_rebalance_intent_id`, exactly one non-null. Consumers relax a
join rather than acquire a second query, and a missed one fails loudly on a NULL.

⚠ **The arc is deliberately NOT in this PR.** It is inert without the manager change and
dangerous without it — it would create exactly the invisible-but-writable core trade this
PR opens by rejecting. Arc and manager land together next, against this table as the FK
target, which is why the intent record comes first.

## The bug this shape exists to avoid

`_state_refusal` refuses `sleeve_valuation_invalid` on a component that is non-finite,
negative or `>= 10^12`, and `sleeve_currency_mismatch` on a blank currency. Storing those
observations into `NUMERIC(18,6) NOT NULL` / `TEXT NOT NULL CHECK (btrim(...) <> '')` makes
the INSERT raise — **the evidence for an unrepresentable observation is the one row that
cannot be written.** #2437's standing pattern: the control cannot express a state the
system can reach.

So the three observation columns are nullable, `NULL` meaning "no representation in this
column's shape; the reason code says what was wrong with it", with an enforceable
`NULL ⟹ refused` CHECK — true by construction, since every non-refused path has already
passed `_state_refusal`.

⚠ I fixed this for the two numeric columns in the spec and then reintroduced it on
`currency` twenty lines later, because a non-blank CHECK reads as hygiene rather than as a
domain restriction. Extracted to `docs/review-prevention-log.md`.

## Codex checkpoint 2 — two findings, both real, both fixed

1. **P1** — the `currency` case above. Notably the constraint suite already contained
   `("blank_currency", {"currency": ""})` as a **rejection** case: it asserted the CHECK
   worked, which it did. Nobody asked whether the writer could reach it. *A constraint test
   that only asserts a bad value is refused cannot see that a legitimate writer path
   produces that value.*
2. **P2** — `evaluated_at DEFAULT now()` is **transaction** start time, so a writer called
   inside a transaction opened before the sleeve was valued stamps the evaluation earlier
   than its own observation, and `CHECK (state_as_of <= evaluated_at)` rejects a fresh
   snapshot over a transaction boundary. Now `clock_timestamp()`; still a DEFAULT and never
   a parameter, per `sql/346`.

Both extracted to `docs/review-prevention-log.md`.

## Verification

| step | result |
| --- | --- |
| `sql/348` applied to dev | `Applied ['348_core_rebalance_intents.sql']` |
| Revert-probe of the NULL-safe event-link CHECK | `=` form **ADMITTED `(NULL, NULL)`** — a verdict with no mandate link and no reason; `IS NOT DISTINCT FROM` refused. Probed in a temp table, not by editing the applied migration (`app/db/migrations.py:118` stores a SHA-256 per file and raises on drift). |
| `tests/test_2603_core_rebalance_intent.py` | exit 0 |
| `tests/test_2603_core_rebalance_intent_db.py` (54 cases) | exit 0 |
| `ruff check` / `ruff format --check` / `pyright` | exit 0 / 0 / 0 (0 errors) |
| `pytest -m "not db"` | exit 0 |
| `pytest tests/smoke` | exit 0 |

Constraint coverage is **one case per NULL-bearing combination**, not just the happy path —
one `hold_missing_<field>` per derived field, plus both directions of the event-link rule.
A CHECK passes on NULL, so a suite that only tries wrong *values* misses the *omission* a
writer bug actually produces (`docs/review-prevention-log.md`: #2679, `sql/341`).

## Notes

- **No ETL/DoD clauses 8-12 evidence table**, and the omission is deliberate: this touches
  no parser, no ingest path and no ownership/observations data. The new table starts empty
  and nothing backfills into it — there is nothing to smoke against `AAPL`/`GME`/`MSFT`/
  `JPM`/`HD`, no cross-source figure, no `sec_rebuild` scope, and no operator-visible
  figure to re-check. Stated rather than silently skipped.
- **No jobs-daemon restart needed** — no job, scheduler or ingest path is touched.
- ⚠ **A hold MAY carry a `reason_code`** and it is not an error:
  `strategy_core_allocator.py:303` returns `_decide("hold", _ZERO,
  "below_min_rebalance_amount", core_pct)`. The first constraint draft said
  `hold ⟹ reason_code IS NULL`, which would have made the allocator's own output
  unstorable. Caught at Codex checkpoint 1.
- **Owed, with a named owner rather than as a silence:** no in-flight suppression, no
  expiry, no eligibility re-proof. All three need the trade linkage and belong to the next
  slice, which must key one trade per intent (UNIQUE), gate a new actionable intent on
  there being no open core trade, and bound `evaluated_at` at submission.

## Security

No new surface: no endpoint, no auth path, no user-controlled input, no broker call. The
one SQL statement is fully parameterised. The table is written only by
`record_core_rebalance_intent` and read by nothing.

Refs #2603. Refs #2437. Refs #2525.
