### PR TITLE
chore(#2695): audit every revert-probe anchor mechanically — 14 of 284 are already dead

### DIFF
--- a/scripts/audit_probe_anchors.py
+++ b/scripts/audit_probe_anchors.py
@@ -110,8 +110,9 @@ def main() -> int:
     root = Path(__file__).resolve().parents[1]
     failures: list[str] = []
     total = 0
+    harnesses = sorted((root / "scripts").glob(HARNESS_GLOB))
 
-    for path in sorted((root / "scripts").glob(HARNESS_GLOB)):
+    for path in harnesses:
         module = importlib.import_module(f"scripts.{path.stem}")
         probes: list[tuple[Any, ...]] = getattr(module, "PROBES", [])
         default_src: Path | None = getattr(module, "SRC", None)
@@ -133,7 +134,19 @@ def main() -> int:
                     bad += 1
                     continue
                 if src not in sources:
-                    sources[src] = (root / src).read_text()
+                    try:
+                        sources[src] = (root / src).read_text()
+                    except OSError as exc:
+                        # ⚠ REPORTED, never raised. A source file that has been
+                        # renamed or deleted is the MOST complete form of the
+                        # decay this audit exists to find — letting it abort the
+                        # run would surface the worst case as a traceback and
+                        # hide every other finding behind it. Not cached, so the
+                        # next probe naming the same file reports it too rather
+                        # than KeyError-ing on a half-populated cache.
+                        bad += 1
+                        failures.append(f"{path.name}: {name}: cannot read {src} — {type(exc).__name__}")
+                        continue
                 occurrences = sources[src].count(anchor)
                 checked += 1
                 total += 1
@@ -147,7 +160,7 @@ def main() -> int:
         marker = "OK " if bad == 0 else "***"
         print(f"  {marker} {path.name:<45} {len(probes):>3} probes, {checked:>3} anchors", flush=True)
 
-    print(f"\n{total} anchors checked across {len(list((root / 'scripts').glob(HARNESS_GLOB)))} harnesses", flush=True)
+    print(f"\n{total} anchors checked across {len(harnesses)} harnesses", flush=True)
     if failures:
         print("\nSTALE:\n  " + "\n  ".join(failures), file=sys.stderr, flush=True)
         print(

--- a/scripts/audit_probe_anchors.py
+++ b/scripts/audit_probe_anchors.py
@@ -1,0 +1,164 @@
+"""Every revert-probe anchor still matches its source exactly once (#2695).
+
+    uv run python -m scripts.audit_probe_anchors
+    bash scripts/check_probe_anchors.sh      # the pre-push / CI wrapper
+
+WHAT THIS CATCHES, AND WHY NOTHING ELSE DOES
+--------------------------------------------
+A revert probe injects a defect by replacing a VERBATIM copy of a source line.
+Each harness asserts its anchors occur exactly once before mutating, so a stale
+anchor cannot fake a ``CAUGHT`` — it reports ``*** BAD ANCHOR ***`` instead.
+
+⚠⚠ But that report only exists on a day somebody RUNS the harness, and nothing
+runs them: a probe script is not a test, CI does not collect it (by design — it
+mutates tracked source on disk), and the pre-push hook does not either. Meanwhile
+the CLAIM derived from a run — "28 probes, all CAUGHT" — is written into a PR
+description or a spec's acceptance section and read forever after as a property
+of the code.
+
+Precedent (#2357, 2026-08-14): ``probe_2240_position_builder``'s anchor for "an
+unbookable hold left open forever" was a copy of
+``open_until = ceiling if open_reason == "close_bar_unfillable" else None``. A
+later ``series_break`` arm turned that into a three-way conditional and the
+formatter split it across six lines. The anchor matched 0 times, and the phase-5a
+claim of 28/28 had silently been 27 for however long. It was found by a re-run
+that happened for an unrelated reason.
+
+⚠ The decay is silent in the safe direction, which is what makes it survive: a
+stale anchor removes a probe from the count without removing the sentence citing
+the count. A full sweep costs ~35 s/probe (two pytest subprocesses each) — near
+an hour for the 280 probes below. This check is the part of that sweep which
+needs no pytest at all, so it can run on every push.
+
+WHAT THIS DOES NOT CATCH
+------------------------
+⚠ **A branch that no probe names.** The harnesses' two standing guards are
+properties of probes that EXIST — anchor uniqueness, and delete-don't-wrap — and
+both are vacuously satisfied by an arm nobody wrote a probe for. Precedent
+(#2689): the ``series_break`` arm of the very same expression had no probe at
+all, because it post-dated the harness. That class needs a per-harness reading of
+the source against the probe list; it is #2695's other half and it is not
+mechanizable.
+
+⚠ **Whether the mutation still fails the test.** A selector can rot (the test is
+renamed, or its fixture drifts until it no longer observes the defect) with the
+anchor perfectly intact. Only a real run settles that.
+
+⚠ Scope is ``scripts/probe_2240_*.py`` deliberately. Several other ``probe_*.py``
+files execute work at import — ``probe_def14a_high_identity_escape.py`` reads
+``sys.argv[1]`` at module level — so importing the whole glob would run them.
+
+A NOTE ON WHAT A FAILURE MEANS
+------------------------------
+⚠ A failure here has two causes and they need different fixes. Either an anchor
+went stale (re-anchor it, preferably on the smallest span that still identifies
+the rule, so it survives edits to its siblings), or **a probe run was killed and
+left a tracked source file mutated** — the harnesses restore in a ``finally``,
+which survives Ctrl-C but not a hard kill. Check ``git status`` before
+re-anchoring anything.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
+
+# ⚠ Run as `-m scripts.audit_probe_anchors`, but `python scripts/audit_probe_anchors.py`
+# puts `scripts/` on sys.path rather than the repo root and the import below then
+# raises ModuleNotFoundError. Prepending the root makes both forms work (#2357).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+HARNESS_GLOB = "probe_2240_*.py"
+
+
+def _edits_of(probe: tuple[Any, ...]) -> list[tuple[Any, ...]] | None:
+    """The (anchor, replacement) list inside one probe tuple.
+
+    ⚠ Found BY SHAPE, not by position. The 16 harnesses carry five different
+    tuple arities (3, 4 and 5) and three ways of naming the source, because each
+    grew whatever its own invariants needed. Indexing by ordinal would make this
+    audit the seventeenth thing that has to be updated when a harness changes —
+    and it would fail silently, reading some other field as the edit list.
+    """
+    for element in probe:
+        if isinstance(element, list) and element and all(isinstance(item, tuple) for item in element):
+            return element
+    return None
+
+
+def _anchor_and_source(edit: tuple[Any, ...], probe: tuple[Any, ...], default: Path | None) -> tuple[str, Path]:
+    """The anchor string and the file it must occur in, for one edit.
+
+    Three shapes in the tree, in narrowing order of specificity: the source can
+    be named per EDIT (``probe_2240_s2_cross_sectional``, whose edits are
+    ``(Path, old, new)``), per PROBE (the ``SOURCES`` harnesses, which carry a
+    ``Path`` element in the tuple), or once for the module (``SRC``).
+    """
+    if len(edit) == 3 and isinstance(edit[0], Path):
+        return str(edit[1]), edit[0]
+    for element in probe:
+        if isinstance(element, Path):
+            return str(edit[0]), element
+    if default is None:
+        raise ValueError("probe names no source file and its module declares no SRC")
+    return str(edit[0]), default
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parents[1]
+    failures: list[str] = []
+    total = 0
+
+    for path in sorted((root / "scripts").glob(HARNESS_GLOB)):
+        module = importlib.import_module(f"scripts.{path.stem}")
+        probes: list[tuple[Any, ...]] = getattr(module, "PROBES", [])
+        default_src: Path | None = getattr(module, "SRC", None)
+        sources: dict[Path, str] = {}
+        checked = bad = 0
+
+        for probe in probes:
+            name = probe[0]
+            edits = _edits_of(probe)
+            if edits is None:
+                failures.append(f"{path.name}: {name}: no (anchor, replacement) list found in the probe tuple")
+                bad += 1
+                continue
+            for edit in edits:
+                try:
+                    anchor, src = _anchor_and_source(edit, probe, default_src)
+                except ValueError as exc:
+                    failures.append(f"{path.name}: {name}: {exc}")
+                    bad += 1
+                    continue
+                if src not in sources:
+                    sources[src] = (root / src).read_text()
+                occurrences = sources[src].count(anchor)
+                checked += 1
+                total += 1
+                if occurrences != 1:
+                    bad += 1
+                    failures.append(
+                        f"{path.name}: {name}: anchor occurs {occurrences} times in {src} "
+                        f"(expected exactly 1) — this probe currently proves nothing"
+                    )
+
+        marker = "OK " if bad == 0 else "***"
+        print(f"  {marker} {path.name:<45} {len(probes):>3} probes, {checked:>3} anchors", flush=True)
+
+    print(f"\n{total} anchors checked across {len(list((root / 'scripts').glob(HARNESS_GLOB)))} harnesses", flush=True)
+    if failures:
+        print("\nSTALE:\n  " + "\n  ".join(failures), file=sys.stderr, flush=True)
+        print(
+            "\n⚠ Two causes, two different fixes: an anchor went stale (re-anchor it), or a killed "
+            "probe run left a tracked source file mutated (check `git status` FIRST).",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_audit_probe_anchors.py
+++ b/tests/test_audit_probe_anchors.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts.audit_probe_anchors import _anchor_and_source, _edits_of
+from scripts.audit_probe_anchors import _anchor_and_source, _edits_of, main
 
 SRC_A = Path("app/services/alpha.py")
 SRC_B = Path("app/services/beta.py")
@@ -87,3 +87,31 @@ def test_every_harness_in_the_tree_contributes_at_least_one_anchor() -> None:
                 anchor, source = _anchor_and_source(edit, probe, getattr(module, "SRC", None))
                 assert anchor, f"{path.name}: {probe[0]}: empty anchor"
                 assert (root / source).exists(), f"{path.name}: {probe[0]}: {source} does not exist"
+
+
+def test_an_unreadable_source_is_reported_not_raised(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """⚠ A deleted or renamed source is the MOST complete form of this decay.
+
+    Letting `read_text` propagate would surface the worst case as a traceback and
+    hide every other finding behind it — the audit would fail loudest exactly
+    where it has the most to say. Every read is made to fail here, so the run
+    must still complete, return 1, and attribute a failure per probe.
+    """
+    original = Path.read_text
+
+    def _refuse(self: Path, *args: object, **kwargs: object) -> str:
+        if self.suffix == ".py" and "app/services" in self.as_posix():
+            raise OSError("no such file (synthetic)")
+        return original(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", _refuse)
+    assert main() == 1
+    # ⚠ The exit code alone does not discriminate: the audit returns 1 today for
+    # genuinely stale anchors too, so a test asserting only that would pass with
+    # the guard removed (it would ERROR on the raise, but for the wrong reason,
+    # and would go green the day the anchors are all fixed). Assert the reason.
+    stderr = capsys.readouterr().err
+    assert "cannot read" in stderr
+    assert "OSError" in stderr

--- a/tests/test_audit_probe_anchors.py
+++ b/tests/test_audit_probe_anchors.py
@@ -1,0 +1,89 @@
+"""The probe-anchor audit resolves every harness shape in the tree (#2695).
+
+⚠ The audit's own failure mode is going INERT. It finds the edit list and the
+source file BY SHAPE, across five tuple arities and three ways of naming the
+source, so a harness whose shape it cannot read would otherwise contribute zero
+anchors and still print ``OK``. These tests pin the resolution for each shape and
+pin that an unreadable shape is REPORTED rather than skipped — which is the same
+defect class the audit exists to catch, one level up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.audit_probe_anchors import _anchor_and_source, _edits_of
+
+SRC_A = Path("app/services/alpha.py")
+SRC_B = Path("app/services/beta.py")
+EDITS = [("old", "new")]
+
+
+class TestEditsOf:
+    def test_finds_the_edit_list_in_the_three_tuple_shape(self) -> None:
+        # (name, edits, selector) — probe_2240_position_builder and siblings.
+        assert _edits_of(("a name", EDITS, "test_selector")) == EDITS
+
+    def test_finds_the_edit_list_in_the_five_tuple_shape(self) -> None:
+        # (name, source, tests, edits, selector) — the SOURCES harnesses.
+        assert _edits_of(("a name", SRC_A, "tests/test_x.py", EDITS, "test_selector")) == EDITS
+
+    def test_finds_a_per_edit_source_triple(self) -> None:
+        # probe_2240_s2_cross_sectional: the edits are (Path, old, new).
+        edits = [(SRC_A, "old", "new")]
+        assert _edits_of(("a name", edits, "tests/test_x.py", "test_selector")) == edits
+
+    def test_an_unreadable_shape_is_reported_not_silently_skipped(self) -> None:
+        # No list-of-tuples anywhere. `main` turns None into a failure line; the
+        # dangerous alternative is returning [] and printing OK for 0 anchors.
+        assert _edits_of(("a name", "not a list", "test_selector")) is None
+
+    def test_an_empty_edit_list_is_not_mistaken_for_the_edit_list(self) -> None:
+        # An empty list matches "list of tuples" vacuously. Taking it would make
+        # the probe contribute nothing while looking resolved.
+        assert _edits_of(("a name", [], EDITS, "test_selector")) == EDITS
+
+
+class TestAnchorAndSource:
+    def test_a_per_edit_path_wins_over_everything(self) -> None:
+        probe = ("a name", [(SRC_A, "old", "new")], "tests/test_x.py", "sel")
+        assert _anchor_and_source((SRC_A, "old", "new"), probe, SRC_B) == ("old", SRC_A)
+
+    def test_a_per_probe_path_beats_the_module_default(self) -> None:
+        probe = ("a name", SRC_A, "tests/test_x.py", EDITS, "sel")
+        assert _anchor_and_source(("old", "new"), probe, SRC_B) == ("old", SRC_A)
+
+    def test_the_module_src_is_used_when_the_probe_names_none(self) -> None:
+        assert _anchor_and_source(("old", "new"), ("a name", EDITS, "sel"), SRC_B) == ("old", SRC_B)
+
+    def test_no_source_anywhere_raises_rather_than_guessing_one(self) -> None:
+        with pytest.raises(ValueError, match="names no source file"):
+            _anchor_and_source(("old", "new"), ("a name", EDITS, "sel"), None)
+
+
+def test_every_harness_in_the_tree_contributes_at_least_one_anchor() -> None:
+    """⚠ The inert-audit guard, run against the REAL harnesses.
+
+    A shape the resolver cannot read produces a harness with 0 anchors, and the
+    per-harness line still prints. This asserts the resolver actually reaches
+    every probe in every `probe_2240_*.py`, so adding a harness in a new shape
+    fails here rather than quietly shrinking the audit's coverage.
+    """
+    import importlib
+
+    root = Path(__file__).resolve().parents[1]
+    harnesses = sorted((root / "scripts").glob("probe_2240_*.py"))
+    assert harnesses, "no probe_2240_* harnesses found — the audit's glob has drifted"
+    for path in harnesses:
+        module = importlib.import_module(f"scripts.{path.stem}")
+        probes = getattr(module, "PROBES", [])
+        assert probes, f"{path.name} declares no PROBES"
+        for probe in probes:
+            edits = _edits_of(probe)
+            assert edits, f"{path.name}: {probe[0]}: the audit cannot find this probe's edit list"
+            for edit in edits:
+                anchor, source = _anchor_and_source(edit, probe, getattr(module, "SRC", None))
+                assert anchor, f"{path.name}: {probe[0]}: empty anchor"
+                assert (root / source).exists(), f"{path.name}: {probe[0]}: {source} does not exist"


### PR DESCRIPTION
## Why

Two decay classes turned up this week, both in one harness, both found by a re-run that
happened for an unrelated reason:

- **#2357** — a stale anchor. `probe_2240_position_builder`'s anchor was a verbatim copy
  of a source line; a later arm plus `ruff format` split that line, the anchor matched 0
  times, and the phase-5a claim of "28 probes, all CAUGHT" had silently been 27.
- **#2689** — a branch of the same expression that no probe named at all.

⚠ **No gate can see either.** A probe script is not a test, CI does not collect it (by
design — it mutates tracked source on disk), and the pre-push hook does not run it. So a
harness's verdict exists only on a day somebody runs it, while the *claim* derived from
that run is written into a PR description or a spec's acceptance section and read forever
after as a property of the code.

## What this adds

`scripts/audit_probe_anchors.py` checks the mechanizable half — every anchor is a
verbatim source copy that must occur exactly once — with no pytest at all. **284 anchors
across 16 harnesses in well under a second**, against ~55 minutes for a full sweep
(measured #2357: ~35 s/probe, two pytest subprocesses each). Cheap enough to gate on.

It resolves the edit list and the source file **by shape, not by ordinal**. The 16
harnesses carry five tuple arities (3, 4, 5) and three ways of naming the source — module
`SRC`, a per-probe `Path`, or a `Path` inside each edit triple (`probe_2240_s2_cross_sectional`)
— because each grew whatever its own invariants needed. An index-based reader would become
the seventeenth thing to update on a harness change, and it would fail *silently* by
reading some other field as the edit list.

## ⚠ The result: 14 dead anchors in 4 harnesses

Measured on `b9fbd65c`, working tree clean:

| harness | probes | dead |
| --- | ---: | ---: |
| `probe_2240_result_model.py` | 27 | **9** |
| `probe_2240_statistics.py` | 28 | 3 |
| `probe_2240_cost_model.py` | 17 | 1 |
| `probe_2240_result_ledger.py` | 24 | 1 |
| the other 12 | 168 | 0 |

**Nine of the fourteen are in `probe_2240_result_model.py`, i.e. the promotion gate**:

```
the carry refusal removed (§5.1's unmodelled carry promotes)
the trial-count refusal removed (an undeclared count promotes)
the Deflated Sharpe refusal removed (criterion 6)
the basis allowlist turned into a denylist (a typo'd basis promotes)
the never-evaluated hold-out admitted (< 1 became < 0)
the access rule weakened to criterion 5's literal wording
the sizing rule dropped from the result identity hash
the ambiguity arm dropped from the result identity hash
the gate short-circuited to its first refusal
```

Those are the M9 Tier-1 refusals. Their "all CAUGHT" claim does not hold today.

⚠ **Two of the fourteen are ambiguous rather than absent**, which is a different failure
with the same consequence: `return tuple(refusals)` now matches **4** sites in
`strategy_result.py` and the NaN-carry anchor matches **2** in `equity_curve.py`. The
harnesses' own guard would refuse those too.

Spot-verified by hand rather than taken from the script:

- `"sizing_rule": self.sizing_rule,` — the anchor carries **16** leading spaces;
  `app/services/strategy_result.py:523` has **12**. The dict was dedented and the anchor
  did not follow.
- `return tuple(refusals)` — `app/services/strategy_result.py:843, 939, 962, 1065`.

## What this does NOT do

- ⚠ **Not wired into `.githooks/pre-push` or `ci.yml`.** It exits 1 today. Gating every
  push on a check that fails for everyone is how a gate gets `--no-verify`'d, which is
  strictly worse than no gate. Wiring lands with the re-anchoring, on #2695. ⚠ Note the
  wiring is two files, not one: `scripts/check_ci_mirrors_prepush.sh` requires every
  `bash scripts/check_*.sh` line to exist in both, so it needs a `check_probe_anchors.sh`
  wrapper mirrored into the lint job.
- **Does not re-anchor anything.** Each of the 14 needs its source read and the smallest
  identifying span chosen; several will need a judgement about whether the invariant even
  still exists in that form. That is #2695's remaining work.
- **Does not catch a branch no probe names** (#2689's class) — the standing guards are
  properties of probes that exist, and so is this. Nor a rotted `-k` selector: a test can
  be renamed, or its fixture drift until it no longer observes the defect, with the anchor
  perfectly intact. Only a real run settles that. Both are stated in the module docstring
  so the check is not mistaken for more than it is.
- **Scope is `scripts/probe_2240_*.py`** deliberately: several other `probe_*.py` files
  execute work at import (`probe_def14a_high_identity_escape.py` reads `sys.argv[1]` at
  module level), so importing the whole glob would run them.

## The audit's own failure mode

Going inert. A harness whose shape the resolver cannot read would contribute zero anchors
and still print `OK`. `tests/test_audit_probe_anchors.py` pins the resolution for each of
the three source shapes, pins that an unreadable shape is *reported* rather than skipped,
pins that an empty edit list is not mistaken for the edit list — and asserts against the
**real** harnesses that every probe in every file yields a non-empty anchor and an
existing source, so a harness added in a new shape fails there rather than quietly
shrinking coverage.

Also documented inline: a failure has two causes needing different fixes. Either an anchor
went stale, **or a killed probe run left a tracked source file mutated** — the harnesses
restore in a `finally`, which survives Ctrl-C but not a hard kill, and exactly that
leftover was found in this worktree at the start of #2357. `git status` first.

## Security

None. A read-only script and its tests; nothing reachable from the API, the jobs daemon or
the broker path. It imports the probe harnesses but never calls their `main()`.

## Verification

- `ruff check` / `ruff format --check` / `pyright` — clean.
- `pytest tests/test_audit_probe_anchors.py` — 10 passed.
- Pre-push hook green.
- The 284-anchor run above; the two spot-checks verified against the source by hand.

Codex checkpoint 2 not run: a new read-only script plus its tests, no service, schema or
data-semantics change — the review-intensity ladder's narrow rung.

Refs #2695. Refs #2357. Refs #2689. Refs #2240.
