### PR TITLE
fix(#2407): read confirmation evidence for universe staleness, and align the threshold with the declared cadence

### DIFF
--- a/app/services/ops_monitor.py
+++ b/app/services/ops_monitor.py
@@ -98,7 +98,29 @@ ALL_LAYERS: list[LayerName] = [
 #   - theses refresh daily for stale Tier 1 → 3 days
 #   - scores run each morning → 2 days
 _STALENESS_THRESHOLDS: dict[LayerName, timedelta] = {
-    "universe": timedelta(days=2),
+    # #2407 — 9 days, not 2. ⚠ The 2-day value contradicted a settled decision.
+    # `sync_orchestrator.freshness.UNIVERSE_REFRESH_WINDOW` is 7 days by #277's
+    # explicit reasoning (eToro's /instruments has no delta filter, so a daily
+    # pull of ~15k identical rows was write amplification for no information
+    # gain), and `nightly_universe_sync` has NO cadence of its own — the
+    # orchestrator fires it only when that 7-day window lapses. So an alert at
+    # 2 days fires on the INTENDED state.
+    #
+    # It never showed because the query below used to read a column that barely
+    # moved; fixing the source without this would have turned a silently-wrong
+    # signal into a permanently-red one, which is worse — a panel that is red by
+    # design teaches you to stop reading it.
+    #
+    # The arithmetic, so a future change can re-derive rather than guess:
+    #   7d   the declared refresh window
+    # + 1d   the orchestrator plans once daily at 03:00, so the window can lapse
+    #        up to a full day before the next planning slot notices
+    # + 1d   `last_confirmed_on` is a DATE, so `latest` resolves to midnight and
+    #        reads up to 24h older than the sync that wrote it
+    #   = 9d, beyond which the cadence itself is not being honoured — which is
+    #        exactly what this alert should mean.
+    # `tests/test_2407_universe_staleness_contract.py` fails if the two drift.
+    "universe": timedelta(days=9),
     "prices": timedelta(hours=4),
     "quotes": timedelta(hours=4),
     "fundamentals": timedelta(days=3),
@@ -111,7 +133,46 @@ _STALENESS_THRESHOLDS: dict[LayerName, timedelta] = {
 # Queries to find the most recent timestamp for each data layer.
 # Each returns a single row with a nullable 'latest' column.
 _LAYER_QUERIES: dict[LayerName, str] = {
-    "universe": "SELECT MAX(last_seen_at) AS latest FROM instruments",
+    # #2407 — NOT `MAX(instruments.last_seen_at)`, which this read until now.
+    #
+    # ⚠⚠ `last_seen_at` does not mean "last seen". `sync_universe`'s upsert bumps
+    # it inside a changed-metadata guard (`app/services/universe.py:106-171`), and
+    # that `WHERE` suppresses the whole UPDATE — the bump included — when nothing
+    # changed. So the column means "last time this row's METADATA CHANGED", and a
+    # MAX over it means "last time ANY instrument's metadata changed". A sync that
+    # runs nightly and returns an identical feed left the reported staleness
+    # advancing one day per day, indistinguishable from the sync having stopped;
+    # conversely one instrument renaming made the layer look fresh for two days
+    # after the sync died. Measured 2026-08-08: 12,696 instruments carried NINE
+    # distinct `last_seen_at` dates, 9,850 of them frozen on 2026-06-12.
+    #
+    # `sql/271_instrument_universe_membership.sql:25-50` is the source rule and
+    # was written for exactly this: `last_confirmed_on` is bumped by every code
+    # path that OBSERVES PRESENCE, unconditionally, which is the question this
+    # layer asks. `sync_universe` calls `reconcile_universe_membership` in the
+    # same pass (`universe.py:227`), so the two cannot drift apart.
+    #
+    # ⚠ Deliberately NOT `job_runs`' last successful `nightly_universe_sync`,
+    # which was the other option on the ticket and is the more obvious one. That
+    # reads the job's OWN SELF-REPORT — precisely the "a job that no-ops and
+    # reports success is invisible to every automated check we have" class this
+    # fix exists to close. `last_confirmed_on` is evidence the rows were touched.
+    #
+    # ⚠ `last_confirmed_on` is a DATE, so this resolves to midnight and reads up
+    # to ~24h older than the sync that produced it. That is affordable ONLY
+    # because the threshold above is 2 days: a nightly sync leaves at least ~26h
+    # of margin, and one missed night trips the alert ~26h later, which is the
+    # intended sensitivity. Tightening `universe` below 2 days requires changing
+    # this source too.
+    #
+    # `effective_to IS NULL` = currently a member. A closed row's
+    # `last_confirmed_on` IS its `effective_to` (`sql/271:126`), so including
+    # them would let a departed instrument's final confirmation stand in for a
+    # refresh that never happened.
+    "universe": (
+        "SELECT MAX(last_confirmed_on)::timestamptz AS latest "
+        "FROM instrument_universe_membership WHERE effective_to IS NULL"
+    ),
     "prices": "SELECT MAX(price_date)::timestamptz AS latest FROM price_daily",
     "quotes": "SELECT MAX(quoted_at) AS latest FROM quotes",
     # #2008: probe the ingest layer, not fundamentals_snapshot.as_of_date —

--- a/app/services/sync_orchestrator/freshness.py
+++ b/app/services/sync_orchestrator/freshness.py
@@ -19,7 +19,7 @@ BEFORE ordering would hide a newer failure behind an older success.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, Final
 
 import psycopg
 
@@ -103,14 +103,24 @@ def _format_age(delta: timedelta) -> str:
 # ---------------------------------------------------------------------------
 
 
+#: Weekly cadence (#277). eToro's /instruments endpoint has no delta filter — we
+#: pull the whole list (~15k rows) every refresh. The universe rarely changes
+#: day-to-day (new listings are rare, ticker changes rarer still), so a daily
+#: refresh was write amplification for no information gain. A 7-day window catches
+#: meaningful changes without re-pulling weekly volumes of identical rows.
+#:
+#: ⚠ NAMED rather than inline because ``ops_monitor._STALENESS_THRESHOLDS`` has to
+#: stay LOOSER than it: this window is what decides how old the universe layer is
+#: ALLOWED to get, so an alert threshold below it fires on the intended state.
+#: They cannot import each other (``sync_orchestrator.adapters`` already imports
+#: ``ops_monitor``), so the relationship is asserted by
+#: ``tests/test_2407_universe_staleness_contract.py`` instead of by a shared
+#: constant. #2407.
+UNIVERSE_REFRESH_WINDOW: Final = timedelta(days=7)
+
+
 def universe_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:
-    # Weekly cadence (#277). eToro's /instruments endpoint has no delta
-    # filter — we pull the whole list (~15k rows) every refresh. The
-    # universe rarely changes day-to-day (new listings are rare, ticker
-    # changes rarer still), so a daily refresh was write amplification
-    # for no information gain. A 7-day window catches meaningful
-    # changes without re-pulling weekly volumes of identical rows.
-    return _fresh_by_audit(conn, "nightly_universe_sync", timedelta(days=7))
+    return _fresh_by_audit(conn, "nightly_universe_sync", UNIVERSE_REFRESH_WINDOW)
 
 
 def candles_is_fresh(conn: psycopg.Connection[Any]) -> tuple[bool, str]:

--- a/tests/test_2407_universe_staleness_contract.py
+++ b/tests/test_2407_universe_staleness_contract.py
@@ -1,0 +1,79 @@
+"""#2407 — the universe staleness alert must be looser than the refresh cadence.
+
+Two constants in two modules describe one thing, and they contradicted each other
+for as long as both existed:
+
+* ``sync_orchestrator.freshness.UNIVERSE_REFRESH_WINDOW`` (7 days, #277) decides
+  how old the universe layer is ALLOWED to get. ``nightly_universe_sync`` has no
+  cadence of its own; the orchestrator fires it only when that window lapses.
+* ``ops_monitor._STALENESS_THRESHOLDS["universe"]`` decides when the operator is
+  TOLD the layer is stale.
+
+An alert threshold at or below the refresh window fires on the intended state. It
+never showed only because the layer query read ``instruments.last_seen_at``, a
+column that barely moves — so the two bugs concealed each other.
+
+⚠ They cannot share a constant: ``sync_orchestrator.adapters`` already imports
+``ops_monitor``, so an import back would risk a cycle. A contract test is the
+repo's established substitute (``test_job_terminal_status_contract``,
+``test_the_deployment_currency_refusal_and_its_constraint_agree``).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from app.services.ops_monitor import _LAYER_QUERIES, _STALENESS_THRESHOLDS
+from app.services.sync_orchestrator.freshness import UNIVERSE_REFRESH_WINDOW
+
+#: The orchestrator plans once daily (03:00 UTC), so the refresh window can lapse
+#: up to a full day before the next planning slot acts on it.
+_PLANNING_SLOT = timedelta(days=1)
+#: ``last_confirmed_on`` is a DATE, so the layer query resolves it to midnight and
+#: reads up to 24h older than the sync that wrote it.
+_DATE_GRANULARITY = timedelta(days=1)
+
+
+def test_the_universe_alert_is_looser_than_the_refresh_window_it_watches() -> None:
+    """The whole point: never alert on a layer behaving exactly as declared."""
+    assert _STALENESS_THRESHOLDS["universe"] >= UNIVERSE_REFRESH_WINDOW + _PLANNING_SLOT + _DATE_GRANULARITY, (
+        f"universe staleness threshold {_STALENESS_THRESHOLDS['universe']} is not loose enough for a "
+        f"{UNIVERSE_REFRESH_WINDOW} refresh window plus a {_PLANNING_SLOT} planning slot and "
+        f"{_DATE_GRANULARITY} of date granularity — the panel would be red while the cadence is honoured"
+    )
+
+
+def test_the_threshold_is_not_so_loose_it_stops_detecting_a_stopped_sync() -> None:
+    """The other direction, which the first assertion alone would let drift.
+
+    A threshold of a month would satisfy the bound above and detect nothing. Two
+    consecutive missed refresh windows must still trip it, since that is the
+    condition the alert exists for.
+    """
+    assert _STALENESS_THRESHOLDS["universe"] < 2 * UNIVERSE_REFRESH_WINDOW, (
+        f"universe staleness threshold {_STALENESS_THRESHOLDS['universe']} would not trip after two "
+        f"consecutive missed {UNIVERSE_REFRESH_WINDOW} windows"
+    )
+
+
+def test_the_universe_layer_query_reads_confirmation_evidence_not_metadata_change() -> None:
+    """⚠ Pins the SOURCE, because the threshold above is only correct for it.
+
+    ``instruments.last_seen_at`` means "last time this row's METADATA CHANGED" —
+    ``sync_universe``'s upsert bumps it inside a changed-metadata ``WHERE`` that
+    suppresses the whole UPDATE when nothing changed. ``last_confirmed_on`` is
+    bumped by every code path that OBSERVES PRESENCE, unconditionally
+    (``sql/271_instrument_universe_membership.sql:25-50``).
+
+    Also pins that it is NOT read from ``job_runs``: that is the job's own
+    self-report, which is the failure class this fix closes.
+    """
+    query = _LAYER_QUERIES["universe"]
+    assert "last_confirmed_on" in query
+    assert "instrument_universe_membership" in query
+    # Current members only — a closed row's `last_confirmed_on` IS its
+    # `effective_to` (sql/271:126), so including them would let a departed
+    # instrument's final confirmation stand in for a refresh that never happened.
+    assert "effective_to IS NULL" in query
+    assert "last_seen_at" not in query
+    assert "job_runs" not in query

--- a/tests/test_ops_monitor.py
+++ b/tests/test_ops_monitor.py
@@ -89,8 +89,11 @@ class TestCheckLayerStaleness:
         assert "no data rows" in result.detail
 
     def test_fresh_layer_returns_ok(self) -> None:
-        # Universe threshold is 2 days; set latest to 1 hour ago.
-        latest = _NOW - timedelta(hours=1)
+        # ⚠ Derived from the threshold, not from a hand-written age. Both of
+        # these cases hard-coded "2 days" until #2407 moved the universe
+        # threshold to 9 days, and the stale case then silently became a fresh
+        # one — a test asserting a boundary must move with the boundary.
+        latest = _NOW - (_STALENESS_THRESHOLDS["universe"] / 2)
         conn = _make_conn([_make_cursor([{"latest": latest}])])
         result = check_layer_staleness(conn, "universe", now=_NOW)
         assert result.status == "ok"
@@ -99,8 +102,8 @@ class TestCheckLayerStaleness:
         assert result.age < _STALENESS_THRESHOLDS["universe"]
 
     def test_stale_layer_returns_stale(self) -> None:
-        # Universe threshold is 2 days; set latest to 3 days ago.
-        latest = _NOW - timedelta(days=3)
+        # One hour past the threshold, whatever the threshold currently is.
+        latest = _NOW - (_STALENESS_THRESHOLDS["universe"] + timedelta(hours=1))
         conn = _make_conn([_make_cursor([{"latest": latest}])])
         result = check_layer_staleness(conn, "universe", now=_NOW)
         assert result.status == "stale"


### PR DESCRIPTION
## What was wrong

`ops_monitor._LAYER_QUERIES["universe"]` asked *"when did the universe layer last
refresh"* with:

```sql
SELECT MAX(last_seen_at) AS latest FROM instruments
```

`last_seen_at` does not mean "last seen". `sync_universe`'s upsert bumps it **inside a
changed-metadata guard** (`app/services/universe.py:106-171`), and that `WHERE` suppresses
the whole `UPDATE` — the bump included — when nothing changed. So the column means "last
time this row's **metadata changed**", and a `MAX` over it means "last time **any**
instrument's metadata changed". Measured on the full dev population: 12,696 instruments
carried **nine** distinct `last_seen_at` dates, 9,850 frozen on 2026-06-12.

A sync that runs on cadence and returns an identical feed left the reported staleness
advancing one day per day — indistinguishable from the sync having stopped. Conversely one
instrument renaming made the layer look fresh after the sync died.

## The fix, part 1 — the source

```sql
SELECT MAX(last_confirmed_on)::timestamptz AS latest
FROM instrument_universe_membership WHERE effective_to IS NULL
```

**Source rule, not inference:** `sql/271_instrument_universe_membership.sql:25-50` was
written for exactly this and states it — `last_confirmed_on` is bumped by every code path
that **observes presence**, unconditionally. `sync_universe` calls
`reconcile_universe_membership` in the same pass (`universe.py:227`), so the two cannot
drift apart.

⚠ **Deliberately not `job_runs`' last successful `nightly_universe_sync`**, which was the
other option on the ticket and the more obvious one. That reads the job's **own
self-report** — precisely the *"a job that no-ops and reports success is invisible to every
automated check we have"* class this fix exists to close. `last_confirmed_on` is evidence
the rows were touched.

`effective_to IS NULL` = currently a member; a closed row's `last_confirmed_on` **is** its
`effective_to` (`sql/271:126`), so including them would let a departed instrument's final
confirmation stand in for a refresh that never happened.

## ⚠⚠ The fix, part 2 — the threshold, because the source fix alone makes it worse

Fixing only the source would have turned a silently-wrong signal into a **permanently-red**
one, and a panel that is red by design teaches you to stop reading it.

`_STALENESS_THRESHOLDS["universe"]` was **2 days**. That contradicts a settled decision:
`sync_orchestrator.freshness.universe_is_fresh` uses a **7-day** window by #277's explicit
reasoning — *eToro's `/instruments` endpoint has no delta filter, so a daily pull of ~15k
identical rows was write amplification for no information gain*. And
`nightly_universe_sync` has **no cadence of its own** (`scheduler.py:804`: "already
on-demand only… it remains in `_INVOKERS` for the Admin UI"); the orchestrator fires it only
when that 7-day window lapses. Confirmed empirically — the last twelve successful runs are
3–8 days apart, not nightly.

So a 2-day alert fires on the **intended** state. It never showed only because the query
read a column that barely moved: the two bugs concealed each other.

New threshold **9 days**, derived rather than picked:

| term | why |
| --- | --- |
| 7d | the declared refresh window (`UNIVERSE_REFRESH_WINDOW`, #277) |
| +1d | the orchestrator plans once daily at 03:00, so the window can lapse up to a full day before the next slot notices |
| +1d | `last_confirmed_on` is a DATE, so `latest` resolves to midnight and reads up to 24h older than the sync that wrote it |

Beyond 9 days the cadence itself is not being honoured — which is exactly what the alert
should mean.

⚠ **I checked whether this changes *scheduling* before touching it: it does not.** The
orchestrator plans with its own `universe_is_fresh` off `job_runs`, not with
`_LAYER_QUERIES`, so the blast radius is the ops/admin signal only. Worth stating because
a shared staleness source would have made this a feedback loop.

## Keeping the two constants honest

They cannot share a constant — `sync_orchestrator/adapters.py:29` already imports
`ops_monitor`, so an import back risks a cycle. `UNIVERSE_REFRESH_WINDOW` is now **named**
in `freshness.py` (it was an inline `timedelta(days=7)`), and
`tests/test_2407_universe_staleness_contract.py` asserts the relationship in **both**
directions — the repo's established substitute for a shared constant
(`test_job_terminal_status_contract`, `test_the_deployment_currency_refusal_and_its_constraint_agree`):

- looser than `window + planning slot + date granularity`, so it cannot alert on the
  intended state;
- **and** stricter than `2 × window`, so it cannot drift to a value that detects nothing.
  A one-directional bound would have let "a month" pass.

It also pins the query source, since the threshold is only correct for that source.

## Verification

| step | result |
| --- | --- |
| old vs new source on dev, same instant | old `2026-08-13 21:36:25` (age 5h40m — fresh *by luck*, some metadata changed last night); new `2026-08-13 00:00` (age 1d3h) |
| actual sync cadence, last 12 successes | 3–8 days apart, never nightly — the 2-day threshold was unreachable in the good case |
| membership coverage | 12,728 of 12,730 current rows confirmed 2026-08-13 |
| **revert-probe** — threshold restored to 2 days | `test_the_universe_alert_is_looser_than_the_refresh_window_it_watches` goes **RED** |
| Codex checkpoint 2 (`review --base origin/main`) | no findings |
| `pytest tests/test_2407_universe_staleness_contract.py tests/test_ops_monitor.py` | exit 0 |
| `pytest -m "not db"` / `tests/smoke` | exit 0 / exit 0 |
| `ruff check` / `ruff format --check` / `pyright` | 0 / 0 / 0 errors |

## Two hard-coded ages in the existing suite, fixed as change-coupled

`test_fresh_layer_returns_ok` and `test_stale_layer_returns_stale` wrote *"Universe
threshold is 2 days"* and used literal 1-hour and 3-day ages. Moving the threshold turned
the **stale** case into a fresh one — it failed, correctly, and would have passed silently
had the literals been 1 hour and 30 days. Both now derive from
`_STALENESS_THRESHOLDS["universe"]`, so a boundary test moves with its boundary.

## Notes

- **No migration, no backfill, no schema change**; `instrument_universe_membership` and its
  reconcile already exist and run (#2290). No jobs-daemon restart needed — no job,
  scheduler cadence or ingest path is altered, only what the ops read reports.
- **Operator-visible change:** the universe row on the admin health panel now reports the
  age of the last *confirmation* rather than of the last metadata change, and tolerates the
  declared weekly cadence. On dev right now that is `ok` at 1d3h.
- ETL Definition-of-Done clauses 8-12 do not apply: no parser, no ingest path, no
  ownership/observations data, nothing backfilled. Stated rather than silently skipped.

## Security

No change: one read-only SELECT in an internal health check, no parameters, no user input,
no new surface. The layer-query error path already redacts table names into
`LAYER_QUERY_FAILED_DETAIL_TEMPLATE`, and that is untouched.

Closes #2407. Refs #2290. Refs #277.
