### PR TITLE
feature(#2602): give the local EOD valuation a measured effective-mark date

### DIFF
--- a/app/services/account_equity_evidence.py
+++ b/app/services/account_equity_evidence.py
@@ -130,6 +130,54 @@ def record_account_equity_snapshot(
     return row is not None
 
 
+def mark_effectiveness_reasons(
+    *,
+    snapshot_date: date,
+    oldest_mark_date: date | None,
+    positions_priced: int,
+) -> tuple[str, ...]:
+    """Name what is unknown about WHEN the local valuation's marks were effective.
+
+    #2602 item 4. Until ``sql/350`` this function did not exist and its caller
+    appended ``local_eod_effective_time_unknown`` **unconditionally**, on the
+    reasoning that ``computed_at`` records when the local job ran rather than
+    when its closing prices were effective. That was true, and it was permanent
+    by construction — nothing recorded the marks' dates, so no evidence could
+    ever retire the caveat. ``portfolio_eod`` now stores them, so the caveat is
+    measured and usually absent.
+
+    ⚠ A DATE, not a timestamp, is the defensible effective time here. The marks
+    are daily closes, and "the close of session D" identifies a market instant
+    exactly; a wall-clock stamp would add precision the input does not have.
+    What the date does NOT settle is whether a same-day bar was final when it was
+    read — deliberately not modelled, because on this corpus it does not arise
+    (``max(price_daily.price_date)`` trails ``current_date``, and the EOD job
+    runs after the US close). Inventing a refusal for a state we have never
+    observed would be the mirror of the defect this replaces.
+
+    ⚠ ``local_eod_effective_time_unknown`` keeps its slug rather than gaining a
+    clearer one. It now means exactly one thing — the row predates ``sql/350`` —
+    and renaming it would make the pre-migration rows, which are the only rows it
+    can describe, read as a new condition.
+    """
+    if oldest_mark_date is None:
+        # Two shapes, one of which is not a caveat at all: no priced position
+        # means nothing carried a mark, so there is no effective time to be
+        # unknown (an all-cash snapshot, or one whose positions all failed to
+        # price — the latter already reported by `local_eod_valuation_incomplete`).
+        return ("local_eod_effective_time_unknown",) if positions_priced > 0 else ()
+    if oldest_mark_date < snapshot_date:
+        # The total is stamped `snapshot_date` but at least one of its inputs is
+        # older, so the valuation is a blend of sessions. ⚠ The verdict is taken
+        # from the DATE BOUND alone and not from `stale_mark_positions`, which
+        # would be a second source of truth for the same fact and could disagree
+        # with it. The count is stored for magnitude — "3 of 7 positions" is what
+        # makes the caveat actionable — and is deliberately not a decision input.
+        return ("local_eod_marks_carried_forward",)
+    # Every priced mark is on the snapshot's own session. Nothing to caveat.
+    return ()
+
+
 def load_account_equity_evidence(
     conn: psycopg.Connection[Any], *, environment: Literal["demo", "real"]
 ) -> AccountEquityEvidence:
@@ -149,7 +197,13 @@ def load_account_equity_evidence(
                coalesce(local.positions_no_price,0) > 0
                  OR coalesce(local.positions_no_fx,0) > 0
                  OR coalesce(local.cash_no_fx_currencies,0) > 0 AS local_valuation_incomplete,
-               latest.account_currency_id
+               latest.account_currency_id,
+               -- ⚠ `stale_mark_positions` is deliberately NOT projected. The
+               -- verdict comes from `oldest_mark_date` alone (see
+               -- `mark_effectiveness_reasons`), and the count has no API
+               -- consumer yet — it is stored evidence for the reconciliation
+               -- write-up, queryable directly. #2602 item 4.
+               local.oldest_mark_date,local.positions_priced
         FROM latest
         LEFT JOIN portfolio_eod_snapshots local ON local.snapshot_date=latest.snapshot_date
         """,
@@ -198,10 +252,13 @@ def load_account_equity_evidence(
             reasons.append("local_eod_currency_mismatch")
         if bool(row[10]):
             reasons.append("local_eod_valuation_incomplete")
-        # computed_at is when the local job ran, not when its closing prices
-        # were effective. Do not call these totals reconciled until the local
-        # valuation carries a defensible effective market timestamp.
-        reasons.append("local_eod_effective_time_unknown")
+        reasons.extend(
+            mark_effectiveness_reasons(
+                snapshot_date=row[1],
+                oldest_mark_date=row[12],
+                positions_priced=int(row[13]),
+            )
+        )
     return AccountEquityEvidence(
         status="collecting",
         days_collected=int(row[0]),

--- a/app/services/portfolio_eod.py
+++ b/app/services/portfolio_eod.py
@@ -15,6 +15,7 @@ demo key). See spec docs/proposals/etl/2026-06-13-portfolio-value-v2-fx-eod.md.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
@@ -52,6 +53,13 @@ class PositionInput:
     # entry.  Kept separate from display FX: strategy accounting is USD even
     # when the operator views the main portfolio in GBP/EUR.
     open_conversion_rate: Decimal = Decimal("1")
+    # ⚠ `price_daily.price_date` OF `close` — the date the mark is effective, not
+    # the date the snapshot is stamped.  The lookup is carry-forward
+    # (`price_date <= snapshot_date ORDER BY price_date DESC`), so an instrument
+    # that has not traded since is marked from an older bar and the two differ.
+    # #2602 item 4: this was fetched and discarded, which is what made
+    # `local_eod_effective_time_unknown` permanent.  None exactly when `close` is.
+    mark_price_date: date | None = None
 
 
 @dataclass(frozen=True)
@@ -64,6 +72,53 @@ class PositionResult:
     value_display: Decimal | None
     price_status: PriceStatus
     unrealised_pnl_usd: Decimal | None = None
+    #: Carried through from ``PositionInput`` unchanged — evidence, not a decision.
+    mark_price_date: date | None = None
+
+
+@dataclass(frozen=True)
+class MarkEffectiveness:
+    """When the marks behind a snapshot's ``positions_value`` were effective.
+
+    ⚠ ``oldest_mark_date`` is a MIN, not a MAX. "As of when is this total true"
+    is bounded by the STALEST input — a snapshot dated today whose worst mark is
+    a week old is a week-old valuation with a today-shaped label on it, and the
+    freshest mark says nothing about that.
+
+    ⚠ ``oldest_mark_date is None`` reads two ways once the value is STORED, and
+    only one of them matters:
+
+    * ``positions_priced > 0`` — the row predates ``sql/350``, so its marks were
+      never recorded. The effective time is genuinely unknown.
+    * ``positions_priced == 0`` — no position contributed to ``positions_value``
+      at all (all cash, or every position unpriced). Pre- and post-migration rows
+      are indistinguishable here **and need not be distinguished**: neither has a
+      mark, so neither has an effective time to be unknown.
+
+    So ``positions_priced`` is the discriminator, and it is only load-bearing in
+    the first case. ``account_equity_evidence.load_account_equity_evidence`` is
+    the only reader that needs it.
+    """
+
+    oldest_mark_date: date | None
+    stale_mark_positions: int
+
+
+def summarise_marks(results: Sequence[PositionResult], snapshot_date: date) -> MarkEffectiveness:
+    """Reduce per-position mark dates to the snapshot-level effectiveness bound.
+
+    ⚠ PRICED POSITIONS ONLY. A ``no_price`` position has no mark to be stale,
+    and a ``no_fx`` one — priced natively but not convertible — contributed
+    nothing to ``positions_value``, so neither can bound a total they are not in.
+    Both are already reported by their own counters, so nothing is hidden by
+    excluding them; including them would make the bound describe a different
+    number than the one it is attached to.
+    """
+    marks = [r.mark_price_date for r in results if r.price_status == "priced" and r.mark_price_date is not None]
+    return MarkEffectiveness(
+        oldest_mark_date=min(marks) if marks else None,
+        stale_mark_positions=sum(1 for mark in marks if mark < snapshot_date),
+    )
 
 
 @dataclass(frozen=True)
@@ -107,8 +162,21 @@ def compute_eod_equity(
     for p in positions:
         if p.close is None:
             no_price += 1
+            # `mark_price_date` is passed rather than left to its default: the
+            # LATERAL filters `close IS NOT NULL`, so it is provably None here —
+            # but a result that is correct only because of an invariant in
+            # another function is one edit away from being wrong silently.
             results.append(
-                PositionResult(p.position_id, p.instrument_id, p.units, p.native_ccy, None, None, "no_price")
+                PositionResult(
+                    p.position_id,
+                    p.instrument_id,
+                    p.units,
+                    p.native_ccy,
+                    None,
+                    None,
+                    "no_price",
+                    mark_price_date=p.mark_price_date,
+                )
             )
             continue
         # Mark-to-market equity, mirroring app/api/portfolio.py:348-357.
@@ -135,6 +203,7 @@ def compute_eod_equity(
                     None,
                     "no_fx",
                     unrealised_pnl_usd,
+                    mark_price_date=p.mark_price_date,
                 )
             )
             continue
@@ -154,6 +223,7 @@ def compute_eod_equity(
                     None,
                     "no_fx",
                     unrealised_pnl_usd,
+                    mark_price_date=p.mark_price_date,
                 )
             )
             continue
@@ -169,6 +239,7 @@ def compute_eod_equity(
                 value_display,
                 "priced",
                 unrealised_pnl_usd,
+                mark_price_date=p.mark_price_date,
             )
         )
 
@@ -234,16 +305,23 @@ def _read_positions(conn: psycopg.Connection[Any], snapshot_date: date) -> list[
                 b.open_conversion_rate,
                 b.is_buy,
                 i.currency AS native_ccy,
-                (
-                    SELECT close FROM price_daily
-                    WHERE instrument_id = b.instrument_id
-                      AND price_date <= %(d)s
-                      AND close IS NOT NULL
-                    ORDER BY price_date DESC
-                    LIMIT 1
-                ) AS close
+                mark.close AS close,
+                mark.price_date AS mark_price_date
             FROM broker_positions b
             JOIN instruments i USING (instrument_id)
+            -- ⚠ LATERAL, not two correlated scalar subqueries. The mark and the
+            -- date it is effective must come from the SAME bar; two independent
+            -- subqueries would re-run the ordering and could in principle be
+            -- planned against different rows, which is a defect no test would
+            -- see because they agree on every ordinary corpus. #2602 item 4.
+            LEFT JOIN LATERAL (
+                SELECT close, price_date FROM price_daily
+                WHERE instrument_id = b.instrument_id
+                  AND price_date <= %(d)s
+                  AND close IS NOT NULL
+                ORDER BY price_date DESC
+                LIMIT 1
+            ) AS mark ON TRUE
             WHERE b.position_id >= 0 AND b.units > 0
             """,
             {"d": snapshot_date},
@@ -260,6 +338,7 @@ def _read_positions(conn: psycopg.Connection[Any], snapshot_date: date) -> list[
             open_rate=Decimal(str(r["open_rate"])),
             is_buy=bool(r["is_buy"]),
             open_conversion_rate=Decimal(str(r["open_conversion_rate"])),
+            mark_price_date=r["mark_price_date"],
         )
         for r in rows
     ]
@@ -308,12 +387,13 @@ def compute_and_store_eod_snapshot(conn: psycopg.Connection[Any]) -> EodEquity:
         rates, fx_rate_date = load_fx_rates_for_date(conn, snapshot_date)
 
     equity = compute_eod_equity(positions, cash, display_ccy, rates)
+    marks = summarise_marks(equity.position_results, snapshot_date)
 
     with conn.transaction():
-        _write_snapshot(conn, snapshot_date, display_ccy, fx_rate_date, equity)
+        _write_snapshot(conn, snapshot_date, display_ccy, fx_rate_date, equity, marks)
 
     logger.info(
-        "eod_snapshot %s: total=%s priced=%d/%d no_price=%d no_fx=%d fx_date=%s",
+        "eod_snapshot %s: total=%s priced=%d/%d no_price=%d no_fx=%d fx_date=%s oldest_mark=%s stale_marks=%d",
         snapshot_date,
         equity.total_value,
         equity.positions_priced,
@@ -321,6 +401,8 @@ def compute_and_store_eod_snapshot(conn: psycopg.Connection[Any]) -> EodEquity:
         equity.positions_no_price,
         equity.positions_no_fx,
         fx_rate_date,
+        marks.oldest_mark_date,
+        marks.stale_mark_positions,
     )
     return equity
 
@@ -331,6 +413,7 @@ def _write_snapshot(
     display_ccy: str,
     fx_rate_date: date | None,
     equity: EodEquity,
+    marks: MarkEffectiveness,
 ) -> None:
     with conn.cursor() as cur:
         cur.execute(
@@ -338,10 +421,12 @@ def _write_snapshot(
             INSERT INTO portfolio_eod_snapshots (
                 snapshot_date, display_currency, total_value, positions_value, cash_value,
                 fx_rate_date, positions_total, positions_priced, positions_no_price,
-                positions_no_fx, cash_no_fx_currencies, computed_at
+                positions_no_fx, cash_no_fx_currencies, oldest_mark_date,
+                stale_mark_positions, computed_at
             ) VALUES (
                 %(d)s, %(ccy)s, %(total)s, %(pos)s, %(cash)s,
-                %(fxd)s, %(ptot)s, %(ppri)s, %(pnp)s, %(pnf)s, %(cnf)s, NOW()
+                %(fxd)s, %(ptot)s, %(ppri)s, %(pnp)s, %(pnf)s, %(cnf)s, %(omd)s,
+                %(smp)s, NOW()
             )
             ON CONFLICT (snapshot_date) DO UPDATE SET
                 display_currency = EXCLUDED.display_currency,
@@ -354,6 +439,12 @@ def _write_snapshot(
                 positions_no_price = EXCLUDED.positions_no_price,
                 positions_no_fx = EXCLUDED.positions_no_fx,
                 cash_no_fx_currencies = EXCLUDED.cash_no_fx_currencies,
+                -- ⚠ A re-run must be able to move these BACK to NULL/0. Omitting
+                -- them from the update set would leave a stale bound sitting
+                -- beside a freshly recomputed total, which is worse than never
+                -- having recorded one.
+                oldest_mark_date = EXCLUDED.oldest_mark_date,
+                stale_mark_positions = EXCLUDED.stale_mark_positions,
                 computed_at = NOW()
             """,
             {
@@ -368,6 +459,8 @@ def _write_snapshot(
                 "pnp": equity.positions_no_price,
                 "pnf": equity.positions_no_fx,
                 "cnf": equity.cash_no_fx_currencies,
+                "omd": marks.oldest_mark_date,
+                "smp": marks.stale_mark_positions,
             },
         )
         # Per-position rows: replace wholesale for this date (re-run overwrites).
@@ -378,11 +471,15 @@ def _write_snapshot(
         if equity.position_results:
             cur.executemany(
                 """
+                -- ⚠ TWO POSITIONAL LISTS THAT MUST AGREE, edited separately: the
+                -- column list here and the tuple below. A new column appended at
+                -- a different ordinal in one of them binds silently to the wrong
+                -- field, and nothing types it. Append to BOTH tails together.
                 INSERT INTO portfolio_eod_position_snapshots (
                     snapshot_date, position_id, instrument_id, units,
                     close_price, native_currency, value_display, price_status,
-                    unrealised_pnl_usd
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    unrealised_pnl_usd, mark_price_date
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 [
                     (
@@ -395,6 +492,7 @@ def _write_snapshot(
                         r.value_display,
                         r.price_status,
                         r.unrealised_pnl_usd,
+                        r.mark_price_date,
                     )
                     for r in equity.position_results
                 ],

--- a/sql/350_portfolio_eod_mark_effective_date.sql
+++ b/sql/350_portfolio_eod_mark_effective_date.sql
@@ -1,0 +1,95 @@
+-- 350_portfolio_eod_mark_effective_date.sql
+--
+-- #2602 item 4 — give the local EOD valuation a MEASURED effective mark date.
+-- Writer: app/services/portfolio_eod.py (`_read_positions`, `compute_eod_equity`,
+--         `_write_snapshot`).
+-- Reader: app/services/account_equity_evidence.py (`load_account_equity_evidence`).
+--
+--
+-- WHAT WAS UNKNOWABLE, AND WHY IT NEED NOT HAVE BEEN
+-- ---------------------------------------------------------------------------
+-- `account_equity_evidence.py` appended `local_eod_effective_time_unknown` to
+-- EVERY comparison that had a local snapshot, with the note "computed_at is when
+-- the local job ran, not when its closing prices were effective". That was true
+-- and it was permanent by construction: nothing recorded when the marks were
+-- effective.
+--
+-- It was also avoidable. `portfolio_eod.py`'s per-position lookup already
+-- ORDERs `price_daily` BY `price_date DESC LIMIT 1` and then projects only
+-- `close` — the ordering key, which IS the effective date of that mark, was
+-- fetched and discarded. `_resolve_snapshot_date` sets `snapshot_date` to
+-- MAX(price_date) across held instruments, so `snapshot_date` is defined by the
+-- MOST CURRENT instrument and every position whose latest bar is older is
+-- carried forward into the total without a record of it.
+--
+--
+-- ⚠ THE HEADER TAKES THE OLDEST MARK, NOT THE NEWEST
+-- ---------------------------------------------------------------------------
+-- "As of when is this total true" is bounded by the STALEST input, not the
+-- freshest. `oldest_mark_date` is therefore MIN(mark_price_date) over the
+-- positions that actually contributed to `positions_value` — i.e. the `priced`
+-- ones. A `no_price` position has no mark to be stale, and a `no_fx` position
+-- contributed nothing to the total, so neither can move the bound; both are
+-- already reported by their own counters.
+--
+-- ⚠ Cash carries no mark date and is unaffected. A snapshot that is ALL cash
+-- has no priced position, so `oldest_mark_date` is NULL with
+-- `stale_mark_positions = 0` — which the reader must distinguish from "written
+-- before this migration". It does, via `positions_priced`.
+--
+--
+-- ⚠⚠ POPULATE FORWARD ONLY. THIS MIGRATION BACKFILLS NOTHING.
+-- ---------------------------------------------------------------------------
+-- The 43 existing `portfolio_eod_snapshots` rows stored `close_price` without
+-- its date. The mark date could be re-derived by re-running the same
+-- carry-forward lookup against `price_daily` today — and that would be a
+-- reconstruction, not an observation: `price_daily` is amendable, so a bar that
+-- has since been backfilled or corrected would hand a historical snapshot a mark
+-- date it did not actually use. Those rows read NULL, permanently, and the
+-- reader keeps reporting `local_eod_effective_time_unknown` for them, which is
+-- the truthful state.
+
+ALTER TABLE portfolio_eod_position_snapshots
+    ADD COLUMN IF NOT EXISTS mark_price_date DATE;
+
+COMMENT ON COLUMN portfolio_eod_position_snapshots.mark_price_date IS
+    'price_daily.price_date of the close used as this position''s mark. NULL when '
+    'price_status = ''no_price'' (there was no bar to use), or when the row predates '
+    'sql/350. #2602 item 4.';
+
+ALTER TABLE portfolio_eod_snapshots
+    ADD COLUMN IF NOT EXISTS oldest_mark_date DATE,
+    ADD COLUMN IF NOT EXISTS stale_mark_positions INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN portfolio_eod_snapshots.oldest_mark_date IS
+    'MIN(mark_price_date) over the PRICED positions — the stalest input, which is what '
+    'bounds "as of when is this total true". NULL when no position was priced (all cash, '
+    'or every position unpriced) or when the row predates sql/350; positions_priced '
+    'distinguishes those. #2602 item 4.';
+
+COMMENT ON COLUMN portfolio_eod_snapshots.stale_mark_positions IS
+    'Priced positions whose mark_price_date < snapshot_date, i.e. carried forward from an '
+    'earlier bar. 0 on rows predating sql/350 is the column default and is NOT evidence '
+    'of freshness — read oldest_mark_date IS NULL first. #2602 item 4.';
+
+-- ⚠ A mark cannot be effective AFTER the session it prices. `snapshot_date` is
+-- MAX(price_date) across held instruments, so a later mark date would mean the
+-- per-position lookup disagreed with the date resolver — a writer defect, and
+-- one that would silently make a snapshot look fresher than its inputs.
+ALTER TABLE portfolio_eod_snapshots
+    ADD CONSTRAINT portfolio_eod_snapshots_oldest_mark_not_future
+    CHECK (oldest_mark_date IS NULL OR oldest_mark_date <= snapshot_date);
+
+-- ⚠ Same rule per position. Stated separately because the header holds only the
+-- MIN: a single position marked from the future would be invisible in the
+-- header the moment any other position is staler.
+ALTER TABLE portfolio_eod_position_snapshots
+    ADD CONSTRAINT portfolio_eod_position_snapshots_mark_not_future
+    CHECK (mark_price_date IS NULL OR mark_price_date <= snapshot_date);
+
+-- ⚠ `stale_mark_positions` counts a SUBSET of the priced positions. Without
+-- this a writer could report more carried-forward marks than it priced, which
+-- would read as a coverage figure rather than as the arithmetic error it is.
+ALTER TABLE portfolio_eod_snapshots
+    ADD CONSTRAINT portfolio_eod_snapshots_stale_marks_within_priced
+    CHECK (stale_mark_positions >= 0 AND stale_mark_positions <= positions_priced);

--- a/tests/test_account_equity_evidence.py
+++ b/tests/test_account_equity_evidence.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 
 import psycopg
@@ -14,6 +14,7 @@ from app.services.account_equity_evidence import (
     DOCUMENTED_ACCOUNT_CURRENCIES,
     AccountEquityEvidenceError,
     load_account_equity_evidence,
+    mark_effectiveness_reasons,
     record_account_equity_snapshot,
 )
 
@@ -154,10 +155,15 @@ def test_incomplete_local_valuation_exposes_reasons_not_false_comparison(
     assert evidence.status == "collecting"
     assert not evidence.comparable
     assert evidence.difference is None
+    # ⚠ No `local_eod_effective_time_unknown` here, and its absence is the point
+    # (#2602 item 4). `positions_priced = 0` — the single position failed to
+    # price — so nothing contributed a mark and there is no effective time to be
+    # unknown. The row's real defect is already named twice over. Before sql/350
+    # the caveat was appended unconditionally and said the same thing about every
+    # row, priced or not, which is what made it unactionable.
     assert set(evidence.incomplete_reasons) == {
         "local_eod_currency_mismatch",
         "local_eod_valuation_incomplete",
-        "local_eod_effective_time_unknown",
     }
 
 
@@ -277,3 +283,91 @@ def test_every_documented_currency_id_is_admitted_by_the_check(
         "SELECT account_currency_id,currency FROM broker_account_equity_snapshots WHERE environment='demo'"
     ).fetchone()
     assert stored == (account_currency_id, currency)
+
+
+class TestMarkEffectivenessReasons:
+    """#2602 item 4 — the effective-time caveat is measured, not assumed.
+
+    Pure-logic, because the decision is a three-way branch over two stored
+    columns and a db-tier test per branch would buy nothing the table does not.
+    The two db-tier tests below cover the wiring: that the columns reach it and
+    that the caveat actually leaves the panel.
+    """
+
+    SNAPSHOT = date(2025, 6, 12)
+    EARLIER = date(2025, 6, 10)
+
+    def test_a_row_written_before_the_marks_were_recorded_is_still_unknown(self) -> None:
+        # NULL bound WITH priced positions can only mean "predates sql/350".
+        assert mark_effectiveness_reasons(snapshot_date=self.SNAPSHOT, oldest_mark_date=None, positions_priced=3) == (
+            "local_eod_effective_time_unknown",
+        )
+
+    def test_a_snapshot_with_no_priced_position_has_no_effective_time_to_be_unknown(self) -> None:
+        # All cash, or every position unpriced. Pre- and post-migration rows are
+        # indistinguishable here and need not be distinguished — neither has a mark.
+        assert mark_effectiveness_reasons(snapshot_date=self.SNAPSHOT, oldest_mark_date=None, positions_priced=0) == ()
+
+    def test_marks_on_the_snapshots_own_session_carry_no_caveat(self) -> None:
+        assert (
+            mark_effectiveness_reasons(snapshot_date=self.SNAPSHOT, oldest_mark_date=self.SNAPSHOT, positions_priced=3)
+            == ()
+        )
+
+    def test_a_mark_older_than_the_snapshot_is_named_as_carried_forward(self) -> None:
+        assert mark_effectiveness_reasons(
+            snapshot_date=self.SNAPSHOT, oldest_mark_date=self.EARLIER, positions_priced=3
+        ) == ("local_eod_marks_carried_forward",)
+
+    def test_one_day_of_staleness_is_enough(self) -> None:
+        # No tolerance is applied here on purpose: "the total is a blend of
+        # sessions" is a fact about the valuation, and how much divergence the
+        # operator will accept is item 4's separate tolerance rule.
+        assert mark_effectiveness_reasons(
+            snapshot_date=self.SNAPSHOT,
+            oldest_mark_date=self.SNAPSHOT - timedelta(days=1),
+            positions_priced=1,
+        ) == ("local_eod_marks_carried_forward",)
+
+
+def test_marks_on_the_session_retire_the_effective_time_caveat(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    """The caveat leaves the panel once the marks are recorded and current."""
+    observed = datetime.now(UTC).replace(microsecond=0)
+    record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=_snapshot(observed_at=observed))
+    ebull_test_conn.execute(
+        """
+        INSERT INTO portfolio_eod_snapshots (
+          snapshot_date,display_currency,total_value,positions_value,cash_value,
+          positions_total,positions_priced,oldest_mark_date,stale_mark_positions,computed_at
+        ) VALUES (%(d)s,'USD',995,495,500,2,2,%(d)s,0,%(c)s)
+        """,
+        {"d": observed.date(), "c": observed + timedelta(minutes=1)},
+    )
+    evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
+    assert evidence.incomplete_reasons == ()
+    # ⚠ Still not comparable. Clearing every named caveat does NOT make the two
+    # totals reconciled — that needs item 4's declared tolerance, which this
+    # slice does not ship. `comparable` staying False with an empty reason list
+    # is the honest state, not a contradiction.
+    assert not evidence.comparable
+    assert evidence.difference == Decimal("5.000000")
+
+
+def test_a_carried_forward_mark_is_named_rather_than_absorbed(
+    ebull_test_conn: psycopg.Connection[tuple],
+) -> None:
+    observed = datetime.now(UTC).replace(microsecond=0)
+    record_account_equity_snapshot(ebull_test_conn, environment="demo", snapshot=_snapshot(observed_at=observed))
+    ebull_test_conn.execute(
+        """
+        INSERT INTO portfolio_eod_snapshots (
+          snapshot_date,display_currency,total_value,positions_value,cash_value,
+          positions_total,positions_priced,oldest_mark_date,stale_mark_positions,computed_at
+        ) VALUES (%(d)s,'USD',995,495,500,2,2,%(old)s,1,%(c)s)
+        """,
+        {"d": observed.date(), "old": observed.date() - timedelta(days=3), "c": observed},
+    )
+    evidence = load_account_equity_evidence(ebull_test_conn, environment="demo")
+    assert evidence.incomplete_reasons == ("local_eod_marks_carried_forward",)

--- a/tests/test_portfolio_eod.py
+++ b/tests/test_portfolio_eod.py
@@ -7,8 +7,10 @@ from decimal import Decimal
 
 from app.services.portfolio_eod import (
     PositionInput,
+    PositionResult,
     compute_eod_equity,
     resolve_snapshot_date,
+    summarise_marks,
 )
 
 # 1 USD = 0.80 GBP; no EUR pair on purpose (exercises the cross-rate skip).
@@ -25,6 +27,7 @@ def _pos(
     open_rate: str = "0",
     is_buy: bool = True,
     open_conversion_rate: str = "1",
+    mark_price_date: date | None = None,
 ) -> PositionInput:
     # Defaults amount=open_rate=0 reduce MTM (amount + units*(close-open_rate))
     # to units*close — the unleveraged-long identity the FX/counter tests assert.
@@ -39,6 +42,7 @@ def _pos(
         open_rate=Decimal(open_rate),
         is_buy=is_buy,
         open_conversion_rate=Decimal(open_conversion_rate),
+        mark_price_date=mark_price_date,
     )
 
 
@@ -159,3 +163,82 @@ class TestComputeEodEquity:
         assert eq.positions_value == Decimal("16.00")
         assert eq.cash_value == Decimal("80.00")
         assert eq.total_value == Decimal("96.00")
+
+
+SNAPSHOT = date(2025, 6, 12)
+EARLIER = date(2025, 6, 10)
+
+
+def _result(status: str, mark: date | None) -> PositionResult:
+    return PositionResult(
+        position_id=1,
+        instrument_id=10,
+        units=Decimal("1"),
+        native_ccy="USD",
+        close=Decimal("1"),
+        value_display=Decimal("1") if status == "priced" else None,
+        price_status=status,
+        mark_price_date=mark,
+    )
+
+
+class TestMarkPriceDateIsCarriedThroughEveryBranch:
+    """#2602 item 4 — the aggregate cannot see a single dropped construction site.
+
+    ``summarise_marks`` reads only the ``priced`` rows, so a test on the bound
+    alone would still pass if the ``no_price`` or ``no_fx`` branches lost the
+    field. There are four ``PositionResult`` construction sites and they were
+    edited separately, which is exactly when a positional field goes missing
+    from one of them.
+    """
+
+    def test_priced_carries_the_mark_date(self) -> None:
+        eq = compute_eod_equity([_pos(1, "2", "USD", "10", mark_price_date=SNAPSHOT)], [], "GBP", RATES)
+        assert [(r.price_status, r.mark_price_date) for r in eq.position_results] == [("priced", SNAPSHOT)]
+
+    def test_no_fx_carries_the_mark_date(self) -> None:
+        # EUR has no pair in RATES, so this prices natively and then fails to convert.
+        eq = compute_eod_equity([_pos(1, "2", "EUR", "10", mark_price_date=EARLIER)], [], "GBP", RATES)
+        assert [(r.price_status, r.mark_price_date) for r in eq.position_results] == [("no_fx", EARLIER)]
+
+    def test_no_currency_carries_the_mark_date(self) -> None:
+        eq = compute_eod_equity([_pos(1, "2", None, "10", mark_price_date=EARLIER)], [], "GBP", RATES)
+        assert [(r.price_status, r.mark_price_date) for r in eq.position_results] == [("no_fx", EARLIER)]
+
+    def test_no_price_carries_the_absent_mark_date(self) -> None:
+        eq = compute_eod_equity([_pos(1, "2", "USD", None)], [], "GBP", RATES)
+        assert [(r.price_status, r.mark_price_date) for r in eq.position_results] == [("no_price", None)]
+
+
+class TestSummariseMarks:
+    def test_all_marks_on_the_session_bound_to_it_with_nothing_stale(self) -> None:
+        marks = summarise_marks([_result("priced", SNAPSHOT), _result("priced", SNAPSHOT)], SNAPSHOT)
+        assert (marks.oldest_mark_date, marks.stale_mark_positions) == (SNAPSHOT, 0)
+
+    def test_the_bound_is_the_OLDEST_mark_not_the_newest(self) -> None:
+        # The whole point: a total stamped SNAPSHOT whose worst input is two days
+        # old is a two-day-old valuation. A max() here would report it as current.
+        marks = summarise_marks([_result("priced", SNAPSHOT), _result("priced", EARLIER)], SNAPSHOT)
+        assert (marks.oldest_mark_date, marks.stale_mark_positions) == (EARLIER, 1)
+
+    def test_unpriced_and_unconvertible_positions_cannot_move_the_bound(self) -> None:
+        # Neither contributed to positions_value, so neither may bound it. A
+        # no_fx row is the trap: it HAS a mark date, just not one that is in the
+        # total, so filtering on `mark_price_date is not None` alone is wrong.
+        marks = summarise_marks(
+            [_result("priced", SNAPSHOT), _result("no_fx", EARLIER), _result("no_price", None)],
+            SNAPSHOT,
+        )
+        assert (marks.oldest_mark_date, marks.stale_mark_positions) == (SNAPSHOT, 0)
+
+    def test_no_priced_position_leaves_the_bound_absent_rather_than_guessing(self) -> None:
+        marks = summarise_marks([_result("no_price", None)], SNAPSHOT)
+        assert (marks.oldest_mark_date, marks.stale_mark_positions) == (None, 0)
+
+    def test_an_all_cash_snapshot_has_no_bound(self) -> None:
+        marks = summarise_marks([], SNAPSHOT)
+        assert (marks.oldest_mark_date, marks.stale_mark_positions) == (None, 0)
+
+    def test_every_priced_mark_stale_counts_all_of_them(self) -> None:
+        marks = summarise_marks([_result("priced", EARLIER), _result("priced", EARLIER)], SNAPSHOT)
+        assert (marks.oldest_mark_date, marks.stale_mark_positions) == (EARLIER, 2)

--- a/tests/test_portfolio_eod_db.py
+++ b/tests/test_portfolio_eod_db.py
@@ -25,6 +25,7 @@ from app.services.portfolio_eod import (
     _read_positions,
     _resolve_snapshot_date,
     _write_snapshot,
+    summarise_marks,
 )
 from tests.fixtures.ebull_test_db import ebull_test_conn  # noqa: F401  (fixture)
 
@@ -81,6 +82,12 @@ def test_read_positions_carries_close_forward(ebull_test_conn: psycopg.Connectio
     rows = _read_positions(conn, date(2025, 6, 11))
     assert len(rows) == 1
     assert rows[0].close == Decimal("20")
+    # ⚠ #2602 item 4 — the mark's own date, which is the whole point of the
+    # LATERAL: the close is the 9th's, not the 11th's, and the snapshot would
+    # otherwise be stamped the 11th with no record that its input was two days
+    # old. Asserted from the SAME row as `close`, because "same bar" is the
+    # property two independent scalar subqueries would not guarantee.
+    assert rows[0].mark_price_date == date(2025, 6, 9)
     assert rows[0].native_ccy == "USD"
     assert rows[0].units == Decimal("3")
     assert rows[0].open_conversion_rate == Decimal("1")
@@ -211,7 +218,7 @@ def test_write_snapshot_is_idempotent(ebull_test_conn: psycopg.Connection[Any]) 
     _seed_position(conn, 5004, 9004, "2")
     d = date(2025, 6, 12)
 
-    def _equity(total: str) -> EodEquity:
+    def _equity(total: str, mark: date | None) -> EodEquity:
         return EodEquity(
             positions_value=Decimal(total),
             cash_value=Decimal("0"),
@@ -221,20 +228,47 @@ def test_write_snapshot_is_idempotent(ebull_test_conn: psycopg.Connection[Any]) 
             positions_no_price=0,
             positions_no_fx=0,
             cash_no_fx_currencies=0,
-            position_results=[PositionResult(5004, 9004, Decimal("2"), "USD", Decimal("10"), Decimal(total), "priced")],
+            position_results=[
+                PositionResult(
+                    5004,
+                    9004,
+                    Decimal("2"),
+                    "USD",
+                    Decimal("10"),
+                    Decimal(total),
+                    "priced",
+                    mark_price_date=mark,
+                )
+            ],
         )
 
+    stale = date(2025, 6, 9)
     with conn.transaction():
-        _write_snapshot(conn, d, "GBP", date(2025, 6, 12), _equity("16.00"))
+        _write_snapshot(
+            conn, d, "GBP", d, _equity("16.00", stale), summarise_marks(_equity("16.00", stale).position_results, d)
+        )
     # Re-run for the same date with a different value → overwrite, not duplicate.
+    # ⚠ The re-run's marks are CURRENT where the first run's were carried
+    # forward. The mark columns must move with the total: leaving a stale bound
+    # beside a freshly recomputed number is worse than never recording one, and
+    # an `ON CONFLICT` update set that forgets them does exactly that silently.
     with conn.transaction():
-        _write_snapshot(conn, d, "GBP", date(2025, 6, 12), _equity("18.00"))
+        _write_snapshot(
+            conn, d, "GBP", d, _equity("18.00", d), summarise_marks(_equity("18.00", d).position_results, d)
+        )
 
     snap_row = conn.execute(
-        "SELECT COUNT(*), MAX(total_value) FROM portfolio_eod_snapshots WHERE snapshot_date = %s", (d,)
+        """
+        SELECT COUNT(*), MAX(total_value), MAX(oldest_mark_date), MAX(stale_mark_positions)
+        FROM portfolio_eod_snapshots WHERE snapshot_date = %s
+        """,
+        (d,),
     ).fetchone()
     pos_row = conn.execute(
-        "SELECT COUNT(*), MAX(unrealised_pnl_usd) FROM portfolio_eod_position_snapshots WHERE snapshot_date = %s",
+        """
+        SELECT COUNT(*), MAX(unrealised_pnl_usd), MAX(mark_price_date)
+        FROM portfolio_eod_position_snapshots WHERE snapshot_date = %s
+        """,
         (d,),
     ).fetchone()
     assert snap_row is not None and pos_row is not None
@@ -242,3 +276,5 @@ def test_write_snapshot_is_idempotent(ebull_test_conn: psycopg.Connection[Any]) 
     assert pos_row[0] == 1
     assert pos_row[1] is None
     assert snap_row[1] == Decimal("18.00")
+    assert (snap_row[2], snap_row[3]) == (d, 0)
+    assert pos_row[2] == d


### PR DESCRIPTION
## Why

F-0's account-equity panel appended `local_eod_effective_time_unknown` to **every**
comparison that had a local snapshot, with the note *"computed_at is when the local job
ran, not when its closing prices were effective. Do not call these totals reconciled
until the local valuation carries a defensible effective market timestamp."*

That was true, and it was permanent by construction — nothing recorded when the marks
were effective, so no evidence could ever retire the caveat, and a caveat that says the
same thing about every row is not a caveat the operator can act on.

The date was already fetched and thrown away. `portfolio_eod._read_positions` ordered
`price_daily` by `price_date DESC LIMIT 1` and projected only `close`, while
`_resolve_snapshot_date` sets `snapshot_date` to `MAX(price_date)` **across held
instruments** — so `snapshot_date` is defined by the most current instrument and any
position whose latest bar is older is carried forward into the total silently.

## What changed

- **`sql/350`** — `portfolio_eod_position_snapshots.mark_price_date`, plus
  `portfolio_eod_snapshots.oldest_mark_date` and `stale_mark_positions`. Three CHECKs:
  no mark post-dates its own session (header and per-position, stated separately because
  the header holds only the MIN), and the stale count is a subset of `positions_priced`.
- **The lookup becomes a `LEFT JOIN LATERAL`.** Two correlated scalar subqueries would
  re-run the ordering independently, so the mark and its date could in principle come
  from different rows — a defect no test would catch, because they agree on every
  ordinary corpus.
- **`summarise_marks`** reduces the per-position dates to the snapshot bound. ⚠ It is a
  **MIN, not a MAX**: "as of when is this total true" is set by the stalest input. And it
  reads **priced positions only** — a `no_fx` row has a mark date but contributed nothing
  to `positions_value`, so filtering on `mark_price_date is not None` alone would let a
  position bound a total it is not in.
- **`mark_effectiveness_reasons`** replaces the unconditional caveat with three measured
  outcomes: `local_eod_effective_time_unknown` (row predates sql/350),
  `local_eod_marks_carried_forward` (new), or nothing.

## ⚠ Forward-only, and why re-derivation is not the safe option

The mark dates *could* be recovered by re-running the same carry-forward lookup against
`price_daily` today. That would be a reconstruction, not an observation: `price_daily` is
amendable, so a bar backfilled or corrected since would hand a historical snapshot a mark
date it never actually used. The 43 existing rows read NULL permanently and keep
reporting `local_eod_effective_time_unknown`, which is the truthful state.

## Full-population check

```
portfolio_eod_snapshots rows: 43
rows whose reason set CHANGES on this diff: 0
positions_priced distribution: [(7, 43)]
```

Every stored row has `positions_priced = 7 > 0`, so every one keeps the old reason. The
behaviour change is entirely forward-looking — asserted rather than assumed, because the
`positions_priced = 0` branch drops the reason and a row in that state would have moved.

`sql/350` applied to the dev DB inside a transaction that was **rolled back** (column
count back to 0 afterwards), with each CHECK probed:

| probe | result |
| --- | --- |
| header `oldest_mark_date = snapshot_date + 1` | REFUSED `portfolio_eod_snapshots_oldest_mark_not_future` |
| per-position `mark_price_date = snapshot_date + 1` | REFUSED `portfolio_eod_position_snapshots_mark_not_future` |
| `stale_mark_positions = positions_priced + 1` | REFUSED `portfolio_eod_snapshots_stale_marks_within_priced` |
| `stale_mark_positions = -1` | REFUSED (same CHECK) |
| `stale_mark_positions = positions_priced` | ACCEPTED |

## What this does NOT do

- **`comparable` stays `Literal[False]`.** Clearing every named caveat does not make two
  totals reconciled — that needs item 4's declared tolerance and the operator repair
  condition, which are not in this slice. A test pins the combination (empty reason list,
  still not comparable) so it reads as deliberate rather than as a contradiction.
- **No frontend change.** ⚠ Worth stating because it is a real gap I found and did not
  widen into: `StrategiesPage.tsx:444-485` renders the two figures and the literal string
  "Reconciliation collecting" and **never renders `incomplete_reasons` at all**. The
  reasons are computed, serialised and dropped. Filed separately as **#2693** rather than
  fixed here — the loop worktree cannot dev-verify a page (the dev stack serves
  `~/Dev/eBull`, which is in use), and shipping FE I cannot eyeball is worse than filing it.
- **No same-day-provisional-bar refusal.** A daily close identifies a market instant
  exactly, so a date IS a defensible effective time for these inputs. Whether a same-day
  bar was final when read is a different question, and it does not arise on this corpus:
  `max(price_daily.price_date)` = 2026-08-13 against `current_date` = 2026-08-14, and the
  EOD job ran at 22:30 UTC. Inventing a refusal for a state never observed would be the
  mirror of the defect this replaces.
- **`stale_mark_positions` is stored but not projected** by the reader. The verdict comes
  from `oldest_mark_date` alone — a second source of truth for the same fact could
  disagree with it — and the count has no API consumer until the FE renders reasons.

## Incidental finding, not ticketed

Two weekdays in the snapshot span have no local EOD row: **2026-06-16** and
**2026-08-12** (the latter has a broker snapshot with no local counterpart, so it reports
`same_day_local_eod_snapshot_missing`). Two gaps in ~45 weekdays is sparse rather than
systematic — most likely daemon downtime — so it is recorded here rather than filed.

## Definition of Done — ETL clauses 8-12

| clause | applicability |
| --- | --- |
| 8 — smoke 3-5 instruments | N/A as written (an instrument panel). The equivalent evidence is the full-population table above: all 43 rows, all 7 priced positions. |
| 9 — cross-source verify | N/A. Nothing here is sourced externally; `mark_price_date` is `price_daily`'s own key, carried rather than derived. |
| 10 — backfill executed | Deliberately none — see "forward-only" above. `sec_rebuild` is an SEC-ownership path and does not touch these tables. |
| 11 — operator-visible figure | The reader's output is unchanged on every stored row (0 of 43 move), which is the measured claim; the panel itself renders no reason today (#2693). |
| 12 — SHA | commit `4566fe49`. |

## Security

No security surface. No auth, no broker call, no order path; two additive columns on
operator-local valuation tables and one reader that already ran on this data.

## Verification

- `ruff check` / `ruff format --check` / `pyright` — clean.
- `pytest -m "not db"` — exit 0.
- `pytest -m db tests/test_portfolio_eod_db.py tests/test_account_equity_evidence.py` — 33 passed.
- Pre-push hook green (fast tier + smoke + chokepoint lints).
- Codex checkpoint 2 (`codex exec review --base origin/main`, migration staged) — no findings.

Refs #2602. Refs #2693.

