### PR TITLE
fix(#2689): probe the series_break arm, which post-dated the harness and was never covered

### DIFF
--- a/scripts/probe_2240_position_builder.py
+++ b/scripts/probe_2240_position_builder.py
@@ -307,6 +307,28 @@ PROBES: list[tuple[str, list[tuple[str, str]], str]] = [
         "test_an_unbookable_hold_does_not_suppress_the_rest_of_history",
     ),
     (
+        # The THIRD arm of the same expression, and the one that had no probe at
+        # all (#2689). It post-dates this harness: when the probe above was
+        # written the expression was a two-way `ceiling if ... else None`, so
+        # `series_break` was added without anything asking whether it was
+        # covered. ⚠ Nothing in the harness can notice that — the guards check
+        # that an anchor matches and that a replacement changes behaviour, and
+        # both are silent about a branch no probe names.
+        #
+        # A `series_break` hold must suppress entries only until the series
+        # RESUMES (`unresolved_until`), not forever. Deleting the bound sends the
+        # arm to None, which the suppression check reads as "open indefinitely"
+        # and drops the whole next segment of that instrument's history.
+        "a series-break hold suppressing the resumed segment instead of ending at its resume boundary",
+        [
+            (
+                '                    else unresolved_until\n                    if open_reason == "series_break"\n',
+                '                    else None\n                    if open_reason == "series_break"\n',
+            )
+        ],
+        "test_a_series_break_outcome_is_unmarked_but_does_not_suppress_the_new_segment",
+    ),
+    (
         # ⚠ MEASURED: 16 bars across 9 series carry `open = 0`, all already
         # quarantined on both axes. A fill at 0 is not a trade — it makes every
         # downstream return infinite.


### PR DESCRIPTION
## What

`app/services/position_builder.py:809-815` decides how long an open position suppresses
later entries, in three arms:

```python
open_until = (
    ceiling
    if open_reason == "close_bar_unfillable"
    else unresolved_until
    if open_reason == "series_break"
    else None
)
```

`scripts/probe_2240_position_builder.py` probed the first arm and the fallthrough. The
`series_break` arm had **no probe at all** — `grep -n "series_break\|unresolved_until"`
over the harness returned nothing.

## Why it was invisible

The arm post-dates the harness. When the `close_bar_unfillable` probe was written the
expression was a two-way `ceiling if ... else None`; `series_break` was added later and
nothing asked whether it was covered.

⚠ **Neither standing guard can see this.** Guard 1 asserts an anchor matches exactly
once; guard 2 asserts the replacement changes behaviour. Both are properties of probes
that exist. A branch no probe names satisfies both vacuously, and the harness's "N probes
caught" reads as coverage.

Surfaced by #2357's re-run, which found the sibling arm's anchor had gone stale in the
same edit. That was re-anchored on `close_bar_unfillable` **alone**, deliberately, so
that the wider mutation would not paper over this gap — this PR is the other half.

## The probe

Deletes the resume boundary, sending the arm to `None`. The suppression check reads
`open_until is None` as "open indefinitely", so the entry that fills on the resume bar is
superseded and the whole resumed segment of that instrument's history disappears —
`test_a_series_break_outcome_is_unmarked_but_does_not_suppress_the_new_segment` then fails
on its two-position unpack.

Deletes rather than wraps, per the standing guard. Anchored on the `series_break` arm's
two lines so it cannot collide with the sibling probe's anchor.

## Measurement

```
$ uv run python scripts/probe_2240_position_builder.py
  CAUGHT   a series-break hold suppressing the resumed segment instead of ending at its resume boundary  (1 test)
  ...
  restored suite: PASS

all 29 probes caught
```

exit 0. No `NOT CAUGHT`, no `BAD ANCHOR`, no `HARNESS FAULT`, no `BAD BASELINE`. Sources
at `06d2e349`; per #2357's prevention entry, that SHA is part of the claim.

The harness now reports **29** where the phase-5a write-up says 28. Both that and #2357's
105 need one re-statement on #2240; deferred to a single edit rather than two.

## What this does NOT do

⚠ **The cross-harness audit the issue asks for is NOT done here.** #2689's closing note
was *"check the same class across the other `probe_2240_*.py` harnesses before closing"* —
16 harnesses against their own source files, which is a session, not a line. Filed as
**#2695** with a concrete method rather than folded in: turning a one-branch fix into an
audit is how a narrow ticket becomes a day. The `series_break` gap itself is closed.

## Security

None. A probe script; not a test, never run by CI, and it restores the source it mutates
in a `finally`.

## Verification

- `ruff check` / `ruff format --check` — clean.
- Pre-push hook green (fast tier + smoke + chokepoint lints).
- The 29/29 run above.

Codex checkpoint 2 not run: one file, no data semantics, no service or schema change —
the review-intensity ladder's "narrow diff" rung, which gets self-review + hook + bot.

Closes #2689. Refs #2240. Refs #2357. Refs #2695.

