### PR TITLE
feature(#2603): the core trade arc — the dispatcher, the loader, and the two mandate caps

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -59,6 +59,7 @@ from app.services.strategy_control_plane import (
     mandate_for_profile,
     promote_strategy,
 )
+from app.services.strategy_core_mandate import CORE_MANDATE_SERIES_ID, CORE_MANDATE_SERIES_TITLE
 from app.services.strategy_live_gate import (
     REQUIRED_KILL_DRILLS,
     LiveGateReport,
@@ -560,8 +561,13 @@ class StrategyWealthHistoryResponse(BaseModel):
 class StrategyOwnedPosition(BaseModel):
     strategy_trade_id: int
     broker_position_id: int
-    strategy_id: str
-    strategy_version: str
+    # NULL on the core/cash arm (#2603, sql/349): a mandate holding is authorised
+    # by a rebalance intent, not by a signal, so it has no strategy identity to
+    # report.  `strategy_title` stays non-null and carries a mandate label
+    # instead, because the column is what the operator reads to tell the two
+    # populations apart -- a blank there would render as an unexplained gap.
+    strategy_id: str | None
+    strategy_version: str | None
     strategy_title: str
     instrument_id: int
     symbol: str
@@ -1856,14 +1862,15 @@ def get_strategy_owned_positions(
             """
             SELECT ownership.strategy_trade_id,ownership.broker_position_id,
                    trade.status AS trade_status,
+                   trade.core_rebalance_intent_id,
                    signal.strategy_id,signal.strategy_version,
                    instrument.instrument_id,instrument.symbol,instrument.company_name
             FROM strategy_position_ownership ownership
             JOIN strategy_trades trade
               ON trade.strategy_trade_id=ownership.strategy_trade_id
-            JOIN strategy_funding_decisions funding
+            LEFT JOIN strategy_funding_decisions funding
               ON funding.funding_decision_id=trade.funding_decision_id
-            JOIN strategy_signals signal ON signal.signal_id=funding.signal_id
+            LEFT JOIN strategy_signals signal ON signal.signal_id=funding.signal_id
             JOIN instruments instrument ON instrument.instrument_id=trade.instrument_id
             WHERE ownership.status='active'
               AND trade.status IN ('open','closing','reconcile_required')
@@ -1885,14 +1892,20 @@ def get_strategy_owned_positions(
             if unrealised is not None and assigned is not None and assigned != 0
             else None
         )
-        strategy_id = str(row["strategy_id"])
+        # The core arm is identified by its AUTHORISATION column, not by
+        # strategy_id being NULL -- the two would coincide today, but only the
+        # former stays true if a signal row ever goes missing.
+        is_core = row["core_rebalance_intent_id"] is not None
+        strategy_id = None if row["strategy_id"] is None else str(row["strategy_id"])
         positions.append(
             StrategyOwnedPosition(
                 strategy_trade_id=int(row["strategy_trade_id"]),
                 broker_position_id=broker_position_id,
                 strategy_id=strategy_id,
-                strategy_version=str(row["strategy_version"]),
-                strategy_title=_TITLES.get(strategy_id, strategy_id),
+                strategy_version=(None if row["strategy_version"] is None else str(row["strategy_version"])),
+                strategy_title=(
+                    CORE_MANDATE_SERIES_TITLE if is_core else _TITLES.get(strategy_id or "", strategy_id or "")
+                ),
                 instrument_id=int(row["instrument_id"]),
                 symbol=str(row["symbol"]),
                 company_name=(str(row["company_name"]) if row["company_name"] is not None else None),
@@ -2049,19 +2062,32 @@ def get_strategy_pnl_history(
         list[tuple[date, str, Decimal]],
         conn.execute(
             """
+        -- A core close has no signal, so the arm is folded into one presentation
+        -- series rather than dropped -- this endpoint's docstring promises EVERY
+        -- exact-owned lifecycle, and an INNER JOIN to funding quietly broke that
+        -- promise the moment sql/349 made a core trade storable.
+        --
+        -- GROUP BY / ORDER BY use ORDINALS, not a repeated COALESCE: repeating it
+        -- would need the same positional parameter three times, and a positional
+        -- list that has to stay aligned across three sites is the exact shape
+        -- that shipped #2623's wrong-column bug. Naming the output column here
+        -- would be worse -- Postgres resolves an ambiguous GROUP BY name to the
+        -- INPUT column, so `GROUP BY strategy_id` would silently mean
+        -- `signal.strategy_id`.
         SELECT (event.executed_at AT TIME ZONE 'UTC')::date AS pnl_date,
-               signal.strategy_id,SUM(event.realized_pnl_usd) AS daily_pnl
+               COALESCE(signal.strategy_id, %(core_series)s) AS strategy_id,
+               SUM(event.realized_pnl_usd) AS daily_pnl
         FROM strategy_position_ownership ownership
         JOIN strategy_trades trade ON trade.strategy_trade_id=ownership.strategy_trade_id
-        JOIN strategy_funding_decisions funding ON funding.funding_decision_id=trade.funding_decision_id
-        JOIN strategy_signals signal ON signal.signal_id=funding.signal_id
+        LEFT JOIN strategy_funding_decisions funding ON funding.funding_decision_id=trade.funding_decision_id
+        LEFT JOIN strategy_signals signal ON signal.signal_id=funding.signal_id
         JOIN trade_events event ON event.position_id=ownership.broker_position_id
         WHERE event.event_kind='close' AND event.realized_pnl_usd IS NOT NULL
-          AND event.executed_at >= now() - make_interval(days => %s)
-        GROUP BY pnl_date,signal.strategy_id
-        ORDER BY pnl_date,signal.strategy_id
+          AND event.executed_at >= now() - make_interval(days => %(days)s)
+        GROUP BY 1,2
+        ORDER BY 1,2
         """,
-            (days,),
+            {"core_series": CORE_MANDATE_SERIES_ID, "days": days},
         ).fetchall(),
     )
     daily: dict[date, dict[str, Decimal]] = defaultdict(dict)

--- a/app/services/strategy_core_arc_sql.py
+++ b/app/services/strategy_core_arc_sql.py
@@ -1,0 +1,86 @@
+"""Shared SQL fragments for the core/cash arm of ``strategy_trades`` (#2603 item 3).
+
+``sql/349`` made ``strategy_trades`` an exclusive arc: exactly one of
+``funding_decision_id`` (signal arm) and ``core_rebalance_intent_id`` (core arm)
+is non-null.  Seven queries previously reached a trade and then INNER JOINed
+``strategy_funding_decisions``, which silently drops every core trade.
+
+The fragments live here rather than being retyped at each site because the
+requirements they encode -- an actionable verdict, a paper-declared mandate --
+are exactly the kind that drift when duplicated, and a site that drops one
+half fails OPEN.  ``sql/348`` stores holds and refusals as evidence, so the FK
+alone would let a ``refused`` intent back a trade.
+
+⚠⚠ THERE ARE TWO PREDICATES AND THEY ARE NOT INTERCHANGEABLE.
+
+``core_arm_authorised`` is for paths that LOAD A POSITION IN ORDER TO ACT ON IT
+-- the paper cycle's owned batch, the position manager's loader.  It fails
+CLOSED: an intent that is not actionable, or a mandate that is not paper, does
+not load, exactly as a non-paper deployment does not load on the signal arm.
+
+``CORE_ARM_PRESENT`` is for paths that REPORT.  It asks only "is this a core
+trade".  Applying the authorised predicate to a read endpoint would HIDE a
+core position whose mandate or intent went unexpected -- and an invisible
+position is the precise failure this whole slice exists to remove.  On a read
+path, fail closed means show it, not hide it.
+
+Alias discipline: the trade alias is supplied by the caller because the existing
+queries disagree (``t`` and ``trade``).  It is typed ``LiteralString``, and that
+is load-bearing rather than decorative -- ``str.format`` preserves
+``LiteralString`` only when every argument is itself a literal, so a runtime
+string CANNOT reach these fragments and psycopg's own ``LiteralString`` guard on
+``execute`` stays intact all the way to the call site.  Verified against pyright
+1.1.408, not assumed.  The two core aliases are FIXED so a reader can grep
+``core_intent`` / ``core_mandate`` and find every site.
+"""
+
+from __future__ import annotations
+
+from typing import LiteralString
+
+# The join pair every core-aware query needs.  ``mode='paper'`` sits in the ON
+# clause rather than the WHERE so that a LEFT JOIN keeps it a filter on this arm
+# only; ``core_mandate.core_mandate_event_id IS NOT NULL`` then witnesses it.
+#
+# ⚠ A join predicate that also FILTERS is a safety control.  Converting an INNER
+# JOIN to a LEFT JOIN moves that control into the WHERE clause or deletes it --
+# there is no third outcome.  That is why each witness below is explicit rather
+# than inherited from the join shape.
+_CORE_ARM_JOINS: LiteralString = """
+        LEFT JOIN strategy_core_rebalance_intents core_intent
+          ON core_intent.core_rebalance_intent_id={t}.core_rebalance_intent_id
+        LEFT JOIN strategy_core_mandate_events core_mandate
+          ON core_mandate.core_mandate_event_id=core_intent.core_mandate_event_id
+         AND core_mandate.mode='paper'
+"""
+
+# Every link witnessed individually.  Witnessing the intent alone would not
+# prove the mandate resolved, and ``core_intent.action`` alone would not prove
+# the mandate is paper.
+_CORE_ARM_AUTHORISED: LiteralString = """(
+              {t}.core_rebalance_intent_id IS NOT NULL
+              AND core_intent.action IN ('buy_core','sell_core')
+              AND core_mandate.core_mandate_event_id IS NOT NULL
+          )"""
+
+#: Report-path predicate: is this a core trade at all.  No join required, so a
+#: read query needs only to stop INNER JOINing funding.
+_CORE_ARM_PRESENT: LiteralString = "{t}.core_rebalance_intent_id IS NOT NULL"
+
+
+def core_arm_joins(trade: LiteralString) -> LiteralString:
+    """LEFT JOINs binding a trade's core intent and its paper-declared mandate."""
+    return _CORE_ARM_JOINS.format(t=trade)
+
+
+def core_arm_authorised(trade: LiteralString) -> LiteralString:
+    """Predicate admitting a core trade that may be ACTED on. Fails closed.
+
+    Requires :func:`core_arm_joins` on the same query.
+    """
+    return _CORE_ARM_AUTHORISED.format(t=trade)
+
+
+def core_arm_present(trade: LiteralString) -> LiteralString:
+    """Predicate admitting any core trade, for REPORT paths. Fails visible."""
+    return _CORE_ARM_PRESENT.format(t=trade)

--- a/app/services/strategy_core_mandate.py
+++ b/app/services/strategy_core_mandate.py
@@ -50,6 +50,28 @@ CORE_MANDATE_BASE_CURRENCY = "USD"
 # (ticket, sub) per strategy_control_plane's PAPER_ALLOCATOR_ADVISORY_LOCK.
 CORE_MANDATE_ADVISORY_LOCK = (2603, 1)
 
+# The core arm's identity in operator-facing series that key on `strategy_id`
+# (#2603 item 3, step 2).  A core position has no strategy, but the P&L history
+# and the owned-positions list both group by one, so the arm needs a stable key
+# rather than each endpoint inventing a literal.
+#
+# ⚠ Deliberately NOT a value that could collide with a real strategy id: every
+# manifest id is a bare slug, and this one is namespaced.  It is a presentation
+# key only -- nothing joins on it and nothing stores it.
+CORE_MANDATE_SERIES_ID = "core:mandate"
+CORE_MANDATE_SERIES_TITLE = "Core / cash mandate"
+
+# The execution mode this authority DECLARES (sql/349), CHECK-pinned to 'paper'.
+#
+# ⚠ Required on insert with no column default, deliberately: a writer that forgets
+# it must fail rather than inherit safety it never asked for.
+#
+# ⚠⚠ It records the AUTHORITY'S DECLARATION and nothing more. It does not record
+# which account, environment or broker credentials a resulting trade actually
+# used -- the real backstop stays the demo-only credential configuration and
+# `app/security/unattended_guard.py`. Do not cite this as the demo gate.
+CORE_MANDATE_MODE = "paper"
+
 PERCENT_BASIS = Decimal("100")
 # NUMERIC(8,4) percentages and NUMERIC(18,6) amounts, matching sql/311.  Both
 # halves of each column type are enforced: scale, so a value cannot be silently
@@ -368,11 +390,15 @@ def configure_core_mandate(
         INSERT INTO strategy_core_mandate_events (
             revision,enabled,base_currency,core_instrument_id,core_target_pct,
             liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
-            policy_version,changed_by,reason
+            policy_version,changed_by,reason,mode
         )
-        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
         RETURNING core_mandate_event_id
         """,
+        # ⚠ THREE lists that must stay aligned: the column list, the placeholder
+        # count, and this tuple. #2623 shipped a value into the wrong column by
+        # appending at a different ordinal in one of them. `mode` is appended
+        # LAST in all three; check all three when adding a field here.
         (
             revision,
             values.enabled,
@@ -385,6 +411,7 @@ def configure_core_mandate(
             CORE_MANDATE_POLICY_VERSION,
             changed_by,
             reason,
+            CORE_MANDATE_MODE,
         ),
     ).fetchone()
     assert row is not None
@@ -406,6 +433,9 @@ __all__ = [
     "AMOUNT_PLACES",
     "AMOUNT_PRECISION",
     "CORE_MANDATE_ADVISORY_LOCK",
+    "CORE_MANDATE_MODE",
+    "CORE_MANDATE_SERIES_ID",
+    "CORE_MANDATE_SERIES_TITLE",
     "CORE_MANDATE_BASE_CURRENCY",
     "CORE_MANDATE_POLICY_VERSION",
     "PERCENT_BASIS",

--- a/app/services/strategy_paper_executor.py
+++ b/app/services/strategy_paper_executor.py
@@ -716,6 +716,71 @@ def _costs(
     return _CostAssessment(stressed=stressed, net=net, basis=bases.pop())
 
 
+# The two PORTFOLIO-MANDATE observations that are sourced from OUR tables rather
+# than from the broker account snapshot -- and therefore the only two that went
+# blind to a core position when sql/349 added the core/cash arm.
+#
+# ⚠⚠ BOTH FEED HARD GATES, NOT REPORTS.  `open_strategy_lifecycles` is compared
+# against `mandate_max_concurrent_positions`, and `daily_realised_pnl` against
+# the daily loss limit; each returns a refusal.  The first inventory of this
+# slice classified these by JOIN SHAPE and so filed the second as cosmetic P&L
+# history and missed the first entirely.  Classify a query by the DECISION IT
+# FEEDS, not by the tables it touches.
+#
+# Why every OTHER mandate control needed no change: `portfolio_capacity`,
+# `instrument_capacity` and `drawdown` read `risk.total_invested`,
+# `risk.instrument_investments` and `risk.equity` -- the broker account snapshot,
+# which already counts a core position with no code at all.  So the split was
+# never a policy decision; it was an artefact of where each number came from.
+#
+# Counting core here is settled by sql/311, not by preference: the mandate is a
+# PORTFOLIO mandate (stored on `strategy_paper_pool_events`, every limit
+# denominated on `pool_base`), so leaving these two alpha-only would make one
+# mandate enforce two different populations depending on each limit's source.
+# It also errs toward the tighter cap, the correct direction for a risk control.
+#
+# The core arm is admitted by PRESENCE, deliberately.  These are caps: counting a
+# position makes a refusal MORE likely, so presence is the fail-closed choice and
+# the authorised witness chain would be the fail-open one.
+_MANDATE_OBSERVATION_SQL = """
+            SELECT
+                (
+                    SELECT count(*)
+                    FROM strategy_trades trade
+                    LEFT JOIN strategy_funding_decisions decision
+                      ON decision.funding_decision_id=trade.funding_decision_id
+                     AND decision.verdict='allocated'
+                    LEFT JOIN strategy_deployments deployment
+                      ON deployment.deployment_id=decision.deployment_id
+                     AND deployment.mode='paper'
+                    WHERE trade.status NOT IN ('closed','failed')
+                      AND (
+                        deployment.deployment_id IS NOT NULL
+                        OR trade.core_rebalance_intent_id IS NOT NULL
+                      )
+                ),
+                (
+                    SELECT COALESCE(SUM(event.realized_pnl_usd),0)
+                    FROM strategy_position_ownership ownership
+                    JOIN strategy_trades trade
+                      ON trade.strategy_trade_id=ownership.strategy_trade_id
+                    LEFT JOIN strategy_funding_decisions decision
+                      ON decision.funding_decision_id=trade.funding_decision_id
+                    LEFT JOIN strategy_deployments deployment
+                      ON deployment.deployment_id=decision.deployment_id
+                     AND deployment.mode='paper'
+                    JOIN trade_events event
+                      ON event.position_id=ownership.broker_position_id
+                     AND event.event_kind='close'
+                    WHERE event.executed_at >= %s AND event.executed_at < %s
+                      AND (
+                        deployment.deployment_id IS NOT NULL
+                        OR trade.core_rebalance_intent_id IS NOT NULL
+                      )
+                )
+"""
+
+
 def _observe_local_mandate_risk(
     conn: psycopg.Connection[Any],
     *,
@@ -752,35 +817,7 @@ def _observe_local_mandate_risk(
         market_day_start = datetime.combine(market_date, time.min, tzinfo=_NY).astimezone(UTC)
         market_day_end = (datetime.combine(market_date, time.min, tzinfo=_NY) + timedelta(days=1)).astimezone(UTC)
         mandate_row = conn.execute(
-            """
-            SELECT
-                (
-                    SELECT count(*)
-                    FROM strategy_trades trade
-                    JOIN strategy_funding_decisions decision
-                      ON decision.funding_decision_id=trade.funding_decision_id
-                    JOIN strategy_deployments deployment
-                      ON deployment.deployment_id=decision.deployment_id
-                     AND deployment.mode='paper'
-                    WHERE decision.verdict='allocated'
-                      AND trade.status NOT IN ('closed','failed')
-                ),
-                (
-                    SELECT COALESCE(SUM(event.realized_pnl_usd),0)
-                    FROM strategy_position_ownership ownership
-                    JOIN strategy_trades trade
-                      ON trade.strategy_trade_id=ownership.strategy_trade_id
-                    JOIN strategy_funding_decisions decision
-                      ON decision.funding_decision_id=trade.funding_decision_id
-                    JOIN strategy_deployments deployment
-                      ON deployment.deployment_id=decision.deployment_id
-                     AND deployment.mode='paper'
-                    JOIN trade_events event
-                      ON event.position_id=ownership.broker_position_id
-                     AND event.event_kind='close'
-                    WHERE event.executed_at >= %s AND event.executed_at < %s
-                )
-            """,
+            _MANDATE_OBSERVATION_SQL,
             (market_day_start, market_day_end),
         ).fetchone()
         if mandate_row is None:  # pragma: no cover - scalar SELECT always returns one row

--- a/app/services/strategy_paper_runtime.py
+++ b/app/services/strategy_paper_runtime.py
@@ -23,6 +23,7 @@ from app.providers.broker import BrokerProvider
 from app.services.backtest_run import BACKTEST_UNIVERSE
 from app.services.cost_model import COST_MODEL_ID
 from app.services.price_masked_bars import QUARANTINE_RULE_SET_VERSION
+from app.services.strategy_core_arc_sql import core_arm_authorised, core_arm_joins
 from app.services.strategy_forecast_outcome_resolution import RESOLVER_VERSION as FORECAST_OUTCOME_RESOLVER_VERSION
 from app.services.strategy_manifest import STRATEGY_MANIFEST
 from app.services.strategy_opportunity_forecast import FORECAST_POLICY_VERSION
@@ -36,6 +37,43 @@ from app.services.strategy_paper_executor import execute_fired_paper_signal
 from app.services.strategy_position_manager import manage_owned_position
 
 logger = logging.getLogger(__name__)
+
+# The batch that SELECTS the positions to manage.  ⚠⚠ This query, not
+# ``manage_owned_position``, is what decides whether a core position is managed
+# at all: the manager is never called for a trade this does not return.  Widening
+# the worker and not the dispatcher looks complete at every level a diff review
+# inspects, and is the defect this slice exists to avoid (#2603, and #2437's R4
+# pattern one level up).
+#
+# The core arm uses the AUTHORISED predicate -- this path acts on what it loads,
+# so a non-actionable intent or a non-paper mandate must not load, exactly as a
+# non-paper deployment does not load on the signal arm.
+#
+# Signal-arm behaviour is unchanged.  The former INNER ``fd``/``d`` pair filtered
+# by ``d.mode='paper'``; the LEFT pair witnessed by ``d.deployment_id IS NOT
+# NULL`` admits precisely the same rows, because the FK makes ``fd`` total for a
+# non-null ``funding_decision_id`` and ``mode`` now filters inside the ON clause.
+_OWNED_BATCH_SQL = f"""
+        WITH active AS (
+          SELECT own.strategy_trade_id,own.broker_position_id,
+                 row_number() OVER (ORDER BY own.ownership_id) AS ordinal,
+                 count(*) OVER () AS total
+          FROM strategy_position_ownership own
+          JOIN strategy_trades t ON t.strategy_trade_id=own.strategy_trade_id
+          LEFT JOIN strategy_funding_decisions fd ON fd.funding_decision_id=t.funding_decision_id
+          LEFT JOIN strategy_deployments d ON d.deployment_id=fd.deployment_id AND d.mode='paper'
+{core_arm_joins("t")}
+          WHERE own.status='active'
+            AND (
+              d.deployment_id IS NOT NULL
+              OR {core_arm_authorised("t")}
+            )
+        )
+        SELECT strategy_trade_id,broker_position_id
+        FROM active
+        ORDER BY mod(ordinal-1-%s+total,total)
+        LIMIT %s
+"""
 
 
 @dataclass(frozen=True)
@@ -231,6 +269,13 @@ def refresh_strategy_health(
         )
         scan = cur.fetchone()
         assert scan is not None
+        # Core arm admitted by PRESENCE, not by the authorised witness chain
+        # (app/services/strategy_core_arc_sql.py).  This population feeds an
+        # execution BLOCK, so counting a position makes the block more likely to
+        # trip -- presence is the fail-closed choice here, and the authorised
+        # predicate would be the fail-open one.  The signal arm's own predicate
+        # is unchanged: the INNER fd/d pair under `d.mode='paper' AND d.enabled`
+        # is exactly the LEFT pair under `d.deployment_id IS NOT NULL`.
         cur.execute(
             """
             SELECT count(*) FILTER (
@@ -239,10 +284,12 @@ def refresh_strategy_health(
                    count(*) AS total
             FROM strategy_position_ownership own
             JOIN strategy_trades t ON t.strategy_trade_id=own.strategy_trade_id
-            JOIN strategy_funding_decisions fd ON fd.funding_decision_id=t.funding_decision_id
-            JOIN strategy_deployments d ON d.deployment_id=fd.deployment_id
+            LEFT JOIN strategy_funding_decisions fd ON fd.funding_decision_id=t.funding_decision_id
+            LEFT JOIN strategy_deployments d ON d.deployment_id=fd.deployment_id
+             AND d.mode='paper' AND d.enabled
             LEFT JOIN quotes q ON q.instrument_id=t.instrument_id
-            WHERE own.status='active' AND d.mode='paper' AND d.enabled
+            WHERE own.status='active'
+              AND (d.deployment_id IS NOT NULL OR t.core_rebalance_intent_id IS NOT NULL)
             """,
             {"cutoff": observed_at - timedelta(seconds=int(policy["quote_age"]))},
         )
@@ -390,22 +437,7 @@ def run_strategy_paper_cycle(
     # and starve later positions once the sleeve grows past the cap.
     position_offset = (int(observed_at.timestamp()) // 300) * position_limit
     owned = conn.execute(
-        """
-        WITH active AS (
-          SELECT own.strategy_trade_id,own.broker_position_id,
-                 row_number() OVER (ORDER BY own.ownership_id) AS ordinal,
-                 count(*) OVER () AS total
-          FROM strategy_position_ownership own
-          JOIN strategy_trades t ON t.strategy_trade_id=own.strategy_trade_id
-          JOIN strategy_funding_decisions fd ON fd.funding_decision_id=t.funding_decision_id
-          JOIN strategy_deployments d ON d.deployment_id=fd.deployment_id
-          WHERE own.status='active' AND d.mode='paper'
-        )
-        SELECT strategy_trade_id,broker_position_id
-        FROM active
-        ORDER BY mod(ordinal-1-%s+total,total)
-        LIMIT %s
-        """,
+        _OWNED_BATCH_SQL,
         (position_offset, position_limit),
     ).fetchall()
     conn.commit()

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -29,6 +29,7 @@ from app.providers.broker import (
     BrokerProvider,
 )
 from app.services.strategy_control_plane import StrategyControlError, StrategyOwnershipError, link_strategy_order
+from app.services.strategy_core_arc_sql import core_arm_authorised, core_arm_joins
 
 _RATE_QUANTUM = Decimal("0.000001")
 _ADVISORY_HASH_SEED = 0
@@ -65,11 +66,22 @@ class _OwnedPosition:
     strategy_trade_id: int
     broker_position_id: int
     instrument_id: int
-    deployment_id: int
-    entry_stop: Decimal
-    entry_take_profit: Decimal
+    # ⚠ The four fields below became nullable in #2603 step 2, when
+    # ``strategy_trades`` gained the core/cash arm (sql/349).  A core position is
+    # authorised by a mandate rebalance intent, so it has no deployment, no
+    # entry preflight and no execution policy to read them from.
+    #
+    # ``is_core`` is the discriminator and is derived from the AUTHORISATION
+    # column, never from these being NULL.  Null-by-absence would conflate "this
+    # is a core holding" with "this deployment configured no such policy", and a
+    # later default would then silently start applying strategy behaviour to a
+    # mandate holding.
+    is_core: bool
+    deployment_id: int | None
+    entry_stop: Decimal | None
+    entry_take_profit: Decimal | None
     max_position_age_seconds: int | None
-    max_quote_age_seconds: int
+    max_quote_age_seconds: int | None
     ratchet_variant_id: int | None
     break_atr_multiple: Decimal | None
     chandelier_atr_multiple: Decimal | None
@@ -261,12 +273,16 @@ def calculate_ratchet_stop(
     return candidate if candidate > current_stop else None
 
 
-def _load_owned(conn: psycopg.Connection[Any], *, strategy_trade_id: int, broker_position_id: int) -> _OwnedPosition:
-    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
-        cur.execute(
-            """
+# The manager's loader.  Signal-arm behaviour is unchanged: the former INNER
+# chain (funding -> deployment mode='paper' -> preflight verdict='allocated' ->
+# execution policy) is reproduced exactly by the LEFT chain plus the four
+# witnesses below.  Converting an INNER JOIN that also FILTERS into a LEFT JOIN
+# moves that filter into the WHERE clause or deletes it; there is no third
+# outcome, so each is restated rather than assumed.
+_LOAD_OWNED_SQL = f"""
             SELECT own.ownership_id, own.strategy_trade_id, own.broker_position_id,
                    t.instrument_id, d.deployment_id,
+                   t.core_rebalance_intent_id,
                    pre.stop_loss_rate AS entry_stop,
                    pre.take_profit_rate AS entry_take_profit,
                    manager.max_position_age_seconds,
@@ -278,34 +294,72 @@ def _load_owned(conn: psycopg.Connection[Any], *, strategy_trade_id: int, broker
                    q.bid AS quote_bid, q.quoted_at
             FROM strategy_position_ownership own
             JOIN strategy_trades t ON t.strategy_trade_id=own.strategy_trade_id
-            JOIN strategy_funding_decisions funding ON funding.funding_decision_id=t.funding_decision_id
-            JOIN strategy_deployments d ON d.deployment_id=funding.deployment_id AND d.mode='paper'
-            JOIN strategy_entry_preflights pre ON pre.signal_id=funding.signal_id AND pre.verdict='allocated'
-            JOIN strategy_execution_policies execution ON execution.deployment_id=d.deployment_id
+            LEFT JOIN strategy_funding_decisions funding
+              ON funding.funding_decision_id=t.funding_decision_id
+            LEFT JOIN strategy_deployments d
+              ON d.deployment_id=funding.deployment_id AND d.mode='paper'
+            LEFT JOIN strategy_entry_preflights pre
+              ON pre.signal_id=funding.signal_id AND pre.verdict='allocated'
+            LEFT JOIN strategy_execution_policies execution
+              ON execution.deployment_id=d.deployment_id
+{core_arm_joins("t")}
             LEFT JOIN strategy_position_manager_policies manager ON manager.deployment_id=d.deployment_id
             LEFT JOIN strategy_ratchet_variants variant
               ON variant.ratchet_variant_id=manager.ratchet_variant_id
             LEFT JOIN quotes q ON q.instrument_id=t.instrument_id
             WHERE own.strategy_trade_id=%s AND own.broker_position_id=%s AND own.status='active'
               AND t.status IN ('open','closing','reconcile_required')
-            """,
+              AND (
+                (
+                  -- ⚠ EVERY LINK NEEDS ITS OWN WITNESS.  `pre` joins on
+                  -- funding.signal_id and is independent of `d`, so witnessing
+                  -- `pre` alone would let a LIVE deployment load (d NULL, pre
+                  -- resolved).  `execution` likewise carries the quote-age
+                  -- policy that the casts below assume; without its own witness
+                  -- a signal trade could load with max_quote_age_seconds NULL
+                  -- and fail at the quote check instead of never loading.
+                  t.funding_decision_id IS NOT NULL
+                  AND d.deployment_id IS NOT NULL          -- carries mode='paper'
+                  AND execution.deployment_id IS NOT NULL  -- carries the quote-age policy
+                  AND pre.signal_id IS NOT NULL            -- carries verdict='allocated'
+                )
+                OR (
+                  {core_arm_authorised("t")}
+                  -- ⚠ The arc alone does not bind the trade's instrument to the
+                  -- intent's.  Without this, a malformed core trade would
+                  -- authorise the manager to close a DIFFERENT instrument's
+                  -- position.  The two live in different tables, so this is a
+                  -- load-time predicate rather than a CHECK -- and here is where
+                  -- the manager is about to act on it.
+                  AND core_intent.core_instrument_id=t.instrument_id
+                )
+              )
+"""
+
+
+def _load_owned(conn: psycopg.Connection[Any], *, strategy_trade_id: int, broker_position_id: int) -> _OwnedPosition:
+    with conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(
+            _LOAD_OWNED_SQL,
             (strategy_trade_id, broker_position_id),
         )
         row = cur.fetchone()
     if row is None:
         raise StrategyOwnershipError("exact active strategy position ownership is required before broker I/O")
+    is_core = row["core_rebalance_intent_id"] is not None
     return _OwnedPosition(
         ownership_id=int(row["ownership_id"]),
         strategy_trade_id=int(row["strategy_trade_id"]),
         broker_position_id=int(row["broker_position_id"]),
         instrument_id=int(row["instrument_id"]),
-        deployment_id=int(row["deployment_id"]),
-        entry_stop=Decimal(str(row["entry_stop"])),
-        entry_take_profit=Decimal(str(row["entry_take_profit"])),
+        is_core=is_core,
+        deployment_id=int(row["deployment_id"]) if row["deployment_id"] is not None else None,
+        entry_stop=Decimal(str(row["entry_stop"])) if row["entry_stop"] is not None else None,
+        entry_take_profit=(Decimal(str(row["entry_take_profit"])) if row["entry_take_profit"] is not None else None),
         max_position_age_seconds=(
             int(row["max_position_age_seconds"]) if row["max_position_age_seconds"] is not None else None
         ),
-        max_quote_age_seconds=int(row["max_quote_age_seconds"]),
+        max_quote_age_seconds=(int(row["max_quote_age_seconds"]) if row["max_quote_age_seconds"] is not None else None),
         ratchet_variant_id=(int(row["ratchet_variant_id"]) if row["ratchet_variant_id"] is not None else None),
         break_atr_multiple=(Decimal(str(row["break_atr_multiple"])) if row["break_atr_multiple"] is not None else None),
         chandelier_atr_multiple=(
@@ -413,6 +467,30 @@ def _resume_operation(
     if operation is None:
         return None
     operation_id = int(operation["position_operation_id"])
+    # ⚠⚠ THIS FUNCTION RUNS IMMEDIATELY AFTER LOAD, BEFORE ANY GATE, so the core
+    # exemption further down `manage_owned_position` cannot protect it.  A
+    # pending edit operation attached to a core ownership would otherwise resume
+    # a stop / take-profit mutation despite that exemption -- the exemption would
+    # hold on every fresh cycle and leak on exactly the crash-recovery path.
+    #
+    # No such operation can be created today (nothing writes an edit on the core
+    # arm), so this is refused rather than handled: a row that cannot legitimately
+    # exist should stop the cycle for that position, not be interpreted.
+    if owned.is_core and operation["operation_type"] != "close":
+        with conn.transaction():
+            _terminal(
+                conn,
+                operation_id=operation_id,
+                status="rejected",
+                error_code="core_mandate_position_exempt",
+            )
+        return PositionManagerResult(
+            owned.strategy_trade_id,
+            owned.broker_position_id,
+            "rejected",
+            "core_mandate_position_exempt",
+            operation_id,
+        )
     position = _exact_broker_position(broker, owned)
     if operation["status"] == "intent_persisted":
         # There is no edit/close lookup by request UUID. A crash can occur on
@@ -779,12 +857,19 @@ def manage_owned_position(
                 strategy_trade_id, broker_position_id, "reconcile_required", "owned_position_missing"
             )
 
+        # ⚠ Age-out is exempted by an EXPLICIT `is_core` test, never by relying on
+        # ``max_position_age_seconds`` being NULL for a core position.  Null-by-
+        # absence conflates "core is exempt" with "this deployment configured no
+        # age policy", so the day a default is introduced, mandate holdings would
+        # silently start being closed for being old.  A core holding has no
+        # horizon by construction -- that is what makes it core.
+        age_seconds = None if owned.is_core else owned.max_position_age_seconds
         timed_out = (
-            owned.max_position_age_seconds is not None
+            age_seconds is not None
             and position.open_date_time is not None
-            and position.open_date_time <= observed_at - timedelta(seconds=owned.max_position_age_seconds)
+            and position.open_date_time <= observed_at - timedelta(seconds=age_seconds)
         )
-        if owned.max_position_age_seconds is not None and position.open_date_time is None:
+        if age_seconds is not None and position.open_date_time is None:
             with conn.transaction():
                 conn.execute(
                     "UPDATE strategy_trades SET status='reconcile_required', updated_at=now() "
@@ -810,6 +895,33 @@ def manage_owned_position(
                 trigger_code=close_reason or "timeout",
             )
 
+        # ⚠⚠ THE CORE RETURN MUST PRECEDE THIS LINE, not merely guard the
+        # `if stop_gap or take_gap` body: the two lines below already dereference
+        # ``entry_stop`` / ``entry_take_profit``, which are NULL on the core arm.
+        #
+        # What a core position is exempt FROM: stop-forcing, take-profit-forcing
+        # and ratcheting.  Each converts a mandate into a strategy.  A stop on a
+        # benchmark holding sells the benchmark into a drawdown -- and "return to
+        # core/cash" is the outcome the viability plan falls back TO, so a stop
+        # underneath it would be giving the fallback a fallback.
+        #
+        # What it is NOT exempt from, and this is what makes the exemption safe:
+        # it is still selected by the paper cycle's batch, loaded here,
+        # reconciled when the broker disagrees, and closable on an explicit
+        # close_reason.  Exempt from three behaviours, not absent from the system.
+        #
+        # ⚠ Its own reason code.  Reusing `position_protected` would assert that a
+        # stop exists and is adequate; on this arm there is no stop at all.
+        if owned.is_core:
+            return PositionManagerResult(
+                strategy_trade_id, broker_position_id, "no_change", "core_mandate_position_exempt"
+            )
+
+        # Past this point the signal arm is guaranteed by _LOAD_OWNED_SQL's
+        # witnesses: a loaded non-core position has a preflight and an execution
+        # policy, so these are non-null.
+        assert owned.entry_stop is not None and owned.entry_take_profit is not None
+        assert owned.max_quote_age_seconds is not None
         current_stop = position.stop_loss_rate
         desired_stop = max(current_stop, owned.entry_stop) if current_stop is not None else owned.entry_stop
         desired_take = owned.entry_take_profit

--- a/app/services/strategy_position_manager.py
+++ b/app/services/strategy_position_manager.py
@@ -920,8 +920,16 @@ def manage_owned_position(
         # Past this point the signal arm is guaranteed by _LOAD_OWNED_SQL's
         # witnesses: a loaded non-core position has a preflight and an execution
         # policy, so these are non-null.
-        assert owned.entry_stop is not None and owned.entry_take_profit is not None
-        assert owned.max_quote_age_seconds is not None
+        #
+        # ⚠ `raise`, NOT `assert`. `python -O` strips asserts, and this guard is
+        # what stands between a mis-witnessed load predicate and a `NoneType`
+        # comparison inside the stop/take-profit arithmetic below. Stripped, the
+        # failure mode is not "no check" but "a confusing TypeError three lines
+        # later, in the code that decides where a stop goes".
+        if owned.entry_stop is None or owned.entry_take_profit is None or owned.max_quote_age_seconds is None:
+            raise StrategyPositionManagerError(
+                "a non-core owned position must carry its entry preflight and execution policy"
+            )
         current_stop = position.stop_loss_rate
         desired_stop = max(current_stop, owned.entry_stop) if current_stop is not None else owned.entry_stop
         desired_take = owned.entry_take_profit

--- a/docs/proposals/ta/2026-08-14-core-trade-arc.md
+++ b/docs/proposals/ta/2026-08-14-core-trade-arc.md
@@ -65,6 +65,49 @@ invisible because a missing row looks like no work rather than like an error.
 and the frontend types follow. **That is the reason step 2 is not a backend-only change**,
 and it was invisible in the draft.
 
+### A′. The two mandate controls sourced from OUR tables — **missed by the first inventory**
+
+⚠ **Third mis-statement, same direction as the first two.** The inventory above was built by
+grepping `strategy_trades` / `strategy_position_ownership` and classifying by *join shape*.
+That reads a query's plumbing, not its consequence, so it filed
+`strategy_paper_executor.py:768-782` under "as above" — i.e. cosmetic P&L history — and did
+not surface `strategy_paper_executor.py:756-767` at all. Both are scalars of one query in
+`_observe_local_mandate_risk` (719-813), and **both feed hard risk gates**, not reports:
+
+| scalar | line | gate | consequence of omitting core |
+| --- | --- | --- | --- |
+| `open_strategy_lifecycles` | 756-767 | `>= mandate_max_concurrent_positions` → `portfolio_concurrency_limit` (790) | the concurrency cap under-counts, so the signal arm may open `max_concurrent_positions + N_core` positions |
+| `daily_realised_pnl` | 768-782 | `<= -daily_loss_limit` → `portfolio_daily_loss_limit` (793) | a core close's realised loss never counts against the daily loss limit, so the limit under-trips |
+
+**Why exactly these two, and no others in that function.** Every *other* mandate control in
+`_risk_and_amount` is sourced from the **broker account snapshot**, and therefore already
+counts a core position with no code change at all:
+
+| control | source | core counted today? |
+| --- | --- | --- |
+| `portfolio_capacity` (844) | `risk.total_invested` | ✅ broker snapshot |
+| `instrument_capacity` (848) | `risk.instrument_investments` | ✅ broker snapshot |
+| `drawdown` (836-839) | `risk.equity` | ✅ broker snapshot |
+| `cash_reserve_capacity` (850), `active_risk_capacity` (856) | `intent.pool_reserved` | pot bookkeeping — signal-arm by construction |
+| **`open_strategy_lifecycles`, `daily_realised_pnl`** | **our tables, INNER JOIN funding** | ❌ **blind to core** |
+
+So the split is not a policy decision anybody made — it is an artefact of which controls
+happen to read the broker and which read our own tables. **A grep that classifies by join
+shape cannot see this**, which is the generalisable lesson: *classify a query by the
+decision it feeds, not by the tables it touches.* A query that INNER JOINs funding is a
+finding about plumbing; a query whose scalar sits on the left of a `>=` guarding a return
+is a finding about safety.
+
+**Decision — core counts in both.** Not an operator call; `sql/311` settles it. The mandate
+is a *portfolio* mandate (stored on `strategy_paper_pool_events`, every limit denominated on
+`pool_base`), and the broker-sourced majority above already counts core. Leaving the two
+table-sourced ones alpha-only would make one mandate enforce two different populations
+depending on where each limit's number came from. Counting core also errs toward the tighter
+cap, which is the correct direction for a risk control.
+
+⚠ These are reachable from a bare trade row plus ownership — no order, no executor — so by
+this document's own sequencing rule they are **step 2, not step 3**.
+
 ### B. Starts from a funding decision — signal-arm-only **by design**, correctly unchanged
 
 `strategy_monitoring.py:202, 445, 655`; `strategy_live_gate.py:411, 464, 491`;
@@ -73,12 +116,37 @@ and it was invisible in the draft.
 decision become a trade"). A core trade has no funding decision and belongs in none of
 them.
 
+Also class B, added 2026-08-14 after re-running the grep — the first inventory left them
+unclassified rather than placing them:
+
+- `strategy_control_plane.py:289, 293` — the committed-capital `EXISTS` pair. Starts from
+  `strategy_funding_decisions` under `deployment.mode='paper'`; asks whether an *allocated
+  decision* became an open trade. Core has no decision to commit against.
+- `strategy_live_gate.py:423` — a LATERAL keyed on `t.strategy_trade_id`, but inside a query
+  rooted at `strategy_signals`. Signal-arm by its root, not by this join.
+
 ### C. Keys on `strategy_trade_id` / `broker_position_id` — **arm-agnostic already**
 
 `strategy_order_reconciliation.py:141, 260, 365`; `strategy_wealth.py:48, 60, 77`;
 `strategy_paper_executor.py`'s status `UPDATE`s. These work on a core trade unchanged,
 which is the strongest argument for the exclusive arc over a sibling table: an arc costs
 these nothing, a sibling table would need every one of them dual-written.
+
+Also class C, added 2026-08-14 on the same re-run — all keyed by `strategy_trade_id` and/or
+`broker_position_id`, so arm-agnostic already: `strategy_control_plane.py:1058`
+(`link_strategy_order`), `:1092` (`claim_exact_position`), `:1147`
+(`assert_exact_position_owned`); `strategy_position_manager.py:368` and its status `UPDATE`s
+(373, 440, 487, 632, 693, 717, 774, 790).
+
+### D. Fail-closed on core, but only reachable once the executor exists — **step 3**
+
+`strategy_paper_executor.py:925-935` — the uncertain-submission resume path. It reaches a
+trade from an *order*, then INNER JOINs funding **and** `strategy_entry_preflights`. On a
+core trade it returns no row and raises `"uncertain strategy submission identity is
+incomplete"` (941-942) rather than silently dropping — so it fails closed, which is the
+right default. But a core trade whose submission went uncertain could then never resolve.
+Listed here so step 3 owes it explicitly; it needs an entry *order* to be reachable, and
+only step 3 creates one.
 
 ## The arc
 
@@ -217,7 +285,8 @@ moment it applies, and this project's own tests and fixtures create rows directl
 today because no core trade exists" stops being true at the migration, not at the writer.
 
 So step 2 is: `sql/349` + `strategy_position_manager` + `strategy_paper_runtime` (both
-queries) + `api/strategies.py` (four queries) + the nullable `strategy_id`/`strategy_version`
+queries) + `strategy_paper_executor._observe_local_mandate_risk` (both mandate scalars, per
+class A′) + `api/strategies.py` (four queries) + the nullable `strategy_id`/`strategy_version`
 in the owned-position response and its frontend types. That is the coherent unit. It is
 substantially larger than "relax one join", which is the finding this document exists to
 record.

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2743,8 +2743,13 @@ export interface StrategyPnlHistoryResponse {
 export interface StrategyOwnedPosition {
   strategy_trade_id: number;
   broker_position_id: number;
-  strategy_id: string;
-  strategy_version: string;
+  /**
+   * Null on the core/cash arm (#2603): a mandate holding is authorised by a
+   * rebalance intent, not a signal, so it has no strategy identity. Use
+   * `strategy_title`, which is never null and carries the mandate label.
+   */
+  strategy_id: string | null;
+  strategy_version: string | null;
   strategy_title: string;
   instrument_id: number;
   symbol: string;

--- a/sql/349_core_trade_arc.sql
+++ b/sql/349_core_trade_arc.sql
@@ -1,0 +1,142 @@
+-- 349_core_trade_arc.sql
+--
+-- #2603 item 3, execution half, step 2.  Step 1 (sql/348) recorded the core
+-- rebalance VERDICT and deliberately authorised nothing.  This migration makes a
+-- core holding STORABLE and therefore visible to the position manager.
+--
+-- Spec: docs/proposals/ta/2026-08-14-core-trade-arc.md
+--
+-- ⚠⚠ THE SHAPE IS AN EXCLUSIVE ARC ON `strategy_trades`, NOT A SIBLING TABLE.
+-- Settled in the spec, and the deciding evidence is the consumer inventory's
+-- class C: `strategy_order_reconciliation`, `strategy_wealth`, the status
+-- UPDATEs and the three `strategy_control_plane` helpers all key on
+-- `strategy_trade_id` / `broker_position_id` and work on a core trade with no
+-- change at all.  An arc costs them nothing.  A sibling table would have to be
+-- dual-written into every one of them, and each omission would be a silently
+-- unreconciled position.
+--
+-- ⚠⚠ THE MIGRATION IS THE MOMENT THE INVARIANT CHANGES, NOT THE WRITER.  From
+-- the instant this applies, a core trade row is legal -- and this repo's tests
+-- and fixtures insert rows directly.  So every query that would DROP such a row
+-- is fixed in the same commit; "correct today because no core trade exists yet"
+-- stops being true here.  Nothing writes a core trade yet (step 3 owns the
+-- executor), but nothing may silently lose one either.
+--
+-- Blast radius: `strategy_trades` has 0 rows on dev, as do
+-- `strategy_funding_decisions`, `strategy_position_ownership`,
+-- `strategy_deployments`, `strategy_core_mandate_events` and
+-- `strategy_core_rebalance_intents`.  Reproduce:
+--   SELECT count(*) FROM strategy_trades;   -- 0
+-- So there is no backfill and no rewrite; every constraint below is added
+-- against an empty table and can be stated at full strength.
+
+---------------------------------------------------------------------------
+-- 1.  The arc.
+---------------------------------------------------------------------------
+
+ALTER TABLE strategy_trades
+    ADD COLUMN IF NOT EXISTS core_rebalance_intent_id BIGINT
+        REFERENCES strategy_core_rebalance_intents(core_rebalance_intent_id)
+        ON DELETE RESTRICT;
+
+-- ⚠ DROP NOT NULL AUDIT (docs/review-prevention-log.md): every CHECK, index
+-- predicate and generated column mentioning the column silently changes meaning
+-- from "enforced" to "enforced except on NULL".  Run BEFORE relying on this:
+--
+--   SELECT conrelid::regclass, conname, pg_get_constraintdef(oid) FROM pg_constraint
+--    WHERE pg_get_constraintdef(oid) LIKE '%funding_decision_id%';
+--   SELECT tablename, indexname FROM pg_indexes WHERE indexdef LIKE '%funding_decision_id%';
+--   SELECT table_name, column_name FROM information_schema.columns
+--    WHERE generation_expression LIKE '%funding_decision%';
+--
+-- Result on dev 2026-08-14: three constraints
+-- (`strategy_funding_decisions_pkey`, `strategy_trades_funding_decision_id_key`
+-- UNIQUE, `strategy_trades_funding_decision_id_fkey`), two indexes (both the
+-- above), ZERO CHECKs, zero partial-index predicates, zero generated columns.
+-- The UNIQUE therefore weakens from "every trade has a funding decision, at most
+-- one each" to "at most one each" -- which is intended, and the exactly-one CHECK
+-- below restores the other half for both arms at once.
+--
+-- ⚠ The catalogue is only the DATABASE half.  The APPLICATION half is the same
+-- audit and is larger: casts like `int(row["max_quote_age_seconds"])` and
+-- `Decimal(str(row["entry_stop"]))` assume a funding-backed trade.  Those are
+-- handled in the same commit, in the load predicates rather than here.
+ALTER TABLE strategy_trades
+    ALTER COLUMN funding_decision_id DROP NOT NULL;
+
+-- Exactly one authorisation, never both and never neither.  `num_nonnulls` is
+-- NULL-safe by construction, which is the point: a bare `a IS NULL <> b IS NULL`
+-- pair invites the `col = x` passes-on-NULL trap (prevention log, #2679).
+ALTER TABLE strategy_trades
+    DROP CONSTRAINT IF EXISTS strategy_trades_exactly_one_authorisation;
+ALTER TABLE strategy_trades
+    ADD CONSTRAINT strategy_trades_exactly_one_authorisation CHECK (
+        num_nonnulls(funding_decision_id, core_rebalance_intent_id) = 1
+    );
+
+-- One trade per authorisation, on the core arm as on the signal arm.  Without
+-- this the two arms would enforce different cardinalities off one CHECK, and a
+-- repeated rebalance evaluation could open a second position against a verdict
+-- already acted on.  ⚠ A UNIQUE index does not constrain NULLs, so this bounds
+-- the core arm only -- exactly as `strategy_trades_funding_decision_id_key` now
+-- bounds only the signal arm.
+CREATE UNIQUE INDEX IF NOT EXISTS strategy_trades_core_rebalance_intent_id_key
+    ON strategy_trades (core_rebalance_intent_id)
+    WHERE core_rebalance_intent_id IS NOT NULL;
+
+COMMENT ON COLUMN strategy_trades.core_rebalance_intent_id IS
+    'Core/cash arm authorisation (#2603 item 3). Exactly one of this and '
+    'funding_decision_id is non-null. A trade on this arm has no signal, no '
+    'deployment and no execution policy, so any query projecting those must '
+    'tolerate NULL rather than INNER JOIN them away.';
+
+COMMENT ON COLUMN strategy_trades.funding_decision_id IS
+    'Signal arm authorisation. NULLABLE since sql/349: a core trade is '
+    'authorised by core_rebalance_intent_id instead. NULL here does NOT mean '
+    'unauthorised -- see strategy_trades_exactly_one_authorisation.';
+
+---------------------------------------------------------------------------
+-- 2.  The core arm's declared paper mode.
+---------------------------------------------------------------------------
+--
+-- The signal arm's demo property is `strategy_deployments.mode = 'paper'`, which
+-- the load predicate witnesses.  A mandate has no deployment, so without this the
+-- core arm would ship with no equivalent link to witness.
+--
+-- ⚠ REQUIRED ON INSERT, NOT DEFAULTED.  A DEFAULT 'paper' would let a writer that
+-- forgets the column inherit safety it never asked for; the next policy that
+-- admits a second mode would then silently relabel those rows.
+--
+-- ⚠⚠ STATE PLAINLY WHAT THIS IS NOT.  An event-level constant records the
+-- AUTHORITY'S DECLARED mode.  It does not record which account, environment or
+-- broker credentials a trade actually used, and nothing here can.  The real
+-- backstop remains the demo-only credential configuration and
+-- `app/security/unattended_guard.py`.  Calling this "the equivalent of the
+-- deployment gate" would overstate it; it is the same SHAPE of gate over a
+-- weaker claim.
+--
+-- ⚠ ADDED NULLABLE, BACKFILLED, THEN CONSTRAINED -- three statements where one
+-- would do TODAY.  Postgres cannot add a NOT NULL column with no default to a
+-- non-empty table, and `strategy_core_mandate_events` is empty on dev (0 rows,
+-- verified) only because `configure_core_mandate` currently has NO caller --
+-- no endpoint, no job, no script.  That is a fact about today's wiring, not a
+-- property of the schema, and it is the first thing the next slice changes.
+-- The three-step form costs nothing on an empty table and keeps the migration
+-- applicable to a machine that acquired a row before pulling it.
+ALTER TABLE strategy_core_mandate_events
+    ADD COLUMN IF NOT EXISTS mode TEXT;
+
+UPDATE strategy_core_mandate_events SET mode = 'paper' WHERE mode IS NULL;
+
+ALTER TABLE strategy_core_mandate_events
+    ALTER COLUMN mode SET NOT NULL;
+
+ALTER TABLE strategy_core_mandate_events
+    DROP CONSTRAINT IF EXISTS strategy_core_mandate_events_mode_check;
+ALTER TABLE strategy_core_mandate_events
+    ADD CONSTRAINT strategy_core_mandate_events_mode_check CHECK (mode = 'paper');
+
+COMMENT ON COLUMN strategy_core_mandate_events.mode IS
+    'Declared execution mode of this mandate revision. CHECK-pinned to paper for '
+    'the current policy. Records the authority''s declaration only -- NOT the '
+    'account or credentials a resulting trade actually used.';

--- a/tests/test_2603_core_arc_sql.py
+++ b/tests/test_2603_core_arc_sql.py
@@ -1,0 +1,80 @@
+"""#2603 item 3 step 2 — the two core-arm predicates must stay DIFFERENT.
+
+Pure-logic: these assert on the composed SQL text, no database.
+
+⚠ The regression this guards is a TIDY-UP, not a bug. There are two predicates
+that look near-identical and a reader will reasonably want to collapse them into
+one. Collapsing in either direction is a defect, and neither direction fails any
+existing test:
+
+* authorised → present on an ACT path would let a ``refused`` intent or a
+  non-paper mandate authorise the manager to trade.
+* present → authorised on a REPORT path would HIDE a core position from the
+  operator -- which is the precise failure the whole slice exists to remove. On
+  a read path, failing closed means SHOWING the row, not hiding it.
+
+The DB module (``test_2603_core_trade_arc_db``) proves what the act path admits
+and refuses against real rows. This one pins the distinction itself, which is a
+property of the source and not of any row.
+"""
+
+from __future__ import annotations
+
+from app.services.strategy_core_arc_sql import (
+    core_arm_authorised,
+    core_arm_joins,
+    core_arm_present,
+)
+
+
+def test_the_authorised_predicate_witnesses_every_link() -> None:
+    """Each conjunct proves a DIFFERENT thing; any one missing fails open.
+
+    The arc column alone proves only that the row is a core trade -- not that its
+    verdict was actionable (sql/348 stores holds and refusals as evidence), and
+    not that the governing mandate declared paper.
+    """
+    predicate = core_arm_authorised("t")
+    assert "t.core_rebalance_intent_id IS NOT NULL" in predicate
+    assert "core_intent.action IN ('buy_core','sell_core')" in predicate
+    assert "core_mandate.core_mandate_event_id IS NOT NULL" in predicate
+
+
+def test_the_report_predicate_requires_neither_verdict_nor_mandate() -> None:
+    """⚠ The half that is easy to 'fix' into a bug.
+
+    A report asks only "is this a core trade". If this ever starts requiring an
+    actionable verdict, a core position that has been HELD -- the normal steady
+    state of a core sleeve -- vanishes from the operator's positions list.
+    """
+    predicate = core_arm_present("trade")
+    assert predicate == "trade.core_rebalance_intent_id IS NOT NULL"
+    assert "action" not in predicate
+    assert "core_mandate" not in predicate
+
+
+def test_the_two_predicates_are_not_the_same_string() -> None:
+    assert core_arm_authorised("t") != core_arm_present("t")
+
+
+def test_the_alias_reaches_every_reference_in_the_joins() -> None:
+    """A half-substituted alias would silently correlate the subquery to the
+    wrong table rather than fail -- Postgres resolves an unqualified outer name.
+    """
+    joins = core_arm_joins("trade")
+    assert "{t}" not in joins
+    assert "trade.core_rebalance_intent_id" in joins
+    # The mandate is bound through the intent, never straight off the trade.
+    assert "core_mandate.core_mandate_event_id=core_intent.core_mandate_event_id" in joins
+    assert "core_mandate.mode='paper'" in joins
+
+
+def test_the_paper_filter_sits_in_the_join_not_the_caller() -> None:
+    """``mode='paper'`` must live in the ON clause so a LEFT JOIN keeps it a
+    filter on this arm only; the caller then witnesses it with an IS NOT NULL.
+    If it migrated to a WHERE clause it would delete the signal arm's rows.
+    """
+    joins = core_arm_joins("t")
+    paper_line_index = joins.index("core_mandate.mode='paper'")
+    assert "WHERE" not in joins[:paper_line_index]
+    assert "LEFT JOIN strategy_core_mandate_events core_mandate" in joins[:paper_line_index]

--- a/tests/test_2603_core_mandate_db.py
+++ b/tests/test_2603_core_mandate_db.py
@@ -21,6 +21,7 @@ import psycopg
 import pytest
 
 from app.services.strategy_core_mandate import (
+    CORE_MANDATE_MODE,
     CORE_MANDATE_POLICY_VERSION,
     CoreMandateError,
     configure_core_mandate,
@@ -31,11 +32,11 @@ _INSERT = """
 INSERT INTO strategy_core_mandate_events (
     revision,enabled,base_currency,core_instrument_id,core_target_pct,
     liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
-    policy_version,changed_by,reason
+    policy_version,changed_by,reason,mode
 ) VALUES (
     1,%(enabled)s,%(base_currency)s,%(core_instrument_id)s,%(core_target_pct)s,
     %(liquidity_reserve_pct)s,%(rebalance_band_pct)s,%(min_rebalance_amount)s,
-    %(policy_version)s,'test','test'
+    %(policy_version)s,'test','test',%(mode)s
 )
 """
 
@@ -51,6 +52,9 @@ _VALID_ROW: dict[str, Any] = {
     # CHECK and not merely assumed: a literal here would make a stale version
     # untestable at the only layer that can still be handed one.
     "policy_version": CORE_MANDATE_POLICY_VERSION,
+    # sql/349. Parameterised for the same reason as policy_version: the CHECK
+    # pins it to 'paper', and a literal here could not exercise a wrong value.
+    "mode": CORE_MANDATE_MODE,
 }
 
 

--- a/tests/test_2603_core_rebalance_intent.py
+++ b/tests/test_2603_core_rebalance_intent.py
@@ -131,35 +131,57 @@ def _mentions_table_in_code(path: Path) -> bool:
     )
 
 
-def test_no_module_outside_the_writer_reads_the_intents_table() -> None:
-    """The enforceable half of "authorises nothing".
+#: Every module allowed to name this table in EXECUTED SQL, and why.
+#:
+#: ⚠ Step 1 asserted this list was EMPTY apart from the writer -- that was the
+#: enforceable half of "authorises nothing", and step 2 (sql/349) deliberately
+#: ends it: the arc gives a row here a way to become a trade. The guard is kept
+#: rather than deleted, converted from "nobody reads it" to "exactly these do",
+#: because the hazard it was really tracking never went away -- an UNREVIEWED
+#: reader is what turns a stored verdict into an action nobody agreed to.
+_SANCTIONED_READERS = {
+    # The writer.
+    "app/services/strategy_core_rebalance_intent.py",
+    # The shared load fragments. Every act-path consumer composes its predicate
+    # from here rather than naming the table, so this stays a one-line list even
+    # as consumers multiply -- and the requirements (actionable verdict, paper
+    # mandate) cannot drift between them.
+    "app/services/strategy_core_arc_sql.py",
+}
 
-    A durable ``buy_core`` row is only safe to ship ahead of an executor because
-    nothing can act on it. When the executor lands it will read this table, and
-    this test is what forces that change to arrive alongside the trade linkage
-    and the position-manager change rather than on its own.
-    """
-    offenders = [
-        str(path) for path in Path("app").rglob("*.py") if str(path) != _WRITER and _mentions_table_in_code(path)
-    ]
+
+def test_only_sanctioned_modules_read_the_intents_table() -> None:
+    """A new reader must be added here deliberately, in the PR that adds it."""
+    offenders = sorted(
+        str(path)
+        for path in Path("app").rglob("*.py")
+        if str(path) not in _SANCTIONED_READERS and _mentions_table_in_code(path)
+    )
     assert offenders == [], (
-        f"{_TABLE} gained a reader outside {_WRITER}: {offenders}. "
-        "It authorises nothing only while nothing reads it — see #2603 item 3."
+        f"{_TABLE} gained an unsanctioned reader: {offenders}. "
+        "Add it to _SANCTIONED_READERS with its reason, or route it through "
+        "strategy_core_arc_sql so the load predicate stays single-sourced."
     )
 
 
-def test_no_table_references_the_intents_table() -> None:
-    """The other half: an FK would let a row here become a row somewhere real.
+def test_only_the_trade_arc_references_the_intents_table() -> None:
+    """An FK is what lets a row here become a row somewhere real.
 
-    The next slice adds exactly that FK, from ``strategy_trades``, together with
-    the manager change. Until then a reference is the whole hazard.
+    ⚠ Step 1 asserted NO table referenced it. ``sql/349`` adds exactly one, from
+    ``strategy_trades``, which is the arc. Pinned to that single migration so a
+    SECOND referencing table -- a sibling design this slice explicitly rejected,
+    because it would need every arm-agnostic consumer dual-written -- cannot land
+    without this failing.
     """
-    referencing = [
+    referencing = sorted(
         path.name
         for path in Path("sql").glob("*.sql")
         if re.search(rf"REFERENCES\s+{_TABLE}\b", path.read_text(encoding="utf-8"))
-    ]
-    assert referencing == [], f"a table now references {_TABLE}: {referencing}"
+    )
+    assert referencing == ["349_core_trade_arc.sql"], (
+        f"the set of tables referencing {_TABLE} changed: {referencing}. "
+        "The arc is deliberately the only one — see docs/proposals/ta/2026-08-14-core-trade-arc.md."
+    )
 
 
 def test_the_migration_reason_codes_match_the_allocator_vocabulary() -> None:

--- a/tests/test_2603_core_rebalance_intent_db.py
+++ b/tests/test_2603_core_rebalance_intent_db.py
@@ -25,7 +25,7 @@ import psycopg
 import pytest
 
 from app.services.strategy_core_allocator import CoreSleeveState
-from app.services.strategy_core_mandate import CORE_MANDATE_POLICY_VERSION
+from app.services.strategy_core_mandate import CORE_MANDATE_MODE, CORE_MANDATE_POLICY_VERSION
 from app.services.strategy_core_rebalance_intent import record_core_rebalance_intent
 
 _INSERT = """
@@ -99,11 +99,11 @@ def _seed_mandate(conn: psycopg.Connection[Any]) -> int:
         INSERT INTO strategy_core_mandate_events (
             revision,enabled,base_currency,core_instrument_id,core_target_pct,
             liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
-            policy_version,changed_by,reason
-        ) VALUES (1,TRUE,'USD',%s,60,20,5,25,%s,'test','test')
+            policy_version,changed_by,reason,mode
+        ) VALUES (1,TRUE,'USD',%s,60,20,5,25,%s,'test','test',%s)
         RETURNING core_mandate_event_id
         """,
-        (_INSTRUMENT_ID, CORE_MANDATE_POLICY_VERSION),
+        (_INSTRUMENT_ID, CORE_MANDATE_POLICY_VERSION, CORE_MANDATE_MODE),
     ).fetchone()
     assert row is not None
     return int(row[0])

--- a/tests/test_2603_core_trade_arc_db.py
+++ b/tests/test_2603_core_trade_arc_db.py
@@ -1,0 +1,405 @@
+"""#2603 item 3 step 2 — what ``sql/349`` enforces, and which queries SELECT a core trade.
+
+Two things are under test and they fail differently, so they are kept apart.
+
+**The migration's backstop.** Raw INSERTs, bypassing every writer, because a CHECK
+that only ever sees writer-produced values is not demonstrably a backstop
+(``docs/review-prevention-log.md``: #2679; same posture as the step-1 module).
+
+**The dispatcher.** ⚠⚠ The defect this slice exists to prevent is NOT "the manager
+mishandles a core position" — it is "nothing ever hands the manager one".
+``manage_owned_position`` is never called for a trade the paper cycle's batch does
+not return, so a widened worker under an unwidened dispatcher looks complete at
+every level a diff review inspects. The batch query is therefore exercised
+directly, as a query, against rows that exist.
+
+⚠ In its own ``_db`` module deliberately: the string ``ebull_test_conn`` in a test
+source db-marks the WHOLE module at collection.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import psycopg
+import psycopg.rows
+import pytest
+
+from app.services.strategy_core_mandate import CORE_MANDATE_MODE, CORE_MANDATE_POLICY_VERSION
+from app.services.strategy_paper_runtime import _OWNED_BATCH_SQL
+from app.services.strategy_position_manager import _LOAD_OWNED_SQL
+
+_INSTRUMENT_ID = 920605
+_OTHER_INSTRUMENT_ID = 920606
+_PAST = datetime(2026, 1, 2, 9, 0, tzinfo=UTC)
+
+
+def _seed_instruments(conn: psycopg.Connection[Any]) -> None:
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (%s,'CORE.ARC','Core Arc Test',TRUE),(%s,'CORE.OTHER','Core Arc Other',TRUE) "
+        "ON CONFLICT DO NOTHING",
+        (_INSTRUMENT_ID, _OTHER_INSTRUMENT_ID),
+    )
+
+
+def _seed_mandate(conn: psycopg.Connection[Any], *, mode: str = CORE_MANDATE_MODE) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO strategy_core_mandate_events (
+            revision,enabled,base_currency,core_instrument_id,core_target_pct,
+            liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
+            policy_version,changed_by,reason,mode
+        ) VALUES (1,TRUE,'USD',%s,60,20,5,25,%s,'test','test',%s)
+        RETURNING core_mandate_event_id
+        """,
+        (_INSTRUMENT_ID, CORE_MANDATE_POLICY_VERSION, mode),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _seed_intent(
+    conn: psycopg.Connection[Any],
+    *,
+    event_id: int,
+    action: str = "buy_core",
+    instrument_id: int = _INSTRUMENT_ID,
+) -> int:
+    """One actionable intent by default; ``action`` is what the callers vary."""
+    refused = action == "refused"
+    row = conn.execute(
+        """
+        INSERT INTO strategy_core_rebalance_intents (
+            core_mandate_event_id, allocator_policy_version, recorded_by,
+            core_instrument_id, currency, core_market_value, cash_balance,
+            state_as_of, action, reason_code, amount, core_pct, target_pct,
+            lower_pct, upper_pct, effective_floor, floor_source,
+            reserve_breached, reserve_margin_pct
+        ) VALUES (
+            %(event_id)s, %(policy)s, 'test', %(instrument_id)s, 'USD', 600, 400,
+            %(state_as_of)s, %(action)s, %(reason_code)s, %(amount)s,
+            %(core_pct)s, %(target_pct)s, %(lower_pct)s, %(upper_pct)s,
+            %(floor)s, %(floor_source)s, %(breached)s, %(margin)s
+        )
+        RETURNING core_rebalance_intent_id
+        """,
+        {
+            "event_id": event_id,
+            "policy": CORE_MANDATE_POLICY_VERSION,
+            "instrument_id": instrument_id,
+            "state_as_of": _PAST,
+            "action": action,
+            # sql/348 requires a refusal to CITE a code, and separately requires
+            # 'core_mandate_absent' to be the one code with no event row. This
+            # seed has an event, so the code must be any other one.
+            "reason_code": "core_sleeve_empty" if refused else None,
+            "amount": Decimal("0") if action in ("hold", "refused") else Decimal("50"),
+            # sql/348's shape CHECK requires every derived field NULL on a
+            # refusal and non-NULL otherwise, so they move together with action.
+            "core_pct": None if refused else Decimal("60"),
+            "target_pct": None if refused else Decimal("60"),
+            "lower_pct": None if refused else Decimal("55"),
+            "upper_pct": None if refused else Decimal("65"),
+            "floor": None if refused else Decimal("25"),
+            "floor_source": None if refused else "mandate",
+            "breached": None if refused else False,
+            "margin": None if refused else Decimal("10"),
+        },
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _seed_core_position(
+    conn: psycopg.Connection[Any],
+    *,
+    intent_id: int,
+    instrument_id: int = _INSTRUMENT_ID,
+) -> tuple[int, int]:
+    """An open core trade with active ownership. Returns (trade_id, position_id)."""
+    trade = conn.execute(
+        "INSERT INTO strategy_trades (core_rebalance_intent_id,instrument_id,status) "
+        "VALUES (%s,%s,'open') RETURNING strategy_trade_id",
+        (intent_id, instrument_id),
+    ).fetchone()
+    assert trade is not None
+    trade_id = int(trade[0])
+    position_id = 7_700_000 + trade_id
+    conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id,broker_position_id,status,claimed_at) "
+        "VALUES (%s,%s,'active',now())",
+        (trade_id, position_id),
+    )
+    return trade_id, position_id
+
+
+# --------------------------------------------------------------------------
+# The migration's backstop.
+# --------------------------------------------------------------------------
+
+
+def test_a_core_trade_stores_with_no_funding_decision(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """The whole point of the arc: before sql/349 this row could not exist."""
+    _seed_instruments(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    trade_id, _ = _seed_core_position(ebull_test_conn, intent_id=intent_id)
+    row = ebull_test_conn.execute(
+        "SELECT funding_decision_id,core_rebalance_intent_id FROM strategy_trades WHERE strategy_trade_id=%s",
+        (trade_id,),
+    ).fetchone()
+    assert row == (None, intent_id)
+
+
+def test_neither_authorisation_is_rejected(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """⚠ The half a plain nullable column would have silently allowed.
+
+    Dropping NOT NULL on funding_decision_id without the exactly-one CHECK would
+    make an UNAUTHORISED trade storable -- a strictly worse state than the
+    pre-migration one it was meant to relax.
+    """
+    _seed_instruments(ebull_test_conn)
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(
+            "INSERT INTO strategy_trades (instrument_id,status) VALUES (%s,'open')",
+            (_INSTRUMENT_ID,),
+        )
+
+
+def test_both_authorisations_are_rejected(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    _seed_instruments(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    deployment_id, funding_id = _seed_signal_funding(ebull_test_conn)
+    assert deployment_id
+    with pytest.raises(psycopg.errors.CheckViolation):
+        ebull_test_conn.execute(
+            "INSERT INTO strategy_trades (funding_decision_id,core_rebalance_intent_id,instrument_id,status) "
+            "VALUES (%s,%s,%s,'open')",
+            (funding_id, intent_id, _INSTRUMENT_ID),
+        )
+
+
+def test_one_trade_per_intent(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """Each arm keeps one-trade-per-authorisation; a repeat rebalance must not
+    open a second position against a verdict already acted on."""
+    _seed_instruments(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    _seed_core_position(ebull_test_conn, intent_id=intent_id)
+    with pytest.raises(psycopg.errors.UniqueViolation):
+        ebull_test_conn.execute(
+            "INSERT INTO strategy_trades (core_rebalance_intent_id,instrument_id,status) VALUES (%s,%s,'open')",
+            (intent_id, _INSTRUMENT_ID),
+        )
+
+
+def test_a_mandate_requires_an_explicit_mode(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """⚠ NOT DEFAULTED, on purpose: a writer that forgets must fail rather than
+    inherit safety it never asked for."""
+    _seed_instruments(ebull_test_conn)
+    with pytest.raises(psycopg.errors.NotNullViolation):
+        ebull_test_conn.execute(
+            """
+            INSERT INTO strategy_core_mandate_events (
+                revision,enabled,base_currency,core_instrument_id,core_target_pct,
+                liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
+                policy_version,changed_by,reason
+            ) VALUES (1,TRUE,'USD',%s,60,20,5,25,%s,'test','test')
+            """,
+            (_INSTRUMENT_ID, CORE_MANDATE_POLICY_VERSION),
+        )
+
+
+# --------------------------------------------------------------------------
+# The dispatcher: which rows the paper cycle's batch actually SELECTS.
+# --------------------------------------------------------------------------
+
+
+def _batch_trade_ids(conn: psycopg.Connection[Any]) -> set[int]:
+    return {int(row[0]) for row in conn.execute(_OWNED_BATCH_SQL, (0, 50)).fetchall()}
+
+
+def test_the_owned_batch_selects_a_core_position(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    """⚠⚠ THE DECISIVE ASSERTION OF THIS SLICE.
+
+    If this fails, ``manage_owned_position`` is never invoked for a core holding
+    and every other change here is dead code -- which is exactly the state the
+    first two drafts of the plan would have shipped.
+    """
+    _seed_instruments(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    trade_id, _ = _seed_core_position(ebull_test_conn, intent_id=intent_id)
+    assert trade_id in _batch_trade_ids(ebull_test_conn)
+
+
+@pytest.mark.parametrize("action", ["hold", "refused"])
+def test_the_owned_batch_refuses_a_non_actionable_intent(ebull_test_conn: psycopg.Connection[Any], action: str) -> None:
+    """sql/348 stores holds and refusals as evidence, so the FK alone would let a
+    refusal back a trade. The load predicate, not convention, is what forbids it."""
+    _seed_instruments(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn), action=action)
+    trade_id, _ = _seed_core_position(ebull_test_conn, intent_id=intent_id)
+    assert trade_id not in _batch_trade_ids(ebull_test_conn)
+
+
+def test_the_loader_refuses_a_trade_whose_instrument_is_not_the_intents(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """Without this the manager would be authorised to close a DIFFERENT
+    instrument's position. The two columns live in separate tables, so this is a
+    load-time predicate rather than a CHECK."""
+    _seed_instruments(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    trade_id, position_id = _seed_core_position(
+        ebull_test_conn, intent_id=intent_id, instrument_id=_OTHER_INSTRUMENT_ID
+    )
+    loaded = ebull_test_conn.execute(_LOAD_OWNED_SQL, (trade_id, position_id)).fetchone()
+    assert loaded is None
+
+
+def test_the_loader_returns_a_core_position_with_null_signal_policy(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The four fields that became nullable, asserted as NULL together -- they are
+    what the manager's core exemption then has to avoid dereferencing."""
+    _seed_instruments(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    trade_id, position_id = _seed_core_position(ebull_test_conn, intent_id=intent_id)
+    with ebull_test_conn.cursor(row_factory=psycopg.rows.dict_row) as cur:
+        cur.execute(_LOAD_OWNED_SQL, (trade_id, position_id))
+        row = cur.fetchone()
+    assert row is not None
+    assert row["core_rebalance_intent_id"] == intent_id
+    assert row["deployment_id"] is None
+    assert row["entry_stop"] is None
+    assert row["entry_take_profit"] is None
+    assert row["max_quote_age_seconds"] is None
+
+
+# --------------------------------------------------------------------------
+# The signal arm must be untouched by all of the above.
+# --------------------------------------------------------------------------
+
+
+def _seed_signal_funding(conn: psycopg.Connection[Any]) -> tuple[int, int]:
+    """A paper deployment with one allocated funding decision. Returns (deployment, funding)."""
+    _seed_instruments(conn)
+    signal = conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id,strategy_version,instrument_id,signal_bar_date,
+            signal_kind,verdict,fill_bar_date,fill_price,universe,
+            input_rule_set_versions
+        )
+        VALUES ('arc_test','arc-v1',%s,DATE '2026-01-02','entry','fired',
+                DATE '2026-01-05',10,'survivor_only','{"arc":"v1"}'::jsonb)
+        RETURNING signal_id
+        """,
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert signal is not None
+    deployment = conn.execute(
+        """
+        INSERT INTO strategy_deployments (
+            strategy_id,strategy_version,mode,capital_limit,currency,enabled,updated_by,reason
+        )
+        VALUES ('arc_test','arc-v1','paper',1000,'USD',TRUE,'test','test')
+        RETURNING deployment_id
+        """
+    ).fetchone()
+    assert deployment is not None
+    funding = conn.execute(
+        """
+        INSERT INTO strategy_funding_decisions (deployment_id,signal_id,verdict,amount,reason_code)
+        VALUES (%s,%s,'allocated',100,'test')
+        RETURNING funding_decision_id
+        """,
+        (int(deployment[0]), int(signal[0])),
+    ).fetchone()
+    assert funding is not None
+    return int(deployment[0]), int(funding[0])
+
+
+def test_the_owned_batch_still_selects_a_signal_position(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """⚠ The regression the LEFT-JOIN rewrite could silently cause.
+
+    Converting an INNER JOIN that also FILTERS into a LEFT JOIN moves that filter
+    into the WHERE clause or deletes it. This asserts the signal arm still loads
+    at all; the paired test below asserts the filter was moved, not deleted.
+    """
+    _, funding_id = _seed_signal_funding(ebull_test_conn)
+    trade = ebull_test_conn.execute(
+        "INSERT INTO strategy_trades (funding_decision_id,instrument_id,status) "
+        "VALUES (%s,%s,'open') RETURNING strategy_trade_id",
+        (funding_id, _INSTRUMENT_ID),
+    ).fetchone()
+    assert trade is not None
+    trade_id = int(trade[0])
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id,broker_position_id,status,claimed_at) "
+        "VALUES (%s,%s,'active',now())",
+        (trade_id, 7_800_000 + trade_id),
+    )
+    assert trade_id in _batch_trade_ids(ebull_test_conn)
+
+
+def test_the_owned_batch_still_excludes_a_live_deployment(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """⚠⚠ The paper gate, asserted on the INPUT rather than assumed from the shape.
+
+    ``d.mode='paper'`` moved from the WHERE clause into a LEFT JOIN's ON clause.
+    That is only safe because ``d.deployment_id IS NOT NULL`` witnesses it -- and
+    if the witness were ever dropped, every previous test here would still pass
+    while a LIVE position started loading.
+    """
+    _seed_instruments(ebull_test_conn)
+    signal = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_signals (
+            strategy_id,strategy_version,instrument_id,signal_bar_date,
+            signal_kind,verdict,fill_bar_date,fill_price,universe,
+            input_rule_set_versions
+        )
+        VALUES ('arc_live','arc-v1',%s,DATE '2026-01-02','entry','fired',
+                DATE '2026-01-05',10,'survivor_only','{"arc":"v1"}'::jsonb)
+        RETURNING signal_id
+        """,
+        (_INSTRUMENT_ID,),
+    ).fetchone()
+    assert signal is not None
+    deployment = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_deployments (
+            strategy_id,strategy_version,mode,capital_limit,currency,enabled,updated_by,reason
+        )
+        VALUES ('arc_live','arc-v1','live',1000,'USD',TRUE,'test','test')
+        RETURNING deployment_id
+        """
+    ).fetchone()
+    assert deployment is not None
+    funding = ebull_test_conn.execute(
+        """
+        INSERT INTO strategy_funding_decisions (deployment_id,signal_id,verdict,amount,reason_code)
+        VALUES (%s,%s,'allocated',100,'test')
+        RETURNING funding_decision_id
+        """,
+        (int(deployment[0]), int(signal[0])),
+    ).fetchone()
+    assert funding is not None
+    trade = ebull_test_conn.execute(
+        "INSERT INTO strategy_trades (funding_decision_id,instrument_id,status) "
+        "VALUES (%s,%s,'open') RETURNING strategy_trade_id",
+        (int(funding[0]), _INSTRUMENT_ID),
+    ).fetchone()
+    assert trade is not None
+    trade_id = int(trade[0])
+    ebull_test_conn.execute(
+        "INSERT INTO strategy_position_ownership (strategy_trade_id,broker_position_id,status,claimed_at) "
+        "VALUES (%s,%s,'active',now())",
+        (trade_id, 7_900_000 + trade_id),
+    )
+    assert trade_id not in _batch_trade_ids(ebull_test_conn)


### PR DESCRIPTION
Step 2 of #2603 item 3's execution half. Step 1 (`8af38991`, `sql/348`) recorded the
core rebalance verdict and deliberately authorised nothing. This makes a core holding
**storable, and therefore visible to the position manager**.

Plan: `docs/proposals/ta/2026-08-14-core-trade-arc.md` (`73b6806f`), corrected in this PR —
see "Plan corrections" below.

## What changed

`sql/349` makes `strategy_trades` an **exclusive arc**: `core_rebalance_intent_id` joins
`funding_decision_id`, `num_nonnulls(...) = 1`, one trade per authorisation on each arm.
`strategy_core_mandate_events` gains a required `mode` declaring paper.

Not a sibling table. The deciding evidence is the inventory's class C —
`strategy_order_reconciliation`, `strategy_wealth`, the status `UPDATE`s and the three
`strategy_control_plane` helpers all key on `strategy_trade_id` / `broker_position_id`
and work on a core trade **unchanged**. An arc costs them nothing; a sibling table would
need every one of them dual-written, and each omission would be a silently unreconciled
position.

**The migration is the moment the invariant changes, not the writer.** From the instant
it applies, a core trade row is legal, and this repo's tests and fixtures insert rows
directly. So every query that would *drop* such a row is fixed in the same commit.
Nothing writes a core trade yet (step 3 owns the executor); nothing may silently lose
one either.

| query | was | now |
| --- | --- | --- |
| `strategy_paper_runtime.py:398` — the cycle's owned batch | core never managed | selected (authorised) |
| `strategy_paper_runtime.py:240` — quote-freshness health | population incomplete | counted (present) |
| `strategy_position_manager.py:279` — `_load_owned` | core unloadable | loads, arm-discriminated |
| `strategy_paper_executor.py:756` — `open_strategy_lifecycles` | **cap under-counted** | counts core |
| `strategy_paper_executor.py:768` — `daily_realised_pnl` | **loss limit under-tripped** | counts core |
| `api/strategies.py:1861` — owned positions | core invisible to operator | rendered |
| `api/strategies.py:2054` — P&L history | core closes excluded | folded into one series |

## Plan corrections — found by re-running the plan's own discriminator

The plan's scope had already been mis-stated twice in the same direction. Re-running its
reproduce command found a third, plus two mis-citations.

**`_observe_local_mandate_risk` was missed entirely, and it is the most serious.** The
inventory classified queries by *join shape*, so it filed `768-782` as cosmetic P&L
history and did not surface `756-767` at all. Both are scalars of one query and **both
feed hard gates**: `>= mandate_max_concurrent_positions → portfolio_concurrency_limit`,
and `<= -daily_loss_limit → portfolio_daily_loss_limit`.

They are the *only two* mandate controls sourced from our tables. Every other one reads
the broker account snapshot (`risk.total_invested`, `risk.instrument_investments`,
`risk.equity`) and therefore already counted a core position with no code at all. The
split was never a policy decision — it was an artefact of where each number came from.
Core now counts in both, settled by `sql/311`: the mandate is a *portfolio* mandate,
every limit denominated on `pool_base`, so leaving these two alpha-only would make one
mandate enforce two different populations. It also errs toward the tighter cap.

Generalisable: **classify a query by the decision it feeds, not by the tables it touches.**

Two mis-citations, both meaning *less* work, not more:

- `api/strategies.py:1998` has no funding join at all — already arm-agnostic. It is the
  close-endpoint ownership check, not P&L history.
- `api/strategies.py:2462` is strategy-scoped by design. A core holding must **not**
  block retiring a strategy it does not belong to.

## Two predicates, deliberately not one

`app/services/strategy_core_arc_sql.py`. The regression to guard against here is a
*tidy-up*, not a bug — the two look near-identical and neither collapse fails any
pre-existing test.

- **act paths fail closed** — actionable verdict + paper mandate, each link witnessed
  individually. `sql/348` stores holds and refusals as evidence, so the FK alone would
  let a `refused` intent back a trade.
- **report paths fail visible** — hiding a position is the precise failure this slice
  removes. On a read path, failing closed means *showing* the row.

The trade alias is typed `LiteralString`, which is load-bearing rather than decorative:
`str.format` preserves `LiteralString` only when every argument is literal, so psycopg's
own guard on `execute` stays intact through the fragments. Verified against pyright
1.1.408 with a two-case probe — the single-case probe passes for the wrong reason.

## What the manager does to a core position

**Applied:** reconciliation and explicit close. **Exempt:** stop-forcing,
take-profit-forcing, ratcheting, age-out — each converts a mandate into a strategy. A
stop on a benchmark holding sells the benchmark into a drawdown, and "return to
core/cash" is the outcome the viability plan falls back *to*.

The exemption is safe only because the position is still **selected, loaded, reconciled
and closable** — exempt from behaviours, not absent from the system. Three placements
that would each silently defeat it:

- the core return precedes the stop dereference, not just the `if stop_gap` body;
- age-out is gated on `is_core` **explicitly**, never on a NULL policy — null-by-absence
  would conflate "core is exempt" with "no age policy configured", and a later default
  would start ageing out mandate holdings;
- `_resume_operation` runs *before* any gate, so it refuses a non-close operation on the
  arm itself — otherwise the exemption holds every fresh cycle and leaks on exactly the
  crash-recovery path.

Its own reason code (`core_mandate_position_exempt`). Reusing `position_protected` would
assert a stop exists.

## Verification

| clause | evidence |
| --- | --- |
| `DROP NOT NULL` audit | catalogue query in the migration; 3 constraints, 2 indexes, **0** CHECKs, 0 generated columns. Only the UNIQUE weakens, intentionally. |
| blast radius | `strategy_trades` 0 rows, as are funding/ownership/deployments/mandate/intents. No backfill. |
| fresh build | test DBs dropped and rebuilt from migrations; arc tests green |
| arc matrix | core stores with no funding; neither and both authorisations rejected; one-trade-per-intent; mandate `mode` required |
| dispatcher | a core position **is** returned by the real batch query; a `hold` and a `refused` intent are not; a trade whose instrument ≠ the intent's does not load |
| signal arm intact | still selected; a **live** deployment still excluded — the paper filter moved into an ON clause, so this asserts the witness was moved and not deleted |
| live endpoint | `/strategies/positions` → 200 with one seeded core position rendering as `strategy_title: "Core / cash mandate"`, `strategy_id: null`; `/strategies/pnl-history` → 200. Rows removed afterwards, counts back to 0. |
| gates | ruff, ruff-format, pyright, `-m "not db"`, smoke, targeted `-m db` (11 modules), `pnpm typecheck`, `pnpm test:unit` (1515) — all green |
| Codex checkpoint 2 | one P1 on the first pass (see below); clean on the second |

**Codex P1, and why the fix landed despite a false rationale.** Codex said the `NOT NULL`
`mode` column would fail "because the existing API can create mandate events". That is
false — `configure_core_mandate` has *no* caller: no endpoint, no job, no script. But the
fragility is real in a narrower form: emptiness is a fact about today's wiring, not a
property of the schema, and it is the first thing the next slice changes. The migration
now adds nullable → backfills → constrains, which costs nothing on an empty table.

## Frontend

`strategy_id` / `strategy_version` become nullable. `strategy_title` stays non-null and
carries the mandate label, because it is what the operator reads to tell the two
populations apart. The row component renders only `strategy_title`, so no component
change was needed — confirmed by reading it, not by the typecheck passing.

## Step-1 guards converted, not deleted

`test_no_module_outside_the_writer_reads_the_intents_table` and
`test_no_table_references_the_intents_table` asserted step 1's "authorises nothing", which
this PR deliberately ends. They are now allowlists — exactly one referencing migration
(the arc) and a named set of reader modules — because the hazard they tracked never went
away: an *unreviewed* reader is what turns a stored verdict into an action nobody agreed
to.

## Security model

Touches an execution authorisation path, so this is not a "not applicable" case.

The arc widens what may be *stored* and what may be *loaded*; it does not widen what may
be *submitted* — step 3 owns the executor and still owes one-trade-per-intent at
submission, a no-open-core-trade precondition, an `evaluated_at` freshness bound, and
eligibility re-proof bound to the exact account and credential pair.

Three controls added rather than assumed: an actionable verdict is required
structurally, not by convention; the trade's instrument must equal the intent's, without
which a malformed core trade would authorise the manager to close a *different*
instrument's position; and the mandate must declare paper.

⚠ **What `mode` is not.** It records the authority's *declaration*. It does not record
which account, environment or broker credentials a trade actually used, and nothing at
event level can. The real backstop remains the demo-only credential configuration and
`app/security/unattended_guard.py`. Calling it "the equivalent of the deployment gate"
would overstate it — it is the same shape of gate over a weaker claim.

## Not in scope

Step 3 (the executor) still owes the four preconditions above, plus
`strategy_paper_executor.py:925-935` — the uncertain-submission resume path, which fails
*closed* on a core trade today (raises rather than dropping) but could then never
resolve. It needs an entry order to be reachable, and only step 3 creates one.

Refs #2603. Refs #2437.
