### PR TITLE
feature(#2603): wire configure_core_mandate — item 3's entry condition

### DIFF
--- a/app/api/strategies.py
+++ b/app/api/strategies.py
@@ -28,7 +28,10 @@ from app.services.backtest_run import BACKTEST_UNIVERSE, runnable_strategies
 from app.services.broker_credentials import (
     CredentialDecryptError,
     CredentialNotFound,
+    CredentialValidationError,
     load_credential_for_provider_use,
+    normalise_environment,
+    normalise_provider,
 )
 from app.services.cost_model import COST_MODEL_ID
 from app.services.equity_curve import BENCHMARK_RULE_ID, SIZING_RULE_ID
@@ -59,7 +62,15 @@ from app.services.strategy_control_plane import (
     mandate_for_profile,
     promote_strategy,
 )
-from app.services.strategy_core_mandate import CORE_MANDATE_SERIES_ID, CORE_MANDATE_SERIES_TITLE
+from app.services.strategy_core_eligibility import CoreEligibilityError
+from app.services.strategy_core_mandate import (
+    CORE_MANDATE_SERIES_ID,
+    CORE_MANDATE_SERIES_TITLE,
+    CoreMandate,
+    CoreMandateError,
+    configure_core_mandate,
+    load_core_mandate,
+)
 from app.services.strategy_live_gate import (
     REQUIRED_KILL_DRILLS,
     LiveGateReport,
@@ -524,6 +535,76 @@ class StrategyPaperPoolUpdateRequest(BaseModel):
         if self.enabled and self.risk_profile == "unconfigured":
             raise ValueError("enabled paper pool requires a configured portfolio risk mandate")
         return self
+
+
+class CoreMandateUpdateRequest(BaseModel):
+    """One core/cash mandate revision, plus the ACCOUNT to prove it against.
+
+    ⚠ The mandate itself is account-agnostic — one series of revisions, no
+    account column — but its eligibility proof is not: ``require_core_eligibility``
+    resolves the live credential pair for ``(operator, provider, environment)``
+    and refuses a proof observed under any other. So the account has to be named
+    on the request. Same shape as ``app/api/broker_credentials.py``, including
+    the ``"demo"`` default, rather than a second convention.
+
+    ⚠⚠ NO MANDATE INVARIANT IS RESTATED HERE. The percentage bounds, the
+    complement rule and the enabled-needs-an-instrument rule all live in
+    ``validate_core_mandate``, which is also what the tests and any future caller
+    exercise. A Pydantic copy would be a second place for them to drift, and the
+    #2623 lesson is that the copy nobody edits is the one that goes wrong. These
+    fields carry SHAPE only.
+    """
+
+    enabled: bool
+    core_instrument_id: int | None = None
+    core_target_pct: Decimal = Field(max_digits=9, decimal_places=6)
+    liquidity_reserve_pct: Decimal = Field(max_digits=9, decimal_places=6)
+    rebalance_band_pct: Decimal = Field(max_digits=9, decimal_places=6)
+    min_rebalance_amount: Decimal = Field(max_digits=18, decimal_places=6)
+    reason: str = Field(min_length=1, max_length=1000)
+    provider: str = Field(default="etoro", min_length=1, max_length=64)
+    environment: str = Field(default="demo", min_length=1, max_length=16)
+
+
+class CoreMandateResponse(BaseModel):
+    """The stored mandate, or its absence.
+
+    ⚠ ``cash_target_pct`` is the service's derived complement, never a stored
+    second column — rendering it beside the target is what stops a reader
+    inventing their own subtraction against a different basis.
+    """
+
+    configured: bool
+    event_id: int | None = None
+    revision: int | None = None
+    enabled: bool | None = None
+    base_currency: str | None = None
+    core_instrument_id: int | None = None
+    core_target_pct: Decimal | None = None
+    cash_target_pct: Decimal | None = None
+    liquidity_reserve_pct: Decimal | None = None
+    rebalance_band_pct: Decimal | None = None
+    min_rebalance_amount: Decimal | None = None
+    policy_version: str | None = None
+
+
+def _core_mandate_response(mandate: CoreMandate | None) -> CoreMandateResponse:
+    if mandate is None:
+        return CoreMandateResponse(configured=False)
+    return CoreMandateResponse(
+        configured=True,
+        event_id=mandate.event_id,
+        revision=mandate.revision,
+        enabled=mandate.enabled,
+        base_currency=mandate.base_currency,
+        core_instrument_id=mandate.core_instrument_id,
+        core_target_pct=mandate.core_target_pct,
+        cash_target_pct=mandate.cash_target_pct,
+        liquidity_reserve_pct=mandate.liquidity_reserve_pct,
+        rebalance_band_pct=mandate.rebalance_band_pct,
+        min_rebalance_amount=mandate.min_rebalance_amount,
+        policy_version=mandate.policy_version,
+    )
 
 
 class StrategyPnlHistoryPoint(BaseModel):
@@ -2179,6 +2260,87 @@ def update_strategy_paper_pool(
     except (StrategyControlError, RuntimeConfigCorrupt, RuntimeConfigNoOp) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return get_strategy_overview(conn).paper_pool
+
+
+@router.get("/core-mandate", response_model=CoreMandateResponse, status_code=status.HTTP_200_OK)
+def read_core_mandate(
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CoreMandateResponse:
+    """The current core/cash mandate revision, or ``configured=false``.
+
+    ⚠ Absence is a 200, not a 404. "No mandate has ever been configured" is a
+    legitimate steady state of this system — it is where every install starts,
+    and it is where the tree stood until this endpoint existed — so a reader must
+    be able to distinguish it from a broken lookup. A 404 conflates the two.
+    """
+    return _core_mandate_response(load_core_mandate(conn))
+
+
+@router.put("/core-mandate", response_model=CoreMandateResponse, status_code=status.HTTP_200_OK)
+def update_core_mandate(
+    body: CoreMandateUpdateRequest,
+    session: SessionRow = Depends(require_session),
+    conn: psycopg.Connection[object] = Depends(get_conn),
+) -> CoreMandateResponse:
+    """Append one operator-authenticated core/cash mandate revision.
+
+    ⚠⚠ THIS IS THE ENTRY CONDITION FOR #2603 ITEM 3, AND ITS ABSENCE WAS THE
+    BLOCKER. ``configure_core_mandate`` had no caller anywhere in ``app/`` or
+    ``scripts/`` — only tests — so no mandate could be configured, therefore no
+    rebalance intent could cite one, therefore no core trade could exist. The
+    whole arc was unreachable from outside the test suite.
+
+    ⚠ Wiring this endpoint deliberately does NOT make the executor act on a
+    mandate. That is the correct intermediate state (step 1's posture), not a
+    gap to route around: a mandate becomes configurable here, and every
+    execution-time control — the one-trade-per-intent guard, the
+    no-open-core-trade precondition, the intent freshness bound — remains
+    unbuilt and is tracked on #2603.
+
+    ⚠ ``require_session``, not the router's ``require_session_or_service_token``.
+    A mandate revision is an operator authorisation and is recorded with a named
+    ``changed_by``; a service token has no operator identity to attribute it to,
+    and ``configure_core_mandate`` needs a real ``operator_id`` to select the
+    right eligibility proof.
+
+    Both refusal families are 409 rather than 400: the request may be perfectly
+    well formed and still be refused because the eligibility proof is stale, was
+    observed under swapped credentials, or because nothing material changed.
+    Those are states of the system, not faults in the payload.
+    """
+    # ⚠ NORMALISED BEFORE THE TRANSACTION, AND CAUGHT SEPARATELY (Codex ckpt-2).
+    # `normalise_provider` / `normalise_environment` raise
+    # `CredentialValidationError` on an unrecognised value, which is a 400 — a
+    # malformed selector — and NOT one of the 409s below. Folding it into that
+    # clause would report "the mandate was refused" for a typo in the account
+    # name, and leaving it uncaught returned a 500 for ordinary bad input.
+    # Hoisting it out of the transaction also keeps a pure-validation failure
+    # from opening and rolling back a transaction for nothing.
+    try:
+        provider = normalise_provider(body.provider)
+        environment = normalise_environment(body.environment)
+    except CredentialValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        with conn.transaction():
+            mandate = configure_core_mandate(
+                conn,
+                enabled=body.enabled,
+                core_instrument_id=body.core_instrument_id,
+                core_target_pct=body.core_target_pct,
+                liquidity_reserve_pct=body.liquidity_reserve_pct,
+                rebalance_band_pct=body.rebalance_band_pct,
+                min_rebalance_amount=body.min_rebalance_amount,
+                changed_by=session.username,
+                reason=body.reason,
+                operator_id=session.operator_id,
+                provider=provider,
+                environment=environment,
+            )
+    except (CoreMandateError, CoreEligibilityError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return _core_mandate_response(mandate)
 
 
 @router.put(

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -1,0 +1,185 @@
+"""The core/cash mandate endpoints (#2603 item 3's entry condition).
+
+Pure-tier by design. ``configure_core_mandate``'s own refusals — the eligibility
+gate, the material-change rule, the percentage invariants — are already exercised
+against a real Postgres in ``tests/test_2603_core_mandate_db.py`` and
+``tests/test_2603_core_eligibility_db.py``. Re-asserting them through HTTP would
+buy nothing and cost a database.
+
+What is genuinely NEW here is the wiring, and each of these three is a thing the
+service tests cannot see:
+
+* the route table (a static path shadowed by a path parameter),
+* the response mapping (including a derived field with no stored column),
+* which auth dependency the mutating route carries.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi.routing import APIRoute
+
+from app.api.strategies import CoreMandateUpdateRequest, _core_mandate_response, router
+from app.services.broker_credentials import (
+    CredentialValidationError,
+    normalise_environment,
+    normalise_provider,
+)
+from app.services.strategy_core_mandate import CoreMandate
+
+CORE_MANDATE_PATH = "/strategies/core-mandate"
+
+
+def _routes() -> list[APIRoute]:
+    return [route for route in router.routes if isinstance(route, APIRoute)]
+
+
+def _mandate(**overrides: object) -> CoreMandate:
+    values: dict[str, object] = {
+        "event_id": 7,
+        "revision": 3,
+        "enabled": True,
+        "base_currency": "USD",
+        "core_instrument_id": 42,
+        "core_target_pct": Decimal("60"),
+        "liquidity_reserve_pct": Decimal("20"),
+        "rebalance_band_pct": Decimal("5"),
+        "min_rebalance_amount": Decimal("25"),
+        "policy_version": "core-mandate-v1",
+    }
+    values.update(overrides)
+    return CoreMandate(**values)  # type: ignore[arg-type]
+
+
+class TestTheRouteTable:
+    def test_the_static_path_is_declared_before_every_strategy_id_route(self) -> None:
+        """⚠⚠ FastAPI matches in DECLARATION ORDER, so a `/{strategy_id}` route
+        declared first would swallow `/strategies/core-mandate` with
+        `strategy_id="core-mandate"`. The failure surfaces as a 404 or a
+        "strategy not found", which reads as a missing record rather than a
+        routing bug — so nobody looks at the route table.
+
+        Asserted as an ORDER, not as "the route exists": the route existing is
+        what a reader checks and is exactly what stays true when this breaks."""
+        paths = [route.path for route in _routes()]
+        assert CORE_MANDATE_PATH in paths
+        first_param_route = next(
+            (index for index, path in enumerate(paths) if "{strategy_id}" in path),
+            len(paths),
+        )
+        # ⚠ THE ANTI-VACUITY ASSERT, and it is the load-bearing one. With no
+        # `{strategy_id}` route on the router at all, `first_param_route` falls
+        # back to `len(paths)` and the comparison below holds for ANY placement
+        # — the test would go permanently green while guarding nothing. Pin that
+        # the hazard still exists before asserting it is avoided.
+        assert first_param_route < len(paths), "no {strategy_id} route — this test can no longer fail"
+        assert paths.index(CORE_MANDATE_PATH) < first_param_route
+
+    def test_both_verbs_are_registered_on_the_one_path(self) -> None:
+        """A read that 405s is a config surface an operator cannot inspect
+        before writing to it."""
+        methods = {method for route in _routes() if route.path == CORE_MANDATE_PATH for method in route.methods}
+        assert {"GET", "PUT"} <= methods
+
+
+class TestTheAuthDependency:
+    def test_the_mutating_route_requires_a_session_not_a_service_token(self) -> None:
+        """⚠ The router's default is `require_session_or_service_token`. A mandate
+        revision is an operator authorisation: it is stored with a named
+        `changed_by`, and `configure_core_mandate` needs a real `operator_id` to
+        select the right per-account eligibility proof. A service token has
+        neither, so the PUT overrides the router default.
+
+        Asserted on the dependency NAMES rather than on behaviour, because the
+        defect this guards is someone deleting the override — which changes no
+        test that exercises the happy path as an operator."""
+        put = next(route for route in _routes() if route.path == CORE_MANDATE_PATH and "PUT" in route.methods)
+        names = {dependency.call.__name__ for dependency in put.dependant.dependencies if dependency.call is not None}
+        assert "require_session" in names
+
+
+class TestTheAccountSelector:
+    def test_an_unsupported_provider_is_rejected_before_any_transaction_opens(self) -> None:
+        """⚠⚠ Codex checkpoint 2 (PR for #2603). `normalise_provider` raises
+        `CredentialValidationError` on an unrecognised value, which the endpoint
+        did not catch — so a typo'd account name returned a **500** for ordinary
+        malformed input.
+
+        Two things are pinned, not one. That it raises at all is the shape the
+        endpoint must handle; that it raises from `normalise_*` rather than from
+        `configure_core_mandate` is why it maps to 400 and not to the 409 the
+        mandate refusals use. A 409 would tell the operator "the mandate was
+        refused" for what is a spelling mistake in the account selector."""
+        for bad in ("not-a-broker", ""):
+            with pytest.raises(CredentialValidationError):
+                normalise_provider(bad)
+
+    def test_case_and_whitespace_are_tolerated_rather_than_refused(self) -> None:
+        """⚠ Written after asserting the opposite and being wrong.
+        `normalise_provider` is `raw.strip().lower()` before the membership test,
+        so `"ETORO "` is ACCEPTED. That matters to the endpoint: it is why the
+        400 above is narrow — reserved for a value that is genuinely not a
+        provider — rather than a trap an operator hits by pasting a name with a
+        trailing space."""
+        assert normalise_provider("ETORO ") == "etoro"
+        assert normalise_environment(" Demo") == "demo"
+
+    def test_an_unsupported_environment_is_rejected_the_same_way(self) -> None:
+        with pytest.raises(CredentialValidationError):
+            normalise_environment("production")
+
+    def test_the_defaults_normalise_rather_than_raise(self) -> None:
+        """The request model's defaults must be values the normalisers accept,
+        or every request omitting them 400s — a default that cannot survive its
+        own validator is worse than a required field."""
+        defaults = CoreMandateUpdateRequest.model_fields
+        assert normalise_provider(str(defaults["provider"].default)) == "etoro"
+        assert normalise_environment(str(defaults["environment"].default)) == "demo"
+
+
+class TestTheResponseMapping:
+    def test_an_unconfigured_mandate_is_a_200_not_an_absence(self) -> None:
+        """⚠ "Never configured" is where every install starts, and it is where
+        this tree stood until the endpoint existed. It must be distinguishable
+        from a broken lookup, which a 404 would conflate it with."""
+        response = _core_mandate_response(None)
+        assert response.configured is False
+        assert response.revision is None
+        assert response.core_target_pct is None
+
+    def test_every_stored_field_reaches_the_response(self) -> None:
+        """⚠ Listed explicitly rather than derived from the dataclass — deriving
+        them would pass for however many fields happen to exist, which is the
+        bug (a field added to `CoreMandate` and not to the response) rather than
+        the check."""
+        response = _core_mandate_response(_mandate())
+        assert (
+            response.configured,
+            response.event_id,
+            response.revision,
+            response.enabled,
+            response.base_currency,
+            response.core_instrument_id,
+            response.core_target_pct,
+            response.liquidity_reserve_pct,
+            response.rebalance_band_pct,
+            response.min_rebalance_amount,
+            response.policy_version,
+        ) == (True, 7, 3, True, "USD", 42, Decimal("60"), Decimal("20"), Decimal("5"), Decimal("25"), "core-mandate-v1")
+
+    def test_cash_target_is_the_services_complement_and_not_recomputed(self) -> None:
+        """⚠⚠ Cash has no stored column — it is `PERCENT_BASIS - core_target_pct`,
+        owned by `CoreMandate.cash_target_pct`. The response must READ that
+        property rather than subtract for itself, or the API acquires a second
+        definition of the same quantity against a basis nobody re-checks."""
+        mandate = _mandate(core_target_pct=Decimal("60"))
+        assert _core_mandate_response(mandate).cash_target_pct == mandate.cash_target_pct
+
+    def test_a_disabled_mandate_may_still_name_an_instrument(self) -> None:
+        """The `strategy_core_mandate_enabled_has_instrument` invariant is
+        one-directional, so the response must not treat a named instrument on a
+        disabled mandate as a contradiction to be normalised away."""
+        response = _core_mandate_response(_mandate(enabled=False, core_instrument_id=42))
+        assert (response.enabled, response.core_instrument_id) == (False, 42)

--- a/tests/test_2603_core_mandate_api.py
+++ b/tests/test_2603_core_mandate_api.py
@@ -16,12 +16,19 @@ service tests cannot see:
 
 from __future__ import annotations
 
+import inspect
 from decimal import Decimal
 
 import pytest
+from fastapi.params import Depends as DependsParam
 from fastapi.routing import APIRoute
 
-from app.api.strategies import CoreMandateUpdateRequest, _core_mandate_response, router
+from app.api.strategies import (
+    CoreMandateUpdateRequest,
+    _core_mandate_response,
+    router,
+    update_core_mandate,
+)
 from app.services.broker_credentials import (
     CredentialValidationError,
     normalise_environment,
@@ -94,10 +101,30 @@ class TestTheAuthDependency:
 
         Asserted on the dependency NAMES rather than on behaviour, because the
         defect this guards is someone deleting the override — which changes no
-        test that exercises the happy path as an operator."""
-        put = next(route for route in _routes() if route.path == CORE_MANDATE_PATH and "PUT" in route.methods)
-        names = {dependency.call.__name__ for dependency in put.dependant.dependencies if dependency.call is not None}
-        assert "require_session" in names
+        test that exercises the happy path as an operator.
+
+        ⚠ READ OFF THE ENDPOINT'S OWN SIGNATURE, not off `route.dependant`
+        (review NITPICK, PR #2702). `Depends.dependency` is FastAPI's public
+        surface; the resolved dependant tree is an internal it is free to
+        reshape. It is also the more precise question: the dependant tree
+        contains BOTH `require_session_or_service_token` (inherited from the
+        router) and `require_session`, because both run — measured, not assumed.
+        The security claim rests on the STRICTER one being present, since it
+        401s a caller with no session whatever the router-level one allowed.
+
+        ⚠ On the failure direction: if FastAPI ever composed these differently,
+        `require_session` would go MISSING from the set and this test would
+        fail. That is the safe direction — a false fail, which gets triaged, not
+        a false pass, which does not. The anti-vacuity assert below makes it so
+        explicitly rather than by luck."""
+        signature = inspect.signature(update_core_mandate)
+        declared = {
+            parameter.default.dependency.__name__
+            for parameter in signature.parameters.values()
+            if isinstance(parameter.default, DependsParam) and parameter.default.dependency is not None
+        }
+        assert declared, "no Depends markers on the endpoint — this test can no longer fail"
+        assert "require_session" in declared
 
 
 class TestTheAccountSelector:


### PR DESCRIPTION
Refs #2603. Refs #2437.

## The blocker

⚠⚠ `configure_core_mandate` had **no caller** anywhere in `app/` or `scripts/` — only tests. So no mandate could be configured, therefore no rebalance intent could cite one, therefore no core trade could exist. The entire item-3 arc was unreachable from outside the test suite.

Re-falsified against the tree before building rather than inherited from the step-3 handoff (`grep` over `app/`, `scripts/`, `frontend/src`): confirmed, the only references are `tests/test_2603_core_mandate_db.py` and `tests/test_2603_core_eligibility_db.py`.

`GET` / `PUT /strategies/core-mandate`.

## What this deliberately does NOT do

⚠ **Wiring this does not make the executor act on a mandate.** That is the correct intermediate state — step 1's posture — not a gap to route around. A mandate becomes configurable; every execution-time control stays unbuilt and stays on #2603:

- one trade per intent **at submission** (`sql/349`'s UNIQUE bounds storage, not two concurrent submissions racing to the broker),
- the no-open-core-trade precondition,
- the intent freshness bound (⚠ needs a source rule first — `CORE_ELIGIBILITY_MAX_AGE` is the *proof's* bound and must not be borrowed by analogy).

Item 3's acceptance remains an operator-attended session. Nothing here executes, approves or simulates a trade.

## Decisions

**The account is named on the request.** The mandate is account-agnostic in storage — one revision series, no account column — but its eligibility proof is not: `require_core_eligibility` resolves the *live* credential pair for `(operator, provider, environment)` and refuses a proof observed under any other, precisely so a credential swap cannot let another eToro account inherit the old one's proof. So the account has to be on the request. Shape copied from `app/api/broker_credentials.py` including the `"demo"` default, rather than inventing a second convention.

**`require_session`, overriding the router's `require_session_or_service_token`.** A revision is an operator authorisation: it is stored with a named `changed_by`, and the service needs a real `operator_id` to select the right per-account proof. A service token has neither.

**No mandate invariant is restated in the request model.** The percentage bounds, the cash complement and enabled-needs-an-instrument all live in `validate_core_mandate`, which is what the DB tests and any future caller exercise. A Pydantic copy would be a second place for them to drift, and #2623's lesson is that the copy nobody edits is the one that goes wrong. The model carries **shape only**.

**Absence is a 200 with `configured=false`, not a 404.** "Never configured" is where every install starts and where this tree stood until now. A 404 conflates it with a broken lookup.

**`cash_target_pct` is read from `CoreMandate.cash_target_pct`, never recomputed.** Cash has no stored column; subtracting again in the API would give the same quantity a second definition against a basis nobody re-checks.

## Codex checkpoint 2 — one real defect

`normalise_provider` / `normalise_environment` raise `CredentialValidationError` on an unrecognised value, and the `except` clause did not include it — so a typo'd account name returned a **500** for ordinary malformed client input.

Fixed: normalised **before** the transaction and mapped to **400**, kept distinct from the 409s. Folding it into the 409 clause would report "the mandate was refused" for what is a spelling mistake in the account selector; hoisting it out of the transaction also stops a pure-validation failure opening and rolling back a transaction for nothing.

## Tests — pure tier, and why

The service's own refusals (eligibility gate, material-change rule, percentage invariants) are already exercised against a real Postgres in the two `test_2603_*_db.py` files. Re-asserting them through HTTP would buy nothing and cost a database. These pin only what those cannot see.

⚠⚠ **The route-ordering test is the one worth having.** FastAPI matches in **declaration order**, so a `/{strategy_id}` route declared first would swallow `/strategies/core-mandate` with `strategy_id="core-mandate"` — surfacing as a 404 or "strategy not found", which reads as a missing record rather than a routing bug, so nobody looks at the route table.

**Revert-probed**, not assumed: moving both routes below every `{strategy_id}` route fails the test (exit 1), restoring passes (exit 0).

It also carries an **anti-vacuity assert**. With no `{strategy_id}` route on the router, `first_param_route` falls back to `len(paths)` and the ordering comparison holds for *any* placement — the test would go permanently green while guarding nothing. The hazard is pinned before it is asserted away.

⚠ One test asserted `"ETORO "` was invalid and was wrong: `normalise_provider` is `raw.strip().lower()` before the membership test, so it is accepted. Replaced with an assertion that the tolerance exists — which is *why* the new 400 is narrow rather than a trap an operator hits by pasting a name with a trailing space.

## Security

⚠ This adds an authenticated write surface, so the model is stated rather than waved past.

- **Authentication:** `require_session`, strictly narrower than the router default. A service token cannot reach it.
- **Authorisation:** the operator identity is taken from `session.operator_id` and **never from the request body**, so a caller cannot configure a mandate against another operator's eligibility proof. `changed_by` is `session.username`, likewise server-derived.
- **The gate it depends on:** an *enabled* mandate is refused unless its instrument has a fresh, passing, same-account proof that it is the underlying product and not a CFD — including a check that the proof was observed under the *currently live* credential pair. That gate is `configure_core_mandate`'s, not this endpoint's, and this endpoint cannot bypass or weaken it.
- **Injection:** no user-controlled string reaches SQL; `provider` / `environment` pass through allowlist normalisers, everything else is typed and parameterised by the service.
- **Trade execution:** none. This writes one mandate revision row.

## Verification

- `ruff check` / `ruff format --check` / `pyright`: clean.
- `pytest -m "not db"`: pass. `pytest tests/smoke`: pass.
- `pytest tests/test_2603_core_mandate_api.py`: 10 pass.
- Codex `exec review --base origin/main` with all files staged: one P2, fixed above.
- Route-ordering test revert-probed (fails on the shadowed placement, passes restored).

⚠ **Not dev-verified against the running stack.** The API on `:8000` serves `~/Dev/eBull`, not this worktree, so hitting the live endpoint needs the documented main-checkout branch dance. The route table, auth dependency and response mapping are covered by tests here; a live `GET /strategies/core-mandate` returning `configured=false` is the one-command confirmation and is owed before the executor half is built on top.
