### PR TITLE
feature(#2603): the core submission gate — item 3 step 3a, the half that refuses

### DIFF
--- a/app/services/strategy_core_eligibility.py
+++ b/app/services/strategy_core_eligibility.py
@@ -118,6 +118,16 @@ class CoreEligibilityProof:
     verdict: CoreEligibilityVerdict
     reason_code: str | None
     age_seconds: Decimal
+    #: ⚠ READ BACK SINCE #2603 step 3a, and NOT part of ``verdict``.  A passing
+    #: verdict requires ``allow_open_position`` (``evaluate_core_eligibility``) and says
+    #: nothing about closing.  A rebalance SELL is a partial close -- never a full
+    #: one, because ``validate_core_mandate`` requires
+    #: ``core_target_pct - rebalance_band_pct > 0`` and the allocator sells only to
+    #: the lower band edge -- so the submission gate tests
+    #: ``allow_partial_close_position`` separately.  ``None`` means the response did
+    #: not say, which is why the gate compares ``IS TRUE`` rather than truthiness.
+    allow_close_position: bool | None
+    allow_partial_close_position: bool | None
     policy_version: str
 
 
@@ -304,7 +314,8 @@ def load_latest_core_eligibility_proof(
         """
         SELECT core_eligibility_proof_id, instrument_id, operator_id, provider, environment,
                api_key_credential_id, user_key_credential_id, observed_at, verdict, reason_code,
-               EXTRACT(EPOCH FROM (now() - observed_at))::numeric AS age_seconds, policy_version
+               EXTRACT(EPOCH FROM (now() - observed_at))::numeric AS age_seconds, policy_version,
+               allow_close_position, allow_partial_close_position
         FROM strategy_core_eligibility_proofs
         WHERE instrument_id = %s AND operator_id = %s AND provider = %s AND environment = %s
         ORDER BY observed_at DESC, core_eligibility_proof_id DESC
@@ -327,6 +338,12 @@ def load_latest_core_eligibility_proof(
         reason_code=None if row[9] is None else str(row[9]),
         age_seconds=Decimal(str(row[10])),
         policy_version=str(row[11]),
+        # Nullable in sql/346 and left as None rather than coerced: False means the
+        # broker said no, None means the response did not answer, and collapsing
+        # them would let an unanswered question read as a refusal (or worse, the
+        # other way round once someone writes `not proof.allow_partial_close`).
+        allow_close_position=None if row[12] is None else bool(row[12]),
+        allow_partial_close_position=None if row[13] is None else bool(row[13]),
     )
 
 

--- a/app/services/strategy_core_submission_gate.py
+++ b/app/services/strategy_core_submission_gate.py
@@ -1,0 +1,487 @@
+"""May this recorded core rebalance verdict become an order? (#2603 item 3, step 3a).
+
+Step 3 is the executor.  This is the half of it that REFUSES: one admission
+decision over one stored ``strategy_core_rebalance_intents`` row.  Step 3b builds
+the observe -> record -> submit path that consumes it, and ships after this one
+deliberately -- the opposite order produces a writer whose preconditions are a
+comment.
+
+⚠⚠ AUTHORISES NOTHING TODAY.  It has no caller in ``app/`` or ``scripts/`` and it
+writes nothing.  Named plainly, as steps 1 and 2 named it, because #2437's R4
+comment records *a control that exists, is tested, and sits on a path the decision
+does not take* nine times over on this ticket alone.
+
+⚠⚠ THE VOCABULARY BELOW IS NOT THE COMPLETE SUBMISSION REFUSAL VOCABULARY.  The
+kill switch, ``enable_auto_trading``, the execution block, market-session state,
+quote availability and staleness, account-risk availability, broker minimums,
+cost assessment and broker rejection are all real refusals of a core submission
+and NONE of them is here -- they belong to 3b, which is the code that holds a
+quote and a broker.  A reader who takes this module for the full set will
+conclude the core arm has no kill-switch check.  It has none YET.
+
+Spec: ``docs/proposals/ta/2026-08-14-core-submission-gate.md``
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Final, Literal
+from uuid import UUID
+
+import psycopg
+from psycopg.pq import TransactionStatus
+
+from app.services.strategy_core_eligibility import (
+    CoreEligibilityError,
+    require_core_eligibility,
+)
+from app.services.strategy_core_mandate import (
+    CORE_MANDATE_ADVISORY_LOCK,
+    CORE_MANDATE_MODE,
+)
+
+#: Frozen with the rule set it stamps.  v1 fixes, BY CONSTRUCTION and with no
+#: published formulation to cite (see the spec's source-rule section): intent
+#: freshness is SUPERSESSION rather than an age threshold; in-flight suppression
+#: is sourced from ``strategy_order_reconciliation_state``'s own terminal set
+#: rather than from ``strategy_trades.status`` names; and a rebalance sell
+#: requires ``allow_partial_close_position``.
+CORE_SUBMISSION_POLICY_VERSION: Final = "core-submission-v1"
+
+#: Submissions against each other.  ``(2603, 1)`` is the mandate writers' key and
+#: is taken FIRST by :func:`core_submission_lock` -- see its docstring.
+CORE_SUBMISSION_ADVISORY_LOCK: Final = (2603, 3)
+
+#: ``sql/285``'s own terminal set: the backlog index is defined
+#: ``WHERE state NOT IN ('resolved','rejected')`` and the
+#: ``strategy_order_reconciliation_resolved_shape`` CHECK ties exactly these two
+#: to a non-NULL ``reconciled_at``.  Quoted from the migration rather than
+#: re-derived, because "is this order's broker effect known" is that table's
+#: entire purpose and inferring it from ``strategy_trades.status`` names is what
+#: the first draft of this module got wrong in both directions.
+_RECONCILIATION_TERMINAL_STATES: Final = ("resolved", "rejected")
+
+CoreSubmissionRefusal = Literal[
+    "core_intent_missing",
+    "core_intent_not_actionable",
+    "core_intent_superseded",
+    "core_mandate_revision_stale",
+    "core_mandate_not_paper",
+    "core_mandate_disabled",
+    "core_intent_already_submitted",
+    "core_trade_in_flight",
+    "core_eligibility_unproved",
+    "core_partial_close_unproved",
+]
+"""The closed vocabulary of reasons admission is refused.
+
+A ``Literal`` rather than ``str``, so pyright checks every ``return`` site against
+it and a code cannot be introduced without appearing here (the allocator's own
+device).  ⚠ PRECEDENCE IS THE DECLARATION ORDER and it is load-bearing: an input
+can be superseded, already submitted AND ineligible at once, and without a fixed
+order the recorded explanation moves with a refactor.
+"""
+
+
+class StrategyCoreSubmissionError(RuntimeError):
+    """A caller contract breach -- not a refusal, and deliberately not returnable.
+
+    Raised only when the serialising advisory lock is not held.  An unserialised
+    caller is a BUG rather than a state of the world; returning it as a verdict
+    would let the caller log it and carry on into the race the lock exists to
+    prevent.
+    """
+
+
+@dataclass(frozen=True)
+class CoreSubmissionAdmission:
+    """One admission verdict, carrying what the caller would otherwise re-read."""
+
+    admitted: bool
+    reason_code: CoreSubmissionRefusal | None
+    detail: str | None
+    """⚠ NOT decoration.  Three refusals collapse materially different causes that
+    the caller cannot re-derive: ``core_eligibility_unproved`` covers four
+    (``require_core_eligibility`` distinguishes them and only in its message),
+    ``core_intent_already_submitted`` hides whether the prior submission is
+    uncertain and therefore needs reconciliation rather than a retry, and
+    ``core_trade_in_flight`` hides WHICH trade blocks and in what state."""
+
+    intent_id: int
+    action: Literal["buy_core", "sell_core"] | None
+    amount: Decimal | None
+    core_instrument_id: int | None
+    core_mandate_event_id: int | None
+    eligibility_proof_id: int | None
+
+
+# ⚠⚠ ONE STATEMENT, and that is the correctness property rather than a tidiness
+# one.  Under READ COMMITTED a sequence of statements sees a sequence of
+# snapshots, so "this is the newest intent" and "no trade cites it yet" could each
+# be true of a different instant and false together.  Every table fact the gate
+# decides on is read here; eligibility is the one read that follows, because it
+# takes FOR SHARE on the credential rows and answers a different question.
+_ADMISSION_SQL: Final = """
+SELECT
+    intent.action,
+    intent.amount,
+    intent.core_instrument_id,
+    intent.core_mandate_event_id,
+    mandate.mode                       AS mandate_mode,
+    mandate.revision                   AS mandate_revision,
+    current_mandate.revision           AS current_mandate_revision,
+    current_mandate.enabled            AS current_mandate_enabled,
+    newer.core_rebalance_intent_id     AS newer_intent_id,
+    existing.strategy_trade_id         AS existing_trade_id,
+    existing.status                    AS existing_trade_status,
+    blocker.strategy_trade_id          AS blocking_trade_id,
+    blocker.blocking_state             AS blocking_state
+FROM strategy_core_rebalance_intents intent
+LEFT JOIN strategy_core_mandate_events mandate
+       ON mandate.core_mandate_event_id = intent.core_mandate_event_id
+LEFT JOIN LATERAL (
+    SELECT revision, enabled FROM strategy_core_mandate_events
+    ORDER BY revision DESC LIMIT 1
+) current_mandate ON TRUE
+LEFT JOIN LATERAL (
+    SELECT core_rebalance_intent_id FROM strategy_core_rebalance_intents newer_intent
+    WHERE newer_intent.core_rebalance_intent_id > intent.core_rebalance_intent_id
+    ORDER BY newer_intent.core_rebalance_intent_id DESC LIMIT 1
+) newer ON TRUE
+LEFT JOIN strategy_trades existing
+       ON existing.core_rebalance_intent_id = intent.core_rebalance_intent_id
+LEFT JOIN LATERAL (
+    -- A non-terminal core trade blocks unless EVERY linked order has reached
+    -- sql/285's terminal set -- and a trade with no linked order at all blocks
+    -- too.
+    --
+    -- ⚠⚠ A MISSING reconciliation row blocks exactly as a non-terminal one does,
+    -- and getting this wrong is a fail-OPEN.  An earlier draft filtered on
+    -- `recon.state IS NOT NULL AND state <> ALL (terminal)`, so a linked order
+    -- with no reconciliation row satisfied neither arm: not blocking by state
+    -- (NULL), not blocking by absence (the order exists).  That admits a second
+    -- rebalance while the FIRST order's broker effect is unknown, which is the
+    -- one outcome this predicate exists to prevent.  Nothing in the schema
+    -- requires a linked order to have a reconciliation row.
+    SELECT t.strategy_trade_id,
+           -- FILTERed, so the reported state is one that ACTUALLY blocks: a bare
+           -- min() over every linked order would report 'rejected' (alphabetically
+           -- first) for a trade blocked by an 'unresolved' sibling order.
+           coalesce(
+               min(coalesce(recon.state, 'no_reconciliation_row')) FILTER (
+                   WHERE link.order_id IS NOT NULL
+                     AND (recon.state IS NULL
+                          OR recon.state <> ALL (%(terminal_reconciliation_states)s))
+               ),
+               'no_order'
+           ) AS blocking_state
+    FROM strategy_trades t
+    LEFT JOIN strategy_trade_orders link ON link.strategy_trade_id = t.strategy_trade_id
+    LEFT JOIN strategy_order_reconciliation_state recon ON recon.order_id = link.order_id
+    WHERE t.core_rebalance_intent_id IS NOT NULL
+      AND t.status <> ALL (%(terminal_trade_statuses)s)
+    GROUP BY t.strategy_trade_id
+    HAVING count(*) FILTER (
+               WHERE link.order_id IS NOT NULL
+                 AND (recon.state IS NULL
+                      OR recon.state <> ALL (%(terminal_reconciliation_states)s))
+           ) > 0
+        -- No linked order at all.  Unreachable through the executor (trade, order
+        -- and link are one transaction) and kept because this repo's tests and
+        -- fixtures insert rows directly -- sql/349's own rule: the invariant
+        -- changes at the migration, not at the writer.
+        OR count(link.order_id) = 0
+    ORDER BY t.strategy_trade_id
+    LIMIT 1
+) blocker ON TRUE
+WHERE intent.core_rebalance_intent_id = %(intent_id)s
+"""
+
+#: Trade statuses that cannot block: nothing is outstanding on either of them, so
+#: a stranded reconciliation row against a closed or failed trade must not deny
+#: every later rebalance for ever.  ⚠ NOT a claim about broker-snapshot
+#: reflection -- that question is answered by the reconciliation state, above.
+_TERMINAL_TRADE_STATUSES: Final = ("closed", "failed")
+
+
+def _lock_held(conn: psycopg.Connection[Any], key: tuple[int, int]) -> bool:
+    """Does THIS backend currently hold ``key`` as a two-int4 advisory lock?
+
+    ⚠ ``objsubid = 2`` is required, not tidiness.  Postgres encodes a two-``int4``
+    advisory key as ``classid``/``objid`` with ``objsubid = 2``, and a one-``int8``
+    key as the high/low halves of the bigint with ``objsubid = 1``.  Without it an
+    unrelated ``pg_advisory_lock(bigint)`` whose halves happen to match satisfies
+    the check.
+
+    ⚠ ``classid``/``objid`` are OID-width (unsigned) while
+    ``pg_advisory_lock(int, int)`` takes signed ``int4``, so a NEGATIVE key
+    component would not compare equal without conversion.  Both keys used here are
+    positive literals; a future negative one breaks this silently.
+
+    What this proves, exactly: that this backend currently holds a matching lock.
+    NOT that this call acquired it, that the context manager owns it, or that no
+    reentrant acquisition is outstanding -- ``pg_locks`` does not expose the
+    reference count.  That is enough for the property the gate needs (the critical
+    section is open) and short of exclusive ownership, so no such claim is made.
+    """
+    row = conn.execute(
+        """
+        SELECT 1 FROM pg_locks
+        WHERE locktype='advisory' AND classid=%s AND objid=%s AND objsubid=2
+          AND pid=pg_backend_pid() AND granted
+        LIMIT 1
+        """,
+        key,
+    ).fetchone()
+    return row is not None
+
+
+@contextmanager
+def core_submission_lock(conn: psycopg.Connection[Any]) -> Iterator[None]:
+    """Serialise the core arm's observe-record-admit-submit-insert section.
+
+    Takes TWO locks, in this order:
+
+    1. ``CORE_MANDATE_ADVISORY_LOCK`` -- the same key ``configure_core_mandate``
+       takes as an *xact* lock.  Without it the gate's
+       ``core_mandate_revision_stale`` check is a TOCTOU: a revision appended
+       between the check and the trade INSERT leaves a trade citing a mandate the
+       operator has replaced.  Session and transaction advisory locks share one
+       lock manager, so holding it blocks mandate writes for the duration of a
+       submission -- which is the intended behaviour, not a side effect.
+    2. ``CORE_SUBMISSION_ADVISORY_LOCK`` -- submissions against each other.
+
+    One acquisition order, and ``configure_core_mandate`` takes only the first, so
+    there is no deadlock cycle.  Shape follows ``_allocator_lock``
+    (``strategy_paper_executor``), unlock-ownership assertion included: a lost
+    lock means the critical section was not what it claimed to be, and that must
+    be loud.
+    """
+    keys = (CORE_MANDATE_ADVISORY_LOCK, CORE_SUBMISSION_ADVISORY_LOCK)
+    for key in keys:
+        conn.execute("SELECT pg_advisory_lock(%s, %s)", key)
+    conn.commit()
+    try:
+        yield
+    finally:
+        if conn.info.transaction_status != TransactionStatus.IDLE:
+            conn.rollback()
+        # Released in reverse acquisition order, and EVERY key is attempted before
+        # anything raises: bailing on the first lost lock would leak the other for
+        # the life of the session.
+        lost = [
+            key
+            for key in reversed(keys)
+            if conn.execute("SELECT pg_advisory_unlock(%s, %s)", key).fetchone() != (True,)
+        ]
+        conn.commit()
+        if lost:
+            raise StrategyCoreSubmissionError(f"core submission advisory lock ownership was lost: {lost}")
+
+
+def _refused(
+    intent_id: int,
+    reason_code: CoreSubmissionRefusal,
+    detail: str | None = None,
+    *,
+    action: Literal["buy_core", "sell_core"] | None = None,
+    amount: Decimal | None = None,
+    core_instrument_id: int | None = None,
+    core_mandate_event_id: int | None = None,
+) -> CoreSubmissionAdmission:
+    return CoreSubmissionAdmission(
+        admitted=False,
+        reason_code=reason_code,
+        detail=detail,
+        intent_id=intent_id,
+        action=action,
+        amount=amount,
+        core_instrument_id=core_instrument_id,
+        core_mandate_event_id=core_mandate_event_id,
+        eligibility_proof_id=None,
+    )
+
+
+def admit_core_rebalance_intent(
+    conn: psycopg.Connection[Any],
+    *,
+    intent_id: int,
+    operator_id: UUID,
+    provider: str,
+    environment: str,
+) -> CoreSubmissionAdmission:
+    """Decide whether this stored rebalance verdict may become an order now.
+
+    Returns a verdict for every input and NEVER raises to signal a refusal -- the
+    allocator's posture, for the allocator's reason: a caller that must catch in
+    order to learn the mandate is disabled will eventually catch too broadly.  The
+    single raise is :class:`StrategyCoreSubmissionError` for an unheld lock, which
+    is a caller contract breach rather than a state of the world.
+
+    ⚠ Reads only.  Writes nothing, calls no broker, and the whole table half is one
+    statement so every fact it decides on comes from one snapshot.
+
+    ⚠ The freshness rule is SUPERSESSION, not an age threshold, and the scope of
+    "newest" is the whole table -- correct only because the mandate is a singleton
+    (``load_core_mandate`` takes no account argument and
+    ``strategy_core_rebalance_intents`` carries no operator/provider/environment
+    column).  If a second mandate is ever introduced this predicate silently starts
+    refusing unrelated intents.
+
+    ⚠ Supersession bounds RELATIVE staleness only.  An intent that is newest, under
+    the newest mandate, and two hours old is admitted: no server-side fact
+    distinguishes it from one recorded two seconds ago.  The absolute bound is the
+    caller's -- observe, record, admit and submit inside ONE hold of
+    :func:`core_submission_lock` -- and this function cannot verify it.
+
+    ⚠ ``require_core_eligibility`` takes ``FOR SHARE`` on the live credential rows
+    and that lock ends at the next commit.  A caller that commits between admission
+    and submission reopens the credential-swap window; keep the two in one
+    transaction or re-admit afterwards.
+    """
+    if not _lock_held(conn, CORE_SUBMISSION_ADVISORY_LOCK):
+        raise StrategyCoreSubmissionError(
+            "core submission admission requires core_submission_lock to be held; "
+            "without it the UNIQUE index refuses the second INSERT only after both callers reached the broker"
+        )
+    if not _lock_held(conn, CORE_MANDATE_ADVISORY_LOCK):
+        raise StrategyCoreSubmissionError(
+            "core submission admission requires the core mandate advisory lock to be held; "
+            "without it a mandate revision can be appended between this check and the trade INSERT"
+        )
+
+    row = conn.execute(
+        _ADMISSION_SQL,
+        {
+            "intent_id": intent_id,
+            "terminal_trade_statuses": list(_TERMINAL_TRADE_STATUSES),
+            "terminal_reconciliation_states": list(_RECONCILIATION_TERMINAL_STATES),
+        },
+    ).fetchone()
+    if row is None:
+        return _refused(intent_id, "core_intent_missing")
+    (
+        action,
+        amount,
+        core_instrument_id,
+        core_mandate_event_id,
+        mandate_mode,
+        mandate_revision,
+        current_mandate_revision,
+        current_mandate_enabled,
+        newer_intent_id,
+        existing_trade_id,
+        existing_trade_status,
+        blocking_trade_id,
+        blocking_state,
+    ) = row
+
+    if action not in ("buy_core", "sell_core"):
+        # A hold or a refusal is stored as evidence (sql/348) and the FK alone
+        # would let one back a trade.  Same requirement `core_arm_authorised`
+        # encodes on the load path, applied here before anything reaches a broker.
+        return _refused(intent_id, "core_intent_not_actionable", f"action={action}")
+
+    # Narrowed for the caller's benefit; every field below is non-NULL on an
+    # actionable row by `core_rebalance_intent_shape_matches_action` plus
+    # `core_rebalance_intent_event_absent_only_when_mandate_absent`.
+    verdict_action: Literal["buy_core", "sell_core"] = action
+    verdict_amount = Decimal(str(amount))
+    instrument_id = int(core_instrument_id)
+    mandate_event_id = int(core_mandate_event_id)
+    context: dict[str, Any] = {
+        "action": verdict_action,
+        "amount": verdict_amount,
+        "core_instrument_id": instrument_id,
+        "core_mandate_event_id": mandate_event_id,
+    }
+
+    if newer_intent_id is not None:
+        return _refused(
+            intent_id,
+            "core_intent_superseded",
+            f"intent {int(newer_intent_id)} is a later evaluation of the same sleeve",
+            **context,
+        )
+    if current_mandate_revision is None or int(current_mandate_revision) != int(mandate_revision):
+        return _refused(
+            intent_id,
+            "core_mandate_revision_stale",
+            f"evaluated under revision {mandate_revision}, current is {current_mandate_revision}",
+            **context,
+        )
+    if mandate_mode != CORE_MANDATE_MODE:
+        return _refused(intent_id, "core_mandate_not_paper", f"mode={mandate_mode!r}", **context)
+    if not current_mandate_enabled:
+        # Reachable precisely because the check above proved the revision current:
+        # the allocator's own `core_mandate_disabled` belongs to a revision this
+        # intent predates, so a mandate disabled AFTER the evaluation passes every
+        # other check here.
+        return _refused(intent_id, "core_mandate_disabled", None, **context)
+    if existing_trade_id is not None:
+        return _refused(
+            intent_id,
+            "core_intent_already_submitted",
+            f"strategy_trade {int(existing_trade_id)} status={existing_trade_status!r}",
+            **context,
+        )
+    if blocking_trade_id is not None:
+        return _refused(
+            intent_id,
+            "core_trade_in_flight",
+            f"strategy_trade {int(blocking_trade_id)} reconciliation={blocking_state!r}",
+            **context,
+        )
+
+    try:
+        proof = require_core_eligibility(
+            conn,
+            instrument_id=instrument_id,
+            operator_id=operator_id,
+            provider=provider,
+            environment=environment,
+        )
+    except CoreEligibilityError as exc:
+        # Four materially different causes -- no observation, a non-`underlying`
+        # verdict, credentials no longer live, and an aged-out proof -- and only
+        # the message distinguishes them, so it is carried rather than dropped.
+        return _refused(intent_id, "core_eligibility_unproved", str(exc), **context)
+
+    if verdict_action == "sell_core" and proof.allow_partial_close_position is not True:
+        # A rebalance sell can never be a full close: `validate_core_mandate`
+        # requires `core_target_pct - rebalance_band_pct > 0` and the allocator
+        # sells only down to the lower band edge, so post-trade core value is
+        # strictly positive.  `is not True` rather than `not ...`: the column is
+        # nullable and None means the response did not say.
+        return _refused(
+            intent_id,
+            "core_partial_close_unproved",
+            f"proof {proof.proof_id} allow_partial_close_position={proof.allow_partial_close_position!r}",
+            **context,
+        )
+
+    return CoreSubmissionAdmission(
+        admitted=True,
+        reason_code=None,
+        detail=None,
+        intent_id=intent_id,
+        action=verdict_action,
+        amount=verdict_amount,
+        core_instrument_id=instrument_id,
+        core_mandate_event_id=mandate_event_id,
+        eligibility_proof_id=proof.proof_id,
+    )
+
+
+__all__ = [
+    "CORE_SUBMISSION_ADVISORY_LOCK",
+    "CORE_SUBMISSION_POLICY_VERSION",
+    "CoreSubmissionAdmission",
+    "CoreSubmissionRefusal",
+    "StrategyCoreSubmissionError",
+    "admit_core_rebalance_intent",
+    "core_submission_lock",
+]

--- a/docs/proposals/ta/2026-08-14-core-submission-gate.md
+++ b/docs/proposals/ta/2026-08-14-core-submission-gate.md
@@ -1,0 +1,306 @@
+# The core submission gate (#2603 item 3, execution half — step 3a)
+
+⚠ **Step 3 is the executor. This is the half of it that REFUSES.** Step 3a builds the
+admission decision — may this recorded rebalance verdict be turned into an order right
+now? — and nothing else. Step 3b builds the observe → record → submit path that consumes
+it. The refusing half ships first deliberately: the opposite order produces a writer whose
+preconditions are a comment.
+
+Prior steps: step 1 `8af38991` (`sql/348`, the intent record), step 2 `7513d77a`
+(`sql/349`, the exclusive arc), entry condition `14d1bf8b` (`GET/PUT
+/strategies/core-mandate`).
+
+## The four inherited scope items, re-falsified against the tree
+
+The step-3 handoff (#2603 comment, 2026-08-14T09:38Z) lists five. A prior session's
+conclusion is evidence, not a finding, so each was re-run. **Two of the four in scope
+changed, and both changed the design rather than the priority.**
+
+| # | inherited statement | verdict | evidence |
+| --- | --- | --- | --- |
+| 1 | one trade per intent **at submission** | **stands** | `sql/349`'s `strategy_trades_core_rebalance_intent_id_key` is a UNIQUE index: it refuses the second INSERT. It does not stop two callers both reaching the broker before either inserts, which is the leg that costs money. |
+| 2 | a **no-open-core-trade** precondition | ⚠ **WRONG AS WRITTEN** | an open core position is the mandate's steady state; the rule would forbid every rebalance after the first. §2 below. |
+| 3 | an **`evaluated_at` freshness bound** | ⚠ **WRONG SHAPE** | the premise that some other producer records intents is false, so an age threshold measures nothing. §3 below. |
+| 4 | eligibility re-proof bound to the exact proof/account/credential pair | **stands — wire, do not build** … ⚠ **plus one gap it does not cover** | `require_core_eligibility` (`strategy_core_eligibility.py:375-428`) already raises on all four failure kinds. It proves only `allow_open_position`. §4 below. |
+
+Item 5 (`strategy_paper_executor.py:925-935`, the uncertain-submission resume path) needs
+an entry *order* to be reachable and only step 3b creates one. Still deferred, still fails
+closed today.
+
+## §2 — "no open core trade" forbids the mandate's own steady state
+
+`strategy_trades.status` is CHECK-pinned to `planned | submitted | open | closing | closed
+| failed | reconcile_required` (measured on dev, `pg_constraint`). A core holding sits at
+`open` for as long as the mandate holds it — that is the *point* of a core sleeve. A
+precondition reading "refuse while an open core trade exists" would admit the first
+rebalance and refuse every later one, permanently, and would look like a working control
+the whole time.
+
+**What the hazard actually is** is already written down, in
+`strategy_core_rebalance_intent.py:16-18`: *"no in-flight suppression (the allocator is
+stateless and will re-recommend a trade already in flight)"*. A submitted-but-unfilled buy
+is not yet in the broker's position snapshot, so the next sleeve observation still shows
+the pre-trade core value and the allocator re-recommends the same buy. That is a double
+buy, and it is the only state that produces one.
+
+### The predicate is sourced, not inferred from lifecycle names
+
+A first draft of this document classified each `status` value as "reflected in the broker
+snapshot" or not, and derived the blocking set from that table. **That is inference from
+lifecycle names and it is wrong in both directions**: `failed` is written both after a
+definitively rejected submission (`strategy_paper_executor.py:1272`) and on the resume
+path (`:998`); `closed` and `open` are local lifecycle transitions that carry no claim
+about when a snapshot catches up.
+
+The system already stores the answer. `sql/285` gives
+`strategy_order_reconciliation_state` a closed state vocabulary and its own settled
+terminal set — the backlog index is defined `WHERE state NOT IN ('resolved','rejected')`,
+and the `strategy_order_reconciliation_resolved_shape` CHECK ties exactly those two to a
+non-NULL `reconciled_at`. **"Is this order's broker effect known" is that table's entire
+purpose.** So:
+
+> A core trade blocks admission while any order linked to it has a reconciliation state
+> outside `('resolved','rejected')`.
+
+`unresolved`, `pending`, `not_found`, `ambiguous` and `error` all block — unknown fails
+closed, and `not_found`/`ambiguous` are precisely the states in which a second order might
+be a duplicate or might be the only one.
+
+⚠ **Belt, for a state the reconciliation table cannot see.** A core trade with **no linked
+order at all** in a non-terminal status also blocks. In the executor, trade creation,
+order INSERT and `link_strategy_order` are one transaction, so this is unreachable through
+that path — but this repo's tests and fixtures insert rows directly, and `sql/349`'s own
+rule applies: the invariant changes at the migration, not at the writer.
+
+⚠ **This can deny service, deliberately.** A core trade whose reconciliation never reaches
+a terminal state blocks every later core submission. That is the correct direction for a
+duplicate-order control, and it is not silent: `enforce_reconciliation_slo` already exists
+and already raises an operator-visible execution block on exactly this backlog.
+
+## §3 — the freshness bound is structural, because there is no second producer
+
+**Source rule.** No published formulation governs how long a portfolio-rebalance verdict
+stays actionable, and this document does not invent a citation. Per `.claude/CLAUDE.md`
+("source-rule before design"), the rule is fixed **by construction** and frozen in
+`CORE_SUBMISSION_POLICY_VERSION`.
+
+The construction rests on one measured fact:
+
+```bash
+grep -rn "record_core_rebalance_intent" app scripts   # → the definition and one docstring. No caller.
+```
+
+`record_core_rebalance_intent` has **no caller in `app/` or `scripts/`**. So an intent the
+executor submits against is one the executor itself recorded moments earlier, from a sleeve
+it itself observed. A wall-clock bound on `evaluated_at` would be measuring the distance
+between two lines of one function — a threshold with no phenomenon under it, which is
+exactly the invented constant the source-rule rule exists to stop.
+
+What the bound is *for* is the case an age threshold reaches at: **a verdict that has been
+overtaken.** That is expressible exactly, with no parameter:
+
+- **`core_intent_superseded`** — refuse unless this intent is the newest row in
+  `strategy_core_rebalance_intents`. Any later evaluation supersedes an earlier one,
+  including a `hold` or a `refused`: the allocator is a pure function of mandate and
+  observed state, so a later row is a later observation of the same sleeve, and acting on
+  the earlier verdict would mean acting on a world we have since re-measured.
+- **`core_mandate_revision_stale`** — refuse unless the intent's `core_mandate_event_id` is
+  the newest revision. `strategy_core_mandate_events` is append-only and revision-ordered;
+  a verdict computed under a superseded mandate is one the operator has replaced.
+
+⚠ **Scope of "newest" is the whole table, and that is correct only because the mandate is a
+singleton.** `load_core_mandate` takes no account, operator or sleeve argument — it is
+`ORDER BY revision DESC LIMIT 1` over one table (`strategy_core_mandate.py:271-299`), and
+`strategy_core_rebalance_intents` carries no operator/provider/environment column. One
+mandate, one sleeve, one intent series. **If a second mandate is ever introduced, this
+predicate silently starts refusing unrelated intents** — recorded here because the failure
+would be a refusal, and refusals are the failures nobody notices.
+
+⚠ **What supersession does NOT do, stated rather than left silent.** It bounds *relative*
+staleness, not absolute. An intent that is newest, under the newest mandate, and two hours
+old is admitted, because no server-side fact distinguishes it from one recorded two seconds
+ago by the caller now asking. **The absolute bound is 3b's obligation**: observe → record →
+admit → submit inside a single lock hold, so that `evaluated_at` is by construction within
+one invocation. The gate cannot verify that and does not claim to.
+
+⚠ Both predicates are evaluated **server-side against the table**, never against a
+caller-supplied timestamp. A gate that takes the caller's word for "when now is" fails open
+on a caller bug.
+
+⚠ Ordering is by `core_rebalance_intent_id`, the BIGSERIAL primary key. Sequence order is
+not commit order in general; it is here, because 3b records and admits inside the same
+advisory lock (§5).
+
+## §4 — a rebalance sell is a PARTIAL CLOSE, and the existing proof does not cover one
+
+`require_core_eligibility` returns a proof whose `verdict='underlying'` requires
+`allow_open_position` (`strategy_core_eligibility.py:202`, `sql/346:110`). It says nothing
+about closing. `sql/346` already **stores** `allow_close_position` and
+`allow_partial_close_position` (`:72-74`); `CoreEligibilityProof` simply does not read them
+back.
+
+A `sell_core` therefore reaches the broker on a proof that the instrument can be *bought*.
+That is a different capability, documented separately by the provider, and assuming one
+from the other is the inference this repo keeps paying for.
+
+**Which of the two a rebalance sell needs is settled by construction, not chosen.**
+`validate_core_mandate` requires `core_target_pct - rebalance_band_pct > 0`
+(`strategy_core_mandate.py:246`), and the allocator sells only down to the lower band edge
+(`strategy_core_allocator.py:313-325`). So the post-trade core value is strictly positive:
+**a rebalance sell can never be a full close.** The capability required is
+`allow_partial_close_position`.
+
+Gate rule: on `action='sell_core'`, refuse `core_partial_close_unproved` unless the proof
+carries `allow_partial_close_position IS TRUE`. `IS TRUE`, not truthiness — the column is
+nullable and NULL means the response did not say.
+
+Reading the two columns back onto `CoreEligibilityProof` is the whole change; nothing about
+the proof's capture, digest or freshness moves.
+
+## §5 — the gate
+
+`app/services/strategy_core_submission_gate.py`
+
+```python
+def admit_core_rebalance_intent(
+    conn, *, intent_id: int, operator_id: UUID, provider: str, environment: str
+) -> CoreSubmissionAdmission
+```
+
+Returns a verdict for every input; **never raises to signal a refusal**. Same posture as
+`evaluate_core_rebalance`, for the same reason: a caller that must catch in order to learn
+the mandate is disabled will eventually catch too broadly. A raise is reserved for a caller
+*contract* breach — the lock, below.
+
+`CoreSubmissionAdmission` carries `admitted`, `reason_code`, `detail`, the intent's
+`action`, `amount`, `core_instrument_id`, the mandate `event_id`, and the eligibility
+`proof_id` when one was obtained. **`detail` is not decoration**: three refusals collapse
+materially different causes and the caller cannot re-derive them (§the vocabulary, below).
+
+### One snapshot, one statement
+
+Every table read the gate makes — the intent, its mandate, the newest intent, the newest
+mandate revision, an existing trade on this intent, and the in-flight population — is **one
+SQL statement**. Under `READ COMMITTED` a sequence of statements sees a sequence of
+snapshots, so "newest intent" and "no trade yet" could each be true of a different instant
+and false together. Eligibility is the one read that follows, because it takes `FOR SHARE`
+on the credential rows and answers a different question.
+
+### The closed refusal vocabulary
+
+Declared as a `Literal`, so pyright checks every `return` site against it and a code cannot
+be introduced without appearing in the vocabulary (the allocator's own device).
+
+**Precedence is fixed and is the order below.** Without one, an input that is simultaneously
+superseded, already submitted and ineligible would record whichever cause the implementation
+happened to test first, and the recorded explanation would move with a refactor. Cheapest
+and most-specific first; the two that need a second query are last.
+
+| # | reason code | refuses when | owed by |
+| --- | --- | --- | --- |
+| 1 | `core_intent_missing` | no such intent row | — |
+| 2 | `core_intent_not_actionable` | `action NOT IN ('buy_core','sell_core')` | step 2's `core_arm_authorised` |
+| 3 | `core_intent_superseded` | a newer intent row exists (`detail` names it) | §3 |
+| 4 | `core_mandate_revision_stale` | the intent's mandate is not the newest revision | §3 |
+| 5 | `core_mandate_not_paper` | the mandate's `mode <> 'paper'` | step 2 |
+| 6 | `core_mandate_disabled` | the current mandate revision is not `enabled` | ⚠ new, below |
+| 7 | `core_intent_already_submitted` | a `strategy_trades` row cites this intent (`detail` carries its status — an uncertain prior submission needs reconciliation, not a retry) | item 1 |
+| 8 | `core_trade_in_flight` | a core trade has an unreconciled order, or none at all (`detail` names the trade and state) | item 2 / §2 |
+| 9 | `core_eligibility_unproved` | `require_core_eligibility` raised (`detail` carries its message, which distinguishes all four causes) | item 4 |
+| 10 | `core_partial_close_unproved` | `sell_core` with `allow_partial_close_position` not TRUE | §4 |
+
+⚠ **`core_mandate_disabled` is not in the inherited list and is not scope creep.** Once
+`core_mandate_revision_stale` requires the intent's revision to be the *current* one, the
+gate already holds that row; a mandate the operator disabled between evaluation and
+submission would otherwise pass every check here, because the allocator's own
+`core_mandate_disabled` refusal belongs to a revision this intent predates. Reading the row
+and not testing its flag would be the same defect this ticket keeps finding.
+
+⚠⚠ **This vocabulary is NOT the complete submission refusal vocabulary, and must not be
+cited as one.** The kill switch, `enable_auto_trading`, the execution block, market-session
+state, quote availability and staleness, account-risk availability, broker minimums, cost
+assessment and broker rejection are all real refusals of a core submission and **none of
+them is here** — they belong to 3b, which is the code that holds a quote and a broker. A
+reader who takes this table for the full set will conclude the core arm has no kill-switch
+check. It has none *yet*.
+
+### The lock, and why the gate verifies it rather than documenting it
+
+Item 1's gap is a race: the UNIQUE index refuses the second INSERT, but by then both callers
+have placed an order. Serialising is the only fix, so admission is meaningful only while a
+session-level advisory lock is held across observe → record → admit → submit → insert.
+
+`core_submission_lock(conn)` takes **two** locks, in this order:
+
+1. `CORE_MANDATE_ADVISORY_LOCK = (2603, 1)` — the same key `configure_core_mandate` takes
+   as an *xact* lock. Without it the gate's `core_mandate_revision_stale` check is a
+   TOCTOU: a revision appended between the check and the INSERT leaves a trade citing a
+   mandate the operator has replaced. Session and transaction advisory locks share one lock
+   manager, so holding it blocks mandate writes for the duration of a submission — which is
+   the intended behaviour, not a side effect.
+2. `CORE_SUBMISSION_ADVISORY_LOCK = (2603, 3)` — submissions against each other.
+
+One acquisition order, and `configure_core_mandate` takes only the first, so there is no
+deadlock cycle. Shape and unlock-ownership assertion follow `_allocator_lock`
+(`strategy_paper_executor.py:166-179`).
+
+⚠⚠ **The gate asserts the lock is held, and this is the load-bearing part.** A precondition
+that lives in a docstring is exactly #2437's standing pattern — *the control exists on a
+path the decision does not take*. One catalogue read converts it into a control:
+
+```sql
+SELECT 1 FROM pg_locks
+ WHERE locktype='advisory' AND classid=%s AND objid=%s AND objsubid=2
+   AND pid=pg_backend_pid() AND granted
+```
+
+⚠ `objsubid=2` is required, not tidiness: Postgres encodes a two-`int4` advisory key as
+`classid`/`objid` with `objsubid=2`, and a one-`int8` key as the high/low halves of the
+bigint with `objsubid=1`. Without it, an unrelated `pg_advisory_lock(bigint)` whose halves
+happen to match satisfies the assertion.
+
+⚠ `classid`/`objid` are OID-width (unsigned) while `pg_advisory_lock(int,int)` takes signed
+`int4`, so a negative key component would not compare equal without conversion. Both keys
+here are positive literals; a future negative key breaks this silently.
+
+**What the assertion proves, exactly:** that this backend currently holds a matching
+advisory lock. It does not prove *this* call acquired it, that the context manager owns it,
+or that no reentrant acquisition is outstanding (`pg_locks` does not expose the reference
+count). That is sufficient for the property the gate needs — the critical section is open —
+and insufficient as a claim of exclusive ownership, so it is not made.
+
+Not held → `StrategyCoreSubmissionError`. That is the one raise, and it is right that it
+raises: an unserialised caller is a **caller bug**, not a state of the world, and returning
+it as a refusal would let the caller log it and carry on.
+
+⚠ **One TOCTOU the lock does not close, so it is named as 3b's obligation.**
+`require_core_eligibility` takes `FOR SHARE` on the live credential rows, and that lock ends
+at the next commit. If 3b commits between admission and submission, a credential swap can
+land in the gap. 3b must keep the eligibility read and the order submission inside one
+transaction, or re-admit after committing.
+
+## What this gate is not
+
+- It authorises nothing on its own: it has no caller until step 3b, and it writes nothing.
+  Stated plainly, as steps 1 and 2 stated it, rather than left to be inferred.
+- It is not a demo-mode gate. `mode='paper'` records the authority's declaration only. The
+  backstop stays the demo-only credential configuration and
+  `app/security/unattended_guard.py` (`sql/349`'s own warning, repeated because a gate
+  module is where it would most easily be misread).
+- It does not size anything. The intent's stored `amount` was computed against a sleeve
+  observed at `state_as_of`; re-solving it against the cost actually quoted is 3b's
+  (`strategy_core_allocator.py:334-339`).
+
+## Acceptance
+
+The gate performs no broker mutation and makes no broker call at all, so it is fully
+testable unattended.
+
+Refusals 1-8 are table-testable against seeded rows. ⚠ 9 and 10 are **not**: they need a
+`strategy_core_eligibility_proofs` row and a live `broker_credentials` pair, and the age
+comparison is against database time — so they are DB-backed tests, not pure-logic ones.
+
+⚠ #2603's own acceptance — initial allocation, forced drift rebalance, kill-switch drill —
+is operator-attended and is not this step's.
+
+Refs #2603. Refs #2437.

--- a/tests/test_2603_core_rebalance_intent.py
+++ b/tests/test_2603_core_rebalance_intent.py
@@ -147,6 +147,15 @@ _SANCTIONED_READERS = {
     # as consumers multiply -- and the requirements (actionable verdict, paper
     # mandate) cannot drift between them.
     "app/services/strategy_core_arc_sql.py",
+    # The submission gate (#2603 step 3a), and it is deliberately NOT routed
+    # through `strategy_core_arc_sql`. Those fragments answer "may this stored
+    # TRADE be acted on", starting from `strategy_trades`; the gate answers "may
+    # this stored INTENT become a trade at all", starting from the intent and
+    # reading facts -- supersession, the current mandate revision, an existing
+    # trade, the in-flight population -- that no load predicate has any business
+    # carrying. Composing them would put admission requirements on every read
+    # path that loads a position.
+    "app/services/strategy_core_submission_gate.py",
 }
 
 

--- a/tests/test_2603_core_submission_gate.py
+++ b/tests/test_2603_core_submission_gate.py
@@ -1,0 +1,112 @@
+"""#2603 item 3 step 3a — the gate's constants must stay bound to their SOURCES.
+
+Pure-logic: no database.  Everything here asserts that a constant in the module
+still matches the migration or the encoding it was copied from, because each of
+these is a value that reads as arbitrary once separated from where it came from —
+and a reader who cannot see the source will eventually "tidy" it.
+
+⚠ This is the same device as
+``test_the_migration_reason_codes_match_the_allocator_vocabulary``: a constant and
+its source in two files with nothing binding them is two constants.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.services.strategy_core_mandate import CORE_MANDATE_ADVISORY_LOCK
+from app.services.strategy_core_submission_gate import (
+    _ADMISSION_SQL,
+    _RECONCILIATION_TERMINAL_STATES,
+    _TERMINAL_TRADE_STATUSES,
+    CORE_SUBMISSION_ADVISORY_LOCK,
+    CoreSubmissionRefusal,
+)
+
+_SQL_DIR = Path(__file__).resolve().parents[1] / "sql"
+
+
+def _migration(prefix: str) -> str:
+    matches = sorted(_SQL_DIR.glob(f"{prefix}_*.sql"))
+    assert len(matches) == 1, f"expected exactly one sql/{prefix}_* migration, found {matches}"
+    return matches[0].read_text()
+
+
+def test_the_reconciliation_terminal_set_matches_the_backlog_index_it_was_copied_from() -> None:
+    """``sql/285`` defines "the broker effect is known", and this must be it.
+
+    The gate's whole in-flight rule is "block unless the reconciliation state is
+    terminal".  If the migration ever adds an eighth state, or promotes one to
+    terminal, a stale copy here would either block forever or admit a duplicate
+    order — and neither would fail any other test.
+    """
+    text = _migration("285")
+    predicate = re.search(r"WHERE state NOT IN \(([^)]*)\)", text)
+    assert predicate is not None, "sql/285's backlog index predicate has moved; re-source this constant"
+    sourced = tuple(sorted(value.strip().strip("'") for value in predicate.group(1).split(",")))
+    assert sourced == tuple(sorted(_RECONCILIATION_TERMINAL_STATES))
+
+
+def test_every_terminal_trade_status_is_one_the_schema_admits() -> None:
+    """A typo here would silently stop blocking nothing, which looks like working.
+
+    ``t.status <> ALL (...)`` against a value the CHECK cannot produce is a
+    no-op — the in-flight arm would then treat closed and failed trades as
+    blockers and deny every later rebalance.
+    """
+    text = _migration("281")
+    check = re.search(r"CHECK \(status IN \(([^)]*)\)\)", text, re.DOTALL)
+    assert check is not None, "sql/281's strategy_trades status CHECK has moved; re-source this constant"
+    admitted = {value.strip().strip("'") for value in check.group(1).split(",")}
+    assert set(_TERMINAL_TRADE_STATUSES) <= admitted
+
+
+def test_the_lock_assertion_pins_the_two_int4_advisory_encoding() -> None:
+    """``objsubid = 2`` is the difference between a control and a coincidence.
+
+    Postgres records a two-``int4`` advisory key as ``classid``/``objid`` with
+    ``objsubid = 2``, and a one-``int8`` key as the halves of the bigint with
+    ``objsubid = 1``.  Drop the predicate and an unrelated
+    ``pg_advisory_lock(bigint)`` whose halves collide satisfies the assertion —
+    i.e. the gate would confirm a critical section that is open somewhere else.
+    """
+    source = Path(__file__).resolve().parents[1] / "app/services/strategy_core_submission_gate.py"
+    text = source.read_text()
+    assert "objsubid=2" in text.replace(" ", "")
+    assert "pid=pg_backend_pid()" in text.replace(" ", "")
+    assert "granted" in text
+
+
+def test_both_advisory_keys_are_positive_because_the_assertion_compares_unsigned() -> None:
+    """``pg_locks.classid``/``objid`` are OID-width; the lock functions take signed int4.
+
+    A negative key component would be stored as its uint32 image and would not
+    compare equal to the signed literal, so ``_lock_held`` would return False for
+    a lock that IS held — and the gate would raise on every call.  Cheap to pin,
+    invisible if it ever changes.
+    """
+    for key in (CORE_MANDATE_ADVISORY_LOCK, CORE_SUBMISSION_ADVISORY_LOCK):
+        assert all(component > 0 for component in key), key
+    assert CORE_MANDATE_ADVISORY_LOCK != CORE_SUBMISSION_ADVISORY_LOCK
+
+
+def test_the_admission_query_is_one_statement() -> None:
+    """One snapshot is the correctness property, not a style choice.
+
+    Under READ COMMITTED a second statement gets a second snapshot, so "this is
+    the newest intent" and "no trade cites it yet" could each be true of a
+    different instant and false together.
+    """
+    assert _ADMISSION_SQL.count(";") == 0
+    assert _ADMISSION_SQL.strip().upper().startswith("SELECT")
+
+
+def test_the_refusal_vocabulary_is_closed_and_has_no_duplicates() -> None:
+    """A `Literal` is the enforcement: pyright checks every return site against it."""
+    codes = CoreSubmissionRefusal.__args__  # type: ignore[attr-defined]
+    assert len(set(codes)) == len(codes)
+    # The four inherited scope items plus the two this slice's falsification added.
+    assert {"core_intent_already_submitted", "core_trade_in_flight"} <= set(codes)
+    assert {"core_intent_superseded", "core_mandate_revision_stale"} <= set(codes)
+    assert {"core_eligibility_unproved", "core_partial_close_unproved"} <= set(codes)

--- a/tests/test_2603_core_submission_gate_db.py
+++ b/tests/test_2603_core_submission_gate_db.py
@@ -1,0 +1,559 @@
+"""#2603 item 3 step 3a — what the submission gate admits, and what it refuses.
+
+Every refusal against real rows, because the gate's whole substance is one SQL
+statement and a mocked cursor would prove nothing about it.
+
+⚠ In its own ``_db`` module deliberately: the string ``ebull_test_conn`` in a test
+source db-marks the WHOLE module at collection.
+
+⚠⚠ The gate REFUSES; it never submits.  Nothing here reaches a broker, and no test
+in this module creates an order.  The trade rows it seeds exist to be blockers.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID, uuid4
+
+import psycopg
+import pytest
+
+from app.services.strategy_core_eligibility import CORE_ELIGIBILITY_POLICY_VERSION
+from app.services.strategy_core_mandate import CORE_MANDATE_MODE, CORE_MANDATE_POLICY_VERSION
+from app.services.strategy_core_submission_gate import (
+    CORE_SUBMISSION_ADVISORY_LOCK,
+    StrategyCoreSubmissionError,
+    admit_core_rebalance_intent,
+    core_submission_lock,
+)
+
+_INSTRUMENT_ID = 920705
+_PAST = datetime(2026, 1, 2, 9, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------
+# Seeds.
+# --------------------------------------------------------------------------
+
+
+def _seed_instrument(conn: psycopg.Connection[Any]) -> None:
+    """``is_tradable`` listed explicitly per #1233 §6.2 (chokepoint lint)."""
+    conn.execute(
+        "INSERT INTO instruments (instrument_id,symbol,company_name,is_tradable) "
+        "VALUES (%s,'CORE.GATE','Core Gate Test',TRUE) ON CONFLICT DO NOTHING",
+        (_INSTRUMENT_ID,),
+    )
+
+
+def _seed_account(conn: psycopg.Connection[Any]) -> tuple[UUID, UUID, UUID]:
+    operator_id = uuid4()
+    conn.execute(
+        "INSERT INTO operators (operator_id, username, password_hash) VALUES (%s,%s,'x')",
+        (operator_id, f"op_{operator_id.hex[:8]}"),
+    )
+    ids: list[UUID] = []
+    for label in ("api_key", "user_key"):
+        row = conn.execute(
+            """
+            INSERT INTO broker_credentials
+                (operator_id, provider, label, environment, ciphertext, last_four, key_version)
+            VALUES (%s,'etoro',%s,'demo','\\x00'::bytea,'0000',1)
+            RETURNING id
+            """,
+            (operator_id, label),
+        ).fetchone()
+        assert row is not None
+        ids.append(row[0])
+    return operator_id, ids[0], ids[1]
+
+
+def _seed_proof(
+    conn: psycopg.Connection[Any],
+    account: tuple[UUID, UUID, UUID],
+    *,
+    allow_partial_close: bool | None = True,
+) -> None:
+    operator_id, api_key_id, user_key_id = account
+    conn.execute(
+        """
+        INSERT INTO strategy_core_eligibility_proofs (
+            instrument_id, operator_id, provider, environment,
+            api_key_credential_id, user_key_credential_id,
+            verdict, reason_code, requested_currency, response_currency,
+            settlement_type, direction, leverage_values, qualifying_arm_count,
+            allow_open_position, allow_close_position, allow_partial_close_position,
+            response_digest, policy_version, recorded_by
+        ) VALUES (
+            %s, %s, 'etoro', 'demo', %s, %s,
+            'underlying', NULL, 'USD', 'USD',
+            'real', 'long', ARRAY[1], 1,
+            TRUE, TRUE, %s, %s, %s, 'test'
+        )
+        """,
+        (
+            _INSTRUMENT_ID,
+            operator_id,
+            api_key_id,
+            user_key_id,
+            allow_partial_close,
+            "0" * 64,
+            CORE_ELIGIBILITY_POLICY_VERSION,
+        ),
+    )
+
+
+def _seed_mandate(
+    conn: psycopg.Connection[Any],
+    *,
+    revision: int = 1,
+    enabled: bool = True,
+    mode: str = CORE_MANDATE_MODE,
+) -> int:
+    row = conn.execute(
+        """
+        INSERT INTO strategy_core_mandate_events (
+            revision,enabled,base_currency,core_instrument_id,core_target_pct,
+            liquidity_reserve_pct,rebalance_band_pct,min_rebalance_amount,
+            policy_version,changed_by,reason,mode
+        ) VALUES (%s,%s,'USD',%s,60,20,5,25,%s,'test','test',%s)
+        RETURNING core_mandate_event_id
+        """,
+        (revision, enabled, _INSTRUMENT_ID, CORE_MANDATE_POLICY_VERSION, mode),
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _seed_intent(conn: psycopg.Connection[Any], *, event_id: int, action: str = "buy_core") -> int:
+    """One actionable intent by default; ``action`` is what the callers vary."""
+    refused = action == "refused"
+    row = conn.execute(
+        """
+        INSERT INTO strategy_core_rebalance_intents (
+            core_mandate_event_id, allocator_policy_version, recorded_by,
+            core_instrument_id, currency, core_market_value, cash_balance,
+            state_as_of, action, reason_code, amount, core_pct, target_pct,
+            lower_pct, upper_pct, effective_floor, floor_source,
+            reserve_breached, reserve_margin_pct
+        ) VALUES (
+            %(event_id)s, %(policy)s, 'test', %(instrument_id)s, 'USD', 600, 400,
+            %(state_as_of)s, %(action)s, %(reason_code)s, %(amount)s,
+            %(core_pct)s, %(target_pct)s, %(lower_pct)s, %(upper_pct)s,
+            %(floor)s, %(floor_source)s, %(breached)s, %(margin)s
+        )
+        RETURNING core_rebalance_intent_id
+        """,
+        {
+            "event_id": event_id,
+            "policy": CORE_MANDATE_POLICY_VERSION,
+            "instrument_id": _INSTRUMENT_ID,
+            "state_as_of": _PAST,
+            "action": action,
+            "reason_code": "core_sleeve_empty" if refused else None,
+            "amount": Decimal("0") if action in ("hold", "refused") else Decimal("50"),
+            "core_pct": None if refused else Decimal("60"),
+            "target_pct": None if refused else Decimal("60"),
+            "lower_pct": None if refused else Decimal("55"),
+            "upper_pct": None if refused else Decimal("65"),
+            "floor": None if refused else Decimal("25"),
+            "floor_source": None if refused else "mandate",
+            "breached": None if refused else False,
+            "margin": None if refused else Decimal("10"),
+        },
+    ).fetchone()
+    assert row is not None
+    return int(row[0])
+
+
+def _seed_blocking_trade(
+    conn: psycopg.Connection[Any],
+    *,
+    intent_id: int,
+    status: str = "submitted",
+    reconciliation_state: str | None = "unresolved",
+    link_order: bool = True,
+) -> int:
+    """A core trade, optionally with a linked order in a reconciliation state.
+
+    ``link_order=False`` seeds the no-linked-order arm — the belt for a row
+    inserted directly rather than through the executor. ``reconciliation_state=
+    None`` with ``link_order=True`` seeds the harder case: a linked order that
+    has NO reconciliation row, which nothing in the schema forbids.
+    """
+    trade = conn.execute(
+        "INSERT INTO strategy_trades (core_rebalance_intent_id,instrument_id,status) "
+        "VALUES (%s,%s,%s) RETURNING strategy_trade_id",
+        (intent_id, _INSTRUMENT_ID, status),
+    ).fetchone()
+    assert trade is not None
+    trade_id = int(trade[0])
+    if link_order:
+        order = conn.execute(
+            """
+            INSERT INTO orders (instrument_id, action, order_type, requested_amount, status, execution_origin)
+            VALUES (%s,'BUY','MARKET',50,'submitted','strategy') RETURNING order_id
+            """,
+            (_INSTRUMENT_ID,),
+        ).fetchone()
+        assert order is not None
+        order_id = int(order[0])
+        conn.execute(
+            "INSERT INTO strategy_trade_orders (strategy_trade_id,order_id,purpose) VALUES (%s,%s,'entry')",
+            (trade_id, order_id),
+        )
+        if reconciliation_state is not None:
+            conn.execute(
+                "INSERT INTO strategy_order_reconciliation_state (order_id,state,reconciled_at) VALUES (%s,%s,%s)",
+                (
+                    order_id,
+                    reconciliation_state,
+                    _PAST if reconciliation_state in ("resolved", "rejected") else None,
+                ),
+            )
+    return trade_id
+
+
+def _admit(conn: psycopg.Connection[Any], intent_id: int, account: tuple[UUID, UUID, UUID]) -> Any:
+    with core_submission_lock(conn):
+        return admit_core_rebalance_intent(
+            conn,
+            intent_id=intent_id,
+            operator_id=account[0],
+            provider="etoro",
+            environment="demo",
+        )
+
+
+# --------------------------------------------------------------------------
+# The happy path, so every refusal below is a difference of one thing.
+# --------------------------------------------------------------------------
+
+
+def test_a_current_actionable_intent_with_a_live_proof_is_admitted(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert verdict.admitted is True
+    assert verdict.reason_code is None
+    assert verdict.action == "buy_core"
+    assert verdict.amount == Decimal("50.000000")
+    assert verdict.eligibility_proof_id is not None
+
+
+def test_a_sell_is_admitted_when_partial_close_is_proved(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account, allow_partial_close=True)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn), action="sell_core")
+    assert _admit(ebull_test_conn, intent_id, account).admitted is True
+
+
+# --------------------------------------------------------------------------
+# The lock is a control, not a docstring.
+# --------------------------------------------------------------------------
+
+
+def test_admission_without_the_lock_raises_rather_than_refusing(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """An unserialised caller is a BUG, and a returned refusal invites logging it.
+
+    The UNIQUE index refuses the second INSERT only after both callers have
+    reached the broker, which is the leg that costs money — so the serialisation
+    has to be proved, not assumed.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    with pytest.raises(StrategyCoreSubmissionError, match="core_submission_lock"):
+        admit_core_rebalance_intent(
+            ebull_test_conn,
+            intent_id=intent_id,
+            operator_id=account[0],
+            provider="etoro",
+            environment="demo",
+        )
+
+
+def test_holding_only_the_submission_lock_still_raises(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """Both keys are required: the mandate lock is what closes the revision TOCTOU.
+
+    Without it a mandate revision can be appended between the staleness check and
+    the trade INSERT, leaving a trade citing a mandate the operator has replaced.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    ebull_test_conn.execute("SELECT pg_advisory_lock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
+    ebull_test_conn.commit()
+    try:
+        with pytest.raises(StrategyCoreSubmissionError, match="mandate advisory lock"):
+            admit_core_rebalance_intent(
+                ebull_test_conn,
+                intent_id=intent_id,
+                operator_id=account[0],
+                provider="etoro",
+                environment="demo",
+            )
+    finally:
+        ebull_test_conn.execute("SELECT pg_advisory_unlock(%s, %s)", CORE_SUBMISSION_ADVISORY_LOCK)
+        ebull_test_conn.commit()
+
+
+# --------------------------------------------------------------------------
+# The refusals, in precedence order.
+# --------------------------------------------------------------------------
+
+
+def test_a_missing_intent_is_refused(ebull_test_conn: psycopg.Connection[Any]) -> None:
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    verdict = _admit(ebull_test_conn, 9_999_999, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_intent_missing")
+
+
+@pytest.mark.parametrize("action", ["hold", "refused"])
+def test_a_hold_or_refusal_cannot_authorise_a_submission(ebull_test_conn: psycopg.Connection[Any], action: str) -> None:
+    """``sql/348`` stores every verdict as evidence, so the FK alone is not authority."""
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn), action=action)
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_intent_not_actionable")
+
+
+def test_a_later_evaluation_supersedes_an_earlier_verdict(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The freshness rule, and it is supersession rather than an age threshold.
+
+    ⚠ A later ``hold`` supersedes an earlier ``buy_core``: the allocator is a pure
+    function of mandate and observed state, so a later row is a later observation
+    of the same sleeve. Acting on the earlier verdict means acting on a world we
+    have since re-measured.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    event_id = _seed_mandate(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=event_id)
+    assert _admit(ebull_test_conn, intent_id, account).admitted is True
+    newer_id = _seed_intent(ebull_test_conn, event_id=event_id, action="hold")
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_intent_superseded")
+    assert str(newer_id) in (verdict.detail or "")
+
+
+def test_a_verdict_computed_under_a_replaced_mandate_is_refused(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn, revision=1))
+    _seed_mandate(ebull_test_conn, revision=2)
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_mandate_revision_stale")
+
+
+def test_a_mandate_disabled_after_the_evaluation_is_refused(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """⚠ Reachable only because the revision check proved the mandate current.
+
+    The allocator's own ``core_mandate_disabled`` belongs to a revision this
+    intent predates, so a mandate disabled AFTER the evaluation passes every other
+    check here. Reading the row and not testing its flag would be the defect this
+    ticket keeps finding.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    event_id = _seed_mandate(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=event_id)
+    ebull_test_conn.execute(
+        "UPDATE strategy_core_mandate_events SET enabled=FALSE WHERE core_mandate_event_id=%s",
+        (event_id,),
+    )
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_mandate_disabled")
+
+
+def test_an_intent_that_already_has_a_trade_is_refused_before_any_broker_leg(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The UNIQUE index bounds STORAGE; this bounds the leg that costs money.
+
+    ``detail`` carries the existing trade's status, because an uncertain prior
+    submission needs reconciliation rather than a retry.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    _seed_blocking_trade(
+        ebull_test_conn, intent_id=intent_id, status="reconcile_required", reconciliation_state="resolved"
+    )
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_intent_already_submitted")
+    assert "reconcile_required" in (verdict.detail or "")
+
+
+@pytest.mark.parametrize("state", ["unresolved", "pending", "not_found", "ambiguous", "error"])
+def test_an_unreconciled_core_order_blocks_a_second_submission(
+    ebull_test_conn: psycopg.Connection[Any], state: str
+) -> None:
+    """The in-flight rule, sourced from ``sql/285``'s own terminal set.
+
+    The hazard is named in ``strategy_core_rebalance_intent``: the allocator is
+    stateless and re-recommends a trade already in flight, because an unfilled buy
+    is not yet in the broker's position snapshot.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    event_id = _seed_mandate(ebull_test_conn)
+    blocker_intent = _seed_intent(ebull_test_conn, event_id=event_id)
+    _seed_blocking_trade(ebull_test_conn, intent_id=blocker_intent, reconciliation_state=state)
+    intent_id = _seed_intent(ebull_test_conn, event_id=event_id)
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_trade_in_flight")
+    assert state in (verdict.detail or "")
+
+
+@pytest.mark.parametrize("state", ["resolved", "rejected"])
+def test_a_reconciled_core_order_does_not_block(ebull_test_conn: psycopg.Connection[Any], state: str) -> None:
+    """⚠ The other half, and the one an over-tight rule would break silently.
+
+    An open core position is the mandate's STEADY STATE. A rule that blocked on
+    "an open core trade exists" would admit the first rebalance and refuse every
+    later one, for ever, while looking like a working control.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    event_id = _seed_mandate(ebull_test_conn)
+    held_intent = _seed_intent(ebull_test_conn, event_id=event_id)
+    _seed_blocking_trade(ebull_test_conn, intent_id=held_intent, status="open", reconciliation_state=state)
+    intent_id = _seed_intent(ebull_test_conn, event_id=event_id)
+    assert _admit(ebull_test_conn, intent_id, account).admitted is True
+
+
+def test_a_core_trade_with_no_linked_order_blocks(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The belt: unreachable through the executor, reachable through a fixture.
+
+    ``sql/349``'s own rule — the invariant changes at the migration, not at the
+    writer — and this repo's tests insert trade rows directly.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    event_id = _seed_mandate(ebull_test_conn)
+    stranded = _seed_intent(ebull_test_conn, event_id=event_id)
+    _seed_blocking_trade(ebull_test_conn, intent_id=stranded, status="planned", link_order=False)
+    intent_id = _seed_intent(ebull_test_conn, event_id=event_id)
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_trade_in_flight")
+    assert "no_order" in (verdict.detail or "")
+
+
+def test_a_linked_order_with_no_reconciliation_row_blocks(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """⚠⚠ The fail-OPEN a first draft shipped, and the one that costs money.
+
+    Nothing in the schema requires a linked order to have a
+    ``strategy_order_reconciliation_state`` row. A predicate that blocks only on
+    a NON-TERMINAL state therefore admits a second rebalance while the first
+    order's broker effect is entirely unknown — neither blocking by state (it is
+    NULL) nor by absence (the order exists). Missing must block exactly as
+    non-terminal does.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    event_id = _seed_mandate(ebull_test_conn)
+    unknown = _seed_intent(ebull_test_conn, event_id=event_id)
+    _seed_blocking_trade(ebull_test_conn, intent_id=unknown, status="submitted", reconciliation_state=None)
+    intent_id = _seed_intent(ebull_test_conn, event_id=event_id)
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_trade_in_flight")
+    assert "no_reconciliation_row" in (verdict.detail or "")
+
+
+def test_a_terminal_core_trade_never_blocks_even_if_its_order_is_unreconciled(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """Otherwise one stranded reconciliation row denies every later rebalance.
+
+    ``closed`` and ``failed`` have nothing outstanding on either arm, so the
+    blocking population is bounded by the trade's own status first.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account)
+    event_id = _seed_mandate(ebull_test_conn)
+    dead = _seed_intent(ebull_test_conn, event_id=event_id)
+    _seed_blocking_trade(ebull_test_conn, intent_id=dead, status="failed", reconciliation_state="unresolved")
+    intent_id = _seed_intent(ebull_test_conn, event_id=event_id)
+    assert _admit(ebull_test_conn, intent_id, account).admitted is True
+
+
+def test_an_unproved_instrument_is_refused_and_the_cause_survives(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """One code covers four causes, so the message is carried rather than dropped."""
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn))
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_eligibility_unproved")
+    assert "no etoro demo eligibility proof" in (verdict.detail or "")
+
+
+@pytest.mark.parametrize("allow_partial_close", [False, None])
+def test_a_sell_without_a_partial_close_capability_is_refused(
+    ebull_test_conn: psycopg.Connection[Any], allow_partial_close: bool | None
+) -> None:
+    """⚠ A passing verdict proves ``allow_open_position`` — a different capability.
+
+    A rebalance sell can never be a full close: ``validate_core_mandate`` requires
+    ``core_target_pct - rebalance_band_pct > 0`` and the allocator sells only down
+    to the lower band edge, so post-trade core value is strictly positive.
+
+    ``None`` is parameterised alongside ``False`` because the column is nullable
+    and means "the response did not say" — a truthiness test would read the same,
+    a ``not`` on a future inversion would not.
+    """
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account, allow_partial_close=allow_partial_close)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn), action="sell_core")
+    verdict = _admit(ebull_test_conn, intent_id, account)
+    assert (verdict.admitted, verdict.reason_code) == (False, "core_partial_close_unproved")
+
+
+def test_a_buy_is_unaffected_by_the_partial_close_capability(
+    ebull_test_conn: psycopg.Connection[Any],
+) -> None:
+    """The direction split is real: a buy needs open authority, which the verdict carries."""
+    _seed_instrument(ebull_test_conn)
+    account = _seed_account(ebull_test_conn)
+    _seed_proof(ebull_test_conn, account, allow_partial_close=False)
+    intent_id = _seed_intent(ebull_test_conn, event_id=_seed_mandate(ebull_test_conn), action="buy_core")
+    assert _admit(ebull_test_conn, intent_id, account).admitted is True


### PR DESCRIPTION
## What this is

#2603 item 3's execution half, **step 3a**. Step 3 is the executor; this is the half of it
that **refuses** — one admission decision over one stored
`strategy_core_rebalance_intents` row. Step 3b builds the observe → record → submit path
that consumes it.

Shipping the refusing half first is deliberate: the opposite order produces a writer whose
preconditions are a comment.

Prior steps: step 1 `8af38991` (`sql/348`, the intent record), step 2 `7513d77a`
(`sql/349`, the exclusive arc), entry condition `14d1bf8b` (`GET/PUT
/strategies/core-mandate`).

Spec: `docs/proposals/ta/2026-08-14-core-submission-gate.md`.

## ⚠ Two of the four inherited scope items were WRONG, and both changed the design

The step-3 handoff (#2603, 2026-08-14T09:38Z) lists five items. A prior session's
conclusion is evidence, not a finding, so each was re-run against the tree.

### "a no-open-core-trade precondition" forbids the mandate's own steady state

An open core position is what a core sleeve **is**. A rule reading "refuse while an open
core trade exists" admits the first rebalance and refuses every later one, permanently,
while looking like a working control the whole time.

The real hazard is already written down, in `strategy_core_rebalance_intent.py:16-18` —
*"no in-flight suppression (the allocator is stateless and will re-recommend a trade
already in flight)"*. A submitted-but-unfilled buy is not in the broker's position
snapshot, so the next sleeve observation still shows the pre-trade core value and the
allocator re-recommends the same buy.

**A first draft then classified each `strategy_trades.status` as "reflected in the broker
snapshot" or not — inference from lifecycle names, and wrong in both directions.** `failed`
is written both after a definitively rejected submission (`strategy_paper_executor.py:1272`)
and on the resume path (`:998`); `open`/`closed` are local transitions carrying no claim
about snapshot timing.

The system already stores the answer. `sql/285` gives
`strategy_order_reconciliation_state` a closed vocabulary and its own terminal set — the
backlog index is `WHERE state NOT IN ('resolved','rejected')` and the
`strategy_order_reconciliation_resolved_shape` CHECK ties exactly those two to a non-NULL
`reconciled_at`. So the rule is **sourced**: a non-terminal core trade blocks unless every
linked order has reached that terminal set.

### "an `evaluated_at` freshness bound" presumes a producer that does not exist

```bash
grep -rn "record_core_rebalance_intent" app scripts   # → the definition and one docstring. No caller.
```

The executor is its own producer, so a wall-clock bound on `evaluated_at` measures the
distance between two lines of one function — a threshold with no phenomenon under it.

**Source rule.** No published formulation governs how long a portfolio-rebalance verdict
stays actionable, and this PR does not invent a citation. Per "source-rule before design"
the rule is fixed **by construction** and frozen in `CORE_SUBMISSION_POLICY_VERSION`:

- `core_intent_superseded` — a newer intent row exists. Any later evaluation supersedes,
  including a `hold`: the allocator is a pure function of mandate and observed state, so a
  later row is a later observation of the same sleeve.
- `core_mandate_revision_stale` — the intent's mandate is not the newest revision.

Strictly stronger than an age bound, which is only a proxy for "the verdict is probably
still true". It also self-heals the crash case: an intent left newest by a crashed
invocation stops being newest the moment the next invocation evaluates.

⚠ **What it does not do, stated rather than left silent.** It bounds *relative* staleness
only. An intent that is newest, under the newest mandate, and two hours old is admitted —
no server-side fact distinguishes it from one recorded two seconds ago. The absolute bound
is 3b's obligation (observe → record → admit → submit inside one lock hold), and the gate
cannot verify it.

⚠ Scope of "newest" is the whole table, which is correct **only because the mandate is a
singleton** (`load_core_mandate` takes no account argument; the intents table carries no
operator/provider/environment column). Recorded in the module docstring because if a second
mandate is ever introduced this predicate silently starts refusing unrelated intents — and
a wrong refusal is the failure nobody notices.

## ⚠ One gap the inherited list did not contain: a rebalance sell is a PARTIAL CLOSE

`require_core_eligibility` returns a proof whose `verdict='underlying'` requires
`allow_open_position` (`strategy_core_eligibility.py`, `sql/346:110`). It says nothing about
closing. `sql/346` already **stores** `allow_close_position` and
`allow_partial_close_position` (`:72-74`); `CoreEligibilityProof` simply did not read them
back — so a `sell_core` would reach the broker on a proof that the instrument can be
*bought*.

Which capability it needs is settled by construction, not chosen: `validate_core_mandate`
requires `core_target_pct - rebalance_band_pct > 0` and the allocator sells only down to the
lower band edge, so post-trade core value is strictly positive — **a rebalance sell can
never be a full close.** The gate requires `allow_partial_close_position IS TRUE` (`IS TRUE`,
not truthiness: the column is nullable and NULL means the response did not say).

## The lock is a control, not a docstring

Item 1's gap is a race: `sql/349`'s UNIQUE index refuses the second INSERT, but by then both
callers have reached the broker — the leg that costs money.

`core_submission_lock` takes **two** session locks in a fixed order: the mandate writers'
key `(2603, 1)` first (without it the revision-staleness check is a TOCTOU — a revision
appended between check and INSERT leaves a trade citing a mandate the operator has
replaced), then `(2603, 3)`. `configure_core_mandate` takes only the first, so no deadlock
cycle.

The gate then **asserts both are held**, via `pg_locks`:

⚠ `objsubid = 2` is required, not tidiness. Postgres encodes a two-`int4` advisory key as
`classid`/`objid` with `objsubid = 2`, and a one-`int8` key as the halves of the bigint with
`objsubid = 1`. Without it an unrelated `pg_advisory_lock(bigint)` whose halves collide
satisfies the assertion — i.e. the gate confirms a critical section that is open somewhere
else.

⚠ What the assertion proves, exactly: **this backend currently holds a matching lock.** Not
that this call acquired it, nor that no reentrant acquisition is outstanding (`pg_locks`
does not expose the reference count). That is sufficient for the property needed and short
of exclusive ownership, so no such claim is made.

Not held → raises. An unserialised caller is a **caller bug**, not a state of the world;
returning it as a refusal would let the caller log it and carry on into the race.

## Codex checkpoint 2 caught a fail-open, and it was the expensive kind

Nothing in the schema requires a linked order to have a
`strategy_order_reconciliation_state` row. The first predicate blocked on
`recon.state IS NOT NULL AND state <> ALL (terminal)`, so a linked order with **no**
reconciliation row satisfied neither arm — not blocking by state (NULL), not blocking by
absence (the order exists). That admits a second rebalance while the first order's broker
effect is entirely unknown, which is the one outcome the predicate exists to prevent.

Fixed, and `test_a_linked_order_with_no_reconciliation_row_blocks` covers it.
**Revert-probed**: re-injecting the old predicate fails exactly that test and no other.

## One snapshot, one statement

Every table fact the gate decides on — the intent, its mandate, the newest intent, the
newest revision, an existing trade, the in-flight population — is one SQL statement. Under
`READ COMMITTED` a sequence of statements sees a sequence of snapshots, so "this is the
newest intent" and "no trade cites it yet" could each be true of a different instant and
false together. Pinned by `test_the_admission_query_is_one_statement`.

## ⚠⚠ The vocabulary is NOT the complete submission refusal vocabulary

The kill switch, `enable_auto_trading`, the execution block, market-session state, quote
availability and staleness, account-risk availability, broker minimums, cost assessment and
broker rejection are all real refusals of a core submission and **none is here** — they
belong to 3b, which is the code that holds a quote and a broker. Stated in the module
docstring because a reader who takes this for the full set concludes the core arm has no
kill-switch check.

## Security model

**Unchanged, and this PR weakens nothing.** The gate is read-only: no writes, no broker
call, no caller. It cannot cause a trade; it can only refuse one that 3b will later attempt.
The demo backstop remains the demo-only credential configuration and
`app/security/unattended_guard.py` — `mode='paper'` records the authority's *declaration*
only, which `sql/349` already says and this module repeats because a gate module is where it
would most easily be misread.

⚠ One TOCTOU the lock does not close, named as 3b's obligation rather than left silent:
`require_core_eligibility` takes `FOR SHARE` on the live credential rows and that lock ends
at the next commit. 3b must keep the eligibility read and the order submission in one
transaction, or re-admit after committing.

## Testing

- `tests/test_2603_core_submission_gate.py` (pure) — every constant bound to its source:
  the reconciliation terminal set parsed from `sql/285`'s backlog index, the terminal trade
  statuses checked against `sql/281`'s CHECK, `objsubid=2` present, both advisory keys
  positive (the assertion compares OID-width unsigned against signed `int4` literals), the
  admission query single-statement, the refusal vocabulary closed.
- `tests/test_2603_core_submission_gate_db.py` (DB) — 25 tests: the admit path for buy and
  sell, both lock assertions raising, and every refusal including all five non-terminal
  reconciliation states, both terminal ones NOT blocking, the missing-reconciliation-row
  fail-open, the no-linked-order belt, and a terminal trade never blocking.
- `tests/test_2603_core_rebalance_intent.py` — the gate added to `_SANCTIONED_READERS` with
  its reason. ⚠ Deliberately **not** routed through `strategy_core_arc_sql`: those fragments
  answer "may this stored TRADE be acted on"; the gate answers "may this stored INTENT
  become a trade at all", and composing them would put admission requirements on every read
  path that loads a position.

Local gates: `ruff check` / `ruff format --check` / `pyright` clean, fast tier green, smoke
green, pre-push hook green.

## Not in scope

- The executor itself (3b), and with it item 5 —
  `strategy_paper_executor.py:925-935`, the uncertain-submission resume path. It needs an
  entry *order* to be reachable and only 3b creates one; it fails closed today.
- #2603 item 4 (non-USD deployment) — provider-blocked, unchanged.
- **#2603's own acceptance is operator-attended** (initial allocation, one forced drift
  rebalance, one kill-switch drill) and is not this step's. Nothing here executes a trade.

Refs #2603. Refs #2437.
