### PR TITLE
fix(#2420): test the zero-spread property on the input, not the symptom in the output

### DIFF
--- a/scripts/verify_2240_statistics.py
+++ b/scripts/verify_2240_statistics.py
@@ -500,13 +500,42 @@ def _criterion6(sleeves: dict[str, _Sleeve], measured: dict[str, StrategyMetrics
     if len(common) < 2:
         print("      → refused: the trials share fewer than 2 active dates, so no correlation exists")
         return problems
-    matrix = np.corrcoef(np.array([[series[label][day] for day in common] for label in labels]))
-    # ⚠ `np.corrcoef` returns NaN for a CONSTANT series — its denominator is that
-    # series' own standard deviation. Reachable: a trial whose per-date mean
-    # return never varies over the shared dates. `average_trial_correlation`
-    # would then raise on the range check rather than report, so it is caught.
-    if not np.all(np.isfinite(matrix)):
-        print("      → refused: a trial's return series is constant over the shared dates, so no correlation exists")
+    panel = np.array([[series[label][day] for day in common] for label in labels])
+    # ⚠⚠ TESTED ON THE INPUT, NOT ON THE SYMPTOM IN THE OUTPUT (#2420). The
+    # previous guard read `np.all(np.isfinite(np.corrcoef(panel)))` on the premise
+    # that `corrcoef` returns NaN for a constant series. **That premise is false
+    # on the installed numpy** — measured on 2.4.4:
+    #
+    #     >>> np.corrcoef(np.array([[0.1, 0.1, 0.1], [0.1, -0.2, 0.3]]))
+    #     array([[1., 0.], [0., 1.]])
+    #
+    # A constant row yields a finite 0.0, so the branch was unreachable and a
+    # trial whose per-date mean return never varies read as UNCORRELATED. That
+    # feeds `implied_independent_trials` as rho_hat = 0 and returns N_hat ≈ M —
+    # the conservative direction, which is exactly why nothing surfaced it: the
+    # harness reported a number nobody measured and it happened to lean safe.
+    #
+    # ⚠ `ptp` (max - min) AND NOT `std == 0.0`. The standard deviation does not
+    # fire on `[0.1, 0.1, 0.1]`: the mean of three binary 0.1s is
+    # 0.10000000000000002, so the deviations are ~1e-17 and the std is a denormal
+    # rather than a zero. "All values equal" is the property that actually means
+    # "no variation", it is exact in floating point, and it invents no tolerance.
+    #
+    # Mirrors `app/services/backtest_run.py::deflate_group` (#2394 §3.2), which is
+    # where this repair was worked out; the guard here was copied from the version
+    # that predates it.
+    degenerate = sorted(label for index, label in enumerate(labels) if float(np.ptp(panel[index])) == 0.0)
+    if degenerate:
+        print(
+            f"      → refused: trials {degenerate} have a constant return series over the "
+            f"{len(common)} shared dates, so there is no correlation to measure"
+        )
+        return problems
+    matrix = np.corrcoef(panel)
+    # Retained as a BACKSTOP, not as the live guard: a future numpy could restore
+    # NaN here, and the zero-spread check above is what actually fires today.
+    if not np.all(np.isfinite(matrix)):  # pragma: no cover - the zero-spread check above is the live guard
+        print("      → refused: the correlation matrix is not finite, so no average correlation exists")
         return problems
     rho = average_trial_correlation(matrix)
     print(f"      shared active dates    {len(common):>12,}   (dates BOTH trials traded)")

--- a/tests/test_2420_criterion6_zero_spread_guard.py
+++ b/tests/test_2420_criterion6_zero_spread_guard.py
@@ -101,10 +101,18 @@ def test_the_std_predicate_would_not_have_fired_on_this_series() -> None:
 
 
 def test_both_trials_constant_names_both(capsys: pytest.CaptureFixture[str]) -> None:
-    """The reason lists every degenerate trial, not the first one found."""
+    """The reason lists every degenerate trial, not the first one found.
+
+    ⚠ Asserts the refusal and the absence of a correlation as well as the two
+    names — checking names alone would pass on any output that happened to
+    mention both trials, which several of this function's other prints do.
+    """
     problems, out = _run([0.1, 0.1, 0.1], [0.2, 0.2, 0.2], capsys)
     assert problems == []
+    assert "refused" in out
+    assert "constant return series" in out
     assert "'S-1'" in out and "'S-3'" in out
+    assert "avg trial correlation" not in out
 
 
 def test_varying_trials_still_measure_a_correlation(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_2420_criterion6_zero_spread_guard.py
+++ b/tests/test_2420_criterion6_zero_spread_guard.py
@@ -1,0 +1,119 @@
+"""#2420 — P11's zero-spread guard, driven through ``_criterion6`` itself.
+
+⚠ THIS EXISTS BECAUSE THE SCRIPT'S OWN ACCEPTANCE RUN CANNOT REACH THE BRANCH.
+``scripts/verify_2240_statistics.py --curve`` refuses on corpus state
+(*"4546 instruments carry more than one research series"*) long before criterion
+6 runs — verified identical on ``origin/main``, so it is pre-existing and
+unrelated, and filed separately. A fix whose only evidence is a command that
+exits 1 for another reason has no evidence at all.
+
+The numpy behaviour these guards exist for is pinned in
+``tests/test_backtest_run.py::test_a_constant_return_series_refuses_and_is_not_read_as_uncorrelated``;
+this file covers the second copy of the guard rather than re-pinning it.
+"""
+
+from __future__ import annotations
+
+from array import array
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.deflated_sharpe import TradeMoments
+from scripts.verify_2240_statistics import _criterion6, _Sleeve
+
+_DATES = [date(2010, 1, 4), date(2010, 1, 5), date(2010, 1, 6)]
+
+
+def _moments(sharpe: float) -> TradeMoments:
+    return TradeMoments(sharpe=sharpe, skewness=0.0, kurtosis=3.0, trade_count=64)
+
+
+def _sleeve(label: str, returns: list[float], *, sharpe: float) -> _Sleeve:
+    """One trial with a declared per-entry-date return series.
+
+    One trade per date, so ``daily_trade_returns``' mean is that date's value —
+    the shape the correlation is measured on.
+    """
+    sleeve = _Sleeve(label)
+    sleeve.returns = array("d", returns)
+    sleeve.entry_dates = list(_DATES)
+    sleeve.moments = _moments(sharpe)
+    return sleeve
+
+
+def _run(s1: list[float], s3: list[float], capsys: pytest.CaptureFixture[str]) -> tuple[list[str], str]:
+    """Drive ``_criterion6`` on two synthetic trials and return (problems, output).
+
+    ``measured`` is read for exactly one attribute — ``effective_sample_size`` —
+    so a namespace carries it. Deliberately NOT asserting ``problems == []`` in
+    here: a refusal path returns early and legitimately reports none, while the
+    varying path runs the whole DSR contrast on invented moments where a P9
+    finding would say nothing about this fix.
+    """
+    sleeves = {
+        "S-1": _sleeve("S-1", s1, sharpe=0.05),
+        "S-3": _sleeve("S-3", s3, sharpe=0.09),
+    }
+    measured = {label: SimpleNamespace(effective_sample_size=48.0) for label in sleeves}
+    problems = _criterion6(sleeves, measured)  # type: ignore[arg-type]
+    return problems, capsys.readouterr().out
+
+
+def test_a_constant_trial_is_refused_by_name_rather_than_read_as_uncorrelated(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """⚠⚠ The defect: ``np.corrcoef`` gives a constant row a finite **0.0**.
+
+    On numpy 2.4.4 the old ``isfinite`` guard never fired, so this trial reached
+    ``average_trial_correlation`` as rho = 0 and ``implied_independent_trials``
+    returned N_hat ≈ M — a number nobody measured, leaning safe, which is exactly
+    why it survived unnoticed.
+
+    Asserts the reason NAMES the trial, per the ticket's acceptance.
+    """
+    problems, out = _run([0.1, 0.1, 0.1], [0.1, -0.2, 0.3], capsys)
+    # A refusal is a reported state, not a property violation.
+    assert problems == []
+    assert "refused" in out
+    assert "constant return series" in out
+    assert "'S-1'" in out
+    # The old branch's wording must not be what fired.
+    assert "correlation matrix is not finite" not in out
+    # And it must refuse BEFORE reporting a correlation it cannot have measured.
+    assert "avg trial correlation" not in out
+
+
+def test_the_std_predicate_would_not_have_fired_on_this_series() -> None:
+    """⚠ Why ``ptp`` and not ``std == 0.0`` — the first repair attempt's bug.
+
+    The mean of three binary ``0.1``s is ``0.10000000000000002``, so the
+    deviations are ~1e-17 and the standard deviation is a denormal rather than a
+    zero. Pinned here because the two predicates look interchangeable and only
+    one of them is exact.
+    """
+    import numpy as np
+
+    row = np.array([0.1, 0.1, 0.1])
+    assert float(np.std(row)) != 0.0
+    assert float(np.ptp(row)) == 0.0
+
+
+def test_both_trials_constant_names_both(capsys: pytest.CaptureFixture[str]) -> None:
+    """The reason lists every degenerate trial, not the first one found."""
+    problems, out = _run([0.1, 0.1, 0.1], [0.2, 0.2, 0.2], capsys)
+    assert problems == []
+    assert "'S-1'" in out and "'S-3'" in out
+
+
+def test_varying_trials_still_measure_a_correlation(capsys: pytest.CaptureFixture[str]) -> None:
+    """The live path is unchanged — the guard must not swallow real series.
+
+    S-1 and S-3 both vary on the real corpus, which is why this defect never
+    changed a shipped number; a fix that also refused these would be worse than
+    the bug.
+    """
+    _, out = _run([0.1, -0.2, 0.3], [0.2, -0.1, 0.4], capsys)
+    assert "constant return series" not in out
+    assert "avg trial correlation" in out

--- a/tests/test_backtest_run.py
+++ b/tests/test_backtest_run.py
@@ -532,12 +532,18 @@ class TestDeflateGroup:
     def test_a_constant_return_series_refuses_and_is_not_read_as_uncorrelated(self) -> None:
         """⚠⚠ A ZERO-VARIANCE TRIAL IS DETECTED ON THE INPUT, NOT ON THE MATRIX.
 
-        ``verify_2240_statistics.py``'s P11 comment says ``np.corrcoef``
-        returns NaN for a constant series. Measured on **numpy 2.4.4**
-        (2026-08-08) it returns a finite **0.0** — pinned below — so an
-        ``isfinite`` guard is dead code and the trial would be read as
-        UNCORRELATED, pushing the implied independent trial count toward ``M``
-        on evidence that does not exist.
+        ``np.corrcoef`` is widely believed to return NaN for a constant series.
+        Measured on **numpy 2.4.4** (2026-08-08) it returns a finite **0.0** —
+        pinned below — so an ``isfinite`` guard is dead code and the trial would
+        be read as UNCORRELATED, pushing the implied independent trial count
+        toward ``M`` on evidence that does not exist.
+
+        ⚠ ``scripts/verify_2240_statistics.py::_criterion6`` carried exactly that
+        dead guard until #2420; it now tests the input the same way this does, and
+        keeps ``isfinite`` only as a backstop against a future numpy restoring
+        NaN. This docstring named that script as the counter-example until the
+        fix landed — kept as the reference the two implementations share, since a
+        pin whose subject silently changes is how the next copy gets made.
         """
         flat = {date(2010, 1, 4): 0.1, date(2010, 1, 5): 0.1, date(2010, 1, 6): 0.1}
         # The behaviour the guard cannot rely on, pinned so a numpy change that


### PR DESCRIPTION
## What was wrong

`scripts/verify_2240_statistics.py::_criterion6` guarded equation (8)'s inter-trial
correlation by checking the *output* matrix for non-finite values, on the premise that
`np.corrcoef` returns NaN for a constant series.

**The premise is false on the installed numpy.** Measured this run on **numpy 2.4.4**:

```
>>> np.corrcoef(np.array([[0.1, 0.1, 0.1], [0.1, -0.2, 0.3]]))
array([[1., 0.],
       [0., 1.]])
>>> np.all(np.isfinite(_))
True
```

A constant row yields a finite **0.0**, so the `isfinite` branch was unreachable and a
trial whose per-entry-date mean return never varies over the shared dates was read as
**uncorrelated**. That feeds `implied_independent_trials` as `rho_hat = 0`, which returns
`N_hat ≈ M` — the *conservative* direction, which is exactly why it never surfaced: the
harness reported a number nobody measured and it happened to lean safe.

## The fix

Test the property on the **input**, matching `app/services/backtest_run.py::deflate_group`
(#2394 §3.2), which is where this repair was worked out; the guard here was copied from the
version that predates it.

```python
degenerate = sorted(label for index, label in enumerate(labels) if float(np.ptp(panel[index])) == 0.0)
```

⚠ **`ptp` and not `std == 0.0`** — the first repair attempt on the reference implementation
used the standard deviation and did not fire. Reproduced here: `np.std([0.1, 0.1, 0.1])` is
**1.39e-17**, not zero, because the mean of three binary `0.1`s is `0.10000000000000002`, so
the deviations are denormals. `ptp` (max − min) is exact and invents no tolerance.

The `isfinite` check is **retained as a documented backstop** — a future numpy could restore
NaN — but is no longer the mechanism, and is marked `# pragma: no cover` like its twin.

## ⚠ The ticket's acceptance command cannot pass, for an unrelated pre-existing reason

Acceptance asked for `--curve` to still exit 0 on the full corpus. It exits **1**, and does
so identically on `origin/main` — verified by checking the script out at `origin/main`,
re-running, and getting the same message:

```
  *** 4546 instruments carry more than one research series — refusing
```

The harness refuses on corpus state at line 722, long before criterion 6 runs. Its
one-series-per-instrument precondition predates the second research archive (30,591 series
over 5,892 instruments; 4,550 carry more than one, because `paperswithbacktest` was ingested
alongside `icyDenev` on a different adjustment basis). **Filed as #2686** with the
measurements — not fixed here, because it is a data-treatment decision needing a sourced
selection rule, and folding it in would turn a one-function fix into a corpus change.

So the fix is verified by **`tests/test_2420_criterion6_zero_spread_guard.py`**, which drives
`_criterion6` directly with synthetic sleeves. *A fix whose only evidence is a command that
exits 1 for another reason has no evidence at all.*

## Verification

| step | result |
| --- | --- |
| numpy premise re-measured on the installed version | `2.4.4`; constant row → finite `0.0`; `std` → `1.39e-17`; `ptp` → exact `0.0` |
| **Revert-probe** — old guard restored, new tests re-run | **both degenerate cases go RED** (`test_a_constant_trial_is_refused_by_name...`, `test_both_trials_constant_names_both`); the varying case stays green under both, which is what pins that the fix does not over-refuse |
| `pytest tests/test_2420_criterion6_zero_spread_guard.py` | exit 0 (4 cases) |
| `pytest tests/test_backtest_run.py` | exit 0 |
| `pytest -m "not db"` | exit 0 |
| `pytest tests/smoke` | exit 0 |
| `ruff check` / `ruff format --check` / `pyright` | 0 / 0 / 0 errors |

## Also updated: a docstring that named the thing it was contrasting against

`tests/test_backtest_run.py::test_a_constant_return_series_refuses_and_is_not_read_as_uncorrelated`
already pins numpy's behaviour, and its docstring cited *this script's P11 comment* as the
counter-example. That citation goes stale the moment this PR lands, so it now records that
both implementations agree and keeps the cross-reference — a pin whose subject silently
changes is how the next copy gets made.

## Notes

- **Ladder rung:** narrow diff — one script function plus a test file. No service logic, no
  endpoint, no stored data, no migration. Self-review + pre-push hook + review bot, no Codex
  checkpoint 2 per `.claude/CLAUDE.md`'s review-intensity ladder.
- **No behaviour change on the live path**, and that is asserted rather than assumed: S-1 and
  S-3 both vary on the real corpus, and `test_varying_trials_still_measure_a_correlation`
  covers it. A guard that also refused those would be worse than the bug.
- The prevention-log entry this ticket cites ("a guard written against a library's documented
  behaviour is dead code once the library changes it") already exists; nothing new to extract.

## Security

No change: a verification script and a test. No endpoint, no credential, no user input, no
data path.

Closes #2420. Refs #2240. Refs #2394. Refs #2686.
