### PR TITLE
fix(#2699): prove the import-time guards still RUN, and probe both invocations

### DIFF
--- a/scripts/probe_2240_cost_model.py
+++ b/scripts/probe_2240_cost_model.py
@@ -45,21 +45,17 @@ reported, not enforced; nothing branches on them, so there is no behaviour to
 revert. ``--calibrate`` prints the live figures beside them, which is the
 mechanism that keeps them honest.
 
-⚠⚠ **THE PRESENCE OF ``_check_unmodelled_components_are_not_charged()``'s
-MODULE-LEVEL CALL** (#2695, Codex checkpoint). Its refusal is proved directly by
-``test_a_component_may_not_carry_an_amount_that_nothing_charges``, which patches
-a value and calls the function. Nothing proves the call still runs AT IMPORT —
-delete the one-line invocation and every test in the file still passes, because
-each reaches the guard by calling it. That is the #2363 tripwire's whole value
-(it fires on an edit somebody makes to the literal, in a file they may not test),
-and it is currently unguarded.
+✅ **CLOSED #2699 (2026-08-14): the module-level INVOCATIONS are now probed.** The
+note here used to record that deleting ``_check_unmodelled_components_are_not_charged()``
+left every test passing, because each reached the guard by calling it — so the
+#2363 tripwire's whole value (firing on an edit somebody makes to the literal, in
+a file they may not test) rested on a line nothing defended.
 
-⚠ It is deliberately NOT probed here rather than probed and reported ``NOT
-CAUGHT``. A probe whose selector cannot fail is noise in a sweep whose signal is
-the failures. Closing it needs a test that imports the module in a SUBPROCESS
-with the constant patched and asserts the import raises — the guard runs at
-import, so no in-process fixture can observe it without a reload dance that
-would itself need probing. Worth a ticket, not a widened diff.
+``TestTheImportTimeGuardsActuallyRun`` closes it by executing the SHIPPED SOURCE in
+a cold interpreter with one literal substituted, which is exactly what that
+maintainer would see. Two probes above now revert the invocations, and both report
+CAUGHT. ⚠ The same asymmetry held for ``_check_bands_are_total(BANDS)`` — every one
+of its tests passes a hand-built tuple — and is probed alongside it.
 """
 
 from __future__ import annotations
@@ -250,6 +246,29 @@ PROBES: list[tuple[str, Path, str, list[tuple[str, str]], str]] = [
             ("CARRY_BPS: Decimal | None = None", 'CARRY_BPS: Decimal | None = Decimal("0")'),
         ],
         "test_carry_is_none or test_the_unmodelled_marker_is_set",
+    ),
+    (
+        # ⚠⚠ THE INVOCATION ITSELF, probeable since #2699. Deleting this one line
+        # leaves the guard defined, imported and directly testable — and never run.
+        # A guard that no longer runs is the #2437 R4 shape arriving through a
+        # missing CALL rather than a missing branch, and it was invisible for the
+        # ordinary reason: every test reached the function by calling it.
+        "the module-level call to the false-promotion tripwire deleted",
+        MODEL,
+        MODEL_TESTS,
+        [("\n_check_unmodelled_components_are_not_charged()\n", "\n")],
+        "test_setting_carry_bps_fails_the_import_itself or test_setting_fx_bps_fails_the_import_itself",
+    ),
+    (
+        # ⚠ The SAME asymmetry, found while closing #2699 rather than stated by it:
+        # every `_check_bands_are_total` test passes a hand-built tuple, so its
+        # module-level call was equally deletable. A gap in the band table then
+        # makes `half_spread_for` raise on an ordinary price at run time.
+        "the module-level call to the band-totality guard deleted",
+        MODEL,
+        MODEL_TESTS,
+        [("\n_check_bands_are_total(BANDS)\n", "\n")],
+        "test_a_gap_in_the_band_table_fails_the_import_itself",
     ),
     (
         # ⚠⚠ THE RE-KEY. §5.1: *"re-keying mid-hold would make the cost depend

--- a/tests/test_cost_model.py
+++ b/tests/test_cost_model.py
@@ -11,6 +11,9 @@ four functions over it.
 
 from __future__ import annotations
 
+import pathlib
+import subprocess
+import sys
 from decimal import Decimal
 from unittest import mock
 
@@ -317,3 +320,102 @@ class TestCarryIsNullNotZero:
             ):
                 cost_model._check_unmodelled_components_are_not_charged()
         assert "new COST_MODEL_ID" in str(excinfo.value)
+
+
+class TestTheImportTimeGuardsActuallyRun:
+    """⚠⚠ Both module-level guards were UNPROVEN until #2699.
+
+    ``_check_unmodelled_components_are_not_charged`` and ``_check_bands_are_total``
+    each end their definition with a module-level call, and each docstring says why:
+    the thing they guard is *an edit somebody makes to the literal above*, so the
+    check belongs beside the literal rather than in a test file that person may never
+    run. That placement IS the guard's whole value.
+
+    Every existing test reaches them by CALLING THEM DIRECTLY. Delete either
+    invocation and the entire file still passes -- the guards become dead code that
+    reads as live, which is the #2437 R4 shape (*a control on a path the decision
+    does not take*) arriving through a missing call rather than a missing branch.
+
+    These tests execute the SHIPPED SOURCE in a fresh interpreter with one literal
+    substituted, which is exactly what the maintainer making that edit would see.
+    A warm interpreter cannot answer the question -- ``app.services.cost_model`` is
+    already in ``sys.modules`` and ``importlib.reload`` re-reads the same literals --
+    so the subprocess is load-bearing, per ``audit_probe_anchors._launch_failure``.
+    """
+
+    SOURCE = pathlib.Path(cost_model.__file__)
+
+    def _run_with_substitution(self, tmp_path: pathlib.Path, old: str, new: str) -> subprocess.CompletedProcess[str]:
+        """Execute the real module source in a cold interpreter, one literal changed.
+
+        ⚠ Anchored on the literal's exact text and asserted to have matched, so a
+        reshaped declaration fails HERE rather than silently testing an unmodified
+        copy -- the dead-anchor class #2695 spent a session on.
+        """
+        source = self.SOURCE.read_text()
+        assert source.count(old) == 1, f"anchor {old!r} matched {source.count(old)} times, expected 1"
+        probe = tmp_path / "cost_model_probe.py"
+        probe.write_text(source.replace(old, new))
+        return subprocess.run(  # noqa: S603 — fixed argv, path from tmp_path
+            [sys.executable, str(probe)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_the_shipped_source_imports_cleanly(self) -> None:
+        """The control arm: an UNMODIFIED copy must exit 0.
+
+        Without it, a probe that fails for an unrelated reason (a syntax error in the
+        substitution, a missing import) reads as the guard firing, and both tests
+        below would pass while proving nothing.
+        """
+        result = subprocess.run(  # noqa: S603 — fixed argv, no user input
+            [sys.executable, str(self.SOURCE)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr
+
+    def test_setting_carry_bps_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
+        """Not merely `the function raises when called` -- THE MODULE WILL NOT LOAD.
+
+        This is the difference the tripwire trades on: someone who measures carry and
+        sets the literal is stopped by their next import, whether or not they run
+        ``tests/test_cost_model.py``.
+        """
+        result = self._run_with_substitution(
+            tmp_path, "CARRY_BPS: Decimal | None = None", 'CARRY_BPS: Decimal | None = Decimal("1.5")'
+        )
+
+        assert result.returncode != 0
+        assert "nothing in this module adds it to a price" in result.stderr
+        assert "new COST_MODEL_ID" in result.stderr
+
+    def test_setting_fx_bps_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
+        """FX shares the guard and had the identical gap (#2699 scope note)."""
+        result = self._run_with_substitution(
+            tmp_path, "FX_BPS: Decimal | None = None", 'FX_BPS: Decimal | None = Decimal("0.25")'
+        )
+
+        assert result.returncode != 0
+        assert "FX_BPS is set" in result.stderr
+
+    def test_a_gap_in_the_band_table_fails_the_import_itself(self, tmp_path: pathlib.Path) -> None:
+        """``_check_bands_are_total`` had the same asymmetry, for the same reason.
+
+        Its existing tests all pass hand-built tuples, so the ``_check_bands_are_total(BANDS)``
+        call at module level was equally deletable. Widening the lowest band's upper
+        bound without moving its neighbour's lower bound opens a hole that
+        ``half_spread_for`` would raise on for an ordinary price.
+        """
+        result = self._run_with_substitution(
+            tmp_path,
+            'label="<$5", lower=None, upper=Decimal("5")',
+            'label="<$5", lower=None, upper=Decimal("4")',
+        )
+
+        assert result.returncode != 0
+        assert "not contiguous" in result.stderr


### PR DESCRIPTION
Closes #2699. Refs #2695. Refs #2363. Refs #2437.

## The gap

`app/services/cost_model.py` ends each guard definition with a module-level call:

```python
_check_unmodelled_components_are_not_charged()   # line 204
_check_bands_are_total(BANDS)                    # line 324
```

Each docstring is explicit about why it lives at import — *"this is an edit
somebody makes to the literal above, so the check belongs beside the literal
rather than in a test file they may not run."* **That placement is the guard's
whole value.** The tripwire's job is to fire on a `CARRY_BPS = Decimal(...)` edit
for someone who never opens `tests/test_cost_model.py`.

**Nothing proved either call still ran.** Every existing test reaches the guards
by calling them directly — the tripwire under `mock.patch.object`, the band check
with hand-built tuples. Delete either one-line invocation and the entire file
still passes. The guards become dead code that reads as live.

⚠ This is the #2437 R4 shape — *a control on a path the decision does not take* —
arriving through a missing **call** rather than a missing branch. It is why the
anchor audit could not see it: the anchors were intact the whole time.

⚠ **`_check_bands_are_total` had the identical gap.** #2699 named it only as
"should be checked for the same asymmetry while in there"; it has it, for exactly
the same reason. A gap in the band table makes `half_spread_for` raise on a
perfectly ordinary price.

## What closes it

`TestTheImportTimeGuardsActuallyRun` executes the **shipped source** in a cold
interpreter with one literal substituted — precisely what the maintainer making
that edit would experience. `cost_model` imports only stdlib, so the substituted
copy runs standalone from `tmp_path` with no package plumbing.

Why a subprocess is load-bearing: `app.services.cost_model` is already in
`sys.modules` by the time any test runs, and `importlib.reload` re-reads the same
literals, so no in-process fixture can observe an import-time guard. Same reason
`scripts/audit_probe_anchors.py::_launch_failure` went to a subprocess in #2695.

Four tests:

- `test_the_shipped_source_imports_cleanly` — **the control arm.** Without it, a
  probe failing for an unrelated reason (a bad substitution, a missing import)
  reads as the guard firing and the other three pass while proving nothing.
- `test_setting_carry_bps_fails_the_import_itself`
- `test_setting_fx_bps_fails_the_import_itself` — FX shares the guard and had the
  same gap (#2699's scope note).
- `test_a_gap_in_the_band_table_fails_the_import_itself`

⚠ Each substitution asserts its anchor matched **exactly once**, so a reshaped
declaration fails loudly here rather than silently testing an unmodified copy —
the dead-anchor class #2695 spent a session on, applied to a checker written the
same week the lesson landed.

## Revert-probed, because a checker at the top of the stack has nothing testing it

Both invocations deleted in turn against the new tests (commit taken first, per
the prevention log):

```
CAUGHT | delete _check_unmodelled_components_are_not_charged() invocation
CAUGHT | delete _check_bands_are_total(BANDS) invocation
```

Both now wired into `scripts/probe_2240_cost_model.py` as standing probes, and
the `WHAT IS NOT PROBED, AND WHY` entry is retired rather than left contradicting
the code. Harness: **19/19 CAUGHT** (was 17 probes).

## Security model

Not applicable — no runtime behaviour changes. Two test files and a probe
harness; `app/services/cost_model.py` is untouched by this diff.

## Gates

`ruff check` · `ruff format --check` · `pyright` (0 errors) · `pytest -m "not db"`
· `pytest tests/smoke` · `scripts/check_probe_anchors.sh` (289 anchors, 16
harnesses) · `python -m scripts.probe_2240_cost_model` (19/19) — all green, gated
on exit code.

Per the review-intensity ladder this is a narrow diff with no data semantics and
no `app/` change, so it gets self-review + pre-push hook + review bot, and no
Codex checkpoint 2.
